### PR TITLE
fix(gateway-manager): fix strip_path and param scope bugs in setup_upstream

### DIFF
--- a/scripts/lib/gateway_manager.sh
+++ b/scripts/lib/gateway_manager.sh
@@ -168,8 +168,8 @@ rebuild_kong_config() {
 }
 
 setup_upstream() {
-    local pgrst_port="${3:-}"
-    local gotrue_port="${4:-}"
+    local pgrst_port="${1:-}"
+    local gotrue_port="${2:-}"
     
     if [ -z "$pgrst_port" ] || [ -z "$gotrue_port" ]; then
         echo "ERROR: pgrst_port and gotrue_port are required for setup-upstream" >&2
@@ -190,7 +190,7 @@ setup_upstream() {
     write_timeout: 60000
     routes:
       - name: route-pgrst-${PROJECT_REF}
-        strip_path: false
+        strip_path: true
         preserve_host: true
         paths:
           - /rest/v1
@@ -205,7 +205,7 @@ setup_upstream() {
     write_timeout: 60000
     routes:
       - name: route-gotrue-${PROJECT_REF}
-        strip_path: false
+        strip_path: true
         preserve_host: true
         paths:
           - /auth/v1
@@ -243,7 +243,7 @@ case "$ACTION" in
         enable_jwt
         ;;
     setup-upstream)
-        setup_upstream
+        setup_upstream "${3:-}" "${4:-}"
         ;;
     remove-service)
         remove_service


### PR DESCRIPTION
## Problem

Two bugs in `scripts/lib/gateway_manager.sh` were **not included** in the previous fix commit (`4756604`), but are critical for production multi-tenant deployments.

### Bug 1: `setup_upstream()` reads wrong positional variables

```bash
# Before (broken): reads global $3/$4, which are always empty inside a function
setup_upstream() {
    local pgrst_port="${3:-}"
    local gotrue_port="${4:-}"
```

```bash
# After (fixed): reads $1/$2 from the function's own arg list
setup_upstream() {
    local pgrst_port="${1:-}"
    local gotrue_port="${2:-}"
```

The case block also needs to forward the arguments:
```bash
# Before
setup_upstream
# After
setup_upstream "${3:-}" "${4:-}"
```

**Impact**: Running `gateway_manager.sh setup-upstream <ref> <pgrst_port> <gotrue_port>` always fails with `ERROR: pgrst_port and gotrue_port are required` because the ports are never received by the function.

---

### Bug 2: `strip_path: false` causes 404 on all auth and REST routes

```yaml
# Before (broken)
strip_path: false
```
```yaml
# After (fixed)
strip_path: true
```

**Impact**: When Kong forwards requests to GoTrue (`/auth/v1/health`) or PostgREST (`/rest/v1/`), it passes the full path including the prefix to the upstream. Since GoTrue listens on `/health` (not `/auth/v1/health`), **all auth requests return 404**. Setting `strip_path: true` strips the route prefix before proxying.

---

Both bugs were **confirmed in production** on a Pigsty 4.1 multi-tenant environment.