### PR TITLE
fix(multi-tenant): add missing API_EXTERNAL_URL and make KONG_YML path configurable

### DIFF
--- a/scripts/lib/gateway_manager.sh
+++ b/scripts/lib/gateway_manager.sh
@@ -126,7 +126,9 @@ enable_jwt() {
 # ========== Per-Tenant Upstream（方案C+：多租户动态路由 - 声明式） ==========
 # 将租户配置追加到 Kong Declarative YAML 中并热重载
 rebuild_kong_config() {
-    local KONG_YML="/root/pigsty/app/supabase/volumes/api/kong.yml"
+    # 支持通过 KONG_YML 环境变量覆盖路径，以适配不同部署场景（Pigsty / 自定义安装）
+    # 默认路径对应 Pigsty 标准安装目录
+    local KONG_YML="${KONG_YML:-/root/pigsty/app/supabase/volumes/api/kong.yml}"
     local KONG_BASE="${KONG_YML}.base"
     local TENANT_DIR="/etc/supabase/kong_tenants"
     

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -200,6 +200,17 @@ generate_tenant_config() {
         exit 1
     fi
 
+    # 查询租户的 API 外部访问 URL（用于 GoTrue API_EXTERNAL_URL）
+    # 优先级：环境变量覆盖 > supacloud_meta.projects.api_url > 默认占位值
+    local api_external_url="${GOTRUE_API_EXTERNAL_URL:-}"
+    if [ -z "$api_external_url" ]; then
+        api_external_url=$(get_tenant_credentials "$ref" "api_url" 2>/dev/null || true)
+    fi
+    if [ -z "$api_external_url" ]; then
+        api_external_url="https://your-supacloud-domain.com"
+        echo "WARNING: API_EXTERNAL_URL not set. Set GOTRUE_API_EXTERNAL_URL env var or add api_url to supacloud_meta.projects" >&2
+    fi
+
     # 1. 生成 PostgREST .env 和 .conf
     cat > "${TENANT_CONFIG_DIR}/${ref}.env" <<EOF
 # SupaCloud Tenant PostgREST Runtime: ${ref}
@@ -235,6 +246,8 @@ EOF
 # Bug Fix: 绑定到 0.0.0.0 以允许 Kong 容器通过宿主机桥接 IP 访问
 GOTRUE_API_HOST=0.0.0.0
 GOTRUE_API_PORT=${gotrue_port}
+# Required: external URL used for email verification links and OAuth redirects
+API_EXTERNAL_URL=${api_external_url}
 GOTRUE_DB_DRIVER=postgres
 GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:${db_password}@${PG_HOST}:${PG_PORT}/${db_name}
 GOTRUE_SITE_URL=http://localhost:3000


### PR DESCRIPTION
## Problems

Two issues found in production multi-tenant deployment.

---

### Bug 1: GoTrue fatal crash — `API_EXTERNAL_URL` missing from env template

```
{"level":"fatal","msg":"Failed to load configuration: required key API_EXTERNAL_URL missing value"}
```

`API_EXTERNAL_URL` is a **required field** for GoTrue (used for email verification links and OAuth redirects). It was completely absent from the generated `_gotrue.env` template in `tenant_runtime.sh`, causing every new tenant's GoTrue instance to crash on startup immediately.

**Fix**: Query `api_url` from `supacloud_meta.projects` table, with fallbacks:
1. `GOTRUE_API_EXTERNAL_URL` environment variable (highest priority)
2. `api_url` column from `supacloud_meta.projects`
3. Placeholder string with a `WARNING` message printed to stderr

---

### Bug 2: `KONG_YML` path hardcoded — breaks non-Pigsty installations

```bash
# Before (hardcoded, non-configurable)
local KONG_YML="/root/pigsty/app/supabase/volumes/api/kong.yml"
```

This path only works on Pigsty-standard deployments. Any other installation layout causes:
```
WARNING: /root/pigsty/app/supabase/volumes/api/kong.yml not found, skip kong reload
```
meaning Kong never gets updated and tenant routes silently fail.

**Fix**: Read from `$KONG_YML` environment variable with the Pigsty path as the default:
```bash
local KONG_YML="${KONG_YML:-/root/pigsty/app/supabase/volumes/api/kong.yml}"
```

---

## Changes

- **`scripts/lib/tenant_runtime.sh`**: Added `API_EXTERNAL_URL` to GoTrue env template with dynamic resolution
- **`scripts/lib/gateway_manager.sh`**: `KONG_YML` is now configurable via environment variable