### PR TITLE
fix(jwt): add missing 'aud' claim to generated JWTs

### DIFF
--- a/scripts/lib/jwt_manager.sh
+++ b/scripts/lib/jwt_manager.sh
@@ -35,7 +35,9 @@ generate_jwt() {
     local exp=$((now + 315360000)) # 10 年
 
     local header='{"alg":"HS256","typ":"JWT"}'
-    local payload="{\"role\":\"${role}\",\"iss\":\"supabase\",\"iat\":${now},\"exp\":${exp}}"
+    # Supabase/GoTrue default behavior requires an 'aud' claim to query correct schemas and user records.
+    # Without 'aud' (even as service_role), Admin APIs mistakenly filter out 'authenticated' users. 
+    local payload="{\"aud\":\"authenticated\",\"role\":\"${role}\",\"iss\":\"supabase\",\"iat\":${now},\"exp\":${exp}}"
 
     local encoded_header
     encoded_header=$(echo -n "$header" | base64url_encode)


### PR DESCRIPTION
Supabase GoTrue's admin APIs implicitly filter users if the admin JWT does not contain an 'aud' claim. This causes 'duplicate key' errors on user creation when an existing user is incorrectly filtered out by listUsers. This PR adds 'aud: authenticated' to the generated payload.