### PR TITLE
fix(cli): push migrations through management API

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,16 @@ type ToolMap = Record<string, ToolEntry>;
 const projectActionSchema = z.enum(["get", "health", "logs", "api_keys", "settings", "tasks"]);
 const genericActionSchema = z.string();
 
+function unwrapMcpSchema(schema: any): any {
+    if (schema && typeof schema === "object" && !Array.isArray(schema) && "args" in schema) {
+        const argsSchema = schema.args;
+        if (argsSchema && typeof argsSchema === "object" && !Array.isArray(argsSchema)) {
+            return argsSchema;
+        }
+    }
+    return schema;
+}
+
 function captureTools(register: (server: { tool: (...args: any[]) => void }) => void): ToolMap {
     const tools: ToolMap = {};
     const server = {
@@ -24,7 +34,7 @@ function captureTools(register: (server: { tool: (...args: any[]) => void }) => 
             if (typeof schemaOrCallback === "function") {
                 tools[name] = { schema: {}, callback: schemaOrCallback };
             } else {
-                tools[name] = { schema: schemaOrCallback, callback };
+                tools[name] = { schema: unwrapMcpSchema(schemaOrCallback), callback };
             }
         },
     };
@@ -182,10 +192,11 @@ function createCliTools(): ToolMap {
     assign(captureTools((server) => registerUserProjectCliTools(server as any, http, {
         projectRef: context.projectRef || undefined,
     })));
-    assign(captureTools((server) => registerDatabaseTools(server as any, http, {
+    const databaseTools = captureTools((server) => registerDatabaseTools(server as any, http, {
         projectRef: context.projectRef || undefined,
         readOnly: context.readOnly,
-    })));
+    }));
+    assign(databaseTools);
     assign(captureTools((server) => registerAuthTools(server as any, http)));
     assign(captureTools((server) => registerStorageTools(server as any, http)));
     assign(captureTools((server) => registerAdvancedTools(server as any, http)));

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -2,6 +2,8 @@
  * Database — Compound tool (18→1)
  * SQL execution, schema introspection, RLS, migrations, stats
  */
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
 import { z } from "zod";
 import type { HttpTransport } from "../transports/http";
 
@@ -40,7 +42,7 @@ export function registerDatabaseTools(
         "connections", "stats", "slow_queries",
         "list_migrations", "project_url", "generate_types",
     ] as const;
-    const writeActions = ["apply_migration", "create_table_rls"] as const;
+    const writeActions = ["apply_migration", "push_migrations", "create_table_rls"] as const;
     const allActions = readOnly ? actions : [...actions, ...writeActions];
 
     server.tool(
@@ -53,6 +55,8 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
             // query
             sql: z.string().optional().describe("[query/apply_migration] SQL statement"),
             file: z.string().optional().describe("[query/apply_migration] Read SQL from local file path (avoids shell escaping issues with $$ and multi-statement DDL)"),
+            dir: z.string().optional().describe("[push_migrations] Directory containing .sql migration files (default: supabase/migrations)"),
+            dry_run: z.boolean().optional().describe("[push_migrations] List pending migration files without applying them"),
             // schema
             schema: z.string().optional().describe("[*] Schema name (default: public)"),
             table: z.string().optional().describe("[describe_columns/indexes/constraints/rls_*] Table name"),
@@ -74,7 +78,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
             // Resolve SQL from --file if provided (avoids shell $$ and ; escaping)
             if (args.file && !args.sql) {
                 try {
-                    args.sql = require("fs").readFileSync(args.file, "utf-8");
+                    args.sql = readFileSync(args.file, "utf-8");
                 } catch (e: any) {
                     return { content: [{ type: "text" as const, text: `❌ Failed to read file ${args.file}: ${e.message}` }] };
                 }
@@ -194,6 +198,59 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     if (!args.name || !args.sql) throw new Error("'name' and 'sql' required");
                     const r = await http.post(`/v1/projects/${ref}/database/migrations`, { name: args.name, sql: args.sql });
                     text = r.ok ? `✅ Migration '${args.name}' applied` : `❌ Failed (${r.status}): ${JSON.stringify(r.data)}`;
+                    break;
+                }
+                case "push_migrations": {
+                    const dir = args.dir || "supabase/migrations";
+                    if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+                        throw new Error(`Migration directory not found: ${dir}`);
+                    }
+
+                    const files = readdirSync(dir)
+                        .filter((file) => file.endsWith(".sql"))
+                        .sort();
+
+                    if (!files.length) {
+                        text = `No .sql migration files found in ${dir}`;
+                        break;
+                    }
+
+                    if (args.dry_run) {
+                        text = [`Found ${files.length} migration file(s) in ${dir}:`, ...files.map((file) => `  - ${file}`)].join("\n");
+                        break;
+                    }
+
+                    const applied: string[] = [];
+                    const skipped: string[] = [];
+                    for (let i = 0; i < files.length; i++) {
+                        const file = files[i];
+                        const name = basename(file, ".sql");
+                        const sql = readFileSync(join(dir, file), "utf-8");
+                        const version = Date.now() * 1000 + i;
+                        const r = await http.post(`/v1/projects/${ref}/database/migrations`, { name, sql, version });
+                        if (r.ok) {
+                            applied.push(file);
+                        } else if (r.status === 409) {
+                            skipped.push(file);
+                        } else {
+                            text = [
+                                `❌ Failed to apply ${file} (${r.status})`,
+                                JSON.stringify(r.data, null, 2),
+                                "",
+                                `Applied before failure: ${applied.length}`,
+                                `Skipped before failure: ${skipped.length}`,
+                            ].join("\n");
+                            return { content: [{ type: "text" as const, text }] };
+                        }
+                    }
+
+                    text = [
+                        `✅ Migration push completed for ${dir}`,
+                        `Applied: ${applied.length}`,
+                        `Skipped: ${skipped.length}`,
+                        ...(applied.length ? ["", "Applied files:", ...applied.map((file) => `  - ${file}`)] : []),
+                        ...(skipped.length ? ["", "Skipped files:", ...skipped.map((file) => `  - ${file}`)] : []),
+                    ].join("\n");
                     break;
                 }
                 case "create_table_rls": {

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -268,33 +268,21 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
             const projectDb = getProjectDb(dbName);
 
             try {
-                const migrationTableExists = await projectDb`
-                    SELECT EXISTS (
-                        SELECT FROM information_schema.tables
-                        WHERE table_schema IN ('public', 'supabase_migrations')
-                        AND table_name = 'schema_migrations'
-                    ) AS exists
+                await projectDb.unsafe(`CREATE SCHEMA IF NOT EXISTS supabase_migrations`);
+                await projectDb`
+                    CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
+                        version BIGINT PRIMARY KEY,
+                        statements TEXT[],
+                        name TEXT
+                    )
                 `;
-
-                const tableExists = (migrationTableExists as Array<{ exists: boolean }>)[0]?.exists ?? false;
-
-                if (!tableExists) {
-                    await projectDb.unsafe(`CREATE SCHEMA IF NOT EXISTS supabase_migrations`);
-                    await projectDb`
-                        CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
-                            version BIGINT PRIMARY KEY,
-                            statements TEXT[],
-                            name TEXT
-                        )
-                    `;
-                    await projectDb`
-                        CREATE TABLE IF NOT EXISTS public.schema_migrations (
-                            version VARCHAR(255) PRIMARY KEY,
-                            statements TEXT[],
-                            name TEXT
-                        )
-                    `;
-                }
+                await projectDb`
+                    CREATE TABLE IF NOT EXISTS public.schema_migrations (
+                        version VARCHAR(255) PRIMARY KEY,
+                        statements TEXT[],
+                        name TEXT
+                    )
+                `;
 
                 const isCliFormat = 'query' in body && typeof (body as Record<string, unknown>).query === 'string';
                 const isStructuredFormat = ('name' in body && 'sql' in body) || ('name' in body && 'statements' in body);
@@ -363,8 +351,10 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
                 return { message: "Body must contain {query} or {name, sql}", code: "400", status: 400 };
             } catch (error: unknown) {
                 set.status = 500;
+                const detail = error instanceof Error ? error.message : String(error);
                 return {
                     message: "Migration failed",
+                    detail,
                     code: "500",
                     status: 500,
                 };


### PR DESCRIPTION
## Summary

This fixes a SupaCloud platform gap exposed by AoristCross migrations: users had to rely on official Supabase CLI direct DB connections (`5432`/`6543`) because `@supacloud/cli` did not provide a project-scoped migration directory push path through the Management API.

Changes:
- Add `supacloud database push_migrations --dir <path>` using Management API `/v1/projects/:ref/database/migrations`
- Add `--dry_run` for local migration discovery without applying SQL
- Return concrete migration failure details from Management API instead of opaque `Migration failed` responses
- Keep the migration path project-scoped via `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` / `SUPACLOUD_*` env

## Verification

- `cd packages/cli && bun run typecheck`
- `cd packages/management-api && bunx tsc --noEmit --ignoreDeprecations 6.0`
- `cd packages/management-api && bun test tests/unit/database-routes.test.ts`
- `cd /Volumes/Data/workspace/AoristCross && SUPABASE_URL=https://api.aorist.net SUPABASE_SERVICE_ROLE_KEY=<redacted> SUPACLOUD_PROJECT_REF=77az24zz7p bun /Volumes/Data/workspace/supacloud/packages/cli/src/index.ts database push_migrations --dir supabase/migrations --dry_run`

The AoristCross dry run discovered 34 migration files.

## Notes

This is a SupaCloud CLI/platform issue, not an AoristCross SQL issue. No AoristCross project migration was applied in this PR.