### PR TITLE
feat: configure edge function runtime flags from CLI

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,6 +76,7 @@ EXAMPLES
   supacloud frontend list --ref abc123
   supacloud database query --sql "select now()"
   supacloud edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
+  supacloud edge_functions config --ref abc123 --slug hello --verify_jwt false --background_routes "/queue/*,/render/*"
 
 SEPARATE ADMIN CLI
 

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { registerAdvancedTools } from "./advanced-tools";
+
+function captureEdgeFunctionsTool(http: Record<string, unknown>) {
+    let schema: Record<string, unknown> | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+    registerAdvancedTools({
+        tool(name: string, _description: string, toolSchema: Record<string, unknown>, toolCallback: typeof callback) {
+            if (name !== "edge_functions") return;
+            schema = toolSchema;
+            callback = toolCallback;
+        },
+    }, http as any);
+
+    if (!schema || !callback) throw new Error("edge_functions tool was not registered");
+    return { schema, callback };
+}
+
+describe("edge_functions CLI tool", () => {
+    test("parses background routes from CLI-friendly comma-separated input", () => {
+        const { schema } = captureEdgeFunctionsTool({});
+        const parsed = z.object(schema as any).parse({
+            action: "config",
+            ref: "proj",
+            slug: "render",
+            verify_jwt: false,
+            background_routes: "/queue/*,/render/*",
+        });
+
+        expect(parsed.background_routes).toEqual(["/queue/*", "/render/*"]);
+    });
+
+    test("updates Edge Function config through the management API", async () => {
+        const calls: Array<{ path: string; body: unknown }> = [];
+        const { callback } = captureEdgeFunctionsTool({
+            patch: async (path: string, body: unknown) => {
+                calls.push({ path, body });
+                return { ok: true, status: 200, data: { verify_jwt: false, background_routes: ["/queue/*"] } };
+            },
+        });
+
+        const result = await callback({
+            action: "config",
+            ref: "proj",
+            slug: "render",
+            verify_jwt: false,
+            background_routes: ["/queue/*"],
+        });
+
+        expect(calls).toEqual([
+            {
+                path: "/v1/projects/proj/functions/render/config",
+                body: { verify_jwt: false, background_routes: ["/queue/*"] },
+            },
+        ]);
+        expect(result.content[0].text).toContain("Function render config updated");
+    });
+
+    test("patches config after bundle deployment when config flags are provided", async () => {
+        const calls: Array<{ method: string; path: string; body: unknown }> = [];
+        const { callback } = captureEdgeFunctionsTool({
+            post: async (path: string, body: unknown) => {
+                calls.push({ method: "post", path, body });
+                return { ok: true, status: 200, data: { success: true } };
+            },
+            patch: async (path: string, body: unknown) => {
+                calls.push({ method: "patch", path, body });
+                return { ok: true, status: 200, data: { verify_jwt: true, background_routes: ["/work/*"] } };
+            },
+        });
+
+        const result = await callback({
+            action: "deploy_bundle",
+            ref: "proj",
+            slug: "worker",
+            files: { "index.ts": "export default {}" },
+            verify_jwt: true,
+            background_routes: ["/work/*"],
+        });
+
+        expect(calls).toEqual([
+            {
+                method: "post",
+                path: "/v1/projects/proj/functions/worker/bundle",
+                body: { files: { "index.ts": "export default {}" }, entrypoint: undefined, minify: undefined },
+            },
+            {
+                method: "patch",
+                path: "/v1/projects/proj/functions/worker/config",
+                body: { verify_jwt: true, background_routes: ["/work/*"] },
+            },
+        ]);
+        expect(result.content[0].text).toContain("Function worker bundle deployed");
+        expect(result.content[0].text).toContain("Function worker config updated");
+    });
+});

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -47,29 +47,62 @@ function resolveEntrypoint(pathArg: string): string {
     return entrypoint;
 }
 
+const backgroundRoutesSchema = z.preprocess((value) => {
+    if (typeof value !== "string") return value;
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith("[")) return JSON.parse(trimmed);
+    return trimmed.split(",").map((route) => route.trim()).filter(Boolean);
+}, z.array(z.string()).optional());
+
+type EdgeFunctionConfigInput = {
+    verify_jwt?: boolean;
+    background_routes?: string[];
+};
+
 export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
 
     // ═══ Edge Functions (5→1) ═══
     server.tool(
         "edge_functions",
         `Edge Function management (Deno/Bun serverless). Server auto-bundles dependencies.
-Actions: list, deploy, deploy_bundle, source, delete, check`,
+Actions: list, deploy, deploy_bundle, config, source, delete, check`,
         {
-            action: z.enum(["list", "deploy", "deploy_bundle", "source", "delete", "check"]).describe("Action"),
+            action: z.enum(["list", "deploy", "deploy_bundle", "config", "source", "delete", "check"]).describe("Action"),
             ref: z.string().describe("Project ref"),
-            slug: z.string().optional().describe("[deploy/deploy_bundle/source/delete/check] Function name"),
+            slug: z.string().optional().describe("[deploy/deploy_bundle/config/source/delete/check] Function name"),
             code: z.string().optional().describe("[deploy/check] Function source code (TypeScript)"),
             path: z.string().optional().describe("[deploy/check] Local file path to read code from (alternative to code)"),
             files: z.record(z.string()).optional().describe("[deploy_bundle] File map: { 'index.ts': '...', '_shared/x.ts': '...' }"),
             entrypoint: z.string().optional().describe("[deploy_bundle] Entrypoint file (default: index.ts)"),
             minify: z.boolean().optional().describe("[deploy/deploy_bundle] Minify bundle"),
+            verify_jwt: z.boolean().optional().describe("[deploy/deploy_bundle/config] Set JWT verification for this function"),
+            background_routes: backgroundRoutesSchema.describe("[deploy/deploy_bundle/config] Background route paths; pass comma-separated or JSON array in CLI"),
         },
         async (args: any) => {
-            const { action, ref, slug, path: pathArg, files, entrypoint, minify } = args;
+            const { action, ref, slug, path: pathArg, files, entrypoint, minify, verify_jwt, background_routes } = args;
             let code = args.code as string | undefined;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
 
             let text: string;
+
+            const functionConfig = (): EdgeFunctionConfigInput => ({
+                ...(typeof verify_jwt === "boolean" ? { verify_jwt } : {}),
+                ...(Array.isArray(background_routes) ? { background_routes } : {}),
+            });
+
+            const hasFunctionConfig = () => Object.keys(functionConfig()).length > 0;
+
+            const updateFunctionConfig = async (): Promise<string> => {
+                need("slug", slug);
+                if (!hasFunctionConfig()) {
+                    throw new Error("'verify_jwt' or 'background_routes' required for 'config'");
+                }
+                const cr = await http.patch(`/v1/projects/${ref}/functions/${slug}/config`, functionConfig());
+                return cr.ok
+                    ? `✅ Function ${slug} config updated\n${JSON.stringify(cr.data, null, 2)}`
+                    : `❌ Config update failed (${cr.status}): ${JSON.stringify(cr.data)}`;
+            };
 
             const checkSyntax = async (sourceCode: string): Promise<{ ok: boolean; err?: string }> => {
                 const tmpDir = mkdtempSync(join(tmpdir(), "supacloud-edge-check-"));
@@ -114,12 +147,27 @@ Actions: list, deploy, deploy_bundle, source, delete, check`,
                         break;
                     }
                     const dr = await http.post(`/v1/projects/${ref}/functions/${slug}`, { code, minify });
-                    text = dr.ok ? `✅ Function ${slug} deployed` : `❌ Failed (${dr.status}): ${JSON.stringify(dr.data)}`;
+                    if (!dr.ok) {
+                        text = `❌ Failed (${dr.status}): ${JSON.stringify(dr.data)}`;
+                        break;
+                    }
+                    text = hasFunctionConfig()
+                        ? `✅ Function ${slug} deployed\n${await updateFunctionConfig()}`
+                        : `✅ Function ${slug} deployed`;
                     break;
                 case "deploy_bundle":
                     need("slug", slug); need("files", files);
                     const br = await http.post(`/v1/projects/${ref}/functions/${slug}/bundle`, { files, entrypoint, minify });
-                    text = br.ok ? `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)` : `❌ Failed (${br.status}): ${JSON.stringify(br.data)}`;
+                    if (!br.ok) {
+                        text = `❌ Failed (${br.status}): ${JSON.stringify(br.data)}`;
+                        break;
+                    }
+                    text = hasFunctionConfig()
+                        ? `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)\n${await updateFunctionConfig()}`
+                        : `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)`;
+                    break;
+                case "config":
+                    text = await updateFunctionConfig();
                     break;
                 case "source":
                     need("slug", slug);


### PR DESCRIPTION
## Summary
- Add edge_functions config action for verify_jwt and background_routes.
- Allow deploy/deploy_bundle to patch runtime config in the same command.
- Accept comma-separated background route input for CLI usage and keep JSON-array/MCP usage working.
- Add CLI tool tests for parsing, config patching, and deploy_bundle config updates.

## Why
The Management API already supports these Edge Function runtime flags, but the project CLI did not expose them. Projects with background routes had to keep custom deployment scripts just to patch config after bundle deploys.

## Validation
- bun test packages/cli/src/shared/tools/advanced-tools.test.ts packages/cli/src/shared/tools/database-tools.test.ts
- cd packages/cli && bun run typecheck
- cd packages/cli && bun run build
