### PR TITLE
fix: accept project ref on internal gateway hosts

### DIFF
--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -65,10 +65,30 @@ function hostBelongsToBaseDomain(host: string): boolean {
     return host === baseDomain || host.endsWith(`.${baseDomain}`);
 }
 
-function isLoopbackRequestHost(request: Request): boolean {
-    const host = firstForwardedHost(request);
+function isPrivateIpv4Host(host: string): boolean {
+    const parts = host.split(".").map((part) => Number(part));
+    if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+    const [a, b] = parts;
+    return a === 10
+        || a === 127
+        || (a === 172 && b >= 16 && b <= 31)
+        || (a === 192 && b === 168)
+        || (a === 169 && b === 254);
+}
+
+function isLoopbackOrPrivateHost(host: string): boolean {
     if (!host) return true;
-    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+    return host === "localhost" || host === "127.0.0.1" || host === "::1" || isPrivateIpv4Host(host);
+}
+
+function isGatewayHost(host: string): boolean {
+    if (isLoopbackOrPrivateHost(host)) return true;
+    const baseDomain = config.baseDomain?.toLowerCase();
+    return Boolean(baseDomain && (host === baseDomain || host === `api.${baseDomain}`));
+}
+
+function isLoopbackRequestHost(request: Request): boolean {
+    return isLoopbackOrPrivateHost(firstForwardedHost(request));
 }
 
 function isTestTenantAuthAllowed(request: Request): boolean {
@@ -331,6 +351,18 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, request: Request)
     for (const rawHost of rawHosts) {
         const host = rawHost.split(',')[0].trim().split(':')[0];
         if (!host) continue;
+
+        if (isGatewayHost(host)) {
+            const rows = await metaSql`
+                SELECT ref
+                FROM projects
+                WHERE ref = ${ref}
+                  AND deleted_at IS NULL
+                  AND status = 'active'
+                LIMIT 1
+            `;
+            return rows.length > 0 && rows[0].ref === ref ? ref : '';
+        }
 
         if (config.baseDomain && host === `${ref}.api.${config.baseDomain}`) {
             return ref;

--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -198,8 +198,47 @@ function isLoopbackHost(host: string): boolean {
     return host === "localhost" || host === "127.0.0.1" || host === "::1";
 }
 
+function isPrivateIpv4Host(host: string): boolean {
+    const parts = host.split(".").map((part) => Number(part));
+    if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+    const [a, b] = parts;
+    return a === 10
+        || a === 127
+        || (a === 172 && b >= 16 && b <= 31)
+        || (a === 192 && b === 168)
+        || (a === 169 && b === 254);
+}
+
+function isGatewayHost(host: string): boolean {
+    if (isLoopbackHost(host) || isPrivateIpv4Host(host)) return true;
+    const baseDomain = config.baseDomain?.toLowerCase();
+    return Boolean(baseDomain && (host === baseDomain || host === `api.${baseDomain}`));
+}
+
 async function resolveProjectRefFromHeaderAndHost(ref: string, host: string): Promise<string> {
     if (!ref || !host) return '';
+    if (isGatewayHost(host)) {
+        try {
+            const { sql } = await import('../db');
+            const rows = await sql`
+                SELECT ref
+                FROM projects
+                WHERE ref = ${ref}
+                  AND deleted_at IS NULL
+                  AND status = 'active'
+                LIMIT 1
+            `;
+            return rows.length > 0 && String(rows[0].ref) === ref ? ref : '';
+        } catch (error: unknown) {
+            logger.warn("[StorageCompat] Failed to validate project header on gateway host", {
+                ref,
+                host,
+                error: error instanceof Error ? error.message : String(error),
+            });
+            return '';
+        }
+    }
+
     try {
         const { sql } = await import('../db');
         const rows = await sql`

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -284,6 +284,39 @@ describe("sdkProxyRoutes functions proxy", () => {
     });
   });
 
+  test("rest proxy accepts project ref on an internal gateway host without apikey", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      const sqlSpy = trackSpy(spyOn(dbModule, "sql"));
+      sqlSpy.mockImplementation(async (...args: unknown[]) => {
+        const text = String(args[0] ?? "");
+        if (text.includes("SELECT ref")) {
+          return [{ ref: "proj_1" }];
+        }
+        if (text.includes("SELECT config")) {
+          return [{
+            config: {
+              postgrest_port: 7361,
+              gotrue_port: 8361,
+            },
+          }];
+        }
+        return [];
+      });
+
+      const response = await request("/rest/v1/todos?select=*", {
+        method: "GET",
+        headers: {
+          host: "192.168.1.168:4100",
+          "x-project-ref": "proj_1",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("http://127.0.0.1:7361/todos?select=*");
+    });
+  });
+
   test("proxy rejects mismatched project header and apikey", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
       const sqlSpy = trackSpy(spyOn(dbModule, "sql"));

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -113,6 +113,37 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     sqlSpy.mockRestore();
   });
 
+  test("accepts project ref on an internal gateway host without apikey", async () => {
+    const sqlSpy = spyOn(dbModule, "sql");
+    sqlSpy.mockImplementation(async (...args: unknown[]) => {
+      const text = String(args[0] ?? "");
+      if (text.includes("FROM projects")) {
+        return [{ ref: "proj_from_header" }];
+      }
+      return [];
+    });
+    const listSpy = spyOn(StorageRLS, "listLogicalBuckets").mockResolvedValue([{
+      id: "manuals",
+      name: "manuals",
+      public: false,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }]);
+
+    const res = await request("/storage/v1/bucket", {
+      headers: {
+        host: "192.168.1.168:9090",
+        "x-project-ref": "proj_from_header",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([expect.objectContaining({ id: "manuals" })]);
+    expect(listSpy).toHaveBeenCalledWith("proj_from_header", undefined, expect.any(Object));
+    sqlSpy.mockRestore();
+    listSpy.mockRestore();
+  });
+
   test("rejects mismatched host tenant and apikey", async () => {
     const sqlSpy = spyOn(dbModule, "sql");
     sqlSpy.mockImplementation(async (...args: unknown[]) => {


### PR DESCRIPTION
## Summary
- allow SDK proxy project-ref resolution on internal gateway hosts such as localhost and private IPs
- apply the same gateway-host handling to storage compatibility routes
- add regression tests for REST and Storage requests that carry only x-project-ref through an internal gateway

## Verification
- bun test tests/unit/sdk-proxy.functions.test.ts tests/unit/storage-compat.sdk.test.ts
- bun run typecheck

## Context
A self-hosted deployment was returning 400 Missing tenant reference for REST/RPC requests through 192.168.x.x gateway hosts even when x-project-ref was present. Tenant-specific/custom hosts are still validated against the project binding; the relaxed path only applies to loopback/private/base-domain gateway hosts and still requires an active project ref.