### PR TITLE
fix(edge-runtime): preserve env for waitUntil tasks

### DIFF
--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun run --watch server.ts",
     "start": "bun run server.ts",
-    "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts auto-deps.ts deno-compat.ts url-import-plugin.ts shims/*.ts"
+    "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts worker-executor.ts worker-pool.ts auto-deps.ts deno-compat.ts url-import-plugin.ts shims/*.ts"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.0",

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -33,6 +33,7 @@ const originalBunEnv = bunRuntime ? { ...bunRuntime.env } : null;
 let envSnapshotActive = false;
 let currentAbortController: AbortController | null = null;
 let currentInjectedEnv: Record<string, string> = {};
+let currentWaitUntilTasks: Promise<unknown>[] = [];
 
 function injectEnv(env: Record<string, string>) {
   if (envSnapshotActive) restoreEnv();
@@ -100,6 +101,35 @@ function restoreConsole() {
   console.error = originalConsole.error;
   console.info = originalConsole.info;
   console.debug = originalConsole.debug;
+}
+
+function setupEdgeRuntimeCompat() {
+  currentWaitUntilTasks = [];
+  (globalThis as any).EdgeRuntime = {
+    waitUntil(promise: PromiseLike<unknown> | unknown) {
+      const task = Promise.resolve(promise).catch((error) => {
+        console.error("[EdgeRuntime.waitUntil] background task failed", error);
+      });
+      currentWaitUntilTasks.push(task);
+    },
+  };
+}
+
+async function flushWaitUntilTasks(functionId: string) {
+  if (currentWaitUntilTasks.length === 0) return;
+  while (currentWaitUntilTasks.length > 0) {
+    const tasks = currentWaitUntilTasks.splice(0);
+    await Promise.allSettled(tasks);
+  }
+  parentPort!.postMessage({
+    type: "wait_until_done",
+    functionId,
+  });
+}
+
+function clearEdgeRuntimeCompat() {
+  currentWaitUntilTasks = [];
+  delete (globalThis as any).EdgeRuntime;
 }
 
 async function loadModule(functionPath: string): Promise<any> {
@@ -207,6 +237,7 @@ parentPort.on("message", async (msg: any) => {
   injectEnv(env);
   setInjectedEnv(env);
   setupConsoleCapture(functionId);
+  setupEdgeRuntimeCompat();
 
   try {
     const handler = await loadModule(functionPath);
@@ -284,7 +315,9 @@ parentPort.on("message", async (msg: any) => {
       status: response.status,
       headers: resHeaders,
       body: resBody,
+      waitUntilPending: currentWaitUntilTasks.length > 0,
     });
+    await flushWaitUntilTasks(functionId);
   } catch (err: any) {
     const aborted = currentAbortController?.signal.aborted || err?.name === "AbortError";
     const message = err instanceof Error ? err.message : String(err);
@@ -297,6 +330,7 @@ parentPort.on("message", async (msg: any) => {
     });
   } finally {
     currentAbortController = null;
+    clearEdgeRuntimeCompat();
     restoreEnv();
     restoreConsole();
     setTenantRef(null);

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { WorkerPool } from "./worker-pool";
+
+const pools: WorkerPool[] = [];
+
+afterEach(async () => {
+  for (const pool of pools.splice(0)) {
+    for (const worker of (pool as any).workers || []) {
+      await worker.terminate();
+    }
+  }
+});
+
+async function waitForFile(path: string, timeoutMs = 2_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return Bun.file(path).text();
+    await Bun.sleep(20);
+  }
+  throw new Error(`Timed out waiting for ${path}`);
+}
+
+describe("WorkerPool EdgeRuntime.waitUntil", () => {
+  test("keeps tenant env available after the HTTP response is returned", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-waituntil-"));
+    const outputPath = join(projectRoot, "waituntil.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch() {
+          globalThis.EdgeRuntime.waitUntil((async () => {
+            await Bun.sleep(25);
+            await Bun.write(process.env.OUT_FILE, process.env.SUPABASE_URL || "missing");
+          })());
+          return new Response("queued", { status: 202 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_waituntil",
+        functionPath,
+        projectRoot,
+        env: {
+          OUT_FILE: outputPath,
+          SUPABASE_URL: "http://tenant.local",
+        },
+        request: new Request("http://edge.local/functions/v1/waituntil", { method: "POST" }),
+      });
+
+      expect(response.status).toBe(202);
+      expect(await response.text()).toBe("queued");
+      expect(await waitForFile(outputPath)).toBe("http://tenant.local");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -18,6 +18,7 @@ interface DispatchOptions {
 const MAX_BODY_SIZE = 10 * 1024 * 1024;
 const MAX_QUEUE_SIZE = Number(process.env.MAX_QUEUE_SIZE) || 200;
 const WORKER_SMOL = process.env.WORKER_SMOL !== "false";
+const WAIT_UNTIL_TIMEOUT_MS = Number(process.env.EDGE_WAIT_UNTIL_TIMEOUT_MS) || 300_000;
 
 export class WorkerPool {
   private workers: Worker[] = [];
@@ -221,6 +222,8 @@ export class WorkerPool {
       });
     }
 
+    let waitUntilTimeout: ReturnType<typeof setTimeout> | undefined;
+
     const onMsg = (msg: {
       type?: string;
       status: number;
@@ -231,6 +234,7 @@ export class WorkerPool {
       stream?: "stdout" | "stderr";
       level?: string;
       message?: string;
+      waitUntilPending?: boolean;
     }) => {
       if (msg.type === "log" && opts.onLog && msg.timestamp && msg.stream && msg.level && msg.message) {
         opts.onLog({
@@ -239,6 +243,16 @@ export class WorkerPool {
           level: msg.level,
           message: msg.message,
         });
+        return;
+      }
+
+      if (msg.type === "wait_until_done") {
+        clearTimeout(timeout);
+        cleanupInFlight();
+        clearCancellationState();
+        worker.removeListener("error", onErr);
+        worker.removeListener("message", onMsg);
+        this.recycle(worker);
         return;
       }
 
@@ -255,8 +269,19 @@ export class WorkerPool {
       clearTimeout(timeout);
       cleanupInFlight();
       clearCancellationState();
-      worker.removeListener("error", onErr);
-      worker.removeListener("message", onMsg);
+      const waitUntilPending = msg.waitUntilPending === true;
+      if (!waitUntilPending) {
+        worker.removeListener("error", onErr);
+        worker.removeListener("message", onMsg);
+      } else {
+        waitUntilTimeout = setTimeout(() => {
+          worker.removeAllListeners("message");
+          worker.removeListener("error", onErr);
+          clearCancellationState();
+          console.error("[Pool] EdgeRuntime.waitUntil timed out; replacing worker");
+          this.replaceWorker(worker);
+        }, WAIT_UNTIL_TIMEOUT_MS);
+      }
 
       const resHeaders = new Headers();
       for (const [k, v] of Object.entries(msg.headers ?? {})) {
@@ -315,12 +340,34 @@ export class WorkerPool {
             headers: resHeaders,
           }),
         );
-        this.recycle(worker);
+        if (waitUntilPending) {
+          worker.removeListener("message", onMsg);
+          const waitUntilListener = (waitMsg: any) => {
+            if (waitMsg.type === "log" && opts.onLog && waitMsg.timestamp && waitMsg.stream && waitMsg.level && waitMsg.message) {
+              opts.onLog({
+                timestamp: waitMsg.timestamp,
+                stream: waitMsg.stream,
+                level: waitMsg.level,
+                message: waitMsg.message,
+              });
+              return;
+            }
+            if (waitMsg.type !== "wait_until_done") return;
+            if (waitUntilTimeout) clearTimeout(waitUntilTimeout);
+            worker.removeListener("message", waitUntilListener);
+            worker.removeListener("error", onErr);
+            this.recycle(worker);
+          };
+          worker.on("message", waitUntilListener);
+        } else {
+          this.recycle(worker);
+        }
       }
     };
 
     const onErr = (err: Error) => {
       clearTimeout(timeout);
+      if (waitUntilTimeout) clearTimeout(waitUntilTimeout);
       cleanupInFlight();
       clearCancellationState();
       worker.removeListener("message", onMsg);

--- a/packages/management-api/src/lib/pg-listen.ts
+++ b/packages/management-api/src/lib/pg-listen.ts
@@ -29,6 +29,8 @@ export interface PgListenerOptions {
   reconnectDelay?: number;
   /** Maximum reconnect delay in ms (default: 300000 = 5 minutes) */
   maxReconnectDelay?: number;
+  /** Keep the LISTEN TCP connection alive with a lightweight SELECT (default: 45000ms). Set 0 to disable. */
+  keepaliveIntervalMs?: number;
   /** Application name for pg_stat_activity */
   applicationName?: string;
 }
@@ -243,6 +245,7 @@ export function createPgListener(opts: PgListenerOptions): PgListenerHandle {
   const { url, channels, onNotification, applicationName } = opts;
   const reconnectDelay = opts.reconnectDelay ?? 3000;
   const maxReconnectDelay = opts.maxReconnectDelay ?? 300_000; // 5 minutes
+  const keepaliveIntervalMs = opts.keepaliveIntervalMs ?? 45_000;
   const connInfo = parseConnectionUrl(url);
 
   let closed = false;
@@ -250,10 +253,32 @@ export function createPgListener(opts: PgListenerOptions): PgListenerHandle {
   let currentDelay = reconnectDelay;
   let socket: ReturnType<typeof Bun.connect> | null = null;
   let reconnectTimer: Timer | null = null;
+  let keepaliveTimer: Timer | null = null;
+
+  function clearKeepalive() {
+    if (!keepaliveTimer) return;
+    clearInterval(keepaliveTimer);
+    keepaliveTimer = null;
+  }
+
+  function startKeepalive(sock: { write: (data: Buffer) => unknown }) {
+    clearKeepalive();
+    if (keepaliveIntervalMs <= 0) return;
+    keepaliveTimer = setInterval(() => {
+      try {
+        sock.write(buildQuery("SELECT 1;"));
+      } catch (err: unknown) {
+        logger.warn("[PgListener] Keepalive query failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }, keepaliveIntervalMs);
+  }
 
   function connect() {
     if (closed || fatalError) return;
 
+    clearKeepalive();
     let buffer: Uint8Array = new Uint8Array(0);
     let authenticated = false;
     let scramClientNonce = "";
@@ -345,6 +370,7 @@ export function createPgListener(opts: PgListenerOptions): PgListenerHandle {
                   logger.info(
                     `[PgListener] Connected and listening on: ${channels.join(", ")}`
                   );
+                  startKeepalive(sock);
                   // Reset backoff delay on successful connection
                   currentDelay = reconnectDelay;
                   // Only send LISTEN once (on first ReadyForQuery after auth)
@@ -382,16 +408,19 @@ export function createPgListener(opts: PgListenerOptions): PgListenerHandle {
         },
 
         close() {
+          clearKeepalive();
           logger.warn(`[PgListener] Connection closed.`);
           scheduleReconnect();
         },
 
         error(_sock, err) {
+          clearKeepalive();
           logger.error(`[PgListener] Socket error: ${err instanceof Error ? err.message : String(err)}`);
           scheduleReconnect();
         },
 
         connectError(_sock, err) {
+          clearKeepalive();
           logger.error(`[PgListener] Connect error: ${err instanceof Error ? err.message : String(err)}`);
           scheduleReconnect();
         },
@@ -422,6 +451,7 @@ export function createPgListener(opts: PgListenerOptions): PgListenerHandle {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
+      clearKeepalive();
       try {
         // socket is the return value of Bun.connect — use type assertion for end()
         (socket as { end?: () => void })?.end?.();


### PR DESCRIPTION
## Summary
- Add EdgeRuntime.waitUntil compatibility in the Bun edge worker so response-detached background work keeps tenant env and log capture until it settles.
- Keep workers out of the idle pool while waitUntil tasks are running, with EDGE_WAIT_UNTIL_TIMEOUT_MS fallback.
- Add pg-listen keepalive queries to reduce periodic LISTEN disconnect/reconnect churn.
- Include a regression test proving waitUntil work can still read SUPABASE_URL after the HTTP response is returned.

## Why
Seagoo tasks could enqueue successfully but detached execution crashed with `supabaseUrl is required` after the function returned. The runtime restored process/Bun env immediately after sending the response, so application code had to add its own env snapshot workaround. This belongs in SupaCloud runtime compatibility instead.

## Verification
- `bun run typecheck` in `packages/edge-runtime`
- `bun test` in `packages/edge-runtime`
- `bun run typecheck` in `packages/management-api`
- `bun test` in `packages/management-api`
- `bun build packages/edge-runtime/server.ts --target bun --outfile /tmp/supacloud-edge-runtime-check.js`
