### PR TITLE
fix(runtime): respect ssl config for tenant urls

### DIFF
--- a/infrastructure/systemd/supacloud-edge-runtime.service
+++ b/infrastructure/systemd/supacloud-edge-runtime.service
@@ -9,7 +9,7 @@ Type=simple
 User=root
 WorkingDirectory=/opt/supacloud/edge-runtime
 ExecStartPre=/bin/bash -c 'for pid in $(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do echo "[EdgeRT] Killing stale pid=$pid"; kill -9 $pid 2>/dev/null || true; done; sleep 0.3; true'
-ExecStart=/usr/local/bin/bun run server.ts
+ExecStart=/usr/local/bin/bun server.ts
 ExecStopPost=/bin/bash -c 'for pid in $(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do kill -9 $pid 2>/dev/null || true; done; true'
 Restart=on-failure
 RestartSec=5
@@ -19,6 +19,9 @@ SyslogIdentifier=supacloud-edge
 
 Environment=PORT=9000
 Environment=EDGE_RUNTIME_HOST=127.0.0.1
+Environment=EDGE_FUNCTIONS_DIR=/opt/supacloud/functions
+Environment=EDGE_FUNCTIONS_BASE_DIR=/opt/supacloud/functions
+Environment=MANAGEMENT_API_URL=http://127.0.0.1:9090
 EnvironmentFile=-/etc/supabase/management-api.env
 EnvironmentFile=-/opt/supacloud/config.env
 

--- a/install.sh
+++ b/install.sh
@@ -1083,11 +1083,13 @@ Wants=supacloud.service
 Type=simple
 WorkingDirectory=/opt/supacloud/edge-runtime
 ExecStartPre=/bin/bash -c 'for pid in \$(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do echo "[EdgeRT] Killing stale pid=\$pid"; kill -9 \$pid 2>/dev/null || true; done; sleep 0.3; true'
-ExecStart=/usr/local/bin/bun run server.ts
+ExecStart=/usr/local/bin/bun server.ts
 ExecStopPost=/bin/bash -c 'for pid in \$(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do kill -9 \$pid 2>/dev/null || true; done; true'
 Restart=always
 RestartSec=5
 Environment=PORT=9000
+Environment=EDGE_FUNCTIONS_DIR=/opt/supacloud/functions
+Environment=EDGE_FUNCTIONS_BASE_DIR=/opt/supacloud/functions
 Environment=MANAGEMENT_API_URL=http://127.0.0.1:9090
 Environment=WORKER_POOL_SIZE=4
 EnvironmentFile=-/etc/supabase/management-api.env

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -682,3 +682,7 @@ process.on("uncaughtException", (err) => {
 process.on("unhandledRejection", (reason) => {
   console.error("[EdgeRuntime] unhandledRejection:", reason);
 });
+
+// Keep the main runtime process alive so systemd can supervise the actual server
+// process instead of observing Bun's temporary bootstrap completion.
+await new Promise<void>(() => {});

--- a/packages/management-api/src/utils/project-routing.ts
+++ b/packages/management-api/src/utils/project-routing.ts
@@ -88,14 +88,14 @@ export function resolveProjectApiUrl(
   projectRef: string,
   projectConfig: ProjectRoutingConfig | string | null | undefined,
 ): string {
-  return `https://${resolveProjectApiHost(projectRef, projectConfig)}`;
+  return `${config.enableSsl ? "https" : "http"}://${resolveProjectApiHost(projectRef, projectConfig)}`;
 }
 
 export function resolveProjectStudioUrl(
   projectRef: string,
   projectConfig: ProjectRoutingConfig | string | null | undefined,
 ): string {
-  return `https://${resolveProjectStudioHost(projectRef, projectConfig)}`;
+  return `${config.enableSsl ? "https" : "http"}://${resolveProjectStudioHost(projectRef, projectConfig)}`;
 }
 
 export function resolveTenantPorts(

--- a/packages/management-api/tests/unit/project-routing.test.ts
+++ b/packages/management-api/tests/unit/project-routing.test.ts
@@ -5,14 +5,18 @@ import {
   normalizeBaseDomain,
   resolveTenantPorts,
   resolveProjectApiHost,
+  resolveProjectApiUrl,
   resolveProjectBaseHost,
   resolveProjectStudioHost,
+  resolveProjectStudioUrl,
 } from "../../src/utils/project-routing";
 
 const originalBaseDomain = config.baseDomain;
+const originalEnableSsl = config.enableSsl;
 
 afterEach(() => {
   config.baseDomain = originalBaseDomain;
+  config.enableSsl = originalEnableSsl;
 });
 
 describe("project routing", () => {
@@ -44,5 +48,17 @@ describe("project routing", () => {
   test("keeps non-JSON strings as legacy custom domains", () => {
     expect(normalizeProjectRoutingConfig("example.com")).toEqual({ custom_domain: "example.com" });
     expect(normalizeProjectRoutingConfig("{bad json")).toEqual({ custom_domain: "{bad json" });
+  });
+
+  test("uses ENABLE_SSL to resolve public API and Studio URL schemes", () => {
+    config.baseDomain = "192.168.1.168.sslip.io";
+
+    config.enableSsl = true;
+    expect(resolveProjectApiUrl("dglewlzugrtygzysqrce", null)).toBe("https://dglewlzugrtygzysqrce.api.192.168.1.168.sslip.io");
+    expect(resolveProjectStudioUrl("dglewlzugrtygzysqrce", null)).toBe("https://studio-dglewlzugrtygzysqrce.192.168.1.168.sslip.io");
+
+    config.enableSsl = false;
+    expect(resolveProjectApiUrl("dglewlzugrtygzysqrce", null)).toBe("http://dglewlzugrtygzysqrce.api.192.168.1.168.sslip.io");
+    expect(resolveProjectStudioUrl("dglewlzugrtygzysqrce", null)).toBe("http://studio-dglewlzugrtygzysqrce.192.168.1.168.sslip.io");
   });
 });


### PR DESCRIPTION
## Summary
- use ENABLE_SSL when resolving public tenant API and Studio URLs
- add routing tests for HTTP/HTTPS URL generation
- fix external edge-runtime systemd defaults for functions dir and Bun entrypoint

## Why
SupaCloud supports domain and custom-domain routing on both 80 and 443. Runtime env should not hardcode https for deployments that are intentionally HTTP-only or do not have trusted TLS certificates.

## Test
- bun test packages/management-api/tests/unit/project-routing.test.ts packages/management-api/tests/unit/gateway.service.test.ts packages/management-api/tests/unit/project.service.comprehensive.test.ts packages/management-api/tests/unit/task.worker.test.ts packages/edge-runtime/tenant-env.test.ts packages/edge-runtime/worker-pool.test.ts