### PR TITLE
fix(management-api): reconcile custom domain runtime routes

### DIFF
--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -18,6 +18,7 @@ import {
   normalizeProjectRoutingConfig,
   resolveProjectApiUrl,
   resolveProjectStudioUrl,
+  resolveTenantPorts,
 } from "../utils/project-routing";
 import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-config";
 
@@ -150,6 +151,30 @@ export class ProjectService {
     max_attempts: 3,
     rate_limit_per_minute: 600,
   };
+
+  private async reconcileGatewayRoutes(
+    ref: string,
+    rawConfig: Record<string, unknown>,
+  ): Promise<void> {
+    const routingConfig = normalizeProjectRoutingConfig(rawConfig);
+    const tenantPorts = resolveTenantPorts(routingConfig);
+    if (!tenantPorts) {
+      logger.warn("[ProjectService] Skipping gateway route reconcile: missing tenant ports", {
+        ref,
+      });
+      return;
+    }
+
+    const result = await gatewayService.setupUpstream(
+      ref,
+      tenantPorts.pgrstPort,
+      tenantPorts.gotruePort,
+      routingConfig,
+    );
+    if (!result.success) {
+      throw new Error(result.error || "gateway route reconcile failed");
+    }
+  }
 
   /** Check if the storage backend (S3/MinIO) is reachable */
   private async checkStorageHealth(): Promise<boolean> {
@@ -489,6 +514,7 @@ export class ProjectService {
     const { tenantRuntimeService } = await import("./tenant-runtime.service");
     try {
       await tenantRuntimeService.restartRuntime(ref);
+      await this.reconcileGatewayRoutes(ref, normalizeProjectConfig(project.config));
       logger.info(`[ProjectService] Restarted services for project ${ref}`);
     } catch (err: unknown) {
       logger.warn(
@@ -538,6 +564,9 @@ export class ProjectService {
       try {
         const { tenantRuntimeService } = await import("./tenant-runtime.service");
         await tenantRuntimeService.restartRuntime(ref);
+        if (updated) {
+          await this.reconcileGatewayRoutes(ref, normalizeProjectConfig(updated.config));
+        }
       } catch (err) {
         logger.warn("[ProjectService] Failed to propagate routing settings to runtime", {
           ref,

--- a/packages/management-api/src/services/runtime-env.service.ts
+++ b/packages/management-api/src/services/runtime-env.service.ts
@@ -1,7 +1,6 @@
 import { projectRepository } from "../repositories/project.repository";
 import { databaseService } from "./database.service";
 import { jwtService } from "./jwt.service";
-import { config } from "../config";
 import { normalizeProjectConfig } from "../utils/project-config";
 import {
   normalizeProjectRoutingConfig,
@@ -24,7 +23,11 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
   );
   const supabaseUrl = resolveProjectApiUrl(projectRef, routingConfig);
   const projectApiHost = resolveProjectApiHost(projectRef, routingConfig);
-  const internalSupabaseUrl = `http://127.0.0.1:${config.port}`;
+  const internalSupabaseUrl = (
+    process.env.SUPACLOUD_INTERNAL_SUPABASE_URL ||
+    process.env.INTERNAL_SUPABASE_URL ||
+    "http://127.0.0.1"
+  ).replace(/\/+$/, "");
 
   let serviceRoleKey = project.service_role_key;
   const encryptedServiceRoleKey = (project as unknown as { service_role_key_encrypted?: string | null }).service_role_key_encrypted;

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -318,4 +318,54 @@ describe("GatewayService", () => {
 
         globalThis.fetch = originalFetch;
     });
+
+    test("setupUpstream propagates explicit custom API and Studio hosts to Kong routes", async () => {
+        const originalFetch = globalThis.fetch;
+        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
+
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string"
+                ? input
+                : input instanceof URL
+                    ? input.toString()
+                    : input.url;
+            const method = init?.method || "GET";
+            let body: Record<string, unknown> | null = null;
+            if (typeof init?.body === "string" && init.body.length > 0) {
+                try {
+                    body = JSON.parse(init.body) as Record<string, unknown>;
+                } catch {
+                    body = null;
+                }
+            }
+            calls.push({ url, method, body });
+            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
+        }) as unknown as typeof fetch;
+
+        const result = await gatewayService.setupUpstream("seagooref", 3000, 9999, {
+            custom_domain: "xg.aizhuliren.cn",
+            api_domain: "api.xg.aizhuliren.cn",
+            studio_domain: "studio.xg.aizhuliren.cn",
+        });
+        expect(result.success).toBe(true);
+
+        const authRoute = calls.find(
+            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-gotrue-seagooref")
+        );
+        expect(authRoute?.body?.hosts).toContain("seagooref.api.example.com");
+        expect(authRoute?.body?.hosts).toContain("api.xg.aizhuliren.cn");
+
+        const functionsRoute = calls.find(
+            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-functions-seagooref")
+        );
+        expect(functionsRoute?.body?.hosts).toContain("api.xg.aizhuliren.cn");
+
+        const studioRoute = calls.find(
+            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-studio-seagooref")
+        );
+        expect(studioRoute?.body?.hosts).toContain("studio-seagooref.example.com");
+        expect(studioRoute?.body?.hosts).toContain("studio.xg.aizhuliren.cn");
+
+        globalThis.fetch = originalFetch;
+    });
 });

--- a/packages/management-api/tests/unit/project.service.comprehensive.test.ts
+++ b/packages/management-api/tests/unit/project.service.comprehensive.test.ts
@@ -91,6 +91,7 @@ mock.module("../../src/services/tenant-runtime.service", () => ({
 
 const { projectRepository } = await import("../../src/repositories/project.repository");
 const { taskRepository } = await import("../../src/repositories/task.repository");
+const { gatewayService } = await import("../../src/services/gateway.service");
 
 const projectRepositoryMock = {
   findAll: spyOn(projectRepository, "findAll"),
@@ -103,6 +104,10 @@ const projectRepositoryMock = {
 
 const taskRepositoryMock = {
   createTask: spyOn(taskRepository, "createTask"),
+};
+
+const gatewayServiceMock = {
+  setupUpstream: spyOn(gatewayService, "setupUpstream"),
 };
 
 const { ProjectService } = await import("../../src/services/project.service");
@@ -142,6 +147,7 @@ describe("ProjectService - Comprehensive", () => {
     projectRepositoryMock.updateConfig.mockReset();
     projectRepositoryMock.softDelete.mockReset();
     taskRepositoryMock.createTask.mockReset();
+    gatewayServiceMock.setupUpstream.mockReset();
     jwtServiceMock.generateProjectRef.mockReset();
     jwtServiceMock.generateKeySet.mockReset();
     databaseServiceMock.generatePassword.mockReset();
@@ -168,6 +174,7 @@ describe("ProjectService - Comprehensive", () => {
     projectRepositoryMock.updateConfig.mockResolvedValue(mockProject);
     projectRepositoryMock.softDelete.mockResolvedValue(mockProject);
     taskRepositoryMock.createTask.mockResolvedValue({ id: "tsk_1" });
+    gatewayServiceMock.setupUpstream.mockResolvedValue({ success: true });
     jwtServiceMock.generateProjectRef.mockReturnValue("newref1234");
     jwtServiceMock.generateKeySet.mockResolvedValue({
       jwtSecret: "jwtsecret",
@@ -320,6 +327,35 @@ describe("ProjectService - Comprehensive", () => {
     expect(result).toBe(true);
   });
 
+  test("restartProject reconciles Kong routes when tenant ports are known", async () => {
+    projectRepositoryMock.findByRef.mockResolvedValueOnce({
+      ...mockProject,
+      config: {
+        postgrest_port: 3234,
+        gotrue_port: 4234,
+        custom_domain: "xg.aizhuliren.cn",
+        api_domain: "api.xg.aizhuliren.cn",
+        studio_domain: "studio.xg.aizhuliren.cn",
+      },
+    });
+
+    const result = await service.restartProject("test123abc");
+
+    expect(result).toBe(true);
+    expect(gatewayServiceMock.setupUpstream).toHaveBeenCalledWith(
+      "test123abc",
+      3234,
+      4234,
+      {
+        postgrest_port: 3234,
+        gotrue_port: 4234,
+        custom_domain: "xg.aizhuliren.cn",
+        api_domain: "api.xg.aizhuliren.cn",
+        studio_domain: "studio.xg.aizhuliren.cn",
+      },
+    );
+  });
+
   test("getProjectSettings returns config", async () => {
     projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
     expect(await service.getProjectSettings("test123abc")).toEqual({ custom: "value" });
@@ -353,6 +389,53 @@ describe("ProjectService - Comprehensive", () => {
       api_domain: "xgapi.aizhuliren.cn",
     });
     expect(tenantRuntimeServiceMock.restartRuntime).toHaveBeenCalledWith("test123abc");
+  });
+
+  test("updateProjectSettings reconciles Kong routes for custom domain changes", async () => {
+    projectRepositoryMock.findByRef.mockResolvedValueOnce({
+      ...mockProject,
+      config: {
+        postgrest_port: 3234,
+        gotrue_port: 4234,
+        custom_domain: "old.example.com",
+      },
+    });
+    projectRepositoryMock.updateConfig.mockResolvedValueOnce({
+      ...mockProject,
+      config: {
+        postgrest_port: 3234,
+        gotrue_port: 4234,
+        custom_domain: "xg.aizhuliren.cn",
+        api_domain: "api.xg.aizhuliren.cn",
+        studio_domain: "studio.xg.aizhuliren.cn",
+      },
+    });
+
+    const result = await service.updateProjectSettings("test123abc", {
+      custom_domain: "xg.aizhuliren.cn",
+      api_domain: "api.xg.aizhuliren.cn",
+      studio_domain: "studio.xg.aizhuliren.cn",
+    });
+
+    expect(result).toEqual({
+      postgrest_port: 3234,
+      gotrue_port: 4234,
+      custom_domain: "xg.aizhuliren.cn",
+      api_domain: "api.xg.aizhuliren.cn",
+      studio_domain: "studio.xg.aizhuliren.cn",
+    });
+    expect(gatewayServiceMock.setupUpstream).toHaveBeenCalledWith(
+      "test123abc",
+      3234,
+      4234,
+      {
+        postgrest_port: 3234,
+        gotrue_port: 4234,
+        custom_domain: "xg.aizhuliren.cn",
+        api_domain: "api.xg.aizhuliren.cn",
+        studio_domain: "studio.xg.aizhuliren.cn",
+      },
+    );
   });
 
   test("getApiKeys returns api keys", async () => {

--- a/packages/management-api/tests/unit/task.worker.test.ts
+++ b/packages/management-api/tests/unit/task.worker.test.ts
@@ -130,9 +130,9 @@ describe("TaskWorker provision_secrets", () => {
 
     const secrets = new Map(upsertSecretSpy.mock.calls.map((call) => [call[1], call[2]]));
     expect(secrets.get("SUPABASE_SERVICE_ROLE_KEY")).toMatch(/^[^.]+\.[^.]+\.[^.]+$/);
-    expect(secrets.get("SUPACLOUD_INTERNAL_SUPABASE_URL")).toBe("http://127.0.0.1:9090");
-    expect(secrets.get("SUPACLOUD_INTERNAL_AUTH_URL")).toBe("http://127.0.0.1:9090/auth/v1");
-    expect(secrets.get("SUPACLOUD_INTERNAL_REST_URL")).toBe("http://127.0.0.1:9090/rest/v1");
+    expect(secrets.get("SUPACLOUD_INTERNAL_SUPABASE_URL")).toBe("http://127.0.0.1");
+    expect(secrets.get("SUPACLOUD_INTERNAL_AUTH_URL")).toBe("http://127.0.0.1/auth/v1");
+    expect(secrets.get("SUPACLOUD_INTERNAL_REST_URL")).toBe("http://127.0.0.1/rest/v1");
     expect(secrets.get("SUPACLOUD_PROJECT_REF")).toBe("proj-ref");
     expect(secrets.get("SUPACLOUD_PROJECT_API_HOST")).toBe("api.app.example.com");
     expect(secrets.get("X_PROJECT_REF")).toBe("proj-ref");


### PR DESCRIPTION
## Summary
- Reconcile Kong tenant routes after project restart and routing-domain settings changes, so custom api/studio domains propagate without manual Kong PATCHes.
- Change injected internal Supabase URLs to default to the local Kong listener (`http://127.0.0.1`) instead of the management API port, so Edge Functions validate auth through tenant-aware Host routing.
- Add regression coverage for explicit custom API/Studio hosts and runtime secret injection.

## Why
A project using `xg.aizhuliren.cn`, `api.xg.aizhuliren.cn`, and `studio.xg.aizhuliren.cn` could update project config successfully, but `supacloud restart <ref>` did not refresh existing Kong route hosts. Edge Functions also received `SUPACLOUD_INTERNAL_AUTH_URL=http://127.0.0.1:9090/auth/v1`, where `/auth/v1/user` can return `Missing tenant reference` because that path bypasses tenant Host routing.

## Tests
- `bun test tests/unit/task.worker.test.ts tests/unit/gateway.service.test.ts tests/unit/project.service.comprehensive.test.ts`
- `bun test tests/unit`
- `bunx tsc --noEmit`

Rejected: fixing this only in business Edge Functions | the platform should provide tenant-aware routes and internal URLs.
Constraint: route reconcile is skipped when existing projects do not yet have tenant runtime ports in config.
