### PR TITLE
fix(cli): infer management URL from project API domains

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -20,6 +20,12 @@ Project-scoped by default. Intended for project users and developers.
 - Reads `SUPABASE_SERVICE_ROLE_KEY` or `SUPACLOUD_API_TOKEN`
 - Can still accept explicit `--ref` when needed
 
+When auto-linking from `SUPABASE_URL`, the CLI accepts tenant API domains and
+derives the matching Management API host. For example,
+`https://api.example.com` maps to `https://studio.example.com`, and
+`https://abc123.api.example.com` maps to `https://studio-abc123.example.com`.
+Set `SUPACLOUD_API_URL` explicitly to override this inference.
+
 ### Typical commands
 
 ```bash

--- a/packages/admin/src/shared/context.ts
+++ b/packages/admin/src/shared/context.ts
@@ -65,31 +65,81 @@ function detectSource(sources: Array<"env" | "dotenv" | "none">): ResolvedContex
     return "mixed";
 }
 
+function normalizeUrl(value: string): string {
+    const trimmed = value.trim().replace(/\/+$/, "");
+    if (!trimmed) return "";
+    try {
+        return new URL(trimmed).toString().replace(/\/+$/, "");
+    } catch {
+        return "";
+    }
+}
+
+function hostFromUrl(value: string): string {
+    try {
+        return new URL(value).hostname;
+    } catch {
+        return "";
+    }
+}
+
+function inferManagementApiUrlFromSupabaseUrl(value: string, projectRef = ""): string {
+    const normalized = normalizeUrl(value);
+    if (!normalized) return "";
+
+    const url = new URL(normalized);
+    const host = url.hostname;
+    if (host.startsWith("api.")) {
+        url.hostname = `studio.${host.slice("api.".length)}`;
+        return url.toString().replace(/\/+$/, "");
+    }
+
+    const ref = projectRef.trim();
+    if (ref && host.startsWith(`${ref}.api.`)) {
+        url.hostname = `studio-${ref}.${host.slice(`${ref}.api.`.length)}`;
+        return url.toString().replace(/\/+$/, "");
+    }
+
+    const managedHostMatch = host.match(/^([a-z0-9-]+)\.api\.(.+)$/i);
+    if (managedHostMatch) {
+        url.hostname = `studio-${managedHostMatch[1]}.${managedHostMatch[2]}`;
+        return url.toString().replace(/\/+$/, "");
+    }
+
+    return normalized;
+}
+
 export function resolveSupaCloudContext(
     env: NodeJS.ProcessEnv = process.env,
     cwd: string = process.cwd(),
 ): ResolvedContext {
     const dotenv = readDotEnvFile(cwd);
-    const inferredUrl = pickValue(env, dotenv, ["SUPABASE_URL", "SUPACLOUD_API_URL"]);
+    const supabaseUrl = pickValue(env, dotenv, ["SUPABASE_URL"]);
+    const explicitApiUrl = pickValue(env, dotenv, ["SUPACLOUD_API_URL", "SUPACLOUD_MANAGEMENT_API_URL", "MANAGEMENT_API_URL"]);
     const inferredToken = pickValue(env, dotenv, ["SUPABASE_SERVICE_ROLE_KEY", "SUPACLOUD_API_TOKEN"]);
+    const projectRef = pickValue(env, dotenv, ["SUPACLOUD_PROJECT_REF", "X_PROJECT_REF"]).value;
 
     const hostFromEnv = env.SUPACLOUD_HOST;
-    const hostFromUrl = inferredUrl.value ? new URL(inferredUrl.value).hostname : "";
+    const normalizedSupabaseUrl = normalizeUrl(supabaseUrl.value);
+    const apiUrl = normalizeUrl(explicitApiUrl.value)
+        || inferManagementApiUrlFromSupabaseUrl(normalizedSupabaseUrl, projectRef)
+        || (hostFromEnv ? `http://${hostFromEnv}:9090` : "");
+    const resolvedHostFromUrl = hostFromUrl(apiUrl || normalizedSupabaseUrl);
 
     return {
-        host: hostFromEnv ?? hostFromUrl,
+        host: hostFromEnv ?? resolvedHostFromUrl,
         sshUser: env.SUPACLOUD_SSH_USER ?? "root",
         sshPort: parseInt(env.SUPACLOUD_SSH_PORT ?? "22", 10),
         sshKey: env.SUPACLOUD_SSH_KEY ?? resolve(homedir(), ".ssh", "id_rsa"),
         sshPass: env.SUPACLOUD_SSH_PASS ?? "",
-        apiUrl: env.SUPACLOUD_API_URL ?? (inferredUrl.value ? inferredUrl.value.replace(/\/+$/, "") : (hostFromEnv ? `http://${hostFromEnv}:9090` : "")),
+        apiUrl,
         apiToken: env.SUPACLOUD_API_TOKEN ?? inferredToken.value,
-        projectRef: env.SUPACLOUD_PROJECT_REF ?? "",
+        projectRef,
         readOnly: env.SUPACLOUD_READ_ONLY === "true",
-        inferredSupabaseUrl: inferredUrl.value,
+        inferredSupabaseUrl: normalizedSupabaseUrl,
         inferredServiceRoleKey: inferredToken.value,
         source: detectSource([
-            inferredUrl.value ? inferredUrl.source : "none",
+            (supabaseUrl.value || explicitApiUrl.value) ? (supabaseUrl.value ? supabaseUrl.source : explicitApiUrl.source) : "none",
             inferredToken.value ? inferredToken.source : "none",
         ]),
     };

--- a/packages/cli/src/shared/context.test.ts
+++ b/packages/cli/src/shared/context.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSupaCloudContext } from "./context";
+
+describe("resolveSupaCloudContext", () => {
+    test("infers management URL from custom project API domain", () => {
+        const context = resolveSupaCloudContext({
+            SUPABASE_URL: "https://api.xg.aizhuliren.cn",
+            SUPABASE_SERVICE_ROLE_KEY: "service-role",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.apiUrl).toBe("https://studio.xg.aizhuliren.cn");
+        expect(context.host).toBe("studio.xg.aizhuliren.cn");
+        expect(context.apiToken).toBe("service-role");
+    });
+
+    test("infers management URL from managed project API domain", () => {
+        const context = resolveSupaCloudContext({
+            SUPABASE_URL: "https://abc123.api.example.com/",
+            SUPABASE_SERVICE_ROLE_KEY: "service-role",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.apiUrl).toBe("https://studio-abc123.example.com");
+        expect(context.projectRef).toBe("abc123");
+    });
+
+    test("explicit management API URL wins over Supabase URL inference", () => {
+        const context = resolveSupaCloudContext({
+            SUPABASE_URL: "https://api.xg.aizhuliren.cn",
+            SUPACLOUD_API_URL: "https://management.example.com/",
+            SUPACLOUD_API_TOKEN: "token",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.apiUrl).toBe("https://management.example.com");
+        expect(context.apiToken).toBe("token");
+    });
+
+    test("invalid placeholder Supabase URL does not throw", () => {
+        const context = resolveSupaCloudContext({
+            SUPABASE_URL: "{API_URL}",
+            SUPABASE_SERVICE_ROLE_KEY: "service-role",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.apiUrl).toBe("");
+        expect(context.host).toBe("");
+        expect(context.inferredSupabaseUrl).toBe("");
+        expect(context.apiToken).toBe("service-role");
+    });
+});

--- a/packages/cli/src/shared/context.ts
+++ b/packages/cli/src/shared/context.ts
@@ -65,31 +65,81 @@ function detectSource(sources: Array<"env" | "dotenv" | "none">): ResolvedContex
     return "mixed";
 }
 
+function normalizeUrl(value: string): string {
+    const trimmed = value.trim().replace(/\/+$/, "");
+    if (!trimmed) return "";
+    try {
+        return new URL(trimmed).toString().replace(/\/+$/, "");
+    } catch {
+        return "";
+    }
+}
+
+function hostFromUrl(value: string): string {
+    try {
+        return new URL(value).hostname;
+    } catch {
+        return "";
+    }
+}
+
+function inferManagementApiUrlFromSupabaseUrl(value: string, projectRef = ""): string {
+    const normalized = normalizeUrl(value);
+    if (!normalized) return "";
+
+    const url = new URL(normalized);
+    const host = url.hostname;
+    if (host.startsWith("api.")) {
+        url.hostname = `studio.${host.slice("api.".length)}`;
+        return url.toString().replace(/\/+$/, "");
+    }
+
+    const ref = projectRef.trim();
+    if (ref && host.startsWith(`${ref}.api.`)) {
+        url.hostname = `studio-${ref}.${host.slice(`${ref}.api.`.length)}`;
+        return url.toString().replace(/\/+$/, "");
+    }
+
+    const managedHostMatch = host.match(/^([a-z0-9-]+)\.api\.(.+)$/i);
+    if (managedHostMatch) {
+        url.hostname = `studio-${managedHostMatch[1]}.${managedHostMatch[2]}`;
+        return url.toString().replace(/\/+$/, "");
+    }
+
+    return normalized;
+}
+
 export function resolveSupaCloudContext(
     env: NodeJS.ProcessEnv = process.env,
     cwd: string = process.cwd(),
 ): ResolvedContext {
     const dotenv = readDotEnvFile(cwd);
-    const inferredUrl = pickValue(env, dotenv, ["SUPABASE_URL", "SUPACLOUD_API_URL"]);
+    const supabaseUrl = pickValue(env, dotenv, ["SUPABASE_URL"]);
+    const explicitApiUrl = pickValue(env, dotenv, ["SUPACLOUD_API_URL", "SUPACLOUD_MANAGEMENT_API_URL", "MANAGEMENT_API_URL"]);
     const inferredToken = pickValue(env, dotenv, ["SUPABASE_SERVICE_ROLE_KEY", "SUPACLOUD_API_TOKEN"]);
+    const projectRef = pickValue(env, dotenv, ["SUPACLOUD_PROJECT_REF", "X_PROJECT_REF"]).value;
 
     const hostFromEnv = env.SUPACLOUD_HOST;
-    const hostFromUrl = inferredUrl.value ? new URL(inferredUrl.value).hostname : "";
+    const normalizedSupabaseUrl = normalizeUrl(supabaseUrl.value);
+    const apiUrl = normalizeUrl(explicitApiUrl.value)
+        || inferManagementApiUrlFromSupabaseUrl(normalizedSupabaseUrl, projectRef)
+        || (hostFromEnv ? `http://${hostFromEnv}:9090` : "");
+    const resolvedHostFromUrl = hostFromUrl(apiUrl || normalizedSupabaseUrl);
 
     return {
-        host: hostFromEnv ?? hostFromUrl,
+        host: hostFromEnv ?? resolvedHostFromUrl,
         sshUser: env.SUPACLOUD_SSH_USER ?? "root",
         sshPort: parseInt(env.SUPACLOUD_SSH_PORT ?? "22", 10),
         sshKey: env.SUPACLOUD_SSH_KEY ?? resolve(homedir(), ".ssh", "id_rsa"),
         sshPass: env.SUPACLOUD_SSH_PASS ?? "",
-        apiUrl: env.SUPACLOUD_API_URL ?? (inferredUrl.value ? inferredUrl.value.replace(/\/+$/, "") : (hostFromEnv ? `http://${hostFromEnv}:9090` : "")),
+        apiUrl,
         apiToken: env.SUPACLOUD_API_TOKEN ?? inferredToken.value,
-        projectRef: env.SUPACLOUD_PROJECT_REF ?? "",
+        projectRef,
         readOnly: env.SUPACLOUD_READ_ONLY === "true",
-        inferredSupabaseUrl: inferredUrl.value,
+        inferredSupabaseUrl: normalizedSupabaseUrl,
         inferredServiceRoleKey: inferredToken.value,
         source: detectSource([
-            inferredUrl.value ? inferredUrl.source : "none",
+            (supabaseUrl.value || explicitApiUrl.value) ? (supabaseUrl.value ? supabaseUrl.source : explicitApiUrl.source) : "none",
             inferredToken.value ? inferredToken.source : "none",
         ]),
     };


### PR DESCRIPTION
## Summary
- infer the Management API URL from tenant API domains when auto-linking from SUPABASE_URL
- support custom domains like api.example.com -> studio.example.com and managed hosts like ref.api.example.com -> studio-ref.example.com
- ignore invalid placeholder URLs instead of throwing from new URL()
- document the inference behavior and add CLI context regression tests

## Verification
- bun test packages/cli/src/shared/context.test.ts packages/cli/src/shared/tools/advanced-tools.test.ts packages/cli/src/shared/tools/database-tools.test.ts
- bun run --cwd packages/cli typecheck && bun run --cwd packages/cli build
- bun run --cwd packages/admin typecheck && bun run --cwd packages/admin build
- manual status smoke: SUPABASE_URL=https://api.xg.aizhuliren.cn maps to https://studio.xg.aizhuliren.cn
