### PR TITLE
Increase PostgREST runtime memory budget

### DIFF
--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -86,6 +86,9 @@ export interface Config {
   pgDataDir: string;
   minDiskGb: number;
   postgrestBin: string;
+  postgrestRts: string;
+  postgrestMemoryMax: string;
+  postgrestCpuWeight: number;
   gotrueBin: string;
   pgrstPortBase: number;
   gotruePortBase: number;
@@ -197,6 +200,9 @@ export const config: Config = {
   pgDataDir: getEnv("PG_DATA_DIR", "/var/lib/pgsql/data"),
   minDiskGb: Number(getEnv("MIN_DISK_GB", "10")),
   postgrestBin: getEnv("POSTGREST_BIN", "/usr/local/bin/postgrest"),
+  postgrestRts: getEnv("POSTGREST_RTS", "-N1 -M256m -I0.5 -A4m"),
+  postgrestMemoryMax: getEnv("POSTGREST_MEMORY_MAX", "384M"),
+  postgrestCpuWeight: Number(getEnv("POSTGREST_CPU_WEIGHT", "40")),
   gotrueBin: getEnv("GOTRUE_BIN", "/usr/local/bin/gotrue"),
   pgrstPortBase: Number(getEnv("PGRST_PORT_BASE", "3100")),
   gotruePortBase: Number(getEnv("GOTRUE_PORT_BASE", "3200")),

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -20,6 +20,9 @@ export interface RuntimeStatus {
 class TenantRuntimeService {
     private readonly TENANT_CONFIG_DIR = config.tenantConfigDir;
     private readonly POSTGREST_BIN = config.postgrestBin;
+    private readonly POSTGREST_RTS = config.postgrestRts;
+    private readonly POSTGREST_MEMORY_MAX = config.postgrestMemoryMax;
+    private readonly POSTGREST_CPU_WEIGHT = config.postgrestCpuWeight;
     private readonly GOTRUE_BIN = config.gotrueBin;
     private readonly PG_HOST = config.pgHost;
     private readonly PG_PORT = String(config.pgPort);
@@ -261,9 +264,10 @@ GOTRUE_MAILER_AUTOCONFIRM=true
         const pgrstUnitPath = "/etc/systemd/system/supacloud-pgrst@.service";
         const gotrueUnitPath = "/etc/systemd/system/supacloud-gotrue@.service";
 
-        // Avoid redundant disk IO if units already exist
+        // Avoid redundant disk IO unless upgrading the old 30 MB PostgREST unit.
         const pgrstExists = await Bun.file(pgrstUnitPath).exists();
-        if (!pgrstExists) {
+        const shouldWritePgrstUnit = !pgrstExists || await unitHasLegacyPostgrestMemoryLimit(pgrstUnitPath);
+        if (shouldWritePgrstUnit) {
             const pgrstUnit = `
 [Unit]
 Description=SupaCloud PostgREST for tenant %i
@@ -276,8 +280,8 @@ Type=simple
 User=nobody
 Group=nobody
 EnvironmentFile=${this.TENANT_CONFIG_DIR}/%i.env
-Environment="GHCRTS=-N1 -M30m -I0.1 -A1m"
-ExecStart=${this.POSTGREST_BIN} ${this.TENANT_CONFIG_DIR}/%i.conf +RTS -N1 -M30m -I0.1 -A1m -RTS
+Environment="GHCRTS=${this.POSTGREST_RTS}"
+ExecStart=${this.POSTGREST_BIN} ${this.TENANT_CONFIG_DIR}/%i.conf +RTS ${this.POSTGREST_RTS} -RTS
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=3
@@ -287,8 +291,8 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 ReadOnlyPaths=${this.TENANT_CONFIG_DIR}
-MemoryMax=45M
-CPUWeight=20
+MemoryMax=${this.POSTGREST_MEMORY_MAX}
+CPUWeight=${this.POSTGREST_CPU_WEIGHT}
 
 [Install]
 WantedBy=multi-user.target
@@ -475,3 +479,8 @@ WantedBy=multi-user.target
 }
 
 export const tenantRuntimeService = new TenantRuntimeService();
+
+async function unitHasLegacyPostgrestMemoryLimit(unitPath: string): Promise<boolean> {
+    const content = await Bun.file(unitPath).text();
+    return content.includes("-M30m") || content.includes("MemoryMax=45M");
+}

--- a/packages/management-api/tests/unit/config.test.ts
+++ b/packages/management-api/tests/unit/config.test.ts
@@ -41,4 +41,10 @@ describe("Config", () => {
     expect(Number.isInteger(config.port)).toBe(true);
     expect(config.port).toBeGreaterThan(0);
   });
+
+  test("PostgREST runtime budget should handle large REST payloads", () => {
+    expect(config.postgrestRts).toContain("-M256m");
+    expect(config.postgrestMemoryMax).toBe("384M");
+    expect(config.postgrestCpuWeight).toBeGreaterThanOrEqual(40);
+  });
 });

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -18,6 +18,9 @@ PGRST_PORT_BASE="${PGRST_PORT_BASE:-3100}"
 GOTRUE_PORT_BASE="${GOTRUE_PORT_BASE:-4100}"
 PORT_RANGE="${PORT_RANGE:-10000}"
 SUPACLOUD_META_DB="${SUPACLOUD_META_DB:-supacloud_meta}"
+POSTGREST_RTS="${POSTGREST_RTS:--N1 -M256m -I0.5 -A4m}"
+POSTGREST_MEMORY_MAX="${POSTGREST_MEMORY_MAX:-384M}"
+POSTGREST_CPU_WEIGHT="${POSTGREST_CPU_WEIGHT:-40}"
 
 # Validate parameters
 validate_params() {
@@ -306,7 +309,7 @@ EOF
 # ========== Install systemd template unit ==========
 install_systemd_template() {
     local pgrst_unit="/etc/systemd/system/supacloud-pgrst@.service"
-    if [ ! -f "$pgrst_unit" ]; then
+    if [ ! -f "$pgrst_unit" ] || grep -Eq -- '-M30m|MemoryMax=45M' "$pgrst_unit"; then
         cat > "$pgrst_unit" <<EOF
 [Unit]
 Description=SupaCloud PostgREST for tenant %i
@@ -319,9 +322,9 @@ Type=simple
 User=nobody
 Group=nobody
 EnvironmentFile=/etc/supabase/tenants/%i.env
-# Extreme squeeze: limit to single thread, force Haskell runtime to aggressively reclaim memory (-M30m cap, -I0.1 idle 0.1s triggers GC)
-Environment="GHCRTS=-N1 -M30m -I0.1 -A1m"
-ExecStart=${POSTGREST_BIN} /etc/supabase/tenants/%i.conf +RTS -N1 -M30m -I0.1 -A1m -RTS
+# Keep PostgREST bounded without starving large REST reads/upserts.
+Environment="GHCRTS=${POSTGREST_RTS}"
+ExecStart=${POSTGREST_BIN} /etc/supabase/tenants/%i.conf +RTS ${POSTGREST_RTS} -RTS
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=3
@@ -332,8 +335,8 @@ NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 ReadOnlyPaths=/etc/supabase/tenants
-MemoryMax=45M
-CPUWeight=20
+MemoryMax=${POSTGREST_MEMORY_MAX}
+CPUWeight=${POSTGREST_CPU_WEIGHT}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- raise tenant PostgREST RTS heap cap from 30 MB to 256 MB and systemd MemoryMax from 45 MB to 384 MB
- expose POSTGREST_RTS, POSTGREST_MEMORY_MAX, and POSTGREST_CPU_WEIGHT config knobs
- automatically replace existing generated units that still contain the legacy 30 MB/45 MB limits

## Why
Large REST reads/upserts that include HTML/text payload columns can exhaust the old 30 MB PostgREST heap. In production this showed up as PostgREST `Heap exhausted`, followed by Kong/SupaCloud returning a 502 to the REST caller.

## Verification
- bash -n scripts/lib/tenant_runtime.sh
- bun test tests/unit/config.test.ts
- bun ./node_modules/typescript/bin/tsc --noEmit
