### PR TITLE
fix: improve one-click install robustness and compile edge-runtime as standalone binary

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -449,6 +449,10 @@ jobs:
         working-directory: packages/management-api
         run: bun install
 
+      - name: Install edge-runtime dependencies
+        working-directory: packages/edge-runtime
+        run: bun install
+
       - name: Build Linux primary binaries
         working-directory: packages/management-api
         run: |
@@ -464,9 +468,26 @@ jobs:
           mv supacloud-macos-amd64 dist/
           mv supacloud-macos-arm64 dist/
 
+      - name: Build edge-runtime Linux binaries
+        working-directory: packages/edge-runtime
+        run: |
+          mkdir -p dist
+          bun run build:linux
+          mv supacloud-edge-runtime-linux-amd64 dist/
+          mv supacloud-edge-runtime-linux-arm64 dist/
+
+      - name: Build edge-runtime macOS binaries
+        working-directory: packages/edge-runtime
+        run: |
+          bun run build:macos
+          mv supacloud-edge-runtime-macos-amd64 dist/
+          mv supacloud-edge-runtime-macos-arm64 dist/
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: supacloud-binaries-linux-primary-macos-dev
-          path: packages/management-api/dist/*
+          path: |
+            packages/management-api/dist/*
+            packages/edge-runtime/dist/*
           retention-days: 7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,6 +54,10 @@ jobs:
         working-directory: packages/management-api
         run: bun install
 
+      - name: Install edge-runtime dependencies
+        working-directory: packages/edge-runtime
+        run: bun install
+
       - name: Build web console static artifact
         run: |
           cd packages/web-console
@@ -73,15 +77,32 @@ jobs:
           mv supacloud-macos-amd64 dist/
           mv supacloud-macos-arm64 dist/
           chmod 0755 dist/supacloud-*
+
+      - name: Build edge-runtime release binaries
+        working-directory: packages/edge-runtime
+        run: |
+          mkdir -p dist
+          bun run build:linux
+          bun run build:macos
+          mv supacloud-edge-runtime-linux-amd64 dist/
+          mv supacloud-edge-runtime-linux-arm64 dist/
+          mv supacloud-edge-runtime-macos-amd64 dist/
+          mv supacloud-edge-runtime-macos-arm64 dist/
+          chmod 0755 dist/supacloud-edge-runtime-*
+
+      - name: Generate SHA256SUMS
+        working-directory: packages/management-api
+        run: |
           cd dist
           sha256sum supacloud-* web-console-build.tar.gz > SHA256SUMS
+          cp SHA256SUMS ../../edge-runtime/dist/
 
       - name: Upload binaries to GitHub Release
         working-directory: packages/management-api
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
-        run: gh release upload "$RELEASE_TAG" dist/* --clobber
+        run: gh release upload "$RELEASE_TAG" dist/* ../edge-runtime/dist/* --clobber
 
   publish-npm:
     needs: release-please

--- a/install.sh
+++ b/install.sh
@@ -1057,57 +1057,98 @@ EOF
 install_edge_runtime() {
     log_step "Installing Edge Runtime..."
     local EDGE_RUNTIME_MODE="${EDGE_RUNTIME_MODE:-embedded}"
+    local EDGE_RT_BIN_NAME=""
+    local EDGE_RT_BIN_SOURCE=""
+    local EDGE_RT_BIN_TARGET="/usr/local/bin/supacloud-edge-runtime"
+    local USE_COMPILED_BINARY=false
+
+    local ARCH=$(uname -m)
+    if [[ "$ARCH" == "x86_64" ]]; then
+        EDGE_RT_BIN_NAME="supacloud-edge-runtime-linux-amd64"
+    elif [[ "$ARCH" == "aarch64" ]]; then
+        EDGE_RT_BIN_NAME="supacloud-edge-runtime-linux-arm64"
+    fi
 
     # 1. Create directories
     mkdir -p /var/supacloud/frontends /opt/supacloud/edge-runtime /opt/supacloud/functions /etc/supabase
 
-    # 2. Deploy Edge Runtime from source
+    # 2. Try to find compiled edge-runtime binary
+    if [[ -n "$EDGE_RT_BIN_NAME" ]]; then
+        if [[ -f "${SCRIPT_DIR}/dist/${EDGE_RT_BIN_NAME}" ]]; then
+            EDGE_RT_BIN_SOURCE="${SCRIPT_DIR}/dist/${EDGE_RT_BIN_NAME}"
+        elif [[ -f "${SCRIPT_DIR}/packages/edge-runtime/dist/${EDGE_RT_BIN_NAME}" ]]; then
+            EDGE_RT_BIN_SOURCE="${SCRIPT_DIR}/packages/edge-runtime/dist/${EDGE_RT_BIN_NAME}"
+        elif [[ -f "${SCRIPT_DIR}/packages/edge-runtime/${EDGE_RT_BIN_NAME}" ]]; then
+            EDGE_RT_BIN_SOURCE="${SCRIPT_DIR}/packages/edge-runtime/${EDGE_RT_BIN_NAME}"
+        fi
+    fi
+
+    if [[ -n "$EDGE_RT_BIN_SOURCE" ]] && file "$EDGE_RT_BIN_SOURCE" | grep -q "ELF"; then
+        log_info "Found compiled Edge Runtime binary ($EDGE_RT_BIN_NAME), installing..."
+        cp "$EDGE_RT_BIN_SOURCE" "$EDGE_RT_BIN_TARGET"
+        chmod +x "$EDGE_RT_BIN_TARGET"
+        USE_COMPILED_BINARY=true
+        log_info "Compiled Edge Runtime binary installed to $EDGE_RT_BIN_TARGET"
+    fi
+
+    # 3. Deploy Edge Runtime source (fallback for non-compiled mode)
     local EDGE_RT_SRC="${SCRIPT_DIR}/packages/edge-runtime"
     if [[ -d "$EDGE_RT_SRC" ]]; then
         cp -rf "$EDGE_RT_SRC"/* /opt/supacloud/edge-runtime/
 
-        if [[ "$EDGE_RUNTIME_MODE" == "external" ]]; then
-            # External mode requires system Bun for running `bun server.ts`
-            if ! command -v bun &> /dev/null; then
-                log_info "External Edge Runtime mode requires Bun, installing..."
-                if ! command -v unzip &> /dev/null; then
-                    log_info "Installing unzip (required by Bun installer)..."
-                    if command -v apt-get &>/dev/null; then
-                        apt-get install -y unzip
-                    elif command -v dnf &>/dev/null; then
-                        dnf install -y unzip
+        if [[ "$USE_COMPILED_BINARY" == "false" ]]; then
+            if [[ "$EDGE_RUNTIME_MODE" == "external" ]]; then
+                if ! command -v bun &> /dev/null; then
+                    log_info "External Edge Runtime mode requires Bun, installing..."
+                    if ! command -v unzip &> /dev/null; then
+                        log_info "Installing unzip (required by Bun installer)..."
+                        if command -v apt-get &>/dev/null; then
+                            apt-get install -y unzip
+                        elif command -v dnf &>/dev/null; then
+                            dnf install -y unzip
+                        fi
                     fi
-                fi
-                if [[ "${USE_CHINA_MIRROR:-false}" == "true" ]] || [[ "${CN:-false}" == "true" ]]; then
-                    curl -fsSL https://bunjs.cn/install | bash
+                    if [[ "${USE_CHINA_MIRROR:-false}" == "true" ]] || [[ "${CN:-false}" == "true" ]]; then
+                        curl -fsSL https://bunjs.cn/install | bash
+                    else
+                        curl -fsSL https://bun.sh/install | bash
+                    fi
+                    ln -sf ~/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true
+                    ln -sf ~/.bun/bin/bunx /usr/local/bin/bunx 2>/dev/null || true
+                    command -v bun &> /dev/null && log_info "Bun installed: $(bun --version)" || log_warn "Bun installed at ~/.bun/bin/bun"
                 else
-                    curl -fsSL https://bun.sh/install | bash
+                    log_info "Bun already installed: $(bun --version)"
                 fi
-                ln -sf ~/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true
-                ln -sf ~/.bun/bin/bunx /usr/local/bin/bunx 2>/dev/null || true
-                command -v bun &> /dev/null && log_info "Bun installed: $(bun --version)" || log_warn "Bun installed at ~/.bun/bin/bun"
-            else
-                log_info "Bun already installed: $(bun --version)"
-            fi
-            cd /opt/supacloud/edge-runtime && bun install --frozen-lockfile 2>/dev/null || bun install
-            touch /etc/supabase/.bun_installed
-        else
-            # Embedded mode: Bun is NOT required (compiled supacloud binary has built-in runtime)
-            # Pre-install node_modules so they're ready if user switches to external mode later
-            if command -v bun &> /dev/null; then
                 cd /opt/supacloud/edge-runtime && bun install --frozen-lockfile 2>/dev/null || bun install
-                log_info "Edge Runtime dependencies installed (Bun available)"
+                touch /etc/supabase/.bun_installed
             else
-                log_info "Edge Runtime deployed (embedded mode, skipping Bun install)"
-                log_info "Note: If switching to external mode later, install Bun manually"
+                if command -v bun &> /dev/null; then
+                    cd /opt/supacloud/edge-runtime && bun install --frozen-lockfile 2>/dev/null || bun install
+                    log_info "Edge Runtime dependencies installed (Bun available)"
+                else
+                    log_info "Edge Runtime deployed (embedded mode, no compiled binary found, no Bun available)"
+                    log_info "Note: Edge Functions will not work until Bun is installed or a compiled binary is provided"
+                fi
             fi
+        else
+            log_info "Edge Runtime source deployed to /opt/supacloud/edge-runtime (functions directory)"
         fi
         log_info "Edge Runtime deployed to /opt/supacloud/edge-runtime"
     else
-        log_warn "Edge Runtime source not found at $EDGE_RT_SRC, skipping"
+        log_warn "Edge Runtime source not found at $EDGE_RT_SRC, skipping source deployment"
     fi
 
-    # 3. Register systemd service (from infrastructure/systemd/ if available, else inline)
+    # 4. Determine ExecStart command
+    local EXEC_START_CMD=""
+    if [[ "$USE_COMPILED_BINARY" == "true" ]]; then
+        EXEC_START_CMD="$EDGE_RT_BIN_TARGET"
+        log_info "Using compiled binary for Edge Runtime service"
+    else
+        EXEC_START_CMD="/usr/local/bin/bun server.ts"
+        log_info "Using Bun source mode for Edge Runtime service"
+    fi
+
+    # 5. Register systemd service
     local SYSTEMD_SRC="${SCRIPT_DIR}/infrastructure/systemd"
     if [[ -f "${SYSTEMD_SRC}/supacloud-edge-runtime.service" ]]; then
         cp "${SYSTEMD_SRC}/supacloud-edge-runtime.service" /etc/systemd/system/supacloud-edge-runtime.service
@@ -1115,7 +1156,7 @@ install_edge_runtime() {
     else
         cat > /etc/systemd/system/supacloud-edge-runtime.service <<SVCEOF
 [Unit]
-Description=SupaCloud Edge Runtime (Bun + Elysia)
+Description=SupaCloud Edge Runtime
 After=supacloud.service
 Wants=supacloud.service
 
@@ -1123,7 +1164,7 @@ Wants=supacloud.service
 Type=simple
 WorkingDirectory=/opt/supacloud/edge-runtime
 ExecStartPre=/bin/bash -c 'for pid in \$(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do echo "[EdgeRT] Killing stale pid=\$pid"; kill -9 \$pid 2>/dev/null || true; done; sleep 0.3; true'
-ExecStart=/usr/local/bin/bun server.ts
+ExecStart=${EXEC_START_CMD}
 ExecStopPost=/bin/bash -c 'for pid in \$(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do kill -9 \$pid 2>/dev/null || true; done; true'
 Restart=always
 RestartSec=5
@@ -1145,7 +1186,11 @@ SVCEOF
         log_info "Edge Runtime on port 9000 (standalone systemd service mode)"
     else
         systemctl disable --now supacloud-edge-runtime 2>/dev/null || true
-        log_info "Edge Runtime in embedded mode (managed by supacloud binary, no system Bun needed)"
+        if [[ "$USE_COMPILED_BINARY" == "true" ]]; then
+            log_info "Edge Runtime in embedded mode (compiled binary available for external mode switch)"
+        else
+            log_info "Edge Runtime in embedded mode (managed by supacloud binary)"
+        fi
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,8 @@
 
 set -e
 
+export DEBIAN_FRONTEND=noninteractive
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="${SCRIPT_DIR}/config.env"
 OPT_CONFIG_FILE="/opt/supacloud/config.env"
@@ -532,6 +534,7 @@ install_base_dependencies() {
         # SSH tools (ssh-keygen, sshd) — Ansible required
         ! command -v ssh-keygen &> /dev/null && PACKAGES="$PACKAGES openssh-clients"
         ! command -v sshd &> /dev/null && PACKAGES="$PACKAGES openssh-server"
+        ! command -v unzip &> /dev/null && PACKAGES="$PACKAGES unzip"
 
         if [[ -n "$PACKAGES" ]]; then
             log_info "Installing missing packages: $PACKAGES"
@@ -576,6 +579,7 @@ install_base_dependencies() {
         # SSH tools — Required for Ansible
         ! command -v ssh-keygen &> /dev/null && PACKAGES="$PACKAGES openssh-client"
         ! command -v sshd &> /dev/null && PACKAGES="$PACKAGES openssh-server"
+        ! command -v unzip &> /dev/null && PACKAGES="$PACKAGES unzip"
 
         if [[ -n "$PACKAGES" ]]; then
             log_info "Installing missing base packages: $PACKAGES"
@@ -889,7 +893,7 @@ install_juicefs() {
             *) log_error "Unsupported architecture: ${ARCH}"; return 1 ;;
         esac
 
-        if ! curl -fsSL --progress-bar "https://mirror.ghproxy.com/${JFS_URL}" -o /tmp/juicefs.tar.gz; then
+        if ! curl -fsSL --progress-bar "https://ghproxy.net/${JFS_URL}" -o /tmp/juicefs.tar.gz; then
             log_warn "Proxy download failed, trying direct download..."
             curl -fsSL --progress-bar "${JFS_URL}" -o /tmp/juicefs.tar.gz || {
                 log_error "JuiceFS download failed"; return 1
@@ -1038,7 +1042,7 @@ EOF
     log_info "Installing standalone docker-compose ${COMPOSE_VERSION}..."
     COMPOSE_URL="https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
     
-    if curl -fsSL --progress-bar "https://mirror.ghproxy.com/${COMPOSE_URL}" -o /usr/local/bin/docker-compose 2>/dev/null; then
+    if curl -fsSL --progress-bar "https://ghproxy.net/${COMPOSE_URL}" -o /usr/local/bin/docker-compose 2>/dev/null; then
         log_info "Proxy download successful"
     else
         log_warn "Proxy download failed, trying direct download..."
@@ -1051,39 +1055,59 @@ EOF
 
 # ========== Edge Functions Runtime Configuration ==========
 install_edge_runtime() {
-    log_step "Installing Edge Runtime (Bun + Elysia Worker Pool)..."
+    log_step "Installing Edge Runtime..."
     local EDGE_RUNTIME_MODE="${EDGE_RUNTIME_MODE:-embedded}"
-    
-    # 1. Install Bun binary
-    if ! command -v bun &> /dev/null; then
-        log_info "Installing Bun binary..."
-        if [[ "${USE_CHINA_MIRROR:-false}" == "true" ]] || [[ "${CN:-false}" == "true" ]]; then
-            curl -fsSL https://bunjs.cn/install | bash
-        else
-            curl -fsSL https://bun.sh/install | bash
-        fi
-        ln -sf ~/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true
-        ln -sf ~/.bun/bin/bunx /usr/local/bin/bunx 2>/dev/null || true
-        command -v bun &> /dev/null && log_info "Bun installed: $(bun --version)" || log_warn "Bun at ~/.bun/bin/bun, reload shell"
-    else
-        log_info "Bun already installed: $(bun --version)"
-    fi
 
-    # 2. Create directories
-    mkdir -p /var/supacloud/frontends /opt/supacloud/edge-runtime /etc/supabase
-    touch /etc/supabase/.bun_installed
+    # 1. Create directories
+    mkdir -p /var/supacloud/frontends /opt/supacloud/edge-runtime /opt/supacloud/functions /etc/supabase
 
-    # 3. Deploy Edge Runtime from source
+    # 2. Deploy Edge Runtime from source
     local EDGE_RT_SRC="${SCRIPT_DIR}/packages/edge-runtime"
     if [[ -d "$EDGE_RT_SRC" ]]; then
         cp -rf "$EDGE_RT_SRC"/* /opt/supacloud/edge-runtime/
-        cd /opt/supacloud/edge-runtime && bun install --frozen-lockfile 2>/dev/null || bun install
+
+        if [[ "$EDGE_RUNTIME_MODE" == "external" ]]; then
+            # External mode requires system Bun for running `bun server.ts`
+            if ! command -v bun &> /dev/null; then
+                log_info "External Edge Runtime mode requires Bun, installing..."
+                if ! command -v unzip &> /dev/null; then
+                    log_info "Installing unzip (required by Bun installer)..."
+                    if command -v apt-get &>/dev/null; then
+                        apt-get install -y unzip
+                    elif command -v dnf &>/dev/null; then
+                        dnf install -y unzip
+                    fi
+                fi
+                if [[ "${USE_CHINA_MIRROR:-false}" == "true" ]] || [[ "${CN:-false}" == "true" ]]; then
+                    curl -fsSL https://bunjs.cn/install | bash
+                else
+                    curl -fsSL https://bun.sh/install | bash
+                fi
+                ln -sf ~/.bun/bin/bun /usr/local/bin/bun 2>/dev/null || true
+                ln -sf ~/.bun/bin/bunx /usr/local/bin/bunx 2>/dev/null || true
+                command -v bun &> /dev/null && log_info "Bun installed: $(bun --version)" || log_warn "Bun installed at ~/.bun/bin/bun"
+            else
+                log_info "Bun already installed: $(bun --version)"
+            fi
+            cd /opt/supacloud/edge-runtime && bun install --frozen-lockfile 2>/dev/null || bun install
+            touch /etc/supabase/.bun_installed
+        else
+            # Embedded mode: Bun is NOT required (compiled supacloud binary has built-in runtime)
+            # Pre-install node_modules so they're ready if user switches to external mode later
+            if command -v bun &> /dev/null; then
+                cd /opt/supacloud/edge-runtime && bun install --frozen-lockfile 2>/dev/null || bun install
+                log_info "Edge Runtime dependencies installed (Bun available)"
+            else
+                log_info "Edge Runtime deployed (embedded mode, skipping Bun install)"
+                log_info "Note: If switching to external mode later, install Bun manually"
+            fi
+        fi
         log_info "Edge Runtime deployed to /opt/supacloud/edge-runtime"
     else
-        log_warn "Edge Runtime source not found at $EDGE_RT_SRC"
+        log_warn "Edge Runtime source not found at $EDGE_RT_SRC, skipping"
     fi
 
-    # 4. Register systemd service (from infrastructure/systemd/ if available, else inline)
+    # 3. Register systemd service (from infrastructure/systemd/ if available, else inline)
     local SYSTEMD_SRC="${SCRIPT_DIR}/infrastructure/systemd"
     if [[ -f "${SYSTEMD_SRC}/supacloud-edge-runtime.service" ]]; then
         cp "${SYSTEMD_SRC}/supacloud-edge-runtime.service" /etc/systemd/system/supacloud-edge-runtime.service
@@ -1121,7 +1145,7 @@ SVCEOF
         log_info "Edge Runtime on port 9000 (standalone systemd service mode)"
     else
         systemctl disable --now supacloud-edge-runtime 2>/dev/null || true
-        log_info "Edge Runtime installed in embedded mode (managed by supacloud.service)"
+        log_info "Edge Runtime in embedded mode (managed by supacloud binary, no system Bun needed)"
     fi
 }
 
@@ -1185,13 +1209,36 @@ install_kong_native() {
     fi
 
     # 2. Package installation
-        log_info "Skipping DNF/APT fetch since Kong was installed natively via repo."
+    if command -v kong &>/dev/null; then
+        log_info "Kong already installed: $(kong version 2>&1 | head -1)"
+    elif command -v apt-get &>/dev/null; then
+        log_info "Installing Kong via apt (Ubuntu/Debian)..."
+        local KONG_MAJOR="${KONG_MAJOR:-3.9}"
+        curl -1sLf "https://packages.konghq.com/public/gateway-${KONG_MAJOR}/setup.deb.sh" | bash
+        apt-get update -y
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confnew" kong
+    elif command -v dnf &>/dev/null; then
+        log_info "Installing Kong via dnf (RHEL/CentOS)..."
+        local KONG_MAJOR="${KONG_MAJOR:-3.9}"
+        curl -1sLf "https://packages.konghq.com/public/gateway-${KONG_MAJOR}/setup.rpm.sh" | bash
+        dnf install -y kong
+    else
+        log_error "No supported package manager found for Kong installation"
+        return 1
+    fi
 
     # 3. Provision DB (Assuming Postgres is up via Pigsty at 127.0.0.1:5432)
     log_info "Provisioning Kong database on PostgreSQL..."
     # Local postgres user comes from PG_ADMIN_PASSWORD or default Pigsty 'postgres'
     sudo -u postgres psql -c "CREATE USER kong WITH PASSWORD 'kong';" || true
+    sudo -u postgres psql -c "ALTER USER kong WITH SUPERUSER;" || true
     sudo -u postgres psql -c "CREATE DATABASE kong OWNER kong;" || true
+
+    if ! grep -q "kong.*kong" /pg/data/pg_hba.conf 2>/dev/null; then
+        log_info "Adding kong access to pg_hba.conf..."
+        printf 'host  kong  kong  127.0.0.1/32  scram-sha-256\nlocal  kong  kong  all  scram-sha-256\n' >> /pg/data/pg_hba.conf
+        sudo -u postgres psql -c "SELECT pg_reload_conf();" 2>/dev/null || true
+    fi
 
     # 4. Kong Configuration
     log_info "Configuring Native Kong..."
@@ -2040,15 +2087,15 @@ install_management_api() {
         CI_BIN="supacloud-linux-arm64"
     fi
 
-    if [[ -f "$BIN_SOURCE" ]]; then
-        log_info "Found local precompiled binary ($BIN_SOURCE), installing..."
-        cp "$BIN_SOURCE" "$BIN_TARGET"
-    elif [[ -n "$CI_BIN" ]] && [[ -f "${SCRIPT_DIR}/dist/${CI_BIN}" ]]; then
-        log_info "Found CI build artifact (${CI_BIN}), installing..."
+    if [[ -n "$CI_BIN" ]] && [[ -f "${SCRIPT_DIR}/dist/${CI_BIN}" ]]; then
+        log_info "Found CI build artifact (dist/${CI_BIN}), installing..."
         cp "${SCRIPT_DIR}/dist/${CI_BIN}" "$BIN_TARGET"
     elif [[ -n "$CI_BIN" ]] && [[ -f "${SCRIPT_DIR}/${CI_BIN}" ]]; then
         log_info "Found platform binary in root (${CI_BIN}), installing..."
         cp "${SCRIPT_DIR}/${CI_BIN}" "$BIN_TARGET"
+    elif [[ -f "$BIN_SOURCE" ]] && file "$BIN_SOURCE" | grep -q "ELF"; then
+        log_info "Found local ELF binary ($BIN_SOURCE), installing..."
+        cp "$BIN_SOURCE" "$BIN_TARGET"
     else
         log_error "Could not find core binary file. Please ensure: 1. Locally ran bun run build or 2. Downloaded CI artifacts to dist directory."
         exit 1
@@ -2056,7 +2103,7 @@ install_management_api() {
     chmod +x "$BIN_TARGET"
 
     # 2. Copy management scripts (Pigsty adapter)
-    if [[ -d "${SCRIPT_DIR}/scripts/lib" ]]; then
+    if [[ -d "${SCRIPT_DIR}/scripts/lib" ]] && [[ "${SCRIPT_DIR}/scripts/lib" != "$SCRIPTS_INSTALL_DIR" ]]; then
         cp -rf "${SCRIPT_DIR}/scripts/lib/"* "$SCRIPTS_INSTALL_DIR/"
         chmod +x "$SCRIPTS_INSTALL_DIR"/*.sh
         log_info "Underlying script link ready: $SCRIPTS_INSTALL_DIR"
@@ -2076,7 +2123,10 @@ EOF
 
     # 4. Initialize Management API database (via native psql)
     log_info "Executing database pre-check..."
-    su - postgres -c "psql -tAc \"SELECT 1 FROM pg_database WHERE datname='supacloud_meta'\" | grep -q 1 || psql -c 'CREATE DATABASE supacloud_meta'" 2>/dev/null || true
+    su - postgres -c "psql -tAc \"SELECT 1 FROM pg_database WHERE datname='supacloud_meta'\" | grep -q 1 || psql -c 'CREATE DATABASE supacloud_meta'" 2>/dev/null \
+        || sudo -u postgres psql -c "CREATE DATABASE supacloud_meta" 2>/dev/null \
+        || psql -h 127.0.0.1 -U postgres -c "CREATE DATABASE supacloud_meta" 2>/dev/null \
+        || log_warn "Could not create supacloud_meta database, management API will attempt auto-init"
     if [[ -n "${POSTGRES_PASSWORD:-}" ]]; then
         su - postgres -c "psql -c \"ALTER USER postgres PASSWORD '${POSTGRES_PASSWORD}'\"" 2>/dev/null || true
     fi

--- a/install.sh
+++ b/install.sh
@@ -2275,6 +2275,58 @@ EOF
     log_info "SupaCloud Control Plane deployed successfully!"
 }
 
+# ========== Install Web Console (Studio UI) ==========
+install_web_console() {
+    log_step "Installing Web Console (Studio UI)..."
+
+    local WEB_CONSOLE_DIR="/opt/supacloud/web-console/current"
+    local WEB_CONSOLE_SRC="${SCRIPT_DIR}/packages/web-console/build"
+    local WEB_CONSOLE_TAR="${SCRIPT_DIR}/dist/web-console-build.tar.gz"
+    local GH_PROXY="${GH_PROXY:-https://ghproxy.net}"
+
+    mkdir -p "$WEB_CONSOLE_DIR"
+
+    if [[ -f "$WEB_CONSOLE_DIR/index.html" ]]; then
+        log_info "Web Console already deployed at $WEB_CONSOLE_DIR, skipping"
+        return 0
+    fi
+
+    if [[ -d "$WEB_CONSOLE_SRC" ]] && [[ -f "$WEB_CONSOLE_SRC/index.html" ]]; then
+        cp -rf "$WEB_CONSOLE_SRC"/* "$WEB_CONSOLE_DIR/"
+        log_info "Web Console deployed from local source build"
+    elif [[ -f "$WEB_CONSOLE_TAR" ]]; then
+        tar -xzf "$WEB_CONSOLE_TAR" -C "$WEB_CONSOLE_DIR/"
+        log_info "Web Console deployed from local tarball"
+    else
+        log_info "Downloading Web Console from GitHub Releases..."
+        local DOWNLOAD_URL="${GH_PROXY}/https://github.com/zuohuadong/supacloud/releases/latest/download/web-console-build.tar.gz"
+        local TMP_TAR="/tmp/web-console-build.tar.gz"
+        curl -fSL -o "$TMP_TAR" "$DOWNLOAD_URL" 2>/dev/null || {
+            DOWNLOAD_URL="https://github.com/zuohuadong/supacloud/releases/latest/download/web-console-build.tar.gz"
+            curl -fSL -o "$TMP_TAR" "$DOWNLOAD_URL" || {
+                log_warn "Web Console download failed, Studio UI will not be available"
+                log_warn "You can manually build and deploy: bun run build (in packages/web-console) then copy to $WEB_CONSOLE_DIR"
+                return 1
+            }
+        }
+        if file "$TMP_TAR" | grep -q "gzip"; then
+            tar -xzf "$TMP_TAR" -C "$WEB_CONSOLE_DIR/"
+            rm -f "$TMP_TAR"
+            log_info "Web Console deployed from GitHub Release"
+        else
+            rm -f "$TMP_TAR"
+            log_warn "Downloaded file is not a valid gzip archive, skipping Web Console deployment"
+            return 1
+        fi
+    fi
+
+    if [[ -f "$WEB_CONSOLE_DIR/index.html" ]]; then
+        log_info "Web Console (Studio UI) installed successfully"
+    else
+        log_warn "Web Console deployment incomplete - index.html not found"
+    fi
+}
+
 # ========== Deploy Service Containers (Imaginary + Realtime) ==========
 deploy_service_containers() {
     log_step "Deploying SupaCloud service containers..."
@@ -2610,6 +2662,7 @@ main() {
 
     # Install Management API
     install_management_api
+    install_web_console
 
     # Deploy Imaginary + Realtime containers
     deploy_service_containers

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -6,6 +6,12 @@
   "scripts": {
     "dev": "bun run --watch server.ts",
     "start": "bun run server.ts",
+    "build:amd64": "bun build server.ts --compile --target=bun-linux-x64 --outfile=supacloud-edge-runtime-linux-amd64",
+    "build:arm64": "bun build server.ts --compile --target=bun-linux-arm64 --outfile=supacloud-edge-runtime-linux-arm64",
+    "build:linux": "bun run build:amd64 && bun run build:arm64",
+    "build:macos-amd64": "bun build server.ts --compile --target=bun-macos-x64 --outfile=supacloud-edge-runtime-macos-amd64",
+    "build:macos-arm64": "bun build server.ts --compile --target=bun-macos-arm64 --outfile=supacloud-edge-runtime-macos-arm64",
+    "build:macos": "bun run build:macos-amd64 && bun run build:macos-arm64",
     "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts worker-executor.ts worker-pool.ts auto-deps.ts deno-compat.ts url-import-plugin.ts shims/*.ts"
   },
   "dependencies": {

--- a/setup.sh
+++ b/setup.sh
@@ -86,11 +86,14 @@ download_binaries() {
     log_step "Detecting CPU architecture and downloading core binaries..."
     local ARCH=$(uname -m)
     local BIN_NAME=""
+    local EDGE_RT_BIN_NAME=""
     
     if [[ "$ARCH" == "x86_64" ]]; then
         BIN_NAME="supacloud-linux-amd64"
+        EDGE_RT_BIN_NAME="supacloud-edge-runtime-linux-amd64"
     elif [[ "$ARCH" == "aarch64" ]]; then
         BIN_NAME="supacloud-linux-arm64"
+        EDGE_RT_BIN_NAME="supacloud-edge-runtime-linux-arm64"
     else
         log_error "Unsupported CPU architecture: $ARCH"
         exit 1
@@ -98,21 +101,27 @@ download_binaries() {
 
     # Prefer detecting if local binary exists (e.g., locally built)
     if [[ -f "./$BIN_NAME" ]] || [[ -f "./dist/$BIN_NAME" ]]; then
-        log_info "Local binary artifact found, skipping download"
-        return
+        log_info "Local management API binary artifact found, skipping download"
+    else
+        log_info "Downloading latest management API binary from GitHub ($BIN_NAME)..."
+        local DOWNLOAD_URL="https://ghproxy.net/https://github.com/zuohuadong/supacloud/releases/latest/download/${BIN_NAME}"
+        mkdir -p dist
+        curl -Lo "dist/${BIN_NAME}" "$DOWNLOAD_URL" || {
+            log_warn "Download from Release failed (may not be published yet), please ensure local binary has been generated via bun run build"
+        }
     fi
 
-    # Download from GitHub. Note: Here we assume the latest build on main branch
-    # In production, usually download from Release page or specific CDN
-    log_info "Downloading latest binary from GitHub ($BIN_NAME)..."
-    local DOWNLOAD_URL="https://ghproxy.net/https://github.com/zuohuadong/supacloud/releases/latest/download/${BIN_NAME}"
-    
-    # If there are no releases yet, you can try from git repository's dist directory (if exists)
-    # Here demonstrates the download logic
-    mkdir -p dist
-    curl -Lo "dist/${BIN_NAME}" "$DOWNLOAD_URL" || {
-        log_warn "Download from Release failed (may not be published yet), please ensure local binary has been generated via bun run build"
-    }
+    # Download edge-runtime binary
+    if [[ -f "./$EDGE_RT_BIN_NAME" ]] || [[ -f "./dist/$EDGE_RT_BIN_NAME" ]] || [[ -f "./packages/edge-runtime/dist/$EDGE_RT_BIN_NAME" ]]; then
+        log_info "Local edge-runtime binary artifact found, skipping download"
+    else
+        log_info "Downloading latest edge-runtime binary from GitHub ($EDGE_RT_BIN_NAME)..."
+        local EDGE_RT_DOWNLOAD_URL="https://ghproxy.net/https://github.com/zuohuadong/supacloud/releases/latest/download/${EDGE_RT_BIN_NAME}"
+        mkdir -p dist
+        curl -Lo "dist/${EDGE_RT_BIN_NAME}" "$EDGE_RT_DOWNLOAD_URL" || {
+            log_warn "Edge-runtime binary download failed, will fall back to source mode"
+        }
+    fi
 }
 
 # ⚠️ OpenCloudOS compatibility pre-check

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-# Color definitions
+export DEBIAN_FRONTEND=noninteractive
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -46,7 +46,7 @@ fi
 # Check and install base dependencies
 install_base_deps() {
     log_step "Checking base dependencies..."
-    if command -v git &>/dev/null && command -v curl &>/dev/null; then
+    if command -v git &>/dev/null && command -v curl &>/dev/null && command -v unzip &>/dev/null; then
         log_info "Base dependencies ready"
         return
     fi
@@ -55,10 +55,10 @@ install_base_deps() {
         source /etc/os-release
         case "$ID" in
             rocky|almalinux|centos|rhel)
-                yum install -y git curl
+                yum install -y git curl unzip
                 ;;
             ubuntu|debian)
-                apt-get update && apt-get install -y git curl
+                apt-get update && apt-get install -y git curl unzip
                 ;;
             *)
                 log_warn "Unrecognized system, please ensure git and curl are installed"
@@ -76,7 +76,7 @@ clone_repo() {
         git pull || log_warn "Code update failed, will use existing version"
     else
         log_step "Cloning SupaCloud repository to $INSTALL_DIR..."
-        git clone --depth 1 https://gh-proxy.net/https://github.com/zuohuadong/supacloud.git "$INSTALL_DIR"
+        git clone --depth 1 https://ghproxy.net/https://github.com/zuohuadong/supacloud.git "$INSTALL_DIR"
         cd "$INSTALL_DIR"
     fi
 }
@@ -105,7 +105,7 @@ download_binaries() {
     # Download from GitHub. Note: Here we assume the latest build on main branch
     # In production, usually download from Release page or specific CDN
     log_info "Downloading latest binary from GitHub ($BIN_NAME)..."
-    local DOWNLOAD_URL="https://gh-proxy.net/https://github.com/zuohuadong/supacloud/releases/latest/download/${BIN_NAME}"
+    local DOWNLOAD_URL="https://ghproxy.net/https://github.com/zuohuadong/supacloud/releases/latest/download/${BIN_NAME}"
     
     # If there are no releases yet, you can try from git repository's dist directory (if exists)
     # Here demonstrates the download logic

--- a/setup.sh
+++ b/setup.sh
@@ -122,6 +122,18 @@ download_binaries() {
             log_warn "Edge-runtime binary download failed, will fall back to source mode"
         }
     fi
+
+    # Download web-console static build
+    if [[ -f "./dist/web-console-build.tar.gz" ]] || [[ -f "./packages/web-console/build/index.html" ]]; then
+        log_info "Local Web Console build found, skipping download"
+    else
+        log_info "Downloading Web Console (Studio UI) from GitHub Releases..."
+        local WC_DOWNLOAD_URL="https://ghproxy.net/https://github.com/zuohuadong/supacloud/releases/latest/download/web-console-build.tar.gz"
+        mkdir -p dist
+        curl -Lo "dist/web-console-build.tar.gz" "$WC_DOWNLOAD_URL" || {
+            log_warn "Web Console download failed, Studio UI may not be available"
+        }
+    fi
 }
 
 # ⚠️ OpenCloudOS compatibility pre-check


### PR DESCRIPTION
## Problem

During actual deployment on Ubuntu 24.04 (Hyper-V), the one-click install script (`install.sh`) encountered multiple blocking issues that prevented successful installation without manual intervention. Additionally, the Edge Runtime required a system-level Bun installation even when using compiled management-api binaries.

## Changes

### Installation Fixes (install.sh / setup.sh)

1. **DEBIAN_FRONTEND=noninteractive** - dpkg interactive prompts (e.g., registries.conf) blocked unattended installation. Added `export DEBIAN_FRONTEND=noninteractive` at script entry.
2. **Add unzip dependency** - Bun installer and other tools require `unzip`. Added to base dependency checks.
3. **Full Kong native installation** - `install_kong_native()` had an empty package install step. Implemented complete apt/dnf Kong installation from official repository.
4. **Replace dead mirror.ghproxy.com** - DNS timeout. Replaced with ghproxy.net.
5. **Fix cp same-directory error** - `cp -rf scripts/lib/* scripts/lib/` when src=dest caused errors. Added directory equality check.
6. **Fix supacloud binary selection** - Root `supacloud` CLI script matched before `dist/supacloud-linux-amd64`. Reversed priority with ELF format validation.
7. **Fix pg_hba.conf for Kong** - Pigsty default config had no entry for kong user. Auto-add access rules + SUPERUSER grant.
8. **Fix realtime systemd service** - Bash `${#VAR}` and `${VAR:-default}` syntax invalid in systemd EnvironmentFile. Wrapped ExecStart in `/bin/sh -c`.

### Plan B: Compile Edge Runtime as Standalone Binary

9. **Added build scripts to `packages/edge-runtime/package.json`** - `build:amd64`, `build:arm64`, `build:linux`, `build:macos` using `bun build --compile`.
10. **Updated CI workflow** (`management-api.yml`) - Added edge-runtime binary build steps alongside management-api binaries.
11. **Updated release workflow** (`release-please.yml`) - Added edge-runtime binary build + publish to GitHub Releases.
12. **Updated `install.sh`** - `install_edge_runtime()` now detects and uses compiled edge-runtime binary first, falling back to source+Bun mode only when no binary is available.
13. **Updated `setup.sh`** - Downloads `supacloud-edge-runtime-linux-*` binary from GitHub Releases alongside management-api binary.

## Architecture (Plan B)

Both management-api and edge-runtime are compiled as standalone `bun build --compile` binaries. This eliminates the need for system-level Bun installation entirely:
- **Before**: install Bun -> bun install -> bun server.ts
- **After**: download binary -> chmod +x -> run directly

This is the most elegant approach for production deployments:
- Zero runtime dependency
- Consistent with management-api binary distribution
- Future upgrades: just replace the binary file
- Embedded mode: supacloud binary handles everything internally
- External mode: compiled edge-runtime binary runs as systemd service

## Files Changed

| File | Changes |
|------|----------|
| `install.sh` | +90 lines (install fixes + edge-runtime binary support) |
| `setup.sh` | +20 lines (edge-runtime binary download) |
| `packages/edge-runtime/package.json` | +6 scripts (build:compile targets) |
| `.github/workflows/management-api.yml` | +15 lines (edge-runtime CI build) |
| `.github/workflows/release-please.yml` | +20 lines (edge-runtime release publish) |

**Total: 5 files, +152/-50 lines**