### PR TITLE
fix(edge-runtime): normalize fallback tenant env

### DIFF
--- a/packages/edge-runtime/tenant-env.test.ts
+++ b/packages/edge-runtime/tenant-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isMaskedSecretValue, stripMaskedSecretValues } from "./tenant-env";
+import { isMaskedSecretValue, normalizeTenantEnv, stripMaskedSecretValues } from "./tenant-env";
 
 describe("tenant env masking guard", () => {
   test("recognizes masked secret placeholders", () => {
@@ -15,5 +15,19 @@ describe("tenant env masking guard", () => {
     })).toEqual({
       SUPABASE_SERVICE_ROLE_KEY: "header.payload.signature",
     });
+  });
+
+  test("normalizes fallback tenant env with routing variables", () => {
+    expect(normalizeTenantEnv("proj_1", {
+      SUPABASE_URL: "https://api.example.com",
+    })).toEqual(expect.objectContaining({
+      SUPABASE_URL: "https://api.example.com",
+      SUPACLOUD_PROJECT_REF: "proj_1",
+      X_PROJECT_REF: "proj_1",
+      SUPACLOUD_PROJECT_API_HOST: "api.example.com",
+      SUPACLOUD_INTERNAL_SUPABASE_URL: "http://127.0.0.1",
+      SUPACLOUD_INTERNAL_AUTH_URL: "http://127.0.0.1/auth/v1",
+      SUPACLOUD_INTERNAL_REST_URL: "http://127.0.0.1/rest/v1",
+    }));
   });
 });

--- a/packages/edge-runtime/tenant-env.ts
+++ b/packages/edge-runtime/tenant-env.ts
@@ -55,6 +55,47 @@ function parseEnvFile(content: string): Record<string, string> {
   return env;
 }
 
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function hostFromUrl(value: string | undefined): string {
+  if (!value) return "";
+  try {
+    return new URL(value).host;
+  } catch {
+    return "";
+  }
+}
+
+function defaultInternalSupabaseUrl(): string {
+  return stripTrailingSlash(
+    process.env.SUPACLOUD_INTERNAL_SUPABASE_URL ||
+      process.env.INTERNAL_SUPABASE_URL ||
+      "http://127.0.0.1",
+  );
+}
+
+export function normalizeTenantEnv(ref: string, env: Record<string, string>): Record<string, string> {
+  const normalized = { ...env };
+  const internalSupabaseUrl = stripTrailingSlash(
+    normalized.SUPACLOUD_INTERNAL_SUPABASE_URL || defaultInternalSupabaseUrl(),
+  );
+  const apiHost =
+    normalized.SUPACLOUD_PROJECT_API_HOST ||
+    hostFromUrl(normalized.SUPABASE_URL) ||
+    hostFromUrl(normalized.SUPACLOUD_EXTERNAL_SUPABASE_URL);
+
+  normalized.SUPACLOUD_PROJECT_REF ||= ref;
+  normalized.X_PROJECT_REF ||= ref;
+  normalized.SUPACLOUD_INTERNAL_SUPABASE_URL = internalSupabaseUrl;
+  normalized.SUPACLOUD_INTERNAL_AUTH_URL ||= `${internalSupabaseUrl}/auth/v1`;
+  normalized.SUPACLOUD_INTERNAL_REST_URL ||= `${internalSupabaseUrl}/rest/v1`;
+  if (apiHost) normalized.SUPACLOUD_PROJECT_API_HOST = apiHost;
+
+  return normalized;
+}
+
 async function loadEnvFromFile(ref: string): Promise<Record<string, string>> {
   for (const dir of TENANTS_DIRS) {
     const envPath = `${dir}/${ref}.env`;
@@ -108,12 +149,12 @@ export async function loadTenantEnv(ref: string): Promise<Record<string, string>
   const apiEnv = await loadEnvFromApi(ref);
   if (apiEnv === null) {
     if (cached) {
-      return { ...fileEnv, ...cached.env };
+      return normalizeTenantEnv(ref, { ...fileEnv, ...cached.env });
     }
-    return fileEnv;
+    return normalizeTenantEnv(ref, fileEnv);
   }
 
-  const merged = { ...fileEnv, ...apiEnv };
+  const merged = normalizeTenantEnv(ref, { ...fileEnv, ...apiEnv });
 
   envCache.set(ref, { env: merged, expiresAt: Date.now() + ENV_CACHE_TTL });
   return merged;


### PR DESCRIPTION
## Summary
- normalize Edge Runtime tenant env even when the internal runtime-env API is unavailable
- always provide SUPACLOUD_PROJECT_REF / X_PROJECT_REF for function runtime fallback env
- infer SUPACLOUD_PROJECT_API_HOST from SUPABASE_URL and seed SUPACLOUD_INTERNAL_* defaults

## Why
When management-api /internal/runtime-env returns 404 or is unreachable, Edge Runtime falls back to tenant env files. Existing deployments may only have SUPABASE_URL in those files, so functions cannot construct tenant headers for local Kong /auth/v1/user calls and user JWT verification fails with no Route matched / unauthorized.

## Test Plan
- bun test packages/edge-runtime/tenant-env.test.ts
- bun run --cwd packages/edge-runtime typecheck
