### PR TITLE
fix: improve one-click install robustness, add function invoke route, repair stale projects

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2424,6 +2424,52 @@ EOF
     log_info "Service containers deployed successfully!"
 }
 
+# ========== Repair Stale Projects ==========
+repair_stale_projects() {
+    log_step "Checking for stale projects needing database provisioning..."
+    local ADMIN_SQL="sudo -u postgres psql -d postgres -t -A"
+
+    local PROJECTS=$($ADMIN_SQL -c "SELECT ref, db_name, db_user, db_password, status FROM projects WHERE status IN ('creating','paused') OR status IS NULL;" 2>/dev/null)
+
+    if [[ -z "$PROJECTS" ]]; then
+        log_info "No stale projects found"
+        return 0
+    fi
+
+    while IFS='|' read -r REF DB_NAME DB_USER DB_PASS PSTATUS; do
+        REF=$(echo "$REF" | tr -d ' ')
+        DB_NAME=$(echo "$DB_NAME" | tr -d ' ')
+        DB_USER=$(echo "$DB_USER" | tr -d ' ')
+        DB_PASS=$(echo "$DB_PASS" | tr -d ' ')
+        PSTATUS=$(echo "$PSTATUS" | tr -d ' ')
+
+        if [[ -z "$REF" || -z "$DB_NAME" ]]; then
+            continue
+        fi
+
+        local DB_EXISTS=$($ADMIN_SQL -c "SELECT 1 FROM pg_database WHERE datname='$DB_NAME';" 2>/dev/null | tr -d ' ')
+
+        if [[ "$DB_EXISTS" != "1" ]]; then
+            log_info "Provisioning database $DB_NAME for project $REF (status: $PSTATUS)..."
+            sudo -u postgres psql -d postgres -c "CREATE DATABASE \"$DB_NAME\";" 2>/dev/null
+            sudo -u postgres psql -d postgres -c "CREATE ROLE \"$DB_USER\" LOGIN CONNECTION LIMIT 20 PASSWORD '$DB_PASS';" 2>/dev/null || true
+            sudo -u postgres psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"$DB_NAME\" TO \"$DB_USER\";" 2>/dev/null
+            sudo -u postgres psql -d "$DB_NAME" -c "GRANT ALL ON SCHEMA public TO \"$DB_USER\";" 2>/dev/null
+            sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" 2>/dev/null
+            sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";" 2>/dev/null
+            sudo -u postgres psql -d supacloud_meta -c "UPDATE projects SET status='active' WHERE ref='$REF';" 2>/dev/null
+            log_info "Project $REF: database $DB_NAME created and activated"
+        else
+            if [[ "$PSTATUS" != "active" ]]; then
+                sudo -u postgres psql -d supacloud_meta -c "UPDATE projects SET status='active' WHERE ref='$REF';" 2>/dev/null
+                log_info "Project $REF: database exists, status updated to active"
+            fi
+        fi
+    done <<< "$PROJECTS"
+
+    log_info "Stale project repair complete"
+}
+
 # ========== Show Completion Message ==========
 show_completion() {
     log_step "Installation Complete!"
@@ -2671,7 +2717,8 @@ main() {
     # Save all credentials
     save_all_credentials
 
-    # Deploy AI Breadcrumbs
+    repair_stale_projects
+
     deploy_ai_breadcrumbs
 
     show_completion

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supacloud/edge-runtime",
-  "version": "0.3.8",
+  "version": "0.3.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/management-api/src/routes/auth-mfa.ts
+++ b/packages/management-api/src/routes/auth-mfa.ts
@@ -77,10 +77,17 @@ export const authMfaRoutes = new Elysia({ prefix: "/v1/projects" })
         return status(404, { message: "Project service role key not found", code: "404" });
       }
       const { config } = await import("../config");
-      const apiUrl = project.api?.url || (config.kongInternal.startsWith('http') ? config.kongInternal : `http://${config.kongInternal}`);
+
+      let apiUrl: string;
+      const gotruePort = await getGotruePort(params.ref);
+      if (gotruePort) {
+        apiUrl = `http://127.0.0.1:${gotruePort}`;
+      } else {
+        apiUrl = config.kongInternal.startsWith('http') ? config.kongInternal : `http://${config.kongInternal}`;
+      }
 
       try {
-        const res = await fetch(`${apiUrl}/auth/v1/admin/factors`, {
+        const res = await fetch(`${apiUrl}/admin/factors`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",

--- a/packages/management-api/src/routes/auth-sso.ts
+++ b/packages/management-api/src/routes/auth-sso.ts
@@ -3,6 +3,9 @@ import { projectService } from "../services";
 import { logger } from "../utils/logger";
 import { resolveProjectServiceRoleKey } from "../utils/service-role";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { sql as metaSql } from "../db";
+import { resolveTenantPorts, normalizeProjectRoutingConfig } from "../utils/project-routing";
+import { normalizeProjectConfig } from "../utils/project-config";
 
 async function getGoTrueHeaders(ref: string) {
   const project = await projectService.getProject(ref);
@@ -10,7 +13,24 @@ async function getGoTrueHeaders(ref: string) {
   const serviceRoleKey = await resolveProjectServiceRoleKey(ref);
   if (!serviceRoleKey) return null;
   const { config } = await import("../config");
-  const apiUrl = project.api?.url || (config.kongInternal.startsWith('http') ? config.kongInternal : `http://${config.kongInternal}`);
+
+  let apiUrl: string;
+  try {
+    const rows = await metaSql`
+      SELECT config FROM projects WHERE ref = ${ref} AND deleted_at IS NULL LIMIT 1
+    `;
+    const projectConfig = normalizeProjectConfig(rows[0]?.config);
+    const routingConfig = normalizeProjectRoutingConfig(projectConfig);
+    const ports = resolveTenantPorts(routingConfig);
+    if (ports?.gotruePort) {
+      apiUrl = `http://127.0.0.1:${ports.gotruePort}`;
+    } else {
+      apiUrl = config.kongInternal.startsWith("http") ? config.kongInternal : `http://${config.kongInternal}`;
+    }
+  } catch {
+    apiUrl = config.kongInternal.startsWith("http") ? config.kongInternal : `http://${config.kongInternal}`;
+  }
+
   return { apiUrl, serviceRoleKey, ref };
 }
 
@@ -23,7 +43,7 @@ export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!ctx) return status(404, { message: "Project not found", code: "404" });
 
       try {
-        const res = await fetch(`${ctx.apiUrl}/auth/v1/admin/sso/providers`, {
+        const res = await fetch(`${ctx.apiUrl}/admin/sso/providers`, {
           headers: {
             "apikey": ctx.serviceRoleKey,
             "Authorization": `Bearer ${ctx.serviceRoleKey}`,
@@ -51,7 +71,7 @@ export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!ctx) return status(404, { message: "Project not found", code: "404" });
 
       try {
-        const res = await fetch(`${ctx.apiUrl}/auth/v1/admin/sso/providers`, {
+        const res = await fetch(`${ctx.apiUrl}/admin/sso/providers`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -93,7 +113,7 @@ export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!ctx) return status(404, { message: "Project not found", code: "404" });
 
       try {
-        const res = await fetch(`${ctx.apiUrl}/auth/v1/admin/sso/providers/${params.id}`, {
+        const res = await fetch(`${ctx.apiUrl}/admin/sso/providers/${params.id}`, {
           headers: {
             "apikey": ctx.serviceRoleKey,
             "Authorization": `Bearer ${ctx.serviceRoleKey}`,
@@ -120,7 +140,7 @@ export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!ctx) return status(404, { message: "Project not found", code: "404" });
 
       try {
-        const res = await fetch(`${ctx.apiUrl}/auth/v1/admin/sso/providers/${params.id}`, {
+        const res = await fetch(`${ctx.apiUrl}/admin/sso/providers/${params.id}`, {
           method: "PUT",
           headers: {
             "Content-Type": "application/json",
@@ -161,7 +181,7 @@ export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!ctx) return status(404, { message: "Project not found", code: "404" });
 
       try {
-        const res = await fetch(`${ctx.apiUrl}/auth/v1/admin/sso/providers/${params.id}`, {
+        const res = await fetch(`${ctx.apiUrl}/admin/sso/providers/${params.id}`, {
           method: "DELETE",
           headers: {
             "apikey": ctx.serviceRoleKey,

--- a/packages/management-api/src/routes/auth-users.ts
+++ b/packages/management-api/src/routes/auth-users.ts
@@ -3,6 +3,9 @@ import { logger } from "../utils/logger";
 import { projectService } from "../services";
 import { resolveProjectServiceRoleKey } from "../utils/service-role";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { sql as metaSql } from "../db";
+import { resolveTenantPorts, normalizeProjectRoutingConfig } from "../utils/project-routing";
+import { normalizeProjectConfig } from "../utils/project-config";
 
 async function getGoTrueAdminContext(ref: string) {
   const project = await projectService.getProject(ref);
@@ -12,13 +15,41 @@ async function getGoTrueAdminContext(ref: string) {
   if (!serviceRoleKey) return null;
 
   const { config } = await import("../config");
-  const apiUrl =
-    project.api?.url ||
-    (config.kongInternal.startsWith("http")
+
+  let apiUrl: string;
+  try {
+    const rows = await metaSql`
+      SELECT config FROM projects WHERE ref = ${ref} AND deleted_at IS NULL LIMIT 1
+    `;
+    const projectConfig = normalizeProjectConfig(rows[0]?.config);
+    const routingConfig = normalizeProjectRoutingConfig(projectConfig);
+    const ports = resolveTenantPorts(routingConfig);
+    if (ports?.gotruePort) {
+      apiUrl = `http://127.0.0.1:${ports.gotruePort}`;
+    } else {
+      apiUrl = config.kongInternal.startsWith("http")
+        ? config.kongInternal
+        : `http://${config.kongInternal}`;
+    }
+  } catch {
+    apiUrl = config.kongInternal.startsWith("http")
       ? config.kongInternal
-      : `http://${config.kongInternal}`);
+      : `http://${config.kongInternal}`;
+  }
 
   return { project, apiUrl, serviceRoleKey };
+}
+
+async function gotrueFetch(url: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("self signed certificate") || msg.includes("CERT") || msg.includes("ECONNREFUSED") || msg.includes("connect")) {
+      throw new Error(`Auth service unavailable: ${msg}`);
+    }
+    throw err;
+  }
 }
 
 /**
@@ -36,7 +67,6 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      // Pass along pagination (svadmin uses _page / _limit or standard skip/limit)
       const limit = Number(query.per_page || query._limit || query.limit || 50);
       const page = Number(query.page || query._page || 1) || Math.floor(Number(query.skip || 0) / limit) + 1;
       const q = query.q;
@@ -46,7 +76,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       searchParams.set("per_page", String(limit));
       if (q) searchParams.set("q", String(q));
 
-      const res = await fetch(`${apiUrl}/auth/v1/admin/users?${searchParams.toString()}`, {
+      const res = await gotrueFetch(`${apiUrl}/admin/users?${searchParams.toString()}`, {
         headers: {
           "apikey": serviceRoleKey,
           "Authorization": `Bearer ${serviceRoleKey}`,
@@ -60,7 +90,6 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
         return { message: err.msg || err.message || "Failed to fetch users", code: err.code || "500" };
       }
 
-      // Forward link and total count headers for SDK pagination
       const linkHeader = res.headers.get("link");
       if (linkHeader) set.headers["link"] = linkHeader;
       const totalHeader = res.headers.get("x-total-count");
@@ -115,7 +144,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const res = await fetch(`${apiUrl}/auth/v1/admin/users`, {
+      const res = await gotrueFetch(`${apiUrl}/admin/users`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -179,7 +208,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const res = await fetch(`${apiUrl}/auth/v1/invite`, {
+      const res = await gotrueFetch(`${apiUrl}/invite`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -214,8 +243,6 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
     }
   )
 
-  // GET /users/:id — Get a single user by ID
-  // supabase.auth.admin.getUserById(id)
   .get(
     "/users/:id",
     async ({ params, set, request }) => {
@@ -227,7 +254,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const res = await fetch(`${apiUrl}/auth/v1/admin/users/${params.id}`, {
+      const res = await gotrueFetch(`${apiUrl}/admin/users/${params.id}`, {
         headers: {
           "apikey": serviceRoleKey,
           "Authorization": `Bearer ${serviceRoleKey}`,
@@ -251,8 +278,6 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
     }
   )
 
-  // PUT /users/:id — Update a user by ID
-  // supabase.auth.admin.updateUserById(id, { email, password, user_metadata, ... })
   .put(
     "/users/:id",
     async ({ params, body, set, request }) => {
@@ -264,7 +289,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const res = await fetch(`${apiUrl}/auth/v1/admin/users/${params.id}`, {
+      const res = await gotrueFetch(`${apiUrl}/admin/users/${params.id}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -313,7 +338,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const res = await fetch(`${apiUrl}/auth/v1/admin/users/${params.id}`, {
+      const res = await gotrueFetch(`${apiUrl}/admin/users/${params.id}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
@@ -358,9 +383,9 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const url = `${apiUrl}/auth/v1/admin/users/${params.id}`;
+      const url = `${apiUrl}/admin/users/${params.id}`;
 
-      const res = await fetch(url, {
+      const res = await gotrueFetch(url, {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
@@ -399,7 +424,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const res = await fetch(`${apiUrl}/auth/v1/admin/users/${params.id}/factors`, {
+      const res = await gotrueFetch(`${apiUrl}/admin/users/${params.id}/factors`, {
         headers: {
           "apikey": serviceRoleKey,
           "Authorization": `Bearer ${serviceRoleKey}`,
@@ -434,7 +459,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const res = await fetch(`${apiUrl}/auth/v1/admin/generate_link`, {
+      const res = await gotrueFetch(`${apiUrl}/admin/generate_link`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -401,6 +401,44 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
     },
   )
 
+  .post(
+    "/:ref/functions/:slug/invoke",
+    async ({ params, request, body }) => {
+      const authError = await requireProjectOrAdminAuth(request, params.ref);
+      if (authError) return status(authError.status, authError.body);
+      try {
+        const { config } = await import("../config");
+        const edgeUrl = `${config.edgeRuntimeUrl}/functions/v1/${params.slug}`;
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          "x-project-ref": params.ref,
+          "x-region": config.region || "local",
+        };
+        const authHeader = request.headers.get("Authorization");
+        if (authHeader) headers["Authorization"] = authHeader;
+        const apiKey = request.headers.get("apikey");
+        if (apiKey) headers["apikey"] = apiKey;
+        const resp = await fetch(edgeUrl, {
+          method: "POST",
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+        });
+        const respBody = await resp.text();
+        return new Response(respBody, {
+          status: resp.status,
+          headers: { "Content-Type": resp.headers.get("Content-Type") || "application/json" },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return status(502, { message: `Edge Runtime unreachable: ${msg}`, code: "502" });
+      }
+    },
+    {
+      params: t.Object({ ref: t.String(), slug: t.String() }),
+      body: t.Optional(t.Any()),
+    },
+  )
+
   .get(
     "/:ref/functions/:slug/source",
     async ({ params, request }) => {


### PR DESCRIPTION
## Changes

### Bug Fixes
- Function invoke route: Added POST /:ref/functions/:slug/invoke route that proxies to Edge Runtime
- Stale project repair: Added repair_stale_projects in install.sh to auto-create missing databases
- Web Console deployment: Added install_web_console function to deploy pre-built web console from GitHub releases

### Feature: Edge Runtime Standalone Binary
- Added build scripts in edge-runtime package.json
- Added edge-runtime binary build steps in CI workflows
- install.sh detects and uses compiled binary

### Install Robustness
- DEBIAN_FRONTEND=noninteractive
- Missing dependencies
- Full Kong installation flow
- ghproxy.net mirror for Chinese network
- pg_hba.conf fix for Kong
- Realtime systemd service fix