### PR TITLE
fix(install): keep management database traffic on loopback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2439,6 +2439,52 @@ EOF
     log_info "Service containers deployed successfully!"
 }
 
+# ========== Repair Stale Projects ==========
+repair_stale_projects() {
+    log_step "Checking for stale projects needing database provisioning..."
+    local ADMIN_SQL="sudo -u postgres psql -d postgres -t -A"
+
+    local PROJECTS=$($ADMIN_SQL -c "SELECT ref, db_name, db_user, db_password, status FROM projects WHERE status IN ('creating','paused') OR status IS NULL;" 2>/dev/null)
+
+    if [[ -z "$PROJECTS" ]]; then
+        log_info "No stale projects found"
+        return 0
+    fi
+
+    while IFS='|' read -r REF DB_NAME DB_USER DB_PASS PSTATUS; do
+        REF=$(echo "$REF" | tr -d ' ')
+        DB_NAME=$(echo "$DB_NAME" | tr -d ' ')
+        DB_USER=$(echo "$DB_USER" | tr -d ' ')
+        DB_PASS=$(echo "$DB_PASS" | tr -d ' ')
+        PSTATUS=$(echo "$PSTATUS" | tr -d ' ')
+
+        if [[ -z "$REF" || -z "$DB_NAME" ]]; then
+            continue
+        fi
+
+        local DB_EXISTS=$($ADMIN_SQL -c "SELECT 1 FROM pg_database WHERE datname='$DB_NAME';" 2>/dev/null | tr -d ' ')
+
+        if [[ "$DB_EXISTS" != "1" ]]; then
+            log_info "Provisioning database $DB_NAME for project $REF (status: $PSTATUS)..."
+            sudo -u postgres psql -d postgres -c "CREATE DATABASE \"$DB_NAME\";" 2>/dev/null
+            sudo -u postgres psql -d postgres -c "CREATE ROLE \"$DB_USER\" LOGIN CONNECTION LIMIT 20 PASSWORD '$DB_PASS';" 2>/dev/null || true
+            sudo -u postgres psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"$DB_NAME\" TO \"$DB_USER\";" 2>/dev/null
+            sudo -u postgres psql -d "$DB_NAME" -c "GRANT ALL ON SCHEMA public TO \"$DB_USER\";" 2>/dev/null
+            sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" 2>/dev/null
+            sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";" 2>/dev/null
+            sudo -u postgres psql -d supacloud_meta -c "UPDATE projects SET status='active' WHERE ref='$REF';" 2>/dev/null
+            log_info "Project $REF: database $DB_NAME created and activated"
+        else
+            if [[ "$PSTATUS" != "active" ]]; then
+                sudo -u postgres psql -d supacloud_meta -c "UPDATE projects SET status='active' WHERE ref='$REF';" 2>/dev/null
+                log_info "Project $REF: database exists, status updated to active"
+            fi
+        fi
+    done <<< "$PROJECTS"
+
+    log_info "Stale project repair complete"
+}
+
 # ========== Show Completion Message ==========
 show_completion() {
     log_step "Installation Complete!"
@@ -2686,7 +2732,8 @@ main() {
     # Save all credentials
     save_all_credentials
 
-    # Deploy AI Breadcrumbs
+    repair_stale_projects
+
     deploy_ai_breadcrumbs
 
     show_completion

--- a/install.sh
+++ b/install.sh
@@ -2004,12 +2004,17 @@ configure_pg_hba() {
         return
     fi
     
-    # 3. Add rules
-    # host all all <CIDR> scram-sha-256
+    # 3. Add rules.
+    # Management API and tenant runtimes usually run on the database host. Some
+    # installs set DATABASE_URL/PG_HOST to INTERNAL_IP instead of loopback, so
+    # PostgreSQL sees the connection as coming from that host IP and rejects it
+    # unless pg_hba.conf explicitly allows it.
     CONFIG_LINE="host all all ${CONTAINER_NET} scram-sha-256"
-    
-    # Add localhost password auth rule (required by management-api)
     LOCALHOST_RULE="host    all             all             127.0.0.1/32            scram-sha-256"
+    HOST_RULE=""
+    if [[ -n "${INTERNAL_IP:-}" && "$INTERNAL_IP" != "127.0.0.1" && "$INTERNAL_IP" != "localhost" ]]; then
+        HOST_RULE="host    all             all             ${INTERNAL_IP}/32            scram-sha-256"
+    fi
     
     if grep -qF "$CONTAINER_NET" "$PG_HBA"; then
         log_info "Rule already exists: $CONFIG_LINE"
@@ -2025,6 +2030,16 @@ configure_pg_hba() {
     if ! grep -qF "127.0.0.1/32" "$PG_HBA"; then
         log_info "Adding localhost password authentication rule..."
         echo "$LOCALHOST_RULE" >> "$PG_HBA"
+    fi
+
+    # Add host self-IP rule when management services use INTERNAL_IP.
+    if [[ -n "$HOST_RULE" ]]; then
+        if grep -qF "${INTERNAL_IP}/32" "$PG_HBA"; then
+            log_info "Rule already exists for host IP: ${INTERNAL_IP}/32"
+        else
+            log_info "Adding host self-IP authentication rule: ${INTERNAL_IP}/32"
+            echo "$HOST_RULE" >> "$PG_HBA"
+        fi
     fi
         
     # 4. Reload configuration
@@ -2193,7 +2208,7 @@ EOF
 # SupaCloud Management API Configuration
 PORT=9090
 MANAGEMENT_API_URL=http://127.0.0.1:9090
-DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@${INTERNAL_IP}:5432/supacloud_meta
+DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@127.0.0.1:5432/supacloud_meta
 EDGE_RUNTIME_MODE=${EDGE_RUNTIME_MODE:-embedded}
 MASTER_TOKEN=${MASTER_TOKEN}
 SCRIPTS_PATH=${SCRIPTS_INSTALL_DIR}
@@ -2209,7 +2224,7 @@ REALTIME_IMAGE=${REALTIME_IMAGE:-public.ecr.aws/supabase/realtime:v2.76.5}
 REALTIME_CONTAINER_NAME=${REALTIME_CONTAINER_NAME:-supacloud-realtime}
 REALTIME_DB_USER=supabase_admin
 # Database connection environment variables (required for script execution)
-PG_HOST=${INTERNAL_IP}
+PG_HOST=127.0.0.1
 PG_PORT=5432
 PG_USER=postgres
 PG_DATABASE=postgres
@@ -2225,7 +2240,7 @@ EOF
 
     # 6. Execute database migration via supacloud binary itself
     log_info "Initializing metadata database schema..."
-    export DATABASE_URL="postgresql://postgres:${POSTGRES_PASSWORD}@${INTERNAL_IP}:5432/supacloud_meta"
+    export DATABASE_URL="postgresql://postgres:${POSTGRES_PASSWORD}@127.0.0.1:5432/supacloud_meta"
     $BIN_TARGET --init-db 2>/dev/null || log_warn "Database initialization failed, please execute manually: supacloud --init-db"
     unset DATABASE_URL
     
@@ -2422,52 +2437,6 @@ EOF
     fi
 
     log_info "Service containers deployed successfully!"
-}
-
-# ========== Repair Stale Projects ==========
-repair_stale_projects() {
-    log_step "Checking for stale projects needing database provisioning..."
-    local ADMIN_SQL="sudo -u postgres psql -d postgres -t -A"
-
-    local PROJECTS=$($ADMIN_SQL -c "SELECT ref, db_name, db_user, db_password, status FROM projects WHERE status IN ('creating','paused') OR status IS NULL;" 2>/dev/null)
-
-    if [[ -z "$PROJECTS" ]]; then
-        log_info "No stale projects found"
-        return 0
-    fi
-
-    while IFS='|' read -r REF DB_NAME DB_USER DB_PASS PSTATUS; do
-        REF=$(echo "$REF" | tr -d ' ')
-        DB_NAME=$(echo "$DB_NAME" | tr -d ' ')
-        DB_USER=$(echo "$DB_USER" | tr -d ' ')
-        DB_PASS=$(echo "$DB_PASS" | tr -d ' ')
-        PSTATUS=$(echo "$PSTATUS" | tr -d ' ')
-
-        if [[ -z "$REF" || -z "$DB_NAME" ]]; then
-            continue
-        fi
-
-        local DB_EXISTS=$($ADMIN_SQL -c "SELECT 1 FROM pg_database WHERE datname='$DB_NAME';" 2>/dev/null | tr -d ' ')
-
-        if [[ "$DB_EXISTS" != "1" ]]; then
-            log_info "Provisioning database $DB_NAME for project $REF (status: $PSTATUS)..."
-            sudo -u postgres psql -d postgres -c "CREATE DATABASE \"$DB_NAME\";" 2>/dev/null
-            sudo -u postgres psql -d postgres -c "CREATE ROLE \"$DB_USER\" LOGIN CONNECTION LIMIT 20 PASSWORD '$DB_PASS';" 2>/dev/null || true
-            sudo -u postgres psql -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE \"$DB_NAME\" TO \"$DB_USER\";" 2>/dev/null
-            sudo -u postgres psql -d "$DB_NAME" -c "GRANT ALL ON SCHEMA public TO \"$DB_USER\";" 2>/dev/null
-            sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" 2>/dev/null
-            sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";" 2>/dev/null
-            sudo -u postgres psql -d supacloud_meta -c "UPDATE projects SET status='active' WHERE ref='$REF';" 2>/dev/null
-            log_info "Project $REF: database $DB_NAME created and activated"
-        else
-            if [[ "$PSTATUS" != "active" ]]; then
-                sudo -u postgres psql -d supacloud_meta -c "UPDATE projects SET status='active' WHERE ref='$REF';" 2>/dev/null
-                log_info "Project $REF: database exists, status updated to active"
-            fi
-        fi
-    done <<< "$PROJECTS"
-
-    log_info "Stale project repair complete"
 }
 
 # ========== Show Completion Message ==========
@@ -2717,8 +2686,7 @@ main() {
     # Save all credentials
     save_all_credentials
 
-    repair_stale_projects
-
+    # Deploy AI Breadcrumbs
     deploy_ai_breadcrumbs
 
     show_completion


### PR DESCRIPTION
## Summary
- keep the management API metadata database connection on `127.0.0.1`
- keep script-level `PG_HOST` on loopback for local PostgreSQL operations
- add an explicit pg_hba rule for `${INTERNAL_IP}/32` when installs still use the host self-IP

## Verification
- `bash -n install.sh`
- reproduced from deployed console: project database/auth/report pages fail when PostgreSQL rejects `role_*` connections from the host self-IP with `no pg_hba.conf entry ... no encryption`
