### PR TITLE
fix: auth middleware response format mismatch with route schemas

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -596,7 +596,7 @@ export async function registerAllRoutes() {
           if (shouldAuditRequest(request)) {
             await logAuditEvent({ request, status: result.status, action: "auth_denied" });
           }
-          return result.body;
+          return { message: result.body.error, code: String(result.status) };
         }
       })
       .onAfterHandle(async ({ request, set }) => {


### PR DESCRIPTION
## Bug Fix: Auth Response Format Mismatch

### Problem
The global `onBeforeHandle` auth hook returned `{ error: "..." }` but route response schemas expected `{ message: "...", code: "..." }`.

### Impact
When Elysia validates the auth error response against the route response schema, it finds a mismatch and throws a response validation error (500) instead of returning a clean 401.

This causes the Studio frontend to receive 500 instead of 401 when token expires, not redirect to login, and show empty project list.

### Fix
Changed the global auth hook to return `{ message: result.body.error, code: String(result.status) }` matching route schemas.

### Root Cause
```
Token expires
  -> Auth hook returns { error: "..." } with 401
  -> Elysia validates against route schema
  -> Schema expects { message, code }, got { error }
  -> Response validation fails -> 500
  -> Frontend doesn't detect auth failure
  -> No redirect to login -> Empty project list
```