### PR TITLE
fix: restoreProject should re-provision resources when tenant DB is missing

### DIFF
--- a/packages/management-api/src/services/database.service.ts
+++ b/packages/management-api/src/services/database.service.ts
@@ -128,6 +128,18 @@ export class DatabaseService {
   }
 
   // Create tenant database
+  async checkDatabaseExists(projectRef: string): Promise<boolean> {
+    const dbName = generateDbName(projectRef);
+    try {
+      return await this.withAdminDb(async (adminDb) => {
+        const [row] = await adminDb`SELECT 1 FROM pg_database WHERE datname = ${dbName}`;
+        return !!row;
+      });
+    } catch {
+      return false;
+    }
+  }
+
   async createDatabase(
     projectRef: string,
     password: string,

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -360,7 +360,19 @@ export class ProjectService {
     const project = await projectRepository.findByRef(ref);
     if (!project) return false;
 
-    await projectRepository.updateStatus(ref, "active");
+    // Check if tenant database exists; if not, re-trigger the provisioning saga
+    // to ensure all resources (DB, S3, runtime, etc.) are available.
+    const dbExists = await databaseService.checkDatabaseExists(ref);
+    if (!dbExists) {
+      logger.info(`[ProjectService] Tenant DB missing for ${ref}, re-provisioning resources`);
+      this.provisionResources(ref, project.db_password).catch((error) => {
+        logger.error(`Failed to re-provision resources for ${ref}:`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    } else {
+      await projectRepository.updateStatus(ref, "active");
+    }
     return true;
   }
 

--- a/packages/management-api/tests/unit/project.service.comprehensive.test.ts
+++ b/packages/management-api/tests/unit/project.service.comprehensive.test.ts
@@ -18,6 +18,7 @@ const jwtServiceMock = {
 
 const databaseServiceMock = {
   generatePassword: mock(() => "dbpassword"),
+  checkDatabaseExists: mock(() => Promise.resolve(true)),
   checkStatus: mock(() => Promise.resolve({ success: true, output: "" })),
   getSecrets: mock(() => Promise.resolve([{ name: "KEY", value: "val" }])),
   upsertSecret: mock(() => Promise.resolve(true)),
@@ -151,6 +152,7 @@ describe("ProjectService - Comprehensive", () => {
     jwtServiceMock.generateProjectRef.mockReset();
     jwtServiceMock.generateKeySet.mockReset();
     databaseServiceMock.generatePassword.mockReset();
+    databaseServiceMock.checkDatabaseExists.mockReset();
     databaseServiceMock.checkStatus.mockReset();
     databaseServiceMock.getSecrets.mockReset();
     databaseServiceMock.upsertSecret.mockReset();
@@ -182,6 +184,7 @@ describe("ProjectService - Comprehensive", () => {
       serviceRoleKey: "servicekey",
     });
     databaseServiceMock.generatePassword.mockReturnValue("dbpassword");
+    databaseServiceMock.checkDatabaseExists.mockResolvedValue(true);
     databaseServiceMock.checkStatus.mockResolvedValue({ success: true, output: "" });
     databaseServiceMock.getSecrets.mockResolvedValue([{ name: "KEY", value: "val" }]);
     databaseServiceMock.upsertSecret.mockResolvedValue(true);
@@ -306,7 +309,21 @@ describe("ProjectService - Comprehensive", () => {
   test("restoreProject updates status", async () => {
     projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
     expect(await service.restoreProject("test123abc")).toBe(true);
+    expect(databaseServiceMock.checkDatabaseExists).toHaveBeenCalledWith("test123abc");
     expect(projectRepositoryMock.updateStatus).toHaveBeenCalledWith("test123abc", "active");
+  });
+
+  test("restoreProject re-provisions resources when tenant database is missing", async () => {
+    projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
+    databaseServiceMock.checkDatabaseExists.mockResolvedValueOnce(false);
+
+    expect(await service.restoreProject("test123abc")).toBe(true);
+
+    expect(projectRepositoryMock.updateStatus).not.toHaveBeenCalledWith("test123abc", "active");
+    expect(taskRepositoryMock.createTask).toHaveBeenCalledWith("test123abc", "provision_db", {
+      dbPassword: "password123",
+      domain: undefined,
+    });
   });
 
   test("getProjectHealth returns null when project not found", async () => {


### PR DESCRIPTION
## Bug Fix: restoreProject Does Not Re-Provision Missing Resources

### Problem
When a project is restored from INACTIVE/paused state via `POST /v1/projects/:ref/restore`, the `restoreProject()` method only updates the project status to `"active"` without checking if the underlying tenant resources (database, roles, S3 bucket, runtime, etc.) actually exist.

This causes 500 errors in the Studio SQL editor, table listing, and all database-dependent features when the tenant database or roles are missing (e.g., after VM rebuild, PostgreSQL reset, or if initial provisioning failed).

### Root Cause
```python
# Before (broken):
async restoreProject(ref):
    project = findByRef(ref)
    updateStatus(ref, "active")  # ← Just flips status, no resource check!
    return true
```

The provisioning saga (`provision_db → provision_s3 → provision_runtime → ... → provision_secrets → active`) is only triggered during `createProject()`. If the project was created but resources were lost, `restoreProject()` never recreates them.

### Fix
1. Added `checkDatabaseExists()` method to `database.service.ts` to verify tenant DB existence
2. Modified `restoreProject()` to check if the tenant database exists before marking as active:
   - If DB exists → mark as active (original behavior)
   - If DB missing → re-trigger the full provisioning saga, which will recreate DB, roles, S3, runtime, etc.

```python
# After (fixed):
async restoreProject(ref):
    project = findByRef(ref)
    dbExists = checkDatabaseExists(ref)
    if not dbExists:
        provisionResources(ref, project.db_password)  # ← Re-trigger saga
    else:
        updateStatus(ref, "active")
    return true
```

### Idempotency
`databaseService.createDatabase()` already checks `if (dbExists) return` before creating, so re-triggering the saga is safe even if some resources partially exist.

### Testing
- Verified that restoring a project with missing tenant DB now correctly triggers re-provisioning
- Verified that SQL editor and table listing work after restore
- Verified that restoring a project with existing DB still works (no-op path)