### PR TITLE
fix: add JWT_SECRET fallback and Kong env vars to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2216,6 +2216,7 @@ PIGSTY_PATH=${HOME}/pigsty
 BASE_DOMAIN=${BASE_DOMAIN_VALUE}
 S3_STORAGE_TYPE=${S3_STORAGE_TYPE:-juicefs}
 IMAGINARY_IMAGE=${IMAGINARY_IMAGE:-h2non/imaginary:1.2.4}
+JWT_SECRET=${JWT_SECRET}
 SUPACLOUD_JWT_SECRET=${JWT_SECRET}
 REALTIME_SECRET_KEY_BASE=${REALTIME_SECRET_KEY_BASE}
 REALTIME_DB_ENC_KEY=${REALTIME_DB_ENC_KEY}
@@ -2234,6 +2235,8 @@ ACME_CLIENT=lego
 LEGO_BIN=${LEGO_BIN:-lego}
 ACME_STATE_DIR=${ACME_STATE_DIR:-/var/lib/supacloud/lego}
 ACME_HTTP_WEBROOT=${ACME_HTTP_WEBROOT:-/var/lib/supacloud/acme-challenges}
+KONG_ADMIN_URL=http://127.0.0.1:8001
+KONG_INTERNAL=127.0.0.1:8000
 EOF
     chmod 600 /etc/supabase/management-api.env
     sync_runtime_config /etc/supabase/management-api.env

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -154,7 +154,7 @@ export const config: Config = {
   nodeEnv: getEnv("NODE_ENV", "development"),
   isGithubActions,
 
-  jwtSecret: getEnv("JWT_SECRET", DEFAULT_JWT_SECRET),
+  jwtSecret: getEnv("JWT_SECRET", getEnv("SUPACLOUD_JWT_SECRET", DEFAULT_JWT_SECRET)),
   jwtIssuer: getEnv("JWT_ISSUER", "supacloud"),
   jwtEnabled: getEnv("JWT_ENABLED", "false") === "true",
   baseDomain: getEnv("BASE_DOMAIN", "example.com"),

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -111,6 +111,26 @@ export class GatewayService {
         return text ? JSON.parse(text) : {};
     }
 
+    async checkKongConnectivity(): Promise<boolean> {
+        try {
+            const res = await fetch(`${this.KONG_ADMIN_URL}/status`, {
+                method: "GET",
+                signal: AbortSignal.timeout(5000),
+            });
+            if (res.ok) {
+                logger.info(`[GatewayService] Kong Admin API is reachable at ${this.KONG_ADMIN_URL}`);
+                return true;
+            }
+            logger.warn(`[GatewayService] Kong Admin API returned ${res.status} at ${this.KONG_ADMIN_URL}`);
+            return false;
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.error(`[GatewayService] Kong Admin API is unreachable at ${this.KONG_ADMIN_URL}: ${msg}`);
+            logger.error(`[GatewayService] Ensure Kong is running and KONG_ADMIN_URL is correctly configured`);
+            return false;
+        }
+    }
+
     // --- Consumer & JWT ---
 
     async upsertCertificateForSnis(opts: {

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -886,6 +886,9 @@ export class GatewayService {
 
     // --- Global Master Routes ---
     async setupMasterRoutes(): Promise<void> {
+        const kongOk = await this.checkKongConnectivity();
+        if (!kongOk) return;
+
         try {
             const hostIp = await this.detectHostIp();
             


### PR DESCRIPTION
## Summary

Fixes configuration issues discovered during v0.14.1 → v0.17.0 upgrade that cause silent failures in production deployments.

## Changes

### 1. `config.ts` — JWT_SECRET fallback to SUPACLOUD_JWT_SECRET

**Problem**: `config.ts` reads `JWT_SECRET` but `install.sh` only writes `SUPACLOUD_JWT_SECRET` to `management-api.env`. The Management API currently works only because `JWT_SECRET` happens to be loaded from `/opt/supacloud/config.env` — this is accidental, not by design.

**Fix**: Add `SUPACLOUD_JWT_SECRET` as a fallback:
```typescript
// Before
jwtSecret: getEnv("JWT_SECRET", DEFAULT_JWT_SECRET),
// After
jwtSecret: getEnv("JWT_SECRET", getEnv("SUPACLOUD_JWT_SECRET", DEFAULT_JWT_SECRET)),
```

This follows the same pattern already used for `PGPASSWORD`/`PG_PASSWORD` and `DASHBOARD_USERNAME`/`STUDIO_USERNAME`.

### 2. `install.sh` — Add missing env vars to management-api.env

**Problem**: The `management-api.env` template is missing:
- `JWT_SECRET` — Management API needs this for auth token verification
- `KONG_ADMIN_URL` — GatewayService needs this to configure Kong routes
- `KONG_INTERNAL` — Used for internal Kong proxy routing

Without these, the Management API falls back to default values which may not match the actual deployment.

**Fix**: Add these three variables to the heredoc template.

### 3. `gateway.service.ts` — Add Kong connectivity check

**Problem**: When Kong is not running, `GatewayService.setupMasterRoutes()` catches the error but only logs a generic message. Users see `[GatewayService] Failed to setup Master Routes: Unable to connect` without knowing what to check.

**Fix**: Add `checkKongConnectivity()` method that:
- Verifies Kong Admin API is reachable with a 5s timeout
- Logs clear, actionable error messages when Kong is unreachable
- Can be called during startup for early failure detection

## Test Plan

- [x] Verified on live deployment: v0.14.1 → v0.17.0 upgrade with these fixes applied
- [x] Management API starts without JWT_SECRET warning
- [x] GatewayService successfully connects to Kong when running
- [x] GatewayService provides clear error when Kong is stopped
- [x] All 7 services (management-api, edge-runtime, realtime, 2x gotrue, 2x postgrest) running healthy