### PR TITLE
fix: runtime bootstrap fixes for v0.18.0

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -665,7 +665,7 @@ export class GatewayService {
                 projectRef,
                 stripPath: true,
                 readTimeout: 60000,
-                protocols: ["http", "https", "grpc", "grpcs", "ws", "wss"],
+                protocols: ["http", "https"],
                 corsOrigins,
             });
             await this.ensureServiceAndRoute({
@@ -899,19 +899,6 @@ export class GatewayService {
                 connect_timeout: 5000,
                 read_timeout: 60000,
                 write_timeout: 60000
-            });
-
-            const baseDomain = config.baseDomain;
-            const apiHosts = [hostIp];
-
-            await this.ensureServiceAndRoute({
-                name: "svc-management-api",
-                url: `http://${hostIp}:${config.port}`,
-                paths: ["/api"],
-                hosts: apiHosts,
-                projectRef: "_management",
-                stripPath: true,
-                corsOrigins: apiHosts,
             });
 
             logger.info(`[GatewayService] Rebuilt global management routes to port ${config.port}`);

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -901,6 +901,19 @@ export class GatewayService {
                 write_timeout: 60000
             });
 
+            const baseDomain = config.baseDomain;
+            const apiHosts = [hostIp];
+
+            await this.ensureServiceAndRoute({
+                name: "svc-management-api",
+                url: `http://${hostIp}:${config.port}`,
+                paths: ["/api"],
+                hosts: apiHosts,
+                projectRef: "_management",
+                stripPath: true,
+                corsOrigins: apiHosts,
+            });
+
             logger.info(`[GatewayService] Rebuilt global management routes to port ${config.port}`);
         } catch (error: unknown) {
             const msg = error instanceof Error ? error.message : String(error);

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -726,10 +726,39 @@ ON CONFLICT DO NOTHING;
         }
     }
 
+    private async ensurePostgrestPrerequest(ref: string): Promise<void> {
+        const dbName = await resolveDbName(ref);
+        const dbUrl = `postgres://postgres:${config.pgPassword}@${this.PG_HOST}:${this.PG_PORT}/${dbName}`;
+
+        const fnSql = `
+CREATE OR REPLACE FUNCTION public.set_request_context() RETURNS void AS $$
+DECLARE
+  role_claim text;
+BEGIN
+  IF current_setting('request.jwt.claims', true) = '' THEN
+    PERFORM set_config('request.jwt.claims', '{}', true);
+  END IF;
+  role_claim := COALESCE(
+    nullif(current_setting('request.jwt.claim.role', true), ''),
+    (nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'),
+    'anon'
+  );
+  PERFORM set_config('request.jwt.claim.role', role_claim, true);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+`.trim();
+        const tmpFile = `/tmp/pgrst-prerequest-${ref}.sql`;
+        await Bun.write(tmpFile, fnSql);
+        await $`psql ${dbUrl} -f ${tmpFile}`.nothrow().quiet();
+        await $`rm -f ${tmpFile}`.nothrow().quiet();
+        logger.info(`[tenant-runtime] Ensured public.set_request_context() for ${ref}`);
+    }
+
     public async startRuntime(ref: string): Promise<RuntimeStatus> {
         await this.ensureBinaries();
         await this.installSystemdTemplate();
         await this.ensureAuthSchema(ref);
+        await this.ensurePostgrestPrerequest(ref);
 
         const pgrstPort = await this.getTenantPort(ref, "pgrst");
         const gotruePort = await this.getTenantPort(ref, "gotrue");


### PR DESCRIPTION
## Summary

Three bugs discovered during v0.18.0 upgrade that prevent proper runtime bootstrap.

### Bug 1: `set_request_context()` not created in tenant databases

PostgREST config uses `db-pre-request = "public.set_request_context"` but the function is never created in tenant databases during `provision_runtime`. This causes PostgREST to fail with:

```
function public.set_request_context() does not exist
```

**Fix**: Add `ensurePostgrestPrerequest()` method that creates the function, called from `startRuntime()` after `ensureAuthSchema()`.

### Bug 2: `setupMasterRoutes()` doesn't create Kong Route

`setupMasterRoutes()` only creates a Kong Service (`svc-management-api`) but no Route, making the management API unreachable through the Kong proxy. Studio and external clients cannot access `/api/v1/*` endpoints.

**Fix**: Add `ensureServiceAndRoute()` call in `setupMasterRoutes()` to create the management API route with path `/api` and `strip_path=true`.

### Bug 3: Kong realtime-api route uses unsupported `ws`/`wss` protocols

Kong v3.x does not support `ws`/`wss` as top-level route protocols. WebSocket connections are proxied through HTTP/HTTPS protocol upgrade. Using `ws`/`wss` causes a 400 schema violation error:

```
Kong API PUT /routes/route-svc-realtime-api-xxx returned 400: 
schema violation (protocols.5: expected one of: grpc, grpcs, http, https, tcp, tls, tls_passthrough, udp)
```

**Fix**: Change protocols from `["http", "https", "grpc", "grpcs", "ws", "wss"]` to `["http", "https"]`.

## Test plan

- [ ] Create a new project and verify PostgREST starts successfully (no `set_request_context` error)
- [ ] Restart management API and verify Kong route for management API is created
- [ ] Verify realtime-api route creation no longer returns 400 error
- [ ] Verify existing projects continue to work after upgrade