### PR TITLE
fix: add Studio root route and management API route to setupMasterRoutes

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -914,15 +914,23 @@ export class GatewayService {
                 corsOrigins: apiHosts,
             });
 
-                        // Create management API route (/api path with strip_path)
-            await this.ensureServiceAndRoute({
-                name: "management-api",
-                url: `http://${hostIp}:${config.port}`,
-                paths: ["/api"],
-                hosts: [hostIp, config.baseDomain || `${hostIp}.nip.io`].filter(Boolean),
-                projectRef: "_system",
-                stripPath: true,
-            });
+                        // Patch existing management API route to include bare IP host
+            try {
+                const existingRoute = await this.kongRequest(`/routes/route-svc-management-api`, "GET");
+                if (existingRoute) {
+                    const existingHosts: string[] = existingRoute.hosts || [];
+                    const desiredHosts = [hostIp, ...(config.baseDomain ? [config.baseDomain] : [])];
+                    const missingHosts = desiredHosts.filter(h => !existingHosts.includes(h));
+                    if (missingHosts.length > 0) {
+                        await this.kongRequest(`/routes/route-svc-management-api`, "PATCH", {
+                            hosts: [...existingHosts, ...missingHosts],
+                        });
+                        logger.info(`[GatewayService] Patched route-svc-management-api hosts: +${missingHosts.join(", ")}`);
+                    }
+                }
+            } catch {
+                // Route may not exist yet if no project has been created; skip silently
+            }
 
             // Create Studio root route for bare IP access
             await this.ensureServiceAndRoute({

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -901,7 +901,6 @@ export class GatewayService {
                 write_timeout: 60000
             });
 
-            const baseDomain = config.baseDomain;
             const apiHosts = [hostIp];
 
             await this.ensureServiceAndRoute({
@@ -914,11 +913,14 @@ export class GatewayService {
                 corsOrigins: apiHosts,
             });
 
-                        // Patch existing management API route to include bare IP host
+            // Patch the existing management API route instead of creating
+            // a second /api route with a different request-transformer config.
             try {
                 const existingRoute = await this.kongRequest(`/routes/route-svc-management-api`, "GET");
                 if (existingRoute) {
-                    const existingHosts: string[] = existingRoute.hosts || [];
+                    const existingHosts = Array.isArray(existingRoute.hosts)
+                        ? existingRoute.hosts.filter((host): host is string => typeof host === "string")
+                        : [];
                     const desiredHosts = [hostIp, ...(config.baseDomain ? [config.baseDomain] : [])];
                     const missingHosts = desiredHosts.filter(h => !existingHosts.includes(h));
                     if (missingHosts.length > 0) {

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -914,6 +914,26 @@ export class GatewayService {
                 corsOrigins: apiHosts,
             });
 
+                        // Create management API route (/api path with strip_path)
+            await this.ensureServiceAndRoute({
+                name: "management-api",
+                url: `http://${hostIp}:${config.port}`,
+                paths: ["/api"],
+                hosts: [hostIp, config.baseDomain || `${hostIp}.nip.io`].filter(Boolean),
+                projectRef: "_system",
+                stripPath: true,
+            });
+
+            // Create Studio root route for bare IP access
+            await this.ensureServiceAndRoute({
+                name: "studio-root",
+                url: `http://${hostIp}:${config.port}`,
+                paths: ["/"],
+                hosts: [hostIp],
+                projectRef: "_system",
+                stripPath: false,
+            });
+
             logger.info(`[GatewayService] Rebuilt global management routes to port ${config.port}`);
         } catch (error: unknown) {
             const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Problem

`setupMasterRoutes()` only creates a Kong Service (`svc-management-api`) but no Routes. This means:

1. The `/api` path for management API is missing (previously fixed in PR #118 Bug 2, but the fix was in `startRuntime` not in `setupMasterRoutes`)
2. The `/` root path for Studio access via bare IP is missing

After a management API restart, `setupMasterRoutes()` is called and overwrites the Kong Service, but without creating any Routes. This requires manual route creation via Kong Admin API.

## Solution

Use `ensureServiceAndRoute()` in `setupMasterRoutes()` to create both the Service and Routes:

1. `/api` route with `strip_path=true` for management API (hosts: bare IP + base domain)
2. `/` route for Studio access via bare IP

This ensures that after every management API restart, all global routes are automatically recreated.

## Testing

- Verified on v0.18.1: manually creating these routes via Kong Admin API resolves the issue