### PR TITLE
fix: make ALTER_TENANT_SQL idempotent for existing tables with missing columns

### DIFF
--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -169,6 +169,39 @@ CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx ON auth.one_time_
 CREATE INDEX IF NOT EXISTS one_time_tokens_relates_to_hash_idx ON auth.one_time_tokens USING hash (relates_to);
 CREATE UNIQUE INDEX IF NOT EXISTS one_time_tokens_user_id_token_type_key ON auth.one_time_tokens (user_id, token_type);
 
+
+-- Post-CREATE TABLE column additions for existing tables with missing columns
+-- These handle the case where CREATE TABLE IF NOT EXISTS skips because the table
+-- already exists but with an older schema that lacks new columns.
+
+-- auth.mfa_factors: add columns needed by GoTrue v2.x
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS phone TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS last_challenged_at TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_credential JSONB; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_aaguid UUID; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.mfa_amr_claims: add id and factor_id columns (old schema only had session_id + authentication_method composite PK)
+DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS id UUID PRIMARY KEY DEFAULT gen_random_uuid(); EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS factor_id UUID REFERENCES auth.mfa_factors(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.sessions: add aal and not_after columns (old schema had aal_level instead of aal)
+DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS not_after TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.one_time_tokens: add user_id column (old schema may lack this)
+DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.identities: add email and phone columns (old schema may lack these)
+DO $$ BEGIN ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS email TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS phone TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.users: add is_sso_user and deleted_at columns
+DO $$ BEGIN ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS is_sso_user BOOLEAN DEFAULT FALSE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.refresh_tokens: add session_id column (newer GoTrue needs this)
+DO $$ BEGIN ALTER TABLE auth.refresh_tokens ADD COLUMN IF NOT EXISTS session_id UUID REFERENCES auth.sessions(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
 -- 8. Storage
 CREATE TABLE IF NOT EXISTS storage.s3_multipart_uploads (
     id TEXT PRIMARY KEY,

--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -165,9 +165,6 @@ CREATE TABLE IF NOT EXISTS auth.one_time_tokens (
     updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
     CHECK (char_length(token_hash) > 0)
 );
-CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx ON auth.one_time_tokens USING hash (token_hash);
-CREATE INDEX IF NOT EXISTS one_time_tokens_relates_to_hash_idx ON auth.one_time_tokens USING hash (relates_to);
-CREATE UNIQUE INDEX IF NOT EXISTS one_time_tokens_user_id_token_type_key ON auth.one_time_tokens (user_id, token_type);
 
 
 -- Post-CREATE TABLE column additions for existing tables with missing columns
@@ -181,11 +178,35 @@ DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_cred
 DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_aaguid UUID; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 -- auth.mfa_amr_claims: add id and factor_id columns (old schema only had session_id + authentication_method composite PK)
-DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS id UUID PRIMARY KEY DEFAULT gen_random_uuid(); EXCEPTION WHEN duplicate_column THEN NULL; END $$;
-DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS factor_id UUID REFERENCES auth.mfa_factors(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$
+BEGIN
+  ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+  UPDATE auth.mfa_amr_claims SET id = gen_random_uuid() WHERE id IS NULL;
+  ALTER TABLE auth.mfa_amr_claims ALTER COLUMN id SET NOT NULL;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'auth.mfa_amr_claims'::regclass AND contype = 'p'
+  ) THEN
+    ALTER TABLE auth.mfa_amr_claims ADD CONSTRAINT mfa_amr_claims_pkey PRIMARY KEY (id);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS factor_id UUID;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'auth.mfa_amr_claims'::regclass
+      AND conname = 'mfa_amr_claims_factor_id_fkey'
+  ) THEN
+    ALTER TABLE auth.mfa_amr_claims
+      ADD CONSTRAINT mfa_amr_claims_factor_id_fkey
+      FOREIGN KEY (factor_id) REFERENCES auth.mfa_factors(id) ON DELETE CASCADE;
+  END IF;
+END $$;
 
 -- auth.sessions: add aal and not_after columns (old schema had aal_level instead of aal)
-DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal VARCHAR(10); EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS not_after TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 -- auth.one_time_tokens: add user_id column (old schema may lack this)
@@ -201,6 +222,10 @@ DO $$ BEGIN ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP
 
 -- auth.refresh_tokens: add session_id column (newer GoTrue needs this)
 DO $$ BEGIN ALTER TABLE auth.refresh_tokens ADD COLUMN IF NOT EXISTS session_id UUID REFERENCES auth.sessions(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx ON auth.one_time_tokens USING hash (token_hash);
+CREATE INDEX IF NOT EXISTS one_time_tokens_relates_to_hash_idx ON auth.one_time_tokens USING hash (relates_to);
+CREATE UNIQUE INDEX IF NOT EXISTS one_time_tokens_user_id_token_type_key ON auth.one_time_tokens (user_id, token_type);
 
 -- 8. Storage
 CREATE TABLE IF NOT EXISTS storage.s3_multipart_uploads (
@@ -231,6 +256,7 @@ CREATE INDEX IF NOT EXISTS idx_multipart_uploads_list ON storage.s3_multipart_up
 GRANT ALL ON ALL TABLES IN SCHEMA storage TO supabase_storage_admin;
 
 -- 9. Realtime
+CREATE SCHEMA IF NOT EXISTS realtime;
 CREATE TABLE IF NOT EXISTS realtime.messages (
     id BIGSERIAL PRIMARY KEY,
     topic TEXT NOT NULL,

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -330,6 +330,39 @@ CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx ON auth.one_time_
 CREATE INDEX IF NOT EXISTS one_time_tokens_relates_to_hash_idx ON auth.one_time_tokens USING hash (relates_to);
 CREATE UNIQUE INDEX IF NOT EXISTS one_time_tokens_user_id_token_type_key ON auth.one_time_tokens (user_id, token_type);
 
+
+-- Post-CREATE TABLE column additions for existing tables with missing columns
+-- These handle the case where CREATE TABLE IF NOT EXISTS skips because the table
+-- already exists but with an older schema that lacks new columns.
+
+-- auth.mfa_factors: add columns needed by GoTrue v2.x
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS phone TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS last_challenged_at TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_credential JSONB; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_aaguid UUID; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.mfa_amr_claims: add id and factor_id columns (old schema only had session_id + authentication_method composite PK)
+DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS id UUID PRIMARY KEY DEFAULT gen_random_uuid(); EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS factor_id UUID REFERENCES auth.mfa_factors(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.sessions: add aal and not_after columns (old schema had aal_level instead of aal)
+DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS not_after TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.one_time_tokens: add user_id column (old schema may lack this)
+DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.identities: add email and phone columns (old schema may lack these)
+DO $$ BEGIN ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS email TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS phone TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.users: add is_sso_user and deleted_at columns
+DO $$ BEGIN ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS is_sso_user BOOLEAN DEFAULT FALSE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+-- auth.refresh_tokens: add session_id column (newer GoTrue needs this)
+DO $$ BEGIN ALTER TABLE auth.refresh_tokens ADD COLUMN IF NOT EXISTS session_id UUID REFERENCES auth.sessions(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
 -- 8. Storage
 CREATE TABLE IF NOT EXISTS storage.s3_multipart_uploads (
     id TEXT PRIMARY KEY,

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -326,9 +326,6 @@ CREATE TABLE IF NOT EXISTS auth.one_time_tokens (
     updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
     CHECK (char_length(token_hash) > 0)
 );
-CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx ON auth.one_time_tokens USING hash (token_hash);
-CREATE INDEX IF NOT EXISTS one_time_tokens_relates_to_hash_idx ON auth.one_time_tokens USING hash (relates_to);
-CREATE UNIQUE INDEX IF NOT EXISTS one_time_tokens_user_id_token_type_key ON auth.one_time_tokens (user_id, token_type);
 
 
 -- Post-CREATE TABLE column additions for existing tables with missing columns
@@ -342,11 +339,35 @@ DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_cred
 DO $$ BEGIN ALTER TABLE auth.mfa_factors ADD COLUMN IF NOT EXISTS web_authn_aaguid UUID; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 -- auth.mfa_amr_claims: add id and factor_id columns (old schema only had session_id + authentication_method composite PK)
-DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS id UUID PRIMARY KEY DEFAULT gen_random_uuid(); EXCEPTION WHEN duplicate_column THEN NULL; END $$;
-DO $$ BEGIN ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS factor_id UUID REFERENCES auth.mfa_factors(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$
+BEGIN
+  ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS id UUID DEFAULT gen_random_uuid();
+  UPDATE auth.mfa_amr_claims SET id = gen_random_uuid() WHERE id IS NULL;
+  ALTER TABLE auth.mfa_amr_claims ALTER COLUMN id SET NOT NULL;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'auth.mfa_amr_claims'::regclass AND contype = 'p'
+  ) THEN
+    ALTER TABLE auth.mfa_amr_claims ADD CONSTRAINT mfa_amr_claims_pkey PRIMARY KEY (id);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE auth.mfa_amr_claims ADD COLUMN IF NOT EXISTS factor_id UUID;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'auth.mfa_amr_claims'::regclass
+      AND conname = 'mfa_amr_claims_factor_id_fkey'
+  ) THEN
+    ALTER TABLE auth.mfa_amr_claims
+      ADD CONSTRAINT mfa_amr_claims_factor_id_fkey
+      FOREIGN KEY (factor_id) REFERENCES auth.mfa_factors(id) ON DELETE CASCADE;
+  END IF;
+END $$;
 
 -- auth.sessions: add aal and not_after columns (old schema had aal_level instead of aal)
-DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal VARCHAR(10); EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS not_after TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 -- auth.one_time_tokens: add user_id column (old schema may lack this)
@@ -362,6 +383,10 @@ DO $$ BEGIN ALTER TABLE auth.users ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP
 
 -- auth.refresh_tokens: add session_id column (newer GoTrue needs this)
 DO $$ BEGIN ALTER TABLE auth.refresh_tokens ADD COLUMN IF NOT EXISTS session_id UUID REFERENCES auth.sessions(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx ON auth.one_time_tokens USING hash (token_hash);
+CREATE INDEX IF NOT EXISTS one_time_tokens_relates_to_hash_idx ON auth.one_time_tokens USING hash (relates_to);
+CREATE UNIQUE INDEX IF NOT EXISTS one_time_tokens_user_id_token_type_key ON auth.one_time_tokens (user_id, token_type);
 
 -- 8. Storage
 CREATE TABLE IF NOT EXISTS storage.s3_multipart_uploads (
@@ -392,6 +417,7 @@ CREATE INDEX IF NOT EXISTS idx_multipart_uploads_list ON storage.s3_multipart_up
 GRANT ALL ON ALL TABLES IN SCHEMA storage TO supabase_storage_admin;
 
 -- 9. Realtime
+CREATE SCHEMA IF NOT EXISTS realtime;
 CREATE TABLE IF NOT EXISTS realtime.messages (
     id BIGSERIAL PRIMARY KEY,
     topic TEXT NOT NULL,
@@ -1539,16 +1565,18 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 
         try {
             await Bun.write(tmpFile, ALTER_TENANT_SQL);
-            const result = await $`psql ${dbUrl} -f ${tmpFile}`.nothrow();
+            const result = await $`psql ${dbUrl} -v ON_ERROR_STOP=1 -f ${tmpFile}`.nothrow();
             if (result.exitCode !== 0) {
                 const stderr = result.stderr.toString().trim();
-                logger.error(`[tenant-runtime] Tenant schema migration FAILED for ${ref} (exitCode=${result.exitCode}): ${stderr}`);
-            } else {
-                logger.info(`[tenant-runtime] Ensured tenant schema migrations for ${ref}`);
+                const stdout = result.stdout.toString().trim();
+                const detail = stderr || stdout || "psql exited without output";
+                throw new Error(`psql exited with code ${result.exitCode}: ${detail}`);
             }
+            logger.info(`[tenant-runtime] Ensured tenant schema migrations for ${ref}`);
         } catch (error: unknown) {
             const msg = error instanceof Error ? error.message : String(error);
             logger.error(`[tenant-runtime] Tenant schema migration error for ${ref}: ${msg}`);
+            throw error;
         } finally {
             try { await $`rm -f ${tmpFile}`.nothrow().quiet(); } catch {}
         }

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+function readRepoFile(relativePath: string): string {
+  return readFileSync(resolve(import.meta.dir, "../..", relativePath), "utf8");
+}
+
 describe("supabase bootstrap schema", () => {
   test("does not switch SQL role inside set_request_context", () => {
-    const schemaPath = resolve(
-      import.meta.dir,
-      "../../src/db/schemas/supabase.sql",
-    );
-    const schema = readFileSync(schemaPath, "utf8");
+    const schema = readRepoFile("src/db/schemas/supabase.sql");
     const start = schema.indexOf(
       "CREATE OR REPLACE FUNCTION public.set_request_context()",
     );
@@ -22,5 +22,49 @@ describe("supabase bootstrap schema", () => {
       "PERFORM set_config('request.jwt.claim.role', role_claim, true);",
     );
     expect(fnBody).not.toContain("SET LOCAL ROLE");
+  });
+
+  test("tenant schema migration adds columns before dependent indexes", () => {
+    for (const filePath of [
+      "src/services/tenant-runtime.service.ts",
+      "src/scripts/migrate-tenant-schema.ts",
+    ]) {
+      const source = readRepoFile(filePath);
+      const userIdAlter = source.indexOf(
+        "ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id",
+      );
+      const userIdIndex = source.indexOf(
+        "CREATE UNIQUE INDEX IF NOT EXISTS one_time_tokens_user_id_token_type_key",
+      );
+
+      expect(userIdAlter).toBeGreaterThanOrEqual(0);
+      expect(userIdIndex).toBeGreaterThanOrEqual(0);
+      expect(userIdAlter).toBeLessThan(userIdIndex);
+    }
+  });
+
+  test("tenant runtime migration stops on psql errors", () => {
+    const source = readRepoFile("src/services/tenant-runtime.service.ts");
+
+    expect(source).toContain("-v ON_ERROR_STOP=1");
+    expect(source).toContain("throw new Error(`psql exited with code");
+  });
+
+  test("tenant schema migration creates realtime schema before realtime objects", () => {
+    for (const filePath of [
+      "src/services/tenant-runtime.service.ts",
+      "src/scripts/migrate-tenant-schema.ts",
+    ]) {
+      const source = readRepoFile(filePath);
+      const schema = source.indexOf("CREATE SCHEMA IF NOT EXISTS realtime;");
+      const messages = source.indexOf("CREATE TABLE IF NOT EXISTS realtime.messages");
+      const notifyFn = source.indexOf(
+        "CREATE OR REPLACE FUNCTION realtime.notify_postgres_changes()",
+      );
+
+      expect(schema).toBeGreaterThanOrEqual(0);
+      expect(messages).toBeGreaterThan(schema);
+      expect(notifyFn).toBeGreaterThan(schema);
+    }
   });
 });


### PR DESCRIPTION
## Problem

When tenant databases are created with an older auth schema and later upgraded (e.g., GoTrue v1.x → v2.x), `CREATE TABLE IF NOT EXISTS` silently skips tables that already exist — even if they are missing new columns required by the newer binary. This causes GoTrue to fail with errors like:

```
column "user_id" does not exist (auth.one_time_tokens)
column "aal" does not exist (auth.sessions)  
column "id" does not exist (auth.mfa_amr_claims)
```

This was discovered during v0.18.2 deployment: existing tenant databases had `auth.one_time_tokens` and `auth.mfa_amr_claims` tables from a prior migration, but with incomplete schemas. The `CREATE TABLE IF NOT EXISTS` statements were skipped, and the subsequent `CREATE INDEX` statements failed because they referenced columns that didn't exist.

## Solution

Add `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements after each `CREATE TABLE IF NOT EXISTS` block. This ensures that:
1. New databases get the full schema from `CREATE TABLE IF NOT EXISTS`
2. Existing databases with missing columns get them added via `ALTER TABLE ADD COLUMN IF NOT EXISTS`

Also fix `ensureTenantSchemaMigrations()` to properly check `psql` exitCode and log errors instead of silently swallowing failures (previously used `.nothrow().quiet()` which hid all errors).

## Affected Tables

| Table | Missing Columns |
|-------|----------------|
| `auth.mfa_factors` | `phone`, `last_challenged_at`, `web_authn_credential`, `web_authn_aaguid` |
| `auth.mfa_amr_claims` | `id`, `factor_id` |
| `auth.sessions` | `aal`, `not_after` |
| `auth.one_time_tokens` | `user_id` |
| `auth.identities` | `email`, `phone` |
| `auth.users` | `is_sso_user`, `deleted_at` |
| `auth.refresh_tokens` | `session_id` |

## Testing

Verified on v0.18.2 deployment:
- Before fix: GoTrue signup returned 500 with "column user_id does not exist"
- After manually applying ALTER TABLE statements: GoTrue signup works correctly, returns access_token

## Files Changed

- `packages/management-api/src/services/tenant-runtime.service.ts` — Added column migration SQL + fixed exitCode check
- `packages/management-api/src/scripts/migrate-tenant-schema.ts` — Added column migration SQL