### PR TITLE
fix: guard one_time_tokens user FK migration

### DIFF
--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -210,7 +210,7 @@ DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal VARCHAR(10); 
 DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS not_after TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 -- auth.one_time_tokens: add user_id column (old schema may lack this)
-DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 -- auth.one_time_tokens: backfill user_id via relates_to -> auth.users.email
 UPDATE auth.one_time_tokens t
@@ -228,11 +228,22 @@ DO $$ BEGIN
 EXCEPTION WHEN others THEN NULL; END $$;
 
 -- auth.one_time_tokens: add FK constraint for tables that have the column but not the FK
-DO $$ BEGIN
-  ALTER TABLE auth.one_time_tokens
-    ADD CONSTRAINT one_time_tokens_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES auth.users ON DELETE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    WHERE c.conrelid = 'auth.one_time_tokens'::regclass
+      AND c.confrelid = 'auth.users'::regclass
+      AND c.contype = 'f'
+      AND c.conkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'auth.one_time_tokens'::regclass AND attname = 'user_id')]
+      AND c.confkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'auth.users'::regclass AND attname = 'id')]
+  ) THEN
+    ALTER TABLE auth.one_time_tokens
+      ADD CONSTRAINT one_time_tokens_user_id_fkey
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
 
 -- auth.identities: add email and phone columns (old schema may lack these)
 DO $$ BEGIN ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS email TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -371,7 +371,24 @@ DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS aal VARCHAR(10); 
 DO $$ BEGIN ALTER TABLE auth.sessions ADD COLUMN IF NOT EXISTS not_after TIMESTAMPTZ; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 -- auth.one_time_tokens: add user_id column (old schema may lack this)
-DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    WHERE c.conrelid = 'auth.one_time_tokens'::regclass
+      AND c.confrelid = 'auth.users'::regclass
+      AND c.contype = 'f'
+      AND c.conkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'auth.one_time_tokens'::regclass AND attname = 'user_id')]
+      AND c.confkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'auth.users'::regclass AND attname = 'id')]
+  ) THEN
+    ALTER TABLE auth.one_time_tokens
+      ADD CONSTRAINT one_time_tokens_user_id_fkey
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
 
 -- auth.identities: add email and phone columns (old schema may lack these)
 DO $$ BEGIN ALTER TABLE auth.identities ADD COLUMN IF NOT EXISTS email TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
@@ -1364,7 +1381,7 @@ CREATE TABLE IF NOT EXISTS auth.one_time_tokens (
     CHECK (char_length(token_hash) > 0)
 );
 
-DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+DO $$ BEGIN ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID; EXCEPTION WHEN duplicate_column THEN NULL; END $$;
 
 UPDATE auth.one_time_tokens t
 SET user_id = u.id
@@ -1378,11 +1395,22 @@ DO $$ BEGIN
   ALTER TABLE auth.one_time_tokens ALTER COLUMN user_id SET NOT NULL;
 EXCEPTION WHEN others THEN NULL; END $$;
 
-DO $$ BEGIN
-  ALTER TABLE auth.one_time_tokens
-    ADD CONSTRAINT one_time_tokens_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES auth.users ON DELETE CASCADE;
-EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    WHERE c.conrelid = 'auth.one_time_tokens'::regclass
+      AND c.confrelid = 'auth.users'::regclass
+      AND c.contype = 'f'
+      AND c.conkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'auth.one_time_tokens'::regclass AND attname = 'user_id')]
+      AND c.confkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'auth.users'::regclass AND attname = 'id')]
+  ) THEN
+    ALTER TABLE auth.one_time_tokens
+      ADD CONSTRAINT one_time_tokens_user_id_fkey
+      FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+  END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS one_time_tokens_token_hash_hash_idx ON auth.one_time_tokens USING hash (token_hash);
 CREATE INDEX IF NOT EXISTS one_time_tokens_relates_to_hash_idx ON auth.one_time_tokens USING hash (relates_to);

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -43,6 +43,29 @@ describe("supabase bootstrap schema", () => {
     }
   });
 
+  test("one_time_tokens user_id migration adds the foreign key separately", () => {
+    for (const filePath of [
+      "src/services/tenant-runtime.service.ts",
+      "src/scripts/migrate-tenant-schema.ts",
+    ]) {
+      const source = readRepoFile(filePath);
+
+      expect(source).toContain(
+        "ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID;",
+      );
+      expect(source).not.toContain(
+        "ALTER TABLE auth.one_time_tokens ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES auth.users",
+      );
+      expect(source).toContain("c.confrelid = 'auth.users'::regclass");
+      expect(source).toContain(
+        "c.conkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'auth.one_time_tokens'::regclass AND attname = 'user_id')]",
+      );
+      expect(source).toContain(
+        "FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE",
+      );
+    }
+  });
+
   test("tenant runtime migration stops on psql errors", () => {
     const source = readRepoFile("src/services/tenant-runtime.service.ts");
 


### PR DESCRIPTION
## Summary
- decouple auth.one_time_tokens.user_id column creation from FK creation
- detect an existing FK by relationship before adding one_time_tokens_user_id_fkey
- cover migrate script and runtime migration SQL with schema tests

## Verification
- cd packages/management-api && bun test tests/unit/supabase-schema.test.ts
- cd packages/management-api && bun run typecheck
- cd packages/management-api && bun test