### PR TITLE
fix: API error handling - prevent connection reset on DB errors

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -609,10 +609,27 @@ export async function registerAllRoutes() {
           await logAuditEvent({ request, status: Number(set.status || 200) });
         }
       })
-      .onError(async ({ request, code, set }) => {
+      .onError(async ({ request, code, error, set }) => {
         if (shouldAuditRequest(request)) {
           await logAuditEvent({ request, status: Number(set.status || 500), action: `error:${code}` });
         }
+        const { isAppError, toAppError } = require("./utils/errors") as typeof import("./utils/errors");
+        if (isAppError(error)) {
+          set.status = error.statusCode;
+          return error.toJSON();
+        }
+        logger.error(`[API] Unhandled error [${code}]:`, error);
+        if (code === "VALIDATION") {
+          set.status = 400;
+          return { message: "Validation failed", code: "VALIDATION_ERROR", details: error.message };
+        }
+        if (code === "NOT_FOUND") {
+          set.status = 404;
+          return { message: "Not found", code: "NOT_FOUND" };
+        }
+        const appError = toAppError(error);
+        set.status = appError.statusCode;
+        return appError.toJSON();
       })
       .use(projectRoutes)
       .use(registeredProjectDashboardRoutes)

--- a/packages/management-api/src/routes/extensions.ts
+++ b/packages/management-api/src/routes/extensions.ts
@@ -1,10 +1,16 @@
 import { Elysia, t, status } from "elysia";
 import { extensionService } from '../services/extension.service';
 import { requireAdminAuth } from '../middleware/auth';
+import { logger } from "../utils/logger";
 
 const ErrorResponse = t.Object({ message: t.String() });
 
 export const extensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/extensions" })
+    .onError(({ code, error, set }) => {
+        logger.error(`[Extensions] Unhandled error [${code}]:`, error);
+        set.status = 500;
+        return { message: "Internal server error", code: "INTERNAL_ERROR" };
+    })
     .get('/', async ({ params }) => {
         return await extensionService.listExtensions(params.ref);
     }, {
@@ -70,6 +76,11 @@ export const extensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/extension
     });
 
 export const databaseExtensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/extensions" })
+    .onError(({ code, error, set }) => {
+        logger.error(`[DatabaseExtensions] Unhandled error [${code}]:`, error);
+        set.status = 500;
+        return { message: "Internal server error", code: "INTERNAL_ERROR" };
+    })
     .get('/', async ({ params }) => {
         return await extensionService.listExtensions(params.ref);
     }, {
@@ -121,6 +132,11 @@ export const databaseExtensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/d
     });
 
 export const systemExtensionRoutes = new Elysia({ prefix: "/v1/system/extensions" })
+    .onError(({ code, error, set }) => {
+        logger.error(`[SystemExtensions] Unhandled error [${code}]:`, error);
+        set.status = 500;
+        return { message: "Internal server error", code: "INTERNAL_ERROR" };
+    })
     .get('/', async () => {
         return await extensionService.listSystemExtensions();
     }, {

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -209,7 +209,21 @@ async function buildProjectResponse(
 }
 
 export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
-  // Get available regions
+  .onError(({ code, error, set }) => {
+    logger.error(`[ProjectCRUD] Unhandled error [${code}]:`, error);
+    if (code === "VALIDATION") {
+      set.status = 400;
+      return { message: "Validation failed", code: "VALIDATION_ERROR", details: error.message };
+    }
+    if (code === "NOT_FOUND") {
+      set.status = 404;
+      return { message: "Not found", code: "NOT_FOUND" };
+    }
+    const { toAppError } = require("../utils/errors") as typeof import("../utils/errors");
+    const appError = toAppError(error);
+    set.status = appError.statusCode;
+    return appError.toJSON();
+  })
   .get("/available-regions", () => {
     return AVAILABLE_REGIONS;
   },

--- a/packages/management-api/src/services/extension.service.ts
+++ b/packages/management-api/src/services/extension.service.ts
@@ -3,6 +3,7 @@ import { getProjectDb, resolveDbName } from "../db";
 import { $ } from "bun";
 
 const IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
+type SystemExtensionInfo = { name: string; version: string; status: string; description: string };
 
 function validatePgIdentifier(name: string, label: string): string {
     if (!IDENTIFIER_REGEX.test(name)) {
@@ -17,6 +18,27 @@ export interface ExtensionInfo {
     installed_version: string | null;
     comment: string;
     is_installed: boolean;
+}
+
+export function parsePigExtensionList(text: string): SystemExtensionInfo[] {
+    const lines = text.split('\n').filter((l: string) => l.trim());
+    const isPsqlTable = lines.some((l: string) => l.includes('|'));
+    if (isPsqlTable) {
+        return lines
+            .filter((l: string) => l.includes('|') && !l.match(/^\s*(name|Name)\s*\|/i))
+            .map((l: string) => {
+                const parts = l.split('|').map((p: string) => p.trim());
+                return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' | ').trim() || '' };
+            })
+            .filter((e: { name: string }) => e.name);
+    }
+    return lines
+        .filter((l: string) => l.trim() && !l.startsWith('#') && !l.startsWith('=') && !l.match(/^\(\d+ rows?\)$/))
+        .map((l: string) => {
+            const parts = l.split(/\s+/);
+            return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' ') || '' };
+        })
+        .filter((e: { name: string }) => e.name);
 }
 
 export class ExtensionService {
@@ -83,36 +105,19 @@ export class ExtensionService {
         return (rows[0] as ExtensionInfo) || { name: extension, default_version: '', installed_version: null, comment: '', is_installed: false };
     }
 
-    async listSystemExtensions(): Promise<{ name: string; version: string; status: string; description: string }[]> {
+    async listSystemExtensions(): Promise<SystemExtensionInfo[]> {
         try {
             const result = await $`pig ext list`.nothrow().quiet();
             if (result.exitCode !== 0) {
                 return await this.listSystemExtensionsFromDb();
             }
-            const text = result.text();
-            const lines = text.split('\n').filter((l: string) => l.trim());
-            if (lines.some((l: string) => l.includes('|'))) {
-                return lines
-                    .filter((l: string) => l.trim() && !l.match(/^[-+|]+$/) && !l.match(/^\s*(name|Name)\s*\|/i))
-                    .map((l: string) => {
-                        const parts = l.split('|').map((p: string) => p.trim());
-                        return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' | ').trim() || '' };
-                    })
-                    .filter((e: { name: string }) => e.name);
-            }
-            return lines
-                .filter((l: string) => l.trim() && !l.startsWith('#') && !l.startsWith('='))
-                .map((l: string) => {
-                    const parts = l.split(/\s+/);
-                    return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' ') || '' };
-                })
-                .filter((e: { name: string }) => e.name);
+            return parsePigExtensionList(result.text());
         } catch {
             return await this.listSystemExtensionsFromDb();
         }
     }
 
-    private async listSystemExtensionsFromDb(): Promise<{ name: string; version: string; status: string; description: string }[]> {
+    private async listSystemExtensionsFromDb(): Promise<SystemExtensionInfo[]> {
         try {
             const { sql } = await import("../db");
             const rows = await sql`

--- a/packages/management-api/src/services/extension.service.ts
+++ b/packages/management-api/src/services/extension.service.ts
@@ -87,14 +87,46 @@ export class ExtensionService {
         try {
             const result = await $`pig ext list`.nothrow().quiet();
             if (result.exitCode !== 0) {
-                return [{ name: 'pig-not-available', version: '-', status: 'unavailable', description: 'pig CLI not found' }];
+                return await this.listSystemExtensionsFromDb();
             }
-            const lines = result.text().split('\n').filter((l: string) => l.trim() && !l.startsWith('#') && !l.startsWith('='));
-            return lines.map((line: string) => {
-                const parts = line.split(/\s+/);
-                return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' ') || '' };
-            }).filter((e: { name: string }) => e.name);
-        } catch (err: unknown) {
+            const text = result.text();
+            const lines = text.split('\n').filter((l: string) => l.trim());
+            if (lines.some((l: string) => l.includes('|'))) {
+                return lines
+                    .filter((l: string) => l.trim() && !l.match(/^[-+|]+$/) && !l.match(/^\s*(name|Name)\s*\|/i))
+                    .map((l: string) => {
+                        const parts = l.split('|').map((p: string) => p.trim());
+                        return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' | ').trim() || '' };
+                    })
+                    .filter((e: { name: string }) => e.name);
+            }
+            return lines
+                .filter((l: string) => l.trim() && !l.startsWith('#') && !l.startsWith('='))
+                .map((l: string) => {
+                    const parts = l.split(/\s+/);
+                    return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' ') || '' };
+                })
+                .filter((e: { name: string }) => e.name);
+        } catch {
+            return await this.listSystemExtensionsFromDb();
+        }
+    }
+
+    private async listSystemExtensionsFromDb(): Promise<{ name: string; version: string; status: string; description: string }[]> {
+        try {
+            const { sql } = await import("../db");
+            const rows = await sql`
+                SELECT name, default_version, installed_version, comment
+                FROM pg_available_extensions
+                ORDER BY name
+            `;
+            return (rows as Array<{ name: string; default_version: string | null; installed_version: string | null; comment: string | null }>).map(row => ({
+                name: row.name,
+                version: row.default_version || '-',
+                status: row.installed_version ? 'installed' : 'available',
+                description: row.comment || '',
+            }));
+        } catch {
             return [];
         }
     }

--- a/packages/management-api/tests/unit/extension.service.test.ts
+++ b/packages/management-api/tests/unit/extension.service.test.ts
@@ -24,7 +24,7 @@ mock.module("../../src/db", () => ({
     resolveDbName: async () => "project_testref123"
 }));
 
-import { extensionService } from "../../src/services/extension.service";
+import { extensionService, parsePigExtensionList } from "../../src/services/extension.service";
 
 describe("ExtensionService", () => {
     beforeEach(() => {
@@ -53,5 +53,20 @@ describe("ExtensionService", () => {
             "DROP FUNCTION IF EXISTS graphql_public.graphql(text, text, jsonb)",
         );
         expect(unsafeCalls[1]).toBe('CREATE EXTENSION IF NOT EXISTS "pg_graphql" CASCADE');
+    });
+
+    test("parsePigExtensionList should ignore psql table footers", () => {
+        const extensions = parsePigExtensionList(`
+ name               | default_version | installed_version | comment
+--------------------+-----------------+-------------------+-------------------------
+ pg_graphql         | 1.5             |                   | GraphQL support
+ pg_stat_statements | 1.10            | 1.10              | track planning stats
+(2 rows)
+`);
+
+        expect(extensions).toEqual([
+            { name: "pg_graphql", version: "1.5", status: "available", description: "GraphQL support" },
+            { name: "pg_stat_statements", version: "1.10", status: "1.10", description: "track planning stats" },
+        ]);
     });
 });


### PR DESCRIPTION
## Summary

Fixes 3 issues found during deep API testing on the VM:

### 1. `GET /v1/projects` connection reset (HTTP 000)
**Root cause**: DB query errors in route handlers were not caught, causing Elysia to reset the TCP connection instead of returning a proper JSON error response.

**Fix**: Added `onError` handler to `projectCrudRoutes` that catches unhandled errors, converts them via `toAppError()` (which maps DB connection errors ? 503, etc.), and returns a proper JSON response.

### 2. `GET /v1/system/extensions` returns psql text instead of JSON
**Root cause**: `listSystemExtensions()` used `pig ext list` CLI output, but the parser only handled simple whitespace-separated format. When the output was psql-style table format (`|`-delimited columns with `---+---` separators), parsing produced garbage.

**Fix**: 
- Added psql-style table parsing (split by `|`, skip separator/header lines)
- Added `listSystemExtensionsFromDb()` fallback that queries `pg_available_extensions` directly when `pig` CLI is unavailable
- Both error and unavailable paths now fall back to the DB query

### 3. All DB-dependent routes lack error handling
**Root cause**: The API routes group's `onError` handler only did audit logging (no response), relying on the global `onError` which could fail due to response schema validation mismatches.

**Fix**: Enhanced the API routes group's `onError` handler in `index.ts` to also return proper JSON error responses (using the same `toAppError()` conversion), ensuring all 25+ route modules are covered.

## Files Changed
- `packages/management-api/src/routes/project-crud.ts` - added `onError` handler
- `packages/management-api/src/services/extension.service.ts` - fixed `listSystemExtensions()` parsing + DB fallback
- `packages/management-api/src/routes/extensions.ts` - added `onError` handlers + logger import
- `packages/management-api/src/index.ts` - enhanced API routes group `onError` with error response

## Test Results
- TypeScript typecheck: ? pass
- Unit tests: ? 400 pass / 14 skip / 5 fail (pre-existing sdk-proxy mock isolation issues)
- Extension + schema tests: ? 9/9 pass