### PR TITLE
fix: improve error handling, extension parsing, and static assets fallback

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -347,7 +347,7 @@ const app = new Elysia({ strictPath: false })
     }
   })
 
-  // WebSocket routes (no HTTP auth guard — WS uses query token)
+  // WebSocket routes (no HTTP auth guard �?WS uses query token)
   .use((await import("./routes/ws")).wsRoutes)
 
   // Main API Routes
@@ -402,9 +402,9 @@ const app = new Elysia({ strictPath: false })
  * Gateway-inspired try_files static asset serving.
  *
  * Strategy (mirrors `try_files $uri $uri/ /index.html`):
- *   1. If exact file exists on disk → serve it (with content-negotiation for br/gzip)
- *   2. If path is an immutable asset (/_app/, /assets/) but missing → 404 (NEVER fallback to HTML)
- *   3. If path has no file extension (SPA route like /project/xxx/tables) → serve index.html
+ *   1. If exact file exists on disk �?serve it (with content-negotiation for br/gzip)
+ *   2. If path is an immutable asset (/_app/, /assets/) but missing �?404 (NEVER fallback to HTML)
+ *   3. If path has no file extension (SPA route like /project/xxx/tables) �?serve index.html
  *   4. Last resort: embedded assets fallback
  */
 export function registerStaticAssets() {
@@ -434,7 +434,7 @@ export function registerStaticAssets() {
       return { message: "Route not found", code: "404" };
     }
 
-    // --- Step 1: try_files $uri — check exact file on disk ---
+    // --- Step 1: try_files $uri �?check exact file on disk ---
     try {
       const acceptEncoding = request.headers.get("accept-encoding") || "";
       let diskFile: string | null = null;
@@ -494,15 +494,18 @@ export function registerStaticAssets() {
       });
     }
 
-    // --- Step 2: immutable asset miss → strict 404 (gateway behavior) ---
+    // --- Step 2: immutable asset miss -> strict 404 (gateway behavior) ---
     // /_app/immutable/... files are content-hashed; if they don't exist, it's a stale reference.
     // Returning index.html here would cause "Expected JS but got text/html" browser errors.
-    if (isImmutableAsset(path) || hasFileExtension(path)) {
+    // Exception: "/" was remapped to "/index.html" above - this is the SPA entry point,
+    // not a missing static asset, so allow it to fall through to embedded fallback.
+    const isRootIndexFallback = url.pathname === "/" && path === "/index.html";
+    if ((isImmutableAsset(path) || hasFileExtension(path)) && !isRootIndexFallback) {
       set.status = 404;
       return "";
     }
 
-    // --- Step 3: SPA fallback → serve index.html (only for navigation routes) ---
+    // --- Step 3: SPA fallback �?serve index.html (only for navigation routes) ---
     const indexHtml = await getIndexHtml();
     if (indexHtml) {
       return new Response(indexHtml, {
@@ -581,7 +584,7 @@ export async function registerAllRoutes() {
 
   return (
     new Elysia({ name: "api-routes" })
-      // Auth guard — runs before every route in this group
+      // Auth guard �?runs before every route in this group
       .onBeforeHandle(async ({ request, set }) => {
         const rateLimit = checkRateLimit(request);
         for (const [key, value] of Object.entries(rateLimit.headers)) {
@@ -609,10 +612,27 @@ export async function registerAllRoutes() {
           await logAuditEvent({ request, status: Number(set.status || 200) });
         }
       })
-      .onError(async ({ request, code, set }) => {
+      .onError(async ({ request, code, error, set }) => {
         if (shouldAuditRequest(request)) {
           await logAuditEvent({ request, status: Number(set.status || 500), action: `error:${code}` });
         }
+        const { isAppError, toAppError } = require("./utils/errors") as typeof import("./utils/errors");
+        if (isAppError(error)) {
+          set.status = error.statusCode;
+          return error.toJSON();
+        }
+        logger.error(`[API] Unhandled error [${code}]:`, error);
+        if (code === "VALIDATION") {
+          set.status = 400;
+          return { message: "Validation failed", code: "VALIDATION_ERROR", details: error.message };
+        }
+        if (code === "NOT_FOUND") {
+          set.status = 404;
+          return { message: "Not found", code: "NOT_FOUND" };
+        }
+        const appError = toAppError(error);
+        set.status = appError.statusCode;
+        return appError.toJSON();
       })
       .use(projectRoutes)
       .use(registeredProjectDashboardRoutes)
@@ -917,7 +937,7 @@ async function bootstrap() {
             try {
               ws.send(event.data as string | ArrayBufferLike);
             } catch {
-              // downstream closed — will be cleaned up in close handler
+              // downstream closed �?will be cleaned up in close handler
             }
           });
 
@@ -1084,13 +1104,7 @@ async function bootstrap() {
     );
 
     logger.info(`
-    ╔═══════════════════════════════════════════════════════════╗
-    ║          SupaCloud Management API                         ║
-    ╠═══════════════════════════════════════════════════════════╣
-    ║  Server running at: http://localhost:${config.port}                ║
-    ║  Swagger docs at:   http://localhost:${config.port}/swagger        ║
-    ╚═══════════════════════════════════════════════════════════╝
-    `);
+    ╔═══════════════════════════════════════════════════════════�?    �?         SupaCloud Management API                         �?    ╠═══════════════════════════════════════════════════════════�?    �? Server running at: http://localhost:${config.port}                �?    �? Swagger docs at:   http://localhost:${config.port}/swagger        �?    ╚═══════════════════════════════════════════════════════════�?    `);
   } else {
     logger.error(`Unknown command or argument: ${args.join(" ")}`);
     process.exit(1);

--- a/packages/management-api/src/routes/extensions.ts
+++ b/packages/management-api/src/routes/extensions.ts
@@ -1,10 +1,16 @@
 import { Elysia, t, status } from "elysia";
 import { extensionService } from '../services/extension.service';
 import { requireAdminAuth } from '../middleware/auth';
+import { logger } from "../utils/logger";
 
 const ErrorResponse = t.Object({ message: t.String() });
 
 export const extensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/extensions" })
+    .onError(({ code, error, set }) => {
+        logger.error(`[Extensions] Unhandled error [${code}]:`, error);
+        set.status = 500;
+        return { message: "Internal server error", code: "INTERNAL_ERROR" };
+    })
     .get('/', async ({ params }) => {
         return await extensionService.listExtensions(params.ref);
     }, {
@@ -70,6 +76,11 @@ export const extensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/extension
     });
 
 export const databaseExtensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/extensions" })
+    .onError(({ code, error, set }) => {
+        logger.error(`[DatabaseExtensions] Unhandled error [${code}]:`, error);
+        set.status = 500;
+        return { message: "Internal server error", code: "INTERNAL_ERROR" };
+    })
     .get('/', async ({ params }) => {
         return await extensionService.listExtensions(params.ref);
     }, {
@@ -121,6 +132,11 @@ export const databaseExtensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/d
     });
 
 export const systemExtensionRoutes = new Elysia({ prefix: "/v1/system/extensions" })
+    .onError(({ code, error, set }) => {
+        logger.error(`[SystemExtensions] Unhandled error [${code}]:`, error);
+        set.status = 500;
+        return { message: "Internal server error", code: "INTERNAL_ERROR" };
+    })
     .get('/', async () => {
         return await extensionService.listSystemExtensions();
     }, {

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -209,7 +209,21 @@ async function buildProjectResponse(
 }
 
 export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
-  // Get available regions
+  .onError(({ code, error, set }) => {
+    logger.error(`[ProjectCRUD] Unhandled error [${code}]:`, error);
+    if (code === "VALIDATION") {
+      set.status = 400;
+      return { message: "Validation failed", code: "VALIDATION_ERROR", details: error.message };
+    }
+    if (code === "NOT_FOUND") {
+      set.status = 404;
+      return { message: "Not found", code: "NOT_FOUND" };
+    }
+    const { toAppError } = require("../utils/errors") as typeof import("../utils/errors");
+    const appError = toAppError(error);
+    set.status = appError.statusCode;
+    return appError.toJSON();
+  })
   .get("/available-regions", () => {
     return AVAILABLE_REGIONS;
   },

--- a/packages/management-api/src/services/extension.service.ts
+++ b/packages/management-api/src/services/extension.service.ts
@@ -87,14 +87,63 @@ export class ExtensionService {
         try {
             const result = await $`pig ext list`.nothrow().quiet();
             if (result.exitCode !== 0) {
-                return [{ name: 'pig-not-available', version: '-', status: 'unavailable', description: 'pig CLI not found' }];
+                return await this.listSystemExtensionsFromDb();
             }
-            const lines = result.text().split('\n').filter((l: string) => l.trim() && !l.startsWith('#') && !l.startsWith('='));
-            return lines.map((line: string) => {
-                const parts = line.split(/\s+/);
-                return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' ') || '' };
-            }).filter((e: { name: string }) => e.name);
-        } catch (err: unknown) {
+            const text = result.text();
+            const rawLines = text.split('\n');
+            // Filter out decorative/header/summary lines from pig ext list output
+            const isDataLine = (l: string): boolean => {
+                const trimmed = l.trim();
+                if (!trimmed) return false;
+                // Skip Unicode box-drawing separator lines
+                if (/^[\s\u2500-\u257F\-+|]+$/.test(trimmed)) return false;
+                // Skip header row (Name | Version | ...)
+                if (/^\s*name\s*\|/i.test(trimmed)) return false;
+                // Skip summary lines like "(464 Rows)"
+                if (/^\(\d+\s+Rows?\)/.test(trimmed)) return false;
+                // Skip banner lines like checkmark + "Found N extensions"
+                if (/^\u2713/.test(trimmed)) return false;
+                // Skip comment and decoration lines
+                if (/^[#=]/.test(trimmed)) return false;
+                return true;
+            };
+            const dataLines = rawLines.filter(isDataLine);
+            // Try pipe-delimited parsing first (table output)
+            if (dataLines.some((l: string) => l.includes('|'))) {
+                return dataLines
+                    .map((l: string) => {
+                        const parts = l.split('|').map((p: string) => p.trim());
+                        return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' | ').trim() || '' };
+                    })
+                    .filter((e: { name: string }) => e.name);
+            }
+            // Fallback: space-delimited parsing
+            return dataLines
+                .map((l: string) => {
+                    const parts = l.split(/\s+/);
+                    return { name: parts[0] || '', version: parts[1] || '', status: parts[2] || 'available', description: parts.slice(3).join(' ') || '' };
+                })
+                .filter((e: { name: string }) => e.name);
+        } catch {
+            return await this.listSystemExtensionsFromDb();
+        }
+    }
+
+    private async listSystemExtensionsFromDb(): Promise<{ name: string; version: string; status: string; description: string }[]> {
+        try {
+            const { sql } = await import("../db");
+            const rows = await sql`
+                SELECT name, default_version, installed_version, comment
+                FROM pg_available_extensions
+                ORDER BY name
+            `;
+            return (rows as Array<{ name: string; default_version: string | null; installed_version: string | null; comment: string | null }>).map(row => ({
+                name: row.name,
+                version: row.default_version || '-',
+                status: row.installed_version ? 'installed' : 'available',
+                description: row.comment || '',
+            }));
+        } catch {
             return [];
         }
     }


### PR DESCRIPTION
## Summary

Deep API and web console testing identified several bugs in the management API. This PR addresses the most impactful issues found during testing against a live SupaCloud instance.

## Changes

### Bug Fix: System Extensions API returns garbage data
**Problem:** The pig ext list CLI output includes Unicode box-drawing separator lines, header rows, banner text (e.g. "✓ Found 464 extensions"), and summary lines (e.g. "(464 Rows)"), which were all being parsed as extension entries and returned to the API consumer.

**Fix:** Added a robust isDataLine filter that removes:
- Unicode box-drawing separators (─, │, etc.)
- Header row (Name | Version | ...)
- Summary lines ((464 Rows))
- Banner lines (✓ Found N extensions)
- Comment/decoration lines (#, =)

Also added a listSystemExtensionsFromDb() fallback that queries pg_available_extensions when pig CLI is unavailable, replacing the unhelpful [pig-not-available] stub entry.

### Bug Fix: Root path / returns 404 when web console build is missing
**Problem:** The static assets handler remaps "/" to "/index.html". When the file doesn't exist on disk, Step 2 checks hasFileExtension("/index.html") which returns 	rue, causing an immediate 404 instead of falling through to the embedded assets fallback.

**Fix:** Added an isRootIndexFallback check that allows the root path to skip the hasFileExtension gate and continue to the embedded assets fallback.

### Improvement: Per-route error handlers
Added onError handlers to extension routes and project CRUD routes to prevent unhandled promise rejections and provide structured JSON error responses.

### Improvement: Global error handler
Enhanced the global onError handler with AppError detection, validation error formatting, and consistent error response shapes.

## Testing
Tested against live instance at 192.168.110.22:9090:
- /v1/system/extensions previously returned header/separator/banner rows as extension entries
- / returned empty 404 instead of attempting embedded fallback
- Multiple endpoints with missing error handlers now return proper error JSON