### PR TITLE
fix: harden web console API handling and streaming

### DIFF
--- a/packages/management-api/src/routes/extensions.ts
+++ b/packages/management-api/src/routes/extensions.ts
@@ -153,8 +153,8 @@ export const systemExtensionRoutes = new Elysia({ prefix: "/v1/system/extensions
         response: {
             200: t.Any(),
             400: ErrorResponse,
-        detail: { tags: ["extensions"], summary: "Install a system extension" },
         },
+        detail: { tags: ["extensions"], summary: "Install a system extension" },
     })
     .post('/remove', async ({ body, request }) => {
         const authError = await requireAdminAuth(request);
@@ -166,6 +166,6 @@ export const systemExtensionRoutes = new Elysia({ prefix: "/v1/system/extensions
         response: {
             200: t.Any(),
             400: ErrorResponse,
-        detail: { tags: ["extensions"], summary: "Remove a system extension" },
         },
+        detail: { tags: ["extensions"], summary: "Remove a system extension" },
     });

--- a/packages/web-console/src/lib/admin/provider.test.ts
+++ b/packages/web-console/src/lib/admin/provider.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chatProvider } from "./provider";
+
+const originalFetch = globalThis.fetch;
+
+function streamFrom(chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("chatProvider", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("buffers SSE lines split across chunks", async () => {
+    globalThis.fetch = async () => new Response(streamFrom([
+      'data: {"choices":[{"delta":{"content":"hel',
+      'lo"}}]}\n',
+      'data: [DONE]\n',
+    ]), { status: 200 });
+
+    const chunks: string[] = [];
+    for await (const chunk of chatProvider.sendMessage([{ role: "user", content: "hi" } as any])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["hello"]);
+  });
+});

--- a/packages/web-console/src/lib/admin/provider.ts
+++ b/packages/web-console/src/lib/admin/provider.ts
@@ -56,24 +56,55 @@ export const chatProvider: ChatProvider = {
       const reader = res.body?.getReader();
       const decoder = new TextDecoder();
 
-      if (!reader) throw new Error('No readable stream');
+      if (!reader) {
+        const fallback = await res.json().catch(() => null);
+        const content = fallback?.choices?.[0]?.message?.content;
+        if (content) {
+          yield content;
+          return;
+        }
+        throw new Error('No readable stream');
+      }
+
+      let buffered = "";
 
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 
-        const lines = decoder.decode(value).split('\n');
+        buffered += decoder.decode(value, { stream: true });
+        const lines = buffered.split('\n');
+        buffered = lines.pop() ?? "";
+
         for (const line of lines) {
-          if (line.startsWith('data: ') && line !== 'data: [DONE]') {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith('data:') || trimmed === 'data: [DONE]') continue;
+          const payload = trimmed.slice(5).trim();
+          if (!payload || payload === '[DONE]') continue;
+          try {
+            const data = JSON.parse(payload);
+            if (data.choices?.[0]?.delta?.content) {
+              yield data.choices[0].delta.content;
+            }
+          } catch {
+            // Ignore malformed stream fragments.
+          }
+        }
+      }
+
+      buffered += decoder.decode();
+      const tail = buffered.trim();
+      if (tail.startsWith('data:') && tail !== 'data: [DONE]') {
+        const payload = tail.slice(5).trim();
+        if (payload && payload !== '[DONE]') {
             try {
-              const data = JSON.parse(line.slice(6));
+              const data = JSON.parse(payload);
               if (data.choices?.[0]?.delta?.content) {
                 yield data.choices[0].delta.content;
               }
             } catch {
-              // Ignore parse errors on partial chunks
+              // Ignore malformed tail payload.
             }
-          }
         }
       }
     } catch (e: any) {
@@ -82,4 +113,3 @@ export const chatProvider: ChatProvider = {
     }
   }
 };
-

--- a/packages/web-console/src/lib/api.test.ts
+++ b/packages/web-console/src/lib/api.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { apiClient } from "./api";
+
+const originalFetch = globalThis.fetch;
+
+describe("apiClient", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("normalizes empty error responses to JSON", async () => {
+    globalThis.fetch = async () => new Response("", {
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    const response = await apiClient("/v1/projects");
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("Content-Type")).toBe("application/json");
+    expect(await response.json()).toEqual({
+      message: "Bad Gateway",
+      code: "502",
+    });
+  });
+});

--- a/packages/web-console/src/lib/api.ts
+++ b/packages/web-console/src/lib/api.ts
@@ -4,6 +4,48 @@
  * and handles common error scenarios (e.g. 401 Unauthorized -> redirect to login).
  */
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 15000;
+
+function mergeAbortSignals(signals: Array<AbortSignal | null | undefined>): AbortSignal | undefined {
+  const validSignals = signals.filter(Boolean) as AbortSignal[];
+  if (validSignals.length === 0) return undefined;
+  if (validSignals.length === 1) return validSignals[0];
+
+  const controller = new AbortController();
+  const abort = () => {
+    if (!controller.signal.aborted) controller.abort();
+  };
+
+  for (const signal of validSignals) {
+    if (signal.aborted) {
+      abort();
+      break;
+    }
+    signal.addEventListener("abort", abort, { once: true });
+  }
+
+  return controller.signal;
+}
+
+async function normalizeErrorResponse(response: Response): Promise<Response> {
+  if (response.ok) return response;
+
+  const contentType = response.headers.get("content-type") || "";
+  const rawBody = await response.clone().text().catch(() => "");
+
+  if (contentType.includes("application/json") && rawBody.trim().length > 0) {
+    return response;
+  }
+
+  return new Response(JSON.stringify({
+    message: rawBody.trim() || response.statusText || "Request failed",
+    code: String(response.status || 500),
+  }), {
+    status: response.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 export async function apiClient(url: string, options: RequestInit = {}): Promise<Response> {
   const token = typeof localStorage !== 'undefined' ? localStorage.getItem("supacloud_session") : null;
   
@@ -19,7 +61,32 @@ export async function apiClient(url: string, options: RequestInit = {}): Promise
     headers.set("Content-Type", "application/json");
   }
 
-  const response = await fetch(url, { ...options, headers });
+  const timeoutController = new AbortController();
+  const timeout = setTimeout(() => timeoutController.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
+  const signal = mergeAbortSignals([options.signal, timeoutController.signal]);
+
+  let response: Response;
+  try {
+    response = await fetch(url, { ...options, headers, signal });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      if (options.signal?.aborted && !timeoutController.signal.aborted) {
+        throw error;
+      }
+      return new Response(JSON.stringify({
+        message: "Request timeout",
+        code: "TIMEOUT",
+      }), {
+        status: 504,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  response = await normalizeErrorResponse(response);
   
   // Handle 401 Unauthorized globally by redirecting to login page (with Race-Condition Pre-Flight check)
   if (response.status === 401 && typeof window !== 'undefined' && window.location.pathname !== '/login') {
@@ -32,7 +99,8 @@ export async function apiClient(url: string, options: RequestInit = {}): Promise
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ token })
         });
-        const verifyData = await verifyRes.json();
+        const verifyText = await verifyRes.text();
+        const verifyData = verifyText ? JSON.parse(verifyText) : { valid: false };
         
         if (verifyData.valid) {
           // Token is actually still valid! Swallow the 401 logout to prevent false disconnect


### PR DESCRIPTION
## What this fixes

Deep testing found a few reliability bugs that break the console under unstable API/server conditions:

1. **Web console requests could hang indefinitely**
- `apiClient` had no timeout, so pages like `/`, `/projects`, and `/platform/settings` could stay loading forever when backend calls stalled.
- Added a default 15s timeout with abort handling.

2. **Empty/non-JSON API errors broke page logic**
- Several backend/proxy failures return empty body or non-JSON body on 4xx/5xx.
- Many pages call `res.json()` directly; this crashed on empty responses.
- Added response normalization in `apiClient` to convert non-JSON/empty error responses into structured JSON `{ message, code }`.

3. **401 verify preflight was brittle**
- Global 401 handler assumed `/auth/verify` always returns JSON.
- Added safe text->JSON parsing fallback.

4. **Chat SSE stream parser could lose chunks**
- Streaming parser split each chunk by newline independently, which drops partial lines across chunk boundaries.
- Added buffered SSE parsing with tail handling and fallback for non-streaming JSON responses.

5. **Route schema metadata bug in system extensions routes**
- `detail` metadata was accidentally nested inside `response` in two routes:
  - `POST /v1/system/extensions/install`
  - `POST /v1/system/extensions/remove`
- Moved `detail` to the correct route options level.

## Files changed
- `packages/web-console/src/lib/api.ts`
- `packages/web-console/src/lib/admin/provider.ts`
- `packages/management-api/src/routes/extensions.ts`