### PR TITLE
fix(i18n): add missing Dashboard.cache_hit_ratio translation

### DIFF
--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -20,7 +20,8 @@
     "storage_used": "Storage Used",
     "auth_users": "Auth Users",
     "api_health": "API Health",
-    "healthy": "Healthy"
+    "healthy": "Healthy",
+    "cache_hit_ratio": "Cache Hit Ratio"
   },
   "Navigation": {
     "table_editor": "Table Editor",

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -20,7 +20,8 @@
     "storage_used": "已用存储",
     "auth_users": "认证用户",
     "api_health": "API 监控",
-    "healthy": "健康"
+    "healthy": "健康",
+    "cache_hit_ratio": "缓存命中率"
   },
   "Navigation": {
     "table_editor": "表编辑器",


### PR DESCRIPTION
## Follow-up fix for PR #142

Parent: #142 (`fix: backup timeout and dashboard i18n hardcoded Chinese`)

### Problem
PR #142 引入了 `$t("Dashboard.cache_hit_ratio", {default: "缓存命中率"})` 调用，但未在 `en.json` / `zh.json` 中添加对应的翻译 key，导致运行时始终回退到 inline default 而非走 i18n 查找。

### Changes
- `en.json`: 在 `Dashboard` section 添加 `"cache_hit_ratio": "Cache Hit Ratio"`
- `zh.json`: 在 `Dashboard` section 添加 `"cache_hit_ratio": "缓存命中率"`

### Verification
- JSON 语法验证通过 (`python3 -c "import json; ..."`)
- `git diff --check` 无 trailing whitespace / EOF 问题
- diff 仅涉及 2 个 locale 文件，无业务逻辑变更

### Notes
- 任务原始描述中提到的 Sidebar.svelte trailing whitespace 和 backup.service.ts EOF 空行经确认不存在于当前 main（是 unrelated 本地修改引起的 diff 噪声），无需修复。