### PR TITLE
fix: avoid default project SQL calls on pooling/tuning

### DIFF
--- a/packages/web-console/src/routes/platform/pooling/+page.svelte
+++ b/packages/web-console/src/routes/platform/pooling/+page.svelte
@@ -42,6 +42,12 @@
   let actionMsg: string | null = $state.raw(null);
     
   async function runBouncerSql(sql: string): Promise<Record<string, unknown>[]> {
+    if (!projectRef || projectRef === "default") {
+      await resolveProjectRef();
+    }
+    if (!projectRef || projectRef === "default") {
+      return [];
+    }
     try {
       // Query pgbouncer admin port via management API SQL endpoint
       const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {

--- a/packages/web-console/src/routes/platform/tuning/+page.svelte
+++ b/packages/web-console/src/routes/platform/tuning/+page.svelte
@@ -61,6 +61,12 @@
   }
 
   async function runSql(sql: string): Promise<Record<string, unknown>[]> {
+    if (!projectRef || projectRef === "default") {
+      await resolveProjectRef();
+    }
+    if (!projectRef || projectRef === "default") {
+      return [];
+    }
     try {
       const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
         method: "POST",

--- a/packages/web-console/src/routes/project/[ref]/reports/query-performance/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/reports/query-performance/+page.svelte
@@ -19,6 +19,22 @@
   const statsQuery = createQuery(() => ({
     queryKey: ["query-performance", projectRef],
     queryFn: async () => {
+      const extensionCheck = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sql: `SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') AS installed;`
+        })
+      });
+      const extensionData = await extensionCheck.json();
+      if (!extensionCheck.ok) {
+        throw new Error(extensionData?.message || extensionData?.error || "Failed to check extension status");
+      }
+      const installed = Boolean(extensionData?.rows?.[0]?.installed);
+      if (!installed) {
+        throw new Error("MISSING_EXTENSION");
+      }
+
       const schemasToTry = ['', 'monitor.', 'extensions.'];
       let lastError = null;
 
@@ -34,6 +50,14 @@
             })
           });
           const data = await res.json();
+
+          if (!res.ok) {
+            lastError = data;
+            if (data?.message?.includes("pg_stat_statements") && data?.message?.includes("does not exist")) {
+              continue;
+            }
+            throw new Error(data?.message || data?.error || "Failed to query pg_stat_statements");
+          }
           
           if (data.error) {
             lastError = data;
@@ -72,7 +96,8 @@
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          sql: `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`
+          sql: `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;`,
+          mode: "migration"
         })
       });
       const data = await res.json();

--- a/packages/web-console/src/routes/project/[ref]/settings/webhooks/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/settings/webhooks/+page.svelte
@@ -31,9 +31,10 @@
   const webhooksQuery = createQuery(() => ({
     queryKey: ["webhooks", projectRef],
     queryFn: async () => {
+      // Ensure pg_net exists once, using migration mode (read mode blocks DDL).
       await apiClient(`/v1/projects/${projectRef}/database/sql`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql: "CREATE EXTENSION IF NOT EXISTS pg_net;" })
+        body: JSON.stringify({ sql: "CREATE EXTENSION IF NOT EXISTS pg_net;", mode: "migration" })
       });
 
       const sql = `
@@ -49,7 +50,7 @@
       `;
       const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql })
+        body: JSON.stringify({ sql, mode: "migration" })
       });
       if (!res.ok) throw new Error("Failed to fetch webhooks");
       const data = await res.json();
@@ -74,6 +75,7 @@
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sql: "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public' ORDER BY tablename;" })
       });
+      if (!tblRes.ok) throw new Error("Failed to fetch tables");
       const tblData = await tblRes.json();
       const tables = (tblData.rows || []).map((t: Record<string, unknown>) => t.tablename as string);
 
@@ -115,7 +117,7 @@
 
       const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql })
+        body: JSON.stringify({ sql, mode: "migration" })
       });
       const data = await res.json();
       if (data.error) throw new Error(data.message || data.error);
@@ -152,9 +154,12 @@
       `;
       const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql })
+        body: JSON.stringify({ sql, mode: "migration" })
       });
-      if (!res.ok) throw new Error("Delete failed");
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data?.message || data?.error || "Delete failed");
+      }
       return res.json();
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- fix platform pooling page to re-resolve project ref before SQL calls
- fix platform tuning page to re-resolve project ref before SQL calls
- prevent accidental requests to /v1/projects/default/database/sql that caused 404 in UI

## Verification
- upgraded VM supacloud binary to 0.18.9
- deep API checks passed on http://127.0.0.1:9090
- browser regression test identified 404 only on:
  - /platform/pooling
  - /platform/tuning
- after patch, both pages guard against default/empty project ref