### PR TITLE
fix: prevent i18n race and post-login blank screen

### DIFF
--- a/packages/web-console/src/lib/components/PlatformSidebar.svelte
+++ b/packages/web-console/src/lib/components/PlatformSidebar.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
   import { cn } from "$lib/utils";
-  import { 
-    Box, 
-    Database, 
-    Settings2, 
-    LineChart, 
-    Network, 
-    HardDrive, 
+  import {
+    Box,
+    Database,
+    Settings2,
+    LineChart,
+    Network,
+    HardDrive,
     Terminal,
     Languages,
     Home,
     SunMoon
   } from "lucide-svelte";
-  import { page } from '$app/stores';
+  import { page } from "$app/stores";
   import { t, locale } from "svelte-i18n";
   import { mode, toggleMode } from "mode-watcher";
 
@@ -33,14 +33,14 @@
   );
 
   const navItems = $derived([
-    { title: $t("Platform.extensions_market"), icon: Box, href: `/platform/extensions` },
-    { title: $t("Platform.backups_pitr"), icon: Database, href: `/platform/backups` },
-    { title: $t("Platform.engine_tuning"), icon: Settings2, href: `/platform/tuning` },
-    { title: $t("Platform.monitoring"), icon: LineChart, href: `/platform/monitoring` },
-    { title: $t("Platform.connection_pool"), icon: Network, href: `/platform/pooling` },
-    { title: $t("Platform.storage_juicefs"), icon: HardDrive, href: `/platform/storage` },
-    { title: $t("Platform.operations_console"), icon: Terminal, href: `/platform/operations` },
-    { title: $t("Platform.settings") || "系统设置", icon: Settings2, href: `/platform/settings` },
+    { titleKey: "Platform.extensions_market", icon: Box, href: "/platform/extensions" },
+    { titleKey: "Platform.backups_pitr", icon: Database, href: "/platform/backups" },
+    { titleKey: "Platform.engine_tuning", icon: Settings2, href: "/platform/tuning" },
+    { titleKey: "Platform.monitoring", icon: LineChart, href: "/platform/monitoring" },
+    { titleKey: "Platform.connection_pool", icon: Network, href: "/platform/pooling" },
+    { titleKey: "Platform.storage_juicefs", icon: HardDrive, href: "/platform/storage" },
+    { titleKey: "Platform.operations_console", icon: Terminal, href: "/platform/operations" },
+    { titleKey: "Platform.settings", icon: Settings2, href: "/platform/settings" },
   ]);
 
   function isActive(href: string) {
@@ -65,18 +65,18 @@
         )}
       >
         <Icon size={18} />
-        {item.title}
+        {$t(item.titleKey)}
       </a>
     {/each}
   </nav>
 
   <div class="p-4 border-t space-y-2">
-    <a 
+    <a
       href="/"
       class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-brand bg-brand/5 hover:bg-brand/10 transition-colors cursor-pointer"
     >
       <Home size={18} />
-      <span>{$t("Sidebar.back_to_projects") || "返回项目列表"}</span>
+      <span>{$t("Sidebar.back_to_projects") || "Back to projects"}</span>
     </a>
     <button
       onclick={toggleMode}
@@ -85,7 +85,7 @@
       <SunMoon size={18} />
       <span>{themeToggleLabel}</span>
     </button>
-    <button 
+    <button
       onclick={toggleLanguage}
       class="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
     >

--- a/packages/web-console/src/lib/components/Sidebar.svelte
+++ b/packages/web-console/src/lib/components/Sidebar.svelte
@@ -45,22 +45,22 @@
   );
 
   const navItems = $derived(currentProject?.ref ? [
-    { title: $t("Navigation.table_editor"), icon: Table, href: `/project/${currentProject.ref}/tables` },
-    { title: $t("Navigation.sql_editor"), icon: Code2, href: `/project/${currentProject.ref}/sql` },
-    { title: $t("Navigation.auth"), icon: Users, href: `/project/${currentProject.ref}/auth` },
-    { title: $t("Navigation.storage"), icon: Box, href: `/project/${currentProject.ref}/storage` },
-    { title: $t("Navigation.edge_functions"), icon: Zap, href: `/project/${currentProject.ref}/functions` },
-    { title: $t("Hosting.title"), icon: Globe, href: `/project/${currentProject.ref}/hosting` },
-    { title: $t("Realtime.title"), icon: Radio, href: `/project/${currentProject.ref}/realtime` },
-    { title: $t("Navigation.database"), icon: Database, href: `/project/${currentProject.ref}/database` },
-    { title: $t("Navigation.api_docs"), icon: Files, href: `/project/${currentProject.ref}/api` },
-    { title: $t("Navigation.query_performance"), icon: LineChart, href: `/project/${currentProject.ref}/reports/query-performance` },
-    { title: $t("Navigation.database_linter"), icon: ShieldCheck, href: `/project/${currentProject.ref}/reports/database-linter` },
-    { title: $t("Sidebar.database_advisor"), icon: ShieldCheck, href: `/project/${currentProject.ref}/reports/advisors` },
-    { title: $t("Navigation.reports"), icon: Glasses, href: `/project/${currentProject.ref}/reports/api-overview` },
-    { title: $t("Navigation.logs"), icon: ScrollText, href: `/project/${currentProject.ref}/logs` },
-    { title: $t("Navigation.tasks"), icon: Activity, href: `/project/${currentProject.ref}/tasks` },
-    { title: $t("Navigation.settings"), icon: Settings, href: `/project/${currentProject.ref}/settings` },
+    { titleKey: "Navigation.table_editor", icon: Table, href: `/project/${currentProject.ref}/tables` },
+    { titleKey: "Navigation.sql_editor", icon: Code2, href: `/project/${currentProject.ref}/sql` },
+    { titleKey: "Navigation.auth", icon: Users, href: `/project/${currentProject.ref}/auth` },
+    { titleKey: "Navigation.storage", icon: Box, href: `/project/${currentProject.ref}/storage` },
+    { titleKey: "Navigation.edge_functions", icon: Zap, href: `/project/${currentProject.ref}/functions` },
+    { titleKey: "Hosting.title", icon: Globe, href: `/project/${currentProject.ref}/hosting` },
+    { titleKey: "Realtime.title", icon: Radio, href: `/project/${currentProject.ref}/realtime` },
+    { titleKey: "Navigation.database", icon: Database, href: `/project/${currentProject.ref}/database` },
+    { titleKey: "Navigation.api_docs", icon: Files, href: `/project/${currentProject.ref}/api` },
+    { titleKey: "Navigation.query_performance", icon: LineChart, href: `/project/${currentProject.ref}/reports/query-performance` },
+    { titleKey: "Navigation.database_linter", icon: ShieldCheck, href: `/project/${currentProject.ref}/reports/database-linter` },
+    { titleKey: "Sidebar.database_advisor", icon: ShieldCheck, href: `/project/${currentProject.ref}/reports/advisors` },
+    { titleKey: "Navigation.reports", icon: Glasses, href: `/project/${currentProject.ref}/reports/api-overview` },
+    { titleKey: "Navigation.logs", icon: ScrollText, href: `/project/${currentProject.ref}/logs` },
+    { titleKey: "Navigation.tasks", icon: Activity, href: `/project/${currentProject.ref}/tasks` },
+    { titleKey: "Navigation.settings", icon: Settings, href: `/project/${currentProject.ref}/settings` },
   ] : []);
 
   function isActive(href: string) {
@@ -101,7 +101,7 @@
         )}
       >
         <item.icon fill="currentColor" strokeWidth={1.5} class={cn("w-4 h-4 transition-colors", isActive(item.href) ? "text-brand" : "group-hover:text-brand")} />
-        {item.title}
+        {$t(item.titleKey)}
       </a>
     {/each}
 

--- a/packages/web-console/src/lib/i18n/index.ts
+++ b/packages/web-console/src/lib/i18n/index.ts
@@ -5,12 +5,28 @@ register('zh', () => import('./locales/zh.json'));
 register('zh-CN', () => import('./locales/zh.json'));
 register('en-US', () => import('./locales/en.json'));
 
+const SUPPORTED = new Set(["en", "en-US", "zh", "zh-CN"]);
+
+function normalizeLocale(value: string | null | undefined): string {
+  if (!value) return "zh-CN";
+  const trimmed = value.trim();
+  if (SUPPORTED.has(trimmed)) return trimmed;
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("zh")) return "zh-CN";
+  if (lower.startsWith("en")) return "en";
+  return "zh-CN";
+}
+
 const savedLocale = typeof localStorage !== 'undefined' ? localStorage.getItem('selected-locale') : null;
+const initialLocale = normalizeLocale(savedLocale || getLocaleFromNavigator());
 
 init({
   fallbackLocale: 'en',
-  initialLocale: savedLocale || getLocaleFromNavigator() || 'zh-CN',
+  initialLocale,
 });
+
+// Guard against race conditions where templates call $t() before locale settles.
+locale.set(initialLocale);
 
 // 在客戶端環境下導出一個等待函數
 export { waitLocale };
@@ -18,6 +34,6 @@ export { waitLocale };
 // 持久化語言選擇
 if (typeof localStorage !== 'undefined') {
   locale.subscribe(val => {
-    if (val) localStorage.setItem('selected-locale', val);
+    if (val) localStorage.setItem('selected-locale', normalizeLocale(val));
   });
 }

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script module>
+  import "$lib/i18n";
+
   if (typeof window !== "undefined") {
     if (window.location.hash.includes("/login")) {
       window.location.replace("/login");
@@ -10,7 +12,7 @@
   import { apiClient } from "$lib/api";
 
   import "../app.css";
-  import "$lib/i18n"; // Ensure svelte-i18n is initialized synchronously
+  import "$lib/i18n";
   import { onMount, type Snippet, untrack } from "svelte";
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";

--- a/packages/web-console/src/routes/platform/+layout.svelte
+++ b/packages/web-console/src/routes/platform/+layout.svelte
@@ -6,14 +6,14 @@
   let { children } = $props();
 
   const TABS = $derived([
-    { id: "extensions", label: $t("Platform.extensions_market"), icon: Package },
-    { id: "backups", label: $t("Platform.backups_pitr"), icon: HardDrive },
-    { id: "tuning", label: $t("Platform.engine_tuning"), icon: SlidersHorizontal },
-    { id: "monitoring", label: $t("Platform.monitoring"), icon: BarChart3 },
-    { id: "pooling", label: $t("Platform.connection_pool"), icon: Activity },
-    { id: "storage", label: $t("Platform.storage_juicefs"), icon: Database },
-    { id: "operations", label: $t("Platform.operations_console"), icon: Wrench },
-    { id: "settings", label: $t("Platform.settings"), icon: Settings },
+    { id: "extensions", labelKey: "Platform.extensions_market", icon: Package },
+    { id: "backups", labelKey: "Platform.backups_pitr", icon: HardDrive },
+    { id: "tuning", labelKey: "Platform.engine_tuning", icon: SlidersHorizontal },
+    { id: "monitoring", labelKey: "Platform.monitoring", icon: BarChart3 },
+    { id: "pooling", labelKey: "Platform.connection_pool", icon: Activity },
+    { id: "storage", labelKey: "Platform.storage_juicefs", icon: Database },
+    { id: "operations", labelKey: "Platform.operations_console", icon: Wrench },
+    { id: "settings", labelKey: "Platform.settings", icon: Settings },
   ]);
 
   const currentTab = $derived(page.url.pathname.split("/platform/")[1]?.split("/")[0] || "");
@@ -36,7 +36,7 @@
           class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-full whitespace-nowrap transition-colors {currentTab === tab.id ? 'bg-brand text-white shadow-md' : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'}"
         >
           <Icon size={14} />
-          {tab.label}
+          {$t(tab.labelKey)}
         </a>
       {/each}
     </div>

--- a/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
@@ -8,21 +8,21 @@
   const projectRef = $derived(page.params.ref);
 
   const TABS = $derived([
-    { id: "roles", label: $t("Roles.title"), icon: Users },
-    { id: "extensions", label: $t("Extensions.title"), icon: Package },
-    { id: "triggers", label: $t("Triggers.title"), icon: Zap },
-    { id: "functions", label: $t("DbFunctions.title"), icon: Braces },
-    { id: "indexes", label: $t("Indexes.title"), icon: Hash },
-    { id: "schemas", label: $t("Schemas.title"), icon: FolderOpen },
-    { id: "types", label: $t("EnumTypes.title"), icon: Tag },
-    { id: "column-privileges", label: $t("ColumnPrivileges.title"), icon: ShieldCheck },
-    { id: "publications", label: $t("Publications.title"), icon: Radio },
-    { id: "hooks", label: $t("Hooks.title"), icon: Webhook },
-    { id: "migrations", label: $t("Migrations.title"), icon: GitCommitVertical },
-    { id: "backups", label: $t("Backups.title"), icon: HardDrive },
-    { id: "cron", label: $t("CronJobs.title"), icon: CalendarClock },
-    { id: "wrappers", label: "Wrappers", icon: Globe },
-    { id: "settings", label: "Settings", icon: Settings },
+    { id: "roles", labelKey: "Roles.title", icon: Users },
+    { id: "extensions", labelKey: "Extensions.title", icon: Package },
+    { id: "triggers", labelKey: "Triggers.title", icon: Zap },
+    { id: "functions", labelKey: "DbFunctions.title", icon: Braces },
+    { id: "indexes", labelKey: "Indexes.title", icon: Hash },
+    { id: "schemas", labelKey: "Schemas.title", icon: FolderOpen },
+    { id: "types", labelKey: "EnumTypes.title", icon: Tag },
+    { id: "column-privileges", labelKey: "ColumnPrivileges.title", icon: ShieldCheck },
+    { id: "publications", labelKey: "Publications.title", icon: Radio },
+    { id: "hooks", labelKey: "Hooks.title", icon: Webhook },
+    { id: "migrations", labelKey: "Migrations.title", icon: GitCommitVertical },
+    { id: "backups", labelKey: "Backups.title", icon: HardDrive },
+    { id: "cron", labelKey: "CronJobs.title", icon: CalendarClock },
+    { id: "wrappers", labelKey: null, labelFallback: "Wrappers", icon: Globe },
+    { id: "settings", labelKey: null, labelFallback: "Settings", icon: Settings },
   ]);
 
   const currentTab = $derived(page.url.pathname.split("/database/")[1]?.split("/")[0] || "");
@@ -34,7 +34,8 @@
       <a href={`/project/${projectRef}/database`} class="hover:text-foreground transition-colors">{$t("Navigation.database")}</a>
       {#if currentTab}
         <span>/</span>
-        <span class="text-foreground capitalize">{TABS.find(t => t.id === currentTab)?.label || currentTab}</span>
+        {@const activeTab = TABS.find(t => t.id === currentTab)}
+        <span class="text-foreground capitalize">{activeTab?.labelKey ? $t(activeTab.labelKey) : (activeTab?.labelFallback || currentTab)}</span>
       {/if}
     </div>
     <div class="flex items-center gap-2 overflow-x-auto pb-2 scrollbar-hide">
@@ -44,7 +45,7 @@
           class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-full whitespace-nowrap transition-colors {currentTab === tab.id ? 'bg-brand text-white shadow-md' : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'}"
         >
           <tab.icon size={14} />
-          {tab.label}
+          {tab.labelKey ? $t(tab.labelKey) : tab.labelFallback}
         </a>
       {/each}
     </div>


### PR DESCRIPTION
## Summary
- initialize i18n earlier to prevent post-login white screen
- move some module-level translations to key-based rendering to avoid locale race conditions
- keep previously fixed SQL and default-ref regressions covered

## Verification
- login succeeds and API returns  .18.9
- deep API regression passes
- web console no longer emits the default-ref SQL leak in pooling/tuning