### PR TITLE
fix: polish reports i18n and query performance errors

### DIFF
--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -331,6 +331,8 @@
     "rows": "Rows",
     "extension_required": "Extension Required",
     "extension_desc": "You need to enable the pg_stat_statements extension to view query performance metrics.",
+    "access_unavailable_title": "Metrics Temporarily Unavailable",
+    "access_unavailable_desc": "pg_stat_statements is installed, but the current database role cannot read its metrics. Grant access to the extension schema or use a more privileged database role.",
     "enable_now": "Enable pg_stat_statements",
     "loading": "Loading performance metrics...",
     "error": "Error loading metrics"
@@ -428,6 +430,26 @@
     "back_to_projects": "Back to Projects",
     "return_to_projects": "Back to Projects",
     "database_advisor": "Database Advisor"
+  },
+  "Reports": {
+    "title": "Reports & Analytics",
+    "subtitle": "View service usage, performance metrics, and optimization hints across the project.",
+    "api_overview": "API Overview",
+    "api_overview_desc": "Gateway request volume, latency, and error-rate statistics.",
+    "database": "Database",
+    "database_desc": "Database connections, disk utilization, and cache hit-rate statistics.",
+    "query_performance": "Query Performance",
+    "query_performance_desc": "Slow-query analysis and execution statistics powered by pg_stat_statements.",
+    "auth": "Auth Reports",
+    "auth_desc": "User sign-up, sign-in, and authentication event statistics.",
+    "storage": "Storage Reports",
+    "storage_desc": "Upload/download traffic and storage-space usage statistics.",
+    "advisors": "Performance Advisor",
+    "advisors_desc": "Database optimization suggestions and security audit insights.",
+    "database_linter": "Database Linter",
+    "database_linter_desc": "Health checks for schema design, indexes, and RLS policies.",
+    "data_sources_note": "Report data comes from PostgreSQL internal statistics views such as",
+    "data_sources_note_suffix": "and systemd logs. Some metrics require the corresponding extension to be enabled."
   },
   "Realtime": {
     "title": "Realtime",

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -331,6 +331,8 @@
     "rows": "返回行数",
     "extension_required": "需要开启系统扩展",
     "extension_desc": "您需要开启 pg_stat_statements 扩展才能查看慢查询指标。",
+    "access_unavailable_title": "指标暂时不可访问",
+    "access_unavailable_desc": "pg_stat_statements 已安装，但当前数据库角色无权读取其统计信息。请为扩展所在 schema 授权，或改用权限更高的数据库角色。",
     "enable_now": "立即开启 pg_stat_statements",
     "loading": "正在加载性能指标...",
     "error": "加载指标时发生错误"
@@ -428,6 +430,26 @@
     "back_to_projects": "返回项目列表",
     "return_to_projects": "返回项目列表",
     "database_advisor": "数据库顾问"
+  },
+  "Reports": {
+    "title": "报表与分析",
+    "subtitle": "查看项目各服务的使用统计、性能指标和优化建议。",
+    "api_overview": "API 概览",
+    "api_overview_desc": "API 网关请求量、延迟、错误率统计。",
+    "database": "数据库",
+    "database_desc": "数据库连接数、磁盘利用率、缓存命中率统计。",
+    "query_performance": "查询性能",
+    "query_performance_desc": "慢查询分析、执行统计，基于 pg_stat_statements。",
+    "auth": "Auth 报表",
+    "auth_desc": "用户注册、登录、认证事件统计。",
+    "storage": "Storage 报表",
+    "storage_desc": "文件上传下载量、存储空间使用统计。",
+    "advisors": "性能顾问",
+    "advisors_desc": "数据库性能优化建议和安全审计。",
+    "database_linter": "数据库检查",
+    "database_linter_desc": "表结构、索引、RLS 策略的健康检查。",
+    "data_sources_note": "报表数据来源于 PostgreSQL 内部统计视图（如",
+    "data_sources_note_suffix": "）和 systemd 日志。部分统计需要启用对应扩展。"
   },
   "Realtime": {
     "title": "实时订阅",

--- a/packages/web-console/src/routes/project/[ref]/reports/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/reports/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { t } from "svelte-i18n";
   import { BarChart3, Activity, Database, Shield, Zap, HardDrive, Clock, TrendingUp } from "lucide-svelte";
 
   let { children } = $props();
@@ -7,13 +8,13 @@
   const projectRef = $derived(page.params.ref);
 
   const TABS = $derived([
-    { id: "api-overview", label: "API 概览", icon: Activity },
-    { id: "database", label: "数据库", icon: Database },
-    { id: "query-performance", label: "查询性能", icon: Clock },
-    { id: "auth", label: "Auth 报表", icon: Shield },
-    { id: "storage", label: "Storage 报表", icon: HardDrive },
-    { id: "advisors", label: "性能顾问", icon: TrendingUp },
-    { id: "database-linter", label: "数据库检查", icon: BarChart3 },
+    { id: "api-overview", labelKey: "Reports.api_overview", icon: Activity },
+    { id: "database", labelKey: "Reports.database", icon: Database },
+    { id: "query-performance", labelKey: "Reports.query_performance", icon: Clock },
+    { id: "auth", labelKey: "Reports.auth", icon: Shield },
+    { id: "storage", labelKey: "Reports.storage", icon: HardDrive },
+    { id: "advisors", labelKey: "Reports.advisors", icon: TrendingUp },
+    { id: "database-linter", labelKey: "Reports.database_linter", icon: BarChart3 },
   ]);
 
   const currentTab = $derived(page.url.pathname.split("/reports/")[1]?.split("/")[0] || "");
@@ -22,10 +23,10 @@
 <div class="h-full flex flex-col pt-4">
   <div class="px-6 mb-6">
     <div class="flex items-center gap-2 text-sm text-muted-foreground mb-4">
-      <a href={`/project/${projectRef}/reports`} class="hover:text-foreground transition-colors">报表</a>
+      <a href={`/project/${projectRef}/reports`} class="hover:text-foreground transition-colors">{$t("Navigation.reports")}</a>
       {#if currentTab}
         <span>/</span>
-        <span class="text-foreground">{TABS.find(t => t.id === currentTab)?.label || currentTab}</span>
+        <span class="text-foreground">{$t(TABS.find((tab) => tab.id === currentTab)?.labelKey || "Navigation.reports")}</span>
       {/if}
     </div>
     <div class="flex items-center gap-2 overflow-x-auto pb-2 scrollbar-hide">
@@ -35,7 +36,7 @@
           class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-full whitespace-nowrap transition-colors {currentTab === tab.id ? 'bg-brand text-white shadow-md' : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'}"
         >
           <tab.icon size={14} />
-          {tab.label}
+          {$t(tab.labelKey)}
         </a>
       {/each}
     </div>

--- a/packages/web-console/src/routes/project/[ref]/reports/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/reports/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/state";
+  import { t } from "svelte-i18n";
   import { BarChart3, Activity, Database, Shield, Zap, HardDrive, Clock, TrendingUp, ArrowRight } from "lucide-svelte";
 
   const projectRef = $derived(page.params.ref);
@@ -7,56 +8,56 @@
   const REPORT_SECTIONS = [
     {
       id: "overview",
-      title: "API 概览",
-      desc: "API 网关请求量、延迟、错误率统计",
+      titleKey: "Reports.api_overview",
+      descKey: "Reports.api_overview_desc",
       icon: Activity,
       color: "text-blue-600 bg-blue-500/10",
       href: "api-overview",
     },
     {
       id: "database",
-      title: "数据库",
-      desc: "数据库连接数、磁盘利用率、缓存命中率统计",
+      titleKey: "Reports.database",
+      descKey: "Reports.database_desc",
       icon: Database,
       color: "text-violet-600 bg-violet-500/10",
       href: "database",
     },
     {
       id: "query-performance",
-      title: "查询性能",
-      desc: "慢查询分析、执行计划统计（pg_stat_statements）",
+      titleKey: "Reports.query_performance",
+      descKey: "Reports.query_performance_desc",
       icon: Clock,
       color: "text-amber-600 bg-amber-500/10",
       href: "query-performance",
     },
     {
       id: "auth",
-      title: "Auth 报表",
-      desc: "用户注册、登录、认证事件统计",
+      titleKey: "Reports.auth",
+      descKey: "Reports.auth_desc",
       icon: Shield,
       color: "text-green-600 bg-green-500/10",
       href: "auth",
     },
     {
       id: "storage",
-      title: "Storage 报表",
-      desc: "文件上传下载量、存储空间使用统计",
+      titleKey: "Reports.storage",
+      descKey: "Reports.storage_desc",
       icon: HardDrive,
       color: "text-teal-600 bg-teal-500/10",
       href: "storage",
     },
     {
       id: "advisors",
-      title: "性能顾问",
-      desc: "数据库性能优化建议和安全审计",
+      titleKey: "Reports.advisors",
+      descKey: "Reports.advisors_desc",
       icon: TrendingUp,
       color: "text-pink-600 bg-pink-500/10",
       href: "advisors",
     },
     {
       id: "database-linter",
-      title: "数据库检查",
-      desc: "表结构、索引、RLS 策略的健康检查",
+      titleKey: "Reports.database_linter",
+      descKey: "Reports.database_linter_desc",
       icon: BarChart3,
       color: "text-orange-600 bg-orange-500/10",
       href: "database-linter",
@@ -66,8 +67,8 @@
 
 <div class="h-full flex flex-col space-y-4">
   <div>
-    <h1 class="text-2xl font-bold">报表与分析</h1>
-    <p class="text-sm text-muted-foreground mt-1">查看项目各服务的使用统计、性能指标和优化建议</p>
+    <h1 class="text-2xl font-bold">{$t("Reports.title")}</h1>
+    <p class="text-sm text-muted-foreground mt-1">{$t("Reports.subtitle")}</p>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -80,16 +81,16 @@
           </div>
         </div>
         <h3 class="font-semibold text-sm flex items-center gap-2">
-          {section.title}
+          {$t(section.titleKey)}
           <ArrowRight size={14} class="opacity-0 group-hover:opacity-100 transition-opacity text-brand" />
         </h3>
-        <p class="text-[10px] text-muted-foreground mt-1 leading-relaxed">{section.desc}</p>
+        <p class="text-[10px] text-muted-foreground mt-1 leading-relaxed">{$t(section.descKey)}</p>
       </a>
     {/each}
   </div>
 
   <div class="rounded-lg border bg-blue-500/5 border-blue-500/20 p-3 flex items-start gap-2">
     <BarChart3 size={14} class="text-blue-600 mt-0.5 shrink-0" />
-    <p class="text-xs text-blue-700">报表数据来源于 PostgreSQL 内部统计视图（如 <code class="bg-blue-500/10 px-1 rounded">pg_stat_statements</code>、<code class="bg-blue-500/10 px-1 rounded">pg_stat_user_tables</code>）和 systemd 日志。部分统计需要启用对应扩展。</p>
+    <p class="text-xs text-blue-700">{$t("Reports.data_sources_note")} <code class="bg-blue-500/10 px-1 rounded">pg_stat_statements</code>、<code class="bg-blue-500/10 px-1 rounded">pg_stat_user_tables</code> {$t("Reports.data_sources_note_suffix")}</p>
   </div>
 </div>

--- a/packages/web-console/src/routes/project/[ref]/reports/query-performance/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/reports/query-performance/+page.svelte
@@ -14,6 +14,9 @@
     rows: number;
   }
 
+  const MISSING_EXTENSION = "MISSING_EXTENSION";
+  const ACCESS_UNAVAILABLE = "ACCESS_UNAVAILABLE";
+
   const projectRef = $derived(page.params.ref);
 
   const statsQuery = createQuery(() => ({
@@ -35,55 +38,53 @@
         throw new Error("MISSING_EXTENSION");
       }
 
-      const schemasToTry = ['', 'monitor.', 'extensions.'];
-      let lastError = null;
+      const schemasToTry = ["", "monitor.", "extensions."];
+      let sawMissingRelation = false;
+      let sawPermissionDenied = false;
+      let lastErrorMessage: string | null = null;
 
       for (const schemaPrefix of schemasToTry) {
-        try {
-          const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              sql: `SELECT query, calls, total_exec_time, mean_exec_time, rows 
-                    FROM ${schemaPrefix}pg_stat_statements 
-                    ORDER BY total_exec_time DESC LIMIT 100;`
-            })
-          });
-          const data = await res.json();
+        const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sql: `SELECT query, calls, total_exec_time, mean_exec_time, rows 
+                  FROM ${schemaPrefix}pg_stat_statements 
+                  ORDER BY total_exec_time DESC LIMIT 100;`
+          })
+        });
+        const data = await res.json();
 
-          if (!res.ok) {
-            lastError = data;
-            if (data?.message?.includes("pg_stat_statements") && data?.message?.includes("does not exist")) {
-              continue;
-            }
-            throw new Error(data?.message || data?.error || "Failed to query pg_stat_statements");
-          }
-          
-          if (data.error) {
-            lastError = data;
-            // If it's a "does not exist" error, continue to the next schema prefix
-            if (data.message?.includes("pg_stat_statements") && data.message?.includes("does not exist")) {
-              continue;
-            } else {
-              throw new Error(data.message || data.error);
-            }
-          }
-          
-          // Success
-          return data.rows || [];
+        if (!res.ok || data.error) {
+          const message = data?.message || data?.error || "Failed to query pg_stat_statements";
+          lastErrorMessage = message;
 
-        } catch (err: unknown) {
-          lastError = { message: (err instanceof Error ? err.message : String(err)) };
-          break; // Stop on non-recoverable error
+          if (message.includes("pg_stat_statements") && message.includes("does not exist")) {
+            sawMissingRelation = true;
+            continue;
+          }
+
+          if (message.includes("permission denied for schema")) {
+            sawPermissionDenied = true;
+            continue;
+          }
+
+          throw new Error(message);
         }
+
+        return data.rows || [];
       }
 
-      if (lastError) {
-         if (lastError.message?.includes("pg_stat_statements") && lastError.message?.includes("does not exist")) {
-           throw new Error("MISSING_EXTENSION");
-         } else {
-           throw new Error(lastError instanceof Error ? lastError.message : String(lastError) || lastError.error || "Unknown error");
-         }
+      if (sawPermissionDenied) {
+        throw new Error(ACCESS_UNAVAILABLE);
+      }
+
+      if (sawMissingRelation) {
+        throw new Error(MISSING_EXTENSION);
+      }
+
+      if (lastErrorMessage) {
+        throw new Error(lastErrorMessage);
       }
 
       return [];
@@ -116,8 +117,13 @@
   const stats = $derived((statsQuery.data || []) as QueryStat[]);
   const isLoading = $derived(statsQuery.isPending);
   const isEnabling = $derived(enableMutation.isPending);
-  const missingExtension = $derived(statsQuery.error?.message === "MISSING_EXTENSION");
-  const error = $derived(statsQuery.error && statsQuery.error.message !== "MISSING_EXTENSION" ? statsQuery.error.message : (enableMutation.error ? enableMutation.error.message : null));
+  const missingExtension = $derived(statsQuery.error?.message === MISSING_EXTENSION);
+  const accessUnavailable = $derived(statsQuery.error?.message === ACCESS_UNAVAILABLE);
+  const error = $derived(
+    statsQuery.error && statsQuery.error.message !== MISSING_EXTENSION && statsQuery.error.message !== ACCESS_UNAVAILABLE
+      ? statsQuery.error.message
+      : (enableMutation.error ? enableMutation.error.message : null)
+  );
 
   function formatMs(ms: number): string {
     if (ms < 1) return ms.toFixed(2) + " ms";
@@ -168,6 +174,14 @@
             <span>{$t("QueryPerformance.enable_now")}</span>
           {/if}
         </button>
+      </div>
+    {:else if accessUnavailable}
+      <div class="flex-1 flex flex-col items-center justify-center text-center gap-4 py-24 max-w-md mx-auto">
+        <div class="w-16 h-16 rounded-full bg-yellow-500/10 text-yellow-600 flex items-center justify-center mb-2">
+          <AlertTriangle size={32} />
+        </div>
+        <h3 class="text-lg font-semibold">{$t("QueryPerformance.access_unavailable_title")}</h3>
+        <p class="text-sm text-muted-foreground">{$t("QueryPerformance.access_unavailable_desc")}</p>
       </div>
     {:else}
       <div class="overflow-x-auto flex-1">

--- a/packages/web-console/src/routes/project/[ref]/reports/query-performance/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/reports/query-performance/+page.svelte
@@ -48,8 +48,8 @@
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            sql: `SELECT query, calls, total_exec_time, mean_exec_time, rows 
-                  FROM ${schemaPrefix}pg_stat_statements 
+            sql: `SELECT query, calls, total_exec_time, mean_exec_time, rows
+                  FROM ${schemaPrefix}pg_stat_statements
                   ORDER BY total_exec_time DESC LIMIT 100;`
           })
         });


### PR DESCRIPTION
## Summary
- localize report breadcrumbs, tabs, and cards
- turn query-performance permission/extension failures into friendly bilingual messages

## Verification
- login succeeds and browser smoke passes
- query-performance no longer shows [object Object]
- reports hub and query-performance switch cleanly between Chinese and English