### PR TITLE
fix: add body schema to /auth/login and /auth/verify routes

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1,4 +1,4 @@
-import { Elysia } from "elysia";
+import { Elysia, t } from "elysia";
 import { logger } from "./utils/logger";
 
 process.on("uncaughtException", (err: Error) => {
@@ -309,6 +309,12 @@ const app = new Elysia({ strictPath: false })
     }
     set.status = 401;
     return { success: false, message: "Invalid username or password", code: "401" };
+  }, {
+    body: t.Object({
+      username: t.String(),
+      password: t.String(),
+    }),
+    detail: { tags: ["auth"], summary: "Studio login" },
   })
   .post("/auth/verify", async ({ body }) => {
     const { token } = body as { token: string };
@@ -345,6 +351,11 @@ const app = new Elysia({ strictPath: false })
       });
       return { valid: false };
     }
+  }, {
+    body: t.Object({
+      token: t.String(),
+    }),
+    detail: { tags: ["auth"], summary: "Verify session token" },
   })
 
   // WebSocket routes (no HTTP auth guard; WS uses query token)


### PR DESCRIPTION
## Summary

Elysia 1.4.28 requires explicit body schema declarations for JSON POST routes. Without t.Object() schemas, the framework rejects JSON requests with 400 Bad Request, breaking the Studio login flow.

## Changes

- Import t from elysia alongside Elysia
- Add body schema to /auth/login (username + password strings)
- Add body schema to /auth/verify (token string)
- Add Swagger detail annotations for both routes

## Testing

- Deployed to VM and verified: Health check PASS, Auth login with JSON body PASS (previously 400), Project list/detail/services PASS, SQL Query PASS, Extensions PASS, API Keys PASS, Web Console HTML PASS, Swagger docs PASS. Full API deep test: 14/16 PASS