### PR TITLE
fix: resolve storage project refs from routing config

### DIFF
--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -9,7 +9,7 @@ import { DEFAULT_CORS_HEADERS, DEFAULT_CORS_EXPOSED } from '../services/gateway.
 import { backgroundTaskService } from "../services/background-task.service";
 import { edgeFunctionService } from "../services/edge-function.service";
 import { projectService } from "../services/project.service";
-import { resolveTenantPorts } from "../utils/project-routing";
+import { matchProjectRefFromHost, resolveTenantPorts } from "../utils/project-routing";
 import { resolveProjectRefFromApiKey } from "../utils/project-auth";
 import { verifyProjectJwtPayload } from "../utils/project-jwt";
 
@@ -283,18 +283,15 @@ async function getProjectRef(request: Request): Promise<string> {
             try {
                 const hostWithoutPort = host.split(':')[0];
                 const rows = await metaSql`
-                    SELECT ref
+                    SELECT ref, config
                     FROM projects
                     WHERE deleted_at IS NULL
                       AND status = 'active'
-                      AND (
-                        config->>'custom_domain' = ${hostWithoutPort}
-                        OR config->>'api_domain' = ${hostWithoutPort}
-                        OR config->>'custom_domain' = ${hostWithoutPort.replace(/^api\./, '')}
-                      )
-                    LIMIT 1
                 `;
-                if (rows.length > 0 && rows[0].ref !== apiKeyRef) return '';
+                const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
+                    matchProjectRefFromHost(hostWithoutPort, String(row.ref || ""), row.config),
+                );
+                if (matchedProject && matchedProject.ref !== apiKeyRef) return '';
             } catch(error: unknown) {
                 logger.warn("[SDK Proxy] Failed to validate API key host binding", {
                     apiKeyRef,
@@ -336,20 +333,20 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, request: Request)
 
         try {
             const rows = await metaSql`
-                SELECT ref
+                SELECT ref, config
                 FROM projects
                 WHERE ref = ${ref}
                   AND deleted_at IS NULL
                   AND status = 'active'
-                  AND (
-                    config->>'custom_domain' = ${host}
-                    OR config->>'api_domain' = ${host}
-                    OR config->>'studio_domain' = ${host}
-                    OR config->>'custom_domain' = ${host.replace(/^api\./, '')}
-                  )
                 LIMIT 1
             `;
-            if (rows.length > 0 && rows[0].ref === ref) return ref;
+            if (
+                rows.length > 0 &&
+                rows[0].ref === ref &&
+                matchProjectRefFromHost(host, ref, rows[0].config)
+            ) {
+                return ref;
+            }
         } catch (error: unknown) {
             logger.warn("[SDK Proxy] Failed to validate project header host binding", {
                 ref,

--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -32,6 +32,7 @@ import { StorageService } from "../services/storage.service";
 import { StorageRLS, mockObjects, normalizeStorageObjectSize } from "../services/storage-rls";
 import { logger } from "../utils/logger";
 import { config } from "../config";
+import { matchProjectRefFromHost } from "../utils/project-routing";
 
 const STORAGE_UPLOAD_MAX_BYTES = Number(process.env.STORAGE_UPLOAD_MAX_BYTES || config.maxRequestBodySize || 100 * 1024 * 1024);
 const TUS_MAX_SIZE = Number(process.env.TUS_MAX_SIZE || 100 * 1024 * 1024);
@@ -233,19 +234,20 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, host: string): Pr
     try {
         const { sql } = await import('../db');
         const rows = await sql`
-            SELECT ref
+            SELECT ref, config
             FROM projects
             WHERE ref = ${ref}
               AND deleted_at IS NULL
               AND status = 'active'
-              AND (
-                config->>'api_domain' = ${host}
-                OR config->>'custom_domain' = ${host}
-                OR config->>'studio_domain' = ${host}
-              )
             LIMIT 1
         `;
-        if (rows.length > 0 && String(rows[0].ref) === ref) return ref;
+        if (
+            rows.length > 0 &&
+            String(rows[0].ref) === ref &&
+            matchProjectRefFromHost(host, ref, rows[0].config)
+        ) {
+            return ref;
+        }
     } catch (error: unknown) {
         logger.warn("[StorageCompat] Failed to validate project header host binding", {
             ref,
@@ -285,18 +287,15 @@ async function getProjectRef(headers: Record<string, string | undefined>): Promi
         try {
             const { sql } = await import('../db');
             const rows = await sql`
-                SELECT ref
+                SELECT ref, config
                 FROM projects
                 WHERE deleted_at IS NULL
                   AND status = 'active'
-                  AND (
-                    config->>'api_domain' = ${host}
-                    OR config->>'custom_domain' = ${host}
-                    OR config->>'studio_domain' = ${host}
-                  )
-                LIMIT 1
             `;
-            if (rows.length > 0 && String(rows[0].ref) !== apiKeyRef) return '';
+            const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
+                matchProjectRefFromHost(host, String(row.ref || ""), row.config),
+            );
+            if (matchedProject && String(matchedProject.ref) !== apiKeyRef) return '';
         } catch (error: unknown) {
             logger.warn("[StorageCompat] Failed to validate API key host binding", {
                 apiKeyRef,

--- a/packages/management-api/src/utils/project-routing.ts
+++ b/packages/management-api/src/utils/project-routing.ts
@@ -32,7 +32,7 @@ export function resolveProjectBaseHost(projectRef: string): string {
 }
 
 export function normalizeProjectRoutingConfig(
-  projectConfig: ProjectRoutingConfig | string | null | undefined,
+  projectConfig: unknown,
 ): ProjectRoutingConfig | undefined {
   if (!projectConfig) return undefined;
   if (typeof projectConfig === "string") {
@@ -49,7 +49,10 @@ export function normalizeProjectRoutingConfig(
     }
     return { custom_domain: projectConfig };
   }
-  return projectConfig;
+  if (typeof projectConfig === "object" && !Array.isArray(projectConfig)) {
+    return projectConfig as ProjectRoutingConfig;
+  }
+  return undefined;
 }
 
 export function resolveProjectApiHost(
@@ -111,7 +114,7 @@ export function resolveTenantPorts(
 export function matchProjectRefFromHost(
   host: string,
   projectRef: string,
-  projectConfig: ProjectRoutingConfig | string | null | undefined,
+  projectConfig: unknown,
 ): boolean {
   const normalizedConfig = normalizeProjectRoutingConfig(projectConfig);
   const normalizedHost = host.split(":")[0].trim().toLowerCase();

--- a/packages/management-api/tests/unit/project-routing.test.ts
+++ b/packages/management-api/tests/unit/project-routing.test.ts
@@ -9,6 +9,7 @@ import {
   resolveProjectBaseHost,
   resolveProjectStudioHost,
   resolveProjectStudioUrl,
+  matchProjectRefFromHost,
 } from "../../src/utils/project-routing";
 
 const originalBaseDomain = config.baseDomain;
@@ -48,6 +49,14 @@ describe("project routing", () => {
   test("keeps non-JSON strings as legacy custom domains", () => {
     expect(normalizeProjectRoutingConfig("example.com")).toEqual({ custom_domain: "example.com" });
     expect(normalizeProjectRoutingConfig("{bad json")).toEqual({ custom_domain: "{bad json" });
+  });
+
+  test("matches hosts from serialized routing config strings", () => {
+    const configJson = '{"custom_domain":"api.aorist.net","studio_domain":"studio.aorist.net"}';
+
+    expect(matchProjectRefFromHost("api.aorist.net", "77az24zz7p", configJson)).toBe(true);
+    expect(matchProjectRefFromHost("studio.aorist.net", "77az24zz7p", configJson)).toBe(true);
+    expect(matchProjectRefFromHost("api.other.example", "77az24zz7p", configJson)).toBe(false);
   });
 
   test("uses ENABLE_SSL to resolve public API and Studio URL schemes", () => {

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -305,10 +305,16 @@ describe("sdkProxyRoutes functions proxy", () => {
   test("functions proxy accepts Kong-injected project ref on trusted custom API host without apikey", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
       const sqlSpy = trackSpy(spyOn(dbModule, "sql"));
+      let sawProjectLookup = false;
       sqlSpy.mockImplementation(async (...args: unknown[]) => {
         const text = String(args[0] ?? "");
         if (text.includes("SELECT ref")) {
-          return [{ ref: "proj_1" }];
+          sawProjectLookup = true;
+          expect(text).not.toContain("config->>");
+          return [{
+            ref: "proj_1",
+            config: '{"custom_domain":"api.aorist.net"}',
+          }];
         }
         return [];
       });
@@ -324,6 +330,7 @@ describe("sdkProxyRoutes functions proxy", () => {
       expect(response.status).toBe(200);
       expect(calls).toHaveLength(1);
       expect(calls[0]?.url).toBe("http://127.0.0.1:9000/functions/v1/aorist-platform/me/identity");
+      expect(sawProjectLookup).toBe(true);
     });
   });
 

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -46,10 +46,16 @@ afterEach(() => {
 describe("storageCompatRoutes supabase-js compatibility", () => {
   test("allows public object reads from trusted custom-domain storage routes without apikey", async () => {
     const sqlSpy = spyOn(dbModule, "sql");
+    let sawProjectLookup = false;
     sqlSpy.mockImplementation(async (...args: unknown[]) => {
       const text = String(args[0] ?? "");
       if (text.includes("FROM projects")) {
-        return [{ ref: "proj_from_header" }];
+        sawProjectLookup = true;
+        expect(text).not.toContain("config->>");
+        return [{
+          ref: "proj_from_header",
+          config: '{"custom_domain":"api.example.com"}',
+        }];
       }
       return [];
     });
@@ -87,6 +93,7 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("ok\n");
     expect(downloadSpy).toHaveBeenCalledWith("proj_from_header", "avatars", "public.txt");
+    expect(sawProjectLookup).toBe(true);
     sqlSpy.mockRestore();
     bucketSpy.mockRestore();
     objectSpy.mockRestore();


### PR DESCRIPTION
## Summary
- resolve Storage and SDK proxy project refs by loading project routing config and using the existing host matcher
- support serialized JSON routing config values when validating custom API hosts
- cover public Storage and SDK proxy no-apikey requests with regression tests

## Verification
- bun test packages/management-api/tests/unit/project-routing.test.ts packages/management-api/tests/unit/storage-compat.sdk.test.ts packages/management-api/tests/unit/sdk-proxy.functions.test.ts
- cd packages/management-api && bun run typecheck
- git diff --check