### PR TITLE
fix(edge-runtime): preserve background invocation auth

### DIFF
--- a/packages/edge-runtime/background-forward.test.ts
+++ b/packages/edge-runtime/background-forward.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildBackgroundForwardedRequest,
+  createBackgroundInvocationToken,
+} from "./background-forward";
+
+describe("background forwarded request", () => {
+  test("uses a tenant-scoped background token without forwarding the master token", async () => {
+    const request = new Request("http://edge-runtime/internal/background/proj/fn", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer management-master-token",
+        apikey: "management-api-key",
+        "x-supacloud-internal-auth": "Bearer management-master-token",
+        "x-supacloud-internal-token": "legacy-management-master-token",
+        "x-supacloud-auth-authorization": "Bearer user-token",
+        "x-supacloud-auth-apikey": "anon-key",
+      },
+      body: JSON.stringify({ ok: true }),
+    });
+
+    const forwarded = buildBackgroundForwardedRequest(request, "background-token");
+
+    expect(forwarded.headers.get("x-supacloud-internal-auth")).toBe("Bearer background-token");
+    expect(forwarded.headers.get("x-supacloud-internal-token")).toBeNull();
+    expect(forwarded.headers.get("authorization")).toBe("Bearer user-token");
+    expect(forwarded.headers.get("apikey")).toBe("anon-key");
+    expect(forwarded.headers.get("x-supacloud-auth-authorization")).toBeNull();
+    expect(forwarded.headers.get("x-supacloud-auth-apikey")).toBeNull();
+    expect(await forwarded.text()).toBe(JSON.stringify({ ok: true }));
+  });
+
+  test("removes privileged headers when no user auth was preserved", () => {
+    const request = new Request("http://edge-runtime/internal/background/proj/fn", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer management-master-token",
+        apikey: "management-api-key",
+        "x-supacloud-internal-auth": "Bearer management-master-token",
+      },
+      body: "{}",
+    });
+
+    const forwarded = buildBackgroundForwardedRequest(request, "background-token");
+
+    expect(forwarded.headers.get("x-supacloud-internal-auth")).toBe("Bearer background-token");
+    expect(forwarded.headers.get("authorization")).toBeNull();
+    expect(forwarded.headers.get("apikey")).toBeNull();
+  });
+
+  test("creates a fresh invocation token", () => {
+    const first = createBackgroundInvocationToken();
+    const second = createBackgroundInvocationToken();
+
+    expect(first).toMatch(/^[0-9a-f-]{36}$/);
+    expect(second).toMatch(/^[0-9a-f-]{36}$/);
+    expect(second).not.toBe(first);
+  });
+});

--- a/packages/edge-runtime/background-forward.test.ts
+++ b/packages/edge-runtime/background-forward.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildBackgroundForwardDispatch,
   buildBackgroundForwardedRequest,
   createBackgroundInvocationToken,
 } from "./background-forward";
@@ -55,5 +56,31 @@ describe("background forwarded request", () => {
     expect(first).toMatch(/^[0-9a-f-]{36}$/);
     expect(second).toMatch(/^[0-9a-f-]{36}$/);
     expect(second).not.toBe(first);
+  });
+
+  test("keeps forwarded header and tenant env token in sync", () => {
+    const request = new Request("http://edge-runtime/internal/background/proj/fn/work", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer management-master-token",
+        "x-supacloud-internal-auth": "Bearer management-master-token",
+        "x-supacloud-auth-authorization": "Bearer user-token",
+      },
+      body: "{}",
+    });
+
+    const dispatch = buildBackgroundForwardDispatch(
+      request,
+      {
+        SUPABASE_URL: "https://api.example.com",
+      },
+      "background-token",
+    );
+
+    expect(dispatch.backgroundInternalToken).toBe("background-token");
+    expect(dispatch.forwardedRequest.headers.get("x-supacloud-internal-auth")).toBe("Bearer background-token");
+    expect(dispatch.forwardedRequest.headers.get("authorization")).toBe("Bearer user-token");
+    expect(dispatch.tenantEnv.SUPACLOUD_BACKGROUND_INTERNAL_TOKEN).toBe("background-token");
+    expect(dispatch.tenantEnv.SUPABASE_URL).toBe("https://api.example.com");
   });
 });

--- a/packages/edge-runtime/background-forward.ts
+++ b/packages/edge-runtime/background-forward.ts
@@ -1,0 +1,40 @@
+export function createBackgroundInvocationToken(): string {
+  return crypto.randomUUID();
+}
+
+export function buildBackgroundForwardedRequest(
+  request: Request,
+  backgroundInternalToken?: string,
+): Request {
+  const headers = new Headers(request.headers);
+  const originalAuthorization = headers.get("x-supacloud-auth-authorization");
+  const originalApikey = headers.get("x-supacloud-auth-apikey");
+
+  headers.delete("x-supacloud-internal-auth");
+  headers.delete("x-supacloud-internal-token");
+  headers.delete("x-supacloud-auth-authorization");
+  headers.delete("x-supacloud-auth-apikey");
+
+  if (backgroundInternalToken) {
+    headers.set("x-supacloud-internal-auth", `Bearer ${backgroundInternalToken}`);
+  }
+
+  if (originalAuthorization) {
+    headers.set("authorization", originalAuthorization);
+  } else {
+    headers.delete("authorization");
+  }
+
+  if (originalApikey) {
+    headers.set("apikey", originalApikey);
+  } else {
+    headers.delete("apikey");
+  }
+
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: ["GET", "HEAD"].includes(request.method) ? undefined : request.body,
+    duplex: ["GET", "HEAD"].includes(request.method) ? undefined : "half",
+  } as RequestInit & { duplex?: "half" });
+}

--- a/packages/edge-runtime/background-forward.ts
+++ b/packages/edge-runtime/background-forward.ts
@@ -1,3 +1,11 @@
+import { withBackgroundInternalToken } from "./tenant-env";
+
+export interface BackgroundForwardDispatch {
+  forwardedRequest: Request;
+  backgroundInternalToken: string;
+  tenantEnv: Record<string, string>;
+}
+
 export function createBackgroundInvocationToken(): string {
   return crypto.randomUUID();
 }
@@ -37,4 +45,16 @@ export function buildBackgroundForwardedRequest(
     body: ["GET", "HEAD"].includes(request.method) ? undefined : request.body,
     duplex: ["GET", "HEAD"].includes(request.method) ? undefined : "half",
   } as RequestInit & { duplex?: "half" });
+}
+
+export function buildBackgroundForwardDispatch(
+  request: Request,
+  tenantEnv: Record<string, string>,
+  backgroundInternalToken = createBackgroundInvocationToken(),
+): BackgroundForwardDispatch {
+  return {
+    forwardedRequest: buildBackgroundForwardedRequest(request, backgroundInternalToken),
+    backgroundInternalToken,
+    tenantEnv: withBackgroundInternalToken(tenantEnv, backgroundInternalToken),
+  };
 }

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -9,8 +9,7 @@ import {
 } from "./tenant-env";
 import { normalizeJwtJwks, verifyEdgeRuntimeJwt } from "./jwt-verifier";
 import {
-  buildBackgroundForwardedRequest,
-  createBackgroundInvocationToken,
+  buildBackgroundForwardDispatch,
 } from "./background-forward";
 import path from "path";
 import fs from "fs/promises";
@@ -153,6 +152,7 @@ async function dispatchFunction(
   opts?: {
     background?: boolean;
     backgroundInternalToken?: string;
+    tenantEnv?: Record<string, string>;
     cancelKey?: string;
     onLog?: (entry: {
       timestamp: string;
@@ -169,7 +169,7 @@ async function dispatchFunction(
     const versionSuffix = requestedVersion ? `_v${requestedVersion}` : "";
     const functionId = `${projectRef}_${functionName}${versionSuffix}`;
     const targetPool = opts?.background ? backgroundPool : pool;
-    const tenantEnv = await loadTenantEnv(projectRef);
+    const tenantEnv = opts?.tenantEnv || await loadTenantEnv(projectRef);
     const backgroundInternalToken = opts?.backgroundInternalToken || INTERNAL_TOKEN;
     const runtimeLogContext = {
       functionVersion: activeVersion,
@@ -526,16 +526,19 @@ const app = new Elysia()
       message: string;
     }> = [];
 
-    const backgroundInternalToken = createBackgroundInvocationToken();
-    const forwardedRequest = buildBackgroundForwardedRequest(c.request, backgroundInternalToken);
+    const backgroundDispatch = buildBackgroundForwardDispatch(
+      c.request,
+      await loadTenantEnv(c.params.ref),
+    );
     const response = await dispatchFunction(
       c.params.ref,
       c.params.functionName,
-      forwardedRequest,
+      backgroundDispatch.forwardedRequest,
       setHeaders,
       {
         background: true,
-        backgroundInternalToken,
+        backgroundInternalToken: backgroundDispatch.backgroundInternalToken,
+        tenantEnv: backgroundDispatch.tenantEnv,
         cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
         onLog: (entry) => {
           logs.push(entry);
@@ -574,16 +577,19 @@ const app = new Elysia()
       message: string;
     }> = [];
 
-    const backgroundInternalToken = createBackgroundInvocationToken();
-    const forwardedRequest = buildBackgroundForwardedRequest(c.request, backgroundInternalToken);
+    const backgroundDispatch = buildBackgroundForwardDispatch(
+      c.request,
+      await loadTenantEnv(c.params.ref),
+    );
     const response = await dispatchFunction(
       c.params.ref,
       c.params.functionName,
-      forwardedRequest,
+      backgroundDispatch.forwardedRequest,
       setHeaders,
       {
         background: true,
-        backgroundInternalToken,
+        backgroundInternalToken: backgroundDispatch.backgroundInternalToken,
+        tenantEnv: backgroundDispatch.tenantEnv,
         cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
         onLog: (entry) => {
           logs.push(entry);

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -8,6 +8,10 @@ import {
   withBackgroundInternalToken,
 } from "./tenant-env";
 import { normalizeJwtJwks, verifyEdgeRuntimeJwt } from "./jwt-verifier";
+import {
+  buildBackgroundForwardedRequest,
+  createBackgroundInvocationToken,
+} from "./background-forward";
 import path from "path";
 import fs from "fs/promises";
 
@@ -148,6 +152,7 @@ async function dispatchFunction(
   setHeaders: Record<string, string>,
   opts?: {
     background?: boolean;
+    backgroundInternalToken?: string;
     cancelKey?: string;
     onLog?: (entry: {
       timestamp: string;
@@ -165,6 +170,7 @@ async function dispatchFunction(
     const functionId = `${projectRef}_${functionName}${versionSuffix}`;
     const targetPool = opts?.background ? backgroundPool : pool;
     const tenantEnv = await loadTenantEnv(projectRef);
+    const backgroundInternalToken = opts?.backgroundInternalToken || INTERNAL_TOKEN;
     const runtimeLogContext = {
       functionVersion: activeVersion,
       executionId: setHeaders["x-sb-execution-id"] || null,
@@ -175,7 +181,7 @@ async function dispatchFunction(
       functionPath,
       projectRoot,
       env: opts?.background
-        ? withBackgroundInternalToken(tenantEnv, INTERNAL_TOKEN)
+        ? withBackgroundInternalToken(tenantEnv, backgroundInternalToken)
         : tenantEnv,
       request,
       cancelKey: opts?.cancelKey,
@@ -260,35 +266,6 @@ function verifyInternalAuth(request: Request): boolean {
 
 function requireInternalAuth(request: Request): Response | undefined {
   return verifyInternalAuth(request) ? undefined : unauthorized();
-}
-
-function buildBackgroundForwardedRequest(request: Request): Request {
-  const headers = new Headers(request.headers);
-  const originalAuthorization = headers.get("x-supacloud-auth-authorization");
-  const originalApikey = headers.get("x-supacloud-auth-apikey");
-
-  headers.delete("x-supacloud-internal-auth");
-  headers.delete("x-supacloud-auth-authorization");
-  headers.delete("x-supacloud-auth-apikey");
-
-  if (originalAuthorization) {
-    headers.set("authorization", originalAuthorization);
-  } else {
-    headers.delete("authorization");
-  }
-
-  if (originalApikey) {
-    headers.set("apikey", originalApikey);
-  } else {
-    headers.delete("apikey");
-  }
-
-  return new Request(request.url, {
-    method: request.method,
-    headers,
-    body: ["GET", "HEAD"].includes(request.method) ? undefined : request.body,
-    duplex: ["GET", "HEAD"].includes(request.method) ? undefined : "half",
-  } as RequestInit & { duplex?: "half" });
 }
 
 const configCache = new Map<
@@ -549,7 +526,8 @@ const app = new Elysia()
       message: string;
     }> = [];
 
-    const forwardedRequest = buildBackgroundForwardedRequest(c.request);
+    const backgroundInternalToken = createBackgroundInvocationToken();
+    const forwardedRequest = buildBackgroundForwardedRequest(c.request, backgroundInternalToken);
     const response = await dispatchFunction(
       c.params.ref,
       c.params.functionName,
@@ -557,6 +535,7 @@ const app = new Elysia()
       setHeaders,
       {
         background: true,
+        backgroundInternalToken,
         cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
         onLog: (entry) => {
           logs.push(entry);
@@ -595,7 +574,8 @@ const app = new Elysia()
       message: string;
     }> = [];
 
-    const forwardedRequest = buildBackgroundForwardedRequest(c.request);
+    const backgroundInternalToken = createBackgroundInvocationToken();
+    const forwardedRequest = buildBackgroundForwardedRequest(c.request, backgroundInternalToken);
     const response = await dispatchFunction(
       c.params.ref,
       c.params.functionName,
@@ -603,6 +583,7 @@ const app = new Elysia()
       setHeaders,
       {
         background: true,
+        backgroundInternalToken,
         cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
         onLog: (entry) => {
           logs.push(entry);


### PR DESCRIPTION
## Task Contract

### Goal
Fix SupaCloud Edge Runtime background dispatch so tenant Edge Functions can verify the SupaCloud background invocation contract without receiving the management-plane master internal token.

### Non-goals
- Do not change management-api task claim/concurrency semantics.
- Do not change tenant application task business logic.
- Do not expose global `EDGE_RUNTIME_MASTER_KEY` / `MASTER_TOKEN` to tenant function code.

### Acceptance Criteria
- Background route invocation forwards a tenant-visible internal auth header.
- The forwarded `x-supacloud-internal-auth` token matches `SUPACLOUD_BACKGROUND_INTERNAL_TOKEN` injected into the tenant function env.
- Management-plane internal headers and fallback authorization/apikey values are stripped unless the original user auth/apikey headers were explicitly preserved by the dispatcher.
- Both background route forms use the same dispatch context.

### Risk
Medium. This touches the auth boundary between management-api, edge-runtime, and tenant functions. The implementation narrows exposure by replacing the management token with a one-time background invocation token.

### Rollback
Revert the PR commits and redeploy edge-runtime; background dispatch returns to the previous behavior.

## Summary
- generate a per-invocation background internal token for Edge Runtime background dispatch
- forward that token to tenant functions via `x-supacloud-internal-auth` while injecting the same value as `SUPACLOUD_BACKGROUND_INTERNAL_TOKEN`
- strip management-plane internal/auth headers before tenant function invocation and preserve only the original user auth/apikey headers
- route both versioned and non-versioned background endpoints through the same background dispatch context
- add focused tests for the background forwarded request contract and header/env token consistency

## Verification
- `bun test background-forward.test.ts tenant-env.test.ts`
- `bun test *.test.ts`
- `bun run typecheck`
- `bun run build:amd64`
- `git diff --check`