### PR TITLE
fix: separate platform mirror table, invoker circuit breaker, WorkerPool NaN metrics

### DIFF
--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -64,3 +64,86 @@ describe("WorkerPool EdgeRuntime.waitUntil", () => {
     }
   });
 });
+
+describe("WorkerPool metrics NaN fix", () => {
+  test("avg_queue_wait_ms is 0 (never NaN) for immediate dispatch", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-nan-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch() {
+          return new Response("ok", { status: 200 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const res = await pool.dispatch({
+        functionId: "test_nan",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/test"),
+      });
+      expect(res.status).toBe(200);
+
+      const metrics = pool.snapshotMetrics("test");
+      for (const [key, value] of Object.entries(metrics)) {
+        expect(Number.isNaN(value)).toBe(false);
+      }
+      expect(metrics["test_avg_queue_wait_ms"]).toBe(0);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("queued dispatch produces non-NaN avg_queue_wait_ms", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-nan-q-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch() {
+          await Bun.sleep(10);
+          return new Response("ok", { status: 200 });
+        }
+      }
+    `);
+
+    // Pool size 1, dispatch 2 requests to force one to queue
+    const pool = new WorkerPool({ size: 1, requestTimeout: 5_000 });
+    pools.push(pool);
+
+    try {
+      const [res1, res2] = await Promise.all([
+        pool.dispatch({
+          functionId: "test_nan_q1",
+          functionPath,
+          projectRoot,
+          env: {},
+          request: new Request("http://edge.local/functions/v1/test1"),
+        }),
+        pool.dispatch({
+          functionId: "test_nan_q2",
+          functionPath,
+          projectRoot,
+          env: {},
+          request: new Request("http://edge.local/functions/v1/test2"),
+        }),
+      ]);
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+
+      const metrics = pool.snapshotMetrics("testq");
+      for (const [key, value] of Object.entries(metrics)) {
+        expect(Number.isNaN(value)).toBe(false);
+      }
+      // At least one request was queued, so total_queue_wait_ms > 0
+      expect(metrics["testq_total_queue_wait_ms"]).toBeGreaterThan(0);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -8,6 +8,7 @@ interface DispatchOptions {
   env: Record<string, string>;
   request: Request;
   cancelKey?: string;
+  envLoadMs?: number;
   onLog?: (entry: {
     timestamp: string;
     stream: "stdout" | "stderr";
@@ -31,6 +32,9 @@ export class WorkerPool {
   private inFlight = new Map<string, { cancel: () => void }>();
   private totalRequests = 0;
   private totalInvalidations = 0;
+  private totalEnvLoadMs = 0;
+  private totalQueueWaitMs = 0;
+  private totalWorkerExecMs = 0;
   private activeWorkers = new Set<Worker>();
   private workerMetadata = new Map<
     Worker,
@@ -70,6 +74,8 @@ export class WorkerPool {
     }
 
     this.totalRequests++;
+    if (opts.envLoadMs) this.totalEnvLoadMs += opts.envLoadMs;
+    const queueStart = performance.now();
     return new Promise<Response>((resolve, reject) => {
       if (this.queue.length >= MAX_QUEUE_SIZE) {
         resolve(new Response(JSON.stringify({ error: "Too many concurrent requests, please retry" }), {
@@ -79,6 +85,7 @@ export class WorkerPool {
         return;
       }
 
+      (opts as any)._queueStart = queueStart;
       const worker = this.idle.pop();
       if (worker) {
         this.execute(worker, opts, resolve).catch(reject);
@@ -93,6 +100,9 @@ export class WorkerPool {
     opts: DispatchOptions,
     resolve: (r: Response) => void,
   ) {
+    const queueStart = (opts as any)._queueStart as number | undefined;
+    const queueWaitMs = queueStart ? Math.round(performance.now() - queueStart) : 0;
+    this.totalQueueWaitMs += queueWaitMs;
     const cancelGraceMs = 3_000;
     const cancelledResponse = () =>
       new Response(JSON.stringify({ error: "Task cancelled" }), {
@@ -188,6 +198,7 @@ export class WorkerPool {
       }
     }
 
+    const execStart = performance.now();
     worker.postMessage({
       functionId: opts.functionId,
       functionPath: opts.functionPath,
@@ -268,6 +279,8 @@ export class WorkerPool {
         return;
       }
 
+      const workerExecMs = Math.round(performance.now() - execStart);
+      this.totalWorkerExecMs += workerExecMs;
       clearTimeout(timeout);
       cleanupInFlight();
       clearCancellationState();
@@ -428,14 +441,10 @@ export class WorkerPool {
   }
 
   getMetrics(): string {
-    return [
-      `supacloud_edge_active_workers ${this.config.size - this.idle.length}`,
-      `supacloud_edge_idle_workers ${this.idle.length}`,
-      `supacloud_edge_queue_length ${this.queue.length}`,
-      `supacloud_edge_total_requests ${this.totalRequests}`,
-      `supacloud_edge_total_invalidations ${this.totalInvalidations}`,
-      `supacloud_edge_tainted_workers ${this.tainted.size}`,
-    ].join("\n");
+    const snapshot = this.snapshotMetrics();
+    return Object.entries(snapshot)
+      .map(([key, value]) => `${key} ${value}`)
+      .join("\n");
   }
 
   invalidateModule(functionId: string): void {
@@ -506,6 +515,13 @@ export class WorkerPool {
       [`${prefix}_total_requests`]: this.totalRequests,
       [`${prefix}_total_invalidations`]: this.totalInvalidations,
       [`${prefix}_tainted_workers`]: this.tainted.size,
+      [`${prefix}_total_env_load_ms`]: this.totalEnvLoadMs,
+      [`${prefix}_total_queue_wait_ms`]: this.totalQueueWaitMs,
+      [`${prefix}_total_worker_exec_ms`]: this.totalWorkerExecMs,
+      [`${prefix}_avg_env_load_ms`]: this.totalRequests > 0 ? Math.round(this.totalEnvLoadMs / this.totalRequests) : 0,
+      [`${prefix}_avg_queue_wait_ms`]: this.totalRequests > 0 ? Math.round(this.totalQueueWaitMs / this.totalRequests) : 0,
+      [`${prefix}_total_queued_requests`]: this.totalQueueWaitMs > 0 ? this.totalRequests : 0,
+      [`${prefix}_avg_worker_exec_ms`]: this.totalRequests > 0 ? Math.round(this.totalWorkerExecMs / this.totalRequests) : 0,
     };
   }
 

--- a/packages/management-api/src/repositories/task.repository.ts
+++ b/packages/management-api/src/repositories/task.repository.ts
@@ -702,6 +702,53 @@ export async function releaseTask(id: string, nextRunAt: Date, error?: string): 
   });
 }
 
+export async function transitionTaskToRunning(
+  id: string,
+  task: ProjectTask,
+  leaseSeconds: number,
+): Promise<{ task: ProjectTask | null; attempt: ProjectTaskAttempt | null }> {
+  return withRetry("TaskRepository.transitionTaskToRunning", async () => {
+    const [updated] = await sql`
+      UPDATE project_tasks
+      SET status = ${TaskStatuses.RUNNING},
+          lease_until = NOW() + (${leaseSeconds} * INTERVAL '1 second'),
+          updated_at = NOW()
+      WHERE id = ${id}
+      RETURNING *
+    `;
+
+    if (!updated) return { task: null, attempt: null };
+
+    const [attempt] = await sql`
+      INSERT INTO project_task_attempts (
+        task_id, project_ref, attempt_no, status, started_at
+      )
+      VALUES (
+        ${id},
+        ${task.project_ref},
+        ${task.attempt || 1},
+        'running',
+        NOW()
+      )
+      ON CONFLICT (task_id, attempt_no)
+      DO UPDATE SET
+        status = 'running',
+        started_at = NOW(),
+        completed_at = NULL,
+        duration_ms = NULL,
+        error = NULL,
+        response_status = NULL,
+        updated_at = NOW()
+      RETURNING *
+    `;
+
+    return {
+      task: mapTask(updated),
+      attempt: attempt ? mapAttempt(attempt) : null,
+    };
+  });
+}
+
 export async function extendLease(id: string, leaseSeconds: number): Promise<ProjectTask | null> {
   return withRetry("TaskRepository.extendLease", async () => {
     const [task] = await sql`
@@ -955,6 +1002,7 @@ export const taskRepository = {
   countQueueMessagesCreatedSince,
   countActiveTasksForProject,
   releaseTask,
+  transitionTaskToRunning,
   extendLease,
   requestTaskCancellation,
   startTaskAttempt,

--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -623,6 +623,131 @@ BEGIN
 EXCEPTION WHEN OTHERS THEN NULL;
 END $$;
 
+-- 18. Platform background task mirror table + User deletion fence
+-- Mirror table stores platform background invocation state separately from
+-- the business public.tasks table (which has incompatible columns/statuses).
+CREATE TABLE IF NOT EXISTS public.background_task_mirrors (
+  id               UUID PRIMARY KEY,
+  project_ref      TEXT NOT NULL,
+  task_type        TEXT NOT NULL DEFAULT 'edge_function',
+  function_slug    TEXT,
+  status           TEXT NOT NULL DEFAULT 'pending'
+                   CHECK (status IN ('pending','leased','running','retry_scheduled',
+                                     'succeeded','failed','dead_lettered','cancelled')),
+  invoker_user_id  UUID,
+  attempt          INTEGER NOT NULL DEFAULT 1,
+  max_attempts     INTEGER NOT NULL DEFAULT 3,
+  trace_id         TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE public.background_task_mirrors ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.background_task_mirrors
+  TO postgres, supabase_auth_admin, supabase_admin;
+
+CREATE INDEX IF NOT EXISTS idx_bg_task_mirrors_invoker_active
+  ON public.background_task_mirrors(invoker_user_id, status)
+  WHERE status IN ('pending','leased','running','retry_scheduled');
+
+CREATE INDEX IF NOT EXISTS idx_bg_task_mirrors_status
+  ON public.background_task_mirrors(status);
+
+-- 辅助函数：检查用户是否有未终态的 platform background tasks
+-- Returns 'active' | 'inactive' | 'unknown' (three-state to avoid silent false on errors)
+CREATE OR REPLACE FUNCTION public.has_active_background_tasks(p_user_id UUID)
+RETURNS TEXT AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'background_task_mirrors'
+  ) THEN
+    RAISE NOTICE 'has_active_background_tasks: background_task_mirrors table missing for user %', p_user_id;
+    RETURN 'unknown';
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.background_task_mirrors
+  WHERE invoker_user_id = p_user_id
+    AND status IN ('pending','leased','running','retry_scheduled');
+
+  IF v_count > 0 THEN
+    RETURN 'active';
+  END IF;
+
+  RETURN 'inactive';
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'has_active_background_tasks: exception for user % — %', p_user_id, SQLERRM;
+  RETURN 'unknown';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+-- 辅助函数：安全软删除用户（标记 deleted_at，但不硬删）
+-- 在 GoTrue DELETE 触发之前，检查是否有活跃任务
+CREATE OR REPLACE FUNCTION public.soft_delete_user_if_no_active_tasks()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_task_state TEXT;
+BEGIN
+  IF OLD.deleted_at IS NOT NULL THEN
+    RETURN OLD;
+  END IF;
+
+  UPDATE auth.users SET deleted_at = NOW() WHERE id = OLD.id;
+
+  v_task_state := public.has_active_background_tasks(OLD.id);
+
+  IF v_task_state = 'active' THEN
+    RETURN NULL;
+  END IF;
+
+  IF v_task_state = 'unknown' THEN
+    RAISE NOTICE 'soft_delete_user_if_no_active_tasks: degraded/unknown for user %, blocking hard delete', OLD.id;
+    RETURN NULL;
+  END IF;
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 仅在 auth.users 上无此触发器时创建
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'auth_users_delete_fence'
+  ) THEN
+    CREATE TRIGGER auth_users_delete_fence
+      BEFORE DELETE ON auth.users
+      FOR EACH ROW
+      EXECUTE FUNCTION public.soft_delete_user_if_no_active_tasks();
+  END IF;
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- 辅助函数：清理已无活跃任务的软删用户（定期调用）
+CREATE OR REPLACE FUNCTION public.hard_delete_soft_deleted_users()
+RETURNS INT AS $$
+DECLARE
+  deleted_count INT := 0;
+  user_record RECORD;
+  v_task_state TEXT;
+BEGIN
+  FOR user_record IN
+    SELECT id FROM auth.users
+    WHERE deleted_at IS NOT NULL
+      AND deleted_at < NOW() - INTERVAL '1 hour'
+  LOOP
+    v_task_state := public.has_active_background_tasks(user_record.id);
+    IF v_task_state = 'inactive' THEN
+      DELETE FROM auth.users WHERE id = user_record.id;
+      deleted_count := deleted_count + 1;
+    END IF;
+  END LOOP;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
 `;
 
 

--- a/packages/management-api/src/services/background-function-worker.ts
+++ b/packages/management-api/src/services/background-function-worker.ts
@@ -10,6 +10,7 @@ import { projectService } from "./project.service";
 import { decryptSecretIfNeeded } from "../utils/secret-crypto";
 import { createHmac } from "node:crypto";
 import { getProjectDb, resolveDbName } from "../db";
+import { createBackgroundTaskMirrorIfUserExists } from "../services/background-task.service";
 
 interface InvocationEnvelope {
   method?: string;
@@ -32,6 +33,78 @@ const DEFAULT_CONCURRENCY_PER_PROJECT = Number(
   process.env.BACKGROUND_TASKS_PER_PROJECT || String(DEFAULT_BACKGROUND_TASK_SETTINGS.concurrency),
 );
 const WORKER_ID = `bgw-${process.pid}`;
+
+// ─── Invoker existence cache + in-flight coalescing ─────────────────────
+interface InvokerCacheEntry {
+  exists: boolean;
+  expiresAt: number;
+}
+
+const invokerCache = new Map<string, InvokerCacheEntry>();
+const INVOKER_POSITIVE_TTL = 15_000;  // 用户存在时缓存 15s
+const INVOKER_NEGATIVE_TTL = 2_000;   // 用户不存在时缓存 2s（快速重试）
+
+const invokerInflight = new Map<string, Promise<boolean>>();
+
+// ─── Invoker DB unknown (degraded) tracking + circuit breaker ──────────────
+const INVOKER_UNKNOWN_WINDOW_MS = 60_000;   // 1-minute sliding window
+const INVOKER_UNKNOWN_THRESHOLD = 10;       // 10 unknowns in window → circuit open
+const INVOKER_CIRCUIT_OPEN_DURATION_MS = 30_000; // 30s cooldown when circuit is open
+
+interface UnknownEvent {
+  timestamp: number;
+  projectRef: string;
+  error: string;
+}
+
+const invokerUnknownEvents: UnknownEvent[] = [];
+let invokerCircuitOpenUntil = 0;  // 0 = circuit closed
+
+function recordInvokerUnknown(projectRef: string, error: string): void {
+  const now = Date.now();
+  invokerUnknownEvents.push({ timestamp: now, projectRef, error });
+
+  // Prune events outside the sliding window
+  const cutoff = now - INVOKER_UNKNOWN_WINDOW_MS;
+  while (invokerUnknownEvents.length > 0 && invokerUnknownEvents[0].timestamp < cutoff) {
+    invokerUnknownEvents.shift();
+  }
+
+  logger.warn("[BackgroundFunctionWorker] invoker DB unknown (degraded)", {
+    projectRef,
+    error,
+    windowCount: invokerUnknownEvents.length,
+    threshold: INVOKER_UNKNOWN_THRESHOLD,
+  });
+
+  // Open circuit breaker if threshold exceeded
+  if (invokerUnknownEvents.length >= INVOKER_UNKNOWN_THRESHOLD && invokerCircuitOpenUntil < now) {
+    invokerCircuitOpenUntil = now + INVOKER_CIRCUIT_OPEN_DURATION_MS;
+    logger.error("[BackgroundFunctionWorker] invoker DB circuit breaker OPENED", {
+      windowCount: invokerUnknownEvents.length,
+      cooldownMs: INVOKER_CIRCUIT_OPEN_DURATION_MS,
+    });
+  }
+}
+
+function isInvokerCircuitOpen(): boolean {
+  return Date.now() < invokerCircuitOpenUntil;
+}
+
+function getInvokerUnknownMetrics(): {
+  unknown_window_count: number;
+  circuit_open: boolean;
+  circuit_open_until: number;
+} {
+  const now = Date.now();
+  const cutoff = now - INVOKER_UNKNOWN_WINDOW_MS;
+  const recentCount = invokerUnknownEvents.filter(e => e.timestamp >= cutoff).length;
+  return {
+    unknown_window_count: recentCount,
+    circuit_open: isInvokerCircuitOpen(),
+    circuit_open_until: invokerCircuitOpenUntil,
+  };
+}
 
 class NonRetryableBackgroundInvocationError extends Error {
   constructor(message: string, readonly responseStatus: number) {
@@ -57,16 +130,98 @@ async function assertBackgroundInvokerUserExists(task: ProjectTask): Promise<voi
     throw new NonRetryableBackgroundInvocationError("Background invoker user id is invalid", 400);
   }
 
-  const dbName = await resolveDbName(task.project_ref);
-  const projectDb = getProjectDb(dbName);
-  const rows = await projectDb`
-    SELECT 1
-    FROM auth.users
-    WHERE id = ${userId}::uuid
-    LIMIT 1
-  `;
-  if (rows.length === 0) {
-    throw new NonRetryableBackgroundInvocationError("Background invoker user no longer exists", 410);
+  const cacheKey = `${task.project_ref}:${userId}`;
+
+  // 检查缓存
+  const cached = invokerCache.get(cacheKey);
+  if (cached) {
+    if (cached.expiresAt > Date.now()) {
+      if (!cached.exists) {
+        throw new NonRetryableBackgroundInvocationError("Background invoker user no longer exists", 410);
+      }
+      return;
+    }
+    // 过期条目清除
+    invokerCache.delete(cacheKey);
+  }
+
+  // In-flight coalescing: 同一用户的并发校验共用一个 Promise
+  const inflight = invokerInflight.get(cacheKey);
+  if (inflight) {
+    const exists = await inflight;
+    if (!exists) {
+      throw new NonRetryableBackgroundInvocationError("Background invoker user no longer exists", 410);
+    }
+    return;
+  }
+
+  const promise = _checkInvokerExists(task.project_ref, userId);
+  invokerInflight.set(cacheKey, promise);
+
+  try {
+    const exists = await promise;
+    if (!exists) {
+      throw new NonRetryableBackgroundInvocationError("Background invoker user no longer exists", 410);
+    }
+  } finally {
+    invokerInflight.delete(cacheKey);
+  }
+}
+
+async function _checkInvokerExists(projectRef: string, userId: string): Promise<boolean> {
+  const cacheKey = `${projectRef}:${userId}`;
+
+  // Circuit breaker: if DB is down system-wide, skip checks and fail-open
+  if (isInvokerCircuitOpen()) {
+    recordInvokerUnknown(projectRef, "circuit_breaker_open");
+    // Fail-open during circuit: assume user exists to avoid mass dead-lettering
+    return true;
+  }
+
+  try {
+    const dbName = await resolveDbName(projectRef);
+    const projectDb = getProjectDb(dbName);
+    const rows = await projectDb`
+      SELECT 1
+      FROM auth.users
+      WHERE id = ${userId}::uuid
+        AND deleted_at IS NULL
+      LIMIT 1
+    `;
+    const exists = rows.length > 0;
+
+    invokerCache.set(cacheKey, {
+      exists,
+      expiresAt: Date.now() + (exists ? INVOKER_POSITIVE_TTL : INVOKER_NEGATIVE_TTL),
+    });
+
+    return exists;
+  } catch (error: unknown) {
+    // DB 查询失败 → record as unknown for circuit breaker tracking
+    const errMsg = error instanceof Error ? error.message : String(error);
+    recordInvokerUnknown(projectRef, errMsg);
+
+    // Short-term fail-open: assume user exists to avoid mass dead-lettering
+    // during transient DB failures. Long-term protection via circuit breaker.
+    return true;
+  }
+}
+
+function invalidateInvokerCache(projectRef: string, userId?: string): void {
+  if (userId) {
+    invokerCache.delete(`${projectRef}:${userId}`);
+    invokerInflight.delete(`${projectRef}:${userId}`);
+  } else {
+    for (const key of invokerCache.keys()) {
+      if (key.startsWith(`${projectRef}:`)) {
+        invokerCache.delete(key);
+      }
+    }
+    for (const key of invokerInflight.keys()) {
+      if (key.startsWith(`${projectRef}:`)) {
+        invokerInflight.delete(key);
+      }
+    }
   }
 }
 
@@ -259,6 +414,7 @@ export class BackgroundFunctionWorker {
       return;
     }
 
+    // extendLease 确认租约，然后并行：状态转换 + invoker 校验 + mirror insert
     const leaseSeconds = computeLeaseSeconds(task.timeout_sec);
     const lease = await taskRepository.extendLease(task.id, leaseSeconds);
     if (!lease) {
@@ -271,14 +427,72 @@ export class BackgroundFunctionWorker {
       });
       return;
     }
-    await taskRepository.markTaskRunning(task.id);
-    await taskRepository.startTaskAttempt(task);
+
+    // 并行执行：transitionTaskToRunning（合并 markRunning + startAttempt）+ invoker 校验 + mirror
+    const [, invokerError, mirrorResult] = await Promise.all([
+      taskRepository.transitionTaskToRunning(task.id, task, leaseSeconds),
+      assertBackgroundInvokerUserExists(task).then(() => null, (e: unknown) => e),
+      createBackgroundTaskMirrorIfUserExists(task),
+    ]);
+
     broadcastTaskUpdate({
       taskId: task.id,
       projectRef: task.project_ref,
       taskType: task.task_type,
       status: TaskStatus.RUNNING,
     });
+
+    // invoker 校验失败 → dead-letter
+    if (invokerError instanceof NonRetryableBackgroundInvocationError) {
+      const heartbeat = scheduleLeaseHeartbeat(task.id, leaseSeconds);
+      clearInterval(heartbeat);
+      await taskRepository.completeTaskAttempt(task.id, task.attempt || 1, {
+        status: "dead_lettered",
+        error: invokerError.message,
+        responseStatus: invokerError.responseStatus,
+        durationMs: 0,
+        logs: [],
+      });
+      await taskRepository.markTaskFailed(task.id, invokerError.message, true);
+      broadcastTaskUpdate({
+        taskId: task.id,
+        projectRef: task.project_ref,
+        taskType: task.task_type,
+        status: TaskStatus.DEAD_LETTERED,
+        error: invokerError.message,
+      });
+      return;
+    }
+
+    // mirror degraded: log warning but continue
+    if (mirrorResult?.degraded) {
+      logger.warn("[BackgroundFunctionWorker] mirror check degraded, continuing without mirror", {
+        taskId: task.id,
+        projectRef: task.project_ref,
+      });
+    }
+
+    // mirror RPC 确认用户不存在 → dead-letter
+    if (mirrorResult && !mirrorResult.userExists) {
+      const heartbeat = scheduleLeaseHeartbeat(task.id, leaseSeconds);
+      clearInterval(heartbeat);
+      await taskRepository.completeTaskAttempt(task.id, task.attempt || 1, {
+        status: "dead_lettered",
+        error: "Background invoker user no longer exists (atomic RPC check)",
+        responseStatus: 410,
+        durationMs: 0,
+        logs: [],
+      });
+      await taskRepository.markTaskFailed(task.id, "Background invoker user no longer exists (atomic RPC check)", true);
+      broadcastTaskUpdate({
+        taskId: task.id,
+        projectRef: task.project_ref,
+        taskType: task.task_type,
+        status: TaskStatus.DEAD_LETTERED,
+        error: "Background invoker user no longer exists (atomic RPC check)",
+      });
+      return;
+    }
 
     const heartbeat = scheduleLeaseHeartbeat(task.id, leaseSeconds);
     const startedAt = Date.now();
@@ -290,7 +504,6 @@ export class BackgroundFunctionWorker {
     }> = [];
 
     try {
-      await assertBackgroundInvokerUserExists(task);
       const request = buildInvocationRequest(task);
       const { dispatchBackgroundFunction } = await importDispatcher();
       const response = await dispatchBackgroundFunction({
@@ -441,4 +654,5 @@ export class BackgroundFunctionWorker {
   }
 }
 
+export { invalidateInvokerCache, getInvokerUnknownMetrics };
 export const backgroundFunctionWorker = new BackgroundFunctionWorker();

--- a/packages/management-api/src/services/background-task.service.ts
+++ b/packages/management-api/src/services/background-task.service.ts
@@ -1,4 +1,4 @@
-import { sql, type ProjectTask, TaskStatus, TaskType } from "../db";
+import { sql, type ProjectTask, TaskStatus, TaskType, getProjectDb, resolveDbName } from "../db";
 import { withRetry } from "../utils/retry";
 import { encryptSecretIfNeeded } from "../utils/secret-crypto";
 
@@ -112,8 +112,89 @@ export async function enqueueBackgroundFunctionTask(
   });
 }
 
+/**
+ * 原子 mirror insert: 在租户 DB 中创建 public.background_task_mirrors 记录,
+ * 同时校验 invoker 用户是否存在（含 deleted_at IS NULL 约束）。
+ * 成功返回 { inserted: true, userExists: true }; 用户不存在返回 { inserted: false, userExists: false };
+ * mirror 表不存在时返回 { inserted: false, userExists: true, degraded: true }。
+ */
+export async function createBackgroundTaskMirrorIfUserExists(
+  task: ProjectTask,
+): Promise<{ inserted: boolean; userExists: boolean; degraded?: boolean }> {
+  const payload = (task.payload || {}) as {
+    auth?: { invoker_user_id?: string | null };
+  };
+  const userId = payload.auth?.invoker_user_id;
+  if (!userId || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(userId)) {
+    return { inserted: false, userExists: true };
+  }
+
+  try {
+    const dbName = await resolveDbName(task.project_ref);
+    const projectDb = getProjectDb(dbName);
+
+    // 检查平台专用 mirror 表是否存在
+    const [tableCheck] = await projectDb`
+      SELECT to_regclass('public.background_task_mirrors') IS NOT NULL AS exists
+    `;
+    if (!tableCheck?.exists) {
+      const { logger } = await import("../utils/logger");
+      logger.warn("[BackgroundTaskService] background_task_mirrors table not found, mirror degraded", {
+        taskId: task.id,
+        projectRef: task.project_ref,
+      });
+      return { inserted: false, userExists: true, degraded: true };
+    }
+
+    // 原子 INSERT ... SELECT ... WHERE EXISTS: 一次 roundtrip 完成校验 + mirror
+    const [result] = await projectDb`
+      INSERT INTO public.background_task_mirrors (
+        id, project_ref, task_type, function_slug, status,
+        invoker_user_id, attempt, max_attempts, trace_id, created_at
+      )
+      SELECT
+        ${task.id}::uuid,
+        ${task.project_ref},
+        ${task.task_type},
+        ${task.function_slug || null},
+        ${TaskStatus.RUNNING},
+        ${userId}::uuid,
+        ${task.attempt || 1},
+        ${task.max_attempts},
+        ${task.trace_id || null},
+        NOW()
+      WHERE EXISTS (
+        SELECT 1 FROM auth.users WHERE id = ${userId}::uuid AND deleted_at IS NULL
+      )
+      ON CONFLICT (id) DO NOTHING
+      RETURNING id
+    `;
+
+    if (result?.id) {
+      return { inserted: true, userExists: true };
+    }
+
+    // INSERT 未插入行 = 用户不存在（或 id 冲突）
+    const [userCheck] = await projectDb`
+      SELECT 1 FROM auth.users WHERE id = ${userId}::uuid AND deleted_at IS NULL LIMIT 1
+    `;
+    return { inserted: false, userExists: !!userCheck };
+  } catch (error: unknown) {
+    const { logger } = await import("../utils/logger");
+    logger.warn("[BackgroundTaskService] mirror insert failed (degraded)", {
+      taskId: task.id,
+      projectRef: task.project_ref,
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // 容错：不因 mirror 失败阻塞任务，但标记为 degraded 供上层判断
+    return { inserted: false, userExists: true, degraded: true };
+  }
+}
+
 export const backgroundTaskService = {
   enqueueBackgroundFunctionTask,
   normalizeBackgroundTaskTimeout,
   normalizeBackgroundTaskMaxAttempts,
+  createBackgroundTaskMirrorIfUserExists,
 };

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -718,6 +718,131 @@ BEGIN
 EXCEPTION WHEN OTHERS THEN NULL;
 END $$;
 
+-- 18. Platform background task mirror table + User deletion fence
+-- Mirror table stores platform background invocation state separately from
+-- the business public.tasks table (which has incompatible columns/statuses).
+CREATE TABLE IF NOT EXISTS public.background_task_mirrors (
+  id               UUID PRIMARY KEY,
+  project_ref      TEXT NOT NULL,
+  task_type        TEXT NOT NULL DEFAULT 'edge_function',
+  function_slug    TEXT,
+  status           TEXT NOT NULL DEFAULT 'pending'
+                   CHECK (status IN ('pending','leased','running','retry_scheduled',
+                                     'succeeded','failed','dead_lettered','cancelled')),
+  invoker_user_id  UUID,
+  attempt          INTEGER NOT NULL DEFAULT 1,
+  max_attempts     INTEGER NOT NULL DEFAULT 3,
+  trace_id         TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE public.background_task_mirrors ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.background_task_mirrors
+  TO postgres, supabase_auth_admin, supabase_admin;
+
+CREATE INDEX IF NOT EXISTS idx_bg_task_mirrors_invoker_active
+  ON public.background_task_mirrors(invoker_user_id, status)
+  WHERE status IN ('pending','leased','running','retry_scheduled');
+
+CREATE INDEX IF NOT EXISTS idx_bg_task_mirrors_status
+  ON public.background_task_mirrors(status);
+
+-- 辅助函数：检查用户是否有未终态的 platform background tasks
+-- Returns 'active' | 'inactive' | 'unknown' (three-state to avoid silent false on errors)
+CREATE OR REPLACE FUNCTION public.has_active_background_tasks(p_user_id UUID)
+RETURNS TEXT AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'background_task_mirrors'
+  ) THEN
+    RAISE NOTICE 'has_active_background_tasks: background_task_mirrors table missing for user %', p_user_id;
+    RETURN 'unknown';
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.background_task_mirrors
+  WHERE invoker_user_id = p_user_id
+    AND status IN ('pending','leased','running','retry_scheduled');
+
+  IF v_count > 0 THEN
+    RETURN 'active';
+  END IF;
+
+  RETURN 'inactive';
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'has_active_background_tasks: exception for user % — %', p_user_id, SQLERRM;
+  RETURN 'unknown';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+-- 辅助函数：安全软删除用户（标记 deleted_at，但不硬删）
+-- 在 GoTrue DELETE 触发之前，检查是否有活跃任务
+CREATE OR REPLACE FUNCTION public.soft_delete_user_if_no_active_tasks()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_task_state TEXT;
+BEGIN
+  IF OLD.deleted_at IS NOT NULL THEN
+    RETURN OLD;
+  END IF;
+
+  UPDATE auth.users SET deleted_at = NOW() WHERE id = OLD.id;
+
+  v_task_state := public.has_active_background_tasks(OLD.id);
+
+  IF v_task_state = 'active' THEN
+    RETURN NULL;
+  END IF;
+
+  IF v_task_state = 'unknown' THEN
+    RAISE NOTICE 'soft_delete_user_if_no_active_tasks: degraded/unknown for user %, blocking hard delete', OLD.id;
+    RETURN NULL;
+  END IF;
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 仅在 auth.users 上无此触发器时创建
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'auth_users_delete_fence'
+  ) THEN
+    CREATE TRIGGER auth_users_delete_fence
+      BEFORE DELETE ON auth.users
+      FOR EACH ROW
+      EXECUTE FUNCTION public.soft_delete_user_if_no_active_tasks();
+  END IF;
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- 辅助函数：清理已无活跃任务的软删用户（定期调用）
+CREATE OR REPLACE FUNCTION public.hard_delete_soft_deleted_users()
+RETURNS INT AS $$
+DECLARE
+  deleted_count INT := 0;
+  user_record RECORD;
+  v_task_state TEXT;
+BEGIN
+  FOR user_record IN
+    SELECT id FROM auth.users
+    WHERE deleted_at IS NOT NULL
+      AND deleted_at < NOW() - INTERVAL '1 hour'
+  LOOP
+    v_task_state := public.has_active_background_tasks(user_record.id);
+    IF v_task_state = 'inactive' THEN
+      DELETE FROM auth.users WHERE id = user_record.id;
+      deleted_count := deleted_count + 1;
+    END IF;
+  END LOOP;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
 `;
 
 class TenantRuntimeService {

--- a/packages/management-api/tests/unit/background-function-worker.test.ts
+++ b/packages/management-api/tests/unit/background-function-worker.test.ts
@@ -18,6 +18,7 @@ const completeTaskAttempt = mock(() => Promise.resolve(null));
 const countActiveTasksForProject = mock(() => Promise.resolve(0));
 const getTaskById = mock(() => Promise.resolve(null));
 const requestTaskCancellation = mock(() => Promise.resolve(null));
+const transitionTaskToRunning = mock(() => Promise.resolve({ task: {}, attempt: { id: "att_1" } }));
 
 const findByRef = mock(() =>
   Promise.resolve({ ref: "proj_1", status: "active" })
@@ -53,6 +54,9 @@ spyOn(taskRepository, "getTaskById").mockImplementation(getTaskById as typeof ta
 spyOn(taskRepository, "requestTaskCancellation").mockImplementation(
   requestTaskCancellation as typeof taskRepository.requestTaskCancellation,
 );
+spyOn(taskRepository, "transitionTaskToRunning").mockImplementation(
+  transitionTaskToRunning as typeof taskRepository.transitionTaskToRunning,
+);
 spyOn(projectRepository, "findByRef").mockImplementation(findByRef as typeof projectRepository.findByRef);
 const broadcastTaskUpdate = spyOn(wsModule, "broadcastTaskUpdate").mockImplementation(() => {});
 spyOn(projectService, "getBackgroundTaskSettings").mockImplementation(
@@ -66,6 +70,15 @@ const resolveDbName = spyOn(dbModule, "resolveDbName").mockImplementation(
 );
 const getProjectDb = spyOn(dbModule, "getProjectDb").mockImplementation(
   () => ((async () => [{ exists: 1 }]) as any),
+);
+
+// Mock createBackgroundTaskMirrorIfUserExists
+const bgTaskServiceModule = await import("../../src/services/background-task.service");
+const createBackgroundTaskMirrorIfUserExists = spyOn(
+  bgTaskServiceModule,
+  "createBackgroundTaskMirrorIfUserExists"
+).mockImplementation(
+  () => Promise.resolve({ inserted: false, userExists: true }),
 );
 
 // We import the worker AFTER mocks are set up
@@ -148,12 +161,14 @@ describe("BackgroundFunctionWorker", () => {
     countActiveTasksForProject.mockReset();
     getTaskById.mockReset();
     requestTaskCancellation.mockReset();
+    transitionTaskToRunning.mockReset();
     findByRef.mockReset();
     broadcastTaskUpdate.mockReset();
     getBackgroundTaskSettings.mockReset();
     dispatchBackgroundFunction.mockReset();
     resolveDbName.mockReset();
     getProjectDb.mockReset();
+    createBackgroundTaskMirrorIfUserExists.mockReset();
 
     // Defaults
     findByRef.mockResolvedValue({ ref: "proj_1", status: "active" } as any);
@@ -164,9 +179,11 @@ describe("BackgroundFunctionWorker", () => {
     dispatchBackgroundFunction.mockResolvedValue({ status: 200, headers: {}, bodyText: "", logs: [] });
     resolveDbName.mockResolvedValue("tenant_proj_1");
     getProjectDb.mockImplementation(() => ((async () => [{ exists: 1 }]) as any));
+    createBackgroundTaskMirrorIfUserExists.mockResolvedValue({ inserted: false, userExists: true });
     startTaskAttempt.mockResolvedValue({ id: "att_1" } as any);
     extendLease.mockResolvedValue(null);
     markTaskRunning.mockResolvedValue(null);
+    transitionTaskToRunning.mockResolvedValue({ task: {} as any, attempt: { id: "att_1" } as any });
     globalThis.fetch = originalFetch;
   });
 
@@ -365,6 +382,60 @@ describe("BackgroundFunctionWorker", () => {
     });
   });
 
+  describe("invoker existence cache", () => {
+    test("caches positive invoker existence across multiple tasks", async () => {
+      const worker = new BackgroundFunctionWorker();
+      const userId = "00000000-0000-4000-8000-000000000002";
+      const task1 = makeTask({
+        id: "tsk_cache_1",
+        payload: {
+          method: "POST", path: "/", query: "", headers: {}, body: null,
+          auth: { kind: "jwt", invoker_user_id: userId, invoker_role: "authenticated" },
+        },
+      });
+      const task2 = makeTask({
+        id: "tsk_cache_2",
+        payload: {
+          method: "POST", path: "/", query: "", headers: {}, body: null,
+          auth: { kind: "jwt", invoker_user_id: userId, invoker_role: "authenticated" },
+        },
+      });
+
+      extendLease.mockResolvedValue({} as any);
+      getProjectDb.mockImplementation(() => ((async () => [{ exists: 1 }]) as any));
+
+      await (worker as any).execute(task1);
+      const firstCallCount = resolveDbName.mock.calls.length;
+      await (worker as any).execute(task2);
+
+      // 缓存命中时 resolveDbName 不会被再次调用（invoker cache 跳过了 DB 查询）
+      expect(resolveDbName.mock.calls.length).toBe(firstCallCount);
+    });
+
+    test("dead-letters when mirror RPC confirms user does not exist", async () => {
+      const worker = new BackgroundFunctionWorker();
+      const task = makeTask({
+        id: "tsk_mirror_dead",
+        payload: {
+          method: "POST", path: "/", query: "", headers: {}, body: null,
+          auth: { kind: "jwt", invoker_user_id: "00000000-0000-4000-8000-000000000003", invoker_role: "authenticated" },
+        },
+      });
+      extendLease.mockResolvedValue({} as any);
+      getProjectDb.mockImplementation(() => ((async () => [{ exists: 1 }]) as any));
+      createBackgroundTaskMirrorIfUserExists.mockResolvedValue({ inserted: false, userExists: false });
+
+      await (worker as any).execute(task);
+
+      expect(markTaskFailed).toHaveBeenCalledWith(
+        "tsk_mirror_dead",
+        expect.stringContaining("atomic RPC check"),
+        true,
+      );
+      expect(dispatchBackgroundFunction).not.toHaveBeenCalled();
+    });
+  });
+
   describe("background invocation contract", () => {
     test("buildInvocationRequest signs trusted background invoker headers", async () => {
       const request = buildInvocationRequest(makeTask({
@@ -456,6 +527,30 @@ describe("BackgroundFunctionWorker pure helpers", () => {
     });
   });
 });
+
+  describe("invoker unknown circuit breaker", () => {
+    test("getInvokerUnknownMetrics returns structured object", async () => {
+      const { getInvokerUnknownMetrics } = await import(
+        "../../src/services/background-function-worker"
+      );
+      const metrics = getInvokerUnknownMetrics();
+      expect(metrics).toHaveProperty("unknown_window_count");
+      expect(metrics).toHaveProperty("circuit_open");
+      expect(metrics).toHaveProperty("circuit_open_until");
+      expect(typeof metrics.unknown_window_count).toBe("number");
+      expect(typeof metrics.circuit_open).toBe("boolean");
+      expect(typeof metrics.circuit_open_until).toBe("number");
+    });
+
+    test("circuit breaker starts closed", async () => {
+      const { getInvokerUnknownMetrics } = await import(
+        "../../src/services/background-function-worker"
+      );
+      const metrics = getInvokerUnknownMetrics();
+      expect(metrics.circuit_open).toBe(false);
+      expect(metrics.unknown_window_count).toBe(0);
+    });
+  });
 
 afterAll(() => {
   mock.restore();

--- a/packages/management-api/tests/unit/background-task.service.test.ts
+++ b/packages/management-api/tests/unit/background-task.service.test.ts
@@ -1,8 +1,71 @@
-import { describe, expect, test } from "bun:test";
-import {
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import type { ProjectTask } from "../../src/db";
+import { TaskStatus, TaskType } from "../../src/db";
+
+const resolveDbName = mock(() => Promise.resolve("tenant_proj_mirror"));
+const getProjectDb = mock(() => {
+  throw new Error("getProjectDb should be mocked per test");
+});
+const loggerWarn = mock(() => undefined);
+
+mock.module("../../src/db", () => ({
+  resolveDbName,
+  getProjectDb,
+}));
+
+mock.module("../../src/utils/logger", () => ({
+  logger: {
+    warn: loggerWarn,
+  },
+}));
+
+const backgroundTaskServiceModule = await import(
+  new URL("../../src/services/background-task.service.ts?background-task-service-test", import.meta.url).href
+);
+
+const {
   normalizeBackgroundTaskTimeout,
   normalizeBackgroundTaskMaxAttempts,
-} from "../../src/services/background-task.service";
+  createBackgroundTaskMirrorIfUserExists,
+} = backgroundTaskServiceModule;
+
+function makeTask(overrides: Partial<ProjectTask> = {}): ProjectTask {
+  return {
+    id: "00000000-0000-4000-8000-000000000099",
+    project_ref: "proj_mirror",
+    task_type: TaskType.EDGE_FUNCTION,
+    status: TaskStatus.PENDING,
+    payload: {
+      method: "POST",
+      path: "/",
+      query: "",
+      headers: {},
+      body: null,
+      auth: {
+        kind: "jwt",
+        invoker_user_id: "00000000-0000-4000-8000-000000000100",
+        invoker_role: "authenticated",
+      },
+    },
+    error: null,
+    retries: 0,
+    attempt: 1,
+    max_attempts: 3,
+    next_run_at: new Date(),
+    lease_until: null,
+    started_at: null,
+    completed_at: null,
+    timeout_sec: 300,
+    idempotency_key: null,
+    trace_id: "trace_mirror",
+    function_slug: "test-fn",
+    function_version: null,
+    result: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
 
 describe("BackgroundTaskService: normalizeBackgroundTaskTimeout", () => {
   test("undefined returns default 300", () => {
@@ -86,22 +149,71 @@ describe("BackgroundTaskService: normalizeBackgroundTaskMaxAttempts", () => {
   });
 });
 
-import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
-import type { ProjectTask } from "../../src/db";
-import { TaskStatus, TaskType } from "../../src/db";
-
-// ─── Mirror table separation & degraded state tests ──────────────────────────
 describe("BackgroundTaskService: createBackgroundTaskMirrorIfUserExists", () => {
-  // These test the contract of the mirror function through the module interface.
-  // Since the function depends on tenant DB connections, we test the pure logic
-  // and the return type contract (inserted/userExists/degraded).
+  let scenario: "table_exists" | "table_missing" | "user_missing" | "db_error" = "table_exists";
 
-  function makeTask(overrides: Partial<ProjectTask> = {}): ProjectTask {
-    return {
-      id: "00000000-0000-4000-8000-000000000099",
-      project_ref: "proj_mirror",
-      task_type: TaskType.EDGE_FUNCTION,
-      status: TaskStatus.PENDING,
+  const projectDb = mock((strings: TemplateStringsArray) => {
+    const sql = strings.join(" ");
+    if (sql.includes("to_regclass('public.background_task_mirrors')")) {
+      if (scenario === "db_error") throw new Error("table check failed");
+      return Promise.resolve([{ exists: scenario !== "table_missing" }]);
+    }
+
+    if (sql.includes("INSERT INTO public.background_task_mirrors")) {
+      if (scenario === "db_error") throw new Error("mirror insert failed");
+      if (scenario === "user_missing") return Promise.resolve([]);
+      return Promise.resolve([{ id: "00000000-0000-4000-8000-000000000099" }]);
+    }
+
+    if (sql.includes("SELECT 1 FROM auth.users")) {
+      return Promise.resolve(scenario === "user_missing" ? [] : [{ exists: 1 }]);
+    }
+
+    throw new Error(`Unexpected SQL: ${sql}`);
+  });
+
+  beforeEach(() => {
+    scenario = "table_exists";
+    resolveDbName.mockReset();
+    getProjectDb.mockReset();
+    loggerWarn.mockReset();
+    resolveDbName.mockResolvedValue("tenant_proj_mirror");
+    getProjectDb.mockReturnValue(projectDb as unknown as ReturnType<typeof getProjectDb>);
+  });
+
+  afterEach(() => {
+    loggerWarn.mockReset();
+  });
+
+  test("returns inserted=true when the mirror table exists and the invoker user exists", async () => {
+    scenario = "table_exists";
+
+    const result = await createBackgroundTaskMirrorIfUserExists(makeTask());
+
+    expect(result).toEqual({ inserted: true, userExists: true });
+    expect(resolveDbName).toHaveBeenCalledWith("proj_mirror");
+    expect(getProjectDb).toHaveBeenCalledWith("tenant_proj_mirror");
+  });
+
+  test("returns userExists=false when the invoker user is missing", async () => {
+    scenario = "user_missing";
+
+    const result = await createBackgroundTaskMirrorIfUserExists(makeTask());
+
+    expect(result).toEqual({ inserted: false, userExists: false });
+  });
+
+  test("returns degraded=true when the mirror table is missing", async () => {
+    scenario = "table_missing";
+
+    const result = await createBackgroundTaskMirrorIfUserExists(makeTask());
+
+    expect(result).toEqual({ inserted: false, userExists: true, degraded: true });
+    expect(loggerWarn).toHaveBeenCalled();
+  });
+
+  test("short-circuits invalid invoker IDs without DB access", async () => {
+    const result = await createBackgroundTaskMirrorIfUserExists(makeTask({
       payload: {
         method: "POST",
         path: "/",
@@ -110,44 +222,14 @@ describe("BackgroundTaskService: createBackgroundTaskMirrorIfUserExists", () => 
         body: null,
         auth: {
           kind: "jwt",
-          invoker_user_id: "00000000-0000-4000-8000-000000000100",
+          invoker_user_id: "not-a-uuid",
           invoker_role: "authenticated",
         },
       },
-      error: null,
-      retries: 0,
-      attempt: 1,
-      max_attempts: 3,
-      next_run_at: new Date(),
-      lease_until: null,
-      started_at: null,
-      completed_at: null,
-      timeout_sec: 300,
-      idempotency_key: null,
-      trace_id: "trace_mirror",
-      function_slug: "test-fn",
-      function_version: null,
-      result: null,
-      created_at: new Date(),
-      updated_at: new Date(),
-      ...overrides,
-    };
-  }
+    }));
 
-  test("returns userExists=true when invoker_user_id is absent", async () => {
-    // No invoker → skip mirror check, always safe
-    const task = makeTask({
-      payload: { method: "POST", path: "/", query: "", headers: {}, body: null, auth: { kind: "none" } },
-    });
-    // We can't directly call the async function without DB, but the contract is:
-    // if userId is empty, return { inserted: false, userExists: true }
-    // This is verified through the pure-logic path in the function.
-    expect(true).toBe(true); // Structural coverage placeholder
-  });
-
-  test("return type includes degraded flag when mirror table missing", () => {
-    // When the table doesn't exist, the function returns degraded: true
-    // This is the key new contract vs. the old silent-fail behavior
-    expect(true).toBe(true); // Verified through integration
+    expect(result).toEqual({ inserted: false, userExists: true });
+    expect(resolveDbName).not.toHaveBeenCalled();
+    expect(getProjectDb).not.toHaveBeenCalled();
   });
 });

--- a/packages/management-api/tests/unit/background-task.service.test.ts
+++ b/packages/management-api/tests/unit/background-task.service.test.ts
@@ -85,3 +85,69 @@ describe("BackgroundTaskService: normalizeBackgroundTaskMaxAttempts", () => {
     expect(normalizeBackgroundTaskMaxAttempts(5.1)).toBe(5);
   });
 });
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import type { ProjectTask } from "../../src/db";
+import { TaskStatus, TaskType } from "../../src/db";
+
+// ─── Mirror table separation & degraded state tests ──────────────────────────
+describe("BackgroundTaskService: createBackgroundTaskMirrorIfUserExists", () => {
+  // These test the contract of the mirror function through the module interface.
+  // Since the function depends on tenant DB connections, we test the pure logic
+  // and the return type contract (inserted/userExists/degraded).
+
+  function makeTask(overrides: Partial<ProjectTask> = {}): ProjectTask {
+    return {
+      id: "00000000-0000-4000-8000-000000000099",
+      project_ref: "proj_mirror",
+      task_type: TaskType.EDGE_FUNCTION,
+      status: TaskStatus.PENDING,
+      payload: {
+        method: "POST",
+        path: "/",
+        query: "",
+        headers: {},
+        body: null,
+        auth: {
+          kind: "jwt",
+          invoker_user_id: "00000000-0000-4000-8000-000000000100",
+          invoker_role: "authenticated",
+        },
+      },
+      error: null,
+      retries: 0,
+      attempt: 1,
+      max_attempts: 3,
+      next_run_at: new Date(),
+      lease_until: null,
+      started_at: null,
+      completed_at: null,
+      timeout_sec: 300,
+      idempotency_key: null,
+      trace_id: "trace_mirror",
+      function_slug: "test-fn",
+      function_version: null,
+      result: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+      ...overrides,
+    };
+  }
+
+  test("returns userExists=true when invoker_user_id is absent", async () => {
+    // No invoker → skip mirror check, always safe
+    const task = makeTask({
+      payload: { method: "POST", path: "/", query: "", headers: {}, body: null, auth: { kind: "none" } },
+    });
+    // We can't directly call the async function without DB, but the contract is:
+    // if userId is empty, return { inserted: false, userExists: true }
+    // This is verified through the pure-logic path in the function.
+    expect(true).toBe(true); // Structural coverage placeholder
+  });
+
+  test("return type includes degraded flag when mirror table missing", () => {
+    // When the table doesn't exist, the function returns degraded: true
+    // This is the key new contract vs. the old silent-fail behavior
+    expect(true).toBe(true); // Verified through integration
+  });
+});

--- a/scripts/004_background_task_mirror_migration.sql
+++ b/scripts/004_background_task_mirror_migration.sql
@@ -1,0 +1,216 @@
+-- Background task mirror schema migration
+--
+-- Separates the platform background task mirror from the business `public.tasks` table,
+-- which has incompatible column names and status semantics (AoristCross uses `name`,
+-- `type`, `created_by`, status `queued/processing/completed/failed/cancelled`).
+--
+-- The new `background_task_mirrors` table stores platform background invocation mirrors
+-- with the correct column contract and is the sole source for deletion fence checks.
+--
+-- Usage:
+--   1. Run the "Tenant database" section against each tenant database.
+--   2. The migrate-tenant-schema.ts and tenant-runtime.service.ts inline DDL will
+--      be updated to emit the same schema during new-project bootstrap.
+
+-- migrate:up
+
+-- Tenant database
+
+-- Platform background task mirror table
+CREATE TABLE IF NOT EXISTS public.background_task_mirrors (
+  id               UUID PRIMARY KEY,
+  project_ref      TEXT NOT NULL,
+  task_type        TEXT NOT NULL DEFAULT 'edge_function',
+  function_slug    TEXT,
+  status           TEXT NOT NULL DEFAULT 'pending'
+                   CHECK (status IN ('pending','leased','running','retry_scheduled',
+                                     'succeeded','failed','dead_lettered','cancelled')),
+  invoker_user_id  UUID,
+  attempt          INTEGER NOT NULL DEFAULT 1,
+  max_attempts     INTEGER NOT NULL DEFAULT 3,
+  trace_id         TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.background_task_mirrors ENABLE ROW LEVEL SECURITY;
+
+-- Grant access to platform roles (postgres, supabase_auth_admin, supabase_admin)
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.background_task_mirrors
+  TO postgres, supabase_auth_admin, supabase_admin;
+
+-- Index for fence lookups: find active tasks by invoker user
+CREATE INDEX IF NOT EXISTS idx_bg_task_mirrors_invoker_active
+  ON public.background_task_mirrors(invoker_user_id, status)
+  WHERE status IN ('pending','leased','running','retry_scheduled');
+
+-- Index for task status lookups
+CREATE INDEX IF NOT EXISTS idx_bg_task_mirrors_status
+  ON public.background_task_mirrors(status);
+
+-- Drop the old mirror function that queried the incompatible public.tasks
+-- (will be replaced below)
+CREATE OR REPLACE FUNCTION public.has_active_background_tasks(p_user_id UUID)
+RETURNS TEXT AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  -- Check whether the platform mirror table exists
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'background_task_mirrors'
+  ) THEN
+    -- Mirror table not yet provisioned — report unknown, do NOT silently return FALSE
+    RAISE NOTICE 'has_active_background_tasks: background_task_mirrors table missing for user %', p_user_id;
+    RETURN 'unknown';
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.background_task_mirrors
+  WHERE invoker_user_id = p_user_id
+    AND status IN ('pending','leased','running','retry_scheduled');
+
+  IF v_count > 0 THEN
+    RETURN 'active';
+  END IF;
+
+  RETURN 'inactive';
+EXCEPTION WHEN OTHERS THEN
+  -- Do NOT silently return FALSE. Log the error and return 'unknown' so callers
+  -- can make an informed decision (e.g., prevent hard deletion).
+  RAISE NOTICE 'has_active_background_tasks: exception for user % — %', p_user_id, SQLERRM;
+  RETURN 'unknown';
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+-- Update soft_delete trigger to handle three-state result
+CREATE OR REPLACE FUNCTION public.soft_delete_user_if_no_active_tasks()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_task_state TEXT;
+BEGIN
+  IF OLD.deleted_at IS NOT NULL THEN
+    RETURN OLD;
+  END IF;
+
+  UPDATE auth.users SET deleted_at = NOW() WHERE id = OLD.id;
+
+  v_task_state := public.has_active_background_tasks(OLD.id);
+
+  IF v_task_state = 'active' THEN
+    -- Active background tasks exist — block hard deletion
+    RETURN NULL;
+  END IF;
+
+  IF v_task_state = 'unknown' THEN
+    -- Degraded state: DB error or mirror table missing. Conservative choice: block hard deletion
+    -- and log a degraded-warning so operators can investigate.
+    RAISE NOTICE 'soft_delete_user_if_no_active_tasks: degraded/unknown for user %, blocking hard delete', OLD.id;
+    RETURN NULL;
+  END IF;
+
+  -- v_task_state = 'inactive' — no active tasks, allow hard deletion
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Ensure the trigger exists (idempotent)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'auth_users_delete_fence'
+  ) THEN
+    CREATE TRIGGER auth_users_delete_fence
+      BEFORE DELETE ON auth.users
+      FOR EACH ROW
+      EXECUTE FUNCTION public.soft_delete_user_if_no_active_tasks();
+  END IF;
+EXCEPTION WHEN OTHERS THEN NULL;
+END $$;
+
+-- Update hard_delete cleanup to handle three-state result
+CREATE OR REPLACE FUNCTION public.hard_delete_soft_deleted_users()
+RETURNS INT AS $$
+DECLARE
+  deleted_count INT := 0;
+  user_record RECORD;
+  v_task_state TEXT;
+BEGIN
+  FOR user_record IN
+    SELECT id FROM auth.users
+    WHERE deleted_at IS NOT NULL
+      AND deleted_at < NOW() - INTERVAL '1 hour'
+  LOOP
+    v_task_state := public.has_active_background_tasks(user_record.id);
+    IF v_task_state = 'inactive' THEN
+      DELETE FROM auth.users WHERE id = user_record.id;
+      deleted_count := deleted_count + 1;
+    END IF;
+    -- 'active' or 'unknown' → skip, keep soft-deleted
+  END LOOP;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+-- Rollback: restore original two-state function on public.tasks and drop mirror table.
+-- WARNING: rollback loses mirror data; fence will query the incompatible public.tasks again.
+
+DROP TABLE IF EXISTS public.background_task_mirrors;
+
+CREATE OR REPLACE FUNCTION public.has_active_background_tasks(p_user_id UUID)
+RETURNS BOOLEAN AS $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'tasks') THEN
+    RETURN FALSE;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1 FROM public.tasks
+    WHERE created_by = p_user_id
+      AND status IN ('pending', 'leased', 'running', 'retry_scheduled')
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+CREATE OR REPLACE FUNCTION public.soft_delete_user_if_no_active_tasks()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.deleted_at IS NOT NULL THEN
+    RETURN OLD;
+  END IF;
+
+  UPDATE auth.users SET deleted_at = NOW() WHERE id = OLD.id;
+
+  IF public.has_active_background_tasks(OLD.id) THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION public.hard_delete_soft_deleted_users()
+RETURNS INT AS $$
+DECLARE
+  deleted_count INT := 0;
+  user_record RECORD;
+BEGIN
+  FOR user_record IN
+    SELECT id FROM auth.users
+    WHERE deleted_at IS NOT NULL
+      AND NOT public.has_active_background_tasks(id)
+      AND deleted_at < NOW() - INTERVAL '1 hour'
+  LOOP
+    DELETE FROM auth.users WHERE id = user_record.id;
+    deleted_count := deleted_count + 1;
+  END LOOP;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Fixes `fix-background-invoker-mirror-observability` from `tasks.md`.

### 1. Platform mirror table separation from business `public.tasks`

The current `createBackgroundTaskMirrorIfUserExists` writes platform background invocation mirrors into the tenant business `public.tasks` table. This table has incompatible columns (`name`, `type`, `created_by`) and status values (`queued`, `processing`) compared to platform semantics (`project_ref`, `task_type`, `function_slug`, `pending`, `leased`, `running`). The mismatch causes silent INSERT catch-and-swallow and `has_active_background_tasks()` queries non-existent columns (`created_by`).

**Fix:** New `public.background_task_mirrors` table with the correct platform column contract. Mirror insert now targets this table. Existing `public.tasks` is untouched for business use.

### 2. Three-state `has_active_background_tasks()` instead of silent FALSE

Old function: `EXCEPTION WHEN OTHERS THEN RETURN FALSE` — silently returns FALSE on any DB error or missing table, potentially allowing hard deletion of users with active tasks during degraded states.

**Fix:** Returns TEXT `'active' | 'inactive' | 'unknown'`. Unknown state logs via `RAISE NOTICE` and blocks hard deletion conservatively. `soft_delete_user_if_no_active_tasks()` and `hard_delete_soft_deleted_users()` handle all three states.

### 3. Invoker existence DB unknown circuit breaker

`_checkInvokerExists` catch block silently returns `true` (user exists) on DB failures, with only a `warn` log. No tracking, no escalation.

**Fix:** 
- Sliding window counter (60s, threshold 10) for DB unknown events
- Circuit breaker: opens for 30s cooldown after threshold exceeded, fail-open during circuit
- `getInvokerUnknownMetrics()` exported for `/metrics` integration
- Each unknown event logged with window count and threshold context

### 4. WorkerPool `avg_queue_wait_ms` NaN fix

When an idle worker is immediately available, `_queueStart` was only set for queued requests (else branch). The immediate dispatch path left `_queueStart` undefined, making `performance.now() - undefined` = NaN.

**Fix:** `_queueStart` set before the idle worker check, and defensive `queueStart ? ... : 0` fallback in `execute()`.

### Files changed

- `scripts/004_background_task_mirror_migration.sql` — migration with up/down
- `packages/management-api/src/services/background-task.service.ts` — mirror insert → `background_task_mirrors`
- `packages/management-api/src/services/background-function-worker.ts` — circuit breaker + degraded handling
- `packages/management-api/src/services/tenant-runtime.service.ts` — inline DDL update
- `packages/management-api/src/scripts/migrate-tenant-schema.ts` — inline DDL update
- `packages/edge-runtime/worker-pool.ts` — NaN fix + `_queueStart` always set
- Tests updated in all three test files

### Verification

- `bun test` (management-api + edge-runtime) — all pass
- `bun run typecheck` (both packages) — clean
- `git diff --check` — no whitespace issues