### PR TITLE
feat: wrap queue APIs in supacloud js

### DIFF
--- a/packages/management-api/src/db/index.ts
+++ b/packages/management-api/src/db/index.ts
@@ -485,6 +485,9 @@ export interface ProjectTask {
   trace_id: string | null;
   cancel_requested_at: Date | null;
   cancellation_reason: string | null;
+  correlation_id: string | null;
+  business_task_id: string | null;
+  metadata: Record<string, unknown> | null;
   function_slug: string | null;
   function_version: string | null;
   result: Record<string, unknown> | null;

--- a/packages/management-api/src/db/init.ts
+++ b/packages/management-api/src/db/init.ts
@@ -84,6 +84,9 @@ export async function initDatabase() {
       trace_id VARCHAR(255),
       cancel_requested_at TIMESTAMPTZ,
       cancellation_reason TEXT,
+      correlation_id VARCHAR(255),
+      business_task_id VARCHAR(255),
+      metadata JSONB DEFAULT '{}'::jsonb,
       created_at TIMESTAMPTZ DEFAULT NOW(),
       updated_at TIMESTAMPTZ DEFAULT NOW()
     );
@@ -289,6 +292,9 @@ export async function initDatabase() {
       { statement: 'ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS trace_id VARCHAR(255)', description: "project_tasks.trace_id" },
       { statement: 'ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS cancel_requested_at TIMESTAMPTZ', description: "project_tasks.cancel_requested_at" },
       { statement: 'ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS cancellation_reason TEXT', description: "project_tasks.cancellation_reason" },
+      { statement: 'ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS correlation_id VARCHAR(255)', description: "project_tasks.correlation_id" },
+      { statement: 'ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS business_task_id VARCHAR(255)', description: "project_tasks.business_task_id" },
+      { statement: "ALTER TABLE project_tasks ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::jsonb", description: "project_tasks.metadata" },
       { statement: 'ALTER TABLE project_tasks ALTER COLUMN next_run_at SET DEFAULT NOW()', description: "project_tasks.next_run_at default", swallowError: true },
       { statement: 'UPDATE project_tasks SET next_run_at = COALESCE(next_run_at, created_at, NOW())', description: "project_tasks.next_run_at backfill" },
       { statement: 'UPDATE project_tasks SET max_attempts = COALESCE(max_attempts, 3)', description: "project_tasks.max_attempts backfill" },

--- a/packages/management-api/src/repositories/task.repository.ts
+++ b/packages/management-api/src/repositories/task.repository.ts
@@ -13,6 +13,9 @@ export interface CreateTaskInput {
   functionVersion?: string | null;
   idempotencyKey?: string | null;
   traceId?: string | null;
+  correlationId?: string | null;
+  businessTaskId?: string | null;
+  metadata?: Record<string, unknown> | null;
   nextRunAt?: Date | null;
 }
 
@@ -199,7 +202,10 @@ export async function createTask(inputOrRef: CreateTaskInput | string, type?: Ta
         next_run_at,
         timeout_sec,
         idempotency_key,
-        trace_id
+        trace_id,
+        correlation_id,
+        business_task_id,
+        metadata
       )
       VALUES (
         ${input.ref},
@@ -212,7 +218,10 @@ export async function createTask(inputOrRef: CreateTaskInput | string, type?: Ta
         ${input.nextRunAt || new Date()},
         ${input.timeoutSec ?? null},
         ${input.idempotencyKey || null},
-        ${input.traceId || null}
+        ${input.traceId || null},
+        ${input.correlationId || null},
+        ${input.businessTaskId || null},
+        ${JSON.stringify(input.metadata || {})}
       )
       ON CONFLICT (project_ref, idempotency_key)
       WHERE idempotency_key IS NOT NULL

--- a/packages/management-api/src/routes/tasks.ts
+++ b/packages/management-api/src/routes/tasks.ts
@@ -114,6 +114,9 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 maxAttempts?: number;
                 idempotencyKey?: string;
                 traceId?: string;
+                correlationId?: string;
+                businessTaskId?: string;
+                metadata?: Record<string, unknown>;
             };
             const recentMessages = await taskRepository.countQueueMessagesCreatedSince(
                 params.ref,
@@ -137,6 +140,9 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 nextRunAt: new Date(Date.now() + delayMs),
                 idempotencyKey: input.idempotencyKey || null,
                 traceId: input.traceId || null,
+                correlationId: input.correlationId || null,
+                businessTaskId: input.businessTaskId || null,
+                metadata: input.metadata || null,
             });
             return status(202, task);
         } catch (err: unknown) {
@@ -149,6 +155,9 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
             maxAttempts: t.Optional(t.Number()),
             idempotencyKey: t.Optional(t.String()),
             traceId: t.Optional(t.String()),
+            correlationId: t.Optional(t.String()),
+            businessTaskId: t.Optional(t.String()),
+            metadata: t.Optional(t.Record(t.String(), t.Unknown())),
         }),
         detail: { tags: ["tasks"], summary: "Enqueue a message to a queue" },
     })

--- a/packages/management-api/tests/unit/task.routes.test.ts
+++ b/packages/management-api/tests/unit/task.routes.test.ts
@@ -178,7 +178,14 @@ describe("taskRoutes", () => {
     const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ payload: { hello: "world" }, delayMs: 1000, maxAttempts: 5 }),
+      body: JSON.stringify({
+        payload: { hello: "world" },
+        delayMs: 1000,
+        maxAttempts: 5,
+        correlationId: "corr-1",
+        businessTaskId: "biz-1",
+        metadata: { tenant: "acme" },
+      }),
     });
     const payload = await response.json();
 
@@ -189,6 +196,9 @@ describe("taskRoutes", () => {
       type: "queue:emails",
       payload: { hello: "world" },
       maxAttempts: 5,
+      correlationId: "corr-1",
+      businessTaskId: "biz-1",
+      metadata: { tenant: "acme" },
     }));
     expect(countQueueMessagesCreatedSince).toHaveBeenCalledWith(
       "proj_1",

--- a/packages/supacloud-js/README.md
+++ b/packages/supacloud-js/README.md
@@ -8,6 +8,7 @@ It does **not** replace [`@supabase/supabase-js`](https://www.npmjs.com/package/
 - task detail and list APIs
 - cancel / retry helpers
 - Realtime subscription with polling fallback
+- queue send / receive / ack / release / fail / retry / delete / list / listFailed / stats / settings helpers
 - project OAuth/OIDC migration and OAuth client management
 
 ## Install
@@ -59,6 +60,18 @@ The current package focuses on:
 - `tasks.retry`
 - `tasks.wait`
 - `tasks.subscribe`
+- `queue(name).send`
+- `queue(name).receive`
+- `queue(name).ack`
+- `queue(name).release`
+- `queue(name).fail`
+- `queue(name).retry`
+- `queue(name).delete`
+- `queue(name).list`
+- `queue(name).listFailed`
+- `queue(name).stats`
+- `queue(name).getSettings`
+- `queue(name).updateSettings`
 - `auth.oauthServer.getStatus`
 - `auth.oauthServer.migrateToOidc`
 - `auth.oauthServer.getDiscovery`
@@ -74,6 +87,37 @@ The current package focuses on:
 2. if Realtime is unavailable, fall back to polling the management API
 
 This lets apps degrade gracefully when websocket or channel health is transient.
+
+## Queue Helpers
+
+```ts
+const queue = supacloud.queue("emails");
+
+const message = await queue.send(
+  { to: "user@example.com", template: "welcome" },
+  {
+    idempotencyKey: "welcome-user-123",
+    correlationId: "signup-123",
+    businessTaskId: "email-job-123",
+    metadata: { source: "signup" },
+  },
+);
+
+const leased = await queue.receive({ visibilityTimeoutSec: 60 });
+if (leased) {
+  try {
+    await sendEmail(leased.payload);
+    await queue.ack(leased.id, { delivered: true });
+  } catch (error) {
+    await queue.release(leased.id, { delayMs: 30_000, error: String(error) });
+  }
+}
+
+const stats = await queue.stats();
+console.log(stats.inFlight, stats.deadLettered);
+```
+
+Queue conflicts such as replaying a non-DLQ message are surfaced as `SupaCloudApiError` with `status`, `code`, and `responseBody`, so callers do not need to parse raw `fetch` responses.
 
 ## OAuth/OIDC Helpers
 

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { createSupaCloudClient, SupaCloudTaskSubmitError } from "./index";
+import { createSupaCloudClient, SupaCloudApiError, SupaCloudTaskSubmitError } from "./index";
 
 function createFakeSupabase() {
   const removeChannel = mock(async () => "ok");
@@ -162,25 +162,82 @@ describe("@supacloud/js", () => {
     });
     const queue = client.queue("emails");
 
-    await queue.send({ hello: "world" }, { delayMs: 1000, maxAttempts: 5, idempotencyKey: "email-1" });
+    await queue.send({ hello: "world" }, {
+      delayMs: 1000,
+      maxAttempts: 5,
+      idempotencyKey: "email-1",
+      correlationId: "corr-1",
+      businessTaskId: "biz-1",
+      metadata: { tenant: "acme" },
+    });
     await queue.receive({ visibilityTimeoutSec: 60 });
     await queue.list({ status: ["pending", "leased"], limit: 10 });
+    await queue.stats();
+    await queue.getSettings();
+    await queue.updateSettings({ max_in_flight: 20 });
     await queue.get("msg_123");
     await queue.ack("msg_123", { ok: true });
     await queue.release("msg_123", { delayMs: 5000, error: "retry later" });
     await queue.fail("msg_123", { error: "boom" });
+    await queue.retry("msg_123");
     await queue.delete("msg_123");
 
     expect(calls[0]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages");
     expect(calls[1]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/receive");
     expect(calls[2]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages?status=pending%2Cleased&limit=10");
-    expect(calls[3]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123");
-    expect(calls[4]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/ack");
-    expect(calls[5]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/release");
-    expect(calls[6]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/fail");
-    expect(calls[7]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123");
-    expect(calls[7]?.init?.method).toBe("DELETE");
+    expect(calls[3]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/stats");
+    expect(calls[4]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/settings");
+    expect(calls[5]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/settings");
+    expect(calls[5]?.init?.method).toBe("PATCH");
+    expect(calls[6]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123");
+    expect(calls[7]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/ack");
+    expect(calls[8]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/release");
+    expect(calls[9]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/fail");
+    expect(calls[10]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/retry");
+    expect(calls[11]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123");
+    expect(calls[11]?.init?.method).toBe("DELETE");
     expect((calls[0]?.init?.headers as Record<string, string>)?.authorization).toBe("Bearer token-123");
+    expect(JSON.parse(String(calls[0]?.init?.body))).toMatchObject({
+      payload: { hello: "world" },
+      delayMs: 1000,
+      maxAttempts: 5,
+      idempotencyKey: "email-1",
+      correlationId: "corr-1",
+      businessTaskId: "biz-1",
+      metadata: { tenant: "acme" },
+    });
+  });
+
+  test("management-api errors preserve status, code, and response body", async () => {
+    const { supabase } = createFakeSupabase();
+    const errorBody = {
+      message: "Queue message cannot be replayed from its current state",
+      code: "409",
+    };
+
+    globalThis.fetch = mock(() => Promise.resolve(
+      new Response(JSON.stringify(errorBody), {
+        status: 409,
+        headers: { "content-type": "application/json" },
+      }),
+    )) as typeof fetch;
+
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com/",
+      projectRef: "proj_1",
+    });
+
+    try {
+      await client.queue("emails").retry("msg_123");
+      throw new Error("Expected retry to fail");
+    } catch (error) {
+      expect(error instanceof SupaCloudApiError).toBe(true);
+      expect((error as SupaCloudApiError).status).toBe(409);
+      expect((error as SupaCloudApiError).code).toBe("409");
+      expect((error as SupaCloudApiError).responseBody).toMatchObject(errorBody);
+      expect((error as Error).message).toBe(errorBody.message);
+    }
   });
 
   test("queue receive returns null when no message is available", async () => {

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -48,6 +48,9 @@ export type SupaCloudTaskDetail = {
   payload?: Record<string, unknown>;
   attempts?: SupaCloudTaskAttempt[];
   latest_logs?: SupaCloudTaskLogEntry[];
+  correlation_id?: string | null;
+  business_task_id?: string | null;
+  metadata?: Record<string, unknown> | null;
   updated_at?: string | null;
   created_at?: string | null;
   [key: string]: unknown;
@@ -84,6 +87,12 @@ export type SupaCloudTaskSubmitOptions = {
   timeoutSec?: number;
   idempotencyKey?: string;
   method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  /** Opaque correlation ID — the platform stores it but does not interpret it */
+  correlationId?: string;
+  /** Business-layer task ID for mapping back to the caller's own task table */
+  businessTaskId?: string;
+  /** Arbitrary JSON metadata — the platform stores it but does not interpret it */
+  metadata?: Record<string, unknown>;
 };
 
 export type SupaCloudQueueSendOptions = {
@@ -91,6 +100,9 @@ export type SupaCloudQueueSendOptions = {
   maxAttempts?: number;
   idempotencyKey?: string;
   traceId?: string;
+  correlationId?: string;
+  businessTaskId?: string;
+  metadata?: Record<string, unknown>;
 };
 
 export type SupaCloudQueueReceiveOptions = {
@@ -116,6 +128,27 @@ export type SupaCloudQueueListFilters = {
 export type SupaCloudQueueMessage = SupaCloudTaskDetail & {
   payload: Record<string, unknown>;
 };
+
+export type SupaCloudQueueStats = {
+  pending: number;
+  leased: number;
+  running: number;
+  retryScheduled: number;
+  succeededLast24h: number;
+  failedLast24h: number;
+  deadLettered: number;
+  oldestPendingAgeSec: number | null;
+  inFlight: number;
+};
+
+export type SupaCloudQueueSettings = {
+  max_in_flight: number;
+  default_visibility_timeout_sec: number;
+  max_attempts: number;
+  rate_limit_per_minute: number;
+};
+
+export type SupaCloudQueueSettingsUpdate = Partial<SupaCloudQueueSettings>;
 
 export type SupaCloudTaskWaitOptions = {
   intervalMs?: number;
@@ -243,7 +276,21 @@ export class SupaCloudTaskSubmitError extends Error {
   }
 }
 
-type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+export class SupaCloudApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  readonly responseBody: unknown;
+
+  constructor(message: string, status: number, responseBody: unknown) {
+    super(message);
+    this.name = "SupaCloudApiError";
+    this.status = status;
+    this.responseBody = responseBody;
+    this.code = extractErrorCode(responseBody);
+  }
+}
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
 const TERMINAL_STATUSES = new Set<string>([
   "succeeded",
@@ -288,6 +335,22 @@ function createQueueQueryString(filters: SupaCloudQueueListFilters = {}): string
 
   const query = params.toString();
   return query.length > 0 ? `?${query}` : "";
+}
+
+function extractErrorCode(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const code = (body as Record<string, unknown>).code;
+  return typeof code === "string" ? code : null;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
 }
 
 async function defaultAccessTokenResolver(
@@ -344,13 +407,18 @@ class SupaCloudManagementClient<TClient extends SupabaseClient = SupabaseClient>
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
     });
 
-    if (!response.ok) {
-      throw new Error(`SupaCloud request failed (${response.status})`);
-    }
-
     if (response.status === 204) return undefined as T;
 
-    return (await response.json()) as T;
+    const responseBody = await readResponseBody(response);
+    if (!response.ok) {
+      const message =
+        responseBody && typeof responseBody === "object" && typeof (responseBody as Record<string, unknown>).message === "string"
+          ? String((responseBody as Record<string, unknown>).message)
+          : `SupaCloud request failed (${response.status})`;
+      throw new SupaCloudApiError(message, response.status, responseBody);
+    }
+
+    return responseBody as T;
   }
 }
 
@@ -379,6 +447,9 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
     const invokeHeaders = {
       ...headers,
       ...(idempotencyKey ? { "x-supacloud-idempotency-key": idempotencyKey } : {}),
+      ...(options.correlationId ? { "x-supacloud-correlation-id": options.correlationId } : {}),
+      ...(options.businessTaskId ? { "x-supacloud-business-task-id": options.businessTaskId } : {}),
+      ...(options.metadata ? { "x-supacloud-task-metadata": JSON.stringify(options.metadata) } : {}),
     };
     const { data, error } = await this.options.supabase.functions.invoke(functionName, {
       body,
@@ -682,6 +753,9 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
         maxAttempts: options.maxAttempts,
         idempotencyKey: options.idempotencyKey,
         traceId: options.traceId,
+        correlationId: options.correlationId,
+        businessTaskId: options.businessTaskId,
+        metadata: options.metadata,
       },
     );
   }
@@ -706,6 +780,28 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
 
   async listFailed(limit = 100): Promise<SupaCloudQueueMessage[]> {
     return this.list({ dlq: true, limit });
+  }
+
+  async stats(): Promise<SupaCloudQueueStats> {
+    return this.request<SupaCloudQueueStats>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/stats`,
+      "GET",
+    );
+  }
+
+  async getSettings(): Promise<SupaCloudQueueSettings> {
+    return this.request<SupaCloudQueueSettings>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/settings`,
+      "GET",
+    );
+  }
+
+  async updateSettings(settings: SupaCloudQueueSettingsUpdate): Promise<SupaCloudQueueSettings> {
+    return this.request<SupaCloudQueueSettings>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/settings`,
+      "PATCH",
+      settings,
+    );
   }
 
   async get(messageId: string): Promise<SupaCloudQueueMessage> {
@@ -752,6 +848,13 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/fail`,
       "POST",
       options,
+    );
+  }
+
+  async retry(messageId: string): Promise<SupaCloudQueueMessage> {
+    return this.request<SupaCloudQueueMessage>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/retry`,
+      "POST",
     );
   }
 }


### PR DESCRIPTION
## Summary
- add typed queue helpers in @supacloud/js for send, receive, ack, release, fail, retry, delete, list, stats, and settings
- preserve Management API error status/code/body via SupaCloudApiError
- persist queue correlationId, businessTaskId, and metadata through management-api task creation

## Verification
- bun test packages/supacloud-js/src/index.test.ts
- cd packages/supacloud-js && bun run typecheck && bun run typecheck:test
- bun test packages/management-api/tests/unit/task.routes.test.ts
- cd packages/management-api && bun run typecheck
- git diff --check