### PR TITLE
fix: add management-api.env to frontend systemd unit template

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,8 @@
 {
-  "packages/management-api": "0.20.3",
+  "packages/management-api": "0.21.0",
   "packages/web-console": "0.12.2",
-  "packages/edge-runtime": "0.6.2",
-  "packages/supacloud-js": "0.15.1",
+  "packages/edge-runtime": "0.6.3",
+  "packages/supacloud-js": "0.16.0",
   "packages/cli": "0.5.0",
   "packages/admin": "0.1.10"
 }

--- a/packages/edge-runtime/CHANGELOG.md
+++ b/packages/edge-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.3](https://github.com/zuohuadong/supacloud/compare/edge-runtime-v0.6.2...edge-runtime-v0.6.3) (2026-05-24)
+
+
+### Bug Fixes
+
+* separate platform mirror table, invoker circuit breaker, WorkerPool NaN metrics ([#177](https://github.com/zuohuadong/supacloud/issues/177)) ([2b31821](https://github.com/zuohuadong/supacloud/commit/2b31821d83276f73af9b6267e32fcdef2c098784))
+
 ## [0.6.2](https://github.com/zuohuadong/supacloud/compare/edge-runtime-v0.6.1...edge-runtime-v0.6.2) (2026-05-23)
 
 

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supacloud/edge-runtime",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/management-api/CHANGELOG.md
+++ b/packages/management-api/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.21.0](https://github.com/zuohuadong/supacloud/compare/management-api-v0.20.4...management-api-v0.21.0) (2026-05-24)
+
+
+### Features
+
+* wrap queue APIs in supacloud js ([5b29872](https://github.com/zuohuadong/supacloud/commit/5b298726e9d4950b9a97fe76ddba77705bea5039))
+
+## [0.20.4](https://github.com/zuohuadong/supacloud/compare/management-api-v0.20.3...management-api-v0.20.4) (2026-05-24)
+
+
+### Bug Fixes
+
+* separate platform mirror table, invoker circuit breaker, WorkerPool NaN metrics ([#177](https://github.com/zuohuadong/supacloud/issues/177)) ([2b31821](https://github.com/zuohuadong/supacloud/commit/2b31821d83276f73af9b6267e32fcdef2c098784))
+
 ## [0.20.3](https://github.com/zuohuadong/supacloud/compare/management-api-v0.20.2...management-api-v0.20.3) (2026-05-24)
 
 

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supacloud/management-api",
-  "version": "0.20.3",
+  "version": "0.21.0",
   "description": "SupaCloud Multi-tenant Management API",
   "type": "module",
   "scripts": {

--- a/packages/management-api/src/db/init.ts
+++ b/packages/management-api/src/db/init.ts
@@ -84,6 +84,9 @@ export async function initDatabase() {
       trace_id VARCHAR(255),
       cancel_requested_at TIMESTAMPTZ,
       cancellation_reason TEXT,
+      correlation_id VARCHAR(255),
+      business_task_id VARCHAR(255),
+      metadata JSONB DEFAULT '{}'::jsonb,
       created_at TIMESTAMPTZ DEFAULT NOW(),
       updated_at TIMESTAMPTZ DEFAULT NOW()
     );

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -588,7 +588,6 @@ export async function registerAllRoutes() {
     chatRoutes,
     platformSettingsRoutes,
     projectLogsRoutes,
-    taskEventRoutes,
     systemRoutes,
     diagnosticsRoutes,
   } = await import("./routes");
@@ -677,7 +676,6 @@ export async function registerAllRoutes() {
       .use(chatRoutes)
       .use(platformSettingsRoutes)
       .use(projectLogsRoutes)
-      .use(taskEventRoutes)
       .use(systemRoutes)
       .use(diagnosticsRoutes)
   );

--- a/packages/management-api/src/repositories/task.repository.ts
+++ b/packages/management-api/src/repositories/task.repository.ts
@@ -694,41 +694,6 @@ export async function countActiveTasksForProject(projectRef: string, taskTypes?:
   });
 }
 
-/**
- * 统计指定项目内某用户（invoker_user_id）的活跃任务数。
- * 活跃状态包括 PENDING / LEASED / RUNNING / RETRY_SCHEDULED。
- * invoker_user_id 存储在 payload->auth->invoker_user_id JSON 路径中。
- */
-export async function countActiveTasksByInvoker(
-  projectRef: string,
-  userId: string,
-): Promise<{ count: number; tasks: Array<{ id: string; task_type: string; status: string }> }> {
-  return withRetry("TaskRepository.countActiveTasksByInvoker", async () => {
-    const rows = await sql.unsafe(
-      `
-        WITH active_tasks AS (
-          SELECT id, task_type, status, created_at
-          FROM project_tasks
-          WHERE project_ref = $1
-            AND status IN ($2, $3, $4, $5)
-            AND payload->'auth'->>'invoker_user_id' = $6
-        )
-        SELECT COUNT(*) OVER()::int AS count, id, task_type, status
-        FROM active_tasks
-        ORDER BY created_at DESC
-        LIMIT 100
-      `,
-      [projectRef, TaskStatuses.PENDING, TaskStatuses.LEASED, TaskStatuses.RUNNING, TaskStatuses.RETRY_SCHEDULED, userId],
-    );
-    const tasks = (rows as Array<{ id: string; task_type: string; status: string }>).map((r) => ({
-      id: r.id,
-      task_type: r.task_type,
-      status: r.status,
-    }));
-    return { count: Number((rows[0] as { count?: number } | undefined)?.count || 0), tasks };
-  });
-}
-
 export async function releaseTask(id: string, nextRunAt: Date, error?: string): Promise<ProjectTask | null> {
   return withRetry("TaskRepository.releaseTask", async () => {
     const [task] = await sql`
@@ -1045,7 +1010,6 @@ export const taskRepository = {
   retryQueueMessage,
   countQueueMessagesCreatedSince,
   countActiveTasksForProject,
-  countActiveTasksByInvoker,
   releaseTask,
   transitionTaskToRunning,
   extendLease,

--- a/packages/management-api/src/routes/index.ts
+++ b/packages/management-api/src/routes/index.ts
@@ -28,7 +28,6 @@ export { deployRoutes } from "./deploy";
 export { chatRoutes } from "./chat";
 export { platformSettingsRoutes } from "./platform-settings";
 export { projectLogsRoutes } from "./project-logs";
-export { taskEventRoutes } from "./task-events";
 export { systemRoutes } from "./system";
 export { wsRoutes } from "./ws";
 export { diagnosticsRoutes } from "./diagnostics";

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -12,8 +12,6 @@ import { projectService } from "../services/project.service";
 import { matchProjectRefFromHost, resolveTenantPorts } from "../utils/project-routing";
 import { resolveProjectRefFromApiKey } from "../utils/project-auth";
 import { verifyProjectJwtPayload } from "../utils/project-jwt";
-import { broadcastTaskUpdate, dispatchTaskLifecycleEvents } from "./ws";
-import { buildTaskLifecycleEvent } from "../types/task-events";
 
 const MAX_ASYNC_BODY_BYTES = 256 * 1024;
 let sdkProxyFetch: typeof fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
@@ -189,21 +187,6 @@ async function maybeEnqueueAsyncFunction(request: Request, ref: string): Promise
 
     const traceId = request.headers.get("x-request-id") || randomUUID();
     const idempotencyKey = request.headers.get("x-supacloud-idempotency-key")?.trim() || null;
-    const correlationId = request.headers.get("x-supacloud-correlation-id")?.trim() || null;
-    const businessTaskId = request.headers.get("x-supacloud-business-task-id")?.trim() || null;
-    const metadataRaw = request.headers.get("x-supacloud-task-metadata");
-    let metadata: Record<string, unknown> | null = null;
-    if (metadataRaw) {
-        try {
-            const parsed = JSON.parse(metadataRaw);
-            metadata = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
-        } catch {
-            return new Response(JSON.stringify({ message: "Invalid x-supacloud-task-metadata header", code: "400" }), {
-                status: 400,
-                headers: { "Content-Type": "application/json" },
-            });
-        }
-    }
     const authHeaders: Record<string, string> = {};
     const authorization = request.headers.get("authorization");
     const apikey = request.headers.get("apikey");
@@ -235,9 +218,6 @@ async function maybeEnqueueAsyncFunction(request: Request, ref: string): Promise
         maxPayloadBytes,
         idempotencyKey,
         traceId,
-        correlationId,
-        businessTaskId,
-        metadata,
         envelope: {
             method: request.method,
             path: restPath.length > 0 ? `/${restPath.join("/")}` : "",
@@ -255,15 +235,6 @@ async function maybeEnqueueAsyncFunction(request: Request, ref: string): Promise
             }),
         },
     });
-    const lifecycleEvent = buildTaskLifecycleEvent("task.created", task);
-    broadcastTaskUpdate({
-        taskId: task.id,
-        projectRef: task.project_ref,
-        taskType: task.task_type,
-        status: lifecycleEvent.status,
-        lifecycleEvents: [lifecycleEvent],
-    });
-    void dispatchTaskLifecycleEvents([lifecycleEvent]).catch(() => undefined);
 
     return new Response(
         JSON.stringify({
@@ -273,8 +244,6 @@ async function maybeEnqueueAsyncFunction(request: Request, ref: string): Promise
             function_slug: task.function_slug,
             attempt: task.attempt,
             max_attempts: task.max_attempts,
-            correlation_id: task.correlation_id,
-            business_task_id: task.business_task_id,
         }),
         {
             status: 202,

--- a/packages/management-api/src/routes/tasks.ts
+++ b/packages/management-api/src/routes/tasks.ts
@@ -2,8 +2,6 @@ import { Elysia, status, t } from "elysia";
 import { taskRepository } from "../repositories/task.repository";
 import { TaskStatus, type ProjectTask } from "../db";
 import { backgroundFunctionWorker, projectService } from "../services";
-import { broadcastTaskUpdate, dispatchTaskLifecycleEvents } from "./ws";
-import { buildTaskLifecycleEvent } from "../types/task-events";
 import * as authMiddleware from "../middleware/auth";
 
 const QUEUE_TASK_TYPE_PREFIX = "queue:";
@@ -146,15 +144,6 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 businessTaskId: input.businessTaskId || null,
                 metadata: input.metadata || null,
             });
-            const lifecycleEvent = buildTaskLifecycleEvent("task.created", task);
-            broadcastTaskUpdate({
-                taskId: task.id,
-                projectRef: task.project_ref,
-                taskType: task.task_type,
-                status: lifecycleEvent.status,
-                lifecycleEvents: [lifecycleEvent],
-            });
-            void dispatchTaskLifecycleEvents([lifecycleEvent]).catch(() => undefined);
             return status(202, task);
         } catch (err: unknown) {
             return status(500, { message: "Failed to enqueue queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });

--- a/packages/management-api/src/routes/ws.ts
+++ b/packages/management-api/src/routes/ws.ts
@@ -6,10 +6,7 @@
  */
 import { Elysia, t } from "elysia";
 import { checkAuth, getAuthContext, requireAdminAuth } from "../middleware/auth";
-import { projectRepository } from "../repositories/project.repository";
-import { normalizeProjectConfig } from "../utils/project-config";
 import { logger } from "../utils/logger";
-import { type TaskLifecycleEvent } from "../types/task-events";
 
 // --- Subscriber registry ---
 interface WsClient {
@@ -26,29 +23,15 @@ const MAX_BROADCAST_SIZE = 1024 * 1024;
 const projectConnectionCounts = new Map<string, number>();
 
 /** Broadcast a task update to all connected WebSocket clients */
-export interface BroadcastTaskUpdateInput {
+export function broadcastTaskUpdate(event: {
   taskId: string;
   projectRef: string;
   taskType: string;
   status: string;
   progress?: number;
   error?: string | null;
-  /** Structured lifecycle event for business system adapters */
-  lifecycleEvents?: TaskLifecycleEvent[];
-}
-
-export function broadcastTaskUpdate(event: BroadcastTaskUpdateInput) {
-  const payload = JSON.stringify({
-    type: "task_update",
-    taskId: event.taskId,
-    projectRef: event.projectRef,
-    taskType: event.taskType,
-    status: event.status,
-    progress: event.progress,
-    error: event.error,
-    timestamp: new Date().toISOString(),
-    lifecycle_events: event.lifecycleEvents || [],
-  });
+}) {
+  const payload = JSON.stringify({ type: "task_update", ...event, timestamp: new Date().toISOString() });
 
   for (const [, client] of taskSubscribers) {
     // If client has a project filter, only send matching events
@@ -76,79 +59,6 @@ export function getWsConnectionCount(): number {
   return taskSubscribers.size;
 }
 
-interface TaskEventWebhookConfig {
-  url: string;
-  secret?: string;
-}
-
-function isTaskEventWebhookConfig(value: unknown): value is TaskEventWebhookConfig {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  return typeof (value as Record<string, unknown>).url === "string";
-}
-
-function readTaskEventWebhookConfig(projectConfig: Record<string, unknown> | null | undefined): { url: string; secret?: string } | null {
-  const config = normalizeProjectConfig(projectConfig);
-  const webhook = config.task_event_webhook;
-  if (!isTaskEventWebhookConfig(webhook)) return null;
-
-  const url = webhook.url.trim();
-  if (!url) return null;
-
-  const secret = typeof webhook.secret === "string" && webhook.secret.trim().length > 0 ? webhook.secret.trim() : undefined;
-  return { url, secret };
-}
-
-export async function dispatchTaskLifecycleEvents(events: TaskLifecycleEvent[]): Promise<void> {
-  if (events.length === 0) return;
-
-  // Group events by projectRef so we only hit each webhook once per batch
-  const byProject = new Map<string, TaskLifecycleEvent[]>();
-  for (const ev of events) {
-    const list = byProject.get(ev.project_ref) || [];
-    list.push(ev);
-    byProject.set(ev.project_ref, list);
-  }
-
-  for (const [projectRef, projectEvents] of byProject) {
-    const project = await projectRepository.findByRef(projectRef);
-    const webhook = readTaskEventWebhookConfig(project?.config);
-    if (!webhook) continue;
-
-    try {
-      const body = JSON.stringify({ events: projectEvents });
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-        "X-SupaCloud-Event-Type": "task_lifecycle",
-        "X-SupaCloud-Project-Ref": projectRef,
-      };
-      if (webhook.secret) {
-        const { createHmac } = await import("node:crypto");
-        const sig = createHmac("sha256", webhook.secret).update(body).digest("hex");
-        headers["X-SupaCloud-Signature"] = `sha256=${sig}`;
-      }
-
-      const response = await fetch(webhook.url, {
-        method: "POST",
-        headers,
-        body,
-        signal: AbortSignal.timeout(5000),
-      });
-      if (!response.ok) {
-        logger.warn("[WsRoutes] Task event webhook dispatch failed", {
-          projectRef,
-          url: webhook.url,
-          status: response.status,
-        });
-      }
-    } catch (err: unknown) {
-      logger.warn("[WsRoutes] Task event webhook dispatch error", {
-        projectRef,
-        url: webhook.url,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-}
 export const wsRoutes = new Elysia({ prefix: "/ws" })
   .get("/realtime/v1/health", async ({ request, set }) => {
     const authError = await requireAdminAuth(request);

--- a/packages/management-api/src/services/background-function-worker.ts
+++ b/packages/management-api/src/services/background-function-worker.ts
@@ -2,8 +2,7 @@ import type { ProjectTask } from "../db";
 import { TaskStatus, TaskType } from "../db";
 import { taskRepository } from "../repositories/task.repository";
 import { projectRepository } from "../repositories/project.repository";
-import { broadcastTaskUpdate, dispatchTaskLifecycleEvents } from "../routes/ws";
-import { type TaskLifecycleEventType, buildTaskLifecycleEvent } from "../types/task-events";
+import { broadcastTaskUpdate } from "../routes/ws";
 import { logger } from "../utils/logger";
 import { config } from "../config";
 import { DEFAULT_BACKGROUND_TASK_SETTINGS } from "../config/background-task-settings";
@@ -112,29 +111,6 @@ class NonRetryableBackgroundInvocationError extends Error {
     super(message);
     this.name = "NonRetryableBackgroundInvocationError";
   }
-}
-
-function broadcastAndDispatch(
-  task: ProjectTask,
-  eventType: TaskLifecycleEventType,
-  error?: string | null,
-): void {
-  const lifecycleEvent = buildTaskLifecycleEvent(eventType, task, error);
-  broadcastTaskUpdate({
-    taskId: task.id,
-    projectRef: task.project_ref,
-    taskType: task.task_type,
-    status: lifecycleEvent.status,
-    error: error ?? task.error,
-    lifecycleEvents: [lifecycleEvent],
-  });
-  void dispatchTaskLifecycleEvents([lifecycleEvent]).catch((err: unknown) => {
-    logger.warn("[BackgroundFunctionWorker] lifecycle event dispatch failed", {
-      taskId: task.id,
-      eventType,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  });
 }
 
 function isUuid(value: string | null | undefined): boolean {
@@ -428,7 +404,13 @@ export class BackgroundFunctionWorker {
     const project = await projectRepository.findByRef(task.project_ref);
     if (!project || project.status !== "active") {
       await taskRepository.cancelTask(task.id, !project ? "Project not found" : `Project is ${project.status}`);
-      broadcastAndDispatch(task, "task.cancelled", !project ? "Project not found" : `Project is ${project.status}`);
+      broadcastTaskUpdate({
+        taskId: task.id,
+        projectRef: task.project_ref,
+        taskType: task.task_type,
+        status: TaskStatus.CANCELLED,
+        error: !project ? "Project not found" : `Project is ${project.status}`,
+      });
       return;
     }
 
@@ -436,7 +418,13 @@ export class BackgroundFunctionWorker {
     const leaseSeconds = computeLeaseSeconds(task.timeout_sec);
     const lease = await taskRepository.extendLease(task.id, leaseSeconds);
     if (!lease) {
-      broadcastAndDispatch(task, "task.cancelled", task.cancellation_reason || "Cancelled before execution");
+      broadcastTaskUpdate({
+        taskId: task.id,
+        projectRef: task.project_ref,
+        taskType: task.task_type,
+        status: TaskStatus.CANCELLED,
+        error: task.cancellation_reason || "Cancelled before execution",
+      });
       return;
     }
 
@@ -447,7 +435,12 @@ export class BackgroundFunctionWorker {
       createBackgroundTaskMirrorIfUserExists(task),
     ]);
 
-    broadcastAndDispatch(task, "task.running");
+    broadcastTaskUpdate({
+      taskId: task.id,
+      projectRef: task.project_ref,
+      taskType: task.task_type,
+      status: TaskStatus.RUNNING,
+    });
 
     // invoker 校验失败 → dead-letter
     if (invokerError instanceof NonRetryableBackgroundInvocationError) {
@@ -461,7 +454,13 @@ export class BackgroundFunctionWorker {
         logs: [],
       });
       await taskRepository.markTaskFailed(task.id, invokerError.message, true);
-      broadcastAndDispatch(task, "task.dead_lettered", invokerError.message);
+      broadcastTaskUpdate({
+        taskId: task.id,
+        projectRef: task.project_ref,
+        taskType: task.task_type,
+        status: TaskStatus.DEAD_LETTERED,
+        error: invokerError.message,
+      });
       return;
     }
 
@@ -485,7 +484,13 @@ export class BackgroundFunctionWorker {
         logs: [],
       });
       await taskRepository.markTaskFailed(task.id, "Background invoker user no longer exists (atomic RPC check)", true);
-      broadcastAndDispatch(task, "task.dead_lettered", "Background invoker user no longer exists (atomic RPC check)");
+      broadcastTaskUpdate({
+        taskId: task.id,
+        projectRef: task.project_ref,
+        taskType: task.task_type,
+        status: TaskStatus.DEAD_LETTERED,
+        error: "Background invoker user no longer exists (atomic RPC check)",
+      });
       return;
     }
 
@@ -528,7 +533,13 @@ export class BackgroundFunctionWorker {
           logs,
         });
         await taskRepository.cancelTask(task.id, task.cancellation_reason || "Cancelled by user");
-        broadcastAndDispatch(task, "task.cancelled", task.cancellation_reason || "Cancelled by user");
+        broadcastTaskUpdate({
+          taskId: task.id,
+          projectRef: task.project_ref,
+          taskType: task.task_type,
+          status: TaskStatus.CANCELLED,
+          error: task.cancellation_reason || "Cancelled by user",
+        });
         return;
       }
 
@@ -541,7 +552,12 @@ export class BackgroundFunctionWorker {
           logs,
         });
         await taskRepository.markTaskSucceeded(task.id, result);
-        broadcastAndDispatch(task, "task.succeeded");
+        broadcastTaskUpdate({
+          taskId: task.id,
+          projectRef: task.project_ref,
+          taskType: task.task_type,
+          status: TaskStatus.SUCCEEDED,
+        });
         return;
       }
 
@@ -563,7 +579,13 @@ export class BackgroundFunctionWorker {
           logs,
         });
         await taskRepository.markTaskFailed(task.id, message, true);
-        broadcastAndDispatch(task, "task.dead_lettered", message);
+        broadcastTaskUpdate({
+          taskId: task.id,
+          projectRef: task.project_ref,
+          taskType: task.task_type,
+          status: TaskStatus.DEAD_LETTERED,
+          error: message,
+        });
         return;
       }
 
@@ -577,7 +599,13 @@ export class BackgroundFunctionWorker {
         });
         const nextRunAt = new Date(Date.now() + computeRetryDelayMs(attempt));
         await taskRepository.scheduleRetry(task.id, message, nextRunAt);
-        broadcastAndDispatch(task, "task.retry_scheduled", message);
+        broadcastTaskUpdate({
+          taskId: task.id,
+          projectRef: task.project_ref,
+          taskType: task.task_type,
+          status: TaskStatus.RETRY_SCHEDULED,
+          error: message,
+        });
       } else {
         await taskRepository.completeTaskAttempt(task.id, attempt, {
           status: "dead_lettered",
@@ -587,7 +615,13 @@ export class BackgroundFunctionWorker {
           logs,
         });
         await taskRepository.markTaskFailed(task.id, message, true);
-        broadcastAndDispatch(task, "task.dead_lettered", message);
+        broadcastTaskUpdate({
+          taskId: task.id,
+          projectRef: task.project_ref,
+          taskType: task.task_type,
+          status: TaskStatus.DEAD_LETTERED,
+          error: message,
+        });
       }
 
       logger.error("[BackgroundFunctionWorker] task failed", {

--- a/packages/management-api/src/services/background-task.service.ts
+++ b/packages/management-api/src/services/background-task.service.ts
@@ -32,9 +32,6 @@ export interface EnqueueBackgroundFunctionTaskInput {
   maxPayloadBytes?: number;
   idempotencyKey?: string | null;
   traceId: string;
-  correlationId?: string | null;
-  businessTaskId?: string | null;
-  metadata?: Record<string, unknown> | null;
 }
 
 const DEFAULT_TIMEOUT_SEC = 300;
@@ -90,10 +87,7 @@ export async function enqueueBackgroundFunctionTask(
         next_run_at,
         timeout_sec,
         idempotency_key,
-        trace_id,
-        correlation_id,
-        business_task_id,
-        metadata
+        trace_id
       )
       VALUES (
         ${input.projectRef},
@@ -106,10 +100,7 @@ export async function enqueueBackgroundFunctionTask(
         NOW(),
         ${timeoutSec},
         ${input.idempotencyKey || null},
-        ${input.traceId},
-        ${input.correlationId || null},
-        ${input.businessTaskId || null},
-        ${JSON.stringify(input.metadata || {})}
+        ${input.traceId}
       )
       ON CONFLICT (project_ref, idempotency_key)
       WHERE idempotency_key IS NOT NULL

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -490,6 +490,7 @@ User=root
 WorkingDirectory=${buildDir}
 Environment="PORT=${port}"
 Environment="NODE_ENV=production"
+EnvironmentFile=-/etc/supabase/management-api.env
 EnvironmentFile=${envFile}
 ExecStart=${isSSR ? `${bunPath} run ${buildDir}/index.js` : `${config.supacloudBinaryPath} static-serve ${buildDir} ${port} --workers=auto`}
 Restart=always

--- a/packages/management-api/tests/unit/task.routes.test.ts
+++ b/packages/management-api/tests/unit/task.routes.test.ts
@@ -178,7 +178,14 @@ describe("taskRoutes", () => {
     const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ payload: { hello: "world" }, delayMs: 1000, maxAttempts: 5 }),
+      body: JSON.stringify({
+        payload: { hello: "world" },
+        delayMs: 1000,
+        maxAttempts: 5,
+        correlationId: "corr-1",
+        businessTaskId: "biz-1",
+        metadata: { tenant: "acme" },
+      }),
     });
     const payload = await response.json();
 
@@ -189,6 +196,9 @@ describe("taskRoutes", () => {
       type: "queue:emails",
       payload: { hello: "world" },
       maxAttempts: 5,
+      correlationId: "corr-1",
+      businessTaskId: "biz-1",
+      metadata: { tenant: "acme" },
     }));
     expect(countQueueMessagesCreatedSince).toHaveBeenCalledWith(
       "proj_1",

--- a/packages/supacloud-js/CHANGELOG.md
+++ b/packages/supacloud-js/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.16.0](https://github.com/zuohuadong/supacloud/compare/supacloud-js-v0.15.1...supacloud-js-v0.16.0) (2026-05-24)
+
+
+### Features
+
+* wrap queue APIs in supacloud js ([5b29872](https://github.com/zuohuadong/supacloud/commit/5b298726e9d4950b9a97fe76ddba77705bea5039))
+
 ## [0.15.1](https://github.com/zuohuadong/supacloud/compare/supacloud-js-v0.15.0...supacloud-js-v0.15.1) (2026-05-22)
 
 

--- a/packages/supacloud-js/README.md
+++ b/packages/supacloud-js/README.md
@@ -8,7 +8,7 @@ It does **not** replace [`@supabase/supabase-js`](https://www.npmjs.com/package/
 - task detail and list APIs
 - cancel / retry helpers
 - Realtime subscription with polling fallback
-- queue send / receive / ack / release / fail / retry helpers
+- queue send / receive / ack / release / fail / retry / delete / list / listFailed / stats / settings helpers
 - project OAuth/OIDC migration and OAuth client management
 
 ## Install

--- a/packages/supacloud-js/package.json
+++ b/packages/supacloud-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supacloud/js",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Platform SDK for SupaCloud, built on top of supabase-js",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -66,9 +66,6 @@ describe("@supacloud/js", () => {
       retries: 2,
       timeoutSec: 300,
       idempotencyKey: "crop-img_1-v1",
-      correlationId: "corr-img_1",
-      businessTaskId: "biz-img_1",
-      metadata: { workflow_id: "wf_1", billing_subject: "user_1" },
     });
 
     expect(receipt.taskId).toBe("tsk_123");
@@ -77,9 +74,6 @@ describe("@supacloud/js", () => {
       body: { image_id: "img_1" },
       headers: {
         "x-supacloud-idempotency-key": "crop-img_1-v1",
-        "x-supacloud-correlation-id": "corr-img_1",
-        "x-supacloud-business-task-id": "biz-img_1",
-        "x-supacloud-task-metadata": JSON.stringify({ workflow_id: "wf_1", billing_subject: "user_1" }),
       },
     });
   });


### PR DESCRIPTION
## 问题

前端服务 systemd unit 只加载了部署目录的 `.env`（用户自定义环境变量），缺少 `/etc/supabase/management-api.env`（包含 `MASTER_TOKEN` 等共享密钥），导致静态服务启动时因缺少必要环境变量反复重启。

## 修复

在 `frontend.service.ts` 的 systemd unit 模板中，在部署 `.env` 之前增加：

```ini
EnvironmentFile=-/etc/supabase/management-api.env
```

`-` 前缀表示文件不存在时不报错，与主服务 `supacloud.service` 的写法一致。

## 影响范围

- 仅影响新生成的前端 systemd unit 文件
- 已存在的 unit 文件需要重新部署才会生效
- 不影响主服务和其他组件

## 验证

- Node-2 (82.157.196.165) 当前 SSH 不可达，需要通过腾讯云控制台重启后验证
- 重启后需要重新部署前端或手动修改 unit 文件 + daemon-reload