### PR TITLE
fix: add management-api.env to frontend systemd unit template

### DIFF
--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -490,6 +490,7 @@ User=root
 WorkingDirectory=${buildDir}
 Environment="PORT=${port}"
 Environment="NODE_ENV=production"
+EnvironmentFile=-/etc/supabase/management-api.env
 EnvironmentFile=${envFile}
 ExecStart=${isSSR ? `${bunPath} run ${buildDir}/index.js` : `${config.supacloudBinaryPath} static-serve ${buildDir} ${port} --workers=auto`}
 Restart=always


### PR DESCRIPTION
## 问题

前端服务 systemd unit 只加载了部署目录的 `.env`（用户自定义环境变量），缺少 `/etc/supabase/management-api.env`（包含 `MASTER_TOKEN` 等共享密钥），导致静态服务启动时因缺少必要环境变量反复重启。

## 修复

在 `frontend.service.ts` 的 systemd unit 模板中，在部署 `.env` 之前增加：

```ini
EnvironmentFile=-/etc/supabase/management-api.env
```

`-` 前缀表示文件不存在时不报错，与主服务 `supacloud.service` 的写法一致。

## 影响范围

- 仅影响新生成的前端 systemd unit 文件
- 已存在的 unit 文件需要重新部署才会生效
- 不影响主服务和其他组件