### PR TITLE
fix(management-api): use release binary for frontend static units

### DIFF
--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -134,6 +134,21 @@ function getEnv(key: string, defaultValue = ""): string {
 const DEFAULT_JWT_SECRET = "super-secret-jwt-token-with-at-least-32-characters-long";
 const DEFAULT_DASHBOARD_PASSWORDS = new Set(["supabase", "supacloud", "admin", "password", "changeme"]);
 const DEVELOPMENT_ENVS = new Set(["development", "test"]);
+const DEFAULT_SUPACLOUD_BINARY_PATH = "/opt/supacloud/supacloud";
+
+export function resolveSupacloudBinaryPath(explicitPath = process.env.SUPACLOUD_BINARY_PATH, execPath = process.execPath): string {
+  const configuredPath = explicitPath?.trim();
+  if (configuredPath) {
+    return configuredPath;
+  }
+
+  const executableName = execPath.split(/[\\/]/).pop() || "";
+  if (executableName === "bun" || executableName.startsWith("bun-")) {
+    return DEFAULT_SUPACLOUD_BINARY_PATH;
+  }
+
+  return execPath || DEFAULT_SUPACLOUD_BINARY_PATH;
+}
 
 const isGithubActions = getEnv("GITHUB_ACTIONS") === "true";
 const edgeRuntimePort = Number(getEnv("EDGE_RUNTIME_PORT", "9000"));
@@ -246,7 +261,7 @@ export const config: Config = {
     ),
   ),
   bunPath: getEnv("BUN_PATH", "bun"),
-  supacloudBinaryPath: getEnv("SUPACLOUD_BINARY_PATH", "/opt/supacloud/supacloud"),
+  supacloudBinaryPath: resolveSupacloudBinaryPath(),
   sdkProxyTimeoutMs: Number(getEnv("SDK_PROXY_TIMEOUT_MS", "30000")),
   restProxyTimeoutMs: Number(getEnv("REST_PROXY_TIMEOUT_MS", "300000")),
   secretsEncryptionKey: getEnv("SECRETS_ENCRYPTION_KEY", getEnv("MASTER_TOKEN", "")),

--- a/packages/management-api/tests/unit/frontend.service.test.ts
+++ b/packages/management-api/tests/unit/frontend.service.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { config } from "../../src/config";
+import { config, resolveSupacloudBinaryPath } from "../../src/config";
 import { FrontendService } from "../../src/services/frontend.service";
 
 const originalFetch = globalThis.fetch;
@@ -65,5 +65,19 @@ describe("FrontendService DNS records", () => {
     } finally {
       await rm(baseDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("FrontendService static binary resolution", () => {
+  test("uses explicit SUPACLOUD_BINARY_PATH when provided", () => {
+    expect(resolveSupacloudBinaryPath("/custom/supacloud", "/usr/local/bin/supacloud")).toBe("/custom/supacloud");
+  });
+
+  test("uses the current release binary when not running through bun", () => {
+    expect(resolveSupacloudBinaryPath("", "/usr/local/bin/supacloud")).toBe("/usr/local/bin/supacloud");
+  });
+
+  test("keeps the legacy install path for source runs through bun", () => {
+    expect(resolveSupacloudBinaryPath("", "/root/.bun/bin/bun")).toBe("/opt/supacloud/supacloud");
   });
 });

--- a/packages/management-api/tests/unit/task.repository.invoker-count.test.ts
+++ b/packages/management-api/tests/unit/task.repository.invoker-count.test.ts
@@ -16,9 +16,6 @@ mock.module("../../src/db", () => ({
   },
 }));
 
-mock.module("../../src/utils/retry", () => ({
-  withRetry: async (_name: string, fn: () => Promise<unknown>) => fn(),
-}));
 
 const { countActiveTasksByInvoker } = await import(
   new URL("../../src/repositories/task.repository.ts?task-repository-invoker-count-test", import.meta.url).href


### PR DESCRIPTION
## Summary
- default `SUPACLOUD_BINARY_PATH` to the running release binary when management-api itself is not launched through Bun
- make `supacloud static-serve` an isolated entrypoint before management-api app/Kong startup
- skip production management-api secret validation for the static file server subcommand
- cover release binary resolution and production static-serve startup without management secrets

## Context
AoristCross frontend upload deploys on the latest SupaCloud release still failed readiness. The generated frontend systemd unit invoked stale `/opt/supacloud/supacloud`, while management-api was running the release binary from `/usr/local/bin/supacloud`. Even when pointed at the release binary, `static-serve` still entered management-api config validation/startup before serving static files, so `/healthz` never came up reliably.

The task CORS issue itself is already fixed in latest SupaCloud and passed the SupaCloud smoke test after restarting the latest release and rebuilding Kong config.

## Verification
- `bun test packages/management-api/tests/unit/frontend.service.test.ts packages/management-api/tests/unit/bun-static-serve.test.ts`
- `cd packages/management-api && bun run typecheck`
- `git diff --check`