### PR TITLE
fix(management-api): isolate static serve entrypoint

### DIFF
--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -1,3 +1,8 @@
+/** Check whether the process was invoked as the static-serve subcommand. */
+export function isStaticServeCommand(): boolean {
+  return process.argv[2] === "static-serve";
+}
+
 import { existsSync, readFileSync } from "node:fs";
 
 const MANAGEMENT_API_ENV = "/etc/supabase/management-api.env";
@@ -268,7 +273,7 @@ export const config: Config = {
 };
 
 function validateConfig() {
-  if (process.argv[2] === "static-serve") {
+  if (isStaticServeCommand()) {
     return;
   }
 

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -268,6 +268,10 @@ export const config: Config = {
 };
 
 function validateConfig() {
+  if (process.argv[2] === "static-serve") {
+    return;
+  }
+
   if (!config.databaseUrl || !/^postgresql?:\/\//.test(config.databaseUrl)) {
     throw new Error("Invalid or missing DATABASE_URL configuration. Must be a valid postgres DSN string.");
   }

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -88,6 +88,18 @@ async function getEmbeddedAssets() {
   return _embeddedAssets;
 }
 
+const args = process.argv.slice(2);
+
+if (args[0] === "static-serve") {
+  const { runStaticServeCli } = await import("./utils/bun-static-serve");
+  runStaticServeCli(args.slice(1));
+  await new Promise<void>((resolve) => {
+    process.once("SIGINT", resolve);
+    process.once("SIGTERM", resolve);
+  });
+  process.exit(0);
+}
+
 // --- Gateway-style try_files static asset serving ---
 // No pre-warmed Set. Direct disk checks per request (Bun.file is near-zero-cost).
 // index.html is cached in memory with mtime-based invalidation.
@@ -680,8 +692,6 @@ export async function registerAllRoutes() {
       .use(diagnosticsRoutes)
   );
 }
-
-const args = process.argv.slice(2);
 
 function readArgValue(...names: string[]) {
   for (const name of names) {

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1,5 +1,6 @@
 import { Elysia, t } from "elysia";
 import { logger } from "./utils/logger";
+import { isStaticServeCommand } from "./config";
 
 process.on("uncaughtException", (err: Error) => {
   logger.error("FATAL UNCAUGHT EXCEPTION:", {
@@ -90,7 +91,7 @@ async function getEmbeddedAssets() {
 
 const args = process.argv.slice(2);
 
-if (args[0] === "static-serve") {
+if (isStaticServeCommand()) {
   const { runStaticServeCli } = await import("./utils/bun-static-serve");
   runStaticServeCli(args.slice(1));
   await new Promise<void>((resolve) => {
@@ -907,7 +908,7 @@ async function bootstrap() {
         process.exit(0);
     }
     process.exit(0);
-  } else if (args[0] === "static-serve") {
+  } else if (isStaticServeCommand()) {
     const { runStaticServeCli } = await import("./utils/bun-static-serve");
     runStaticServeCli(args.slice(1));
   } else if (args.includes("--version") || args.includes("-v")) {

--- a/packages/management-api/tests/unit/bun-static-serve.test.ts
+++ b/packages/management-api/tests/unit/bun-static-serve.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { spawn } from "bun";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -91,7 +92,6 @@ describe("bun-static-serve", () => {
     expect(response.headers.get("content-length")).toBe("5");
     expect(await response.text()).toBe("");
   });
-});
 
   test("/healthz returns 200 for readiness probes", async () => {
     const root = await createRoot();
@@ -114,3 +114,55 @@ describe("bun-static-serve", () => {
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("ok");
   });
+
+  test("index static-serve subcommand does not require management-api production secrets", async () => {
+    const root = await createRoot();
+    await writeFile(join(root, "index.html"), "index");
+
+    const port = 41000 + Math.floor(Math.random() * 1000);
+    const indexPath = join(import.meta.dir, "../../src/index.ts");
+    const proc = spawn({
+      cmd: ["bun", indexPath, "static-serve", root, String(port), "--workers=1"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        PATH: process.env.PATH ?? "",
+        NODE_ENV: "production",
+      },
+    });
+
+    let exited = false;
+    proc.exited.then(() => {
+      exited = true;
+    });
+
+    let ready = false;
+    const deadline = Date.now() + 5_000;
+    try {
+      while (Date.now() < deadline && !exited) {
+        try {
+          const response = await fetch(`http://127.0.0.1:${port}/healthz`, {
+            signal: AbortSignal.timeout(200),
+          });
+          if (response.ok && await response.text() === "ok") {
+            ready = true;
+            break;
+          }
+        } catch {
+          await Bun.sleep(100);
+        }
+      }
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited.catch(() => undefined);
+    }
+
+    if (!ready) {
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`static-serve did not become ready\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    }
+
+    expect(ready).toBe(true);
+  }, 10_000);
+});

--- a/packages/management-api/tests/unit/bun-static-serve.test.ts
+++ b/packages/management-api/tests/unit/bun-static-serve.test.ts
@@ -5,6 +5,20 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createFetchHandler } from "../../src/utils/bun-static-serve";
 
+import { createServer } from "node:net";
+
+/** Get a free TCP port by briefly listening on port 0. */
+async function getFreePort(): Promise<number> {
+  const server = createServer();
+  return new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      server.close(() => resolve(addr.port));
+    });
+    server.on("error", reject);
+  });
+}
+
 let roots: string[] = [];
 
 afterEach(async () => {
@@ -119,7 +133,7 @@ describe("bun-static-serve", () => {
     const root = await createRoot();
     await writeFile(join(root, "index.html"), "index");
 
-    const port = 41000 + Math.floor(Math.random() * 1000);
+    const port = await getFreePort();
     const indexPath = join(import.meta.dir, "../../src/index.ts");
     const proc = spawn({
       cmd: ["bun", indexPath, "static-serve", root, String(port), "--workers=1"],
@@ -164,5 +178,34 @@ describe("bun-static-serve", () => {
     }
 
     expect(ready).toBe(true);
+  }, 10_000);
+});
+
+describe("config validation bypass", () => {
+  test("non-static-serve entry fails in production without DATABASE_URL", async () => {
+    const indexPath = join(import.meta.dir, "../../src/index.ts");
+    const proc = spawn({
+      cmd: ["bun", indexPath],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        PATH: process.env.PATH ?? "",
+        NODE_ENV: "production",
+      },
+    });
+
+    const exitPromise = proc.exited;
+    const timeout = Bun.sleep(8_000).then(() => -1);
+    const exitCode = await Promise.race([exitPromise, timeout]);
+
+    if (exitCode === -1) {
+      proc.kill("SIGKILL");
+      await proc.exited.catch(() => undefined);
+      throw new Error("Process did not exit within timeout — config bypass may have been applied incorrectly");
+    }
+
+    const stderr = await new Response(proc.stderr).text();
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/MASTER_TOKEN|JWT_SECRET|DATABASE_URL|SECRETS_ENCRYPTION_KEY/);
   }, 10_000);
 });


### PR DESCRIPTION
## Summary
- make `supacloud static-serve` take over before management-api app/Kong startup
- skip management-api production secret validation for the static file server subcommand
- add a regression test that starts `src/index.ts static-serve` under `NODE_ENV=production` without management secrets and waits for `/healthz`

## Context
PR #187 fixed frontend systemd units choosing the stale `/opt/supacloud/supacloud` binary by default. Production validation then exposed a second issue: even when using the release binary, `static-serve` still executed management-api config validation/startup before serving files. Static frontend units should not need `MASTER_TOKEN` or run Kong setup just to expose `/healthz`.

## Task Contract

**Goal**: Allow `supacloud static-serve` to start without requiring production management-api secrets (DATABASE_URL, MASTER_TOKEN, JWT_SECRET, etc.), so that frontend-only systemd units can serve static files and health checks independently.

**Non-goals**: This does NOT relax validation for the normal API server path. The full management-api still requires all production secrets.

**What config validation is bypassed**: Only `validateConfig()` is skipped when `isStaticServeCommand()` returns true. This includes DATABASE_URL, MASTER_TOKEN, JWT_SECRET, DASHBOARD_PASSWORD, and SECRETS_ENCRYPTION_KEY checks. The bypass is gated by the single shared helper `isStaticServeCommand()`.

**Normal API startup still validates**: Any invocation without `static-serve` as the first subcommand runs the full `validateConfig()` suite in production.

**Rollback**: Revert this PR; static-serve will again require all production secrets (matching pre-#187 behavior where the old binary path was used).

**Verification**:
- `bun test packages/management-api/tests/unit/bun-static-serve.test.ts` — 10 tests pass (including subprocess integration test and negative regression test)
- `cd packages/management-api && bun run typecheck` — clean
- `git diff --check origin/main..HEAD` — no whitespace issues
- CI: All checks green (Lint & Type Check, Unit Tests, Integration & Compliance Tests, Package Checks, Docker & Scripts Checks, Shell Scripts Lint)

## Review fixes (addressing AI Code Review REQUEST_CHANGES)
1. **Shared helper**: Extracted `isStaticServeCommand()` in `config.ts` and used it in both `validateConfig()` and `index.ts` entry routing, eliminating the duplicated `process.argv[2] === "static-serve"` / `args[0] === "static-serve"` pattern.
2. **Port conflict**: Replaced `41000 + Math.random() * 1000` with `getFreePort()` (listen on port 0, return the OS-assigned port) to eliminate flaky CI failures from port collisions.
3. **Negative regression test**: Added `non-static-serve entry fails in production without DATABASE_URL` test that confirms the normal API entry still enforces production config validation.
4. **Task Contract**: Added goal, non-goals, bypass scope, rollback, and verification evidence to PR description.