### PR TITLE
fix: spawn static workers from release binary path

### DIFF
--- a/packages/management-api/src/utils/bun-static-serve.ts
+++ b/packages/management-api/src/utils/bun-static-serve.ts
@@ -271,19 +271,46 @@ export function startStaticServer(root: string, port: number, reusePort = false)
 
 // ─── Cluster Manager: spawns N workers sharing the same port ─────────────────
 
-function getSpawnCmd(): string[] {
-  // When running as a compiled binary, process.execPath is the binary itself.
-  // When running via bun, fall back to "bun run <source>".
-  const isBun = process.argv[0].includes("bun");
-  if (isBun) {
-    return ["bun", "run", import.meta.path];
+function isBunExecutable(path: string): boolean {
+  const executableName = path.split(/[\\/]/).pop() || "";
+  return executableName === "bun" || executableName.startsWith("bun-");
+}
+
+function isBundledVirtualPath(path: string): boolean {
+  return path.startsWith("/$bunfs/") || path.startsWith("\\$bunfs\\");
+}
+
+export function resolveStaticServeSpawnCmd({
+  argv0 = process.argv[0] || "",
+  processArgv0 = process.argv0 || "",
+  execPath = process.execPath,
+  sourcePath = import.meta.path,
+}: {
+  argv0?: string;
+  processArgv0?: string;
+  execPath?: string;
+  sourcePath?: string;
+} = {}): string[] {
+  // Release binaries may expose process.execPath as /$bunfs/root/<binary>, which
+  // is not spawnable from a child process. Prefer the real path used to invoke us.
+  for (const candidate of [processArgv0, execPath, argv0]) {
+    if (!candidate || isBunExecutable(candidate) || isBundledVirtualPath(candidate)) {
+      continue;
+    }
+
+    return [candidate, "static-serve"];
   }
-  // Binary mode: must include "static-serve" subcommand so workers route correctly
-  return [process.execPath, "static-serve"];
+
+  // When running via bun, fall back to "bun run <source>".
+  if (isBunExecutable(argv0) || isBunExecutable(processArgv0) || isBunExecutable(execPath)) {
+    return ["bun", "run", sourcePath];
+  }
+
+  return [execPath, "static-serve"];
 }
 
 function spawnWorker(root: string, port: number, workerId: number): ReturnType<typeof spawn> {
-  const cmd = [...getSpawnCmd(), root, String(port), "--worker"];
+  const cmd = [...resolveStaticServeSpawnCmd(), root, String(port), "--worker"];
   return spawn({
     cmd,
     stdout: "inherit",

--- a/packages/management-api/tests/unit/bun-static-serve.test.ts
+++ b/packages/management-api/tests/unit/bun-static-serve.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "bun";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { createFetchHandler } from "../../src/utils/bun-static-serve";
+import { createFetchHandler, resolveStaticServeSpawnCmd } from "../../src/utils/bun-static-serve";
 
 import { createServer } from "node:net";
 
@@ -35,6 +35,24 @@ async function createRoot(): Promise<string> {
 }
 
 describe("bun-static-serve", () => {
+  test("spawns release binary workers from the real executable path", () => {
+    expect(resolveStaticServeSpawnCmd({
+      argv0: "bun",
+      processArgv0: "/usr/local/bin/supacloud",
+      execPath: "/$bunfs/root/supacloud-linux-amd64",
+      sourcePath: "/repo/packages/management-api/src/utils/bun-static-serve.ts",
+    })).toEqual(["/usr/local/bin/supacloud", "static-serve"]);
+  });
+
+  test("spawns script workers through bun run in development", () => {
+    expect(resolveStaticServeSpawnCmd({
+      argv0: "/home/dev/.bun/bin/bun",
+      processArgv0: "/home/dev/.bun/bin/bun",
+      execPath: "/home/dev/.bun/bin/bun",
+      sourcePath: "/repo/packages/management-api/src/utils/bun-static-serve.ts",
+    })).toEqual(["bun", "run", "/repo/packages/management-api/src/utils/bun-static-serve.ts"]);
+  });
+
   test("prefers flat route html over a directory collision", async () => {
     const root = await createRoot();
     await writeFile(join(root, "index.html"), "index");


### PR DESCRIPTION
## Summary
- Fix static-serve cluster mode under compiled release binaries by avoiding Bun's / virtual entrypoint when spawning workers.
- Prefer the real invocation path from process.argv0 / process.execPath, while keeping bun run behavior for development.
- Add unit coverage for release-binary and development spawn command resolution.

## Verification
- bun test packages/management-api/tests/unit/bun-static-serve.test.ts
- bun run typecheck (packages/management-api)
- git diff --check
- Built a local compiled binary and verified: supacloud static-serve <root> <port> --workers=2 responds ok from /healthz