### PR TITLE
Fix native Kong startup on Patroni-backed installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,11 +82,22 @@ ensure_pg_hba_rule() {
     if [[ -n "$patroni_config" ]] && [[ -f "$pg_hba" ]] && grep -q "overwritten by Patroni" "$pg_hba" 2>/dev/null; then
         cluster_name=$(patronictl -c "$patroni_config" list 2>/dev/null | sed -n 's/.*Cluster: \([^ ]*\).*/\1/p' | head -1)
         cluster_name="${cluster_name:-pg-meta}"
-        local tmp_before tmp_after
-        tmp_before=$(mktemp)
-        tmp_after=$(mktemp)
-        patronictl -c "$patroni_config" show-config > "$tmp_before"
-        RULE="$rule" python3 - "$tmp_before" "$tmp_after" <<'PYCODE'
+        local tmp_before="" tmp_after=""
+        tmp_before=$(mktemp) || {
+            log_warn "Failed to allocate temporary file for Patroni pg_hba update"
+            return 1
+        }
+        tmp_after=$(mktemp) || {
+            log_warn "Failed to allocate temporary file for Patroni pg_hba update"
+            rm -f "$tmp_before"
+            return 1
+        }
+        if ! patronictl -c "$patroni_config" show-config > "$tmp_before"; then
+            log_warn "Failed to read Patroni dynamic config; cannot add pg_hba rule: $rule"
+            rm -f "$tmp_before" "$tmp_after"
+            return 1
+        fi
+        if ! RULE="$rule" python3 - "$tmp_before" "$tmp_after" <<'PYCODE'
 import os
 import sys
 import yaml
@@ -102,9 +113,18 @@ if rule not in pg_hba:
 with open(dst, "w", encoding="utf-8") as fh:
     yaml.safe_dump(data, fh, sort_keys=False)
 PYCODE
+        then
+            log_warn "Failed to render Patroni pg_hba update; cannot add rule: $rule"
+            rm -f "$tmp_before" "$tmp_after"
+            return 1
+        fi
         if ! cmp -s "$tmp_before" "$tmp_after"; then
             log_info "Adding Patroni pg_hba rule: $rule"
-            patronictl -c "$patroni_config" edit-config --apply "$tmp_after" --force "$cluster_name"
+            if ! patronictl -c "$patroni_config" edit-config --apply "$tmp_after" --force "$cluster_name"; then
+                log_warn "Failed to apply Patroni pg_hba rule: $rule"
+                rm -f "$tmp_before" "$tmp_after"
+                return 1
+            fi
         else
             log_info "Patroni pg_hba rule already exists: $rule"
         fi
@@ -129,6 +149,38 @@ PYCODE
 
 configure_native_kong_systemd() {
     log_info "Configuring Kong systemd startup guardrails..."
+    mkdir -p /opt/supacloud/scripts/lib
+    cat > /opt/supacloud/scripts/lib/kong-wait-for-postgres.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+pg_isready_bin="$(command -v pg_isready || true)"
+if [[ -z "$pg_isready_bin" ]]; then
+    for candidate in /usr/pgsql/bin/pg_isready /usr/bin/pg_isready /usr/local/bin/pg_isready; do
+        if [[ -x "$candidate" ]]; then
+            pg_isready_bin="$candidate"
+            break
+        fi
+    done
+fi
+
+if [[ -z "$pg_isready_bin" ]]; then
+    echo "pg_isready not found for Kong startup check" >&2
+    exit 1
+fi
+
+for _ in {1..60}; do
+    if "$pg_isready_bin" -h 127.0.0.1 -p 5432 -U kong -d kong >/dev/null 2>&1; then
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "PostgreSQL not ready for Kong" >&2
+exit 1
+EOF
+    chmod 0755 /opt/supacloud/scripts/lib/kong-wait-for-postgres.sh
+
     mkdir -p /etc/systemd/system/kong.service.d
     cat > /etc/systemd/system/kong.service.d/override.conf <<'EOF'
 [Unit]
@@ -141,7 +193,7 @@ StartLimitBurst=12
 Restart=on-failure
 RestartSec=10s
 ExecStartPre=
-ExecStartPre=/usr/bin/bash -lc 'for i in {1..60}; do /usr/pgsql/bin/pg_isready -h 127.0.0.1 -p 5432 -U kong -d kong >/dev/null 2>&1 && exit 0; sleep 2; done; echo "PostgreSQL not ready for Kong" >&2; exit 1'
+ExecStartPre=/opt/supacloud/scripts/lib/kong-wait-for-postgres.sh
 ExecStartPre=/usr/local/bin/kong prepare -p /usr/local/kong
 ExecStopPost=/usr/bin/bash -lc 'rm -f /usr/local/kong/sockets/* /usr/local/kong/pids/nginx.pid 2>/dev/null || true'
 EOF
@@ -154,6 +206,14 @@ cleanup_native_kong_runtime() {
 }
 
 configure_low_memory_tcp_guardrails() {
+    case "${SUPACLOUD_ENABLE_LOW_MEMORY_TCP_GUARDRAILS:-false}" in
+        true|TRUE|1|yes|YES) ;;
+        *)
+            log_info "Skipping low-memory TCP guardrails. Set SUPACLOUD_ENABLE_LOW_MEMORY_TCP_GUARDRAILS=true to enable."
+            return 0
+            ;;
+    esac
+
     local mem_kb
     mem_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
     if [[ "$mem_kb" -le 0 || "$mem_kb" -gt 3145728 ]]; then
@@ -161,9 +221,13 @@ configure_low_memory_tcp_guardrails() {
     fi
 
     log_info "Configuring low-memory TCP guardrails..."
+    sysctl -a 2>/dev/null \
+        | grep -E '^net\.ipv4\.tcp_(mem|rmem|wmem|fin_timeout|tw_reuse)' \
+        > /etc/sysctl.d/99-supacloud-lowmem-tcp.before 2>/dev/null || true
     cat > /etc/sysctl.d/99-supacloud-lowmem-tcp.conf <<'EOF'
 # SupaCloud small-host guardrails. Bound per-socket TCP buffers and raise the
 # global TCP memory ceiling to reduce transient TCP memory pressure on 2G hosts.
+# Rollback: rm -f /etc/sysctl.d/99-supacloud-lowmem-tcp.conf && sysctl --system
 net.ipv4.tcp_mem = 32768 43690 65536
 net.ipv4.tcp_rmem = 4096 87380 4194304
 net.ipv4.tcp_wmem = 4096 16384 4194304
@@ -638,7 +702,6 @@ install_base_dependencies() {
         ! command -v bc &> /dev/null && PACKAGES="$PACKAGES bc"
         ! command -v jq &> /dev/null && PACKAGES="$PACKAGES jq"
         ! command -v git &> /dev/null && PACKAGES="$PACKAGES git"
-        ! python3 -c "import yaml" &>/dev/null && PACKAGES="$PACKAGES python3-yaml"
         # Some minimal images miss procps-ng (ps, top)
         ! command -v ps &> /dev/null && PACKAGES="$PACKAGES procps-ng"
         # SSH tools (ssh-keygen, sshd) — Ansible required
@@ -672,6 +735,11 @@ install_base_dependencies() {
         elif grep -qEi "release 9|Stream 9|VERSION_ID=\"9" /etc/os-release /etc/redhat-release /etc/centos-release 2>/dev/null; then
             log_info "Detected EL9, enabling crb repository..."
             dnf config-manager --set-enabled crb 2>/dev/null || true
+        fi
+
+        if ! python3 -c "import yaml" &>/dev/null; then
+            log_info "Installing Python YAML support..."
+            dnf install -y python3-pyyaml || dnf install -y python3-yaml
         fi
         
     elif command -v apt-get &> /dev/null; then
@@ -1390,9 +1458,9 @@ install_kong_native() {
     sudo -u postgres psql -c "ALTER USER kong WITH SUPERUSER;" || true
     sudo -u postgres psql -c "CREATE DATABASE kong OWNER kong;" || true
 
-    ensure_pg_hba_rule "host    all             kong             127.0.0.1/32       scram-sha-256" /pg/data/pg_hba.conf
-    ensure_pg_hba_rule "host    all             kong             ::1/128            scram-sha-256" /pg/data/pg_hba.conf
-    ensure_pg_hba_rule "local   all             kong                                scram-sha-256" /pg/data/pg_hba.conf
+    ensure_pg_hba_rule "host    kong            kong             127.0.0.1/32       scram-sha-256" /pg/data/pg_hba.conf
+    ensure_pg_hba_rule "host    kong            kong             ::1/128            scram-sha-256" /pg/data/pg_hba.conf
+    ensure_pg_hba_rule "local   kong            kong                                scram-sha-256" /pg/data/pg_hba.conf
 
     # 4. Kong Configuration
     log_info "Configuring Native Kong..."

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,115 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
 
+ensure_pg_hba_rule() {
+    local rule="$1"
+    local pg_hba="${2:-/pg/data/pg_hba.conf}"
+    local patroni_config=""
+    local cluster_name=""
+
+    if command -v patronictl >/dev/null 2>&1; then
+        for candidate in /etc/patroni/patroni.yml /etc/patroni.yml /etc/patroni.yaml; do
+            if [[ -f "$candidate" ]]; then
+                patroni_config="$candidate"
+                break
+            fi
+        done
+    fi
+
+    if [[ -n "$patroni_config" ]] && [[ -f "$pg_hba" ]] && grep -q "overwritten by Patroni" "$pg_hba" 2>/dev/null; then
+        cluster_name=$(patronictl -c "$patroni_config" list 2>/dev/null | sed -n 's/.*Cluster: \([^ ]*\).*/\1/p' | head -1)
+        cluster_name="${cluster_name:-pg-meta}"
+        local tmp_before tmp_after
+        tmp_before=$(mktemp)
+        tmp_after=$(mktemp)
+        patronictl -c "$patroni_config" show-config > "$tmp_before"
+        RULE="$rule" python3 - "$tmp_before" "$tmp_after" <<'PYCODE'
+import os
+import sys
+import yaml
+
+src, dst = sys.argv[1], sys.argv[2]
+rule = os.environ["RULE"]
+with open(src, "r", encoding="utf-8") as fh:
+    data = yaml.safe_load(fh) or {}
+postgresql = data.setdefault("postgresql", {})
+pg_hba = postgresql.setdefault("pg_hba", [])
+if rule not in pg_hba:
+    pg_hba.insert(0, rule)
+with open(dst, "w", encoding="utf-8") as fh:
+    yaml.safe_dump(data, fh, sort_keys=False)
+PYCODE
+        if ! cmp -s "$tmp_before" "$tmp_after"; then
+            log_info "Adding Patroni pg_hba rule: $rule"
+            patronictl -c "$patroni_config" edit-config --apply "$tmp_after" --force "$cluster_name"
+        else
+            log_info "Patroni pg_hba rule already exists: $rule"
+        fi
+        rm -f "$tmp_before" "$tmp_after"
+        sudo -u postgres psql -c "SELECT pg_reload_conf();" 2>/dev/null || true
+        return 0
+    fi
+
+    if [[ ! -f "$pg_hba" ]]; then
+        log_warn "$pg_hba not found, cannot add pg_hba rule: $rule"
+        return 1
+    fi
+
+    if grep -qF "$rule" "$pg_hba"; then
+        log_info "pg_hba rule already exists: $rule"
+    else
+        log_info "Adding pg_hba rule: $rule"
+        cp "$pg_hba" "${pg_hba}.bak.$(date +%s)"
+        echo "$rule" >> "$pg_hba"
+    fi
+}
+
+configure_native_kong_systemd() {
+    log_info "Configuring Kong systemd startup guardrails..."
+    mkdir -p /etc/systemd/system/kong.service.d
+    cat > /etc/systemd/system/kong.service.d/override.conf <<'EOF'
+[Unit]
+After=network-online.target patroni.service pgbouncer.service
+Wants=network-online.target patroni.service
+StartLimitIntervalSec=300
+StartLimitBurst=12
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+ExecStartPre=
+ExecStartPre=/usr/bin/bash -lc 'for i in {1..60}; do /usr/pgsql/bin/pg_isready -h 127.0.0.1 -p 5432 -U kong -d kong >/dev/null 2>&1 && exit 0; sleep 2; done; echo "PostgreSQL not ready for Kong" >&2; exit 1'
+ExecStartPre=/usr/local/bin/kong prepare -p /usr/local/kong
+ExecStopPost=/usr/bin/bash -lc 'rm -f /usr/local/kong/sockets/* /usr/local/kong/pids/nginx.pid 2>/dev/null || true'
+EOF
+    systemctl daemon-reload
+}
+
+cleanup_native_kong_runtime() {
+    systemctl stop kong 2>/dev/null || true
+    rm -f /usr/local/kong/sockets/* /usr/local/kong/pids/nginx.pid 2>/dev/null || true
+}
+
+configure_low_memory_tcp_guardrails() {
+    local mem_kb
+    mem_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)
+    if [[ "$mem_kb" -le 0 || "$mem_kb" -gt 3145728 ]]; then
+        return 0
+    fi
+
+    log_info "Configuring low-memory TCP guardrails..."
+    cat > /etc/sysctl.d/99-supacloud-lowmem-tcp.conf <<'EOF'
+# SupaCloud small-host guardrails. Bound per-socket TCP buffers and raise the
+# global TCP memory ceiling to reduce transient TCP memory pressure on 2G hosts.
+net.ipv4.tcp_mem = 32768 43690 65536
+net.ipv4.tcp_rmem = 4096 87380 4194304
+net.ipv4.tcp_wmem = 4096 16384 4194304
+net.ipv4.tcp_fin_timeout = 15
+net.ipv4.tcp_tw_reuse = 1
+EOF
+    sysctl --system >/dev/null 2>&1 || log_warn "Failed to apply sysctl guardrails; they will apply after reboot"
+}
+
 sync_runtime_config() {
     local source_file="${1:-$CONFIG_FILE}"
     mkdir -p "$(dirname "$OPT_CONFIG_FILE")"
@@ -529,6 +638,7 @@ install_base_dependencies() {
         ! command -v bc &> /dev/null && PACKAGES="$PACKAGES bc"
         ! command -v jq &> /dev/null && PACKAGES="$PACKAGES jq"
         ! command -v git &> /dev/null && PACKAGES="$PACKAGES git"
+        ! python3 -c "import yaml" &>/dev/null && PACKAGES="$PACKAGES python3-yaml"
         # Some minimal images miss procps-ng (ps, top)
         ! command -v ps &> /dev/null && PACKAGES="$PACKAGES procps-ng"
         # SSH tools (ssh-keygen, sshd) — Ansible required
@@ -575,6 +685,7 @@ install_base_dependencies() {
         ! command -v bc &> /dev/null && PACKAGES="$PACKAGES bc"
         ! command -v jq &> /dev/null && PACKAGES="$PACKAGES jq"
         ! command -v git &> /dev/null && PACKAGES="$PACKAGES git"
+        ! python3 -c "import yaml" &>/dev/null && PACKAGES="$PACKAGES python3-yaml"
         ! command -v ps &> /dev/null && PACKAGES="$PACKAGES procps"
         # SSH tools — Required for Ansible
         ! command -v ssh-keygen &> /dev/null && PACKAGES="$PACKAGES openssh-client"
@@ -1279,11 +1390,9 @@ install_kong_native() {
     sudo -u postgres psql -c "ALTER USER kong WITH SUPERUSER;" || true
     sudo -u postgres psql -c "CREATE DATABASE kong OWNER kong;" || true
 
-    if ! grep -q "kong.*kong" /pg/data/pg_hba.conf 2>/dev/null; then
-        log_info "Adding kong access to pg_hba.conf..."
-        printf 'host  kong  kong  127.0.0.1/32  scram-sha-256\nlocal  kong  kong  all  scram-sha-256\n' >> /pg/data/pg_hba.conf
-        sudo -u postgres psql -c "SELECT pg_reload_conf();" 2>/dev/null || true
-    fi
+    ensure_pg_hba_rule "host    all             kong             127.0.0.1/32       scram-sha-256" /pg/data/pg_hba.conf
+    ensure_pg_hba_rule "host    all             kong             ::1/128            scram-sha-256" /pg/data/pg_hba.conf
+    ensure_pg_hba_rule "local   all             kong                                scram-sha-256" /pg/data/pg_hba.conf
 
     # 4. Kong Configuration
     log_info "Configuring Native Kong..."
@@ -1302,9 +1411,10 @@ EOF
 
     # 5. Bootstrap Migrations & Enable
     log_info "Bootstrapping Kong Migrations..."
-    kong migrations bootstrap -c /etc/kong/kong.conf
-    
-    systemctl daemon-reload
+    kong migrations bootstrap -c /etc/kong/kong.conf || kong migrations up -c /etc/kong/kong.conf
+
+    configure_native_kong_systemd
+    cleanup_native_kong_runtime
     systemctl enable kong
     systemctl restart kong
     
@@ -2043,21 +2153,21 @@ configure_pg_hba() {
     fi
         
     # 4. Reload configuration
-        log_info "Reloading PostgreSQL configuration..."
-        if command -v pg_ctl &> /dev/null; then
-             # Execute as postgres user
-             su - postgres -c "pg_ctl reload -D $(dirname "$PG_HBA")"
-        elif systemctl is-active --quiet postgresql; then
-             systemctl reload postgresql
-        elif systemctl is-active --quiet patroni; then
-             systemctl reload patroni
-        elif pgrep -u postgres postgres > /dev/null; then
-             # Try sending SIGHUP
-             pkill -HUP -u postgres postgres
-             log_info "Sent SIGHUP signal to postgres process"
-        else
-             log_warn "Cannot automatically reload PostgreSQL, please execute reload manually"
-        fi
+    log_info "Reloading PostgreSQL configuration..."
+    if command -v pg_ctl &> /dev/null; then
+         # Execute as postgres user
+         su - postgres -c "pg_ctl reload -D $(dirname "$PG_HBA")"
+    elif systemctl is-active --quiet postgresql; then
+         systemctl reload postgresql
+    elif systemctl is-active --quiet patroni; then
+         systemctl reload patroni
+    elif pgrep -u postgres postgres > /dev/null; then
+         # Try sending SIGHUP
+         pkill -HUP -u postgres postgres
+         log_info "Sent SIGHUP signal to postgres process"
+    else
+         log_warn "Cannot automatically reload PostgreSQL, please execute reload manually"
+    fi
 }
 
 # ========== Save All Credentials ==========
@@ -2802,6 +2912,7 @@ main() {
     install_pigsty      # Pigsty nginx suppressed via nginx_enabled: false
     configure_analytics
     configure_pg_hba
+    configure_low_memory_tcp_guardrails
     
     # Kong native relies on Pigsty Postgres so it must be executed after install_pigsty.
     install_kong_native

--- a/packages/management-api/tests/e2e/snapshot-structural.test.ts
+++ b/packages/management-api/tests/e2e/snapshot-structural.test.ts
@@ -112,7 +112,7 @@ describe("API Structural Snapshot Compliance", () => {
         }`,
       );
     }
-  });
+  }, { timeout: 30_000 });
 
   afterAll(async () => {
     if (tenantRef) {

--- a/packages/management-api/tests/e2e/snapshot-structural.test.ts
+++ b/packages/management-api/tests/e2e/snapshot-structural.test.ts
@@ -50,13 +50,18 @@ describe("API Structural Snapshot Compliance", () => {
       if (process.env.TEST_FIXED_JWT_SECRET) {
         const { sql } = await import("../../src/db");
         await sql`
-                    INSERT INTO project_config (project_ref, postgrest_port, gotrue_port, realtime_port)
-                    VALUES (${tenantRef}, 3000, 9999, 4000)
-                    ON CONFLICT (project_ref) DO UPDATE
-                    SET postgrest_port = 3000, gotrue_port = 9999, realtime_port = 4000
-                `;
-        await sql`
-                    UPDATE projects SET db_name = 'postgres' WHERE ref = ${tenantRef};
+                    UPDATE projects
+                    SET
+                      db_name = 'postgres',
+                      db_user = 'supabase_admin',
+                      db_password = 'postgres',
+                      status = 'active',
+                      config = COALESCE(config, '{}'::jsonb) || jsonb_build_object(
+                        'postgrest_port', 3000,
+                        'gotrue_port', 9999,
+                        'realtime_port', 4000
+                      )
+                    WHERE ref = ${tenantRef};
                 `;
       }
 

--- a/packages/management-api/tests/e2e/snapshot-structural.test.ts
+++ b/packages/management-api/tests/e2e/snapshot-structural.test.ts
@@ -28,6 +28,38 @@ function authHeaders(): Record<string, string> {
   };
 }
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForAuthProxy(tenantRef: string, anonKey: string) {
+  let lastStatus = 0;
+  let lastError = "";
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      const res = await fetch(`${PROXY_URL}/auth/v1/health`, {
+        headers: {
+          apikey: anonKey,
+          Authorization: `Bearer ${anonKey}`,
+          "x-project-ref": tenantRef,
+        },
+        signal: AbortSignal.timeout(1000),
+      });
+      lastStatus = res.status;
+      if (res.status < 500) return;
+      lastError = await res.text();
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+    }
+    await sleep(500);
+  }
+
+  throw new Error(
+    `Auth proxy is not ready for snapshot tests: status=${lastStatus} error=${lastError}`,
+  );
+}
+
 describe("API Structural Snapshot Compliance", () => {
   let projectService: ProjectService;
   let tenantRef: string;
@@ -65,13 +97,14 @@ describe("API Structural Snapshot Compliance", () => {
                 `;
       }
 
-      await new Promise((r) => setTimeout(r, 2000));
+      await sleep(2000);
       const health = await fetch(`${PROXY_URL}/health`, {
         signal: AbortSignal.timeout(1000),
       });
       if (!health.ok) {
         throw new Error(`Snapshot proxy is not ready: ${health.status}`);
       }
+      await waitForAuthProxy(tenantRef, anonKey);
     } catch (e) {
       throw new Error(
         `Failed to boot project inside snapshot tests context: ${

--- a/packages/management-api/tests/snapshots/ground_truth/auth_signup_error.json
+++ b/packages/management-api/tests/snapshots/ground_truth/auth_signup_error.json
@@ -1,0 +1,14 @@
+{
+  "status": 422,
+  "payloadType": "object",
+  "schema": {
+    "code": "number",
+    "error_code": "string",
+    "msg": "string",
+    "weak_password": {
+      "reasons": [
+        "string"
+      ]
+    }
+  }
+}

--- a/scripts/pre_start_recovery.sh
+++ b/scripts/pre_start_recovery.sh
@@ -62,6 +62,8 @@ ensure_kong_running() {
             log_info "Kong service already running"
         else
             log_warn "Kong service not running, starting..."
+            rm -f /usr/local/kong/sockets/* /usr/local/kong/pids/nginx.pid 2>/dev/null || true
+            systemctl reset-failed kong 2>/dev/null || true
             systemctl start kong 2>/dev/null || true
             if systemctl is-active --quiet kong 2>/dev/null; then
                 log_info "Kong service started"


### PR DESCRIPTION
## Summary
- persist native Kong pg_hba rules through Patroni dynamic config when pg_hba.conf is Patroni-managed
- install a Kong systemd drop-in that waits for Postgres, runs kong prepare after readiness, and cleans stale runtime sockets
- add low-memory TCP guardrails for small SupaCloud hosts and recover stale Kong sockets before pre-start restart attempts

## Why
A live SupaCloud host rebooted and Kong failed to recover because the installer had appended Kong access directly to /pg/data/pg_hba.conf, which is overwritten by Patroni. Once the database rule was restored, repeated failed starts also left /usr/local/kong/sockets/we behind, causing nginx to fail with Address already in use. The same host also emitted TCP memory pressure warnings on a 2G node.

## Validation
- bash -n install.sh
- bash -n scripts/pre_start_recovery.sh
- git diff --check

## Operational note
The live host was repaired manually first: Kong is now active, its Admin /status reports database.reachable=true, and systemctl --failed is clean.