### PR TITLE
fix: align storage health checks with tenant runtime

### DIFF
--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -244,7 +244,7 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, host: string): Pr
         if (
             rows.length > 0 &&
             String(rows[0].ref) === ref &&
-            matchProjectRefFromHost(host, ref, rows[0].config)
+            (isLoopbackHost(host) || matchProjectRefFromHost(host, ref, rows[0].config))
         ) {
             return ref;
         }

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -186,6 +186,28 @@ export class ProjectService {
     }
   }
 
+  private async checkProjectStorageHealth(ref: string): Promise<boolean> {
+    try {
+      const { tenantRuntimeService } = await import("./tenant-runtime.service");
+      const services = await tenantRuntimeService.getProjectServiceStatuses(ref, "studio");
+      const storage = services.find((service) => service.id === "storage" || service.name.toLowerCase() === "storage");
+      if (storage?.healthy || storage?.status === "ACTIVE_HEALTHY") return true;
+    } catch {
+      // 忽略租户服务状态探测异常，继续使用本地探测兜底。
+    }
+
+    try {
+      const result = await $`systemctl is-active ${`supacloud-storage@${ref}`}`
+        .nothrow()
+        .quiet();
+      if (result.exitCode === 0) return true;
+    } catch {
+      // 忽略 systemd 探测异常，继续使用共享存储探测兜底。
+    }
+
+    return await this.checkStorageHealth();
+  }
+
   // Get all projects
   async listProjects(): Promise<ProjectResponse[]> {
     const projects = await projectRepository.findAll();
@@ -525,7 +547,7 @@ export class ProjectService {
     return {
       status: project.status,
       database: dbStatus.success ? "healthy" : "unhealthy",
-      storage: (await this.checkStorageHealth()) ? "healthy" : "unhealthy",
+      storage: (await this.checkProjectStorageHealth(ref)) ? "healthy" : "unhealthy",
     };
   }
 

--- a/packages/management-api/tests/unit/project.service.comprehensive.test.ts
+++ b/packages/management-api/tests/unit/project.service.comprehensive.test.ts
@@ -66,6 +66,9 @@ const tenantRuntimeServiceMock = {
   pauseProjectRuntime: mock(() => Promise.resolve()),
   resumeProjectRuntime: mock(() => Promise.resolve({ status: "running" })),
   restartRuntime: mock(() => Promise.resolve({ status: "running" })),
+  getProjectServiceStatuses: mock(() => Promise.resolve([
+    { id: "storage", name: "storage", status: "ACTIVE_HEALTHY", healthy: true },
+  ])),
 };
 
 mock.module("../../src/db", () => ({

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -44,6 +44,56 @@ afterEach(() => {
 });
 
 describe("storageCompatRoutes supabase-js compatibility", () => {
+  test("accepts project header on loopback health checks without apikey", async () => {
+    const sqlSpy = spyOn(dbModule, "sql");
+    sqlSpy.mockImplementation(async (...args: unknown[]) => {
+      const text = String(args[0] ?? "");
+      if (text.includes("FROM projects")) {
+        return [{ ref: "proj_from_header", config: {} }];
+      }
+      return [];
+    });
+
+    const bucketSpy = spyOn(StorageRLS, "getLogicalBucket").mockResolvedValue({
+      id: "avatars",
+      name: "avatars",
+      public: true,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    const objectSpy = spyOn(StorageRLS, "getObjectInfo").mockResolvedValue({
+      id: "obj_1",
+      bucket_id: "avatars",
+      name: "public.txt",
+      metadata: { size: 3, mimetype: "text/plain" },
+      cache_control: "3600",
+      updated_at: new Date().toISOString(),
+    });
+    const downloadSpy = spyOn(StorageService, "getDownloadResponse").mockResolvedValue(
+      new Response("ok\n", {
+        headers: {
+          "Content-Type": "text/plain",
+          "Content-Length": "3",
+        },
+      })
+    );
+
+    const res = await request("/storage/v1/object/public/avatars/public.txt", {
+      headers: {
+        host: "127.0.0.1:9090",
+        "x-project-ref": "proj_from_header",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok\n");
+    expect(downloadSpy).toHaveBeenCalledWith("proj_from_header", "avatars", "public.txt");
+    sqlSpy.mockRestore();
+    bucketSpy.mockRestore();
+    objectSpy.mockRestore();
+    downloadSpy.mockRestore();
+  });
+
   test("allows public object reads from trusted custom-domain storage routes without apikey", async () => {
     const sqlSpy = spyOn(dbModule, "sql");
     let sawProjectLookup = false;


### PR DESCRIPTION
## Summary
- Align project storage health status with tenant runtime service health probing before falling back to local S3 health checks.
- Allow loopback storage compatibility checks to resolve a valid `x-project-ref` without an API key for local health probes.
- Add focused unit coverage for loopback public storage access and project status mocks.

## Verification
- `bun test packages/management-api/tests/unit/storage-compat.sdk.test.ts packages/management-api/tests/unit/project.service.comprehensive.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `git diff --check origin/main...HEAD`
