### PR TITLE
fix(realtime): harden global service startup

### DIFF
--- a/infrastructure/systemd/supacloud-realtime.service
+++ b/infrastructure/systemd/supacloud-realtime.service
@@ -60,8 +60,10 @@ NoNewPrivileges=true
 ProtectSystem=full
 ReadWritePaths=/etc/supabase /opt/supacloud /tmp /var/log/supacloud
 
-SystemCallFilter=@system-service
-SystemCallFilter=~@mount @reboot @swap @privileged @raw-io @keyring
+# Do not add SystemCallFilter here. This unit runs podman, and recent podman
+# builds need mount/procfs-related syscalls such as open_tree during startup.
+# Blocking them makes systemd kill podman with status=31/SYS before the
+# multi-tenant Realtime container can be created.
 
 MemoryMax=4G
 MemoryHigh=3G

--- a/install.sh
+++ b/install.sh
@@ -2469,17 +2469,30 @@ deploy_service_containers() {
 
     # --- 2. Deploy Supabase Realtime (Multi-tenant WebSocket) ---
     local REALTIME_UNIT_SRC="${SCRIPT_DIR}/infrastructure/systemd/supacloud-realtime.service"
+    local REALTIME_IMAGE_VALUE="${REALTIME_IMAGE:-public.ecr.aws/supabase/realtime:v2.76.5}"
     if [[ -f "$REALTIME_UNIT_SRC" ]]; then
         log_info "Registering SupaCloud Realtime systemd unit..."
         cp "$REALTIME_UNIT_SRC" /etc/systemd/system/supacloud-realtime.service
         systemctl daemon-reload
         systemctl enable supacloud-realtime
+
+        # The systemd unit uses the canonical REALTIME_IMAGE name. Pre-pull it
+        # here so installs behind registry mirrors still work without editing
+        # the unit file. When a mirror pull succeeds, tag it back to the
+        # canonical name expected by the unit.
+        local REALTIME_IMAGE_PULL="${MIRROR_PREFIX}${REALTIME_IMAGE_VALUE}"
+        log_info "Pulling Supabase Realtime image: ${REALTIME_IMAGE_VALUE}"
+        if [[ -n "$MIRROR_PREFIX" ]] && $RUNTIME pull "$REALTIME_IMAGE_PULL" 2>/dev/null; then
+            $RUNTIME tag "$REALTIME_IMAGE_PULL" "$REALTIME_IMAGE_VALUE" 2>/dev/null || true
+        else
+            $RUNTIME pull "$REALTIME_IMAGE_VALUE"
+        fi
+
         systemctl restart supacloud-realtime || log_warn "Realtime service start failed, please check journalctl -u supacloud-realtime"
     elif $RUNTIME ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "${REALTIME_CONTAINER_NAME:-supacloud-realtime}"; then
         log_info "Realtime container already exists, skipping"
     else
         log_info "Pulling and deploying Supabase Realtime (multi-tenant)..."
-        local REALTIME_IMAGE_VALUE="${REALTIME_IMAGE:-public.ecr.aws/supabase/realtime:v2.76.5}"
         $RUNTIME pull "$REALTIME_IMAGE_VALUE"
 
         if [[ -n "${POSTGRES_PASSWORD:-}" ]]; then

--- a/packages/management-api/tests/unit/realtime-systemd.test.ts
+++ b/packages/management-api/tests/unit/realtime-systemd.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../../..", "..");
+
+describe("Realtime systemd deployment", () => {
+  test("global Realtime unit does not sandbox podman syscalls", () => {
+    const unit = readFileSync(
+      join(repoRoot, "infrastructure/systemd/supacloud-realtime.service"),
+      "utf8",
+    );
+
+    expect(unit).toContain("SupaCloud Realtime Service");
+    expect(unit).toContain("podman run");
+    expect(unit).not.toContain("SystemCallFilter=");
+  });
+
+  test("installer pre-pulls and tags the Realtime image before systemd restart", () => {
+    const installer = readFileSync(join(repoRoot, "install.sh"), "utf8");
+    const realtimeSection = installer.slice(
+      installer.indexOf("# --- 2. Deploy Supabase Realtime"),
+      installer.indexOf("# --- 3. Update management API env"),
+    );
+
+    expect(realtimeSection).toContain("REALTIME_IMAGE_PULL");
+    expect(realtimeSection).toContain("$RUNTIME pull \"$REALTIME_IMAGE_PULL\"");
+    expect(realtimeSection).toContain("$RUNTIME tag \"$REALTIME_IMAGE_PULL\" \"$REALTIME_IMAGE_VALUE\"");
+    expect(realtimeSection.indexOf("$RUNTIME pull")).toBeLessThan(
+      realtimeSection.indexOf("systemctl restart supacloud-realtime"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep Realtime as one global multi-tenant service and avoid per-project unit changes
- remove the systemd syscall filter that kills podman with status=31/SYS on newer distros
- pre-pull and tag the Realtime image during install so mirror-based deployments work with the canonical unit image name
- add regression coverage for the Realtime systemd and installer behavior

## Verification
- bun test packages/management-api/tests/unit/realtime-systemd.test.ts packages/management-api/tests/unit/project-services.runtime.test.ts packages/management-api/tests/unit/task.worker.test.ts
- bun run typecheck (packages/management-api)

## Notes
This does not change the SupaCloud multi-project model. Projects continue to be allocated as tenants in the shared Realtime service via the tenant management API.