### PR TITLE
fix: cap background queue control-plane pressure

### DIFF
--- a/packages/edge-runtime/tenant-env.test.ts
+++ b/packages/edge-runtime/tenant-env.test.ts
@@ -140,4 +140,34 @@ describe("tenant env masking guard", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("coalesces concurrent runtime env loads for the same project", async () => {
+    const originalFetch = globalThis.fetch;
+    const ref = `proj_inflight_${Date.now()}`;
+    let calls = 0;
+    let resolveResponse!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resolveResponse = resolve;
+    });
+
+    globalThis.fetch = mock(async () => {
+      calls++;
+      await gate;
+      return Response.json({ RESULT_S3_ENDPOINT: "http://coalesced-s3.local" });
+    }) as unknown as typeof fetch;
+
+    try {
+      const first = loadTenantEnv(ref);
+      const second = loadTenantEnv(ref);
+      resolveResponse();
+      const [firstEnv, secondEnv] = await Promise.all([first, second]);
+
+      expect(firstEnv.RESULT_S3_ENDPOINT).toBe("http://coalesced-s3.local");
+      expect(secondEnv.RESULT_S3_ENDPOINT).toBe("http://coalesced-s3.local");
+      expect(calls).toBe(1);
+    } finally {
+      invalidateTenantEnvCache(ref);
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/edge-runtime/tenant-env.ts
+++ b/packages/edge-runtime/tenant-env.ts
@@ -7,6 +7,7 @@ const TENANTS_DIRS = [
 ];
 
 const envCache = new Map<string, { env: Record<string, string>; expiresAt: number }>();
+const envInflightLoads = new Map<string, Promise<Record<string, string>>>();
 const ENV_CACHE_TTL = 5_000;
 const ENV_FALLBACK_CACHE_TTL = 30_000;
 const MASKED_SECRET_VALUE = "********";
@@ -197,7 +198,7 @@ async function loadEnvFromLegacySecretsApi(ref: string): Promise<Record<string, 
   }
 }
 
-export async function loadTenantEnv(ref: string): Promise<Record<string, string>> {
+async function loadTenantEnvUncached(ref: string): Promise<Record<string, string>> {
   const cached = envCache.get(ref);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.env;
@@ -221,6 +222,27 @@ export async function loadTenantEnv(ref: string): Promise<Record<string, string>
   return merged;
 }
 
+export async function loadTenantEnv(ref: string): Promise<Record<string, string>> {
+  const cached = envCache.get(ref);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.env;
+  }
+
+  const inflight = envInflightLoads.get(ref);
+  if (inflight) {
+    return inflight;
+  }
+
+  const load = loadTenantEnvUncached(ref).finally(() => {
+    if (envInflightLoads.get(ref) === load) {
+      envInflightLoads.delete(ref);
+    }
+  });
+  envInflightLoads.set(ref, load);
+  return load;
+}
+
 export function invalidateTenantEnvCache(ref: string) {
   envCache.delete(ref);
+  envInflightLoads.delete(ref);
 }

--- a/packages/management-api/src/repositories/task.repository.ts
+++ b/packages/management-api/src/repositories/task.repository.ts
@@ -309,7 +309,7 @@ export async function claimNextTask(options: TaskLeaseOptions): Promise<LeasedTa
       params.push(...allowedTaskTypes);
     }
 
-    params.push(DEFAULT_BACKGROUND_TASK_SETTINGS.concurrency);
+    params.push(Math.max(1, Math.floor(options.concurrencyByProject || DEFAULT_BACKGROUND_TASK_SETTINGS.concurrency)));
     const defaultConcurrencyIdx = params.length;
     params.push(TaskStatuses.LEASED);
     const leasedStatusIdx = params.length;
@@ -332,11 +332,14 @@ export async function claimNextTask(options: TaskLeaseOptions): Promise<LeasedTa
               AND active.status IN ($1, $2)
               AND active.lease_until IS NOT NULL
               AND active.lease_until > NOW()
-          ) < GREATEST(
-            1,
-            COALESCE(
-              NULLIF((p.config->'background_tasks'->>'concurrency'), '')::int,
-              $${defaultConcurrencyIdx}
+          ) < LEAST(
+            $${defaultConcurrencyIdx},
+            GREATEST(
+              1,
+              COALESCE(
+                NULLIF((p.config->'background_tasks'->>'concurrency'), '')::int,
+                $${defaultConcurrencyIdx}
+              )
             )
           )
           ${taskTypeFilter}

--- a/packages/management-api/src/services/background-function-worker.ts
+++ b/packages/management-api/src/services/background-function-worker.ts
@@ -9,6 +9,7 @@ import { DEFAULT_BACKGROUND_TASK_SETTINGS } from "../config/background-task-sett
 import { projectService } from "./project.service";
 import { decryptSecretIfNeeded } from "../utils/secret-crypto";
 import { createHmac } from "node:crypto";
+import { availableParallelism } from "node:os";
 import { getProjectDb, resolveDbName } from "../db";
 import { createBackgroundTaskMirrorIfUserExists } from "../services/background-task.service";
 import { createPgListener, type PgListenerHandle } from "../lib/pg-listen";
@@ -30,8 +31,18 @@ interface InvocationEnvelope {
   };
 }
 
-const DEFAULT_CONCURRENCY_PER_PROJECT = Number(
-  process.env.BACKGROUND_TASKS_PER_PROJECT || String(DEFAULT_BACKGROUND_TASK_SETTINGS.concurrency),
+export function resolveBackgroundConcurrencyPerProject(value?: string): number {
+  const parsed = Number.parseInt(String(value || "").trim(), 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.min(DEFAULT_BACKGROUND_TASK_SETTINGS.concurrency, parsed);
+  }
+
+  const cpuScaledLimit = Math.max(2, availableParallelism() * 4);
+  return Math.min(DEFAULT_BACKGROUND_TASK_SETTINGS.concurrency, cpuScaledLimit);
+}
+
+const DEFAULT_CONCURRENCY_PER_PROJECT = resolveBackgroundConcurrencyPerProject(
+  process.env.BACKGROUND_TASKS_PER_PROJECT,
 );
 const WORKER_ID = `bgw-${process.pid}`;
 
@@ -450,6 +461,7 @@ export class BackgroundFunctionWorker {
           workerId: WORKER_ID,
           allowedTaskTypes: [TaskType.EDGE_FUNCTION],
           leaseSeconds: 900,
+          concurrencyByProject: DEFAULT_CONCURRENCY_PER_PROJECT,
         });
         if (!task) break;
 

--- a/packages/management-api/tests/unit/background-function-worker.test.ts
+++ b/packages/management-api/tests/unit/background-function-worker.test.ts
@@ -286,6 +286,12 @@ describe("BackgroundFunctionWorker", () => {
       await (worker as any).poll();
 
       expect(claimNextTask).toHaveBeenCalledTimes(1);
+      expect(claimNextTask).toHaveBeenCalledWith(expect.objectContaining({
+        concurrencyByProject: expect.any(Number),
+      }));
+      expect(claimNextTask.mock.calls[0][0].concurrencyByProject).toBeLessThanOrEqual(
+        DEFAULT_BACKGROUND_TASK_SETTINGS.concurrency,
+      );
       expect(markTaskRunning).not.toHaveBeenCalled();
     });
 

--- a/packages/management-api/tests/unit/task.repository.test.ts
+++ b/packages/management-api/tests/unit/task.repository.test.ts
@@ -73,4 +73,12 @@ describe("TaskRepository query builders", () => {
     expect(sqlText).not.toContain("SELECT *");
     expect(values).toEqual(["proj_1", 25]);
   });
+
+  test("claimNextTask caps project config by the worker host concurrency limit", () => {
+    const source = repo.claimNextTask.toString();
+
+    expect(source).toContain("options.concurrencyByProject");
+    expect(source).toContain("LEAST(");
+    expect(source).toContain("p.config->'background_tasks'->>'concurrency'");
+  });
 });


### PR DESCRIPTION
## Summary
- coalesce concurrent edge-runtime tenant-env loads per project so bursty background workers share one runtime-env request
- cap background task claims with a host-level concurrency limit in addition to project `background_tasks.concurrency`
- keep explicit `BACKGROUND_TASKS_PER_PROJECT` override, otherwise scale the host cap from available CPU and never exceed the configured product max

## Why
A tenant can enqueue a burst of background function tasks faster than the consumer limit can protect the control plane. In the AoristCross incident, 100+ tasks were submitted in one minute; even though task consumption was bounded, concurrent background dispatches still fanned out into repeated tenant-env/control-plane calls and caused edge auth/runtime-env timeouts on a small 2C/2G node.

This keeps the queue semantics intact: tasks can still wait in the queue, but a single project cannot exceed the host-level safe execution cap, and concurrent dispatches for the same project no longer stampede the management API for identical runtime env.

## Verification
- `bun test packages/edge-runtime/tenant-env.test.ts`
- `bun test packages/management-api/tests/unit/background-function-worker.test.ts packages/management-api/tests/unit/task.repository.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `bun run --cwd packages/edge-runtime typecheck`
