### PR TITLE
feat: add FerretDB profile and DocumentDB-backed Postgres extensions

### DIFF
--- a/docker/self-host/.env.example
+++ b/docker/self-host/.env.example
@@ -9,6 +9,16 @@ POSTGRES_PASSWORD=change-me
 POSTGRES_DB=postgres
 POSTGRES_PORT=5432
 
+# Optional MongoDB wire protocol compatibility through FerretDB.
+# Set ENABLE_FERRETDB=true before first database initialization, then run with:
+#   COMPOSE_PROFILES=ferretdb docker compose up -d --build
+ENABLE_FERRETDB=false
+FERRETDB_IMAGE=ghcr.io/ferretdb/ferretdb:2.7.0
+FERRETDB_USER=ferretdb
+FERRETDB_PASSWORD=ferretdb-change-me
+FERRETDB_DATABASE=postgres
+FERRETDB_PORT=27017
+
 JWT_SECRET=
 ANON_KEY=
 SERVICE_ROLE_KEY=

--- a/docker/self-host/README.md
+++ b/docker/self-host/README.md
@@ -10,10 +10,11 @@ This stack is isolated from `docker/dev` and is intended for one-command self-ho
 - PostgREST
 - SupaCloud Management API
 - SupaCloud Bun Edge Runtime
+- FerretDB MongoDB wire protocol gateway, optional through the `ferretdb` Compose profile
 
 ## Packaged PostgreSQL extensions
 
-The PostgreSQL image preinstalls these common extensions:
+The PostgreSQL image stays on `postgres:18-bookworm` and installs PGDG, Pigsty/PGEXT, and DocumentDB packages. It bootstraps these common Supabase/SupaCloud extensions when available:
 
 - `uuid-ossp`
 - `pgcrypto`
@@ -24,12 +25,27 @@ The PostgreSQL image preinstalls these common extensions:
 - `postgis`
 - `hypopg`
 - `pg_stat_kcache`
+- `http`
+- `pg_graphql`
+- `pg_jsonschema`
+- `wrappers`
+- `index_advisor`
+- `pg_net`
+- `supabase_vault` from the Pigsty `vault` package
+- `pgjwt`
+- `pgsodium`
 - `wal2json`
+
+It also packages these PostgreSQL libraries and optional extensions:
+
+- `supautils`
+- `pg_plan_filter`, loaded as `plan_filter`
+- `documentdb`, created only when the FerretDB profile is enabled
 
 It also sets:
 
-- `shared_preload_libraries=pg_stat_statements,pg_cron,pgaudit`
-- `cron.database_name=postgres`
+- `shared_preload_libraries=pg_stat_statements, pg_cron, pgaudit, pg_net, pg_stat_kcache, plan_filter, pg_documentdb, pg_documentdb_core`
+- `cron.database_name=${POSTGRES_DB}`
 - `wal_level=logical`
 
 ## Quick start
@@ -52,8 +68,20 @@ Endpoints:
 - API gateway: `${PUBLIC_URL}` (default `http://localhost:8000`)
 - Management API / Studio shell: `${STUDIO_URL}` (default `http://localhost:9090`)
 
+## Optional FerretDB profile
+
+FerretDB is disabled by default. To expose the MongoDB wire protocol on top of the same PostgreSQL container and `postgres-data` volume, enable it before the first database initialization:
+
+```bash
+ENABLE_FERRETDB=true COMPOSE_PROFILES=ferretdb docker compose up -d --build
+```
+
+The profile creates a separate FerretDB database user and installs `documentdb` in `${FERRETDB_DATABASE}`. By default `${FERRETDB_DATABASE}` is the same as `${POSTGRES_DB}` because `documentdb` depends on `pg_cron`, and `pg_cron` can only be created in the database configured by `cron.database_name`. The MongoDB wire protocol endpoint is exposed on `${FERRETDB_PORT}` (default `27017`).
+
+If `postgres-data` already exists, Docker entrypoint init scripts will not run again. Enable FerretDB on a fresh volume or create the FerretDB role/database and `documentdb` extension manually.
+
 ## Notes
 
-- This stack is for self-host bootstrap and small deployments. It does not replace the Pigsty-based production path.
+- This stack is for self-host bootstrap and small deployments. It borrows Pigsty/PGEXT packages for extension coverage, but it does not replace a full Pigsty HA production deployment.
 - `BASE_DOMAIN` is derived from `PUBLIC_URL` by `init-env.py`. Override it manually if you need a different wildcard routing suffix.
 - Kong gzip is disabled by default to avoid the HTTP/2 proxy corruption issue already seen on API traffic.

--- a/docker/self-host/docker-compose.yml
+++ b/docker/self-host/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     build:
@@ -11,6 +9,10 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
       TZ: ${TZ:-Asia/Shanghai}
       PGTZ: ${TZ:-Asia/Shanghai}
+      ENABLE_FERRETDB: ${ENABLE_FERRETDB:-false}
+      FERRETDB_USER: ${FERRETDB_USER:-ferretdb}
+      FERRETDB_PASSWORD: ${FERRETDB_PASSWORD:-}
+      FERRETDB_DATABASE: ${FERRETDB_DATABASE:-${POSTGRES_DB:-postgres}}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
@@ -54,6 +56,19 @@ services:
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_SERVER_PROXY_URI: ${PUBLIC_URL}
+
+  ferretdb:
+    image: ${FERRETDB_IMAGE:-ghcr.io/ferretdb/ferretdb:2.7.0}
+    restart: unless-stopped
+    profiles:
+      - ferretdb
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      FERRETDB_POSTGRESQL_URL: postgres://${FERRETDB_USER:-ferretdb}:${FERRETDB_PASSWORD:-}@postgres:5432/${FERRETDB_DATABASE:-${POSTGRES_DB:-postgres}}
+    ports:
+      - "${FERRETDB_PORT:-27017}:27017"
 
   management-api:
     build:

--- a/docker/self-host/init-env.py
+++ b/docker/self-host/init-env.py
@@ -58,6 +58,11 @@ def main() -> None:
         help="Postgres superuser password",
     )
     parser.add_argument(
+        "--ferretdb-password",
+        default=secrets.token_urlsafe(18),
+        help="FerretDB database user password",
+    )
+    parser.add_argument(
         "--jwt-secret",
         default=secrets.token_urlsafe(32),
         help="JWT signing secret",
@@ -109,6 +114,12 @@ def main() -> None:
     print(f"POSTGRES_PASSWORD={args.postgres_password}")
     print("POSTGRES_DB=postgres")
     print("POSTGRES_PORT=5432")
+    print("ENABLE_FERRETDB=false")
+    print("FERRETDB_IMAGE=ghcr.io/ferretdb/ferretdb:2.7.0")
+    print("FERRETDB_USER=ferretdb")
+    print(f"FERRETDB_PASSWORD={args.ferretdb_password}")
+    print("FERRETDB_DATABASE=postgres")
+    print("FERRETDB_PORT=27017")
     print(f"JWT_SECRET={args.jwt_secret}")
     print(f"ANON_KEY={anon_key}")
     print(f"SERVICE_ROLE_KEY={service_role_key}")

--- a/docker/self-host/postgres/Dockerfile
+++ b/docker/self-host/postgres/Dockerfile
@@ -3,21 +3,36 @@ FROM postgres:18-bookworm
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends curl ca-certificates gnupg lsb-release; \
-    install -d /usr/share/postgresql-common/pgdg; \
-    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-      | gpg --dearmor -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc; \
-    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] http://apt.postgresql.org/pub/repos/apt $(. /etc/os-release && echo $VERSION_CODENAME)-pgdg main" \
-      > /etc/apt/sources.list.d/pgdg.list; \
+    install -d /etc/apt/keyrings; \
+    curl -fsSL https://repo.pigsty.io/key \
+      | gpg --batch --yes --dearmor -o /etc/apt/keyrings/pigsty.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/pigsty.gpg] https://repo.pigsty.io/apt/pgsql/$(. /etc/os-release && echo $VERSION_CODENAME) $(. /etc/os-release && echo $VERSION_CODENAME) main" \
+      > /etc/apt/sources.list.d/pigsty-pgsql.list; \
+    curl -fsSL https://documentdb.io/documentdb-archive-keyring.gpg \
+      | gpg --batch --yes --dearmor -o /usr/share/keyrings/documentdb-archive-keyring.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/documentdb-archive-keyring.gpg] https://documentdb.io/deb stable deb12" \
+      > /etc/apt/sources.list.d/documentdb.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
       postgresql-18-cron \
+      postgresql-18-documentdb \
+      postgresql-18-http \
       postgresql-18-pgaudit \
+      postgresql-18-pg-graphql \
+      postgresql-18-pg-jsonschema \
+      postgresql-18-pg-net \
       postgresql-18-pgvector \
       postgresql-18-postgis-3 \
+      postgresql-18-pgjwt \
+      postgresql-18-pgsodium \
       postgresql-18-hypopg \
+      postgresql-18-index-advisor \
       postgresql-18-pg-stat-kcache \
+      postgresql-18-pg-plan-filter \
+      postgresql-18-supautils \
+      postgresql-18-vault \
       postgresql-18-wal2json \
-      postgresql-contrib; \
+      postgresql-18-wrappers; \
     rm -rf /var/lib/apt/lists/*
 
 COPY initdb /docker-entrypoint-initdb.d

--- a/docker/self-host/postgres/initdb/00-configure-postgres.sh
+++ b/docker/self-host/postgres/initdb/00-configure-postgres.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<'SQL'
-ALTER SYSTEM SET shared_preload_libraries = 'pg_stat_statements,pg_cron,pgaudit';
-ALTER SYSTEM SET cron.database_name = 'postgres';
+psql -v ON_ERROR_STOP=1 \
+  --username "$POSTGRES_USER" \
+  --dbname "$POSTGRES_DB" \
+  -v cron_database="$POSTGRES_DB" <<'SQL'
+ALTER SYSTEM SET cron.database_name = :'cron_database';
 ALTER SYSTEM SET wal_level = 'logical';
 ALTER SYSTEM SET max_wal_senders = '10';
 ALTER SYSTEM SET max_replication_slots = '10';
 ALTER SYSTEM SET track_io_timing = 'on';
 ALTER SYSTEM SET log_min_duration_statement = '1000';
 SQL
+
+cat >> "$PGDATA/postgresql.conf" <<'EOF'
+shared_preload_libraries = 'pg_stat_statements, pg_cron, pgaudit, pg_net, pg_stat_kcache, plan_filter, pg_documentdb, pg_documentdb_core'
+EOF
+
+pg_ctl -D "$PGDATA" -m fast -w restart

--- a/docker/self-host/postgres/initdb/01-bootstrap-extensions.sql
+++ b/docker/self-host/postgres/initdb/01-bootstrap-extensions.sql
@@ -1,9 +1,36 @@
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
-CREATE EXTENSION IF NOT EXISTS pg_cron;
-CREATE EXTENSION IF NOT EXISTS pgaudit;
-CREATE EXTENSION IF NOT EXISTS vector;
-CREATE EXTENSION IF NOT EXISTS postgis;
-CREATE EXTENSION IF NOT EXISTS hypopg;
-CREATE EXTENSION IF NOT EXISTS pg_stat_kcache;
+DO $$
+DECLARE
+  extension_name text;
+BEGIN
+  FOREACH extension_name IN ARRAY ARRAY[
+    'uuid-ossp',
+    'pgcrypto',
+    'pg_stat_statements',
+    'pg_cron',
+    'pgaudit',
+    'vector',
+    'postgis',
+    'hypopg',
+    'index_advisor',
+    'pg_stat_kcache',
+    'http',
+    'pg_net',
+    'pg_graphql',
+    'pg_jsonschema',
+    'wrappers',
+    'pgjwt',
+    'pgsodium',
+    'supabase_vault'
+  ] LOOP
+    IF EXISTS (
+      SELECT 1
+      FROM pg_available_extensions
+      WHERE name = extension_name
+    ) THEN
+      EXECUTE format('CREATE EXTENSION IF NOT EXISTS %I CASCADE', extension_name);
+    ELSE
+      RAISE NOTICE 'Skipping unavailable PostgreSQL extension: %', extension_name;
+    END IF;
+  END LOOP;
+END
+$$;

--- a/docker/self-host/postgres/initdb/02-configure-ferretdb.sh
+++ b/docker/self-host/postgres/initdb/02-configure-ferretdb.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${ENABLE_FERRETDB:-false}" != "true" ]]; then
+  echo "FerretDB bootstrap disabled; set ENABLE_FERRETDB=true before the first database initialization to enable it."
+  exit 0
+fi
+
+ferretdb_user="${FERRETDB_USER:-ferretdb}"
+ferretdb_password="${FERRETDB_PASSWORD:-}"
+ferretdb_database="${FERRETDB_DATABASE:-$POSTGRES_DB}"
+
+if [[ -z "$ferretdb_password" ]]; then
+  echo "FERRETDB_PASSWORD is required when ENABLE_FERRETDB=true" >&2
+  exit 1
+fi
+
+psql -v ON_ERROR_STOP=1 \
+  --username "$POSTGRES_USER" \
+  --dbname postgres \
+  -v ferretdb_user="$ferretdb_user" \
+  -v ferretdb_password="$ferretdb_password" \
+  -v ferretdb_database="$ferretdb_database" <<'SQL'
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'ferretdb_user', :'ferretdb_password')
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM pg_roles
+  WHERE rolname = :'ferretdb_user'
+)\gexec
+
+SELECT format('CREATE DATABASE %I OWNER %I', :'ferretdb_database', :'ferretdb_user')
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM pg_database
+  WHERE datname = :'ferretdb_database'
+)\gexec
+
+SELECT format('GRANT CONNECT, CREATE, TEMPORARY ON DATABASE %I TO %I', :'ferretdb_database', :'ferretdb_user')\gexec
+SQL
+
+psql -v ON_ERROR_STOP=1 \
+  --username "$POSTGRES_USER" \
+  --dbname "$ferretdb_database" \
+  -v ferretdb_user="$ferretdb_user" <<'SQL'
+CREATE EXTENSION IF NOT EXISTS documentdb CASCADE;
+GRANT USAGE, CREATE ON SCHEMA public TO :"ferretdb_user";
+
+CREATE TEMP TABLE ferretdb_bootstrap_user(name text);
+INSERT INTO ferretdb_bootstrap_user VALUES (:'ferretdb_user');
+
+DO $$
+DECLARE
+  ferretdb_role text := (SELECT name FROM ferretdb_bootstrap_user LIMIT 1);
+  schema_name text;
+BEGIN
+  FOR schema_name IN
+    SELECT nspname
+    FROM pg_namespace
+    WHERE nspname LIKE 'documentdb_%' OR nspname = 'documentdb_core'
+  LOOP
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', schema_name, ferretdb_role);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO %I', schema_name, ferretdb_role);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO %I', schema_name, ferretdb_role);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', schema_name, ferretdb_role);
+  END LOOP;
+END
+$$;
+SQL


### PR DESCRIPTION
## Summary

- extend the self-host PostgreSQL 18 image with Pigsty/PGEXT Supabase extensions, DocumentDB packages, and required preload configuration
- add an optional `ferretdb` Compose profile that exposes MongoDB wire protocol on port 27017 while using the same PostgreSQL container and volume
- add FerretDB env generation/docs and bootstrap role/grants for DocumentDB-backed FerretDB access

## Notes

- FerretDB is disabled by default.
- `FERRETDB_DATABASE` defaults to `POSTGRES_DB` because DocumentDB depends on `pg_cron`, and `pg_cron` can only be created in the configured cron database.

## Verification

- `docker compose --env-file .env.example config`
- `ENABLE_FERRETDB=true COMPOSE_PROFILES=ferretdb docker compose --env-file .env.example config`
- `python3 -m py_compile docker/self-host/init-env.py`
- `docker compose --env-file .env.example build postgres`
- started a temporary Postgres container with `ENABLE_FERRETDB=true` and verified `pg_graphql`, `pg_jsonschema`, `wrappers`, `index_advisor`, `pg_net`, `supabase_vault`, `pgjwt`, `pgsodium`, and `documentdb` extensions
- started a temporary default Postgres container and verified `documentdb` and `ferretdb` role are not created by default
- started `ghcr.io/ferretdb/ferretdb:2.7.0` against the temporary Postgres container and verified the service stayed running and handled its readiness ping
