### PR TITLE
ci: publish custom postgres image to GHCR on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ permissions:
   issues: write
   id-token: write
   actions: write
+  packages: write
 
 jobs:
   release-please:
@@ -108,6 +109,48 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           RELEASE_TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
         run: gh release upload "$RELEASE_TAG" release-assets/* --clobber
+
+
+  publish-docker-postgres:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.management_api_released == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.management_api_tag_name }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        env:
+          TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
+        run: echo "version=${TAG#management-api-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push postgres image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/self-host/postgres
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/postgres:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}/postgres:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
   publish-npm:
     needs: release-please


### PR DESCRIPTION
## Summary

- Add `publish-docker-postgres` job to `release-please.yml` that builds and pushes the self-host PostgreSQL image to GHCR on every management-api release
- Image includes all Pigsty/PGEXT + DocumentDB extensions from the merged PR #206
- Tags: `ghcr.io/zuohuadong/supacloud/postgres:<version>` and `:latest`
- Supports `linux/amd64` + `linux/arm64` multi-platform builds with GHA cache
- Add `packages: write` to top-level workflow permissions

## Why

PR #206 added a custom PostgreSQL image with Supabase extensions, but there was no CI pipeline to publish it. Users currently must `docker compose build` locally. Publishing to GHCR makes the image directly pullable.

## Test plan

- [x] Merge and wait for next management-api release to trigger the job
- [x] Verify image appears at `ghcr.io/zuohuadong/supacloud/postgres:latest`
- [x] Verify `docker pull ghcr.io/zuohuadong/supacloud/postgres:latest` works and extensions are available