### PR TITLE
ci: extract postgres docker workflow, support manual dispatch

### DIFF
--- a/.github/workflows/publish-docker-postgres.yml
+++ b/.github/workflows/publish-docker-postgres.yml
@@ -1,0 +1,68 @@
+name: Publish Docker Postgres
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: "Version (e.g. 0.23.0) or full tag (e.g. management-api-v0.23.0). Leave empty to use latest release."
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      tag_version:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Resolve version
+        id: version
+        run: |
+          raw="${{ inputs.tag_version }}"
+          if [[ -n "$raw" ]]; then
+            # 去除可能的管理前缀：management-api-v0.23.0 -> 0.23.0
+            version="${raw#management-api-v}"
+          else
+            LATEST=$(gh release list --repo ${{ github.repository }} --limit 50 \
+              | grep -oP 'management-api-v\K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+            if [[ -z "$LATEST" ]]; then
+              echo "ERROR: No management-api release found" >&2
+              exit 1
+            fi
+            version="$LATEST"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building postgres image: $version"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push postgres image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/self-host/postgres
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/postgres:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}/postgres:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ permissions:
   issues: write
   id-token: write
   actions: write
+  packages: write
 
 jobs:
   release-please:
@@ -108,6 +109,48 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           RELEASE_TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
         run: gh release upload "$RELEASE_TAG" release-assets/* --clobber
+
+
+  publish-docker-postgres:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.management_api_released == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.management_api_tag_name }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: version
+        env:
+          TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
+        run: echo "version=${TAG#management-api-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push postgres image
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/self-host/postgres
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}/postgres:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}/postgres:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
   publish-npm:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -114,43 +114,12 @@ jobs:
   publish-docker-postgres:
     needs: release-please
     if: ${{ needs.release-please.outputs.management_api_released == 'true' }}
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/publish-docker-postgres.yml
+    with:
+      tag_version: ${{ needs.release-please.outputs.management_api_tag_name }}
     permissions:
       contents: read
       packages: write
-    steps:
-      - name: Checkout release tag
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.release-please.outputs.management_api_tag_name }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version from tag
-        id: version
-        env:
-          TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
-        run: echo "version=${TAG#management-api-v}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push postgres image
-        uses: docker/build-push-action@v6
-        with:
-          context: docker/self-host/postgres
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}/postgres:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository }}/postgres:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
 
   publish-npm:
     needs: release-please


### PR DESCRIPTION
## Summary

- Extract `publish-docker-postgres` into a standalone reusable workflow (`publish-docker-postgres.yml`)
- Supports `workflow_dispatch` (manual trigger from Actions tab) and `workflow_call` (called from release-please)
- `release-please.yml` now calls the reusable workflow via `uses:` instead of inlining the job
- Manual trigger can optionally specify a version, or auto-detect latest management-api release

## Why

PR #208 merged the inline job, but there was no way to manually trigger a postgres image build without waiting for the next management-api release. The standalone workflow enables on-demand builds from the Actions tab.

## Test plan

- [ ] Merge this PR
- [ ] Go to Actions -> "Publish Docker Postgres" -> Run workflow
- [ ] Verify image is pushed to `ghcr.io/zuohuadong/supacloud/postgres:latest`