### PR TITLE
ci: postgres image builds on Dockerfile change

### DIFF
--- a/.github/workflows/publish-docker-postgres.yml
+++ b/.github/workflows/publish-docker-postgres.yml
@@ -1,17 +1,15 @@
 name: Publish Docker Postgres
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/self-host/postgres/**"
   workflow_dispatch:
-    inputs:
-      tag_version:
-        description: "Version (e.g. 0.23.0) or full tag (e.g. management-api-v0.23.0). Leave empty to use latest release."
-        required: false
-        type: string
-  workflow_call:
-    inputs:
-      tag_version:
-        required: true
-        type: string
+
+concurrency:
+  group: publish-docker-postgres
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -24,26 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Resolve version
-        id: version
-        run: |
-          raw="${{ inputs.tag_version }}"
-          if [[ -n "$raw" ]]; then
-            version="${raw#management-api-v}"
-          else
-            LATEST=$(gh release list --repo ${{ github.repository }} --limit 50 \
-              | grep -oP 'management-api-v\K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-            if [[ -z "$LATEST" ]]; then
-              echo "ERROR: No management-api release found" >&2
-              exit 1
-            fi
-            version="$LATEST"
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Building postgres image: $version"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -54,13 +32,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker metadata
+        id: meta
+        run: |
+          SHA=$(git rev-parse --short=7 HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Building postgres image: sha-$SHA, latest"
+
       - name: Build and push postgres image
         uses: docker/build-push-action@v6
         with:
           context: docker/self-host/postgres
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/postgres:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}/postgres:sha-${{ steps.meta.outputs.sha }}
             ghcr.io/${{ github.repository }}/postgres:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,6 @@ permissions:
   issues: write
   id-token: write
   actions: write
-  packages: write
 
 jobs:
   release-please:
@@ -110,16 +109,6 @@ jobs:
           RELEASE_TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
         run: gh release upload "$RELEASE_TAG" release-assets/* --clobber
 
-
-  publish-docker-postgres:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.management_api_released == 'true' }}
-    uses: ./.github/workflows/publish-docker-postgres.yml
-    with:
-      tag_version: ${{ needs.release-please.outputs.management_api_tag_name }}
-    permissions:
-      contents: read
-      packages: write
 
   publish-npm:
     needs: release-please


### PR DESCRIPTION
## Summary

- `publish-docker-postgres` 现在完全独立于 release-please
- 触发条件：push to main 且 `docker/self-host/postgres/**` 有变更，或手动 workflow_dispatch
- 版本标签：`sha-<7位短hash>` + `latest`
- 从 `release-please.yml` 中移除 postgres job（postgres 镜像有自己的生命周期）

## Why

Postgres Dockerfile 变更跟 management-api 发版没有绑定关系。Dockerfile 改了就应该立即构建新镜像，不需要等到下次 API 发版。

## After merge

合并后因为 main 上的 `docker/self-host/postgres/` 路径刚被 PR #206 改过，会立即触发一次构建（但上一次 push 的 commit 已经被之前的 run 覆盖了，不会重复触发）。之后每次 Dockerfile 或 initdb 脚本变动都会自动构建推送。