### PR TITLE
docs: add TrueNAS custom app deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ docker compose up -d --build
 
 The compose stack is isolated under [`docker/self-host`](/Volumes/Data/workspace/supacloud/docker/self-host) and ships a PostgreSQL 18 image with common extensions preinstalled.
 
+For TrueNAS SCALE `Custom App` deployment of the published PostgreSQL image, see [`docker/self-host/TRUENAS.md`](./docker/self-host/TRUENAS.md).
+
 **Available CLI Options:**
 | Option | Description | Example |
 |--------|-------------|---------|

--- a/docker/self-host/README.md
+++ b/docker/self-host/README.md
@@ -68,6 +68,10 @@ Endpoints:
 - API gateway: `${PUBLIC_URL}` (default `http://localhost:8000`)
 - Management API / Studio shell: `${STUDIO_URL}` (default `http://localhost:9090`)
 
+## TrueNAS SCALE
+
+For TrueNAS SCALE `Custom App` deployment of the published PostgreSQL image, see [`TRUENAS.md`](./TRUENAS.md).
+
 ## Optional FerretDB profile
 
 FerretDB is disabled by default. To expose the MongoDB wire protocol on top of the same PostgreSQL container and `postgres-data` volume, enable it before the first database initialization:

--- a/docker/self-host/TRUENAS.md
+++ b/docker/self-host/TRUENAS.md
@@ -1,0 +1,121 @@
+# TrueNAS SCALE Custom App Guide
+
+This guide is for running the published SupaCloud PostgreSQL image on **TrueNAS SCALE** as a **Custom App**.
+
+## When to use this
+
+Use this path when you want:
+
+- the SupaCloud PostgreSQL image from GHCR
+- the Pigsty/PGEXT extension set already baked into the image
+- optional FerretDB + DocumentDB support on the same PostgreSQL instance
+
+Do **not** use the TrueNAS catalog PostgreSQL app if your goal is to reuse this image's extension set. The catalog app and this image are different deployment paths.
+
+## Recommended image
+
+Use a released tag instead of `latest`.
+
+```text
+ghcr.io/zuohuadong/supacloud/postgres:0.23.0
+```
+
+The package is public, so no GHCR credentials are required for normal pulls.
+
+## Custom App form values
+
+Repository:
+
+```text
+ghcr.io/zuohuadong/supacloud/postgres
+```
+
+Tag:
+
+```text
+0.23.0
+```
+
+Container port:
+
+```text
+5432/TCP
+```
+
+Persistent storage mount:
+
+```text
+/var/lib/postgresql/data
+```
+
+Required environment variables:
+
+```text
+POSTGRES_PASSWORD=<strong password>
+```
+
+Common optional environment variables:
+
+```text
+POSTGRES_USER=postgres
+POSTGRES_DB=postgres
+TZ=Asia/Shanghai
+```
+
+## Optional FerretDB
+
+Enable these only when you also want MongoDB wire protocol compatibility:
+
+```text
+ENABLE_FERRETDB=true
+FERRETDB_USER=ferretdb
+FERRETDB_PASSWORD=<another strong password>
+FERRETDB_DATABASE=postgres
+```
+
+When FerretDB is enabled, also expose:
+
+```text
+27017/TCP
+```
+
+`FERRETDB_DATABASE` defaults to the main PostgreSQL database on purpose. `documentdb` depends on `pg_cron`, and `pg_cron` can only be created in the database selected by `cron.database_name`.
+
+## Important initialization rule
+
+Set all required environment variables **before the first start**.
+
+This image uses init scripts to:
+
+- create and preload required PostgreSQL extensions
+- optionally create the FerretDB role
+- optionally create the `documentdb` extension
+
+If TrueNAS already initialized the app data directory, changing `ENABLE_FERRETDB` later will not replay those init scripts. In that case, use a fresh data directory or apply the role and extension changes manually.
+
+## Minimal deployment checklist
+
+1. Create a new Custom App.
+2. Set the image repository and fixed tag.
+3. Add a host path or dataset mount for `/var/lib/postgresql/data`.
+4. Set `POSTGRES_PASSWORD`.
+5. Optionally add the FerretDB variables and `27017/TCP`.
+6. Start the app on an empty data directory.
+
+## Verification after first start
+
+Basic PostgreSQL readiness:
+
+```bash
+pg_isready -h <truenas-app-ip> -p 5432 -U postgres -d postgres
+```
+
+Basic extension check:
+
+```sql
+SELECT extname
+FROM pg_extension
+ORDER BY extname;
+```
+
+When FerretDB is enabled, verify the port is listening on `27017` and test it with a MongoDB-compatible client.


### PR DESCRIPTION
## Summary

- add a dedicated `docker/self-host/TRUENAS.md` guide for running the published SupaCloud PostgreSQL image on TrueNAS SCALE as a Custom App
- link the new guide from the top-level README and the self-host README
- document the TrueNAS-specific constraints that matter for this image: fixed release tags, required env vars, persistent mount path, first-init behavior, and the FerretDB/DocumentDB dependency on `pg_cron`

## Why

The PostgreSQL image and FerretDB support are already merged, but TrueNAS users still need a deployment path that matches how they actually install apps. This follow-up keeps platform-specific guidance in docs instead of adding more runtime branching to the image or compose files.

## Verification

- reviewed the merged PostgreSQL self-host docs on `origin/main`
- checked the package publication and release flow already present on `main`
- ran `git diff --check`
