### PR TITLE
feat: PGMQ queue compatibility and postgres CI trigger

### DIFF
--- a/.github/workflows/publish-docker-postgres.yml
+++ b/.github/workflows/publish-docker-postgres.yml
@@ -1,17 +1,15 @@
 name: Publish Docker Postgres
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/self-host/postgres/**"
   workflow_dispatch:
-    inputs:
-      tag_version:
-        description: "Version (e.g. 0.23.0) or full tag (e.g. management-api-v0.23.0). Leave empty to use latest release."
-        required: false
-        type: string
-  workflow_call:
-    inputs:
-      tag_version:
-        required: true
-        type: string
+
+concurrency:
+  group: publish-docker-postgres
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -24,26 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Resolve version
-        id: version
-        run: |
-          raw="${{ inputs.tag_version }}"
-          if [[ -n "$raw" ]]; then
-            version="${raw#management-api-v}"
-          else
-            LATEST=$(gh release list --repo ${{ github.repository }} --limit 50 \
-              | grep -oP 'management-api-v\K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-            if [[ -z "$LATEST" ]]; then
-              echo "ERROR: No management-api release found" >&2
-              exit 1
-            fi
-            version="$LATEST"
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "Building postgres image: $version"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -54,13 +32,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker metadata
+        id: meta
+        run: |
+          SHA=$(git rev-parse --short=7 HEAD)
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Building postgres image: sha-$SHA, latest"
+
       - name: Build and push postgres image
         uses: docker/build-push-action@v6
         with:
           context: docker/self-host/postgres
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/postgres:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}/postgres:sha-${{ steps.meta.outputs.sha }}
             ghcr.io/${{ github.repository }}/postgres:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,6 @@ permissions:
   issues: write
   id-token: write
   actions: write
-  packages: write
 
 jobs:
   release-please:
@@ -110,16 +109,6 @@ jobs:
           RELEASE_TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
         run: gh release upload "$RELEASE_TAG" release-assets/* --clobber
 
-
-  publish-docker-postgres:
-    needs: release-please
-    if: ${{ needs.release-please.outputs.management_api_released == 'true' }}
-    uses: ./.github/workflows/publish-docker-postgres.yml
-    with:
-      tag_version: ${{ needs.release-please.outputs.management_api_tag_name }}
-    permissions:
-      contents: read
-      packages: write
 
   publish-npm:
     needs: release-please

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     restart: always
     environment:
       PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/postgres
+      PGRST_DB_SCHEMAS: public,storage,graphql_public,pgmq_public
       PGRST_JWT_SECRET: ${JWT_SECRET}
     networks:
       - supacloud-dev

--- a/docker/self-host/.env.example
+++ b/docker/self-host/.env.example
@@ -29,7 +29,7 @@ PUBLIC_URL=http://localhost:8000
 STUDIO_URL=http://localhost:9090
 BASE_DOMAIN=localhost
 
-PGRST_DB_SCHEMAS=public,storage,graphql_public
+PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public
 
 KONG_HTTP_PORT=8000
 KONG_HTTPS_PORT=8443

--- a/docker/self-host/docker-compose.yml
+++ b/docker/self-host/docker-compose.yml
@@ -52,7 +52,7 @@ services:
         condition: service_healthy
     environment:
       PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}
-      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS:-public,storage,graphql_public}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS:-public,storage,graphql_public,pgmq_public}
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_SERVER_PROXY_URI: ${PUBLIC_URL}

--- a/docker/self-host/init-env.py
+++ b/docker/self-host/init-env.py
@@ -128,7 +128,7 @@ def main() -> None:
     print(f"PUBLIC_URL={args.public_url}")
     print(f"STUDIO_URL={args.studio_url}")
     print(f"BASE_DOMAIN={derive_base_domain(args.public_url)}")
-    print("PGRST_DB_SCHEMAS=public,storage,graphql_public")
+    print("PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public")
     print("KONG_HTTP_PORT=8000")
     print("KONG_HTTPS_PORT=8443")
     print("KONG_ADMIN_PORT=8001")

--- a/docker/self-host/postgres/Dockerfile
+++ b/docker/self-host/postgres/Dockerfile
@@ -29,6 +29,7 @@ RUN set -eux; \
       postgresql-18-index-advisor \
       postgresql-18-pg-stat-kcache \
       postgresql-18-pg-plan-filter \
+      postgresql-18-pgmq \
       postgresql-18-supautils \
       postgresql-18-vault \
       postgresql-18-wal2json \

--- a/docker/self-host/postgres/initdb/01-bootstrap-extensions.sql
+++ b/docker/self-host/postgres/initdb/01-bootstrap-extensions.sql
@@ -17,6 +17,7 @@ BEGIN
     'pg_net',
     'pg_graphql',
     'pg_jsonschema',
+    'pgmq',
     'wrappers',
     'pgjwt',
     'pgsodium',

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@
 - [Background Functions With supabase-js](./background-functions-supabase-js-tutorial.md) - Tenant SDK tutorial for invoke, polling, cancel, DLQ, lifecycle webhooks, and queues
 - [Background Functions API Reference](./background-functions-api-reference.md) - Headers, task states, control-plane endpoints, and runtime semantics
 - [@supacloud/js](./supacloud-js.md) - Official platform SDK layered on top of `supabase-js`, including tasks, lifecycle webhooks, queues, and OAuth helpers
+- [Queues PGMQ Migration Guide](./queues-pgmq-migration.md) - Migration notes for Supabase Queues compatibility and SupaCloud queue extensions
 
 ## Product Positioning
 

--- a/docs/queues-pgmq-migration.md
+++ b/docs/queues-pgmq-migration.md
@@ -1,0 +1,174 @@
+# Queues PGMQ Migration Guide
+
+This guide documents the migration of SupaCloud Queues to the official Supabase Queues foundation, which is backed by the PostgreSQL `pgmq` extension.
+
+Use this together with the official Supabase Queues docs:
+
+- [Supabase Queues](https://supabase.com/docs/guides/queues)
+- [Queues API](https://supabase.com/docs/guides/queues/api)
+- [Queues Quickstart](https://supabase.com/docs/guides/queues/quickstart)
+- [Expose self-hosted Queues](https://supabase.com/docs/guides/queues/expose-self-hosted-queues)
+
+## Scope
+
+SupaCloud now treats Supabase's `pgmq_public` API as the compatibility baseline.
+
+The official public API contains:
+
+- `pgmq_public.send(queue_name, message, sleep_seconds)`
+- `pgmq_public.send_batch(queue_name, messages, sleep_seconds)`
+- `pgmq_public.read(queue_name, sleep_seconds, n)`
+- `pgmq_public.pop(queue_name)`
+- `pgmq_public.archive(queue_name, message_id)`
+- `pgmq_public.delete(queue_name, message_id)`
+
+SupaCloud only extends the API where the official client surface is intentionally missing operational capabilities:
+
+- create, drop, and list queues
+- queue metrics
+- purge
+- diagnostic message/archive listing
+- queue settings
+- visibility-timeout adjustment through `pgmq.set_vt`
+
+## Platform Changes
+
+Tenant databases now install and expose the `pgmq` foundation:
+
+1. `CREATE EXTENSION IF NOT EXISTS pgmq`
+2. `CREATE SCHEMA IF NOT EXISTS pgmq_public`
+3. wrapper functions in `pgmq_public` for the official API
+4. `GRANT EXECUTE` on `pgmq_public` functions to `anon`, `authenticated`, and `service_role`
+5. PostgREST schemas include `pgmq_public`
+
+For self-hosted deployments, `PGRST_DB_SCHEMAS` must include:
+
+```env
+PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public
+```
+
+The bundled self-hosted PostgreSQL image installs `postgresql-18-pgmq` and bootstraps `pgmq` during initdb.
+
+## SDK Migration
+
+`@supacloud/js` core queue message operations now call the wrapped Supabase client directly:
+
+```ts
+supabase.schema("pgmq_public").rpc("send", {
+  queue_name: "emails",
+  message: { to: "user@example.com" },
+  sleep_seconds: 10,
+});
+```
+
+Use the SDK helper for normal application code:
+
+```ts
+const queue = supacloud.queue("emails");
+
+const sent = await queue.send(
+  { to: "user@example.com", template: "welcome" },
+  { sleepSeconds: 10 },
+);
+
+const messages = await queue.read({ sleepSeconds: 60, n: 5 });
+
+for (const message of messages) {
+  try {
+    await sendEmail(message.payload);
+    await queue.ack(message.msg_id);
+  } catch {
+    await queue.release(message.msg_id, { delayMs: 30_000 });
+  }
+}
+```
+
+Queue creation is not part of the official public Supabase Queues API. Use the SupaCloud management extension before sending messages:
+
+```ts
+await supacloud.queues.create("emails");
+```
+
+## API Mapping
+
+| Previous SupaCloud API | New behavior |
+| --- | --- |
+| `queue.send(payload, options)` | Calls `pgmq_public.send`; returns numeric `msg_id` metadata. |
+| `queue.sendBatch(messages, options)` | Calls `pgmq_public.send_batch`. |
+| `queue.receive(options)` | Compatibility shortcut for `queue.read({ n: 1 })`. |
+| `queue.read({ sleepSeconds, n })` | Calls `pgmq_public.read`. |
+| `queue.pop()` | Calls `pgmq_public.pop`; the message is deleted immediately. |
+| `queue.ack(messageId)` | Alias of `queue.archive(messageId)`. |
+| `queue.archive(messageId)` | Calls `pgmq_public.archive`. |
+| `queue.delete(messageId)` | Calls `pgmq_public.delete`. |
+| `queue.release(messageId, options)` | SupaCloud extension backed by `pgmq.set_vt`. |
+| `queue.fail(messageId)` | Compatibility alias that archives the message; PGMQ has no failed state. |
+| `queue.get(messageId)` | Deprecated; PGMQ has no official random message lookup API. |
+| `queue.retry(messageId)` | Deprecated; replay archived messages with SQL/application workflows. |
+| `queue.listFailed()` | Diagnostic alias for archived-message inspection, not a PGMQ dead-letter state. |
+
+## Behavior Differences
+
+PGMQ changes the queue contract in several important ways:
+
+- Message IDs are numeric `msg_id` values, not generated string IDs.
+- `read` leases messages by changing their visibility timeout.
+- `archive` is the official acknowledgement path.
+- `pop` reads and deletes in one operation.
+- PGMQ does not provide an official failed or retry state.
+- Queue tables live under the `pgmq` schema and should not be treated as application tables.
+- Delivery remains at-least-once. Consumers must stay idempotent.
+
+## Migration Checklist
+
+For existing SupaCloud deployments:
+
+1. Upgrade management-api and tenant schema migration code.
+2. Ensure the tenant PostgreSQL package set includes `pgmq`.
+3. Apply the tenant schema migration so `pgmq_public` wrappers exist.
+4. Restart or reload PostgREST with `pgmq_public` in `PGRST_DB_SCHEMAS`.
+5. Upgrade `@supacloud/js`.
+6. Replace direct queue retry/get assumptions with `read`, `archive`, `delete`, metrics, or application-level replay.
+7. Make consumers use `message.msg_id` for `ack`, `archive`, `delete`, and `release`.
+
+## Verification
+
+Check tenant SQL:
+
+```sql
+select extname from pg_extension where extname = 'pgmq';
+select nspname from pg_namespace where nspname = 'pgmq_public';
+```
+
+Check PostgREST RPC through `supabase-js`:
+
+```ts
+const { data, error } = await supabase
+  .schema("pgmq_public")
+  .rpc("send", {
+    queue_name: "emails",
+    message: { hello: "world" },
+    sleep_seconds: 0,
+  });
+
+if (error) throw error;
+console.log(data);
+```
+
+Check SupaCloud extensions:
+
+```ts
+await supacloud.queues.create("emails");
+const stats = await supacloud.queue("emails").stats();
+console.log(stats.queue_length);
+```
+
+## Rollback Notes
+
+This migration is additive at the database level. Rolling back the application code does not require dropping `pgmq` or `pgmq_public`.
+
+If a rollback is needed:
+
+1. deploy the previous management-api and SDK versions
+2. keep `pgmq` installed to avoid breaking tenants that already created queues
+3. keep `pgmq_public` exposed until all clients have stopped using official Supabase Queues RPCs

--- a/docs/supacloud-js.md
+++ b/docs/supacloud-js.md
@@ -59,24 +59,32 @@ Current first-class API surface:
 - `client.tasks.subscribe(...)`
 - `client.functions.invokeBackground(...)`
 - `client.queue(name).send(...)`
+- `client.queue(name).sendBatch(...)`
+- `client.queue(name).read(...)`
 - `client.queue(name).receive(...)`
+- `client.queue(name).pop(...)`
+- `client.queue(name).archive(...)`
+- `client.queue(name).ack(...)`
+- `client.queue(name).delete(...)`
+- `client.queue(name).release(...)`
 - `client.queue(name).list(...)`
+- `client.queue(name).listArchived(...)`
 - `client.queue(name).listFailed(...)`
 - `client.queue(name).get(...)`
-- `client.queue(name).ack(...)`
-- `client.queue(name).release(...)`
 - `client.queue(name).fail(...)`
 - `client.queue(name).retry(...)`
-- `client.queue(name).delete(...)`
 - `client.queue(name).stats(...)`
 - `client.queue(name).getSettings(...)`
 - `client.queue(name).updateSettings(...)`
+- `client.queues.list/create/drop(...)`
 - `client.auth.oauthServer.getStatus()`
 - `client.auth.oauthServer.migrateToOidc()`
 - `client.auth.oauthServer.getDiscovery()`
 - `client.auth.oauthServer.getJwks()`
 - `client.auth.oauthServer.buildAuthorizeUrl()`
 - `client.auth.oauthClients.list()/create()/get()/update()/delete()/regenerateSecret()`
+
+Core queue message operations follow the official Supabase Queues `pgmq_public` RPC API. `client.queues.*`, queue metrics, purge, settings, diagnostics, and `release` are SupaCloud management extensions. See [Queues PGMQ Migration Guide](./queues-pgmq-migration.md).
 
 ## Example
 

--- a/packages/management-api/src/db/schemas/supabase.sql
+++ b/packages/management-api/src/db/schemas/supabase.sql
@@ -4044,6 +4044,61 @@ BEGIN
 END;
 $graphql_fallback$;
 
+-- 7b. Supabase Queues compatibility via the official PGMQ extension.
+CREATE EXTENSION IF NOT EXISTS pgmq;
+CREATE SCHEMA IF NOT EXISTS pgmq_public;
+GRANT USAGE ON SCHEMA pgmq_public TO anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send(queue_name text, message jsonb, sleep_seconds integer DEFAULT 0)
+RETURNS SETOF bigint
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.send(queue_name, message, sleep_seconds); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send_batch(queue_name text, messages jsonb[], sleep_seconds integer DEFAULT 0)
+RETURNS SETOF bigint
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.send_batch(queue_name, messages, sleep_seconds); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.read(queue_name text, sleep_seconds integer, n integer)
+RETURNS SETOF pgmq.message_record
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.read(queue_name, sleep_seconds, n); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.pop(queue_name text)
+RETURNS SETOF pgmq.message_record
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.pop(queue_name); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.archive(queue_name text, message_id bigint)
+RETURNS boolean
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT pgmq.archive(queue_name, message_id); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public."delete"(queue_name text, message_id bigint)
+RETURNS boolean
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT pgmq.delete(queue_name, message_id); $$;
+
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgmq_public TO anon, authenticated, service_role;
+
 -- 8. Functions Schema (Webhooks)
 CREATE SCHEMA IF NOT EXISTS supabase_functions;
 GRANT USAGE ON SCHEMA supabase_functions TO postgres, anon, authenticated, service_role;

--- a/packages/management-api/src/routes/tasks.ts
+++ b/packages/management-api/src/routes/tasks.ts
@@ -2,16 +2,16 @@ import { Elysia, status, t } from "elysia";
 import { taskRepository } from "../repositories/task.repository";
 import { TaskStatus, type ProjectTask } from "../db";
 import { backgroundFunctionWorker, projectService } from "../services";
+import { pgmqService } from "../services/pgmq.service";
 import * as authMiddleware from "../middleware/auth";
 
 const QUEUE_TASK_TYPE_PREFIX = "queue:";
-const DEFAULT_QUEUE_MAX_ATTEMPTS = 3;
 const DEFAULT_QUEUE_VISIBILITY_TIMEOUT_SEC = 330;
 const MAX_QUEUE_DELAY_MS = 30 * 24 * 60 * 60 * 1000;
 
 function normalizeQueueName(name: string): string | null {
     const value = name.trim();
-    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) return null;
+    if (!/^[a-z0-9][a-z0-9_-]{0,127}$/.test(value)) return null;
     return value;
 }
 
@@ -25,17 +25,13 @@ function normalizePositiveInteger(value: unknown, fallback: number, min: number,
     return Math.max(min, Math.min(max, Math.floor(numberValue)));
 }
 
-function buildQueueListFilters(queueName: string, query: Record<string, unknown>) {
-    const statuses = typeof query.status === "string"
-      ? query.status.split(",").map((value) => value.trim()).filter(Boolean)
-      : undefined;
-    const limit = normalizePositiveInteger(query.limit, 50, 1, 500);
-    return {
-        statuses,
-        taskTypes: [queueTaskType(queueName)],
-        onlyDeadLettered: query.dlq === "true",
-        limit,
-    };
+function normalizeNonNegativeSeconds(value: unknown, fallback: number, max: number): number {
+    return normalizePositiveInteger(value, fallback, 0, max);
+}
+
+function normalizeMessageId(value: string): number | null {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 function isTaskDetailRead(request: Request, projectRef: string): boolean {
@@ -97,69 +93,120 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
         const authError = await authMiddleware.requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
     })
+    .get("/queues", async ({ params }) => {
+        try {
+            return await pgmqService.listQueues(params.ref);
+        } catch (err: unknown) {
+            return status(500, { message: "Failed to list queues", code: "500", details: (err instanceof Error ? err.message : String(err)) });
+        }
+    }, { detail: { tags: ["tasks"], summary: "List PGMQ queues" } })
+    .post("/queues", async ({ params, body }) => {
+        try {
+            const input = body as { queueName?: string; queue_name?: string; unlogged?: boolean };
+            const queueName = normalizeQueueName(input.queueName || input.queue_name || "");
+            if (!queueName) {
+                return status(400, { message: "Invalid queue name", code: "400" });
+            }
+            await pgmqService.createQueue(params.ref, queueName, { unlogged: input.unlogged });
+            return status(201, { queue_name: queueName, type: input.unlogged ? "unlogged" : "basic" });
+        } catch (err: unknown) {
+            return status(500, { message: "Failed to create queue", code: "500", details: (err instanceof Error ? err.message : String(err)) });
+        }
+    }, {
+        body: t.Object({
+            queueName: t.Optional(t.String()),
+            queue_name: t.Optional(t.String()),
+            unlogged: t.Optional(t.Boolean()),
+        }),
+        detail: { tags: ["tasks"], summary: "Create a PGMQ queue" },
+    })
+    .delete("/queues/:queueName", async ({ params }) => {
+        try {
+            const queueName = normalizeQueueName(params.queueName);
+            if (!queueName) {
+                return status(400, { message: "Invalid queue name", code: "400" });
+            }
+            const dropped = await pgmqService.dropQueue(params.ref, queueName);
+            return dropped ? status(204) : status(404, { message: "Queue not found", code: "404" });
+        } catch (err: unknown) {
+            return status(500, { message: "Failed to drop queue", code: "500", details: (err instanceof Error ? err.message : String(err)) });
+        }
+    }, { detail: { tags: ["tasks"], summary: "Drop a PGMQ queue" } })
     .post("/queues/:queueName/messages", async ({ params, body }) => {
         try {
             const queueName = normalizeQueueName(params.queueName);
             if (!queueName) {
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
-            const queueSettings = await projectService.getQueueSettings(params.ref, queueName);
-            if (!queueSettings) {
-                return status(404, { message: "Project not found", code: "404" });
-            }
 
             const input = body as {
                 payload?: Record<string, unknown>;
+                message?: Record<string, unknown>;
                 delayMs?: number;
-                maxAttempts?: number;
-                idempotencyKey?: string;
-                traceId?: string;
-                correlationId?: string;
-                businessTaskId?: string;
-                metadata?: Record<string, unknown>;
+                sleepSeconds?: number;
+                sleep_seconds?: number;
             };
-            const recentMessages = await taskRepository.countQueueMessagesCreatedSince(
+            const sleepSeconds = input.sleepSeconds ?? input.sleep_seconds ??
+                Math.floor(normalizeNonNegativeSeconds(input.delayMs, 0, MAX_QUEUE_DELAY_MS) / 1000);
+            const msgId = await pgmqService.send(
                 params.ref,
-                queueTaskType(queueName),
-                new Date(Date.now() - 60_000),
+                queueName,
+                input.message || input.payload || {},
+                normalizeNonNegativeSeconds(sleepSeconds, 0, MAX_QUEUE_DELAY_MS / 1000),
             );
-            if (recentMessages >= queueSettings.rate_limit_per_minute) {
-                return status(429, {
-                    message: "Queue rate limit exceeded",
-                    code: "429",
-                    limit: queueSettings.rate_limit_per_minute,
-                    window_seconds: 60,
-                });
-            }
-            const delayMs = normalizePositiveInteger(input.delayMs, 0, 0, MAX_QUEUE_DELAY_MS);
-            const task = await taskRepository.createTask({
-                ref: params.ref,
-                type: queueTaskType(queueName),
-                payload: input.payload || {},
-                maxAttempts: normalizePositiveInteger(input.maxAttempts, queueSettings.max_attempts, 1, 10),
-                nextRunAt: new Date(Date.now() + delayMs),
-                idempotencyKey: input.idempotencyKey || null,
-                traceId: input.traceId || null,
-                correlationId: input.correlationId || null,
-                businessTaskId: input.businessTaskId || null,
-                metadata: input.metadata || null,
+            return status(202, {
+                id: String(msgId),
+                msg_id: msgId,
+                queue_name: queueName,
+                task_type: queueTaskType(queueName),
+                status: "pending",
             });
-            return status(202, task);
         } catch (err: unknown) {
             return status(500, { message: "Failed to enqueue queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
     }, {
         body: t.Object({
             payload: t.Optional(t.Record(t.String(), t.Unknown())),
+            message: t.Optional(t.Record(t.String(), t.Unknown())),
             delayMs: t.Optional(t.Number()),
-            maxAttempts: t.Optional(t.Number()),
-            idempotencyKey: t.Optional(t.String()),
-            traceId: t.Optional(t.String()),
-            correlationId: t.Optional(t.String()),
-            businessTaskId: t.Optional(t.String()),
-            metadata: t.Optional(t.Record(t.String(), t.Unknown())),
+            sleepSeconds: t.Optional(t.Number()),
+            sleep_seconds: t.Optional(t.Number()),
         }),
-        detail: { tags: ["tasks"], summary: "Enqueue a message to a queue" },
+        detail: { tags: ["tasks"], summary: "Enqueue a PGMQ message" },
+    })
+    .post("/queues/:queueName/messages/batch", async ({ params, body }) => {
+        try {
+            const queueName = normalizeQueueName(params.queueName);
+            if (!queueName) {
+                return status(400, { message: "Invalid queue name", code: "400" });
+            }
+            const input = body as { messages?: Record<string, unknown>[]; sleepSeconds?: number; sleep_seconds?: number; delayMs?: number };
+            const messages = Array.isArray(input.messages) ? input.messages : [];
+            const sleepSeconds = input.sleepSeconds ?? input.sleep_seconds ??
+                Math.floor(normalizeNonNegativeSeconds(input.delayMs, 0, MAX_QUEUE_DELAY_MS) / 1000);
+            const ids = await pgmqService.sendBatch(
+                params.ref,
+                queueName,
+                messages,
+                normalizeNonNegativeSeconds(sleepSeconds, 0, MAX_QUEUE_DELAY_MS / 1000),
+            );
+            return status(202, {
+                queue_name: queueName,
+                task_type: queueTaskType(queueName),
+                msg_ids: ids,
+                count: ids.length,
+            });
+        } catch (err: unknown) {
+            return status(500, { message: "Failed to enqueue queue message batch", code: "500", details: (err instanceof Error ? err.message : String(err)) });
+        }
+    }, {
+        body: t.Object({
+            messages: t.Array(t.Record(t.String(), t.Unknown())),
+            delayMs: t.Optional(t.Number()),
+            sleepSeconds: t.Optional(t.Number()),
+            sleep_seconds: t.Optional(t.Number()),
+        }),
+        detail: { tags: ["tasks"], summary: "Enqueue a PGMQ message batch" },
     })
     .post("/queues/:queueName/messages/receive", async ({ params, body }) => {
         try {
@@ -168,32 +215,35 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            const input = body as { visibilityTimeoutSec?: number } | undefined;
+            const input = body as { visibilityTimeoutSec?: number; sleep_seconds?: number; n?: number; count?: number } | undefined;
             const queueSettings = await projectService.getQueueSettings(params.ref, queueName);
             if (!queueSettings) {
                 return status(404, { message: "Project not found", code: "404" });
             }
-            const task = await taskRepository.claimQueueMessage({
-                projectRef: params.ref,
-                queueName: queueTaskType(queueName),
-                visibilityTimeoutSec: normalizePositiveInteger(
-                    input?.visibilityTimeoutSec,
+            const messages = await pgmqService.read(
+                params.ref,
+                queueName,
+                normalizePositiveInteger(
+                    input?.sleep_seconds ?? input?.visibilityTimeoutSec,
                     queueSettings.default_visibility_timeout_sec || DEFAULT_QUEUE_VISIBILITY_TIMEOUT_SEC,
                     1,
                     1800,
                 ),
-                maxInFlight: queueSettings.max_in_flight,
-            });
-            if (!task) return status(204);
-            return task;
+                normalizePositiveInteger(input?.n ?? input?.count, 1, 1, Math.max(1, queueSettings.max_in_flight)),
+            );
+            if (messages.length === 0) return status(204);
+            return (input?.n ?? input?.count) ? messages : messages[0];
         } catch (err: unknown) {
             return status(500, { message: "Failed to receive queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
     }, {
         body: t.Optional(t.Object({
             visibilityTimeoutSec: t.Optional(t.Number()),
+            sleep_seconds: t.Optional(t.Number()),
+            n: t.Optional(t.Number()),
+            count: t.Optional(t.Number()),
         })),
-        detail: { tags: ["tasks"], summary: "Receive a message from a queue" },
+        detail: { tags: ["tasks"], summary: "Read PGMQ messages with a visibility timeout" },
     })
     .get("/queues/:queueName/messages", async ({ params, query }) => {
         try {
@@ -202,18 +252,35 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            return await taskRepository.listTasksByProjectFiltered(params.ref, buildQueueListFilters(queueName, query));
+            return await pgmqService.listMessages(params.ref, queueName, {
+                archived: query.archived === "true" || query.dlq === "true",
+                limit: normalizePositiveInteger(query.limit, 50, 1, 500),
+            });
         } catch (err: unknown) {
             return status(500, { message: "Failed to list queue messages", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
     }, {
         query: t.Optional(t.Object({
-            status: t.Optional(t.String()),
+            archived: t.Optional(t.String()),
             dlq: t.Optional(t.String()),
             limit: t.Optional(t.String()),
         })),
-        detail: { tags: ["tasks"], summary: "List messages in a queue" },
+        detail: { tags: ["tasks"], summary: "List PGMQ messages for operator diagnostics" },
     })
+    .post("/queues/:queueName/messages/pop", async ({ params }) => {
+        try {
+            const queueName = normalizeQueueName(params.queueName);
+            if (!queueName) {
+                return status(400, { message: "Invalid queue name", code: "400" });
+            }
+
+            const message = await pgmqService.pop(params.ref, queueName);
+            if (!message) return status(204);
+            return message;
+        } catch (err: unknown) {
+            return status(500, { message: "Failed to pop queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
+        }
+    }, { detail: { tags: ["tasks"], summary: "Pop and delete the next PGMQ message" } })
     .get("/queues/:queueName/stats", async ({ params }) => {
         try {
             const queueName = normalizeQueueName(params.queueName);
@@ -221,11 +288,24 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            return await taskRepository.getQueueStats(params.ref, queueTaskType(queueName));
+            const metrics = await pgmqService.metrics(params.ref, queueName);
+            return metrics || status(404, { message: "Queue not found", code: "404" });
         } catch (err: unknown) {
             return status(500, { message: "Failed to retrieve queue stats", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
     }, { detail: { tags: ["tasks"], summary: "Get queue statistics" } })
+    .post("/queues/:queueName/purge", async ({ params }) => {
+        try {
+            const queueName = normalizeQueueName(params.queueName);
+            if (!queueName) {
+                return status(400, { message: "Invalid queue name", code: "400" });
+            }
+
+            return { queue_name: queueName, purged: await pgmqService.purge(params.ref, queueName) };
+        } catch (err: unknown) {
+            return status(500, { message: "Failed to purge queue", code: "500", details: (err instanceof Error ? err.message : String(err)) });
+        }
+    }, { detail: { tags: ["tasks"], summary: "Purge pending PGMQ messages" } })
     .get("/queues/:queueName/settings", async ({ params }) => {
         try {
             const queueName = normalizeQueueName(params.queueName);
@@ -280,38 +360,30 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            const task = await taskRepository.getTaskByIdAndType(params.messageId, params.ref, queueTaskType(queueName));
-            if (!task) {
-                return status(404, { message: "Queue message not found", code: "404" });
-            }
-            const attempts = await taskRepository.listTaskAttempts(params.messageId);
-            const latestAttempt = attempts[0] || null;
-            return {
-                ...task,
-                attempts,
-                latest_logs: latestAttempt?.logs || [],
-            };
+            return status(410, {
+                message: "PGMQ does not expose random message lookup through the official queue API; use receive/read, stats, archive, or delete",
+                code: "410",
+            });
         } catch (err: unknown) {
             return status(500, { message: "Failed to retrieve queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
     }, { detail: { tags: ["tasks"], summary: "Get a queue message by ID" } })
-    .post("/queues/:queueName/messages/:messageId/ack", async ({ params, body }) => {
+    .post("/queues/:queueName/messages/:messageId/ack", async ({ params }) => {
         try {
             const queueName = normalizeQueueName(params.queueName);
             if (!queueName) {
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            const current = await taskRepository.getTaskByIdAndType(params.messageId, params.ref, queueTaskType(queueName));
-            if (!current) {
-                return status(404, { message: "Queue message not found", code: "404" });
+            const messageId = normalizeMessageId(params.messageId);
+            if (!messageId) {
+                return status(400, { message: "Invalid queue message ID", code: "400" });
             }
-            const input = body as { result?: Record<string, unknown> } | undefined;
-            const task = await taskRepository.acknowledgeQueueMessage(params.messageId, input?.result || null);
-            if (!task) {
+            const archived = await pgmqService.archive(params.ref, queueName, messageId);
+            if (!archived) {
                 return status(409, { message: "Queue message is not currently leased", code: "409" });
             }
-            return task;
+            return { id: String(messageId), msg_id: messageId, queue_name: queueName, status: "archived" };
         } catch (err: unknown) {
             return status(500, { message: "Failed to acknowledge queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
@@ -328,13 +400,19 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            const current = await taskRepository.getTaskByIdAndType(params.messageId, params.ref, queueTaskType(queueName));
-            if (!current) {
-                return status(404, { message: "Queue message not found", code: "404" });
+            const messageId = normalizeMessageId(params.messageId);
+            if (!messageId) {
+                return status(400, { message: "Invalid queue message ID", code: "400" });
             }
-            const input = body as { delayMs?: number; error?: string } | undefined;
-            const delayMs = normalizePositiveInteger(input?.delayMs, 0, 0, MAX_QUEUE_DELAY_MS);
-            const task = await taskRepository.releaseTask(params.messageId, new Date(Date.now() + delayMs), input?.error);
+            const input = body as { delayMs?: number; sleep_seconds?: number } | undefined;
+            const sleepSeconds = input?.sleep_seconds ??
+                Math.floor(normalizeNonNegativeSeconds(input?.delayMs, 0, MAX_QUEUE_DELAY_MS) / 1000);
+            const task = await pgmqService.setVisibilityTimeout(
+                params.ref,
+                queueName,
+                messageId,
+                normalizeNonNegativeSeconds(sleepSeconds, 0, MAX_QUEUE_DELAY_MS / 1000),
+            );
             return task || status(404, { message: "Queue message not found", code: "404" });
         } catch (err: unknown) {
             return status(500, { message: "Failed to release queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
@@ -342,24 +420,25 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
     }, {
         body: t.Optional(t.Object({
             delayMs: t.Optional(t.Number()),
-            error: t.Optional(t.String()),
+            sleep_seconds: t.Optional(t.Number()),
         })),
         detail: { tags: ["tasks"], summary: "Release a queue message back to the queue" },
     })
-    .post("/queues/:queueName/messages/:messageId/fail", async ({ params, body }) => {
+    .post("/queues/:queueName/messages/:messageId/fail", async ({ params }) => {
         try {
             const queueName = normalizeQueueName(params.queueName);
             if (!queueName) {
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            const current = await taskRepository.getTaskByIdAndType(params.messageId, params.ref, queueTaskType(queueName));
-            if (!current) {
-                return status(404, { message: "Queue message not found", code: "404" });
+            const messageId = normalizeMessageId(params.messageId);
+            if (!messageId) {
+                return status(400, { message: "Invalid queue message ID", code: "400" });
             }
-            const input = body as { error?: string; deadLetter?: boolean } | undefined;
-            const task = await taskRepository.markTaskFailed(params.messageId, input?.error || "Queue message failed", input?.deadLetter ?? true);
-            return task || status(404, { message: "Queue message not found", code: "404" });
+            const archived = await pgmqService.archive(params.ref, queueName, messageId);
+            return archived
+                ? { id: String(messageId), msg_id: messageId, queue_name: queueName, status: "archived" }
+                : status(404, { message: "Queue message not found", code: "404" });
         } catch (err: unknown) {
             return status(500, { message: "Failed to fail queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
@@ -377,11 +456,10 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            const task = await taskRepository.retryQueueMessage(params.messageId, params.ref, queueTaskType(queueName));
-            if (!task) {
-                return status(409, { message: "Queue message cannot be replayed from its current state", code: "409" });
-            }
-            return task;
+            return status(410, {
+                message: "PGMQ archived messages are retained for replay via SQL/archive workflows; direct retry is not part of the official queue API",
+                code: "410",
+            });
         } catch (err: unknown) {
             return status(500, { message: "Failed to retry queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });
         }
@@ -393,11 +471,14 @@ export const taskRoutes = new Elysia({ prefix: "/v1/projects/:ref/tasks" })
                 return status(400, { message: "Invalid queue name", code: "400" });
             }
 
-            const current = await taskRepository.getTaskByIdAndType(params.messageId, params.ref, queueTaskType(queueName));
-            if (!current) {
+            const messageId = normalizeMessageId(params.messageId);
+            if (!messageId) {
+                return status(400, { message: "Invalid queue message ID", code: "400" });
+            }
+            const deleted = await pgmqService.deleteMessage(params.ref, queueName, messageId);
+            if (!deleted) {
                 return status(404, { message: "Queue message not found", code: "404" });
             }
-            await taskRepository.cancelTask(params.messageId, "Deleted by queue client");
             return status(204);
         } catch (err: unknown) {
             return status(500, { message: "Failed to delete queue message", code: "500", details: (err instanceof Error ? err.message : String(err)) });

--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -605,7 +605,62 @@ BEGIN
 END;
 $graphql_fallback$;
 
--- 17. Realtime WAL logical replication support
+-- 17. Supabase Queues compatibility via the official PGMQ extension.
+CREATE EXTENSION IF NOT EXISTS pgmq;
+CREATE SCHEMA IF NOT EXISTS pgmq_public;
+GRANT USAGE ON SCHEMA pgmq_public TO anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send(queue_name text, message jsonb, sleep_seconds integer DEFAULT 0)
+RETURNS SETOF bigint
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.send(queue_name, message, sleep_seconds); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send_batch(queue_name text, messages jsonb[], sleep_seconds integer DEFAULT 0)
+RETURNS SETOF bigint
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.send_batch(queue_name, messages, sleep_seconds); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.read(queue_name text, sleep_seconds integer, n integer)
+RETURNS SETOF pgmq.message_record
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.read(queue_name, sleep_seconds, n); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.pop(queue_name text)
+RETURNS SETOF pgmq.message_record
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.pop(queue_name); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.archive(queue_name text, message_id bigint)
+RETURNS boolean
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT pgmq.archive(queue_name, message_id); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public."delete"(queue_name text, message_id bigint)
+RETURNS boolean
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT pgmq.delete(queue_name, message_id); $$;
+
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgmq_public TO anon, authenticated, service_role;
+
+-- 18. Realtime WAL logical replication support
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'wal2json') THEN

--- a/packages/management-api/src/services/pgmq.service.ts
+++ b/packages/management-api/src/services/pgmq.service.ts
@@ -1,0 +1,284 @@
+import { getProjectDb, resolveDbName } from "../db";
+import { withRetry } from "../utils/retry";
+
+const QUEUE_TASK_TYPE_PREFIX = "queue:";
+
+export interface PgmqMessage {
+  id: string;
+  msg_id: number;
+  read_ct: number;
+  enqueued_at: string | Date;
+  vt: string | Date;
+  message: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  status: "pending" | "leased" | "archived" | "deleted";
+  task_type: string;
+}
+
+export interface PgmqQueueInfo {
+  queue_name: string;
+  created_at: string | Date | null;
+  is_partitioned: boolean;
+  is_unlogged: boolean;
+}
+
+export interface PgmqQueueMetrics {
+  queue_name: string;
+  queue_length: number;
+  newest_msg_age_sec: number | null;
+  oldest_msg_age_sec: number | null;
+  total_messages: number;
+  scrape_time: string | Date;
+}
+
+function asJsonObject(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function normalizeMsgId(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function queueTableName(queueName: string, archived: boolean): string {
+  return `pgmq.${quoteIdentifier(`${archived ? "a" : "q"}_${queueName}`)}`;
+}
+
+function mapMessage(queueName: string, row: Record<string, unknown>, status: PgmqMessage["status"]): PgmqMessage {
+  const message = asJsonObject(row.message);
+  const msgId = normalizeMsgId(row.msg_id);
+  return {
+    id: String(msgId),
+    msg_id: msgId,
+    read_ct: Number(row.read_ct || 0),
+    enqueued_at: row.enqueued_at as string | Date,
+    vt: row.vt as string | Date,
+    message,
+    payload: message,
+    status,
+    task_type: `${QUEUE_TASK_TYPE_PREFIX}${queueName}`,
+  };
+}
+
+async function listMessages(
+  projectRef: string,
+  queueName: string,
+  options: { archived?: boolean; limit?: number } = {},
+): Promise<PgmqMessage[]> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const limit = Math.max(1, Math.min(500, Math.floor(options.limit || 50)));
+  const rows = await db.unsafe(
+    `
+      SELECT
+        msg_id,
+        read_ct,
+        enqueued_at,
+        vt,
+        message,
+        CASE
+          WHEN $2::boolean THEN 'archived'
+          WHEN vt > NOW() THEN 'leased'
+          ELSE 'pending'
+        END AS queue_status
+      FROM ${queueTableName(queueName, Boolean(options.archived))}
+      ORDER BY msg_id DESC
+      LIMIT $1
+    `,
+    [limit, Boolean(options.archived)],
+  );
+  return (rows as Record<string, unknown>[]).map((row) =>
+    mapMessage(queueName, row as Record<string, unknown>, String(row.queue_status) as PgmqMessage["status"])
+  );
+}
+
+async function projectDb(projectRef: string) {
+  return getProjectDb(await resolveDbName(projectRef));
+}
+
+async function ensurePgmq(projectRef: string): Promise<void> {
+  const db = await projectDb(projectRef);
+  await db`CREATE EXTENSION IF NOT EXISTS pgmq`;
+}
+
+async function createQueue(projectRef: string, queueName: string, options: { unlogged?: boolean } = {}): Promise<void> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  if (options.unlogged) {
+    await db`SELECT pgmq.create_unlogged(${queueName})`;
+  } else {
+    await db`SELECT pgmq.create(${queueName})`;
+  }
+}
+
+async function dropQueue(projectRef: string, queueName: string): Promise<boolean> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const [row] = await db`SELECT pgmq.drop_queue(${queueName}) AS dropped`;
+  return Boolean(row?.dropped);
+}
+
+async function listQueues(projectRef: string): Promise<PgmqQueueInfo[]> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const rows = await db`SELECT * FROM pgmq.list_queues() ORDER BY queue_name`;
+  return (rows as Record<string, unknown>[]).map((row) => ({
+    queue_name: String(row.queue_name),
+    created_at: row.created_at as string | Date | null,
+    is_partitioned: Boolean(row.is_partitioned),
+    is_unlogged: Boolean(row.is_unlogged),
+  }));
+}
+
+async function send(projectRef: string, queueName: string, message: Record<string, unknown>, sleepSeconds = 0): Promise<number> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const [row] = await db`
+    SELECT * FROM pgmq.send(${queueName}, ${JSON.stringify(message)}::jsonb, ${sleepSeconds}) AS msg_id
+  `;
+  return normalizeMsgId(row?.msg_id ?? row?.send);
+}
+
+async function sendBatch(
+  projectRef: string,
+  queueName: string,
+  messages: Record<string, unknown>[],
+  sleepSeconds = 0,
+): Promise<number[]> {
+  await ensurePgmq(projectRef);
+  if (messages.length === 0) return [];
+  const db = await projectDb(projectRef);
+  const values = messages.map((message) => JSON.stringify(message));
+  const params: unknown[] = [queueName, ...values, sleepSeconds];
+  const messagePlaceholders = values.map((_, index) => `$${index + 2}::jsonb`).join(", ");
+  const delayIndex = values.length + 2;
+  const rows = await db.unsafe(
+    `SELECT * FROM pgmq.send_batch($1, ARRAY[${messagePlaceholders}]::jsonb[], $${delayIndex}) AS msg_id`,
+    params,
+  );
+  return (rows as Record<string, unknown>[]).map((row) => normalizeMsgId(row.msg_id ?? row.send_batch));
+}
+
+async function read(projectRef: string, queueName: string, sleepSeconds: number, count: number): Promise<PgmqMessage[]> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const rows = await db`SELECT * FROM pgmq.read(${queueName}, ${sleepSeconds}, ${count})`;
+  return (rows as Record<string, unknown>[]).map((row) => mapMessage(queueName, row, "leased"));
+}
+
+async function pop(projectRef: string, queueName: string): Promise<PgmqMessage | null> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const rows = await db`SELECT * FROM pgmq.pop(${queueName})`;
+  const row = rows[0] as Record<string, unknown> | undefined;
+  return row ? mapMessage(queueName, row, "deleted") : null;
+}
+
+async function archive(projectRef: string, queueName: string, messageId: number): Promise<boolean> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const [row] = await db`SELECT pgmq.archive(${queueName}, ${messageId}) AS archived`;
+  return Boolean(row?.archived);
+}
+
+async function deleteMessage(projectRef: string, queueName: string, messageId: number): Promise<boolean> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const [row] = await db`SELECT pgmq.delete(${queueName}, ${messageId}) AS deleted`;
+  return Boolean(row?.deleted);
+}
+
+async function setVisibilityTimeout(
+  projectRef: string,
+  queueName: string,
+  messageId: number,
+  sleepSeconds: number,
+): Promise<PgmqMessage | null> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const rows = await db`SELECT * FROM pgmq.set_vt(${queueName}, ${messageId}, ${sleepSeconds})`;
+  const row = rows[0] as Record<string, unknown> | undefined;
+  return row ? mapMessage(queueName, row, "leased") : null;
+}
+
+async function purge(projectRef: string, queueName: string): Promise<number> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const [row] = await db`SELECT pgmq.purge_queue(${queueName}) AS purged`;
+  return Number(row?.purged || 0);
+}
+
+async function metrics(projectRef: string, queueName: string): Promise<PgmqQueueMetrics | null> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const [row] = await db`SELECT * FROM pgmq.metrics(${queueName})`;
+  if (!row) return null;
+  return {
+    queue_name: String(row.queue_name),
+    queue_length: Number(row.queue_length || 0),
+    newest_msg_age_sec: row.newest_msg_age_sec == null ? null : Number(row.newest_msg_age_sec),
+    oldest_msg_age_sec: row.oldest_msg_age_sec == null ? null : Number(row.oldest_msg_age_sec),
+    total_messages: Number(row.total_messages || 0),
+    scrape_time: row.scrape_time as string | Date,
+  };
+}
+
+async function metricsAll(projectRef: string): Promise<PgmqQueueMetrics[]> {
+  await ensurePgmq(projectRef);
+  const db = await projectDb(projectRef);
+  const rows = await db`SELECT * FROM pgmq.metrics_all() ORDER BY queue_name`;
+  return (rows as Record<string, unknown>[]).map((row) => ({
+    queue_name: String(row.queue_name),
+    queue_length: Number(row.queue_length || 0),
+    newest_msg_age_sec: row.newest_msg_age_sec == null ? null : Number(row.newest_msg_age_sec),
+    oldest_msg_age_sec: row.oldest_msg_age_sec == null ? null : Number(row.oldest_msg_age_sec),
+    total_messages: Number(row.total_messages || 0),
+    scrape_time: row.scrape_time as string | Date,
+  }));
+}
+
+export const pgmqService = {
+  createQueue: (projectRef: string, queueName: string, options?: { unlogged?: boolean }) =>
+    createQueue(projectRef, queueName, options),
+  dropQueue: (projectRef: string, queueName: string) =>
+    dropQueue(projectRef, queueName),
+  listQueues: (projectRef: string) =>
+    withRetry("PgmqService.listQueues", () => listQueues(projectRef)),
+  listMessages: (projectRef: string, queueName: string, options?: { archived?: boolean; limit?: number }) =>
+    withRetry("PgmqService.listMessages", () => listMessages(projectRef, queueName, options)),
+  send: (projectRef: string, queueName: string, message: Record<string, unknown>, sleepSeconds?: number) =>
+    send(projectRef, queueName, message, sleepSeconds),
+  sendBatch: (projectRef: string, queueName: string, messages: Record<string, unknown>[], sleepSeconds?: number) =>
+    sendBatch(projectRef, queueName, messages, sleepSeconds),
+  read: (projectRef: string, queueName: string, sleepSeconds: number, count: number) =>
+    read(projectRef, queueName, sleepSeconds, count),
+  pop: (projectRef: string, queueName: string) =>
+    pop(projectRef, queueName),
+  archive: (projectRef: string, queueName: string, messageId: number) =>
+    archive(projectRef, queueName, messageId),
+  deleteMessage: (projectRef: string, queueName: string, messageId: number) =>
+    deleteMessage(projectRef, queueName, messageId),
+  setVisibilityTimeout: (projectRef: string, queueName: string, messageId: number, sleepSeconds: number) =>
+    setVisibilityTimeout(projectRef, queueName, messageId, sleepSeconds),
+  purge: (projectRef: string, queueName: string) =>
+    purge(projectRef, queueName),
+  metrics: (projectRef: string, queueName: string) =>
+    withRetry("PgmqService.metrics", () => metrics(projectRef, queueName)),
+  metricsAll: (projectRef: string) =>
+    withRetry("PgmqService.metricsAll", () => metricsAll(projectRef)),
+};

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -1147,7 +1147,7 @@ ${jwtJwksEnv}${jwtKeysEnv}
         const pgrstConf = `
 # PostgREST config for tenant: ${ref}
 db-uri = "postgres://${resolveAuthenticatorName(ref)}:${creds.dbPassword}@${this.PG_HOST}:${this.PG_PORT}/${creds.dbName}"
-db-schemas = "public, storage, graphql_public"
+db-schemas = "public, storage, graphql_public, pgmq_public"
 db-extra-search-path = "public, extensions, auth"
 db-anon-role = "anon"
 jwt-secret = ${JSON.stringify(jwtVerifierSecret)}
@@ -1724,6 +1724,60 @@ BEGIN
   END IF;
 END;
 $graphql_fallback$;
+
+CREATE EXTENSION IF NOT EXISTS pgmq;
+CREATE SCHEMA IF NOT EXISTS pgmq_public;
+GRANT USAGE ON SCHEMA pgmq_public TO anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send(queue_name text, message jsonb, sleep_seconds integer DEFAULT 0)
+RETURNS SETOF bigint
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.send(queue_name, message, sleep_seconds); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.send_batch(queue_name text, messages jsonb[], sleep_seconds integer DEFAULT 0)
+RETURNS SETOF bigint
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.send_batch(queue_name, messages, sleep_seconds); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.read(queue_name text, sleep_seconds integer, n integer)
+RETURNS SETOF pgmq.message_record
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.read(queue_name, sleep_seconds, n); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.pop(queue_name text)
+RETURNS SETOF pgmq.message_record
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT * FROM pgmq.pop(queue_name); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public.archive(queue_name text, message_id bigint)
+RETURNS boolean
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT pgmq.archive(queue_name, message_id); $$;
+
+CREATE OR REPLACE FUNCTION pgmq_public."delete"(queue_name text, message_id bigint)
+RETURNS boolean
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER
+SET search_path = pgmq, public
+AS $$ SELECT pgmq.delete(queue_name, message_id); $$;
+
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgmq_public TO anon, authenticated, service_role;
 `.trim();
         const tmpFile = `/tmp/ott-graphql-migration-${ref}.sql`;
         try {

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -104,6 +104,44 @@ describe("supabase bootstrap schema", () => {
     }
   });
 
+  test("tenant schema exposes Supabase Queues PGMQ public RPCs", () => {
+    for (const filePath of [
+      "src/db/schemas/supabase.sql",
+      "src/services/tenant-runtime.service.ts",
+      "src/scripts/migrate-tenant-schema.ts",
+    ]) {
+      const source = readRepoFile(filePath);
+
+      expect(source).toContain("CREATE EXTENSION IF NOT EXISTS pgmq");
+      expect(source).toContain("CREATE SCHEMA IF NOT EXISTS pgmq_public");
+      expect(source).toContain("CREATE OR REPLACE FUNCTION pgmq_public.send(queue_name text, message jsonb, sleep_seconds integer DEFAULT 0)");
+      expect(source).toContain("CREATE OR REPLACE FUNCTION pgmq_public.pop(queue_name text)");
+      expect(source).toContain('CREATE OR REPLACE FUNCTION pgmq_public."delete"(queue_name text, message_id bigint)');
+      expect(source).toContain("GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgmq_public TO anon, authenticated, service_role");
+    }
+  });
+
+  test("PostgREST tenant config exposes pgmq_public for supabase-js schema rpc", () => {
+    for (const filePath of [
+      "src/services/tenant-runtime.service.ts",
+      "../../scripts/lib/tenant_runtime.sh",
+      "../../docker/self-host/docker-compose.yml",
+      "../../docker/self-host/.env.example",
+      "../../docker/self-host/init-env.py",
+    ]) {
+      const source = readRepoFile(filePath);
+      expect(source).toContain("pgmq_public");
+    }
+  });
+
+  test("self-host postgres image installs and bootstraps PGMQ", () => {
+    const dockerfile = readRepoFile("../../docker/self-host/postgres/Dockerfile");
+    const bootstrap = readRepoFile("../../docker/self-host/postgres/initdb/01-bootstrap-extensions.sql");
+
+    expect(dockerfile).toContain("postgresql-18-pgmq");
+    expect(bootstrap).toContain("'pgmq'");
+  });
+
   test("tenant schema migration creates realtime schema before realtime objects", () => {
     for (const filePath of [
       "src/services/tenant-runtime.service.ts",

--- a/packages/management-api/tests/unit/task.routes.test.ts
+++ b/packages/management-api/tests/unit/task.routes.test.ts
@@ -37,6 +37,17 @@ const getQueueStats = mock(() => Promise.resolve({
   oldestPendingAgeSec: null,
   inFlight: 0,
 }));
+const pgmqCreateQueue = mock(() => Promise.resolve(undefined));
+const pgmqListQueues = mock(() => Promise.resolve([]));
+const pgmqListMessages = mock(() => Promise.resolve([]));
+const pgmqSend = mock(() => Promise.resolve(1));
+const pgmqSendBatch = mock(() => Promise.resolve([1, 2]));
+const pgmqRead = mock(() => Promise.resolve([]));
+const pgmqPop = mock(() => Promise.resolve(null));
+const pgmqArchive = mock(() => Promise.resolve(true));
+const pgmqDeleteMessage = mock(() => Promise.resolve(true));
+const pgmqSetVisibilityTimeout = mock(() => Promise.resolve(null));
+const pgmqMetrics = mock(() => Promise.resolve(null));
 
 const backgroundFunctionWorker = {
   cancel: mock(() => Promise.resolve(true)),
@@ -69,6 +80,7 @@ const projectService = {
 
 const { taskRepository } = await import("../../src/repositories/task.repository");
 const services = await import("../../src/services");
+const { pgmqService } = await import("../../src/services/pgmq.service");
 const authModule = await import("../../src/middleware/auth");
 
 spyOn(taskRepository, "listTasksByProjectFiltered").mockImplementation(
@@ -110,6 +122,19 @@ spyOn(services.projectService, "getQueueSettings").mockImplementation(
 spyOn(services.projectService, "updateQueueSettings").mockImplementation(
   projectService.updateQueueSettings as typeof services.projectService.updateQueueSettings,
 );
+spyOn(pgmqService, "createQueue").mockImplementation(pgmqCreateQueue as typeof pgmqService.createQueue);
+spyOn(pgmqService, "listQueues").mockImplementation(pgmqListQueues as typeof pgmqService.listQueues);
+spyOn(pgmqService, "listMessages").mockImplementation(pgmqListMessages as typeof pgmqService.listMessages);
+spyOn(pgmqService, "send").mockImplementation(pgmqSend as typeof pgmqService.send);
+spyOn(pgmqService, "sendBatch").mockImplementation(pgmqSendBatch as typeof pgmqService.sendBatch);
+spyOn(pgmqService, "read").mockImplementation(pgmqRead as typeof pgmqService.read);
+spyOn(pgmqService, "pop").mockImplementation(pgmqPop as typeof pgmqService.pop);
+spyOn(pgmqService, "archive").mockImplementation(pgmqArchive as typeof pgmqService.archive);
+spyOn(pgmqService, "deleteMessage").mockImplementation(pgmqDeleteMessage as typeof pgmqService.deleteMessage);
+spyOn(pgmqService, "setVisibilityTimeout").mockImplementation(
+  pgmqSetVisibilityTimeout as typeof pgmqService.setVisibilityTimeout,
+);
+spyOn(pgmqService, "metrics").mockImplementation(pgmqMetrics as typeof pgmqService.metrics);
 
 const verifyProjectJwt = mock(() => Promise.resolve(null));
 spyOn(authModule, "verifyProjectJwt").mockImplementation(
@@ -155,6 +180,17 @@ describe("taskRoutes", () => {
     projectService.updateBackgroundTaskSettings.mockReset();
     projectService.getQueueSettings.mockReset();
     projectService.updateQueueSettings.mockReset();
+    pgmqCreateQueue.mockReset();
+    pgmqListQueues.mockReset();
+    pgmqListMessages.mockReset();
+    pgmqSend.mockReset();
+    pgmqSendBatch.mockReset();
+    pgmqRead.mockReset();
+    pgmqPop.mockReset();
+    pgmqArchive.mockReset();
+    pgmqDeleteMessage.mockReset();
+    pgmqSetVisibilityTimeout.mockReset();
+    pgmqMetrics.mockReset();
 
     backgroundFunctionWorker.cancel.mockResolvedValue(true);
     projectService.getQueueSettings.mockResolvedValue({
@@ -170,10 +206,21 @@ describe("taskRoutes", () => {
       rate_limit_per_minute: 1200,
     });
     countQueueMessagesCreatedSince.mockResolvedValue(0);
+    pgmqCreateQueue.mockResolvedValue(undefined);
+    pgmqListQueues.mockResolvedValue([]);
+    pgmqListMessages.mockResolvedValue([]);
+    pgmqSend.mockResolvedValue(1);
+    pgmqSendBatch.mockResolvedValue([1, 2]);
+    pgmqRead.mockResolvedValue([]);
+    pgmqPop.mockResolvedValue(null);
+    pgmqArchive.mockResolvedValue(true);
+    pgmqDeleteMessage.mockResolvedValue(true);
+    pgmqSetVisibilityTimeout.mockResolvedValue(null);
+    pgmqMetrics.mockResolvedValue(null);
   });
 
   test("POST /queues/:queueName/messages enqueues a JSON message", async () => {
-    createTask.mockResolvedValueOnce({ id: "msg_1", task_type: "queue:emails", status: "pending" });
+    pgmqSend.mockResolvedValueOnce(42);
 
     const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages", {
       method: "POST",
@@ -181,55 +228,52 @@ describe("taskRoutes", () => {
       body: JSON.stringify({
         payload: { hello: "world" },
         delayMs: 1000,
-        maxAttempts: 5,
-        correlationId: "corr-1",
-        businessTaskId: "biz-1",
-        metadata: { tenant: "acme" },
       }),
     });
     const payload = await response.json();
 
     expect(response.status).toBe(202);
-    expect(payload.id).toBe("msg_1");
-    expect(createTask).toHaveBeenCalledWith(expect.objectContaining({
-      ref: "proj_1",
-      type: "queue:emails",
-      payload: { hello: "world" },
-      maxAttempts: 5,
-      correlationId: "corr-1",
-      businessTaskId: "biz-1",
-      metadata: { tenant: "acme" },
-    }));
-    expect(countQueueMessagesCreatedSince).toHaveBeenCalledWith(
+    expect(payload.id).toBe("42");
+    expect(payload.task_type).toBe("queue:emails");
+    expect(pgmqSend).toHaveBeenCalledWith(
       "proj_1",
-      "queue:emails",
-      expect.any(Date),
+      "emails",
+      { hello: "world" },
+      1,
     );
   });
 
-  test("POST /queues/:queueName/messages enforces queue rate limit", async () => {
-    projectService.getQueueSettings.mockResolvedValueOnce({
-      max_in_flight: 10,
-      default_visibility_timeout_sec: 330,
-      max_attempts: 3,
-      rate_limit_per_minute: 1,
-    });
-    countQueueMessagesCreatedSince.mockResolvedValueOnce(1);
-
-    const response = await request("/v1/projects/proj_1/tasks/queues/crawl/messages", {
+  test("POST /queues creates a PGMQ queue", async () => {
+    const response = await request("/v1/projects/proj_1/tasks/queues", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ payload: { url: "https://example.com" } }),
+      body: JSON.stringify({ queue_name: "emails", unlogged: true }),
     });
     const payload = await response.json();
 
-    expect(response.status).toBe(429);
-    expect(payload.message).toBe("Queue rate limit exceeded");
-    expect(createTask).not.toHaveBeenCalled();
+    expect(response.status).toBe(201);
+    expect(payload.queue_name).toBe("emails");
+    expect(payload.type).toBe("unlogged");
+    expect(pgmqCreateQueue).toHaveBeenCalledWith("proj_1", "emails", { unlogged: true });
+  });
+
+  test("POST /queues/:queueName/messages/batch sends JSON messages through PGMQ", async () => {
+    pgmqSendBatch.mockResolvedValueOnce([7, 8]);
+
+    const response = await request("/v1/projects/proj_1/tasks/queues/crawl/messages/batch", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ a: 1 }, { b: 2 }], sleep_seconds: 30 }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(payload.msg_ids).toEqual([7, 8]);
+    expect(pgmqSendBatch).toHaveBeenCalledWith("proj_1", "crawl", [{ a: 1 }, { b: 2 }], 30);
   });
 
   test("POST /queues/:queueName/messages/receive leases the next available message", async () => {
-    claimQueueMessage.mockResolvedValueOnce({ id: "msg_1", task_type: "queue:emails", status: "leased" });
+    pgmqRead.mockResolvedValueOnce([{ id: "11", msg_id: 11, task_type: "queue:emails", status: "leased", payload: { hello: "world" } }]);
 
     const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages/receive", {
       method: "POST",
@@ -239,17 +283,12 @@ describe("taskRoutes", () => {
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(payload.id).toBe("msg_1");
-    expect(claimQueueMessage).toHaveBeenCalledWith({
-      projectRef: "proj_1",
-      queueName: "queue:emails",
-      visibilityTimeoutSec: 60,
-      maxInFlight: 10,
-    });
+    expect(payload.id).toBe("11");
+    expect(pgmqRead).toHaveBeenCalledWith("proj_1", "emails", 60, 1);
   });
 
   test("POST /queues/:queueName/messages/receive returns 204 when empty", async () => {
-    claimQueueMessage.mockResolvedValueOnce(null);
+    pgmqRead.mockResolvedValueOnce([]);
 
     const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages/receive", {
       method: "POST",
@@ -261,10 +300,9 @@ describe("taskRoutes", () => {
   });
 
   test("POST /queues/:queueName/messages/:messageId/ack acknowledges a leased message", async () => {
-    getTaskByIdAndType.mockResolvedValueOnce({ id: "msg_1", task_type: "queue:emails", status: "leased" });
-    acknowledgeQueueMessage.mockResolvedValueOnce({ id: "msg_1", task_type: "queue:emails", status: "succeeded" });
+    pgmqArchive.mockResolvedValueOnce(true);
 
-    const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages/msg_1/ack", {
+    const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages/11/ack", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ result: { ok: true } }),
@@ -272,45 +310,39 @@ describe("taskRoutes", () => {
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(payload.status).toBe("succeeded");
-    expect(acknowledgeQueueMessage).toHaveBeenCalledWith("msg_1", { ok: true });
+    expect(payload.status).toBe("archived");
+    expect(pgmqArchive).toHaveBeenCalledWith("proj_1", "emails", 11);
   });
 
-  test("GET /queues/:queueName/messages lists only that queue", async () => {
-    listTasksByProjectFiltered.mockResolvedValueOnce([
-      { id: "msg_1", task_type: "queue:emails", status: "dead_lettered" },
-    ]);
+  test("POST /queues/:queueName/messages/pop deletes and returns next PGMQ message", async () => {
+    pgmqPop.mockResolvedValueOnce({ id: "12", msg_id: 12, task_type: "queue:emails", status: "deleted", payload: { ok: true } });
 
-    const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages?dlq=true&limit=5");
+    const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages/pop", {
+      method: "POST",
+    });
+    const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(listTasksByProjectFiltered).toHaveBeenCalledWith("proj_1", {
-      statuses: undefined,
-      taskTypes: ["queue:emails"],
-      onlyDeadLettered: true,
-      limit: 5,
-    });
+    expect(payload.id).toBe("12");
+    expect(pgmqPop).toHaveBeenCalledWith("proj_1", "emails");
   });
 
   test("GET /queues/:queueName/stats returns queue-level metrics", async () => {
-    getQueueStats.mockResolvedValueOnce({
-      pending: 4,
-      leased: 1,
-      running: 0,
-      retryScheduled: 2,
-      succeededLast24h: 8,
-      failedLast24h: 1,
-      deadLettered: 3,
-      oldestPendingAgeSec: 42,
-      inFlight: 1,
+    pgmqMetrics.mockResolvedValueOnce({
+      queue_name: "crawl",
+      queue_length: 4,
+      newest_msg_age_sec: 3,
+      oldest_msg_age_sec: 42,
+      total_messages: 9,
+      scrape_time: "2026-05-26T00:00:00Z",
     });
 
     const response = await request("/v1/projects/proj_1/tasks/queues/crawl/stats");
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(payload.pending).toBe(4);
-    expect(getQueueStats).toHaveBeenCalledWith("proj_1", "queue:crawl");
+    expect(payload.queue_length).toBe(4);
+    expect(pgmqMetrics).toHaveBeenCalledWith("proj_1", "crawl");
   });
 
   test("PATCH /queues/:queueName/settings updates queue reliability controls", async () => {
@@ -337,28 +369,24 @@ describe("taskRoutes", () => {
   });
 
   test("DELETE /queues/:queueName/messages/:messageId marks queue message deleted", async () => {
-    getTaskByIdAndType.mockResolvedValueOnce({ id: "msg_1", task_type: "queue:emails", status: "leased" });
-    cancelTask.mockResolvedValueOnce({ id: "msg_1", status: "cancelled" });
+    pgmqDeleteMessage.mockResolvedValueOnce(true);
 
-    const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages/msg_1", {
+    const response = await request("/v1/projects/proj_1/tasks/queues/emails/messages/11", {
       method: "DELETE",
     });
 
     expect(response.status).toBe(204);
-    expect(cancelTask).toHaveBeenCalledWith("msg_1", "Deleted by queue client");
+    expect(pgmqDeleteMessage).toHaveBeenCalledWith("proj_1", "emails", 11);
   });
 
-  test("POST /queues/:queueName/messages/:messageId/retry replays DLQ messages", async () => {
-    retryQueueMessage.mockResolvedValueOnce({ id: "msg_1", task_type: "queue:crawl", status: "pending" });
-
-    const response = await request("/v1/projects/proj_1/tasks/queues/crawl/messages/msg_1/retry", {
+  test("POST /queues/:queueName/messages/:messageId/retry reports official PGMQ limitation", async () => {
+    const response = await request("/v1/projects/proj_1/tasks/queues/crawl/messages/11/retry", {
       method: "POST",
     });
     const payload = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(payload.status).toBe("pending");
-    expect(retryQueueMessage).toHaveBeenCalledWith("msg_1", "proj_1", "queue:crawl");
+    expect(response.status).toBe(410);
+    expect(payload.message).toContain("official queue API");
   });
 
   test("GET /v1/projects/:ref/tasks forwards function_slug filter to repository", async () => {

--- a/packages/supacloud-js/README.md
+++ b/packages/supacloud-js/README.md
@@ -8,7 +8,7 @@ It does **not** replace [`@supabase/supabase-js`](https://www.npmjs.com/package/
 - task detail and list APIs
 - cancel / retry helpers
 - Realtime subscription with polling fallback
-- queue send / receive / ack / release / fail / retry / delete / list / listFailed / stats / settings helpers
+- Supabase Queues helpers backed by the official `pgmq_public` RPC API, plus SupaCloud management extensions for queue administration and diagnostics
 - project OAuth/OIDC migration and OAuth client management
 - SupAuth provisioning and runtime verification helpers
 
@@ -114,16 +114,22 @@ The current package focuses on:
 - `tasks.retry`
 - `tasks.wait`
 - `tasks.subscribe`
+- `queues.list`
+- `queues.create`
+- `queues.drop`
 - `queue(name).send`
+- `queue(name).sendBatch`
+- `queue(name).read`
 - `queue(name).receive`
+- `queue(name).pop`
+- `queue(name).archive`
 - `queue(name).ack`
-- `queue(name).release`
-- `queue(name).fail`
-- `queue(name).retry`
 - `queue(name).delete`
+- `queue(name).release`
 - `queue(name).list`
-- `queue(name).listFailed`
+- `queue(name).listArchived`
 - `queue(name).stats`
+- `queue(name).purge`
 - `queue(name).getSettings`
 - `queue(name).updateSettings`
 - `auth.oauthServer.getStatus`
@@ -180,22 +186,24 @@ If `secret` is set, verify `X-SupaCloud-Signature: sha256=<hmac>` against the ra
 
 ## Queue Helpers
 
+The core message operations use the official Supabase Queues API exposed through `pgmq_public`:
+
+- `pgmq_public.send(queue_name, message, sleep_seconds)`
+- `pgmq_public.send_batch(queue_name, messages, sleep_seconds)`
+- `pgmq_public.read(queue_name, sleep_seconds, n)`
+- `pgmq_public.pop(queue_name)`
+- `pgmq_public.archive(queue_name, message_id)`
+- `pgmq_public.delete(queue_name, message_id)`
+
+These calls go through your wrapped `supabase` client as `supabase.schema('pgmq_public').rpc(...)`. Queue creation/drop, queue listing, metrics, purge, settings, diagnostics, and visibility-timeout adjustment are SupaCloud management extensions because Supabase's public Queue API intentionally does not expose those as client-side RPCs.
+
 ```ts
 const queue = supacloud.queue("emails");
 
 const message = await queue.send(
   { to: "user@example.com", template: "welcome" },
   {
-    idempotencyKey: "welcome-user-123",
-    delayMs: 10_000,
-    maxAttempts: 5,
-    traceId: "trace-123",
-    correlationId: "signup-123",
-    businessTaskId: "email-job-123",
-    metadata: {
-      source: "signup",
-      billing_subject: "user-123",
-    },
+    sleepSeconds: 10,
   },
 );
 
@@ -203,40 +211,44 @@ const leased = await queue.receive({ visibilityTimeoutSec: 60 });
 if (leased) {
   try {
     await sendEmail(leased.payload);
-    await queue.ack(leased.id, { delivered: true });
+    await queue.ack(leased.msg_id);
   } catch (error) {
-    await queue.release(leased.id, { delayMs: 30_000, error: String(error) });
+    await queue.release(leased.msg_id, { delayMs: 30_000, error: String(error) });
   }
 }
 
 const stats = await queue.stats();
-console.log(stats.inFlight, stats.deadLettered);
+console.log(stats.queue_length, stats.oldest_msg_age_sec);
 ```
 
 Queue API surface:
 
-- `queue.send(payload, options)`: enqueue a message, optionally delayed and idempotent
-- `queue.receive({ visibilityTimeoutSec })`: lease the next message, or return `null`
-- `queue.ack(messageId, result)`: mark the leased message succeeded
-- `queue.release(messageId, { delayMs, error })`: return the message to the queue later
-- `queue.fail(messageId, { error, deadLetter })`: mark failed or dead-lettered
-- `queue.retry(messageId)`: replay a dead-lettered message
-- `queue.delete(messageId)`: cancel/delete a message
-- `queue.list(filters)`: list messages by status, DLQ flag, and limit
-- `queue.listFailed(limit)`: shortcut for DLQ messages
-- `queue.get(messageId)`: read message detail, attempts, and latest logs
-- `queue.stats()`: inspect queue depth and recent success/failure counts
+- `queue.send(payload, { sleepSeconds })`: enqueue one message through `pgmq_public.send`
+- `queue.sendBatch(messages, { sleepSeconds })`: enqueue messages through `pgmq_public.send_batch`
+- `queue.read({ sleepSeconds, n })`: read up to `n` messages through `pgmq_public.read`
+- `queue.receive({ visibilityTimeoutSec })`: compatibility shortcut for `read({ n: 1 })`
+- `queue.pop()`: read and delete the next message through `pgmq_public.pop`
+- `queue.archive(messageId)` / `queue.ack(messageId)`: archive a message through `pgmq_public.archive`
+- `queue.delete(messageId)`: delete a message through `pgmq_public.delete`
+- `queue.release(messageId, { sleepSeconds | delayMs })`: SupaCloud extension for `pgmq.set_vt`
+- `queue.list(filters)`: SupaCloud diagnostic extension for queue/archive table inspection
+- `queue.listArchived(limit)`: SupaCloud diagnostic shortcut for archived messages
+- `queue.stats()`: SupaCloud extension for `pgmq.metrics`
+- `queue.purge()`: SupaCloud extension for `pgmq.purge_queue`
 - `queue.getSettings()`: read concurrency, lease, retry, and rate-limit settings
 - `queue.updateSettings(settings)`: patch queue settings
+- `supacloud.queues.list()`: list queues with `pgmq.list_queues`
+- `supacloud.queues.create(name, { unlogged })`: create a basic or unlogged queue
+- `supacloud.queues.drop(name)`: drop a queue
 
 Queue settings:
 
 - `max_in_flight`: max concurrently leased/running messages for this queue
 - `default_visibility_timeout_sec`: lease timeout used by `receive()`
-- `max_attempts`: default retry budget for new messages
+- `max_attempts`: application-level retry budget for SupaCloud consumers; PGMQ itself stores plain JSON messages
 - `rate_limit_per_minute`: producer enqueue limit
 
-Queue conflicts such as replaying a non-DLQ message are surfaced as `SupaCloudApiError` with `status`, `code`, and `responseBody`, so callers do not need to parse raw `fetch` responses.
+Management extension conflicts are surfaced as `SupaCloudApiError` with `status`, `code`, and `responseBody`, so callers do not need to parse raw `fetch` responses.
 
 ## OAuth/OIDC Helpers
 

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -3,6 +3,11 @@ import { createSupaCloudClient, SupaCloudApiError, SupaCloudTaskSubmitError } fr
 
 function createFakeSupabase() {
   const removeChannel = mock(async () => "ok");
+  const rpc = mock<[string, Record<string, unknown>], Promise<{ data: unknown; error: unknown }>>(async (_fn, _params) => ({
+    data: null,
+    error: null,
+  }));
+  const schema = mock((_name: string) => ({ rpc }));
   type FakeChannel = {
     on: ReturnType<typeof mock>;
     subscribe: ReturnType<typeof mock>;
@@ -28,11 +33,12 @@ function createFakeSupabase() {
     functions: {
       invoke: mock(),
     },
+    schema,
     channel: mock(() => channelInstance),
     removeChannel,
   };
 
-  return { supabase, channelInstance, removeChannel };
+  return { supabase, channelInstance, removeChannel, schema, rpc };
 }
 
 describe("@supacloud/js", () => {
@@ -136,7 +142,89 @@ describe("@supacloud/js", () => {
     expect((calls[0]?.init?.headers as Record<string, string>)?.authorization).toBe("Bearer token-123");
   });
 
-  test("queue client builds management-api requests with bearer auth", async () => {
+  test("queue client uses official pgmq_public RPCs for documented Supabase Queues APIs", async () => {
+    const { supabase, schema, rpc } = createFakeSupabase();
+    rpc.mockImplementation(async (fn: string) => {
+      if (fn === "send") return { data: [101], error: null };
+      if (fn === "send_batch") return { data: [102, 103], error: null };
+      if (fn === "read") return {
+        data: [{ msg_id: 104, read_ct: 1, message: { hello: "world" }, enqueued_at: "now", vt: "later" }],
+        error: null,
+      };
+      if (fn === "pop") return {
+        data: [{ msg_id: 105, read_ct: 1, message: { popped: true }, enqueued_at: "now", vt: "now" }],
+        error: null,
+      };
+      if (fn === "archive") return { data: true, error: null };
+      if (fn === "delete") return { data: true, error: null };
+      return { data: null, error: null };
+    });
+
+    globalThis.fetch = mock(() => {
+      throw new Error("official queue methods must not call the management API");
+    }) as typeof fetch;
+
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com/",
+      projectRef: "proj_1",
+    });
+    const queue = client.queue("emails");
+
+    const sent = await queue.send({ hello: "world" }, { sleepSeconds: 30 });
+    const sentBatch = await queue.sendBatch([{ a: 1 }, { b: 2 }], { delayMs: 5000 });
+    const read = await queue.read({ sleep_seconds: 60, n: 2 });
+    const received = await queue.receive({ visibilityTimeoutSec: 45 });
+    const popped = await queue.pop();
+    const archived = await queue.archive(104);
+    const acked = await queue.ack(104);
+    const failed = await queue.fail(104);
+    const deleted = await queue.delete(104);
+
+    expect(schema.mock.calls[0]?.[0]).toBe("pgmq_public");
+    expect(JSON.stringify(rpc.mock.calls.map((call) => call[0]))).toBe(JSON.stringify([
+      "send",
+      "send_batch",
+      "read",
+      "read",
+      "pop",
+      "archive",
+      "archive",
+      "archive",
+      "delete",
+    ]));
+    expect(JSON.stringify(rpc.mock.calls[0]?.[1])).toBe(JSON.stringify({
+      queue_name: "emails",
+      message: { hello: "world" },
+      sleep_seconds: 30,
+    }));
+    expect(JSON.stringify(rpc.mock.calls[1]?.[1])).toBe(JSON.stringify({
+      queue_name: "emails",
+      messages: [{ a: 1 }, { b: 2 }],
+      sleep_seconds: 5,
+    }));
+    expect(JSON.stringify(rpc.mock.calls[2]?.[1])).toBe(JSON.stringify({
+      queue_name: "emails",
+      sleep_seconds: 60,
+      n: 2,
+    }));
+    expect(JSON.stringify(rpc.mock.calls[3]?.[1])).toBe(JSON.stringify({
+      queue_name: "emails",
+      sleep_seconds: 45,
+      n: 1,
+    }));
+    expect(sent).toMatchObject({ msg_id: 101, queue_name: "emails", status: "pending" });
+    expect(JSON.stringify(sentBatch.map((message) => message.msg_id))).toBe(JSON.stringify([102, 103]));
+    expect(read[0]).toMatchObject({ msg_id: 104, payload: { hello: "world" }, status: "leased" });
+    expect(received).toMatchObject({ msg_id: 104, payload: { hello: "world" } });
+    expect(popped).toMatchObject({ msg_id: 105, payload: { popped: true }, status: "deleted" });
+    expect(archived).toMatchObject({ msg_id: 104, status: "archived", success: true });
+    expect(acked).toMatchObject({ msg_id: 104, status: "archived", success: true });
+    expect(failed).toMatchObject({ msg_id: 104, status: "archived", success: true });
+    expect(deleted).toMatchObject({ msg_id: 104, status: "deleted", success: true });
+  });
+
+  test("queue management extensions use management-api requests with bearer auth", async () => {
     const { supabase } = createFakeSupabase();
     const calls: Array<{ url: string; init?: RequestInit }> = [];
 
@@ -162,50 +250,35 @@ describe("@supacloud/js", () => {
     });
     const queue = client.queue("emails");
 
-    await queue.send({ hello: "world" }, {
-      delayMs: 1000,
-      maxAttempts: 5,
-      idempotencyKey: "email-1",
-      correlationId: "corr-1",
-      businessTaskId: "biz-1",
-      metadata: { tenant: "acme" },
-    });
-    await queue.receive({ visibilityTimeoutSec: 60 });
-    await queue.list({ status: ["pending", "leased"], limit: 10 });
+    await client.queues.list();
+    await client.queues.create("emails", { unlogged: true });
+    await client.queues.drop("emails");
+    await queue.list({ archived: true, limit: 10 });
     await queue.stats();
     await queue.getSettings();
     await queue.updateSettings({ max_in_flight: 20 });
-    await queue.get("msg_123");
-    await queue.ack("msg_123", { ok: true });
-    await queue.release("msg_123", { delayMs: 5000, error: "retry later" });
-    await queue.fail("msg_123", { error: "boom" });
+    await queue.release(123, { delayMs: 5000, error: "retry later" });
+    await queue.purge();
+    await queue.get("123");
     await queue.retry("msg_123");
-    await queue.delete("msg_123");
 
-    expect(calls[0]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages");
-    expect(calls[1]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/receive");
-    expect(calls[2]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages?status=pending%2Cleased&limit=10");
-    expect(calls[3]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/stats");
-    expect(calls[4]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/settings");
+    expect(calls[0]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues");
+    expect(calls[1]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues");
+    expect(calls[1]?.init?.method).toBe("POST");
+    expect(calls[2]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails");
+    expect(calls[2]?.init?.method).toBe("DELETE");
+    expect(calls[3]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages?archived=true&limit=10");
+    expect(calls[4]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/stats");
     expect(calls[5]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/settings");
-    expect(calls[5]?.init?.method).toBe("PATCH");
-    expect(calls[6]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123");
-    expect(calls[7]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/ack");
-    expect(calls[8]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/release");
-    expect(calls[9]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/fail");
+    expect(calls[6]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/settings");
+    expect(calls[6]?.init?.method).toBe("PATCH");
+    expect(calls[7]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/123/release");
+    expect(calls[8]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/purge");
+    expect(calls[9]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/123");
     expect(calls[10]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123/retry");
-    expect(calls[11]?.url).toBe("https://admin.example.com/v1/projects/proj_1/tasks/queues/emails/messages/msg_123");
-    expect(calls[11]?.init?.method).toBe("DELETE");
     expect((calls[0]?.init?.headers as Record<string, string>)?.authorization).toBe("Bearer token-123");
-    expect(JSON.parse(String(calls[0]?.init?.body))).toMatchObject({
-      payload: { hello: "world" },
-      delayMs: 1000,
-      maxAttempts: 5,
-      idempotencyKey: "email-1",
-      correlationId: "corr-1",
-      businessTaskId: "biz-1",
-      metadata: { tenant: "acme" },
-    });
+    expect(JSON.parse(String(calls[1]?.init?.body))).toMatchObject({ queue_name: "emails", unlogged: true });
+    expect(JSON.parse(String(calls[7]?.init?.body))).toMatchObject({ sleep_seconds: 5, error: "retry later" });
   });
 
   test("management-api errors preserve status, code, and response body", async () => {
@@ -241,8 +314,11 @@ describe("@supacloud/js", () => {
   });
 
   test("queue receive returns null when no message is available", async () => {
-    const { supabase } = createFakeSupabase();
-    globalThis.fetch = mock(() => Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
+    const { supabase, rpc } = createFakeSupabase();
+    rpc.mockResolvedValue({ data: [], error: null });
+    globalThis.fetch = mock(() => {
+      throw new Error("receive should use pgmq_public.read");
+    }) as typeof fetch;
 
     const client = createSupaCloudClient({
       supabase: supabase as never,

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -96,20 +96,42 @@ export type SupaCloudTaskSubmitOptions = {
 };
 
 export type SupaCloudQueueSendOptions = {
+  /** Official Supabase Queues visibility delay, in seconds. */
+  sleepSeconds?: number;
+  /** Official Supabase Queues visibility delay, in seconds. */
+  sleep_seconds?: number;
+  /** Convenience alias converted to sleep_seconds for compatibility with older SupaCloud callers. */
   delayMs?: number;
+  /** @deprecated PGMQ does not store per-message retry budgets. Keep retry policy at the consumer layer. */
   maxAttempts?: number;
+  /** @deprecated PGMQ does not provide enqueue idempotency keys. Deduplicate in your payload or application table. */
   idempotencyKey?: string;
+  /** @deprecated PGMQ messages are plain JSON payloads. Put trace data inside message if needed. */
   traceId?: string;
+  /** @deprecated PGMQ messages are plain JSON payloads. Put correlation data inside message if needed. */
   correlationId?: string;
+  /** @deprecated PGMQ messages are plain JSON payloads. Put business IDs inside message if needed. */
   businessTaskId?: string;
+  /** @deprecated PGMQ messages are plain JSON payloads. Put metadata inside message if needed. */
   metadata?: Record<string, unknown>;
 };
 
 export type SupaCloudQueueReceiveOptions = {
+  /** Official Supabase Queues visibility timeout, in seconds. */
+  sleepSeconds?: number;
+  /** Official Supabase Queues visibility timeout, in seconds. */
+  sleep_seconds?: number;
+  /** Number of messages to read when using read(). receive() always reads one. */
+  n?: number;
+  /** Alias for n. */
+  count?: number;
+  /** Convenience alias converted to sleep_seconds for older SupaCloud callers. */
   visibilityTimeoutSec?: number;
 };
 
 export type SupaCloudQueueReleaseOptions = {
+  sleepSeconds?: number;
+  sleep_seconds?: number;
   delayMs?: number;
   error?: string;
 };
@@ -121,24 +143,61 @@ export type SupaCloudQueueFailOptions = {
 
 export type SupaCloudQueueListFilters = {
   status?: string | string[];
+  archived?: boolean;
   dlq?: boolean;
   limit?: number;
 };
 
-export type SupaCloudQueueMessage = SupaCloudTaskDetail & {
+export type SupaCloudQueueMessage = {
+  id: string;
+  msg_id: number;
+  read_ct?: number;
+  enqueued_at?: string | null;
+  vt?: string | null;
+  message?: Record<string, unknown>;
+  payload: Record<string, unknown>;
+  status?: string;
+  queue_name?: string;
+  task_type?: string;
+  [key: string]: unknown;
+};
+
+export type SupaCloudQueueSendResult = {
+  id: string;
+  msg_id: number;
+  queue_name: string;
+  status: "pending";
   payload: Record<string, unknown>;
 };
 
+export type SupaCloudQueueMutationResult = {
+  id: string;
+  msg_id: number;
+  queue_name: string;
+  status: "archived" | "deleted" | "released";
+  success: boolean;
+};
+
 export type SupaCloudQueueStats = {
-  pending: number;
-  leased: number;
-  running: number;
-  retryScheduled: number;
-  succeededLast24h: number;
-  failedLast24h: number;
-  deadLettered: number;
-  oldestPendingAgeSec: number | null;
-  inFlight: number;
+  queue_name: string;
+  queue_length: number;
+  newest_msg_age_sec: number | null;
+  oldest_msg_age_sec: number | null;
+  total_messages: number;
+  scrape_time: string;
+  [key: string]: unknown;
+};
+
+export type SupaCloudQueueInfo = {
+  queue_name: string;
+  created_at?: string | null;
+  is_partitioned?: boolean;
+  is_unlogged?: boolean;
+  type?: string;
+};
+
+export type SupaCloudQueueCreateOptions = {
+  unlogged?: boolean;
 };
 
 export type SupaCloudQueueSettings = {
@@ -411,11 +470,72 @@ function createQueueQueryString(filters: SupaCloudQueueListFilters = {}): string
   const statuses = toArray(filters.status);
 
   if (statuses?.length) params.set("status", statuses.join(","));
+  if (filters.archived) params.set("archived", "true");
   if (filters.dlq) params.set("dlq", "true");
   if (filters.limit !== undefined) params.set("limit", String(filters.limit));
 
   const query = params.toString();
   return query.length > 0 ? `?${query}` : "";
+}
+
+function normalizeSecondsFromOptions(
+  options: { sleepSeconds?: number; sleep_seconds?: number; delayMs?: number; visibilityTimeoutSec?: number } = {},
+): number {
+  if (typeof options.sleepSeconds === "number") return Math.max(0, Math.floor(options.sleepSeconds));
+  if (typeof options.sleep_seconds === "number") return Math.max(0, Math.floor(options.sleep_seconds));
+  if (typeof options.visibilityTimeoutSec === "number") return Math.max(0, Math.floor(options.visibilityTimeoutSec));
+  if (typeof options.delayMs === "number") return Math.max(0, Math.floor(options.delayMs / 1000));
+  return 0;
+}
+
+function normalizeMessageId(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function firstRpcValue(value: unknown): unknown {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function normalizeRpcMessage(queueName: string, value: unknown, status?: string): SupaCloudQueueMessage | null {
+  const row = firstRpcValue(value);
+  if (!row || typeof row !== "object") return null;
+  const record = row as Record<string, unknown>;
+  const message = record.message && typeof record.message === "object" && !Array.isArray(record.message)
+    ? record.message as Record<string, unknown>
+    : {};
+  const msgId = normalizeMessageId(record.msg_id ?? record.id);
+  return {
+    ...record,
+    id: String(msgId),
+    msg_id: msgId,
+    message,
+    payload: message,
+    status,
+    queue_name: queueName,
+    task_type: `queue:${queueName}`,
+  };
+}
+
+function normalizeRpcMessages(queueName: string, value: unknown, status?: string): SupaCloudQueueMessage[] {
+  const rows = Array.isArray(value) ? value : value == null ? [] : [value];
+  return rows
+    .map((row) => normalizeRpcMessage(queueName, row, status))
+    .filter((row): row is SupaCloudQueueMessage => Boolean(row));
+}
+
+function normalizeRpcMessageId(value: unknown): number {
+  const row = firstRpcValue(value);
+  if (row && typeof row === "object") {
+    const record = row as Record<string, unknown>;
+    return normalizeMessageId(record.msg_id ?? record.send ?? record.send_batch ?? record.id);
+  }
+  return normalizeMessageId(row);
+}
+
+function normalizeRpcMessageIds(value: unknown): number[] {
+  const rows = Array.isArray(value) ? value : value == null ? [] : [value];
+  return rows.map((row) => normalizeRpcMessageId(row)).filter((id) => id > 0);
 }
 
 function extractErrorCode(body: unknown): string | null {
@@ -821,35 +941,80 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     return encodeURIComponent(this.name);
   }
 
+  private async rpc<T>(fn: string, params: Record<string, unknown>): Promise<T> {
+    const scopedClient = (this.options.supabase as unknown as {
+      schema: (name: string) => {
+        rpc: (fn: string, params: Record<string, unknown>) => Promise<{ data: unknown; error: unknown }>;
+      };
+    }).schema("pgmq_public");
+    const { data, error } = await scopedClient.rpc(fn, params);
+    if (error) throw error;
+    return data as T;
+  }
+
   async send(
     payload: Record<string, unknown> = {},
     options: SupaCloudQueueSendOptions = {},
-  ): Promise<SupaCloudQueueMessage> {
-    return this.request<SupaCloudQueueMessage>(
-      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages`,
-      "POST",
-      {
-        payload,
-        delayMs: options.delayMs,
-        maxAttempts: options.maxAttempts,
-        idempotencyKey: options.idempotencyKey,
-        traceId: options.traceId,
-        correlationId: options.correlationId,
-        businessTaskId: options.businessTaskId,
-        metadata: options.metadata,
-      },
+  ): Promise<SupaCloudQueueSendResult> {
+    const msgId = normalizeRpcMessageId(await this.rpc("send", {
+      queue_name: this.name,
+      message: payload,
+      sleep_seconds: normalizeSecondsFromOptions(options),
+    }));
+    return {
+      id: String(msgId),
+      msg_id: msgId,
+      queue_name: this.name,
+      status: "pending",
+      payload,
+    };
+  }
+
+  async sendBatch(
+    messages: Record<string, unknown>[],
+    options: SupaCloudQueueSendOptions = {},
+  ): Promise<SupaCloudQueueSendResult[]> {
+    const ids = normalizeRpcMessageIds(await this.rpc("send_batch", {
+      queue_name: this.name,
+      messages,
+      sleep_seconds: normalizeSecondsFromOptions(options),
+    }));
+    return ids.map((msgId, index) => ({
+      id: String(msgId),
+      msg_id: msgId,
+      queue_name: this.name,
+      status: "pending",
+      payload: messages[index] ?? {},
+    }));
+  }
+
+  async read(
+    options: SupaCloudQueueReceiveOptions = {},
+  ): Promise<SupaCloudQueueMessage[]> {
+    return normalizeRpcMessages(
+      this.name,
+      await this.rpc("read", {
+        queue_name: this.name,
+        sleep_seconds: normalizeSecondsFromOptions(options),
+        n: Math.max(1, Math.floor(options.n ?? options.count ?? 1)),
+      }),
+      "leased",
     );
   }
 
   async receive(
     options: SupaCloudQueueReceiveOptions = {},
   ): Promise<SupaCloudQueueMessage | null> {
-    const message = await this.request<SupaCloudQueueMessage | undefined>(
-      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/receive`,
-      "POST",
-      options,
+    const messages = await this.read({ ...options, n: 1 });
+    return messages[0] ?? null;
+  }
+
+  async pop(): Promise<SupaCloudQueueMessage | null> {
+    return normalizeRpcMessage(
+      this.name,
+      await this.rpc("pop", { queue_name: this.name }),
+      "deleted",
     );
-    return message ?? null;
   }
 
   async list(filters: SupaCloudQueueListFilters = {}): Promise<SupaCloudQueueMessage[]> {
@@ -860,7 +1025,11 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
   }
 
   async listFailed(limit = 100): Promise<SupaCloudQueueMessage[]> {
-    return this.list({ dlq: true, limit });
+    return this.list({ archived: true, dlq: true, limit });
+  }
+
+  async listArchived(limit = 100): Promise<SupaCloudQueueMessage[]> {
+    return this.list({ archived: true, limit });
   }
 
   async stats(): Promise<SupaCloudQueueStats> {
@@ -885,6 +1054,63 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     );
   }
 
+  async archive(messageId: string | number): Promise<SupaCloudQueueMutationResult> {
+    const msgId = normalizeMessageId(messageId);
+    const success = Boolean(firstRpcValue(await this.rpc("archive", {
+      queue_name: this.name,
+      message_id: msgId,
+    })));
+    return { id: String(msgId), msg_id: msgId, queue_name: this.name, status: "archived", success };
+  }
+
+  async ack(messageId: string | number): Promise<SupaCloudQueueMutationResult> {
+    return this.archive(messageId);
+  }
+
+  async delete(messageId: string | number): Promise<SupaCloudQueueMutationResult> {
+    const msgId = normalizeMessageId(messageId);
+    const success = Boolean(firstRpcValue(await this.rpc("delete", {
+      queue_name: this.name,
+      message_id: msgId,
+    })));
+    return { id: String(msgId), msg_id: msgId, queue_name: this.name, status: "deleted", success };
+  }
+
+  async release(
+    messageId: string | number,
+    options: SupaCloudQueueReleaseOptions = {},
+  ): Promise<SupaCloudQueueMessage> {
+    return this.request<SupaCloudQueueMessage>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/release`,
+      "POST",
+      {
+        sleep_seconds: normalizeSecondsFromOptions(options),
+        ...(options.error ? { error: options.error } : {}),
+      },
+    );
+  }
+
+  async purge(): Promise<{ queue_name: string; purged: number }> {
+    return this.request<{ queue_name: string; purged: number }>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/purge`,
+      "POST",
+    );
+  }
+
+  /**
+   * SupaCloud extension alias: PGMQ has archive/delete but no failed state.
+   * This archives the message, matching the management API's compatibility behavior.
+   */
+  async fail(
+    messageId: string | number,
+    _options: SupaCloudQueueFailOptions = {},
+  ): Promise<SupaCloudQueueMutationResult> {
+    return this.archive(messageId);
+  }
+
+  /**
+   * @deprecated Direct random lookup is not part of Supabase Queues' official API.
+   */
   async get(messageId: string): Promise<SupaCloudQueueMessage> {
     return this.request<SupaCloudQueueMessage>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}`,
@@ -892,50 +1118,37 @@ class SupaCloudQueueClient<TClient extends SupabaseClient = SupabaseClient> exte
     );
   }
 
-  async ack(
-    messageId: string,
-    result?: Record<string, unknown>,
-  ): Promise<SupaCloudQueueMessage> {
-    return this.request<SupaCloudQueueMessage>(
-      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/ack`,
-      "POST",
-      result ? { result } : {},
-    );
-  }
-
-  async delete(messageId: string): Promise<void> {
-    await this.request<void>(
-      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}`,
-      "DELETE",
-    );
-  }
-
-  async release(
-    messageId: string,
-    options: SupaCloudQueueReleaseOptions = {},
-  ): Promise<SupaCloudQueueMessage> {
-    return this.request<SupaCloudQueueMessage>(
-      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/release`,
-      "POST",
-      options,
-    );
-  }
-
-  async fail(
-    messageId: string,
-    options: SupaCloudQueueFailOptions = {},
-  ): Promise<SupaCloudQueueMessage> {
-    return this.request<SupaCloudQueueMessage>(
-      `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/fail`,
-      "POST",
-      options,
-    );
-  }
-
+  /**
+   * @deprecated PGMQ archived messages are replayed with SQL/application workflows, not an official Queue API call.
+   */
   async retry(messageId: string): Promise<SupaCloudQueueMessage> {
     return this.request<SupaCloudQueueMessage>(
       `/v1/projects/${this.options.projectRef}/tasks/queues/${this.encodedName}/messages/${messageId}/retry`,
       "POST",
+    );
+  }
+}
+
+class SupaCloudQueuesClient<TClient extends SupabaseClient = SupabaseClient> extends SupaCloudManagementClient<TClient> {
+  async list(): Promise<SupaCloudQueueInfo[]> {
+    return this.request<SupaCloudQueueInfo[]>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues`,
+      "GET",
+    );
+  }
+
+  async create(queueName: string, options: SupaCloudQueueCreateOptions = {}): Promise<SupaCloudQueueInfo> {
+    return this.request<SupaCloudQueueInfo>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues`,
+      "POST",
+      { queue_name: queueName, unlogged: options.unlogged },
+    );
+  }
+
+  async drop(queueName: string): Promise<void> {
+    await this.request<void>(
+      `/v1/projects/${this.options.projectRef}/tasks/queues/${encodeURIComponent(queueName)}`,
+      "DELETE",
     );
   }
 }
@@ -1096,6 +1309,7 @@ export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseC
   const oauthServer = new SupaCloudOAuthServerClient(normalized);
   const oauthClients = new SupaCloudOAuthClientsClient(normalized);
   const supauth = new SupaCloudSupAuthClient(normalized);
+  const queues = new SupaCloudQueuesClient(normalized);
 
   return {
     supabase: options.supabase,
@@ -1107,6 +1321,7 @@ export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseC
     },
     tasks,
     supauth,
+    queues,
     queue: (name: string) => new SupaCloudQueueClient(normalized, name),
     functions: {
       invokeBackground: (

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -230,7 +230,7 @@ generate_tenant_config() {
     cat > "${TENANT_CONFIG_DIR}/${ref}.env" <<EOF
 # SupaCloud Tenant PostgREST Runtime: ${ref}
 PGRST_DB_URI=postgres://authenticator_${ref}:${db_password}@${PG_HOST}:${PG_PORT}/${db_name}
-PGRST_DB_SCHEMAS=public,storage,graphql_public
+PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public
 PGRST_DB_EXTRA_SEARCH_PATH=public
 PGRST_DB_ANON_ROLE=anon
 PGRST_JWT_SECRET=${jwt_secret}
@@ -244,7 +244,7 @@ EOF
     cat > "${TENANT_CONFIG_DIR}/${ref}.conf" <<EOF
 # PostgREST config for tenant: ${ref}
 db-uri = "postgres://authenticator_${ref}:${db_password}@${PG_HOST}:${PG_PORT}/${db_name}"
-db-schemas = "public, storage, graphql_public"
+db-schemas = "public, storage, graphql_public, pgmq_public"
 # Bug Fix: Multi-tenant isolation - extra search path should include tenant-specific schema
 db-extra-search-path = "public, extensions, auth, ${ref}"
 db-anon-role = "anon"


### PR DESCRIPTION
## Summary

- Extract postgres Docker image CI workflow to trigger on Dockerfile change, decouple from release cycle
- Add PGMQ (Supabase official queue) compatibility layer: tenant `pgmq` extension, `pgmq_public` PostgREST RPC schema, management-api queue API migration
- Migrate `@supacloud/js` queue SDK to use `supabase.schema("pgmq_public").rpc(...)` for send/sendBatch/read/receive/pop/archive/ack/delete
- Retain SupaCloud extensions: queues.list/create/drop, stats, release(set_vt), purge, diagnostics
- Update self-host PostgreSQL image to include `postgresql-18-pgmq` and bootstrap extension

## Verification

- `bun run --cwd packages/management-api typecheck` pass
- `bun test packages/management-api/tests/unit/task.routes.test.ts packages/management-api/tests/unit/supabase-schema.test.ts` 32 pass
- `bun run --cwd packages/supacloud-js typecheck` pass
- `bun test packages/supacloud-js/src/index.test.ts` 13 pass
- `git diff --check origin/main..HEAD` clean