### PR TITLE
feat(gateway): replace Kong default edge with Caddy

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -445,9 +445,15 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
       - name: Show runtime versions
         run: |
           node --version
+          go version
           bun --version
 
       - name: Install dependencies
@@ -487,6 +493,12 @@ jobs:
           bun run build:macos
           mv supacloud-edge-runtime-macos-amd64 dist/
           mv supacloud-edge-runtime-macos-arm64 dist/
+
+      - name: Install xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+
+      - name: Build Caddy edge binaries
+        run: OUT_DIR=packages/management-api/dist bash scripts/build_supacloud_caddy.sh
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,6 +55,11 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
       - name: Install dependencies
         working-directory: packages/management-api
         run: bun install
@@ -94,6 +99,12 @@ jobs:
           mv supacloud-edge-runtime-macos-amd64 dist/
           mv supacloud-edge-runtime-macos-arm64 dist/
           chmod 0755 dist/supacloud-edge-runtime-*
+
+      - name: Install xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+
+      - name: Build Caddy edge binaries
+        run: OUT_DIR=packages/management-api/dist bash scripts/build_supacloud_caddy.sh
 
       - name: Generate SHA256SUMS
         run: |

--- a/infrastructure/systemd/supacloud-caddy.service
+++ b/infrastructure/systemd/supacloud-caddy.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=SupaCloud Caddy Edge Gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+User=root
+Group=root
+EnvironmentFile=-/etc/supabase/management-api.env
+ExecStart=/usr/local/bin/supacloud-caddy run --config /etc/supacloud/caddy/config.json
+ExecReload=/usr/local/bin/supacloud-caddy reload --config /etc/supacloud/caddy/config.json --force
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -1509,6 +1509,125 @@ EOF
     log_info "Kong Native Gateway Installation completed."
 }
 
+# ========== Install Caddy Gateway (Default Edge proxy + TLS) ==========
+install_caddy_gateway() {
+    log_step "Installing SupaCloud Caddy Gateway..."
+
+    # Caddy owns public 80/443 in the new gateway model. Stop legacy listeners
+    # without uninstalling them so GATEWAY_PROVIDER=kong can still roll back.
+    for svc in nginx angie kong caddy; do
+        if systemctl list-unit-files "${svc}.service" &>/dev/null || systemctl list-units "${svc}.service" &>/dev/null; then
+            systemctl stop "$svc" 2>/dev/null || true
+            systemctl disable "$svc" 2>/dev/null || true
+        fi
+    done
+
+    mkdir -p /etc/supacloud/caddy /var/lib/supacloud/caddy /opt/supacloud/bin
+
+    local arch="amd64"
+    case "$(uname -m)" in
+        aarch64|arm64) arch="arm64" ;;
+    esac
+    local local_asset=""
+    for candidate in \
+        "${SCRIPT_DIR}/packages/management-api/supacloud-caddy-linux-${arch}" \
+        "${SCRIPT_DIR}/packages/management-api/dist/supacloud-caddy-linux-${arch}" \
+        "${SCRIPT_DIR}/dist/supacloud-caddy-linux-${arch}" \
+        "${SCRIPT_DIR}/supacloud-caddy-linux-${arch}"; do
+        if [[ -f "$candidate" ]]; then
+            local_asset="$candidate"
+            break
+        fi
+    done
+    local target="/usr/local/bin/supacloud-caddy"
+
+    if [[ -x "$target" ]]; then
+        log_info "supacloud-caddy already installed: $($target version 2>/dev/null | head -1 || echo installed)"
+    elif [[ -n "$local_asset" ]]; then
+        install -m 0755 "$local_asset" "$target"
+    elif [[ -n "${SUPACLOUD_CADDY_URL:-}" ]]; then
+        curl -fsSL "$SUPACLOUD_CADDY_URL" -o "$target"
+        chmod 0755 "$target"
+    elif [[ -x "${SCRIPT_DIR}/scripts/build_supacloud_caddy.sh" ]] && command -v go >/dev/null 2>&1; then
+        log_info "Building supacloud-caddy locally with xcaddy and the rate-limit module..."
+        if ! command -v xcaddy >/dev/null 2>&1; then
+            GOBIN=/usr/local/bin go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+        fi
+        OUT_DIR=/tmp/supacloud-caddy-build "${SCRIPT_DIR}/scripts/build_supacloud_caddy.sh"
+        install -m 0755 "/tmp/supacloud-caddy-build/supacloud-caddy-linux-${arch}" "$target"
+        rm -rf /tmp/supacloud-caddy-build
+    elif [[ "${SUPACLOUD_ALLOW_STOCK_CADDY_FALLBACK:-false}" == "true" ]]; then
+        log_warn "Installing stock Caddy fallback without SupaCloud rate-limit module. Do not use this for production rate limits."
+        local caddy_version="${CADDY_VERSION:-2.10.2}"
+        local caddy_url="https://github.com/caddyserver/caddy/releases/download/v${caddy_version}/caddy_${caddy_version}_linux_${arch}.tar.gz"
+        mkdir -p /tmp/supacloud-caddy
+        curl -fsSL "https://ghproxy.net/${caddy_url}" -o /tmp/supacloud-caddy/caddy.tar.gz 2>/dev/null || \
+            curl -fsSL "$caddy_url" -o /tmp/supacloud-caddy/caddy.tar.gz
+        tar -xzf /tmp/supacloud-caddy/caddy.tar.gz -C /tmp/supacloud-caddy caddy
+        install -m 0755 /tmp/supacloud-caddy/caddy "$target"
+        rm -rf /tmp/supacloud-caddy
+    else
+        log_error "supacloud-caddy artifact not found. Provide SUPACLOUD_CADDY_URL, include supacloud-caddy-linux-${arch}, or install Go so the installer can build it."
+        return 1
+    fi
+
+    cat > /etc/supacloud/caddy/config.json <<'EOF'
+{
+  "admin": { "listen": "127.0.0.1:2019" },
+  "storage": { "module": "file_system", "root": "/var/lib/supacloud/caddy" },
+  "apps": {
+    "tls": {
+      "automation": {
+        "on_demand": {
+          "permission": {
+            "module": "http",
+            "endpoint": "http://127.0.0.1:9090/v1/gateway/caddy/ask"
+          }
+        },
+        "policies": [{ "on_demand": true }]
+      }
+    },
+    "http": {
+      "servers": {
+        "supacloud": {
+          "listen": [":80", ":443"],
+          "routes": []
+        }
+      }
+    }
+  }
+}
+EOF
+
+    cat > /etc/systemd/system/supacloud-caddy.service <<'EOF'
+[Unit]
+Description=SupaCloud Caddy Edge Gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+User=root
+Group=root
+EnvironmentFile=-/etc/supabase/management-api.env
+ExecStart=/usr/local/bin/supacloud-caddy run --config /etc/supacloud/caddy/config.json
+ExecReload=/usr/local/bin/supacloud-caddy reload --config /etc/supacloud/caddy/config.json --force
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    systemctl daemon-reload
+    systemctl enable supacloud-caddy
+    # supacloud may not be installed yet on first run; start will be retried by lifecycle/pre-start.
+    systemctl restart supacloud-caddy || log_warn "supacloud-caddy start deferred; management API will populate routes after install."
+    log_info "SupaCloud Caddy Gateway installation completed."
+}
+
 cleanup_legacy_supabase_compose_stack() {
     log_step "Cleaning legacy Supabase compose residues..."
 
@@ -1835,7 +1954,7 @@ update_pigsty_config() {
 
         sed -i "s|supa.pigsty|${SUPABASE_PUBLIC_DOMAIN}|g" "$PIGSTY_YML"
     else
-        log_info "Skipping Pigsty app domain/certbot patch; Kong/lego owns public HTTP(S)."
+        log_info "Skipping Pigsty app domain/certbot patch; SupaCloud Caddy owns public HTTP(S)."
     fi
     
     # Update password configuration
@@ -1880,7 +1999,7 @@ update_pigsty_config() {
     configure_s3_in_pigsty
     # Container/CI environment detection limit variables now moved to ansible-playbook command line (EXTRA_ARGS)
     
-    # -- Disable Pigsty's Nginx management (Kong owns 80/443) -----
+    # -- Disable Pigsty's Nginx management (SupaCloud Caddy owns 80/443 by default) -----
     # Must be injected after ./configure and before bootstrap/install, otherwise Pigsty will still try to install Nginx
     if [[ -f "$PIGSTY_YML" ]]; then
         if ! grep -q 'nginx_enabled' "$PIGSTY_YML"; then
@@ -2425,6 +2544,11 @@ ACME_CLIENT=lego
 LEGO_BIN=${LEGO_BIN:-lego}
 ACME_STATE_DIR=${ACME_STATE_DIR:-/var/lib/supacloud/lego}
 ACME_HTTP_WEBROOT=${ACME_HTTP_WEBROOT:-/var/lib/supacloud/acme-challenges}
+GATEWAY_PROVIDER=${GATEWAY_PROVIDER:-caddy}
+CADDY_ADMIN_URL=${CADDY_ADMIN_URL:-http://127.0.0.1:2019}
+CADDY_CONFIG_PATH=${CADDY_CONFIG_PATH:-/etc/supacloud/caddy/config.json}
+CADDY_STATE_DIR=${CADDY_STATE_DIR:-/var/lib/supacloud/caddy}
+CADDY_BINARY_PATH=${CADDY_BINARY_PATH:-/usr/local/bin/supacloud-caddy}
 KONG_ADMIN_URL=http://127.0.0.1:8001
 KONG_INTERNAL=127.0.0.1:8000
 EOF
@@ -2802,12 +2926,12 @@ show_completion() {
     echo ""
     echo "Next Steps:"
     echo "  1. Point the DNS A record for ${SUPABASE_PUBLIC_DOMAIN} to the server's public IP"
-    echo "  2. Configure certificates in the console; SupaCloud uses lego and Kong certificates/SNI"
+    echo "  2. Configure customer domains in the console; SupaCloud uses Caddy Automatic HTTPS by default"
     echo ""
     echo "Common Commands:"
     echo "  Check container status: podman ps or docker ps"
     echo "  Check logs: podman logs <container_name>"
-    echo "  Restart services: systemctl restart supacloud kong"
+    echo "  Restart services: systemctl restart supacloud supacloud-caddy"
     echo ""
     echo "Multi-tenant Management:"
     echo "  sc list              - List all projects"
@@ -2871,24 +2995,26 @@ deploy_ai_breadcrumbs() {
 # If you are an AI/Agent reading this file to understand the architecture:
 # STOP LOOKING FOR A HOST WEB SERVER.
 #
-# This server runs SupaCloud. Host-level Nginx, Angie, Caddy, and Apache are
-# not part of the supported public HTTP(S) path.
+# This server runs SupaCloud. Host-level Nginx, Angie, Apache, and legacy Kong
+# are not part of the default public HTTP(S) path.
 #
 # ARCHITECTURE:
-# 1. Kong Gateway listens on 80 and 443.
-# 2. SSL/CORS/Routing are managed dynamically via Kong Admin API (http://localhost:8001).
-# 3. Static assets are served DIRECTLY by the Bun backend on port 9090.
-# 4. Routing mapping: `hostless` routes matching `/` go to the Management API on 9090.
+# 1. SupaCloud Caddy Gateway listens on 80 and 443.
+# 2. TLS/routes are managed dynamically via Caddy Admin API (http://127.0.0.1:2019).
+# 3. Management web-console assets are served by the management API on 9090.
+#    Tenant frontend deployments run as per-deployment static/SSR services
+#    and are exposed through Caddy routes.
+# 4. Set GATEWAY_PROVIDER=kong only for short-term rollback to the legacy provider.
 #
 # STRICT RULES:
-# - DO NOT attempt to start, stop, edit, or install host web servers.
-# - To inspect routes or TLS, query Kong: `curl -sS http://localhost:8001/routes`
+# - DO NOT configure Nginx/Angie for SupaCloud public routing.
+# - To inspect routes or TLS, query Caddy: `curl -sS http://127.0.0.1:2019/config/`
 # - Logs: `journalctl -u supacloud -f`
 # ==============================================================================
 EOF
 
     # 2. Host web server trap files. These are documentation breadcrumbs only.
-    # They intentionally point future operators/agents back to Kong + SupaCloud.
+    # They intentionally point future operators/agents back to Caddy + SupaCloud.
     mkdir -p /etc/nginx
     cat << "EOF" > /etc/nginx/nginx.conf
 # ==============================================================================
@@ -2897,15 +3023,16 @@ EOF
 # Do not configure or start host Nginx for this SupaCloud node.
 #
 # Public HTTP(S):
-# - Kong Gateway owns ports 80/443.
-# - TLS/CORS/routes are managed through Kong Admin API on http://localhost:8001.
+# - SupaCloud Caddy Gateway owns ports 80/443.
+# - TLS/routes are managed through Caddy Admin API on http://127.0.0.1:2019.
 #
-# Static frontend:
-# - Static assets are served by SupaCloud's Bun/Elysia management API on 9090.
-# - Kong routes browser traffic to SupaCloud; Nginx is not involved.
+# Frontend and console:
+# - Web-console assets are served by the SupaCloud management API on 9090.
+# - Tenant frontend deployments run behind Caddy as per-deployment static/SSR services.
+# - Caddy routes browser traffic to SupaCloud; Nginx is not involved.
 #
 # Useful checks:
-# - curl -sS http://localhost:8001/routes
+# - curl -sS http://127.0.0.1:2019/config/
 # - journalctl -u supacloud -f
 # ==============================================================================
 
@@ -2924,8 +3051,8 @@ EOF
 # SupaCloud Breadcrumb: Angie is not the serving path
 # ==============================================================================
 # Do not configure or start host Angie for this SupaCloud node.
-# Kong Gateway owns ports 80/443. Static assets are served by SupaCloud on 9090.
-# Inspect Kong routes with: curl -sS http://localhost:8001/routes
+# SupaCloud Caddy Gateway owns ports 80/443. Web-console assets are served by the management API on 9090; tenant frontends run behind Caddy as per-deployment services.
+# Inspect Caddy routes with: curl -sS http://127.0.0.1:2019/config/
 # ==============================================================================
 
 events {
@@ -2940,11 +3067,11 @@ EOF
     mkdir -p /etc/caddy
     cat << "EOF" > /etc/caddy/Caddyfile
 # ==============================================================================
-# SupaCloud Breadcrumb: Caddy is not the serving path
+# SupaCloud Breadcrumb: Caddy is the serving path
 # ==============================================================================
-# Do not configure or start host Caddy for this SupaCloud node.
-# Kong Gateway owns public HTTP(S), and SupaCloud serves static assets itself.
-# Inspect Kong routes with: curl -sS http://localhost:8001/routes
+# This file is documentation only. SupaCloud writes JSON config to
+# /etc/supacloud/caddy/config.json and publishes it via Caddy Admin API.
+# Inspect routes with: curl -sS http://127.0.0.1:2019/config/
 # ==============================================================================
 EOF
 
@@ -2995,8 +3122,12 @@ main() {
     configure_pg_hba
     configure_low_memory_tcp_guardrails
     
-    # Kong native relies on Pigsty Postgres so it must be executed after install_pigsty.
-    install_kong_native
+    # Gateway setup runs after Pigsty so rollback provider=kong can still provision its database.
+    if [[ "${GATEWAY_PROVIDER:-caddy}" == "kong" ]]; then
+        install_kong_native
+    else
+        install_caddy_gateway
+    fi
 
     # Performance tuning after Pigsty PG initialization
     tune_postgres

--- a/packages/management-api/src/cli.ts
+++ b/packages/management-api/src/cli.ts
@@ -16,42 +16,19 @@ async function setupStudioDomain(domain: string) {
   const MANAGEMENT_API_INTERNAL = appConfig.managementApiInternal;
   const STUDIO_INTERNAL = appConfig.studioInternal;
   
-  logger.info(`Provisioning global Studio & Management API in Native Kong for domain ${domain}...`);
+  logger.info(`Provisioning global Studio & Management API through ${gatewayService.name} gateway for domain ${domain}...`);
 
   try {
-    // 1. Management API Services
-    await gatewayService['kongRequest']('/services/svc-global-management', 'PUT', {
-      name: 'svc-global-management',
-      url: `http://${MANAGEMENT_API_INTERNAL}`,
-    });
-    
-    // Management Auth & Platform Routes
-    await gatewayService['kongRequest']('/routes/route-global-management', 'PUT', {
-       name: 'route-global-management',
-       service: { name: 'svc-global-management' },
-       paths: ['/api/platform/', '/api/auth/'],
-       hosts: [domain],
-       strip_path: false,
-       preserve_host: true
+    await gatewayService.setupMasterRoutes();
+    const studioPort = Number(STUDIO_INTERNAL.split(":").pop() || "3000");
+    await gatewayService.configureFrontendRoute({
+      projectRef: "_global",
+      deploymentId: "studio",
+      hosts: [domain],
+      port: studioPort,
     });
 
-    // 2. Studio SPA frontend
-    await gatewayService['kongRequest']('/services/svc-global-studio', 'PUT', {
-      name: 'svc-global-studio',
-      url: `http://${STUDIO_INTERNAL}`,
-    });
-
-    // Studio Root path
-    await gatewayService['kongRequest']('/routes/route-global-studio', 'PUT', {
-       name: 'route-global-studio',
-       service: { name: 'svc-global-studio' },
-       paths: ['/'],
-       hosts: [domain],
-       strip_path: false,
-       preserve_host: true
-    });
-
-    logger.info(`\n\n✅ Successfully bound Global Studio to: https://${domain}`);
+    logger.info(`\n\nSuccessfully bound Global Studio to: https://${domain}`);
     logger.info(`Make sure to point your DNS A record for ${domain} to this server's IP address.\n`);
   } catch (error: unknown) {
     logger.error(`Failed to bind global domain: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/management-api/src/cli/lifecycle.ts
+++ b/packages/management-api/src/cli/lifecycle.ts
@@ -1,8 +1,10 @@
 import { $ } from "bun";
 import * as p from "@clack/prompts";
 import { logger } from "../utils/logger";
+import { config } from "../config";
 
-const CONTROL_UNITS = ["supacloud", "kong", "supacloud-realtime"];
+const GATEWAY_UNIT = config.gatewayProvider === "kong" ? "kong" : "supacloud-caddy";
+const CONTROL_UNITS = ["supacloud", GATEWAY_UNIT, "supacloud-realtime"];
 
 async function unitExists(unit: string): Promise<boolean> {
   const normalized = unit.endsWith(".service") ? unit : `${unit}.service`;

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -68,6 +68,11 @@ export interface Config {
   storageType: string;
   storageMountPoint: string;
   imaginaryUrl: string;
+  gatewayProvider: "caddy" | "kong";
+  caddyAdminUrl: string;
+  caddyConfigPath: string;
+  caddyStateDir: string;
+  caddyBinaryPath: string;
   kongAdminUrl: string;
   kongInternal: string;
   victoriaMetricsUrl: string;
@@ -192,6 +197,21 @@ export const config: Config = {
   storageMountPoint: getEnv("STORAGE_MOUNT_POINT", "/data/storage"),
 
   imaginaryUrl: getEnv("IMAGINARY_URL", "http://127.0.0.1:9010"),
+  gatewayProvider: getEnv("GATEWAY_PROVIDER", "caddy") === "kong" ? "kong" : "caddy",
+  caddyAdminUrl: getEnv("CADDY_ADMIN_URL", "http://127.0.0.1:2019"),
+  caddyConfigPath: getEnv(
+    "CADDY_CONFIG_PATH",
+    process.env.NODE_ENV === "test" || process.env.BUN_ENV === "test"
+      ? "/tmp/supacloud-caddy-test/config.json"
+      : "/etc/supacloud/caddy/config.json",
+  ),
+  caddyStateDir: getEnv(
+    "CADDY_STATE_DIR",
+    process.env.NODE_ENV === "test" || process.env.BUN_ENV === "test"
+      ? "/tmp/supacloud-caddy-test/state"
+      : "/var/lib/supacloud/caddy",
+  ),
+  caddyBinaryPath: getEnv("CADDY_BINARY_PATH", "/usr/local/bin/supacloud-caddy"),
   kongAdminUrl: getEnv("KONG_ADMIN_URL", "http://localhost:8001"),
   kongInternal: getEnv("KONG_INTERNAL", "127.0.0.1:8000"),
   victoriaMetricsUrl: getEnv("VICTORIAMETRICS_URL", "http://127.0.0.1:8428"),

--- a/packages/management-api/src/diagnostics/checks/platform-service.ts
+++ b/packages/management-api/src/diagnostics/checks/platform-service.ts
@@ -6,20 +6,24 @@ import { $ } from "bun";
 import { hashPayload, statusForHash } from "../hash";
 import { registerCheck } from "../../services/diagnostics.registry";
 import type { DiagnosticCheckResult, DiagnosticRepairResult } from "../../services/diagnostics.types";
+import { config } from "../../config";
 
 // --- Systemd service check ---
 registerCheck({
   id: "platform-service-status",
   name: "Platform Services",
-  description: "Check critical systemd services: supacloud, kong, supacloud-edge-runtime",
+  description: "Check critical systemd services: supacloud, gateway, supacloud-edge-runtime",
   category: "service",
   scope: "platform",
   severity: "critical",
   repairable: false,
   async run(): Promise<DiagnosticCheckResult | null> {
+    const gateway = config.gatewayProvider === "kong"
+      ? { unit: "kong", label: "Kong Gateway" }
+      : { unit: "supacloud-caddy", label: "Caddy Gateway" };
     const services = [
       { unit: "supacloud", label: "Management API" },
-      { unit: "kong", label: "Kong Gateway" },
+      gateway,
       { unit: "supacloud-edge-runtime", label: "Edge Runtime" },
       { unit: "patroni", label: "Patroni (PostgreSQL HA)" },
     ];
@@ -62,7 +66,7 @@ registerCheck({
 registerCheck({
   id: "platform-port-listeners",
   name: "Port Listeners",
-  description: "Verify expected ports are listening: 9090 (API), 8000/8443 (Kong), 9000 (Edge Runtime)",
+  description: "Verify expected ports are listening: 9090 (API), 80/443 (Gateway), 9000 (Edge Runtime)",
   category: "service",
   scope: "platform",
   severity: "critical",
@@ -70,8 +74,8 @@ registerCheck({
   async run(): Promise<DiagnosticCheckResult | null> {
     const ports = [
       { port: 9090, label: "Management API" },
-      { port: 8000, label: "Kong HTTP" },
-      { port: 8443, label: "Kong HTTPS" },
+      { port: 80, label: "Gateway HTTP" },
+      { port: 443, label: "Gateway HTTPS" },
       { port: 9000, label: "Edge Runtime" },
       { port: 5432, label: "PostgreSQL" },
     ];

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -262,8 +262,8 @@ const app = new Elysia({ strictPath: false })
   // Health check (no auth required)
   .get("/health", () => ({ status: "ok", timestamp: new Date().toISOString() }))
 
-  // ACME HTTP-01 challenge files for lego --http.webroot. Kong routes
-  // /.well-known/acme-challenge for tenant hosts back to this service.
+  // Compatibility path for manual/lego HTTP-01 challenge files. The default
+  // Caddy flow uses Automatic HTTPS with the on-demand permission endpoint.
   .get("/.well-known/acme-challenge/:token", async ({ params, set }) => {
     const token = String(params.token || "");
     if (!/^[A-Za-z0-9_-]+$/.test(token)) {
@@ -369,6 +369,30 @@ const app = new Elysia({ strictPath: false })
       token: t.String(),
     }),
     detail: { tags: ["auth"], summary: "Verify session token" },
+  })
+
+  .get("/v1/gateway/caddy/ask", async ({ query }) => {
+    const domain = String((query as Record<string, unknown>).domain || (query as Record<string, unknown>).host || "")
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/:\d+$/, "");
+    if (!domain) {
+      return new Response("missing domain", { status: 400 });
+    }
+    if (domain === config.baseDomain || domain.endsWith(`.${config.baseDomain}`)) {
+      return new Response("ok");
+    }
+    const rows = await sql`
+      SELECT ref FROM projects
+      WHERE status != 'deleted'
+        AND deleted_at IS NULL
+        AND config::text ILIKE ${`%${domain}%`}
+      LIMIT 1
+    `;
+    return rows.length > 0 ? new Response("ok") : new Response("domain not allowed", { status: 403 });
+  }, {
+    detail: { tags: ["gateway"], summary: "Authorize Caddy On-Demand TLS domain" },
   })
 
   // WebSocket routes (no HTTP auth guard; WS uses query token)

--- a/packages/management-api/src/infra/pigsty.ts
+++ b/packages/management-api/src/infra/pigsty.ts
@@ -230,7 +230,7 @@ async function updatePigstyConfig(config: PigstyConfig, ymlPath: string) {
 
             yml = yml.replace(/supa.pigsty/g, config.publicDomain); // Generic placeholder replacement
         } else {
-            logger.info("[PigstyManager] Skipping Pigsty app domain/certbot patch; Kong/lego owns public HTTP(S).");
+            logger.info("[PigstyManager] Skipping Pigsty app domain/certbot patch; SupaCloud Caddy owns public HTTP(S).");
         }
 
         // Passwords and security certificates

--- a/packages/management-api/src/install.ts
+++ b/packages/management-api/src/install.ts
@@ -256,7 +256,7 @@ async function runInteractiveConfig(installerPath: string, forceYes = false): Pr
                 ]
             }),
             enableSsl: () => p.confirm({
-                message: 'Enable automatic SSL/HTTPS (via lego + Kong certificates)?',
+                message: 'Enable automatic SSL/HTTPS (via Caddy Automatic HTTPS)?',
                 initialValue: true
             }),
             acmeClient: ({ results }) => results.enableSsl ? p.select({
@@ -358,6 +358,11 @@ BASE_DOMAIN="${deriveBaseDomain(publicDomain)}"
 LEGO_BIN="lego"
 ACME_STATE_DIR="/var/lib/supacloud/lego"
 ACME_HTTP_WEBROOT="/var/lib/supacloud/acme-challenges"
+GATEWAY_PROVIDER="caddy"
+CADDY_ADMIN_URL="http://127.0.0.1:2019"
+CADDY_CONFIG_PATH="/etc/supacloud/caddy/config.json"
+CADDY_STATE_DIR="/var/lib/supacloud/caddy"
+CADDY_BINARY_PATH="/usr/local/bin/supacloud-caddy"
 KONG_INTERNAL="127.0.0.1:8000"
 `;
     await Bun.write(configFile, envContent.trim());

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -2031,7 +2031,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
 },
   )
 
-  // Get Kong certificate automation settings
+  // Get gateway certificate automation settings
   .get(
     "/:ref/gateway/certificate",
     async ({ params, request }) => {
@@ -2076,7 +2076,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
     },
   )
 
-  // Issue or renew a certificate with lego, then deploy it into Kong certificates/SNIs.
+  // Issue or renew a certificate with lego, then deploy it into gateway certificates.
   .post(
     "/:ref/gateway/certificate/issue",
     async ({ params, body, request }) => {
@@ -2099,7 +2099,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
         auto_renew: t.Optional(t.Boolean()),
         renew: t.Optional(t.Boolean()),
       }),
-      detail: { tags: ["projects"], summary: "Issue or renew a Kong certificate with lego" },
+      detail: { tags: ["projects"], summary: "Issue or renew a gateway certificate with lego" },
     },
   )
 
@@ -2126,11 +2126,11 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
         key: t.String(),
         domains: t.Optional(t.Array(t.String())),
       }),
-      detail: { tags: ["projects"], summary: "Deploy an existing certificate into Kong" },
+      detail: { tags: ["projects"], summary: "Deploy an existing certificate into gateway" },
     },
   )
 
-  // Rebuild ALL tenant Kong configs (propagate CORS / template changes)
+  // Rebuild ALL tenant gateway configs (propagate CORS / template changes)
   .post(
     "/:ref/gateway/rebuild-all",
     async ({ request }) => {
@@ -2146,12 +2146,12 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       params: t.Object({ ref: t.String() }),
       detail: {
         tags: ["projects"],
-        summary: "Rebuild all tenant Kong configs",
+        summary: "Rebuild all tenant gateway configs",
       },
     },
   )
 
-  // --- Programmable Rate Limiting (Kong Admin API) ---
+  // --- Programmable Rate Limiting (gateway provider) ---
 
   // Get current rate limit config for a project
   .get(
@@ -2239,7 +2239,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
         });
       }
 
-      // 2. Apply to Kong
+      // 2. Apply to gateway
       const success = await gatewayService.setCustomRouteRateLimit(
         params.ref,
         body.path,
@@ -2303,7 +2303,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!settings)
         return status(404, { message: "Project not found", code: "404" });
 
-      // 2. Remove from Kong
+      // 2. Remove from gateway
       const success = await gatewayService.removeCustomRouteRateLimit(
         params.ref,
         body.path,

--- a/packages/management-api/src/routes/project-logs.ts
+++ b/packages/management-api/src/routes/project-logs.ts
@@ -37,7 +37,7 @@ export const projectLogsRoutes = new Elysia({ prefix: "/v1/projects/:ref/logs" }
 
             try {
                 const limit = query.limit || "200";
-                const result = await $`journalctl -u supacloud-gotrue@${params.ref} -u supacloud-pgrst@${params.ref} -u supacloud-postgres@${params.ref} -u supacloud-realtime -u supacloud-storage@${params.ref} -u supacloud-kong@${params.ref} -n ${limit} --output short-iso --no-pager`.nothrow().quiet();
+                const result = await $`journalctl -u supacloud-gotrue@${params.ref} -u supacloud-pgrst@${params.ref} -u supacloud-postgres@${params.ref} -u supacloud-realtime -u supacloud-storage@${params.ref} -u supacloud-caddy -u kong -n ${limit} --output short-iso --no-pager`.nothrow().quiet();
                 const output = result.text();
                 const lines = output.split('\n').filter(line => line.trim() !== '' && !line.startsWith('-- '));
 

--- a/packages/management-api/src/routes/project-services.ts
+++ b/packages/management-api/src/routes/project-services.ts
@@ -7,6 +7,7 @@ import { projectService } from "../services";
 import { getAuthContext, requireProjectOrAdminAuth } from "../middleware/auth";
 import { $ } from "bun";
 import { tenantRuntimeService } from "../services/tenant-runtime.service";
+import { config } from "../config";
 
 export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get project health status
@@ -224,7 +225,9 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
       const sharedUnitMap: Record<string, string> = {
         postgresql: "patroni",
         realtime: "supacloud-realtime",
+        gateway: config.gatewayProvider === "kong" ? "kong" : "supacloud-caddy",
         kong: "kong",
+        caddy: "supacloud-caddy",
       };
       const serviceMap: Record<string, string> = { ...projectUnitMap, ...sharedUnitMap };
 

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -5,10 +5,10 @@
  * - FrontendDomainService — custom domains, deploy tokens, env vars, git config
  * - FrontendRecordService — deployment records (history/audit trail)
  *
- * This file handles: CRUD, build, Kong routing, process management
+ * This file handles: CRUD, build, gateway routing, process management
  *
  * Deployment flow (blue-green):
- *   build → start process → wait for /healthz readiness → switch Kong route → done
+ *   build → start process → wait for /healthz readiness → switch gateway route → done
  *   If readiness fails: stop process, do NOT switch route, report failure
  */
 import { $ } from "bun";
@@ -79,7 +79,7 @@ export class FrontendService {
     this.domainService = new FrontendDomainService(
       baseDir,
       this.getDeployment.bind(this),
-      this.configureKongRoute.bind(this),
+      this.configureGatewayRoute.bind(this),
     );
     this.recordService = new FrontendRecordService(baseDir);
   }
@@ -226,7 +226,7 @@ export class FrontendService {
       const deployment = await this.getDeployment(projectRef, deploymentId);
       if (deployment) {
         await this.stopProcess(projectRef, deploymentId);
-        await this.removeKongRoute(deployment);
+        await this.removeGatewayRoute(deployment);
       }
       await $`rm -rf ${deploymentDir}`.quiet();
       return true;
@@ -367,7 +367,7 @@ export class FrontendService {
   }
 
   /**
-   * Blue-green build: build → start process → readiness gate → switch Kong route
+   * Blue-green build: build → start process → readiness gate → switch gateway route
    * If readiness fails, stop process and do NOT switch route.
    */
   private async buildDeployment(
@@ -420,17 +420,17 @@ export class FrontendService {
       // Blue-green: start process FIRST, but do NOT route traffic yet
       const port = await this.startProcess(projectRef, deploymentId, deployment, buildDir, defaults.is_ssr);
 
-      // Readiness gate: wait for /healthz before switching Kong route
+      // Readiness gate: wait for /healthz before switching gateway route
       const ready = await this.waitForReadiness(port);
       if (!ready) {
-        // Rollback: stop the process, leave Kong pointing at old state (or nothing)
+        // Rollback: stop the process, leave the gateway pointing at old state (or nothing)
         logger.error(`[FrontendService] Readiness failed for ${projectRef}/${deploymentId}, stopping process`);
         await this.stopProcess(projectRef, deploymentId);
         throw new Error(`Frontend process failed readiness check on port ${port} within ${READINESS_TIMEOUT_MS}ms`);
       }
 
-      // Process is healthy — NOW switch Kong route
-      await this.configureKongRoute(deployment, buildDir, defaults.is_ssr);
+      // Process is healthy — NOW switch gateway route
+      await this.configureGatewayRoute(deployment, buildDir, defaults.is_ssr);
 
       await this.updateDeployment(projectRef, deploymentId, {
         status: "success",
@@ -456,47 +456,26 @@ export class FrontendService {
     }
   }
 
-  // ── Kong (Web Server) Config ─────────────────────────────────────
+  // ── Gateway (Web Server) Config ───────────────────────────────────
 
-  async configureKongRoute(deployment: FrontendDeployment, buildDir: string, isSSR: boolean): Promise<void> {
+  async configureGatewayRoute(deployment: FrontendDeployment, buildDir: string, isSSR: boolean): Promise<void> {
     const port = 30000 + parseInt(deployment.id, 16) % 10000;
-    
     const hosts = [deployment.domain, ...deployment.custom_domains];
-    const serviceName = `svc-frontend-${deployment.project_ref}-${deployment.id}`;
-    const routeName = `route-frontend-${deployment.project_ref}-${deployment.id}`;
 
     const { gatewayService } = await import("./gateway.service");
-    await gatewayService.addCorsOriginsForHosts(deployment.project_ref, hosts);
-
-    await gatewayService['kongRequest'](`/services/${serviceName}`, 'PUT', {
-        name: serviceName,
-        url: `http://127.0.0.1:${port}`,
-        connect_timeout: 5000,
-        read_timeout: 60000,
-        write_timeout: 60000
-    });
-
-    await gatewayService['kongRequest'](`/routes/${routeName}`, 'PUT', {
-        name: routeName,
-        service: { name: serviceName },
-        paths: ["/"],
-        hosts: hosts.length > 0 ? hosts : undefined,
-        strip_path: false,
-        preserve_host: true,
-        request_buffering: false,
-        response_buffering: false,
+    await gatewayService.configureFrontendRoute({
+      projectRef: deployment.project_ref,
+      deploymentId: deployment.id,
+      hosts,
+      port,
     });
   }
 
-  private async removeKongRoute(deployment: FrontendDeployment): Promise<void> {
-    const serviceName = `svc-frontend-${deployment.project_ref}-${deployment.id}`;
-    const routeName = `route-frontend-${deployment.project_ref}-${deployment.id}`;
-    
+  private async removeGatewayRoute(deployment: FrontendDeployment): Promise<void> {
     const { gatewayService } = await import("./gateway.service");
 
     try {
-        await gatewayService['kongRequest'](`/routes/${routeName}`, 'DELETE');
-        await gatewayService['kongRequest'](`/services/${serviceName}`, 'DELETE');
+        await gatewayService.removeFrontendRoute(deployment.project_ref, deployment.id);
     } catch (e: unknown) { logger.debug("suppressed error removing route", { error: String(e) }); }
   }
 

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -91,7 +91,59 @@ interface RateLimitConfig {
     hour: number;
 }
 
-export class GatewayService {
+type GatewaySetupOptions = { functionsPort?: number; storagePort?: number; realtimeApiPort?: number; realtimeWsPort?: number };
+
+export interface FrontendGatewayRoute {
+    projectRef: string;
+    deploymentId: string;
+    hosts: string[];
+    port: number;
+}
+
+export interface GatewayProvider {
+    readonly name: "caddy" | "kong";
+    setupJwt(projectRef: string, jwtSecret: string): Promise<boolean>;
+    enableJwtAuth(projectRef: string): Promise<boolean>;
+    setIpRestriction(projectRef: string, allowedIps: string[]): Promise<boolean>;
+    getRateLimit(projectRef: string): Promise<{ tier: string; second: number; minute: number; hour: number; enabled: boolean } | null>;
+    setRateLimit(projectRef: string, opts?: string | { second?: number; minute?: number; hour?: number }): Promise<boolean>;
+    setCustomRouteRateLimit(projectRef: string, basePath: string, limits: { second?: number; minute?: number; hour?: number }): Promise<boolean>;
+    removeCustomRouteRateLimit(projectRef: string, basePath: string): Promise<boolean>;
+    setCors(projectRef: string, origins?: string[]): Promise<boolean>;
+    addCorsOriginsForHosts(projectRef: string, hosts: string[]): Promise<boolean>;
+    setupUpstream(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions): Promise<{ success: boolean; error?: string }>;
+    addProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean>;
+    removeProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean>;
+    removeService(projectRef: string): Promise<{ success: boolean; error?: string }>;
+    addUpstreamTarget(projectRef: string, replicaIp: string): Promise<{ success: boolean; error?: string }>;
+    removeUpstreamTarget(projectRef: string, replicaIp: string): Promise<{ success: boolean; error?: string }>;
+    applyConfig(projectRef: string, gatewayConfig: GatewayConfig): Promise<{ success: boolean; message: string }>;
+    rebuildAllTenantConfigs(): Promise<{ success: boolean; updated: number; errors: string[] }>;
+    setupMasterRoutes(): Promise<void>;
+    upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }>;
+    configureFrontendRoute(route: FrontendGatewayRoute): Promise<void>;
+    removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void>;
+}
+
+function getRateLimitConfig(tier: string): RateLimitConfig {
+    switch (tier) {
+        case "pro": return { second: 100, minute: 2000, hour: 50000 };
+        case "enterprise": return { second: 1000, minute: 50000, hour: 1000000 };
+        default: return { second: 10, minute: 100, hour: 1000 };
+    }
+}
+
+function hashStr(str: string): string {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        hash = (hash << 5) - hash + str.charCodeAt(i);
+        hash |= 0;
+    }
+    return Math.abs(hash).toString(36);
+}
+
+export class KongGatewayProvider implements GatewayProvider {
+    readonly name = "kong" as const;
     private readonly KONG_ADMIN_URL = config.kongAdminUrl;
     private readonly TENANT_DIR = config.tenantConfigDir;
 
@@ -230,14 +282,6 @@ export class GatewayService {
 
     // --- Rate Limiting ---
 
-    private getRateLimitConfig(tier: string): RateLimitConfig {
-        switch (tier) {
-            case "pro": return { second: 100, minute: 2000, hour: 50000 };
-            case "enterprise": return { second: 1000, minute: 50000, hour: 1000000 };
-            default: return { second: 10, minute: 100, hour: 1000 };
-        }
-    }
-
     /** Query current rate-limit config from Kong Admin API */
     async getRateLimit(projectRef: string): Promise<{ tier: string; second: number; minute: number; hour: number; enabled: boolean } | null> {
         try {
@@ -270,7 +314,7 @@ export class GatewayService {
         try {
             let second: number, minute: number, hour: number;
             if (typeof opts === "string") {
-                ({ second, minute, hour } = this.getRateLimitConfig(opts));
+                ({ second, minute, hour } = getRateLimitConfig(opts));
             } else {
                 ({ second = 10, minute = 100, hour = 1000 } = opts);
             }
@@ -311,15 +355,6 @@ export class GatewayService {
         return null;
     }
 
-    private hashStr(str: string): string {
-        let hash = 0;
-        for (let i = 0; i < str.length; i++) {
-            hash = (hash << 5) - hash + str.charCodeAt(i);
-            hash |= 0;
-        }
-        return Math.abs(hash).toString(36);
-    }
-
     async setCustomRouteRateLimit(projectRef: string, basePath: string, limits: { second?: number; minute?: number; hour?: number }): Promise<boolean> {
         try {
             const serviceName = this.getServiceForPath(basePath, projectRef);
@@ -333,7 +368,7 @@ export class GatewayService {
             const minute = Math.min(limits.minute ?? this.MAX_RATE_LIMIT.minute, this.MAX_RATE_LIMIT.minute);
             const hour = Math.min(limits.hour ?? this.MAX_RATE_LIMIT.hour, this.MAX_RATE_LIMIT.hour);
 
-            const routeName = `route-custom-${projectRef}-${this.hashStr(basePath)}`;
+            const routeName = `route-custom-${projectRef}-${hashStr(basePath)}`;
 
             // 1. Check if we need to infer hosts from parent route
             const parentRouteName = `route-${serviceName}`;
@@ -389,7 +424,7 @@ export class GatewayService {
 
     async removeCustomRouteRateLimit(projectRef: string, basePath: string): Promise<boolean> {
         try {
-            const routeName = `route-custom-${projectRef}-${this.hashStr(basePath)}`;
+            const routeName = `route-custom-${projectRef}-${hashStr(basePath)}`;
             await this.kongRequest(`/routes/${routeName}`, "DELETE");
             logger.info(`[GatewayService] Custom rate limit removed for ${projectRef} at ${basePath}`);
             return true;
@@ -960,6 +995,740 @@ export class GatewayService {
             logger.error(`[GatewayService] Failed to setup Master Routes:`, msg);
         }
     }
+
+    async configureFrontendRoute(route: FrontendGatewayRoute): Promise<void> {
+        const serviceName = `svc-frontend-${route.projectRef}-${route.deploymentId}`;
+        const routeName = `route-frontend-${route.projectRef}-${route.deploymentId}`;
+
+        await this.addCorsOriginsForHosts(route.projectRef, route.hosts);
+        await this.kongRequest(`/services/${serviceName}`, "PUT", {
+            name: serviceName,
+            url: `http://127.0.0.1:${route.port}`,
+            connect_timeout: 5000,
+            read_timeout: 60000,
+            write_timeout: 60000,
+        });
+        await this.kongRequest(`/routes/${routeName}`, "PUT", {
+            name: routeName,
+            service: { name: serviceName },
+            paths: ["/"],
+            hosts: route.hosts.length > 0 ? route.hosts : undefined,
+            strip_path: false,
+            preserve_host: true,
+            request_buffering: false,
+            response_buffering: false,
+        });
+    }
+
+    async removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void> {
+        const serviceName = `svc-frontend-${projectRef}-${deploymentId}`;
+        const routeName = `route-frontend-${projectRef}-${deploymentId}`;
+        await this.kongRequest(`/routes/${routeName}`, "DELETE").catch(() => null);
+        await this.kongRequest(`/services/${serviceName}`, "DELETE").catch(() => null);
+    }
+}
+
+type CaddyHeaderValue = string | string[];
+type CaddyRoute = Record<string, unknown>;
+type CaddyConfig = {
+    admin?: Record<string, unknown>;
+    storage?: Record<string, unknown>;
+    apps: {
+        tls?: Record<string, unknown>;
+        http: {
+            servers: Record<string, { listen: string[]; routes: CaddyRoute[] }>;
+        };
+    };
+};
+
+function uniqueStrings(values: Array<string | undefined | null>): string[] {
+    return Array.from(new Set(values.map((v) => String(v || "").trim()).filter(Boolean)));
+}
+
+function caddyRouteId(projectRef: string, kind: string): string {
+    return `route-project-${projectRef}-${kind}`;
+}
+
+function normalizeCaddyHost(host: string): string {
+    return host.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/:\d+$/, "");
+}
+
+function caddyAdminListen(): string {
+    try {
+        const url = new URL(config.caddyAdminUrl);
+        const host = url.hostname === "localhost" ? "127.0.0.1" : url.hostname;
+        const port = url.port || (url.protocol === "https:" ? "443" : "80");
+        return `${host}:${port}`;
+    } catch {
+        return "127.0.0.1:2019";
+    }
+}
+
+function caddyDial(upstream: string): string {
+    return upstream.replace(/^https?:\/\//, "").split("/")[0] || upstream;
+}
+
+function sanitizeCaddyId(value: string): string {
+    return value.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+const CADDY_PROJECT_ROUTE_KINDS = [
+    "rest",
+    "graphql",
+    "auth",
+    "gotrue-well-known",
+    "functions",
+    "storage",
+    "realtime-api",
+    "realtime",
+    "acme",
+    "studio",
+];
+
+export class CaddyGatewayProvider implements GatewayProvider {
+    readonly name = "caddy" as const;
+    private readonly routesById = new Map<string, CaddyRoute>();
+    private readonly certsById = new Map<string, { certificate: string; key: string }>();
+    private readonly rateLimits = new Map<string, { tier: string; second: number; minute: number; hour: number; enabled: boolean }>();
+    private readonly customRateLimits = new Map<string, { second: number; minute: number; hour: number }>();
+    private hydrated = false;
+
+    private async caddyRequest(pathname: string, method = "GET", body?: unknown): Promise<Response> {
+        return fetch(`${config.caddyAdminUrl}${pathname}`, {
+            method,
+            headers: body ? { "Content-Type": "application/json" } : undefined,
+            body: body === undefined ? undefined : JSON.stringify(body),
+        });
+    }
+
+    async checkCaddyConnectivity(): Promise<boolean> {
+        try {
+            const res = await this.caddyRequest("/config/");
+            if (res.ok || res.status === 404) return true;
+            logger.warn(`[CaddyGatewayProvider] Caddy Admin API returned ${res.status}`);
+            return false;
+        } catch (error: unknown) {
+            logger.warn(`[CaddyGatewayProvider] Caddy Admin API is not reachable: ${error instanceof Error ? error.message : String(error)}`);
+            return false;
+        }
+    }
+
+    private baseConfig(): CaddyConfig {
+        const routes = Array.from(this.routesById.values())
+            .sort((a, b) => this.compareRoutesForCaddy(a, b))
+            .map((route) => this.renderRouteForCaddy(route));
+
+        return {
+            admin: { listen: caddyAdminListen() },
+            storage: { module: "file_system", root: config.caddyStateDir },
+            apps: {
+                tls: {
+                    automation: {
+                        on_demand: {
+                            permission: {
+                                module: "http",
+                                endpoint: `http://${config.managementApiInternal}/v1/gateway/caddy/ask`,
+                            },
+                        },
+                        policies: [{ on_demand: true }],
+                    },
+                    certificates: {
+                        load_files: Array.from(this.certsById.values()),
+                    },
+                },
+                http: {
+                    servers: {
+                        supacloud: {
+                            listen: [":80", ":443"],
+                            routes,
+                        },
+                    },
+                },
+            },
+        };
+    }
+
+    private async hydrateFromDisk(): Promise<void> {
+        if (this.hydrated) return;
+        this.hydrated = true;
+
+        try {
+            const raw = await fs.readFile(config.caddyConfigPath, "utf8");
+            const parsed = JSON.parse(raw) as CaddyConfig;
+            const routes = parsed.apps?.http?.servers?.supacloud?.routes;
+            if (Array.isArray(routes)) {
+                for (const route of routes) {
+                    const id = typeof route?.["@id"] === "string" ? route["@id"] : "";
+                    if (!id) continue;
+                    if (!this.routesById.has(id)) this.routesById.set(id, route);
+                    this.hydrateRateLimitFromRoute(id, route);
+                }
+            }
+
+            const certs = (parsed.apps?.tls as Record<string, any> | undefined)?.certificates?.load_files;
+            if (Array.isArray(certs)) {
+                for (const cert of certs) {
+                    if (typeof cert?.certificate !== "string" || typeof cert?.key !== "string") continue;
+                    const id = `disk-${hashStr(`${cert.certificate}:${cert.key}`)}`;
+                    if (!this.certsById.has(id)) {
+                        this.certsById.set(id, { certificate: cert.certificate, key: cert.key });
+                    }
+                }
+            }
+        } catch (error: unknown) {
+            const code = typeof error === "object" && error && "code" in error ? String((error as { code?: unknown }).code) : "";
+            if (code !== "ENOENT") {
+                logger.warn(`[CaddyGatewayProvider] Failed to hydrate existing Caddy config: ${error instanceof Error ? error.message : String(error)}`);
+            }
+        }
+    }
+
+    private hydrateRateLimitFromRoute(routeId: string, route: CaddyRoute): void {
+        const handle = Array.isArray(route.handle) ? route.handle as Record<string, unknown>[] : [];
+        const rateHandler = handle.find((handler) => handler.handler === "rate_limit");
+        const limits = this.extractRateLimits(rateHandler);
+        if (!limits) return;
+
+        if (routeId.startsWith("route-custom-")) {
+            this.customRateLimits.set(routeId, limits);
+            return;
+        }
+
+        const projectRef = this.projectRefFromRouteId(routeId);
+        if (projectRef && !this.rateLimits.has(projectRef)) {
+            this.rateLimits.set(projectRef, { tier: "custom", ...limits, enabled: true });
+        }
+    }
+
+    private extractRateLimits(handler: Record<string, unknown> | undefined): { second: number; minute: number; hour: number } | null {
+        const zones = handler?.rate_limits;
+        if (!zones || typeof zones !== "object") return null;
+
+        const limits = { second: 0, minute: 0, hour: 0 };
+        for (const zone of Object.values(zones as Record<string, any>)) {
+            const window = String(zone?.window || "");
+            const maxEvents = Number(zone?.max_events || 0);
+            if (window === "1s") limits.second = maxEvents;
+            if (window === "1m") limits.minute = maxEvents;
+            if (window === "1h") limits.hour = maxEvents;
+        }
+
+        return limits.second || limits.minute || limits.hour ? limits : null;
+    }
+
+    private projectRefFromRouteId(routeId: string): string | null {
+        if (!routeId.startsWith("route-project-")) return null;
+        for (const kind of CADDY_PROJECT_ROUTE_KINDS) {
+            const suffix = `-${kind}`;
+            if (routeId.endsWith(suffix)) {
+                return routeId.slice("route-project-".length, -suffix.length);
+            }
+        }
+        return null;
+    }
+
+    private compareRoutesForCaddy(a: CaddyRoute, b: CaddyRoute): number {
+        const aid = String(a["@id"] || "");
+        const bid = String(b["@id"] || "");
+        const aCustom = aid.startsWith("route-custom-");
+        const bCustom = bid.startsWith("route-custom-");
+        if (aCustom !== bCustom) return aCustom ? -1 : 1;
+
+        const aPath = Array.isArray((a.match as any)?.[0]?.path) ? String((a.match as any)[0].path[0] || "") : "";
+        const bPath = Array.isArray((b.match as any)?.[0]?.path) ? String((b.match as any)[0].path[0] || "") : "";
+        if (aPath.length !== bPath.length) return bPath.length - aPath.length;
+        return aid.localeCompare(bid);
+    }
+
+    private makeRateLimitHandler(projectRef: string, limits: { second: number; minute: number; hour: number }, suffix = "default"): Record<string, unknown> {
+        const zones: Record<string, unknown> = {};
+        const entries: Array<[string, number, string]> = [
+            ["second", limits.second, "1s"],
+            ["minute", limits.minute, "1m"],
+            ["hour", limits.hour, "1h"],
+        ];
+
+        for (const [name, maxEvents, window] of entries) {
+            if (!Number.isFinite(maxEvents) || maxEvents <= 0) continue;
+            zones[`supacloud_${sanitizeCaddyId(projectRef)}_${sanitizeCaddyId(suffix)}_${name}`] = {
+                key: "{http.request.remote.host}",
+                window,
+                max_events: maxEvents,
+            };
+        }
+
+        return {
+            handler: "rate_limit",
+            rate_limits: zones,
+        };
+    }
+
+    private projectRefForRoute(routeId: string): string | null {
+        for (const projectRef of this.rateLimits.keys()) {
+            if (routeId.startsWith(`route-project-${projectRef}-`)) return projectRef;
+        }
+        return this.projectRefFromRouteId(routeId);
+    }
+
+    private renderRouteForCaddy(route: CaddyRoute): CaddyRoute {
+        const rendered = JSON.parse(JSON.stringify(route)) as CaddyRoute;
+        const id = String(rendered["@id"] || "");
+        const handle = Array.isArray(rendered.handle) ? rendered.handle as Record<string, unknown>[] : [];
+        const withoutRateLimit = handle.filter((handler) => handler.handler !== "rate_limit");
+
+        const customLimits = this.customRateLimits.get(id);
+        let rateLimitHandler: Record<string, unknown> | null = null;
+        if (customLimits) {
+            rateLimitHandler = this.makeRateLimitHandler(id, customLimits, "custom");
+        } else {
+            const projectRef = this.projectRefForRoute(id);
+            const limit = projectRef ? this.rateLimits.get(projectRef) : undefined;
+            const isApiRoute = id.startsWith("route-project-") && !id.endsWith("-acme") && !id.endsWith("-studio");
+            if (projectRef && limit?.enabled && isApiRoute) {
+                rateLimitHandler = this.makeRateLimitHandler(projectRef, limit, "api");
+            }
+        }
+
+        if (rateLimitHandler) {
+            const proxyIndex = withoutRateLimit.findIndex((handler) => handler.handler === "reverse_proxy");
+            const insertAt = proxyIndex >= 0 ? proxyIndex : withoutRateLimit.length;
+            withoutRateLimit.splice(insertAt, 0, rateLimitHandler);
+            rendered.handle = withoutRateLimit;
+        }
+
+        return rendered;
+    }
+
+    private async validateCandidateConfig(candidatePath: string): Promise<void> {
+        try {
+            await fs.access(config.caddyBinaryPath);
+        } catch {
+            return;
+        }
+
+        const result = await $`${config.caddyBinaryPath} validate --config ${candidatePath}`.nothrow().quiet();
+        if (result.exitCode !== 0) {
+            const detail = result.stderr.toString() || result.stdout.toString();
+            throw new Error(`Caddy config validation failed: ${detail.slice(0, 1000)}`);
+        }
+    }
+
+    private async persistAndLoad(): Promise<void> {
+        await this.hydrateFromDisk();
+        const next = this.baseConfig();
+        await fs.mkdir(path.dirname(config.caddyConfigPath), { recursive: true });
+        const tmpPath = `${config.caddyConfigPath}.tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        await fs.writeFile(tmpPath, JSON.stringify(next, null, 2));
+
+        try {
+            await this.validateCandidateConfig(tmpPath);
+            const res = await this.caddyRequest("/load", "POST", next);
+            if (!res.ok) {
+                const text = await res.text().catch(() => "");
+                throw new Error(`Caddy /load failed with ${res.status}: ${text}`);
+            }
+            await fs.rename(tmpPath, config.caddyConfigPath);
+        } catch (error) {
+            await fs.unlink(tmpPath).catch(() => undefined);
+            throw error;
+        }
+    }
+
+    private makeReverseProxy(upstream: string, headers: Record<string, CaddyHeaderValue>, readTimeoutMs?: number): Record<string, unknown> {
+        return {
+            handler: "reverse_proxy",
+            upstreams: [{ dial: caddyDial(upstream) }],
+            flush_interval: -1,
+            headers: {
+                request: {
+                    set: Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value : [value]])),
+                },
+            },
+            transport: {
+                protocol: "http",
+                read_timeout: `${Math.ceil((readTimeoutMs || 500_000) / 1000)}s`,
+                write_timeout: "500s",
+            },
+        };
+    }
+
+    private makeCorsHandler(origins: string[]): Record<string, unknown> {
+        return {
+            handler: "headers",
+            response: {
+                set: {
+                    "Access-Control-Allow-Origin": origins.length === 1 ? origins : ["{http.request.header.Origin}"],
+                    "Access-Control-Allow-Methods": ["GET, POST, PUT, PATCH, DELETE, OPTIONS"],
+                    "Access-Control-Allow-Headers": [DEFAULT_CORS_HEADERS.join(", ")],
+                    "Access-Control-Expose-Headers": [DEFAULT_CORS_EXPOSED.join(", ")],
+                    "Access-Control-Max-Age": ["86400"],
+                    "Vary": ["Origin, Access-Control-Request-Headers, Accept-Encoding"],
+                },
+            },
+        };
+    }
+
+    private makeRoute(opts: {
+        id: string;
+        hosts: string[];
+        path: string;
+        upstream: string;
+        projectRef: string;
+        stripPrefix?: string;
+        rewriteUri?: string;
+        headers?: string[];
+        corsOrigins?: string[];
+        readTimeout?: number;
+    }): CaddyRoute {
+        const requestHeaders: Record<string, CaddyHeaderValue> = {
+            "X-Project-Ref": opts.projectRef,
+            "X-Forwarded-Host": "{http.request.host}",
+        };
+        for (const header of opts.headers || []) {
+            const [key, ...rest] = header.split(":");
+            if (key && rest.length > 0) requestHeaders[key.trim()] = rest.join(":").trim();
+        }
+
+        const handle: Record<string, unknown>[] = [];
+        if (opts.corsOrigins) handle.push(this.makeCorsHandler(opts.corsOrigins));
+        if (opts.rewriteUri) handle.push({ handler: "rewrite", uri: opts.rewriteUri });
+        else if (opts.stripPrefix) handle.push({ handler: "rewrite", strip_path_prefix: opts.stripPrefix });
+        handle.push(this.makeReverseProxy(opts.upstream, requestHeaders, opts.readTimeout));
+
+        return {
+            "@id": opts.id,
+            match: [{
+                host: uniqueStrings(opts.hosts.map(normalizeCaddyHost)),
+                path: [opts.path],
+            }],
+            handle,
+            terminal: true,
+        };
+    }
+
+    private async putRoute(route: CaddyRoute): Promise<void> {
+        const id = String(route["@id"]);
+        this.routesById.set(id, route);
+        await this.persistAndLoad();
+    }
+
+    private async removeRoutes(ids: string[]): Promise<void> {
+        for (const id of ids) this.routesById.delete(id);
+        await this.persistAndLoad();
+    }
+
+    async setupJwt(_projectRef: string, _jwtSecret: string): Promise<boolean> {
+        // Supabase-compatible upstreams validate JWTs; Caddy remains the edge data plane.
+        return true;
+    }
+
+    async enableJwtAuth(_projectRef: string): Promise<boolean> {
+        return true;
+    }
+
+    async setIpRestriction(projectRef: string, allowedIps: string[]): Promise<boolean> {
+        logger.info(`[CaddyGatewayProvider] IP restriction is tracked by policy layer for ${projectRef}`, { allowedIps });
+        return true;
+    }
+
+    async getRateLimit(projectRef: string): Promise<{ tier: string; second: number; minute: number; hour: number; enabled: boolean }> {
+        return this.rateLimits.get(projectRef) || { tier: "none", second: 0, minute: 0, hour: 0, enabled: false };
+    }
+
+    async setRateLimit(projectRef: string, opts: string | { second?: number; minute?: number; hour?: number } = "free"): Promise<boolean> {
+        const limits = typeof opts === "string" ? getRateLimitConfig(opts) : {
+            second: opts.second ?? 10,
+            minute: opts.minute ?? 100,
+            hour: opts.hour ?? 1000,
+        };
+        this.rateLimits.set(projectRef, {
+            tier: typeof opts === "string" ? opts : "custom",
+            ...limits,
+            enabled: true,
+        });
+        await this.persistAndLoad();
+        return true;
+    }
+
+    async setCustomRouteRateLimit(projectRef: string, basePath: string, limits: { second?: number; minute?: number; hour?: number }): Promise<boolean> {
+        await this.hydrateFromDisk();
+        const routeId = `route-custom-${projectRef}-${hashStr(basePath)}`;
+        const parent = this.cloneRouteForCustomLimit(projectRef, basePath, routeId);
+        if (!parent) {
+            logger.error(`[CaddyGatewayProvider] Cannot determine upstream route for custom path: ${basePath}`);
+            return false;
+        }
+
+        this.routesById.set(routeId, parent);
+        this.customRateLimits.set(routeId, {
+            second: Math.min(limits.second ?? 100, 100),
+            minute: Math.min(limits.minute ?? 2000, 2000),
+            hour: Math.min(limits.hour ?? 50000, 50000),
+        });
+        await this.persistAndLoad();
+        return true;
+    }
+
+    async removeCustomRouteRateLimit(projectRef: string, basePath: string): Promise<boolean> {
+        await this.hydrateFromDisk();
+        const routeId = `route-custom-${projectRef}-${hashStr(basePath)}`;
+        this.customRateLimits.delete(routeId);
+        this.routesById.delete(routeId);
+        await this.persistAndLoad();
+        return true;
+    }
+
+    private cloneRouteForCustomLimit(projectRef: string, basePath: string, routeId: string): CaddyRoute | null {
+        const normalizedPath = basePath.startsWith("/") ? basePath : `/${basePath}`;
+        const parentKind =
+            normalizedPath.startsWith("/rest/v1") ? "rest" :
+            normalizedPath.startsWith("/graphql/v1") ? "graphql" :
+            normalizedPath.startsWith("/auth/v1") ? "auth" :
+            normalizedPath.startsWith("/functions/v1") ? "functions" :
+            normalizedPath.startsWith("/storage/v1") ? "storage" :
+            normalizedPath.startsWith("/realtime/v1/api") ? "realtime-api" :
+            normalizedPath.startsWith("/realtime/v1") ? "realtime" :
+            "";
+        if (!parentKind) return null;
+
+        const parent = this.routesById.get(caddyRouteId(projectRef, parentKind));
+        if (!parent) return null;
+
+        const cloned = JSON.parse(JSON.stringify(parent)) as CaddyRoute;
+        cloned["@id"] = routeId;
+        const match = Array.isArray(cloned.match) ? cloned.match[0] as Record<string, unknown> | undefined : undefined;
+        if (match) {
+            match.path = [normalizedPath.endsWith("*") ? normalizedPath : `${normalizedPath.replace(/\/$/, "")}*`];
+        }
+        return cloned;
+    }
+
+    async setCors(projectRef: string, _origins: string[] = DEFAULT_CORS_ORIGINS): Promise<boolean> {
+        logger.debug(`[CaddyGatewayProvider] CORS is rendered into route JSON for ${projectRef}`);
+        await this.persistAndLoad();
+        return true;
+    }
+
+    async addCorsOriginsForHosts(projectRef: string, hosts: string[]): Promise<boolean> {
+        return this.setCors(projectRef, buildTenantCorsOrigins(projectRef, undefined, hosts));
+    }
+
+    async setupUpstream(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions): Promise<{ success: boolean; error?: string }> {
+        try {
+            const hostIp = await this.detectHostIp();
+            const routingConfig = normalizeProjectRoutingConfig(projectRouting);
+            const hosts = uniqueStrings([
+                `${projectRef}.api.${config.baseDomain}`,
+                resolveProjectApiHost(projectRef, routingConfig),
+            ]);
+            const studioHosts = uniqueStrings([
+                `studio-${projectRef}.${config.baseDomain}`,
+                resolveProjectStudioHost(projectRef, routingConfig),
+            ]);
+            const corsOrigins = buildTenantCorsOrigins(projectRef, routingConfig, [...hosts, ...studioHosts]);
+
+            const routes = [
+                this.makeRoute({ id: caddyRouteId(projectRef, "rest"), hosts, path: "/rest/v1*", upstream: `${hostIp}:${pgrstPort}`, projectRef, stripPrefix: "/rest/v1", corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "graphql"), hosts, path: "/graphql/v1*", upstream: `${hostIp}:${pgrstPort}`, projectRef, rewriteUri: "/rpc/graphql", headers: ["Content-Profile:graphql_public", "Accept-Profile:graphql_public"], corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "auth"), hosts, path: "/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, stripPrefix: "/auth/v1", corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "gotrue-well-known"), hosts, path: "/.well-known/oauth-authorization-server/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "functions"), hosts, path: "/functions/v1*", upstream: `${hostIp}:${config.port}`, projectRef, readTimeout: 500_000, corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "storage"), hosts, path: "/storage/v1*", upstream: `${hostIp}:${opts?.storagePort || config.port}`, projectRef, corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "realtime-api"), hosts, path: "/realtime/v1/api*", upstream: `${hostIp}:${config.port}`, projectRef, readTimeout: 60_000, corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "realtime"), hosts, path: "/realtime/v1/websocket*", upstream: `${hostIp}:${config.port}`, projectRef, readTimeout: 86_400_000, corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "acme"), hosts: [...hosts, ...studioHosts], path: "/.well-known/acme-challenge*", upstream: `${hostIp}:${config.port}`, projectRef, corsOrigins }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "studio"), hosts: studioHosts, path: "/*", upstream: `${hostIp}:${config.port}`, projectRef, headers: ["x-supacloud-ui-host:studio"], corsOrigins }),
+            ];
+
+            for (const route of routes) this.routesById.set(String(route["@id"]), route);
+            await this.persistAndLoad();
+            logger.info(`[CaddyGatewayProvider] Routes registered for ${projectRef}`);
+            return { success: true };
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            logger.error(`[CaddyGatewayProvider] Failed to setup upstream for ${projectRef}:`, message);
+            return { success: false, error: message };
+        }
+    }
+
+    async addProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean> {
+        await this.hydrateFromDisk();
+        const existingKinds = ["rest", "graphql", "auth", "gotrue-well-known", "functions", "storage", "realtime-api", "realtime", "acme"];
+        for (const kind of existingKinds) {
+            const route = this.routesById.get(caddyRouteId(projectRef, kind));
+            const match = Array.isArray(route?.match) ? route.match[0] as Record<string, unknown> | undefined : undefined;
+            if (match) match.host = uniqueStrings([...(Array.isArray(match.host) ? match.host as string[] : []), ...apiDomains]);
+        }
+        const studio = this.routesById.get(caddyRouteId(projectRef, "studio"));
+        const studioMatch = Array.isArray(studio?.match) ? studio.match[0] as Record<string, unknown> | undefined : undefined;
+        if (studioMatch) studioMatch.host = uniqueStrings([...(Array.isArray(studioMatch.host) ? studioMatch.host as string[] : []), ...studioDomains]);
+        await this.persistAndLoad();
+        return true;
+    }
+
+    async removeProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean> {
+        await this.hydrateFromDisk();
+        const remove = new Set([...apiDomains, ...studioDomains].map(normalizeCaddyHost));
+        for (const route of this.routesById.values()) {
+            const id = String(route["@id"] || "");
+            if (!id.includes(`-${projectRef}-`)) continue;
+            const match = Array.isArray(route.match) ? route.match[0] as Record<string, unknown> | undefined : undefined;
+            if (match && Array.isArray(match.host)) {
+                match.host = (match.host as string[]).filter((host) => !remove.has(normalizeCaddyHost(host)));
+            }
+        }
+        await this.persistAndLoad();
+        return true;
+    }
+
+    async removeService(projectRef: string): Promise<{ success: boolean; error?: string }> {
+        await this.hydrateFromDisk();
+        const ids = Array.from(this.routesById.keys()).filter((id) => id.includes(`-${projectRef}-`) || id.endsWith(`-${projectRef}`));
+        await this.removeRoutes(ids);
+        return { success: true };
+    }
+
+    async addUpstreamTarget(_projectRef: string, _replicaIp: string): Promise<{ success: boolean; error?: string }> {
+        return { success: true };
+    }
+
+    async removeUpstreamTarget(_projectRef: string, _replicaIp: string): Promise<{ success: boolean; error?: string }> {
+        return { success: true };
+    }
+
+    async applyConfig(projectRef: string, gatewayConfig: GatewayConfig): Promise<{ success: boolean; message: string }> {
+        if (gatewayConfig.jwtSecret) await this.setupJwt(projectRef, gatewayConfig.jwtSecret);
+        if (gatewayConfig.rateLimitTier) await this.setRateLimit(projectRef, gatewayConfig.rateLimitTier);
+        if (gatewayConfig.corsOrigins) {
+            const originsArray = gatewayConfig.corsOrigins.split(",").map((s) => s.trim()).filter(Boolean);
+            await this.setCors(projectRef, originsArray.length > 0 ? originsArray : DEFAULT_CORS_ORIGINS);
+        }
+        if (gatewayConfig.jwtEnabled) await this.enableJwtAuth(projectRef);
+        return { success: true, message: "Gateway configuration updated" };
+    }
+
+    async rebuildAllTenantConfigs(): Promise<{ success: boolean; updated: number; errors: string[] }> {
+        const errors: string[] = [];
+        let updated = 0;
+        try {
+            const projects = await sql`
+                SELECT ref, config FROM projects
+                WHERE status != 'deleted' AND deleted_at IS NULL
+            `;
+            for (const project of projects) {
+                const ref = project.ref as string;
+                const cfg = normalizeProjectConfig(project.config);
+                const pgrstPort = cfg.postgrest_port as number | undefined;
+                const gotruePort = cfg.gotrue_port as number | undefined;
+                if (!pgrstPort || !gotruePort) {
+                    errors.push(`${ref}: missing port config`);
+                    continue;
+                }
+                const result = await this.setupUpstream(ref, pgrstPort, gotruePort, cfg);
+                if (result.success) updated++;
+                else errors.push(`${ref}: ${result.error || "unknown error"}`);
+            }
+            return { success: errors.length === 0, updated, errors };
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return { success: false, updated, errors: [...errors, msg] };
+        }
+    }
+
+    async setupMasterRoutes(): Promise<void> {
+        const hostIp = await this.detectHostIp();
+        const hosts = uniqueStrings([hostIp, config.baseDomain]);
+        this.routesById.set("route-system-management-api", this.makeRoute({
+            id: "route-system-management-api",
+            hosts,
+            path: "/api*",
+            upstream: `${hostIp}:${config.port}`,
+            projectRef: "_management",
+            stripPrefix: "/api",
+            corsOrigins: buildTenantCorsOrigins("_management", undefined, hosts),
+        }));
+        this.routesById.set("route-system-studio-root", this.makeRoute({
+            id: "route-system-studio-root",
+            hosts,
+            path: "/*",
+            upstream: `${hostIp}:${config.port}`,
+            projectRef: "_system",
+        }));
+        await this.persistAndLoad();
+    }
+
+    async upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }> {
+        const snis = uniqueStrings(opts.snis.map(normalizeCaddyHost));
+        if (!opts.cert.trim() || !opts.key.trim()) return { success: false, error: "Certificate and private key are required" };
+        if (snis.length === 0) return { success: false, error: "At least one SNI is required" };
+        const certificateId = opts.existingCertificateId || `caddy-${opts.projectRef}-${hashStr(snis.join(","))}`;
+        const certDir = path.join(config.caddyStateDir, "manual-certs", opts.projectRef);
+        await fs.mkdir(certDir, { recursive: true });
+        const certPath = path.join(certDir, `${certificateId}.crt`);
+        const keyPath = path.join(certDir, `${certificateId}.key`);
+        await fs.writeFile(certPath, opts.cert);
+        await fs.writeFile(keyPath, opts.key, { mode: 0o600 });
+        this.certsById.set(certificateId, { certificate: certPath, key: keyPath });
+        await this.persistAndLoad();
+        return { success: true, certificateId };
+    }
+
+    async configureFrontendRoute(route: FrontendGatewayRoute): Promise<void> {
+        await this.addCorsOriginsForHosts(route.projectRef, route.hosts);
+        await this.putRoute(this.makeRoute({
+            id: `route-frontend-${route.projectRef}-${route.deploymentId}`,
+            hosts: route.hosts,
+            path: "/*",
+            upstream: `127.0.0.1:${route.port}`,
+            projectRef: route.projectRef,
+            readTimeout: 60_000,
+        }));
+    }
+
+    async removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void> {
+        await this.removeRoutes([`route-frontend-${projectRef}-${deploymentId}`]);
+    }
+
+    private async detectHostIp(): Promise<string> {
+        if (config.dockerHostIp) return config.dockerHostIp;
+        for (const iface of ["podman1", "docker0"]) {
+            const result = await $`ip addr show ${iface}`.nothrow().quiet();
+            if (result.exitCode === 0) {
+                const match = result.text().match(/inet (\d+\.\d+\.\d+\.\d+)/);
+                if (match) return match[1];
+            }
+        }
+        return "127.0.0.1";
+    }
+}
+
+export class GatewayService implements GatewayProvider {
+    readonly name = config.gatewayProvider;
+    private readonly provider: GatewayProvider = config.gatewayProvider === "kong"
+        ? new KongGatewayProvider()
+        : new CaddyGatewayProvider();
+
+    setupJwt(projectRef: string, jwtSecret: string) { return this.provider.setupJwt(projectRef, jwtSecret); }
+    enableJwtAuth(projectRef: string) { return this.provider.enableJwtAuth(projectRef); }
+    setIpRestriction(projectRef: string, allowedIps: string[]) { return this.provider.setIpRestriction(projectRef, allowedIps); }
+    getRateLimit(projectRef: string) { return this.provider.getRateLimit(projectRef); }
+    setRateLimit(projectRef: string, opts?: string | { second?: number; minute?: number; hour?: number }) { return this.provider.setRateLimit(projectRef, opts); }
+    setCustomRouteRateLimit(projectRef: string, basePath: string, limits: { second?: number; minute?: number; hour?: number }) { return this.provider.setCustomRouteRateLimit(projectRef, basePath, limits); }
+    removeCustomRouteRateLimit(projectRef: string, basePath: string) { return this.provider.removeCustomRouteRateLimit(projectRef, basePath); }
+    setCors(projectRef: string, origins?: string[]) { return this.provider.setCors(projectRef, origins); }
+    addCorsOriginsForHosts(projectRef: string, hosts: string[]) { return this.provider.addCorsOriginsForHosts(projectRef, hosts); }
+    setupUpstream(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions) { return this.provider.setupUpstream(projectRef, pgrstPort, gotruePort, projectRouting, opts); }
+    addProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]) { return this.provider.addProjectDomains(projectRef, apiDomains, studioDomains); }
+    removeProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]) { return this.provider.removeProjectDomains(projectRef, apiDomains, studioDomains); }
+    removeService(projectRef: string) { return this.provider.removeService(projectRef); }
+    addUpstreamTarget(projectRef: string, replicaIp: string) { return this.provider.addUpstreamTarget(projectRef, replicaIp); }
+    removeUpstreamTarget(projectRef: string, replicaIp: string) { return this.provider.removeUpstreamTarget(projectRef, replicaIp); }
+    applyConfig(projectRef: string, gatewayConfig: GatewayConfig) { return this.provider.applyConfig(projectRef, gatewayConfig); }
+    rebuildAllTenantConfigs() { return this.provider.rebuildAllTenantConfigs(); }
+    setupMasterRoutes() { return this.provider.setupMasterRoutes(); }
+    upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }) { return this.provider.upsertCertificateForSnis(opts); }
+    configureFrontendRoute(route: FrontendGatewayRoute) { return this.provider.configureFrontendRoute(route); }
+    removeFrontendRoute(projectRef: string, deploymentId: string) { return this.provider.removeFrontendRoute(projectRef, deploymentId); }
 }
 
 export const gatewayService = new GatewayService();

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -454,14 +454,14 @@ export class ProjectService {
       gotrueStatus,
       realtimeSystemd,
       storagePerTenant,
-      kongSystemd,
+      gatewaySystemd,
       realtimeDocker,
     ] = await Promise.all([
       checkService(`supacloud-pgrst@${ref}`),
       checkService(`supacloud-gotrue@${ref}`),
       checkService("supacloud-realtime"),
       checkService(`supacloud-storage@${ref}`),
-      checkService("kong"),
+      checkService(config.gatewayProvider === "kong" ? "kong" : "supacloud-caddy"),
       checkContainer("supacloud-realtime"),
     ]);
 
@@ -470,8 +470,8 @@ export class ProjectService {
     if (realtimeSystemd === "ACTIVE_HEALTHY") {
       realtimeStatus = "ACTIVE_HEALTHY";
     } else {
-      // Fall back to the global Realtime container, but only when native Kong is healthy.
-      if (kongSystemd === "ACTIVE_HEALTHY") {
+      // Fall back to the global Realtime container, but only when the public gateway is healthy.
+      if (gatewaySystemd === "ACTIVE_HEALTHY") {
         if (realtimeDocker === "ACTIVE_HEALTHY") {
           const { realtimeService } = await import("./realtime.service");
           const hasTenant = await realtimeService.getTenant(ref);
@@ -512,7 +512,7 @@ export class ProjectService {
         { name: "GoTrue", status: gotrueStatus },
         { name: "Realtime", status: realtimeStatus },
         { name: "Storage", status: storageStatus },
-        { name: "Kong", status: kongSystemd },
+        { name: config.gatewayProvider === "kong" ? "Kong" : "Caddy", status: gatewaySystemd },
       ],
     };
   }

--- a/packages/management-api/src/services/router.service.ts
+++ b/packages/management-api/src/services/router.service.ts
@@ -31,11 +31,10 @@ export class RouterService {
       const apiDomain = domains?.apiDomain || resolveProjectApiHost(projectRef, null);
       const studioDomain = domains?.studioDomain || resolveProjectStudioHost(projectRef, null);
       
-      // We map the domain through Native Kong API using GatewayService
-      // This function now delegates domain registration to Kong
+      // Domain registration is owned by the selected gateway provider.
       await gatewayService.addProjectDomains(projectRef, [apiDomain], [studioDomain]);
 
-      logger.info(`Kong routes dynamically added for ${projectRef} (api: ${apiDomain})`);
+      logger.info(`Gateway routes dynamically added for ${projectRef} (api: ${apiDomain})`);
       return { success: true };
     } catch (error: unknown) {
       return { success: false, error: (error instanceof Error ? error.message : String(error)) };
@@ -45,7 +44,7 @@ export class RouterService {
   async removeRoute(projectRef: string): Promise<{ success: boolean; error?: string }> {
     try {
       await gatewayService.removeService(projectRef);
-      logger.info(`Kong routes explicitly removed for ${projectRef}`);
+      logger.info(`Gateway routes explicitly removed for ${projectRef}`);
       return { success: true };
     } catch (error: unknown) {
       return { success: false, error: (error instanceof Error ? error.message : String(error)) };
@@ -77,7 +76,7 @@ export class RouterService {
   async updateNetworkRestrictions(projectRef: string, allowedIps: string[]): Promise<{ success: boolean; error?: string }> {
     try {
       await gatewayService.setIpRestriction(projectRef, allowedIps);
-      logger.info(`Kong Network IP restrictions explicitly updated for ${projectRef}`);
+      logger.info(`Gateway network IP restrictions explicitly updated for ${projectRef}`);
       return { success: true };
     } catch (error: unknown) {
         return { success: false, error: (error instanceof Error ? error.message : String(error)) };

--- a/packages/management-api/src/services/task.worker.ts
+++ b/packages/management-api/src/services/task.worker.ts
@@ -211,7 +211,7 @@ export class TaskWorker {
                         return false;
                     }
 
-                    // Register this tenant's independent upstream in Kong (declarative)
+                    // Register this tenant's independent upstream in the configured gateway
                     const upstreamRes = await databaseService.setupUpstream(project_ref, port, gotruePort);
                     if (!upstreamRes.success) {
                         logger.error(`[TaskWorker] Failed to setup Kong upstream for ${project_ref}`);
@@ -280,12 +280,12 @@ export class TaskWorker {
                         logger.info(`[TaskWorker] Running in CI mode, skipping actual gateway provision for ${project_ref}`);
                         return true;
                     }
-                    // Apply JWT credentials, CORS, and rate limiting via Kong Admin API
+                    // Apply JWT credentials, CORS, and rate limiting through the gateway provider
                     try {
                         await gatewayService.setupJwt(project_ref, project.jwt_secret);
                         await gatewayService.setCors(project_ref);
                         await gatewayService.setRateLimit(project_ref, "free");
-                        logger.info(`[TaskWorker] Kong gateway plugins configured for ${project_ref}`);
+                        logger.info(`[TaskWorker] Gateway policy configured for ${project_ref}`);
                         return true;
                     } catch (err: unknown) {
                         logger.error(`[TaskWorker] Gateway config failed for ${project_ref}`, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -2274,7 +2274,11 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
                 { id: "gotrue", name: "GoTrue", unit: `supacloud-gotrue@${ref}` },
                 { id: "realtime", name: "Realtime", unit: "supacloud-realtime" },
                 { id: "storage", name: "Storage", unit: "supacloud-storage" },
-                { id: "kong", name: "Kong", unit: "kong" },
+                {
+                    id: config.gatewayProvider === "kong" ? "kong" : "caddy",
+                    name: config.gatewayProvider === "kong" ? "Kong" : "Caddy",
+                    unit: config.gatewayProvider === "kong" ? "kong" : "supacloud-caddy",
+                },
             ];
 
         const [postgrest, dbHealth, storageHealth, ...otherSystemResults] = await Promise.allSettled([
@@ -2313,8 +2317,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 
         const postgresql = this.systemServiceEntry(ref, "postgresql", "PostgreSQL", dbStatus);
         const storage = this.systemServiceEntry(ref, "storage", "Storage", storageStatus);
-        const [gotrue, realtime, kong] = otherEntries;
-        return [postgresql, postgrestEntry, gotrue, realtime, storage, kong];
+        const [gotrue, realtime, gateway] = otherEntries;
+        return [postgresql, postgrestEntry, gotrue, realtime, storage, gateway];
     }
 
     public async restartRuntime(ref: string): Promise<RuntimeStatus> {

--- a/packages/management-api/src/utils/bun-static-serve.ts
+++ b/packages/management-api/src/utils/bun-static-serve.ts
@@ -119,7 +119,7 @@ export function createFetchHandler(root: string) {
       return new Response("Bad Request", { status: 400 });
     }
 
-    // Readiness probe for health checks (Kong / systemd ExecStartPre)
+    // Readiness probe for gateway/systemd cutover checks.
     if (path === "/healthz") {
       return new Response("ok", { status: 200, headers: { "Content-Type": "text/plain" } });
     }

--- a/packages/management-api/tests/unit/frontend.service.test.ts
+++ b/packages/management-api/tests/unit/frontend.service.test.ts
@@ -12,8 +12,9 @@ beforeEach(() => {
   globalThis.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({ data: [] })))) as unknown as typeof fetch;
 });
 
-afterEach(() => {
+afterEach(async () => {
   globalThis.fetch = originalFetch;
+  await rm("/tmp/supacloud-caddy-test", { recursive: true, force: true });
 });
 
 describe("FrontendService DNS records", () => {
@@ -83,9 +84,9 @@ describe("FrontendService static binary resolution", () => {
   });
 });
 
-describe("FrontendService Kong routing", () => {
-  test("disables buffering on frontend root routes", async () => {
-    const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
+describe("FrontendService gateway routing", () => {
+  test("registers frontend root route through the gateway provider", async () => {
+    const calls: Array<{ url: string; method: string; body: any }> = [];
 
     globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string"
@@ -94,10 +95,10 @@ describe("FrontendService Kong routing", () => {
           ? input.toString()
           : input.url;
       const method = init?.method || "GET";
-      let body: Record<string, unknown> | null = null;
+      let body: any = null;
       if (typeof init?.body === "string" && init.body.length > 0) {
         try {
-          body = JSON.parse(init.body) as Record<string, unknown>;
+          body = JSON.parse(init.body);
         } catch {
           body = null;
         }
@@ -125,20 +126,16 @@ describe("FrontendService Kong routing", () => {
       deployment_url: "https://site.example.com",
     };
 
-    await service.configureKongRoute(deployment, "/tmp/build", false);
+    await service.configureGatewayRoute(deployment, "/tmp/build", false);
 
-    const routeCall = calls.find(
-      (call) => call.method === "PUT" && call.url.includes("/routes/route-frontend-proj123-0000002a")
-    );
+    const loadCall = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+    const routes = loadCall?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+    const route = routes.find((item: any) => item["@id"] === "route-frontend-proj123-0000002a");
 
-    expect(routeCall).toBeDefined();
-    expect(routeCall?.body).toMatchObject({
-      paths: ["/"],
-      hosts: ["site.example.com", "www.example.com"],
-      strip_path: false,
-      preserve_host: true,
-      request_buffering: false,
-      response_buffering: false,
-    });
+    expect(route).toBeDefined();
+    expect(route?.match?.[0]?.path).toEqual(["/*"]);
+    expect(route?.match?.[0]?.host).toEqual(["site.example.com", "www.example.com"]);
+    expect(route?.handle?.at(-1)?.flush_interval).toBe(-1);
+    expect(route?.handle?.at(-1)?.upstreams?.[0]?.dial).toBe("127.0.0.1:30042");
   });
 });

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -1,53 +1,86 @@
-import { describe, test, expect, mock } from "bun:test";
-import { DEFAULT_CORS_HEADERS, buildTenantCorsOrigins, gatewayService } from "../../src/services/gateway.service";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { rm } from "node:fs/promises";
+import { config } from "../../src/config";
+import {
+    CaddyGatewayProvider,
+    DEFAULT_CORS_HEADERS,
+    buildTenantCorsOrigins,
+    gatewayService,
+    KongGatewayProvider,
+} from "../../src/services/gateway.service";
 
-/** Type-safe mock for globalThis.fetch using two-step cast */
-function mockFetch(handler: () => Promise<Response>): void {
-    globalThis.fetch = mock(handler) as unknown as typeof fetch;
+function captureFetch(calls: Array<{ url: string; method: string; body: any }>) {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        const method = init?.method || "GET";
+        let body: any = null;
+        if (typeof init?.body === "string" && init.body.length > 0) {
+            try { body = JSON.parse(init.body); } catch { body = init.body; }
+        }
+        calls.push({ url, method, body });
+        return Promise.resolve(new Response(JSON.stringify({ id: "cert_123", data: [] })));
+    }) as unknown as typeof fetch;
+    return () => { globalThis.fetch = originalFetch; };
 }
 
-describe("GatewayService", () => {
-    test("applyConfig should combine multiple calls", async () => {
-        const originalFetch = globalThis.fetch;
-        mockFetch(() => Promise.resolve(new Response(JSON.stringify({ data: [] }))));
+async function cleanCaddyTmp() {
+    await rm("/tmp/supacloud-caddy-test", { recursive: true, force: true });
+}
 
-        const result = await gatewayService.applyConfig("testref123", {
-            rateLimitTier: 'enterprise',
-            jwtEnabled: true
-        });
+const VALID_TEST_CERT = `-----BEGIN CERTIFICATE-----
+MIIDFTCCAf2gAwIBAgIUbK5x4GDxAV2j+g2vjuPbCwxaJqowDQYJKoZIhvcNAQEL
+BQAwGjEYMBYGA1UEAwwPYXBpLmV4YW1wbGUuY29tMB4XDTI2MDUyNjE2NDExNVoX
+DTI2MDYyNTE2NDExNVowGjEYMBYGA1UEAwwPYXBpLmV4YW1wbGUuY29tMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtkg5Df0ZNT7QLKelt7pcbBPssuT6
+qISVvGSmk/TW5kt2v1TfBYUoIJe7mRB0muq4r9i3IvxuysRTbrEEzelOytH8kY3e
++049kmxE+OnoAn7MyJ/BBkR870CZaMfyCvQ4NSs1DGCwPd+nrq01nykiHKcWzDfb
+TAUWjtuWSoezEiwmz6U9Pkh1qk+p2lernD3aUKUyWbCttfP3EL1sNQaLu4ZoOKSg
+mkih7IIs+FRL9p243qnv4NEC81gGKgzVtEefP9OJUJW/q8t9x6JaGJtciJ/3jsjC
+i31J2GrKLe3sP0JMptz/491YQv2LHRKXeHlfLLBdkp/0PBnruWPgRUPL0wIDAQAB
+o1MwUTAdBgNVHQ4EFgQU9uaVrNJN9jsecy5i0qxF9siJIQ4wHwYDVR0jBBgwFoAU
+9uaVrNJN9jsecy5i0qxF9siJIQ4wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAAHOvIwG5/6r2I4MV2oirrsFZc0Wcgl5LEfe+qEZ44iRlDrDLxM1d
+FtV47e2YuOIXCDP5bulYAOc6tXmwWJp4UsGVdcIrqSWxRYQHbQb4rj/WbCuoi6Or
+lq5IlYEcF6tII159V/w27STx6PtXRrnZlO5M6vZANkFnwa1/xH5Fl4AeA0ldQbV6
+UrWoTu4mlV79iJj4eVsn/VOphqz0Tx4cDTOLjKb+4luSnX0WNkjFZY8G+bZMjfrj
+WFHJEHW9P9SZ21+5kAXMdGmXXRMQy3V8pcVd8UC8ZCduKh5Kk/TBJGPTsivzy/cq
+Fl3Tj7s2iD5pVVCKKcD0lig/xQRcC+D8Vg==
+-----END CERTIFICATE-----`;
 
-        expect(result.success).toBe(true);
-        expect(result.message).toBe("Gateway configuration updated");
+const VALID_TEST_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC2SDkN/Rk1PtAs
+p6W3ulxsE+yy5PqohJW8ZKaT9NbmS3a/VN8FhSggl7uZEHSa6riv2Lci/G7KxFNu
+sQTN6U7K0fyRjd77Tj2SbET46egCfszIn8EGRHzvQJlox/IK9Dg1KzUMYLA936eu
+rTWfKSIcpxbMN9tMBRaO25ZKh7MSLCbPpT0+SHWqT6naV6ucPdpQpTJZsK218/cQ
+vWw1Bou7hmg4pKCaSKHsgiz4VEv2nbjeqe/g0QLzWAYqDNW0R58/04lQlb+ry33H
+oloYm1yIn/eOyMKLfUnYasot7ew/Qkym3P/j3VhC/YsdEpd4eV8ssF2Sn/Q8Geu5
+Y+BFQ8vTAgMBAAECggEADiBkw4/E31qB2aQYdLetp/aXVnnmbx7vV81ZF4hXCzv3
+9PYH3q6mIHiB4mfjEYp1S7N45e44S+CRMrfnTmnxYEiL0V/0UveKUAmyArRl9aOM
+DVRMKkcug4A3I2azfGPW40/46X+oyPLHVQM5b59JdH0CiEsf5LFUQTgFWrtPhm3h
+3ytiCwTd4sppCz4iuUcnKa7CV9BBHI11n6QsL10wCoQusiN4KP90qd+fB0/CQX8S
+cyE/0RRsTi0BeB9EtsQxuF/PPqxGfKNustd9CJjdSxtGDaUrlTZ0Om3TfTP7Ao73
+pbc+EQCmvFUPn1dUPoqUJB+FKHcon0tyo1piHq4a8QKBgQDvbCPGiQhvOXx4XNLg
+1Jbm2KfiqMNTLp9IRQIIfp6Qq51CeK08VPu1SinhQKakmP+xi9/SyxeDHF76LBz1
+OWWd4r217UoevFoYDTSdIdKpNklUu4Cr2RCsW5odcZT4IjjUb/mscW0+Uxpms7JH
+bqDpCHSuEVkfn+DakhVAZRWraQKBgQDC5z95gqY/nZ5t10dNJzlAJBJHJOAzukKU
+OmDSrJvtKmlp+u4nG4kFxNtmiR25C2R4a0AcdqOBBOzd94yKIwiw1yLZXJDGPQSo
+5wbFEx2vvpOqsT91SQdIHBZ85raXvy/EFnvooSA5inxFTg9VvZgC4ivLVBlcrVtL
+YThFmYDB2wKBgACnZ/Wb3DUJkCh4AG9yxTK+Nr8svNPWVcMJxTamueIlRdmvoLGA
+feuB11lxJsNeU5x1iFf4DAlko3HFexLEZF2pB+GeU0yAMTLNnm4rcHrb1hlwJarS
+ffQqj+IytDh1R3h1EdaBvM2lxnWvWfZN/AyG5GKxU2/9rMyMB5jUbdm5AoGBAJue
+2OfEkcmpqJ47jgrkjqnQI2f64alrx01jb3vHppivjIu6d/1x1u5sSGKOiNT/a7Fa
+sU4IzHRv4lE5H1YMsxvAK2sypcYjYl0aWiVxJfr1SCK6c9jJ/q5s/uerr49qcFE5
+QqZ0QK6xDJipw0TKpV1oCV/IPpfpM0P01GF+N3iRAoGAR2Va6a8YaJpSwp/5XsRP
+K2wyK+c1cuXLwT76F9hLSDA9rcF80RHmBpBSeP2aG8Nd361hto35VLiPdBvjXJxn
+QCga9rEA9mgt+9AWvlXa+H7LWic9kvhtw9QMl4vWMccuFKRt77VTjs146EoXVqaX
+AwNbYPcbTU4kMp3H5JKzKdI=
+-----END PRIVATE KEY-----`;
 
-        globalThis.fetch = originalFetch;
-    });
-
-    test("setRateLimit should return true", async () => {
-        const originalFetch = globalThis.fetch;
-        mockFetch(() => Promise.resolve(new Response(JSON.stringify({ data: [] }))));
-
-        const result = await gatewayService.setRateLimit("testref123", "pro");
-        expect(result).toBe(true);
-
-        globalThis.fetch = originalFetch;
-    });
-
-    test("setCors should return true and map across multiple routes", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: string[] = [];
-        globalThis.fetch = mock((input: string | URL | Request) => {
-            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-            calls.push(url);
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.setCors("testref123");
-        expect(result).toBe(true);
-
-        const patchedRoutes = calls.filter(c => c.includes("route-svc-pgrst-") || c.includes("route-svc-gotrue-") || c.includes("route-svc-realtime-") || c.includes("route-svc-storage-") || c.includes("route-svc-functions-"));
-        expect(patchedRoutes.length).toBeGreaterThan(0);
-
-        globalThis.fetch = originalFetch;
+describe("GatewayService provider selection", () => {
+    test("defaults to the Caddy gateway provider", () => {
+        expect(config.gatewayProvider).toBe("caddy");
+        expect(gatewayService.name).toBe("caddy");
     });
 
     test("default cors headers allow SupaCloud browser invocation headers", () => {
@@ -71,340 +104,176 @@ describe("GatewayService", () => {
         expect(origins).toContain("https://sapi.dbbaby.top");
         expect(origins).toContain("https://sadmin.dbbaby.top");
     });
+});
 
-    test("setupUpstream should configure realtime route through management websocket proxy", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
-
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                try {
-                    body = JSON.parse(init.body) as Record<string, unknown>;
-                } catch {
-                    body = null;
-                }
-            }
-            calls.push({ url, method, body });
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.setupUpstream("testref123", 3000, 9999);
-        expect(result.success).toBe(true);
-
-        const realtimeService = calls.find(
-            (c) => c.method === "PUT" && c.url.includes("/services/svc-realtime-testref123")
-        );
-        expect(realtimeService).toBeDefined();
-        expect(realtimeService?.body?.url).toMatch(/http:\/\/.*:(8080|9090)$/);
-
-        const realtimeRoute = calls.find(
-            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-realtime-testref123")
-        );
-        expect(realtimeRoute).toBeDefined();
-        expect(realtimeRoute?.body?.paths).toEqual(["/realtime/v1/websocket"]);
-        expect(realtimeRoute?.body?.protocols).toEqual(["http", "https"]);
-        expect(realtimeRoute?.body?.strip_path).toBe(false);
-
-        globalThis.fetch = originalFetch;
+describe("CaddyGatewayProvider", () => {
+    afterEach(async () => {
+        await cleanCaddyTmp();
     });
 
-    test("setupUpstream should preserve /functions/v1 prefix for management sdk-proxy", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
+    test("setupUpstream renders Caddy JSON routes for Supabase-compatible APIs", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
 
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                try {
-                    body = JSON.parse(init.body) as Record<string, unknown>;
-                } catch {
-                    body = null;
-                }
-            }
-            calls.push({ url, method, body });
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
+        const result = await provider.setupUpstream("testref123", 3000, 9999);
+        expect(result.success).toBe(true);
 
-        const result = await gatewayService.setupUpstream("testref123", 3000, 9999);
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        expect(load).toBeDefined();
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const rest = routes.find((route: any) => route["@id"] === "route-project-testref123-rest");
+        const storage = routes.find((route: any) => route["@id"] === "route-project-testref123-storage");
+        const functions = routes.find((route: any) => route["@id"] === "route-project-testref123-functions");
+        const realtime = routes.find((route: any) => route["@id"] === "route-project-testref123-realtime");
+
+        expect(rest?.match?.[0]?.path).toEqual(["/rest/v1*"]);
+        expect(rest?.handle?.some((handler: any) => handler.strip_path_prefix === "/rest/v1")).toBe(true);
+        expect(rest?.handle?.at(-1)?.headers?.request?.set?.["X-Project-Ref"]).toEqual(["testref123"]);
+        expect(routes.flatMap((route: any) => route.handle ?? [])
+            .filter((handler: any) => handler.handler === "reverse_proxy")
+            .every((handler: any) => !handler.upstreams?.[0]?.dial?.includes("/"))).toBe(true);
+        expect(routes.find((route: any) => route["@id"] === "route-project-testref123-graphql")
+            ?.handle?.some((handler: any) => handler.uri === "/rpc/graphql")).toBe(true);
+        expect(storage?.match?.[0]?.path).toEqual(["/storage/v1*"]);
+        expect(functions?.match?.[0]?.path).toEqual(["/functions/v1*"]);
+        expect(realtime?.match?.[0]?.path).toEqual(["/realtime/v1/websocket*"]);
+
+        restore();
+    });
+
+    test("configureFrontendRoute renders a stable frontend root route", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.configureFrontendRoute({
+            projectRef: "proj123",
+            deploymentId: "0000002a",
+            hosts: ["site.example.com", "www.example.com"],
+            port: 30042,
+        });
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const route = routes.find((item: any) => item["@id"] === "route-frontend-proj123-0000002a");
+        expect(route?.match?.[0]?.host).toEqual(["site.example.com", "www.example.com"]);
+        expect(route?.match?.[0]?.path).toEqual(["/*"]);
+        expect(route?.handle?.at(-1)?.upstreams?.[0]?.dial).toBe("127.0.0.1:30042");
+
+        restore();
+    });
+
+    test("upsertCertificateForSnis stores manual certificate paths in Caddy JSON", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        const result = await provider.upsertCertificateForSnis({
+            projectRef: "proj123",
+            cert: VALID_TEST_CERT,
+            key: VALID_TEST_KEY,
+            snis: ["api.example.com", "studio.example.com"],
+        });
+        expect(result.success).toBe(true);
+        const load = calls.find((call) => call.method === "POST" && call.url.endsWith("/load"));
+        const certs = load?.body?.apps?.tls?.certificates?.load_files ?? [];
+        expect(certs[0]?.certificate).toContain("/tmp/supacloud-caddy-test/state/manual-certs/proj123/");
+        expect(certs[0]?.key).toContain("/tmp/supacloud-caddy-test/state/manual-certs/proj123/");
+
+        restore();
+    });
+
+    test("setRateLimit renders caddy rate_limit handlers for tenant API routes", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.setupUpstream("testref123", 3000, 9999);
+        await provider.setRateLimit("testref123", { second: 7, minute: 70, hour: 700 });
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const rest = routes.find((route: any) => route["@id"] === "route-project-testref123-rest");
+        const rateLimit = rest?.handle?.find((handler: any) => handler.handler === "rate_limit");
+        const zones = Object.values(rateLimit?.rate_limits ?? {}) as any[];
+
+        expect(rateLimit).toBeDefined();
+        expect(zones.some((zone) => zone.window === "1s" && zone.max_events === 7)).toBe(true);
+        expect(zones.some((zone) => zone.window === "1m" && zone.max_events === 70)).toBe(true);
+        expect(zones.some((zone) => zone.window === "1h" && zone.max_events === 700)).toBe(true);
+
+        restore();
+    });
+
+    test("setCustomRouteRateLimit creates a stable custom route before parent routes", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.setupUpstream("testref123", 3000, 9999);
+        const ok = await provider.setCustomRouteRateLimit("testref123", "/rest/v1/audit", { second: 2 });
+        expect(ok).toBe(true);
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const custom = routes.find((route: any) => route["@id"]?.startsWith("route-custom-testref123-"));
+
+        expect(routes[0]?.["@id"]).toStartWith("route-custom-testref123-");
+        expect(custom?.match?.[0]?.path).toEqual(["/rest/v1/audit*"]);
+        expect(custom?.handle?.some((handler: any) => handler.handler === "rate_limit")).toBe(true);
+
+        restore();
+    });
+
+    test("new provider instances hydrate existing Caddy JSON before publishing changes", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+
+        const firstProvider = new CaddyGatewayProvider();
+        await firstProvider.setupUpstream("persistref", 3000, 9999);
+
+        const secondProvider = new CaddyGatewayProvider();
+        await secondProvider.upsertCertificateForSnis({
+            projectRef: "persistref",
+            cert: VALID_TEST_CERT,
+            key: VALID_TEST_KEY,
+            snis: ["api.example.com"],
+        });
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const certs = load?.body?.apps?.tls?.certificates?.load_files ?? [];
+
+        expect(routes.some((route: any) => route["@id"] === "route-project-persistref-rest")).toBe(true);
+        expect(certs.length).toBeGreaterThan(0);
+
+        restore();
+    });
+});
+
+describe("KongGatewayProvider rollback compatibility", () => {
+    test("setupUpstream preserves functions prefix and storage streaming flags", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new KongGatewayProvider();
+
+        const result = await provider.setupUpstream("testref123", 3000, 9999);
         expect(result.success).toBe(true);
 
         const functionsRoute = calls.find(
             (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-functions-testref123")
         );
-        expect(functionsRoute).toBeDefined();
         expect(functionsRoute?.body?.paths).toEqual(["/functions/v1"]);
         expect(functionsRoute?.body?.strip_path).toBe(false);
-
-        globalThis.fetch = originalFetch;
-    });
-
-    test("setupUpstream should disable buffering on storage routes", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
-
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                try {
-                    body = JSON.parse(init.body) as Record<string, unknown>;
-                } catch {
-                    body = null;
-                }
-            }
-            calls.push({ url, method, body });
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.setupUpstream("testref123", 3000, 9999);
-        expect(result.success).toBe(true);
 
         const storageRoute = calls.find(
             (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-storage-testref123")
         );
-        expect(storageRoute).toBeDefined();
         expect(storageRoute?.body?.paths).toEqual(["/storage/v1/"]);
         expect(storageRoute?.body?.request_buffering).toBe(false);
         expect(storageRoute?.body?.response_buffering).toBe(false);
 
-        globalThis.fetch = originalFetch;
-    });
-
-    test("setupUpstream should reserve API root paths for ACME-safe host routing", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
-
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                try {
-                    body = JSON.parse(init.body) as Record<string, unknown>;
-                } catch {
-                    body = null;
-                }
-            }
-            calls.push({ url, method, body });
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.setupUpstream("testref123", 3000, 9999);
-        expect(result.success).toBe(true);
-
-        const apiRootRoute = calls.find(
-            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-api-root-testref123")
-        );
-        expect(apiRootRoute).toBeDefined();
-        expect(apiRootRoute?.body?.paths).toEqual(["/.well-known/acme-challenge"]);
-        expect(apiRootRoute?.body?.strip_path).toBe(false);
-        expect(apiRootRoute?.body?.hosts).toContain("testref123.api.example.com");
-        expect(apiRootRoute?.body?.hosts).toContain("studio-testref123.example.com");
-
-        const studioTransformer = calls.find(
-            (c) => c.method === "POST"
-                && c.url.includes("/routes/route-svc-studio-testref123/plugins")
-                && c.body?.name === "request-transformer"
-        );
-        expect(studioTransformer).toBeDefined();
-        expect(((studioTransformer?.body?.config as Record<string, unknown>)?.add as Record<string, unknown>)?.headers).toContain("x-supacloud-ui-host:studio");
-
-        globalThis.fetch = originalFetch;
-    });
-
-    test("setupUpstream should route OAuth 2.1 metadata discovery to GoTrue", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
-
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                try {
-                    body = JSON.parse(init.body) as Record<string, unknown>;
-                } catch {
-                    body = null;
-                }
-            }
-            calls.push({ url, method, body });
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.setupUpstream("testref123", 3000, 9999);
-        expect(result.success).toBe(true);
-
-        const oauthMetadataRoute = calls.find(
-            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-gotrue-well-known-testref123")
-        );
-        expect(oauthMetadataRoute).toBeDefined();
-        expect(oauthMetadataRoute?.body?.paths).toEqual(["/.well-known/oauth-authorization-server/auth/v1"]);
-        expect(oauthMetadataRoute?.body?.strip_path).toBe(false);
-
-        globalThis.fetch = originalFetch;
-    });
-
-    test("upsertCertificateForSnis writes Kong certificate and SNI bindings", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
-
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                body = JSON.parse(init.body) as Record<string, unknown>;
-            }
-            calls.push({ url, method, body });
-            if (url.includes("/certificates?")) {
-                return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-            }
-            if (url.endsWith("/certificates")) {
-                return Promise.resolve(new Response(JSON.stringify({ id: "cert_123" })));
-            }
-            return Promise.resolve(new Response(JSON.stringify({ id: "ok" })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.upsertCertificateForSnis({
-            projectRef: "testref123",
-            cert: "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
-            key: "-----BEGIN PRIVATE KEY-----\nMIIB\n-----END PRIVATE KEY-----",
-            snis: ["api.example.com", "studio.example.com"],
-        });
-
-        expect(result).toEqual({ success: true, certificateId: "cert_123" });
-
-        const certCreate = calls.find((c) => c.method === "POST" && c.url.endsWith("/certificates"));
-        expect(certCreate?.body?.cert).toContain("BEGIN CERTIFICATE");
-        expect(certCreate?.body?.tags).toContain("supacloud-project:testref123");
-
-        const sniCalls = calls.filter((c) => c.method === "PUT" && c.url.includes("/snis/"));
-        expect(sniCalls).toHaveLength(2);
-        expect(sniCalls.map((c) => c.body?.name)).toEqual(["api.example.com", "studio.example.com"]);
-        expect((sniCalls[0]?.body?.certificate as Record<string, unknown>)?.id).toBe("cert_123");
-
-        globalThis.fetch = originalFetch;
-    });
-
-    test("setupUpstream applies exact studio origin to auth cors plugin", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
-
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                try {
-                    body = JSON.parse(init.body) as Record<string, unknown>;
-                } catch {
-                    body = null;
-                }
-            }
-            calls.push({ url, method, body });
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.setupUpstream("dbbabyref", 3000, 9999, {
-            api_domain: "sapi.dbbaby.top",
-            studio_domain: "sadmin.dbbaby.top",
-        });
-        expect(result.success).toBe(true);
-
-        const authCors = calls.find(
-            (c) => c.method === "POST"
-                && c.url.includes("/routes/route-svc-gotrue-dbbabyref/plugins")
-                && c.body?.name === "cors"
-        );
-        expect(authCors).toBeDefined();
-        const origins = ((authCors?.body?.config as Record<string, unknown>)?.origins as string[]) || [];
-        expect(origins).toContain("https://sapi.dbbaby.top");
-        expect(origins).toContain("https://sadmin.dbbaby.top");
-
-        globalThis.fetch = originalFetch;
-    });
-
-    test("setupUpstream propagates explicit custom API and Studio hosts to Kong routes", async () => {
-        const originalFetch = globalThis.fetch;
-        const calls: Array<{ url: string; method: string; body: Record<string, unknown> | null }> = [];
-
-        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
-            const url = typeof input === "string"
-                ? input
-                : input instanceof URL
-                    ? input.toString()
-                    : input.url;
-            const method = init?.method || "GET";
-            let body: Record<string, unknown> | null = null;
-            if (typeof init?.body === "string" && init.body.length > 0) {
-                try {
-                    body = JSON.parse(init.body) as Record<string, unknown>;
-                } catch {
-                    body = null;
-                }
-            }
-            calls.push({ url, method, body });
-            return Promise.resolve(new Response(JSON.stringify({ data: [] })));
-        }) as unknown as typeof fetch;
-
-        const result = await gatewayService.setupUpstream("seagooref", 3000, 9999, {
-            custom_domain: "xg.aizhuliren.cn",
-            api_domain: "api.xg.aizhuliren.cn",
-            studio_domain: "studio.xg.aizhuliren.cn",
-        });
-        expect(result.success).toBe(true);
-
-        const authRoute = calls.find(
-            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-gotrue-seagooref")
-        );
-        expect(authRoute?.body?.hosts).toContain("seagooref.api.example.com");
-        expect(authRoute?.body?.hosts).toContain("api.xg.aizhuliren.cn");
-
-        const functionsRoute = calls.find(
-            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-functions-seagooref")
-        );
-        expect(functionsRoute?.body?.hosts).toContain("api.xg.aizhuliren.cn");
-
-        const studioRoute = calls.find(
-            (c) => c.method === "PUT" && c.url.includes("/routes/route-svc-studio-seagooref")
-        );
-        expect(studioRoute?.body?.hosts).toContain("studio-seagooref.example.com");
-        expect(studioRoute?.body?.hosts).toContain("studio.xg.aizhuliren.cn");
-
-        globalThis.fetch = originalFetch;
+        restore();
     });
 });

--- a/packages/management-api/tests/unit/project.service.comprehensive.test.ts
+++ b/packages/management-api/tests/unit/project.service.comprehensive.test.ts
@@ -361,7 +361,7 @@ describe("ProjectService - Comprehensive", () => {
     expect(result).toBe(true);
   });
 
-  test("restartProject reconciles Kong routes when tenant ports are known", async () => {
+  test("restartProject reconciles gateway routes when tenant ports are known", async () => {
     projectRepositoryMock.findByRef.mockResolvedValueOnce({
       ...mockProject,
       config: {
@@ -425,7 +425,7 @@ describe("ProjectService - Comprehensive", () => {
     expect(tenantRuntimeServiceMock.restartRuntime).toHaveBeenCalledWith("test123abc");
   });
 
-  test("updateProjectSettings reconciles Kong routes for custom domain changes", async () => {
+  test("updateProjectSettings reconciles gateway routes for custom domain changes", async () => {
     projectRepositoryMock.findByRef.mockResolvedValueOnce({
       ...mockProject,
       config: {

--- a/scripts/build_supacloud_caddy.sh
+++ b/scripts/build_supacloud_caddy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CADDY_VERSION="${CADDY_VERSION:-v2.10.2}"
+RATE_LIMIT_MODULE="${RATE_LIMIT_MODULE:-github.com/mholt/caddy-ratelimit}"
+OUT_DIR="${OUT_DIR:-dist}"
+mkdir -p "$OUT_DIR"
+
+if ! command -v xcaddy >/dev/null 2>&1; then
+  echo "xcaddy is required. Install with: go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest" >&2
+  exit 1
+fi
+
+build_one() {
+  local goos="$1"
+  local goarch="$2"
+  local suffix="$3"
+  echo "=> building supacloud-caddy-${suffix}"
+  GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 xcaddy build "$CADDY_VERSION" \
+    --with "$RATE_LIMIT_MODULE" \
+    --output "$OUT_DIR/supacloud-caddy-${suffix}"
+  chmod 0755 "$OUT_DIR/supacloud-caddy-${suffix}"
+}
+
+build_one linux amd64 linux-amd64
+build_one linux arm64 linux-arm64
+
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$OUT_DIR" && sha256sum supacloud-caddy-linux-amd64 supacloud-caddy-linux-arm64 > SHA256SUMS.caddy)
+fi

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -55,11 +55,10 @@ fi
 # Check Management API
 check_service "Management API (9090)" "curl -sf http://localhost:9090/health"
 
-# Check Kong API Gateway
-check_service "Kong Gateway (8000)" "curl -sf http://localhost:8000"
-
-# Check Kong Admin API
-check_service "Kong Admin API (8001)" "curl -sf http://localhost:8001/status"
+# Check Caddy Gateway
+check_service "Caddy Gateway HTTP (80)" "ss -ltn | grep -q ':80 '"
+check_service "Caddy Gateway HTTPS (443)" "ss -ltn | grep -q ':443 '"
+check_service "Caddy Admin API (2019)" "curl -sf http://127.0.0.1:2019/config/ >/dev/null"
 
 # Check SupaCloud service runtimes
 check_service "Image Service (9010)" "ss -ltn | grep -q ':9010 '"

--- a/scripts/pre_start_recovery.sh
+++ b/scripts/pre_start_recovery.sh
@@ -56,17 +56,23 @@ fix_gotrue_search_path() {
     fi
 }
 
-ensure_kong_running() {
-    if systemctl list-unit-files kong.service &>/dev/null || systemctl list-units kong.service &>/dev/null; then
-        if systemctl is-active --quiet kong 2>/dev/null; then
-            log_info "Kong service already running"
+ensure_gateway_running() {
+    local gateway_unit="${GATEWAY_UNIT:-supacloud-caddy}"
+    if [[ "${GATEWAY_PROVIDER:-caddy}" == "kong" ]]; then
+        gateway_unit="kong"
+    fi
+    if systemctl list-unit-files "${gateway_unit}.service" &>/dev/null || systemctl list-units "${gateway_unit}.service" &>/dev/null; then
+        if systemctl is-active --quiet "$gateway_unit" 2>/dev/null; then
+            log_info "$gateway_unit service already running"
         else
-            log_warn "Kong service not running, starting..."
-            rm -f /usr/local/kong/sockets/* /usr/local/kong/pids/nginx.pid 2>/dev/null || true
-            systemctl reset-failed kong 2>/dev/null || true
-            systemctl start kong 2>/dev/null || true
-            if systemctl is-active --quiet kong 2>/dev/null; then
-                log_info "Kong service started"
+            log_warn "$gateway_unit service not running, starting..."
+            if [[ "$gateway_unit" == "kong" ]]; then
+                rm -f /usr/local/kong/sockets/* /usr/local/kong/pids/nginx.pid 2>/dev/null || true
+            fi
+            systemctl reset-failed "$gateway_unit" 2>/dev/null || true
+            systemctl start "$gateway_unit" 2>/dev/null || true
+            if systemctl is-active --quiet "$gateway_unit" 2>/dev/null; then
+                log_info "$gateway_unit service started"
             fi
         fi
     fi
@@ -168,7 +174,7 @@ main() {
     fix_stale_postmaster_pid
     fix_gotrue_search_path
     kill_edge_runtime_zombies
-    ensure_kong_running
+    ensure_gateway_running
     ensure_service_containers_running
     restart_failed_tenants
     


### PR DESCRIPTION
## Summary
- Make Caddy the default public edge provider while keeping Kong as rollback provider via `GATEWAY_PROVIDER=kong`.
- Generate native Caddy JSON from management-api and publish via the Caddy Admin API.
- Add Caddy install/systemd/build flow, release artifacts, diagnostics/lifecycle updates, and frontend gateway route wiring.
- Keep tenant frontend runtime services for static/SSR execution while moving public routing/TLS/streaming proxy responsibilities to Caddy.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...)`
- `bash -n install.sh && bash -n scripts/pre_start_recovery.sh && bash -n scripts/health_check.sh && bash -n scripts/build_supacloud_caddy.sh && git diff --check`
- `CADDY_BINARY_PATH=/tmp/supacloud-caddy-darwin bun test packages/management-api/tests/unit/gateway.service.test.ts packages/management-api/tests/unit/frontend.service.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `bun run --cwd packages/management-api test` (446 pass, 0 fail)
