### PR TITLE
fix(edge-runtime): tolerate missing functions directory

### DIFF
--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -32,8 +32,25 @@ const AUTH_FAILURE_WINDOW_MS = Number(process.env.EDGE_AUTH_FAILURE_WINDOW_MS) |
 const AUTH_FAILURE_LIMIT = Number(process.env.EDGE_AUTH_FAILURE_LIMIT) || 8;
 const AUTH_FAILURE_COOLDOWN_MS = Number(process.env.EDGE_AUTH_FAILURE_COOLDOWN_MS) || 60_000;
 const AUTH_FAILURE_MAX_ENTRIES = Number(process.env.EDGE_AUTH_FAILURE_MAX_ENTRIES) || 2_048;
-const FUNCTIONS_BASE_REALPATH = await fs.realpath(FUNCTIONS_BASE_DIR);
-const FUNCTIONS_DIR_REALPATH = await fs.realpath(FUNCTIONS_DIR);
+
+// 空集群和 CI 环境可能尚未创建函数目录，启动时先落盘以避免健康检查前崩溃。
+async function ensureDir(dir: string): Promise<string> {
+  try {
+    return await fs.realpath(dir);
+  } catch {
+    await fs.mkdir(dir, { recursive: true });
+    return await fs.realpath(dir);
+  }
+}
+
+const FUNCTIONS_BASE_REALPATH = await ensureDir(FUNCTIONS_BASE_DIR);
+if (
+  !isPathInside(FUNCTIONS_DIR, FUNCTIONS_BASE_DIR) &&
+  !isPathInside(FUNCTIONS_DIR, FUNCTIONS_BASE_REALPATH)
+) {
+  throw new Error(`EDGE_FUNCTIONS_DIR must be inside EDGE_FUNCTIONS_BASE_DIR`);
+}
+const FUNCTIONS_DIR_REALPATH = await ensureDir(FUNCTIONS_DIR);
 
 type AuthFailureEntry = {
   count: number;

--- a/packages/management-api/src/plugins/edge-runtime-manager.ts
+++ b/packages/management-api/src/plugins/edge-runtime-manager.ts
@@ -1,6 +1,7 @@
 import type { Subprocess } from "bun";
 import { logger } from "../utils/logger";
 import path from "node:path";
+import { mkdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { config } from "../config";
 
@@ -98,11 +99,15 @@ export class EdgeRuntimeManager {
     // Kill any orphan processes on the port BEFORE spawning
     this.killStaleListeners();
 
+    const edgeFunctionsDir = this.resolveFunctionsDir();
+    mkdirSync(edgeFunctionsDir, { recursive: true });
+
     this.proc = Bun.spawn(["bun", "run", runnerPath], {
       env: {
         ...process.env,
         PORT: String(this.config.port),
-        EDGE_FUNCTIONS_DIR: config.edgeFunctionsDir,
+        EDGE_FUNCTIONS_DIR: edgeFunctionsDir,
+        EDGE_FUNCTIONS_BASE_DIR: process.env.EDGE_FUNCTIONS_BASE_DIR || edgeFunctionsDir,
         EDGE_RUNTIME_MASTER_KEY: config.edgeRuntimeMasterKey,
         MASTER_TOKEN: config.masterToken,
         MANAGEMENT_API_URL: `http://127.0.0.1:${config.port || 9090}`,
@@ -142,7 +147,15 @@ export class EdgeRuntimeManager {
     this.restartDelay = 500;
   }
 
-  private async waitForReady(timeout = 5000) {
+  private resolveFunctionsDir(): string {
+    if (process.env.EDGE_FUNCTIONS_DIR) return path.resolve(process.env.EDGE_FUNCTIONS_DIR);
+    if (process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true") {
+      return path.resolve(process.cwd(), ".tmp/edge-functions");
+    }
+    return config.edgeFunctionsDir;
+  }
+
+  private async waitForReady(timeout = 15_000) {
     const start = Date.now();
     while (Date.now() - start < timeout) {
       try {

--- a/packages/management-api/tests/e2e/snapshot-structural.test.ts
+++ b/packages/management-api/tests/e2e/snapshot-structural.test.ts
@@ -36,7 +36,7 @@ async function waitForAuthProxy(tenantRef: string, anonKey: string) {
   let lastStatus = 0;
   let lastError = "";
 
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
     try {
       const res = await fetch(`${PROXY_URL}/auth/v1/health`, {
         headers: {
@@ -52,7 +52,7 @@ async function waitForAuthProxy(tenantRef: string, anonKey: string) {
     } catch (e) {
       lastError = e instanceof Error ? e.message : String(e);
     }
-    await sleep(500);
+    await sleep(750);
   }
 
   throw new Error(
@@ -97,7 +97,7 @@ describe("API Structural Snapshot Compliance", () => {
                 `;
       }
 
-      await sleep(2000);
+      await sleep(3000);
       const health = await fetch(`${PROXY_URL}/health`, {
         signal: AbortSignal.timeout(1000),
       });
@@ -112,7 +112,7 @@ describe("API Structural Snapshot Compliance", () => {
         }`,
       );
     }
-  }, { timeout: 30_000 });
+  }, { timeout: 60_000 });
 
   afterAll(async () => {
     if (tenantRef) {


### PR DESCRIPTION
## Summary
- Create the edge functions root on startup when it does not exist instead of crashing before `/health` is available.
- Make the embedded management-api edge-runtime launcher use a CI-local writable functions dir and create it before spawning.
- Extend the structural snapshot E2E readiness window so tenant auth proxy bootstrapping is not falsely marked unhealthy while runtime starts.

## Risk control
- This is required before production rollout because `management-api-v0.25.0` main CI failed with `ENOENT: no such file or directory, lstat '/opt/supacloud/functions'` and tenant auth proxy 502.
- Production rollout will keep `GATEWAY_PROVIDER=kong` until Caddy is explicitly cut over.

## Validation
- `bun run --cwd packages/edge-runtime typecheck`
- `bun run --cwd packages/management-api typecheck`
- Missing-functions startup smoke: edge-runtime created the absent functions directory and `/health` returned `{"status":"ok"}`
- `git diff --check`
