### PR TITLE
fix: stop bootstrapping pgsodium in self-host postgres

### DIFF
--- a/docker/self-host/README.md
+++ b/docker/self-host/README.md
@@ -31,9 +31,7 @@ The PostgreSQL image stays on `postgres:18-bookworm` and installs PGDG, Pigsty/P
 - `wrappers`
 - `index_advisor`
 - `pg_net`
-- `supabase_vault` from the Pigsty `vault` package
 - `pgjwt`
-- `pgsodium`
 - `wal2json`
 
 It also packages these PostgreSQL libraries and optional extensions:
@@ -41,6 +39,7 @@ It also packages these PostgreSQL libraries and optional extensions:
 - `supautils`
 - `pg_plan_filter`, loaded as `plan_filter`
 - `documentdb`, created only when the FerretDB profile is enabled
+- `pgsodium` and `supabase_vault`, packaged but not bootstrapped by default
 
 It also sets:
 
@@ -87,5 +86,6 @@ If `postgres-data` already exists, Docker entrypoint init scripts will not run a
 ## Notes
 
 - This stack is for self-host bootstrap and small deployments. It borrows Pigsty/PGEXT packages for extension coverage, but it does not replace a full Pigsty HA production deployment.
+- `pgsodium` and `supabase_vault` stay installed but are not created automatically in self-host mode. They require extra runtime wiring such as a valid `pgsodium_getkey` script before they are safe to enable by default.
 - `BASE_DOMAIN` is derived from `PUBLIC_URL` by `init-env.py`. Override it manually if you need a different wildcard routing suffix.
 - Kong gzip is disabled by default to avoid the HTTP/2 proxy corruption issue already seen on API traffic.

--- a/docker/self-host/TRUENAS.md
+++ b/docker/self-host/TRUENAS.md
@@ -45,7 +45,7 @@ Container port:
 Persistent storage mount:
 
 ```text
-/var/lib/postgresql/data
+/var/lib/postgresql
 ```
 
 Required environment variables:
@@ -91,13 +91,15 @@ This image uses init scripts to:
 - optionally create the FerretDB role
 - optionally create the `documentdb` extension
 
+`pgsodium` and `supabase_vault` packages are present in the image, but they are not bootstrapped by default in self-host mode. They need extra runtime wiring, including a valid `pgsodium_getkey` script, before enabling them safely.
+
 If TrueNAS already initialized the app data directory, changing `ENABLE_FERRETDB` later will not replay those init scripts. In that case, use a fresh data directory or apply the role and extension changes manually.
 
 ## Minimal deployment checklist
 
 1. Create a new Custom App.
 2. Set the image repository and fixed tag.
-3. Add a host path or dataset mount for `/var/lib/postgresql/data`.
+3. Add a host path or dataset mount for `/var/lib/postgresql`.
 4. Set `POSTGRES_PASSWORD`.
 5. Optionally add the FerretDB variables and `27017/TCP`.
 6. Start the app on an empty data directory.

--- a/docker/self-host/postgres/initdb/01-bootstrap-extensions.sql
+++ b/docker/self-host/postgres/initdb/01-bootstrap-extensions.sql
@@ -19,9 +19,7 @@ BEGIN
     'pg_jsonschema',
     'pgmq',
     'wrappers',
-    'pgjwt',
-    'pgsodium',
-    'supabase_vault'
+    'pgjwt'
   ] LOOP
     IF EXISTS (
       SELECT 1


### PR DESCRIPTION
## Summary

- stop auto-creating `pgsodium` and `supabase_vault` in the self-host PostgreSQL bootstrap path
- keep both packages installed, but require explicit manual enablement after runtime KMS wiring is configured
- fix the TrueNAS self-host guide to mount PostgreSQL 18 data at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`

## Why

The current self-host defaults eagerly create `pgsodium`, which is not safe on a fresh self-host deployment unless the runtime is also configured with a working `pgsodium_getkey` script and matching settings.

In practice this causes two classes of failures:

- PostgreSQL startup failure when `pgsodium` is pushed into `shared_preload_libraries` without a valid getkey script
- `documentdb` / FerretDB write failures on clusters where `pgsodium` was auto-created but its runtime settings were never fully wired

This PR keeps extension coverage in the image, but moves `pgsodium` and `supabase_vault` out of the default bootstrap set so self-host deployments start from a safer baseline.

## Verification

- `git diff --check`
- confirmed the self-host bootstrap list only removes `pgsodium` / `supabase_vault` from automatic `CREATE EXTENSION`
- verified the docs now describe `/var/lib/postgresql` as the persistent mount path for PostgreSQL 18 based images
