### PR TITLE
fix: restore hosted frontend Caddy routes

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -148,6 +148,11 @@ async function getIndexHtml(): Promise<string | null> {
 try {
   const { gatewayService } = await import("./services/gateway.service");
   await gatewayService.setupMasterRoutes();
+  const { frontendService } = await import("./services/frontend.service");
+  const result = await frontendService.reconcileGatewayRoutes();
+  if (result.configured > 0 || result.errors.length > 0) {
+    logger.info("[FrontendService] Reconciled gateway routes", result);
+  }
 } catch (e) {
   logger.error(
     "Failed to setup master routes",

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -2137,10 +2137,12 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       const authError = await requireAdminAuth(request);
       if (authError) return status(authError.status, authError.body);
       const result = await gatewayService.rebuildAllTenantConfigs();
+      const { frontendService } = await import("../services/frontend.service");
+      const frontend = await frontendService.reconcileGatewayRoutes();
       if (!result.success) {
-        return { ...result, message: "Rebuild failed" };
+        return { ...result, frontend, message: "Rebuild failed" };
       }
-      return result;
+      return { ...result, frontend };
     },
     {
       params: t.Object({ ref: t.String() }),

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -185,6 +185,62 @@ export class FrontendService {
     return deployments;
   }
 
+  async reconcileGatewayRoutes(projectRef?: string): Promise<{ total: number; configured: number; skipped: number; errors: string[] }> {
+    const errors: string[] = [];
+    let total = 0;
+    let configured = 0;
+    let skipped = 0;
+
+    let projectRefs: string[] = [];
+    if (projectRef) {
+      projectRefs = [projectRef];
+    } else {
+      try {
+        const entries = await readdir(this.baseDir, { withFileTypes: true });
+        projectRefs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+      } catch (error: unknown) {
+        const code = typeof error === "object" && error && "code" in error ? String((error as { code?: unknown }).code) : "";
+        if (code === "ENOENT") {
+          return { total, configured, skipped, errors };
+        }
+        return {
+          total,
+          configured,
+          skipped,
+          errors: [error instanceof Error ? error.message : String(error)],
+        };
+      }
+    }
+
+    for (const ref of projectRefs) {
+      const deployments = await this.listDeployments(ref);
+      for (const deployment of deployments) {
+        total++;
+        if (deployment.status !== "success") {
+          skipped++;
+          continue;
+        }
+
+        const buildDir = this.joinPath(this.baseDir, ref, deployment.id, "build");
+        const buildStat = await stat(buildDir).catch(() => null);
+        if (!buildStat?.isDirectory()) {
+          skipped++;
+          continue;
+        }
+
+        const defaults = FRAMEWORK_DEFAULTS[deployment.framework];
+        try {
+          await this.configureGatewayRoute(deployment, buildDir, defaults.is_ssr);
+          configured++;
+        } catch (error: unknown) {
+          errors.push(`${ref}/${deployment.id}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+    }
+
+    return { total, configured, skipped, errors };
+  }
+
   async getDeployment(projectRef: string, deploymentId: string): Promise<FrontendDeployment | null> {
     const configPath = this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json");
     try {

--- a/packages/management-api/tests/unit/frontend.service.test.ts
+++ b/packages/management-api/tests/unit/frontend.service.test.ts
@@ -141,6 +141,72 @@ describe("FrontendService gateway routing", () => {
     expect(fileServer?.root).toBe("/tmp/build");
     expect(fileServer?.precompressed_order).toEqual(["br", "zstd", "gzip"]);
   });
+
+  test("reconciles successful static deployments back into Caddy routes", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-reconcile-test-"));
+    const calls: Array<{ url: string; method: string; body: any }> = [];
+
+    globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      const method = init?.method || "GET";
+      let body: any = null;
+      if (typeof init?.body === "string" && init.body.length > 0) {
+        try {
+          body = JSON.parse(init.body);
+        } catch {
+          body = null;
+        }
+      }
+      calls.push({ url, method, body });
+      return Promise.resolve(new Response(JSON.stringify({ data: [] })));
+    }) as unknown as typeof fetch;
+
+    try {
+      const deploymentDir = join(baseDir, "proj123", "0000002c");
+      const buildDir = join(deploymentDir, "build");
+      await mkdir(buildDir, { recursive: true });
+      await writeFile(join(buildDir, "index.html"), "<!doctype html><title>site</title>");
+      await writeFile(join(deploymentDir, "deployment.json"), JSON.stringify({
+        id: "0000002c",
+        project_ref: "proj123",
+        name: "site",
+        framework: "static",
+        domain: "site.example.com",
+        custom_domains: ["www.example.com"],
+        build_command: "",
+        output_dir: ".",
+        install_command: "",
+        node_version: "20",
+        env_vars: {},
+        status: "success",
+        created_at: "2026-05-27T00:00:00.000Z",
+        updated_at: "2026-05-27T00:00:00.000Z",
+        deployment_url: "https://site.example.com",
+      }));
+
+      const service = new FrontendService(baseDir);
+      const result = await service.reconcileGatewayRoutes();
+
+      expect(result).toEqual({ total: 1, configured: 1, skipped: 0, errors: [] });
+
+      const loadCall = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+      const routes = loadCall?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+      const route = routes.find((item: any) => item["@id"] === "route-frontend-proj123-0000002c");
+      const subroute = route?.handle?.find((handler: any) => handler.handler === "subroute");
+      const fileServer = subroute?.routes?.at(-1)?.handle?.at(-1);
+
+      expect(route?.match?.[0]?.host).toEqual(["site.example.com", "www.example.com"]);
+      expect(route?.match?.[0]?.path).toEqual(["/*"]);
+      expect(fileServer?.handler).toBe("file_server");
+      expect(fileServer?.root).toBe(buildDir);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("FrontendService optimizer", () => {


### PR DESCRIPTION
## Summary
- restore hosted frontend gateway routes from successful deployment metadata during management-api startup
- include hosted frontend route reconciliation in gateway rebuild-all responses
- cover static SPA route recovery with a regression test that verifies Caddy `file_server` routing for custom domains

## Why
A Caddy config regeneration can leave existing frontend deployments unreachable when their custom-domain routes are absent from the generated config. Static SPA deployments should be recovered as Caddy `file_server` routes, while SSR deployments continue to recover as proxy routes.

## Validation
- `bun test packages/management-api/tests/unit/frontend.service.test.ts packages/management-api/tests/unit/gateway.service.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `git diff --check`
