### PR TITLE
fix(gateway): preserve frontend origins in Caddy CORS

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -1765,6 +1765,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
 
     async setupUpstream(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions): Promise<{ success: boolean; error?: string }> {
         try {
+            await this.hydrateFromDisk();
             const hostIp = await this.detectHostIp();
             const routingConfig = normalizeProjectRoutingConfig(projectRouting);
             const hosts = uniqueStrings([
@@ -1775,7 +1776,11 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 `studio-${projectRef}.${config.baseDomain}`,
                 resolveProjectStudioHost(projectRef, routingConfig),
             ]);
-            const corsOrigins = buildTenantCorsOrigins(projectRef, routingConfig, [...hosts, ...studioHosts]);
+            const corsOrigins = buildTenantCorsOrigins(projectRef, routingConfig, [
+                ...hosts,
+                ...studioHosts,
+                ...this.hostsForProjectRoutes(projectRef),
+            ]);
 
             const routes = [
                 this.makeRoute({ id: caddyRouteId(projectRef, "rest"), hosts, path: "/rest/v1*", upstream: `${hostIp}:${pgrstPort}`, projectRef, stripPrefix: "/rest/v1", corsOrigins }),

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -1441,6 +1441,44 @@ export class CaddyGatewayProvider implements GatewayProvider {
         };
     }
 
+    private isCorsHeaderHandler(handler: Record<string, unknown>): boolean {
+        return handler.handler === "headers" &&
+            typeof (handler.response as any)?.set?.["Access-Control-Allow-Origin"] !== "undefined";
+    }
+
+    private isCorsSubroute(handler: Record<string, unknown>): boolean {
+        if (handler.handler !== "subroute" || !Array.isArray(handler.routes)) return false;
+        return handler.routes.some((route: any) =>
+            Array.isArray(route?.handle) &&
+            route.handle.some((item: any) => this.isCorsHeaderHandler(item)),
+        );
+    }
+
+    private setRouteCors(route: CaddyRoute, origins: string[]): void {
+        const corsSubroute = this.makeCorsSubroute(origins);
+        const handle = Array.isArray(route.handle) ? route.handle as Record<string, unknown>[] : [];
+        const withoutCors = handle.filter((handler) =>
+            !this.isCorsHeaderHandler(handler) && !this.isCorsSubroute(handler),
+        );
+        route.handle = corsSubroute ? [corsSubroute, ...withoutCors] : withoutCors;
+    }
+
+    private projectRouteIds(projectRef: string): string[] {
+        return Array.from(this.routesById.keys()).filter((id) =>
+            id.includes(`-${projectRef}-`) || id.endsWith(`-${projectRef}`),
+        );
+    }
+
+    private hostsForProjectRoutes(projectRef: string): string[] {
+        const hosts: string[] = [];
+        for (const id of this.projectRouteIds(projectRef)) {
+            const route = this.routesById.get(id);
+            const match = Array.isArray(route?.match) ? route.match[0] as Record<string, unknown> | undefined : undefined;
+            if (match && Array.isArray(match.host)) hosts.push(...match.host as string[]);
+        }
+        return uniqueStrings(hosts);
+    }
+
     private makeEncodeHandler(): Record<string, unknown> {
         return {
             handler: "encode",
@@ -1708,14 +1746,21 @@ export class CaddyGatewayProvider implements GatewayProvider {
         return cloned;
     }
 
-    async setCors(projectRef: string, _origins: string[] = DEFAULT_CORS_ORIGINS): Promise<boolean> {
+    async setCors(projectRef: string, origins: string[] = DEFAULT_CORS_ORIGINS): Promise<boolean> {
         logger.debug(`[CaddyGatewayProvider] CORS is rendered into route JSON for ${projectRef}`);
+        await this.hydrateFromDisk();
+        for (const id of this.projectRouteIds(projectRef)) {
+            const route = this.routesById.get(id);
+            if (route) this.setRouteCors(route, origins);
+        }
         await this.persistAndLoad();
         return true;
     }
 
     async addCorsOriginsForHosts(projectRef: string, hosts: string[]): Promise<boolean> {
-        return this.setCors(projectRef, buildTenantCorsOrigins(projectRef, undefined, hosts));
+        await this.hydrateFromDisk();
+        const allHosts = uniqueStrings([...this.hostsForProjectRoutes(projectRef), ...hosts]);
+        return this.setCors(projectRef, buildTenantCorsOrigins(projectRef, undefined, allHosts));
     }
 
     async setupUpstream(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions): Promise<{ success: boolean; error?: string }> {

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -185,6 +185,10 @@ describe("CaddyGatewayProvider", () => {
         const restore = captureFetch(calls);
         const provider = new CaddyGatewayProvider();
 
+        await provider.setupUpstream("proj123", 3000, 9999, {
+            api_domain: "api.example.com",
+            studio_domain: "studio.example.com",
+        });
         await provider.configureFrontendRoute({
             projectRef: "proj123",
             deploymentId: "0000002a",
@@ -198,6 +202,12 @@ describe("CaddyGatewayProvider", () => {
         expect(route?.match?.[0]?.host).toEqual(["site.example.com", "www.example.com"]);
         expect(route?.match?.[0]?.path).toEqual(["/*"]);
         expect(route?.handle?.at(-1)?.upstreams?.[0]?.dial).toBe("127.0.0.1:30042");
+        const apiRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-functions");
+        const corsSubroute = findCorsSubroute(apiRoute);
+        const exactMatcher = corsSubroute?.routes?.[0]?.match?.find((matcher: any) => matcher.header?.Origin);
+        expect(exactMatcher?.header?.Origin).toContain("https://site.example.com");
+        expect(exactMatcher?.header?.Origin).toContain("https://www.example.com");
+        expect(exactMatcher?.header?.Origin).toContain("https://api.example.com");
 
         restore();
     });

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -212,6 +212,33 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("setupUpstream preserves existing frontend hosts as allowed CORS origins", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.configureFrontendRoute({
+            projectRef: "proj123",
+            deploymentId: "0000002c",
+            hosts: ["app.example.com"],
+            port: 30043,
+        });
+        await provider.setupUpstream("proj123", 3000, 9999, {
+            api_domain: "api.example.com",
+            studio_domain: "studio.example.com",
+        });
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const functionsRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-functions");
+        const corsSubroute = findCorsSubroute(functionsRoute);
+        const exactMatcher = corsSubroute?.routes?.[0]?.match?.find((matcher: any) => matcher.header?.Origin);
+        expect(exactMatcher?.header?.Origin).toContain("https://app.example.com");
+        expect(exactMatcher?.header?.Origin).toContain("https://api.example.com");
+
+        restore();
+    });
+
     test("configureFrontendRoute renders Caddy static file_server route with precompression", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);


### PR DESCRIPTION
## Summary
- update Caddy setCors to rewrite existing project routes with the current CORS subroute
- merge hosted frontend route hosts into project CORS origins so app origins like aorist.net remain allowed
- cover frontend-origin preservation in Caddy gateway tests

## Verification
- bun test packages/management-api/tests/unit/gateway.service.test.ts packages/management-api/tests/unit/frontend.service.test.ts
- bun run --cwd packages/management-api typecheck
- bun run --cwd packages/management-api test:unit
- git diff --check