### PR TITLE
fix: resolve PR #229 review findings

### DIFF
--- a/docker/self-host/README.md
+++ b/docker/self-host/README.md
@@ -112,6 +112,18 @@ ENABLE_SUPABASE_VAULT=true
 
 `ENABLE_SUPABASE_VAULT=true` requires `ENABLE_PGSODIUM=true`. The key must stay stable across restarts and upgrades; rotating it without a planned migration can make encrypted data unreadable.
 
+
+## Rolling back pgsodium
+
+If you enabled pgsodium on a fresh volume and need to disable it:
+
+1. Stop the stack: `docker compose down`.
+2. Remove or rename the `postgres-data` volume to start fresh: `docker volume rm supacloud_postgres-data`.
+3. Set `ENABLE_PGSODIUM=false` and `ENABLE_SUPABASE_VAULT=false` in `.env`.
+4. Start the stack again: `docker compose up -d --build`.
+
+**Important**: Once pgsodium has been initialized, encrypted data (including Vault secrets) depends on the original key. Starting over with a new volume means that data is lost. If you need to keep existing data, do **not** remove the volume. Instead, keep the same `PGSODIUM_KEY` or `PGSODIUM_KEY_FILE` value and simply stop using the `pgsodium` and `vault` schemas. The extension stays loaded in `shared_preload_libraries` until you rebuild PostgreSQL with `ENABLE_PGSODIUM=false` on a fresh volume.
+
 ## Notes
 
 - This stack is for self-host bootstrap and small deployments. It borrows Pigsty/PGEXT packages for extension coverage, but it does not replace a full Pigsty HA production deployment.

--- a/docker/self-host/TRUENAS.md
+++ b/docker/self-host/TRUENAS.md
@@ -127,8 +127,6 @@ This image uses init scripts to:
 
 `pgsodium` and `supabase_vault` packages are present in the image, but they are not bootstrapped by default in self-host mode. When `ENABLE_PGSODIUM=true`, the image preloads `pgsodium`, uses the bundled `pgsodium_getkey` script, and creates the extension during first initialization.
 
-`pgsodium` and `supabase_vault` packages are present in the image, but they are not bootstrapped by default in self-host mode. They need extra runtime wiring, including a valid `pgsodium_getkey` script, before enabling them safely.
-
 If TrueNAS already initialized the app data directory, changing `ENABLE_FERRETDB` later will not replay those init scripts. In that case, use a fresh data directory or apply the role and extension changes manually.
 
 ## Minimal deployment checklist
@@ -140,6 +138,18 @@ If TrueNAS already initialized the app data directory, changing `ENABLE_FERRETDB
 5. Optionally add the FerretDB variables and `27017/TCP`.
 6. Optionally add the pgsodium variables before first start.
 7. Start the app on an empty data directory.
+
+## Rolling back pgsodium
+
+If you enabled pgsodium and need to disable it on TrueNAS:
+
+1. Stop the Custom App.
+2. Back up or note the current dataset used for PostgreSQL storage.
+3. Delete the dataset contents (or point the app to a new empty dataset).
+4. Set `ENABLE_PGSODIUM=false` and `ENABLE_SUPABASE_VAULT=false` in the app environment.
+5. Start the app again.
+
+**Important**: Encrypted data and Vault secrets depend on the original pgsodium key. Starting with a new empty dataset means that data is lost. To preserve existing data, keep the same key and simply stop using the pgsodium and vault schemas.
 
 ## Verification after first start
 

--- a/docker/self-host/postgres/initdb/00-common.sh
+++ b/docker/self-host/postgres/initdb/00-common.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Shared helpers for Docker entrypoint init scripts.
+# Source this file: . /docker-entrypoint-initdb.d/00-common.sh
+
+truthy() {
+  case "${1,,}" in
+    1 | true | yes | on) return 0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/docker/self-host/postgres/initdb/00-configure-postgres.sh
+++ b/docker/self-host/postgres/initdb/00-configure-postgres.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-truthy() {
-  case "${1,,}" in
-    1 | true | yes | on) return 0 ;;
-    *) return 1 ;;
-  esac
-}
+. /docker-entrypoint-initdb.d/00-common.sh
 
 bool_setting() {
   case "${1,,}" in

--- a/docker/self-host/postgres/initdb/03-configure-pgsodium.sh
+++ b/docker/self-host/postgres/initdb/03-configure-pgsodium.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-truthy() {
-  case "${1,,}" in
-    1 | true | yes | on) return 0 ;;
-    *) return 1 ;;
-  esac
-}
+. /docker-entrypoint-initdb.d/00-common.sh
 
 if ! truthy "${ENABLE_PGSODIUM:-false}"; then
   if truthy "${ENABLE_SUPABASE_VAULT:-false}"; then


### PR DESCRIPTION
## Summary

Follow-up fix for PR #229 (merged) addressing AI review findings.

### Changes

1. **Extract `truthy()` into shared `00-common.sh`** — eliminates duplicate function definition in `00-configure-postgres.sh` and `03-configure-pgsodium.sh`. Both scripts now source `/docker-entrypoint-initdb.d/00-common.sh`.

2. **Remove contradictory TRUENAS.md paragraph** — the old paragraph ("They need extra runtime wiring, including a valid pgsodium_getkey script...") contradicted the new paragraph above it. Removed the old one, keeping the accurate description.

3. **Add rollback instructions** — both README.md and TRUENAS.md now include a "Rolling back pgsodium" section with clear steps and data-loss warnings.

### Verification

- `bash -n` passes for all three initdb scripts
- `python3 -m py_compile init-env.py` passes
- `git diff --check` clean

### Parent

Follow-up from #229. Reason: review findings not addressed before merge.