### PR TITLE
fix(gateway): strip upstream CORS headers in Caddy routes

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -26,6 +26,14 @@ export const DEFAULT_CORS_EXPOSED = [
     "Content-Profile", "accept-profile", "Range", "Range-Unit",
     "X-Relay-Error", "link", "x-total-count",
 ];
+const UPSTREAM_CORS_RESPONSE_HEADERS = [
+    "Access-Control-Allow-Origin",
+    "Access-Control-Allow-Credentials",
+    "Access-Control-Allow-Methods",
+    "Access-Control-Allow-Headers",
+    "Access-Control-Expose-Headers",
+    "Access-Control-Max-Age",
+] as const;
 export const DEFAULT_CORS_ORIGINS = [
     "~^https?://.*\\.dbbaby\\.top$",
     "~^https?://localhost(:[0-9]+)?$",
@@ -1353,6 +1361,9 @@ export class CaddyGatewayProvider implements GatewayProvider {
             headers: {
                 request: {
                     set: Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value : [value]])),
+                },
+                response: {
+                    delete: [...UPSTREAM_CORS_RESPONSE_HEADERS],
                 },
             },
             transport: {

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -28,6 +28,11 @@ function findCorsSubroute(route: any) {
     return route?.handle?.find((handler: any) => handler.handler === "subroute" && Array.isArray(handler.routes));
 }
 
+function findReverseProxyHandlers(routes: any[]) {
+    return routes.flatMap((route: any) => route.handle ?? [])
+        .filter((handler: any) => handler.handler === "reverse_proxy");
+}
+
 async function cleanCaddyTmp() {
     await rm("/tmp/supacloud-caddy-test", { recursive: true, force: true });
 }
@@ -137,9 +142,16 @@ describe("CaddyGatewayProvider", () => {
         expect(rest?.match?.[0]?.path).toEqual(["/rest/v1*"]);
         expect(rest?.handle?.some((handler: any) => handler.strip_path_prefix === "/rest/v1")).toBe(true);
         expect(rest?.handle?.at(-1)?.headers?.request?.set?.["X-Project-Ref"]).toEqual(["testref123"]);
-        expect(routes.flatMap((route: any) => route.handle ?? [])
-            .filter((handler: any) => handler.handler === "reverse_proxy")
-            .every((handler: any) => !handler.upstreams?.[0]?.dial?.includes("/"))).toBe(true);
+        const reverseProxyHandlers = findReverseProxyHandlers(routes);
+        expect(reverseProxyHandlers.every((handler: any) => !handler.upstreams?.[0]?.dial?.includes("/"))).toBe(true);
+        for (const handler of reverseProxyHandlers) {
+            expect(handler.headers?.response?.delete).toContain("Access-Control-Allow-Origin");
+            expect(handler.headers?.response?.delete).toContain("Access-Control-Allow-Credentials");
+            expect(handler.headers?.response?.delete).toContain("Access-Control-Allow-Methods");
+            expect(handler.headers?.response?.delete).toContain("Access-Control-Allow-Headers");
+            expect(handler.headers?.response?.delete).toContain("Access-Control-Expose-Headers");
+            expect(handler.headers?.response?.delete).toContain("Access-Control-Max-Age");
+        }
         expect(routes.find((route: any) => route["@id"] === "route-project-testref123-graphql")
             ?.handle?.some((handler: any) => handler.uri === "/rpc/graphql")).toBe(true);
         expect(storage?.match?.[0]?.path).toEqual(["/storage/v1*"]);


### PR DESCRIPTION
## Summary
- Strip upstream `Access-Control-Allow-*` response headers from generated Caddy `reverse_proxy` handlers.
- Keep Caddy as the single CORS authority for tenant/project routes so reflected tenant origins are not combined with upstream wildcard CORS headers.
- Add Caddy JSON generation coverage to prevent duplicate CORS headers on auth/rest/storage/functions/realtime routes.

## Production context
Aorist login was failing because `https://api.aorist.net/auth/v1/token?grant_type=password` returned multiple `Access-Control-Allow-Origin` values: `https://aorist.net, *`. The live Caddy config was hotfixed to delete upstream CORS response headers before Caddy sets its own CORS headers.

## Verification
- `bun test packages/management-api/tests/unit/gateway.service.test.ts`
- `bun run --cwd packages/management-api typecheck`
- Live hotfix verification on `82.157.196.165`: browser fetch from `https://aorist.net/login` now reaches GoTrue and returns `400 invalid_credentials` instead of CORS `Failed to fetch`.
