### PR TITLE
fix: support external s3 credentials in manager

### DIFF
--- a/scripts/lib/s3_manager.sh
+++ b/scripts/lib/s3_manager.sh
@@ -40,6 +40,12 @@ load_credentials() {
             S3_ACCESS_KEY="${MINIO_ACCESS_KEY:-minioadmin}"
             S3_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
             ;;
+        external)
+            S3_ENDPOINT="${EXTERNAL_S3_ENDPOINT:-$S3_ENDPOINT}"
+            S3_ACCESS_KEY="${EXTERNAL_S3_ACCESS_KEY:-$S3_ACCESS_KEY}"
+            S3_SECRET_KEY="${EXTERNAL_S3_SECRET_KEY:-$S3_SECRET_KEY}"
+            BUCKET_NAME="${EXTERNAL_S3_BUCKET:-$BUCKET_NAME}"
+            ;;
     esac
 }
 


### PR DESCRIPTION
## Summary
- teach scripts/lib/s3_manager.sh to honor S3_STORAGE_TYPE=external
- read EXTERNAL_S3_ENDPOINT, EXTERNAL_S3_ACCESS_KEY, EXTERNAL_S3_SECRET_KEY, and optional EXTERNAL_S3_BUCKET
- prevent external deployments from falling back to localhost:9000 credentials

## Verification
- bash -n scripts/lib/s3_manager.sh
- S3_STORAGE_TYPE=external EXTERNAL_S3_ENDPOINT=https://s3.example.test EXTERNAL_S3_ACCESS_KEY=ak EXTERNAL_S3_SECRET_KEY=sk EXTERNAL_S3_BUCKET=shared-bucket scripts/lib/s3_manager.sh credentials abc123

Constraint: external S3 deployments may share a pre-created bucket, so EXTERNAL_S3_BUCKET must be able to override the default supa-${PROJECT_REF} bucket name.