### PR TITLE
docs: align gateway docs with caddy runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **Pigsty Powered**: Enterprise-grade PostgreSQL with built-in monitoring (Grafana)
 - **One-Click Installation**: Fully automated setup via `install.sh`
 - **JuiceFS Storage**: Powered by PostgreSQL Large Objects (LO) for ultra-thin metadata
-- **Caddy Gateway**: Dynamic API Router, native ACME SSL, Gzip, Security Headers, Programmable Rate Limiting, and CORS
+- **Caddy Gateway**: Automatic HTTPS, Admin API-driven route publishing, programmable rate limiting, security headers, and CORS
 - **Auto-scaling Engine**: Rule-based vertical and horizontal scaling based on real-time metrics
 - **Bun Edge Runtime**: Bun.js + Elysia Worker Pool for Edge Functions, with built-in Deno compatibility shim for legacy user code
 - **SSE Real-time Logs**: Server-Sent Events streaming for live log tailing via `journalctl --follow`
@@ -324,7 +324,7 @@ Function management read endpoints under `/v1/projects/:ref/functions*` require 
 | Deploy | `/v1/deploy/*` | Edge Function deployment |
 | Tasks | `/v1/projects/:ref/tasks/*` | Background task monitoring, including lightweight `summary=true` list mode |
 | **Logs SSE** | `GET /v1/projects/:ref/logs/stream` | **Real-time log streaming via Server-Sent Events** |
-| **Rate Limit** | `GET/PUT /v1/projects/:ref/gateway/rate-limit` | **Programmable per-project rate limiting (Caddy Admin API)** |
+| **Rate Limit** | `GET/PUT /v1/projects/:ref/gateway/rate-limit` | **Programmable per-project rate limiting (Caddy route policy)** |
 | **WebSocket** | `ws://host/ws/tasks` | **Real-time task progress notifications** |
 
 #### Runtime Switching
@@ -352,9 +352,8 @@ SupaCloud (:9090)          Edge Runtime (:9000)
 └── Static Assets (ETag)   ├── URL Import Plugin
                            └── /preheat (zero cold-start)
 
-Caddy Gateway (API-driven, native JSON config):
-  Global: ACME SSL, Gzip, Security Headers, Access Logs
-  Per-route: CORS, Rate Limiting, JWT, IP Restriction
+Caddy Gateway (Admin API-driven):
+  Automatic HTTPS, route JSON publishing, security headers, rate limiting, CORS
   /api/*        → :9090
   /functions/*  → :9090 (sdk-proxy, async enqueue + sync relay)
 ```
@@ -489,7 +488,7 @@ supacloud/
 ├── scripts/
 │   └── lib/                    # Shell script modules
 │       ├── db_manager.sh       # Database lifecycle
-│       ├── gateway_manager.sh  # Caddy gateway configuration
+│       ├── gateway provider    # Caddy route publishing is managed in management-api
 │       ├── tenant_runtime.sh   # Tenant PostgREST & GoTrue runtime
 │       ├── function_manager.sh # Edge Functions management
 │       ├── s3_manager.sh       # Storage backend management
@@ -555,7 +554,7 @@ Key settings in `config.env`:
 - **Pigsty 驱动**: 企业级 PostgreSQL，内置 Grafana 监控
 - **一键部署**: 通过 `install.sh` 全自动安装
 - **JuiceFS 存储**: 基于 PostgreSQL Large Objects (LO) 后端，极致轻量
-- **Caddy 深度集成**: 原生动态路由，全程 Caddy Admin API 驱动，原生 ACME SSL、Gzip 压缩、安全响应头、编程式限流
+- **Caddy 网关**: Automatic HTTPS、Admin API 驱动的动态路由发布、安全响应头与编程式限流
 - **自动扩缩容**: 基于负载指标的垂直提升与水平副本扩展
 - **Bun Edge Runtime**: 基于 Bun.js + Elysia Worker Pool，内置 Deno 兼容层以兼容旧函数代码
 - **SSE 实时日志**: 基于 Server-Sent Events 的实时日志流，`journalctl --follow` 推送
@@ -843,7 +842,7 @@ curl http://localhost:9090/v1/projects/<ref>/api-keys \
 | 部署 | `/v1/deploy/*` | Edge Function 部署 |
 | 任务 | `/v1/projects/:ref/tasks/*` | 后台 AI/通用异步任务生命周期观测与监控，支持 `summary=true` 轻量列表 |
 | **日志 SSE** | `GET /v1/projects/:ref/logs/stream` | **实时日志流（Server-Sent Events）** |
-| **限流** | `GET/PUT /v1/projects/:ref/gateway/rate-limit` 及 `custom-rate-limits` | **编程式架构与客户端路由自定限流（Caddy Admin API 驱动）** |
+| **限流** | `GET/PUT /v1/projects/:ref/gateway/rate-limit` 及 `custom-rate-limits` | **编程式架构与客户端路由自定限流（Caddy 路由策略）** |
 | **WebSocket** | `ws://host/ws/tasks` | **实时任务进度推送** |
 
 #### 运行时切换
@@ -871,9 +870,8 @@ SupaCloud (:9090)          Edge Runtime (:9000)
 └── 静态资源 (ETag/304)    ├── URL Import 插件
                            └── /preheat (零冷启动预热)
 
-Caddy 网关 (API 驱动，原生 JSON 配置):
-  全局插件: ACME SSL, Gzip 压缩, 安全响应头, 访问日志
-  路由级插件: CORS, 限流, JWT, IP 限制
+Caddy 网关 (Admin API 驱动):
+  Automatic HTTPS、动态路由 JSON 发布、安全响应头、限流、CORS
   /api/*        → :9090 (管理 API)
   /functions/*  → :9090 (sdk-proxy，异步入队 + 同步转发)
 ```
@@ -970,7 +968,7 @@ supacloud/
 ├── scripts/
 │   └── lib/                    # Shell 脚本模块
 │       ├── db_manager.sh       # 数据库生命周期
-│       ├── gateway_manager.sh  # Caddy 网关配置
+│       ├── gateway provider    # Caddy 路由发布由 management-api 内部管理
 │       ├── tenant_runtime.sh   # 租户 PostgREST & GoTrue 运行时
 │       ├── function_manager.sh # 云函数管理
 │       ├── s3_manager.sh       # 存储后端管理

--- a/docs/architecture-multi-tenant.md
+++ b/docs/architecture-multi-tenant.md
@@ -1,14 +1,14 @@
 # SupaCloud Multi-Tenant Architecture
 
-> **Status**: Implemented (Option C+ with Kong Native API-Driven Gateway)  
+> **Status**: Implemented (Option C+ with Caddy Admin API-Driven Gateway)  
 > **Last Updated**: 2026-05-11
 
 ## Current Architecture
 
 ```
 ┌──────────────┐     ┌──────────────────┐     ┌───────────────┐
-│  Kong (Native │ ──► │ PostgREST(:310x) ──► │ supa_tenant_1 │
-│  OpenResty)  │     │ GoTrue(:410x)    │     └───────────────┘
+│  Caddy       │ ──► │ PostgREST(:310x) ──► │ supa_tenant_1 │
+│  Gateway     │     │ GoTrue(:410x)    │     └───────────────┘
 │  :80/:443    │     │ (per-tenant)     │     ┌───────────────┐
 │              │     └──────────────────┘ ──► │ supa_tenant_N │
 │  Plugins:    │                              └───────────────┘
@@ -27,8 +27,8 @@
                      └──────────────────┘
 ```
 
-> **Note**: SupaCloud natively relies on **Kong (DB-backed, API-driven)** running as a systemd service.
-> All tenant routing, rate limiting, CORS, and SSL are managed via Kong Admin API — no manual config file edits needed.
+> **Note**: SupaCloud natively relies on **Caddy** running as a systemd service.
+> All tenant routing, rate limiting, CORS, and TLS are managed via the Caddy Admin API — no manual config file edits needed.
 
 ### 1. PostgREST & GoTrue (Per-Tenant Processes) ⭐ Implemented
 These core REST, GraphQL, and Authentication services are extremely lightweight (20-50MB RAM). 
@@ -40,13 +40,13 @@ We spin up a unique `postgrest` AND `gotrue` process for *every* tenant dynamica
 - Desired state is stored per project in dedicated `projects.postgrest_*` metadata columns and is reconciled to actual systemd state in the runtime worker.
 - PostgREST-only lifecycle actions do not restart GoTrue, so REST-only repairs do not disturb authentication traffic.
 
-### 2. Kong API-Driven Gateway ⭐ Implemented
-Kong runs in **DB-backed mode** (PostgreSQL) as a native systemd service, fully managed via the Kong Admin API:
-- `GatewayService.ensureServiceAndRoute()` creates/updates Kong services and routes per tenant.
-- Per-route plugins (CORS, rate-limiting, JWT, request-transformer) are applied dynamically.
-- Global plugins (Gzip compression, security response headers, ACME SSL) are configured at the Kong level.
+### 2. Caddy API-Driven Gateway ⭐ Implemented
+Caddy runs as a native systemd service, fully managed via the Caddy Admin API:
+- `GatewayService.ensureServiceAndRoute()` creates/updates Caddy routes per tenant.
+- Per-route CORS, rate-limiting, auth forwarding, and websocket behavior are rendered dynamically into JSON config.
+- Global Automatic HTTPS, security response headers, and TLS issuance policy are configured at the gateway level.
 - **Programmable Rate Limiting**: Per-tenant rate limits can be set via `PUT /v1/projects/:ref/gateway/rate-limit` (supports tier presets or custom second/minute/hour values).
-- No manual YAML editing or `kong reload` — all changes take effect immediately via Admin API.
+- No manual config editing or daemon reload workflow — all changes take effect via Admin API publishing.
 
 ### 3. Storage API
 SupaCloud serves Supabase-compatible Storage through Management API storage routes. Binary data is written to the configured physical backend, while metadata is written to the tenant database with Row Level Security context applied.
@@ -75,7 +75,7 @@ Storage object listing is paginated and sorted in SQL rather than loading full o
 ### 6. Realtime API & Admin Console
 - **Realtime (Elixir)**: Very resource-intensive as it listens to PostgreSQL logical replication slots. Recommended to remain a shared premium feature or require dedicated high-tier clusters.
 - **Web Console (SVAdmin Hybrid Mount)**: The central dashboard (`web-console`) is fully multi-tenant aware via URL routing parameter `[ref]`. It acts as the Host/SuperAdmin dashboard, but internally relies on the `@svadmin/core` `DataProvider`. When standard CRUD is requested (e.g. Auth Users or DB Tables), the root `+layout.svelte` dynamically bridges SvelteKit routing into SVAdmin's resources array. 
-  - This allows the UI to render `svadmin` `<AutoTable>` and `useList` hooks seamlessly while hitting RESTful routes securely proxied to the tenant specific GoTrue / PostgREST instances via the Kong proxy.
+  - This allows the UI to render `svadmin` `<AutoTable>` and `useList` hooks seamlessly while hitting RESTful routes securely proxied to the tenant specific GoTrue / PostgREST instances via the Caddy gateway.
 
 ### 7. Edge Function Preheating ⭐ Implemented
 When a function is deployed via the Management API:

--- a/docs/edge-runtime-guide.md
+++ b/docs/edge-runtime-guide.md
@@ -16,9 +16,8 @@ SupaCloud (:9090)             Edge Runtime (:9000)
                               ├── URL Import Mapping (compat imports → npm/shims)
                               └── /preheat endpoint (zero cold-start)
 
-Kong Gateway (API-driven, native OpenResty):
-  Global: ACME SSL, Gzip, Security Headers
-  Per-route: CORS, Rate Limiting, JWT
+Caddy Gateway (Admin API-driven):
+  Automatic HTTPS, security headers, route JSON publishing, CORS, rate limiting
   /api/*        → :9090 (Management API)
   /functions/*  → :9090 (Management API sdk-proxy)
   /realtime/*   → :9090 (Management API websocket proxy)
@@ -136,7 +135,7 @@ Browser websocket traffic should enter through the Management API first:
 - upstream owner: Management API websocket proxy on `:9090`
 - Realtime container remains the internal upstream
 
-Do not route browser websocket traffic straight from Kong to the Elixir Realtime container's `/socket` path. That older topology is prone to:
+Do not route browser websocket traffic straight from Caddy to the Elixir Realtime container's `/socket` path. That older topology is prone to:
 
 - tenant host/path mismatches
 - wrong upstream rewrite behavior
@@ -145,7 +144,7 @@ Do not route browser websocket traffic straight from Kong to the Elixir Realtime
 The current supported model is:
 
 ```text
-browser -> Kong -> Management API (:9090) -> Realtime upstream
+browser -> Caddy -> Management API (:9090) -> Realtime upstream
 ```
 
 ## Realtime Tenant Recovery

--- a/docs/multi-tenant-management.md
+++ b/docs/multi-tenant-management.md
@@ -6,7 +6,7 @@ This document details the technical solution design for multi-project management
 
 ## 1. Architecture Overview
 
-Multiple Supabase projects are run with logical isolation by sharing infrastructure (Pigsty PostgreSQL, Kong API gateway, and object storage).
+Multiple Supabase projects are run with logical isolation by sharing infrastructure (Pigsty PostgreSQL, the SupaCloud Caddy gateway, and object storage).
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -26,7 +26,7 @@ Multiple Supabase projects are run with logical isolation by sharing infrastruct
 ├─────────────────────────────────────────────────────────────┤
 │                    Shared Infrastructure                     │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐             │
-│  │ PostgreSQL │  │   Kong     │  │ Obj Storage│             │
+│  │ PostgreSQL │  │   Caddy    │  │ Obj Storage│             │
 │  │  (Pigsty)  │  │  Gateway   │  │(JuiceFS/…) │             │
 │  └────────────┘  └────────────┘  └────────────┘             │
 └─────────────────────────────────────────────────────────────┘
@@ -86,13 +86,13 @@ CREATE INDEX idx_projects_status ON projects(status);
 
 ### 2.4 DNS and Routing Isolation
 
-Dynamic Vhost generation via Kong API-driven routing. Management API configures Kong routes programmatically.
+Dynamic Vhost generation via Caddy Admin API-driven routing. Management API publishes Caddy routes programmatically.
 
 | Domain Pattern | Routing Target |
 |----------------|----------------|
-| `api.example.com` | Shared Kong Gateway |
+| `api.example.com` | Shared Caddy Gateway |
 | `studio.example.com` | Shared Studio Console |
-| `<project>.api.example.com` | Kong + Tenant Header |
+| `<project>.api.example.com` | Caddy + Tenant Header |
 
 ---
 
@@ -121,9 +121,9 @@ Migration is project-scoped and writes ES256 `JWT_KEYS` / `JWT_JWKS` material in
 
 Existing `anon` and `service_role` API keys remain project-scoped and verifiable during migration. They are not shared across projects or accounts.
 
-### 3.4 Kong Integration
+### 3.4 Caddy Gateway Integration
 
-Kong dynamically validates JWT keys for different projects based on `Host` Header.
+Caddy dynamically routes requests for different projects based on `Host` header and the route JSON published by Management API.
 
 ---
 
@@ -222,7 +222,7 @@ Kong dynamically validates JWT keys for different projects based on `Host` Heade
 /opt/supacloud/scripts/lib/
 ├── db_manager.sh      # Database management
 ├── storage_manager.sh # Storage management (JuiceFS/S3)
-├── gateway_manager.sh # Kong routing management
+├── gateway service    # Caddy routing is managed in the Management API gateway provider
 └── jwt_manager.sh     # JWT key management
 ```
 
@@ -254,18 +254,9 @@ storage_manager.sh delete <project_ref>
 storage_manager.sh credentials <project_ref>
 ```
 
-#### gateway_manager.sh
+#### Gateway routing
 
-```bash
-# Provision Kong consumer/JWT settings for a project
-gateway_manager.sh setup-project <project_ref> <jwt_secret>
-
-# Update rate limiting profile
-gateway_manager.sh set-rate-limit <project_ref> <free|pro|enterprise>
-
-# Configure CORS origins
-gateway_manager.sh set-cors <project_ref> <origins>
-```
+Caddy routing is no longer managed through a standalone shell helper. The Management API publishes tenant routes, rate limiting, CORS, and TLS state directly to the Caddy Admin API.
 
 #### jwt_manager.sh
 
@@ -348,7 +339,7 @@ supacloud_project_storage_bytes{project_ref="abc123"}
 3. Create database → Rollback on failure
 4. Create storage bucket → Rollback database on failure
 5. Generate JWT keys
-6. Configure Kong routing
+6. Configure Caddy routing
 7. Update status: active
 ```
 
@@ -366,7 +357,7 @@ supacloud_project_storage_bytes{project_ref="abc123"}
 |-------|------|--------|
 | 1 | Basic API + Database layer | Runnable CRUD API |
 | 2 | Shell script integration | Complete project creation flow |
-| 3 | Kong dynamic routing | Multi-tenant domain support |
+| 3 | Caddy dynamic routing | Multi-tenant domain support |
 | 4 | Monitoring integration | Grafana multi-project dashboard |
 | 5 | CLI segmentation | Separate operator and project-user workflows |
 

--- a/docs/supacloud-vs-supabase.md
+++ b/docs/supacloud-vs-supabase.md
@@ -58,7 +58,7 @@ SupaCloud is opinionated about running **many projects per server or cluster**. 
 - a management API for project lifecycle and settings
 - a self-hosted web console
 - tenant runtime generation/restart flows
-- Kong-based per-project routing
+- Caddy-based per-project routing
 - operator and project-user CLIs
 
 That is the main difference from the official self-hosted Supabase stack, which is documented as Docker-based self-hosting where **you are responsible for server provisioning, security hardening, database operations, backups, and disaster recovery**.

--- a/docs/upgrade-to-pigsty-4.1.md
+++ b/docs/upgrade-to-pigsty-4.1.md
@@ -1,6 +1,6 @@
 # Upgrade to Pigsty 4.3
 
-This guide helps existing SupaCloud users upgrade the Pigsty foundation to v4.3 while preserving SupaCloud's own Kong, Edge Runtime, task, and JuiceFS-backed storage integration.
+This guide helps existing SupaCloud users upgrade the Pigsty foundation to v4.3 while preserving SupaCloud's own Caddy gateway, Edge Runtime, task, and JuiceFS-backed storage integration.
 
 ## Important Notes
 

--- a/install.sh
+++ b/install.sh
@@ -2864,7 +2864,7 @@ deploy_ai_breadcrumbs() {
 # If you are an AI/Agent reading this file to understand the architecture:
 # STOP LOOKING FOR A HOST WEB SERVER.
 #
-# This server runs SupaCloud. Host-level Nginx, Angie, Apache, and legacy Kong
+# This server runs SupaCloud. Host-level Nginx, Angie, and Apache
 # are not part of the default public HTTP(S) path.
 #
 # ARCHITECTURE:
@@ -2876,7 +2876,7 @@ deploy_ai_breadcrumbs() {
 #
 # STRICT RULES:
 # - DO NOT configure Nginx/Angie for SupaCloud public routing.
-# - DO NOT enable Kong for SupaCloud public routing.
+# - DO NOT introduce alternate public gateways for SupaCloud routing.
 # - To inspect routes or TLS, query Caddy: `curl -sS http://127.0.0.1:2019/config/`
 # - Logs: `journalctl -u supacloud -f`
 # ==============================================================================

--- a/packages/supacloud-js/README.md
+++ b/packages/supacloud-js/README.md
@@ -87,7 +87,7 @@ The helper maps to these SupaCloud Management API routes:
 
 Boundary:
 
-- Use `@supacloud/js` for SupaCloud-owned infrastructure orchestration: GoTrue env injection, restart/reconcile, Kong route setup, runtime health checks, and public client config discovery.
+- Use `@supacloud/js` for SupaCloud-owned infrastructure orchestration: GoTrue env injection, restart/reconcile, Caddy route setup, runtime health checks, and public client config discovery.
 - Use `@supabase/supabase-js` for normal application runtime calls: auth session, database, storage, realtime, and edge functions.
 - Use the SupaOAuth product SDK or Management API for SupaOAuth-owned resources: applications, connectors, organizations, roles, permissions, audit logs, and webhooks.
 - Do not expose SupaCloud Management API credentials in browser code.


### PR DESCRIPTION
## Summary
- align README gateway descriptions and architecture diagrams with the Caddy-only runtime introduced in `90ae018`
- remove stale Kong wording from operator docs and upgrade notes
- trim misleading install/script references while keeping legacy cleanup logic intact

## Why
TypeScript gateway/runtime code already uses Caddy as the sole gateway provider, but several user-facing docs still described Kong as the current runtime. That mismatch can mislead operators during installation and troubleshooting.

## Scope
- `README.md`
- `docs/architecture-multi-tenant.md`
- `docs/edge-runtime-guide.md`
- `docs/multi-tenant-management.md`
- `docs/supacloud-vs-supabase.md`
- `docs/upgrade-to-pigsty-4.1.md`
- `install.sh` comments/breadcrumb text
- `packages/supacloud-js/README.md`

## Verification
- searched remaining `Kong` references in user-facing docs/install surfaces after the edit
- confirmed only legacy cleanup references remain in `install.sh` (`kong.service` stop and `supabase-kong` cleanup)
