### PR TITLE
fix: skip edge runtime cleanup in external mode

### DIFF
--- a/scripts/pre_start_recovery.sh
+++ b/scripts/pre_start_recovery.sh
@@ -139,6 +139,13 @@ ensure_service_containers_running() {
 # only the newly started runtime claims the port.
 kill_edge_runtime_zombies() {
     local EDGE_PORT="${EDGE_RUNTIME_PORT:-9000}"
+    local EDGE_MODE="${EDGE_RUNTIME_MODE:-embedded}"
+
+    if [[ "$EDGE_MODE" == "external" ]]; then
+        log_info "EDGE_RUNTIME_MODE=external, skipping stale Edge Runtime cleanup on port ${EDGE_PORT}"
+        return
+    fi
+
     log_info "Checking for stale Edge Runtime processes on port ${EDGE_PORT}..."
     
     local stale_pids


### PR DESCRIPTION
## Summary
- skip the port-9000 stale listener cleanup when `EDGE_RUNTIME_MODE=external`
- keep the zombie cleanup behavior unchanged for embedded mode

## Why
In external mode, `supacloud-edge-runtime.service` owns port `9000`. Restarting `supacloud.service` should not kill that independent runtime during `ExecStartPre`, otherwise the management API restart causes an unnecessary edge-runtime blip and a systemd restart cycle.

## Verification
- reproduced on a VM with `EDGE_RUNTIME_MODE=external`
- after the change, restarting `supacloud.service` no longer interrupts `supacloud-edge-runtime.service`
