### PR TITLE
feat(auth): orchestrate dedicated auth domains with Caddy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1462,6 +1462,7 @@ install_caddy_gateway() {
       "servers": {
         "supacloud": {
           "listen": [":80", ":443"],
+          "tls_connection_policies": [{}],
           "http3": {},
           "routes": []
         }

--- a/packages/management-api/src/routes/auth-oauth-server.ts
+++ b/packages/management-api/src/routes/auth-oauth-server.ts
@@ -7,6 +7,7 @@ import { resolveProjectServiceRoleKey } from "../utils/service-role";
 import { sql as metaSql } from "../db";
 import {
   normalizeProjectRoutingConfig,
+  resolveProjectAuthUrl,
   resolveProjectApiUrl,
   resolveTenantPorts,
 } from "../utils/project-routing";
@@ -72,6 +73,7 @@ async function loadProjectContext(ref: string) {
   const rawConfig = normalizeProjectConfig(rows[0]?.config);
   const routingConfig = normalizeProjectRoutingConfig(rawConfig);
   const apiUrl = resolveProjectApiUrl(ref, routingConfig).replace(/\/+$/, "");
+  const authUrl = resolveProjectAuthUrl(ref, routingConfig).replace(/\/+$/, "");
   const serviceRoleKey = await resolveProjectServiceRoleKey(ref);
   const ports = resolveTenantPorts(routingConfig);
   const gotrueUrl = ports?.gotruePort
@@ -85,7 +87,8 @@ async function loadProjectContext(ref: string) {
     organizationId: rows[0]?.organization_id || project.organization_id || "default",
     jwtSecret: String(rows[0]?.jwt_secret || ""),
     apiUrl,
-    issuer: oauthServer.issuer || `${apiUrl}/auth/v1`,
+    authUrl,
+    issuer: oauthServer.issuer || `${authUrl}/auth/v1`,
     gotrueUrl,
     serviceRoleKey,
     oauthServer,
@@ -94,7 +97,7 @@ async function loadProjectContext(ref: string) {
 
 function buildOAuthServerStatus(ctx: NonNullable<Awaited<ReturnType<typeof loadProjectContext>>>) {
   const issuer = ctx.issuer.replace(/\/+$/, "");
-  const apiUrl = ctx.apiUrl.replace(/\/+$/, "");
+  const authUrl = ctx.authUrl.replace(/\/+$/, "");
   const jwtKeys = normalizeProjectJwtKeys(ctx.oauthServer.jwt_keys);
   const jwtJwks = normalizeProjectJwtJwks(ctx.oauthServer.jwt_jwks);
   const migrated = Boolean(jwtKeys && jwtJwks);
@@ -106,7 +109,7 @@ function buildOAuthServerStatus(ctx: NonNullable<Awaited<ReturnType<typeof loadP
     allow_dynamic_registration: ctx.oauthServer.allow_dynamic_registration === true,
     issuer,
     discovery_url: `${issuer}/.well-known/openid-configuration`,
-    oauth_authorization_server_metadata_url: `${apiUrl}/.well-known/oauth-authorization-server/auth/v1`,
+    oauth_authorization_server_metadata_url: `${authUrl}/.well-known/oauth-authorization-server/auth/v1`,
     jwks_url: `${issuer}/.well-known/jwks.json`,
     authorization_endpoint: `${issuer}/oauth/authorize`,
     token_endpoint: `${issuer}/oauth/token`,

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -314,6 +314,11 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
             description: "Explicit API domain (e.g., 'xg-api.example.com')",
           }),
         ),
+        auth_domain: t.Optional(
+          t.String({
+            description: "Explicit Auth/OIDC domain (e.g., 'auth.example.com')",
+          }),
+        ),
         studio_domain: t.Optional(
           t.String({
             description:

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -6,6 +6,7 @@ import {
     type ProjectRoutingConfig,
     normalizeProjectRoutingConfig,
     resolveProjectApiHost,
+    resolveProjectAuthHost,
     resolveProjectStudioHost,
 } from "../utils/project-routing";
 import { normalizeProjectConfig } from "../utils/project-config";
@@ -66,6 +67,7 @@ export function buildTenantCorsOrigins(
     const hosts = [
         `${projectRef}.api.${config.baseDomain}`,
         resolveProjectApiHost(projectRef, routingConfig),
+        resolveProjectAuthHost(projectRef, routingConfig),
         `studio-${projectRef}.${config.baseDomain}`,
         resolveProjectStudioHost(projectRef, routingConfig),
         ...extraHosts,
@@ -151,6 +153,7 @@ type CaddyRoute = Record<string, unknown>;
 type CaddyMatcher = Record<string, unknown>;
 type CaddyServer = {
     listen: string[];
+    tls_connection_policies?: Array<Record<string, unknown>>;
     routes: CaddyRoute[];
 };
 
@@ -199,6 +202,8 @@ function sanitizeCaddyId(value: string): string {
 const CADDY_PROJECT_ROUTE_KINDS = [
     "rest",
     "graphql",
+    "auth-domain-auth",
+    "auth-domain-gotrue-well-known",
     "auth",
     "gotrue-well-known",
     "functions",
@@ -265,6 +270,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     servers: {
                         supacloud: {
                             listen: [":80", ":443"],
+                            tls_connection_policies: [{}],
                             routes,
                         },
                     },
@@ -889,12 +895,16 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 `${projectRef}.api.${config.baseDomain}`,
                 resolveProjectApiHost(projectRef, routingConfig),
             ]);
+            const hostSet = new Set(hosts.map(normalizeCaddyHost));
+            const authHosts = uniqueStrings([resolveProjectAuthHost(projectRef, routingConfig)])
+                .filter((host) => !hostSet.has(normalizeCaddyHost(host)));
             const studioHosts = uniqueStrings([
                 `studio-${projectRef}.${config.baseDomain}`,
                 resolveProjectStudioHost(projectRef, routingConfig),
             ]);
             const corsOrigins = buildTenantCorsOrigins(projectRef, routingConfig, [
                 ...hosts,
+                ...authHosts,
                 ...studioHosts,
                 ...this.hostsForProjectRoutes(projectRef),
             ]);
@@ -914,6 +924,28 @@ export class CaddyGatewayProvider implements GatewayProvider {
             ];
 
             for (const route of routes) this.routesById.set(String(route["@id"]), route);
+            if (authHosts.length > 0) {
+                this.routesById.set(caddyRouteId(projectRef, "auth-domain-auth"), this.makeRoute({
+                    id: caddyRouteId(projectRef, "auth-domain-auth"),
+                    hosts: authHosts,
+                    path: "/auth/v1*",
+                    upstream: `${hostIp}:${gotruePort}`,
+                    projectRef,
+                    stripPrefix: "/auth/v1",
+                    corsOrigins,
+                }));
+                this.routesById.set(caddyRouteId(projectRef, "auth-domain-gotrue-well-known"), this.makeRoute({
+                    id: caddyRouteId(projectRef, "auth-domain-gotrue-well-known"),
+                    hosts: authHosts,
+                    path: "/.well-known/oauth-authorization-server/auth/v1*",
+                    upstream: `${hostIp}:${gotruePort}`,
+                    projectRef,
+                    corsOrigins,
+                }));
+            } else {
+                this.routesById.delete(caddyRouteId(projectRef, "auth-domain-auth"));
+                this.routesById.delete(caddyRouteId(projectRef, "auth-domain-gotrue-well-known"));
+            }
             await this.persistAndLoad();
             logger.info(`[CaddyGatewayProvider] Routes registered for ${projectRef}`);
             return { success: true };

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -32,6 +32,7 @@ export interface CreateProjectRequest {
   organization_id?: string;
   domain?: string; // Base custom domain (e.g., "aorist.cn") — auto generates api.X / studio.X
   api_domain?: string; // Explicit API domain (e.g., "xg-api.aizhuliren.cn")
+  auth_domain?: string; // Explicit Auth/OIDC domain (e.g., "auth.example.com")
   studio_domain?: string; // Explicit Studio domain (e.g., "xg-studio.aizhuliren.cn")
 }
 
@@ -244,6 +245,9 @@ export class ProjectService {
     // Support explicit api_domain / studio_domain (takes precedence over base domain)
     if (request.api_domain) {
       initialConfig.api_domain = request.api_domain;
+    }
+    if (request.auth_domain) {
+      initialConfig.auth_domain = request.auth_domain;
     }
     if (request.studio_domain) {
       initialConfig.studio_domain = request.studio_domain;
@@ -598,6 +602,7 @@ export class ProjectService {
     const routingKeys: Array<keyof typeof config> = [
       "custom_domain",
       "api_domain",
+      "auth_domain",
       "studio_domain",
       "site_url",
       "siteUrl",

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -7,7 +7,7 @@ import * as path from "node:path";
 import type { OAuthProvider, OAuthProviderConfig } from "../types/oauth";
 import { OAUTH_ENV_MAPPINGS } from "../types/oauth";
 import { tenantOAuthService } from "./tenant-oauth.service";
-import { resolveProjectApiUrl, resolveProjectStudioUrl } from "../utils/project-routing";
+import { resolveProjectApiUrl, resolveProjectAuthUrl, resolveProjectStudioUrl } from "../utils/project-routing";
 import { normalizeProjectConfig } from "../utils/project-config";
 import { normalizeProjectJwtJwks, normalizeProjectJwtKeys } from "../utils/project-jwt";
 
@@ -18,6 +18,10 @@ function stringifyJsonConfig(value: unknown): string | null {
 
 function quoteSystemdEnvValue(value: string): string {
     return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function uniqueStrings(values: Array<string | undefined | null>): string[] {
+    return Array.from(new Set(values.map((value) => String(value || "").trim()).filter(Boolean)));
 }
 
 export interface RuntimeStatus {
@@ -1004,6 +1008,10 @@ class TenantRuntimeService {
         return resolveProjectApiUrl(ref, projectConfig);
     }
 
+    private deriveAuthUrl(ref: string, projectConfig: Record<string, unknown> | null | undefined): string {
+        return resolveProjectAuthUrl(ref, projectConfig);
+    }
+
     /**
      * Deterministic port allocation based on hashing
      * Aligned with original bash awk behavior using native Bun logic
@@ -1072,6 +1080,7 @@ class TenantRuntimeService {
             jwtJwks,
             dbName: await resolveDbName(ref),
             apiUrl: this.deriveApiUrl(ref, projectConfig),
+            authUrl: this.deriveAuthUrl(ref, projectConfig),
             anonKey: project.anonKey || project.anon_key,
             serviceRoleKey: project.serviceRoleKey || project.service_role_key,
             siteUrl: typeof projectConfig.site_url === "string"
@@ -1176,7 +1185,16 @@ db-channel = "${resolvePgrstChannel(ref)}"
         await Bun.write(path.join(this.TENANT_CONFIG_DIR, `${ref}.conf`), pgrstConf);
 
         // Generate GoTrue .env configuration
-        const apiExternalUrl = creds.apiUrl;
+        const hasDedicatedAuthUrl = Boolean(creds.authUrl && creds.authUrl !== creds.apiUrl);
+        const apiExternalUrl = hasDedicatedAuthUrl ? creds.authUrl : creds.apiUrl;
+        const siteExternalUrl = hasDedicatedAuthUrl ? creds.authUrl : creds.siteUrl;
+        const siteHost = siteExternalUrl.replace('https://', '').replace('http://', '').split('/')[0].split(':')[0];
+        const redirectOrigins = uniqueStrings([
+            creds.uriAllowList,
+            creds.siteUrl,
+            creds.apiUrl,
+            creds.authUrl,
+        ].flatMap((value) => String(value || "").split(",")));
         const gotrueSender = config.gotrueSmtpAdminEmail || `noreply@${apiExternalUrl.replace('https://', '').replace('http://', '')}`;
 
         let gotrueEnv = `
@@ -1184,8 +1202,8 @@ db-channel = "${resolvePgrstChannel(ref)}"
 GOTRUE_API_HOST=0.0.0.0
 GOTRUE_API_PORT=${gotruePort}
 API_EXTERNAL_URL=${apiExternalUrl}
-GOTRUE_SITE_URL=${creds.siteUrl}
-GOTRUE_URI_ALLOW_LIST=${creds.uriAllowList || creds.siteUrl}
+GOTRUE_SITE_URL=${siteExternalUrl}
+GOTRUE_URI_ALLOW_LIST=${redirectOrigins.join(",")}
 GOTRUE_DB_DRIVER=postgres
 GOTRUE_DB_DATABASE_URL=postgres://supabase_auth_admin:${config.pgPassword}@${this.PG_HOST}:${this.PG_PORT}/${creds.dbName}
 GOTRUE_JWT_SECRET=${creds.jwtSecret}
@@ -1199,8 +1217,8 @@ GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED=true
 GOTRUE_EXTERNAL_EMAIL_ENABLED=true
 GOTRUE_EXTERNAL_PHONE_ENABLED=true
 GOTRUE_WEBAUTHN_ENABLED=true
-GOTRUE_WEBAUTHN_RP_ID=${creds.siteUrl.replace('https://', '').replace('http://', '').split('/')[0].split(':')[0]}
-GOTRUE_WEBAUTHN_RP_ORIGINS=https://${creds.siteUrl.replace('https://', '').replace('http://', '').split('/')[0].split(':')[0]},${apiExternalUrl}
+GOTRUE_WEBAUTHN_RP_ID=${siteHost}
+GOTRUE_WEBAUTHN_RP_ORIGINS=${uniqueStrings([siteExternalUrl, creds.apiUrl, creds.siteUrl]).join(",")}
 GOTRUE_PASSWORD_MIN_LENGTH=8
 GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=true
 GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_REUSE_INTERVAL=10
@@ -1214,13 +1232,16 @@ GOTRUE_OPERATOR_TOKEN=${config.masterToken || creds.serviceRoleKey}
 
         const oauthServerConfig = (creds.authConfig.oauth_server || {}) as Record<string, unknown>;
         if (oauthServerConfig.enabled === true) {
+            const authorizationPath = typeof oauthServerConfig.authorization_path === "string"
+                ? oauthServerConfig.authorization_path
+                : (typeof oauthServerConfig.authorizationPath === "string" ? oauthServerConfig.authorizationPath : "");
             gotrueEnv += `
 
 # OAuth 2.1 / OIDC Provider Configuration
 GOTRUE_OAUTH_SERVER_ENABLED=true
 GOTRUE_OAUTH_SERVER_ALLOW_DYNAMIC_REGISTRATION=${oauthServerConfig.allow_dynamic_registration === true ? "true" : "false"}
 GOTRUE_JWT_ISSUER=${oauthServerConfig.issuer || `${apiExternalUrl}/auth/v1`}
-${creds.jwtKeys ? `GOTRUE_JWT_KEYS=${quoteSystemdEnvValue(creds.jwtKeys)}\nJWT_KEYS=${quoteSystemdEnvValue(creds.jwtKeys)}` : ""}
+${authorizationPath ? `GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH=${authorizationPath}\n` : ""}${creds.jwtKeys ? `GOTRUE_JWT_KEYS=${quoteSystemdEnvValue(creds.jwtKeys)}\nJWT_KEYS=${quoteSystemdEnvValue(creds.jwtKeys)}` : ""}
 `;
         }
 

--- a/packages/management-api/src/utils/project-routing.ts
+++ b/packages/management-api/src/utils/project-routing.ts
@@ -3,6 +3,7 @@ import { config } from "../config";
 export interface ProjectRoutingConfig {
   custom_domain?: unknown;
   api_domain?: unknown;
+  auth_domain?: unknown;
   studio_domain?: unknown;
   postgrest_port?: unknown;
   gotrue_port?: unknown;
@@ -71,6 +72,17 @@ export function resolveProjectApiHost(
   return `${projectRef}.api.${normalizeBaseDomain(config.baseDomain)}`;
 }
 
+export function resolveProjectAuthHost(
+  projectRef: string,
+  projectConfig: ProjectRoutingConfig | string | null | undefined,
+): string {
+  const normalizedConfig = normalizeProjectRoutingConfig(projectConfig);
+  const explicitAuthDomain = pickString(normalizedConfig?.auth_domain);
+  if (explicitAuthDomain) return explicitAuthDomain;
+
+  return resolveProjectApiHost(projectRef, normalizedConfig);
+}
+
 export function resolveProjectStudioHost(
   projectRef: string,
   projectConfig: ProjectRoutingConfig | string | null | undefined,
@@ -92,6 +104,13 @@ export function resolveProjectApiUrl(
   projectConfig: ProjectRoutingConfig | string | null | undefined,
 ): string {
   return `${config.enableSsl ? "https" : "http"}://${resolveProjectApiHost(projectRef, projectConfig)}`;
+}
+
+export function resolveProjectAuthUrl(
+  projectRef: string,
+  projectConfig: ProjectRoutingConfig | string | null | undefined,
+): string {
+  return `${config.enableSsl ? "https" : "http"}://${resolveProjectAuthHost(projectRef, projectConfig)}`;
 }
 
 export function resolveProjectStudioUrl(
@@ -123,12 +142,14 @@ export function matchProjectRefFromHost(
   const baseDomain = normalizeBaseDomain(config.baseDomain).toLowerCase();
   if (baseDomain && normalizedHost.endsWith(baseDomain)) {
     return normalizedHost === resolveProjectApiHost(projectRef, normalizedConfig).toLowerCase()
+      || normalizedHost === resolveProjectAuthHost(projectRef, normalizedConfig).toLowerCase()
       || normalizedHost === resolveProjectStudioHost(projectRef, normalizedConfig).toLowerCase()
       || normalizedHost === `${projectRef}.${baseDomain}`.toLowerCase()
       || normalizedHost === `${projectRef}.api.${baseDomain}`.toLowerCase();
   }
 
   return normalizedHost === resolveProjectApiHost(projectRef, normalizedConfig).toLowerCase()
+    || normalizedHost === resolveProjectAuthHost(projectRef, normalizedConfig).toLowerCase()
     || normalizedHost === resolveProjectStudioHost(projectRef, normalizedConfig).toLowerCase()
     || normalizedHost === pickString(normalizedConfig?.custom_domain)?.toLowerCase();
 }

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -106,10 +106,12 @@ describe("GatewayService provider selection", () => {
     test("tenant cors origins include exact api and studio custom domains", () => {
         const origins = buildTenantCorsOrigins("dbbabyref", {
             api_domain: "sapi.dbbaby.top",
+            auth_domain: "auth.dbbaby.top",
             studio_domain: "sadmin.dbbaby.top",
         });
 
         expect(origins).toContain("https://sapi.dbbaby.top");
+        expect(origins).toContain("https://auth.dbbaby.top");
         expect(origins).toContain("https://sadmin.dbbaby.top");
     });
 });
@@ -131,6 +133,7 @@ describe("CaddyGatewayProvider", () => {
         expect(load).toBeDefined();
         const server = load?.body?.apps?.http?.servers?.supacloud;
         expect(server).not.toHaveProperty("http3");
+        expect(server?.tls_connection_policies).toEqual([{}]);
         expect(load?.body?.apps?.tls?.automation?.policies?.[0]?.key_type).toBe("p256");
         const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
         const rest = routes.find((route: any) => route["@id"] === "route-project-testref123-rest");
@@ -171,6 +174,34 @@ describe("CaddyGatewayProvider", () => {
         expect(corsHeaders?.response?.set?.["Access-Control-Allow-Origin"]).toEqual(["{http.request.header.Origin}"]);
         expect(corsHeaders?.response?.set?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
         expect(preflight?.match?.some((matcher: any) => matcher.header_regexp?.Origin?.pattern?.includes("localhost"))).toBe(true);
+
+        restore();
+    });
+
+    test("setupUpstream renders auth-only routes for a dedicated auth domain", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        const result = await provider.setupUpstream("proj123", 3000, 9999, {
+            api_domain: "api.example.com",
+            auth_domain: "auth.example.com",
+            studio_domain: "studio.example.com",
+        });
+        expect(result.success).toBe(true);
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const rest = routes.find((route: any) => route["@id"] === "route-project-proj123-rest");
+        const auth = routes.find((route: any) => route["@id"] === "route-project-proj123-auth-domain-auth");
+        const wellKnown = routes.find((route: any) => route["@id"] === "route-project-proj123-auth-domain-gotrue-well-known");
+
+        expect(rest?.match?.[0]?.host).not.toContain("auth.example.com");
+        expect(auth?.match?.[0]?.host).toEqual(["auth.example.com"]);
+        expect(auth?.match?.[0]?.path).toEqual(["/auth/v1*"]);
+        expect(auth?.handle?.some((handler: any) => handler.strip_path_prefix === "/auth/v1")).toBe(true);
+        expect(wellKnown?.match?.[0]?.host).toEqual(["auth.example.com"]);
+        expect(wellKnown?.match?.[0]?.path).toEqual(["/.well-known/oauth-authorization-server/auth/v1*"]);
 
         restore();
     });


### PR DESCRIPTION
## Summary
- add project-level auth_domain routing helpers and Caddy auth-only routes for /auth/v1 and OAuth server metadata
- make GoTrue runtime env derive API_EXTERNAL_URL, site URL, WebAuthn origin, issuer, and authorization_path from a dedicated auth domain
- keep REST/Storage/Functions on API domains and avoid exposing them on the auth domain
- add Caddy tls_connection_policies to generated and installed JSON so :443 stays TLS-enabled after reload/restart

## Verification
- bun run typecheck
- bun test tests/unit/gateway.service.test.ts tests/unit/auth-oauth-server.test.ts
- bun run test:unit
