### PR TITLE
fix(auth): address auth domain review feedback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1442,6 +1442,8 @@ install_caddy_gateway() {
         return 1
     fi
 
+    # The empty TLS connection policy is intentional: without it Caddy can keep
+    # :443 as a plain HTTP listener when loading JSON with both :80 and :443.
     cat > /etc/supacloud/caddy/config.json <<'EOF'
 {
   "admin": { "listen": "127.0.0.1:2019" },

--- a/packages/management-api/src/routes/auth-oauth-server.ts
+++ b/packages/management-api/src/routes/auth-oauth-server.ts
@@ -11,7 +11,7 @@ import {
   resolveProjectApiUrl,
   resolveTenantPorts,
 } from "../utils/project-routing";
-import { normalizeProjectConfig } from "../utils/project-config";
+import { normalizeOAuthServerConfig, normalizeProjectConfig } from "../utils/project-config";
 import {
   generateOidcJwtKeyMaterial,
   normalizeProjectJwtJwks,
@@ -52,6 +52,7 @@ type OAuthServerSettings = {
   migrated_at?: string;
   signing_alg?: string;
   key_id?: string;
+  authorization_path?: string;
   jwt_keys?: unknown;
   jwt_jwks?: unknown;
 };
@@ -80,7 +81,7 @@ async function loadProjectContext(ref: string) {
     ? `http://127.0.0.1:${ports.gotruePort}`
     : apiUrl.replace(/\/+$/, "").replace(/\/auth\/v1$/, "");
   const authConfig = (rawConfig.auth || {}) as Record<string, unknown>;
-  const oauthServer = (authConfig.oauth_server || {}) as OAuthServerSettings;
+  const oauthServer = normalizeOAuthServerConfig(authConfig.oauth_server) as OAuthServerSettings;
 
   return {
     project,
@@ -184,7 +185,7 @@ async function migrateProjectToOidc(
   if (!settings) return status(404, { message: "Project not found", code: "404" });
 
   const currentAuth = (settings.auth || {}) as Record<string, unknown>;
-  const currentOauthServer = (currentAuth.oauth_server || {}) as OAuthServerSettings;
+  const currentOauthServer = normalizeOAuthServerConfig(currentAuth.oauth_server) as OAuthServerSettings;
   const existingJwtKeys = normalizeProjectJwtKeys(currentOauthServer.jwt_keys);
   const existingJwtJwks = normalizeProjectJwtJwks(currentOauthServer.jwt_jwks);
   const keyMaterial = existingJwtKeys && existingJwtJwks && typeof currentOauthServer.key_id === "string"

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -10,6 +10,7 @@ import {
     resolveProjectStudioHost,
 } from "../utils/project-routing";
 import { normalizeProjectConfig } from "../utils/project-config";
+import { uniqueStrings } from "../utils/strings";
 
 export const DEFAULT_CORS_HEADERS = [
     "Accept", "Accept-Language", "Authorization", "Content-Language", "Content-Type",
@@ -168,10 +169,6 @@ type CaddyConfig = {
     };
 };
 
-function uniqueStrings(values: Array<string | undefined | null>): string[] {
-    return Array.from(new Set(values.map((v) => String(v || "").trim()).filter(Boolean)));
-}
-
 function caddyRouteId(projectRef: string, kind: string): string {
     return `route-project-${projectRef}-${kind}`;
 }
@@ -270,6 +267,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     servers: {
                         supacloud: {
                             listen: [":80", ":443"],
+                            // Caddy JSON requires an explicit TLS policy to keep :443 in TLS mode after file reloads.
                             tls_connection_policies: [{}],
                             routes,
                         },

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -8,8 +8,9 @@ import type { OAuthProvider, OAuthProviderConfig } from "../types/oauth";
 import { OAUTH_ENV_MAPPINGS } from "../types/oauth";
 import { tenantOAuthService } from "./tenant-oauth.service";
 import { resolveProjectApiUrl, resolveProjectAuthUrl, resolveProjectStudioUrl } from "../utils/project-routing";
-import { normalizeProjectConfig } from "../utils/project-config";
+import { normalizeOAuthServerConfig, normalizeProjectConfig } from "../utils/project-config";
 import { normalizeProjectJwtJwks, normalizeProjectJwtKeys } from "../utils/project-jwt";
+import { uniqueStrings } from "../utils/strings";
 
 function stringifyJsonConfig(value: unknown): string | null {
     if (!value) return null;
@@ -18,10 +19,6 @@ function stringifyJsonConfig(value: unknown): string | null {
 
 function quoteSystemdEnvValue(value: string): string {
     return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
-
-function uniqueStrings(values: Array<string | undefined | null>): string[] {
-    return Array.from(new Set(values.map((value) => String(value || "").trim()).filter(Boolean)));
 }
 
 export interface RuntimeStatus {
@@ -1070,7 +1067,7 @@ class TenantRuntimeService {
 
         const projectConfig = normalizeProjectConfig(project.config);
         const authConfig = (projectConfig.auth as Record<string, unknown>) || {};
-        const oauthServerConfig = (authConfig.oauth_server || {}) as Record<string, unknown>;
+        const oauthServerConfig = normalizeOAuthServerConfig(authConfig.oauth_server);
         const jwtKeys = stringifyJsonConfig(normalizeProjectJwtKeys(oauthServerConfig.jwt_keys));
         const jwtJwks = stringifyJsonConfig(normalizeProjectJwtJwks(oauthServerConfig.jwt_jwks));
         return {
@@ -1189,6 +1186,8 @@ db-channel = "${resolvePgrstChannel(ref)}"
         const apiExternalUrl = hasDedicatedAuthUrl ? creds.authUrl : creds.apiUrl;
         const siteExternalUrl = hasDedicatedAuthUrl ? creds.authUrl : creds.siteUrl;
         const siteHost = siteExternalUrl.replace('https://', '').replace('http://', '').split('/')[0].split(':')[0];
+        const webAuthnOrigins = uniqueStrings([siteExternalUrl, creds.apiUrl, creds.siteUrl]
+            .map((value) => this.toWebAuthnOrigin(value)));
         const redirectOrigins = uniqueStrings([
             creds.uriAllowList,
             creds.siteUrl,
@@ -1218,7 +1217,7 @@ GOTRUE_EXTERNAL_EMAIL_ENABLED=true
 GOTRUE_EXTERNAL_PHONE_ENABLED=true
 GOTRUE_WEBAUTHN_ENABLED=true
 GOTRUE_WEBAUTHN_RP_ID=${siteHost}
-GOTRUE_WEBAUTHN_RP_ORIGINS=${uniqueStrings([siteExternalUrl, creds.apiUrl, creds.siteUrl]).join(",")}
+GOTRUE_WEBAUTHN_RP_ORIGINS=${webAuthnOrigins.join(",")}
 GOTRUE_PASSWORD_MIN_LENGTH=8
 GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=true
 GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_REUSE_INTERVAL=10
@@ -1230,11 +1229,11 @@ GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
 GOTRUE_OPERATOR_TOKEN=${config.masterToken || creds.serviceRoleKey}
 `.trim();
 
-        const oauthServerConfig = (creds.authConfig.oauth_server || {}) as Record<string, unknown>;
+        const oauthServerConfig = normalizeOAuthServerConfig(creds.authConfig.oauth_server);
         if (oauthServerConfig.enabled === true) {
             const authorizationPath = typeof oauthServerConfig.authorization_path === "string"
                 ? oauthServerConfig.authorization_path
-                : (typeof oauthServerConfig.authorizationPath === "string" ? oauthServerConfig.authorizationPath : "");
+                : "";
             gotrueEnv += `
 
 # OAuth 2.1 / OIDC Provider Configuration
@@ -1268,6 +1267,22 @@ GOTRUE_MAILER_AUTOCONFIRM=true
         await Bun.write(path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`), gotrueEnv);
 
         logger.info(`Config generated for ${ref} (pgrst_port=${pgrstPort}, gotrue_port=${gotruePort})`);
+    }
+
+    private toWebAuthnOrigin(value: string | undefined | null): string | null {
+        const raw = String(value || "").trim();
+        if (!raw) return null;
+
+        try {
+            const parsed = new URL(raw.includes("://") ? raw : `https://${raw}`);
+            const hostname = parsed.hostname.toLowerCase();
+            const protocol = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]"
+                ? parsed.protocol
+                : "https:";
+            return `${protocol}//${parsed.host}`;
+        } catch {
+            return null;
+        }
     }
 
     private async installSystemdTemplate() {

--- a/packages/management-api/src/utils/project-config.ts
+++ b/packages/management-api/src/utils/project-config.ts
@@ -28,6 +28,15 @@ export function mergeProjectConfig(
   };
 }
 
+export function normalizeOAuthServerConfig(value: unknown): Record<string, unknown> {
+  const config = isRecord(value) ? { ...value } : {};
+  if (typeof config.authorizationPath === "string" && typeof config.authorization_path !== "string") {
+    config.authorization_path = config.authorizationPath;
+  }
+  delete config.authorizationPath;
+  return config;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/management-api/src/utils/strings.ts
+++ b/packages/management-api/src/utils/strings.ts
@@ -1,0 +1,3 @@
+export function uniqueStrings(values: Array<string | undefined | null>): string[] {
+  return Array.from(new Set(values.map((value) => String(value || "").trim()).filter(Boolean)));
+}

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -206,6 +206,32 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("setupUpstream does not render duplicate auth-domain routes without a dedicated auth domain", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.setupUpstream("proj-no-auth", 3000, 9999, {
+            api_domain: "api.example.com",
+            studio_domain: "studio.example.com",
+        });
+        await provider.setupUpstream("proj-same-auth", 3001, 9998, {
+            api_domain: "api2.example.com",
+            auth_domain: "api2.example.com",
+            studio_domain: "studio2.example.com",
+        });
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+
+        expect(routes.some((route: any) => route["@id"] === "route-project-proj-no-auth-auth-domain-auth")).toBe(false);
+        expect(routes.some((route: any) => route["@id"] === "route-project-proj-no-auth-auth-domain-gotrue-well-known")).toBe(false);
+        expect(routes.some((route: any) => route["@id"] === "route-project-proj-same-auth-auth-domain-auth")).toBe(false);
+        expect(routes.some((route: any) => route["@id"] === "route-project-proj-same-auth-auth-domain-gotrue-well-known")).toBe(false);
+
+        restore();
+    });
+
     test("setupMasterRoutes applies the same Caddy CORS handling to system routes", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);

--- a/packages/management-api/tests/unit/project-config.test.ts
+++ b/packages/management-api/tests/unit/project-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   mergeProjectConfig,
+  normalizeOAuthServerConfig,
   normalizeProjectConfig,
 } from "../../src/utils/project-config";
 
@@ -28,6 +29,18 @@ describe("project-config utils", () => {
     ).toEqual({
       postgrest_port: 3234,
       gotrue_port: 3334,
+    });
+  });
+
+  test("normalizes OAuth server camelCase authorization path to snake_case", () => {
+    expect(
+      normalizeOAuthServerConfig({
+        enabled: true,
+        authorizationPath: "/authorize.html",
+      }),
+    ).toEqual({
+      enabled: true,
+      authorization_path: "/authorize.html",
     });
   });
 });

--- a/packages/management-api/tests/unit/project-routing.test.ts
+++ b/packages/management-api/tests/unit/project-routing.test.ts
@@ -6,6 +6,8 @@ import {
   resolveTenantPorts,
   resolveProjectApiHost,
   resolveProjectApiUrl,
+  resolveProjectAuthHost,
+  resolveProjectAuthUrl,
   resolveProjectBaseHost,
   resolveProjectStudioHost,
   resolveProjectStudioUrl,
@@ -59,15 +61,29 @@ describe("project routing", () => {
     expect(matchProjectRefFromHost("api.other.example", "77az24zz7p", configJson)).toBe(false);
   });
 
+  test("resolves dedicated auth domains without changing the API host", () => {
+    const projectConfig = {
+      api_domain: "api.example.com",
+      auth_domain: "auth.example.com",
+      studio_domain: "studio.example.com",
+    };
+
+    expect(resolveProjectApiHost("77az24zz7p", projectConfig)).toBe("api.example.com");
+    expect(resolveProjectAuthHost("77az24zz7p", projectConfig)).toBe("auth.example.com");
+    expect(matchProjectRefFromHost("auth.example.com", "77az24zz7p", projectConfig)).toBe(true);
+  });
+
   test("uses ENABLE_SSL to resolve public API and Studio URL schemes", () => {
     config.baseDomain = "192.168.1.168.sslip.io";
 
     config.enableSsl = true;
     expect(resolveProjectApiUrl("dglewlzugrtygzysqrce", null)).toBe("https://dglewlzugrtygzysqrce.api.192.168.1.168.sslip.io");
+    expect(resolveProjectAuthUrl("dglewlzugrtygzysqrce", null)).toBe("https://dglewlzugrtygzysqrce.api.192.168.1.168.sslip.io");
     expect(resolveProjectStudioUrl("dglewlzugrtygzysqrce", null)).toBe("https://studio-dglewlzugrtygzysqrce.192.168.1.168.sslip.io");
 
     config.enableSsl = false;
     expect(resolveProjectApiUrl("dglewlzugrtygzysqrce", null)).toBe("http://dglewlzugrtygzysqrce.api.192.168.1.168.sslip.io");
+    expect(resolveProjectAuthUrl("dglewlzugrtygzysqrce", null)).toBe("http://dglewlzugrtygzysqrce.api.192.168.1.168.sslip.io");
     expect(resolveProjectStudioUrl("dglewlzugrtygzysqrce", null)).toBe("http://studio-dglewlzugrtygzysqrce.192.168.1.168.sslip.io");
   });
 });


### PR DESCRIPTION
## Summary
- move duplicated uniqueStrings helper into shared utils/strings
- normalize OAuth server authorizationPath to authorization_path in project config helpers
- keep WebAuthn RP origins HTTPS for non-localhost hosts even when runtime URLs use non-SSL schemes
- document why Caddy JSON includes an empty TLS connection policy
- add regression coverage for missing auth_domain and auth_domain equal to api_domain

## Verification
- bun run typecheck
- bun test tests/unit/gateway.service.test.ts tests/unit/project-config.test.ts tests/unit/project-routing.test.ts tests/unit/auth-oauth-server.test.ts
- bun run test:unit

Follow-up to #240.
