### PR TITLE
fix(auth): use ES256 for GoTrue admin proxy

### DIFF
--- a/docs/multi-tenant-management.md
+++ b/docs/multi-tenant-management.md
@@ -117,7 +117,7 @@ Projects can be migrated to the Supabase-compatible OAuth 2.1 / OIDC Provider mo
 POST /v1/projects/:ref/auth/oauth-server/migrate
 ```
 
-Migration is project-scoped and writes ES256 `JWT_KEYS` / `JWT_JWKS` material into the project's Auth config. GoTrue signs new OIDC tokens with `GOTRUE_JWT_KEYS`; PostgREST, Storage, Realtime, SDK proxy, and Management API validators verify through the project JWKS.
+Migration is project-scoped and writes ES256 `JWT_KEYS` / `JWT_JWKS` material into the project's Auth config. GoTrue signs new OIDC tokens with `GOTRUE_JWT_KEYS`, and SupaCloud admin proxy calls use short-lived ES256 `service_role` tokens instead of requiring HS256 in `JWT_KEYS`; PostgREST, Storage, Realtime, SDK proxy, and Management API validators verify through the project JWKS.
 
 Existing `anon` and `service_role` API keys remain project-scoped and verifiable during migration. They are not shared across projects or accounts.
 

--- a/docs/oauth-oidc-provider.md
+++ b/docs/oauth-oidc-provider.md
@@ -61,13 +61,15 @@ After migration, tenant runtime generation injects:
 | Edge/runtime env | `JWT_KEYS`, `JWT_JWKS`, existing `JWT_SECRET` for compatibility |
 | SupaCloud internal validators | Project JWKS first, legacy HS256 fallback when needed |
 
-`JWT_KEYS` contains private signing material for Auth. `JWT_JWKS` contains public verification material for API components.
+`JWT_KEYS` contains only ES256 private signing material for Auth. `JWT_JWKS` contains public verification material for API components. The GoTrue admin proxy signs short-lived ES256 `service_role` tokens from `JWT_KEYS`; it does not require HS256 in `JWT_KEYS`.
 
 ## Legacy API Key Compatibility
 
 Migration keeps existing `anon` and `service_role` API keys usable.
 
 The project JWKS includes legacy HS256 verification material so PostgREST, Storage, Realtime, SDK proxy, and Management API project-token checks can continue to verify existing API keys during and after migration.
+
+Legacy HS256 user sessions are not a migration blocker. If an old session is rejected by Auth after ES256 migration, the user should re-enter their password to obtain a fresh ES256 token.
 
 This is not a shared-auth model:
 

--- a/packages/management-api/src/routes/auth-oauth-server.ts
+++ b/packages/management-api/src/routes/auth-oauth-server.ts
@@ -3,7 +3,6 @@ import { projectService } from "../services";
 import { tenantRuntimeService } from "../services/tenant-runtime.service";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { logger } from "../utils/logger";
-import { resolveProjectServiceRoleKey } from "../utils/service-role";
 import { sql as metaSql } from "../db";
 import {
   normalizeProjectRoutingConfig,
@@ -16,6 +15,7 @@ import {
   generateOidcJwtKeyMaterial,
   normalizeProjectJwtJwks,
   normalizeProjectJwtKeys,
+  signOidcServiceRoleJwt,
 } from "../utils/project-jwt";
 
 const OAUTH_CLIENT_BODY = t.Object({
@@ -75,7 +75,6 @@ async function loadProjectContext(ref: string) {
   const routingConfig = normalizeProjectRoutingConfig(rawConfig);
   const apiUrl = resolveProjectApiUrl(ref, routingConfig).replace(/\/+$/, "");
   const authUrl = resolveProjectAuthUrl(ref, routingConfig).replace(/\/+$/, "");
-  const serviceRoleKey = await resolveProjectServiceRoleKey(ref);
   const ports = resolveTenantPorts(routingConfig);
   const gotrueUrl = ports?.gotruePort
     ? `http://127.0.0.1:${ports.gotruePort}`
@@ -91,7 +90,6 @@ async function loadProjectContext(ref: string) {
     authUrl,
     issuer: oauthServer.issuer || `${authUrl}/auth/v1`,
     gotrueUrl,
-    serviceRoleKey,
     oauthServer,
   };
 }
@@ -131,16 +129,20 @@ async function proxyGoTrueAdmin(
   path: string,
   init: RequestInit = {},
 ) {
-  if (!ctx.serviceRoleKey) {
-    return new Response(JSON.stringify({ message: "Project service role key not available", code: "500" }), {
-      status: 500,
+  const adminToken = await signOidcServiceRoleJwt(ctx.oauthServer.jwt_keys, ctx.issuer);
+  if (!adminToken) {
+    return new Response(JSON.stringify({
+      message: "Project OAuth ES256 signing key not available. Re-apply OAuth server migration before managing OAuth clients.",
+      code: "409",
+    }), {
+      status: 409,
       headers: { "content-type": "application/json" },
     });
   }
 
   const headers = new Headers(init.headers);
-  headers.set("apikey", ctx.serviceRoleKey);
-  headers.set("authorization", `Bearer ${ctx.serviceRoleKey}`);
+  headers.set("apikey", adminToken);
+  headers.set("authorization", `Bearer ${adminToken}`);
   headers.set("x-project-ref", ctx.project.ref);
   if (init.body !== undefined && !headers.has("content-type")) {
     headers.set("content-type", "application/json");

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -3,7 +3,9 @@ import {
   createLocalJWKSet,
   exportJWK,
   generateKeyPair,
+  importJWK,
   jwtVerify,
+  SignJWT,
   type JWK,
   type JWTHeaderParameters,
   type JWTPayload,
@@ -58,14 +60,14 @@ export async function generateOidcJwtKeyMaterial(jwtSecret: string): Promise<Oid
     key_ops: ["sign"],
   };
 
-  // GoTrue uses key_ops:["sign"] to choose the single signing key. Keep the
-  // legacy HS256 key in jwt_keys so existing anon/service_role keys remain valid.
+  // GoTrue uses key_ops:["sign"] to choose the single signing key. Do not add
+  // legacy HS256 here; old user sessions should re-authenticate for ES256 tokens.
   const legacyJwk = buildLegacyHs256Jwk(jwtSecret);
 
   return {
     key_id: keyId,
     signing_alg: "ES256",
-    jwt_keys: [privateSigningJwk, legacyJwk],
+    jwt_keys: [privateSigningJwk],
     jwt_jwks: { keys: [publicSigningJwk, legacyJwk] },
   };
 }
@@ -85,7 +87,40 @@ export function normalizeProjectJwtKeys(value: unknown): JWK[] | null {
     ? JSON.parse(value)
     : value;
   if (!Array.isArray(parsed) || parsed.length === 0) return null;
-  return parsed as JWK[];
+  const signingKeys = (parsed as JWK[]).filter(
+    (k) => k.alg === "ES256" && k.kty === "EC",
+  );
+  return signingKeys.length > 0 ? signingKeys : (parsed as JWK[]);
+}
+
+export async function signOidcServiceRoleJwt(
+  jwtKeysValue: unknown,
+  issuer: string,
+  ttlSeconds = 300,
+): Promise<string | null> {
+  let jwtKeys: JWK[] | null = null;
+  try {
+    jwtKeys = normalizeProjectJwtKeys(jwtKeysValue);
+  } catch {
+    return null;
+  }
+
+  const signingJwk = jwtKeys?.find(
+    (key) => key.alg === "ES256" && key.kty === "EC" && typeof key.d === "string",
+  );
+  if (!signingJwk) return null;
+
+  const privateKey = await importJWK(signingJwk, "ES256");
+  const now = Math.floor(Date.now() / 1000);
+  const header: { alg: "ES256"; typ: "JWT"; kid?: string } = { alg: "ES256", typ: "JWT" };
+  if (typeof signingJwk.kid === "string") header.kid = signingJwk.kid;
+
+  return new SignJWT({ role: "service_role" })
+    .setProtectedHeader(header)
+    .setIssuer(issuer)
+    .setIssuedAt(now)
+    .setExpirationTime(now + ttlSeconds)
+    .sign(privateKey);
 }
 
 function extractJwtJwksFromConfig(config: unknown): { keys: JWK[] } | null {

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -55,16 +55,17 @@ export async function generateOidcJwtKeyMaterial(jwtSecret: string): Promise<Oid
     kid: keyId,
     alg: "ES256",
     use: "sig",
+    key_ops: ["sign"],
   };
 
-  // jwt_keys (signing): only ES256 private key — GoTrue uses this to sign new tokens.
-  // Legacy HS256 is kept in jwt_jwks (verification) so old tokens still validate.
+  // GoTrue uses key_ops:["sign"] to choose the single signing key. Keep the
+  // legacy HS256 key in jwt_keys so existing anon/service_role keys remain valid.
   const legacyJwk = buildLegacyHs256Jwk(jwtSecret);
 
   return {
     key_id: keyId,
     signing_alg: "ES256",
-    jwt_keys: [privateSigningJwk],
+    jwt_keys: [privateSigningJwk, legacyJwk],
     jwt_jwks: { keys: [publicSigningJwk, legacyJwk] },
   };
 }
@@ -84,12 +85,7 @@ export function normalizeProjectJwtKeys(value: unknown): JWK[] | null {
     ? JSON.parse(value)
     : value;
   if (!Array.isArray(parsed) || parsed.length === 0) return null;
-  // Only return signing-suitable keys (ES256 asymmetric). Filter out legacy
-  // HS256 symmetric keys that would cause GoTrue to fail key selection.
-  const signingKeys = (parsed as JWK[]).filter(
-    (k) => k.alg === "ES256" && k.kty === "EC",
-  );
-  return signingKeys.length > 0 ? signingKeys : (parsed as JWK[]);
+  return parsed as JWK[];
 }
 
 function extractJwtJwksFromConfig(config: unknown): { keys: JWK[] } | null {

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -110,17 +110,21 @@ export async function signOidcServiceRoleJwt(
   );
   if (!signingJwk) return null;
 
-  const privateKey = await importJWK(signingJwk, "ES256");
-  const now = Math.floor(Date.now() / 1000);
-  const header: { alg: "ES256"; typ: "JWT"; kid?: string } = { alg: "ES256", typ: "JWT" };
-  if (typeof signingJwk.kid === "string") header.kid = signingJwk.kid;
+  try {
+    const privateKey = await importJWK(signingJwk, "ES256");
+    const now = Math.floor(Date.now() / 1000);
+    const header: { alg: "ES256"; typ: "JWT"; kid?: string } = { alg: "ES256", typ: "JWT" };
+    if (typeof signingJwk.kid === "string") header.kid = signingJwk.kid;
 
-  return new SignJWT({ role: "service_role" })
-    .setProtectedHeader(header)
-    .setIssuer(issuer)
-    .setIssuedAt(now)
-    .setExpirationTime(now + ttlSeconds)
-    .sign(privateKey);
+    return new SignJWT({ role: "service_role" })
+      .setProtectedHeader(header)
+      .setIssuer(issuer)
+      .setIssuedAt(now)
+      .setExpirationTime(now + ttlSeconds)
+      .sign(privateKey);
+  } catch {
+    return null;
+  }
 }
 
 function extractJwtJwksFromConfig(config: unknown): { keys: JWK[] } | null {

--- a/packages/management-api/tests/unit/auth-oauth-server.test.ts
+++ b/packages/management-api/tests/unit/auth-oauth-server.test.ts
@@ -198,6 +198,23 @@ describe("authOAuthServerRoutes", () => {
     expect(typeof updatePayload.auth?.oauth_server?.migrated_at).toBe("string");
     expect(restartSpy).toHaveBeenCalledWith("proj_1");
 
+    const jwtKeys = updatePayload.auth?.oauth_server?.jwt_keys as Array<Record<string, unknown>>;
+    const signingKey = jwtKeys.find((key) => key.alg === "ES256");
+    const legacyKey = jwtKeys.find((key) => key.kid === "legacy-hs256");
+    expect(jwtKeys).toHaveLength(2);
+    expect(signingKey).toMatchObject({
+      kty: "EC",
+      alg: "ES256",
+      use: "sig",
+      key_ops: ["sign"],
+    });
+    expect(legacyKey).toMatchObject({
+      kty: "oct",
+      alg: "HS256",
+      use: "sig",
+    });
+    expect(legacyKey).not.toHaveProperty("key_ops");
+
     projectSpy.mockRestore();
     settingsSpy.mockRestore();
     updateSpy.mockRestore();

--- a/packages/management-api/tests/unit/auth-oauth-server.test.ts
+++ b/packages/management-api/tests/unit/auth-oauth-server.test.ts
@@ -3,8 +3,8 @@ import { Elysia } from "elysia";
 import { authOAuthServerRoutes } from "../../src/routes/auth-oauth-server";
 import { projectService } from "../../src/services";
 import * as dbModule from "../../src/db";
-import * as serviceRole from "../../src/utils/service-role";
 import { tenantRuntimeService } from "../../src/services/tenant-runtime.service";
+import { generateOidcJwtKeyMaterial } from "../../src/utils/project-jwt";
 
 const migratedJwtKeys = [{
   kty: "EC",
@@ -157,7 +157,6 @@ describe("authOAuthServerRoutes", () => {
       },
     } as never);
     const restartSpy = spyOn(tenantRuntimeService, "restartRuntime").mockResolvedValue(undefined);
-    const serviceRoleSpy = spyOn(serviceRole, "resolveProjectServiceRoleKey").mockResolvedValue("service");
     const sqlSpy = spyOn(dbModule, "sql");
     sqlSpy.mockImplementation(async (...args: unknown[]) => {
       const text = String(args[0] ?? "");
@@ -201,29 +200,24 @@ describe("authOAuthServerRoutes", () => {
     const jwtKeys = updatePayload.auth?.oauth_server?.jwt_keys as Array<Record<string, unknown>>;
     const signingKey = jwtKeys.find((key) => key.alg === "ES256");
     const legacyKey = jwtKeys.find((key) => key.kid === "legacy-hs256");
-    expect(jwtKeys).toHaveLength(2);
+    expect(jwtKeys).toHaveLength(1);
     expect(signingKey).toMatchObject({
       kty: "EC",
       alg: "ES256",
       use: "sig",
       key_ops: ["sign"],
     });
-    expect(legacyKey).toMatchObject({
-      kty: "oct",
-      alg: "HS256",
-      use: "sig",
-    });
-    expect(legacyKey).not.toHaveProperty("key_ops");
+    expect(legacyKey).toBeUndefined();
 
     projectSpy.mockRestore();
     settingsSpy.mockRestore();
     updateSpy.mockRestore();
     restartSpy.mockRestore();
-    serviceRoleSpy.mockRestore();
     sqlSpy.mockRestore();
   });
 
   test("GET /oauth-clients proxies to GoTrue admin client listing", async () => {
+    const keyMaterial = await generateOidcJwtKeyMaterial("jwt");
     const projectSpy = spyOn(projectService, "getProject").mockResolvedValue({
       id: "proj_id",
       ref: "proj_1",
@@ -260,7 +254,6 @@ describe("authOAuthServerRoutes", () => {
         },
       },
     } as never);
-    const serviceRoleSpy = spyOn(serviceRole, "resolveProjectServiceRoleKey").mockResolvedValue("service");
     const sqlSpy = spyOn(dbModule, "sql");
     sqlSpy.mockImplementation(async (...args: unknown[]) => {
       const text = String(args[0] ?? "");
@@ -272,6 +265,8 @@ describe("authOAuthServerRoutes", () => {
                 enabled: true,
                 allow_dynamic_registration: true,
                 issuer: "https://api.example.com/auth/v1",
+                jwt_keys: keyMaterial.jwt_keys,
+                jwt_jwks: keyMaterial.jwt_jwks,
               },
             },
             postgrest_port: 3100,
@@ -301,11 +296,17 @@ describe("authOAuthServerRoutes", () => {
 
       expect(response.status).toBe(200);
       expect(calls[0]?.url).toBe("http://127.0.0.1:3200/admin/oauth/clients");
-      expect(new Headers(calls[0]?.init?.headers).get("x-project-ref")).toBe("proj_1");
+      const headers = new Headers(calls[0]?.init?.headers);
+      const authorization = headers.get("authorization") ?? "";
+      const adminToken = authorization.replace(/^Bearer\s+/i, "");
+      const jwtHeader = JSON.parse(Buffer.from(adminToken.split(".")[0] ?? "", "base64url").toString("utf8"));
+      expect(headers.get("x-project-ref")).toBe("proj_1");
+      expect(headers.get("apikey")).toBe(adminToken);
+      expect(adminToken).not.toBe("service");
+      expect(jwtHeader).toMatchObject({ alg: "ES256", kid: keyMaterial.key_id });
     } finally {
       projectSpy.mockRestore();
       settingsSpy.mockRestore();
-      serviceRoleSpy.mockRestore();
       sqlSpy.mockRestore();
       globalThis.fetch = originalFetch;
     }

--- a/packages/management-api/tests/unit/runtime-env.service.test.ts
+++ b/packages/management-api/tests/unit/runtime-env.service.test.ts
@@ -24,10 +24,7 @@ describe("runtimeEnvService", () => {
       config: {
         auth: {
           oauth_server: {
-            jwt_keys: [
-              { kty: "EC", kid: "kid_1", alg: "ES256", key_ops: ["sign"] },
-              { kty: "oct", kid: "legacy-hs256", alg: "HS256" },
-            ],
+            jwt_keys: [{ kty: "EC", kid: "kid_1", alg: "ES256", key_ops: ["sign"] }],
             jwt_jwks: { keys: [{ kty: "EC", kid: "kid_1", alg: "ES256" }] },
           },
         },
@@ -44,7 +41,7 @@ describe("runtimeEnvService", () => {
 
       expect(env?.JWT_SECRET).toBe("legacy-secret");
       expect(env?.JWT_KEYS).toContain("kid_1");
-      expect(env?.JWT_KEYS).toContain("legacy-hs256");
+      expect(env?.JWT_KEYS).not.toContain("legacy-hs256");
       expect(env?.JWT_JWKS).toContain("kid_1");
       expect(env?.SUPABASE_SERVICE_ROLE_KEY).toBe("service.header.signature");
     } finally {

--- a/packages/management-api/tests/unit/runtime-env.service.test.ts
+++ b/packages/management-api/tests/unit/runtime-env.service.test.ts
@@ -24,7 +24,10 @@ describe("runtimeEnvService", () => {
       config: {
         auth: {
           oauth_server: {
-            jwt_keys: [{ kty: "EC", kid: "kid_1", alg: "ES256" }],
+            jwt_keys: [
+              { kty: "EC", kid: "kid_1", alg: "ES256", key_ops: ["sign"] },
+              { kty: "oct", kid: "legacy-hs256", alg: "HS256" },
+            ],
             jwt_jwks: { keys: [{ kty: "EC", kid: "kid_1", alg: "ES256" }] },
           },
         },
@@ -41,6 +44,7 @@ describe("runtimeEnvService", () => {
 
       expect(env?.JWT_SECRET).toBe("legacy-secret");
       expect(env?.JWT_KEYS).toContain("kid_1");
+      expect(env?.JWT_KEYS).toContain("legacy-hs256");
       expect(env?.JWT_JWKS).toContain("kid_1");
       expect(env?.SUPABASE_SERVICE_ROLE_KEY).toBe("service.header.signature");
     } finally {

--- a/packages/web-console/src/routes/project/[ref]/auth/oauth-server/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/oauth-server/+page.svelte
@@ -288,7 +288,7 @@
           </div>
           <div class="flex items-start gap-2">
             <CheckCircle2 size={15} class="mt-0.5 text-green-600" />
-            <span>Legacy HS256、anon key、service_role key 仍保留兼容路径。</span>
+            <span>GoTrue admin proxy 使用 ES256 临时 service_role token；旧 HS256 登录态如失效，请用户重新输入密码登录。</span>
           </div>
           <div class="flex items-start gap-2">
             <AlertTriangle size={15} class="mt-0.5 text-amber-600" />


### PR DESCRIPTION
## Summary
- keep GoTrue `JWT_KEYS` signing-only with the ES256 private key and `key_ops:["sign"]`
- remove the admin proxy dependency on legacy HS256 by minting short-lived ES256 `service_role` tokens for GoTrue admin calls
- update tests, docs, and web-console copy to treat stale HS256 user sessions as a re-authentication case

## Verification
- `bun test packages/management-api/tests/unit/auth-oauth-server.test.ts packages/management-api/tests/unit/runtime-env.service.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `npx @sveltejs/mcp svelte-autofixer 'packages/web-console/src/routes/project/[ref]/auth/oauth-server/+page.svelte' --svelte-version 5`
- `bun run --cwd packages/web-console check`
- `bun run --cwd packages/management-api build:amd64`
- `git diff --check`

## Context
Current deployments do not need HS256 user-session compatibility for the GoTrue admin proxy path. If a stale HS256 user session is rejected after migration, the user can re-enter their password and receive a fresh ES256 token.
