### PR TITLE
fix(gateway): authorize Caddy route domains for TLS ask

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -26,6 +26,7 @@ import { migrateLegacyVersionArtifacts } from "./services/edge-function.service"
 import { resolveRealtimeTenantHost } from "./utils/sdk-parity";
 import { resolveProjectRefFromApiKey } from "./utils/project-auth";
 import { isFrontendDomain } from "./utils/frontend-domains";
+import { isCaddyRouteDomain } from "./utils/caddy-domains";
 
 const WEB_CONSOLE_CURRENT_DIR = "/opt/supacloud/web-console/current";
 const WEB_CONSOLE_LEGACY_DIR = "/opt/supacloud/packages/web-console/build";
@@ -355,6 +356,7 @@ const app = new Elysia({ strictPath: false })
     `;
     if (rows.length > 0) return new Response("ok");
     if (await isFrontendDomain(domain)) return new Response("ok");
+    if (await isCaddyRouteDomain(domain)) return new Response("ok");
     return new Response("domain not allowed", { status: 403 });
   }, {
     detail: { tags: ["gateway"], summary: "Authorize Caddy On-Demand TLS domain" },

--- a/packages/management-api/src/utils/caddy-domains.ts
+++ b/packages/management-api/src/utils/caddy-domains.ts
@@ -1,0 +1,58 @@
+/**
+ * Reads the persisted Caddy JSON and checks whether a host is already
+ * registered on any HTTP route. This backs the on-demand TLS ask endpoint:
+ * if management-api has already published a route, Caddy should be allowed
+ * to issue/load a certificate for that SNI.
+ */
+import { readFile } from "node:fs/promises";
+import { config } from "../config";
+
+type CaddyRoute = {
+  match?: Array<{
+    host?: unknown;
+  }>;
+  handle?: Array<{
+    routes?: CaddyRoute[];
+  }>;
+};
+
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/:\d+$/, "");
+}
+
+function routeMatchesHost(route: CaddyRoute, domain: string): boolean {
+  const matches = Array.isArray(route.match) ? route.match : [];
+  for (const matcher of matches) {
+    const hosts = Array.isArray(matcher.host) ? matcher.host : [];
+    if (hosts.some((host) => typeof host === "string" && normalizeHost(host) === domain)) {
+      return true;
+    }
+  }
+
+  const handlers = Array.isArray(route.handle) ? route.handle : [];
+  return handlers.some((handler) =>
+    Array.isArray(handler.routes) && handler.routes.some((child) => routeMatchesHost(child, domain)),
+  );
+}
+
+export async function isCaddyRouteDomain(domain: string, caddyConfigPath = config.caddyConfigPath): Promise<boolean> {
+  const normalizedDomain = normalizeHost(domain);
+  if (!normalizedDomain) return false;
+
+  try {
+    const raw = await readFile(caddyConfigPath, "utf8");
+    const parsed = JSON.parse(raw) as {
+      apps?: {
+        http?: {
+          servers?: Record<string, { routes?: CaddyRoute[] }>;
+        };
+      };
+    };
+    const servers = parsed.apps?.http?.servers || {};
+    return Object.values(servers).some((server) =>
+      (server.routes || []).some((route) => routeMatchesHost(route, normalizedDomain)),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/management-api/tests/unit/caddy-domains.test.ts
+++ b/packages/management-api/tests/unit/caddy-domains.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { isCaddyRouteDomain } from "../../src/utils/caddy-domains";
+
+const fixturePath = "/tmp/supacloud-caddy-test/caddy-domains/config.json";
+
+afterEach(async () => {
+  await rm(dirname(fixturePath), { recursive: true, force: true });
+});
+
+describe("isCaddyRouteDomain", () => {
+  test("allows hosts already registered in persisted Caddy routes", async () => {
+    await mkdir(dirname(fixturePath), { recursive: true });
+    await writeFile(fixturePath, JSON.stringify({
+      apps: {
+        http: {
+          servers: {
+            supacloud: {
+              routes: [
+                {
+                  "@id": "route-auth-login",
+                  match: [{ host: ["auth.ai.xigu.org"], path: ["/", "/login.html"] }],
+                  handle: [{ handler: "static_response", body: "ok" }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    }));
+
+    await expect(isCaddyRouteDomain("https://auth.ai.xigu.org:443", fixturePath)).resolves.toBe(true);
+  });
+
+  test("allows hosts registered on nested subroutes", async () => {
+    await mkdir(dirname(fixturePath), { recursive: true });
+    await writeFile(fixturePath, JSON.stringify({
+      apps: {
+        http: {
+          servers: {
+            supacloud: {
+              routes: [
+                {
+                  handle: [{
+                    handler: "subroute",
+                    routes: [
+                      {
+                        match: [{ host: ["api.ai.xigu.org"], path: ["/auth/v1*"] }],
+                        handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "127.0.0.1:9999" }] }],
+                      },
+                    ],
+                  }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    }));
+
+    await expect(isCaddyRouteDomain("api.ai.xigu.org", fixturePath)).resolves.toBe(true);
+  });
+
+  test("rejects missing or unregistered domains", async () => {
+    await expect(isCaddyRouteDomain("unknown.ai.xigu.org", fixturePath)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- allow the Caddy on-demand TLS ask endpoint to authorize domains already registered in the persisted Caddy route JSON
- keep existing checks for base domains, project config domains, and frontend deployment domains
- add unit coverage for direct and nested Caddy route host matches

## Why
Dedicated auth/API/frontend routes can already be registered in Caddy, but the ask endpoint could still reject an SNI if that host was not discoverable through `projects.config` or frontend deployment metadata. That forced operators to patch or disable Caddy on-demand TLS for valid routed domains.

This does not make SupaCloud responsible for serving a business login HTML page. SupaCloud owns the project auth API route (`/auth/v1*`) and TLS authorization. A custom unified login UI still belongs to the auth application or hosted frontend layer.

## Test Plan
- `bun test tests/unit/caddy-domains.test.ts tests/unit/gateway.service.test.ts`
- `bun run typecheck`
