### PR TITLE
fix(management-api): verify project secret upserts

### DIFF
--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -758,8 +758,9 @@ export class ProjectService {
       if (!success) return false;
     }
 
-    // After update, can trigger Runtime restart logic
-    return true;
+    const persistedSecrets = await databaseService.getSecrets(ref);
+    const persistedNames = new Set(persistedSecrets.map((secret) => secret.name));
+    return secrets.every((secret) => persistedNames.has(secret.name));
   }
 
   async deleteSecret(ref: string, name: string): Promise<boolean> {

--- a/packages/management-api/tests/unit/project.service.comprehensive.test.ts
+++ b/packages/management-api/tests/unit/project.service.comprehensive.test.ts
@@ -485,6 +485,35 @@ describe("ProjectService - Comprehensive", () => {
     expect(result).toBe(false);
   });
 
+  test("upsertSecrets returns true only after written names are readable", async () => {
+    projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
+    databaseServiceMock.upsertSecret.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+    databaseServiceMock.getSecrets.mockResolvedValueOnce([
+      { name: "KEY1", value: "val1" },
+      { name: "KEY2", value: "val2" },
+    ]);
+
+    const result = await service.upsertSecrets("test123abc", [
+      { name: "KEY1", value: "val1" },
+      { name: "KEY2", value: "val2" },
+    ]);
+
+    expect(result).toBe(true);
+    expect(databaseServiceMock.getSecrets).toHaveBeenCalledWith("test123abc");
+  });
+
+  test("upsertSecrets returns false when write reports success but secrets remain invisible", async () => {
+    projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
+    databaseServiceMock.upsertSecret.mockResolvedValueOnce(true);
+    databaseServiceMock.getSecrets.mockResolvedValueOnce([]);
+
+    const result = await service.upsertSecrets("test123abc", [
+      { name: "DATA_ORGANIZATION_API_TOKEN", value: "token" },
+    ]);
+
+    expect(result).toBe(false);
+  });
+
   test("deleteSecret delegates to database service", async () => {
     projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
     expect(await service.deleteSecret("test123abc", "KEY")).toBe(true);


### PR DESCRIPTION
## Summary
- verify project secret upserts by re-reading persisted secret names before reporting success
- make false-positive writes fail closed so Edge Runtime secret injection cannot silently remain empty
- add regression coverage for writes that report success but remain invisible to `getSecrets()`

## Context
While debugging `api.ai.xigu.org/functions/v1/data-organization/process`, the management API returned HTTP 200 for `POST /v1/projects/:ref/secrets`, but `GET /v1/projects/:ref/secrets?reveal=true` still returned an empty array. Edge Runtime then had no `DATA_ORGANIZATION_API_TOKEN` and the function returned 503.

## Tests
- `bun test packages/management-api/tests/unit/project.service.comprehensive.test.ts`
- `bun test packages/management-api/tests/unit/final-security-regression.test.ts packages/management-api/tests/unit/runtime-env.service.test.ts`
- `bun run --cwd packages/management-api typecheck`