### PR TITLE
fix(gateway): allow forwarded CORS headers

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -15,6 +15,7 @@ import { uniqueStrings } from "../utils/strings";
 export const DEFAULT_CORS_HEADERS = [
     "Accept", "Accept-Language", "Authorization", "Content-Language", "Content-Type",
     "apikey", "x-client-info", "x-project-ref", "X-Api-Version", "x-supabase-api-version",
+    "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto", "x-real-ip",
     "Prefer", "Content-Profile", "accept-profile", "Range", "Range-Unit",
     "x-upsert", "Cache-Control", "x-retry-count", "x-metadata",
     "x-supacloud-async", "x-supacloud-timeout", "x-supacloud-retries",

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -110,6 +110,10 @@ describe("GatewayService provider selection", () => {
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-correlation-id");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-business-task-id");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-task-metadata");
+        expect(DEFAULT_CORS_HEADERS).toContain("x-forwarded-for");
+        expect(DEFAULT_CORS_HEADERS).toContain("x-forwarded-host");
+        expect(DEFAULT_CORS_HEADERS).toContain("x-forwarded-proto");
+        expect(DEFAULT_CORS_HEADERS).toContain("x-real-ip");
     });
 
     test("tenant cors origins include exact api and studio custom domains", () => {


### PR DESCRIPTION
## Summary
- add forwarded proxy headers to the default Caddy CORS allow-header list
- cover `x-forwarded-host`, `x-forwarded-proto`, `x-forwarded-for`, and `x-real-ip` in the gateway unit test

## Context
Browser auth flows can send `x-forwarded-host` during Supabase-compatible Auth calls. The Caddy preflight response did not allow that header, so requests from web apps failed before reaching GoTrue.

This reproduced on the seagoo-ai deployment after unified login returned to `www.ai.xigu.team`: `supabase-js` called `http://api.ai.xigu.team/auth/v1/user` with `x-forwarded-host`, and the browser rejected the 204 preflight because `Access-Control-Allow-Headers` omitted that header.

## Test
- `bun test packages/management-api/tests/unit/gateway.service.test.ts`
- Live hotfix verification on seagoo-ai: `OPTIONS http://api.ai.xigu.team/auth/v1/user` now returns 204 with `x-forwarded-host` allowed; full browser login reaches `http://www.ai.xigu.team/#/app`, with `POST /auth/v1/token`, `GET /auth/v1/user`, and `GET /rest/v1/background_tasks` all returning 200.
