### PR TITLE
fix(edge-runtime): support custom TLS trust for function fetch

### DIFF
--- a/config.env
+++ b/config.env
@@ -95,6 +95,17 @@ LOGFLARE_ERL_FLAGS="+P 32768 +Q 4096 +S 2:2 +hms 64 +hmbs 64 +e 128 +L"
 # ========== Edge Functions Runtime ==========
 # Edge Runtime: Bun + Elysia Worker Pool (built-in, no configuration needed)
 # Managed by supacloud-edge-runtime.service on port 9000
+#
+# Optional outbound HTTPS trust controls for Edge Function fetch().
+# Prefer a CA bundle for self-signed/internal certificates:
+#SUPACLOUD_EDGE_TLS_CA_FILE="/etc/supacloud/edge-runtime/ca.pem"
+# Or inject an inline PEM through project/function secrets:
+#SUPACLOUD_EDGE_TLS_CA="-----BEGIN CERTIFICATE-----..."
+#
+# Last-resort compatibility switch. This disables certificate verification for
+# HTTPS fetch() calls inside Edge Function workers only; do not enable globally
+# unless you accept the security tradeoff.
+#SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY=false
 
 # ========== SMTP Configuration (Optional) ==========
 # Uncomment to enable email functionality

--- a/docs/edge-runtime-guide.md
+++ b/docs/edge-runtime-guide.md
@@ -72,6 +72,33 @@ The Bun entrypoint is `packages/edge-runtime/server.ts`, and the checked-in stan
 - `https://deno.land/std/...` — Mapped to local shims for compatibility ✅
 - Other npm imports — Auto-scanned and installed ✅
 
+## Outbound HTTPS Trust
+
+Edge Runtime release assets are native `supacloud-edge-runtime` binaries, not
+Node.js processes. `NODE_TLS_REJECT_UNAUTHORIZED=0` is therefore not the
+supported control surface for user function `fetch()` calls.
+
+For private/self-signed services, prefer adding the issuing CA:
+
+```bash
+# Host-level CA bundle, read by supacloud-edge-runtime.service through config.env
+SUPACLOUD_EDGE_TLS_CA_FILE=/etc/supacloud/edge-runtime/ca.pem
+
+# Or project/function-level inline PEM through Edge Function secrets
+SUPACLOUD_EDGE_TLS_CA='-----BEGIN CERTIFICATE-----...'
+```
+
+If compatibility requires fully bypassing certificate verification, set the
+explicit dangerous switch:
+
+```bash
+SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY=true
+```
+
+The bypass is scoped to HTTPS `fetch()` calls inside Edge Function workers. It
+does not disable TLS verification for the Management API, Caddy, tenant
+PostgREST/GoTrue services, or other host processes.
+
 ## Function Examples
 
 ```typescript

--- a/packages/edge-runtime/fetch-tls-policy.test.ts
+++ b/packages/edge-runtime/fetch-tls-policy.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  installEdgeFetchTlsPolicy,
+  resolveEdgeFetchTlsPolicy,
+  type EdgeFetchTlsPolicy,
+} from "./fetch-tls-policy";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function captureFetchInit(policy: EdgeFetchTlsPolicy, url = "https://example.test") {
+  let capturedInit: RequestInit | undefined;
+  const fakeFetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    capturedInit = init;
+    return new Response("ok");
+  }) as typeof globalThis.fetch;
+
+  const restore = installEdgeFetchTlsPolicy(policy, fakeFetch);
+  try {
+    await fetch(url, { headers: { "x-test": "1" } });
+  } finally {
+    restore();
+  }
+
+  return capturedInit as RequestInit & { tls?: Record<string, unknown> };
+}
+
+describe("Edge fetch TLS policy", () => {
+  test("defaults to no fetch override", async () => {
+    const policy = await resolveEdgeFetchTlsPolicy({});
+    expect(policy).toEqual({ source: "none" });
+
+    const before = globalThis.fetch;
+    const restore = installEdgeFetchTlsPolicy(policy);
+    expect(globalThis.fetch).toBe(before);
+    restore();
+    expect(globalThis.fetch).toBe(before);
+  });
+
+  test("loads inline CA for HTTPS fetches", async () => {
+    const policy = await resolveEdgeFetchTlsPolicy({
+      SUPACLOUD_EDGE_TLS_CA: "-----BEGIN CERTIFICATE-----\ninline\n-----END CERTIFICATE-----",
+    });
+
+    const init = await captureFetchInit(policy);
+    expect(init.tls?.ca).toContain("inline");
+    expect(init.tls?.rejectUnauthorized).toBeUndefined();
+  });
+
+  test("loads CA bundle from file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "supacloud-edge-ca-"));
+    const caPath = join(dir, "ca.pem");
+    await Bun.write(caPath, "-----BEGIN CERTIFICATE-----\nfile\n-----END CERTIFICATE-----");
+
+    try {
+      const policy = await resolveEdgeFetchTlsPolicy({
+        SUPACLOUD_EDGE_TLS_CA_FILE: "/tenant/ca-file-is-ignored.pem",
+      }, {
+        SUPACLOUD_EDGE_TLS_CA_FILE: caPath,
+      });
+      const init = await captureFetchInit(policy);
+      expect(init.tls?.ca).toContain("file");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses host env as the fallback policy source", async () => {
+    const policy = await resolveEdgeFetchTlsPolicy({}, {
+      SUPACLOUD_EDGE_TLS_CA: "-----BEGIN CERTIFICATE-----\nhost\n-----END CERTIFICATE-----",
+    });
+
+    const init = await captureFetchInit(policy);
+    expect(init.tls?.ca).toContain("host");
+  });
+
+  test("explicit insecure skip verify overrides HTTPS verification", async () => {
+    const policy = await resolveEdgeFetchTlsPolicy({
+      SUPACLOUD_EDGE_TLS_CA: "ignored when insecure is enabled",
+      SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY: "true",
+    });
+
+    const init = await captureFetchInit(policy);
+    expect(init.tls?.rejectUnauthorized).toBe(false);
+    expect(init.tls?.ca).toBeUndefined();
+  });
+
+  test("does not attach TLS options to plain HTTP fetches", async () => {
+    const policy = await resolveEdgeFetchTlsPolicy({
+      SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY: "true",
+    });
+
+    const init = await captureFetchInit(policy, "http://example.test");
+    expect(init.tls).toBeUndefined();
+  });
+});

--- a/packages/edge-runtime/fetch-tls-policy.ts
+++ b/packages/edge-runtime/fetch-tls-policy.ts
@@ -1,0 +1,85 @@
+type FetchLike = typeof globalThis.fetch;
+
+export type EdgeFetchTlsPolicy = {
+  ca?: string;
+  rejectUnauthorized?: boolean;
+  source: "none" | "ca-inline" | "ca-file" | "insecure";
+};
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
+function enabled(value: string | undefined): boolean {
+  return value ? TRUE_VALUES.has(value.trim().toLowerCase()) : false;
+}
+
+function pickString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export async function resolveEdgeFetchTlsPolicy(
+  env: Record<string, string | undefined>,
+  hostEnv: Record<string, string | undefined> = {},
+): Promise<EdgeFetchTlsPolicy> {
+  if (
+    enabled(env.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY) ||
+    enabled(hostEnv.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY)
+  ) {
+    return { rejectUnauthorized: false, source: "insecure" };
+  }
+
+  const inlineCa = pickString(env.SUPACLOUD_EDGE_TLS_CA) ?? pickString(hostEnv.SUPACLOUD_EDGE_TLS_CA);
+  if (inlineCa) {
+    return { ca: inlineCa, source: "ca-inline" };
+  }
+
+  const caFile = pickString(hostEnv.SUPACLOUD_EDGE_TLS_CA_FILE);
+  if (caFile) {
+    return { ca: await Bun.file(caFile).text(), source: "ca-file" };
+  }
+
+  return { source: "none" };
+}
+
+function isHttpsRequest(input: Parameters<FetchLike>[0]): boolean {
+  if (typeof input === "string") return input.startsWith("https:");
+  if (input instanceof URL) return input.protocol === "https:";
+  return input.url.startsWith("https:");
+}
+
+function withTlsPolicy(
+  init: Parameters<FetchLike>[1],
+  policy: EdgeFetchTlsPolicy,
+): Parameters<FetchLike>[1] {
+  if (policy.source === "none") return init;
+
+  const currentTls = (init as { tls?: Record<string, unknown> } | undefined)?.tls ?? {};
+  const nextTls: Record<string, unknown> = { ...currentTls };
+
+  if (policy.ca && nextTls.ca === undefined) {
+    nextTls.ca = policy.ca;
+  }
+  if (policy.rejectUnauthorized === false) {
+    nextTls.rejectUnauthorized = false;
+  }
+
+  return { ...init, tls: nextTls } as Parameters<FetchLike>[1];
+}
+
+export function installEdgeFetchTlsPolicy(
+  policy: EdgeFetchTlsPolicy,
+  originalFetch: FetchLike = globalThis.fetch,
+): () => void {
+  if (policy.source === "none") {
+    return () => {};
+  }
+
+  globalThis.fetch = ((input, init) => {
+    const nextInit = isHttpsRequest(input) ? withTlsPolicy(init, policy) : init;
+    return originalFetch(input, nextInit);
+  }) as FetchLike;
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -12,7 +12,7 @@
     "build:macos-amd64": "bun build server.ts --compile --target=bun-macos-x64 --outfile=supacloud-edge-runtime-macos-amd64",
     "build:macos-arm64": "bun build server.ts --compile --target=bun-macos-arm64 --outfile=supacloud-edge-runtime-macos-arm64",
     "build:macos": "bun run build:macos-amd64 && bun run build:macos-arm64",
-    "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts worker-executor.ts worker-pool.ts auto-deps.ts deno-compat.ts url-import-plugin.ts shims/*.ts"
+    "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts worker-executor.ts worker-pool.ts auto-deps.ts deno-compat.ts fetch-tls-policy.ts url-import-plugin.ts shims/*.ts"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.0",

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -1,6 +1,7 @@
 import { parentPort, workerData } from "worker_threads";
 import path from "path";
 import { getCapturedServeHandler, clearCapturedServeHandler, setTenantRef, setProjectRoot, setInjectedEnv, envWriteLog } from "./deno-compat";
+import { installEdgeFetchTlsPolicy, resolveEdgeFetchTlsPolicy } from "./fetch-tls-policy";
 
 export function getInjectedEnv(): Record<string, string> {
   return currentInjectedEnv;
@@ -203,7 +204,14 @@ parentPort.on("message", async (msg: any) => {
       setProjectRoot(msg.projectRoot || path.dirname(msg.functionPath));
       injectEnv(env);
       setInjectedEnv(env);
-      await loadModule(msg.functionPath);
+      const restoreFetchTlsPolicy = installEdgeFetchTlsPolicy(
+        await resolveEdgeFetchTlsPolicy(currentInjectedEnv, originalProcessEnv),
+      );
+      try {
+        await loadModule(msg.functionPath);
+      } finally {
+        restoreFetchTlsPolicy();
+      }
       parentPort!.postMessage({
         type: "preheat_done",
         functionId: msg.functionId,
@@ -238,6 +246,9 @@ parentPort.on("message", async (msg: any) => {
   setInjectedEnv(env);
   setupConsoleCapture(functionId);
   setupEdgeRuntimeCompat();
+  const restoreFetchTlsPolicy = installEdgeFetchTlsPolicy(
+    await resolveEdgeFetchTlsPolicy(currentInjectedEnv, originalProcessEnv),
+  );
 
   try {
     const handler = await loadModule(functionPath);
@@ -329,6 +340,7 @@ parentPort.on("message", async (msg: any) => {
       ).buffer,
     });
   } finally {
+    restoreFetchTlsPolicy();
     currentAbortController = null;
     clearEdgeRuntimeCompat();
     restoreEnv();


### PR DESCRIPTION
## Summary
- add worker-scoped fetch TLS policy for Edge Runtime HTTPS requests
- support CA trust via host or function env, with explicit insecure bypass as last resort
- document the native binary constraint and supported runtime env knobs

## Verification
- bun test
- bun run typecheck
- bun build server.ts --compile --target=bun-macos-arm64 --outfile=/tmp/supacloud-edge-runtime-tls-test