### PR TITLE
fix(gateway): disable Caddy proxy streaming for storage compat routes

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -492,15 +492,14 @@ export class CaddyGatewayProvider implements GatewayProvider {
         }
     }
 
-    private makeReverseProxy(upstream: string, headers: Record<string, CaddyHeaderValue>, readTimeoutMs?: number, preserveUpstreamCors?: boolean): Record<string, unknown> {
+    private makeReverseProxy(upstream: string, headers: Record<string, CaddyHeaderValue>, readTimeoutMs?: number, preserveUpstreamCors?: boolean, streaming?: boolean): Record<string, unknown> {
         const responseHeaders: Record<string, unknown> = {};
         if (!preserveUpstreamCors) {
             responseHeaders.delete = [...UPSTREAM_CORS_RESPONSE_HEADERS];
         }
-        return {
+        const proxy: Record<string, unknown> = {
             handler: "reverse_proxy",
             upstreams: [{ dial: caddyDial(upstream) }],
-            flush_interval: -1,
             headers: {
                 request: {
                     set: Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value : [value]])),
@@ -513,6 +512,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 write_timeout: "500s",
             },
         };
+        if (streaming !== false) {
+            proxy.flush_interval = -1;
+        }
+        return proxy;
     }
 
     private makeCorsHeaderHandler(): Record<string, unknown> {
@@ -773,6 +776,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
         corsOrigins?: string[];
         readTimeout?: number;
         preserveUpstreamCors?: boolean;
+        streaming?: boolean;
     }): CaddyRoute {
         const requestHeaders: Record<string, CaddyHeaderValue> = {
             "X-Project-Ref": opts.projectRef,
@@ -788,7 +792,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
         if (corsSubroute) handle.push(corsSubroute);
         if (opts.rewriteUri) handle.push({ handler: "rewrite", uri: opts.rewriteUri });
         else if (opts.stripPrefix) handle.push({ handler: "rewrite", strip_path_prefix: opts.stripPrefix });
-        handle.push(this.makeReverseProxy(opts.upstream, requestHeaders, opts.readTimeout, opts.preserveUpstreamCors));
+        handle.push(this.makeReverseProxy(opts.upstream, requestHeaders, opts.readTimeout, opts.preserveUpstreamCors, opts.streaming));
 
         return {
             "@id": opts.id,
@@ -944,7 +948,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 this.makeRoute({ id: caddyRouteId(projectRef, "auth"), hosts, path: "/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, stripPrefix: "/auth/v1", corsOrigins }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "gotrue-well-known"), hosts, path: "/.well-known/oauth-authorization-server/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, corsOrigins }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "functions"), hosts, path: "/functions/v1*", upstream: `${hostIp}:${config.port}`, projectRef, readTimeout: 500_000, corsOrigins }),
-                this.makeRoute({ id: caddyRouteId(projectRef, "storage"), hosts, path: "/storage/v1*", upstream: `${hostIp}:${opts?.storagePort || config.port}`, projectRef, stripPrefix: "/storage/v1", corsOrigins, preserveUpstreamCors: true }),
+                this.makeRoute({ id: caddyRouteId(projectRef, "storage"), hosts, path: "/storage/v1*", upstream: `${hostIp}:${opts?.storagePort || config.port}`, projectRef, stripPrefix: "/storage/v1", corsOrigins, preserveUpstreamCors: true, streaming: false }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "realtime-api"), hosts, path: "/realtime/v1/api*", upstream: `${hostIp}:${config.port}`, projectRef, readTimeout: 60_000, corsOrigins }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "realtime"), hosts, path: "/realtime/v1/websocket*", upstream: `${hostIp}:${config.port}`, projectRef, readTimeout: 86_400_000, corsOrigins }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "management"), hosts, path: [`/v1/projects/${projectRef}`, `/v1/projects/${projectRef}/*`], upstream: `${hostIp}:${config.port}`, projectRef, corsOrigins }),

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -183,6 +183,10 @@ describe("CaddyGatewayProvider", () => {
         expect(routes.find((route: any) => route["@id"] === "route-project-testref123-graphql")
             ?.handle?.some((handler: any) => handler.uri === "/rpc/graphql")).toBe(true);
         expect(storage?.match?.[0]?.path).toEqual(["/storage/v1*"]);
+        const storageProxy = storage?.handle?.find((h: any) => h.handler === "reverse_proxy");
+        expect(storageProxy?.flush_interval).toBeUndefined();
+        const restProxy = rest?.handle?.find((h: any) => h.handler === "reverse_proxy");
+        expect(restProxy?.flush_interval).toBe(-1);
         expect(functions?.match?.[0]?.path).toEqual(["/functions/v1*"]);
         expect(realtime?.match?.[0]?.path).toEqual(["/realtime/v1/websocket*"]);
         expect(management?.match?.[0]?.path).toEqual(["/v1/projects/testref123", "/v1/projects/testref123/*"]);


### PR DESCRIPTION
This PR introduces a `streaming` option to the Caddy routing/proxy generator configuration and sets it to `false` for the storage compat API route. This disables the `flush_interval: -1` streaming setting on Caddy reverse proxy for these routes, preventing empty response disconnects caused by Bun/Elysia when proxying through Caddy under streaming mode.