### PR TITLE
fix(ci): define identity variable in AI review script

### DIFF
--- a/.github/scripts/ai-review-merge.mjs
+++ b/.github/scripts/ai-review-merge.mjs
@@ -546,6 +546,7 @@ async function main() {
 
   // 跳过 draft PR
   const prDetails = await getPRDetails();
+  const identity = isTrustedSubmitter(prDetails);
   if (prDetails.draft) {
     console.log('PR is a draft. Skipping.');
     return;


### PR DESCRIPTION
This PR fixes a fatal runtime error `identity is not defined` in the `ai-review-merge.mjs` script. It calls `isTrustedSubmitter(prDetails)` and stores it in `identity` before it is checked for Layer 5 trusted submitter verification.