### PR TITLE
feat(gateway): SupAuth hosted login page route management

### DIFF
--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -127,6 +127,9 @@ export interface Config {
   sdkProxyTimeoutMs: number;
   restProxyTimeoutMs: number;
   secretsEncryptionKey: string;
+  supauthHostedLoginEnabled: boolean;
+  supauthHostedLoginHost: string;
+  supauthHostedLoginPageRoot: string;
 }
 
 function getEnv(key: string, defaultValue = ""): string {
@@ -263,6 +266,10 @@ export const config: Config = {
   sdkProxyTimeoutMs: Number(getEnv("SDK_PROXY_TIMEOUT_MS", "30000")),
   restProxyTimeoutMs: Number(getEnv("REST_PROXY_TIMEOUT_MS", "300000")),
   secretsEncryptionKey: getEnv("SECRETS_ENCRYPTION_KEY", getEnv("MASTER_TOKEN", "")),
+
+  supauthHostedLoginEnabled: getEnv("SUPAUTH_HOSTED_LOGIN_ENABLED", "false") === "true",
+  supauthHostedLoginHost: getEnv("SUPAUTH_HOSTED_LOGIN_HOST", ""),
+  supauthHostedLoginPageRoot: getEnv("SUPAUTH_HOSTED_LOGIN_PAGE_ROOT", ""),
 };
 
 function validateConfig() {

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -124,6 +124,7 @@ async function getIndexHtml(): Promise<string | null> {
 try {
   const { gatewayService } = await import("./services/gateway.service");
   await gatewayService.setupMasterRoutes();
+  await gatewayService.setupSupauthHostedLogin();
   const { frontendService } = await import("./services/frontend.service");
   const result = await frontendService.reconcileGatewayRoutes();
   if (result.configured > 0 || result.errors.length > 0) {

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -131,6 +131,7 @@ export interface GatewayProvider {
     upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }>;
     configureFrontendRoute(route: FrontendGatewayRoute): Promise<void>;
     removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void>;
+    setupSupauthHostedLogin(): Promise<{ success: boolean; error?: string }>;
 }
 
 function getRateLimitConfig(tier: string): RateLimitConfig {
@@ -387,8 +388,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
     private compareRoutesForCaddy(a: CaddyRoute, b: CaddyRoute): number {
         const aid = String(a["@id"] || "");
         const bid = String(b["@id"] || "");
-        const aCustom = aid.startsWith("route-custom-");
-        const bCustom = bid.startsWith("route-custom-");
+        const aCustom = aid.startsWith("route-custom-") || aid.startsWith("route-supauth-");
+        const bCustom = bid.startsWith("route-custom-") || bid.startsWith("route-supauth-");
         if (aCustom !== bCustom) return aCustom ? -1 : 1;
 
         const aPath = Array.isArray((a.match as any)?.[0]?.path) ? String((a.match as any)[0].path[0] || "") : "";
@@ -1148,6 +1149,72 @@ export class CaddyGatewayProvider implements GatewayProvider {
         }
         return "127.0.0.1";
     }
+
+    /**
+     * 注册 SupAuth hosted login / authorize 页面的 Caddy 路由。
+     * 当配置了 SUPAUTH_HOSTED_LOGIN_ENABLED=true 时，自动创建:
+     *   - route-supauth-hosted-login:  / 和 /login.html -> authorize.html (file_server)
+     *   - route-supauth-authorize-page: /oauth/authorize* -> authorize.html (file_server)
+     * 这些路由排在 catch-all /* 之前，确保不会被吞掉。
+     */
+    async setupSupauthHostedLogin(): Promise<{ success: boolean; error?: string }> {
+        if (!config.supauthHostedLoginEnabled) {
+            // 清除已有路由
+            await this.hydrateFromDisk();
+            let changed = false;
+            for (const id of ["route-supauth-hosted-login", "route-supauth-authorize-page"]) {
+                if (this.routesById.has(id)) {
+                    this.routesById.delete(id);
+                    changed = true;
+                }
+            }
+            if (changed) await this.persistAndLoad();
+            return { success: true };
+        }
+
+        if (!config.supauthHostedLoginHost) {
+            return { success: false, error: "SUPAUTH_HOSTED_LOGIN_HOST is required when SUPAUTH_HOSTED_LOGIN_ENABLED=true" };
+        }
+        if (!config.supauthHostedLoginPageRoot) {
+            return { success: false, error: "SUPAUTH_HOSTED_LOGIN_PAGE_ROOT is required when SUPAUTH_HOSTED_LOGIN_ENABLED=true" };
+        }
+
+        await this.hydrateFromDisk();
+        const host = normalizeCaddyHost(config.supauthHostedLoginHost);
+        const pageRoot = config.supauthHostedLoginPageRoot;
+
+        // hosted login page (covers / and /login.html)
+        this.routesById.set("route-supauth-hosted-login", {
+            "@id": "route-supauth-hosted-login",
+            match: [{
+                host: [host],
+                path: ["/", "/login.html"],
+            }],
+            handle: [
+                { handler: "rewrite", uri: "/authorize.html" },
+                { handler: "file_server", root: pageRoot },
+            ],
+            terminal: true,
+        });
+
+        // authorize page (covers /oauth/authorize*)
+        this.routesById.set("route-supauth-authorize-page", {
+            "@id": "route-supauth-authorize-page",
+            match: [{
+                host: [host],
+                path: ["/oauth/authorize*"],
+            }],
+            handle: [
+                { handler: "rewrite", uri: "/authorize.html" },
+                { handler: "file_server", root: pageRoot },
+            ],
+            terminal: true,
+        });
+
+        await this.persistAndLoad();
+        logger.info(`[CaddyGatewayProvider] SupAuth hosted login page routes registered for ${host}`);
+        return { success: true };
+    }
 }
 
 export class GatewayService implements GatewayProvider {
@@ -1175,6 +1242,7 @@ export class GatewayService implements GatewayProvider {
     upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }) { return this.provider.upsertCertificateForSnis(opts); }
     configureFrontendRoute(route: FrontendGatewayRoute) { return this.provider.configureFrontendRoute(route); }
     removeFrontendRoute(projectRef: string, deploymentId: string) { return this.provider.removeFrontendRoute(projectRef, deploymentId); }
+    setupSupauthHostedLogin() { return this.provider.setupSupauthHostedLogin(); }
 }
 
 export const gatewayService = new GatewayService();


### PR DESCRIPTION
## 问题

`auth.ai.xigu.team/login.html` 返回 NOT_FOUND。

根因：SupAuth hosted authorize 登录页面的 Caddy 路由是手动添加到 JSON 配置中的，不在 supacloud 代码管理范围内。路由配置错误（file_server root 指向空目录、路由排在 catch-all 之后）。

## 修复

在 `CaddyGatewayProvider` 中添加 `setupSupauthHostedLogin()` 方法，通过 supacloud 配置驱动自动注册 SupAuth 登录页面的 Caddy 路由。

### 新增环境变量

| 变量 | 说明 |
|------|------|
| `SUPAUTH_HOSTED_LOGIN_ENABLED` | 设为 `true` 启用 |
| `SUPAUTH_HOSTED_LOGIN_HOST` | auth 域名（如 `auth.ai.xigu.team`）|
| `SUPAUTH_HOSTED_LOGIN_PAGE_ROOT` | authorize.html 所在目录 |

### 注册的路由

- `route-supauth-hosted-login`: `/` 和 `/login.html` → `authorize.html`
- `route-supauth-authorize-page`: `/oauth/authorize*` → `authorize.html`

路由排序优先级与 `route-custom-` 相同，排在 catch-all `/*` 之前。

### 启动时自动注册

在 `index.ts` 的 gateway 初始化流程中，于 `setupMasterRoutes` 之后调用 `setupSupauthHostedLogin`。

## 验证

- `bunx tsc --noEmit` 通过
- 单元测试 459 pass（1 个 E2E snapshot 测试因无数据库连接 fail，与本次改动无关）

## 部署

合并后，在 2201 的 `/etc/supabase/management-api.env` 或 `/opt/supacloud/config.env` 中配置：

```
SUPAUTH_HOSTED_LOGIN_ENABLED=true
SUPAUTH_HOSTED_LOGIN_HOST=auth.ai.xigu.team
SUPAUTH_HOSTED_LOGIN_PAGE_ROOT=/opt/supauth/packages/admin-console/build
```

然后重启 `supacloud.service`，路由会自动注册。之前手动添加的 `route-auth-ai-xigu-*` 路由在下次 hydrate 后可手动清理。