### PR TITLE
fix: harden PostgREST tenant schema defaults and watchdog alerts

### DIFF
--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     restart: always
     environment:
       PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/postgres
-      PGRST_DB_SCHEMAS: public,storage,graphql_public,pgmq_public
+      PGRST_DB_SCHEMAS: public,storage,graphql_public
       PGRST_JWT_SECRET: ${JWT_SECRET}
     networks:
       - supacloud-dev

--- a/docker/self-host/.env.example
+++ b/docker/self-host/.env.example
@@ -38,7 +38,7 @@ PUBLIC_URL=http://localhost:8000
 STUDIO_URL=http://localhost:9090
 BASE_DOMAIN=localhost
 
-PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public
+PGRST_DB_SCHEMAS=public,storage,graphql_public
 
 CADDY_HTTP_PORT=8000
 CADDY_HTTPS_PORT=8443

--- a/docker/self-host/docker-compose.yml
+++ b/docker/self-host/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         condition: service_healthy
     environment:
       PGRST_DB_URI: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}
-      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS:-public,storage,graphql_public,pgmq_public}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS:-public,storage,graphql_public}
       PGRST_DB_ANON_ROLE: anon
       PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_SERVER_PROXY_URI: ${PUBLIC_URL}

--- a/docker/self-host/init-env.py
+++ b/docker/self-host/init-env.py
@@ -135,7 +135,7 @@ def main() -> None:
     print(f"PUBLIC_URL={args.public_url}")
     print(f"STUDIO_URL={args.studio_url}")
     print(f"BASE_DOMAIN={derive_base_domain(args.public_url)}")
-    print("PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public")
+    print("PGRST_DB_SCHEMAS=public,storage,graphql_public")
     print("CADDY_HTTP_PORT=8000")
     print("CADDY_HTTPS_PORT=8443")
     print("# CADDY_ADMIN_PORT=2019 (internal only)")

--- a/docs/queues-pgmq-migration.md
+++ b/docs/queues-pgmq-migration.md
@@ -39,9 +39,15 @@ Tenant databases now install and expose the `pgmq` foundation:
 2. `CREATE SCHEMA IF NOT EXISTS pgmq_public`
 3. wrapper functions in `pgmq_public` for the official API
 4. `GRANT EXECUTE` on `pgmq_public` functions to `anon`, `authenticated`, and `service_role`
-5. PostgREST schemas include `pgmq_public`
+5. PostgREST may expose `pgmq_public`, but only after the wrapper schema actually exists
 
-For self-hosted deployments, `PGRST_DB_SCHEMAS` must include:
+For self-hosted deployments, keep the safe baseline first:
+
+```env
+PGRST_DB_SCHEMAS=public,storage,graphql_public
+```
+
+After the tenant database has the `pgmq_public` wrapper schema, you can add it back explicitly:
 
 ```env
 PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public

--- a/infrastructure/systemd/supacloud-postgrest-watchdog.service
+++ b/infrastructure/systemd/supacloud-postgrest-watchdog.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=SupaCloud PostgREST tenant watchdog
+Documentation=https://github.com/zuohuadong/supacloud
+After=network-online.target supacloud.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/supabase/management-api.env
+ExecStart=/opt/supacloud/scripts/postgrest_watchdog.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=supacloud-postgrest-watchdog
+
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/var/lib/supacloud /etc/supabase/tenants
+PrivateTmp=true

--- a/infrastructure/systemd/supacloud-postgrest-watchdog.timer
+++ b/infrastructure/systemd/supacloud-postgrest-watchdog.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run SupaCloud PostgREST tenant watchdog every minute
+Documentation=https://github.com/zuohuadong/supacloud
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=15s
+Persistent=true
+Unit=supacloud-postgrest-watchdog.service
+
+[Install]
+WantedBy=timers.target

--- a/install.sh
+++ b/install.sh
@@ -2316,9 +2316,11 @@ install_management_api() {
     local BIN_NAME="supacloud"
     local BIN_SOURCE="${SCRIPT_DIR}/${BIN_NAME}"
     local BIN_TARGET="/usr/local/bin/${BIN_NAME}"
-    local SCRIPTS_INSTALL_DIR="/opt/supacloud/scripts/lib"
+    local ROOT_SCRIPTS_INSTALL_DIR="/opt/supacloud/scripts"
+    local SCRIPTS_INSTALL_DIR="${ROOT_SCRIPTS_INSTALL_DIR}/lib"
     local API_DATA_DIR="/opt/supacloud/management-api"
 
+    mkdir -p "$ROOT_SCRIPTS_INSTALL_DIR"
     mkdir -p "$SCRIPTS_INSTALL_DIR"
     mkdir -p "$API_DATA_DIR"
     mkdir -p /etc/supabase
@@ -2350,13 +2352,20 @@ install_management_api() {
     fi
     chmod +x "$BIN_TARGET"
 
-    # 2. Copy management scripts (Pigsty adapter)
+    # 2. Copy management scripts
+    if [[ -d "${SCRIPT_DIR}/scripts" ]] && [[ "${SCRIPT_DIR}/scripts" != "$ROOT_SCRIPTS_INSTALL_DIR" ]]; then
+        find "${SCRIPT_DIR}/scripts" -maxdepth 1 -type f -name '*.sh' -exec cp {} "$ROOT_SCRIPTS_INSTALL_DIR/" \;
+        chmod +x "$ROOT_SCRIPTS_INSTALL_DIR"/*.sh
+        log_info "Management scripts ready: $ROOT_SCRIPTS_INSTALL_DIR"
+    fi
+
+    # 2b. Copy management script libraries (Pigsty adapter)
     if [[ -d "${SCRIPT_DIR}/scripts/lib" ]] && [[ "${SCRIPT_DIR}/scripts/lib" != "$SCRIPTS_INSTALL_DIR" ]]; then
         cp -rf "${SCRIPT_DIR}/scripts/lib/"* "$SCRIPTS_INSTALL_DIR/"
         chmod +x "$SCRIPTS_INSTALL_DIR"/*.sh
         log_info "Underlying script link ready: $SCRIPTS_INSTALL_DIR"
 
-    # 2b. Copy database schema files (required for project provisioning)
+    # 2c. Copy database schema files (required for project provisioning)
     local SCHEMA_SRC="${SCRIPT_DIR}/packages/management-api/src/db/schemas"
     local SCHEMA_DST="/opt/supacloud/packages/management-api/src/db/schemas"
     if [[ -d "$SCHEMA_SRC" ]]; then
@@ -2439,6 +2448,8 @@ CADDY_ADMIN_URL=${CADDY_ADMIN_URL:-http://127.0.0.1:2019}
 CADDY_CONFIG_PATH=${CADDY_CONFIG_PATH:-/etc/supacloud/caddy/config.json}
 CADDY_STATE_DIR=${CADDY_STATE_DIR:-/var/lib/supacloud/caddy}
 CADDY_BINARY_PATH=${CADDY_BINARY_PATH:-/usr/local/bin/supacloud-caddy}
+SUPACLOUD_ALERT_WEBHOOK_URL=${SUPACLOUD_ALERT_WEBHOOK_URL:-}
+SUPACLOUD_WATCHDOG_JOURNAL_WINDOW=${SUPACLOUD_WATCHDOG_JOURNAL_WINDOW:-5 minutes ago}
 EOF
     chmod 600 /etc/supabase/management-api.env
     sync_runtime_config /etc/supabase/management-api.env
@@ -2480,9 +2491,19 @@ LimitNOFILE=65536
 WantedBy=multi-user.target
 EOF
     fi
+    if [[ -f "${SYSTEMD_SRC}/supacloud-postgrest-watchdog.service" ]]; then
+        cp "${SYSTEMD_SRC}/supacloud-postgrest-watchdog.service" /etc/systemd/system/supacloud-postgrest-watchdog.service
+    fi
+    if [[ -f "${SYSTEMD_SRC}/supacloud-postgrest-watchdog.timer" ]]; then
+        cp "${SYSTEMD_SRC}/supacloud-postgrest-watchdog.timer" /etc/systemd/system/supacloud-postgrest-watchdog.timer
+    fi
     systemctl daemon-reload
     systemctl enable supacloud
     systemctl start supacloud || log_warn "Service start failed, please check journalctl -u supacloud"
+    if [[ -f /etc/systemd/system/supacloud-postgrest-watchdog.timer ]]; then
+        systemctl enable supacloud-postgrest-watchdog.timer
+        systemctl start supacloud-postgrest-watchdog.timer || log_warn "PostgREST watchdog timer start failed, please check journalctl -u supacloud-postgrest-watchdog.service"
+    fi
 
 
     # 7b. Ensure GoTrue binary and systemd template are deployed

--- a/install.sh
+++ b/install.sh
@@ -2364,6 +2364,7 @@ install_management_api() {
         cp -rf "${SCRIPT_DIR}/scripts/lib/"* "$SCRIPTS_INSTALL_DIR/"
         chmod +x "$SCRIPTS_INSTALL_DIR"/*.sh
         log_info "Underlying script link ready: $SCRIPTS_INSTALL_DIR"
+    fi
 
     # 2c. Copy database schema files (required for project provisioning)
     local SCHEMA_SRC="${SCRIPT_DIR}/packages/management-api/src/db/schemas"
@@ -2374,7 +2375,6 @@ install_management_api() {
         log_info "Database schema files deployed to $SCHEMA_DST"
     else
         log_warn "Schema source directory not found: $SCHEMA_SRC"
-    fi
     fi
 
     # 3. Generate management credentials

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -27,7 +27,7 @@ function pickPositivePort(value: unknown): number | null {
 const DEFAULT_POSTGREST_SCHEMAS = ["public", "storage", "graphql_public"] as const;
 
 export function renderPostgrestDbSchemas(includePgmqPublic = false): string {
-    const schemas = [...DEFAULT_POSTGREST_SCHEMAS];
+    const schemas: string[] = [...DEFAULT_POSTGREST_SCHEMAS];
     if (includePgmqPublic) schemas.push("pgmq_public");
     return schemas.join(", ");
 }

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -24,6 +24,14 @@ function pickPositivePort(value: unknown): number | null {
     return Math.trunc(port);
 }
 
+const DEFAULT_POSTGREST_SCHEMAS = ["public", "storage", "graphql_public"] as const;
+
+export function renderPostgrestDbSchemas(includePgmqPublic = false): string {
+    const schemas = [...DEFAULT_POSTGREST_SCHEMAS];
+    if (includePgmqPublic) schemas.push("pgmq_public");
+    return schemas.join(", ");
+}
+
 export interface RuntimeStatus {
     status: "running" | "stopped" | "starting" | "error";
     port: number;
@@ -1177,10 +1185,26 @@ class TenantRuntimeService {
         await this.ensureGotrueBinary();
     }
 
+    private async hasPgmqPublicSchema(ref: string, dbName: string, dbPassword: string): Promise<boolean> {
+        const dbUrl = `postgres://${resolveAuthenticatorName(ref)}:${dbPassword}@${this.PG_HOST}:${this.PG_PORT}/${dbName}`;
+        const query = "SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'pgmq_public') THEN 1 ELSE 0 END;";
+        const result = await $`psql ${dbUrl} -Atqc ${query}`.nothrow().quiet();
+        if (result.exitCode !== 0) {
+            const stderr = result.stderr.toString().trim();
+            logger.warn(`[tenant-runtime] Failed to detect pgmq_public schema for ${ref}; falling back to base PostgREST schemas`, {
+                error: stderr || `psql exited with code ${result.exitCode}`,
+            });
+            return false;
+        }
+        return result.stdout.toString().trim() === "1";
+    }
+
     private async generateTenantConfig(ref: string, pgrstPort: number, gotruePort: number) {
         await fs.mkdir(this.TENANT_CONFIG_DIR, { recursive: true });
 
         const creds = await this.getTenantCredentials(ref);
+        const includePgmqPublic = await this.hasPgmqPublicSchema(ref, creds.dbName, creds.dbPassword);
+        const dbSchemas = renderPostgrestDbSchemas(includePgmqPublic);
 
         const jwtVerifierSecret = creds.jwtJwks || creds.jwtSecret;
         const jwtJwksEnv = creds.jwtJwks ? `\nJWT_JWKS=${quoteSystemdEnvValue(creds.jwtJwks)}` : "";
@@ -1207,7 +1231,7 @@ ${jwtJwksEnv}${jwtKeysEnv}
         const pgrstConf = `
 # PostgREST config for tenant: ${ref}
 db-uri = "postgres://${resolveAuthenticatorName(ref)}:${creds.dbPassword}@${this.PG_HOST}:${this.PG_PORT}/${creds.dbName}"
-db-schemas = "public, storage, graphql_public, pgmq_public"
+db-schemas = "${dbSchemas}"
 db-extra-search-path = "public, extensions, auth"
 db-anon-role = "anon"
 jwt-secret = ${JSON.stringify(jwtVerifierSecret)}

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -121,13 +121,23 @@ describe("supabase bootstrap schema", () => {
     }
   });
 
-  test("PostgREST tenant config exposes pgmq_public for supabase-js schema rpc", () => {
+  test("PostgREST tenant config keeps pgmq_public out of safe defaults", () => {
     for (const filePath of [
-      "src/services/tenant-runtime.service.ts",
-      "../../scripts/lib/tenant_runtime.sh",
+      "../../docker/dev/docker-compose.yml",
       "../../docker/self-host/docker-compose.yml",
       "../../docker/self-host/.env.example",
       "../../docker/self-host/init-env.py",
+    ]) {
+      const source = readRepoFile(filePath);
+      expect(source).toContain("public,storage,graphql_public");
+      expect(source).not.toContain("public,storage,graphql_public,pgmq_public");
+    }
+  });
+
+  test("tenant runtime only exposes pgmq_public after detecting wrapper schema", () => {
+    for (const filePath of [
+      "src/services/tenant-runtime.service.ts",
+      "../../scripts/lib/tenant_runtime.sh",
     ]) {
       const source = readRepoFile(filePath);
       expect(source).toContain("pgmq_public");

--- a/packages/management-api/tests/unit/tenant-runtime.env.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.env.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { quoteSystemdEnvValue } from "../../src/utils/systemd-env";
+import { renderPostgrestDbSchemas } from "../../src/services/tenant-runtime.service";
 
 describe("TenantRuntimeService systemd env quoting", () => {
   test("single-quotes JSON values so systemd preserves double quotes", () => {
@@ -12,5 +13,15 @@ describe("TenantRuntimeService systemd env quoting", () => {
 
   test("rejects values that cannot be represented safely in EnvironmentFile", () => {
     expect(() => quoteSystemdEnvValue(`{"name":"can't"}`)).toThrow("both single and double quotes");
+  });
+});
+
+describe("TenantRuntimeService PostgREST schema rendering", () => {
+  test("does not expose pgmq_public by default", () => {
+    expect(renderPostgrestDbSchemas()).toBe("public, storage, graphql_public");
+  });
+
+  test("exposes pgmq_public only when the wrapper schema exists", () => {
+    expect(renderPostgrestDbSchemas(true)).toBe("public, storage, graphql_public, pgmq_public");
   });
 });

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -9,6 +9,65 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+check_postgrest_tenant_runtimes() {
+    local tenant_dir="/etc/supabase/tenants"
+    local checked=0
+    local unhealthy=0
+
+    if [[ ! -d "$tenant_dir" ]]; then
+        echo -e "${YELLOW}?${NC} Tenant PostgREST (config dir missing: $tenant_dir)"
+        return 0
+    fi
+
+    shopt -s nullglob
+    for conf in "$tenant_dir"/*.conf; do
+        [[ "$conf" == *.bak* ]] && continue
+
+        local tenant="${conf##*/}"
+        tenant="${tenant%.conf}"
+
+        local port
+        port=$(sed -n 's/^server-port = \([0-9][0-9]*\)$/\1/p' "$conf" | head -n 1)
+        checked=$((checked + 1))
+
+        if [[ -z "$port" ]]; then
+            echo -e "${RED}✗${NC} Tenant PostgREST ${tenant} (missing server-port)"
+            unhealthy=$((unhealthy + 1))
+            continue
+        fi
+
+        if curl -fsS --max-time 3 "http://127.0.0.1:${port}/" >/dev/null 2>&1; then
+            echo -e "${GREEN}✓${NC} Tenant PostgREST ${tenant} (${port})"
+            continue
+        fi
+
+        unhealthy=$((unhealthy + 1))
+        local detail
+        detail=$(journalctl -u "supacloud-pgrst@${tenant}" -n 20 --no-pager 2>/dev/null \
+            | grep -E 'PGRST002|Failed to load the schema cache|schema "pgmq_public" does not exist' \
+            | tail -n 1 || true)
+        if [[ -n "$detail" ]]; then
+            echo -e "${RED}✗${NC} Tenant PostgREST ${tenant} (${port}) ${detail}"
+        else
+            echo -e "${RED}✗${NC} Tenant PostgREST ${tenant} (${port})"
+        fi
+    done
+    shopt -u nullglob
+
+    if [[ "$checked" -eq 0 ]]; then
+        echo -e "${YELLOW}?${NC} Tenant PostgREST (no tenant configs found)"
+        return 0
+    fi
+
+    if [[ "$unhealthy" -gt 0 ]]; then
+        echo -e "${RED}✗${NC} Tenant PostgREST summary (${unhealthy}/${checked} unhealthy)"
+        return 1
+    fi
+
+    echo -e "${GREEN}✓${NC} Tenant PostgREST summary (${checked} healthy)"
+    return 0
+}
+
 check_service() {
     local name="$1"
     local check_cmd="$2"
@@ -72,6 +131,8 @@ if [[ "$active_tenants" -gt 0 ]]; then
 else
     echo -e "${YELLOW}?${NC} No active tenant runtimes"
 fi
+
+check_postgrest_tenant_runtimes
 
 # Check S3 Storage
 if systemctl is-active --quiet juicefs-s3 2>/dev/null; then

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -215,6 +215,19 @@ generate_tenant_config() {
         exit 1
     fi
 
+    local pgrst_db_schemas="public,storage,graphql_public"
+    local pgrst_db_schemas_conf="public, storage, graphql_public"
+    local pgmq_public_exists=""
+    if command -v psql >/dev/null 2>&1; then
+        pgmq_public_exists=$(psql "postgres://authenticator_${ref}:${db_password}@${PG_HOST}:${PG_PORT}/${db_name}" \
+            -Atqc "SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'pgmq_public') THEN 1 ELSE 0 END;" \
+            2>/dev/null || true)
+    fi
+    if [ "$pgmq_public_exists" = "1" ]; then
+        pgrst_db_schemas="${pgrst_db_schemas},pgmq_public"
+        pgrst_db_schemas_conf="${pgrst_db_schemas_conf}, pgmq_public"
+    fi
+
     # Query tenant's API external access URL (for GoTrue API_EXTERNAL_URL)
     # Priority: environment variable override > supacloud_meta.projects.api_url > default placeholder
     local api_external_url="${GOTRUE_API_EXTERNAL_URL:-}"
@@ -230,7 +243,7 @@ generate_tenant_config() {
     cat > "${TENANT_CONFIG_DIR}/${ref}.env" <<EOF
 # SupaCloud Tenant PostgREST Runtime: ${ref}
 PGRST_DB_URI=postgres://authenticator_${ref}:${db_password}@${PG_HOST}:${PG_PORT}/${db_name}
-PGRST_DB_SCHEMAS=public,storage,graphql_public,pgmq_public
+PGRST_DB_SCHEMAS=${pgrst_db_schemas}
 PGRST_DB_EXTRA_SEARCH_PATH=public
 PGRST_DB_ANON_ROLE=anon
 PGRST_JWT_SECRET=${jwt_secret}
@@ -244,7 +257,7 @@ EOF
     cat > "${TENANT_CONFIG_DIR}/${ref}.conf" <<EOF
 # PostgREST config for tenant: ${ref}
 db-uri = "postgres://authenticator_${ref}:${db_password}@${PG_HOST}:${PG_PORT}/${db_name}"
-db-schemas = "public, storage, graphql_public, pgmq_public"
+db-schemas = "${pgrst_db_schemas_conf}"
 # Bug Fix: Multi-tenant isolation - extra search path should include tenant-specific schema
 db-extra-search-path = "public, extensions, auth, ${ref}"
 db-anon-role = "anon"

--- a/scripts/postgrest_watchdog.sh
+++ b/scripts/postgrest_watchdog.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# SupaCloud - PostgREST tenant watchdog
+# Detects tenant-local PostgREST HTTP 503s and schema-cache failures such as PGRST002.
+
+set -euo pipefail
+
+STATE_ROOT="${SUPACLOUD_WATCHDOG_STATE_DIR:-/var/lib/supacloud/postgrest-watchdog}"
+TENANT_DIR="${SUPACLOUD_TENANT_CONFIG_DIR:-/etc/supabase/tenants}"
+JOURNAL_WINDOW="${SUPACLOUD_WATCHDOG_JOURNAL_WINDOW:-5 minutes ago}"
+HOSTNAME_VALUE="$(hostname)"
+
+mkdir -p "$STATE_ROOT"
+
+if [[ -f /etc/supabase/management-api.env ]]; then
+    # shellcheck disable=SC1091
+    source /etc/supabase/management-api.env
+fi
+
+ALERT_WEBHOOK_URL="${SUPACLOUD_ALERT_WEBHOOK_URL:-}"
+
+json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\t'/\\t}"
+    printf '"%s"' "$value"
+}
+
+send_alert() {
+    local severity="$1"
+    local tenant="$2"
+    local message="$3"
+    local payload
+    payload=$(cat <<EOF
+{"severity":"${severity}","tenant":"${tenant}","host":"${HOSTNAME_VALUE}","message":$(json_escape "$message")}
+EOF
+)
+
+    logger -t supacloud-postgrest-watchdog "[$severity] ${tenant}: ${message}"
+
+    if [[ -n "$ALERT_WEBHOOK_URL" ]]; then
+        curl -fsS -X POST \
+            -H 'Content-Type: application/json' \
+            -d "$payload" \
+            "$ALERT_WEBHOOK_URL" >/dev/null || logger -t supacloud-postgrest-watchdog "[warn] webhook delivery failed for ${tenant}"
+    fi
+}
+
+set_state() {
+    local tenant="$1"
+    local state="$2"
+    printf '%s' "$state" > "${STATE_ROOT}/${tenant}.state"
+}
+
+get_state() {
+    local tenant="$1"
+    local state_file="${STATE_ROOT}/${tenant}.state"
+    if [[ -f "$state_file" ]]; then
+        cat "$state_file"
+    fi
+}
+
+check_tenant() {
+    local conf="$1"
+    local tenant="${conf##*/}"
+    tenant="${tenant%.conf}"
+
+    local port
+    port=$(sed -n 's/^server-port = \([0-9][0-9]*\)$/\1/p' "$conf" | head -n 1)
+    if [[ -z "$port" ]]; then
+        echo "missing-port|Tenant config ${conf} is missing server-port"
+        return 0
+    fi
+
+    local http_code
+    http_code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 3 "http://127.0.0.1:${port}/" || true)
+    if [[ "$http_code" != "200" ]]; then
+        echo "http-${http_code}|Local PostgREST probe on 127.0.0.1:${port} returned HTTP ${http_code}"
+        return 0
+    fi
+
+    local journal_match
+    journal_match=$(journalctl -u "supacloud-pgrst@${tenant}" --since "$JOURNAL_WINDOW" --no-pager 2>/dev/null \
+        | grep -E 'PGRST002|Failed to load the schema cache|schema "pgmq_public" does not exist' \
+        | tail -n 1 || true)
+    if [[ -n "$journal_match" ]]; then
+        echo "journal-error|${journal_match}"
+        return 0
+    fi
+
+    echo "ok|healthy"
+}
+
+main() {
+    local any_issue=0
+    shopt -s nullglob
+    local confs=("$TENANT_DIR"/*.conf)
+    shopt -u nullglob
+
+    if [[ "${#confs[@]}" -eq 0 ]]; then
+        logger -t supacloud-postgrest-watchdog "[info] no tenant config files found under ${TENANT_DIR}"
+        exit 0
+    fi
+
+    for conf in "${confs[@]}"; do
+        [[ "$conf" == *.bak* ]] && continue
+
+        local tenant="${conf##*/}"
+        tenant="${tenant%.conf}"
+
+        local result issue detail fingerprint previous
+        result=$(check_tenant "$conf")
+        issue="${result%%|*}"
+        detail="${result#*|}"
+        previous="$(get_state "$tenant")"
+
+        if [[ "$issue" == "ok" ]]; then
+            if [[ -n "$previous" && "$previous" != ok ]]; then
+                send_alert "recovered" "$tenant" "PostgREST recovered: ${detail}"
+            fi
+            set_state "$tenant" "ok"
+            continue
+        fi
+
+        any_issue=1
+        fingerprint="${issue}|${detail}"
+        if [[ "$previous" != "$fingerprint" ]]; then
+            send_alert "critical" "$tenant" "$detail"
+            set_state "$tenant" "$fingerprint"
+        fi
+    done
+
+    if [[ "$any_issue" -ne 0 ]]; then
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- stop default PostgREST tenant configs from always exposing `pgmq_public`
- only add `pgmq_public` when the tenant database actually contains the wrapper schema
- add tenant-level PostgREST watchdog checks plus install-time systemd timer wiring

## Validation
- `bash -n scripts/health_check.sh`
- `bash -n scripts/postgrest_watchdog.sh`
- `bash -n install.sh`
- `bun run typecheck` in `packages/management-api`
- `bun test tests/unit/tenant-runtime.env.test.ts`