### PR TITLE
fix(storage): accept configured API domains for SDK requests

### DIFF
--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -295,7 +295,9 @@ async function getProjectRef(headers: Record<string, string | undefined>): Promi
             const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
                 matchProjectRefFromHost(host, String(row.ref || ""), row.config),
             );
-            if (matchedProject && String(matchedProject.ref) !== apiKeyRef) return '';
+            if (matchedProject) {
+                return String(matchedProject.ref) === apiKeyRef ? apiKeyRef : '';
+            }
         } catch (error: unknown) {
             logger.warn("[StorageCompat] Failed to validate API key host binding", {
                 apiKeyRef,

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -150,6 +150,62 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     downloadSpy.mockRestore();
   });
 
+  test("allows API-key storage requests on configured api_domain under the base domain", async () => {
+    const sqlSpy = spyOn(dbModule, "sql");
+    sqlSpy.mockImplementation(async (...args: unknown[]) => {
+      const text = String(args[0] ?? "");
+      if (text.includes("anon_key")) {
+        return [{ ref: "proj_from_key" }];
+      }
+      if (text.includes("FROM projects")) {
+        return [{
+          ref: "proj_from_key",
+          config: { api_domain: "api.example.com", custom_domain: "www.example.com" },
+        }];
+      }
+      return [];
+    });
+    const bucketSpy = spyOn(StorageRLS, "getLogicalBucket").mockResolvedValue({
+      id: "avatars",
+      name: "avatars",
+      public: true,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    const objectSpy = spyOn(StorageRLS, "getObjectInfo").mockResolvedValue({
+      id: "obj_1",
+      bucket_id: "avatars",
+      name: "public.txt",
+      metadata: { size: 3, mimetype: "text/plain" },
+      cache_control: "3600",
+      updated_at: new Date().toISOString(),
+    });
+    const downloadSpy = spyOn(StorageService, "getDownloadResponse").mockResolvedValue(
+      new Response("ok\n", {
+        headers: {
+          "Content-Type": "text/plain",
+          "Content-Length": "3",
+        },
+      })
+    );
+
+    const res = await request("/storage/v1/object/public/avatars/public.txt", {
+      headers: {
+        apikey: "anon-for-proj-from-key",
+        host: "api.example.com",
+        "x-project-ref": "proj_from_key",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok\n");
+    expect(downloadSpy).toHaveBeenCalledWith("proj_from_key", "avatars", "public.txt");
+    sqlSpy.mockRestore();
+    bucketSpy.mockRestore();
+    objectSpy.mockRestore();
+    downloadSpy.mockRestore();
+  });
+
   test("public downloads prefer stored object mimetype when backend returns octet-stream", async () => {
     mockObjects.set("avatars/folder/cat.png", {
       metadata: { size: 3, mimetype: "image/png" },


### PR DESCRIPTION
## Summary
- fix storage-compat host validation for SDK requests on configured `api_domain` hosts
- accept a request once the host matches the same project resolved from the API key
- add a regression test for `api.<baseDomain>` custom API domains, which previously fell through to the legacy subdomain check and was rejected

## Verification
- `bun test packages/management-api/tests/unit/storage-compat.sdk.test.ts packages/management-api/tests/unit/gateway.service.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `bun run --cwd packages/management-api test`
- `git diff --check`

Context: reproduced from vm1 where `api.ai.xigu.team/storage/v1*` was rejected as `Missing or invalid project reference` even though `projects.config.api_domain` was `api.ai.xigu.team`.