### PR TITLE
fix(gateway): omit empty Caddy response headers

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -536,7 +536,6 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 request: {
                     set: Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value : [value]])),
                 },
-                response: responseHeaders,
             },
             transport: {
                 protocol: "http",
@@ -544,6 +543,9 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 write_timeout: "500s",
             },
         };
+        if (Object.keys(responseHeaders).length > 0) {
+            (proxy.headers as Record<string, unknown>).response = responseHeaders;
+        }
         if (streaming !== false) {
             proxy.flush_interval = -1;
         }

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -660,8 +660,9 @@ describe("CaddyGatewayProvider route headers", () => {
 
         const storageProxy = storage?.handle?.find((h: any) => h.handler === "reverse_proxy");
         expect(storage?.handle?.some((h: any) => h.strip_path_prefix === "/storage/v1")).toBe(false);
-        // Storage route should preserve upstream CORS (no response.delete)
-        expect(storageProxy?.headers?.response?.delete).toBeUndefined();
+        // Storage route should preserve upstream CORS without rendering an empty
+        // response header block, which can break Caddy proxy responses.
+        expect(storageProxy?.headers?.response).toBeUndefined();
         // Storage route must have project routing headers
         const requestSet = storageProxy?.headers?.request?.set;
         expect(requestSet?.["Host"]).toEqual([`storagetest.api.${config.baseDomain}`]);


### PR DESCRIPTION
## Summary
- omit `reverse_proxy.headers.response` when no response header mutations are needed
- keep Storage routes preserving upstream CORS without rendering an empty response header block
- strengthen the gateway unit test to catch the empty response block regression

## Why
On VM1 after v0.29.7, generated Storage routes had the right path and canonical Host/X-Forwarded-Host, but Caddy returned an empty/aborted response for proxied Storage object requests. Removing the empty `headers.response: {}` block from the generated Storage route restored public Storage upload immediately.

## Verification
- `bun test packages/management-api/tests/unit/gateway.service.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `bun run --cwd packages/management-api test`
- `git diff --check`

Rejected: keeping the VM-specific Storage route hotfix | SupaCloud API owns Caddy config generation, so the generator should stop emitting the bad shape.