### PR TITLE
fix(gateway): support additional api domains

### DIFF
--- a/packages/management-api/src/services/certificate.service.ts
+++ b/packages/management-api/src/services/certificate.service.ts
@@ -6,7 +6,7 @@ import { logger } from "../utils/logger";
 import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-config";
 import {
   normalizeProjectRoutingConfig,
-  resolveProjectApiHost,
+  resolveProjectApiHosts,
   resolveProjectStudioHost,
 } from "../utils/project-routing";
 import { gatewayService } from "./gateway.service";
@@ -134,7 +134,7 @@ export class CertificateService {
   private fallbackDomains(ref: string, projectConfig: Record<string, unknown>): string[] {
     const routing = normalizeProjectRoutingConfig(projectConfig);
     return Array.from(new Set([
-      resolveProjectApiHost(ref, routing),
+      ...resolveProjectApiHosts(ref, routing),
       resolveProjectStudioHost(ref, routing),
     ].map(normalizeDomain).filter(Boolean)));
   }

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -341,14 +341,19 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     private migrateHydratedRoute(routeId: string, route: CaddyRoute): CaddyRoute {
-        if (!routeId.startsWith("route-project-") || !routeId.endsWith("-storage")) return route;
+        if (!routeId.startsWith("route-project-")) return route;
+        const isStorageRoute = routeId.endsWith("-storage");
+        const isFunctionsRoute = routeId.endsWith("-functions");
+        if (!isStorageRoute && !isFunctionsRoute) return route;
 
         const projectRef = this.projectRefFromRouteId(routeId);
         if (!projectRef) return route;
 
         const migrated = JSON.parse(JSON.stringify(route)) as CaddyRoute;
         const handle = Array.isArray(migrated.handle) ? migrated.handle as Record<string, unknown>[] : [];
-        const migratedHandle = handle.filter((handler) => handler.strip_path_prefix !== "/storage/v1");
+        const migratedHandle = isStorageRoute
+            ? handle.filter((handler) => handler.strip_path_prefix !== "/storage/v1")
+            : handle;
         migrated.handle = migratedHandle;
 
         const proxy = migratedHandle.find((handler) => handler.handler === "reverse_proxy") as Record<string, any> | undefined;
@@ -364,9 +369,11 @@ export class CaddyGatewayProvider implements GatewayProvider {
         proxy.headers.request.set["x-project-ref"] = [projectRef];
         proxy.headers.request.set["X-Forwarded-Proto"] = ["{http.request.scheme}"];
 
-        proxy.headers.response = proxy.headers.response && typeof proxy.headers.response === "object" ? proxy.headers.response : {};
-        delete proxy.headers.response.delete;
-        delete proxy.flush_interval;
+        if (isStorageRoute) {
+            proxy.headers.response = proxy.headers.response && typeof proxy.headers.response === "object" ? proxy.headers.response : {};
+            delete proxy.headers.response.delete;
+            delete proxy.flush_interval;
+        }
 
         return migrated;
     }

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -984,7 +984,19 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 this.makeRoute({ id: caddyRouteId(projectRef, "graphql"), hosts, path: "/graphql/v1*", upstream: `${hostIp}:${pgrstPort}`, projectRef, rewriteUri: "/rpc/graphql", headers: ["Content-Profile:graphql_public", "Accept-Profile:graphql_public"], corsOrigins }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "auth"), hosts, path: "/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, stripPrefix: "/auth/v1", corsOrigins }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "gotrue-well-known"), hosts, path: "/.well-known/oauth-authorization-server/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, corsOrigins }),
-                this.makeRoute({ id: caddyRouteId(projectRef, "functions"), hosts, path: "/functions/v1*", upstream: `${hostIp}:${config.port}`, projectRef, readTimeout: 500_000, corsOrigins }),
+                this.makeRoute({
+                    id: caddyRouteId(projectRef, "functions"),
+                    hosts,
+                    path: "/functions/v1*",
+                    upstream: `${hostIp}:${config.port}`,
+                    projectRef,
+                    headers: [
+                        `Host:${projectRef}.api.${config.baseDomain}`,
+                        `X-Forwarded-Host:${projectRef}.api.${config.baseDomain}`,
+                    ],
+                    readTimeout: 500_000,
+                    corsOrigins,
+                }),
                 this.makeRoute({
                     id: caddyRouteId(projectRef, "storage"),
                     hosts,

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -5,7 +5,7 @@ import { sql } from "../db";
 import {
     type ProjectRoutingConfig,
     normalizeProjectRoutingConfig,
-    resolveProjectApiHost,
+    resolveProjectApiHosts,
     resolveProjectAuthHost,
     resolveProjectStudioHost,
 } from "../utils/project-routing";
@@ -67,8 +67,7 @@ export function buildTenantCorsOrigins(
 ): string[] {
     const routingConfig = normalizeProjectRoutingConfig(projectRouting);
     const hosts = [
-        `${projectRef}.api.${config.baseDomain}`,
-        resolveProjectApiHost(projectRef, routingConfig),
+        ...resolveProjectApiHosts(projectRef, routingConfig),
         resolveProjectAuthHost(projectRef, routingConfig),
         `studio-${projectRef}.${config.baseDomain}`,
         resolveProjectStudioHost(projectRef, routingConfig),
@@ -961,10 +960,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
             await this.hydrateFromDisk();
             const hostIp = await this.detectHostIp();
             const routingConfig = normalizeProjectRoutingConfig(projectRouting);
-            const hosts = uniqueStrings([
-                `${projectRef}.api.${config.baseDomain}`,
-                resolveProjectApiHost(projectRef, routingConfig),
-            ]);
+            const hosts = uniqueStrings(resolveProjectApiHosts(projectRef, routingConfig));
             const hostSet = new Set(hosts.map(normalizeCaddyHost));
             const authHosts = uniqueStrings([resolveProjectAuthHost(projectRef, routingConfig)])
                 .filter((host) => !hostSet.has(normalizeCaddyHost(host)));
@@ -1113,7 +1109,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
         try {
             const projects = await sql`
                 SELECT ref, config FROM projects
-                WHERE status != 'deleted' AND deleted_at IS NULL
+                WHERE status = 'active' AND deleted_at IS NULL
             `;
             for (const project of projects) {
                 const ref = project.ref as string;

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -599,9 +599,12 @@ export class ProjectService {
     );
 
     const currentConfig = normalizeProjectConfig(project.config);
-    const routingKeys: Array<keyof typeof config> = [
+    const updatedConfig = updated ? normalizeProjectConfig(updated.config) : mergeProjectConfig(project.config, config);
+    const routingKeys = [
       "custom_domain",
       "api_domain",
+      "additional_api_domains",
+      "api_domains",
       "auth_domain",
       "studio_domain",
       "site_url",
@@ -609,14 +612,16 @@ export class ProjectService {
       "additional_redirect_urls",
       "additionalRedirectUrls",
     ];
-    const shouldRestartRuntime = routingKeys.some((key) => currentConfig[key as string] !== config[key as string]);
+    const shouldRestartRuntime = routingKeys.some((key) =>
+      JSON.stringify(currentConfig[key]) !== JSON.stringify(updatedConfig[key])
+    );
 
     if (shouldRestartRuntime) {
       try {
         const { tenantRuntimeService } = await import("./tenant-runtime.service");
         await tenantRuntimeService.restartRuntime(ref);
         if (updated) {
-          await this.reconcileGatewayRoutes(ref, normalizeProjectConfig(updated.config));
+          await this.reconcileGatewayRoutes(ref, updatedConfig);
         }
       } catch (err) {
         logger.warn("[ProjectService] Failed to propagate routing settings to runtime", {

--- a/packages/management-api/src/utils/project-routing.ts
+++ b/packages/management-api/src/utils/project-routing.ts
@@ -3,6 +3,8 @@ import { config } from "../config";
 export interface ProjectRoutingConfig {
   custom_domain?: unknown;
   api_domain?: unknown;
+  additional_api_domains?: unknown;
+  api_domains?: unknown;
   auth_domain?: unknown;
   studio_domain?: unknown;
   postgrest_port?: unknown;
@@ -16,6 +18,30 @@ export interface TenantPorts {
 
 function pickString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function pickStrings(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => pickString(item))
+      .filter((item): item is string => Boolean(item));
+  }
+
+  const single = pickString(value);
+  return single ? [single] : [];
+}
+
+function uniqueHosts(hosts: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const host of hosts) {
+    if (!host) continue;
+    const key = host.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(host);
+  }
+  return result;
 }
 
 function pickPort(value: unknown): number | undefined {
@@ -80,6 +106,20 @@ export function resolveProjectApiHost(
   }
 
   return `${projectRef}.api.${normalizeBaseDomain(config.baseDomain)}`;
+}
+
+export function resolveProjectApiHosts(
+  projectRef: string,
+  projectConfig: ProjectRoutingConfig | string | null | undefined,
+): string[] {
+  const normalizedConfig = normalizeProjectRoutingConfig(projectConfig);
+  const canonicalHost = `${projectRef}.api.${normalizeBaseDomain(config.baseDomain)}`;
+  return uniqueHosts([
+    canonicalHost,
+    resolveProjectApiHost(projectRef, normalizedConfig),
+    ...pickStrings(normalizedConfig?.additional_api_domains),
+    ...pickStrings(normalizedConfig?.api_domains),
+  ]);
 }
 
 export function resolveProjectAuthHost(
@@ -153,16 +193,18 @@ export function matchProjectRefFromHost(
   if (!normalizedHost) return false;
 
   const baseDomain = normalizeBaseDomain(config.baseDomain).toLowerCase();
+  const knownHosts = uniqueHosts([
+    ...resolveProjectApiHosts(projectRef, normalizedConfig),
+    resolveProjectAuthHost(projectRef, normalizedConfig),
+    resolveProjectStudioHost(projectRef, normalizedConfig),
+    `${projectRef}.${baseDomain}`,
+    `${projectRef}.api.${baseDomain}`,
+    pickString(normalizedConfig?.custom_domain),
+  ]).map((item) => item.toLowerCase());
+
   if (baseDomain && normalizedHost.endsWith(baseDomain)) {
-    return normalizedHost === resolveProjectApiHost(projectRef, normalizedConfig).toLowerCase()
-      || normalizedHost === resolveProjectAuthHost(projectRef, normalizedConfig).toLowerCase()
-      || normalizedHost === resolveProjectStudioHost(projectRef, normalizedConfig).toLowerCase()
-      || normalizedHost === `${projectRef}.${baseDomain}`.toLowerCase()
-      || normalizedHost === `${projectRef}.api.${baseDomain}`.toLowerCase();
+    return knownHosts.includes(normalizedHost);
   }
 
-  return normalizedHost === resolveProjectApiHost(projectRef, normalizedConfig).toLowerCase()
-    || normalizedHost === resolveProjectAuthHost(projectRef, normalizedConfig).toLowerCase()
-    || normalizedHost === resolveProjectStudioHost(projectRef, normalizedConfig).toLowerCase()
-    || normalizedHost === pickString(normalizedConfig?.custom_domain)?.toLowerCase();
+  return knownHosts.includes(normalizedHost);
 }

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -119,11 +119,13 @@ describe("GatewayService provider selection", () => {
     test("tenant cors origins include exact api and studio custom domains", () => {
         const origins = buildTenantCorsOrigins("dbbabyref", {
             api_domain: "sapi.dbbaby.top",
+            additional_api_domains: ["api-alt.dbbaby.top"],
             auth_domain: "auth.dbbaby.top",
             studio_domain: "sadmin.dbbaby.top",
         });
 
         expect(origins).toContain("https://sapi.dbbaby.top");
+        expect(origins).toContain("https://api-alt.dbbaby.top");
         expect(origins).toContain("https://auth.dbbaby.top");
         expect(origins).toContain("https://sadmin.dbbaby.top");
     });
@@ -770,6 +772,44 @@ describe("CaddyGatewayProvider route headers", () => {
         expect(requestSet?.["x-project-ref"]).toEqual(["domaintest"]);
         expect(requestSet?.["X-Forwarded-Host"]).toEqual([`domaintest.api.${config.baseDomain}`]);
         expect(requestSet?.["X-Forwarded-Proto"]).toEqual(["{http.request.scheme}"]);
+
+        restore();
+    });
+
+    test("setupUpstream includes additional API domains on project API routes", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        const result = await provider.setupUpstream("multidomain", 3000, 9999, {
+            api_domain: "api.primary.example.com",
+            additional_api_domains: ["ingest-api.example.com", "api.ingest.example.com"],
+            studio_domain: "studio.primary.example.com",
+        });
+        expect(result.success).toBe(true);
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const apiRoutes = routes.filter((route: any) => [
+            "route-project-multidomain-rest",
+            "route-project-multidomain-functions",
+            "route-project-multidomain-storage",
+            "route-project-multidomain-auth",
+        ].includes(route["@id"]));
+
+        expect(apiRoutes).toHaveLength(4);
+        for (const route of apiRoutes) {
+            const hosts = route?.match?.[0]?.host ?? [];
+            expect(hosts).toContain(`multidomain.api.${config.baseDomain}`);
+            expect(hosts).toContain("api.primary.example.com");
+            expect(hosts).toContain("ingest-api.example.com");
+            expect(hosts).toContain("api.ingest.example.com");
+        }
+
+        const functions = routes.find((route: any) => route["@id"] === "route-project-multidomain-functions");
+        const functionsProxy = functions?.handle?.find((h: any) => h.handler === "reverse_proxy");
+        expect(functionsProxy?.headers?.request?.set?.["Host"]).toEqual([`multidomain.api.${config.baseDomain}`]);
+        expect(functionsProxy?.headers?.request?.set?.["X-Forwarded-Host"]).toEqual([`multidomain.api.${config.baseDomain}`]);
 
         restore();
     });

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -631,8 +631,9 @@ describe("CaddyGatewayProvider route headers", () => {
         for (const route of apiRoutes) {
             const proxy = route?.handle?.find((h: any) => h.handler === "reverse_proxy");
             const requestSet = proxy?.headers?.request?.set;
-            const isStorageRoute = String(route["@id"] || "").endsWith("-storage");
-            const expectedHost = isStorageRoute ? `hdrtest.api.${config.baseDomain}` : "{http.request.host}";
+            const routeId = String(route["@id"] || "");
+            const usesProjectCanonicalHost = routeId.endsWith("-storage") || routeId.endsWith("-functions");
+            const expectedHost = usesProjectCanonicalHost ? `hdrtest.api.${config.baseDomain}` : "{http.request.host}";
             expect(requestSet?.["Host"]).toEqual([expectedHost]);
             expect(requestSet?.["X-Project-Ref"]).toEqual(["hdrtest"]);
             expect(requestSet?.["x-project-ref"]).toEqual(["hdrtest"]);

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -743,6 +743,61 @@ describe("CaddyGatewayProvider route headers", () => {
         restore();
     });
 
+    test("hydrates and migrates legacy functions routes to canonical project host headers", async () => {
+        await mkdir("/tmp/supacloud-caddy-test", { recursive: true });
+        await writeFile("/tmp/supacloud-caddy-test/config.json", JSON.stringify({
+            apps: {
+                http: {
+                    servers: {
+                        supacloud: {
+                            routes: [
+                                {
+                                    "@id": "route-project-legacyfn-functions",
+                                    match: [{ host: ["legacyfn.api.example.com", "api.custom.example.com"], path: ["/functions/v1*"] }],
+                                    handle: [
+                                        {
+                                            handler: "reverse_proxy",
+                                            headers: {
+                                                request: {
+                                                    set: {
+                                                        "Host": ["{http.request.host}"],
+                                                        "X-Forwarded-Host": ["{http.request.host}"],
+                                                    },
+                                                },
+                                            },
+                                            upstreams: [{ dial: "127.0.0.1:9090" }],
+                                        },
+                                    ],
+                                    terminal: true,
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        }));
+
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.setCors("legacyfn", ["https://app.example.com"]);
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const functions = routes.find((route: any) => route["@id"] === "route-project-legacyfn-functions");
+        const functionsProxy = functions?.handle?.find((h: any) => h.handler === "reverse_proxy");
+        const requestSet = functionsProxy?.headers?.request?.set;
+
+        expect(requestSet?.["Host"]).toEqual([`legacyfn.api.${config.baseDomain}`]);
+        expect(requestSet?.["X-Forwarded-Host"]).toEqual([`legacyfn.api.${config.baseDomain}`]);
+        expect(requestSet?.["X-Project-Ref"]).toEqual(["legacyfn"]);
+        expect(requestSet?.["x-project-ref"]).toEqual(["legacyfn"]);
+        expect(requestSet?.["X-Forwarded-Proto"]).toEqual(["{http.request.scheme}"]);
+
+        restore();
+    });
+
     test("addProjectDomains preserves Host and routing headers for custom API domain", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);

--- a/packages/management-api/tests/unit/performance-regressions.test.ts
+++ b/packages/management-api/tests/unit/performance-regressions.test.ts
@@ -62,4 +62,12 @@ describe("performance regressions", () => {
     expect(gatewayInitCall).toBeGreaterThan(serverBranch);
     expect(gatewayInitCall).toBeLessThan(serveCall);
   });
+
+  test("gateway rebuild-all skips inactive projects", async () => {
+    const gatewaySource = await read("../../src/services/gateway.service.ts");
+
+    expect(gatewaySource).toContain("async rebuildAllTenantConfigs()");
+    expect(gatewaySource).toContain("WHERE status = 'active' AND deleted_at IS NULL");
+    expect(gatewaySource).not.toContain("WHERE status != 'deleted' AND deleted_at IS NULL");
+  });
 });

--- a/packages/management-api/tests/unit/project-routing.test.ts
+++ b/packages/management-api/tests/unit/project-routing.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeBaseDomain,
   resolveTenantPorts,
   resolveProjectApiHost,
+  resolveProjectApiHosts,
   resolveProjectApiUrl,
   resolveProjectAuthHost,
   resolveProjectAuthUrl,
@@ -72,6 +73,25 @@ describe("project routing", () => {
     expect(resolveProjectApiHost("77az24zz7p", projectConfig)).toBe("api.example.com");
     expect(resolveProjectAuthHost("77az24zz7p", projectConfig)).toBe("auth.example.com");
     expect(matchProjectRefFromHost("auth.example.com", "77az24zz7p", projectConfig)).toBe(true);
+  });
+
+  test("supports additional API domains for routing host matching", () => {
+    config.baseDomain = "ai.xigu.team";
+    const projectConfig = {
+      api_domain: "api.xgic-ingest.192.168.1.48.sslip.io",
+      additional_api_domains: ["ingest-api.ai.xigu.team", "api.xgic-ingest.ai.xigu.team"],
+    };
+
+    expect(resolveProjectApiHost("afemibrarjkvzuuawjfi", projectConfig)).toBe("api.xgic-ingest.192.168.1.48.sslip.io");
+    expect(resolveProjectApiHosts("afemibrarjkvzuuawjfi", projectConfig)).toEqual([
+      "afemibrarjkvzuuawjfi.api.ai.xigu.team",
+      "api.xgic-ingest.192.168.1.48.sslip.io",
+      "ingest-api.ai.xigu.team",
+      "api.xgic-ingest.ai.xigu.team",
+    ]);
+    expect(matchProjectRefFromHost("ingest-api.ai.xigu.team", "afemibrarjkvzuuawjfi", projectConfig)).toBe(true);
+    expect(matchProjectRefFromHost("api.xgic-ingest.ai.xigu.team", "afemibrarjkvzuuawjfi", projectConfig)).toBe(true);
+    expect(matchProjectRefFromHost("ingest-api.other.example", "afemibrarjkvzuuawjfi", projectConfig)).toBe(false);
   });
 
   test("derives Studio host from an api-prefixed API domain when Studio domain is not explicit", () => {

--- a/packages/management-api/tests/unit/project.service.comprehensive.test.ts
+++ b/packages/management-api/tests/unit/project.service.comprehensive.test.ts
@@ -463,6 +463,61 @@ describe("ProjectService - Comprehensive", () => {
     );
   });
 
+  test("updateProjectSettings reconciles gateway routes for additional API domain changes", async () => {
+    projectRepositoryMock.findByRef.mockResolvedValueOnce({
+      ...mockProject,
+      config: {
+        postgrest_port: 3260,
+        gotrue_port: 3360,
+        api_domain: "api.xgic-ingest.192.168.1.48.sslip.io",
+      },
+    });
+    projectRepositoryMock.updateConfig.mockResolvedValueOnce({
+      ...mockProject,
+      config: {
+        postgrest_port: 3260,
+        gotrue_port: 3360,
+        api_domain: "api.xgic-ingest.192.168.1.48.sslip.io",
+        additional_api_domains: [
+          "ingest-api.ai.xigu.team",
+          "api.xgic-ingest.ai.xigu.team",
+        ],
+      },
+    });
+
+    const result = await service.updateProjectSettings("test123abc", {
+      additional_api_domains: [
+        "ingest-api.ai.xigu.team",
+        "api.xgic-ingest.ai.xigu.team",
+      ],
+    });
+
+    expect(result).toEqual({
+      postgrest_port: 3260,
+      gotrue_port: 3360,
+      api_domain: "api.xgic-ingest.192.168.1.48.sslip.io",
+      additional_api_domains: [
+        "ingest-api.ai.xigu.team",
+        "api.xgic-ingest.ai.xigu.team",
+      ],
+    });
+    expect(tenantRuntimeServiceMock.restartRuntime).toHaveBeenCalledWith("test123abc");
+    expect(gatewayServiceMock.setupUpstream).toHaveBeenCalledWith(
+      "test123abc",
+      3260,
+      3360,
+      {
+        postgrest_port: 3260,
+        gotrue_port: 3360,
+        api_domain: "api.xgic-ingest.192.168.1.48.sslip.io",
+        additional_api_domains: [
+          "ingest-api.ai.xigu.team",
+          "api.xgic-ingest.ai.xigu.team",
+        ],
+      },
+    );
+  });
+
   test("getApiKeys returns api keys", async () => {
     projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
     const result = await service.getApiKeys("test123abc");


### PR DESCRIPTION
## Summary
- add project-level additional API domain routing for REST, Functions, Storage, and Auth routes
- include additional API domains in CORS origins and certificate fallback domains
- reconcile gateway routes when additional API domain settings change
- keep Functions custom-domain proxying on the canonical project Host/X-Forwarded-Host
- make gateway rebuild-all skip inactive projects so stale inactive records without port config do not fail rebuilds

## Live Context
- VM1 still has an inactive project ref carpfivdhqegnakcgijo with empty config; rebuild-all should not report it after this change
- route-svc-storage-afemibrarjkvzuuawjfi should remain until afemibrarjkvzuuawjfi has additional_api_domains set and generated project routes cover ingest-api.ai.xigu.team/storage/v1

## Tests
- bun test packages/management-api/tests/unit/project-routing.test.ts packages/management-api/tests/unit/gateway.service.test.ts packages/management-api/tests/unit/project.service.comprehensive.test.ts packages/management-api/tests/unit/performance-regressions.test.ts
- bun run --cwd packages/management-api typecheck
- bun run --cwd packages/management-api test
- git diff --check