### PR TITLE
fix(management-api): prevent empty_stream connection reset during frontend zip upload

### DIFF
--- a/packages/management-api/src/routes/frontend.ts
+++ b/packages/management-api/src/routes/frontend.ts
@@ -17,7 +17,7 @@ function isSafeZipEntryName(name: string): boolean {
 }
 
 async function validateZipArchive(zipPath: string): Promise<{ ok: true } | { ok: false; message: string }> {
-  const namesResult = await Bun.$`unzip -Z -1 ${zipPath}`.quiet();
+  const namesResult = await Bun.$`unzip -Z -1 ${zipPath}`.quiet().nothrow();
   if (namesResult.exitCode !== 0) {
     return { ok: false, message: "Invalid zip archive" };
   }
@@ -33,7 +33,7 @@ async function validateZipArchive(zipPath: string): Promise<{ ok: true } | { ok:
     }
   }
 
-  const listResult = await Bun.$`unzip -Z -l ${zipPath}`.quiet();
+  const listResult = await Bun.$`unzip -Z -l ${zipPath}`.quiet().nothrow();
   if (listResult.exitCode !== 0) {
     return { ok: false, message: "Invalid zip archive" };
   }
@@ -58,27 +58,60 @@ async function validateZipArchive(zipPath: string): Promise<{ ok: true } | { ok:
 }
 
 async function readUploadedZip(request: Request, body: unknown): Promise<Uint8Array> {
-  if (body instanceof File || body instanceof Blob) {
-    return new Uint8Array(await body.arrayBuffer());
+  // 1. 如果 body 本身就是 File / Blob，或具有 arrayBuffer 方法
+  if (body && typeof body === "object" && typeof (body as any).arrayBuffer === "function") {
+    try {
+      return new Uint8Array(await (body as any).arrayBuffer());
+    } catch {
+      // ignore
+    }
   }
 
+  // 2. 如果 body 是一个对象，检测其属性（例如 file 字段，或其他任意包含 arrayBuffer 的字段）
   if (body && typeof body === "object") {
     const directFile = (body as Record<string, unknown>).file;
-    if (directFile instanceof File || directFile instanceof Blob) {
-      return new Uint8Array(await directFile.arrayBuffer());
+    if (directFile && typeof directFile === "object" && typeof (directFile as any).arrayBuffer === "function") {
+      try {
+        return new Uint8Array(await (directFile as any).arrayBuffer());
+      } catch {
+        // ignore
+      }
+    }
+
+    // 遍历所有键，兼容不同客户端的自定义字段名
+    for (const val of Object.values(body)) {
+      if (val && typeof val === "object" && typeof (val as any).arrayBuffer === "function") {
+        try {
+          return new Uint8Array(await (val as any).arrayBuffer());
+        } catch {
+          // ignore
+        }
+      }
     }
   }
 
+  // 3. 若流未被 Elysia 消费，直接从 request 读取，添加异常保护，移除 clone
   const contentType = request.headers.get("content-type") || "";
   if (contentType.includes("multipart/form-data")) {
-    const form = await request.clone().formData();
-    const file = form.get("file");
-    if (file instanceof File) {
-      return new Uint8Array(await file.arrayBuffer());
+    try {
+      const form = await request.formData();
+      const file = form.get("file");
+      if (file && typeof file === "object" && typeof (file as any).arrayBuffer === "function") {
+        return new Uint8Array(await (file as any).arrayBuffer());
+      }
+    } catch {
+      // ignore
     }
   }
 
-  return new Uint8Array(await request.clone().arrayBuffer());
+  // 4. 最后回退：尝试直接读取 request 二进制，添加异常保护
+  try {
+    return new Uint8Array(await request.arrayBuffer());
+  } catch {
+    // ignore
+  }
+
+  return new Uint8Array(0);
 }
 
 export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" })

--- a/packages/management-api/tests/unit/frontend.routes.test.ts
+++ b/packages/management-api/tests/unit/frontend.routes.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+import { frontendRoutes } from "../../src/routes/frontend";
+import { frontendService } from "../../src/services/frontend.service";
+import { rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+describe("Frontend deployment upload routes", () => {
+  let app: Elysia;
+  let testZipBytes: Uint8Array;
+  let tempZipPath: string;
+
+  beforeAll(async () => {
+    app = new Elysia().use(frontendRoutes);
+
+    // 动态生成一个合法但极小的 zip 二进制，用于完整的 unzip 验证测试
+    const tempDir = path.join(tmpdir(), "supacloud-test-zip-");
+    const testFile = path.join(tempDir, "index.html");
+    tempZipPath = path.join(tempDir, "test.zip");
+
+    await Bun.$`mkdir -p ${tempDir}`;
+    await writeFile(testFile, "<h1>Hello</h1>");
+    await Bun.$`cd ${tempDir} && zip -q test.zip index.html`;
+
+    testZipBytes = new Uint8Array(await Bun.file(tempZipPath).arrayBuffer());
+
+    // 清理临时目录
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    // Mock getDeployment 保证存在该部署
+    spyOn(frontendService, "getDeployment").mockImplementation(async (ref, id) => {
+      return {
+        id,
+        project_ref: ref,
+        name: "test-site",
+        framework: "static",
+        domain: "test.example.com",
+        custom_domains: [],
+        status: "pending",
+      } as any;
+    });
+
+    // Mock deployFromSource 避免启动真实的构建发布逻辑
+    spyOn(frontendService, "deployFromSource").mockImplementation(async (ref, id, sourceDir) => {
+      return {
+        success: true,
+        deployment_id: id,
+        url: "https://test.example.com",
+        build_log: "Success mock",
+        message: "Deployed successfully",
+      };
+    });
+  });
+
+  test("supports direct raw binary uploads (application/zip)", async () => {
+    const req = new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/deploy/upload",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Length": String(testZipBytes.byteLength),
+        },
+        body: testZipBytes,
+      }
+    );
+
+    const res = await app.handle(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.deployment_id).toBe("dep123");
+  });
+
+  test("supports multipart/form-data upload when parsed by Elysia (mocked body.file)", async () => {
+    // 模拟 Elysia 已经内置解析为 body: { file: Blob } 的对象形式
+    const mockFile = new Blob([testZipBytes], { type: "application/zip" });
+
+    // 我们直接发起带有 Form 数据的请求，Elysia 默认应该解析它
+    const form = new FormData();
+    form.append("file", mockFile, "upload.zip");
+
+    const req = new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/deploy/upload",
+      {
+        method: "POST",
+        body: form,
+      }
+    );
+
+    const res = await app.handle(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+  });
+
+  test("gracefully handles invalid zip archive upload", async () => {
+    const invalidBytes = new Uint8Array([1, 2, 3, 4, 5]);
+    const req = new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/deploy/upload",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/zip",
+        },
+        body: invalidBytes,
+      }
+    );
+
+    const res = await app.handle(req);
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.success).toBe(false);
+    expect(data.message).toBe("Invalid zip archive");
+  });
+});


### PR DESCRIPTION
Resolves the empty_stream connection reset and 500 crashes during frontend zip upload by cleaning up request.clone() and using duck-typing for arrayBuffer.