### PR TITLE
fix(edge-runtime): raise request body limit to 30MB

### DIFF
--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -24,6 +24,81 @@ async function waitForFile(path: string, timeoutMs = 2_000): Promise<string> {
   throw new Error(`Timed out waiting for ${path}`);
 }
 
+describe("WorkerPool request body size limit", () => {
+  const maxBodySize = 30 * 1024 * 1024;
+
+  test("rejects declared request bodies above 30MB", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-body-limit-header-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch() {
+          return new Response("should-not-run", { status: 200 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "test_body_limit_header",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/test", {
+          method: "POST",
+          headers: { "content-length": String(maxBodySize + 1) },
+          body: new Uint8Array([1]),
+        }),
+      });
+
+      expect(response.status).toBe(413);
+      expect(await response.json()).toEqual({
+        error: "Request body too large (max 30MB)",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects actual request bodies above 30MB", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-body-limit-actual-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch() {
+          return new Response("should-not-run", { status: 200 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "test_body_limit_actual",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/test", {
+          method: "POST",
+          body: new Uint8Array(maxBodySize + 1),
+        }),
+      });
+
+      expect(response.status).toBe(413);
+      expect(await response.json()).toEqual({
+        error: "Request body too large (max 30MB)",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("WorkerPool EdgeRuntime.waitUntil", () => {
   test("keeps tenant env available after the HTTP response is returned", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-waituntil-"));

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -19,7 +19,7 @@ interface DispatchOptions {
   }) => void;
 }
 
-const MAX_BODY_SIZE = 10 * 1024 * 1024;
+const MAX_BODY_SIZE = 30 * 1024 * 1024;
 const MAX_QUEUE_SIZE = Number(process.env.MAX_QUEUE_SIZE) || 200;
 const WORKER_SMOL = process.env.WORKER_SMOL !== "false";
 const WAIT_UNTIL_TIMEOUT_MS = Number(process.env.EDGE_WAIT_UNTIL_TIMEOUT_MS) || 300_000;


### PR DESCRIPTION
## Summary
- Raise Edge Runtime request body limit from 10MB to 30MB.
- Reject both declared Content-Length and actual request bodies above the new limit.
- Add regression coverage for both rejection paths.

## Context
This was exposed by a production Seagoo report-export flow where a valid FormData payload was rejected by the Edge Runtime before the application function could handle it: `Request body too large (max 10MB)`.

This PR only addresses the SupaCloud platform limit. The Operation Card min/max and tan-delta mismatches are business rule/evidence/validation issues in seagoo-ai, not SupaCloud platform bugs.

## Validation
- `bun test worker-pool.test.ts -t "request body size limit"` from `packages/edge-runtime`: 2 pass
- `bun run --cwd packages/edge-runtime typecheck`: pass
- `git diff --check -- packages/edge-runtime/worker-pool.ts packages/edge-runtime/worker-pool.test.ts`: pass

Note: running the whole `worker-pool.test.ts` file from `packages/edge-runtime` currently leaves the existing TLS policy handoff test failing locally with `Bun.serve({ port: 0 })` / `EADDRINUSE`; the new body-limit tests pass.
