### PR TITLE
fix(auth): sign GoTrue admin tokens with project JWKS

### DIFF
--- a/packages/management-api/src/utils/service-role.ts
+++ b/packages/management-api/src/utils/service-role.ts
@@ -1,11 +1,42 @@
+import { signOidcServiceRoleJwt } from "./project-jwt";
+import { normalizeProjectConfig } from "./project-config";
+
+function resolveOauthServerConfig(config: unknown): Record<string, unknown> {
+  const projectConfig = normalizeProjectConfig(config);
+  const auth = projectConfig.auth && typeof projectConfig.auth === "object"
+    ? projectConfig.auth as Record<string, unknown>
+    : {};
+  const oauthServer = auth.oauth_server && typeof auth.oauth_server === "object"
+    ? auth.oauth_server as Record<string, unknown>
+    : {};
+  return oauthServer;
+}
+
+function resolveOauthIssuer(ref: string | undefined, oauthServer: Record<string, unknown>): string {
+  if (typeof oauthServer.issuer === "string" && oauthServer.issuer.trim()) {
+    return oauthServer.issuer.replace(/\/+$/, "");
+  }
+  return ref ? `supacloud-${ref}` : "supacloud";
+}
+
 export async function resolveProjectServiceRoleKey(projectOrRef: string | {
   ref?: string | null;
   service_role_key?: string | null;
   jwt_secret?: string | null;
+  config?: unknown;
 }): Promise<string | null> {
   const project = typeof projectOrRef === "string"
     ? await loadProjectSecrets(projectOrRef)
     : projectOrRef;
+
+  const oauthServer = resolveOauthServerConfig(project?.config);
+  const oidcServiceRoleKey = await signOidcServiceRoleJwt(
+    oauthServer.jwt_keys,
+    resolveOauthIssuer(project?.ref ?? (typeof projectOrRef === "string" ? projectOrRef : undefined), oauthServer),
+  );
+  if (oidcServiceRoleKey) {
+    return oidcServiceRoleKey;
+  }
 
   if (project?.service_role_key) {
     return project.service_role_key;
@@ -20,12 +51,14 @@ export async function resolveProjectServiceRoleKey(projectOrRef: string | {
 }
 
 async function loadProjectSecrets(ref: string): Promise<{
+  ref?: string | null;
   service_role_key?: string | null;
   jwt_secret?: string | null;
+  config?: unknown;
 } | null> {
   const { sql } = await import("../db");
   const rows = await sql`
-    SELECT service_role_key, jwt_secret
+    SELECT ref, service_role_key, jwt_secret, config
     FROM projects
     WHERE ref = ${ref} AND deleted_at IS NULL
     LIMIT 1

--- a/packages/management-api/tests/unit/service-role.test.ts
+++ b/packages/management-api/tests/unit/service-role.test.ts
@@ -1,8 +1,34 @@
 import { describe, expect, test } from "bun:test";
 import { resolveProjectServiceRoleKey } from "../../src/utils/service-role";
+import { generateOidcJwtKeyMaterial } from "../../src/utils/project-jwt";
 
 describe("service-role utils", () => {
-  test("prefers the stored canonical service_role_key", async () => {
+  test("signs an ES256 service_role key from migrated OAuth server material", async () => {
+    const keyMaterial = await generateOidcJwtKeyMaterial("legacy-jwt-secret");
+    const key = await resolveProjectServiceRoleKey({
+      ref: "proj_1",
+      service_role_key: "stored-hs256-key",
+      jwt_secret: "legacy-jwt-secret",
+      config: {
+        auth: {
+          oauth_server: {
+            issuer: "https://auth.example.com/auth/v1",
+            jwt_keys: keyMaterial.jwt_keys,
+          },
+        },
+      },
+    });
+
+    expect(key).toBeTruthy();
+    expect(key).not.toBe("stored-hs256-key");
+    const [header, payload] = String(key).split(".").slice(0, 2).map((part) => JSON.parse(Buffer.from(part, "base64url").toString("utf8")));
+    expect(header.alg).toBe("ES256");
+    expect(header.kid).toBe(keyMaterial.key_id);
+    expect(payload.iss).toBe("https://auth.example.com/auth/v1");
+    expect(payload.role).toBe("service_role");
+  });
+
+  test("prefers the stored canonical service_role_key when no OIDC signing key exists", async () => {
     await expect(
       resolveProjectServiceRoleKey({
         service_role_key: "stored-key",


### PR DESCRIPTION
## Summary
- use migrated project OAuth signing material to mint short-lived ES256 service_role JWTs for GoTrue admin proxies
- fall back to the stored service_role key or jwt_secret-generated key when no migrated JWKS exists
- cover the migrated ES256 path in service-role unit tests

## Root cause
Projects migrated to ES256 GoTrue signing keys can reject the legacy stored HS256 service_role key with `signing method HS256 is invalid`. Management API auth user proxies were still using that stored key for `/admin/users`, so SupAuth account provisioning could not create or update users through SupaCloud after the auth runtime migration.

## Verification
- `bun test packages/management-api/tests/unit/service-role.test.ts`
- `bun test packages/management-api/tests/unit/auth-oauth-server.test.ts packages/management-api/tests/unit/runtime-env.service.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `git diff --check`