### PR TITLE
ci: run management unit tests serially

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -174,7 +174,11 @@ jobs:
         run: |
           bun test tests/unit/sdk-proxy.functions.test.ts
           bun test tests/unit/gateway.service.test.ts
-          bun test $(find tests/unit -name "*.test.ts" ! -name "sdk-proxy.functions.test.ts" ! -name "gateway.service.test.ts" | sort)
+          find tests/unit -name "*.test.ts" ! -name "sdk-proxy.functions.test.ts" ! -name "gateway.service.test.ts" | sort | while read -r test_file; do
+            echo "::group::$test_file"
+            bun test "$test_file"
+            echo "::endgroup::"
+          done
 
   integration-test:
     name: Integration & Compliance Tests


### PR DESCRIPTION
## Summary
- run remaining management-api unit tests one file at a time in CI
- keep the dedicated sdk-proxy and gateway test steps unchanged
- add GitHub log groups per unit file for easier diagnosis

## Why
Main CI failed after PR #307 with Bun reporting missing named exports from existing modules such as RouterService, DatabaseService, and renderGoTrueAuthEnv. Those exports exist and the same commit passes locally. Running the files serially avoids the Bun 1.3.14 GitHub runner ESM import race while preserving coverage.

## Verification
- local serial CI unit command in packages/management-api
- git diff --check