### PR TITLE
fix(auth-wechat): 微信登录成功响应格式与 supabase-mp-js signInWithWechat 不兼容

### DIFF
--- a/packages/management-api/src/routes/auth-wechat.ts
+++ b/packages/management-api/src/routes/auth-wechat.ts
@@ -311,7 +311,7 @@ Deno.serve(async (req) => {
     // Refetch the user to bundle the completed identity payload within the first session
     const { data: finalUser } = await supabaseAdmin.auth.admin.getUserById(sessionData.user.id)
     const finalSession = finalUser?.user ? { ...sessionData.session, user: finalUser.user } : sessionData.session
-    const responseUser = finalUser?.user ?? sessionData.user ?? null
+    const responseUser = finalSession.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
     if (session_key) (finalSession as any).provider_token = session_key;
 
@@ -432,7 +432,7 @@ Deno.serve(async (req) => {
     // Refetch the user to bundle the completed identity payload within the first session
     const { data: finalUser } = await supabaseAdmin.auth.admin.getUserById(sessionData.user.id)
     const finalSession = finalUser?.user ? { ...sessionData.session, user: finalUser.user } : sessionData.session
-    const responseUser = finalUser?.user ?? sessionData.user ?? null
+    const responseUser = finalSession.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
     if (tokenData.access_token) (finalSession as any).provider_token = tokenData.access_token;
     if (tokenData.refresh_token) (finalSession as any).provider_refresh_token = tokenData.refresh_token;
@@ -445,3 +445,8 @@ Deno.serve(async (req) => {
   }
 })`;
 }
+
+export const wechatAuthInternals = {
+  generateWeChatMiniProgramLoginFunction,
+  generateWeChatMPLoginFunction,
+};

--- a/packages/management-api/src/routes/auth-wechat.ts
+++ b/packages/management-api/src/routes/auth-wechat.ts
@@ -314,7 +314,9 @@ Deno.serve(async (req) => {
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
     if (session_key) (finalSession as any).provider_token = session_key;
 
-    return new Response(JSON.stringify(finalSession), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
+    // 包裹在 { data: { session, user } } 中，符合 supabase-mp-js 的 signInWithWechat 契约
+    // signInWithWechat 从 responseData.data.session 和 responseData.data.user 解构 session/user
+    return new Response(JSON.stringify({ data: { session: finalSession, user: (finalSession as any).user } }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
   } catch (error: unknown) {
     console.error("WeChat MiniProgram Login Error:", error instanceof Error ? error.message : String(error))
     return new Response(JSON.stringify({ data: { session: null, user: null }, error: (error instanceof Error ? error.message : String(error)) }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" }, status: 400 })
@@ -433,7 +435,8 @@ Deno.serve(async (req) => {
     if (tokenData.access_token) (finalSession as any).provider_token = tokenData.access_token;
     if (tokenData.refresh_token) (finalSession as any).provider_refresh_token = tokenData.refresh_token;
 
-    return new Response(JSON.stringify(finalSession), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
+    // 包裹在 { data: { session, user } } 中，符合 supabase-mp-js 的 signInWithWechat 契约
+    return new Response(JSON.stringify({ data: { session: finalSession, user: (finalSession as any).user } }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
   } catch (error: unknown) {
     console.error("WeChat MP Login Error:", error instanceof Error ? error.message : String(error))
     return new Response(JSON.stringify({ data: { session: null, user: null }, error: (error instanceof Error ? error.message : String(error)) }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" }, status: 400 })

--- a/packages/management-api/src/routes/auth-wechat.ts
+++ b/packages/management-api/src/routes/auth-wechat.ts
@@ -311,10 +311,13 @@ Deno.serve(async (req) => {
     // Refetch the user to bundle the completed identity payload within the first session
     const { data: finalUser } = await supabaseAdmin.auth.admin.getUserById(sessionData.user.id)
     const finalSession = finalUser?.user ? { ...sessionData.session, user: finalUser.user } : sessionData.session
+    const responseUser = finalUser?.user ?? sessionData.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
     if (session_key) (finalSession as any).provider_token = session_key;
 
-    return new Response(JSON.stringify(finalSession), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
+    // 包裹在 { data: { session, user } } 中，符合 supabase-mp-js 的 signInWithWechat 契约
+    // signInWithWechat 从 responseData.data.session 和 responseData.data.user 解构 session/user
+    return new Response(JSON.stringify({ data: { session: finalSession, user: responseUser } }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
   } catch (error: unknown) {
     console.error("WeChat MiniProgram Login Error:", error instanceof Error ? error.message : String(error))
     return new Response(JSON.stringify({ data: { session: null, user: null }, error: (error instanceof Error ? error.message : String(error)) }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" }, status: 400 })
@@ -429,11 +432,13 @@ Deno.serve(async (req) => {
     // Refetch the user to bundle the completed identity payload within the first session
     const { data: finalUser } = await supabaseAdmin.auth.admin.getUserById(sessionData.user.id)
     const finalSession = finalUser?.user ? { ...sessionData.session, user: finalUser.user } : sessionData.session
+    const responseUser = finalUser?.user ?? sessionData.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
     if (tokenData.access_token) (finalSession as any).provider_token = tokenData.access_token;
     if (tokenData.refresh_token) (finalSession as any).provider_refresh_token = tokenData.refresh_token;
 
-    return new Response(JSON.stringify(finalSession), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
+    // 包裹在 { data: { session, user } } 中，符合 supabase-mp-js 的 signInWithWechat 契约
+    return new Response(JSON.stringify({ data: { session: finalSession, user: responseUser } }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
   } catch (error: unknown) {
     console.error("WeChat MP Login Error:", error instanceof Error ? error.message : String(error))
     return new Response(JSON.stringify({ data: { session: null, user: null }, error: (error instanceof Error ? error.message : String(error)) }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" }, status: 400 })

--- a/packages/management-api/tests/unit/auth-wechat.test.ts
+++ b/packages/management-api/tests/unit/auth-wechat.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { wechatAuthInternals } from "../../src/routes/auth-wechat";
+
+function expectWechatLoginResponseContract(functionCode: string) {
+  expect(functionCode).toContain("const responseUser = finalSession.user ?? null");
+  expect(functionCode).toContain("JSON.stringify({ data: { session: finalSession, user: responseUser } })");
+  expect(functionCode).toContain("JSON.stringify({ data: { session: null, user: null }, error:");
+  expect(functionCode).not.toContain("(finalSession as any).user");
+}
+
+describe("wechat auth edge function generators", () => {
+  test("mini program login success response matches supabase-mp-js contract", () => {
+    const functionCode = wechatAuthInternals.generateWeChatMiniProgramLoginFunction("app-id", "secret");
+
+    expectWechatLoginResponseContract(functionCode);
+  });
+
+  test("official account login success response matches supabase-mp-js contract", () => {
+    const functionCode = wechatAuthInternals.generateWeChatMPLoginFunction("app-id", "secret", "https://example.com/callback");
+
+    expectWechatLoginResponseContract(functionCode);
+  });
+});


### PR DESCRIPTION
## 问题

SupaCloud 自动部署的 `wechat-login`（小程序）和 `wechat-mp-login`（公众号）Edge Function 的**成功路径**返回格式与 `supabase-mp-js` 的 `signInWithWechat` 客户端契约不兼容，导致微信登录后 session 始终为 null，RLS 行级安全策略完全失效。

## 根因

`signInWithWechat` 从响应体的 `data` 属性解构 session 和 user（[源码](https://github.com/zuohuadong/supabase-mp-js/blob/main/packages/supabase-mp-js/src/lib/SupabaseAuthClient.ts)）：

```typescript
const responseData = await res.json() as WechatLoginResponse
// responseData.data.session, responseData.data.user
const { session = null, user = null } = responseData.data || {}
if (session) {
  await this._saveSession(session)  // 持久化 session 到 wx.storage
}
```

但 Edge Function 的成功路径直接返回 session 对象本身：

```typescript
// 修复前 — 成功路径
return new Response(JSON.stringify(finalSession), { ... })
```

由于缺少 `{ data: { session, user } }` 包裹层，`responseData.data` 为 `undefined`，session 永远为 `null`。

**错误路径**已经是正确的格式：
```typescript
return new Response(JSON.stringify({ data: { session: null, user: null }, error: ... }), ...)
```

成功路径与错误路径格式不一致。

## 影响

1. `_saveSession()` 从不执行，session 无法持久化到 `wx.storage`
2. `getSession()` 始终返回 `{ session: null }`
3. `fetchWithAuth` 回退到 anon key，`Authorization: Bearer <anon-key>`
4. **所有 RLS 策略中的 `auth.uid()` 永远为 NULL**，行级安全策略形同虚设
5. `private_maps` 等用户私有数据的 RLS 对所有人失效

## 修复

成功路径包裹在 `{ data: { session, user } }` 中，与错误路径和 `supabase-mp-js` 的 `WechatLoginResponse` 类型契约保持一致：

```typescript
// 修复后 — 成功路径
return new Response(
  JSON.stringify({ data: { session: finalSession, user: finalSession.user } }),
  { ... }
)
```

## 验证

- `tsc --noEmit` 编译通过（0 errors）
- 修改仅影响响应序列化，不改变 session 生成逻辑

## 影响范围

- `generateWeChatMiniProgramLoginFunction()` — 小程序登录（`wechat-login` slug）
- `generateWeChatMPLoginFunction()` — 公众号登录（`wechat-mp-login` slug）

两处成功路径均已修复。