### PR TITLE
feat(management-api): add project RBAC facade

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -602,6 +602,7 @@ export async function registerAllRoutes() {
     pgMetaRoutes,
     storageS3Routes,
     autoBranchingRoutes,
+    projectRbacRoutes,
   } = await import("./routes");
 
   return (
@@ -697,6 +698,7 @@ export async function registerAllRoutes() {
       .use(pgMetaRoutes)
       .use(storageS3Routes)
       .use(autoBranchingRoutes)
+      .use(projectRbacRoutes)
   );
 }
 

--- a/packages/management-api/src/routes/index.ts
+++ b/packages/management-api/src/routes/index.ts
@@ -38,3 +38,4 @@ export { branchRoutes } from "./branches";
 export { pgMetaRoutes } from "./pg-meta";
 export { storageS3Routes } from "./storage-s3";
 export { autoBranchingRoutes } from "./auto-branching";
+export { projectRbacRoutes } from "./project-rbac";

--- a/packages/management-api/src/routes/project-rbac.ts
+++ b/packages/management-api/src/routes/project-rbac.ts
@@ -1,0 +1,167 @@
+import { Elysia, status, t } from "elysia";
+import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { projectRbacService } from "../services/project-rbac.service";
+
+function toHttpError(error: unknown) {
+  const record = error && typeof error === "object" ? error as Record<string, unknown> : {};
+  const statusCode = typeof record.statusCode === "number" ? record.statusCode : 500;
+  const message = error instanceof Error ? error.message : "RBAC request failed";
+  return status(statusCode, { message, code: String(statusCode) });
+}
+
+export const projectRbacRoutes = new Elysia({ prefix: "/v1/projects/:ref" })
+  .onBeforeHandle(async ({ params, request }) => {
+    const authError = await requireProjectOrAdminAuth(request, params.ref);
+    if (authError) return status(authError.status, authError.body);
+  })
+  .get("/rbac/roles", async ({ params }) => {
+    try {
+      const roles = await projectRbacService.listRoles(params.ref);
+      return { items: roles, total: roles.length };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "List project RBAC roles" },
+  })
+  .post("/rbac/roles", async ({ params, body }) => {
+    try {
+      return await projectRbacService.createRole(params.ref, body);
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    body: t.Object({
+      name: t.String(),
+      description: t.Optional(t.Nullable(t.String())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["rbac"], summary: "Create project RBAC role" },
+  })
+  .get("/rbac/roles/:roleId", async ({ params }) => {
+    try {
+      return await projectRbacService.getRole(params.ref, params.roleId);
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "Get project RBAC role" },
+  })
+  .put("/rbac/roles/:roleId", async ({ params, body }) => {
+    try {
+      return await projectRbacService.updateRole(params.ref, params.roleId, body);
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    body: t.Object({
+      name: t.Optional(t.String()),
+      description: t.Optional(t.Nullable(t.String())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["rbac"], summary: "Update project RBAC role" },
+  })
+  .delete("/rbac/roles/:roleId", async ({ params }) => {
+    try {
+      await projectRbacService.deleteRole(params.ref, params.roleId);
+      return { deleted: true, role_id: params.roleId };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "Delete project RBAC role" },
+  })
+  .get("/rbac/roles/:roleId/permissions", async ({ params }) => {
+    try {
+      const permissions = await projectRbacService.listRolePermissions(params.ref, params.roleId);
+      return { items: permissions, total: permissions.length };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "List project RBAC role permissions" },
+  })
+  .post("/rbac/roles/:roleId/permissions", async ({ params, body }) => {
+    try {
+      return await projectRbacService.createPermission(params.ref, params.roleId, body);
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    body: t.Object({
+      name: t.String(),
+      description: t.Optional(t.Nullable(t.String())),
+      resource_id: t.Optional(t.Nullable(t.String())),
+      resourceId: t.Optional(t.Nullable(t.String())),
+      scope_id: t.Optional(t.Nullable(t.String())),
+      scopeId: t.Optional(t.Nullable(t.String())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["rbac"], summary: "Create project RBAC permission" },
+  })
+  .delete("/rbac/roles/:roleId/permissions/:permissionId", async ({ params }) => {
+    try {
+      await projectRbacService.deletePermission(params.ref, params.roleId, params.permissionId);
+      return { deleted: true, permission_id: params.permissionId };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "Delete project RBAC permission" },
+  })
+  .post("/rbac/roles/:roleId/assign", async ({ params, body }) => {
+    try {
+      return await projectRbacService.assignRole(params.ref, params.roleId, body);
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    body: t.Object({
+      user_id: t.Optional(t.Nullable(t.String())),
+      userId: t.Optional(t.Nullable(t.String())),
+      organization_id: t.Optional(t.Nullable(t.String())),
+      organizationId: t.Optional(t.Nullable(t.String())),
+      application_id: t.Optional(t.Nullable(t.String())),
+      applicationId: t.Optional(t.Nullable(t.String())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["rbac"], summary: "Assign project RBAC role" },
+  })
+  .delete("/rbac/roles/:roleId/assign/:assignmentId", async ({ params }) => {
+    try {
+      await projectRbacService.revokeRole(params.ref, params.roleId, params.assignmentId);
+      return { deleted: true, assignment_id: params.assignmentId };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "Revoke project RBAC role assignment" },
+  })
+  .get("/auth/users/:id/roles", async ({ params }) => {
+    try {
+      const assignments = await projectRbacService.listUserRoleAssignments(params.ref, params.id);
+      return { items: assignments, total: assignments.length };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "List project RBAC roles assigned to a user" },
+  })
+  .get("/auth/users/:id/permissions", async ({ params, query }) => {
+    try {
+      return await projectRbacService.resolveUserPermissions(params.ref, params.id, query.org_id);
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    query: t.Object({
+      org_id: t.Optional(t.String()),
+    }, { additionalProperties: true }),
+    detail: { tags: ["rbac"], summary: "Resolve project RBAC permissions for a user" },
+  })
+  .get("/organizations/:orgId/roles", async ({ params }) => {
+    try {
+      const assignments = await projectRbacService.listOrganizationRoleAssignments(params.ref, params.orgId);
+      return { items: assignments, total: assignments.length };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "List project RBAC assignments for an organization" },
+  });

--- a/packages/management-api/src/services/project-rbac.service.ts
+++ b/packages/management-api/src/services/project-rbac.service.ts
@@ -1,0 +1,497 @@
+import type { Project } from "../db";
+import { projectRepository } from "../repositories/project.repository";
+import { config } from "../config";
+import { resolveProjectServiceRoleKey } from "../utils/service-role";
+import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-config";
+import { normalizeProjectRoutingConfig, resolveTenantPorts } from "../utils/project-routing";
+
+export interface ProjectRbacPermission {
+  id: string;
+  name: string;
+  description?: string | null;
+  resource_id?: string | null;
+  scope_id?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectRbacRole {
+  id: string;
+  name: string;
+  description?: string | null;
+  permissions: ProjectRbacPermission[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProjectRbacAssignment {
+  id: string;
+  role_id: string;
+  user_id?: string | null;
+  organization_id?: string | null;
+  application_id?: string | null;
+  created_at: string;
+}
+
+export interface ProjectRbacConfig {
+  roles: ProjectRbacRole[];
+  assignments: ProjectRbacAssignment[];
+  version: number;
+  updated_at?: string;
+}
+
+export interface ProjectRbacUserPermissions {
+  roles: string[];
+  permissions: string[];
+  scopes: string[];
+}
+
+export interface AssignRoleInput {
+  user_id?: string | null;
+  userId?: string | null;
+  organization_id?: string | null;
+  organizationId?: string | null;
+  application_id?: string | null;
+  applicationId?: string | null;
+}
+
+type RoleUpdateInput = {
+  name?: string;
+  description?: string | null;
+};
+
+type PermissionInput = {
+  name?: string;
+  description?: string | null;
+  resource_id?: string | null;
+  resourceId?: string | null;
+  scope_id?: string | null;
+  scopeId?: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function makeId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+function normalizePermission(value: unknown): ProjectRbacPermission | null {
+  if (!isRecord(value)) return null;
+  const id = optionalString(value.id);
+  const name = optionalString(value.name);
+  if (!id || !name) return null;
+  const createdAt = optionalString(value.created_at) ?? nowIso();
+  const updatedAt = optionalString(value.updated_at) ?? createdAt;
+  return {
+    id,
+    name,
+    description: optionalString(value.description) ?? null,
+    resource_id: optionalString(value.resource_id) ?? optionalString(value.resourceId) ?? null,
+    scope_id: optionalString(value.scope_id) ?? optionalString(value.scopeId) ?? null,
+    created_at: createdAt,
+    updated_at: updatedAt,
+  };
+}
+
+function normalizeRole(value: unknown): ProjectRbacRole | null {
+  if (!isRecord(value)) return null;
+  const id = optionalString(value.id);
+  const name = optionalString(value.name);
+  if (!id || !name) return null;
+  const createdAt = optionalString(value.created_at) ?? nowIso();
+  const updatedAt = optionalString(value.updated_at) ?? createdAt;
+  const permissions = Array.isArray(value.permissions)
+    ? value.permissions.map(normalizePermission).filter((item): item is ProjectRbacPermission => item !== null)
+    : [];
+  return {
+    id,
+    name,
+    description: optionalString(value.description) ?? null,
+    permissions,
+    created_at: createdAt,
+    updated_at: updatedAt,
+  };
+}
+
+function normalizeAssignment(value: unknown): ProjectRbacAssignment | null {
+  if (!isRecord(value)) return null;
+  const id = optionalString(value.id);
+  const roleId = optionalString(value.role_id) ?? optionalString(value.roleId);
+  if (!id || !roleId) return null;
+  const userId = optionalString(value.user_id) ?? optionalString(value.userId) ?? null;
+  const applicationId = optionalString(value.application_id) ?? optionalString(value.applicationId) ?? null;
+  if (!userId && !applicationId) return null;
+  return {
+    id,
+    role_id: roleId,
+    user_id: userId,
+    organization_id: optionalString(value.organization_id) ?? optionalString(value.organizationId) ?? null,
+    application_id: applicationId,
+    created_at: optionalString(value.created_at) ?? nowIso(),
+  };
+}
+
+function readRbacConfig(projectConfig: unknown): ProjectRbacConfig {
+  const config = normalizeProjectConfig(projectConfig);
+  const raw = isRecord(config.rbac) ? config.rbac : {};
+  const roles = Array.isArray(raw.roles)
+    ? raw.roles.map(normalizeRole).filter((item): item is ProjectRbacRole => item !== null)
+    : [];
+  const roleIds = new Set(roles.map((role) => role.id));
+  const assignments = Array.isArray(raw.assignments)
+    ? raw.assignments
+      .map(normalizeAssignment)
+      .filter((item): item is ProjectRbacAssignment => item !== null && roleIds.has(item.role_id))
+    : [];
+  const version = Number(raw.version);
+  return {
+    roles,
+    assignments,
+    version: Number.isFinite(version) && version > 0 ? Math.trunc(version) : 0,
+    updated_at: optionalString(raw.updated_at) ?? undefined,
+  };
+}
+
+function uniqueSorted(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))].sort();
+}
+
+function getRoleOrThrow(rbac: ProjectRbacConfig, roleId: string): ProjectRbacRole {
+  const role = rbac.roles.find((item) => item.id === roleId);
+  if (!role) throw Object.assign(new Error("Role not found"), { statusCode: 404 });
+  return role;
+}
+
+function assignmentMatchesUser(assignment: ProjectRbacAssignment, userId: string, orgId?: string | null): boolean {
+  if (assignment.user_id !== userId) return false;
+  if (orgId && assignment.organization_id && assignment.organization_id !== orgId) return false;
+  return true;
+}
+
+function resolvePermissionsFromConfig(
+  rbac: ProjectRbacConfig,
+  userId: string,
+  orgId?: string | null,
+): ProjectRbacUserPermissions {
+  const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
+  const assignments = rbac.assignments.filter((assignment) => assignmentMatchesUser(assignment, userId, orgId));
+  const roles = assignments
+    .map((assignment) => rolesById.get(assignment.role_id)?.name)
+    .filter((value): value is string => Boolean(value));
+  const permissions = assignments.flatMap((assignment) => rolesById.get(assignment.role_id)?.permissions ?? []);
+
+  return {
+    roles: uniqueSorted(roles),
+    permissions: uniqueSorted(permissions.map((permission) => permission.name)),
+    scopes: uniqueSorted(permissions.map((permission) => permission.scope_id)),
+  };
+}
+
+function withNextVersion(rbac: ProjectRbacConfig): ProjectRbacConfig {
+  return {
+    ...rbac,
+    version: rbac.version + 1,
+    updated_at: nowIso(),
+  };
+}
+
+async function saveRbacConfig(ref: string, currentProjectConfig: unknown, rbac: ProjectRbacConfig): Promise<ProjectRbacConfig> {
+  const next = withNextVersion(rbac);
+  const updated = await projectRepository.updateConfig(
+    ref,
+    mergeProjectConfig(currentProjectConfig, { rbac: next }),
+  );
+  if (!updated) throw Object.assign(new Error("Project not found"), { statusCode: 404 });
+  return readRbacConfig(updated.config);
+}
+
+async function getProjectOrThrow(ref: string): Promise<Project> {
+  const project = await projectRepository.findByRef(ref);
+  if (!project) throw Object.assign(new Error("Project not found"), { statusCode: 404 });
+  return project;
+}
+
+async function getGoTrueAdminContext(ref: string) {
+  const project = await projectRepository.findByRef(ref);
+  if (!project) return null;
+
+  const serviceRoleKey = await resolveProjectServiceRoleKey(project);
+  if (!serviceRoleKey) return null;
+
+  const projectConfig = normalizeProjectConfig(project.config);
+  const ports = resolveTenantPorts(normalizeProjectRoutingConfig(projectConfig));
+  const apiUrl = ports?.gotruePort
+    ? `http://127.0.0.1:${ports.gotruePort}`
+    : `http://${config.managementApiInternal}/auth/v1`;
+  return { apiUrl, serviceRoleKey };
+}
+
+async function gotrueFetch(url: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Auth service unavailable: ${message}`);
+  }
+}
+
+async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacConfig): Promise<void> {
+  const ctx = await getGoTrueAdminContext(ref);
+  if (!ctx) throw Object.assign(new Error("Project service role key not found"), { statusCode: 404 });
+
+  const headers = {
+    apikey: ctx.serviceRoleKey,
+    Authorization: `Bearer ${ctx.serviceRoleKey}`,
+    "x-project-ref": ref,
+  };
+  const userRes = await gotrueFetch(`${ctx.apiUrl}/admin/users/${encodeURIComponent(userId)}`, { headers });
+  if (!userRes.ok) {
+    throw Object.assign(new Error("Failed to fetch user for RBAC metadata sync"), { statusCode: userRes.status });
+  }
+
+  const user = await userRes.json() as Record<string, unknown>;
+  const appMetadata = isRecord(user.app_metadata) ? user.app_metadata : {};
+  const existingSupauth = isRecord(appMetadata.supaoauth) ? appMetadata.supaoauth : {};
+  const resolved = resolvePermissionsFromConfig(rbac, userId);
+  const orgIds = uniqueSorted(rbac.assignments
+    .filter((assignment) => assignment.user_id === userId)
+    .map((assignment) => assignment.organization_id));
+  const existingCurrentOrgId = typeof existingSupauth.current_org_id === "string"
+    ? existingSupauth.current_org_id
+    : undefined;
+  const currentOrgId = existingCurrentOrgId && orgIds.includes(existingCurrentOrgId)
+    ? existingCurrentOrgId
+    : orgIds.length === 1 ? orgIds[0] : undefined;
+
+  const patchRes = await gotrueFetch(`${ctx.apiUrl}/admin/users/${encodeURIComponent(userId)}`, {
+    method: "PATCH",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      app_metadata: {
+        ...appMetadata,
+        supaoauth: {
+          ...existingSupauth,
+          roles: resolved.roles,
+          permissions: resolved.permissions,
+          scopes: resolved.scopes,
+          organization_ids: orgIds,
+          current_org_id: currentOrgId,
+          rbac_version: rbac.version,
+          rbac_synced_at: nowIso(),
+        },
+      },
+    }),
+  });
+  if (!patchRes.ok) {
+    throw Object.assign(new Error("Failed to sync RBAC metadata to user"), { statusCode: patchRes.status });
+  }
+}
+
+async function syncUsersMetadata(ref: string, userIds: string[], rbac: ProjectRbacConfig): Promise<void> {
+  for (const userId of uniqueSorted(userIds)) {
+    await syncUserMetadata(ref, userId, rbac);
+  }
+}
+
+function affectedUserIds(assignments: ProjectRbacAssignment[]): string[] {
+  return uniqueSorted(assignments.map((assignment) => assignment.user_id));
+}
+
+export const projectRbacService = {
+  async listRoles(ref: string): Promise<ProjectRbacRole[]> {
+    const project = await getProjectOrThrow(ref);
+    return readRbacConfig(project.config).roles;
+  },
+
+  async createRole(ref: string, input: { name: string; description?: string | null }): Promise<ProjectRbacRole> {
+    const name = input.name.trim();
+    if (!name) throw Object.assign(new Error("name is required"), { statusCode: 400 });
+
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    if (rbac.roles.some((role) => role.name.toLowerCase() === name.toLowerCase())) {
+      throw Object.assign(new Error("Role name already exists"), { statusCode: 409 });
+    }
+
+    const timestamp = nowIso();
+    const role: ProjectRbacRole = {
+      id: makeId("role"),
+      name,
+      description: input.description ?? null,
+      permissions: [],
+      created_at: timestamp,
+      updated_at: timestamp,
+    };
+    const saved = await saveRbacConfig(ref, project.config, { ...rbac, roles: [...rbac.roles, role] });
+    return getRoleOrThrow(saved, role.id);
+  },
+
+  async getRole(ref: string, roleId: string): Promise<ProjectRbacRole> {
+    const project = await getProjectOrThrow(ref);
+    return getRoleOrThrow(readRbacConfig(project.config), roleId);
+  },
+
+  async updateRole(ref: string, roleId: string, input: RoleUpdateInput): Promise<ProjectRbacRole> {
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    const role = getRoleOrThrow(rbac, roleId);
+    const nextName = input.name?.trim() || role.name;
+    if (rbac.roles.some((item) => item.id !== roleId && item.name.toLowerCase() === nextName.toLowerCase())) {
+      throw Object.assign(new Error("Role name already exists"), { statusCode: 409 });
+    }
+    const roles = rbac.roles.map((item) => item.id === roleId
+      ? { ...item, name: nextName, description: input.description ?? item.description ?? null, updated_at: nowIso() }
+      : item);
+    const saved = await saveRbacConfig(ref, project.config, { ...rbac, roles });
+    const updated = getRoleOrThrow(saved, roleId);
+    await syncUsersMetadata(ref, affectedUserIds(saved.assignments.filter((assignment) => assignment.role_id === roleId)), saved);
+    return updated;
+  },
+
+  async deleteRole(ref: string, roleId: string): Promise<void> {
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    getRoleOrThrow(rbac, roleId);
+    const removedAssignments = rbac.assignments.filter((assignment) => assignment.role_id === roleId);
+    const saved = await saveRbacConfig(ref, project.config, {
+      ...rbac,
+      roles: rbac.roles.filter((role) => role.id !== roleId),
+      assignments: rbac.assignments.filter((assignment) => assignment.role_id !== roleId),
+    });
+    await syncUsersMetadata(ref, affectedUserIds(removedAssignments), saved);
+  },
+
+  async listRolePermissions(ref: string, roleId: string): Promise<ProjectRbacPermission[]> {
+    const project = await getProjectOrThrow(ref);
+    return getRoleOrThrow(readRbacConfig(project.config), roleId).permissions;
+  },
+
+  async createPermission(ref: string, roleId: string, input: PermissionInput): Promise<ProjectRbacPermission> {
+    const name = input.name?.trim();
+    if (!name) throw Object.assign(new Error("name is required"), { statusCode: 400 });
+
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    const role = getRoleOrThrow(rbac, roleId);
+    if (role.permissions.some((permission) => permission.name.toLowerCase() === name.toLowerCase())) {
+      throw Object.assign(new Error("Permission name already exists"), { statusCode: 409 });
+    }
+    const timestamp = nowIso();
+    const permission: ProjectRbacPermission = {
+      id: makeId("perm"),
+      name,
+      description: input.description ?? null,
+      resource_id: input.resource_id ?? input.resourceId ?? null,
+      scope_id: input.scope_id ?? input.scopeId ?? null,
+      created_at: timestamp,
+      updated_at: timestamp,
+    };
+    const roles = rbac.roles.map((item) => item.id === roleId
+      ? { ...item, permissions: [...item.permissions, permission], updated_at: timestamp }
+      : item);
+    const saved = await saveRbacConfig(ref, project.config, { ...rbac, roles });
+    await syncUsersMetadata(ref, affectedUserIds(saved.assignments.filter((assignment) => assignment.role_id === roleId)), saved);
+    return getRoleOrThrow(saved, roleId).permissions.find((item) => item.id === permission.id) ?? permission;
+  },
+
+  async deletePermission(ref: string, roleId: string, permissionId: string): Promise<void> {
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    const role = getRoleOrThrow(rbac, roleId);
+    if (!role.permissions.some((permission) => permission.id === permissionId)) {
+      throw Object.assign(new Error("Permission not found"), { statusCode: 404 });
+    }
+    const roles = rbac.roles.map((item) => item.id === roleId
+      ? { ...item, permissions: item.permissions.filter((permission) => permission.id !== permissionId), updated_at: nowIso() }
+      : item);
+    const saved = await saveRbacConfig(ref, project.config, { ...rbac, roles });
+    await syncUsersMetadata(ref, affectedUserIds(saved.assignments.filter((assignment) => assignment.role_id === roleId)), saved);
+  },
+
+  async assignRole(ref: string, roleId: string, input: AssignRoleInput): Promise<ProjectRbacAssignment> {
+    const userId = input.user_id ?? input.userId ?? null;
+    const organizationId = input.organization_id ?? input.organizationId ?? null;
+    const applicationId = input.application_id ?? input.applicationId ?? null;
+    if (!userId && !applicationId) {
+      throw Object.assign(new Error("Either userId or applicationId is required for role assignment"), { statusCode: 400 });
+    }
+
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    getRoleOrThrow(rbac, roleId);
+    const existing = rbac.assignments.find((assignment) =>
+      assignment.role_id === roleId &&
+      assignment.user_id === userId &&
+      assignment.organization_id === organizationId &&
+      assignment.application_id === applicationId
+    );
+    if (existing) {
+      if (userId) await syncUserMetadata(ref, userId, rbac);
+      return existing;
+    }
+
+    const assignment: ProjectRbacAssignment = {
+      id: makeId("assign"),
+      role_id: roleId,
+      user_id: userId,
+      organization_id: organizationId,
+      application_id: applicationId,
+      created_at: nowIso(),
+    };
+    const saved = await saveRbacConfig(ref, project.config, { ...rbac, assignments: [...rbac.assignments, assignment] });
+    if (userId) await syncUserMetadata(ref, userId, saved);
+    return saved.assignments.find((item) => item.id === assignment.id) ?? assignment;
+  },
+
+  async revokeRole(ref: string, roleId: string, assignmentId: string): Promise<void> {
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    getRoleOrThrow(rbac, roleId);
+    const assignment = rbac.assignments.find((item) => item.id === assignmentId && item.role_id === roleId);
+    if (!assignment) throw Object.assign(new Error("Assignment not found"), { statusCode: 404 });
+    const saved = await saveRbacConfig(ref, project.config, {
+      ...rbac,
+      assignments: rbac.assignments.filter((item) => item.id !== assignmentId),
+    });
+    if (assignment.user_id) await syncUserMetadata(ref, assignment.user_id, saved);
+  },
+
+  async listUserRoleAssignments(ref: string, userId: string): Promise<Array<ProjectRbacAssignment & { role?: ProjectRbacRole }>> {
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
+    return rbac.assignments
+      .filter((assignment) => assignment.user_id === userId)
+      .map((assignment) => ({ ...assignment, role: rolesById.get(assignment.role_id) }));
+  },
+
+  async listOrganizationRoleAssignments(ref: string, orgId: string): Promise<Array<ProjectRbacAssignment & { role?: ProjectRbacRole }>> {
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
+    return rbac.assignments
+      .filter((assignment) => assignment.organization_id === orgId)
+      .map((assignment) => ({ ...assignment, role: rolesById.get(assignment.role_id) }));
+  },
+
+  async resolveUserPermissions(ref: string, userId: string, orgId?: string | null): Promise<ProjectRbacUserPermissions> {
+    const project = await getProjectOrThrow(ref);
+    return resolvePermissionsFromConfig(readRbacConfig(project.config), userId, orgId);
+  },
+};

--- a/packages/management-api/tests/unit/project-rbac.routes.test.ts
+++ b/packages/management-api/tests/unit/project-rbac.routes.test.ts
@@ -1,0 +1,283 @@
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const findByRef = mock(() => Promise.resolve(null));
+const updateConfig = mock(() => Promise.resolve(null));
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+
+const { projectRepository } = await import("../../src/repositories/project.repository");
+const authModule = await import("../../src/middleware/auth");
+
+const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(
+  findByRef as typeof projectRepository.findByRef,
+);
+const updateConfigSpy = spyOn(projectRepository, "updateConfig").mockImplementation(
+  updateConfig as typeof projectRepository.updateConfig,
+);
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+
+const { projectRbacRoutes } = await import("../../src/routes/project-rbac");
+const app = new Elysia().use(projectRbacRoutes);
+
+const originalFetch = globalThis.fetch;
+
+type TestProject = {
+  id: string;
+  ref: string;
+  organization_id: string;
+  name: string;
+  db_name: string;
+  db_user: string;
+  db_password: string;
+  jwt_secret: string;
+  anon_key: string;
+  service_role_key: string;
+  s3_bucket: string;
+  s3_access_key: null;
+  s3_secret_key: null;
+  region: string;
+  status: "active";
+  config: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: null;
+};
+
+function makeProject(config: Record<string, unknown>): TestProject {
+  return {
+    id: "proj-id",
+    ref: "proj_1",
+    organization_id: "org-root",
+    name: "Project 1",
+    db_name: "supa_proj_1",
+    db_user: "role_proj_1",
+    db_password: "pw",
+    jwt_secret: "jwt-secret",
+    anon_key: "anon",
+    service_role_key: "service-role-key",
+    s3_bucket: "bucket",
+    s3_access_key: null,
+    s3_secret_key: null,
+    region: "local",
+    status: "active",
+    config,
+    created_at: new Date(),
+    updated_at: new Date(),
+    deleted_at: null,
+  };
+}
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: {
+        authorization: "Bearer dev-master-token",
+        "content-type": "application/json",
+        ...(init.headers || {}),
+      },
+    }),
+  );
+}
+
+describe("projectRbacRoutes", () => {
+  let storedConfig: Record<string, unknown>;
+  const patchBodies: Array<Record<string, unknown>> = [];
+
+  afterAll(() => {
+    findByRefSpy.mockRestore();
+    updateConfigSpy.mockRestore();
+    requireProjectOrAdminAuthSpy.mockRestore();
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    storedConfig = {};
+    patchBodies.length = 0;
+    findByRef.mockReset();
+    updateConfig.mockReset();
+    requireProjectOrAdminAuth.mockReset();
+
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+    findByRef.mockImplementation(async () => makeProject(storedConfig) as never);
+    updateConfig.mockImplementation(async (_ref, nextConfig) => {
+      storedConfig = nextConfig;
+      return makeProject(storedConfig) as never;
+    });
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith("/admin/users/user-one") && init?.method === "PATCH") {
+        if (typeof init.body === "string") {
+          patchBodies.push(JSON.parse(init.body) as Record<string, unknown>);
+        }
+        return Response.json({ id: "user-one" });
+      }
+      if (url.endsWith("/admin/users/user-one")) {
+        return Response.json({
+          id: "user-one",
+          app_metadata: {
+            provider: "email",
+            providers: ["email"],
+            supaoauth: {
+              profile: { role: "管理员" },
+            },
+          },
+        });
+      }
+      return Response.json({ message: "not found" }, { status: 404 });
+    }) as unknown as typeof fetch;
+  });
+
+  test("creates roles and permissions in project config", async () => {
+    const createRole = await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "admin", description: "Administrators" }),
+    });
+    expect(createRole.status).toBe(200);
+    const role = await createRole.json() as { id: string; name: string; permissions: unknown[] };
+    expect(role.name).toBe("admin");
+    expect(role.permissions).toEqual([]);
+
+    const createPermission = await request(`/v1/projects/proj_1/rbac/roles/${role.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "project.manage", description: "Manage project", scopeId: "scope-manage" }),
+    });
+    expect(createPermission.status).toBe(200);
+    const permission = await createPermission.json() as { id: string; name: string; scope_id: string };
+    expect(permission.name).toBe("project.manage");
+    expect(permission.scope_id).toBe("scope-manage");
+
+    const listRoles = await request("/v1/projects/proj_1/rbac/roles");
+    const listBody = await listRoles.json() as { items: Array<{ permissions: unknown[] }>; total: number };
+    expect(listBody.total).toBe(1);
+    expect(listBody.items[0].permissions).toHaveLength(1);
+  });
+
+  test("rejects requests when project auth guard denies access", async () => {
+    requireProjectOrAdminAuth.mockResolvedValueOnce({
+      status: 403,
+      body: { error: "Project service role or admin privileges required" },
+    });
+
+    const res = await request("/v1/projects/proj_1/rbac/roles");
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: "Project service role or admin privileges required",
+    });
+    expect(findByRef).not.toHaveBeenCalled();
+  });
+
+  test("updates and deletes roles and permissions", async () => {
+    const role = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "admin" }),
+    })).json() as { id: string };
+    const permission = await (await request(`/v1/projects/proj_1/rbac/roles/${role.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "project.manage" }),
+    })).json() as { id: string };
+
+    const update = await request(`/v1/projects/proj_1/rbac/roles/${role.id}`, {
+      method: "PUT",
+      body: JSON.stringify({ name: "owner", description: "Project owner" }),
+    });
+    expect(update.status).toBe(200);
+    expect(await update.json()).toMatchObject({
+      id: role.id,
+      name: "owner",
+      description: "Project owner",
+    });
+
+    const deletePermission = await request(`/v1/projects/proj_1/rbac/roles/${role.id}/permissions/${permission.id}`, {
+      method: "DELETE",
+    });
+    expect(deletePermission.status).toBe(200);
+    const permissions = await request(`/v1/projects/proj_1/rbac/roles/${role.id}/permissions`);
+    expect(await permissions.json()).toMatchObject({ items: [], total: 0 });
+
+    const deleteRole = await request(`/v1/projects/proj_1/rbac/roles/${role.id}`, {
+      method: "DELETE",
+    });
+    expect(deleteRole.status).toBe(200);
+    const roles = await request("/v1/projects/proj_1/rbac/roles");
+    expect(await roles.json()).toMatchObject({ items: [], total: 0 });
+  });
+
+  test("returns RBAC validation errors for missing and duplicate resources", async () => {
+    const missingRole = await request("/v1/projects/proj_1/rbac/roles/missing");
+    expect(missingRole.status).toBe(404);
+    expect(await missingRole.json()).toMatchObject({ message: "Role not found", code: "404" });
+
+    await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "admin" }),
+    });
+    const duplicateRole = await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "admin" }),
+    });
+    expect(duplicateRole.status).toBe(409);
+    expect(await duplicateRole.json()).toMatchObject({ message: "Role name already exists", code: "409" });
+  });
+
+  test("assigns and revokes a user role while syncing app_metadata.supaoauth", async () => {
+    const role = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "admin" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${role.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "project.manage", scope_id: "scope-manage" }),
+    });
+
+    const assign = await request(`/v1/projects/proj_1/rbac/roles/${role.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({ userId: "user-one", organizationId: "org-one" }),
+    });
+    expect(assign.status).toBe(200);
+    const assignment = await assign.json() as { id: string; role_id: string; user_id: string; organization_id: string };
+    expect(assignment).toMatchObject({
+      role_id: role.id,
+      user_id: "user-one",
+      organization_id: "org-one",
+    });
+
+    const projection = patchBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    expect(projection.provider).toBe("email");
+    expect(projection.supaoauth).toMatchObject({
+      profile: { role: "管理员" },
+      roles: ["admin"],
+      permissions: ["project.manage"],
+      scopes: ["scope-manage"],
+      organization_ids: ["org-one"],
+      current_org_id: "org-one",
+    });
+
+    const permissions = await request("/v1/projects/proj_1/auth/users/user-one/permissions?org_id=org-one");
+    expect(await permissions.json()).toEqual({
+      roles: ["admin"],
+      permissions: ["project.manage"],
+      scopes: ["scope-manage"],
+    });
+
+    const orgAssignments = await request("/v1/projects/proj_1/organizations/org-one/roles");
+    const orgBody = await orgAssignments.json() as { items: unknown[]; total: number };
+    expect(orgBody.total).toBe(1);
+
+    const revoke = await request(`/v1/projects/proj_1/rbac/roles/${role.id}/assign/${assignment.id}`, {
+      method: "DELETE",
+    });
+    expect(revoke.status).toBe(200);
+    const revokedProjection = patchBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    const revokedSupauth = revokedProjection.supaoauth as Record<string, unknown>;
+    expect(revokedProjection.supaoauth).toMatchObject({
+      roles: [],
+      permissions: [],
+      scopes: [],
+      organization_ids: [],
+    });
+    expect("current_org_id" in revokedSupauth).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add project-scoped RBAC Management API endpoints for SupAuth role, permission, assignment, user-role, user-permission, and org-role flows.
- Store RBAC source-of-truth under `projects.config.rbac` and sync affected users into `auth.users.app_metadata.supaoauth` without changing GoTrue top-level `role`.
- Register the new route module and add focused unit coverage for CRUD, auth rejection, validation errors, metadata projection, and revoke cleanup.

## Verification
- `bun test packages/management-api/tests/unit/project-rbac.routes.test.ts` → 5 pass / 0 fail / 30 expects
- `bun run --cwd packages/management-api typecheck` → pass
- `bun run --cwd packages/management-api test:unit` → 578 pass / 0 fail / 1696 expects
- independent verifier: PASS, no blocking findings

## Notes
- Existing SupAuth-local RBAC fallback was rejected to keep SupaCloud as the platform RBAC owner.
- Future hardening can add optimistic locking around `projects.config.rbac.version` if concurrent RBAC writes become common.