### PR TITLE
fix(management-api): sync project RBAC metadata with GoTrue PUT

### DIFF
--- a/packages/management-api/src/services/project-rbac.service.ts
+++ b/packages/management-api/src/services/project-rbac.service.ts
@@ -248,6 +248,28 @@ async function gotrueFetch(url: string, init?: RequestInit): Promise<Response> {
   }
 }
 
+async function updateGoTrueUserMetadata(
+  apiUrl: string,
+  userId: string,
+  headers: Record<string, string>,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const url = `${apiUrl}/admin/users/${encodeURIComponent(userId)}`;
+  const init = (method: "PUT" | "PATCH"): RequestInit => ({
+    method,
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const putRes = await gotrueFetch(url, init("PUT"));
+  if (putRes.status !== 405) return putRes;
+
+  return gotrueFetch(url, init("PATCH"));
+}
+
 async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacConfig): Promise<void> {
   const ctx = await getGoTrueAdminContext(ref);
   if (!ctx) throw Object.assign(new Error("Project service role key not found"), { statusCode: 404 });
@@ -276,30 +298,23 @@ async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacCo
     ? existingCurrentOrgId
     : orgIds.length === 1 ? orgIds[0] : undefined;
 
-  const patchRes = await gotrueFetch(`${ctx.apiUrl}/admin/users/${encodeURIComponent(userId)}`, {
-    method: "PATCH",
-    headers: {
-      ...headers,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      app_metadata: {
-        ...appMetadata,
-        supaoauth: {
-          ...existingSupauth,
-          roles: resolved.roles,
-          permissions: resolved.permissions,
-          scopes: resolved.scopes,
-          organization_ids: orgIds,
-          current_org_id: currentOrgId,
-          rbac_version: rbac.version,
-          rbac_synced_at: nowIso(),
-        },
+  const updateRes = await updateGoTrueUserMetadata(ctx.apiUrl, userId, headers, {
+    app_metadata: {
+      ...appMetadata,
+      supaoauth: {
+        ...existingSupauth,
+        roles: resolved.roles,
+        permissions: resolved.permissions,
+        scopes: resolved.scopes,
+        organization_ids: orgIds,
+        current_org_id: currentOrgId,
+        rbac_version: rbac.version,
+        rbac_synced_at: nowIso(),
       },
-    }),
+    },
   });
-  if (!patchRes.ok) {
-    throw Object.assign(new Error("Failed to sync RBAC metadata to user"), { statusCode: patchRes.status });
+  if (!updateRes.ok) {
+    throw Object.assign(new Error("Failed to sync RBAC metadata to user"), { statusCode: updateRes.status });
   }
 }
 

--- a/packages/management-api/tests/unit/project-rbac.routes.test.ts
+++ b/packages/management-api/tests/unit/project-rbac.routes.test.ts
@@ -84,7 +84,9 @@ function request(path: string, init: RequestInit = {}) {
 
 describe("projectRbacRoutes", () => {
   let storedConfig: Record<string, unknown>;
-  const patchBodies: Array<Record<string, unknown>> = [];
+  let putUserUpdateReturns405 = false;
+  const userUpdateMethods: string[] = [];
+  const userUpdateBodies: Array<Record<string, unknown>> = [];
 
   afterAll(() => {
     findByRefSpy.mockRestore();
@@ -95,7 +97,9 @@ describe("projectRbacRoutes", () => {
 
   beforeEach(() => {
     storedConfig = {};
-    patchBodies.length = 0;
+    putUserUpdateReturns405 = false;
+    userUpdateMethods.length = 0;
+    userUpdateBodies.length = 0;
     findByRef.mockReset();
     updateConfig.mockReset();
     requireProjectOrAdminAuth.mockReset();
@@ -108,9 +112,13 @@ describe("projectRbacRoutes", () => {
     });
     globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      if (url.endsWith("/admin/users/user-one") && init?.method === "PATCH") {
+      if (url.endsWith("/admin/users/user-one") && (init?.method === "PUT" || init?.method === "PATCH")) {
+        userUpdateMethods.push(init.method);
         if (typeof init.body === "string") {
-          patchBodies.push(JSON.parse(init.body) as Record<string, unknown>);
+          userUpdateBodies.push(JSON.parse(init.body) as Record<string, unknown>);
+        }
+        if (init.method === "PUT" && putUserUpdateReturns405) {
+          return Response.json({ message: "method not allowed" }, { status: 405 });
         }
         return Response.json({ id: "user-one" });
       }
@@ -244,7 +252,8 @@ describe("projectRbacRoutes", () => {
       organization_id: "org-one",
     });
 
-    const projection = patchBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    expect(userUpdateMethods.at(-1)).toBe("PUT");
+    const projection = userUpdateBodies.at(-1)?.app_metadata as Record<string, unknown>;
     expect(projection.provider).toBe("email");
     expect(projection.supaoauth).toMatchObject({
       profile: { role: "管理员" },
@@ -270,7 +279,8 @@ describe("projectRbacRoutes", () => {
       method: "DELETE",
     });
     expect(revoke.status).toBe(200);
-    const revokedProjection = patchBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    expect(userUpdateMethods.at(-1)).toBe("PUT");
+    const revokedProjection = userUpdateBodies.at(-1)?.app_metadata as Record<string, unknown>;
     const revokedSupauth = revokedProjection.supaoauth as Record<string, unknown>;
     expect(revokedProjection.supaoauth).toMatchObject({
       roles: [],
@@ -279,5 +289,27 @@ describe("projectRbacRoutes", () => {
       organization_ids: [],
     });
     expect("current_org_id" in revokedSupauth).toBe(false);
+  });
+
+  test("falls back to PATCH when GoTrue rejects PUT user updates", async () => {
+    putUserUpdateReturns405 = true;
+    const role = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "admin" }),
+    })).json() as { id: string };
+
+    const assign = await request(`/v1/projects/proj_1/rbac/roles/${role.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({ userId: "user-one" }),
+    });
+
+    expect(assign.status).toBe(200);
+    expect(userUpdateMethods).toEqual(["PUT", "PATCH"]);
+    const projection = userUpdateBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    expect(projection.supaoauth).toMatchObject({
+      roles: ["admin"],
+      permissions: [],
+      scopes: [],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- update project RBAC metadata sync to call GoTrue admin user updates with PUT first
- keep PATCH fallback for runtimes that reject PUT
- add regression coverage for the PUT path and fallback path

## Why
Production vm1 on management-api v0.33.0 accepted the RBAC role/permission/assignment write, but automatic metadata projection failed with GoTrue 405 because the new facade called `/admin/users/:id` with PATCH. Existing auth user facade and the current GoTrue runtime use PUT for admin user updates.

## Verification
- `bun test packages/management-api/tests/unit/project-rbac.routes.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `git diff --check`

## Production note
The affected Yang Jun admin assignment was manually projected through the existing PUT user facade after creating the formal project RBAC role/permissions/assignment. No secrets are included here.