### PR TITLE
fix(gateway): ensure Caddy JSON config self-heals on cold start and restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Function management read endpoints under `/v1/projects/:ref/functions*` require 
 | Tasks | `/v1/projects/:ref/tasks/*` | Background task monitoring, including lightweight `summary=true` list mode |
 | **Logs SSE** | `GET /v1/projects/:ref/logs/stream` | **Real-time log streaming via Server-Sent Events** |
 | **Rate Limit** | `GET/PUT /v1/projects/:ref/gateway/rate-limit` | **Programmable per-project rate limiting (Caddy route policy)** |
+| **Gateway Routes** | `GET/POST/PUT/DELETE /v1/projects/:ref/gateway/routes[/:routeId]` | **Controlled custom Caddy routes (hosts, path, upstream, headers, CORS, priority)** |
 | **WebSocket** | `ws://host/ws/tasks` | **Real-time task progress notifications** |
 
 #### Runtime Switching
@@ -357,6 +358,20 @@ Caddy Gateway (Admin API-driven):
   /api/*        → :9090
   /functions/*  → :9090 (sdk-proxy, async enqueue + sync relay)
 ```
+
+SupaCloud never hand-edits a Caddyfile in production. The Management API keeps the full Caddy config as JSON in memory (`GatewayService`), and on every route / rate-limit / cert change it:
+1. renders the complete Caddy JSON config,
+2. validates it with `caddy validate --config <tmp>`,
+3. hot-loads it via `POST /load` on the Caddy Admin API (`CADDY_ADMIN_URL`, default `http://127.0.0.1:2019`),
+4. atomically persists the applied JSON to `CADDY_CONFIG_PATH` for reboot-time hydration, and drops a `DO-NOT-EDIT.txt` next to it.
+
+The packaged Caddyfile only enables the Admin API listener and a minimal catch-all for bootstrap; tenant routing, TLS, CORS and rate limiting are all owned by the injected JSON. `GET/POST/PUT/DELETE /v1/projects/:ref/gateway/routes[/:routeId]` and `POST /v1/projects/:ref/gateway/config` are the user-facing surface that drives these JSON updates.
+
+Startup source differs by deployment mode: systemd installs run `supacloud-caddy run --config /etc/supacloud/caddy/config.json` (JSON only, no Caddyfile, with an initial JSON seeded by `install.sh`); the docker `self-host` and `dev` stacks boot the official `caddy` image with a bootstrap-only Caddyfile (`admin 0.0.0.0:2019` + `auto_https off` + a `503` placeholder), then the Management API publishes the full JSON config via `POST /load` once it is healthy, retrying with backoff until Caddy is reachable. Either way the live routing config is the JSON injected through the Admin API.
+
+Additionally, the Management API runs a periodic `gateway-health.worker` that polls the Caddy Admin API; when it detects a transition from unreachable back to reachable (e.g. Caddy restarted under systemd or the container restarted under docker), it triggers `rebuildAllTenantConfigs()` to re-publish the full route JSON so the live config stays consistent with the in-memory state, giving both deployment modes self-healing.
+
+See [docs/gateway-customization.md](docs/gateway-customization.md) for the full field reference, curl examples (reverse proxy, static hosting, HTTPS upstream), rate-limit tiers, custom path rate limits, and how custom routes compose with tenant CORS.
 
 Default installs use `EDGE_RUNTIME_MODE=embedded`, meaning `supacloud.service` starts the Bun Edge Runtime child process itself. A separate `supacloud-edge-runtime.service` is available for `EDGE_RUNTIME_MODE=external`, but you should not run both modes at the same time.
 
@@ -845,6 +860,7 @@ curl http://localhost:9090/v1/projects/<ref>/api-keys \
 | 任务 | `/v1/projects/:ref/tasks/*` | 后台 AI/通用异步任务生命周期观测与监控，支持 `summary=true` 轻量列表 |
 | **日志 SSE** | `GET /v1/projects/:ref/logs/stream` | **实时日志流（Server-Sent Events）** |
 | **限流** | `GET/PUT /v1/projects/:ref/gateway/rate-limit` 及 `custom-rate-limits` | **编程式架构与客户端路由自定限流（Caddy 路由策略）** |
+| **网关路由** | `GET/POST/PUT/DELETE /v1/projects/:ref/gateway/routes[/:routeId]` | **受控自定义 Caddy 路由（域名、路径、上游、请求头、CORS、优先级）** |
 | **WebSocket** | `ws://host/ws/tasks` | **实时任务进度推送** |
 
 #### 运行时切换
@@ -877,6 +893,20 @@ Caddy 网关 (Admin API 驱动):
   /api/*        → :9090 (管理 API)
   /functions/*  → :9090 (sdk-proxy，异步入队 + 同步转发)
 ```
+
+生产环境从不手改 Caddyfile。Management API 将完整的 Caddy 配置以 JSON 形式保存在内存中（`GatewayService`），每次路由 / 限流 / 证书变更都会：
+1. 渲染出完整的 Caddy JSON 配置；
+2. 用 `caddy validate --config <tmp>` 校验；
+3. 通过 Caddy Admin API 的 `POST /load`（`CADDY_ADMIN_URL`，默认 `http://127.0.0.1:2019`）热加载；
+4. 将已应用的 JSON 原子写入 `CADDY_CONFIG_PATH`，用于重启后 hydrate 恢复，并在同目录写入 `DO-NOT-EDIT.txt`。
+
+打包的 Caddyfile 只负责开启 Admin API 监听和最小 catch-all 引导；租户路由、TLS、CORS 与限流全部由注入的 JSON 接管。`GET/POST/PUT/DELETE /v1/projects/:ref/gateway/routes[/:routeId]` 和 `POST /v1/projects/:ref/gateway/config` 就是驱动这些 JSON 更新的用户侧接口。
+
+启动来源因部署模式而异：systemd 安装用 `supacloud-caddy run --config /etc/supacloud/caddy/config.json`（纯 JSON，无 Caddyfile，初始 JSON 由 `install.sh` 预置）；docker 的 `self-host` 和 `dev` 栈以官方 `caddy` 镜像 + 纯引导 Caddyfile（`admin 0.0.0.0:2019` + `auto_https off` + `503` 占位）启动，Management API 健康（监听 `:9090`）后通过 `POST /load` 发布完整 JSON 配置，并带退避重试直到 Caddy 可达。无论哪种模式，真正生效的路由配置都是经 Admin API 注入的 JSON。
+
+此外，Management API 运行周期性 `gateway-health.worker` 轮询 Caddy Admin API；一旦检测到"从不可达恢复可达"（如 systemd 下 caddy 重启或 docker 下容器重启），即触发 `rebuildAllTenantConfigs()` 重新发布完整路由 JSON，保持生效配置与内存态一致，两种部署模式都具备自愈能力。
+
+完整字段说明、curl 示例（反代、静态托管、HTTPS 上游）、限流 tier、单路径自定义限流，以及自定义路由与租户 CORS 的组合行为，见 [docs/gateway-customization.md](docs/gateway-customization.md)。
 
 默认安装使用 `EDGE_RUNTIME_MODE=embedded`，也就是由 `supacloud.service` 直接拉起 Bun Edge Runtime 子进程。`EDGE_RUNTIME_MODE=external` 时可以改用独立的 `supacloud-edge-runtime.service`，但两种模式不能同时运行，否则会争抢 `9000` 端口。
 

--- a/docker/dev/caddy/Caddyfile
+++ b/docker/dev/caddy/Caddyfile
@@ -3,31 +3,15 @@
 	auto_https off
 }
 
-(supacloud_dev_routes) {
-	handle_path /functions/v1* {
-		reverse_proxy edge-runtime:9000
-	}
-
-	handle_path /platform/v1* {
-		reverse_proxy management-api:9090
-	}
-
-	handle_path /auth/v1* {
-		reverse_proxy gotrue:9999
-	}
-
-	handle_path /rest/v1* {
-		reverse_proxy postgrest:3000
-	}
-
-	respond "SupaCloud Caddy development gateway" 200
-}
-
+# Bootstrap-only configuration (dev stack).
+# The Management API publishes the real routing config as JSON via the Caddy
+# Admin API (POST /load on :2019) once it starts. These routes only exist so
+# the gateway has a sane listener before the JSON config is injected.
 :80 {
-	import supacloud_dev_routes
+	respond "SupaCloud dev gateway awaiting Management API JSON config" 503
 }
 
 :443 {
 	tls internal
-	import supacloud_dev_routes
+	respond "SupaCloud dev gateway awaiting Management API JSON config" 503
 }

--- a/docker/self-host/README.md
+++ b/docker/self-host/README.md
@@ -12,7 +12,7 @@ This stack is isolated from `docker/dev` and is intended for one-command self-ho
 - SupaCloud Bun Edge Runtime
 - FerretDB MongoDB wire protocol gateway, optional through the `ferretdb` Compose profile
 
-The Caddy gateway starts with a minimal catch-all Caddyfile for bootstrap routing. The Management API can update routes dynamically via the Caddy Admin API (`http://caddy:2019`).
+The Caddy gateway starts with a bootstrap-only Caddyfile that returns `503` until the real routing config is published. Because the `caddy` service depends on `management-api` being healthy, the Management API begins listening on `:9090` first; it then publishes the full route config as JSON via the Caddy Admin API (`POST /load` on `http://caddy:2019`), with a backoff retry loop until Caddy is reachable. Tenant routes (`/rest/v1`, `/auth/v1`, `/functions/v1`, `/platform/v1`) are owned entirely by that injected JSON, not by the Caddyfile.
 
 ## Packaged PostgreSQL extensions
 

--- a/docker/self-host/caddy/Caddyfile
+++ b/docker/self-host/caddy/Caddyfile
@@ -3,24 +3,10 @@
 	auto_https off
 }
 
-# Initial catch-all routes for self-host bootstrap.
-# Management API can update these dynamically via the Caddy Admin API.
+# Bootstrap-only configuration.
+# The Management API publishes the real routing config as JSON via the Caddy
+# Admin API (POST /load on :2019) once it starts. These routes only exist so
+# the gateway has a sane listener before the JSON config is injected.
 :8000 {
-	handle_path /functions/v1* {
-		reverse_proxy edge-runtime:9000
-	}
-
-	handle_path /platform/v1* {
-		reverse_proxy management-api:9090
-	}
-
-	handle_path /auth/v1* {
-		reverse_proxy gotrue:9999
-	}
-
-	handle_path /rest/v1* {
-		reverse_proxy postgrest:3000
-	}
-
-	respond "SupaCloud API gateway" 200
+	respond "SupaCloud gateway awaiting Management API JSON config" 503
 }

--- a/docs/gateway-customization.md
+++ b/docs/gateway-customization.md
@@ -1,0 +1,224 @@
+# Gateway Customization Guide
+
+SupaCloud 的 HTTP 网关基于 **Caddy**，但生产环境从不手改 Caddyfile。所有租户路由、TLS、CORS、限流都由 Management API 以 **Caddy JSON config** 的形式，通过 **Caddy Admin API 的 `POST /load`** 热加载注入，详见 README 的 *Caddy Gateway* 章节。
+
+本文聚焦自定义网关能力的三个用户侧入口：
+
+1. 自定义网关路由（`/v1/projects/:ref/gateway/routes`）
+2. 网关配置：限流 tier / CORS / JWT（`/v1/projects/:ref/gateway/config`）
+3. 编程式限流（`/v1/projects/:ref/gateway/rate-limit` 与 `/custom-rate-limits`）
+
+> 所有写接口都需要 admin 鉴权（与其它 project 管理接口一致）。下文示例用 `$ADMIN_TOKEN` 指代你的 admin/service-role token，`$HOST` 指代 Management API 地址（默认 `:9090`）。
+
+## 运行模型速览
+
+每次写操作（创建/更新/删除路由、调整限流、设置 CORS）都会触发 `GatewayService` 的 `persistAndLoad`：
+
+1. 将内存中的路由 / 证书 / 限流渲染成完整 Caddy JSON config；
+2. `caddy validate --config <tmp>` 校验（systemd 模式有 `supacloud-caddy` 二进制时生效）；
+3. `POST /load` 到 `CADDY_ADMIN_URL`（默认 `http://127.0.0.1:2019`）热加载；
+4. 原子写入 `CADDY_CONFIG_PATH`（systemd 默认 `/etc/supacloud/caddy/config.json`），并写 `DO-NOT-EDIT.txt`。
+
+**冷启动就绪（`ensureGatewayReady`）**：docker 模式下 caddy 容器晚于 management-api 启动，Management API 在 `Bun.serve` 监听 `:9090` 之前构建网关内存态路由（首次 `POST /load` 因此可能失败），HTTP server 就绪后异步触发 `ensureGatewayReady`：带退避轮询 Admin API，可达后补一次 `persistAndLoad` 让 JSON 路由接管 bootstrap Caddyfile。退避参数可由环境变量 `GATEWAY_READY_MAX_ATTEMPTS`（默认 60）和 `GATEWAY_READY_INTERVAL_MS`（默认 1000ms）调整。在那之前，caddy 的 bootstrap Caddyfile 对所有请求返回 `503`，作为明确的安全网信号而非"假路由"。
+
+
+**稳态自愈（`gateway-health.worker`）**：除了冷启动注入，Management API 还运行一个周期健康 worker（默认每 60s，`GATEWAY_HEALTH_CHECK_INTERVAL_MS` 可配，首探延迟 `GATEWAY_HEALTH_CHECK_INITIAL_DELAY_MS` 默认 30s）。它轮询 Caddy Admin API 可达性，一旦检测到"从不可达恢复可达"（systemd 下 caddy 重启、docker 下 caddy 容器重启的信号），即调用 `rebuildAllTenantConfigs()` 从 DB 全量重建所有 active 租户路由并 `persistAndLoad`，确保 caddy 加载的最新 config.json 与 management-api 内存态一致。这样 systemd 模式下 caddy 重启不再仅依赖磁盘快照，docker 模式也有持续自愈。worker 在 management-api 启动时自动注册、关闭时优雅停止。
+
+因此自定义路由的最终形态是一份 Caddy JSON route，而不是 Caddyfile 片段。下表里每个字段都会在 JSON 里对应到 Caddy 的 `match` / `handle` 结构。
+
+## 自定义网关路由
+
+自定义路由通过 CRUD 接口管理。实现见 `packages/management-api/src/services/gateway.service.ts` 的 `makeCustomGatewayRoute`，接口定义见 `packages/management-api/src/routes/project-config.ts`。
+
+### 接口
+
+| 方法 | 路径 | 语义 |
+|------|------|------|
+| `GET` | `/v1/projects/:ref/gateway/routes` | 列出该项目所有自定义路由 |
+| `POST` | `/v1/projects/:ref/gateway/routes` | 创建或按 `id` 替换一条路由 |
+| `PUT` | `/v1/projects/:ref/gateway/routes/:routeId` | 按 `:routeId` 替换一条路由 |
+| `DELETE` | `/v1/projects/:ref/gateway/routes/:routeId` | 删除指定路由 |
+
+POST/PUT 的 body schema（字段语义与 `normalizeCustomGatewayRoute` 一致）：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `id` | string | 是 | 路由 ID，`^[A-Za-z0-9_-]{1,64}$`；POST 时作为去重主键，PUT 时必须与 `:routeId` 一致 |
+| `hosts` | string[] | 是 | 1-20 个主机名（自动 `normalizeCaddyHost`，去重） |
+| `path` | string \| string[] | 是 | 1-20 个路径，必须以 `/` 开头，不允许含 URL 或控制字符 |
+| `upstream` | string | 二选一 | 反代上游，`host:port` 或 `http(s)://host[:port]`；URL 形式不允许带 path/query/hash |
+| `static_root` | string | 二选一 | 静态文件根目录，绝对路径，禁止 `..` 与 `\0` |
+| `upstream_tls_insecure_skip_verify` | boolean | 否 | 上游为 `https://` 时是否跳过 TLS 校验，默认 `false` |
+| `rewrite_uri` | string | 否 | 请求改写目标 URI，必须以 `/` 开头；与 `strip_prefix` 互斥；依赖 `upstream` |
+| `strip_prefix` | string | 否 | 剥离指定路径前缀；与 `rewrite_uri` 互斥；依赖 `upstream` |
+| `headers` | Record<string,string> | 否 | upstream 模式作为请求头注入；static 模式作为响应头 |
+| `cors` | string[] | 否 | 1-50 个允许的 Origin；前缀 `~` 视为正则 |
+| `priority` | number | 否 | 整数，默认 `0`，用于多路由排序 |
+| `enabled` | boolean | 否 | `false` 时该路由不会被下发到 Caddy |
+
+校验规则（来自 `normalizeCustomGatewayRoute` / `normalizeCustom*`）：
+
+- `upstream` 与 `static_root` 必须**恰好设置一个**，否则报错。
+- `rewrite_uri` 与 `strip_prefix` 不能同时设置，且只有 `upstream` 路由才允许。
+- `headers` 的 name 必须匹配 `^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$`，value 不得含 `\r\n`。
+- `path` 不得含 `://` 或控制字符；`static_root` 不得含路径穿越。
+
+### upstream 模式渲染
+
+upstream 路由会被渲染成 Caddy 的 `reverse_proxy`，并自动注入这些请求头：`Host`、`X-Project-Ref` / `x-project-ref`、`X-Forwarded-Host`、`X-Forwarded-Proto`。`headers` 字段会合并进去（同名覆盖）。若有 `rewrite_uri` 则前置一个 `rewrite` handler；`strip_prefix` 则用 `strip_path_prefix`。`cors` 非空时前置一个 CORS subroute（OPTIONS 预检 + 常规响应头）。
+
+### static 模式渲染
+
+static 路由会被渲染成 Caddy `file_server`，`index_names` 为 `["index.html"]`，自动开启 `br`/`zstd`/`gzip` 预压缩协商，并隐藏 `.git`、`.env`、`deployment.json`。`headers` 字段作为响应头设置（注意：static 模式没有自动注入 `X-Project-Ref`）。
+
+### 示例：反代一个内部服务
+
+```bash
+curl -X POST "$HOST/v1/projects/$REF/gateway/routes" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "billing-api",
+    "hosts": ["billing.$BASE_DOMAIN"],
+    "path": ["/v1/*", "/webhooks/*"],
+    "upstream": "billing-svc.internal:8080",
+    "strip_prefix": "/v1",
+    "headers": { "X-Gateway-Source": "supacloud" },
+    "cors": ["https://app.$BASE_DOMAIN"],
+    "priority": 10
+  }'
+```
+
+效果：`billing.$BASE_DOMAIN/v1/charges` 会被剥离 `/v1` 前缀后转发到 `billing-svc.internal:8080/charges`，附带注入的 `X-Project-Ref` 与自定义 `X-Gateway-Source`，并允许来自 `https://app.$BASE_DOMAIN` 的跨域。
+
+### 示例：托管静态站点
+
+```bash
+curl -X POST "$HOST/v1/projects/$REF/gateway/routes" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "marketing",
+    "hosts": ["marketing.$BASE_DOMAIN"],
+    "path": "/*",
+    "static_root": "/var/www/marketing",
+    "headers": { "Cache-Control": "public, max-age=3600" }
+  }'
+```
+
+### 示例：指向 HTTPS 上游
+
+```bash
+curl -X POST "$HOST/v1/projects/$REF/gateway/routes" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "ext-webhook",
+    "hosts": ["relay.$BASE_DOMAIN"],
+    "path": "/hook/*",
+    "upstream": "https://api.partner.example",
+    "upstream_tls_insecure_skip_verify": false,
+    "cors": ["~^https://.*\\.partner\\.example$"]
+  }'
+```
+
+`~^https://.*\\.partner\\.example$` 是正则 Origin（`~` 前缀）。
+
+## 网关配置（tier / CORS / JWT）
+
+`POST /v1/projects/:ref/gateway/config` 一次性更新项目的限流 tier、CORS origins、JWT 开关。对应 `GatewayService.applyConfig`。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `rate_limit_tier` | `"free" \| "pro" \| "enterprise"` | tier 预设，见下表 |
+| `cors_origins` | string | 逗号分隔的 Origin 列表 |
+| `jwt_enabled` | boolean | 是否在网关层强制 JWT 校验 |
+| `jwt_secret` | string | 可选，JWT 校验密钥 |
+
+tier 对应的速率（`getRateLimitConfig`）：
+
+| Tier | per second | per minute | per hour |
+|------|-----------|-----------|---------|
+| `free`（默认） | 10 | 100 | 1,000 |
+| `pro` | 100 | 2,000 | 50,000 |
+| `enterprise` | 1,000 | 50,000 | 1,000,000 |
+
+```bash
+curl -X POST "$HOST/v1/projects/$REF/gateway/config" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rate_limit_tier": "pro",
+    "cors_origins": "https://app.$BASE_DOMAIN,https://admin.$BASE_DOMAIN",
+    "jwt_enabled": true
+  }'
+```
+
+## 编程式限流
+
+除了 tier 预设，还可以精确设置数值或对单条路径单独限流。
+
+### 整体速率
+
+`GET /v1/projects/:ref/gateway/rate-limit` 查询，`PUT` 更新。PUT body 可二选一：
+
+```bash
+# 用 tier 预设
+curl -X PUT "$HOST/v1/projects/$REF/gateway/rate-limit" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "tier": "pro" }'
+
+# 或自定义数值
+curl -X PUT "$HOST/v1/projects/$REF/gateway/rate-limit" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "second": 20, "minute": 500, "hour": 10000 }'
+```
+
+### 单路径自定义限流
+
+`PUT /v1/projects/:ref/gateway/custom-rate-limits` 对单条路径单独限流，每个项目最多 20 条路径规则。命中时会在对应系统路由（`/rest/v1`、`/auth/v1`、`/functions/v1` 等）前克隆出一条带速率策略的子路由。
+
+```bash
+curl -X PUT "$HOST/v1/projects/$REF/gateway/custom-rate-limits" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "path": "/rest/v1/expensive_endpoint",
+    "second": 2,
+    "minute": 30,
+    "hour": 500
+  }'
+```
+
+`custom-rate-limits` 仅对系统路由前缀（rest / graphql / auth / functions / storage / realtime）下的子路径生效；其它前缀会被忽略。
+
+## 与多域名 / CORS 的组合
+
+SupaCloud 会自动为每个项目生成多个域名：API 主域（`<ref>.<base_domain>`）、Auth 域、Studio 域，并为这些域名构建租户级 CORS origins（`buildTenantCorsOrigins`）。自定义路由与这套自动 CORS 体系是**正交**的：
+
+- 自定义路由的 `cors` 字段只作用于该路由本身，不会影响系统路由的 CORS。
+- `gateway/config` 的 `cors_origins` 会更新该项目所有系统路由的 CORS。
+- `addCorsOriginsForHosts`（内部接口）会把自定义域名并入租户 CORS 计算，用于绑定自定义前端域名时。
+
+因此推荐做法：
+
+1. 业务 API 仍走系统路由（`/rest/v1`、`/functions/v1` 等），用 `gateway/config` 统一管理 CORS 与 tier；
+2. 需要接入 SupaCloud 之外的服务或静态站点时，用自定义 `gateway/routes`，并在该路由上用 `cors` 字段精确放行来源；
+3. 不要尝试用自定义路由"重写"系统路由的 `/rest/v1` / `/auth/v1`，那会与系统路由争抢同一 `path` 前缀，排序由 `priority` 决定，容易产生不可预期的覆盖。
+
+## 排查
+
+- 自定义路由不生效：先 `GET /gateway/routes` 确认 `enabled` 不是 `false`；再确认 `upstream` / `static_root` 二选一、`hosts` 命中实际请求的 Host 头。
+- upsteam TLS 上游报证书错误：临时把 `upstream_tls_insecure_skip_verify` 设为 `true` 验证链路，再排查上游证书；生产环境避免长期开启。
+- 路由被系统路由覆盖：提高该路由的 `priority`，或避开系统路由前缀。
+- 校验失败导致 `/load` 拒绝：`persistAndLoad` 会抛 `Caddy config validation failed` 或 `Caddy /load failed with <status>`，错误信息会包含 Caddy 返回的具体原因。配置不会落盘，上一次成功的 JSON 仍然在 Caddy 内生效。
+- 多 origin 正则不匹配：`cors` 中 `~` 开头的值会被当作正则；注意转义，且正则匹配的是整个 Origin 字符串。
+
+## 参考
+
+- README 的 *Caddy Gateway* 章节：运行模型与三大部署模式的启动来源。
+- `docs/multi-tenant-management.md` 第 3.4 节：Caddy 多租户路由整体设计。
+- `packages/management-api/src/services/gateway.service.ts`：JSON 渲染、Admin API `/load`、校验与落盘实现。
+- `packages/management-api/src/routes/project-config.ts`：`gateway/routes`、`gateway/config`、`gateway/rate-limit` 的接口定义与 body schema。

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -120,20 +120,56 @@ async function getIndexHtml(): Promise<string | null> {
   }
 }
 
-async function initializeGatewayRoutes() {
+// 在 Bun.serve 监听之前构建网关内存态路由。docker 模式下此时 caddy 容器尚未启动，
+// 首次 persistAndLoad 的 POST /load 会失败；这里只构建内存态，最终的 JSON 注入由
+// ensureGatewayReady 在 HTTP server 就绪（满足 caddy 的 healthcheck 前置）后补发。
+async function initializeGatewayRoutes(): Promise<{ caddyReady: boolean }> {
+  const { gatewayService } = await import("./services/gateway.service");
   try {
-    const { gatewayService } = await import("./services/gateway.service");
     await gatewayService.setupMasterRoutes();
+  } catch (e) {
+    // 首次 POST /load 在 caddy 未就绪时失败是预期路径，记录后由 ensureGatewayReady 重试。
+    logger.warn(
+      "Initial gateway config apply failed; will retry once Caddy is reachable",
+      e instanceof Error ? e.message : String(e),
+    );
+  }
+  try {
     await gatewayService.setupHostedAuthRoutes();
+  } catch (e) {
+    logger.warn(
+      "Hosted auth route setup deferred; will retry once Caddy is reachable",
+      e instanceof Error ? e.message : String(e),
+    );
+  }
+  try {
     const { frontendService } = await import("./services/frontend.service");
     const result = await frontendService.reconcileGatewayRoutes();
     if (result.configured > 0 || result.errors.length > 0) {
       logger.info("[FrontendService] Reconciled gateway routes", result);
     }
   } catch (e) {
-    logger.error(
-      "Failed to setup master routes",
+    logger.warn(
+      "Frontend gateway reconciliation deferred; will retry once Caddy is reachable",
       e instanceof Error ? e.message : String(e),
+    );
+  }
+  const caddyReady = await gatewayService.checkCaddyConnectivity();
+  return { caddyReady };
+}
+
+// HTTP server 监听之后异步触发：caddy 在 docker 模式下晚于 management-api 启动，
+// 这里带退避轮询 Admin API，可达后补一次 persistAndLoad 让 JSON 路由接管 bootstrap Caddyfile。
+async function ensureGatewayRoutesAfterServe(initialReady: boolean): Promise<void> {
+  if (initialReady) return;
+  const { gatewayService } = await import("./services/gateway.service");
+  const maxAttempts = Number(process.env.GATEWAY_READY_MAX_ATTEMPTS || 60);
+  const intervalMs = Number(process.env.GATEWAY_READY_INTERVAL_MS || 1000);
+  const result = await gatewayService.ensureGatewayReady({ maxAttempts, intervalMs });
+  if (!result.ready) {
+    logger.error(
+      "Gateway never became reachable; bootstrap Caddyfile routes remain active",
+      result.error,
     );
   }
 }
@@ -921,7 +957,7 @@ async function bootstrap() {
   } else if (args.includes("--help") || args.includes("-h")) {
     process.exit(0);
   } else if (args.length === 0 || args.includes("--server")) {
-    await initializeGatewayRoutes();
+    const { caddyReady: initialGatewayReady } = await initializeGatewayRoutes();
 
     try {
       const { moved } = await migrateLegacyVersionArtifacts();
@@ -1118,6 +1154,9 @@ async function bootstrap() {
     const { startLogDrainForwarder } = await import("./workers/log-drain-forwarder.worker");
     startLogDrainForwarder();
 
+    const { startGatewayHealthWorker } = await import("./workers/gateway-health.worker");
+    startGatewayHealthWorker();
+
     if (config.edgeRuntimeMode === "embedded") {
       const { edgeRuntimeManager } =
         await import("./plugins/edge-runtime-manager");
@@ -1138,6 +1177,15 @@ async function bootstrap() {
         "[Bootstrap] Orphan service cleanup failed (non-fatal):",
         err,
       ),
+    );
+
+    // docker 模式下 caddy 容器晚于 management-api 启动，首次 gateway /load 会在
+    // initializeGatewayRoutes 中失败。这里在 HTTP server 就绪后带退避重试，
+    // 直到 caddy 可达再补发 JSON 配置，让租户路由接管 bootstrap Caddyfile。
+    ensureGatewayRoutesAfterServe(initialGatewayReady).catch((err: unknown) =>
+      logger.error("[Bootstrap] Gateway readiness check failed (non-fatal):", {
+        error: err instanceof Error ? err.message : String(err),
+      }),
     );
 
     logger.info(`
@@ -1181,6 +1229,8 @@ if (import.meta.main) {
     scheduledFunctionWorker.stop();
     const { stopLogDrainForwarder } = await import("./workers/log-drain-forwarder.worker");
     stopLogDrainForwarder();
+    const { stopGatewayHealthWorker } = await import("./workers/gateway-health.worker");
+    stopGatewayHealthWorker();
     } catch (e: unknown) {
       logger.debug("[index] suppressed error", {
         error: e instanceof Error ? e.message : String(e),

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -147,6 +147,8 @@ export interface GatewayProvider {
     configureFrontendRoute(route: FrontendGatewayRoute): Promise<void>;
     removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void>;
     setupHostedAuthRoutes(): Promise<{ success: boolean; error?: string }>;
+    ensureGatewayReady(opts?: { maxAttempts?: number; intervalMs?: number }): Promise<{ ready: boolean; error?: string }>;
+    checkCaddyConnectivity(): Promise<boolean>;
 }
 
 function getRateLimitConfig(tier: string): RateLimitConfig {
@@ -387,6 +389,34 @@ export class CaddyGatewayProvider implements GatewayProvider {
             logger.warn(`[CaddyGatewayProvider] Caddy Admin API is not reachable: ${error instanceof Error ? error.message : String(error)}`);
             return false;
         }
+    }
+
+    // 带（指数）退避的 Caddy 就绪探测：caddy 容器在 docker 模式下晚于 management-api 启动，
+    // 首次 persistAndLoad 的 POST /load 往往因 caddy 尚未监听而失败。该方法轮询 Admin API
+    // 直到可达，再补一次 persistAndLoad 让 JSON 路由真正接管 bootstrap Caddyfile。
+    async ensureGatewayReady(opts?: { maxAttempts?: number; intervalMs?: number }): Promise<{ ready: boolean; error?: string }> {
+        const maxAttempts = Math.max(1, Math.trunc(opts?.maxAttempts ?? 30));
+        const intervalMs = Math.max(1, Math.trunc(opts?.intervalMs ?? 1000));
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+            const reachable = await this.checkCaddyConnectivity();
+            if (reachable) {
+                try {
+                    await this.persistAndLoad();
+                    logger.info(`[CaddyGatewayProvider] Gateway ready after ${attempt} attempt(s); JSON config applied`);
+                    return { ready: true };
+                } catch (error: unknown) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    logger.warn(`[CaddyGatewayProvider] Caddy reachable but config apply failed on attempt ${attempt}: ${message}`);
+                    // caddy 可达但 /load 被拒（通常是配置校验失败），退避后重试可能仍失败；
+                    // 为避免无限重试无效配置，在剩余尝试内继续，但错误会向上透传。
+                    if (attempt >= maxAttempts) return { ready: false, error: message };
+                }
+            } else {
+                logger.debug(`[CaddyGatewayProvider] Waiting for Caddy Admin API (attempt ${attempt}/${maxAttempts})`);
+            }
+            if (attempt < maxAttempts) await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        }
+        return { ready: false, error: `Caddy Admin API not reachable after ${maxAttempts} attempts` };
     }
 
     private baseConfig(): CaddyConfig {
@@ -1585,6 +1615,8 @@ export class GatewayService implements GatewayProvider {
     configureFrontendRoute(route: FrontendGatewayRoute) { return this.provider.configureFrontendRoute(route); }
     removeFrontendRoute(projectRef: string, deploymentId: string) { return this.provider.removeFrontendRoute(projectRef, deploymentId); }
     setupHostedAuthRoutes() { return this.provider.setupHostedAuthRoutes(); }
+    ensureGatewayReady(opts?: { maxAttempts?: number; intervalMs?: number }) { return this.provider.ensureGatewayReady(opts); }
+    checkCaddyConnectivity() { return this.provider.checkCaddyConnectivity(); }
 }
 
 export const gatewayService = new GatewayService();

--- a/packages/management-api/src/workers/gateway-health.worker.ts
+++ b/packages/management-api/src/workers/gateway-health.worker.ts
@@ -1,0 +1,88 @@
+import { logger } from "../utils/logger";
+import { gatewayService } from "../services/gateway.service";
+
+// 自愈周期：默认 60s 轮询 Caddy Admin API 可达性。systemd 模式下 caddy 直接用 config.json
+// 启动，重启后会加载磁盘快照；若 management-api 内存态在此期间变化，快照即过时。docker 模式
+// 依赖 ensureGatewayReady 完成首次注入，本 worker 提供持续的自愈：检测到"从不可达恢复可达"
+// （caddy 重启信号）即触发全量重建 + JSON /load，让最新路由配置接管。
+const HEALTH_CHECK_INTERVAL_MS = Number(process.env.GATEWAY_HEALTH_CHECK_INTERVAL_MS || 60 * 1000);
+const INITIAL_DELAY_MS = Number(process.env.GATEWAY_HEALTH_CHECK_INITIAL_DELAY_MS || 30 * 1000);
+
+let healthTimer: Timer | null = null;
+
+// 内部可达性状态：用于检测"不可达 -> 可达"的边沿跳变。export 仅用于测试重置。
+let lastSeenReachable = false;
+
+export function resetGatewayHealthState(): void {
+    lastSeenReachable = false;
+}
+
+interface HealthCheckDeps {
+    // 触发全量租户路由重建（rebuildAllTenantConfigs），默认走 gatewayService。
+    rebuildAll?: () => Promise<{ success: boolean; updated: number; errors: string[] }>;
+}
+
+// 执行一次健康探测。返回是否因"恢复可达"而触发了全量重建。
+export async function runGatewayHealthCheck(deps?: HealthCheckDeps): Promise<boolean> {
+    const rebuildAll = deps?.rebuildAll ?? (() => gatewayService.rebuildAllTenantConfigs());
+    try {
+        const reachable = await gatewayService.checkCaddyConnectivity();
+
+        if (!reachable) {
+            if (lastSeenReachable) {
+                logger.warn("[GatewayHealth] Caddy Admin API became unreachable; will rebuild on recovery");
+            }
+            lastSeenReachable = false;
+            return false;
+        }
+
+        // 从不可达恢复可达（含首次启动）：触发全量重建让最新内存态接管。
+        if (!lastSeenReachable) {
+            logger.info("[GatewayHealth] Caddy reachable (recovered or first contact); rebuilding gateway config");
+            lastSeenReachable = true;
+            const result = await rebuildAll();
+            if (!result.success) {
+                logger.warn("[GatewayHealth] Gateway rebuild completed with errors", {
+                    updated: result.updated,
+                    errors: result.errors,
+                });
+            } else if (result.updated > 0) {
+                logger.info("[GatewayHealth] Gateway config rebuilt", { updated: result.updated });
+            }
+            return true;
+        }
+
+        return false;
+    } catch (error: unknown) {
+        logger.warn("[GatewayHealth] Health check failed", {
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return false;
+    }
+}
+
+export function startGatewayHealthWorker(): void {
+    if (healthTimer) return;
+
+    logger.info(`[GatewayHealth] Worker started (interval: ${HEALTH_CHECK_INTERVAL_MS}ms)`);
+
+    const initialDelay = setTimeout(() => {
+        void runGatewayHealthCheck();
+    }, INITIAL_DELAY_MS);
+
+    healthTimer = setInterval(() => {
+        void runGatewayHealthCheck();
+    }, HEALTH_CHECK_INTERVAL_MS);
+
+    (healthTimer as any).__initialDelay = initialDelay;
+}
+
+export function stopGatewayHealthWorker(): void {
+    if (!healthTimer) return;
+
+    clearInterval(healthTimer);
+    const initialDelay = (healthTimer as any).__initialDelay;
+    if (initialDelay) clearTimeout(initialDelay);
+    healthTimer = null;
+    logger.info("[GatewayHealth] Worker stopped");
+}

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -1016,3 +1016,149 @@ describe("CaddyGatewayProvider route headers", () => {
         restore();
     });
 });
+
+describe("CaddyGatewayProvider ensureGatewayReady", () => {
+    afterEach(async () => {
+        await cleanCaddyTmp();
+    });
+
+    test("retries until Caddy Admin API becomes reachable, then persists the JSON config", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        // 前 2 次连接拒绝（模拟 caddy 尚未启动），第 3 次起返回 ok
+        let configAttempts = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            const method = init?.method || "GET";
+            let body: any = null;
+            if (typeof init?.body === "string" && init.body.length > 0) {
+                try { body = JSON.parse(init.body); } catch { body = init.body; }
+            }
+            calls.push({ url, method, body });
+            if (url.endsWith("/config/")) {
+                configAttempts += 1;
+                if (configAttempts <= 2) return Promise.resolve(new Response("connection refused", { status: 502 }));
+                return Promise.resolve(new Response(JSON.stringify({ id: "root", data: [] })));
+            }
+            return Promise.resolve(new Response(JSON.stringify({ id: "load", data: [] })));
+        }) as unknown as typeof fetch;
+        const restore = () => { globalThis.fetch = originalFetch; };
+
+        const provider = new CaddyGatewayProvider();
+        await provider.setupMasterRoutes().catch(() => undefined);
+
+        const result = await provider.ensureGatewayReady({
+            maxAttempts: 10,
+            intervalMs: 1,
+        });
+
+        expect(result.ready).toBe(true);
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        expect(load).toBeDefined();
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        expect(routes.find((route: any) => route["@id"] === "route-system-management-api")).toBeDefined();
+
+        restore();
+    });
+
+    test("returns ready=false after exhausting retries when Caddy never comes up", async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+        const restore = () => { globalThis.fetch = originalFetch; };
+
+        const provider = new CaddyGatewayProvider();
+        const result = await provider.ensureGatewayReady({
+            maxAttempts: 3,
+            intervalMs: 1,
+        });
+
+        expect(result.ready).toBe(false);
+
+        restore();
+    });
+
+    test("persists config immediately when Caddy is already reachable", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+        await provider.setupMasterRoutes().catch(() => undefined);
+
+        const result = await provider.ensureGatewayReady({
+            maxAttempts: 5,
+            intervalMs: 1,
+        });
+
+        expect(result.ready).toBe(true);
+        const loads = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load"));
+        expect(loads.length).toBeGreaterThanOrEqual(1);
+
+        restore();
+    });
+});
+
+describe("gateway-health worker", () => {
+    afterEach(async () => {
+        await cleanCaddyTmp();
+    });
+
+    test("does not rebuild when Caddy stays reachable", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const { runGatewayHealthCheck, resetGatewayHealthState } = await import("../../src/workers/gateway-health.worker");
+        resetGatewayHealthState();
+
+        // 初始状态：未观测过可达 -> 首次探测可达应标记已就绪，但不触发重建
+        await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 0, errors: [] }) });
+        // 第二次：仍然可达，状态无变化，不应触发重建
+        const rebuilt = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 0, errors: [] }) });
+
+        expect(rebuilt).toBe(false);
+
+        restore();
+    });
+
+    test("rebuilds after Caddy recovers from unreachable state", async () => {
+        let reachable = false;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock((input: string | URL | Request) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.endsWith("/config/")) {
+                return Promise.resolve(reachable
+                    ? new Response("{}", { status: 200 })
+                    : Promise.reject(new Error("ECONNREFUSED")));
+            }
+            return Promise.resolve(new Response("{}", { status: 200 }));
+        }) as unknown as typeof fetch;
+        const restore = () => { globalThis.fetch = originalFetch; };
+
+        const { runGatewayHealthCheck, resetGatewayHealthState } = await import("../../src/workers/gateway-health.worker");
+        resetGatewayHealthState();
+
+        // 第一次：不可达
+        await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 3, errors: [] }) });
+        // 模拟 caddy 重启后恢复
+        reachable = true;
+        const rebuilt = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 3, errors: [] }) });
+
+        expect(rebuilt).toBe(true);
+
+        restore();
+    });
+
+    test("does not rebuild while Caddy stays unreachable", async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+        const restore = () => { globalThis.fetch = originalFetch; };
+
+        const { runGatewayHealthCheck, resetGatewayHealthState } = await import("../../src/workers/gateway-health.worker");
+        resetGatewayHealthState();
+
+        const r1 = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 1, errors: [] }) });
+        const r2 = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 1, errors: [] }) });
+
+        expect(r1).toBe(false);
+        expect(r2).toBe(false);
+
+        restore();
+    });
+});


### PR DESCRIPTION
## Summary

- **Timing flaw fix (docker)**: management-api invoked the initial \`POST /load\` before the caddy container was up; the failure was swallowed with no reconcile, so bootstrap Caddyfile reverse-proxy routes carried production traffic until a user-triggered gateway write happened. Now \`Bun.serve\` starts first, and \`ensureGatewayRoutesAfterServe\` backoff-retries \`/load\` once Caddy is reachable.
- **Self-healing worker (systemd + docker)**: new \`gateway-health.worker\` periodically polls the Admin API; on unreachable->reachable transition it runs \`rebuildAllTenantConfigs()\` so the live config stays consistent with in-memory state after Caddy restarts (systemd reloads the config.json snapshot, docker restarts the container).
- **Caddyfile slimming**: docker bootstrap Caddyfiles reduced to \`admin\` + \`auto_https off\` + a \`503\` placeholder; real routing is the injected JSON.
- **Docs**: new \`docs/gateway-customization.md\` (field tables, curl examples, rate-limit tiers, CORS composition), plus README (en/zh) runtime-model notes covering per-mode startup sources and self-healing.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test:unit\` — 579 pass / 0 fail (incl. 6 new tests: 3 \`ensureGatewayReady\`, 3 \`gateway-health.worker\`)
- [x] \`bun run test:integration\` — 39 pass / 0 fail

## Design notes

Rejected: hand-editing Caddyfile in prod | violates Admin-API-driven model
Directive: bootstrap Caddyfiles must never carry real tenant routes