### PR TITLE
feat(management-api): add SupAuth webhook audit facade

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -299,21 +299,31 @@ jobs:
         run: |
           echo "Waiting for Realtime container to be ready..."
           JWT_SECRET="super-secret-jwt-token-with-at-least-32-characters-long"
-          for i in $(seq 1 30); do
+          realtime_ready=false
+          for i in $(seq 1 60); do
             # Check the health endpoint for the self-seeded tenant
             if curl -sf -H "Authorization: Bearer ${JWT_SECRET}" "http://127.0.0.1:4000/api/tenants/realtime-dev/health" > /dev/null 2>&1; then
               echo "✅ Realtime self-hosted tenant is ready"
+              realtime_ready=true
               break
             elif curl -sf "http://127.0.0.1:4000/health" > /dev/null 2>&1; then
               echo "✅ Realtime container is ready (basic health)"
+              realtime_ready=true
               break
             fi
-            echo "  Attempt $i/30: Realtime not ready, waiting 2s..."
+            echo "  Attempt $i/60: Realtime not ready, waiting 2s..."
             sleep 2
           done
           if [ "${realtime_ready}" != "true" ]; then
             echo "::error title=Realtime service not ready::Realtime did not become reachable on :4000"
             docker ps -a --filter "ancestor=public.ecr.aws/supabase/realtime:v2.109.1" || true
+            realtime_container_id="$(docker ps -a -q --filter "ancestor=public.ecr.aws/supabase/realtime:v2.109.1" | head -n1)"
+            if [ -n "${realtime_container_id}" ]; then
+              echo "--- Realtime container status ---"
+              docker inspect --format='{{.State.Status}} exit={{.State.ExitCode}} err={{.State.Error}} oom={{.State.OOMKilled}} restart={{.RestartCount}}' "${realtime_container_id}" || true
+              echo "--- Realtime container logs (last 200 lines) ---"
+              docker logs --tail 200 "${realtime_container_id}" || true
+            fi
             exit 1
           fi
           echo "Waiting for MinIO container to be ready..."

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -299,14 +299,17 @@ jobs:
         run: |
           echo "Waiting for Realtime container to be ready..."
           JWT_SECRET="super-secret-jwt-token-with-at-least-32-characters-long"
+          # Realtime v2.109 validates Bearer tokens as HS256 JWTs signed with API_JWT_SECRET;
+          # passing the raw secret returns 403. Sign an admin JWT for the health probe.
+          REALTIME_ADMIN_TOKEN="$(JWT_SECRET="${JWT_SECRET}" node -e 'const crypto=require("node:crypto");const s=process.env.JWT_SECRET;const n=Math.floor(Date.now()/1000);const e=v=>Buffer.from(JSON.stringify(v)).toString("base64url");const h=e({alg:"HS256",typ:"JWT"});const p=e({iss:"supabase",role:"supabase_admin",iat:n,exp:n+3600});const sig=crypto.createHmac("sha256",s).update(`${h}.${p}`).digest("base64url");console.log(`${h}.${p}.${sig}`);')"
           realtime_ready=false
           for i in $(seq 1 60); do
             # Check the health endpoint for the self-seeded tenant
-            if curl -sf -H "Authorization: Bearer ${JWT_SECRET}" "http://127.0.0.1:4000/api/tenants/realtime-dev/health" > /dev/null 2>&1; then
+            if curl -sf -H "Authorization: Bearer ${REALTIME_ADMIN_TOKEN}" "http://127.0.0.1:4000/api/tenants/realtime-dev/health" > /dev/null 2>&1; then
               echo "✅ Realtime self-hosted tenant is ready"
               realtime_ready=true
               break
-            elif curl -sf "http://127.0.0.1:4000/health" > /dev/null 2>&1; then
+            elif curl -sf "http://127.0.0.1:4000/healthcheck" > /dev/null 2>&1; then
               echo "✅ Realtime container is ready (basic health)"
               realtime_ready=true
               break

--- a/packages/management-api/src/api.test.ts
+++ b/packages/management-api/src/api.test.ts
@@ -26,7 +26,6 @@ describe("Management API Integration Tests", () => {
 
     beforeAll(async () => {
         const routes = await registerAllRoutes();
-        // @ts-expect-error TS2589: Elysia type inference depth limit in testing
         app = baseApp.use(routes as unknown as typeof baseApp);
     });
 

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1,4 +1,5 @@
 import { Elysia, t } from "elysia";
+import type { AnyElysia } from "elysia";
 import { logger } from "./utils/logger";
 
 process.on("uncaughtException", (err: Error) => {
@@ -595,7 +596,7 @@ export function registerStaticAssets() {
 /**
  * Register all route modules
  */
-export async function registerAllRoutes() {
+export async function registerAllRoutes(): Promise<AnyElysia> {
   const {
     projectRoutes,
     projectDashboardRoutes: registeredProjectDashboardRoutes,
@@ -639,6 +640,8 @@ export async function registerAllRoutes() {
     storageS3Routes,
     autoBranchingRoutes,
     projectRbacRoutes,
+    projectWebhookRoutes,
+    projectAuditRoutes,
   } = await import("./routes");
 
   return (
@@ -735,7 +738,9 @@ export async function registerAllRoutes() {
       .use(storageS3Routes)
       .use(autoBranchingRoutes)
       .use(projectRbacRoutes)
-  );
+      .use(projectWebhookRoutes)
+      .use(projectAuditRoutes)
+  ) as AnyElysia;
 }
 
 function readArgValue(...names: string[]) {

--- a/packages/management-api/src/routes/index.ts
+++ b/packages/management-api/src/routes/index.ts
@@ -39,3 +39,5 @@ export { pgMetaRoutes } from "./pg-meta";
 export { storageS3Routes } from "./storage-s3";
 export { autoBranchingRoutes } from "./auto-branching";
 export { projectRbacRoutes } from "./project-rbac";
+export { projectWebhookRoutes } from "./project-webhooks";
+export { projectAuditRoutes } from "./project-audit";

--- a/packages/management-api/src/routes/log-drains.ts
+++ b/packages/management-api/src/routes/log-drains.ts
@@ -105,7 +105,7 @@ export function validateLogDrainUrl(urlValue: string): { ok: true; url: string }
   return { ok: true, url: parsed.toString() };
 }
 
-async function isLogDrainUrlSafeForFetch(urlValue: string): Promise<boolean> {
+export async function isLogDrainUrlSafeForFetch(urlValue: string): Promise<boolean> {
   const validated = validateLogDrainUrl(urlValue);
   if (!validated.ok) return false;
 

--- a/packages/management-api/src/routes/project-audit.ts
+++ b/packages/management-api/src/routes/project-audit.ts
@@ -1,0 +1,181 @@
+import { Elysia, status, t } from "elysia";
+import { sql } from "../db";
+import { requireProjectOrAdminAuth } from "../middleware/auth";
+
+interface AuditLogRow {
+  id: string;
+  project_ref: string | null;
+  actor: string;
+  action: string;
+  method: string;
+  path: string;
+  status: number | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  request_id: string | null;
+  metadata: Record<string, unknown> | string | null;
+  created_at: Date | string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseMetadata(value: AuditLogRow["metadata"]): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      return isRecord(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function stringFromMetadata(metadata: Record<string, unknown>, key: string): string | null {
+  const value = metadata[key];
+  return typeof value === "string" && value ? value : null;
+}
+
+function toAuditEntry(row: AuditLogRow) {
+  const metadata = parseMetadata(row.metadata);
+  const details = isRecord(metadata.details) ? metadata.details : metadata;
+  return {
+    id: row.id,
+    project_ref: row.project_ref,
+    event_type: row.action,
+    actor_id: stringFromMetadata(metadata, "actor_id") || row.actor,
+    actor_type: stringFromMetadata(metadata, "actor_type") || "system",
+    resource_type: stringFromMetadata(metadata, "resource_type") || "management_api",
+    resource_id: stringFromMetadata(metadata, "resource_id") || row.path,
+    details,
+    method: row.method,
+    path: row.path,
+    status: row.status,
+    request_id: row.request_id,
+    created_at: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+  };
+}
+
+function parseLimit(value: unknown, fallback: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(Math.trunc(parsed), 1), max);
+}
+
+function parseOffset(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(Math.trunc(parsed), 0);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export const projectAuditRoutes = new Elysia({ prefix: "/v1/projects/:ref/audit" })
+  .onBeforeHandle(async ({ params, request }) => {
+    const authError = await requireProjectOrAdminAuth(request, params.ref);
+    if (authError) return status(authError.status, authError.body);
+  })
+  .get("", async ({ params, query }) => {
+    const eventType = optionalString(query.event_type);
+    const resourceType = optionalString(query.resource_type);
+    const resourceId = optionalString(query.resource_id);
+    const actorId = optionalString(query.actor_id);
+    const from = optionalString(query.from);
+    const to = optionalString(query.to);
+    const limit = parseLimit(query.limit, 100, 200);
+    const offset = parseOffset(query.offset);
+
+    const rows = await sql`
+      SELECT id, project_ref, actor, action, method, path, status, ip_address, user_agent, request_id, metadata, created_at
+      FROM audit_logs
+      WHERE project_ref = ${params.ref}
+        AND (${eventType}::text IS NULL OR action = ${eventType})
+        AND (${resourceType}::text IS NULL OR metadata->>'resource_type' = ${resourceType})
+        AND (${resourceId}::text IS NULL OR metadata->>'resource_id' = ${resourceId})
+        AND (${actorId}::text IS NULL OR metadata->>'actor_id' = ${actorId} OR actor = ${actorId})
+        AND (${from}::timestamptz IS NULL OR created_at >= ${from}::timestamptz)
+        AND (${to}::timestamptz IS NULL OR created_at <= ${to}::timestamptz)
+      ORDER BY created_at DESC
+      LIMIT ${limit}
+      OFFSET ${offset}
+    ` as AuditLogRow[];
+
+    const items = rows.map(toAuditEntry);
+    return { items, total: items.length };
+  }, {
+    query: t.Object({
+      event_type: t.Optional(t.String()),
+      resource_type: t.Optional(t.String()),
+      resource_id: t.Optional(t.String()),
+      actor_id: t.Optional(t.String()),
+      limit: t.Optional(t.String()),
+      offset: t.Optional(t.String()),
+      from: t.Optional(t.String()),
+      to: t.Optional(t.String()),
+    }, { additionalProperties: true }),
+    detail: { tags: ["audit"], summary: "Query project audit logs" },
+  })
+  .post("/events", async ({ params, body }) => {
+    const input = body as {
+      event_type: string;
+      actor_id?: string | null;
+      actor_type?: string | null;
+      resource_type: string;
+      resource_id: string;
+      details?: Record<string, unknown>;
+    };
+    if (!input.event_type?.trim()) return status(400, { message: "event_type is required", code: "400" });
+    if (!input.resource_type?.trim()) return status(400, { message: "resource_type is required", code: "400" });
+    if (!input.resource_id?.trim()) return status(400, { message: "resource_id is required", code: "400" });
+
+    const requestId = crypto.randomUUID();
+    const metadata = {
+      actor_id: input.actor_id || null,
+      actor_type: input.actor_type || "system",
+      resource_type: input.resource_type,
+      resource_id: input.resource_id,
+      details: isRecord(input.details) ? input.details : {},
+    };
+    const rows = await sql`
+      INSERT INTO audit_logs (project_ref, actor, action, method, path, status, request_id, metadata)
+      VALUES (
+        ${params.ref},
+        ${input.actor_id || input.actor_type || "system"},
+        ${input.event_type},
+        ${"EVENT"},
+        ${`/v1/projects/${params.ref}/audit/events`},
+        ${200},
+        ${requestId},
+        ${JSON.stringify(metadata)}::jsonb
+      )
+      RETURNING id, project_ref, actor, action, method, path, status, ip_address, user_agent, request_id, metadata, created_at
+    ` as AuditLogRow[];
+    return toAuditEntry(rows[0]);
+  }, {
+    body: t.Object({
+      event_type: t.String(),
+      actor_id: t.Optional(t.Nullable(t.String())),
+      actor_type: t.Optional(t.Nullable(t.String())),
+      resource_type: t.String(),
+      resource_id: t.String(),
+      details: t.Optional(t.Record(t.String(), t.Unknown())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["audit"], summary: "Record a project audit event" },
+  })
+  .get("/:logId", async ({ params }) => {
+    const rows = await sql`
+      SELECT id, project_ref, actor, action, method, path, status, ip_address, user_agent, request_id, metadata, created_at
+      FROM audit_logs
+      WHERE project_ref = ${params.ref} AND id = ${params.logId}
+      LIMIT 1
+    ` as AuditLogRow[];
+    if (!rows[0]) return status(404, { message: "Audit log not found", code: "404" });
+    return toAuditEntry(rows[0]);
+  }, {
+    detail: { tags: ["audit"], summary: "Get a project audit log entry" },
+  });

--- a/packages/management-api/src/routes/project-webhooks.ts
+++ b/packages/management-api/src/routes/project-webhooks.ts
@@ -1,0 +1,409 @@
+import { Elysia, status, t } from "elysia";
+import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { projectRepository } from "../repositories/project.repository";
+import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-config";
+import { isLogDrainUrlSafeForFetch, validateLogDrainUrl } from "./log-drains";
+
+interface ProjectWebhook {
+  id: string;
+  url: string;
+  events: string[];
+  secret: string;
+  signing_key_id?: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface WebhookDeliveryLog {
+  id: string;
+  webhook_id: string;
+  event: string;
+  status: "delivered" | "failed";
+  status_code?: number;
+  error?: string;
+  created_at: string;
+}
+
+const MAX_WEBHOOKS_PER_PROJECT = 50;
+const MAX_DELIVERY_LOGS_PER_PROJECT = 200;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function randomSecret(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return `whsec_${Array.from(bytes).map((byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function readWebhooks(configValue: unknown): ProjectWebhook[] {
+  const config = normalizeProjectConfig(configValue);
+  const raw = config.webhooks;
+  if (!Array.isArray(raw)) return [];
+
+  return raw.filter((item): item is ProjectWebhook => {
+    if (!isRecord(item)) return false;
+    return typeof item.id === "string"
+      && typeof item.url === "string"
+      && Array.isArray(item.events)
+      && item.events.every((event) => typeof event === "string")
+      && typeof item.secret === "string"
+      && typeof item.enabled === "boolean"
+      && typeof item.created_at === "string"
+      && typeof item.updated_at === "string";
+  });
+}
+
+function readDeliveryLogs(configValue: unknown): WebhookDeliveryLog[] {
+  const config = normalizeProjectConfig(configValue);
+  const raw = config.webhook_delivery_logs;
+  if (!Array.isArray(raw)) return [];
+
+  return raw.filter((item): item is WebhookDeliveryLog => {
+    if (!isRecord(item)) return false;
+    return typeof item.id === "string"
+      && typeof item.webhook_id === "string"
+      && typeof item.event === "string"
+      && (item.status === "delivered" || item.status === "failed")
+      && typeof item.created_at === "string";
+  });
+}
+
+function publicWebhook(webhook: ProjectWebhook) {
+  return {
+    id: webhook.id,
+    url: webhook.url,
+    events: webhook.events,
+    signing_key_id: webhook.signing_key_id,
+    enabled: webhook.enabled,
+    has_secret: !!webhook.secret,
+    created_at: webhook.created_at,
+    updated_at: webhook.updated_at,
+  };
+}
+
+function findWebhook(webhooks: ProjectWebhook[], webhookId: string): ProjectWebhook | null {
+  return webhooks.find((webhook) => webhook.id === webhookId) || null;
+}
+
+async function signPayload(secret: string, payload: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  const hex = Array.from(new Uint8Array(signature)).map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `sha256=${hex}`;
+}
+
+async function saveWebhookState(
+  ref: string,
+  projectConfig: unknown,
+  webhooks: ProjectWebhook[],
+  logs: WebhookDeliveryLog[],
+) {
+  const updated = await projectRepository.updateConfig(
+    ref,
+    mergeProjectConfig(projectConfig, {
+      webhooks,
+      webhook_delivery_logs: logs.slice(0, MAX_DELIVERY_LOGS_PER_PROJECT),
+    }),
+  );
+  if (!updated) return null;
+  return updated;
+}
+
+async function deliverWebhook(
+  ref: string,
+  webhook: ProjectWebhook,
+  event: string,
+  payload: Record<string, unknown>,
+): Promise<{ ok: boolean; status?: number; error?: string; log: WebhookDeliveryLog }> {
+  const body = JSON.stringify({
+    type: event,
+    payload,
+    timestamp: nowIso(),
+    webhook_id: webhook.id,
+    project_ref: ref,
+  });
+  const createdAt = nowIso();
+
+  try {
+    if (!(await isLogDrainUrlSafeForFetch(webhook.url))) {
+      const log: WebhookDeliveryLog = {
+        id: crypto.randomUUID(),
+        webhook_id: webhook.id,
+        event,
+        status: "failed",
+        error: "webhook url is not allowed",
+        created_at: createdAt,
+      };
+      return { ok: false, error: log.error, log };
+    }
+
+    const signature = await signPayload(webhook.secret, body);
+    const response = await fetch(webhook.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-SupaCloud-Webhook-Id": webhook.id,
+        "X-SupaCloud-Event": event,
+        "X-SupaCloud-Signature": signature,
+      },
+      body,
+      signal: AbortSignal.timeout(5000),
+    });
+    const log: WebhookDeliveryLog = {
+      id: crypto.randomUUID(),
+      webhook_id: webhook.id,
+      event,
+      status: response.ok ? "delivered" : "failed",
+      status_code: response.status,
+      created_at: createdAt,
+    };
+    return { ok: response.ok, status: response.status, log };
+  } catch (error) {
+    const log: WebhookDeliveryLog = {
+      id: crypto.randomUUID(),
+      webhook_id: webhook.id,
+      event,
+      status: "failed",
+      error: error instanceof Error ? error.message : String(error),
+      created_at: createdAt,
+    };
+    return { ok: false, error: log.error, log };
+  }
+}
+
+function eventMatches(webhook: ProjectWebhook, event: string): boolean {
+  return webhook.enabled && (webhook.events.includes("*") || webhook.events.includes(event));
+}
+
+function normalizeEvents(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((event) => String(event).trim()).filter(Boolean);
+}
+
+export const projectWebhookRoutes = new Elysia({ prefix: "/v1/projects/:ref/webhooks" })
+  .onBeforeHandle(async ({ params, request }) => {
+    const authError = await requireProjectOrAdminAuth(request, params.ref);
+    if (authError) return status(authError.status, authError.body);
+  })
+  .get("", async ({ params }) => {
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+
+    const items = readWebhooks(project.config).map(publicWebhook);
+    return { items, total: items.length };
+  }, {
+    detail: { tags: ["webhooks"], summary: "List project webhooks" },
+  })
+  .post("", async ({ params, body }) => {
+    const input = body as { url: string; events: string[]; enabled?: boolean; signing_key_id?: string };
+    const urlResult = validateLogDrainUrl(input.url || "");
+    if (!urlResult.ok) return status(400, { message: urlResult.error, code: "400" });
+
+    const events = normalizeEvents(input.events);
+    if (events.length === 0) return status(400, { message: "events must not be empty", code: "400" });
+
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+
+    const existing = readWebhooks(project.config);
+    if (existing.length >= MAX_WEBHOOKS_PER_PROJECT) {
+      return status(400, { message: `A project can have at most ${MAX_WEBHOOKS_PER_PROJECT} webhooks`, code: "400" });
+    }
+
+    const timestamp = nowIso();
+    const webhook: ProjectWebhook = {
+      id: crypto.randomUUID(),
+      url: urlResult.url,
+      events,
+      secret: randomSecret(),
+      signing_key_id: input.signing_key_id,
+      enabled: input.enabled ?? true,
+      created_at: timestamp,
+      updated_at: timestamp,
+    };
+
+    const updated = await saveWebhookState(params.ref, project.config, [...existing, webhook], readDeliveryLogs(project.config));
+    if (!updated) return status(404, { message: "Project not found", code: "404" });
+
+    return { ...publicWebhook(webhook), secret: webhook.secret };
+  }, {
+    body: t.Object({
+      url: t.String(),
+      events: t.Array(t.String()),
+      enabled: t.Optional(t.Boolean()),
+      signing_key_id: t.Optional(t.String()),
+    }, { additionalProperties: true }),
+    detail: { tags: ["webhooks"], summary: "Create a project webhook" },
+  })
+  .post("/events", async ({ params, body }) => {
+    const input = body as { event?: string; type?: string; payload?: Record<string, unknown> };
+    const event = String(input.event || input.type || "").trim();
+    if (!event) return status(400, { message: "event or type is required", code: "400" });
+
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+
+    const webhooks = readWebhooks(project.config);
+    const targets = webhooks.filter((webhook) => eventMatches(webhook, event));
+    const results = await Promise.all(targets.map((webhook) =>
+      deliverWebhook(params.ref, webhook, event, input.payload || {}),
+    ));
+    const logs = [...results.map((result) => result.log), ...readDeliveryLogs(project.config)];
+    await saveWebhookState(params.ref, project.config, webhooks, logs);
+    return {
+      queued: true,
+      delivered: results.filter((result) => result.ok).length,
+      failed: results.filter((result) => !result.ok).length,
+      total: results.length,
+    };
+  }, {
+    body: t.Object({
+      event: t.Optional(t.String()),
+      type: t.Optional(t.String()),
+      payload: t.Optional(t.Record(t.String(), t.Unknown())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["webhooks"], summary: "Enqueue a project webhook event" },
+  })
+  .get("/:webhookId/logs", async ({ params, query }) => {
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+    const limit = Math.min(Math.max(Number(query.limit || 50), 1), 100);
+    const items = readDeliveryLogs(project.config)
+      .filter((log) => log.webhook_id === params.webhookId)
+      .slice(0, limit);
+    return { items, total: items.length };
+  }, {
+    query: t.Object({ limit: t.Optional(t.String()) }, { additionalProperties: true }),
+    detail: { tags: ["webhooks"], summary: "List project webhook delivery logs" },
+  })
+  .post("/:webhookId/rotate-secret", async ({ params }) => {
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+    const webhooks = readWebhooks(project.config);
+    const webhook = findWebhook(webhooks, params.webhookId);
+    if (!webhook) return status(404, { message: "Webhook not found", code: "404" });
+
+    const nextSecret = randomSecret();
+    const updatedWebhook = { ...webhook, secret: nextSecret, updated_at: nowIso() };
+    const updatedWebhooks = webhooks.map((item) => item.id === webhook.id ? updatedWebhook : item);
+    const updated = await saveWebhookState(params.ref, project.config, updatedWebhooks, readDeliveryLogs(project.config));
+    if (!updated) return status(404, { message: "Project not found", code: "404" });
+
+    return { ...publicWebhook(updatedWebhook), secret: nextSecret };
+  }, {
+    detail: { tags: ["webhooks"], summary: "Rotate project webhook secret" },
+  })
+  .post("/:webhookId/test", async ({ params, body }) => {
+    const input = body as { event?: string; payload?: Record<string, unknown> };
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+    const webhooks = readWebhooks(project.config);
+    const webhook = findWebhook(webhooks, params.webhookId);
+    if (!webhook) return status(404, { message: "Webhook not found", code: "404" });
+
+    const result = await deliverWebhook(
+      params.ref,
+      webhook,
+      input.event || "webhook.test",
+      input.payload || {},
+    );
+    await saveWebhookState(params.ref, project.config, webhooks, [result.log, ...readDeliveryLogs(project.config)]);
+    return { ok: result.ok, status: result.status, error: result.error };
+  }, {
+    body: t.Object({
+      event: t.Optional(t.String()),
+      payload: t.Optional(t.Record(t.String(), t.Unknown())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["webhooks"], summary: "Send a project webhook test event" },
+  })
+  .post("/:webhookId/replay", async ({ params, body }) => {
+    const input = body as { event: string; payload?: Record<string, unknown> };
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+    const webhooks = readWebhooks(project.config);
+    const webhook = findWebhook(webhooks, params.webhookId);
+    if (!webhook) return status(404, { message: "Webhook not found", code: "404" });
+
+    const result = await deliverWebhook(params.ref, webhook, input.event, input.payload || {});
+    await saveWebhookState(params.ref, project.config, webhooks, [result.log, ...readDeliveryLogs(project.config)]);
+    return { ok: result.ok, status: result.status, error: result.error };
+  }, {
+    body: t.Object({
+      event: t.String(),
+      payload: t.Optional(t.Record(t.String(), t.Unknown())),
+    }, { additionalProperties: true }),
+    detail: { tags: ["webhooks"], summary: "Replay a project webhook event" },
+  })
+  .get("/:webhookId", async ({ params }) => {
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+    const webhook = findWebhook(readWebhooks(project.config), params.webhookId);
+    if (!webhook) return status(404, { message: "Webhook not found", code: "404" });
+    return publicWebhook(webhook);
+  }, {
+    detail: { tags: ["webhooks"], summary: "Get a project webhook" },
+  })
+  .put("/:webhookId", async ({ params, body }) => {
+    const input = body as { url?: string; events?: string[]; enabled?: boolean; signing_key_id?: string };
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+    const webhooks = readWebhooks(project.config);
+    const webhook = findWebhook(webhooks, params.webhookId);
+    if (!webhook) return status(404, { message: "Webhook not found", code: "404" });
+
+    let nextUrl = webhook.url;
+    if (input.url !== undefined) {
+      const urlResult = validateLogDrainUrl(input.url);
+      if (!urlResult.ok) return status(400, { message: urlResult.error, code: "400" });
+      nextUrl = urlResult.url;
+    }
+    const nextEvents = input.events !== undefined ? normalizeEvents(input.events) : webhook.events;
+    if (nextEvents.length === 0) return status(400, { message: "events must not be empty", code: "400" });
+
+    const updatedWebhook: ProjectWebhook = {
+      ...webhook,
+      url: nextUrl,
+      events: nextEvents,
+      enabled: input.enabled ?? webhook.enabled,
+      signing_key_id: input.signing_key_id ?? webhook.signing_key_id,
+      updated_at: nowIso(),
+    };
+    const updatedWebhooks = webhooks.map((item) => item.id === webhook.id ? updatedWebhook : item);
+    const updated = await saveWebhookState(params.ref, project.config, updatedWebhooks, readDeliveryLogs(project.config));
+    if (!updated) return status(404, { message: "Project not found", code: "404" });
+    return publicWebhook(updatedWebhook);
+  }, {
+    body: t.Object({
+      url: t.Optional(t.String()),
+      events: t.Optional(t.Array(t.String())),
+      enabled: t.Optional(t.Boolean()),
+      signing_key_id: t.Optional(t.String()),
+    }, { additionalProperties: true }),
+    detail: { tags: ["webhooks"], summary: "Update a project webhook" },
+  })
+  .delete("/:webhookId", async ({ params }) => {
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { message: "Project not found", code: "404" });
+    const webhooks = readWebhooks(project.config);
+    const webhook = findWebhook(webhooks, params.webhookId);
+    if (!webhook) return status(404, { message: "Webhook not found", code: "404" });
+    const logs = readDeliveryLogs(project.config).filter((log) => log.webhook_id !== webhook.id);
+    const updated = await saveWebhookState(params.ref, project.config, webhooks.filter((item) => item.id !== webhook.id), logs);
+    if (!updated) return status(404, { message: "Project not found", code: "404" });
+    return { deleted: true, webhook_id: webhook.id };
+  }, {
+    detail: { tags: ["webhooks"], summary: "Delete a project webhook" },
+  });

--- a/packages/management-api/tests/scripts/ci-tenant-bridge.ts
+++ b/packages/management-api/tests/scripts/ci-tenant-bridge.ts
@@ -255,7 +255,7 @@ export async function setupCiBridge(sql: InstanceType<typeof SQL>): Promise<{
       const realtimeService = new RealtimeService();
       await realtimeService.ensureSupabaseAdminReplication();
       let registered = false;
-      for (let attempt = 1; attempt <= 5; attempt++) {
+      for (let attempt = 1; attempt <= 30; attempt++) {
         registered = await realtimeService.registerTenant({
           projectRef: CI_TENANT_REF,
           dbName: "postgres",
@@ -264,13 +264,13 @@ export async function setupCiBridge(sql: InstanceType<typeof SQL>): Promise<{
           jwtSecret: CI_JWT_SECRET,
         });
         if (registered) break;
-        console.warn(`[CIBridge] Realtime registration attempt ${attempt}/5 failed, retrying in 2s...`);
+        console.warn(`[CIBridge] Realtime registration attempt ${attempt}/30 failed, retrying in 2s...`);
         await new Promise((r) => setTimeout(r, 2000));
       }
       if (registered) {
         console.log("[CIBridge] Realtime tenant registered.");
       } else {
-        console.warn("[CIBridge] Realtime tenant registration failed after 5 attempts.");
+        throw new Error("[CIBridge] Realtime tenant registration failed after 30 attempts.");
       }
     } catch (e: any) {
       console.warn("[CIBridge] Realtime tenant registration error:", e.message?.substring(0, 80));

--- a/packages/management-api/tests/scripts/run-official-sdk-compliance.ts
+++ b/packages/management-api/tests/scripts/run-official-sdk-compliance.ts
@@ -74,7 +74,7 @@ async function bootstrap() {
       const realtimeService = new RealtimeService();
       await realtimeService.ensureSupabaseAdminReplication();
       let registered = false;
-      for (let attempt = 1; attempt <= 5; attempt++) {
+      for (let attempt = 1; attempt <= 30; attempt++) {
         registered = await realtimeService.registerTenant({
           projectRef: project.ref,
           dbName: "postgres",
@@ -83,13 +83,13 @@ async function bootstrap() {
           jwtSecret: OFFICIAL_JWT_SECRET,
         });
         if (registered) break;
-        console.warn(`[SDK Compliance] Realtime registration attempt ${attempt}/5 failed, retrying in 2s...`);
+        console.warn(`[SDK Compliance] Realtime registration attempt ${attempt}/30 failed, retrying in 2s...`);
         await new Promise((r) => setTimeout(r, 2000));
       }
       if (registered) {
         console.log(`✅ Realtime tenant registered for [${project.ref}]`);
       } else {
-        console.warn(`⚠️ Realtime tenant registration failed for [${project.ref}] after 5 attempts`);
+        throw new Error(`Realtime tenant registration failed for [${project.ref}] after 30 attempts`);
       }
     } catch (e: any) {
       console.warn("⚠️ Realtime tenant registration error:", e.message?.substring(0, 80));

--- a/packages/management-api/tests/unit/project-audit.routes.test.ts
+++ b/packages/management-api/tests/unit/project-audit.routes.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const sqlCalls: string[] = [];
+const insertedRows: Array<Record<string, unknown>> = [];
+
+const sqlMock = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+  const text = strings.join("?");
+  sqlCalls.push(text);
+  if (text.includes("INSERT INTO audit_logs")) {
+    const metadata = JSON.parse(String(values[7] || "{}")) as Record<string, unknown>;
+    const row = {
+      id: "audit-new",
+      project_ref: values[0],
+      actor: values[1],
+      action: values[2],
+      method: values[3],
+      path: values[4],
+      status: values[5],
+      ip_address: null,
+      user_agent: "",
+      request_id: values[6],
+      metadata,
+      created_at: new Date("2026-06-18T12:00:00.000Z"),
+    };
+    insertedRows.push(row);
+    return Promise.resolve([row]);
+  }
+  if (text.includes("WHERE project_ref =") && text.includes("id =")) {
+    return Promise.resolve([
+      {
+        id: "audit-one",
+        project_ref: "proj_1",
+        actor: "user-one",
+        action: "webhook.create",
+        method: "EVENT",
+        path: "/v1/projects/proj_1/audit/events",
+        status: 200,
+        ip_address: null,
+        user_agent: "",
+        request_id: "req-one",
+        metadata: {
+          actor_id: "user-one",
+          actor_type: "admin",
+          resource_type: "webhook",
+          resource_id: "wh-one",
+          details: { url: "https://example.com" },
+        },
+        created_at: new Date("2026-06-18T12:00:00.000Z"),
+      },
+    ]);
+  }
+  if (text.includes("FROM audit_logs")) {
+    return Promise.resolve([
+      {
+        id: "audit-one",
+        project_ref: "proj_1",
+        actor: "user-one",
+        action: "webhook.create",
+        method: "EVENT",
+        path: "/v1/projects/proj_1/audit/events",
+        status: 200,
+        ip_address: null,
+        user_agent: "",
+        request_id: "req-one",
+        metadata: {
+          actor_id: "user-one",
+          actor_type: "admin",
+          resource_type: "webhook",
+          resource_id: "wh-one",
+          details: { url: "https://example.com" },
+        },
+        created_at: new Date("2026-06-18T12:00:00.000Z"),
+      },
+    ]);
+  }
+  return Promise.resolve([]);
+});
+
+mock.module("../../src/db", () => ({ sql: sqlMock }));
+
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+const authModule = await import("../../src/middleware/auth");
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+
+const { projectAuditRoutes } = await import("../../src/routes/project-audit");
+const app = new Elysia().use(projectAuditRoutes);
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer dev-master-token",
+        ...(init.headers || {}),
+      },
+    }),
+  );
+}
+
+describe("projectAuditRoutes", () => {
+  afterAll(() => {
+    requireProjectOrAdminAuthSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    sqlCalls.length = 0;
+    insertedRows.length = 0;
+    sqlMock.mockClear();
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+  });
+
+  test("queries project audit logs with SupAuth-compatible fields", async () => {
+    const res = await request("/v1/projects/proj_1/audit?event_type=webhook.create&resource_type=webhook&limit=5");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { items: Array<Record<string, unknown>>; total: number };
+    expect(body.total).toBe(1);
+    expect(body.items[0]).toMatchObject({
+      id: "audit-one",
+      event_type: "webhook.create",
+      actor_id: "user-one",
+      actor_type: "admin",
+      resource_type: "webhook",
+      resource_id: "wh-one",
+    });
+    expect(sqlCalls.at(-1)).toContain("FROM audit_logs");
+  });
+
+  test("gets one audit log and records product audit events", async () => {
+    const detail = await request("/v1/projects/proj_1/audit/audit-one");
+    expect(detail.status).toBe(200);
+    expect(await detail.json()).toMatchObject({ id: "audit-one", event_type: "webhook.create" });
+
+    const create = await request("/v1/projects/proj_1/audit/events", {
+      method: "POST",
+      body: JSON.stringify({
+        event_type: "webhook.test",
+        actor_id: "admin-one",
+        actor_type: "admin",
+        resource_type: "webhook",
+        resource_id: "wh-one",
+        details: { ok: true },
+      }),
+    });
+    expect(create.status).toBe(200);
+    expect(await create.json()).toMatchObject({
+      id: "audit-new",
+      event_type: "webhook.test",
+      actor_id: "admin-one",
+      resource_type: "webhook",
+    });
+    expect(insertedRows).toHaveLength(1);
+  });
+});

--- a/packages/management-api/tests/unit/project-webhooks.routes.test.ts
+++ b/packages/management-api/tests/unit/project-webhooks.routes.test.ts
@@ -1,0 +1,181 @@
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const findByRef = mock(() => Promise.resolve(null));
+const updateConfig = mock(() => Promise.resolve(null));
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+
+const { projectRepository } = await import("../../src/repositories/project.repository");
+const authModule = await import("../../src/middleware/auth");
+
+const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(
+  findByRef as typeof projectRepository.findByRef,
+);
+const updateConfigSpy = spyOn(projectRepository, "updateConfig").mockImplementation(
+  updateConfig as typeof projectRepository.updateConfig,
+);
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+
+const { projectWebhookRoutes } = await import("../../src/routes/project-webhooks");
+const app = new Elysia().use(projectWebhookRoutes);
+
+type TestProject = {
+  ref: string;
+  config: Record<string, unknown>;
+};
+
+const originalFetch = globalThis.fetch;
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer dev-master-token",
+        ...(init.headers || {}),
+      },
+    }),
+  );
+}
+
+describe("projectWebhookRoutes", () => {
+  let storedConfig: Record<string, unknown>;
+  const delivered: Array<{ url: string; body: Record<string, unknown>; headers: Record<string, string> }> = [];
+
+  afterAll(() => {
+    findByRefSpy.mockRestore();
+    updateConfigSpy.mockRestore();
+    requireProjectOrAdminAuthSpy.mockRestore();
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    storedConfig = {};
+    delivered.length = 0;
+    findByRef.mockReset();
+    updateConfig.mockReset();
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+    findByRef.mockImplementation(async () => ({ ref: "proj_1", config: storedConfig }) as TestProject as never);
+    updateConfig.mockImplementation(async (_ref, nextConfig) => {
+      storedConfig = nextConfig;
+      return { ref: "proj_1", config: storedConfig } as TestProject as never;
+    });
+    globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      delivered.push({
+        url,
+        body: JSON.parse(String(init?.body || "{}")) as Record<string, unknown>,
+        headers: init?.headers as Record<string, string>,
+      });
+      return Response.json({ ok: true }, { status: 202 });
+    }) as unknown as typeof fetch;
+  });
+
+  test("creates, lists, updates, rotates, and deletes project webhooks", async () => {
+    const create = await request("/v1/projects/proj_1/webhooks", {
+      method: "POST",
+      body: JSON.stringify({ url: "https://1.1.1.1/webhook", events: ["user.created"], enabled: true }),
+    });
+    expect(create.status).toBe(200);
+    const created = await create.json() as { id: string; secret: string; has_secret: boolean };
+    expect(created.id).toBeTruthy();
+    expect(created.secret).toMatch(/^whsec_/);
+    expect(created.has_secret).toBe(true);
+
+    const list = await request("/v1/projects/proj_1/webhooks");
+    expect(await list.json()).toMatchObject({
+      total: 1,
+      items: [{ id: created.id, url: "https://1.1.1.1/webhook", has_secret: true }],
+    });
+
+    const update = await request(`/v1/projects/proj_1/webhooks/${created.id}`, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: false, events: ["*"] }),
+    });
+    expect(update.status).toBe(200);
+    expect(await update.json()).toMatchObject({ id: created.id, enabled: false, events: ["*"] });
+
+    const rotate = await request(`/v1/projects/proj_1/webhooks/${created.id}/rotate-secret`, { method: "POST" });
+    expect(rotate.status).toBe(200);
+    const rotated = await rotate.json() as { secret: string };
+    expect(rotated.secret).toMatch(/^whsec_/);
+    expect(rotated.secret).not.toBe(created.secret);
+
+    const remove = await request(`/v1/projects/proj_1/webhooks/${created.id}`, { method: "DELETE" });
+    expect(remove.status).toBe(200);
+    expect(await request("/v1/projects/proj_1/webhooks").then((res) => res.json())).toMatchObject({ items: [], total: 0 });
+  });
+
+  test("delivers test and event payloads and exposes delivery logs", async () => {
+    const created = await (await request("/v1/projects/proj_1/webhooks", {
+      method: "POST",
+      body: JSON.stringify({ url: "https://1.1.1.1/webhook", events: ["user.created"], enabled: true }),
+    })).json() as { id: string };
+    const second = await (await request("/v1/projects/proj_1/webhooks", {
+      method: "POST",
+      body: JSON.stringify({ url: "https://1.1.1.2/webhook", events: ["user.created"], enabled: true }),
+    })).json() as { id: string };
+
+    const testDelivery = await request(`/v1/projects/proj_1/webhooks/${created.id}/test`, {
+      method: "POST",
+      body: JSON.stringify({ event: "webhook.test", payload: { source: "unit" } }),
+    });
+    expect(testDelivery.status).toBe(200);
+    expect(await testDelivery.json()).toMatchObject({ ok: true, status: 202 });
+    expect(delivered.at(-1)?.body).toMatchObject({ type: "webhook.test", payload: { source: "unit" } });
+    expect(delivered.at(-1)?.headers["X-SupaCloud-Signature"]).toMatch(/^sha256=/);
+
+    const eventDelivery = await request("/v1/projects/proj_1/webhooks/events", {
+      method: "POST",
+      body: JSON.stringify({ type: "user.created", payload: { id: "user-one" } }),
+    });
+    expect(eventDelivery.status).toBe(200);
+    expect(await eventDelivery.json()).toMatchObject({ queued: true, delivered: 2, failed: 0 });
+
+    const logs = await request(`/v1/projects/proj_1/webhooks/${created.id}/logs?limit=5`);
+    const body = await logs.json() as { items: Array<{ webhook_id: string; event: string; status: string }>; total: number };
+    expect(body.total).toBe(2);
+    expect(body.items[0]).toMatchObject({ webhook_id: created.id, event: "user.created", status: "delivered" });
+
+    const secondLogs = await request(`/v1/projects/proj_1/webhooks/${second.id}/logs?limit=5`);
+    expect(await secondLogs.json()).toMatchObject({
+      total: 1,
+      items: [{ webhook_id: second.id, event: "user.created", status: "delivered" }],
+    });
+  });
+
+  test("skips unsafe stored webhook URLs before fetch", async () => {
+    storedConfig = {
+      webhooks: [
+        {
+          id: "unsafe-webhook",
+          url: "http://127.0.0.1/internal",
+          events: ["*"],
+          secret: "whsec_test",
+          enabled: true,
+          created_at: "2026-06-18T00:00:00.000Z",
+          updated_at: "2026-06-18T00:00:00.000Z",
+        },
+      ],
+    };
+
+    const res = await request("/v1/projects/proj_1/webhooks/unsafe-webhook/test", {
+      method: "POST",
+      body: JSON.stringify({ event: "webhook.test" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: false, error: "webhook url is not allowed" });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    const logs = await request("/v1/projects/proj_1/webhooks/unsafe-webhook/logs");
+    expect(await logs.json()).toMatchObject({
+      total: 1,
+      items: [{ webhook_id: "unsafe-webhook", event: "webhook.test", status: "failed" }],
+    });
+  });
+});

--- a/packages/management-api/tests/unit/realtime-systemd.test.ts
+++ b/packages/management-api/tests/unit/realtime-systemd.test.ts
@@ -45,3 +45,25 @@ describe("Realtime systemd deployment", () => {
     );
   });
 });
+
+describe("Management API CI Realtime readiness probe", () => {
+  test("signs an admin JWT and uses the v2.109 healthcheck route", () => {
+    const workflow = readFileSync(join(repoRoot, ".github/workflows/management-api.yml"), "utf8");
+    const waitStep = workflow.slice(
+      workflow.indexOf("Waiting for Realtime container to be ready"),
+      workflow.indexOf('echo "Waiting for MinIO container to be ready..."'),
+    );
+
+    // v2.109 requires a signed HS256 JWT, not the raw JWT_SECRET string.
+    expect(waitStep).toContain("REALTIME_ADMIN_TOKEN");
+    expect(waitStep).toContain("createHmac(\"sha256\",s)");
+    expect(waitStep).toContain("Authorization: Bearer ${REALTIME_ADMIN_TOKEN}");
+
+    // /health returns 404 on v2.109; the basic health fallback uses /healthcheck.
+    expect(waitStep).toContain("http://127.0.0.1:4000/healthcheck");
+
+    // Guard against regressing to the raw-secret probe that returns 403.
+    expect(waitStep).not.toContain("Authorization: Bearer ${JWT_SECRET}");
+    expect(waitStep).not.toContain("http://127.0.0.1:4000/health\"");
+  });
+});


### PR DESCRIPTION
## Summary
- add project-scoped webhook facade routes for SupAuth Admin Console: CRUD, rotate-secret, logs, test, replay, and events
- add project-scoped audit facade routes backed by existing audit_logs without a new migration
- register both route groups in Management API and keep webhook secrets limited to create/rotate responses

## Verification
- bun test packages/management-api/tests/unit/project-webhooks.routes.test.ts packages/management-api/tests/unit/project-audit.routes.test.ts
- bun run --cwd packages/management-api typecheck
- bun run --cwd packages/management-api test:unit
- git diff --check

No production deployment in this PR.