### PR TITLE
feat(gotrue): enable tenant config hot reload

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2576,7 +2576,8 @@ EOF
         log_info "GoTrue binary already available at $GOTRUE_BIN"
     fi
 
-    if [[ ! -f /etc/systemd/system/supacloud-gotrue@.service ]]; then
+    if [[ ! -f /etc/systemd/system/supacloud-gotrue@.service ]] || \
+       ! grep -q -- '--config-dir /etc/supabase/tenants/%i_gotrue.d' /etc/systemd/system/supacloud-gotrue@.service; then
         log_info "Installing supacloud-gotrue@.service systemd template..."
         cat > /etc/systemd/system/supacloud-gotrue@.service << 'GOTRUE_SVC'
 [Unit]
@@ -2591,7 +2592,8 @@ Group=nobody
 EnvironmentFile=/etc/supabase/tenants/%i_gotrue.env
 Environment="GOMEMLIMIT=15MiB"
 Environment="GOGC=20"
-ExecStart=GOTRUE_BIN_PLACEHOLDER
+ExecStart=GOTRUE_BIN_PLACEHOLDER --config-dir /etc/supabase/tenants/%i_gotrue.d
+ExecReload=/bin/kill -USR1 $MAINPID
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=3

--- a/packages/management-api/src/services/tenant-oauth.service.ts
+++ b/packages/management-api/src/services/tenant-oauth.service.ts
@@ -7,6 +7,7 @@
 import { $ } from "bun";
 import { logger } from "../utils/logger";
 import { config } from "../config";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { OAuthProvider, OAuthProviderConfig } from "../types/oauth";
 import { OAUTH_ENV_MAPPINGS } from "../types/oauth";
@@ -14,8 +15,44 @@ import { OAUTH_ENV_MAPPINGS } from "../types/oauth";
 export class TenantOAuthService {
     private readonly TENANT_CONFIG_DIR = config.tenantConfigDir;
 
-    private async restartAndPollGoTrue(ref: string, message: string): Promise<void> {
-        await $`systemctl restart supacloud-gotrue@${ref}`.nothrow().quiet();
+    private gotrueConfigDir(ref: string): string {
+        return path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.d`);
+    }
+
+    private gotrueRuntimeEnvPath(ref: string): string {
+        return path.join(this.gotrueConfigDir(ref), "runtime.env");
+    }
+
+    private gotrueLegacyEnvPath(ref: string): string {
+        return path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`);
+    }
+
+    private async readGoTrueEnv(ref: string): Promise<string> {
+        const runtimeEnvPath = this.gotrueRuntimeEnvPath(ref);
+        if (await Bun.file(runtimeEnvPath).exists()) {
+            return Bun.file(runtimeEnvPath).text();
+        }
+
+        const legacyEnvPath = this.gotrueLegacyEnvPath(ref);
+        if (await Bun.file(legacyEnvPath).exists()) {
+            return Bun.file(legacyEnvPath).text();
+        }
+
+        throw new Error(`GoTrue config file not found for project ${ref}`);
+    }
+
+    private async writeGoTrueEnv(ref: string, content: string): Promise<void> {
+        await fs.mkdir(this.gotrueConfigDir(ref), { recursive: true });
+        await Bun.write(this.gotrueRuntimeEnvPath(ref), content);
+        // Keep the legacy flat env file in sync for older units and diagnostics.
+        await Bun.write(this.gotrueLegacyEnvPath(ref), content);
+    }
+
+    private async reloadAndPollGoTrue(ref: string, message: string): Promise<void> {
+        const reloadResult = await $`systemctl reload supacloud-gotrue@${ref}`.nothrow().quiet();
+        if (reloadResult.exitCode !== 0) {
+            await $`systemctl restart supacloud-gotrue@${ref}`.nothrow().quiet();
+        }
         logger.info(message);
 
         try {
@@ -36,14 +73,7 @@ export class TenantOAuthService {
     }
 
     async updateOAuthConfig(ref: string, provider: OAuthProvider, providerConfig: OAuthProviderConfig): Promise<void> {
-        const gotrueEnvPath = path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`);
-
-        const exists = await Bun.file(gotrueEnvPath).exists();
-        if (!exists) {
-            throw new Error(`GoTrue config file not found for project ${ref}`);
-        }
-
-        const envContent = await Bun.file(gotrueEnvPath).text();
+        const envContent = await this.readGoTrueEnv(ref);
 
         const mapping = OAUTH_ENV_MAPPINGS[provider];
         if (!mapping) {
@@ -114,17 +144,17 @@ export class TenantOAuthService {
             updatedLines.push(...newLines);
         }
 
-        await Bun.write(gotrueEnvPath, updatedLines.join("\n"));
-        await this.restartAndPollGoTrue(ref, `OAuth config updated for ${provider} in project ${ref}`);
+        await this.writeGoTrueEnv(ref, updatedLines.join("\n"));
+        await this.reloadAndPollGoTrue(ref, `OAuth config updated for ${provider} in project ${ref}`);
     }
 
     async removeOAuthConfig(ref: string, provider: OAuthProvider): Promise<void> {
-        const gotrueEnvPath = path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`);
-
-        const exists = await Bun.file(gotrueEnvPath).exists();
-        if (!exists) return;
-
-        const envContent = await Bun.file(gotrueEnvPath).text();
+        let envContent: string;
+        try {
+            envContent = await this.readGoTrueEnv(ref);
+        } catch {
+            return;
+        }
 
         const mapping = OAUTH_ENV_MAPPINGS[provider];
         if (!mapping) {
@@ -138,6 +168,7 @@ export class TenantOAuthService {
 
         const lines = envContent.split("\n");
         const updatedLines: string[] = [];
+        let wroteDisabledFlag = false;
 
         for (const line of lines) {
             const trimmed = line.trim();
@@ -147,12 +178,23 @@ export class TenantOAuthService {
             }
             const [key] = trimmed.split("=");
             const keyTrimmed = key?.trim();
+            if (keyTrimmed === enabledKey) {
+                updatedLines.push(`${enabledKey}=false`);
+                wroteDisabledFlag = true;
+                continue;
+            }
             if (keyTrimmed && keysToRemove.has(keyTrimmed)) continue;
             updatedLines.push(line);
         }
 
-        await Bun.write(gotrueEnvPath, updatedLines.join("\n"));
-        await this.restartAndPollGoTrue(ref, `OAuth config removed for ${provider} in project ${ref}`);
+        if (!wroteDisabledFlag) {
+            updatedLines.push("");
+            updatedLines.push(`# OAuth Provider: ${provider}`);
+            updatedLines.push(`${enabledKey}=false`);
+        }
+
+        await this.writeGoTrueEnv(ref, updatedLines.join("\n"));
+        await this.reloadAndPollGoTrue(ref, `OAuth config removed for ${provider} in project ${ref}`);
     }
 
     async updateGoTrueCustomOAuth(ref: string, oauthConfig: {
@@ -165,14 +207,7 @@ export class TenantOAuthService {
         user_url: string;
         auth_scheme?: string;
     }): Promise<void> {
-        const gotrueEnvPath = path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`);
-
-        const exists = await Bun.file(gotrueEnvPath).exists();
-        if (!exists) {
-            throw new Error(`GoTrue config file not found for project ${ref}`);
-        }
-
-        const envContent = await Bun.file(gotrueEnvPath).text();
+        const envContent = await this.readGoTrueEnv(ref);
 
         const prefix = `GOTRUE_EXTERNAL_${oauthConfig.name.toUpperCase()}`;
         const customOAuthEnv = `
@@ -228,8 +263,8 @@ ${oauthConfig.auth_scheme ? `${prefix}_AUTH_SCHEME=${oauthConfig.auth_scheme}` :
             }
         }
 
-        await Bun.write(gotrueEnvPath, updatedLines.join("\n"));
-        await this.restartAndPollGoTrue(ref, `Custom OAuth config updated for ${oauthConfig.name} in project ${ref}`);
+        await this.writeGoTrueEnv(ref, updatedLines.join("\n"));
+        await this.reloadAndPollGoTrue(ref, `Custom OAuth config updated for ${oauthConfig.name} in project ${ref}`);
     }
 }
 

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -1313,6 +1313,8 @@ GOTRUE_JWT_AUD=authenticated
 GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
 GOTRUE_LOG_LEVEL=info
 GOTRUE_SERVER_READ_TIMEOUT=20
+GOTRUE_RELOADING_SIGNAL_ENABLED=true
+GOTRUE_RELOADING_POLLER_ENABLED=true
 GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION=true
 ${renderGoTrueAuthEnv(creds.authConfig)}
 GOTRUE_WEBAUTHN_ENABLED=true
@@ -1364,7 +1366,12 @@ GOTRUE_SMTP_SENDER_NAME=SupaCloud
 GOTRUE_MAILER_AUTOCONFIRM=true
 `;
         }
-        await Bun.write(path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`), gotrueEnv);
+        const gotrueEnvPath = path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`);
+        const gotrueConfigDir = path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.d`);
+        await fs.mkdir(gotrueConfigDir, { recursive: true });
+        await Bun.write(path.join(gotrueConfigDir, "runtime.env"), gotrueEnv);
+        // Keep the legacy flat env file for older units and diagnostics.
+        await Bun.write(gotrueEnvPath, gotrueEnv);
         await this.persistTenantPortConfig(ref, pgrstPort, gotruePort);
 
         logger.info(`Config generated for ${ref} (pgrst_port=${pgrstPort}, gotrue_port=${gotruePort})`);
@@ -1427,7 +1434,13 @@ WantedBy=multi-user.target
         }
 
         const gotrueExists = await Bun.file(gotrueUnitPath).exists();
-        if (!gotrueExists) {
+        const currentGotrueUnit = gotrueExists
+            ? await Bun.file(gotrueUnitPath).text().catch(() => "")
+            : "";
+        const shouldWriteGotrueUnit = !gotrueExists
+            || !currentGotrueUnit.includes("--config-dir")
+            || !currentGotrueUnit.includes("ExecReload=/bin/kill -USR1 $MAINPID");
+        if (shouldWriteGotrueUnit) {
             const gotrueUnit = `
 [Unit]
 Description=SupaCloud GoTrue for tenant %i
@@ -1442,7 +1455,8 @@ Group=nogroup
 EnvironmentFile=${this.TENANT_CONFIG_DIR}/%i_gotrue.env
 Environment="GOMEMLIMIT=15MiB"
 Environment="GOGC=20"
-ExecStart=${this.GOTRUE_BIN}
+ExecStart=${this.GOTRUE_BIN} --config-dir ${this.TENANT_CONFIG_DIR}/%i_gotrue.d
+ExecReload=/bin/kill -USR1 $MAINPID
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=3
@@ -1461,7 +1475,7 @@ WantedBy=multi-user.target
             await Bun.write(gotrueUnitPath, gotrueUnit);
         }
 
-        if (shouldWritePgrstUnit || !gotrueExists) {
+        if (shouldWritePgrstUnit || shouldWriteGotrueUnit) {
             await $`systemctl daemon-reload`.nothrow().quiet();
             logger.info("systemd template units installed");
         }
@@ -2037,10 +2051,12 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
         const pgrstEnvFile = Bun.file(path.join(this.TENANT_CONFIG_DIR, `${ref}.env`));
         const pgrstConfFile = Bun.file(path.join(this.TENANT_CONFIG_DIR, `${ref}.conf`));
         const gotrueEnvFile = Bun.file(path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`));
+        const gotrueConfigDir = path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.d`);
 
         if (await pgrstEnvFile.exists()) await fs.unlink(pgrstEnvFile.name!);
         if (await pgrstConfFile.exists()) await fs.unlink(pgrstConfFile.name!);
         if (await gotrueEnvFile.exists()) await fs.unlink(gotrueEnvFile.name!);
+        await fs.rm(gotrueConfigDir, { recursive: true, force: true });
     }
 
     private getPostgrestDesiredState(project: { status?: unknown; postgrest_desired?: unknown }): RuntimeDesiredState {

--- a/packages/management-api/tests/unit/tenant-runtime.ports.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.ports.test.ts
@@ -21,10 +21,12 @@ describe("TenantRuntimeService port synchronization", () => {
   test("persists generated runtime ports after tenant config is written", () => {
     const source = sourceFile("src/services/tenant-runtime.service.ts");
 
-    const gotrueEnvWrite = source.indexOf("await Bun.write(path.join(this.TENANT_CONFIG_DIR, `${ref}_gotrue.env`), gotrueEnv);");
+    const gotrueConfigDirWrite = source.indexOf('await Bun.write(path.join(gotrueConfigDir, "runtime.env"), gotrueEnv);');
+    const gotrueEnvWrite = source.indexOf("await Bun.write(gotrueEnvPath, gotrueEnv);");
     const persistPorts = source.indexOf("await this.persistTenantPortConfig(ref, pgrstPort, gotruePort);");
 
-    expect(gotrueEnvWrite).toBeGreaterThan(0);
+    expect(gotrueConfigDirWrite).toBeGreaterThan(0);
+    expect(gotrueEnvWrite).toBeGreaterThan(gotrueConfigDirWrite);
     expect(persistPorts).toBeGreaterThan(gotrueEnvWrite);
   });
 
@@ -35,5 +37,26 @@ describe("TenantRuntimeService port synchronization", () => {
     expect(source).toContain("GOTRUE_API_PORT=${port}");
     expect(source).toContain('file.endsWith(".conf")');
     expect(source).toContain("server-port\\\\s*=\\\\s*${port}");
+  });
+
+  test("starts GoTrue with a watched config directory for hot reload", () => {
+    const source = sourceFile("src/services/tenant-runtime.service.ts");
+
+    expect(source).toContain("GOTRUE_RELOADING_SIGNAL_ENABLED=true");
+    expect(source).toContain("GOTRUE_RELOADING_POLLER_ENABLED=true");
+    expect(source).toContain("ExecStart=${this.GOTRUE_BIN} --config-dir ${this.TENANT_CONFIG_DIR}/%i_gotrue.d");
+    expect(source).toContain("ExecReload=/bin/kill -USR1 $MAINPID");
+    expect(source).toContain('!currentGotrueUnit.includes("--config-dir")');
+  });
+
+  test("OAuth edits reload GoTrue and keep runtime config dir in sync", () => {
+    const source = sourceFile("src/services/tenant-oauth.service.ts");
+
+    expect(source).toContain("return path.join(this.gotrueConfigDir(ref), \"runtime.env\");");
+    expect(source).toContain("await Bun.write(this.gotrueRuntimeEnvPath(ref), content);");
+    expect(source).toContain("await Bun.write(this.gotrueLegacyEnvPath(ref), content);");
+    expect(source).toContain("systemctl reload supacloud-gotrue@${ref}");
+    expect(source).toContain("systemctl restart supacloud-gotrue@${ref}");
+    expect(source).toContain("updatedLines.push(`${enabledKey}=false`);");
   });
 });

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -279,6 +279,9 @@ EOF
     local smtp_user="${GOTRUE_SMTP_USER:-}"
     local smtp_pass="${GOTRUE_SMTP_PASS:-}"
     
+    local gotrue_config_dir="${TENANT_CONFIG_DIR}/${ref}_gotrue.d"
+    mkdir -p "$gotrue_config_dir"
+
     cat > "${TENANT_CONFIG_DIR}/${ref}_gotrue.env" <<EOF
 # SupaCloud Tenant GoTrue Runtime: ${ref}
 # Bind to 0.0.0.0 so the host gateway can reach the tenant runtime.
@@ -299,6 +302,8 @@ GOTRUE_JWT_DEFAULT_GROUP_NAME=authenticated
 GOTRUE_JWT_AUD=authenticated
 GOTRUE_LOG_LEVEL=info
 GOTRUE_SERVER_READ_TIMEOUT=20
+GOTRUE_RELOADING_SIGNAL_ENABLED=true
+GOTRUE_RELOADING_POLLER_ENABLED=true
 GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION=true
 EOF
 
@@ -314,7 +319,9 @@ GOTRUE_SMTP_PASS=${smtp_pass}
 GOTRUE_SMTP_SENDER_NAME=SupaCloud
 EOF
     fi
+    cp "${TENANT_CONFIG_DIR}/${ref}_gotrue.env" "${gotrue_config_dir}/runtime.env"
     chmod 644 "${TENANT_CONFIG_DIR}/${ref}_gotrue.env"
+    chmod 644 "${gotrue_config_dir}/runtime.env"
 
     echo "Config generated for ${ref} (pgrst_port=${pgrst_port}, gotrue_port=${gotrue_port})"
 }
@@ -357,7 +364,7 @@ EOF
     fi
 
     local gotrue_unit="/etc/systemd/system/supacloud-gotrue@.service"
-    if [ ! -f "$gotrue_unit" ]; then
+    if [ ! -f "$gotrue_unit" ] || ! grep -q -- '--config-dir /etc/supabase/tenants/%i_gotrue.d' "$gotrue_unit"; then
         cat > "$gotrue_unit" <<EOF
 [Unit]
 Description=SupaCloud GoTrue for tenant %i
@@ -373,7 +380,8 @@ EnvironmentFile=/etc/supabase/tenants/%i_gotrue.env
 # Extreme squeeze: Go native memory wall 15MB and trigger GC immediately at 20% growth
 Environment="GOMEMLIMIT=15MiB"
 Environment="GOGC=20"
-ExecStart=${GOTRUE_BIN}
+ExecStart=${GOTRUE_BIN} --config-dir /etc/supabase/tenants/%i_gotrue.d
+ExecReload=/bin/kill -USR1 \$MAINPID
 Restart=on-failure
 RestartSec=5
 StartLimitBurst=3
@@ -462,7 +470,7 @@ stop_runtime() {
     systemctl disable "supacloud-gotrue@${ref}" 2>/dev/null || true
 
     # Clean up config files
-    rm -f "${TENANT_CONFIG_DIR}/${ref}.env" "${TENANT_CONFIG_DIR}/${ref}.conf" "${TENANT_CONFIG_DIR}/${ref}_gotrue.env"
+    rm -rf "${TENANT_CONFIG_DIR}/${ref}.env" "${TENANT_CONFIG_DIR}/${ref}.conf" "${TENANT_CONFIG_DIR}/${ref}_gotrue.env" "${TENANT_CONFIG_DIR}/${ref}_gotrue.d"
 
     echo "Runtime stopped for ${ref}"
 }


### PR DESCRIPTION
Write GoTrue runtime env into a watched config directory and reload tenant services with SIGHUP, while keeping the legacy env file synced for older units and diagnostics.

GoTrue v2.180+ supports config-dir reload via signal/poller. This replaces process restart with signal-based hot reload in the tenant-runtime applyRuntime flow, simplifying config changes (password rotation, OAuth edits) without dropping active connections.

Cherry-picked from the previously unmerged local commit `7f22961d` and rebased onto current main.

Validation: typecheck pass, tenant-runtime.ports.test.ts 5 pass (3 new hot-reload cases), bash -n install.sh pass.