### PR TITLE
fix(edge-runtime): embed worker executor in compiled binary

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -502,6 +502,34 @@ jobs:
           mv supacloud-edge-runtime-linux-amd64 dist/
           mv supacloud-edge-runtime-linux-arm64 dist/
 
+      - name: Smoke edge-runtime Linux amd64 binary
+        working-directory: packages/edge-runtime
+        run: |
+          tmp_functions="$(mktemp -d)"
+          EDGE_RUNTIME_HOST=127.0.0.1 PORT=19090 \
+            EDGE_FUNCTIONS_DIR="$tmp_functions" \
+            EDGE_FUNCTIONS_BASE_DIR="$tmp_functions" \
+            ./dist/supacloud-edge-runtime-linux-amd64 > /tmp/supacloud-edge-runtime-smoke.log 2>&1 &
+          pid=$!
+          cleanup() {
+            kill "$pid" 2>/dev/null || true
+            rm -rf "$tmp_functions"
+          }
+          trap cleanup EXIT
+          for _ in $(seq 1 40); do
+            if curl -fsS http://127.0.0.1:19090/health >/tmp/supacloud-edge-runtime-health.json; then
+              cat /tmp/supacloud-edge-runtime-health.json
+              exit 0
+            fi
+            if ! kill -0 "$pid" 2>/dev/null; then
+              cat /tmp/supacloud-edge-runtime-smoke.log
+              exit 1
+            fi
+            sleep 0.5
+          done
+          cat /tmp/supacloud-edge-runtime-smoke.log
+          exit 1
+
       - name: Build edge-runtime macOS binaries
         working-directory: packages/edge-runtime
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -140,6 +140,34 @@ jobs:
           mv supacloud-edge-runtime-macos-arm64 dist/
           chmod 0755 dist/supacloud-edge-runtime-*
 
+      - name: Smoke edge-runtime Linux amd64 binary
+        working-directory: packages/edge-runtime
+        run: |
+          tmp_functions="$(mktemp -d)"
+          EDGE_RUNTIME_HOST=127.0.0.1 PORT=19090 \
+            EDGE_FUNCTIONS_DIR="$tmp_functions" \
+            EDGE_FUNCTIONS_BASE_DIR="$tmp_functions" \
+            ./dist/supacloud-edge-runtime-linux-amd64 > /tmp/supacloud-edge-runtime-smoke.log 2>&1 &
+          pid=$!
+          cleanup() {
+            kill "$pid" 2>/dev/null || true
+            rm -rf "$tmp_functions"
+          }
+          trap cleanup EXIT
+          for _ in $(seq 1 40); do
+            if curl -fsS http://127.0.0.1:19090/health >/tmp/supacloud-edge-runtime-health.json; then
+              cat /tmp/supacloud-edge-runtime-health.json
+              exit 0
+            fi
+            if ! kill -0 "$pid" 2>/dev/null; then
+              cat /tmp/supacloud-edge-runtime-smoke.log
+              exit 1
+            fi
+            sleep 0.5
+          done
+          cat /tmp/supacloud-edge-runtime-smoke.log
+          exit 1
+
       - name: Generate SHA256SUMS
         working-directory: packages/edge-runtime/dist
         run: sha256sum * > SHA256SUMS

--- a/packages/edge-runtime/generated/embedded-worker.ts
+++ b/packages/edge-runtime/generated/embedded-worker.ts
@@ -1,0 +1,2 @@
+export const EMBEDDED_WORKER_HASH = "";
+export const EMBEDDED_WORKER_SOURCE = "";

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "dev": "bun run --watch server.ts",
     "start": "bun run server.ts",
-    "build:amd64": "bun build server.ts --compile --target=bun-linux-x64 --outfile=supacloud-edge-runtime-linux-amd64",
-    "build:arm64": "bun build server.ts --compile --target=bun-linux-arm64 --outfile=supacloud-edge-runtime-linux-arm64",
+    "build:amd64": "bun run scripts/build-compiled.ts --target bun-linux-x64 --outfile supacloud-edge-runtime-linux-amd64",
+    "build:arm64": "bun run scripts/build-compiled.ts --target bun-linux-arm64 --outfile supacloud-edge-runtime-linux-arm64",
     "build:linux": "bun run build:amd64 && bun run build:arm64",
-    "build:macos-amd64": "bun build server.ts --compile --target=bun-macos-x64 --outfile=supacloud-edge-runtime-macos-amd64",
-    "build:macos-arm64": "bun build server.ts --compile --target=bun-macos-arm64 --outfile=supacloud-edge-runtime-macos-arm64",
+    "build:macos-amd64": "bun run scripts/build-compiled.ts --target bun-macos-x64 --outfile supacloud-edge-runtime-macos-amd64",
+    "build:macos-arm64": "bun run scripts/build-compiled.ts --target bun-macos-arm64 --outfile supacloud-edge-runtime-macos-arm64",
     "build:macos": "bun run build:macos-amd64 && bun run build:macos-arm64",
     "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts worker-executor.ts worker-pool.ts auto-deps.ts deno-compat.ts fetch-tls-policy.ts url-import-plugin.ts shims/*.ts"
   },

--- a/packages/edge-runtime/scripts/build-compiled.ts
+++ b/packages/edge-runtime/scripts/build-compiled.ts
@@ -1,0 +1,71 @@
+import { createHash } from "crypto";
+import { existsSync, readFileSync, rmSync } from "fs";
+import { mkdir, writeFile } from "fs/promises";
+import { dirname, resolve } from "path";
+import { $ } from "bun";
+
+const root = resolve(import.meta.dir, "..");
+const generatedPath = resolve(root, "generated/embedded-worker.ts");
+const tmpDir = resolve(root, ".tmp/compiled-worker");
+const workerBundlePath = resolve(tmpDir, "worker-executor.js");
+
+function argValue(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const inline = Bun.argv.find((arg) => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+  const index = Bun.argv.indexOf(name);
+  return index >= 0 ? Bun.argv[index + 1] : undefined;
+}
+
+const target = argValue("--target");
+const outfile = argValue("--outfile");
+
+if (!target || !outfile) {
+  console.error("Usage: bun run scripts/build-compiled.ts --target <bun-target> --outfile <path>");
+  process.exit(1);
+}
+
+const originalGenerated = existsSync(generatedPath)
+  ? readFileSync(generatedPath, "utf8")
+  : 'export const EMBEDDED_WORKER_HASH = "";\nexport const EMBEDDED_WORKER_SOURCE = "";\n';
+
+try {
+  rmSync(tmpDir, { recursive: true, force: true });
+  await mkdir(tmpDir, { recursive: true });
+
+  const result = await Bun.build({
+    entrypoints: [resolve(root, "worker-executor.ts")],
+    outdir: tmpDir,
+    target: "bun",
+    format: "esm",
+    minify: false,
+    sourcemap: "none",
+    naming: {
+      entry: "worker-executor.js",
+    },
+  });
+
+  if (!result.success) {
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    process.exit(1);
+  }
+
+  const workerSource = readFileSync(workerBundlePath, "utf8");
+  const workerHash = createHash("sha256").update(workerSource).digest("hex").slice(0, 16);
+  await mkdir(dirname(generatedPath), { recursive: true });
+  await writeFile(
+    generatedPath,
+    [
+      `export const EMBEDDED_WORKER_HASH = ${JSON.stringify(workerHash)};`,
+      `export const EMBEDDED_WORKER_SOURCE = ${JSON.stringify(workerSource)};`,
+      "",
+    ].join("\n"),
+  );
+
+  await $`bun build server.ts --compile --target=${target} --outfile=${outfile}`.cwd(root);
+} finally {
+  await writeFile(generatedPath, originalGenerated);
+  rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -1,7 +1,10 @@
 import { Worker, MessagePort } from "worker_threads";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 import path from "path";
 import { resolveEdgeFetchTlsPolicy } from "./fetch-tls-policy";
 import type { EdgeFetchTlsPolicy } from "./fetch-tls-policy";
+import { EMBEDDED_WORKER_HASH, EMBEDDED_WORKER_SOURCE } from "./generated/embedded-worker";
 
 interface DispatchOptions {
   functionId: string;
@@ -32,6 +35,29 @@ const MAX_BODY_SIZE = resolveMaxBodySizeBytes();
 const MAX_QUEUE_SIZE = Number(process.env.MAX_QUEUE_SIZE) || 200;
 const WORKER_SMOL = process.env.WORKER_SMOL !== "false";
 const WAIT_UNTIL_TIMEOUT_MS = Number(process.env.EDGE_WAIT_UNTIL_TIMEOUT_MS) || 300_000;
+
+function resolveWorkerEntry(): string | URL {
+  if (process.env.EDGE_RUNTIME_WORKER_PATH) {
+    return path.resolve(process.env.EDGE_RUNTIME_WORKER_PATH);
+  }
+
+  const sourceEntry = path.resolve(import.meta.dir, "worker-executor.ts");
+  if (existsSync(sourceEntry)) {
+    return sourceEntry;
+  }
+
+  if (!EMBEDDED_WORKER_SOURCE || !EMBEDDED_WORKER_HASH) {
+    return new URL("./worker-executor.ts", import.meta.url);
+  }
+
+  const cacheDir = path.join(tmpdir(), "supacloud-edge-runtime");
+  const embeddedEntry = path.join(cacheDir, `worker-executor-${EMBEDDED_WORKER_HASH}.mjs`);
+  if (!existsSync(embeddedEntry)) {
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(embeddedEntry, EMBEDDED_WORKER_SOURCE, { mode: 0o600 });
+  }
+  return embeddedEntry;
+}
 
 export class WorkerPool {
   private workers: Worker[] = [];
@@ -67,10 +93,7 @@ export class WorkerPool {
   }
 
   private createWorker(): Worker {
-    // worker-executor.ts 与本文件同目录。使用 import.meta.dir 解析，避免依赖 process.cwd()
-    // （management-api 以 embedded 模式启动时 cwd 是 management-api 目录，会导致找不到入口）。
-    const workerEntry = process.env.EDGE_RUNTIME_WORKER_PATH
-      || path.resolve(import.meta.dir, "worker-executor.ts");
+    const workerEntry = resolveWorkerEntry();
     const w = new Worker(workerEntry, {
       ...(WORKER_SMOL ? { smol: true } : {}),
     } as any);


### PR DESCRIPTION
## Summary
- bundle the edge-runtime worker executor and embed it into compiled binaries
- fall back to the embedded worker when source files are unavailable in standalone binaries
- add release/main CI smoke for the Linux amd64 edge-runtime binary before upload

## Verification
- bun run typecheck (packages/edge-runtime)
- bun test (packages/edge-runtime)
- local compiled binary health smoke
- vm1 Linux amd64 compiled binary health smoke on temporary port 19091
- git diff --check