### PR TITLE
fix(web-console): enforce SPA-only API access

### DIFF
--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -12,8 +12,6 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {
-    "@sveltejs/adapter-auto": "^7.0.1",
-    "@sveltejs/adapter-node": "^5.5.5",
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.66.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -29,7 +27,6 @@
     "paneforge": "^1.0.2",
     "postcss": "^8.5.15",
     "svelte": "^5.56.3",
-    "svelte-adapter-bun": "^1.0.1",
     "svelte-check": "^4.6.0",
     "svelte-sonner": "^1.1.1",
     "sveltekit-superforms": "^2.30.1",

--- a/packages/web-console/src/lib/function-snippets.test.ts
+++ b/packages/web-console/src/lib/function-snippets.test.ts
@@ -31,7 +31,7 @@ describe("function snippets", () => {
 
   test("buildFunctionTasksPath scopes by function_slug and limit", () => {
     expect(buildFunctionTasksPath("proj_123", "hello/world", 5)).toBe(
-      "/api/query?path=/v1/projects/proj_123/tasks?function_slug=hello%2Fworld&limit=5",
+      "/v1/projects/proj_123/tasks?function_slug=hello%2Fworld&limit=5",
     );
   });
 

--- a/packages/web-console/src/lib/function-snippets.ts
+++ b/packages/web-console/src/lib/function-snippets.ts
@@ -107,7 +107,7 @@ export function buildFunctionTasksPath(
     query.set("function_version", version);
   }
 
-  return `/api/query?path=/v1/projects/${projectRef}/tasks?${query.toString()}`;
+  return `/v1/projects/${projectRef}/tasks?${query.toString()}`;
 }
 
 export function buildFunctionTaskConsolePath(

--- a/packages/web-console/src/routes/api/query/+server.ts
+++ b/packages/web-console/src/routes/api/query/+server.ts
@@ -1,6 +1,0 @@
-import { json } from '@sveltejs/kit';
-import type { RequestHandler } from './$types';
-
-export const POST: RequestHandler = async () => {
-    return json({ error: 'SQL query proxy is not available in the static console build' }, { status: 501 });
-};

--- a/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
@@ -303,7 +303,7 @@ export async function waitForTask(
     tasksLoading = true;
     tasksError = null;
     try {
-      const res = await fetch(
+      const res = await apiClient(
         buildFunctionTasksPath(String(projectRef), slug, 8, version),
       );
       const payload = await res.json().catch(() => []);


### PR DESCRIPTION
## Summary
- remove the Web Console SvelteKit /api/query server endpoint
- route function task requests directly through the Management API client
- drop unused non-static SvelteKit adapters from Web Console dependencies

## Verification
- bun test src/lib/function-snippets.test.ts
- bun run check
- bun run build
- find packages/web-console/src/routes \( -name '+server.*' -o -name '+page.server.*' -o -name '+layout.server.*' \) -print
- rg -n "/api/query|api/query|adapter-node|adapter-auto|svelte-adapter-bun" packages/web-console