### PR TITLE
fix(management-api): prefer Bun auth provider templates

### DIFF
--- a/packages/management-api/src/routes/auth-china.ts
+++ b/packages/management-api/src/routes/auth-china.ts
@@ -147,7 +147,7 @@ const ${providerUpper}_APP_ID = "${appId}"
 const ${providerUpper}_APP_SECRET = "${appSecret}"
 const REDIRECT_URI = "${redirectUri || ''}"
 
-Deno.serve(async (req) => {
+export default async function handler(req: Request) {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
 
   const url = new URL(req.url)
@@ -242,5 +242,9 @@ Deno.serve(async (req) => {
     console.error("${providerInfo.name} Login Error:", error instanceof Error ? error.message : String(error))
     return new Response(JSON.stringify({ data: { session: null, user: null }, error: (error instanceof Error ? error.message : String(error)) }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" }, status: 400 })
   }
-})`;
+}`;
 }
+
+export const chinaAuthInternals = {
+  generateChinaOAuthFunction,
+};

--- a/packages/management-api/src/routes/auth-wechat.ts
+++ b/packages/management-api/src/routes/auth-wechat.ts
@@ -234,7 +234,7 @@ function corsOriginHeader(req: Request): Record<string, string> {
   return { "Access-Control-Allow-Origin": origin, "Vary": "Origin" };
 }
 
-Deno.serve(async (req) => {
+export default async function handler(req: Request) {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
   try {
     const { code } = await req.json()
@@ -322,7 +322,7 @@ Deno.serve(async (req) => {
     console.error("WeChat MiniProgram Login Error:", error instanceof Error ? error.message : String(error))
     return new Response(JSON.stringify({ data: { session: null, user: null }, error: (error instanceof Error ? error.message : String(error)) }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" }, status: 400 })
   }
-})`;
+}`;
 }
 
 function generateWeChatMPLoginFunction(appId: string, appSecret: string, redirectUri?: string): string {
@@ -343,7 +343,7 @@ function corsOriginHeader(req: Request): Record<string, string> {
 const WECHAT_MP_APP_ID = "${appId}"
 const WECHAT_MP_APP_SECRET = "${appSecret}"
 
-Deno.serve(async (req) => {
+export default async function handler(req: Request) {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
 
   const url = new URL(req.url)
@@ -443,7 +443,7 @@ Deno.serve(async (req) => {
     console.error("WeChat MP Login Error:", error instanceof Error ? error.message : String(error))
     return new Response(JSON.stringify({ data: { session: null, user: null }, error: (error instanceof Error ? error.message : String(error)) }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" }, status: 400 })
   }
-})`;
+}`;
 }
 
 export const wechatAuthInternals = {

--- a/packages/management-api/tests/unit/auth-china.test.ts
+++ b/packages/management-api/tests/unit/auth-china.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { chinaAuthInternals } from "../../src/routes/auth-china";
+
+describe("china auth edge function generators", () => {
+  test("generated provider login function uses Bun-native default handler", () => {
+    const functionCode = chinaAuthInternals.generateChinaOAuthFunction(
+      "alipay",
+      "app-id",
+      "secret",
+      "https://example.com/callback"
+    );
+
+    expect(functionCode).toContain("export default async function handler(req: Request)");
+    expect(functionCode).not.toContain("Deno.serve");
+    expect(functionCode).toContain("Bun.env[\"SUPABASE_URL\"]");
+    expect(functionCode).toContain("JSON.stringify(finalSession)");
+  });
+});

--- a/packages/management-api/tests/unit/auth-wechat.test.ts
+++ b/packages/management-api/tests/unit/auth-wechat.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { wechatAuthInternals } from "../../src/routes/auth-wechat";
 
 function expectWechatLoginResponseContract(functionCode: string) {
+  expect(functionCode).toContain("export default async function handler(req: Request)");
+  expect(functionCode).not.toContain("Deno.serve");
   expect(functionCode).toContain("const responseUser = finalSession.user ?? null");
   expect(functionCode).toContain("JSON.stringify({ data: { session: finalSession, user: responseUser } })");
   expect(functionCode).toContain("JSON.stringify({ data: { session: null, user: null }, error:");


### PR DESCRIPTION
## Summary
- switch Management API-generated China OAuth and WeChat Edge Function templates from `Deno.serve` to Bun-native default `Request` handlers
- keep existing WeChat/Supabase session response contracts unchanged
- add generator tests covering Bun handler output and the absence of `Deno.serve`

## Verification
- `bun test tests/unit/auth-wechat.test.ts tests/unit/auth-china.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `rg -n "Deno\.serve|Deno\.env|TypeScript / Deno" packages/management-api/src packages/web-console/src -g "*.ts" -g "*.svelte" || true`
- `bun run --cwd packages/management-api test:unit`
- `git diff --check`

## Scope
This closes the remaining Deno-first generated template residue for Management API auth provider helpers. Web Console templates were already moved to Bun-first in `web-console-v0.16.2`.
