### PR TITLE
fix(management-api): mark storage enterprise capabilities unavailable

### DIFF
--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -250,10 +250,12 @@ function buildStorageConfigResponse(raw: Record<string, unknown>) {
     icebergCatalog: {
       ...((response.features as Record<string, any>).icebergCatalog || {}),
       ...((features.icebergCatalog as Record<string, unknown>) || {}),
+      enabled: false,
     },
     vectorBuckets: {
       ...((response.features as Record<string, any>).vectorBuckets || {}),
       ...((features.vectorBuckets as Record<string, unknown>) || {}),
+      enabled: false,
     },
   };
   response.capabilities = {
@@ -262,6 +264,9 @@ function buildStorageConfigResponse(raw: Record<string, unknown>) {
       string,
       unknown
     >),
+    iceberg_catalog: false,
+    storage_iceberg: false,
+    storage_vectors: false,
   };
   response.external = {
     ...(response.external as Record<string, unknown>),
@@ -1440,13 +1445,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
           string,
           unknown
         >) || {};
-      return {
-        fileSizeLimit: raw.fileSizeLimit || raw.file_size_limit || 52428800,
-        features: raw.features || {
-          imageTransformation: { enabled: true, maxTransformations: 100 },
-        },
-        ...raw,
-      };
+      return buildStorageConfigResponse(raw);
     },
     {
       params: t.Object({ ref: t.String() }),

--- a/packages/management-api/src/utils/openapi-defaults.gen.ts
+++ b/packages/management-api/src/utils/openapi-defaults.gen.ts
@@ -298,7 +298,9 @@ export const OPENAPI_STORAGE_CONFIG_RESPONSE_TEMPLATE = {
   },
   "capabilities": {
     "list_v2": false,
-    "iceberg_catalog": false
+    "iceberg_catalog": false,
+    "storage_iceberg": false,
+    "storage_vectors": false
   },
   "external": {
     "upstreamTarget": "main"
@@ -320,4 +322,3 @@ export const OPENAPI_REALTIME_CONFIG_RESPONSE_TEMPLATE = {
   "suspend": null,
   "presence_enabled": false
 } as const;
-

--- a/packages/management-api/tests/unit/project-storage-config.routes.test.ts
+++ b/packages/management-api/tests/unit/project-storage-config.routes.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+const getProjectSettings = mock(() => Promise.resolve(null));
+const updateProjectSettings = mock(() => Promise.resolve({}));
+
+const authModule = await import("../../src/middleware/auth");
+const servicesModule = await import("../../src/services");
+
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const getProjectSettingsSpy = spyOn(servicesModule.projectService, "getProjectSettings").mockImplementation(
+  getProjectSettings as typeof servicesModule.projectService.getProjectSettings,
+);
+const updateProjectSettingsSpy = spyOn(servicesModule.projectService, "updateProjectSettings").mockImplementation(
+  updateProjectSettings as typeof servicesModule.projectService.updateProjectSettings,
+);
+
+const { projectConfigRoutes } = await import("../../src/routes/project-config");
+
+const app = new Elysia().use(projectConfigRoutes);
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: {
+        Authorization: "Bearer dev-master-token",
+        "content-type": "application/json",
+        ...(init.headers || {}),
+      },
+    }),
+  );
+}
+
+describe("project storage config routes", () => {
+  afterAll(() => {
+    requireProjectOrAdminAuthSpy.mockRestore();
+    getProjectSettingsSpy.mockRestore();
+    updateProjectSettingsSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+    getProjectSettings.mockReset();
+    getProjectSettings.mockResolvedValue({
+      storage: {
+        features: {
+          icebergCatalog: { enabled: true, maxTables: 99 },
+          vectorBuckets: { enabled: true, maxBuckets: 12 },
+        },
+        capabilities: {
+          iceberg_catalog: true,
+          storage_iceberg: true,
+          storage_vectors: true,
+        },
+      },
+    } as never);
+    updateProjectSettings.mockReset();
+    updateProjectSettings.mockImplementation(async (_ref, settings) => settings as never);
+  });
+
+  test("GET marks vector and Iceberg storage surfaces as unavailable capabilities", async () => {
+    const res = await request("/v1/projects/proj_1/config/storage");
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.features.icebergCatalog).toMatchObject({ enabled: false, maxTables: 99 });
+    expect(body.features.vectorBuckets).toMatchObject({ enabled: false, maxBuckets: 12 });
+    expect(body.capabilities).toMatchObject({
+      iceberg_catalog: false,
+      storage_iceberg: false,
+      storage_vectors: false,
+    });
+  });
+
+  test("PATCH response uses the same unavailable capability normalization", async () => {
+    const res = await request("/v1/projects/proj_1/config/storage", {
+      method: "PATCH",
+      body: JSON.stringify({
+        features: {
+          vectorBuckets: { enabled: true, maxIndexes: 3 },
+        },
+        capabilities: {
+          storage_vectors: true,
+        },
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.features.vectorBuckets).toMatchObject({ enabled: false, maxIndexes: 3 });
+    expect(body.capabilities.storage_vectors).toBe(false);
+    expect(requireProjectOrAdminAuth).toHaveBeenCalledWith(expect.any(Request), "proj_1");
+  });
+});


### PR DESCRIPTION
## Summary
- force storage vector bucket and Iceberg config surfaces to report `enabled: false` until the backing features are implemented
- expose explicit `storage_vectors: false` and `storage_iceberg: false` capability flags in storage config/OpenAPI defaults
- make PATCH `/v1/projects/:ref/config/storage` return the same normalized response shape as GET

## Verification
- `bun test tests/unit/project-storage-config.routes.test.ts tests/unit/storage-compat.sdk.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `bun run --cwd packages/management-api test:unit`
- `git diff --check`

## Scope
This keeps SDK compatibility stubs for `/storage/v1/vector/*` and `/storage/v1/iceberg/*`, but prevents product UI/OpenAPI consumers from treating those enterprise surfaces as enabled capabilities before implementation.
