### PR TITLE
fix(management-api): expose content disposition in gateway CORS

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -27,7 +27,7 @@ export const DEFAULT_CORS_EXPOSED = [
     "Content-Length", "Content-Range", "X-Content-Range", "X-JSON",
     "x-supabase-api-version", "X-Client-Info", "Prefer",
     "Content-Profile", "accept-profile", "Range", "Range-Unit",
-    "X-Relay-Error", "link", "x-total-count",
+    "X-Relay-Error", "link", "x-total-count", "Content-Disposition",
 ];
 const UPSTREAM_CORS_RESPONSE_HEADERS = [
     "Access-Control-Allow-Origin",

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { config } from "../../src/config";
 import {
     CaddyGatewayProvider,
+    DEFAULT_CORS_EXPOSED,
     DEFAULT_CORS_HEADERS,
     buildTenantCorsOrigins,
     gatewayService,
@@ -114,6 +115,10 @@ describe("GatewayService provider selection", () => {
         expect(DEFAULT_CORS_HEADERS).toContain("x-forwarded-host");
         expect(DEFAULT_CORS_HEADERS).toContain("x-forwarded-proto");
         expect(DEFAULT_CORS_HEADERS).toContain("x-real-ip");
+    });
+
+    test("default cors exposed headers allow browsers to read download filenames", () => {
+        expect(DEFAULT_CORS_EXPOSED).toContain("Content-Disposition");
     });
 
     test("tenant cors origins include exact api and studio custom domains", () => {


### PR DESCRIPTION
## Summary
- add `Content-Disposition` to the default Caddy gateway `Access-Control-Expose-Headers` list
- cover the download filename header exposure with a management-api gateway unit test

## Validation
- `bun test packages/management-api/tests/unit/gateway.service.test.ts packages/management-api/tests/unit/gateway-custom-routes.api.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `bun run --cwd packages/management-api build:amd64`
- `git diff --check`

## Production Evidence
- vm1 patched binary remained `SupaCloud Version: 0.36.3`
- rebuilt Caddy through `POST /v1/projects/dglewlzugrtygzysqrce/gateway/rebuild-all`
- restarted `supacloud.service` and `supacloud-caddy.service`; target project gateway routes still had zero missing `Content-Disposition` expose headers
- browser-origin export smoke returned the business `filename*` header and XLSX body successfully