### PR TITLE
fix(ci): tolerate unavailable AI review provider

### DIFF
--- a/.github/scripts/ai-review-merge.mjs
+++ b/.github/scripts/ai-review-merge.mjs
@@ -30,6 +30,8 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const API_KEY  = process.env.AI_API_KEY;
 const API_BASE = process.env.AI_API_BASE;
@@ -44,6 +46,71 @@ const HEAD_SHA = process.env.HEAD_SHA;
 const GH_API = `https://api.github.com/repos/${REPO}`;
 const MAX_DIFF_CHARS = 100_000;
 const MAX_CONTEXT_FILE_CHARS = 8_000;
+const AI_UNAVAILABLE_COMMENT_PREFIX = '## AI Review Unavailable';
+const MAX_ERROR_SUMMARY_CHARS = 500;
+
+// --- AI provider failure handling ---------------------------------------
+
+export class AiApiError extends Error {
+  constructor(status, body) {
+    super(`AI API ${status}: ${sanitizeErrorText(body)}`);
+    this.name = 'AiApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function sanitizeErrorText(value) {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  return text
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(/(api[_-]?key["':=]\s*)[^"',\s}]+/gi, '$1[redacted]')
+    .slice(0, MAX_ERROR_SUMMARY_CHARS);
+}
+
+function errorText(error) {
+  if (!error) return '';
+  const pieces = [
+    error.name,
+    error.message,
+    error.body,
+    error.cause?.message,
+  ];
+  return pieces.filter(Boolean).map(String).join(' ');
+}
+
+export function summarizeAiProviderError(error) {
+  if (error instanceof AiApiError) {
+    return sanitizeErrorText(`HTTP ${error.status}: ${error.body}`);
+  }
+  return sanitizeErrorText(errorText(error) || 'unknown provider error');
+}
+
+export function isAiProviderUnavailableError(error) {
+  const status = error instanceof AiApiError ? error.status : undefined;
+  if (status && ([401, 403, 408, 409, 425, 429].includes(status) || status >= 500)) {
+    return true;
+  }
+
+  const text = errorText(error);
+  return /AppIdNoAuthError|NoAuth|Unauthorized|Forbidden|permission|quota|rate limit|temporar(?:y|ily)|timeout|timed out|ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|fetch failed|network/i.test(text);
+}
+
+export function formatAiUnavailableComment({ model, sha, error, ciStatus }) {
+  const shortSha = sha?.slice(0, 7) || 'unknown';
+  const ciLine = ciStatus?.allCompleted && ciStatus?.allPassed
+    ? '当前业务 CI 已完成并通过；本次不会自动合并。'
+    : '当前业务 CI 尚未全部完成或通过；本次不会自动合并。';
+  return [
+    `${AI_UNAVAILABLE_COMMENT_PREFIX} (${model}) — ${shortSha}`,
+    '',
+    'AI 审查模型暂不可用，本次已跳过 AI 审查并关闭自动合并。',
+    '',
+    `- 原因摘要：\`${summarizeAiProviderError(error)}\``,
+    `- CI 状态：${ciLine}`,
+    '- 安全策略：merge-bypass、自修改、CI、提交者身份等硬门禁未放宽；需要维护者人工审查或等待 AI provider 恢复后重新运行 workflow。',
+  ].join('\n');
+}
 
 // --- Merge-bypass detection patterns (Layer 1 hard block) ---------------
 
@@ -418,6 +485,13 @@ async function hasExistingAIReview() {
   );
 }
 
+async function hasExistingAIUnavailableNotice() {
+  const comments = await getPRComments();
+  return comments.some((c) =>
+    c.body && c.body.startsWith(AI_UNAVAILABLE_COMMENT_PREFIX) && c.body.includes(HEAD_SHA)
+  );
+}
+
 // --- AI review (Layer 2 — prompt guardrails) ---------------------------
 
 async function aiReview(diff, changedFiles, projectContext, ciStatus) {
@@ -507,7 +581,7 @@ async function aiReview(diff, changedFiles, projectContext, ciStatus) {
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`AI API ${res.status}: ${text}`);
+    throw new AiApiError(res.status, text);
   }
 
   const data = await res.json();
@@ -633,7 +707,25 @@ async function main() {
   console.log(`Diff size: ${diff.length} chars`);
 
   console.log(`Calling AI model: ${MODEL}...`);
-  const review = await aiReview(diff, changedFiles, projectContext, ciStatus);
+  let review;
+  try {
+    review = await aiReview(diff, changedFiles, projectContext, ciStatus);
+  } catch (err) {
+    if (!isAiProviderUnavailableError(err)) {
+      throw err;
+    }
+
+    const summary = summarizeAiProviderError(err);
+    console.warn(`AI review provider unavailable: ${summary}`);
+    if (await hasExistingAIUnavailableNotice()) {
+      console.log('AI unavailable notice already exists for this commit SHA. Skipping duplicate comment.');
+    } else {
+      await postComment(formatAiUnavailableComment({ model: MODEL, sha, error: err, ciStatus }));
+      console.log('AI unavailable notice posted.');
+    }
+    console.log('AI review unavailable. Auto-merge disabled for this run.');
+    return;
+  }
   console.log('Review completed.');
 
   const comment = `## AI Code Review (${MODEL}) — ${sha?.slice(0, 7) || 'unknown'}\n\n${review}`;
@@ -671,7 +763,13 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error('Fatal error:', err.message);
-  process.exit(1);
-});
+function isDirectRun() {
+  return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+}
+
+if (isDirectRun()) {
+  main().catch((err) => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+  AiApiError,
+  formatAiUnavailableComment,
+  isAiProviderUnavailableError,
+  summarizeAiProviderError,
+} from './ai-review-merge.mjs';
+
+describe('AI review provider failure handling', () => {
+  test('classifies provider auth failures hidden behind HTTP 500 as unavailable', () => {
+    const error = new AiApiError(
+      500,
+      '{"error":{"message":"xunfei response error: AppIdNoAuthError (request id: 2026062214080095251574710887624)"}}',
+    );
+
+    assert.equal(isAiProviderUnavailableError(error), true);
+    assert.match(summarizeAiProviderError(error), /HTTP 500/);
+    assert.match(summarizeAiProviderError(error), /AppIdNoAuthError/);
+  });
+
+  test('classifies rate limits and network failures as unavailable', () => {
+    assert.equal(isAiProviderUnavailableError(new AiApiError(429, 'rate limit exceeded')), true);
+    assert.equal(isAiProviderUnavailableError(new TypeError('fetch failed: ECONNRESET')), true);
+  });
+
+  test('does not hide local script bugs as provider downtime', () => {
+    assert.equal(isAiProviderUnavailableError(new Error('Cannot read properties of undefined')), false);
+    assert.equal(isAiProviderUnavailableError(new AiApiError(400, 'invalid JSON request body')), false);
+  });
+
+  test('formats a neutral notice that disables auto-merge without leaking secrets', () => {
+    const comment = formatAiUnavailableComment({
+      model: 'qwen-review',
+      sha: 'a854c3d6f2503859531be54b2b1cbdbb9d86dde3',
+      error: new AiApiError(403, 'Authorization: Bearer sk-secret api_key=abc123 Forbidden'),
+      ciStatus: { allCompleted: true, allPassed: true },
+    });
+
+    assert.match(comment, /^## AI Review Unavailable \(qwen-review\) — a854c3d/m);
+    assert.match(comment, /关闭自动合并/);
+    assert.match(comment, /当前业务 CI 已完成并通过/);
+    assert.doesNotMatch(comment, /sk-secret/);
+    assert.doesNotMatch(comment, /abc123/);
+  });
+});

--- a/.github/workflows/ai-review-merge.yml
+++ b/.github/workflows/ai-review-merge.yml
@@ -83,6 +83,12 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Validate AI review script
+        if: steps.pr-info.outputs.pr_number != ''
+        run: |
+          node --check .github/scripts/ai-review-merge.mjs
+          node --test .github/scripts/ai-review-merge.test.mjs
+
       - name: AI Review & Merge
         if: steps.pr-info.outputs.pr_number != ''
         env:

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -13,6 +13,8 @@ on:
       - "install.sh"
       - "setup.sh"
       - "switch.sh"
+      - ".github/scripts/**"
+      - ".github/workflows/ai-review-merge.yml"
       - ".github/workflows/management-api.yml"
   pull_request:
     branches: ["main", "dev"]
@@ -26,6 +28,8 @@ on:
       - "install.sh"
       - "setup.sh"
       - "switch.sh"
+      - ".github/scripts/**"
+      - ".github/workflows/ai-review-merge.yml"
       - ".github/workflows/management-api.yml"
   workflow_dispatch:
 
@@ -140,6 +144,11 @@ jobs:
         run: |
           bash -n install.sh setup.sh switch.sh deploy_all.sh scripts/pre_start_recovery.sh
           find scripts -name "*.sh" -print0 | xargs -0 -n1 bash -n
+
+      - name: Validate AI review script
+        run: |
+          node --check .github/scripts/ai-review-merge.mjs
+          node --test .github/scripts/ai-review-merge.test.mjs
 
   unit-test:
     name: Unit Tests


### PR DESCRIPTION
## Summary
- treat AI provider auth/rate-limit/5xx/network failures as review-unavailable instead of failing the PR check
- post a neutral unavailable notice and disable auto-merge for that run while keeping hard security gates intact
- add Node tests for provider failure classification and wire them into AI review and Management API CI workflows

## Validation
- node --check .github/scripts/ai-review-merge.mjs
- node --test .github/scripts/ai-review-merge.test.mjs
- git diff --check
- verifier: .mailbox/029-ai-review-provider-local-verifier.md and .mailbox/030-ai-review-workflow-verifier.md