### PR TITLE
fix(gateway): support mounted static custom routes

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -323,7 +323,6 @@ export function normalizeCustomGatewayRoute(input: CustomGatewayRouteConfig): Cu
     const rewriteUri = normalizeCustomRewriteUri(input.rewrite_uri);
     const stripPrefix = normalizeCustomStripPrefix(input.strip_prefix);
     if (rewriteUri && stripPrefix) throw new Error("Custom route must not set both rewrite_uri and strip_prefix");
-    if ((rewriteUri || stripPrefix) && !hasUpstream) throw new Error("Custom route rewrite_uri or strip_prefix requires an upstream route");
 
     return {
         id,
@@ -1099,6 +1098,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     },
                 });
             }
+            if (route.rewrite_uri) handle.push({ handler: "rewrite", uri: route.rewrite_uri });
+            else if (route.strip_prefix) handle.push({ handler: "rewrite", strip_path_prefix: route.strip_prefix });
             handle.push(this.makeStaticFileServer(route.static_root));
         } else {
             return null;

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -478,6 +478,54 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("configureCustomGatewayRoutes supports mounted static SPA rewrites", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+        const staticRoot = "/opt/supauth/packages/admin-console/build";
+
+        const result = await provider.configureCustomGatewayRoutes("proj123", [
+            {
+                id: "admin-assets",
+                hosts: ["auth.example.com"],
+                path: ["/admin/_app/*", "/admin/assets/*"],
+                static_root: staticRoot,
+                strip_prefix: "/admin",
+                priority: 20,
+            },
+            {
+                id: "admin-spa",
+                hosts: ["auth.example.com"],
+                path: ["/admin", "/admin/*"],
+                static_root: staticRoot,
+                rewrite_uri: "/index.html",
+                headers: { "Cache-Control": "no-cache" },
+                priority: 19,
+            },
+        ]);
+
+        expect(result.success).toBe(true);
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const assets = routes.find((item: any) => item["@id"] === "route-custom-gateway-proj123-admin-assets");
+        const spa = routes.find((item: any) => item["@id"] === "route-custom-gateway-proj123-admin-spa");
+
+        expect(assets?.match?.[0]?.host).toEqual(["auth.example.com"]);
+        expect(assets?.match?.[0]?.path).toEqual(["/admin/_app/*", "/admin/assets/*"]);
+        expect(assets?.handle?.[0]).toEqual({ handler: "rewrite", strip_path_prefix: "/admin" });
+        expect(assets?.handle?.[1]?.handler).toBe("file_server");
+        expect(assets?.handle?.[1]?.root).toBe(staticRoot);
+
+        expect(spa?.match?.[0]?.path).toEqual(["/admin", "/admin/*"]);
+        expect(spa?.handle?.[0]?.response?.set?.["Cache-Control"]).toEqual(["no-cache"]);
+        expect(spa?.handle?.[1]).toEqual({ handler: "rewrite", uri: "/index.html" });
+        expect(spa?.handle?.[2]?.handler).toBe("file_server");
+        expect(spa?.handle?.[2]?.root).toBe(staticRoot);
+        expect(routes.indexOf(assets)).toBeLessThan(routes.indexOf(spa));
+
+        restore();
+    });
+
     test("configureCustomGatewayRoutes replaces stale custom routes for the project", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);


### PR DESCRIPTION
## Summary
- allow controlled custom gateway static routes to use rewrite_uri or strip_prefix
- render the static rewrite handler before file_server
- add regression coverage for a mounted /admin SPA with immutable assets and index fallback

## Context
SupaAuth mounted at auth.ai.xigu.team needs Caddy routes like /admin/_app/* -> strip /admin -> file_server and /admin/* -> /index.html -> file_server. The current custom gateway route API can declare static_root but rejects rewrite_uri/strip_prefix unless the route has an upstream, so the only working fix was a manual Caddy JSON patch. This makes installed-app routing non-idempotent and lets legacy routes keep shadowing the intended Admin SPA/API paths.

## Verification
- bun test packages/management-api/tests/unit/gateway.service.test.ts
- bun test packages/management-api/tests/unit/gateway-custom-routes.api.test.ts
- bun run --cwd packages/management-api typecheck