### PR TITLE
fix(gateway): preserve external auth upstream on rebuild

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -9,7 +9,7 @@ import {
     resolveProjectAuthHost,
     resolveProjectStudioHost,
 } from "../utils/project-routing";
-import { normalizeProjectConfig } from "../utils/project-config";
+import { normalizeProjectConfig, normalizeThirdPartyAuthConfig } from "../utils/project-config";
 import { uniqueStrings } from "../utils/strings";
 
 export const DEFAULT_CORS_HEADERS = [
@@ -1095,6 +1095,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
         readTimeout?: number;
         preserveUpstreamCors?: boolean;
         streaming?: boolean;
+        upstreamTls?: boolean;
+        upstreamTlsInsecureSkipVerify?: boolean;
     }): CaddyRoute {
         const requestHeaders: Record<string, CaddyHeaderValue> = {
             "Host": "{http.request.host}",
@@ -1113,7 +1115,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
         if (corsSubroute) handle.push(corsSubroute);
         if (opts.rewriteUri) handle.push({ handler: "rewrite", uri: opts.rewriteUri });
         else if (opts.stripPrefix) handle.push({ handler: "rewrite", strip_path_prefix: opts.stripPrefix });
-        handle.push(this.makeReverseProxy(opts.upstream, requestHeaders, opts.readTimeout, opts.preserveUpstreamCors, opts.streaming));
+        handle.push(this.makeReverseProxy(opts.upstream, requestHeaders, opts.readTimeout, opts.preserveUpstreamCors, opts.streaming, opts.upstreamTls, opts.upstreamTlsInsecureSkipVerify));
 
         return {
             "@id": opts.id,
@@ -1310,7 +1312,19 @@ export class CaddyGatewayProvider implements GatewayProvider {
     async setupUpstream(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions): Promise<{ success: boolean; error?: string }> {
         try {
             const hostIp = await this.detectHostIp();
+            const projectConfig = normalizeProjectConfig(projectRouting);
             const routingConfig = normalizeProjectRoutingConfig(projectRouting);
+            const authConfig = projectConfig.auth && typeof projectConfig.auth === "object" && !Array.isArray(projectConfig.auth)
+                ? projectConfig.auth as Record<string, unknown>
+                : {};
+            const thirdPartyAuth = normalizeThirdPartyAuthConfig(authConfig.third_party_auth);
+            const externalAuthUpstream = thirdPartyAuth.enabled && thirdPartyAuth.auth_endpoint_mode === "external" && thirdPartyAuth.auth_upstream
+                ? normalizeCustomUpstream(thirdPartyAuth.auth_upstream)
+                : null;
+            const authUpstream = externalAuthUpstream?.dial || `${hostIp}:${gotruePort}`;
+            const authHeaders = externalAuthUpstream && thirdPartyAuth.auth_host_header
+                ? [`Host:${thirdPartyAuth.auth_host_header}`, `X-Forwarded-Host:${thirdPartyAuth.auth_host_header}`]
+                : undefined;
             const hosts = uniqueStrings(resolveProjectApiHosts(projectRef, routingConfig));
             const hostSet = new Set(hosts.map(normalizeCaddyHost));
             const authHosts = uniqueStrings([resolveProjectAuthHost(projectRef, routingConfig)])
@@ -1329,8 +1343,29 @@ export class CaddyGatewayProvider implements GatewayProvider {
             const routes = [
                 this.makeRoute({ id: caddyRouteId(projectRef, "rest"), hosts, path: "/rest/v1*", upstream: `${hostIp}:${pgrstPort}`, projectRef, stripPrefix: "/rest/v1", corsOrigins }),
                 this.makeRoute({ id: caddyRouteId(projectRef, "graphql"), hosts, path: "/graphql/v1*", upstream: `${hostIp}:${pgrstPort}`, projectRef, rewriteUri: "/rpc/graphql", headers: ["Content-Profile:graphql_public", "Accept-Profile:graphql_public"], corsOrigins }),
-                this.makeRoute({ id: caddyRouteId(projectRef, "auth"), hosts, path: "/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, stripPrefix: "/auth/v1", corsOrigins }),
-                this.makeRoute({ id: caddyRouteId(projectRef, "gotrue-well-known"), hosts, path: "/.well-known/oauth-authorization-server/auth/v1*", upstream: `${hostIp}:${gotruePort}`, projectRef, corsOrigins }),
+                this.makeRoute({
+                    id: caddyRouteId(projectRef, "auth"),
+                    hosts,
+                    path: "/auth/v1*",
+                    upstream: authUpstream,
+                    projectRef,
+                    stripPrefix: "/auth/v1",
+                    headers: authHeaders,
+                    corsOrigins,
+                    upstreamTls: externalAuthUpstream?.tls,
+                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
+                }),
+                this.makeRoute({
+                    id: caddyRouteId(projectRef, "gotrue-well-known"),
+                    hosts,
+                    path: "/.well-known/oauth-authorization-server/auth/v1*",
+                    upstream: authUpstream,
+                    projectRef,
+                    headers: authHeaders,
+                    corsOrigins,
+                    upstreamTls: externalAuthUpstream?.tls,
+                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
+                }),
                 this.makeRoute({
                     id: caddyRouteId(projectRef, "functions"),
                     hosts,
@@ -1386,18 +1421,24 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     id: caddyRouteId(projectRef, "auth-domain-auth"),
                     hosts: authHosts,
                     path: "/auth/v1*",
-                    upstream: `${hostIp}:${gotruePort}`,
+                    upstream: authUpstream,
                     projectRef,
                     stripPrefix: "/auth/v1",
+                    headers: authHeaders,
                     corsOrigins,
+                    upstreamTls: externalAuthUpstream?.tls,
+                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
                 }));
                 this.routesById.set(caddyRouteId(projectRef, "auth-domain-gotrue-well-known"), this.makeRoute({
                     id: caddyRouteId(projectRef, "auth-domain-gotrue-well-known"),
                     hosts: authHosts,
                     path: "/.well-known/oauth-authorization-server/auth/v1*",
-                    upstream: `${hostIp}:${gotruePort}`,
+                    upstream: authUpstream,
                     projectRef,
+                    headers: authHeaders,
                     corsOrigins,
+                    upstreamTls: externalAuthUpstream?.tls,
+                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
                 }));
             } else {
                 this.routesById.delete(caddyRouteId(projectRef, "auth-domain-auth"));

--- a/packages/management-api/src/utils/project-config.ts
+++ b/packages/management-api/src/utils/project-config.ts
@@ -37,6 +37,66 @@ export function normalizeOAuthServerConfig(value: unknown): Record<string, unkno
   return config;
 }
 
+export interface ThirdPartyAuthConfig {
+  enabled: boolean;
+  issuer?: string;
+  jwks_url?: string;
+  jwt_jwks?: unknown;
+  audience?: string | string[];
+  client_id?: string;
+  auth_endpoint_mode: "local" | "external";
+  auth_upstream?: string;
+  auth_host_header?: string;
+  auth_upstream_tls_insecure_skip_verify?: boolean;
+  claim_mapping: Record<string, string>;
+}
+
+export function normalizeThirdPartyAuthConfig(value: unknown): ThirdPartyAuthConfig {
+  const config = isRecord(value) ? { ...value } : {};
+  const authUpstream = pickString(config.auth_upstream) || pickString(config.authUpstream);
+  const mode = config.auth_endpoint_mode === "local" || config.authEndpointMode === "local"
+    ? "local"
+    : "external";
+
+  return {
+    enabled: config.enabled === true,
+    issuer: pickString(config.issuer),
+    jwks_url: pickString(config.jwks_url) || pickString(config.jwksUrl),
+    jwt_jwks: config.jwt_jwks ?? config.jwtJwks,
+    audience: normalizeAudience(config.audience),
+    client_id: pickString(config.client_id) || pickString(config.clientId),
+    auth_endpoint_mode: mode,
+    auth_upstream: authUpstream,
+    auth_host_header: pickString(config.auth_host_header) || pickString(config.authHostHeader),
+    auth_upstream_tls_insecure_skip_verify: config.auth_upstream_tls_insecure_skip_verify === true || config.authUpstreamTlsInsecureSkipVerify === true,
+    claim_mapping: normalizeClaimMapping(config.claim_mapping ?? config.claimMapping),
+  };
+}
+
+function pickString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizeAudience(value: unknown): string | string[] | undefined {
+  const single = pickString(value);
+  if (single) return single;
+  if (!Array.isArray(value)) return undefined;
+  const entries = value.map((item) => pickString(item)).filter((item): item is string => Boolean(item));
+  if (entries.length === 0) return undefined;
+  return Array.from(new Set(entries));
+}
+
+function normalizeClaimMapping(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  const mapping: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const normalizedKey = pickString(key);
+    const normalizedValue = pickString(raw);
+    if (normalizedKey && normalizedValue) mapping[normalizedKey] = normalizedValue;
+  }
+  return mapping;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -242,6 +242,60 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("setupUpstream splits business auth routes to an external IdP upstream", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        const result = await provider.setupUpstream("bizproj", 3000, 3372, {
+            api_domain: "api.biz.example.com",
+            auth_domain: "auth.biz.example.com",
+            studio_domain: "studio.biz.example.com",
+            auth: {
+                third_party_auth: {
+                    enabled: true,
+                    issuer: "https://auth.example.com/auth/v1",
+                    jwks_url: "https://auth.example.com/auth/v1/.well-known/jwks.json",
+                    audience: "authenticated",
+                    client_id: "client_1",
+                    auth_endpoint_mode: "external",
+                    auth_upstream: "127.0.0.1:3367",
+                    auth_host_header: "auth.example.com",
+                    claim_mapping: {
+                        sub: "sub",
+                        role: "role",
+                        email: "email",
+                    },
+                },
+            },
+        });
+        expect(result.success).toBe(true);
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const rest = routes.find((route: any) => route["@id"] === "route-project-bizproj-rest");
+        const functions = routes.find((route: any) => route["@id"] === "route-project-bizproj-functions");
+        const auth = routes.find((route: any) => route["@id"] === "route-project-bizproj-auth");
+        const wellKnown = routes.find((route: any) => route["@id"] === "route-project-bizproj-gotrue-well-known");
+        const authDomain = routes.find((route: any) => route["@id"] === "route-project-bizproj-auth-domain-auth");
+
+        const restProxy = rest?.handle?.find((handler: any) => handler.handler === "reverse_proxy");
+        const functionsProxy = functions?.handle?.find((handler: any) => handler.handler === "reverse_proxy");
+        const authProxy = auth?.handle?.find((handler: any) => handler.handler === "reverse_proxy");
+        const wellKnownProxy = wellKnown?.handle?.find((handler: any) => handler.handler === "reverse_proxy");
+        const authDomainProxy = authDomain?.handle?.find((handler: any) => handler.handler === "reverse_proxy");
+
+        expect(restProxy?.upstreams?.[0]?.dial).toBe("127.0.0.1:3000");
+        expect(functionsProxy?.upstreams?.[0]?.dial).not.toBe("127.0.0.1:3367");
+        expect(authProxy?.upstreams?.[0]?.dial).toBe("127.0.0.1:3367");
+        expect(wellKnownProxy?.upstreams?.[0]?.dial).toBe("127.0.0.1:3367");
+        expect(authDomainProxy?.upstreams?.[0]?.dial).toBe("127.0.0.1:3367");
+        expect(authProxy?.headers?.request?.set?.Host).toEqual(["auth.example.com"]);
+        expect(authProxy?.headers?.request?.set?.["X-Forwarded-Host"]).toEqual(["auth.example.com"]);
+
+        restore();
+    });
+
     test("setupUpstream does not render duplicate auth-domain routes without a dedicated auth domain", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);


### PR DESCRIPTION
## Summary
- restore third-party auth config normalization for gateway rebuilds
- route business project `/auth/v1*` and well-known auth metadata to configured external IdP upstreams during clean Caddy reconciliation
- add regression coverage proving data routes stay local while auth routes use the external upstream

## Verification
- `bun test tests/unit/gateway.service.test.ts tests/unit/gateway-custom-routes.api.test.ts`
- `bun run typecheck`
- `bun run build:amd64`

## Live verification on vm1
- deployed patched `supacloud` binary after backing up the previous binary
- restarted `supacloud.service`; generated Caddy routes kept both `auth.ai.xigu.team/auth/v1*` and `api.ai.xigu.team/auth/v1*` on `127.0.0.1:3367`
- verified `auth.ai.xigu.team/admin`, `/admin/security`, `/admin/_app/version.json`, `/login`, `auth.ai.xigu.team/auth/v1/.well-known/openid-configuration`, and `api.ai.xigu.team/auth/v1/.well-known/openid-configuration` all return 200
- invalid OAuth code exchange returns `400 invalid_grant` from central GoTrue; business GoTrue had no `/oauth/token`, HS256, or 500 hits in the verification window