### PR TITLE
fix: restore studio compatibility routes

### DIFF
--- a/packages/management-api/src/api.test.ts
+++ b/packages/management-api/src/api.test.ts
@@ -82,6 +82,58 @@ describe("Management API Integration Tests", () => {
         });
     });
 
+    describe("Studio compatibility", () => {
+        it("returns Studio profile aliases only for Studio-hosted requests", async () => {
+            const studioResponse = await app.handle(
+                new Request(`${baseUrl}/api/platform/profile`, {
+                    headers: {
+                        "x-supacloud-ui-host": "studio",
+                        Authorization: `Bearer ${masterToken}`,
+                    },
+                }),
+            );
+
+            expect(studioResponse.status).toBe(200);
+            const studioData = await studioResponse.json();
+            expect(studioData).toHaveProperty("organizations");
+
+            const apiResponse = await app.handle(
+                new Request(`${baseUrl}/api/platform/profile`, {
+                    headers: {
+                        Authorization: `Bearer ${masterToken}`,
+                    },
+                }),
+            );
+
+            expect(apiResponse.status).toBe(404);
+
+            const unauthenticatedStudioResponse = await app.handle(
+                new Request(`${baseUrl}/api/platform/profile`, {
+                    headers: {
+                        "x-supacloud-ui-host": "studio",
+                    },
+                }),
+            );
+
+            expect(unauthenticatedStudioResponse.status).toBe(401);
+        });
+
+        it("lists Studio projects through the platform alias", async () => {
+            const response = await app.handle(
+                new Request(`${baseUrl}/platform/projects`, {
+                    headers: {
+                        "x-supacloud-ui-host": "studio",
+                        Authorization: `Bearer ${masterToken}`,
+                    },
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            const data = await response.json();
+            expect(Array.isArray(data)).toBe(true);
+        });
+    });
+
     describe("Projects", () => {
         it("should list projects", async () => {
             const response = await app.handle(

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -76,6 +76,135 @@ async function getEmbeddedAssets() {
   return _embeddedAssets;
 }
 
+const STUDIO_COMPAT_NOT_FOUND = { message: "Route not found", code: "404" };
+
+function isStudioCompatibilityRequest(request: Request): boolean {
+  if (request.headers.get("x-supacloud-ui-host") === "studio") {
+    return true;
+  }
+
+  const host = (request.headers.get("host") || "").toLowerCase();
+  return host.startsWith("studio.") || host.startsWith("studio-");
+}
+
+async function rejectStudioCompatibilityRequest(request: Request, set: any) {
+  if (!isStudioCompatibilityRequest(request)) {
+    set.status = 404;
+    return STUDIO_COMPAT_NOT_FOUND;
+  }
+
+  const rateLimit = checkRateLimit(request);
+  set.headers ??= {};
+  for (const [key, value] of Object.entries(rateLimit.headers)) {
+    set.headers[key] = value;
+  }
+  if (!rateLimit.allowed) {
+    set.status = rateLimit.status;
+    return rateLimit.body;
+  }
+
+  const authError = await checkAuth(request);
+  if (authError) {
+    set.status = authError.status;
+    return { message: authError.body.error, code: String(authError.status) };
+  }
+
+  return undefined;
+}
+
+async function listStudioCompatibilityProjects() {
+  const { projectService } = await import("./services");
+  const projects = await projectService.listProjects();
+
+  return projects.map((project: any) => ({
+    id: project.id,
+    ref: project.ref,
+    name: project.name,
+    status: project.status?.toUpperCase() || "ACTIVE_HEALTHY",
+    region: project.region || "local",
+    organization_id: "default",
+    cloud_provider: project.cloud_provider || "localhost",
+    inserted_at: project.created_at,
+    updated_at: project.updated_at ?? null,
+    database: {
+      host: project.database?.host || "localhost",
+      name: project.database?.name || `supa_${project.ref}`,
+      user: project.database?.user || `role_${project.ref}`,
+      port: project.database?.port || 5432,
+      pool_size: project.database?.pool_size || 20,
+    },
+    api: {
+      url: project.api?.url || "",
+    },
+    studio: {
+      url: project.studio?.url || "",
+    },
+    services: project.services || [],
+    rest: project.rest || {},
+    realtime: project.realtime || false,
+  }));
+}
+
+async function getStudioCompatibilityProject(ref: string) {
+  const { projectService } = await import("./services");
+  let project: Record<string, any> | null = await projectService.getProject(ref) as Record<string, any> | null;
+
+  if (!project && ref === "default") {
+    const projects = await projectService.listProjects();
+    project = (projects[0] as Record<string, any> | undefined) ?? null;
+  }
+
+  if (!project) return null;
+
+  return {
+    id: project.id,
+    ref: project.ref,
+    name: project.name,
+    status: project.status?.toUpperCase() || "ACTIVE_HEALTHY",
+    region: project.region || "local",
+    organization_id: "default",
+    cloud_provider: project.cloud_provider || "localhost",
+    inserted_at: project.created_at,
+    connectionString: project.connectionString || "",
+    created_at: project.created_at,
+    updated_at: project.updated_at ?? null,
+    database: {
+      host: project.database?.host || "localhost",
+      name: project.database?.name || `supa_${project.ref}`,
+      user: project.database?.user || `role_${project.ref}`,
+      port: project.database?.port || 5432,
+      pool_size: project.database?.pool_size || 20,
+    },
+    api: {
+      url: project.api?.url || "",
+    },
+    studio: {
+      url: project.studio?.url || "",
+    },
+    services: project.services || [],
+    rest: project.rest || {},
+    realtime: project.realtime || false,
+  };
+}
+
+async function buildStudioCompatibilityProfile() {
+  const projects = await listStudioCompatibilityProjects();
+
+  return {
+    id: 1,
+    primary_email: "admin@supacloud.local",
+    username: "admin",
+    first_name: "Admin",
+    last_name: "User",
+    organizations: [{
+      id: 1,
+      name: "SupaCloud",
+      slug: "supacloud",
+      projects,
+    }],
+  };
+}
+
 const args = process.argv.slice(2);
 
 // --- Gateway-style try_files static asset serving ---
@@ -264,6 +393,67 @@ const app = new Elysia({ strictPath: false })
 
   // Health check (no auth required)
   .get("/health", () => ({ status: "ok", timestamp: new Date().toISOString() }))
+
+  .get("/platform/projects", async ({ request, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    return listStudioCompatibilityProjects();
+  })
+  .get("/platform/projects/:ref", async ({ request, params, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    const project = await getStudioCompatibilityProject(params.ref);
+    if (!project) {
+      set.status = 404;
+      return { message: "Project not found", code: "404" };
+    }
+
+    return project;
+  })
+  .get("/platform/organizations", async ({ request, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    return [{ id: 1, name: "SupaCloud", slug: "supacloud" }];
+  })
+  .get("/platform/profile", async ({ request, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    return buildStudioCompatibilityProfile();
+  })
+  .get("/api/platform/projects", async ({ request, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    return listStudioCompatibilityProjects();
+  })
+  .get("/api/platform/projects/:ref", async ({ request, params, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    const project = await getStudioCompatibilityProject(params.ref);
+    if (!project) {
+      set.status = 404;
+      return { message: "Project not found", code: "404" };
+    }
+
+    return project;
+  })
+  .get("/api/platform/organizations", async ({ request, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    return [{ id: 1, name: "SupaCloud", slug: "supacloud" }];
+  })
+  .get("/api/platform/profile", async ({ request, set }) => {
+    const rejected = await rejectStudioCompatibilityRequest(request, set);
+    if (rejected) return rejected;
+
+    return buildStudioCompatibilityProfile();
+  })
 
   // Compatibility path for manual/lego HTTP-01 challenge files. The default
   // Caddy flow uses Automatic HTTPS with the on-demand permission endpoint.

--- a/packages/web-console/src/lib/admin/resources.test.ts
+++ b/packages/web-console/src/lib/admin/resources.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { buildResourceRegistry } from "./resources";
+
+describe("buildResourceRegistry", () => {
+  test("includes tenant auth resources for every known project", () => {
+    const registry = buildResourceRegistry(["alpha123", "beta456"]);
+    const names = registry.map((resource) => resource.name);
+
+    expect(names).toContain("v1/projects/alpha123/auth/users");
+    expect(names).toContain("v1/projects/beta456/auth/users");
+    expect(names).toContain("v1/projects/alpha123/database/tables");
+  });
+
+  test("deduplicates repeated project refs", () => {
+    const registry = buildResourceRegistry(["alpha123", "alpha123"]);
+    const authResources = registry.filter(
+      (resource) => resource.name === "v1/projects/alpha123/auth/users",
+    );
+
+    expect(authResources).toHaveLength(1);
+  });
+});

--- a/packages/web-console/src/lib/admin/resources.ts
+++ b/packages/web-console/src/lib/admin/resources.ts
@@ -60,3 +60,12 @@ export const getTenantResources = (ref: string): ResourceDefinition[] => [
     ]
   }
 ];
+
+export function buildResourceRegistry(projectRefs: string[]): ResourceDefinition[] {
+  const uniqueRefs = [...new Set(projectRefs.filter(Boolean))];
+
+  return [
+    ...resources,
+    ...uniqueRefs.flatMap((ref) => getTenantResources(ref)),
+  ];
+}

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -38,7 +38,7 @@
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import { dataProvider, chatProvider } from "$lib/admin/provider";
   import { authProvider } from "$lib/admin/auth";
-  import { resources as defaultResources, getTenantResources } from "$lib/admin/resources";
+  import { buildResourceRegistry } from "$lib/admin/resources";
   
   import zhLocales from "$lib/i18n/locales/zh.json";
   import enLocales from "$lib/i18n/locales/en.json";
@@ -113,13 +113,15 @@
   
   let lastResourcesKey = "";
 
-  // Keep SVAdmin resources in sync with the current tenant route without mutating
-  // global provider state from inside a derived computation.
+  const getResourceKey = (resources: { identifier?: string; name: string }[]) =>
+    resources.map((resource) => resource.identifier ?? resource.name).join("|");
+
   $effect(() => {
-    const freshResources = refFromUrl
-      ? [...defaultResources, ...getTenantResources(refFromUrl)]
-      : defaultResources;
-    const nextKey = freshResources.map((resource) => resource.identifier ?? resource.name).join("|");
+    const projectRefs = projects
+      .map((project) => String((project as Record<string, unknown>).ref ?? ""))
+      .filter(Boolean);
+    const freshResources = buildResourceRegistry(projectRefs);
+    const nextKey = getResourceKey(freshResources);
 
     if (nextKey === lastResourcesKey) {
       return;
@@ -200,7 +202,15 @@
       try {
         const response = await apiClient('/v1/projects');
         if (response.ok) {
-          projects = await response.json();
+          const nextProjects = await response.json();
+          const projectRefs = nextProjects
+            .map((project: Record<string, unknown>) => String(project.ref ?? ""))
+            .filter(Boolean);
+          const nextResources = buildResourceRegistry(projectRefs);
+
+          projects = nextProjects;
+          lastResourcesKey = getResourceKey(nextResources);
+          setResources(nextResources);
         }
       } catch (err: unknown) {
         toast.error($t("Common.network_error") || "Network error");


### PR DESCRIPTION
## Summary
- preload tenant SVAdmin resources as soon as project metadata is fetched so project auth navigation no longer races resource registration
- restore Studio-only `/platform/*` and `/api/platform/*` compatibility aliases in Management API with auth + Studio-host gating
- add regression tests for resource registry building and Studio compatibility aliases

## Root cause
1. After Studio login, navigating from the dashboard to `/project/:ref/auth` could mount the auth page before the tenant resource registry had been updated, causing `Resource "v1/projects/:ref/auth/users" not found in resource definitions`.
2. Historical Studio compatibility aliases for `/platform/*` and `/api/platform/*` had been dropped from `packages/management-api/src/index.ts`, so direct Studio compatibility requests like `/api/platform/profile` returned 404.

## Verification
- `bun test packages/web-console/src/lib/admin/resources.test.ts`
- `bun run --cwd packages/web-console check` (`0 errors`, existing `Cannot find type definition file for 'node'` warning only)
- `bun test packages/management-api/src/api.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `git diff --check`

## Delegation Gate
- Used `gpt-5.5` as an independent high-risk reviewer/executor for root-cause confirmation and patch review.
- Final implementation kept to the scoped files in this PR.
