### PR TITLE
fix(runtime): update companion binary download versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2560,19 +2560,20 @@ EOF
     if [[ ! -x "$GOTRUE_BIN" ]]; then
         local GOTRUE_VERSION="${GOTRUE_VERSION:-v2.191.0}"
         local GOTRUE_ARCH
+        local GOTRUE_EXT="tar.xz"
         GOTRUE_ARCH=$(uname -m)
         case "$GOTRUE_ARCH" in
-            x86_64) GOTRUE_ARCH="linux-amd64" ;;
-            aarch64) GOTRUE_ARCH="linux-arm64" ;;
+            x86_64) GOTRUE_ARCH="amd64" ;;
+            aarch64) GOTRUE_ARCH="arm64" ;;
             *) log_error "Unsupported architecture for GoTrue: $GOTRUE_ARCH"; exit 1 ;;
         esac
-        local GOTRUE_URL="https://github.com/supabase/auth/releases/download/${GOTRUE_VERSION}/auth-${GOTRUE_VERSION}-${GOTRUE_ARCH}.tar.gz"
+        local GOTRUE_URL="https://github.com/supabase/auth/releases/download/${GOTRUE_VERSION}/auth-${GOTRUE_VERSION}-${GOTRUE_ARCH}.${GOTRUE_EXT}"
         log_info "Downloading GoTrue ${GOTRUE_VERSION}..."
         local TMP_DIR
         TMP_DIR=$(mktemp -d)
-        if curl -fsSL "https://gh-proxy.net/${GOTRUE_URL}" -o "${TMP_DIR}/gotrue.tar.gz" 2>/dev/null || \
-           curl -fsSL "${GOTRUE_URL}" -o "${TMP_DIR}/gotrue.tar.gz"; then
-            tar -xf "${TMP_DIR}/gotrue.tar.gz" -C "${TMP_DIR}"
+        if curl -fsSL "https://gh-proxy.net/${GOTRUE_URL}" -o "${TMP_DIR}/gotrue.${GOTRUE_EXT}" 2>/dev/null || \
+           curl -fsSL "${GOTRUE_URL}" -o "${TMP_DIR}/gotrue.${GOTRUE_EXT}"; then
+            tar -xf "${TMP_DIR}/gotrue.${GOTRUE_EXT}" -C "${TMP_DIR}"
             if [[ -f "${TMP_DIR}/auth" ]]; then
                 mv "${TMP_DIR}/auth" "$GOTRUE_BIN"
             elif [[ -f "${TMP_DIR}/gotrue" ]]; then

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "../../..", "..");
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+
+describe("runtime companion version assets", () => {
+  test("installer downloads the current GoTrue release asset names", () => {
+    const installer = readRepoFile("install.sh");
+
+    expect(installer).toContain('GOTRUE_VERSION="${GOTRUE_VERSION:-v2.191.0}"');
+    expect(installer).toContain('x86_64) GOTRUE_ARCH="amd64"');
+    expect(installer).toContain('aarch64) GOTRUE_ARCH="arm64"');
+    expect(installer).toContain('local GOTRUE_EXT="tar.xz"');
+    expect(installer).toContain(
+      'auth-${GOTRUE_VERSION}-${GOTRUE_ARCH}.${GOTRUE_EXT}',
+    );
+    expect(installer).not.toContain("auth-${GOTRUE_VERSION}-${GOTRUE_ARCH}.tar.gz");
+    expect(installer).not.toContain('GOTRUE_ARCH="linux-amd64"');
+  });
+
+  test("tenant runtime installs the current PostgREST and GoTrue releases", () => {
+    const runtime = readRepoFile("scripts/lib/tenant_runtime.sh");
+
+    expect(runtime).toContain('local version="${POSTGREST_VERSION:-v14.13}"');
+    expect(runtime).toContain('x86_64) arch="linux-static-x86-64"');
+    expect(runtime).toContain('aarch64) arch="ubuntu-aarch64"');
+    expect(runtime).toContain("postgrest-${version}-${arch}.tar.xz");
+
+    expect(runtime).toContain('local version="${GOTRUE_VERSION:-v2.191.0}"');
+    expect(runtime).toContain('x86_64) arch="amd64"');
+    expect(runtime).toContain('aarch64) arch="arm64"');
+    expect(runtime).toContain('local archive_ext="tar.xz"');
+    expect(runtime).toContain("auth-${version}-${arch}.${archive_ext}");
+
+    expect(runtime).not.toContain('local version="v12.2.3"');
+    expect(runtime).not.toContain('local version="v2.189.0"');
+    expect(runtime).not.toContain("linux-static-x64");
+  });
+});

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -123,12 +123,12 @@ ensure_postgrest() {
     local arch
     arch=$(uname -m)
     case "$arch" in
-        x86_64) arch="linux-static-x64" ;;
-        aarch64) arch="linux-static-aarch64" ;;
+        x86_64) arch="linux-static-x86-64" ;;
+        aarch64) arch="ubuntu-aarch64" ;;
         *) echo "ERROR: Unsupported architecture: $arch" >&2; exit 1 ;;
     esac
 
-    local version="v12.2.3"
+    local version="${POSTGREST_VERSION:-v14.13}"
     local url="https://github.com/PostgREST/postgrest/releases/download/${version}/postgrest-${version}-${arch}.tar.xz"
     echo "Downloading PostgREST ${version}..."
 
@@ -165,20 +165,21 @@ ensure_gotrue() {
     local arch
     arch=$(uname -m)
     case "$arch" in
-        x86_64) arch="x86" ;;
+        x86_64) arch="amd64" ;;
         aarch64) arch="arm64" ;;
         *) echo "ERROR: Unsupported architecture: $arch" >&2; exit 1 ;;
     esac
 
-    local version="v2.189.0"
-    local url="https://github.com/supabase/auth/releases/download/${version}/auth-${version}-${arch}.tar.gz"
+    local version="${GOTRUE_VERSION:-v2.191.0}"
+    local archive_ext="tar.xz"
+    local url="https://github.com/supabase/auth/releases/download/${version}/auth-${version}-${arch}.${archive_ext}"
     echo "Downloading GoTrue ${version}..."
 
     local tmp_dir
     tmp_dir=$(mktemp -d)
-    if curl -fsSL "https://gh-proxy.net/${url}" -o "${tmp_dir}/gotrue.tar.gz" 2>/dev/null || \
-       curl -fsSL "${url}" -o "${tmp_dir}/gotrue.tar.gz"; then
-        tar -xf "${tmp_dir}/gotrue.tar.gz" -C "${tmp_dir}"
+    if curl -fsSL "https://gh-proxy.net/${url}" -o "${tmp_dir}/gotrue.${archive_ext}" 2>/dev/null || \
+       curl -fsSL "${url}" -o "${tmp_dir}/gotrue.${archive_ext}"; then
+        tar -xf "${tmp_dir}/gotrue.${archive_ext}" -C "${tmp_dir}"
         # The binary may be named 'auth' or 'gotrue' depending on the release
         if [ -f "${tmp_dir}/auth" ]; then
             mv "${tmp_dir}/auth" "$GOTRUE_BIN"


### PR DESCRIPTION
## Summary
- update tenant runtime PostgREST fallback download from v12.2.3 to v14.13 and fix Linux asset names
- update tenant runtime GoTrue fallback download from v2.189.0 to v2.191.0 and use the current .tar.xz assets
- fix install.sh GoTrue v2.191.0 asset naming so fresh installs download real upstream release files
- add a static regression test for companion runtime asset versions and URL templates

## Verification
- bash -n install.sh scripts/lib/tenant_runtime.sh
- bun test packages/management-api/tests/unit/runtime-version-assets.test.ts packages/management-api/tests/unit/realtime-systemd.test.ts packages/management-api/tests/unit/supabase-schema.test.ts
- bun run --cwd packages/management-api typecheck
- git diff --check