### PR TITLE
fix(management-api): support generic postgres health

### DIFF
--- a/packages/management-api/src/diagnostics/checks/platform-service.ts
+++ b/packages/management-api/src/diagnostics/checks/platform-service.ts
@@ -7,6 +7,20 @@ import { hashPayload, statusForHash } from "../hash";
 import { registerCheck } from "../../services/diagnostics.registry";
 import type { DiagnosticCheckResult, DiagnosticRepairResult } from "../../services/diagnostics.types";
 
+async function isSystemdUnitInstalled(unit: string): Promise<boolean> {
+  try {
+    const serviceUnit = unit.endsWith(".service") ? unit : `${unit}.service`;
+    const result = await $`systemctl cat ${serviceUnit}`.nothrow().quiet();
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+function isLocalHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "0.0.0.0";
+}
+
 // --- Systemd service check ---
 registerCheck({
   id: "platform-service-status",
@@ -22,8 +36,14 @@ registerCheck({
       { unit: "supacloud", label: "Management API" },
       gateway,
       { unit: "supacloud-edge-runtime", label: "Edge Runtime" },
-      { unit: "patroni", label: "Patroni (PostgreSQL HA)" },
     ];
+    const optionalSkipped: string[] = [];
+
+    if (await isSystemdUnitInstalled("patroni")) {
+      services.push({ unit: "patroni", label: "Patroni (PostgreSQL HA)" });
+    } else {
+      optionalSkipped.push("Patroni (PostgreSQL HA)");
+    }
 
     const failed: string[] = [];
     const ok: string[] = [];
@@ -47,14 +67,15 @@ registerCheck({
         status: "degraded",
         message: `Services down: ${failed.join(", ")}`,
         detail: `Running: ${ok.join(", ") || "none"}`,
-        metadata: { failed, ok },
+        metadata: { failed, ok, optionalSkipped },
       };
     }
 
     return {
       checkId: "platform-service-status",
       status: "pass",
-      message: `All ${services.length} critical services running`,
+      message: `All ${services.length} required platform services running`,
+      metadata: { ok, optionalSkipped },
     };
   },
 });
@@ -69,13 +90,20 @@ registerCheck({
   severity: "critical",
   repairable: false,
   async run(): Promise<DiagnosticCheckResult | null> {
+    const { dbConfig } = await import("../../db");
     const ports = [
       { port: 9090, label: "Management API" },
       { port: 80, label: "Gateway HTTP" },
       { port: 443, label: "Gateway HTTPS" },
       { port: 9000, label: "Edge Runtime" },
-      { port: 5432, label: "PostgreSQL" },
     ];
+    const skipped: string[] = [];
+
+    if (isLocalHost(dbConfig.hostname)) {
+      ports.push({ port: dbConfig.port, label: "PostgreSQL" });
+    } else {
+      skipped.push(`PostgreSQL(${dbConfig.hostname}:${dbConfig.port})`);
+    }
 
     const notListening: string[] = [];
     const listening: string[] = [];
@@ -99,14 +127,15 @@ registerCheck({
         status: "degraded",
         message: `Ports not listening: ${notListening.join(", ")}`,
         detail: `Listening: ${listening.join(", ") || "none"}`,
-        metadata: { notListening, listening },
+        metadata: { notListening, listening, skipped },
       };
     }
 
     return {
       checkId: "platform-port-listeners",
       status: "pass",
-      message: `All ${ports.length} expected ports are listening`,
+      message: `All ${ports.length} expected local ports are listening`,
+      metadata: { listening, skipped },
     };
   },
 });

--- a/packages/management-api/src/infra/health.ts
+++ b/packages/management-api/src/infra/health.ts
@@ -122,20 +122,12 @@ export class HealthChecker {
 
     private static async checkPostgresHealth(): Promise<HealthReport> {
         try {
-            // 1. Basic connectivity
-            const isReady = (await $`pg_isready -h localhost`.nothrow()).exitCode === 0;
-            if (!isReady) {
-                return {
-                    component: "Database (PostgreSQL)",
-                    status: "ERROR",
-                    message: "Database not accepting connections",
-                    recommendation: "Check if port 5432 is blocked by firewall, or query 'systemctl status postgres'."
-                };
-            }
-
-            // 2. Get version
-            const pgVersionRaw = await $`sudo -u postgres psql -At -c "SHOW server_version;"`.nothrow().text();
-            const pgVersion = pgVersionRaw.split(/\r?\n/)[0];
+            // Use the configured Management API database connection. SupaCloud can run
+            // against Pigsty, Patroni, a custom Postgres container, or an external DB.
+            const { sql } = await import("../db");
+            await sql`SELECT 1`;
+            const [versionRow] = await sql`SHOW server_version`;
+            const pgVersion = String(versionRow?.server_version || "unknown");
 
             // 3. Cluster HA detection (Patroni)
             const { ClusterManager } = await import("./cluster");
@@ -171,26 +163,46 @@ export class HealthChecker {
                 };
             }
 
-            // 4. Fallback: Detect primary-replica sync (try simple query on management DB)
-            const syncStatus = await $`sudo -u postgres psql -At -c "SELECT count(*) FROM pg_stat_replication;"`.nothrow();
-            if (syncStatus.exitCode === 0) {
-                const replicas = parseInt(syncStatus.stdout.toString().trim());
+            // 4. Fallback: Detect primary-replica sync using the configured DB.
+            try {
+                const [syncRow] = await sql`SELECT count(*)::int AS replicas FROM pg_stat_replication`;
+                const replicas = Number(syncRow?.replicas || 0);
                 return {
                     component: "Database Connection",
                     status: "OK",
                     message: `PostgreSQL ${pgVersion.trim()} ready (Active replicas: ${replicas})`
                 };
+            } catch (err: unknown) {
+                logger.debug("[HealthChecker] pg_stat_replication unavailable", {
+                    error: err instanceof Error ? err.message : String(err),
+                });
             }
 
             return { component: "Database (PostgreSQL)", status: "OK", message: `PG ${pgVersion.trim()} running in single-node mode` };
         } catch (err: unknown) {
-          logger.warn("[HealthChecker] PostgreSQL health check failed", { error: err });
-            return { component: "Database", status: "WARN", message: "Cannot detect detailed database metrics" };
+            const message = err instanceof Error ? err.message : String(err);
+            logger.warn("[HealthChecker] PostgreSQL health check failed", { error: message });
+            return {
+                component: "Database (PostgreSQL)",
+                status: "ERROR",
+                message: "Database not accepting connections",
+                recommendation: "Check DATABASE_URL or PG_* connection settings for the active database provider."
+            };
         }
     }
 
     private static async checkPigstyStatus(): Promise<HealthReport> {
         try {
+            const hasPig = (await $`command -v pig`.nothrow().quiet()).exitCode === 0;
+            if (!hasPig) {
+                return {
+                    component: "Database Infrastructure",
+                    status: "OK",
+                    message: "Generic PostgreSQL profile active; Pigsty not configured",
+                    recommendation: "This is expected when SupaCloud uses a custom or external PostgreSQL provider."
+                };
+            }
+
             const version = await $`pig version`.nothrow().text();
             if (version.trim()) {
                 return {

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -2112,9 +2112,18 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 `.trim();
         const tmpFile = `/tmp/pgrst-prerequest-${ref}.sql`;
         await Bun.write(tmpFile, fnSql);
-        await $`psql ${dbUrl} -f ${tmpFile}`.nothrow().quiet();
-        await $`rm -f ${tmpFile}`.nothrow().quiet();
-        logger.info(`[tenant-runtime] Ensured public.set_request_context() for ${ref}`);
+        try {
+            const result = await $`psql ${dbUrl} -v ON_ERROR_STOP=1 -f ${tmpFile}`.nothrow();
+            if (result.exitCode !== 0) {
+                const stderr = result.stderr.toString().trim();
+                const stdout = result.stdout.toString().trim();
+                const detail = stderr || stdout || "psql exited without output";
+                throw new Error(`psql exited with code ${result.exitCode}: ${detail}`);
+            }
+            logger.info(`[tenant-runtime] Ensured public.set_request_context() for ${ref}`);
+        } finally {
+            await $`rm -f ${tmpFile}`.nothrow().quiet();
+        }
     }
 
     public async startRuntime(ref: string): Promise<RuntimeStatus> {
@@ -2309,6 +2318,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
     private async preparePostgrestRuntime(ref: string): Promise<void> {
         await this.ensurePostgrestBinary();
         await this.installSystemdTemplate();
+        await this.ensureTenantSchemaMigrations(ref);
+        await this.ensurePostgrestPrerequest(ref);
 
         const pgrstPort = await this.getTenantPort(ref, "pgrst");
         const gotruePort = await this.getTenantPort(ref, "gotrue");
@@ -2504,6 +2515,17 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
         }
     }
 
+    private async checkContainerService(containerName: string): Promise<string> {
+        try {
+            const result = await $`docker inspect -f '{{.State.Status}}' ${containerName} 2>/dev/null || podman inspect -f '{{.State.Status}}' ${containerName} 2>/dev/null`
+                .nothrow()
+                .quiet();
+            return result.text().trim() === "running" ? "ACTIVE_HEALTHY" : "INACTIVE";
+        } catch {
+            return "INACTIVE";
+        }
+    }
+
     /** Check DB health: try systemd first, then SQL probe as fallback */
     private async checkDbHealth(ref: string): Promise<string> {
         const systemdResult = await this.checkSystemService("patroni");
@@ -2558,13 +2580,13 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
             ? [
                 { id: "db", name: "db", unit: "patroni" },
                 { id: "auth", name: "auth", unit: `supacloud-gotrue@${ref}` },
-                { id: "realtime", name: "realtime", unit: "supacloud-realtime" },
+                { id: "realtime", name: "realtime", unit: "supacloud-realtime", container: "supacloud-realtime" },
                 { id: "storage", name: "storage", unit: "supacloud-storage" },
             ]
             : [
                 { id: "postgresql", name: "PostgreSQL", unit: "patroni" },
                 { id: "gotrue", name: "GoTrue", unit: `supacloud-gotrue@${ref}` },
-                { id: "realtime", name: "Realtime", unit: "supacloud-realtime" },
+                { id: "realtime", name: "Realtime", unit: "supacloud-realtime", container: "supacloud-realtime" },
                 { id: "storage", name: "Storage", unit: "supacloud-storage" },
                 {
                     id: "caddy",
@@ -2578,7 +2600,14 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
             this.checkDbHealth(ref),
             this.checkStorageHealth(),
             ...serviceDefs.filter(s => s.id !== "db" && s.id !== "storage" && s.id !== "postgresql")
-                .map((service) => this.checkSystemService(service.unit)),
+                .map(async (service) => {
+                    const systemdStatus = await this.checkSystemService(service.unit);
+                    const containerName = "container" in service ? service.container : undefined;
+                    if (systemdStatus === "ACTIVE_HEALTHY" || typeof containerName !== "string") {
+                        return systemdStatus;
+                    }
+                    return this.checkContainerService(containerName);
+                }),
         ]);
 
         const restId = mode === "studio" ? "rest" : "postgrest";

--- a/packages/management-api/tests/unit/infra-health.test.ts
+++ b/packages/management-api/tests/unit/infra-health.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(resolve(import.meta.dir, "../..", relativePath), "utf8");
+}
+
+describe("platform infrastructure health checks", () => {
+  test("PostgreSQL health uses configured database connectivity instead of localhost sudo probes", () => {
+    const source = readRepoFile("src/infra/health.ts");
+    const start = source.indexOf("private static async checkPostgresHealth");
+    const end = source.indexOf("private static async checkPigstyStatus", start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const body = source.slice(start, end);
+    expect(body).toContain('await import("../db")');
+    expect(body).toContain("SHOW server_version");
+    expect(body).not.toContain("pg_isready -h localhost");
+    expect(body).not.toContain("sudo -u postgres");
+    expect(body).not.toContain("systemctl status postgres");
+  });
+
+  test("Pigsty absence is reported as a healthy generic PostgreSQL profile instead of a hard failure", () => {
+    const source = readRepoFile("src/infra/health.ts");
+    const start = source.indexOf("private static async checkPigstyStatus");
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    const body = source.slice(start);
+    expect(body).toContain("command -v pig");
+    expect(body).toContain("Database Infrastructure");
+    expect(body).toContain("Generic PostgreSQL profile active; Pigsty not configured");
+    expect(body).toContain("status: \"OK\"");
+  });
+
+  test("diagnostics treat Patroni as optional database infrastructure", () => {
+    const source = readRepoFile("src/diagnostics/checks/platform-service.ts");
+    const start = source.indexOf('id: "platform-service-status"');
+    const end = source.indexOf("// --- Port listener check ---", start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const body = source.slice(start, end);
+    expect(body).toContain('await isSystemdUnitInstalled("patroni")');
+    expect(body).toContain('optionalSkipped.push("Patroni (PostgreSQL HA)")');
+    expect(body).not.toContain('{ unit: "patroni", label: "Patroni (PostgreSQL HA)" },');
+  });
+
+  test("diagnostics only check PostgreSQL listener when configured DB is local", () => {
+    const source = readRepoFile("src/diagnostics/checks/platform-service.ts");
+    const start = source.indexOf('id: "platform-port-listeners"');
+    const end = source.indexOf("// --- Disk space check ---", start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const body = source.slice(start, end);
+    expect(body).toContain('const { dbConfig } = await import("../../db");');
+    expect(body).toContain("if (isLocalHost(dbConfig.hostname))");
+    expect(body).toContain('ports.push({ port: dbConfig.port, label: "PostgreSQL" });');
+    expect(body).not.toContain("{ port: 5432, label: \"PostgreSQL\" },");
+  });
+});

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -86,6 +86,35 @@ describe("supabase bootstrap schema", () => {
     expect(migrationBody).toContain("throw new Error(`psql exited with code");
   });
 
+  test("PostgREST repair path reapplies pre-request function", () => {
+    const source = readRepoFile("src/services/tenant-runtime.service.ts");
+    const prerequestStart = source.indexOf("private async ensurePostgrestPrerequest");
+    const prerequestEnd = source.indexOf("public async startRuntime", prerequestStart);
+    const prepareStart = source.indexOf("private async preparePostgrestRuntime");
+    const prepareEnd = source.indexOf("private async persistPostgrestObservation", prepareStart);
+
+    expect(prerequestStart).toBeGreaterThanOrEqual(0);
+    expect(prerequestEnd).toBeGreaterThan(prerequestStart);
+    expect(prepareStart).toBeGreaterThanOrEqual(0);
+    expect(prepareEnd).toBeGreaterThan(prepareStart);
+
+    const prerequestBody = source.slice(prerequestStart, prerequestEnd);
+    const prepareBody = source.slice(prepareStart, prepareEnd);
+    expect(prerequestBody).toContain("-v ON_ERROR_STOP=1");
+    expect(prerequestBody).toContain("throw new Error(`psql exited with code");
+    expect(prepareBody).toContain("await this.ensureTenantSchemaMigrations(ref);");
+    expect(prepareBody).toContain("await this.ensurePostgrestPrerequest(ref);");
+  });
+
+  test("project service status accepts the deployed Realtime container fallback", () => {
+    const source = readRepoFile("src/services/tenant-runtime.service.ts");
+
+    expect(source).toContain("private async checkContainerService");
+    expect(source).toContain('container: "supacloud-realtime"');
+    expect(source).toContain('typeof containerName !== "string"');
+    expect(source).toContain("return this.checkContainerService(containerName);");
+  });
+
   test("graphql fallback does not replace an existing pg_graphql RPC", () => {
     for (const filePath of [
       "src/db/schemas/supabase.sql",

--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -424,7 +424,7 @@
     "operations_console": "Operations Console",
     "diagnostics": "Diagnostics Center",
     "settings": "AI Service Settings",
-    "subtitle": "Global control panel for Pigsty infrastructure."
+    "subtitle": "Global control panel for database infrastructure and SupaCloud services."
   },
   "Sidebar": {
     "platform_admin": "Platform Admin",
@@ -660,6 +660,7 @@
     "memory_status": "Memory Status",
     "supacloud_management_api": "SupaCloud Management API",
     "pigsty_infrastructure": "Pigsty Infrastructure",
+    "database_infrastructure": "Database Infrastructure",
     "database_postgresql": "Database (PostgreSQL)",
     "cloudnative_storage": "Cloud-native Storage",
     "cloudnative_storage_juicefs": "Cloud-native Storage (JuiceFS)",
@@ -667,7 +668,7 @@
     "database_cluster_ha": "Database Cluster (HA)",
     "pigsty_engine": "Pigsty Engine",
     "operations": "Operations",
-    "curated_pigsty_patroni_operations_executed": "Curated Pigsty / Patroni operations executed through a safe ticket-style UI",
+    "curated_pigsty_patroni_operations_executed": "Curated database operations for Pigsty, Patroni, and generic PostgreSQL profiles",
     "cluster_health_check": "Cluster health check",
     "run_check": "Run Check",
     "health_check_in_progress": "Health check in progress...",

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -424,7 +424,7 @@
     "operations_console": "运维控制",
     "diagnostics": "自检中心",
     "settings": "AI 服务配置",
-    "subtitle": "Pigsty ????????????"
+    "subtitle": "数据库基础设施与 SupaCloud 服务的全局控制台"
   },
   "Sidebar": {
     "platform_admin": "平台管理",
@@ -660,14 +660,15 @@
     "memory_status": "系统内存",
     "supacloud_management_api": "SupaCloud 管理接口",
     "pigsty_infrastructure": "Pigsty 基础设施",
-    "database_postgresql": "Database (PostgreSQL)",
+    "database_infrastructure": "数据库基础设施",
+    "database_postgresql": "PostgreSQL 数据库",
     "cloudnative_storage": "云原生存储",
     "cloudnative_storage_juicefs": "云原生存储 (JuiceFS)",
     "database_connection": "数据库连接",
     "database_cluster_ha": "数据库集群 (HA高可用)",
     "pigsty_engine": "Pigsty 引擎",
     "operations": "运维操作",
-    "curated_pigsty_patroni_operations_executed": "精选的 Pigsty / Patroni 运维操作，以安全的工单式 UI 执行",
+    "curated_pigsty_patroni_operations_executed": "适配 Pigsty、Patroni 与通用 PostgreSQL 的安全运维操作",
     "cluster_health_check": "集群健康检查",
     "run_check": "执行检查",
     "health_check_in_progress": "正在进行健康检查...",

--- a/packages/web-console/src/routes/platform/operations/+page.svelte
+++ b/packages/web-console/src/routes/platform/operations/+page.svelte
@@ -133,6 +133,7 @@
       "Memory Status": $t("PlatformOperations.memory_status"),
       "Management API": $t("PlatformOperations.supacloud_management_api"),
       "Pigsty Infrastructure": $t("PlatformOperations.pigsty_infrastructure"),
+      "Database Infrastructure": $t("PlatformOperations.database_infrastructure"),
       "Database (PostgreSQL)": $t("PlatformOperations.database_postgresql"),
       "Cloud-native Storage": $t("PlatformOperations.cloudnative_storage"),
       "Cloud-native Storage (JuiceFS)": $t("PlatformOperations.cloudnative_storage_juicefs"),
@@ -149,6 +150,7 @@
     if (msg === "Running") return "正在运行";
     if (msg === "Service stopped") return "服务已停止";
     if (msg === "System not booted by Systemd") return "非 Systemd 启动环境，服务状态未知";
+    if (msg === "Generic PostgreSQL profile active; Pigsty not configured") return "当前使用通用 PostgreSQL 配置，未启用 Pigsty";
     if (msg === "Cloud-native storage backend not mounted") return "云原生存储后端未挂载或未配置";
     if (msg === "Cannot detect storage mount status") return "无法检测存储挂载状态";
     if (msg === "Cannot get disk info") return "无法获取系统磁盘信息";
@@ -191,7 +193,7 @@
         <p class="text-xs text-muted-foreground">{$t("PlatformOperations.health_check_in_progress")}</p>
       {:else}
         <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-          {#each (healthStatus as any[]) as report}
+          {#each (healthStatus as any[]) as report (report.component)}
             <div class="rounded-lg border p-3 flex flex-col justify-between">
               <div class="text-[10px] font-bold uppercase text-muted-foreground mb-1">{translateComponent(report.component)}</div>
               <div class="mt-1">
@@ -211,7 +213,7 @@
 
   <!-- Operations Cards -->
   <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-    {#each OPERATIONS as op}
+    {#each OPERATIONS as op (op.id)}
       {@const Icon = op.icon}
       <div class="rounded-xl border bg-card overflow-hidden {activeOp === op.id ? 'ring-2 ring-brand' : ''}">
         <button
@@ -236,7 +238,7 @@
 
         {#if activeOp === op.id}
           <div class="p-4 space-y-3">
-            {#each op.fields as field}
+            {#each op.fields as field (field.key)}
               <div>
                 <label for="op-{op.id}-{field.key}" class="text-xs font-semibold text-muted-foreground block mb-1">
                   {field.label} {#if field.required}<span class="text-red-500">*</span>{/if}
@@ -285,7 +287,7 @@
             </tr>
           </thead>
           <tbody class="divide-y divide-border/20 font-mono">
-            {#each logs as log}
+            {#each logs as log (`${log.time}-${log.op}-${log.result}-${log.success}`)}
               <tr class="hover:bg-muted/10">
                 <td class="px-4 py-2 text-muted-foreground">{log.time}</td>
                 <td class="px-3 py-2 font-medium">{log.op}</td>


### PR DESCRIPTION
## Summary
- make platform health checks use the configured PostgreSQL connection instead of hard-coded localhost/Pigsty assumptions
- treat Pigsty/Patroni as optional infrastructure profiles while keeping SupaCloud core services critical
- repair PostgREST runtime preparation so missing tenant pre-request functions are reapplied and Realtime container status is recognized
- update platform operations copy for Pigsty, Patroni, and generic PostgreSQL profiles

## Verification
- bun test packages/management-api/tests/unit/infra-health.test.ts packages/management-api/tests/unit/supabase-schema.test.ts packages/management-api/tests/unit/project-services.runtime.test.ts
- bun run --cwd packages/management-api typecheck
- bun run --cwd packages/web-console check
- npx @sveltejs/mcp svelte-autofixer packages/web-console/src/routes/platform/operations/+page.svelte --svelte-version 5
- git diff --check