### PR TITLE
ci: enable weekly docker dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,21 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker/self-host"
+      - "/docker/self-host/postgres"
+      - "/packages/edge-runtime"
+      - "/packages/management-api"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker-compose"
+    directories:
+      - "/docker/dev"
+      - "/docker/self-host"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- add Dependabot weekly updates for Dockerfile image tags
- add Dependabot weekly updates for Docker Compose image tags

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'
- git diff --check