### PR TITLE
fix(storage): prioritize S3 compatibility routes

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -899,6 +899,10 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
       .use(databaseExtensionRoutes)
       .use(systemExtensionRoutes)
       .use(securityRoutes)
+      // Register the S3-compatible surface before the generic storage API.
+      // Otherwise `/v1/storage/:ref/buckets...` style routes can capture
+      // `/v1/storage/:ref/s3/...` requests first.
+      .use(storageS3Routes)
       .use(storageRoutes)
       .use(projectStorageRoutes)
       .use(scalingRoutes)
@@ -925,7 +929,6 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
       .use(scheduledFunctionRoutes)
       .use(branchRoutes)
       .use(pgMetaRoutes)
-      .use(storageS3Routes)
       .use(autoBranchingRoutes)
       .use(projectRbacRoutes)
       .use(projectWebhookRoutes)

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -303,7 +303,7 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, request: Request)
             if (
                 rows.length > 0 &&
                 rows[0].ref === ref &&
-                matchProjectRefFromHost(host, ref, rows[0].config)
+                (isLoopbackRequestHost(request) || matchProjectRefFromHost(host, ref, rows[0].config))
             ) {
                 return ref;
             }

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -8,7 +8,7 @@ import { logger } from "../utils/logger";
 import { backgroundTaskService } from "../services/background-task.service";
 import { edgeFunctionService } from "../services/edge-function.service";
 import { projectService } from "../services/project.service";
-import { matchProjectRefFromHost, resolveTenantPorts } from "../utils/project-routing";
+import { matchProjectRefFromHost, resolveProjectApiHost, resolveTenantPorts } from "../utils/project-routing";
 import { resolveProjectRefFromApiKey } from "../utils/project-auth";
 import { verifyProjectJwtPayload } from "../utils/project-jwt";
 
@@ -53,10 +53,43 @@ function buildEncryptedBackgroundAuth(input: {
     };
 }
 
+function hostFromRequestUrl(request: Request): string {
+    try {
+        return new URL(request.url).host;
+    } catch {
+        return "";
+    }
+}
+
+function hostNameFromHeaderValue(rawHost: string): string {
+    const host = rawHost.split(",")[0].trim();
+    if (!host) return "";
+    try {
+        return new URL(`http://${host}`).hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    } catch {
+        return host.replace(/^\[|\]$/g, "").split(":")[0].toLowerCase();
+    }
+}
+
+function requestHostCandidates(request: Request): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const rawHost of [
+        request.headers.get('x-forwarded-host'),
+        request.headers.get('host'),
+        hostFromRequestUrl(request),
+    ]) {
+        const host = rawHost?.trim();
+        if (!host || seen.has(host)) continue;
+        seen.add(host);
+        result.push(host);
+    }
+    return result;
+}
+
 function firstForwardedHost(request: Request): string {
-    const forwardedHost = request.headers.get('x-forwarded-host');
-    const rawHost = (forwardedHost || request.headers.get('host') || "").split(",")[0].trim();
-    return rawHost.split(":")[0].toLowerCase();
+    const [rawHost] = requestHostCandidates(request);
+    return rawHost ? hostNameFromHeaderValue(rawHost) : "";
 }
 
 function hostBelongsToBaseDomain(host: string): boolean {
@@ -229,19 +262,18 @@ async function getProjectRef(request: Request): Promise<string> {
 
     if (apiKeyRef) {
         if (refHeader && refHeader !== apiKeyRef) return '';
+        if (isLoopbackRequestHost(request)) return apiKeyRef;
 
-        const forwardedHost = request.headers.get('x-forwarded-host');
-        const rawHosts = [forwardedHost, request.headers.get('host')].filter(Boolean) as string[];
+        const rawHosts = requestHostCandidates(request);
         for (const rawHost of rawHosts) {
-            const host = rawHost.split(',')[0].trim();
+            const host = hostNameFromHeaderValue(rawHost);
             if (!host) continue;
 
-            if (hostBelongsToBaseDomain(host.split(':')[0].toLowerCase())) {
+            if (hostBelongsToBaseDomain(host)) {
                 const hostRef = host.split('.')[0];
                 if (hostRef && hostRef !== apiKeyRef) return '';
             }
             try {
-                const hostWithoutPort = host.split(':')[0];
                 const rows = await metaSql`
                     SELECT ref, config
                     FROM projects
@@ -249,7 +281,7 @@ async function getProjectRef(request: Request): Promise<string> {
                       AND lower(status) = ANY(${SDK_PROXY_PROJECT_STATUSES})
                 `;
                 const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
-                    matchProjectRefFromHost(hostWithoutPort, String(row.ref || ""), row.config),
+                    matchProjectRefFromHost(host, String(row.ref || ""), row.config),
                 );
                 if (matchedProject && matchedProject.ref !== apiKeyRef) return '';
             } catch(error: unknown) {
@@ -258,7 +290,7 @@ async function getProjectRef(request: Request): Promise<string> {
                     host,
                     error: error instanceof Error ? error.message : String(error),
                 });
-                if (!hostBelongsToBaseDomain(host.split(':')[0].toLowerCase())) return '';
+                if (!hostBelongsToBaseDomain(host)) return '';
             }
         }
 
@@ -280,11 +312,10 @@ async function getProjectRef(request: Request): Promise<string> {
 }
 
 async function resolveProjectRefFromHeaderAndHost(ref: string, request: Request): Promise<string> {
-    const forwardedHost = request.headers.get('x-forwarded-host');
-    const rawHosts = [forwardedHost, request.headers.get('host')].filter(Boolean) as string[];
+    const rawHosts = requestHostCandidates(request);
 
     for (const rawHost of rawHosts) {
-        const host = rawHost.split(',')[0].trim().split(':')[0];
+        const host = hostNameFromHeaderValue(rawHost);
         if (!host) continue;
 
         if (config.baseDomain && host === `${ref}.api.${config.baseDomain}`) {
@@ -340,6 +371,7 @@ async function getTenantPorts(ref: string): Promise<{ gotruePort: number, pgrstP
 type ProxyInterceptors = {
     linkOrigin?: string;
     ref?: string;
+    host?: string;
     extraHeaders?: Record<string, string>;
     timeoutMs?: number;
 };
@@ -360,7 +392,11 @@ async function executeProxy(request: Request, targetUrl: string, interceptors: P
         reqHeaders.delete('x-real-ip');
         
         const url = new URL(request.url);
-        reqHeaders.set('x-forwarded-host', url.host);
+        const upstreamHost = interceptors.host || url.host;
+        if (interceptors.host) {
+            reqHeaders.set('host', upstreamHost);
+        }
+        reqHeaders.set('x-forwarded-host', upstreamHost);
         reqHeaders.set('x-forwarded-proto', url.protocol.replace(':', ''));
         reqHeaders.set('x-forwarded-for', '127.0.0.1');
         
@@ -452,7 +488,7 @@ const sdkProxyRoutesBase = new Elysia({ prefix: "" })
             
             const url = new URL(request.url);
             const targetUrl = `http://127.0.0.1:${ports.gotruePort}${url.pathname.replace(/^\/auth\/v1/, '')}${url.search}`;
-            return executeProxy(request, targetUrl, { linkOrigin: url.origin });
+            return executeProxy(request, targetUrl, { linkOrigin: url.origin, ref, host: resolveProjectApiHost(ref, undefined) });
         };
         return app.get("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).post("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).put("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).patch("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).delete("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).options("/*", handler)
                   .get("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).post("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).put("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).patch("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).delete("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).options("", handler);
@@ -469,7 +505,7 @@ const sdkProxyRoutesBase = new Elysia({ prefix: "" })
             if (!targetPath || targetPath === '') targetPath = '/';
             const targetUrl = `http://127.0.0.1:${ports.pgrstPort}${targetPath}${url.search}`;
             const linkOrigin = `${url.protocol}//${url.host}/rest/v1`;
-            return executeProxy(request, targetUrl, { linkOrigin, timeoutMs: config.restProxyTimeoutMs });
+            return executeProxy(request, targetUrl, { linkOrigin, ref, host: resolveProjectApiHost(ref, undefined), timeoutMs: config.restProxyTimeoutMs });
         };
         return app.get("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).post("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).put("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).patch("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).delete("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).options("/*", handler)
                   .get("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).post("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).put("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).patch("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).delete("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy REST request" } }).options("", handler);

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -13,7 +13,6 @@ import { resolveProjectRefFromApiKey } from "../utils/project-auth";
 import { verifyProjectJwtPayload } from "../utils/project-jwt";
 
 const MAX_ASYNC_BODY_BYTES = 256 * 1024;
-const SDK_PROXY_PROJECT_STATUSES = ["active", "creating"];
 let sdkProxyFetch: typeof fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     globalThis.fetch(input, init)) as typeof fetch;
 
@@ -278,7 +277,7 @@ async function getProjectRef(request: Request): Promise<string> {
                     SELECT ref, config
                     FROM projects
                     WHERE deleted_at IS NULL
-                      AND lower(status) = ANY(${SDK_PROXY_PROJECT_STATUSES})
+                      AND lower(status) IN ('active', 'creating')
                 `;
                 const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
                     matchProjectRefFromHost(host, String(row.ref || ""), row.config),
@@ -328,7 +327,7 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, request: Request)
                 FROM projects
                 WHERE ref = ${ref}
                   AND deleted_at IS NULL
-                  AND lower(status) = ANY(${SDK_PROXY_PROJECT_STATUSES})
+                  AND lower(status) IN ('active', 'creating')
                 LIMIT 1
             `;
             if (

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -13,6 +13,7 @@ import { resolveProjectRefFromApiKey } from "../utils/project-auth";
 import { verifyProjectJwtPayload } from "../utils/project-jwt";
 
 const MAX_ASYNC_BODY_BYTES = 256 * 1024;
+const SDK_PROXY_PROJECT_STATUSES = ["active", "creating"];
 let sdkProxyFetch: typeof fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
     globalThis.fetch(input, init)) as typeof fetch;
 
@@ -224,7 +225,7 @@ async function getProjectRef(request: Request): Promise<string> {
     const auth = request.headers.get('authorization') || '';
     const key = request.headers.get('apikey') || '';
     const refHeader = request.headers.get("x-project-ref") || request.headers.get("x-supabase-project") || "";
-    const apiKeyRef = await sdkProxyInternals.resolveProjectRefFromApiKey(key) || '';
+    const apiKeyRef = await sdkProxyInternals.resolveProjectRefFromApiKey(key, { includeProvisioning: true }) || '';
 
     if (apiKeyRef) {
         if (refHeader && refHeader !== apiKeyRef) return '';
@@ -245,7 +246,7 @@ async function getProjectRef(request: Request): Promise<string> {
                     SELECT ref, config
                     FROM projects
                     WHERE deleted_at IS NULL
-                      AND status = 'active'
+                      AND lower(status) = ANY(${SDK_PROXY_PROJECT_STATUSES})
                 `;
                 const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
                     matchProjectRefFromHost(hostWithoutPort, String(row.ref || ""), row.config),
@@ -296,7 +297,7 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, request: Request)
                 FROM projects
                 WHERE ref = ${ref}
                   AND deleted_at IS NULL
-                  AND status = 'active'
+                  AND lower(status) = ANY(${SDK_PROXY_PROJECT_STATUSES})
                 LIMIT 1
             `;
             if (

--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -202,7 +202,7 @@ async function resolveProjectRefFromApiKey(key: string): Promise<string> {
     if (!key) return '';
     try {
         const { resolveProjectRefFromApiKey: resolveActiveProjectRefFromApiKey } = await import('../utils/project-auth');
-        return (await resolveActiveProjectRefFromApiKey(key)) || '';
+        return (await resolveActiveProjectRefFromApiKey(key, { includeProvisioning: true })) || '';
     } catch {}
     return '';
 }

--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -39,6 +39,7 @@ const STORAGE_UPLOAD_MAX_BYTES = Number(process.env.STORAGE_UPLOAD_MAX_BYTES || 
 const TUS_MAX_SIZE = Number(process.env.TUS_MAX_SIZE || DEFAULT_TUS_MAX_SIZE_BYTES);
 const TUS_MAX_CHUNK_SIZE = Number(process.env.TUS_MAX_CHUNK_SIZE || Math.min(TUS_MAX_SIZE, 16 * 1024 * 1024));
 const STORAGE_BATCH_CONCURRENCY = Math.max(1, Number(process.env.STORAGE_BATCH_CONCURRENCY || 12));
+const STORAGE_PROJECT_STATUSES = ["active", "creating"];
 
 // ── Imaginary Config ──────────────────────────────────────────────
 const IMAGINARY_URL = config.imaginaryUrl;
@@ -239,7 +240,7 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, host: string): Pr
             FROM projects
             WHERE ref = ${ref}
               AND deleted_at IS NULL
-              AND status = 'active'
+              AND lower(status) = ANY(${STORAGE_PROJECT_STATUSES})
             LIMIT 1
         `;
         if (
@@ -291,7 +292,7 @@ async function getProjectRef(headers: Record<string, string | undefined>): Promi
                 SELECT ref, config
                 FROM projects
                 WHERE deleted_at IS NULL
-                  AND status = 'active'
+                  AND lower(status) = ANY(${STORAGE_PROJECT_STATUSES})
             `;
             const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
                 matchProjectRefFromHost(host, String(row.ref || ""), row.config),

--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -39,7 +39,6 @@ const STORAGE_UPLOAD_MAX_BYTES = Number(process.env.STORAGE_UPLOAD_MAX_BYTES || 
 const TUS_MAX_SIZE = Number(process.env.TUS_MAX_SIZE || DEFAULT_TUS_MAX_SIZE_BYTES);
 const TUS_MAX_CHUNK_SIZE = Number(process.env.TUS_MAX_CHUNK_SIZE || Math.min(TUS_MAX_SIZE, 16 * 1024 * 1024));
 const STORAGE_BATCH_CONCURRENCY = Math.max(1, Number(process.env.STORAGE_BATCH_CONCURRENCY || 12));
-const STORAGE_PROJECT_STATUSES = ["active", "creating"];
 
 // ── Imaginary Config ──────────────────────────────────────────────
 const IMAGINARY_URL = config.imaginaryUrl;
@@ -240,7 +239,7 @@ async function resolveProjectRefFromHeaderAndHost(ref: string, host: string): Pr
             FROM projects
             WHERE ref = ${ref}
               AND deleted_at IS NULL
-              AND lower(status) = ANY(${STORAGE_PROJECT_STATUSES})
+              AND lower(status) IN ('active', 'creating')
             LIMIT 1
         `;
         if (
@@ -292,7 +291,7 @@ async function getProjectRef(headers: Record<string, string | undefined>): Promi
                 SELECT ref, config
                 FROM projects
                 WHERE deleted_at IS NULL
-                  AND lower(status) = ANY(${STORAGE_PROJECT_STATUSES})
+                  AND lower(status) IN ('active', 'creating')
             `;
             const matchedProject = rows.find((row: { ref?: unknown; config?: unknown }) =>
                 matchProjectRefFromHost(host, String(row.ref || ""), row.config),

--- a/packages/management-api/src/services/storage-rls.ts
+++ b/packages/management-api/src/services/storage-rls.ts
@@ -242,7 +242,7 @@ export class StorageRLS {
 
   static async verifyToken(ref: string, token: string) {
     const cleanToken = token.replace('Bearer ', '');
-    const verification = await verifyProjectJwtPayload(ref, cleanToken);
+    const verification = await verifyProjectJwtPayload(ref, cleanToken, { includeProvisioning: true });
     if (!verification) throw new Error("tenant not found");
     return {
       ...verification.payload,

--- a/packages/management-api/src/utils/project-auth.ts
+++ b/packages/management-api/src/utils/project-auth.ts
@@ -6,16 +6,21 @@ export async function resolveProjectRefFromApiKey(
 ): Promise<string | null> {
   if (!key) return null;
   try {
-    const allowedStatuses = options.includeProvisioning
-      ? ["active", "creating"]
-      : ["active"];
-    const rows = await metaSql`
-      SELECT ref FROM projects
-      WHERE (anon_key = ${key} OR service_role_key = ${key})
-        AND deleted_at IS NULL
-        AND lower(status) = ANY(${allowedStatuses})
-      LIMIT 1
-    `;
+    const rows = options.includeProvisioning
+      ? await metaSql`
+        SELECT ref FROM projects
+        WHERE (anon_key = ${key} OR service_role_key = ${key})
+          AND deleted_at IS NULL
+          AND lower(status) IN ('active', 'creating')
+        LIMIT 1
+      `
+      : await metaSql`
+        SELECT ref FROM projects
+        WHERE (anon_key = ${key} OR service_role_key = ${key})
+          AND deleted_at IS NULL
+          AND lower(status) = 'active'
+        LIMIT 1
+      `;
     if (rows.length > 0) return String(rows[0].ref);
   } catch {}
   return null;

--- a/packages/management-api/src/utils/project-auth.ts
+++ b/packages/management-api/src/utils/project-auth.ts
@@ -1,13 +1,19 @@
 import { sql as metaSql } from "../db";
 
-export async function resolveProjectRefFromApiKey(key: string): Promise<string | null> {
+export async function resolveProjectRefFromApiKey(
+  key: string,
+  options: { includeProvisioning?: boolean } = {},
+): Promise<string | null> {
   if (!key) return null;
   try {
+    const allowedStatuses = options.includeProvisioning
+      ? ["active", "creating"]
+      : ["active"];
     const rows = await metaSql`
       SELECT ref FROM projects
       WHERE (anon_key = ${key} OR service_role_key = ${key})
         AND deleted_at IS NULL
-        AND status = 'active'
+        AND lower(status) = ANY(${allowedStatuses})
       LIMIT 1
     `;
     if (rows.length > 0) return String(rows[0].ref);

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -195,12 +195,18 @@ function extractJwtJwksFromConfig(config: unknown): { keys: JWK[] } | null {
 export async function verifyProjectJwtPayload(
   ref: string,
   token: string,
+  options: { includeProvisioning?: boolean } = {},
 ): Promise<ProjectJwtVerification | null> {
   const cleanToken = token.replace(/^Bearer\s+/i, "");
+  const allowedStatuses = options.includeProvisioning
+    ? ["active", "creating"]
+    : ["active"];
   const [project] = await metaSql`
     SELECT jwt_secret, service_role_key, config
     FROM projects
-    WHERE ref = ${ref} AND deleted_at IS NULL AND lower(status) = 'active'
+    WHERE ref = ${ref}
+      AND deleted_at IS NULL
+      AND lower(status) = ANY(${allowedStatuses})
     LIMIT 1
   `;
 

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -198,17 +198,23 @@ export async function verifyProjectJwtPayload(
   options: { includeProvisioning?: boolean } = {},
 ): Promise<ProjectJwtVerification | null> {
   const cleanToken = token.replace(/^Bearer\s+/i, "");
-  const allowedStatuses = options.includeProvisioning
-    ? ["active", "creating"]
-    : ["active"];
-  const [project] = await metaSql`
-    SELECT jwt_secret, service_role_key, config
-    FROM projects
-    WHERE ref = ${ref}
-      AND deleted_at IS NULL
-      AND lower(status) = ANY(${allowedStatuses})
-    LIMIT 1
-  `;
+  const [project] = options.includeProvisioning
+    ? await metaSql`
+      SELECT jwt_secret, service_role_key, config
+      FROM projects
+      WHERE ref = ${ref}
+        AND deleted_at IS NULL
+        AND lower(status) IN ('active', 'creating')
+      LIMIT 1
+    `
+    : await metaSql`
+      SELECT jwt_secret, service_role_key, config
+      FROM projects
+      WHERE ref = ${ref}
+        AND deleted_at IS NULL
+        AND lower(status) = 'active'
+      LIMIT 1
+    `;
 
   if (!project?.jwt_secret) return null;
   const jwtJwks = extractJwtJwksFromConfig(project.config);

--- a/packages/management-api/tests/e2e/snapshot-structural.test.ts
+++ b/packages/management-api/tests/e2e/snapshot-structural.test.ts
@@ -32,6 +32,16 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function expectSnapshotStatus(res: Response, expectedStatus: number, label: string): Promise<unknown> {
+  const text = await res.text();
+  if (res.status !== expectedStatus) {
+    throw new Error(
+      `${label} status mismatch: expected ${expectedStatus}, received ${res.status}, body=${text.slice(0, 500)}`,
+    );
+  }
+  return JSON.parse(text);
+}
+
 async function waitForAuthProxy(tenantRef: string, anonKey: string) {
   let lastStatus = 0;
   let lastError = "";
@@ -136,9 +146,7 @@ describe("API Structural Snapshot Compliance", () => {
       },
     );
 
-    expect(res.status).toBe(gt.status);
-
-    const data = await res.json();
+    const data = await expectSnapshotStatus(res, gt.status, "storage_list_error");
     const schema = buildSchemaObject(data);
 
     expect(schema).toEqual(gt.schema);
@@ -158,9 +166,7 @@ describe("API Structural Snapshot Compliance", () => {
       body: JSON.stringify({ email: "invalid", password: "1" }),
     });
 
-    expect(res.status).toBe(gt.status);
-
-    const data = await res.json();
+    const data = await expectSnapshotStatus(res, gt.status, "auth_signup_error");
     const schema = buildSchemaObject(data);
 
     expect(schema).toEqual(gt.schema);

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -264,6 +264,10 @@ describe("sdkProxyRoutes functions proxy", () => {
       expect(response.status).toBe(200);
       expect(calls).toHaveLength(1);
       expect(calls[0]?.url).toBe("http://127.0.0.1:8361/health");
+      const headers = new Headers(calls[0]?.init?.headers);
+      expect(headers.get("host")).toBe(`proj_1.api.${config.baseDomain}`);
+      expect(headers.get("x-forwarded-host")).toBe(`proj_1.api.${config.baseDomain}`);
+      expect(headers.get("x-project-ref")).toBe("proj_1");
       expect(sdkProxyInternals.resolveProjectRefFromApiKey).toHaveBeenCalledWith("anon", { includeProvisioning: true });
     });
   });
@@ -331,6 +335,44 @@ describe("sdkProxyRoutes functions proxy", () => {
       expect(response.status).toBe(200);
       expect(calls).toHaveLength(1);
       expect(calls[0]?.url).toBe("http://127.0.0.1:8361/health");
+    });
+  });
+
+  test("auth proxy accepts gateway-injected project ref from loopback request URL when apikey lookup misses", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectRefFromApiKey").mockResolvedValueOnce(null),
+      );
+      const sqlSpy = trackSpy(spyOn(dbModule, "sql"));
+      sqlSpy.mockImplementation(async (...args: unknown[]) => {
+        const text = String(args[0] ?? "");
+        if (text.includes("SELECT ref")) {
+          return [{ ref: "proj_from_header", config: {} }];
+        }
+        if (text.includes("SELECT config")) {
+          return [{ config: { gotrue_port: 8361, postgrest_port: 7361 } }];
+        }
+        return [];
+      });
+
+      const response = await request("/auth/v1/signup", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          apikey: "unindexed-bootstrap-anon-key",
+          authorization: "Bearer unindexed-bootstrap-anon-key",
+          "x-project-ref": "proj_from_header",
+        },
+        body: JSON.stringify({ email: "invalid", password: "1" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("http://127.0.0.1:8361/signup");
+      const headers = new Headers(calls[0]?.init?.headers);
+      expect(headers.get("host")).toBe(`proj_from_header.api.${config.baseDomain}`);
+      expect(headers.get("x-forwarded-host")).toBe(`proj_from_header.api.${config.baseDomain}`);
+      expect(headers.get("x-project-ref")).toBe("proj_from_header");
     });
   });
 
@@ -421,7 +463,8 @@ describe("sdkProxyRoutes functions proxy", () => {
       expect(response.status).toBe(200);
       expect(calls).toHaveLength(1);
       const headers = new Headers(calls[0]?.init?.headers);
-      expect(headers.get("x-forwarded-host")).toBe("localhost");
+      expect(headers.get("host")).toBe(`proj_1.api.${config.baseDomain}`);
+      expect(headers.get("x-forwarded-host")).toBe(`proj_1.api.${config.baseDomain}`);
       expect(headers.get("x-forwarded-proto")).toBe("http");
       expect(headers.get("x-forwarded-for")).toBe("127.0.0.1");
       expect(headers.get("x-real-ip")).toBeNull();

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -264,6 +264,7 @@ describe("sdkProxyRoutes functions proxy", () => {
       expect(response.status).toBe(200);
       expect(calls).toHaveLength(1);
       expect(calls[0]?.url).toBe("http://127.0.0.1:8361/health");
+      expect(sdkProxyInternals.resolveProjectRefFromApiKey).toHaveBeenCalledWith("anon", { includeProvisioning: true });
     });
   });
 

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -301,6 +301,39 @@ describe("sdkProxyRoutes functions proxy", () => {
     });
   });
 
+  test("auth proxy accepts gateway-injected project ref on loopback without apikey", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      const sqlSpy = trackSpy(spyOn(dbModule, "sql"));
+      sqlSpy.mockImplementation(async (...args: unknown[]) => {
+        const text = String(args[0] ?? "");
+        if (text.includes("SELECT ref")) {
+          return [{ ref: "proj_from_header", config: {} }];
+        }
+        if (text.includes("SELECT config")) {
+          return [{
+            config: {
+              postgrest_port: 7361,
+              gotrue_port: 8361,
+            },
+          }];
+        }
+        return [];
+      });
+
+      const response = await request("/auth/v1/health", {
+        method: "GET",
+        headers: {
+          host: "127.0.0.1:9090",
+          "x-project-ref": "proj_from_header",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("http://127.0.0.1:8361/health");
+    });
+  });
+
   test("functions proxy accepts gateway-injected project ref on trusted custom API host without apikey", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
       const sqlSpy = trackSpy(spyOn(dbModule, "sql"));

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -311,6 +311,7 @@ describe("sdkProxyRoutes functions proxy", () => {
       sqlSpy.mockImplementation(async (...args: unknown[]) => {
         const text = String(args[0] ?? "");
         if (text.includes("SELECT ref")) {
+          expect(text).not.toContain("ANY(");
           return [{ ref: "proj_from_header", config: {} }];
         }
         if (text.includes("SELECT config")) {

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -275,6 +275,35 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     bucketSpy.mockRestore();
   });
 
+  test("allows provisioning project refs from trusted loopback storage headers", async () => {
+    const sqlSpy = spyOn(dbModule, "sql");
+    let sawProvisioningStatuses = false;
+    sqlSpy.mockImplementation(async (...args: unknown[]) => {
+      const text = String(args[0] ?? "");
+      if (text.includes("FROM projects")) {
+        sawProvisioningStatuses = args.some((arg) => Array.isArray(arg) && arg.includes("creating"));
+        return [{ ref: "provisioning_header_ref", config: {} }];
+      }
+      return [];
+    });
+
+    const bucketSpy = spyOn(StorageRLS, "listLogicalBuckets").mockResolvedValue([]);
+
+    const res = await request("/storage/v1/bucket", {
+      headers: {
+        host: "127.0.0.1:9090",
+        "x-project-ref": "provisioning_header_ref",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+    expect(sawProvisioningStatuses).toBe(true);
+    expect(bucketSpy).toHaveBeenCalledWith("provisioning_header_ref", undefined, expect.any(Object));
+    sqlSpy.mockRestore();
+    bucketSpy.mockRestore();
+  });
+
   test("public downloads prefer stored object mimetype when backend returns octet-stream", async () => {
     mockObjects.set("avatars/folder/cat.png", {
       metadata: { size: 3, mimetype: "image/png" },

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -251,7 +251,7 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     sqlSpy.mockImplementation(async (...args: unknown[]) => {
       const text = String(args[0] ?? "");
       if (text.includes("anon_key") || text.includes("service_role_key")) {
-        sawProvisioningStatuses = args.some((arg) => Array.isArray(arg) && arg.includes("creating"));
+        sawProvisioningStatuses = text.includes("lower(status) IN ('active', 'creating')");
         return [{ ref: "provisioning_ref" }];
       }
       return [];
@@ -281,7 +281,7 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     sqlSpy.mockImplementation(async (...args: unknown[]) => {
       const text = String(args[0] ?? "");
       if (text.includes("FROM projects")) {
-        sawProvisioningStatuses = args.some((arg) => Array.isArray(arg) && arg.includes("creating"));
+        sawProvisioningStatuses = text.includes("lower(status) IN ('active', 'creating')");
         return [{ ref: "provisioning_header_ref", config: {} }];
       }
       return [];

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -245,6 +245,36 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     downloadSpy.mockRestore();
   });
 
+  test("allows project-scoped storage requests while a new project is provisioning", async () => {
+    const sqlSpy = spyOn(dbModule, "sql");
+    let sawProvisioningStatuses = false;
+    sqlSpy.mockImplementation(async (...args: unknown[]) => {
+      const text = String(args[0] ?? "");
+      if (text.includes("anon_key") || text.includes("service_role_key")) {
+        sawProvisioningStatuses = args.some((arg) => Array.isArray(arg) && arg.includes("creating"));
+        return [{ ref: "provisioning_ref" }];
+      }
+      return [];
+    });
+
+    const bucketSpy = spyOn(StorageRLS, "listLogicalBuckets").mockResolvedValue([]);
+
+    const res = await request("/storage/v1/bucket", {
+      headers: {
+        apikey: "service-role-key-for-provisioning-project",
+        authorization: "Bearer service-role-key-for-provisioning-project",
+        "x-project-ref": "provisioning_ref",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+    expect(sawProvisioningStatuses).toBe(true);
+    expect(bucketSpy).toHaveBeenCalledWith("provisioning_ref", "Bearer service-role-key-for-provisioning-project", expect.any(Object));
+    sqlSpy.mockRestore();
+    bucketSpy.mockRestore();
+  });
+
   test("public downloads prefer stored object mimetype when backend returns octet-stream", async () => {
     mockObjects.set("avatars/folder/cat.png", {
       metadata: { size: 3, mimetype: "image/png" },

--- a/packages/management-api/tests/unit/storage-s3.routes.test.ts
+++ b/packages/management-api/tests/unit/storage-s3.routes.test.ts
@@ -36,7 +36,9 @@ const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(mo
 const updateConfigSpy = spyOn(projectRepository, "updateConfig").mockImplementation(mockUpdateConfig as never);
 
 const { storageS3Routes } = await import("../../src/routes/storage-s3");
+const { storageRoutes } = await import("../../src/routes/storage");
 const app = new Elysia().use(storageS3Routes);
+const combinedStorageApp = new Elysia().use(storageS3Routes).use(storageRoutes);
 
 // Helper: build an authenticated request.
 function authedRequest(path: string, init: RequestInit = {}): Promise<Response> {
@@ -211,6 +213,29 @@ describe("storageS3Routes", () => {
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("etag")).toBeTruthy();
+    expect(mockUploadFile).toHaveBeenCalledWith(
+      "testproj",
+      "mybucket",
+      "path/to/file.txt",
+      expect.anything(),
+      "text/plain",
+    );
+  });
+
+  test("S3 routes take precedence when generic storage routes are registered too", async () => {
+    mockUploadFile.mockResolvedValue(true);
+    const res = await combinedStorageApp.handle(
+      new Request("http://localhost/v1/storage/testproj/s3/mybucket/path/to/file.txt", {
+        method: "PUT",
+        body: "hello world",
+        headers: {
+          authorization: "Bearer test-service-key",
+          "content-type": "text/plain",
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
     expect(mockUploadFile).toHaveBeenCalledWith(
       "testproj",
       "mybucket",


### PR DESCRIPTION
## Summary
- register the S3-compatible storage routes before the generic storage API routes
- add a regression test proving /v1/storage/:ref/s3/* is handled by the S3 route surface when both route modules are mounted

## Verification
- bun test packages/management-api/tests/unit/storage-s3.routes.test.ts packages/management-api/tests/unit/storage-compat.sdk.test.ts packages/management-api/tests/unit/sdk-proxy.functions.test.ts
- bun run --cwd packages/management-api typecheck
- git diff --check