### PR TITLE
fix(storage): prioritize S3 compatibility routes

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -899,6 +899,10 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
       .use(databaseExtensionRoutes)
       .use(systemExtensionRoutes)
       .use(securityRoutes)
+      // Register the S3-compatible surface before the generic storage API.
+      // Otherwise `/v1/storage/:ref/buckets...` style routes can capture
+      // `/v1/storage/:ref/s3/...` requests first.
+      .use(storageS3Routes)
       .use(storageRoutes)
       .use(projectStorageRoutes)
       .use(scalingRoutes)
@@ -925,7 +929,6 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
       .use(scheduledFunctionRoutes)
       .use(branchRoutes)
       .use(pgMetaRoutes)
-      .use(storageS3Routes)
       .use(autoBranchingRoutes)
       .use(projectRbacRoutes)
       .use(projectWebhookRoutes)

--- a/packages/management-api/tests/unit/storage-s3.routes.test.ts
+++ b/packages/management-api/tests/unit/storage-s3.routes.test.ts
@@ -36,7 +36,9 @@ const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(mo
 const updateConfigSpy = spyOn(projectRepository, "updateConfig").mockImplementation(mockUpdateConfig as never);
 
 const { storageS3Routes } = await import("../../src/routes/storage-s3");
+const { storageRoutes } = await import("../../src/routes/storage");
 const app = new Elysia().use(storageS3Routes);
+const combinedStorageApp = new Elysia().use(storageS3Routes).use(storageRoutes);
 
 // Helper: build an authenticated request.
 function authedRequest(path: string, init: RequestInit = {}): Promise<Response> {
@@ -211,6 +213,29 @@ describe("storageS3Routes", () => {
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("etag")).toBeTruthy();
+    expect(mockUploadFile).toHaveBeenCalledWith(
+      "testproj",
+      "mybucket",
+      "path/to/file.txt",
+      expect.anything(),
+      "text/plain",
+    );
+  });
+
+  test("S3 routes take precedence when generic storage routes are registered too", async () => {
+    mockUploadFile.mockResolvedValue(true);
+    const res = await combinedStorageApp.handle(
+      new Request("http://localhost/v1/storage/testproj/s3/mybucket/path/to/file.txt", {
+        method: "PUT",
+        body: "hello world",
+        headers: {
+          authorization: "Bearer test-service-key",
+          "content-type": "text/plain",
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
     expect(mockUploadFile).toHaveBeenCalledWith(
       "testproj",
       "mybucket",


### PR DESCRIPTION
## Summary
- register the S3-compatible storage routes before the generic storage API routes
- add a regression test proving /v1/storage/:ref/s3/* is handled by the S3 route surface when both route modules are mounted

## Verification
- bun test packages/management-api/tests/unit/storage-s3.routes.test.ts packages/management-api/tests/unit/storage-compat.sdk.test.ts packages/management-api/tests/unit/sdk-proxy.functions.test.ts
- bun run --cwd packages/management-api typecheck
- git diff --check