### PR TITLE
fix(storage): let S3 SigV4 bypass API bearer guard

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -28,6 +28,7 @@ import { resolveRealtimeTenantHost } from "./utils/sdk-parity";
 import { resolveProjectRefFromApiKey } from "./utils/project-auth";
 import { isFrontendDomain } from "./utils/frontend-domains";
 import { isCaddyRouteDomain, isCaddyTlsBlockedDomain, normalizeCaddyHost } from "./utils/caddy-domains";
+import { isS3DataPlaneRequest } from "./utils/storage-s3-paths";
 
 const WEB_CONSOLE_CURRENT_DIR = "/opt/supacloud/web-console/current";
 const WEB_CONSOLE_LEGACY_DIR = "/opt/supacloud/packages/web-console/build";
@@ -850,13 +851,15 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
           return rateLimit.body;
         }
 
-        const result = await checkAuth(request);
-        if (result) {
-          set.status = result.status;
-          if (shouldAuditRequest(request)) {
-            await logAuditEvent({ request, status: result.status, action: "auth_denied" });
+        if (!isS3DataPlaneRequest(request)) {
+          const result = await checkAuth(request);
+          if (result) {
+            set.status = result.status;
+            if (shouldAuditRequest(request)) {
+              await logAuditEvent({ request, status: result.status, action: "auth_denied" });
+            }
+            return { message: result.body.error, code: String(result.status) };
           }
-          return { message: result.body.error, code: String(result.status) };
         }
       })
       .onAfterHandle(async ({ request, set }) => {

--- a/packages/management-api/src/utils/storage-s3-paths.ts
+++ b/packages/management-api/src/utils/storage-s3-paths.ts
@@ -1,0 +1,10 @@
+const S3_PREFIX_PATTERN = /^\/v1\/storage\/[^/]+\/s3(?:\/|$)/;
+const S3_CREDENTIALS_PATTERN = /^\/v1\/storage\/[^/]+\/s3\/credentials\/?$/;
+
+export function isS3DataPlanePath(pathname: string): boolean {
+  return S3_PREFIX_PATTERN.test(pathname) && !S3_CREDENTIALS_PATTERN.test(pathname);
+}
+
+export function isS3DataPlaneRequest(request: Request): boolean {
+  return isS3DataPlanePath(new URL(request.url).pathname);
+}

--- a/packages/management-api/tests/unit/storage-s3-paths.test.ts
+++ b/packages/management-api/tests/unit/storage-s3-paths.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { isS3DataPlanePath } from "../../src/utils/storage-s3-paths";
+
+describe("storage S3 path classification", () => {
+  test("classifies S3 object and bucket operations as data-plane requests", () => {
+    expect(isS3DataPlanePath("/v1/storage/testproj/s3")).toBe(true);
+    expect(isS3DataPlanePath("/v1/storage/testproj/s3/")).toBe(true);
+    expect(isS3DataPlanePath("/v1/storage/testproj/s3/mybucket")).toBe(true);
+    expect(isS3DataPlanePath("/v1/storage/testproj/s3/mybucket/path/to/file.txt")).toBe(true);
+  });
+
+  test("keeps credential and generic storage requests under platform auth", () => {
+    expect(isS3DataPlanePath("/v1/storage/testproj/s3/credentials")).toBe(false);
+    expect(isS3DataPlanePath("/v1/storage/testproj/s3/credentials/")).toBe(false);
+    expect(isS3DataPlanePath("/v1/storage/testproj/buckets")).toBe(false);
+    expect(isS3DataPlanePath("/storage/v1/object/testproj/mybucket/file.txt")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- let `/v1/storage/:ref/s3` data-plane requests bypass the global Bearer-only API guard
- keep `/v1/storage/:ref/s3/credentials` under platform auth
- add path classification regression coverage

## Verification
- `bun test packages/management-api/tests/unit/storage-s3-paths.test.ts packages/management-api/tests/unit/storage-s3.routes.test.ts packages/management-api/tests/unit/storage-compat.sdk.test.ts`
- `bun run --cwd packages/management-api typecheck`
- `git diff --check`
- vm1 live smoke against `xgic-ocr-review-images`: SigV4 `PUT` returned 200, `GET` returned 200, and payload SHA matched
