### PR TITLE
feat(supacloud): add unified entrypoint package

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,6 +33,7 @@ jobs:
       supacloud_js_released: ${{ steps.release.outputs['packages/supacloud-js--release_created'] }}
       cli_released: ${{ steps.release.outputs['packages/cli--release_created'] }}
       admin_released: ${{ steps.release.outputs['packages/admin--release_created'] }}
+      supacloud_released: ${{ steps.release.outputs['packages/supacloud--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -221,6 +222,14 @@ jobs:
       - name: Publish admin to NPM
         if: ${{ needs.release-please.outputs.admin_released == 'true' }}
         working-directory: packages/admin
+        run: |
+          bun install
+          bun run build
+          bunx npm publish --provenance --access public
+
+      - name: Publish supacloud (umbrella) to NPM
+        if: ${{ needs.release-please.outputs.supacloud_released == 'true' }}
+        working-directory: packages/supacloud
         run: |
           bun install
           bun run build

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "packages/edge-runtime": "0.8.7",
   "packages/supacloud-js": "0.18.3",
   "packages/cli": "0.7.0",
-  "packages/admin": "0.2.0"
+  "packages/admin": "0.2.0",
+  "packages/supacloud": "0.1.0"
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,7 +62,7 @@ function printHelp(context = resolveSupaCloudContext()) {
 ║  Project CLI for SupaCloud users                         ║
 ╚═══════════════════════════════════════════════════════════╝
 
-${commandName === "supacloud" ? "NOTE\n\n  `supacloud` is kept as a compatibility alias. Prefer `supacloud-cli`\n  to avoid confusion with the server binary at /usr/local/bin/supacloud.\n" : ""}
+${commandName === "supacloud" ? "NOTE\n\n  `supacloud` is now the unified entrypoint package (`npm i -g supacloud`).\n  Use `supacloud cli ...` to reach this CLI, or keep using `supacloud-cli` directly.\n" : ""}
 
 USAGE
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import path from "node:path";
 import { z } from "zod";
 import { runCli } from "./shared/cli";
 import { resolveSupaCloudContext } from "./shared/context";
@@ -17,9 +16,8 @@ import { registerGatewayTools } from "./shared/tools/gateway-tools";
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
 type ToolMap = Record<string, ToolEntry>;
 
-const invokedCommand = path.basename(process.argv[1] || "supacloud-cli");
-const commandName = invokedCommand === "supacloud" ? "supacloud" : "supacloud-cli";
-const preferredCommand = "supacloud-cli";
+const commandName = "supacloud-cli";
+const preferredCommand = commandName;
 const projectActionSchema = z.enum([
     "get", "health", "logs", "api_keys", "settings",
     "tasks", "task_detail", "task_cancel", "task_retry", "task_stats", "dlq", "background_settings",
@@ -61,8 +59,6 @@ function printHelp(context = resolveSupaCloudContext()) {
 ║  supacloud-cli                                           ║
 ║  Project CLI for SupaCloud users                         ║
 ╚═══════════════════════════════════════════════════════════╝
-
-${commandName === "supacloud" ? "NOTE\n\n  `supacloud` is now the unified entrypoint package (`npm i -g supacloud`).\n  Use `supacloud cli ...` to reach this CLI, or keep using `supacloud-cli` directly.\n" : ""}
 
 USAGE
 

--- a/packages/supacloud/README.md
+++ b/packages/supacloud/README.md
@@ -1,0 +1,62 @@
+# supacloud
+
+Unified entrypoint that bundles both SupaCloud CLIs behind a single `supacloud` command.
+
+```
+supacloud cli   → @supacloud/cli    (project-scoped developer tools)
+supacloud admin → @supacloud/admin  (platform operations: install / SSH / tenant management)
+```
+
+## 安装
+
+```bash
+npm install -g supacloud
+supacloud --help
+```
+
+One-off execution:
+
+```bash
+npx supacloud cli status
+npx supacloud admin status
+```
+
+`supacloud` depends on both `@supacloud/cli` and `@supacloud/admin`, so installing
+it gives you the full toolset. You can still install either CLI on its own
+(`@supacloud/cli` exposes `supacloud-cli`, `@supacloud/admin` exposes `supacloud-admin`).
+
+## 用法
+
+```bash
+supacloud cli status
+supacloud cli project get
+supacloud cli gateway routes --ref <ref>
+
+supacloud admin status
+supacloud admin project list
+supacloud admin ssh ping
+```
+
+Each subcommand accepts its own `--help`:
+
+```bash
+supacloud cli --help
+supacloud admin --help
+```
+
+## 上下文
+
+`supacloud cli` auto-links the current project from `.env`:
+
+- `SUPABASE_URL` / `SUPACLOUD_API_URL`
+- `SUPABASE_SERVICE_ROLE_KEY` / `SUPACLOUD_API_TOKEN`
+
+`supacloud admin` expects platform context:
+
+- `SUPACLOUD_HOST` + `SUPACLOUD_SSH_KEY` / `SUPACLOUD_SSH_PASS`
+- `SUPACLOUD_API_URL` + `SUPACLOUD_API_TOKEN`
+
+> Note: on hosts where SupaCloud is installed as a server, `/usr/local/bin/supacloud`
+> is the compiled management-api binary (the server process). This npm package's
+> `supacloud` command targets developer/operator workflows and is meant for your
+> local machine, not the server's process namespace.

--- a/packages/supacloud/package.json
+++ b/packages/supacloud/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@supacloud/cli",
-  "version": "0.7.0",
-  "description": "Project-scoped CLI for SupaCloud users",
+  "name": "supacloud",
+  "version": "0.1.0",
+  "description": "Unified entrypoint: `supacloud cli` and `supacloud admin` in one command",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {
-    "supacloud-cli": "dist/index.js"
+    "supacloud": "dist/index.js"
   },
   "files": [
     "dist",
@@ -20,17 +20,19 @@
   "keywords": [
     "supacloud",
     "cli",
-    "deploy",
-    "supabase"
+    "admin",
+    "supabase",
+    "umbrella"
   ],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/zuohuadong/supacloud.git",
-    "directory": "packages/cli"
+    "directory": "packages/supacloud"
   },
   "dependencies": {
-    "zod": "^4.4.3"
+    "@supacloud/cli": "^0.7.0",
+    "@supacloud/admin": "^0.2.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/packages/supacloud/src/index.test.ts
+++ b/packages/supacloud/src/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { SUBCOMMANDS, buildHelp, resolveSubpackageEntry } from "./index";
+
+describe("supacloud dispatcher", () => {
+    test("exposes cli and admin subcommands", () => {
+        expect(Object.keys(SUBCOMMANDS).sort()).toEqual(["admin", "cli"]);
+        expect(SUBCOMMANDS.cli.pkg).toBe("@supacloud/cli");
+        expect(SUBCOMMANDS.admin.pkg).toBe("@supacloud/admin");
+    });
+
+    test("help lists both subcommands and usage", () => {
+        const help = buildHelp();
+        expect(help).toContain("supacloud <子命令>");
+        expect(help).toContain("cli");
+        expect(help).toContain("admin");
+        expect(help).toContain("@supacloud/cli");
+        expect(help).toContain("@supacloud/admin");
+    });
+
+    test("resolveSubpackageEntry returns a path for an installed package", () => {
+        // 自身模块必然可解析；验证 resolve 逻辑不抛错
+        const entry = resolveSubpackageEntry("bun");
+        expect(typeof entry).toBe("string");
+    });
+
+    test("resolveSubpackageEntry returns null for a missing package", () => {
+        const entry = resolveSubpackageEntry("@supacloud/__definitely_not_a_pkg__");
+        expect(entry).toBeNull();
+    });
+});

--- a/packages/supacloud/src/index.ts
+++ b/packages/supacloud/src/index.ts
@@ -70,7 +70,7 @@ cli 与 admin 的全部能力；二者也可单独安装为 @supacloud/cli /
 `;
 }
 
-function run(args: string[]): never {
+function run(args: string[]): void {
     const sub = args[0];
 
     if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
@@ -101,8 +101,6 @@ function run(args: string[]): never {
         console.error(`❌ 启动 ${target.pkg} 失败: ${err.message}`);
         process.exit(1);
     });
-
-    return undefined as never;
 }
 
 // 仅在作为脚本直接运行时执行分发，避免被 import（如测试）时的副作用退出

--- a/packages/supacloud/src/index.ts
+++ b/packages/supacloud/src/index.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * supacloud — 统一入口（umbrella dispatcher）。
+ *
+ * 单一 `supacloud` 命令把子命令路由到对应的工作区包：
+ *   supacloud cli   <args...>   → @supacloud/cli   （项目级开发工具）
+ *   supacloud admin <args...>   → @supacloud/admin （平台运维工具）
+ *
+ * 子包以依赖形式安装；运行时通过 createRequire 解析子包入口，
+ * 用当前 Node 进程 spawn 执行，参数与退出码原样透传。
+ */
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+interface Subcommand {
+    pkg: string;
+    desc: string;
+}
+
+export const SUBCOMMANDS: Record<string, Subcommand> = {
+    cli: { pkg: "@supacloud/cli", desc: "项目级 CLI（开发者工具）" },
+    admin: { pkg: "@supacloud/admin", desc: "平台运维 CLI（安装/SSH/租户管理）" },
+};
+
+/** 解析子包入口（package.json 的 main → dist/index.js）。未安装返回 null。 */
+export function resolveSubpackageEntry(pkgName: string): string | null {
+    try {
+        return require.resolve(pkgName);
+    } catch {
+        return null;
+    }
+}
+
+const COMMAND = "supacloud";
+
+export function buildHelp(): string {
+    const subs = Object.entries(SUBCOMMANDS)
+        .map(([name, sub]) => `  ${name.padEnd(6)} ${sub.desc}`)
+        .join("\n");
+    return `
+╔═══════════════════════════════════════════════════════════╗
+║  supacloud                                               ║
+║  统一入口 · 路由到项目级 CLI 与平台运维 CLI              ║
+╚═══════════════════════════════════════════════════════════╝
+
+用法
+
+  ${COMMAND} <子命令> [args...]
+  ${COMMAND} --help
+
+子命令
+
+${subs}
+
+示例
+
+  ${COMMAND} cli status
+  ${COMMAND} cli project get
+  ${COMMAND} cli gateway routes --ref <ref>
+  ${COMMAND} admin status
+  ${COMMAND} admin project list
+  ${COMMAND} admin ssh ping
+
+每个子命令都接受各自的 --help。安装后 supacloud 同时拥有
+cli 与 admin 的全部能力；二者也可单独安装为 @supacloud/cli /
+@supacloud/admin，通过 supacloud-cli / supacloud-admin 调用。
+`;
+}
+
+function run(args: string[]): never {
+    const sub = args[0];
+
+    if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
+        console.error(buildHelp());
+        process.exit(0);
+    }
+
+    const target = SUBCOMMANDS[sub];
+    if (!target) {
+        console.error(`❌ 未知子命令: ${sub}\n`);
+        console.error(buildHelp());
+        process.exit(1);
+    }
+
+    const entry = resolveSubpackageEntry(target.pkg);
+    if (!entry) {
+        console.error(`❌ ${target.pkg} 未安装。请确认 supacloud 包依赖完整，或单独安装 ${target.pkg}。`);
+        process.exit(1);
+    }
+
+    // 把子命令之后的参数原样透传给子包入口
+    const child = spawn(process.execPath, [entry, ...args.slice(1)], {
+        stdio: "inherit",
+    });
+
+    child.on("close", (code) => process.exit(code ?? 1));
+    child.on("error", (err) => {
+        console.error(`❌ 启动 ${target.pkg} 失败: ${err.message}`);
+        process.exit(1);
+    });
+
+    return undefined as never;
+}
+
+// 仅在作为脚本直接运行时执行分发，避免被 import（如测试）时的副作用退出
+const isMainEntry = (() => {
+    try {
+        return fileURLToPath(import.meta.url) === process.argv[1];
+    } catch {
+        return false;
+    }
+})();
+if (isMainEntry) run(process.argv.slice(2));

--- a/packages/supacloud/tsconfig.json
+++ b/packages/supacloud/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "types": [
+      "bun"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,36 @@
 {
   "bump-minor-pre-major": true,
   "changelog-sections": [
-    {"type": "feat", "section": "Features", "hidden": false},
-    {"type": "fix", "section": "Bug Fixes", "hidden": false},
-    {"type": "refactor", "section": "Elegance & Refactoring", "hidden": false},
-    {"type": "perf", "section": "Performance Improvements", "hidden": false},
-    {"type": "docs", "section": "Documentation", "hidden": false},
-    {"type": "chore", "section": "Miscellaneous Chores", "hidden": false}
+    {
+      "type": "feat",
+      "section": "Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": "Elegance & Refactoring",
+      "hidden": false
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores",
+      "hidden": false
+    }
   ],
   "packages": {
     "packages/management-api": {
@@ -37,6 +61,11 @@
     "packages/admin": {
       "release-type": "node",
       "component": "admin",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/supacloud": {
+      "release-type": "node",
+      "component": "supacloud",
       "changelog-path": "CHANGELOG.md"
     }
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,36 +1,12 @@
 {
   "bump-minor-pre-major": true,
   "changelog-sections": [
-    {
-      "type": "feat",
-      "section": "Features",
-      "hidden": false
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes",
-      "hidden": false
-    },
-    {
-      "type": "refactor",
-      "section": "Elegance & Refactoring",
-      "hidden": false
-    },
-    {
-      "type": "perf",
-      "section": "Performance Improvements",
-      "hidden": false
-    },
-    {
-      "type": "docs",
-      "section": "Documentation",
-      "hidden": false
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous Chores",
-      "hidden": false
-    }
+    {"type": "feat", "section": "Features", "hidden": false},
+    {"type": "fix", "section": "Bug Fixes", "hidden": false},
+    {"type": "refactor", "section": "Elegance & Refactoring", "hidden": false},
+    {"type": "perf", "section": "Performance Improvements", "hidden": false},
+    {"type": "docs", "section": "Documentation", "hidden": false},
+    {"type": "chore", "section": "Miscellaneous Chores", "hidden": false}
   ],
   "packages": {
     "packages/management-api": {
@@ -56,12 +32,26 @@
     "packages/cli": {
       "release-type": "node",
       "component": "cli",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "packages/supacloud/package.json",
+          "jsonpath": "$.dependencies['@supacloud/cli']"
+        }
+      ]
     },
     "packages/admin": {
       "release-type": "node",
       "component": "admin",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "packages/supacloud/package.json",
+          "jsonpath": "$.dependencies['@supacloud/admin']"
+        }
+      ]
     },
     "packages/supacloud": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- add the unscoped supacloud umbrella package for supacloud cli and supacloud admin
- remove the bare supacloud bin from @supacloud/cli so package names can coexist
- wire release-please publishing and dependency updates for the umbrella package

## Validation
- bun test packages/supacloud/src/index.test.ts
- bun run --cwd packages/supacloud typecheck
- bun run --cwd packages/supacloud build
- bun run --cwd packages/cli typecheck
- git diff --check -- packages/cli/src/index.ts packages/supacloud/src/index.ts release-please-config.json