### PR TITLE
fix(auth): repair tenant auth schema ownership

### DIFF
--- a/packages/management-api/src/services/database.service.ts
+++ b/packages/management-api/src/services/database.service.ts
@@ -24,6 +24,76 @@ function pgEscapePassword(password: string): string {
   return `$${tag}$${password}$${tag}$`;
 }
 
+export function renderAuthSchemaOwnershipSql(authOwner = "supabase_auth_admin"): string {
+  assertValidIdentifier("authOwner", authOwner);
+  const owner = `"${authOwner}"`;
+  return `
+ALTER SCHEMA auth OWNER TO ${owner};
+
+DO $$
+DECLARE
+  auth_object RECORD;
+  alter_kind TEXT;
+BEGIN
+  FOR auth_object IN
+    SELECT c.relkind, n.nspname, c.relname
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'auth'
+      AND c.relkind IN ('r', 'p', 'S', 'v', 'm', 'f')
+      AND NOT (
+        c.relkind = 'S'
+        AND EXISTS (
+          SELECT 1
+          FROM pg_depend d
+          WHERE d.classid = 'pg_class'::regclass
+            AND d.objid = c.oid
+            AND d.deptype = 'a'
+        )
+      )
+  LOOP
+    alter_kind := CASE auth_object.relkind
+      WHEN 'S' THEN 'SEQUENCE'
+      WHEN 'v' THEN 'VIEW'
+      WHEN 'm' THEN 'MATERIALIZED VIEW'
+      WHEN 'f' THEN 'FOREIGN TABLE'
+      ELSE 'TABLE'
+    END;
+    EXECUTE format('ALTER %s %I.%I OWNER TO ${owner}', alter_kind, auth_object.nspname, auth_object.relname);
+  END LOOP;
+END $$;
+
+DO $$
+DECLARE
+  auth_function RECORD;
+BEGIN
+  FOR auth_function IN
+    SELECT n.nspname, p.proname, pg_get_function_identity_arguments(p.oid) AS args
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'auth'
+  LOOP
+    EXECUTE format('ALTER FUNCTION %I.%I(%s) OWNER TO ${owner}', auth_function.nspname, auth_function.proname, auth_function.args);
+  END LOOP;
+END $$;
+
+DO $$
+DECLARE
+  auth_type RECORD;
+BEGIN
+  FOR auth_type IN
+    SELECT n.nspname, t.typname
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'auth'
+      AND t.typtype IN ('d', 'e')
+  LOOP
+    EXECUTE format('ALTER TYPE %I.%I OWNER TO ${owner}', auth_type.nspname, auth_type.typname);
+  END LOOP;
+END $$;
+`;
+}
+
 export class DatabaseService {
   private readonly PG_HOST = config.pgHost;
   private readonly PG_PORT = config.pgPort;
@@ -323,6 +393,7 @@ export class DatabaseService {
       try {
         const schemaSql = await this.loadSupabaseSchema();
         await tenantDb.unsafe(schemaSql);
+        await tenantDb.unsafe(renderAuthSchemaOwnershipSql());
         logger.info(
           `[services/database.service] Successfully applied supabase.sql to tenant ${dbName}`,
         );

--- a/packages/management-api/tests/unit/database.service.test.ts
+++ b/packages/management-api/tests/unit/database.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, mock, spyOn } from "bun:test";
-import { DatabaseService } from "../../src/services/database.service";
+import { DatabaseService, renderAuthSchemaOwnershipSql } from "../../src/services/database.service";
 import { shellService } from "../../src/services/shell.service";
 
 /** Typed mock for SQL connection used in DatabaseService */
@@ -20,6 +20,7 @@ function createMockSql(): MockSql {
 describe("DatabaseService", () => {
   let databaseService: DatabaseService;
   let mockSql: MockSql;
+  let applySupabaseSchemaSpy: { mockRestore: () => void };
 
   beforeEach(() => {
     databaseService = new DatabaseService();
@@ -34,7 +35,8 @@ describe("DatabaseService", () => {
     spyOn(DatabaseService.prototype as unknown as Record<string, unknown>, "checkDiskSpace").mockResolvedValue(undefined);
 
     // Mock applySupabaseSchema to avoid complex nested DB calls in simple tests
-    spyOn(DatabaseService.prototype as unknown as Record<string, unknown>, "applySupabaseSchema").mockResolvedValue(undefined);
+    applySupabaseSchemaSpy = spyOn(DatabaseService.prototype as unknown as Record<string, unknown>, "applySupabaseSchema")
+      .mockResolvedValue(undefined);
   });
 
   describe("generatePassword", () => {
@@ -64,6 +66,39 @@ describe("DatabaseService", () => {
       expect(mockSql.unsafe).toHaveBeenCalledWith(expect.stringContaining(
         'GRANT CONNECT, TEMPORARY ON DATABASE "supa_testref123" TO "authenticator_testref123"',
       ));
+    });
+  });
+
+  describe("renderAuthSchemaOwnershipSql", () => {
+    test("transfers auth schema objects to the GoTrue runtime role", () => {
+      const sql = renderAuthSchemaOwnershipSql();
+
+      expect(sql).toContain('ALTER SCHEMA auth OWNER TO "supabase_auth_admin"');
+      expect(sql).toContain("ALTER %s %I.%I OWNER TO \"supabase_auth_admin\"");
+      expect(sql).toContain("ALTER FUNCTION %I.%I(%s) OWNER TO \"supabase_auth_admin\"");
+      expect(sql).toContain("ALTER TYPE %I.%I OWNER TO \"supabase_auth_admin\"");
+      expect(sql).toContain("c.relkind IN ('r', 'p', 'S', 'v', 'm', 'f')");
+      expect(sql).toContain("FROM pg_depend d");
+      expect(sql).toContain("d.deptype = 'a'");
+      expect(sql).toContain("t.typtype IN ('d', 'e')");
+    });
+
+    test("rejects unsafe owner identifiers before building DDL", () => {
+      expect(() => renderAuthSchemaOwnershipSql("bad-role;DROP SCHEMA auth")).toThrow();
+    });
+
+    test("applySupabaseSchema runs ownership repair after loading tenant schema", async () => {
+      applySupabaseSchemaSpy.mockRestore();
+      const service = new DatabaseService();
+      const tenantSql = createMockSql();
+      spyOn(DatabaseService.prototype as any, "getTenantDb").mockReturnValue(tenantSql);
+      spyOn(DatabaseService.prototype as any, "loadSupabaseSchema").mockResolvedValue("SELECT 'tenant schema loaded';");
+
+      await (service as unknown as { applySupabaseSchema(dbName: string, projectRef: string, password: string): Promise<void> })
+        .applySupabaseSchema("supa_testref123", "testref123", "testpass");
+
+      expect(tenantSql.unsafe).toHaveBeenCalledWith("SELECT 'tenant schema loaded';");
+      expect(tenantSql.unsafe).toHaveBeenCalledWith(expect.stringContaining('ALTER SCHEMA auth OWNER TO "supabase_auth_admin"'));
     });
   });
 


### PR DESCRIPTION
## Summary
- transfer tenant `auth` schema ownership to `supabase_auth_admin` after Supabase-compatible bootstrap SQL is applied
- include auth tables, sequences, views, functions, and enum/domain types so GoTrue can run later migrations as its runtime role
- cover ownership SQL generation and the applySupabaseSchema execution path with unit tests

## Context
The xgic OCR review flow does not depend on GoTrue, but newly provisioned SupaCloud projects still start the Auth runtime. GoTrue can crash-loop with `must be owner of table users` when bootstrap SQL created auth objects through the management connection and only granted privileges. PostgreSQL owner-only ALTER paths require actual ownership, not just GRANT ALL.

## Verification
- bun test tests/unit/database.service.test.ts tests/unit/supabase-schema.test.ts
- bun run typecheck
- git diff --check
