### PR TITLE
feat(supacloud): auto-update cli dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,8 +461,10 @@ The desired state is stored in dedicated project metadata columns (`postgrest_de
 For human operators, the CLI split is now:
 
 - `@supacloud/cli` / `supacloud-cli`: project-scoped user CLI with `.env` auto-link defaults
-- Preferred command: `supacloud-cli`. The bare `supacloud` name is only a backward-compatible alias because `/usr/local/bin/supacloud` is the server binary.
+- `supacloud cli ...`: unified local entrypoint. It checks the npm `latest` dist-tag and runs a newer `@supacloud/cli` automatically; set `SUPACLOUD_NO_AUTO_UPDATE=1` to force the bundled version.
 - `@supacloud/admin` / `supacloud-admin`: server and platform administration CLI
+- `supacloud admin ...`: unified local entrypoint with the same latest-check behavior for `@supacloud/admin`.
+- On installed servers, `/usr/local/bin/supacloud` remains the compiled server binary; server upgrades still use `sudo supacloud upgrade --yes`.
 
 
 ### Project Structure
@@ -958,8 +960,11 @@ desired state 保存在项目专用元数据列里（`postgrest_desired`、`post
 
 面向真人操作者的命令行现已拆分为：
 
-- `@supacloud/cli` / `supacloud-cli`：项目使用者 CLI，默认从当前目录 `.env` 自动绑定项目；裸 `supacloud` 仅为兼容别名
+- `@supacloud/cli` / `supacloud-cli`：项目使用者 CLI，默认从当前目录 `.env` 自动绑定项目
+- `supacloud cli ...`：统一本地入口，执行前检查 npm `latest`，发现新版 `@supacloud/cli` 会自动运行最新版；设置 `SUPACLOUD_NO_AUTO_UPDATE=1` 可强制使用随包安装的版本
 - `@supacloud/admin` / `supacloud-admin`：服务器管理员 CLI，处理 SSH、安装、升级、租户运维
+- `supacloud admin ...`：统一本地入口，对 `@supacloud/admin` 使用同样的 latest 检查
+- 已安装服务器上的 `/usr/local/bin/supacloud` 仍是编译后的服务端二进制，服务端升级继续使用 `sudo supacloud upgrade --yes`
 
 
 ### 项目结构

--- a/packages/supacloud/README.md
+++ b/packages/supacloud/README.md
@@ -25,6 +25,23 @@ npx supacloud admin status
 it gives you the full toolset. You can still install either CLI on its own
 (`@supacloud/cli` exposes `supacloud-cli`, `@supacloud/admin` exposes `supacloud-admin`).
 
+## 自动更新
+
+`supacloud cli ...` and `supacloud admin ...` check the npm `latest` dist-tag before dispatch.
+When a newer `@supacloud/cli` or `@supacloud/admin` version exists, the dispatcher runs it with
+`npm exec --package <pkg>@<latest> -- <bin> ...args`. If the registry is unavailable, it falls
+back to the dependency version bundled with the installed `supacloud` package.
+
+Disable the latest check when you need a pinned local version:
+
+```bash
+SUPACLOUD_NO_AUTO_UPDATE=1 supacloud cli status
+# or
+SUPACLOUD_AUTO_UPDATE=0 supacloud admin status
+```
+
+Use `SUPACLOUD_NPM_REGISTRY` or `npm_config_registry` to point the check at a registry mirror.
+
 ## 用法
 
 ```bash

--- a/packages/supacloud/src/index.test.ts
+++ b/packages/supacloud/src/index.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, test } from "bun:test";
-import { SUBCOMMANDS, buildHelp, resolveSubpackageEntry } from "./index";
+import {
+    SUBCOMMANDS,
+    buildHelp,
+    buildLatestMetadataUrl,
+    createLaunchPlan,
+    fetchLatestVersion,
+    isAutoUpdateDisabled,
+    resolveSubpackageEntry,
+} from "./index";
 
 describe("supacloud dispatcher", () => {
     test("exposes cli and admin subcommands", () => {
         expect(Object.keys(SUBCOMMANDS).sort()).toEqual(["admin", "cli"]);
         expect(SUBCOMMANDS.cli.pkg).toBe("@supacloud/cli");
+        expect(SUBCOMMANDS.cli.bin).toBe("supacloud-cli");
         expect(SUBCOMMANDS.admin.pkg).toBe("@supacloud/admin");
+        expect(SUBCOMMANDS.admin.bin).toBe("supacloud-admin");
     });
 
     test("help lists both subcommands and usage", () => {
@@ -26,5 +36,115 @@ describe("supacloud dispatcher", () => {
     test("resolveSubpackageEntry returns null for a missing package", () => {
         const entry = resolveSubpackageEntry("@supacloud/__definitely_not_a_pkg__");
         expect(entry).toBeNull();
+    });
+
+    test("buildLatestMetadataUrl encodes scoped package names", () => {
+        expect(buildLatestMetadataUrl("@supacloud/cli", "https://registry.npmjs.org")).toBe(
+            "https://registry.npmjs.org/@supacloud%2Fcli/latest",
+        );
+    });
+
+    test("fetchLatestVersion parses registry latest metadata", async () => {
+        const latest = await fetchLatestVersion(
+            "@supacloud/cli",
+            {},
+            async (input, init) => {
+                expect(input).toBe("https://registry.npmjs.org/@supacloud%2Fcli/latest");
+                expect(init?.headers).toEqual({ Accept: "application/json" });
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ version: "0.8.0" }),
+                };
+            },
+        );
+
+        expect(latest).toBe("0.8.0");
+    });
+
+    test("isAutoUpdateDisabled honors opt-out env vars", () => {
+        expect(isAutoUpdateDisabled({})).toBe(false);
+        expect(isAutoUpdateDisabled({ SUPACLOUD_NO_AUTO_UPDATE: "1" })).toBe(true);
+        expect(isAutoUpdateDisabled({ SUPACLOUD_NO_AUTO_UPDATE: "false" })).toBe(false);
+        expect(isAutoUpdateDisabled({ SUPACLOUD_AUTO_UPDATE: "0" })).toBe(true);
+    });
+
+    test("createLaunchPlan runs the latest package when registry version is newer", async () => {
+        const plan = await createLaunchPlan(SUBCOMMANDS.cli, ["status"], {
+            env: {},
+            fetchLatest: async () => "0.8.0",
+            resolveInstalled: () => ({ entry: "/local/cli.js", version: "0.7.0" }),
+            npmCommand: "npm",
+            platform: "linux",
+        });
+
+        expect(plan).toEqual({
+            mode: "latest",
+            command: "npm",
+            args: ["exec", "--yes", "--package", "@supacloud/cli@0.8.0", "--", "supacloud-cli", "status"],
+            shell: false,
+        });
+    });
+
+    test("createLaunchPlan uses local package when registry is not newer", async () => {
+        const plan = await createLaunchPlan(SUBCOMMANDS.admin, ["status"], {
+            env: {},
+            fetchLatest: async () => "0.2.0",
+            resolveInstalled: () => ({ entry: "/local/admin.js", version: "0.2.0" }),
+            nodePath: "/usr/bin/node",
+            platform: "linux",
+        });
+
+        expect(plan).toEqual({
+            mode: "local",
+            command: "/usr/bin/node",
+            args: ["/local/admin.js", "status"],
+            shell: false,
+        });
+    });
+
+    test("createLaunchPlan falls back to local package when registry is unreachable", async () => {
+        const plan = await createLaunchPlan(SUBCOMMANDS.cli, ["project", "get"], {
+            env: {},
+            fetchLatest: async () => null,
+            resolveInstalled: () => ({ entry: "/local/cli.js", version: "0.7.0" }),
+            nodePath: "/usr/bin/node",
+            platform: "linux",
+        });
+
+        expect(plan.mode).toBe("local");
+        expect(plan.args).toEqual(["/local/cli.js", "project", "get"]);
+    });
+
+    test("createLaunchPlan skips registry lookup when auto-update is disabled", async () => {
+        let fetchCalls = 0;
+        const plan = await createLaunchPlan(SUBCOMMANDS.cli, ["status"], {
+            env: { SUPACLOUD_NO_AUTO_UPDATE: "1" },
+            fetchLatest: async () => {
+                fetchCalls += 1;
+                return "9.9.9";
+            },
+            resolveInstalled: () => ({ entry: "/local/cli.js", version: "0.7.0" }),
+            nodePath: "/usr/bin/node",
+            platform: "linux",
+        });
+
+        expect(fetchCalls).toBe(0);
+        expect(plan.mode).toBe("local");
+    });
+
+    test("createLaunchPlan reports a clear error when latest and local package are unavailable", async () => {
+        let message = "";
+        try {
+            await createLaunchPlan(SUBCOMMANDS.cli, ["status"], {
+                env: {},
+                fetchLatest: async () => null,
+                resolveInstalled: () => null,
+            });
+        } catch (err) {
+            message = err instanceof Error ? err.message : String(err);
+        }
+
+        expect(message).toContain("@supacloud/cli 未安装");
     });
 });

--- a/packages/supacloud/src/index.ts
+++ b/packages/supacloud/src/index.ts
@@ -6,24 +6,50 @@
  *   supacloud cli   <args...>   → @supacloud/cli   （项目级开发工具）
  *   supacloud admin <args...>   → @supacloud/admin （平台运维工具）
  *
- * 子包以依赖形式安装；运行时通过 createRequire 解析子包入口，
- * 用当前 Node 进程 spawn 执行，参数与退出码原样透传。
+ * 默认先检查 npm latest dist-tag；发现新版本时通过 npm exec 运行最新版。
+ * 离线、registry 不可达或显式禁用自动更新时，回退到随包安装的本地依赖。
  */
 import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname, join, parse } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 
 interface Subcommand {
     pkg: string;
+    bin: string;
     desc: string;
 }
 
 export const SUBCOMMANDS: Record<string, Subcommand> = {
-    cli: { pkg: "@supacloud/cli", desc: "项目级 CLI（开发者工具）" },
-    admin: { pkg: "@supacloud/admin", desc: "平台运维 CLI（安装/SSH/租户管理）" },
+    cli: { pkg: "@supacloud/cli", bin: "supacloud-cli", desc: "项目级 CLI（开发者工具）" },
+    admin: { pkg: "@supacloud/admin", bin: "supacloud-admin", desc: "平台运维 CLI（安装/SSH/租户管理）" },
 };
+
+interface InstalledPackage {
+    entry: string;
+    version: string | null;
+}
+
+interface LaunchPlan {
+    mode: "latest" | "local";
+    command: string;
+    args: string[];
+    shell: boolean;
+}
+
+interface LaunchPlanOptions {
+    env?: Record<string, string | undefined>;
+    fetchLatest?: (pkgName: string, env?: Record<string, string | undefined>) => Promise<string | null>;
+    resolveInstalled?: (pkgName: string) => InstalledPackage | null;
+    nodePath?: string;
+    npmCommand?: string;
+    platform?: NodeJS.Platform;
+}
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Pick<Response, "ok" | "status" | "json">>;
 
 /** 解析子包入口（package.json 的 main → dist/index.js）。未安装返回 null。 */
 export function resolveSubpackageEntry(pkgName: string): string | null {
@@ -35,6 +61,182 @@ export function resolveSubpackageEntry(pkgName: string): string | null {
 }
 
 const COMMAND = "supacloud";
+const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org/";
+const AUTO_UPDATE_TIMEOUT_MS = 2_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readPackageVersion(packageJsonPath: string): string | null {
+    try {
+        const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+        if (isRecord(parsed) && typeof parsed.version === "string") return parsed.version;
+    } catch {
+        // ignore malformed package metadata and fall back to latest execution
+    }
+    return null;
+}
+
+function packageJsonMatches(path: string, pkgName: string): boolean {
+    try {
+        const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+        return isRecord(parsed) && parsed.name === pkgName;
+    } catch {
+        return false;
+    }
+}
+
+function findPackageJsonFromEntry(entry: string, pkgName: string): string | null {
+    let dir = dirname(entry);
+    const root = parse(dir).root;
+
+    while (dir && dir !== root) {
+        const candidate = join(dir, "package.json");
+        if (existsSync(candidate) && packageJsonMatches(candidate, pkgName)) {
+            return candidate;
+        }
+        dir = dirname(dir);
+    }
+
+    return null;
+}
+
+export function resolveInstalledPackage(pkgName: string): InstalledPackage | null {
+    const entry = resolveSubpackageEntry(pkgName);
+    if (!entry) return null;
+
+    let packageJsonPath: string | null = null;
+    try {
+        packageJsonPath = require.resolve(`${pkgName}/package.json`);
+    } catch {
+        packageJsonPath = findPackageJsonFromEntry(entry, pkgName);
+    }
+
+    return {
+        entry,
+        version: packageJsonPath ? readPackageVersion(packageJsonPath) : null,
+    };
+}
+
+export function isAutoUpdateDisabled(env: Record<string, string | undefined> = process.env): boolean {
+    const noAutoUpdate = env.SUPACLOUD_NO_AUTO_UPDATE;
+    if (noAutoUpdate && !["0", "false", "no", "off"].includes(noAutoUpdate.toLowerCase())) {
+        return true;
+    }
+
+    const autoUpdate = env.SUPACLOUD_AUTO_UPDATE;
+    return Boolean(autoUpdate && ["0", "false", "no", "off"].includes(autoUpdate.toLowerCase()));
+}
+
+export function getNpmRegistry(env: Record<string, string | undefined> = process.env): string {
+    const registry =
+        env.SUPACLOUD_NPM_REGISTRY ||
+        env.npm_config_registry ||
+        env.NPM_CONFIG_REGISTRY ||
+        DEFAULT_NPM_REGISTRY;
+    return registry.endsWith("/") ? registry : `${registry}/`;
+}
+
+export function buildLatestMetadataUrl(pkgName: string, registry = DEFAULT_NPM_REGISTRY): string {
+    const base = registry.endsWith("/") ? registry : `${registry}/`;
+    const encodedName = encodeURIComponent(pkgName).replace(/^%40/, "@");
+    return `${base}${encodedName}/latest`;
+}
+
+export async function fetchLatestVersion(
+    pkgName: string,
+    env: Record<string, string | undefined> = process.env,
+    fetchImpl?: FetchLike,
+): Promise<string | null> {
+    const activeFetch: FetchLike | undefined = fetchImpl ?? globalThis.fetch;
+    if (!activeFetch) return null;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), AUTO_UPDATE_TIMEOUT_MS);
+
+    try {
+        const response = await activeFetch(buildLatestMetadataUrl(pkgName, getNpmRegistry(env)), {
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+        });
+        if (!response.ok) return null;
+
+        const metadata: unknown = await response.json();
+        if (isRecord(metadata) && typeof metadata.version === "string") {
+            return metadata.version;
+        }
+        return null;
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+function parseSemver(version: string): { main: number[]; prerelease: string | null } | null {
+    const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+    if (!match) return null;
+
+    return {
+        main: [Number(match[1]), Number(match[2]), Number(match[3])],
+        prerelease: match[4] ?? null,
+    };
+}
+
+export function compareSemver(left: string, right: string): number {
+    const a = parseSemver(left);
+    const b = parseSemver(right);
+    if (!a || !b) return left.localeCompare(right);
+
+    for (let i = 0; i < 3; i += 1) {
+        if (a.main[i] !== b.main[i]) return a.main[i] > b.main[i] ? 1 : -1;
+    }
+
+    if (a.prerelease === b.prerelease) return 0;
+    if (!a.prerelease) return 1;
+    if (!b.prerelease) return -1;
+    return a.prerelease.localeCompare(b.prerelease);
+}
+
+export function isNewerVersion(latestVersion: string, currentVersion: string | null): boolean {
+    if (!currentVersion) return true;
+    return compareSemver(latestVersion, currentVersion) > 0;
+}
+
+export async function createLaunchPlan(
+    target: Subcommand,
+    forwardedArgs: string[],
+    options: LaunchPlanOptions = {},
+): Promise<LaunchPlan> {
+    const env = options.env ?? process.env;
+    const resolveInstalled = options.resolveInstalled ?? resolveInstalledPackage;
+    const fetchLatest = options.fetchLatest ?? fetchLatestVersion;
+    const installed = resolveInstalled(target.pkg);
+
+    if (!isAutoUpdateDisabled(env)) {
+        const latestVersion = await fetchLatest(target.pkg, env);
+        if (latestVersion && isNewerVersion(latestVersion, installed?.version ?? null)) {
+            return {
+                mode: "latest",
+                command: options.npmCommand ?? "npm",
+                args: ["exec", "--yes", "--package", `${target.pkg}@${latestVersion}`, "--", target.bin, ...forwardedArgs],
+                shell: (options.platform ?? process.platform) === "win32",
+            };
+        }
+    }
+
+    if (!installed) {
+        throw new Error(`${target.pkg} 未安装，且无法从 npm registry 获取最新版。`);
+    }
+
+    return {
+        mode: "local",
+        command: options.nodePath ?? process.execPath,
+        args: [installed.entry, ...forwardedArgs],
+        shell: false,
+    };
+}
 
 export function buildHelp(): string {
     const subs = Object.entries(SUBCOMMANDS)
@@ -64,13 +266,13 @@ ${subs}
   ${COMMAND} admin project list
   ${COMMAND} admin ssh ping
 
-每个子命令都接受各自的 --help。安装后 supacloud 同时拥有
-cli 与 admin 的全部能力；二者也可单独安装为 @supacloud/cli /
-@supacloud/admin，通过 supacloud-cli / supacloud-admin 调用。
+每次执行子命令时默认检查 npm latest；发现 @supacloud/cli 或
+@supacloud/admin 有新版本时会自动通过 npm exec 运行最新版。
+离线时回退到本地依赖。设置 SUPACLOUD_NO_AUTO_UPDATE=1 可禁用。
 `;
 }
 
-function run(args: string[]): void {
+async function run(args: string[]): Promise<void> {
     const sub = args[0];
 
     if (!sub || sub === "--help" || sub === "-h" || sub === "help") {
@@ -85,15 +287,12 @@ function run(args: string[]): void {
         process.exit(1);
     }
 
-    const entry = resolveSubpackageEntry(target.pkg);
-    if (!entry) {
-        console.error(`❌ ${target.pkg} 未安装。请确认 supacloud 包依赖完整，或单独安装 ${target.pkg}。`);
-        process.exit(1);
-    }
+    const plan = await createLaunchPlan(target, args.slice(1));
 
     // 把子命令之后的参数原样透传给子包入口
-    const child = spawn(process.execPath, [entry, ...args.slice(1)], {
+    const child = spawn(plan.command, plan.args, {
         stdio: "inherit",
+        shell: plan.shell,
     });
 
     child.on("close", (code) => process.exit(code ?? 1));
@@ -111,4 +310,10 @@ const isMainEntry = (() => {
         return false;
     }
 })();
-if (isMainEntry) run(process.argv.slice(2));
+if (isMainEntry) {
+    run(process.argv.slice(2)).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`❌ supacloud 启动失败: ${message}`);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- make the umbrella `supacloud cli` / `supacloud admin` dispatcher check npm latest before launching sub CLIs
- run newer `@supacloud/cli` / `@supacloud/admin` with `npm exec`, with local fallback for offline or opt-out cases
- document `SUPACLOUD_NO_AUTO_UPDATE`, `SUPACLOUD_AUTO_UPDATE=0`, and registry mirror overrides

## Verification
- `cd packages/supacloud && bun install --frozen-lockfile && bun run typecheck && bun test && bun run build`
- `cd packages/cli && bun install --frozen-lockfile && bun run typecheck`
- `cd packages/admin && bun install --frozen-lockfile && bun run typecheck`
- dist smoke: latest metadata lookup, normal `supacloud cli --help`, offline registry fallback, and disabled auto-update fallback
- `git diff --check`