### PR TITLE
fix(supacloud): run dispatcher from npm bin

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,5 @@
   "packages/supacloud-js": "0.18.3",
   "packages/cli": "0.8.0",
   "packages/admin": "0.2.0",
-  "packages/supacloud": "0.3.0"
+  "packages/supacloud": "0.3.1"
 }

--- a/packages/supacloud/CHANGELOG.md
+++ b/packages/supacloud/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.1](https://github.com/zuohuadong/supacloud/compare/supacloud-v0.3.0...supacloud-v0.3.1) (2026-06-29)
+
+
+### Bug Fixes
+
+* **supacloud:** run dispatcher when launched through npm bin symlink
+
 ## [0.3.0](https://github.com/zuohuadong/supacloud/compare/supacloud-v0.2.0...supacloud-v0.3.0) (2026-06-29)
 
 

--- a/packages/supacloud/package.json
+++ b/packages/supacloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supacloud",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Unified entrypoint: `supacloud cli` and `supacloud admin` in one command",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/supacloud/src/index.test.ts
+++ b/packages/supacloud/src/index.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { closeSync, mkdtempSync, openSync, symlinkSync, writeSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
     SUBCOMMANDS,
     buildHelp,
@@ -6,6 +10,7 @@ import {
     createLaunchPlan,
     fetchLatestVersion,
     isAutoUpdateDisabled,
+    isMainModule,
     resolveSubpackageEntry,
 } from "./index";
 
@@ -36,6 +41,18 @@ describe("supacloud dispatcher", () => {
     test("resolveSubpackageEntry returns null for a missing package", () => {
         const entry = resolveSubpackageEntry("@supacloud/__definitely_not_a_pkg__");
         expect(entry).toBeNull();
+    });
+
+    test("isMainModule treats npm bin symlinks as the main script", () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-main-module-"));
+        const target = join(dir, "dist-index.js");
+        const link = join(dir, "supacloud");
+        const fd = openSync(target, "w");
+        writeSync(fd, "#!/usr/bin/env node\n");
+        closeSync(fd);
+        symlinkSync(target, link);
+
+        expect(isMainModule(pathToFileURL(target).href, link)).toBe(true);
     });
 
     test("buildLatestMetadataUrl encodes scoped package names", () => {

--- a/packages/supacloud/src/index.ts
+++ b/packages/supacloud/src/index.ts
@@ -10,7 +10,7 @@
  * 离线、registry 不可达或显式禁用自动更新时，回退到随包安装的本地依赖。
  */
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, parse } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -302,15 +302,17 @@ async function run(args: string[]): Promise<void> {
     });
 }
 
-// 仅在作为脚本直接运行时执行分发，避免被 import（如测试）时的副作用退出
-const isMainEntry = (() => {
+export function isMainModule(moduleUrl: string, argvEntry = process.argv[1]): boolean {
+    if (!argvEntry) return false;
     try {
-        return fileURLToPath(import.meta.url) === process.argv[1];
+        return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(argvEntry);
     } catch {
         return false;
     }
-})();
-if (isMainEntry) {
+}
+
+// 仅在作为脚本直接运行时执行分发，避免被 import（如测试）时的副作用退出
+if (isMainModule(import.meta.url)) {
     run(process.argv.slice(2)).catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         console.error(`❌ supacloud 启动失败: ${message}`);


### PR DESCRIPTION
## Summary
- fix umbrella dispatcher main-entry detection when launched through npm's bin symlink
- add a regression test for npm bin symlink execution
- bump supacloud package metadata to 0.3.1 for the republish

## Verification
- `cd packages/supacloud && bun install --frozen-lockfile && bun run typecheck && bun test && bun run build`
- `npm pack --dry-run --json`
- local npm bin smoke: `./node_modules/.bin/supacloud --help`
- local npm bin smoke: `./node_modules/.bin/supacloud cli status`
- `git diff --check`