### PR TITLE
fix(management-api): serialize Caddy config publishes

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -372,6 +372,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
     private readonly customRateLimits = new Map<string, { second: number; minute: number; hour: number }>();
     private deferredPersistDepth = 0;
     private deferredPersistPending = false;
+    private persistAndLoadTail: Promise<void> = Promise.resolve();
     private hydrated = false;
 
     private async caddyRequest(pathname: string, method = "GET", body?: unknown): Promise<Response> {
@@ -705,11 +706,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
         }
     }
 
-    private async persistAndLoad(): Promise<void> {
-        if (this.deferredPersistDepth > 0) {
-            this.deferredPersistPending = true;
-            return;
-        }
+    private async writeAndLoadCurrentConfig(): Promise<void> {
         const next = this.baseConfig();
         await fs.mkdir(path.dirname(config.caddyConfigPath), { recursive: true });
         const tmpPath = `${config.caddyConfigPath}.tmp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -728,6 +725,18 @@ export class CaddyGatewayProvider implements GatewayProvider {
             await fs.unlink(tmpPath).catch(() => undefined);
             throw error;
         }
+    }
+
+    private async persistAndLoad(): Promise<void> {
+        if (this.deferredPersistDepth > 0) {
+            this.deferredPersistPending = true;
+            return;
+        }
+
+        const previous = this.persistAndLoadTail.catch(() => undefined);
+        const current = previous.then(() => this.writeAndLoadCurrentConfig());
+        this.persistAndLoadTail = current.catch(() => undefined);
+        await current;
     }
 
     async withDeferredPersist<T>(fn: () => Promise<T>, shouldFlush: (result: T) => boolean = () => true): Promise<T> {

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -471,6 +471,76 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("serializes Caddy load publishes so concurrent frontend routes cannot finish with stale config", async () => {
+        const originalFetch = globalThis.fetch;
+        const appliedLoads: any[] = [];
+        let delayedSingleRouteLoad = false;
+        let releaseSingleRouteLoad: (() => void) | null = null;
+        let resolveSingleRouteStarted: (() => void) | null = null;
+        const singleRouteStarted = new Promise<void>((resolve) => {
+            resolveSingleRouteStarted = resolve;
+        });
+
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            const method = init?.method || "GET";
+            let body: any = null;
+            if (typeof init?.body === "string" && init.body.length > 0) {
+                try { body = JSON.parse(init.body); } catch { body = init.body; }
+            }
+
+            if (method === "POST" && url.endsWith("/load")) {
+                const routeIds = (body?.apps?.http?.servers?.supacloud?.routes ?? []).map((route: any) => route["@id"]);
+                const hasAdmin = routeIds.includes("route-frontend-proj123-admin0001");
+                const hasMobile = routeIds.includes("route-frontend-proj123-mobile001");
+                if (hasAdmin && !hasMobile && !delayedSingleRouteLoad) {
+                    delayedSingleRouteLoad = true;
+                    resolveSingleRouteStarted?.();
+                    return new Promise<Response>((resolve) => {
+                        releaseSingleRouteLoad = () => {
+                            appliedLoads.push(body);
+                            resolve(new Response(JSON.stringify({ ok: true })));
+                        };
+                    });
+                }
+                appliedLoads.push(body);
+            }
+
+            return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+        }) as unknown as typeof fetch;
+
+        try {
+            const provider = new CaddyGatewayProvider();
+            const adminRoute = provider.configureFrontendRoute({
+                projectRef: "proj123",
+                deploymentId: "admin0001",
+                hosts: ["admin.example.com"],
+                root: "/var/supacloud/frontends/proj123/admin0001/build",
+                mode: "static",
+            });
+
+            await singleRouteStarted;
+
+            const mobileRoute = provider.configureFrontendRoute({
+                projectRef: "proj123",
+                deploymentId: "mobile001",
+                hosts: ["m.example.com"],
+                root: "/var/supacloud/frontends/proj123/mobile001/build",
+                mode: "static",
+            });
+
+            await Promise.race([mobileRoute.catch(() => undefined), Bun.sleep(25)]);
+            releaseSingleRouteLoad?.();
+            await Promise.all([adminRoute, mobileRoute]);
+
+            const finalRouteIds = (appliedLoads.at(-1)?.apps?.http?.servers?.supacloud?.routes ?? []).map((route: any) => route["@id"]);
+            expect(finalRouteIds).toContain("route-frontend-proj123-admin0001");
+            expect(finalRouteIds).toContain("route-frontend-proj123-mobile001");
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
     test("configureCustomGatewayRoutes renders controlled proxy and static Caddy routes", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);


### PR DESCRIPTION
## Summary
- Serialize Caddy config publish/load operations in the management API gateway provider.
- Prevent an older in-flight `/load` from completing after a newer route update and overwriting the final Caddy state.
- Add a regression test that simulates concurrent frontend route publishes where one stale load returns late.

## Context
During Houqin deployment, parallel frontend custom-domain operations could leave a domain recorded in deployment metadata but missing from Caddy until a clean gateway rebuild was run. The race is in the shared Caddy publish path, so the fix is applied at `CaddyGatewayProvider.persistAndLoad()` instead of only the frontend domain endpoint.

## Verification
- `bun test packages/management-api/tests/unit/gateway.service.test.ts`
- `bun run typecheck` in `packages/management-api`
- `bun test packages/management-api/tests/unit/gateway.service.test.ts packages/management-api/tests/unit/frontend.service.test.ts packages/management-api/tests/unit/frontend.routes.test.ts`
- `bun test tests/unit/edge-function.service.bundle-metadata.test.ts`

## Note
`bun run test:local` in `packages/management-api` currently reports 706 pass / 1 fail. The failing test is `edgeFunctionService bundle metadata`; it passes when run alone, so this appears to be existing suite-order/shared-environment interference and not related to the Caddy publish change.