### PR TITLE
fix(management-api): stabilize auth user update proxy

### DIFF
--- a/packages/management-api/src/routes/auth-users.ts
+++ b/packages/management-api/src/routes/auth-users.ts
@@ -46,6 +46,35 @@ async function gotrueFetch(url: string, init?: RequestInit): Promise<Response> {
   }
 }
 
+async function readGoTrueError(res: Response, fallbackMessage: string) {
+  const text = await res.text().catch(() => "");
+  let parsed: unknown;
+  if (text.trim().length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = undefined;
+    }
+  }
+
+  if (parsed !== null && typeof parsed === "object") {
+    const body = parsed as Record<string, unknown>;
+    return {
+      message: readOptionalString(body.msg) ?? readOptionalString(body.message) ?? fallbackMessage,
+      code: readOptionalString(body.code) ?? String(res.status)
+    };
+  }
+
+  return {
+    message: text.trim().length > 0 && text.trim() !== "null" ? text.trim() : fallbackMessage,
+    code: String(res.status)
+  };
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
 /**
  * User Management routes — Admin API proxy to GoTrue
  */
@@ -80,8 +109,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to fetch users", code: err.code || "500" };
+        return readGoTrueError(res, "Failed to fetch users");
       }
 
       const linkHeader = res.headers.get("link");
@@ -166,8 +194,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to create user", code: err.code || "500" };
+        return readGoTrueError(res, "Failed to create user");
       }
 
       return res.json();
@@ -222,8 +249,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to invite user", code: err.code || "500" };
+        return readGoTrueError(res, "Failed to invite user");
       }
 
       return res.json();
@@ -261,8 +287,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "User not found", code: err.code || "500" };
+        return readGoTrueError(res, "User not found");
       }
 
       return res.json();
@@ -300,8 +325,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to update user", code: err.code || "500" };
+        return readGoTrueError(res, "Failed to update user");
       }
 
       return res.json();
@@ -338,7 +362,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       const { apiUrl, serviceRoleKey } = ctx;
 
       const res = await gotrueFetch(`${apiUrl}/admin/users/${params.id}`, {
-        method: "PATCH",
+        method: "PUT",
         headers: {
           "Content-Type": "application/json",
           "apikey": serviceRoleKey,
@@ -349,8 +373,8 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       });
 
       if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to update user", code: err.code || "500" };
+        set.status = res.status;
+        return readGoTrueError(res, "Failed to update user");
       }
 
       return res.json();
@@ -398,8 +422,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to delete user", code: err.code || "500" };
+        return readGoTrueError(res, "Failed to delete user");
       }
 
       return res.json();
@@ -435,8 +458,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to list factors", code: err.code || "500" };
+        return readGoTrueError(res, "Failed to list factors");
       }
 
       return res.json();
@@ -474,8 +496,7 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       if (!res.ok) {
         set.status = res.status;
-        const err = await res.json().catch(() => ({}));
-        return { message: err.msg || err.message || "Failed to generate link", code: err.code || "500" };
+        return readGoTrueError(res, "Failed to generate link");
       }
 
       return res.json();

--- a/packages/management-api/tests/unit/auth-users.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-users.routes.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+const getProject = mock(() => Promise.resolve({ ref: "proj_1", config: {} }));
+const resolveProjectServiceRoleKey = mock(() => Promise.resolve("service-role-key"));
+const sqlMock = mock(() => Promise.resolve([{ config: {} }]));
+
+mock.module("../../src/db", () => ({ sql: sqlMock }));
+mock.module("../../src/middleware/auth", () => ({ requireProjectOrAdminAuth }));
+mock.module("../../src/services", () => ({ projectService: { getProject } }));
+mock.module("../../src/utils/service-role", () => ({ resolveProjectServiceRoleKey }));
+
+const { userManagementRoutes } = await import("../../src/routes/auth-users");
+const app = new Elysia().use(userManagementRoutes);
+const originalFetch = globalThis.fetch;
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: {
+        authorization: "Bearer dev-master-token",
+        "content-type": "application/json",
+        ...(init.headers || {}),
+      },
+    }),
+  );
+}
+
+describe("userManagementRoutes", () => {
+  const userUpdateMethods: string[] = [];
+  const userUpdateBodies: Array<Record<string, unknown>> = [];
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+    getProject.mockReset();
+    getProject.mockResolvedValue({ ref: "proj_1", config: {} } as never);
+    resolveProjectServiceRoleKey.mockReset();
+    resolveProjectServiceRoleKey.mockResolvedValue("service-role-key" as never);
+    sqlMock.mockReset();
+    sqlMock.mockResolvedValue([{ config: {} }] as never);
+    userUpdateMethods.length = 0;
+    userUpdateBodies.length = 0;
+  });
+
+  test("PATCH user updates proxy to GoTrue with PUT for compatibility", async () => {
+    globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      userUpdateMethods.push(init?.method ?? "GET");
+      if (typeof init?.body === "string") {
+        userUpdateBodies.push(JSON.parse(init.body) as Record<string, unknown>);
+      }
+      return Response.json({ id: "user-one", email: "worker@example.test" });
+    }) as unknown as typeof fetch;
+
+    const res = await request("/v1/projects/proj_1/auth/users/user-one", {
+      method: "PATCH",
+      body: JSON.stringify({
+        user_metadata: {
+          houqin_profile_id: "profile-one",
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(userUpdateMethods).toEqual(["PUT"]);
+    expect(userUpdateBodies[0]).toEqual({
+      user_metadata: {
+        houqin_profile_id: "profile-one",
+      },
+    });
+  });
+
+  test("returns stable GoTrue errors when the upstream body is null", async () => {
+    globalThis.fetch = mock(async () => Response.json(null, { status: 405 })) as unknown as typeof fetch;
+
+    const res = await request("/v1/projects/proj_1/auth/users/user-one", {
+      method: "PATCH",
+      body: JSON.stringify({
+        user_metadata: {
+          houqin_profile_id: "profile-one",
+        },
+      }),
+    });
+
+    expect(res.status).toBe(405);
+    expect(await res.json()).toEqual({
+      message: "Failed to update user",
+      code: "405",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- proxy Management API auth user PATCH updates to GoTrue with PUT for current GoTrue compatibility
- add safe GoTrue error parsing for JSON, text, empty, and null upstream bodies
- add unit coverage for PUT proxying and null-body upstream errors

## Verification
- bun test packages/management-api/tests/unit/auth-users.routes.test.ts
- cd packages/management-api && bun test tests/unit/auth-users.routes.test.ts tests/unit/project-rbac.routes.test.ts
- cd packages/management-api && bun run typecheck
- agmesh verifier attempted with gpt-5.3-codex; runtime first timed out/spawn ETIMEDOUT, then returned read-only PASS-style review with no blocking findings; local deterministic tests above are the primary verification evidence.