### PR TITLE
fix(management-api): return 404 for unmatched gateway hosts

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -134,6 +134,7 @@ type CaddyConfig = {
 
 const CADDY_GENERATED_CONFIG_NOTICE_LOG =
     "supacloud_notice_do_not_edit_caddy_config_json_use_supacloud_cli_management_api_or_web_console";
+const CADDY_UNMATCHED_HOST_ROUTE_ID = "route-system-unmatched-host-404";
 
 function caddyGeneratedConfigNoticeLog(): Record<string, unknown> {
     return {
@@ -248,6 +249,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
         const routes = Array.from(this.routesById.values())
             .sort((a, b) => this.compareRoutesForCaddy(a, b))
             .map((route) => this.renderRouteForCaddy(route));
+        routes.push(this.makeUnmatchedHostRoute());
 
         return {
             admin: { listen: caddyAdminListen() },
@@ -511,6 +513,14 @@ export class CaddyGatewayProvider implements GatewayProvider {
         }
 
         return rendered;
+    }
+
+    private makeUnmatchedHostRoute(): CaddyRoute {
+        return {
+            "@id": CADDY_UNMATCHED_HOST_ROUTE_ID,
+            handle: [{ handler: "static_response", status_code: 404 }],
+            terminal: true,
+        };
     }
 
     private async validateCandidateConfig(candidatePath: string): Promise<void> {

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -541,6 +541,32 @@ describe("CaddyGatewayProvider", () => {
         }
     });
 
+    test("appends a terminal 404 route for unmatched hosts", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.configureFrontendRoute({
+            projectRef: "proj123",
+            deploymentId: "0000002d",
+            hosts: ["static.example.com"],
+            root: "/var/supacloud/frontends/proj123/0000002d/build",
+            mode: "static",
+        });
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const fallback = routes.at(-1);
+
+        expect(routes.find((item: any) => item["@id"] === "route-frontend-proj123-0000002d")).toBeDefined();
+        expect(fallback?.["@id"]).toBe("route-system-unmatched-host-404");
+        expect(fallback?.match).toBeUndefined();
+        expect(fallback?.handle).toEqual([{ handler: "static_response", status_code: 404 }]);
+        expect(fallback?.terminal).toBe(true);
+
+        restore();
+    });
+
     test("configureCustomGatewayRoutes renders controlled proxy and static Caddy routes", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);


### PR DESCRIPTION
## Summary
- append a terminal Caddy static_response 404 route after generated SupaCloud routes so unknown hosts do not receive an empty 200 response
- add gateway coverage for the unmatched-host fallback route
- make edge function bundle metadata tests isolated across full management-api unit runs by resolving EDGE_FUNCTIONS_DIR at runtime and avoiding module mock leakage

## Verification
- bun run --cwd packages/management-api test:unit
- bun run --cwd packages/management-api typecheck