### PR TITLE
ci(release): handle stale umbrella lockfiles

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -167,22 +167,11 @@ jobs:
 
       - name: Check unified supacloudctl CLI
         working-directory: packages/supacloud
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          install_mode="$(bun -e '
-            const pkg = await Bun.file("package.json").json();
-            const cli = await Bun.file("../cli/package.json").json();
-            const admin = await Bun.file("../admin/package.json").json();
-            const lock = await Bun.file("bun.lock").text();
-            const dependenciesMatchCandidates =
-              pkg.dependencies["@supacloud/cli"] === `^${cli.version}` &&
-              pkg.dependencies["@supacloud/admin"] === `^${admin.version}`;
-            const lockHasCandidates =
-              lock.includes(`@supacloud/cli@${cli.version}`) &&
-              lock.includes(`@supacloud/admin@${admin.version}`);
-            console.log(dependenciesMatchCandidates && !lockHasCandidates ? "local" : "frozen");
-          ')"
-          if [[ "$install_mode" == "local" ]]; then
-            # Release 提升 sibling 包版本时，锁文件会暂时落后；使用同一提交中的候选包验证。
+          if [[ "$PR_AUTHOR" == "github-actions[bot]" && "${GITHUB_HEAD_REF:-}" == release-please--branches--* ]]; then
+            # Release Please 会在发布前先提升 sibling 包版本；此时 registry 与锁文件尚未包含候选版本。
             bun -e '
               const pkg = await Bun.file("package.json").json();
               const cli = await Bun.file("../cli/package.json").json();

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -167,12 +167,22 @@ jobs:
 
       - name: Check unified supacloudctl CLI
         working-directory: packages/supacloud
-        env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [[ "$PR_AUTHOR" == "github-actions[bot]" && "${GITHUB_HEAD_REF:-}" == release-please--branches--* ]]; then
-            # Release Please 会在同一个 PR 中先提升依赖包版本；合并发布前 registry 中还不存在这些版本。
-            # 使用同一发布候选中的本地包验证统一 CLI，同时保留普通 PR 的 frozen lockfile 门禁。
+          install_mode="$(bun -e '
+            const pkg = await Bun.file("package.json").json();
+            const cli = await Bun.file("../cli/package.json").json();
+            const admin = await Bun.file("../admin/package.json").json();
+            const lock = await Bun.file("bun.lock").text();
+            const dependenciesMatchCandidates =
+              pkg.dependencies["@supacloud/cli"] === `^${cli.version}` &&
+              pkg.dependencies["@supacloud/admin"] === `^${admin.version}`;
+            const lockHasCandidates =
+              lock.includes(`@supacloud/cli@${cli.version}`) &&
+              lock.includes(`@supacloud/admin@${admin.version}`);
+            console.log(dependenciesMatchCandidates && !lockHasCandidates ? "local" : "frozen");
+          ')"
+          if [[ "$install_mode" == "local" ]]; then
+            # Release 提升 sibling 包版本时，锁文件会暂时落后；使用同一提交中的候选包验证。
             bun -e '
               const pkg = await Bun.file("package.json").json();
               const cli = await Bun.file("../cli/package.json").json();
@@ -183,6 +193,7 @@ jobs:
               }
             '
             bun add --no-save '@supacloud/cli@file:../cli' '@supacloud/admin@file:../admin'
+            git diff --exit-code -- package.json bun.lock
           else
             bun install --frozen-lockfile
           fi

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "supacloud",
       "dependencies": {
-        "@supacloud/admin": "^0.3.1",
-        "@supacloud/cli": "^0.9.1",
+        "@supacloud/admin": "^0.3.2",
+        "@supacloud/cli": "^0.9.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -15,9 +15,9 @@
     },
   },
   "packages": {
-    "@supacloud/admin": ["@supacloud/admin@0.3.1", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.3.1.tgz", { "dependencies": { "ssh2": "^1.17.0", "zod": "^4.4.3" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-oe4K48FaBK4r15mH7QKnunTiAmh069MB+FhDDI6bTomVVTwI7BVjtztpoUYqvsz+cqtRn1/0KPxJA43CX8NBkw=="],
+    "@supacloud/admin": ["@supacloud/admin@0.3.2", "", { "dependencies": { "ssh2": "^1.17.0", "zod": "^4.4.3" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-/dh9NYm1Yvcba3YS/eitlnIcDcgfUcx72511+hlK11bVZygYDrh70Fnu+m8P5BEqRdoy0Hj2IOE7QUi2deRaTQ=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.9.1", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.9.1.tgz", { "dependencies": { "zod": "^4.4.3" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-pcJ7P75UHHY3ylpD/GUs4tlJmGVVKSeiHXJomws4UeXjcIP5L2zbOxXESklbFCxdddGMR2PrJ+XtPI7X4zvQKg=="],
+    "@supacloud/cli": ["@supacloud/cli@0.9.2", "", { "dependencies": { "zod": "^4.4.3" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-5L8B882VMetfHzszNav7NZjq7EnV/5jJ5eaLx/PYSWYj9eJZ0se9p57ptU7dvlVHUNhgXHg2gXVMVrHQRvX1TQ=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## 变更
- 当 `packages/supacloud` 的 registry 依赖版本已提升但 `bun.lock` 尚未同步时，使用同一提交中的 sibling CLI/Admin 候选包进行验证。
- 版本与 sibling manifest 不一致时仍保持 frozen lockfile 失败，避免掩盖真实依赖漂移。
- 普通依赖与锁文件一致时继续使用 `bun install --frozen-lockfile`。

## 背景
Release Please 全包发布后，主分支 CI 在 npm 发布并行期间遇到旧 bun.lock 与新 `@supacloud/cli`/`@supacloud/admin` 版本不一致，导致 umbrella 检查失败。

## 验证
- stale-lockfile 路径：version assertion、local sibling install、diff guard、typecheck、14 tests、build、audit 通过。
- frozen-lockfile 路径：bun install --frozen-lockfile 通过。
- YAML parse 与 git diff --check 通过。

Follow-up to merged release PR #431.