### PR TITLE
fix(management-api): allow standard idempotency header in CORS

### DIFF
--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -33,7 +33,7 @@ export const DEFAULT_CORS_HEADERS = [
     "Prefer", "Content-Profile", "accept-profile", "Range", "Range-Unit",
     "x-upsert", "Cache-Control", "x-retry-count", "x-metadata",
     "x-supacloud-async", "x-supacloud-timeout", "x-supacloud-retries",
-    "x-supacloud-idempotency-key", "x-supacloud-function-version",
+    "Idempotency-Key", "x-supacloud-idempotency-key", "x-supacloud-function-version",
     "x-supacloud-trace-id", "x-supacloud-correlation-id",
     "x-supacloud-business-task-id", "x-supacloud-task-metadata",
 ];

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -105,6 +105,7 @@ describe("GatewayService provider selection", () => {
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-async");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-retries");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-timeout");
+        expect(DEFAULT_CORS_HEADERS).toContain("Idempotency-Key");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-idempotency-key");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-function-version");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-trace-id");
@@ -215,6 +216,7 @@ describe("CaddyGatewayProvider", () => {
         expect(preflight?.handle?.some((handler: any) => handler.handler === "static_response" && handler.status_code === 204)).toBe(true);
         expect(corsHeaders?.response?.set?.["Access-Control-Allow-Origin"]).toEqual(["{http.request.header.Origin}"]);
         expect(corsHeaders?.response?.set?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
+        expect(corsHeaders?.response?.set?.["Access-Control-Allow-Headers"]?.[0]).toContain("Idempotency-Key");
         expect(preflight?.match?.some((matcher: any) => matcher.header_regexp?.Origin?.pattern?.includes("localhost"))).toBe(true);
 
         restore();


### PR DESCRIPTION
## Summary

- allow the standard Idempotency-Key request header in generated Caddy CORS responses
- retain the existing x-supacloud-idempotency-key compatibility header
- cover both the exported default list and rendered preflight configuration

## Verification

- bun test tests/unit/gateway.service.test.ts (42 pass, 0 fail)
- bun run typecheck
- git diff --check