### PR TITLE
fix: make generated WeChat functions self-contained

### DIFF
--- a/packages/management-api/src/routes/auth-wechat.ts
+++ b/packages/management-api/src/routes/auth-wechat.ts
@@ -3,6 +3,7 @@ import { logger } from "../utils/logger";
 import { projectService } from "../services";
 import { tenantRuntimeService } from "../services/tenant-runtime.service";
 import { edgeFunctionService } from "../services/edge-function.service";
+import { runtimeCacheService } from "../services/runtime-cache.service";
 import { WECHAT_PROVIDER_INFO } from "../types/oauth";
 import type { WeChatProviderType } from "../types/oauth";
 
@@ -31,6 +32,15 @@ export const wechatAuthRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
         wechat_miniprogram: providerConfig,
       };
 
+      const secretsSaved = await projectService.upsertSecrets(params.ref, [
+        { name: "WECHAT_MINIPROGRAM_APP_ID", value: body.app_id },
+        { name: "WECHAT_MINIPROGRAM_APP_SECRET", value: body.app_secret },
+      ]);
+      if (!secretsSaved) {
+        return status(500, { message: "Failed to save WeChat Mini Program credentials", code: "500" });
+      }
+      await runtimeCacheService.invalidateProjectRuntimeEnv(params.ref);
+
       await projectService.updateProjectSettings(params.ref, {
         ...settings,
         auth: {
@@ -41,7 +51,7 @@ export const wechatAuthRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
 
       if (body.deploy_function !== false) {
         try {
-          await deployWeChatMiniProgramFunction(params.ref, body.app_id, body.app_secret);
+          await deployWeChatMiniProgramFunction(params.ref);
         } catch (error: unknown) {
           logger.error("Failed to deploy wechat-login function:", { error: error instanceof Error ? error.message : String(error) });
         }
@@ -90,6 +100,20 @@ export const wechatAuthRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
         wechat_mp: providerConfig,
       };
 
+      const runtimeSecrets = [
+        { name: "WECHAT_MP_APP_ID", value: body.app_id },
+        { name: "WECHAT_MP_APP_SECRET", value: body.app_secret },
+        ...(body.redirect_uri ? [{ name: "WECHAT_MP_REDIRECT_URI", value: body.redirect_uri }] : []),
+      ];
+      if (!body.redirect_uri) {
+        await projectService.deleteSecret(params.ref, "WECHAT_MP_REDIRECT_URI");
+      }
+      const secretsSaved = await projectService.upsertSecrets(params.ref, runtimeSecrets);
+      if (!secretsSaved) {
+        return status(500, { message: "Failed to save WeChat Official Account credentials", code: "500" });
+      }
+      await runtimeCacheService.invalidateProjectRuntimeEnv(params.ref);
+
       await projectService.updateProjectSettings(params.ref, {
         ...settings,
         auth: {
@@ -100,7 +124,7 @@ export const wechatAuthRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
 
       if (body.deploy_function !== false) {
         try {
-          await deployWeChatMPFunction(params.ref, body.app_id, body.app_secret, body.redirect_uri);
+          await deployWeChatMPFunction(params.ref);
         } catch (error: unknown) {
           logger.error("Failed to deploy wechat-mp-login function:", { error: error instanceof Error ? error.message : String(error) });
         }
@@ -202,25 +226,132 @@ export const wechatAuthRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
 
 // --- Deploy helper functions ---
 
-async function deployWeChatMiniProgramFunction(ref: string, appId: string, appSecret: string): Promise<void> {
-  const functionCode = generateWeChatMiniProgramLoginFunction(appId, appSecret);
+async function deployWeChatMiniProgramFunction(ref: string): Promise<void> {
+  const functionCode = generateWeChatMiniProgramLoginFunction();
   const ok = await edgeFunctionService.deploy(ref, "wechat-login", functionCode);
   if (!ok) {
     throw new Error("Failed to deploy wechat-login function");
   }
 }
 
-async function deployWeChatMPFunction(ref: string, appId: string, appSecret: string, redirectUri?: string): Promise<void> {
-  const functionCode = generateWeChatMPLoginFunction(appId, appSecret, redirectUri);
+async function deployWeChatMPFunction(ref: string): Promise<void> {
+  const functionCode = generateWeChatMPLoginFunction();
   const ok = await edgeFunctionService.deploy(ref, "wechat-mp-login", functionCode);
   if (!ok) {
     throw new Error("Failed to deploy wechat-mp-login function");
   }
 }
 
-function generateWeChatMiniProgramLoginFunction(appId: string, appSecret: string): string {
-  return `import { createClient } from "@supabase/supabase-js"
-import { SQL } from "bun"
+/**
+ * Keep generated auth functions self-contained.
+ *
+ * A function is bundled from its tenant directory, so importing
+ * `@supabase/supabase-js` here is not reliable: the management API's
+ * node_modules directory is not on the tenant resolver path. The small
+ * fetch wrapper below mirrors the Admin API calls used by the SDK without
+ * introducing a runtime package dependency.
+ */
+function generateGoTrueAdminHelpers(): string {
+  return `
+function runtimeEnv(name) {
+  const value = Bun.env[name]
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function resolveAuthUrl() {
+  const configured = runtimeEnv("SUPACLOUD_INTERNAL_AUTH_URL") || runtimeEnv("SUPABASE_URL")
+  if (!configured) throw new Error("Supabase URL is not configured")
+  const base = configured.replace(/\\/+$/, "")
+  return base.endsWith("/auth/v1") ? base : base + "/auth/v1"
+}
+
+function authHeaders() {
+  const serviceRoleKey = runtimeEnv("SUPABASE_SERVICE_ROLE_KEY")
+  if (!serviceRoleKey) throw new Error("Supabase service role key is not configured")
+  const headers = {
+    "apikey": serviceRoleKey,
+    "Authorization": "Bearer " + serviceRoleKey,
+    "Accept": "application/json",
+  }
+  const projectRef = runtimeEnv("X_PROJECT_REF") || runtimeEnv("SUPACLOUD_PROJECT_REF")
+  if (projectRef) headers["x-project-ref"] = projectRef
+  return headers
+}
+
+async function authRequest(path, options = {}) {
+  const headers = { ...authHeaders(), ...(options.headers || {}) }
+  if (options.body !== undefined) headers["Content-Type"] = "application/json"
+  const response = await fetch(resolveAuthUrl() + "/" + String(path).replace(/^\\/+/, ""), {
+    method: options.method || "POST",
+    headers,
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  })
+  const text = await response.text()
+  let payload = null
+  if (text.trim()) {
+    try { payload = JSON.parse(text) } catch { payload = text }
+  }
+  if (!response.ok) {
+    const detail = payload && typeof payload === "object"
+      ? payload.msg || payload.message || payload.error_description || payload.error || payload.code
+      : payload
+    throw new Error("GoTrue request failed (" + response.status + "): " + (detail || response.statusText || "unknown error"))
+  }
+  return payload
+}
+
+async function createWechatSession(email, userMetadata, provider) {
+  try {
+    await authRequest("admin/users", { body: {
+      email,
+      email_confirm: true,
+      user_metadata: { ...userMetadata, provider },
+    }})
+  } catch (error) {
+    const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase()
+    if (!message.includes("already registered") && !message.includes("already exists")) {
+      throw new Error("Cannot create user. Error: " + (error instanceof Error ? error.message : String(error)))
+    }
+  }
+
+  const rawLinkData = await authRequest("admin/generate_link", {
+    body: { type: "magiclink", email },
+  })
+  const linkData = rawLinkData?.data?.properties ? rawLinkData.data : rawLinkData
+  const hashedToken = linkData?.properties?.hashed_token || linkData?.hashed_token
+  if (!hashedToken) throw new Error("Failed to generate magic link")
+
+  const rawSessionData = await authRequest("verify", {
+    body: { type: "magiclink", token_hash: hashedToken, gotrue_meta_security: {} },
+  })
+  const sessionData = rawSessionData?.data?.session
+    ? { ...rawSessionData.data.session, user: rawSessionData.data.user || rawSessionData.data.session.user }
+    : rawSessionData
+  const session = sessionData && sessionData.access_token && sessionData.refresh_token && sessionData.expires_in
+    ? { ...sessionData, expires_at: sessionData.expires_at || Math.floor(Date.now() / 1000) + Number(sessionData.expires_in) }
+    : null
+  const user = sessionData?.user || null
+  if (!session || !user?.id) throw new Error("Failed to verify GoTrue session")
+
+  await authRequest("admin/users/" + encodeURIComponent(user.id), { method: "PUT", body: {
+    user_metadata: { ...(user.user_metadata || {}), ...userMetadata, provider },
+    app_metadata: { ...(user.app_metadata || {}), provider, providers: [provider] },
+  }})
+
+  return { session, user }
+}
+
+async function getAuthUser(userId) {
+  const payload = await authRequest("admin/users/" + encodeURIComponent(userId), { method: "GET" })
+  return payload?.user || payload
+}
+`;
+}
+
+function generateWeChatMiniProgramLoginFunction(): string {
+  return `import { SQL } from "bun"
+
+${generateGoTrueAdminHelpers()}
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "",
@@ -237,11 +368,12 @@ function corsOriginHeader(req: Request): Record<string, string> {
 export default async function handler(req: Request) {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
   try {
-    const { code } = await req.json()
-    const WECHAT_APP_ID = Bun.env["WECHAT_MINIPROGRAM_APP_ID"] || "${appId}"
-    const WECHAT_APP_SECRET = Bun.env["WECHAT_MINIPROGRAM_APP_SECRET"] || "${appSecret}"
-    const SUPABASE_URL = Bun.env["SUPABASE_URL"]
-    const SUPABASE_SERVICE_ROLE_KEY = Bun.env["SUPABASE_SERVICE_ROLE_KEY"]
+    const body = await req.json()
+    const code = body && typeof body.code === "string" ? body.code : ""
+    if (!code) throw new Error("WeChat login code is required")
+    const WECHAT_APP_ID = runtimeEnv("WECHAT_MINIPROGRAM_APP_ID")
+    const WECHAT_APP_SECRET = runtimeEnv("WECHAT_MINIPROGRAM_APP_SECRET")
+    if (!WECHAT_APP_ID || !WECHAT_APP_SECRET) throw new Error("WeChat Mini Program credentials are not configured")
 
     const tokenUrl = \`https://api.weixin.qq.com/sns/jscode2session?appid=\${WECHAT_APP_ID}&secret=\${WECHAT_APP_SECRET}&js_code=\${code}&grant_type=authorization_code\`
     const wechatRes = await fetch(tokenUrl)
@@ -253,42 +385,13 @@ export default async function handler(req: Request) {
 
     const { openid, session_key, unionid } = wechatData
 
-    const supabaseAdmin = createClient(SUPABASE_URL as string, SUPABASE_SERVICE_ROLE_KEY as string, {
-      auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
-    })
-
     const email = \`\${openid.toLowerCase()}@wechat.com\`
 
-    const { data: newUser, error: createError } = await supabaseAdmin.auth.admin.createUser({
-      email, email_confirm: true, user_metadata: { openid, unionid, provider: "wechat_miniprogram" }
-    })
-
-    if (createError && !(createError.message.toLowerCase().includes("already registered") || createError.message.toLowerCase().includes("already exists"))) {
-      throw new Error(\`Cannot create user. Error: \${createError.message}\`)
-    }
-
-    const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
-      type: "magiclink",
-      email: email,
-    })
-
-    if (linkError || !linkData?.properties?.hashed_token) {
-      throw new Error(\`Failed to generate magic link: \${linkError?.message}\`)
-    }
-
-    const { data: sessionData, error: verifyError } = await supabaseAdmin.auth.verifyOtp({
-      type: "magiclink",
-      token_hash: linkData.properties.hashed_token,
-    })
-
-    if (verifyError || !sessionData?.session) {
-      throw new Error(\`Failed to verify GoTrue session: \${verifyError?.message}\`)
-    }
-
-    await supabaseAdmin.auth.admin.updateUserById(sessionData.user.id, {
-        user_metadata: { ...sessionData.user.user_metadata, openid, unionid, provider: "wechat_miniprogram" },
-        app_metadata: { ...sessionData.user.app_metadata, provider: "wechat_miniprogram", providers: ["wechat_miniprogram"] }
-    })
+    const { session, user: sessionUser } = await createWechatSession(
+      email,
+      { openid, unionid },
+      "wechat_miniprogram",
+    )
 
     // Explicitly link physical identity row mirroring real OAuth behavior
     const SUPABASE_DB_URL = Bun.env["SUPABASE_DB_URL"]
@@ -297,7 +400,7 @@ export default async function handler(req: Request) {
       try {
         await sql\`
           INSERT INTO auth.identities (id, user_id, provider, identity_data, last_sign_in_at, created_at, updated_at)
-          VALUES (\${openid}, \${sessionData.user.id}, 'wechat_miniprogram', \${JSON.stringify({ sub: openid, unionid })}::jsonb, NOW(), NOW(), NOW())
+          VALUES (\${openid}, \${sessionUser.id}, 'wechat_miniprogram', \${JSON.stringify({ sub: openid, unionid })}::jsonb, NOW(), NOW(), NOW())
           ON CONFLICT (provider, id) DO UPDATE 
           SET identity_data = EXCLUDED.identity_data, last_sign_in_at = EXCLUDED.last_sign_in_at, updated_at = EXCLUDED.updated_at
         \`
@@ -309,8 +412,8 @@ export default async function handler(req: Request) {
     }
 
     // Refetch the user to bundle the completed identity payload within the first session
-    const { data: finalUser } = await supabaseAdmin.auth.admin.getUserById(sessionData.user.id)
-    const finalSession = finalUser?.user ? { ...sessionData.session, user: finalUser.user } : sessionData.session
+    const finalUser = await getAuthUser(sessionUser.id)
+    const finalSession = { ...session, user: finalUser || sessionUser }
     const responseUser = finalSession.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
     if (session_key) (finalSession as any).provider_token = session_key;
@@ -325,9 +428,10 @@ export default async function handler(req: Request) {
 }`;
 }
 
-function generateWeChatMPLoginFunction(appId: string, appSecret: string, redirectUri?: string): string {
-  return `import { createClient } from "@supabase/supabase-js"
-import { SQL } from "bun"
+function generateWeChatMPLoginFunction(): string {
+  return `import { SQL } from "bun"
+
+${generateGoTrueAdminHelpers()}
 
 const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
@@ -340,8 +444,8 @@ function corsOriginHeader(req: Request): Record<string, string> {
   return { "Access-Control-Allow-Origin": origin, "Vary": "Origin" };
 }
 
-const WECHAT_MP_APP_ID = "${appId}"
-const WECHAT_MP_APP_SECRET = "${appSecret}"
+const WECHAT_MP_APP_ID = runtimeEnv("WECHAT_MP_APP_ID")
+const WECHAT_MP_APP_SECRET = runtimeEnv("WECHAT_MP_APP_SECRET")
 
 export default async function handler(req: Request) {
   if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
@@ -349,10 +453,11 @@ export default async function handler(req: Request) {
   const url = new URL(req.url)
 
   try {
+    if (!WECHAT_MP_APP_ID || !WECHAT_MP_APP_SECRET) throw new Error("WeChat Official Account credentials are not configured")
     const code = url.searchParams.get("code") || (await req.json().catch(() => ({})))?.code
 
     if (!code) {
-      const redirectUri = "${redirectUri || ''}"
+      const redirectUri = runtimeEnv("WECHAT_MP_REDIRECT_URI")
       const state = url.searchParams.get("state") || Math.random().toString(36).substring(7)
       const authUrl = \`https://open.weixin.qq.com/connect/oauth2/authorize?appid=\${WECHAT_MP_APP_ID}&redirect_uri=\${encodeURIComponent(redirectUri)}&response_type=code&scope=snsapi_userinfo&state=\${state}#wechat_redirect\`
       return new Response(JSON.stringify({ auth_url: authUrl }), { headers: { ...corsHeaders, ...corsOriginHeader(req), "Content-Type": "application/json" } })
@@ -372,44 +477,13 @@ export default async function handler(req: Request) {
     const userRes = await fetch(userUrl)
     const userData = await userRes.json()
 
-    const SUPABASE_URL = Bun.env["SUPABASE_URL"]
-    const SUPABASE_SERVICE_ROLE_KEY = Bun.env["SUPABASE_SERVICE_ROLE_KEY"]
-
-    const supabaseAdmin = createClient(SUPABASE_URL as string, SUPABASE_SERVICE_ROLE_KEY as string, {
-      auth: { autoRefreshToken: false, persistSession: false, detectSessionInUrl: false },
-    })
-
     const email = \`\${openid.toLowerCase()}@wechat-mp.com\`
 
-    const { data: newUser, error: createError } = await supabaseAdmin.auth.admin.createUser({
-      email, email_confirm: true, user_metadata: { openid, unionid, nickname: userData.nickname, headimgurl: userData.headimgurl, provider: "wechat_mp" }
-    })
-
-    if (createError && !(createError.message.toLowerCase().includes("already registered") || createError.message.toLowerCase().includes("already exists"))) {
-      throw new Error(\`Cannot create user. Error: \${createError.message}\`)
-    }
-    const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
-      type: "magiclink",
-      email: email,
-    })
-
-    if (linkError || !linkData?.properties?.hashed_token) {
-      throw new Error(\`Failed to generate magic link: \${linkError?.message}\`)
-    }
-
-    const { data: sessionData, error: verifyError } = await supabaseAdmin.auth.verifyOtp({
-      type: "magiclink",
-      token_hash: linkData.properties.hashed_token,
-    })
-
-    if (verifyError || !sessionData?.session) {
-      throw new Error(\`Failed to verify GoTrue session: \${verifyError?.message}\`)
-    }
-
-    await supabaseAdmin.auth.admin.updateUserById(sessionData.user.id, {
-        user_metadata: { ...sessionData.user.user_metadata, openid, unionid, nickname: userData.nickname, headimgurl: userData.headimgurl, provider: "wechat_mp" },
-        app_metadata: { ...sessionData.user.app_metadata, provider: "wechat_mp", providers: ["wechat_mp"] }
-    })
+    const { session, user: sessionUser } = await createWechatSession(
+      email,
+      { openid, unionid, nickname: userData.nickname, headimgurl: userData.headimgurl },
+      "wechat_mp",
+    )
 
     // Explicitly link physical identity row mirroring real OAuth behavior
     const SUPABASE_DB_URL = Bun.env["SUPABASE_DB_URL"]
@@ -418,7 +492,7 @@ export default async function handler(req: Request) {
       try {
         await sql\`
           INSERT INTO auth.identities (id, user_id, provider, identity_data, last_sign_in_at, created_at, updated_at)
-          VALUES (\${openid}, \${sessionData.user.id}, \${'wechat_mp'}, CAST(\${JSON.stringify({ sub: openid, unionid, nickname: userData.nickname, headimgurl: userData.headimgurl })} AS jsonb), NOW(), NOW(), NOW())
+          VALUES (\${openid}, \${sessionUser.id}, \${'wechat_mp'}, CAST(\${JSON.stringify({ sub: openid, unionid, nickname: userData.nickname, headimgurl: userData.headimgurl })} AS jsonb), NOW(), NOW(), NOW())
           ON CONFLICT (provider, id) DO UPDATE 
           SET identity_data = EXCLUDED.identity_data, last_sign_in_at = EXCLUDED.last_sign_in_at, updated_at = EXCLUDED.updated_at
         \`
@@ -430,8 +504,8 @@ export default async function handler(req: Request) {
     }
 
     // Refetch the user to bundle the completed identity payload within the first session
-    const { data: finalUser } = await supabaseAdmin.auth.admin.getUserById(sessionData.user.id)
-    const finalSession = finalUser?.user ? { ...sessionData.session, user: finalUser.user } : sessionData.session
+    const finalUser = await getAuthUser(sessionUser.id)
+    const finalSession = { ...session, user: finalUser || sessionUser }
     const responseUser = finalSession.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
     if (tokenData.access_token) (finalSession as any).provider_token = tokenData.access_token;

--- a/packages/management-api/src/routes/auth-wechat.ts
+++ b/packages/management-api/src/routes/auth-wechat.ts
@@ -258,14 +258,31 @@ function runtimeEnv(name) {
   return typeof value === "string" ? value.trim() : ""
 }
 
-function resolveAuthUrl() {
-  const configured = runtimeEnv("SUPACLOUD_INTERNAL_AUTH_URL") || runtimeEnv("SUPABASE_URL")
-  if (!configured) throw new Error("Supabase URL is not configured")
-  const base = configured.replace(/\\/+$/, "")
+function normalizeAuthUrl(value) {
+  if (!value) return ""
+  const base = value.replace(/\\/+$/, "")
   return base.endsWith("/auth/v1") ? base : base + "/auth/v1"
 }
 
-function authHeaders() {
+function requestProjectRef(req) {
+  const requestRef = req?.headers?.get("x-project-ref") || ""
+  return requestRef.trim() || runtimeEnv("X_PROJECT_REF") || runtimeEnv("SUPACLOUD_PROJECT_REF")
+}
+
+function resolveAuthUrls(projectRef) {
+  const internalUrl = normalizeAuthUrl(runtimeEnv("SUPACLOUD_INTERNAL_AUTH_URL"))
+  const externalUrl = normalizeAuthUrl(runtimeEnv("SUPABASE_URL"))
+  const urls = []
+  // The shared internal auth gateway requires x-project-ref. If the runtime
+  // did not inject one, go directly to the tenant's external API URL.
+  if (internalUrl && projectRef) urls.push(internalUrl)
+  if (externalUrl && !urls.includes(externalUrl)) urls.push(externalUrl)
+  if (internalUrl && urls.length === 0) urls.push(internalUrl)
+  if (urls.length === 0) throw new Error("Supabase URL is not configured")
+  return urls
+}
+
+function authHeaders(projectRef) {
   const serviceRoleKey = runtimeEnv("SUPABASE_SERVICE_ROLE_KEY")
   if (!serviceRoleKey) throw new Error("Supabase service role key is not configured")
   const headers = {
@@ -273,36 +290,53 @@ function authHeaders() {
     "Authorization": "Bearer " + serviceRoleKey,
     "Accept": "application/json",
   }
-  const projectRef = runtimeEnv("X_PROJECT_REF") || runtimeEnv("SUPACLOUD_PROJECT_REF")
   if (projectRef) headers["x-project-ref"] = projectRef
   return headers
 }
 
-async function authRequest(path, options = {}) {
-  const headers = { ...authHeaders(), ...(options.headers || {}) }
+async function authRequest(req, path, options = {}) {
+  const projectRef = requestProjectRef(req)
+  const authUrls = resolveAuthUrls(projectRef)
+  const headers = { ...authHeaders(projectRef), ...(options.headers || {}) }
   if (options.body !== undefined) headers["Content-Type"] = "application/json"
-  const response = await fetch(resolveAuthUrl() + "/" + String(path).replace(/^\\/+/, ""), {
-    method: options.method || "POST",
-    headers,
-    body: options.body === undefined ? undefined : JSON.stringify(options.body),
-  })
-  const text = await response.text()
-  let payload = null
-  if (text.trim()) {
-    try { payload = JSON.parse(text) } catch { payload = text }
-  }
-  if (!response.ok) {
+  const requestPath = "/" + String(path).replace(/^\\/+/, "")
+  let lastError = null
+
+  for (let index = 0; index < authUrls.length; index++) {
+    let response
+    try {
+      response = await fetch(authUrls[index] + requestPath, {
+        method: options.method || "POST",
+        headers,
+        body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      })
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error))
+      if (index + 1 < authUrls.length) continue
+      throw lastError
+    }
+
+    const text = await response.text()
+    let payload = null
+    if (text.trim()) {
+      try { payload = JSON.parse(text) } catch { payload = text }
+    }
+    if (response.ok) return payload
+
     const detail = payload && typeof payload === "object"
       ? payload.msg || payload.message || payload.error_description || payload.error || payload.code
       : payload
-    throw new Error("GoTrue request failed (" + response.status + "): " + (detail || response.statusText || "unknown error"))
+    lastError = new Error("GoTrue request failed (" + response.status + "): " + (detail || response.statusText || "unknown error"))
+    if (/missing tenant reference/i.test(String(detail || "")) && index + 1 < authUrls.length) continue
+    throw lastError
   }
-  return payload
+
+  throw lastError || new Error("GoTrue request failed")
 }
 
-async function createWechatSession(email, userMetadata, provider) {
+async function createWechatSession(req, email, userMetadata, provider) {
   try {
-    await authRequest("admin/users", { body: {
+    await authRequest(req, "admin/users", { body: {
       email,
       email_confirm: true,
       user_metadata: { ...userMetadata, provider },
@@ -314,14 +348,14 @@ async function createWechatSession(email, userMetadata, provider) {
     }
   }
 
-  const rawLinkData = await authRequest("admin/generate_link", {
+  const rawLinkData = await authRequest(req, "admin/generate_link", {
     body: { type: "magiclink", email },
   })
   const linkData = rawLinkData?.data?.properties ? rawLinkData.data : rawLinkData
   const hashedToken = linkData?.properties?.hashed_token || linkData?.hashed_token
   if (!hashedToken) throw new Error("Failed to generate magic link")
 
-  const rawSessionData = await authRequest("verify", {
+  const rawSessionData = await authRequest(req, "verify", {
     body: { type: "magiclink", token_hash: hashedToken, gotrue_meta_security: {} },
   })
   const sessionData = rawSessionData?.data?.session
@@ -333,7 +367,7 @@ async function createWechatSession(email, userMetadata, provider) {
   const user = sessionData?.user || null
   if (!session || !user?.id) throw new Error("Failed to verify GoTrue session")
 
-  await authRequest("admin/users/" + encodeURIComponent(user.id), { method: "PUT", body: {
+  await authRequest(req, "admin/users/" + encodeURIComponent(user.id), { method: "PUT", body: {
     user_metadata: { ...(user.user_metadata || {}), ...userMetadata, provider },
     app_metadata: { ...(user.app_metadata || {}), provider, providers: [provider] },
   }})
@@ -341,8 +375,8 @@ async function createWechatSession(email, userMetadata, provider) {
   return { session, user }
 }
 
-async function getAuthUser(userId) {
-  const payload = await authRequest("admin/users/" + encodeURIComponent(userId), { method: "GET" })
+async function getAuthUser(req, userId) {
+  const payload = await authRequest(req, "admin/users/" + encodeURIComponent(userId), { method: "GET" })
   return payload?.user || payload
 }
 `;
@@ -388,6 +422,7 @@ export default async function handler(req: Request) {
     const email = \`\${openid.toLowerCase()}@wechat.com\`
 
     const { session, user: sessionUser } = await createWechatSession(
+      req,
       email,
       { openid, unionid },
       "wechat_miniprogram",
@@ -412,7 +447,7 @@ export default async function handler(req: Request) {
     }
 
     // Refetch the user to bundle the completed identity payload within the first session
-    const finalUser = await getAuthUser(sessionUser.id)
+    const finalUser = await getAuthUser(req, sessionUser.id)
     const finalSession = { ...session, user: finalUser || sessionUser }
     const responseUser = finalSession.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase
@@ -480,6 +515,7 @@ export default async function handler(req: Request) {
     const email = \`\${openid.toLowerCase()}@wechat-mp.com\`
 
     const { session, user: sessionUser } = await createWechatSession(
+      req,
       email,
       { openid, unionid, nickname: userData.nickname, headimgurl: userData.headimgurl },
       "wechat_mp",
@@ -504,7 +540,7 @@ export default async function handler(req: Request) {
     }
 
     // Refetch the user to bundle the completed identity payload within the first session
-    const finalUser = await getAuthUser(sessionUser.id)
+    const finalUser = await getAuthUser(req, sessionUser.id)
     const finalSession = { ...session, user: finalUser || sessionUser }
     const responseUser = finalSession.user ?? null
     // Embed native OAuth provider tokens to complete the session payload matching Official Supabase

--- a/packages/management-api/tests/unit/auth-wechat.test.ts
+++ b/packages/management-api/tests/unit/auth-wechat.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { wechatAuthInternals } from "../../src/routes/auth-wechat";
 
 function expectWechatLoginResponseContract(functionCode: string) {
@@ -10,16 +14,129 @@ function expectWechatLoginResponseContract(functionCode: string) {
   expect(functionCode).not.toContain("(finalSession as any).user");
 }
 
+async function expectSelfContainedBundle(functionCode: string) {
+  const directory = await mkdtemp(join(tmpdir(), "supacloud-wechat-function-"));
+  try {
+    const entrypoint = join(directory, "index.ts");
+    await Bun.write(entrypoint, functionCode);
+    const result = await Bun.build({ entrypoints: [entrypoint], target: "bun" });
+    expect(result.success).toBe(true);
+    expect(result.logs).toEqual([]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
 describe("wechat auth edge function generators", () => {
   test("mini program login success response matches supabase-mp-js contract", () => {
-    const functionCode = wechatAuthInternals.generateWeChatMiniProgramLoginFunction("app-id", "secret");
+    const functionCode = wechatAuthInternals.generateWeChatMiniProgramLoginFunction();
 
     expectWechatLoginResponseContract(functionCode);
+    expect(functionCode).not.toContain("@supabase/supabase-js");
+    expect(functionCode).toContain("SUPACLOUD_INTERNAL_AUTH_URL");
+    expect(functionCode).toContain("WECHAT_MINIPROGRAM_APP_SECRET");
   });
 
   test("official account login success response matches supabase-mp-js contract", () => {
-    const functionCode = wechatAuthInternals.generateWeChatMPLoginFunction("app-id", "secret", "https://example.com/callback");
+    const functionCode = wechatAuthInternals.generateWeChatMPLoginFunction();
 
     expectWechatLoginResponseContract(functionCode);
+    expect(functionCode).not.toContain("@supabase/supabase-js");
+    expect(functionCode).toContain("WECHAT_MP_APP_SECRET");
+  });
+
+  test("generated login functions bundle without npm dependencies", async () => {
+    await expectSelfContainedBundle(wechatAuthInternals.generateWeChatMiniProgramLoginFunction());
+    await expectSelfContainedBundle(wechatAuthInternals.generateWeChatMPLoginFunction());
+  });
+
+  test("mini program function exchanges a code for a refreshable session through GoTrue", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "supacloud-wechat-function-run-"));
+    const originalFetch = globalThis.fetch;
+    const envNames = [
+      "WECHAT_MINIPROGRAM_APP_ID",
+      "WECHAT_MINIPROGRAM_APP_SECRET",
+      "SUPACLOUD_INTERNAL_AUTH_URL",
+      "SUPABASE_SERVICE_ROLE_KEY",
+      "X_PROJECT_REF",
+      "SUPABASE_DB_URL",
+    ] as const;
+    const originalEnv = Object.fromEntries(envNames.map((name) => [name, Bun.env[name]]));
+    const authRequests: Array<{ url: string; method: string; headers: Headers }> = [];
+    const user = {
+      id: "11111111-1111-1111-1111-111111111111",
+      user_metadata: {},
+      app_metadata: {},
+    };
+
+    try {
+      Bun.env.WECHAT_MINIPROGRAM_APP_ID = "test-app-id";
+      Bun.env.WECHAT_MINIPROGRAM_APP_SECRET = "test-app-secret";
+      Bun.env.SUPACLOUD_INTERNAL_AUTH_URL = "http://auth.internal/auth/v1";
+      Bun.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
+      Bun.env.X_PROJECT_REF = "test-project";
+      delete Bun.env.SUPABASE_DB_URL;
+
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.startsWith("https://api.weixin.qq.com/sns/jscode2session")) {
+          return Response.json({ openid: "openid", unionid: "unionid", session_key: "provider-token" });
+        }
+
+        const method = init?.method || "GET";
+        const headers = new Headers(init?.headers);
+        authRequests.push({ url, method, headers });
+        if (url.endsWith("/admin/users") && method === "POST") return Response.json(user, { status: 201 });
+        if (url.endsWith("/admin/generate_link")) return Response.json({ ...user, hashed_token: "hashed-token" });
+        if (url.endsWith("/verify")) {
+          return Response.json({ access_token: "access-token", refresh_token: "refresh-token", expires_in: 3600, user });
+        }
+        if (url.endsWith(`/admin/users/${user.id}`) && method === "PUT") {
+          return Response.json({ ...user, user_metadata: { openid: "openid" } });
+        }
+        if (url.endsWith(`/admin/users/${user.id}`) && method === "GET") {
+          return Response.json({ ...user, user_metadata: { openid: "openid" } });
+        }
+        return Response.json({ message: "unexpected request" }, { status: 500 });
+      }) as typeof fetch;
+
+      const entrypoint = join(directory, "index.ts");
+      await Bun.write(entrypoint, wechatAuthInternals.generateWeChatMiniProgramLoginFunction());
+      const moduleUrl = `${pathToFileURL(entrypoint).href}?test=${Date.now()}`;
+      const loginFunction = (await import(moduleUrl)).default as (request: Request) => Promise<Response>;
+      const response = await loginFunction(new Request("http://localhost/functions/v1/wechat-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "wx-code" }),
+      }));
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.data.session).toMatchObject({
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        provider_token: "provider-token",
+      });
+      expect(payload.data.user.user_metadata.openid).toBe("openid");
+      expect(authRequests.map((request) => `${request.method} ${request.url}`)).toEqual([
+        "POST http://auth.internal/auth/v1/admin/users",
+        "POST http://auth.internal/auth/v1/admin/generate_link",
+        "POST http://auth.internal/auth/v1/verify",
+        `PUT http://auth.internal/auth/v1/admin/users/${user.id}`,
+        `GET http://auth.internal/auth/v1/admin/users/${user.id}`,
+      ]);
+      for (const request of authRequests) {
+        expect(request.headers.get("authorization")).toBe("Bearer test-service-role");
+        expect(request.headers.get("x-project-ref")).toBe("test-project");
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      for (const name of envNames) {
+        const value = originalEnv[name];
+        if (value === undefined) delete Bun.env[name];
+        else Bun.env[name] = value;
+      }
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/management-api/tests/unit/auth-wechat.test.ts
+++ b/packages/management-api/tests/unit/auth-wechat.test.ts
@@ -34,6 +34,7 @@ describe("wechat auth edge function generators", () => {
     expectWechatLoginResponseContract(functionCode);
     expect(functionCode).not.toContain("@supabase/supabase-js");
     expect(functionCode).toContain("SUPACLOUD_INTERNAL_AUTH_URL");
+    expect(functionCode).toContain('req?.headers?.get("x-project-ref")');
     expect(functionCode).toContain("WECHAT_MINIPROGRAM_APP_SECRET");
   });
 
@@ -57,8 +58,10 @@ describe("wechat auth edge function generators", () => {
       "WECHAT_MINIPROGRAM_APP_ID",
       "WECHAT_MINIPROGRAM_APP_SECRET",
       "SUPACLOUD_INTERNAL_AUTH_URL",
+      "SUPABASE_URL",
       "SUPABASE_SERVICE_ROLE_KEY",
       "X_PROJECT_REF",
+      "SUPACLOUD_PROJECT_REF",
       "SUPABASE_DB_URL",
     ] as const;
     const originalEnv = Object.fromEntries(envNames.map((name) => [name, Bun.env[name]]));
@@ -73,8 +76,10 @@ describe("wechat auth edge function generators", () => {
       Bun.env.WECHAT_MINIPROGRAM_APP_ID = "test-app-id";
       Bun.env.WECHAT_MINIPROGRAM_APP_SECRET = "test-app-secret";
       Bun.env.SUPACLOUD_INTERNAL_AUTH_URL = "http://auth.internal/auth/v1";
+      delete Bun.env.SUPABASE_URL;
       Bun.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
-      Bun.env.X_PROJECT_REF = "test-project";
+      delete Bun.env.X_PROJECT_REF;
+      delete Bun.env.SUPACLOUD_PROJECT_REF;
       delete Bun.env.SUPABASE_DB_URL;
 
       globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -106,7 +111,7 @@ describe("wechat auth edge function generators", () => {
       const loginFunction = (await import(moduleUrl)).default as (request: Request) => Promise<Response>;
       const response = await loginFunction(new Request("http://localhost/functions/v1/wechat-login", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-project-ref": "request-project" },
         body: JSON.stringify({ code: "wx-code" }),
       }));
       const payload = await response.json();
@@ -127,8 +132,80 @@ describe("wechat auth edge function generators", () => {
       ]);
       for (const request of authRequests) {
         expect(request.headers.get("authorization")).toBe("Bearer test-service-role");
-        expect(request.headers.get("x-project-ref")).toBe("test-project");
+        expect(request.headers.get("x-project-ref")).toBe("request-project");
       }
+    } finally {
+      globalThis.fetch = originalFetch;
+      for (const name of envNames) {
+        const value = originalEnv[name];
+        if (value === undefined) delete Bun.env[name];
+        else Bun.env[name] = value;
+      }
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("mini program function falls back to the external auth URL when no project ref is available", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "supacloud-wechat-function-fallback-"));
+    const originalFetch = globalThis.fetch;
+    const envNames = [
+      "WECHAT_MINIPROGRAM_APP_ID",
+      "WECHAT_MINIPROGRAM_APP_SECRET",
+      "SUPACLOUD_INTERNAL_AUTH_URL",
+      "SUPABASE_URL",
+      "SUPABASE_SERVICE_ROLE_KEY",
+      "X_PROJECT_REF",
+      "SUPACLOUD_PROJECT_REF",
+      "SUPABASE_DB_URL",
+    ] as const;
+    const originalEnv = Object.fromEntries(envNames.map((name) => [name, Bun.env[name]]));
+    const authUrls: string[] = [];
+    const user = {
+      id: "22222222-2222-2222-2222-222222222222",
+      user_metadata: {},
+      app_metadata: {},
+    };
+
+    try {
+      Bun.env.WECHAT_MINIPROGRAM_APP_ID = "test-app-id";
+      Bun.env.WECHAT_MINIPROGRAM_APP_SECRET = "test-app-secret";
+      Bun.env.SUPACLOUD_INTERNAL_AUTH_URL = "http://auth.internal/auth/v1";
+      Bun.env.SUPABASE_URL = "https://project.example";
+      Bun.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
+      delete Bun.env.X_PROJECT_REF;
+      delete Bun.env.SUPACLOUD_PROJECT_REF;
+      delete Bun.env.SUPABASE_DB_URL;
+
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.startsWith("https://api.weixin.qq.com/sns/jscode2session")) {
+          return Response.json({ openid: "openid", session_key: "provider-token" });
+        }
+        authUrls.push(url);
+        const method = init?.method || "GET";
+        if (url.endsWith("/admin/users") && method === "POST") return Response.json(user, { status: 201 });
+        if (url.endsWith("/admin/generate_link")) return Response.json({ ...user, hashed_token: "hashed-token" });
+        if (url.endsWith("/verify")) {
+          return Response.json({ access_token: "access-token", refresh_token: "refresh-token", expires_in: 3600, user });
+        }
+        if (url.endsWith(`/admin/users/${user.id}`)) return Response.json(user);
+        return Response.json({ message: "unexpected request" }, { status: 500 });
+      }) as typeof fetch;
+
+      const entrypoint = join(directory, "index.ts");
+      await Bun.write(entrypoint, wechatAuthInternals.generateWeChatMiniProgramLoginFunction());
+      const moduleUrl = `${pathToFileURL(entrypoint).href}?test=${Date.now()}`;
+      const loginFunction = (await import(moduleUrl)).default as (request: Request) => Promise<Response>;
+      const response = await loginFunction(new Request("http://localhost/functions/v1/wechat-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: "wx-code" }),
+      }));
+
+      expect(response.status).toBe(200);
+      expect(authUrls).toHaveLength(5);
+      expect(authUrls.every((url) => url.startsWith("https://project.example/auth/v1/"))).toBe(true);
+      expect(authUrls.some((url) => url.startsWith("http://auth.internal/"))).toBe(false);
     } finally {
       globalThis.fetch = originalFetch;
       for (const name of envNames) {


### PR DESCRIPTION
## What changed

- Make generated WeChat Mini Program and Official Account functions self-contained.
- Replace the runtime `@supabase/supabase-js` dependency with a small GoTrue Admin API fetch wrapper.
- Prefer SupaCloud's internal auth URL and forward `x-project-ref` for tenant routing.
- Persist WeChat credentials in encrypted project secrets and invalidate the Edge Runtime environment cache.
- Keep identity linking and the `supabase-mp-js` `{ data: { session, user } }` response contract.
- Add bundle and end-to-end mocked GoTrue tests.

## Why

Functions are bundled from the tenant directory. The generated import of `@supabase/supabase-js` could not be resolved there, so deployment fell back to raw source and preheat failed with an AggregateError. The generated source also embedded the app secret.

## Verification

```text
bun test tests/unit/auth-wechat.test.ts tests/unit/runtime-env.service.test.ts tests/unit/edge-function.service.bundle-metadata.test.ts
7 pass, 0 fail

bun run typecheck
```
