### PR TITLE
fix(rbac): isolate user permissions by application

### DIFF
--- a/packages/management-api/src/routes/project-rbac.ts
+++ b/packages/management-api/src/routes/project-rbac.ts
@@ -133,25 +133,29 @@ export const projectRbacRoutes = new Elysia({ prefix: "/v1/projects/:ref" })
   }, {
     detail: { tags: ["rbac"], summary: "Revoke project RBAC role assignment" },
   })
-  .get("/auth/users/:id/roles", async ({ params }) => {
+  .get("/auth/users/:id/roles", async ({ params, query }) => {
     try {
-      const assignments = await projectRbacService.listUserRoleAssignments(params.ref, params.id);
+      const assignments = await projectRbacService.listUserRoleAssignments(params.ref, params.id, query.application_id);
       return { items: assignments, total: assignments.length };
     } catch (error) {
       return toHttpError(error);
     }
   }, {
+    query: t.Object({
+      application_id: t.Optional(t.String()),
+    }, { additionalProperties: true }),
     detail: { tags: ["rbac"], summary: "List project RBAC roles assigned to a user" },
   })
   .get("/auth/users/:id/permissions", async ({ params, query }) => {
     try {
-      return await projectRbacService.resolveUserPermissions(params.ref, params.id, query.org_id);
+      return await projectRbacService.resolveUserPermissions(params.ref, params.id, query.org_id, query.application_id);
     } catch (error) {
       return toHttpError(error);
     }
   }, {
     query: t.Object({
       org_id: t.Optional(t.String()),
+      application_id: t.Optional(t.String()),
     }, { additionalProperties: true }),
     detail: { tags: ["rbac"], summary: "Resolve project RBAC permissions for a user" },
   })

--- a/packages/management-api/src/services/project-rbac.service.ts
+++ b/packages/management-api/src/services/project-rbac.service.ts
@@ -36,15 +36,24 @@ export interface ProjectRbacAssignment {
 export interface ProjectRbacConfig {
   roles: ProjectRbacRole[];
   assignments: ProjectRbacAssignment[];
+  application_ids: string[];
   version: number;
   updated_at?: string;
 }
 
-export interface ProjectRbacUserPermissions {
-  application_id?: string | null;
+interface ProjectRbacPermissionSet {
   roles: string[];
   permissions: string[];
   scopes: string[];
+}
+
+interface ProjectRbacApplicationPermissions extends ProjectRbacPermissionSet {
+  organization_ids: string[];
+  organizations: Record<string, ProjectRbacPermissionSet>;
+}
+
+export interface ProjectRbacUserPermissions extends ProjectRbacPermissionSet {
+  application_id?: string | null;
 }
 
 export interface AssignRoleInput {
@@ -158,9 +167,16 @@ function readRbacConfig(projectConfig: unknown): ProjectRbacConfig {
       .filter((item): item is ProjectRbacAssignment => item !== null && roleIds.has(item.role_id))
     : [];
   const version = Number(raw.version);
+  const configuredApplicationIds = Array.isArray(raw.application_ids)
+    ? raw.application_ids.map(optionalString)
+    : [];
   return {
     roles,
     assignments,
+    application_ids: uniqueSorted([
+      ...configuredApplicationIds,
+      ...assignments.map((assignment) => assignment.application_id),
+    ]),
     version: Number.isFinite(version) && version > 0 ? Math.trunc(version) : 0,
     updated_at: optionalString(raw.updated_at) ?? undefined,
   };
@@ -176,6 +192,16 @@ function getRoleOrThrow(rbac: ProjectRbacConfig, roleId: string): ProjectRbacRol
   return role;
 }
 
+function assignmentScopeMatches(
+  assignmentScope: string | null | undefined,
+  requestedScope: string | null | undefined,
+): boolean {
+  if (requestedScope === undefined || requestedScope === null) {
+    return !assignmentScope;
+  }
+  return !assignmentScope || assignmentScope === requestedScope;
+}
+
 function assignmentMatchesUser(
   assignment: ProjectRbacAssignment,
   userId: string,
@@ -183,16 +209,50 @@ function assignmentMatchesUser(
   applicationId?: string | null,
 ): boolean {
   if (assignment.user_id !== userId) return false;
-  if (orgId && assignment.organization_id && assignment.organization_id !== orgId) return false;
-  // A missing application_id is an intentional project-wide grant. Once an
-  // application context is supplied, only project-wide grants and grants for
-  // that exact application are eligible. Never carry another application's
-  // assignment into the result.
-  if (applicationId !== undefined && assignment.application_id && assignment.application_id !== applicationId) return false;
-  // Without an application context, expose only project-wide grants. This
-  // keeps legacy callers from accidentally receiving app-scoped permissions.
-  if (applicationId === undefined && assignment.application_id) return false;
-  return true;
+  return assignmentScopeMatches(assignment.organization_id, orgId)
+    && assignmentScopeMatches(assignment.application_id, applicationId);
+}
+
+function resolvePermissionSet(
+  rbac: ProjectRbacConfig,
+  assignments: ProjectRbacAssignment[],
+): ProjectRbacPermissionSet {
+  const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
+  const roles = assignments
+    .map((assignment) => rolesById.get(assignment.role_id)?.name)
+    .filter((value): value is string => Boolean(value));
+  const permissions = assignments.flatMap((assignment) => rolesById.get(assignment.role_id)?.permissions ?? []);
+
+  return {
+    roles: uniqueSorted(roles),
+    permissions: uniqueSorted(permissions.map((permission) => permission.name)),
+    scopes: uniqueSorted(permissions.map((permission) => permission.scope_id)),
+  };
+}
+
+function resolveApplicationMetadata(
+  rbac: ProjectRbacConfig,
+  userId: string,
+  applicationId: string,
+): ProjectRbacApplicationPermissions {
+  const assignments = rbac.assignments.filter((assignment) =>
+    assignment.user_id === userId
+    && (!assignment.application_id || assignment.application_id === applicationId)
+  );
+  const organizationIds = uniqueSorted(assignments.map((assignment) => assignment.organization_id));
+  const organizations = Object.fromEntries(organizationIds.map((organizationId) => [
+    organizationId,
+    resolvePermissionSet(
+      rbac,
+      assignments.filter((assignment) => !assignment.organization_id || assignment.organization_id === organizationId),
+    ),
+  ]));
+
+  return {
+    ...resolvePermissionSet(rbac, assignments.filter((assignment) => !assignment.organization_id)),
+    organization_ids: organizationIds,
+    organizations,
+  };
 }
 
 function resolvePermissionsFromConfig(
@@ -201,24 +261,21 @@ function resolvePermissionsFromConfig(
   orgId?: string | null,
   applicationId?: string | null,
 ): ProjectRbacUserPermissions {
-  const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
   const assignments = rbac.assignments.filter((assignment) => assignmentMatchesUser(assignment, userId, orgId, applicationId));
-  const roles = assignments
-    .map((assignment) => rolesById.get(assignment.role_id)?.name)
-    .filter((value): value is string => Boolean(value));
-  const permissions = assignments.flatMap((assignment) => rolesById.get(assignment.role_id)?.permissions ?? []);
 
   return {
     ...(applicationId !== undefined ? { application_id: applicationId } : {}),
-    roles: uniqueSorted(roles),
-    permissions: uniqueSorted(permissions.map((permission) => permission.name)),
-    scopes: uniqueSorted(permissions.map((permission) => permission.scope_id)),
+    ...resolvePermissionSet(rbac, assignments),
   };
 }
 
 function withNextVersion(rbac: ProjectRbacConfig): ProjectRbacConfig {
   return {
     ...rbac,
+    application_ids: uniqueSorted([
+      ...rbac.application_ids,
+      ...rbac.assignments.map((assignment) => assignment.application_id),
+    ]),
     version: rbac.version + 1,
     updated_at: nowIso(),
   };
@@ -304,31 +361,34 @@ async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacCo
   const appMetadata = isRecord(user.app_metadata) ? user.app_metadata : {};
   const existingSupauth = isRecord(appMetadata.supaoauth) ? appMetadata.supaoauth : {};
   const resolved = resolvePermissionsFromConfig(rbac, userId);
-  const orgIds = uniqueSorted(rbac.assignments
-    .filter((assignment) => assignment.user_id === userId && !assignment.application_id)
-    .map((assignment) => assignment.organization_id));
+  const organizationAssignments = rbac.assignments.filter((assignment) =>
+    assignment.user_id === userId && !assignment.application_id,
+  );
+  const orgIds = uniqueSorted(organizationAssignments.map((assignment) => assignment.organization_id));
+  const organizations = Object.fromEntries(orgIds.map((organizationId) => [
+    organizationId,
+    resolvePermissionSet(
+      rbac,
+      organizationAssignments.filter((assignment) =>
+        !assignment.organization_id || assignment.organization_id === organizationId,
+      ),
+    ),
+  ]));
   const existingCurrentOrgId = typeof existingSupauth.current_org_id === "string"
     ? existingSupauth.current_org_id
     : undefined;
   const currentOrgId = existingCurrentOrgId && orgIds.includes(existingCurrentOrgId)
     ? existingCurrentOrgId
     : orgIds.length === 1 ? orgIds[0] : undefined;
-  const applicationIds = uniqueSorted(rbac.assignments
-    .filter((assignment) => assignment.user_id === userId && Boolean(assignment.application_id))
-    .map((assignment) => assignment.application_id));
-  const applications = Object.fromEntries(applicationIds.map((applicationId) => {
-    const applicationResolved = resolvePermissionsFromConfig(rbac, userId, undefined, applicationId);
-    const applicationOrganizationIds = uniqueSorted(rbac.assignments
-      .filter((assignment) => assignment.user_id === userId
-        && (!assignment.application_id || assignment.application_id === applicationId))
-      .map((assignment) => assignment.organization_id));
-    return [applicationId, {
-      roles: applicationResolved.roles,
-      permissions: applicationResolved.permissions,
-      scopes: applicationResolved.scopes,
-      organization_ids: applicationOrganizationIds,
-    }];
-  }));
+  // Application IDs are project-owned RBAC state. They remain known after the
+  // last user assignment is revoked, so a sync cannot erase a namespace that
+  // still carries project-wide grants. Existing user metadata is never used as
+  // an authority for namespace discovery or permission contents.
+  const applicationIds = rbac.application_ids;
+  const applications = Object.fromEntries(applicationIds.map((applicationId) => [
+    applicationId,
+    resolveApplicationMetadata(rbac, userId, applicationId),
+  ]));
 
   const updateRes = await updateGoTrueUserMetadata(ctx.apiUrl, userId, headers, {
     app_metadata: {
@@ -340,6 +400,7 @@ async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacCo
         scopes: resolved.scopes,
         organization_ids: orgIds,
         current_org_id: currentOrgId,
+        organizations,
         applications,
         rbac_version: rbac.version,
         rbac_synced_at: nowIso(),
@@ -529,7 +590,10 @@ export const projectRbacService = {
     const rbac = readRbacConfig(project.config);
     const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
     return rbac.assignments
-      .filter((assignment) => assignmentMatchesUser(assignment, userId, undefined, applicationId))
+      .filter((assignment) =>
+        assignment.user_id === userId
+        && assignmentScopeMatches(assignment.application_id, applicationId),
+      )
       .map((assignment) => ({ ...assignment, role: rolesById.get(assignment.role_id) }));
   },
 

--- a/packages/management-api/src/services/project-rbac.service.ts
+++ b/packages/management-api/src/services/project-rbac.service.ts
@@ -41,6 +41,7 @@ export interface ProjectRbacConfig {
 }
 
 export interface ProjectRbacUserPermissions {
+  application_id?: string | null;
   roles: string[];
   permissions: string[];
   scopes: string[];
@@ -175,9 +176,22 @@ function getRoleOrThrow(rbac: ProjectRbacConfig, roleId: string): ProjectRbacRol
   return role;
 }
 
-function assignmentMatchesUser(assignment: ProjectRbacAssignment, userId: string, orgId?: string | null): boolean {
+function assignmentMatchesUser(
+  assignment: ProjectRbacAssignment,
+  userId: string,
+  orgId?: string | null,
+  applicationId?: string | null,
+): boolean {
   if (assignment.user_id !== userId) return false;
   if (orgId && assignment.organization_id && assignment.organization_id !== orgId) return false;
+  // A missing application_id is an intentional project-wide grant. Once an
+  // application context is supplied, only project-wide grants and grants for
+  // that exact application are eligible. Never carry another application's
+  // assignment into the result.
+  if (applicationId !== undefined && assignment.application_id && assignment.application_id !== applicationId) return false;
+  // Without an application context, expose only project-wide grants. This
+  // keeps legacy callers from accidentally receiving app-scoped permissions.
+  if (applicationId === undefined && assignment.application_id) return false;
   return true;
 }
 
@@ -185,15 +199,17 @@ function resolvePermissionsFromConfig(
   rbac: ProjectRbacConfig,
   userId: string,
   orgId?: string | null,
+  applicationId?: string | null,
 ): ProjectRbacUserPermissions {
   const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
-  const assignments = rbac.assignments.filter((assignment) => assignmentMatchesUser(assignment, userId, orgId));
+  const assignments = rbac.assignments.filter((assignment) => assignmentMatchesUser(assignment, userId, orgId, applicationId));
   const roles = assignments
     .map((assignment) => rolesById.get(assignment.role_id)?.name)
     .filter((value): value is string => Boolean(value));
   const permissions = assignments.flatMap((assignment) => rolesById.get(assignment.role_id)?.permissions ?? []);
 
   return {
+    ...(applicationId !== undefined ? { application_id: applicationId } : {}),
     roles: uniqueSorted(roles),
     permissions: uniqueSorted(permissions.map((permission) => permission.name)),
     scopes: uniqueSorted(permissions.map((permission) => permission.scope_id)),
@@ -289,7 +305,7 @@ async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacCo
   const existingSupauth = isRecord(appMetadata.supaoauth) ? appMetadata.supaoauth : {};
   const resolved = resolvePermissionsFromConfig(rbac, userId);
   const orgIds = uniqueSorted(rbac.assignments
-    .filter((assignment) => assignment.user_id === userId)
+    .filter((assignment) => assignment.user_id === userId && !assignment.application_id)
     .map((assignment) => assignment.organization_id));
   const existingCurrentOrgId = typeof existingSupauth.current_org_id === "string"
     ? existingSupauth.current_org_id
@@ -297,6 +313,22 @@ async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacCo
   const currentOrgId = existingCurrentOrgId && orgIds.includes(existingCurrentOrgId)
     ? existingCurrentOrgId
     : orgIds.length === 1 ? orgIds[0] : undefined;
+  const applicationIds = uniqueSorted(rbac.assignments
+    .filter((assignment) => assignment.user_id === userId && Boolean(assignment.application_id))
+    .map((assignment) => assignment.application_id));
+  const applications = Object.fromEntries(applicationIds.map((applicationId) => {
+    const applicationResolved = resolvePermissionsFromConfig(rbac, userId, undefined, applicationId);
+    const applicationOrganizationIds = uniqueSorted(rbac.assignments
+      .filter((assignment) => assignment.user_id === userId
+        && (!assignment.application_id || assignment.application_id === applicationId))
+      .map((assignment) => assignment.organization_id));
+    return [applicationId, {
+      roles: applicationResolved.roles,
+      permissions: applicationResolved.permissions,
+      scopes: applicationResolved.scopes,
+      organization_ids: applicationOrganizationIds,
+    }];
+  }));
 
   const updateRes = await updateGoTrueUserMetadata(ctx.apiUrl, userId, headers, {
     app_metadata: {
@@ -308,6 +340,7 @@ async function syncUserMetadata(ref: string, userId: string, rbac: ProjectRbacCo
         scopes: resolved.scopes,
         organization_ids: orgIds,
         current_org_id: currentOrgId,
+        applications,
         rbac_version: rbac.version,
         rbac_synced_at: nowIso(),
       },
@@ -487,12 +520,16 @@ export const projectRbacService = {
     if (assignment.user_id) await syncUserMetadata(ref, assignment.user_id, saved);
   },
 
-  async listUserRoleAssignments(ref: string, userId: string): Promise<Array<ProjectRbacAssignment & { role?: ProjectRbacRole }>> {
+  async listUserRoleAssignments(
+    ref: string,
+    userId: string,
+    applicationId?: string | null,
+  ): Promise<Array<ProjectRbacAssignment & { role?: ProjectRbacRole }>> {
     const project = await getProjectOrThrow(ref);
     const rbac = readRbacConfig(project.config);
     const rolesById = new Map(rbac.roles.map((role) => [role.id, role]));
     return rbac.assignments
-      .filter((assignment) => assignment.user_id === userId)
+      .filter((assignment) => assignmentMatchesUser(assignment, userId, undefined, applicationId))
       .map((assignment) => ({ ...assignment, role: rolesById.get(assignment.role_id) }));
   },
 
@@ -505,8 +542,13 @@ export const projectRbacService = {
       .map((assignment) => ({ ...assignment, role: rolesById.get(assignment.role_id) }));
   },
 
-  async resolveUserPermissions(ref: string, userId: string, orgId?: string | null): Promise<ProjectRbacUserPermissions> {
+  async resolveUserPermissions(
+    ref: string,
+    userId: string,
+    orgId?: string | null,
+    applicationId?: string | null,
+  ): Promise<ProjectRbacUserPermissions> {
     const project = await getProjectOrThrow(ref);
-    return resolvePermissionsFromConfig(readRbacConfig(project.config), userId, orgId);
+    return resolvePermissionsFromConfig(readRbacConfig(project.config), userId, orgId, applicationId);
   },
 };

--- a/packages/management-api/tests/unit/project-rbac.routes.test.ts
+++ b/packages/management-api/tests/unit/project-rbac.routes.test.ts
@@ -291,6 +291,77 @@ describe("projectRbacRoutes", () => {
     expect("current_org_id" in revokedSupauth).toBe(false);
   });
 
+  test("does not leak an application-scoped assignment across application contexts", async () => {
+    const role = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "fa_engineer" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${role.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "fa.rework.approve" }),
+    });
+    const otherRole = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "other_app_admin" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${otherRole.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "other.manage" }),
+    });
+
+    const first = await request(`/v1/projects/proj_1/rbac/roles/${role.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({ user_id: "user-one", application_id: "fa-app" }),
+    });
+    expect(first.status).toBe(200);
+    const second = await request(`/v1/projects/proj_1/rbac/roles/${otherRole.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({ user_id: "user-one", application_id: "other-app" }),
+    });
+    expect(second.status).toBe(200);
+
+    const faPermissions = await request(
+      "/v1/projects/proj_1/auth/users/user-one/permissions?application_id=fa-app",
+    );
+    expect(await faPermissions.json()).toEqual({
+      application_id: "fa-app",
+      roles: ["fa_engineer"],
+      permissions: ["fa.rework.approve"],
+      scopes: [],
+    });
+
+    const otherPermissions = await request(
+      "/v1/projects/proj_1/auth/users/user-one/permissions?application_id=other-app",
+    );
+    expect(await otherPermissions.json()).toEqual({
+      application_id: "other-app",
+      roles: ["other_app_admin"],
+      permissions: ["other.manage"],
+      scopes: [],
+    });
+
+    const legacyPermissions = await request(
+      "/v1/projects/proj_1/auth/users/user-one/permissions",
+    );
+    expect(await legacyPermissions.json()).toEqual({ roles: [], permissions: [], scopes: [] });
+
+    const faRoles = await request(
+      "/v1/projects/proj_1/auth/users/user-one/roles?application_id=fa-app",
+    );
+    expect(await faRoles.json()).toMatchObject({
+      total: 1,
+      items: [{ application_id: "fa-app", role: { name: "fa_engineer" } }],
+    });
+    const projectWideRoles = await request("/v1/projects/proj_1/auth/users/user-one/roles");
+    expect(await projectWideRoles.json()).toEqual({ items: [], total: 0 });
+
+    const projection = userUpdateBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    expect((projection.supaoauth as Record<string, unknown>).applications).toMatchObject({
+      "fa-app": { roles: ["fa_engineer"], permissions: ["fa.rework.approve"] },
+      "other-app": { roles: ["other_app_admin"], permissions: ["other.manage"] },
+    });
+  });
+
   test("falls back to PATCH when GoTrue rejects PUT user updates", async () => {
     putUserUpdateReturns405 = true;
     const role = await (await request("/v1/projects/proj_1/rbac/roles", {

--- a/packages/management-api/tests/unit/project-rbac.routes.test.ts
+++ b/packages/management-api/tests/unit/project-rbac.routes.test.ts
@@ -82,8 +82,13 @@ function request(path: string, init: RequestInit = {}) {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 describe("projectRbacRoutes", () => {
   let storedConfig: Record<string, unknown>;
+  let userAppMetadata: Record<string, unknown>;
   let putUserUpdateReturns405 = false;
   const userUpdateMethods: string[] = [];
   const userUpdateBodies: Array<Record<string, unknown>> = [];
@@ -97,6 +102,13 @@ describe("projectRbacRoutes", () => {
 
   beforeEach(() => {
     storedConfig = {};
+    userAppMetadata = {
+      provider: "email",
+      providers: ["email"],
+      supaoauth: {
+        profile: { role: "管理员" },
+      },
+    };
     putUserUpdateReturns405 = false;
     userUpdateMethods.length = 0;
     userUpdateBodies.length = 0;
@@ -114,24 +126,23 @@ describe("projectRbacRoutes", () => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith("/admin/users/user-one") && (init?.method === "PUT" || init?.method === "PATCH")) {
         userUpdateMethods.push(init.method);
+        let updateBody: Record<string, unknown> | undefined;
         if (typeof init.body === "string") {
-          userUpdateBodies.push(JSON.parse(init.body) as Record<string, unknown>);
+          updateBody = JSON.parse(init.body) as Record<string, unknown>;
+          userUpdateBodies.push(updateBody);
         }
         if (init.method === "PUT" && putUserUpdateReturns405) {
           return Response.json({ message: "method not allowed" }, { status: 405 });
+        }
+        if (isRecord(updateBody?.app_metadata)) {
+          userAppMetadata = updateBody.app_metadata;
         }
         return Response.json({ id: "user-one" });
       }
       if (url.endsWith("/admin/users/user-one")) {
         return Response.json({
           id: "user-one",
-          app_metadata: {
-            provider: "email",
-            providers: ["email"],
-            supaoauth: {
-              profile: { role: "管理员" },
-            },
-          },
+          app_metadata: userAppMetadata,
         });
       }
       return Response.json({ message: "not found" }, { status: 404 });
@@ -257,11 +268,18 @@ describe("projectRbacRoutes", () => {
     expect(projection.provider).toBe("email");
     expect(projection.supaoauth).toMatchObject({
       profile: { role: "管理员" },
-      roles: ["admin"],
-      permissions: ["project.manage"],
-      scopes: ["scope-manage"],
+      roles: [],
+      permissions: [],
+      scopes: [],
       organization_ids: ["org-one"],
       current_org_id: "org-one",
+      organizations: {
+        "org-one": {
+          roles: ["admin"],
+          permissions: ["project.manage"],
+          scopes: ["scope-manage"],
+        },
+      },
     });
 
     const permissions = await request("/v1/projects/proj_1/auth/users/user-one/permissions?org_id=org-one");
@@ -269,6 +287,12 @@ describe("projectRbacRoutes", () => {
       roles: ["admin"],
       permissions: ["project.manage"],
       scopes: ["scope-manage"],
+    });
+
+    const userRoles = await request("/v1/projects/proj_1/auth/users/user-one/roles");
+    expect(await userRoles.json()).toMatchObject({
+      total: 1,
+      items: [{ organization_id: "org-one", role: { name: "admin" } }],
     });
 
     const orgAssignments = await request("/v1/projects/proj_1/organizations/org-one/roles");
@@ -287,6 +311,7 @@ describe("projectRbacRoutes", () => {
       permissions: [],
       scopes: [],
       organization_ids: [],
+      organizations: {},
     });
     expect("current_org_id" in revokedSupauth).toBe(false);
   });
@@ -359,6 +384,174 @@ describe("projectRbacRoutes", () => {
     expect((projection.supaoauth as Record<string, unknown>).applications).toMatchObject({
       "fa-app": { roles: ["fa_engineer"], permissions: ["fa.rework.approve"] },
       "other-app": { roles: ["other_app_admin"], permissions: ["other.manage"] },
+    });
+  });
+
+  test("keeps application metadata permissions isolated by organization", async () => {
+    const projectRole = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "project_reader" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${projectRole.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "project.read", scope_id: "scope-project" }),
+    });
+
+    const adminRole = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "fa_admin" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${adminRole.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "fa.approve", scope_id: "scope-fa-admin" }),
+    });
+
+    const viewerRole = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "fa_viewer" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${viewerRole.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "fa.view", scope_id: "scope-fa-viewer" }),
+    });
+
+    await request(`/v1/projects/proj_1/rbac/roles/${projectRole.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({ user_id: "user-one" }),
+    });
+    await request(`/v1/projects/proj_1/rbac/roles/${adminRole.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({
+        user_id: "user-one",
+        application_id: "fa-app",
+        organization_id: "org-a",
+      }),
+    });
+    await request(`/v1/projects/proj_1/rbac/roles/${viewerRole.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({
+        user_id: "user-one",
+        application_id: "fa-app",
+        organization_id: "org-b",
+      }),
+    });
+
+    const projection = userUpdateBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    const supaoauth = projection.supaoauth as Record<string, unknown>;
+    const applications = supaoauth.applications as Record<string, unknown>;
+    expect(applications["fa-app"]).toEqual({
+      roles: ["project_reader"],
+      permissions: ["project.read"],
+      scopes: ["scope-project"],
+      organization_ids: ["org-a", "org-b"],
+      organizations: {
+        "org-a": {
+          roles: ["fa_admin", "project_reader"],
+          permissions: ["fa.approve", "project.read"],
+          scopes: ["scope-fa-admin", "scope-project"],
+        },
+        "org-b": {
+          roles: ["fa_viewer", "project_reader"],
+          permissions: ["fa.view", "project.read"],
+          scopes: ["scope-fa-viewer", "scope-project"],
+        },
+      },
+    });
+
+    const appOnlyPermissions = await request(
+      "/v1/projects/proj_1/auth/users/user-one/permissions?application_id=fa-app",
+    );
+    expect(await appOnlyPermissions.json()).toEqual({
+      application_id: "fa-app",
+      roles: ["project_reader"],
+      permissions: ["project.read"],
+      scopes: ["scope-project"],
+    });
+
+    const orgAPermissions = await request(
+      "/v1/projects/proj_1/auth/users/user-one/permissions?application_id=fa-app&org_id=org-a",
+    );
+    expect(await orgAPermissions.json()).toEqual({
+      application_id: "fa-app",
+      roles: ["fa_admin", "project_reader"],
+      permissions: ["fa.approve", "project.read"],
+      scopes: ["scope-fa-admin", "scope-project"],
+    });
+    const orgBPermissions = await request(
+      "/v1/projects/proj_1/auth/users/user-one/permissions?application_id=fa-app&org_id=org-b",
+    );
+    expect(await orgBPermissions.json()).toEqual({
+      application_id: "fa-app",
+      roles: ["fa_viewer", "project_reader"],
+      permissions: ["fa.view", "project.read"],
+      scopes: ["scope-fa-viewer", "scope-project"],
+    });
+  });
+
+  test("keeps a known application namespace after revoking its last scoped assignment", async () => {
+    const projectRole = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "project_reader" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${projectRole.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "project.read", scope_id: "scope-project" }),
+    });
+
+    const appRole = await (await request("/v1/projects/proj_1/rbac/roles", {
+      method: "POST",
+      body: JSON.stringify({ name: "fa_admin" }),
+    })).json() as { id: string };
+    await request(`/v1/projects/proj_1/rbac/roles/${appRole.id}/permissions`, {
+      method: "POST",
+      body: JSON.stringify({ name: "fa.approve", scope_id: "scope-fa" }),
+    });
+
+    await request(`/v1/projects/proj_1/rbac/roles/${projectRole.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({ user_id: "user-one" }),
+    });
+    const appAssignmentResponse = await request(`/v1/projects/proj_1/rbac/roles/${appRole.id}/assign`, {
+      method: "POST",
+      body: JSON.stringify({ user_id: "user-one", application_id: "fa-app" }),
+    });
+    const appAssignment = await appAssignmentResponse.json() as { id: string };
+
+    const currentSupaoauth = isRecord(userAppMetadata.supaoauth) ? userAppMetadata.supaoauth : {};
+    userAppMetadata = {
+      ...userAppMetadata,
+      supaoauth: {
+        ...currentSupaoauth,
+        applications: {},
+      },
+    };
+
+    const revoke = await request(
+      `/v1/projects/proj_1/rbac/roles/${appRole.id}/assign/${appAssignment.id}`,
+      { method: "DELETE" },
+    );
+    expect(revoke.status).toBe(200);
+    expect((storedConfig.rbac as Record<string, unknown>).application_ids).toEqual(["fa-app"]);
+
+    const projection = userUpdateBodies.at(-1)?.app_metadata as Record<string, unknown>;
+    const supaoauth = projection.supaoauth as Record<string, unknown>;
+    const applications = supaoauth.applications as Record<string, unknown>;
+    expect(applications["fa-app"]).toEqual({
+      roles: ["project_reader"],
+      permissions: ["project.read"],
+      scopes: ["scope-project"],
+      organization_ids: [],
+      organizations: {},
+    });
+
+    const permissions = await request(
+      "/v1/projects/proj_1/auth/users/user-one/permissions?application_id=fa-app",
+    );
+    expect(await permissions.json()).toEqual({
+      application_id: "fa-app",
+      roles: ["project_reader"],
+      permissions: ["project.read"],
+      scopes: ["scope-project"],
     });
   });
 


### PR DESCRIPTION
## Summary

- resolve user role assignments and permissions in an explicit `application_id` context
- keep application-scoped grants out of legacy project-wide queries
- project per-application role/permission namespaces into GoTrue user metadata
- preserve project-wide grants inside each application while preventing cross-application leakage

## Verification

- `bun run test:unit`
- `bun run typecheck`
- added route coverage for project-wide, FA application, and unrelated application results

## Compatibility

Assignments without `application_id` remain intentional project-wide grants. Callers that need application roles must pass `application_id`; another application's grants are never included.