### PR TITLE
fix(management-api): redact sensitive Caddy request headers

### DIFF
--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -136,6 +136,29 @@ const CADDY_GENERATED_CONFIG_NOTICE_LOG =
     "supacloud_notice_do_not_edit_caddy_config_json_use_supacloud_cli_management_api_or_web_console";
 const CADDY_UNMATCHED_HOST_ROUTE_ID = "route-system-unmatched-host-404";
 
+const CADDY_SENSITIVE_REQUEST_HEADERS = [
+    "Apikey",
+    "Authorization",
+    "Cookie",
+    "Proxy-Authorization",
+    "X-Api-Key",
+    "X-Auth-Token",
+    "X-Supabase-Api-Key",
+] as const;
+
+export function caddySensitiveRequestLogEncoder(): Record<string, unknown> {
+    return {
+        format: "filter",
+        wrap: { format: "json" },
+        fields: Object.fromEntries(
+            CADDY_SENSITIVE_REQUEST_HEADERS.map((header) => [
+                `request>headers>${header}`,
+                { filter: "replace", value: "REDACTED" },
+            ]),
+        ),
+    };
+}
+
 function caddyGeneratedConfigNoticeLog(): Record<string, unknown> {
     return {
         writer: { output: "discard" },
@@ -259,6 +282,9 @@ export class CaddyGatewayProvider implements GatewayProvider {
             admin: { listen: caddyAdminListen() },
             logging: {
                 logs: {
+                    default: {
+                        encoder: caddySensitiveRequestLogEncoder(),
+                    },
                     [CADDY_GENERATED_CONFIG_NOTICE_LOG]: caddyGeneratedConfigNoticeLog(),
                 },
             },

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -6,6 +6,7 @@ import {
     DEFAULT_CORS_EXPOSED,
     DEFAULT_CORS_HEADERS,
     buildTenantCorsOrigins,
+    caddySensitiveRequestLogEncoder,
     gatewayService,
 } from "../../src/services/gateway.service";
 
@@ -122,6 +123,31 @@ describe("GatewayService provider selection", () => {
         expect(DEFAULT_CORS_EXPOSED).toContain("Content-Disposition");
     });
 
+    test("default Caddy logger redacts sensitive request headers", () => {
+        const encoder = caddySensitiveRequestLogEncoder() as {
+            format: string;
+            wrap: { format: string };
+            fields: Record<string, { filter: string; value: string }>;
+        };
+
+        expect(encoder.format).toBe("filter");
+        expect(encoder.wrap).toEqual({ format: "json" });
+        for (const header of [
+            "Apikey",
+            "Authorization",
+            "Cookie",
+            "Proxy-Authorization",
+            "X-Api-Key",
+            "X-Auth-Token",
+            "X-Supabase-Api-Key",
+        ]) {
+            expect(encoder.fields[`request>headers>${header}`]).toEqual({
+                filter: "replace",
+                value: "REDACTED",
+            });
+        }
+    });
+
     test("tenant cors origins include exact api and studio custom domains", () => {
         const origins = buildTenantCorsOrigins("dbbabyref", {
             api_domain: "sapi.dbbaby.top",
@@ -158,6 +184,13 @@ describe("CaddyGatewayProvider", () => {
         const noticeLog = load?.body?.logging?.logs?.supacloud_notice_do_not_edit_caddy_config_json_use_supacloud_cli_management_api_or_web_console;
         expect(noticeLog?.writer?.output).toBe("discard");
         expect(noticeLog?.level).toBe("INFO");
+        const defaultLogEncoder = load?.body?.logging?.logs?.default?.encoder;
+        expect(defaultLogEncoder?.format).toBe("filter");
+        expect(defaultLogEncoder?.wrap).toEqual({ format: "json" });
+        expect(defaultLogEncoder?.fields?.["request>headers>Apikey"]).toEqual({
+            filter: "replace",
+            value: "REDACTED",
+        });
         expect(load?.body?.apps?.tls?.automation?.policies?.[0]?.key_type).toBe("p256");
         const notice = await readFile("/tmp/supacloud-caddy-test/DO-NOT-EDIT.txt", "utf8");
         expect(notice).toContain("Do not edit /tmp/supacloud-caddy-test/config.json by hand.");


### PR DESCRIPTION
## Summary

- Add a generated Caddy default filter encoder that replaces sensitive request-header values with `REDACTED`.
- Cover `Apikey`, `Authorization`, `Cookie`, `Proxy-Authorization`, `X-Api-Key`, `X-Auth-Token`, and `X-Supabase-Api-Key`.
- Keep the existing generated-config notice logger unchanged and add unit coverage for the encoder and persisted Caddy JSON.

## Validation

- `bun test packages/management-api/tests/unit/gateway.service.test.ts` (43 pass)
- `bun run --cwd packages/management-api typecheck`
- Caddy candidate configuration validation passed.
- Linux amd64 management binary build passed.
- Isolated live Caddy probe produced a controlled 502: the dummy `Apikey` value was absent from both journald and syslog, while the request was logged with `REDACTED`.

## Security note

Legacy service-role key rotation is intentionally out of scope because it invalidates JWTs, static frontend keys, Edge Function secrets, and external consumers; it requires a coordinated maintenance window.