### PR TITLE
fix(gateway): preserve TUS CORS and capabilities

### DIFF
--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -262,7 +262,8 @@ const STORAGE_CORS_EXPOSE_HEADERS = [
     "x-supabase-api-version", "X-Client-Info", "Prefer",
     "Content-Profile", "accept-profile", "Range", "Range-Unit",
     "X-Relay-Error", "link", "x-total-count",
-    "Tus-Resumable", "Upload-Offset", "Upload-Length", "Location",
+    "Tus-Resumable", "Tus-Version", "Tus-Extension", "Tus-Max-Size",
+    "Upload-Offset", "Upload-Length", "Location",
 ].join(", ");
 
 export const storageCompatRoutes = new Elysia({ prefix: "" })

--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -37,6 +37,7 @@ export const DEFAULT_CORS_HEADERS = [
     "apikey", "x-client-info", "x-project-ref", "X-Api-Version", "x-supabase-api-version",
     "Prefer", "Content-Profile", "accept-profile", "Range", "Range-Unit",
     "x-upsert", "Cache-Control", "x-retry-count", "x-metadata",
+    "tus-resumable", "upload-length", "upload-offset", "upload-metadata",
     "x-supacloud-async", "x-supacloud-timeout", "x-supacloud-retries",
     "Idempotency-Key", "x-supacloud-idempotency-key", "x-supacloud-function-version",
     "x-supacloud-trace-id", "x-supacloud-correlation-id",

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -872,7 +872,9 @@ export class CaddyGatewayProvider implements GatewayProvider {
         }
 
         const handle: Record<string, unknown>[] = [];
-        const corsSubroute = opts.corsOrigins ? makeCorsSubroute(opts.corsOrigins) : null;
+        const corsSubroute = opts.corsOrigins && !opts.preserveUpstreamCors
+            ? makeCorsSubroute(opts.corsOrigins)
+            : null;
         if (corsSubroute) handle.push(corsSubroute);
         if (opts.rewriteUri) handle.push({ handler: "rewrite", uri: opts.rewriteUri });
         else if (opts.stripPrefix) handle.push({ handler: "rewrite", strip_path_prefix: opts.stripPrefix });

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -203,6 +203,7 @@ describe("CaddyGatewayProvider", () => {
         const rest = routes.find((route: any) => route["@id"] === "route-project-testref123-rest");
         const opaqueRest = routes.find((route: any) => route["@id"] === "route-project-testref123-opaque-rest");
         const storage = routes.find((route: any) => route["@id"] === "route-project-testref123-storage");
+        const storageResumable = routes.find((route: any) => route["@id"] === "route-project-testref123-storage-resumable");
         const functions = routes.find((route: any) => route["@id"] === "route-project-testref123-functions");
         const realtime = routes.find((route: any) => route["@id"] === "route-project-testref123-realtime");
         const management = routes.find((route: any) => route["@id"] === "route-project-testref123-management");
@@ -234,6 +235,8 @@ describe("CaddyGatewayProvider", () => {
         expect(routes.find((route: any) => route["@id"] === "route-project-testref123-graphql")
             ?.handle?.some((handler: any) => handler.uri === "/rpc/graphql")).toBe(true);
         expect(storage?.match?.[0]?.path).toEqual(["/storage/v1*"]);
+        expect(findCorsSubroute(storage)).toBeUndefined();
+        expect(findCorsSubroute(storageResumable)).toBeUndefined();
         const storageProxy = storage?.handle?.find((h: any) => h.handler === "reverse_proxy");
         expect(storageProxy?.flush_interval).toBeUndefined();
         const restProxy = rest?.handle?.find((h: any) => h.handler === "reverse_proxy");
@@ -1367,6 +1370,8 @@ describe("CaddyGatewayProvider route headers", () => {
         const resumableProxy = resumable?.handle?.find((h: any) => h.handler === "reverse_proxy");
         expect(storage?.handle?.some((h: any) => h.strip_path_prefix === "/storage/v1")).toBe(false);
         expect(resumable?.handle?.some((h: any) => h.strip_path_prefix === "/storage/v1")).toBe(false);
+        expect(findCorsSubroute(storage)).toBeUndefined();
+        expect(findCorsSubroute(resumable)).toBeUndefined();
         // Storage route should preserve upstream CORS without rendering an empty
         // response header block, which can break Caddy proxy responses.
         expect(storageProxy?.headers?.response).toBeUndefined();

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -106,6 +106,10 @@ describe("GatewayService provider selection", () => {
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-async");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-retries");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-timeout");
+        expect(DEFAULT_CORS_HEADERS).toContain("tus-resumable");
+        expect(DEFAULT_CORS_HEADERS).toContain("upload-length");
+        expect(DEFAULT_CORS_HEADERS).toContain("upload-offset");
+        expect(DEFAULT_CORS_HEADERS).toContain("upload-metadata");
         expect(DEFAULT_CORS_HEADERS).toContain("Idempotency-Key");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-idempotency-key");
         expect(DEFAULT_CORS_HEADERS).toContain("x-supacloud-function-version");
@@ -250,6 +254,8 @@ describe("CaddyGatewayProvider", () => {
         expect(corsHeaders?.response?.set?.["Access-Control-Allow-Origin"]).toEqual(["{http.request.header.Origin}"]);
         expect(corsHeaders?.response?.set?.["Access-Control-Allow-Credentials"]).toEqual(["true"]);
         expect(corsHeaders?.response?.set?.["Access-Control-Allow-Headers"]?.[0]).toContain("Idempotency-Key");
+        expect(corsHeaders?.response?.set?.["Access-Control-Allow-Headers"]?.[0]).toContain("tus-resumable");
+        expect(corsHeaders?.response?.set?.["Access-Control-Allow-Headers"]?.[0]).toContain("upload-metadata");
         expect(preflight?.match?.some((matcher: any) => matcher.header_regexp?.Origin?.pattern?.includes("localhost"))).toBe(true);
 
         restore();

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -76,10 +76,18 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
       headers: {
         apikey: "test-token",
         "x-project-ref": "test_mock",
+        origin: "https://app.example.com",
       },
     });
 
     expect([200, 204]).toContain(res.status);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://app.example.com");
+    expect(res.headers.get("Access-Control-Expose-Headers")).toContain("Tus-Version");
+    expect(res.headers.get("Access-Control-Expose-Headers")).toContain("Tus-Extension");
+    expect(res.headers.get("Access-Control-Expose-Headers")).toContain("Tus-Max-Size");
+    expect(res.headers.get("Tus-Resumable")).toBe("1.0.0");
+    expect(res.headers.get("Tus-Version")).toBe("1.0.0");
+    expect(res.headers.get("Tus-Extension")).toBe("creation,termination");
     expect(res.headers.get("Tus-Max-Size")).toBe(String(500 * 1024 * 1024));
   });
 


### PR DESCRIPTION
## Summary

- Allow standard TUS request headers in gateway-generated CORS preflight responses.
- Let routes marked `preserveUpstreamCors` pass preflight and explicit `OPTIONS` requests through to their upstream.
- Preserve Storage's `Tus-Version`, `Tus-Extension`, and `Tus-Max-Size` capability response headers.
- Keep client-controlled proxy headers such as `x-forwarded-host` denied.

## Why

The Storage compatibility layer already accepts TUS headers and owns complete TUS capability responses, but Caddy previously handled requests with two incomplete behaviors:

1. Browser preflight omitted `tus-resumable`, `upload-length`, `upload-offset`, and `upload-metadata` from `Access-Control-Allow-Headers`.
2. Any `OPTIONS` carrying an allowed `Origin` was terminated at Caddy with a generic 204, so Storage could not return its TUS capability headers.

This caused browsers to reject resumable uploads before Storage or lose TUS discovery metadata.

## Verification

- `bun test packages/management-api/tests/unit/gateway.service.test.ts` (48 pass)
- `git diff --check`
- Live reproduction on v0.41.1 confirmed the generic Caddy 204 differs from the upstream capability response.
