### PR TITLE
fix(auth): isolate third-party JWT verification

### DIFF
--- a/packages/edge-runtime/jwt-verifier.test.ts
+++ b/packages/edge-runtime/jwt-verifier.test.ts
@@ -40,6 +40,27 @@ describe("verifyEdgeRuntimeJwt", () => {
     }, "Bearer service-role-key")).toBe(true);
   });
 
+  test("does not let a valid anon apikey mask an invalid bearer JWT", async () => {
+    expect(await verifyEdgeRuntimeJwt({
+      anonKey: "anon-key",
+      jwtSecret: "legacy-secret-with-at-least-32-characters",
+    }, "Bearer forged-user-token", "anon-key")).toBe(false);
+  });
+
+  test("verifies a bearer JWT when supabase-js also sends the anon apikey", async () => {
+    const jwtSecret = "legacy-secret-with-at-least-32-characters";
+    const token = await new SignJWT({ role: "authenticated", sub: "user_1" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode(jwtSecret));
+
+    expect(await verifyEdgeRuntimeJwt({
+      anonKey: "anon-key",
+      jwtSecret,
+    }, `Bearer ${token}`, "anon-key")).toBe(true);
+  });
+
   test("normalizes JWKS JSON from runtime env", () => {
     expect(normalizeJwtJwks(JSON.stringify({
       keys: [{ kty: "EC", kid: "kid_1", alg: "ES256" }],

--- a/packages/edge-runtime/jwt-verifier.ts
+++ b/packages/edge-runtime/jwt-verifier.ts
@@ -5,6 +5,14 @@ export type EdgeRuntimeProjectSecrets = {
   serviceRoleKey?: string;
   jwtSecret?: string;
   jwtJwks?: { keys: JWK[] } | null;
+  thirdParty?: EdgeRuntimeThirdPartyJwtPolicy | null;
+};
+
+export type EdgeRuntimeThirdPartyJwtPolicy = {
+  issuer: string;
+  audience: string[];
+  clientId: string;
+  jwtJwks: { keys: JWK[] };
 };
 
 export function normalizeJwtJwks(value: unknown): { keys: JWK[] } | null {
@@ -29,6 +37,57 @@ export function normalizeJwtJwks(value: unknown): { keys: JWK[] } | null {
   return { keys: keys as JWK[] };
 }
 
+export function normalizeThirdPartyJwtPolicy(value: unknown): EdgeRuntimeThirdPartyJwtPolicy | null {
+  let parsed = value;
+  if (typeof value === "string" && value.trim().startsWith("{")) {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const record = parsed as Record<string, unknown>;
+  if (record.enabled !== undefined && record.enabled !== true) return null;
+  const issuer = typeof record.issuer === "string" ? record.issuer.replace(/\/+$/, "") : "";
+  const rawClientId = record.clientId ?? record.client_id;
+  const clientId = typeof rawClientId === "string" ? rawClientId : "";
+  const audience = Array.isArray(record.audience)
+    ? record.audience.filter((item): item is string => typeof item === "string" && item.length > 0)
+    : (typeof record.audience === "string" && record.audience.length > 0 ? [record.audience] : []);
+  const jwtJwks = normalizeJwtJwks(record.jwtJwks ?? record.jwt_jwks);
+  if (!issuer || !clientId || audience.length === 0 || !jwtJwks) return null;
+  return { issuer, clientId, audience, jwtJwks };
+}
+
+function decodeJwtPart(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isThirdPartyCandidate(
+  header: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  policy: EdgeRuntimeThirdPartyJwtPolicy,
+): boolean {
+  const kid = typeof header.kid === "string" ? header.kid : "";
+  const alg = typeof header.alg === "string" ? header.alg : "";
+  return policy.jwtJwks.keys.some((key) => key.kid === kid && key.alg === alg)
+    || payload.iss === policy.issuer
+    || payload.client_id === policy.clientId;
+}
+
+function isExternalKey(key: JWK, policy: EdgeRuntimeThirdPartyJwtPolicy | null): boolean {
+  return Boolean(policy?.jwtJwks.keys.some((external) =>
+    external.kid === key.kid && external.alg === key.alg));
+}
+
 export async function verifyEdgeRuntimeJwt(
   secrets: EdgeRuntimeProjectSecrets,
   authHeader: string | null | undefined,
@@ -49,18 +108,46 @@ export async function verifyEdgeRuntimeJwt(
     return true;
   }
 
+  const parts = token.split(".");
+  if (parts.length !== 3) return false;
+  const header = decodeJwtPart(parts[0]);
+  const payload = decodeJwtPart(parts[1]);
+  if (!header || !payload || typeof header.alg !== "string") return false;
+
+  if (secrets.thirdParty && isThirdPartyCandidate(header, payload, secrets.thirdParty)) {
+    try {
+      const verified = await jwtVerify(token, createLocalJWKSet(secrets.thirdParty.jwtJwks), {
+        algorithms: ["ES256", "RS256"],
+        issuer: secrets.thirdParty.issuer,
+        audience: secrets.thirdParty.audience,
+      });
+      return verified.payload.client_id === secrets.thirdParty.clientId
+        && verified.payload.role === "authenticated";
+    } catch {
+      return false;
+    }
+  }
+
   if (secrets.jwtJwks) {
     try {
-      await jwtVerify(token, createLocalJWKSet(secrets.jwtJwks));
-      return true;
+      const localKeys = secrets.jwtJwks.keys.filter((key) => !isExternalKey(key, secrets.thirdParty ?? null));
+      if (localKeys.length > 0) {
+        await jwtVerify(token, createLocalJWKSet({ keys: localKeys }), {
+          algorithms: ["ES256", "RS256"],
+        });
+        return true;
+      }
     } catch {
       // Fall through to legacy HS256 verification for old tokens without kid.
     }
   }
 
   if (!secrets.jwtSecret) return false;
+  if (header.alg !== "HS256" || (header.kid !== undefined && header.kid !== "legacy-hs256")) return false;
   try {
-    await jwtVerify(token, new TextEncoder().encode(secrets.jwtSecret));
+    await jwtVerify(token, new TextEncoder().encode(secrets.jwtSecret), {
+      algorithms: ["HS256"],
+    });
     return true;
   } catch {
     return false;

--- a/packages/edge-runtime/jwt-verifier.ts
+++ b/packages/edge-runtime/jwt-verifier.ts
@@ -96,11 +96,12 @@ export async function verifyEdgeRuntimeJwt(
   const anonKey = secrets.anonKey || "";
   const serviceRoleKey = secrets.serviceRoleKey || "";
 
-  if (apikeyHeader && (apikeyHeader === anonKey || apikeyHeader === serviceRoleKey)) {
-    return true;
+  if (!authHeader) {
+    return Boolean(
+      apikeyHeader &&
+      (apikeyHeader === anonKey || apikeyHeader === serviceRoleKey),
+    );
   }
-
-  if (!authHeader) return false;
   const token = authHeader.replace(/^Bearer\s+/i, "");
   if (!token) return false;
 

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -7,7 +7,11 @@ import {
   loadTenantEnv,
   withBackgroundInternalToken,
 } from "./tenant-env";
-import { normalizeJwtJwks, verifyEdgeRuntimeJwt } from "./jwt-verifier";
+import {
+  normalizeJwtJwks,
+  normalizeThirdPartyJwtPolicy,
+  verifyEdgeRuntimeJwt,
+} from "./jwt-verifier";
 import {
   buildBackgroundForwardDispatch,
 } from "./background-forward";
@@ -493,6 +497,7 @@ interface ProjectSecrets {
   serviceRoleKey: string;
   jwtSecret: string;
   jwtJwks: ReturnType<typeof normalizeJwtJwks>;
+  thirdParty: ReturnType<typeof normalizeThirdPartyJwtPolicy>;
   expiresAt: number;
 }
 const secretsCache = new Map<string, ProjectSecrets>();
@@ -517,6 +522,7 @@ async function getProjectSecrets(
         serviceRoleKey: runtimeEnv.SUPABASE_SERVICE_ROLE_KEY || "",
         jwtSecret: runtimeEnv.JWT_SECRET || "",
         jwtJwks: normalizeJwtJwks(runtimeEnv.JWT_JWKS),
+        thirdParty: normalizeThirdPartyJwtPolicy(runtimeEnv.SUPACLOUD_THIRD_PARTY_JWT_POLICY),
         expiresAt: Date.now() + SECRETS_CACHE_TTL,
       };
       secretsCache.set(projectRef, secrets);
@@ -548,7 +554,10 @@ async function getProjectSecrets(
     }[];
     const detail = (await detailRes.json()) as {
       jwt_secret?: string;
-      config?: { auth?: { oauth_server?: { jwt_jwks?: unknown } } };
+      config?: { auth?: {
+        oauth_server?: { jwt_jwks?: unknown };
+        third_party_auth?: unknown;
+      } };
     };
 
     const secrets: ProjectSecrets = {
@@ -557,6 +566,7 @@ async function getProjectSecrets(
         keysArray?.find?.((k) => k.name === "service_role")?.api_key || "",
       jwtSecret: detail.jwt_secret || "",
       jwtJwks: normalizeJwtJwks(detail.config?.auth?.oauth_server?.jwt_jwks),
+      thirdParty: normalizeThirdPartyJwtPolicy(detail.config?.auth?.third_party_auth),
       expiresAt: Date.now() + SECRETS_CACHE_TTL,
     };
     secretsCache.set(projectRef, secrets);

--- a/packages/management-api/src/services/runtime-env.service.ts
+++ b/packages/management-api/src/services/runtime-env.service.ts
@@ -11,8 +11,8 @@ import {
 import { decryptSecretIfNeeded } from "../utils/secret-crypto";
 import { logger } from "../utils/logger";
 import {
-  normalizeProjectJwtJwks,
   normalizeProjectJwtKeys,
+  resolveProjectJwtVerificationMaterial,
 } from "../utils/project-jwt";
 
 function isJwtLike(value: string | null | undefined): value is string {
@@ -46,7 +46,8 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
   const authConfig = (projectConfig.auth || {}) as Record<string, unknown>;
   const oauthServerConfig = (authConfig.oauth_server || {}) as Record<string, unknown>;
   const jwtKeys = normalizeProjectJwtKeys(oauthServerConfig.jwt_keys);
-  const jwtJwks = normalizeProjectJwtJwks(oauthServerConfig.jwt_jwks);
+  const jwtMaterial = resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret);
+  const jwtJwks = jwtMaterial.jwtJwks;
   const supabaseUrl = resolveProjectApiUrl(projectRef, routingConfig);
   const projectApiHost = resolveProjectApiHost(projectRef, routingConfig);
   const tenantPorts = resolveTenantPorts(routingConfig);
@@ -102,6 +103,9 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
     JWT_SECRET: project.jwt_secret,
     ...(jwtKeys ? { JWT_KEYS: JSON.stringify(jwtKeys) } : {}),
     ...(jwtJwks ? { JWT_JWKS: JSON.stringify(jwtJwks) } : {}),
+    ...(jwtMaterial.thirdParty ? {
+      SUPACLOUD_THIRD_PARTY_JWT_POLICY: JSON.stringify(jwtMaterial.thirdParty),
+    } : {}),
     SUPACLOUD_INTERNAL_SUPABASE_URL: internalSupabaseUrl,
     SUPACLOUD_INTERNAL_AUTH_URL: internalAuthUrl,
     SUPACLOUD_INTERNAL_REST_URL: internalRestUrl,

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -9,7 +9,11 @@ import { OAUTH_ENV_MAPPINGS } from "../types/oauth";
 import { tenantOAuthService } from "./tenant-oauth.service";
 import { resolveProjectApiUrl, resolveProjectAuthUrl, resolveProjectStudioUrl } from "../utils/project-routing";
 import { normalizeOAuthServerConfig, normalizeProjectConfig } from "../utils/project-config";
-import { normalizeProjectJwtJwks, normalizeProjectJwtKeys } from "../utils/project-jwt";
+import {
+    normalizeProjectJwtKeys,
+    resolveProjectJwtVerificationMaterial,
+    type ThirdPartyJwtPolicy,
+} from "../utils/project-jwt";
 import { uniqueStrings } from "../utils/strings";
 import { ALTER_TENANT_SQL } from "./tenant-runtime-migration";
 import {
@@ -46,6 +50,11 @@ export interface RuntimeStatus {
 }
 
 export type RuntimeDesiredState = "running" | "stopped";
+
+function quoteSqlLiteral(value: string): string {
+    assertSafeConfigValue("PostgreSQL literal", value);
+    return `'${value.replace(/'/g, "''")}'`;
+}
 
 export interface PostgrestRuntimeStatus {
     component: "postgrest";
@@ -474,12 +483,18 @@ class TenantRuntimeService {
         const authConfig = (projectConfig.auth as Record<string, unknown>) || {};
         const oauthServerConfig = normalizeOAuthServerConfig(authConfig.oauth_server);
         const jwtKeys = stringifyJsonConfig(normalizeProjectJwtKeys(oauthServerConfig.jwt_keys));
-        const jwtJwks = stringifyJsonConfig(normalizeProjectJwtJwks(oauthServerConfig.jwt_jwks));
+        const jwtMaterial = resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret);
+        const jwtJwks = stringifyJsonConfig(jwtMaterial.jwtJwks);
+        const localJwtIssuer = typeof oauthServerConfig.issuer === "string" && oauthServerConfig.issuer.trim()
+            ? oauthServerConfig.issuer.trim().replace(/\/+$/, "")
+            : null;
         return {
             dbPassword: project.db_password,
             jwtSecret: project.jwt_secret,
             jwtKeys,
             jwtJwks,
+            thirdPartyJwtPolicy: jwtMaterial.thirdParty,
+            localJwtIssuer,
             dbName: await resolveDbName(ref),
             apiUrl: this.deriveApiUrl(ref, projectConfig),
             authUrl: this.deriveAuthUrl(ref, projectConfig),
@@ -684,6 +699,8 @@ class TenantRuntimeService {
             jwtSecret: creds.jwtSecret,
             jwtKeys: creds.jwtKeys || "",
             jwtJwks: creds.jwtJwks || "",
+            thirdPartyJwtPolicy: creds.thirdPartyJwtPolicy ? JSON.stringify(creds.thirdPartyJwtPolicy) : "",
+            localJwtIssuer: creds.localJwtIssuer || "",
             dbName: creds.dbName,
             apiUrl: creds.apiUrl,
             authUrl: creds.authUrl,
@@ -724,6 +741,13 @@ class TenantRuntimeService {
         const jwtVerifierSecret = creds.jwtJwks || creds.jwtSecret;
         const jwtJwksEnv = creds.jwtJwks ? renderSystemdEnvLine("JWT_JWKS", creds.jwtJwks) : "";
         const jwtKeysEnv = creds.jwtKeys ? renderSystemdEnvLine("JWT_KEYS", creds.jwtKeys) : "";
+        const thirdPartyJwtPolicyEnv = creds.thirdPartyJwtPolicy
+            ? renderSystemdEnvLine("SUPACLOUD_THIRD_PARTY_JWT_POLICY", JSON.stringify(creds.thirdPartyJwtPolicy))
+            : "";
+        const postgrestJwtAudience = creds.thirdPartyJwtPolicy?.audience[0] || "";
+        const postgrestJwtAudienceConfig = postgrestJwtAudience
+            ? `jwt-aud = ${quoteTomlBasicString(postgrestJwtAudience)}`
+            : "";
 
         // Generate PostgREST .env configuration
         // Edge runtime and other services consume these env vars
@@ -745,6 +769,7 @@ class TenantRuntimeService {
             renderTenantInternalRuntimeEnv(pgrstPort, gotruePort),
             jwtJwksEnv,
             jwtKeysEnv,
+            thirdPartyJwtPolicyEnv,
         ].filter(Boolean).join("\n");
         await this.writeTenantSecretFile(
             path.join(this.TENANT_CONFIG_DIR, `${ref}.env`),
@@ -760,6 +785,7 @@ db-schemas = ${quoteTomlBasicString(dbSchemas)}
 db-extra-search-path = "public, extensions, auth"
 db-anon-role = "anon"
 jwt-secret = ${quoteTomlBasicString(jwtVerifierSecret)}
+${postgrestJwtAudienceConfig}
 server-port = ${pgrstPort}
 server-host = "0.0.0.0"
 db-pool = ${this.POSTGREST_DB_POOL}
@@ -1500,17 +1526,54 @@ GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgmq_public TO anon, authenticated, ser
         }
     }
 
-    private async ensurePostgrestPrerequest(ref: string): Promise<void> {
+    private async ensurePostgrestPrerequest(
+        ref: string,
+        thirdPartyPolicy: ThirdPartyJwtPolicy | null,
+        localJwtIssuer: string | null,
+    ): Promise<void> {
         // Error contract: `-v ON_ERROR_STOP=1` is passed as a structured arg and
         // runTenantPsqlOrThrow performs `throw new Error(`psql exited with code ...`)`.
         const dbName = await resolveDbName(ref);
         const connection = this.adminPsqlConnection(dbName);
 
+        const thirdPartyGate = thirdPartyPolicy
+            ? `
+  issuer_claim := claims ->> 'iss';
+  client_id_claim := claims ->> 'client_id';
+  audience_matches := CASE
+    WHEN jsonb_typeof(claims -> 'aud') = 'string'
+      THEN claims ->> 'aud' = ${quoteSqlLiteral(thirdPartyPolicy.audience[0])}
+    WHEN jsonb_typeof(claims -> 'aud') = 'array'
+      THEN (claims -> 'aud') ? ${quoteSqlLiteral(thirdPartyPolicy.audience[0])}
+    ELSE false
+  END;
+
+  IF issuer_claim = ${quoteSqlLiteral(thirdPartyPolicy.issuer)}
+     OR (
+       client_id_claim IS NOT NULL
+       AND ${localJwtIssuer
+           ? `issuer_claim IS DISTINCT FROM ${quoteSqlLiteral(localJwtIssuer)}`
+           : "true"}
+     ) THEN
+    IF issuer_claim IS DISTINCT FROM ${quoteSqlLiteral(thirdPartyPolicy.issuer)}
+       OR client_id_claim IS DISTINCT FROM ${quoteSqlLiteral(thirdPartyPolicy.clientId)}
+       OR role_claim IS DISTINCT FROM 'authenticated'
+       OR NOT audience_matches THEN
+      RAISE EXCEPTION USING
+        ERRCODE = '28000',
+        MESSAGE = 'third-party JWT claims rejected';
+    END IF;
+  END IF;
+`.trimEnd()
+            : "";
         const fnSql = `
 CREATE OR REPLACE FUNCTION public.set_request_context() RETURNS void AS $$
 DECLARE
   claims jsonb;
   role_claim text;
+  issuer_claim text;
+  client_id_claim text;
+  audience_matches boolean := false;
 BEGIN
   BEGIN
     claims := COALESCE(
@@ -1521,18 +1584,20 @@ BEGIN
     claims := '{}'::jsonb;
   END;
 
-  PERFORM set_config('request.jwt.claims', claims::text, true);
-  PERFORM set_config('request.jwt.claim.sub', coalesce(claims ->> 'sub', ''), true);
-  PERFORM set_config('request.jwt.claim.email', coalesce(claims ->> 'email', ''), true);
-
   role_claim := COALESCE(
     nullif(current_setting('request.jwt.claim.role', true), ''),
     claims ->> 'role',
     'anon'
   );
+
+${thirdPartyGate}
+
+  PERFORM set_config('request.jwt.claims', claims::text, true);
+  PERFORM set_config('request.jwt.claim.sub', coalesce(claims ->> 'sub', ''), true);
+  PERFORM set_config('request.jwt.claim.email', coalesce(claims ->> 'email', ''), true);
   PERFORM set_config('request.jwt.claim.role', role_claim, true);
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
 `.trim();
         const temporary = await this.writeTemporaryTenantSql(ref, "pgrst-prerequest", fnSql);
         try {
@@ -1553,7 +1618,12 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
         await this.ensureAuthSchema(ref);
         await this.ensureOneTimeTokensAndGraphQL(ref);
         await this.ensureTenantSchemaMigrations(ref);
-        await this.ensurePostgrestPrerequest(ref);
+        const jwtPolicy = await this.getTenantCredentials(ref);
+        await this.ensurePostgrestPrerequest(
+            ref,
+            jwtPolicy.thirdPartyJwtPolicy,
+            jwtPolicy.localJwtIssuer,
+        );
 
         const pgrstPort = await this.getTenantPort(ref, "pgrst");
         const gotruePort = await this.getTenantPort(ref, "gotrue");
@@ -1740,7 +1810,12 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
         await this.ensurePostgrestBinary();
         await this.installSystemdTemplate();
         await this.ensureTenantSchemaMigrations(ref);
-        await this.ensurePostgrestPrerequest(ref);
+        const jwtPolicy = await this.getTenantCredentials(ref);
+        await this.ensurePostgrestPrerequest(
+            ref,
+            jwtPolicy.thirdPartyJwtPolicy,
+            jwtPolicy.localJwtIssuer,
+        );
 
         const pgrstPort = await this.getTenantPort(ref, "pgrst");
         const gotruePort = await this.getTenantPort(ref, "gotrue");

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -11,7 +11,7 @@ import {
   type JWTPayload,
 } from "jose";
 import { sql as metaSql } from "../db";
-import { normalizeProjectConfig } from "./project-config";
+import { normalizeProjectConfig, normalizeThirdPartyAuthConfig } from "./project-config";
 
 export type OidcJwtKeyMaterial = {
   key_id: string;
@@ -30,11 +30,24 @@ export type ProjectJwtVerification = {
   isServiceRole: boolean;
 };
 
+export type ThirdPartyJwtPolicy = {
+  issuer: string;
+  audience: string[];
+  clientId: string;
+  jwtJwks: { keys: JWK[] };
+};
+
+export type ProjectJwtVerificationMaterial = {
+  jwtJwks: { keys: JWK[] } | null;
+  localJwks: { keys: JWK[] } | null;
+  thirdParty: ThirdPartyJwtPolicy | null;
+};
+
 function base64UrlEncode(input: string): string {
   return Buffer.from(input, "utf8").toString("base64url");
 }
 
-function buildLegacyHs256Jwk(jwtSecret: string): JWK {
+export function buildLegacyHs256Jwk(jwtSecret: string): JWK {
   return {
     kty: "oct",
     k: base64UrlEncode(jwtSecret),
@@ -128,6 +141,172 @@ export function normalizeProjectJwtJwks(value: unknown): { keys: JWK[] } | null 
   return { keys: keys as JWK[] };
 }
 
+function jwkIdentity(key: JWK): string {
+  const kid = typeof key.kid === "string" ? key.kid : "";
+  const kty = typeof key.kty === "string" ? key.kty : "";
+  const alg = typeof key.alg === "string" ? key.alg : "";
+  return `${kid}|${kty}|${alg}`;
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableJson(entry)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+    return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function assertThirdPartyPublicJwk(key: JWK, index: number): JWK {
+  const prefix = `third_party_auth.jwt_jwks.keys[${index}]`;
+  const kid = typeof key.kid === "string" ? key.kid.trim() : "";
+  if (!kid) throw new Error(`${prefix}.kid is required`);
+  if (kid === "legacy-hs256") throw new Error(`${prefix}.kid is reserved`);
+
+  const record = key as Record<string, unknown>;
+  for (const privateField of ["k", "d", "p", "q", "dp", "dq", "qi", "oth"]) {
+    if (record[privateField] !== undefined) {
+      throw new Error(`${prefix} must not contain private key material`);
+    }
+  }
+  if (key.use !== undefined && key.use !== "sig") {
+    throw new Error(`${prefix}.use must be sig`);
+  }
+  if (Array.isArray(key.key_ops) && (key.key_ops.includes("sign") || !key.key_ops.includes("verify"))) {
+    throw new Error(`${prefix}.key_ops must only permit verification`);
+  }
+
+  if (key.kty === "EC" && key.alg === "ES256") {
+    if (key.crv !== "P-256" || typeof key.x !== "string" || !key.x || typeof key.y !== "string" || !key.y) {
+      throw new Error(`${prefix} must be a complete P-256 public key`);
+    }
+    return { ...key, kid };
+  }
+  if (key.kty === "RSA" && key.alg === "RS256") {
+    if (typeof key.n !== "string" || !key.n || typeof key.e !== "string" || !key.e) {
+      throw new Error(`${prefix} must be a complete RSA public key`);
+    }
+    return { ...key, kid };
+  }
+  throw new Error(`${prefix} must use EC/ES256 or RSA/RS256`);
+}
+
+export function resolveThirdPartyJwtPolicy(config: unknown): ThirdPartyJwtPolicy | null {
+  const projectConfig = normalizeProjectConfig(config);
+  const auth = (projectConfig.auth || {}) as Record<string, unknown>;
+  const thirdParty = normalizeThirdPartyAuthConfig(auth.third_party_auth);
+  if (!thirdParty.enabled) return null;
+
+  if (!thirdParty.issuer) throw new Error("third_party_auth.issuer is required");
+  let issuerUrl: URL;
+  try {
+    issuerUrl = new URL(thirdParty.issuer);
+  } catch {
+    throw new Error("third_party_auth.issuer must be a valid HTTPS URL");
+  }
+  if (
+    issuerUrl.protocol !== "https:"
+    || issuerUrl.username
+    || issuerUrl.password
+    || issuerUrl.search
+    || issuerUrl.hash
+  ) {
+    throw new Error("third_party_auth.issuer must be a valid HTTPS URL");
+  }
+  const issuer = thirdParty.issuer.replace(/\/+$/, "");
+
+  const audience = Array.isArray(thirdParty.audience)
+    ? thirdParty.audience
+    : (thirdParty.audience ? [thirdParty.audience] : []);
+  if (audience.length !== 1 || !audience[0]) {
+    throw new Error("third_party_auth.audience must contain exactly one audience");
+  }
+  if (!thirdParty.client_id) throw new Error("third_party_auth.client_id is required");
+
+  const rawJwks = normalizeProjectJwtJwks(thirdParty.jwt_jwks);
+  if (!rawJwks) throw new Error("third_party_auth.jwt_jwks is required");
+  const keys = rawJwks.keys.map(assertThirdPartyPublicJwk);
+  const seen = new Map<string, string>();
+  for (const key of keys) {
+    const identity = jwkIdentity(key);
+    const material = stableJson(key);
+    const existing = seen.get(identity);
+    if (existing && existing !== material) {
+      throw new Error(`third_party_auth.jwt_jwks contains conflicting key ${String(key.kid)}`);
+    }
+    if (existing) throw new Error(`third_party_auth.jwt_jwks contains duplicate key ${String(key.kid)}`);
+    seen.set(identity, material);
+  }
+
+  return {
+    issuer,
+    audience: [...audience],
+    clientId: thirdParty.client_id,
+    jwtJwks: { keys },
+  };
+}
+
+function mergeVerificationJwks(groups: JWK[][]): { keys: JWK[] } | null {
+  const keys: JWK[] = [];
+  const seen = new Map<string, string>();
+  for (const key of groups.flat()) {
+    const identity = jwkIdentity(key);
+    const material = stableJson(key);
+    const existing = seen.get(identity);
+    if (existing && existing !== material) {
+      throw new Error(`JWT verification key conflict for ${identity}`);
+    }
+    if (existing) continue;
+    seen.set(identity, material);
+    keys.push(key);
+  }
+  return keys.length > 0 ? { keys } : null;
+}
+
+export function resolveProjectJwtVerificationMaterial(
+  config: unknown,
+  jwtSecret: string,
+): ProjectJwtVerificationMaterial {
+  const projectConfig = normalizeProjectConfig(config);
+  const auth = (projectConfig.auth || {}) as Record<string, unknown>;
+  const oauthServer = (auth.oauth_server || {}) as Record<string, unknown>;
+  const localJwks = normalizeProjectJwtJwks(oauthServer.jwt_jwks);
+  const thirdParty = resolveThirdPartyJwtPolicy(projectConfig);
+
+  if (!localJwks && !thirdParty) {
+    return { jwtJwks: null, localJwks: null, thirdParty: null };
+  }
+
+  return {
+    jwtJwks: mergeVerificationJwks([
+      localJwks?.keys || [],
+      thirdParty?.jwtJwks.keys || [],
+      [buildLegacyHs256Jwk(jwtSecret)],
+    ]),
+    localJwks,
+    thirdParty,
+  };
+}
+
+/**
+ * Resolve every public key accepted by a project's runtime JWT consumers.
+ *
+ * A project configured with third_party_auth receives user tokens from an
+ * external GoTrue/OIDC issuer, while legacy anon/service-role keys remain
+ * signed with the project's HS256 secret. PostgREST, Storage and the Bun
+ * runtime must therefore verify against the union of both key sets.
+ */
+export function resolveProjectVerificationJwks(
+  config: unknown,
+  jwtSecret: string,
+): { keys: JWK[] } | null {
+  return resolveProjectJwtVerificationMaterial(config, jwtSecret).jwtJwks;
+}
+
 export function normalizeProjectJwtKeys(value: unknown): JWK[] | null {
   const parsed = typeof value === "string" && value.trim().startsWith("[")
     ? JSON.parse(value)
@@ -181,12 +360,75 @@ export async function signOidcServiceRoleJwt(
   }
 }
 
-function extractJwtJwksFromConfig(config: unknown): { keys: JWK[] } | null {
-  const projectConfig = normalizeProjectConfig(config);
-  const auth = (projectConfig.auth || {}) as Record<string, unknown>;
-  const oauthServer = (auth.oauth_server || {}) as Record<string, unknown>;
+function decodeJwtPart(value: string): Record<string, unknown> | null {
   try {
-    return normalizeProjectJwtJwks(oauthServer.jwt_jwks);
+    const parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isThirdPartyTokenCandidate(
+  header: Record<string, unknown>,
+  payload: Record<string, unknown>,
+  policy: ThirdPartyJwtPolicy,
+): boolean {
+  const kid = typeof header.kid === "string" ? header.kid : "";
+  const alg = typeof header.alg === "string" ? header.alg : "";
+  if (policy.jwtJwks.keys.some((key) => key.kid === kid && key.alg === alg)) return true;
+  if (payload.iss === policy.issuer) return true;
+  return payload.client_id === policy.clientId;
+}
+
+async function verifyThirdPartyJwt(
+  token: string,
+  policy: ThirdPartyJwtPolicy,
+): Promise<{ payload: JWTPayload; protectedHeader: JWTHeaderParameters } | null> {
+  try {
+    const result = await jwtVerify(token, createLocalJWKSet(policy.jwtJwks), {
+      algorithms: ["ES256", "RS256"],
+      issuer: policy.issuer,
+      audience: policy.audience,
+    });
+    if (result.payload.client_id !== policy.clientId) return null;
+    if (result.payload.role !== "authenticated") return null;
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+async function verifyLocalAsymmetricJwt(
+  token: string,
+  localJwks: { keys: JWK[] } | null,
+): Promise<{ payload: JWTPayload; protectedHeader: JWTHeaderParameters } | null> {
+  const publicKeys = (localJwks?.keys || []).filter(
+    (key) => (key.kty === "EC" && key.alg === "ES256") || (key.kty === "RSA" && key.alg === "RS256"),
+  );
+  if (publicKeys.length === 0) return null;
+  try {
+    return await jwtVerify(token, createLocalJWKSet({ keys: publicKeys }), {
+      algorithms: ["ES256", "RS256"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function verifyLegacyHs256Jwt(
+  token: string,
+  jwtSecret: string,
+  header: Record<string, unknown>,
+): Promise<{ payload: JWTPayload; protectedHeader: JWTHeaderParameters } | null> {
+  if (header.alg !== "HS256") return null;
+  if (header.kid !== undefined && header.kid !== "legacy-hs256") return null;
+  try {
+    return await jwtVerify(token, new TextEncoder().encode(jwtSecret), {
+      algorithms: ["HS256"],
+    });
   } catch {
     return null;
   }
@@ -217,29 +459,33 @@ export async function verifyProjectJwtPayload(
     `;
 
   if (!project?.jwt_secret) return null;
-  const jwtJwks = extractJwtJwksFromConfig(project.config);
+  const parts = cleanToken.split(".");
+  if (parts.length !== 3) return null;
+  const header = decodeJwtPart(parts[0]);
+  const payload = decodeJwtPart(parts[1]);
+  if (!header || !payload || typeof header.alg !== "string") return null;
 
-  if (jwtJwks) {
-    try {
-      const result = await jwtVerify(cleanToken, createLocalJWKSet(jwtJwks));
-      return {
-        payload: result.payload,
-        protectedHeader: result.protectedHeader,
-        isServiceRole: cleanToken === project.service_role_key,
-      };
-    } catch {
-      // Fall back to direct HS256 verification for legacy tokens without a kid.
-    }
-  }
-
+  let material: ProjectJwtVerificationMaterial;
   try {
-    const result = await jwtVerify(cleanToken, new TextEncoder().encode(String(project.jwt_secret)));
-    return {
-      payload: result.payload,
-      protectedHeader: result.protectedHeader,
-      isServiceRole: cleanToken === project.service_role_key,
-    };
+    material = resolveProjectJwtVerificationMaterial(project.config, String(project.jwt_secret));
   } catch {
     return null;
   }
+
+  let result: { payload: JWTPayload; protectedHeader: JWTHeaderParameters } | null = null;
+  if (material.thirdParty && isThirdPartyTokenCandidate(header, payload, material.thirdParty)) {
+    result = await verifyThirdPartyJwt(cleanToken, material.thirdParty);
+  } else {
+    result = await verifyLocalAsymmetricJwt(cleanToken, material.localJwks);
+    if (!result) {
+      result = await verifyLegacyHs256Jwt(cleanToken, String(project.jwt_secret), header);
+    }
+  }
+  if (!result) return null;
+
+  return {
+    payload: result.payload,
+    protectedHeader: result.protectedHeader,
+    isServiceRole: cleanToken === project.service_role_key,
+  };
 }

--- a/packages/management-api/tests/unit/project-jwt.test.ts
+++ b/packages/management-api/tests/unit/project-jwt.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { resolveProjectVerificationJwks, resolveThirdPartyJwtPolicy } from "../../src/utils/project-jwt";
+
+const thirdPartyConfig = {
+  enabled: true,
+  issuer: "https://auth.example.com/auth/v1",
+  audience: "authenticated",
+  client_id: "business-client",
+};
+
+describe("project JWT verification key resolution", () => {
+  test("keeps legacy HS256 verification when third-party auth is enabled", () => {
+    const jwks = resolveProjectVerificationJwks({
+      auth: {
+        third_party_auth: {
+          ...thirdPartyConfig,
+          jwt_jwks: {
+            keys: [{ kty: "EC", kid: "central-kid", alg: "ES256", crv: "P-256", x: "x", y: "y" }],
+          },
+        },
+      },
+    }, "legacy-secret");
+
+    expect(jwks?.keys.map((key) => key.kid)).toEqual(["central-kid", "legacy-hs256"]);
+    expect(jwks?.keys.find((key) => key.kid === "legacy-hs256")?.kty).toBe("oct");
+  });
+
+  test("does not add external keys when third-party auth is disabled", () => {
+    expect(resolveProjectVerificationJwks({
+      auth: {
+        third_party_auth: {
+          enabled: false,
+          jwt_jwks: { keys: [{ kty: "EC", kid: "should-not-be-used", alg: "ES256" }] },
+        },
+      },
+    }, "legacy-secret")).toBeNull();
+  });
+
+  test("merges local OAuth keys, external keys, and the legacy key", () => {
+    const jwks = resolveProjectVerificationJwks({
+      auth: {
+        oauth_server: {
+          jwt_jwks: { keys: [{ kty: "EC", kid: "local-kid", alg: "ES256" }] },
+        },
+        third_party_auth: {
+          ...thirdPartyConfig,
+          jwt_jwks: { keys: [{ kty: "EC", kid: "central-kid", alg: "ES256", crv: "P-256", x: "x", y: "y" }] },
+        },
+      },
+    }, "legacy-secret");
+
+    expect(jwks?.keys.map((key) => key.kid)).toEqual(["local-kid", "central-kid", "legacy-hs256"]);
+  });
+
+  test("rejects unscoped or symmetric third-party trust material", () => {
+    expect(() => resolveThirdPartyJwtPolicy({
+      auth: { third_party_auth: { enabled: true, jwt_jwks: { keys: [] } } },
+    })).toThrow("issuer is required");
+
+    expect(() => resolveThirdPartyJwtPolicy({
+      auth: {
+        third_party_auth: {
+          ...thirdPartyConfig,
+          jwt_jwks: { keys: [{ kty: "oct", kid: "legacy-hs256", alg: "HS256", k: "secret" }] },
+        },
+      },
+    })).toThrow("reserved");
+  });
+
+  test("rejects a conflicting external key that reuses a local key id", () => {
+    expect(() => resolveProjectVerificationJwks({
+      auth: {
+        oauth_server: {
+          jwt_jwks: { keys: [{ kty: "EC", kid: "shared-kid", alg: "ES256", crv: "P-256", x: "local", y: "local" }] },
+        },
+        third_party_auth: {
+          ...thirdPartyConfig,
+          jwt_jwks: { keys: [{ kty: "EC", kid: "shared-kid", alg: "ES256", crv: "P-256", x: "external", y: "external" }] },
+        },
+      },
+    }, "legacy-secret")).toThrow("JWT verification key conflict");
+  });
+});

--- a/packages/management-api/tests/unit/runtime-env.service.test.ts
+++ b/packages/management-api/tests/unit/runtime-env.service.test.ts
@@ -98,4 +98,57 @@ describe("runtimeEnvService", () => {
       secretsSpy.mockRestore();
     }
   });
+
+  test("merges enabled third-party issuer JWKS with the legacy project verifier key", async () => {
+    const findByRefSpy = spyOn(projectRepository, "findByRef").mockResolvedValue({
+      id: "proj_id",
+      ref: "proj_1",
+      name: "Project 1",
+      db_name: "supa_proj_1",
+      db_user: "role_proj_1",
+      db_password: "pw",
+      jwt_secret: "legacy-secret",
+      anon_key: "anon.header.signature",
+      service_role_key: "service.header.signature",
+      s3_bucket: "bucket",
+      s3_access_key: null,
+      s3_secret_key: null,
+      region: "local",
+      status: "active",
+      organization_id: "org_1",
+      config: {
+        auth: {
+          third_party_auth: {
+            enabled: true,
+            issuer: "https://auth.example.com/auth/v1",
+            audience: "authenticated",
+            client_id: "business-client",
+            jwt_jwks: { keys: [{ kty: "EC", kid: "central-kid", alg: "ES256", crv: "P-256", x: "x", y: "y" }] },
+          },
+        },
+        api_url: "https://api.example.com",
+      },
+      created_at: new Date(),
+      updated_at: new Date(),
+      deleted_at: null,
+    } as never);
+    const secretsSpy = spyOn(databaseService, "getSecrets").mockResolvedValue([]);
+
+    try {
+      const env = await runtimeEnvService.buildProjectRuntimeEnv("proj_1");
+      const jwks = JSON.parse(String(env?.JWT_JWKS));
+      expect(jwks.keys.map((key: { kid?: string }) => key.kid)).toEqual([
+        "central-kid",
+        "legacy-hs256",
+      ]);
+      expect(JSON.parse(String(env?.SUPACLOUD_THIRD_PARTY_JWT_POLICY))).toMatchObject({
+        issuer: "https://auth.example.com/auth/v1",
+        audience: ["authenticated"],
+        clientId: "business-client",
+      });
+    } finally {
+      findByRefSpy.mockRestore();
+      secretsSpy.mockRestore();
+    }
+  });
 });

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -31,7 +31,13 @@ describe("supabase bootstrap schema", () => {
       const start = schema.indexOf(
         "CREATE OR REPLACE FUNCTION public.set_request_context()",
       );
-      const end = schema.indexOf("$$ LANGUAGE plpgsql SECURITY DEFINER;", start);
+      const end = [
+        "$$ LANGUAGE plpgsql SECURITY DEFINER;",
+        "$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;",
+      ]
+        .map((marker) => schema.indexOf(marker, start))
+        .filter((index) => index >= 0)
+        .sort((a, b) => a - b)[0] ?? -1;
 
       expect(start).toBeGreaterThanOrEqual(0);
       expect(end).toBeGreaterThan(start);
@@ -224,7 +230,9 @@ describe("supabase bootstrap schema", () => {
     expect(prerequestBody).toContain("-v ON_ERROR_STOP=1");
     expect(prerequestBody).toContain("throw new Error(`psql exited with code");
     expect(prepareBody).toContain("await this.ensureTenantSchemaMigrations(ref);");
-    expect(prepareBody).toContain("await this.ensurePostgrestPrerequest(ref);");
+    expect(prepareBody).toContain("await this.ensurePostgrestPrerequest(");
+    expect(prepareBody).toContain("jwtPolicy.thirdPartyJwtPolicy");
+    expect(prepareBody).toContain("jwtPolicy.localJwtIssuer");
   });
 
   test("project service status accepts the deployed Realtime container fallback", () => {

--- a/packages/management-api/tests/unit/tenant-runtime.security.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.security.test.ts
@@ -29,4 +29,11 @@ describe("TenantRuntimeService secret handling", () => {
     expect(source).toContain("ensure_postgrest");
     expect(source).toContain("ensure_gotrue");
   });
+
+  test("injects third-party issuer keys into the tenant PostgREST verifier", () => {
+    expect(source).toContain("resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret)");
+    expect(source).toContain("jwt-aud =");
+    expect(source).toContain("client_id_claim");
+    expect(source).toContain("third-party JWT claims rejected");
+  });
 });


### PR DESCRIPTION
Summary\n- Enforce explicit third-party issuer, audience, client ID, and public-key validation.\n- Carry the trust policy into PostgREST and Edge Runtime.\n- Reject cross-client tokens in the PostgREST pre-request gate while preserving project-local legacy HS256 validation.\n- Prioritize an explicit Authorization bearer token over the public anon or service apikey so an invalid user JWT cannot be masked by a valid API key.\n- Preserve the verified JWT subject forwarding added on current main.\n- Update schema regression checks for the hardened pre-request function signature and search path.\n- Synchronize the branch with current main and resolve the Edge Runtime JWT conflicts.\n\nVerification\n- Bearer/apikey regression test failed before the precedence fix: received true, expected false.\n- Edge Runtime JWT tests after main sync: 8 passed.\n- Supabase schema tests: 32 passed.\n- Management API typecheck: passed.\n- Edge Runtime typecheck: passed.\n- git diff --check: passed.\n- Full Management API unit suite before main sync: 724 passed; one unrelated image optimizer test hit its existing 5-second timeout, then passed in isolation in 686 ms.\n- GitHub Actions after conflict resolution: all required jobs passed, including Unit Tests, Package Checks, PostgreSQL 18 compatibility, and Integration & Compliance Tests.\n- CI run: https://github.com/zuohuadong/supacloud/actions/runs/29576853181\n- Independent verifier dispatch was attempted twice but the Codex subagent runtime timed out during spawn; no verifier verdict is claimed.