### PR TITLE
fix(gateway): reconcile managed route drift

### DIFF
--- a/docs/gateway-customization.md
+++ b/docs/gateway-customization.md
@@ -22,7 +22,7 @@ SupaCloud 的 HTTP 网关基于 **Caddy**，但生产环境从不手改 Caddyfil
 **冷启动就绪（`ensureGatewayReady`）**：docker 模式下 caddy 容器晚于 management-api 启动，Management API 在 `Bun.serve` 监听 `:9090` 之前构建网关内存态路由（首次 `POST /load` 因此可能失败），HTTP server 就绪后异步触发 `ensureGatewayReady`：带退避轮询 Admin API，可达后补一次 `persistAndLoad` 让 JSON 路由接管 bootstrap Caddyfile。退避参数可由环境变量 `GATEWAY_READY_MAX_ATTEMPTS`（默认 60）和 `GATEWAY_READY_INTERVAL_MS`（默认 1000ms）调整。在那之前，caddy 的 bootstrap Caddyfile 对所有请求返回 `503`，作为明确的安全网信号而非"假路由"。
 
 
-**稳态自愈（`gateway-health.worker`）**：除了冷启动注入，Management API 还运行一个周期健康 worker（默认每 60s，`GATEWAY_HEALTH_CHECK_INTERVAL_MS` 可配，首探延迟 `GATEWAY_HEALTH_CHECK_INITIAL_DELAY_MS` 默认 30s）。它轮询 Caddy Admin API 可达性，一旦检测到"从不可达恢复可达"（systemd 下 caddy 重启、docker 下 caddy 容器重启的信号），即调用 `rebuildAllTenantConfigs()` 从 DB 全量重建所有 active 租户路由并 `persistAndLoad`，确保 caddy 加载的最新 config.json 与 management-api 内存态一致。这样 systemd 模式下 caddy 重启不再仅依赖磁盘快照，docker 模式也有持续自愈。worker 在 management-api 启动时自动注册、关闭时优雅停止。
+**稳态自愈（`gateway-health.worker`）**：除了冷启动注入，Management API 还运行一个周期健康 worker（默认每 60s，`GATEWAY_HEALTH_CHECK_INTERVAL_MS` 可配，首探延迟 `GATEWAY_HEALTH_CHECK_INITIAL_DELAY_MS` 默认 30s）。它轮询 Caddy Admin API 可达性，一旦检测到"从不可达恢复可达"（systemd 下 caddy 重启、docker 下 caddy 容器重启的信号），即调用 `rebuildAllTenantConfigs()` 从 DB 全量重建所有 active 租户路由并 `persistAndLoad`。Caddy 持续可达时，worker 也会默认每 5 分钟重新应用一次受管路由（`GATEWAY_ROUTE_RECONCILE_INTERVAL_MS` 可配），自动修复进程外修改或启动钩子造成的 upstream、请求头与路由顺序漂移。这样 systemd 模式下 caddy 重启不再仅依赖磁盘快照，docker 模式与持续运行实例也有稳态自愈。worker 在 management-api 启动时自动注册、关闭时优雅停止。
 
 因此自定义路由的最终形态是一份 Caddy JSON route，而不是 Caddyfile 片段。下表里每个字段都会在 JSON 里对应到 Caddy 的 `match` / `handle` 结构。
 

--- a/packages/management-api/src/workers/gateway-health.worker.ts
+++ b/packages/management-api/src/workers/gateway-health.worker.ts
@@ -7,24 +7,47 @@ import { gatewayService } from "../services/gateway.service";
 // （caddy 重启信号）即触发全量重建 + JSON /load，让最新路由配置接管。
 const HEALTH_CHECK_INTERVAL_MS = Number(process.env.GATEWAY_HEALTH_CHECK_INTERVAL_MS || 60 * 1000);
 const INITIAL_DELAY_MS = Number(process.env.GATEWAY_HEALTH_CHECK_INITIAL_DELAY_MS || 30 * 1000);
+const ROUTE_RECONCILE_INTERVAL_MS = Number(process.env.GATEWAY_ROUTE_RECONCILE_INTERVAL_MS || 5 * 60 * 1000);
 
 let healthTimer: Timer | null = null;
 
 // 内部可达性状态：用于检测"不可达 -> 可达"的边沿跳变。export 仅用于测试重置。
 let lastSeenReachable = false;
+let lastRouteReconcileAt = 0;
 
 export function resetGatewayHealthState(): void {
     lastSeenReachable = false;
+    lastRouteReconcileAt = 0;
 }
 
 interface HealthCheckDeps {
     // 触发全量租户路由重建（rebuildAllTenantConfigs），默认走 gatewayService。
     rebuildAll?: () => Promise<{ success: boolean; updated: number; errors: string[] }>;
+    // 测试可注入时钟和周期，生产环境使用环境变量配置。
+    now?: () => number;
+    reconcileIntervalMs?: number;
 }
 
-// 执行一次健康探测。返回是否因"恢复可达"而触发了全量重建。
+// 执行一次健康探测。返回本轮是否触发了全量重建。
 export async function runGatewayHealthCheck(deps?: HealthCheckDeps): Promise<boolean> {
     const rebuildAll = deps?.rebuildAll ?? (() => gatewayService.rebuildAllTenantConfigs());
+    const now = deps?.now?.() ?? Date.now();
+    const reconcileIntervalMs = Math.max(0, deps?.reconcileIntervalMs ?? ROUTE_RECONCILE_INTERVAL_MS);
+
+    const rebuild = async (reason: "recovered" | "periodic"): Promise<boolean> => {
+        lastRouteReconcileAt = now;
+        const result = await rebuildAll();
+        if (!result.success) {
+            logger.warn(`[GatewayHealth] Gateway ${reason} rebuild completed with errors`, {
+                updated: result.updated,
+                errors: result.errors,
+            });
+        } else if (result.updated > 0) {
+            logger.info(`[GatewayHealth] Gateway ${reason} rebuild applied`, { updated: result.updated });
+        }
+        return true;
+    };
+
     try {
         const reachable = await gatewayService.checkCaddyConnectivity();
 
@@ -40,16 +63,15 @@ export async function runGatewayHealthCheck(deps?: HealthCheckDeps): Promise<boo
         if (!lastSeenReachable) {
             logger.info("[GatewayHealth] Caddy reachable (recovered or first contact); rebuilding gateway config");
             lastSeenReachable = true;
-            const result = await rebuildAll();
-            if (!result.success) {
-                logger.warn("[GatewayHealth] Gateway rebuild completed with errors", {
-                    updated: result.updated,
-                    errors: result.errors,
-                });
-            } else if (result.updated > 0) {
-                logger.info("[GatewayHealth] Gateway config rebuilt", { updated: result.updated });
-            }
-            return true;
+            return rebuild("recovered");
+        }
+
+        // Caddy can stay reachable while its live config is changed out-of-band
+        // (for example by a restart hook or an operator patch). Periodically
+        // replay the persisted tenant routes so managed upstreams and headers
+        // cannot remain stale indefinitely.
+        if (reconcileIntervalMs === 0 || now - lastRouteReconcileAt >= reconcileIntervalMs) {
+            return rebuild("periodic");
         }
 
         return false;

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -1703,12 +1703,36 @@ describe("gateway-health worker", () => {
         const { runGatewayHealthCheck, resetGatewayHealthState } = await import("../../src/workers/gateway-health.worker");
         resetGatewayHealthState();
 
-        // 初始状态：未观测过可达 -> 首次探测可达应标记已就绪，但不触发重建
+        // 初始状态：未观测过可达 -> 首次探测可达会执行恢复重建。
         await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 0, errors: [] }) });
-        // 第二次：仍然可达，状态无变化，不应触发重建
+        // 第二次：仍然可达且未达到周期阈值，不应重复重建。
         const rebuilt = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 0, errors: [] }) });
 
         expect(rebuilt).toBe(false);
+
+        restore();
+    });
+
+    test("periodically rebuilds managed routes while Caddy stays reachable", async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock(() => Promise.resolve(new Response("{}", { status: 200 }))) as unknown as typeof fetch;
+        const restore = () => { globalThis.fetch = originalFetch; };
+        const { runGatewayHealthCheck, resetGatewayHealthState } = await import("../../src/workers/gateway-health.worker");
+        resetGatewayHealthState();
+
+        let now = 1_000;
+        let rebuildCount = 0;
+        const rebuildAll = async () => {
+            rebuildCount += 1;
+            return { success: true, updated: 1, errors: [] };
+        };
+
+        await runGatewayHealthCheck({ rebuildAll, now: () => now, reconcileIntervalMs: 5_000 });
+        now += 4_999;
+        expect(await runGatewayHealthCheck({ rebuildAll, now: () => now, reconcileIntervalMs: 5_000 })).toBe(false);
+        now += 1;
+        expect(await runGatewayHealthCheck({ rebuildAll, now: () => now, reconcileIntervalMs: 5_000 })).toBe(true);
+        expect(rebuildCount).toBe(2);
 
         restore();
     });


### PR DESCRIPTION
## Summary

- periodically replay persisted managed gateway routes while Caddy remains reachable
- make the reconcile interval configurable with `GATEWAY_ROUTE_RECONCILE_INTERVAL_MS` (default: 5 minutes)
- document steady-state route self-healing and add regression coverage

## Problem

The gateway health worker only rebuilt tenant routes after Caddy changed from unreachable to reachable. If a restart hook or an out-of-band operator patch changed a managed route while Caddy stayed healthy, the persisted project route and the live upstream could remain different indefinitely.

This was observed with a central OAuth route whose persisted upstream pointed to the central GoTrue instance while the live Caddy route was overwritten to a business-tenant GoTrue port, causing valid OAuth clients to return `oauth_client_not_found`.

## Verification

- `bun test tests/unit/gateway.service.test.ts`
- `bun run test:unit`
- `bun run typecheck`
- `git diff --check`
