### PR TITLE
feat(auth): enforce SupAuth shared runtime boundaries

### DIFF
--- a/docs/architecture-multi-tenant.md
+++ b/docs/architecture-multi-tenant.md
@@ -30,15 +30,32 @@
 > **Note**: SupaCloud natively relies on **Caddy** running as a systemd service.
 > All tenant routing, rate limiting, CORS, and TLS are managed via the Caddy Admin API — no manual config file edits needed.
 
-### 1. PostgREST & GoTrue (Per-Tenant Processes) ⭐ Implemented
-These core REST, GraphQL, and Authentication services are extremely lightweight (20-50MB RAM). 
-We spin up a unique `postgrest` AND `gotrue` process for *every* tenant dynamically using `systemd` templates (`supacloud-pgrst@.service` and `supacloud-gotrue@.service`):
+### 1. PostgREST & Authentication Runtime ⭐ Implemented
+PostgREST remains a per-tenant process. Authentication supports two explicit product modes:
+
+- **Local mode (default):** the project owns its own `gotrue` process and `auth` schema.
+- **SupAuth shared mode:** `SUPACLOUD_AUTH_RUNTIME_OWNER_REF=<owner-ref>` designates one project as the authentication authority. Other projects do not start local GoTrue; their public `/auth/v1` traffic is routed to the owner's GoTrue runtime.
+
+In local mode, we spin up unique `postgrest` and `gotrue` processes dynamically using `systemd` templates (`supacloud-pgrst@.service` and `supacloud-gotrue@.service`):
 - They bind to unique deterministically generated ports (e.g., PostgREST starts from 3100, GoTrue starts from 4100).
 - They connect securely to the tenant's isolated Postgres database (`supa_<ref>`) using unique credentials.
 - They possess isolated `JWT_SECRET`s to ensure cryptographic boundary security (users from Tenant A cannot authenticate into Tenant B).
 - PostgREST now has a component-level lifecycle controller in Management API: `pausePostgrest`, `resumePostgrest`, `statusPostgrest`, and `restartPostgrest`.
 - Desired state is stored per project in dedicated `projects.postgrest_*` metadata columns and is reconciled to actual systemd state in the runtime worker.
 - PostgREST-only lifecycle actions do not restart GoTrue, so REST-only repairs do not disturb authentication traffic.
+
+In SupAuth shared mode:
+
+- only the owner project can manage users, providers, OAuth clients, MFA, SSO, email templates, hooks, rate limits, and other GoTrue configuration
+- dependent Studio projects expose local RLS policy management, but hide and server-side block GoTrue user/configuration pages
+- service status points to `supacloud-gotrue@<owner-ref>` and is read-only from dependent projects; project-wide start/stop/restart does not control the shared owner runtime
+- local project databases remain the authority for business data, project membership, profiles, and RLS; application tables should reference the verified JWT `sub` as an external identity rather than treating local `auth.users` as the user authority
+- disabling shared mode restores per-project GoTrue only after the operator has planned user/config migration; SupaCloud does not silently copy global users into tenant databases
+- the owner must use ES256 or RS256 signing so dependents can verify public JWKS without receiving the owner's private key; enabling shared mode with HS256-only owner signing is rejected
+- shared dependents use only the SupAuth owner plus their legacy API-key verification material; a dependent `third_party_auth` issuer is not admitted while shared mode is enabled because PostgREST cannot bind payload claims to key provenance
+- official Realtime tenant auth currently accepts a single HS256 secret rather than JWKS, so authenticated Realtime subscriptions are explicitly unsupported for shared dependents until the upstream runtime supports asymmetric JWKS
+
+This prevents duplicate authentication authorities and avoids exposing the shared global user directory through every tenant's Studio panel.
 
 ### 2. Caddy API-Driven Gateway ⭐ Implemented
 Caddy runs as a native systemd service, fully managed via the Caddy Admin API:

--- a/packages/edge-runtime/jwt-verifier.test.ts
+++ b/packages/edge-runtime/jwt-verifier.test.ts
@@ -147,4 +147,34 @@ describe("verifyEdgeRuntimeJwt", () => {
       keys: [{ kty: "EC", kid: "kid_1", alg: "ES256" }],
     });
   });
+
+  test("shared mode accepts owner user tokens but rejects owner service-role tokens", async () => {
+    const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+    const publicJwk = await exportJWK(publicKey);
+    const privateJwk = await exportJWK(privateKey);
+    const kid = "supauth-owner";
+    const signingKey = await crypto.subtle.importKey(
+      "jwk",
+      { ...privateJwk, kid, alg: "ES256", use: "sig" },
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign"],
+    );
+    const userToken = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setSubject("user_1")
+      .setExpirationTime("5m")
+      .sign(signingKey);
+    const serviceToken = await new SignJWT({ role: "service_role" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setExpirationTime("5m")
+      .sign(signingKey);
+    const secrets = {
+      authRuntimeMode: "shared" as const,
+      jwtJwks: { keys: [{ ...publicJwk, kid, alg: "ES256", use: "sig" }] },
+    };
+
+    expect(await verifyEdgeRuntimeJwt(secrets, `Bearer ${userToken}`)).toBe(true);
+    expect(await verifyEdgeRuntimeJwt(secrets, `Bearer ${serviceToken}`)).toBe(false);
+  });
 });

--- a/packages/edge-runtime/jwt-verifier.ts
+++ b/packages/edge-runtime/jwt-verifier.ts
@@ -20,6 +20,7 @@ export type EdgeRuntimeProjectSecrets = {
   jwtSecret?: string;
   jwtJwks?: { keys: JWK[] } | null;
   thirdParty?: EdgeRuntimeThirdPartyJwtPolicy | null;
+  authRuntimeMode?: "local" | "owner" | "shared";
 };
 
 export type EdgeRuntimeThirdPartyJwtPolicy = {
@@ -164,6 +165,9 @@ export async function verifyEdgeRuntimeJwtContext(
         const verified = await jwtVerify(token, createLocalJWKSet({ keys: localKeys }), {
           algorithms: ["ES256", "RS256"],
         });
+        if (secrets.authRuntimeMode === "shared" && verified.payload.role !== "authenticated") {
+          return { verified: false, source: "none" };
+        }
         return { verified: true, source: "jwt", payload: verified.payload };
       }
     } catch {

--- a/packages/edge-runtime/server-cache.test.ts
+++ b/packages/edge-runtime/server-cache.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./server.ts", import.meta.url), "utf8");
+
+describe("Edge Runtime cache invalidation", () => {
+  test("runtime env invalidation also clears cached JWT verification material", () => {
+    const endpoint = source.slice(
+      source.indexOf('.post("/invalidate-env/:ref"'),
+      source.indexOf('.post("/preheat/:ref/:slug"'),
+    );
+    expect(endpoint).toContain("invalidateTenantEnvCache(c.params.ref)");
+    expect(endpoint).toContain("secretsCache.delete(c.params.ref)");
+  });
+
+  test("does not treat an unknown runtime mode as local during fallback", () => {
+    expect(source).toContain("/auth/runtime");
+    expect(source).toContain("if (authRuntime.mode === \"shared\")");
+    expect(source).toContain("Refusing local fallback secrets for SupAuth dependent");
+  });
+});

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -500,6 +500,7 @@ interface ProjectSecrets {
   jwtSecret: string;
   jwtJwks: ReturnType<typeof normalizeJwtJwks>;
   thirdParty: ReturnType<typeof normalizeThirdPartyJwtPolicy>;
+  authRuntimeMode: "local" | "owner" | "shared";
   expiresAt: number;
 }
 const secretsCache = new Map<string, ProjectSecrets>();
@@ -525,13 +526,18 @@ async function getProjectSecrets(
         jwtSecret: runtimeEnv.JWT_SECRET || "",
         jwtJwks: normalizeJwtJwks(runtimeEnv.JWT_JWKS),
         thirdParty: normalizeThirdPartyJwtPolicy(runtimeEnv.SUPACLOUD_THIRD_PARTY_JWT_POLICY),
+        authRuntimeMode: runtimeEnv.SUPACLOUD_AUTH_RUNTIME_MODE === "shared"
+          ? "shared"
+          : runtimeEnv.SUPACLOUD_AUTH_RUNTIME_MODE === "owner"
+            ? "owner"
+            : "local",
         expiresAt: Date.now() + SECRETS_CACHE_TTL,
       };
       secretsCache.set(projectRef, secrets);
       return secrets;
     }
 
-    const [keysRes, detailRes] = await Promise.all([
+    const [keysRes, detailRes, authRuntimeRes] = await Promise.all([
       fetch(`${MGMT_API}/v1/projects/${projectRef}/api-keys`, {
         headers: { Authorization: `Bearer ${MASTER_TOKEN}` },
         signal: AbortSignal.timeout(5000),
@@ -540,11 +546,15 @@ async function getProjectSecrets(
         headers: { Authorization: `Bearer ${MASTER_TOKEN}` },
         signal: AbortSignal.timeout(5000),
       }),
+      fetch(`${MGMT_API}/v1/projects/${projectRef}/auth/runtime`, {
+        headers: { Authorization: `Bearer ${MASTER_TOKEN}` },
+        signal: AbortSignal.timeout(5000),
+      }),
     ]);
 
-    if (!keysRes.ok || !detailRes.ok) {
+    if (!keysRes.ok || !detailRes.ok || !authRuntimeRes.ok) {
       console.warn(
-        `[verifyJwt] Failed to fetch secrets for ${projectRef}: keys=${keysRes.status} detail=${detailRes.status}`,
+        `[verifyJwt] Failed to fetch secrets for ${projectRef}: keys=${keysRes.status} detail=${detailRes.status} authRuntime=${authRuntimeRes.status}`,
       );
       if (cached) return cached;
       return null;
@@ -561,6 +571,13 @@ async function getProjectSecrets(
         third_party_auth?: unknown;
       } };
     };
+    const authRuntime = (await authRuntimeRes.json()) as {
+      mode?: "local" | "owner" | "shared";
+    };
+    if (authRuntime.mode === "shared") {
+      console.warn(`[verifyJwt] Refusing local fallback secrets for SupAuth dependent ${projectRef}`);
+      return null;
+    }
 
     const secrets: ProjectSecrets = {
       anonKey: keysArray?.find?.((k) => k.name === "anon")?.api_key || "",
@@ -569,6 +586,7 @@ async function getProjectSecrets(
       jwtSecret: detail.jwt_secret || "",
       jwtJwks: normalizeJwtJwks(detail.config?.auth?.oauth_server?.jwt_jwks),
       thirdParty: normalizeThirdPartyJwtPolicy(detail.config?.auth?.third_party_auth),
+      authRuntimeMode: authRuntime.mode === "owner" ? "owner" : "local",
       expiresAt: Date.now() + SECRETS_CACHE_TTL,
     };
     secretsCache.set(projectRef, secrets);
@@ -691,6 +709,7 @@ const app = new Elysia()
 
     const functionId = `${c.params.ref}_${c.params.slug}`;
     invalidateTenantEnvCache(c.params.ref);
+    secretsCache.delete(c.params.ref);
     const [foreground, background] = await Promise.all([
       pool.invalidateModule(functionId),
       backgroundPool.invalidateModule(functionId),
@@ -706,6 +725,7 @@ const app = new Elysia()
     }
 
     invalidateTenantEnvCache(c.params.ref);
+    secretsCache.delete(c.params.ref);
     const moduleEpoch = bumpProjectModuleEpoch(c.params.ref);
     const [foreground, background] = await Promise.all([
       pool.invalidateProject(c.params.ref),

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -118,6 +118,8 @@ export interface Config {
   gotrueBin: string;
   pgrstPortBase: number;
   gotruePortBase: number;
+  /** Optional project ref that exclusively owns the local GoTrue runtime. */
+  authRuntimeOwnerRef: string;
   portRange: string;
   gotrueSmtpAdminEmail: string;
   gotrueSmtpHost: string;
@@ -251,6 +253,7 @@ export const config: Config = {
   gotrueBin: getEnv("GOTRUE_BIN", "/usr/local/bin/gotrue"),
   pgrstPortBase: Number(getEnv("PGRST_PORT_BASE", "3100")),
   gotruePortBase: Number(getEnv("GOTRUE_PORT_BASE", "3200")),
+  authRuntimeOwnerRef: getEnv("SUPACLOUD_AUTH_RUNTIME_OWNER_REF", "").trim(),
   portRange: getEnv("PORT_RANGE", "3100-3299"),
   gotrueSmtpAdminEmail: getEnv("GOTRUE_SMTP_ADMIN_EMAIL", ""),
   gotrueSmtpHost: getEnv("GOTRUE_SMTP_HOST", ""),

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -22,7 +22,7 @@ import { checkAuth } from "./middleware/auth";
 import { checkRateLimit } from "./middleware/rate-limit";
 import { logAuditEvent, shouldAuditRequest } from "./services/audit.service";
 import { closeDb } from "./db";
-import { authRoutes, deployRoutes, storageCompatRoutes } from "./routes";
+import { authRoutes, authRuntimeRoutes, deployRoutes, storageCompatRoutes } from "./routes";
 import { migrateLegacyVersionArtifacts } from "./services/edge-function.service";
 import { resolveRealtimeTenantHost } from "./utils/sdk-parity";
 import { resolveProjectApiKey } from "./utils/project-auth";
@@ -797,6 +797,7 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
       .use(taskRoutes)
       .use(databaseRoutes)
       .use(authRoutes)
+      .use(authRuntimeRoutes)
       .use(wechatAuthRoutes)
       .use(chinaAuthRoutes)
       .use(userManagementRoutes)

--- a/packages/management-api/src/routes/auth-china.ts
+++ b/packages/management-api/src/routes/auth-china.ts
@@ -4,6 +4,7 @@ import { projectService } from "../services";
 import { edgeFunctionService } from "../services/edge-function.service";
 import { CHINA_OAUTH_PROVIDER_INFO } from "../types/oauth";
 import type { ChinaOAuthProvider } from "../types/oauth";
+import { requireAuthRuntimeManagement } from "./auth-runtime";
 
 const CHINA_PROVIDERS: ChinaOAuthProvider[] = ["qq", "weibo", "alipay", "dingtalk", "douyin", "baidu", "huawei", "xiaomi", "kuaishou", "bilibili"];
 
@@ -11,6 +12,7 @@ const CHINA_PROVIDERS: ChinaOAuthProvider[] = ["qq", "weibo", "alipay", "dingtal
  * China OAuth provider routes — QQ, Weibo, Alipay, DingTalk, Douyin, etc.
  */
 export const chinaAuthRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
+  .onBeforeHandle(requireAuthRuntimeManagement("providers"))
   .get(
     "/china/providers",
     async ({ params, set }) => {

--- a/packages/management-api/src/routes/auth-hooks.ts
+++ b/packages/management-api/src/routes/auth-hooks.ts
@@ -3,6 +3,7 @@ import { projectService } from "../services";
 import { resolveDbName, getProjectDb } from "../db";
 import { logger } from "../utils/logger";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { getAuthRuntimeManagedError } from "../services/auth-runtime.service";
 
 export const authHooksRoutes = new Elysia({ prefix: "/v1/projects" })
 
@@ -172,7 +173,11 @@ export const authHooksRoutes = new Elysia({ prefix: "/v1/projects" })
 
   .get(
     "/:ref/auth/hooks",
-    async ({ params }) => {
+    async ({ params, request }) => {
+      const authError = await requireProjectOrAdminAuth(request, params.ref);
+      if (authError) return status(authError.status, authError.body);
+      const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
+      if (managedError) return status(409, managedError);
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings) return status(404, { message: "Project not found", code: "404" });
 
@@ -195,6 +200,8 @@ export const authHooksRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
+      const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
+      if (managedError) return status(409, managedError);
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings) return status(404, { message: "Project not found", code: "404" });
 

--- a/packages/management-api/src/routes/auth-mfa.ts
+++ b/packages/management-api/src/routes/auth-mfa.ts
@@ -5,6 +5,7 @@ import { logger } from "../utils/logger";
 import { projectService } from "../services";
 import { resolveTenantPorts } from "../utils/project-routing";
 import { resolveProjectServiceRoleKey } from "../utils/service-role";
+import { requireAuthRuntimeManagement } from "./auth-runtime";
 
 async function getGotruePort(ref: string): Promise<number | null> {
     try {
@@ -21,6 +22,7 @@ async function getGotruePort(ref: string): Promise<number | null> {
 }
 
 export const authMfaRoutes = new Elysia({ prefix: "/v1/projects" })
+  .onBeforeHandle(requireAuthRuntimeManagement("mfa"))
 
   .get(
     "/:ref/auth/factors",

--- a/packages/management-api/src/routes/auth-oauth-server.ts
+++ b/packages/management-api/src/routes/auth-oauth-server.ts
@@ -11,6 +11,7 @@ import {
   resolveTenantPorts,
 } from "../utils/project-routing";
 import { normalizeOAuthServerConfig, normalizeProjectConfig } from "../utils/project-config";
+import { requireAuthRuntimeManagement } from "./auth-runtime";
 import {
   buildAwsKmsRs256JwtKeyMaterial,
   generateOidcJwtKeyMaterial,
@@ -211,6 +212,10 @@ async function configureKmsRs256Signing(
       ref,
       error: error instanceof Error ? error.message : String(error),
     });
+    return status(503, {
+      code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+      message: "JWT signing configuration was saved, but one or more SupAuth runtimes failed to refresh",
+    });
   }
 
   return buildOAuthServerStatus({
@@ -266,6 +271,10 @@ async function proxyGoTrueAdmin(
       ref: ctx.project.ref,
       path,
       error: error instanceof Error ? error.message : String(error),
+    });
+    return status(503, {
+      code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+      message: "OIDC signing configuration was saved, but one or more SupAuth runtimes failed to refresh",
     });
     return new Response(JSON.stringify({ message: "GoTrue OAuth admin endpoint unavailable", code: "502" }), {
       status: 502,
@@ -334,6 +343,7 @@ async function migrateProjectToOidc(
 }
 
 export const authOAuthServerRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
+  .onBeforeHandle(requireAuthRuntimeManagement("oauth"))
   .get(
     "/oauth-server",
     async ({ params, request }) => {

--- a/packages/management-api/src/routes/auth-runtime.ts
+++ b/packages/management-api/src/routes/auth-runtime.ts
@@ -1,0 +1,46 @@
+import { Elysia, status, t } from "elysia";
+import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { projectService } from "../services";
+import {
+  getAuthRuntimeDescriptor,
+  getAuthRuntimeManagedError,
+  type AuthRuntimeManagedResource,
+} from "../services/auth-runtime.service";
+
+type AuthRuntimeGuardContext = {
+  params: Record<string, string>;
+  request: Request;
+};
+
+export function requireAuthRuntimeManagement(resource: AuthRuntimeManagedResource) {
+  return async ({ params, request }: AuthRuntimeGuardContext) => {
+    const ref = params.ref;
+    if (!ref) return;
+
+    const authError = await requireProjectOrAdminAuth(request, ref);
+    if (authError) return status(authError.status, authError.body);
+
+    const managedError = getAuthRuntimeManagedError(ref, resource);
+    if (managedError) return status(409, managedError);
+  };
+}
+
+export const authRuntimeRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
+  .get(
+    "/runtime",
+    async ({ params, request }) => {
+      const authError = await requireProjectOrAdminAuth(request, params.ref);
+      if (authError) return status(authError.status, authError.body);
+
+      const project = await projectService.getProject(params.ref);
+      if (!project) {
+        return status(404, { message: "Project not found", code: "404" });
+      }
+
+      return getAuthRuntimeDescriptor(params.ref);
+    },
+    {
+      params: t.Object({ ref: t.String() }),
+      detail: { tags: ["auth"], summary: "Get project auth runtime ownership" },
+    },
+  );

--- a/packages/management-api/src/routes/auth-sso.ts
+++ b/packages/management-api/src/routes/auth-sso.ts
@@ -6,6 +6,7 @@ import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { sql as metaSql } from "../db";
 import { resolveTenantPorts, normalizeProjectRoutingConfig } from "../utils/project-routing";
 import { normalizeProjectConfig } from "../utils/project-config";
+import { requireAuthRuntimeManagement } from "./auth-runtime";
 
 async function getGoTrueHeaders(ref: string) {
   const project = await projectService.getProject(ref);
@@ -33,6 +34,7 @@ async function getGoTrueHeaders(ref: string) {
 }
 
 export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
+  .onBeforeHandle(requireAuthRuntimeManagement("sso"))
 
   .get(
     "/:ref/auth/sso/providers",

--- a/packages/management-api/src/routes/auth-users.ts
+++ b/packages/management-api/src/routes/auth-users.ts
@@ -6,6 +6,7 @@ import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { sql as metaSql } from "../db";
 import { resolveTenantPorts, normalizeProjectRoutingConfig } from "../utils/project-routing";
 import { normalizeProjectConfig } from "../utils/project-config";
+import { requireAuthRuntimeManagement } from "./auth-runtime";
 
 async function getGoTrueAdminContext(ref: string) {
   const project = await projectService.getProject(ref);
@@ -79,6 +80,7 @@ function readOptionalString(value: unknown): string | undefined {
  * User Management routes — Admin API proxy to GoTrue
  */
 export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
+  .onBeforeHandle(requireAuthRuntimeManagement("users"))
   .get(
     "/users",
     async ({ params, query, set, request }) => {

--- a/packages/management-api/src/routes/auth-wechat.ts
+++ b/packages/management-api/src/routes/auth-wechat.ts
@@ -6,11 +6,13 @@ import { edgeFunctionService } from "../services/edge-function.service";
 import { runtimeCacheService } from "../services/runtime-cache.service";
 import { WECHAT_PROVIDER_INFO } from "../types/oauth";
 import type { WeChatProviderType } from "../types/oauth";
+import { requireAuthRuntimeManagement } from "./auth-runtime";
 
 /**
  * WeChat OAuth routes — miniprogram, official account (mp), and open platform
  */
 export const wechatAuthRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
+  .onBeforeHandle(requireAuthRuntimeManagement("providers"))
   .post(
     "/wechat/miniprogram",
     async ({ params, body, set }) => {

--- a/packages/management-api/src/routes/auth.ts
+++ b/packages/management-api/src/routes/auth.ts
@@ -16,6 +16,8 @@ import {
   WECHAT_PROVIDER_INFO,
   CHINA_OAUTH_PROVIDER_INFO,
 } from "../types/oauth";
+import { requireAuthRuntimeManagement } from "./auth-runtime";
+import { getAuthRuntimeDescriptor } from "../services/auth-runtime.service";
 
 function generateGoTrueOAuthEnv(provider: OAuthProvider, config: OAuthProviderConfig): string {
   const mapping = OAUTH_ENV_MAPPINGS[provider];
@@ -56,6 +58,7 @@ function maskSecret(value: string): string {
  *   - ./auth-users.ts
  */
 export const authRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
+  .onBeforeHandle(requireAuthRuntimeManagement("configuration"))
   .get(
     "/providers",
     async ({ params, set }) => {
@@ -407,6 +410,12 @@ export const authRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
         await tenantRuntimeService.restartRuntime(params.ref);
       } catch (error: unknown) {
         logger.error("Failed to restart GoTrue after config update:", { error: error instanceof Error ? error.message : String(error) });
+        if (getAuthRuntimeDescriptor(params.ref).mode === "owner") {
+          return status(503, {
+            code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+            message: "Auth configuration was saved, but one or more SupAuth dependents failed to refresh",
+          });
+        }
       }
 
       return updated?.auth || {};

--- a/packages/management-api/src/routes/index.ts
+++ b/packages/management-api/src/routes/index.ts
@@ -16,6 +16,7 @@ export { taskRoutes } from "./tasks";
 export { taskEventRoutes } from "./task-events";
 export { databaseRoutes } from "./database";
 export { authRoutes } from "./auth";
+export { authRuntimeRoutes } from "./auth-runtime";
 export { wechatAuthRoutes } from "./auth-wechat";
 export { chinaAuthRoutes } from "./auth-china";
 export { userManagementRoutes } from "./auth-users";

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -21,6 +21,10 @@ import {
 import { resolveRoleName, resolveDbName as resolveDbNameTopLevel } from "../db";
 import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
 import { projectNetworkRestrictionRoutes } from "./project-network-restrictions";
+import {
+  getAuthRuntimeDescriptor,
+  getAuthRuntimeManagedError,
+} from "../services/auth-runtime.service";
 
 /** Map PostgreSQL column types to TypeScript types */
 function pgTypeToTs(udtName: string, dataType: string): string {
@@ -333,7 +337,6 @@ function buildAuthConfigResponse(settings: Record<string, unknown>) {
 
   const response: Record<string, unknown> = {
     ...cloneTemplate(OPENAPI_AUTH_CONFIG_RESPONSE_TEMPLATE),
-    ...authConfig,
     enable_signup: authConfig.enable_signup ?? true,
     enable_signups: authConfig.enable_signup ?? true,
     enable_confirmations: authConfig.enable_confirmations ?? false,
@@ -441,7 +444,7 @@ function buildAuthConfigResponse(settings: Record<string, unknown>) {
     response[`hook_${suffix}_enabled`] = hook.enabled ?? null;
     response[`hook_${suffix}_uri`] = hook.uri ?? null;
     if ("secrets" in hook) {
-      response[`hook_${suffix}_secrets`] = hook.secrets ?? null;
+      response[`hook_${suffix}_secrets`] = hook.secrets ? "********" : null;
     }
   }
 
@@ -747,7 +750,11 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get Auth config (Studio compatible format)
   .get(
     "/:ref/config/auth",
-    async ({ params, set }) => {
+    async ({ params, request }) => {
+      const authError = await requireProjectOrAdminAuth(request, params.ref);
+      if (authError) return status(authError.status, authError.body);
+      const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
+      if (managedError) return status(409, managedError);
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings) {
         return status(404, { message: "Project not found", code: "404" });
@@ -770,6 +777,8 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
+      const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
+      if (managedError) return status(409, managedError);
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings) {
         return status(404, { message: "Project not found", code: "404" });
@@ -1046,6 +1055,12 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
           "[project-config] Failed to propagate auth config to runtime",
           { error: err },
         );
+        if (getAuthRuntimeDescriptor(params.ref).mode === "owner") {
+          return status(503, {
+            code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+            message: "Auth configuration was saved, but one or more SupAuth dependents failed to refresh",
+          });
+        }
       }
 
       const freshSettings = await projectService.getProjectSettings(params.ref);
@@ -1056,7 +1071,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       const freshSmtp = (freshAuth.smtp as Record<string, unknown>) || {};
 
       const response: Record<string, unknown> = {
-        ...freshAuth,
+        ...cloneTemplate(OPENAPI_AUTH_CONFIG_RESPONSE_TEMPLATE),
         enable_signup: freshAuth.enable_signup ?? true,
         enable_signups: freshAuth.enable_signup ?? true,
         enable_confirmations: freshAuth.enable_confirmations ?? false,
@@ -1088,18 +1103,23 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
         !!freshHooks.custom_access_token_hook?.enabled;
       response.hook_custom_access_token_uri =
         freshHooks.custom_access_token_hook?.uri || null;
+      response.hook_custom_access_token_secrets = freshHooks.custom_access_token_hook?.secrets ? "********" : null;
       response.hook_mfa_verification_enabled =
         !!freshHooks.mfa_verification_hook?.enabled;
       response.hook_mfa_verification_uri =
         freshHooks.mfa_verification_hook?.uri || null;
+      response.hook_mfa_verification_secrets = freshHooks.mfa_verification_hook?.secrets ? "********" : null;
       response.hook_password_verification_enabled =
         !!freshHooks.password_verification_hook?.enabled;
       response.hook_password_verification_uri =
         freshHooks.password_verification_hook?.uri || null;
+      response.hook_password_verification_secrets = freshHooks.password_verification_hook?.secrets ? "********" : null;
       response.hook_send_email_enabled = !!freshHooks.send_email_hook?.enabled;
       response.hook_send_email_uri = freshHooks.send_email_hook?.uri || null;
+      response.hook_send_email_secrets = freshHooks.send_email_hook?.secrets ? "********" : null;
       response.hook_send_sms_enabled = !!freshHooks.send_sms_hook?.enabled;
       response.hook_send_sms_uri = freshHooks.send_sms_hook?.uri || null;
+      response.hook_send_sms_secrets = freshHooks.send_sms_hook?.secrets ? "********" : null;
 
       response.smtp_admin_email = freshSmtp.admin_email || "";
       response.smtp_host = freshSmtp.host || "";

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -9,6 +9,10 @@ import { getProjectDb, resolveDbName, resolveRoleName } from "../db";
 import { normalizeProjectConfig } from "../utils/project-config";
 import { getAuthContext, requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
 import { tenantRuntimeService } from "../services/tenant-runtime.service";
+import {
+  getAuthRuntimeManagedError,
+  getAuthRuntimeOwnerProtectionError,
+} from "../services/auth-runtime.service";
 import { ScalingService } from "../services/scaling.service";
 import { listBackups } from "../services/backup.service";
 import type { BackupInfo } from "../types/backup";
@@ -500,6 +504,8 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!project) {
         return status(404, { message: "Project not found", code: "404" });
       }
+      const ownerError = getAuthRuntimeOwnerProtectionError(params.ref, "delete");
+      if (ownerError) return status(409, ownerError);
       const deleted = await projectService.deleteProject(params.ref);
       if (!deleted) {
         return status(404, { message: "Project not found", code: "404" });
@@ -520,6 +526,8 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
       if (authError) {
         return status(authError.status as 401 | 403, { message: authError.body.error, code: String(authError.status) });
       }
+      const ownerError = getAuthRuntimeOwnerProtectionError(params.ref, "pause");
+      if (ownerError) return status(409, ownerError);
       const paused = await projectService.pauseProject(params.ref);
       if (!paused) {
         return status(404, { message: "Project not found", code: "404" });
@@ -817,6 +825,8 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status as 401 | 403, { message: authError.body.error, code: String(authError.status) });
+      const managedError = getAuthRuntimeManagedError(params.ref, "email_templates");
+      if (managedError) return status(409, managedError);
 
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings)
@@ -839,6 +849,8 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status as 401 | 403, { message: authError.body.error, code: String(authError.status) });
+      const managedError = getAuthRuntimeManagedError(params.ref, "email_templates");
+      if (managedError) return status(409, managedError);
 
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings)
@@ -884,6 +896,8 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status as 401 | 403, { message: authError.body.error, code: String(authError.status) });
+      const managedError = getAuthRuntimeManagedError(params.ref, "email_templates");
+      if (managedError) return status(409, managedError);
 
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings)

--- a/packages/management-api/src/routes/project-dashboard.ts
+++ b/packages/management-api/src/routes/project-dashboard.ts
@@ -4,6 +4,7 @@ import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { edgeFunctionService } from "../services/edge-function.service";
 import { taskRepository } from "../repositories/task.repository";
 import { logger } from "../utils/logger";
+import { getAuthRuntimeDescriptor } from "../services/auth-runtime.service";
 
 type DashboardRow = Record<string, unknown>;
 
@@ -65,6 +66,8 @@ export const projectDashboardRoutes = new Elysia({ prefix: "/v1/projects" })
         String(project.db_user),
         String(project.db_password),
       );
+      const authRuntime = getAuthRuntimeDescriptor(params.ref);
+      const sharedAuth = authRuntime.mode === "shared";
 
       const [
         dbInfoRows,
@@ -92,9 +95,11 @@ export const projectDashboardRoutes = new Elysia({ prefix: "/v1/projects" })
             (SELECT count(*)::int FROM pg_stat_activity WHERE backend_type = 'client backend') AS active,
             (SELECT setting::int FROM pg_settings WHERE name = 'max_connections') AS max
         `),
-        safeRead<DashboardRow[]>("auth user count", [], () => projectDb`
-          SELECT count(*)::int AS total FROM auth.users
-        `),
+        sharedAuth
+          ? Promise.resolve<DashboardRow[]>([])
+          : safeRead<DashboardRow[]>("auth user count", [], () => projectDb`
+              SELECT count(*)::int AS total FROM auth.users
+            `),
         safeRead<DashboardRow[]>("table count", [], () => projectDb`
           SELECT count(*)::int AS cnt FROM pg_stat_user_tables
         `),
@@ -110,12 +115,14 @@ export const projectDashboardRoutes = new Elysia({ prefix: "/v1/projects" })
           ), 0)) AS size
           FROM storage.objects
         `),
-        safeRead<DashboardRow[]>("recent users", [], () => projectDb`
-          SELECT email, created_at::text
-          FROM auth.users
-          ORDER BY created_at DESC
-          LIMIT 5
-        `),
+        sharedAuth
+          ? Promise.resolve<DashboardRow[]>([])
+          : safeRead<DashboardRow[]>("recent users", [], () => projectDb`
+              SELECT email, created_at::text
+              FROM auth.users
+              ORDER BY created_at DESC
+              LIMIT 5
+            `),
         safeRead<DashboardRow[]>("active queries", [], () => projectDb`
           SELECT pid, usename, state, left(query, 80) AS query
           FROM pg_stat_activity
@@ -143,8 +150,10 @@ export const projectDashboardRoutes = new Elysia({ prefix: "/v1/projects" })
           index_count: numberValue(indexInfo.cnt),
         },
         auth: {
-          total_users: numberValue(userInfo.total),
+          total_users: sharedAuth ? null : numberValue(userInfo.total),
           recent_users: recentUsers,
+          source: sharedAuth ? "supauth" : "local",
+          managed_by_ref: sharedAuth ? authRuntime.authority_project_ref : null,
         },
         storage: {
           size: String(storageInfo.size || "0 bytes"),

--- a/packages/management-api/src/routes/project-services.ts
+++ b/packages/management-api/src/routes/project-services.ts
@@ -4,10 +4,18 @@
  */
 import { Elysia, t, status } from "elysia";
 import { projectService } from "../services";
-import { getAuthContext, requireProjectOrAdminAuth } from "../middleware/auth";
+import {
+  getAuthContext,
+  requireAdminAuth,
+  requireProjectOrAdminAuth,
+} from "../middleware/auth";
 import { $ } from "bun";
 import { tenantRuntimeService } from "../services/tenant-runtime.service";
 import { config } from "../config";
+import {
+  getAuthRuntimeDescriptor,
+  getAuthRuntimeManagedError,
+} from "../services/auth-runtime.service";
 
 export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get project health status
@@ -97,13 +105,18 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
           /* storage schema may not exist */
         }
 
-        // Auth user count
+        const authRuntime = getAuthRuntimeDescriptor(params.ref);
+
+        // In SupAuth shared mode auth.users in the tenant database is not the
+        // identity authority and must not be presented as the global user count.
         let userCount = 0;
-        try {
-          const [authStats] = await db`SELECT count(*) as cnt FROM auth.users`;
-          userCount = Number(authStats.cnt);
-        } catch {
-          /* auth schema may not exist */
+        if (authRuntime.mode !== "shared") {
+          try {
+            const [authStats] = await db`SELECT count(*) as cnt FROM auth.users`;
+            userCount = Number(authStats.cnt);
+          } catch {
+            /* auth schema may not exist */
+          }
         }
 
         return {
@@ -115,7 +128,13 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
               limit: 0,
               unit: "count",
             },
-            auth_users: { usage: userCount, limit: 0, unit: "count" },
+            auth_users: {
+              usage: authRuntime.mode === "shared" ? null : userCount,
+              limit: 0,
+              unit: "count",
+              source: authRuntime.mode === "shared" ? "supauth" : "local",
+              managed_by_ref: authRuntime.mode === "shared" ? authRuntime.authority_project_ref : null,
+            },
             tables: { usage: Number(tableCount.cnt), limit: 0, unit: "count" },
             connections: {
               usage: Number(connCount.cnt),
@@ -145,10 +164,22 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
   // Restart project
   .post(
     "/:ref/restart",
-    async ({ params, set }) => {
-      const restarted = await projectService.restartProject(params.ref);
-      if (!restarted) {
-        return status(404, { message: "Project not found", code: "404" });
+    async ({ params, request }) => {
+      const authRuntime = getAuthRuntimeDescriptor(params.ref);
+      const authError = authRuntime.mode === "owner"
+        ? await requireAdminAuth(request)
+        : await requireProjectOrAdminAuth(request, params.ref);
+      if (authError) return status(authError.status, authError.body);
+      try {
+        const restarted = await projectService.restartProject(params.ref);
+        if (!restarted) {
+          return status(404, { message: "Project not found", code: "404" });
+        }
+      } catch (error: unknown) {
+        return status(503, {
+          message: `Project restart failed: ${error instanceof Error ? error.message : String(error)}`,
+          code: "PROJECT_RESTART_FAILED",
+        });
       }
       return { ref: params.ref, message: "Project restart initiated" };
     },
@@ -207,6 +238,18 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
       const auth = await getAuthContext(request);
       if ("status" in auth) return status(auth.status, auth.body);
 
+      const authRuntime = getAuthRuntimeDescriptor(ref);
+      if (
+        authRuntime.mode === "owner"
+        && auth.role !== "admin"
+        && (service === "gotrue" || service === "auth")
+      ) {
+        return status(403, {
+          message: "Admin privileges required to control the SupAuth owner runtime",
+          code: "403",
+        });
+      }
+
       const validActions = ["start", "stop", "restart", "pause", "resume", "status"];
       if (!validActions.includes(action)) {
         set.status = 400;
@@ -220,6 +263,7 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
         postgrest: `supacloud-pgrst@${ref}`,
         rest: `supacloud-pgrst@${ref}`,
         gotrue: `supacloud-gotrue@${ref}`,
+        auth: `supacloud-gotrue@${ref}`,
         storage: "supacloud-storage",
       };
       const sharedUnitMap: Record<string, string> = {
@@ -232,6 +276,11 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
 
       if (auth.role === "project" && !(service in projectUnitMap)) {
         return status(403, { message: "Admin privileges required for shared services", code: "403" });
+      }
+
+      if (service === "gotrue" || service === "auth") {
+        const managedError = getAuthRuntimeManagedError(ref, "service_control");
+        if (managedError) return status(409, managedError);
       }
 
       if (service === "postgrest" || service === "rest") {

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -15,6 +15,7 @@ import {
 } from "../utils/project-auth";
 import { isOpaqueApiKey } from "../utils/api-keys";
 import { verifyProjectJwtPayload } from "../utils/project-jwt";
+import { getAuthRuntimeDescriptor } from "../services/auth-runtime.service";
 
 const MAX_ASYNC_BODY_BYTES = 256 * 1024;
 type SdkProxySql = (
@@ -269,27 +270,49 @@ export const sdkProxyInternals = {
     buildEncryptedBackgroundAuth,
 };
 
-async function translateOpaqueApiKeyHeaders(headers: Headers, ref: string): Promise<boolean> {
+async function getUpstreamApiKey(ref: string, role: "anon" | "service_role"): Promise<string | null> {
+    const keys = await projectService.getApiKeys(ref);
+    if (!keys) return null;
+    return role === "service_role" ? keys.service_role_key : keys.anon_key;
+}
+
+async function translateOpaqueApiKeyHeaders(
+    headers: Headers,
+    ref: string,
+    authAuthorityRef = ref,
+): Promise<boolean> {
     const apikey = headers.get("apikey")?.trim() || "";
     const authorization = headers.get("authorization")?.trim() || "";
     const bearerToken = authorization.replace(/^Bearer\s+/i, "");
-    const candidate = isOpaqueApiKey(apikey)
-        ? apikey
-        : isOpaqueApiKey(bearerToken)
-            ? bearerToken
-            : "";
-    if (!candidate) return true;
+    let rewrittenApiKey: string | null = null;
 
-    const resolved = await sdkProxyInternals.resolveProjectApiKey(candidate, { includeProvisioning: true });
-    if (!resolved || resolved.ref !== ref || !resolved.upstreamKey) return false;
+    const resolveUpstream = async (candidate: string): Promise<string | null | undefined> => {
+        if (!candidate) return undefined;
+        const resolved = await sdkProxyInternals.resolveProjectApiKey(candidate, { includeProvisioning: true });
+        if (!resolved) return isOpaqueApiKey(candidate) ? null : undefined;
+        if (resolved.ref !== ref || !resolved.upstreamKey) return null;
+        if (authAuthorityRef === ref) return resolved.upstreamKey;
+        // 从属项目只能借用 SupAuth owner 的匿名入口。绝不能把从属项目的
+        // service_role/secret 凭据升级为 owner 的全局管理员凭据。
+        if (resolved.role === "service_role") return null;
+        return getUpstreamApiKey(authAuthorityRef, resolved.role);
+    };
 
-    if (apikey === candidate) {
-        headers.set("apikey", resolved.upstreamKey);
+    if (apikey) {
+        const upstream = await resolveUpstream(apikey);
+        if (upstream === null) return false;
+        if (upstream) {
+            rewrittenApiKey = upstream;
+            headers.set("apikey", upstream);
+        }
     }
-    if (bearerToken === candidate) {
-        headers.set("authorization", `Bearer ${resolved.upstreamKey}`);
-    } else if (apikey === candidate && !authorization) {
-        headers.set("authorization", `Bearer ${resolved.upstreamKey}`);
+
+    if (bearerToken && (isOpaqueApiKey(bearerToken) || bearerToken === apikey)) {
+        const upstream = await resolveUpstream(bearerToken);
+        if (upstream === null) return false;
+        if (upstream) headers.set("authorization", `Bearer ${upstream}`);
+    } else if (rewrittenApiKey && !authorization) {
+        headers.set("authorization", `Bearer ${rewrittenApiKey}`);
     }
     return true;
 }
@@ -416,8 +439,10 @@ async function getTenantPorts(ref: string): Promise<{ gotruePort: number, pgrstP
 type ProxyInterceptors = {
     linkOrigin?: string;
     ref?: string;
+    upstreamRef?: string;
     host?: string;
     extraHeaders?: Record<string, string>;
+    authAuthorityRef?: string;
     timeoutMs?: number;
 };
 
@@ -430,7 +455,11 @@ async function executeProxy(request: Request, targetUrl: string, interceptors: P
         const body = ["GET", "HEAD"].includes(request.method) ? undefined : request.body;
         
         const reqHeaders = new Headers(request.headers);
-        if (!(await translateOpaqueApiKeyHeaders(reqHeaders, interceptors.ref || ""))) {
+        if (!(await translateOpaqueApiKeyHeaders(
+            reqHeaders,
+            interceptors.ref || "",
+            interceptors.authAuthorityRef,
+        ))) {
             return new Response(JSON.stringify({ message: "Invalid API key" }), {
                 status: 401,
                 headers: { "Content-Type": "application/json" },
@@ -452,7 +481,7 @@ async function executeProxy(request: Request, targetUrl: string, interceptors: P
         reqHeaders.set('x-forwarded-for', '127.0.0.1');
         
         if (interceptors.ref) {
-            reqHeaders.set('x-project-ref', interceptors.ref);
+            reqHeaders.set('x-project-ref', interceptors.upstreamRef || interceptors.ref);
         }
         if (interceptors.extraHeaders) {
             for (const [k, v] of Object.entries(interceptors.extraHeaders)) {
@@ -534,12 +563,19 @@ const sdkProxyRoutesBase = new Elysia({ prefix: "" })
         const handler = async ({ request }: any) => {
             const ref = await getProjectRef(request);
             if (!ref) return new Response(JSON.stringify({ message: 'Missing tenant reference' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
-            const ports = await getTenantPorts(ref);
+            const authAuthorityRef = getAuthRuntimeDescriptor(ref).authority_project_ref;
+            const ports = await getTenantPorts(authAuthorityRef);
             if (!ports) return new Response(JSON.stringify({ message: 'Tenant backend not active' }), { status: 502, headers: { 'Content-Type': 'application/json' } });
             
             const url = new URL(request.url);
             const targetUrl = `http://127.0.0.1:${ports.gotruePort}${url.pathname.replace(/^\/auth\/v1/, '')}${url.search}`;
-            return executeProxy(request, targetUrl, { linkOrigin: url.origin, ref, host: resolveProjectApiHost(ref, undefined) });
+            return executeProxy(request, targetUrl, {
+                linkOrigin: url.origin,
+                ref,
+                upstreamRef: authAuthorityRef,
+                authAuthorityRef,
+                host: resolveProjectApiHost(ref, undefined),
+            });
         };
         return app.get("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).post("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).put("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).patch("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).delete("/*", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).options("/*", handler)
                   .get("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).post("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).put("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).patch("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).delete("", handler, { detail: { tags: ["sdk-proxy"], summary: "Proxy Auth request" } }).options("", handler);

--- a/packages/management-api/src/services/auth-runtime.service.ts
+++ b/packages/management-api/src/services/auth-runtime.service.ts
@@ -1,0 +1,95 @@
+import { config } from "../config";
+
+export type AuthRuntimeMode = "local" | "owner" | "shared";
+export type AuthRuntimeManagement = "local" | "owner_only";
+
+export interface AuthRuntimeDescriptor {
+  project_ref: string;
+  mode: AuthRuntimeMode;
+  authority_project_ref: string;
+  owner_project_ref: string | null;
+  local_gotrue_enabled: boolean;
+  public_auth_route: "local_gotrue" | "owner_proxy";
+  user_management: AuthRuntimeManagement;
+  configuration_management: AuthRuntimeManagement;
+  local_membership_source: "project_database";
+  realtime_auth_supported: boolean;
+  owner_management_path: string | null;
+}
+
+export type AuthRuntimeManagedResource =
+  | "users"
+  | "providers"
+  | "configuration"
+  | "sso"
+  | "mfa"
+  | "oauth"
+  | "email_templates"
+  | "service_control";
+
+export function isSharedAuthRuntime(ref: string): boolean {
+  const ownerRef = config.authRuntimeOwnerRef.trim();
+  return ownerRef.length > 0 && ownerRef !== ref;
+}
+
+export function getAuthRuntimeDescriptor(ref: string): AuthRuntimeDescriptor {
+  const configuredOwnerRef = config.authRuntimeOwnerRef.trim() || null;
+  const mode: AuthRuntimeMode = configuredOwnerRef === null
+    ? "local"
+    : configuredOwnerRef === ref
+      ? "owner"
+      : "shared";
+  const shared = mode === "shared";
+
+  return {
+    project_ref: ref,
+    mode,
+    authority_project_ref: configuredOwnerRef ?? ref,
+    owner_project_ref: configuredOwnerRef,
+    local_gotrue_enabled: !shared,
+    public_auth_route: shared ? "owner_proxy" : "local_gotrue",
+    user_management: shared ? "owner_only" : "local",
+    configuration_management: shared ? "owner_only" : "local",
+    local_membership_source: "project_database",
+    realtime_auth_supported: !shared,
+    owner_management_path: shared && configuredOwnerRef
+      ? `/project/${configuredOwnerRef}/auth`
+      : null,
+  };
+}
+
+export function getAuthRuntimeManagedError(
+  ref: string,
+  resource: AuthRuntimeManagedResource,
+): Record<string, unknown> | null {
+  const runtime = getAuthRuntimeDescriptor(ref);
+  if (runtime.mode !== "shared") return null;
+
+  return {
+    code: "AUTH_RUNTIME_MANAGED_BY_OWNER",
+    message: `This project's ${resource} are managed by the SupAuth owner project. Local GoTrue is disabled for ${ref}.`,
+    project_ref: ref,
+    authority_project_ref: runtime.authority_project_ref,
+    owner_project_ref: runtime.owner_project_ref,
+    owner_management_path: runtime.owner_management_path,
+    public_auth_route: runtime.public_auth_route,
+    local_membership_source: runtime.local_membership_source,
+    realtime_auth_supported: runtime.realtime_auth_supported,
+  };
+}
+
+export function getAuthRuntimeOwnerProtectionError(
+  ref: string,
+  action: "pause" | "delete",
+): Record<string, unknown> | null {
+  const runtime = getAuthRuntimeDescriptor(ref);
+  if (runtime.mode !== "owner") return null;
+
+  return {
+    code: "AUTH_RUNTIME_OWNER_REQUIRED",
+    message: `Cannot ${action} the SupAuth owner project while SUPACLOUD_AUTH_RUNTIME_OWNER_REF points to ${ref}. Disable SupAuth or migrate dependents first.`,
+    project_ref: ref,
+    authority_project_ref: runtime.authority_project_ref,
+    required_operator_action: "disable_supauth_or_migrate_dependents",
+  };
+}

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -1082,10 +1082,25 @@ export class CaddyGatewayProvider implements GatewayProvider {
             const externalAuthUpstream = thirdPartyAuth.enabled && thirdPartyAuth.auth_endpoint_mode === "external" && thirdPartyAuth.auth_upstream
                 ? normalizeCustomUpstream(thirdPartyAuth.auth_upstream)
                 : null;
-            const authUpstream = externalAuthUpstream?.dial || `${hostIp}:${gotruePort}`;
+            let sharedAuthPort: number | null = null;
+            if (config.authRuntimeOwnerRef && config.authRuntimeOwnerRef !== projectRef) {
+                const [owner] = await sql`
+                    SELECT ref, config FROM projects
+                    WHERE ref=${config.authRuntimeOwnerRef} AND status='active' AND deleted_at IS NULL
+                `;
+                const ownerConfig = normalizeProjectConfig(owner?.config);
+                const port = Number(ownerConfig.gotrue_port);
+                if (!owner || !Number.isInteger(port) || port <= 0) {
+                    throw new Error(`shared auth runtime owner ${config.authRuntimeOwnerRef} is unavailable`);
+                }
+                sharedAuthPort = port;
+            }
+            const authUpstream = externalAuthUpstream?.dial || `${hostIp}:${sharedAuthPort ?? gotruePort}`;
             const authHeaders = externalAuthUpstream && thirdPartyAuth.auth_host_header
                 ? [`Host:${thirdPartyAuth.auth_host_header}`, `X-Forwarded-Host:${thirdPartyAuth.auth_host_header}`]
-                : undefined;
+                : sharedAuthPort !== null
+                    ? [`X-Project-Ref:${config.authRuntimeOwnerRef}`, `x-project-ref:${config.authRuntimeOwnerRef}`]
+                    : undefined;
             const hosts = uniqueStrings(resolveProjectApiHosts(projectRef, routingConfig));
             const hostSet = new Set(hosts.map(normalizeCaddyHost));
             const authHosts = uniqueStrings([resolveProjectAuthHost(projectRef, routingConfig)])

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -1095,12 +1095,17 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 }
                 sharedAuthPort = port;
             }
-            const authUpstream = externalAuthUpstream?.dial || `${hostIp}:${sharedAuthPort ?? gotruePort}`;
+            const sharedAuthProxy = sharedAuthPort !== null && !externalAuthUpstream;
+            const directAuthUpstream = externalAuthUpstream?.dial || `${hostIp}:${sharedAuthPort ?? gotruePort}`;
+            const authUpstream = sharedAuthProxy
+                ? `${hostIp}:${config.port}`
+                : directAuthUpstream;
             const authHeaders = externalAuthUpstream && thirdPartyAuth.auth_host_header
                 ? [`Host:${thirdPartyAuth.auth_host_header}`, `X-Forwarded-Host:${thirdPartyAuth.auth_host_header}`]
                 : sharedAuthPort !== null
                     ? [`X-Project-Ref:${config.authRuntimeOwnerRef}`, `x-project-ref:${config.authRuntimeOwnerRef}`]
                     : undefined;
+            const authProxyHeaders = sharedAuthProxy ? undefined : authHeaders;
             const hosts = uniqueStrings(resolveProjectApiHosts(projectRef, routingConfig));
             const hostSet = new Set(hosts.map(normalizeCaddyHost));
             const authHosts = uniqueStrings([resolveProjectAuthHost(projectRef, routingConfig)])
@@ -1155,8 +1160,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     path: "/auth/v1*",
                     upstream: authUpstream,
                     projectRef,
-                    stripPrefix: "/auth/v1",
-                    headers: authHeaders,
+                    stripPrefix: sharedAuthProxy ? undefined : "/auth/v1",
+                    headers: authProxyHeaders,
                     corsOrigins,
                     upstreamTls: externalAuthUpstream?.tls,
                     upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
@@ -1165,7 +1170,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     id: caddyRouteId(projectRef, "gotrue-well-known"),
                     hosts,
                     path: "/.well-known/oauth-authorization-server/auth/v1*",
-                    upstream: authUpstream,
+                    upstream: directAuthUpstream,
                     projectRef,
                     headers: authHeaders,
                     corsOrigins,
@@ -1244,8 +1249,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     path: "/auth/v1*",
                     upstream: authUpstream,
                     projectRef,
-                    stripPrefix: "/auth/v1",
-                    headers: authHeaders,
+                    stripPrefix: sharedAuthProxy ? undefined : "/auth/v1",
+                    headers: authProxyHeaders,
                     corsOrigins,
                     upstreamTls: externalAuthUpstream?.tls,
                     upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
@@ -1254,7 +1259,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     id: caddyRouteId(projectRef, "auth-domain-gotrue-well-known"),
                     hosts: authHosts,
                     path: "/.well-known/oauth-authorization-server/auth/v1*",
-                    upstream: authUpstream,
+                    upstream: directAuthUpstream,
                     projectRef,
                     headers: authHeaders,
                     corsOrigins,

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -579,6 +579,7 @@ export class ProjectService {
         `[ProjectService] Service restart partial failure for ${ref}`,
         { error: err },
       );
+      throw err;
     }
 
     return true;

--- a/packages/management-api/src/services/runtime-env.service.ts
+++ b/packages/management-api/src/services/runtime-env.service.ts
@@ -11,9 +11,11 @@ import {
 import { decryptSecretIfNeeded } from "../utils/secret-crypto";
 import { logger } from "../utils/logger";
 import {
+  buildSharedProjectJwtVerificationMaterial,
   normalizeProjectJwtKeys,
   resolveProjectJwtVerificationMaterial,
 } from "../utils/project-jwt";
+import { getAuthRuntimeDescriptor } from "./auth-runtime.service";
 
 function isJwtLike(value: string | null | undefined): value is string {
   return typeof value === "string" && value.split(".").length === 3;
@@ -46,11 +48,26 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
   const authConfig = (projectConfig.auth || {}) as Record<string, unknown>;
   const oauthServerConfig = (authConfig.oauth_server || {}) as Record<string, unknown>;
   const jwtKeys = normalizeProjectJwtKeys(oauthServerConfig.jwt_keys);
-  const jwtMaterial = resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret);
+  let jwtMaterial = resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret);
+  let authRoutingConfig = routingConfig;
+  const authRuntime = getAuthRuntimeDescriptor(projectRef);
+  if (authRuntime.mode === "shared") {
+    const owner = await projectRepository.findByRef(authRuntime.authority_project_ref);
+    if (!owner || !["active", "creating"].includes(String(owner.status).toLowerCase())) {
+      throw new Error(`Cannot find active SupAuth owner project ${authRuntime.authority_project_ref}`);
+    }
+    jwtMaterial = buildSharedProjectJwtVerificationMaterial({
+      projectJwtSecret: project.jwt_secret,
+      projectConfig: project.config,
+      ownerConfig: owner.config,
+    });
+    authRoutingConfig = normalizeProjectRoutingConfig(normalizeProjectConfig(owner.config));
+  }
   const jwtJwks = jwtMaterial.jwtJwks;
   const supabaseUrl = resolveProjectApiUrl(projectRef, routingConfig);
   const projectApiHost = resolveProjectApiHost(projectRef, routingConfig);
   const tenantPorts = resolveTenantPorts(routingConfig);
+  const authPorts = resolveTenantPorts(authRoutingConfig);
   const internalSupabaseUrl = internalSupabaseBaseUrl();
   const internalRestUrl = stripTrailingSlash(
     process.env.SUPACLOUD_INTERNAL_REST_URL ||
@@ -60,7 +77,7 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
   const internalAuthUrl = stripTrailingSlash(
     process.env.SUPACLOUD_INTERNAL_AUTH_URL ||
     process.env.INTERNAL_AUTH_URL ||
-    `${internalSupabaseUrl}/auth/v1`,
+    (authPorts ? localServiceBaseUrl(authPorts.gotruePort) : `${internalSupabaseUrl}/auth/v1`),
   );
 
   let serviceRoleKey = project.service_role_key;
@@ -100,18 +117,20 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
     ...(project.secret_key_encrypted ? {
       SUPABASE_SECRET_KEY: decryptSecretIfNeeded(project.secret_key_encrypted),
     } : {}),
-    JWT_SECRET: project.jwt_secret,
-    ...(jwtKeys ? { JWT_KEYS: JSON.stringify(jwtKeys) } : {}),
+    ...(authRuntime.mode === "shared" ? {} : { JWT_SECRET: project.jwt_secret }),
+    ...(authRuntime.mode !== "shared" && jwtKeys ? { JWT_KEYS: JSON.stringify(jwtKeys) } : {}),
     ...(jwtJwks ? { JWT_JWKS: JSON.stringify(jwtJwks) } : {}),
     ...(jwtMaterial.thirdParty ? {
       SUPACLOUD_THIRD_PARTY_JWT_POLICY: JSON.stringify(jwtMaterial.thirdParty),
     } : {}),
+    SUPACLOUD_AUTH_RUNTIME_MODE: authRuntime.mode,
+    SUPACLOUD_AUTH_AUTHORITY_REF: authRuntime.authority_project_ref,
     SUPACLOUD_INTERNAL_SUPABASE_URL: internalSupabaseUrl,
     SUPACLOUD_INTERNAL_AUTH_URL: internalAuthUrl,
     SUPACLOUD_INTERNAL_REST_URL: internalRestUrl,
     ...(tenantPorts ? {
       SUPACLOUD_INTERNAL_POSTGREST_PORT: String(tenantPorts.pgrstPort),
-      SUPACLOUD_INTERNAL_GOTRUE_PORT: String(tenantPorts.gotruePort),
+      SUPACLOUD_INTERNAL_GOTRUE_PORT: String(authPorts?.gotruePort || tenantPorts.gotruePort),
     } : {}),
     SUPACLOUD_PROJECT_REF: projectRef,
     SUPACLOUD_PROJECT_API_HOST: projectApiHost,

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -354,6 +354,24 @@ class TenantRuntimeService {
     private readonly postgrestController = new PostgrestRuntimeController();
     private readonly gotrueController = new GotrueRuntimeController();
 
+    private usesSharedAuthRuntime(ref: string): boolean {
+        return Boolean(config.authRuntimeOwnerRef && config.authRuntimeOwnerRef !== ref);
+    }
+
+    private async effectiveGoTruePort(ref: string, localPort: number): Promise<number> {
+        if (!this.usesSharedAuthRuntime(ref)) return localPort;
+        const [owner] = await metaSql`
+          SELECT ref, status, config FROM projects
+          WHERE ref=${config.authRuntimeOwnerRef} AND deleted_at IS NULL
+        `;
+        const ownerConfig = normalizeProjectConfig(owner?.config);
+        const ownerPort = pickPositivePort(ownerConfig.gotrue_port);
+        if (!owner || owner.status !== "active" || !ownerPort) {
+            throw new Error(`shared auth runtime owner ${config.authRuntimeOwnerRef} is unavailable`);
+        }
+        return ownerPort;
+    }
+
     // config.portRange is a string like "3100-3200". We just need the difference as the range size.
     private readonly PORT_RANGE = (() => {
         const parts = config.portRange.split('-');
@@ -693,6 +711,7 @@ class TenantRuntimeService {
         await fs.mkdir(this.TENANT_CONFIG_DIR, { recursive: true, mode: 0o711 });
         await fs.chmod(this.TENANT_CONFIG_DIR, 0o711);
 
+        const runtimeGoTruePort = await this.effectiveGoTruePort(ref, gotruePort);
         const creds = await this.getTenantCredentials(ref);
         for (const [name, value] of Object.entries({
             dbPassword: creds.dbPassword,
@@ -766,7 +785,7 @@ class TenantRuntimeService {
             renderSystemdEnvLine("SUPABASE_SECRET_KEY", String(creds.secretKey || "")),
             renderSystemdEnvLine("SUPABASE_DB_URL", edgeDbUri),
             renderSystemdEnvLine("JWT_SECRET", creds.jwtSecret),
-            renderTenantInternalRuntimeEnv(pgrstPort, gotruePort),
+            renderTenantInternalRuntimeEnv(pgrstPort, runtimeGoTruePort),
             jwtJwksEnv,
             jwtKeysEnv,
             thirdPartyJwtPolicyEnv,
@@ -813,6 +832,14 @@ db-channel = ${quoteTomlBasicString(resolvePgrstChannel(ref))}
             pgrstConf,
             runtimeUser,
         );
+
+        // 共享认证模式下从项目只使用主项目 GoTrue，不再生成本地认证运行时。
+        if (this.usesSharedAuthRuntime(ref)) {
+            await this.gotrueController.stopAndDisable(ref);
+            await this.persistTenantPortConfig(ref, pgrstPort, gotruePort);
+            logger.info(`Config generated for ${ref} with shared GoTrue owner ${config.authRuntimeOwnerRef}`);
+            return;
+        }
 
         // Generate GoTrue .env configuration
         const hasDedicatedAuthUrl = Boolean(creds.authUrl && creds.authUrl !== creds.apiUrl);
@@ -1634,8 +1661,10 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         await this.postgrestController.enable(ref);
         await this.postgrestController.start(ref);
 
-        await this.gotrueController.enable(ref);
-        await this.gotrueController.start(ref);
+        if (!this.usesSharedAuthRuntime(ref)) {
+            await this.gotrueController.enable(ref);
+            await this.gotrueController.start(ref);
+        }
 
         // Wait for service health checks
         logger.info(`Waiting for PostgREST(${pgrstPort}) and GoTrue(${gotruePort}) health checks...`);
@@ -1648,14 +1677,14 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 pgrstOk = status.health === "healthy";
             }
 
-            if (!gotrueOk) {
+            if (!gotrueOk && !this.usesSharedAuthRuntime(ref)) {
                 try {
                     const res = await fetch(`http://127.0.0.1:${gotruePort}/health`);
                     if (res.ok) gotrueOk = true;
                 } catch (e: unknown) { logger.debug("[services/tenant-runtime.service] suppressed error", { error: e instanceof Error ? e.message : String(e) }); }
             }
 
-            if (pgrstOk && gotrueOk) {
+            if (pgrstOk && (gotrueOk || this.usesSharedAuthRuntime(ref))) {
                 await this.setPostgrestDesiredState(ref, "running");
                 await this.recordPostgrestObservation(ref, {
                     actual: "running",
@@ -2159,6 +2188,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
     public async restartRuntime(ref: string): Promise<RuntimeStatus> {
         const pgrstActive = await this.postgrestController.isActive(ref);
         const gotrueActive = await this.gotrueController.isActive(ref);
+        const sharedAuthRuntime = this.usesSharedAuthRuntime(ref);
 
         if (pgrstActive || gotrueActive) {
             await this.ensureBinaries();
@@ -2169,7 +2199,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
             await this.generateTenantConfig(ref, pgrstPort, gotruePort);
 
             await this.postgrestController.restart(ref);
-            await this.gotrueController.restart(ref);
+            if (sharedAuthRuntime) await this.gotrueController.stopAndDisable(ref);
+            else await this.gotrueController.restart(ref);
 
             const postgrestStatus = await this.statusPostgrest(ref);
             await this.setPostgrestDesiredState(ref, "running");
@@ -2190,9 +2221,10 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         const gotrueActive = await this.gotrueController.isActive(ref);
 
         const port = await this.getTenantPort(ref, "pgrst");
-        const gotruePort = await this.getTenantPort(ref, "gotrue");
+        const localGoTruePort = await this.getTenantPort(ref, "gotrue");
+        const gotruePort = await this.effectiveGoTruePort(ref, localGoTruePort);
 
-        if (pgrstActive || gotrueActive) {
+        if (pgrstActive || gotrueActive || this.usesSharedAuthRuntime(ref)) {
             let pgrstOk = false;
             let gotrueOk = false;
 
@@ -2286,11 +2318,24 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 }
 
                 // --- GoTrue reconcile ---
+                const sharedAuthRuntime = this.usesSharedAuthRuntime(ref);
                 const gotrueActive = await this.gotrueController.isActive(ref);
                 const gotruePort = await this.getTenantPort(ref, "gotrue");
                 const gotrueObserved = await this.gotrueController.observe(ref, gotruePort);
 
                 if (desired === "running" && status === "active") {
+                    if (sharedAuthRuntime) {
+                        if (gotrueActive) await this.gotrueController.stopAndDisable(ref);
+                        await this.setPostgrestDesiredState(ref, desired);
+                        await this.recordPostgrestObservation(ref, {
+                            actual: actual.actual,
+                            health: actual.health,
+                            port: actual.port,
+                            last_error: actual.health === "healthy" ? null : actual.last_error,
+                        }, { reconciled: true });
+                        updated++;
+                        continue;
+                    }
                     // Active project: ensure GoTrue is running and healthy
                     if (!gotrueActive || gotrueObserved.health !== "healthy") {
                         // Ensure config exists before starting

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -10,6 +10,7 @@ import { tenantOAuthService } from "./tenant-oauth.service";
 import { resolveProjectApiUrl, resolveProjectAuthUrl, resolveProjectStudioUrl } from "../utils/project-routing";
 import { normalizeOAuthServerConfig, normalizeProjectConfig } from "../utils/project-config";
 import {
+    buildSharedProjectJwtVerificationMaterial,
     normalizeProjectJwtKeys,
     resolveProjectJwtVerificationMaterial,
     type ThirdPartyJwtPolicy,
@@ -32,6 +33,8 @@ import {
 } from "./tenant-runtime-config";
 import type { PostgresConnectionConfig } from "./tenant-runtime-config";
 import { decryptSecretIfNeeded } from "../utils/secret-crypto";
+import { getAuthRuntimeDescriptor, isSharedAuthRuntime } from "./auth-runtime.service";
+import { runtimeCacheService } from "./runtime-cache.service";
 
 export {
     renderGoTrueAuthEnv,
@@ -42,6 +45,11 @@ export {
 } from "./tenant-runtime-config";
 export type { GoTrueWebAuthnDefaults } from "./tenant-runtime-config";
 
+function quoteSqlLiteral(value: string): string {
+    assertSafeConfigValue("PostgreSQL literal", value);
+    return `'${value.replace(/'/g, "''")}'`;
+}
+
 export interface RuntimeStatus {
     status: "running" | "stopped" | "starting" | "error";
     port: number;
@@ -50,11 +58,6 @@ export interface RuntimeStatus {
 }
 
 export type RuntimeDesiredState = "running" | "stopped";
-
-function quoteSqlLiteral(value: string): string {
-    assertSafeConfigValue("PostgreSQL literal", value);
-    return `'${value.replace(/'/g, "''")}'`;
-}
 
 export interface PostgrestRuntimeStatus {
     component: "postgrest";
@@ -83,6 +86,9 @@ export interface ProjectServiceStatus {
     last_error?: string | null;
     updated_at?: string | null;
     last_reconciled_at?: string | null;
+    runtime_mode?: "local" | "owner" | "shared";
+    managed_by_ref?: string;
+    local_runtime_enabled?: boolean;
 }
 
 const POSTGREST_HEALTH_PATHS = ["/live", "/ready", "/"] as const;
@@ -354,12 +360,8 @@ class TenantRuntimeService {
     private readonly postgrestController = new PostgrestRuntimeController();
     private readonly gotrueController = new GotrueRuntimeController();
 
-    private usesSharedAuthRuntime(ref: string): boolean {
-        return Boolean(config.authRuntimeOwnerRef && config.authRuntimeOwnerRef !== ref);
-    }
-
     private async effectiveGoTruePort(ref: string, localPort: number): Promise<number> {
-        if (!this.usesSharedAuthRuntime(ref)) return localPort;
+        if (!isSharedAuthRuntime(ref)) return localPort;
         const [owner] = await metaSql`
           SELECT ref, status, config FROM projects
           WHERE ref=${config.authRuntimeOwnerRef} AND deleted_at IS NULL
@@ -387,6 +389,26 @@ class TenantRuntimeService {
 
     private deriveAuthUrl(ref: string, projectConfig: Record<string, unknown> | null | undefined): string {
         return resolveProjectAuthUrl(ref, projectConfig);
+    }
+
+    private async sharedAuthIssuer(ref: string): Promise<string | null> {
+        const runtime = getAuthRuntimeDescriptor(ref);
+        if (runtime.mode !== "shared") return null;
+        const [owner] = await metaSql`
+          SELECT config
+          FROM projects
+          WHERE ref=${runtime.authority_project_ref}
+            AND deleted_at IS NULL
+            AND lower(status) = 'active'
+          LIMIT 1
+        `;
+        if (!owner) throw new Error(`Cannot find active SupAuth owner project ${runtime.authority_project_ref}`);
+        const ownerConfig = normalizeProjectConfig(owner.config);
+        const ownerAuth = (ownerConfig.auth as Record<string, unknown>) || {};
+        const oauthServer = normalizeOAuthServerConfig(ownerAuth.oauth_server);
+        return typeof oauthServer.issuer === "string" && oauthServer.issuer.trim()
+            ? oauthServer.issuer.trim().replace(/\/+$/, "")
+            : `${this.deriveAuthUrl(runtime.authority_project_ref, ownerConfig)}/auth/v1`;
     }
 
     private async readPersistedTenantPort(ref: string, type: "pgrst" | "gotrue"): Promise<number | null> {
@@ -501,11 +523,36 @@ class TenantRuntimeService {
         const authConfig = (projectConfig.auth as Record<string, unknown>) || {};
         const oauthServerConfig = normalizeOAuthServerConfig(authConfig.oauth_server);
         const jwtKeys = stringifyJsonConfig(normalizeProjectJwtKeys(oauthServerConfig.jwt_keys));
-        const jwtMaterial = resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret);
-        const jwtJwks = stringifyJsonConfig(jwtMaterial.jwtJwks);
-        const localJwtIssuer = typeof oauthServerConfig.issuer === "string" && oauthServerConfig.issuer.trim()
+        let jwtMaterial = resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret);
+        let localJwtIssuer = typeof oauthServerConfig.issuer === "string" && oauthServerConfig.issuer.trim()
             ? oauthServerConfig.issuer.trim().replace(/\/+$/, "")
             : null;
+        const authRuntime = getAuthRuntimeDescriptor(ref);
+        if (authRuntime.mode === "shared") {
+            const [owner] = await metaSql`
+              SELECT config
+              FROM projects
+              WHERE ref=${authRuntime.authority_project_ref}
+                AND deleted_at IS NULL
+                AND lower(status) = 'active'
+              LIMIT 1
+            `;
+            if (!owner) {
+                throw new Error(`Cannot find active SupAuth owner project ${authRuntime.authority_project_ref}`);
+            }
+            const ownerConfig = normalizeProjectConfig(owner.config);
+            jwtMaterial = buildSharedProjectJwtVerificationMaterial({
+                projectJwtSecret: String(project.jwt_secret),
+                projectConfig: project.config,
+                ownerConfig: owner.config,
+            });
+            const ownerAuth = (ownerConfig.auth as Record<string, unknown>) || {};
+            const ownerOauthServer = normalizeOAuthServerConfig(ownerAuth.oauth_server);
+            localJwtIssuer = typeof ownerOauthServer.issuer === "string" && ownerOauthServer.issuer.trim()
+                ? ownerOauthServer.issuer.trim().replace(/\/+$/, "")
+                : `${this.deriveAuthUrl(authRuntime.authority_project_ref, ownerConfig)}/auth/v1`;
+        }
+        const jwtJwks = stringifyJsonConfig(jwtMaterial.jwtJwks);
         return {
             dbPassword: project.db_password,
             jwtSecret: project.jwt_secret,
@@ -757,13 +804,19 @@ class TenantRuntimeService {
             database: creds.dbName,
         });
 
+        const sharedAuthRuntime = isSharedAuthRuntime(ref);
         const jwtVerifierSecret = creds.jwtJwks || creds.jwtSecret;
         const jwtJwksEnv = creds.jwtJwks ? renderSystemdEnvLine("JWT_JWKS", creds.jwtJwks) : "";
         const jwtKeysEnv = creds.jwtKeys ? renderSystemdEnvLine("JWT_KEYS", creds.jwtKeys) : "";
         const thirdPartyJwtPolicyEnv = creds.thirdPartyJwtPolicy
             ? renderSystemdEnvLine("SUPACLOUD_THIRD_PARTY_JWT_POLICY", JSON.stringify(creds.thirdPartyJwtPolicy))
             : "";
-        const postgrestJwtAudience = creds.thirdPartyJwtPolicy?.audience[0] || "";
+        // Shared mode accepts both SupAuth owner tokens and an optional scoped
+        // third-party issuer. A single global jwt-aud would reject one side;
+        // the pre-request guard validates each issuer's audience instead.
+        const postgrestJwtAudience = sharedAuthRuntime
+            ? ""
+            : (creds.thirdPartyJwtPolicy?.audience[0] || "");
         const postgrestJwtAudienceConfig = postgrestJwtAudience
             ? `jwt-aud = ${quoteTomlBasicString(postgrestJwtAudience)}`
             : "";
@@ -784,10 +837,12 @@ class TenantRuntimeService {
             renderSystemdEnvLine("SUPABASE_PUBLISHABLE_KEY", String(creds.publishableKey || "")),
             renderSystemdEnvLine("SUPABASE_SECRET_KEY", String(creds.secretKey || "")),
             renderSystemdEnvLine("SUPABASE_DB_URL", edgeDbUri),
-            renderSystemdEnvLine("JWT_SECRET", creds.jwtSecret),
+            sharedAuthRuntime ? "" : renderSystemdEnvLine("JWT_SECRET", creds.jwtSecret),
+            renderSystemdEnvLine("SUPACLOUD_AUTH_RUNTIME_MODE", sharedAuthRuntime ? "shared" : "local"),
+            renderSystemdEnvLine("SUPACLOUD_AUTH_AUTHORITY_REF", getAuthRuntimeDescriptor(ref).authority_project_ref),
             renderTenantInternalRuntimeEnv(pgrstPort, runtimeGoTruePort),
             jwtJwksEnv,
-            jwtKeysEnv,
+            sharedAuthRuntime ? "" : jwtKeysEnv,
             thirdPartyJwtPolicyEnv,
         ].filter(Boolean).join("\n");
         await this.writeTenantSecretFile(
@@ -834,7 +889,7 @@ db-channel = ${quoteTomlBasicString(resolvePgrstChannel(ref))}
         );
 
         // 共享认证模式下从项目只使用主项目 GoTrue，不再生成本地认证运行时。
-        if (this.usesSharedAuthRuntime(ref)) {
+        if (sharedAuthRuntime) {
             await this.gotrueController.stopAndDisable(ref);
             await this.persistTenantPortConfig(ref, pgrstPort, gotruePort);
             logger.info(`Config generated for ${ref} with shared GoTrue owner ${config.authRuntimeOwnerRef}`);
@@ -1562,6 +1617,27 @@ GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgmq_public TO anon, authenticated, ser
         // runTenantPsqlOrThrow performs `throw new Error(`psql exited with code ...`)`.
         const dbName = await resolveDbName(ref);
         const connection = this.adminPsqlConnection(dbName);
+        const supauthIssuer = await this.sharedAuthIssuer(ref);
+        const issuerLiteral = supauthIssuer ? quoteSqlLiteral(supauthIssuer) : "NULL";
+        const thirdPartyIssuerBranch = thirdPartyPolicy
+            ? `ELSIF claims ->> 'iss' = ${quoteSqlLiteral(thirdPartyPolicy.issuer)} THEN\n    NULL;`
+            : "";
+        const sharedAuthGuard = supauthIssuer
+            ? `
+  IF claims ->> 'iss' = ${issuerLiteral} THEN
+    IF role_claim <> 'authenticated' THEN
+      RAISE insufficient_privilege USING MESSAGE = 'SupAuth owner tokens may only use the authenticated role';
+    END IF;
+  ${thirdPartyIssuerBranch}
+  ELSIF claims ->> 'iss' = 'supabase' THEN
+    IF role_claim NOT IN ('anon', 'service_role') THEN
+      RAISE insufficient_privilege USING MESSAGE = 'Dependent legacy user sessions are disabled while SupAuth is active';
+    END IF;
+  ELSE
+    RAISE insufficient_privilege USING MESSAGE = 'JWT issuer is not allowed for this SupAuth dependent project';
+  END IF;
+`
+            : "";
 
         const thirdPartyGate = thirdPartyPolicy
             ? `
@@ -1593,6 +1669,7 @@ GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA pgmq_public TO anon, authenticated, ser
   END IF;
 `.trimEnd()
             : "";
+
         const fnSql = `
 CREATE OR REPLACE FUNCTION public.set_request_context() RETURNS void AS $$
 DECLARE
@@ -1619,6 +1696,7 @@ BEGIN
 
 ${thirdPartyGate}
 
+${sharedAuthGuard}
   PERFORM set_config('request.jwt.claims', claims::text, true);
   PERFORM set_config('request.jwt.claim.sub', coalesce(claims ->> 'sub', ''), true);
   PERFORM set_config('request.jwt.claim.email', coalesce(claims ->> 'email', ''), true);
@@ -1661,7 +1739,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         await this.postgrestController.enable(ref);
         await this.postgrestController.start(ref);
 
-        if (!this.usesSharedAuthRuntime(ref)) {
+        if (!isSharedAuthRuntime(ref)) {
             await this.gotrueController.enable(ref);
             await this.gotrueController.start(ref);
         }
@@ -1677,14 +1755,14 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 pgrstOk = status.health === "healthy";
             }
 
-            if (!gotrueOk && !this.usesSharedAuthRuntime(ref)) {
+            if (!gotrueOk && !isSharedAuthRuntime(ref)) {
                 try {
                     const res = await fetch(`http://127.0.0.1:${gotruePort}/health`);
                     if (res.ok) gotrueOk = true;
                 } catch (e: unknown) { logger.debug("[services/tenant-runtime.service] suppressed error", { error: e instanceof Error ? e.message : String(e) }); }
             }
 
-            if (pgrstOk && (gotrueOk || this.usesSharedAuthRuntime(ref))) {
+            if (pgrstOk && (gotrueOk || isSharedAuthRuntime(ref))) {
                 await this.setPostgrestDesiredState(ref, "running");
                 await this.recordPostgrestObservation(ref, {
                     actual: "running",
@@ -2115,16 +2193,18 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         ref: string,
         mode: "studio" | "detail" = "studio",
     ): Promise<ProjectServiceStatus[]> {
+        const authRuntime = getAuthRuntimeDescriptor(ref);
+        const authRuntimeRef = authRuntime.authority_project_ref;
         const serviceDefs = mode === "studio"
             ? [
                 { id: "db", name: "db", unit: "patroni" },
-                { id: "auth", name: "auth", unit: `supacloud-gotrue@${ref}` },
+                { id: "auth", name: "auth", unit: `supacloud-gotrue@${authRuntimeRef}` },
                 { id: "realtime", name: "realtime", unit: "supacloud-realtime", container: "supacloud-realtime" },
                 { id: "storage", name: "storage", unit: "supacloud-storage" },
             ]
             : [
                 { id: "postgresql", name: "PostgreSQL", unit: "patroni" },
-                { id: "gotrue", name: "GoTrue", unit: `supacloud-gotrue@${ref}` },
+                { id: "gotrue", name: "GoTrue", unit: `supacloud-gotrue@${authRuntimeRef}` },
                 { id: "realtime", name: "Realtime", unit: "supacloud-realtime", container: "supacloud-realtime" },
                 { id: "storage", name: "Storage", unit: "supacloud-storage" },
                 {
@@ -2171,24 +2251,36 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 const serviceStatus = result?.status === "fulfilled" ? result.value : "INACTIVE";
                 return this.systemServiceEntry(ref, service.id, service.name, serviceStatus);
             });
+        const [rawAuthCandidate, ...remainingEntries] = otherEntries;
+        const authId = mode === "studio" ? "auth" : "gotrue";
+        const authName = mode === "studio" ? "auth" : "GoTrue";
+        const rawAuth = rawAuthCandidate ?? this.unhealthyService(ref, authId, authName);
+        const authEntry: ProjectServiceStatus = {
+            ...rawAuth,
+            service_host_ids: [`${authRuntimeRef}-${authId}`],
+            unit: `supacloud-gotrue@${authRuntimeRef}`,
+            runtime_mode: authRuntime.mode,
+            managed_by_ref: authRuntime.mode === "local" ? undefined : authRuntimeRef,
+            local_runtime_enabled: authRuntime.local_gotrue_enabled,
+        };
 
         if (mode === "studio") {
             const db = this.systemServiceEntry(ref, "db", "db", dbStatus);
             const storage = this.systemServiceEntry(ref, "storage", "storage", storageStatus);
-            const [auth, realtime] = otherEntries;
-            return [db, postgrestEntry, auth, realtime, storage];
+            const [realtime] = remainingEntries;
+            return [db, postgrestEntry, authEntry, realtime, storage];
         }
 
         const postgresql = this.systemServiceEntry(ref, "postgresql", "PostgreSQL", dbStatus);
         const storage = this.systemServiceEntry(ref, "storage", "Storage", storageStatus);
-        const [gotrue, realtime, gateway] = otherEntries;
-        return [postgresql, postgrestEntry, gotrue, realtime, storage, gateway];
+        const [realtime, gateway] = remainingEntries;
+        return [postgresql, postgrestEntry, authEntry, realtime, storage, gateway];
     }
 
     public async restartRuntime(ref: string): Promise<RuntimeStatus> {
         const pgrstActive = await this.postgrestController.isActive(ref);
         const gotrueActive = await this.gotrueController.isActive(ref);
-        const sharedAuthRuntime = this.usesSharedAuthRuntime(ref);
+        const sharedAuthRuntime = isSharedAuthRuntime(ref);
 
         if (pgrstActive || gotrueActive) {
             await this.ensureBinaries();
@@ -2210,9 +2302,56 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 port: postgrestStatus.port,
                 last_error: postgrestStatus.health === "healthy" ? null : "PostgREST health check did not become healthy after runtime restart",
             });
-            return await this.checkStatus(ref);
+            const status = await this.checkStatus(ref);
+            if (!sharedAuthRuntime && getAuthRuntimeDescriptor(ref).mode === "owner") {
+                await this.refreshSharedAuthDependents(ref);
+            }
+            return status;
         } else {
-            return await this.startRuntime(ref);
+            const status = await this.startRuntime(ref);
+            if (!sharedAuthRuntime && getAuthRuntimeDescriptor(ref).mode === "owner") {
+                await this.refreshSharedAuthDependents(ref);
+            }
+            return status;
+        }
+    }
+
+    private async refreshSharedAuthDependents(ownerRef: string): Promise<void> {
+        const dependents = await metaSql`
+          SELECT ref
+          FROM projects
+          WHERE ref <> ${ownerRef}
+            AND deleted_at IS NULL
+            AND lower(status) IN ('active', 'creating')
+        `;
+        const failures: string[] = [];
+        for (const dependent of dependents) {
+            const ref = String(dependent.ref || "");
+            if (!ref) continue;
+            try {
+                const pgrstPort = await this.getTenantPort(ref, "pgrst");
+                const gotruePort = await this.getTenantPort(ref, "gotrue");
+                await this.generateTenantConfig(ref, pgrstPort, gotruePort);
+                const jwtPolicy = await this.getTenantCredentials(ref);
+                await this.ensurePostgrestPrerequest(
+                    ref,
+                    jwtPolicy.thirdPartyJwtPolicy,
+                    jwtPolicy.localJwtIssuer,
+                );
+                await runtimeCacheService.invalidateProjectRuntimeEnv(ref);
+                if (await this.postgrestController.isActive(ref)) {
+                    await this.postgrestController.restart(ref);
+                }
+            } catch (error: unknown) {
+                failures.push(ref);
+                logger.error(`[TenantRuntime] Failed to refresh shared auth dependent ${ref}`, {
+                    ownerRef,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+        }
+        if (failures.length > 0) {
+            throw new Error(`Failed to refresh SupAuth dependents: ${failures.join(", ")}`);
         }
     }
 
@@ -2224,7 +2363,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         const localGoTruePort = await this.getTenantPort(ref, "gotrue");
         const gotruePort = await this.effectiveGoTruePort(ref, localGoTruePort);
 
-        if (pgrstActive || gotrueActive || this.usesSharedAuthRuntime(ref)) {
+        if (pgrstActive || gotrueActive || isSharedAuthRuntime(ref)) {
             let pgrstOk = false;
             let gotrueOk = false;
 
@@ -2318,7 +2457,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 }
 
                 // --- GoTrue reconcile ---
-                const sharedAuthRuntime = this.usesSharedAuthRuntime(ref);
+                const sharedAuthRuntime = isSharedAuthRuntime(ref);
                 const gotrueActive = await this.gotrueController.isActive(ref);
                 const gotruePort = await this.getTenantPort(ref, "gotrue");
                 const gotrueObserved = await this.gotrueController.observe(ref, gotruePort);

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -11,7 +11,12 @@ import {
   type JWTPayload,
 } from "jose";
 import { sql as metaSql } from "../db";
-import { normalizeProjectConfig, normalizeThirdPartyAuthConfig } from "./project-config";
+import {
+  normalizeOAuthServerConfig,
+  normalizeProjectConfig,
+  normalizeThirdPartyAuthConfig,
+} from "./project-config";
+import { getAuthRuntimeDescriptor } from "../services/auth-runtime.service";
 
 export type OidcJwtKeyMaterial = {
   key_id: string;
@@ -139,6 +144,17 @@ export function normalizeProjectJwtJwks(value: unknown): { keys: JWK[] } | null 
   const keys = (parsed as { keys?: unknown }).keys;
   if (!Array.isArray(keys) || keys.length === 0) return null;
   return { keys: keys as JWK[] };
+}
+
+export function extractJwtJwksFromConfig(config: unknown): { keys: JWK[] } | null {
+  const projectConfig = normalizeProjectConfig(config);
+  const auth = (projectConfig.auth || {}) as Record<string, unknown>;
+  const oauthServer = (auth.oauth_server || {}) as Record<string, unknown>;
+  try {
+    return normalizeProjectJwtJwks(oauthServer.jwt_jwks);
+  } catch {
+    return null;
+  }
 }
 
 function jwkIdentity(key: JWK): string {
@@ -292,6 +308,66 @@ export function resolveProjectJwtVerificationMaterial(
   };
 }
 
+function publicAsymmetricKeys(jwks: { keys: JWK[] } | null): JWK[] {
+  return (jwks?.keys || [])
+    .filter((key) =>
+      ((key.kty === "EC" && key.alg === "ES256") || (key.kty === "RSA" && key.alg === "RS256"))
+      && typeof key.d !== "string"
+    )
+    .map((key) => {
+      const publicKey = { ...key } as JWK & Record<string, unknown>;
+      for (const field of ["d", "p", "q", "dp", "dq", "qi", "oth", "aws:kms:arn"]) {
+        delete publicKey[field];
+      }
+      publicKey.key_ops = ["verify"];
+      return publicKey;
+    });
+}
+
+export function buildSharedProjectJwtVerificationMaterial(input: {
+  projectJwtSecret: string;
+  projectConfig: unknown;
+  ownerConfig: unknown;
+}): ProjectJwtVerificationMaterial {
+  const ownerConfig = normalizeProjectConfig(input.ownerConfig);
+  const ownerAuth = (ownerConfig.auth || {}) as Record<string, unknown>;
+  const ownerOauthServer = normalizeOAuthServerConfig(ownerAuth.oauth_server);
+  const signingAlg = ownerOauthServer.signing_alg;
+  const ownerSigningKeys = normalizeProjectJwtKeys(ownerOauthServer.jwt_keys);
+  const signingEnabled = ownerOauthServer.enabled === true
+    && (signingAlg === "ES256" || signingAlg === "RS256")
+    && ownerSigningKeys?.some((key) => key.alg === signingAlg);
+  const ownerKeys = publicAsymmetricKeys(extractJwtJwksFromConfig(ownerConfig));
+  if (!signingEnabled || ownerKeys.length === 0) {
+    throw new Error(
+      "SupAuth owner must enable asymmetric ES256 or RS256 JWT signing before dependent projects can use shared authentication",
+    );
+  }
+
+  // SupAuth shared mode has a single authentication authority. A dependent's
+  // third-party issuer is intentionally not admitted into the shared verifier:
+  // PostgREST cannot bind a payload issuer to the key that verified it, so
+  // mixing external keys with owner/legacy keys would create an issuer-confusion
+  // path. Third-party auth remains available in local/owner mode.
+  const thirdParty: ThirdPartyJwtPolicy | null = null;
+  const localJwks = { keys: ownerKeys };
+  const jwtJwks = mergeVerificationJwks([
+    [buildLegacyHs256Jwk(input.projectJwtSecret)],
+    ownerKeys,
+  ]);
+  if (!jwtJwks) throw new Error("SupAuth shared JWT verification material is empty");
+
+  return { jwtJwks, localJwks, thirdParty };
+}
+
+export function buildSharedProjectJwtVerifierJwks(input: {
+  projectJwtSecret: string;
+  projectConfig: unknown;
+  ownerConfig: unknown;
+}): { keys: JWK[] } {
+  return buildSharedProjectJwtVerificationMaterial(input).jwtJwks!;
+}
+
 /**
  * Resolve every public key accepted by a project's runtime JWT consumers.
  *
@@ -442,7 +518,7 @@ export async function verifyProjectJwtPayload(
   const cleanToken = token.replace(/^Bearer\s+/i, "");
   const [project] = options.includeProvisioning
     ? await metaSql`
-      SELECT jwt_secret, service_role_key, config
+      SELECT jwt_secret, anon_key, service_role_key, config
       FROM projects
       WHERE ref = ${ref}
         AND deleted_at IS NULL
@@ -450,7 +526,7 @@ export async function verifyProjectJwtPayload(
       LIMIT 1
     `
     : await metaSql`
-      SELECT jwt_secret, service_role_key, config
+      SELECT jwt_secret, anon_key, service_role_key, config
       FROM projects
       WHERE ref = ${ref}
         AND deleted_at IS NULL
@@ -465,9 +541,27 @@ export async function verifyProjectJwtPayload(
   const payload = decodeJwtPart(parts[1]);
   if (!header || !payload || typeof header.alg !== "string") return null;
 
+  const authRuntime = getAuthRuntimeDescriptor(ref);
   let material: ProjectJwtVerificationMaterial;
   try {
-    material = resolveProjectJwtVerificationMaterial(project.config, String(project.jwt_secret));
+    if (authRuntime.mode === "shared") {
+      const [owner] = await metaSql`
+        SELECT config
+        FROM projects
+        WHERE ref = ${authRuntime.authority_project_ref}
+          AND deleted_at IS NULL
+          AND lower(status) = 'active'
+        LIMIT 1
+      `;
+      if (!owner) return null;
+      material = buildSharedProjectJwtVerificationMaterial({
+        projectJwtSecret: String(project.jwt_secret),
+        projectConfig: project.config,
+        ownerConfig: owner.config,
+      });
+    } else {
+      material = resolveProjectJwtVerificationMaterial(project.config, String(project.jwt_secret));
+    }
   } catch {
     return null;
   }
@@ -477,7 +571,14 @@ export async function verifyProjectJwtPayload(
     result = await verifyThirdPartyJwt(cleanToken, material.thirdParty);
   } else {
     result = await verifyLocalAsymmetricJwt(cleanToken, material.localJwks);
-    if (!result) {
+    if (result && authRuntime.mode === "shared" && result.payload.role !== "authenticated") {
+      return null;
+    }
+    if (!result && authRuntime.mode === "shared") {
+      const isLegacyApiKey = cleanToken === project.anon_key || cleanToken === project.service_role_key;
+      if (!isLegacyApiKey) return null;
+      result = await verifyLegacyHs256Jwt(cleanToken, String(project.jwt_secret), header);
+    } else if (!result) {
       result = await verifyLegacyHs256Jwt(cleanToken, String(project.jwt_secret), header);
     }
   }

--- a/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { config } from "../../src/config";
+import { projectConfigRoutes } from "../../src/routes/project-config";
+import { projectService } from "../../src/services";
+
+const app = new Elysia().use(projectConfigRoutes);
+const authHeaders = { Authorization: "Bearer dev-master-token" };
+const originalOwnerRef = config.authRuntimeOwnerRef;
+const originalGetProjectSettings = projectService.getProjectSettings;
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(new Request(`http://localhost${path}`, {
+    ...init,
+    headers: { ...authHeaders, ...(init.headers || {}) },
+  }));
+}
+
+afterEach(() => {
+  config.authRuntimeOwnerRef = originalOwnerRef;
+  projectService.getProjectSettings = originalGetProjectSettings;
+});
+
+describe("SupAuth auth config boundary", () => {
+  test("requires authentication for auth config reads", async () => {
+    const response = await app.handle(new Request("http://localhost/v1/projects/tenant-a/config/auth"));
+    expect(response.status).toBe(401);
+  });
+
+  test("blocks dependent auth config reads and writes", async () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+
+    const getResponse = await request("/v1/projects/tenant-a/config/auth");
+    expect(getResponse.status).toBe(409);
+    expect((await getResponse.json()).code).toBe("AUTH_RUNTIME_MANAGED_BY_OWNER");
+
+    const patchResponse = await request("/v1/projects/tenant-a/config/auth", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ EXTERNAL_EMAIL_ENABLED: false }),
+    });
+    expect(patchResponse.status).toBe(409);
+  });
+
+  test("allowlists owner auth config fields and masks hook secrets", async () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+    projectService.getProjectSettings = async () => ({
+      auth: {
+        jwt_secret: "must-not-leak",
+        hooks: {
+          custom_access_token_hook: {
+            enabled: true,
+            uri: "pg-functions://postgrest/auth_hook",
+            secrets: "must-mask",
+          },
+        },
+        smtp: { pass: "must-mask" },
+        saml: { private_key: "must-not-leak" },
+      },
+    } as never);
+
+    const response = await request("/v1/projects/auth-owner/config/auth");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.jwt_secret).toBeUndefined();
+    expect(body.saml).toBeUndefined();
+    expect(body.hook_custom_access_token_secrets).toBe("********");
+    expect(body.smtp_pass).toBe("********");
+  });
+});

--- a/packages/management-api/tests/unit/auth-runtime.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-runtime.routes.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Elysia } from "elysia";
+import { config } from "../../src/config";
+import { authRuntimeRoutes } from "../../src/routes/auth-runtime";
+import { userManagementRoutes } from "../../src/routes/auth-users";
+import { projectServiceRoutes } from "../../src/routes/project-services";
+import { projectService } from "../../src/services";
+
+const app = new Elysia()
+  .use(authRuntimeRoutes)
+  .use(userManagementRoutes)
+  .use(projectServiceRoutes);
+const authHeaders = { Authorization: "Bearer dev-master-token" };
+const originalOwnerRef = config.authRuntimeOwnerRef;
+const originalGetProject = projectService.getProject;
+const originalRestartProject = projectService.restartProject;
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(
+    new Request(`http://localhost${path}`, {
+      ...init,
+      headers: { ...authHeaders, ...(init.headers || {}) },
+    }),
+  );
+}
+
+afterEach(() => {
+  config.authRuntimeOwnerRef = originalOwnerRef;
+  projectService.getProject = originalGetProject;
+  projectService.restartProject = originalRestartProject;
+});
+
+describe("SupAuth management boundaries", () => {
+  test("reports owner and dependent runtime modes", async () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+    projectService.getProject = async (ref: string) => ({ ref }) as never;
+
+    const ownerResponse = await request("/v1/projects/auth-owner/auth/runtime");
+    const owner = await ownerResponse.json();
+    expect(ownerResponse.status).toBe(200);
+    expect(owner.mode).toBe("owner");
+    expect(owner.local_gotrue_enabled).toBe(true);
+
+    const dependentResponse = await request("/v1/projects/tenant-a/auth/runtime");
+    const dependent = await dependentResponse.json();
+    expect(dependentResponse.status).toBe(200);
+    expect(dependent.mode).toBe("shared");
+    expect(dependent.authority_project_ref).toBe("auth-owner");
+    expect(dependent.public_auth_route).toBe("owner_proxy");
+    expect(dependent.local_gotrue_enabled).toBe(false);
+  });
+
+  test("blocks dependent Studio user management before contacting GoTrue", async () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+
+    const response = await request("/v1/projects/tenant-a/auth/users");
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("AUTH_RUNTIME_MANAGED_BY_OWNER");
+    expect(body.authority_project_ref).toBe("auth-owner");
+    expect(body.owner_management_path).toBe("/project/auth-owner/auth");
+  });
+
+  test("blocks dependent GoTrue service control", async () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+
+    const response = await request("/v1/projects/tenant-a/services/gotrue/restart", {
+      method: "POST",
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("AUTH_RUNTIME_MANAGED_BY_OWNER");
+    expect(body.public_auth_route).toBe("owner_proxy");
+  });
+
+  test("reports owner restart fan-out failures instead of returning success", async () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+    projectService.restartProject = async () => {
+      throw new Error("dependent refresh failed");
+    };
+
+    const response = await request("/v1/projects/auth-owner/restart", { method: "POST" });
+    const body = await response.json();
+    expect(response.status).toBe(503);
+    expect(body.code).toBe("PROJECT_RESTART_FAILED");
+    expect(body.message).toContain("dependent refresh failed");
+  });
+});

--- a/packages/management-api/tests/unit/auth-runtime.service.test.ts
+++ b/packages/management-api/tests/unit/auth-runtime.service.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { config } from "../../src/config";
+import {
+  getAuthRuntimeDescriptor,
+  getAuthRuntimeManagedError,
+  getAuthRuntimeOwnerProtectionError,
+  isSharedAuthRuntime,
+} from "../../src/services/auth-runtime.service";
+
+const originalOwnerRef = config.authRuntimeOwnerRef;
+
+afterEach(() => {
+  config.authRuntimeOwnerRef = originalOwnerRef;
+});
+
+describe("SupAuth runtime ownership", () => {
+  test("keeps every project local when no owner is configured", () => {
+    config.authRuntimeOwnerRef = "";
+
+    expect(isSharedAuthRuntime("tenant-a")).toBe(false);
+    expect(getAuthRuntimeDescriptor("tenant-a")).toEqual({
+      project_ref: "tenant-a",
+      mode: "local",
+      authority_project_ref: "tenant-a",
+      owner_project_ref: null,
+      local_gotrue_enabled: true,
+      public_auth_route: "local_gotrue",
+      user_management: "local",
+      configuration_management: "local",
+      local_membership_source: "project_database",
+      realtime_auth_supported: true,
+      owner_management_path: null,
+    });
+  });
+
+  test("keeps the SupAuth owner local and makes dependent projects shared", () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+
+    expect(isSharedAuthRuntime("auth-owner")).toBe(false);
+    const owner = getAuthRuntimeDescriptor("auth-owner");
+    expect(owner.mode).toBe("owner");
+    expect(owner.owner_project_ref).toBe("auth-owner");
+    expect(owner.local_gotrue_enabled).toBe(true);
+    expect(owner.user_management).toBe("local");
+
+    const dependent = getAuthRuntimeDescriptor("tenant-a");
+    expect(dependent.mode).toBe("shared");
+    expect(dependent.authority_project_ref).toBe("auth-owner");
+    expect(dependent.local_gotrue_enabled).toBe(false);
+    expect(dependent.public_auth_route).toBe("owner_proxy");
+    expect(dependent.user_management).toBe("owner_only");
+    expect(dependent.configuration_management).toBe("owner_only");
+    expect(dependent.realtime_auth_supported).toBe(false);
+    expect(dependent.owner_management_path).toBe("/project/auth-owner/auth");
+  });
+
+  test("returns a structured conflict for dependent project management", () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+
+    expect(getAuthRuntimeManagedError("auth-owner", "users")).toBeNull();
+    expect(getAuthRuntimeManagedError("tenant-a", "users")).toEqual({
+      code: "AUTH_RUNTIME_MANAGED_BY_OWNER",
+      message: "This project's users are managed by the SupAuth owner project. Local GoTrue is disabled for tenant-a.",
+      project_ref: "tenant-a",
+      authority_project_ref: "auth-owner",
+      owner_project_ref: "auth-owner",
+      owner_management_path: "/project/auth-owner/auth",
+      public_auth_route: "owner_proxy",
+      local_membership_source: "project_database",
+      realtime_auth_supported: false,
+    });
+  });
+
+  test("protects the configured owner from pause and deletion", () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+    expect(getAuthRuntimeOwnerProtectionError("tenant-a", "pause")).toBeNull();
+    expect(getAuthRuntimeOwnerProtectionError("auth-owner", "pause")).toMatchObject({
+      code: "AUTH_RUNTIME_OWNER_REQUIRED",
+      required_operator_action: "disable_supauth_or_migrate_dependents",
+    });
+    expect(getAuthRuntimeOwnerProtectionError("auth-owner", "delete")?.message).toContain("Cannot delete");
+  });
+});

--- a/packages/management-api/tests/unit/project-jwt.shared.test.ts
+++ b/packages/management-api/tests/unit/project-jwt.shared.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { createLocalJWKSet, exportJWK, generateKeyPair, jwtVerify, SignJWT } from "jose";
+import {
+  buildSharedProjectJwtVerificationMaterial,
+  buildSharedProjectJwtVerifierJwks,
+} from "../../src/utils/project-jwt";
+
+describe("SupAuth shared JWT verifier material", () => {
+  test("keeps dependent legacy API-key verification and owner public asymmetric keys only", () => {
+    const jwks = buildSharedProjectJwtVerifierJwks({
+      projectJwtSecret: "dependent-secret-with-at-least-32-characters",
+      projectConfig: {
+        auth: {
+          oauth_server: {
+            jwt_jwks: { keys: [{ kty: "EC", kid: "dependent-old-user-key", alg: "ES256", x: "x", y: "y", crv: "P-256" }] },
+          },
+        },
+      },
+      ownerConfig: {
+        auth: {
+          oauth_server: {
+            enabled: true,
+            signing_alg: "ES256",
+            jwt_keys: [{ kty: "EC", kid: "owner-user-key", alg: "ES256", d: "private", x: "owner-x", y: "owner-y", crv: "P-256" }],
+            jwt_jwks: {
+              keys: [
+                { kty: "EC", kid: "owner-user-key", alg: "ES256", x: "owner-x", y: "owner-y", crv: "P-256" },
+                { kty: "oct", kid: "legacy-hs256", alg: "HS256", k: "owner-secret" },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(jwks.keys.some((key) => key.kty === "oct" && key.kid === "legacy-hs256")).toBe(true);
+    expect(jwks.keys.some((key) => key.kid === "owner-user-key" && key.key_ops?.includes("verify"))).toBe(true);
+    expect(jwks.keys.some((key) => key.kid === "dependent-old-user-key")).toBe(false);
+    expect(jwks.keys.some((key) => key.kty === "oct" && key.k === "owner-secret")).toBe(false);
+  });
+
+  test("rejects HS256-only SupAuth owners", () => {
+    expect(() => buildSharedProjectJwtVerifierJwks({
+      projectJwtSecret: "dependent-secret-with-at-least-32-characters",
+      projectConfig: {},
+      ownerConfig: {
+        auth: {
+          oauth_server: {
+            enabled: true,
+            signing_alg: "HS256",
+            jwt_jwks: { keys: [{ kty: "oct", kid: "legacy-hs256", alg: "HS256", k: "owner-secret" }] },
+          },
+        },
+      },
+    })).toThrow("must enable asymmetric ES256 or RS256 JWT signing");
+  });
+
+  test("excludes dependent third-party trust material while SupAuth is shared", () => {
+    const material = buildSharedProjectJwtVerificationMaterial({
+      projectJwtSecret: "dependent-secret-with-at-least-32-characters",
+      projectConfig: {
+        auth: {
+          third_party_auth: {
+            enabled: true,
+            issuer: "https://business-auth.example.com/auth/v1",
+            audience: "authenticated",
+            client_id: "business-client",
+            jwt_jwks: {
+              keys: [{
+                kty: "EC",
+                kid: "business-user-key",
+                alg: "ES256",
+                crv: "P-256",
+                x: "business-x",
+                y: "business-y",
+                key_ops: ["verify"],
+              }],
+            },
+          },
+        },
+      },
+      ownerConfig: {
+        auth: {
+          oauth_server: {
+            enabled: true,
+            signing_alg: "ES256",
+            jwt_keys: [{ kty: "EC", kid: "owner-user-key", alg: "ES256", d: "private" }],
+            jwt_jwks: {
+              keys: [{ kty: "EC", kid: "owner-user-key", alg: "ES256", crv: "P-256", x: "owner-x", y: "owner-y" }],
+            },
+          },
+        },
+      },
+    });
+
+    expect(material.jwtJwks?.keys.map((key) => key.kid)).toEqual([
+      "legacy-hs256",
+      "owner-user-key",
+    ]);
+    expect(material.thirdParty).toBeNull();
+    expect(material.jwtJwks?.keys.some((key) => key.kid === "business-user-key")).toBe(false);
+  });
+
+  test("does not let an external key forge dependent service-role claims", async () => {
+    const ownerPair = await generateKeyPair("ES256", { extractable: true });
+    const ownerPublic = await exportJWK(ownerPair.publicKey);
+    const ownerPrivate = await exportJWK(ownerPair.privateKey);
+    const externalPair = await generateKeyPair("ES256", { extractable: true });
+    const externalPublic = await exportJWK(externalPair.publicKey);
+    const externalPrivate = await exportJWK(externalPair.privateKey);
+    const material = buildSharedProjectJwtVerificationMaterial({
+      projectJwtSecret: "dependent-secret-with-at-least-32-characters",
+      projectConfig: {
+        auth: {
+          third_party_auth: {
+            enabled: true,
+            issuer: "https://business-auth.example.com/auth/v1",
+            audience: "business-audience",
+            client_id: "business-client",
+            jwt_jwks: {
+              keys: [{ ...externalPublic, kid: "external-key", alg: "ES256", use: "sig", key_ops: ["verify"] }],
+            },
+          },
+        },
+      },
+      ownerConfig: {
+        auth: {
+          oauth_server: {
+            enabled: true,
+            signing_alg: "ES256",
+            jwt_keys: [{ ...ownerPrivate, kid: "owner-key", alg: "ES256", use: "sig", key_ops: ["sign"] }],
+            jwt_jwks: {
+              keys: [{ ...ownerPublic, kid: "owner-key", alg: "ES256", use: "sig", key_ops: ["verify"] }],
+            },
+          },
+        },
+      },
+    });
+    const forged = await new SignJWT({ iss: "supabase", role: "service_role" })
+      .setProtectedHeader({ alg: "ES256", kid: "external-key" })
+      .setExpirationTime("5m")
+      .sign(await crypto.subtle.importKey(
+        "jwk",
+        { ...externalPrivate, kid: "external-key", alg: "ES256", use: "sig" },
+        { name: "ECDSA", namedCurve: "P-256" },
+        false,
+        ["sign"],
+      ));
+
+    let rejected = false;
+    try {
+      await jwtVerify(forged, createLocalJWKSet(material.jwtJwks!));
+    } catch {
+      rejected = true;
+    }
+    expect(rejected).toBe(true);
+  });
+});

--- a/packages/management-api/tests/unit/runtime-env.service.test.ts
+++ b/packages/management-api/tests/unit/runtime-env.service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import { runtimeEnvService } from "../../src/services/runtime-env.service";
 import { projectRepository } from "../../src/repositories/project.repository";
 import { databaseService } from "../../src/services/database.service";
+import { config } from "../../src/config";
 
 describe("runtimeEnvService", () => {
   test("includes project JWKS for Bun Edge Runtime JWT verification", async () => {
@@ -147,6 +148,93 @@ describe("runtimeEnvService", () => {
         clientId: "business-client",
       });
     } finally {
+      findByRefSpy.mockRestore();
+      secretsSpy.mockRestore();
+    }
+  });
+
+  test("uses owner public JWKS and GoTrue port without exposing dependent signing secrets", async () => {
+    const originalOwnerRef = config.authRuntimeOwnerRef;
+    config.authRuntimeOwnerRef = "auth-owner";
+    const dependent = {
+      id: "dependent-id",
+      ref: "proj_1",
+      name: "Dependent",
+      db_name: "supa_proj_1",
+      db_user: "role_proj_1",
+      db_password: "pw",
+      jwt_secret: "dependent-secret-with-at-least-32-characters",
+      anon_key: "anon.header.signature",
+      service_role_key: "service.header.signature",
+      s3_bucket: "bucket",
+      s3_access_key: null,
+      s3_secret_key: null,
+      region: "local",
+      status: "active",
+      organization_id: "org_1",
+      config: {
+        postgrest_port: 3272,
+        gotrue_port: 4272,
+        auth: {
+          third_party_auth: {
+            enabled: true,
+            issuer: "https://business-auth.example.com/auth/v1",
+            audience: "business-audience",
+            client_id: "business-client",
+            jwt_jwks: {
+              keys: [{ kty: "EC", kid: "business-user-key", alg: "ES256", crv: "P-256", x: "business-x", y: "business-y" }],
+            },
+          },
+          oauth_server: {
+            jwt_keys: [{ kty: "EC", kid: "dependent-private", alg: "ES256", d: "private" }],
+          },
+        },
+      },
+      created_at: new Date(),
+      updated_at: new Date(),
+      deleted_at: null,
+    };
+    const owner = {
+      ...dependent,
+      id: "owner-id",
+      ref: "auth-owner",
+      name: "Auth Owner",
+      jwt_secret: "owner-secret-with-at-least-32-characters",
+      config: {
+        postgrest_port: 3372,
+        gotrue_port: 9372,
+        auth: {
+          oauth_server: {
+            enabled: true,
+            signing_alg: "ES256",
+            jwt_keys: [{ kty: "EC", kid: "owner-public", alg: "ES256", d: "private", crv: "P-256", x: "x", y: "y" }],
+            jwt_jwks: {
+              keys: [{ kty: "EC", kid: "owner-public", alg: "ES256", crv: "P-256", x: "x", y: "y" }],
+            },
+          },
+        },
+      },
+    };
+    const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(async (ref: string) =>
+      (ref === "auth-owner" ? owner : dependent) as never
+    );
+    const secretsSpy = spyOn(databaseService, "getSecrets").mockResolvedValue([]);
+
+    try {
+      const env = await runtimeEnvService.buildProjectRuntimeEnv("proj_1");
+      expect(env?.SUPACLOUD_AUTH_RUNTIME_MODE).toBe("shared");
+      expect(env?.SUPACLOUD_AUTH_AUTHORITY_REF).toBe("auth-owner");
+      expect(env?.SUPACLOUD_INTERNAL_POSTGREST_PORT).toBe("3272");
+      expect(env?.SUPACLOUD_INTERNAL_GOTRUE_PORT).toBe("9372");
+      expect(env?.JWT_JWKS).toContain("owner-public");
+      expect(env?.JWT_JWKS).toContain("legacy-hs256");
+      expect(env?.JWT_JWKS).not.toContain("business-user-key");
+      expect(env?.SUPACLOUD_THIRD_PARTY_JWT_POLICY).toBeUndefined();
+      expect(env?.JWT_SECRET).toBeUndefined();
+      expect(env?.JWT_KEYS).toBeUndefined();
+      expect(env?.JWT_JWKS).not.toContain("dependent-private");
+    } finally {
+      config.authRuntimeOwnerRef = originalOwnerRef;
       findByRefSpy.mockRestore();
       secretsSpy.mockRestore();
     }

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -304,6 +304,98 @@ describe("sdkProxyRoutes functions proxy", () => {
     });
   });
 
+  test("shared auth proxy uses the owner GoTrue port, key, and project header", async () => {
+    const originalOwnerRef = config.authRuntimeOwnerRef;
+    const originalGetApiKeys = projectService.getApiKeys;
+    config.authRuntimeOwnerRef = "auth-owner";
+    projectService.getApiKeys = async (ref: string) => ref === "auth-owner"
+      ? {
+        anon_key: "owner-anon-jwt",
+        service_role_key: "owner-service-jwt",
+        publishable_key: "owner-publishable",
+        secret_key: "owner-secret",
+      }
+      : null;
+
+    try {
+      await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+        trackSpy(
+          spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
+            ref: "proj_1",
+            kind: "publishable",
+            role: "anon",
+            upstreamKey: "dependent-anon-jwt",
+          }),
+        );
+        setSdkProxySqlForTests(async (...args: unknown[]) => {
+          const text = String(args[0] ?? "");
+          if (text.includes("SELECT config")) return [{ config: { gotrue_port: 9361, postgrest_port: 7361 } }];
+          return [];
+        });
+
+        const response = await request("/auth/v1/health", {
+          headers: {
+            apikey: "sb_publishable_client_key",
+            authorization: "Bearer sb_publishable_client_key",
+          },
+        });
+
+        expect(response.status).toBe(200);
+        expect(calls[0]?.url).toBe("http://127.0.0.1:9361/health");
+        const headers = new Headers(calls[0]?.init?.headers);
+        expect(headers.get("apikey")).toBe("owner-anon-jwt");
+        expect(headers.get("authorization")).toBe("Bearer owner-anon-jwt");
+        expect(headers.get("x-project-ref")).toBe("auth-owner");
+        expect(headers.get("host")).toBe(`proj_1.api.${config.baseDomain}`);
+      });
+    } finally {
+      config.authRuntimeOwnerRef = originalOwnerRef;
+      projectService.getApiKeys = originalGetApiKeys;
+    }
+  });
+
+  test("shared auth proxy rejects dependent service-role credentials before upstream", async () => {
+    const originalOwnerRef = config.authRuntimeOwnerRef;
+    const originalGetApiKeys = projectService.getApiKeys;
+    config.authRuntimeOwnerRef = "auth-owner";
+    projectService.getApiKeys = async () => ({
+      anon_key: "owner-anon-jwt",
+      service_role_key: "owner-service-jwt",
+    } as Awaited<ReturnType<typeof projectService.getApiKeys>>);
+
+    try {
+      await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+        trackSpy(
+          spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
+            ref: "proj_1",
+            kind: "secret",
+            role: "service_role",
+            upstreamKey: "dependent-service-jwt",
+          }),
+        );
+        setSdkProxySqlForTests(async (...args: unknown[]) => {
+          const text = String(args[0] ?? "");
+          if (text.includes("SELECT config")) return [{ config: { gotrue_port: 9361, postgrest_port: 7361 } }];
+          return [];
+        });
+
+        const response = await request("/auth/v1/admin/users", {
+          headers: {
+            apikey: "sb_secret_client_key",
+            authorization: "Bearer sb_secret_client_key",
+          },
+        });
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ message: "Invalid API key" });
+        expect(calls).toHaveLength(0);
+      });
+    } finally {
+      config.authRuntimeOwnerRef = originalOwnerRef;
+      projectService.getApiKeys = originalGetApiKeys;
+    }
+  });
+
   test("REST proxy translates a publishable key to the legacy anon JWT", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
       trackSpy(

--- a/packages/management-api/tests/unit/supauth-gateway-routing.test.ts
+++ b/packages/management-api/tests/unit/supauth-gateway-routing.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("../../src/services/gateway.service.ts", import.meta.url), "utf8");
+
+describe("SupAuth gateway routing", () => {
+  test("routes every shared auth request through the owner-aware SDK proxy", () => {
+    expect(source).toContain("const sharedAuthProxy = sharedAuthPort !== null && !externalAuthUpstream");
+    expect(source).toContain("? `${hostIp}:${config.port}`");
+    expect(source).toContain('id: caddyRouteId(projectRef, "auth")');
+    expect(source).toContain("upstream: authUpstream");
+    expect(source).toContain('stripPrefix: sharedAuthProxy ? undefined : "/auth/v1"');
+  });
+
+  test("keeps well-known metadata on the direct owner runtime", () => {
+    expect(source).toContain("const directAuthUpstream = externalAuthUpstream?.dial");
+    expect(source).toContain('id: caddyRouteId(projectRef, "gotrue-well-known")');
+    expect(source).toContain("upstream: directAuthUpstream");
+  });
+});

--- a/packages/management-api/tests/unit/tenant-runtime.ports.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.ports.test.ts
@@ -23,7 +23,10 @@ describe("TenantRuntimeService port synchronization", () => {
 
     const gotrueConfigDirWrite = source.indexOf('await this.writeTenantSecretFile(path.join(gotrueConfigDir, "runtime.env"), gotrueEnv, runtimeUser);');
     const gotrueEnvWrite = source.indexOf("await this.writeTenantSecretFile(gotrueEnvPath, gotrueEnv, runtimeUser);");
-    const persistPorts = source.indexOf("await this.persistTenantPortConfig(ref, pgrstPort, gotruePort);");
+    const persistPorts = source.indexOf(
+      "await this.persistTenantPortConfig(ref, pgrstPort, gotruePort);",
+      gotrueEnvWrite,
+    );
 
     expect(gotrueConfigDirWrite).toBeGreaterThan(0);
     expect(gotrueEnvWrite).toBeGreaterThan(gotrueConfigDirWrite);

--- a/packages/management-api/tests/unit/tenant-runtime.security.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.security.test.ts
@@ -36,4 +36,13 @@ describe("TenantRuntimeService secret handling", () => {
     expect(source).toContain("client_id_claim");
     expect(source).toContain("third-party JWT claims rejected");
   });
+
+  test("shared auth keeps owner private signing material out and rejects non-user owner roles", () => {
+    expect(source).toContain("buildSharedProjectJwtVerificationMaterial");
+    expect(source).toContain('sharedAuthRuntime ? "" : renderSystemdEnvLine("JWT_SECRET"');
+    expect(source).toContain('sharedAuthRuntime ? "" : jwtKeysEnv');
+    expect(source).toContain("const postgrestJwtAudience = sharedAuthRuntime");
+    expect(source).toContain("SupAuth owner tokens may only use the authenticated role");
+    expect(source).toContain("Dependent legacy user sessions are disabled while SupAuth is active");
+  });
 });

--- a/packages/web-console/src/routes/project/[ref]/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/+page.svelte
@@ -2,6 +2,7 @@
   import { apiClient } from "$lib/api";
 
   import { onMount } from "svelte";
+  import { resolve } from "$app/paths";
   import { page } from "$app/state";
   import { t } from "svelte-i18n";
   import {
@@ -20,6 +21,7 @@
   let connections = $state(0);
   let maxConnections = $state(100);
   let totalUsers = $state(0);
+  let authManagedByRef = $state<string | null>(null);
   let functionsCount = $state(0);
   let storageSize = $state("-");
   let cacheHitRatio = $state(0);
@@ -40,7 +42,7 @@
   } | null>(null);
   let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
-  const projectRef = $derived(page.params.ref);
+  const projectRef = $derived(page.params.ref ?? "");
 
   type DashboardSummary = {
     database?: {
@@ -52,8 +54,10 @@
       index_count?: number;
     };
     auth?: {
-      total_users?: number;
+      total_users?: number | null;
       recent_users?: Record<string, unknown>[];
+      source?: "local" | "supauth";
+      managed_by_ref?: string | null;
     };
     storage?: {
       size?: string;
@@ -88,12 +92,13 @@
     cacheHitRatio = Number(database.cache_hit_ratio || 0);
     connections = Number(database.connections || 0);
     maxConnections = Number(database.max_connections || 100);
-    totalUsers = Number(auth.total_users || 0);
+    authManagedByRef = auth.source === "supauth" ? auth.managed_by_ref || null : null;
+    totalUsers = authManagedByRef ? 0 : Number(auth.total_users || 0);
     tableCount = Number(database.table_count || 0);
     indexCount = Number(database.index_count || 0);
     storageSize = String(storage.size || "0 bytes");
     functionsCount = Number(functions.count || 0);
-    recentUsers = auth.recent_users || [];
+    recentUsers = authManagedByRef ? [] : auth.recent_users || [];
     activeQueries = summary.active_queries || [];
     taskStats = summary.tasks || null;
   }
@@ -109,16 +114,37 @@
     }
   }
 
-  async function fetchDashboardLegacy() {
+  async function refreshAuthRuntimeOwner(): Promise<boolean> {
+    try {
+      const response = await apiClient(`/v1/projects/${projectRef}/auth/runtime`);
+      if (!response.ok) return false;
+      const runtime = await response.json() as {
+        mode?: "local" | "owner" | "shared";
+        authority_project_ref?: string;
+      };
+      authManagedByRef = runtime.mode === "shared" && runtime.authority_project_ref
+        ? runtime.authority_project_ref
+        : null;
+      return true;
+    } catch {
+      // Dashboard summary remains the primary source; this is only a safe fallback.
+      return false;
+    }
+  }
+
+  async function fetchDashboardLegacy(authRuntimeKnown: boolean) {
+    const canReadLocalAuth = authRuntimeKnown && !authManagedByRef;
     const [dbInfo, connInfo, userInfo, tableInfo, indexInfo, storageInfo, recentUserInfo, activeInfo] = await Promise.all([
       runSql(`SELECT pg_size_pretty(pg_database_size(current_database())) as size,
               (SELECT round(100.0 * blks_hit / NULLIF(blks_hit + blks_read, 0), 1) FROM pg_stat_database WHERE datname = current_database()) as cache_ratio;`),
       runSql(`SELECT count(*) as active FROM pg_stat_activity WHERE backend_type = 'client backend';`),
-      runSql(`SELECT count(*) as total FROM auth.users;`),
+      canReadLocalAuth ? runSql(`SELECT count(*) as total FROM auth.users;`) : Promise.resolve([]),
       runSql(`SELECT count(*) as cnt FROM pg_stat_user_tables;`),
       runSql(`SELECT count(*) as cnt FROM pg_stat_user_indexes;`),
       runSql(`SELECT pg_size_pretty(coalesce(sum((metadata->>'size')::bigint), 0)) as size FROM storage.objects;`),
-      runSql(`SELECT email, created_at::text FROM auth.users ORDER BY created_at DESC LIMIT 5;`),
+      canReadLocalAuth
+        ? runSql(`SELECT email, created_at::text FROM auth.users ORDER BY created_at DESC LIMIT 5;`)
+        : Promise.resolve([]),
       runSql(`SELECT pid, usename, state, left(query, 80) as query FROM pg_stat_activity WHERE backend_type = 'client backend' AND state = 'active' LIMIT 5;`),
     ]);
 
@@ -127,11 +153,11 @@
       cacheHitRatio = parseFloat(String(dbInfo[0].cache_ratio || "0"));
     }
     if (connInfo[0]) connections = parseInt(String(connInfo[0].active || "0"));
-    if (userInfo[0]) totalUsers = parseInt(String(userInfo[0].total || "0"));
+    if (!authManagedByRef && userInfo[0]) totalUsers = parseInt(String(userInfo[0].total || "0"));
     if (tableInfo[0]) tableCount = parseInt(String(tableInfo[0].cnt || "0"));
     if (indexInfo[0]) indexCount = parseInt(String(indexInfo[0].cnt || "0"));
     if (storageInfo[0]) storageSize = String(storageInfo[0].size || "0 bytes");
-    recentUsers = recentUserInfo;
+    recentUsers = authManagedByRef ? [] : recentUserInfo;
     activeQueries = activeInfo;
     functionsCount = await fetchFunctionsCountLegacy();
     await fetchTaskStats();
@@ -144,7 +170,8 @@
       if (!res.ok) throw new Error("summary unavailable");
       applyDashboardSummary(await res.json());
     } catch {
-      await fetchDashboardLegacy();
+      const authRuntimeKnown = await refreshAuthRuntimeOwner();
+      await fetchDashboardLegacy(authRuntimeKnown);
     } finally {
       isLoading = false;
     }
@@ -192,15 +219,15 @@
     };
   });
 
-  const QUICK_LINKS = $derived(projectRef ? [
-    { name: $t("Navigation.sql_editor"), href: "sql", icon: Terminal, color: "text-blue-600 bg-blue-500/10 border-blue-500/20" },
-    { name: $t("Navigation.table_editor"), href: "tables", icon: Database, color: "text-violet-600 bg-violet-500/10 border-violet-500/20" },
-    { name: $t("Navigation.auth"), href: "auth", icon: Users, color: "text-emerald-600 bg-emerald-500/10 border-emerald-500/20" },
-    { name: $t("Navigation.storage"), href: "storage", icon: Folder, color: "text-teal-600 bg-teal-500/10 border-teal-500/20" },
-    { name: $t("Navigation.edge_functions"), href: "functions", icon: Zap, color: "text-amber-600 bg-amber-500/10 border-amber-500/20" },
-    { name: $t("Navigation.logs"), href: "logs", icon: ScrollText, color: "text-pink-600 bg-pink-500/10 border-pink-500/20" },
-    { name: $t("Navigation.settings"), href: "settings", icon: Server, color: "text-slate-600 bg-slate-500/10 border-slate-500/20" },
-  ] : []);
+  const QUICK_LINKS = $derived(projectRef ? ([
+    { name: $t("Navigation.sql_editor"), route: "/project/[ref]/sql", icon: Terminal, color: "text-blue-600 bg-blue-500/10 border-blue-500/20" },
+    { name: $t("Navigation.table_editor"), route: "/project/[ref]/tables", icon: Database, color: "text-violet-600 bg-violet-500/10 border-violet-500/20" },
+    { name: $t("Navigation.auth"), route: "/project/[ref]/auth", icon: Users, color: "text-emerald-600 bg-emerald-500/10 border-emerald-500/20" },
+    { name: $t("Navigation.storage"), route: "/project/[ref]/storage", icon: Folder, color: "text-teal-600 bg-teal-500/10 border-teal-500/20" },
+    { name: $t("Navigation.edge_functions"), route: "/project/[ref]/functions", icon: Zap, color: "text-amber-600 bg-amber-500/10 border-amber-500/20" },
+    { name: $t("Navigation.logs"), route: "/project/[ref]/logs", icon: ScrollText, color: "text-pink-600 bg-pink-500/10 border-pink-500/20" },
+    { name: $t("Navigation.settings"), route: "/project/[ref]/settings", icon: Server, color: "text-slate-600 bg-slate-500/10 border-slate-500/20" },
+  ] as const) : []);
 
   function getStatusColor(status: string): string {
     if (status === "RUNNING" || status === "running" || status === "active" || status === "ACTIVE_HEALTHY") return "text-green-600";
@@ -249,9 +276,9 @@
   {:else}
     <!-- Quick Access Cards -->
     <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3">
-      {#each QUICK_LINKS as link}
+      {#each QUICK_LINKS as link (link.route)}
         {@const Icon = link.icon}
-        <a href={`/project/${projectRef}/${link.href}`} class="group flex flex-col items-center justify-center gap-3 p-4 rounded-xl border bg-card hover:border-brand/40 hover:shadow-sm transition-all text-center">
+        <a href={resolve(link.route, { ref: projectRef })} class="group flex flex-col items-center justify-center gap-3 p-4 rounded-xl border bg-card hover:border-brand/40 hover:shadow-sm transition-all text-center">
           <div class={`w-10 h-10 rounded-xl flex items-center justify-center border transition-transform group-hover:scale-110 ${link.color}`}>
             <Icon size={18} />
           </div>
@@ -290,8 +317,19 @@
           <Users size={14} />
           <span class="text-[10px] font-semibold uppercase">{$t("Dashboard.auth_users")}</span>
         </div>
-        <div class="mt-2 text-2xl font-bold">{totalUsers.toLocaleString()}</div>
-        <div class="mt-1 text-[10px] text-muted-foreground">{$t("Auth.users_count")}</div>
+        {#if authManagedByRef}
+          <div class="mt-2 text-lg font-bold">SupAuth</div>
+          <div class="mt-1 text-[10px] text-muted-foreground">
+            用户由
+            <a class="font-mono text-brand hover:underline" href={resolve("/project/[ref]/auth", { ref: authManagedByRef })}>
+              {authManagedByRef}
+            </a>
+            统一管理
+          </div>
+        {:else}
+          <div class="mt-2 text-2xl font-bold">{totalUsers.toLocaleString()}</div>
+          <div class="mt-1 text-[10px] text-muted-foreground">{$t("Auth.users_count")}</div>
+        {/if}
       </div>
 
       <div class="rounded-xl border bg-card p-5 shadow-sm hover:shadow-md transition-shadow">
@@ -319,7 +357,7 @@
           <h2 class="text-sm font-semibold flex items-center gap-2"><Activity size={14} /> {$t("DashboardTasks.title")}</h2>
           <p class="text-[11px] text-muted-foreground mt-1">{$t("DashboardTasks.subtitle")}</p>
         </div>
-        <a href={`/project/${projectRef}/tasks`} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardTasks.open_panel")} <ArrowRight size={10} /></a>
+        <a href={resolve("/project/[ref]/tasks", { ref: projectRef })} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardTasks.open_panel")} <ArrowRight size={10} /></a>
       </div>
 
       <div class="p-5 space-y-5">
@@ -371,7 +409,7 @@
               </svg>
 
               <div class="space-y-2">
-                {#each taskStats.failedTrend as point}
+                {#each taskStats.failedTrend as point (point.bucket)}
                   <div class="grid grid-cols-[88px_1fr_32px] items-center gap-3">
                     <div class="text-[11px] font-mono text-muted-foreground">{point.bucket}</div>
                     <div class="h-2 rounded-full bg-muted overflow-hidden">
@@ -399,7 +437,7 @@
             </div>
           {:else}
             <div class="space-y-2">
-              {#each taskStats.topFailures as item}
+              {#each taskStats.topFailures as item (`${item.message}:${item.count}`)}
                 <div class="rounded-lg border border-border/60 px-3 py-2">
                   <div class="text-xs text-foreground break-all">{item.message}</div>
                   <div class="mt-1 text-[11px] text-muted-foreground font-mono">{$t("DashboardTasks.occurrences", { default: `出现 ${item.count} 次` })}</div>
@@ -416,7 +454,7 @@
       <div class="rounded-xl border bg-card overflow-hidden">
         <div class="border-b px-5 py-3 bg-muted/20 flex items-center justify-between">
           <h2 class="text-sm font-semibold flex items-center gap-2"><Server size={14} /> {$t("DashboardServices.title")} </h2>
-          <a href={`/project/${projectRef}/settings/services`} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardServices.manage")} <ArrowRight size={10} /></a>
+          <a href={resolve("/project/[ref]/settings/services", { ref: projectRef })} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardServices.manage")} <ArrowRight size={10} /></a>
         </div>
         <div class="divide-y divide-border/20">
           {#if servicesLoading}
@@ -426,7 +464,7 @@
           {:else if services.length === 0}
             <div class="p-4 text-xs text-muted-foreground text-center">{$t("DashboardServices.unavailable")}</div>
           {:else}
-            {#each services as svc}
+            {#each services as svc (svc.name)}
               {@const StatusIcon = getStatusIcon(svc.status)}
               <div class="flex items-center justify-between px-5 py-2.5">
                 <div class="flex items-center gap-2">
@@ -444,16 +482,21 @@
       <div class="rounded-xl border bg-card overflow-hidden">
         <div class="border-b px-5 py-3 bg-muted/20 flex items-center justify-between">
           <h2 class="text-sm font-semibold flex items-center gap-2"><Users size={14} /> {$t("DashboardRecentUsers.title")} </h2>
-          <a href={`/project/${projectRef}/auth`} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardRecentUsers.view_all")} <ArrowRight size={10} /></a>
+          <a href={resolve("/project/[ref]/auth", { ref: authManagedByRef || projectRef })} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardRecentUsers.view_all")} <ArrowRight size={10} /></a>
         </div>
-        {#if recentUsers.length === 0}
+        {#if authManagedByRef}
+          <div class="flex flex-col items-center justify-center py-10 text-muted-foreground gap-2">
+            <Shield size={24} strokeWidth={1} />
+            <p class="text-xs">共享用户目录仅在 SupAuth 权威项目中展示</p>
+          </div>
+        {:else if recentUsers.length === 0}
           <div class="flex flex-col items-center justify-center py-10 text-muted-foreground gap-2 opacity-40">
             <Users size={24} strokeWidth={1} />
             <p class="text-xs">{$t("DashboardRecentUsers.no_users")}</p>
           </div>
         {:else}
           <div class="divide-y divide-border/20">
-            {#each recentUsers as user}
+            {#each recentUsers as user (`${String(user.email)}:${String(user.created_at)}`)}
               <div class="px-5 py-2.5 flex items-center justify-between">
                 <div class="flex items-center gap-2">
                   <div class="w-6 h-6 rounded-full bg-brand/10 text-brand flex items-center justify-center text-[10px] font-bold">
@@ -472,7 +515,7 @@
       <div class="rounded-xl border bg-card overflow-hidden">
         <div class="border-b px-5 py-3 bg-muted/20 flex items-center justify-between">
           <h2 class="text-sm font-semibold flex items-center gap-2"><Code2 size={14} /> {$t("DashboardActiveQueries.title")} </h2>
-          <a href={`/project/${projectRef}/reports/api-overview`} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardActiveQueries.details")} <ArrowRight size={10} /></a>
+          <a href={resolve("/project/[ref]/reports/api-overview", { ref: projectRef })} class="text-[10px] text-brand hover:underline flex items-center gap-1">{$t("DashboardActiveQueries.details")} <ArrowRight size={10} /></a>
         </div>
         {#if activeQueries.length === 0}
           <div class="flex flex-col items-center justify-center py-10 text-muted-foreground gap-2 opacity-40">
@@ -481,7 +524,7 @@
           </div>
         {:else}
           <div class="divide-y divide-border/20">
-            {#each activeQueries as q}
+            {#each activeQueries as q (String(q.pid))}
               <div class="px-5 py-2.5">
                 <div class="flex items-center gap-2 mb-1">
                   <span class="text-[10px] font-mono text-muted-foreground">PID {q.pid}</span>
@@ -499,8 +542,8 @@
     <div>
       <h2 class="text-sm font-semibold mb-3 flex items-center gap-2"><ArrowRight size={14} /> {$t("DashboardQuickAccess.title")} </h2>
       <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
-        {#each QUICK_LINKS as link}
-          <a href={`/project/${projectRef}/${link.href}`}
+        {#each QUICK_LINKS as link (link.route)}
+          <a href={resolve(link.route, { ref: projectRef })}
             class="flex items-center gap-3 rounded-xl border bg-card p-4 hover:border-brand/40 hover:shadow-md transition-all group">
             <div class="w-9 h-9 rounded-lg {link.color} flex items-center justify-center group-hover:scale-110 transition-transform">
               <link.icon size={18} />

--- a/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
@@ -1,27 +1,78 @@
 <script lang="ts">
+  import { onMount } from "svelte";
+  import { resolve } from "$app/paths";
   import { page } from "$app/state";
+  import { apiClient } from "$lib/api";
   import { Users, Shield, KeyRound, Link2, Mail, Clock, Webhook, BadgeCheck } from "lucide-svelte";
 
-  const projectRef = $derived(page.params.ref);
+  type AuthRuntimeDescriptor = {
+    project_ref: string;
+    mode: "local" | "owner" | "shared";
+    authority_project_ref: string;
+    owner_project_ref: string | null;
+    local_gotrue_enabled: boolean;
+    public_auth_route: "local_gotrue" | "owner_proxy";
+    user_management: "local" | "owner_only";
+    configuration_management: "local" | "owner_only";
+    local_membership_source: "project_database";
+    realtime_auth_supported: boolean;
+    owner_management_path: string | null;
+  };
+
+  const projectRef = $derived(page.params.ref ?? "");
   const currentPath = $derived(page.url.pathname);
+  let authRuntime = $state.raw<AuthRuntimeDescriptor | null>(null);
+  let authRuntimeError = $state<string | null>(null);
+  let authRuntimeLoading = $state(true);
 
   const AUTH_TABS = [
-    { name: "用户", path: "", icon: Users },
-    { name: "提供者", path: "providers", icon: KeyRound },
-    { name: "OAuth Server", path: "oauth-server", icon: BadgeCheck },
-    { name: "RLS 策略", path: "policies", icon: Shield },
-    { name: "URL 配置", path: "url-configuration", icon: Link2 },
-    { name: "邮件模板", path: "templates", icon: Mail },
-    { name: "SMTP", path: "smtp", icon: Mail },
-    { name: "Hooks", path: "hooks", icon: Webhook },
-    { name: "会话", path: "sessions", icon: Clock },
-    { name: "MFA", path: "mfa", icon: Shield },
-    { name: "限频", path: "rate-limits", icon: Shield },
-    { name: "安全防护", path: "protection", icon: Shield },
-  ];
+    { name: "用户", path: "", route: "/project/[ref]/auth", icon: Users },
+    { name: "提供者", path: "providers", route: "/project/[ref]/auth/providers", icon: KeyRound },
+    { name: "OAuth Server", path: "oauth-server", route: "/project/[ref]/auth/oauth-server", icon: BadgeCheck },
+    { name: "RLS 策略", path: "policies", route: "/project/[ref]/auth/policies", icon: Shield },
+    { name: "URL 配置", path: "url-configuration", route: "/project/[ref]/auth/url-configuration", icon: Link2 },
+    { name: "邮件模板", path: "templates", route: "/project/[ref]/auth/templates", icon: Mail },
+    { name: "SMTP", path: "smtp", route: "/project/[ref]/auth/smtp", icon: Mail },
+    { name: "Hooks", path: "hooks", route: "/project/[ref]/auth/hooks", icon: Webhook },
+    { name: "会话", path: "sessions", route: "/project/[ref]/auth/sessions", icon: Clock },
+    { name: "MFA", path: "mfa", route: "/project/[ref]/auth/mfa", icon: Shield },
+    { name: "限频", path: "rate-limits", route: "/project/[ref]/auth/rate-limits", icon: Shield },
+    { name: "安全防护", path: "protection", route: "/project/[ref]/auth/protection", icon: Shield },
+  ] as const;
+
+  const visibleTabs = $derived(
+    authRuntime?.mode === "local" || authRuntime?.mode === "owner"
+      ? AUTH_TABS
+      : AUTH_TABS.filter((tab) => tab.path === "policies"),
+  );
+  const ownerManagedPage = $derived(
+    authRuntime?.mode === "shared" && !currentPath.endsWith("/policies"),
+  );
+
+  onMount(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await apiClient(`/v1/projects/${projectRef}/auth/runtime`);
+        const data = await response.json().catch(() => ({})) as Partial<AuthRuntimeDescriptor> & { message?: string };
+        if (!response.ok) throw new Error(data.message || "无法读取认证运行模式");
+        if (!cancelled) authRuntime = data as AuthRuntimeDescriptor;
+      } catch (error: unknown) {
+        if (!cancelled) {
+          authRuntimeError = error instanceof Error ? error.message : String(error);
+        }
+      } finally {
+        if (!cancelled) authRuntimeLoading = false;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  });
 
   function isActive(tabPath: string): boolean {
-    const base = `/project/${projectRef}/auth`;
+    const base = resolve("/project/[ref]/auth", { ref: projectRef });
     if (tabPath === "") return currentPath === base;
     return currentPath === `${base}/${tabPath}`;
   }
@@ -32,9 +83,9 @@
 <div class="h-full flex flex-col space-y-4">
   <!-- Auth Tab Navigation -->
   <div class="flex items-center gap-1 px-1 overflow-x-auto border-b border-border/30 pb-0">
-    {#each AUTH_TABS as tab}
+    {#each visibleTabs as tab (tab.path)}
       <a
-        href={`/project/${projectRef}/auth${tab.path ? '/' + tab.path : ''}`}
+        href={resolve(tab.route, { ref: projectRef })}
         class="flex items-center gap-1.5 px-3 py-2 text-xs font-medium border-b-2 transition-colors whitespace-nowrap {isActive(tab.path) ? 'border-brand text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
       >
         <tab.icon size={12} />
@@ -43,8 +94,65 @@
     {/each}
   </div>
 
+  {#if authRuntimeLoading}
+    <div class="rounded-lg border border-border/50 bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
+      正在确认项目认证运行模式…
+    </div>
+  {:else if authRuntimeError}
+    <div class="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-xs text-destructive">
+      无法确认认证运行模式：{authRuntimeError}。为避免误操作，认证管理面暂不可用，请刷新后重试。
+    </div>
+  {:else if authRuntime?.mode === "owner"}
+    <div class="rounded-lg border border-blue-500/30 bg-blue-500/5 px-4 py-4 text-sm text-blue-950 space-y-2">
+      <p class="font-semibold">此项目是 SupAuth 认证权威</p>
+      <p class="text-xs leading-5">
+        此处的用户、OAuth、MFA、邮件和安全配置会影响所有使用 SupAuth 的从属项目。GoTrue 在本项目运行，并作为共享身份目录的唯一管理入口。
+      </p>
+    </div>
+  {:else if authRuntime?.mode === "shared"}
+    <div class="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-4 text-sm text-amber-950 space-y-2">
+      <p class="font-semibold">此项目使用 SupAuth 共享认证</p>
+      <p class="text-xs leading-5">
+        本项目的公开认证请求会转发到 SupAuth，但本地 GoTrue 已停用。用户、OAuth、MFA、邮件和认证安全配置由权威项目
+        <code class="font-mono">{authRuntime.authority_project_ref}</code> 统一管理；当前项目的本地数据库只负责业务数据、成员关系和 RLS。
+      </p>
+      <p class="text-xs leading-5 font-medium">
+        shared 模式只接受权威项目签发的用户令牌；本项目的第三方 JWT 配置不会参与认证验证，请在权威项目统一规划认证来源。
+      </p>
+      {#if !authRuntime.realtime_auth_supported}
+        <p class="text-xs leading-5 font-medium">
+          当前官方 Realtime 租户仅支持单个 HS256 密钥，尚不能验证 SupAuth 的非对称用户令牌；共享模式下请暂不启用 Realtime 用户订阅。
+        </p>
+      {/if}
+      {#if authRuntime.owner_management_path}
+        <a
+          class="inline-flex text-xs font-semibold text-amber-800 underline underline-offset-2"
+          href={resolve("/project/[ref]/auth", { ref: authRuntime.authority_project_ref })}
+        >
+          前往权威项目管理认证
+        </a>
+      {/if}
+    </div>
+  {/if}
+
   <!-- Sub-page content -->
   <div class="flex-1 min-h-0 overflow-auto">
-    {@render children()}
+    {#if authRuntimeLoading}
+      <div class="h-full flex items-center justify-center text-xs text-muted-foreground">正在加载…</div>
+    {:else if authRuntimeError}
+      <div class="h-full flex items-center justify-center text-xs text-muted-foreground">认证管理面已安全锁定。</div>
+    {:else if ownerManagedPage}
+      <div class="h-full flex items-center justify-center p-8">
+        <div class="max-w-lg rounded-xl border border-amber-500/30 bg-amber-500/5 p-6 text-center space-y-3">
+          <h1 class="text-lg font-semibold">认证设置由 SupAuth 权威项目管理</h1>
+          <p class="text-xs leading-5 text-muted-foreground">
+            为避免把共享用户误显示为本地用户，当前项目不提供本地 GoTrue 用户管理或认证配置写入。
+            请在上方链接的权威项目中完成操作。
+          </p>
+        </div>
+      </div>
+    {:else}
+      {@render children()}
+    {/if}
   </div>
 </div>

--- a/packages/web-console/src/routes/project/[ref]/settings/services/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/settings/services/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
 
+  import { resolve } from "$app/paths";
   import { page } from "$app/state";
   import { Loader2, Play, Square, RotateCw, Activity, Server, Shield, Database, Radio, HardDrive, AlertTriangle } from "lucide-svelte";
   import { toast } from "svelte-sonner";
@@ -12,6 +13,10 @@
     icon: typeof Server;
     status: string;
     systemdUnit: string;
+    controlName: string;
+    runtimeMode?: "local" | "owner" | "shared";
+    managedByRef?: string;
+    localRuntimeEnabled?: boolean;
   }
 
   let actionInProgress = $state<string | null>(null);
@@ -28,15 +33,44 @@
   const services = $derived.by(() => {
     const data = query.data?.data as Record<string, any>;
     const svcArr = data?.services || [];
+    const findService = (name: string) => svcArr.find((service: Record<string, unknown>) => service.name === name);
+    const authService = svcArr.find((service: Record<string, unknown>) =>
+      service.id === "gotrue"
+      || service.id === "auth"
+      || service.name === "GoTrue"
+      || service.name === "auth"
+    );
+    const authRuntimeMode = authService?.runtime_mode === "shared"
+      ? "shared"
+      : authService?.runtime_mode === "owner"
+        ? "owner"
+        : "local";
+    const authOwnerRef = typeof authService?.managed_by_ref === "string" ? authService.managed_by_ref : undefined;
     return [
-      { name: "PostgreSQL", icon: Database, status: svcArr.find((s: Record<string, unknown>) => s.name === "PostgreSQL")?.status || "INACTIVE", systemdUnit: "patroni" },
-      { name: "PostgREST", icon: Server, status: svcArr.find((s: Record<string, unknown>) => s.name === "PostgREST")?.status || "INACTIVE", systemdUnit: `supacloud-pgrst@${projectRef}` },
-      { name: "GoTrue", icon: Shield, status: svcArr.find((s: Record<string, unknown>) => s.name === "GoTrue")?.status || "INACTIVE", systemdUnit: `supacloud-gotrue@${projectRef}` },
-      { name: "Realtime", icon: Radio, status: svcArr.find((s: Record<string, unknown>) => s.name === "Realtime")?.status || "INACTIVE", systemdUnit: `supacloud-realtime@${projectRef}` },
-      { name: "Storage", icon: HardDrive, status: svcArr.find((s: Record<string, unknown>) => s.name === "Storage")?.status || "INACTIVE", systemdUnit: `supacloud-storage@${projectRef}` },
-      { name: "Caddy", icon: Activity, status: svcArr.find((s: Record<string, unknown>) => s.name === "Caddy")?.status || "INACTIVE", systemdUnit: "supacloud-caddy" },
+      { name: "PostgreSQL", controlName: "postgresql", icon: Database, status: findService("PostgreSQL")?.status || "INACTIVE", systemdUnit: "patroni" },
+      { name: "PostgREST", controlName: "postgrest", icon: Server, status: findService("PostgREST")?.status || "INACTIVE", systemdUnit: `supacloud-pgrst@${projectRef}` },
+      {
+        name: authRuntimeMode === "shared"
+          ? "SupAuth（共享）"
+          : authRuntimeMode === "owner"
+            ? "SupAuth（权威）"
+            : "GoTrue",
+        controlName: "gotrue",
+        icon: Shield,
+        status: authService?.status || "INACTIVE",
+        systemdUnit: authService?.unit || `supacloud-gotrue@${authOwnerRef || projectRef}`,
+        runtimeMode: authRuntimeMode,
+        managedByRef: authOwnerRef,
+        localRuntimeEnabled: authService?.local_runtime_enabled !== false,
+      },
+      { name: "Realtime", controlName: "realtime", icon: Radio, status: findService("Realtime")?.status || "INACTIVE", systemdUnit: `supacloud-realtime@${projectRef}` },
+      { name: "Storage", controlName: "storage", icon: HardDrive, status: findService("Storage")?.status || "INACTIVE", systemdUnit: `supacloud-storage@${projectRef}` },
+      { name: "Caddy", controlName: "caddy", icon: Activity, status: findService("Caddy")?.status || "INACTIVE", systemdUnit: "supacloud-caddy" },
     ];
   });
+
+  const sharedAuthService = $derived(services.find((service) => service.runtimeMode === "shared"));
+  const ownerAuthService = $derived(services.find((service) => service.runtimeMode === "owner"));
 
   const isLoading = $derived(query.isLoading);
 
@@ -149,6 +183,32 @@
     </p>
   </div>
 
+  {#if sharedAuthService}
+    <div class="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 flex items-start gap-2">
+      <Shield size={14} class="text-amber-700 mt-0.5 shrink-0" />
+      <p class="text-xs leading-5 text-amber-950">
+        本项目使用 SupAuth 共享认证，本地 GoTrue 已停用。公开认证流量与认证状态来自权威项目
+        {#if sharedAuthService.managedByRef}
+          <a
+            class="font-mono font-semibold underline underline-offset-2"
+            href={resolve("/project/[ref]/auth", { ref: sharedAuthService.managedByRef })}
+          >
+            {sharedAuthService.managedByRef}
+          </a>
+        {:else}
+          <span class="font-semibold">SupAuth 权威项目</span>
+        {/if}；启动全部、重启全部和暂停项目不会控制该共享认证服务。
+      </p>
+    </div>
+  {:else if ownerAuthService}
+    <div class="rounded-lg border border-blue-500/30 bg-blue-500/5 p-3 flex items-start gap-2">
+      <Shield size={14} class="text-blue-700 mt-0.5 shrink-0" />
+      <p class="text-xs leading-5 text-blue-950">
+        本项目运行 SupAuth 权威 GoTrue。对该服务及认证设置的操作会影响所有从属项目，请按共享基础设施变更处理。
+      </p>
+    </div>
+  {/if}
+
   <div class="flex-1 rounded-xl border border-border/50 bg-background shadow-sm overflow-hidden">
     {#if isLoading}
       <div class="flex flex-col items-center justify-center py-24 text-muted-foreground gap-3">
@@ -166,14 +226,21 @@
               <div>
                 <span class="font-semibold text-sm">{svc.name}</span>
                 <p class="text-[10px] font-mono text-muted-foreground">{svc.systemdUnit}</p>
+                {#if svc.runtimeMode === "shared"}
+                  <p class="text-[10px] text-amber-700">由项目 {svc.managedByRef} 统一管理，本地实例不可操作</p>
+                {:else if svc.runtimeMode === "owner"}
+                  <p class="text-[10px] text-blue-700">共享认证权威实例，变更会影响所有从属项目</p>
+                {/if}
               </div>
             </div>
             <div class="flex items-center gap-3">
               <span class="px-2.5 py-1 rounded-full text-[10px] font-bold {statusColor(svc.status)}">{statusLabel(svc.status)}</span>
-              <div class="flex items-center gap-1">
-                {#if svc.status === "ACTIVE_HEALTHY"}
+              <div class="flex items-center gap-1 min-w-14 justify-end">
+                {#if svc.runtimeMode === "shared"}
+                  <span class="text-[10px] font-semibold text-muted-foreground">只读</span>
+                {:else if svc.status === "ACTIVE_HEALTHY"}
                   <button
-                    onclick={() => controlService("restart", svc.name.toLowerCase())}
+                    onclick={() => controlService("restart", svc.controlName)}
                     disabled={!!actionInProgress}
                     class="p-1.5 hover:bg-brand/10 hover:text-brand rounded transition-colors disabled:opacity-50"
                     title="重启"
@@ -181,7 +248,7 @@
                     <RotateCw size={14} />
                   </button>
                   <button
-                    onclick={() => controlService("stop", svc.name.toLowerCase())}
+                    onclick={() => controlService("stop", svc.controlName)}
                     disabled={!!actionInProgress}
                     class="p-1.5 hover:bg-destructive/10 hover:text-destructive rounded transition-colors disabled:opacity-50"
                     title="停止"
@@ -190,7 +257,7 @@
                   </button>
                 {:else}
                   <button
-                    onclick={() => controlService("start", svc.name.toLowerCase())}
+                    onclick={() => controlService("start", svc.controlName)}
                     disabled={!!actionInProgress}
                     class="p-1.5 hover:bg-green-500/10 hover:text-green-600 rounded transition-colors disabled:opacity-50"
                     title="启动"


### PR DESCRIPTION
## Summary
- make SupAuth the single authentication authority for shared dependent projects
- disable dependent local GoTrue and lock dependent Studio auth management while keeping RLS available
- route public auth to the owner without elevating dependent service-role credentials
- verify owner user JWTs with public asymmetric keys and fail closed on legacy/local/third-party user trust
- fan out owner runtime/JWKS changes to dependent PostgREST and Edge caches
- document that shared Realtime user subscriptions and dependent third-party JWT auth are unsupported

## Verification
- Management API typecheck, unit, integration, and compliance checks
- Edge Runtime typecheck and full test suite
- Web Console svelte-check, production build, and Svelte autofixer
- independent security review and verifier review