### PR TITLE
feat(edge-runtime): expose verified JWT subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ OPENCODE.md
 .zed/CONVENTIONS.md
 .agents/goal-forge/runs/
 CODEBUDDY.md
+.agents/docs/

--- a/docs/edge-runtime-guide.md
+++ b/docs/edge-runtime-guide.md
@@ -124,6 +124,49 @@ const { data, error } = await supabase.functions.invoke('my-function', {
 });
 ```
 
+### Verified JWT Context
+
+When a request enters the public `/functions/v1/*` path for a function with
+`verify_jwt: true`, the Edge Runtime verifies the bearer JWT before dispatch and
+exposes its verified subject through
+`x-supacloud-jwt-sub`. Any client-supplied value for this header is removed and
+replaced by the runtime, so functions may use it as the authenticated user ID
+without calling GoTrue `getUser()` again.
+
+The original `Authorization` header is preserved. Use that user JWT with a
+user-scoped Supabase client so PostgREST applies RLS when loading the local
+membership/profile record:
+
+```typescript
+const authorization = req.headers.get("authorization");
+const userId = req.headers.get("x-supacloud-jwt-sub");
+
+if (!authorization || !userId) {
+  return new Response("Unauthorized", { status: 401 });
+}
+
+const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  global: { headers: { Authorization: authorization } },
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const { data: membership, error } = await userClient
+  .from("profiles")
+  .select("id, username, role")
+  .eq("id", userId)
+  .maybeSingle();
+```
+
+API-key-only requests and raw anon/service-role key bypasses do not receive a
+verified subject header. Authorization roles should come from the RLS-protected
+membership lookup, not from an unverified client header.
+
+Background dispatch also strips client-supplied values for this header. It does
+not currently inject a subject because queued execution may outlive the original
+JWT validity window; background jobs should persist an already-authorized user
+identifier in their trusted task payload instead of treating request headers as
+durable identity.
+
 Background invocation uses the same API surface. SupaCloud supports two activation modes:
 
 - server-side per-function `background_routes`

--- a/packages/edge-runtime/background-forward.test.ts
+++ b/packages/edge-runtime/background-forward.test.ts
@@ -16,6 +16,7 @@ describe("background forwarded request", () => {
         "x-supacloud-internal-token": "legacy-management-master-token",
         "x-supacloud-auth-authorization": "Bearer user-token",
         "x-supacloud-auth-apikey": "anon-key",
+        "x-supacloud-jwt-sub": "attacker-controlled",
       },
       body: JSON.stringify({ ok: true }),
     });
@@ -28,6 +29,7 @@ describe("background forwarded request", () => {
     expect(forwarded.headers.get("apikey")).toBe("anon-key");
     expect(forwarded.headers.get("x-supacloud-auth-authorization")).toBeNull();
     expect(forwarded.headers.get("x-supacloud-auth-apikey")).toBeNull();
+    expect(forwarded.headers.get("x-supacloud-jwt-sub")).toBeNull();
     expect(await forwarded.text()).toBe(JSON.stringify({ ok: true }));
   });
 

--- a/packages/edge-runtime/background-forward.ts
+++ b/packages/edge-runtime/background-forward.ts
@@ -1,4 +1,5 @@
 import { withBackgroundInternalToken } from "./tenant-env";
+import { VERIFIED_JWT_SUB_HEADER } from "./jwt-verifier";
 
 export interface BackgroundForwardDispatch {
   forwardedRequest: Request;
@@ -22,6 +23,7 @@ export function buildBackgroundForwardedRequest(
   headers.delete("x-supacloud-internal-token");
   headers.delete("x-supacloud-auth-authorization");
   headers.delete("x-supacloud-auth-apikey");
+  headers.delete(VERIFIED_JWT_SUB_HEADER);
 
   if (backgroundInternalToken) {
     headers.set("x-supacloud-internal-auth", `Bearer ${backgroundInternalToken}`);

--- a/packages/edge-runtime/jwt-verifier.test.ts
+++ b/packages/edge-runtime/jwt-verifier.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
-import { normalizeJwtJwks, verifyEdgeRuntimeJwt } from "./jwt-verifier";
+import {
+  VERIFIED_JWT_SUB_HEADER,
+  normalizeJwtJwks,
+  withVerifiedJwtContext,
+  verifyEdgeRuntimeJwt,
+  verifyEdgeRuntimeJwtContext,
+} from "./jwt-verifier";
 
 describe("verifyEdgeRuntimeJwt", () => {
   test("accepts ES256 tokens from project JWKS for Bun Edge Functions", async () => {
@@ -28,6 +34,69 @@ describe("verifyEdgeRuntimeJwt", () => {
     expect(verified).toBe(true);
   });
 
+  test("returns the verified subject for downstream Edge Functions", async () => {
+    const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+    const publicJwk = await exportJWK(publicKey);
+    const privateJwk = await exportJWK(privateKey);
+    const kid = "test-subject";
+    const token = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setSubject("00000000-0000-4000-8000-000000000001")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(await crypto.subtle.importKey(
+        "jwk",
+        { ...privateJwk, kid, alg: "ES256", use: "sig" },
+        { name: "ECDSA", namedCurve: "P-256" },
+        false,
+        ["sign"],
+      ));
+
+    const result = await verifyEdgeRuntimeJwtContext({
+      jwtJwks: { keys: [{ ...publicJwk, kid, alg: "ES256", use: "sig" }] },
+    }, `Bearer ${token}`);
+
+    expect(result).toMatchObject({
+      verified: true,
+      source: "jwt",
+      payload: { sub: "00000000-0000-4000-8000-000000000001" },
+    });
+  });
+
+  test("overwrites spoofed verified-sub headers and preserves the request body", async () => {
+    const spoofed = new Request("https://example.com/functions/v1/fa", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer user-token",
+        "Content-Type": "application/json",
+        [VERIFIED_JWT_SUB_HEADER]: "attacker-controlled",
+      },
+      body: JSON.stringify({ action: "analyze" }),
+    });
+
+    const trusted = withVerifiedJwtContext(spoofed, {
+      sub: "00000000-0000-4000-8000-000000000002",
+    });
+    expect(trusted.headers.get(VERIFIED_JWT_SUB_HEADER)).toBe(
+      "00000000-0000-4000-8000-000000000002",
+    );
+    expect(trusted.method).toBe("POST");
+    expect(await trusted.json()).toEqual({ action: "analyze" });
+  });
+
+  test("strips spoofed verified-sub headers without verified JWT claims", () => {
+    const spoofed = new Request("https://example.com/functions/v1/fa", {
+      headers: {
+        Authorization: "Bearer user-token",
+        [VERIFIED_JWT_SUB_HEADER]: "attacker-controlled",
+      },
+    });
+
+    const stripped = withVerifiedJwtContext(spoofed);
+    expect(stripped.headers.has(VERIFIED_JWT_SUB_HEADER)).toBe(false);
+    expect(stripped.headers.get("authorization")).toBe("Bearer user-token");
+  });
+
   test("keeps legacy api key bypasses for anon and service_role", async () => {
     expect(await verifyEdgeRuntimeJwt({
       anonKey: "anon-key",
@@ -38,6 +107,37 @@ describe("verifyEdgeRuntimeJwt", () => {
       anonKey: "anon-key",
       serviceRoleKey: "service-role-key",
     }, "Bearer service-role-key")).toBe(true);
+  });
+
+  test("verifies a user bearer JWT even when supabase-js also sends the anon apikey", async () => {
+    const jwtSecret = "legacy-secret-with-at-least-32-characters";
+    const token = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setSubject("00000000-0000-4000-8000-000000000003")
+      .setIssuedAt()
+      .setExpirationTime("5m")
+      .sign(new TextEncoder().encode(jwtSecret));
+
+    const result = await verifyEdgeRuntimeJwtContext({
+      anonKey: "anon-key",
+      jwtSecret,
+    }, `Bearer ${token}`, "anon-key");
+
+    expect(result).toMatchObject({
+      verified: true,
+      source: "jwt",
+      payload: { sub: "00000000-0000-4000-8000-000000000003" },
+    });
+  });
+
+  test("does not let a valid anon apikey mask an invalid bearer JWT", async () => {
+    expect(await verifyEdgeRuntimeJwtContext({
+      anonKey: "anon-key",
+      jwtSecret: "legacy-secret-with-at-least-32-characters",
+    }, "Bearer forged-user-token", "anon-key")).toEqual({
+      verified: false,
+      source: "none",
+    });
   });
 
   test("normalizes JWKS JSON from runtime env", () => {

--- a/packages/edge-runtime/jwt-verifier.ts
+++ b/packages/edge-runtime/jwt-verifier.ts
@@ -1,4 +1,18 @@
-import { createLocalJWKSet, jwtVerify, type JWK } from "jose";
+import { createLocalJWKSet, jwtVerify, type JWK, type JWTPayload } from "jose";
+
+export const VERIFIED_JWT_SUB_HEADER = "x-supacloud-jwt-sub";
+
+export type EdgeRuntimeJwtVerificationResult =
+  | { verified: false; source: "none" }
+  | {
+    verified: true;
+    source: "anon_key" | "service_role_key";
+  }
+  | {
+    verified: true;
+    source: "jwt";
+    payload: JWTPayload;
+  };
 
 export type EdgeRuntimeProjectSecrets = {
   anonKey?: string;
@@ -29,40 +43,86 @@ export function normalizeJwtJwks(value: unknown): { keys: JWK[] } | null {
   return { keys: keys as JWK[] };
 }
 
+export async function verifyEdgeRuntimeJwtContext(
+  secrets: EdgeRuntimeProjectSecrets,
+  authHeader: string | null | undefined,
+  apikeyHeader?: string | null,
+): Promise<EdgeRuntimeJwtVerificationResult> {
+  const anonKey = secrets.anonKey || "";
+  const serviceRoleKey = secrets.serviceRoleKey || "";
+
+  if (authHeader) {
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    if (!token) return { verified: false, source: "none" };
+
+    if (token === anonKey || token === serviceRoleKey) {
+      return {
+        verified: true,
+        source: token === anonKey ? "anon_key" : "service_role_key",
+      };
+    }
+
+    if (secrets.jwtJwks) {
+      try {
+        const { payload } = await jwtVerify(token, createLocalJWKSet(secrets.jwtJwks));
+        return { verified: true, source: "jwt", payload };
+      } catch {
+        // Fall through to legacy HS256 verification for old tokens without kid.
+      }
+    }
+
+    if (secrets.jwtSecret) {
+      try {
+        const { payload } = await jwtVerify(
+          token,
+          new TextEncoder().encode(secrets.jwtSecret),
+        );
+        return { verified: true, source: "jwt", payload };
+      } catch {
+        return { verified: false, source: "none" };
+      }
+    }
+
+    return { verified: false, source: "none" };
+  }
+
+  if (apikeyHeader && apikeyHeader === anonKey) {
+    return { verified: true, source: "anon_key" };
+  }
+  if (apikeyHeader && apikeyHeader === serviceRoleKey) {
+    return { verified: true, source: "service_role_key" };
+  }
+
+  return { verified: false, source: "none" };
+}
+
 export async function verifyEdgeRuntimeJwt(
   secrets: EdgeRuntimeProjectSecrets,
   authHeader: string | null | undefined,
   apikeyHeader?: string | null,
 ): Promise<boolean> {
-  const anonKey = secrets.anonKey || "";
-  const serviceRoleKey = secrets.serviceRoleKey || "";
+  return (await verifyEdgeRuntimeJwtContext(
+    secrets,
+    authHeader,
+    apikeyHeader,
+  )).verified;
+}
 
-  if (apikeyHeader && (apikeyHeader === anonKey || apikeyHeader === serviceRoleKey)) {
-    return true;
+/**
+ * Only the Edge Runtime may set this header. Incoming values are always removed,
+ * then replaced with the subject from the JWT payload verified by the gateway.
+ */
+export function withVerifiedJwtContext(
+  request: Request,
+  payload?: Pick<JWTPayload, "sub">,
+): Request {
+  const headers = new Headers(request.headers);
+  headers.delete(VERIFIED_JWT_SUB_HEADER);
+
+  const subject = typeof payload?.sub === "string" ? payload.sub.trim() : "";
+  if (subject) {
+    headers.set(VERIFIED_JWT_SUB_HEADER, subject);
   }
 
-  if (!authHeader) return false;
-  const token = authHeader.replace(/^Bearer\s+/i, "");
-  if (!token) return false;
-
-  if (token === anonKey || token === serviceRoleKey) {
-    return true;
-  }
-
-  if (secrets.jwtJwks) {
-    try {
-      await jwtVerify(token, createLocalJWKSet(secrets.jwtJwks));
-      return true;
-    } catch {
-      // Fall through to legacy HS256 verification for old tokens without kid.
-    }
-  }
-
-  if (!secrets.jwtSecret) return false;
-  try {
-    await jwtVerify(token, new TextEncoder().encode(secrets.jwtSecret));
-    return true;
-  } catch {
-    return false;
-  }
+  return new Request(request, { headers });
 }

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -7,7 +7,12 @@ import {
   loadTenantEnv,
   withBackgroundInternalToken,
 } from "./tenant-env";
-import { normalizeJwtJwks, verifyEdgeRuntimeJwt } from "./jwt-verifier";
+import {
+  normalizeJwtJwks,
+  verifyEdgeRuntimeJwtContext,
+  withVerifiedJwtContext,
+  type EdgeRuntimeJwtVerificationResult,
+} from "./jwt-verifier";
 import {
   buildBackgroundForwardDispatch,
 } from "./background-forward";
@@ -575,15 +580,19 @@ async function verifyJwt(
   projectRef: string,
   authHeader: string | null | undefined,
   apikeyHeader?: string | null,
-): Promise<boolean> {
+): Promise<EdgeRuntimeJwtVerificationResult> {
   const secrets = await getProjectSecrets(projectRef);
-  if (!secrets) return false;
+  if (!secrets) return { verified: false, source: "none" };
 
-  const verified = await verifyEdgeRuntimeJwt(secrets, authHeader, apikeyHeader);
-  if (!verified) {
+  const result = await verifyEdgeRuntimeJwtContext(
+    secrets,
+    authHeader,
+    apikeyHeader,
+  );
+  if (!result.verified) {
     console.warn(`[verifyJwt] JWT verification failed for ${projectRef}`);
   }
-  return verified;
+  return result;
 }
 
 async function handleFunctionRequest(
@@ -608,13 +617,14 @@ async function handleFunctionRequest(
 
   const projectRoot = await resolveProjectRoot(projectRef);
   const fnConfig = await getFunctionConfig(projectRef, functionName, projectRoot);
+  let functionRequest = withVerifiedJwtContext(c.request);
   if (c.request.method !== "OPTIONS" && fnConfig.verify_jwt) {
-    const authorized = await verifyJwt(
+    const verification = await verifyJwt(
       projectRef,
       authHeader,
       apikeyHeader,
     );
-    if (!authorized) {
+    if (!verification.verified) {
       const rateLimitResponse = await recordAuthFailure(projectRef, functionName, authHeader, apikeyHeader);
       if (rateLimitResponse) return rateLimitResponse;
       return new Response(JSON.stringify({ msg: "Invalid JWT" }), {
@@ -625,13 +635,17 @@ async function handleFunctionRequest(
         },
       });
     }
+    functionRequest = withVerifiedJwtContext(
+      c.request,
+      verification.source === "jwt" ? verification.payload : undefined,
+    );
   }
 
   c.set.headers["x-sb-execution-id"] = crypto.randomUUID();
   const response = await dispatchFunction(
     projectRef,
     functionName,
-    c.request,
+    functionRequest,
     c.set.headers as Record<string, string>,
   );
 


### PR DESCRIPTION
## Summary

- expose the verified JWT subject to Edge Functions through the runtime-owned `x-supacloud-jwt-sub` header
- strip client-spoofed subject headers from foreground and background dispatch
- ensure a valid anon `apikey` cannot mask an invalid bearer JWT
- document the RLS-safe membership lookup pattern
- ignore generated `.agents/docs/` output

## Security model

Only JWTs cryptographically verified by the Edge Runtime receive a subject header. API-key bypasses do not receive one, and incoming values are always removed before dispatch.

## Verification

- `bun test` in `packages/edge-runtime`: 41 pass, 0 fail
- focused JWT/background tests: 12 pass, 0 fail
- `bun run typecheck`
- `git diff --check`
