### PR TITLE
fix(supacloud-js): support SupAuth OAuth refresh

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -137,6 +137,8 @@ jobs:
           bun install --frozen-lockfile
           bun run typecheck
           bun run typecheck:test
+          bun run build
+          bun run typecheck:consumer
           bun test src/index.test.ts src/auth-fetch.test.ts
           bun audit --audit-level high
 

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -137,7 +137,7 @@ jobs:
           bun install --frozen-lockfile
           bun run typecheck
           bun run typecheck:test
-          bun test src/index.test.ts
+          bun test src/index.test.ts src/auth-fetch.test.ts
           bun audit --audit-level high
 
       - name: Check edge runtime

--- a/packages/supacloud-js/README.md
+++ b/packages/supacloud-js/README.md
@@ -76,9 +76,10 @@ environment configuration without maintaining a second session implementation.
 The adapter only transforms `POST /auth/v1/token?grant_type=refresh_token`:
 it sends the same refresh token as an OAuth form request, moves
 `grant_type=refresh_token` into the form body, and adds `client_id` when the
-request does not already contain one. All other Supabase Auth,
-Database, Storage, Realtime, and Functions requests pass through unchanged.
-Never pass a client secret to browser code.
+request does not already contain one. Rewritten refresh requests reject HTTP
+redirects instead of forwarding the refresh token to a second endpoint. All
+other Supabase Auth, Database, Storage, Realtime, and Functions requests pass
+through unchanged. Never pass a client secret to browser code.
 
 ## SupAuth Management
 

--- a/packages/supacloud-js/README.md
+++ b/packages/supacloud-js/README.md
@@ -47,6 +47,39 @@ const finalState = await task.wait();
 console.log(finalState.status);
 ```
 
+## SupAuth OAuth refresh with `supabase-js`
+
+SupAuth OAuth public clients can require `client_id` on refresh-token requests.
+Keep using `@supabase/supabase-js` for session storage, locking, and automatic
+refresh, and provide the SupaCloud transport adapter when creating the client:
+
+```ts
+import { createClient } from "@supabase/supabase-js";
+import { createSupaCloudOAuthFetch } from "@supacloud/js";
+
+const supabase = createClient("https://auth.example.com", "anon-key", {
+  global: {
+    fetch: createSupaCloudOAuthFetch({
+      clientId: "public-oauth-client-id",
+      tokenEndpoint: "https://auth.example.com/auth/v1/oauth/token",
+    }),
+  },
+});
+```
+
+For a standard single-project Supabase app without SupAuth, omit `clientId` (or
+omit the adapter entirely). With no `clientId`, the returned transport is a
+transparent pass-through, so the regular `/auth/v1/token` refresh flow remains
+unchanged. This allows shared application setup to enable SupAuth by
+environment configuration without maintaining a second session implementation.
+
+The adapter only transforms `POST /auth/v1/token?grant_type=refresh_token`:
+it sends the same refresh token as an OAuth form request, moves
+`grant_type=refresh_token` into the form body, and adds `client_id` when the
+request does not already contain one. All other Supabase Auth,
+Database, Storage, Realtime, and Functions requests pass through unchanged.
+Never pass a client secret to browser code.
+
 ## SupAuth Management
 
 `supacloud.supauth` is a management-plane helper for provisioning and verifying a SupAuth/SupaOAuth runtime on SupaCloud. It is intended for trusted server-side tools, CI jobs, or admin backends that can call the SupaCloud Management API.

--- a/packages/supacloud-js/package.json
+++ b/packages/supacloud-js/package.json
@@ -23,6 +23,7 @@
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
     "clean": "rm -rf dist",
     "prepublishOnly": "bun run build",
+    "typecheck:consumer": "tsc -p tsconfig.consumer.json --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },

--- a/packages/supacloud-js/src/auth-fetch.test.ts
+++ b/packages/supacloud-js/src/auth-fetch.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import { createClient } from "@supabase/supabase-js";
+import { createSupaCloudOAuthFetch } from "./auth-fetch";
+
+describe("createSupaCloudOAuthFetch", () => {
+  test("passes non-refresh requests through unchanged", async () => {
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const transport = createSupaCloudOAuthFetch({
+      clientId: "client_1",
+      fetch: async (input, init) => {
+        calls.push({ input, init });
+        return new Response("ok");
+      },
+    });
+
+    await transport("https://auth.example.com/auth/v1/user", { method: "GET" });
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.input).toBe("https://auth.example.com/auth/v1/user");
+    expect(calls[0]?.init).toMatchObject({ method: "GET" });
+  });
+
+  test("rewrites Supabase JSON refresh requests to the OAuth endpoint", async () => {
+    const calls: Request[] = [];
+    const transport = createSupaCloudOAuthFetch({
+      clientId: "client_1",
+      tokenEndpoint: "https://auth.example.com/auth/v1/oauth/token",
+      fetch: async (input) => {
+        calls.push(input instanceof Request ? input : new Request(input));
+        return new Response("ok");
+      },
+    });
+
+    await transport("https://auth.example.com/auth/v1/token?grant_type=refresh_token", {
+      method: "POST",
+      headers: {
+        apikey: "anon-key",
+        authorization: "Bearer current-session-token",
+        cookie: "session=browser-cookie",
+        "proxy-authorization": "Basic proxy-credentials",
+        "x-client-info": "supabase-js",
+      },
+      body: JSON.stringify({ refresh_token: "refresh_1" }),
+    });
+
+    const captured = calls[0]!;
+    expect(captured.url).toBe("https://auth.example.com/auth/v1/oauth/token");
+    expect(captured.method).toBe("POST");
+    expect(captured.headers.get("apikey")).toBe("anon-key");
+    expect(captured.headers.get("authorization")).toBe(null);
+    expect(captured.headers.get("cookie")).toBe(null);
+    expect(captured.headers.get("proxy-authorization")).toBe(null);
+    expect(captured.headers.get("x-client-info")).toBe("supabase-js");
+    expect(captured.headers.get("content-type")).toContain("application/x-www-form-urlencoded");
+    expect(await captured.text()).toBe(
+      "refresh_token=refresh_1&grant_type=refresh_token&client_id=client_1",
+    );
+  });
+
+  test("preserves an existing client_id and supports Request input", async () => {
+    const calls: Request[] = [];
+    const transport = createSupaCloudOAuthFetch({
+      clientId: "client_default",
+      fetch: async (input) => {
+        calls.push(input instanceof Request ? input : new Request(input));
+        return new Response("ok");
+      },
+    });
+    const request = new Request("https://auth.example.com/auth/v1/token?grant_type=refresh_token", {
+      method: "POST",
+      body: "refresh_token=refresh_2&client_id=client_existing",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+
+    await transport(request);
+    const captured = calls[0]!;
+    expect(captured.url).toBe("https://auth.example.com/auth/v1/oauth/token");
+    expect(await captured.text()).toBe(
+      "refresh_token=refresh_2&client_id=client_existing&grant_type=refresh_token",
+    );
+  });
+
+  test("preserves a reverse-proxy path prefix and rejects cross-origin endpoints", async () => {
+    const calls: Request[] = [];
+    const transport = createSupaCloudOAuthFetch({
+      clientId: "client_1",
+      fetch: async (input) => {
+        calls.push(input instanceof Request ? input : new Request(input));
+        return new Response("ok");
+      },
+    });
+    await transport("https://auth.example.com/tenant/auth/v1/token?grant_type=refresh_token", {
+      method: "POST",
+      body: JSON.stringify({ refresh_token: "refresh_3" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(calls[0]?.url).toBe("https://auth.example.com/tenant/auth/v1/oauth/token");
+
+    let message = "";
+    try {
+      await createSupaCloudOAuthFetch({
+        clientId: "client_1",
+        tokenEndpoint: "https://other.example.com/auth/v1/oauth/token",
+      })("https://auth.example.com/auth/v1/token?grant_type=refresh_token", {
+        method: "POST",
+        body: JSON.stringify({ refresh_token: "refresh_4" }),
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain("must use the Supabase Auth origin");
+  });
+
+  test("is a transparent pass-through for a single-project Supabase app", async () => {
+    const calls: Request[] = [];
+    const supabase = createClient("https://project.example.com", "anon-key", {
+      auth: { autoRefreshToken: false, persistSession: false },
+      global: {
+        fetch: createSupaCloudOAuthFetch({
+          fetch: async (input, init) => {
+            calls.push(input instanceof Request ? input : new Request(input, init));
+            return Response.json({
+              access_token: "project_access_2",
+              refresh_token: "project_refresh_2",
+              expires_in: 3600,
+              token_type: "bearer",
+              user: { id: "user_1", aud: "authenticated", role: "authenticated" },
+            });
+          },
+        }),
+      },
+    });
+
+    const { data, error } = await supabase.auth.refreshSession({
+      refresh_token: "project_refresh_1",
+    });
+    expect(error).toBe(null);
+    expect(data.session?.access_token).toBe("project_access_2");
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.url).toBe(
+      "https://project.example.com/auth/v1/token?grant_type=refresh_token",
+    );
+    expect(calls[0]?.headers.get("content-type")).toContain("application/json");
+    const body = JSON.parse(await calls[0]!.text()) as { refresh_token?: string };
+    expect(body.refresh_token).toBe("project_refresh_1");
+  });
+
+  test("keeps supabase-js in charge of refresh session lifecycle", async () => {
+    const calls: Request[] = [];
+    const authFetch = createSupaCloudOAuthFetch({
+      clientId: "client_1",
+      fetch: async (input) => {
+        const request = input instanceof Request ? input : new Request(input);
+        calls.push(request);
+        return Response.json({
+          access_token: "access_2",
+          refresh_token: "refresh_2",
+          expires_in: 3600,
+          token_type: "bearer",
+          user: { id: "user_1", aud: "authenticated", role: "authenticated" },
+        });
+      },
+    });
+    const supabase = createClient("https://auth.example.com", "anon-key", {
+      auth: { autoRefreshToken: false, persistSession: false },
+      global: { fetch: authFetch },
+    });
+
+    const { data, error } = await supabase.auth.refreshSession({ refresh_token: "refresh_1" });
+    expect(error).toBe(null);
+    expect(data.session?.access_token).toBe("access_2");
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.url).toBe("https://auth.example.com/auth/v1/oauth/token");
+    expect(await calls[0]!.text()).toBe(
+      "refresh_token=refresh_1&grant_type=refresh_token&client_id=client_1",
+    );
+  });
+});

--- a/packages/supacloud-js/src/auth-fetch.test.ts
+++ b/packages/supacloud-js/src/auth-fetch.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { createClient } from "@supabase/supabase-js";
 import { createSupaCloudOAuthFetch } from "./auth-fetch";
 
+declare const Bun: {
+  serve(options: {
+    port: number;
+    fetch(request: Request): Response | Promise<Response>;
+  }): {
+    port: number;
+    stop(closeActiveConnections?: boolean): void | Promise<void>;
+  };
+};
+
 describe("createSupaCloudOAuthFetch", () => {
   test("passes non-refresh requests through unchanged", async () => {
     const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
@@ -108,6 +118,45 @@ describe("createSupaCloudOAuthFetch", () => {
       message = error instanceof Error ? error.message : String(error);
     }
     expect(message).toContain("must use the Supabase Auth origin");
+  });
+
+  test("does not follow redirects from the OAuth token endpoint", async () => {
+    const redirectedBodies: string[] = [];
+    const redirected = Bun.serve({
+      port: 0,
+      async fetch(request: Request) {
+        redirectedBodies.push(await request.text());
+        return new Response("unexpected redirect target");
+      },
+    });
+    const redirectedUrl = `http://127.0.0.1:${redirected.port}/capture`;
+    const auth = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.redirect(redirectedUrl, 307);
+      },
+    });
+
+    try {
+      const origin = `http://127.0.0.1:${auth.port}`;
+      const transport = createSupaCloudOAuthFetch({ clientId: "client_1" });
+      let message = "";
+      try {
+        await transport(`${origin}/auth/v1/token?grant_type=refresh_token`, {
+          method: "POST",
+          body: JSON.stringify({ refresh_token: "refresh_secret" }),
+          headers: { "content-type": "application/json" },
+        });
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+
+      expect(message === "").toBe(false);
+      expect(redirectedBodies.length).toBe(0);
+    } finally {
+      await auth.stop(true);
+      await redirected.stop(true);
+    }
   });
 
   test("is a transparent pass-through for a single-project Supabase app", async () => {

--- a/packages/supacloud-js/src/auth-fetch.ts
+++ b/packages/supacloud-js/src/auth-fetch.ts
@@ -1,0 +1,114 @@
+export type SupaCloudOAuthFetchOptions = {
+  /**
+   * Public OAuth client identifier registered with SupAuth. Leave empty for a
+   * standard single-project Supabase deployment; the transport then becomes a
+   * transparent pass-through.
+   */
+  clientId?: string | null;
+  /**
+   * OAuth token endpoint. When omitted, `/auth/v1/oauth/token` is derived from
+   * the Supabase Auth refresh URL origin.
+   */
+  tokenEndpoint?: string;
+  /** Injectable transport for tests or runtimes with a custom fetch. */
+  fetch?: typeof fetch;
+};
+
+function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  return (init?.method || (input instanceof Request ? input.method : "GET")).toUpperCase();
+}
+
+function isRefreshTokenRequest(url: URL, method: string): boolean {
+  return method === "POST"
+    && url.pathname.endsWith("/auth/v1/token")
+    && url.searchParams.get("grant_type") === "refresh_token";
+}
+
+function parseRefreshBody(body: string, contentType: string): URLSearchParams | null {
+  if (!body) return null;
+  if (contentType.toLowerCase().includes("application/json") || body.trimStart().startsWith("{")) {
+    let value: unknown;
+    try { value = JSON.parse(body); } catch { return null; }
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const record = value as Record<string, unknown>;
+    const refreshToken = typeof record.refresh_token === "string" ? record.refresh_token.trim() : "";
+    if (!refreshToken) return null;
+    const params = new URLSearchParams();
+    for (const [key, item] of Object.entries(record)) {
+      if (typeof item === "string") params.set(key, item);
+    }
+    return params;
+  }
+  const params = new URLSearchParams(body);
+  return params.get("refresh_token")?.trim() ? params : null;
+}
+
+function replacementRequest(
+  request: Request,
+  tokenEndpoint: string,
+  body: URLSearchParams,
+): Request {
+  const headers = new Headers(request.headers);
+  headers.set("content-type", "application/x-www-form-urlencoded");
+  headers.delete("content-length");
+  headers.delete("authorization");
+  headers.delete("cookie");
+  headers.delete("proxy-authorization");
+  return new Request(tokenEndpoint, {
+    method: "POST",
+    headers,
+    body,
+    cache: request.cache,
+    credentials: request.credentials,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    mode: request.mode,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    signal: request.signal,
+  });
+}
+
+/**
+ * Adapts Supabase Auth's built-in refresh request to SupAuth's OAuth token
+ * contract while leaving every other supabase-js request untouched.
+ *
+ * Usage:
+ * createClient(authUrl, anonKey, {
+ *   global: { fetch: createSupaCloudOAuthFetch({ clientId }) },
+ * });
+ */
+export function createSupaCloudOAuthFetch(
+  options: SupaCloudOAuthFetchOptions = {},
+): typeof fetch {
+  const fetchImpl = options.fetch || globalThis.fetch.bind(globalThis);
+  const clientId = options.clientId?.trim();
+  if (!clientId) return fetchImpl;
+
+  return async (input, init) => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (!isRefreshTokenRequest(url, requestMethod(input, init))) {
+      return fetchImpl(input, init);
+    }
+
+    const request = new Request(input, init);
+    const body = parseRefreshBody(
+      await request.clone().text(),
+      request.headers.get("content-type") || "",
+    );
+    if (!body) return fetchImpl(input, init);
+
+    body.set("grant_type", "refresh_token");
+    if (!body.get("client_id")) body.set("client_id", clientId);
+    const endpoint = options.tokenEndpoint?.trim()
+      || new URL(
+        url.pathname.replace(/\/auth\/v1\/token$/, "/auth/v1/oauth/token"),
+        url.origin,
+      ).toString();
+    if (new URL(endpoint).origin !== url.origin) {
+      throw new Error("SupaCloud OAuth tokenEndpoint must use the Supabase Auth origin");
+    }
+    return fetchImpl(replacementRequest(request, endpoint, body));
+  };
+}

--- a/packages/supacloud-js/src/auth-fetch.ts
+++ b/packages/supacloud-js/src/auth-fetch.ts
@@ -63,7 +63,7 @@ function replacementRequest(
     integrity: request.integrity,
     keepalive: request.keepalive,
     mode: request.mode,
-    redirect: request.redirect,
+    redirect: "error",
     referrer: request.referrer,
     referrerPolicy: request.referrerPolicy,
     signal: request.signal,

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -3,6 +3,11 @@ import type {
   SupabaseClient,
 } from "@supabase/supabase-js";
 
+export {
+  createSupaCloudOAuthFetch,
+  type SupaCloudOAuthFetchOptions,
+} from "./auth-fetch";
+
 export type SupaCloudTaskStatus =
   | "pending"
   | "leased"

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -6,7 +6,7 @@ import type {
 export {
   createSupaCloudOAuthFetch,
   type SupaCloudOAuthFetchOptions,
-} from "./auth-fetch";
+} from "./auth-fetch.js";
 
 export type SupaCloudTaskStatus =
   | "pending"

--- a/packages/supacloud-js/test/consumer-node-next.ts
+++ b/packages/supacloud-js/test/consumer-node-next.ts
@@ -1,0 +1,10 @@
+import {
+  createSupaCloudOAuthFetch,
+  type SupaCloudOAuthFetchOptions,
+} from "@supacloud/js";
+
+const options = {
+  clientId: "public-client",
+} satisfies SupaCloudOAuthFetchOptions;
+
+void createSupaCloudOAuthFetch(options);

--- a/packages/supacloud-js/test/supabase-js-stub.d.ts
+++ b/packages/supacloud-js/test/supabase-js-stub.d.ts
@@ -1,0 +1,1 @@
+export interface SupabaseClient {}

--- a/packages/supacloud-js/tsconfig.consumer.json
+++ b/packages/supacloud-js/tsconfig.consumer.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "paths": {
+      "@supabase/supabase-js": ["./test/supabase-js-stub.d.ts"]
+    },
+    "strict": true,
+    "skipLibCheck": false,
+    "noEmit": true
+  },
+  "include": [
+    "test/consumer-node-next.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- add createSupaCloudOAuthFetch for SupAuth public OAuth clients while keeping @supabase/supabase-js in charge of persistence, locking, and automatic refresh
- preserve standard single-project Supabase behavior when clientId is omitted
- rewrite only POST /auth/v1/token?grant_type=refresh_token to the same-origin OAuth token endpoint
- send refresh_token, grant_type=refresh_token, and public client_id as form data
- strip Authorization, Cookie, and Proxy-Authorization from the replacement request and reject cross-origin token endpoints
- run the new adapter tests in package CI

## Why

Supabase Auth refresh requests do not include the OAuth client_id required for SupAuth OAuth sessions. Applications had to disable built-in refresh or duplicate session lifecycle code. This adapter changes only the transport request, so consumers can continue using the official Supabase SDK.

## Compatibility

- Single-project app without SupAuth: omit clientId and requests pass through unchanged.
- SupAuth user center: configure a public clientId and keep the Supabase client pointed at the SupAuth origin.

## Verification

- bun run typecheck
- bun run typecheck:test
- bun test src/index.test.ts src/auth-fetch.test.ts (19 passed)
- bun run build
- bun audit --audit-level high (official npm registry; no vulnerabilities)
- real supabase.auth.refreshSession() coverage for both standard Supabase and SupAuth OAuth modes