### PR TITLE
fix(auth): close shared runtime boundary gaps

### DIFF
--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -307,7 +307,14 @@ async function translateOpaqueApiKeyHeaders(
         }
     }
 
-    if (bearerToken && (isOpaqueApiKey(bearerToken) || bearerToken === apikey)) {
+    // Shared mode must also resolve legacy API-key bearers. Otherwise a
+    // dependent service_role JWT could reach the owner unchanged and become
+    // an owner admin credential when historical projects share a JWT secret.
+    if (bearerToken && (
+        authAuthorityRef !== ref
+        || isOpaqueApiKey(bearerToken)
+        || bearerToken === apikey
+    )) {
         const upstream = await resolveUpstream(bearerToken);
         if (upstream === null) return false;
         if (upstream) headers.set("authorization", `Bearer ${upstream}`);

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -396,6 +396,65 @@ describe("sdkProxyRoutes functions proxy", () => {
     }
   });
 
+  test("shared auth proxy rejects a dependent legacy service-role bearer paired with an anon apikey", async () => {
+    const originalOwnerRef = config.authRuntimeOwnerRef;
+    const originalGetApiKeys = projectService.getApiKeys;
+    config.authRuntimeOwnerRef = "auth-owner";
+    projectService.getApiKeys = async (ref: string) => ref === "auth-owner"
+      ? {
+        anon_key: "owner-anon-jwt",
+        service_role_key: "owner-service-jwt",
+        publishable_key: "owner-publishable",
+        secret_key: "owner-secret",
+      }
+      : null;
+
+    try {
+      await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+        trackSpy(
+          spyOn(sdkProxyInternals, "resolveProjectApiKey").mockImplementation(async (candidate: string) => {
+            if (candidate === "sb_publishable_client_key") {
+              return {
+                ref: "proj_1",
+                kind: "publishable",
+                role: "anon",
+                upstreamKey: "dependent-anon-jwt",
+              };
+            }
+            if (candidate === "dependent-service-jwt") {
+              return {
+                ref: "proj_1",
+                kind: "service_role",
+                role: "service_role",
+                upstreamKey: "dependent-service-jwt",
+              };
+            }
+            return null;
+          }),
+        );
+        setSdkProxySqlForTests(async (...args: unknown[]) => {
+          const text = String(args[0] ?? "");
+          if (text.includes("SELECT config")) return [{ config: { gotrue_port: 9361, postgrest_port: 7361 } }];
+          return [];
+        });
+
+        const response = await request("/auth/v1/admin/users", {
+          headers: {
+            apikey: "sb_publishable_client_key",
+            authorization: "Bearer dependent-service-jwt",
+          },
+        });
+
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ message: "Invalid API key" });
+        expect(calls).toHaveLength(0);
+      });
+    } finally {
+      config.authRuntimeOwnerRef = originalOwnerRef;
+      projectService.getApiKeys = originalGetApiKeys;
+    }
+  });
+
   test("REST proxy translates a publishable key to the legacy anon JWT", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
       trackSpy(


### PR DESCRIPTION
## Summary
- bind legacy and opaque Bearer API keys to the requesting project and reject dependent `service_role` credentials before owner GoTrue
- close the generic `/settings` auth-config bypass for shared dependents
- make SupAuth owner routing override stale dependent external-auth upstreams, including TLS settings
- require the owner issuer as well as owner JWKS signature and `authenticated` role in Management API and Edge Runtime

## Follow-up
- Parent: #469 (already merged)
- Reason: #469 was merged before these security regressions were identified and fixed

## Verification
- legacy service-role regression reproduced old behavior as 200/upstream, then passes as 401/no upstream
- Management targeted auth boundary/JWT/gateway/proxy tests: 46/46
- Edge Runtime JWT/cache tests: 11/11; typecheck PASS
- Management API typecheck PASS
- Management API full unit: 753 shared tests passed, all isolated suites passed
- `git diff --check` PASS
