### PR TITLE
fix(auth): close SupAuth shared runtime boundary gaps

### DIFF
--- a/packages/edge-runtime/jwt-verifier.test.ts
+++ b/packages/edge-runtime/jwt-verifier.test.ts
@@ -163,18 +163,35 @@ describe("verifyEdgeRuntimeJwt", () => {
     const userToken = await new SignJWT({ role: "authenticated" })
       .setProtectedHeader({ alg: "ES256", kid })
       .setSubject("user_1")
+      .setIssuer("https://auth-owner.example.com/auth/v1")
       .setExpirationTime("5m")
       .sign(signingKey);
     const serviceToken = await new SignJWT({ role: "service_role" })
       .setProtectedHeader({ alg: "ES256", kid })
+      .setIssuer("https://auth-owner.example.com/auth/v1")
       .setExpirationTime("5m")
       .sign(signingKey);
     const secrets = {
       authRuntimeMode: "shared" as const,
+      authIssuer: "https://auth-owner.example.com/auth/v1",
       jwtJwks: { keys: [{ ...publicJwk, kid, alg: "ES256", use: "sig" }] },
     };
 
     expect(await verifyEdgeRuntimeJwt(secrets, `Bearer ${userToken}`)).toBe(true);
     expect(await verifyEdgeRuntimeJwt(secrets, `Bearer ${serviceToken}`)).toBe(false);
+
+    const wrongIssuerToken = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setIssuer("https://attacker.example.com/auth/v1")
+      .setExpirationTime("5m")
+      .sign(signingKey);
+    expect(await verifyEdgeRuntimeJwt(secrets, `Bearer ${wrongIssuerToken}`)).toBe(false);
+
+    const missingIssuerToken = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setExpirationTime("5m")
+      .sign(signingKey);
+    expect(await verifyEdgeRuntimeJwt(secrets, `Bearer ${missingIssuerToken}`)).toBe(false);
+    expect(await verifyEdgeRuntimeJwt({ ...secrets, authIssuer: "" }, `Bearer ${userToken}`)).toBe(false);
   });
 });

--- a/packages/edge-runtime/jwt-verifier.ts
+++ b/packages/edge-runtime/jwt-verifier.ts
@@ -21,6 +21,7 @@ export type EdgeRuntimeProjectSecrets = {
   jwtJwks?: { keys: JWK[] } | null;
   thirdParty?: EdgeRuntimeThirdPartyJwtPolicy | null;
   authRuntimeMode?: "local" | "owner" | "shared";
+  authIssuer?: string;
 };
 
 export type EdgeRuntimeThirdPartyJwtPolicy = {
@@ -162,8 +163,15 @@ export async function verifyEdgeRuntimeJwtContext(
     try {
       const localKeys = secrets.jwtJwks.keys.filter((key) => !isExternalKey(key, secrets.thirdParty ?? null));
       if (localKeys.length > 0) {
+        const sharedIssuer = secrets.authRuntimeMode === "shared"
+          ? secrets.authIssuer?.trim()
+          : undefined;
+        if (secrets.authRuntimeMode === "shared" && !sharedIssuer) {
+          return { verified: false, source: "none" };
+        }
         const verified = await jwtVerify(token, createLocalJWKSet({ keys: localKeys }), {
           algorithms: ["ES256", "RS256"],
+          ...(sharedIssuer ? { issuer: sharedIssuer } : {}),
         });
         if (secrets.authRuntimeMode === "shared" && verified.payload.role !== "authenticated") {
           return { verified: false, source: "none" };

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -501,6 +501,7 @@ interface ProjectSecrets {
   jwtJwks: ReturnType<typeof normalizeJwtJwks>;
   thirdParty: ReturnType<typeof normalizeThirdPartyJwtPolicy>;
   authRuntimeMode: "local" | "owner" | "shared";
+  authIssuer: string;
   expiresAt: number;
 }
 const secretsCache = new Map<string, ProjectSecrets>();
@@ -531,6 +532,7 @@ async function getProjectSecrets(
           : runtimeEnv.SUPACLOUD_AUTH_RUNTIME_MODE === "owner"
             ? "owner"
             : "local",
+        authIssuer: runtimeEnv.SUPACLOUD_AUTH_ISSUER || "",
         expiresAt: Date.now() + SECRETS_CACHE_TTL,
       };
       secretsCache.set(projectRef, secrets);
@@ -587,6 +589,7 @@ async function getProjectSecrets(
       jwtJwks: normalizeJwtJwks(detail.config?.auth?.oauth_server?.jwt_jwks),
       thirdParty: normalizeThirdPartyJwtPolicy(detail.config?.auth?.third_party_auth),
       authRuntimeMode: authRuntime.mode === "owner" ? "owner" : "local",
+      authIssuer: "",
       expiresAt: Date.now() + SECRETS_CACHE_TTL,
     };
     secretsCache.set(projectRef, secrets);

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -459,6 +459,21 @@ function buildAuthConfigResponse(settings: Record<string, unknown>) {
   return response;
 }
 
+function buildSharedSettingsResponse(
+  settings: Record<string, unknown>,
+  authorityProjectRef: unknown,
+) {
+  const { auth: _auth, ...safeSettings } = settings;
+  return {
+    ...safeSettings,
+    auth_runtime: {
+      mode: "shared",
+      authority_project_ref: authorityProjectRef,
+      configuration_management: "owner_only",
+    },
+  };
+}
+
 export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get project settings
   .get(
@@ -472,15 +487,10 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       }
       const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
       if (managedError) {
-        const { auth: _auth, ...safeSettings } = settings;
-        return {
-          ...safeSettings,
-          auth_runtime: {
-            mode: "shared",
-            authority_project_ref: managedError.authority_project_ref,
-            configuration_management: "owner_only",
-          },
-        };
+        return buildSharedSettingsResponse(
+          settings,
+          managedError.authority_project_ref,
+        );
       }
       return settings;
     },
@@ -509,6 +519,12 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       );
       if (settings === null) {
         return status(404, { message: "Project not found", code: "404" });
+      }
+      if (managedError) {
+        return buildSharedSettingsResponse(
+          settings,
+          managedError.authority_project_ref,
+        );
       }
       return settings;
     },

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -470,6 +470,18 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       if (settings === null) {
         return status(404, { message: "Project not found", code: "404" });
       }
+      const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
+      if (managedError) {
+        const { auth: _auth, ...safeSettings } = settings;
+        return {
+          ...safeSettings,
+          auth_runtime: {
+            mode: "shared",
+            authority_project_ref: managedError.authority_project_ref,
+            configuration_management: "owner_only",
+          },
+        };
+      }
       return settings;
     },
     {
@@ -487,6 +499,10 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
+      const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
+      if (managedError && Object.prototype.hasOwnProperty.call(body, "auth")) {
+        return status(409, managedError);
+      }
       const settings = await projectService.updateProjectSettings(
         params.ref,
         body,

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -1095,17 +1095,22 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 }
                 sharedAuthPort = port;
             }
-            const sharedAuthProxy = sharedAuthPort !== null && !externalAuthUpstream;
-            const directAuthUpstream = externalAuthUpstream?.dial || `${hostIp}:${sharedAuthPort ?? gotruePort}`;
+            const sharedAuthProxy = sharedAuthPort !== null;
+            const directAuthUpstream = sharedAuthPort !== null
+                ? `${hostIp}:${sharedAuthPort}`
+                : externalAuthUpstream?.dial || `${hostIp}:${gotruePort}`;
             const authUpstream = sharedAuthProxy
                 ? `${hostIp}:${config.port}`
                 : directAuthUpstream;
-            const authHeaders = externalAuthUpstream && thirdPartyAuth.auth_host_header
-                ? [`Host:${thirdPartyAuth.auth_host_header}`, `X-Forwarded-Host:${thirdPartyAuth.auth_host_header}`]
-                : sharedAuthPort !== null
+            const authHeaders = sharedAuthPort !== null
                     ? [`X-Project-Ref:${config.authRuntimeOwnerRef}`, `x-project-ref:${config.authRuntimeOwnerRef}`]
+                    : externalAuthUpstream && thirdPartyAuth.auth_host_header
+                        ? [`Host:${thirdPartyAuth.auth_host_header}`, `X-Forwarded-Host:${thirdPartyAuth.auth_host_header}`]
                     : undefined;
             const authProxyHeaders = sharedAuthProxy ? undefined : authHeaders;
+            const authUpstreamTls = sharedAuthPort === null ? externalAuthUpstream?.tls : false;
+            const authUpstreamTlsInsecureSkipVerify = sharedAuthPort === null
+                && thirdPartyAuth.auth_upstream_tls_insecure_skip_verify;
             const hosts = uniqueStrings(resolveProjectApiHosts(projectRef, routingConfig));
             const hostSet = new Set(hosts.map(normalizeCaddyHost));
             const authHosts = uniqueStrings([resolveProjectAuthHost(projectRef, routingConfig)])
@@ -1140,7 +1145,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     corsOrigins,
                     readTimeout: config.restProxyTimeoutMs,
                 }),
-                ...(!externalAuthUpstream ? [this.makeOpaqueApiKeyProxyRoute({
+                ...(!externalAuthUpstream || sharedAuthProxy ? [this.makeOpaqueApiKeyProxyRoute({
                     id: caddyRouteId(projectRef, "opaque-auth"),
                     hosts,
                     path: "/auth/v1*",
@@ -1163,8 +1168,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     stripPrefix: sharedAuthProxy ? undefined : "/auth/v1",
                     headers: authProxyHeaders,
                     corsOrigins,
-                    upstreamTls: externalAuthUpstream?.tls,
-                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
+                    upstreamTls: authUpstreamTls,
+                    upstreamTlsInsecureSkipVerify: authUpstreamTlsInsecureSkipVerify,
                 }),
                 this.makeRoute({
                     id: caddyRouteId(projectRef, "gotrue-well-known"),
@@ -1174,8 +1179,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     projectRef,
                     headers: authHeaders,
                     corsOrigins,
-                    upstreamTls: externalAuthUpstream?.tls,
-                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
+                    upstreamTls: authUpstreamTls,
+                    upstreamTlsInsecureSkipVerify: authUpstreamTlsInsecureSkipVerify,
                 }),
                 this.makeRoute({
                     id: caddyRouteId(projectRef, "functions"),
@@ -1252,8 +1257,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     stripPrefix: sharedAuthProxy ? undefined : "/auth/v1",
                     headers: authProxyHeaders,
                     corsOrigins,
-                    upstreamTls: externalAuthUpstream?.tls,
-                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
+                    upstreamTls: authUpstreamTls,
+                    upstreamTlsInsecureSkipVerify: authUpstreamTlsInsecureSkipVerify,
                 }));
                 this.routesById.set(caddyRouteId(projectRef, "auth-domain-gotrue-well-known"), this.makeRoute({
                     id: caddyRouteId(projectRef, "auth-domain-gotrue-well-known"),
@@ -1263,8 +1268,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     projectRef,
                     headers: authHeaders,
                     corsOrigins,
-                    upstreamTls: externalAuthUpstream?.tls,
-                    upstreamTlsInsecureSkipVerify: thirdPartyAuth.auth_upstream_tls_insecure_skip_verify,
+                    upstreamTls: authUpstreamTls,
+                    upstreamTlsInsecureSkipVerify: authUpstreamTlsInsecureSkipVerify,
                 }));
             } else {
                 this.routesById.delete(caddyRouteId(projectRef, "opaque-auth-domain"));

--- a/packages/management-api/src/services/runtime-env.service.ts
+++ b/packages/management-api/src/services/runtime-env.service.ts
@@ -13,6 +13,7 @@ import { logger } from "../utils/logger";
 import {
   buildSharedProjectJwtVerificationMaterial,
   normalizeProjectJwtKeys,
+  resolveSharedAuthIssuer,
   resolveProjectJwtVerificationMaterial,
 } from "../utils/project-jwt";
 import { getAuthRuntimeDescriptor } from "./auth-runtime.service";
@@ -50,6 +51,7 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
   const jwtKeys = normalizeProjectJwtKeys(oauthServerConfig.jwt_keys);
   let jwtMaterial = resolveProjectJwtVerificationMaterial(projectConfig, project.jwt_secret);
   let authRoutingConfig = routingConfig;
+  let sharedAuthIssuer: string | null = null;
   const authRuntime = getAuthRuntimeDescriptor(projectRef);
   if (authRuntime.mode === "shared") {
     const owner = await projectRepository.findByRef(authRuntime.authority_project_ref);
@@ -61,6 +63,7 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
       projectConfig: project.config,
       ownerConfig: owner.config,
     });
+    sharedAuthIssuer = resolveSharedAuthIssuer(authRuntime.authority_project_ref, owner.config);
     authRoutingConfig = normalizeProjectRoutingConfig(normalizeProjectConfig(owner.config));
   }
   const jwtJwks = jwtMaterial.jwtJwks;
@@ -125,6 +128,7 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
     } : {}),
     SUPACLOUD_AUTH_RUNTIME_MODE: authRuntime.mode,
     SUPACLOUD_AUTH_AUTHORITY_REF: authRuntime.authority_project_ref,
+    ...(sharedAuthIssuer ? { SUPACLOUD_AUTH_ISSUER: sharedAuthIssuer } : {}),
     SUPACLOUD_INTERNAL_SUPABASE_URL: internalSupabaseUrl,
     SUPACLOUD_INTERNAL_AUTH_URL: internalAuthUrl,
     SUPACLOUD_INTERNAL_REST_URL: internalRestUrl,

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -840,6 +840,9 @@ class TenantRuntimeService {
             sharedAuthRuntime ? "" : renderSystemdEnvLine("JWT_SECRET", creds.jwtSecret),
             renderSystemdEnvLine("SUPACLOUD_AUTH_RUNTIME_MODE", sharedAuthRuntime ? "shared" : "local"),
             renderSystemdEnvLine("SUPACLOUD_AUTH_AUTHORITY_REF", getAuthRuntimeDescriptor(ref).authority_project_ref),
+            sharedAuthRuntime && creds.localJwtIssuer
+                ? renderSystemdEnvLine("SUPACLOUD_AUTH_ISSUER", creds.localJwtIssuer)
+                : "",
             renderTenantInternalRuntimeEnv(pgrstPort, runtimeGoTruePort),
             jwtJwksEnv,
             sharedAuthRuntime ? "" : jwtKeysEnv,

--- a/packages/management-api/src/utils/project-jwt.ts
+++ b/packages/management-api/src/utils/project-jwt.ts
@@ -16,6 +16,7 @@ import {
   normalizeProjectConfig,
   normalizeThirdPartyAuthConfig,
 } from "./project-config";
+import { resolveProjectAuthUrl } from "./project-routing";
 import { getAuthRuntimeDescriptor } from "../services/auth-runtime.service";
 
 export type OidcJwtKeyMaterial = {
@@ -360,6 +361,16 @@ export function buildSharedProjectJwtVerificationMaterial(input: {
   return { jwtJwks, localJwks, thirdParty };
 }
 
+export function resolveSharedAuthIssuer(ownerRef: string, ownerConfig: unknown): string {
+  const normalizedOwnerConfig = normalizeProjectConfig(ownerConfig);
+  const ownerAuth = (normalizedOwnerConfig.auth || {}) as Record<string, unknown>;
+  const ownerOauthServer = normalizeOAuthServerConfig(ownerAuth.oauth_server);
+  const configuredIssuer = typeof ownerOauthServer.issuer === "string"
+    ? ownerOauthServer.issuer.trim().replace(/\/+$/, "")
+    : "";
+  return configuredIssuer || `${resolveProjectAuthUrl(ownerRef, normalizedOwnerConfig)}/auth/v1`;
+}
+
 export function buildSharedProjectJwtVerifierJwks(input: {
   projectJwtSecret: string;
   projectConfig: unknown;
@@ -480,6 +491,7 @@ async function verifyThirdPartyJwt(
 async function verifyLocalAsymmetricJwt(
   token: string,
   localJwks: { keys: JWK[] } | null,
+  issuer?: string,
 ): Promise<{ payload: JWTPayload; protectedHeader: JWTHeaderParameters } | null> {
   const publicKeys = (localJwks?.keys || []).filter(
     (key) => (key.kty === "EC" && key.alg === "ES256") || (key.kty === "RSA" && key.alg === "RS256"),
@@ -488,10 +500,19 @@ async function verifyLocalAsymmetricJwt(
   try {
     return await jwtVerify(token, createLocalJWKSet({ keys: publicKeys }), {
       algorithms: ["ES256", "RS256"],
+      ...(issuer ? { issuer } : {}),
     });
   } catch {
     return null;
   }
+}
+
+export async function verifyAsymmetricProjectJwt(
+  token: string,
+  localJwks: { keys: JWK[] } | null,
+  issuer?: string,
+): Promise<{ payload: JWTPayload; protectedHeader: JWTHeaderParameters } | null> {
+  return verifyLocalAsymmetricJwt(token, localJwks, issuer);
 }
 
 async function verifyLegacyHs256Jwt(
@@ -543,6 +564,7 @@ export async function verifyProjectJwtPayload(
 
   const authRuntime = getAuthRuntimeDescriptor(ref);
   let material: ProjectJwtVerificationMaterial;
+  let sharedAuthIssuer: string | undefined;
   try {
     if (authRuntime.mode === "shared") {
       const [owner] = await metaSql`
@@ -554,6 +576,7 @@ export async function verifyProjectJwtPayload(
         LIMIT 1
       `;
       if (!owner) return null;
+      sharedAuthIssuer = resolveSharedAuthIssuer(authRuntime.authority_project_ref, owner.config);
       material = buildSharedProjectJwtVerificationMaterial({
         projectJwtSecret: String(project.jwt_secret),
         projectConfig: project.config,
@@ -570,7 +593,7 @@ export async function verifyProjectJwtPayload(
   if (material.thirdParty && isThirdPartyTokenCandidate(header, payload, material.thirdParty)) {
     result = await verifyThirdPartyJwt(cleanToken, material.thirdParty);
   } else {
-    result = await verifyLocalAsymmetricJwt(cleanToken, material.localJwks);
+    result = await verifyLocalAsymmetricJwt(cleanToken, material.localJwks, sharedAuthIssuer);
     if (result && authRuntime.mode === "shared" && result.payload.role !== "authenticated") {
       return null;
     }

--- a/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
@@ -8,6 +8,7 @@ const app = new Elysia().use(projectConfigRoutes);
 const authHeaders = { Authorization: "Bearer dev-master-token" };
 const originalOwnerRef = config.authRuntimeOwnerRef;
 const originalGetProjectSettings = projectService.getProjectSettings;
+const originalUpdateProjectSettings = projectService.updateProjectSettings;
 
 function request(path: string, init: RequestInit = {}) {
   return app.handle(new Request(`http://localhost${path}`, {
@@ -19,6 +20,7 @@ function request(path: string, init: RequestInit = {}) {
 afterEach(() => {
   config.authRuntimeOwnerRef = originalOwnerRef;
   projectService.getProjectSettings = originalGetProjectSettings;
+  projectService.updateProjectSettings = originalUpdateProjectSettings;
 });
 
 describe("SupAuth auth config boundary", () => {
@@ -67,5 +69,36 @@ describe("SupAuth auth config boundary", () => {
     expect(body.saml).toBeUndefined();
     expect(body.hook_custom_access_token_secrets).toBe("********");
     expect(body.smtp_pass).toBe("********");
+  });
+
+  test("shared settings alias hides auth config and rejects auth writes", async () => {
+    config.authRuntimeOwnerRef = "auth-owner";
+    projectService.getProjectSettings = async () => ({
+      auth: { jwt_secret: "dependent-secret" },
+      api_domain: "tenant-a.api.example.com",
+    });
+    let updateCalls = 0;
+    projectService.updateProjectSettings = async () => {
+      updateCalls += 1;
+      return {};
+    };
+
+    const getResponse = await request("/v1/projects/tenant-a/settings");
+    const body = await getResponse.json();
+    expect(getResponse.status).toBe(200);
+    expect(body.auth).toBeUndefined();
+    expect(body.auth_runtime).toEqual({
+      mode: "shared",
+      authority_project_ref: "auth-owner",
+      configuration_management: "owner_only",
+    });
+
+    const putResponse = await request("/v1/projects/tenant-a/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ auth: { enable_signup: false } }),
+    });
+    expect(putResponse.status).toBe(409);
+    expect(updateCalls).toBe(0);
   });
 });

--- a/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
@@ -80,7 +80,10 @@ describe("SupAuth auth config boundary", () => {
     let updateCalls = 0;
     projectService.updateProjectSettings = async () => {
       updateCalls += 1;
-      return {};
+      return {
+        auth: { smtp: { pass: "dependent-secret" } },
+        api_domain: "updated.api.example.com",
+      } as never;
     };
 
     const getResponse = await request("/v1/projects/tenant-a/settings");
@@ -100,5 +103,20 @@ describe("SupAuth auth config boundary", () => {
     });
     expect(putResponse.status).toBe(409);
     expect(updateCalls).toBe(0);
+
+    const safePutResponse = await request("/v1/projects/tenant-a/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ api_domain: "updated.api.example.com" }),
+    });
+    const safePutBody = await safePutResponse.json();
+    expect(safePutResponse.status).toBe(200);
+    expect(safePutBody.auth).toBeUndefined();
+    expect(safePutBody.auth_runtime).toEqual({
+      mode: "shared",
+      authority_project_ref: "auth-owner",
+      configuration_management: "owner_only",
+    });
+    expect(updateCalls).toBe(1);
   });
 });

--- a/packages/management-api/tests/unit/project-jwt.shared.test.ts
+++ b/packages/management-api/tests/unit/project-jwt.shared.test.ts
@@ -3,9 +3,58 @@ import { createLocalJWKSet, exportJWK, generateKeyPair, jwtVerify, SignJWT } fro
 import {
   buildSharedProjectJwtVerificationMaterial,
   buildSharedProjectJwtVerifierJwks,
+  resolveSharedAuthIssuer,
+  verifyAsymmetricProjectJwt,
 } from "../../src/utils/project-jwt";
 
 describe("SupAuth shared JWT verifier material", () => {
+  test("derives the owner issuer when OAuth issuer is not explicitly configured", () => {
+    expect(resolveSharedAuthIssuer("auth-owner", {
+      api_domain: "api.example.com",
+      auth: { oauth_server: { enabled: true } },
+    })).toBe("https://api.example.com/auth/v1");
+  });
+
+  test("preserves an explicitly configured owner issuer", () => {
+    expect(resolveSharedAuthIssuer("auth-owner", {
+      auth: { oauth_server: { issuer: "https://issuer.example.com/auth" } },
+    })).toBe("https://issuer.example.com/auth");
+  });
+
+  test("management shared JWT verification requires the owner issuer", async () => {
+    const { publicKey, privateKey } = await generateKeyPair("ES256", { extractable: true });
+    const publicJwk = await exportJWK(publicKey);
+    const privateJwk = await exportJWK(privateKey);
+    const kid = "owner-issuer-key";
+    const signingKey = await crypto.subtle.importKey(
+      "jwk",
+      { ...privateJwk, kid, alg: "ES256", use: "sig" },
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign"],
+    );
+    const expectedIssuer = "https://auth-owner.example.com/auth/v1";
+    const valid = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setIssuer(expectedIssuer)
+      .setExpirationTime("5m")
+      .sign(signingKey);
+    const wrong = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setIssuer("https://wrong.example.com/auth/v1")
+      .setExpirationTime("5m")
+      .sign(signingKey);
+    const missing = await new SignJWT({ role: "authenticated" })
+      .setProtectedHeader({ alg: "ES256", kid })
+      .setExpirationTime("5m")
+      .sign(signingKey);
+    const jwks = { keys: [{ ...publicJwk, kid, alg: "ES256", use: "sig" }] };
+
+    expect(await verifyAsymmetricProjectJwt(valid, jwks, expectedIssuer)).not.toBeNull();
+    expect(await verifyAsymmetricProjectJwt(wrong, jwks, expectedIssuer)).toBeNull();
+    expect(await verifyAsymmetricProjectJwt(missing, jwks, expectedIssuer)).toBeNull();
+  });
+
   test("keeps dependent legacy API-key verification and owner public asymmetric keys only", () => {
     const jwks = buildSharedProjectJwtVerifierJwks({
       projectJwtSecret: "dependent-secret-with-at-least-32-characters",

--- a/packages/management-api/tests/unit/runtime-env.service.test.ts
+++ b/packages/management-api/tests/unit/runtime-env.service.test.ts
@@ -224,6 +224,7 @@ describe("runtimeEnvService", () => {
       const env = await runtimeEnvService.buildProjectRuntimeEnv("proj_1");
       expect(env?.SUPACLOUD_AUTH_RUNTIME_MODE).toBe("shared");
       expect(env?.SUPACLOUD_AUTH_AUTHORITY_REF).toBe("auth-owner");
+      expect(env?.SUPACLOUD_AUTH_ISSUER).toContain("/auth/v1");
       expect(env?.SUPACLOUD_INTERNAL_POSTGREST_PORT).toBe("3272");
       expect(env?.SUPACLOUD_INTERNAL_GOTRUE_PORT).toBe("9372");
       expect(env?.JWT_JWKS).toContain("owner-public");

--- a/packages/management-api/tests/unit/supauth-gateway-routing.test.ts
+++ b/packages/management-api/tests/unit/supauth-gateway-routing.test.ts
@@ -5,7 +5,7 @@ const source = readFileSync(new URL("../../src/services/gateway.service.ts", imp
 
 describe("SupAuth gateway routing", () => {
   test("routes every shared auth request through the owner-aware SDK proxy", () => {
-    expect(source).toContain("const sharedAuthProxy = sharedAuthPort !== null && !externalAuthUpstream");
+    expect(source).toContain("const sharedAuthProxy = sharedAuthPort !== null");
     expect(source).toContain("? `${hostIp}:${config.port}`");
     expect(source).toContain('id: caddyRouteId(projectRef, "auth")');
     expect(source).toContain("upstream: authUpstream");
@@ -13,8 +13,15 @@ describe("SupAuth gateway routing", () => {
   });
 
   test("keeps well-known metadata on the direct owner runtime", () => {
-    expect(source).toContain("const directAuthUpstream = externalAuthUpstream?.dial");
+    expect(source).toContain("const directAuthUpstream = sharedAuthPort !== null");
     expect(source).toContain('id: caddyRouteId(projectRef, "gotrue-well-known")');
     expect(source).toContain("upstream: directAuthUpstream");
+  });
+
+  test("shared auth always overrides a dependent external auth upstream", () => {
+    expect(source).toContain("!externalAuthUpstream || sharedAuthProxy");
+    expect(source).toContain("sharedAuthPort !== null");
+    expect(source).toContain("X-Project-Ref:${config.authRuntimeOwnerRef}");
+    expect(source).toContain("const authUpstreamTls = sharedAuthPort === null");
   });
 });

--- a/packages/management-api/tests/unit/tenant-runtime.security.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.security.test.ts
@@ -39,6 +39,7 @@ describe("TenantRuntimeService secret handling", () => {
 
   test("shared auth keeps owner private signing material out and rejects non-user owner roles", () => {
     expect(source).toContain("buildSharedProjectJwtVerificationMaterial");
+    expect(source).toContain('renderSystemdEnvLine("SUPACLOUD_AUTH_ISSUER", creds.localJwtIssuer)');
     expect(source).toContain('sharedAuthRuntime ? "" : renderSystemdEnvLine("JWT_SECRET"');
     expect(source).toContain('sharedAuthRuntime ? "" : jwtKeysEnv');
     expect(source).toContain("const postgrestJwtAudience = sharedAuthRuntime");


### PR DESCRIPTION
## 背景

PR #469 与 follow-up #476 在最终安全修复完成前被并发合并。本 PR 只补齐当前 main 尚缺失的 shared auth 边界修复。

## 修复

- shared settings GET/PUT 统一隐藏 dependent auth 密钥；auth 写入继续返回 409
- shared gateway 强制 owner auth precedence，忽略 dependent external upstream 与 TLS 配置
- Management/Edge asymmetric JWT 强制校验 owner issuer 与 authenticated role
- shared Bearer API key 绑定请求租户，拒绝 dependent legacy service_role 到达 owner GoTrue

## 验证

- Management 定向测试：47 pass
- Edge 定向测试：11 pass
- Management/Edge typecheck：PASS
- Management unit：751 pass；2 个 installer 用例在并发负载下超时，随后单独重跑 2/2 PASS
- git diff --check：PASS

Follow-up of #476 and #469.