### PR TITLE
chore(packages): sync supacloud lockfile

### DIFF
--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "supacloud",
       "dependencies": {
-        "@supacloud/admin": "^0.4.0",
-        "@supacloud/cli": "^0.10.0",
+        "@supacloud/admin": "^0.5.0",
+        "@supacloud/cli": "^0.11.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -15,9 +15,11 @@
     },
   },
   "packages": {
-    "@supacloud/admin": ["@supacloud/admin@0.4.0", "", { "dependencies": { "ssh2": "^1.17.0", "zod": "^4.4.3" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-mSaX3RTobnNd65azHegj5kXE27ktMoFVwEYrokrcAYZl6dqygUXnMSc9TM65Ai02iBJapfg0qyP0AAO/lqXWIQ=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.10.0", "", { "dependencies": { "zod": "^4.4.3" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-ZkT14iTJ8m9WbCyTjtXxKa9567OjtBLM8bs1jl7Rp77ZSm2a+aeQH1gCaH6EE8kit3S/itLEiekAWpNoXxkClg=="],
+    "@supacloud/admin": ["@supacloud/admin@0.5.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.5.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-sLgfbRytIw03rI1etm8IOqoY6VoN1DMWC+MwZUGiJa8+lHqkyEpauVMDb3WKbU6xLbD+hg0OoDL1DZR8rAOv7Q=="],
+
+    "@supacloud/cli": ["@supacloud/cli@0.11.0", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.11.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-x/tgS2d66ipJ+vnwCCAa6OrfUoOcj5y1Mw3d4nKtRkh8UnXu4+BeJaeIEsTyOd2cQCCObl1wDW8aUsUysGDTTA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -84,7 +86,5 @@
     "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@8.3.0", "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
-
-    "zod": ["zod@4.4.3", "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }
 }


### PR DESCRIPTION
## Summary

- synchronize `packages/supacloud/bun.lock` with the already-released dependency ranges in `packages/supacloud/package.json`
- resolve `@supacloud/cli` to `0.11.0` and `@supacloud/admin` to `0.5.0`
- update the transitive dependency graph from `zod` to `@sinclair/typebox` as published by those package versions

## Why

`bun install --frozen-lockfile` currently fails on `main` because the manifest requires `@supacloud/cli@^0.11.0` and `@supacloud/admin@^0.5.0`, while the lockfile still records the previous `0.10.0` and `0.4.0` releases.

This focused maintenance PR unblocks the Package Checks baseline used by #480 and #481 without including any auth/session implementation changes.

## Verification

- reproduced the pre-fix frozen-lockfile failure
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test src/index.test.ts` (19 passing)
- `bun run build`
- `bun audit --audit-level high` against the official npm registry (no vulnerabilities)
- `git diff --check`

## Deployment

Not deployed.
