### PR TITLE
fix(ci): handle stale release lockfiles on main

### DIFF
--- a/.github/scripts/supacloud-install-mode.mjs
+++ b/.github/scripts/supacloud-install-mode.mjs
@@ -1,0 +1,85 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const FROZEN = 'frozen';
+const LOCAL_CANDIDATE = 'local-candidate';
+const DEFAULT_REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+function dependencyMatches(dependencies, packageName, version) {
+  return typeof version === 'string' && dependencies?.[packageName] === `^${version}`;
+}
+
+function lockfileHasCandidate(lockfile, packageName, version) {
+  return typeof version === 'string' && lockfile.includes(`"${packageName}@${version}"`);
+}
+
+export function selectSupacloudInstallMode({
+  eventName,
+  ref,
+  prAuthor,
+  headRef,
+  supacloudPackage,
+  cliPackage,
+  adminPackage,
+  lockfile,
+}) {
+  const dependencies = supacloudPackage?.dependencies;
+  const dependenciesMatchCandidates =
+    dependencyMatches(dependencies, '@supacloud/cli', cliPackage?.version) &&
+    dependencyMatches(dependencies, '@supacloud/admin', adminPackage?.version);
+  const lockfileHasCandidates =
+    lockfileHasCandidate(lockfile, '@supacloud/cli', cliPackage?.version) &&
+    lockfileHasCandidate(lockfile, '@supacloud/admin', adminPackage?.version);
+  const trustedReleaseContext =
+    (eventName === 'push' && ref === 'refs/heads/main') ||
+    (eventName === 'pull_request' &&
+      prAuthor === 'github-actions[bot]' &&
+      headRef === 'release-please--branches--main');
+
+  return trustedReleaseContext && dependenciesMatchCandidates && !lockfileHasCandidates
+    ? LOCAL_CANDIDATE
+    : FROZEN;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+export async function selectSupacloudInstallModeFromRepository({
+  repoRoot = DEFAULT_REPO_ROOT,
+  env = process.env,
+} = {}) {
+  const packageRoot = resolve(repoRoot, 'packages');
+  const [supacloudPackage, cliPackage, adminPackage, lockfile] = await Promise.all([
+    readJson(resolve(packageRoot, 'supacloud/package.json')),
+    readJson(resolve(packageRoot, 'cli/package.json')),
+    readJson(resolve(packageRoot, 'admin/package.json')),
+    readFile(resolve(packageRoot, 'supacloud/bun.lock'), 'utf8'),
+  ]);
+
+  return selectSupacloudInstallMode({
+    eventName: env.GITHUB_EVENT_NAME,
+    ref: env.GITHUB_REF,
+    prAuthor: env.PR_AUTHOR,
+    headRef: env.GITHUB_HEAD_REF,
+    supacloudPackage,
+    cliPackage,
+    adminPackage,
+    lockfile,
+  });
+}
+
+function isMainModule() {
+  const entrypoint = process.argv[1];
+  return entrypoint && pathToFileURL(resolve(entrypoint)).href === import.meta.url;
+}
+
+if (isMainModule()) {
+  try {
+    console.log(await selectSupacloudInstallModeFromRepository());
+  } catch (error) {
+    console.error(`Failed to select SupaCloud install mode: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/.github/scripts/supacloud-install-mode.test.mjs
+++ b/.github/scripts/supacloud-install-mode.test.mjs
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, test } from 'node:test';
+
+import { selectSupacloudInstallMode } from './supacloud-install-mode.mjs';
+
+const staleReleaseContent = {
+  supacloudPackage: {
+    dependencies: {
+      '@supacloud/cli': '^0.13.0',
+      '@supacloud/admin': '^0.7.0',
+    },
+  },
+  cliPackage: { version: '0.13.0' },
+  adminPackage: { version: '0.7.0' },
+  lockfile: [
+    '"@supacloud/cli": ["@supacloud/cli@0.12.0"]',
+    '"@supacloud/admin": ["@supacloud/admin@0.6.0"]',
+  ].join('\n'),
+};
+
+function select(context, content = staleReleaseContent) {
+  return selectSupacloudInstallMode({ ...context, ...content });
+}
+
+describe('SupaCloud release install mode', () => {
+  test('uses local candidates for a stale Release Please commit pushed to main', () => {
+    assert.equal(select({
+      eventName: 'push',
+      ref: 'refs/heads/main',
+      prAuthor: '',
+      headRef: '',
+    }), 'local-candidate');
+  });
+
+  test('uses local candidates for a stale Release Please bot pull request', () => {
+    assert.equal(select({
+      eventName: 'pull_request',
+      ref: 'refs/pull/487/merge',
+      prAuthor: 'github-actions[bot]',
+      headRef: 'release-please--branches--main',
+    }), 'local-candidate');
+  });
+
+  test('keeps every untrusted event on the frozen install path', () => {
+    const untrustedContexts = [
+      {
+        eventName: 'pull_request',
+        ref: 'refs/pull/487/merge',
+        prAuthor: 'zuohuadong',
+        headRef: 'codex/fix-release-lockfile-validation',
+      },
+      {
+        eventName: 'push',
+        ref: 'refs/heads/dev',
+        prAuthor: '',
+        headRef: '',
+      },
+      {
+        eventName: 'workflow_dispatch',
+        ref: 'refs/heads/main',
+        prAuthor: '',
+        headRef: '',
+      },
+      {
+        eventName: 'pull_request',
+        ref: 'refs/pull/487/merge',
+        prAuthor: 'github-actions[bot]',
+        headRef: 'codex/generated-change',
+      },
+      {
+        eventName: 'pull_request',
+        ref: 'refs/pull/487/merge',
+        prAuthor: 'github-actions[bot]',
+        headRef: 'release-please--branches--dev',
+      },
+      {
+        eventName: 'pull_request',
+        ref: 'refs/pull/487/merge',
+        prAuthor: 'zuohuadong',
+        headRef: 'release-please--branches--main',
+      },
+    ];
+
+    for (const context of untrustedContexts) {
+      assert.equal(select(context), 'frozen', JSON.stringify(context));
+    }
+  });
+
+  test('keeps a synchronized lockfile on the frozen install path', () => {
+    assert.equal(select({
+      eventName: 'push',
+      ref: 'refs/heads/main',
+      prAuthor: '',
+      headRef: '',
+    }, {
+      ...staleReleaseContent,
+      lockfile: [
+        '"@supacloud/cli": ["@supacloud/cli@0.13.0"]',
+        '"@supacloud/admin": ["@supacloud/admin@0.7.0"]',
+      ].join('\n'),
+    }), 'frozen');
+  });
+
+  test('does not treat a prerelease locator as the exact lockfile candidate', () => {
+    assert.equal(select({
+      eventName: 'push',
+      ref: 'refs/heads/main',
+      prAuthor: '',
+      headRef: '',
+    }, {
+      ...staleReleaseContent,
+      lockfile: [
+        '"@supacloud/cli": ["@supacloud/cli@0.13.0-beta.1"]',
+        '"@supacloud/admin": ["@supacloud/admin@0.7.0"]',
+      ].join('\n'),
+    }), 'local-candidate');
+  });
+
+  test('keeps mismatched local package versions on the frozen install path', () => {
+    for (const dependencies of [
+      {
+        '@supacloud/cli': '^0.12.0',
+        '@supacloud/admin': '^0.7.0',
+      },
+      {
+        '@supacloud/cli': '^0.13.0',
+        '@supacloud/admin': '^0.6.0',
+      },
+    ]) {
+      assert.equal(select({
+        eventName: 'push',
+        ref: 'refs/heads/main',
+        prAuthor: '',
+        headRef: '',
+      }, {
+        ...staleReleaseContent,
+        supacloudPackage: { dependencies },
+      }), 'frozen');
+    }
+  });
+
+  test('keeps the workflow wired to the tested selector', () => {
+    const workflow = readFileSync(new URL('../workflows/management-api.yml', import.meta.url), 'utf8');
+
+    assert.match(
+      workflow,
+      /install_mode="\$\(node \.\.\/\.\.\/\.github\/scripts\/supacloud-install-mode\.mjs\)"/,
+    );
+    assert.match(workflow, /node --check \.github\/scripts\/supacloud-install-mode\.mjs/);
+    assert.match(workflow, /node --test \.github\/scripts\/supacloud-install-mode\.test\.mjs/);
+    assert.doesNotMatch(workflow, /content_install_mode=/);
+  });
+});

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -172,8 +172,30 @@ jobs:
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [[ "$PR_AUTHOR" == "github-actions[bot]" && "${GITHUB_HEAD_REF:-}" == release-please--branches--* ]]; then
-            # Release Please 会在发布前先提升 sibling 包版本；此时 registry 与锁文件尚未包含候选版本。
+          content_install_mode="$(bun -e '
+            const pkg = await Bun.file("package.json").json();
+            const cli = await Bun.file("../cli/package.json").json();
+            const admin = await Bun.file("../admin/package.json").json();
+            const lock = await Bun.file("bun.lock").text();
+            const dependenciesMatchCandidates =
+              pkg.dependencies["@supacloud/cli"] === `^${cli.version}` &&
+              pkg.dependencies["@supacloud/admin"] === `^${admin.version}`;
+            const lockHasCandidates =
+              lock.includes(`@supacloud/cli@${cli.version}`) &&
+              lock.includes(`@supacloud/admin@${admin.version}`);
+            console.log(dependenciesMatchCandidates && !lockHasCandidates ? "local-candidate" : "frozen");
+          ')"
+          trusted_release_context=false
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]] ||
+             [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$PR_AUTHOR" == "github-actions[bot]" && "${GITHUB_HEAD_REF:-}" == release-please--branches--* ]]; then
+            trusted_release_context=true
+          fi
+          install_mode="frozen"
+          if [[ "$trusted_release_context" == "true" && "$content_install_mode" == "local-candidate" ]]; then
+            install_mode="local-candidate"
+          fi
+          if [[ "$install_mode" == "local-candidate" ]]; then
+            # Release 提升 sibling 包版本时，锁文件会暂时落后；使用同一提交中的候选包验证。
             bun -e '
               const pkg = await Bun.file("package.json").json();
               const cli = await Bun.file("../cli/package.json").json();

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -172,39 +172,9 @@ jobs:
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          content_install_mode="$(bun -e '
-            const pkg = await Bun.file("package.json").json();
-            const cli = await Bun.file("../cli/package.json").json();
-            const admin = await Bun.file("../admin/package.json").json();
-            const lock = await Bun.file("bun.lock").text();
-            const dependenciesMatchCandidates =
-              pkg.dependencies["@supacloud/cli"] === `^${cli.version}` &&
-              pkg.dependencies["@supacloud/admin"] === `^${admin.version}`;
-            const lockHasCandidates =
-              lock.includes(`@supacloud/cli@${cli.version}`) &&
-              lock.includes(`@supacloud/admin@${admin.version}`);
-            console.log(dependenciesMatchCandidates && !lockHasCandidates ? "local-candidate" : "frozen");
-          ')"
-          trusted_release_context=false
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]] ||
-             [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$PR_AUTHOR" == "github-actions[bot]" && "${GITHUB_HEAD_REF:-}" == release-please--branches--* ]]; then
-            trusted_release_context=true
-          fi
-          install_mode="frozen"
-          if [[ "$trusted_release_context" == "true" && "$content_install_mode" == "local-candidate" ]]; then
-            install_mode="local-candidate"
-          fi
+          install_mode="$(node ../../.github/scripts/supacloud-install-mode.mjs)"
           if [[ "$install_mode" == "local-candidate" ]]; then
             # Release 提升 sibling 包版本时，锁文件会暂时落后；使用同一提交中的候选包验证。
-            bun -e '
-              const pkg = await Bun.file("package.json").json();
-              const cli = await Bun.file("../cli/package.json").json();
-              const admin = await Bun.file("../admin/package.json").json();
-              if (pkg.dependencies["@supacloud/cli"] !== `^${cli.version}` ||
-                  pkg.dependencies["@supacloud/admin"] !== `^${admin.version}`) {
-                throw new Error("supacloud dependency versions do not match local release candidates");
-              }
-            '
             bun add --no-save '@supacloud/cli@file:../cli' '@supacloud/admin@file:../admin'
             git diff --exit-code -- package.json bun.lock
           else
@@ -243,10 +213,12 @@ jobs:
           find scripts -name "*.sh" -print0 | xargs -0 -n1 bash -n
           bash scripts/lib/tenant_runtime.test.sh
 
-      - name: Validate AI review script
+      - name: Validate CI scripts
         run: |
           node --check .github/scripts/ai-review-merge.mjs
           node --test .github/scripts/ai-review-merge.test.mjs
+          node --check .github/scripts/supacloud-install-mode.mjs
+          node --test .github/scripts/supacloud-install-mode.test.mjs
 
   unit-test:
     name: Unit Tests


### PR DESCRIPTION
## Summary

- detect when `packages/supacloud` manifests already target the local CLI/Admin release candidates but `bun.lock` still contains the previous published versions
- allow the existing local-candidate validation path for trusted `main` pushes as well as Release Please bot PRs
- keep ordinary PRs, `dev` pushes, manual runs, and synchronized lockfiles on `bun install --frozen-lockfile`

## Root cause

Release Please updates the umbrella package and sibling package versions in one release commit. The CI exception only recognized the Release Please PR, so the merged `main` commit took the frozen path before the umbrella lockfile could be synchronized. This caused Management API CI run [29682272221](https://github.com/zuohuadong/supacloud/actions/runs/29682272221) to fail with `lockfile had changes, but lockfile is frozen`, skipping binary builds.

The Caddy duplicate fallback incident is already fixed in `management-api-v0.45.1`; this PR intentionally does not duplicate that runtime patch.

## Security boundary

The local-candidate path requires both:

1. a trusted release context (`main` push or `github-actions[bot]` Release Please PR), and
2. exact umbrella dependency alignment with the local CLI/Admin package versions while the lockfile lacks those candidates.

All other contexts fail closed through the frozen lockfile path.

## Verification

- YAML parse and extracted step `bash -n`
- real `management-api-v0.45.0` stale snapshot: `main` push selects local candidates
- Release Please bot PR selects local candidates
- ordinary PR, `dev` push, and `workflow_dispatch` select frozen install
- current synchronized `main` snapshot selects frozen install
- both real local-candidate and frozen paths: TypeScript check, 19 tests, and build passed
- `git diff --check`

Local `bun audit` reached the configured npm mirror, which returns HTTP 404 for the audit endpoint; GitHub CI remains the authoritative audit check.
