### PR TITLE
fix(edge-runtime): release workers after Caddy disconnects

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -602,9 +602,41 @@ jobs:
           done
           shellcheck -s bash -e "$ignored_rules" "${root_scripts[@]}"
 
+  caddy-edge-proxy-smoke:
+    name: Caddy Edge Proxy Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: stable
+
+      - name: Install edge-runtime dependencies
+        working-directory: packages/edge-runtime
+        run: bun install --frozen-lockfile
+
+      - name: Install xcaddy
+        run: go install github.com/caddyserver/xcaddy/cmd/xcaddy@${XCADDY_VERSION}
+
+      - name: Build Caddy Linux amd64 binary
+        run: CADDY_BUILD_TARGETS=linux-amd64 OUT_DIR=packages/management-api/dist bash scripts/build_supacloud_caddy.sh
+
+      - name: Test Caddy to Edge Runtime cancellation and proxying
+        run: CADDY_BINARY=packages/management-api/dist/supacloud-caddy-linux-amd64 bash scripts/test_supacloud_caddy_edge_proxy.sh
+
   build-binaries:
     name: Build Binaries
-    needs: [lint-and-typecheck, package-checks, docker-and-scripts-checks, unit-test, integration-test, shell-scripts-lint]
+    needs: [lint-and-typecheck, package-checks, docker-and-scripts-checks, unit-test, integration-test, shell-scripts-lint, caddy-edge-proxy-smoke]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,6 +71,10 @@ jobs:
         working-directory: packages/management-api
         run: bun install --frozen-lockfile
 
+      - name: Install edge-runtime dependencies
+        working-directory: packages/edge-runtime
+        run: bun install --frozen-lockfile
+
       - name: Build web console static artifact
         run: |
           cd packages/web-console
@@ -96,6 +100,9 @@ jobs:
 
       - name: Build Caddy edge binaries
         run: OUT_DIR=packages/management-api/dist bash scripts/build_supacloud_caddy.sh
+
+      - name: Smoke Caddy to Edge Runtime proxy
+        run: CADDY_BINARY=packages/management-api/dist/supacloud-caddy-linux-amd64 bash scripts/test_supacloud_caddy_edge_proxy.sh
 
       - name: Generate SHA256SUMS
         run: |

--- a/packages/edge-runtime/background-forward.test.ts
+++ b/packages/edge-runtime/background-forward.test.ts
@@ -7,6 +7,7 @@ import {
 
 describe("background forwarded request", () => {
   test("uses a tenant-scoped background token without forwarding the master token", async () => {
+    const controller = new AbortController();
     const request = new Request("http://edge-runtime/internal/background/proj/fn", {
       method: "POST",
       headers: {
@@ -19,6 +20,7 @@ describe("background forwarded request", () => {
         "x-supacloud-jwt-sub": "attacker-controlled",
       },
       body: JSON.stringify({ ok: true }),
+      signal: controller.signal,
     });
 
     const forwarded = buildBackgroundForwardedRequest(request, "background-token");
@@ -30,6 +32,8 @@ describe("background forwarded request", () => {
     expect(forwarded.headers.get("x-supacloud-auth-authorization")).toBeNull();
     expect(forwarded.headers.get("x-supacloud-auth-apikey")).toBeNull();
     expect(forwarded.headers.get("x-supacloud-jwt-sub")).toBeNull();
+    controller.abort();
+    expect(forwarded.signal.aborted).toBe(true);
     expect(await forwarded.text()).toBe(JSON.stringify({ ok: true }));
   });
 

--- a/packages/edge-runtime/background-forward.ts
+++ b/packages/edge-runtime/background-forward.ts
@@ -46,6 +46,7 @@ export function buildBackgroundForwardedRequest(
     headers,
     body: ["GET", "HEAD"].includes(request.method) ? undefined : request.body,
     duplex: ["GET", "HEAD"].includes(request.method) ? undefined : "half",
+    signal: request.signal,
   } as RequestInit & { duplex?: "half" });
 }
 

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -364,6 +364,7 @@ async function dispatchFunction(
         : tenantEnv,
       request,
       cancelKey: opts?.cancelKey,
+      signal: request.signal,
       onLog: (entry) => {
         void appendFunctionRuntimeLog(projectRef, functionName, entry, runtimeLogContext);
         opts?.onLog?.(entry);

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -153,6 +153,344 @@ describe("WorkerPool framework routing", () => {
   });
 });
 
+describe("WorkerPool cancellation and replacement", () => {
+  test("replaces a timed-out worker and immediately serves the queued request", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-timeout-replace-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch(request) {
+          if (new URL(request.url).pathname.endsWith("/slow")) {
+            await new Promise(() => {});
+          }
+          return new Response("fast", { status: 200 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 100 });
+    pools.push(pool);
+
+    try {
+      const slowResponse = pool.dispatch({
+        functionId: "proj_timeout_fn",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fn/slow"),
+      });
+      await Bun.sleep(20);
+      const fastResponse = pool.dispatch({
+        functionId: "proj_timeout_fn",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fn/fast"),
+      });
+
+      expect((await slowResponse).status).toBe(504);
+      expect(await (await fastResponse).text()).toBe("fast");
+      const metrics = pool.snapshotMetrics("timeout");
+      expect(metrics["timeout_total_worker_replacements"]).toBe(1);
+      expect(metrics["timeout_total_queued_requests"]).toBe(1);
+      expect(metrics["timeout_idle_workers"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates an in-flight AbortSignal and releases the worker", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-signal-cancel-"));
+    const startedPath = join(projectRoot, "started.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch(request) {
+          if (new URL(request.url).pathname.endsWith("/slow")) {
+            await Bun.write(process.env.STARTED_PATH, "started");
+            await new Promise((_, reject) => {
+              request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true });
+            });
+          }
+          return new Response("fast", { status: 200 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 5_000 });
+    const controller = new AbortController();
+    pools.push(pool);
+
+    try {
+      const slowResponse = pool.dispatch({
+        functionId: "proj_cancel_fn",
+        functionPath,
+        projectRoot,
+        env: { STARTED_PATH: startedPath },
+        request: new Request("http://edge.local/functions/v1/fn/slow", {
+          signal: controller.signal,
+        }),
+      });
+      await waitForFile(startedPath);
+      const fastResponse = pool.dispatch({
+        functionId: "proj_cancel_fn",
+        functionPath,
+        projectRoot,
+        env: { STARTED_PATH: startedPath },
+        request: new Request("http://edge.local/functions/v1/fn/fast"),
+      });
+
+      controller.abort();
+
+      expect((await slowResponse).status).toBe(499);
+      expect(await (await fastResponse).text()).toBe("fast");
+      expect(pool.snapshotMetrics("cancel")["cancel_idle_workers"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("isolates HTTP aborts when requests share an external cancel key", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-duplicate-cancel-key-"));
+    const firstStartedPath = join(projectRoot, "first-started.txt");
+    const secondStartedPath = join(projectRoot, "second-started.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch(request) {
+          await Bun.write(process.env.STARTED_PATH, "started");
+          await new Promise((_, reject) => {
+            request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true });
+          });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 2, requestTimeout: 5_000 });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    pools.push(pool);
+
+    try {
+      const firstResponse = pool.dispatch({
+        functionId: "proj_duplicate_first",
+        functionPath,
+        projectRoot,
+        cancelKey: "shared-task-id",
+        env: { STARTED_PATH: firstStartedPath },
+        request: new Request("http://edge.local/functions/v1/fn/first", {
+          signal: firstController.signal,
+        }),
+      });
+      const secondResponse = pool.dispatch({
+        functionId: "proj_duplicate_second",
+        functionPath,
+        projectRoot,
+        cancelKey: "shared-task-id",
+        env: { STARTED_PATH: secondStartedPath },
+        request: new Request("http://edge.local/functions/v1/fn/second", {
+          signal: secondController.signal,
+        }),
+      });
+      await Promise.all([
+        waitForFile(firstStartedPath),
+        waitForFile(secondStartedPath),
+      ]);
+
+      firstController.abort();
+
+      expect((await firstResponse).status).toBe(499);
+      const secondSettled = await Promise.race([
+        secondResponse.then(() => true),
+        Bun.sleep(50).then(() => false),
+      ]);
+      expect(secondSettled).toBe(false);
+
+      expect(pool.cancel("shared-task-id")).toBe(true);
+      expect((await secondResponse).status).toBe(499);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("removes an aborted queued request before it occupies a worker", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-queued-cancel-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch(request) {
+          if (new URL(request.url).pathname.endsWith("/slow")) await Bun.sleep(100);
+          return new Response("done", { status: 200 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    const controller = new AbortController();
+    pools.push(pool);
+
+    try {
+      const slowResponse = pool.dispatch({
+        functionId: "proj_queue_fn",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fn/slow"),
+      });
+      const queuedResponse = pool.dispatch({
+        functionId: "proj_queue_fn",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fn/cancel", {
+          signal: controller.signal,
+        }),
+      });
+
+      controller.abort();
+
+      expect((await queuedResponse).status).toBe(499);
+      expect((await slowResponse).status).toBe(200);
+      expect(pool.snapshotMetrics("queue")["queue_total_queued_requests"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("replaces a cancelled streaming worker before serving the queue", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-stream-cancel-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch(request) {
+          if (!new URL(request.url).pathname.endsWith("/stream")) {
+            return Response.json({ overlap: false });
+          }
+          return new Response(new ReadableStream({
+            start(controller) {
+              const timer = setInterval(() => controller.enqueue(new TextEncoder().encode("tick\\n")), 10);
+              request.signal.addEventListener("abort", () => clearInterval(timer), { once: true });
+            }
+          }), { headers: { "content-type": "text/event-stream" } });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 5_000 });
+    pools.push(pool);
+
+    try {
+      const streamResponse = await pool.dispatch({
+        functionId: "proj_stream_fn",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fn/stream"),
+      });
+      const reader = streamResponse.body!.getReader();
+      expect((await reader.read()).done).toBe(false);
+
+      const queuedResponse = pool.dispatch({
+        functionId: "proj_stream_fn",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fn/fast"),
+      });
+      await reader.cancel();
+
+      expect(await (await queuedResponse).json()).toEqual({ overlap: false });
+      const metrics = pool.snapshotMetrics("stream");
+      expect(metrics["stream_total_worker_replacements"]).toBe(1);
+      expect(metrics["stream_idle_workers"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("drain waits for ordinary requests without an external cancel key", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-drain-active-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch() {
+          await Bun.sleep(120);
+          return new Response("done", { status: 200 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const responsePromise = pool.dispatch({
+        functionId: "proj_drain_fn",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fn"),
+      });
+      await Bun.sleep(20);
+      let drained = false;
+      const drainPromise = pool.drain().then(() => {
+        drained = true;
+      });
+
+      await Bun.sleep(40);
+      expect(drained).toBe(false);
+      expect((await responsePromise).status).toBe(200);
+      await drainPromise;
+      expect(drained).toBe(true);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("drain waits for EdgeRuntime.waitUntil after the response", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-drain-waituntil-"));
+    const completedPath = join(projectRoot, "waituntil-complete.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch() {
+          EdgeRuntime.waitUntil((async () => {
+            await Bun.sleep(120);
+            await Bun.write(process.env.COMPLETED_PATH, "done");
+          })());
+          return new Response("accepted", { status: 202 });
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_waituntil_drain_fn",
+        functionPath,
+        projectRoot,
+        env: { COMPLETED_PATH: completedPath },
+        request: new Request("http://edge.local/functions/v1/fn"),
+      });
+      expect(response.status).toBe(202);
+
+      let drained = false;
+      const drainPromise = pool.drain().then(() => {
+        drained = true;
+      });
+      await Bun.sleep(40);
+      expect(drained).toBe(false);
+      expect(await waitForFile(completedPath)).toBe("done");
+      await drainPromise;
+      expect(drained).toBe(true);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("WorkerPool TLS policy handoff", () => {
   test("passes host TLS policy into smol workers for HTTPS fetch", async () => {
     const openssl = Bun.spawnSync(["openssl", "version"], { stdout: "pipe", stderr: "pipe" });

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -15,6 +15,7 @@ interface DispatchOptions {
   env: Record<string, string>;
   request: Request;
   cancelKey?: string;
+  signal?: AbortSignal;
   envLoadMs?: number;
   onLog?: (entry: {
     timestamp: string;
@@ -23,6 +24,17 @@ interface DispatchOptions {
     message: string;
   }) => void;
 }
+
+type ScheduledDispatch = DispatchOptions & {
+  executionKey: string;
+};
+
+type QueuedDispatch = {
+  opts: ScheduledDispatch;
+  enqueuedAt: number;
+  resolve: (response: Response) => void;
+  reject: (error: unknown) => void;
+};
 
 const DEFAULT_MAX_BODY_SIZE_MB = 30;
 function resolveMaxBodySizeBytes(value = process.env.EDGE_MAX_BODY_SIZE_MB): number {
@@ -37,6 +49,13 @@ const MAX_BODY_SIZE = resolveMaxBodySizeBytes();
 const MAX_QUEUE_SIZE = Number(process.env.MAX_QUEUE_SIZE) || 200;
 const WAIT_UNTIL_TIMEOUT_MS = Number(process.env.EDGE_WAIT_UNTIL_TIMEOUT_MS) || 300_000;
 const CONTROL_MESSAGE_TIMEOUT_MS = Number(process.env.EDGE_CONTROL_MESSAGE_TIMEOUT_MS) || 1_000;
+
+function cancelledResponse(): Response {
+  return new Response(JSON.stringify({ error: "Task cancelled" }), {
+    status: 499,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 type WorkerControlMessage =
   | { type: "invalidate_module"; functionId: string }
@@ -106,15 +125,13 @@ function resolveWorkerEntry(): string | URL {
 export class WorkerPool {
   private workers: Worker[] = [];
   private idle: Worker[] = [];
-  private queue: Array<{
-    opts: DispatchOptions;
-    resolve: (r: Response) => void;
-  }> = [];
-  private inFlight = new Map<string, { cancel: () => void }>();
+  private queue: QueuedDispatch[] = [];
+  private inFlight = new Map<string, { cancel: () => void; cancelKey?: string }>();
   private totalRequests = 0;
   private totalInvalidations = 0;
   private totalEnvLoadMs = 0;
   private totalQueueWaitMs = 0;
+  private totalQueuedRequests = 0;
   private totalWorkerExecMs = 0;
   private totalModuleCacheHits = 0;
   private totalModuleCacheMisses = 0;
@@ -128,7 +145,6 @@ export class WorkerPool {
   private workerMetadata = new Map<
     Worker,
     {
-      cancelKey?: string;
       replacementTimer?: ReturnType<typeof setTimeout>;
       isCancelling?: boolean;
     }
@@ -170,7 +186,26 @@ export class WorkerPool {
 
     this.totalRequests++;
     if (opts.envLoadMs) this.totalEnvLoadMs += opts.envLoadMs;
-    const queueStart = performance.now();
+    const executionKey = crypto.randomUUID();
+    const signal = opts.signal ?? opts.request.signal;
+    if (signal.aborted) return cancelledResponse();
+
+    const responsePromise = this.enqueue({ ...opts, executionKey });
+    const cancelDispatch = () => {
+      this.cancelExecution(executionKey);
+    };
+    signal.addEventListener("abort", cancelDispatch, { once: true });
+    if (signal.aborted) cancelDispatch();
+
+    try {
+      return await responsePromise;
+    } finally {
+      signal.removeEventListener("abort", cancelDispatch);
+    }
+  }
+
+  private enqueue(opts: ScheduledDispatch): Promise<Response> {
+    const enqueuedAt = performance.now();
     return new Promise<Response>((resolve, reject) => {
       if (this.queue.length >= MAX_QUEUE_SIZE) {
         resolve(new Response(JSON.stringify({ error: "Too many concurrent requests, please retry" }), {
@@ -180,30 +215,25 @@ export class WorkerPool {
         return;
       }
 
-      (opts as any)._queueStart = queueStart;
       const worker = this.idle.pop();
       if (worker) {
-        this.execute(worker, opts, resolve).catch(reject);
+        this.execute(worker, opts, enqueuedAt, resolve).catch(reject);
       } else {
-        this.queue.push({ opts, resolve });
+        this.totalQueuedRequests++;
+        this.queue.push({ opts, enqueuedAt, resolve, reject });
       }
     });
   }
 
   private async execute(
     worker: Worker,
-    opts: DispatchOptions,
+    opts: ScheduledDispatch,
+    enqueuedAt: number,
     resolve: (r: Response) => void,
   ) {
-    const queueStart = (opts as any)._queueStart as number | undefined;
-    const queueWaitMs = queueStart ? Math.round(performance.now() - queueStart) : 0;
+    const queueWaitMs = Math.round(performance.now() - enqueuedAt);
     this.totalQueueWaitMs += queueWaitMs;
     const cancelGraceMs = 3_000;
-    const cancelledResponse = () =>
-      new Response(JSON.stringify({ error: "Task cancelled" }), {
-        status: 499,
-        headers: { "Content-Type": "application/json" },
-      });
 
     let resolved = false;
     const safeResolve = (r: Response) => {
@@ -212,10 +242,9 @@ export class WorkerPool {
       resolve(r);
     };
     const cleanupInFlight = () => {
-      if (opts.cancelKey) this.inFlight.delete(opts.cancelKey);
+      this.inFlight.delete(opts.executionKey);
     };
     const metadata = this.workerMetadata.get(worker) || {};
-    metadata.cancelKey = opts.cancelKey;
     metadata.isCancelling = false;
     if (metadata.replacementTimer) {
       clearTimeout(metadata.replacementTimer);
@@ -225,7 +254,6 @@ export class WorkerPool {
     const clearCancellationState = () => {
       const current = this.workerMetadata.get(worker);
       if (!current) return;
-      current.cancelKey = undefined;
       current.isCancelling = false;
       if (current.replacementTimer) {
         clearTimeout(current.replacementTimer);
@@ -233,12 +261,62 @@ export class WorkerPool {
       }
     };
 
+    let executionStarted = false;
+    let cancellationRequested = false;
+    let detachResponseListeners = () => {};
+
     const timeout = setTimeout(() => {
+      detachResponseListeners();
       cleanupInFlight();
       clearCancellationState();
       safeResolve(new Response("Gateway Timeout", { status: 504 }));
-      this.recycle(worker);
+      this.replaceWorker(worker);
     }, this.config.requestTimeout);
+
+    const replaceCancelledWorker = () => {
+      detachResponseListeners();
+      cleanupInFlight();
+      clearCancellationState();
+      safeResolve(cancelledResponse());
+      this.replaceWorker(worker);
+    };
+
+    const cancelExecution = () => {
+      cancellationRequested = true;
+      if (!executionStarted) return;
+      const current = this.workerMetadata.get(worker);
+      if (!current || current.isCancelling) return;
+      current.isCancelling = true;
+      clearTimeout(timeout);
+      try {
+        worker.postMessage({ type: "cancel_current" });
+      } catch (error) {
+        console.warn("[Pool] Failed to signal worker cancellation; replacing worker", error);
+        replaceCancelledWorker();
+        return;
+      }
+      current.replacementTimer = setTimeout(replaceCancelledWorker, cancelGraceMs);
+    };
+
+    this.inFlight.set(opts.executionKey, {
+      cancel: cancelExecution,
+      cancelKey: opts.cancelKey,
+    });
+
+    const releaseBeforeExecution = () => {
+      clearTimeout(timeout);
+      cleanupInFlight();
+      clearCancellationState();
+      this.recycle(worker);
+    };
+
+    const finishCancelledBeforeExecution = () => {
+      if (resolved) return true;
+      if (!cancellationRequested) return false;
+      releaseBeforeExecution();
+      safeResolve(cancelledResponse());
+      return true;
+    };
 
     const headers: Record<string, string | string[]> = {};
     opts.request.headers.forEach((v, k) => {
@@ -257,7 +335,7 @@ export class WorkerPool {
     if (opts.request.body && !["GET", "HEAD"].includes(opts.request.method)) {
       const contentLength = opts.request.headers.get("content-length");
       if (contentLength && parseInt(contentLength) > MAX_BODY_SIZE) {
-        clearCancellationState();
+        releaseBeforeExecution();
         safeResolve(
           new Response(
             JSON.stringify({
@@ -269,13 +347,18 @@ export class WorkerPool {
             },
           ),
         );
-        this.recycle(worker);
-        clearTimeout(timeout);
         return;
       }
-      body = await opts.request.arrayBuffer();
+      try {
+        body = await opts.request.arrayBuffer();
+      } catch (error) {
+        if (finishCancelledBeforeExecution()) return;
+        releaseBeforeExecution();
+        throw error;
+      }
+      if (finishCancelledBeforeExecution()) return;
       if (body.byteLength > MAX_BODY_SIZE) {
-        clearCancellationState();
+        releaseBeforeExecution();
         safeResolve(
           new Response(
             JSON.stringify({
@@ -287,54 +370,23 @@ export class WorkerPool {
             },
           ),
         );
-        this.recycle(worker);
-        clearTimeout(timeout);
         return;
       }
     }
 
     const execStart = performance.now();
-    const tlsPolicy = await this.resolveTlsPolicy(opts.env);
-    worker.postMessage({
-      functionId: opts.functionId,
-      functionPath: opts.functionPath,
-      projectRoot: opts.projectRoot,
-      projectRef: opts.projectRef,
-      moduleVersion: opts.moduleVersion,
-      env: opts.env,
-      tlsPolicy,
-      url: opts.request.url,
-      method: opts.request.method,
-      headers,
-      body,
-    });
-
-    if (opts.cancelKey) {
-      this.inFlight.set(opts.cancelKey, {
-        cancel: () => {
-          const current = this.workerMetadata.get(worker);
-          if (current?.isCancelling) return;
-          if (current) current.isCancelling = true;
-          clearTimeout(timeout);
-          try {
-            worker.postMessage({ type: "cancel_current" });
-          } catch {
-          }
-          cleanupInFlight();
-          if (current) {
-            current.replacementTimer = setTimeout(() => {
-              worker.removeListener("message", onMsg);
-              worker.removeListener("error", onErr);
-              clearCancellationState();
-              safeResolve(cancelledResponse());
-              this.replaceWorker(worker);
-            }, cancelGraceMs);
-          }
-        },
-      });
+    let tlsPolicy: EdgeFetchTlsPolicy;
+    try {
+      tlsPolicy = await this.resolveTlsPolicy(opts.env);
+    } catch (error) {
+      if (finishCancelledBeforeExecution()) return;
+      releaseBeforeExecution();
+      throw error;
     }
+    if (finishCancelledBeforeExecution()) return;
 
     let waitUntilTimeout: ReturnType<typeof setTimeout> | undefined;
+    let failActiveStream: ((error: Error) => void) | undefined;
 
     const onMsg = (msg: {
       type?: string;
@@ -384,20 +436,24 @@ export class WorkerPool {
       this.totalWorkerExecMs += workerExecMs;
       this.recordModuleCacheStats(msg);
       clearTimeout(timeout);
-      cleanupInFlight();
-      clearCancellationState();
       const waitUntilPending = msg.waitUntilPending === true;
-      if (!waitUntilPending) {
+      const streamPending = msg.type === "stream_start" && !!msg.streamId;
+      if (!waitUntilPending && !streamPending) {
+        cleanupInFlight();
+        clearCancellationState();
         worker.removeListener("error", onErr);
         worker.removeListener("message", onMsg);
-      } else {
+      } else if (waitUntilPending) {
         waitUntilTimeout = setTimeout(() => {
           worker.removeAllListeners("message");
           worker.removeListener("error", onErr);
+          cleanupInFlight();
           clearCancellationState();
           console.error("[Pool] EdgeRuntime.waitUntil timed out; replacing worker");
           this.replaceWorker(worker);
         }, WAIT_UNTIL_TIMEOUT_MS);
+      } else {
+        worker.removeListener("message", onMsg);
       }
 
       const resHeaders = new Headers();
@@ -411,18 +467,34 @@ export class WorkerPool {
 
       if (msg.type === "stream_start" && msg.streamId) {
         const streamId = msg.streamId;
-        let recycled = false;
-        const recycle = () => {
-          if (!recycled) {
-            recycled = true;
-            clearCancellationState();
-            this.recycle(worker);
-          }
+        let streamFinished = false;
+        let streamListener: ((streamMsg: any) => void) | undefined;
+        const clearStreamState = () => {
+          streamFinished = true;
+          if (streamListener) worker.removeListener("message", streamListener);
+          worker.removeListener("error", onErr);
+          cleanupInFlight();
+          clearCancellationState();
+          failActiveStream = undefined;
+        };
+        const completeStream = () => {
+          if (streamFinished) return;
+          clearStreamState();
+          this.recycle(worker);
+        };
+        const abandonStream = () => {
+          if (streamFinished) return;
+          clearStreamState();
+          this.replaceWorker(worker);
         };
 
         const bodyStream = new ReadableStream<Uint8Array>({
           start(controller) {
-            const streamListener = (streamMsg: any) => {
+            failActiveStream = (error) => {
+              controller.error(error);
+              abandonStream();
+            };
+            streamListener = (streamMsg: any) => {
               if (streamMsg.type === "stream_chunk" && streamMsg.streamId === streamId) {
                 if (streamMsg.done) {
                   if (streamMsg.error) {
@@ -430,8 +502,7 @@ export class WorkerPool {
                   } else {
                     controller.close();
                   }
-                  worker.removeListener("message", streamListener);
-                  recycle();
+                  completeStream();
                 } else if (streamMsg.chunk) {
                   controller.enqueue(new Uint8Array(streamMsg.chunk));
                 }
@@ -440,7 +511,7 @@ export class WorkerPool {
             worker.on("message", streamListener);
           },
           cancel() {
-            recycle();
+            abandonStream();
           },
         });
 
@@ -473,6 +544,8 @@ export class WorkerPool {
             if (waitUntilTimeout) clearTimeout(waitUntilTimeout);
             worker.removeListener("message", waitUntilListener);
             worker.removeListener("error", onErr);
+            cleanupInFlight();
+            clearCancellationState();
             this.recycle(worker);
           };
           worker.on("message", waitUntilListener);
@@ -485,48 +558,76 @@ export class WorkerPool {
     const onErr = (err: Error) => {
       clearTimeout(timeout);
       if (waitUntilTimeout) clearTimeout(waitUntilTimeout);
+      console.error("[Pool] Worker error:", err);
+      if (failActiveStream) {
+        failActiveStream(err);
+        return;
+      }
       cleanupInFlight();
       clearCancellationState();
-      worker.removeListener("message", onMsg);
-      console.error("[Pool] Worker error:", err);
+      detachResponseListeners();
       safeResolve(new Response("Internal Error", { status: 500 }));
       this.replaceWorker(worker);
     };
 
+    detachResponseListeners = () => {
+      worker.removeListener("message", onMsg);
+      worker.removeListener("error", onErr);
+    };
     worker.on("message", onMsg);
     worker.once("error", onErr);
+    try {
+      worker.postMessage({
+        functionId: opts.functionId,
+        functionPath: opts.functionPath,
+        projectRoot: opts.projectRoot,
+        projectRef: opts.projectRef,
+        moduleVersion: opts.moduleVersion,
+        env: opts.env,
+        tlsPolicy,
+        url: opts.request.url,
+        method: opts.request.method,
+        headers,
+        body,
+      });
+    } catch (error) {
+      onErr(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+    executionStarted = true;
+    if (cancellationRequested) cancelExecution();
   }
 
   private recycle(worker: Worker) {
+    if (!this.activeWorkers.has(worker)) return;
     const metadata = this.workerMetadata.get(worker);
     if (metadata?.replacementTimer) {
       clearTimeout(metadata.replacementTimer);
       metadata.replacementTimer = undefined;
     }
     if (metadata) {
-      metadata.cancelKey = undefined;
       metadata.isCancelling = false;
     }
     if (this.tainted.has(worker)) {
       this.tainted.delete(worker);
       this.replaceWorker(worker);
-      if (this.queue.length > 0 && this.idle.length > 0) {
-        const fresh = this.idle.pop()!;
-        const next = this.queue.shift()!;
-        this.execute(fresh, next.opts, next.resolve);
-      }
       return;
     }
 
-    if (this.queue.length > 0) {
-      const next = this.queue.shift()!;
-      this.execute(worker, next.opts, next.resolve);
-    } else {
+    this.schedule(worker);
+  }
+
+  private schedule(worker: Worker) {
+    const next = this.queue.shift();
+    if (!next) {
       this.idle.push(worker);
+      return;
     }
+    this.execute(worker, next.opts, next.enqueuedAt, next.resolve).catch(next.reject);
   }
 
   private replaceWorker(dead: Worker) {
+    if (!this.activeWorkers.delete(dead)) return;
     this.totalWorkerReplacements++;
     const metadata = this.workerMetadata.get(dead);
     if (metadata?.replacementTimer) clearTimeout(metadata.replacementTimer);
@@ -535,14 +636,12 @@ export class WorkerPool {
     if (idleIdx !== -1) this.idle.splice(idleIdx, 1);
     const idx = this.workers.indexOf(dead);
     if (idx !== -1) this.workers.splice(idx, 1);
-    this.activeWorkers.delete(dead);
-    try {
-      dead.terminate();
-    } catch {
-    }
+    void dead.terminate().catch((error) => {
+      console.warn("[Pool] Failed to terminate replaced worker", error);
+    });
     const w = this.createWorker();
     this.activeWorkers.add(w);
-    this.idle.push(w);
+    this.schedule(w);
   }
 
   getMetrics(): string {
@@ -779,27 +878,37 @@ export class WorkerPool {
       [`${prefix}_total_preheat_ms`]: this.totalPreheatMs,
       [`${prefix}_avg_env_load_ms`]: this.totalRequests > 0 ? Math.round(this.totalEnvLoadMs / this.totalRequests) : 0,
       [`${prefix}_avg_queue_wait_ms`]: this.totalRequests > 0 ? Math.round(this.totalQueueWaitMs / this.totalRequests) : 0,
-      [`${prefix}_total_queued_requests`]: this.totalQueueWaitMs > 0 ? this.totalRequests : 0,
+      [`${prefix}_total_queued_requests`]: this.totalQueuedRequests,
       [`${prefix}_avg_worker_exec_ms`]: this.totalRequests > 0 ? Math.round(this.totalWorkerExecMs / this.totalRequests) : 0,
     };
   }
 
   cancel(cancelKey: string): boolean {
     const queuedIndex = this.queue.findIndex((entry) => entry.opts.cancelKey === cancelKey);
-    if (queuedIndex >= 0) {
-      const [queued] = this.queue.splice(queuedIndex, 1);
-      queued.resolve(
-        new Response(JSON.stringify({ error: "Task cancelled" }), {
-          status: 499,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-      return true;
-    }
+    if (queuedIndex >= 0) return this.cancelQueued(queuedIndex);
 
-    const inFlight = this.inFlight.get(cancelKey);
+    const inFlight = [...this.inFlight.values()]
+      .find((execution) => execution.cancelKey === cancelKey);
     if (!inFlight) return false;
     inFlight.cancel();
+    return true;
+  }
+
+  private cancelExecution(executionKey: string): boolean {
+    const queuedIndex = this.queue.findIndex(
+      (entry) => entry.opts.executionKey === executionKey,
+    );
+    if (queuedIndex >= 0) return this.cancelQueued(queuedIndex);
+
+    const inFlight = this.inFlight.get(executionKey);
+    if (!inFlight) return false;
+    inFlight.cancel();
+    return true;
+  }
+
+  private cancelQueued(queuedIndex: number): boolean {
+    const [queued] = this.queue.splice(queuedIndex, 1);
+    queued.resolve(cancelledResponse());
     return true;
   }
 

--- a/scripts/build_supacloud_caddy.sh
+++ b/scripts/build_supacloud_caddy.sh
@@ -5,6 +5,7 @@ CADDY_VERSION="${CADDY_VERSION:-v2.11.4}"
 XCADDY_VERSION="${XCADDY_VERSION:-v0.4.5}"
 RATE_LIMIT_MODULE_VERSION="${RATE_LIMIT_MODULE_VERSION:-5625512f24f6f59d6f64fb3aafe5eecff0b286db}"
 RATE_LIMIT_MODULE="${RATE_LIMIT_MODULE:-github.com/mholt/caddy-ratelimit@${RATE_LIMIT_MODULE_VERSION}}"
+CADDY_BUILD_TARGETS="${CADDY_BUILD_TARGETS:-linux-amd64 linux-arm64}"
 OUT_DIR="${OUT_DIR:-dist}"
 mkdir -p "$OUT_DIR"
 
@@ -29,9 +30,21 @@ build_one() {
   chmod 0755 "$OUT_DIR/supacloud-caddy-${suffix}"
 }
 
-build_one linux amd64 linux-amd64
-build_one linux arm64 linux-arm64
+read -r -a targets <<<"$CADDY_BUILD_TARGETS"
+if [[ "${#targets[@]}" -eq 0 ]]; then
+  echo "CADDY_BUILD_TARGETS must include at least one target" >&2
+  exit 1
+fi
+built_binaries=()
+for target in "${targets[@]}"; do
+  case "$target" in
+    linux-amd64) build_one linux amd64 linux-amd64 ;;
+    linux-arm64) build_one linux arm64 linux-arm64 ;;
+    *) echo "Unsupported Caddy build target: $target" >&2; exit 1 ;;
+  esac
+  built_binaries+=("supacloud-caddy-$target")
+done
 
 if command -v sha256sum >/dev/null 2>&1; then
-  (cd "$OUT_DIR" && sha256sum supacloud-caddy-linux-amd64 supacloud-caddy-linux-arm64 > SHA256SUMS.caddy)
+  (cd "$OUT_DIR" && sha256sum "${built_binaries[@]}" > SHA256SUMS.caddy)
 fi

--- a/scripts/test_supacloud_caddy_edge_proxy.sh
+++ b/scripts/test_supacloud_caddy_edge_proxy.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CADDY_BINARY="${CADDY_BINARY:-$ROOT_DIR/packages/management-api/dist/supacloud-caddy-linux-amd64}"
+BUN_BINARY="${BUN_BINARY:-bun}"
+EDGE_PORT="${EDGE_PORT:-19090}"
+CADDY_PORT="${CADDY_PORT:-18081}"
+PROJECT_REF="caddyedgecompat"
+
+if [[ ! -x "$CADDY_BINARY" ]]; then
+  echo "Caddy smoke binary is not executable: $CADDY_BINARY" >&2
+  exit 1
+fi
+if ! command -v "$BUN_BINARY" >/dev/null 2>&1; then
+  echo "Bun is required for the Edge Runtime proxy smoke" >&2
+  exit 1
+fi
+
+work_dir="$(mktemp -d)"
+functions_dir="$work_dir/functions"
+tenants_dir="$work_dir/tenants"
+cancel_started_path="$work_dir/slow-request-started"
+edge_log="$work_dir/edge-runtime.log"
+caddy_log="$work_dir/caddy.log"
+edge_pid=""
+caddy_pid=""
+
+terminate_process() {
+  local pid="$1"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 20); do
+      if ! kill -0 "$pid" 2>/dev/null; then
+        break
+      fi
+      sleep 0.1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+
+cleanup() {
+  terminate_process "$caddy_pid"
+  terminate_process "$edge_pid"
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$functions_dir/$PROJECT_REF" "$tenants_dir"
+cat >"$tenants_dir/$PROJECT_REF.env" <<EOF
+CANCEL_STARTED_PATH=$cancel_started_path
+EOF
+cat >"$functions_dir/$PROJECT_REF/supauth.ts" <<'EOF'
+export default {
+  async fetch(request: Request) {
+    const requestUrl = new URL(request.url);
+    if (requestUrl.pathname.endsWith("/slow")) {
+      await Bun.write(process.env.CANCEL_STARTED_PATH, "started");
+      await new Promise((_, reject) => {
+        request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true });
+      });
+    }
+    const requestBody = await request.text();
+    return new Response([
+      requestUrl.pathname,
+      request.headers.get("host"),
+      request.headers.get("x-project-ref"),
+      request.headers.get("x-forwarded-host"),
+      request.headers.get("x-forwarded-proto"),
+      requestBody,
+    ].join("|"));
+  },
+};
+EOF
+cat >"$functions_dir/$PROJECT_REF/supauth.config.json" <<'EOF'
+{"verify_jwt":false}
+EOF
+
+cat >"$work_dir/caddy.json" <<EOF
+{
+  "admin": { "disabled": true },
+  "apps": {
+    "http": {
+      "servers": {
+        "supacloud": {
+          "listen": ["127.0.0.1:$CADDY_PORT"],
+          "automatic_https": { "disable": true },
+          "routes": [{
+            "match": [{ "host": ["auth.edge.test"] }],
+            "handle": [
+              {
+                "handler": "rewrite",
+                "uri": "/functions/v1/supauth{http.request.uri.path}"
+              },
+              {
+                "handler": "reverse_proxy",
+                "upstreams": [{ "dial": "127.0.0.1:$EDGE_PORT" }],
+                "headers": {
+                  "request": {
+                    "set": {
+                      "Host": ["{http.request.host}"],
+                      "X-Project-Ref": ["$PROJECT_REF"],
+                      "x-project-ref": ["$PROJECT_REF"],
+                      "X-Forwarded-Host": ["{http.request.host}"],
+                      "X-Forwarded-Proto": ["{http.request.scheme}"]
+                    }
+                  }
+                },
+                "transport": {
+                  "protocol": "http",
+                  "read_timeout": "500s",
+                  "write_timeout": "500s"
+                },
+                "flush_interval": -1
+              }
+            ]
+          }]
+        }
+      }
+    }
+  }
+}
+EOF
+
+EDGE_RUNTIME_HOST=127.0.0.1 \
+EDGE_RUNTIME_PORT="$EDGE_PORT" \
+EDGE_FUNCTIONS_DIR="$functions_dir" \
+EDGE_FUNCTIONS_BASE_DIR="$functions_dir" \
+EDGE_RUNTIME_MASTER_KEY=caddy-edge-smoke \
+TENANTS_DIR="$tenants_dir" \
+WORKER_POOL_SIZE=1 \
+"$BUN_BINARY" "$ROOT_DIR/packages/edge-runtime/server.ts" >"$edge_log" 2>&1 &
+edge_pid=$!
+
+edge_ready=false
+for _ in $(seq 1 40); do
+  if curl -fsS "http://127.0.0.1:$EDGE_PORT/health" >/dev/null 2>&1; then
+    edge_ready=true
+    break
+  fi
+  if ! kill -0 "$edge_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$edge_ready" != true ]]; then
+  cat "$edge_log" >&2
+  exit 1
+fi
+
+XDG_DATA_HOME="$work_dir/caddy-data" \
+XDG_CONFIG_HOME="$work_dir/caddy-config" \
+"$CADDY_BINARY" run --config "$work_dir/caddy.json" >"$caddy_log" 2>&1 &
+caddy_pid=$!
+
+caddy_ready=false
+for _ in $(seq 1 40); do
+  if curl -fsS -H "Host: auth.edge.test" \
+    "http://127.0.0.1:$CADDY_PORT/api/v1/health" >/dev/null 2>&1; then
+    caddy_ready=true
+    break
+  fi
+  if ! kill -0 "$caddy_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.25
+done
+if [[ "$caddy_ready" != true ]]; then
+  cat "$caddy_log" >&2
+  cat "$edge_log" >&2
+  exit 1
+fi
+
+if curl -fsS --max-time 0.2 -H "Host: auth.edge.test" \
+  "http://127.0.0.1:$CADDY_PORT/api/v1/slow" >/dev/null 2>&1; then
+  echo "Expected the client-side timeout probe to disconnect" >&2
+  exit 1
+fi
+if [[ ! -s "$cancel_started_path" ]]; then
+  echo "Client disconnected before the slow Edge Function started" >&2
+  exit 1
+fi
+
+cancel_released_worker=false
+for _ in $(seq 1 20); do
+  if curl -fsS --max-time 2 -H "Host: auth.edge.test" \
+    "http://127.0.0.1:$CADDY_PORT/api/v1/health" >/dev/null 2>&1; then
+    cancel_released_worker=true
+    break
+  fi
+  sleep 0.1
+done
+if [[ "$cancel_released_worker" != true ]]; then
+  echo "Caddy disconnect did not release the Edge Runtime worker" >&2
+  cat "$caddy_log" >&2
+  cat "$edge_log" >&2
+  exit 1
+fi
+
+expected_response="/functions/v1/supauth/api/v1/health|auth.edge.test|$PROJECT_REF|auth.edge.test|http|round-trip"
+probe_pids=()
+for probe_id in $(seq 1 12); do
+  curl -fsS \
+    -H "Host: auth.edge.test" \
+    -H "Content-Type: text/plain" \
+    --data 'round-trip' \
+    "http://127.0.0.1:$CADDY_PORT/api/v1/health" >"$work_dir/response-$probe_id.txt" &
+  probe_pids+=("$!")
+done
+
+probe_failed=false
+for probe_pid in "${probe_pids[@]}"; do
+  if ! wait "$probe_pid"; then
+    probe_failed=true
+  fi
+done
+
+for probe_id in $(seq 1 12); do
+  actual_response="$(<"$work_dir/response-$probe_id.txt")"
+  if [[ "$actual_response" != "$expected_response" ]]; then
+    probe_failed=true
+    echo "probe $probe_id: $actual_response" >&2
+  fi
+done
+
+if [[ "$probe_failed" == true ]]; then
+  echo "Unexpected Caddy to Edge Runtime response" >&2
+  echo "expected: $expected_response" >&2
+  cat "$caddy_log" >&2
+  cat "$edge_log" >&2
+  exit 1
+fi
+
+echo "Caddy disconnect cancellation and 12 concurrent Edge Runtime round-trips passed"


### PR DESCRIPTION
## Root cause

The Caddy 2.11.4 canary exposed a shared Edge Runtime worker-pool failure mode rather than a deterministic Caddy core regression:

- foreground requests did not propagate the incoming Request.signal into WorkerPool cancellation
- a Caddy/client timeout could leave the Edge Function running and occupying a shared worker
- request timeout recycled the still-running worker, allowing overlapping executions and late responses
- replacement workers were left idle while queued requests remained blocked
- stream cancellation and waitUntil completion were not represented in the in-flight lifecycle

Under long-running tenant traffic, the orphaned work amplified FIFO queueing until hosted auth routes exceeded the canary deadline.

## Fix

- assign a unique internal execution key while preserving external task cancellation keys
- cancel queued and in-flight work when the HTTP request aborts
- replace timed-out or abandoned streaming workers instead of recycling them
- schedule queued work immediately on replacement workers
- keep streams and waitUntil work in-flight until their real terminal state
- preserve Request.signal when constructing background forwarded requests
- report the actual queued-request count

## Caddy release gate

Adds a real SupaCloud Caddy 2.11.4 to Edge Runtime round-trip gate on pull requests and release publishing. The gate uses the production-equivalent rewrite, Host and project headers, HTTP transport, 500 second timeouts, flush_interval=-1, and response body forwarding. With a one-worker pool it also:

1. starts a slow Edge Function and proves it reached the worker
2. disconnects the Caddy client with a deadline
3. verifies the worker is released for a fast follow-up request
4. verifies 12 concurrent proxy round-trips

The Caddy build helper now supports a validated single-target build so PR CI does not need to build the unused arm64 binary.

## Verification

- Edge Runtime: 66 tests passed, 0 failed
- Edge Runtime strict typecheck passed
- Edge Runtime Linux amd64 compiled bundle passed
- Management API Caddy and SupAuth routing tests: 4 passed, 0 failed
- custom SupaCloud Caddy v2.11.4 plus Edge Runtime disconnect and concurrent proxy smoke passed
- workflow YAML parse, bash syntax checks, and git diff check passed
- independent verifier reproduced the original cancel-key, waitUntil, and stream races and confirmed all three regressions are fixed

## Rollout

Production remains on Caddy 2.10.2 and Edge Runtime 0.13.0. After the Edge Runtime release is published, deploy it first, then canary Caddy 2.11.4 with direct/proxy probes and retain the 2.10.2 rollback binary.