### PR TITLE
fix(edge-runtime): retire workers without unsafe termination

### DIFF
--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -29,6 +29,33 @@ type FrameworkRouterHandler = Record<string, unknown> & {
   routes: unknown[];
 };
 
+type InvalidateModuleMessage = { type: "invalidate_module"; functionId: string };
+type InvalidateProjectMessage = { type: "invalidate_project"; projectRef: string };
+type WorkerLifecycleMessage = { type: "cancel_current" } | { type: "retire" };
+type PreheatMessage = {
+  type: "preheat";
+  functionId: string;
+  functionPath: string;
+  projectRoot: string;
+  projectRef?: string;
+  moduleVersion?: string;
+  env: Record<string, string>;
+  tlsPolicy?: EdgeFetchTlsPolicy;
+};
+type ExecuteMessage = Omit<PreheatMessage, "type"> & {
+  type?: undefined;
+  url: string;
+  method: string;
+  headers: Record<string, string | string[]>;
+  body?: ArrayBuffer | null;
+};
+type ParentMessage =
+  | InvalidateModuleMessage
+  | InvalidateProjectMessage
+  | WorkerLifecycleMessage
+  | PreheatMessage
+  | ExecuteMessage;
+
 const moduleCache = new Map<string, ModuleCacheEntry>();
 
 function evictOldestModule() {
@@ -75,6 +102,7 @@ let envSnapshotActive = false;
 let currentAbortController: AbortController | null = null;
 let currentInjectedEnv: Record<string, string> = {};
 let currentWaitUntilTasks: Promise<unknown>[] = [];
+let retiring = false;
 
 async function resolveMessageTlsPolicy(
   tlsPolicy: EdgeFetchTlsPolicy | undefined,
@@ -124,7 +152,7 @@ const originalConsole = {
 function setupConsoleCapture(functionId: string) {
   const sendLog = (stream: "stdout" | "stderr", level: string, ...args: any[]) => {
     try {
-      parentPort!.postMessage({
+      postToParent({
         type: "log",
         timestamp: new Date().toISOString(),
         stream,
@@ -168,7 +196,7 @@ async function flushWaitUntilTasks(functionId: string) {
     const tasks = currentWaitUntilTasks.splice(0);
     await Promise.allSettled(tasks);
   }
-  parentPort!.postMessage({
+  postToParent({
     type: "wait_until_done",
     functionId,
   });
@@ -275,10 +303,82 @@ function extractProjectRef(functionId: string): string | null {
   return functionId.substring(0, idx);
 }
 
-parentPort.on("message", async (msg: any) => {
+function isStringRecord(candidate: unknown): candidate is Record<string, string> {
+  if (!candidate || typeof candidate !== "object") return false;
+  return Object.values(candidate).every((entry) => typeof entry === "string");
+}
+
+function isHeaderRecord(candidate: unknown): candidate is Record<string, string | string[]> {
+  if (!candidate || typeof candidate !== "object") return false;
+  return Object.values(candidate).every((header) =>
+    typeof header === "string"
+      || Array.isArray(header) && header.every((entry) => typeof entry === "string")
+  );
+}
+
+function isTlsPolicy(candidate: unknown): candidate is EdgeFetchTlsPolicy {
+  if (!candidate || typeof candidate !== "object") return false;
+  const policy = candidate as Record<string, unknown>;
+  return typeof policy.source === "string"
+    && ["none", "ca-inline", "ca-file", "insecure"].includes(policy.source)
+    && (policy.ca === undefined || typeof policy.ca === "string")
+    && (policy.rejectUnauthorized === undefined || typeof policy.rejectUnauthorized === "boolean");
+}
+
+function hasPreheatFields(candidate: Record<string, unknown>): boolean {
+  return typeof candidate.functionId === "string"
+    && typeof candidate.functionPath === "string"
+    && typeof candidate.projectRoot === "string"
+    && (candidate.projectRef === undefined || typeof candidate.projectRef === "string")
+    && (candidate.moduleVersion === undefined || typeof candidate.moduleVersion === "string")
+    && isStringRecord(candidate.env)
+    && (candidate.tlsPolicy === undefined || isTlsPolicy(candidate.tlsPolicy));
+}
+
+function isExecuteMessage(candidate: Record<string, unknown>): boolean {
+  return candidate.type === undefined
+    && hasPreheatFields(candidate)
+    && typeof candidate.url === "string"
+    && typeof candidate.method === "string"
+    && isHeaderRecord(candidate.headers)
+    && (candidate.body == null || candidate.body instanceof ArrayBuffer);
+}
+
+function isParentMessage(message: unknown): message is ParentMessage {
+  if (!message || typeof message !== "object") return false;
+  const candidate = message as Record<string, unknown>;
+  if (candidate.type === "retire" || candidate.type === "cancel_current") return true;
+  if (candidate.type === "invalidate_module") return typeof candidate.functionId === "string";
+  if (candidate.type === "invalidate_project") return typeof candidate.projectRef === "string";
+  if (candidate.type === "preheat") return hasPreheatFields(candidate);
+  return isExecuteMessage(candidate);
+}
+
+function postToParent(message: unknown) {
+  if (retiring) return;
+  parentPort!.postMessage(message);
+}
+
+async function onParentMessage(msg: unknown): Promise<void> {
+  if (!isParentMessage(msg)) {
+    console.warn("[Worker] Ignoring invalid parent message");
+    return;
+  }
+
+  if (msg.type === "retire") {
+    if (retiring) return;
+    retiring = true;
+    currentAbortController?.abort(new DOMException("Worker retiring", "AbortError"));
+    parentPort!.off("message", onParentMessage);
+    parentPort!.close();
+    return;
+  }
+
+  if (retiring) return;
+
   if (msg.type === "invalidate_module") {
     const invalidated = invalidateCachedModules((entry) => entry.functionId === msg.functionId);
-    parentPort!.postMessage({
+    postToParent({
       type: "invalidate_done",
       functionId: msg.functionId,
       invalidated,
@@ -289,7 +389,7 @@ parentPort.on("message", async (msg: any) => {
 
   if (msg.type === "invalidate_project") {
     const invalidated = invalidateCachedModules((entry) => entry.projectRef === msg.projectRef);
-    parentPort!.postMessage({
+    postToParent({
       type: "invalidate_done",
       projectRef: msg.projectRef,
       invalidated,
@@ -316,7 +416,7 @@ parentPort.on("message", async (msg: any) => {
           moduleVersion: msg.moduleVersion,
           projectRef: ref,
         });
-        parentPort!.postMessage({
+        postToParent({
           type: "preheat_done",
           functionId: msg.functionId,
           moduleCacheHit: moduleLoad.cacheHit,
@@ -326,7 +426,7 @@ parentPort.on("message", async (msg: any) => {
         restoreFetchTlsPolicy();
       }
     } catch (err: any) {
-      parentPort!.postMessage({
+      postToParent({
         type: "preheat_error",
         functionId: msg.functionId,
         error: err.message,
@@ -342,7 +442,7 @@ parentPort.on("message", async (msg: any) => {
 
   if (msg.type === "cancel_current") {
     currentAbortController?.abort(new DOMException("Task cancelled", "AbortError"));
-    parentPort!.postMessage({ type: "cancel_ack" });
+    postToParent({ type: "cancel_ack" });
     return;
   }
 
@@ -386,7 +486,7 @@ parentPort.on("message", async (msg: any) => {
       response.headers.get("content-type")?.includes("text/event-stream")
     ) {
       const streamId = crypto.randomUUID();
-      parentPort!.postMessage({
+      postToParent({
         type: "stream_start",
         streamId,
         status: response.status,
@@ -400,14 +500,14 @@ parentPort.on("message", async (msg: any) => {
         while (true) {
           const { done, value } = await reader.read();
           if (done) {
-            parentPort!.postMessage({
+            postToParent({
               type: "stream_chunk",
               streamId,
               done: true,
             });
             break;
           }
-          parentPort!.postMessage({
+          postToParent({
             type: "stream_chunk",
             streamId,
             chunk: Buffer.from(value).buffer,
@@ -415,7 +515,7 @@ parentPort.on("message", async (msg: any) => {
           });
         }
       } catch (err: any) {
-        parentPort!.postMessage({
+        postToParent({
           type: "stream_chunk",
           streamId,
           done: true,
@@ -442,7 +542,7 @@ parentPort.on("message", async (msg: any) => {
       resHeaders[k] = v;
     });
 
-    parentPort!.postMessage({
+    postToParent({
       status: response.status,
       headers: resHeaders,
       body: resBody,
@@ -454,7 +554,7 @@ parentPort.on("message", async (msg: any) => {
   } catch (err: any) {
     const aborted = currentAbortController?.signal.aborted || err?.name === "AbortError";
     const message = err instanceof Error ? err.message : String(err);
-    parentPort!.postMessage({
+    postToParent({
       status: aborted ? 499 : 500,
       headers: { "Content-Type": "application/json" },
       body: Buffer.from(
@@ -471,4 +571,6 @@ parentPort.on("message", async (msg: any) => {
     setProjectRoot(null);
     setInjectedEnv({});
   }
-});
+}
+
+parentPort.on("message", onParentMessage);

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -9,9 +9,7 @@ const pools: WorkerPool[] = [];
 
 afterEach(async () => {
   for (const pool of pools.splice(0)) {
-    for (const worker of (pool as any).workers || []) {
-      await worker.terminate();
-    }
+    await pool.shutdown();
   }
 });
 
@@ -22,6 +20,20 @@ async function waitForFile(path: string, timeoutMs = 2_000): Promise<string> {
     await Bun.sleep(20);
   }
   throw new Error(`Timed out waiting for ${path}`);
+}
+
+async function waitForMetric(
+  pool: WorkerPool,
+  metric: string,
+  expected: number,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (pool.snapshotMetrics("test")[`test_${metric}`] === expected) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Timed out waiting for ${metric}=${expected}`);
 }
 
 describe("WorkerPool EdgeRuntime.waitUntil", () => {
@@ -192,8 +204,11 @@ describe("WorkerPool cancellation and replacement", () => {
       expect(await (await fastResponse).text()).toBe("fast");
       const metrics = pool.snapshotMetrics("timeout");
       expect(metrics["timeout_total_worker_replacements"]).toBe(1);
+      expect(metrics["timeout_total_worker_retirements"]).toBe(1);
       expect(metrics["timeout_total_queued_requests"]).toBe(1);
       expect(metrics["timeout_idle_workers"]).toBe(1);
+      await waitForMetric(pool, "total_natural_worker_exits", 1);
+      expect(pool.snapshotMetrics("timeout")["timeout_retired_workers"]).toBe(0);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -485,6 +500,137 @@ describe("WorkerPool cancellation and replacement", () => {
       expect(await waitForFile(completedPath)).toBe("done");
       await drainPromise;
       expect(drained).toBe(true);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("WorkerPool cooperative retirement", () => {
+  test("triggers the count budget once and stops accepting requests", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-retirement-count-"));
+    const functionPath = join(projectRoot, "slow.ts");
+    await Bun.write(functionPath, `
+      export default async function fetch(request) {
+        await new Promise((resolve) => {
+          const keepAlive = setInterval(() => {}, 10);
+          request.signal.addEventListener("abort", () => {
+            setTimeout(() => {
+              clearInterval(keepAlive);
+              resolve();
+            }, 150);
+          }, { once: true });
+        });
+        return new Response("retired");
+      }
+    `);
+
+    const exceeded: string[] = [];
+    const pool = new WorkerPool({
+      size: 1,
+      requestTimeout: 25,
+      retirementBudget: { maxRetiredWorkers: 1, maxRetirementAgeMs: 1_000 },
+      onRetirementBudgetExceeded: (event) => exceeded.push(event.limit),
+    });
+    pools.push(pool);
+
+    try {
+      const dispatchSlow = () => pool.dispatch({
+        functionId: "proj_retirement_count",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/slow"),
+      });
+      expect((await dispatchSlow()).status).toBe(504);
+      expect((await dispatchSlow()).status).toBe(504);
+      expect(exceeded).toEqual(["count"]);
+      expect(pool.snapshotMetrics("retirement")["retirement_retirement_budget_exceeded"]).toBe(1);
+      expect((await dispatchSlow()).status).toBe(503);
+      await waitForMetric(pool, "total_natural_worker_exits", 2);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("triggers the age budget once for a worker that cannot drain promptly", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-retirement-age-"));
+    const functionPath = join(projectRoot, "slow.ts");
+    await Bun.write(functionPath, `
+      export default async function fetch(request) {
+        await new Promise((resolve) => {
+          const keepAlive = setInterval(() => {}, 10);
+          request.signal.addEventListener("abort", () => {
+            setTimeout(() => {
+              clearInterval(keepAlive);
+              resolve();
+            }, 150);
+          }, { once: true });
+        });
+        return new Response("retired");
+      }
+    `);
+
+    const exceeded: string[] = [];
+    const pool = new WorkerPool({
+      size: 1,
+      requestTimeout: 25,
+      retirementBudget: { maxRetiredWorkers: 8, maxRetirementAgeMs: 30 },
+      onRetirementBudgetExceeded: (event) => exceeded.push(event.limit),
+    });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_retirement_age",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/slow"),
+      });
+      expect(response.status).toBe(504);
+      await waitForMetric(pool, "retirement_budget_exceeded", 1);
+      expect(exceeded).toEqual(["age"]);
+      await Bun.sleep(50);
+      expect(exceeded).toEqual(["age"]);
+      await waitForMetric(pool, "total_natural_worker_exits", 1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("never returns a timed-out preheat worker to the idle pool", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-retirement-"));
+    const slowFunctionPath = join(projectRoot, "slow-preheat.ts");
+    const fastFunctionPath = join(projectRoot, "fast.ts");
+    await Bun.write(slowFunctionPath, `
+      await Bun.sleep(150);
+      export default () => new Response("late");
+    `);
+    await Bun.write(fastFunctionPath, `export default () => new Response("replacement");`);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 1_000, preheatTimeoutMs: 25 });
+    pools.push(pool);
+
+    try {
+      expect(await pool.preheat(
+        "proj_preheat_slow",
+        slowFunctionPath,
+        projectRoot,
+        {},
+        { moduleVersion: "v1" },
+      )).toBe(false);
+      const response = await pool.dispatch({
+        functionId: "proj_preheat_fast",
+        functionPath: fastFunctionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fast"),
+      });
+      expect(await response.text()).toBe("replacement");
+      expect(pool.snapshotMetrics("preheat")["preheat_total_worker_retirements"]).toBe(1);
+      await waitForMetric(pool, "total_natural_worker_exits", 1);
+      expect(pool.snapshotMetrics("preheat")["preheat_idle_workers"]).toBe(1);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -49,7 +49,7 @@ const MAX_BODY_SIZE = resolveMaxBodySizeBytes();
 const MAX_QUEUE_SIZE = Number(process.env.MAX_QUEUE_SIZE) || 200;
 const WAIT_UNTIL_TIMEOUT_MS = Number(process.env.EDGE_WAIT_UNTIL_TIMEOUT_MS) || 300_000;
 const CONTROL_MESSAGE_TIMEOUT_MS = Number(process.env.EDGE_CONTROL_MESSAGE_TIMEOUT_MS) || 1_000;
-const DEFAULT_MAX_RETIREMENT_AGE_MS = 30_000;
+const DEFAULT_MAX_RETIREMENT_AGE_MS = 60_000;
 const DEFAULT_PREHEAT_TIMEOUT_MS = 10_000;
 
 function cancelledResponse(): Response {

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -49,6 +49,8 @@ const MAX_BODY_SIZE = resolveMaxBodySizeBytes();
 const MAX_QUEUE_SIZE = Number(process.env.MAX_QUEUE_SIZE) || 200;
 const WAIT_UNTIL_TIMEOUT_MS = Number(process.env.EDGE_WAIT_UNTIL_TIMEOUT_MS) || 300_000;
 const CONTROL_MESSAGE_TIMEOUT_MS = Number(process.env.EDGE_CONTROL_MESSAGE_TIMEOUT_MS) || 1_000;
+const DEFAULT_MAX_RETIREMENT_AGE_MS = 30_000;
+const DEFAULT_PREHEAT_TIMEOUT_MS = 10_000;
 
 function cancelledResponse(): Response {
   return new Response(JSON.stringify({ error: "Task cancelled" }), {
@@ -91,6 +93,29 @@ export type WorkerPoolPreheatResult = {
   cacheHits: number;
   cacheMisses: number;
   durationMs: number;
+};
+
+type RetirementBudgetExceeded = {
+  limit: "count" | "age";
+  retiredWorkers: number;
+  oldestRetirementAgeMs: number;
+};
+
+type WorkerPoolConfig = {
+  size: number;
+  requestTimeout: number;
+  smol?: boolean;
+  preheatTimeoutMs?: number;
+  retirementBudget?: {
+    maxRetiredWorkers: number;
+    maxRetirementAgeMs: number;
+  };
+  onRetirementBudgetExceeded?: (exceeded: RetirementBudgetExceeded) => void;
+};
+
+type RetiredWorker = {
+  retiredAt: number;
+  ageTimer: ReturnType<typeof setTimeout>;
 };
 
 function extractProjectRef(functionId: string): string | null {
@@ -141,7 +166,11 @@ export class WorkerPool {
   private totalPreheatAttempts = 0;
   private totalPreheatSucceeded = 0;
   private totalPreheatMs = 0;
+  private totalWorkerRetirements = 0;
+  private totalNaturalWorkerExits = 0;
+  private retirementBudgetExceeded = false;
   private activeWorkers = new Set<Worker>();
+  private retiredWorkers = new Map<Worker, RetiredWorker>();
   private workerMetadata = new Map<
     Worker,
     {
@@ -152,7 +181,21 @@ export class WorkerPool {
   private tainted = new Set<Worker>();
   private draining = false;
 
-  constructor(private config: { size: number; requestTimeout: number; smol?: boolean }) {
+  private readonly retirementBudget: {
+    maxRetiredWorkers: number;
+    maxRetirementAgeMs: number;
+  };
+  private readonly onRetirementBudgetExceeded: (exceeded: RetirementBudgetExceeded) => void;
+
+  constructor(private config: WorkerPoolConfig) {
+    this.retirementBudget = config.retirementBudget ?? {
+      maxRetiredWorkers: Math.max(config.size * 2, 8),
+      maxRetirementAgeMs: DEFAULT_MAX_RETIREMENT_AGE_MS,
+    };
+    this.onRetirementBudgetExceeded = config.onRetirementBudgetExceeded ?? ((exceeded) => {
+      console.error("[Pool] Worker retirement budget exceeded; restarting Edge Runtime", exceeded);
+      process.exit(1);
+    });
     for (let i = 0; i < config.size; i++) {
       const w = this.createWorker();
       this.idle.push(w);
@@ -167,6 +210,7 @@ export class WorkerPool {
     } as any);
     this.workers.push(w);
     this.workerMetadata.set(w, {});
+    w.once("exit", () => this.onWorkerExit(w));
     return w;
   }
 
@@ -270,7 +314,7 @@ export class WorkerPool {
       cleanupInFlight();
       clearCancellationState();
       safeResolve(new Response("Gateway Timeout", { status: 504 }));
-      this.replaceWorker(worker);
+      this.retireWorker(worker);
     }, this.config.requestTimeout);
 
     const replaceCancelledWorker = () => {
@@ -278,7 +322,7 @@ export class WorkerPool {
       cleanupInFlight();
       clearCancellationState();
       safeResolve(cancelledResponse());
-      this.replaceWorker(worker);
+      this.retireWorker(worker);
     };
 
     const cancelExecution = () => {
@@ -450,7 +494,7 @@ export class WorkerPool {
           cleanupInFlight();
           clearCancellationState();
           console.error("[Pool] EdgeRuntime.waitUntil timed out; replacing worker");
-          this.replaceWorker(worker);
+          this.retireWorker(worker);
         }, WAIT_UNTIL_TIMEOUT_MS);
       } else {
         worker.removeListener("message", onMsg);
@@ -485,7 +529,7 @@ export class WorkerPool {
         const abandonStream = () => {
           if (streamFinished) return;
           clearStreamState();
-          this.replaceWorker(worker);
+          this.retireWorker(worker);
         };
 
         const bodyStream = new ReadableStream<Uint8Array>({
@@ -567,7 +611,7 @@ export class WorkerPool {
       clearCancellationState();
       detachResponseListeners();
       safeResolve(new Response("Internal Error", { status: 500 }));
-      this.replaceWorker(worker);
+      this.retireWorker(worker);
     };
 
     detachResponseListeners = () => {
@@ -610,7 +654,7 @@ export class WorkerPool {
     }
     if (this.tainted.has(worker)) {
       this.tainted.delete(worker);
-      this.replaceWorker(worker);
+      this.retireWorker(worker);
       return;
     }
 
@@ -626,22 +670,98 @@ export class WorkerPool {
     this.execute(worker, next.opts, next.enqueuedAt, next.resolve).catch(next.reject);
   }
 
-  private replaceWorker(dead: Worker) {
-    if (!this.activeWorkers.delete(dead)) return;
-    this.totalWorkerReplacements++;
-    const metadata = this.workerMetadata.get(dead);
+  private retireWorker(worker: Worker) {
+    if (!this.activeWorkers.delete(worker)) return;
+    this.totalWorkerRetirements++;
+    const metadata = this.workerMetadata.get(worker);
     if (metadata?.replacementTimer) clearTimeout(metadata.replacementTimer);
-    this.workerMetadata.delete(dead);
-    const idleIdx = this.idle.indexOf(dead);
+    this.workerMetadata.delete(worker);
+    this.tainted.delete(worker);
+    const idleIdx = this.idle.indexOf(worker);
     if (idleIdx !== -1) this.idle.splice(idleIdx, 1);
-    const idx = this.workers.indexOf(dead);
-    if (idx !== -1) this.workers.splice(idx, 1);
-    void dead.terminate().catch((error) => {
-      console.warn("[Pool] Failed to terminate replaced worker", error);
+    this.trackRetiredWorker(worker);
+
+    try {
+      worker.postMessage({ type: "retire" });
+    } catch (error) {
+      console.warn("[Pool] Failed to signal cooperative worker retirement", error);
+    }
+    worker.unref();
+
+    if (!this.draining) {
+      this.totalWorkerReplacements++;
+      const replacement = this.createWorker();
+      this.activeWorkers.add(replacement);
+      this.schedule(replacement);
+    }
+  }
+
+  private trackRetiredWorker(worker: Worker) {
+    const retiredAt = Date.now();
+    const ageTimer = setTimeout(() => {
+      if (!this.retiredWorkers.has(worker)) return;
+      this.triggerRetirementFailSafe("age");
+    }, this.retirementBudget.maxRetirementAgeMs);
+    this.retiredWorkers.set(worker, { retiredAt, ageTimer });
+    if (this.retiredWorkers.size > this.retirementBudget.maxRetiredWorkers) {
+      this.triggerRetirementFailSafe("count");
+    }
+  }
+
+  private onWorkerExit(worker: Worker) {
+    const retired = this.retiredWorkers.get(worker);
+    if (retired) {
+      clearTimeout(retired.ageTimer);
+      this.retiredWorkers.delete(worker);
+      this.totalNaturalWorkerExits++;
+    }
+
+    this.removeWorkerReferences(worker);
+    if (!this.activeWorkers.delete(worker) || this.draining) return;
+
+    this.totalWorkerReplacements++;
+    const replacement = this.createWorker();
+    this.activeWorkers.add(replacement);
+    this.schedule(replacement);
+  }
+
+  private removeWorkerReferences(worker: Worker) {
+    this.workerMetadata.delete(worker);
+    this.tainted.delete(worker);
+    const idleIndex = this.idle.indexOf(worker);
+    if (idleIndex !== -1) this.idle.splice(idleIndex, 1);
+    const workerIndex = this.workers.indexOf(worker);
+    if (workerIndex !== -1) this.workers.splice(workerIndex, 1);
+  }
+
+  private triggerRetirementFailSafe(limit: "count" | "age") {
+    if (this.retirementBudgetExceeded) return;
+    this.retirementBudgetExceeded = true;
+    this.stopDispatching();
+    this.onRetirementBudgetExceeded({
+      limit,
+      retiredWorkers: this.retiredWorkers.size,
+      oldestRetirementAgeMs: this.oldestRetirementAgeMs(),
     });
-    const w = this.createWorker();
-    this.activeWorkers.add(w);
-    this.schedule(w);
+  }
+
+  private oldestRetirementAgeMs(): number {
+    let oldestRetiredAt = Date.now();
+    for (const retired of this.retiredWorkers.values()) {
+      oldestRetiredAt = Math.min(oldestRetiredAt, retired.retiredAt);
+    }
+    return this.retiredWorkers.size === 0 ? 0 : Date.now() - oldestRetiredAt;
+  }
+
+  private stopDispatching() {
+    this.draining = true;
+    for (const entry of this.queue) {
+      entry.resolve(new Response(JSON.stringify({ error: "Server shutting down" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }));
+    }
+    this.queue = [];
   }
 
   getMetrics(): string {
@@ -714,7 +834,7 @@ export class WorkerPool {
     for (const { worker, result } of results) {
       if (result.acked) continue;
       if (this.idle.includes(worker)) {
-        this.replaceWorker(worker);
+        this.retireWorker(worker);
       } else {
         this.tainted.add(worker);
       }
@@ -755,8 +875,9 @@ export class WorkerPool {
     return new Promise((resolve) => {
       const timeout = setTimeout(() => {
         worker.removeListener("message", onMsg);
+        this.retireWorker(worker);
         resolve({ success: false, cacheHit: null, moduleCacheSize: this.lastModuleCacheEntries });
-      }, 10000);
+      }, this.config.preheatTimeoutMs ?? DEFAULT_PREHEAT_TIMEOUT_MS);
 
       const onMsg = (msg: {
         type?: string;
@@ -784,16 +905,24 @@ export class WorkerPool {
       };
 
       worker.on("message", onMsg);
-      worker.postMessage({
-        type: "preheat",
-        functionId,
-        functionPath,
-        projectRoot,
-        projectRef,
-        moduleVersion: options.moduleVersion,
-        env,
-        tlsPolicy,
-      });
+      try {
+        worker.postMessage({
+          type: "preheat",
+          functionId,
+          functionPath,
+          projectRoot,
+          projectRef,
+          moduleVersion: options.moduleVersion,
+          env,
+          tlsPolicy,
+        });
+      } catch (error) {
+        clearTimeout(timeout);
+        worker.removeListener("message", onMsg);
+        console.warn("[Pool] Failed to dispatch worker preheat", error);
+        this.retireWorker(worker);
+        resolve({ success: false, cacheHit: null, moduleCacheSize: this.lastModuleCacheEntries });
+      }
     });
   }
 
@@ -873,6 +1002,11 @@ export class WorkerPool {
       [`${prefix}_total_module_cache_invalidated`]: this.totalModuleCacheInvalidated,
       [`${prefix}_module_cache_entries_last_worker`]: this.lastModuleCacheEntries,
       [`${prefix}_total_worker_replacements`]: this.totalWorkerReplacements,
+      [`${prefix}_retired_workers`]: this.retiredWorkers.size,
+      [`${prefix}_total_worker_retirements`]: this.totalWorkerRetirements,
+      [`${prefix}_total_natural_worker_exits`]: this.totalNaturalWorkerExits,
+      [`${prefix}_oldest_retired_worker_age_ms`]: this.oldestRetirementAgeMs(),
+      [`${prefix}_retirement_budget_exceeded`]: this.retirementBudgetExceeded ? 1 : 0,
       [`${prefix}_total_preheat_attempts`]: this.totalPreheatAttempts,
       [`${prefix}_total_preheat_succeeded`]: this.totalPreheatSucceeded,
       [`${prefix}_total_preheat_ms`]: this.totalPreheatMs,
@@ -917,14 +1051,7 @@ export class WorkerPool {
   }
 
   drain(): Promise<void> {
-    this.draining = true;
-    for (const entry of this.queue) {
-      entry.resolve(new Response(JSON.stringify({ error: "Server shutting down" }), {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      }));
-    }
-    this.queue = [];
+    this.stopDispatching();
 
     return new Promise((resolve) => {
       const check = () => {
@@ -936,5 +1063,20 @@ export class WorkerPool {
       };
       check();
     });
+  }
+
+  async shutdown(): Promise<void> {
+    const maxDrainMs = Math.min(this.config.requestTimeout + 100, 5_000);
+    const drained = await Promise.race([
+      this.drain().then(() => true),
+      Bun.sleep(maxDrainMs).then(() => false),
+    ]);
+    if (!drained) {
+      console.error(`[Pool] Cooperative shutdown drain exceeded ${maxDrainMs}ms`);
+    }
+    for (const worker of [...this.activeWorkers]) {
+      this.retireWorker(worker);
+    }
+    await Bun.sleep(0);
   }
 }

--- a/packages/edge-runtime/worker-retirement-stress-fixture.ts
+++ b/packages/edge-runtime/worker-retirement-stress-fixture.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkerPool } from "./worker-pool";
+
+const CHURN_BATCHES = 4;
+const REQUESTS_PER_BATCH = 6;
+
+async function waitForNaturalExits(pool: WorkerPool, expected: number): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    if (pool.snapshotMetrics("stress").stress_total_natural_worker_exits === expected) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`Only ${pool.snapshotMetrics("stress").stress_total_natural_worker_exits} workers exited naturally`);
+}
+
+async function runStress(): Promise<void> {
+  const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-retirement-stress-"));
+  const functionPath = join(projectRoot, "fetch.ts");
+  const heldFetchServer = Bun.serve({
+    port: 0,
+    async fetch() {
+      await Bun.sleep(120);
+      return new Response("released");
+    },
+  });
+  await Bun.write(functionPath, `
+    export default async function execute(request) {
+      if (new URL(request.url).pathname.endsWith("/slow")) {
+        await globalThis.fetch(process.env.HELD_FETCH_URL);
+      }
+      return new Response("replacement");
+    }
+  `);
+
+  const pool = new WorkerPool({
+    size: 2,
+    requestTimeout: 35,
+    retirementBudget: { maxRetiredWorkers: 64, maxRetirementAgeMs: 2_000 },
+  });
+
+  try {
+    const dispatch = (path: "fast" | "slow") => pool.dispatch({
+      functionId: "proj_retirement_stress",
+      functionPath,
+      projectRoot,
+      env: { HELD_FETCH_URL: `http://127.0.0.1:${heldFetchServer.port}` },
+      request: new Request(`http://edge.local/functions/v1/stress/${path}`),
+    });
+    expectStatus(await dispatch("fast"), 200);
+
+    for (let batch = 0; batch < CHURN_BATCHES; batch++) {
+      const timedOut = await Promise.all(
+        Array.from({ length: REQUESTS_PER_BATCH }, () => dispatch("slow")),
+      );
+      timedOut.forEach((response) => expectStatus(response, 504));
+      const replacementResponses = await Promise.all([dispatch("fast"), dispatch("fast")]);
+      replacementResponses.forEach((response) => expectStatus(response, 200));
+    }
+
+    const expectedRetirements = CHURN_BATCHES * REQUESTS_PER_BATCH;
+    await waitForNaturalExits(pool, expectedRetirements);
+    const metrics = pool.snapshotMetrics("stress");
+    console.log(JSON.stringify({
+      survived: true,
+      retirements: metrics.stress_total_worker_retirements,
+      naturalExits: metrics.stress_total_natural_worker_exits,
+      retiredWorkers: metrics.stress_retired_workers,
+      budgetExceeded: metrics.stress_retirement_budget_exceeded,
+      idleWorkers: metrics.stress_idle_workers,
+    }));
+  } finally {
+    await pool.shutdown();
+    heldFetchServer.stop(true);
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+}
+
+function expectStatus(response: Response, expected: number) {
+  if (response.status !== expected) {
+    throw new Error(`Expected HTTP ${expected}, received ${response.status}`);
+  }
+}
+
+await runStress();

--- a/packages/edge-runtime/worker-retirement-stress.test.ts
+++ b/packages/edge-runtime/worker-retirement-stress.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+describe("WorkerPool process-level cooperative retirement", () => {
+  test("survives held fetch timeout churn and serves through replacements", async () => {
+    const fixturePath = join(import.meta.dir, "worker-retirement-stress-fixture.ts");
+    const child = Bun.spawn([process.execPath, fixturePath], {
+      cwd: import.meta.dir,
+      env: process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+
+    expect(exitCode, stderr).toBe(0);
+    const reportLine = stdout.trim().split("\n").at(-1);
+    expect(reportLine).toBeDefined();
+    const report = JSON.parse(reportLine!);
+    expect(report).toEqual({
+      survived: true,
+      retirements: 24,
+      naturalExits: 24,
+      retiredWorkers: 0,
+      budgetExceeded: 0,
+      idleWorkers: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Root cause

#488 correctly stopped recycling requests that were still executing after a Caddy/client disconnect, but its replacement path called `Worker.terminate()`. Bun 1.3.14 can free a worker VM while an in-flight fetch/native completion still references its event loop, causing the confirmed use-after-free in [oven-sh/bun#33911](https://github.com/oven-sh/bun/issues/33911).

This matches the Edge Runtime 0.13.1 production crash: workers were spawned/replaced under disconnect traffic, then Bun segfaulted while delivering a late completion.

## Fix

- replace runtime `Worker.terminate()` calls with cooperative retirement
- remove a retired worker from scheduling, create its replacement immediately, then ask the old worker to abort its current request and close `parentPort`
- treat the worker `exit` event as the only successful reclamation signal
- prevent late responses, errors, and preheat completions from returning retired workers to the idle pool
- fix the preheat-timeout race that previously reused a still-running worker
- add retired-worker count and 60-second age budgets; budget exhaustion stops dispatch and restarts the whole Edge Runtime process instead of force-terminating one worker
- expose retirement, natural-exit, age, and budget metrics

## Regression coverage

The new process-level test runs 24 timeout retirements while each worker has a held fetch that is deliberately not connected to the request AbortSignal. It verifies:

- the Bun process survives
- all 24 retired workers exit naturally
- replacement workers continue serving requests
- no retirement budget is exceeded
- the pool returns to its configured idle capacity

## Verification

- `bun test`: 70 passed, 0 failed
- focused retirement tests: 27 passed, 0 failed
- strict TypeScript typecheck passed
- Linux amd64 compiled binary build passed
- `git diff --check` passed
- `rg -n '\.terminate\(' packages/edge-runtime`: 0 matches
- independent verifier: PASS, no P0-P3 findings

## Rollout

Production remains safely rolled back to Edge Runtime 0.13.0 and Caddy 2.10.2. After the next Edge Runtime release is published, deploy Edge alone first, verify a stable PID/`NRestarts` and retirement metrics for at least five minutes, then resume the separate Caddy 2.11.4 canary.
