### PR TITLE
fix(realtime): dedupe auto-attached triggers

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -456,6 +456,12 @@ jobs:
           SUPAOAUTH_BFF_SIGNING_SECRET: ci-integration-bff-signing-secret-0123456789abcdef
           DASHBOARD_PASSWORD: ci-integration-dashboard-password-0123456789abcdef
 
+      - name: Verify Realtime auto-attach DDL
+        working-directory: packages/management-api
+        run: bun test tests/integration/realtime-auto-attach-trigger.test.ts
+        env:
+          DATABASE_URL: postgresql://supabase_admin:postgres@localhost:5432/postgres
+
       - name: Wait for CI services
         run: |
           echo "Waiting for Realtime container to be ready..."

--- a/packages/management-api/src/db/sql-modules.ts
+++ b/packages/management-api/src/db/sql-modules.ts
@@ -3,6 +3,7 @@ import backgroundTaskMirrorDownSql from "./sql-modules/background-task-mirror-do
 import backgroundTaskMirrorUpSql from "./sql-modules/background-task-mirror-up.sql" with { type: "text" };
 import pgmqPublicSql from "./sql-modules/pgmq-public.sql" with { type: "text" };
 import postgrestRequestContextSql from "./sql-modules/postgrest-request-context.sql" with { type: "text" };
+import realtimeAutoAttachTriggerSql from "./sql-modules/realtime-auto-attach-trigger.sql" with { type: "text" };
 import storagePathHelpersSql from "./sql-modules/storage-path-helpers.sql" with { type: "text" };
 
 export const SQL_MODULES = {
@@ -11,6 +12,7 @@ export const SQL_MODULES = {
   "background-task-mirror-up": backgroundTaskMirrorUpSql.trim(),
   "pgmq-public": pgmqPublicSql.trim(),
   "postgrest-request-context": postgrestRequestContextSql.trim(),
+  "realtime-auto-attach-trigger": realtimeAutoAttachTriggerSql.trim(),
   "storage-path-helpers": storagePathHelpersSql.trim(),
 } as const;
 

--- a/packages/management-api/src/db/sql-modules/realtime-auto-attach-trigger.sql
+++ b/packages/management-api/src/db/sql-modules/realtime-auto-attach-trigger.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION realtime.auto_attach_notify_trigger()
+RETURNS event_trigger AS $fn$
+DECLARE
+  relation RECORD;
+BEGIN
+  FOR relation IN
+    SELECT c.oid, n.nspname AS schema_name, c.relname
+    FROM pg_catalog.pg_event_trigger_ddl_commands() AS ddl
+    JOIN pg_catalog.pg_class AS c
+      ON c.oid = ddl.objid
+    JOIN pg_catalog.pg_namespace AS n
+      ON n.oid = c.relnamespace
+    WHERE ddl.classid = 'pg_catalog.pg_class'::pg_catalog.regclass
+      AND ddl.object_type = 'table'
+      AND ddl.schema_name = 'public'
+      AND NOT ddl.in_extension
+      AND n.nspname = 'public'
+      AND c.relkind IN ('r', 'p')
+      AND NOT c.relispartition
+    GROUP BY c.oid, n.nspname, c.relname
+  LOOP
+    EXECUTE format(
+      'CREATE TRIGGER realtime_notify_trigger AFTER INSERT OR UPDATE OR DELETE ON %I.%I '
+      'FOR EACH ROW EXECUTE FUNCTION realtime.notify_postgres_changes()',
+      relation.schema_name,
+      relation.relname
+    );
+  END LOOP;
+END;
+$fn$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;

--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -441,21 +441,7 @@ $fn$ LANGUAGE plpgsql SECURITY DEFINER;
 SELECT realtime.ensure_tasks_publication();
 
 -- Event Trigger: automatically attach realtime triggers to NEW tables created in public schema
-CREATE OR REPLACE FUNCTION realtime.auto_attach_notify_trigger() RETURNS event_trigger AS $fn$
-DECLARE
-  obj RECORD;
-BEGIN
-  FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() 
-    WHERE object_type = 'table' AND schema_name = 'public'
-  LOOP
-    EXECUTE format(
-      'CREATE TRIGGER realtime_notify_trigger AFTER INSERT OR UPDATE OR DELETE ON %s '
-      'FOR EACH ROW EXECUTE FUNCTION realtime.notify_postgres_changes()',
-      obj.object_identity
-    );
-  END LOOP;
-END;
-$fn$ LANGUAGE plpgsql SECURITY DEFINER;
+${SQL_MODULES["realtime-auto-attach-trigger"]}
 
 -- Event Trigger: automatically publish public.tasks when applications create it later.
 CREATE OR REPLACE FUNCTION realtime.auto_publish_tasks_table() RETURNS event_trigger AS $fn$

--- a/packages/management-api/src/services/tenant-runtime-migration.ts
+++ b/packages/management-api/src/services/tenant-runtime-migration.ts
@@ -423,21 +423,7 @@ $fn$ LANGUAGE plpgsql SECURITY DEFINER;
 SELECT realtime.ensure_tasks_publication();
 
 -- Event Trigger: automatically attach realtime triggers to NEW tables created in public schema
-CREATE OR REPLACE FUNCTION realtime.auto_attach_notify_trigger() RETURNS event_trigger AS $fn$
-DECLARE
-  obj RECORD;
-BEGIN
-  FOR obj IN SELECT * FROM pg_event_trigger_ddl_commands() 
-    WHERE object_type = 'table' AND schema_name = 'public'
-  LOOP
-    EXECUTE format(
-      'CREATE TRIGGER realtime_notify_trigger AFTER INSERT OR UPDATE OR DELETE ON %s '
-      'FOR EACH ROW EXECUTE FUNCTION realtime.notify_postgres_changes()',
-      obj.object_identity
-    );
-  END LOOP;
-END;
-$fn$ LANGUAGE plpgsql SECURITY DEFINER;
+${SQL_MODULES["realtime-auto-attach-trigger"]}
 
 -- Event Trigger: automatically publish public.tasks when applications create it later.
 CREATE OR REPLACE FUNCTION realtime.auto_publish_tasks_table() RETURNS event_trigger AS $fn$

--- a/packages/management-api/tests/integration/realtime-auto-attach-trigger.test.ts
+++ b/packages/management-api/tests/integration/realtime-auto-attach-trigger.test.ts
@@ -1,0 +1,177 @@
+import { expect, test } from "bun:test";
+import { SQL, type ReservedSQL } from "bun";
+import { randomUUID } from "node:crypto";
+import { SQL_MODULES } from "../../src/db/sql-modules";
+
+interface RealtimeFixtureNames {
+  eventTrigger: string;
+  ownerTable: string;
+  targetTable: string;
+  privateSchema: string;
+  privateTable: string;
+  partitionRoot: string;
+  partitionChild: string;
+}
+
+interface TriggerObservation {
+  triggerCount: number;
+  functionMatchCount: number;
+}
+
+function fixtureNames(): RealtimeFixtureNames {
+  const suffix = randomUUID().replaceAll("-", "").slice(0, 12);
+  return {
+    eventTrigger: `realtime_attach_test_${suffix}`,
+    ownerTable: `realtime_owner_${suffix}`,
+    targetTable: `realtime_target_${suffix}`,
+    privateSchema: `realtime_private_${suffix}`,
+    privateTable: `realtime_private_target_${suffix}`,
+    partitionRoot: `realtime_partition_root_${suffix}`,
+    partitionChild: `realtime_partition_child_${suffix}`,
+  };
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+async function installNotifyFixture(database: ReservedSQL): Promise<void> {
+  await database.unsafe("CREATE SCHEMA IF NOT EXISTS realtime");
+  await database.unsafe(`
+    CREATE OR REPLACE FUNCTION realtime.notify_postgres_changes()
+    RETURNS trigger AS $fn$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+      END IF;
+      RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql
+  `);
+}
+
+async function installAutoAttachTrigger(
+  database: ReservedSQL,
+  eventTriggerName: string,
+): Promise<void> {
+  await database.unsafe(SQL_MODULES["realtime-auto-attach-trigger"]);
+  await database.unsafe(`
+    CREATE EVENT TRIGGER ${quoteIdentifier(eventTriggerName)} ON ddl_command_end
+      WHEN TAG IN ('CREATE TABLE')
+      EXECUTE FUNCTION realtime.auto_attach_notify_trigger()
+  `);
+}
+
+async function createRegressionTables(
+  database: ReservedSQL,
+  names: RealtimeFixtureNames,
+): Promise<void> {
+  await database.unsafe(`CREATE TABLE public.${quoteIdentifier(names.ownerTable)} (id uuid PRIMARY KEY)`);
+  await database.unsafe(`
+    CREATE TABLE public.${quoteIdentifier(names.targetTable)} (
+      id uuid PRIMARY KEY,
+      owner_id uuid NOT NULL REFERENCES public.${quoteIdentifier(names.ownerTable)}(id)
+    )
+  `);
+  await database.unsafe(`CREATE SCHEMA ${quoteIdentifier(names.privateSchema)}`);
+  await database.unsafe(`
+    CREATE TABLE ${quoteIdentifier(names.privateSchema)}.${quoteIdentifier(names.privateTable)} (
+      id uuid PRIMARY KEY,
+      owner_id uuid NOT NULL REFERENCES public.${quoteIdentifier(names.ownerTable)}(id)
+    )
+  `);
+}
+
+async function createPartitionTables(
+  database: ReservedSQL,
+  names: RealtimeFixtureNames,
+): Promise<void> {
+  await database.unsafe(`
+    CREATE TABLE public.${quoteIdentifier(names.partitionRoot)} (id integer NOT NULL)
+      PARTITION BY RANGE (id)
+  `);
+  await database.unsafe(`
+    CREATE TABLE public.${quoteIdentifier(names.partitionChild)}
+      PARTITION OF public.${quoteIdentifier(names.partitionRoot)}
+      FOR VALUES FROM (0) TO (100)
+  `);
+}
+
+async function triggerObservation(
+  database: ReservedSQL,
+  schemaName: string,
+  tableName: string,
+): Promise<TriggerObservation> {
+  const [observation] = await database<TriggerObservation[]>`
+    SELECT
+      count(*) FILTER (WHERE t.tgname = 'realtime_notify_trigger')::int AS "triggerCount",
+      count(*) FILTER (
+        WHERE t.tgname = 'realtime_notify_trigger'
+          AND t.tgfoid = 'realtime.notify_postgres_changes()'::regprocedure
+      )::int AS "functionMatchCount"
+    FROM pg_catalog.pg_trigger AS t
+    JOIN pg_catalog.pg_class AS c ON c.oid = t.tgrelid
+    JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
+    WHERE n.nspname = ${schemaName}
+      AND c.relname = ${tableName}
+      AND NOT t.tgisinternal
+  `;
+  return observation;
+}
+
+async function verifyTriggerObservations(
+  database: ReservedSQL,
+  names: RealtimeFixtureNames,
+): Promise<void> {
+  expect(await triggerObservation(database, "public", names.targetTable)).toEqual({
+    triggerCount: 1,
+    functionMatchCount: 1,
+  });
+  expect(await triggerObservation(database, names.privateSchema, names.privateTable)).toEqual({
+    triggerCount: 0,
+    functionMatchCount: 0,
+  });
+  for (const tableName of [names.partitionRoot, names.partitionChild]) {
+    expect(await triggerObservation(database, "public", tableName)).toEqual({
+      triggerCount: 1,
+      functionMatchCount: 1,
+    });
+  }
+}
+
+async function runRollbackIsolatedRegression(
+  database: SQL,
+  names: RealtimeFixtureNames,
+): Promise<void> {
+  const connection = await database.reserve();
+  let transactionStarted = false;
+
+  try {
+    await connection.unsafe("BEGIN");
+    transactionStarted = true;
+    await installNotifyFixture(connection);
+    await installAutoAttachTrigger(connection, names.eventTrigger);
+    await createRegressionTables(connection, names);
+    await createPartitionTables(connection, names);
+    await verifyTriggerObservations(connection, names);
+  } finally {
+    try {
+      if (transactionStarted) await connection.unsafe("ROLLBACK");
+    } finally {
+      connection.release();
+    }
+  }
+}
+
+test("auto-attaches one realtime trigger per public relation OID", async () => {
+  const database = new SQL({
+    url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+    max: 1,
+  });
+
+  try {
+    await runRollbackIsolatedRegression(database, fixtureNames());
+  } finally {
+    await database.close();
+  }
+});

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -61,6 +61,36 @@ describe("supabase bootstrap schema", () => {
     }
   });
 
+  test("tenant migrations reuse the fail-closed realtime auto-attach module", () => {
+    const autoAttachSql = SQL_MODULES["realtime-auto-attach-trigger"];
+
+    for (const filePath of [
+      "src/services/tenant-runtime-migration.ts",
+      "src/scripts/migrate-tenant-schema.ts",
+    ]) {
+      expect(readRepoFile(filePath)).toContain(
+        '${SQL_MODULES["realtime-auto-attach-trigger"]}',
+      );
+    }
+
+    expect(ALTER_TENANT_SQL).toContain(autoAttachSql);
+    expect(autoAttachSql).toContain(
+      "ddl.classid = 'pg_catalog.pg_class'::pg_catalog.regclass",
+    );
+    expect(autoAttachSql).toContain("AND NOT ddl.in_extension");
+    expect(autoAttachSql).toContain("AND n.nspname = 'public'");
+    expect(autoAttachSql).toContain("AND c.relkind IN ('r', 'p')");
+    expect(autoAttachSql).toContain("AND NOT c.relispartition");
+    expect(autoAttachSql).toContain("GROUP BY c.oid, n.nspname, c.relname");
+    expect(autoAttachSql).toContain("ON %I.%I");
+    expect(autoAttachSql).toContain(
+      "LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog",
+    );
+    expect(autoAttachSql).not.toContain("DROP TRIGGER");
+    expect(autoAttachSql).not.toContain("WHEN duplicate_object");
+    expect(autoAttachSql).not.toContain("WHEN OTHERS");
+  });
+
   test("auth helpers preserve claims-only user identity for modern PostgREST", () => {
     for (const schema of [
       SQL_MODULES["auth-jwt-helpers"],


### PR DESCRIPTION
## Summary
- deduplicate ddl_command_end table records by relation OID before attaching the Realtime trigger
- centralize the security-definer event-trigger function in one canonical SQL module
- add real PostgreSQL 17/18 regression coverage for PK/FK, non-public, and partitioned tables

## Verification
- unit: 35/35
- exact supabase/postgres:17.6.1.143 integration: pass, cleanup 0
- postgres:18 integration: pass, cleanup 0
- typecheck, sql:check, in-memory bundle expansion, diff check
- independent verifier and clean-code-guard: PASS

## Production evidence
The previous implementation caused exact compatibility fixture CREATE TABLE statements with inline PK/FK constraints to emit duplicate table DDL records and attempt the same trigger twice. Both failed fixture attempts were rolled back with no residual objects.