### PR TITLE
fix(management-api): prevent false-active bootstrap hangs

### DIFF
--- a/packages/management-api/src/db/platform-v2.ts
+++ b/packages/management-api/src/db/platform-v2.ts
@@ -8,6 +8,7 @@ import {
   PROJECT_USER_LIFECYCLE_LOCK_NAMESPACE,
 } from "../utils/project-user-lifecycle";
 import { config } from "../config";
+import { executeSqlStatements } from "./sql-statements";
 
 function configuredAuthAuthoritySql(): { backfill: string; constant: string } {
   const authorityRef = config.authRuntimeOwnerRef.trim();
@@ -25,10 +26,12 @@ function configuredAuthAuthoritySql(): { backfill: string; constant: string } {
  * Authentication data (users, sessions, factors and OAuth grants) deliberately
  * remains in the tenant GoTrue database.  These tables only contain project
  * control-plane state and references to GoTrue/application identifiers.
+ * The caller supplies the transaction so canonical init can keep adjacent
+ * migrations inside the same atomic boundary.
  */
-export async function ensurePlatformV2Schema(db: SQL): Promise<void> {
+export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
   const authAuthoritySql = configuredAuthAuthoritySql();
-  await db.unsafe(`
+  await executeSqlStatements(transaction, `
     CREATE TABLE IF NOT EXISTS project_business_organizations (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
       project_ref VARCHAR(20) NOT NULL REFERENCES projects(ref) ON DELETE CASCADE,
@@ -451,7 +454,7 @@ export async function ensurePlatformV2Schema(db: SQL): Promise<void> {
       FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_mutation();
   `);
 
-  await db`
+  await transaction`
     INSERT INTO project_collaborators (project_ref, principal_id, role, created_by)
     SELECT DISTINCT p.ref, o.owner_id, 'owner', 'platform-migration'
     FROM projects p
@@ -463,6 +466,10 @@ export async function ensurePlatformV2Schema(db: SQL): Promise<void> {
       AND NULLIF(o.owner_id, '') IS NOT NULL
     ON CONFLICT (project_ref, principal_id) DO NOTHING
   `;
+}
+
+export async function ensurePlatformV2SchemaInTransaction(controlPlaneDb: SQL): Promise<void> {
+  await controlPlaneDb.begin(async (transaction) => ensurePlatformV2Schema(transaction));
 }
 
 type LegacyWebhook = {

--- a/packages/management-api/src/db/sql-statements.ts
+++ b/packages/management-api/src/db/sql-statements.ts
@@ -1,0 +1,225 @@
+import type { SQL } from "bun";
+
+function startsEscapeString(sql: string, quoteIndex: number): boolean {
+  const prefixIndex = quoteIndex - 1;
+  const prefix = sql[prefixIndex] || "";
+  const preceding = sql[prefixIndex - 1] || "";
+  return /[eE]/.test(prefix) && !/[A-Za-z0-9_$]/.test(preceding);
+}
+
+function dollarQuoteTagAt(sql: string, index: number): string {
+  const previous = sql[index - 1] || "";
+  if (/[A-Za-z0-9_$]/.test(previous)) return "";
+  return sql.slice(index).match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/)?.[0] || "";
+}
+
+class PostgreSqlStatementScanner {
+  private readonly statements: string[] = [];
+  private statementBuffer = "";
+  private containsSql = false;
+  private index = 0;
+  private inSingleQuote = false;
+  private singleQuoteUsesBackslashEscapes = false;
+  private inDoubleQuote = false;
+  private inLineComment = false;
+  private blockCommentDepth = 0;
+  private dollarQuoteTag = "";
+
+  constructor(private readonly sql: string) {}
+
+  scan(): string[] {
+    for (this.index = 0; this.index < this.sql.length; this.index += 1) {
+      if (this.consumeActiveConstruct()) continue;
+      this.consumeTopLevelCharacter();
+    }
+
+    this.assertComplete();
+    this.pushStatement();
+    return this.statements;
+  }
+
+  private get character(): string {
+    return this.sql[this.index]!;
+  }
+
+  private get nextCharacter(): string {
+    return this.sql[this.index + 1] || "";
+  }
+
+  private consumeActiveConstruct(): boolean {
+    return this.consumeActiveComment() || this.consumeActiveQuotedConstruct();
+  }
+
+  private consumeActiveComment(): boolean {
+    if (this.inLineComment) {
+      this.consumeLineComment();
+      return true;
+    }
+    if (this.blockCommentDepth > 0) {
+      this.consumeBlockComment();
+      return true;
+    }
+    return false;
+  }
+
+  private consumeActiveQuotedConstruct(): boolean {
+    if (this.inSingleQuote) {
+      this.consumeSingleQuotedString();
+      return true;
+    }
+    if (this.inDoubleQuote) {
+      this.consumeDoubleQuotedIdentifier();
+      return true;
+    }
+    if (this.dollarQuoteTag) {
+      this.consumeDollarQuotedBody();
+      return true;
+    }
+    return false;
+  }
+
+  private consumeLineComment(): void {
+    this.statementBuffer += this.character;
+    if (this.character === "\n") this.inLineComment = false;
+  }
+
+  private consumeBlockComment(): void {
+    this.statementBuffer += this.character;
+    if (this.matchesPair("/", "*")) {
+      this.appendNextCharacter();
+      this.blockCommentDepth += 1;
+    } else if (this.matchesPair("*", "/")) {
+      this.appendNextCharacter();
+      this.blockCommentDepth -= 1;
+    }
+  }
+
+  private consumeSingleQuotedString(): void {
+    this.statementBuffer += this.character;
+    if (this.singleQuoteUsesBackslashEscapes && this.character === "\\" && this.nextCharacter) {
+      this.appendNextCharacter();
+    } else if (this.matchesPair("'", "'")) {
+      this.appendNextCharacter();
+    } else if (this.character === "'") {
+      this.inSingleQuote = false;
+      this.singleQuoteUsesBackslashEscapes = false;
+    }
+  }
+
+  private consumeDoubleQuotedIdentifier(): void {
+    this.statementBuffer += this.character;
+    if (this.matchesPair('"', '"')) {
+      this.appendNextCharacter();
+    } else if (this.character === '"') {
+      this.inDoubleQuote = false;
+    }
+  }
+
+  private consumeDollarQuotedBody(): void {
+    if (this.sql.startsWith(this.dollarQuoteTag, this.index)) {
+      this.statementBuffer += this.dollarQuoteTag;
+      this.index += this.dollarQuoteTag.length - 1;
+      this.dollarQuoteTag = "";
+      return;
+    }
+    this.statementBuffer += this.character;
+  }
+
+  private consumeTopLevelCharacter(): void {
+    if (this.beginComment() || this.beginQuotedConstruct()) return;
+    if (this.character === ";") {
+      this.pushStatement();
+      return;
+    }
+    this.statementBuffer += this.character;
+    if (!/\s/.test(this.character)) this.containsSql = true;
+  }
+
+  private beginComment(): boolean {
+    if (this.matchesPair("-", "-")) {
+      this.appendCharacterPair();
+      this.inLineComment = true;
+      return true;
+    }
+    if (this.matchesPair("/", "*")) {
+      this.appendCharacterPair();
+      this.blockCommentDepth = 1;
+      return true;
+    }
+    return false;
+  }
+
+  private beginQuotedConstruct(): boolean {
+    if (this.character === "'") {
+      this.statementBuffer += this.character;
+      this.containsSql = true;
+      this.inSingleQuote = true;
+      this.singleQuoteUsesBackslashEscapes = startsEscapeString(this.sql, this.index);
+      return true;
+    }
+    if (this.character === '"') {
+      this.statementBuffer += this.character;
+      this.containsSql = true;
+      this.inDoubleQuote = true;
+      return true;
+    }
+    return this.beginDollarQuote();
+  }
+
+  private beginDollarQuote(): boolean {
+    if (this.character !== "$") return false;
+    const quoteTag = dollarQuoteTagAt(this.sql, this.index);
+    if (!quoteTag) return false;
+    this.statementBuffer += quoteTag;
+    this.index += quoteTag.length - 1;
+    this.dollarQuoteTag = quoteTag;
+    this.containsSql = true;
+    return true;
+  }
+
+  private matchesPair(first: string, second: string): boolean {
+    return this.character === first && this.nextCharacter === second;
+  }
+
+  private appendCharacterPair(): void {
+    this.statementBuffer += this.character + this.nextCharacter;
+    this.index += 1;
+  }
+
+  private appendNextCharacter(): void {
+    this.statementBuffer += this.nextCharacter;
+    this.index += 1;
+  }
+
+  private assertComplete(): void {
+    if (this.blockCommentDepth > 0 || this.inSingleQuote || this.inDoubleQuote || this.dollarQuoteTag) {
+      throw new Error("Unterminated SQL comment, quoted literal, or dollar-quoted body");
+    }
+  }
+
+  private pushStatement(): void {
+    const statement = this.statementBuffer.trim();
+    if (this.containsSql && statement) this.statements.push(statement);
+    this.statementBuffer = "";
+    this.containsSql = false;
+  }
+}
+
+/**
+ * Split PostgreSQL statements without treating semicolons inside SQL literals,
+ * comments, or dollar-quoted PL/pgSQL bodies as statement boundaries.
+ */
+export function splitSqlStatements(sql: string): string[] {
+  return new PostgreSqlStatementScanner(sql).scan();
+}
+
+/**
+ * Execute a SQL batch on the caller-owned transaction so adjacent migrations
+ * can share one atomic boundary without nesting `begin` calls.
+ */
+export async function executeSqlStatements(transaction: SQL, sql: string): Promise<void> {
+  const statements = splitSqlStatements(sql);
+  if (statements.length === 0) throw new Error("SQL migration contains no executable statements");
+
+  for (const statement of statements) await transaction.unsafe(statement);
+}

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1,6 +1,7 @@
 import { Elysia, t } from "elysia";
 import type { AnyElysia } from "elysia";
 import { logger } from "./utils/logger";
+import { runBootstrapOrExit } from "./runtime/bootstrap-fatal";
 
 process.on("uncaughtException", (err: Error) => {
   logger.error("FATAL UNCAUGHT EXCEPTION:", {
@@ -1090,12 +1091,12 @@ async function bootstrap() {
   } else if (args.length === 0 || args.includes("--server")) {
     const { sql: controlPlaneSql } = await import("./db");
     const {
-      ensurePlatformV2Schema,
+      ensurePlatformV2SchemaInTransaction,
       migrateLegacyProjectWebhooks,
       migrateLegacyProviderLinkingConfig,
       migrateWebhookSecretsToControlStore,
     } = await import("./db/platform-v2");
-    await ensurePlatformV2Schema(controlPlaneSql);
+    await ensurePlatformV2SchemaInTransaction(controlPlaneSql);
     await migrateLegacyProjectWebhooks(controlPlaneSql);
     await migrateWebhookSecretsToControlStore(controlPlaneSql);
     await migrateLegacyProviderLinkingConfig(controlPlaneSql);
@@ -1380,7 +1381,7 @@ async function bootstrap() {
 }
 
 if (import.meta.main) {
-  bootstrap();
+  void runBootstrapOrExit(bootstrap);
 
   const shutdown = async (signal: string) => {
     logger.info(`\nReceived ${signal}. Gracefully shutting down...`);

--- a/packages/management-api/src/runtime/bootstrap-fatal.ts
+++ b/packages/management-api/src/runtime/bootstrap-fatal.ts
@@ -1,0 +1,26 @@
+import { logger } from "../utils/logger";
+
+export type FatalExit = (code: number) => never | void;
+export type FatalLogger = (message: string, metadata: Record<string, unknown>) => void;
+
+export function terminateFatalProcess(
+  message: string,
+  reason: unknown,
+  exit: FatalExit = (code) => process.exit(code),
+  log: FatalLogger = (entry, metadata) => logger.error(entry, metadata),
+): void {
+  const error = reason instanceof Error ? reason : new Error(String(reason));
+  log(message, { reason: error.message, stack: error.stack });
+  exit(1);
+}
+
+export async function runBootstrapOrExit(
+  bootstrap: () => Promise<void>,
+  fatal: (message: string, reason: unknown) => void = terminateFatalProcess,
+): Promise<void> {
+  try {
+    await bootstrap();
+  } catch (error) {
+    fatal("FATAL BOOTSTRAP FAILURE:", error);
+  }
+}

--- a/packages/management-api/tests/unit/bootstrap-fatal.test.ts
+++ b/packages/management-api/tests/unit/bootstrap-fatal.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { runBootstrapOrExit, terminateFatalProcess } from "../../src/runtime/bootstrap-fatal";
+
+describe("management API fatal bootstrap handling", () => {
+  test("normal bootstrap resolves without invoking fatal exit", async () => {
+    let served = false;
+    let fatalCalls = 0;
+    await runBootstrapOrExit(
+      async () => { served = true; },
+      () => { fatalCalls += 1; },
+    );
+    expect(served).toBe(true);
+    expect(fatalCalls).toBe(0);
+  });
+
+  test("bootstrap rejection invokes the fatal path", async () => {
+    let exitCode: number | undefined;
+    let message = "";
+    await runBootstrapOrExit(
+      async () => { throw new Error("bootstrap failed"); },
+      (entry, reason) => {
+        message = `${entry} ${reason instanceof Error ? reason.message : String(reason)}`;
+        exitCode = 1;
+      },
+    );
+    expect(message).toContain("FATAL BOOTSTRAP FAILURE");
+    expect(message).toContain("bootstrap failed");
+    expect(exitCode).toBe(1);
+  });
+
+  test("fatal process logging includes a code location and exits nonzero", () => {
+    let exitCode: number | undefined;
+    let metadata: Record<string, unknown> | undefined;
+    terminateFatalProcess(
+      "FATAL TEST:",
+      new Error("test failure"),
+      (code) => { exitCode = code; },
+      (_message, entry) => { metadata = entry; },
+    );
+    expect(exitCode).toBe(1);
+    expect(metadata?.reason).toBe("test failure");
+    expect(metadata?.stack).toContain("bootstrap-fatal.test.ts");
+  });
+});

--- a/packages/management-api/tests/unit/platform-v2-bootstrap.test.ts
+++ b/packages/management-api/tests/unit/platform-v2-bootstrap.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test";
+import type { SQL } from "bun";
+import {
+  ensurePlatformV2Schema,
+  ensurePlatformV2SchemaInTransaction,
+} from "../../src/db/platform-v2";
+import { splitSqlStatements } from "../../src/db/sql-statements";
+
+type FakeTransaction = {
+  (strings: TemplateStringsArray): Promise<unknown[]>;
+  unsafe: (statement: string) => Promise<void>;
+};
+
+function fakeControlPool(options: { failAt?: number } = {}) {
+  const transactionalStatements: string[] = [];
+  let beginCalls = 0;
+  let taggedCalls = 0;
+  let rolledBack = false;
+
+  const transaction = Object.assign(
+    async () => {
+      taggedCalls += 1;
+      return [];
+    },
+    {
+      unsafe: async (statement: string) => {
+        transactionalStatements.push(statement);
+        if (transactionalStatements.length === options.failAt) {
+          throw new Error("platform bootstrap fixture failure");
+        }
+      },
+    },
+  ) as FakeTransaction;
+  const database = {
+    begin: async (callback: (activeTransaction: FakeTransaction) => Promise<void>) => {
+      beginCalls += 1;
+      try {
+        await callback(transaction);
+      } catch (error) {
+        rolledBack = true;
+        throw error;
+      }
+    },
+  } as unknown as SQL;
+
+  return {
+    database,
+    transactionalStatements,
+    observations: () => ({ beginCalls, taggedCalls, rolledBack }),
+  };
+}
+
+test("platform v2 bootstrap executes canonical DDL as individual statements in one transaction", async () => {
+  const fixture = fakeControlPool();
+  await ensurePlatformV2SchemaInTransaction(fixture.database);
+
+  expect(fixture.observations()).toEqual({ beginCalls: 1, taggedCalls: 1, rolledBack: false });
+  expect(fixture.transactionalStatements.length).toBeGreaterThan(30);
+  for (const statement of fixture.transactionalStatements) {
+    expect(splitSqlStatements(statement)).toHaveLength(1);
+  }
+});
+
+test("canonical init reuses its outer transaction without nesting begin", async () => {
+  const fixture = fakeControlPool();
+  await fixture.database.begin(async (transaction) => ensurePlatformV2Schema(transaction));
+
+  expect(fixture.observations()).toEqual({ beginCalls: 1, taggedCalls: 1, rolledBack: false });
+});
+
+test("canonical init rolls back and stops before owner backfill when DDL fails", async () => {
+  const fixture = fakeControlPool({ failAt: 3 });
+  await expect(
+    fixture.database.begin(async (transaction) => ensurePlatformV2Schema(transaction)),
+  ).rejects.toThrow("platform bootstrap fixture failure");
+
+  expect(fixture.observations()).toEqual({ beginCalls: 1, taggedCalls: 0, rolledBack: true });
+  expect(fixture.transactionalStatements).toHaveLength(3);
+});

--- a/packages/management-api/tests/unit/platform-v2.migration.test.ts
+++ b/packages/management-api/tests/unit/platform-v2.migration.test.ts
@@ -89,15 +89,16 @@ describe("platform v2 migrations", () => {
 
   test("seeds owners only from verifiable organization members", async () => {
     let ownerSeedQuery = "";
-    const database = Object.assign(
+    const unsafe = mock(() => Promise.resolve([]));
+    const transaction = Object.assign(
       mock((strings: TemplateStringsArray) => {
         ownerSeedQuery = strings.join("?");
         return Promise.resolve([]);
       }),
-      { unsafe: mock(() => Promise.resolve([])) },
+      { unsafe },
     );
 
-    await ensurePlatformV2Schema(database as unknown as SQL);
+    await ensurePlatformV2Schema(transaction as unknown as SQL);
 
     expect(ownerSeedQuery).toContain("JOIN organization_members owner_member");
     expect(ownerSeedQuery).toContain("owner_member.user_id = o.owner_id");

--- a/packages/management-api/tests/unit/sql-statements.test.ts
+++ b/packages/management-api/tests/unit/sql-statements.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { executeSqlStatements, splitSqlStatements } from "../../src/db/sql-statements";
+
+describe("PostgreSQL statement splitter", () => {
+  test("keeps quoted literals, comments, and dollar-quoted bodies intact", () => {
+    const statements = splitSqlStatements(`
+      -- semicolon ; in a line comment
+      CREATE FUNCTION public.fixture_fn() RETURNS text AS $fn$
+      BEGIN
+        PERFORM E'escaped\\';semicolon';
+        PERFORM 'single;quoted';
+        /* nested ; comment /* still comment ; */ */
+        RETURN 'body;value';
+      END;
+      $fn$ LANGUAGE plpgsql;
+      CREATE TABLE "table;name" (value text DEFAULT 'default;value');
+      SELECT $$dollar;quoted$$;
+    `);
+
+    expect(statements).toHaveLength(3);
+    expect(statements[0]).toContain("$fn$");
+    expect(statements[0]).toContain("escaped\\';semicolon");
+    expect(statements[1]).toContain('"table;name"');
+    expect(statements[2]).toContain("$$dollar;quoted$$");
+  });
+
+  test("rejects unterminated SQL constructs", () => {
+    expect(() => splitSqlStatements("SELECT 'unterminated;")).toThrow(/Unterminated SQL/);
+    expect(() => splitSqlStatements("SELECT $$unterminated;")).toThrow(/Unterminated SQL/);
+    expect(() => splitSqlStatements("/* unterminated;")).toThrow(/Unterminated SQL/);
+  });
+
+  test("accepts a line comment at end of input", () => {
+    expect(splitSqlStatements("SELECT 1; -- trailing comment")).toEqual(["SELECT 1"]);
+  });
+
+  test("does not treat backslashes as escapes in standard strings", () => {
+    expect(splitSqlStatements("SELECT '\\'; SELECT 2;")).toEqual(["SELECT '\\'", "SELECT 2"]);
+  });
+
+  test("keeps escaped quotes and semicolons inside escape strings", () => {
+    const statements = splitSqlStatements(String.raw`SELECT E'escaped\';semicolon'; SELECT 2;`);
+
+    expect(statements).toEqual([String.raw`SELECT E'escaped\';semicolon'`, "SELECT 2"]);
+  });
+
+  test("executes statements on the caller-owned transaction and stops after failure", async () => {
+    const calls: string[] = [];
+    const transaction = {
+      unsafe: async (statement: string) => {
+        calls.push(statement);
+        if (statement.includes("FAIL")) throw new Error("fixture failure");
+      },
+    } as never;
+
+    await expect(executeSqlStatements(transaction, "SELECT 1; SELECT FAIL; SELECT 3;")).rejects.toThrow("fixture failure");
+    expect(calls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- split Platform V2 PostgreSQL DDL at safe top-level statement boundaries instead of sending one giant Bun SQL multi-statement request
- execute the statements in the caller-owned transaction so canonical init and server bootstrap retain atomic rollback without nested `begin`
- make rejected server bootstrap promises log and exit nonzero instead of leaving systemd active while port 9090 is not listening

## Production incident

The Management API stayed active in systemd but never reached `Bun.serve`. Startup stalled in `ensurePlatformV2Schema`, then Bun SQL rejected after the 30 second idle timeout. PostgreSQL itself remained reachable and showed no active query or lock wait. The stock `management-api-v0.47.0` tag still contains both affected startup patterns.

## Verification

- targeted unit tests: 20 pass, 0 fail
- full unit suite: pass
- integration suite: 39 pass, 0 fail
- typecheck, SQL synchronization, and diff check: pass
- fresh PostgreSQL 18 canonical init: 2 consecutive passes
- fresh PostgreSQL 18 server bootstrap wrapper: 2 consecutive passes
- fresh PostgreSQL 17 canonical init: 2 consecutive passes
- fresh PostgreSQL 17 server bootstrap wrapper: 2 consecutive passes
- Linux amd64 build SHA256: `b1b765c11278f97fcdaa1615c5735b4621ecc4975c295d4136a6a1d0af3c6228`

## Safety and rollback

The DDL content and order are unchanged. Any statement failure still aborts the surrounding transaction. The production rollout retains the previous binary for atomic rollback and is gated on independent verifier re-review plus health checks lasting beyond the previous 30 second failure window.

## Task contract

Follow-up to the SupaOAuth v0.3.0 production deployment interruption. Non-goals: no production config or secret changes, no tenant fixtures, no FA Functions changes, and no timeout increase.