### PR TITLE
fix(management-api): move audit backfill out of startup

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -314,6 +314,12 @@ jobs:
         # E2E Storage fixture that init.ts enables when CI variables are set.
         run: env -u CI -u GITHUB_ACTIONS bun src/db/init.ts
 
+      - name: Verify audit chain migration on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: bun test tests/integration/audit-chain-migration.test.ts
+
       - name: Apply and verify Docker PostgreSQL compatibility
         env:
           SUPACLOUD_META_DB: postgres

--- a/packages/management-api/src/db/audit-chain-lock.ts
+++ b/packages/management-api/src/db/audit-chain-lock.ts
@@ -1,0 +1,17 @@
+import type { SQL } from "bun";
+
+export const AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY = "20260720_audit_chain_sequences_v1";
+
+const AUDIT_CHAIN_MIGRATION_LOCK_KEY = `platform-schema:${AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY}`;
+
+export async function acquireAuditChainAppendLock(transaction: SQL): Promise<void> {
+  await transaction`
+    SELECT pg_advisory_xact_lock_shared(hashtextextended(${AUDIT_CHAIN_MIGRATION_LOCK_KEY}, 0))
+  `;
+}
+
+export async function acquireAuditChainMigrationLock(transaction: SQL): Promise<void> {
+  await transaction`
+    SELECT pg_advisory_xact_lock(hashtextextended(${AUDIT_CHAIN_MIGRATION_LOCK_KEY}, 0))
+  `;
+}

--- a/packages/management-api/src/db/audit-chain-migration.ts
+++ b/packages/management-api/src/db/audit-chain-migration.ts
@@ -1,0 +1,277 @@
+import type { SQL } from "bun";
+import {
+  AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY,
+  acquireAuditChainMigrationLock,
+} from "./audit-chain-lock";
+
+export { AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY } from "./audit-chain-lock";
+
+const AUDIT_CHAIN_RESOLUTION_CTE = `
+  WITH RECURSIVE resolved_audit_chain AS (
+    SELECT id, project_ref, event_hash, 1::bigint AS chain_sequence
+    FROM audit_logs
+    WHERE event_hash IS NOT NULL AND previous_hash IS NULL
+    UNION ALL
+    SELECT child.id, child.project_ref, child.event_hash, parent.chain_sequence + 1
+    FROM resolved_audit_chain parent
+    JOIN audit_logs child
+      ON child.project_ref IS NOT DISTINCT FROM parent.project_ref
+     AND child.previous_hash = parent.event_hash
+     AND child.event_hash IS NOT NULL
+  )
+`;
+const AUDIT_CHAIN_HEADS_CTE = `
+  WITH audit_chain_heads AS (
+    SELECT DISTINCT ON (project_ref)
+      COALESCE(project_ref, '__platform__') AS project_key,
+      id AS last_event_id,
+      event_hash AS last_event_hash,
+      count(*) OVER (PARTITION BY project_ref) AS event_count
+    FROM audit_logs
+    WHERE event_hash IS NOT NULL
+    ORDER BY project_ref, chain_sequence DESC, id DESC
+  )
+`;
+
+type ViolationCount = { violation_count: number | string };
+type ResolutionCounts = {
+  unresolved_count: number | string;
+  sequence_mismatch_count: number | string;
+};
+type MigrationSummary = {
+  hashed_event_count: number | string;
+  project_chain_count: number | string;
+};
+
+export class PlatformMigrationRequiredError extends Error {
+  readonly code = "platform_migration_required" as const;
+
+  constructor() {
+    super(
+      `Required platform migration ${AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY} is incomplete. Run supacloud --init-db before starting the server.`,
+    );
+    this.name = "PlatformMigrationRequiredError";
+  }
+}
+
+function assertNoViolations(label: string, violation: ViolationCount | undefined): void {
+  const count = Number(violation?.violation_count || 0);
+  if (count > 0) throw new Error(`Audit chain migration rejected ${count} ${label}`);
+}
+
+async function migrationIsCompleted(transaction: SQL): Promise<boolean> {
+  const [marker] = await transaction`
+    SELECT migration_key
+    FROM platform_schema_migrations
+    WHERE migration_key = ${AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY}
+  `;
+  return marker?.migration_key === AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY;
+}
+
+async function assertNoDuplicateHashes(transaction: SQL): Promise<void> {
+  const [violation] = await transaction<ViolationCount[]>`
+    SELECT count(*) AS violation_count
+    FROM (
+      SELECT event_hash
+      FROM audit_logs
+      WHERE event_hash IS NOT NULL
+      GROUP BY event_hash
+      HAVING count(*) > 1
+    ) duplicate_hashes
+  `;
+  assertNoViolations("duplicate event hash group(s)", violation);
+}
+
+async function assertNoBranches(transaction: SQL): Promise<void> {
+  const [violation] = await transaction<ViolationCount[]>`
+    SELECT count(*) AS violation_count
+    FROM (
+      SELECT project_ref, previous_hash
+      FROM audit_logs
+      WHERE event_hash IS NOT NULL AND previous_hash IS NOT NULL
+      GROUP BY project_ref, previous_hash
+      HAVING count(*) > 1
+    ) branched_parents
+  `;
+  assertNoViolations("branched parent hash(es)", violation);
+}
+
+async function assertNoOrphans(transaction: SQL): Promise<void> {
+  const [violation] = await transaction<ViolationCount[]>`
+    SELECT count(*) AS violation_count
+    FROM audit_logs child
+    WHERE child.event_hash IS NOT NULL
+      AND child.previous_hash IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM audit_logs parent
+        WHERE parent.project_ref IS NOT DISTINCT FROM child.project_ref
+          AND parent.event_hash = child.previous_hash
+      )
+  `;
+  assertNoViolations("orphaned event(s)", violation);
+}
+
+async function assertOneRootPerChain(transaction: SQL): Promise<void> {
+  const [violation] = await transaction<ViolationCount[]>`
+    SELECT count(*) AS violation_count
+    FROM (
+      SELECT project_ref
+      FROM audit_logs
+      WHERE event_hash IS NOT NULL
+      GROUP BY project_ref
+      HAVING count(*) FILTER (WHERE previous_hash IS NULL) <> 1
+    ) invalid_roots
+  `;
+  assertNoViolations("project chain(s) without exactly one root", violation);
+}
+
+async function createAuditChainIndexes(transaction: SQL): Promise<void> {
+  await transaction.unsafe(`
+    CREATE UNIQUE INDEX IF NOT EXISTS audit_logs_event_hash_unique_idx
+      ON audit_logs(event_hash) WHERE event_hash IS NOT NULL
+  `);
+  await transaction.unsafe(`
+    CREATE UNIQUE INDEX IF NOT EXISTS audit_logs_chain_parent_unique_idx
+      ON audit_logs(project_ref, previous_hash) NULLS NOT DISTINCT
+      WHERE event_hash IS NOT NULL AND previous_hash IS NOT NULL
+  `);
+}
+
+async function assertResolutionIsComplete(transaction: SQL): Promise<void> {
+  const [counts] = await transaction.unsafe(`
+    ${AUDIT_CHAIN_RESOLUTION_CTE}
+    SELECT
+      count(*) FILTER (WHERE resolved.id IS NULL) AS unresolved_count,
+      count(*) FILTER (
+        WHERE resolved.id IS NOT NULL
+          AND audit.chain_sequence IS NOT NULL
+          AND audit.chain_sequence IS DISTINCT FROM resolved.chain_sequence
+      ) AS sequence_mismatch_count
+    FROM audit_logs audit
+    LEFT JOIN resolved_audit_chain resolved ON resolved.id = audit.id
+    WHERE audit.event_hash IS NOT NULL
+  `) as ResolutionCounts[];
+  assertNoViolations("unresolved cycle event(s)", {
+    violation_count: counts?.unresolved_count || 0,
+  });
+  assertNoViolations("existing sequence mismatch(es)", {
+    violation_count: counts?.sequence_mismatch_count || 0,
+  });
+}
+
+async function backfillMissingSequences(transaction: SQL): Promise<void> {
+  await transaction.unsafe("DROP TRIGGER IF EXISTS audit_logs_append_only ON audit_logs");
+  await transaction.unsafe(`
+    ${AUDIT_CHAIN_RESOLUTION_CTE}
+    UPDATE audit_logs audit
+    SET chain_sequence = resolved.chain_sequence
+    FROM resolved_audit_chain resolved
+    WHERE audit.id = resolved.id AND audit.chain_sequence IS NULL
+  `);
+}
+
+async function assertCheckpointCompatibility(transaction: SQL): Promise<void> {
+  const [violation] = await transaction.unsafe(`
+    ${AUDIT_CHAIN_HEADS_CTE}
+    SELECT count(*) AS violation_count
+    FROM audit_log_checkpoints checkpoint
+    FULL OUTER JOIN audit_chain_heads head ON head.project_key = checkpoint.project_ref
+    WHERE (
+      head.project_key IS NULL
+      AND (checkpoint.event_count <> 0 OR checkpoint.last_event_id IS NOT NULL OR checkpoint.last_event_hash IS NOT NULL)
+    ) OR (
+      head.project_key IS NOT NULL
+      AND checkpoint.project_ref IS NOT NULL
+      AND (
+        checkpoint.event_count IS DISTINCT FROM head.event_count
+        OR checkpoint.last_event_id IS DISTINCT FROM head.last_event_id
+        OR checkpoint.last_event_hash IS DISTINCT FROM head.last_event_hash
+      )
+    )
+  `) as ViolationCount[];
+  assertNoViolations("checkpoint mismatch(es)", violation);
+}
+
+async function createMissingCheckpoints(transaction: SQL): Promise<void> {
+  await transaction.unsafe(`
+    ${AUDIT_CHAIN_HEADS_CTE}
+    INSERT INTO audit_log_checkpoints (
+      project_ref, last_event_id, last_event_hash, event_count, updated_at
+    )
+    SELECT project_key, last_event_id, last_event_hash, event_count, NOW()
+    FROM audit_chain_heads
+    ON CONFLICT (project_ref) DO NOTHING
+  `);
+}
+
+async function assertFinalContinuity(transaction: SQL): Promise<void> {
+  const [violation] = await transaction<ViolationCount[]>`
+    SELECT count(*) AS violation_count
+    FROM audit_logs child
+    LEFT JOIN audit_logs parent
+      ON parent.project_ref IS NOT DISTINCT FROM child.project_ref
+     AND parent.event_hash = child.previous_hash
+    WHERE child.event_hash IS NOT NULL
+      AND (
+        child.chain_sequence IS NULL
+        OR (child.previous_hash IS NULL AND child.chain_sequence <> 1)
+        OR (child.previous_hash IS NOT NULL AND child.chain_sequence <> parent.chain_sequence + 1)
+      )
+  `;
+  assertNoViolations("final continuity mismatch(es)", violation);
+}
+
+async function finalizeAuditChainSchema(transaction: SQL): Promise<void> {
+  await transaction.unsafe(`
+    CREATE UNIQUE INDEX IF NOT EXISTS audit_logs_chain_sequence_unique_idx
+      ON audit_logs(project_ref, chain_sequence) NULLS NOT DISTINCT
+      WHERE event_hash IS NOT NULL
+  `);
+  await transaction.unsafe(`
+    CREATE TRIGGER audit_logs_append_only
+      BEFORE UPDATE OR DELETE ON audit_logs
+      FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_mutation()
+  `);
+}
+
+async function recordMigrationMarker(transaction: SQL): Promise<void> {
+  const [summary] = await transaction<MigrationSummary[]>`
+    SELECT
+      count(*) AS hashed_event_count,
+      count(DISTINCT COALESCE(project_ref, '__platform__')) AS project_chain_count
+    FROM audit_logs
+    WHERE event_hash IS NOT NULL
+  `;
+  const details = JSON.stringify({
+    hashed_event_count: Number(summary?.hashed_event_count || 0),
+    project_chain_count: Number(summary?.project_chain_count || 0),
+  });
+  await transaction`
+    INSERT INTO platform_schema_migrations (migration_key, details)
+    VALUES (${AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY}, ${details}::jsonb)
+  `;
+}
+
+export async function migrateAuditChainSequences(transaction: SQL): Promise<void> {
+  await acquireAuditChainMigrationLock(transaction);
+  if (await migrationIsCompleted(transaction)) return;
+
+  await assertNoDuplicateHashes(transaction);
+  await assertNoBranches(transaction);
+  await assertNoOrphans(transaction);
+  await assertOneRootPerChain(transaction);
+  await createAuditChainIndexes(transaction);
+  await assertResolutionIsComplete(transaction);
+  await backfillMissingSequences(transaction);
+  await createMissingCheckpoints(transaction);
+  await assertFinalContinuity(transaction);
+  await assertCheckpointCompatibility(transaction);
+  await finalizeAuditChainSchema(transaction);
+  await recordMigrationMarker(transaction);
+}
+
+export async function assertPlatformMigrationCompleted(database: SQL): Promise<void> {
+  if (await migrationIsCompleted(database)) return;
+  throw new PlatformMigrationRequiredError();
+}

--- a/packages/management-api/src/db/init.ts
+++ b/packages/management-api/src/db/init.ts
@@ -18,6 +18,7 @@ import {
   migrateUnsupportedWebAuthnConfig,
   migrateWebhookSecretsToControlStore,
 } from "./platform-v2";
+import { migrateAuditChainSequences } from "./audit-chain-migration";
 import { migrateLegacyEncryptedSecretsInTransaction } from "./secret-key-migration";
 import { GOTRUE_USER_ID_POSTGRES_PATTERN } from "../utils/project-user-lifecycle";
 
@@ -730,6 +731,7 @@ export async function initDatabase() {
 
     await sql.begin(async (transaction) => {
       await ensurePlatformV2Schema(transaction);
+      await migrateAuditChainSequences(transaction);
       await migrateLegacyControlSecrets(transaction);
       await migrateLegacyProjectWebhooks(transaction);
       await migrateUnsupportedWebAuthnConfig(transaction);

--- a/packages/management-api/src/db/platform-v2.ts
+++ b/packages/management-api/src/db/platform-v2.ts
@@ -153,6 +153,12 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       PRIMARY KEY (scheme, key_fingerprint)
     );
 
+    CREATE TABLE IF NOT EXISTS platform_schema_migrations (
+      migration_key TEXT PRIMARY KEY,
+      completed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      details JSONB NOT NULL DEFAULT '{}'::jsonb
+    );
+
     CREATE TABLE IF NOT EXISTS supaoauth_bff_proof_nonces (
       nonce VARCHAR(128) PRIMARY KEY,
       expires_at TIMESTAMPTZ NOT NULL,
@@ -419,39 +425,25 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
     CREATE INDEX IF NOT EXISTS audit_exports_project_idx
       ON audit_exports(project_ref, created_at DESC);
 
-    DROP TRIGGER IF EXISTS audit_logs_append_only ON audit_logs;
-    WITH RECURSIVE linked_audit_events AS (
-      SELECT id, project_ref, event_hash, 1::bigint AS chain_sequence, ARRAY[id] AS path
-      FROM audit_logs
-      WHERE event_hash IS NOT NULL AND previous_hash IS NULL
-      UNION ALL
-      SELECT child.id, child.project_ref, child.event_hash,
-             parent.chain_sequence + 1, parent.path || child.id
-      FROM linked_audit_events parent
-      JOIN audit_logs child
-        ON child.project_ref IS NOT DISTINCT FROM parent.project_ref
-       AND child.previous_hash = parent.event_hash
-       AND child.event_hash IS NOT NULL
-       AND NOT child.id = ANY(parent.path)
-    ), resolved_sequences AS (
-      SELECT id, MIN(chain_sequence) AS chain_sequence
-      FROM linked_audit_events
-      GROUP BY id
-    )
-    UPDATE audit_logs audit
-    SET chain_sequence = resolved.chain_sequence
-    FROM resolved_sequences resolved
-    WHERE audit.id = resolved.id
-      AND audit.chain_sequence IS DISTINCT FROM resolved.chain_sequence;
-
     CREATE OR REPLACE FUNCTION prevent_audit_log_mutation() RETURNS trigger AS $$
     BEGIN
       RAISE EXCEPTION 'audit_logs is append-only';
     END;
     $$ LANGUAGE plpgsql;
-    CREATE TRIGGER audit_logs_append_only
-      BEFORE UPDATE OR DELETE ON audit_logs
-      FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_mutation();
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgrelid = 'audit_logs'::regclass
+          AND tgname = 'audit_logs_append_only'
+          AND NOT tgisinternal
+      ) THEN
+        CREATE TRIGGER audit_logs_append_only
+          BEFORE UPDATE OR DELETE ON audit_logs
+          FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_mutation();
+      END IF;
+    END;
+    $$;
   `);
 
   await transaction`

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1090,6 +1090,7 @@ async function bootstrap() {
     process.exit(0);
   } else if (args.length === 0 || args.includes("--server")) {
     const { sql: controlPlaneSql } = await import("./db");
+    const { assertPlatformMigrationCompleted } = await import("./db/audit-chain-migration");
     const {
       ensurePlatformV2SchemaInTransaction,
       migrateLegacyProjectWebhooks,
@@ -1097,6 +1098,7 @@ async function bootstrap() {
       migrateWebhookSecretsToControlStore,
     } = await import("./db/platform-v2");
     await ensurePlatformV2SchemaInTransaction(controlPlaneSql);
+    await assertPlatformMigrationCompleted(controlPlaneSql);
     await migrateLegacyProjectWebhooks(controlPlaneSql);
     await migrateWebhookSecretsToControlStore(controlPlaneSql);
     await migrateLegacyProviderLinkingConfig(controlPlaneSql);

--- a/packages/management-api/src/services/audit.service.ts
+++ b/packages/management-api/src/services/audit.service.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { sql } from "../db";
+import { acquireAuditChainAppendLock } from "../db/audit-chain-lock";
 import { getVerifiedRequestPrincipal } from "../middleware/auth";
 import { extractProjectRefFromPath } from "../utils/project-auth";
 import { resolveProxyClientIp } from "../utils/client-ip";
@@ -260,6 +261,7 @@ export async function appendAuditEvent(input: AppendAuditEventInput) {
   const source = input.source || "management-api";
 
   return sql.begin(async (tx) => {
+    await acquireAuditChainAppendLock(tx);
     await tx`SELECT pg_advisory_xact_lock(hashtext(${`audit-chain:${projectChainKey}`}))`;
     const [checkpoint] = await tx`
       SELECT last_event_hash, event_count

--- a/packages/management-api/tests/integration/audit-chain-migration.test.ts
+++ b/packages/management-api/tests/integration/audit-chain-migration.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { SQL } from "bun";
+import {
+  AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY,
+  assertPlatformMigrationCompleted,
+  migrateAuditChainSequences,
+} from "../../src/db/audit-chain-migration";
+import { ensurePlatformV2Schema } from "../../src/db/platform-v2";
+
+const database = new SQL({
+  url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+  max: 1,
+});
+
+type ReservedSql = Awaited<ReturnType<typeof database.reserve>>;
+
+async function withRollback(operation: (transaction: SQL) => Promise<void>): Promise<void> {
+  const connection = await database.reserve();
+  await connection.unsafe("BEGIN");
+  try {
+    await operation(connection as unknown as SQL);
+  } finally {
+    await connection.unsafe("ROLLBACK");
+    connection.release();
+  }
+}
+
+async function resetAuditFixture(transaction: SQL): Promise<void> {
+  await transaction.unsafe("DROP TRIGGER IF EXISTS audit_logs_append_only ON audit_logs");
+  await transaction.unsafe("DROP INDEX IF EXISTS audit_logs_event_hash_unique_idx");
+  await transaction.unsafe("DROP INDEX IF EXISTS audit_logs_chain_parent_unique_idx");
+  await transaction.unsafe("DROP INDEX IF EXISTS audit_logs_chain_sequence_unique_idx");
+  await transaction`DELETE FROM audit_log_checkpoints`;
+  await transaction`DELETE FROM platform_schema_migrations WHERE migration_key = ${AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY}`;
+  await transaction`DELETE FROM audit_logs`;
+}
+
+async function insertLinearChain(
+  transaction: SQL,
+  projectRef: string,
+  eventCount: number,
+  includeSequences: boolean,
+): Promise<void> {
+  await transaction`
+    INSERT INTO audit_logs (
+      id, project_ref, actor, actor_type, action, method, path, status,
+      request_id, metadata, source, previous_hash, event_hash, chain_sequence, created_at
+    )
+    SELECT
+      gen_random_uuid(), ${projectRef}, 'fixture', 'system', 'fixture', 'POST', '/fixture', 200,
+      'request-' || event_number, '{}'::jsonb, 'migration-test',
+      CASE WHEN event_number = 1 THEN NULL ELSE ${projectRef} || '-hash-' || (event_number - 1) END,
+      ${projectRef} || '-hash-' || event_number,
+      CASE WHEN ${includeSequences} THEN event_number ELSE NULL END,
+      NOW() + event_number * INTERVAL '1 millisecond'
+    FROM generate_series(1, ${eventCount}) event_number
+  `;
+}
+
+async function insertCheckpointForHead(transaction: SQL, projectRef: string): Promise<void> {
+  await transaction`
+    INSERT INTO audit_log_checkpoints (
+      project_ref, last_event_id, last_event_hash, event_count
+    )
+    SELECT ${projectRef}, id, event_hash, chain_sequence
+    FROM audit_logs
+    WHERE project_ref = ${projectRef}
+    ORDER BY chain_sequence DESC
+    LIMIT 1
+  `;
+}
+
+async function markerCount(transaction: SQL): Promise<number> {
+  const [marker] = await transaction<{ count: number | string }[]>`
+    SELECT count(*) AS count
+    FROM platform_schema_migrations
+    WHERE migration_key = ${AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY}
+  `;
+  return Number(marker?.count || 0);
+}
+
+async function expectRejectedMigration(transaction: SQL, message: RegExp): Promise<void> {
+  let rejection: unknown;
+  try {
+    await migrateAuditChainSequences(transaction);
+  } catch (error) {
+    rejection = error;
+  }
+  expect(rejection).toBeInstanceOf(Error);
+  expect((rejection as Error).message).toMatch(message);
+  expect(await markerCount(transaction)).toBe(0);
+}
+
+async function insertRawEvents(transaction: SQL, rows: Array<[string, string | null]>): Promise<void> {
+  for (const [eventHash, previousHash] of rows) {
+    await transaction`
+      INSERT INTO audit_logs (
+        id, project_ref, actor, actor_type, action, method, path, status,
+        request_id, metadata, source, previous_hash, event_hash, created_at
+      ) VALUES (
+        gen_random_uuid(), 'invalid-chain', 'fixture', 'system', 'fixture', 'POST', '/fixture', 200,
+        ${`request-${eventHash}`}, '{}'::jsonb, 'migration-test', ${previousHash}, ${eventHash}, NOW()
+      )
+    `;
+  }
+}
+
+afterAll(async () => {
+  await database.close();
+}, 30_000);
+
+describe("audit chain explicit platform migration", () => {
+  test("marks empty init and stays idempotent", async () => {
+    await withRollback(async (transaction) => {
+      await resetAuditFixture(transaction);
+      await migrateAuditChainSequences(transaction);
+      await assertPlatformMigrationCompleted(transaction);
+      await migrateAuditChainSequences(transaction);
+      expect(await markerCount(transaction)).toBe(1);
+    });
+  }, 30_000);
+
+  test("validates complete chains and backfills missing sequences and checkpoints", async () => {
+    await withRollback(async (transaction) => {
+      await resetAuditFixture(transaction);
+      await insertLinearChain(transaction, "complete-chain", 3, true);
+      await insertCheckpointForHead(transaction, "complete-chain");
+      await insertLinearChain(transaction, "missing-sequence", 10_000, false);
+
+      await migrateAuditChainSequences(transaction);
+
+      const [summary] = await transaction<{ count: number | string; max: number | string }[]>`
+        SELECT count(*) AS count, max(chain_sequence) AS max
+        FROM audit_logs WHERE project_ref = 'missing-sequence'
+      `;
+      expect(Number(summary?.count)).toBe(10_000);
+      expect(Number(summary?.max)).toBe(10_000);
+      expect(await markerCount(transaction)).toBe(1);
+    });
+  }, 120_000);
+
+  test("rejects duplicate, branch, orphan, cycle, and checkpoint mismatch without a marker", async () => {
+    const invalidFixtures: Array<{ message: RegExp; rows: Array<[string, string | null]> }> = [
+      { message: /duplicate event hash/, rows: [["same", null], ["same", null]] },
+      { message: /branched parent/, rows: [["root", null], ["child-a", "root"], ["child-b", "root"]] },
+      { message: /orphaned event/, rows: [["root", null], ["orphan", "missing"]] },
+      { message: /unresolved cycle/, rows: [["root", null], ["cycle-a", "cycle-b"], ["cycle-b", "cycle-a"]] },
+    ];
+    for (const fixture of invalidFixtures) {
+      await withRollback(async (transaction) => {
+        await resetAuditFixture(transaction);
+        await insertRawEvents(transaction, fixture.rows);
+        await expectRejectedMigration(transaction, fixture.message);
+      });
+    }
+    await withRollback(async (transaction) => {
+      await resetAuditFixture(transaction);
+      await insertLinearChain(transaction, "checkpoint-mismatch", 2, false);
+      await transaction`
+        INSERT INTO audit_log_checkpoints (
+          project_ref, last_event_id, last_event_hash, event_count
+        ) VALUES ('checkpoint-mismatch', NULL, 'wrong', 99)
+      `;
+      await expectRejectedMigration(transaction, /checkpoint mismatch/);
+    });
+  }, 30_000);
+
+  test("keeps server schema and marker gate bounded with a large existing chain", async () => {
+    await withRollback(async (transaction) => {
+      await resetAuditFixture(transaction);
+      await insertLinearChain(transaction, "server-fast-path", 25_000, true);
+      await transaction`
+        INSERT INTO platform_schema_migrations (migration_key)
+        VALUES (${AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY})
+      `;
+      const startedAt = performance.now();
+      await ensurePlatformV2Schema(transaction);
+      await assertPlatformMigrationCompleted(transaction);
+      expect(performance.now() - startedAt).toBeLessThan(30_000);
+    });
+  }, 40_000);
+});

--- a/packages/management-api/tests/unit/audit-chain-migration.test.ts
+++ b/packages/management-api/tests/unit/audit-chain-migration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type { SQL } from "bun";
+import {
+  AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY,
+  assertPlatformMigrationCompleted,
+  migrateAuditChainSequences,
+  PlatformMigrationRequiredError,
+} from "../../src/db/audit-chain-migration";
+
+type QueryCall = { query: string; parameters: unknown[] };
+
+function markerDatabase(markerExists: boolean): { database: SQL; calls: QueryCall[] } {
+  const calls: QueryCall[] = [];
+  const database = Object.assign(
+    async (strings: TemplateStringsArray, ...parameters: unknown[]) => {
+      const query = strings.join("?");
+      calls.push({ query, parameters });
+      if (query.includes("FROM platform_schema_migrations")) {
+        return markerExists ? [{ migration_key: AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY }] : [];
+      }
+      return [];
+    },
+    {
+      unsafe: async () => {
+        throw new Error("marker fast path must not execute unsafe SQL");
+      },
+    },
+  ) as unknown as SQL;
+  return { database, calls };
+}
+
+describe("audit chain platform migration gate", () => {
+  test("fails fast with one marker lookup when the migration is missing", async () => {
+    const fixture = markerDatabase(false);
+
+    await expect(assertPlatformMigrationCompleted(fixture.database))
+      .rejects.toBeInstanceOf(PlatformMigrationRequiredError);
+    expect(fixture.calls).toHaveLength(1);
+    expect(fixture.calls[0]?.query).toContain("WHERE migration_key = ?");
+    expect(fixture.calls[0]?.query).not.toContain("audit_logs");
+  });
+
+  test("passes with one marker lookup when the migration is complete", async () => {
+    const fixture = markerDatabase(true);
+
+    await assertPlatformMigrationCompleted(fixture.database);
+    expect(fixture.calls).toHaveLength(1);
+    expect(fixture.calls[0]?.parameters).toEqual([AUDIT_CHAIN_SEQUENCE_MIGRATION_KEY]);
+  });
+
+  test("returns after the advisory lock and marker lookup on repeat init", async () => {
+    const fixture = markerDatabase(true);
+
+    await migrateAuditChainSequences(fixture.database);
+    expect(fixture.calls).toHaveLength(2);
+    expect(fixture.calls[0]?.query).toContain("pg_advisory_xact_lock");
+    expect(fixture.calls[0]?.query).not.toContain("pg_advisory_xact_lock_shared");
+    expect(fixture.calls[1]?.query).toContain("FROM platform_schema_migrations");
+  });
+});

--- a/packages/management-api/tests/unit/invitation-audit-actor.test.ts
+++ b/packages/management-api/tests/unit/invitation-audit-actor.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 
 let persistedActor: { id: string; type: string } | null = null;
+const transactionQueries: string[] = [];
 const transaction = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
   const query = strings.join("?");
+  transactionQueries.push(query);
   if (query.includes("SELECT last_event_hash")) return Promise.resolve([]);
   if (query.includes("INSERT INTO audit_logs")) {
     persistedActor = { id: String(values[2]), type: String(values[3]) };
@@ -39,5 +41,9 @@ describe("invitation acceptance audit actor", () => {
 
     expect(persistedActor).toEqual({ id: "gotrue-user", type: "user" });
     expect(persistedActor?.id).not.toBe("anonymous");
+    expect(transactionQueries[0]).toContain("pg_advisory_xact_lock_shared");
+    expect(transactionQueries[1]).toContain("pg_advisory_xact_lock(hashtext(");
+    expect(transactionQueries.findIndex((query) => query.includes("INSERT INTO audit_logs")))
+      .toBeGreaterThan(1);
   });
 });

--- a/packages/management-api/tests/unit/platform-v2.schema.test.ts
+++ b/packages/management-api/tests/unit/platform-v2.schema.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 const schema = readFileSync(new URL("../../src/db/platform-v2.ts", import.meta.url), "utf8");
+const auditMigration = readFileSync(
+  new URL("../../src/db/audit-chain-migration.ts", import.meta.url),
+  "utf8",
+);
 const databaseInit = readFileSync(new URL("../../src/db/init.ts", import.meta.url), "utf8");
 const serverEntrypoint = readFileSync(new URL("../../src/index.ts", import.meta.url), "utf8");
 const userSafetyService = readFileSync(
@@ -44,19 +48,35 @@ describe("platform v2 schema contract", () => {
     expect(schema).toContain("BEFORE UPDATE OR DELETE ON audit_logs");
   });
 
-  test("keeps deleted webhook history and orders hashed audit chains explicitly", () => {
+  test("moves audit chain backfill out of server schema bootstrap", () => {
     expect(schema).toContain("ALTER TABLE project_webhooks ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ");
     expect(schema).toContain("WHERE deleted_at IS NULL");
     expect(schema).toContain("ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS chain_sequence BIGINT");
-    expect(schema).toContain("WITH RECURSIVE linked_audit_events AS");
-    expect(schema).toContain("child.previous_hash = parent.event_hash");
-    expect(schema).toContain("SET chain_sequence = resolved.chain_sequence");
-    expect(schema).toContain("chain_sequence IS DISTINCT FROM resolved.chain_sequence");
+    expect(schema).toContain("CREATE TABLE IF NOT EXISTS platform_schema_migrations");
+    expect(schema).not.toContain("WITH RECURSIVE resolved_audit_chain AS");
+    expect(schema).not.toContain("UPDATE audit_logs audit");
+    expect(schema).not.toContain("audit_logs_event_hash_unique_idx");
+    expect(schema).toContain("audit_logs_project_hash_idx");
+    expect(schema).toContain("audit_logs_project_sequence_idx");
+    expect(schema).toContain("IF NOT EXISTS (");
+    expect(schema).not.toContain("DROP TRIGGER IF EXISTS audit_logs_append_only");
+    expect(auditMigration).toContain("WITH RECURSIVE resolved_audit_chain AS");
+    expect(auditMigration).toContain("child.previous_hash = parent.event_hash");
+    expect(auditMigration).toContain("UPDATE audit_logs audit");
+    expect(auditMigration).toContain("INSERT INTO platform_schema_migrations");
+    expect(auditMigration).toContain("DROP TRIGGER IF EXISTS audit_logs_append_only");
   });
 
   test("runs the provider linking forward migration before runtime config is rendered", () => {
     expect(databaseInit).toContain("await migrateLegacyProviderLinkingConfig(transaction)");
     expect(serverEntrypoint).toContain("await migrateLegacyProviderLinkingConfig(controlPlaneSql)");
+  });
+
+  test("requires the durable audit migration marker before server startup continues", () => {
+    expect(databaseInit).toContain("await migrateAuditChainSequences(transaction)");
+    expect(serverEntrypoint).toContain("await assertPlatformMigrationCompleted(controlPlaneSql)");
+    expect(serverEntrypoint.indexOf("await assertPlatformMigrationCompleted(controlPlaneSql)"))
+      .toBeLessThan(serverEntrypoint.indexOf("await migrateLegacyProjectWebhooks(controlPlaneSql)"));
   });
 
   test("serializes task activation with durable GoTrue user deletion fences", () => {


### PR DESCRIPTION
## Summary

- remove the unbounded recursive audit-chain data backfill from steady-state Management API startup
- add a durable platform migration marker and make server startup perform one primary-key marker lookup only
- move validation, backfill, indexes, checkpoint repair, and marker recording into explicit `--init-db` maintenance
- coordinate audit appends and the migration with shared/exclusive transaction advisory locks

## Production incident

After PR #497 fixed false-active bootstrap handling, v0.47.1 still failed before port 9090 because `WITH RECURSIVE linked_audit_events` stayed active longer than the Bun server pool 30-second idle timeout. The database showed no lock wait. The service now exits correctly, but the historical data migration must not run on every server start.

## Safety

- server startup never scans or updates `audit_logs`
- a missing marker fails quickly with an explicit `supacloud --init-db` remediation
- marker insertion is the final migration operation
- duplicate hashes, branches, multiple roots, orphans, disconnected cycles, sequence mismatches, checkpoint mismatches, and final continuity mismatches fail closed and roll back
- steady-state trigger creation is catalog-conditional; trigger drop/recreate occurs only inside explicit migration
- production marker state remains unknown and will not be guessed

## Verification

- targeted tests: 21 pass, 0 fail
- full unit suite: pass, shared 1017/0 plus isolated suites
- integration suite: 39/39
- PostgreSQL 18 fresh canonical init: pass
- PostgreSQL 18 audit migration integration: 4/4
  - 10,000-event explicit backfill: 13.7–14.6 seconds
  - 25,000-event server marker fast path: 168–172 ms
  - invalid graph rollback leaves no marker
- typecheck, SQL synchronization, and diff check: pass
- Linux amd64 SHA256: `68313aee89cb3d9b480d89ae705d73fa80f5b7785b7d92378fc7bfd29d13e630`

PostgreSQL 17 was intentionally not added as a new gate for this follow-up; the production target is PostgreSQL 18.

## Rollout

The production rollout remains gated on a maintenance-window integrity proof. Only after the live audit chain validates may the durable marker be recorded and the locally built binary activated. No tenant fixture or FA Function changes are part of this PR.