### PR TITLE
fix(storage): expose ETag through CORS

### DIFF
--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -258,7 +258,7 @@ const STORAGE_CORS_ALLOW_HEADERS = [
 ].join(", ");
 
 const STORAGE_CORS_EXPOSE_HEADERS = [
-    "Content-Length", "Content-Range", "X-Content-Range", "X-JSON",
+    "Content-Length", "Content-Range", "X-Content-Range", "X-JSON", "ETag",
     "x-supabase-api-version", "X-Client-Info", "Prefer",
     "Content-Profile", "accept-profile", "Range", "Range-Unit",
     "X-Relay-Error", "link", "x-total-count",

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -91,6 +91,24 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
     expect(res.headers.get("Tus-Max-Size")).toBe(String(500 * 1024 * 1024));
   });
 
+  test("Storage CORS exposes ETag without dropping TUS headers", async () => {
+    const res = await request("/storage/v1/object/public/avatars/public.txt", {
+      method: "OPTIONS",
+      headers: {
+        apikey: "test-token",
+        "x-project-ref": "test_mock",
+        origin: "https://app.example.com",
+      },
+    });
+
+    const exposedHeaders = res.headers.get("Access-Control-Expose-Headers");
+    expect(exposedHeaders).toContain("ETag");
+    expect(exposedHeaders).toContain("Tus-Resumable");
+    expect(exposedHeaders).toContain("Tus-Version");
+    expect(exposedHeaders).toContain("Tus-Extension");
+    expect(exposedHeaders).toContain("Tus-Max-Size");
+  });
+
   test("accepts project header on loopback health checks without apikey", async () => {
     const sqlSpy = spyOn(dbModule, "sql");
     sqlSpy.mockImplementation(async (...args: unknown[]) => {

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -101,12 +101,14 @@ describe("storageCompatRoutes supabase-js compatibility", () => {
       },
     });
 
-    const exposedHeaders = res.headers.get("Access-Control-Expose-Headers");
-    expect(exposedHeaders).toContain("ETag");
-    expect(exposedHeaders).toContain("Tus-Resumable");
-    expect(exposedHeaders).toContain("Tus-Version");
-    expect(exposedHeaders).toContain("Tus-Extension");
-    expect(exposedHeaders).toContain("Tus-Max-Size");
+    const exposedHeaderTokens = (res.headers.get("Access-Control-Expose-Headers") ?? "")
+      .split(",")
+      .map((header) => header.trim().toLowerCase());
+    expect(exposedHeaderTokens).toContain("etag");
+    expect(exposedHeaderTokens).toContain("tus-resumable");
+    expect(exposedHeaderTokens).toContain("tus-version");
+    expect(exposedHeaderTokens).toContain("tus-extension");
+    expect(exposedHeaderTokens).toContain("tus-max-size");
   });
 
   test("accepts project header on loopback health checks without apikey", async () => {


### PR DESCRIPTION
## Summary

- add ETag to the Storage compatibility CORS exposed-header list
- preserve the existing TUS exposed headers
- add a regression test covering ETag and all existing TUS exposed headers on a Storage preflight response

## Root cause

The Storage gateway preserves upstream CORS headers, but the Management API Storage compatibility route did not include ETag in Access-Control-Expose-Headers. Browsers therefore could not read the ETag header even when the object response contained it.

## Verification

- bun test packages/management-api/tests/unit/storage-compat.sdk.test.ts
- bun run typecheck
- bun run test:unit
- git diff --check