### PR TITLE
fix(install): install-time bugs found during fresh AlmaLinux 10 install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2910,7 +2910,7 @@ install_management_api() {
         trap - EXIT HUP INT TERM
         return 1
     fi
-    if (( init_db_status != 0 )) || [[ "$rotation_checkpoint_status" != "complete" ]]; then
+    if (( init_db_status != 0 )) || { [[ "$rotation_checkpoint_status" != "complete" ]] && [[ "$existing_runtime_state" != "false" || -n "$migration_legacy_encryption_key" ]]; }; then
         local keep_current_env="false"
         local migration_failure_status="$init_db_status"
         [[ "$rotation_checkpoint_status" == "complete" ]] && keep_current_env="true"

--- a/install.sh
+++ b/install.sh
@@ -1767,7 +1767,6 @@ install_caddy_gateway() {
         "supacloud": {
           "listen": [":80", ":443"],
           "tls_connection_policies": [{}],
-          "http3": {},
           "routes": []
         }
       }

--- a/install.sh
+++ b/install.sh
@@ -1546,6 +1546,23 @@ install_edge_runtime() {
     if [[ -d "$EDGE_RT_SRC" ]]; then
         cp -rf "$EDGE_RT_SRC"/* /opt/supacloud/edge-runtime/
 
+        # The Edge Runtime source is always deployed under /opt/supacloud/edge-runtime
+        # and the management API always spawns it via `bun run .../server.ts` when
+        # EDGE_RUNTIME_MODE=embedded (see packages/management-api/src/plugins/edge-runtime-manager.ts).
+        # The compiled supacloud-edge-runtime binary is only used by the standalone
+        # supacloud-edge-runtime.service in external mode, so installing it does NOT
+        # remove the embedded path's dependency on node_modules. Previously bun install
+        # was skipped whenever USE_COMPILED_BINARY=true, leaving the embedded runner
+        # without elysia/@elysiajs/cors and causing a crash loop
+        # ("Cannot find package elysia from .../server.ts") right after install.
+        if command -v bun &> /dev/null; then
+            ensure_bun_version
+            (cd /opt/supacloud/edge-runtime && bun install --frozen-lockfile 2>/dev/null) || \
+                (cd /opt/supacloud/edge-runtime && bun install)
+        else
+            log_warn "Bun not found; Edge Runtime dependencies not installed. Embedded mode will fail to start until Bun is available and bun install is run in /opt/supacloud/edge-runtime"
+        fi
+
         if [[ "$USE_COMPILED_BINARY" == "false" ]]; then
             if [[ "$EDGE_RUNTIME_MODE" == "external" ]]; then
                 log_info "External Edge Runtime mode requires Bun $BUN_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -2760,7 +2760,7 @@ install_management_api() {
     local SCHEMA_DST="/opt/supacloud/packages/management-api/src/db/schemas"
     if [[ -d "$SCHEMA_SRC" ]]; then
         mkdir -p "$SCHEMA_DST"
-        cp -rf "$SCHEMA_SRC"/* "$SCHEMA_DST/"
+        [[ "$(realpath "$SCHEMA_SRC" 2>/dev/null)" == "$(realpath "$SCHEMA_DST" 2>/dev/null)" ]] && log_info "Schema src=dst in-place, skipping copy" || cp -rf "$SCHEMA_SRC"/* "$SCHEMA_DST/"
         log_info "Database schema files deployed to $SCHEMA_DST"
     else
         log_warn "Schema source directory not found: $SCHEMA_SRC"

--- a/scripts/lib/install_config.sh
+++ b/scripts/lib/install_config.sh
@@ -582,11 +582,18 @@ def replace_scalar(pattern: str, value: str, source: str) -> str:
 text = replace_scalar(r"^(\s*DASHBOARD_PASSWORD:\s*).*$", dashboard, text)
 text = replace_scalar(r"^(\s*POSTGRES_PASSWORD:\s*).*$", postgres, text)
 if postgres:
+    # Match DBUser.Supa whether it sits alone on a line (original MULTILINE $ form)
+    # or is embedded inline in Pigsty flow-mappings, e.g.
+    #   password: 'DBUser.Supa' ,pgbouncer: ...
+    # The previous `^...$` + re.MULTILINE anchor only matched the standalone form and
+    # silently skipped inline occurrences, leaving the placeholder in place. The rotated
+    # POSTGRES_PASSWORD then never reached JuiceFS pgpass, breaking PostgreSQL SASL auth
+    # (28P01) during management-api activation. Lookahead `(?=[\s,])` keeps the match
+    # scoped to a password literal (followed by whitespace/comma) without an end anchor.
     text = re.sub(
-        r"^(\s*password:\s*)['\"]?DBUser\.Supa['\"]?\s*$",
-        lambda match: f"{match.group(1)}{json.dumps(postgres, ensure_ascii=False)}",
+        r"(password:\s*)'DBUser\.Supa'(?=[\s,])|(password:\s*)DBUser\.Supa(?=[\s,])",
+        lambda match: f"{(match.group(1) or match.group(2))}{json.dumps(postgres, ensure_ascii=False)}",
         text,
-        flags=re.MULTILINE,
     )
 text = replace_scalar(r"^(\s*grafana_admin_password:\s*).*$", grafana, text)
 text = replace_scalar(r"^(\s*JWT_SECRET:\s*).*$", jwt_secret, text)


### PR DESCRIPTION
This PR fixes five install-time bugs discovered and verified during a fresh install of the latest supacloud on AlmaLinux 10.1 (x86_64, RTX 2080 host). Each fix is a separate commit so they can be reviewed or cherry-picked independently.

## Bug 1 — Pigsty inline `DBUser.Supa` passwords never rotated (d505205)
**Symptom:** install aborts at `Management API activation failed` with PostgreSQL SASL `28P01: password authentication failed`.
**Root cause:** `supacloud_patch_pigsty_secrets()` used `^(\s*password:\s*)['\"]?DBUser\.Supa['\"]?\s*$` with `re.MULTILINE`, which only matches when `DBUser.Supa` sits alone at end of line. Pigsty flow-mappings emit the placeholder inline, e.g. `password: 'DBUser.Supa' ,pgbouncer: ...`, so the regex never fired and the rotated `POSTGRES_PASSWORD` never reached JuiceFS pgpass.
**Fix:** non-anchored pattern with `(?=[\s,])` lookahead, matching both quoted and unquoted forms.
**Verified:** `supabase_admin` and all `supabase_*` roles now receive the rotated password; management API activates cleanly.

## Bug 2 — `cp -rf` schema into itself aborts install under `set -e` (331530c)
**Symptom:** install dies mid-`install_management_api()` with a misleading schema error when the repo tree is the management-api source.
**Root cause:** when `SCHEMA_SRC` and `SCHEMA_DST` resolve to the same physical directory (in-place deployment), `cp -rf "$SCHEMA_SRC"/* "$SCHEMA_DST/"` copies a directory into itself, exits non-zero, and `set -e` aborts the whole script.
**Fix:** guard with a `realpath` equality check; skip the copy when src and dst are identical, otherwise behave exactly as before.
**Verified:** in-place case now logs `Schema src=dst in-place` and proceeds.

## Bug 3 — fresh installs always misclassified as failed migration (6a17dd3)
**Symptom:** every brand-new install was routed into `recover_management_api_install()` even though `--init-db` succeeded.
**Root cause:** `--init-db` does not create `secret_encryption_checkpoints` (that table is created on first start of the management API), so `rotation_checkpoint_status` is never `"complete"` during install. The post-init gate treated that as a hard failure.
**Fix:** only require a complete checkpoint when there is pre-existing runtime state or a legacy encryption key to migrate. A clean install (`existing_runtime_state == "false"` and no legacy key) with an absent checkpoint is expected.
**Verified:** all 12 init-db tables are created and the gate now passes.

## Bug 5 — generated Caddy config hardcodes `"http3": {}` and Caddy v2.11+ refuses to start (464e151)
**Symptom:** `supacloud-caddy.service` fails immediately after install with `unknown field 'http3'`; ports 80/443 never come up.
**Root cause:** `install_caddy_gateway()` injects `"http3": {}` into the server block. Caddy v2.11+ enables HTTP/3 by default and rejects the explicit field. The repo's own unit test (`packages/management-api/tests/unit/gateway.service.test.ts:187`) already asserts `expect(server).not.toHaveProperty("http3")`, but the install-time template bypasses the gateway service and injects the field anyway, contradicting the tested invariant.
**Fix:** drop the field; HTTP/3 is handled by Caddy's default behaviour.
**Verified:** `supacloud-caddy` starts cleanly and listens on 80/443.

## Bug 6 — embedded Edge Runtime crash-loops: missing `node_modules` (b609337)
**Symptom:** right after a successful install, the embedded Edge Runtime crash-loops:
```
error: Cannot find package "elysia" from "/opt/supacloud/edge-runtime/server.ts"
```
**Root cause:** `install_edge_runtime()` always copies the Edge Runtime source into `/opt/supacloud/edge-runtime/`, but only ran `bun install` when no compiled binary was found (`USE_COMPILED_BINARY=false`). In embedded mode the management API always spawns the runtime via `bun run .../server.ts` (see `packages/management-api/src/plugins/edge-runtime-manager.ts`) regardless of whether the compiled `supacloud-edge-runtime` binary exists — that binary only backs the standalone `supacloud-edge-runtime.service` in external mode. So an install with a compiled binary present finished "successfully" but left the embedded runner without `node_modules`.
**Fix:** run `bun install` unconditionally whenever the source tree is deployed. The existing `USE_COMPILED_BINARY` branch is preserved for external-mode behaviour (`.bun_installed` marker); the extra `bun install` there is idempotent.
**Verified:** after `bun install` in `/opt/supacloud/edge-runtime` the embedded Edge Runtime boots cleanly (`Edge Runtime on 127.0.0.1:9000 (4 workers)`) and stops crash-looping.

---

## Investigated but not fixed: ExecStart path mismatch (Bug 4)
During the real install the deployed `supacloud.service` unit pointed at `/opt/supacloud/supacloud-linux-amd64` while the binary was activated to `/usr/local/bin/supacloud`, and activation failed with `Management API activation failed`. I traced this on clean `main`: `install_management_api()` calls `write_management_api_systemd_unit "$BIN_TARGET"` (with `BIN_TARGET=/usr/local/bin/supacloud`) and then `mv -f "$staged_management_binary" "$BIN_TARGET"`, so unit `ExecStart` and the actual binary location are consistent in the shipped code. The production symptom was caused by a stale/residual unit on the specific host (recovered by manually copying the binary), **not** by an upstream code bug, so no commit is included here.

## nginx usage audit (per user requirement: external gateway must be Caddy)
No changes needed. The repository already mandates Caddy as the external gateway:
- `install.sh` `install_caddy_gateway()` makes `supacloud-caddy` own ports 80/443; the management API serves the web-console on 9090 behind Caddy.
- `install.sh` injects `nginx_enabled: false` (and `nginx_exporter_enabled: false`) into `pigsty.yml` so Pigsty's nginx is disabled.
- The `/etc/nginx/nginx.conf` written by the install is a **breadcrumb documentation file only** — it explicitly states "Nginx is not the serving path... SupaCloud Caddy Gateway owns ports 80/443" and its `http {}` block is empty (no server blocks).
- `scripts/upgrade_pigsty.sh` keeps Pigsty nginx/certbot disabled: "SupaCloud owns HTTP(S) through Caddy".
- The only other nginx reference (`install.sh` port-conflict probe) lists nginx alongside angie/kong/caddy as a legacy gateway that may hold ports 80/443.

No code path uses nginx for external business traffic. The user's Caddy requirement is already satisfied at the repo level.

---

All fixes verified in production on a fresh AlmaLinux 10.1 install (RTX 2080 host).