### PR TITLE
fix(realtime): prevent oversized NOTIFY rollback

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -320,6 +320,15 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
         run: bun test tests/integration/audit-chain-migration.test.ts
 
+      - name: Verify Realtime payload safety on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: |
+          export POSTGRES_CONTAINER="$(docker compose -f ../../docker/self-host/docker-compose.yml ps -q postgres)"
+          test -n "${POSTGRES_CONTAINER}"
+          bun test tests/integration/realtime-notify-payload.test.ts
+
       - name: Apply and verify Docker PostgreSQL compatibility
         env:
           SUPACLOUD_META_DB: postgres

--- a/packages/management-api/src/db/schemas/supabase.sql
+++ b/packages/management-api/src/db/schemas/supabase.sql
@@ -494,7 +494,7 @@ BEGIN
     WHEN SQLSTATE '22023' THEN RETURN;
   END;
 END;
-$fn$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
+$fn$ LANGUAGE plpgsql SECURITY INVOKER SET search_path = pg_catalog;
 -- supacloud:sql-module:realtime-notify-payload:end
 
 DO $$

--- a/packages/management-api/src/db/schemas/supabase.sql
+++ b/packages/management-api/src/db/schemas/supabase.sql
@@ -478,6 +478,25 @@ CREATE POLICY "Allow authenticated multipart upload parts" ON storage.s3_multipa
 CREATE SCHEMA IF NOT EXISTS realtime;
 GRANT USAGE ON SCHEMA realtime TO anon, authenticated, service_role;
 
+-- supacloud:sql-module:realtime-notify-payload:start
+CREATE OR REPLACE FUNCTION realtime.notify_change_payload(payload jsonb)
+RETURNS void AS $fn$
+DECLARE
+  payload_text text := payload::text;
+BEGIN
+  IF pg_catalog.octet_length(payload_text) >= 8000 THEN
+    RETURN;
+  END IF;
+
+  BEGIN
+    PERFORM pg_catalog.pg_notify('realtime_changes', payload_text);
+  EXCEPTION
+    WHEN SQLSTATE '22023' THEN RETURN;
+  END;
+END;
+$fn$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
+-- supacloud:sql-module:realtime-notify-payload:end
+
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN

--- a/packages/management-api/src/db/sql-module-sync.ts
+++ b/packages/management-api/src/db/sql-module-sync.ts
@@ -25,6 +25,7 @@ export const SQL_MODULE_TARGETS = [
     moduleIds: [
       "auth-jwt-helpers",
       "storage-path-helpers",
+      "realtime-notify-payload",
       "postgrest-request-context",
       "pgmq-public",
     ],

--- a/packages/management-api/src/db/sql-modules.ts
+++ b/packages/management-api/src/db/sql-modules.ts
@@ -4,6 +4,7 @@ import backgroundTaskMirrorUpSql from "./sql-modules/background-task-mirror-up.s
 import pgmqPublicSql from "./sql-modules/pgmq-public.sql" with { type: "text" };
 import postgrestRequestContextSql from "./sql-modules/postgrest-request-context.sql" with { type: "text" };
 import realtimeAutoAttachTriggerSql from "./sql-modules/realtime-auto-attach-trigger.sql" with { type: "text" };
+import realtimeNotifyPayloadSql from "./sql-modules/realtime-notify-payload.sql" with { type: "text" };
 import storagePathHelpersSql from "./sql-modules/storage-path-helpers.sql" with { type: "text" };
 
 export const SQL_MODULES = {
@@ -13,6 +14,7 @@ export const SQL_MODULES = {
   "pgmq-public": pgmqPublicSql.trim(),
   "postgrest-request-context": postgrestRequestContextSql.trim(),
   "realtime-auto-attach-trigger": realtimeAutoAttachTriggerSql.trim(),
+  "realtime-notify-payload": realtimeNotifyPayloadSql.trim(),
   "storage-path-helpers": storagePathHelpersSql.trim(),
 } as const;
 

--- a/packages/management-api/src/db/sql-modules/realtime-notify-payload.sql
+++ b/packages/management-api/src/db/sql-modules/realtime-notify-payload.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION realtime.notify_change_payload(payload jsonb)
+RETURNS void AS $fn$
+DECLARE
+  payload_text text := payload::text;
+BEGIN
+  IF pg_catalog.octet_length(payload_text) >= 8000 THEN
+    RETURN;
+  END IF;
+
+  BEGIN
+    PERFORM pg_catalog.pg_notify('realtime_changes', payload_text);
+  EXCEPTION
+    WHEN SQLSTATE '22023' THEN RETURN;
+  END;
+END;
+$fn$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;

--- a/packages/management-api/src/db/sql-modules/realtime-notify-payload.sql
+++ b/packages/management-api/src/db/sql-modules/realtime-notify-payload.sql
@@ -13,4 +13,4 @@ BEGIN
     WHEN SQLSTATE '22023' THEN RETURN;
   END;
 END;
-$fn$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
+$fn$ LANGUAGE plpgsql SECURITY INVOKER SET search_path = pg_catalog;

--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -342,6 +342,8 @@ CREATE TABLE IF NOT EXISTS supabase_functions.migrations (
 );
 
 -- 11. Native Bun Realtime LISTEN/NOTIFY Emulation Triggers (P0-16 enrichment)
+${SQL_MODULES["realtime-notify-payload"]}
+
 -- This function emulates WAL-level postgres_changes by serializing full OLD/NEW records
 CREATE OR REPLACE FUNCTION realtime.notify_postgres_changes() RETURNS trigger AS $fn$
 DECLARE
@@ -388,7 +390,7 @@ BEGIN
       )
     )
   );
-  PERFORM pg_notify('realtime_changes', payload::text);
+  PERFORM realtime.notify_change_payload(payload);
   IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
 END;
 $fn$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/packages/management-api/src/services/realtime-bun.service.ts
+++ b/packages/management-api/src/services/realtime-bun.service.ts
@@ -3,6 +3,7 @@ import type { JWTPayload } from 'jose';
 import { logger } from '../utils/logger';
 import { databaseService } from './database.service';
 import { resolveDbName, getProjectDb, resolveSlotName } from '../db';
+import { SQL_MODULES } from '../db/sql-modules';
 import { verifyProjectJwtPayload } from '../utils/project-jwt';
 
 const IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
@@ -221,6 +222,8 @@ class RealtimeBunService {
 
         try {
             await db.unsafe(`
+                ${SQL_MODULES["realtime-notify-payload"]}
+
                 CREATE OR REPLACE FUNCTION realtime_supacloud_notify()
                 RETURNS TRIGGER AS $$
                 DECLARE
@@ -256,7 +259,7 @@ class RealtimeBunService {
                         'commit_timestamp', now()::text
                     );
 
-                    PERFORM pg_notify('realtime_changes', payload::text);
+                    PERFORM realtime.notify_change_payload(payload);
                     RETURN COALESCE(NEW, OLD);
                 END;
                 $$ LANGUAGE plpgsql;

--- a/packages/management-api/src/services/realtime-bun.service.ts
+++ b/packages/management-api/src/services/realtime-bun.service.ts
@@ -262,7 +262,7 @@ class RealtimeBunService {
                     PERFORM realtime.notify_change_payload(payload);
                     RETURN COALESCE(NEW, OLD);
                 END;
-                $$ LANGUAGE plpgsql;
+                $$ LANGUAGE plpgsql SECURITY INVOKER;
             `);
 
             for (const sub of subscriptions) {

--- a/packages/management-api/src/services/tenant-runtime-migration.ts
+++ b/packages/management-api/src/services/tenant-runtime-migration.ts
@@ -324,6 +324,8 @@ CREATE TABLE IF NOT EXISTS supabase_functions.migrations (
 );
 
 -- 11. Native Bun Realtime LISTEN/NOTIFY Emulation Triggers (P0-16 enrichment)
+${SQL_MODULES["realtime-notify-payload"]}
+
 -- This function emulates WAL-level postgres_changes by serializing full OLD/NEW records
 CREATE OR REPLACE FUNCTION realtime.notify_postgres_changes() RETURNS trigger AS $fn$
 DECLARE
@@ -370,7 +372,7 @@ BEGIN
       )
     )
   );
-  PERFORM pg_notify('realtime_changes', payload::text);
+  PERFORM realtime.notify_change_payload(payload);
   IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
 END;
 $fn$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/packages/management-api/tests/integration/realtime-notify-payload.test.ts
+++ b/packages/management-api/tests/integration/realtime-notify-payload.test.ts
@@ -19,6 +19,11 @@ interface ServerVersion {
   versionNumber: number;
 }
 
+interface RealtimeSecurityModes {
+  helperSecurityDefiner: boolean;
+  triggerSecurityDefiner: boolean;
+}
+
 const databaseUrl = process.env.DATABASE_URL
   ?? "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 const postgresContainer = process.env.POSTGRES_CONTAINER;
@@ -127,22 +132,60 @@ async function expectBoundaryBehavior(boundary: PayloadBoundary): Promise<void> 
   )), boundary.label).toBeNull();
 }
 
-async function expectNonPayloadError(): Promise<void> {
+async function realtimeSecurityModes(): Promise<RealtimeSecurityModes> {
+  const [securityModes] = await database<RealtimeSecurityModes[]>`
+    SELECT
+      (SELECT prosecdef FROM pg_catalog.pg_proc
+        WHERE oid = 'realtime.notify_change_payload(jsonb)'::regprocedure) AS "helperSecurityDefiner",
+      (SELECT prosecdef FROM pg_catalog.pg_proc
+        WHERE oid = 'realtime.notify_postgres_changes()'::regprocedure) AS "triggerSecurityDefiner"
+  `;
+  return securityModes;
+}
+
+async function createRestrictedRole(connection: ReservedSQL): Promise<void> {
+  await connection.unsafe(`CREATE ROLE ${quoteIdentifier(fixtureRole)} NOLOGIN`);
+  await connection.unsafe(`GRANT USAGE ON SCHEMA realtime TO ${quoteIdentifier(fixtureRole)}`);
+  await connection.unsafe(
+    `GRANT INSERT ON TABLE public.${quoteIdentifier(fixtureTable)} TO ${quoteIdentifier(fixtureRole)}`,
+  );
+}
+
+async function invokeWithOrdinaryPermissions(connection: ReservedSQL): Promise<void> {
+  await connection.unsafe(`SET LOCAL ROLE ${quoteIdentifier(fixtureRole)}`);
+  await connection.unsafe("SELECT realtime.notify_change_payload('{\"ordinary\":true}'::jsonb)");
+  await connection.unsafe(
+    `INSERT INTO public.${quoteIdentifier(fixtureTable)} (id, body) VALUES (3, 'restricted caller')`,
+  );
+  await connection.unsafe("RESET ROLE");
+}
+
+async function restrictedPermissionError(connection: ReservedSQL): Promise<unknown> {
+  await connection.unsafe("REVOKE EXECUTE ON FUNCTION pg_catalog.pg_notify(text, text) FROM PUBLIC");
+  await connection.unsafe(`SET LOCAL ROLE ${quoteIdentifier(fixtureRole)}`);
+  await connection.unsafe(
+    `INSERT INTO public.${quoteIdentifier(fixtureTable)} (id, body) VALUES (4, 'definer trigger')`,
+  );
+  try {
+    await connection.unsafe("SELECT realtime.notify_change_payload('{\"small\":true}'::jsonb)");
+  } catch (error: unknown) {
+    return error;
+  }
+  return undefined;
+}
+
+async function expectInvokerSecurityAndNonPayloadError(): Promise<void> {
+  expect(await realtimeSecurityModes()).toEqual({
+    helperSecurityDefiner: false,
+    triggerSecurityDefiner: true,
+  });
+
   const connection = await database.reserve();
   await connection.unsafe("BEGIN");
   try {
-    await connection.unsafe(`CREATE ROLE ${quoteIdentifier(fixtureRole)} NOLOGIN`);
-    await connection.unsafe(`GRANT USAGE, CREATE ON SCHEMA realtime TO ${quoteIdentifier(fixtureRole)}`);
-    await connection.unsafe(
-      `ALTER FUNCTION realtime.notify_change_payload(jsonb) OWNER TO ${quoteIdentifier(fixtureRole)}`,
-    );
-    await connection.unsafe("REVOKE EXECUTE ON FUNCTION pg_catalog.pg_notify(text, text) FROM PUBLIC");
-    let permissionError: unknown;
-    try {
-      await connection.unsafe("SELECT realtime.notify_change_payload('{\"small\":true}'::jsonb)");
-    } catch (error: unknown) {
-      permissionError = error;
-    }
+    await createRestrictedRole(connection);
+    await invokeWithOrdinaryPermissions(connection);
+    const permissionError = await restrictedPermissionError(connection);
     expect(permissionError).toBeInstanceOf(Error);
     expect((permissionError as Error).message).toContain("permission denied for function pg_notify");
   } finally {
@@ -224,7 +267,7 @@ describe("realtime NOTIFY payload safety on PostgreSQL 18", () => {
     expect(await database`SELECT id FROM ${database(fixtureTable)} WHERE id = 2`).toHaveLength(0);
   });
 
-  test("propagates errors other than SQLSTATE 22023", async () => {
-    await expectNonPayloadError();
+  test("uses invoker rights and propagates errors other than SQLSTATE 22023", async () => {
+    await expectInvokerSecurityAndNonPayloadError();
   });
 });

--- a/packages/management-api/tests/integration/realtime-notify-payload.test.ts
+++ b/packages/management-api/tests/integration/realtime-notify-payload.test.ts
@@ -1,0 +1,230 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { SQL, type ReservedSQL } from "bun";
+import { SQL_MODULES } from "../../src/db/sql-modules";
+import { ALTER_TENANT_SQL } from "../../src/services/tenant-runtime-migration";
+
+interface PayloadBoundary {
+  label: string;
+  belowLimitExpression: string;
+  atLimitExpression: string;
+}
+
+interface PayloadSizes {
+  belowLimit: number;
+  atLimit: number;
+}
+
+interface ServerVersion {
+  versionNumber: number;
+}
+
+const databaseUrl = process.env.DATABASE_URL
+  ?? "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+const postgresContainer = process.env.POSTGRES_CONTAINER;
+const fixtureSuffix = randomUUID().replaceAll("-", "").slice(0, 12);
+const fixtureTable = `realtime_payload_${fixtureSuffix}`;
+const fixtureRole = `realtime_notify_owner_${fixtureSuffix}`;
+const database = new SQL({ url: databaseUrl, max: 3 });
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function canonicalTriggerFunctionSql(): string {
+  const signature = "CREATE OR REPLACE FUNCTION realtime.notify_postgres_changes()";
+  const terminator = "$fn$ LANGUAGE plpgsql SECURITY DEFINER;";
+  const functionStart = ALTER_TENANT_SQL.indexOf(signature);
+  const functionEnd = ALTER_TENANT_SQL.indexOf(terminator, functionStart);
+  if (functionStart < 0 || functionEnd < 0) {
+    throw new Error("Canonical realtime trigger function is missing");
+  }
+  return ALTER_TENANT_SQL.slice(functionStart, functionEnd + terminator.length);
+}
+
+async function collectListenerOutput(
+  stream: ReadableStream<Uint8Array>,
+  markReady: () => void,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let listenerOutput = "";
+  while (true) {
+    const { done, value: chunk } = await reader.read();
+    if (done) return listenerOutput + decoder.decode();
+    listenerOutput += decoder.decode(chunk, { stream: true });
+    if (listenerOutput.includes("LISTEN\n")) markReady();
+  }
+}
+
+async function waitForListenerReady(ready: Promise<void>): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error("Timed out waiting for LISTEN readiness")), 2_000);
+  });
+  try {
+    await Promise.race([ready, timeout]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function notificationFrom(action: () => Promise<unknown>): Promise<string | null> {
+  if (!postgresContainer) throw new Error("POSTGRES_CONTAINER is required for PG18 notification tests");
+
+  let markReady!: () => void;
+  const ready = new Promise<void>((resolve) => { markReady = resolve; });
+  const listenerProcess = Bun.spawn([
+    "docker", "exec", postgresContainer, "psql", "-U", "postgres", "-d", "postgres", "-X",
+    "-v", "ON_ERROR_STOP=1", "-c", "LISTEN realtime_changes", "-c", "SELECT pg_sleep(2)",
+  ], { stdout: "pipe", stderr: "pipe" });
+  const stdout = collectListenerOutput(listenerProcess.stdout, markReady);
+  const stderr = new Response(listenerProcess.stderr).text();
+
+  await waitForListenerReady(ready);
+  await action();
+
+  const [exitCode, listenerOutput, listenerError] = await Promise.all([
+    listenerProcess.exited,
+    stdout,
+    stderr,
+  ]);
+  expect(exitCode, listenerError).toBe(0);
+  return listenerOutput.match(
+    /Asynchronous notification "realtime_changes" with payload "(.*)" received/,
+  )?.[1] ?? null;
+}
+
+async function installRealtimeFixture(): Promise<void> {
+  await database.unsafe("CREATE SCHEMA IF NOT EXISTS realtime");
+  await database.unsafe(SQL_MODULES["realtime-notify-payload"]);
+  await database.unsafe(canonicalTriggerFunctionSql());
+  await database.unsafe(`CREATE TABLE public.${quoteIdentifier(fixtureTable)} (id integer PRIMARY KEY, body text NOT NULL)`);
+  await database.unsafe(`DROP TRIGGER IF EXISTS realtime_notify_trigger ON public.${quoteIdentifier(fixtureTable)}`);
+  await database.unsafe(`
+    CREATE TRIGGER realtime_notify_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON public.${quoteIdentifier(fixtureTable)}
+    FOR EACH ROW EXECUTE FUNCTION realtime.notify_postgres_changes()
+  `);
+}
+
+async function payloadSizes(boundary: PayloadBoundary): Promise<PayloadSizes> {
+  const [sizes] = await database.unsafe<PayloadSizes[]>(`
+    SELECT
+      pg_catalog.octet_length((${boundary.belowLimitExpression})::text)::int AS "belowLimit",
+      pg_catalog.octet_length((${boundary.atLimitExpression})::text)::int AS "atLimit"
+  `);
+  return sizes;
+}
+
+async function expectBoundaryBehavior(boundary: PayloadBoundary): Promise<void> {
+  expect(await payloadSizes(boundary), boundary.label).toEqual({ belowLimit: 7999, atLimit: 8000 });
+  expect(await notificationFrom(() => database.unsafe(
+    `SELECT realtime.notify_change_payload(${boundary.belowLimitExpression})`,
+  )), boundary.label).not.toBeNull();
+  expect(await notificationFrom(() => database.unsafe(
+    `SELECT realtime.notify_change_payload(${boundary.atLimitExpression})`,
+  )), boundary.label).toBeNull();
+}
+
+async function expectNonPayloadError(): Promise<void> {
+  const connection = await database.reserve();
+  await connection.unsafe("BEGIN");
+  try {
+    await connection.unsafe(`CREATE ROLE ${quoteIdentifier(fixtureRole)} NOLOGIN`);
+    await connection.unsafe(`GRANT USAGE, CREATE ON SCHEMA realtime TO ${quoteIdentifier(fixtureRole)}`);
+    await connection.unsafe(
+      `ALTER FUNCTION realtime.notify_change_payload(jsonb) OWNER TO ${quoteIdentifier(fixtureRole)}`,
+    );
+    await connection.unsafe("REVOKE EXECUTE ON FUNCTION pg_catalog.pg_notify(text, text) FROM PUBLIC");
+    let permissionError: unknown;
+    try {
+      await connection.unsafe("SELECT realtime.notify_change_payload('{\"small\":true}'::jsonb)");
+    } catch (error: unknown) {
+      permissionError = error;
+    }
+    expect(permissionError).toBeInstanceOf(Error);
+    expect((permissionError as Error).message).toContain("permission denied for function pg_notify");
+  } finally {
+    await connection.unsafe("ROLLBACK");
+    connection.release();
+  }
+}
+
+beforeAll(async () => {
+  const [server] = await database<ServerVersion[]>`
+    SELECT current_setting('server_version_num')::int AS "versionNumber"
+  `;
+  expect(server.versionNumber).toBeGreaterThanOrEqual(180_000);
+  expect(server.versionNumber).toBeLessThan(190_000);
+  await installRealtimeFixture();
+});
+
+afterAll(async () => {
+  await database.unsafe(`DROP TABLE IF EXISTS public.${quoteIdentifier(fixtureTable)}`);
+  await database.close();
+});
+
+describe("realtime NOTIFY payload safety on PostgreSQL 18", () => {
+  test("uses byte length for ASCII, Chinese, and emoji boundaries", async () => {
+    const boundaries: PayloadBoundary[] = [
+      {
+        label: "ASCII",
+        belowLimitExpression: "to_jsonb(repeat('a', 7997))",
+        atLimitExpression: "to_jsonb(repeat('a', 7998))",
+      },
+      {
+        label: "Chinese",
+        belowLimitExpression: "to_jsonb(repeat('中', 2665) || 'aa')",
+        atLimitExpression: "to_jsonb(repeat('中', 2665) || 'aaa')",
+      },
+      {
+        label: "emoji",
+        belowLimitExpression: "to_jsonb(repeat('😀', 1999) || 'a')",
+        atLimitExpression: "to_jsonb(repeat('😀', 1999) || 'aa')",
+      },
+    ];
+    for (const boundary of boundaries) await expectBoundaryBehavior(boundary);
+  }, 20_000);
+
+  test("preserves the small postgres_changes notification shape", async () => {
+    const notification = await notificationFrom(() => database.unsafe(
+      `INSERT INTO public.${quoteIdentifier(fixtureTable)} (id, body) VALUES (1, 'small')`,
+    ));
+    const parsedNotification = JSON.parse(notification!);
+
+    expect(parsedNotification).toEqual({
+      event: "postgres_changes",
+      payload: {
+        columns: [{ name: "id", type: "int4" }, { name: "body", type: "text" }],
+        commit_timestamp: expect.any(String),
+        old_record: null,
+        record: { body: "small", id: 1 },
+        schema: "public",
+        table: fixtureTable,
+        type: "INSERT",
+      },
+      topic: "realtime:public",
+    });
+  });
+
+  test("commits oversized INSERT, UPDATE, and DELETE statements", async () => {
+    await database.unsafe(
+      `INSERT INTO public.${quoteIdentifier(fixtureTable)} (id, body) VALUES (2, repeat('x', 9000))`,
+    );
+    expect(await database`SELECT body FROM ${database(fixtureTable)} WHERE id = 2`).toHaveLength(1);
+
+    await database.unsafe(
+      `UPDATE public.${quoteIdentifier(fixtureTable)} SET body = repeat('中', 4000) WHERE id = 2`,
+    );
+    const [updated] = await database`SELECT pg_catalog.octet_length(body)::int AS bytes FROM ${database(fixtureTable)} WHERE id = 2`;
+    expect(updated.bytes).toBe(12_000);
+
+    await database.unsafe(`DELETE FROM public.${quoteIdentifier(fixtureTable)} WHERE id = 2`);
+    expect(await database`SELECT id FROM ${database(fixtureTable)} WHERE id = 2`).toHaveLength(0);
+  });
+
+  test("propagates errors other than SQLSTATE 22023", async () => {
+    await expectNonPayloadError();
+  });
+});

--- a/packages/management-api/tests/unit/sql-module-sync.test.ts
+++ b/packages/management-api/tests/unit/sql-module-sync.test.ts
@@ -41,6 +41,9 @@ describe("canonical SQL module synchronization", () => {
     expect(SQL_MODULES["postgrest-request-context"]).toContain(
       "LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog",
     );
+    expect(SQL_MODULES["realtime-notify-payload"]).toContain(
+      "CREATE OR REPLACE FUNCTION realtime.notify_change_payload(payload jsonb)",
+    );
     expect(SQL_MODULES["pgmq-public"]).toContain(
       "CREATE OR REPLACE FUNCTION pgmq_public.read(queue_name text, sleep_seconds integer, n integer)",
     );

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -91,6 +91,43 @@ describe("supabase bootstrap schema", () => {
     expect(autoAttachSql).not.toContain("WHEN OTHERS");
   });
 
+  test("all realtime trigger generators reuse the byte-safe notify module", () => {
+    const notifyPayloadSql = SQL_MODULES["realtime-notify-payload"];
+    const migrationPaths = [
+      "src/services/tenant-runtime-migration.ts",
+      "src/scripts/migrate-tenant-schema.ts",
+    ];
+
+    expect(notifyPayloadSql).toContain("payload_text text := payload::text");
+    expect(notifyPayloadSql).toContain("octet_length(payload_text) >= 8000");
+    expect(notifyPayloadSql).toContain(
+      "pg_catalog.pg_notify('realtime_changes', payload_text)",
+    );
+    expect(notifyPayloadSql).toContain("WHEN SQLSTATE '22023' THEN RETURN");
+    expect(notifyPayloadSql).not.toContain("WHEN OTHERS");
+
+    for (const filePath of migrationPaths) {
+      const migrationSource = readRepoFile(filePath);
+      expect(migrationSource).toContain('${SQL_MODULES["realtime-notify-payload"]}');
+      expect(migrationSource).toContain("PERFORM realtime.notify_change_payload(payload)");
+      expect(migrationSource).not.toContain(
+        "PERFORM pg_notify('realtime_changes', payload::text)",
+      );
+    }
+
+    expect(ALTER_TENANT_SQL).toContain(notifyPayloadSql);
+
+    const realtimeBunSource = readRepoFile("src/services/realtime-bun.service.ts");
+    expect(realtimeBunSource).toContain('${SQL_MODULES["realtime-notify-payload"]}');
+    expect(realtimeBunSource).toContain("PERFORM realtime.notify_change_payload(payload)");
+    expect(realtimeBunSource).not.toContain(
+      "PERFORM pg_notify('realtime_changes', payload::text)",
+    );
+
+    const initialSchema = readRepoFile("src/db/schemas/supabase.sql");
+    expect(initialSchema).toContain(notifyPayloadSql);
+  });
+
   test("auth helpers preserve claims-only user identity for modern PostgREST", () => {
     for (const schema of [
       SQL_MODULES["auth-jwt-helpers"],

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -104,6 +104,10 @@ describe("supabase bootstrap schema", () => {
       "pg_catalog.pg_notify('realtime_changes', payload_text)",
     );
     expect(notifyPayloadSql).toContain("WHEN SQLSTATE '22023' THEN RETURN");
+    expect(notifyPayloadSql).toContain(
+      "LANGUAGE plpgsql SECURITY INVOKER SET search_path = pg_catalog",
+    );
+    expect(notifyPayloadSql).not.toContain("SECURITY DEFINER");
     expect(notifyPayloadSql).not.toContain("WHEN OTHERS");
 
     for (const filePath of migrationPaths) {
@@ -120,6 +124,15 @@ describe("supabase bootstrap schema", () => {
     const realtimeBunSource = readRepoFile("src/services/realtime-bun.service.ts");
     expect(realtimeBunSource).toContain('${SQL_MODULES["realtime-notify-payload"]}');
     expect(realtimeBunSource).toContain("PERFORM realtime.notify_change_payload(payload)");
+    const realtimeBunTriggerStart = realtimeBunSource.indexOf(
+      "CREATE OR REPLACE FUNCTION realtime_supacloud_notify()",
+    );
+    const realtimeBunTriggerEnd = realtimeBunSource.indexOf(
+      "$$ LANGUAGE plpgsql SECURITY INVOKER;",
+      realtimeBunTriggerStart,
+    );
+    expect(realtimeBunTriggerStart).toBeGreaterThanOrEqual(0);
+    expect(realtimeBunTriggerEnd).toBeGreaterThan(realtimeBunTriggerStart);
     expect(realtimeBunSource).not.toContain(
       "PERFORM pg_notify('realtime_changes', payload::text)",
     );


### PR DESCRIPTION
## Root cause

The full-row Realtime triggers passed `payload::text` directly to PostgreSQL `pg_notify`. Payloads at or above PostgreSQL's 8,000-byte limit raised SQLSTATE `22023` inside the AFTER trigger and rolled back the originating INSERT, UPDATE, or DELETE.

## Changes

- add one canonical `realtime.notify_change_payload(jsonb)` SQL module
- serialize once and send only payloads below 8,000 bytes
- recover only from SQLSTATE `22023`; propagate every other database error
- reuse the helper from the tenant runtime migration, administrative migration, initial schema, and RealtimeBun subscription trigger
- keep small payload construction and channel contracts unchanged
- add a PostgreSQL 18 CI regression gate

## Verification

- `bun run sql:check`
- `bun run test:sql-modules` (11/11, 100% coverage)
- `bun run test:unit`
- `bun run typecheck`
- `bun run build:amd64`
- PostgreSQL 18.4 integration: ASCII/Chinese/emoji 7,999 vs 8,000 bytes, small payload LISTEN shape, oversized INSERT/UPDATE/DELETE commit, non-22023 error propagation (4/4)
- `git diff --cached --check`

PostgreSQL 17 was not used for this change.

## Rollback

Revert commit `721f78ef`. The migration is idempotent and does not alter tables, triggers, publications, or client payload schemas.
