### PR TITLE
fix(auth): sign proxied service-role credentials

### DIFF
--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -15,6 +15,7 @@ import {
 } from "../utils/project-auth";
 import { isOpaqueApiKey } from "../utils/api-keys";
 import { verifyProjectJwtPayload } from "../utils/project-jwt";
+import { resolveProjectServiceRoleKey } from "../utils/service-role";
 import { getAuthRuntimeDescriptor } from "../services/auth-runtime.service";
 import { GOTRUE_USER_ID_PATTERN } from "../utils/project-user-lifecycle";
 
@@ -341,6 +342,7 @@ async function maybeEnqueueAsyncFunction(request: Request, ref: string): Promise
 export const sdkProxyInternals = {
     resolveProjectRefFromApiKey,
     resolveProjectApiKey,
+    resolveProjectServiceRoleKey,
     maybeEnqueueAsyncFunction,
     buildEncryptedBackgroundAuth,
     translateOpaqueApiKeyHeaders,
@@ -348,10 +350,9 @@ export const sdkProxyInternals = {
     adminUserDeletionBody,
 };
 
-async function getUpstreamApiKey(ref: string, role: "anon" | "service_role"): Promise<string | null> {
+async function getUpstreamAnonKey(ref: string): Promise<string | null> {
     const keys = await projectService.getApiKeys(ref);
-    if (!keys) return null;
-    return role === "service_role" ? keys.service_role_key : keys.anon_key;
+    return keys?.anon_key || null;
 }
 
 async function translateOpaqueApiKeyHeaders(
@@ -363,17 +364,26 @@ async function translateOpaqueApiKeyHeaders(
     const authorization = headers.get("authorization")?.trim() || "";
     const bearerToken = authorization.replace(/^Bearer\s+/i, "");
     let rewrittenApiKey: string | null = null;
+    let projectServiceRoleKey: Promise<string | null> | undefined;
+
+    const resolveSameProjectServiceRoleKey = (): Promise<string | null> => {
+        projectServiceRoleKey ??= sdkProxyInternals.resolveProjectServiceRoleKey(ref);
+        return projectServiceRoleKey;
+    };
 
     const resolveUpstream = async (candidate: string): Promise<string | null | undefined> => {
         if (!candidate) return undefined;
         const resolved = await sdkProxyInternals.resolveProjectApiKey(candidate, { includeProvisioning: true });
         if (!resolved) return isOpaqueApiKey(candidate) ? null : undefined;
-        if (resolved.ref !== ref || !resolved.upstreamKey) return null;
-        if (authAuthorityRef === ref) return resolved.upstreamKey;
+        if (resolved.ref !== ref) return null;
         // 从属项目只能借用 SupAuth owner 的匿名入口。绝不能把从属项目的
         // service_role/secret 凭据升级为 owner 的全局管理员凭据。
-        if (resolved.role === "service_role") return null;
-        return getUpstreamApiKey(authAuthorityRef, resolved.role);
+        if (authAuthorityRef !== ref) {
+            if (resolved.role === "service_role") return null;
+            return getUpstreamAnonKey(authAuthorityRef);
+        }
+        if (resolved.role === "service_role") return resolveSameProjectServiceRoleKey();
+        return resolved.upstreamKey || null;
     };
 
     if (apikey) {

--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -395,14 +395,9 @@ async function translateOpaqueApiKeyHeaders(
         }
     }
 
-    // Shared mode must also resolve legacy API-key bearers. Otherwise a
-    // dependent service_role JWT could reach the owner unchanged and become
-    // an owner admin credential when historical projects share a JWT secret.
-    if (bearerToken && (
-        authAuthorityRef !== ref
-        || isOpaqueApiKey(bearerToken)
-        || bearerToken === apikey
-    )) {
+    // Resolve every bearer so a legacy service_role JWT cannot bypass project
+    // binding. Unknown user JWTs return undefined and remain unchanged.
+    if (bearerToken) {
         const upstream = await resolveUpstream(bearerToken);
         if (upstream === null) return false;
         if (upstream) headers.set("authorization", `Bearer ${upstream}`);

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -99,6 +99,7 @@ async function withSdkProxyTestContext(
 describe("sdkProxyRoutes functions proxy", () => {
   test("exposes tenant-bound API key header translation through the internal test seam", () => {
     expect(typeof sdkProxyInternals.translateOpaqueApiKeyHeaders).toBe("function");
+    expect(typeof sdkProxyInternals.resolveProjectServiceRoleKey).toBe("function");
     expect(sdkProxyInternals.dispatchAdminUserDeletionThroughManagement.toString())
       .toContain("userManagementRoutes.handle");
   });
@@ -418,6 +419,9 @@ describe("sdkProxyRoutes functions proxy", () => {
     config.authRuntimeOwnerRef = "auth-owner";
     try {
       await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+        const serviceRoleSigner = trackSpy(
+          spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("owner-service-jwt"),
+        );
         trackSpy(
           spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
             ref: "proj_1",
@@ -450,6 +454,7 @@ describe("sdkProxyRoutes functions proxy", () => {
           message: "Admin user deletion must use the auth authority project",
         });
         expect(calls).toHaveLength(0);
+        expect(serviceRoleSigner).not.toHaveBeenCalled();
       });
     } finally {
       config.authRuntimeOwnerRef = originalOwnerRef;
@@ -517,6 +522,9 @@ describe("sdkProxyRoutes functions proxy", () => {
 
     try {
       await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+        const serviceRoleSigner = trackSpy(
+          spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("owner-service-jwt"),
+        );
         trackSpy(
           spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
             ref: "proj_1",
@@ -541,6 +549,7 @@ describe("sdkProxyRoutes functions proxy", () => {
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ message: "Invalid API key" });
         expect(calls).toHaveLength(0);
+        expect(serviceRoleSigner).not.toHaveBeenCalled();
       });
     } finally {
       config.authRuntimeOwnerRef = originalOwnerRef;
@@ -639,8 +648,11 @@ describe("sdkProxyRoutes functions proxy", () => {
     });
   });
 
-  test("REST proxy supplies the upstream JWT for an apikey-only opaque request", async () => {
+  test("REST proxy signs one project service-role token for an apikey-only opaque request", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("short-lived-es256-jwt"),
+      );
       trackSpy(
         spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
           ref: "proj_1",
@@ -663,8 +675,139 @@ describe("sdkProxyRoutes functions proxy", () => {
 
       expect(response.status).toBe(200);
       const headers = new Headers(calls[0]?.init?.headers);
-      expect(headers.get("apikey")).toBe("legacy-service-jwt");
-      expect(headers.get("authorization")).toBe("Bearer legacy-service-jwt");
+      expect(headers.get("apikey")).toBe("short-lived-es256-jwt");
+      expect(headers.get("authorization")).toBe("Bearer short-lived-es256-jwt");
+      expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
+      expect(serviceRoleSigner).toHaveBeenCalledWith("proj_1");
+    });
+  });
+
+  test("reuses one signed service-role token for opaque apikey and bearer headers", async () => {
+    await withSdkProxyTestContext(async ({ trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
+          ref: "proj_1",
+          kind: "secret",
+          role: "service_role",
+          upstreamKey: "legacy-service-jwt",
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("short-lived-es256-jwt"),
+      );
+      const headers = new Headers({
+        apikey: "sb_secret_client_key",
+        authorization: "Bearer sb_secret_client_key",
+      });
+
+      expect(await sdkProxyInternals.translateOpaqueApiKeyHeaders(headers, "proj_1")).toBe(true);
+      expect(headers.get("apikey")).toBe("short-lived-es256-jwt");
+      expect(headers.get("authorization")).toBe("Bearer short-lived-es256-jwt");
+      expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("keeps a user bearer while signing an opaque service-role apikey", async () => {
+    await withSdkProxyTestContext(async ({ trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
+          ref: "proj_1",
+          kind: "secret",
+          role: "service_role",
+          upstreamKey: "legacy-service-jwt",
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("short-lived-es256-jwt"),
+      );
+      const headers = new Headers({
+        apikey: "sb_secret_client_key",
+        authorization: "Bearer user.session.jwt",
+      });
+
+      expect(await sdkProxyInternals.translateOpaqueApiKeyHeaders(headers, "proj_1")).toBe(true);
+      expect(headers.get("apikey")).toBe("short-lived-es256-jwt");
+      expect(headers.get("authorization")).toBe("Bearer user.session.jwt");
+      expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("re-signs a paired same-project legacy service-role credential", async () => {
+    await withSdkProxyTestContext(async ({ trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
+          ref: "proj_1",
+          kind: "service_role",
+          role: "service_role",
+          upstreamKey: "legacy-service-jwt",
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("short-lived-es256-jwt"),
+      );
+      const headers = new Headers({
+        apikey: "legacy-service-jwt",
+        authorization: "Bearer legacy-service-jwt",
+      });
+
+      expect(await sdkProxyInternals.translateOpaqueApiKeyHeaders(headers, "proj_1")).toBe(true);
+      expect(headers.get("apikey")).toBe("short-lived-es256-jwt");
+      expect(headers.get("authorization")).toBe("Bearer short-lived-es256-jwt");
+      expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("rejects another project's service-role key before signing or proxying", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
+          ref: "proj_2",
+          kind: "secret",
+          role: "service_role",
+          upstreamKey: "project-2-service-jwt",
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("must-not-be-used"),
+      );
+      setSdkProxySqlForTests(async (...args: unknown[]) => String(args[0] ?? "").includes("SELECT config")
+        ? [{ config: { postgrest_port: 7361, gotrue_port: 8361 } }]
+        : []);
+
+      const response = await request("/rest/v1/widgets", {
+        headers: { apikey: "sb_secret_project_2_key" },
+      });
+
+      expect(response.status).toBe(401);
+      expect(calls).toHaveLength(0);
+      expect(serviceRoleSigner).not.toHaveBeenCalled();
+    });
+  });
+
+  test("rejects a service-role key when project signing material is unavailable", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
+          ref: "proj_1",
+          kind: "secret",
+          role: "service_role",
+          upstreamKey: "legacy-service-jwt",
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue(null),
+      );
+      setSdkProxySqlForTests(async (...args: unknown[]) => String(args[0] ?? "").includes("SELECT config")
+        ? [{ config: { postgrest_port: 7361, gotrue_port: 8361 } }]
+        : []);
+
+      const response = await request("/rest/v1/widgets", {
+        headers: { apikey: "sb_secret_client_key" },
+      });
+
+      expect(response.status).toBe(401);
+      expect(calls).toHaveLength(0);
+      expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -710,12 +710,15 @@ describe("sdkProxyRoutes functions proxy", () => {
   test("keeps a user bearer while signing an opaque service-role apikey", async () => {
     await withSdkProxyTestContext(async ({ trackSpy }) => {
       trackSpy(
-        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
-          ref: "proj_1",
-          kind: "secret",
-          role: "service_role",
-          upstreamKey: "legacy-service-jwt",
-        }),
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockImplementation(async (candidate: string) =>
+          candidate === "sb_secret_client_key"
+            ? {
+                ref: "proj_1",
+                kind: "secret",
+                role: "service_role",
+                upstreamKey: "legacy-service-jwt",
+              }
+            : null),
       );
       const serviceRoleSigner = trackSpy(
         spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("short-lived-es256-jwt"),
@@ -753,6 +756,137 @@ describe("sdkProxyRoutes functions proxy", () => {
       expect(await sdkProxyInternals.translateOpaqueApiKeyHeaders(headers, "proj_1")).toBe(true);
       expect(headers.get("apikey")).toBe("short-lived-es256-jwt");
       expect(headers.get("authorization")).toBe("Bearer short-lived-es256-jwt");
+      expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("rejects a cross-project legacy service-role bearer paired with an anon apikey", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockImplementation(async (candidate: string) => {
+          if (candidate === "sb_publishable_project_1_key") {
+            return {
+              ref: "proj_1",
+              kind: "publishable",
+              role: "anon",
+              upstreamKey: "project-1-anon-jwt",
+            };
+          }
+          if (candidate === "project-2-legacy-service-jwt") {
+            return {
+              ref: "proj_2",
+              kind: "service_role",
+              role: "service_role",
+              upstreamKey: candidate,
+            };
+          }
+          return null;
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("must-not-be-used"),
+      );
+      setSdkProxySqlForTests(async (...args: unknown[]) => String(args[0] ?? "").includes("SELECT config")
+        ? [{ config: { postgrest_port: 7361, gotrue_port: 8361 } }]
+        : []);
+
+      const response = await request("/rest/v1/widgets", {
+        headers: {
+          apikey: "sb_publishable_project_1_key",
+          authorization: "Bearer project-2-legacy-service-jwt",
+        },
+      });
+
+      expect(response.status).toBe(401);
+      expect(calls).toHaveLength(0);
+      expect(serviceRoleSigner).not.toHaveBeenCalled();
+    });
+  });
+
+  test("re-signs a standalone same-project legacy service-role bearer", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockImplementation(async (candidate: string) => {
+          if (candidate === "sb_publishable_project_1_key") {
+            return {
+              ref: "proj_1",
+              kind: "publishable",
+              role: "anon",
+              upstreamKey: "project-1-anon-jwt",
+            };
+          }
+          if (candidate === "project-1-legacy-service-jwt") {
+            return {
+              ref: "proj_1",
+              kind: "service_role",
+              role: "service_role",
+              upstreamKey: candidate,
+            };
+          }
+          return null;
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue("short-lived-es256-jwt"),
+      );
+      setSdkProxySqlForTests(async (...args: unknown[]) => String(args[0] ?? "").includes("SELECT config")
+        ? [{ config: { postgrest_port: 7361, gotrue_port: 8361 } }]
+        : []);
+
+      const response = await request("/rest/v1/widgets", {
+        headers: {
+          apikey: "sb_publishable_project_1_key",
+          authorization: "Bearer project-1-legacy-service-jwt",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      const headers = new Headers(calls[0]?.init?.headers);
+      expect(headers.get("apikey")).toBe("project-1-anon-jwt");
+      expect(headers.get("authorization")).toBe("Bearer short-lived-es256-jwt");
+      expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("rejects a standalone legacy service-role bearer when signing material is unavailable", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockImplementation(async (candidate: string) => {
+          if (candidate === "sb_publishable_project_1_key") {
+            return {
+              ref: "proj_1",
+              kind: "publishable",
+              role: "anon",
+              upstreamKey: "project-1-anon-jwt",
+            };
+          }
+          if (candidate === "project-1-legacy-service-jwt") {
+            return {
+              ref: "proj_1",
+              kind: "service_role",
+              role: "service_role",
+              upstreamKey: candidate,
+            };
+          }
+          return null;
+        }),
+      );
+      const serviceRoleSigner = trackSpy(
+        spyOn(sdkProxyInternals, "resolveProjectServiceRoleKey").mockResolvedValue(null),
+      );
+      setSdkProxySqlForTests(async (...args: unknown[]) => String(args[0] ?? "").includes("SELECT config")
+        ? [{ config: { postgrest_port: 7361, gotrue_port: 8361 } }]
+        : []);
+
+      const response = await request("/rest/v1/widgets", {
+        headers: {
+          apikey: "sb_publishable_project_1_key",
+          authorization: "Bearer project-1-legacy-service-jwt",
+        },
+      });
+
+      expect(response.status).toBe(401);
+      expect(calls).toHaveLength(0);
       expect(serviceRoleSigner).toHaveBeenCalledTimes(1);
     });
   });
@@ -814,12 +948,15 @@ describe("sdkProxyRoutes functions proxy", () => {
   test("REST proxy preserves a user JWT while translating the publishable apikey", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
       trackSpy(
-        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
-          ref: "proj_1",
-          kind: "publishable",
-          role: "anon",
-          upstreamKey: "legacy-anon-jwt",
-        }),
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockImplementation(async (candidate: string) =>
+          candidate === "sb_publishable_client_key"
+            ? {
+                ref: "proj_1",
+                kind: "publishable",
+                role: "anon",
+                upstreamKey: "legacy-anon-jwt",
+              }
+            : null),
       );
       setSdkProxySqlForTests(async (...args: unknown[]) => {
         const text = String(args[0] ?? "");
@@ -846,12 +983,15 @@ describe("sdkProxyRoutes functions proxy", () => {
   test("GraphQL proxy translates an opaque key and preserves the user JWT", async () => {
     await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
       trackSpy(
-        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockResolvedValue({
-          ref: "proj_1",
-          kind: "publishable",
-          role: "anon",
-          upstreamKey: "legacy-anon-jwt",
-        }),
+        spyOn(sdkProxyInternals, "resolveProjectApiKey").mockImplementation(async (candidate: string) =>
+          candidate === "sb_publishable_client_key"
+            ? {
+                ref: "proj_1",
+                kind: "publishable",
+                role: "anon",
+                upstreamKey: "legacy-anon-jwt",
+              }
+            : null),
       );
       setSdkProxySqlForTests(async (...args: unknown[]) => {
         const text = String(args[0] ?? "");


### PR DESCRIPTION
## Summary

- bind proxied credentials to the resolved project and role before translation
- replace same-project service-role credentials with a lazily signed key and memoize the signer per request
- resolve every non-empty Bearer so legacy service-role credentials cannot bypass project binding
- preserve unknown user Bearer JWTs while translating opaque service apikey headers
- fail closed for wrong-project, dependent shared-auth service-role, and missing signing material

## Security properties

- service-role signing occurs only after project and role resolution
- dependent projects cannot upgrade service-role credentials into owner admin credentials
- paired apikey and Bearer service-role headers receive the exact same signed token
- standalone legacy service-role Bearers are project-bound and re-signed
- unknown non-opaque user JWTs remain unchanged
- no JWK, TTL, signer, secret storage, or production configuration changes

## Verification

- bun test tests/unit/service-role.test.ts tests/unit/sdk-proxy.functions.test.ts (41 pass, 0 fail, 152 expect)
- bun run test:unit
- bun run typecheck
- bun run sql:check
- Linux amd64 compile
- git diff --check
- independent verifier: PASS
- clean-code-guard: clean