### PR TITLE
fix(install): do not roll back management API on transient systemctl start exit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2959,8 +2959,18 @@ install_management_api() {
     if (( activation_status == 0 )); then
         systemctl enable supacloud || activation_status=$?
     fi
+    # supacloud.service is Type=simple with Restart=always. The management API
+    # spawns the embedded Edge Runtime, PgListener, and several workers during boot;
+    # a transient first-exit (e.g. Edge Runtime crash before dependencies settle) makes
+    # `systemctl start` return non-zero even though systemd auto-restarts the unit and
+    # the service becomes healthy seconds later. Capturing that immediate exit code as
+    # activation_status short-circuits the 30s health retry that follows and rolls back
+    # a binary that was about to come up, leaving installs stuck on the previous version.
+    #
+    # For a Restart=always unit the authoritative readiness signal is the health probe
+    # below, so do not treat a non-zero synchronous start exit as fatal here.
     if (( activation_status == 0 )); then
-        systemctl start supacloud || activation_status=$?
+        systemctl start supacloud || log_warn "systemctl start supacloud returned non-zero (Type=simple + Restart=always); deferring readiness to the health check"
     fi
     if (( activation_status == 0 )); then
         supacloud_wait_http_health http://127.0.0.1:9090/health || activation_status=$?


### PR DESCRIPTION
## Problem

`install_management_api()` activates the staged binary like this:

```bash
systemctl start supacloud || activation_status=$?
if (( activation_status == 0 )); then
    supacloud_wait_http_health http://127.0.0.1:9090/health || activation_status=$?
fi
if (( activation_status != 0 )); then
    recover_management_api_install ...   # roll back to previous binary
fi
```

`supacloud.service` is `Type=simple` with `Restart=always`. During boot the management API spawns the embedded Edge Runtime, PgListener, task workers, background function workers, etc. A transient first-exit (e.g. the Edge Runtime process exiting once before elysia/node_modules settle, or a PgListener connection racing listener setup) makes the main process exit briefly, so `systemctl start` returns non-zero even though systemd auto-restarts the unit and the service becomes healthy a few seconds later.

Capturing that immediate exit code as `activation_status` short-circuits the 30s health retry in `supacloud_wait_http_health` (it is guarded by `if (( activation_status == 0 ))` and therefore never runs), so the install declares activation failed and rolls the newly placed binary back to the previous version.

## Symptom observed during upgrade

Upgrading 0.45.1 -> 0.47.4: the management API came up cleanly (health ok within seconds, Edge Runtime logging \`🚀 on 127.0.0.1:9000 (4 workers)\`), but install.sh had already rolled the 0.47.4 binary back to 0.45.1 because \`systemctl start\` returned non-zero on a transient boot exit. The install reported "Management API activation failed; the previous binary was restored" even though the new binary would have been healthy moments later.

## Fix

For a `Restart=always` unit the authoritative readiness signal is the health probe. Stop treating a non-zero synchronous \`systemctl start\` exit as fatal: log it as a warning and still run the health check, which preserves the existing retry + rollback semantics for genuinely broken activations.

```diff
     if (( activation_status == 0 )); then
-        systemctl start supacloud || activation_status=$?
+        systemctl start supacloud || log_warn "systemctl start supacloud returned non-zero (Type=simple + Restart=always); deferring readiness to the health check"
     fi
     if (( activation_status == 0 )); then
         supacloud_wait_http_health http://127.0.0.1:9090/health || activation_status=$?
     fi
```

`daemon-reload`, `enable`, and the post-health rollback path are unchanged.

Verified in production on an AlmaLinux 10.1 host during a real 0.45.1 -> 0.47.4 upgrade.