### PR TITLE
fix(install): set STUDIO_INTERNAL to the management API port by default

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2841,6 +2841,7 @@ install_management_api() {
     if ! supacloud_write_service_env_pairs "$MANAGEMENT_ENV_FILE" \
         PORT 9090 \
         MANAGEMENT_API_URL http://127.0.0.1:9090 \
+        STUDIO_INTERNAL "${STUDIO_INTERNAL:-127.0.0.1:9090}" \
         DATABASE_URL "postgresql://postgres:${encoded_postgres_password}@127.0.0.1:5432/supacloud_meta" \
         EDGE_RUNTIME_MODE "${EDGE_RUNTIME_MODE:-embedded}" \
         MASTER_TOKEN "$MASTER_TOKEN" \


### PR DESCRIPTION
## Problem

The management API serves the Web Console (Studio UI) itself via a try_files static-asset handler registered on its own HTTP port (\`packages/management-api/src/index.ts\`: \`registerStaticAssets()\`, served from the web-console dir resolved by \`getWebConsoleDir()\`). install.sh deploys the web-console archive under \`/opt/supacloud/web-console/current\` for exactly this in-process serving mode.

But \`packages/management-api/src/config.ts\` defaults \`STUDIO_INTERNAL\` to \`127.0.0.1:3000\`:

\`\`\`ts
studioInternal: getEnv(\"STUDIO_INTERNAL\", \"127.0.0.1:3000\"),
\`\`\`

and install.sh never wrote \`STUDIO_INTERNAL\` into \`management-api.env\`, so the default \`3000\` took effect. \`bun run src/cli.ts setup-studio-domain <domain>\` reads \`config.studioInternal\` to decide the studio route upstream, so the studio host was bound to \`127.0.0.1:3000\` instead of the management API port.

## Symptom observed during install

On hosts that also run Pigsty (which runs Grafana on \`:3000\`), the studio domain transparently returned **Grafana's UI** instead of the SupaCloud console, with no error anywhere — \`studio.<domain>\` was 200 OK, just the wrong app. On hosts where \`:3000\` is simply unused, the studio route pointed at a dead port.

## Fix

install.sh already manages the rest of the management API env (\`PORT\`, \`MANAGEMENT_API_URL\`, ...). Add \`STUDIO_INTERNAL\` there too, defaulting to the management API port (\`127.0.0.1:9090\`, matching \`PORT\`) while still honouring an explicit \`STUDIO_INTERNAL\` from the install environment for deployments that really do run a separate web-console container on 3000:

\`\`\`diff
     if ! supacloud_write_service_env_pairs \"\$MANAGEMENT_ENV_FILE\" \\\\
         PORT 9090 \\\\
         MANAGEMENT_API_URL http://127.0.0.1:9090 \\\\
+        STUDIO_INTERNAL \"\${STUDIO_INTERNAL:-127.0.0.1:9090}\" \\\\
         DATABASE_URL \"postgresql://postgres:\${encoded_postgres_password}@127.0.0.1:5432/supacloud_meta\" \\\\
\`\`\`

## Verification

During a fresh AlmaLinux 10 install: with \`STUDIO_INTERNAL\` unset, \`setup-studio-domain\` bound \`studio.<domain>\` to \`127.0.0.1:3000\` and requests hit Grafana. After setting \`STUDIO_INTERNAL=127.0.0.1:9090\` and re-binding, the studio domain served the SupaCloud console.

Note: the \`config.ts\` default of \`3000\` is intentionally left unchanged here — it is correct for the containerized web-console mode. The install.sh fix makes the in-process serving mode (which is what install.sh deploys) correct without breaking the container mode, since an explicit \`STUDIO_INTERNAL\` is still respected.