### PR TITLE
fix(install): auto-bind the configured Studio domain after web-console deploy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3128,6 +3128,27 @@ install_web_console() {
 
     if [[ -f "$WEB_CONSOLE_DIR/index.html" ]]; then
         log_info "Web Console (Studio UI) installed successfully"
+
+        # Bind the configured Studio domain to the gateway so the console is
+        # reachable at https://<SUPABASE_STUDIO_DOMAIN> without a manual
+        # `bun run src/cli.ts setup-studio-domain` step. Mirrors the CLI
+        # command (setupMasterRoutes + configureFrontendRoute for the
+        # _global/studio frontend) and is idempotent.
+        # Best-effort: a failure here only means the operator must bind by
+        # hand, so it must never abort the install.
+        if [[ -n "${SUPABASE_STUDIO_DOMAIN:-}" ]] && systemctl is-active --quiet supacloud; then
+            local mgmt_src_dir="${SCRIPT_DIR}/packages/management-api"
+            if [[ -d "$mgmt_src_dir" ]] && command -v bun &> /dev/null; then
+                log_info "Binding Studio domain ${SUPABASE_STUDIO_DOMAIN} to the gateway..."
+                if (cd "$mgmt_src_dir" && bun run src/cli.ts setup-studio-domain "$SUPABASE_STUDIO_DOMAIN"); then
+                    log_info "Studio domain ${SUPABASE_STUDIO_DOMAIN} bound"
+                else
+                    log_warn "Studio domain auto-bind failed; bind manually via setup-studio-domain"
+                fi
+            else
+                log_warn "Studio domain ${SUPABASE_STUDIO_DOMAIN} not auto-bound (management-api source or bun missing)"
+            fi
+        fi
     else
         log_warn "Web Console deployment incomplete - index.html not found"
     fi


### PR DESCRIPTION
## Problem

install.sh collects \`SUPABASE_STUDIO_DOMAIN\` (via \`--studio\` or the interactive prompt, defaulting to \`studio.<base-domain>\`) and \`deploy_web_console()\` places the Web Console under \`/opt/supacloud/web-console/current\`, but **nothing in the install flow ever binds that domain to the Caddy gateway**. The binding only exists as a standalone CLI command:

\`\`\`
bun run src/cli.ts setup-studio-domain <domain>
\`\`\`

which an operator has no reason to know about.

## Symptom observed during install

A fresh install leaves \`studio.<domain>\` returning 404 (the host falls through to the \`route-system-unmatched-host-404\` route) until someone discovers and runs that command by hand. The caddy on-demand TLS ask endpoint even returns \`domain not allowed\` for the studio host because it was never registered. The \`cli.ts\` output even tells the operator to \"point your DNS A record for <domain> to this server's IP address\", implying it should just work end-to-end.

## Fix

After the Web Console is successfully deployed, run the same \`setup-studio-domain\` binding automatically when \`SUPABASE_STUDIO_DOMAIN\` is set and the management API is already active:

\`\`\`bash
if [[ -n \"\${SUPABASE_STUDIO_DOMAIN:-}\" ]] && systemctl is-active --quiet supacloud; then
    local mgmt_src_dir=\"\${SCRIPT_DIR}/packages/management-api\"
    if [[ -d \"\$mgmt_src_dir\" ]] && command -v bun &> /dev/null; then
        log_info \"Binding Studio domain \${SUPABASE_STUDIO_DOMAIN} to the gateway...\"
        if (cd \"\$mgmt_src_dir\" && bun run src/cli.ts setup-studio-domain \"\$SUPABASE_STUDIO_DOMAIN\"); then
            log_info \"Studio domain \${SUPABASE_STUDIO_DOMAIN} bound\"
        else
            log_warn \"Studio domain auto-bind failed; bind manually via setup-studio-domain\"
        fi
    else
        log_warn \"Studio domain \${SUPABASE_STUDIO_DOMAIN} not auto-bound (management-api source or bun missing)\"
    fi
fi
\`\`\`

The call is idempotent (it just upserts the \`_global/studio\` frontend route via \`configureFrontendRoute\`) and best-effort: a failure only logs a warning pointing at the manual command, so it cannot abort an otherwise successful install.

## Verification

During a fresh AlmaLinux 10 install: without this step \`studio.xai.xigu.team\` returned 404; after running \`setup-studio-domain\` the host served the SupaCloud console (HTTP 200, correct SvelteKit entry assets).

## Related

Pairs naturally with #509 (STUDIO_INTERNAL default), since \`setup-studio-domain\` reads \`config.studioInternal\` to decide the upstream — but each fix is independently correct.