### PR TITLE
fix(install): ensure management scripts are executable in-place

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2760,16 +2760,21 @@ install_management_api() {
     # 2. Copy management scripts
     if [[ -d "${SCRIPT_DIR}/scripts" ]] && [[ "${SCRIPT_DIR}/scripts" != "$ROOT_SCRIPTS_INSTALL_DIR" ]]; then
         find "${SCRIPT_DIR}/scripts" -maxdepth 1 -type f -name '*.sh' -exec cp {} "$ROOT_SCRIPTS_INSTALL_DIR/" \;
-        chmod +x "$ROOT_SCRIPTS_INSTALL_DIR"/*.sh
         log_info "Management scripts ready: $ROOT_SCRIPTS_INSTALL_DIR"
     fi
+    # Ensure scripts are executable regardless of the copy path: a git checkout
+    # leaves .sh files at 0644, which breaks systemd ExecStartPre for
+    # pre_start_recovery.sh (status=203/EXEC, Permission denied) in the common
+    # in-place case where SCRIPT_DIR/scripts == ROOT_SCRIPTS_INSTALL_DIR and the
+    # copy above is (correctly) skipped.
+    chmod +x "$ROOT_SCRIPTS_INSTALL_DIR"/*.sh 2>/dev/null || true
 
     # 2b. Copy management script libraries (Pigsty adapter)
     if [[ -d "${SCRIPT_DIR}/scripts/lib" ]] && [[ "${SCRIPT_DIR}/scripts/lib" != "$SCRIPTS_INSTALL_DIR" ]]; then
         cp -rf "${SCRIPT_DIR}/scripts/lib/"* "$SCRIPTS_INSTALL_DIR/"
-        chmod +x "$SCRIPTS_INSTALL_DIR"/*.sh
         log_info "Underlying script link ready: $SCRIPTS_INSTALL_DIR"
     fi
+    chmod +x "$SCRIPTS_INSTALL_DIR"/*.sh 2>/dev/null || true
 
     # 2c. Copy database schema files (required for project provisioning)
     local SCHEMA_SRC="${SCRIPT_DIR}/packages/management-api/src/db/schemas"


### PR DESCRIPTION
## Problem

\`install_management_api()\` deploys management scripts with a src!=dst guard, the same shape as the schema copy fixed earlier:

\`\`\`bash
if [[ -d \"\${SCRIPT_DIR}/scripts\" ]] && [[ \"\${SCRIPT_DIR}/scripts\" != \"\$ROOT_SCRIPTS_INSTALL_DIR\" ]]; then
    find ... -exec cp {} \"\$ROOT_SCRIPTS_INSTALL_DIR/\" \\;
    chmod +x \"\$ROOT_SCRIPTS_INSTALL_DIR\"/*.sh
fi
\`\`\`

\`ROOT_SCRIPTS_INSTALL_DIR\` is \`/opt/supacloud/scripts\`, and for the standard in-place install where the repo is checked out at \`/opt/supacloud\`, \`\${SCRIPT_DIR}/scripts\` is also \`/opt/supacloud/scripts\`. The inequality guard is therefore **always false**, so the whole block — including \`chmod +x\` — is skipped.

## Symptom

A git checkout leaves \`.sh\` files at 0644 unless the executable bit is stored in the index. \`supacloud.service\` has:

\`\`\`ini
ExecStartPre=/opt/supacloud/scripts/pre_start_recovery.sh
\`\`\`

So on a fresh in-place install ExecStartPre fails with \`status=203/EXEC (Permission denied)\`, the unit fails to start, and the install declares management-API activation failed even though the binary itself is fine. This was masked on some hosts by an earlier restart eventually succeeding, but it makes the activation path flaky and triggers spurious rollbacks.

The same src==dst shape affects the \`scripts/lib\` copy block.

## Fix

Move \`chmod +x\` out of the conditional so it runs regardless of whether the copy happened. The copy itself stays conditional to avoid copying a directory into itself:

\`\`\`diff
     if [[ -d \"\${SCRIPT_DIR}/scripts\" ]] && [[ \"\${SCRIPT_DIR}/scripts\" != \"\$ROOT_SCRIPTS_INSTALL_DIR\" ]]; then
         find ... -exec cp {} \"\$ROOT_SCRIPTS_INSTALL_DIR/\" \\;
-        chmod +x \"\$ROOT_SCRIPTS_INSTALL_DIR\"/*.sh
         log_info \"Management scripts ready: \$ROOT_SCRIPTS_INSTALL_DIR\"
     fi
+    chmod +x \"\$ROOT_SCRIPTS_INSTALL_DIR\"/*.sh 2>/dev/null || true
\`\`\`

\`chmod\` is idempotent and harmless when files are already executable, so this is safe for both in-place and out-of-tree installs. Same treatment for \`scripts/lib\`.

## Verification

Fresh AlmaLinux 10.1 install: \`pre_start_recovery.sh\` was \`-rw-r--r--\` after git checkout; \`systemctl start supacloud\` failed with \`203/EXEC Permission denied\` at ExecStartPre. After \`chmod +x\` the unit started cleanly and health check passed.

## Related

Same class of src==dst bug as the schema copy fix merged earlier; these guards consistently need their side effects (chmod / deploy) to run unconditionally while only the copy itself stays conditional.