### PR TITLE
fix(install): detect podman before docker to avoid podman-docker misclassification

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -999,13 +999,20 @@ enable_ksm_optimization() {
 install_container_runtime() {
     log_step "Checking container runtime..."
     
-    # Check for Docker or Podman
-    if command -v docker &> /dev/null; then
-        log_info "Docker installed: $(docker --version)"
-        CONTAINER_RUNTIME="docker"
-    elif command -v podman &> /dev/null; then
+    # Check for Podman first, then Docker. The podman-docker package installs a
+    # /usr/bin/docker shim that forwards to podman, so on hosts that use podman
+    # (with the podman-docker alias for docker-CLI compatibility) `command -v docker`
+    # succeeds even though podman is the real runtime. Detecting docker first
+    # misclassifies such hosts as docker, skips setup_podman_socket, and then runs
+    # Pigsty's docker.yml which tries to install docker-ce and conflicts with the
+    # already-installed podman-docker package. Podman is the authoritative runtime
+    # whenever it is present, so check it first.
+    if command -v podman &> /dev/null; then
         log_info "Podman installed: $(podman --version)"
         CONTAINER_RUNTIME="podman"
+    elif command -v docker &> /dev/null; then
+        log_info "Docker installed: $(docker --version)"
+        CONTAINER_RUNTIME="docker"
     else
         log_warn "Container runtime not detected, installing Podman"
         install_podman


### PR DESCRIPTION
## Problem

\`install_container_runtime()\` checked docker first:

\`\`\`bash
if command -v docker &> /dev/null; then
    CONTAINER_RUNTIME=\"docker\"
elif command -v podman &> /dev/null; then
    CONTAINER_RUNTIME=\"podman\"
\`\`\`

The \`podman-docker\` package (commonly installed on RHEL-family hosts that use podman, exactly to provide docker-CLI compatibility) ships a \`/usr/bin/docker\` shim that forwards every invocation to podman. On such hosts \`command -v docker\` succeeds even though podman is the real runtime, so the check above classifies the host as **docker**.

## Consequences

- \`setup_podman_socket\` is skipped (the \`CONTAINER_RUNTIME == \"podman\"\` branch never runs), so podman's API socket is not prepared.
- \`install_pigsty()\` then runs Pigsty's \`docker.yml\`, which tries to install \`docker-ce\`. \`docker-ce\` conflicts with the already-installed \`podman-docker\` package:
  \`\`\`
  Depsolve Error: package podman-docker-7:5.8.2-5.el10_2.noarch conflicts with docker-ce provided by docker-ce-3:29.6.2-1.el10.x86_64
  \`\`\`
- \`deploy_service_containers()\` uses \`CONTAINER_RUNTIME\` to drive the runtime; picking docker on a podman host routes container operations through the emulation shim instead of podman directly.

## Fix

Podman is the authoritative runtime whenever it is present (the podman-docker shim cannot function without podman), so check podman first and only fall back to docker when podman is absent:

\`\`\`diff
-    if command -v docker &> /dev/null; then
-        CONTAINER_RUNTIME=\"docker\"
-    elif command -v podman &> /dev/null; then
+    if command -v podman &> /dev/null; then
         CONTAINER_RUNTIME=\"podman\"
+    elif command -v docker &> /dev/null; then
+        CONTAINER_RUNTIME=\"docker\"
\`\`\`

## Verification

AlmaLinux 10.1 host with \`podman-docker\` installed: with the old order, \`CONTAINER_RUNTIME\` was misdetected as \`docker\` and \`docker.yml\` failed with the podman-docker/docker-ce conflict. Setting \`CONTAINER_RUNTIME=podman\` explicitly made install.sh skip \`docker.yml\` and proceed cleanly — which is exactly what this reorder now does automatically.