### PR TITLE
fix(install): replace stale symlink before mkdir of tenants config dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3059,7 +3059,18 @@ GOTRUE_SVC
         log_info "supacloud-gotrue@.service template already exists"
     fi
 
-    # Ensure tenant config directory exists
+    # Ensure tenant config directory exists. A previous Pigsty/legacy-supabase
+    # install may have left /etc/supabase/tenants as a symlink whose target no
+    # longer exists (e.g. pointing at a removed /opt/supabase/volumes/... path).
+    # `mkdir -p` on a path that traverses a dangling symlink fails with
+    # "File exists" (EEXIST) and, under `set -e`, aborts the whole install right
+    # after the management API has come up. If the entry exists but is not a
+    # directory, remove it first so mkdir can create a real directory in its
+    # place; never touch an already-valid directory.
+    if [[ -e /etc/supabase/tenants || -L /etc/supabase/tenants ]] && [[ ! -d /etc/supabase/tenants ]]; then
+        log_warn "Replacing non-directory entry at /etc/supabase/tenants (likely a stale symlink) before creating the tenant config directory"
+        rm -f /etc/supabase/tenants
+    fi
     mkdir -p /etc/supabase/tenants
 
     # 8. Configure non-secret CLI conveniences without overwriting DOCKER_HOST.


### PR DESCRIPTION
## Problem

\`install_management_api()\` ends with:

\`\`\`bash
mkdir -p /etc/supabase/tenants
\`\`\`

right after logging \`SupaCloud Control Plane deployed successfully!\`. On hosts that previously ran Pigsty's legacy Supabase compose stack, \`/etc/supabase/tenants\` is frequently a **symlink** to a compose volume path (e.g. \`/opt/supabase/volumes/api/kong_tenants\`) that no longer exists after the legacy stack is removed.

\`mkdir -p\` following a dangling symlink fails with \`EEXIST\` (\`File exists\`) and, because install.sh runs under \`set -e\`, this aborts the whole install immediately after the management API came up — before \`install_web_console()\`, \`deploy_service_containers()\`, and the rest of \`main()\` can run.

## Symptom

\`\`\`
[INFO] SupaCloud Control Plane deployed successfully!
mkdir: 无法创建目录 \"/etc/supabase/tenants\": 文件已存在
\`\`\`

(The Chinese message is \`mkdir: cannot create directory: File exists\`.) \`install.sh\` exits here, leaving the install visibly incomplete even though the core management API is healthy.

## Fix

Detect the pathological case explicitly: if the entry exists (or is a symlink — including a dangling one, where \`-e\` is false but \`-L\` is true) and is not a directory, remove it and let \`mkdir\` create a real directory. A valid existing directory is never touched:

\`\`\`bash
if [[ -e /etc/supabase/tenants || -L /etc/supabase/tenants ]] && [[ ! -d /etc/supabase/tenants ]]; then
    log_warn \"Replacing non-directory entry at /etc/supabase/tenants (likely a stale symlink) ...\"
    rm -f /etc/supabase/tenants
fi
mkdir -p /etc/supabase/tenants
\`\`\`

## Verification

AlmaLinux 10.1 host where \`/etc/supabase/tenants\` was a broken symlink to \`/opt/supabase/volumes/api/kong_tenants\`: \`mkdir -p\` failed with \`EEXIST\` and aborted install.sh right after \`Control Plane deployed successfully\`. After removing the dangling symlink, the directory was created and the install proceeded to \`install_web_console\`.