### PR TITLE
fix(install): pin postgres user for pigsty-4.4 compat invocation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3649,7 +3649,11 @@ main() {
     # Install Management API
     install_management_api
     if [[ -f "${SCRIPT_DIR}/scripts/upgrade_pigsty_4_4_compat.sh" ]]; then
-        PGHOST="${PGHOST:-}" PGPORT="${PGPORT:-5432}" PGUSER="${PGUSER:-postgres}" \
+        # Pigsty exports PGUSER=dbuser_dba globally; ${PGUSER:-postgres} would inherit the
+        # wrong DBA role and make the compat script authenticate as dbuser_dba (auth fail
+        # on 127.0.0.1), aborting before install_web_console ever runs. Pin the superuser
+        # explicitly so role/password checks use postgres regardless of the shell env.
+        PGHOST=127.0.0.1 PGPORT=5432 PGUSER=postgres \
             PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}" \
             bash "${SCRIPT_DIR}/scripts/upgrade_pigsty_4_4_compat.sh" --apply
     fi


### PR DESCRIPTION
## Problem

On any host provisioned by Pigsty, the shell environment exports \`PGUSER=dbuser_dba\` (Pigsty's default DBA role, set in its env template). \`install.sh\` invoked the pigsty-4.4 compat script with:

\`\`\`bash
PGHOST=\"\${PGHOST:-}\" PGPORT=\"\${PGPORT:-5432}\" PGUSER=\"\${PGUSER:-postgres}\" \\
    PGPASSWORD=\"\${PGPASSWORD:-\$POSTGRES_PASSWORD}\" \\
    bash \"\${SCRIPT_DIR}/scripts/upgrade_pigsty_4_4_compat.sh\" --apply
\`\`\`

Because \`PGUSER\` was already \`dbuser_dba\` in the environment, the \`\${PGUSER:-postgres}\` fallback never applied. The compat script's \`run_psql\` then connected as **dbuser_dba** to \`127.0.0.1:5432\`, failed password authentication, and \`apply_analytics_database()\` reported:

\`\`\`
psql: error: connection to server at \"127.0.0.1\", port 5432 failed: FATAL: password authentication failed for user \"dbuser_dba\"
Required Analytics owner role does not exist: supabase_admin
\`\`\`

Since the compat script runs under \`set -euo pipefail\`, this aborted the **entire install** right after \`install_management_api\` — before \`install_web_console\` ran.

## Impact

This silently disabled everything after the control-plane deploy on every real Pigsty install, most notably **PR #510 (auto-bind Studio domain) never executed**, so the Studio domain was never bound automatically. The bug is invisible unless you trace the compat invocation, because the failure message looks like a database/credential issue rather than a wrong-username issue.

## Reproduction

\`\`\`
# On a Pigsty host (PGUSER=dbuser_dba is in the base env):
$ env | grep ^PG
PGUSER=dbuser_dba
PGPORT=5432
...
# Reproduce the install-time failure exactly:
$ cd /opt/supacloud
$ PGHOST= PGPORT=5432 PGUSER=\${PGUSER:-postgres} PGPASSWORD=SupaCloud.2026 \\
    bash scripts/upgrade_pigsty_4_4_compat.sh --apply
=> FATAL: password authentication failed for user \"dbuser_dba\"
# With the explicit superuser it passes:
$ PGHOST=127.0.0.1 PGPORT=5432 PGUSER=postgres PGPASSWORD=SupaCloud.2026 \\
    bash scripts/upgrade_pigsty_4_4_compat.sh --apply
=> [PASS] Analytics isolated at _supabase._analytics  (and all checks pass)
\`\`\`

## Fix

Pin the connection explicitly so it does not depend on the inherited shell environment:

\`\`\`bash
PGHOST=127.0.0.1 PGPORT=5432 PGUSER=postgres \\
    PGPASSWORD=\"\${PGPASSWORD:-\$POSTGRES_PASSWORD}\" \\
    bash \"\${SCRIPT_DIR}/scripts/upgrade_pigsty_4_4_compat.sh\" --apply
\`\`\`

This matches the management-api's own connection (\`PG_User=postgres\`, \`PG_HOST=127.0.0.1\`) and is independent of Pigsty's global \`PGUSER=dbuser_dba\`.

## Verification

End-to-end re-run of \`install.sh\` on an AlmaLinux 10.1 + Pigsty host (192.168.200.112):
- compat script now passes: \`[PASS] Analytics isolated at _supabase._analytics\`
- install proceeds to \`install_web_console\` → \`Binding Studio domain … bound\` (#510 fires)
- install reaches \`SupaCloud Installed Successfully!\` with no manual workaround