### PR TITLE
fix(install): skip docker-compose re-download on podman when already installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1343,6 +1343,17 @@ install_docker_compose() {
     
     COMPOSE_VERSION="v5.3.1"
     
+    # The standalone binary is preferred on both Docker and Podman hosts. Skip
+    # re-downloading it when the target version is already present. Previously the
+    # presence-check was gated on CONTAINER_RUNTIME != podman, so every Podman install
+    # re-fetched the ~31MB binary from GitHub even when it was already installed -- and
+    # behind flaky GitHub connectivity the download (curl SSL_ERROR_SYSCALL) aborted
+    # the whole install despite docker-compose being perfectly functional.
+    if command -v docker-compose &>/dev/null && docker-compose version 2>/dev/null | grep -q "${COMPOSE_VERSION}"; then
+        log_info "Docker Compose already installed: $(docker-compose --version)"
+        return
+    fi
+    
     # If using Podman, always install standalone docker-compose binary
     # (instead of relying on 'podman compose' which might have different behavior).
     # Compose v5 delegates BuildKit builds to Docker Buildx/Bake; this installer


### PR DESCRIPTION
## Problem

\`install_docker_compose()\` only skipped the standalone-binary re-download when \`CONTAINER_RUNTIME != podman\`:

\`\`\`bash
if [[ \"\${CONTAINER_RUNTIME:-}\" != \"podman\" ]] && command -v docker-compose &> /dev/null; then
    log_info \"Docker Compose already installed: ...\"
    return
fi
\`\`\`

The \`!= podman\` guard exists for a good reason (avoid misdetecting \`podman-compose\` as the docker plugin), but it had the side effect of disabling the **standalone binary** skip too. So under Podman (the runtime PR #512 correctly detects), every install re-fetched the ~31MB docker-compose binary from GitHub even when v5.3.1 was already installed at \`/usr/local/bin/docker-compose\`.

Behind flaky GitHub connectivity (common on internal/offline hosts) the \`curl\` download fails:

\`\`\`
curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 0
\`\`\`

and because \`install.sh\` runs under \`set -e\`, this **aborts the entire install** even though docker-compose is perfectly functional.

## Fix

Add a version-aware skip that runs for both Docker and Podman hosts, before the runtime-gated checks:

\`\`\`bash
if command -v docker-compose &>/dev/null && docker-compose version 2>/dev/null | grep -q \"\${COMPOSE_VERSION}\"; then
    log_info \"Docker Compose already installed: \$(docker-compose --version)\"
    return
fi
\`\`\`

If the standalone binary is already present at the target \`COMPOSE_VERSION\`, return early regardless of runtime. The existing \`!= podman\` plugin-detection logic below is preserved unchanged for the not-yet-installed case.

## Verification

On an AlmaLinux 10.1 + Podman host (192.168.200.112) where docker-compose v5.3.1 was already installed:

\`\`\`
[INFO] Docker Compose already installed: Docker Compose version v5.3.1
\`\`\`

The install now proceeds past this step instead of dying on the GitHub download.