### PR TITLE
fix(install): detect podman before docker to avoid podman-docker misc…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -999,13 +999,20 @@ enable_ksm_optimization() {
 install_container_runtime() {
     log_step "Checking container runtime..."
     
-    # Check for Docker or Podman
-    if command -v docker &> /dev/null; then
-        log_info "Docker installed: $(docker --version)"
-        CONTAINER_RUNTIME="docker"
-    elif command -v podman &> /dev/null; then
+    # Check for Podman first, then Docker. The podman-docker package installs a
+    # /usr/bin/docker shim that forwards to podman, so on hosts that use podman
+    # (with the podman-docker alias for docker-CLI compatibility) `command -v docker`
+    # succeeds even though podman is the real runtime. Detecting docker first
+    # misclassifies such hosts as docker, skips setup_podman_socket, and then runs
+    # Pigsty's docker.yml which tries to install docker-ce and conflicts with the
+    # already-installed podman-docker package. Podman is the authoritative runtime
+    # whenever it is present, so check it first.
+    if command -v podman &> /dev/null; then
         log_info "Podman installed: $(podman --version)"
         CONTAINER_RUNTIME="podman"
+    elif command -v docker &> /dev/null; then
+        log_info "Docker installed: $(docker --version)"
+        CONTAINER_RUNTIME="docker"
     else
         log_warn "Container runtime not detected, installing Podman"
         install_podman

--- a/packages/management-api/bun.lock
+++ b/packages/management-api/bun.lock
@@ -27,7 +27,7 @@
   },
   "overrides": {
     "@hono/node-server": "^2.0.5",
-    "fast-uri": "3.1.3",
+    "fast-uri": "3.1.4",
     "hono": "^4.12.26",
     "path-to-regexp": "^8.4.2",
   },
@@ -142,7 +142,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -50,7 +50,7 @@
     "typescript": "^7.0.2"
   },
   "overrides": {
-    "fast-uri": "3.1.3",
+    "fast-uri": "3.1.4",
     "hono": "^4.12.26",
     "@hono/node-server": "^2.0.5",
     "path-to-regexp": "^8.4.2"

--- a/packages/web-console/src/routes/project/[ref]/database/migrations/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/database/migrations/+page.svelte
@@ -23,7 +23,20 @@
       const res = await apiClient(`/v1/projects/${projectRef}/database/migrations`);
       const data = await res.json();
       if (!res.ok) throw new Error(data.message || data.error || "Failed to load migration history");
-      return (Array.isArray(data) ? data : []) as Migration[];
+      return (Array.isArray(data) ? data : []).map((row: Record<string, unknown>): Migration => {
+        const statements = Array.isArray(row.statements)
+          ? row.statements.filter((statement): statement is string => typeof statement === "string")
+          : [];
+
+        return {
+          version: String(row.version || ""),
+          name: typeof row.name === "string" ? row.name : null,
+          statements,
+          statement_count: Number(row.statement_count ?? statements.length),
+          checksum: typeof row.checksum === "string" ? row.checksum : "",
+          applied_at: typeof row.applied_at === "string" ? row.applied_at : null,
+        };
+      });
     }
   }));
 
@@ -76,7 +89,7 @@
             </tr>
           </thead>
           <tbody class="divide-y divide-border/20">
-            {#each migrations as mig}
+            {#each migrations as mig (mig.version)}
               <tr class="hover:bg-muted/10 transition-colors">
                 <td class="px-4 py-2.5">
                   <div class="flex items-center gap-2">

--- a/packages/web-console/src/routes/project/[ref]/database/migrations/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/database/migrations/+page.svelte
@@ -27,12 +27,15 @@
         const statements = Array.isArray(row.statements)
           ? row.statements.filter((statement): statement is string => typeof statement === "string")
           : [];
+        const statementCount = typeof row.statement_count === "number" && Number.isFinite(row.statement_count)
+          ? row.statement_count
+          : statements.length;
 
         return {
           version: String(row.version || ""),
           name: typeof row.name === "string" ? row.name : null,
           statements,
-          statement_count: Number(row.statement_count ?? statements.length),
+          statement_count: statementCount,
           checksum: typeof row.checksum === "string" ? row.checksum : "",
           applied_at: typeof row.applied_at === "string" ? row.applied_at : null,
         };
@@ -40,7 +43,7 @@
     }
   }));
 
-  const migrations = $derived((migrationsQuery.data as Migration[]) || []);
+  const migrations = $derived(migrationsQuery.data || []);
   const isLoading = $derived(migrationsQuery.isPending);
   const error = $derived(migrationsQuery.error?.message || null);
   const fallbackMsg = $derived(!isLoading && !error && migrations.length === 0 ? "暂无迁移历史" : null);


### PR DESCRIPTION
…lassification

install_container_runtime() checked docker first:

    if command -v docker &> /dev/null; then
        CONTAINER_RUNTIME="docker"
    elif command -v podman &> /dev/null; then
        CONTAINER_RUNTIME="podman"

The podman-docker package (commonly installed on RHEL-family hosts that use podman, exactly for docker-CLI compatibility) ships a /usr/bin/docker shim that forwards every invocation to podman. On such hosts `command -v docker` succeeds even though podman is the real runtime, so the check above classifies the host as docker. Consequences:

  * setup_podman_socket is skipped (the CONTAINER_RUNTIME == "podman" branch never runs), so podman's API socket is not prepared.
  * install_pigsty() then runs Pigsty's docker.yml, which tries to install docker-ce. docker-ce conflicts with the already-installed podman-docker package (RPM Depsolve Error: package podman-docker conflicts with docker-ce), failing the install.
  * deploy_service_containers() uses CONTAINER_RUNTIME to drive the runtime; picking docker on a podman host routes container operations through the emulation shim instead of podman directly.

Podman is the authoritative runtime whenever it is present (the podman-docker shim cannot function without podman), so check podman first and only fall back to docker when podman is absent.

Verified on an AlmaLinux 10.1 host with podman-docker installed: with the old order CONTAINER_RUNTIME was misdetected as docker and docker.yml failed with a podman-docker/docker-ce conflict; setting CONTAINER_RUNTIME=podman explicitly made install.sh skip docker.yml and proceed cleanly, which is exactly what this reorder now does automatically.