### PR TITLE
fix(backups): verify completed pgBackRest backups

### DIFF
--- a/packages/management-api/src/api.test.ts
+++ b/packages/management-api/src/api.test.ts
@@ -274,10 +274,12 @@ describe("Management API Integration Tests", () => {
                     headers: { Authorization: `Bearer ${masterToken}` },
                 })
             );
-            expect([200, 404, 500]).toContain(response.status);
+            expect([200, 404, 503]).toContain(response.status);
             if (response.status === 200) {
                 const data = await response.json();
                 expect(Array.isArray(data)).toBe(true);
+            } else if (response.status === 503) {
+                expect(await response.json()).toEqual({ message: "pgBackRest backup inventory is unavailable" });
             }
         });
 

--- a/packages/management-api/src/routes/backups.ts
+++ b/packages/management-api/src/routes/backups.ts
@@ -1,5 +1,12 @@
 import { Elysia, t, status } from "elysia";
-import { listBackups, createBackup, restore, createLogicalBackup, restoreLogicalBackup } from '../services/backup.service';
+import {
+    listBackups,
+    createBackup,
+    restore,
+    createLogicalBackup,
+    restoreLogicalBackup,
+    PgBackRestUnavailableError,
+} from '../services/backup.service';
 import type { RestoreRequest } from '../types/backup';
 import { resolveDbName } from '../db';
 import { requireAdminAuth, requireProjectOrAdminAuth } from '../middleware/auth';
@@ -12,17 +19,30 @@ export const backupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
         if (authError) return status(authError.status, authError.body);
 
         const dbName = await resolveDbName(params.ref);
-        return await listBackups(dbName);
+        try {
+            return await listBackups(dbName);
+        } catch (error) {
+            if (error instanceof PgBackRestUnavailableError) {
+                return status(503, { message: "pgBackRest backup inventory is unavailable" });
+            }
+            throw error;
+        }
     }, {
-        response: { 200: t.Any() },
+        response: { 200: t.Any(), 503: ErrorResponse },
         detail: { tags: ["backups"], summary: "List project backups" },
     })
-    .post('/', async ({ params, body, request }) => {
+    .post('/', async ({ body, request }) => {
         const authError = await requireAdminAuth(request);
         if (authError) return status(authError.status, authError.body);
 
-        const dbName = await resolveDbName(params.ref);
-        return await createBackup(dbName, body.type);
+        try {
+            return await createBackup(body.type);
+        } catch (error) {
+            if (error instanceof PgBackRestUnavailableError) {
+                return status(503, { message: "pgBackRest backup failed" });
+            }
+            throw error;
+        }
     }, {
         body: t.Object({
             type: t.Optional(t.Union([
@@ -31,7 +51,7 @@ export const backupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
                 t.Literal('diff'),
             ])),
         }),
-        response: { 200: t.Any() },
+        response: { 200: t.Any(), 503: ErrorResponse },
         detail: { tags: ["backups"], summary: "Create a database backup" },
     })
     .post('/restore', async ({ body, request }) => {

--- a/packages/management-api/src/routes/backups.ts
+++ b/packages/management-api/src/routes/backups.ts
@@ -6,14 +6,15 @@ import {
     createLogicalBackup,
     restoreLogicalBackup,
     PgBackRestUnavailableError,
+    PitrRestoreUnavailableError,
+    isPitrEnabled,
 } from '../services/backup.service';
-import type { RestoreRequest } from '../types/backup';
 import { resolveDbName } from '../db';
 import { requireAdminAuth, requireProjectOrAdminAuth } from '../middleware/auth';
 
 const ErrorResponse = t.Object({ message: t.String() });
 
-export const backupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/backups" })
+const projectBackupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/backups" })
     .get('/', async ({ params, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
@@ -54,22 +55,6 @@ export const backupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
         response: { 200: t.Any(), 503: ErrorResponse },
         detail: { tags: ["backups"], summary: "Create a database backup" },
     })
-    .post('/restore', async ({ body, request }) => {
-        const authError = await requireAdminAuth(request);
-        if (authError) return status(authError.status, authError.body);
-        try {
-            return await restore(body as RestoreRequest);
-        } catch (err) {
-            return status(400, { message: err instanceof Error ? err.message : "Invalid restore request" });
-        }
-    }, {
-        body: t.Object({ target: t.String() }),
-        response: {
-            200: t.Any(),
-            400: ErrorResponse,
-        },
-        detail: { tags: ["backups"], summary: "Restore from backup" },
-    })
     .post('/logical', async ({ params: { ref }, request }) => {
         const authError = await requireAdminAuth(request);
         if (authError) return status(authError.status, authError.body);
@@ -91,4 +76,41 @@ export const backupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
             400: ErrorResponse,
         },
         detail: { tags: ["backups"], summary: "Restore from logical backup" },
+    });
+
+export const backupRoutes = new Elysia()
+    .use(projectBackupRoutes)
+    .post('/v1/platform/backups/restore', async ({ body, request }) => {
+        const authError = await requireAdminAuth(request);
+        if (authError) return status(authError.status, authError.body);
+        if (body.confirmation !== `RESTORE_CLUSTER:${body.target}`) {
+            return status(400, { message: "Exact cluster restore confirmation is required" });
+        }
+        if (!isPitrEnabled()) {
+            return status(409, { message: "Physical PITR is not enabled for this cluster" });
+        }
+        try {
+            const backups = await listBackups();
+            if (!backups.some((backup) => backup.timestamp.stop > 0)) {
+                return status(409, { message: "No completed physical backup is available for PITR" });
+            }
+            return await restore({ target: body.target });
+        } catch (err) {
+            if (err instanceof PgBackRestUnavailableError) {
+                return status(503, { message: "pgBackRest backup inventory is unavailable" });
+            }
+            if (err instanceof PitrRestoreUnavailableError) {
+                return status(503, { message: err.message });
+            }
+            return status(400, { message: err instanceof Error ? err.message : "Invalid restore request" });
+        }
+    }, {
+        body: t.Object({ target: t.String(), confirmation: t.String() }),
+        response: {
+            200: t.Any(),
+            400: ErrorResponse,
+            409: ErrorResponse,
+            503: ErrorResponse,
+        },
+        detail: { tags: ["backups"], summary: "Restore the physical cluster to a point in time" },
     });

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -710,54 +710,6 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
 },
   )
 
-  // Get backup list
-  .get(
-    "/:ref/database/backups",
-    async ({ params, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
-      const backups = await projectService.listBackups(params.ref);
-      return backups;
-    },
-    {
-      params: t.Object({
-        ref: t.String(),
-      }),
-    
-      detail: { tags: ["projects"], summary: "List database backups" },
-},
-  )
-
-  // Restore backup
-  .post(
-    "/:ref/database/backups/restore",
-    async ({ params, body, request }) => {
-      const authError = await requireAdminAuth(request);
-      if (authError) return status(authError.status, authError.body);
-      const success = await projectService.restoreBackup(
-        params.ref,
-        body.backup_id,
-      );
-      if (!success) {
-        return status(500, {
-          message: "Failed to restore backup",
-          code: "500",
-        });
-      }
-      return { success: true };
-    },
-    {
-      params: t.Object({
-        ref: t.String(),
-      }),
-      body: t.Object({
-        backup_id: t.String(),
-      }),
-    
-      detail: { tags: ["projects"], summary: "Restore a database backup" },
-},
-  )
-
   .use(projectNetworkRestrictionRoutes)
 
   // Get custom domain

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -14,7 +14,7 @@ import {
   getAuthRuntimeOwnerProtectionError,
 } from "../services/auth-runtime.service";
 import { ScalingService } from "../services/scaling.service";
-import { listBackups } from "../services/backup.service";
+import { listBackups, PgBackRestUnavailableError } from "../services/backup.service";
 import type { BackupInfo } from "../types/backup";
 import {
   applyAuthEmailTemplatePatch,
@@ -986,8 +986,15 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!project)
         return status(404, { message: "Project not found", code: "404" });
       const dbName = await resolveDbName(params.ref);
-      const backups = await listBackups(dbName);
-      return buildPitrStatus(params.ref, dbName, backups);
+      try {
+        const backups = await listBackups(dbName);
+        return buildPitrStatus(params.ref, dbName, backups);
+      } catch (error) {
+        if (error instanceof PgBackRestUnavailableError) {
+          return status(503, { message: "pgBackRest backup inventory is unavailable", code: "BACKUP_UNAVAILABLE" });
+        }
+        throw error;
+      }
     },
     {
       params: t.Object({ ref: t.String() }),

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -14,7 +14,7 @@ import {
   getAuthRuntimeOwnerProtectionError,
 } from "../services/auth-runtime.service";
 import { ScalingService } from "../services/scaling.service";
-import { listBackups, PgBackRestUnavailableError } from "../services/backup.service";
+import { getPgBackRestStanza, isPitrEnabled, listBackups, PgBackRestUnavailableError } from "../services/backup.service";
 import type { BackupInfo } from "../types/backup";
 import {
   applyAuthEmailTemplatePatch,
@@ -169,7 +169,7 @@ function normalizeBackupTimestamp(value: unknown): string | null {
   return new Date(millis).toISOString();
 }
 
-function buildPitrStatus(ref: string, dbName: string, backups: BackupInfo[]) {
+function buildPitrStatus(ref: string, stanza: string, backups: BackupInfo[]) {
   const dates = backups
     .flatMap((backup) => [
       normalizeBackupTimestamp(backup.timestamp?.start),
@@ -177,9 +177,7 @@ function buildPitrStatus(ref: string, dbName: string, backups: BackupInfo[]) {
     ])
     .filter((value): value is string => Boolean(value))
     .sort();
-  const pitrEnabled =
-    process.env.SUPACLOUD_PITR_ENABLED === "true" ||
-    process.env.PITR_ENABLED === "true";
+  const pitrEnabled = isPitrEnabled();
   const hasPhysicalBackups = dates.length > 0;
   const available = pitrEnabled && hasPhysicalBackups;
 
@@ -200,14 +198,18 @@ function buildPitrStatus(ref: string, dbName: string, backups: BackupInfo[]) {
     latest_physical_backup_date: dates.at(-1) ?? null,
     backups: {
       count: backups.length,
-      stanza: dbName,
+      stanza,
+      scope: "cluster",
     },
     restore: {
       supported: available,
       method: "POST",
-      endpoint: `/v1/projects/${ref}/database/backups/restore`,
+      endpoint: "/v1/platform/backups/restore",
       requires_admin: true,
-      request_body: { target: "ISO-8601 timestamp" },
+      request_body: {
+        target: "ISO-8601 timestamp",
+        confirmation: "RESTORE_CLUSTER:<target>",
+      },
     },
   };
 }
@@ -988,7 +990,7 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
       const dbName = await resolveDbName(params.ref);
       try {
         const backups = await listBackups(dbName);
-        return buildPitrStatus(params.ref, dbName, backups);
+        return buildPitrStatus(params.ref, getPgBackRestStanza(), backups);
       } catch (error) {
         if (error instanceof PgBackRestUnavailableError) {
           return status(503, { message: "pgBackRest backup inventory is unavailable", code: "BACKUP_UNAVAILABLE" });

--- a/packages/management-api/src/services/backup.service.ts
+++ b/packages/management-api/src/services/backup.service.ts
@@ -11,6 +11,8 @@ const BACKUP_USER_PATTERN = /^[a-z_][a-z0-9_-]{0,31}$/;
 const BACKUP_BINARY_PATTERN = /^(?:[A-Za-z0-9_.-]+|\/[A-Za-z0-9_./-]+)$/;
 const INFO_TIMEOUT_MS = 5_000;
 const BACKUP_TIMEOUT_MS = 30 * 60_000;
+const PITR_TIMEOUT_MS = 30 * 60_000;
+const TIMEOUT_KILL_AFTER = "--kill-after=30s";
 
 interface PgBackRestCommandResult {
   exitCode: number;
@@ -22,6 +24,13 @@ export class PgBackRestUnavailableError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "PgBackRestUnavailableError";
+  }
+}
+
+export class PitrRestoreUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PitrRestoreUnavailableError";
   }
 }
 
@@ -43,6 +52,14 @@ function readPgBackRestConfiguration(environment: Record<string, string | undefi
   return { stanza, user, binary };
 }
 
+export function getPgBackRestStanza(environment: Record<string, string | undefined> = process.env): string {
+  return readPgBackRestConfiguration(environment).stanza;
+}
+
+export function isPitrEnabled(environment: Record<string, string | undefined> = process.env): boolean {
+  return environment.SUPACLOUD_PITR_ENABLED === "true" || environment.PITR_ENABLED === "true";
+}
+
 function pgBackRestCommand(
   pgBackRestArguments: string[],
   timeoutMs = pgBackRestArguments.includes("backup") ? BACKUP_TIMEOUT_MS : INFO_TIMEOUT_MS,
@@ -50,6 +67,7 @@ function pgBackRestCommand(
   const configuration = readPgBackRestConfiguration();
   return [
     "timeout",
+    TIMEOUT_KILL_AFTER,
     String(Math.ceil(timeoutMs / 1000)),
     "sudo",
     "-n",
@@ -124,7 +142,8 @@ function backupInfoFromEntry(serializedBackupEntry: unknown, database?: string):
   const start = timestamp?.start;
   const stop = timestamp?.stop;
   const size = backupSizeFromMetadata(backupMetadata);
-  if (typeof id !== "string" || !PGBACKREST_NAME_PATTERN.test(id)
+  if (backupEntry.error === true
+    || typeof id !== "string" || !PGBACKREST_NAME_PATTERN.test(id)
     || (type !== "full" && type !== "incr" && type !== "diff")
     || typeof start !== "number" || !Number.isFinite(start)
     || typeof stop !== "number" || !Number.isFinite(stop) || size === null) {
@@ -136,9 +155,18 @@ function backupInfoFromEntry(serializedBackupEntry: unknown, database?: string):
 function parseBackups(inventoryJson: string, database?: string): BackupInfo[] {
   try {
     const inventory = JSON.parse(inventoryJson);
-    if (!Array.isArray(inventory) || inventory.length === 0) return [];
+    if (!Array.isArray(inventory) || inventory.length !== 1) {
+      throw new PgBackRestUnavailableError("Invalid pgBackRest backup inventory");
+    }
     const cluster = inventory[0] as Record<string, unknown>;
-    const backupEntries = Array.isArray(cluster.backup) ? cluster.backup : [];
+    if (!cluster || typeof cluster !== "object" || cluster.name !== getPgBackRestStanza()) {
+      throw new PgBackRestUnavailableError("Invalid pgBackRest backup inventory");
+    }
+    if (!Array.isArray(cluster.backup)) {
+      throw new PgBackRestUnavailableError("Invalid pgBackRest backup inventory");
+    }
+    const backupEntries = cluster.backup;
+    assertInventoryReadable(cluster, backupEntries);
     // pgBackRest stanzas are PostgreSQL clusters, while this API is project scoped.
     return backupEntries.map((serializedBackupEntry) => backupInfoFromEntry(
       serializedBackupEntry,
@@ -151,6 +179,28 @@ function parseBackups(inventoryJson: string, database?: string): BackupInfo[] {
     });
     throw new PgBackRestUnavailableError("Invalid pgBackRest backup inventory");
   }
+}
+
+function assertInventoryReadable(cluster: Record<string, unknown>, backupEntries: unknown[]): void {
+  const stanzaStatus = cluster.status as Record<string, unknown> | undefined;
+  const repositories = cluster.repo;
+  const repositoryStatusesMatch = Array.isArray(repositories) && repositories.length > 0
+    && repositories.every((repository) => {
+      if (!repository || typeof repository !== "object") return false;
+      const status = (repository as Record<string, unknown>).status;
+      return Boolean(status)
+        && typeof status === "object"
+        && (status as Record<string, unknown>).code === stanzaStatus?.code;
+    });
+  const readableStatus = stanzaStatus?.code === 0
+    || (stanzaStatus?.code === 2 && backupEntries.length === 0);
+  if (readableStatus && repositoryStatusesMatch) return;
+
+  logger.error("[Backup] pgBackRest inventory reported an unhealthy stanza", {
+    stanza: cluster.name,
+    statusCode: stanzaStatus?.code,
+  });
+  throw new PgBackRestUnavailableError("pgBackRest backup inventory is unavailable");
 }
 
 /**
@@ -173,43 +223,93 @@ export async function createBackup(
 ): Promise<{ message: string }> {
   const beforeExecution = await runPgBackRest(["info", "--output=json"], INFO_TIMEOUT_MS);
   assertCommandSucceeded("backup inventory", beforeExecution);
-  const previousBackupIds = new Set(parseBackups(beforeExecution.stdout).map((backup) => backup.id));
+  const previousBackups = parseBackups(beforeExecution.stdout);
+  const previousBackupIds = new Set(previousBackups.map((backup) => backup.id));
+  const hasPreviousFullBackup = previousBackups.some((backup) => backup.type === "full");
 
   const backupExecution = await runPgBackRest([`--type=${type}`, "backup"], BACKUP_TIMEOUT_MS);
   assertCommandSucceeded("backup", backupExecution);
 
   const afterExecution = await runPgBackRest(["info", "--output=json"], INFO_TIMEOUT_MS);
   assertCommandSucceeded("backup inventory", afterExecution);
-  assertNewCompletedBackup(parseBackups(afterExecution.stdout), previousBackupIds, type);
-  return { message: `${type} backup completed` };
+  const completedBackup = assertNewCompletedBackup(
+    parseBackups(afterExecution.stdout),
+    previousBackupIds,
+    type,
+    hasPreviousFullBackup,
+  );
+  return { message: `${completedBackup.type} backup completed` };
 }
 
 function assertNewCompletedBackup(
   backups: BackupInfo[],
   previousBackupIds: Set<string>,
   type: BackupInfo["type"],
-): void {
-  const completedBackup = backups.find((backup) => (
+  hasPreviousFullBackup: boolean,
+): BackupInfo {
+  const newCompletedBackups = backups.filter((backup) => (
     !previousBackupIds.has(backup.id)
-    && backup.type === type
     && backup.timestamp.stop > 0
   ));
-  if (completedBackup) return;
+  const completedBackup = newCompletedBackups.find((backup) => backup.type === type)
+    ?? (!hasPreviousFullBackup && type !== "full"
+      ? newCompletedBackups.find((backup) => backup.type === "full")
+      : undefined);
+  if (completedBackup) return completedBackup;
   logger.error("[Backup] pgBackRest completed without a new inventory record", { type });
   throw new PgBackRestUnavailableError("pgBackRest backup record is unavailable");
 }
 
 const PITR_TARGET_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$/;
+let pitrRestoreInFlight = false;
 
 export async function restore(request: RestoreRequest): Promise<{ message: string }> {
-        if (!PITR_TARGET_PATTERN.test(request.target)) {
-            throw new Error("Invalid PITR target");
-        }
-        $`sudo -u postgres pig pitr ${request.target}`.nothrow().quiet().catch(err => {
-            logger.error('[Backup] Async restore task failed:', { error: err instanceof Error ? err.message : String(err) });
-        });
-        return { message: `Point-in-time recovery (PITR) task started, target: ${request.target}` };
+  if (!PITR_TARGET_PATTERN.test(request.target)) {
+    throw new Error("Invalid PITR target");
+  }
+  if (pitrRestoreInFlight) {
+    throw new PitrRestoreUnavailableError("A PITR restore is already in progress");
+  }
+  pitrRestoreInFlight = true;
+
+  try {
+    let exitCode: number;
+    try {
+      const restoreProcess = Bun.spawn([
+        "timeout",
+        TIMEOUT_KILL_AFTER,
+        String(Math.ceil(PITR_TIMEOUT_MS / 1000)),
+        "sudo",
+        "-n",
+        "-u",
+        "postgres",
+        "pig",
+        "pitr",
+        "-s",
+        getPgBackRestStanza(),
+        "-t",
+        request.target,
+        "-y",
+      ], { stdout: "pipe", stderr: "pipe" });
+      [exitCode] = await Promise.all([
+        restoreProcess.exited,
+        new Response(restoreProcess.stdout).text(),
+        new Response(restoreProcess.stderr).text(),
+      ]);
+    } catch {
+      logger.error("[Backup] PITR restore command could not start");
+      throw new PitrRestoreUnavailableError("PITR restore command is unavailable");
     }
+
+    if (exitCode !== 0) {
+      logger.error("[Backup] PITR restore failed", { exitCode, timedOut: exitCode === 124 });
+      throw new PitrRestoreUnavailableError(exitCode === 124 ? "PITR restore timed out" : "PITR restore failed");
+    }
+    return { message: `Point-in-time recovery (PITR) completed, target: ${request.target}` };
+  } finally {
+    pitrRestoreInFlight = false;
+  }
+}
 
 const LOGICAL_BACKUP_DIR = process.env.SUPACLOUD_LOGICAL_BACKUP_DIR || "/tmp/supacloud-backups";
 const LOGICAL_BACKUP_FILE_PATTERN = /^backup_[A-Za-z0-9_-]{1,64}_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.sql\.gz$/;

--- a/packages/management-api/src/services/backup.service.ts
+++ b/packages/management-api/src/services/backup.service.ts
@@ -6,81 +6,199 @@ import type { BackupInfo, RestoreRequest } from '../types/backup';
 import { projectRepository } from '../repositories/project.repository';
 import { resolveDbName, resolveRoleName } from '../db';
 
+const PGBACKREST_NAME_PATTERN = /^[A-Za-z0-9_.-]{1,128}$/;
+const BACKUP_USER_PATTERN = /^[a-z_][a-z0-9_-]{0,31}$/;
+const BACKUP_BINARY_PATTERN = /^(?:[A-Za-z0-9_.-]+|\/[A-Za-z0-9_./-]+)$/;
+const INFO_TIMEOUT_MS = 5_000;
+const BACKUP_TIMEOUT_MS = 30 * 60_000;
 
-    /**
-     * Get backup list
-     * @param stanza Database name/instance name, defaults to db-main
-     */
-export async function listBackups(stanza: string = 'db-main'): Promise<BackupInfo[]> {
-        let result: { exitCode: number; stdout: string; timedOut: boolean };
-        try {
-            result = await runPgBackrestInfo(stanza, 5000);
-        } catch {
-            logger.warn('[Backup] pgbackrest command failed');
-            return [];
-        }
-        if (result.timedOut) {
-            logger.warn('[Backup] pgbackrest command timed out after 5s');
-            return [];
-        }
-
-        if (result.exitCode !== 0) {
-            // Return empty list when pgbackrest is not installed
-            logger.warn('[Backup] pgbackrest not available or no backups found');
-            return [];
-        }
-
-        try {
-            const rawData = JSON.parse(result.stdout);
-            if (!Array.isArray(rawData) || rawData.length === 0) return [];
-            const backups = rawData[0].backup || [];
-            return backups.map((b: Record<string, unknown>) => ({
-                id: b.label,
-                type: b.type,
-                timestamp: { start: (b.timestamp as Record<string, unknown>)?.start, stop: (b.timestamp as Record<string, unknown>)?.stop },
-                size: ((b.info as Record<string, unknown>)?.size as Record<string, unknown>)?.backup,
-                database: rawData[0].name,
-            }));
-        } catch (e: unknown) {
-            logger.error('Failed to parse backup list:', { error: e instanceof Error ? e.message : String(e) });
-            throw new Error('Failed to parse backup list');
-        }
-    }
-
-async function runPgBackrestInfo(stanza: string, timeoutMs: number): Promise<{ exitCode: number; stdout: string; timedOut: boolean }> {
-    const proc = Bun.spawn([
-        "timeout",
-        String(Math.ceil(timeoutMs / 1000)),
-        "sudo",
-        "-u",
-        "postgres",
-        "pgbackrest",
-        `--stanza=${stanza}`,
-        "info",
-        "--output=json",
-    ], {
-        stdout: "pipe",
-        stderr: "pipe",
-    });
-
-    const exitCode = await proc.exited;
-    const output = await new Response(proc.stdout).text();
-    const errorOutput = await new Response(proc.stderr).text();
-    const timedOut = exitCode === 124;
-
-    if (timedOut) {
-        logger.warn("[Backup] pgbackrest timed out after " + timeoutMs + "ms");
-    } else if (errorOutput.trim()) {
-        logger.debug("[Backup] pgbackrest stderr:", { stderr: errorOutput.trim() });
-    }
-    return { exitCode, stdout: output, timedOut };
+interface PgBackRestCommandResult {
+  exitCode: number;
+  stdout: string;
+  timedOut: boolean;
 }
-export async function createBackup(stanza: string = 'db-main', type: 'full' | 'incr' | 'diff' = 'incr'): Promise<{ message: string }> {
-        $`sudo -u postgres pgbackrest --stanza=${stanza} --type=${type} backup`.nothrow().quiet().catch(err => {
-            logger.error('[Backup] Async backup task failed:', { error: err instanceof Error ? err.message : String(err) });
-        });
-        return { message: `${type} backup task started` };
-    }
+
+export class PgBackRestUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PgBackRestUnavailableError";
+  }
+}
+
+interface PgBackRestConfiguration {
+  stanza: string;
+  user: string;
+  binary: string;
+}
+
+function readPgBackRestConfiguration(environment: Record<string, string | undefined> = process.env): PgBackRestConfiguration {
+  const stanza = (environment.SUPACLOUD_PGBACKREST_STANZA || "db-main").trim();
+  const user = (environment.SUPACLOUD_PGBACKREST_USER || "postgres").trim();
+  const binary = (environment.SUPACLOUD_PGBACKREST_BIN || "pgbackrest").trim();
+
+  if (!PGBACKREST_NAME_PATTERN.test(stanza)) throw new PgBackRestUnavailableError("Invalid SUPACLOUD_PGBACKREST_STANZA");
+  if (!BACKUP_USER_PATTERN.test(user)) throw new PgBackRestUnavailableError("Invalid SUPACLOUD_PGBACKREST_USER");
+  if (!BACKUP_BINARY_PATTERN.test(binary)) throw new PgBackRestUnavailableError("Invalid SUPACLOUD_PGBACKREST_BIN");
+
+  return { stanza, user, binary };
+}
+
+function pgBackRestCommand(
+  pgBackRestArguments: string[],
+  timeoutMs = pgBackRestArguments.includes("backup") ? BACKUP_TIMEOUT_MS : INFO_TIMEOUT_MS,
+): string[] {
+  const configuration = readPgBackRestConfiguration();
+  return [
+    "timeout",
+    String(Math.ceil(timeoutMs / 1000)),
+    "sudo",
+    "-n",
+    "-u",
+    configuration.user,
+    configuration.binary,
+    `--stanza=${configuration.stanza}`,
+    ...pgBackRestArguments,
+  ];
+}
+
+async function runPgBackRest(pgBackRestArguments: string[], timeoutMs: number): Promise<PgBackRestCommandResult> {
+  try {
+    const pgBackRestProcess = Bun.spawn(pgBackRestCommand(pgBackRestArguments, timeoutMs), { stdout: "pipe", stderr: "pipe" });
+    const [exitCode, stdout] = await Promise.all([
+      pgBackRestProcess.exited,
+      new Response(pgBackRestProcess.stdout).text(),
+      new Response(pgBackRestProcess.stderr).text(),
+    ]);
+    return { exitCode, stdout, timedOut: exitCode === 124 };
+  } catch {
+    logger.error("[Backup] pgBackRest command could not start");
+    throw new PgBackRestUnavailableError("pgBackRest command is unavailable");
+  }
+}
+
+function commandFailure(
+  operation: "backup inventory" | "backup",
+  commandExecution: PgBackRestCommandResult,
+): PgBackRestUnavailableError {
+  logger.error(`[Backup] pgBackRest ${operation} failed`, {
+    exitCode: commandExecution.exitCode,
+    timedOut: commandExecution.timedOut,
+  });
+  return new PgBackRestUnavailableError(
+    commandExecution.timedOut ? `pgBackRest ${operation} timed out` : `pgBackRest ${operation} failed`,
+  );
+}
+
+function assertCommandSucceeded(
+  operation: "backup inventory" | "backup",
+  commandExecution: PgBackRestCommandResult,
+): void {
+  if (commandExecution.exitCode !== 0 || commandExecution.timedOut) {
+    throw commandFailure(operation, commandExecution);
+  }
+}
+
+function backupSizeFromMetadata(backupMetadata: Record<string, unknown> | undefined): number | null {
+  const sourceSize = backupMetadata?.size;
+  if (typeof sourceSize === "number" && Number.isFinite(sourceSize)) return sourceSize;
+  if (sourceSize && typeof sourceSize === "object") {
+    const legacyBackupSize = (sourceSize as Record<string, unknown>).backup;
+    if (typeof legacyBackupSize === "number" && Number.isFinite(legacyBackupSize)) return legacyBackupSize;
+  }
+  const repository = backupMetadata?.repository;
+  const repositorySize = repository && typeof repository === "object"
+    ? (repository as Record<string, unknown>).size
+    : undefined;
+  return typeof repositorySize === "number" && Number.isFinite(repositorySize) ? repositorySize : null;
+}
+
+function backupInfoFromEntry(serializedBackupEntry: unknown, database?: string): BackupInfo {
+  if (!serializedBackupEntry || typeof serializedBackupEntry !== "object") {
+    throw new PgBackRestUnavailableError("Invalid pgBackRest backup inventory");
+  }
+  const backupEntry = serializedBackupEntry as Record<string, unknown>;
+  const timestamp = backupEntry.timestamp as Record<string, unknown> | undefined;
+  const backupMetadata = backupEntry.info as Record<string, unknown> | undefined;
+  const id = backupEntry.label;
+  const type = backupEntry.type;
+  const start = timestamp?.start;
+  const stop = timestamp?.stop;
+  const size = backupSizeFromMetadata(backupMetadata);
+  if (typeof id !== "string" || !PGBACKREST_NAME_PATTERN.test(id)
+    || (type !== "full" && type !== "incr" && type !== "diff")
+    || typeof start !== "number" || !Number.isFinite(start)
+    || typeof stop !== "number" || !Number.isFinite(stop) || size === null) {
+    throw new PgBackRestUnavailableError("Invalid pgBackRest backup inventory");
+  }
+  return { id, type, timestamp: { start, stop }, size, database };
+}
+
+function parseBackups(inventoryJson: string, database?: string): BackupInfo[] {
+  try {
+    const inventory = JSON.parse(inventoryJson);
+    if (!Array.isArray(inventory) || inventory.length === 0) return [];
+    const cluster = inventory[0] as Record<string, unknown>;
+    const backupEntries = Array.isArray(cluster.backup) ? cluster.backup : [];
+    // pgBackRest stanzas are PostgreSQL clusters, while this API is project scoped.
+    return backupEntries.map((serializedBackupEntry) => backupInfoFromEntry(
+      serializedBackupEntry,
+      database || String(cluster.name || ""),
+    ));
+  } catch (error: unknown) {
+    if (error instanceof PgBackRestUnavailableError) throw error;
+    logger.error("[Backup] Failed to parse pgBackRest inventory", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new PgBackRestUnavailableError("Invalid pgBackRest backup inventory");
+  }
+}
+
+/**
+ * List cluster backups and associate them with the requested project database.
+ * The caller-provided database is deliberately not used as a pgBackRest stanza:
+ * a stanza describes a PostgreSQL cluster and can contain many tenant databases.
+ */
+export async function listBackups(database?: string): Promise<BackupInfo[]> {
+  const inventoryExecution = await runPgBackRest(["info", "--output=json"], INFO_TIMEOUT_MS);
+  assertCommandSucceeded("backup inventory", inventoryExecution);
+  return parseBackups(inventoryExecution.stdout, database);
+}
+
+/**
+ * Complete the physical backup before reporting success, so callers never
+ * mistake a failed background process for a completed recovery point.
+ */
+export async function createBackup(
+  type: "full" | "incr" | "diff" = "incr",
+): Promise<{ message: string }> {
+  const beforeExecution = await runPgBackRest(["info", "--output=json"], INFO_TIMEOUT_MS);
+  assertCommandSucceeded("backup inventory", beforeExecution);
+  const previousBackupIds = new Set(parseBackups(beforeExecution.stdout).map((backup) => backup.id));
+
+  const backupExecution = await runPgBackRest([`--type=${type}`, "backup"], BACKUP_TIMEOUT_MS);
+  assertCommandSucceeded("backup", backupExecution);
+
+  const afterExecution = await runPgBackRest(["info", "--output=json"], INFO_TIMEOUT_MS);
+  assertCommandSucceeded("backup inventory", afterExecution);
+  assertNewCompletedBackup(parseBackups(afterExecution.stdout), previousBackupIds, type);
+  return { message: `${type} backup completed` };
+}
+
+function assertNewCompletedBackup(
+  backups: BackupInfo[],
+  previousBackupIds: Set<string>,
+  type: BackupInfo["type"],
+): void {
+  const completedBackup = backups.find((backup) => (
+    !previousBackupIds.has(backup.id)
+    && backup.type === type
+    && backup.timestamp.stop > 0
+  ));
+  if (completedBackup) return;
+  logger.error("[Backup] pgBackRest completed without a new inventory record", { type });
+  throw new PgBackRestUnavailableError("pgBackRest backup record is unavailable");
+}
+
 const PITR_TARGET_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$/;
 
 export async function restore(request: RestoreRequest): Promise<{ message: string }> {

--- a/packages/management-api/tests/unit/backup.routes.test.ts
+++ b/packages/management-api/tests/unit/backup.routes.test.ts
@@ -6,6 +6,7 @@ const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
 const resolveDbName = mock((ref: string) => Promise.resolve(`supa_${ref}`));
 const listBackups = mock(() => Promise.resolve([]));
 const createBackup = mock(() => Promise.resolve({ message: "full backup completed" }));
+const restore = mock(() => Promise.resolve({ message: "PITR restore completed" }));
 
 const authModule = await import("../../src/middleware/auth");
 const dbModule = await import("../../src/db");
@@ -25,6 +26,9 @@ const listBackupsSpy = spyOn(backupModule, "listBackups").mockImplementation(
 );
 const createBackupSpy = spyOn(backupModule, "createBackup").mockImplementation(
   createBackup as typeof backupModule.createBackup,
+);
+const restoreSpy = spyOn(backupModule, "restore").mockImplementation(
+  restore as typeof backupModule.restore,
 );
 
 const { backupRoutes } = await import("../../src/routes/backups");
@@ -54,6 +58,10 @@ describe("physical backup routes", () => {
     listBackups.mockResolvedValue([]);
     createBackup.mockReset();
     createBackup.mockResolvedValue({ message: "full backup completed" });
+    restore.mockReset();
+    restore.mockResolvedValue({ message: "PITR restore completed" });
+    delete process.env.SUPACLOUD_PITR_ENABLED;
+    delete process.env.PITR_ENABLED;
   });
 
   afterAll(() => {
@@ -62,6 +70,7 @@ describe("physical backup routes", () => {
     resolveDbNameSpy.mockRestore();
     listBackupsSpy.mockRestore();
     createBackupSpy.mockRestore();
+    restoreSpy.mockRestore();
   });
 
   test("lists cluster inventory under the requested project database", async () => {
@@ -103,6 +112,82 @@ describe("physical backup routes", () => {
     });
     expect(createResponse.status).toBe(503);
     expect(await createResponse.json()).toEqual({ message: "pgBackRest backup failed" });
+  });
+
+  test("exposes PITR only at the platform endpoint, requires exact confirmation, and reports execution failure", async () => {
+    const target = "2026-07-22T01:30:00Z";
+    const confirmation = `RESTORE_CLUSTER:${target}`;
+    const projectResponse = await request("/v1/projects/project_a/database/backups/restore", {
+      method: "POST",
+      body: JSON.stringify({ target, confirmation }),
+    });
+    expect(projectResponse.status).toBe(404);
+    expect(restore).not.toHaveBeenCalled();
+
+    const unconfirmedResponse = await request("/v1/platform/backups/restore", {
+      method: "POST",
+      body: JSON.stringify({ target, confirmation: "RESTORE_CLUSTER" }),
+    });
+    expect(unconfirmedResponse.status).toBe(400);
+    expect(restore).not.toHaveBeenCalled();
+
+    const disabledResponse = await request("/v1/platform/backups/restore", {
+      method: "POST",
+      body: JSON.stringify({ target, confirmation }),
+    });
+    expect(disabledResponse.status).toBe(409);
+    expect(restore).not.toHaveBeenCalled();
+
+    process.env.SUPACLOUD_PITR_ENABLED = "true";
+    const noBackupResponse = await request("/v1/platform/backups/restore", {
+      method: "POST",
+      body: JSON.stringify({ target, confirmation }),
+    });
+    expect(noBackupResponse.status).toBe(409);
+    expect(restore).not.toHaveBeenCalled();
+
+    listBackups.mockResolvedValueOnce([{
+      id: "20260722-120000F",
+      type: "full",
+      timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
+      size: 2048,
+    }]);
+
+    const successResponse = await request("/v1/platform/backups/restore", {
+      method: "POST",
+      body: JSON.stringify({ target, confirmation }),
+    });
+    expect(successResponse.status).toBe(200);
+    expect(restore).toHaveBeenCalledWith({ target });
+
+    listBackups.mockResolvedValueOnce([{
+      id: "20260722-120000F",
+      type: "full",
+      timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
+      size: 2048,
+    }]);
+    restore.mockRejectedValueOnce(new backupModule.PitrRestoreUnavailableError("PITR restore failed"));
+    const failureResponse = await request("/v1/platform/backups/restore", {
+      method: "POST",
+      body: JSON.stringify({ target, confirmation }),
+    });
+    expect(failureResponse.status).toBe(503);
+  });
+
+  test("requires admin authentication before checking PITR capability or inventory", async () => {
+    requireAdminAuth.mockResolvedValueOnce({ status: 401, body: { error: "Unauthorized" } } as never);
+
+    const response = await request("/v1/platform/backups/restore", {
+      method: "POST",
+      body: JSON.stringify({
+        target: "2026-07-22T01:30:00Z",
+        confirmation: "RESTORE_CLUSTER:2026-07-22T01:30:00Z",
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(listBackups).not.toHaveBeenCalled();
+    expect(restore).not.toHaveBeenCalled();
   });
 
   test("does not leave a second backup or restore contract in project config routes", () => {

--- a/packages/management-api/tests/unit/backup.routes.test.ts
+++ b/packages/management-api/tests/unit/backup.routes.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const requireAdminAuth = mock(() => Promise.resolve(null));
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+const resolveDbName = mock((ref: string) => Promise.resolve(`supa_${ref}`));
+const listBackups = mock(() => Promise.resolve([]));
+const createBackup = mock(() => Promise.resolve({ message: "full backup completed" }));
+
+const authModule = await import("../../src/middleware/auth");
+const dbModule = await import("../../src/db");
+const backupModule = await import("../../src/services/backup.service");
+
+const requireAdminAuthSpy = spyOn(authModule, "requireAdminAuth").mockImplementation(
+  requireAdminAuth as typeof authModule.requireAdminAuth,
+);
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const resolveDbNameSpy = spyOn(dbModule, "resolveDbName").mockImplementation(
+  resolveDbName as typeof dbModule.resolveDbName,
+);
+const listBackupsSpy = spyOn(backupModule, "listBackups").mockImplementation(
+  listBackups as typeof backupModule.listBackups,
+);
+const createBackupSpy = spyOn(backupModule, "createBackup").mockImplementation(
+  createBackup as typeof backupModule.createBackup,
+);
+
+const { backupRoutes } = await import("../../src/routes/backups");
+const { projectConfigRoutes } = await import("../../src/routes/project-config");
+const app = new Elysia().use(backupRoutes);
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(new Request(`http://localhost${path}`, {
+    ...init,
+    headers: {
+      Authorization: "Bearer dev-master-token",
+      "content-type": "application/json",
+      ...(init.headers || {}),
+    },
+  }));
+}
+
+describe("physical backup routes", () => {
+  beforeEach(() => {
+    requireAdminAuth.mockReset();
+    requireAdminAuth.mockResolvedValue(null);
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+    resolveDbName.mockReset();
+    resolveDbName.mockImplementation((ref: string) => Promise.resolve(`supa_${ref}`));
+    listBackups.mockReset();
+    listBackups.mockResolvedValue([]);
+    createBackup.mockReset();
+    createBackup.mockResolvedValue({ message: "full backup completed" });
+  });
+
+  afterAll(() => {
+    requireAdminAuthSpy.mockRestore();
+    requireProjectOrAdminAuthSpy.mockRestore();
+    resolveDbNameSpy.mockRestore();
+    listBackupsSpy.mockRestore();
+    createBackupSpy.mockRestore();
+  });
+
+  test("lists cluster inventory under the requested project database", async () => {
+    listBackups.mockResolvedValue([{
+      id: "20260722-120000F",
+      type: "full",
+      timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
+      size: 2048,
+      database: "supa_project_a",
+    }]);
+
+    const response = await request("/v1/projects/project_a/database/backups");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toHaveLength(1);
+    expect(listBackups).toHaveBeenCalledWith("supa_project_a");
+  });
+
+  test("reports backup success only after the service returns a completed result", async () => {
+    const response = await request("/v1/projects/project_a/database/backups", {
+      method: "POST",
+      body: JSON.stringify({ type: "full" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ message: "full backup completed" });
+    expect(createBackup).toHaveBeenCalledWith("full");
+  });
+
+  test("returns 503 instead of an empty list or started response on pgBackRest failure", async () => {
+    listBackups.mockRejectedValueOnce(new backupModule.PgBackRestUnavailableError("pgBackRest backup inventory failed"));
+    const listResponse = await request("/v1/projects/project_a/database/backups");
+    expect(listResponse.status).toBe(503);
+    expect(await listResponse.json()).toEqual({ message: "pgBackRest backup inventory is unavailable" });
+
+    createBackup.mockRejectedValueOnce(new backupModule.PgBackRestUnavailableError("pgBackRest backup failed"));
+    const createResponse = await request("/v1/projects/project_a/database/backups", {
+      method: "POST",
+      body: JSON.stringify({ type: "full" }),
+    });
+    expect(createResponse.status).toBe(503);
+    expect(await createResponse.json()).toEqual({ message: "pgBackRest backup failed" });
+  });
+
+  test("does not leave a second backup or restore contract in project config routes", () => {
+    const duplicatePaths = projectConfigRoutes.routes
+      .filter((route) => route.path === "/v1/projects/:ref/database/backups" || route.path === "/v1/projects/:ref/database/backups/restore");
+    expect(duplicatePaths).toHaveLength(0);
+  });
+});

--- a/packages/management-api/tests/unit/backup.service.test.ts
+++ b/packages/management-api/tests/unit/backup.service.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { createBackup, listBackups } from "../../src/services/backup.service";
+import { createBackup, listBackups, restore } from "../../src/services/backup.service";
 
 interface CommandOutcome {
-  exitCode?: number;
+  exitCode?: number | Promise<number>;
   startError?: Error;
   stdout?: string;
+  stderr?: string;
 }
 
 const commandOutcomes: CommandOutcome[] = [];
@@ -15,22 +16,30 @@ const spawnSpy = spyOn(Bun, "spawn").mockImplementation((command) => {
   if (commandOutcome.startError) throw commandOutcome.startError;
   spawnedCommands.push(command as string[]);
   return {
-    exited: Promise.resolve(commandOutcome.exitCode || 0),
+    exited: Promise.resolve(commandOutcome.exitCode ?? 0),
     stdout: new Blob([commandOutcome.stdout || ""]).stream(),
-    stderr: new Blob([]).stream(),
+    stderr: new Blob([commandOutcome.stderr || ""]).stream(),
   } as never;
 });
 
-function inventory(backups: unknown[]) {
-  return JSON.stringify([{ name: "db-main", backup: backups }]);
+function inventory(backups: unknown[], statusCode = 0, stanza = "db-main") {
+  const message = statusCode === 0 ? "ok" : statusCode === 2 ? "no valid backups" : "missing stanza path";
+  const status = { code: statusCode, message };
+  return JSON.stringify([{
+    name: stanza,
+    backup: backups,
+    status,
+    repo: [{ key: 1, status }],
+  }]);
 }
 
-function fullBackup(label = "20260722-120000F") {
+function fullBackup(label = "20260722-120000F", error = false) {
   return {
     label,
     type: "full",
     timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
     info: { size: 2048, repository: { size: 1024 } },
+    error,
   };
 }
 
@@ -47,7 +56,7 @@ describe("BackupService", () => {
     const backups = await listBackups("supa_project_a");
 
     expect(spawnedCommands).toEqual([[
-      "timeout", "5", "sudo", "-n", "-u", "postgres", "pgbackrest",
+      "timeout", "--kill-after=30s", "5", "sudo", "-n", "-u", "postgres", "pgbackrest",
       "--stanza=db-main", "info", "--output=json",
     ]]);
     expect(backups).toEqual([{
@@ -61,7 +70,7 @@ describe("BackupService", () => {
 
   test("does not report success until a new completed backup record is readable", async () => {
     commandOutcomes.push(
-      { exitCode: 0, stdout: inventory([]) },
+      { exitCode: 0, stdout: inventory([], 2) },
       { exitCode: 0 },
       { exitCode: 0, stdout: inventory([fullBackup()]) },
     );
@@ -71,12 +80,67 @@ describe("BackupService", () => {
     expect(spawnedCommands[1]).toContain("--type=full");
   });
 
+  test("reports the effective full backup when pgBackRest promotes the first incremental backup", async () => {
+    commandOutcomes.push(
+      { exitCode: 0, stdout: inventory([], 2) },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: inventory([fullBackup()]) },
+    );
+
+    await expect(createBackup("incr")).resolves.toEqual({ message: "full backup completed" });
+  });
+
+  test("fails closed when pgBackRest reports an unhealthy stanza in successful JSON output", async () => {
+    commandOutcomes.push({ exitCode: 0, stdout: inventory([], 1) });
+
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest backup inventory is unavailable");
+  });
+
+  test("treats the official no-valid-backups status as an empty readable inventory", async () => {
+    commandOutcomes.push({ exitCode: 0, stdout: inventory([], 2) });
+
+    await expect(listBackups("supa_project_a")).resolves.toEqual([]);
+  });
+
+  test("fails closed when a pgBackRest repository is unhealthy", async () => {
+    commandOutcomes.push({
+      exitCode: 0,
+      stdout: JSON.stringify([{
+        name: "db-main",
+        backup: [],
+        status: { code: 0, message: "mixed" },
+        repo: [{ key: 1, status: { code: 3, message: "missing stanza data" } }],
+      }]),
+    });
+
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest backup inventory is unavailable");
+  });
+
+  test("fails closed when the pgBackRest repository status array is missing", async () => {
+    commandOutcomes.push({
+      exitCode: 0,
+      stdout: JSON.stringify([{
+        name: "db-main",
+        backup: [fullBackup()],
+        status: { code: 0, message: "ok" },
+      }]),
+    });
+
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest backup inventory is unavailable");
+  });
+
+  test("does not expose a backup record that pgBackRest marked as erroneous", async () => {
+    commandOutcomes.push({ exitCode: 0, stdout: inventory([fullBackup("20260722-120000F", true)]) });
+
+    await expect(listBackups("supa_project_a")).rejects.toThrow("Invalid pgBackRest backup inventory");
+  });
+
   test("fails closed when pgBackRest cannot produce an inventory or backup", async () => {
     commandOutcomes.push({ exitCode: 1, stderr: "not available" });
     await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest backup inventory failed");
 
     commandOutcomes.push(
-      { exitCode: 0, stdout: inventory([]) },
+      { exitCode: 0, stdout: inventory([], 2) },
       { exitCode: 1 },
     );
     await expect(createBackup("full")).rejects.toThrow("pgBackRest backup failed");
@@ -89,15 +153,60 @@ describe("BackupService", () => {
 
   test("fails closed when the completed backup does not appear in inventory", async () => {
     commandOutcomes.push(
-      { exitCode: 0, stdout: inventory([]) },
+      { exitCode: 0, stdout: inventory([], 2) },
       { exitCode: 0 },
-      { exitCode: 0, stdout: inventory([]) },
+      { exitCode: 0, stdout: inventory([], 2) },
     );
 
     await expect(createBackup("full")).rejects.toThrow("pgBackRest backup record is unavailable");
   });
 
-  test("builds a non-interactive command from the configured cluster stanza", async () => {
+  test("waits for PITR execution and fails closed when the cluster restore command fails", async () => {
+    commandOutcomes.push({ exitCode: 1, stderr: "restore failed" });
+
+    await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore failed");
+    expect(spawnedCommands.at(-1)).toEqual([
+      "timeout", "--kill-after=30s", "1800", "sudo", "-n", "-u", "postgres", "pig", "pitr",
+      "-s", "db-main", "-t", "2026-07-22T01:30:00Z", "-y",
+    ]);
+  });
+
+  test("reports PITR success only after the cluster restore command exits successfully", async () => {
+    commandOutcomes.push({ exitCode: 0 });
+
+    await expect(restore({ target: "2026-07-22T01:30:00Z" })).resolves.toEqual({
+      message: "Point-in-time recovery (PITR) completed, target: 2026-07-22T01:30:00Z",
+    });
+  });
+
+  test("fails closed when PITR times out or cannot start", async () => {
+    commandOutcomes.push({ exitCode: 124 });
+    await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore timed out");
+
+    commandOutcomes.push({ startError: new Error("pig is not installed") });
+    await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore command is unavailable");
+  });
+
+  test("rejects concurrent PITR restores and releases the guard after completion", async () => {
+    let finishRestore!: (exitCode: number) => void;
+    commandOutcomes.push({
+      exitCode: new Promise<number>((resolve) => {
+        finishRestore = resolve;
+      }),
+    });
+
+    const activeRestore = restore({ target: "2026-07-22T01:30:00Z" });
+    await expect(restore({ target: "2026-07-22T01:31:00Z" })).rejects.toThrow("already in progress");
+    finishRestore(0);
+    await expect(activeRestore).resolves.toMatchObject({ message: expect.stringContaining("completed") });
+
+    commandOutcomes.push({ exitCode: 0 });
+    await expect(restore({ target: "2026-07-22T01:32:00Z" })).resolves.toMatchObject({
+      message: expect.stringContaining("completed"),
+    });
+  });
+
+  test("builds non-interactive backup and PITR commands from the configured cluster stanza", async () => {
     const previousEnvironment = {
       stanza: process.env.SUPACLOUD_PGBACKREST_STANZA,
       user: process.env.SUPACLOUD_PGBACKREST_USER,
@@ -107,12 +216,19 @@ describe("BackupService", () => {
     process.env.SUPACLOUD_PGBACKREST_USER = "pgbackrest";
     process.env.SUPACLOUD_PGBACKREST_BIN = "/usr/bin/pgbackrest";
     try {
-      commandOutcomes.push({ exitCode: 0, stdout: inventory([]) });
+      commandOutcomes.push({ exitCode: 0, stdout: inventory([], 0, "cluster-main") });
       await listBackups("supa_project_a");
       expect(spawnedCommands).toEqual([[
-        "timeout", "5", "sudo", "-n", "-u", "pgbackrest", "/usr/bin/pgbackrest",
+        "timeout", "--kill-after=30s", "5", "sudo", "-n", "-u", "pgbackrest", "/usr/bin/pgbackrest",
         "--stanza=cluster-main", "info", "--output=json",
       ]]);
+
+      commandOutcomes.push({ exitCode: 0 });
+      await restore({ target: "2026-07-22T01:30:00Z" });
+      expect(spawnedCommands[1]).toEqual([
+        "timeout", "--kill-after=30s", "1800", "sudo", "-n", "-u", "postgres", "pig", "pitr",
+        "-s", "cluster-main", "-t", "2026-07-22T01:30:00Z", "-y",
+      ]);
     } finally {
       if (previousEnvironment.stanza === undefined) delete process.env.SUPACLOUD_PGBACKREST_STANZA;
       else process.env.SUPACLOUD_PGBACKREST_STANZA = previousEnvironment.stanza;

--- a/packages/management-api/tests/unit/backup.service.test.ts
+++ b/packages/management-api/tests/unit/backup.service.test.ts
@@ -1,16 +1,125 @@
-import { describe, test, expect, spyOn, mock } from "bun:test";
-import { createBackup, restore } from "../../src/services/backup.service";
-import { $ } from "bun";
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { createBackup, listBackups } from "../../src/services/backup.service";
+
+interface CommandOutcome {
+  exitCode?: number;
+  startError?: Error;
+  stdout?: string;
+}
+
+const commandOutcomes: CommandOutcome[] = [];
+const spawnedCommands: string[][] = [];
+const spawnSpy = spyOn(Bun, "spawn").mockImplementation((command) => {
+  const commandOutcome = commandOutcomes.shift();
+  if (!commandOutcome) throw new Error("Unexpected pgBackRest command");
+  if (commandOutcome.startError) throw commandOutcome.startError;
+  spawnedCommands.push(command as string[]);
+  return {
+    exited: Promise.resolve(commandOutcome.exitCode || 0),
+    stdout: new Blob([commandOutcome.stdout || ""]).stream(),
+    stderr: new Blob([]).stream(),
+  } as never;
+});
+
+function inventory(backups: unknown[]) {
+  return JSON.stringify([{ name: "db-main", backup: backups }]);
+}
+
+function fullBackup(label = "20260722-120000F") {
+  return {
+    label,
+    type: "full",
+    timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
+    info: { size: 2048, repository: { size: 1024 } },
+  };
+}
 
 describe("BackupService", () => {
+  beforeEach(() => {
+    commandOutcomes.length = 0;
+    spawnedCommands.length = 0;
+  });
 
-    test("createBackup should return success message immediately", async () => {
-        const result = await createBackup("db-main", "full");
-        expect(result.message).toContain("started");
-    });
+  afterAll(() => spawnSpy.mockRestore());
 
-    test("restore should return success message", async () => {
-        const result = await restore({ target: "2024-01-01T12:00:00Z" });
-        expect(result.message).toContain("started");
-    });
+  test("uses one cluster stanza and reports the requested tenant database", async () => {
+    commandOutcomes.push({ exitCode: 0, stdout: inventory([fullBackup()]) });
+    const backups = await listBackups("supa_project_a");
+
+    expect(spawnedCommands).toEqual([[
+      "timeout", "5", "sudo", "-n", "-u", "postgres", "pgbackrest",
+      "--stanza=db-main", "info", "--output=json",
+    ]]);
+    expect(backups).toEqual([{
+      id: "20260722-120000F",
+      type: "full",
+      timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
+      size: 2048,
+      database: "supa_project_a",
+    }]);
+  });
+
+  test("does not report success until a new completed backup record is readable", async () => {
+    commandOutcomes.push(
+      { exitCode: 0, stdout: inventory([]) },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: inventory([fullBackup()]) },
+    );
+
+    await expect(createBackup("full")).resolves.toEqual({ message: "full backup completed" });
+    expect(spawnedCommands.map((command) => command.at(-1))).toEqual(["--output=json", "backup", "--output=json"]);
+    expect(spawnedCommands[1]).toContain("--type=full");
+  });
+
+  test("fails closed when pgBackRest cannot produce an inventory or backup", async () => {
+    commandOutcomes.push({ exitCode: 1, stderr: "not available" });
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest backup inventory failed");
+
+    commandOutcomes.push(
+      { exitCode: 0, stdout: inventory([]) },
+      { exitCode: 1 },
+    );
+    await expect(createBackup("full")).rejects.toThrow("pgBackRest backup failed");
+  });
+
+  test("fails closed when the pgBackRest command cannot start", async () => {
+    commandOutcomes.push({ startError: new Error("timeout is not installed") });
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest command is unavailable");
+  });
+
+  test("fails closed when the completed backup does not appear in inventory", async () => {
+    commandOutcomes.push(
+      { exitCode: 0, stdout: inventory([]) },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: inventory([]) },
+    );
+
+    await expect(createBackup("full")).rejects.toThrow("pgBackRest backup record is unavailable");
+  });
+
+  test("builds a non-interactive command from the configured cluster stanza", async () => {
+    const previousEnvironment = {
+      stanza: process.env.SUPACLOUD_PGBACKREST_STANZA,
+      user: process.env.SUPACLOUD_PGBACKREST_USER,
+      binary: process.env.SUPACLOUD_PGBACKREST_BIN,
+    };
+    process.env.SUPACLOUD_PGBACKREST_STANZA = "cluster-main";
+    process.env.SUPACLOUD_PGBACKREST_USER = "pgbackrest";
+    process.env.SUPACLOUD_PGBACKREST_BIN = "/usr/bin/pgbackrest";
+    try {
+      commandOutcomes.push({ exitCode: 0, stdout: inventory([]) });
+      await listBackups("supa_project_a");
+      expect(spawnedCommands).toEqual([[
+        "timeout", "5", "sudo", "-n", "-u", "pgbackrest", "/usr/bin/pgbackrest",
+        "--stanza=cluster-main", "info", "--output=json",
+      ]]);
+    } finally {
+      if (previousEnvironment.stanza === undefined) delete process.env.SUPACLOUD_PGBACKREST_STANZA;
+      else process.env.SUPACLOUD_PGBACKREST_STANZA = previousEnvironment.stanza;
+      if (previousEnvironment.user === undefined) delete process.env.SUPACLOUD_PGBACKREST_USER;
+      else process.env.SUPACLOUD_PGBACKREST_USER = previousEnvironment.user;
+      if (previousEnvironment.binary === undefined) delete process.env.SUPACLOUD_PGBACKREST_BIN;
+      else process.env.SUPACLOUD_PGBACKREST_BIN = previousEnvironment.binary;
+    }
+  });
 });

--- a/packages/management-api/tests/unit/platform-capabilities.routes.test.ts
+++ b/packages/management-api/tests/unit/platform-capabilities.routes.test.ts
@@ -70,6 +70,7 @@ describe("project platform capability endpoints", () => {
     listBackups.mockResolvedValue([]);
     resolveDbName.mockReset();
     resolveDbName.mockImplementation((ref: string) => Promise.resolve(`supa_${ref}`));
+    delete process.env.SUPACLOUD_PGBACKREST_STANZA;
     delete process.env.SUPACLOUD_PITR_ENABLED;
     delete process.env.PITR_ENABLED;
   });
@@ -127,10 +128,10 @@ describe("project platform capability endpoints", () => {
       reason: "pitr_not_enabled",
       earliest_physical_backup_date: "2026-06-21T00:00:00.000Z",
       latest_physical_backup_date: "2026-06-21T01:00:00.000Z",
-      backups: { count: 1, stanza: "supa_proj_1" },
+      backups: { count: 1, stanza: "db-main" },
       restore: {
         supported: false,
-        endpoint: "/v1/projects/proj_1/database/backups/restore",
+        endpoint: "/v1/platform/backups/restore",
         requires_admin: true,
       },
     });
@@ -159,5 +160,18 @@ describe("project platform capability endpoints", () => {
       reason: null,
       restore: { supported: true },
     });
+  });
+
+  test("GET PITR reports the configured cluster stanza instead of the tenant database", async () => {
+    process.env.SUPACLOUD_PGBACKREST_STANZA = "cluster-main";
+    try {
+      const res = await request("/v1/projects/proj_1/database/backups/pitr");
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ backups: { stanza: "cluster-main" } });
+      expect(listBackups).toHaveBeenCalledWith("supa_proj_1");
+    } finally {
+      delete process.env.SUPACLOUD_PGBACKREST_STANZA;
+    }
   });
 });

--- a/packages/web-console/src/lib/physical-backup.test.ts
+++ b/packages/web-console/src/lib/physical-backup.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { toPhysicalBackupViewModel, type PhysicalBackupRecord } from "./physical-backup";
+
+describe("physical backup view model", () => {
+  test("maps the management API wire record into renderable backup history fields", () => {
+    const backup: PhysicalBackupRecord = {
+      id: "20260722-120000F",
+      type: "full",
+      timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
+      size: 2048,
+      database: "supa_project_a",
+    };
+
+    expect(toPhysicalBackupViewModel(backup)).toEqual({
+      id: "20260722-120000F",
+      type: "full",
+      status: "completed",
+      timestamp: "2026-07-14T03:33:50.000Z",
+      size: "2 KB",
+      label: "20260722-120000F",
+    });
+  });
+
+  test("uses the start timestamp and running state for an unfinished record", () => {
+    expect(toPhysicalBackupViewModel({
+      id: "20260722-120000I",
+      type: "incr",
+      timestamp: { start: 1_784_000_000, stop: 0 },
+      size: 512,
+    })).toMatchObject({
+      status: "in_progress",
+      timestamp: "2026-07-14T03:33:20.000Z",
+      size: "512 B",
+    });
+  });
+});

--- a/packages/web-console/src/lib/physical-backup.ts
+++ b/packages/web-console/src/lib/physical-backup.ts
@@ -1,0 +1,50 @@
+import type { BaseRecord } from "@svadmin/core";
+
+export type PhysicalBackupRecord = BaseRecord & {
+  id: string;
+  type: "full" | "incr" | "diff";
+  timestamp: {
+    start: number;
+    stop: number;
+  };
+  size: number;
+  database?: string;
+};
+
+export interface PhysicalBackupViewModel {
+  id: string;
+  type: string;
+  status: "completed" | "in_progress";
+  timestamp: string;
+  size: string;
+  label: string;
+}
+
+function formatTimestamp(epoch: number): string {
+  const millis = epoch < 10_000_000_000 ? epoch * 1000 : epoch;
+  return new Date(millis).toISOString();
+}
+
+function formatSize(size: number): string {
+  if (size < 1024) return `${size} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = size / 1024;
+  let unit = units[0];
+  for (let index = 1; index < units.length && value >= 1024; index += 1) {
+    value /= 1024;
+    unit = units[index];
+  }
+  return `${Number(value.toFixed(1))} ${unit}`;
+}
+
+export function toPhysicalBackupViewModel(backup: PhysicalBackupRecord): PhysicalBackupViewModel {
+  const completed = backup.timestamp.stop > 0;
+  return {
+    id: backup.id,
+    type: backup.type,
+    status: completed ? "completed" : "in_progress",
+    timestamp: formatTimestamp(completed ? backup.timestamp.stop : backup.timestamp.start),
+    size: formatSize(backup.size),
+    label: backup.id,
+  };
+}

--- a/packages/web-console/src/routes/platform/backups/+page.svelte
+++ b/packages/web-console/src/routes/platform/backups/+page.svelte
@@ -1,23 +1,18 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
+  import { toPhysicalBackupViewModel, type PhysicalBackupRecord } from "$lib/physical-backup";
 
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
   import { Loader2, HardDrive, Play, RotateCcw, Calendar, Clock, AlertTriangle, CheckCircle2, RefreshCw } from "lucide-svelte";
 
-  import { useList, type BaseRecord } from "@svadmin/core";
+  import { useList } from "@svadmin/core";
 
-  interface BackupInfo extends BaseRecord {
-    id: string;
-    type: string;
-    status: string;
-    timestamp: string;
-    size: string;
-    label: string;
-  }
-
-  const query = useList<BackupInfo>({ resource: "v1/projects/default/database/backups" });
-  const backups = $derived(Array.isArray(query.data?.data) ? query.data.data : ((query.data?.data as unknown as Record<string, unknown>)?.backups as BackupInfo[] || []));
+  const query = useList<PhysicalBackupRecord>({ resource: "v1/projects/default/database/backups" });
+  const backupRecords = $derived(Array.isArray(query.data?.data)
+    ? query.data.data
+    : ((query.data?.data as unknown as Record<string, unknown>)?.backups as PhysicalBackupRecord[] || []));
+  const backups = $derived(backupRecords.map(toPhysicalBackupViewModel));
 
   let actionMsg: string | null = $state.raw(null);
   let isCreating = $state(false);
@@ -44,6 +39,15 @@
     return Number.isNaN(value.getTime()) ? null : value.toISOString();
   }
 
+  async function readActionResponse(response: Response): Promise<Record<string, unknown>> {
+    const payload: unknown = await response.json().catch(() => ({}));
+    return payload && typeof payload === "object" ? payload as Record<string, unknown> : {};
+  }
+
+  function responseMessage(payload: Record<string, unknown>, fallback: string): string {
+    return typeof payload.message === "string" && payload.message ? payload.message : fallback;
+  }
+
   async function createBackup() {
     isCreating = true;
     actionMsg = null;
@@ -53,10 +57,11 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ type: backupType })
       });
-      const data = await res.json();
-      actionMsg = data.success !== false
-        ? `✅ ${$t("PlatformBackups.backup_triggered")} (${backupLabel(backupType)})`
-        : `❌ ${data.message || ($t("PlatformBackups.backup_failed") || "Backup failed")}`;
+      const data = await readActionResponse(res);
+      if (!res.ok) {
+        throw new Error(responseMessage(data, $t("PlatformBackups.backup_failed") || "Backup failed"));
+      }
+      actionMsg = `✅ ${responseMessage(data, `${$t("PlatformBackups.backup_triggered")} (${backupLabel(backupType)})`)}`;
       query.refetch();
     } catch (err: unknown) {
       actionMsg = `❌ ${(err instanceof Error ? err.message : String(err))}`;
@@ -82,15 +87,16 @@
     isRestoring = true;
     actionMsg = null;
     try {
-      const res = await apiClient("/v1/projects/default/database/backups/restore", {
+      const res = await apiClient("/v1/platform/backups/restore", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ target })
+        body: JSON.stringify({ target, confirmation: `RESTORE_CLUSTER:${target}` })
       });
-      const data = await res.json();
-      actionMsg = data.success !== false
-        ? `✅ ${$t("PlatformBackups.restore_sent") || "PITR restore command sent"}`
-        : `❌ ${data.message}`;
+      const data = await readActionResponse(res);
+      if (!res.ok) {
+        throw new Error(responseMessage(data, "PITR restore failed"));
+      }
+      actionMsg = `✅ ${responseMessage(data, $t("PlatformBackups.restore_sent") || "PITR restore completed")}`;
       showPitr = false;
     } catch (err: unknown) {
       actionMsg = `❌ ${(err instanceof Error ? err.message : String(err))}`;
@@ -201,6 +207,12 @@
     {#if query.isLoading}
       <div class="flex items-center justify-center py-16">
         <Loader2 size={24} class="animate-spin text-brand opacity-50" />
+      </div>
+    {:else if query.isError}
+      <div class="p-4">
+        <div class="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-xs">
+          {query.error?.message || ($t("PlatformBackups.backup_failed") || "Backup inventory is unavailable")}
+        </div>
       </div>
     {:else if backups.length === 0}
       <div class="p-8 text-center text-muted-foreground text-xs">{$t("PlatformBackups.no_history") || "No backup history yet. Run a backup above and it will appear here."}</div>


### PR DESCRIPTION
## Summary
- use one explicit cluster pgBackRest stanza instead of treating tenant database names as stanzas
- require info -> backup -> info readback of a new completed backup before returning success
- return explicit 503 responses when pgBackRest is unavailable and remove duplicate backup/restore routes

## Verification
- bun run test:unit
- bun run typecheck
- bun run build:amd64
- git diff --check