### PR TITLE
fix(migrations): preserve transactional migration compatibility

### DIFF
--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -86,6 +86,52 @@ describe("database migration helpers", () => {
         }
     });
 
+    test("skips only the exact already-applied migration response", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                post: async () => ({
+                    ok: false,
+                    status: 409,
+                    data: { code: "409", message: "Migration already applied" },
+                }),
+            });
+
+            const toolResult = await callback({ action: "push_migrations", ref: "proj", dir });
+            expect(toolResult.content[0].text).toContain("Migration push completed");
+            expect(toolResult.content[0].text).toContain("Applied: 0");
+            expect(toolResult.content[0].text).toContain("Skipped: 1");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("fails migration pushes on checksum-conflict 409 responses", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                post: async () => ({
+                    ok: false,
+                    status: 409,
+                    data: {
+                        code: "migration_checksum_conflict",
+                        message: "Migration conflicts with an existing checksum",
+                    },
+                }),
+            });
+
+            const toolResult = await callback({ action: "push_migrations", ref: "proj", dir });
+            expect(toolResult.content[0].text).toContain("Failed to apply 20260425123000_create_users.sql (409)");
+            expect(toolResult.content[0].text).toContain("migration_checksum_conflict");
+            expect(toolResult.content[0].text).toContain("Skipped before failure: 0");
+            expect(toolResult.content[0].text).not.toContain("Migration push completed");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     test("previews baseline repair without executing SQL", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         const posts: Array<{ path: string; body: unknown }> = [];

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -31,6 +31,12 @@ function appliedMigrationKeys(data: unknown): Set<string> {
     return keys;
 }
 
+function isAlreadyAppliedMigrationResponse(response: { status: number; data: unknown }): boolean {
+    if (response.status !== 409 || !response.data || typeof response.data !== "object") return false;
+    const body = response.data as Record<string, unknown>;
+    return body.code === "409" && body.message === "Migration already applied";
+}
+
 function sqlReferencesVector(sql: string): boolean {
     return /\bvector\s*\(\s*\d+\s*\)/i.test(sql)
         || /::\s*vector\b/i.test(sql)
@@ -316,7 +322,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         const r = await http.post(`/v1/projects/${ref}/database/migrations`, { name, sql, version });
                         if (r.ok) {
                             applied.push(file);
-                        } else if (r.status === 409) {
+                        } else if (isAlreadyAppliedMigrationResponse(r)) {
                             skipped.push(file);
                         } else {
                             text = [

--- a/packages/management-api/src/db/sql-policy.ts
+++ b/packages/management-api/src/db/sql-policy.ts
@@ -63,12 +63,96 @@ const LEGACY_DANGEROUS_SQL_PATTERNS: readonly RegExp[] = [
   /\bpg_catalog\b.*\bpg_execute_server_program\b/i,
 ];
 
+function startsEscapeString(sql: string, quoteIndex: number): boolean {
+  const prefixIndex = quoteIndex - 1;
+  const prefix = sql[prefixIndex] || "";
+  const preceding = sql[prefixIndex - 1] || "";
+  return /[eE]/.test(prefix) && !/[A-Za-z0-9_$]/.test(preceding);
+}
+
+function singleQuotedLiteralEnd(sql: string, start: number): number {
+  const usesBackslashEscapes = startsEscapeString(sql, start);
+  let cursor = start + 1;
+  while (cursor < sql.length) {
+    if (usesBackslashEscapes && sql[cursor] === "\\" && cursor + 1 < sql.length) cursor += 2;
+    else if (sql[cursor] === "'" && sql[cursor + 1] === "'") cursor += 2;
+    else if (sql[cursor] === "'") return cursor + 1;
+    else cursor += 1;
+  }
+  return sql.length;
+}
+
+function doubleQuotedIdentifierEnd(sql: string, start: number): number {
+  let cursor = start + 1;
+  while (cursor < sql.length) {
+    if (sql[cursor] === '"' && sql[cursor + 1] === '"') cursor += 2;
+    else if (sql[cursor] === '"') return cursor + 1;
+    else cursor += 1;
+  }
+  return sql.length;
+}
+
+function lineCommentEnd(sql: string, start: number): number {
+  const end = sql.indexOf("\n", start + 2);
+  return end === -1 ? sql.length : end;
+}
+
+function blockCommentEnd(sql: string, start: number): number {
+  let depth = 1;
+  let cursor = start + 2;
+  while (cursor < sql.length && depth > 0) {
+    if (sql.startsWith("/*", cursor)) {
+      depth += 1;
+      cursor += 2;
+    } else if (sql.startsWith("*/", cursor)) {
+      depth -= 1;
+      cursor += 2;
+    } else cursor += 1;
+  }
+  return cursor;
+}
+
+function dollarQuoteTagAt(sql: string, index: number): string {
+  if (/[A-Za-z0-9_$]/.test(sql[index - 1] || "")) return "";
+  return sql.slice(index).match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/)?.[0] || "";
+}
+
+function maskSqlPolicyNoise(sql: string): string {
+  let maskedSql = "";
+  let cursor = 0;
+  while (cursor < sql.length) {
+    let protectedEnd = 0;
+    if (sql.startsWith("--", cursor)) protectedEnd = lineCommentEnd(sql, cursor);
+    else if (sql.startsWith("/*", cursor)) protectedEnd = blockCommentEnd(sql, cursor);
+    else if (sql[cursor] === "'") protectedEnd = singleQuotedLiteralEnd(sql, cursor);
+    else if (sql[cursor] === '"') {
+      protectedEnd = doubleQuotedIdentifierEnd(sql, cursor);
+      maskedSql += sql.slice(cursor, protectedEnd);
+      cursor = protectedEnd;
+      continue;
+    }
+    if (protectedEnd > 0) {
+      maskedSql += " ".repeat(protectedEnd - cursor);
+      cursor = protectedEnd;
+      continue;
+    }
+
+    const tag = sql[cursor] === "$" ? dollarQuoteTagAt(sql, cursor) : "";
+    if (!tag) {
+      maskedSql += sql[cursor]!;
+      cursor += 1;
+      continue;
+    }
+    const end = sql.indexOf(tag, cursor + tag.length);
+    if (end === -1) return maskedSql + sql.slice(cursor);
+    maskedSql += tag + " ".repeat(end - cursor - tag.length) + tag;
+    cursor = end + tag.length;
+  }
+  return maskedSql;
+}
+
 export function normalizeSqlForPolicy(sqlQuery: string): string {
-  return sqlQuery
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/--.*$/gm, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return maskSqlPolicyNoise(sqlQuery).replace(/\s+/g, " ").trim();
 }
 
 export function isDangerousSQL(sqlQuery: string): boolean {

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -2,6 +2,8 @@ import { Elysia, t } from "elysia";
 import type { TransactionSQL } from "bun";
 import { projectService } from "../services";
 import { db, getProjectDb, getProjectRoleDb, removeProjectDbCache, resolveDbName, sql as metaSql, type SqlExecutionMode } from "../db";
+import { normalizeSqlForPolicy } from "../db/sql-policy";
+import { splitSqlStatements } from "../db/sql-statements";
 import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
 import {
   calculateMigrationChecksum,
@@ -64,6 +66,24 @@ export function resolveMigrationStatements(body: MigrationBody): string[] {
   }
 
   return [];
+}
+
+/**
+ * Migration clients commonly submit a file wrapped in one outer transaction.
+ * The management API already owns that transaction, so execute only the file
+ * contents while retaining the original statements for checksums and history.
+ */
+export function migrationExecutionStatements(statements: readonly string[]): string[] {
+  const normalized = statements.flatMap((statement) => splitSqlStatements(statement));
+  const executionStatements = normalized.length >= 2
+    && /^(?:BEGIN(?:\s+(?:WORK|TRANSACTION))?|START\s+TRANSACTION)$/i.test(normalizeSqlForPolicy(normalized[0]!))
+    && /^(?:COMMIT|END)(?:\s+(?:WORK|TRANSACTION))?$/i.test(normalizeSqlForPolicy(normalized[normalized.length - 1]!))
+    ? normalized.slice(1, -1)
+    : normalized;
+  if (executionStatements.length === 0) {
+    throw new MigrationRouteError(400, "empty_migration", "Migration contains no executable statements");
+  }
+  return executionStatements;
 }
 
 const MAX_MIGRATION_VERSION = 9_223_372_036_854_775_807n;
@@ -241,6 +261,11 @@ interface RecordedMigrationInput {
   conflictOnName: boolean;
 }
 
+interface MigrationExecutionPlan {
+  checksum: string;
+  statements: readonly string[];
+}
+
 function existingMigrationChecksum(
   row: Record<string, unknown>,
   fallback: { version: string; name: string },
@@ -307,14 +332,14 @@ async function executeMigrationTransaction(
   connection: ReservedProjectSql,
   adminDb: ProjectSql,
   input: RecordedMigrationInput,
-  checksum: string,
+  execution: MigrationExecutionPlan,
 ): Promise<boolean> {
   const leaseHolder: { current?: Awaited<ReturnType<typeof issueMigrationLedgerLease>> } = {};
   try {
     return await connection.begin(async (tx) => {
       const existing = await findExistingMigration(tx, input);
       if (existing.length > 0) {
-        if (existingMigrationChecksum(existing[0]!, input) !== checksum) {
+        if (existingMigrationChecksum(existing[0]!, input) !== execution.checksum) {
           throw new MigrationRouteError(
             409,
             "migration_checksum_conflict",
@@ -323,10 +348,18 @@ async function executeMigrationTransaction(
         }
         return true;
       }
-      for (const statement of input.statements) await tx.unsafe(statement);
-      const issuedLease = await issueMigrationLedgerLease(adminDb, input.version, checksum);
+      const unsupported = detectUnsupportedMigrationOperations(execution.statements);
+      if (unsupported.length > 0) {
+        throw new MigrationRouteError(
+          400,
+          "unsupported_migration_sql",
+          `Migration contains SQL outside the project-scoped path: ${unsupported.join(", ")}`,
+        );
+      }
+      for (const statement of execution.statements) await tx.unsafe(statement);
+      const issuedLease = await issueMigrationLedgerLease(adminDb, input.version, execution.checksum);
       leaseHolder.current = issuedLease;
-      await insertMigrationLedger(tx, input, checksum, issuedLease.token);
+      await insertMigrationLedger(tx, input, execution.checksum, issuedLease.token);
       return false;
     });
   } finally {
@@ -365,20 +398,18 @@ async function applyRecordedMigration(input: RecordedMigrationInput): Promise<{
   checksum: string;
   alreadyApplied: boolean;
 }> {
-  const unsupported = detectUnsupportedMigrationOperations(input.statements);
-  if (unsupported.length > 0) {
-    throw new MigrationRouteError(
-      400,
-      "unsupported_migration_sql",
-      `Migration contains SQL outside the project-scoped path: ${unsupported.join(", ")}`,
-    );
-  }
   const checksum = calculateMigrationChecksum(input);
+  const executionStatements = migrationExecutionStatements(input.statements);
 
   return withProjectMigrationLocks({ projectRefs: [input.projectRef] }, async () => {
     await branchReplacementJournal.assertInactive([input.projectRef]);
     return withMigrationRoleSession(input, async (connection, adminDb) => {
-      const alreadyApplied = await executeMigrationTransaction(connection, adminDb, input, checksum);
+      const alreadyApplied = await executeMigrationTransaction(
+        connection,
+        adminDb,
+        input,
+        { checksum, statements: executionStatements },
+      );
       await ensureTasksRealtimePublication(adminDb);
       return { checksum, alreadyApplied };
     });

--- a/packages/management-api/tests/unit/database-routes.test.ts
+++ b/packages/management-api/tests/unit/database-routes.test.ts
@@ -7,11 +7,14 @@ import {
   buildCreateMaterializedViewSql,
   buildDropMaterializedViewSql,
   buildRefreshMaterializedViewSql,
+  migrationExecutionStatements,
   normalizeMigrationVersion,
   resetEnsuredMigrationTablesForTests,
   resolveMigrationStatements,
   sqlRouteResponse,
 } from "../../src/routes/database";
+import { projectMigrationSqlViolations } from "../../src/db/sql-policy";
+import { calculateMigrationChecksum } from "../../src/services/migration-promotion";
 
 describe("database route helpers", () => {
   beforeEach(() => {
@@ -47,6 +50,102 @@ describe("database route helpers", () => {
       }),
     ).toEqual([]);
     expect(resolveMigrationStatements({ query: "   " })).toEqual([]);
+  });
+
+  test("removes only an outer transaction wrapper before execution", () => {
+    const wrappedFile = ["BEGIN;", "CREATE TABLE public.example(id integer);", "COMMIT;"];
+    expect(migrationExecutionStatements(wrappedFile)).toEqual([
+      "CREATE TABLE public.example(id integer)",
+    ]);
+    expect(migrationExecutionStatements(["BEGIN;\nCREATE TABLE public.example(id integer);\nCOMMIT;"]))
+      .toEqual(["CREATE TABLE public.example(id integer)"]);
+    expect(migrationExecutionStatements([
+      "-- generated migration\nBEGIN TRANSACTION;\nCREATE TABLE public.example(id integer);\nCOMMIT WORK;",
+    ])).toEqual(["CREATE TABLE public.example(id integer)"]);
+
+    const wrappedDoBlock = ["BEGIN;", "DO $$ BEGIN PERFORM 1; END $$;", "COMMIT;"];
+    expect(migrationExecutionStatements(wrappedDoBlock)).toEqual([
+      "DO $$ BEGIN PERFORM 1; END $$",
+    ]);
+    expect(projectMigrationSqlViolations(migrationExecutionStatements(wrappedFile)))
+      .not.toContain("transaction control");
+    expect(projectMigrationSqlViolations(migrationExecutionStatements(wrappedDoBlock)))
+      .not.toContain("transaction control");
+    expect(projectMigrationSqlViolations(migrationExecutionStatements(wrappedDoBlock)))
+      .toContain("opaque procedural SQL");
+  });
+
+  test("derives xigu-style function execution without changing ledger input", () => {
+    const wrappedSql = `
+      BEGIN;
+      CREATE OR REPLACE FUNCTION public.fa_case_member_role_compatibility_guard()
+      RETURNS trigger
+      LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $function$
+      BEGIN
+        IF NEW.membership_id IS NULL THEN
+          RAISE EXCEPTION 'FA_CASE_MEMBER_REQUIRED';
+        END IF;
+        RETURN NEW;
+      END;
+      $function$;
+      GRANT EXECUTE ON FUNCTION public.fa_case_member_role_compatibility_guard() TO service_role;
+      COMMIT;
+    `.trim();
+    const originalStatements = [wrappedSql];
+    const executionStatements = migrationExecutionStatements(originalStatements);
+
+    expect(executionStatements).toHaveLength(2);
+    expect(executionStatements[0]).toContain("BEGIN\n        IF NEW.membership_id IS NULL");
+    expect(executionStatements[0]).toContain("END;\n      $function$");
+    expect(executionStatements[1]).toStartWith("GRANT EXECUTE ON FUNCTION");
+    expect(originalStatements).toEqual([wrappedSql]);
+    expect(calculateMigrationChecksum({ version: "20260719126000", name: "xigu", statements: originalStatements }))
+      .not.toBe(calculateMigrationChecksum({ version: "20260719126000", name: "xigu", statements: executionStatements }));
+  });
+
+  test("rejects migrations that are empty after execution derivation", () => {
+    expect(() => migrationExecutionStatements(["BEGIN; COMMIT;"]))
+      .toThrow("Migration contains no executable statements");
+    expect(() => migrationExecutionStatements(["BEGIN; -- no statements\nCOMMIT;"]))
+      .toThrow("Migration contains no executable statements");
+    expect(() => migrationExecutionStatements(["-- comment only"]))
+      .toThrow("Migration contains no executable statements");
+  });
+
+  test("checks existing checksums before applying the current SQL policy", () => {
+    const source = readFileSync(join(import.meta.dirname, "../../src/routes/database.ts"), "utf8");
+    const transactionStart = source.indexOf("async function executeMigrationTransaction(");
+    const transactionEnd = source.indexOf("async function withMigrationRoleSession", transactionStart);
+    const transactionSource = source.slice(transactionStart, transactionEnd);
+    const existingLookup = transactionSource.indexOf("findExistingMigration(tx, input)");
+    const checksumCheck = transactionSource.indexOf("existingMigrationChecksum(existing[0]!, input)");
+    const checksumConflict = transactionSource.indexOf('"migration_checksum_conflict"');
+    const alreadyAppliedReturn = transactionSource.indexOf("return true;");
+    const policyCheck = transactionSource.indexOf("detectUnsupportedMigrationOperations(execution.statements)");
+
+    expect(existingLookup).toBeGreaterThan(-1);
+    expect(checksumCheck).toBeGreaterThan(existingLookup);
+    expect(checksumConflict).toBeGreaterThan(checksumCheck);
+    expect(alreadyAppliedReturn).toBeGreaterThan(checksumConflict);
+    expect(policyCheck).toBeGreaterThan(alreadyAppliedReturn);
+  });
+
+  test("does not let quoted dollar markers hide top-level policy controls", () => {
+    const adversarialCases: Array<[string, string]> = [
+      ["SELECT '$$'; COMMIT; SELECT $$x$$;", "transaction control"],
+      ["SELECT '$$'; SET ROLE postgres; SELECT $$x$$;", "session role control"],
+      [
+        "SELECT '$$'; INSERT INTO supabase_migrations.schema_migrations(version) VALUES ('1'); SELECT $$x$$;",
+        "migration ledger modification",
+      ],
+      ["SELECT '$$'; SELECT pg_advisory_lock(1); SELECT $$x$$;", "advisory lock control"],
+      ["SELECT '$$'; DO $$ BEGIN PERFORM 1; END $$;", "opaque procedural SQL"],
+    ];
+
+    for (const [sql, expectedViolation] of adversarialCases) {
+      expect(projectMigrationSqlViolations(migrationExecutionStatements([sql])))
+        .toContain(expectedViolation);
+    }
   });
 
   test("preserves bigint migration versions without Number precision loss", () => {

--- a/packages/management-api/tests/unit/sql-policy.test.ts
+++ b/packages/management-api/tests/unit/sql-policy.test.ts
@@ -41,6 +41,42 @@ describe("project migration SQL policy", () => {
     ]));
   });
 
+  test("does not treat PL/pgSQL function-body operations as top-level migration control", () => {
+    const functionDefinition = `
+      CREATE FUNCTION public.lock_example() RETURNS void
+      LANGUAGE plpgsql AS $function$
+      BEGIN
+        SET LOCAL ROLE postgres;
+        PERFORM pg_advisory_xact_lock(1);
+      END;
+      $function$;
+    `;
+    expect(projectMigrationSqlViolations([functionDefinition])).not.toContain("transaction control");
+    expect(projectMigrationSqlViolations([functionDefinition])).not.toContain("advisory lock control");
+    expect(projectMigrationSqlViolations([functionDefinition])).not.toContain("session role control");
+    expect(projectMigrationSqlViolations(["DO $$ BEGIN PERFORM 1; END $$;"]))
+      .toContain("opaque procedural SQL");
+  });
+
+  test("continues to block privileged operations at the migration top level", () => {
+    const violations = projectMigrationSqlViolations([
+      "CREATE FUNCTION public.safe_body() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$",
+      "SET ROLE postgres",
+      "SELECT pg_advisory_xact_lock(1)",
+      "COMMIT",
+    ]);
+
+    expect(violations).toEqual(expect.arrayContaining([
+      "session role control",
+      "advisory lock control",
+      "transaction control",
+    ]));
+    expect(projectMigrationSqlViolations(["SELECT $unterminated$", "SET ROLE postgres"]))
+      .toContain("session role control");
+    expect(projectMigrationSqlViolations(["SELECT $unterminated$; SET ROLE postgres"]))
+      .toContain("session role control");
+  });
+
   test("keeps the generic migration endpoint's older conservative policy", () => {
     expect(isDangerousSQL("drop table public.accounts")).toBe(true);
   });


### PR DESCRIPTION
## Summary

- make migration replay idempotency check the ledger and checksum before current SQL policy validation
- execute only the derived SQL statements inside the management API transaction while preserving original SQL for checksum and ledger history
- keep outer transaction wrappers compatible with project migration files and reject empty wrappers
- make the CLI skip only the exact already-applied 409 response; checksum conflicts remain failures
- make migration SQL policy scanning quote/comment-aware so PL/pgSQL bodies do not create false positives without hiding top-level controls

## Verification

- Management API focused tests: 23 passed
- CLI focused tests: 12 passed
- Management API and CLI typechecks passed
- xigu-fa pending migrations 20260722001000, 20260722090000, 20260722091000, 20260722092000 accepted with stable original checksums
- adversarial transaction/role/ledger/advisory-lock/DO policy probes blocked
- git diff --check passed
