### PR TITLE
fix(management-api): order migration-owned sequences after tables

### DIFF
--- a/packages/management-api/src/services/project-migration-role.ts
+++ b/packages/management-api/src/services/project-migration-role.ts
@@ -100,6 +100,7 @@ export function renderProjectMigrationRoleSql(dbName: string, dbUser: string): s
               AND d.objid = c.oid
               AND d.deptype = 'e'
           )
+        ORDER BY CASE WHEN c.relkind = 'S' THEN 1 ELSE 0 END, c.oid
       LOOP
         routine_kind := CASE object_row.relkind
           WHEN 'S' THEN 'SEQUENCE'

--- a/packages/management-api/tests/unit/project-migration-role.test.ts
+++ b/packages/management-api/tests/unit/project-migration-role.test.ts
@@ -21,6 +21,12 @@ describe("project migration role preparation", () => {
     expect(sql).not.toContain("CREATEROLE");
   });
 
+  test("orders tables and partitioned tables before linked sequences", () => {
+    const sql = renderProjectMigrationRoleSql("supa_parent", "role_parent");
+
+    expect(sql).toContain("ORDER BY CASE WHEN c.relkind = 'S' THEN 1 ELSE 0 END, c.oid");
+  });
+
   test("rejects unsafe database and role identifiers", () => {
     expect(() => renderProjectMigrationRoleSql("supa_parent; drop database x", "role_parent")).toThrow();
     expect(() => renderProjectMigrationRoleSql("supa_parent", "role_parent; alter role postgres")).toThrow();

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.6.0",
-        "@supacloud/cli": "^0.12.0",
+        "@supacloud/cli": "^0.12.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -17,9 +17,9 @@
   "packages": {
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supacloud/admin": ["@supacloud/admin@0.6.0", "", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
+    "@supacloud/admin": ["@supacloud/admin@0.6.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.6.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.12.0", "", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-zczHnMoHWghEBksr1+0qxciEQe79NdaAWUIfVE9aBFt+gu2F72gti8bn0yrS9Qu29MGzedhcXjCYpPyX7h8iBw=="],
+    "@supacloud/cli": ["@supacloud/cli@0.12.1", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-Zmo+WX3mrOfPZiORprfEFJv6y5iIe9Xw0+CdVMlJGL1L7SDtmzioegCMuVsGXYwnc+QdygWib4VRvUex025cig=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary
- order public object ownership repair so tables/partitioned tables are transferred before linked sequences
- prevent PostgreSQL 18 serial/identity migrations from failing with `cannot change owner of sequence`
- add a regression assertion for the ordering contract

## Verification
- `bun test tests/unit/project-migration-role.test.ts tests/unit/database-routes.test.ts tests/unit/migration-ledger.test.ts`
- `bun run typecheck` (packages/management-api)
- `git diff --check`
- PostgreSQL 18 smoke covering serial, identity, partition, standalone and owned sequences
