### PR TITLE
fix(cli): skip explicit baseline migration markers

### DIFF
--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -91,6 +91,7 @@ describe("database migration helpers", () => {
         try {
             writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
             const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
                 post: async () => ({
                     ok: false,
                     status: 409,
@@ -112,6 +113,7 @@ describe("database migration helpers", () => {
         try {
             writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
             const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
                 post: async () => ({
                     ok: false,
                     status: 409,
@@ -127,6 +129,49 @@ describe("database migration helpers", () => {
             expect(toolResult.content[0].text).toContain("migration_checksum_conflict");
             expect(toolResult.content[0].text).toContain("Skipped before failure: 0");
             expect(toolResult.content[0].text).not.toContain("Migration push completed");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("skips baseline markers before POST but still POSTs ordinary existing migrations", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const posts: Array<{ path: string; body: unknown }> = [];
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [
+                        {
+                            version: "20260425123000",
+                            name: "20260425123000_create_users",
+                            statements: ["baseline:20260425123000_create_users"],
+                        },
+                        {
+                            version: "20260425124000",
+                            name: "20260425124000_create_tasks",
+                            statements: ["CREATE TABLE tasks (id uuid);"],
+                        },
+                    ],
+                }),
+                post: async (path: string, body: unknown) => {
+                    posts.push({ path, body });
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            const toolResult = await callback({ action: "push_migrations", ref: "proj", dir });
+            const text = toolResult.content[0].text;
+
+            expect(text).toContain("Migration push completed");
+            expect(text).toContain("Applied: 1");
+            expect(text).toContain("Skipped: 1");
+            expect(posts).toHaveLength(1);
+            expect(posts[0].path).toBe("/v1/projects/proj/database/migrations");
+            expect((posts[0].body as { name: string }).name).toBe("20260425124000_create_tasks");
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -24,11 +24,14 @@ describe("database migration helpers", () => {
 
     test("preserves valid 19-digit migration versions without precision loss", () => {
         expect(migrationVersionFromFilename("9007199254740993001_create_users.sql")).toBe("9007199254740993001");
+        expect(migrationVersionFromFilename("9223372036854775807_max_version.sql")).toBe("9223372036854775807");
     });
 
     test("rejects migration versions above the PostgreSQL BIGINT limit", () => {
         expect(() => migrationVersionFromFilename("20260425123000123456-create-users.sql"))
             .toThrow("expected 1..9223372036854775807");
+        expect(() => migrationVersionFromFilename("8000000000000000001-collides-with-fallback.sql"))
+            .toThrow("reserved for non-timestamp migrations");
     });
 
     test("uses a stable numeric version for non timestamp names", () => {
@@ -39,6 +42,49 @@ describe("database migration helpers", () => {
         expect(first).toMatch(/^\d+$/);
         expect(BigInt(first)).toBeGreaterThanOrEqual(8_000_000_000_000_000_000n);
         expect(BigInt(first)).toBeLessThan(9_000_000_000_000_000_000n);
+    });
+
+    test("pushes non-timestamp migrations in stable fallback-version order", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const posts: Array<{ name: string; version: string }> = [];
+        try {
+            writeFileSync(join(dir, "alpha.sql"), "CREATE TABLE alpha (id uuid);\n");
+            writeFileSync(join(dir, "beta.sql"), "CREATE TABLE beta (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                post: async (_path: string, body: { name: string; version: string }) => {
+                    posts.push({ name: body.name, version: body.version });
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(posts).toHaveLength(2);
+            expect(BigInt(posts[0].version)).toBeLessThan(BigInt(posts[1].version));
+            expect(posts.map(({ name }) => name)).toEqual(
+                [...posts].sort((a, b) => BigInt(a.version) < BigInt(b.version) ? -1 : 1).map(({ name }) => name),
+            );
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects distinct migration files with the same version", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_alpha.sql"), "CREATE TABLE alpha (id uuid);\n");
+            writeFileSync(join(dir, "20260425123000_beta.sql"), "CREATE TABLE beta (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                post: async () => ({ ok: true, status: 200, data: {} }),
+            });
+
+            await expect(callback({ action: "push_migrations", ref: "proj", dir }))
+                .rejects.toThrow("Migration version collision");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
     });
 
     test("warns when pending migrations use pgvector without enabled extension", () => {

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -19,14 +19,26 @@ function captureDatabaseTool(http: Record<string, unknown>) {
 
 describe("database migration helpers", () => {
     test("uses Supabase timestamp prefix as migration version", () => {
-        expect(migrationVersionFromFilename("20260425123000_create_users.sql")).toBe(20260425123000);
-        expect(migrationVersionFromFilename("20260425123000123456-create-users.sql")).toBe(20260425123000123456);
+        expect(migrationVersionFromFilename("20260425123000_create_users.sql")).toBe("20260425123000");
     });
 
-    test("falls back to a generated numeric version for non timestamp names", () => {
-        const version = migrationVersionFromFilename("create_users.sql", 2);
-        expect(Number.isFinite(version)).toBe(true);
-        expect(version).toBeGreaterThan(Date.now() * 1000 - 60_000_000);
+    test("preserves valid 19-digit migration versions without precision loss", () => {
+        expect(migrationVersionFromFilename("9007199254740993001_create_users.sql")).toBe("9007199254740993001");
+    });
+
+    test("rejects migration versions above the PostgreSQL BIGINT limit", () => {
+        expect(() => migrationVersionFromFilename("20260425123000123456-create-users.sql"))
+            .toThrow("expected 1..9223372036854775807");
+    });
+
+    test("uses a stable numeric version for non timestamp names", () => {
+        const first = migrationVersionFromFilename("create_users.sql");
+        const second = migrationVersionFromFilename("create_users.sql");
+
+        expect(second).toBe(first);
+        expect(first).toMatch(/^\d+$/);
+        expect(BigInt(first)).toBeGreaterThanOrEqual(8_000_000_000_000_000_000n);
+        expect(BigInt(first)).toBeLessThan(9_000_000_000_000_000_000n);
     });
 
     test("warns when pending migrations use pgvector without enabled extension", () => {
@@ -172,6 +184,7 @@ describe("database migration helpers", () => {
             expect(posts).toHaveLength(1);
             expect(posts[0].path).toBe("/v1/projects/proj/database/migrations");
             expect((posts[0].body as { name: string }).name).toBe("20260425124000_create_tasks");
+            expect((posts[0].body as { version: string }).version).toBe("20260425124000");
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -2,6 +2,7 @@
  * Database — Compound tool (18→1)
  * SQL execution, schema introspection, RLS, migrations, stats
  */
+import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import { Type } from "@sinclair/typebox";
@@ -13,10 +14,23 @@ export interface DatabaseToolsConfig {
     projectRef?: string;
 }
 
-export function migrationVersionFromFilename(file: string, fallbackIndex = 0): number {
+const MAX_MIGRATION_VERSION = 9_223_372_036_854_775_807n;
+const FALLBACK_MIGRATION_VERSION_BASE = 8_000_000_000_000_000_000n;
+const FALLBACK_MIGRATION_VERSION_RANGE = 1_000_000_000_000_000_000n;
+
+export function migrationVersionFromFilename(file: string): string {
     const match = basename(file).match(/^(\d{8,20})[_-]/);
-    if (match) return Number(match[1]);
-    return Date.now() * 1000 + fallbackIndex;
+    if (match) {
+        const version = BigInt(match[1]);
+        if (version < 1n || version > MAX_MIGRATION_VERSION) {
+            throw new Error(`Invalid migration version '${match[1]}' in ${basename(file)}: expected 1..${MAX_MIGRATION_VERSION}`);
+        }
+        return version.toString();
+    }
+
+    const digest = createHash("sha256").update(basename(file)).digest("hex");
+    const offset = BigInt(`0x${digest}`) % FALLBACK_MIGRATION_VERSION_RANGE;
+    return (FALLBACK_MIGRATION_VERSION_BASE + offset).toString();
 }
 
 function appliedMigrationKeys(data: unknown): Set<string> {
@@ -38,8 +52,8 @@ function migrationRows(data: unknown): Array<Record<string, unknown>> {
         : [];
 }
 
-function baselineMigrationKey(version: number | string, name: string): string {
-    return `${String(version)}\u0000${name}`;
+function baselineMigrationKey(version: string, name: string): string {
+    return `${version}\u0000${name}`;
 }
 
 function baselineMigrationKeys(data: unknown): Set<string> {
@@ -295,10 +309,10 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const migrationFiles = files.map((file, i) => ({
+                    const migrationFiles = files.map((file) => ({
                         file,
                         name: basename(file, ".sql"),
-                        version: migrationVersionFromFilename(file, i),
+                        version: migrationVersionFromFilename(file),
                     }));
 
                     const migrationsResult = await http.get(`/v1/projects/${ref}/database/migrations`);
@@ -387,10 +401,10 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const migrationFiles = files.map((file, i) => ({
+                    const migrationFiles = files.map((file) => ({
                         file,
                         name: basename(file, ".sql"),
-                        version: migrationVersionFromFilename(file, i),
+                        version: migrationVersionFromFilename(file),
                     }));
 
                     const r = await http.get(`/v1/projects/${ref}/database/migrations`);
@@ -511,7 +525,7 @@ function sqlString(value: string): string {
     return `'${value.replace(/'/g, "''")}'`;
 }
 
-function buildMigrationBaselineSql(migrations: Array<{ name: string; version: number }>): string {
+function buildMigrationBaselineSql(migrations: Array<{ name: string; version: string }>): string {
     const values = migrations
         .map(({ name, version }) => `(${version}, ${sqlString(name)}, ARRAY[${sqlString(`baseline:${name}`)}]::text[])`)
         .join(",\n    ");

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -31,6 +31,27 @@ function appliedMigrationKeys(data: unknown): Set<string> {
     return keys;
 }
 
+function migrationRows(data: unknown): Array<Record<string, unknown>> {
+    const rows = Array.isArray(data) ? data : (data as { rows?: unknown[] })?.rows || [];
+    return Array.isArray(rows)
+        ? rows.filter((row): row is Record<string, unknown> => Boolean(row && typeof row === "object"))
+        : [];
+}
+
+function baselineMigrationKey(version: number | string, name: string): string {
+    return `${String(version)}\u0000${name}`;
+}
+
+function baselineMigrationKeys(data: unknown): Set<string> {
+    const keys = new Set<string>();
+    for (const row of migrationRows(data)) {
+        if (row.version == null || row.name == null || !Array.isArray(row.statements)) continue;
+        if (row.statements.length !== 1 || row.statements[0] !== `baseline:${String(row.name)}`) continue;
+        keys.add(baselineMigrationKey(String(row.version), String(row.name)));
+    }
+    return keys;
+}
+
 function isAlreadyAppliedMigrationResponse(response: { status: number; data: unknown }): boolean {
     if (response.status !== 409 || !response.data || typeof response.data !== "object") return false;
     const body = response.data as Record<string, unknown>;
@@ -280,13 +301,14 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         version: migrationVersionFromFilename(file, i),
                     }));
 
+                    const migrationsResult = await http.get(`/v1/projects/${ref}/database/migrations`);
+                    if (!migrationsResult.ok) {
+                        text = `❌ Failed to load applied migrations (${migrationsResult.status}): ${JSON.stringify(migrationsResult.data)}`;
+                        break;
+                    }
+
                     if (args.dry_run) {
-                        const r = await http.get(`/v1/projects/${ref}/database/migrations`);
-                        if (!r.ok) {
-                            text = `❌ Failed to load applied migrations (${r.status}): ${JSON.stringify(r.data)}`;
-                            break;
-                        }
-                        const appliedKeys = appliedMigrationKeys(r.data);
+                        const appliedKeys = appliedMigrationKeys(migrationsResult.data);
                         const pending = migrationFiles.filter(({ name, version }) => !appliedKeys.has(name) && !appliedKeys.has(String(version)));
                         const alreadyApplied = migrationFiles.filter(({ name, version }) => appliedKeys.has(name) || appliedKeys.has(String(version)));
                         const pendingWithSql = pending.map((migration) => ({
@@ -317,7 +339,12 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
 
                     const applied: string[] = [];
                     const skipped: string[] = [];
+                    const baselineKeys = baselineMigrationKeys(migrationsResult.data);
                     for (const { file, name, version } of migrationFiles) {
+                        if (baselineKeys.has(baselineMigrationKey(version, name))) {
+                            skipped.push(file);
+                            continue;
+                        }
                         const sql = readFileSync(join(dir, file), "utf-8");
                         const r = await http.post(`/v1/projects/${ref}/database/migrations`, { name, sql, version });
                         if (r.ok) {

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -17,6 +17,13 @@ export interface DatabaseToolsConfig {
 const MAX_MIGRATION_VERSION = 9_223_372_036_854_775_807n;
 const FALLBACK_MIGRATION_VERSION_BASE = 8_000_000_000_000_000_000n;
 const FALLBACK_MIGRATION_VERSION_RANGE = 1_000_000_000_000_000_000n;
+const FALLBACK_MIGRATION_VERSION_LIMIT = FALLBACK_MIGRATION_VERSION_BASE + FALLBACK_MIGRATION_VERSION_RANGE;
+
+interface MigrationFile {
+    file: string;
+    name: string;
+    version: string;
+}
 
 export function migrationVersionFromFilename(file: string): string {
     const match = basename(file).match(/^(\d{8,20})[_-]/);
@@ -25,12 +32,33 @@ export function migrationVersionFromFilename(file: string): string {
         if (version < 1n || version > MAX_MIGRATION_VERSION) {
             throw new Error(`Invalid migration version '${match[1]}' in ${basename(file)}: expected 1..${MAX_MIGRATION_VERSION}`);
         }
+        if (version >= FALLBACK_MIGRATION_VERSION_BASE && version < FALLBACK_MIGRATION_VERSION_LIMIT) {
+            throw new Error(`Invalid migration version '${match[1]}' in ${basename(file)}: version range ${FALLBACK_MIGRATION_VERSION_BASE}..${FALLBACK_MIGRATION_VERSION_LIMIT - 1n} is reserved for non-timestamp migrations`);
+        }
         return version.toString();
     }
 
     const digest = createHash("sha256").update(basename(file)).digest("hex");
     const offset = BigInt(`0x${digest}`) % FALLBACK_MIGRATION_VERSION_RANGE;
     return (FALLBACK_MIGRATION_VERSION_BASE + offset).toString();
+}
+
+function sortMigrationFiles(migrations: MigrationFile[]): MigrationFile[] {
+    const sorted = [...migrations].sort((a, b) => {
+        const versionA = BigInt(a.version);
+        const versionB = BigInt(b.version);
+        if (versionA < versionB) return -1;
+        if (versionA > versionB) return 1;
+        return a.file.localeCompare(b.file);
+    });
+    for (let i = 1; i < sorted.length; i += 1) {
+        const previous = sorted[i - 1];
+        const current = sorted[i];
+        if (previous.version === current.version && (previous.file !== current.file || previous.name !== current.name)) {
+            throw new Error(`Migration version collision for ${current.version}: ${previous.file} and ${current.file}`);
+        }
+    }
+    return sorted;
 }
 
 function appliedMigrationKeys(data: unknown): Set<string> {
@@ -309,11 +337,11 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const migrationFiles = files.map((file) => ({
+                    const migrationFiles = sortMigrationFiles(files.map((file) => ({
                         file,
                         name: basename(file, ".sql"),
                         version: migrationVersionFromFilename(file),
-                    }));
+                    })));
 
                     const migrationsResult = await http.get(`/v1/projects/${ref}/database/migrations`);
                     if (!migrationsResult.ok) {
@@ -401,11 +429,11 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const migrationFiles = files.map((file) => ({
+                    const migrationFiles = sortMigrationFiles(files.map((file) => ({
                         file,
                         name: basename(file, ".sql"),
                         version: migrationVersionFromFilename(file),
-                    }));
+                    })));
 
                     const r = await http.get(`/v1/projects/${ref}/database/migrations`);
                     if (!r.ok) {


### PR DESCRIPTION
## Summary
- pre-read the migration ledger before `push_migrations`
- skip only exact `baseline:<name>` marker rows matching both version and name
- preserve normal migration POSTs, checksum-conflict failures, and exact already-applied 409 skips

## Verification
- `bun test packages/cli/src/shared/tools/database-tools.test.ts` (13 pass)
- `bun run typecheck` (packages/cli)
- `git diff --check`
