### PR TITLE
fix(cli): recognize historical migration hash markers

### DIFF
--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -231,6 +232,56 @@ describe("database migration helpers", () => {
             expect(posts[0].path).toBe("/v1/projects/proj/database/migrations");
             expect((posts[0].body as { name: string }).name).toBe("20260425124000_create_tasks");
             expect((posts[0].body as { version: string }).version).toBe("20260425124000");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("skips only matching historical sha256 markers before POST", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const posts: Array<{ name: string }> = [];
+        try {
+            const sql = "CREATE TABLE users (id uuid);\n";
+            const rawLegacyBytes = new Uint8Array([...new TextEncoder().encode("-- legacy bytes\r\n"), 0xff, 0x0a]);
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), sql);
+            writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            writeFileSync(join(dir, "20260425125000_legacy_bytes.sql"), rawLegacyBytes);
+            const checksum = createHash("sha256").update(sql).digest("hex");
+            const rawChecksum = createHash("sha256").update(rawLegacyBytes).digest("hex");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [
+                        {
+                            version: "20260425123000",
+                            name: "20260425123000_create_users",
+                            statements: [`sha256:${checksum}`],
+                        },
+                        {
+                            version: "20260425124000",
+                            name: "20260425124000_create_tasks",
+                            statements: ["sha256:0000000000000000000000000000000000000000000000000000000000000000"],
+                        },
+                        {
+                            version: "20260425125000",
+                            name: "20260425125000_legacy_bytes",
+                            statements: [`sha256:${rawChecksum}`],
+                        },
+                    ],
+                }),
+                post: async (_path: string, body: { name: string }) => {
+                    posts.push({ name: body.name });
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            const toolResult = await callback({ action: "push_migrations", ref: "proj", dir });
+            const text = toolResult.content[0].text;
+
+            expect(text).toContain("Applied: 1");
+            expect(text).toContain("Skipped: 2");
+            expect(posts).toEqual([{ name: "20260425124000_create_tasks" }]);
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -23,6 +23,19 @@ interface MigrationFile {
     file: string;
     name: string;
     version: string;
+    sql: string;
+    rawBytes: Uint8Array;
+}
+
+function readMigrationFile(dir: string, file: string): MigrationFile {
+    const rawBytes = readFileSync(join(dir, file));
+    return {
+        file,
+        name: basename(file, ".sql"),
+        version: migrationVersionFromFilename(file),
+        sql: Buffer.from(rawBytes).toString("utf8"),
+        rawBytes,
+    };
 }
 
 export function migrationVersionFromFilename(file: string): string {
@@ -90,6 +103,25 @@ function baselineMigrationKeys(data: unknown): Set<string> {
         if (row.version == null || row.name == null || !Array.isArray(row.statements)) continue;
         if (row.statements.length !== 1 || row.statements[0] !== `baseline:${String(row.name)}`) continue;
         keys.add(baselineMigrationKey(String(row.version), String(row.name)));
+    }
+    return keys;
+}
+
+function historicalChecksumMarkerKeys(
+    data: unknown,
+    migrationFiles: MigrationFile[],
+): Set<string> {
+    const filesByKey = new Map(migrationFiles.map((migration) => [baselineMigrationKey(migration.version, migration.name), migration]));
+    const keys = new Set<string>();
+    for (const row of migrationRows(data)) {
+        if (row.version == null || row.name == null || !Array.isArray(row.statements) || row.statements.length !== 1) continue;
+        const marker = row.statements[0];
+        if (typeof marker !== "string" || !/^sha256:[0-9a-f]{64}$/.test(marker)) continue;
+        const key = baselineMigrationKey(String(row.version), String(row.name));
+        const migration = filesByKey.get(key);
+        if (!migration) continue;
+        const checksum = createHash("sha256").update(migration.rawBytes).digest("hex");
+        if (marker === `sha256:${checksum}`) keys.add(key);
     }
     return keys;
 }
@@ -337,11 +369,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const migrationFiles = sortMigrationFiles(files.map((file) => ({
-                        file,
-                        name: basename(file, ".sql"),
-                        version: migrationVersionFromFilename(file),
-                    })));
+                    const migrationFiles = sortMigrationFiles(files.map((file) => readMigrationFile(dir, file)));
 
                     const migrationsResult = await http.get(`/v1/projects/${ref}/database/migrations`);
                     if (!migrationsResult.ok) {
@@ -353,10 +381,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         const appliedKeys = appliedMigrationKeys(migrationsResult.data);
                         const pending = migrationFiles.filter(({ name, version }) => !appliedKeys.has(name) && !appliedKeys.has(String(version)));
                         const alreadyApplied = migrationFiles.filter(({ name, version }) => appliedKeys.has(name) || appliedKeys.has(String(version)));
-                        const pendingWithSql = pending.map((migration) => ({
-                            ...migration,
-                            sql: readFileSync(join(dir, migration.file), "utf-8"),
-                        }));
+                        const pendingWithSql = pending;
                         let vectorEnabled: boolean | null = null;
                         if (pendingWithSql.some(({ sql }) => sqlReferencesVector(sql) || sqlCreatesVectorExtension(sql))) {
                             const extResult = await execSql("SELECT extname AS name FROM pg_extension WHERE extname = 'vector';");
@@ -382,12 +407,13 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     const applied: string[] = [];
                     const skipped: string[] = [];
                     const baselineKeys = baselineMigrationKeys(migrationsResult.data);
-                    for (const { file, name, version } of migrationFiles) {
-                        if (baselineKeys.has(baselineMigrationKey(version, name))) {
+                    const historicalChecksumKeys = historicalChecksumMarkerKeys(migrationsResult.data, migrationFiles);
+                    for (const { file, name, version, sql } of migrationFiles) {
+                        const migrationKey = baselineMigrationKey(version, name);
+                        if (baselineKeys.has(migrationKey) || historicalChecksumKeys.has(migrationKey)) {
                             skipped.push(file);
                             continue;
                         }
-                        const sql = readFileSync(join(dir, file), "utf-8");
                         const r = await http.post(`/v1/projects/${ref}/database/migrations`, { name, sql, version });
                         if (r.ok) {
                             applied.push(file);
@@ -429,11 +455,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const migrationFiles = sortMigrationFiles(files.map((file) => ({
-                        file,
-                        name: basename(file, ".sql"),
-                        version: migrationVersionFromFilename(file),
-                    })));
+                    const migrationFiles = sortMigrationFiles(files.map((file) => readMigrationFile(dir, file)));
 
                     const r = await http.get(`/v1/projects/${ref}/database/migrations`);
                     if (!r.ok) {

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.6.0",
-        "@supacloud/cli": "^0.12.1",
+        "@supacloud/cli": "^0.12.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -19,7 +19,7 @@
 
     "@supacloud/admin": ["@supacloud/admin@0.6.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.6.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.12.1", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-Zmo+WX3mrOfPZiORprfEFJv6y5iIe9Xw0+CdVMlJGL1L7SDtmzioegCMuVsGXYwnc+QdygWib4VRvUex025cig=="],
+    "@supacloud/cli": ["@supacloud/cli@0.12.2", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.2.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-todyXqdsVKUr+3gMzUmORssVfIJBRwBatPpMVO439QbMBt7L1Ya2Hz6dGrq/TcuLKg8b5ex1v7Deb68tYI1zcQ=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary
- recognize legacy migration ledger rows only when version, name, and raw-file SHA-256 marker all match exactly
- keep mismatched markers and checksum-conflict 409 responses fail-closed
- snapshot raw bytes and decoded SQL once so marker verification and POST cannot drift; preserve BOM/CRLF behavior

## Verification
- `bun test src/shared/tools/database-tools.test.ts` (18 pass, 65 assertions)
- `bun run typecheck` in `packages/cli`
- `git diff --check`
- independent PostgreSQL 18 and adversarial marker verification: PASS
- clean-code-guard: clean