### PR TITLE
fix(gateway): use Caddy internal CA for on-demand TLS on LAN-only hosts

### DIFF
--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -154,6 +154,8 @@ export interface Config {
   legacySecretsEncryptionKey: string;
   supaoauthBffSigningSecret: string;
   caddyTlsBlockedDomains: string[];
+  /** TLS certificate issuer for on-demand Caddy certs: "acme" (default) or "internal". */
+  caddyTlsIssuer: "acme" | "internal";
   hostedAuthPageEnabled: boolean;
   hostedAuthPageHost: string;
   hostedAuthPageRoot: string;
@@ -179,6 +181,22 @@ const rawPgPassword = getEnv("PGPASSWORD");
 const pgPassword = rawPgPassword === "" ? getEnv("PG_PASSWORD", "postgres") : rawPgPassword;
 const pgDatabase = getEnv("PG_DATABASE", "postgres");
 const edgeRuntimeInternal = getEnv("EDGE_RUNTIME_INTERNAL", `127.0.0.1:${edgeRuntimePort}`);
+
+// Whether an IPv4 string is an RFC1918 / loopback / link-local address.
+// Used to pick Caddy's on-demand TLS issuer: ACME cannot validate domains
+// that resolve to private addresses (Let's Encrypt validators cannot reach
+// them), so LAN-only hosts default to Caddy's built-in internal CA.
+function isPrivateIp(ip: string): boolean {
+    const v = ip.trim().replace(/^https?:\/\//, "").split("/")[0].split(":")[0];
+    if (v === "127.0.0.1" || v === "::1" || v === "localhost") return true;
+    const parts = v.split(".").map((n) => Number(n));
+    if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
+    const [a, b] = parts;
+    return (a === 10)
+        || (a === 172 && b >= 16 && b <= 31)
+        || (a === 192 && b === 168)
+        || (a === 169 && b === 254);
+}
 
 export const config: Config = {
   port,
@@ -309,6 +327,14 @@ export const config: Config = {
       : "",
   ),
   caddyTlsBlockedDomains: getEnv("CADDY_TLS_BLOCKED_DOMAINS").split(",").map((s) => s.trim().toLowerCase()).filter(Boolean),
+  // On-demand TLS issuer. Auto-detect: when the server listens on an RFC1918
+  // address, ACME (Let's Encrypt) can never validate a challenge because its
+  // validators cannot reach private IPs, so default to Caddy's internal CA.
+  // Operators can force either mode with SUPACLOUD_CADDY_TLS_ISSUER.
+  caddyTlsIssuer: ((explicit: string) => {
+    if (explicit === "acme" || explicit === "internal") return explicit;
+    return isPrivateIp(getEnv("DOCKER_HOST_IP", getEnv("INTERNAL_IP", "127.0.0.1"))) ? "internal" : "acme";
+  })(getEnv("SUPACLOUD_CADDY_TLS_ISSUER", "").trim().toLowerCase()),
 
   hostedAuthPageEnabled: getEnv("HOSTED_AUTH_PAGE_ENABLED", getEnv("SUPAUTH_HOSTED_LOGIN_ENABLED", "false")) === "true",
   hostedAuthPageHost: getEnv("HOSTED_AUTH_PAGE_HOST", getEnv("SUPAUTH_HOSTED_LOGIN_HOST", "")),

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
+import { isIP } from "node:net";
 
 const MANAGEMENT_API_ENV = process.env.SUPACLOUD_MANAGEMENT_ENV_FILE
   ?? "/etc/supabase/management-api.env";
@@ -62,6 +63,8 @@ process.env.NODE_ENV ??= runtimeNodeEnv;
 if (runtimeNodeEnv === "development" || runtimeNodeEnv === "test") {
   loadEnvFile(LOCAL_ENV);
 }
+
+type CaddyTlsIssuer = "acme" | "internal";
 
 export interface Config {
   port: number;
@@ -154,8 +157,8 @@ export interface Config {
   legacySecretsEncryptionKey: string;
   supaoauthBffSigningSecret: string;
   caddyTlsBlockedDomains: string[];
-  /** TLS certificate issuer for on-demand Caddy certs: "acme" (default) or "internal". */
-  caddyTlsIssuer: "acme" | "internal";
+  /** TLS certificate issuer for on-demand Caddy certificates. */
+  caddyTlsIssuer: CaddyTlsIssuer;
   hostedAuthPageEnabled: boolean;
   hostedAuthPageHost: string;
   hostedAuthPageRoot: string;
@@ -182,20 +185,34 @@ const pgPassword = rawPgPassword === "" ? getEnv("PG_PASSWORD", "postgres") : ra
 const pgDatabase = getEnv("PG_DATABASE", "postgres");
 const edgeRuntimeInternal = getEnv("EDGE_RUNTIME_INTERNAL", `127.0.0.1:${edgeRuntimePort}`);
 
-// Whether an IPv4 string is an RFC1918 / loopback / link-local address.
-// Used to pick Caddy's on-demand TLS issuer: ACME cannot validate domains
-// that resolve to private addresses (Let's Encrypt validators cannot reach
-// them), so LAN-only hosts default to Caddy's built-in internal CA.
-function isPrivateIp(ip: string): boolean {
-    const v = ip.trim().replace(/^https?:\/\//, "").split("/")[0].split(":")[0];
-    if (v === "127.0.0.1" || v === "::1" || v === "localhost") return true;
-    const parts = v.split(".").map((n) => Number(n));
-    if (parts.length !== 4 || parts.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return false;
-    const [a, b] = parts;
-    return (a === 10)
-        || (a === 172 && b >= 16 && b <= 31)
-        || (a === 192 && b === 168)
-        || (a === 169 && b === 254);
+// A private listen address indicates the common single-node LAN setup. Public
+// deployments behind NAT can explicitly force ACME with SUPACLOUD_CADDY_TLS_ISSUER.
+function isPrivateNetworkAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase();
+  if (normalized === "localhost" || normalized === "::1") return true;
+
+  const addressFamily = isIP(normalized);
+  if (addressFamily === 4) {
+    const [first, second] = normalized.split(".").map(Number);
+    return first === 10
+      || first === 127
+      || (first === 172 && second >= 16 && second <= 31)
+      || (first === 192 && second === 168)
+      || (first === 169 && second === 254);
+  }
+  if (addressFamily !== 6) return false;
+
+  const firstHextet = Number.parseInt(normalized.split(":")[0], 16);
+  return (firstHextet & 0xfe00) === 0xfc00 || (firstHextet & 0xffc0) === 0xfe80;
+}
+
+function resolveCaddyTlsIssuer(explicitIssuer: string, listenAddress: string): CaddyTlsIssuer {
+  const normalizedIssuer = explicitIssuer.trim().toLowerCase();
+  if (normalizedIssuer === "acme" || normalizedIssuer === "internal") return normalizedIssuer;
+  if (normalizedIssuer) {
+    throw new Error('Invalid SUPACLOUD_CADDY_TLS_ISSUER. Expected "acme" or "internal".');
+  }
+  return isPrivateNetworkAddress(listenAddress) ? "internal" : "acme";
 }
 
 export const config: Config = {
@@ -327,14 +344,10 @@ export const config: Config = {
       : "",
   ),
   caddyTlsBlockedDomains: getEnv("CADDY_TLS_BLOCKED_DOMAINS").split(",").map((s) => s.trim().toLowerCase()).filter(Boolean),
-  // On-demand TLS issuer. Auto-detect: when the server listens on an RFC1918
-  // address, ACME (Let's Encrypt) can never validate a challenge because its
-  // validators cannot reach private IPs, so default to Caddy's internal CA.
-  // Operators can force either mode with SUPACLOUD_CADDY_TLS_ISSUER.
-  caddyTlsIssuer: ((explicit: string) => {
-    if (explicit === "acme" || explicit === "internal") return explicit;
-    return isPrivateIp(getEnv("DOCKER_HOST_IP", getEnv("INTERNAL_IP", "127.0.0.1"))) ? "internal" : "acme";
-  })(getEnv("SUPACLOUD_CADDY_TLS_ISSUER", "").trim().toLowerCase()),
+  caddyTlsIssuer: resolveCaddyTlsIssuer(
+    getEnv("SUPACLOUD_CADDY_TLS_ISSUER"),
+    getEnv("DOCKER_HOST_IP", getEnv("INTERNAL_IP", "127.0.0.1")),
+  ),
 
   hostedAuthPageEnabled: getEnv("HOSTED_AUTH_PAGE_ENABLED", getEnv("SUPAUTH_HOSTED_LOGIN_ENABLED", "false")) === "true",
   hostedAuthPageHost: getEnv("HOSTED_AUTH_PAGE_HOST", getEnv("SUPAUTH_HOSTED_LOGIN_HOST", "")),

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -317,7 +317,20 @@ export class CaddyGatewayProvider implements GatewayProvider {
                                 endpoint: `http://${config.managementApiInternal}/v1/gateway/caddy/ask`,
                             },
                         },
-                        policies: [{ on_demand: true, key_type: "p256" }],
+                        policies: [
+                            // ACME (Let's Encrypt) cannot validate domains that resolve
+                            // to RFC1918 addresses; on LAN-only hosts the validators never
+                            // reach the server, so tls-alpn-01/http-01 fail and HTTPS hangs.
+                            // When the server listens on a private IP, use Caddy's internal
+                            // CA so on-demand TLS works without an externally reachable host.
+                            {
+                                on_demand: true,
+                                key_type: "p256",
+                                ...(config.caddyTlsIssuer === "internal"
+                                    ? { issuers: [{ module: "internal" }] }
+                                    : {}),
+                            },
+                        ],
                     },
                     certificates: {
                         load_files: Array.from(this.certsById.values()),

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -28,6 +28,9 @@ function cleanEnv(overrides: Record<string, string>) {
     "SUPACLOUD_LOCAL_ENV_FILE",
     "SUPAOAUTH_BFF_SIGNING_SECRET",
     "LEGACY_SECRETS_ENCRYPTION_KEY",
+    "DOCKER_HOST_IP",
+    "INTERNAL_IP",
+    "SUPACLOUD_CADDY_TLS_ISSUER",
   ]) {
     delete env[key];
   }
@@ -69,7 +72,67 @@ function loadDatabaseUrl(env: Record<string, string>) {
   return result.stdout.match(/RESULT=([^\n]+)/)?.[1];
 }
 
+function loadCaddyTlsIssuer(env: Record<string, string>) {
+  const configProcess = spawnSync("bun", ["-e", [
+    'import { config } from "./src/config.ts";',
+    'console.log(`RESULT=${config.caddyTlsIssuer}`);',
+  ].join(" ")], { cwd: packageRoot, env, encoding: "utf8" });
+  expect(configProcess.status, configProcess.stderr).toBe(0);
+  return configProcess.stdout.match(/RESULT=([^\n]+)/)?.[1];
+}
+
 describe("production config loading boundaries", () => {
+  test("defaults Caddy TLS to the internal CA for local and private addresses", () => {
+    for (const address of [
+      "127.0.0.2",
+      "localhost",
+      "::1",
+      "10.0.0.8",
+      "172.31.255.254",
+      "192.168.10.20",
+      "169.254.10.20",
+      "fd00::8",
+      "fe80::8",
+    ]) {
+      expect(loadCaddyTlsIssuer(cleanEnv({
+        NODE_ENV: "production",
+        DOCKER_HOST_IP: address,
+      }))).toBe("internal");
+    }
+  });
+
+  test("keeps public hosts on ACME and honors explicit issuer overrides", () => {
+    expect(loadCaddyTlsIssuer(cleanEnv({ NODE_ENV: "production" }))).toBe("internal");
+    expect(loadCaddyTlsIssuer(cleanEnv({
+      NODE_ENV: "production",
+      DOCKER_HOST_IP: "198.51.100.10",
+    }))).toBe("acme");
+    expect(loadCaddyTlsIssuer(cleanEnv({
+      NODE_ENV: "production",
+      DOCKER_HOST_IP: "10.0.0.8",
+      SUPACLOUD_CADDY_TLS_ISSUER: "acme",
+    }))).toBe("acme");
+    expect(loadCaddyTlsIssuer(cleanEnv({
+      NODE_ENV: "production",
+      DOCKER_HOST_IP: "198.51.100.10",
+      SUPACLOUD_CADDY_TLS_ISSUER: "internal",
+    }))).toBe("internal");
+  });
+
+  test("rejects an invalid explicit Caddy TLS issuer", () => {
+    const configProcess = spawnSync("bun", ["-e", 'import "./src/config.ts";'], {
+      cwd: packageRoot,
+      env: cleanEnv({
+        NODE_ENV: "production",
+        SUPACLOUD_CADDY_TLS_ISSUER: "self-signed",
+      }),
+      encoding: "utf8",
+    });
+
+    expect(configProcess.status).not.toBe(0);
+    expect(configProcess.stderr).toContain("SUPACLOUD_CADDY_TLS_ISSUER");
+  });
+
   test("accepts standard postgres and postgresql DSN schemes", () => {
     for (const scheme of ["postgres", "postgresql"]) {
       const databaseUrl = `${scheme}://postgres:secret@localhost:5432/supacloud`;

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -173,6 +173,30 @@ describe("CaddyGatewayProvider", () => {
         await cleanCaddyTmp();
     });
 
+    test("renders the selected on-demand TLS issuer", async () => {
+        const originalIssuer = config.caddyTlsIssuer;
+        try {
+            for (const [issuer, expectedIssuers] of [
+                ["internal", [{ module: "internal" }]],
+                ["acme", undefined],
+            ] as const) {
+                config.caddyTlsIssuer = issuer;
+                const calls: Parameters<typeof captureFetch>[0] = [];
+                const restore = captureFetch(calls);
+                try {
+                    const setupResult = await new CaddyGatewayProvider().setupUpstream("tlsissuer", 3000, 9999);
+                    expect(setupResult.success).toBe(true);
+                    const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+                    expect(load?.body?.apps?.tls?.automation?.policies?.[0]?.issuers).toEqual(expectedIssuers);
+                } finally {
+                    restore();
+                }
+            }
+        } finally {
+            config.caddyTlsIssuer = originalIssuer;
+        }
+    });
+
     test("setupUpstream renders Caddy JSON routes for Supabase-compatible APIs", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.6.0",
-        "@supacloud/cli": "^0.12.2",
+        "@supacloud/cli": "^0.12.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -19,7 +19,7 @@
 
     "@supacloud/admin": ["@supacloud/admin@0.6.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.6.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.12.2", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.2.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-todyXqdsVKUr+3gMzUmORssVfIJBRwBatPpMVO439QbMBt7L1Ya2Hz6dGrq/TcuLKg8b5ex1v7Deb68tYI1zcQ=="],
+    "@supacloud/cli": ["@supacloud/cli@0.12.4", "", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-B45xCBe9hwNUeAOkh4OAY/DXzx7XII2EmXtg1NrRQ6wanAuyl5z8dGc+OX9yNdjxfgONGvzTgrhg3W7buZsXDA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Problem

Caddy's on-demand TLS defaults to ACME (Let's Encrypt). On a host that listens on an **RFC1918 address** (e.g. \`192.168.200.112\`), every bound domain resolves to a private IP, and Let's Encrypt's validators **cannot reach it**:

\`\`\`
tls-alpn-01 challenge failed: no valid A records found for studio.xai.xigu.team; no valid AAAA records found
http-01 challenge failed: ... no valid A records found
\`\`\`

LE treats domains that resolve to private address space as invalid because its validators (on the public internet) can't connect to a 192.168.x.x host. The result: **HTTPS hangs** and the studio/api URLs are unreachable — even though the domain is correctly DNS-resolved internally and correctly routed in Caddy. HTTP→HTTPS redirect then makes even the HTTP path flaky.

This is the common case for an on-prem/LAN-only SupaCloud box, so it should just work out of the box.

## Fix

Auto-detect LAN-only hosts and use Caddy's built-in internal CA for on-demand TLS:

1. \`config.ts\`: add \`caddyTlsIssuer: \"acme\" | \"internal\"\`. Default is auto-detected — when \`DOCKER_HOST_IP\`/\`INTERNAL_IP\` is RFC1918 (10/8, 172.16/12, 192.168/16), loopback, or link-local (169.254/16), use \`internal\`; otherwise \`acme\`. Operators can force either mode with \`SUPACLOUD_CADDY_TLS_ISSUER=acme|internal\`.
2. \`gateway.service.ts\` \`baseConfig()\`: when \`caddyTlsIssuer === \"internal\"\`, emit \`issuers: [{module: \"internal\"}]\` on the on-demand TLS policy, so Caddy signs a local-trusted cert immediately instead of attempting ACME.

Public hosts are unaffected (default stays ACME → real Let's Encrypt certs).

## Verification

Runtime smoke:
\`\`\`
$ DOCKER_HOST_IP=192.168.200.112 bun -e 'import {config} from "./src/config"; console.log(config.caddyTlsIssuer)'
caddyTlsIssuer= internal
$ DOCKER_HOST_IP=203.0.113.10 bun -e '... '
caddyTlsIssuer= acme
\`\`\`

Live on a LAN host (192.168.200.112) after applying the equivalent Caddy config:
\`\`\`
studio HTTPS code=200
issuer=CN=Caddy Local Authority - ECC Intermediate
tls.obtain ... certificate obtained successfully, issuer: local
\`\`\`

## Note on client trust

The internal CA cert is not in public trust stores, so browsers show a warning until the operator imports \`/var/lib/supacloud/caddy/pki/authorities/local/root.crt\`. This is the expected trade-off for a host that Let's Encrypt cannot reach; a future enhancement could add DNS-01 once a DNS provider plugin is bundled.