### PR TITLE
fix(cli): recognize direct-apply migration markers

### DIFF
--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -237,6 +237,75 @@ describe("database migration helpers", () => {
         }
     });
 
+    test("skips only exact historical direct-apply markers before POST", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const postedNames: string[] = [];
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            writeFileSync(join(dir, "20260425125000_create_reports.sql"), "CREATE TABLE reports (id uuid);\n");
+            writeFileSync(join(dir, "20260425126000_create_audits.sql"), "CREATE TABLE audits (id uuid);\n");
+            writeFileSync(join(dir, "20260425127000_create_metrics.sql"), "CREATE TABLE metrics (id uuid);\n");
+            writeFileSync(join(dir, "20260425128000_create_events.sql"), "CREATE TABLE events (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [
+                        {
+                            version: "20260425123000",
+                            name: "20260425123000_create_users",
+                            statements: ["direct-apply:20260425123000_create_users"],
+                        },
+                        {
+                            version: "20260425124000",
+                            name: "20260425124000_create_tasks",
+                            statements: ["direct-apply:20260425123000_create_users"],
+                        },
+                        {
+                            version: "20260425125000",
+                            name: "20260425125000_renamed_reports",
+                            statements: ["direct-apply:20260425125000_renamed_reports"],
+                        },
+                        {
+                            version: "20260425126000",
+                            name: "20260425126000_create_audits",
+                            statements: ["direct-apply:20260425126000_create_audits", "extra"],
+                        },
+                        {
+                            version: "20260425127001",
+                            name: "20260425127000_create_metrics",
+                            statements: ["direct-apply:20260425127000_create_metrics"],
+                        },
+                        {
+                            version: "20260425128000",
+                            name: "20260425128000_create_events",
+                            statements: ["direct-apply:20260425128000_create_events "],
+                        },
+                    ],
+                }),
+                post: async (_path: string, body: { name: string }) => {
+                    postedNames.push(body.name);
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            const toolResult = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(toolResult.content[0].text).toContain("Applied: 5");
+            expect(toolResult.content[0].text).toContain("Skipped: 1");
+            expect(postedNames).toEqual([
+                "20260425124000_create_tasks",
+                "20260425125000_create_reports",
+                "20260425126000_create_audits",
+                "20260425127000_create_metrics",
+                "20260425128000_create_events",
+            ]);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     test("skips only matching historical sha256 markers before POST", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         const posts: Array<{ name: string }> = [];

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -93,16 +93,19 @@ function migrationRows(data: unknown): Array<Record<string, unknown>> {
         : [];
 }
 
-function baselineMigrationKey(version: string, name: string): string {
+function migrationIdentityKey(version: string, name: string): string {
     return `${version}\u0000${name}`;
 }
 
-function baselineMigrationKeys(data: unknown): Set<string> {
+function nameBoundMigrationMarkerKeys(data: unknown): Set<string> {
     const keys = new Set<string>();
     for (const row of migrationRows(data)) {
         if (row.version == null || row.name == null || !Array.isArray(row.statements)) continue;
-        if (row.statements.length !== 1 || row.statements[0] !== `baseline:${String(row.name)}`) continue;
-        keys.add(baselineMigrationKey(String(row.version), String(row.name)));
+        if (row.statements.length !== 1) continue;
+        const name = String(row.name);
+        const marker = row.statements[0];
+        if (marker !== `baseline:${name}` && marker !== `direct-apply:${name}`) continue;
+        keys.add(migrationIdentityKey(String(row.version), String(row.name)));
     }
     return keys;
 }
@@ -111,13 +114,13 @@ function historicalChecksumMarkerKeys(
     data: unknown,
     migrationFiles: MigrationFile[],
 ): Set<string> {
-    const filesByKey = new Map(migrationFiles.map((migration) => [baselineMigrationKey(migration.version, migration.name), migration]));
+    const filesByKey = new Map(migrationFiles.map((migration) => [migrationIdentityKey(migration.version, migration.name), migration]));
     const keys = new Set<string>();
     for (const row of migrationRows(data)) {
         if (row.version == null || row.name == null || !Array.isArray(row.statements) || row.statements.length !== 1) continue;
         const marker = row.statements[0];
         if (typeof marker !== "string" || !/^sha256:[0-9a-f]{64}$/.test(marker)) continue;
-        const key = baselineMigrationKey(String(row.version), String(row.name));
+        const key = migrationIdentityKey(String(row.version), String(row.name));
         const migration = filesByKey.get(key);
         if (!migration) continue;
         const checksum = createHash("sha256").update(migration.rawBytes).digest("hex");
@@ -406,11 +409,11 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
 
                     const applied: string[] = [];
                     const skipped: string[] = [];
-                    const baselineKeys = baselineMigrationKeys(migrationsResult.data);
+                    const nameBoundMarkerKeys = nameBoundMigrationMarkerKeys(migrationsResult.data);
                     const historicalChecksumKeys = historicalChecksumMarkerKeys(migrationsResult.data, migrationFiles);
                     for (const { file, name, version, sql } of migrationFiles) {
-                        const migrationKey = baselineMigrationKey(version, name);
-                        if (baselineKeys.has(migrationKey) || historicalChecksumKeys.has(migrationKey)) {
+                        const migrationKey = migrationIdentityKey(version, name);
+                        if (nameBoundMarkerKeys.has(migrationKey) || historicalChecksumKeys.has(migrationKey)) {
                             skipped.push(file);
                             continue;
                         }

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.6.0",
-        "@supacloud/cli": "^0.12.2",
+        "@supacloud/cli": "^0.12.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -19,7 +19,7 @@
 
     "@supacloud/admin": ["@supacloud/admin@0.6.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.6.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.12.2", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.2.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-todyXqdsVKUr+3gMzUmORssVfIJBRwBatPpMVO439QbMBt7L1Ya2Hz6dGrq/TcuLKg8b5ex1v7Deb68tYI1zcQ=="],
+    "@supacloud/cli": ["@supacloud/cli@0.12.3", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.3.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-baLKvfoi0gzLAZZDi/FLrz7bTBrJmqSeJ66Rq/I3RgpxSMgh73HQw1bGhCMqY7WlXN2s3mcgOoSAbmB3eIOd8A=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary
- recognize exact historical `direct-apply:<name>` migration ledger markers
- require exact version/name identity and a single marker before skipping
- keep mismatches on the checksum-conflict path
- synchronize the unified CLI lockfile to published 0.12.3

## Verification
- focused database tools: 19 tests, 68 assertions
- CLI full suite: 87 tests, 269 assertions
- CLI typecheck/build/audit
- unified package: frozen install, 19 tests, typecheck/build/audit
- git diff --check
- clean-code-guard: clean