### PR TITLE
fix(migrations): accept exact legacy ledger contents

### DIFF
--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -280,6 +280,30 @@ function existingMigrationChecksum(
   });
 }
 
+function normalizedMigrationStatements(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((statement): statement is string => typeof statement === "string")
+    .map((statement) => statement.replace(/\r\n?/g, "\n").trim())
+    .filter(Boolean);
+}
+
+/**
+ * Legacy ledgers stored a raw file SHA-256 in `checksum`, while the current
+ * route stores a structured checksum over version/name/statements. When the
+ * identity and exact normalized SQL both match, the migration is already
+ * applied even though those checksum formats differ.
+ */
+export function migrationLedgerEntryMatches(
+  row: Record<string, unknown>,
+  input: Pick<RecordedMigrationInput, "version" | "name" | "statements">,
+): boolean {
+  return String(row.version ?? "").trim() === input.version
+    && (typeof row.name === "string" ? row.name.trim() : "") === input.name
+    && JSON.stringify(normalizedMigrationStatements(row.statements))
+      === JSON.stringify(normalizedMigrationStatements(input.statements));
+}
+
 async function resetMigrationSession(connection: ReservedProjectSql, dbName: string): Promise<boolean> {
   try {
     await connection.unsafe("DISCARD ALL");
@@ -339,7 +363,8 @@ async function executeMigrationTransaction(
     return await connection.begin(async (tx) => {
       const existing = await findExistingMigration(tx, input);
       if (existing.length > 0) {
-        if (existingMigrationChecksum(existing[0]!, input) !== execution.checksum) {
+        const alreadyApplied = existing.some((row) => migrationLedgerEntryMatches(row, input));
+        if (!alreadyApplied && existingMigrationChecksum(existing[0]!, input) !== execution.checksum) {
           throw new MigrationRouteError(
             409,
             "migration_checksum_conflict",

--- a/packages/management-api/tests/unit/database-routes.test.ts
+++ b/packages/management-api/tests/unit/database-routes.test.ts
@@ -8,6 +8,7 @@ import {
   buildDropMaterializedViewSql,
   buildRefreshMaterializedViewSql,
   migrationExecutionStatements,
+  migrationLedgerEntryMatches,
   normalizeMigrationVersion,
   resetEnsuredMigrationTablesForTests,
   resolveMigrationStatements,
@@ -128,6 +129,32 @@ describe("database route helpers", () => {
     expect(checksumConflict).toBeGreaterThan(checksumCheck);
     expect(alreadyAppliedReturn).toBeGreaterThan(checksumConflict);
     expect(policyCheck).toBeGreaterThan(alreadyAppliedReturn);
+  });
+
+  test("accepts exact legacy ledger SQL when its stored checksum uses the raw file format", () => {
+    const input = {
+      version: "20260720111000",
+      name: "20260720111000_accept_linked_rework_case_on_scope_approval",
+      statements: ["CREATE FUNCTION demo() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;\n"],
+    };
+    expect(migrationLedgerEntryMatches({
+      version: input.version,
+      name: input.name,
+      checksum: "raw-file-sha256",
+      statements: ["CREATE FUNCTION demo() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;"],
+    }, input)).toBe(true);
+    expect(migrationLedgerEntryMatches({
+      version: input.version,
+      name: "different-name",
+      checksum: "raw-file-sha256",
+      statements: input.statements,
+    }, input)).toBe(false);
+    expect(migrationLedgerEntryMatches({
+      version: input.version,
+      name: input.name,
+      checksum: "raw-file-sha256",
+      statements: ["CREATE FUNCTION demo() RETURNS void LANGUAGE sql AS $$ SELECT 2 $$;"],
+    }, input)).toBe(false);
   });
 
   test("does not let quoted dollar markers hide top-level policy controls", () => {

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.6.0",
-        "@supacloud/cli": "^0.12.3",
+        "@supacloud/cli": "^0.12.4",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -19,7 +19,7 @@
 
     "@supacloud/admin": ["@supacloud/admin@0.6.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.6.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.12.3", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.3.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-baLKvfoi0gzLAZZDi/FLrz7bTBrJmqSeJ66Rq/I3RgpxSMgh73HQw1bGhCMqY7WlXN2s3mcgOoSAbmB3eIOd8A=="],
+    "@supacloud/cli": ["@supacloud/cli@0.12.4", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.4.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-B45xCBe9hwNUeAOkh4OAY/DXzx7XII2EmXtg1NrRQ6wanAuyl5z8dGc+OX9yNdjxfgONGvzTgrhg3W7buZsXDA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
The FA release is blocked by historical migration rows that store raw file SHA-256 values in checksum while retaining the exact applied SQL in statements.

When version, name, and normalized statements all match, treat the migration as already applied; retain checksum conflict failures for identity/content mismatches. Adds regression coverage for legacy checksum format and mismatch cases.

Validated: management-api database-routes 18/18, full management-api unit suite passed, typecheck passed, git diff --check.