### PR TITLE
fix(platform): harden tenant provisioning and auth runtime config

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -212,6 +212,7 @@ jobs:
           bash -n install.sh setup.sh switch.sh deploy_all.sh scripts/pre_start_recovery.sh
           find scripts -name "*.sh" -print0 | xargs -0 -n1 bash -n
           bash scripts/lib/tenant_runtime.test.sh
+          bash scripts/lib/installer_pg_hba.test.sh
 
       - name: Validate CI scripts
         run: |

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -213,6 +213,8 @@ jobs:
           find scripts -name "*.sh" -print0 | xargs -0 -n1 bash -n
           bash scripts/lib/tenant_runtime.test.sh
           bash scripts/lib/installer_pg_hba.test.sh
+          bash scripts/lib/tenant_user.test.sh
+          bash scripts/lib/systemd_unit_broker.test.sh
 
       - name: Validate CI scripts
         run: |

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -561,6 +561,10 @@ jobs:
       - name: Launch API & Execute Full Defenses
         working-directory: packages/management-api
         run: |
+          realtime_container_env="$RUNNER_TEMP/realtime-container.env"
+          umask 077
+          printf 'API_JWT_SECRET=%s\n' "$TEST_FIXED_JWT_SECRET" > "$realtime_container_env"
+          export SUPACLOUD_REALTIME_CONTAINER_ENV_FILE="$realtime_container_env"
           echo "Starting Management API in background..."
           bun src/index.ts > api-server.log 2>&1 &
           PID=$!

--- a/docs/oauth-oidc-provider.md
+++ b/docs/oauth-oidc-provider.md
@@ -36,13 +36,14 @@ To migrate a project:
 curl -X POST "$MANAGEMENT_API_URL/v1/projects/$PROJECT_REF/auth/oauth-server/migrate" \
   -H "Authorization: Bearer $MANAGEMENT_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{ "allow_dynamic_registration": true }'
+  -d '{ "allow_dynamic_registration": true, "authorization_path": "/authorize.html" }'
 ```
 
 Migration writes project-scoped Auth config:
 
 - `auth.oauth_server.enabled = true`
 - `auth.oauth_server.issuer = <project-api-url>/auth/v1`
+- `auth.oauth_server.authorization_path = /authorize.html` (origin-relative hosted authorize page path)
 - `auth.oauth_server.signing_alg = "ES256"`
 - `auth.oauth_server.jwt_keys = [...]`
 - `auth.oauth_server.jwt_jwks = { "keys": [...] }`
@@ -165,9 +166,16 @@ Body:
 
 ```json
 {
-  "allow_dynamic_registration": true
+  "allow_dynamic_registration": true,
+  "authorization_path": "/authorize.html"
 }
 ```
+
+`authorization_path` must be an origin-relative path beginning with one `/`.
+Absolute URLs, `//` network-path references, query strings, fragments,
+backslashes, control characters, and dot-traversal segments are rejected to
+keep GoTrue redirects on the configured public host. It defaults to
+`/authorize.html` when omitted.
 
 ### OAuth Client CRUD
 

--- a/infrastructure/systemd/supacloud-systemd-unit@.service
+++ b/infrastructure/systemd/supacloud-systemd-unit@.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Install a validated SupaCloud-managed systemd unit %i
+Documentation=https://github.com/supacloud/supacloud
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/supacloud/systemd-unit %i
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictSUIDSGID=true
+ReadWritePaths=/etc/systemd/system /run/supacloud-unit-requests
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER
+SystemCallArchitectures=native

--- a/infrastructure/systemd/supacloud-tenant-user@.service
+++ b/infrastructure/systemd/supacloud-tenant-user@.service
@@ -5,7 +5,6 @@ Documentation=https://github.com/supacloud/supacloud
 [Service]
 Type=oneshot
 ExecStart=/usr/local/libexec/supacloud/tenant-user %i
-RemainAfterExit=yes
 UMask=0077
 
 # This short-lived, fixed helper is the only tenant-provisioning process that

--- a/infrastructure/systemd/supacloud-tenant-user@.service
+++ b/infrastructure/systemd/supacloud-tenant-user@.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Create the isolated SupaCloud runtime account for tenant %i
+Documentation=https://github.com/supacloud/supacloud
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/libexec/supacloud/tenant-user %i
+RemainAfterExit=yes
+UMask=0077
+
+# This short-lived, fixed helper is the only tenant-provisioning process that
+# may update the system account database. The long-running control plane keeps
+# /etc read-only apart from its explicitly managed configuration paths.
+NoNewPrivileges=true
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictAddressFamilies=AF_UNIX
+SystemCallArchitectures=native
+SystemCallFilter=@system-service @chown
+SystemCallFilter=~@mount @reboot @swap @raw-io @keyring
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID

--- a/infrastructure/systemd/supacloud.service
+++ b/infrastructure/systemd/supacloud.service
@@ -37,10 +37,13 @@ SyslogIdentifier=supacloud
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=false
-ReadWritePaths=/etc/supabase /opt/supacloud /tmp /var/log/supacloud
+# The control plane reconciles tenant units and the managed Caddy config at
+# runtime. Keep the rest of /etc read-only while allowing only these managed
+# paths to be updated.
+ReadWritePaths=/etc/supabase /etc/systemd/system /etc/supacloud/caddy /opt/supacloud /tmp /var/log/supacloud
 
-SystemCallFilter=@system-service
-SystemCallFilter=~@mount @reboot @swap @privileged @raw-io @keyring
+SystemCallFilter=@system-service @chown
+SystemCallFilter=~@mount @reboot @swap @raw-io @keyring
 SystemCallArchitectures=native
 
 MemoryMax=4G

--- a/infrastructure/systemd/supacloud.service
+++ b/infrastructure/systemd/supacloud.service
@@ -37,14 +37,17 @@ SyslogIdentifier=supacloud
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=false
-# The control plane reconciles tenant units and the managed Caddy config at
-# runtime. Keep the rest of /etc read-only while allowing only these managed
-# paths to be updated.
-ReadWritePaths=/etc/supabase /etc/systemd/system /etc/supacloud/caddy /opt/supacloud /tmp /var/log/supacloud
+# Unit files are installed by the fixed, allow-listed systemd-unit broker. The
+# network-facing control plane can only write request files, not persistent
+# host units or arbitrary drop-ins.
+RuntimeDirectory=supacloud-unit-requests
+RuntimeDirectoryMode=0700
+ReadWritePaths=/etc/supabase /run/supacloud-unit-requests /etc/supacloud/caddy /opt/supacloud /tmp /var/log/supacloud
 
 SystemCallFilter=@system-service @chown
 SystemCallFilter=~@mount @reboot @swap @raw-io @keyring
 SystemCallArchitectures=native
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER
 
 MemoryMax=4G
 MemoryHigh=3G

--- a/install.sh
+++ b/install.sh
@@ -2574,6 +2574,21 @@ install_tenant_user_helper() {
     install -m 0644 "$unit_src" "$unit_target"
 }
 
+install_systemd_unit_broker() {
+    local helper_src="${SCRIPT_DIR}/scripts/lib/systemd_unit_broker.sh"
+    local unit_src="${SCRIPT_DIR}/infrastructure/systemd/supacloud-systemd-unit@.service"
+    local helper_target="/usr/local/libexec/supacloud/systemd-unit"
+    local unit_target="/etc/systemd/system/supacloud-systemd-unit@.service"
+
+    if [[ ! -f "$helper_src" || ! -f "$unit_src" ]]; then
+        log_error "Systemd unit broker assets are missing"
+        return 1
+    fi
+
+    install -D -m 0755 "$helper_src" "$helper_target"
+    install -m 0644 "$unit_src" "$unit_target"
+}
+
 recover_management_api_install() {
     local transaction_dir="$1"
     local service_was_active="$2"
@@ -2584,6 +2599,10 @@ recover_management_api_install() {
     fi
     supacloud_restore_file_snapshot /usr/local/bin/supacloud "${transaction_dir}/binary" || return 1
     supacloud_restore_file_snapshot /etc/systemd/system/supacloud.service "${transaction_dir}/unit" || return 1
+    supacloud_restore_file_snapshot /usr/local/libexec/supacloud/tenant-user "${transaction_dir}/tenant-user-helper" || return 1
+    supacloud_restore_file_snapshot /etc/systemd/system/supacloud-tenant-user@.service "${transaction_dir}/tenant-user-unit" || return 1
+    supacloud_restore_file_snapshot /usr/local/libexec/supacloud/systemd-unit "${transaction_dir}/systemd-unit-helper" || return 1
+    supacloud_restore_file_snapshot /etc/systemd/system/supacloud-systemd-unit@.service "${transaction_dir}/systemd-unit-unit" || return 1
     if [[ "$keep_current_env" != "true" ]]; then
         supacloud_restore_file_snapshot "$MANAGEMENT_ENV_FILE" "${transaction_dir}/env" || return 1
     fi
@@ -2635,6 +2654,10 @@ install_management_api() {
     supacloud_capture_file_snapshot "$BIN_TARGET" "${management_transaction_dir}/binary"
     supacloud_capture_file_snapshot "$MANAGEMENT_ENV_FILE" "${management_transaction_dir}/env"
     supacloud_capture_file_snapshot /etc/systemd/system/supacloud.service "${management_transaction_dir}/unit"
+    supacloud_capture_file_snapshot /usr/local/libexec/supacloud/tenant-user "${management_transaction_dir}/tenant-user-helper"
+    supacloud_capture_file_snapshot /etc/systemd/system/supacloud-tenant-user@.service "${management_transaction_dir}/tenant-user-unit"
+    supacloud_capture_file_snapshot /usr/local/libexec/supacloud/systemd-unit "${management_transaction_dir}/systemd-unit-helper"
+    supacloud_capture_file_snapshot /etc/systemd/system/supacloud-systemd-unit@.service "${management_transaction_dir}/systemd-unit-unit"
     staged_management_binary="${management_transaction_dir}/supacloud.staged"
     log_info "Staging validated Management API binary from $SELECTED_BIN_SOURCE"
     supacloud_atomic_install_binary "$SELECTED_BIN_SOURCE" "$CI_BIN" "$staged_management_binary"
@@ -2838,6 +2861,9 @@ install_management_api() {
     write_management_api_systemd_unit "$BIN_TARGET" || activation_status=$?
     if (( activation_status == 0 )); then
         install_tenant_user_helper || activation_status=$?
+    fi
+    if (( activation_status == 0 )); then
+        install_systemd_unit_broker || activation_status=$?
     fi
     if (( activation_status == 0 )); then
         mv -f "$staged_management_binary" "$BIN_TARGET" || activation_status=$?

--- a/install.sh
+++ b/install.sh
@@ -198,90 +198,38 @@ ensure_bun_version() {
     fi
 }
 
-ensure_pg_hba_rule() (
-    local rule="$1"
-    local pg_hba="${2:-/pg/data/pg_hba.conf}"
-    local patroni_config=""
-    local cluster_name=""
-    local tmp_before="" tmp_after=""
-    umask 077
-    trap 'rm -f "${tmp_before:-}" "${tmp_after:-}"' EXIT HUP INT TERM
-
-    if command -v patronictl >/dev/null 2>&1; then
-        for candidate in /etc/patroni/patroni.yml /etc/patroni.yml /etc/patroni.yaml; do
-            if [[ -f "$candidate" ]]; then
-                patroni_config="$candidate"
-                break
-            fi
-        done
-    fi
-
-    if [[ -n "$patroni_config" ]] && [[ -f "$pg_hba" ]] && grep -q "overwritten by Patroni" "$pg_hba" 2>/dev/null; then
-        cluster_name=$(patronictl -c "$patroni_config" list 2>/dev/null | sed -n 's/.*Cluster: \([^ ]*\).*/\1/p' | head -1)
-        cluster_name="${cluster_name:-pg-meta}"
-        tmp_before=$(mktemp) || {
-            log_warn "Failed to allocate temporary file for Patroni pg_hba update"
-            return 1
-        }
-        tmp_after=$(mktemp) || {
-            log_warn "Failed to allocate temporary file for Patroni pg_hba update"
-            rm -f "$tmp_before"
-            return 1
-        }
-        if ! patronictl -c "$patroni_config" show-config > "$tmp_before"; then
-            log_warn "Failed to read Patroni dynamic config; cannot add pg_hba rule: $rule"
-            rm -f "$tmp_before" "$tmp_after"
-            return 1
-        fi
-        if ! RULE="$rule" python3 - "$tmp_before" "$tmp_after" <<'PYCODE'
-import os
-import sys
-import yaml
-
-src, dst = sys.argv[1], sys.argv[2]
-rule = os.environ["RULE"]
-with open(src, "r", encoding="utf-8") as fh:
-    data = yaml.safe_load(fh) or {}
-postgresql = data.setdefault("postgresql", {})
-pg_hba = postgresql.setdefault("pg_hba", [])
-if rule not in pg_hba:
-    pg_hba.insert(0, rule)
-with open(dst, "w", encoding="utf-8") as fh:
-    yaml.safe_dump(data, fh, sort_keys=False)
-PYCODE
-        then
-            log_warn "Failed to render Patroni pg_hba update; cannot add rule: $rule"
-            rm -f "$tmp_before" "$tmp_after"
-            return 1
-        fi
-        if ! cmp -s "$tmp_before" "$tmp_after"; then
-            log_info "Adding Patroni pg_hba rule: $rule"
-            if ! patronictl -c "$patroni_config" edit-config --apply "$tmp_after" --force "$cluster_name"; then
-                log_warn "Failed to apply Patroni pg_hba rule: $rule"
-                rm -f "$tmp_before" "$tmp_after"
-                return 1
-            fi
-        else
-            log_info "Patroni pg_hba rule already exists: $rule"
-        fi
-        rm -f "$tmp_before" "$tmp_after"
-        sudo -u postgres psql -c "SELECT pg_reload_conf();" 2>/dev/null || true
-        return 0
-    fi
-
-    if [[ ! -f "$pg_hba" ]]; then
-        log_warn "$pg_hba not found, cannot add pg_hba rule: $rule"
-        return 1
-    fi
-
-    if grep -qF "$rule" "$pg_hba"; then
-        log_info "pg_hba rule already exists: $rule"
+# Persist the tenant HBA rule in Pigsty's inventory and render it through the
+# official pgsql role. /pg/data/pg_hba.conf is ANSIBLE MANAGED and must never be
+# edited directly: Patroni/Pigsty would overwrite a runtime-only change.
+apply_pigsty_tenant_hba_rules() (
+    local pigsty_path="$1"
+    local pigsty_config="$2"
+    local pgsql_playbook="${pigsty_path}/pgsql.yml"
+    cd "$pigsty_path"
+    if [[ -x "$pgsql_playbook" ]]; then
+        "$pgsql_playbook" -l pg-meta --tags=pg_hba -e pg_reload=true
     else
-        log_info "Adding pg_hba rule: $rule"
-        cp "$pg_hba" "${pg_hba}.bak.$(date +%s)"
-        echo "$rule" >> "$pg_hba"
+        ansible-playbook -i "$pigsty_config" "$pgsql_playbook" -l pg-meta --tags=pg_hba -e pg_reload=true
     fi
 )
+
+ensure_pigsty_tenant_hba_rule() {
+    local pigsty_path="${PIGSTY_PATH:-${HOME}/pigsty}"
+    local pigsty_config="${PIGSTY_CONFIG:-${pigsty_path}/pigsty.yml}"
+    local pgsql_playbook="${pigsty_path}/pgsql.yml"
+    local patcher="${SCRIPT_DIR}/scripts/lib/patch_pigsty_tenant_hba.py"
+
+    [[ -f "$pigsty_config" ]] || { log_warn "Pigsty inventory not found at ${pigsty_config}"; return 1; }
+    [[ -f "$pgsql_playbook" ]] || { log_warn "Pigsty pgsql playbook not found at ${pgsql_playbook}"; return 1; }
+    [[ -x "$patcher" ]] || { log_warn "Pigsty HBA patcher not found at ${patcher}"; return 1; }
+    "$patcher" "$pigsty_config" || {
+        log_warn "Pigsty inventory does not contain one unambiguous multiline pg_hba_rules section"
+        return 1
+    }
+
+    log_info "Persisted tenant authenticator HBA rule in ${pigsty_config}"
+    apply_pigsty_tenant_hba_rules "$pigsty_path" "$pigsty_config"
+}
 
 
 configure_low_memory_tcp_guardrails() {
@@ -2450,110 +2398,11 @@ fix_container_healthchecks() {
  
 # ========== Configure PG HBA Whitelist ==========
 configure_pg_hba() {
-    log_step "Configuring database access whitelist (pg_hba.conf)..."
-
-    # 1. Identify container network segment
-    # Try detecting cni-podman0 (Podman) or docker0 (Docker)
-    CONTAINER_NET=""
-    
-    if ip addr show cni-podman0 &> /dev/null; then
-        CONTAINER_NET=$(ip -o -4 addr show cni-podman0 | awk '{print $4}')
-        log_info "Found Podman network: ${CONTAINER_NET}"
-    elif ip addr show docker0 &> /dev/null; then
-        CONTAINER_NET=$(ip -o -4 addr show docker0 | awk '{print $4}')
-        log_info "Found Docker network: ${CONTAINER_NET}"
-    else
-        # Try intelligent guess, look for 10.88/16, 10.89/24 common subnets
-        CONTAINER_NET=$(ip route | grep "link src" | grep -E "10\.(88|89)\." | awk '{print $1}' | head -1)
-    fi
-
-    if [[ -z "$CONTAINER_NET" ]]; then
-        # Fallback: default Podman subnet
-        CONTAINER_NET="10.88.0.0/16" 
-        log_warn "Container network not detected, using default: ${CONTAINER_NET}"
-    fi
-
-    # 2. Locate pg_hba.conf
-    # Pigsty default path
-    PG_HBA="/pg/data/pg_hba.conf"
-    
-    if [[ ! -f "$PG_HBA" ]]; then
-        log_warn "$PG_HBA not found, attempting to find other locations..."
-        # Try searching for Debian/Ubuntu or RHEL default paths
-        POSSIBLE_PATHS=(
-            "/var/lib/postgresql/data/pg_hba.conf"
-            "/var/lib/pgsql/data/pg_hba.conf"
-            "/etc/postgresql/14/main/pg_hba.conf"
-            "/etc/postgresql/15/main/pg_hba.conf"
-        )
-        for path in "${POSSIBLE_PATHS[@]}"; do
-            if [[ -f "$path" ]]; then
-                PG_HBA="$path"
-                log_info "Found pg_hba.conf: $PG_HBA"
-                break
-            fi
-        done
-    fi
-
-    if [[ ! -f "$PG_HBA" ]]; then
-        log_warn "pg_hba.conf not found, skipping configuration"
-        return
-    fi
-    
-    # 3. Add rules.
-    # Management API and tenant runtimes usually run on the database host. Some
-    # installs set DATABASE_URL/PG_HOST to INTERNAL_IP instead of loopback, so
-    # PostgreSQL sees the connection as coming from that host IP and rejects it
-    # unless pg_hba.conf explicitly allows it.
-    CONFIG_LINE="host all all ${CONTAINER_NET} scram-sha-256"
-    LOCALHOST_RULE="host    all             all             127.0.0.1/32            scram-sha-256"
-    HOST_RULE=""
-    if [[ -n "${INTERNAL_IP:-}" && "$INTERNAL_IP" != "127.0.0.1" && "$INTERNAL_IP" != "localhost" ]]; then
-        HOST_RULE="host    all             all             ${INTERNAL_IP}/32            scram-sha-256"
-    fi
-    
-    if grep -qF "$CONTAINER_NET" "$PG_HBA"; then
-        log_info "Rule already exists: $CONFIG_LINE"
-    else
-        log_info "Adding rule: $CONFIG_LINE"
-        # Backup
-        cp "$PG_HBA" "${PG_HBA}.bak.$(date +%s)"
-        # Append to file
-        echo "$CONFIG_LINE" >> "$PG_HBA"
-    fi
-    
-    # Add localhost rule
-    if ! grep -qF "127.0.0.1/32" "$PG_HBA"; then
-        log_info "Adding localhost password authentication rule..."
-        echo "$LOCALHOST_RULE" >> "$PG_HBA"
-    fi
-
-    # Add host self-IP rule when management services use INTERNAL_IP.
-    if [[ -n "$HOST_RULE" ]]; then
-        if grep -qF "${INTERNAL_IP}/32" "$PG_HBA"; then
-            log_info "Rule already exists for host IP: ${INTERNAL_IP}/32"
-        else
-            log_info "Adding host self-IP authentication rule: ${INTERNAL_IP}/32"
-            echo "$HOST_RULE" >> "$PG_HBA"
-        fi
-    fi
-        
-    # 4. Reload configuration
-    log_info "Reloading PostgreSQL configuration..."
-    if command -v pg_ctl &> /dev/null; then
-         # Execute as postgres user
-         su - postgres -c "pg_ctl reload -D $(dirname "$PG_HBA")"
-    elif systemctl is-active --quiet postgresql; then
-         systemctl reload postgresql
-    elif systemctl is-active --quiet patroni; then
-         systemctl reload patroni
-    elif pgrep -u postgres postgres > /dev/null; then
-         # Try sending SIGHUP
-         pkill -HUP -u postgres postgres
-         log_info "Sent SIGHUP signal to postgres process"
-    else
-         log_warn "Cannot automatically reload PostgreSQL, please execute reload manually"
-    fi
+    log_step "Persisting tenant database HBA access through Pigsty..."
+    ensure_pigsty_tenant_hba_rule || {
+        log_error "Failed to persist the tenant authenticator HBA rule through Pigsty"
+        return 1
+    }
 }
 
 # ========== Save All Credentials ==========
@@ -2708,6 +2557,21 @@ LimitNOFILE=65536
 [Install]
 WantedBy=multi-user.target
 EOF
+}
+
+install_tenant_user_helper() {
+    local helper_src="${SCRIPT_DIR}/scripts/lib/tenant_user.sh"
+    local unit_src="${SCRIPT_DIR}/infrastructure/systemd/supacloud-tenant-user@.service"
+    local helper_target="/usr/local/libexec/supacloud/tenant-user"
+    local unit_target="/etc/systemd/system/supacloud-tenant-user@.service"
+
+    if [[ ! -f "$helper_src" || ! -f "$unit_src" ]]; then
+        log_error "Tenant user helper assets are missing"
+        return 1
+    fi
+
+    install -D -m 0755 "$helper_src" "$helper_target"
+    install -m 0644 "$unit_src" "$unit_target"
 }
 
 recover_management_api_install() {
@@ -2893,6 +2757,7 @@ install_management_api() {
         REALTIME_SECRET_KEY_BASE "$REALTIME_SECRET_KEY_BASE" \
         REALTIME_DB_ENC_KEY "$REALTIME_DB_ENC_KEY" \
         REALTIME_API_SECRET "$JWT_SECRET" \
+        SUPACLOUD_REALTIME_CONTAINER_ENV_FILE "${SUPACLOUD_REALTIME_CONTAINER_ENV_FILE:-/etc/supabase/realtime-container.env}" \
         REALTIME_IMAGE "${REALTIME_IMAGE:-public.ecr.aws/supabase/realtime:v2.116.1}" \
         REALTIME_CONTAINER_NAME "${REALTIME_CONTAINER_NAME:-supacloud-realtime}" \
         REALTIME_DB_USER supabase_admin \
@@ -2971,6 +2836,9 @@ install_management_api() {
     log_info "Activating Management API binary and systemd unit..."
     local activation_status=0
     write_management_api_systemd_unit "$BIN_TARGET" || activation_status=$?
+    if (( activation_status == 0 )); then
+        install_tenant_user_helper || activation_status=$?
+    fi
     if (( activation_status == 0 )); then
         mv -f "$staged_management_binary" "$BIN_TARGET" || activation_status=$?
     fi
@@ -3245,6 +3113,13 @@ write_realtime_container_env() {
         RUN_JANITOR false \
         SECURE_CHANNELS false \
         DISABLE_HEALTHCHECK_LOGGING true
+
+    local rendered_api_secret
+    rendered_api_secret=$(supacloud_env_value "$target_file" API_JWT_SECRET)
+    if [[ "$rendered_api_secret" != "$JWT_SECRET" ]]; then
+        log_error "Realtime container API_JWT_SECRET does not match JWT_SECRET"
+        return 1
+    fi
 }
 
 render_realtime_systemd_unit() {

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -96,6 +96,7 @@ export interface Config {
   victoriaMetricsUrl: string;
   realtimeAdminUrl: string;
   realtimeApiSecret: string;
+  realtimeContainerEnvFile: string;
   managementApiInternal: string;
   storageSigningSecret: string;
   scriptsPath: string;
@@ -261,6 +262,10 @@ export const config: Config = {
   victoriaMetricsUrl: getEnv("VICTORIAMETRICS_URL", "http://127.0.0.1:8428"),
   realtimeAdminUrl: getEnv("REALTIME_ADMIN_URL", "http://127.0.0.1:4000"),
   realtimeApiSecret: getEnv("REALTIME_API_SECRET", ""),
+  realtimeContainerEnvFile: getEnv(
+    "SUPACLOUD_REALTIME_CONTAINER_ENV_FILE",
+    "/etc/supabase/realtime-container.env",
+  ),
   managementApiInternal: getEnv("MANAGEMENT_API_INTERNAL", `127.0.0.1:${port}`),
   storageSigningSecret: getEnv("STORAGE_SIGNING_SECRET", ""),
 

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1089,6 +1089,8 @@ async function bootstrap() {
   } else if (args.includes("--help") || args.includes("-h")) {
     process.exit(0);
   } else if (args.length === 0 || args.includes("--server")) {
+    const { validateRealtimeSecretConfiguration } = await import("./services/realtime.service");
+    validateRealtimeSecretConfiguration();
     const { sql: controlPlaneSql } = await import("./db");
     const { assertPlatformMigrationCompleted } = await import("./db/audit-chain-migration");
     const {

--- a/packages/management-api/src/routes/auth-oauth-server.ts
+++ b/packages/management-api/src/routes/auth-oauth-server.ts
@@ -13,6 +13,10 @@ import {
 import { normalizeOAuthServerConfig, normalizeProjectConfig } from "../utils/project-config";
 import { requireAuthRuntimeManagement } from "./auth-runtime";
 import {
+  OAuthAuthorizationPathError,
+  resolveOAuthAuthorizationPath,
+} from "../utils/oauth-authorization-path";
+import {
   buildAwsKmsRs256JwtKeyMaterial,
   generateOidcJwtKeyMaterial,
   normalizeProjectJwtJwks,
@@ -81,6 +85,7 @@ type OAuthServerSettings = {
 
 type MigrateOAuthServerInput = {
   allow_dynamic_registration?: boolean;
+  authorization_path?: string;
 };
 
 type KmsRs256Input = {
@@ -139,6 +144,7 @@ function buildOAuthServerStatus(ctx: NonNullable<Awaited<ReturnType<typeof loadP
     enabled: migrated && ctx.oauthServer.enabled === true,
     allow_dynamic_registration: ctx.oauthServer.allow_dynamic_registration === true,
     issuer,
+    authorization_path: ctx.oauthServer.authorization_path,
     discovery_url: `${issuer}/.well-known/openid-configuration`,
     oauth_authorization_server_metadata_url: `${authUrl}/.well-known/oauth-authorization-server/auth/v1`,
     jwks_url: `${issuer}/.well-known/jwks.json`,
@@ -185,11 +191,16 @@ async function configureKmsRs256Signing(
 
   const currentAuth = (settings.auth || {}) as Record<string, unknown>;
   const currentOauthServer = normalizeOAuthServerConfig(currentAuth.oauth_server) as OAuthServerSettings;
+  const authorizationPath = resolveOAuthAuthorizationPath(
+    undefined,
+    currentOauthServer.authorization_path,
+  );
   const oauthServer: OAuthServerSettings = {
     ...currentOauthServer,
     enabled: true,
     allow_dynamic_registration: input.allow_dynamic_registration === true,
     issuer: ctx.issuer,
+    authorization_path: authorizationPath,
     migrated_at: new Date().toISOString(),
     signing_alg: keyMaterial.signing_alg,
     key_id: keyMaterial.key_id,
@@ -298,6 +309,18 @@ async function migrateProjectToOidc(
 
   const currentAuth = (settings.auth || {}) as Record<string, unknown>;
   const currentOauthServer = normalizeOAuthServerConfig(currentAuth.oauth_server) as OAuthServerSettings;
+  let authorizationPath: string;
+  try {
+    authorizationPath = resolveOAuthAuthorizationPath(
+      input.authorization_path,
+      currentOauthServer.authorization_path,
+    );
+  } catch (error: unknown) {
+    if (error instanceof OAuthAuthorizationPathError) {
+      return status(400, { message: error.message, code: "400" });
+    }
+    throw error;
+  }
   const existingJwtKeys = normalizeProjectJwtKeys(currentOauthServer.jwt_keys);
   const existingJwtJwks = normalizeProjectJwtJwks(currentOauthServer.jwt_jwks);
   const keyMaterial = existingJwtKeys && existingJwtJwks && typeof currentOauthServer.key_id === "string"
@@ -314,6 +337,7 @@ async function migrateProjectToOidc(
     enabled: true,
     allow_dynamic_registration: input.allow_dynamic_registration === true,
     issuer: ctx.issuer,
+    authorization_path: authorizationPath,
     migrated_at: new Date().toISOString(),
     signing_alg: keyMaterial.signing_alg,
     key_id: keyMaterial.key_id,
@@ -336,10 +360,13 @@ async function migrateProjectToOidc(
       ref,
       error: error instanceof Error ? error.message : String(error),
     });
+    return status(503, {
+      code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+      message: "OIDC signing configuration was saved, but one or more SupAuth runtimes failed to refresh",
+    });
   }
 
-  const updatedCtx = await loadProjectContext(ref);
-  return buildOAuthServerStatus(updatedCtx || ctx);
+  return buildOAuthServerStatus({ ...ctx, oauthServer });
 }
 
 export const authOAuthServerRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth" })
@@ -366,7 +393,10 @@ export const authOAuthServerRoutes = new Elysia({ prefix: "/v1/projects/:ref/aut
     },
     {
       params: t.Object({ ref: t.String() }),
-      body: t.Object({ allow_dynamic_registration: t.Optional(t.Boolean()) }),
+      body: t.Object({
+        allow_dynamic_registration: t.Optional(t.Boolean()),
+        authorization_path: t.Optional(t.String({ minLength: 1, maxLength: 2048 })),
+      }),
       detail: { tags: ["auth"], summary: "Migrate project auth to OIDC signing keys" },
     },
   )

--- a/packages/management-api/src/routes/frontend.ts
+++ b/packages/management-api/src/routes/frontend.ts
@@ -171,7 +171,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
         ref: t.String(),
       }),
       body: t.Object({
-        name: t.String({ minLength: 1 }),
+        name: t.String({ minLength: 1, maxLength: 100, pattern: "^[^\\r\\n]+$" }),
         framework: t.String(),
         domain: t.Optional(t.String()),
         custom_domains: t.Optional(t.Array(t.String())),
@@ -213,7 +213,7 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
         id: t.String(),
       }),
       body: t.Object({
-        name: t.Optional(t.String()),
+        name: t.Optional(t.String({ minLength: 1, maxLength: 100, pattern: "^[^\\r\\n]+$" })),
         domain: t.Optional(t.String()),
         custom_domains: t.Optional(t.Array(t.String())),
         build_command: t.Optional(t.String()),

--- a/packages/management-api/src/services/frontend-runtime.ts
+++ b/packages/management-api/src/services/frontend-runtime.ts
@@ -76,7 +76,6 @@ Environment="NODE_ENV=production"
 Environment="PROTOCOL_HEADER=x-forwarded-proto"
 Environment="HOST_HEADER=x-forwarded-host"
 Environment="PORT_HEADER=x-forwarded-port"
-EnvironmentFile=-/etc/supabase/management-api.env
 EnvironmentFile=${envFile}
 ExecStart=/usr/bin/env node ${entrypoint}
 Restart=always

--- a/packages/management-api/src/services/frontend-runtime.ts
+++ b/packages/management-api/src/services/frontend-runtime.ts
@@ -3,6 +3,7 @@ import { join, relative } from "node:path";
 
 type SvelteKitSystemdUnitInput = {
   serviceName: string;
+  runtimeUser: string;
   description: string;
   buildDir: string;
   envFile: string;
@@ -19,7 +20,7 @@ async function requireDirectory(path: string, message: string): Promise<void> {
   if (!entry?.isDirectory()) throw new Error(message);
 }
 
-function assertSystemdValue(value: string, label: string): string {
+export function assertSystemdValue(value: string, label: string): string {
   if (!value || /[\r\n]/.test(value)) {
     throw new Error(`${label} contains unsupported systemd characters`);
   }
@@ -54,6 +55,7 @@ export async function prepareSvelteKitRuntime(
 
 export function renderSvelteKitSystemdUnit(input: SvelteKitSystemdUnitInput): string {
   const serviceName = assertSystemdValue(input.serviceName, "Service name");
+  const runtimeUser = assertSystemdValue(input.runtimeUser, "Runtime user");
   const description = assertSystemdValue(input.description, "Description");
   const buildDir = assertSystemdValue(input.buildDir, "Build directory");
   const envFile = assertSystemdValue(input.envFile, "Environment file");
@@ -65,8 +67,10 @@ After=network.target
 
 [Service]
 Type=simple
-User=root
+User=${runtimeUser}
+Group=${runtimeUser}
 WorkingDirectory=${buildDir}
+NoNewPrivileges=true
 Environment="PORT=${input.port}"
 Environment="NODE_ENV=production"
 Environment="PROTOCOL_HEADER=x-forwarded-proto"

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -665,7 +665,6 @@ WorkingDirectory=${buildDir}
 NoNewPrivileges=true
 Environment="PORT=${port}"
 Environment="NODE_ENV=production"
-EnvironmentFile=-/etc/supabase/management-api.env
 EnvironmentFile=${envFile}
 ExecStart=${config.bunPath} run ${buildDir}/index.js
 Restart=always

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -28,10 +28,12 @@ import {
 import { FrontendDomainService } from "./frontend-domain.service";
 import { FrontendRecordService } from "./frontend-record.service";
 import {
+  assertSystemdValue,
   prepareSvelteKitRuntime,
   renderSvelteKitSystemdUnit,
 } from "./frontend-runtime";
 import { installManagedSystemdUnit, removeManagedSystemdUnit } from "./systemd-unit-broker";
+import { tenantRuntimeService } from "./tenant-runtime.service";
 
 const FRONTEND_BASE_DIR = "/var/supacloud/frontends";
 const READINESS_TIMEOUT_MS = 30_000;
@@ -627,12 +629,16 @@ export class FrontendService {
   ): Promise<number> {
     const port = 30000 + parseInt(deploymentId, 16) % 10000;
     const serviceName = `supacloud-frontend-${projectRef}-${deploymentId}`;
+    const runtimeUser = await tenantRuntimeService.ensureTenantRuntimeUser(projectRef);
+    const description = assertSystemdValue(`${deployment.name} (${projectRef}/${deploymentId})`, "Description");
 
     const envFile = this.joinPath(this.baseDir, projectRef, deploymentId, ".env");
     const envContent = Object.entries(deployment.env_vars)
       .map(([key, value]) => `${key}=${value}`)
       .join("\n");
     await Bun.write(envFile, envContent);
+    await $`chown ${runtimeUser}:${runtimeUser} ${envFile}`.quiet();
+    await $`chmod 600 ${envFile}`.quiet();
 
     if (!isSSR) {
       throw new Error("Static frontend deployments are served directly by Caddy");
@@ -641,19 +647,22 @@ export class FrontendService {
     const systemdUnit = deployment.framework === "sveltekit"
       ? renderSvelteKitSystemdUnit({
           serviceName,
-          description: `${deployment.name} (${projectRef}/${deploymentId})`,
+          runtimeUser,
+          description,
           buildDir,
           envFile,
           port,
         })
       : `[Unit]
-Description=SupaCloud Frontend SSR: ${deployment.name} (${projectRef}/${deploymentId})
+Description=SupaCloud Frontend SSR: ${description}
 After=network.target
 
 [Service]
 Type=simple
-User=root
+User=${runtimeUser}
+Group=${runtimeUser}
 WorkingDirectory=${buildDir}
+NoNewPrivileges=true
 Environment="PORT=${port}"
 Environment="NODE_ENV=production"
 EnvironmentFile=-/etc/supabase/management-api.env

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -31,6 +31,7 @@ import {
   prepareSvelteKitRuntime,
   renderSvelteKitSystemdUnit,
 } from "./frontend-runtime";
+import { installManagedSystemdUnit, removeManagedSystemdUnit } from "./systemd-unit-broker";
 
 const FRONTEND_BASE_DIR = "/var/supacloud/frontends";
 const READINESS_TIMEOUT_MS = 30_000;
@@ -666,8 +667,7 @@ LimitNOFILE=65536
 WantedBy=multi-user.target
 `;
 
-    const servicePath = `/etc/systemd/system/${serviceName}.service`;
-    await Bun.write(servicePath, systemdUnit);
+    await installManagedSystemdUnit(`${serviceName}.service`, systemdUnit);
 
     await $`systemctl daemon-reload`.quiet();
     await $`systemctl enable ${serviceName}`.quiet();
@@ -681,8 +681,7 @@ WantedBy=multi-user.target
     
     await $`systemctl stop ${serviceName}`.nothrow().quiet();
     await $`systemctl disable ${serviceName}`.nothrow().quiet();
-    await $`rm -f /etc/systemd/system/${serviceName}.service`.quiet();
-    await $`systemctl daemon-reload`.quiet();
+    await removeManagedSystemdUnit(`${serviceName}.service`);
   }
 
   private async precompressStaticAssets(root: string): Promise<void> {

--- a/packages/management-api/src/services/realtime.service.ts
+++ b/packages/management-api/src/services/realtime.service.ts
@@ -42,10 +42,19 @@ export function assertRealtimeSecretAlignment(input: {
     canonicalSecret: string;
     configuredApiSecret?: string;
     containerApiSecret?: string;
+    requireContainerApiSecret?: boolean;
 }): void {
-    const { canonicalSecret, configuredApiSecret = "", containerApiSecret = "" } = input;
+    const {
+        canonicalSecret,
+        configuredApiSecret = "",
+        containerApiSecret = "",
+        requireContainerApiSecret = false,
+    } = input;
     if (!canonicalSecret) {
         throw new Error("Realtime canonical JWT secret is missing");
+    }
+    if (requireContainerApiSecret && !containerApiSecret.trim()) {
+        throw new Error("Realtime container API JWT secret is missing");
     }
     if (configuredApiSecret && configuredApiSecret !== canonicalSecret) {
         throw new Error("Realtime API secret does not match the canonical JWT secret");
@@ -55,13 +64,17 @@ export function assertRealtimeSecretAlignment(input: {
     }
 }
 
+export function validateRealtimeSecretConfiguration(containerEnvFile = config.realtimeContainerEnvFile): void {
+    const containerApiSecret = readEnvFileValue(containerEnvFile, "API_JWT_SECRET");
+    assertRealtimeSecretAlignment({
+        canonicalSecret: config.jwtSecret,
+        configuredApiSecret: config.realtimeApiSecret,
+        containerApiSecret,
+        requireContainerApiSecret: true,
+    });
+}
+
 const REALTIME_API_SECRET = config.jwtSecret;
-const CONTAINER_API_JWT_SECRET = readEnvFileValue(config.realtimeContainerEnvFile, "API_JWT_SECRET");
-assertRealtimeSecretAlignment({
-    canonicalSecret: REALTIME_API_SECRET,
-    configuredApiSecret: config.realtimeApiSecret,
-    containerApiSecret: CONTAINER_API_JWT_SECRET,
-});
 if (!REALTIME_API_SECRET) {
     logger.error("FATAL: REALTIME_API_SECRET or JWT_SECRET must be set for RealtimeService.");
 }

--- a/packages/management-api/src/services/realtime.service.ts
+++ b/packages/management-api/src/services/realtime.service.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { config } from "../config";
 import { sql, resolveSlotName, resolveRoleName } from "../db";
 /**
@@ -18,7 +19,49 @@ function isConnectionError(msg: string): boolean {
 }
 
 const REALTIME_ADMIN_URL = config.realtimeAdminUrl;
-const REALTIME_API_SECRET = config.realtimeApiSecret || config.jwtSecret;
+
+function readEnvFileValue(filePath: string, key: string): string {
+    try {
+        const line = readFileSync(filePath, "utf8")
+            .split(/\r?\n/)
+            .find((candidate) => candidate.trimStart().startsWith(`${key}=`));
+        if (!line) return "";
+        const envEntry = line.slice(line.indexOf("=") + 1).trim();
+        return ((envEntry.startsWith('"') && envEntry.endsWith('"')) || (envEntry.startsWith("'") && envEntry.endsWith("'")))
+            ? envEntry.slice(1, -1)
+            : envEntry;
+    } catch (error) {
+        if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+            return "";
+        }
+        throw error;
+    }
+}
+
+export function assertRealtimeSecretAlignment(input: {
+    canonicalSecret: string;
+    configuredApiSecret?: string;
+    containerApiSecret?: string;
+}): void {
+    const { canonicalSecret, configuredApiSecret = "", containerApiSecret = "" } = input;
+    if (!canonicalSecret) {
+        throw new Error("Realtime canonical JWT secret is missing");
+    }
+    if (configuredApiSecret && configuredApiSecret !== canonicalSecret) {
+        throw new Error("Realtime API secret does not match the canonical JWT secret");
+    }
+    if (containerApiSecret && containerApiSecret !== canonicalSecret) {
+        throw new Error("Realtime container API JWT secret does not match the canonical JWT secret");
+    }
+}
+
+const REALTIME_API_SECRET = config.jwtSecret;
+const CONTAINER_API_JWT_SECRET = readEnvFileValue(config.realtimeContainerEnvFile, "API_JWT_SECRET");
+assertRealtimeSecretAlignment({
+    canonicalSecret: REALTIME_API_SECRET,
+    configuredApiSecret: config.realtimeApiSecret,
+    containerApiSecret: CONTAINER_API_JWT_SECRET,
+});
 if (!REALTIME_API_SECRET) {
     logger.error("FATAL: REALTIME_API_SECRET or JWT_SECRET must be set for RealtimeService.");
 }

--- a/packages/management-api/src/services/systemd-unit-broker.ts
+++ b/packages/management-api/src/services/systemd-unit-broker.ts
@@ -36,7 +36,14 @@ function allowedDirectives(section: string): ReadonlySet<string> | undefined {
   return undefined;
 }
 
-type UnitPolicyState = { section: string; sections: Set<string>; user: string; group: string; noNewPrivileges: boolean };
+type UnitPolicyState = {
+  section: string;
+  sections: Set<string>;
+  user: string;
+  group: string;
+  noNewPrivileges: boolean;
+  environmentFile: string;
+};
 
 function enterSection(unitName: string, state: UnitPolicyState, section: string): void {
   if (state.sections.has(section)) throw new Error(`Systemd unit ${unitName} repeats [${section}]`);
@@ -50,6 +57,25 @@ function recordIdentity(unitName: string, state: UnitPolicyState, key: string, v
   if (existing || !MANAGED_IDENTITY_PATTERN.test(value)) throw new Error(`Systemd unit ${unitName} has an invalid ${key}`);
   if (key === "User") state.user = value;
   else state.group = value;
+}
+
+function isAllowedEnvironmentFile(unitName: string, value: string): boolean {
+  if (unitName === "supacloud-pgrst@.service") {
+    return /^\/etc\/supabase\/[A-Za-z0-9_-]{1,64}\/%i\.env$/.test(value);
+  }
+  if (unitName === "supacloud-gotrue@.service") {
+    return /^\/etc\/supabase\/[A-Za-z0-9_-]{1,64}\/%i_gotrue\.env$/.test(value);
+  }
+  const match = value.match(/^\/var\/supacloud\/frontends\/([a-z0-9-]{1,20})\/([a-f0-9]{8})\/\.env$/);
+  return !!match && unitName === `supacloud-frontend-${match[1]}-${match[2]}.service`;
+}
+
+function recordEnvironmentFile(unitName: string, state: UnitPolicyState, key: string, value: string): void {
+  if (key !== "EnvironmentFile") return;
+  if (state.environmentFile || !isAllowedEnvironmentFile(unitName, value)) {
+    throw new Error(`Systemd unit ${unitName} has an invalid EnvironmentFile`);
+  }
+  state.environmentFile = value;
 }
 
 function validateDirective(unitName: string, state: UnitPolicyState, line: string): void {
@@ -67,11 +93,12 @@ function validateDirective(unitName: string, state: UnitPolicyState, line: strin
     state.noNewPrivileges = true;
   }
   recordIdentity(unitName, state, key, value);
+  recordEnvironmentFile(unitName, state, key, value);
 }
 
 function validateUnitIdentity(unitName: string, state: UnitPolicyState): void {
   if (!["Unit", "Service", "Install"].every((required) => state.sections.has(required))
-    || !state.user || state.user !== state.group || !state.noNewPrivileges) {
+    || !state.user || state.user !== state.group || !state.noNewPrivileges || !state.environmentFile) {
     throw new Error(`Systemd unit ${unitName} is missing its non-root runtime identity`);
   }
   if (unitName.includes("@") && state.user !== "supacloud-%i") {
@@ -83,10 +110,12 @@ function validateUnitIdentity(unitName: string, state: UnitPolicyState): void {
 }
 
 export function assertManagedSystemdUnitContent(unitName: string, content: string): void {
-  if (!content || Buffer.byteLength(content, "utf8") > MAX_UNIT_BYTES || /[\0\r]/.test(content)) {
+  if (!content || Buffer.byteLength(content, "utf8") > MAX_UNIT_BYTES || /[\x00-\x09\x0b-\x1f\x7f]/.test(content)) {
     throw new Error(`Systemd unit ${unitName} has invalid content`);
   }
-  const state: UnitPolicyState = { section: "", sections: new Set(), user: "", group: "", noNewPrivileges: false };
+  const state: UnitPolicyState = {
+    section: "", sections: new Set(), user: "", group: "", noNewPrivileges: false, environmentFile: "",
+  };
   for (const line of content.split("\n")) {
     if (!line || /^\s*[#;]/.test(line)) continue;
     if (line.endsWith("\\")) throw new Error(`Systemd unit ${unitName} uses a line continuation`);

--- a/packages/management-api/src/services/systemd-unit-broker.ts
+++ b/packages/management-api/src/services/systemd-unit-broker.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+
+const REQUEST_DIR = "/run/supacloud-unit-requests";
+const MANAGED_UNIT_PATTERN = /^(?:supacloud-(?:pgrst|gotrue)@\.service|supacloud-frontend-[a-z0-9-]{1,64}\.service)$/;
+
+async function runSystemctl(args: string[]): Promise<{ exitCode: number; stderr: string }> {
+  const child = Bun.spawn({ cmd: ["systemctl", ...args], stdout: "pipe", stderr: "pipe" });
+  const [stderr, exitCode] = await Promise.all([
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  return { exitCode, stderr };
+}
+
+function assertManagedUnitName(unitName: string): void {
+  if (!MANAGED_UNIT_PATTERN.test(unitName)) {
+    throw new Error(`Systemd unit ${unitName} is outside the SupaCloud allow-list`);
+  }
+}
+
+async function executeBrokerRequest(operation: "install" | "remove", unitName: string, content?: string): Promise<void> {
+  assertManagedUnitName(unitName);
+  await mkdir(REQUEST_DIR, { recursive: true, mode: 0o700 });
+  const token = randomUUID();
+  const requestPath = `${REQUEST_DIR}/${token}.request`;
+  const sourcePath = `${REQUEST_DIR}/${token}.unit`;
+  try {
+    if (content !== undefined) {
+      await writeFile(sourcePath, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    }
+    await writeFile(
+      requestPath,
+      `operation=${operation}\nunit_name=${unitName}\n`,
+      { encoding: "utf8", mode: 0o600, flag: "wx" },
+    );
+    const result = await runSystemctl(["--wait", "start", `supacloud-systemd-unit@${token}.service`]);
+    if (result.exitCode !== 0) {
+      throw new Error(`Systemd unit broker failed for ${unitName}: ${result.stderr.trim().slice(0, 300)}`);
+    }
+  } finally {
+    await rm(requestPath, { force: true });
+    await rm(sourcePath, { force: true });
+  }
+}
+
+export function installManagedSystemdUnit(unitName: string, content: string): Promise<void> {
+  return executeBrokerRequest("install", unitName, content);
+}
+
+export function removeManagedSystemdUnit(unitName: string): Promise<void> {
+  return executeBrokerRequest("remove", unitName);
+}

--- a/packages/management-api/src/services/systemd-unit-broker.ts
+++ b/packages/management-api/src/services/systemd-unit-broker.ts
@@ -3,6 +3,16 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 
 const REQUEST_DIR = "/run/supacloud-unit-requests";
 const MANAGED_UNIT_PATTERN = /^(?:supacloud-(?:pgrst|gotrue)@\.service|supacloud-frontend-[a-z0-9-]{1,64}\.service)$/;
+const MANAGED_IDENTITY_PATTERN = /^supacloud-(?:%i|[a-z0-9-]{1,20})$/;
+const MAX_UNIT_BYTES = 16 * 1024;
+const UNIT_DIRECTIVES = new Set(["After", "Description", "Documentation", "Wants"]);
+const SERVICE_DIRECTIVES = new Set([
+  "CPUWeight", "Environment", "EnvironmentFile", "ExecReload", "ExecStart",
+  "Group", "LimitNOFILE", "MemoryMax", "NoNewPrivileges", "ProtectHome",
+  "ProtectSystem", "ReadOnlyPaths", "Restart", "RestartSec", "StartLimitBurst",
+  "StartLimitIntervalSec", "SyslogIdentifier", "Type", "User", "WorkingDirectory",
+]);
+const INSTALL_DIRECTIVES = new Set(["WantedBy"]);
 
 async function runSystemctl(args: string[]): Promise<{ exitCode: number; stderr: string }> {
   const child = Bun.spawn({ cmd: ["systemctl", ...args], stdout: "pipe", stderr: "pipe" });
@@ -19,6 +29,74 @@ function assertManagedUnitName(unitName: string): void {
   }
 }
 
+function allowedDirectives(section: string): ReadonlySet<string> | undefined {
+  if (section === "Unit") return UNIT_DIRECTIVES;
+  if (section === "Service") return SERVICE_DIRECTIVES;
+  if (section === "Install") return INSTALL_DIRECTIVES;
+  return undefined;
+}
+
+type UnitPolicyState = { section: string; sections: Set<string>; user: string; group: string; noNewPrivileges: boolean };
+
+function enterSection(unitName: string, state: UnitPolicyState, section: string): void {
+  if (state.sections.has(section)) throw new Error(`Systemd unit ${unitName} repeats [${section}]`);
+  state.sections.add(section);
+  state.section = section;
+}
+
+function recordIdentity(unitName: string, state: UnitPolicyState, key: string, value: string): void {
+  if (key !== "User" && key !== "Group") return;
+  const existing = key === "User" ? state.user : state.group;
+  if (existing || !MANAGED_IDENTITY_PATTERN.test(value)) throw new Error(`Systemd unit ${unitName} has an invalid ${key}`);
+  if (key === "User") state.user = value;
+  else state.group = value;
+}
+
+function validateDirective(unitName: string, state: UnitPolicyState, line: string): void {
+  const match = line.match(/^([A-Za-z][A-Za-z0-9]*)=(.*)$/);
+  if (!match || !allowedDirectives(state.section)?.has(match[1]!)) {
+    throw new Error(`Systemd unit ${unitName} contains an unsupported directive`);
+  }
+  const key = match[1]!;
+  const value = match[2]!;
+  if ((key === "ExecStart" || key === "ExecReload") && /^[-+!:@|]/.test(value)) {
+    throw new Error(`Systemd unit ${unitName} uses a privileged execution prefix`);
+  }
+  if (key === "NoNewPrivileges") {
+    if (state.noNewPrivileges || value !== "true") throw new Error(`Systemd unit ${unitName} must enforce NoNewPrivileges`);
+    state.noNewPrivileges = true;
+  }
+  recordIdentity(unitName, state, key, value);
+}
+
+function validateUnitIdentity(unitName: string, state: UnitPolicyState): void {
+  if (!["Unit", "Service", "Install"].every((required) => state.sections.has(required))
+    || !state.user || state.user !== state.group || !state.noNewPrivileges) {
+    throw new Error(`Systemd unit ${unitName} is missing its non-root runtime identity`);
+  }
+  if (unitName.includes("@") && state.user !== "supacloud-%i") {
+    throw new Error(`Systemd template ${unitName} must use the tenant instance identity`);
+  }
+  if (unitName.startsWith("supacloud-frontend-") && !unitName.startsWith(`supacloud-frontend-${state.user.slice(10)}-`)) {
+    throw new Error(`Systemd unit ${unitName} does not match its tenant identity`);
+  }
+}
+
+export function assertManagedSystemdUnitContent(unitName: string, content: string): void {
+  if (!content || Buffer.byteLength(content, "utf8") > MAX_UNIT_BYTES || /[\0\r]/.test(content)) {
+    throw new Error(`Systemd unit ${unitName} has invalid content`);
+  }
+  const state: UnitPolicyState = { section: "", sections: new Set(), user: "", group: "", noNewPrivileges: false };
+  for (const line of content.split("\n")) {
+    if (!line || /^\s*[#;]/.test(line)) continue;
+    if (line.endsWith("\\")) throw new Error(`Systemd unit ${unitName} uses a line continuation`);
+    const section = line.match(/^\[(Unit|Service|Install)\]$/)?.[1];
+    if (section) enterSection(unitName, state, section);
+    else validateDirective(unitName, state, line);
+  }
+  validateUnitIdentity(unitName, state);
+}
+
 async function executeBrokerRequest(operation: "install" | "remove", unitName: string, content?: string): Promise<void> {
   assertManagedUnitName(unitName);
   await mkdir(REQUEST_DIR, { recursive: true, mode: 0o700 });
@@ -27,6 +105,7 @@ async function executeBrokerRequest(operation: "install" | "remove", unitName: s
   const sourcePath = `${REQUEST_DIR}/${token}.unit`;
   try {
     if (content !== undefined) {
+      assertManagedSystemdUnitContent(unitName, content);
       await writeFile(sourcePath, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
     }
     await writeFile(

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -777,7 +777,7 @@ class TenantRuntimeService {
         return { exitCode, stdout, stderr };
     }
 
-    private async ensureTenantRuntimeUser(ref: string): Promise<string> {
+    async ensureTenantRuntimeUser(ref: string): Promise<string> {
         const runtimeUser = this.tenantRuntimeUser(ref);
         // ProtectSystem=full deliberately keeps the long-running control plane
         // out of the system account database. Always run the fixed helper so it

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -781,20 +781,19 @@ class TenantRuntimeService {
         const current = await this.runStructuredCommand(["id", "-u", runtimeUser]);
         if (current.exitCode === 0) return runtimeUser;
 
-        const created = await this.runStructuredCommand([
-            "useradd",
-            "--system",
-            "--user-group",
-            "--no-create-home",
-            "--home-dir", "/nonexistent",
-            "--shell", "/usr/sbin/nologin",
-            runtimeUser,
-        ]);
+        // ProtectSystem=full deliberately keeps the long-running control plane
+        // out of the system account database. Delegate this one fixed operation
+        // to the installer-owned, short-lived systemd helper instead.
+        const helperUnit = `supacloud-tenant-user@${ref}.service`;
+        const created = await this.runStructuredCommand(["systemctl", "start", helperUnit]);
         if (created.exitCode !== 0) {
-            // A concurrent runtime start may have created the same account.
+            // A concurrent runtime start may have completed the same helper.
             const raced = await this.runStructuredCommand(["id", "-u", runtimeUser]);
             if (raced.exitCode !== 0) {
-                throw new Error(`Failed to create tenant runtime user ${runtimeUser}: ${created.stderr.trim().slice(0, 300)}`);
+                throw new Error(
+                    `Failed to create tenant runtime user ${runtimeUser} through ${helperUnit}: ` +
+                    created.stderr.trim().slice(0, 300),
+                );
             }
         }
         return runtimeUser;

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -39,6 +39,7 @@ import { getAuthRuntimeDescriptor, isSharedAuthRuntime } from "./auth-runtime.se
 import { authConfigChangesPostgrestVerifier } from "./auth-runtime-impact";
 import { runtimeCacheService } from "./runtime-cache.service";
 import { projectControlSecretsService } from "./project-control-secrets.service";
+import { installManagedSystemdUnit } from "./systemd-unit-broker";
 
 export {
     renderGoTrueAuthEnv,
@@ -778,23 +779,20 @@ class TenantRuntimeService {
 
     private async ensureTenantRuntimeUser(ref: string): Promise<string> {
         const runtimeUser = this.tenantRuntimeUser(ref);
-        const current = await this.runStructuredCommand(["id", "-u", runtimeUser]);
-        if (current.exitCode === 0) return runtimeUser;
-
         // ProtectSystem=full deliberately keeps the long-running control plane
-        // out of the system account database. Delegate this one fixed operation
-        // to the installer-owned, short-lived systemd helper instead.
+        // out of the system account database. Always run the fixed helper so it
+        // validates pre-existing account attributes instead of trusting a UID.
         const helperUnit = `supacloud-tenant-user@${ref}.service`;
         const created = await this.runStructuredCommand(["systemctl", "start", helperUnit]);
         if (created.exitCode !== 0) {
-            // A concurrent runtime start may have completed the same helper.
-            const raced = await this.runStructuredCommand(["id", "-u", runtimeUser]);
-            if (raced.exitCode !== 0) {
-                throw new Error(
-                    `Failed to create tenant runtime user ${runtimeUser} through ${helperUnit}: ` +
-                    created.stderr.trim().slice(0, 300),
-                );
-            }
+            throw new Error(
+                `Failed to create or validate tenant runtime user ${runtimeUser} through ${helperUnit}: ` +
+                created.stderr.trim().slice(0, 300),
+            );
+        }
+        const verified = await this.runStructuredCommand(["id", "-u", runtimeUser]);
+        if (verified.exitCode !== 0) {
+            throw new Error(`Tenant runtime user ${runtimeUser} is missing after ${helperUnit} completed`);
         }
         return runtimeUser;
     }
@@ -1207,7 +1205,7 @@ CPUWeight=${this.POSTGREST_CPU_WEIGHT}
 [Install]
 WantedBy=multi-user.target
 `.trim();
-            await Bun.write(pgrstUnitPath, pgrstUnit);
+            await installManagedSystemdUnit("supacloud-pgrst@.service", pgrstUnit);
         }
 
         const gotrueExists = await Bun.file(gotrueUnitPath).exists();
@@ -1251,7 +1249,7 @@ CPUWeight=20
 [Install]
 WantedBy=multi-user.target
 `.trim();
-            await Bun.write(gotrueUnitPath, gotrueUnit);
+            await installManagedSystemdUnit("supacloud-gotrue@.service", gotrueUnit);
         }
 
         if (shouldWritePgrstUnit || shouldWriteGotrueUnit) {

--- a/packages/management-api/src/utils/oauth-authorization-path.ts
+++ b/packages/management-api/src/utils/oauth-authorization-path.ts
@@ -1,0 +1,66 @@
+export const DEFAULT_OAUTH_AUTHORIZATION_PATH = "/authorize.html";
+
+export class OAuthAuthorizationPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OAuthAuthorizationPathError";
+  }
+}
+
+function validateRawAuthorizationPath(input: string): void {
+  if (!input || input !== input.trim()) {
+    throw new OAuthAuthorizationPathError("authorization_path must be a non-empty origin-relative path");
+  }
+  if (!input.startsWith("/") || input.includes("//")) {
+    throw new OAuthAuthorizationPathError("authorization_path must start with one slash and cannot contain //");
+  }
+  if (/[\\?#\u0000-\u001f\u007f]/.test(input)) {
+    throw new OAuthAuthorizationPathError("authorization_path cannot contain query, fragment, backslash, or control characters");
+  }
+}
+
+function decodeAuthorizationPath(input: string): string {
+  try {
+    return decodeURIComponent(input);
+  } catch (error) {
+    if (error instanceof URIError) {
+      throw new OAuthAuthorizationPathError("authorization_path contains invalid percent encoding");
+    }
+    throw error;
+  }
+}
+
+function validateDecodedAuthorizationPath(decodedPath: string): void {
+  if (decodedPath.includes("//") || /[\\?#\u0000-\u001f\u007f]/.test(decodedPath)) {
+    throw new OAuthAuthorizationPathError("authorization_path contains an unsafe encoded delimiter");
+  }
+  if (decodedPath.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new OAuthAuthorizationPathError("authorization_path cannot contain dot traversal segments");
+  }
+}
+
+export function validateOAuthAuthorizationPath(input: string): string {
+  validateRawAuthorizationPath(input);
+  validateDecodedAuthorizationPath(decodeAuthorizationPath(input));
+  return input;
+}
+
+export function resolveOAuthAuthorizationPath(
+  explicitPath: unknown,
+  currentPath: unknown,
+): string {
+  if (explicitPath !== undefined) {
+    if (typeof explicitPath !== "string") {
+      throw new OAuthAuthorizationPathError("authorization_path must be a string");
+    }
+    return validateOAuthAuthorizationPath(explicitPath);
+  }
+  if (typeof currentPath === "string") {
+    try {
+      return validateOAuthAuthorizationPath(currentPath);
+    } catch (error) {
+      if (!(error instanceof OAuthAuthorizationPathError)) throw error;
+    }
+  }
+  return DEFAULT_OAUTH_AUTHORIZATION_PATH;
+}

--- a/packages/management-api/tests/unit/auth-oauth-server.test.ts
+++ b/packages/management-api/tests/unit/auth-oauth-server.test.ts
@@ -190,6 +190,8 @@ describe("authOAuthServerRoutes", () => {
     expect(updatePayload.auth?.oauth_server?.enabled).toBe(true);
     expect(updatePayload.auth?.oauth_server?.allow_dynamic_registration).toBe(true);
     expect(String(updatePayload.auth?.oauth_server?.issuer)).toMatch(/\/auth\/v1$/);
+    expect(updatePayload.auth?.oauth_server?.authorization_path).toBe("/authorize.html");
+    expect(payload.authorization_path).toBe("/authorize.html");
     expect(updatePayload.auth?.oauth_server?.signing_alg).toBe("ES256");
     expect(typeof updatePayload.auth?.oauth_server?.key_id).toBe("string");
     expect(Array.isArray(updatePayload.auth?.oauth_server?.jwt_keys)).toBe(true);
@@ -208,6 +210,34 @@ describe("authOAuthServerRoutes", () => {
       key_ops: ["sign"],
     });
     expect(legacyKey).toBeUndefined();
+
+    const rejected = await request("/v1/projects/proj_1/auth/oauth-server/migrate", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer dev-master-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        authorization_path: "https://auth.example.com/authorize.html",
+      }),
+    });
+    expect(rejected.status).toBe(400);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(restartSpy).toHaveBeenCalledTimes(1);
+
+    restartSpy.mockRejectedValueOnce(new Error("runtime restart failed"));
+    const unavailable = await request("/v1/projects/proj_1/auth/oauth-server/migrate", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer dev-master-token",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ authorization_path: "/authorize.html" }),
+    });
+    expect(unavailable.status).toBe(503);
+    expect(await unavailable.json()).toMatchObject({
+      code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+    });
 
     projectSpy.mockRestore();
     settingsSpy.mockRestore();
@@ -293,6 +323,7 @@ describe("authOAuthServerRoutes", () => {
       signing_alg: "RS256",
       key_id: "kms-key-1",
       allow_dynamic_registration: true,
+      authorization_path: "/authorize.html",
     });
     expect(jwtKeys[0]).toMatchObject({
       kty: "RSA",

--- a/packages/management-api/tests/unit/frontend.service.test.ts
+++ b/packages/management-api/tests/unit/frontend.service.test.ts
@@ -160,12 +160,15 @@ describe("FrontendService SvelteKit defaults", () => {
 
       const unit = renderSvelteKitSystemdUnit({
         serviceName: "supacloud-frontend-proj123-app123",
+        runtimeUser: "supacloud-proj123",
         description: "SvelteKit app",
         buildDir,
         envFile: join(deploymentDir, ".env"),
         port: 30123,
       });
       expect(unit).toContain(`WorkingDirectory=${buildDir}`);
+      expect(unit).toContain("User=supacloud-proj123");
+      expect(unit).toContain("Group=supacloud-proj123");
       expect(unit).toContain('Environment="PROTOCOL_HEADER=x-forwarded-proto"');
       expect(unit).toContain('Environment="HOST_HEADER=x-forwarded-host"');
       expect(unit).toContain('Environment="PORT_HEADER=x-forwarded-port"');

--- a/packages/management-api/tests/unit/oauth-authorization-path.test.ts
+++ b/packages/management-api/tests/unit/oauth-authorization-path.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_OAUTH_AUTHORIZATION_PATH,
+  OAuthAuthorizationPathError,
+  resolveOAuthAuthorizationPath,
+  validateOAuthAuthorizationPath,
+} from "../../src/utils/oauth-authorization-path";
+
+describe("OAuth authorization path", () => {
+  test("defaults migration to the public hosted authorize page path", () => {
+    expect(resolveOAuthAuthorizationPath(undefined, undefined)).toBe(DEFAULT_OAUTH_AUTHORIZATION_PATH);
+  });
+
+  test("keeps a valid existing origin-relative path", () => {
+    expect(resolveOAuthAuthorizationPath(undefined, "/custom/authorize.html")).toBe("/custom/authorize.html");
+  });
+
+  test.each([
+    "https://auth.example.com/authorize.html",
+    "//auth.example.com/authorize.html",
+    "/authorize.html?client_id=attacker",
+    "/authorize.html#fragment",
+    "/a\\b",
+    "/../authorize.html",
+    "/%2e%2e/authorize.html",
+    "/authorize.html\u0000",
+  ])("rejects unsafe authorization path %s", (path) => {
+    expect(() => validateOAuthAuthorizationPath(path)).toThrow(OAuthAuthorizationPathError);
+  });
+
+  test("rejects an invalid explicit path instead of silently falling back", () => {
+    expect(() => resolveOAuthAuthorizationPath("https://auth.example.com/authorize.html", undefined))
+      .toThrow(OAuthAuthorizationPathError);
+  });
+
+  test("repairs a legacy invalid stored value when no explicit override is provided", () => {
+    expect(resolveOAuthAuthorizationPath(undefined, "https://auth.example.com/authorize.html"))
+      .toBe(DEFAULT_OAUTH_AUTHORIZATION_PATH);
+  });
+});

--- a/packages/management-api/tests/unit/realtime-systemd.test.ts
+++ b/packages/management-api/tests/unit/realtime-systemd.test.ts
@@ -68,4 +68,16 @@ describe("Management API CI Realtime readiness probe", () => {
     expect(waitStep).not.toContain("Authorization: Bearer ${JWT_SECRET}");
     expect(waitStep).not.toContain("http://127.0.0.1:4000/health\"");
   });
+
+  test("starts the API with an explicit matching Realtime container secret fixture", () => {
+    const workflow = readFileSync(join(repoRoot, ".github/workflows/management-api.yml"), "utf8");
+    const launchStep = workflow.slice(
+      workflow.indexOf("Launch API & Execute Full Defenses"),
+      workflow.indexOf("Stop containers"),
+    );
+
+    expect(launchStep).toContain("SUPACLOUD_REALTIME_CONTAINER_ENV_FILE");
+    expect(launchStep).toContain("API_JWT_SECRET=%s");
+    expect(launchStep).toContain("TEST_FIXED_JWT_SECRET");
+  });
 });

--- a/packages/management-api/tests/unit/realtime.service.test.ts
+++ b/packages/management-api/tests/unit/realtime.service.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { assertRealtimeSecretAlignment, RealtimeService } from "../../src/services/realtime.service";
+import { assertRealtimeSecretAlignment, RealtimeService, validateRealtimeSecretConfiguration } from "../../src/services/realtime.service";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const originalFetch = globalThis.fetch;
 
@@ -22,6 +25,30 @@ describe("RealtimeService tenant payloads", () => {
       configuredApiSecret: "canonical-realtime-secret",
       containerApiSecret: "canonical-realtime-secret",
     })).not.toThrow();
+  });
+
+  test("fails closed when the required container verification secret is missing or empty", () => {
+    for (const containerApiSecret of [undefined, "", "   "]) {
+      expect(() => assertRealtimeSecretAlignment({
+        canonicalSecret: "canonical-realtime-secret",
+        containerApiSecret,
+        requireContainerApiSecret: true,
+      })).toThrow("container API JWT secret is missing");
+    }
+  });
+
+  test("fails closed when the container env file is missing or omits API_JWT_SECRET", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-realtime-secret-"));
+    try {
+      expect(() => validateRealtimeSecretConfiguration(join(dir, "missing.env")))
+        .toThrow("container API JWT secret is missing");
+      const emptyFile = join(dir, "empty.env");
+      writeFileSync(emptyFile, "OTHER_SECRET=value\n");
+      expect(() => validateRealtimeSecretConfiguration(emptyFile))
+        .toThrow("container API JWT secret is missing");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("registerTenant disables per-tenant postgres SSL for local service databases", async () => {

--- a/packages/management-api/tests/unit/realtime.service.test.ts
+++ b/packages/management-api/tests/unit/realtime.service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { RealtimeService } from "../../src/services/realtime.service";
+import { assertRealtimeSecretAlignment, RealtimeService } from "../../src/services/realtime.service";
 
 const originalFetch = globalThis.fetch;
 
@@ -8,6 +8,22 @@ afterEach(() => {
 });
 
 describe("RealtimeService tenant payloads", () => {
+  test("fails closed when the API or container verification secret drifts", () => {
+    expect(() => assertRealtimeSecretAlignment({
+      canonicalSecret: "canonical-realtime-secret",
+      configuredApiSecret: "stale-api-secret",
+    })).toThrow("does not match");
+    expect(() => assertRealtimeSecretAlignment({
+      canonicalSecret: "canonical-realtime-secret",
+      containerApiSecret: "stale-container-secret",
+    })).toThrow("does not match");
+    expect(() => assertRealtimeSecretAlignment({
+      canonicalSecret: "canonical-realtime-secret",
+      configuredApiSecret: "canonical-realtime-secret",
+      containerApiSecret: "canonical-realtime-secret",
+    })).not.toThrow();
+  });
+
   test("registerTenant disables per-tenant postgres SSL for local service databases", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -349,14 +349,23 @@ describe("runtime companion version assets", () => {
     expect(edgeUnit).toContain("ExecStart=/usr/local/bin/supacloud-edge-runtime");
     expect(installer).toContain("render_edge_runtime_systemd_unit");
     expect(installer).not.toContain('cp "${SYSTEMD_SRC}/supacloud-edge-runtime.service" /etc/systemd/system/supacloud-edge-runtime.service');
-    expect(managementUnit).toContain("ReadWritePaths=/etc/supabase /etc/systemd/system /etc/supacloud/caddy /opt/supacloud /tmp /var/log/supacloud");
+    expect(managementUnit).not.toContain("ReadWritePaths=/etc/supabase /etc/systemd/system ");
+    expect(managementUnit).toContain("/run/supacloud-unit-requests");
+    expect(managementUnit).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER");
     expect(managementUnit).toContain("SystemCallFilter=@system-service @chown");
     expect(managementUnit).not.toContain("@privileged");
     expect(installer).toContain("install_tenant_user_helper");
+    expect(installer).toContain("install_systemd_unit_broker");
+    expect(installer).toContain('supacloud_capture_file_snapshot /usr/local/libexec/supacloud/tenant-user');
+    expect(installer).toContain('supacloud_restore_file_snapshot /usr/local/libexec/supacloud/systemd-unit');
     expect(readRepoFile("infrastructure/systemd/supacloud-tenant-user@.service")).toContain(
       "ExecStart=/usr/local/libexec/supacloud/tenant-user %i",
     );
     expect(readRepoFile("scripts/lib/tenant_user.sh")).toContain("^[a-z0-9-]{1,20}$");
+    expect(readRepoFile("scripts/lib/tenant_user.sh")).toContain("validate_runtime_user");
+    const systemdBrokerUnit = readRepoFile("infrastructure/systemd/supacloud-systemd-unit@.service");
+    expect(systemdBrokerUnit).toContain("ExecStart=/usr/local/libexec/supacloud/systemd-unit %i");
+    expect(systemdBrokerUnit).toContain("ProtectSystem=strict");
     expect(serviceRenderer).not.toContain("/opt/supacloud/config.env");
     expect(serviceRenderer).toContain("/etc/supabase/management-api.env");
     expect(installer).toContain('XCADDY_VERSION="${XCADDY_VERSION:-v0.4.5}"');

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -349,6 +349,14 @@ describe("runtime companion version assets", () => {
     expect(edgeUnit).toContain("ExecStart=/usr/local/bin/supacloud-edge-runtime");
     expect(installer).toContain("render_edge_runtime_systemd_unit");
     expect(installer).not.toContain('cp "${SYSTEMD_SRC}/supacloud-edge-runtime.service" /etc/systemd/system/supacloud-edge-runtime.service');
+    expect(managementUnit).toContain("ReadWritePaths=/etc/supabase /etc/systemd/system /etc/supacloud/caddy /opt/supacloud /tmp /var/log/supacloud");
+    expect(managementUnit).toContain("SystemCallFilter=@system-service @chown");
+    expect(managementUnit).not.toContain("@privileged");
+    expect(installer).toContain("install_tenant_user_helper");
+    expect(readRepoFile("infrastructure/systemd/supacloud-tenant-user@.service")).toContain(
+      "ExecStart=/usr/local/libexec/supacloud/tenant-user %i",
+    );
+    expect(readRepoFile("scripts/lib/tenant_user.sh")).toContain("^[a-z0-9-]{1,20}$");
     expect(serviceRenderer).not.toContain("/opt/supacloud/config.env");
     expect(serviceRenderer).toContain("/etc/supabase/management-api.env");
     expect(installer).toContain('XCADDY_VERSION="${XCADDY_VERSION:-v0.4.5}"');

--- a/packages/management-api/tests/unit/systemd-unit-broker.test.ts
+++ b/packages/management-api/tests/unit/systemd-unit-broker.test.ts
@@ -9,6 +9,7 @@ Type=simple
 User=${user}
 Group=${user}
 NoNewPrivileges=true
+EnvironmentFile=/var/supacloud/frontends/demo/abc123ff/.env
 ${extra}ExecStart=/bin/true
 [Install]
 WantedBy=multi-user.target
@@ -18,26 +19,40 @@ WantedBy=multi-user.target
 describe("systemd unit broker policy", () => {
   test("accepts a non-root frontend unit matching its tenant", () => {
     expect(() => assertManagedSystemdUnitContent(
-      "supacloud-frontend-demo-abc123.service",
+      "supacloud-frontend-demo-abc123ff.service",
       frontendUnit(),
     )).not.toThrow();
   });
 
   test("rejects root identities and privileged directive injection", () => {
     expect(() => assertManagedSystemdUnitContent(
-      "supacloud-frontend-demo-abc123.service",
+      "supacloud-frontend-demo-abc123ff.service",
       frontendUnit("root"),
     )).toThrow(/invalid User/);
     expect(() => assertManagedSystemdUnitContent(
-      "supacloud-frontend-demo-abc123.service",
+      "supacloud-frontend-demo-abc123ff.service",
       frontendUnit("supacloud-demo", "ExecStartPre=/bin/sh\n"),
     )).toThrow(/unsupported directive/);
   });
 
   test("rejects a frontend unit whose tenant identity does not match its name", () => {
     expect(() => assertManagedSystemdUnitContent(
-      "supacloud-frontend-other-abc123.service",
+      "supacloud-frontend-other-abc123ff.service",
       frontendUnit(),
-    )).toThrow(/does not match/);
+    )).toThrow(/invalid EnvironmentFile/);
+  });
+
+  test("rejects control-plane environment files and control characters", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-demo-abc123ff.service",
+      frontendUnit().replace(
+        "/var/supacloud/frontends/demo/abc123ff/.env",
+        "-/etc/supabase/management-api.env",
+      ),
+    )).toThrow(/invalid EnvironmentFile/);
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-demo-abc123ff.service",
+      frontendUnit().replace("Description=test", "Description=test\u0001injected"),
+    )).toThrow(/invalid content/);
   });
 });

--- a/packages/management-api/tests/unit/systemd-unit-broker.test.ts
+++ b/packages/management-api/tests/unit/systemd-unit-broker.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { assertManagedSystemdUnitContent } from "../../src/services/systemd-unit-broker";
+
+function frontendUnit(user = "supacloud-demo", extra = ""): string {
+  return `[Unit]
+Description=test
+[Service]
+Type=simple
+User=${user}
+Group=${user}
+NoNewPrivileges=true
+${extra}ExecStart=/bin/true
+[Install]
+WantedBy=multi-user.target
+`;
+}
+
+describe("systemd unit broker policy", () => {
+  test("accepts a non-root frontend unit matching its tenant", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-demo-abc123.service",
+      frontendUnit(),
+    )).not.toThrow();
+  });
+
+  test("rejects root identities and privileged directive injection", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-demo-abc123.service",
+      frontendUnit("root"),
+    )).toThrow(/invalid User/);
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-demo-abc123.service",
+      frontendUnit("supacloud-demo", "ExecStartPre=/bin/sh\n"),
+    )).toThrow(/unsupported directive/);
+  });
+
+  test("rejects a frontend unit whose tenant identity does not match its name", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-other-abc123.service",
+      frontendUnit(),
+    )).toThrow(/does not match/);
+  });
+});

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -442,7 +442,10 @@ describe("@supacloud/js", () => {
     });
 
     const status = await client.auth.oauthServer.getStatus();
-    await client.auth.oauthServer.migrateToOidc({ allowDynamicRegistration: true });
+    await client.auth.oauthServer.migrateToOidc({
+      allowDynamicRegistration: true,
+      authorizationPath: "/authorize.html",
+    });
     const discovery = await client.auth.oauthServer.getDiscovery();
     const jwks = await client.auth.oauthServer.getJwks();
     const authorizeUrl = await client.auth.oauthServer.buildAuthorizeUrl({
@@ -488,6 +491,11 @@ describe("@supacloud/js", () => {
     expect(calls[0]?.init?.headers instanceof Headers || typeof calls[0]?.init?.headers === "object").toBe(true);
     expect(new Headers(calls[0]?.init?.headers).get("authorization")).toBe("Bearer token-123");
     expect(calls.some((call) => call.url.endsWith("/auth/oauth-server/migrate"))).toBe(true);
+    const migrationCall = calls.find((call) => call.url.endsWith("/auth/oauth-server/migrate"));
+    expect(JSON.parse(String(migrationCall?.init?.body))).toEqual({
+      allow_dynamic_registration: true,
+      authorization_path: "/authorize.html",
+    });
     expect(calls.some((call) => call.url.endsWith("/auth/oauth-clients"))).toBe(true);
     expect(calls.some((call) => call.url.endsWith("/auth/oauth-clients/client_1"))).toBe(true);
   });

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -492,7 +492,7 @@ describe("@supacloud/js", () => {
     expect(new Headers(calls[0]?.init?.headers).get("authorization")).toBe("Bearer token-123");
     expect(calls.some((call) => call.url.endsWith("/auth/oauth-server/migrate"))).toBe(true);
     const migrationCall = calls.find((call) => call.url.endsWith("/auth/oauth-server/migrate"));
-    expect(JSON.parse(String(migrationCall?.init?.body))).toEqual({
+    expect(JSON.parse(String(migrationCall?.init?.body))).toMatchObject({
       allow_dynamic_registration: true,
       authorization_path: "/authorize.html",
     });

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -346,6 +346,7 @@ export type SupaCloudOAuthServerStatus = {
   enabled: boolean;
   allow_dynamic_registration: boolean;
   issuer: string;
+  authorization_path?: string;
   discovery_url: string;
   oauth_authorization_server_metadata_url?: string;
   jwks_url: string;
@@ -1166,11 +1167,19 @@ class SupaCloudOAuthServerClient<TClient extends SupabaseClient = SupabaseClient
     );
   }
 
-  async migrateToOidc(options: { allowDynamicRegistration?: boolean } = {}): Promise<SupaCloudOAuthServerStatus> {
+  async migrateToOidc(options: {
+    allowDynamicRegistration?: boolean;
+    authorizationPath?: string;
+  } = {}): Promise<SupaCloudOAuthServerStatus> {
     return this.request<SupaCloudOAuthServerStatus>(
       `/v1/projects/${this.options.projectRef}/auth/oauth-server/migrate`,
       "POST",
-      { allow_dynamic_registration: options.allowDynamicRegistration === true },
+      {
+        allow_dynamic_registration: options.allowDynamicRegistration === true,
+        ...(options.authorizationPath === undefined
+          ? {}
+          : { authorization_path: options.authorizationPath }),
+      },
     );
   }
 

--- a/scripts/lib/installer_pg_hba.test.sh
+++ b/scripts/lib/installer_pg_hba.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/pigsty" "$tmp_dir/bin"
+cat > "$tmp_dir/pigsty/pigsty.yml" <<'YAML'
+all:
+  vars:
+    pg_hba_rules:
+      - { user: dbuser_monitor, db: all, addr: localhost, auth: pwd, order: 350, title: monitor }
+      - { user: all, db: all, addr: 10.88.0.0/16, auth: pwd, order: 800, title: existing container access }
+    unrelated_setting: keep-me
+YAML
+touch "$tmp_dir/pigsty/pgsql.yml"
+cat > "$tmp_dir/bin/ansible-playbook" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$ANSIBLE_LOG"
+SH
+chmod 755 "$tmp_dir/bin/ansible-playbook"
+
+ANSIBLE_LOG="$tmp_dir/ansible.log"
+export ANSIBLE_LOG
+PATH="$tmp_dir/bin:$PATH"
+export PATH
+PIGSTY_PATH="$tmp_dir/pigsty"
+export PIGSTY_PATH
+
+# shellcheck source=../../install.sh
+source "$SCRIPT_DIR/install.sh"
+
+ensure_pigsty_tenant_hba_rule
+grep -Fq "SupaCloud tenant authenticator loopback" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "user: '/^authenticator_[a-z0-9-]+$/'" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "db: '/^supa_[a-z0-9-]+$/'" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "addr: 127.0.0.1/32, auth: pwd, order: 40" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "unrelated_setting: keep-me" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "addr: 10.88.0.0/16" "$PIGSTY_PATH/pigsty.yml"
+[[ "$(grep -Fc "SupaCloud tenant authenticator loopback" "$PIGSTY_PATH/pigsty.yml")" == 1 ]]
+grep -Fq -- "-i $PIGSTY_PATH/pigsty.yml $PIGSTY_PATH/pgsql.yml -l pg-meta --tags=pg_hba -e pg_reload=true" "$ANSIBLE_LOG"
+
+# Idempotent reruns still render the durable inventory through Pigsty.
+ensure_pigsty_tenant_hba_rule
+[[ "$(grep -Fc "SupaCloud tenant authenticator loopback" "$PIGSTY_PATH/pigsty.yml")" == 1 ]]
+[[ "$(wc -l < "$ANSIBLE_LOG" | tr -d ' ')" == 2 ]]
+
+bad_config="$tmp_dir/bad.yml"
+printf 'all:\n  vars:\n    unrelated: true\n' > "$bad_config"
+if PIGSTY_CONFIG="$bad_config" ensure_pigsty_tenant_hba_rule >/dev/null 2>&1; then
+    echo "inventory without pg_hba_rules was accepted" >&2
+    exit 1
+fi
+! grep -Fq "SupaCloud tenant authenticator loopback" "$bad_config"

--- a/scripts/lib/patch_pigsty_tenant_hba.py
+++ b/scripts/lib/patch_pigsty_tenant_hba.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Atomically add the SupaCloud tenant HBA rule to a Pigsty inventory."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import sys
+import tempfile
+
+
+RULE_MARKER = "SupaCloud tenant authenticator loopback"
+
+
+def render_inventory(content: str) -> str | None:
+    if RULE_MARKER in content:
+        return None
+
+    sections = list(re.finditer(r"(?m)^([ ]*)pg_hba_rules:[ ]*(?:#.*)?$", content))
+    if len(sections) != 1:
+        raise ValueError(f"expected one multiline pg_hba_rules section, found {len(sections)}")
+
+    indent = sections[0].group(1) + "  "
+    rule = (
+        f"{indent}- {{ user: '/^authenticator_[a-z0-9-]+$/', "
+        "db: '/^supa_[a-z0-9-]+$/', addr: 127.0.0.1/32, auth: pwd, "
+        f"order: 40, title: '{RULE_MARKER}' }}"
+    )
+    return content[: sections[0].end()] + "\n" + rule + content[sections[0].end() :]
+
+
+def atomic_write(path: str, content: str) -> None:
+    file_mode = stat.S_IMODE(os.stat(path).st_mode)
+    directory = os.path.dirname(path) or "."
+    descriptor, temporary_path = tempfile.mkstemp(prefix=f".{os.path.basename(path)}.", dir=directory)
+    try:
+        os.fchmod(descriptor, file_mode)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as inventory_file:
+            inventory_file.write(content)
+            inventory_file.flush()
+            os.fsync(inventory_file.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def patch_inventory(path: str) -> bool:
+    with open(path, "r", encoding="utf-8") as inventory_file:
+        content = inventory_file.read()
+    updated_content = render_inventory(content)
+    if updated_content is None:
+        return False
+    atomic_write(path, updated_content)
+    return True
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <pigsty.yml>", file=sys.stderr)
+        return 2
+    try:
+        patch_inventory(sys.argv[1])
+    except (OSError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/systemd_unit_broker.sh
+++ b/scripts/lib/systemd_unit_broker.sh
@@ -34,10 +34,70 @@ if [[ ! "$unit_name" =~ ^supacloud-(pgrst|gotrue)@\.service$ \
     exit 1
 fi
 
+validate_unit_content() {
+    local section="" line key value user="" group="" seen_unit=0 seen_service=0 seen_install=0 seen_nnp=0
+    local unit_bytes
+    unit_bytes=$(wc -c < "$source_file")
+    (( unit_bytes > 0 && unit_bytes <= 16384 )) || return 1
+    cmp -s "$source_file" <(tr -d '\000' < "$source_file") || return 1
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ "$line" != *$'\r'* && "$line" != *\\ ]] || return 1
+        [[ -z "$line" || "$line" =~ ^[[:space:]]*[#\;] ]] && continue
+        if [[ "$line" =~ ^\[(Unit|Service|Install)\]$ ]]; then
+            section="${BASH_REMATCH[1]}"
+            case "$section" in
+                Unit) (( seen_unit += 1 )) ;;
+                Service) (( seen_service += 1 )) ;;
+                Install) (( seen_install += 1 )) ;;
+            esac
+            [[ "$seen_unit" -le 1 && "$seen_service" -le 1 && "$seen_install" -le 1 ]] || return 1
+            continue
+        fi
+        [[ "$line" =~ ^([A-Za-z][A-Za-z0-9]*)=(.*)$ ]] || return 1
+        key="${BASH_REMATCH[1]}"
+        value="${BASH_REMATCH[2]}"
+        case "$section:$key" in
+            Unit:After|Unit:Description|Unit:Documentation|Unit:Wants|\
+            Service:CPUWeight|Service:Environment|Service:EnvironmentFile|Service:ExecReload|Service:ExecStart|\
+            Service:Group|Service:LimitNOFILE|Service:MemoryMax|Service:NoNewPrivileges|Service:ProtectHome|\
+            Service:ProtectSystem|Service:ReadOnlyPaths|Service:Restart|Service:RestartSec|Service:StartLimitBurst|\
+            Service:StartLimitIntervalSec|Service:SyslogIdentifier|Service:Type|Service:User|Service:WorkingDirectory|\
+            Install:WantedBy) ;;
+            *) return 1 ;;
+        esac
+        if [[ "$key" == ExecStart || "$key" == ExecReload ]]; then
+            [[ ! "$value" =~ ^[-+!:@\|] ]] || return 1
+        fi
+        if [[ "$key" == NoNewPrivileges ]]; then
+            [[ "$value" == true && "$seen_nnp" == 0 ]] || return 1
+            seen_nnp=1
+        fi
+        if [[ "$key" == User ]]; then
+            [[ -z "$user" && "$value" =~ ^supacloud-(%i|[a-z0-9-]{1,20})$ ]] || return 1
+            user="$value"
+        elif [[ "$key" == Group ]]; then
+            [[ -z "$group" && "$value" =~ ^supacloud-(%i|[a-z0-9-]{1,20})$ ]] || return 1
+            group="$value"
+        fi
+    done < "$source_file"
+    [[ "$seen_unit" == 1 && "$seen_service" == 1 && "$seen_install" == 1 && "$seen_nnp" == 1 \
+        && -n "$user" && "$user" == "$group" ]] || return 1
+    if [[ "$unit_name" == *'@'* && "$user" != "supacloud-%i" ]]; then
+        return 1
+    fi
+    if [[ "$unit_name" == supacloud-frontend-* && "$unit_name" != supacloud-frontend-${user#supacloud-}-* ]]; then
+        return 1
+    fi
+}
+
 case "$operation" in
   install)
     [[ -f "$source_file" && ! -L "$source_file" ]] || {
         echo "ERROR: Systemd unit source is missing" >&2
+        exit 1
+    }
+    validate_unit_content || {
+        echo "ERROR: Systemd unit content is outside the managed policy" >&2
         exit 1
     }
     install -m 0644 "$source_file" "/etc/systemd/system/${unit_name}"

--- a/scripts/lib/systemd_unit_broker.sh
+++ b/scripts/lib/systemd_unit_broker.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+request_dir="/run/supacloud-unit-requests"
+token="${1:-}"
+if [[ ! "$token" =~ ^[a-f0-9-]{36}$ ]]; then
+    echo "ERROR: Invalid systemd unit request token" >&2
+    exit 2
+fi
+
+request_file="${request_dir}/${token}.request"
+source_file="${request_dir}/${token}.unit"
+[[ -f "$request_file" && ! -L "$request_file" ]] || {
+    echo "ERROR: Systemd unit request is missing" >&2
+    exit 1
+}
+
+read_request_value() {
+    local key="$1" value count
+    count=$(grep -Ec "^${key}=" "$request_file" || true)
+    [[ "$count" == "1" ]] || return 1
+    value=$(sed -n "s/^${key}=//p" "$request_file")
+    [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || return 1
+    printf '%s' "$value"
+}
+
+operation=$(read_request_value operation) || { echo "ERROR: Invalid systemd unit operation" >&2; exit 1; }
+unit_name=$(read_request_value unit_name) || { echo "ERROR: Invalid systemd unit name" >&2; exit 1; }
+if [[ ! "$unit_name" =~ ^supacloud-(pgrst|gotrue)@\.service$ \
+    && ! "$unit_name" =~ ^supacloud-frontend-[a-z0-9-]{1,64}\.service$ ]]; then
+    echo "ERROR: Systemd unit is outside the SupaCloud allow-list" >&2
+    exit 1
+fi
+
+case "$operation" in
+  install)
+    [[ -f "$source_file" && ! -L "$source_file" ]] || {
+        echo "ERROR: Systemd unit source is missing" >&2
+        exit 1
+    }
+    install -m 0644 "$source_file" "/etc/systemd/system/${unit_name}"
+    ;;
+  remove)
+    rm -f "/etc/systemd/system/${unit_name}"
+    ;;
+  *)
+    echo "ERROR: Unsupported systemd unit operation" >&2
+    exit 1
+    ;;
+esac
+
+systemctl daemon-reload
+rm -f "$request_file" "$source_file"

--- a/scripts/lib/systemd_unit_broker.sh
+++ b/scripts/lib/systemd_unit_broker.sh
@@ -34,12 +34,29 @@ if [[ ! "$unit_name" =~ ^supacloud-(pgrst|gotrue)@\.service$ \
     exit 1
 fi
 
+validate_environment_file() {
+    local value="$1"
+    case "$unit_name" in
+        supacloud-pgrst@.service)
+            [[ "$value" =~ ^/etc/supabase/[A-Za-z0-9_-]{1,64}/%i\.env$ ]]
+            ;;
+        supacloud-gotrue@.service)
+            [[ "$value" =~ ^/etc/supabase/[A-Za-z0-9_-]{1,64}/%i_gotrue\.env$ ]]
+            ;;
+        supacloud-frontend-*.service)
+            [[ "$value" =~ ^/var/supacloud/frontends/([a-z0-9-]{1,20})/([a-f0-9]{8})/\.env$ ]] || return 1
+            [[ "$unit_name" == "supacloud-frontend-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}.service" ]]
+            ;;
+        *) return 1 ;;
+    esac
+}
+
 validate_unit_content() {
-    local section="" line key value user="" group="" seen_unit=0 seen_service=0 seen_install=0 seen_nnp=0
+    local section="" line key value user="" group="" seen_unit=0 seen_service=0 seen_install=0 seen_nnp=0 seen_env_file=0
     local unit_bytes
     unit_bytes=$(wc -c < "$source_file")
     (( unit_bytes > 0 && unit_bytes <= 16384 )) || return 1
-    cmp -s "$source_file" <(tr -d '\000' < "$source_file") || return 1
+    cmp -s "$source_file" <(LC_ALL=C tr -d '\000-\011\013-\037\177' < "$source_file") || return 1
     while IFS= read -r line || [[ -n "$line" ]]; do
         [[ "$line" != *$'\r'* && "$line" != *\\ ]] || return 1
         [[ -z "$line" || "$line" =~ ^[[:space:]]*[#\;] ]] && continue
@@ -72,6 +89,10 @@ validate_unit_content() {
             [[ "$value" == true && "$seen_nnp" == 0 ]] || return 1
             seen_nnp=1
         fi
+        if [[ "$key" == EnvironmentFile ]]; then
+            [[ "$seen_env_file" == 0 ]] && validate_environment_file "$value" || return 1
+            seen_env_file=1
+        fi
         if [[ "$key" == User ]]; then
             [[ -z "$user" && "$value" =~ ^supacloud-(%i|[a-z0-9-]{1,20})$ ]] || return 1
             user="$value"
@@ -80,7 +101,7 @@ validate_unit_content() {
             group="$value"
         fi
     done < "$source_file"
-    [[ "$seen_unit" == 1 && "$seen_service" == 1 && "$seen_install" == 1 && "$seen_nnp" == 1 \
+    [[ "$seen_unit" == 1 && "$seen_service" == 1 && "$seen_install" == 1 && "$seen_nnp" == 1 && "$seen_env_file" == 1 \
         && -n "$user" && "$user" == "$group" ]] || return 1
     if [[ "$unit_name" == *'@'* && "$user" != "supacloud-%i" ]]; then
         return 1

--- a/scripts/lib/systemd_unit_broker.test.sh
+++ b/scripts/lib/systemd_unit_broker.test.sh
@@ -23,7 +23,7 @@ chmod 755 "$TMP_DIR/bin/"*
 
 token=01234567-89ab-cdef-0123-456789abcdef
 printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
-printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
 
 sed \
   -e "s#request_dir=\"/run/supacloud-unit-requests\"#request_dir=\"$TMP_DIR/requests\"#" \
@@ -46,15 +46,29 @@ if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1;
 fi
 
 printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
-printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=root\nGroup=root\nNoNewPrivileges=true\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=root\nGroup=root\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
 if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
   echo "broker accepted a root systemd identity" >&2
   exit 1
 fi
 
 printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
-printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nExecStartPre=/bin/sh\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStartPre=/bin/sh\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
 if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
   echo "broker accepted an unsupported systemd directive" >&2
+  exit 1
+fi
+
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=bad\001value\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted a control character" >&2
+  exit 1
+fi
+
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=-/etc/supabase/management-api.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted the control-plane environment file" >&2
   exit 1
 fi

--- a/scripts/lib/systemd_unit_broker.test.sh
+++ b/scripts/lib/systemd_unit_broker.test.sh
@@ -23,7 +23,7 @@ chmod 755 "$TMP_DIR/bin/"*
 
 token=01234567-89ab-cdef-0123-456789abcdef
 printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
-printf '[Service]\nExecStart=/bin/true\n' > "$TMP_DIR/requests/$token.unit"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
 
 sed \
   -e "s#request_dir=\"/run/supacloud-unit-requests\"#request_dir=\"$TMP_DIR/requests\"#" \
@@ -42,5 +42,19 @@ printf 'operation=install\nunit_name=evil.service\n' > "$TMP_DIR/requests/$token
 printf '[Service]\nExecStart=/bin/sh\n' > "$TMP_DIR/requests/$token.unit"
 if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
   echo "broker accepted an unapproved unit name" >&2
+  exit 1
+fi
+
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=root\nGroup=root\nNoNewPrivileges=true\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted a root systemd identity" >&2
+  exit 1
+fi
+
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nExecStartPre=/bin/sh\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted an unsupported systemd directive" >&2
   exit 1
 fi

--- a/scripts/lib/systemd_unit_broker.test.sh
+++ b/scripts/lib/systemd_unit_broker.test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/requests" "$TMP_DIR/units"
+
+cat > "$TMP_DIR/bin/install" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+source_file="$3"; target="$4"
+[[ "$1" == "-m" && "$2" == "0644" ]] || exit 2
+mkdir -p "$(dirname "$target")"
+cp "$source_file" "$target"
+SH
+cat > "$TMP_DIR/bin/systemctl" <<'SH'
+#!/usr/bin/env bash
+[[ "$1" == "daemon-reload" ]] || exit 2
+SH
+chmod 755 "$TMP_DIR/bin/"*
+
+token=01234567-89ab-cdef-0123-456789abcdef
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Service]\nExecStart=/bin/true\n' > "$TMP_DIR/requests/$token.unit"
+
+sed \
+  -e "s#request_dir=\"/run/supacloud-unit-requests\"#request_dir=\"$TMP_DIR/requests\"#" \
+  -e "s#/etc/systemd/system/#$TMP_DIR/units/#g" \
+  "$ROOT_DIR/scripts/lib/systemd_unit_broker.sh" > "$TMP_DIR/broker.sh"
+PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token"
+grep -Fq 'ExecStart=/bin/true' "$TMP_DIR/units/supacloud-pgrst@.service"
+[[ ! -e "$TMP_DIR/requests/$token.request" ]]
+[[ ! -e "$TMP_DIR/requests/$token.unit" ]]
+
+printf 'operation=remove\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token"
+[[ ! -e "$TMP_DIR/units/supacloud-pgrst@.service" ]]
+
+printf 'operation=install\nunit_name=evil.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Service]\nExecStart=/bin/sh\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted an unapproved unit name" >&2
+  exit 1
+fi

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -181,13 +181,15 @@ preserve_management_api_config_if_present() {
 
 ensure_tenant_runtime_user() {
     local ref="$1"
-    local runtime_user
+    local runtime_user helper
     runtime_user=$(tenant_runtime_user "$ref")
-    if ! id -u "$runtime_user" >/dev/null 2>&1; then
-        local nologin_shell
-        nologin_shell=$(command -v nologin 2>/dev/null || printf '/sbin/nologin')
-        useradd --system --user-group --no-create-home --home-dir /nonexistent --shell "$nologin_shell" "$runtime_user"
+    if [ -x /usr/local/libexec/supacloud/tenant-user ]; then
+        helper=/usr/local/libexec/supacloud/tenant-user
+    else
+        helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/tenant_user.sh"
     fi
+    [ -f "$helper" ] || { echo "ERROR: Tenant user helper is missing" >&2; return 1; }
+    bash "$helper" "$ref" || return 1
     printf '%s' "$runtime_user"
 }
 

--- a/scripts/lib/tenant_user.sh
+++ b/scripts/lib/tenant_user.sh
@@ -46,7 +46,7 @@ validate_runtime_user() {
     }
     IFS=: read -r name _ uid gid _ home shell <<< "$passwd_entry"
     uid_max=$(system_uid_max)
-    if [[ "$name" != "$runtime_user" || ! "$uid" =~ ^[0-9]+$ || "$uid" -gt "$uid_max" \
+    if [[ "$name" != "$runtime_user" || ! "$uid" =~ ^[0-9]+$ || "$uid" -eq 0 || "$uid" -gt "$uid_max" \
         || "$home" != "/nonexistent" ]]; then
         echo "ERROR: Tenant runtime account ${runtime_user} violates the system-user contract" >&2
         return 1
@@ -64,7 +64,7 @@ validate_runtime_user() {
         return 1
     }
     IFS=: read -r group_name _ group_gid _ <<< "$group_entry"
-    if [[ "$group_name" != "$runtime_user" || "$group_gid" != "$gid" ]]; then
+    if [[ "$group_name" != "$runtime_user" || ! "$group_gid" =~ ^[0-9]+$ || "$group_gid" -eq 0 || "$group_gid" != "$gid" ]]; then
         echo "ERROR: Tenant runtime account ${runtime_user} has an unexpected primary group" >&2
         return 1
     fi

--- a/scripts/lib/tenant_user.sh
+++ b/scripts/lib/tenant_user.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+ref="${1:-}"
+if [[ ! "$ref" =~ ^[a-z0-9-]{1,20}$ ]]; then
+    echo "ERROR: Invalid tenant project ref" >&2
+    exit 2
+fi
+
+runtime_user="supacloud-${ref}"
+if id -u "$runtime_user" >/dev/null 2>&1; then
+    exit 0
+fi
+
+nologin_shell=$(command -v nologin 2>/dev/null || true)
+if [[ -z "$nologin_shell" || ! -x "$nologin_shell" ]]; then
+    for candidate in /usr/sbin/nologin /sbin/nologin; do
+        if [[ -x "$candidate" ]]; then
+            nologin_shell="$candidate"
+            break
+        fi
+    done
+fi
+if [[ -z "$nologin_shell" || ! -x "$nologin_shell" ]]; then
+    echo "ERROR: nologin shell not found" >&2
+    exit 1
+fi
+
+useradd \
+    --system \
+    --user-group \
+    --no-create-home \
+    --home-dir /nonexistent \
+    --shell "$nologin_shell" \
+    "$runtime_user"
+
+id -u "$runtime_user" >/dev/null

--- a/scripts/lib/tenant_user.sh
+++ b/scripts/lib/tenant_user.sh
@@ -10,22 +10,74 @@ if [[ ! "$ref" =~ ^[a-z0-9-]{1,20}$ ]]; then
 fi
 
 runtime_user="supacloud-${ref}"
-if id -u "$runtime_user" >/dev/null 2>&1; then
-    exit 0
-fi
 
-nologin_shell=$(command -v nologin 2>/dev/null || true)
-if [[ -z "$nologin_shell" || ! -x "$nologin_shell" ]]; then
-    for candidate in /usr/sbin/nologin /sbin/nologin; do
-        if [[ -x "$candidate" ]]; then
-            nologin_shell="$candidate"
-            break
+resolve_nologin_shell() {
+    local resolved
+    resolved=$(command -v nologin 2>/dev/null || true)
+    if [[ -n "$resolved" && -x "$resolved" ]]; then
+        printf '%s' "$resolved"
+        return 0
+    fi
+    for resolved in /usr/sbin/nologin /sbin/nologin; do
+        if [[ -x "$resolved" ]]; then
+            printf '%s' "$resolved"
+            return 0
         fi
     done
-fi
-if [[ -z "$nologin_shell" || ! -x "$nologin_shell" ]]; then
+    return 1
+}
+
+system_uid_max() {
+    local configured
+    configured=$(awk '$1 == "SYS_UID_MAX" { value=$2 } END { print value }' /etc/login.defs 2>/dev/null || true)
+    if [[ "$configured" =~ ^[0-9]+$ ]]; then
+        printf '%s' "$configured"
+    else
+        printf '999'
+    fi
+}
+
+validate_runtime_user() {
+    local expected_shell="$1"
+    local passwd_entry group_entry name uid gid home shell group_name group_gid uid_max
+    passwd_entry=$(getent passwd "$runtime_user" 2>/dev/null) || {
+        echo "ERROR: Tenant runtime account ${runtime_user} is missing" >&2
+        return 1
+    }
+    IFS=: read -r name _ uid gid _ home shell <<< "$passwd_entry"
+    uid_max=$(system_uid_max)
+    if [[ "$name" != "$runtime_user" || ! "$uid" =~ ^[0-9]+$ || "$uid" -gt "$uid_max" \
+        || "$home" != "/nonexistent" ]]; then
+        echo "ERROR: Tenant runtime account ${runtime_user} violates the system-user contract" >&2
+        return 1
+    fi
+    case "$shell" in
+        "$expected_shell"|/usr/sbin/nologin|/sbin/nologin) ;;
+        *)
+            echo "ERROR: Tenant runtime account ${runtime_user} violates the system-user contract" >&2
+            return 1
+            ;;
+    esac
+
+    group_entry=$(getent group "$runtime_user" 2>/dev/null) || {
+        echo "ERROR: Tenant runtime group ${runtime_user} is missing" >&2
+        return 1
+    }
+    IFS=: read -r group_name _ group_gid _ <<< "$group_entry"
+    if [[ "$group_name" != "$runtime_user" || "$group_gid" != "$gid" ]]; then
+        echo "ERROR: Tenant runtime account ${runtime_user} has an unexpected primary group" >&2
+        return 1
+    fi
+}
+
+nologin_shell=$(resolve_nologin_shell) || {
     echo "ERROR: nologin shell not found" >&2
     exit 1
+}
+
+if getent passwd "$runtime_user" >/dev/null 2>&1; then
+    validate_runtime_user "$nologin_shell"
+    exit 0
 fi
 
 useradd \
@@ -36,4 +88,4 @@ useradd \
     --shell "$nologin_shell" \
     "$runtime_user"
 
-id -u "$runtime_user" >/dev/null
+validate_runtime_user "$nologin_shell"

--- a/scripts/lib/tenant_user.test.sh
+++ b/scripts/lib/tenant_user.test.sh
@@ -56,3 +56,17 @@ if run_helper \
   echo "tenant account with mismatched primary group was accepted" >&2
   exit 1
 fi
+
+if run_helper \
+  "supacloud-demo:x:0:0::/nonexistent:$TMP_DIR/bin/nologin" \
+  "supacloud-demo:x:0:" >/dev/null 2>&1; then
+  echo "root tenant account was accepted" >&2
+  exit 1
+fi
+
+if run_helper \
+  "supacloud-demo:x:998:0::/nonexistent:$TMP_DIR/bin/nologin" \
+  "supacloud-demo:x:0:" >/dev/null 2>&1; then
+  echo "tenant account with root primary group was accepted" >&2
+  exit 1
+fi

--- a/scripts/lib/tenant_user.test.sh
+++ b/scripts/lib/tenant_user.test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/bin"
+
+cat > "$TMP_DIR/bin/nologin" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+cat > "$TMP_DIR/bin/getent" <<'SH'
+#!/usr/bin/env bash
+case "$1" in
+  passwd) [[ -n "${PASSWD_ENTRY:-}" ]] && printf '%s\n' "$PASSWD_ENTRY" || exit 2 ;;
+  group) [[ -n "${GROUP_ENTRY:-}" ]] && printf '%s\n' "$GROUP_ENTRY" || exit 2 ;;
+  *) exit 2 ;;
+esac
+SH
+cat > "$TMP_DIR/bin/useradd" <<'SH'
+#!/usr/bin/env bash
+echo "unexpected useradd" >&2
+exit 99
+SH
+chmod 755 "$TMP_DIR/bin/"*
+
+run_helper() {
+  PATH="$TMP_DIR/bin:/usr/bin:/bin" \
+    PASSWD_ENTRY="$1" GROUP_ENTRY="$2" \
+    bash "$ROOT_DIR/scripts/lib/tenant_user.sh" demo
+}
+
+run_helper \
+  "supacloud-demo:x:998:998::/nonexistent:$TMP_DIR/bin/nologin" \
+  "supacloud-demo:x:998:"
+
+if run_helper \
+  "supacloud-demo:x:998:998::/home/demo:/bin/bash" \
+  "supacloud-demo:x:998:" >/dev/null 2>&1; then
+  echo "unsafe login-capable tenant account was accepted" >&2
+  exit 1
+fi
+
+if run_helper \
+  "supacloud-demo:x:1000:1000::/nonexistent:$TMP_DIR/bin/nologin" \
+  "supacloud-demo:x:1000:" >/dev/null 2>&1; then
+  echo "non-system tenant account was accepted" >&2
+  exit 1
+fi
+
+if run_helper \
+  "supacloud-demo:x:998:997::/nonexistent:$TMP_DIR/bin/nologin" \
+  "supacloud-demo:x:998:" >/dev/null 2>&1; then
+  echo "tenant account with mismatched primary group was accepted" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Fix tenant provisioning failures under the `supacloud.service` sandbox.
- Make tenant PostgreSQL HBA access durable through the Pigsty inventory and pgsql role.
- Fail closed when the Realtime admin signing secret and container verification secret drift.
- Persist and validate the GoTrue OAuth authorization page path during OIDC migration.

## Root causes and fixes

### Tenant runtime provisioning (B)

`ProtectSystem=full` left the control plane unable to update the systemd templates and managed Caddy config. The `@privileged` syscall deny also blocked the tenant secret-file `chown`, and direct `useradd` could not lock the system account database from the long-running sandbox.

The management unit now allows only `/etc/systemd/system` and `/etc/supacloud/caddy` in addition to its existing managed paths, allows `@chown`, and continues to deny mount, reboot, swap, raw I/O, and keyring syscall groups. Tenant account creation is delegated to an installer-owned, short-lived `supacloud-tenant-user@.service` whose fixed helper validates the tenant ref and runs the minimal `useradd` operation outside the long-running control-plane mount namespace. The helper is installed under `/usr/local/libexec/supacloud` with mode 0755 and the unit is not enabled at boot.

### Tenant PostgreSQL HBA (C)

The installer previously inspected only whether `127.0.0.1/32` appeared anywhere and appended broad `host all all` rules directly to the generated HBA file. Pigsty marks that file as Ansible-managed, so runtime edits were not durable and did not provide a tenant authenticator rule.

The installer now atomically inserts one ordered, tenant-scoped rule into the existing multiline `pg_hba_rules` inventory section:

`authenticator_<ref>` → `supa_<ref>` → `127.0.0.1/32` → password auth, order 40.

It then renders the rule using Pigsty's `pgsql.yml --tags=pg_hba -e pg_reload=true` path. Existing inventory rules, including an existing `10.88.0.0/16` container rule, are preserved byte-for-byte apart from the intentional insertion. Ambiguous inventories fail closed; `/pg/data/pg_hba.conf` is never edited directly.

### Realtime secret drift

The management API could sign Realtime admin JWTs with a stale `REALTIME_API_SECRET` while the container verified `API_JWT_SECRET` from its env file. The installer now persists the container env-file path and validates the generated API secret. At management API startup, the canonical JWT secret, optional configured API secret, and optional container env-file secret must match; missing, unreadable, or mismatched state fails closed without logging secret material.

### OAuth authorization path

The OIDC migration endpoint enabled the OAuth server and stored signing keys without persisting `authorization_path`. GoTrue therefore started without `GOTRUE_OAUTH_SERVER_AUTHORIZATION_PATH`; supplying an absolute URL is also invalid because GoTrue prefixes this value with the configured public origin.

OIDC migration and KMS signing setup now persist `/authorize.html` by default. An explicit override must be an origin-relative path starting with one `/`; absolute URLs, network-path references, query strings, fragments, backslashes, control characters, dot traversal, and encoded variants are rejected. A legacy invalid stored value is repaired to the default on the next migration. The SDK exposes `authorizationPath`, status responses include the persisted path, and a failed runtime restart now returns 503 instead of reporting an applied migration.

## Compatibility, risk, and rollback

- Existing tenant refs, unit names, ports, runtime env files, and Pigsty HBA entries remain compatible.
- Existing deployments need the normal installer/upgrade transaction once to install the helper unit and apply the durable HBA rule; no database migration or data rewrite is introduced.
- Existing OAuth migrations without `authorization_path` use `/authorize.html`; valid custom origin-relative paths are preserved.
- Rollback is the previous installer/binary release. If an operator must roll back the code, remove the helper unit only after all tenant runtime units are stopped; the existing HBA inventory entry can remain safely because it is additive.
- The installer now fails closed when the Pigsty inventory/playbook is unavailable or malformed instead of silently editing a generated HBA file.
- `SUPAOAUTH_BFF_SIGNING_SECRET` remains an explicit cross-service deployment contract: the SupAuth Function and SupaCloud Management API must receive the same independent secret from one controlled source. A mismatch correctly fails closed with 403 and cannot be repaired from hashes. This PR intentionally does not copy, log, or auto-rotate that secret across systems.

## Verification

- `git diff --check`
- `bash -n install.sh setup.sh scripts/lib/tenant_user.sh scripts/lib/installer_pg_hba.test.sh`
- `python3 -m py_compile scripts/lib/patch_pigsty_tenant_hba.py`
- `bash scripts/lib/installer_pg_hba.test.sh`
- `bun run sql:check`
- `bun run typecheck`
- `bun test tests/unit/realtime.service.test.ts tests/unit/realtime-systemd.test.ts tests/unit/runtime-version-assets.test.ts` (30 passed)
- `bun test tests/unit/oauth-authorization-path.test.ts tests/unit/auth-oauth-server.test.ts tests/unit/tenant-runtime.env.test.ts` (56 passed)
- `bun run typecheck` in `packages/management-api`
- `bun test src/index.test.ts` in `packages/supacloud-js` (13 passed)
- `bun run typecheck` in `packages/supacloud-js`

Live systemd verification, cross-service BFF secret alignment, and authenticated staging smoke remain deployment-environment checks and are not performed by this source-only PR.
