### PR TITLE
fix(gateway): preserve internal TLS for empty LAN address

### DIFF
--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -184,6 +184,9 @@ const rawPgPassword = getEnv("PGPASSWORD");
 const pgPassword = rawPgPassword === "" ? getEnv("PG_PASSWORD", "postgres") : rawPgPassword;
 const pgDatabase = getEnv("PG_DATABASE", "postgres");
 const edgeRuntimeInternal = getEnv("EDGE_RUNTIME_INTERNAL", `127.0.0.1:${edgeRuntimePort}`);
+const dockerHostIp = getEnv("DOCKER_HOST_IP").trim()
+  || getEnv("INTERNAL_IP").trim()
+  || "127.0.0.1";
 
 // A private listen address indicates the common single-node LAN setup. Public
 // deployments behind NAT can explicitly force ACME with SUPACLOUD_CADDY_TLS_ISSUER.
@@ -273,7 +276,7 @@ export const config: Config = {
       : "",
   ),
   logLevel: getEnv("LOG_LEVEL", "info"),
-  dockerHostIp: getEnv("DOCKER_HOST_IP", getEnv("INTERNAL_IP", "127.0.0.1")),
+  dockerHostIp,
 
   pgHost,
   pgPort,
@@ -346,7 +349,7 @@ export const config: Config = {
   caddyTlsBlockedDomains: getEnv("CADDY_TLS_BLOCKED_DOMAINS").split(",").map((s) => s.trim().toLowerCase()).filter(Boolean),
   caddyTlsIssuer: resolveCaddyTlsIssuer(
     getEnv("SUPACLOUD_CADDY_TLS_ISSUER"),
-    getEnv("DOCKER_HOST_IP", getEnv("INTERNAL_IP", "127.0.0.1")),
+    dockerHostIp,
   ),
 
   hostedAuthPageEnabled: getEnv("HOSTED_AUTH_PAGE_ENABLED", getEnv("SUPAUTH_HOSTED_LOGIN_ENABLED", "false")) === "true",

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -119,6 +119,17 @@ describe("production config loading boundaries", () => {
     }))).toBe("internal");
   });
 
+  test("defaults Caddy TLS to the internal CA when configured addresses are empty", () => {
+    expect(loadCaddyTlsIssuer(cleanEnv({
+      NODE_ENV: "production",
+      DOCKER_HOST_IP: "",
+    }))).toBe("internal");
+    expect(loadCaddyTlsIssuer(cleanEnv({
+      NODE_ENV: "production",
+      INTERNAL_IP: "",
+    }))).toBe("internal");
+  });
+
   test("rejects an invalid explicit Caddy TLS issuer", () => {
     const configProcess = spawnSync("bun", ["-e", 'import "./src/config.ts";'], {
       cwd: packageRoot,

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -128,6 +128,16 @@ describe("production config loading boundaries", () => {
       NODE_ENV: "production",
       INTERNAL_IP: "",
     }))).toBe("internal");
+    expect(loadCaddyTlsIssuer(cleanEnv({
+      NODE_ENV: "production",
+      DOCKER_HOST_IP: "",
+      INTERNAL_IP: "198.51.100.10",
+    }))).toBe("acme");
+    expect(loadCaddyTlsIssuer(cleanEnv({
+      NODE_ENV: "production",
+      DOCKER_HOST_IP: "  ",
+      INTERNAL_IP: "10.0.0.8",
+    }))).toBe("internal");
   });
 
   test("rejects an invalid explicit Caddy TLS issuer", () => {


### PR DESCRIPTION
Follow-up to #529.

## Summary
- normalize `DOCKER_HOST_IP` / `INTERNAL_IP` once
- fall back to `127.0.0.1` when configured address values are empty
- keep Caddy internal CA as the default for single-node LAN deployments

## Verification
- `bun test tests/unit/config-loading.test.ts tests/unit/gateway.service.test.ts` (62 pass)
- `bun run typecheck`
- `git diff --check`