### PR TITLE
fix(migrations): preserve pooled prepared statements

### DIFF
--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -266,6 +266,8 @@ interface MigrationExecutionPlan {
   statements: readonly string[];
 }
 
+export const MIGRATION_SESSION_RESET_SQL = "RESET ALL; DISCARD TEMP; DISCARD PLANS";
+
 function existingMigrationChecksum(
   row: Record<string, unknown>,
   fallback: { version: string; name: string },
@@ -306,7 +308,8 @@ export function migrationLedgerEntryMatches(
 
 async function resetMigrationSession(connection: ReservedProjectSql, dbName: string): Promise<boolean> {
   try {
-    await connection.unsafe("DISCARD ALL");
+    // Keep the driver's prepared-statement cache valid across pooled requests.
+    await connection.unsafe(MIGRATION_SESSION_RESET_SQL);
     return true;
   } catch (error: unknown) {
     logger.warn(`[database] failed to reset migration session for ${dbName}`, {

--- a/packages/management-api/tests/unit/database-routes.test.ts
+++ b/packages/management-api/tests/unit/database-routes.test.ts
@@ -7,6 +7,7 @@ import {
   buildCreateMaterializedViewSql,
   buildDropMaterializedViewSql,
   buildRefreshMaterializedViewSql,
+  MIGRATION_SESSION_RESET_SQL,
   migrationExecutionStatements,
   migrationLedgerEntryMatches,
   normalizeMigrationVersion,
@@ -155,6 +156,11 @@ describe("database route helpers", () => {
       checksum: "raw-file-sha256",
       statements: ["CREATE FUNCTION demo() RETURNS void LANGUAGE sql AS $$ SELECT 2 $$;"],
     }, input)).toBe(false);
+  });
+
+  test("resets migration sessions without deallocating pooled prepared statements", () => {
+    expect(MIGRATION_SESSION_RESET_SQL).toBe("RESET ALL; DISCARD TEMP; DISCARD PLANS");
+    expect(MIGRATION_SESSION_RESET_SQL).not.toContain("DISCARD ALL");
   });
 
   test("does not let quoted dollar markers hide top-level policy controls", () => {


### PR DESCRIPTION
Sequential structured migration POSTs fail after the first request because `DISCARD ALL` deallocates PostgreSQL prepared statements while Bun reuses its client-side prepared statement cache. The next request then receives `prepared statement ... does not exist`.

Reset session GUCs, temporary objects, and cached query plans without deallocating prepared statements.

Validated: database-routes 19/19, management-api typecheck, git diff --check, and a live PostgreSQL probe confirmed PREPARE survives `RESET ALL; DISCARD TEMP; DISCARD PLANS`.