### PR TITLE
test(migrations): remove duplicate helper import

### DIFF
--- a/packages/management-api/tests/unit/database-routes.test.ts
+++ b/packages/management-api/tests/unit/database-routes.test.ts
@@ -7,7 +7,6 @@ import {
   buildCreateMaterializedViewSql,
   buildDropMaterializedViewSql,
   buildRefreshMaterializedViewSql,
-  migrationExecutionStatements,
   MIGRATION_SESSION_RESET_SQL,
   migrationExecutionStatements,
   migrationLedgerEntryMatches,


### PR DESCRIPTION
## Summary
- remove the duplicate migrationExecutionStatements import left by the PR #533 conflict resolution
- keep runtime behavior unchanged

## Validation
- bun test tests/unit/database-routes.test.ts
- bun run typecheck
- git diff --check

Follow-up to #533.