### PR TITLE
fix(systemd): keep podman out of management prestart

### DIFF
--- a/packages/management-api/tests/unit/pre-start-recovery.test.ts
+++ b/packages/management-api/tests/unit/pre-start-recovery.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const repoRoot = join(import.meta.dir, "../../..", "..");
+const temporaryDirectories: string[] = [];
+
+function readRepoFile(path: string): string {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+
+function writeExecutable(path: string, source: string): void {
+  writeFileSync(path, source);
+  chmodSync(path, 0o755);
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Management pre-start recovery sandbox", () => {
+  test("does not invoke a container runtime from the mount-filtered service", () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-pre-start-"));
+    temporaryDirectories.push(directory);
+    const marker = join(directory, "container-runtime-called");
+
+    for (const runtime of ["podman", "docker"]) {
+      writeExecutable(join(directory, runtime), `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> "${marker}"\nexit 99\n`);
+    }
+    writeExecutable(join(directory, "psql"), "#!/usr/bin/env bash\nprintf 'search_path=auth, public\\n'\n");
+    writeExecutable(join(directory, "systemctl"), "#!/usr/bin/env bash\nexit 0\n");
+
+    const run = Bun.spawnSync(["bash", join(repoRoot, "scripts/pre_start_recovery.sh")], {
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH || ""}`,
+        PGDATA: join(directory, "missing-pgdata"),
+        EDGE_RUNTIME_MODE: "external",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(run.exitCode, run.stderr.toString()).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+    const preStart = readRepoFile("scripts/pre_start_recovery.sh");
+    expect(preStart).not.toContain("podman");
+    expect(preStart).not.toContain("docker");
+    expect(preStart).not.toContain("ensure_service_containers_running");
+  });
+
+  test("keeps container ownership outside the management sandbox", () => {
+    const managementUnit = readRepoFile("infrastructure/systemd/supacloud.service");
+    const realtimeUnit = readRepoFile("infrastructure/systemd/supacloud-realtime.service");
+    const installer = readRepoFile("install.sh");
+    const imaginarySection = installer.slice(
+      installer.indexOf("# --- 1. Deploy Imaginary"),
+      installer.indexOf("# --- 2. Deploy Supabase Realtime"),
+    );
+
+    expect(managementUnit).toContain("SystemCallFilter=~@mount");
+    expect(managementUnit).not.toContain("ExecStartPre=/usr/bin/podman");
+    expect(realtimeUnit).toContain("ExecStart=/usr/bin/podman run");
+    expect(realtimeUnit).not.toContain("SystemCallFilter=");
+    expect(imaginarySection).toContain("--restart=always");
+  });
+});

--- a/scripts/pre_start_recovery.sh
+++ b/scripts/pre_start_recovery.sh
@@ -110,27 +110,6 @@ restart_failed_tenants() {
     log_info "Tenant service recovery complete"
 }
 
-ensure_service_containers_running() {
-    log_info "Checking service containers (Imaginary, Realtime)..."
-
-    local RUNTIME="podman"
-    command -v podman &>/dev/null || RUNTIME="docker"
-
-    for container in supacloud-imaginary supacloud-realtime; do
-        local status
-        status=$($RUNTIME ps -a --filter "name=${container}" --format '{{.Status}}' 2>/dev/null || echo "")
-
-        if [[ -n "$status" ]]; then
-            if [[ "$status" != *"Up"* ]] && [[ "$status" != *"Running"* ]]; then
-                log_warn "${container} not running, starting..."
-                $RUNTIME start "${container}" 2>/dev/null || true
-            else
-                log_info "${container} already running"
-            fi
-        fi
-    done
-}
-
 # ── Edge Runtime Zombie Killer ──────────────────────────────────────
 # SO_REUSEPORT allows multiple processes to bind the same port.
 # If an old bun runtime survives a restart/deploy, requests get split
@@ -176,7 +155,9 @@ main() {
     fix_gotrue_search_path
     kill_edge_runtime_zombies
     ensure_gateway_running
-    ensure_service_containers_running
+    # Container recovery stays outside this sandbox. Realtime has a dedicated
+    # systemd unit, and Imaginary uses the installer-managed restart policy.
+    # Container CLIs require mount-family syscalls that this unit denies.
     restart_failed_tenants
     
     echo ""


### PR DESCRIPTION
## Summary

- Stop `supacloud.service` pre-start recovery from invoking Podman or Docker inside the mount-filtered management sandbox.
- Keep container ownership with the dedicated Realtime systemd unit and the installer-managed Imaginary restart policy.
- Add regression coverage for the syscall-boundary behavior and ownership contract.

## Root cause

`supacloud.service` intentionally denies the `@mount` syscall group. `scripts/pre_start_recovery.sh` nevertheless ran `podman ps -a` for Realtime and Imaginary before every management restart. Recent Podman initialization calls `open_tree`; systemd killed those child processes with `SIGSYS`, producing coredumps and making the recovery check ineffective. The script swallowed the failure, so the API could appear healthy while emitting a host-level crash.

## Fix

The pre-start script no longer probes or starts containers. Realtime is already owned by `supacloud-realtime.service`, whose unit deliberately has no syscall filter because it runs Podman. Imaginary is installed with `--restart=always` and remains outside the Management API service boundary. The Management API continues to deny `@mount`, `@reboot`, `@swap`, `@raw-io`, and `@keyring`; no sandbox permission is widened.

## Verification

- `bun test packages/management-api/tests/unit/pre-start-recovery.test.ts packages/management-api/tests/unit/realtime-systemd.test.ts` (6 passed)
- `bun test packages/management-api/tests/unit/pre-start-recovery.test.ts packages/management-api/tests/unit/runtime-version-assets.test.ts packages/management-api/tests/unit/realtime-systemd.test.ts` (29 passed)
- `bun run typecheck` in `packages/management-api`
- `bun build src/index.ts --target bun --outdir /tmp/supacloud-prestart-build`
- `bash -n scripts/pre_start_recovery.sh install.sh`
- `git diff --check`

The staging host was not modified for this follow-up. It currently runs the separately verified v0.47.11 binary; after this PR merges, deploy the updated pre-start script/unit through the normal test-environment release transaction and verify that no new Podman SIGSYS coredumps occur.
