### PR TITLE
fix(management-api): bind pre-start recovery to service unit

### DIFF
--- a/packages/management-api/tests/unit/pre-start-recovery.test.ts
+++ b/packages/management-api/tests/unit/pre-start-recovery.test.ts
@@ -62,6 +62,7 @@ describe("Management pre-start recovery sandbox", () => {
     );
 
     expect(managementUnit).toContain("SystemCallFilter=~@mount");
+    expect(managementUnit).toContain("ExecStartPre=/opt/supacloud/scripts/pre_start_recovery.sh");
     expect(managementUnit).not.toContain("ExecStartPre=/usr/bin/podman");
     expect(realtimeUnit).toContain("ExecStart=/usr/bin/podman run");
     expect(realtimeUnit).not.toContain("SystemCallFilter=");


### PR DESCRIPTION
## Summary
- bind the sandbox regression test to the actual Management API ExecStartPre unit
- preserve the mount syscall deny boundary introduced by #541
- provide a Conventional Commit that Release Please can classify for the Management API patch release

## Verification
- bun test packages/management-api/tests/unit/pre-start-recovery.test.ts
- bun run typecheck (packages/management-api)
- bash -n scripts/pre_start_recovery.sh
- git diff --check