### PR TITLE
fix(edge-runtime): execute multi-file bundles from source dir

### DIFF
--- a/packages/edge-runtime/function-source.test.ts
+++ b/packages/edge-runtime/function-source.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import path from "path";
+import { BUNDLED_SOURCE_RUNTIME_ENTRY, functionPathCandidates } from "./function-source";
+
+describe("multi-file function runtime source", () => {
+  test("loads the active source-dir entry before the legacy bundle", () => {
+    expect(functionPathCandidates("/functions/project", "supauth")).toEqual([
+      path.join("/functions/project", ".src-supauth", BUNDLED_SOURCE_RUNTIME_ENTRY),
+      "/functions/project/supauth.js",
+      "/functions/project/supauth.ts",
+    ]);
+  });
+
+  test("loads a requested version from its immutable source directory", () => {
+    expect(functionPathCandidates("/functions/project", "supauth", "7")).toEqual([
+      path.join("/functions/project", ".versions", "supauth", "7", "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
+      "/functions/project/.versions/supauth/7/index.js",
+    ]);
+  });
+});

--- a/packages/edge-runtime/function-source.ts
+++ b/packages/edge-runtime/function-source.ts
@@ -1,0 +1,23 @@
+import path from "path";
+
+export const BUNDLED_SOURCE_RUNTIME_ENTRY = ".supacloud-entry.js";
+
+export function functionPathCandidates(
+  projectRoot: string,
+  functionName: string,
+  requestedVersion?: string | null,
+): string[] {
+  if (requestedVersion) {
+    const versionRoot = path.join(projectRoot, ".versions", functionName, requestedVersion);
+    return [
+      path.join(versionRoot, "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
+      path.join(versionRoot, "index.js"),
+    ];
+  }
+
+  return [
+    path.join(projectRoot, `.src-${functionName}`, BUNDLED_SOURCE_RUNTIME_ENTRY),
+    path.join(projectRoot, `${functionName}.js`),
+    path.join(projectRoot, `${functionName}.ts`),
+  ];
+}

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -20,6 +20,7 @@ import {
 import {
   buildBackgroundForwardDispatch,
 } from "./background-forward";
+import { functionPathCandidates } from "./function-source";
 import path from "path";
 import fs from "fs/promises";
 
@@ -39,7 +40,6 @@ const BACKGROUND_WORKER_SMOL = resolveBooleanEnv(
 const FUNCTIONS_DIR = path.resolve(process.env.EDGE_FUNCTIONS_DIR || "./functions");
 const FUNCTIONS_BASE_DIR = path.resolve(process.env.EDGE_FUNCTIONS_BASE_DIR || FUNCTIONS_DIR);
 const MGMT_API = process.env.MANAGEMENT_API_URL || "http://127.0.0.1:9090";
-const VERSIONED_DIR = ".versions";
 const FUNCTION_REQUEST_TIMEOUT_MS = Number(process.env.EDGE_FUNCTION_TIMEOUT_MS) || 60_000;
 const BACKGROUND_FUNCTION_TIMEOUT_MS = Number(process.env.EDGE_BACKGROUND_FUNCTION_TIMEOUT_MS) || 300_000;
 const INTERNAL_TOKEN = process.env.EDGE_RUNTIME_MASTER_KEY || process.env.MASTER_TOKEN || "";
@@ -284,9 +284,7 @@ async function resolveFunctionPath(
   const projectRoot = await resolveProjectRoot(projectRef);
   const resolvedConfig = await getFunctionConfig(projectRef, functionName, projectRoot);
   const activeVersion = requestedVersion || resolvedConfig.version || null;
-  const candidates = requestedVersion
-    ? [path.resolve(projectRoot, VERSIONED_DIR, functionName, requestedVersion, "index.js")]
-    : [path.resolve(projectRoot, `${functionName}.js`), path.resolve(projectRoot, `${functionName}.ts`)];
+  const candidates = functionPathCandidates(projectRoot, functionName, requestedVersion);
 
   for (const candidate of candidates) {
     if (!isPathInside(candidate, projectRoot)) {

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -98,6 +98,7 @@ const DEFAULT_FUNCTION_CONFIG: EdgeFunctionConfig = {
  */
 
 const VERSIONED_DIR = ".versions";
+const BUNDLED_SOURCE_RUNTIME_ENTRY = ".supacloud-entry.js";
 const SAFE_REF_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
 const SAFE_SLUG_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 const EXTERNAL_PACKAGE_REGEX = /^(?:@[a-zA-Z0-9._-]+\/)?[a-zA-Z0-9._-]+$/;
@@ -789,6 +790,12 @@ export const edgeFunctionService = {
       }
 
       // Validate the entrypoint
+      if (Object.prototype.hasOwnProperty.call(files, BUNDLED_SOURCE_RUNTIME_ENTRY)) {
+        return {
+          success: false,
+          error: `Bundle path '${BUNDLED_SOURCE_RUNTIME_ENTRY}' is reserved by the runtime`,
+        };
+      }
       const validation = validateFunctionCode(files[entrypoint]);
       if (!validation.valid) {
         logger.error(`[EdgeFunction] Validation failed: ${validation.error}`, {
@@ -857,6 +864,7 @@ export const edgeFunctionService = {
       const srcDir = assertInside(dir, path.join(dir, `.src-${safeSlug}`));
       await fs.rm(srcDir, { recursive: true, force: true }).catch(() => {});
       await fs.rename(stageDir, srcDir);
+      await Bun.write(path.join(srcDir, BUNDLED_SOURCE_RUNTIME_ENTRY), bundle.code);
       const versionedSrcDir = assertInside(dir, path.join(dir, VERSIONED_DIR, safeSlug, version, "src"));
       await fs.rm(versionedSrcDir, {
         recursive: true,

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { tmpdir } from "node:os";
 
 const functionsRoot = await mkdtemp(join(tmpdir(), "supacloud-edge-functions-"));
@@ -44,6 +45,64 @@ afterAll(async () => {
 });
 
 describe("edgeFunctionService bundle metadata", () => {
+  test("keeps multi-file runtime code beside its static assets", async () => {
+    globalThis.fetch = (() => Promise.resolve(Response.json({ ok: true }))) as typeof fetch;
+
+    const deployResult = await edgeFunctionService.deployBundleDetailed(
+      "proj_assets",
+      "asset-reader",
+      {
+        "index.ts": `
+          export default {
+            async fetch() {
+              const asset = await Bun.file(import.meta.dir + "/public/message.txt").text();
+              return new Response(asset);
+            }
+          };
+        `,
+        "public/message.txt": "asset-from-source-dir",
+      },
+    );
+
+    expect(deployResult.success).toBe(true);
+    const runtimeEntry = join(
+      functionsRoot,
+      "proj_assets",
+      ".src-asset-reader",
+      ".supacloud-entry.js",
+    );
+    const versionedRuntimeEntry = join(
+      functionsRoot,
+      "proj_assets",
+      ".versions",
+      "asset-reader",
+      "1",
+      "src",
+      ".supacloud-entry.js",
+    );
+    expect(existsSync(runtimeEntry)).toBe(true);
+    expect(existsSync(versionedRuntimeEntry)).toBe(true);
+    const runtimeModule = await import(`${pathToFileURL(runtimeEntry).href}?test=${Date.now()}`);
+    const runtimeResponse = await runtimeModule.default.fetch(new Request("http://localhost/"));
+    expect(await runtimeResponse.text()).toBe("asset-from-source-dir");
+  });
+
+  test("rejects a bundle upload that collides with the runtime entry", async () => {
+    const deployResult = await edgeFunctionService.deployBundleDetailed(
+      "proj_reserved",
+      "reserved-entry",
+      {
+        "index.ts": "export default { fetch: () => new Response('ok') };",
+        ".supacloud-entry.js": "user-controlled",
+      },
+    );
+
+    expect(deployResult).toEqual({
+      success: false,
+      error: "Bundle path '.supacloud-entry.js' is reserved by the runtime",
+    });
+  });
+
   test("writes content-addressed version artifacts and returns deploy preheat metadata", async () => {
     const metricsBefore = edgeFunctionService.deployMetrics();
     const fetchCalls: string[] = [];


### PR DESCRIPTION
## Summary

- materialize a reserved runtime entry beside each multi-file bundle source tree
- make Edge Runtime prefer that source-local entry for active and requested versions
- retain legacy bundle paths as compatibility fallbacks
- reject uploads that collide with the reserved runtime entry

## Why

Bun resolves import.meta.dir from the executed bundled module. Multi-file sources and static assets were preserved under .src-{slug}, while Edge Runtime executed {slug}.js from the project root. Functions that read uploaded assets relative to import.meta.dir therefore received ENOENT/404 despite a successful deployment.

## Verification

- bun test packages/edge-runtime/function-source.test.ts packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
- bun test (packages/edge-runtime): 72 pass, 0 fail
- bun run typecheck (packages/edge-runtime)
- bun run typecheck (packages/management-api)
- bun run test:unit (packages/management-api): all shared and isolated suites passed
- bun run build:macos-arm64 (packages/edge-runtime)
- git diff --check
