### PR TITLE
fix(gateway): raise custom route path limit

### DIFF
--- a/packages/admin/src/shared/tools/gateway-tools.ts
+++ b/packages/admin/src/shared/tools/gateway-tools.ts
@@ -100,7 +100,7 @@ Actions: routes, upsert_route, update_route, delete_route, config, get_certifica
             // 路由参数
             route_id: optional(Type.String(), "[upsert_route/update_route/delete_route] 路由 ID（字母/数字/_/-，1-64）"),
             hosts: withDescription(stringArray, "[upsert_route/update_route] 主机名列表，逗号分隔或 JSON 数组（1-20）"),
-            paths: withDescription(stringArray, "[upsert_route/update_route] 路径列表，逗号分隔或 JSON 数组（1-20）"),
+            paths: withDescription(stringArray, "[upsert_route/update_route] 路径列表，逗号分隔或 JSON 数组（1-32）"),
             upstream: optional(Type.String(), "[upsert_route/update_route] 反代上游 host:port 或 http(s)://host[:port]"),
             upstream_tls_insecure_skip_verify: optional(Type.Boolean(), "[upsert_route/update_route] 上游 TLS 跳过校验"),
             static_root: optional(Type.String(), "[upsert_route/update_route] 静态站点根目录"),

--- a/packages/cli/src/shared/tools/gateway-tools.ts
+++ b/packages/cli/src/shared/tools/gateway-tools.ts
@@ -100,7 +100,7 @@ Actions: routes, upsert_route, update_route, delete_route, config, get_certifica
             // 路由参数
             route_id: optional(Type.String(), "[upsert_route/update_route/delete_route] 路由 ID（字母/数字/_/-，1-64）"),
             hosts: withDescription(stringArray, "[upsert_route/update_route] 主机名列表，逗号分隔或 JSON 数组（1-20）"),
-            paths: withDescription(stringArray, "[upsert_route/update_route] 路径列表，逗号分隔或 JSON 数组（1-20）"),
+            paths: withDescription(stringArray, "[upsert_route/update_route] 路径列表，逗号分隔或 JSON 数组（1-32）"),
             upstream: optional(Type.String(), "[upsert_route/update_route] 反代上游 host:port 或 http(s)://host[:port]"),
             upstream_tls_insecure_skip_verify: optional(Type.Boolean(), "[upsert_route/update_route] 上游 TLS 跳过校验"),
             static_root: optional(Type.String(), "[upsert_route/update_route] 静态站点根目录"),

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -6,6 +6,8 @@ import { Elysia, t, status } from "elysia";
 import { projectService } from "../services";
 import {
   type CustomGatewayRouteConfig,
+  MAX_CUSTOM_GATEWAY_HOSTS,
+  MAX_CUSTOM_GATEWAY_PATHS,
   gatewayService,
   normalizeCustomGatewayRoute,
   normalizeCustomGatewayRoutes,
@@ -144,6 +146,15 @@ function addConfigRoutes(section: string) {
 function cloneTemplate<T>(template: T): T {
   return structuredClone(template);
 }
+
+const CustomGatewayHostsSchema = t.Array(t.String(), {
+  minItems: 1,
+  maxItems: MAX_CUSTOM_GATEWAY_HOSTS,
+});
+const CustomGatewayPathSchema = t.Union([
+  t.String(),
+  t.Array(t.String(), { minItems: 1, maxItems: MAX_CUSTOM_GATEWAY_PATHS }),
+]);
 
 function readCustomGatewayRoutes(settings: Record<string, unknown>): CustomGatewayRouteConfig[] {
   return normalizeCustomGatewayRoutes(settings.gateway_routes);
@@ -2015,8 +2026,8 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       params: t.Object({ ref: t.String() }),
       body: t.Object({
         id: t.String(),
-        hosts: t.Array(t.String()),
-        path: t.Union([t.String(), t.Array(t.String())]),
+        hosts: CustomGatewayHostsSchema,
+        path: CustomGatewayPathSchema,
         upstream: t.Optional(t.String()),
         upstream_tls_insecure_skip_verify: t.Optional(t.Boolean()),
         static_root: t.Optional(t.String()),
@@ -2055,8 +2066,8 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
     {
       params: t.Object({ ref: t.String(), routeId: t.String() }),
       body: t.Object({
-        hosts: t.Array(t.String()),
-        path: t.Union([t.String(), t.Array(t.String())]),
+        hosts: CustomGatewayHostsSchema,
+        path: CustomGatewayPathSchema,
         upstream: t.Optional(t.String()),
         upstream_tls_insecure_skip_verify: t.Optional(t.Boolean()),
         static_root: t.Optional(t.String()),

--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -13,6 +13,9 @@ export type CaddyRoute = Record<string, unknown>;
 export type CaddyMatcher = Record<string, unknown>;
 export type CustomGatewayProtocol = "http" | "https";
 export type CustomGatewayRedirectStatus = 301 | 302 | 307 | 308;
+export const MAX_CUSTOM_GATEWAY_HOSTS = 20;
+// Hosted applications can exceed twenty exact paths; keep the larger Caddy matcher bounded.
+export const MAX_CUSTOM_GATEWAY_PATHS = 32;
 
 export interface CustomGatewayRouteConfig {
     id: string;
@@ -239,9 +242,13 @@ export function normalizeCustomGatewayRoute(input: CustomGatewayRouteConfig): Cu
     }
 
     const hosts = uniqueStrings((input.hosts || []).map(normalizeCaddyHost).filter(Boolean));
-    if (hosts.length === 0 || hosts.length > 20) throw new Error("Custom route requires 1-20 hosts");
+    if (hosts.length === 0 || hosts.length > MAX_CUSTOM_GATEWAY_HOSTS) {
+        throw new Error(`Custom route requires 1-${MAX_CUSTOM_GATEWAY_HOSTS} hosts`);
+    }
     const normalizedPaths = uniqueStrings((Array.isArray(input.path) ? input.path : [input.path]).map(normalizeCustomPath));
-    if (normalizedPaths.length === 0 || normalizedPaths.length > 20) throw new Error("Custom route requires 1-20 paths");
+    if (normalizedPaths.length === 0 || normalizedPaths.length > MAX_CUSTOM_GATEWAY_PATHS) {
+        throw new Error(`Custom route requires 1-${MAX_CUSTOM_GATEWAY_PATHS} paths`);
+    }
 
     const hasUpstream = typeof input.upstream === "string" && input.upstream.trim().length > 0;
     const hasStaticRoot = typeof input.static_root === "string" && input.static_root.trim().length > 0;

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -35,6 +35,8 @@ export {
     DEFAULT_CORS_EXPOSED,
     DEFAULT_CORS_HEADERS,
     DEFAULT_CORS_ORIGINS,
+    MAX_CUSTOM_GATEWAY_HOSTS,
+    MAX_CUSTOM_GATEWAY_PATHS,
     buildTenantCorsOrigins,
     normalizeCustomGatewayRoute,
     normalizeCustomGatewayRoutes,

--- a/packages/management-api/tests/unit/gateway-custom-routes.api.test.ts
+++ b/packages/management-api/tests/unit/gateway-custom-routes.api.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
 import { projectConfigRoutes } from "../../src/routes/project-config";
 import { frontendService } from "../../src/services/frontend.service";
-import { gatewayService } from "../../src/services/gateway.service";
+import { gatewayService, MAX_CUSTOM_GATEWAY_PATHS } from "../../src/services/gateway.service";
 import { projectService } from "../../src/services/project.service";
 
 const masterHeaders = { Authorization: "Bearer dev-master-token", "Content-Type": "application/json" };
@@ -175,6 +175,59 @@ describe("controlled custom gateway routes API", () => {
       updateSettings.mockRestore();
       configureRoutes.mockRestore();
     }
+  });
+
+  test("POST accepts and reconciles a hosted route with twenty-one paths", async () => {
+    const hostedPaths = Array.from({ length: 21 }, (_, index) => `/hosted-${index}`);
+    const getSettings = spyOn(projectService, "getProjectSettings").mockResolvedValue({
+      gateway_routes: [],
+    } as any);
+    const updateSettings = spyOn(projectService, "updateProjectSettings").mockResolvedValue({} as any);
+    const configureRoutes = spyOn(gatewayService, "configureCustomGatewayRoutes").mockResolvedValue({ success: true });
+
+    try {
+      const response = await request("/v1/projects/proj123/gateway/routes", {
+        method: "POST",
+        headers: masterHeaders,
+        body: JSON.stringify({
+          id: "hosted-auth",
+          hosts: ["auth.example.com"],
+          path: hostedPaths,
+          upstream: "127.0.0.1:9000",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(configureRoutes).toHaveBeenCalledWith("proj123", [
+        expect.objectContaining({ id: "hosted-auth", path: hostedPaths }),
+      ]);
+      expect(updateSettings).toHaveBeenCalledWith("proj123", {
+        gateway_routes: [expect.objectContaining({ id: "hosted-auth", path: hostedPaths })],
+      });
+    } finally {
+      getSettings.mockRestore();
+      updateSettings.mockRestore();
+      configureRoutes.mockRestore();
+    }
+  });
+
+  test("POST rejects path arrays above the API schema limit", async () => {
+    const excessivePaths = Array.from(
+      { length: MAX_CUSTOM_GATEWAY_PATHS + 1 },
+      (_, index) => `/excessive-${index}`,
+    );
+    const response = await request("/v1/projects/proj123/gateway/routes", {
+      method: "POST",
+      headers: masterHeaders,
+      body: JSON.stringify({
+        id: "too-many-paths",
+        hosts: ["auth.example.com"],
+        path: excessivePaths,
+        upstream: "127.0.0.1:9000",
+      }),
+    });
+
+    expect(response.status).toBe(422);
   });
 
   test("rolls Caddy back to persisted routes when the project config write fails", async () => {

--- a/packages/management-api/tests/unit/gateway-route-builders.test.ts
+++ b/packages/management-api/tests/unit/gateway-route-builders.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+    MAX_CUSTOM_GATEWAY_PATHS,
     makeCorsSubroute,
     makeCustomGatewayRoute,
     normalizeCustomGatewayRoute,
@@ -52,6 +53,34 @@ describe("gateway route builders", () => {
         expect(subroute.routes[0].handle.at(-1)).toEqual({ handler: "static_response", status_code: 204 });
         expect(subroute.routes[0].match.some((matcher: any) => matcher.header?.Origin?.includes("https://app.example.com"))).toBe(true);
         expect(subroute.routes[0].match.some((matcher: any) => matcher.header_regexp?.Origin?.pattern?.includes("preview-"))).toBe(true);
+    });
+
+    test("accepts the maximum bounded hosted route path count", () => {
+        const hostedPaths = Array.from(
+            { length: MAX_CUSTOM_GATEWAY_PATHS },
+            (_, index) => `/hosted-${index}`,
+        );
+        const normalized = normalizeCustomGatewayRoute({
+            id: "hosted-auth",
+            hosts: ["auth.example.com"],
+            path: hostedPaths,
+            upstream: "127.0.0.1:9000",
+        });
+        const caddyRoute = makeCustomGatewayRoute("project-ref", normalized) as any;
+
+        expect(normalized.path).toEqual(hostedPaths);
+        expect(caddyRoute.match).toEqual([{ host: ["auth.example.com"], path: hostedPaths }]);
+
+        const excessivePaths = Array.from(
+            { length: MAX_CUSTOM_GATEWAY_PATHS + 1 },
+            (_, index) => `/excessive-${index}`,
+        );
+        expect(() => normalizeCustomGatewayRoute({
+            id: "too-many-paths",
+            hosts: ["auth.example.com"],
+            path: excessivePaths,
+            upstream: "127.0.0.1:9000",
+        })).toThrow(`Custom route requires 1-${MAX_CUSTOM_GATEWAY_PATHS} paths`);
     });
 
     test("renders a custom HTTPS proxy route with the existing Caddy shape", () => {

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -805,6 +805,30 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("configureCustomGatewayRoutes reconciles twenty-one paths into one Caddy matcher", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+        const hostedPaths = Array.from({ length: 21 }, (_, index) => `/hosted-${index}`);
+
+        const reconcileResult = await provider.configureCustomGatewayRoutes("proj123", [{
+            id: "hosted-auth",
+            hosts: ["auth.example.com"],
+            path: hostedPaths,
+            upstream: "127.0.0.1:9000",
+        }]);
+
+        expect(reconcileResult.success).toBe(true);
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const hostedRoute = routes.find(
+            (route: any) => route["@id"] === "route-custom-gateway-proj123-hosted-auth",
+        );
+        expect(hostedRoute?.match).toEqual([{ host: ["auth.example.com"], path: hostedPaths }]);
+
+        restore();
+    });
+
     test("configureCustomGatewayRoutes replaces stale custom routes for the project", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);


### PR DESCRIPTION
## Summary

- raise the bounded custom gateway route path limit from 20 to 32 while keeping the host limit at 20
- share the path and host limits between request schema validation and runtime normalization
- update Admin/CLI descriptions and add API, builder, and Caddy reconciliation boundary coverage

## Why

Hosted applications such as SupAuth can require more than 20 exact paths on one managed route. The previous limit rejected those manifests and forced artificial route splitting.

## Verification

- `bun test packages/management-api/tests/unit/gateway-custom-routes.api.test.ts packages/management-api/tests/unit/gateway-route-builders.test.ts packages/management-api/tests/unit/gateway.service.test.ts` (68 pass)
- `bun run typecheck` in management-api, admin, and cli
- `bun run test:unit` in management-api
- `git diff --check`