### PR TITLE
fix(web): redirect authenticated Studio users to projects

### DIFF
--- a/packages/web-console/src/routes/layout.test.ts
+++ b/packages/web-console/src/routes/layout.test.ts
@@ -16,6 +16,10 @@ describe("root layout source guards", () => {
     expect(loginPageSource).toContain('import { onMount } from "svelte";');
     expect(loginPageSource).toContain("getStudioSession");
     expect(loginPageSource).toContain("session.authenticated");
-    expect(loginPageSource).toContain('window.location.replace("/")');
+    expect(loginPageSource).toContain('const CONSOLE_LANDING_PATH = "/projects";');
+    expect(loginPageSource).toContain("window.location.replace(CONSOLE_LANDING_PATH)");
+    expect(loginPageSource).toContain("window.location.href = CONSOLE_LANDING_PATH");
+    expect(loginPageSource).not.toContain('window.location.replace("/")');
+    expect(loginPageSource).not.toContain('window.location.href = "/"');
   });
 });

--- a/packages/web-console/src/routes/login/+page.svelte
+++ b/packages/web-console/src/routes/login/+page.svelte
@@ -5,6 +5,8 @@
   import { t, locale } from "svelte-i18n";
   import { Loader2, Lock, Eye, EyeOff, User, Globe, Sun, Moon, Info } from "lucide-svelte";
 
+  const CONSOLE_LANDING_PATH = "/projects";
+
   let username = $state("");
   let password = $state("");
   let isLoading = $state(false);
@@ -18,7 +20,7 @@
     void getStudioSession()
       .then((session) => {
         if (isMounted && session.authenticated) {
-          window.location.replace("/");
+          window.location.replace(CONSOLE_LANDING_PATH);
         }
       })
       .catch(() => {
@@ -50,7 +52,7 @@
     try {
       const result = await loginStudio(username.trim(), password);
       if (result.success) {
-        window.location.href = "/";
+        window.location.href = CONSOLE_LANDING_PATH;
       } else {
         error = result.error || "登录失败";
         triggerShake();


### PR DESCRIPTION
## Summary

- redirect successful Studio logins to `/projects`
- redirect already-authenticated visitors away from `/login` to `/projects`
- guard against regressing either redirect back to the marketing homepage

## Root cause

The Studio login page still redirected authenticated users to `/`. After `/` became the marketing homepage, successful logins and existing sessions were sent back there, creating the observed login loop.

## Verification

- `bun test ./src/routes/layout.test.ts` — 2 passed
- `bun run build` — passed
- `git diff --check` — passed
- live `POST /auth/login` — HTTP 200
- live `GET /auth/session` with the issued secure session cookie — HTTP 200
- live `GET /v1/projects` with the same session — HTTP 200
- deployed login route bundle contains both authenticated redirects to `/projects`

The test environment intentionally uses a SupaCloud Caddy internal certificate, so browsers that do not trust the internal CA will continue to show the expected certificate warning.