### PR TITLE
fix(studio): repair tenant database access and routes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -227,7 +227,7 @@ ensure_pigsty_tenant_hba_rule() {
         return 1
     }
 
-    log_info "Persisted tenant authenticator HBA rule in ${pigsty_config}"
+    log_info "Persisted tenant HBA rules in ${pigsty_config}"
     apply_pigsty_tenant_hba_rules "$pigsty_path" "$pigsty_config"
 }
 
@@ -3070,9 +3070,7 @@ install_web_console() {
 
         # Bind the configured Studio domain to the gateway so the console is
         # reachable at https://<SUPABASE_STUDIO_DOMAIN> without a manual
-        # `bun run src/cli.ts setup-studio-domain` step. Mirrors the CLI
-        # command (setupMasterRoutes + configureFrontendRoute for the
-        # _global/studio frontend) and is idempotent.
+        # `bun run src/cli.ts setup-studio-domain` step.
         # Best-effort: a failure here only means the operator must bind by
         # hand, so it must never abort the install.
         if [[ -n "${SUPABASE_STUDIO_DOMAIN:-}" ]] && systemctl is-active --quiet supacloud; then

--- a/packages/management-api/src/cli.ts
+++ b/packages/management-api/src/cli.ts
@@ -13,19 +13,15 @@ async function setupStudioDomain(domain: string) {
     process.exit(1);
   }
 
-  const MANAGEMENT_API_INTERNAL = appConfig.managementApiInternal;
   const STUDIO_INTERNAL = appConfig.studioInternal;
   
   logger.info(`Provisioning global Studio & Management API through ${gatewayService.name} gateway for domain ${domain}...`);
 
   try {
-    await gatewayService.setupMasterRoutes();
     const studioPort = Number(STUDIO_INTERNAL.split(":").pop() || "3000");
-    await gatewayService.configureFrontendRoute({
-      projectRef: "_global",
-      deploymentId: "studio",
-      hosts: [domain],
-      port: studioPort,
+    await gatewayService.withDeferredPersist(async () => {
+      await gatewayService.setupMasterRoutes();
+      await gatewayService.configureStudioDomain(domain, studioPort);
     });
 
     logger.info(`\n\nSuccessfully bound Global Studio to: https://${domain}`);

--- a/packages/management-api/src/services/database.service.ts
+++ b/packages/management-api/src/services/database.service.ts
@@ -157,17 +157,12 @@ export class DatabaseService {
   private readonly PG_PASSWORD = config.pgPassword;
   private readonly PG_DATABASE = config.pgDatabase;
 
-  // Generate secure random password
-  generatePassword(length = 24): string {
-    const charset =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    let ret = "";
-    const bytes = new Uint8Array(length);
+  generatePassword(length = 32): string {
+    const bytes = new Uint8Array(Math.ceil(length / 2));
     crypto.getRandomValues(bytes);
-    for (let i = 0; i < length; i++) {
-      ret += charset[bytes[i] % charset.length];
-    }
-    return ret;
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"))
+      .join("")
+      .slice(0, length);
   }
 
   private async loadSupabaseSchema(): Promise<string> {
@@ -272,6 +267,7 @@ export class DatabaseService {
   ): Promise<{ success: boolean; error?: string }> {
     const dbName = generateDbName(projectRef);
     const dbUser = resolveRoleName(projectRef);
+    let databaseCreated = false;
 
     try {
       // Verify identifiers for safety to prevent SQL injection in DDL
@@ -286,19 +282,15 @@ export class DatabaseService {
           SELECT 1 FROM pg_database WHERE datname = ${dbName}
         `;
 
-        if (dbExists) {
-          return;
+        await this.reconcileProjectRole(adminDb, dbUser, password);
+
+        if (!dbExists) {
+          // Create database - use double quotes to support identifiers with hyphens
+          await adminDb.unsafe(
+            `CREATE DATABASE "${dbName}" OWNER ${this.PG_USER}`,
+          );
+          databaseCreated = true;
         }
-
-        // Create database - use double quotes to support identifiers with hyphens
-        await adminDb.unsafe(
-          `CREATE DATABASE "${dbName}" OWNER ${this.PG_USER}`,
-        );
-
-        // Create role - limit connections for low-resource environments (prevent connection exhaustion)
-        await adminDb.unsafe(
-          `CREATE ROLE "${dbUser}" LOGIN CONNECTION LIMIT 20 PASSWORD ${pgEscapePassword(password)}`,
-        );
 
         // Set kernel-level configs for resource exhaustion prevention
         await adminDb.unsafe(`
@@ -312,8 +304,11 @@ export class DatabaseService {
         await adminDb.unsafe(`GRANT ALL PRIVILEGES ON DATABASE "${dbName}" TO ${this.PG_USER}`);
       });
 
-      // Apply schema independently
-      await this.applySupabaseSchema(dbName, projectRef, password);
+      if (databaseCreated) {
+        await this.applySupabaseSchema(dbName, projectRef, password);
+      } else {
+        await this.reconcileAuthenticatorRole(dbName, projectRef, password);
+      }
       await this.prepareMigrationRole(dbName, dbUser);
 
       await this.withAdminDb(async (adminDb) => {
@@ -333,6 +328,55 @@ export class DatabaseService {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  private async reconcileProjectRole(
+    adminDb: SQL,
+    dbUser: string,
+    password: string,
+  ): Promise<void> {
+    const escapedPassword = pgEscapePassword(password);
+    await adminDb.unsafe(`
+      DO $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${dbUser}') THEN
+          ALTER ROLE "${dbUser}" LOGIN CONNECTION LIMIT 20 PASSWORD ${escapedPassword};
+        ELSE
+          CREATE ROLE "${dbUser}" LOGIN CONNECTION LIMIT 20 PASSWORD ${escapedPassword};
+        END IF;
+      END
+      $$;
+    `);
+  }
+
+  private async reconcileAuthenticatorRole(
+    dbName: string,
+    projectRef: string,
+    password: string,
+  ): Promise<void> {
+    const authenticatorRole = resolveAuthenticatorName(projectRef);
+    assertValidIdentifier("authenticatorRole", authenticatorRole);
+    const escapedPassword = pgEscapePassword(password);
+
+    await this.withAdminDb(async (adminDb) => {
+      await adminDb.unsafe(`
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${authenticatorRole}') THEN
+            ALTER ROLE "${authenticatorRole}" CONNECTION LIMIT 30 NOINHERIT LOGIN PASSWORD ${escapedPassword};
+          ELSE
+            CREATE ROLE "${authenticatorRole}" CONNECTION LIMIT 30 NOINHERIT LOGIN PASSWORD ${escapedPassword};
+          END IF;
+        END
+        $$;
+
+        GRANT anon, authenticated, service_role TO "${authenticatorRole}";
+        ALTER ROLE "${authenticatorRole}" SET statement_timeout = '15s';
+        ALTER ROLE "${authenticatorRole}" SET idle_in_transaction_session_timeout = '30s';
+        ALTER ROLE "${authenticatorRole}" SET work_mem = '4MB';
+        GRANT CONNECT, TEMPORARY ON DATABASE "${dbName}" TO "${authenticatorRole}";
+      `);
+    });
   }
 
   private async prepareMigrationRole(dbName: string, dbUser: string): Promise<void> {

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -112,6 +112,7 @@ export interface GatewayProvider {
     withDeferredPersist<T>(fn: () => Promise<T>, shouldFlush?: (result: T) => boolean): Promise<T>;
     configureCustomGatewayRoutes(projectRef: string, routes: CustomGatewayRouteConfig[]): Promise<{ success: boolean; error?: string }>;
     setupMasterRoutes(): Promise<void>;
+    configureStudioDomain(domain: string, port: number): Promise<void>;
     upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }>;
     configureFrontendRoute(route: FrontendGatewayRoute): Promise<void>;
     removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void>;
@@ -403,8 +404,13 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async prepareCleanRebuild(): Promise<void> {
+        await this.hydrateFromDiskIfUninitialized();
         await this.hydrateCertificatesFromDisk();
+        const globalRoutes = Array.from(this.routesById.entries()).filter(([id]) =>
+            id.startsWith("route-custom-gateway-_global-") || id.startsWith("route-frontend-_global-")
+        );
         this.routesById.clear();
+        for (const [id, route] of globalRoutes) this.routesById.set(id, route);
         this.rateLimits.clear();
         this.customRateLimits.clear();
         this.hydrated = true;
@@ -1445,6 +1451,37 @@ export class CaddyGatewayProvider implements GatewayProvider {
         await this.persistAndLoad();
     }
 
+    async configureStudioDomain(domain: string, port: number): Promise<void> {
+        await this.hydrateFromDiskIfUninitialized();
+        const host = normalizeCaddyHost(domain);
+        if (!host) throw new Error("Studio domain is required");
+        if (!Number.isInteger(port) || port < 1 || port > 65535) {
+            throw new Error("Studio upstream port must be between 1 and 65535");
+        }
+
+        const redirect = makeCustomGatewayRoute("_global", {
+            id: "studio-https-redirect",
+            hosts: [host],
+            path: "/*",
+            protocol: "http",
+            redirect_to: `https://${host}{http.request.uri}`,
+            redirect_status: 308,
+            priority: 10_000,
+        });
+        if (!redirect) throw new Error("Failed to build Studio HTTPS redirect route");
+
+        this.routesById.set(String(redirect["@id"]), redirect);
+        this.routesById.set("route-frontend-_global-studio", this.makeRoute({
+            id: "route-frontend-_global-studio",
+            hosts: [host],
+            path: "/*",
+            upstream: `127.0.0.1:${port}`,
+            projectRef: "_global",
+            readTimeout: 60_000,
+        }));
+        await this.persistAndLoad();
+    }
+
     async upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }> {
         await this.hydrateFromDiskIfUninitialized();
         const snis = uniqueStrings(opts.snis.map(normalizeCaddyHost));
@@ -1592,6 +1629,7 @@ export class GatewayService implements GatewayProvider {
     withDeferredPersist<T>(fn: () => Promise<T>, shouldFlush?: (result: T) => boolean) { return this.provider.withDeferredPersist(fn, shouldFlush); }
     configureCustomGatewayRoutes(projectRef: string, routes: CustomGatewayRouteConfig[]) { return this.provider.configureCustomGatewayRoutes(projectRef, routes); }
     setupMasterRoutes() { return this.provider.setupMasterRoutes(); }
+    configureStudioDomain(domain: string, port: number) { return this.provider.configureStudioDomain(domain, port); }
     upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }) { return this.provider.upsertCertificateForSnis(opts); }
     configureFrontendRoute(route: FrontendGatewayRoute) { return this.provider.configureFrontendRoute(route); }
     removeFrontendRoute(projectRef: string, deploymentId: string) { return this.provider.removeFrontendRoute(projectRef, deploymentId); }

--- a/packages/management-api/tests/unit/database.service.test.ts
+++ b/packages/management-api/tests/unit/database.service.test.ts
@@ -24,7 +24,7 @@ function createMockSql(): MockSql {
 describe("DatabaseService", () => {
   let databaseService: DatabaseService;
   let mockSql: MockSql;
-  let applySupabaseSchemaSpy: { mockRestore: () => void };
+  let applySupabaseSchemaSpy: { mockClear: () => void; mockRestore: () => void };
 
   beforeEach(() => {
     databaseService = new DatabaseService();
@@ -49,7 +49,7 @@ describe("DatabaseService", () => {
     test("should generate a password string", () => {
       const password = databaseService.generatePassword();
       expect(typeof password).toBe("string");
-      expect(password.length).toBe(24);
+      expect(password.length).toBe(32);
     });
 
     test("should generate unique passwords", () => {
@@ -58,9 +58,13 @@ describe("DatabaseService", () => {
       expect(password1).not.toBe(password2);
     });
 
-    test("should only contain URL-safe characters", () => {
+    test("should only contain lowercase hexadecimal characters", () => {
       const password = databaseService.generatePassword();
-      expect(password).toMatch(/^[A-Za-z0-9]+$/);
+      expect(password).toMatch(/^[a-f0-9]+$/);
+    });
+
+    test("should respect an explicit password length", () => {
+      expect(databaseService.generatePassword(17)).toMatch(/^[a-f0-9]{17}$/);
     });
   });
 
@@ -71,6 +75,22 @@ describe("DatabaseService", () => {
       expect(mockSql.unsafe).toHaveBeenCalled();
       expect(mockSql.unsafe).toHaveBeenCalledWith(expect.stringContaining(
         'GRANT CONNECT, TEMPORARY ON DATABASE "supa_testref123" TO "authenticator_testref123"',
+      ));
+    });
+
+    test("reconciles tenant login passwords when the database already exists", async () => {
+      applySupabaseSchemaSpy.mockClear();
+      (mockSql as unknown as ReturnType<typeof mock>).mockResolvedValueOnce([{ exists: 1 }]);
+
+      const result = await databaseService.createDatabase("testref123", "replacement-pass");
+
+      expect(result.success).toBe(true);
+      expect(applySupabaseSchemaSpy).not.toHaveBeenCalled();
+      expect(mockSql.unsafe).toHaveBeenCalledWith(expect.stringContaining(
+        'ALTER ROLE "role_testref123" LOGIN CONNECTION LIMIT 20 PASSWORD',
+      ));
+      expect(mockSql.unsafe).toHaveBeenCalledWith(expect.stringContaining(
+        'ALTER ROLE "authenticator_testref123" CONNECTION LIMIT 30 NOINHERIT LOGIN PASSWORD',
       ));
     });
   });

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -474,6 +474,41 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("configureStudioDomain adds an HTTP-only 308 redirect without replacing custom routes", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.configureCustomGatewayRoutes("_global", [{
+            id: "existing-global-route",
+            hosts: ["existing.example.com"],
+            path: "/*",
+            upstream: "127.0.0.1:8080",
+        }]);
+        await provider.configureStudioDomain("studio.example.com", 9090);
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const redirect = routes.find((route: any) => route["@id"] === "route-custom-gateway-_global-studio-https-redirect");
+        const studio = routes.find((route: any) => route["@id"] === "route-frontend-_global-studio");
+
+        expect(routes.some((route: any) => route["@id"] === "route-custom-gateway-_global-existing-global-route")).toBe(true);
+        expect(redirect?.match?.[0]).toEqual({
+            host: ["studio.example.com"],
+            path: ["/*"],
+            protocol: "http",
+        });
+        expect(redirect?.handle?.[0]).toMatchObject({
+            handler: "static_response",
+            status_code: 308,
+            headers: { Location: ["https://studio.example.com{http.request.uri}"] },
+        });
+        expect(studio?.match?.[0]?.host).toEqual(["studio.example.com"]);
+        expect(studio?.handle?.at(-1)?.upstreams?.[0]?.dial).toBe("127.0.0.1:9090");
+
+        restore();
+    });
+
     test("setupUpstream preserves existing frontend hosts as allowed CORS origins", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         const restore = captureFetch(calls);
@@ -1208,6 +1243,29 @@ describe("CaddyGatewayProvider", () => {
         expect(certs).toEqual([
             { certificate: "/etc/supacloud/certs/manual.crt", key: "/etc/supacloud/certs/manual.key" },
         ]);
+
+        restore();
+    });
+
+    test("clean rebuild preserves global Studio routes", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const configuredProvider = new CaddyGatewayProvider();
+
+        await configuredProvider.configureStudioDomain("studio.example.com", 9090);
+        calls.length = 0;
+        const restartedProvider = new CaddyGatewayProvider();
+
+        await restartedProvider.withDeferredPersist(async () => {
+            await restartedProvider.prepareCleanRebuild();
+            await restartedProvider.setupMasterRoutes();
+        });
+
+        const load = calls.find((call) => call.method === "POST" && call.url.endsWith("/load"));
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+
+        expect(routes.some((route: any) => route["@id"] === "route-custom-gateway-_global-studio-https-redirect")).toBe(true);
+        expect(routes.some((route: any) => route["@id"] === "route-frontend-_global-studio")).toBe(true);
 
         restore();
     });

--- a/packages/web-console/src/lib/admin/provider.test.ts
+++ b/packages/web-console/src/lib/admin/provider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chatProvider } from "./provider";
+import { chatProvider, parseListResponse } from "./provider";
 
 const originalFetch = globalThis.fetch;
 
@@ -33,5 +33,21 @@ describe("chatProvider", () => {
     }
 
     expect(chunks).toEqual(["hello"]);
+  });
+});
+
+describe("parseListResponse", () => {
+  test("normalizes GoTrue user lists", () => {
+    expect(parseListResponse({ users: [{ id: "user-1" }], total: 9 }, "auth/users")).toEqual({
+      data: [{ id: "user-1" }],
+      total: 9,
+    });
+  });
+
+  test("normalizes frontend deployment lists", () => {
+    expect(parseListResponse({ deployments: [{ id: "site-1" }] }, "frontend/deployments")).toEqual({
+      data: [{ id: "site-1" }],
+      total: 1,
+    });
   });
 });

--- a/packages/web-console/src/lib/admin/provider.ts
+++ b/packages/web-console/src/lib/admin/provider.ts
@@ -6,21 +6,33 @@ const getApiUrl = () => {
     return window.location.origin;
 };
 
-// ... DataProvider logic ...
+export function parseListResponse(payload: unknown, resource: string) {
+    if (Array.isArray(payload)) return { data: payload, total: payload.length };
+    if (!payload || typeof payload !== "object") throw new Error(`Invalid list response for ${resource}`);
+
+    const response = payload as Record<string, unknown>;
+    if (response.error || response.message) {
+        const message = typeof response.error === "string" ? response.error : response.message;
+        throw new Error(typeof message === "string" ? message : "API Application Error");
+    }
+
+    for (const key of ["items", "data", "rows", "users", "deployments"] as const) {
+        const records = response[key];
+        if (Array.isArray(records)) {
+            const total = typeof response.total === "number" ? response.total : records.length;
+            return { data: records, total };
+        }
+    }
+
+    throw new Error(
+        `Unrecognized list response format from API for resource ${resource}. Expected an array or an object containing items, data, rows, users, or deployments.`,
+    );
+}
+
 export const dataProvider = createElysiaDataProvider({
     apiUrl: getApiUrl(),
     withCredentials: true,
-    parseListResponse: (json: any, resource: string) => {
-        if (json && (json.error || json.message)) {
-            const msg = typeof json.error === "string" ? json.error : json.message;
-            throw new Error(msg || "API Application Error");
-        }
-        if (Array.isArray(json)) return { data: json, total: json.length };
-        if (json && Array.isArray(json.items)) return { data: json.items, total: json.total ?? json.items.length };
-        if (json && Array.isArray(json.data)) return { data: json.data, total: json.total ?? json.data.length };
-        if (json && json.rows && Array.isArray(json.rows)) return { data: json.rows, total: json.total ?? json.rows.length };
-        throw new Error(`Unrecognized list response format from API for resource ${resource}. Expected { items, total }, { data, total }, or an array.`);
-    }
+    parseListResponse,
 });
 
 // Implementation of ChatProvider using Fetch API + SSE for streaming

--- a/scripts/lib/installer_pg_hba.test.sh
+++ b/scripts/lib/installer_pg_hba.test.sh
@@ -34,18 +34,38 @@ source "$SCRIPT_DIR/install.sh"
 
 ensure_pigsty_tenant_hba_rule
 grep -Fq "SupaCloud tenant authenticator loopback" "$PIGSTY_PATH/pigsty.yml"
-grep -Fq "user: '/^authenticator_[a-z0-9-]+$/'" "$PIGSTY_PATH/pigsty.yml"
-grep -Fq "db: '/^supa_[a-z0-9-]+$/'" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "user: '\"/^authenticator_[a-z0-9-]+$\"'" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "SupaCloud tenant database role loopback" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "user: '\"/^role_[a-z0-9-]+$\"'" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "db: '\"/^supa_[a-z0-9-]+$\"'" "$PIGSTY_PATH/pigsty.yml"
 grep -Fq "addr: 127.0.0.1/32, auth: pwd, order: 40" "$PIGSTY_PATH/pigsty.yml"
+grep -Fq "addr: 127.0.0.1/32, auth: pwd, order: 41" "$PIGSTY_PATH/pigsty.yml"
 grep -Fq "unrelated_setting: keep-me" "$PIGSTY_PATH/pigsty.yml"
 grep -Fq "addr: 10.88.0.0/16" "$PIGSTY_PATH/pigsty.yml"
 [[ "$(grep -Fc "SupaCloud tenant authenticator loopback" "$PIGSTY_PATH/pigsty.yml")" == 1 ]]
+[[ "$(grep -Fc "SupaCloud tenant database role loopback" "$PIGSTY_PATH/pigsty.yml")" == 1 ]]
 grep -Fq -- "-i $PIGSTY_PATH/pigsty.yml $PIGSTY_PATH/pgsql.yml -l pg-meta --tags=pg_hba -e pg_reload=true" "$ANSIBLE_LOG"
 
 # Idempotent reruns still render the durable inventory through Pigsty.
 ensure_pigsty_tenant_hba_rule
 [[ "$(grep -Fc "SupaCloud tenant authenticator loopback" "$PIGSTY_PATH/pigsty.yml")" == 1 ]]
+[[ "$(grep -Fc "SupaCloud tenant database role loopback" "$PIGSTY_PATH/pigsty.yml")" == 1 ]]
 [[ "$(wc -l < "$ANSIBLE_LOG" | tr -d ' ')" == 2 ]]
+
+# Upgrades from releases that already installed only the authenticator rule
+# must add the project database role rule without duplicating the old rule.
+legacy_config="$tmp_dir/legacy.yml"
+cat > "$legacy_config" <<'YAML'
+all:
+  vars:
+    pg_hba_rules:
+      - { user: '/^authenticator_[a-z0-9-]+$/', db: '/^supa_[a-z0-9-]+$/', addr: 127.0.0.1/32, auth: pwd, order: 40, title: 'SupaCloud tenant authenticator loopback' }
+YAML
+PIGSTY_CONFIG="$legacy_config" ensure_pigsty_tenant_hba_rule
+[[ "$(grep -Fc "SupaCloud tenant authenticator loopback" "$legacy_config")" == 1 ]]
+[[ "$(grep -Fc "SupaCloud tenant database role loopback" "$legacy_config")" == 1 ]]
+grep -Fq "user: '\"/^authenticator_[a-z0-9-]+$\"'" "$legacy_config"
+! grep -Fq "user: '/^authenticator_[a-z0-9-]+$/'" "$legacy_config"
 
 bad_config="$tmp_dir/bad.yml"
 printf 'all:\n  vars:\n    unrelated: true\n' > "$bad_config"

--- a/scripts/lib/installer_pg_hba.test.sh
+++ b/scripts/lib/installer_pg_hba.test.sh
@@ -65,7 +65,10 @@ PIGSTY_CONFIG="$legacy_config" ensure_pigsty_tenant_hba_rule
 [[ "$(grep -Fc "SupaCloud tenant authenticator loopback" "$legacy_config")" == 1 ]]
 [[ "$(grep -Fc "SupaCloud tenant database role loopback" "$legacy_config")" == 1 ]]
 grep -Fq "user: '\"/^authenticator_[a-z0-9-]+$\"'" "$legacy_config"
-! grep -Fq "user: '/^authenticator_[a-z0-9-]+$/'" "$legacy_config"
+if grep -Fq "user: '/^authenticator_[a-z0-9-]+$/'" "$legacy_config"; then
+    echo "Legacy PostgreSQL HBA regex syntax was not reconciled" >&2
+    exit 1
+fi
 
 bad_config="$tmp_dir/bad.yml"
 printf 'all:\n  vars:\n    unrelated: true\n' > "$bad_config"

--- a/scripts/lib/patch_pigsty_tenant_hba.py
+++ b/scripts/lib/patch_pigsty_tenant_hba.py
@@ -10,24 +10,56 @@ import sys
 import tempfile
 
 
-RULE_MARKER = "SupaCloud tenant authenticator loopback"
+AUTHENTICATOR_RULE_MARKER = "SupaCloud tenant authenticator loopback"
+DATABASE_ROLE_RULE_MARKER = "SupaCloud tenant database role loopback"
+
+TENANT_HBA_RULES = (
+    (
+        AUTHENTICATOR_RULE_MARKER,
+        "user: '\"/^authenticator_[a-z0-9-]+$\"', db: '\"/^supa_[a-z0-9-]+$\"', "
+        "addr: 127.0.0.1/32, auth: pwd, order: 40",
+    ),
+    (
+        DATABASE_ROLE_RULE_MARKER,
+        "user: '\"/^role_[a-z0-9-]+$\"', db: '\"/^supa_[a-z0-9-]+$\"', "
+        "addr: 127.0.0.1/32, auth: pwd, order: 41",
+    ),
+)
 
 
 def render_inventory(content: str) -> str | None:
-    if RULE_MARKER in content:
-        return None
+    updated_content = content
+    missing_rules: list[tuple[str, str]] = []
+    for marker, fields in TENANT_HBA_RULES:
+        rule_pattern = re.compile(
+            rf"(?m)^(?P<indent>[ ]*)-[ ]*\{{[^\n]*title:[ ]*['\"]{re.escape(marker)}['\"][^\n]*\}}[ ]*$"
+        )
+        existing_rule = rule_pattern.search(updated_content)
+        if existing_rule:
+            rendered_rule = f"{existing_rule.group('indent')}- {{ {fields}, title: '{marker}' }}"
+            updated_content = rule_pattern.sub(rendered_rule, updated_content, count=1)
+        else:
+            missing_rules.append((marker, fields))
 
-    sections = list(re.finditer(r"(?m)^([ ]*)pg_hba_rules:[ ]*(?:#.*)?$", content))
+    if not missing_rules:
+        return updated_content if updated_content != content else None
+
+    sections = list(re.finditer(r"(?m)^([ ]*)pg_hba_rules:[ ]*(?:#.*)?$", updated_content))
     if len(sections) != 1:
         raise ValueError(f"expected one multiline pg_hba_rules section, found {len(sections)}")
 
     indent = sections[0].group(1) + "  "
-    rule = (
-        f"{indent}- {{ user: '/^authenticator_[a-z0-9-]+$/', "
-        "db: '/^supa_[a-z0-9-]+$/', addr: 127.0.0.1/32, auth: pwd, "
-        f"order: 40, title: '{RULE_MARKER}' }}"
+    rendered_rules = "\n".join(
+        f"{indent}- {{ {fields}, title: '{marker}' }}"
+        for marker, fields in missing_rules
     )
-    return content[: sections[0].end()] + "\n" + rule + content[sections[0].end() :]
+    updated_content = (
+        updated_content[: sections[0].end()]
+        + "\n"
+        + rendered_rules
+        + updated_content[sections[0].end() :]
+    )
+    return updated_content
 
 
 def atomic_write(path: str, content: str) -> None:


### PR DESCRIPTION
## Summary

- render PostgreSQL 18-compatible Pigsty HBA regexes for both authenticator and project database roles, including upgrade reconciliation
- reconcile passwords and privileges for existing tenant roles so Studio SQL, table inspection, and query diagnostics keep working after credential rotation
- accept GoTrue `{ users }` and frontend `{ deployments }` list responses in the Web Console
- preserve global Studio routes across clean Caddy rebuilds and retain the full request URI in HTTP-to-HTTPS redirects

## Validation

- Management API focused unit tests: 69 passed
- Web Console provider tests: 3 passed
- Management API TypeScript typecheck and SQL module check
- Svelte check: 0 errors, 0 warnings
- Pigsty HBA install/upgrade regression test
- `bash -n install.sh`, Python compile check, and `git diff --check`
- Linux amd64 Management API binary and Web Console production build
- live Studio acceptance for table editor, SQL/query diagnostics, schema linter, Auth users, frontend deployments, and dashboard
