### PR TITLE
[codex] harden secrets and Studio sessions

### DIFF
--- a/packages/management-api/src/routes/auth.ts
+++ b/packages/management-api/src/routes/auth.ts
@@ -59,6 +59,22 @@ const SENSITIVE_AUTH_SUFFIXES = [
   "token",
 ];
 const JWK_PRIVATE_FIELDS = new Set(["d", "p", "q", "dp", "dq", "qi", "oth", "k"]);
+const PUBLIC_ASYMMETRIC_JWK_TYPES = new Set(["EC", "OKP", "RSA"]);
+const PUBLIC_JWK_FIELDS = [
+  "kty",
+  "crv",
+  "x",
+  "y",
+  "n",
+  "e",
+  "kid",
+  "alg",
+  "use",
+  "x5u",
+  "x5c",
+  "x5t",
+  "x5t#S256",
+] as const;
 const FLAT_HOOK_SECRET_NAMES: Record<string, string> = {
   hook_before_user_created_secrets: "before_user_created_hook",
   hook_custom_access_token_secrets: "custom_access_token_hook",
@@ -349,6 +365,45 @@ async function safeAuthConfig(ref: string, authConfig: Record<string, unknown>) 
   await applyCaptchaSecretStatus(ref, safeConfig);
   await applyHookSecretStatuses(ref, safeConfig);
   return safeConfig;
+}
+
+function publicAsymmetricJwk(candidate: unknown): Record<string, unknown> | null {
+  if (!isRecord(candidate) || !PUBLIC_ASYMMETRIC_JWK_TYPES.has(String(candidate.kty))) {
+    return null;
+  }
+  const publicJwk: Record<string, unknown> = {};
+  for (const field of PUBLIC_JWK_FIELDS) {
+    if (candidate[field] !== undefined) publicJwk[field] = structuredClone(candidate[field]);
+  }
+  return publicJwk;
+}
+
+function publicAsymmetricJwks(candidate: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(candidate)) return [];
+  return candidate
+    .map(publicAsymmetricJwk)
+    .filter((entry): entry is Record<string, unknown> => entry !== null);
+}
+
+export async function safeProjectSettingsAuthConfig(
+  ref: string,
+  authConfig: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const safeConfig = await safeAuthConfig(ref, authConfig);
+  if (!isRecord(safeConfig.oauth_server)) return safeConfig;
+
+  const oauthServer = { ...safeConfig.oauth_server };
+  if (Object.prototype.hasOwnProperty.call(oauthServer, "jwt_keys")) {
+    oauthServer.jwt_keys = publicAsymmetricJwks(oauthServer.jwt_keys);
+  }
+  if (isRecord(oauthServer.jwt_jwks)) {
+    oauthServer.jwt_jwks = {
+      ...oauthServer.jwt_jwks,
+      keys: publicAsymmetricJwks(oauthServer.jwt_jwks.keys),
+    };
+  }
+
+  return { ...safeConfig, oauth_server: oauthServer };
 }
 
 /**

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -45,6 +45,7 @@ import {
   canonicalAuthProviderLinkingConfig,
   ProviderLinkingDomainsValidationError,
 } from "../utils/provider-linking";
+import { safeProjectSettingsAuthConfig } from "./auth";
 
 /** Map PostgreSQL column types to TypeScript types */
 function pgTypeToTs(udtName: string, dataType: string): string {
@@ -562,6 +563,18 @@ function buildSharedSettingsResponse(
   };
 }
 
+async function buildProjectSettingsResponse(
+  ref: string,
+  settings: Record<string, unknown>,
+) {
+  const auth = settings.auth;
+  if (!auth || typeof auth !== "object" || Array.isArray(auth)) return settings;
+  return {
+    ...settings,
+    auth: await safeProjectSettingsAuthConfig(ref, auth as Record<string, unknown>),
+  };
+}
+
 export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get project settings
   .get(
@@ -580,7 +593,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
           managedError.authority_project_ref,
         );
       }
-      return settings;
+      return buildProjectSettingsResponse(params.ref, settings);
     },
     {
       params: t.Object({
@@ -620,7 +633,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
           managedError.authority_project_ref,
         );
       }
-      return settings;
+      return buildProjectSettingsResponse(params.ref, settings);
     },
     {
       params: t.Object({

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -1,6 +1,7 @@
 import { Elysia, t, status } from "elysia";
 import { projectService } from "../services";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { isUserManagedFunctionSecretName } from "../utils/project-secret-visibility";
 
 async function requireFunctionManagementAuth(request: Request, ref: string) {
   const authError = await requireProjectOrAdminAuth(request, ref);
@@ -40,32 +41,6 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
     {
       params: t.Object({ ref: t.String() }),
       detail: { tags: ["frontend"], summary: "List edge functions" },
-    },
-  )
-
-  // GET /v1/projects/:ref/functions/secrets
-  // Alias for secrets endpoint — Supabase Studio and some SDK versions call this path
-  .get(
-    "/:ref/functions/secrets",
-    async ({ params, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
-      const { projectService: svc } = await import("../services");
-      const secrets = await svc.getSecrets(params.ref);
-      if (!secrets) {
-        return status(404, { message: "Project not found" });
-      }
-      return secrets.map(
-        (s: { name: string; value: string; updated_at?: string }) => ({
-          name: s.name,
-          value: "********",
-          updated_at: s.updated_at ?? new Date().toISOString(),
-        }),
-      );
-    },
-    {
-      params: t.Object({ ref: t.String() }),
-      detail: { tags: ["frontend"], summary: "List function secrets (project-level)" },
     },
   )
 
@@ -921,11 +896,13 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         name: string;
         value: string;
         updated_at?: string;
-      }>).map((s) => ({
-        name: s.name,
-        value: "********",
-        updated_at: s.updated_at ?? new Date().toISOString(),
-      }));
+      }>)
+        .filter((secret) => isUserManagedFunctionSecretName(secret.name))
+        .map((secret) => ({
+          name: secret.name,
+          value: "********",
+          updated_at: secret.updated_at ?? new Date().toISOString(),
+        }));
     },
     { params: t.Object({ ref: t.String() }), detail: { tags: ["frontend"], summary: "List function secrets (project-level)" } },
   )

--- a/packages/management-api/src/routes/project-secrets.ts
+++ b/packages/management-api/src/routes/project-secrets.ts
@@ -4,6 +4,10 @@ import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { getAuthContext } from "../middleware/auth";
 import { runtimeEnvService } from "../services/runtime-env.service";
 import { runtimeCacheService } from "../services/runtime-cache.service";
+import {
+  isSystemManagedProjectSecretName,
+  isUserManagedProjectSecretName,
+} from "../utils/project-secret-visibility";
 
 export const projectSecretsRoutes = new Elysia({ prefix: "/v1/projects" })
   .get(
@@ -35,12 +39,14 @@ export const projectSecretsRoutes = new Elysia({ prefix: "/v1/projects" })
       if (!secrets) {
         return status(404, { message: "Project not found", code: "404" });
       }
-      return secrets.map((s: { name: string; value: string }) => ({
-        name: s.name,
-        // 明文只允许内部 runtime-env 通道读取；兼容旧的 reveal=true
-        // 查询参数，但永远不在项目管理 API 响应中回显。
-        value: "********",
-      }));
+      return secrets
+        .filter((secret: { name: string }) => isUserManagedProjectSecretName(secret.name))
+        .map((secret: { name: string }) => ({
+          name: secret.name,
+          // 明文只允许内部 runtime-env 通道读取；兼容旧的 reveal=true
+          // 查询参数，但永远不在项目管理 API 响应中回显。
+          value: "********",
+        }));
     },
     {
       params: t.Object({ ref: t.String() }),
@@ -53,12 +59,12 @@ export const projectSecretsRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
-      const reserved = (body as { name: string; value: string }[]).filter((s) =>
-        s.name.toUpperCase().startsWith("SUPABASE_"),
+      const reserved = (body as { name: string; value: string }[]).filter((secret) =>
+        isSystemManagedProjectSecretName(secret.name),
       );
       if (reserved.length > 0) {
         return status(400, {
-          message: `Secret names starting with SUPABASE_ are reserved: ${reserved.map((s) => s.name).join(", ")}`,
+          message: `System-managed secret names are reserved: ${reserved.map((secret) => secret.name).join(", ")}`,
           code: "400",
         });
       }
@@ -99,6 +105,13 @@ export const projectSecretsRoutes = new Elysia({ prefix: "/v1/projects" })
       const names = (body as Array<string | { name: string }>).map((item) =>
         typeof item === "string" ? item : item.name,
       );
+      const reserved = names.filter(isSystemManagedProjectSecretName);
+      if (reserved.length > 0) {
+        return status(400, {
+          message: `System-managed secrets cannot be deleted: ${reserved.join(", ")}`,
+          code: "400",
+        });
+      }
       const results = await Promise.all(
         names.map((name) => projectService.deleteSecret(params.ref, name)),
       );
@@ -121,6 +134,12 @@ export const projectSecretsRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
+      if (isSystemManagedProjectSecretName(params.name)) {
+        return status(400, {
+          message: "System-managed secrets cannot be deleted",
+          code: "400",
+        });
+      }
       const success = await projectService.deleteSecret(params.ref, params.name);
       if (!success) {
         return status(500, { message: "Failed to delete secret", code: "500" });

--- a/packages/management-api/src/utils/project-secret-visibility.ts
+++ b/packages/management-api/src/utils/project-secret-visibility.ts
@@ -1,0 +1,32 @@
+const SYSTEM_MANAGED_SECRET_NAMES = new Set([
+  "JWT_SECRET",
+  "JWT_KEYS",
+  "JWT_JWKS",
+  "X_PROJECT_REF",
+  "WECHAT_MINIPROGRAM_APP_ID",
+  "WECHAT_MINIPROGRAM_APP_SECRET",
+  "WECHAT_MP_APP_ID",
+  "WECHAT_MP_APP_SECRET",
+  "WECHAT_MP_REDIRECT_URI",
+]);
+
+const SYSTEM_MANAGED_SECRET_PREFIXES = [
+  "ADMIN_SSO_",
+  "SUPABASE_",
+  "SUPACLOUD_",
+  "SUPAOAUTH_",
+] as const;
+
+export function isSystemManagedProjectSecretName(name: string): boolean {
+  const normalized = name.trim().toUpperCase();
+  return SYSTEM_MANAGED_SECRET_NAMES.has(normalized)
+    || SYSTEM_MANAGED_SECRET_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+export function isUserManagedProjectSecretName(name: string): boolean {
+  return !isSystemManagedProjectSecretName(name);
+}
+
+export function isUserManagedFunctionSecretName(name: string): boolean {
+  return name.trim().toUpperCase().startsWith("EDGEFN_");
+}

--- a/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
@@ -737,6 +737,78 @@ describe("SupAuth auth config boundary", () => {
     });
   });
 
+  test("project settings expose only public asymmetric JWK material", async () => {
+    config.authRuntimeOwnerRef = "";
+    projectService.getProjectSettings = async () => ({
+      auth: {
+        jwt_secret: "stored-jwt-secret",
+        oauth_server: {
+          enabled: true,
+          jwt_keys: [{
+            kty: "EC",
+            crv: "P-256",
+            x: "public-x",
+            y: "public-y",
+            d: "private-d",
+            kid: "ec-key",
+            alg: "ES256",
+            use: "sig",
+            key_ops: ["sign"],
+          }],
+          jwt_jwks: {
+            keys: [
+              {
+                kty: "EC",
+                crv: "P-256",
+                x: "public-x",
+                y: "public-y",
+                kid: "ec-key",
+                alg: "ES256",
+                use: "sig",
+              },
+              {
+                kty: "oct",
+                k: "symmetric-signing-secret",
+                kid: "legacy-key",
+                alg: "HS256",
+                use: "sig",
+              },
+            ],
+          },
+        },
+      },
+      api_domain: "tenant-a.api.example.com",
+    } as never);
+
+    const response = await request("/v1/projects/tenant-a/settings");
+    const body = await response.json();
+    const serialized = JSON.stringify(body);
+
+    expect(response.status).toBe(200);
+    expect(serialized).not.toContain("stored-jwt-secret");
+    expect(serialized).not.toContain("private-d");
+    expect(serialized).not.toContain("symmetric-signing-secret");
+    expect(body.auth.jwt_secret).toBe("********");
+    expect(body.auth.oauth_server.jwt_keys).toEqual([{
+      kty: "EC",
+      crv: "P-256",
+      x: "public-x",
+      y: "public-y",
+      kid: "ec-key",
+      alg: "ES256",
+      use: "sig",
+    }]);
+    expect(body.auth.oauth_server.jwt_jwks.keys).toEqual([{
+      kty: "EC",
+      crv: "P-256",
+      x: "public-x",
+      y: "public-y",
+      kid: "ec-key",
+      alg: "ES256",
+      use: "sig",
+    }]);
+  });
+
   test("shared settings alias hides auth config and rejects auth writes", async () => {
     config.authRuntimeOwnerRef = "auth-owner";
     projectService.getProjectSettings = async () => ({

--- a/packages/management-api/tests/unit/final-security-regression.test.ts
+++ b/packages/management-api/tests/unit/final-security-regression.test.ts
@@ -53,6 +53,8 @@ describe("final security regressions", () => {
   test("function secrets GET requires auth and never reveals values", async () => {
     const getSecretsSpy = spyOn(projectService, "getSecrets").mockResolvedValue([
       { name: "EDGEFN_SECRET", value: "plain-secret" },
+      { name: "SUPACLOUD_INTERNAL_TOKEN", value: "internal-secret" },
+      { name: "JWT_SECRET", value: "jwt-secret" },
     ] as Awaited<ReturnType<typeof projectService.getSecrets>>);
     const request = appWith(projectFunctionsRoutes);
 
@@ -79,6 +81,9 @@ describe("final security regressions", () => {
   test("project secrets never reveal values outside the internal runtime endpoint", async () => {
     const getSecretsSpy = spyOn(projectService, "getSecrets").mockResolvedValue([
       { name: "CAPTCHA_SECRET", value: "plain-secret" },
+      { name: "SUPACLOUD_INTERNAL_TOKEN", value: "internal-secret" },
+      { name: "ADMIN_SSO_CLIENT_ID", value: "internal-client" },
+      { name: "JWT_SECRET", value: "jwt-secret" },
     ] as Awaited<ReturnType<typeof projectService.getSecrets>>);
     const request = appWith(projectSecretsRoutes);
 
@@ -92,6 +97,38 @@ describe("final security regressions", () => {
       ]);
     } finally {
       getSecretsSpy.mockRestore();
+    }
+  });
+
+  test("project secret writes cannot overwrite or delete system-managed names", async () => {
+    const upsertSecretsSpy = spyOn(projectService, "upsertSecrets").mockResolvedValue(true);
+    const deleteSecretSpy = spyOn(projectService, "deleteSecret").mockResolvedValue(true);
+    const request = appWith(projectSecretsRoutes);
+
+    try {
+      const writeResponse = await request("/v1/projects/proj_1/secrets", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify([{ name: "SUPACLOUD_INTERNAL_TOKEN", value: "replacement" }]),
+      });
+      const bulkDeleteResponse = await request("/v1/projects/proj_1/secrets", {
+        method: "DELETE",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(["JWT_SECRET"]),
+      });
+      const singleDeleteResponse = await request("/v1/projects/proj_1/secrets/JWT_SECRET", {
+        method: "DELETE",
+        headers: masterHeaders,
+      });
+
+      expect(writeResponse.status).toBe(400);
+      expect(bulkDeleteResponse.status).toBe(400);
+      expect(singleDeleteResponse.status).toBe(400);
+      expect(upsertSecretsSpy).not.toHaveBeenCalled();
+      expect(deleteSecretSpy).not.toHaveBeenCalled();
+    } finally {
+      upsertSecretsSpy.mockRestore();
+      deleteSecretSpy.mockRestore();
     }
   });
 

--- a/packages/web-console/src/lib/api.test.ts
+++ b/packages/web-console/src/lib/api.test.ts
@@ -3,10 +3,16 @@ import { readFileSync } from "node:fs";
 import { apiClient, getStudioSession, loginStudio, logoutStudio } from "./api";
 
 const originalFetch = globalThis.fetch;
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
 
 describe("apiClient", () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "window");
+    }
   });
 
   test("normalizes empty error responses to JSON", async () => {
@@ -50,7 +56,11 @@ describe("apiClient", () => {
     const calls: Array<{ input: string; init?: RequestInit }> = [];
     const responses = [
       new Response(JSON.stringify({ success: true, username: "admin" }), { status: 200 }),
-      new Response(JSON.stringify({ valid: true, username: "admin" }), { status: 200 }),
+      new Response(JSON.stringify({
+        valid: true,
+        username: "admin",
+        expires_at: "2026-07-24T03:00:00.000Z",
+      }), { status: 200 }),
       new Response(JSON.stringify({ success: true }), { status: 200 }),
     ];
     globalThis.fetch = async (input, init) => {
@@ -63,7 +73,11 @@ describe("apiClient", () => {
     const logout = await logoutStudio();
 
     expect(login).toEqual({ success: true, username: "admin" });
-    expect(session).toEqual({ authenticated: true, username: "admin" });
+    expect(session).toEqual({
+      authenticated: true,
+      username: "admin",
+      expiresAt: "2026-07-24T03:00:00.000Z",
+    });
     expect(logout).toBe(true);
     expect(calls.map(call => [call.input, call.init?.method, call.init?.credentials])).toEqual([
       ["/auth/login", "POST", "include"],
@@ -71,6 +85,155 @@ describe("apiClient", () => {
       ["/auth/logout", "POST", "include"],
     ]);
     expect(JSON.stringify(login)).not.toContain("token");
+  });
+
+  test("preserves a managed API 401 when the cookie session remains valid", async () => {
+    const location = {
+      pathname: "/project/proj_1",
+      href: "https://console.example.com/project/proj_1",
+    };
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location },
+    });
+    const calls: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url === "/auth/session") {
+        return Response.json({ valid: true, username: "admin" });
+      }
+      return Response.json({ message: "Unauthorized" }, { status: 401 });
+    };
+
+    const response = await apiClient("/v1/projects");
+
+    expect(response.status).toBe(401);
+    expect(location.href).toBe("https://console.example.com/project/proj_1");
+    expect(calls).toEqual(["/v1/projects", "/auth/session"]);
+  });
+
+  test("refreshes an expiring Studio session once before a managed API request", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: { pathname: "/project/proj_1", href: "https://console.example.com/project/proj_1" } },
+    });
+    const calls: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url === "/auth/session") {
+        return new Response(JSON.stringify({
+          valid: true,
+          username: "admin",
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (url === "/auth/refresh") {
+        return new Response(JSON.stringify({
+          success: true,
+          username: "admin",
+          expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
+        }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+    };
+
+    await getStudioSession();
+    const response = await apiClient("/v1/projects");
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["/auth/session", "/auth/refresh", "/v1/projects"]);
+  });
+
+  test("shares one refresh across concurrent managed API requests", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: { pathname: "/project/proj_1", href: "https://console.example.com/project/proj_1" } },
+    });
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const calls: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url === "/auth/session") {
+        return Response.json({
+          valid: true,
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+        });
+      }
+      if (url === "/auth/refresh") {
+        await refreshGate;
+        return Response.json({
+          success: true,
+          expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
+        });
+      }
+      return Response.json({ ok: true });
+    };
+
+    await getStudioSession();
+    const requests = Promise.all([
+      apiClient("/v1/projects/first"),
+      apiClient("/v1/projects/second"),
+    ]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls.filter((url) => url === "/auth/refresh")).toHaveLength(1);
+    releaseRefresh();
+    const responses = await requests;
+    expect(responses.every((response) => response.ok)).toBe(true);
+  });
+
+  test("continues the managed request when session refresh hits a network error", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: { pathname: "/project/proj_1", href: "https://console.example.com/project/proj_1" } },
+    });
+    const calls: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url === "/auth/session") {
+        return Response.json({
+          valid: true,
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+        });
+      }
+      if (url === "/auth/refresh") throw new TypeError("network unavailable");
+      return Response.json({ ok: true });
+    };
+
+    await getStudioSession();
+    const response = await apiClient("/v1/projects");
+
+    expect(response.status).toBe(200);
+    expect(calls).toEqual(["/auth/session", "/auth/refresh", "/v1/projects"]);
+  });
+
+  test("does not hide unexpected session refresh errors", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: { pathname: "/project/proj_1", href: "https://console.example.com/project/proj_1" } },
+    });
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url === "/auth/session") {
+        return Response.json({
+          valid: true,
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+        });
+      }
+      throw new Error("unexpected refresh failure");
+    };
+
+    await getStudioSession();
+
+    await expect(apiClient("/v1/projects")).rejects.toThrow("unexpected refresh failure");
   });
 
   test("Studio browser code never persists or forwards the session token", () => {

--- a/packages/web-console/src/lib/api.ts
+++ b/packages/web-console/src/lib/api.ts
@@ -5,6 +5,9 @@
  */
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 15000;
+const SESSION_REFRESH_WINDOW_MS = 2 * 60 * 1000;
+let studioSessionExpiresAtMs = 0;
+let studioSessionRefreshPromise: Promise<StudioSessionState> | null = null;
 
 export type StudioLoginResult =
   | { success: true; username?: string }
@@ -13,6 +16,7 @@ export type StudioLoginResult =
 export interface StudioSessionState {
   authenticated: boolean;
   username?: string;
+  expiresAt?: string;
 }
 
 async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
@@ -20,6 +24,18 @@ async function readJsonObject(response: Response): Promise<Record<string, unknow
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {};
+}
+
+function rememberStudioSessionExpiry(candidate: unknown): string | undefined {
+  if (typeof candidate !== "string") return undefined;
+  const timestamp = Date.parse(candidate);
+  if (!Number.isFinite(timestamp)) return undefined;
+  studioSessionExpiresAtMs = timestamp;
+  return candidate;
+}
+
+function clearStudioSessionExpiry(): void {
+  studioSessionExpiresAtMs = 0;
 }
 
 export async function loginStudio(username: string, password: string): Promise<StudioLoginResult> {
@@ -31,6 +47,7 @@ export async function loginStudio(username: string, password: string): Promise<S
   });
   const data = await readJsonObject(response);
   if (response.ok && data.success === true) {
+    rememberStudioSessionExpiry(data.expires_at);
     return {
       success: true,
       ...(typeof data.username === "string" ? { username: data.username } : {}),
@@ -52,9 +69,29 @@ export async function getStudioSession(): Promise<StudioSessionState> {
   });
   const data = await readJsonObject(response);
   const authenticated = response.ok && (data.valid === true || data.authenticated === true);
+  const expiresAt = authenticated ? rememberStudioSessionExpiry(data.expires_at) : undefined;
+  if (!authenticated) clearStudioSessionExpiry();
   return {
     authenticated,
     ...(authenticated && typeof data.username === "string" ? { username: data.username } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+  };
+}
+
+export async function refreshStudioSession(): Promise<StudioSessionState> {
+  const response = await fetch("/auth/refresh", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Accept": "application/json" },
+  });
+  const data = await readJsonObject(response);
+  const authenticated = response.ok && data.success === true;
+  const expiresAt = authenticated ? rememberStudioSessionExpiry(data.expires_at) : undefined;
+  if (!authenticated) clearStudioSessionExpiry();
+  return {
+    authenticated,
+    ...(authenticated && typeof data.username === "string" ? { username: data.username } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
   };
 }
 
@@ -64,7 +101,30 @@ export async function logoutStudio(): Promise<boolean> {
     credentials: "include",
     headers: { "Accept": "application/json" },
   });
+  clearStudioSessionExpiry();
   return response.ok;
+}
+
+async function refreshExpiringStudioSession(): Promise<void> {
+  if (
+    typeof window === "undefined"
+    || studioSessionExpiresAtMs === 0
+    || studioSessionExpiresAtMs - Date.now() > SESSION_REFRESH_WINDOW_MS
+  ) {
+    return;
+  }
+
+  const refreshPromise = studioSessionRefreshPromise ??= refreshStudioSession();
+  try {
+    await refreshPromise;
+  } catch (error) {
+    if (!(error instanceof TypeError)) throw error;
+    // 网络瞬断不应直接触发登出；原请求与后续 401 会话校验仍是最终依据。
+  } finally {
+    if (studioSessionRefreshPromise === refreshPromise) {
+      studioSessionRefreshPromise = null;
+    }
+  }
 }
 
 function mergeAbortSignals(signals: Array<AbortSignal | null | undefined>): AbortSignal | undefined {
@@ -108,6 +168,7 @@ async function normalizeErrorResponse(response: Response): Promise<Response> {
 }
 
 export async function apiClient(url: string, options: RequestInit = {}): Promise<Response> {
+  await refreshExpiringStudioSession();
   const headers = new Headers(options.headers || {});
   
   // Set default Content-Type for JSON requests if body is stringified JSON

--- a/packages/web-console/src/routes/project/[ref]/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/+page.svelte
@@ -274,19 +274,6 @@
       <Loader2 size={32} class="animate-spin text-brand opacity-50" />
     </div>
   {:else}
-    <!-- Quick Access Cards -->
-    <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3">
-      {#each QUICK_LINKS as link (link.route)}
-        {@const Icon = link.icon}
-        <a href={resolve(link.route, { ref: projectRef })} class="group flex flex-col items-center justify-center gap-3 p-4 rounded-xl border bg-card hover:border-brand/40 hover:shadow-sm transition-all text-center">
-          <div class={`w-10 h-10 rounded-xl flex items-center justify-center border transition-transform group-hover:scale-110 ${link.color}`}>
-            <Icon size={18} />
-          </div>
-          <span class="text-xs font-semibold text-muted-foreground group-hover:text-foreground transition-colors">{link.name}</span>
-        </a>
-      {/each}
-    </div>
-
     <!-- Stats Cards -->
     <div class="grid gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
       <div class="rounded-xl border bg-card p-5 shadow-sm hover:shadow-md transition-shadow">

--- a/packages/web-console/src/routes/project/[ref]/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/page.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const pageSource = readFileSync(new URL("./+page.svelte", import.meta.url), "utf8");
+
+describe("project dashboard", () => {
+  test("renders the project quick links in exactly one section", () => {
+    expect(pageSource.match(/\{#each QUICK_LINKS/g) ?? []).toHaveLength(1);
+    expect(pageSource).toContain("<!-- Quick Links -->");
+    expect(pageSource).not.toContain("<!-- Quick Access Cards -->");
+  });
+});


### PR DESCRIPTION
## What changed

- sanitize project settings so only public asymmetric JWK fields are returned
- hide system-managed project and function secret names and protect them from public mutation routes
- refresh expiring Studio cookie sessions with concurrent-request deduplication while preserving business 401 responses
- remove the duplicated project dashboard quick-link section

## Root cause

Project settings returned stored signing-key structures without a public-key projection, secret list routes shared internal and user-managed namespaces, Studio requests had no proactive refresh window, and the project dashboard rendered the same quick-link collection twice.

## Validation

- Management API targeted security tests: 32 passed
- Management API `tsc --noEmit`: passed
- Web Console targeted tests: 10 passed
- `svelte-check`: 0 errors and 0 warnings
- Web Console production build: passed
- staged `git diff --check`: passed
- independent high-risk security review: PASS
- independent session/UI review: PASS

## Scope

This PR contains exactly the 11 implementation and regression-test files for the reported CNB issues. It excludes the concurrent Web Console redesign, package metadata, lockfiles, Vite configuration, Playwright artifacts, deployment changes, TLS production configuration, and secret rotation.

Related CNB issues: [#1](https://cnb.cool/aizhuliren/xgic/supacloud/-/issues/1), [#3](https://cnb.cool/aizhuliren/xgic/supacloud/-/issues/3), [#4](https://cnb.cool/aizhuliren/xgic/supacloud/-/issues/4), [#5](https://cnb.cool/aizhuliren/xgic/supacloud/-/issues/5).
