### PR TITLE
fix(storage): add Studio bucket creation route

### DIFF
--- a/packages/management-api/src/routes/storage.ts
+++ b/packages/management-api/src/routes/storage.ts
@@ -7,6 +7,19 @@ import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth"
 
 const ErrorResponse = t.Object({ message: t.String() });
 const SuccessResponse = t.Object({ success: t.Boolean(), message: t.String() });
+const StorageBucketCreateBody = t.Object({
+    name: t.String(),
+    id: t.Optional(t.String()),
+    public: t.Optional(t.Boolean()),
+    file_size_limit: t.Optional(t.Number()),
+    allowed_mime_types: t.Optional(t.Array(t.String())),
+});
+
+type StorageBucketCreateInput = {
+    name: string;
+    id?: string;
+    public?: boolean;
+};
 
 // ── Imaginary Config ──────────────────────────────────────────────
 const IMAGINARY_URL = config.imaginaryUrl;
@@ -41,6 +54,12 @@ function buildSourceUrl(bucket: string, path: string): string {
     return `${base}/${encodeURIComponent(bucket)}/${normalizedPath.split("/").map(encodeURIComponent).join("/")}`;
 }
 
+async function createStorageBucket(ref: string, input: StorageBucketCreateInput) {
+    const bucketName = input.name || input.id || "";
+    const storageResult = await StorageService.createBucket(ref, bucketName);
+    return { bucketName, storageResult };
+}
+
 // ── Storage Routes ────────────────────────────────────────────────
 export const storageRoutes = new Elysia({ prefix: "/v1/storage" })
     .get('/status', async () => {
@@ -51,6 +70,19 @@ export const storageRoutes = new Elysia({ prefix: "/v1/storage" })
         if (authError) return status(authError.status, authError.body);
         return await StorageService.listBuckets(params.ref);
     }, { detail: { tags: ["storage"], summary: "List storage buckets for a project" } })
+    .post('/:ref/buckets', async ({ params, body, set, request }) => {
+        const authError = await requireProjectOrAdminAuth(request, params.ref);
+        if (authError) return status(authError.status, authError.body);
+        const { bucketName, storageResult } = await createStorageBucket(params.ref, body);
+        if (!storageResult.success) {
+            set.status = 500;
+            return { message: storageResult.error || "Failed to create bucket", code: "500" };
+        }
+        return { id: bucketName, name: bucketName, public: body.public || false };
+    }, {
+        body: StorageBucketCreateBody,
+        detail: { tags: ["storage"], summary: "Create a storage bucket for a project" },
+    })
     .get('/:ref/buckets/:name/files', async ({ params, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
@@ -425,21 +457,14 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
     .post('/buckets', async ({ params, body, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
-        const bucketName = (body as Record<string, unknown>).name as string || (body as Record<string, unknown>).id as string;
-        const result = await StorageService.createBucket(params.ref, bucketName);
-        if (!result.success) {
+        const { bucketName, storageResult } = await createStorageBucket(params.ref, body);
+        if (!storageResult.success) {
             set.status = 500;
-            return { message: result.error || "Failed to create bucket", code: "500" };
+            return { message: storageResult.error || "Failed to create bucket", code: "500" };
         }
-        return { id: bucketName, name: bucketName, public: (body as Record<string, unknown>).public || false };
+        return { id: bucketName, name: bucketName, public: body.public || false };
     }, {
-        body: t.Object({
-            name: t.String(),
-            id: t.Optional(t.String()),
-            public: t.Optional(t.Boolean()),
-            file_size_limit: t.Optional(t.Number()),
-            allowed_mime_types: t.Optional(t.Array(t.String())),
-        }),
+        body: StorageBucketCreateBody,
         detail: { tags: ["storage"], summary: "Create a storage bucket" },
     })
     .get('/buckets/:id', async ({ params, set, request }) => {

--- a/packages/management-api/tests/unit/storage-routes.test.ts
+++ b/packages/management-api/tests/unit/storage-routes.test.ts
@@ -12,6 +12,49 @@ function request(path: string, init?: RequestInit) {
 }
 
 describe("storage management routes", () => {
+  test("Studio bucket creation requires auth and creates the requested bucket", async () => {
+    const createBucketSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
+
+    try {
+      const createRequest = {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "studio-assets", public: false, file_size_limit: 1024 }),
+      };
+      const unauthenticated = await request("/v1/storage/test-ref/buckets", createRequest);
+      expect(unauthenticated.status).toBe(401);
+
+      const authorized = await request("/v1/storage/test-ref/buckets", {
+        ...createRequest,
+        headers: { ...createRequest.headers, Authorization: "Bearer dev-master-token" },
+      });
+      expect(authorized.status).toBe(200);
+      expect(await authorized.json()).toEqual({ id: "studio-assets", name: "studio-assets", public: false });
+      expect(createBucketSpy).toHaveBeenCalledWith("test-ref", "studio-assets");
+    } finally {
+      createBucketSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket creation preserves storage failures", async () => {
+    const createBucketSpy = spyOn(StorageService, "createBucket").mockResolvedValue({
+      success: false,
+      error: "storage unavailable",
+    });
+
+    try {
+      const response = await request("/v1/storage/test-ref/buckets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify({ name: "studio-assets" }),
+      });
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ message: "storage unavailable", code: "500" });
+    } finally {
+      createBucketSpy.mockRestore();
+    }
+  });
+
   test("management upload accepts zero-byte files and honors explicit path", async () => {
     const uploadSpy = spyOn(StorageService, "uploadFile").mockResolvedValue(true);
     const formData = new FormData();


### PR DESCRIPTION
## Summary
- add the missing `POST /v1/storage/:ref/buckets` endpoint used by Studio
- reuse the existing project bucket creation contract so request validation and storage-failure behavior do not drift
- cover unauthorized, successful, and storage-failure requests at the exact Studio API path

## Verification
- `bun test tests/unit/storage-routes.test.ts tests/unit/storage-s3.routes.test.ts`
- `bun run typecheck`
- `bun run sql:check`
- `bun run test:unit`

Resolves the missing create endpoint reported in [CNB issue #8](https://cnb.cool/aizhuliren/xgic/supacloud/-/issues/8).