### PR TITLE
fix(console): make extension table header opaque

### DIFF
--- a/packages/web-console/src/routes/platform/extensions/+page.svelte
+++ b/packages/web-console/src/routes/platform/extensions/+page.svelte
@@ -157,7 +157,7 @@
     {:else}
       <div class="overflow-auto max-h-96">
         <table class="w-full text-left text-xs">
-          <thead class="bg-muted/30 border-b sticky top-0 z-10">
+          <thead class="bg-muted border-b sticky top-0 z-10">
             <tr>
               <th class="px-4 py-2.5 font-semibold text-muted-foreground">{$t("PlatformExtensions.package")}</th>
               <th class="px-3 py-2.5 font-semibold text-muted-foreground">{$t("PlatformExtensions.version")}</th>


### PR DESCRIPTION
## Summary
- give the sticky system-extension table header an opaque background
- prevent scrolled rows from showing through header labels

## Validation
- `bun run check`
- `bun run build`