### PR TITLE
fix(management-api): list quoted table identifiers safely (#6)

### DIFF
--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -468,6 +468,22 @@ function normalizePagination(
   return { limit, page, skip };
 }
 
+function tableListErrorDetails(error: unknown) {
+  const candidate = error && typeof error === "object"
+    ? error as { code?: unknown; message?: unknown }
+    : {};
+  const rawCode = typeof candidate.code === "string" ? candidate.code : "unknown";
+  const errorCode = /^[A-Za-z0-9_-]{1,64}$/.test(rawCode) ? rawCode : "unknown";
+  const rawMessage = typeof candidate.message === "string" ? candidate.message : "Unknown database error";
+  const errorMessage = rawMessage
+    .replace(/(postgres(?:ql)?:\/\/)([^@\s]+)@/gi, "$1[REDACTED]@")
+    .replace(/\b(password|passwd|secret|token|api[_-]?key)\s*=\s*\S+/gi, "$1=[REDACTED]")
+    .replace(/\s+/g, " ")
+    .slice(0, 512);
+
+  return { errorCode, errorMessage };
+}
+
 export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" })
     .get(
         "/tables",
@@ -490,31 +506,31 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
                     set.status = 404;
                     return { message: "Project database credentials not found", code: "404", status: 404 };
                 }
-                let rows: any[];
-                if (search) {
-                    rows = await projectDb`
-                        SELECT table_name, table_schema, table_type,
-                        (SELECT reltuples::bigint FROM pg_class WHERE oid = ('"'||table_schema||'"."'||table_name||'"')::regclass) as row_estimate
-                        FROM information_schema.tables
-                        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
-                        AND table_name ILIKE ${'%' + search + '%'}
-                        ORDER BY table_name
-                    `;
-                } else {
-                    rows = await projectDb`
-                        SELECT table_name, table_schema, table_type,
-                        (SELECT reltuples::bigint FROM pg_class WHERE oid = ('"'||table_schema||'"."'||table_name||'"')::regclass) as row_estimate
-                        FROM information_schema.tables
-                        WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
-                        ORDER BY table_name
-                    `;
-                }
+                const rows = await projectDb`
+                    SELECT
+                      c.relname AS table_name,
+                      n.nspname AS table_schema,
+                      'BASE TABLE' AS table_type,
+                      c.reltuples::bigint AS row_estimate
+                    FROM pg_class AS c
+                    JOIN pg_namespace AS n ON n.oid = c.relnamespace
+                    WHERE n.nspname = 'public'
+                      AND c.relkind IN ('r', 'p')
+                      AND c.relname ILIKE ${'%' + search + '%'}
+                    ORDER BY c.relname
+                `;
 
                 return {
                     data: rows.slice(skip, skip + limit),
                     total: rows.length
                 };
             } catch (error: unknown) {
+                const { errorCode, errorMessage } = tableListErrorDetails(error);
+                logger.error("[database] failed to list tables", {
+                    projectRef: params.ref,
+                    errorCode,
+                    errorMessage,
+                });
                 set.status = 500;
                 return {
                     message: "Failed to list tables",

--- a/packages/management-api/tests/unit/database-tables.routes.test.ts
+++ b/packages/management-api/tests/unit/database-tables.routes.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+
+type QueryCall = { text: string; values: unknown[] };
+
+const tableQueries: QueryCall[] = [];
+let tableRows: Array<Record<string, unknown>> = [];
+let tableQueryError: Error | null = null;
+
+const managementDb = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+  const text = strings.join("?");
+  if (text.includes("SELECT db_name, db_user, db_password")) {
+    return Promise.resolve([{ db_name: "tenant_db", db_user: "tenant_user", db_password: "test-password" }]);
+  }
+  return Promise.resolve([]);
+});
+
+const tenantDb = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+  tableQueries.push({ text: strings.join("?"), values });
+  if (tableQueryError) return Promise.reject(tableQueryError);
+  return Promise.resolve(tableRows);
+});
+
+const getProject = mock(async () => ({ ref: "proj_1" }));
+const requireProjectOrAdminAuth = mock(async () => undefined);
+const loggerError = mock(() => undefined);
+
+const actualDb = await import("../../src/db");
+mock.module("../../src/db", () => ({
+  ...actualDb,
+  sql: managementDb,
+  getProjectRoleDb: mock(() => tenantDb),
+}));
+mock.module("../../src/services", () => ({ projectService: { getProject } }));
+mock.module("../../src/middleware/auth", () => ({
+  requireAdminAuth: mock(async () => undefined),
+  requireProjectOrAdminAuth,
+}));
+mock.module("../../src/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: loggerError,
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { databaseRoutes } = await import(
+  new URL("../../src/routes/database.ts?database-tables-routes-test", import.meta.url).href,
+);
+const app = new Elysia().use(databaseRoutes);
+
+function request(query = "") {
+  return app.handle(new Request(`http://localhost/v1/projects/proj_1/database/tables${query}`));
+}
+
+describe("database table list route", () => {
+  beforeEach(() => {
+    tableQueries.length = 0;
+    tableRows = [];
+    tableQueryError = null;
+    managementDb.mockClear();
+    tenantDb.mockClear();
+    getProject.mockClear();
+    requireProjectOrAdminAuth.mockClear();
+    loggerError.mockClear();
+  });
+
+  test("lists quoted identifiers through catalogs without constructing a regclass name", async () => {
+    tableRows = [
+      { table_name: 'a"b', table_schema: "public", table_type: "BASE TABLE", row_estimate: 2 },
+      { table_name: "plain", table_schema: "public", table_type: "BASE TABLE", row_estimate: 5 },
+    ];
+
+    const response = await request("?_page=1&_limit=10");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: tableRows, total: 2 });
+    expect(tableQueries).toHaveLength(1);
+    expect(tableQueries[0]).toMatchObject({ values: ["%%"] });
+    expect(tableQueries[0]?.text).toContain("FROM pg_class AS c");
+    expect(tableQueries[0]?.text).toContain("JOIN pg_namespace AS n ON n.oid = c.relnamespace");
+    expect(tableQueries[0]?.text).toContain("c.reltuples::bigint AS row_estimate");
+    expect(tableQueries[0]?.text).not.toContain("::regclass");
+    expect(tableQueries[0]?.text).not.toContain("information_schema.tables");
+  });
+
+  test("uses the same catalog query when searching for a quoted identifier", async () => {
+    tableRows = [{ table_name: 'a"b', table_schema: "public", table_type: "BASE TABLE", row_estimate: 2 }];
+
+    const response = await request(`?q=${encodeURIComponent('a"b')}&_page=1&_limit=10`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: tableRows, total: 1 });
+    expect(tableQueries).toHaveLength(1);
+    expect(tableQueries[0]).toMatchObject({ values: ['%a"b%'] });
+    expect(tableQueries[0]?.text).toContain("FROM pg_class AS c");
+    expect(tableQueries[0]?.text).not.toContain("::regclass");
+  });
+
+  test("keeps the safe 500 response while logging redacted database details", async () => {
+    tableQueryError = Object.assign(new Error("connection failed password=super-secret"), { code: "08006" });
+
+    const response = await request();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      message: "Failed to list tables",
+      code: "500",
+      status: 500,
+    });
+    expect(loggerError).toHaveBeenCalledWith("[database] failed to list tables", {
+      projectRef: "proj_1",
+      errorCode: "08006",
+      errorMessage: "connection failed password=[REDACTED]",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- query table metadata directly from `pg_class` and `pg_namespace` instead of reconstructing a `regclass` identifier
- preserve one parameterized query for both searched and unsearched table lists
- retain the safe 500 response and add redacted diagnostic logging

## Tests
- `bun test tests/unit/database-tables.routes.test.ts`
- `bun test tests/unit/database-routes.test.ts`
- `bun run typecheck`
- `bun run test:unit`
- `git diff --check`

Fixes #6