### PR TITLE
fix(studio): restore Auth user management

### DIFF
--- a/packages/management-api/src/routes/auth-users.ts
+++ b/packages/management-api/src/routes/auth-users.ts
@@ -356,6 +356,71 @@ async function listGoTrueUserSessions(
   };
 }
 
+type AuthUserSearchRow = {
+  id: string;
+  aud: string | null;
+  role: string | null;
+  email: string | null;
+  phone: string | null;
+  raw_app_meta_data: Record<string, unknown> | null;
+  raw_user_meta_data: Record<string, unknown> | null;
+  created_at: Date | string;
+  last_sign_in_at: Date | string | null;
+  total_count: string | number;
+};
+
+type UserListPaginationQuery = {
+  skip?: string;
+  limit?: string;
+  page?: string;
+  per_page?: string;
+  _page?: string;
+  _limit?: string;
+};
+
+function userListPagination(query: UserListPaginationQuery) {
+  // Cases: missing/non-numeric values use defaults; zero/negative values start
+  // at page one; oversized pages are bounded before the tenant query runs.
+  const requestedLimit = Number.parseInt(query.per_page || query._limit || query.limit || "50", 10);
+  const limit = Math.min(100, Math.max(1, Number.isFinite(requestedLimit) ? requestedLimit : 50));
+  const requestedPage = Number.parseInt(query.page || query._page || "", 10);
+  const skip = Math.max(0, Number.parseInt(query.skip || "0", 10) || 0);
+  const fallbackPage = Math.floor(skip / limit) + 1;
+  return { limit, page: Math.max(1, Number.isFinite(requestedPage) ? requestedPage : fallbackPage) };
+}
+
+async function searchGoTrueUsers(ref: string, search: string, page: number, limit: number) {
+  const projectDb = getProjectDb(await resolveDbName(ref));
+  const offset = (page - 1) * limit;
+  const pattern = `%${search}%`;
+  const rows = await projectDb`
+    SELECT
+      user_record.id::text AS id,
+      user_record.aud::text AS aud,
+      user_record.role::text AS role,
+      user_record.email,
+      user_record.phone,
+      user_record.raw_app_meta_data,
+      user_record.raw_user_meta_data,
+      user_record.created_at,
+      user_record.last_sign_in_at,
+      COUNT(*) OVER() AS total_count
+    FROM auth.users AS user_record
+    WHERE user_record.email ILIKE ${pattern}
+       OR user_record.phone ILIKE ${pattern}
+       OR user_record.id::text ILIKE ${pattern}
+    ORDER BY user_record.created_at DESC, user_record.id DESC
+    LIMIT ${limit} OFFSET ${offset}
+  ` as AuthUserSearchRow[];
+
+  return {
+    users: rows.map(({ total_count: _totalCount, ...user }) => user),
+    total: rows.length > 0 ? Number(rows[0].total_count) : 0,
+    page,
+    per_page: limit,
+  };
+}
+
 /**
  * User Management routes — Admin API proxy to GoTrue
  */
@@ -372,14 +437,17 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
       }
       const { apiUrl, serviceRoleKey } = ctx;
 
-      const limit = Number(query.per_page || query._limit || query.limit || 50);
-      const page = Number(query.page || query._page || 1) || Math.floor(Number(query.skip || 0) / limit) + 1;
-      const q = query.q;
+      const { limit, page } = userListPagination(query);
+      // The generic data provider encodes the Auth page's email search as
+      // `email_like`, while GoTrue's Admin API has no search parameter. Search
+      // the tenant's authoritative auth.users relation instead of silently
+      // dropping the UI filter or pretending GoTrue supports `q`/`filter`.
+      const search = query.search || query.email_like;
+      if (search) return searchGoTrueUsers(params.ref, String(search), page, limit);
       
       const searchParams = new URLSearchParams();
       searchParams.set("page", String(page));
       searchParams.set("per_page", String(limit));
-      if (q) searchParams.set("q", String(q));
 
       const res = await gotrueFetch(`${apiUrl}/admin/users?${searchParams.toString()}`, {
         headers: {
@@ -401,26 +469,29 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
 
       const d = await res.json() as Record<string, unknown>;
       
-      if (Array.isArray(d)) {
-          const totalHeader = res.headers.get('x-total-count');
-          const linkHeader = res.headers.get('link');
-          let nextPage: number | null = null;
-          let lastPage: number | null = null;
-          if (linkHeader) {
-            const lastMatch = linkHeader.match(/page=(\d+)[^>]*>; rel="last"/);
-            const nextMatch = linkHeader.match(/page=(\d+)[^>]*>; rel="next"/);
-            if (lastMatch) lastPage = parseInt(lastMatch[1], 10);
-            if (nextMatch) nextPage = parseInt(nextMatch[1], 10);
-          }
-          return {
-              users: d,
-              aud: 'authenticated',
-              next_page: nextPage,
-              last_page: lastPage,
-              total: totalHeader ? Number(totalHeader) : d.length
-          };
+      const users = Array.isArray(d) ? d : d.users;
+      if (!Array.isArray(users)) return d;
+
+      const list = users as unknown[];
+      let nextPage: number | null = null;
+      let lastPage: number | null = null;
+      if (linkHeader) {
+        const lastMatch = linkHeader.match(/page=(\d+)[^>]*>; rel="last"/);
+        const nextMatch = linkHeader.match(/page=(\d+)[^>]*>; rel="next"/);
+        if (lastMatch) lastPage = Number.parseInt(lastMatch[1], 10);
+        if (nextMatch) nextPage = Number.parseInt(nextMatch[1], 10);
       }
-      return d;
+      const parsedTotal = totalHeader ? Number(totalHeader) : Number.NaN;
+
+      return {
+        ...(Array.isArray(d) ? { aud: "authenticated" } : d),
+        users: list,
+        next_page: nextPage,
+        last_page: lastPage,
+        // GoTrue exposes the count in a response header. Include it in the
+        // JSON envelope so the data provider can render pagination correctly.
+        total: Number.isFinite(parsedTotal) ? parsedTotal : list.length,
+      };
     },
     {
       params: t.Object({ ref: t.String() }),
@@ -433,6 +504,8 @@ export const userManagementRoutes = new Elysia({ prefix: "/v1/projects/:ref/auth
         _limit: t.Optional(t.String()),
         _sort: t.Optional(t.String()),
         _order: t.Optional(t.String()),
+        search: t.Optional(t.String()),
+        email_like: t.Optional(t.String()),
         q: t.Optional(t.String()),
       }, { additionalProperties: true }),
       detail: { tags: ["auth"], summary: "List users" },

--- a/packages/management-api/tests/unit/auth-users.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-users.routes.test.ts
@@ -43,8 +43,12 @@ const failUserDeletion = mock(() => Promise.resolve(true));
 const recordUserDeletionUncertainty = mock(() => Promise.resolve(true));
 
 let grantsTableAvailable = true;
+let authUserSearchRows: Array<Record<string, unknown>> = [];
 const tenantDb = mock((strings: TemplateStringsArray) => {
   const text = strings.join("?");
+  if (text.includes("COUNT(*) OVER()") && text.includes("FROM auth.users AS user_record")) {
+    return Promise.resolve(authUserSearchRows);
+  }
   if (text.includes("FROM auth.sessions AS session")) {
     return Promise.resolve([
       {
@@ -199,6 +203,18 @@ describe("userManagementRoutes", () => {
     userUpdateMethods.length = 0;
     userUpdateBodies.length = 0;
     grantsTableAvailable = true;
+    authUserSearchRows = [{
+      id: "user-one",
+      aud: "authenticated",
+      role: "authenticated",
+      email: "worker@example.test",
+      phone: null,
+      raw_app_meta_data: { provider: "email" },
+      raw_user_meta_data: {},
+      created_at: new Date("2026-07-26T00:00:00.000Z"),
+      last_sign_in_at: null,
+      total_count: "2",
+    }];
   });
 
   test("PATCH user updates proxy to GoTrue with PUT for compatibility", async () => {
@@ -286,6 +302,82 @@ describe("userManagementRoutes", () => {
 
     expect(res.status).toBe(400);
     expect(upstreamCalls).toBe(0);
+  });
+
+  test("searches auth.users for AutoTable email filters without forwarding unsupported GoTrue parameters", async () => {
+    let upstreamCalls = 0;
+    globalThis.fetch = mock(async () => {
+      upstreamCalls += 1;
+      return Response.json({ users: [] });
+    }) as unknown as typeof fetch;
+
+    const res = await request("/v1/projects/proj_1/auth/users?_page=1&_limit=1&email_like=worker");
+
+    expect(res.status).toBe(200);
+    expect(upstreamCalls).toBe(0);
+    const queryCall = tenantDb.mock.calls.find(([strings]) => strings.join("?").includes("FROM auth.users AS user_record"));
+    expect(queryCall?.slice(1)).toContain("%worker%");
+    expect(await res.json()).toEqual({
+      users: [{
+        id: "user-one",
+        aud: "authenticated",
+        role: "authenticated",
+        email: "worker@example.test",
+        phone: null,
+        raw_app_meta_data: { provider: "email" },
+        raw_user_meta_data: {},
+        created_at: "2026-07-26T00:00:00.000Z",
+        last_sign_in_at: null,
+      }],
+      total: 2,
+      page: 1,
+      per_page: 1,
+    });
+  });
+
+  test("returns an empty page when an Auth user search has no matches", async () => {
+    authUserSearchRows = [];
+    let upstreamCalls = 0;
+    globalThis.fetch = mock(async () => {
+      upstreamCalls += 1;
+      return Response.json({ users: [] });
+    }) as unknown as typeof fetch;
+
+    const res = await request("/v1/projects/proj_1/auth/users?_page=1&_limit=1&email_like=__no_match__");
+
+    expect(res.status).toBe(200);
+    expect(upstreamCalls).toBe(0);
+    expect(await res.json()).toEqual({ users: [], total: 0, page: 1, per_page: 1 });
+  });
+
+  test("bounds Auth user search pagination before querying the tenant database", async () => {
+    const res = await request("/v1/projects/proj_1/auth/users?_page=-5&_limit=0&email_like=worker");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ page: 1, per_page: 1 });
+  });
+
+  test("keeps GoTrue list totals in the JSON envelope for pagination", async () => {
+    globalThis.fetch = mock(async () => Response.json(
+      { users: [{ id: "user-one", email: "worker@example.test" }], aud: "authenticated" },
+      {
+        headers: {
+          "link": '</admin/users?page=2&per_page=1>; rel="next", </admin/users?page=2&per_page=1>; rel="last"',
+          "x-total-count": "2",
+        },
+      },
+    )) as unknown as typeof fetch;
+
+    const res = await request("/v1/projects/proj_1/auth/users?_page=1&_limit=1");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      users: [{ id: "user-one", email: "worker@example.test" }],
+      aud: "authenticated",
+      next_page: 2,
+      last_page: 2,
+      total: 2,
+    });
   });
 
   test("lists OAuth grants from GoTrue's authoritative tenant tables", async () => {

--- a/packages/web-console/src/lib/admin/resources.test.ts
+++ b/packages/web-console/src/lib/admin/resources.test.ts
@@ -19,4 +19,15 @@ describe("buildResourceRegistry", () => {
 
     expect(authResources).toHaveLength(1);
   });
+
+  test("keeps Auth user actions on the dedicated page instead of API-like routes", () => {
+    const [authUsers] = buildResourceRegistry(["alpha123"]).filter(
+      (resource) => resource.name === "v1/projects/alpha123/auth/users",
+    );
+
+    expect(authUsers).toMatchObject({
+      canCreate: false,
+      canEdit: false,
+    });
+  });
 });

--- a/packages/web-console/src/lib/admin/resources.ts
+++ b/packages/web-console/src/lib/admin/resources.ts
@@ -47,6 +47,10 @@ export const getTenantResources = (ref: string): ResourceDefinition[] => [
   {
     name: `v1/projects/${ref}/auth/users`,
     label: 'Users',
+    // The generic AutoTable routes actions to `/:id` and `/create`; this
+    // tenant API is intentionally handled by the dedicated Auth page instead.
+    canCreate: false,
+    canEdit: false,
     fields: [
       { key: 'id', label: 'UUID', type: 'text', showInForm: false },
       { key: 'email', label: 'Email', type: 'text', required: true, searchable: true },

--- a/packages/web-console/src/routes/project/[ref]/auth/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/+page.svelte
@@ -1,11 +1,103 @@
 <script lang="ts">
+  import { apiClient } from "$lib/api";
   import { page } from "$app/state";
-  import { AutoTable } from "@svadmin/ui";
+  import { AutoTable, Button } from "@svadmin/ui";
   import { t } from "svelte-i18n";
-  import { Mail } from "lucide-svelte";
-  import { Button } from "@svadmin/ui";
+  import { Mail, UserPlus } from "lucide-svelte";
+  import { createMutation } from "@tanstack/svelte-query";
+  import { toast } from "svelte-sonner";
 
   const projectRef = $derived(page.params.ref);
+  let tableVersion = $state(0);
+  let showInvite = $state(false);
+  let showCreateUser = $state(false);
+  let inviteEmail = $state("");
+  let newUserEmail = $state("");
+  let newUserPassword = $state("");
+  let confirmEmail = $state(true);
+
+  async function responseError(response: Response, fallback: string): Promise<string> {
+    const body: unknown = await response.json().catch(() => null);
+    if (body && typeof body === "object") {
+      const message = (body as Record<string, unknown>).message ?? (body as Record<string, unknown>).error;
+      if (typeof message === "string" && message.trim()) return message;
+    }
+    return fallback;
+  }
+
+  function refreshUsers() {
+    tableVersion += 1;
+  }
+
+  function closeInvite() {
+    showInvite = false;
+    inviteEmail = "";
+  }
+
+  function closeCreateUser() {
+    showCreateUser = false;
+    newUserEmail = "";
+    newUserPassword = "";
+    confirmEmail = true;
+  }
+
+  const inviteMutation = createMutation(() => ({
+    mutationFn: async () => {
+      const response = await apiClient(`/v1/projects/${projectRef}/auth/users/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteEmail.trim() }),
+      });
+      if (!response.ok) throw new Error(await responseError(response, "邀请用户失败"));
+    },
+    onSuccess: () => {
+      closeInvite();
+      refreshUsers();
+      toast.success("邀请已发送");
+    },
+    onError: (error: unknown) => {
+      toast.error(error instanceof Error ? error.message : "邀请用户失败");
+    },
+  }));
+
+  const createUserMutation = createMutation(() => ({
+    mutationFn: async () => {
+      const response = await apiClient(`/v1/projects/${projectRef}/auth/users`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: newUserEmail.trim(),
+          password: newUserPassword,
+          email_confirm: confirmEmail,
+        }),
+      });
+      if (!response.ok) throw new Error(await responseError(response, "新建用户失败"));
+    },
+    onSuccess: () => {
+      closeCreateUser();
+      refreshUsers();
+      toast.success("用户已创建");
+    },
+    onError: (error: unknown) => {
+      toast.error(error instanceof Error ? error.message : "新建用户失败");
+    },
+  }));
+
+  function inviteUser() {
+    if (!inviteEmail.trim()) {
+      toast.error("请输入邮箱地址");
+      return;
+    }
+    inviteMutation.mutate();
+  }
+
+  function createUser() {
+    if (!newUserEmail.trim() || !newUserPassword) {
+      toast.error("邮箱和密码均为必填项");
+      return;
+    }
+    createUserMutation.mutate();
+  }
 
   function getProviders(record: Record<string, unknown>): string[] {
     const rawApp = record.raw_app_meta_data as Record<string, unknown>;
@@ -25,7 +117,7 @@
   </div>
 
   <div class="flex-1 rounded-xl bg-background overflow-hidden relative min-h-[500px]">
-    {#key projectRef}
+    {#key `${projectRef}:${tableVersion}`}
       {#snippet emailRenderer({ value, record }: { value: any, record: any })}
         <div class="flex items-center gap-3">
           <div class="w-8 h-8 rounded-full bg-brand/10 text-brand flex items-center justify-center font-bold text-xs ring-1 ring-brand/20">
@@ -62,12 +154,92 @@
         columns={{ email: emailRenderer, role: roleRenderer, created_at: dateRenderer, last_sign_in_at: dateRenderer }}
       >
         {#snippet headerActions()}
-          <Button variant="outline" size="sm" class="gap-2 border-brand/20 text-brand hover:bg-brand/10">
+          <Button onclick={() => showCreateUser = true} size="sm" class="gap-2">
+            <UserPlus class="h-4 w-4" />
+            新建用户
+          </Button>
+          <Button onclick={() => showInvite = true} variant="outline" size="sm" class="gap-2 border-brand/20 text-brand hover:bg-brand/10">
             <Mail class="h-4 w-4" />
             {$t("Auth.invite_user") || "Invite"}
           </Button>
         {/snippet}
       </AutoTable>
     {/key}
+
+    {#if showInvite}
+      <div class="absolute inset-0 z-10 flex items-center justify-center bg-background/70 p-4 backdrop-blur-sm">
+        <form
+          class="w-full max-w-md rounded-xl border bg-card p-5 shadow-xl space-y-4"
+          onsubmit={(event) => { event.preventDefault(); inviteUser(); }}
+        >
+          <div>
+            <h2 class="text-base font-semibold">邀请用户</h2>
+            <p class="mt-1 text-xs text-muted-foreground">将向该邮箱发送注册邀请。</p>
+          </div>
+          <label class="block space-y-1.5">
+            <span class="text-xs font-medium">邮箱</span>
+            <input
+              bind:value={inviteEmail}
+              type="email"
+              autocomplete="email"
+              required
+              placeholder="user@example.com"
+              class="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-brand/40"
+            />
+          </label>
+          <div class="flex justify-end gap-2">
+            <Button type="button" variant="outline" onclick={closeInvite}>取消</Button>
+            <Button type="submit" disabled={inviteMutation.isPending}>
+              {inviteMutation.isPending ? "发送中…" : "发送邀请"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    {/if}
+
+    {#if showCreateUser}
+      <div class="absolute inset-0 z-10 flex items-center justify-center bg-background/70 p-4 backdrop-blur-sm">
+        <form
+          class="w-full max-w-md rounded-xl border bg-card p-5 shadow-xl space-y-4"
+          onsubmit={(event) => { event.preventDefault(); createUser(); }}
+        >
+          <div>
+            <h2 class="text-base font-semibold">新建用户</h2>
+            <p class="mt-1 text-xs text-muted-foreground">创建邮箱密码用户，可选择直接确认邮箱。</p>
+          </div>
+          <label class="block space-y-1.5">
+            <span class="text-xs font-medium">邮箱</span>
+            <input
+              bind:value={newUserEmail}
+              type="email"
+              autocomplete="email"
+              required
+              placeholder="user@example.com"
+              class="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-brand/40"
+            />
+          </label>
+          <label class="block space-y-1.5">
+            <span class="text-xs font-medium">密码</span>
+            <input
+              bind:value={newUserPassword}
+              type="password"
+              autocomplete="new-password"
+              required
+              class="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-brand/40"
+            />
+          </label>
+          <label class="flex items-center gap-2 text-xs text-muted-foreground">
+            <input bind:checked={confirmEmail} type="checkbox" />
+            直接确认邮箱
+          </label>
+          <div class="flex justify-end gap-2">
+            <Button type="button" variant="outline" onclick={closeCreateUser}>取消</Button>
+            <Button type="submit" disabled={createUserMutation.isPending}>
+              {createUserMutation.isPending ? "创建中…" : "创建用户"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    {/if}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add Studio forms for creating and inviting Auth users; refresh the list after either operation
- search tenant `auth.users` with a parameterized email/phone/UUID match instead of forwarding unsupported GoTrue query parameters
- include GoTrue `x-total-count` in the JSON list envelope so the table paginates correctly
- disable generic AutoTable create/edit routes for the dedicated Auth users screen

## Verification
- `bun test tests/unit/auth-users.routes.test.ts` (28 pass)
- `bun run typecheck` (management-api)
- `bun test src/lib/admin/resources.test.ts` (3 pass)
- `bun run check` (web-console, 0 errors / 0 warnings)
- `bun run build` (web-console)

Fixes #7