### PR TITLE
fix(monitoring): proxy Grafana before Studio fallback

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -31,7 +31,7 @@ import { resolveProjectApiKey } from "./utils/project-auth";
 import { translateRealtimeProxyCredentials } from "./utils/realtime-proxy-auth";
 import { recordRequestPeerAddress } from "./utils/client-ip";
 import { resolveWebConsoleDir } from "./utils/web-console-path";
-import { grafanaProxyRoutes } from "./routes/grafana";
+import { grafanaProxyRoutes, handleGrafanaRequest } from "./routes/grafana";
 import { closeTaskWebSocket, messageTaskWebSocket, openTaskWebSocket } from "./routes/ws";
 import { isS3DataPlaneRequest } from "./utils/storage-s3-paths";
 import { studioAuthRoutes } from "./routes/studio-auth";
@@ -558,6 +558,14 @@ export function registerStaticAssets() {
     const { request, set } = context;
     const url = new URL(request.url);
     const path = url.pathname === "/" ? "/index.html" : url.pathname;
+
+    // Grafana proxy must win over the SPA catch-all. Elysia resolves `get("*")`
+    // before plugin `.all("/grafana/*")` routes, so delegate Grafana GET requests
+    // here without registering a global onRequest hook (which would force body
+    // parsing on every request and break SDK proxy streaming bodies).
+    if (url.pathname === "/grafana" || url.pathname.startsWith("/grafana/")) {
+      return handleGrafanaRequest(request);
+    }
 
     // Do NOT catch API routes
     if (path.startsWith("/api/") || path.startsWith("/v1/")) {

--- a/packages/management-api/src/routes/grafana.ts
+++ b/packages/management-api/src/routes/grafana.ts
@@ -101,7 +101,15 @@ const handler = async ({ request, set }: { request: Request; set: { status?: num
   return proxyGrafana(request);
 };
 
+function isGrafanaRequest(request: Request): boolean {
+  const pathname = new URL(request.url).pathname;
+  return pathname === "/grafana" || pathname.startsWith("/grafana/");
+}
+
 export const grafanaProxyRoutes = new Elysia({ name: "grafana-proxy" })
+  // The Studio static-asset fallback is a GET wildcard, which takes precedence
+  // over plugin wildcard routes. Intercept Grafana before route resolution.
+  .onRequest((context) => isGrafanaRequest(context.request) ? handler(context) : undefined)
   .all("/grafana", handler, { detail: { tags: ["monitoring"], summary: "Proxy Grafana root" } })
   .all("/grafana/*", handler, { detail: { tags: ["monitoring"], summary: "Proxy Grafana assets and dashboards" } });
 

--- a/packages/management-api/src/routes/grafana.ts
+++ b/packages/management-api/src/routes/grafana.ts
@@ -101,15 +101,19 @@ const handler = async ({ request, set }: { request: Request; set: { status?: num
   return proxyGrafana(request);
 };
 
-function isGrafanaRequest(request: Request): boolean {
-  const pathname = new URL(request.url).pathname;
-  return pathname === "/grafana" || pathname.startsWith("/grafana/");
+// Handle a Grafana request from the SPA static-asset catch-all. The wildcard
+// `get("*")` in `registerStaticAssets` takes precedence over plugin routes in
+// Elysia, so Grafana GET requests must be delegated here instead of relying on
+// `.all("/grafana/*")` route matching.
+export async function handleGrafanaRequest(request: Request): Promise<Response> {
+  const authError = await checkAuth(request);
+  if (authError) {
+    return Response.json(authError.body, { status: authError.status });
+  }
+  return proxyGrafana(request);
 }
 
 export const grafanaProxyRoutes = new Elysia({ name: "grafana-proxy" })
-  // The Studio static-asset fallback is a GET wildcard, which takes precedence
-  // over plugin wildcard routes. Intercept Grafana before route resolution.
-  .onRequest((context) => isGrafanaRequest(context.request) ? handler(context) : undefined)
   .all("/grafana", handler, { detail: { tags: ["monitoring"], summary: "Proxy Grafana root" } })
   .all("/grafana/*", handler, { detail: { tags: ["monitoring"], summary: "Proxy Grafana assets and dashboards" } });
 

--- a/packages/management-api/tests/unit/grafana.routes.test.ts
+++ b/packages/management-api/tests/unit/grafana.routes.test.ts
@@ -4,6 +4,9 @@ import { config } from "../../src/config";
 import { grafanaProxyInternals, grafanaProxyRoutes } from "../../src/routes/grafana";
 
 const app = new Elysia().use(grafanaProxyRoutes);
+const appWithStaticFallback = new Elysia()
+  .use(grafanaProxyRoutes)
+  .get("*", () => new Response("studio"));
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
@@ -29,7 +32,7 @@ describe("grafana proxy routes", () => {
       });
     }) as unknown as typeof fetch;
 
-    const response = await app.handle(
+    const response = await appWithStaticFallback.handle(
       new Request("https://studio.example.com/grafana/api/search?query=pgsql", {
         headers: { authorization: `Bearer ${config.masterToken}` },
       }),

--- a/packages/management-api/tests/unit/grafana.routes.test.ts
+++ b/packages/management-api/tests/unit/grafana.routes.test.ts
@@ -1,12 +1,25 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { Elysia } from "elysia";
 import { config } from "../../src/config";
-import { grafanaProxyInternals, grafanaProxyRoutes } from "../../src/routes/grafana";
+import {
+  grafanaProxyInternals,
+  grafanaProxyRoutes,
+  handleGrafanaRequest,
+} from "../../src/routes/grafana";
 
 const app = new Elysia().use(grafanaProxyRoutes);
+// Mirror `registerStaticAssets`: the SPA catch-all is a GET wildcard that
+// takes precedence over plugin routes in Elysia, so Grafana requests are
+// delegated from the catch-all instead of relying on `.all` route matching.
 const appWithStaticFallback = new Elysia()
   .use(grafanaProxyRoutes)
-  .get("*", () => new Response("studio"));
+  .get("*", ({ request }) => {
+    const { pathname } = new URL(request.url);
+    if (pathname === "/grafana" || pathname.startsWith("/grafana/")) {
+      return handleGrafanaRequest(request);
+    }
+    return new Response("studio");
+  });
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
@@ -22,7 +35,7 @@ describe("grafana proxy routes", () => {
     expect(target.toString()).toBe("http://127.0.0.1:3000/d/pgsql-overview?orgId=1");
   });
 
-  test("proxies Grafana responses before the SPA catch-all can handle them", async () => {
+  test("proxies Grafana responses delegated from the SPA catch-all", async () => {
     const seen: string[] = [];
     globalThis.fetch = mock(async (input: string | URL | Request) => {
       seen.push(String(input));
@@ -50,7 +63,7 @@ describe("grafana proxy routes", () => {
       return new Response("unexpected upstream call");
     }) as unknown as typeof fetch;
 
-    const response = await app.handle(
+    const response = await appWithStaticFallback.handle(
       new Request("https://studio.example.com/grafana/api/search?query=pgsql"),
     );
 


### PR DESCRIPTION
Fixes #14

Studio static assets use a GET wildcard. Elysia resolves that wildcard before the Grafana plugin wildcard, so `/grafana/api/health` returned the Studio HTML instead of Grafana.

Intercept Grafana requests in the plugin before route resolution while retaining the declared proxy routes. Add a regression test with the SPA fallback composed into the app.

Validated with:
- `bun test tests/unit/grafana.routes.test.ts`
- `bun run typecheck`
- `git diff --check`