### PR TITLE
fix(edge-runtime): fairly schedule queued projects

### DIFF
--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -811,6 +811,52 @@ describe("WorkerPool metrics NaN fix", () => {
   });
 });
 
+describe("WorkerPool project fairness", () => {
+  test("serves a newly queued project before the same-project backlog", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-fair-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    const orderPath = join(projectRoot, "order.txt");
+    await Bun.write(orderPath, "");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch(request) {
+          const label = new URL(request.url).pathname.slice(1);
+          const previous = await Bun.file(process.env.ORDER_FILE).text();
+          await Bun.write(process.env.ORDER_FILE, previous + label + "\\n");
+          if (label === "a1") await Bun.sleep(100);
+          return new Response(label);
+        }
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const dispatch = (projectRef: string, label: string) => pool.dispatch({
+      functionId: `${projectRef}_fn`,
+      projectRef,
+      functionPath,
+      projectRoot,
+      env: { ORDER_FILE: orderPath },
+      request: new Request(`http://edge.local/${label}`),
+    });
+
+    try {
+      const first = dispatch("project-a", "a1");
+      await waitForMetric(pool, "active_workers", 1);
+      const queued = [
+        dispatch("project-a", "a2"),
+        dispatch("project-a", "a3"),
+        dispatch("project-b", "b1"),
+      ];
+      await Promise.all([first, ...queued]);
+      const order = (await Bun.file(orderPath).text()).trim().split("\n");
+      expect(order).toEqual(["a1", "b1", "a2", "a3"]);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("WorkerPool module cache", () => {
   function moduleLoadCounterSource(counterPath: string): string {
     return `

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -150,7 +150,11 @@ function resolveWorkerEntry(): string | URL {
 export class WorkerPool {
   private workers: Worker[] = [];
   private idle: Worker[] = [];
-  private queue: QueuedDispatch[] = [];
+  // Keep each project FIFO while rotating projects through the shared pool.
+  private queuedDispatches = new Map<string, QueuedDispatch[]>();
+  private queuedProjects: string[] = [];
+  private queuedCount = 0;
+  private lastDispatchedProjectRef: string | null = null;
   private inFlight = new Map<string, { cancel: () => void; cancelKey?: string }>();
   private totalRequests = 0;
   private totalInvalidations = 0;
@@ -251,7 +255,7 @@ export class WorkerPool {
   private enqueue(opts: ScheduledDispatch): Promise<Response> {
     const enqueuedAt = performance.now();
     return new Promise<Response>((resolve, reject) => {
-      if (this.queue.length >= MAX_QUEUE_SIZE) {
+      if (this.queuedCount >= MAX_QUEUE_SIZE) {
         resolve(new Response(JSON.stringify({ error: "Too many concurrent requests, please retry" }), {
           status: 503,
           headers: { "Content-Type": "application/json", "Retry-After": "5" },
@@ -261,12 +265,52 @@ export class WorkerPool {
 
       const worker = this.idle.pop();
       if (worker) {
+        this.lastDispatchedProjectRef = this.projectKey(opts);
         this.execute(worker, opts, enqueuedAt, resolve).catch(reject);
       } else {
         this.totalQueuedRequests++;
-        this.queue.push({ opts, enqueuedAt, resolve, reject });
+        this.enqueueQueued({ opts, enqueuedAt, resolve, reject });
       }
     });
+  }
+
+  private projectKey(opts: DispatchOptions): string {
+    return opts.projectRef ?? extractProjectRef(opts.functionId) ?? opts.functionId;
+  }
+
+  private enqueueQueued(entry: QueuedDispatch): void {
+    const projectRef = this.projectKey(entry.opts);
+    const projectQueue = this.queuedDispatches.get(projectRef);
+    if (projectQueue) {
+      projectQueue.push(entry);
+    } else {
+      this.queuedDispatches.set(projectRef, [entry]);
+      this.queuedProjects.push(projectRef);
+    }
+    this.queuedCount++;
+  }
+
+  private dequeueQueued(): QueuedDispatch | null {
+    if (this.queuedCount === 0) return null;
+
+    const preferredIndex = this.queuedProjects.findIndex(
+      (projectRef) => projectRef !== this.lastDispatchedProjectRef,
+    );
+    const projectIndex = preferredIndex >= 0 ? preferredIndex : 0;
+    const [projectRef] = this.queuedProjects.splice(projectIndex, 1);
+    const projectQueue = this.queuedDispatches.get(projectRef);
+    if (!projectQueue) throw new Error(`Missing dispatch queue for project ${projectRef}`);
+    const entry = projectQueue.shift();
+    if (!entry) throw new Error(`Empty dispatch queue for project ${projectRef}`);
+
+    this.queuedCount--;
+    if (projectQueue.length > 0) {
+      this.queuedProjects.push(projectRef);
+    } else {
+      this.queuedDispatches.delete(projectRef);
+    }
+    this.lastDispatchedProjectRef = projectRef;
+    return entry;
   }
 
   private async execute(
@@ -662,7 +706,7 @@ export class WorkerPool {
   }
 
   private schedule(worker: Worker) {
-    const next = this.queue.shift();
+    const next = this.dequeueQueued();
     if (!next) {
       this.idle.push(worker);
       return;
@@ -755,13 +799,17 @@ export class WorkerPool {
 
   private stopDispatching() {
     this.draining = true;
-    for (const entry of this.queue) {
-      entry.resolve(new Response(JSON.stringify({ error: "Server shutting down" }), {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      }));
+    for (const projectQueue of this.queuedDispatches.values()) {
+      for (const entry of projectQueue) {
+        entry.resolve(new Response(JSON.stringify({ error: "Server shutting down" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }));
+      }
     }
-    this.queue = [];
+    this.queuedDispatches.clear();
+    this.queuedProjects = [];
+    this.queuedCount = 0;
   }
 
   getMetrics(): string {
@@ -990,7 +1038,7 @@ export class WorkerPool {
       [`${prefix}_active_workers`]: this.config.size - this.idle.length,
       [`${prefix}_idle_workers`]: this.idle.length,
       [`${prefix}_worker_smol`]: this.config.smol ? 1 : 0,
-      [`${prefix}_queue_length`]: this.queue.length,
+      [`${prefix}_queue_length`]: this.queuedCount,
       [`${prefix}_total_requests`]: this.totalRequests,
       [`${prefix}_total_invalidations`]: this.totalInvalidations,
       [`${prefix}_tainted_workers`]: this.tainted.size,
@@ -1018,8 +1066,8 @@ export class WorkerPool {
   }
 
   cancel(cancelKey: string): boolean {
-    const queuedIndex = this.queue.findIndex((entry) => entry.opts.cancelKey === cancelKey);
-    if (queuedIndex >= 0) return this.cancelQueued(queuedIndex);
+    const queued = this.findQueued((entry) => entry.opts.cancelKey === cancelKey);
+    if (queued) return this.cancelQueued(queued.projectRef, queued.index);
 
     const inFlight = [...this.inFlight.values()]
       .find((execution) => execution.cancelKey === cancelKey);
@@ -1029,10 +1077,8 @@ export class WorkerPool {
   }
 
   private cancelExecution(executionKey: string): boolean {
-    const queuedIndex = this.queue.findIndex(
-      (entry) => entry.opts.executionKey === executionKey,
-    );
-    if (queuedIndex >= 0) return this.cancelQueued(queuedIndex);
+    const queued = this.findQueued((entry) => entry.opts.executionKey === executionKey);
+    if (queued) return this.cancelQueued(queued.projectRef, queued.index);
 
     const inFlight = this.inFlight.get(executionKey);
     if (!inFlight) return false;
@@ -1040,8 +1086,26 @@ export class WorkerPool {
     return true;
   }
 
-  private cancelQueued(queuedIndex: number): boolean {
-    const [queued] = this.queue.splice(queuedIndex, 1);
+  private findQueued(
+    predicate: (entry: QueuedDispatch) => boolean,
+  ): { projectRef: string; index: number } | null {
+    for (const [projectRef, projectQueue] of this.queuedDispatches) {
+      const index = projectQueue.findIndex(predicate);
+      if (index >= 0) return { projectRef, index };
+    }
+    return null;
+  }
+
+  private cancelQueued(projectRef: string, queuedIndex: number): boolean {
+    const projectQueue = this.queuedDispatches.get(projectRef);
+    if (!projectQueue) return false;
+    const [queued] = projectQueue.splice(queuedIndex, 1);
+    if (!queued) return false;
+    this.queuedCount--;
+    if (projectQueue.length === 0) {
+      this.queuedDispatches.delete(projectRef);
+      this.queuedProjects = this.queuedProjects.filter((queuedProject) => queuedProject !== projectRef);
+    }
     queued.resolve(cancelledResponse());
     return true;
   }


### PR DESCRIPTION
## Summary

- keep queued requests FIFO within each project
- rotate projects through the shared foreground worker pool
- preserve queue limits, cancellation, drain behavior, and queue-length metrics
- add a regression test proving a newly queued project is served before another project's backlog

## Problem

The foreground `WorkerPool` used one global FIFO queue. A single project's long-running backlog could therefore hold the head of the queue and delay unrelated projects even after a worker became available.

## Verification

- `bun test packages/edge-runtime/worker-pool.test.ts` (27 pass)
- `bun run --cwd packages/edge-runtime typecheck`
- `git diff --check`
