### PR TITLE
fix(edge-runtime): preserve queue order after preheat

### DIFF
--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -36,6 +36,16 @@ async function waitForMetric(
   throw new Error(`Timed out waiting for ${metric}=${expected}`);
 }
 
+async function waitForResponse(
+  responsePromise: Promise<Response>,
+  timeoutMs: number,
+): Promise<Response | null> {
+  return Promise.race([
+    responsePromise,
+    Bun.sleep(timeoutMs).then(() => null),
+  ]);
+}
+
 describe("WorkerPool EdgeRuntime.waitUntil", () => {
   test("keeps tenant env available after the HTTP response is returned", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-waituntil-"));
@@ -1049,6 +1059,87 @@ describe("WorkerPool module cache", () => {
       expect(result.invalidated).toBe(1);
 
       expect(await (await dispatch("env:1:stat:same", "new")).text()).toBe("new");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("schedules a queued request when a single worker finishes preheating", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-queue-"));
+    const slowFunctionPath = join(projectRoot, "slow-preheat.ts");
+    const fastFunctionPath = join(projectRoot, "fast.ts");
+    await Bun.write(slowFunctionPath, `
+      await Bun.sleep(150);
+      export default () => new Response("preheated");
+    `);
+    await Bun.write(fastFunctionPath, `export default () => new Response("queued");`);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const preheatPromise = pool.preheat(
+        "proj_preheat_slow",
+        slowFunctionPath,
+        projectRoot,
+        {},
+        { projectRef: "proj_preheat", moduleVersion: "v1" },
+      );
+      const responsePromise = pool.dispatch({
+        functionId: "proj_preheat_fast",
+        functionPath: fastFunctionPath,
+        projectRoot,
+        projectRef: "proj_preheat",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fast"),
+      });
+
+      await waitForMetric(pool, "queue_length", 1);
+      expect(await preheatPromise).toBe(true);
+      const response = await waitForResponse(responsePromise, 500);
+      expect(response).not.toBeNull();
+      expect(await response!.text()).toBe("queued");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("schedules queued requests when multiple workers finish preheating", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-queue-all-"));
+    const slowFunctionPath = join(projectRoot, "slow-preheat.ts");
+    const fastFunctionPath = join(projectRoot, "fast.ts");
+    await Bun.write(slowFunctionPath, `
+      await Bun.sleep(150);
+      export default () => new Response("preheated");
+    `);
+    await Bun.write(fastFunctionPath, `export default () => new Response("queued");`);
+
+    const pool = new WorkerPool({ size: 2, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const preheatPromise = pool.preheatIdleWorkers(
+        "proj_preheat_slow",
+        slowFunctionPath,
+        projectRoot,
+        {},
+        { projectRef: "proj_preheat", moduleVersion: "v1" },
+      );
+      const responsePromise = pool.dispatch({
+        functionId: "proj_preheat_fast",
+        functionPath: fastFunctionPath,
+        projectRoot,
+        projectRef: "proj_preheat",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/fast"),
+      });
+
+      await waitForMetric(pool, "queue_length", 1);
+      const result = await preheatPromise;
+      expect(result.succeeded).toBe(2);
+      const response = await waitForResponse(responsePromise, 500);
+      expect(response).not.toBeNull();
+      expect(await response!.text()).toBe("queued");
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -990,7 +990,7 @@ export class WorkerPool {
       .then((result) => result.success)
       .finally(() => {
         if (!this.draining && this.activeWorkers.has(worker)) {
-          this.idle.push(worker);
+          this.schedule(worker);
         }
       });
   }
@@ -1028,7 +1028,9 @@ export class WorkerPool {
       };
     } finally {
       if (!this.draining) {
-        this.idle.push(...workers.filter((worker) => this.activeWorkers.has(worker)));
+        for (const worker of workers) {
+          if (this.activeWorkers.has(worker)) this.schedule(worker);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- return preheated workers through the fair scheduler so queued requests are dispatched before workers become idle
- cover both single-worker preheat and multi-worker preheatIdleWorkers paths with regression tests

## Verification

- `bun test packages/edge-runtime/worker-pool.test.ts`: 29 pass, 0 fail
- `bun run typecheck` from `packages/edge-runtime`: pass
- `git diff --check`: pass

Follow-up to merged PR #580.