### PR TITLE
fix(console): surface SQL failures and save RLS policies

### DIFF
--- a/packages/web-console/src/lib/database-sql-response.test.ts
+++ b/packages/web-console/src/lib/database-sql-response.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { readDatabaseSqlResponse } from "./database-sql-response";
+
+test("returns successful SQL rows and metadata", async () => {
+  const response = new Response(JSON.stringify({ rows: [{ answer: 42 }], rowCount: 1, command: "SELECT" }), { status: 200 });
+
+  await expect(readDatabaseSqlResponse(response)).resolves.toEqual({
+    rows: [{ answer: 42 }],
+    rowCount: 1,
+    command: "SELECT",
+  });
+});
+
+test("surfaces SQL API error messages from failed responses", async () => {
+  const response = new Response(JSON.stringify({ message: 'syntax error at or near "FRM"' }), { status: 400 });
+
+  await expect(readDatabaseSqlResponse(response)).rejects.toThrow('syntax error at or near "FRM"');
+});
+
+test("does not treat an error envelope as an empty successful result", async () => {
+  const response = new Response(JSON.stringify({ error: "multiple statements are not allowed" }), { status: 200 });
+
+  await expect(readDatabaseSqlResponse(response)).rejects.toThrow("multiple statements are not allowed");
+});

--- a/packages/web-console/src/lib/database-sql-response.ts
+++ b/packages/web-console/src/lib/database-sql-response.ts
@@ -1,0 +1,49 @@
+type DatabaseSqlPayload = {
+  rows?: unknown;
+  rowCount?: unknown;
+  command?: unknown;
+  error?: unknown;
+  message?: unknown;
+  details?: unknown;
+  hint?: unknown;
+};
+
+export type DatabaseSqlResponse = {
+  rows: unknown[];
+  rowCount: number;
+  command: string | null;
+};
+
+function responseMessage(payload: DatabaseSqlPayload, fallback: string): string {
+  const message = typeof payload.message === "string" ? payload.message : payload.error;
+  if (typeof message === "string" && message.trim()) return message;
+  return fallback;
+}
+
+async function responsePayload(response: Response): Promise<DatabaseSqlPayload> {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    const payload: unknown = JSON.parse(text);
+    return payload && typeof payload === "object" && !Array.isArray(payload)
+      ? payload as DatabaseSqlPayload
+      : { message: text };
+  } catch {
+    return { message: text };
+  }
+}
+
+export async function readDatabaseSqlResponse(response: Response): Promise<DatabaseSqlResponse> {
+  const payload = await responsePayload(response);
+  if (!response.ok || payload.error) {
+    throw new Error(responseMessage(payload, `SQL 请求失败 (${response.status})`));
+  }
+
+  const rows = Array.isArray(payload.rows) ? payload.rows : [];
+  const rowCount = typeof payload.rowCount === "number" ? payload.rowCount : rows.length;
+  return {
+    rows,
+    rowCount,
+    command: typeof payload.command === "string" ? payload.command : null,
+  };
+}

--- a/packages/web-console/src/routes/project/[ref]/auth/policies/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/policies/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
+  import { readDatabaseSqlResponse } from "$lib/database-sql-response";
 
   import { page } from "$app/state";
   import { Loader2, Shield, Table, Plus, Search, Trash2 } from "lucide-svelte";
@@ -62,9 +63,8 @@
         method: "POST", headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sql: POLICIES_SQL })
       });
-      const data = await res.json();
-      if (data.error) throw new Error(data.message || data.error);
-      return (data.rows || []) as RlsPolicy[];
+      const data = await readDatabaseSqlResponse(res);
+      return data.rows as RlsPolicy[];
     }
   }));
 
@@ -115,16 +115,15 @@
 
       const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql })
+        body: JSON.stringify({ sql, mode: "migration" })
       });
-      const data = await res.json();
-      if (data.error) throw new Error(data.message || data.error);
-      return data;
+      return readDatabaseSqlResponse(res);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["auth_policies", projectRef] });
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["auth_policies", projectRef] });
       showAdd = false;
       newPolName = ""; newPolUsing = ""; newPolWithCheck = "";
+      toast.success("RLS 策略已创建");
     },
     onError: (err: unknown) => {
       addError = (err instanceof Error ? err.message : String(err)) || "创建失败";
@@ -145,11 +144,9 @@
       const sql = `DROP POLICY "${policy.policyname}" ON "${policy.schemaname}"."${policy.tablename}";`;
       const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
         method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql })
+        body: JSON.stringify({ sql, mode: "migration" })
       });
-      const data = await res.json();
-      if (data.error) throw new Error(data.message || data.error);
-      return data;
+      return readDatabaseSqlResponse(res);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["auth_policies", projectRef] });

--- a/packages/web-console/src/routes/project/[ref]/sql/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/sql/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
+  import { readDatabaseSqlResponse } from "$lib/database-sql-response";
 
   import { onMount } from "svelte";
   import { page } from "$app/state";
@@ -192,10 +193,7 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sql: wrappedSql })
       });
-      const data = await res.json();
-      if (data.error) throw new Error(data.message || data.error);
-      const rows = data.rows || [];
-      return { rows, command: data.command || null, rowCount: data.rowCount ?? rows.length };
+      return readDatabaseSqlResponse(res);
     },
     onMutate: () => { isRunning = true; },
     onSuccess: (result, variables) => {


### PR DESCRIPTION
Fixes CNB issues #23, #25, and #31.

- parse failed SQL HTTP responses before rendering results
- keep SQL errors out of the success state
- execute RLS creates/deletes through migration mode and refresh the policy list
- add focused response parsing coverage

Validation:
- bun test src/lib/database-sql-response.test.ts
- bun run check
- bun run build