### PR TITLE
fix(console): clarify auth settings feedback

### DIFF
--- a/packages/web-console/src/routes/project/[ref]/auth-api-response.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/auth-api-response.test.ts
@@ -11,6 +11,8 @@ describe("auth API response helpers", () => {
     expect(unwrapAuthApiObject({ data: { code: "ENVELOPED" } })).toEqual({ code: "ENVELOPED" });
     expect(authApiResponseMessage({ error: { message: "managed by owner" } }, "fallback"))
       .toBe("managed by owner");
+    expect(authApiResponseMessage({ message: "SITE_URL 格式不合法" }, "fallback"))
+      .toBe("SITE_URL 格式不合法");
   });
 
   test("parses JSON and preserves plain-text error bodies", async () => {

--- a/packages/web-console/src/routes/project/[ref]/auth/oauth-server/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/oauth-server/+page.svelte
@@ -166,6 +166,8 @@
   async function deleteClient(client: OAuthClient) {
     const clientId = client.client_id || client.id;
     if (!clientId) return;
+    const clientName = client.client_name || client.name || clientId;
+    if (!confirm(`确定要删除 OAuth Client “${clientName}”吗？此操作不可恢复。`)) return;
     saving = true;
     try {
       const res = await apiClient(`/v1/projects/${projectRef}/auth/oauth-clients/${encodeURIComponent(clientId)}`, {

--- a/packages/web-console/src/routes/project/[ref]/auth/providers/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/providers/+page.svelte
@@ -3,7 +3,7 @@
 
   import { page } from "$app/state";
   import { untrack } from "svelte";
-  import { Loader2, Check, X, Search, Shield, KeyRound, ChevronDown, ChevronUp, Save, Trash2, Eye, EyeOff } from "lucide-svelte";
+  import { Loader2, X, Search, Shield, KeyRound, ChevronDown, ChevronUp, Save, Trash2, Eye, EyeOff } from "lucide-svelte";
   import { createQuery, createMutation, useQueryClient } from "@tanstack/svelte-query";
 
   interface ProviderConfig {
@@ -304,9 +304,8 @@
                     <span class="pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transform ring-0 transition duration-200 ease-in-out {providers[i].enabled ? 'translate-x-4' : 'translate-x-0'}"></span>
                   </button>
                 {:else}
-                  <div class="flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-green-500/30 bg-green-500/10">
-                    <Check size={12} class="text-green-600" />
-                    <span class="text-[10px] font-bold text-green-600">内置</span>
+                  <div class="px-2.5 py-1 rounded-full border border-blue-500/30 bg-blue-500/10">
+                    <span class="text-[10px] font-bold text-blue-600">内置方式</span>
                   </div>
                 {/if}
                 {#if providers[i].expanded}

--- a/packages/web-console/src/routes/project/[ref]/auth/url-configuration/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/url-configuration/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
+  import { authApiResponseMessage, readAuthApiPayload } from "../../auth-api-response";
 
   import { page } from "$app/state";
   import { Loader2, Link2, Globe, Plus, Trash2, Save } from "lucide-svelte";
@@ -57,11 +58,9 @@
           URI_ALLOW_LIST: redirectUrls.join(","),
         })
       });
-      if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.error || res.statusText);
-      }
-      return res.json();
+      const payload = await readAuthApiPayload(res);
+      if (!res.ok) throw new Error(authApiResponseMessage(payload, res.statusText || "保存失败"));
+      return payload;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["auth_config", projectRef] });


### PR DESCRIPTION
Fixes CNB issues #28, #30, and #32.

- show built-in providers as informational rather than enabled
- require confirmation before deleting an OAuth client
- preserve API error messages when URL configuration saves fail

Validation:
- bun test src/routes/project/[ref]/auth-api-response.test.ts
- bun run check
- bun run build