### PR TITLE
fix(auth): support multiline mail templates in GoTrue env

### DIFF
--- a/packages/management-api/src/services/tenant-runtime-config.ts
+++ b/packages/management-api/src/services/tenant-runtime-config.ts
@@ -1,10 +1,11 @@
-import { AUTH_EMAIL_TEMPLATE_DEFINITIONS } from "../utils/auth-email-templates";
+import { renderGoTrueEmailTemplateEnv } from "../utils/auth-email-templates";
 import { serializedProviderLinkingDomains } from "../utils/provider-linking";
+import { renderSystemdEnvLine } from "../utils/systemd-env";
 
 export { renderGoTrueSessionPolicyEnv } from "./auth-session-policy";
+export { renderSystemdEnvLine } from "../utils/systemd-env";
 
 const CONFIG_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
-const ENVIRONMENT_NAME = /^[A-Z][A-Z0-9_]*$/;
 
 export function assertSafeConfigValue(name: string, value: string): void {
     if (CONFIG_CONTROL_CHARACTERS.test(value)) {
@@ -17,14 +18,6 @@ function encodeUriComponent(value: string): string {
     return encodeURIComponent(value).replace(/[!'()*]/g, (character) =>
         `%${character.charCodeAt(0).toString(16).toUpperCase()}`
     );
-}
-
-export function renderSystemdEnvLine(name: string, value: string): string {
-    if (!ENVIRONMENT_NAME.test(name)) {
-        throw new Error(`Invalid EnvironmentFile variable name: ${name}`);
-    }
-    assertSafeConfigValue(`${name} EnvironmentFile value`, value);
-    return `${name}=${JSON.stringify(value)}`;
 }
 
 export function quoteTomlBasicString(value: string): string {
@@ -149,20 +142,6 @@ export function renderGoTrueAuthEnv(authConfig: Record<string, unknown>): string
     const externalEmailEnabled = readBooleanSetting(authConfig, "external_email_enabled", true);
     const externalPhoneEnabled = readBooleanSetting(authConfig, "external_phone_enabled", true);
 
-    const emailTemplateLines: string[] = [];
-    for (const definition of AUTH_EMAIL_TEMPLATE_DEFINITIONS) {
-        const upperSubjectKey = definition.subjectKey.toUpperCase();
-        const upperContentKey = definition.contentKey.toUpperCase();
-        const subject = authConfig[definition.subjectKey] ?? authConfig[upperSubjectKey];
-        const content = authConfig[definition.contentKey] ?? authConfig[upperContentKey];
-        if (typeof subject === "string") {
-            emailTemplateLines.push(renderSystemdEnvLine(definition.envSubject, subject));
-        }
-        if (typeof content === "string") {
-            emailTemplateLines.push(renderSystemdEnvLine(definition.envContent, content));
-        }
-    }
-
     return [
 `
 GOTRUE_DISABLE_SIGNUP=${disableSignup ? "true" : "false"}
@@ -170,7 +149,7 @@ GOTRUE_EXTERNAL_ANONYMOUS_USERS_ENABLED=${externalAnonymousUsersEnabled ? "true"
 GOTRUE_EXTERNAL_EMAIL_ENABLED=${externalEmailEnabled ? "true" : "false"}
 GOTRUE_EXTERNAL_PHONE_ENABLED=${externalPhoneEnabled ? "true" : "false"}
 `.trim(),
-        emailTemplateLines.join("\n"),
+        renderGoTrueEmailTemplateEnv(authConfig),
     ].filter(Boolean).join("\n");
 }
 

--- a/packages/management-api/src/utils/auth-email-templates.ts
+++ b/packages/management-api/src/utils/auth-email-templates.ts
@@ -1,4 +1,4 @@
-import { quoteSystemdEnvValue } from "./systemd-env";
+import { quoteSystemdEnvValue, renderSystemdEnvLine } from "./systemd-env";
 
 export const AUTH_EMAIL_TEMPLATE_DEFINITIONS = [
   {
@@ -199,7 +199,7 @@ export function renderGoTrueEmailTemplateEnv(authConfig: Record<string, unknown>
     const subject = readString(authConfig, definition.subjectKey);
     const content = readString(authConfig, definition.contentKey);
     if (subject !== null) {
-      lines.push(`${definition.envSubject}=${quoteSystemdEnvValue(subject)}`);
+      lines.push(renderSystemdEnvLine(definition.envSubject, subject));
     }
     if (content !== null) {
       lines.push(`${definition.envContent}=${quoteSystemdEnvValue(content)}`);

--- a/packages/management-api/src/utils/systemd-env.ts
+++ b/packages/management-api/src/utils/systemd-env.ts
@@ -1,3 +1,17 @@
+const ENVIRONMENT_NAME = /^[A-Z][A-Z0-9_]*$/;
+const FORBIDDEN_ENVIRONMENT_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+const UNSUPPORTED_ENVIRONMENT_CONTROL_CHARACTERS = /[\u0000-\u0008\u000b-\u001f\u007f]/;
+
+export function renderSystemdEnvLine(name: string, value: string): string {
+    if (!ENVIRONMENT_NAME.test(name)) {
+        throw new Error(`Invalid EnvironmentFile variable name: ${name}`);
+    }
+    if (FORBIDDEN_ENVIRONMENT_CONTROL_CHARACTERS.test(value)) {
+        throw new Error(`${name} EnvironmentFile value contains a forbidden control character`);
+    }
+    return `${name}=${JSON.stringify(value)}`;
+}
+
 /**
  * Quote a value for systemd EnvironmentFile.
  *
@@ -10,6 +24,9 @@
  * preserve the content exactly.
  */
 export function quoteSystemdEnvValue(value: string): string {
+    if (UNSUPPORTED_ENVIRONMENT_CONTROL_CHARACTERS.test(value)) {
+        throw new Error("systemd EnvironmentFile value contains a forbidden control character");
+    }
     if (value.includes('"')) {
         if (!value.includes("'")) {
             return `'${value}'`;

--- a/packages/management-api/tests/unit/tenant-runtime.env.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.env.test.ts
@@ -95,6 +95,13 @@ describe("TenantRuntimeService systemd env quoting", () => {
   test("double-quotes and escapes values containing both single and double quotes", () => {
     expect(quoteSystemdEnvValue(`{"name":"can't"}`)).toBe(`"{\\"name\\":\\"can't\\"}"`);
   });
+
+  test.each(["bad\rINJECTED=value", "bad\0INJECTED=value"])(
+    "rejects unsupported EnvironmentFile control characters (%j)",
+    (value) => {
+      expect(() => quoteSystemdEnvValue(value)).toThrow(/control character/i);
+    },
+  );
 });
 
 describe("TenantRuntimeService PostgREST schema rendering", () => {
@@ -228,8 +235,18 @@ describe("TenantRuntimeService GoTrue auth env rendering", () => {
       MAILER_SUBJECTS_RECOVERY: "Reset your password",
     })).toContain([
       "GOTRUE_MAILER_SUBJECTS_CONFIRMATION=\"欢迎确认\"",
-      "GOTRUE_MAILER_TEMPLATES_CONFIRMATION_CONTENT=\"<p>Hi {{ .Email }}</p><a href=\\\"{{ .ConfirmationURL }}\\\">Confirm</a>\"",
+      "GOTRUE_MAILER_TEMPLATES_CONFIRMATION_CONTENT='<p>Hi {{ .Email }}</p><a href=\"{{ .ConfirmationURL }}\">Confirm</a>'",
       "GOTRUE_MAILER_SUBJECTS_RECOVERY=\"Reset your password\"",
+    ].join("\n"));
+  });
+
+  test("preserves multiline email templates in a systemd-compatible value", () => {
+    expect(renderGoTrueAuthEnv({
+      mailer_templates_confirmation_content: `<p>Hi {{ .Email }}</p>
+<a href="{{ .ConfirmationURL }}">Confirm</a>`,
+    })).toContain([
+      "GOTRUE_MAILER_TEMPLATES_CONFIRMATION_CONTENT='<p>Hi {{ .Email }}</p>",
+      '<a href="{{ .ConfirmationURL }}">Confirm</a>\'',
     ].join("\n"));
   });
 


### PR DESCRIPTION
## Summary
- render mail template bodies with the existing multiline-safe systemd serializer
- keep title and non-template EnvironmentFile values strict against control-character injection
- cover multiline HTML bodies and rejected CR/NUL controls

Fixes the root cause behind CNB issue #29: reapplying OAuth/OIDC signing config failed because a persisted multiline mail template could not be rendered into the GoTrue EnvironmentFile.

## Verification
- bun run test:unit
- bun test tests/unit/tenant-runtime.env.test.ts tests/unit/auth-email-templates.routes.test.ts
- bun run typecheck
- bun run build:amd64