### PR TITLE
fix(auth): validate template subjects and duplicate URLs

### DIFF
--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -861,6 +861,15 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
       if (Object.keys(patch).length === 0) {
         return status(400, { message: "No email templates provided", code: "400" });
       }
+      const emptySubject = Object.entries(patch).find(
+        ([, template]) => template.subject !== undefined && !template.subject.trim(),
+      );
+      if (emptySubject) {
+        return status(400, {
+          message: `Email subject for template '${emptySubject[0]}' must not be empty`,
+          code: "400",
+        });
+      }
 
       const currentAuth = (settings.auth as Record<string, unknown>) || {};
       const nextAuth = applyAuthEmailTemplatePatch(currentAuth, patch);

--- a/packages/management-api/tests/unit/auth-email-templates.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-email-templates.routes.test.ts
@@ -131,6 +131,27 @@ describe("project auth email template routes", () => {
     expect(restartRuntime).not.toHaveBeenCalled();
   });
 
+  test("PUT rejects empty email subjects before persisting or restarting", async () => {
+    const res = await request("/v1/projects/proj_1/auth/template", {
+      method: "PUT",
+      body: JSON.stringify({
+        templates: {
+          confirmation: {
+            subject: "   ",
+            content: "<p>{{ .ConfirmationURL }}</p>",
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      message: "Email subject for template 'confirmation' must not be empty",
+    });
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+    expect(restartRuntime).not.toHaveBeenCalled();
+  });
+
   test("DELETE clears canonical and legacy template keys for rollback", async () => {
     getProjectSettings.mockResolvedValue({
       auth: {

--- a/packages/web-console/src/routes/project/[ref]/auth/templates/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/templates/+page.svelte
@@ -101,6 +101,12 @@
 
   async function saveTemplates() {
     saveMsg = null;
+    const emptySubject = templates.find((template) => !template.subject.trim());
+    if (emptySubject) {
+      saveMsg = `❌ ${emptySubject.name}的邮件主题不能为空`;
+      setTimeout(() => saveMsg = null, 4000);
+      return;
+    }
     saveMutation.mutate();
   }
 

--- a/packages/web-console/src/routes/project/[ref]/auth/url-configuration/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/url-configuration/+page.svelte
@@ -4,6 +4,7 @@
 
   import { page } from "$app/state";
   import { Loader2, Link2, Globe, Plus, Trash2, Save } from "lucide-svelte";
+  import { toast } from "svelte-sonner";
   import { createQuery, createMutation, useQueryClient } from "@tanstack/svelte-query";
 
   let newUrl = $state("");
@@ -38,10 +39,13 @@
   const isLoading = $derived(urlConfigQuery.isPending);
   function addUrl() {
     const url = newUrl.trim();
-    if (url && !redirectUrls.includes(url)) {
-      redirectUrls = [...redirectUrls, url];
-      newUrl = "";
+    if (!url) return;
+    if (redirectUrls.includes(url)) {
+      toast.warning("该重定向 URL 已存在，无需重复添加");
+      return;
     }
+    redirectUrls = [...redirectUrls, url];
+    newUrl = "";
   }
 
   function removeUrl(index: number) {


### PR DESCRIPTION
Fixes console feedback gaps reported in CNB issues #33 and #34.

- show a warning when a redirect URL already exists
- reject blank email template subjects in the UI and API
- add API regression coverage for whitespace-only subjects

Validation:
- `bun test tests/unit/auth-email-templates.routes.test.ts`
- `bun run check` (packages/web-console)