### PR TITLE
fix(console): validate auth template and redirect settings

### DIFF
--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -861,6 +861,12 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
       if (Object.keys(patch).length === 0) {
         return status(400, { message: "No email templates provided", code: "400" });
       }
+      const hasBlankSubject = Object.values(patch).some(
+        (template) => template?.subject !== undefined && !template.subject.trim(),
+      );
+      if (hasBlankSubject) {
+        return status(400, { message: "Email template subject is required", code: "AUTH_TEMPLATE_SUBJECT_REQUIRED" });
+      }
 
       const currentAuth = (settings.auth as Record<string, unknown>) || {};
       const nextAuth = applyAuthEmailTemplatePatch(currentAuth, patch);

--- a/packages/management-api/tests/unit/auth-email-templates.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-email-templates.routes.test.ts
@@ -131,6 +131,50 @@ describe("project auth email template routes", () => {
     expect(restartRuntime).not.toHaveBeenCalled();
   });
 
+  test("PUT preserves an existing subject for content-only patches", async () => {
+    const res = await request("/v1/projects/proj_1/auth/template", {
+      method: "PUT",
+      body: JSON.stringify({
+        templates: {
+          confirmation: {
+            content: "<p>Updated {{ .ConfirmationURL }}</p>",
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(updateProjectSettings).toHaveBeenCalledWith("proj_1", {
+      auth: expect.objectContaining({
+        mailer_subjects_confirmation: "Custom confirmation",
+        mailer_templates_confirmation_content: "<p>Updated {{ .ConfirmationURL }}</p>",
+      }),
+    });
+    expect(restartRuntime).toHaveBeenCalledWith("proj_1");
+  });
+
+  test("PUT rejects blank email template subjects", async () => {
+    const res = await request("/v1/projects/proj_1/auth/template", {
+      method: "PUT",
+      body: JSON.stringify({
+        templates: {
+          confirmation: {
+            subject: "  ",
+            content: "<p>{{ .ConfirmationURL }}</p>",
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      message: "Email template subject is required",
+      code: "AUTH_TEMPLATE_SUBJECT_REQUIRED",
+    });
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+    expect(restartRuntime).not.toHaveBeenCalled();
+  });
+
   test("DELETE clears canonical and legacy template keys for rollback", async () => {
     getProjectSettings.mockResolvedValue({
       auth: {

--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -100,6 +100,9 @@
     "verified": "Verified",
     "created": "Created",
     "last_sign_in": "Last Sign In",
+    "redirect_url_duplicate": "This redirect URL already exists",
+    "template_subject_required": "Every email template must have a subject",
+    "template_save_failed": "Failed to save email templates",
     "signOut": "Sign Out"
   },
   "Tables": {

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -100,6 +100,9 @@
     "verified": "已验证",
     "created": "创建时间",
     "last_sign_in": "最后登录",
+    "redirect_url_duplicate": "该重定向 URL 已存在，无需重复添加",
+    "template_subject_required": "每个邮件模板都必须填写邮件主题",
+    "template_save_failed": "邮件模板保存失败",
     "signOut": "退出登录"
   },
   "Tables": {

--- a/packages/web-console/src/routes/project/[ref]/auth/templates/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/templates/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
+  import { authApiResponseMessage, readAuthApiPayload } from "../../auth-api-response";
 
   import { page } from "$app/state";
   import { untrack } from "svelte";
+  import { t } from "svelte-i18n";
   import { Loader2, Mail, Save, ChevronDown, ChevronUp, RotateCcw } from "lucide-svelte";
   import { createQuery, createMutation, useQueryClient } from "@tanstack/svelte-query";
 
@@ -66,8 +68,9 @@
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ templates: payload })
       });
-      if (!res.ok) throw new Error("保存失败");
-      return res.json();
+      const responsePayload = await readAuthApiPayload(res);
+      if (!res.ok) throw new Error(authApiResponseMessage(responsePayload, $t("Auth.template_save_failed")));
+      return responsePayload;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["auth_templates", projectRef] });
@@ -101,6 +104,10 @@
 
   async function saveTemplates() {
     saveMsg = null;
+    if (templates.some((template) => !template.subject.trim())) {
+      saveMsg = `❌ ${$t("Auth.template_subject_required")}`;
+      return;
+    }
     saveMutation.mutate();
   }
 

--- a/packages/web-console/src/routes/project/[ref]/auth/url-configuration/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/url-configuration/+page.svelte
@@ -3,6 +3,7 @@
   import { authApiResponseMessage, readAuthApiPayload } from "../../auth-api-response";
 
   import { page } from "$app/state";
+  import { t } from "svelte-i18n";
   import { Loader2, Link2, Globe, Plus, Trash2, Save } from "lucide-svelte";
   import { createQuery, createMutation, useQueryClient } from "@tanstack/svelte-query";
 
@@ -38,10 +39,14 @@
   const isLoading = $derived(urlConfigQuery.isPending);
   function addUrl() {
     const url = newUrl.trim();
-    if (url && !redirectUrls.includes(url)) {
-      redirectUrls = [...redirectUrls, url];
-      newUrl = "";
+    if (!url) return;
+    if (redirectUrls.includes(url)) {
+      saveMsg = `❌ ${$t("Auth.redirect_url_duplicate")}`;
+      setTimeout(() => saveMsg = null, 4000);
+      return;
     }
+    redirectUrls = [...redirectUrls, url];
+    newUrl = "";
   }
 
   function removeUrl(index: number) {


### PR DESCRIPTION
Fixes CNB issues #33 and #34.

- show a localized feedback message when a redirect URL is added twice
- reject blank or whitespace-only email template subjects in both the console and Management API
- preserve partial content-only template updates when an existing subject is present
- surface API error messages and add matching zh-CN/en i18n keys

Validation:
- bun test tests/unit/auth-email-templates.routes.test.ts (6 passed)
- bun run typecheck (packages/management-api)
- bun run check (packages/web-console)
- bun run build (packages/web-console)
- zh-CN/en Auth i18n keys match
- git diff --check