### PR TITLE
fix(console): restore project creation and SQL tab names

### DIFF
--- a/packages/web-console/src/lib/components/ProjectSwitcher.svelte
+++ b/packages/web-console/src/lib/components/ProjectSwitcher.svelte
@@ -39,7 +39,13 @@
         </button>
       {/each}
       <div class="border-t my-1"></div>
-      <button class="w-full text-left px-3 py-2 text-sm hover:bg-secondary text-brand flex items-center gap-2">
+      <button
+        class="w-full text-left px-3 py-2 text-sm hover:bg-secondary text-brand flex items-center gap-2"
+        onclick={() => {
+          isOpen = false;
+          goto("/projects/create");
+        }}
+      >
         <Plus class="w-4 h-4" />
         {$t("Project.new_project")}
       </button>

--- a/packages/web-console/src/lib/sql-tab-names.test.ts
+++ b/packages/web-console/src/lib/sql-tab-names.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { isSqlTabNameAvailable, nextSqlTabName } from "./sql-tab-names";
+
+describe("SQL tab names", () => {
+  test("starts untitled tabs at one and fills the first available suffix", () => {
+    expect(nextSqlTabName([], "Untitled query")).toBe("Untitled query 1");
+    expect(nextSqlTabName([
+      { id: "first", name: "Untitled query 1" },
+      { id: "third", name: "Untitled query 3" },
+    ], "Untitled query")).toBe("Untitled query 2");
+  });
+
+  test("prevents duplicate renamed tabs without rejecting the current tab name", () => {
+    const tabs = [
+      { id: "first", name: "Untitled query 1" },
+      { id: "second", name: "Revenue" },
+    ];
+
+    expect(isSqlTabNameAvailable(tabs, "second", "revenue")).toBe(true);
+    expect(isSqlTabNameAvailable(tabs, "second", " untitled query 1 ")).toBe(false);
+  });
+});

--- a/packages/web-console/src/lib/sql-tab-names.ts
+++ b/packages/web-console/src/lib/sql-tab-names.ts
@@ -1,0 +1,29 @@
+export type NamedSqlTab = {
+  id: string;
+  name: string;
+};
+
+function normalizedTabName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+export function nextSqlTabName(tabs: NamedSqlTab[], untitledName: string): string {
+  const names = new Set(tabs.map((tab) => normalizedTabName(tab.name)));
+
+  // Start at one and fill the first unused suffix so restored tabs remain easy to distinguish.
+  for (let suffix = 1; ; suffix += 1) {
+    const candidate = `${untitledName} ${suffix}`;
+    if (!names.has(normalizedTabName(candidate))) return candidate;
+  }
+}
+
+export function isSqlTabNameAvailable(
+  tabs: NamedSqlTab[],
+  tabId: string,
+  candidate: string,
+): boolean {
+  const normalizedCandidate = normalizedTabName(candidate);
+  return !tabs.some(
+    (tab) => tab.id !== tabId && normalizedTabName(tab.name) === normalizedCandidate,
+  );
+}

--- a/packages/web-console/src/routes/page.test.ts
+++ b/packages/web-console/src/routes/page.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
 const pageSource = readFileSync(new URL("./+page.svelte", import.meta.url), "utf8");
+const projectsPageSource = readFileSync(new URL("./projects/+page.svelte", import.meta.url), "utf8");
+const createProjectPageSource = readFileSync(new URL("./projects/create/+page.svelte", import.meta.url), "utf8");
+const projectSwitcherSource = readFileSync(new URL("../lib/components/ProjectSwitcher.svelte", import.meta.url), "utf8");
 const packageJson = JSON.parse(
   readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
 ) as { dependencies: Record<string, string> };
@@ -22,6 +25,15 @@ describe("SupaCloud root dashboard", () => {
     expect(pageSource).toContain('goto(resolve("/projects"))');
     expect(pageSource).toContain("{#each filteredProjects.slice(0, 6) as project (project.ref)}");
     expect(pageSource).toContain('href={resolve("/project/[ref]", { ref: project.ref })}');
+  });
+
+  test("keeps every new-project entrypoint connected to the creation form", () => {
+    expect(projectsPageSource).toContain('href="/projects/create"');
+    expect(projectSwitcherSource).toContain('goto("/projects/create")');
+    expect(createProjectPageSource).toContain('apiClient("/v1/projects"');
+    expect(createProjectPageSource).toContain("method: \"POST\"");
+    expect(createProjectPageSource).toContain("window.location.assign");
+    expect(createProjectPageSource).toContain("encodeURIComponent(ref)");
   });
 
   test("contains no unrelated demo business content", () => {

--- a/packages/web-console/src/routes/project/[ref]/sql/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/sql/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
   import { readDatabaseSqlResponse } from "$lib/database-sql-response";
+  import { isSqlTabNameAvailable, nextSqlTabName } from "$lib/sql-tab-names";
+  import { toast } from "svelte-sonner";
 
   import { onMount } from "svelte";
   import { page } from "$app/state";
@@ -47,7 +49,7 @@
     tabCounter++;
     return {
       id,
-      name: name || $t("SqlEditor.untitled_query"),
+      name: name?.trim() || nextSqlTabName(tabs, $t("SqlEditor.untitled_query")),
       sql: sqlContent || "",
       results: null,
       error: null,
@@ -250,9 +252,13 @@
     const tab = tabs.find(tb => tb.id === id);
     if (!tab) return;
     const newName = prompt("重命名查询 Tab：", tab.name);
-    if (newName?.trim()) {
-      tabs = tabs.map(tb => tb.id === id ? { ...tb, name: newName.trim() } : tb);
+    const trimmedName = newName?.trim();
+    if (!trimmedName) return;
+    if (!isSqlTabNameAvailable(tabs, id, trimmedName)) {
+      toast.error("查询标签名称已存在");
+      return;
     }
+    tabs = tabs.map(tb => tb.id === id ? { ...tb, name: trimmedName } : tb);
   }
 </script>
 

--- a/packages/web-console/src/routes/projects/+page.svelte
+++ b/packages/web-console/src/routes/projects/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { useList } from "@svadmin/core";
   import { Loader2 } from "lucide-svelte";
-  import { CreateButton } from "@svadmin/ui";
 
   const query = useList({ resource: "v1/projects" });
 </script>

--- a/packages/web-console/src/routes/projects/create/+page.svelte
+++ b/packages/web-console/src/routes/projects/create/+page.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { apiClient } from "$lib/api";
+  import { Loader2, ArrowLeft } from "lucide-svelte";
+
+  let name = $state("");
+  let isCreating = $state(false);
+  let error = $state<string | null>(null);
+
+  function errorMessage(payload: unknown, fallback: string): string {
+    if (!payload || typeof payload !== "object") return fallback;
+    const message = (payload as Record<string, unknown>).message;
+    return typeof message === "string" && message.trim() ? message : fallback;
+  }
+
+  async function submitProjectCreation(projectName: string): Promise<string> {
+    const response = await apiClient("/v1/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: projectName }),
+    });
+    const project: unknown = await response.json().catch(() => null);
+    if (!response.ok) throw new Error(errorMessage(project, "创建项目失败"));
+
+    const ref = (project as Record<string, unknown> | null)?.ref;
+    if (typeof ref !== "string" || !ref) throw new Error("创建项目响应缺少项目标识");
+    return ref;
+  }
+
+  async function createProject() {
+    const projectName = name.trim();
+    if (!projectName) {
+      error = "请输入项目名称";
+      return;
+    }
+
+    isCreating = true;
+    error = null;
+    try {
+      const ref = await submitProjectCreation(projectName);
+      window.location.assign(`/project/${encodeURIComponent(ref)}`);
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : "创建项目失败";
+    } finally {
+      isCreating = false;
+    }
+  }
+</script>
+
+<div class="mx-auto max-w-xl space-y-6">
+  <div class="flex items-center gap-3">
+    <a href="/projects" class="rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground" aria-label="返回项目列表">
+      <ArrowLeft size={18} />
+    </a>
+    <div>
+      <h1 class="text-2xl font-bold">新建项目</h1>
+      <p class="mt-1 text-sm text-muted-foreground">创建后会在后台初始化数据库与服务。</p>
+    </div>
+  </div>
+
+  <form class="space-y-5 rounded-xl border bg-card p-6 shadow-sm" onsubmit={(event) => { event.preventDefault(); void createProject(); }}>
+    <label class="block space-y-1.5">
+      <span class="text-sm font-medium">项目名称</span>
+      <input
+        bind:value={name}
+        required
+        maxlength="100"
+        placeholder="my-project"
+        class="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-brand"
+      />
+    </label>
+
+    {#if error}
+      <p class="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>
+    {/if}
+
+    <div class="flex justify-end gap-3">
+      <a href="/projects" class="rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground">取消</a>
+      <button type="submit" disabled={isCreating} class="inline-flex items-center gap-2 rounded-md bg-brand px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+        {#if isCreating}
+          <Loader2 size={16} class="animate-spin" />
+          正在创建…
+        {:else}
+          创建项目
+        {/if}
+      </button>
+    </div>
+  </form>
+</div>


### PR DESCRIPTION
## Summary

- add the missing `/projects/create` form and wire both New Project entries to it
- reload the console after project creation so the resource registry includes the new project
- give untitled SQL tabs deterministic numbered names and reject duplicate renames

## Verification

- `bun run check`
- `bun test` (70 passed)
- `bun run build`
- `git diff --check`

Related CNB issues: #16, #17, #22.