### PR TITLE
fix(console): sync function, hosting, and report feedback

### DIFF
--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -117,7 +117,13 @@
   "Functions": {
     "create_new": "Create New Function",
     "no_functions": "No functions deployed",
-    "description": "Edge Functions allow you to run server-side logic close to your users."
+    "description": "Edge Functions allow you to run server-side logic close to your users.",
+    "jwt_verification": "JWT Verification",
+    "jwt_enabled": "JWT verification enabled",
+    "jwt_disabled": "JWT verification disabled",
+    "jwt_enable_action": "JWT verification is disabled; click to enable",
+    "jwt_disable_action": "JWT verification is enabled; click to disable",
+    "jwt_update_failed": "Unable to update JWT settings for {slug}"
   },
   "Database": {
     "backups": "Backups",

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -117,7 +117,13 @@
   "Functions": {
     "create_new": "创建新函数",
     "no_functions": "暂无已部署的函数",
-    "description": "边缘函数允许您在靠近用户的位置运行服务端逻辑。"
+    "description": "边缘函数允许您在靠近用户的位置运行服务端逻辑。",
+    "jwt_verification": "JWT 验证",
+    "jwt_enabled": "JWT 验证已开启",
+    "jwt_disabled": "JWT 验证已关闭",
+    "jwt_enable_action": "JWT 验证已关闭，点击开启",
+    "jwt_disable_action": "JWT 验证已开启，点击关闭",
+    "jwt_update_failed": "无法修改 {slug} 的 JWT 配置"
   },
   "Database": {
     "backups": "备份",

--- a/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
@@ -60,12 +60,23 @@
     source_code: string | null;
   }
 
+  interface VerifyJwtRequest {
+    slug: string;
+    verifyJwt: boolean;
+  }
+
+  interface VerifyJwtResponse {
+    verify_jwt: boolean;
+  }
+
   const projectRef = $derived(page.params.ref);
   const query = useList<EdgeFunction>({ get resource() { return `v1/projects/${projectRef}/functions`; } });
-  const functions = $derived(Array.isArray(query.data?.data) ? query.data.data : ((query.data?.data as unknown as Record<string, unknown>)?.functions as EdgeFunction[] || []));
+  const fetchedFunctions = $derived(Array.isArray(query.data?.data) ? query.data.data : ((query.data?.data as unknown as Record<string, unknown>)?.functions as EdgeFunction[] || []));
+  let functions = $state<EdgeFunction[]>([]);
   let showCreate = $state(false);
   let selectedFunction = $state<EdgeFunction | null>(null);
   let drawerOpen = $state(false);
+  let jwtUpdatingSlug = $state<string | null>(null);
   let functionTasks = $state<FunctionTaskRecord[]>([]);
   let taskDetails = $state<Record<string, {
     id: string;
@@ -126,6 +137,10 @@
 }`);
   let deploying = $state(false);
   let deployMsg = $state<string | null>(null);
+
+  $effect(() => {
+    functions = fetchedFunctions;
+  });
 
   const invokeAsyncHelperCode = `import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -535,22 +550,52 @@ export async function waitForTask(
     deleteMutation.mutate(slug);
   }
 
-  // Toggle verify_jwt config
-  async function toggleVerifyJwt(fn: EdgeFunction) {
-    const newValue = !fn.verify_jwt;
-    try {
-      const res = await apiClient(`/v1/projects/${projectRef}/functions/${fn.slug}/config`, {
+  function requireVerifyJwtResponse(payload: unknown): VerifyJwtResponse {
+    if (
+      typeof payload !== "object"
+      || payload === null
+      || !("verify_jwt" in payload)
+      || typeof payload.verify_jwt !== "boolean"
+    ) {
+      throw new Error("Invalid function configuration response");
+    }
+    return { verify_jwt: payload.verify_jwt };
+  }
+
+  const verifyJwtMutation = createMutation(() => ({
+    mutationFn: async ({ slug, verifyJwt }: VerifyJwtRequest) => {
+      const res = await apiClient(`/v1/projects/${projectRef}/functions/${slug}/config`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ verify_jwt: newValue }),
+        body: JSON.stringify({ verify_jwt: verifyJwt }),
       });
-      if (!res.ok) throw new Error("Failed");
-      fn.verify_jwt = newValue;
-      toast.success(`${fn.slug}: JWT 验证已${newValue ? '开启' : '关闭'}`);
-      query.refetch();
-    } catch {
-      toast.error(`无法修改 ${fn.slug} 的 JWT 配置`);
-    }
+      if (!res.ok) throw new Error("Function configuration update failed");
+      const config = requireVerifyJwtResponse(await res.json());
+      return { slug, verifyJwt: config.verify_jwt };
+    },
+    onMutate: ({ slug }) => {
+      jwtUpdatingSlug = slug;
+    },
+    onSuccess: ({ slug, verifyJwt }) => {
+      functions = functions.map((fn) => (
+        fn.slug === slug ? { ...fn, verify_jwt: verifyJwt } : fn
+      ));
+      if (selectedFunction?.slug === slug) {
+        selectedFunction = { ...selectedFunction, verify_jwt: verifyJwt };
+      }
+      toast.success(`${slug}: ${$t(verifyJwt ? "Functions.jwt_enabled" : "Functions.jwt_disabled")}`);
+      void query.refetch();
+    },
+    onError: (_error, { slug }) => {
+      toast.error($t("Functions.jwt_update_failed", { values: { slug } }));
+    },
+    onSettled: () => {
+      jwtUpdatingSlug = null;
+    },
+  }));
+
+  function toggleVerifyJwt(fn: EdgeFunction) {
+    verifyJwtMutation.mutate({ slug: fn.slug, verifyJwt: !fn.verify_jwt });
   }
 </script>
 
@@ -759,7 +804,7 @@ export async function waitForTask(
             <tr>
               <th class="px-5 py-3 font-semibold text-muted-foreground text-xs">函数名</th>
               <th class="px-5 py-3 font-semibold text-muted-foreground text-xs">状态</th>
-              <th class="px-5 py-3 font-semibold text-muted-foreground text-xs">JWT 验证</th>
+              <th class="px-5 py-3 font-semibold text-muted-foreground text-xs">{$t("Functions.jwt_verification")}</th>
               <th class="px-5 py-3 font-semibold text-muted-foreground text-xs">端点</th>
               <th class="px-5 py-3 font-semibold text-muted-foreground text-xs">创建时间</th>
               <th class="px-5 py-3"></th>
@@ -781,10 +826,21 @@ export async function waitForTask(
                   <span class="px-2 py-0.5 rounded-full text-[9px] font-bold {fn.status === 'ACTIVE' ? 'text-green-600 bg-green-500/10' : 'text-amber-600 bg-amber-500/10'}">{fn.status}</span>
                 </td>
                 <td class="px-5 py-3">
-                  <button onclick={() => toggleVerifyJwt(fn)}
-                    class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors {fn.verify_jwt ? 'bg-brand' : 'bg-muted-foreground/30'}"
-                    title={fn.verify_jwt ? 'JWT 验证已开启（点击关闭）' : 'JWT 验证已关闭（点击开启）'}>
-                    <span class="inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform shadow-sm {fn.verify_jwt ? 'translate-x-[18px]' : 'translate-x-[3px]'}"></span>
+                  <button
+                    type="button"
+                    onclick={() => toggleVerifyJwt(fn)}
+                    disabled={verifyJwtMutation.isPending}
+                    aria-busy={jwtUpdatingSlug === fn.slug}
+                    aria-pressed={fn.verify_jwt}
+                    aria-label={$t(fn.verify_jwt ? "Functions.jwt_disable_action" : "Functions.jwt_enable_action")}
+                    class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors disabled:cursor-wait disabled:opacity-70 {fn.verify_jwt ? 'bg-brand' : 'bg-muted-foreground/30'}"
+                    title={$t(fn.verify_jwt ? "Functions.jwt_disable_action" : "Functions.jwt_enable_action")}
+                  >
+                    {#if jwtUpdatingSlug === fn.slug}
+                      <Loader2 size={12} class="absolute left-3 animate-spin text-white" />
+                    {:else}
+                      <span class="inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform shadow-sm {fn.verify_jwt ? 'translate-x-[18px]' : 'translate-x-[3px]'}"></span>
+                    {/if}
                   </button>
                 </td>
                 <td class="px-5 py-3">
@@ -850,7 +906,7 @@ export async function waitForTask(
           <div class="mt-2 text-sm font-semibold">v{selectedFunction.version || 1}</div>
         </div>
         <div class="rounded-xl border border-border/60 bg-muted/20 p-4">
-          <div class="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">JWT</div>
+          <div class="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">{$t("Functions.jwt_verification")}</div>
           <div class="mt-2 text-sm font-semibold">{selectedFunction.verify_jwt ? "Enabled" : "Disabled"}</div>
         </div>
         <div class="rounded-xl border border-border/60 bg-muted/20 p-4">

--- a/packages/web-console/src/routes/project/[ref]/functions/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/functions/page.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./+page.svelte", import.meta.url), "utf8");
+
+describe("edge function JWT toggle", () => {
+  test("renders the confirmed server state without mutating query records", () => {
+    expect(source).toContain("requireVerifyJwtResponse(await res.json())");
+    expect(source).toContain("functions = functions.map");
+    expect(source).toContain("selectedFunction = { ...selectedFunction, verify_jwt: verifyJwt }");
+    expect(source).not.toContain("fn.verify_jwt =");
+  });
+
+  test("prevents repeated updates while a toggle request is pending", () => {
+    expect(source).toContain("disabled={verifyJwtMutation.isPending}");
+    expect(source).toContain("aria-busy={jwtUpdatingSlug === fn.slug}");
+  });
+});

--- a/packages/web-console/src/routes/project/[ref]/hosting/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/hosting/+layout.svelte
@@ -1,15 +1,10 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { Globe, FolderGit2, Settings, History } from "lucide-svelte";
+  import { t } from "svelte-i18n";
+  import { Globe } from "lucide-svelte";
 
   let { children } = $props();
   const projectRef = $derived(page.params.ref);
-
-  const TABS = [
-    { id: "", label: "站点列表", icon: Globe },
-    { id: "new", label: "新建部署", icon: FolderGit2 },
-  ];
-
   const currentTab = $derived(page.url.pathname.split("/hosting/")[1]?.split("/")[0] || "");
 </script>
 
@@ -23,16 +18,13 @@
       <span class="px-2 py-1 text-[10px] font-bold rounded-full bg-brand/10 text-brand border border-brand/20">HOSTING</span>
     </div>
     <div class="flex items-center gap-2 overflow-x-auto pb-2">
-      {#each TABS as tab}
-        {@const Icon = tab.icon}
-        <a
-          href={`/project/${projectRef}/hosting${tab.id ? '/' + tab.id : ''}`}
-          class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-full whitespace-nowrap transition-colors {currentTab === tab.id ? 'bg-brand text-white shadow-md' : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'}"
-        >
-          <Icon size={14} />
-          {tab.label}
-        </a>
-      {/each}
+      <a
+        href={`/project/${projectRef}/hosting`}
+        class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-full whitespace-nowrap transition-colors {currentTab === '' ? 'bg-brand text-white shadow-md' : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'}"
+      >
+        <Globe size={14} />
+        {$t("Hosting.site_list")}
+      </a>
     </div>
   </div>
   <div class="flex-1 overflow-y-auto px-6 pb-6">

--- a/packages/web-console/src/routes/project/[ref]/hosting/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/hosting/+page.svelte
@@ -3,7 +3,8 @@
 
   import { page } from "$app/state";
   import { goto } from "$app/navigation";
-  import { Loader2, Globe, ExternalLink, GitBranch, Clock, CheckCircle2, XCircle, RefreshCw, Trash2, Settings, AlertTriangle } from "lucide-svelte";
+  import { t } from "svelte-i18n";
+  import { Loader2, Globe, ExternalLink, GitBranch, Clock, CheckCircle2, XCircle, RefreshCw, Trash2, Settings } from "lucide-svelte";
   import { useList, type BaseRecord } from "@svadmin/core";
   import { createMutation } from "@tanstack/svelte-query";
 
@@ -106,11 +107,13 @@
     <h2 class="text-xl font-bold">站点列表</h2>
     <div class="flex items-center gap-2">
       <button onclick={() => query.refetch()} class="flex items-center gap-2 px-3 py-2 text-xs rounded-lg border hover:bg-muted/50 transition-colors">
-        <RefreshCw size={12} /> 刷新
+        <RefreshCw size={12} /> {$t("Hosting.refresh")}
       </button>
-      <a href={`/project/${projectRef}/hosting/new`} class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-lg bg-brand text-white hover:bg-brand/90 transition-colors">
-        + 新建部署
-      </a>
+      {#if deployments.length > 0}
+        <a href={`/project/${projectRef}/hosting/new`} class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-lg bg-brand text-white hover:bg-brand/90 transition-colors">
+          + {$t("Hosting.new_deploy")}
+        </a>
+      {/if}
     </div>
   </div>
 
@@ -127,10 +130,10 @@
   {:else if deployments.length === 0}
     <div class="rounded-xl border bg-card p-12 text-center">
       <Globe size={48} class="mx-auto text-muted-foreground/30 mb-4" />
-      <h3 class="text-lg font-bold mb-2">还没有任何部署</h3>
-      <p class="text-xs text-muted-foreground mb-4">创建你的第一个前端部署 — 支持静态站点、React、Vue、Next.js、SvelteKit 等</p>
+      <h3 class="text-lg font-bold mb-2">{$t("Hosting.no_deployments")}</h3>
+      <p class="text-xs text-muted-foreground mb-4">{$t("Hosting.no_deployments_desc")}</p>
       <a href={`/project/${projectRef}/hosting/new`} class="inline-flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-lg bg-brand text-white hover:bg-brand/90 transition-colors">
-        + 新建部署
+        + {$t("Hosting.new_deploy")}
       </a>
     </div>
   {:else}

--- a/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const pageSource = readFileSync(new URL("./+page.svelte", import.meta.url), "utf8");
+const layoutSource = readFileSync(new URL("./+layout.svelte", import.meta.url), "utf8");
+
+describe("hosting deployment entrypoints", () => {
+  test("shows only the empty-state action when no deployments exist", () => {
+    expect(pageSource).toContain("{#if deployments.length > 0}");
+    expect(pageSource).toContain('{$t("Hosting.no_deployments")}');
+    expect(layoutSource).not.toContain('{ id: "new"');
+  });
+});

--- a/packages/web-console/src/routes/project/[ref]/reports/database/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/reports/database/+page.svelte
@@ -2,8 +2,7 @@
   import { apiClient } from "$lib/api";
 
   import { page } from "$app/state";
-  import { Loader2, Database, ArrowLeft, HardDrive, Activity } from "lucide-svelte";
-  import { toast } from "svelte-sonner";
+  import { Loader2, ArrowLeft, HardDrive } from "lucide-svelte";
   import { createQuery } from "@tanstack/svelte-query";
 
   const projectRef = $derived(page.params.ref);
@@ -119,7 +118,7 @@
       </div>
       <div class="overflow-auto max-h-[55vh]">
         <table class="w-full text-left text-xs">
-          <thead class="bg-muted/30 border-b sticky top-0">
+          <thead class="bg-card border-b sticky top-0 z-10">
             <tr>
               <th class="px-4 py-2 font-semibold text-muted-foreground">Schema</th>
               <th class="px-4 py-2 font-semibold text-muted-foreground">表名</th>

--- a/packages/web-console/src/routes/project/[ref]/reports/database/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/reports/database/page.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./+page.svelte", import.meta.url), "utf8");
+const reportIndexSource = readFileSync(new URL("../+page.svelte", import.meta.url), "utf8");
+
+describe("database report table", () => {
+  test("keeps database and query performance on distinct routes", () => {
+    expect(reportIndexSource).toContain('href: "database"');
+    expect(reportIndexSource).toContain('href: "query-performance"');
+  });
+
+  test("keeps the sticky header opaque and above table rows", () => {
+    expect(source).toContain('<thead class="bg-card border-b sticky top-0 z-10">');
+  });
+});


### PR DESCRIPTION
## Summary

- update the Edge Function JWT switch from the validated PATCH response, replace list and drawer state immutably, block duplicate mutations, and add matching zh/en feedback
- keep the Hosting empty state to one primary deployment entry while preserving a single header action once deployments exist
- lock database and query-performance reports to distinct routes and render the database table sticky header with an opaque, layered background

## CNB issues

- #39: JWT toggle state and Toast now follow the persisted server response
- #40: no-deployment state now exposes only the centered creation action
- #42: fixes the table-header overlap and adds a regression assertion for the already-distinct report routes

## Validation

- `bun test` — 75 passed
- `bun run check` — 0 errors, 0 warnings
- `bun run build`
- zh/en locale parity — 699 keys
- `git diff --check`

The build still prints the existing Tailwind/PostCSS radial-gradient syntax warning; the build completes successfully and this PR does not touch that generated rule.