### PR TITLE
chore(console): upgrade svadmin ui to 0.38.7

### DIFF
--- a/packages/web-console/bun.lock
+++ b/packages/web-console/bun.lock
@@ -8,7 +8,7 @@
         "@svadmin/core": "^0.32.2",
         "@svadmin/elysia": "^0.10.7",
         "@svadmin/sveltekit": "^0.9.4",
-        "@svadmin/ui": "^0.38.5",
+        "@svadmin/ui": "^0.38.7",
         "@tanstack/svelte-query": "^6.1.38",
         "highlight.js": "^11.11.1",
         "isomorphic-dompurify": "^3.19.0",
@@ -237,7 +237,7 @@
 
     "@svadmin/sveltekit": ["@svadmin/sveltekit@0.9.4", "", { "peerDependencies": { "@svadmin/core": "^0.27.1", "@sveltejs/kit": "^2.0.0", "svelte": "^5.0.0" }, "optionalPeers": ["@svadmin/core", "@sveltejs/kit", "svelte"] }, "sha512-PpkQQRyDJ+Byllxmh6s4LgjqA8ZoqRd6u6mV3BWMCa5UX87Xz3CCOmm/V9okxjSErLxABc9sgDOiEskAYLBphQ=="],
 
-    "@svadmin/ui": ["@svadmin/ui@0.38.5", "", { "dependencies": { "@floating-ui/dom": "^1.8.0", "@lucide/svelte": "^1.25.0", "@tanstack/svelte-table": "9.0.0-alpha.53", "@tanstack/table-core": "9.0.0-alpha.53", "bits-ui": "^2.18.1", "clsx": "^2.1.1", "svelte-sonner": "^1.1.1", "tailwind-merge": "^3.6.0", "tailwind-variants": "^3.2.2" }, "peerDependencies": { "@svadmin/core": "^0.32.2", "@svadmin/editor": "*", "@tanstack/svelte-query": "^6.1.29", "highlight.js": "^11.11.1", "isomorphic-dompurify": "^3.15.0", "marked": "^18.0.0", "marked-highlight": "^2.2.3", "svelte": "^5.33.0" }, "optionalPeers": ["@svadmin/core", "@svadmin/editor", "@tanstack/svelte-query", "highlight.js", "isomorphic-dompurify", "marked", "marked-highlight", "svelte"] }, "sha512-Bol2UQA0qWKtEhISLtCVZojRlhCkerXjl8I+DaNCaIaVp9GbTXDHrHZI5+9GCYRK4OamDho8g3qRYC0eG39+7A=="],
+    "@svadmin/ui": ["@svadmin/ui@0.38.7", "", { "dependencies": { "@floating-ui/dom": "^1.8.0", "@lucide/svelte": "^1.25.0", "@tanstack/svelte-store": "^0.12.0", "@tanstack/svelte-table": "9.0.0-alpha.53", "@tanstack/table-core": "9.0.0-alpha.53", "bits-ui": "^2.18.1", "clsx": "^2.1.1", "svelte-sonner": "^1.1.1", "tailwind-merge": "^3.6.0", "tailwind-variants": "^3.2.2" }, "peerDependencies": { "@svadmin/core": "^0.32.2", "@svadmin/editor": "*", "@tanstack/svelte-query": "^6.1.29", "highlight.js": "^11.11.1", "isomorphic-dompurify": "^3.15.0", "marked": "^18.0.0", "marked-highlight": "^2.2.3", "svelte": "^5.33.0" }, "optionalPeers": ["@svadmin/core", "@svadmin/editor", "@tanstack/svelte-query", "highlight.js", "isomorphic-dompurify", "marked", "marked-highlight", "svelte"] }, "sha512-FalTUTGMWeWuZx+8ePO3t7cuF+mjMjCwb3wht3AP+4xMIqQeGqaiGhrVBBfSMus7j+PgHjo5MuKv6glktD8Nug=="],
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -42,7 +42,7 @@
     "@svadmin/core": "^0.32.2",
     "@svadmin/elysia": "^0.10.7",
     "@svadmin/sveltekit": "^0.9.4",
-    "@svadmin/ui": "^0.38.5",
+    "@svadmin/ui": "^0.38.7",
     "@tanstack/svelte-query": "^6.1.38",
     "highlight.js": "^11.11.1",
     "isomorphic-dompurify": "^3.19.0",

--- a/packages/web-console/src/routes/page.test.ts
+++ b/packages/web-console/src/routes/page.test.ts
@@ -45,11 +45,11 @@ describe("SupaCloud root dashboard", () => {
 
   test("tracks the latest stable svadmin packages and Vite compatibility rule", () => {
     expect(packageJson.dependencies["@svadmin/core"]).toBe("^0.32.2");
-    expect(packageJson.dependencies["@svadmin/ui"]).toBe("^0.38.5");
+    expect(packageJson.dependencies["@svadmin/ui"]).toBe("^0.38.7");
     expect(packageJson.dependencies["@svadmin/sveltekit"]).toBe("^0.9.4");
     expect(packageJson.dependencies["@svadmin/elysia"]).toBe("^0.10.7");
     expect(lockSource).toContain('"@svadmin/core@0.32.2"');
-    expect(lockSource).toContain('"@svadmin/ui@0.38.5"');
+    expect(lockSource).toContain('"@svadmin/ui@0.38.7"');
     expect(viteSource).toContain("'@svadmin/core'");
   });
 });


### PR DESCRIPTION
## Summary
- upgrade the Studio web console to `@svadmin/ui@0.38.7`
- refresh the Bun lockfile, including the new `@tanstack/svelte-store` transitive dependency
- update the stable dependency regression assertion

`@svadmin/sveltekit` remains at `^0.9.4`: GitHub has a `sveltekit-v0.9.6` release/tag, but the official npm registry still returns 404 for `@svadmin/sveltekit@0.9.6` and reports `0.9.4` as latest.

## Verification
- `bun install --frozen-lockfile`
- `bun test src` (76 pass)
- `bun run check` (0 errors, 0 warnings)
- `bun run build`
- `bun audit --audit-level high`
- `git diff --check`