### PR TITLE
chore(console): upgrade svadmin sveltekit to 0.9.6

### DIFF
--- a/packages/web-console/bun.lock
+++ b/packages/web-console/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@svadmin/core": "^0.32.2",
         "@svadmin/elysia": "^0.10.7",
-        "@svadmin/sveltekit": "^0.9.4",
+        "@svadmin/sveltekit": "^0.9.6",
         "@svadmin/ui": "^0.38.7",
         "@tanstack/svelte-query": "^6.1.38",
         "highlight.js": "^11.11.1",
@@ -235,7 +235,7 @@
 
     "@svadmin/elysia": ["@svadmin/elysia@0.10.7", "", { "peerDependencies": { "@elysiajs/eden": ">=1.0.0", "@svadmin/core": "^0.27.1", "elysia": ">=1.0.0" }, "optionalPeers": ["@elysiajs/eden", "@svadmin/core", "elysia"] }, "sha512-vVpEdofjj+9zbbo7eUmyhi5aC1W4LYIDmjFdLOFWl++V8iVhr10Vx7eafMnIkFbSV06CkFdegKyhheMF4FQQCg=="],
 
-    "@svadmin/sveltekit": ["@svadmin/sveltekit@0.9.4", "", { "peerDependencies": { "@svadmin/core": "^0.27.1", "@sveltejs/kit": "^2.0.0", "svelte": "^5.0.0" }, "optionalPeers": ["@svadmin/core", "@sveltejs/kit", "svelte"] }, "sha512-PpkQQRyDJ+Byllxmh6s4LgjqA8ZoqRd6u6mV3BWMCa5UX87Xz3CCOmm/V9okxjSErLxABc9sgDOiEskAYLBphQ=="],
+    "@svadmin/sveltekit": ["@svadmin/sveltekit@0.9.6", "", { "peerDependencies": { "@svadmin/core": "^0.32.2", "@sveltejs/kit": "^2.0.0", "svelte": "^5.0.0" }, "optionalPeers": ["@svadmin/core", "@sveltejs/kit", "svelte"] }, "sha512-JaGpIbe61M5C/nKRrCObVWeI949w+O70r0NffsrPF8MDR0WnIpo9vl5Ev+8IA2+WsgVjDQtmQHR1kNStTLG8Ww=="],
 
     "@svadmin/ui": ["@svadmin/ui@0.38.7", "", { "dependencies": { "@floating-ui/dom": "^1.8.0", "@lucide/svelte": "^1.25.0", "@tanstack/svelte-store": "^0.12.0", "@tanstack/svelte-table": "9.0.0-alpha.53", "@tanstack/table-core": "9.0.0-alpha.53", "bits-ui": "^2.18.1", "clsx": "^2.1.1", "svelte-sonner": "^1.1.1", "tailwind-merge": "^3.6.0", "tailwind-variants": "^3.2.2" }, "peerDependencies": { "@svadmin/core": "^0.32.2", "@svadmin/editor": "*", "@tanstack/svelte-query": "^6.1.29", "highlight.js": "^11.11.1", "isomorphic-dompurify": "^3.15.0", "marked": "^18.0.0", "marked-highlight": "^2.2.3", "svelte": "^5.33.0" }, "optionalPeers": ["@svadmin/core", "@svadmin/editor", "@tanstack/svelte-query", "highlight.js", "isomorphic-dompurify", "marked", "marked-highlight", "svelte"] }, "sha512-FalTUTGMWeWuZx+8ePO3t7cuF+mjMjCwb3wht3AP+4xMIqQeGqaiGhrVBBfSMus7j+PgHjo5MuKv6glktD8Nug=="],
 

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@svadmin/core": "^0.32.2",
     "@svadmin/elysia": "^0.10.7",
-    "@svadmin/sveltekit": "^0.9.4",
+    "@svadmin/sveltekit": "^0.9.6",
     "@svadmin/ui": "^0.38.7",
     "@tanstack/svelte-query": "^6.1.38",
     "highlight.js": "^11.11.1",

--- a/packages/web-console/src/routes/page.test.ts
+++ b/packages/web-console/src/routes/page.test.ts
@@ -46,10 +46,11 @@ describe("SupaCloud root dashboard", () => {
   test("tracks the latest stable svadmin packages and Vite compatibility rule", () => {
     expect(packageJson.dependencies["@svadmin/core"]).toBe("^0.32.2");
     expect(packageJson.dependencies["@svadmin/ui"]).toBe("^0.38.7");
-    expect(packageJson.dependencies["@svadmin/sveltekit"]).toBe("^0.9.4");
+    expect(packageJson.dependencies["@svadmin/sveltekit"]).toBe("^0.9.6");
     expect(packageJson.dependencies["@svadmin/elysia"]).toBe("^0.10.7");
     expect(lockSource).toContain('"@svadmin/core@0.32.2"');
     expect(lockSource).toContain('"@svadmin/ui@0.38.7"');
+    expect(lockSource).toContain('"@svadmin/sveltekit@0.9.6"');
     expect(viteSource).toContain("'@svadmin/core'");
   });
 });


### PR DESCRIPTION
## Summary
- upgrade `@svadmin/sveltekit` from `^0.9.4` to `^0.9.6`
- refresh the Bun lockfile and verify the npm integrity for 0.9.6
- add an explicit lockfile regression assertion for the SvelteKit adapter

## Release timing
PR #593 was submitted at 06:14:50Z while npm still returned 404 for 0.9.6. `@svadmin/sveltekit@0.9.6` was published at 06:17:02Z, shortly before #593 merged at 06:19:57Z, so this follow-up applies the now-installable package without rewriting the historically accurate #593 submission context.

## Verification
- `bun install --frozen-lockfile`
- `bun test src` (76 pass)
- `bun run check` (0 errors, 0 warnings)
- `bun run build`
- `bun audit --audit-level high`
- `git diff --check`