### PR TITLE
fix(release): preserve conventional squash titles

### DIFF
--- a/.github/scripts/ai-review-merge.mjs
+++ b/.github/scripts/ai-review-merge.mjs
@@ -300,8 +300,12 @@ export function validatePullRequestForMerge(prDetails, {
   const headSha = prDetails.head?.sha;
   const headRef = prDetails.head?.ref;
   const baseRef = prDetails.base?.ref;
-  if (!headSha || !headRef || !baseRef) {
+  const title = typeof prDetails.title === 'string' ? prDetails.title.trim() : '';
+  if (!headSha || !headRef || !baseRef || !title) {
     throw new Error('Pull request metadata is incomplete.');
+  }
+  if (/\r|\n/.test(title)) {
+    throw new Error('Pull request title must be a single line.');
   }
   if (!expectedHeadSha || headSha !== expectedHeadSha) {
     throw new Error(`Pull request head SHA changed (expected ${expectedHeadSha || 'missing'}, current ${headSha}).`);
@@ -316,7 +320,7 @@ export function validatePullRequestForMerge(prDetails, {
     throw new Error(`Pull request head ref changed (expected ${expectedHeadRef || 'missing'}, current ${headRef}).`);
   }
 
-  return { headSha, headRef, baseRef };
+  return { headSha, headRef, baseRef, title };
 }
 
 async function getPRComments() {
@@ -659,9 +663,9 @@ async function postComment(body) {
   });
 }
 
-export function buildMergeRequestBody({ prNumber, headRef, expectedHeadSha }) {
+export function buildMergeRequestBody({ prTitle, expectedHeadSha }) {
   return {
-    commit_title: `Merge pull request #${prNumber} from ${headRef}`,
+    commit_title: prTitle,
     merge_method: 'squash',
     sha: expectedHeadSha,
   };
@@ -680,8 +684,7 @@ async function mergePR({ expectedHeadSha, expectedHeadRef, expectedBaseRef }) {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(buildMergeRequestBody({
-      prNumber: PR_NUM,
-      headRef: current.headRef,
+      prTitle: current.title,
       expectedHeadSha,
     })),
   });

--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -174,6 +174,7 @@ describe('atomic merge preconditions', () => {
   const openPullRequest = {
     state: 'open',
     draft: false,
+    title: 'fix(release): preserve conventional commit titles',
     head: { sha: 'head-sha', ref: 'feature/harden-merge' },
     base: { ref: 'main' },
   };
@@ -187,6 +188,7 @@ describe('atomic merge preconditions', () => {
       headSha: 'head-sha',
       headRef: 'feature/harden-merge',
       baseRef: 'main',
+      title: 'fix(release): preserve conventional commit titles',
     });
 
     assert.throws(
@@ -222,15 +224,20 @@ describe('atomic merge preconditions', () => {
       }),
       /head ref changed/,
     );
+    assert.throws(
+      () => validatePullRequestForMerge({ ...openPullRequest, title: 'fix: valid\nInjected-Header: true' }, {
+        expectedHeadSha: 'head-sha', expectedHeadRef: 'feature/harden-merge', expectedBaseRef: 'main',
+      }),
+      /single line/,
+    );
   });
 
-  test('passes the expected head SHA to GitHub merge API', () => {
+  test('preserves the conventional PR title and expected SHA for squash commits', () => {
     assert.deepEqual(buildMergeRequestBody({
-      prNumber: '411',
-      headRef: 'feature/harden-merge',
+      prTitle: 'fix(console): ship svadmin upgrades',
       expectedHeadSha: 'head-sha',
     }), {
-      commit_title: 'Merge pull request #411 from feature/harden-merge',
+      commit_title: 'fix(console): ship svadmin upgrades',
       merge_method: 'squash',
       sha: 'head-sha',
     });

--- a/packages/web-console/src/routes/page.test.ts
+++ b/packages/web-console/src/routes/page.test.ts
@@ -43,7 +43,7 @@ describe("SupaCloud root dashboard", () => {
     expect(pageSource).not.toContain("images.unsplash.com");
   });
 
-  test("tracks the latest stable svadmin packages and Vite compatibility rule", () => {
+  test("locks the released svadmin adapters and Vite compatibility rule", () => {
     expect(packageJson.dependencies["@svadmin/core"]).toBe("^0.32.2");
     expect(packageJson.dependencies["@svadmin/ui"]).toBe("^0.38.7");
     expect(packageJson.dependencies["@svadmin/sveltekit"]).toBe("^0.9.6");


### PR DESCRIPTION
## Problem

The trusted review workflow uses squash mode but overwrites every resulting commit title with `Merge pull request #<number> from <branch>`. Release Please cannot parse that title. Run 30243037663 explicitly reported both #593 and #594 as unparseable and produced zero web-console commits, so the merged SvAdmin dependency updates cannot produce a release.

## Fix

- preserve the reviewed PR title as the squash commit title
- retain the immutable expected-head SHA check
- validate the external PR title as non-empty and single-line before using it
- cover the conventional-title path and multiline rejection

This PR changes the trusted review control code and therefore intentionally requires human review under the repository self-modification guard. Please use **squash merge** and retain this Conventional Commit title so Release Please can parse this fix and the pending web-console changes.

## Verification

- `node --check .github/scripts/ai-review-merge.mjs`
- `node --test .github/scripts/ai-review-merge.test.mjs` (13 pass)
- `git diff --check`