### PR TITLE
fix(upgrade): provision Edge Runtime account

### DIFF
--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -13,6 +13,8 @@ const RELEASE_REPOSITORY = "zuohuadong/supacloud";
 const RELEASE_SIGNER_WORKFLOW = `${RELEASE_REPOSITORY}/.github/workflows/release-please.yml`;
 const BIN_TARGET = "/usr/local/bin/supacloud";
 const DEFAULT_MANAGEMENT_ENV_FILE = "/etc/supabase/management-api.env";
+const DEFAULT_EDGE_RUNTIME_USER = "supacloud-edge";
+const DEFAULT_EDGE_RUNTIME_GROUP = "supacloud-edge";
 const LEGACY_CONFIG_FILE = "/opt/supacloud/config.env";
 const DEFAULT_GITHUB_PROXY = "https://ghproxy.net/";
 const WEB_CONSOLE_ASSET = "web-console-build.tar.gz";
@@ -25,6 +27,7 @@ const DEFAULT_EDGE_BACKGROUND_WORKER_POOL_SIZE = 20;
 const DEFAULT_EDGE_RESOURCE_RATIO = 0.6;
 const DEFAULT_EDGE_TASKS_MAX = 256;
 const WEB_CONSOLE_DIR_ENV_KEY = "WEB_CONSOLE_DIR";
+const LINUX_ACCOUNT_NAME = /^[a-z_][a-z0-9_-]{0,30}\$?$/;
 
 type GithubEndpoint = {
     label: string;
@@ -56,6 +59,24 @@ export type BinaryBackupState = {
     hadTarget: boolean;
     backupReady: boolean;
     activated: boolean;
+};
+
+type HostIdentityCommandResult = {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+};
+
+type HostIdentityCommandRunner = (command: string[]) => Promise<HostIdentityCommandResult>;
+
+export type EdgeRuntimeIdentity = {
+    user: string;
+    group: string;
+};
+
+type EdgeRuntimeIdentityOptions = {
+    platform?: NodeJS.Platform;
+    run?: HostIdentityCommandRunner;
 };
 
 export function createBinaryBackupState(targetPath: string, runId = randomUUID()): BinaryBackupState {
@@ -862,12 +883,99 @@ function upsertEnvFileValue(filePath: string, key: string, value: string) {
     }
 }
 
+function envFileHasNonEmptyValue(filePath: string, key: string): boolean {
+    if (!existsSync(filePath)) return false;
+    return Boolean(parseEnv(readFileSync(filePath, "utf8"))[key]?.trim());
+}
+
+export function upsertEdgeRuntimeIdentityDefaults(filePath: string, identity: EdgeRuntimeIdentity) {
+    if (!envFileHasNonEmptyValue(filePath, "EDGE_RUNTIME_USER")) {
+        upsertEnvFileValue(filePath, "EDGE_RUNTIME_USER", identity.user);
+    }
+    if (!envFileHasNonEmptyValue(filePath, "EDGE_RUNTIME_GROUP")) {
+        upsertEnvFileValue(filePath, "EDGE_RUNTIME_GROUP", identity.group);
+    }
+}
+
 export function upsertManagementWebConsoleDir(managementEnvPath: string = managementEnvFile()) {
     upsertEnvFileValue(managementEnvPath, WEB_CONSOLE_DIR_ENV_KEY, WEB_CONSOLE_CURRENT_LINK);
 }
 
 function managementEnvFile() {
     return process.env.SUPACLOUD_MANAGEMENT_ENV_FILE || DEFAULT_MANAGEMENT_ENV_FILE;
+}
+
+async function runHostIdentityCommand(command: string[]): Promise<HostIdentityCommandResult> {
+    const child = Bun.spawn({ cmd: command, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+    ]);
+    return { exitCode, stdout, stderr };
+}
+
+function validatedAccountName(value: string | undefined, fallback: string, label: string): string {
+    const accountName = value?.trim() || fallback;
+    if (!LINUX_ACCOUNT_NAME.test(accountName)) {
+        throw new Error(`${label} is not a valid Linux account name`);
+    }
+    return accountName;
+}
+
+async function ensureHostGroup(group: string, run: HostIdentityCommandRunner): Promise<void> {
+    if ((await run(["getent", "group", group])).exitCode === 0) return;
+    const created = await run(["groupadd", "--system", group]);
+    if (created.exitCode === 0 || (await run(["getent", "group", group])).exitCode === 0) return;
+    throw new Error(`Failed to create Edge Runtime group ${group}: ${created.stderr.trim().slice(-300)}`);
+}
+
+async function verifyHostUser(user: string, group: string, run: HostIdentityCommandRunner): Promise<void> {
+    const uid = await run(["id", "-u", user]);
+    const primaryGroup = await run(["id", "-gn", user]);
+    if (uid.exitCode !== 0 || primaryGroup.exitCode !== 0) {
+        throw new Error(`Failed to verify Edge Runtime user ${user}`);
+    }
+    if (uid.stdout.trim() === "0" || primaryGroup.stdout.trim() !== group) {
+        throw new Error(`Existing Edge Runtime account ${user} violates the dedicated runtime-user contract`);
+    }
+}
+
+async function ensureHostUser(user: string, group: string, run: HostIdentityCommandRunner): Promise<void> {
+    const current = await run(["id", "-u", user]);
+    if (current.exitCode !== 0) {
+        const created = await run([
+            "useradd", "--system", "--no-create-home", "--home-dir", "/nonexistent",
+            "--shell", "/usr/sbin/nologin", "--gid", group, user,
+        ]);
+        if (created.exitCode !== 0 && (await run(["id", "-u", user])).exitCode !== 0) {
+            throw new Error(`Failed to create Edge Runtime user ${user}: ${created.stderr.trim().slice(-300)}`);
+        }
+    }
+    await verifyHostUser(user, group, run);
+}
+
+export async function ensureEdgeRuntimeIdentity(
+    env: Record<string, string | undefined>,
+    options: EdgeRuntimeIdentityOptions = {},
+): Promise<EdgeRuntimeIdentity> {
+    const user = validatedAccountName(env.EDGE_RUNTIME_USER, DEFAULT_EDGE_RUNTIME_USER, "EDGE_RUNTIME_USER");
+    const group = validatedAccountName(env.EDGE_RUNTIME_GROUP, DEFAULT_EDGE_RUNTIME_GROUP, "EDGE_RUNTIME_GROUP");
+    if ((options.platform ?? process.platform) !== "linux") return { user, group };
+
+    const run = options.run ?? runHostIdentityCommand;
+    await ensureHostGroup(group, run);
+    await ensureHostUser(user, group, run);
+    return { user, group };
+}
+
+export async function ensurePersistedEdgeRuntimeIdentity(
+    filePath: string,
+    options: EdgeRuntimeIdentityOptions = {},
+): Promise<EdgeRuntimeIdentity> {
+    const identity = await ensureEdgeRuntimeIdentity(await readEnvFile(filePath), options);
+    upsertEdgeRuntimeIdentityDefaults(filePath, identity);
+    return identity;
 }
 
 function edgeRuntimeCapacityDropIn() {
@@ -1089,6 +1197,7 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                 if (!activationState) throw new Error("Upgrade activation state is unavailable");
                 activationState.managementEnvState = captureFileState(managementEnvFile());
                 activationState.edgeRuntimeDropInState = captureFileState(edgeRuntimeCapacityDropIn());
+                await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
                 await ensureRuntimeModeForBinaryUpgrade();
                 await ensureEdgeRuntimeCapacityDropIn(env);
                 upsertManagementWebConsoleDir(managementEnvFile());

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -9,6 +9,8 @@ import {
     cleanupBinaryBackup,
     createBinaryBackupState,
     executeUpgradeTransaction,
+    ensureEdgeRuntimeIdentity,
+    ensurePersistedEdgeRuntimeIdentity,
     normalizeManagementReleaseTag,
     prepareUpgradeSecrets,
     resolveArtifactVerificationMode,
@@ -21,6 +23,7 @@ import {
     selectManagementRelease,
     stopManagementService,
     upsertManagementWebConsoleDir,
+    upsertEdgeRuntimeIdentityDefaults,
     validateWebConsoleArchiveEntries,
     verifyArtifactChecksum,
     waitForManagementHealth,
@@ -44,6 +47,127 @@ afterEach(() => {
 });
 
 describe("upgrade release selection", () => {
+  test("creates the dedicated Edge Runtime identity during a Linux upgrade", async () => {
+    const commands: string[][] = [];
+    const responses = [
+      { exitCode: 2, stdout: "", stderr: "missing group" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 1, stdout: "", stderr: "missing user" },
+      { exitCode: 0, stdout: "", stderr: "" },
+      { exitCode: 0, stdout: "998\n", stderr: "" },
+      { exitCode: 0, stdout: "supacloud-edge\n", stderr: "" },
+    ];
+
+    const identity = await ensureEdgeRuntimeIdentity({}, {
+      platform: "linux",
+      run: async (command) => {
+        commands.push(command);
+        const response = responses.shift();
+        if (!response) throw new Error("Unexpected identity command");
+        return response;
+      },
+    });
+
+    expect(identity).toEqual({ user: "supacloud-edge", group: "supacloud-edge" });
+    expect(commands).toEqual([
+      ["getent", "group", "supacloud-edge"],
+      ["groupadd", "--system", "supacloud-edge"],
+      ["id", "-u", "supacloud-edge"],
+      [
+        "useradd", "--system", "--no-create-home", "--home-dir", "/nonexistent",
+        "--shell", "/usr/sbin/nologin", "--gid", "supacloud-edge", "supacloud-edge",
+      ],
+      ["id", "-u", "supacloud-edge"],
+      ["id", "-gn", "supacloud-edge"],
+    ]);
+  });
+
+  test("rejects a privileged or mismatched existing Edge Runtime account", async () => {
+    const responses = [
+      { exitCode: 0, stdout: "supacloud-edge:x:998:\n", stderr: "" },
+      { exitCode: 0, stdout: "0\n", stderr: "" },
+      { exitCode: 0, stdout: "0\n", stderr: "" },
+      { exitCode: 0, stdout: "supacloud-edge\n", stderr: "" },
+    ];
+
+    await expect(ensureEdgeRuntimeIdentity({}, {
+      platform: "linux",
+      run: async () => {
+        const response = responses.shift();
+        if (!response) throw new Error("Unexpected identity command");
+        return response;
+      },
+    })).rejects.toThrow("violates the dedicated runtime-user contract");
+  });
+
+  test("keeps an existing dedicated Edge Runtime identity unchanged", async () => {
+    const commands: string[][] = [];
+    const responses = [
+      { exitCode: 0, stdout: "supacloud-edge:x:998:\n", stderr: "" },
+      { exitCode: 0, stdout: "998\n", stderr: "" },
+      { exitCode: 0, stdout: "998\n", stderr: "" },
+      { exitCode: 0, stdout: "supacloud-edge\n", stderr: "" },
+    ];
+
+    await ensureEdgeRuntimeIdentity({}, {
+      platform: "linux",
+      run: async (command) => {
+        commands.push(command);
+        const response = responses.shift();
+        if (!response) throw new Error("Unexpected identity command");
+        return response;
+      },
+    });
+
+    expect(commands.every(([command]) => command !== "groupadd" && command !== "useradd")).toBe(true);
+  });
+
+  test("adds missing Edge Runtime defaults without replacing custom account values", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-edge-identity-"));
+    const envFile = join(dir, "management-api.env");
+    writeFileSync(envFile, "EDGE_RUNTIME_USER=custom-edge\nEDGE_RUNTIME_GROUP=\nPORT=9090\n", { mode: 0o600 });
+
+    try {
+      upsertEdgeRuntimeIdentityDefaults(envFile, {
+        user: "supacloud-edge",
+        group: "supacloud-edge",
+      });
+      expect(readFileSync(envFile, "utf8")).toBe(
+        "EDGE_RUNTIME_USER=custom-edge\nEDGE_RUNTIME_GROUP=supacloud-edge\nPORT=9090\n",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("provisions the identity from the persistent service environment", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-persisted-edge-"));
+    const envFile = join(dir, "management-api.env");
+    writeFileSync(envFile, "EDGE_RUNTIME_USER=file-edge\nEDGE_RUNTIME_GROUP=file-edge-group\n", { mode: 0o600 });
+
+    try {
+      const identity = await ensurePersistedEdgeRuntimeIdentity(envFile, { platform: "darwin" });
+      expect(identity).toEqual({ user: "file-edge", group: "file-edge-group" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("replaces empty persisted Edge Runtime identity values", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-empty-edge-"));
+    const envFile = join(dir, "management-api.env");
+    writeFileSync(envFile, "EDGE_RUNTIME_USER=\nEDGE_RUNTIME_GROUP=\n", { mode: 0o600 });
+
+    try {
+      upsertEdgeRuntimeIdentityDefaults(envFile, { user: "supacloud-edge", group: "supacloud-edge" });
+      expect(readFileSync(envFile, "utf8")).toBe(
+        "EDGE_RUNTIME_USER=supacloud-edge\nEDGE_RUNTIME_GROUP=supacloud-edge\n",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("restores the old runtime key when init-db fails before the rotation checkpoint", async () => {
     const events: string[] = [];
     const prepared = prepareUpgradeSecrets({


### PR DESCRIPTION
## 问题\n旧版 SupaCloud 主机执行二进制升级时，升级事务会激活新的 embedded/external Edge Runtime 配置，但不会迁移 `supacloud-edge` 系统用户和组；随后降权启动失败。Rocky Linux 10 上还验证到 `runuser` 的 PAM `pam_keyinit` 会被 Management API 的 systemd seccomp 沙箱以 `SIGSYS` 终止。\n\n## 修复\n- 在升级重启前幂等创建并验证专用 Linux group/user。\n- 拒绝 root UID 或主组不匹配的既有账号；账号名在命令边界校验。\n- 以持久化 `management-api.env` 为账号配置来源，空键按缺失处理，不覆盖非空自定义账号。\n- embedded Edge 使用无 PAM 的 `setpriv` 降权，避免开放 keyring syscall。\n- 仅为 embedded 模式补 `CAP_SETUID/CAP_SETGID`，并把升级 drop-in 纳入现有制品回滚。\n\n全新安装路径已有账号创建逻辑，本 PR 补齐旧版本二进制升级以及 systemd sandbox 兼容路径。\n\n## 验证\n- `bun run typecheck`\n- `bun run test:unit`（132 个单元测试文件）\n- 相关定向测试（61 passed）\n- Rocky Linux 10 现场证据：旧 `runuser` 路径由 `pam_keyinit` 触发 `SIGSYS`；新实现不允许 keyring，也不回退 root\n