### PR TITLE
fix(edge): harden embedded runtime privilege drop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,7 @@ PGREDIS_RUNTIME_BIN_FILE="${SUPACLOUD_PGREDIS_RUNTIME_BIN_FILE:-/usr/local/bin/s
 PGREDIS_RUNTIME_UNIT_FILE="${SUPACLOUD_PGREDIS_RUNTIME_UNIT_FILE:-/etc/systemd/system/supacloud-pgredis-runtime.service}"
 PGREDIS_RUNTIME_SOURCE_DIR="${SUPACLOUD_PGREDIS_RUNTIME_SOURCE_DIR:-/opt/supacloud/pgredis-runtime}"
 PGREDIS_TENANT_CONFIG_DIR="${SUPACLOUD_PGREDIS_TENANT_CONFIG_DIR:-/etc/supabase/pgredis-tenants}"
+MANAGEMENT_EDGE_PRIVILEGE_DROPIN="${SUPACLOUD_EMBEDDED_EDGE_PRIVILEGE_DROPIN:-/etc/systemd/system/supacloud.service.d/50-embedded-edge-privilege.conf}"
 PGREDIS_INSTALL_TRANSACTION_DIR=""
 CREDENTIALS_FILE="${SUPACLOUD_CREDENTIALS_FILE:-/etc/supabase/supacloud-credentials.env}"
 MASTER_TOKEN_FILE="${SUPACLOUD_MASTER_TOKEN_FILE:-/etc/supabase/master-token.env}"
@@ -2827,6 +2828,7 @@ capture_management_api_install() {
         supacloud_capture_file_snapshot "$MANAGEMENT_ENV_FILE" "${transaction_dir}/env" &&
         supacloud_capture_file_snapshot "$EDGE_RUNTIME_ENV_FILE" "${transaction_dir}/edge-env" &&
         supacloud_capture_file_snapshot /etc/systemd/system/supacloud.service "${transaction_dir}/unit" &&
+        supacloud_capture_file_snapshot "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN" "${transaction_dir}/edge-privilege-dropin" &&
         supacloud_capture_file_snapshot /usr/local/libexec/supacloud/tenant-user "${transaction_dir}/tenant-user-helper" &&
         supacloud_capture_file_snapshot /etc/systemd/system/supacloud-tenant-user@.service "${transaction_dir}/tenant-user-unit" &&
         supacloud_capture_file_snapshot /usr/local/libexec/supacloud/systemd-unit "${transaction_dir}/systemd-unit-helper" &&
@@ -2843,6 +2845,7 @@ recover_management_api_install() {
     fi
     supacloud_restore_file_snapshot /usr/local/bin/supacloud "${transaction_dir}/binary" || return 1
     supacloud_restore_file_snapshot /etc/systemd/system/supacloud.service "${transaction_dir}/unit" || return 1
+    supacloud_restore_file_snapshot "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN" "${transaction_dir}/edge-privilege-dropin" || return 1
     supacloud_restore_file_snapshot /usr/local/libexec/supacloud/tenant-user "${transaction_dir}/tenant-user-helper" || return 1
     supacloud_restore_file_snapshot /etc/systemd/system/supacloud-tenant-user@.service "${transaction_dir}/tenant-user-unit" || return 1
     supacloud_restore_file_snapshot /usr/local/libexec/supacloud/systemd-unit "${transaction_dir}/systemd-unit-helper" || return 1
@@ -2851,11 +2854,53 @@ recover_management_api_install() {
         supacloud_restore_file_snapshot "$MANAGEMENT_ENV_FILE" "${transaction_dir}/env" || return 1
     fi
     supacloud_restore_file_snapshot "$EDGE_RUNTIME_ENV_FILE" "${transaction_dir}/edge-env" || return 1
+    local restored_edge_runtime_mode
+    restored_edge_runtime_mode=$(management_edge_runtime_mode) || return 1
+    if [[ "$keep_current_env" == "true" ]]; then
+        configure_management_edge_privilege_dropin "$restored_edge_runtime_mode" || return 1
+    fi
     systemctl daemon-reload >/dev/null 2>&1 || return 1
     if [[ "$service_was_active" == "true" ]]; then
         systemctl start supacloud >/dev/null 2>&1 || return 1
         supacloud_wait_http_health http://127.0.0.1:9090/health || return 1
+        ensure_management_edge_runtime_ready "$restored_edge_runtime_mode" || return 1
     fi
+}
+
+management_edge_runtime_mode() {
+    local persisted_mode
+    persisted_mode=$(supacloud_env_value "$MANAGEMENT_ENV_FILE" EDGE_RUNTIME_MODE) || return 1
+    case "$persisted_mode" in
+        ""|embedded) printf 'embedded' ;;
+        external) printf 'external' ;;
+        *)
+            log_error "Invalid persisted EDGE_RUNTIME_MODE: $persisted_mode"
+            return 1
+            ;;
+    esac
+}
+
+ensure_management_edge_runtime_ready() {
+    local runtime_mode="$1"
+    if [[ "$runtime_mode" == "external" ]]; then
+        systemctl restart supacloud-edge-runtime || log_warn "systemctl restart supacloud-edge-runtime returned non-zero; deferring readiness to the health check"
+    fi
+    supacloud_wait_http_health http://127.0.0.1:9000/health
+}
+
+configure_management_edge_privilege_dropin() {
+    local runtime_mode="$1"
+    if [[ "$runtime_mode" == "external" ]]; then
+        rm -f "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN"
+        return
+    fi
+    install -d -m 0755 "$(dirname "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN")"
+    install -m 0644 /dev/stdin "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN" <<'EOF'
+[Service]
+# The embedded Edge Runtime uses setpriv to drop privileges before tenant code starts.
+CapabilityBoundingSet=
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID
+EOF
 }
 
 install_management_api() {
@@ -3120,7 +3165,14 @@ install_management_api() {
     # after preserving an exact rollback copy of every runtime file it uses.
     log_info "Activating Management API binary and systemd unit..."
     local activation_status=0
-    write_management_api_systemd_unit "$BIN_TARGET" || activation_status=$?
+    local active_edge_runtime_mode=""
+    active_edge_runtime_mode=$(management_edge_runtime_mode) || activation_status=$?
+    if (( activation_status == 0 )); then
+        write_management_api_systemd_unit "$BIN_TARGET" || activation_status=$?
+    fi
+    if (( activation_status == 0 )); then
+        configure_management_edge_privilege_dropin "$active_edge_runtime_mode" || activation_status=$?
+    fi
     if (( activation_status == 0 )); then
         install_tenant_user_helper || activation_status=$?
     fi
@@ -3155,12 +3207,15 @@ install_management_api() {
     if (( activation_status == 0 )); then
         supacloud_wait_http_health http://127.0.0.1:9090/health || activation_status=$?
     fi
+    if (( activation_status == 0 )); then
+        ensure_management_edge_runtime_ready "$active_edge_runtime_mode" || activation_status=$?
+    fi
     if (( activation_status != 0 )); then
         management_keep_current_env_on_abort="true"
         log_error "Management API activation failed; the previous binary was restored with the committed encryption key"
         abort_management_install_transaction "$management_transaction_dir" "$management_service_was_active" true "$activation_status"
     fi
-    log_info "SupaCloud Management API is healthy"
+    log_info "SupaCloud Management API and Edge Runtime are healthy"
 
     # Management and pgredis are now one healthy control-plane baseline. Commit
     # both before optional watchdog and GoTrue follow-up work can fail.

--- a/packages/management-api/src/plugins/edge-runtime-manager.ts
+++ b/packages/management-api/src/plugins/edge-runtime-manager.ts
@@ -62,7 +62,7 @@ export function buildEdgeRuntimeCommand(
     user: string;
     group: string;
     isRoot: boolean;
-    runuserPath?: string;
+    setprivPath?: string;
   },
 ): string[] {
   const command = [options.bunPath, "run", runnerPath];
@@ -71,16 +71,17 @@ export function buildEdgeRuntimeCommand(
     throw new Error("EDGE_RUNTIME_USER is required when Management API runs as root");
   }
 
-  const runuser = options.runuserPath;
-  if (!runuser) {
-    throw new Error("EDGE_RUNTIME_USER requires runuser for embedded privilege separation");
+  const setpriv = options.setprivPath;
+  if (!setpriv) {
+    throw new Error("EDGE_RUNTIME_USER requires setpriv for embedded privilege separation");
   }
   return [
-    runuser,
-    "--user",
+    setpriv,
+    "--reuid",
     options.user,
-    "--group",
+    "--regid",
     options.group || options.user,
+    "--clear-groups",
     "--",
     ...command,
   ];
@@ -92,7 +93,7 @@ function edgeRuntimeCommand(runnerPath: string): string[] {
     user: config.edgeRuntimeUser,
     group: config.edgeRuntimeGroup,
     isRoot: process.getuid?.() === 0,
-    runuserPath: ["/usr/sbin/runuser", "/sbin/runuser"].find(existsSync),
+    setprivPath: ["/usr/bin/setpriv", "/bin/setpriv"].find(existsSync),
   });
 }
 

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -22,6 +22,7 @@ const WEB_CONSOLE_ROOT = "/opt/supacloud/web-console";
 const WEB_CONSOLE_RELEASES_DIR = `${WEB_CONSOLE_ROOT}/releases`;
 const WEB_CONSOLE_CURRENT_LINK = WEB_CONSOLE_CURRENT_DIR;
 const DEFAULT_EDGE_RUNTIME_CAPACITY_DROPIN = "/etc/systemd/system/supacloud-edge-runtime.service.d/50-edge-runtime-capacity.conf";
+const DEFAULT_EMBEDDED_EDGE_PRIVILEGE_DROPIN = "/etc/systemd/system/supacloud.service.d/50-embedded-edge-privilege.conf";
 const DEFAULT_EDGE_WORKER_POOL_SIZE = 20;
 const DEFAULT_EDGE_BACKGROUND_WORKER_POOL_SIZE = 20;
 const DEFAULT_EDGE_RESOURCE_RATIO = 0.6;
@@ -538,6 +539,15 @@ OOMPolicy=stop
 `;
 }
 
+export function buildEmbeddedEdgePrivilegeDropIn() {
+    return `[Service]
+# The embedded Edge Runtime uses setpriv to drop from the root Management API
+# account before any tenant function code starts.
+CapabilityBoundingSet=
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID
+`;
+}
+
 async function downloadAsset(downloadUrl: string, localPath: string, preferredEndpoint: GithubEndpoint, forceYes?: boolean) {
     let lastError = "";
     let endpoints = buildGithubEndpoints(preferredEndpoint.proxyPrefix || undefined);
@@ -982,6 +992,10 @@ function edgeRuntimeCapacityDropIn() {
     return process.env.SUPACLOUD_EDGE_RUNTIME_CAPACITY_DROPIN || DEFAULT_EDGE_RUNTIME_CAPACITY_DROPIN;
 }
 
+function embeddedEdgePrivilegeDropIn() {
+    return process.env.SUPACLOUD_EMBEDDED_EDGE_PRIVILEGE_DROPIN || DEFAULT_EMBEDDED_EDGE_PRIVILEGE_DROPIN;
+}
+
 function writeFileAtomically(filePath: string, content: string, mode: number) {
     mkdirSync(path.dirname(filePath), { recursive: true });
     const temporaryPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
@@ -994,12 +1008,31 @@ function writeFileAtomically(filePath: string, content: string, mode: number) {
     }
 }
 
-async function ensureRuntimeModeForBinaryUpgrade() {
-    const edgeUnit = await $`systemctl list-unit-files supacloud-edge-runtime.service --no-legend`.nothrow().quiet();
-    const edgeServiceKnown = edgeUnit.exitCode === 0 && edgeUnit.stdout.toString().includes("supacloud-edge-runtime.service");
-    if (!edgeServiceKnown) return;
+async function runtimeModeForBinaryUpgrade(): Promise<"embedded" | "external"> {
+    const persistedEnv = await readEnvFile(managementEnvFile());
+    return resolvePersistedEdgeRuntimeMode(persistedEnv.EDGE_RUNTIME_MODE);
+}
 
-    upsertEnvFileValue(managementEnvFile(), "EDGE_RUNTIME_MODE", "external");
+export function resolvePersistedEdgeRuntimeMode(persistedMode?: string): "embedded" | "external" {
+    if (persistedMode === undefined || persistedMode === "" || persistedMode === "embedded") return "embedded";
+    if (persistedMode === "external") return "external";
+    throw new Error(`Invalid persisted EDGE_RUNTIME_MODE: ${persistedMode}`);
+}
+
+async function reloadSystemdUnits() {
+    const reload = await $`systemctl daemon-reload`.nothrow().quiet();
+    if (reload.exitCode !== 0) {
+        throw new Error(`Failed to reload systemd units: ${reload.stderr.toString().trim().slice(-500)}`);
+    }
+}
+
+async function reconcileEmbeddedEdgePrivilegeDropIn(mode: "embedded" | "external") {
+    if (mode === "embedded") {
+        writeFileAtomically(embeddedEdgePrivilegeDropIn(), buildEmbeddedEdgePrivilegeDropIn(), 0o644);
+    } else {
+        rmSync(embeddedEdgePrivilegeDropIn(), { force: true });
+    }
+    await reloadSystemdUnits();
 }
 
 async function ensureEdgeRuntimeCapacityDropIn(env: Record<string, string | undefined>) {
@@ -1009,7 +1042,7 @@ async function ensureEdgeRuntimeCapacityDropIn(env: Record<string, string | unde
 
     const config = resolveEdgeRuntimeCapacityConfig({ env });
     writeFileAtomically(edgeRuntimeCapacityDropIn(), buildEdgeRuntimeCapacityDropIn(config), 0o644);
-    await $`systemctl daemon-reload`.nothrow().quiet();
+    await reloadSystemdUnits();
 }
 
 async function restartServices() {
@@ -1069,12 +1102,36 @@ export async function waitForManagementHealth() {
     throw new Error(`SupaCloud failed the post-upgrade health checks: ${lastError ?? "timeout"}`);
 }
 
+export async function waitForEdgeRuntimeHealth() {
+    const attempts = positiveInteger(process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS, 30);
+    let lastError = "timeout";
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            const response = await fetch("http://127.0.0.1:9000/health", {
+                signal: AbortSignal.timeout(2_000),
+            });
+            if (response.ok) return;
+            lastError = `returned HTTP ${response.status}`;
+        } catch (error: unknown) {
+            lastError = error instanceof Error ? error.message : String(error);
+        }
+        await Bun.sleep(1_000);
+    }
+    throw new Error(`Edge Runtime failed the post-upgrade health check: ${lastError}`);
+}
+
+export async function waitForUpgradeHealth() {
+    await waitForManagementHealth();
+    await waitForEdgeRuntimeHealth();
+}
+
 type UpgradeActivationState = {
     binary: BinaryBackupState;
     oldWebTarget: string | null;
     oldWebBackup: string | null;
     managementEnvState: FileState | null;
     edgeRuntimeDropInState: FileState | null;
+    embeddedEdgePrivilegeDropInState: FileState | null;
 };
 
 async function activateArtifacts(stagedBinary: StagedBinary, stagedWeb: StagedWebConsole | null, state: UpgradeActivationState) {
@@ -1118,11 +1175,14 @@ async function rollbackArtifacts(state: UpgradeActivationState, stagedWeb: Stage
     }
     if (state.edgeRuntimeDropInState) {
         restoreFileState(state.edgeRuntimeDropInState);
-        await $`systemctl daemon-reload`.nothrow().quiet();
     }
+    if (state.embeddedEdgePrivilegeDropInState) {
+        restoreFileState(state.embeddedEdgePrivilegeDropInState);
+    }
+    await reloadSystemdUnits();
 
     await restartServices();
-    await waitForManagementHealth();
+    await waitForUpgradeHealth();
 }
 
 export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: string } = {}) {
@@ -1165,6 +1225,7 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
         let committed = false;
         let downloadEndpointLabel = endpoint.label;
         let webConsoleEndpointLabel: string | null = null;
+        let activatedEdgeRuntimeMode: "embedded" | "external" | null = null;
 
         await executeUpgradeTransaction({
             stage: async () => {
@@ -1189,6 +1250,7 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                     oldWebBackup: null,
                     managementEnvState: null,
                     edgeRuntimeDropInState: null,
+                    embeddedEdgePrivilegeDropInState: null,
                 };
                 await activateArtifacts(stagedBinary, stagedWeb, activationState);
             },
@@ -1197,15 +1259,18 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                 if (!activationState) throw new Error("Upgrade activation state is unavailable");
                 activationState.managementEnvState = captureFileState(managementEnvFile());
                 activationState.edgeRuntimeDropInState = captureFileState(edgeRuntimeCapacityDropIn());
+                activationState.embeddedEdgePrivilegeDropInState = captureFileState(embeddedEdgePrivilegeDropIn());
                 await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
-                await ensureRuntimeModeForBinaryUpgrade();
+                activatedEdgeRuntimeMode = await runtimeModeForBinaryUpgrade();
+                await reconcileEmbeddedEdgePrivilegeDropIn(activatedEdgeRuntimeMode);
                 await ensureEdgeRuntimeCapacityDropIn(env);
                 upsertManagementWebConsoleDir(managementEnvFile());
                 await restartServices();
             },
             healthCheck: async () => {
                 s.start("Waiting for the SupaCloud health endpoint");
-                await waitForManagementHealth();
+                if (!activatedEdgeRuntimeMode) throw new Error("Edge Runtime mode was not resolved");
+                await waitForUpgradeHealth();
                 committed = true;
             },
             rollback: async () => {

--- a/packages/management-api/tests/unit/edge-runtime-manager.security.test.ts
+++ b/packages/management-api/tests/unit/edge-runtime-manager.security.test.ts
@@ -35,23 +35,24 @@ describe("embedded Edge Runtime process boundary", () => {
       user: "",
       group: "",
       isRoot: true,
-      runuserPath: "/usr/sbin/runuser",
+      setprivPath: "/usr/bin/setpriv",
     })).toThrow("EDGE_RUNTIME_USER is required");
   });
 
-  test("uses runuser for an embedded runtime launched by root", () => {
+  test("uses setpriv for an embedded runtime launched by root", () => {
     expect(buildEdgeRuntimeCommand("/opt/supacloud/edge-runtime/server.ts", {
       bunPath: "/usr/local/bin/bun",
       user: "supacloud-edge",
       group: "supacloud-edge",
       isRoot: true,
-      runuserPath: "/usr/sbin/runuser",
+      setprivPath: "/usr/bin/setpriv",
     })).toEqual([
-      "/usr/sbin/runuser",
-      "--user",
+      "/usr/bin/setpriv",
+      "--reuid",
       "supacloud-edge",
-      "--group",
+      "--regid",
       "supacloud-edge",
+      "--clear-groups",
       "--",
       "/usr/local/bin/bun",
       "run",

--- a/packages/management-api/tests/unit/install-config.test.ts
+++ b/packages/management-api/tests/unit/install-config.test.ts
@@ -926,6 +926,86 @@ describe("installer configuration persistence", () => {
     expect(() => statSync(join(runtime, "extra.ts"))).toThrow();
   });
 
+  test("management Edge readiness restarts external mode and gates every mode on port 9000", () => {
+    const dir = makeTempDir();
+    const externalCalls = join(dir, "external-calls");
+    const external = runBash([
+      "source install.sh",
+      'systemctl() { printf "systemctl:%s\\n" "$*" >> "$CALLS"; return 1; }',
+      'log_warn() { printf "warn:%s\\n" "$*" >> "$CALLS"; }',
+      'supacloud_wait_http_health() { printf "health:%s\\n" "$1" >> "$CALLS"; return 0; }',
+      "ensure_management_edge_runtime_ready external",
+    ].join("; "), { CALLS: externalCalls });
+
+    expect(external.status, external.stderr).toBe(0);
+    expect(readFileSync(externalCalls, "utf8")).toBe([
+      "systemctl:restart supacloud-edge-runtime",
+      "warn:systemctl restart supacloud-edge-runtime returned non-zero; deferring readiness to the health check",
+      "health:http://127.0.0.1:9000/health",
+      "",
+    ].join("\n"));
+
+    const embeddedCalls = join(dir, "embedded-calls");
+    const embedded = runBash([
+      "source install.sh",
+      'systemctl() { printf "unexpected-systemctl\\n" >> "$CALLS"; }',
+      'supacloud_wait_http_health() { printf "health:%s\\n" "$1" >> "$CALLS"; return 7; }',
+      "ensure_management_edge_runtime_ready embedded",
+    ].join("; "), { CALLS: embeddedCalls });
+
+    expect(embedded.status).toBe(7);
+    expect(readFileSync(embeddedCalls, "utf8")).toBe("health:http://127.0.0.1:9000/health\n");
+  });
+
+  test("management Edge mode uses the persisted service environment and fails closed", () => {
+    const dir = makeTempDir();
+    const runtimeEnv = join(dir, "management-api.env");
+    const resolveMode = () => runBash(
+      "source install.sh; management_edge_runtime_mode",
+      { SUPACLOUD_MANAGEMENT_ENV_FILE: runtimeEnv },
+    );
+
+    writeFileSync(runtimeEnv, "EDGE_RUNTIME_MODE=external\n");
+    expect(resolveMode().stdout).toBe("external");
+    writeFileSync(runtimeEnv, "OTHER=value\n");
+    expect(resolveMode().stdout).toBe("embedded");
+    writeFileSync(runtimeEnv, "EDGE_RUNTIME_MODE=invalid\n");
+    expect(resolveMode().status).not.toBe(0);
+  });
+
+  test("management recovery reconciles the privilege drop-in when the committed mode changes", () => {
+    const runRecovery = (runtimeMode: "embedded" | "external", priorDropIn: "present" | "absent") => {
+      const dir = makeTempDir();
+      const runtimeEnv = join(dir, "management-api.env");
+      const edgeRuntimeEnv = join(dir, "edge-runtime.env");
+      const privilegeDropIn = join(dir, "supacloud.service.d", "50-embedded-edge-privilege.conf");
+      writeFileSync(runtimeEnv, `EDGE_RUNTIME_MODE=${runtimeMode}\n`);
+
+      const recovery = runBash([
+        "source install.sh",
+        'supacloud_restore_file_snapshot() { if [[ "$1" == "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN" ]]; then if [[ "$PRIOR_DROPIN" == "present" ]]; then install -D -m 0644 /dev/stdin "$1" <<< "old-drop-in"; else rm -f "$1"; fi; fi; return 0; }',
+        'systemctl() { [[ "$1" == "is-active" ]] && return 1; return 0; }',
+        "supacloud_wait_http_health() { return 0; }",
+        'recover_management_api_install "$SNAPSHOT" true true',
+      ].join("; "), {
+        PRIOR_DROPIN: priorDropIn,
+        SNAPSHOT: join(dir, "snapshot"),
+        SUPACLOUD_MANAGEMENT_ENV_FILE: runtimeEnv,
+        SUPACLOUD_EDGE_RUNTIME_ENV_FILE: edgeRuntimeEnv,
+        SUPACLOUD_EMBEDDED_EDGE_PRIVILEGE_DROPIN: privilegeDropIn,
+      });
+
+      expect(recovery.status, recovery.stderr).toBe(0);
+      return privilegeDropIn;
+    };
+
+    const externalDropIn = runRecovery("external", "present");
+    expect(() => statSync(externalDropIn)).toThrow();
+
+    const embeddedDropIn = runRecovery("embedded", "absent");
+    expect(readFileSync(embeddedDropIn, "utf8")).toContain("CAP_SETGID CAP_SETUID");
+  });
+
   test("pgredis transaction restores the previous data plane after a later install failure", () => {
     const dir = makeTempDir();
     const fakeBin = join(dir, "bin");

--- a/packages/management-api/tests/unit/pgredis-runtime-boundary.test.ts
+++ b/packages/management-api/tests/unit/pgredis-runtime-boundary.test.ts
@@ -85,7 +85,7 @@ describe("pgredis-runtime platform boundary", () => {
 
     expect(tenantRuntime).not.toContain('renderSystemdEnvLine("SUPABASE_DB_URL"');
     expect(edgeManager).not.toContain("...process.env");
-    expect(edgeManager).toContain("EDGE_RUNTIME_USER requires runuser");
+    expect(edgeManager).toContain("EDGE_RUNTIME_USER requires setpriv");
     expect(managementConfig).toContain('process.platform === "linux" ? "supacloud-edge" : ""');
     expect(denoCompat).not.toContain("kvStores");
     expect(denoCompat).toContain("Deno.openKv is disabled");

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -356,6 +356,20 @@ describe("runtime companion version assets", () => {
     expect(managementUnit).not.toContain("ReadWritePaths=/etc/supabase /etc/systemd/system ");
     expect(managementUnit).toContain("/run/supacloud-unit-requests");
     expect(managementUnit).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER");
+    expect(managementUnit).not.toContain("CAP_SETUID");
+    expect(installer).toContain("configure_management_edge_privilege_dropin");
+    expect(installer).toContain(
+      'MANAGEMENT_EDGE_PRIVILEGE_DROPIN="${SUPACLOUD_EMBEDDED_EDGE_PRIVILEGE_DROPIN:-/etc/systemd/system/supacloud.service.d/50-embedded-edge-privilege.conf}"',
+    );
+    expect(installer).toContain(
+      'supacloud_capture_file_snapshot "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN" "${transaction_dir}/edge-privilege-dropin"',
+    );
+    expect(installer).toContain(
+      'supacloud_restore_file_snapshot "$MANAGEMENT_EDGE_PRIVILEGE_DROPIN" "${transaction_dir}/edge-privilege-dropin"',
+    );
+    expect(installer.match(/ensure_management_edge_runtime_ready/g)).toHaveLength(3);
+    expect(installer).toContain("systemctl restart supacloud-edge-runtime");
+    expect(installer).toContain("http://127.0.0.1:9000/health");
     expect(managementUnit).toContain("SystemCallFilter=@system-service @chown");
     expect(managementUnit).not.toContain("@privileged");
     expect(installer).toContain("install_tenant_user_helper");

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
     buildEdgeRuntimeCapacityDropIn,
+    buildEmbeddedEdgePrivilegeDropIn,
     backupCurrentBinary,
     captureFileState,
     cleanupBinaryBackup,
@@ -16,6 +17,7 @@ import {
     resolveArtifactVerificationMode,
     resolveEdgeRuntimeCapacityConfig,
     resolveGithubEndpointPrefixes,
+    resolvePersistedEdgeRuntimeMode,
     resolveUpgradeEnvironment,
     runStagedDatabaseMigration,
     restoreCurrentBinary,
@@ -27,14 +29,18 @@ import {
     validateWebConsoleArchiveEntries,
     verifyArtifactChecksum,
     waitForManagementHealth,
+    waitForEdgeRuntimeHealth,
+    waitForUpgradeHealth,
 } from "../../src/upgrade";
 
 const originalFetch = globalThis.fetch;
 
 const originalUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS;
+const originalEdgeUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS;
 
 const ensureHealthTimeout = () => {
   process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS = "1";
+  process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS = "1";
 };
 
 afterEach(() => {
@@ -43,6 +49,11 @@ afterEach(() => {
     delete process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS;
   } else {
     process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS = originalUpgradeHealthAttempts;
+  }
+  if (originalEdgeUpgradeHealthAttempts === undefined) {
+    delete process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS;
+  } else {
+    process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS = originalEdgeUpgradeHealthAttempts;
   }
 });
 
@@ -528,6 +539,44 @@ describe("upgrade release selection", () => {
     ]);
   });
 
+  test("post-upgrade health check rejects an unavailable Edge Runtime", async () => {
+    ensureHealthTimeout();
+    globalThis.fetch = (async () => new Response("forbidden", { status: 403 })) as typeof fetch;
+
+    await expect(waitForEdgeRuntimeHealth()).rejects.toThrow("returned HTTP 403");
+  });
+
+  test("combined upgrade and rollback health rejects an unavailable restored Edge Runtime", async () => {
+    const calls: string[] = [];
+    ensureHealthTimeout();
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url === "http://127.0.0.1:9000/health") {
+        return new Response("unavailable", { status: 503 });
+      }
+      return new Response(url.endsWith("/") ? "<!doctype html>" : "ok", {
+        status: 200,
+        headers: { "content-type": url.endsWith("/") ? "text/html" : "application/json" },
+      });
+    }) as typeof fetch;
+
+    await expect(waitForUpgradeHealth()).rejects.toThrow("returned HTTP 503");
+    expect(calls).toEqual([
+      "http://127.0.0.1:9090/health",
+      "http://127.0.0.1:9090/",
+      "http://127.0.0.1:9000/health",
+    ]);
+  });
+
+  test("persisted Edge Runtime mode rejects invalid upgrade state", () => {
+    expect(resolvePersistedEdgeRuntimeMode(undefined)).toBe("embedded");
+    expect(resolvePersistedEdgeRuntimeMode("")).toBe("embedded");
+    expect(resolvePersistedEdgeRuntimeMode("embedded")).toBe("embedded");
+    expect(resolvePersistedEdgeRuntimeMode("external")).toBe("external");
+    expect(() => resolvePersistedEdgeRuntimeMode("externel")).toThrow("Invalid persisted EDGE_RUNTIME_MODE");
+  });
+
   test("normalizes management env WEB_CONSOLE_DIR to runtime link", () => {
     const envDir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-web-console-env-"));
     const managementEnv = join(envDir, "management-api.env");
@@ -542,6 +591,12 @@ describe("upgrade release selection", () => {
 });
 
 describe("upgrade edge-runtime capacity defaults", () => {
+  test("grants only the capabilities needed for embedded privilege drop", () => {
+    const dropIn = buildEmbeddedEdgePrivilegeDropIn();
+    expect(dropIn).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID");
+    expect(dropIn).not.toContain("@keyring");
+  });
+
   test("sizes systemd limits to sixty percent of a two-core node", () => {
     const config = resolveEdgeRuntimeCapacityConfig({
       env: {},


### PR DESCRIPTION
Follow-up to merged PR #599.\n\n### Summary\n\n- Replace PAM-backed runuser with setpriv and --clear-groups for embedded Edge Runtime privilege separation.\n- Keep CAP_SETUID and CAP_SETGID out of the canonical Management API unit; grant them only through an embedded-mode drop-in and remove that drop-in in external mode.\n- Make daemon-reload failures transactional, snapshot and restore the privilege drop-in, and fail closed on invalid persisted EDGE_RUNTIME_MODE values.\n- Restart external Edge Runtime after Management API readiness and require both Management API and Edge Runtime port 9000 health during install, upgrade, and rollback.\n\n### Verification\n\n- bash -n install.sh\n- bun run typecheck\n- 104 focused tests passed across the six security and upgrade test files\n- bun run test:unit: 1140 shared tests passed, followed by all isolated suites with exit code 0\n- git diff --check\n\nNo Caddy, certificate, production host, or unrelated runtime changes are included.