### PR TITLE
fix: run scheduled functions from serialized project config

### DIFF
--- a/packages/management-api/src/workers/scheduled-function.worker.ts
+++ b/packages/management-api/src/workers/scheduled-function.worker.ts
@@ -13,6 +13,7 @@
 import { sql } from "../db";
 import { config } from "../config";
 import { logger } from "../utils/logger";
+import { normalizeProjectConfig } from "../utils/project-config";
 import { projectRepository } from "../repositories/project.repository";
 import type { ScheduledFunctionConfig } from "../routes/scheduled-functions";
 
@@ -22,6 +23,25 @@ const INVOKE_TIMEOUT_MS = 30_000;
 interface DueSchedule {
   ref: string;
   schedule: ScheduledFunctionConfig;
+}
+
+export function scheduledFunctionsDueAt(
+  rows: { ref: string; config: unknown }[],
+  now: Date,
+): DueSchedule[] {
+  const due: DueSchedule[] = [];
+  for (const row of rows) {
+    const projectConfig = normalizeProjectConfig(row.config);
+    const rawSchedules = projectConfig.scheduled_functions;
+    if (!Array.isArray(rawSchedules)) continue;
+    for (const item of rawSchedules) {
+      if (!item || typeof item !== "object") continue;
+      const schedule = item as ScheduledFunctionConfig;
+      if (schedule.enabled === false || !schedule.cron || !schedule.slug) continue;
+      if (isDue(schedule.cron, now)) due.push({ ref: row.ref, schedule });
+    }
+  }
+  return due;
 }
 
 function parseField(field: string, min: number, max: number): Set<number> {
@@ -99,23 +119,7 @@ async function loadAllSchedules(): Promise<DueSchedule[]> {
     return [];
   }
 
-  const due: DueSchedule[] = [];
-  const now = new Date();
-  for (const row of rows) {
-    const cfg = (row.config && typeof row.config === "object" ? row.config : {}) as Record<string, unknown>;
-    const raw = cfg.scheduled_functions;
-    if (!Array.isArray(raw)) continue;
-    for (const item of raw) {
-      if (!item || typeof item !== "object") continue;
-      const schedule = item as ScheduledFunctionConfig;
-      if (schedule.enabled === false) continue;
-      if (!schedule.cron || !schedule.slug) continue;
-      if (isDue(schedule.cron, now)) {
-        due.push({ ref: row.ref, schedule });
-      }
-    }
-  }
-  return due;
+  return scheduledFunctionsDueAt(rows, new Date());
 }
 
 export interface TriggerResult {

--- a/packages/management-api/tests/unit/scheduled-function.worker.test.ts
+++ b/packages/management-api/tests/unit/scheduled-function.worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isDue } from "../../src/workers/scheduled-function.worker";
+import { isDue, scheduledFunctionsDueAt } from "../../src/workers/scheduled-function.worker";
 
 describe("scheduled-function cron parser (isDue)", () => {
   test("wildcard expression fires every minute", () => {
@@ -56,5 +56,33 @@ describe("scheduled-function cron parser (isDue)", () => {
     const date = new Date("2026-06-15T10:00:00Z");
     expect(isDue("not a cron", date)).toBe(false);
     expect(isDue("* * *", date)).toBe(false);
+  });
+});
+
+describe("scheduled-function selection", () => {
+  test("reads schedules from legacy JSON-string project config", () => {
+    const now = new Date("2026-06-15T10:30:00Z");
+    const due = scheduledFunctionsDueAt([
+      {
+        ref: "proj_1",
+        config: JSON.stringify({
+          scheduled_functions: [
+            {
+              id: "schedule_1",
+              name: "Every minute",
+              slug: "cleanup",
+              cron: "* * * * *",
+              method: "POST",
+              enabled: true,
+              created_at: "",
+              updated_at: "",
+            },
+          ],
+        }),
+      },
+    ], now);
+
+    expect(due).toHaveLength(1);
+    expect(due[0]).toMatchObject({ ref: "proj_1", schedule: { slug: "cleanup" } });
   });
 });


### PR DESCRIPTION
## Summary

- normalize project config before the scheduled-function worker reads schedules
- preserve compatibility with existing JSON-string config rows
- add a regression test for an every-minute schedule stored in serialized config

## Root cause

Scheduled-function CRUD already normalized legacy JSON-string project config, but the worker accepted only object-valued config. Schedules could be created and manually triggered while automatic cron ticks silently ignored them.

## Validation

- 15 focused scheduled-function tests passed
- full Management API unit suite passed
- TypeScript typecheck passed
- SQL module sync check passed
- Linux amd64 compiled binary built successfully