### PR TITLE
fix(pgredis): align test cache doubles with interfaces

### DIFF
--- a/packages/pgredis-runtime/src/app.test.ts
+++ b/packages/pgredis-runtime/src/app.test.ts
@@ -108,7 +108,7 @@ describe("pgredis-runtime internal API", () => {
     const acquiredRefs: string[] = [];
     let releases = 0;
     const cache: TenantCache = {
-      async get(key) { return `value:${key}`; },
+      async get<T = unknown>(key: string): Promise<T | null> { return `value:${key}` as T; },
       async set() { return true; },
       async delete() { return true; },
       async ttl() { return 250; },

--- a/packages/pgredis-runtime/src/cache-registry.postgres.test.ts
+++ b/packages/pgredis-runtime/src/cache-registry.postgres.test.ts
@@ -77,8 +77,8 @@ test.skipIf(!databaseUrl)("PostgreSQL commits notifications atomically and clear
 
       await first.cache.set("flush:a", { version: 1 });
       await first.cache.set("flush:b", { version: 1 });
-      expect(await second.cache.get("flush:a")).toEqual({ version: 1 });
-      expect(await second.cache.get("flush:b")).toEqual({ version: 1 });
+      expect(await second.cache.get<{ version: number }>("flush:a")).toEqual({ version: 1 });
+      expect(await second.cache.get<{ version: number }>("flush:b")).toEqual({ version: 1 });
       expect(await first.cache.flush()).toBe(2);
       await waitFor(() => notifications.some(({ op }) => op === "clearNamespace"));
       expect(await second.cache.get("flush:a")).toBeNull();

--- a/packages/pgredis-runtime/src/cache-registry.test.ts
+++ b/packages/pgredis-runtime/src/cache-registry.test.ts
@@ -7,7 +7,7 @@ import {
   type TenantCache,
 } from "./cache-registry";
 
-function fakeCache(): TenantCache {
+function fakeCache(): TenantCache & { clearNamespace(): Promise<number> } {
   return {
     async get() { return null; },
     async set() { return true; },
@@ -16,6 +16,7 @@ function fakeCache(): TenantCache {
     async getset() { return null; },
     async getdel() { return null; },
     async flush() { return 0; },
+    async clearNamespace() { return 0; },
   };
 }
 


### PR DESCRIPTION
## Summary

- make test doubles implement the generic `TenantCache.get` contract
- include the transaction-only `clearNamespace` member in the shared fake
- type PostgreSQL integration assertions explicitly

## Validation

- `bun test src/app.test.ts src/cache-registry.test.ts src/cache-registry.postgres.test.ts` — 17 passed, 1 skipped
- local TypeScript was attempted but macOS killed the process with exit 137 under current host memory pressure; GitHub `Package Checks` is the required independent typecheck evidence
