### PR TITLE
fix(upgrade): pin checkpoint verification to metadata database

### DIFF
--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -796,8 +796,17 @@ export async function stopManagementService(
     throw stopError;
 }
 
+export function buildCheckpointDatabaseOptions(databaseUrl: string) {
+    const parsed = new URL(databaseUrl);
+    const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+    if (!database) {
+        throw new Error("DATABASE_URL must include a database name for secret migration checkpoint verification");
+    }
+    return { url: databaseUrl, database, max: 1 };
+}
+
 async function checkpointExists(databaseUrl: string, encryptionKey: string): Promise<boolean> {
-    const database = new SQL({ url: databaseUrl, max: 1 });
+    const database = new SQL(buildCheckpointDatabaseOptions(databaseUrl));
     try {
         return await hasSecretEncryptionCheckpoint(database, encryptionKey);
     } finally {

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -63,12 +63,13 @@ describe("upgrade release selection", () => {
   test("pins secret checkpoint verification to DATABASE_URL despite ambient PGDATABASE", async () => {
     const originalPgDatabase = process.env.PGDATABASE;
     process.env.PGDATABASE = "postgres";
-    const options = buildCheckpointDatabaseOptions(
-      "postgresql://postgres:placeholder@127.0.0.1:5432/supacloud_meta?sslmode=disable",
-    );
-    const database = new SQL(options);
+    let database: SQL | undefined;
 
     try {
+      const options = buildCheckpointDatabaseOptions(
+        "postgresql://postgres:placeholder@127.0.0.1:5432/supacloud_meta?sslmode=disable",
+      );
+      database = new SQL(options);
       expect(options).toEqual({
         url: "postgresql://postgres:placeholder@127.0.0.1:5432/supacloud_meta?sslmode=disable",
         database: "supacloud_meta",
@@ -76,7 +77,7 @@ describe("upgrade release selection", () => {
       });
       expect(database.options.database).toBe("supacloud_meta");
     } finally {
-      await database.close();
+      if (database) await database.close();
       if (originalPgDatabase === undefined) delete process.env.PGDATABASE;
       else process.env.PGDATABASE = originalPgDatabase;
     }

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { SQL } from "bun";
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
     buildEdgeRuntimeCapacityDropIn,
     buildEmbeddedEdgePrivilegeDropIn,
+    buildCheckpointDatabaseOptions,
     backupCurrentBinary,
     captureFileState,
     cleanupBinaryBackup,
@@ -58,6 +60,40 @@ afterEach(() => {
 });
 
 describe("upgrade release selection", () => {
+  test("pins secret checkpoint verification to DATABASE_URL despite ambient PGDATABASE", async () => {
+    const originalPgDatabase = process.env.PGDATABASE;
+    process.env.PGDATABASE = "postgres";
+    const options = buildCheckpointDatabaseOptions(
+      "postgresql://postgres:placeholder@127.0.0.1:5432/supacloud_meta?sslmode=disable",
+    );
+    const database = new SQL(options);
+
+    try {
+      expect(options).toEqual({
+        url: "postgresql://postgres:placeholder@127.0.0.1:5432/supacloud_meta?sslmode=disable",
+        database: "supacloud_meta",
+        max: 1,
+      });
+      expect(database.options.database).toBe("supacloud_meta");
+    } finally {
+      await database.close();
+      if (originalPgDatabase === undefined) delete process.env.PGDATABASE;
+      else process.env.PGDATABASE = originalPgDatabase;
+    }
+  });
+
+  test("decodes an escaped database name for checkpoint verification", () => {
+    expect(buildCheckpointDatabaseOptions(
+      "postgresql://postgres:placeholder@127.0.0.1:5432/tenant%5Fmeta",
+    ).database).toBe("tenant_meta");
+  });
+
+  test("rejects checkpoint verification without an explicit database name", () => {
+    expect(() => buildCheckpointDatabaseOptions(
+      "postgresql://postgres:placeholder@127.0.0.1:5432",
+    )).toThrow("DATABASE_URL must include a database name");
+  });
+
   test("creates the dedicated Edge Runtime identity during a Linux upgrade", async () => {
     const commands: string[][] = [];
     const responses = [


### PR DESCRIPTION
## Summary

- derive the checkpoint database name from DATABASE_URL and pass it explicitly to Bun SQL
- prevent ambient PGDATABASE (for example Pigsty root shells using postgres) from redirecting checkpoint verification away from supacloud_meta
- fail closed when DATABASE_URL has no database path and cover encoded database names

## Root cause

On Bun 1.3.14, PGDATABASE can override the database path from the SQL URL. The upgrade migration correctly wrote the encryption checkpoint to supacloud_meta, but checkpointExists then queried postgres and aborted with Secret migration checkpoint is missing after init-db.

## Verification

- bun test tests/unit/upgrade.test.ts: 35 pass, 0 fail
- bun run typecheck
- bun run test:unit: exit 0
- git diff --check
- live test host reproduction: URL path supacloud_meta plus ambient PGDATABASE=postgres connected to postgres before the fix; explicit database connected to supacloud_meta and saw the existing checkpoint
