### PR TITLE
fix(edge): preserve source access for embedded privilege drop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1490,6 +1490,18 @@ ensure_edge_runtime_user() {
     fi
 }
 
+configure_edge_runtime_source_access() {
+    local source_dir="$1"
+    chmod -R g-w,g+rX "$source_dir" || {
+        log_error "Failed to grant Edge Runtime source access"
+        return 1
+    }
+    chgrp -R supacloud-edge "$source_dir" || {
+        log_error "Failed to assign Edge Runtime source group"
+        return 1
+    }
+}
+
 install_edge_runtime() {
     log_step "Installing Edge Runtime..."
     supacloud_resolve_artifact_policy || return 1
@@ -1578,6 +1590,7 @@ install_edge_runtime() {
         else
             log_info "Edge Runtime source deployed to /opt/supacloud/edge-runtime (functions directory)"
         fi
+        configure_edge_runtime_source_access /opt/supacloud/edge-runtime || return 1
         log_info "Edge Runtime deployed to /opt/supacloud/edge-runtime"
     else
         log_warn "Edge Runtime source not found at $EDGE_RT_SRC, skipping source deployment"

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -15,6 +15,7 @@ const BIN_TARGET = "/usr/local/bin/supacloud";
 const DEFAULT_MANAGEMENT_ENV_FILE = "/etc/supabase/management-api.env";
 const DEFAULT_EDGE_RUNTIME_USER = "supacloud-edge";
 const DEFAULT_EDGE_RUNTIME_GROUP = "supacloud-edge";
+const DEFAULT_EDGE_RUNTIME_SOURCE_DIR = "/opt/supacloud/edge-runtime";
 const LEGACY_CONFIG_FILE = "/opt/supacloud/config.env";
 const DEFAULT_GITHUB_PROXY = "https://ghproxy.net/";
 const WEB_CONSOLE_ASSET = "web-console-build.tar.gz";
@@ -78,6 +79,10 @@ export type EdgeRuntimeIdentity = {
 type EdgeRuntimeIdentityOptions = {
     platform?: NodeJS.Platform;
     run?: HostIdentityCommandRunner;
+};
+
+type EmbeddedEdgeSourceAccessOptions = EdgeRuntimeIdentityOptions & {
+    sourceDir?: string;
 };
 
 export function createBinaryBackupState(targetPath: string, runId = randomUUID()): BinaryBackupState {
@@ -988,6 +993,29 @@ export async function ensurePersistedEdgeRuntimeIdentity(
     return identity;
 }
 
+async function runRequiredHostCommand(
+    command: string[],
+    failureMessage: string,
+    run: HostIdentityCommandRunner,
+): Promise<void> {
+    const completed = await run(command);
+    if (completed.exitCode !== 0) {
+        throw new Error(`${failureMessage}: ${completed.stderr.trim().slice(-300)}`);
+    }
+}
+
+export async function ensureEmbeddedEdgeRuntimeSourceAccess(
+    identity: EdgeRuntimeIdentity,
+    options: EmbeddedEdgeSourceAccessOptions = {},
+): Promise<void> {
+    if ((options.platform ?? process.platform) !== "linux") return;
+    const sourceDir = options.sourceDir || DEFAULT_EDGE_RUNTIME_SOURCE_DIR;
+    if (!existsSync(sourceDir)) throw new Error(`Embedded Edge Runtime source directory is missing: ${sourceDir}`);
+    const run = options.run ?? runHostIdentityCommand;
+    await runRequiredHostCommand(["chmod", "-R", "g-w,g+rX", sourceDir], "Failed to grant Edge Runtime source access", run);
+    await runRequiredHostCommand(["chgrp", "-R", identity.group, sourceDir], "Failed to assign Edge Runtime source group", run);
+}
+
 function edgeRuntimeCapacityDropIn() {
     return process.env.SUPACLOUD_EDGE_RUNTIME_CAPACITY_DROPIN || DEFAULT_EDGE_RUNTIME_CAPACITY_DROPIN;
 }
@@ -1026,8 +1054,9 @@ async function reloadSystemdUnits() {
     }
 }
 
-async function reconcileEmbeddedEdgePrivilegeDropIn(mode: "embedded" | "external") {
+async function reconcileEmbeddedEdgePrivilegeDropIn(mode: "embedded" | "external", identity: EdgeRuntimeIdentity) {
     if (mode === "embedded") {
+        await ensureEmbeddedEdgeRuntimeSourceAccess(identity);
         writeFileAtomically(embeddedEdgePrivilegeDropIn(), buildEmbeddedEdgePrivilegeDropIn(), 0o644);
     } else {
         rmSync(embeddedEdgePrivilegeDropIn(), { force: true });
@@ -1260,9 +1289,9 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                 activationState.managementEnvState = captureFileState(managementEnvFile());
                 activationState.edgeRuntimeDropInState = captureFileState(edgeRuntimeCapacityDropIn());
                 activationState.embeddedEdgePrivilegeDropInState = captureFileState(embeddedEdgePrivilegeDropIn());
-                await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
+                const edgeRuntimeIdentity = await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
                 activatedEdgeRuntimeMode = await runtimeModeForBinaryUpgrade();
-                await reconcileEmbeddedEdgePrivilegeDropIn(activatedEdgeRuntimeMode);
+                await reconcileEmbeddedEdgePrivilegeDropIn(activatedEdgeRuntimeMode, edgeRuntimeIdentity);
                 await ensureEdgeRuntimeCapacityDropIn(env);
                 upsertManagementWebConsoleDir(managementEnvFile());
                 await restartServices();

--- a/packages/management-api/tests/unit/install-config.test.ts
+++ b/packages/management-api/tests/unit/install-config.test.ts
@@ -957,6 +957,27 @@ describe("installer configuration persistence", () => {
     expect(readFileSync(embeddedCalls, "utf8")).toBe("health:http://127.0.0.1:9000/health\n");
   });
 
+  test("installer grants the dedicated runtime group read-only source access", () => {
+    const dir = makeTempDir();
+    const calls = join(dir, "calls");
+    const sourceDir = join(dir, "edge-runtime");
+    mkdirSync(sourceDir);
+
+    const configured = runBash([
+      "source install.sh",
+      'chgrp() { printf "chgrp:%s\\n" "$*" >> "$CALLS"; }',
+      'chmod() { printf "chmod:%s\\n" "$*" >> "$CALLS"; }',
+      'configure_edge_runtime_source_access "$SOURCE_DIR"',
+    ].join("; "), { CALLS: calls, SOURCE_DIR: sourceDir });
+
+    expect(configured.status, configured.stderr).toBe(0);
+    expect(readFileSync(calls, "utf8")).toBe([
+      `chmod:-R g-w,g+rX ${sourceDir}`,
+      `chgrp:-R supacloud-edge ${sourceDir}`,
+      "",
+    ].join("\n"));
+  });
+
   test("management Edge mode uses the persisted service environment and fails closed", () => {
     const dir = makeTempDir();
     const runtimeEnv = join(dir, "management-api.env");

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -11,6 +11,7 @@ import {
     createBinaryBackupState,
     executeUpgradeTransaction,
     ensureEdgeRuntimeIdentity,
+    ensureEmbeddedEdgeRuntimeSourceAccess,
     ensurePersistedEdgeRuntimeIdentity,
     normalizeManagementReleaseTag,
     prepareUpgradeSecrets,
@@ -587,6 +588,44 @@ describe("upgrade release selection", () => {
     } finally {
       rmSync(envDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("embedded Edge Runtime source access", () => {
+  test("grants read-only source access to the dedicated runtime group", async () => {
+    const commands: string[][] = [];
+    const sourceDir = mkdtempSync(join(tmpdir(), "supacloud-edge-source-"));
+
+    await ensureEmbeddedEdgeRuntimeSourceAccess(
+      { user: "supacloud-edge", group: "supacloud-edge" },
+      {
+        platform: "linux",
+        sourceDir,
+        run: async (command) => {
+          commands.push(command);
+          return { exitCode: 0, stdout: "", stderr: "" };
+        },
+      },
+    );
+
+    expect(commands).toEqual([
+      ["chmod", "-R", "g-w,g+rX", sourceDir],
+      ["chgrp", "-R", "supacloud-edge", sourceDir],
+    ]);
+    rmSync(sourceDir, { recursive: true, force: true });
+  });
+
+  test("fails before privilege drop when source permissions cannot be changed", async () => {
+    const sourceDir = mkdtempSync(join(tmpdir(), "supacloud-edge-source-"));
+    await expect(ensureEmbeddedEdgeRuntimeSourceAccess(
+      { user: "supacloud-edge", group: "supacloud-edge" },
+      {
+        platform: "linux",
+        sourceDir,
+        run: async () => ({ exitCode: 1, stdout: "", stderr: "permission denied" }),
+      },
+    )).rejects.toThrow("Failed to grant Edge Runtime source access: permission denied");
+    rmSync(sourceDir, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
## Summary

- grant the dedicated `supacloud-edge` group recursive read/traverse access to the managed Edge Runtime source tree
- remove group write access before changing the tree group, so tenant code cannot modify runtime sources
- apply the same fail-closed permission reconciliation during fresh installs and binary upgrades

## Root cause

Upgrades from older installations can retain `/opt/supacloud/edge-runtime` as `0700 root:root`. After the embedded runtime privilege-drop hardening, the `supacloud-edge` child cannot traverse that tree and exits with `Module not found "/edge-runtime/server.ts"`, causing the post-upgrade health check to roll back an otherwise healthy Management API upgrade.

## Verification

- `bun test tests/unit/upgrade.test.ts tests/unit/install-config.test.ts` (75 pass)
- `bun run typecheck`
- `bun run test:unit`
- `bun run build:amd64`
- `git diff --check`