### PR TITLE
fix(edge): avoid native storage port collision

### DIFF
--- a/infrastructure/systemd/supacloud-edge-runtime.service
+++ b/infrastructure/systemd/supacloud-edge-runtime.service
@@ -9,16 +9,17 @@ Type=simple
 User=supacloud-edge
 Group=supacloud-edge
 WorkingDirectory=/opt/supacloud/edge-runtime
-ExecStartPre=/bin/bash -c 'for pid in $(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do echo "[EdgeRT] Killing stale pid=$pid"; kill -9 $pid 2>/dev/null || true; done; sleep 0.3; true'
+ExecStartPre=/bin/bash -c 'for pid in $(lsof -iTCP:@EDGE_RUNTIME_PORT@ -sTCP:LISTEN -t 2>/dev/null); do echo "[EdgeRT] Killing stale pid=$pid"; kill -9 $pid 2>/dev/null || true; done; sleep 0.3; true'
 ExecStart=/usr/local/bin/supacloud-edge-runtime
-ExecStopPost=/bin/bash -c 'for pid in $(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do kill -9 $pid 2>/dev/null || true; done; true'
+ExecStopPost=/bin/bash -c 'for pid in $(lsof -iTCP:@EDGE_RUNTIME_PORT@ -sTCP:LISTEN -t 2>/dev/null); do kill -9 $pid 2>/dev/null || true; done; true'
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=supacloud-edge
 
-Environment=PORT=9000
+Environment=PORT=@EDGE_RUNTIME_PORT@
+Environment=EDGE_RUNTIME_PORT=@EDGE_RUNTIME_PORT@
 Environment=EDGE_RUNTIME_HOST=127.0.0.1
 Environment=EDGE_FUNCTIONS_DIR=/opt/supacloud/functions
 Environment=EDGE_FUNCTIONS_BASE_DIR=/opt/supacloud/functions

--- a/install.sh
+++ b/install.sh
@@ -61,7 +61,7 @@ SUPACLOUD_INSTALL_KEYS=(
     S3_ENDPOINT S3_PROTOCOL S3_REGION S3_BUCKET S3_ACCESS_KEY S3_SECRET_KEY
     S3_FORCE_PATH_STYLE
     EXTERNAL_S3_ENDPOINT EXTERNAL_S3_REGION EXTERNAL_S3_BUCKET
-    EXTERNAL_S3_ACCESS_KEY EXTERNAL_S3_SECRET_KEY IMAGINARY_IMAGE EDGE_RUNTIME
+    EXTERNAL_S3_ACCESS_KEY EXTERNAL_S3_SECRET_KEY IMAGINARY_IMAGE EDGE_RUNTIME EDGE_RUNTIME_PORT
     ENABLE_ANALYTICS ANALYTICS_BACKEND LOGFLARE_DB LOGFLARE_SCHEMA LOGFLARE_ERL_FLAGS
 )
 SUPACLOUD_EXPLICIT_INSTALL_KEYS=()
@@ -408,6 +408,7 @@ recover_legacy_install_config() {
     apply_recovered_env_value POSTGRES_PASSWORD "$MANAGEMENT_ENV_FILE" PGPASSWORD
     apply_recovered_env_value JWT_SECRET "$MANAGEMENT_ENV_FILE" JWT_SECRET
     apply_recovered_env_value S3_STORAGE_TYPE "$MANAGEMENT_ENV_FILE" S3_STORAGE_TYPE
+    apply_recovered_env_value EDGE_RUNTIME_PORT "$MANAGEMENT_ENV_FILE" EDGE_RUNTIME_PORT
     apply_recovered_env_value IMAGINARY_IMAGE "$MANAGEMENT_ENV_FILE" IMAGINARY_IMAGE
     local recovered_base_domain
     recovered_base_domain=$(supacloud_env_value "$MANAGEMENT_ENV_FILE" BASE_DOMAIN)
@@ -1440,7 +1441,8 @@ render_edge_runtime_systemd_unit() {
     local source_file="$1"
     local target_file="$2"
     local exec_start="$3"
-    python3 - "$source_file" "$target_file" "$exec_start" <<'PY'
+    local runtime_port="$4"
+    python3 - "$source_file" "$target_file" "$exec_start" "$runtime_port" <<'PY'
 import os
 import sys
 import tempfile
@@ -1449,10 +1451,12 @@ from pathlib import Path
 source = Path(sys.argv[1])
 target = Path(sys.argv[2])
 exec_start = sys.argv[3]
+runtime_port = sys.argv[4]
 lines = source.read_text().splitlines()
 rendered = []
 replaced = False
 for line in lines:
+    line = line.replace("@EDGE_RUNTIME_PORT@", runtime_port)
     if line.startswith("ExecStart="):
         rendered.append(f"ExecStart={exec_start}")
         replaced = True
@@ -1612,7 +1616,8 @@ install_edge_runtime() {
         render_edge_runtime_systemd_unit \
             "${SYSTEMD_SRC}/supacloud-edge-runtime.service" \
             /etc/systemd/system/supacloud-edge-runtime.service \
-            "$EXEC_START_CMD"
+            "$EXEC_START_CMD" \
+            "${EDGE_RUNTIME_PORT:-9005}"
         log_info "Rendered checked-in supacloud-edge-runtime.service with $EXEC_START_CMD"
     else
         cat > /etc/systemd/system/supacloud-edge-runtime.service <<SVCEOF
@@ -1626,12 +1631,13 @@ Type=simple
 User=supacloud-edge
 Group=supacloud-edge
 WorkingDirectory=/opt/supacloud/edge-runtime
-ExecStartPre=/bin/bash -c 'for pid in \$(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do echo "[EdgeRT] Killing stale pid=\$pid"; kill -9 \$pid 2>/dev/null || true; done; sleep 0.3; true'
+ExecStartPre=/bin/bash -c 'for pid in \$(lsof -iTCP:${EDGE_RUNTIME_PORT:-9005} -sTCP:LISTEN -t 2>/dev/null); do echo "[EdgeRT] Killing stale pid=\$pid"; kill -9 \$pid 2>/dev/null || true; done; sleep 0.3; true'
 ExecStart=${EXEC_START_CMD}
-ExecStopPost=/bin/bash -c 'for pid in \$(lsof -iTCP:9000 -sTCP:LISTEN -t 2>/dev/null); do kill -9 \$pid 2>/dev/null || true; done; true'
+ExecStopPost=/bin/bash -c 'for pid in \$(lsof -iTCP:${EDGE_RUNTIME_PORT:-9005} -sTCP:LISTEN -t 2>/dev/null); do kill -9 \$pid 2>/dev/null || true; done; true'
 Restart=always
 RestartSec=5
-Environment=PORT=9000
+Environment=PORT=${EDGE_RUNTIME_PORT:-9005}
+Environment=EDGE_RUNTIME_PORT=${EDGE_RUNTIME_PORT:-9005}
 Environment=EDGE_FUNCTIONS_DIR=/opt/supacloud/functions
 Environment=EDGE_FUNCTIONS_BASE_DIR=/opt/supacloud/functions
 Environment=MANAGEMENT_API_URL=http://127.0.0.1:9090
@@ -1647,7 +1653,7 @@ SVCEOF
     systemctl daemon-reload
     if [[ "$EDGE_RUNTIME_MODE" == "external" ]]; then
         systemctl enable supacloud-edge-runtime 2>/dev/null || true
-        log_info "Edge Runtime on port 9000 (standalone systemd service mode)"
+        log_info "Edge Runtime on port ${EDGE_RUNTIME_PORT:-9005} (standalone systemd service mode)"
     else
         systemctl disable --now supacloud-edge-runtime 2>/dev/null || true
         if [[ "$USE_COMPILED_BINARY" == "true" ]]; then
@@ -1855,7 +1861,7 @@ install_pgredis_runtime() {
         return 1
     fi
     render_edge_runtime_systemd_unit "$systemd_src" \
-        "$PGREDIS_RUNTIME_UNIT_FILE" "$PGR_EXEC_START"
+        "$PGREDIS_RUNTIME_UNIT_FILE" "$PGR_EXEC_START" 9010
     systemctl daemon-reload || return 1
     systemctl enable --now supacloud-pgredis-runtime || return 1
     supacloud_wait_http_health http://127.0.0.1:9010/health || return 1
@@ -2682,6 +2688,7 @@ save_all_credentials() {
         LOGFLARE_DB "${LOGFLARE_DB:-_supabase}" \
         LOGFLARE_SCHEMA "${LOGFLARE_SCHEMA:-_analytics}" \
         S3_STORAGE_TYPE "$S3_STORAGE_TYPE" \
+        EDGE_RUNTIME_PORT "${EDGE_RUNTIME_PORT:-9005}" \
         JUICEFS_BACKEND "${JUICEFS_BACKEND:-}" \
         S3_ENDPOINT "${S3_ENDPOINT:-}" \
         S3_PROTOCOL "${S3_PROTOCOL:-}" \
@@ -2895,10 +2902,17 @@ management_edge_runtime_mode() {
 
 ensure_management_edge_runtime_ready() {
     local runtime_mode="$1"
+    local runtime_port
+    runtime_port=$(supacloud_env_value "$MANAGEMENT_ENV_FILE" EDGE_RUNTIME_PORT)
+    runtime_port="${runtime_port:-9005}"
+    if [[ ! "$runtime_port" =~ ^[0-9]+$ ]] || (( runtime_port < 1 || runtime_port > 65535 )); then
+        log_error "Invalid persisted EDGE_RUNTIME_PORT: $runtime_port"
+        return 1
+    fi
     if [[ "$runtime_mode" == "external" ]]; then
         systemctl restart supacloud-edge-runtime || log_warn "systemctl restart supacloud-edge-runtime returned non-zero; deferring readiness to the health check"
     fi
-    supacloud_wait_http_health http://127.0.0.1:9000/health
+    supacloud_wait_http_health "http://127.0.0.1:${runtime_port}/health"
 }
 
 configure_management_edge_privilege_dropin() {
@@ -3059,6 +3073,8 @@ install_management_api() {
         STUDIO_INTERNAL "${STUDIO_INTERNAL:-127.0.0.1:9090}" \
         DATABASE_URL "postgresql://postgres:${encoded_postgres_password}@127.0.0.1:5432/supacloud_meta" \
         EDGE_RUNTIME_MODE "${EDGE_RUNTIME_MODE:-embedded}" \
+        EDGE_RUNTIME_PORT "${EDGE_RUNTIME_PORT:-9005}" \
+        EDGE_RUNTIME_INTERNAL "${EDGE_RUNTIME_INTERNAL:-127.0.0.1:${EDGE_RUNTIME_PORT:-9005}}" \
         EDGE_RUNTIME_USER supacloud-edge \
         EDGE_RUNTIME_GROUP supacloud-edge \
         PGREDIS_RUNTIME_INTERNAL_URL "${PGREDIS_RUNTIME_INTERNAL_URL:-http://127.0.0.1:9010}" \
@@ -3119,6 +3135,7 @@ install_management_api() {
         abort_management_install_transaction "$management_transaction_dir" "$management_service_was_active" false 1
     fi
     if ! supacloud_write_service_env_pairs "$EDGE_RUNTIME_ENV_FILE" \
+        EDGE_RUNTIME_PORT "${EDGE_RUNTIME_PORT:-9005}" \
         EDGE_RUNTIME_MASTER_KEY "$MASTER_TOKEN" \
         MANAGEMENT_API_URL http://127.0.0.1:9090 \
         TENANTS_DIR /etc/supabase/tenants \

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -15,7 +15,9 @@ const BIN_TARGET = "/usr/local/bin/supacloud";
 const DEFAULT_MANAGEMENT_ENV_FILE = "/etc/supabase/management-api.env";
 const DEFAULT_EDGE_RUNTIME_USER = "supacloud-edge";
 const DEFAULT_EDGE_RUNTIME_GROUP = "supacloud-edge";
+const DEFAULT_EDGE_RUNTIME_PORT = 9005;
 const DEFAULT_EDGE_RUNTIME_SOURCE_DIR = "/opt/supacloud/edge-runtime";
+const DEFAULT_EDGE_RUNTIME_ENV_FILE = "/etc/supabase/edge-runtime.env";
 const LEGACY_CONFIG_FILE = "/opt/supacloud/config.env";
 const DEFAULT_GITHUB_PROXY = "https://ghproxy.net/";
 const WEB_CONSOLE_ASSET = "web-console-build.tar.gz";
@@ -921,6 +923,37 @@ export function upsertEdgeRuntimeIdentityDefaults(filePath: string, identity: Ed
     }
 }
 
+function edgeRuntimeEnvFile() {
+    return process.env.SUPACLOUD_EDGE_RUNTIME_ENV_FILE || DEFAULT_EDGE_RUNTIME_ENV_FILE;
+}
+
+export function resolvePersistedEdgeRuntimePort(
+    managementEnvPath: string = managementEnvFile(),
+    runtimeEnvPath: string = edgeRuntimeEnvFile(),
+): number {
+    const managementEnv = existsSync(managementEnvPath) ? parseEnv(readFileSync(managementEnvPath, "utf8")) : {};
+    const runtimeEnv = existsSync(runtimeEnvPath) ? parseEnv(readFileSync(runtimeEnvPath, "utf8")) : {};
+    const persistedPort = managementEnv.EDGE_RUNTIME_PORT || runtimeEnv.EDGE_RUNTIME_PORT;
+    const port = Number(persistedPort || DEFAULT_EDGE_RUNTIME_PORT);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`Invalid persisted EDGE_RUNTIME_PORT: ${persistedPort}`);
+    }
+    return port;
+}
+
+export function upsertPersistedEdgeRuntimePort(
+    managementEnvPath: string = managementEnvFile(),
+    runtimeEnvPath: string = edgeRuntimeEnvFile(),
+) {
+    const port = resolvePersistedEdgeRuntimePort(managementEnvPath, runtimeEnvPath);
+    upsertEnvFileValue(managementEnvPath, "EDGE_RUNTIME_PORT", String(port));
+    upsertEnvFileValue(runtimeEnvPath, "EDGE_RUNTIME_PORT", String(port));
+    if (!envFileHasNonEmptyValue(managementEnvPath, "EDGE_RUNTIME_INTERNAL")) {
+        upsertEnvFileValue(managementEnvPath, "EDGE_RUNTIME_INTERNAL", `127.0.0.1:${port}`);
+    }
+    return port;
+}
+
 export function upsertManagementWebConsoleDir(managementEnvPath: string = managementEnvFile()) {
     upsertEnvFileValue(managementEnvPath, WEB_CONSOLE_DIR_ENV_KEY, WEB_CONSOLE_CURRENT_LINK);
 }
@@ -1142,10 +1175,11 @@ export async function waitForManagementHealth() {
 
 export async function waitForEdgeRuntimeHealth() {
     const attempts = positiveInteger(process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS, 30);
+    const port = resolvePersistedEdgeRuntimePort();
     let lastError = "timeout";
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
         try {
-            const response = await fetch("http://127.0.0.1:9000/health", {
+            const response = await fetch(`http://127.0.0.1:${port}/health`, {
                 signal: AbortSignal.timeout(2_000),
             });
             if (response.ok) return;
@@ -1168,6 +1202,7 @@ type UpgradeActivationState = {
     oldWebTarget: string | null;
     oldWebBackup: string | null;
     managementEnvState: FileState | null;
+    edgeRuntimeEnvState: FileState | null;
     edgeRuntimeDropInState: FileState | null;
     embeddedEdgePrivilegeDropInState: FileState | null;
 };
@@ -1210,6 +1245,9 @@ async function rollbackArtifacts(state: UpgradeActivationState, stagedWeb: Stage
 
     if (state.managementEnvState) {
         restoreFileState(state.managementEnvState);
+    }
+    if (state.edgeRuntimeEnvState) {
+        restoreFileState(state.edgeRuntimeEnvState);
     }
     if (state.edgeRuntimeDropInState) {
         restoreFileState(state.edgeRuntimeDropInState);
@@ -1287,6 +1325,7 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                     oldWebTarget: null,
                     oldWebBackup: null,
                     managementEnvState: null,
+                    edgeRuntimeEnvState: null,
                     edgeRuntimeDropInState: null,
                     embeddedEdgePrivilegeDropInState: null,
                 };
@@ -1296,9 +1335,11 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                 s.start("Applying runtime settings and restarting SupaCloud services");
                 if (!activationState) throw new Error("Upgrade activation state is unavailable");
                 activationState.managementEnvState = captureFileState(managementEnvFile());
+                activationState.edgeRuntimeEnvState = captureFileState(edgeRuntimeEnvFile());
                 activationState.edgeRuntimeDropInState = captureFileState(edgeRuntimeCapacityDropIn());
                 activationState.embeddedEdgePrivilegeDropInState = captureFileState(embeddedEdgePrivilegeDropIn());
                 const edgeRuntimeIdentity = await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
+                upsertPersistedEdgeRuntimePort(managementEnvFile(), edgeRuntimeEnvFile());
                 activatedEdgeRuntimeMode = await runtimeModeForBinaryUpgrade();
                 await reconcileEmbeddedEdgePrivilegeDropIn(activatedEdgeRuntimeMode, edgeRuntimeIdentity);
                 await ensureEdgeRuntimeCapacityDropIn(env);

--- a/packages/management-api/tests/unit/install-config.test.ts
+++ b/packages/management-api/tests/unit/install-config.test.ts
@@ -926,8 +926,9 @@ describe("installer configuration persistence", () => {
     expect(() => statSync(join(runtime, "extra.ts"))).toThrow();
   });
 
-  test("management Edge readiness restarts external mode and gates every mode on port 9000", () => {
+  test("management Edge readiness restarts external mode and uses the persisted port", () => {
     const dir = makeTempDir();
+    const runtimeEnv = join(dir, "management-api.env");
     const externalCalls = join(dir, "external-calls");
     const external = runBash([
       "source install.sh",
@@ -941,7 +942,7 @@ describe("installer configuration persistence", () => {
     expect(readFileSync(externalCalls, "utf8")).toBe([
       "systemctl:restart supacloud-edge-runtime",
       "warn:systemctl restart supacloud-edge-runtime returned non-zero; deferring readiness to the health check",
-      "health:http://127.0.0.1:9000/health",
+      "health:http://127.0.0.1:9005/health",
       "",
     ].join("\n"));
 
@@ -954,7 +955,21 @@ describe("installer configuration persistence", () => {
     ].join("; "), { CALLS: embeddedCalls });
 
     expect(embedded.status).toBe(7);
-    expect(readFileSync(embeddedCalls, "utf8")).toBe("health:http://127.0.0.1:9000/health\n");
+    expect(readFileSync(embeddedCalls, "utf8")).toBe("health:http://127.0.0.1:9005/health\n");
+
+    writeFileSync(runtimeEnv, "EDGE_RUNTIME_PORT=9123\n");
+    const customCalls = join(dir, "custom-calls");
+    const custom = runBash([
+      "source install.sh",
+      'supacloud_wait_http_health() { printf "health:%s\\n" "$1" >> "$CALLS"; }',
+      "ensure_management_edge_runtime_ready embedded",
+    ].join("; "), {
+      CALLS: customCalls,
+      SUPACLOUD_MANAGEMENT_ENV_FILE: runtimeEnv,
+    });
+
+    expect(custom.status, custom.stderr).toBe(0);
+    expect(readFileSync(customCalls, "utf8")).toBe("health:http://127.0.0.1:9123/health\n");
   });
 
   test("installer grants the dedicated runtime group read-only source access", () => {

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -369,7 +369,7 @@ describe("runtime companion version assets", () => {
     );
     expect(installer.match(/ensure_management_edge_runtime_ready/g)).toHaveLength(3);
     expect(installer).toContain("systemctl restart supacloud-edge-runtime");
-    expect(installer).toContain("http://127.0.0.1:9000/health");
+    expect(installer).toContain('http://127.0.0.1:${runtime_port}/health');
     expect(managementUnit).toContain("SystemCallFilter=@system-service @chown");
     expect(managementUnit).not.toContain("@privileged");
     expect(installer).toContain("install_tenant_user_helper");

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -20,6 +20,7 @@ import {
     resolveArtifactVerificationMode,
     resolveEdgeRuntimeCapacityConfig,
     resolveGithubEndpointPrefixes,
+    resolvePersistedEdgeRuntimePort,
     resolvePersistedEdgeRuntimeMode,
     resolveUpgradeEnvironment,
     runStagedDatabaseMigration,
@@ -28,6 +29,7 @@ import {
     selectManagementRelease,
     stopManagementService,
     upsertManagementWebConsoleDir,
+    upsertPersistedEdgeRuntimePort,
     upsertEdgeRuntimeIdentityDefaults,
     validateWebConsoleArchiveEntries,
     verifyArtifactChecksum,
@@ -590,7 +592,7 @@ describe("upgrade release selection", () => {
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = String(input);
       calls.push(url);
-      if (url === "http://127.0.0.1:9000/health") {
+      if (url === "http://127.0.0.1:9005/health") {
         return new Response("unavailable", { status: 503 });
       }
       return new Response(url.endsWith("/") ? "<!doctype html>" : "ok", {
@@ -603,7 +605,7 @@ describe("upgrade release selection", () => {
     expect(calls).toEqual([
       "http://127.0.0.1:9090/health",
       "http://127.0.0.1:9090/",
-      "http://127.0.0.1:9000/health",
+      "http://127.0.0.1:9005/health",
     ]);
   });
 
@@ -613,6 +615,50 @@ describe("upgrade release selection", () => {
     expect(resolvePersistedEdgeRuntimeMode("embedded")).toBe("embedded");
     expect(resolvePersistedEdgeRuntimeMode("external")).toBe("external");
     expect(() => resolvePersistedEdgeRuntimeMode("externel")).toThrow("Invalid persisted EDGE_RUNTIME_MODE");
+  });
+
+  test("upgrade persists a non-conflicting native Edge Runtime port", () => {
+    const envDir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-edge-port-"));
+    const managementEnv = join(envDir, "management-api.env");
+    const runtimeEnv = join(envDir, "edge-runtime.env");
+    try {
+      writeFileSync(managementEnv, "EDGE_RUNTIME_MODE=embedded\n");
+
+      expect(upsertPersistedEdgeRuntimePort(managementEnv, runtimeEnv)).toBe(9005);
+      expect(readFileSync(managementEnv, "utf8")).toContain("EDGE_RUNTIME_PORT=9005\n");
+      expect(readFileSync(managementEnv, "utf8")).toContain("EDGE_RUNTIME_INTERNAL=127.0.0.1:9005\n");
+      expect(readFileSync(runtimeEnv, "utf8")).toContain("EDGE_RUNTIME_PORT=9005\n");
+    } finally {
+      rmSync(envDir, { recursive: true, force: true });
+    }
+  });
+
+  test("upgrade preserves an explicit valid Edge Runtime port", () => {
+    const envDir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-custom-edge-port-"));
+    const managementEnv = join(envDir, "management-api.env");
+    const runtimeEnv = join(envDir, "edge-runtime.env");
+    try {
+      writeFileSync(managementEnv, "EDGE_RUNTIME_PORT=9123\n");
+
+      expect(upsertPersistedEdgeRuntimePort(managementEnv, runtimeEnv)).toBe(9123);
+      expect(resolvePersistedEdgeRuntimePort(managementEnv, runtimeEnv)).toBe(9123);
+      expect(readFileSync(runtimeEnv, "utf8")).toContain("EDGE_RUNTIME_PORT=9123\n");
+    } finally {
+      rmSync(envDir, { recursive: true, force: true });
+    }
+  });
+
+  test("upgrade rejects an invalid persisted Edge Runtime port", () => {
+    const envDir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-invalid-edge-port-"));
+    const managementEnv = join(envDir, "management-api.env");
+    const runtimeEnv = join(envDir, "edge-runtime.env");
+    try {
+      writeFileSync(managementEnv, "EDGE_RUNTIME_PORT=70000\n");
+      expect(() => resolvePersistedEdgeRuntimePort(managementEnv, runtimeEnv))
+        .toThrow("Invalid persisted EDGE_RUNTIME_PORT");
+    } finally {
+      rmSync(envDir, { recursive: true, force: true });
+    }
   });
 
   test("normalizes management env WEB_CONSOLE_DIR to runtime link", () => {

--- a/scripts/pre_start_recovery.sh
+++ b/scripts/pre_start_recovery.sh
@@ -114,10 +114,10 @@ restart_failed_tenants() {
 # SO_REUSEPORT allows multiple processes to bind the same port.
 # If an old bun runtime survives a restart/deploy, requests get split
 # 50/50 between old and new code — causing phantom failures.
-# This function kills ALL processes listening on port 9000 so that
+# This function kills stale processes listening on the Edge Runtime port so that
 # only the newly started runtime claims the port.
 kill_edge_runtime_zombies() {
-    local EDGE_PORT="${EDGE_RUNTIME_PORT:-9000}"
+    local EDGE_PORT="${EDGE_RUNTIME_PORT:-9005}"
     local EDGE_MODE="${EDGE_RUNTIME_MODE:-embedded}"
 
     if [[ "$EDGE_MODE" == "external" ]]; then


### PR DESCRIPTION
## Summary

- move the native host Edge Runtime default from storage port 9000 to 9005
- persist the selected port in both management and isolated Edge Runtime env files
- make upgrade health checks follow the persisted port and roll both env files back atomically
- render standalone Edge Runtime systemd cleanup and listener settings with the selected port

## Root cause

Native JuiceFS/MinIO storage can own port 9000. During a Management API restart, the storage service can claim that port before embedded Edge starts, causing repeated EADDRINUSE failures and an upgrade health response from the wrong service.

## Verification

- `bun run typecheck`
- `bun run test:unit`
- `bun test packages/management-api/tests/unit/upgrade.test.ts packages/management-api/tests/unit/install-config.test.ts packages/management-api/tests/unit/runtime-version-assets.test.ts`
- `bun run build:amd64`
- `bash -n install.sh scripts/pre_start_recovery.sh`
- `git diff --check`