### PR TITLE
fix(pages): add ZIP upload UI and managed default domains

### DIFF
--- a/docs/frontend-hosting.md
+++ b/docs/frontend-hosting.md
@@ -36,7 +36,7 @@ GET /v1/projects/:ref/frontend/deployments
       "project_ref": "my-project",
       "name": "my-app",
       "framework": "react",
-      "domain": "abc12345.my-project.app",
+      "domain": "abc12345.my-project.example.com",
       "custom_domains": ["www.myapp.com"],
       "build_command": "npm run build",
       "output_dir": "dist",
@@ -50,7 +50,7 @@ GET /v1/projects/:ref/frontend/deployments
       "created_at": "2024-01-01T00:00:00Z",
       "updated_at": "2024-01-01T00:00:00Z",
       "last_deployed_at": "2024-01-01T12:00:00Z",
-      "deployment_url": "https://abc12345.my-project.app"
+      "deployment_url": "https://abc12345.my-project.example.com"
     }
   ]
 }
@@ -101,7 +101,7 @@ POST /v1/projects/:ref/frontend/deployments/:id/deploy/git
 POST /v1/projects/:ref/frontend/deployments/:id/deploy/upload
 ```
 
-**请求体：** `multipart/form-data` 或 `application/octet-stream`
+**请求体：** `multipart/form-data` 的 `file` 字段，或 `application/zip`
 
 ### 重新部署
 
@@ -321,8 +321,8 @@ curl -X POST http://localhost:9090/v1/projects/my-project/frontend/deployments/a
 
 | 类型 | 主机记录 | 记录值 |
 |------|---------|---------|
-| CNAME | www | abc12345.my-project.app |
-| CNAME | @ | abc12345.my-project.app |
+| CNAME | www | abc12345.my-project.example.com |
+| CNAME | @ | abc12345.my-project.example.com |
 
 ## 构建状态
 
@@ -333,31 +333,11 @@ curl -X POST http://localhost:9090/v1/projects/my-project/frontend/deployments/a
 | `success` | 构建成功，已部署 |
 | `failed` | 构建失败 |
 
-## Nginx 配置
+## Caddy 路由
 
-系统会自动为每个部署生成 Nginx 配置：
-
-```nginx
-server {
-    listen 80;
-    server_name abc12345.my-project.app www.myapp.com;
-
-    root /var/supacloud/frontends/my-project/abc12345/build;
-    index index.html index.htm;
-
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-    }
-
-    gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
-}
-```
+系统会在部署构建成功后，通过 SupaCloud Caddy API 为默认域名和自定义域名创建托管路由。
+默认域名格式为 `<部署ID>.<项目ref>.<BASE_DOMAIN>`；静态站点由 Caddy 直接提供文件服务，
+SSR 站点则由 Caddy 反向代理到对应的受管进程。无需安装或维护 Nginx。
 
 ## 目录结构
 

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -16,6 +16,7 @@ import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
 import { logger } from "../utils/logger";
 import { config } from "../config";
+import { normalizeBaseDomain } from "../utils/project-routing";
 import type {
   FrontendDeployment,
   FrontendDeploymentConfig,
@@ -101,6 +102,14 @@ function assertSafeGitBranch(branch: string): void {
   if (!/^[A-Za-z0-9._/-]{1,128}$/.test(branch) || branch.includes("..") || branch.startsWith("-")) {
     throw new Error("Invalid git branch");
   }
+}
+
+function defaultFrontendDomain(projectRef: string, deploymentId: string): string {
+  const baseDomain = normalizeBaseDomain(config.baseDomain).replace(/^\.+|\.+$/g, "");
+  if (!baseDomain) {
+    throw new Error("BASE_DOMAIN must be configured for frontend deployments");
+  }
+  return `${deploymentId}.${projectRef}.${baseDomain}`;
 }
 
 export class FrontendService {
@@ -277,7 +286,7 @@ export class FrontendService {
   async createDeployment(projectRef: string, deploymentConfig: FrontendDeploymentConfig): Promise<FrontendDeployment> {
     const deploymentId = this.generateId();
     const defaults = FRAMEWORK_DEFAULTS[deploymentConfig.framework];
-    const domain = deploymentConfig.domain || `${deploymentId}.${projectRef}.app`;
+    const domain = deploymentConfig.domain || defaultFrontendDomain(projectRef, deploymentId);
 
     const deployment: FrontendDeployment = {
       id: deploymentId,
@@ -366,7 +375,7 @@ export class FrontendService {
 
     const records: FrontendDnsRecord[] = [];
     const apexValue = config.dockerHostIp || config.baseDomain;
-    const temporaryHost = deployment.domain || `${deployment.id}.${deployment.project_ref}.app`;
+    const temporaryHost = deployment.domain || defaultFrontendDomain(projectRef, deployment.id);
 
     records.push({
       id: `${deployment.id}-temporary-domain`,

--- a/packages/management-api/tests/unit/frontend.service.test.ts
+++ b/packages/management-api/tests/unit/frontend.service.test.ts
@@ -22,6 +22,28 @@ afterEach(async () => {
 });
 
 describe("FrontendService DNS records", () => {
+  test("uses the normalized base domain for temporary frontend hosts", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-domain-test-"));
+    const originalBaseDomain = config.baseDomain;
+
+    try {
+      for (const configuredBaseDomain of ["xai.xigu.team", "api.xai.xigu.team"]) {
+        config.baseDomain = configuredBaseDomain;
+        const service = new FrontendService(baseDir);
+        const deployment = await service.createDeployment("proj123", {
+          name: "site",
+          framework: "static",
+        });
+
+        expect(deployment.domain).toBe(`${deployment.id}.proj123.xai.xigu.team`);
+        expect(deployment.deployment_url).toBe(`https://${deployment.id}.proj123.xai.xigu.team`);
+      }
+    } finally {
+      config.baseDomain = originalBaseDomain;
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   test("returns managed temporary domain record and expected custom domain records", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-test-"));
     const service = new FrontendService(baseDir);
@@ -58,6 +80,31 @@ describe("FrontendService DNS records", () => {
         source: "custom_domain",
       });
     } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses the configured domain when a legacy deployment has no stored host", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-dns-fallback-test-"));
+    const originalBaseDomain = config.baseDomain;
+
+    try {
+      config.baseDomain = "api.xai.xigu.team";
+      const service = new FrontendService(baseDir);
+      const deployment = await service.createDeployment("proj123", {
+        name: "site",
+        framework: "static",
+      });
+      await writeFile(
+        join(baseDir, "proj123", deployment.id, "deployment.json"),
+        JSON.stringify({ ...deployment, domain: "" }),
+      );
+
+      const records = await service.listDnsRecords("proj123", deployment.id);
+
+      expect(records?.[0]?.hostname).toBe(`${deployment.id}.proj123.xai.xigu.team`);
+    } finally {
+      config.baseDomain = originalBaseDomain;
       await rm(baseDir, { recursive: true, force: true });
     }
   });

--- a/packages/web-console/src/lib/api.test.ts
+++ b/packages/web-console/src/lib/api.test.ts
@@ -52,6 +52,27 @@ describe("apiClient", () => {
     expect(headers.get("X-Test")).toBe("1");
   });
 
+  test("allows long-running requests to override the default timeout", async () => {
+    globalThis.fetch = async (_input, init) => {
+      await new Promise<void>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("Aborted", "AbortError")),
+          { once: true },
+        );
+      });
+      return Response.json({});
+    };
+
+    const response = await apiClient("/v1/slow-build", { timeoutMs: 1 });
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual({
+      message: "Request timeout",
+      code: "TIMEOUT",
+    });
+  });
+
   test("normalizes the cookie login, session, and logout contract without returning a token", async () => {
     const calls: Array<{ input: string; init?: RequestInit }> = [];
     const responses = [

--- a/packages/web-console/src/lib/api.ts
+++ b/packages/web-console/src/lib/api.ts
@@ -19,6 +19,10 @@ export interface StudioSessionState {
   expiresAt?: string;
 }
 
+export interface ApiRequestInit extends RequestInit {
+  timeoutMs?: number;
+}
+
 async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
   const value: unknown = await response.json().catch(() => ({}));
   return value && typeof value === "object" && !Array.isArray(value)
@@ -167,30 +171,31 @@ async function normalizeErrorResponse(response: Response): Promise<Response> {
   });
 }
 
-export async function apiClient(url: string, options: RequestInit = {}): Promise<Response> {
+export async function apiClient(url: string, options: ApiRequestInit = {}): Promise<Response> {
   await refreshExpiringStudioSession();
-  const headers = new Headers(options.headers || {});
+  const { timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS, ...requestInit } = options;
+  const headers = new Headers(requestInit.headers || {});
   
   // Set default Content-Type for JSON requests if body is stringified JSON
-  if (options.body && typeof options.body === 'string' && options.body.startsWith('{') && !headers.has("Content-Type")) {
+  if (requestInit.body && typeof requestInit.body === 'string' && requestInit.body.startsWith('{') && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
 
   const timeoutController = new AbortController();
-  const timeout = setTimeout(() => timeoutController.abort(), DEFAULT_REQUEST_TIMEOUT_MS);
-  const signal = mergeAbortSignals([options.signal, timeoutController.signal]);
+  const timeout = setTimeout(() => timeoutController.abort(), timeoutMs);
+  const signal = mergeAbortSignals([requestInit.signal, timeoutController.signal]);
 
   let response: Response;
   try {
     response = await fetch(url, {
-      ...options,
+      ...requestInit,
       headers,
       signal,
-      credentials: options.credentials ?? "include",
+      credentials: requestInit.credentials ?? "include",
     });
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") {
-      if (options.signal?.aborted && !timeoutController.signal.aborted) {
+      if (requestInit.signal?.aborted && !timeoutController.signal.aborted) {
         throw error;
       }
       return new Response(JSON.stringify({

--- a/packages/web-console/src/routes/project/[ref]/hosting/[id]/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/hosting/[id]/+page.svelte
@@ -2,8 +2,11 @@
   import { apiClient } from "$lib/api";
 
   import { page } from "$app/state";
-  import { Loader2, Save, Key, Globe, GitBranch, Terminal, Copy, RefreshCw, Trash2, Plus, ExternalLink } from "lucide-svelte";
+  import { Loader2, Save, Key, Globe, GitBranch, Terminal, Copy, RefreshCw, Trash2, Plus, ExternalLink, Upload } from "lucide-svelte";
+  import { keys } from "@svadmin/core";
   import { createQuery, createMutation, useQueryClient } from "@tanstack/svelte-query";
+
+  const FRONTEND_DEPLOY_TIMEOUT_MS = 5 * 60 * 1000;
 
   const projectRef = $derived(page.params.ref);
   const deployId = $derived(page.url.pathname.split("/hosting/")[1]?.split("/")[0] || "");
@@ -24,6 +27,8 @@
   // Custom Domains
   let newDomain = $state("");
   let isAddingDomain = $state(false);
+
+  let zipFile = $state<File | null>(null);
 
   let isCreatingToken = $state(false);
   let newTokenName = $state("");
@@ -162,6 +167,49 @@
     addDomainMutation.mutate();
   }
 
+  const uploadMutation = createMutation(() => ({
+    mutationFn: async (file: File) => {
+      const uploadBody = new FormData();
+      uploadBody.append("file", file);
+      const res = await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${deployId}/deploy/upload`, {
+        method: "POST",
+        body: uploadBody,
+        timeoutMs: FRONTEND_DEPLOY_TIMEOUT_MS,
+      });
+      const deploymentResult = await res.json();
+      if (!res.ok || deploymentResult.success === false) {
+        throw new Error(deploymentResult.message || deploymentResult.error || "ZIP 部署失败");
+      }
+      return deploymentResult;
+    },
+    onSuccess: () => {
+      actionMsg = "✅ ZIP 部署已完成";
+      zipFile = null;
+      queryClient.invalidateQueries({ queryKey: ["deployment", projectRef, deployId] });
+      queryClient.invalidateQueries({ queryKey: ["deployment_logs", projectRef, deployId] });
+      queryClient.invalidateQueries({
+        queryKey: keys()
+          .resource(`v1/projects/${projectRef}/frontend/deployments`)
+          .action("list")
+          .get(),
+      });
+      setTimeout(() => actionMsg = null, 4000);
+    },
+    onError: (err: unknown) => {
+      actionMsg = `❌ ${(err instanceof Error ? err.message : String(err))}`;
+      setTimeout(() => actionMsg = null, 4000);
+    },
+  }));
+
+  function selectZipFile(event: Event) {
+    const input = event.currentTarget as HTMLInputElement;
+    zipFile = input.files?.[0] || null;
+  }
+
+  function uploadZip() {
+    if (zipFile) uploadMutation.mutate(zipFile);
+  }
+
   const removeDomainMutation = createMutation(() => ({
     mutationFn: async (domain: string) => {
       await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${deployId}/domains/${domain}`, { method: "DELETE" });
@@ -262,6 +310,21 @@
         {#if dep.framework === 'sveltekit'}
           <div><span class="text-xs font-semibold text-muted-foreground block mb-1">健康检查路径</span><input bind:value={healthCheckPath} placeholder="/" class="w-full px-3 py-2 text-xs font-mono rounded-md border bg-muted/30 focus:outline-none focus:ring-1 focus:ring-brand" /></div>
         {/if}
+      </div>
+    </div>
+
+    <div class="rounded-xl border bg-card overflow-hidden">
+      <div class="border-b px-5 py-3 bg-muted/20">
+        <h3 class="text-sm font-semibold flex items-center gap-2"><Upload size={16} /> ZIP 部署</h3>
+      </div>
+      <div class="p-5 space-y-3">
+        <label for="zip-upload" class="text-xs font-semibold text-muted-foreground block">上传站点 ZIP 文件</label>
+        <input id="zip-upload" type="file" accept=".zip,application/zip" onchange={selectZipFile} class="block w-full text-xs file:mr-3 file:rounded-md file:border-0 file:bg-brand file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-white hover:file:bg-brand/90" />
+        <p class="text-[10px] text-muted-foreground">ZIP 内容会经过路径、文件数量和解压大小校验后部署。</p>
+        <button onclick={uploadZip} disabled={!zipFile || uploadMutation.isPending} class="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold rounded-md bg-brand text-white hover:bg-brand/90 disabled:opacity-50">
+          {#if uploadMutation.isPending}<Loader2 size={12} class="animate-spin" />{:else}<Upload size={12} />{/if}
+          {uploadMutation.isPending ? "部署中..." : "上传并部署"}
+        </button>
       </div>
     </div>
 

--- a/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
@@ -3,11 +3,23 @@ import { readFileSync } from "node:fs";
 
 const pageSource = readFileSync(new URL("./+page.svelte", import.meta.url), "utf8");
 const layoutSource = readFileSync(new URL("./+layout.svelte", import.meta.url), "utf8");
+const settingsSource = readFileSync(new URL("./[id]/+page.svelte", import.meta.url), "utf8");
 
 describe("hosting deployment entrypoints", () => {
   test("shows only the empty-state action when no deployments exist", () => {
     expect(pageSource).toContain("{#if deployments.length > 0}");
     expect(pageSource).toContain('{$t("Hosting.no_deployments")}');
     expect(layoutSource).not.toContain('{ id: "new"');
+  });
+
+  test("exposes the existing ZIP deployment endpoint in site settings", () => {
+    expect(settingsSource).toContain('id="zip-upload"');
+    expect(settingsSource).toContain('accept=".zip,application/zip"');
+    expect(settingsSource).toContain("/deployments/${deployId}/deploy/upload");
+    expect(settingsSource).toContain("new FormData()");
+    expect(settingsSource).toContain('uploadBody.append("file", file)');
+    expect(settingsSource).toContain("timeoutMs: FRONTEND_DEPLOY_TIMEOUT_MS");
+    expect(settingsSource).not.toContain('headers: { "Content-Type": "application/zip" }');
+    expect(settingsSource).toContain('.resource(`v1/projects/${projectRef}/frontend/deployments`)');
   });
 });


### PR DESCRIPTION
## Summary

- expose the existing secure ZIP deployment endpoint in Pages settings
- allow the upload/build request to use a five-minute timeout and refresh deployment state after success
- derive default Pages hosts from normalized BASE_DOMAIN instead of the non-resolving .app suffix
- document SupaCloud-managed Caddy routing and remove the obsolete Nginx example

## Domain behavior

New automatic hosts use deployment-id.project-ref.BASE_DOMAIN. Explicit deployment domains and custom domains remain unchanged. Historical automatic .app records are intentionally not bulk-rewritten by the application because that could overwrite operator-owned domains; the test environment will be repaired explicitly during verification.

## Verification

- Management API focused tests: 17 passed
- Management API full unit suite: passed
- Management API typecheck: passed
- Web Console tests: 83 passed
- Svelte check: 0 errors, 0 warnings
- Web Console production build: passed
- Linux amd64 binary build: passed
- git diff --check: passed

Tracks CNB issue #41: https://cnb.cool/aizhuliren/xgic/supacloud/-/issues/41