### PR TITLE
fix(storage): persist Studio bucket metadata

### DIFF
--- a/packages/management-api/src/routes/storage.ts
+++ b/packages/management-api/src/routes/storage.ts
@@ -19,7 +19,11 @@ type StorageBucketCreateInput = {
     name: string;
     id?: string;
     public?: boolean;
+    file_size_limit?: number;
+    allowed_mime_types?: string[];
 };
+
+type StorageOperationResult = { success: boolean; error?: string };
 
 // ── Imaginary Config ──────────────────────────────────────────────
 const IMAGINARY_URL = config.imaginaryUrl;
@@ -69,10 +73,98 @@ function buildSourceUrl(bucket: string, path: string): string {
     return `${base}/${encodeURIComponent(bucket)}/${normalizedPath.split("/").map(encodeURIComponent).join("/")}`;
 }
 
+function logStorageMetadataFailure(message: string, ref: string, bucketName: string, error: unknown): void {
+    logger.error(message, {
+        ref,
+        bucketName,
+        error: error instanceof Error ? error.message : String(error),
+    });
+}
+
+async function createLogicalStorageBucket(ref: string, bucketName: string, input: StorageBucketCreateInput): Promise<StorageOperationResult> {
+    try {
+        const created = await StorageRLS.createLogicalBucketAsAdmin(ref, {
+            id: bucketName,
+            name: bucketName,
+            public: input.public ?? false,
+            fileSizeLimit: input.file_size_limit,
+            allowedMimeTypes: input.allowed_mime_types,
+        });
+        return created ? { success: true } : { success: false, error: "Bucket already exists" };
+    } catch (error: unknown) {
+        logStorageMetadataFailure("Failed to persist Studio storage bucket metadata", ref, bucketName, error);
+        return { success: false, error: "Failed to persist bucket metadata" };
+    }
+}
+
+async function rollbackLogicalStorageBucket(ref: string, bucketName: string): Promise<void> {
+    try {
+        await StorageRLS.deleteLogicalBucketAsAdmin(ref, bucketName);
+    } catch (error: unknown) {
+        logStorageMetadataFailure("Failed to roll back Studio storage bucket metadata", ref, bucketName, error);
+    }
+}
+
 async function createStorageBucket(ref: string, input: StorageBucketCreateInput) {
     const bucketName = input.name || input.id || "";
+    const logicalResult = await createLogicalStorageBucket(ref, bucketName, input);
+    if (!logicalResult.success) return { bucketName, storageResult: logicalResult };
     const storageResult = await StorageService.createBucket(ref, bucketName);
+    if (!storageResult.success) await rollbackLogicalStorageBucket(ref, bucketName);
     return { bucketName, storageResult };
+}
+
+function mergeStorageBuckets(
+    physicalBuckets: Array<Record<string, unknown>>,
+    logicalBuckets: Array<Record<string, unknown>>,
+): Record<string, unknown>[] {
+    const bucketsById = new Map<string, Record<string, unknown>>();
+    for (const bucket of physicalBuckets) bucketsById.set(String(bucket.id), bucket);
+    for (const bucket of logicalBuckets) {
+        const id = String(bucket.id);
+        bucketsById.set(id, { ...bucketsById.get(id), ...bucket, id });
+    }
+    return Array.from(bucketsById.values());
+}
+
+async function listStorageBuckets(ref: string): Promise<Record<string, unknown>[]> {
+    const [physicalBuckets, logicalBuckets] = await Promise.all([
+        StorageService.listBuckets(ref),
+        StorageRLS.listLogicalBucketsAsAdmin(ref),
+    ]);
+    return mergeStorageBuckets(physicalBuckets, logicalBuckets);
+}
+
+async function listLegacyStorageBuckets(ref: string): Promise<Record<string, unknown>[]> {
+    if (ref === "default") return await StorageService.listBuckets(ref);
+    return await listStorageBuckets(ref);
+}
+
+async function assertStorageBucketDeletable(ref: string, bucketName: string): Promise<void> {
+    if (!await StorageService.isBucketEmpty(ref, bucketName)) throw new Error("Bucket is not empty");
+    await StorageRLS.assertLogicalBucketDeletableAsAdmin(ref, bucketName);
+}
+
+async function deleteStorageBucket(ref: string, bucketName: string) {
+    try {
+        await assertStorageBucketDeletable(ref, bucketName);
+    } catch (error: unknown) {
+        return { success: false, error: error instanceof Error ? error.message : "Failed to validate bucket" };
+    }
+    const storageResult = await StorageService.deleteBucket(ref, bucketName);
+    if (!storageResult.success) return storageResult;
+
+    try {
+        await StorageRLS.deleteLogicalBucketAsAdmin(ref, bucketName);
+        return storageResult;
+    } catch (error: unknown) {
+        logger.error("Failed to delete Studio storage bucket metadata", {
+            ref,
+            bucketName,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return { success: false, error: "Failed to delete bucket metadata" };
+    }
 }
 
 // ── Storage Routes ────────────────────────────────────────────────
@@ -83,15 +175,15 @@ export const storageRoutes = new Elysia({ prefix: "/v1/storage" })
     .get('/:ref/buckets', async ({ params, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
-        return await StorageService.listBuckets(params.ref);
+        return await listLegacyStorageBuckets(params.ref);
     }, { detail: { tags: ["storage"], summary: "List storage buckets for a project" } })
     .post('/:ref/buckets', async ({ params, body, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
         const { bucketName, storageResult } = await createStorageBucket(params.ref, body);
         if (!storageResult.success) {
-            set.status = 500;
-            return { message: storageResult.error || "Failed to create bucket", code: "500" };
+            set.status = storageResult.error === "Bucket already exists" ? 409 : 500;
+            return { message: storageResult.error || "Failed to create bucket", code: String(set.status) };
         }
         return { id: bucketName, name: bucketName, public: body.public || false };
     }, {
@@ -511,15 +603,15 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
     .get('/buckets', async ({ params, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
-        return await StorageService.listBuckets(params.ref);
+        return await listStorageBuckets(params.ref);
     }, { detail: { tags: ["storage"], summary: "List project storage buckets" } })
     .post('/buckets', async ({ params, body, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
         const { bucketName, storageResult } = await createStorageBucket(params.ref, body);
         if (!storageResult.success) {
-            set.status = 500;
-            return { message: storageResult.error || "Failed to create bucket", code: "500" };
+            set.status = storageResult.error === "Bucket already exists" ? 409 : 500;
+            return { message: storageResult.error || "Failed to create bucket", code: String(set.status) };
         }
         return { id: bucketName, name: bucketName, public: body.public || false };
     }, {
@@ -529,7 +621,7 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
     .get('/buckets/:id', async ({ params, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
-        const buckets = await StorageService.listBuckets(params.ref);
+        const buckets = await listStorageBuckets(params.ref);
         const bucket = (buckets as Array<Record<string, unknown>>).find((b: Record<string, unknown>) => b.id === params.id || b.name === params.id);
         if (!bucket) {
             set.status = 404;
@@ -563,10 +655,10 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
     .delete('/buckets/:id', async ({ params, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
-        const result = await StorageService.deleteBucket(params.ref, params.id);
+        const result = await deleteStorageBucket(params.ref, params.id);
         if (!result.success) {
-            set.status = 500;
-            return { message: result.error || "Failed to delete bucket", code: "500" };
+            set.status = result.error === "Bucket is not empty" ? 409 : 500;
+            return { message: result.error || "Failed to delete bucket", code: String(set.status) };
         }
         return { id: params.id, deleted: true };
     }, { detail: { tags: ["storage"], summary: "Delete a storage bucket" } });

--- a/packages/management-api/src/services/storage-rls.ts
+++ b/packages/management-api/src/services/storage-rls.ts
@@ -9,6 +9,14 @@ import { resolveProjectApiKey } from "../utils/project-auth";
 export const mockBuckets = new Map<string, any>();
 export const mockObjects = new Map<string, any>();
 
+type LogicalBucketInput = {
+  id: string;
+  name: string;
+  public: boolean;
+  fileSizeLimit?: number | null;
+  allowedMimeTypes?: string[] | null;
+};
+
 function normalizeSqlRole(role: unknown, allowServiceRole = false): 'anon' | 'authenticated' | 'service_role' {
   if (allowServiceRole && role === 'service_role') return 'service_role';
   return role === 'authenticated' ? 'authenticated' : 'anon';
@@ -36,6 +44,15 @@ async function applyRlsContext(tx: import("bun").SQL, payload: Record<string, un
   await tx`SELECT set_config('request.jwt.claim.role', ${role}, true)`;
 }
 
+async function upsertLogicalBucket(db: import("bun").SQL, bucket: LogicalBucketInput): Promise<void> {
+  const allowedMimeTypes = bucket.allowedMimeTypes?.length ? bucket.allowedMimeTypes : null;
+  await db`
+    INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types, created_at, updated_at)
+    VALUES (${bucket.id}, ${bucket.name}, ${bucket.public}, ${bucket.fileSizeLimit || null}, ${allowedMimeTypes}, now(), now())
+    ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public, name = EXCLUDED.name, file_size_limit = EXCLUDED.file_size_limit, allowed_mime_types = EXCLUDED.allowed_mime_types, updated_at = now()
+  `;
+}
+
 export class StorageRLS {
 
   
@@ -47,15 +64,78 @@ export class StorageRLS {
 
     try {
         await this.withBucketRLS(ref, token, async (tx) => {
-            await tx`
-              INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types, created_at, updated_at)
-              VALUES (${bucketId}, ${name}, ${isPublic}, ${fileSizeLimit || null}, ${(allowedMimeTypes && allowedMimeTypes.length > 0) ? allowedMimeTypes : null}, now(), now())
-              ON CONFLICT (id) DO UPDATE SET public = EXCLUDED.public, name = EXCLUDED.name, file_size_limit = EXCLUDED.file_size_limit, allowed_mime_types = EXCLUDED.allowed_mime_types, updated_at = now()
-            `;
+            await upsertLogicalBucket(tx, {
+              id: bucketId,
+              name,
+              public: isPublic,
+              fileSizeLimit,
+              allowedMimeTypes,
+            });
         });
     } catch (e: any) {
         throw new Error(e.message || "Failed to create bucket");
     }
+  }
+
+  static async createLogicalBucketAsAdmin(ref: string, bucket: LogicalBucketInput): Promise<boolean> {
+    if (ref === 'test_mock') {
+      if (mockBuckets.has(bucket.id)) return false;
+      mockBuckets.set(bucket.id, {
+        id: bucket.id,
+        name: bucket.name,
+        public: bucket.public,
+        file_size_limit: bucket.fileSizeLimit || null,
+        allowed_mime_types: bucket.allowedMimeTypes?.length ? bucket.allowedMimeTypes : null,
+      });
+      return true;
+    }
+    const dbName = await resolveDbName(ref);
+    const db = getProjectDb(dbName);
+    const rows = await db`
+      INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types, created_at, updated_at)
+      VALUES (${bucket.id}, ${bucket.name}, ${bucket.public}, ${bucket.fileSizeLimit || null}, ${bucket.allowedMimeTypes?.length ? bucket.allowedMimeTypes : null}, now(), now())
+      ON CONFLICT (id) DO NOTHING
+      RETURNING id
+    `;
+    return rows.length > 0;
+  }
+
+  static async listLogicalBucketsAsAdmin(ref: string): Promise<Record<string, unknown>[]> {
+    if (ref === 'test_mock') return Array.from(mockBuckets.values());
+    const dbName = await resolveDbName(ref);
+    const db = getProjectDb(dbName);
+    return await db`
+      SELECT id, name, public, created_at, updated_at, file_size_limit, allowed_mime_types
+      FROM storage.buckets
+      ORDER BY name ASC
+    `;
+  }
+
+  static async deleteLogicalBucketAsAdmin(ref: string, bucketId: string): Promise<void> {
+    if (ref === 'test_mock') {
+      mockBuckets.delete(bucketId);
+      return;
+    }
+    const dbName = await resolveDbName(ref);
+    const db = getProjectDb(dbName);
+    await db`DELETE FROM storage.buckets WHERE id = ${bucketId}`;
+  }
+
+  static async assertLogicalBucketDeletableAsAdmin(ref: string, bucketId: string): Promise<void> {
+    if (ref === 'test_mock') {
+      if (Array.from(mockObjects.keys()).some((key) => key.startsWith(`${bucketId}/`))) {
+        throw new Error("Bucket is not empty");
+      }
+      return;
+    }
+    const dbName = await resolveDbName(ref);
+    const db = getProjectDb(dbName);
+    const [row] = await db`
+      SELECT EXISTS(
+        SELECT 1 FROM storage.objects WHERE bucket_id = ${bucketId}
+      ) AS has_objects
+    `;
+    if (row?.has_objects === true) throw new Error("Bucket is not empty");
   }
 
   

--- a/packages/management-api/src/services/storage.adapter.ts
+++ b/packages/management-api/src/services/storage.adapter.ts
@@ -47,6 +47,7 @@ export interface StorageDriver {
   ): Promise<
     { id: string; name: string; updated?: string; size: string; type: string }[]
   >;
+  isBucketEmpty(projectRef: string, bucket: string): Promise<boolean>;
   getDownloadResponse(
     projectRef: string,
     bucket: string,
@@ -222,6 +223,11 @@ export class JuiceFSDriver implements StorageDriver {
     } catch (e) {
       return [];
     }
+  }
+
+  async isBucketEmpty(projectRef: string, bucket: string): Promise<boolean> {
+    const entries = await fs.readdir(this.getBasePath(projectRef, bucket));
+    return entries.length === 0;
   }
 
   async getDownloadResponse(
@@ -646,6 +652,23 @@ export class S3Driver implements StorageDriver {
     } catch (e) {
       return [];
     }
+  }
+
+  async isBucketEmpty(projectRef: string, bucket: string): Promise<boolean> {
+    const creds = await this.getCreds(projectRef);
+    if (!creds?.accessKey || !creds?.secretKey) {
+      throw new Error("Storage credentials are unavailable");
+    }
+    const s3 = this.getClient(
+      creds as {
+        accessKey: string;
+        secretKey: string;
+        endpoint: string;
+        bucket: string;
+      },
+    );
+    const response = await s3.list({ prefix: `${bucket}/`, maxKeys: 1 });
+    return (response.contents?.length ?? 0) === 0;
   }
 
   async getDownloadResponse(

--- a/packages/management-api/src/services/storage.service.ts
+++ b/packages/management-api/src/services/storage.service.ts
@@ -151,6 +151,10 @@ export class StorageService {
     return await getStorageDriver().listFiles(projectRef, bucketName);
   }
 
+  static async isBucketEmpty(projectRef: string, bucketName: string): Promise<boolean> {
+    return await getStorageDriver().isBucketEmpty(projectRef, bucketName);
+  }
+
   static async updateBucket(projectRef: string, bucketId: string, updates: { public?: boolean; file_size_limit?: number; allowed_mime_types?: string[] }): Promise<{ success: boolean; error?: string; bucket?: Record<string, unknown> }> {
     if (!/^[a-zA-Z0-9._-]+$/.test(bucketId)) {
       return { success: false, error: "Invalid bucket id" };

--- a/packages/management-api/tests/unit/storage-routes.test.ts
+++ b/packages/management-api/tests/unit/storage-routes.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
-import { storageRoutes } from "../../src/routes/storage";
+import { projectStorageRoutes, storageRoutes } from "../../src/routes/storage";
 import { StorageService } from "../../src/services/storage.service";
-import { StorageRLS } from "../../src/services/storage-rls";
+import { mockBuckets, StorageRLS } from "../../src/services/storage-rls";
 
 const BASE = "http://localhost";
-const app = new Elysia().use(storageRoutes);
+const app = new Elysia().use(storageRoutes).use(projectStorageRoutes);
 
 function request(path: string, init?: RequestInit) {
   return app.handle(new Request(`${BASE}${path}`, init));
@@ -14,6 +14,7 @@ function request(path: string, init?: RequestInit) {
 describe("storage management routes", () => {
   test("Studio bucket creation requires auth and creates the requested bucket", async () => {
     const createBucketSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
+    const registerBucketSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(true);
 
     try {
       const createRequest = {
@@ -31,16 +32,255 @@ describe("storage management routes", () => {
       expect(authorized.status).toBe(200);
       expect(await authorized.json()).toEqual({ id: "studio-assets", name: "studio-assets", public: false });
       expect(createBucketSpy).toHaveBeenCalledWith("test-ref", "studio-assets");
+      expect(registerBucketSpy).toHaveBeenCalledWith("test-ref", {
+        id: "studio-assets",
+        name: "studio-assets",
+        public: false,
+        fileSizeLimit: 1024,
+        allowedMimeTypes: undefined,
+      });
     } finally {
       createBucketSpy.mockRestore();
+      registerBucketSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket creation persists public metadata without project JWT verification", async () => {
+    const createBucketSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
+    const registerBucketSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(true);
+    const verifyTokenSpy = spyOn(StorageRLS, "verifyToken");
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify({
+          name: "public-assets",
+          public: true,
+          file_size_limit: 1024,
+          allowed_mime_types: ["image/png"],
+        }),
+      });
+      expect(response.status).toBe(200);
+      expect(registerBucketSpy).toHaveBeenCalledWith("test-ref", {
+        id: "public-assets",
+        name: "public-assets",
+        public: true,
+        fileSizeLimit: 1024,
+        allowedMimeTypes: ["image/png"],
+      });
+      expect(verifyTokenSpy).not.toHaveBeenCalled();
+    } finally {
+      createBucketSpy.mockRestore();
+      registerBucketSpy.mockRestore();
+      verifyTokenSpy.mockRestore();
+    }
+  });
+
+  test("Studio-created public buckets immediately expose public file URLs", async () => {
+    mockBuckets.clear();
+    const createBucketSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
+
+    try {
+      const createResponse = await request("/v1/storage/test_mock/buckets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify({ name: "public-assets", public: true }),
+      });
+      expect(createResponse.status).toBe(200);
+
+      const publicUrlResponse = await request(
+        "/v1/storage/test_mock/buckets/public-assets/files/public-url?path=folder%2Flogo.svg",
+        { headers: { Authorization: "Bearer dev-master-token", "x-forwarded-proto": "https" } },
+      );
+      expect(publicUrlResponse.status).toBe(200);
+      expect(await publicUrlResponse.json()).toEqual({
+        public_url: "https://test_mock.api.example.com/storage/v1/object/public/public-assets/folder/logo.svg",
+      });
+    } finally {
+      createBucketSpy.mockRestore();
+      mockBuckets.clear();
+    }
+  });
+
+  test("Studio bucket creation does not overwrite an existing logical bucket", async () => {
+    const createLogicalSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(false);
+    const createPhysicalSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify({ name: "existing", public: false }),
+      });
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ message: "Bucket already exists", code: "409" });
+      expect(createLogicalSpy).toHaveBeenCalled();
+      expect(createPhysicalSpy).not.toHaveBeenCalled();
+    } finally {
+      createLogicalSpy.mockRestore();
+      createPhysicalSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket listing overlays logical metadata and keeps logical-only buckets", async () => {
+    const listPhysicalSpy = spyOn(StorageService, "listBuckets").mockResolvedValue([
+      { id: "public-assets", name: "public-assets", public: false, size: "-" },
+      { id: "physical-only", name: "physical-only", public: false, size: "-" },
+    ]);
+    const listLogicalSpy = spyOn(StorageRLS, "listLogicalBucketsAsAdmin").mockResolvedValue([
+      { id: "public-assets", name: "public-assets", public: true, file_size_limit: 1024 },
+      { id: "logical-only", name: "logical-only", public: false },
+    ]);
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets", {
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual([
+        { id: "public-assets", name: "public-assets", public: true, size: "-", file_size_limit: 1024 },
+        { id: "physical-only", name: "physical-only", public: false, size: "-" },
+        { id: "logical-only", name: "logical-only", public: false },
+      ]);
+    } finally {
+      listPhysicalSpy.mockRestore();
+      listLogicalSpy.mockRestore();
+    }
+  });
+
+  test("legacy default bucket listing falls back to physical storage", async () => {
+    const physicalBuckets = [{ id: "platform", name: "platform", public: false, size: "-" }];
+    const listPhysicalSpy = spyOn(StorageService, "listBuckets").mockResolvedValue(physicalBuckets);
+    const listLogicalSpy = spyOn(StorageRLS, "listLogicalBucketsAsAdmin");
+
+    try {
+      const response = await request("/v1/storage/default/buckets", {
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(physicalBuckets);
+      expect(listLogicalSpy).not.toHaveBeenCalled();
+    } finally {
+      listPhysicalSpy.mockRestore();
+      listLogicalSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket deletion removes physical storage before logical metadata", async () => {
+    const callOrder: string[] = [];
+    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockImplementation(async () => {
+      callOrder.push("physical-preflight");
+      return true;
+    });
+    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockImplementation(async () => {
+      callOrder.push("logical-preflight");
+    });
+    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockImplementation(async () => {
+      callOrder.push("physical");
+      return { success: true };
+    });
+    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockImplementation(async () => {
+      callOrder.push("logical");
+    });
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+      expect(response.status).toBe(200);
+      expect(callOrder).toEqual(["physical-preflight", "logical-preflight", "physical", "logical"]);
+      expect(deleteLogicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
+    } finally {
+      isBucketEmptySpy.mockRestore();
+      deletePhysicalSpy.mockRestore();
+      deleteLogicalSpy.mockRestore();
+      assertDeletableSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket deletion leaves physical data untouched when logical objects exist", async () => {
+    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockResolvedValue(true);
+    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockRejectedValue(
+      new Error("Bucket is not empty"),
+    );
+    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
+    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ message: "Bucket is not empty", code: "409" });
+      expect(deletePhysicalSpy).not.toHaveBeenCalled();
+      expect(deleteLogicalSpy).not.toHaveBeenCalled();
+    } finally {
+      isBucketEmptySpy.mockRestore();
+      assertDeletableSpy.mockRestore();
+      deletePhysicalSpy.mockRestore();
+      deleteLogicalSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket deletion leaves physical data untouched when Studio files exist", async () => {
+    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockResolvedValue(false);
+    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockResolvedValue();
+    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
+    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ message: "Bucket is not empty", code: "409" });
+      expect(assertDeletableSpy).not.toHaveBeenCalled();
+      expect(deletePhysicalSpy).not.toHaveBeenCalled();
+      expect(deleteLogicalSpy).not.toHaveBeenCalled();
+    } finally {
+      isBucketEmptySpy.mockRestore();
+      assertDeletableSpy.mockRestore();
+      deletePhysicalSpy.mockRestore();
+      deleteLogicalSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket deletion fails closed when physical inspection fails", async () => {
+    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockRejectedValue(
+      new Error("storage unavailable"),
+    );
+    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockResolvedValue();
+    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
+    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+      expect(response.status).toBe(500);
+      expect(assertDeletableSpy).not.toHaveBeenCalled();
+      expect(deletePhysicalSpy).not.toHaveBeenCalled();
+      expect(deleteLogicalSpy).not.toHaveBeenCalled();
+    } finally {
+      isBucketEmptySpy.mockRestore();
+      assertDeletableSpy.mockRestore();
+      deletePhysicalSpy.mockRestore();
+      deleteLogicalSpy.mockRestore();
     }
   });
 
   test("Studio bucket creation preserves storage failures", async () => {
+    const registerBucketSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(true);
     const createBucketSpy = spyOn(StorageService, "createBucket").mockResolvedValue({
       success: false,
       error: "storage unavailable",
     });
+    const rollbackSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
 
     try {
       const response = await request("/v1/storage/test-ref/buckets", {
@@ -50,8 +290,11 @@ describe("storage management routes", () => {
       });
       expect(response.status).toBe(500);
       expect(await response.json()).toEqual({ message: "storage unavailable", code: "500" });
+      expect(rollbackSpy).toHaveBeenCalledWith("test-ref", "studio-assets");
     } finally {
+      registerBucketSpy.mockRestore();
       createBucketSpy.mockRestore();
+      rollbackSpy.mockRestore();
     }
   });
 

--- a/packages/management-api/tests/unit/storage.adapter.test.ts
+++ b/packages/management-api/tests/unit/storage.adapter.test.ts
@@ -69,6 +69,26 @@ describe("S3Driver uploadFile", () => {
       else process.env.GITHUB_ACTIONS = previousGithubActions;
     }
   });
+
+  test("checks bucket emptiness with a bounded prefix query", async () => {
+    const driver = new S3Driver();
+    let listOptions: unknown;
+    (driver as unknown as { getCreds: () => unknown }).getCreds = async () => ({
+      accessKey: "test-access",
+      secretKey: "test-secret",
+      endpoint: "http://127.0.0.1:9000",
+      bucket: "supa_test",
+    });
+    (driver as unknown as { getClient: () => unknown }).getClient = () => ({
+      list: async (options: unknown) => {
+        listOptions = options;
+        return { contents: [{ key: "gallery/logo.svg" }] };
+      },
+    });
+
+    expect(await driver.isBucketEmpty("testref", "gallery")).toBe(false);
+    expect(listOptions).toEqual({ prefix: "gallery/", maxKeys: 1 });
+  });
 });
 
 describe("JuiceFSDriver uploadFile", () => {

--- a/packages/management-api/tests/unit/storage.service.test.ts
+++ b/packages/management-api/tests/unit/storage.service.test.ts
@@ -8,6 +8,7 @@ const mockStorageDriver = {
   emptyBucket: mock().mockResolvedValue(true),
   listBuckets: mock().mockResolvedValue([]),
   listFiles: mock().mockResolvedValue([]),
+  isBucketEmpty: mock().mockResolvedValue(true),
   uploadFile: mock().mockResolvedValue(true),
   deleteFile: mock().mockResolvedValue(true),
   getDownloadResponse: mock().mockResolvedValue(new Response()),
@@ -53,6 +54,13 @@ describe("StorageService (using adapter)", () => {
       mockStorageDriver.deleteBucket.mockResolvedValueOnce(true);
       await storageService.deleteBucket("myproj", "bucket");
       expect(mockStorageDriver.deleteBucket).toHaveBeenCalledWith("myproj", "bucket");
+    });
+  });
+
+  describe("isBucketEmpty", () => {
+    test("should preserve strict driver failures", async () => {
+      mockStorageDriver.isBucketEmpty.mockRejectedValueOnce(new Error("storage unavailable"));
+      await expect(StorageService.isBucketEmpty("myproj", "bucket")).rejects.toThrow("storage unavailable");
     });
   });
 


### PR DESCRIPTION
## Summary

- persist Studio-created bucket metadata in the tenant `storage.buckets` table before allocating physical storage
- merge logical bucket metadata into Studio listings so `public` survives refresh and public URL generation works
- keep destructive bucket deletion fail-closed across JuiceFS and S3, including strict empty checks and bounded S3 prefix queries
- preserve the platform `default` physical-only bucket listing

## Verification

- `bun test tests/unit/storage-routes.test.ts tests/unit/storage.service.test.ts tests/unit/storage.adapter.test.ts tests/unit/storage-compat.helpers.test.ts tests/unit/storage-compat.sdk.test.ts tests/unit/storage-s3.routes.test.ts` (80 passed)
- `bunx tsc --noEmit`
- `git diff --check origin/main`
- independent verifier: PASS; clean-code-guard: clean

## Context

Released v0.49.1 still returns `404 Bucket not found` when Studio requests `/files/public-url` for a bucket created as public. The management create path allocated only physical storage, while public URL generation requires the logical bucket row. This follows up #589 and the open CNB issue #38.
