### PR TITLE
fix(cache): return disabled status without data plane

### DIFF
--- a/packages/management-api/src/services/pgredis-runtime.service.ts
+++ b/packages/management-api/src/services/pgredis-runtime.service.ts
@@ -73,9 +73,23 @@ export class PgredisRuntimeService {
   }
 
   async projectStatus(projectRef: string): Promise<PgredisProjectStatus> {
-    return this.request<PgredisProjectStatus>(
-      `/internal/v1/admin/projects/${encodeURIComponent(projectRef)}/status`,
-    );
+    try {
+      return await this.request<PgredisProjectStatus>(
+        `/internal/v1/admin/projects/${encodeURIComponent(projectRef)}/status`,
+      );
+    } catch (error) {
+      if (error instanceof AppError && error.code === "PGREDIS_RUNTIME_NOT_CONFIGURED") {
+        return {
+          projectRef,
+          configured: false,
+          active: false,
+          configurationCurrent: false,
+          leases: 0,
+          lastUsedAt: null,
+        };
+      }
+      throw error;
+    }
   }
 
   async execute(

--- a/packages/management-api/tests/unit/pgredis-runtime.service.test.ts
+++ b/packages/management-api/tests/unit/pgredis-runtime.service.test.ts
@@ -68,7 +68,7 @@ describe("PgredisRuntimeService", () => {
     });
   });
 
-  test("fails closed when the token is missing", async () => {
+  test("reports a disabled project cache without contacting an unconfigured data plane", async () => {
     const fetchImpl = mock(() => Promise.resolve(Response.json({ ok: true })));
     const service = new PgredisRuntimeService({
       baseUrl: "http://pgredis-runtime:9010",
@@ -77,7 +77,25 @@ describe("PgredisRuntimeService", () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
+    await expect(service.projectStatus("tenant-a")).resolves.toEqual({
+      projectRef: "tenant-a",
+      configured: false,
+      active: false,
+      configurationCurrent: false,
+      leases: 0,
+      lastUsedAt: null,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+
     await expect(service.platformStatus()).rejects.toMatchObject({
+      statusCode: 503,
+      code: "PGREDIS_RUNTIME_NOT_CONFIGURED",
+    });
+    await expect(service.execute("tenant-a", { op: "get", key: "key-a" })).rejects.toMatchObject({
+      statusCode: 503,
+      code: "PGREDIS_RUNTIME_NOT_CONFIGURED",
+    });
+    await expect(service.flush("tenant-a")).rejects.toMatchObject({
       statusCode: 503,
       code: "PGREDIS_RUNTIME_NOT_CONFIGURED",
     });
@@ -86,11 +104,14 @@ describe("PgredisRuntimeService", () => {
 
   test("does not expose upstream authentication failures", async () => {
     const { service } = serviceWith(() => Response.json({ error: "Unauthorized" }, { status: 401 }));
-    await expect(service.platformStatus()).rejects.toMatchObject({
+    const expectedError = {
       statusCode: 502,
       code: "PGREDIS_UPSTREAM_ERROR",
       message: "Cache data plane proxy failed",
-    });
+    };
+
+    await expect(service.platformStatus()).rejects.toMatchObject(expectedError);
+    await expect(service.projectStatus("tenant-a")).rejects.toMatchObject(expectedError);
   });
 
   test("maps transport failures without swallowing unexpected errors", async () => {
@@ -99,8 +120,13 @@ describe("PgredisRuntimeService", () => {
       statusCode: 503,
       code: "PGREDIS_RUNTIME_UNAVAILABLE",
     });
+    await expect(transportFailure.projectStatus("tenant-a")).rejects.toMatchObject({
+      statusCode: 503,
+      code: "PGREDIS_RUNTIME_UNAVAILABLE",
+    });
 
     const unexpectedFailure = serviceWith(() => { throw new Error("programmer error"); }).service;
     await expect(unexpectedFailure.platformStatus()).rejects.toThrow("programmer error");
+    await expect(unexpectedFailure.projectStatus("tenant-a")).rejects.toThrow("programmer error");
   });
 });

--- a/packages/management-api/tests/unit/pgredis.routes.test.ts
+++ b/packages/management-api/tests/unit/pgredis.routes.test.ts
@@ -47,6 +47,29 @@ describe("pgredis routes", () => {
     expect(requireProject).toHaveBeenCalledTimes(1);
   });
 
+  test("returns a disabled project cache status when the data plane is not configured", async () => {
+    projectStatus.mockResolvedValueOnce({
+      projectRef: "tenant-a",
+      configured: false,
+      active: false,
+      configurationCurrent: false,
+      leases: 0,
+      lastUsedAt: null,
+    });
+
+    const response = await request("/v1/projects/tenant-a/cache");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      projectRef: "tenant-a",
+      configured: false,
+      active: false,
+      configurationCurrent: false,
+      leases: 0,
+      lastUsedAt: null,
+    });
+  });
+
   test("maps exact-key operations and keeps projectRef server-derived", async () => {
     const response = await request("/v1/projects/tenant-a/cache/operations", {
       method: "POST",


### PR DESCRIPTION
## Summary

- return a normal disabled cache status from `GET /v1/projects/:ref/cache` when the global pgredis data plane has not been provisioned
- keep platform status, exact-key operations, and flush fail-closed with `PGREDIS_RUNTIME_NOT_CONFIGURED`
- add service and route regressions for the HTTP 200 disabled-state contract and error boundaries

## Root cause

The management configuration defaults `PGREDIS_RUNTIME_INTERNAL_TOKEN` to an empty value. The project-status read used the generic cache request path, which correctly rejects missing credentials but incorrectly treated the normal unprovisioned project-cache state as an API error. Studio already renders `configured: false` and disables cache mutations.

## Validation

- `bun run typecheck`
- `bun test tests/unit/pgredis-runtime.service.test.ts tests/unit/pgredis.routes.test.ts` (`9 pass, 0 fail`)
- Web Console project-cache test (`2 pass, 0 fail`)
- `bun run check` (`0 errors, 0 warnings`)
- `git diff --check`

No server deployment or configuration change is included.