### PR TITLE
feat(console): reorganize navigation hierarchy

### DIFF
--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.6.0",
-        "@supacloud/cli": "^0.12.4",
+        "@supacloud/cli": "^0.13.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -19,7 +19,7 @@
 
     "@supacloud/admin": ["@supacloud/admin@0.6.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.6.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.12.4", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.12.4.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-B45xCBe9hwNUeAOkh4OAY/DXzx7XII2EmXtg1NrRQ6wanAuyl5z8dGc+OX9yNdjxfgONGvzTgrhg3W7buZsXDA=="],
+    "@supacloud/cli": ["@supacloud/cli@0.13.0", "", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-/GMoffOoL7W0wJ0KsJ0SYl8Cz0Fucoe7fhHO+JeDmRiiCkQhVGlg7ukfWNrvODmA1E77JkJVgVhn/ynn+G7mpQ=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 

--- a/packages/web-console/src/lib/components/PlatformSidebar.svelte
+++ b/packages/web-console/src/lib/components/PlatformSidebar.svelte
@@ -3,16 +3,16 @@
   import {
     Box,
     Database,
-    Settings2,
-    LineChart,
-    Network,
+    Gauge,
     HardDrive,
-    Terminal,
-    Languages,
     Home,
-    SunMoon,
+    LineChart,
+    MemoryStick,
+    Network,
+    Settings2,
     ShieldCheck,
-    MemoryStick
+    SunMoon,
+    Terminal,
   } from "lucide-svelte";
   import { page } from "$app/stores";
   import { t, locale } from "svelte-i18n";
@@ -34,96 +34,95 @@
       : ($t("Common.dark_mode") || "Dark mode")
   );
 
-  const navItems = $derived([
+  const infrastructureItems = [
     { titleKey: "Platform.extensions_market", icon: Box, href: "/platform/extensions" },
     { titleKey: "Platform.backups_pitr", icon: Database, href: "/platform/backups" },
-    { titleKey: "Platform.engine_tuning", icon: Settings2, href: "/platform/tuning" },
-    { titleKey: "Platform.monitoring", icon: LineChart, href: "/platform/monitoring" },
     { titleKey: "Platform.connection_pool", icon: Network, href: "/platform/pooling" },
-    { titleKey: "Platform.cache_runtime", icon: MemoryStick, href: "/platform/cache" },
     { titleKey: "Platform.storage_juicefs", icon: HardDrive, href: "/platform/storage" },
+  ];
+
+  const runtimeItems = [
+    { titleKey: "Platform.monitoring", icon: LineChart, href: "/platform/monitoring" },
+    { titleKey: "Platform.engine_tuning", icon: Gauge, href: "/platform/tuning" },
+    { titleKey: "Platform.cache_runtime", icon: MemoryStick, href: "/platform/cache" },
+  ];
+
+  const operationsItems = [
     { titleKey: "Platform.operations_console", icon: Terminal, href: "/platform/operations" },
     { titleKey: "Platform.diagnostics", icon: ShieldCheck, href: "/platform/diagnostics" },
-  ]);
+  ];
 
   function isActive(href: string) {
-    return $page.url.pathname === href || $page.url.pathname.startsWith(href);
+    return $page.url.pathname === href || $page.url.pathname.startsWith(`${href}/`);
   }
 </script>
 
-<aside class={cn("flex flex-col w-64 h-screen border-r bg-card text-foreground", className)}>
-  <div class="h-16 flex flex-col justify-center px-6 border-b">
+<aside class={cn("flex h-screen w-64 shrink-0 flex-col border-r bg-card text-foreground", className)}>
+  <div class="flex h-16 flex-col justify-center border-b px-6">
     <span class="text-xl font-bold tracking-tight text-brand">SupaCloud</span>
-    <span class="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase mt-0.5">{$t("Platform.title")}</span>
+    <span class="mt-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{$t("Platform.title")}</span>
   </div>
 
-  <nav class="flex-1 overflow-y-auto py-4 px-3 space-y-1">
-    {#each navItems as item}
-      {@const Icon = item.icon}
-      <a
-        href={item.href}
-        class={cn(
-          "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors cursor-pointer",
-          isActive(item.href) ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-muted hover:text-foreground"
-        )}
-      >
-        <Icon size={18} />
-        {$t(item.titleKey)}
-      </a>
-    {/each}
+  <nav class="flex-1 overflow-y-auto px-3 py-4">
+    <span class="mb-2 block px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">{$t("Platform.infrastructure")}</span>
+    <div class="space-y-0.5">
+      {#each infrastructureItems as item (item.href)}
+        {@const Icon = item.icon}
+        <a href={item.href} class={cn("flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors", isActive(item.href) ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-muted hover:text-foreground")}>
+          <Icon class="h-[18px] w-[18px]" />
+          {$t(item.titleKey)}
+        </a>
+      {/each}
+    </div>
+
+    <span class="mb-2 mt-6 block px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">{$t("Platform.performance_runtime")}</span>
+    <div class="space-y-0.5">
+      {#each runtimeItems as item (item.href)}
+        {@const Icon = item.icon}
+        <a href={item.href} class={cn("flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors", isActive(item.href) ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-muted hover:text-foreground")}>
+          <Icon class="h-[18px] w-[18px]" />
+          {$t(item.titleKey)}
+        </a>
+      {/each}
+    </div>
+
+    <span class="mb-2 mt-6 block px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">{$t("Platform.operations")}</span>
+    <div class="space-y-0.5">
+      {#each operationsItems as item (item.href)}
+        {@const Icon = item.icon}
+        <a href={item.href} class={cn("flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors", isActive(item.href) ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-muted hover:text-foreground")}>
+          <Icon class="h-[18px] w-[18px]" />
+          {$t(item.titleKey)}
+        </a>
+      {/each}
+    </div>
+
+    <span class="mb-2 mt-6 block px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">{$t("Sidebar.configure")}</span>
+    <a href="/platform/settings" class={cn("flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors", isActive("/platform/settings") ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-muted hover:text-foreground")}>
+      <Settings2 class="h-[18px] w-[18px]" />
+      {$t("Platform.settings")}
+    </a>
   </nav>
 
-  <div class="p-3 border-t space-y-2">
-    <div class="grid grid-cols-[1fr_36px_36px_36px] gap-1.5">
-      <a
-        href="/"
-        class="flex min-w-0 items-center gap-2 rounded-md bg-brand/5 px-2.5 py-2 text-xs font-semibold text-brand transition-colors hover:bg-brand/10"
-        title={$t("Sidebar.back_to_projects") || "Back to projects"}
-        aria-label={$t("Sidebar.back_to_projects") || "Back to projects"}
-      >
+  <div class="space-y-2 border-t p-3">
+    <div class="grid grid-cols-[1fr_36px_36px] gap-1.5">
+      <a href="/" class="flex min-w-0 items-center gap-2 rounded-md bg-brand/5 px-2.5 py-2 text-xs font-semibold text-brand transition-colors hover:bg-brand/10" title={$t("Sidebar.back_to_projects") || "Back to projects"} aria-label={$t("Sidebar.back_to_projects") || "Back to projects"}>
         <Home size={16} class="shrink-0" />
         <span class="truncate">{$t("Sidebar.back_to_projects") || "Back"}</span>
       </a>
-      <a
-        href="/platform/settings"
-        class={cn(
-          "flex h-9 w-9 items-center justify-center rounded-md transition-colors",
-          isActive("/platform/settings")
-            ? "bg-accent text-accent-foreground"
-            : "text-muted-foreground hover:bg-muted hover:text-foreground"
-        )}
-        title={$t("Platform.settings") || "Settings"}
-        aria-label={$t("Platform.settings") || "Settings"}
-      >
-        <Settings2 size={16} />
-      </a>
-      <button
-        type="button"
-        onclick={toggleMode}
-        class="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        title={themeToggleLabel}
-        aria-label={themeToggleLabel}
-      >
+      <button type="button" onclick={toggleMode} class="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground" title={themeToggleLabel} aria-label={themeToggleLabel}>
         <SunMoon size={16} />
       </button>
-      <button
-        type="button"
-        onclick={toggleLanguage}
-        class="flex h-9 w-9 items-center justify-center rounded-md text-xs font-bold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        title={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")}
-        aria-label={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")}
-      >
+      <button type="button" onclick={toggleLanguage} class="flex h-9 w-9 items-center justify-center rounded-md text-xs font-bold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground" title={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")} aria-label={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")}>
         {isZhLocale($locale) ? "EN" : "中"}
       </button>
     </div>
 
     <div class="flex w-full items-center gap-2 rounded-md border bg-muted/20 px-2.5 py-2">
-      <span class="w-7 h-7 shrink-0 rounded-full bg-gradient-to-tr from-brand to-emerald-400 flex items-center justify-center text-white font-bold text-[11px]">
-        SC
-      </span>
-      <span class="flex flex-col min-w-0 text-left">
-        <span class="text-xs font-semibold truncate text-foreground">Platform Admin</span>
-        <span class="text-[10px] leading-tight text-muted-foreground truncate">admin@supacloud.local</span>
+      <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-tr from-brand to-emerald-400 text-[11px] font-bold text-white">SC</span>
+      <span class="flex min-w-0 flex-col text-left">
+        <span class="truncate text-xs font-semibold text-foreground">Platform Admin</span>
+        <span class="truncate text-[10px] leading-tight text-muted-foreground">admin@supacloud.local</span>
       </span>
     </div>
   </div>

--- a/packages/web-console/src/lib/components/Sidebar.svelte
+++ b/packages/web-console/src/lib/components/Sidebar.svelte
@@ -2,27 +2,23 @@
   import { t, locale } from "svelte-i18n";
   import { cn } from "$lib/utils";
   import {
-    Home,
-    Table,
-    Database,
-    Code2,
-    Users,
     Box,
-    Zap,
-    Settings,
-    LayoutDashboard,
-    Files,
-    Shield,
-    Languages,
-    LineChart,
-    ShieldCheck,
-    ScrollText,
-    Radio,
+    ChartNoAxesCombined,
+    ChevronDown,
+    Code2,
+    Database,
     Globe,
-    Glasses,
-    Activity,
+    LayoutDashboard,
+    ListChecks,
+    MemoryStick,
+    Radio,
+    ScrollText,
+    Settings,
+    Shield,
     SunMoon,
-    MemoryStick
+    Table,
+    Users,
+    Zap,
   } from "lucide-svelte";
   import { page } from "$app/stores";
   import { mode, toggleMode } from "mode-watcher";
@@ -45,127 +41,133 @@
       : ($t("Common.dark_mode") || "Dark mode")
   );
 
-  const navItems = $derived(currentProject?.ref ? [
-    { titleKey: "Navigation.table_editor", icon: Table, href: `/project/${currentProject.ref}/tables` },
-    { titleKey: "Navigation.sql_editor", icon: Code2, href: `/project/${currentProject.ref}/sql` },
-    { titleKey: "Navigation.auth", icon: Users, href: `/project/${currentProject.ref}/auth` },
-    { titleKey: "Navigation.storage", icon: Box, href: `/project/${currentProject.ref}/storage` },
-    { titleKey: "Navigation.edge_functions", icon: Zap, href: `/project/${currentProject.ref}/functions` },
-    { titleKey: "Hosting.title", icon: Globe, href: `/project/${currentProject.ref}/hosting` },
-    { titleKey: "Realtime.title", icon: Radio, href: `/project/${currentProject.ref}/realtime` },
-    { titleKey: "Navigation.database", icon: Database, href: `/project/${currentProject.ref}/database` },
-    { titleKey: "Navigation.cache", icon: MemoryStick, href: `/project/${currentProject.ref}/cache` },
-    { titleKey: "Navigation.api_docs", icon: Files, href: `/project/${currentProject.ref}/api` },
-    { titleKey: "Navigation.query_performance", icon: LineChart, href: `/project/${currentProject.ref}/reports/query-performance` },
-    { titleKey: "Navigation.database_linter", icon: ShieldCheck, href: `/project/${currentProject.ref}/reports/database-linter` },
-    { titleKey: "Navigation.diagnostics", icon: ShieldCheck, href: `/project/${currentProject.ref}/reports/diagnostics` },
-    { titleKey: "Sidebar.database_advisor", icon: ShieldCheck, href: `/project/${currentProject.ref}/reports/advisors` },
-    { titleKey: "Navigation.reports", icon: Glasses, href: `/project/${currentProject.ref}/reports/api-overview` },
-    { titleKey: "Navigation.logs", icon: ScrollText, href: `/project/${currentProject.ref}/logs` },
-    { titleKey: "Navigation.tasks", icon: Activity, href: `/project/${currentProject.ref}/tasks` },
-    { titleKey: "Navigation.settings", icon: Settings, href: `/project/${currentProject.ref}/settings` },
+  const projectRef = $derived(currentProject?.ref ?? "");
+
+  const dataItems = $derived(projectRef ? [
+    { titleKey: "Navigation.table_editor", icon: Table, href: `/project/${projectRef}/tables` },
+    { titleKey: "Navigation.sql_editor", icon: Code2, href: `/project/${projectRef}/sql` },
+    { titleKey: "Navigation.database_objects", icon: Database, href: `/project/${projectRef}/database` },
+    { titleKey: "Navigation.cache", icon: MemoryStick, href: `/project/${projectRef}/cache` },
+  ] : []);
+
+  const buildItems = $derived(projectRef ? [
+    { titleKey: "Navigation.auth", icon: Users, href: `/project/${projectRef}/auth` },
+    { titleKey: "Navigation.storage", icon: Box, href: `/project/${projectRef}/storage` },
+    { titleKey: "Navigation.edge_functions", icon: Zap, href: `/project/${projectRef}/functions` },
+    { titleKey: "Hosting.title", icon: Globe, href: `/project/${projectRef}/hosting` },
+  ] : []);
+
+  const observeItems = $derived(projectRef ? [
+    { titleKey: "Navigation.reports", icon: ChartNoAxesCombined, href: `/project/${projectRef}/reports` },
+    { titleKey: "Navigation.realtime_inspector", icon: Radio, href: `/project/${projectRef}/realtime` },
+    { titleKey: "Navigation.logs", icon: ScrollText, href: `/project/${projectRef}/logs` },
+    { titleKey: "Navigation.tasks", icon: ListChecks, href: `/project/${projectRef}/tasks` },
   ] : []);
 
   function isActive(href: string) {
-    return $page.url.pathname === href || $page.url.pathname.startsWith(href);
+    return $page.url.pathname === href || $page.url.pathname.startsWith(`${href}/`);
+  }
+
+  function isProjectHome() {
+    return $page.url.pathname === `/project/${projectRef}` || $page.url.pathname === `/project/${projectRef}/`;
+  }
+
+  function hasActive(items: Array<{ href: string }>) {
+    return items.some((item) => isActive(item.href));
   }
 </script>
 
-<aside class={cn("flex flex-col w-64 h-screen border-r bg-card/80 backdrop-blur-2xl text-foreground", className)}>
-  <div class="h-16 flex items-center gap-3 px-6 border-b border-border/50">
-    <div class="w-7 h-7 rounded-lg bg-gradient-to-br from-brand to-purple-600 flex items-center justify-center text-white font-black text-sm shadow-md shadow-brand/20">SC</div>
-    <span class="text-lg font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-foreground to-muted-foreground">SupaCloud</span>
+<aside class={cn("flex h-screen w-64 shrink-0 flex-col border-r bg-card/80 text-foreground backdrop-blur-2xl", className)}>
+  <div class="flex h-16 items-center gap-3 border-b border-border/50 px-6">
+    <div class="flex h-7 w-7 items-center justify-center rounded-lg bg-gradient-to-br from-brand to-purple-600 text-sm font-black text-white shadow-md shadow-brand/20">SC</div>
+    <span class="bg-gradient-to-r from-foreground to-muted-foreground bg-clip-text text-lg font-bold tracking-tight text-transparent">SupaCloud</span>
   </div>
 
   <ProjectSwitcher {projects} {currentProject} />
 
-  <nav class="flex-1 overflow-y-auto py-6 px-4 space-y-1.5 scrollbar-thin scrollbar-thumb-secondary">
+  <nav class="scrollbar-thin scrollbar-thumb-secondary flex-1 overflow-y-auto px-3 py-4">
     <a
-      href={`/project/${currentProject?.ref}`}
+      href={`/project/${projectRef}`}
       class={cn(
-        "group flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-xl transition-all duration-300",
-        $page.url.pathname === `/project/${currentProject?.ref}` || $page.url.pathname === `/project/${currentProject?.ref}/`
-          ? "bg-secondary/80 text-foreground shadow-sm ring-1 ring-border/50" 
-          : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground hover:translate-x-1"
+        "group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors",
+        isProjectHome() ? "bg-secondary/80 text-foreground shadow-sm ring-1 ring-border/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
       )}
     >
-      <LayoutDashboard fill="currentColor" strokeWidth={1.5} class={cn("w-4 h-4 transition-colors", $page.url.pathname === `/project/${currentProject?.ref}` || $page.url.pathname === `/project/${currentProject?.ref}/` ? "text-brand" : "group-hover:text-brand")} />
+      <LayoutDashboard fill="currentColor" strokeWidth={1.5} class={cn("h-4 w-4", isProjectHome() ? "text-brand" : "group-hover:text-brand")} />
       {$t("Dashboard.title")}
     </a>
-    <div class="h-3"></div>
-    {#each navItems as item}
-      <a
-        href={item.href}
-        class={cn(
-          "group flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-xl transition-all duration-300",
-          isActive(item.href) 
-            ? "bg-secondary/80 text-foreground shadow-sm ring-1 ring-border/50" 
-            : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground hover:translate-x-1"
-        )}
-      >
-        <item.icon fill="currentColor" strokeWidth={1.5} class={cn("w-4 h-4 transition-colors", isActive(item.href) ? "text-brand" : "group-hover:text-brand")} />
-        {$t(item.titleKey)}
-      </a>
-    {/each}
 
-    <!-- Platform Admin separator -->
-    <div class="h-px bg-border/40 my-4"></div>
-    <span class="px-3 text-[10px] font-bold uppercase text-muted-foreground/40 tracking-widest mb-1 block">{$t("Sidebar.platform_admin")}</span>
-    <a
-      href="/platform"
-      class={cn(
-        "group flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-xl transition-all duration-300",
-        $page.url.pathname.startsWith("/platform")
-          ? "bg-secondary/80 text-foreground shadow-sm ring-1 ring-border/50" 
-          : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground hover:translate-x-1"
-      )}
-    >
-      <Settings fill="currentColor" strokeWidth={1.5} class={cn("w-4 h-4 transition-colors", $page.url.pathname.startsWith("/platform") ? "text-brand" : "group-hover:text-brand")} />
-      {$t("Sidebar.infrastructure")}
+    <div class="my-5 h-px bg-border/40"></div>
+
+    <span class="mb-2 block px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">{$t("Sidebar.build")}</span>
+    <details open={hasActive(dataItems)} class="group/details">
+      <summary class={cn(
+        "flex cursor-pointer list-none items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-semibold transition-colors [&::-webkit-details-marker]:hidden",
+        hasActive(dataItems) ? "bg-secondary/60 text-foreground" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+      )}>
+        <Database class="h-4 w-4 text-brand" strokeWidth={1.7} />
+        <span class="flex-1">{$t("Navigation.database")}</span>
+        <ChevronDown class="h-4 w-4 transition-transform group-open/details:rotate-180" />
+      </summary>
+      <div class="ml-4 mt-1 space-y-0.5 border-l border-border/60 pl-3">
+        {#each dataItems as item (item.href)}
+          {@const Icon = item.icon}
+          <a href={item.href} class={cn("group flex items-center gap-2 rounded-lg px-3 py-2 text-xs font-medium transition-colors", isActive(item.href) ? "bg-brand/10 text-brand" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground")}>
+            <Icon class="h-3.5 w-3.5" strokeWidth={1.7} />
+            {$t(item.titleKey)}
+          </a>
+        {/each}
+      </div>
+    </details>
+
+    <div class="mt-4 space-y-0.5">
+      {#each buildItems as item (item.href)}
+        {@const Icon = item.icon}
+        <a href={item.href} class={cn("group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors", isActive(item.href) ? "bg-secondary/80 text-foreground shadow-sm ring-1 ring-border/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground")}>
+          <Icon class={cn("h-4 w-4", isActive(item.href) ? "text-brand" : "group-hover:text-brand")} strokeWidth={1.5} />
+          {$t(item.titleKey)}
+        </a>
+      {/each}
+    </div>
+
+    <span class="mb-2 mt-6 block px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">{$t("Sidebar.observe")}</span>
+    <div class="space-y-0.5">
+      {#each observeItems as item (item.href)}
+        {@const Icon = item.icon}
+        <a href={item.href} class={cn("group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors", isActive(item.href) ? "bg-secondary/80 text-foreground shadow-sm ring-1 ring-border/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground")}>
+          <Icon class={cn("h-4 w-4", isActive(item.href) ? "text-brand" : "group-hover:text-brand")} strokeWidth={1.5} />
+          {$t(item.titleKey)}
+        </a>
+      {/each}
+    </div>
+
+    <span class="mb-2 mt-6 block px-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground/50">{$t("Sidebar.configure")}</span>
+    <a href={`/project/${projectRef}/settings`} class={cn("group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors", isActive(`/project/${projectRef}/settings`) ? "bg-secondary/80 text-foreground shadow-sm ring-1 ring-border/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground")}>
+      <Settings class={cn("h-4 w-4", isActive(`/project/${projectRef}/settings`) ? "text-brand" : "group-hover:text-brand")} strokeWidth={1.5} />
+      {$t("Navigation.settings")}
     </a>
   </nav>
 
-  <div class="p-3 border-t border-border/50 space-y-2 relative overflow-hidden">
-    <!-- Subtle glow background at bottom -->
-    <div class="absolute -bottom-10 -left-10 w-32 h-32 bg-brand/5 rounded-full blur-3xl pointer-events-none"></div>
-
+  <div class="relative space-y-2 overflow-hidden border-t border-border/50 p-3">
+    <div class="absolute -bottom-10 -left-10 h-32 w-32 rounded-full bg-brand/5 blur-3xl"></div>
     <div class="grid grid-cols-[1fr_40px_40px] gap-1.5">
-      <a
-        href="/platform"
-        class="group flex min-w-0 items-center gap-2 rounded-lg bg-brand/5 px-2.5 py-2 text-xs font-semibold text-brand transition-colors hover:bg-brand/10"
-        title={$t("Sidebar.platform_admin")}
-        aria-label={$t("Sidebar.platform_admin")}
-      >
-        <Shield fill="currentColor" strokeWidth={1.5} class="h-4 w-4 shrink-0 transition-transform group-hover:scale-105" />
+      <a href="/platform" class="group flex min-w-0 items-center gap-2 rounded-lg bg-secondary/40 px-2.5 py-2 text-xs font-semibold text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground" title={$t("Sidebar.platform_admin")}>
+        <Shield class="h-4 w-4 shrink-0" strokeWidth={1.5} />
         <span class="truncate">{$t("Sidebar.platform_admin")}</span>
       </a>
-      <button
-        type="button"
-        onclick={(e) => { e.preventDefault(); toggleMode(); }}
-        class="flex h-9 w-10 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground"
-        title={themeToggleLabel}
-        aria-label={themeToggleLabel}
-      >
+      <button type="button" onclick={(e) => { e.preventDefault(); toggleMode(); }} class="flex h-9 w-10 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground" title={themeToggleLabel} aria-label={themeToggleLabel}>
         <SunMoon class="h-4 w-4" />
       </button>
-      <button
-        type="button"
-        onclick={(e) => { e.preventDefault(); toggleLanguage(); }}
-        class="flex h-9 w-10 items-center justify-center rounded-lg text-xs font-bold text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground"
-        title={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")}
-        aria-label={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")}
-      >
+      <button type="button" onclick={(e) => { e.preventDefault(); toggleLanguage(); }} class="flex h-9 w-10 items-center justify-center rounded-lg text-xs font-bold text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground" title={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")} aria-label={isZhLocale($locale) ? "English" : ($t("Common.chinese") || "中文")}>
         {isZhLocale($locale) ? "EN" : "中"}
       </button>
     </div>
 
-    <div class="flex items-center gap-2 px-2.5 py-2 bg-secondary/30 rounded-lg border border-border/30">
-      <div class="w-7 h-7 shrink-0 rounded-full bg-gradient-to-tr from-brand to-emerald-400 flex items-center justify-center text-white font-bold text-[11px] shadow-inner">
-        SC
-      </div>
-      <div class="flex flex-col flex-1 min-w-0">
-        <span class="text-xs font-semibold truncate text-foreground">Admin User</span>
-        <span class="text-[10px] leading-tight text-muted-foreground truncate opacity-80">admin@supacloud.local</span>
+    <div class="flex items-center gap-2 rounded-lg border border-border/30 bg-secondary/30 px-2.5 py-2">
+      <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-tr from-brand to-emerald-400 text-[11px] font-bold text-white shadow-inner">SC</div>
+      <div class="flex min-w-0 flex-1 flex-col">
+        <span class="truncate text-xs font-semibold text-foreground">Admin User</span>
+        <span class="truncate text-[10px] leading-tight text-muted-foreground opacity-80">admin@supacloud.local</span>
       </div>
     </div>
   </div>

--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -30,15 +30,18 @@
     "storage": "Storage",
     "edge_functions": "Edge Functions",
     "database": "Database",
-    "cache": "Project Cache",
+    "database_objects": "Objects & Operations",
+    "cache": "Cache",
     "api_docs": "API Docs",
+    "connect_api": "Connect / API",
     "query_performance": "Query Performance",
     "database_linter": "Database Linter",
     "diagnostics": "Project Diagnostics",
     "logs": "Logs",
-    "settings": "Settings",
-    "reports": "Reports & Analytics",
-    "tasks": "Tasks"
+    "settings": "Project Settings",
+    "reports": "Monitoring & Diagnostics",
+    "realtime_inspector": "Realtime Inspector",
+    "tasks": "Task Center"
   },
   "Project": {
     "home": "Home",
@@ -473,7 +476,9 @@
     "storage_juicefs": "Storage (JuiceFS)",
     "operations_console": "Operations Console",
     "diagnostics": "Diagnostics Center",
-    "settings": "AI Service Settings",
+    "settings": "Platform Settings",
+    "performance_runtime": "Performance & Runtime",
+    "operations": "Operations & Diagnostics",
     "subtitle": "Global control panel for database infrastructure and SupaCloud services."
   },
   "Cache": {
@@ -534,9 +539,27 @@
   "Sidebar": {
     "platform_admin": "Platform Admin",
     "infrastructure": "Infrastructure",
+    "build": "Build",
+    "observe": "Observe",
+    "configure": "Configure",
+    "open_navigation": "Open navigation",
+    "close_navigation": "Close navigation",
     "back_to_projects": "Back to Projects",
     "return_to_projects": "Back to Projects",
     "database_advisor": "Database Advisor"
+  },
+  "DatabaseNav": {
+    "build": "Development Objects",
+    "access": "Access & Security",
+    "data_flow": "Performance & Data Flow",
+    "operations": "Operations"
+  },
+  "AuthNav": {
+    "users": "Users",
+    "sign_in": "Sign-in Methods",
+    "security": "Security",
+    "messaging": "Email & Links",
+    "advanced": "Advanced"
   },
   "Reports": {
     "title": "Reports & Analytics",

--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -559,7 +559,23 @@
     "sign_in": "Sign-in Methods",
     "security": "Security",
     "messaging": "Email & Links",
-    "advanced": "Advanced"
+    "advanced": "Advanced",
+    "tabs": {
+      "users": "Users",
+      "providers": "Providers",
+      "custom_oauth": "Custom OAuth",
+      "passkeys": "Passkeys",
+      "oauth_server": "OAuth Server",
+      "rls_policies": "RLS Policies",
+      "sessions": "Sessions",
+      "mfa": "MFA",
+      "rate_limits": "Rate Limits",
+      "protection": "Security Protection",
+      "url_configuration": "URL Configuration",
+      "email_templates": "Email Templates",
+      "smtp": "SMTP",
+      "hooks": "Hooks"
+    }
   },
   "Reports": {
     "title": "Reports & Analytics",

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -559,7 +559,23 @@
     "sign_in": "登录方式",
     "security": "安全",
     "messaging": "邮件与链接",
-    "advanced": "高级"
+    "advanced": "高级",
+    "tabs": {
+      "users": "用户",
+      "providers": "提供者",
+      "custom_oauth": "自定义 OAuth",
+      "passkeys": "通行密钥",
+      "oauth_server": "OAuth 服务器",
+      "rls_policies": "RLS 策略",
+      "sessions": "会话",
+      "mfa": "多因素认证",
+      "rate_limits": "限频",
+      "protection": "安全防护",
+      "url_configuration": "URL 配置",
+      "email_templates": "邮件模板",
+      "smtp": "SMTP",
+      "hooks": "Hooks"
+    }
   },
   "Reports": {
     "title": "报表与分析",

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -30,15 +30,18 @@
     "storage": "存储",
     "edge_functions": "边缘函数",
     "database": "数据库",
-    "cache": "项目缓存",
+    "database_objects": "对象与运维",
+    "cache": "缓存",
     "api_docs": "API 文档",
+    "connect_api": "连接 / API",
     "query_performance": "慢查询看板",
     "database_linter": "表结构体检",
     "diagnostics": "项目自检",
     "logs": "日志",
     "settings": "项目设置",
-    "reports": "各类监控报表",
-    "tasks": "后台任务"
+    "reports": "监控与诊断",
+    "realtime_inspector": "Realtime 调试器",
+    "tasks": "任务中心"
   },
   "Project": {
     "home": "首页",
@@ -473,7 +476,9 @@
     "storage_juicefs": "存储 (JuiceFS)",
     "operations_console": "运维控制",
     "diagnostics": "自检中心",
-    "settings": "AI 服务配置",
+    "settings": "平台设置",
+    "performance_runtime": "性能与运行时",
+    "operations": "运维与诊断",
     "subtitle": "数据库基础设施与 SupaCloud 服务的全局控制台"
   },
   "Cache": {
@@ -534,9 +539,27 @@
   "Sidebar": {
     "platform_admin": "平台管理",
     "infrastructure": "基础设施",
+    "build": "构建",
+    "observe": "观测",
+    "configure": "配置",
+    "open_navigation": "打开导航",
+    "close_navigation": "关闭导航",
     "back_to_projects": "返回项目列表",
     "return_to_projects": "返回项目列表",
     "database_advisor": "数据库顾问"
+  },
+  "DatabaseNav": {
+    "build": "开发对象",
+    "access": "访问与安全",
+    "data_flow": "性能与数据流",
+    "operations": "运维"
+  },
+  "AuthNav": {
+    "users": "用户",
+    "sign_in": "登录方式",
+    "security": "安全",
+    "messaging": "邮件与链接",
+    "advanced": "高级"
   },
   "Reports": {
     "title": "报表与分析",

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 
   import "../app.css";
   import "$lib/i18n";
-  import { onMount, type Snippet, untrack } from "svelte";
+  import { onMount, tick, type Snippet, untrack } from "svelte";
   import { goto } from "$app/navigation";
   import { resolve } from "$app/paths";
   import { page } from "$app/stores";
@@ -37,7 +37,7 @@
   import { createSvelteKitRouterProvider } from "@svadmin/sveltekit";
   import { Toast as SvadminToast, DevTools, setComponentRegistry, ChatDialog } from "@svadmin/ui";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
-  import { Menu, Plug } from "lucide-svelte";
+  import { Menu, Plug, X } from "lucide-svelte";
   import { dataProvider, chatProvider } from "$lib/admin/provider";
   import { authProvider } from "$lib/admin/auth";
   import { buildResourceRegistry } from "$lib/admin/resources";
@@ -71,6 +71,9 @@
   let isAuthenticated = $state(false);
   let i18nLoadGuardExpired = $state(false);
   let mobileNavOpen = $state(false);
+  let mobileNavTrigger = $state<HTMLButtonElement>();
+  let mobileNavCloseButton = $state<HTMLButtonElement>();
+  let mobileNavDialog = $state<HTMLDivElement>();
   
   let isCoreLoading = $derived(projectsLoading || ($isLoading && !i18nLoadGuardExpired));
 
@@ -131,15 +134,53 @@
     }
   }
 
-  function handleMobileNavigation(event: MouseEvent) {
-    if ((event.target as HTMLElement).closest("a")) {
-      mobileNavOpen = false;
+  async function openMobileNavigation() {
+    mobileNavOpen = true;
+    await tick();
+    mobileNavCloseButton?.focus();
+  }
+
+  function closeMobileNavigation(restoreFocus = true) {
+    mobileNavOpen = false;
+    if (restoreFocus) {
+      void tick().then(() => mobileNavTrigger?.focus());
     }
   }
 
   function handleNavigationKeydown(event: KeyboardEvent) {
-    if (event.key === "Escape") mobileNavOpen = false;
+    if (!mobileNavOpen) return;
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeMobileNavigation();
+      return;
+    }
+
+    if (event.key !== "Tab" || !mobileNavDialog) return;
+
+    const focusable = Array.from(
+      mobileNavDialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((element) => !element.hasAttribute("hidden"));
+    if (!focusable.length) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && (active === first || !mobileNavDialog.contains(active))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
   }
+
+  $effect(() => {
+    $page.url.pathname;
+    mobileNavOpen = false;
+  });
 
   $effect(() => {
     const projectRefs = projects
@@ -274,9 +315,26 @@
             type="button"
             class="absolute inset-0 bg-black/50 backdrop-blur-sm"
             aria-label={$t("Sidebar.close_navigation") || "Close navigation"}
-            onclick={() => (mobileNavOpen = false)}
+            onclick={() => closeMobileNavigation()}
           ></button>
-          <div id="mobile-navigation" class="relative z-10 w-fit shadow-2xl" onclick={handleMobileNavigation} role="presentation">
+          <div
+            id="mobile-navigation"
+            bind:this={mobileNavDialog}
+            class="relative z-10 w-fit shadow-2xl"
+            role="dialog"
+            aria-modal="true"
+            aria-label={$t("Sidebar.open_navigation") || "Navigation"}
+            tabindex="-1"
+          >
+            <button
+              bind:this={mobileNavCloseButton}
+              type="button"
+              class="absolute right-3 top-3 z-20 flex h-8 w-8 items-center justify-center rounded-lg border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+              aria-label={$t("Sidebar.close_navigation") || "Close navigation"}
+              onclick={() => closeMobileNavigation()}
+            >
+              <X class="h-4 w-4" />
+            </button>
             {#if isPlatformRoute}
               <PlatformSidebar />
             {:else}
@@ -289,12 +347,13 @@
       <main class="flex-1 overflow-y-auto relative bg-muted/30">
         <div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b bg-background px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
           <button
+            bind:this={mobileNavTrigger}
             type="button"
             class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:hidden"
             aria-label={$t("Sidebar.open_navigation") || "Open navigation"}
             aria-controls="mobile-navigation"
             aria-expanded={mobileNavOpen}
-            onclick={() => (mobileNavOpen = true)}
+            onclick={openMobileNavigation}
           >
             <Menu class="h-5 w-5" />
           </button>

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -147,6 +147,12 @@
     }
   }
 
+  function handleMobileNavigation(event: MouseEvent) {
+    if (event.target instanceof Element && event.target.closest("a")) {
+      closeMobileNavigation(false);
+    }
+  }
+
   function handleNavigationKeydown(event: KeyboardEvent) {
     if (!mobileNavOpen) return;
 
@@ -176,11 +182,6 @@
       first.focus();
     }
   }
-
-  $effect(() => {
-    $page.url.pathname;
-    mobileNavOpen = false;
-  });
 
   $effect(() => {
     const projectRefs = projects
@@ -281,8 +282,6 @@
   });
 </script>
 
-<svelte:window onkeydown={handleNavigationKeydown} />
-
 <ModeWatcher defaultMode="light" />
 <!-- Alias Toaster as SonnerToaster in script but use the original name in markup if not aliased -->
 <Toaster richColors position="top-right" />
@@ -321,6 +320,8 @@
             id="mobile-navigation"
             bind:this={mobileNavDialog}
             class="relative z-10 w-fit shadow-2xl"
+            onclick={handleMobileNavigation}
+            onkeydown={handleNavigationKeydown}
             role="dialog"
             aria-modal="true"
             aria-label={$t("Sidebar.open_navigation") || "Navigation"}

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -37,6 +37,7 @@
   import { createSvelteKitRouterProvider } from "@svadmin/sveltekit";
   import { Toast as SvadminToast, DevTools, setComponentRegistry, ChatDialog } from "@svadmin/ui";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
+  import { Menu, Plug } from "lucide-svelte";
   import { dataProvider, chatProvider } from "$lib/admin/provider";
   import { authProvider } from "$lib/admin/auth";
   import { buildResourceRegistry } from "$lib/admin/resources";
@@ -69,6 +70,7 @@
   let projectsLoading = $state(true);
   let isAuthenticated = $state(false);
   let i18nLoadGuardExpired = $state(false);
+  let mobileNavOpen = $state(false);
   
   let isCoreLoading = $derived(projectsLoading || ($isLoading && !i18nLoadGuardExpired));
 
@@ -127,6 +129,16 @@
     } finally {
       window.location.href = "/login";
     }
+  }
+
+  function handleMobileNavigation(event: MouseEvent) {
+    if ((event.target as HTMLElement).closest("a")) {
+      mobileNavOpen = false;
+    }
+  }
+
+  function handleNavigationKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") mobileNavOpen = false;
   }
 
   $effect(() => {
@@ -228,6 +240,8 @@
   });
 </script>
 
+<svelte:window onkeydown={handleNavigationKeydown} />
+
 <ModeWatcher defaultMode="light" />
 <!-- Alias Toaster as SonnerToaster in script but use the original name in markup if not aliased -->
 <Toaster richColors position="top-right" />
@@ -249,13 +263,41 @@
       </div>
     {:else}
       {#if isPlatformRoute}
-        <PlatformSidebar />
+        <PlatformSidebar className="hidden lg:flex" />
       {:else}
-        <Sidebar {projects} {currentProject} />
+        <Sidebar className="hidden lg:flex" {projects} {currentProject} />
+      {/if}
+
+      {#if mobileNavOpen}
+        <div class="fixed inset-0 z-50 lg:hidden">
+          <button
+            type="button"
+            class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            aria-label={$t("Sidebar.close_navigation") || "Close navigation"}
+            onclick={() => (mobileNavOpen = false)}
+          ></button>
+          <div id="mobile-navigation" class="relative z-10 w-fit shadow-2xl" onclick={handleMobileNavigation} role="presentation">
+            {#if isPlatformRoute}
+              <PlatformSidebar />
+            {:else}
+              <Sidebar {projects} {currentProject} />
+            {/if}
+          </div>
+        </div>
       {/if}
       
       <main class="flex-1 overflow-y-auto relative bg-muted/30">
         <div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b bg-background px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
+          <button
+            type="button"
+            class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:hidden"
+            aria-label={$t("Sidebar.open_navigation") || "Open navigation"}
+            aria-controls="mobile-navigation"
+            aria-expanded={mobileNavOpen}
+            onclick={() => (mobileNavOpen = true)}
+          >
+            <Menu class="h-5 w-5" />
+          </button>
           <div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
             <div class="flex items-center gap-2 text-sm text-muted-foreground">
               <span class="hover:text-foreground cursor-pointer transition-colors">{$t("Dashboard.org_default") || "Default Organization"}</span>
@@ -263,6 +305,15 @@
               <span class="text-foreground font-medium">{isPlatformRoute ? ($t("Sidebar.platform_admin") || "Platform Admin") : (currentProject?.name || ($t("Project.home") || "Home"))}</span>
             </div>
           </div>
+          {#if !isPlatformRoute && currentProject?.ref}
+            <a
+              href={`/project/${currentProject.ref}/api`}
+              class="inline-flex h-9 items-center gap-2 rounded-lg border bg-background px-3 text-xs font-semibold text-foreground transition-colors hover:border-brand/40 hover:bg-brand/5 hover:text-brand"
+            >
+              <Plug class="h-4 w-4" />
+              <span class="hidden sm:inline">{$t("Navigation.connect_api")}</span>
+            </a>
+          {/if}
           <button
             onclick={handleLogout}
             class="px-3 py-1.5 text-xs font-medium rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"

--- a/packages/web-console/src/routes/navigation.test.ts
+++ b/packages/web-console/src/routes/navigation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const read = (relativePath: string) => readFileSync(new URL(relativePath, import.meta.url), "utf8");
 
@@ -30,7 +30,7 @@ describe("console navigation information architecture", () => {
     expect(rootLayoutSource).toContain('role="dialog"');
     expect(rootLayoutSource).toContain("mobileNavCloseButton?.focus()");
     expect(rootLayoutSource).toContain('event.key !== "Tab"');
-    expect(rootLayoutSource).toContain("$page.url.pathname;");
+    expect(rootLayoutSource).toContain("handleMobileNavigation");
   });
 
   test("uses one grouped platform navigation instead of duplicate top tabs", () => {
@@ -53,7 +53,38 @@ describe("console navigation information architecture", () => {
     expect(authLayoutSource).toContain('name="auth-navigation"');
     expect(databaseLayoutSource).toContain("closeMenusOnOutsideClick");
     expect(authLayoutSource).toContain("closeMenusOnOutsideClick");
+    expect(databaseLayoutSource).toContain("closeMenuFromLink");
+    expect(authLayoutSource).toContain("closeMenuFromLink");
     expect(authLayoutSource).toContain("AuthNav.tabs.providers");
     expect(authLayoutSource).not.toContain('name: "提供者"');
+  });
+
+  test("keeps every grouped database navigation target reachable", () => {
+    const routeIds = [
+      "schemas",
+      "types",
+      "functions",
+      "triggers",
+      "materialized-views",
+      "roles",
+      "column-privileges",
+      "rls-tester",
+      "temporary-access",
+      "indexes",
+      "extensions",
+      "publications",
+      "hooks",
+      "pipelines",
+      "wrappers",
+      "cron",
+      "migrations",
+      "backups",
+      "upgrade",
+      "settings",
+    ];
+
+    for (const routeId of routeIds) {
+      expect(existsSync(new URL(`./project/[ref]/database/${routeId}/+page.svelte`, import.meta.url))).toBe(true);
+    }
   });
 });

--- a/packages/web-console/src/routes/navigation.test.ts
+++ b/packages/web-console/src/routes/navigation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const read = (relativePath: string) => readFileSync(new URL(relativePath, import.meta.url), "utf8");
+
+const rootLayoutSource = read("./+layout.svelte");
+const sidebarSource = read("../lib/components/Sidebar.svelte");
+const platformSidebarSource = read("../lib/components/PlatformSidebar.svelte");
+const platformLayoutSource = read("./platform/+layout.svelte");
+const databaseLayoutSource = read("./project/[ref]/database/+layout.svelte");
+const authLayoutSource = read("./project/[ref]/auth/+layout.svelte");
+
+describe("console navigation information architecture", () => {
+  test("groups project data tools and exposes one monitoring entry", () => {
+    expect(sidebarSource).toContain('titleKey: "Navigation.database_objects"');
+    expect(sidebarSource).toContain('titleKey: "Navigation.cache"');
+    expect(sidebarSource).toContain('titleKey: "Navigation.reports"');
+    expect(sidebarSource).toContain('href: `/project/${projectRef}/reports`');
+    expect(sidebarSource).not.toContain("reports/query-performance");
+    expect(sidebarSource).not.toContain("reports/database-linter");
+    expect(sidebarSource).not.toContain("reports/diagnostics");
+    expect(sidebarSource).not.toContain("reports/advisors");
+  });
+
+  test("keeps API connection and mobile navigation in the global project header", () => {
+    expect(rootLayoutSource).toContain('Navigation.connect_api');
+    expect(rootLayoutSource).toContain('id="mobile-navigation"');
+    expect(rootLayoutSource).toContain('className="hidden lg:flex"');
+    expect(rootLayoutSource).toContain('aria-controls="mobile-navigation"');
+  });
+
+  test("uses one grouped platform navigation instead of duplicate top tabs", () => {
+    expect(platformSidebarSource).toContain("Platform.performance_runtime");
+    expect(platformSidebarSource).toContain("Platform.operations");
+    expect(platformSidebarSource).toContain('href="/platform/settings"');
+    expect(platformLayoutSource).not.toContain("const TABS");
+    expect(platformLayoutSource).not.toContain("/platform/${tab.id}");
+  });
+
+  test("groups dense database and auth secondary navigation", () => {
+    expect(databaseLayoutSource).toContain("DatabaseNav.build");
+    expect(databaseLayoutSource).toContain("DatabaseNav.access");
+    expect(databaseLayoutSource).toContain("DatabaseNav.data_flow");
+    expect(databaseLayoutSource).toContain("DatabaseNav.operations");
+    expect(authLayoutSource).toContain("AuthNav.sign_in");
+    expect(authLayoutSource).toContain("AuthNav.security");
+    expect(authLayoutSource).toContain("AuthNav.messaging");
+  });
+});

--- a/packages/web-console/src/routes/navigation.test.ts
+++ b/packages/web-console/src/routes/navigation.test.ts
@@ -27,6 +27,10 @@ describe("console navigation information architecture", () => {
     expect(rootLayoutSource).toContain('id="mobile-navigation"');
     expect(rootLayoutSource).toContain('className="hidden lg:flex"');
     expect(rootLayoutSource).toContain('aria-controls="mobile-navigation"');
+    expect(rootLayoutSource).toContain('role="dialog"');
+    expect(rootLayoutSource).toContain("mobileNavCloseButton?.focus()");
+    expect(rootLayoutSource).toContain('event.key !== "Tab"');
+    expect(rootLayoutSource).toContain("$page.url.pathname;");
   });
 
   test("uses one grouped platform navigation instead of duplicate top tabs", () => {
@@ -45,5 +49,11 @@ describe("console navigation information architecture", () => {
     expect(authLayoutSource).toContain("AuthNav.sign_in");
     expect(authLayoutSource).toContain("AuthNav.security");
     expect(authLayoutSource).toContain("AuthNav.messaging");
+    expect(databaseLayoutSource).toContain('name="database-navigation"');
+    expect(authLayoutSource).toContain('name="auth-navigation"');
+    expect(databaseLayoutSource).toContain("closeMenusOnOutsideClick");
+    expect(authLayoutSource).toContain("closeMenusOnOutsideClick");
+    expect(authLayoutSource).toContain("AuthNav.tabs.providers");
+    expect(authLayoutSource).not.toContain('name: "提供者"');
   });
 });

--- a/packages/web-console/src/routes/platform/+layout.svelte
+++ b/packages/web-console/src/routes/platform/+layout.svelte
@@ -1,54 +1,20 @@
 <script lang="ts">
-  import { page } from "$app/state";
-  import { Package, HardDrive, Activity, SlidersHorizontal, BarChart3, Database, Wrench, Settings, ShieldCheck, MemoryStick } from "lucide-svelte";
   import { t } from "svelte-i18n";
 
   let { children } = $props();
-
-  const TABS = $derived([
-    { id: "extensions", labelKey: "Platform.extensions_market", icon: Package },
-    { id: "backups", labelKey: "Platform.backups_pitr", icon: HardDrive },
-    { id: "tuning", labelKey: "Platform.engine_tuning", icon: SlidersHorizontal },
-    { id: "monitoring", labelKey: "Platform.monitoring", icon: BarChart3 },
-    { id: "pooling", labelKey: "Platform.connection_pool", icon: Activity },
-    { id: "cache", labelKey: "Platform.cache_runtime", icon: MemoryStick },
-    { id: "storage", labelKey: "Platform.storage_juicefs", icon: Database },
-    { id: "operations", labelKey: "Platform.operations_console", icon: Wrench },
-    { id: "diagnostics", labelKey: "Platform.diagnostics", icon: ShieldCheck },
-    { id: "settings", labelKey: "Platform.settings", icon: Settings },
-  ]);
-
-  const currentTab = $derived(page.url.pathname.split("/platform/")[1]?.split("/")[0] || "");
 </script>
 
-<div class="h-full flex flex-col pt-4">
-  <div class="px-6 mb-6">
-    <div class="flex items-center justify-between mb-4">
+<div class="flex h-full flex-col pt-4">
+  <div class="mb-6 px-6">
+    <div class="flex items-center justify-between gap-4">
       <div>
         <h1 class="text-2xl font-bold">{$t("Platform.title")}</h1>
-        <p class="text-sm text-muted-foreground mt-1">{$t("Platform.subtitle", { default: "Global control panel for Pigsty infrastructure." })}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{$t("Platform.subtitle", { default: "Global control panel for Pigsty infrastructure." })}</p>
       </div>
-      <span class="px-2 py-1 text-[10px] font-bold rounded-full bg-amber-500/10 text-amber-600 border border-amber-500/20">SYSTEM</span>
-    </div>
-    <div class="flex items-center gap-2 overflow-x-auto pb-2 scrollbar-hide">
-      {#each TABS as tab}
-        {@const Icon = tab.icon}
-        <a
-          href={`/platform/${tab.id}`}
-          class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-full whitespace-nowrap transition-colors {currentTab === tab.id ? 'bg-brand text-white shadow-md' : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'}"
-        >
-          <Icon size={14} />
-          {$t(tab.labelKey)}
-        </a>
-      {/each}
+      <span class="rounded-full border border-amber-500/20 bg-amber-500/10 px-2 py-1 text-[10px] font-bold text-amber-600">SYSTEM</span>
     </div>
   </div>
   <div class="flex-1 overflow-y-auto px-6 pb-6">
     {@render children()}
   </div>
 </div>
-
-<style>
-  .scrollbar-hide::-webkit-scrollbar { display: none; }
-  .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
-</style>

--- a/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
@@ -30,40 +30,40 @@
     {
       labelKey: "AuthNav.users",
       tabs: [
-        { name: "用户", path: "", route: "/project/[ref]/auth", icon: Users },
+        { labelKey: "AuthNav.tabs.users", path: "", route: "/project/[ref]/auth", icon: Users },
       ],
     },
     {
       labelKey: "AuthNav.sign_in",
       tabs: [
-        { name: "提供者", path: "providers", route: "/project/[ref]/auth/providers", icon: KeyRound },
-        { name: "Custom OAuth", path: "custom-providers", route: "/project/[ref]/auth/custom-providers", icon: KeyRound },
-        { name: "Passkeys", path: "passkeys", route: "/project/[ref]/auth/passkeys", icon: Fingerprint },
-        { name: "OAuth Server", path: "oauth-server", route: "/project/[ref]/auth/oauth-server", icon: BadgeCheck },
+        { labelKey: "AuthNav.tabs.providers", path: "providers", route: "/project/[ref]/auth/providers", icon: KeyRound },
+        { labelKey: "AuthNav.tabs.custom_oauth", path: "custom-providers", route: "/project/[ref]/auth/custom-providers", icon: KeyRound },
+        { labelKey: "AuthNav.tabs.passkeys", path: "passkeys", route: "/project/[ref]/auth/passkeys", icon: Fingerprint },
+        { labelKey: "AuthNav.tabs.oauth_server", path: "oauth-server", route: "/project/[ref]/auth/oauth-server", icon: BadgeCheck },
       ],
     },
     {
       labelKey: "AuthNav.security",
       tabs: [
-        { name: "RLS 策略", path: "policies", route: "/project/[ref]/auth/policies", icon: Shield },
-        { name: "会话", path: "sessions", route: "/project/[ref]/auth/sessions", icon: Clock },
-        { name: "MFA", path: "mfa", route: "/project/[ref]/auth/mfa", icon: Shield },
-        { name: "限频", path: "rate-limits", route: "/project/[ref]/auth/rate-limits", icon: Shield },
-        { name: "安全防护", path: "protection", route: "/project/[ref]/auth/protection", icon: Shield },
+        { labelKey: "AuthNav.tabs.rls_policies", path: "policies", route: "/project/[ref]/auth/policies", icon: Shield },
+        { labelKey: "AuthNav.tabs.sessions", path: "sessions", route: "/project/[ref]/auth/sessions", icon: Clock },
+        { labelKey: "AuthNav.tabs.mfa", path: "mfa", route: "/project/[ref]/auth/mfa", icon: Shield },
+        { labelKey: "AuthNav.tabs.rate_limits", path: "rate-limits", route: "/project/[ref]/auth/rate-limits", icon: Shield },
+        { labelKey: "AuthNav.tabs.protection", path: "protection", route: "/project/[ref]/auth/protection", icon: Shield },
       ],
     },
     {
       labelKey: "AuthNav.messaging",
       tabs: [
-        { name: "URL 配置", path: "url-configuration", route: "/project/[ref]/auth/url-configuration", icon: Link2 },
-        { name: "邮件模板", path: "templates", route: "/project/[ref]/auth/templates", icon: Mail },
-        { name: "SMTP", path: "smtp", route: "/project/[ref]/auth/smtp", icon: Mail },
+        { labelKey: "AuthNav.tabs.url_configuration", path: "url-configuration", route: "/project/[ref]/auth/url-configuration", icon: Link2 },
+        { labelKey: "AuthNav.tabs.email_templates", path: "templates", route: "/project/[ref]/auth/templates", icon: Mail },
+        { labelKey: "AuthNav.tabs.smtp", path: "smtp", route: "/project/[ref]/auth/smtp", icon: Mail },
       ],
     },
     {
       labelKey: "AuthNav.advanced",
       tabs: [
-        { name: "Hooks", path: "hooks", route: "/project/[ref]/auth/hooks", icon: Webhook },
+        { labelKey: "AuthNav.tabs.hooks", path: "hooks", route: "/project/[ref]/auth/hooks", icon: Webhook },
       ],
     },
   ] as const;
@@ -81,6 +81,7 @@
   const ownerManagedPage = $derived(
     authRuntime?.mode === "shared" && !currentPath.endsWith("/policies"),
   );
+  let menuBar = $state<HTMLDivElement>();
 
   onMount(() => {
     let cancelled = false;
@@ -114,15 +115,33 @@
     return tabs.some((tab) => isActive(tab.path));
   }
 
+  function closeMenusOnOutsideClick(event: MouseEvent) {
+    if (!(event.target instanceof Node)) return;
+    for (const details of menuBar?.querySelectorAll<HTMLDetailsElement>("details[open]") ?? []) {
+      if (!details.contains(event.target)) details.open = false;
+    }
+  }
+
+  function handleMenuKeydown(event: KeyboardEvent) {
+    if (event.key !== "Escape" || !(event.currentTarget instanceof HTMLElement)) return;
+    const details = event.currentTarget.closest("details");
+    if (!(details instanceof HTMLDetailsElement)) return;
+    event.preventDefault();
+    details.open = false;
+    event.currentTarget.focus();
+  }
+
   let { children } = $props();
 </script>
 
+<svelte:window onclick={closeMenusOnOutsideClick} />
+
 <div class="h-full flex flex-col space-y-4">
   <!-- 按用户任务分组，避免十多个认证入口在窄屏横向溢出。 -->
-  <div class="flex flex-wrap items-center gap-2 border-b border-border/30 px-1 pb-3">
+  <div bind:this={menuBar} class="flex flex-wrap items-center gap-2 border-b border-border/30 px-1 pb-3">
     {#each visibleGroups as group (group.labelKey)}
-      <details class="group/details relative">
-        <summary class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors [&::-webkit-details-marker]:hidden {groupIsActive(group.tabs) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
+      <details name="auth-navigation" class="group/details relative">
+        <summary onkeydown={handleMenuKeydown} class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors [&::-webkit-details-marker]:hidden {groupIsActive(group.tabs) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
           {$t(group.labelKey)}
           <ChevronDown class="h-3.5 w-3.5 transition-transform group-open/details:rotate-180" />
         </summary>
@@ -131,7 +150,7 @@
             {@const Icon = tab.icon}
             <a href={resolve(tab.route, { ref: projectRef })} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {isActive(tab.path) ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
               <Icon class="h-4 w-4" />
-              {tab.name}
+              {$t(tab.labelKey)}
             </a>
           {/each}
         </div>

--- a/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
@@ -131,6 +131,12 @@
     event.currentTarget.focus();
   }
 
+  function closeMenuFromLink(event: MouseEvent) {
+    if (!(event.currentTarget instanceof HTMLElement)) return;
+    const details = event.currentTarget.closest("details");
+    if (details instanceof HTMLDetailsElement) details.open = false;
+  }
+
   let { children } = $props();
 </script>
 
@@ -148,7 +154,7 @@
         <div class="absolute left-0 z-30 mt-2 w-56 overflow-hidden rounded-xl border bg-popover p-1.5 text-popover-foreground shadow-xl">
           {#each group.tabs as tab (tab.path)}
             {@const Icon = tab.icon}
-            <a href={resolve(tab.route, { ref: projectRef })} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {isActive(tab.path) ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
+            <a href={resolve(tab.route, { ref: projectRef })} onclick={closeMenuFromLink} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {isActive(tab.path) ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
               <Icon class="h-4 w-4" />
               {$t(tab.labelKey)}
             </a>

--- a/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
@@ -3,7 +3,8 @@
   import { resolve } from "$app/paths";
   import { page } from "$app/state";
   import { apiClient } from "$lib/api";
-  import { Users, Shield, KeyRound, Link2, Mail, Clock, Webhook, BadgeCheck, Fingerprint } from "lucide-svelte";
+  import { t } from "svelte-i18n";
+  import { Users, Shield, KeyRound, Link2, Mail, Clock, Webhook, BadgeCheck, ChevronDown, Fingerprint } from "lucide-svelte";
 
   type AuthRuntimeDescriptor = {
     project_ref: string;
@@ -25,27 +26,57 @@
   let authRuntimeError = $state<string | null>(null);
   let authRuntimeLoading = $state(true);
 
-  const AUTH_TABS = [
-    { name: "用户", path: "", route: "/project/[ref]/auth", icon: Users },
-    { name: "提供者", path: "providers", route: "/project/[ref]/auth/providers", icon: KeyRound },
-    { name: "Custom OAuth", path: "custom-providers", route: "/project/[ref]/auth/custom-providers", icon: KeyRound },
-    { name: "Passkeys", path: "passkeys", route: "/project/[ref]/auth/passkeys", icon: Fingerprint },
-    { name: "OAuth Server", path: "oauth-server", route: "/project/[ref]/auth/oauth-server", icon: BadgeCheck },
-    { name: "RLS 策略", path: "policies", route: "/project/[ref]/auth/policies", icon: Shield },
-    { name: "URL 配置", path: "url-configuration", route: "/project/[ref]/auth/url-configuration", icon: Link2 },
-    { name: "邮件模板", path: "templates", route: "/project/[ref]/auth/templates", icon: Mail },
-    { name: "SMTP", path: "smtp", route: "/project/[ref]/auth/smtp", icon: Mail },
-    { name: "Hooks", path: "hooks", route: "/project/[ref]/auth/hooks", icon: Webhook },
-    { name: "会话", path: "sessions", route: "/project/[ref]/auth/sessions", icon: Clock },
-    { name: "MFA", path: "mfa", route: "/project/[ref]/auth/mfa", icon: Shield },
-    { name: "限频", path: "rate-limits", route: "/project/[ref]/auth/rate-limits", icon: Shield },
-    { name: "安全防护", path: "protection", route: "/project/[ref]/auth/protection", icon: Shield },
+  const AUTH_GROUPS = [
+    {
+      labelKey: "AuthNav.users",
+      tabs: [
+        { name: "用户", path: "", route: "/project/[ref]/auth", icon: Users },
+      ],
+    },
+    {
+      labelKey: "AuthNav.sign_in",
+      tabs: [
+        { name: "提供者", path: "providers", route: "/project/[ref]/auth/providers", icon: KeyRound },
+        { name: "Custom OAuth", path: "custom-providers", route: "/project/[ref]/auth/custom-providers", icon: KeyRound },
+        { name: "Passkeys", path: "passkeys", route: "/project/[ref]/auth/passkeys", icon: Fingerprint },
+        { name: "OAuth Server", path: "oauth-server", route: "/project/[ref]/auth/oauth-server", icon: BadgeCheck },
+      ],
+    },
+    {
+      labelKey: "AuthNav.security",
+      tabs: [
+        { name: "RLS 策略", path: "policies", route: "/project/[ref]/auth/policies", icon: Shield },
+        { name: "会话", path: "sessions", route: "/project/[ref]/auth/sessions", icon: Clock },
+        { name: "MFA", path: "mfa", route: "/project/[ref]/auth/mfa", icon: Shield },
+        { name: "限频", path: "rate-limits", route: "/project/[ref]/auth/rate-limits", icon: Shield },
+        { name: "安全防护", path: "protection", route: "/project/[ref]/auth/protection", icon: Shield },
+      ],
+    },
+    {
+      labelKey: "AuthNav.messaging",
+      tabs: [
+        { name: "URL 配置", path: "url-configuration", route: "/project/[ref]/auth/url-configuration", icon: Link2 },
+        { name: "邮件模板", path: "templates", route: "/project/[ref]/auth/templates", icon: Mail },
+        { name: "SMTP", path: "smtp", route: "/project/[ref]/auth/smtp", icon: Mail },
+      ],
+    },
+    {
+      labelKey: "AuthNav.advanced",
+      tabs: [
+        { name: "Hooks", path: "hooks", route: "/project/[ref]/auth/hooks", icon: Webhook },
+      ],
+    },
   ] as const;
 
-  const visibleTabs = $derived(
-    authRuntime?.mode === "local" || authRuntime?.mode === "owner"
-      ? AUTH_TABS
-      : AUTH_TABS.filter((tab) => tab.path === "policies"),
+  const visibleGroups = $derived(
+    AUTH_GROUPS
+      .map((group) => ({
+        ...group,
+        tabs: group.tabs.filter((tab) =>
+          authRuntime?.mode === "local" || authRuntime?.mode === "owner" || tab.path === "policies"
+        ),
+      }))
+      .filter((group) => group.tabs.length > 0),
   );
   const ownerManagedPage = $derived(
     authRuntime?.mode === "shared" && !currentPath.endsWith("/policies"),
@@ -79,20 +110,32 @@
     return currentPath === `${base}/${tabPath}`;
   }
 
+  function groupIsActive(tabs: readonly { path: string }[]) {
+    return tabs.some((tab) => isActive(tab.path));
+  }
+
   let { children } = $props();
 </script>
 
 <div class="h-full flex flex-col space-y-4">
-  <!-- Auth Tab Navigation -->
-  <div class="flex items-center gap-1 px-1 overflow-x-auto border-b border-border/30 pb-0">
-    {#each visibleTabs as tab (tab.path)}
-      <a
-        href={resolve(tab.route, { ref: projectRef })}
-        class="flex items-center gap-1.5 px-3 py-2 text-xs font-medium border-b-2 transition-colors whitespace-nowrap {isActive(tab.path) ? 'border-brand text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}"
-      >
-        <tab.icon size={12} />
-        {tab.name}
-      </a>
+  <!-- 按用户任务分组，避免十多个认证入口在窄屏横向溢出。 -->
+  <div class="flex flex-wrap items-center gap-2 border-b border-border/30 px-1 pb-3">
+    {#each visibleGroups as group (group.labelKey)}
+      <details class="group/details relative">
+        <summary class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors [&::-webkit-details-marker]:hidden {groupIsActive(group.tabs) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
+          {$t(group.labelKey)}
+          <ChevronDown class="h-3.5 w-3.5 transition-transform group-open/details:rotate-180" />
+        </summary>
+        <div class="absolute left-0 z-30 mt-2 w-56 overflow-hidden rounded-xl border bg-popover p-1.5 text-popover-foreground shadow-xl">
+          {#each group.tabs as tab (tab.path)}
+            {@const Icon = tab.icon}
+            <a href={resolve(tab.route, { ref: projectRef })} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {isActive(tab.path) ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
+              <Icon class="h-4 w-4" />
+              {tab.name}
+            </a>
+          {/each}
+        </div>
+      </details>
     {/each}
   </div>
 

--- a/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
@@ -107,6 +107,12 @@
     details.open = false;
     event.currentTarget.focus();
   }
+
+  function closeMenuFromLink(event: MouseEvent) {
+    if (!(event.currentTarget instanceof HTMLElement)) return;
+    const details = event.currentTarget.closest("details");
+    if (details instanceof HTMLDetailsElement) details.open = false;
+  }
 </script>
 
 <svelte:window onclick={closeMenusOnOutsideClick} />
@@ -134,7 +140,7 @@
           <div class="absolute left-0 z-30 mt-2 w-64 overflow-hidden rounded-xl border bg-popover p-1.5 text-popover-foreground shadow-xl">
             {#each group.items as tab (tab.id)}
               {@const Icon = tab.icon}
-              <a href={`/project/${projectRef}/database/${tab.id}`} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {currentTab === tab.id ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
+              <a href={`/project/${projectRef}/database/${tab.id}`} onclick={closeMenuFromLink} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {currentTab === tab.id ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
                 <Icon class="h-4 w-4" />
                 {tab.labelKey ? $t(tab.labelKey) : tab.labelFallback}
               </a>

--- a/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
@@ -1,53 +1,127 @@
 <script lang="ts">
   import { page } from "$app/state";
   import { t } from "svelte-i18n";
-  import { Users, Package, Zap, Braces, Hash, FolderOpen, CalendarClock, Radio, Webhook, GitCommitVertical, Tag, ShieldCheck, HardDrive, Globe, Settings, Layers } from "lucide-svelte";
+  import {
+    ArrowUpCircle,
+    Braces,
+    CalendarClock,
+    ChevronDown,
+    FlaskConical,
+    FolderOpen,
+    GitCommitVertical,
+    Globe,
+    HardDrive,
+    Hash,
+    KeyRound,
+    Layers,
+    Package,
+    Radio,
+    Settings,
+    ShieldCheck,
+    Tag,
+    Users,
+    Webhook,
+    Workflow,
+    Zap,
+  } from "lucide-svelte";
 
   let { children } = $props();
 
   const projectRef = $derived(page.params.ref);
 
-  const TABS = $derived([
-    { id: "roles", labelKey: "Roles.title", icon: Users },
-    { id: "extensions", labelKey: "Extensions.title", icon: Package },
-    { id: "triggers", labelKey: "Triggers.title", icon: Zap },
-    { id: "functions", labelKey: "DbFunctions.title", icon: Braces },
-    { id: "indexes", labelKey: "Indexes.title", icon: Hash },
-    { id: "materialized-views", labelKey: null, labelFallback: "Materialized Views", icon: Layers },
-    { id: "schemas", labelKey: "Schemas.title", icon: FolderOpen },
-    { id: "types", labelKey: "EnumTypes.title", icon: Tag },
-    { id: "column-privileges", labelKey: "ColumnPrivileges.title", icon: ShieldCheck },
-    { id: "publications", labelKey: "Publications.title", icon: Radio },
-    { id: "hooks", labelKey: "Hooks.title", icon: Webhook },
-    { id: "migrations", labelKey: "Migrations.title", icon: GitCommitVertical },
-    { id: "backups", labelKey: "Backups.title", icon: HardDrive },
-    { id: "cron", labelKey: "CronJobs.title", icon: CalendarClock },
-    { id: "wrappers", labelKey: null, labelFallback: "Wrappers", icon: Globe },
-    { id: "settings", labelKey: null, labelFallback: "Settings", icon: Settings },
-  ]);
+  type DatabaseTab = {
+    id: string;
+    labelKey?: string;
+    labelFallback?: string;
+    icon: typeof FolderOpen;
+  };
+
+  type DatabaseTabGroup = {
+    labelKey: string;
+    items: readonly DatabaseTab[];
+  };
+
+  const TAB_GROUPS: readonly DatabaseTabGroup[] = [
+    {
+      labelKey: "DatabaseNav.build",
+      items: [
+        { id: "schemas", labelKey: "Schemas.title", icon: FolderOpen },
+        { id: "types", labelKey: "EnumTypes.title", icon: Tag },
+        { id: "functions", labelKey: "DbFunctions.title", icon: Braces },
+        { id: "triggers", labelKey: "Triggers.title", icon: Zap },
+        { id: "materialized-views", labelFallback: "Materialized Views", icon: Layers },
+      ],
+    },
+    {
+      labelKey: "DatabaseNav.access",
+      items: [
+        { id: "roles", labelKey: "Roles.title", icon: Users },
+        { id: "column-privileges", labelKey: "ColumnPrivileges.title", icon: ShieldCheck },
+        { id: "rls-tester", labelFallback: "RLS Tester", icon: FlaskConical },
+        { id: "temporary-access", labelFallback: "Temporary Access", icon: KeyRound },
+      ],
+    },
+    {
+      labelKey: "DatabaseNav.data_flow",
+      items: [
+        { id: "indexes", labelKey: "Indexes.title", icon: Hash },
+        { id: "extensions", labelKey: "Extensions.title", icon: Package },
+        { id: "publications", labelKey: "Publications.title", icon: Radio },
+        { id: "hooks", labelKey: "Hooks.title", icon: Webhook },
+        { id: "pipelines", labelFallback: "Pipelines", icon: Workflow },
+        { id: "wrappers", labelFallback: "Wrappers", icon: Globe },
+        { id: "cron", labelKey: "CronJobs.title", icon: CalendarClock },
+      ],
+    },
+    {
+      labelKey: "DatabaseNav.operations",
+      items: [
+        { id: "migrations", labelKey: "Migrations.title", icon: GitCommitVertical },
+        { id: "backups", labelKey: "Backups.title", icon: HardDrive },
+        { id: "upgrade", labelFallback: "PostgreSQL Upgrade", icon: ArrowUpCircle },
+        { id: "settings", labelFallback: "Settings", icon: Settings },
+      ],
+    },
+  ];
 
   const currentTab = $derived(page.url.pathname.split("/database/")[1]?.split("/")[0] || "");
+  const activeTab = $derived(TAB_GROUPS.flatMap((group) => group.items).find((tab) => tab.id === currentTab));
+
+  function groupIsActive(items: readonly { id: string }[]) {
+    return items.some((item) => item.id === currentTab);
+  }
 </script>
 
-<div class="h-full flex flex-col pt-4">
-  <div class="px-6 mb-6">
-    <div class="flex items-center gap-2 text-sm text-muted-foreground mb-4">
-      <a href={`/project/${projectRef}/database`} class="hover:text-foreground transition-colors">{$t("Navigation.database")}</a>
-      {#if currentTab}
+<div class="flex h-full flex-col pt-4">
+  <div class="mb-6 px-6">
+    <div class="mb-4 flex items-center gap-2 text-sm text-muted-foreground">
+      <a href={`/project/${projectRef}/database`} class="transition-colors hover:text-foreground">{$t("Navigation.database")}</a>
+      {#if activeTab}
         <span>/</span>
-        {@const activeTab = TABS.find(t => t.id === currentTab)}
-        <span class="text-foreground capitalize">{activeTab?.labelKey ? $t(activeTab.labelKey) : (activeTab?.labelFallback || currentTab)}</span>
+        <span class="text-foreground">{activeTab.labelKey ? $t(activeTab.labelKey) : activeTab.labelFallback}</span>
       {/if}
     </div>
-    <div class="flex flex-wrap items-center gap-2 pb-2">
-      {#each TABS as tab}
-        <a
-          href={`/project/${projectRef}/database/${tab.id}`}
-          class="flex items-center gap-2 px-4 py-2 text-xs font-semibold rounded-full whitespace-nowrap transition-colors {currentTab === tab.id ? 'bg-brand text-white shadow-md' : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'}"
-        >
-          <tab.icon size={14} />
-          {tab.labelKey ? $t(tab.labelKey) : tab.labelFallback}
-        </a>
+
+    <div class="flex flex-wrap items-center gap-2">
+      <a href={`/project/${projectRef}/database`} class="rounded-lg px-3 py-2 text-xs font-semibold transition-colors {currentTab === '' ? 'bg-brand text-white shadow-sm' : 'border bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
+        {$t("Navigation.database_objects")}
+      </a>
+      {#each TAB_GROUPS as group (group.labelKey)}
+        <details class="group/details relative">
+          <summary class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors [&::-webkit-details-marker]:hidden {groupIsActive(group.items) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
+            {$t(group.labelKey)}
+            <ChevronDown class="h-3.5 w-3.5 transition-transform group-open/details:rotate-180" />
+          </summary>
+          <div class="absolute left-0 z-30 mt-2 w-64 overflow-hidden rounded-xl border bg-popover p-1.5 text-popover-foreground shadow-xl">
+            {#each group.items as tab (tab.id)}
+              {@const Icon = tab.icon}
+              <a href={`/project/${projectRef}/database/${tab.id}`} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {currentTab === tab.id ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
+                <Icon class="h-4 w-4" />
+                {tab.labelKey ? $t(tab.labelKey) : tab.labelFallback}
+              </a>
+            {/each}
+          </div>
+        </details>
       {/each}
     </div>
   </div>

--- a/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/database/+layout.svelte
@@ -86,11 +86,30 @@
 
   const currentTab = $derived(page.url.pathname.split("/database/")[1]?.split("/")[0] || "");
   const activeTab = $derived(TAB_GROUPS.flatMap((group) => group.items).find((tab) => tab.id === currentTab));
+  let menuBar = $state<HTMLDivElement>();
 
   function groupIsActive(items: readonly { id: string }[]) {
     return items.some((item) => item.id === currentTab);
   }
+
+  function closeMenusOnOutsideClick(event: MouseEvent) {
+    if (!(event.target instanceof Node)) return;
+    for (const details of menuBar?.querySelectorAll<HTMLDetailsElement>("details[open]") ?? []) {
+      if (!details.contains(event.target)) details.open = false;
+    }
+  }
+
+  function handleMenuKeydown(event: KeyboardEvent) {
+    if (event.key !== "Escape" || !(event.currentTarget instanceof HTMLElement)) return;
+    const details = event.currentTarget.closest("details");
+    if (!(details instanceof HTMLDetailsElement)) return;
+    event.preventDefault();
+    details.open = false;
+    event.currentTarget.focus();
+  }
 </script>
+
+<svelte:window onclick={closeMenusOnOutsideClick} />
 
 <div class="flex h-full flex-col pt-4">
   <div class="mb-6 px-6">
@@ -102,13 +121,13 @@
       {/if}
     </div>
 
-    <div class="flex flex-wrap items-center gap-2">
+    <div bind:this={menuBar} class="flex flex-wrap items-center gap-2">
       <a href={`/project/${projectRef}/database`} class="rounded-lg px-3 py-2 text-xs font-semibold transition-colors {currentTab === '' ? 'bg-brand text-white shadow-sm' : 'border bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
         {$t("Navigation.database_objects")}
       </a>
       {#each TAB_GROUPS as group (group.labelKey)}
-        <details class="group/details relative">
-          <summary class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors [&::-webkit-details-marker]:hidden {groupIsActive(group.items) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
+        <details name="database-navigation" class="group/details relative">
+          <summary onkeydown={handleMenuKeydown} class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors [&::-webkit-details-marker]:hidden {groupIsActive(group.items) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
             {$t(group.labelKey)}
             <ChevronDown class="h-3.5 w-3.5 transition-transform group-open/details:rotate-180" />
           </summary>


### PR DESCRIPTION
## What changed

- reorganize project and platform navigation into clear product groups
- move project cache under Database instead of a top-level menu item
- consolidate monitoring, remove duplicate platform navigation, and add mobile navigation
- group dense Database and Auth secondary navigation
- add navigation information-architecture tests

## Why

The previous flat navigation exposed implementation-level capabilities as equal top-level destinations, making common workflows harder to scan.

## Validation

- `bun run --cwd packages/web-console check`
- `bun test packages/web-console/src/routes/*.test.ts packages/web-console/src/routes/project/'[ref]'/cache/page.test.ts packages/web-console/src/routes/platform/cache/page.test.ts`
- `bun run --cwd packages/web-console build`
