### PR TITLE
fix(gateway): protect project-bound request headers

### DIFF
--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -69,6 +69,13 @@ const UPSTREAM_CORS_RESPONSE_HEADERS = [
     "Access-Control-Max-Age",
 ] as const;
 
+const RESERVED_CUSTOM_PROXY_REQUEST_HEADERS = new Set([
+    "x-project-ref",
+    "x-supabase-project",
+    "x-supacloud-internal-auth",
+    "x-supacloud-internal-token",
+]);
+
 function hostToCorsOrigins(host: string): string[] {
     const trimmed = host.trim();
     if (!trimmed) return [];
@@ -235,6 +242,16 @@ function normalizeCustomHeaders(headers: Record<string, string> | undefined): Re
     return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
+function normalizeCustomProxyHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    const normalized = normalizeCustomHeaders(headers);
+    for (const header of Object.keys(normalized || {})) {
+        if (RESERVED_CUSTOM_PROXY_REQUEST_HEADERS.has(header.toLowerCase())) {
+            throw new Error(`Custom proxy route headers must not override reserved header: ${header}`);
+        }
+    }
+    return normalized;
+}
+
 export function normalizeCustomGatewayRoute(input: CustomGatewayRouteConfig): CustomGatewayRouteConfig {
     const id = String(input.id || "").trim();
     if (!/^[A-Za-z0-9_-]{1,64}$/.test(id)) {
@@ -267,6 +284,9 @@ export function normalizeCustomGatewayRoute(input: CustomGatewayRouteConfig): Cu
     if (hasRedirect && Object.keys(input.headers || {}).some((key) => key.trim().toLowerCase() === "location")) {
         throw new Error("Custom redirect routes must not override the Location header");
     }
+    const headers = hasUpstream
+        ? normalizeCustomProxyHeaders(input.headers)
+        : normalizeCustomHeaders(input.headers);
 
     return {
         id,
@@ -280,7 +300,7 @@ export function normalizeCustomGatewayRoute(input: CustomGatewayRouteConfig): Cu
         redirect_status: normalizeCustomRedirectStatus(input.redirect_status, hasRedirect),
         rewrite_uri: rewriteUri,
         strip_prefix: stripPrefix,
-        headers: normalizeCustomHeaders(input.headers),
+        headers,
         cors: input.cors ? uniqueStrings(input.cors.map((origin) => origin.trim()).filter(Boolean)).slice(0, 50) : undefined,
         priority: Number.isFinite(input.priority) ? Math.trunc(input.priority || 0) : 0,
         enabled: input.enabled ?? true,

--- a/packages/management-api/tests/unit/gateway-custom-routes.api.test.ts
+++ b/packages/management-api/tests/unit/gateway-custom-routes.api.test.ts
@@ -112,6 +112,40 @@ describe("controlled custom gateway routes API", () => {
     }
   });
 
+  test("POST rejects reserved proxy request headers before changing gateway state", async () => {
+    const getSettings = spyOn(projectService, "getProjectSettings").mockResolvedValue({
+      gateway_routes: [],
+    } as any);
+    const updateSettings = spyOn(projectService, "updateProjectSettings").mockResolvedValue({} as any);
+    const configureRoutes = spyOn(gatewayService, "configureCustomGatewayRoutes").mockResolvedValue({ success: true });
+
+    try {
+      const response = await request("/v1/projects/proj123/gateway/routes", {
+        method: "POST",
+        headers: masterHeaders,
+        body: JSON.stringify({
+          id: "unsafe-project-ref",
+          hosts: ["api.example.com"],
+          path: "/*",
+          upstream: "127.0.0.1:8080",
+          headers: { "X-pRoJeCt-ReF": "other-project" },
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        message: "Custom proxy route headers must not override reserved header: X-pRoJeCt-ReF",
+        code: "400",
+      });
+      expect(updateSettings).not.toHaveBeenCalled();
+      expect(configureRoutes).not.toHaveBeenCalled();
+    } finally {
+      getSettings.mockRestore();
+      updateSettings.mockRestore();
+      configureRoutes.mockRestore();
+    }
+  });
+
   test("PUT persists a protocol-scoped redirect route", async () => {
     const getSettings = spyOn(projectService, "getProjectSettings").mockResolvedValue({
       gateway_routes: [
@@ -170,6 +204,41 @@ describe("controlled custom gateway routes API", () => {
           }),
         ],
       });
+    } finally {
+      getSettings.mockRestore();
+      updateSettings.mockRestore();
+      configureRoutes.mockRestore();
+    }
+  });
+
+  test("PUT rejects reserved internal proxy headers before changing gateway state", async () => {
+    const getSettings = spyOn(projectService, "getProjectSettings").mockResolvedValue({
+      gateway_routes: [
+        { id: "proxy", hosts: ["api.example.com"], path: "/*", upstream: "127.0.0.1:8080" },
+      ],
+    } as any);
+    const updateSettings = spyOn(projectService, "updateProjectSettings").mockResolvedValue({} as any);
+    const configureRoutes = spyOn(gatewayService, "configureCustomGatewayRoutes").mockResolvedValue({ success: true });
+
+    try {
+      const response = await request("/v1/projects/proj123/gateway/routes/proxy", {
+        method: "PUT",
+        headers: masterHeaders,
+        body: JSON.stringify({
+          hosts: ["api.example.com"],
+          path: "/*",
+          upstream: "127.0.0.1:8080",
+          headers: { "x-SUPACLOUD-internal-token": "untrusted-token" },
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        message: "Custom proxy route headers must not override reserved header: x-SUPACLOUD-internal-token",
+        code: "400",
+      });
+      expect(updateSettings).not.toHaveBeenCalled();
+      expect(configureRoutes).not.toHaveBeenCalled();
     } finally {
       getSettings.mockRestore();
       updateSettings.mockRestore();

--- a/packages/management-api/tests/unit/gateway-route-builders.test.ts
+++ b/packages/management-api/tests/unit/gateway-route-builders.test.ts
@@ -42,6 +42,62 @@ describe("gateway route builders", () => {
         })).toThrow("control characters");
     });
 
+    test("rejects reserved proxy request headers case-insensitively", () => {
+        for (const header of [
+            "X-Project-Ref",
+            "x-SuPaBaSe-PrOjEcT",
+            "X-SupaCloud-Internal-Auth",
+            "x-SUPACLOUD-internal-token",
+        ]) {
+            expect(() => normalizeCustomGatewayRoute({
+                id: "reserved-header",
+                hosts: ["api.example.com"],
+                path: "/*",
+                upstream: "127.0.0.1:8080",
+                headers: { [header]: "untrusted" },
+            })).toThrow(`must not override reserved header: ${header}`);
+        }
+    });
+
+    test("keeps supported proxy overrides and response headers compatible", () => {
+        const proxy = makeCustomGatewayRoute("project-ref", {
+            id: "virtual-host",
+            hosts: ["api.example.com"],
+            path: "/*",
+            upstream: "127.0.0.1:8080",
+            headers: {
+                Host: "upstream.example.com",
+                "X-Forwarded-Host": "public.example.com",
+                "X-Service": "reports",
+            },
+        }) as any;
+        const proxyHeaders = proxy.handle[0].headers.request.set;
+
+        expect(proxyHeaders.Host).toEqual(["upstream.example.com"]);
+        expect(proxyHeaders["X-Forwarded-Host"]).toEqual(["public.example.com"]);
+        expect(proxyHeaders["X-Service"]).toEqual(["reports"]);
+        expect(proxyHeaders["X-Project-Ref"]).toEqual(["project-ref"]);
+        expect(proxyHeaders["x-project-ref"]).toEqual(["project-ref"]);
+
+        const staticRoute = makeCustomGatewayRoute("project-ref", {
+            id: "static-response-header",
+            hosts: ["static.example.com"],
+            path: "/*",
+            static_root: "/var/www/static",
+            headers: { "X-Project-Ref": "response-value" },
+        }) as any;
+        const redirectRoute = makeCustomGatewayRoute("project-ref", {
+            id: "redirect-response-header",
+            hosts: ["www.example.com"],
+            path: "/*",
+            redirect_to: "https://example.com{http.request.uri}",
+            headers: { "X-SupaCloud-Internal-Auth": "response-value" },
+        }) as any;
+
+        expect(staticRoute.handle[0].response.set["X-Project-Ref"]).toEqual(["response-value"]);
+        expect(redirectRoute.handle[0].headers["X-SupaCloud-Internal-Auth"]).toEqual(["response-value"]);
+    });
+
     test("builds exact and regex CORS matchers with a terminal preflight", () => {
         const subroute = makeCorsSubroute([
             "https://app.example.com",


### PR DESCRIPTION
## Summary

- reject custom proxy headers that override project-bound or internal authentication headers
- match reserved names case-insensitively while preserving Host and X-Forwarded-Host overrides
- keep static and redirect response headers backward compatible

## Why

Custom gateway routes previously merged user-configured request headers after the platform's tenant headers. A route for one project could therefore override X-Project-Ref, x-supabase-project, or internal Edge Runtime authentication headers.

This change fails closed during route normalization and returns HTTP 400 before project settings or Gateway state are changed.

## Compatibility

Existing proxy routes that configure one of the reserved headers must remove that override before they can be reconciled. Static and redirect response headers are unchanged.

## Verification

- `bun test tests/unit/gateway-route-builders.test.ts tests/unit/gateway-custom-routes.api.test.ts tests/unit/gateway.service.test.ts` (74 pass)
- `bun run typecheck`
- `git diff --check`
