### PR TITLE
docs(upgrade): refresh component compatibility notes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@
 
 - [OAuth Providers](./oauth-providers.md) - OAuth provider configuration
 - [OAuth 2.1 / OIDC Provider](./oauth-oidc-provider.md) - Project-scoped OAuth server migration, discovery, JWKS, and OAuth client management
-- [GoTrue v2.193.0 Upgrade](./gotrue-v2.193-upgrade.md) - Checksums, additive migration read-back, opt-in provider linking, MFA acceptance, and rollback boundary
+- [GoTrue v2.191.0 to v2.193.0 Historical Upgrade Baseline](./gotrue-v2.193-upgrade.md) - Historical checksums, additive migration read-back, opt-in provider linking, MFA acceptance, and rollback boundary
 - [China OAuth Integration](./china-oauth-integration.md) - China OAuth (WeChat, Alipay, DingTalk)
 - [WeChat Auth Integration](./wechat-auth-integration.md) - WeChat Mini Program login
 

--- a/docs/gotrue-v2.193-upgrade.md
+++ b/docs/gotrue-v2.193-upgrade.md
@@ -1,6 +1,6 @@
-# GoTrue v2.193.0 Upgrade
+# GoTrue v2.191.0 to v2.193.0 Historical Upgrade Baseline
 
-SupaCloud pins the stock [`supabase/auth` v2.193.0 release](https://github.com/supabase/auth/releases/tag/v2.193.0). The release assets accepted by the installer are:
+This document preserves the historical acceptance baseline for upgrading GoTrue from v2.191.0 through the stock [`supabase/auth` v2.193.0 release](https://github.com/supabase/auth/releases/tag/v2.193.0). SupaCloud no longer uses v2.193.0 as its current pin; see the [platform component upgrade notes](./platform-component-upgrade-notes.md) for the current runtime default. The v2.193.0 release assets accepted by the historical installer were:
 
 | Architecture | Asset SHA256 |
 | --- | --- |
@@ -45,7 +45,7 @@ After rendering the tenant runtime, inspect the generated environment without pr
 
 ## MFA acceptance
 
-Run the compatibility suite against an unmodified v2.193.0 runtime. The MFA case must:
+For this historical baseline, run the compatibility suite against an unmodified v2.193.0 runtime. The MFA case must:
 
 1. Enroll, challenge, and verify a TOTP factor through GoTrue.
 2. Confirm the session reaches `aal2` and AMR records authentication methods.
@@ -57,6 +57,6 @@ Also run the full password, session, refresh, OAuth PKCE, UserInfo, JWT/RLS, Sto
 
 ## Rollback boundary
 
-Rollback restores the v2.192.0 GoTrue binary or image and the previous generated runtime manifest. The v2.192.0 `custom_claims_allowlist` column is additive and remains in place; do not drop it during application rollback. Restore the `auth` schema backup only for an actual data or schema recovery incident, after stopping writers and following the database recovery procedure.
+Rollback from this historical baseline restores the v2.192.0 GoTrue binary or image and the previous generated runtime manifest. The v2.192.0 `custom_claims_allowlist` column is additive and remains in place; do not drop it during application rollback. Restore the `auth` schema backup only for an actual data or schema recovery incident, after stopping writers and following the database recovery procedure.
 
 Provider-linking variables can be removed independently before or after the binary rollback because they are opt-in. Re-run session refresh, OAuth PKCE, TOTP, and dependent Supabase service smoke tests after rollback.

--- a/docs/platform-component-upgrade-notes.md
+++ b/docs/platform-component-upgrade-notes.md
@@ -1,14 +1,14 @@
 # 平台组件升级兼容说明
 
-本说明对应 2026-07-19 的组件基线。它和版本号清单一起使用，明确区分“升级后自动生效的修复”“需要迁移或回滚准备的破坏性变化”和“仅作为可选能力保留的新功能”。本轮不在生产环境自动启用可选功能。
+本说明对应 2026-07-29 的组件基线。它和版本号清单一起使用，明确区分“升级后自动生效的修复”“需要迁移或回滚准备的破坏性变化”和“仅作为可选能力保留的新功能”。本轮不在生产环境自动启用可选功能。
 
 ## 版本与影响
 
 | 组件 | 旧版本 | 当前版本 | 破坏性/迁移关注点 | 本仓库处理 |
 | --- | --- | --- | --- | --- |
-| GoTrue | v2.191.0 | v2.193.0 | v2.192 增加 `custom_oauth_providers.custom_claims_allowlist` 数据库迁移；v2.193 的 provider linking domains 仍是 experimental；MFA 删除因子后的 AAL 降级修复会改变安全行为 | GoTrue 根命令启动时执行嵌入迁移；`supabase_auth_admin` 保留建表/改列权限。新 custom claims 和 linking domains 不默认打开，等 Management API 契约单独接入 |
-| PostgREST | v14.13 | v14.15 | v14.14/v14.15 均为 admin server 错误处理修复，没有配置或数据库迁移要求 | 保持现有 per-tenant `.conf` 配置和健康检查；不需要改变 PostgreSQL 18 schema |
-| Realtime | v2.111.4 | v2.116.1 | 2.112 恢复 pg filters；2.113/2.114/2.115 增加 feature flags、Forum.Muster、tenant dump 能力；2.116.1 修复 tenant dump 缺少 role。上游还包含 realtime schema/role 泄漏修复 | 保持 `SEED_SELF_HOST=true`、`supabase_realtime_admin` 角色和现有 schema/grant reconcile；不默认启用新管理 API |
+| GoTrue | v2.191.0 | v2.194.0 | v2.192 增加 `custom_oauth_providers.custom_claims_allowlist` 数据库迁移；v2.193.1 不再错误接受应撤销的旧 refresh token，并关闭 OAuth authorization code 重放竞态；v2.194 的 admin users cursor pagination 默认关闭，启用后响应增加 `pagination`/`Link` 且不再返回 `X-Total-Count` | GoTrue 根命令启动时执行嵌入迁移；`supabase_auth_admin` 保留建表/改列权限。cursor pagination、custom claims 和 linking domains 均不默认打开；依赖 token/code 重放的错误客户端必须修复，不能放宽服务端校验 |
+| PostgREST | v14.13 | v14.16 | v14.14-v14.16 均为 admin server 错误处理与崩溃恢复修复，没有新增配置、数据库迁移或运行时前置要求 | 保持现有 per-tenant `.conf` 配置和健康检查；不需要改变 PostgreSQL 18 schema |
+| Realtime | v2.111.4 | v2.121.0 | 2.112 恢复 pg filters；2.117-2.121 增加 inspector/status、tenant shutdown、Muster 和 fanout 可观测性。v2.120.1 修订既有 `20241019105805_uuid_auto_generation.ex`：先回填 `realtime.messages.uuid` 空值，再设置 default 和 `NOT NULL`；已记录成功的同名迁移不会自动重跑 | 升级前备份 tenant Realtime schema；若 2.120.0 曾在该迁移失败，升级后读回 `uuid` 空值数量、default 和 `NOT NULL`。保持 `SEED_SELF_HOST=true`、`supabase_realtime_admin` 角色和现有 schema/grant reconcile；不默认启用新管理能力或 feature flag |
 | Caddy | v2.10.2 | v2.11.4 | 2.11 对 HTTPS upstream 默认重写 `Host`；2.11.4 的路径、rewrite、模板和下划线 header 安全修复可能让依赖旧错误行为的配置失效 | SupaCloud JSON 路由显式设置 `Host`/`X-Forwarded-Host`，并只发送连字符 header；Caddy 自定义 rate-limit 模块已用 v2.11.4 双架构构建验证 |
 | JuiceFS | 1.2.2 | 1.4.0 | 1.4 是 LTS；启用 storage tiers 时所有客户端必须先到 1.4.0；元数据备份默认清理两年以上备份；1.4 包含 SQL 元数据字段类型调整 | 本平台只使用单一 gateway 和 Postgres metadata；不启用 storage tiers。已有 `juicefs` metadata 在生产升级前必须做 `juicefs dump`/pg_dump 并保留回滚副本 |
 | Docker Compose | v2.29.2 | v5.3.1 | v5 删除内部构建器，`compose build` 改走 Docker Bake，并要求 Docker Buildx >= 0.17；这是唯一需要额外运行时前置条件的主版本更新 | CI 已使用 Docker Buildx；安装器的 Podman 路径只负责 `pull/up`，不把 Compose v5 当作 Podman 的构建器。Podman 用户构建镜像应使用 Podman build/兼容的 Buildx，或先提供已构建镜像 |
@@ -26,9 +26,9 @@ SupaCloud 的实际部署、Dockerfile 和 self-host Compose 继续使用 `postg
 
 ## 官方变更记录
 
-- [GoTrue v2.192.0](https://github.com/supabase/auth/releases/tag/v2.192.0) / [v2.193.0](https://github.com/supabase/auth/releases/tag/v2.193.0)
-- [PostgREST v14.14](https://github.com/PostgREST/postgrest/releases/tag/v14.14) / [v14.15](https://github.com/PostgREST/postgrest/releases/tag/v14.15)
-- [Realtime v2.112.0](https://github.com/supabase/realtime/releases/tag/v2.112.0)、[v2.113.0](https://github.com/supabase/realtime/releases/tag/v2.113.0)、[v2.115.0](https://github.com/supabase/realtime/releases/tag/v2.115.0)、[v2.116.0](https://github.com/supabase/realtime/releases/tag/v2.116.0)、[v2.116.1](https://github.com/supabase/realtime/releases/tag/v2.116.1)
+- [GoTrue v2.192.0](https://github.com/supabase/auth/releases/tag/v2.192.0)、[v2.193.1](https://github.com/supabase/auth/releases/tag/v2.193.1)、[v2.194.0](https://github.com/supabase/auth/releases/tag/v2.194.0) / [v2.193.0...v2.194.0](https://github.com/supabase/auth/compare/v2.193.0...v2.194.0)
+- [PostgREST v14.14](https://github.com/PostgREST/postgrest/releases/tag/v14.14)、[v14.15](https://github.com/PostgREST/postgrest/releases/tag/v14.15)、[v14.16](https://github.com/PostgREST/postgrest/releases/tag/v14.16) / [v14.15...v14.16](https://github.com/PostgREST/postgrest/compare/v14.15...v14.16)
+- [Realtime v2.112.0](https://github.com/supabase/realtime/releases/tag/v2.112.0)、[v2.116.1](https://github.com/supabase/realtime/releases/tag/v2.116.1)、[v2.117.0](https://github.com/supabase/realtime/releases/tag/v2.117.0)、[v2.119.0](https://github.com/supabase/realtime/releases/tag/v2.119.0)、[v2.120.0](https://github.com/supabase/realtime/releases/tag/v2.120.0)、[v2.120.1](https://github.com/supabase/realtime/releases/tag/v2.120.1)、[v2.121.0](https://github.com/supabase/realtime/releases/tag/v2.121.0) / [v2.116.1...v2.121.0](https://github.com/supabase/realtime/compare/v2.116.1...v2.121.0)
 - [Caddy v2.11.1](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) / [v2.11.4](https://github.com/caddyserver/caddy/releases/tag/v2.11.4)
 - [JuiceFS v1.4.0](https://github.com/juicedata/juicefs/releases/tag/v1.4.0)
 - [Docker Compose v5.0.0](https://github.com/docker/compose/releases/tag/v5.0.0) / [v5.3.1](https://github.com/docker/compose/releases/tag/v5.3.1)

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -19,6 +19,20 @@ function readShellConstant(script: string, name: string): string {
   return assignment[1];
 }
 
+function readDocumentedComponentVersion(notes: string, component: string): string {
+  const componentRow = notes.split("\n").find((line) => line.startsWith(`| ${component} |`));
+  if (!componentRow) throw new Error(`Missing component row: ${component}`);
+  const currentVersion = componentRow.split("|")[3]?.trim();
+  if (!currentVersion) throw new Error(`Missing current version for component: ${component}`);
+  return currentVersion;
+}
+
+function readRealtimeImageVersion(systemdUnit: string): string {
+  const version = systemdUnit.match(/^Environment=REALTIME_IMAGE=.*:(v[^\s]+)$/m)?.[1];
+  if (!version) throw new Error("Missing Realtime image version");
+  return version;
+}
+
 describe("runtime companion version assets", () => {
   test("release resolver falls back to the latest component release containing every requested asset", () => {
     const releases = JSON.stringify([
@@ -1010,5 +1024,22 @@ describe("runtime companion version assets", () => {
     expect(upgradeNotes).toContain("postgres:18-bookworm");
     expect(upgradeNotes).toContain("custom_oauth_providers.custom_claims_allowlist");
     expect(upgradeNotes).toContain("storage tiers");
+  });
+
+  test("platform component upgrade notes match runtime version sources", () => {
+    const upgradeNotes = readRepoFile("docs/platform-component-upgrade-notes.md");
+    const gotrueUpgrade = readRepoFile("scripts/lib/gotrue_upgrade.sh");
+    const tenantRuntime = readRepoFile("scripts/lib/tenant_runtime.sh");
+    const realtimeUnit = readRepoFile("infrastructure/systemd/supacloud-realtime.service");
+
+    expect(readDocumentedComponentVersion(upgradeNotes, "GoTrue")).toBe(
+      readShellConstant(gotrueUpgrade, "SUPACLOUD_GOTRUE_DEFAULT_VERSION"),
+    );
+    expect(readDocumentedComponentVersion(upgradeNotes, "PostgREST")).toBe(
+      readShellConstant(tenantRuntime, "POSTGREST_DEFAULT_VERSION"),
+    );
+    expect(readDocumentedComponentVersion(upgradeNotes, "Realtime")).toBe(
+      readRealtimeImageVersion(realtimeUnit),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- align the component compatibility table with the versions actually pinned by SupaCloud
- document the security and API-contract changes introduced between the previous and current GoTrue, PostgREST, and Realtime baselines
- mark the GoTrue v2.193 document as a historical baseline and add a source-derived drift test

## Current repository pins

- GoTrue `v2.194.0`
- PostgREST `v14.16`
- Realtime `v2.121.0`

Realtime `v2.121.1` is newer upstream but is intentionally not described as deployed or pinned by this documentation-only PR.

## Breaking and migration notes

- GoTrue refresh-token and OAuth authorization-code replay handling is stricter; cursor pagination remains opt-in.
- PostgREST changes are admin-server recovery fixes without a new schema migration.
- Realtime `v2.120.1` repairs an existing UUID migration; operators must back up and read back tenant state when recovering a failed prior attempt.

## Verification

- `bun test packages/management-api/tests/unit/runtime-version-assets.test.ts packages/management-api/tests/unit/realtime-systemd.test.ts` (28 pass)
- `bash scripts/lib/gotrue_upgrade.test.sh`
- `bash scripts/lib/tenant_runtime.test.sh`
- `git diff --check`
