### PR TITLE
fix(upgrade): verify the active management binary

### DIFF
--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -2,7 +2,7 @@ import { $, SQL } from "bun";
 import * as p from "@clack/prompts";
 import os from "node:os";
 import path from "node:path";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, readlinkSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { logger } from "./utils/logger";
 import { WEB_CONSOLE_CURRENT_DIR } from "./utils/web-console-path";
@@ -12,6 +12,7 @@ const RELEASES_API = "https://api.github.com/repos/zuohuadong/supacloud/releases
 const RELEASE_REPOSITORY = "zuohuadong/supacloud";
 const RELEASE_SIGNER_WORKFLOW = `${RELEASE_REPOSITORY}/.github/workflows/release-please.yml`;
 const BIN_TARGET = "/usr/local/bin/supacloud";
+const MANAGEMENT_SERVICE_UNIT = "supacloud.service";
 const DEFAULT_MANAGEMENT_ENV_FILE = "/etc/supabase/management-api.env";
 const DEFAULT_EDGE_RUNTIME_USER = "supacloud-edge";
 const DEFAULT_EDGE_RUNTIME_GROUP = "supacloud-edge";
@@ -72,6 +73,20 @@ type HostIdentityCommandResult = {
 };
 
 type HostIdentityCommandRunner = (command: string[]) => Promise<HostIdentityCommandResult>;
+
+export type ActiveManagementBinary = {
+    unit: string;
+    execStartPath: string;
+    pid: number;
+    executablePath: string;
+    sha256: string;
+};
+
+type ManagementBinaryInspectorOptions = {
+    run?: HostIdentityCommandRunner;
+    readlink?: (filePath: string) => string;
+    sha256?: (filePath: string) => string;
+};
 
 export type EdgeRuntimeIdentity = {
     user: string;
@@ -220,10 +235,147 @@ export function verifyArtifactChecksum(filePath: string, assetName: string, chec
     if (!expected || !/^[0-9a-f]{64}$/.test(expected)) {
         throw new Error(`SHA256SUMS does not contain a valid checksum for ${assetName}`);
     }
-    const actual = createHash("sha256").update(readFileSync(filePath)).digest("hex");
+    const actual = sha256File(filePath);
     if (actual !== expected) {
         throw new Error(`SHA256 mismatch for ${assetName}`);
     }
+    return actual;
+}
+
+function sha256File(filePath: string): string {
+    return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+export function parseSystemdExecStartPath(value: string): string {
+    const matches = Array.from(value.trim().matchAll(/(?:^|[{;]\s*)path=([^;}\r\n]+?)\s*(?=;|}|$)/g));
+    if (matches.length !== 1) {
+        throw new Error("ExecStart must contain exactly one executable path");
+    }
+
+    const executablePath = matches[0]?.[1]?.trim() || "";
+    if (!path.posix.isAbsolute(executablePath) || /\s/.test(executablePath)) {
+        throw new Error("ExecStart executable path must be an unambiguous absolute path");
+    }
+    return executablePath;
+}
+
+export function parseSystemdMainPid(value: string): number {
+    const normalized = value.trim();
+    if (!/^\d+$/.test(normalized)) {
+        throw new Error("MainPID must be a decimal integer");
+    }
+    const pid = Number(normalized);
+    if (!Number.isSafeInteger(pid) || pid <= 1) {
+        throw new Error("MainPID must identify a running service process");
+    }
+    return pid;
+}
+
+async function readSystemdProperty(
+    unit: string,
+    property: "ExecStart" | "MainPID",
+    run: HostIdentityCommandRunner,
+): Promise<string> {
+    let result: HostIdentityCommandResult;
+    try {
+        result = await run(["systemctl", "show", unit, `--property=${property}`, "--value"]);
+    } catch (error: unknown) {
+        throw new Error(`Failed to inspect ${unit} ${property}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (result.exitCode !== 0) {
+        throw new Error(`Failed to inspect ${unit} ${property}: ${result.stderr.trim().slice(-300) || `systemctl exited with ${result.exitCode}`}`);
+    }
+    return result.stdout;
+}
+
+async function readManagementExecStartPath(run: HostIdentityCommandRunner): Promise<string> {
+    try {
+        const rawExecStart = await readSystemdProperty(MANAGEMENT_SERVICE_UNIT, "ExecStart", run);
+        return parseSystemdExecStartPath(rawExecStart);
+    } catch (error: unknown) {
+        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} ExecStart: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+
+async function readManagementMainPid(run: HostIdentityCommandRunner): Promise<number> {
+    try {
+        const rawMainPid = await readSystemdProperty(MANAGEMENT_SERVICE_UNIT, "MainPID", run);
+        return parseSystemdMainPid(rawMainPid);
+    } catch (error: unknown) {
+        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} MainPID: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+
+function resolveActiveExecutablePath(procExecutablePath: string, readlink: (filePath: string) => string): string {
+    try {
+        return readlink(procExecutablePath).trim();
+    } catch (error: unknown) {
+        throw new Error(`Cannot resolve ${MANAGEMENT_SERVICE_UNIT} active executable at ${procExecutablePath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+
+function hashActiveExecutable(procExecutablePath: string, sha256: (filePath: string) => string): string {
+    let digest: string;
+    try {
+        digest = sha256(procExecutablePath).trim().toLowerCase();
+    } catch (error: unknown) {
+        throw new Error(`Cannot hash ${MANAGEMENT_SERVICE_UNIT} active executable at ${procExecutablePath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    if (!/^[0-9a-f]{64}$/.test(digest)) {
+        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} active executable: invalid SHA-256 digest`);
+    }
+    return digest;
+}
+
+export async function inspectActiveManagementBinary(
+    options: ManagementBinaryInspectorOptions = {},
+): Promise<ActiveManagementBinary> {
+    const run = options.run ?? runHostIdentityCommand;
+    const readlink = options.readlink ?? ((filePath: string) => readlinkSync(filePath, "utf8"));
+    const sha256 = options.sha256 ?? sha256File;
+    const execStartPath = await readManagementExecStartPath(run);
+    const pid = await readManagementMainPid(run);
+    const procExecutablePath = `/proc/${pid}/exe`;
+    const executablePath = resolveActiveExecutablePath(procExecutablePath, readlink);
+    const digest = hashActiveExecutable(procExecutablePath, sha256);
+    const stablePid = await readManagementMainPid(run);
+    if (stablePid !== pid) {
+        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} active executable: MainPID changed from ${pid} to ${stablePid}`);
+    }
+    return { unit: MANAGEMENT_SERVICE_UNIT, execStartPath, pid, executablePath, sha256: digest };
+}
+
+function assertCanonicalManagementBinary(snapshot: ActiveManagementBinary, phase: string): void {
+    if (snapshot.execStartPath !== BIN_TARGET) {
+        throw new Error(`${phase}: ${snapshot.unit} ExecStart is ${snapshot.execStartPath}; upgrade target is ${BIN_TARGET}`);
+    }
+    if (snapshot.executablePath !== BIN_TARGET) {
+        throw new Error(`${phase}: ${snapshot.unit} runs ${snapshot.executablePath}; expected ${BIN_TARGET}`);
+    }
+}
+
+export async function verifyManagementUpgradePreflight(
+    options: ManagementBinaryInspectorOptions = {},
+): Promise<ActiveManagementBinary> {
+    const snapshot = await inspectActiveManagementBinary(options);
+    assertCanonicalManagementBinary(snapshot, "Refusing to migrate");
+    return snapshot;
+}
+
+export async function verifyActivatedManagementBinary(
+    expectedSha256: string,
+    options: ManagementBinaryInspectorOptions = {},
+): Promise<ActiveManagementBinary> {
+    const normalizedExpected = expectedSha256.trim().toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(normalizedExpected)) {
+        throw new Error("Post-upgrade binary verification requires a valid staged SHA-256 digest");
+    }
+    const snapshot = await inspectActiveManagementBinary(options);
+    assertCanonicalManagementBinary(snapshot, "Post-upgrade binary verification failed");
+    if (snapshot.sha256 !== normalizedExpected) {
+        throw new Error(`Post-upgrade binary verification failed: ${snapshot.unit} is running a binary whose SHA-256 does not match the staged release binary`);
+    }
+    return snapshot;
 }
 
 export function validateWebConsoleArchiveEntries(entriesText: string) {
@@ -239,6 +391,7 @@ export function validateWebConsoleArchiveEntries(entriesText: string) {
 }
 
 export type UpgradeTransactionOperations = {
+    preflight: () => Promise<void>;
     stage: () => Promise<void>;
     migrate: () => Promise<void>;
     activate: () => Promise<void>;
@@ -251,6 +404,7 @@ export type UpgradeTransactionOperations = {
 export async function executeUpgradeTransaction(operations: UpgradeTransactionOperations) {
     let activationStarted = false;
     try {
+        await operations.preflight();
         await operations.stage();
         // Database migrations executed by the staged binary must remain backward
         // compatible because artifact rollback cannot reverse committed schema changes.
@@ -659,6 +813,7 @@ async function downloadReleaseChecksums(release: GithubRelease, preferredEndpoin
 type StagedBinary = {
     path: string;
     endpoint: GithubEndpoint;
+    sha256: string;
 };
 
 async function stageBinary(
@@ -672,11 +827,19 @@ async function stageBinary(
     const stagedBinary = `${BIN_TARGET}.new-${process.pid}`;
     try {
         const endpoint = await downloadAsset(downloadUrl, tmpBinary, preferredEndpoint, forceYes);
-        verifyArtifactChecksum(tmpBinary, binaryName, checksums);
+        const releaseSha256 = verifyArtifactChecksum(tmpBinary, binaryName, checksums);
         await verifyArtifactAttestation(tmpBinary);
         await validateBinaryArtifact(tmpBinary, binaryName);
         await $`install -m 0755 ${tmpBinary} ${stagedBinary}`;
-        return { path: stagedBinary, endpoint };
+        const stagedSha256 = sha256File(stagedBinary);
+        if (stagedSha256 !== releaseSha256) {
+            await $`rm -f ${stagedBinary}`.nothrow().quiet();
+            throw new Error(`SHA256 mismatch for staged ${binaryName}`);
+        }
+        return { path: stagedBinary, endpoint, sha256: stagedSha256 };
+    } catch (error: unknown) {
+        await $`rm -f ${stagedBinary}`.nothrow().quiet();
+        throw error;
     } finally {
         await $`rm -f ${tmpBinary}`.nothrow().quiet();
     }
@@ -1339,6 +1502,10 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
         let activatedEdgeRuntimeMode: EdgeRuntimeMode | null = null;
 
         await executeUpgradeTransaction({
+            preflight: async () => {
+                s.start(`Verifying ${MANAGEMENT_SERVICE_UNIT} uses the canonical upgrade target`);
+                await verifyManagementUpgradePreflight();
+            },
             stage: async () => {
                 s.start(`Downloading, verifying, and staging ${binaryName}`);
                 stagedBinary = await stageBinary(releaseUrl, binaryName, checksums, endpoint, options.forceYes);
@@ -1388,6 +1555,8 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                 s.start("Waiting for the SupaCloud health endpoint");
                 if (!activatedEdgeRuntimeMode) throw new Error("Edge Runtime mode was not resolved");
                 await waitForUpgradeHealth();
+                if (!stagedBinary) throw new Error("Upgrade binary was not staged");
+                await verifyActivatedManagementBinary(stagedBinary.sha256);
                 committed = true;
             },
             rollback: async () => {

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -16,7 +16,10 @@ import {
     ensureEdgeRuntimeIdentity,
     ensureEmbeddedEdgeRuntimeSourceAccess,
     ensurePersistedEdgeRuntimeIdentity,
+    inspectActiveManagementBinary,
     normalizeManagementReleaseTag,
+    parseSystemdExecStartPath,
+    parseSystemdMainPid,
     prepareUpgradeSecrets,
     resolveArtifactVerificationMode,
     resolveEdgeRuntimeCapacityConfig,
@@ -33,7 +36,9 @@ import {
     upsertPersistedEdgeRuntimePort,
     upsertEdgeRuntimeIdentityDefaults,
     validateWebConsoleArchiveEntries,
+    verifyActivatedManagementBinary,
     verifyArtifactChecksum,
+    verifyManagementUpgradePreflight,
     waitForManagementHealth,
     waitForEdgeRuntimeHealth,
     waitForUpgradeHealth,
@@ -43,6 +48,40 @@ const originalFetch = globalThis.fetch;
 
 const originalUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS;
 const originalEdgeUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS;
+const canonicalManagementBinary = "/usr/local/bin/supacloud";
+const currentBinarySha256 = "a".repeat(64);
+
+type ManagementBinaryFixture = {
+  execStartPath?: string;
+  executablePath?: string;
+  mainPids?: string[];
+  sha256?: string;
+};
+
+function managementBinaryFixture(input: ManagementBinaryFixture = {}) {
+  const mainPids = input.mainPids ?? ["4242", "4242"];
+  let mainPidRead = 0;
+  return {
+    run: async (command: string[]) => {
+      if (command[3] === "--property=ExecStart") {
+        const executablePath = input.execStartPath ?? canonicalManagementBinary;
+        return {
+          exitCode: 0,
+          stdout: `{ path=${executablePath} ; argv[]=${executablePath} ; ignore_errors=no ; }\n`,
+          stderr: "",
+        };
+      }
+      if (command[3] === "--property=MainPID") {
+        const stdout = mainPids[Math.min(mainPidRead, mainPids.length - 1)] ?? "";
+        mainPidRead += 1;
+        return { exitCode: 0, stdout: `${stdout}\n`, stderr: "" };
+      }
+      throw new Error(`Unexpected command: ${command.join(" ")}`);
+    },
+    readlink: () => input.executablePath ?? canonicalManagementBinary,
+    sha256: () => input.sha256 ?? currentBinarySha256,
+  };
+}
 
 const ensureHealthTimeout = () => {
   process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS = "1";
@@ -428,10 +467,163 @@ describe("upgrade release selection", () => {
     }
   });
 
+  test("parses a single canonical systemd ExecStart path", () => {
+    expect(parseSystemdExecStartPath(
+      "{ path=/usr/local/bin/supacloud ; argv[]=/usr/local/bin/supacloud --serve ; ignore_errors=no ; }\n",
+    )).toBe(canonicalManagementBinary);
+  });
+
+  test("rejects empty, relative, and ambiguous systemd ExecStart values", () => {
+    expect(() => parseSystemdExecStartPath("")).toThrow("exactly one executable path");
+    expect(() => parseSystemdExecStartPath("{ path=bin/supacloud ; argv[]=bin/supacloud ; }"))
+      .toThrow("absolute path");
+    expect(() => parseSystemdExecStartPath(
+      "{ path=/usr/local/bin/supacloud ; } ; { path=/opt/supacloud/bin/supacloud ; }",
+    )).toThrow("exactly one executable path");
+  });
+
+  test("rejects inactive, malformed, and unsafe MainPID values", () => {
+    for (const value of ["0", "1", "not-a-pid", "9007199254740992"]) {
+      expect(() => parseSystemdMainPid(value)).toThrow();
+    }
+    expect(parseSystemdMainPid("4242\n")).toBe(4242);
+  });
+
+  test("inspects a stable canonical active Management binary", async () => {
+    await expect(inspectActiveManagementBinary(managementBinaryFixture())).resolves.toEqual({
+      unit: "supacloud.service",
+      execStartPath: canonicalManagementBinary,
+      pid: 4242,
+      executablePath: canonicalManagementBinary,
+      sha256: currentBinarySha256,
+    });
+  });
+
+  test("fails closed when systemd, procfs, hashing, or PID stability cannot be verified", async () => {
+    await expect(verifyManagementUpgradePreflight({
+      ...managementBinaryFixture(),
+      run: async () => ({ exitCode: 1, stdout: "", stderr: "unit unavailable" }),
+    })).rejects.toThrow("unit unavailable");
+
+    await expect(verifyManagementUpgradePreflight({
+      ...managementBinaryFixture(),
+      readlink: () => { throw new Error("procfs unavailable"); },
+    })).rejects.toThrow("procfs unavailable");
+
+    await expect(verifyManagementUpgradePreflight({
+      ...managementBinaryFixture(),
+      sha256: () => { throw new Error("read failed"); },
+    })).rejects.toThrow("Cannot hash supacloud.service active executable");
+
+    await expect(verifyManagementUpgradePreflight(managementBinaryFixture({
+      mainPids: ["4242", "4343"],
+    }))).rejects.toThrow("MainPID changed from 4242 to 4343");
+  });
+
+  test("rejects a deleted active executable", async () => {
+    await expect(verifyManagementUpgradePreflight(managementBinaryFixture({
+      executablePath: `${canonicalManagementBinary} (deleted)`,
+    }))).rejects.toThrow(`runs ${canonicalManagementBinary} (deleted)`);
+  });
+
+  test("preflight mismatch stops before staging or database migration", async () => {
+    const events: string[] = [];
+    const customBinary = "/opt/supacloud/bin/supacloud";
+
+    await expect(executeUpgradeTransaction({
+      preflight: async () => {
+        events.push("preflight");
+        await verifyManagementUpgradePreflight(managementBinaryFixture({
+          execStartPath: customBinary,
+          executablePath: customBinary,
+        }));
+      },
+      stage: async () => { events.push("stage"); },
+      migrate: async () => { events.push("migrate"); },
+      activate: async () => { events.push("activate"); },
+      restart: async () => { events.push("restart"); },
+      healthCheck: async () => { events.push("health"); },
+      rollback: async () => { events.push("rollback"); },
+      cleanup: async () => { events.push("cleanup"); },
+    })).rejects.toThrow(`ExecStart is ${customBinary}`);
+
+    expect(events).toEqual(["preflight", "cleanup"]);
+  });
+
+  test("healthy old service with a different digest triggers rollback", async () => {
+    const events: string[] = [];
+    const stagedSha256 = "b".repeat(64);
+    ensureHealthTimeout();
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      return new Response(url.endsWith("/") ? "<!doctype html>" : "ok", {
+        status: 200,
+        headers: { "content-type": url.endsWith("/") ? "text/html" : "application/json" },
+      });
+    }) as typeof fetch;
+
+    await expect(executeUpgradeTransaction({
+      preflight: async () => { events.push("preflight"); },
+      stage: async () => { events.push("stage"); },
+      migrate: async () => { events.push("migrate"); },
+      activate: async () => { events.push("activate"); },
+      restart: async () => { events.push("restart"); },
+      healthCheck: async () => {
+        events.push("health");
+        await waitForUpgradeHealth();
+        await verifyActivatedManagementBinary(stagedSha256, managementBinaryFixture({
+          sha256: currentBinarySha256,
+        }));
+      },
+      rollback: async () => { events.push("rollback"); },
+      cleanup: async () => { events.push("cleanup"); },
+    })).rejects.toThrow("does not match the staged release binary");
+
+    expect(events).toEqual([
+      "preflight",
+      "stage",
+      "migrate",
+      "activate",
+      "restart",
+      "health",
+      "rollback",
+      "cleanup",
+    ]);
+  });
+
+  test("canonical active path with a stable PID and staged digest can commit", async () => {
+    const events: string[] = [];
+
+    await expect(executeUpgradeTransaction({
+      preflight: async () => { events.push("preflight"); },
+      stage: async () => { events.push("stage"); },
+      migrate: async () => { events.push("migrate"); },
+      activate: async () => { events.push("activate"); },
+      restart: async () => { events.push("restart"); },
+      healthCheck: async () => {
+        events.push("health");
+        await verifyActivatedManagementBinary(currentBinarySha256, managementBinaryFixture());
+      },
+      rollback: async () => { events.push("rollback"); },
+      cleanup: async () => { events.push("cleanup"); },
+    })).resolves.toBeUndefined();
+
+    expect(events).toEqual([
+      "preflight",
+      "stage",
+      "migrate",
+      "activate",
+      "restart",
+      "health",
+      "cleanup",
+    ]);
+  });
+
   test("restores activated artifacts when the post-restart health check fails", async () => {
     const events: string[] = [];
 
     await expect(executeUpgradeTransaction({
+      preflight: async () => { events.push("preflight"); },
       stage: async () => { events.push("stage"); },
       migrate: async () => { events.push("migrate"); },
       activate: async () => { events.push("activate"); },
@@ -445,6 +637,7 @@ describe("upgrade release selection", () => {
     })).rejects.toThrow("unhealthy");
 
     expect(events).toEqual([
+      "preflight",
       "stage",
       "migrate",
       "activate",


### PR DESCRIPTION
## Summary

- fail closed before staging or database migration unless `supacloud.service` runs the canonical Management API binary
- verify systemd `ExecStart`, a stable `MainPID`, and `/proc/<pid>/exe`
- after health checks, require the active executable SHA-256 to match the staged and release-verified binary before committing the upgrade

## Why

The upgrader always replaces `/usr/local/bin/supacloud`, but previously accepted HTTP health as proof of success. A custom or legacy unit running `/opt/supacloud/bin/supacloud` could stay healthy while the upgrader replaced an inactive path, causing a false success after database migration.

## Compatibility

This deliberately rejects inactive services, wrappers, symlinks, deleted executables, and custom Management API paths. Operators must first align the service unit with the installer-owned canonical path. The upgrader does not rewrite arbitrary `ExecStart` paths.

## Verification

- `bun test tests/unit/upgrade.test.ts` (50 pass)
- `bun run typecheck`
- `bun run test:unit`
- `git diff --check`
