### PR TITLE
fix(cli): synchronize unified package lockfile

### DIFF
--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "supacloud",
       "dependencies": {
-        "@supacloud/admin": "^0.6.0",
-        "@supacloud/cli": "^0.13.0",
+        "@supacloud/admin": "^0.7.0",
+        "@supacloud/cli": "^0.14.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -17,9 +17,9 @@
   "packages": {
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supacloud/admin": ["@supacloud/admin@0.6.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.6.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-xGXXOMaRzmt0S+zsORoPnQ/H2HGxtmOZ6waoJvIY1d7Rt+WDEccvPDoQGEsGxlQKO+tIRbBb+rVeEzq7gNxvHA=="],
+    "@supacloud/admin": ["@supacloud/admin@0.7.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.7.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-L3b0LbPacF2p1nzuFHJ7OCPhME11TF+tVXeJuqmVo5sgUo+G0f/s5BUDbWW3veYrzHPEyXS04HZU4mgenjiZIg=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.13.0", "", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-/GMoffOoL7W0wJ0KsJ0SYl8Cz0Fucoe7fhHO+JeDmRiiCkQhVGlg7ukfWNrvODmA1E77JkJVgVhn/ynn+G7mpQ=="],
+    "@supacloud/cli": ["@supacloud/cli@0.14.0", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-Ig2dUZl1cEILvJ6Ff1X/Dz1Ubw4s1TJJxiXwARkAvNn0dfDlq/hEx/3ZaPvEOtsJXwHWR9tm7R/ddQkGTXTUaw=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary
- align the unified `supacloud` package lock with released Admin 0.7.0 and CLI 0.14.0 dependencies already declared on main
- restore frozen-install Package Checks for main and dependent PRs

## Verification
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test src/index.test.ts` (19 passed)
- `bun run build`
- `npm_config_registry=https://registry.npmjs.org/ bun audit --audit-level high`
- `git diff --check`