### PR TITLE
fix(realtime): centralize tenant capacity payload

### DIFF
--- a/packages/management-api/scripts/reconcile-realtime-tenants.ts
+++ b/packages/management-api/scripts/reconcile-realtime-tenants.ts
@@ -1,5 +1,6 @@
 import { config } from "../src/config";
-import { sql, resolveDbName } from "../src/db";
+import { sql, resolveDbName, resolveSlotName } from "../src/db";
+import { buildRealtimeTenantPayload } from "../src/services/realtime-tenant-payload";
 import { logger } from "../src/utils/logger";
 import { createHmac } from "node:crypto";
 
@@ -86,9 +87,8 @@ function pickRoutingHost(projectRef: string, projectConfig: unknown): string {
   return host;
 }
 
-async function tenantPayload(project: ProjectRow) {
+async function authoritativeTenantPayload(project: ProjectRow) {
   const dbName = project.db_name || (await resolveDbName(project.ref));
-  const dbUser = "supabase_admin";
   const dbPassword = config.pgPassword || project.db_password;
   const jwtSecret = project.jwt_secret;
 
@@ -98,35 +98,19 @@ async function tenantPayload(project: ProjectRow) {
     );
   }
 
-  return {
-    tenant: {
-      external_id: project.ref,
-      name: `Project ${project.ref}`,
-      jwt_secret: jwtSecret,
-      extensions: [
-        {
-          type: "postgres_cdc_rls",
-          settings: {
-            db_host: config.pgHost,
-            db_port: String(config.pgPort),
-            db_name: dbName,
-            db_user: dbUser,
-            db_password: dbPassword,
-            region: "us-east-1",
-            poll_interval_ms: 100,
-            poll_max_changes: 100,
-            poll_max_record_bytes: 1_048_576,
-            slot_name: `supabase_realtime_rls_${project.ref}`,
-            publication: "supabase_realtime",
-          },
-        },
-      ],
-    },
-  };
+  return buildRealtimeTenantPayload({
+    projectRef: project.ref,
+    dbHost: config.pgHost,
+    dbPort: String(config.pgPort),
+    dbName,
+    adminDbPassword: dbPassword,
+    jwtSecret,
+    slotName: resolveSlotName(project.ref),
+  });
 }
 
 async function registerTenant(project: ProjectRow): Promise<void> {
-  const payload = await tenantPayload(project);
+  const payload = await authoritativeTenantPayload(project);
 
   const res = await realtimeFetch("/api/tenants", {
     method: "POST",
@@ -146,7 +130,7 @@ async function registerTenant(project: ProjectRow): Promise<void> {
 }
 
 async function updateTenant(project: ProjectRow): Promise<void> {
-  const payload = await tenantPayload(project);
+  const payload = await authoritativeTenantPayload(project);
 
   const res = await realtimeFetch(`/api/tenants/${project.ref}`, {
     method: "PUT",

--- a/packages/management-api/src/services/realtime-tenant-payload.ts
+++ b/packages/management-api/src/services/realtime-tenant-payload.ts
@@ -1,0 +1,50 @@
+interface RealtimeTenantPayloadInput {
+    projectRef: string;
+    dbHost: string;
+    dbPort: string;
+    dbName: string;
+    adminDbPassword: string;
+    jwtSecret: string;
+    slotName: string;
+}
+
+const POSTGRES_CDC_DEFAULTS = {
+    ssl_enforced: false,
+    region: "us-east-1",
+    poll_interval_ms: 100,
+    poll_max_changes: 100,
+    poll_max_record_bytes: 1_048_576,
+    publication: "supabase_realtime",
+    db_pool: 1,
+    // Realtime 仍读取这个历史拼写；同时发送 canonical 字段保证升级兼容。
+    subcriber_pool_size: 1,
+    subs_pool_size: 1,
+} as const;
+
+function postgresCdcSettings(input: RealtimeTenantPayloadInput) {
+    return {
+        ...POSTGRES_CDC_DEFAULTS,
+        db_host: input.dbHost,
+        db_port: input.dbPort,
+        db_name: input.dbName,
+        db_user: "supabase_admin",
+        db_password: input.adminDbPassword,
+        db_user_realtime: "supabase_realtime_admin",
+        db_pass_realtime: input.adminDbPassword,
+        slot_name: input.slotName,
+    };
+}
+
+export function buildRealtimeTenantPayload(input: RealtimeTenantPayloadInput) {
+    return {
+        tenant: {
+            external_id: input.projectRef,
+            name: `Project ${input.projectRef}`,
+            jwt_secret: input.jwtSecret,
+            extensions: [{
+                type: "postgres_cdc_rls",
+                settings: postgresCdcSettings(input),
+            }],
+        },
+    };
+}

--- a/packages/management-api/src/services/realtime-tenant-payload.ts
+++ b/packages/management-api/src/services/realtime-tenant-payload.ts
@@ -29,8 +29,6 @@ function postgresCdcSettings(input: RealtimeTenantPayloadInput) {
         db_name: input.dbName,
         db_user: "supabase_admin",
         db_password: input.adminDbPassword,
-        db_user_realtime: "supabase_realtime_admin",
-        db_pass_realtime: input.adminDbPassword,
         slot_name: input.slotName,
     };
 }

--- a/packages/management-api/src/services/realtime.service.ts
+++ b/packages/management-api/src/services/realtime.service.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { config } from "../config";
-import { sql, resolveSlotName, resolveRoleName } from "../db";
+import { sql, resolveSlotName } from "../db";
+import { buildRealtimeTenantPayload } from "./realtime-tenant-payload";
 /**
  * RealtimeService - Manages Supabase Realtime tenant registration
  * 
@@ -141,6 +142,19 @@ export class RealtimeService {
         };
     }
 
+    private async authoritativeTenantPayload(tenantConfig: RealtimeTenantConfig) {
+        const globalConfig = (await import("../config")).config;
+        return buildRealtimeTenantPayload({
+            projectRef: tenantConfig.projectRef,
+            dbHost: PG_HOST,
+            dbPort: PG_PORT,
+            dbName: tenantConfig.dbName,
+            adminDbPassword: globalConfig.pgPassword || tenantConfig.dbPassword || "postgres",
+            jwtSecret: tenantConfig.jwtSecret,
+            slotName: resolveSlotName(tenantConfig.projectRef),
+        });
+    }
+
     /**
      * Register a new tenant with the Realtime server.
      * Called during project provisioning.
@@ -150,9 +164,7 @@ export class RealtimeService {
      * 响应级错误（4xx/5xx，不含 409）不重试，那是逻辑错误需立即暴露。
      */
     async registerTenant(config: RealtimeTenantConfig): Promise<boolean> {
-        const globalConfig = (await import("../config")).config;
-        const adminDbUser = "supabase_admin";
-        const adminDbPassword = globalConfig.pgPassword || config.dbPassword || "postgres";
+        const tenantPayload = await this.authoritativeTenantPayload(config);
         // CI 冷启动 Realtime 容器常需 ~20-40s 才接受连接；给足重试窗口。
         const MAX_ATTEMPTS = Number(process.env.REALTIME_REGISTER_MAX_ATTEMPTS || 12);
         const BACKOFF_MS = Number(process.env.REALTIME_REGISTER_BACKOFF_MS || 3000);
@@ -161,31 +173,7 @@ export class RealtimeService {
                 const res = await fetch(`${this.adminUrl}/api/tenants`, {
                     method: "POST",
                     headers: await this.authHeaders(),
-                    body: JSON.stringify({
-                        tenant: {
-                            external_id: config.projectRef,
-                            name: `Project ${config.projectRef}`,
-                            jwt_secret: config.jwtSecret,
-                            extensions: [{
-                                type: "postgres_cdc_rls",
-                                settings: {
-                                    db_host: PG_HOST,
-                                    db_port: PG_PORT,
-                                    db_name: config.dbName,
-                                    db_user: adminDbUser,
-                                    db_password: adminDbPassword,
-                                    db_user_realtime: "supabase_realtime_admin",
-                                    db_pass_realtime: adminDbPassword,
-                                    ssl_enforced: false,
-                                    region: "us-east-1",
-                                    poll_interval_ms: 100,
-                                    poll_max_changes: 100,
-                                    poll_max_record_bytes: 1048576,
-                                    slot_name: resolveSlotName(config.projectRef),
-                                },
-                            }],
-                        },
-                    }),
+                    body: JSON.stringify(tenantPayload),
                 });
 
                 if (res.ok || res.status === 409) {
@@ -257,34 +245,12 @@ export class RealtimeService {
      * Update tenant configuration (e.g., after password rotation).
      */
     async updateTenant(config: RealtimeTenantConfig): Promise<boolean> {
-        const globalConfig = (await import("../config")).config;
-        const adminDbUser = "supabase_admin";
-        const adminDbPassword = globalConfig.pgPassword || config.dbPassword || "postgres";
+        const tenantPayload = await this.authoritativeTenantPayload(config);
         try {
             const res = await fetch(`${this.adminUrl}/api/tenants/${config.projectRef}`, {
                 method: "PUT",
                 headers: await this.authHeaders(),
-                body: JSON.stringify({
-                    tenant: {
-                        jwt_secret: config.jwtSecret,
-                        extensions: [{
-                            type: "postgres_cdc_rls",
-                            settings: {
-                                db_host: PG_HOST,
-                                db_port: PG_PORT,
-                                db_name: config.dbName,
-                                db_user: adminDbUser,
-                                db_password: adminDbPassword,
-                                db_user_realtime: "supabase_realtime_admin",
-                                db_pass_realtime: adminDbPassword,
-                                ssl_enforced: false,
-                                region: "us-east-1",
-                                poll_interval_ms: 100,
-                                slot_name: resolveSlotName(config.projectRef),
-                            },
-                        }],
-                    },
-                }),
+                body: JSON.stringify(tenantPayload),
             });
 
             if (res.ok) {

--- a/packages/management-api/tests/unit/realtime.service.test.ts
+++ b/packages/management-api/tests/unit/realtime.service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { assertRealtimeSecretAlignment, RealtimeService, validateRealtimeSecretConfiguration } from "../../src/services/realtime.service";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { buildRealtimeTenantPayload } from "../../src/services/realtime-tenant-payload";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -11,6 +12,44 @@ afterEach(() => {
 });
 
 describe("RealtimeService tenant payloads", () => {
+  test("builds the authoritative plaintext tenant capacity contract", () => {
+    const payload = buildRealtimeTenantPayload({
+      projectRef: "testref",
+      dbHost: "postgres",
+      dbPort: "5432",
+      dbName: "supa_testref",
+      adminDbPassword: "database-secret",
+      jwtSecret: "jwt-secret",
+      slotName: "supabase_realtime_testref",
+    });
+
+    expect(payload.tenant.external_id).toBe("testref");
+    expect(payload.tenant.jwt_secret).toBe("jwt-secret");
+    expect(payload.tenant.extensions).toHaveLength(1);
+    expect(payload.tenant.extensions[0]).toEqual({
+      type: "postgres_cdc_rls",
+      settings: {
+        ssl_enforced: false,
+        region: "us-east-1",
+        poll_interval_ms: 100,
+        poll_max_changes: 100,
+        poll_max_record_bytes: 1_048_576,
+        publication: "supabase_realtime",
+        db_pool: 1,
+        subcriber_pool_size: 1,
+        subs_pool_size: 1,
+        db_host: "postgres",
+        db_port: "5432",
+        db_name: "supa_testref",
+        db_user: "supabase_admin",
+        db_password: "database-secret",
+        db_user_realtime: "supabase_realtime_admin",
+        db_pass_realtime: "database-secret",
+        slot_name: "supabase_realtime_testref",
+      },
+    });
+  });
+
   test("fails closed when the API or container verification secret drifts", () => {
     expect(() => assertRealtimeSecretAlignment({
       canonicalSecret: "canonical-realtime-secret",
@@ -51,7 +90,7 @@ describe("RealtimeService tenant payloads", () => {
     }
   });
 
-  test("registerTenant disables per-tenant postgres SSL for local service databases", async () => {
+  test("registerTenant and updateTenant send the same authoritative payload", async () => {
     const calls: Array<{ url: string; init?: RequestInit }> = [];
     globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
       calls.push({ url: String(url), init });
@@ -59,21 +98,45 @@ describe("RealtimeService tenant payloads", () => {
     }) as typeof fetch;
 
     const service = new RealtimeService();
-    const ok = await service.registerTenant({
+    const tenantConfig = {
       projectRef: "testref",
       dbName: "postgres",
       dbPassword: "postgres",
       jwtSecret: "super-secret-jwt-token-with-at-least-32-characters-long",
-    });
+    };
+    const registered = await service.registerTenant(tenantConfig);
+    const updated = await service.updateTenant(tenantConfig);
 
-    expect(ok).toBe(true);
-    const body = JSON.parse(String(calls[0]?.init?.body ?? "{}"));
-    const settings = body.tenant.extensions[0].settings;
+    expect(registered).toBe(true);
+    expect(updated).toBe(true);
+    expect(calls).toHaveLength(2);
+    const registerBody = JSON.parse(String(calls[0]?.init?.body ?? "{}"));
+    const updateBody = JSON.parse(String(calls[1]?.init?.body ?? "{}"));
+    expect(updateBody).toEqual(registerBody);
+    const settings = registerBody.tenant.extensions[0].settings;
     expect(settings.ssl_enforced).toBe(false);
     expect(settings.db_user).toBe("supabase_admin");
     expect(settings.db_password).toBe("postgres");
     expect(settings.db_user_realtime).toBe("supabase_realtime_admin");
     expect(settings.db_pass_realtime).toBe("postgres");
+    expect(settings.slot_name).toBe("supabase_realtime_testref");
+    expect(settings.publication).toBe("supabase_realtime");
+    expect(settings.db_pool).toBe(1);
+    expect(settings.subcriber_pool_size).toBe(1);
+    expect(settings.subs_pool_size).toBe(1);
+  });
+
+  test("reconcile uses the shared authoritative payload builder", () => {
+    const reconcileSource = readFileSync(
+      join(import.meta.dir, "../../scripts/reconcile-realtime-tenants.ts"),
+      "utf8",
+    );
+
+    expect(reconcileSource).toContain(
+      'import { buildRealtimeTenantPayload } from "../src/services/realtime-tenant-payload"',
+    );
+    expect(reconcileSource).toContain("return buildRealtimeTenantPayload({");
+    expect(reconcileSource).not.toContain("function tenantPayload(");
   });
 });
 

--- a/packages/management-api/tests/unit/realtime.service.test.ts
+++ b/packages/management-api/tests/unit/realtime.service.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 describe("RealtimeService tenant payloads", () => {
-  test("builds the authoritative plaintext tenant capacity contract", () => {
+  test("builds the authoritative allow-listed tenant capacity contract", () => {
     const payload = buildRealtimeTenantPayload({
       projectRef: "testref",
       dbHost: "postgres",
@@ -26,7 +26,8 @@ describe("RealtimeService tenant payloads", () => {
     expect(payload.tenant.external_id).toBe("testref");
     expect(payload.tenant.jwt_secret).toBe("jwt-secret");
     expect(payload.tenant.extensions).toHaveLength(1);
-    expect(payload.tenant.extensions[0]).toEqual({
+    const extension = payload.tenant.extensions[0];
+    expect(extension).toEqual({
       type: "postgres_cdc_rls",
       settings: {
         ssl_enforced: false,
@@ -43,11 +44,13 @@ describe("RealtimeService tenant payloads", () => {
         db_name: "supa_testref",
         db_user: "supabase_admin",
         db_password: "database-secret",
-        db_user_realtime: "supabase_realtime_admin",
-        db_pass_realtime: "database-secret",
         slot_name: "supabase_realtime_testref",
       },
     });
+    expect(Object.entries(extension.settings)
+      .filter(([, settingValue]) => settingValue === "database-secret")
+      .map(([settingName]) => settingName))
+      .toEqual(["db_password"]);
   });
 
   test("fails closed when the API or container verification secret drifts", () => {
@@ -117,8 +120,8 @@ describe("RealtimeService tenant payloads", () => {
     expect(settings.ssl_enforced).toBe(false);
     expect(settings.db_user).toBe("supabase_admin");
     expect(settings.db_password).toBe("postgres");
-    expect(settings.db_user_realtime).toBe("supabase_realtime_admin");
-    expect(settings.db_pass_realtime).toBe("postgres");
+    expect(settings).not.toHaveProperty("db_user_realtime");
+    expect(settings).not.toHaveProperty("db_pass_realtime");
     expect(settings.slot_name).toBe("supabase_realtime_testref");
     expect(settings.publication).toBe("supabase_realtime");
     expect(settings.db_pool).toBe(1);


### PR DESCRIPTION
## Summary

- centralize the authoritative plaintext tenant payload used by Management API register/update and reconciliation
- align Realtime 2.121.x capacity settings: `db_pool=1`, legacy `subcriber_pool_size=1`, and canonical `subs_pool_size=1`
- preserve SSL, region, poll limits, database users/passwords, publication, and the shared `resolveSlotName(ref)` contract
- never copy encrypted connection fields returned by Realtime GET into a subsequent PUT

## Breaking-upgrade context

Realtime 2.121.x returns encrypted connection fields from tenant GET responses. Replaying that response into PUT causes double encryption and can break the connection (`:nxdomain`). This PR makes management-side plaintext credentials authoritative and keeps the register/update/reconcile payload contract identical.

The reconcile path previously used an isolated `_rls_` slot name. It now uses `resolveSlotName(ref)`, matching provisioning and migration code; the production canary authoritative slot was `supabase_realtime_<ref>`, so this does not introduce slot drift.

## Contract

- Goal: make tenant capacity and connection settings deterministic across all write paths.
- Non-goals: no database schema migration, no runtime deployment, no Realtime GET response rewriting.
- Acceptance: one shared builder, identical register/update payloads, reconcile uses the builder only, and capacity/publication/slot fields are covered by tests.
- Rollback: revert commit `626db8e6`; no data migration is required. Existing Realtime tenant state remains unchanged until a write/reconcile is explicitly run.

## Verification

- `bun test tests/unit/realtime.service.test.ts` — 8 passed, 0 failed
- `bun run typecheck` — passed
- `bun run test:unit` — passed (136 files; 0 failures)
- `git diff --check` — passed
- Existing v2.121.0 upgrade canary evidence: Realtime health/db/replication healthy, strict compatibility 26/26, JSON/binary broadcast 202/202, restart count 0. The v2.121.1 image rollout remains a separate deployment gate.

## Deployment

Not deployed by this PR.