### PR TITLE
fix(observability): expand VictoriaLogs systemd env

### DIFF
--- a/infrastructure/systemd/supacloud-victorialogs.service
+++ b/infrastructure/systemd/supacloud-victorialogs.service
@@ -5,9 +5,12 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=VICTORIALOGS_BINARY=/usr/local/bin/victoria-logs-prod
+Environment=VICTORIALOGS_DATA_DIR=/var/lib/supacloud/victorialogs
+Environment=VICTORIALOGS_RETENTION=7d
 EnvironmentFile=-/etc/supabase/victorialogs.env
-ExecStartPre=/usr/bin/test -x ${VICTORIALOGS_BINARY}
-ExecStart=${VICTORIALOGS_BINARY} -storageDataPath=${VICTORIALOGS_DATA_DIR} -retentionPeriod=${VICTORIALOGS_RETENTION} -httpListenAddr=127.0.0.1:9428
+ExecStartPre=/bin/sh -ec 'test -x "$${VICTORIALOGS_BINARY}"'
+ExecStart=/bin/sh -ec 'exec "$${VICTORIALOGS_BINARY}" "-storageDataPath=$${VICTORIALOGS_DATA_DIR}" "-retentionPeriod=$${VICTORIALOGS_RETENTION}" -httpListenAddr=127.0.0.1:9428'
 Restart=on-failure
 RestartSec=5
 NoNewPrivileges=true

--- a/packages/management-api/tests/unit/observability-install.test.ts
+++ b/packages/management-api/tests/unit/observability-install.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const repoRoot = join(import.meta.dir, "../../../..");
@@ -28,7 +29,16 @@ test("observability uses one native service and the embedded collector, without 
   const installer = readRepoFile("install.sh");
 
   expect(victoriaLogsUnit).toContain("-httpListenAddr=127.0.0.1:9428");
-  expect(victoriaLogsUnit).toContain("ExecStart=${VICTORIALOGS_BINARY}");
+  expect(victoriaLogsUnit).not.toContain("ExecStart=${VICTORIALOGS_BINARY}");
+  expect(victoriaLogsUnit).not.toContain("ExecStartPre=/usr/bin/test -x ${VICTORIALOGS_BINARY}");
+  expect(victoriaLogsUnit).not.toMatch(/^ExecStart(?:Pre)?=\$\{/m);
+  expect(victoriaLogsUnit).toContain("Environment=VICTORIALOGS_BINARY=/usr/local/bin/victoria-logs-prod");
+  expect(victoriaLogsUnit).toContain("Environment=VICTORIALOGS_DATA_DIR=/var/lib/supacloud/victorialogs");
+  expect(victoriaLogsUnit).toContain("Environment=VICTORIALOGS_RETENTION=7d");
+  expect(victoriaLogsUnit).toContain('ExecStartPre=/bin/sh -ec \'test -x "$${VICTORIALOGS_BINARY}"\'');
+  expect(victoriaLogsUnit).toContain('exec "$${VICTORIALOGS_BINARY}"');
+  expect(victoriaLogsUnit).toContain('"-storageDataPath=$${VICTORIALOGS_DATA_DIR}"');
+  expect(victoriaLogsUnit).toContain('"-retentionPeriod=$${VICTORIALOGS_RETENTION}"');
   expect(victoriaLogsUnit).not.toContain("podman");
   expect(victoriaLogsUnit).not.toContain("GRAFANA");
   expect(victoriaLogsUnit).not.toContain("POSTGRES");
@@ -39,4 +49,33 @@ test("observability uses one native service and the embedded collector, without 
   expect(installer).toContain("install_victorialogs_binary");
   expect(installer).toContain("supacloud-vector.service");
   expect(installer).toContain("systemctl disable --now supacloud-vector");
+});
+
+test("VictoriaLogs systemd wrapper honors EnvironmentFile overrides", () => {
+  const victoriaLogsUnit = readRepoFile("infrastructure/systemd/supacloud-victorialogs.service");
+  const shellCommand = victoriaLogsUnit.match(/^ExecStart=\/bin\/sh -ec '(.*)'$/m)?.[1];
+  expect(shellCommand).toBeDefined();
+
+  const runtimeDir = mkdtempSync(join(tmpdir(), "supacloud-victorialogs-unit-"));
+  const fakeBinary = join(runtimeDir, "victoria logs prod");
+  writeFileSync(fakeBinary, '#!/bin/sh\nprintf \'<%s>\\n\' "$@"\n');
+  chmodSync(fakeBinary, 0o755);
+
+  try {
+    const execution = Bun.spawnSync({
+      cmd: ["/bin/sh", "-ec", shellCommand!.replaceAll("$$", "$")],
+      env: {
+        VICTORIALOGS_BINARY: fakeBinary,
+        VICTORIALOGS_DATA_DIR: "/srv/victoria logs",
+        VICTORIALOGS_RETENTION: "30d",
+      },
+      stdout: "pipe",
+    });
+    expect(execution.exitCode).toBe(0);
+    expect(execution.stdout.toString()).toBe(
+      "<-storageDataPath=/srv/victoria logs>\n<-retentionPeriod=30d>\n<-httpListenAddr=127.0.0.1:9428>\n",
+    );
+  } finally {
+    rmSync(runtimeDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- provide VictoriaLogs binary, data directory, and retention defaults with systemd `Environment=` entries
- execute through a fixed `/bin/sh` wrapper so `EnvironmentFile` overrides are expanded safely
- cover default values, invalid literal executable tokens, and quoted override arguments

## Production evidence
The previous unit attempted to execute the literal `${VICTORIALOGS_BINARY}` token and failed with systemd status `203/EXEC`. The failed installation was rolled back before this PR; this PR does not deploy anything.

## Verification
- `bun test tests/unit/observability-install.test.ts`
- `bun run typecheck`
- `systemd-analyze verify infrastructure/systemd/supacloud-victorialogs.service` (Ubuntu 24.04 container)
- `git diff --check`

## Scope
Only the VictoriaLogs systemd unit and its existing observability contract test are changed.