### PR TITLE
fix(management-api): validate project database settings

### DIFF
--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -56,6 +56,16 @@ import {
   canonicalizeAuthUrlConfig,
 } from "../utils/auth-url-config";
 import { safeProjectSettingsAuthConfig } from "./auth";
+import {
+  DatabaseConfigValidationError,
+  type DatabaseSettingsUpdateResult,
+  type LiveDatabaseSetting,
+  liveSettingNumber,
+  parseDatabaseConfigPatch,
+  quoteDatabaseIdentifier,
+  readLiveDatabaseSettings,
+  updateDatabaseSettings,
+} from "../services/project-database-config.service";
 
 /** Map PostgreSQL column types to TypeScript types */
 function pgTypeToTs(udtName: string, dataType: string): string {
@@ -156,6 +166,56 @@ function addConfigRoutes(section: string) {
 
 function cloneTemplate<T>(template: T): T {
   return structuredClone(template);
+}
+
+function buildDatabaseConfigResponse(
+  projectRef: string,
+  databaseName: string,
+  metadata: Record<string, unknown>,
+  settings: LiveDatabaseSetting[],
+) {
+  return {
+    pgbouncer_enabled: metadata.pgbouncer_enabled ?? false,
+    pgbouncer_settings: metadata.pgbouncer_settings || {},
+    connection_string: `postgresql://${resolveRoleName(projectRef)}:[YOUR-PASSWORD]@localhost:5432/${databaseName}`,
+    max_connections: liveSettingNumber(settings, "max_connections"),
+    statement_timeout: liveSettingNumber(settings, "statement_timeout"),
+    idle_in_transaction_session_timeout: liveSettingNumber(
+      settings,
+      "idle_in_transaction_session_timeout",
+    ),
+    settings,
+  };
+}
+
+function databaseUpdateFailureBody(
+  update: Extract<DatabaseSettingsUpdateResult<unknown>, { ok: false }>,
+) {
+  const applyFailed = update.stage === "apply";
+  return {
+    code: applyFailed
+      ? "DATABASE_SETTINGS_APPLY_FAILED"
+      : "DATABASE_SETTINGS_PERSIST_FAILED",
+    message: applyFailed
+      ? "Failed to apply database settings; persisted configuration was not changed"
+      : update.restoreAttempted
+        ? "Database settings were applied but configuration persistence failed; restoration was attempted"
+        : "Failed to persist database configuration",
+    rollback: {
+      attempted: update.restoreAttempted,
+      succeeded: update.restoreAttempted
+        ? update.restoreFailures.length === 0
+        : null,
+      failed_settings: update.restoreFailures.map((failure) => failure.name),
+    },
+  };
+}
+
+async function projectDatabaseConnection(projectRef: string) {
+  const { getProjectDb, resolveDbName } = await import("../db");
+  const databaseName = await resolveDbName(projectRef);
+  quoteDatabaseIdentifier(databaseName);
+  return { databaseName, database: getProjectDb(databaseName) };
 }
 
 const CustomGatewayHostsSchema = t.Array(t.String(), {
@@ -1204,43 +1264,34 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   .get(
     "/:ref/config/database",
     async ({ params }) => {
-      const settings = await projectService.getProjectSettings(params.ref);
-      if (!settings)
+      const projectSettings = await projectService.getProjectSettings(params.ref);
+      if (!projectSettings)
         return status(404, { message: "Project not found", code: "404" });
-      const dbSettings = (settings as Record<string, unknown>).database || {};
+      const databaseMetadata =
+        ((projectSettings as Record<string, unknown>).database as Record<
+          string,
+          unknown
+        >) || {};
       try {
-        const { getProjectDb, resolveDbName } = await import("../db");
-        const dbName = await resolveDbName(params.ref);
-        const db = getProjectDb(dbName);
-        const rows = await db`
-            SELECT name, setting FROM pg_settings
-            WHERE name IN ('max_connections', 'statement_timeout', 'idle_in_transaction_session_timeout')
-        `;
-        const pgMap: Record<string, string> = {};
-        for (const row of rows) {
-          pgMap[row.name] = row.setting;
-        }
-        return {
-          pgbouncer_enabled:
-            (dbSettings as Record<string, unknown>).pgbouncer_enabled ?? false,
-          pgbouncer_settings:
-            (dbSettings as Record<string, unknown>).pgbouncer_settings || {},
-          connection_string: `postgresql://${resolveRoleName(params.ref)}:[YOUR-PASSWORD]@localhost:5432/${dbName}`,
-          max_connections: parseInt(pgMap.max_connections || "100"),
-          statement_timeout: parseInt(pgMap.statement_timeout || "0"),
-          idle_in_transaction_session_timeout: parseInt(
-            pgMap.idle_in_transaction_session_timeout || "0",
-          ),
-        };
-      } catch {
-        return {
-          pgbouncer_enabled: false,
-          pgbouncer_settings: {},
-          connection_string: `postgresql://${resolveRoleName(params.ref)}:[YOUR-PASSWORD]@localhost:5432/postgres`,
-          max_connections: 100,
-          statement_timeout: 0,
-          idle_in_transaction_session_timeout: 0,
-        };
+        const { database, databaseName } = await projectDatabaseConnection(
+          params.ref,
+        );
+        const liveSettings = await readLiveDatabaseSettings(database);
+        return buildDatabaseConfigResponse(
+          params.ref,
+          databaseName,
+          databaseMetadata,
+          liveSettings,
+        );
+      } catch (error: unknown) {
+        logger.warn("[project-config] Failed to read live database settings", {
+          errorType: error instanceof Error ? error.name : typeof error,
+          projectRef: params.ref,
+        });
+        return status(503, {
+          message: "Failed to read live database settings",
+          code: "DATABASE_SETTINGS_READ_FAILED",
+        });
       }
     },
     {
@@ -1364,68 +1415,93 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
-      const settings = await projectService.getProjectSettings(params.ref);
-      if (!settings)
+
+      let patch;
+      try {
+        patch = parseDatabaseConfigPatch(body);
+      } catch (error: unknown) {
+        if (error instanceof DatabaseConfigValidationError) {
+          return status(400, { code: error.code, message: error.message });
+        }
+        throw error;
+      }
+
+      const projectSettings = await projectService.getProjectSettings(params.ref);
+      if (!projectSettings)
         return status(404, { message: "Project not found", code: "404" });
       const current =
-        ((settings as Record<string, unknown>).database as Record<
+        ((projectSettings as Record<string, unknown>).database as Record<
           string,
           unknown
         >) || {};
-      const merged = { ...current, ...(typeof body === "object" ? body : {}) };
-      const updated = await projectService.updateProjectSettings(params.ref, {
-        ...settings,
-        database: merged,
+      let databaseConnection;
+      try {
+        databaseConnection = await projectDatabaseConnection(params.ref);
+      } catch (error: unknown) {
+        logger.warn("[project-config] Failed to resolve project database", {
+          errorType: error instanceof Error ? error.name : typeof error,
+          projectRef: params.ref,
+        });
+        return status(503, {
+          code: "DATABASE_SETTINGS_APPLY_FAILED",
+          message: "Failed to resolve the project database; persisted configuration was not changed",
+          rollback: { attempted: false, succeeded: null, failed_settings: [] },
+        });
+      }
+      const { database, databaseName } = databaseConnection;
+      const update = await updateDatabaseSettings({
+        database,
+        databaseName,
+        patch,
+        persist: async () => {
+          const persisted = await projectService.updateProjectSettings(params.ref, {
+            ...projectSettings,
+            database: { ...current, ...patch },
+          });
+          if (!persisted) throw new Error("Project settings update returned no result");
+          return persisted;
+        },
       });
 
-      try {
-        const { getProjectDb, resolveDbName } = await import("../db");
-        const dbName = await resolveDbName(params.ref);
-        const db = getProjectDb(dbName);
-        if (merged.statement_timeout !== undefined) {
-          await db.unsafe(
-            `ALTER DATABASE "${dbName}" SET statement_timeout = '${merged.statement_timeout}'`,
-          );
-        }
-        if (merged.max_connections !== undefined) {
-          await db.unsafe(
-            `ALTER DATABASE "${dbName}" SET max_connections = '${merged.max_connections}'`,
-          );
-        }
-      } catch (err) {
-        logger.warn(
-          "[project-config] Failed to apply database config to PostgreSQL",
-          { error: err },
+      if (!update.ok) {
+        logger.warn(`[project-config] Database settings ${update.stage} failed`, {
+          errorType: update.error instanceof Error
+            ? update.error.name
+            : typeof update.error,
+          projectRef: params.ref,
+          restoreFailedSettings: update.restoreFailures.map(
+            (failure) => failure.name,
+          ),
+        });
+        return status(
+          update.stage === "apply" ? 503 : 500,
+          databaseUpdateFailureBody(update),
         );
       }
 
       try {
-        const { tenantRuntimeService } =
-          await import("../services/tenant-runtime.service");
-        await tenantRuntimeService.restartRuntime(params.ref);
-      } catch (err) {
-        logger.warn(
-          "[project-config] Failed to propagate database config to runtime",
-          { error: err },
+        const liveSettings = await readLiveDatabaseSettings(database);
+        const persistedDatabase =
+          ((update.persisted as Record<string, unknown>).database as Record<
+            string,
+            unknown
+          >) || { ...current, ...patch };
+        return buildDatabaseConfigResponse(
+          params.ref,
+          databaseName,
+          persistedDatabase,
+          liveSettings,
         );
+      } catch (error: unknown) {
+        logger.warn("[project-config] Failed to read applied database settings", {
+          errorType: error instanceof Error ? error.name : typeof error,
+          projectRef: params.ref,
+        });
+        return status(503, {
+          message: "Database settings were updated but the live read-back failed",
+          code: "DATABASE_SETTINGS_READ_FAILED",
+        });
       }
-
-      const raw =
-        ((updated as Record<string, unknown>).database as Record<
-          string,
-          unknown
-        >) || {};
-      return {
-        pgbouncer_enabled: raw.pgbouncer_enabled ?? false,
-        pgbouncer_settings: raw.pgbouncer_settings || {},
-        connection_string:
-          raw.connection_string ||
-          `postgresql://${resolveRoleName(params.ref)}:[YOUR-PASSWORD]@localhost:5432/${await resolveDbNameTopLevel(params.ref)}`,
-        max_connections: raw.max_connections ?? 100,
-        statement_timeout: raw.statement_timeout ?? 0,
-        idle_in_transaction_session_timeout:
-          raw.idle_in_transaction_session_timeout ?? 0,
-      };
     },
     {
       params: t.Object({ ref: t.String() }),

--- a/packages/management-api/src/services/project-database-config.service.ts
+++ b/packages/management-api/src/services/project-database-config.service.ts
@@ -1,0 +1,396 @@
+const MAX_POSTGRES_TIMEOUT = 2_147_483_647;
+const DATABASE_IDENTIFIER_PATTERN = /^[A-Za-z0-9_][A-Za-z0-9_-]*$/;
+const DATABASE_METADATA_SETTINGS = new Set([
+  "pgbouncer_enabled",
+  "pgbouncer_settings",
+]);
+
+export const MUTABLE_DATABASE_SETTINGS = [
+  "statement_timeout",
+  "idle_in_transaction_session_timeout",
+] as const;
+
+export type MutableDatabaseSetting = (typeof MUTABLE_DATABASE_SETTINGS)[number];
+export interface DatabaseConfigPatch
+  extends Partial<Record<MutableDatabaseSetting, number>> {
+  pgbouncer_enabled?: boolean;
+  pgbouncer_settings?: Record<string, unknown>;
+}
+
+export interface LiveDatabaseSetting {
+  name: string;
+  setting: string;
+  unit: string | null;
+  context: string;
+  pending_restart: boolean;
+}
+
+interface DatabaseExecutor {
+  unsafe(query: string): PromiseLike<unknown>;
+}
+
+interface DatabaseSettingOverride {
+  name: MutableDatabaseSetting;
+  setting: string;
+}
+
+type PreviousDatabaseSettings = Record<MutableDatabaseSetting, string | null>;
+
+interface DatabaseSettingsUpdate<T> {
+  database: DatabaseExecutor;
+  databaseName: string;
+  patch: DatabaseConfigPatch;
+  persist: () => Promise<T>;
+}
+
+interface DatabaseSettingRestoreFailure {
+  name: MutableDatabaseSetting;
+  error: unknown;
+}
+
+interface PreparedDatabaseSettings {
+  previousSettings: PreviousDatabaseSettings;
+  settingNames: MutableDatabaseSetting[];
+}
+
+export type DatabaseSettingsUpdateResult<T> =
+  | { ok: true; persisted: T }
+  | {
+      ok: false;
+      stage: "apply" | "persist";
+      error: unknown;
+      restoreAttempted: boolean;
+      restoreFailures: DatabaseSettingRestoreFailure[];
+    };
+
+export class DatabaseConfigValidationError extends Error {
+  constructor(
+    public readonly code: "INVALID_SETTING_SCOPE" | "INVALID_DATABASE_SETTING",
+    message: string,
+  ) {
+    super(message);
+    this.name = "DatabaseConfigValidationError";
+  }
+}
+
+function hasOwn(input: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(input, key);
+}
+
+function parseTimeout(name: string, input: unknown): number {
+  // 边界：接受 0 和 int32 最大值；拒绝负数、越界、非整数和非纯数字字符串。
+  const parsed = typeof input === "string" && /^\d+$/.test(input)
+    ? Number(input)
+    : input;
+  if (
+    typeof parsed !== "number"
+    || !Number.isInteger(parsed)
+    || parsed < 0
+    || parsed > MAX_POSTGRES_TIMEOUT
+  ) {
+    throw new DatabaseConfigValidationError(
+      "INVALID_DATABASE_SETTING",
+      `${name} must be an integer between 0 and ${MAX_POSTGRES_TIMEOUT}`,
+    );
+  }
+  return parsed;
+}
+
+function assertSupportedPatchKeys(body: Record<string, unknown>): void {
+  const settingNames = Object.keys(body);
+  const unknownSetting = settingNames.find(
+    (name) =>
+      !MUTABLE_DATABASE_SETTINGS.includes(name as MutableDatabaseSetting)
+      && !DATABASE_METADATA_SETTINGS.has(name),
+  );
+  if (!unknownSetting && settingNames.length > 0) return;
+  throw new DatabaseConfigValidationError(
+    "INVALID_DATABASE_SETTING",
+    unknownSetting
+      ? `Unsupported database setting: ${unknownSetting}`
+      : "At least one supported database setting is required",
+  );
+}
+
+function pgbouncerEnabledPatch(
+  body: Record<string, unknown>,
+): Pick<DatabaseConfigPatch, "pgbouncer_enabled"> {
+  if (!hasOwn(body, "pgbouncer_enabled")) return {};
+  if (typeof body.pgbouncer_enabled !== "boolean") {
+    throw new DatabaseConfigValidationError(
+      "INVALID_DATABASE_SETTING",
+      "pgbouncer_enabled must be a boolean",
+    );
+  }
+  return { pgbouncer_enabled: body.pgbouncer_enabled };
+}
+
+function pgbouncerSettingsPatch(
+  body: Record<string, unknown>,
+): Pick<DatabaseConfigPatch, "pgbouncer_settings"> {
+  if (!hasOwn(body, "pgbouncer_settings")) return {};
+  const settings = body.pgbouncer_settings;
+  if (typeof settings !== "object" || settings === null || Array.isArray(settings)) {
+    throw new DatabaseConfigValidationError(
+      "INVALID_DATABASE_SETTING",
+      "pgbouncer_settings must be an object",
+    );
+  }
+  return { pgbouncer_settings: settings as Record<string, unknown> };
+}
+
+export function parseDatabaseConfigPatch(
+  body: Record<string, unknown>,
+): DatabaseConfigPatch {
+  if (hasOwn(body, "max_connections")) {
+    throw new DatabaseConfigValidationError(
+      "INVALID_SETTING_SCOPE",
+      "max_connections is an instance-level setting and cannot be changed per project",
+    );
+  }
+  assertSupportedPatchKeys(body);
+  const patch: DatabaseConfigPatch = {
+    ...pgbouncerEnabledPatch(body),
+    ...pgbouncerSettingsPatch(body),
+  };
+  for (const name of MUTABLE_DATABASE_SETTINGS) {
+    if (hasOwn(body, name)) patch[name] = parseTimeout(name, body[name]);
+  }
+  return patch;
+}
+
+export function quoteDatabaseIdentifier(databaseName: string): string {
+  if (
+    !DATABASE_IDENTIFIER_PATTERN.test(databaseName)
+    || Buffer.byteLength(databaseName, "utf8") > 63
+  ) {
+    throw new Error("Invalid PostgreSQL database identifier");
+  }
+  return `"${databaseName}"`;
+}
+
+function rowsFromQuery(queryResult: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(queryResult)) {
+    throw new Error("PostgreSQL settings query returned an invalid result");
+  }
+  return queryResult as Record<string, unknown>[];
+}
+
+function liveSettingFromRow(row: Record<string, unknown>): LiveDatabaseSetting {
+  if (
+    typeof row.name !== "string"
+    || typeof row.setting !== "string"
+    || typeof row.context !== "string"
+    || typeof row.pending_restart !== "boolean"
+  ) {
+    throw new Error("PostgreSQL settings query returned an invalid row");
+  }
+  return {
+    name: row.name,
+    setting: row.setting,
+    unit: typeof row.unit === "string" ? row.unit : null,
+    context: row.context,
+    pending_restart: row.pending_restart,
+  };
+}
+
+export async function readLiveDatabaseSettings(
+  database: DatabaseExecutor,
+): Promise<LiveDatabaseSetting[]> {
+  const queryResult = await database.unsafe(`
+    SELECT name, setting, unit, context, pending_restart
+    FROM pg_settings
+    WHERE name IN ('max_connections', 'statement_timeout', 'idle_in_transaction_session_timeout')
+    ORDER BY name
+  `);
+  return rowsFromQuery(queryResult).map(liveSettingFromRow);
+}
+
+export function liveSettingNumber(
+  settings: LiveDatabaseSetting[],
+  name: string,
+): number | null {
+  const setting = settings.find((candidate) => candidate.name === name)?.setting;
+  if (setting === undefined) return null;
+  const numericSetting = Number(setting);
+  return Number.isFinite(numericSetting) ? numericSetting : null;
+}
+
+function emptyPreviousSettings(): PreviousDatabaseSettings {
+  return {
+    statement_timeout: null,
+    idle_in_transaction_session_timeout: null,
+  };
+}
+
+function settingOverrideFromRow(
+  row: Record<string, unknown>,
+): DatabaseSettingOverride | null {
+  if (
+    !MUTABLE_DATABASE_SETTINGS.includes(row.name as MutableDatabaseSetting)
+    || typeof row.setting !== "string"
+  ) return null;
+  return {
+    name: row.name as MutableDatabaseSetting,
+    setting: row.setting,
+  };
+}
+
+async function readDatabaseSettingOverrides(
+  database: DatabaseExecutor,
+): Promise<PreviousDatabaseSettings> {
+  const queryResult = await database.unsafe(`
+    SELECT split_part(entry, '=', 1) AS name,
+           substr(entry, strpos(entry, '=') + 1) AS setting
+    FROM pg_db_role_setting
+    CROSS JOIN LATERAL unnest(setconfig) AS entry
+    WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname = current_database())
+      AND setrole = 0
+      AND split_part(entry, '=', 1) IN ('statement_timeout', 'idle_in_transaction_session_timeout')
+  `);
+  const previousSettings = emptyPreviousSettings();
+  for (const row of rowsFromQuery(queryResult)) {
+    const settingOverride = settingOverrideFromRow(row);
+    if (settingOverride) previousSettings[settingOverride.name] = settingOverride.setting;
+  }
+  return previousSettings;
+}
+
+function requestedSettingNames(patch: DatabaseConfigPatch): MutableDatabaseSetting[] {
+  return MUTABLE_DATABASE_SETTINGS.filter((name) => patch[name] !== undefined);
+}
+
+function quoteSettingLiteral(setting: string): string {
+  return `'${setting.replaceAll("'", "''")}'`;
+}
+
+function restoreStatement(
+  databaseName: string,
+  name: MutableDatabaseSetting,
+  previousSetting: string | null,
+): string {
+  const target = `ALTER DATABASE ${quoteDatabaseIdentifier(databaseName)}`;
+  return previousSetting === null
+    ? `${target} RESET ${name}`
+    : `${target} SET ${name} = ${quoteSettingLiteral(previousSetting)}`;
+}
+
+async function restoreDatabaseSettings(
+  database: DatabaseExecutor,
+  databaseName: string,
+  previousSettings: PreviousDatabaseSettings,
+  names: MutableDatabaseSetting[],
+): Promise<DatabaseSettingRestoreFailure[]> {
+  const failures: DatabaseSettingRestoreFailure[] = [];
+  for (const name of names) {
+    try {
+      await database.unsafe(restoreStatement(databaseName, name, previousSettings[name]));
+    } catch (error: unknown) {
+      failures.push({ name, error });
+    }
+  }
+  return failures;
+}
+
+async function applyRequestedSettings(
+  database: DatabaseExecutor,
+  databaseName: string,
+  patch: DatabaseConfigPatch,
+  previousSettings: PreviousDatabaseSettings,
+): Promise<
+  Extract<DatabaseSettingsUpdateResult<never>, { ok: false }> | null
+> {
+  const appliedNames: MutableDatabaseSetting[] = [];
+  for (const name of requestedSettingNames(patch)) {
+    try {
+      await database.unsafe(
+        `ALTER DATABASE ${quoteDatabaseIdentifier(databaseName)} SET ${name} = ${patch[name]}`,
+      );
+      appliedNames.push(name);
+    } catch (error: unknown) {
+      const restoreNames = [...appliedNames, name];
+      const restoreFailures = await restoreDatabaseSettings(
+        database,
+        databaseName,
+        previousSettings,
+        restoreNames,
+      );
+      return {
+        ok: false,
+        stage: "apply",
+        error,
+        restoreAttempted: true,
+        restoreFailures,
+      };
+    }
+  }
+  return null;
+}
+
+async function prepareDatabaseSettings(
+  input: DatabaseSettingsUpdate<unknown>,
+): Promise<
+  | { ok: true; prepared: PreparedDatabaseSettings }
+  | Extract<DatabaseSettingsUpdateResult<never>, { ok: false }>
+> {
+  const settingNames = requestedSettingNames(input.patch);
+  if (settingNames.length === 0) {
+    return {
+      ok: true,
+      prepared: { previousSettings: emptyPreviousSettings(), settingNames },
+    };
+  }
+  try {
+    quoteDatabaseIdentifier(input.databaseName);
+    const previousSettings = await readDatabaseSettingOverrides(input.database);
+    const applyFailure = await applyRequestedSettings(
+      input.database,
+      input.databaseName,
+      input.patch,
+      previousSettings,
+    );
+    return applyFailure || {
+      ok: true,
+      prepared: { previousSettings, settingNames },
+    };
+  } catch (error: unknown) {
+    return {
+      ok: false,
+      stage: "apply",
+      error,
+      restoreAttempted: false,
+      restoreFailures: [],
+    };
+  }
+}
+
+async function persistDatabaseSettings<T>(
+  input: DatabaseSettingsUpdate<T>,
+  prepared: PreparedDatabaseSettings,
+): Promise<DatabaseSettingsUpdateResult<T>> {
+  try {
+    return { ok: true, persisted: await input.persist() };
+  } catch (error: unknown) {
+    const restoreFailures = await restoreDatabaseSettings(
+      input.database,
+      input.databaseName,
+      prepared.previousSettings,
+      prepared.settingNames,
+    );
+    return {
+      ok: false,
+      stage: "persist",
+      error,
+      restoreAttempted: prepared.settingNames.length > 0,
+      restoreFailures,
+    };
+  }
+}
+
+export async function updateDatabaseSettings<T>(
+  input: DatabaseSettingsUpdate<T>,
+): Promise<DatabaseSettingsUpdateResult<T>> {
+  const preparation = await prepareDatabaseSettings(input);
+  if (!preparation.ok) return preparation;
+  return persistDatabaseSettings(input, preparation.prepared);
+}

--- a/packages/management-api/tests/unit/project-database-config.routes.test.ts
+++ b/packages/management-api/tests/unit/project-database-config.routes.test.ts
@@ -1,0 +1,248 @@
+// @supacloud-test-isolate
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const authModule = await import("../../src/middleware/auth");
+const databaseModule = await import("../../src/db");
+const servicesModule = await import("../../src/services");
+
+const requireProjectOrAdminAuth = mock(async () => null);
+const getProjectSettings = mock(async () => ({ database: {} }));
+const updateProjectSettings = mock(async (_ref: string, settings: unknown) => settings);
+const databaseUnsafe = mock(async (_query: string) => [] as Record<string, unknown>[]);
+
+const authSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const resolveDbNameSpy = spyOn(databaseModule, "resolveDbName").mockResolvedValue(
+  "supa_proj_1",
+);
+const getProjectDbSpy = spyOn(databaseModule, "getProjectDb").mockImplementation(
+  () => ({ unsafe: databaseUnsafe }) as never,
+);
+const getProjectSettingsSpy = spyOn(
+  servicesModule.projectService,
+  "getProjectSettings",
+).mockImplementation(
+  getProjectSettings as typeof servicesModule.projectService.getProjectSettings,
+);
+const updateProjectSettingsSpy = spyOn(
+  servicesModule.projectService,
+  "updateProjectSettings",
+).mockImplementation(
+  updateProjectSettings as typeof servicesModule.projectService.updateProjectSettings,
+);
+
+const { projectConfigRoutes } = await import(
+  "../../src/routes/project-config?project-database-config-routes-test"
+);
+const app = new Elysia().use(projectConfigRoutes);
+
+function request(method: "GET" | "PATCH", body?: Record<string, unknown>) {
+  return app.handle(new Request(
+    "http://localhost/v1/projects/proj_1/config/database",
+    {
+      method,
+      headers: {
+        authorization: "Bearer dev-master-token",
+        "content-type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    },
+  ));
+}
+
+function liveSettings() {
+  return [
+    {
+      name: "idle_in_transaction_session_timeout",
+      setting: "5000",
+      unit: "ms",
+      context: "user",
+      pending_restart: false,
+    },
+    {
+      name: "max_connections",
+      setting: "100",
+      unit: null,
+      context: "postmaster",
+      pending_restart: false,
+    },
+    {
+      name: "statement_timeout",
+      setting: "2500",
+      unit: "ms",
+      context: "user",
+      pending_restart: false,
+    },
+  ];
+}
+
+afterAll(() => {
+  authSpy.mockRestore();
+  resolveDbNameSpy.mockRestore();
+  getProjectDbSpy.mockRestore();
+  getProjectSettingsSpy.mockRestore();
+  updateProjectSettingsSpy.mockRestore();
+});
+
+beforeEach(() => {
+  requireProjectOrAdminAuth.mockReset();
+  requireProjectOrAdminAuth.mockResolvedValue(null);
+  getProjectSettings.mockReset();
+  getProjectSettings.mockResolvedValue({
+    database: {
+      pgbouncer_enabled: true,
+      pgbouncer_settings: { pool_mode: "transaction" },
+    },
+  } as never);
+  updateProjectSettings.mockReset();
+  updateProjectSettings.mockImplementation(async (_ref, settings) => settings as never);
+  databaseUnsafe.mockReset();
+  databaseUnsafe.mockResolvedValue([]);
+});
+
+describe("project database config routes", () => {
+  test("GET returns live settings metadata and legacy flat fields", async () => {
+    databaseUnsafe.mockResolvedValue(liveSettings());
+
+    const response = await request("GET");
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(responseBody).toMatchObject({
+      max_connections: 100,
+      statement_timeout: 2500,
+      idle_in_transaction_session_timeout: 5000,
+      pgbouncer_enabled: true,
+      settings: liveSettings(),
+    });
+  });
+
+  test("GET reports database read failures instead of fabricated defaults", async () => {
+    databaseUnsafe.mockRejectedValue(new Error("database unavailable"));
+
+    const response = await request("GET");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      message: "Failed to read live database settings",
+      code: "DATABASE_SETTINGS_READ_FAILED",
+    });
+  });
+
+  test("PATCH rejects max_connections with zero project or database side effects", async () => {
+    const response = await request("PATCH", { max_connections: 200 });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      code: "INVALID_SETTING_SCOPE",
+    });
+    expect(getProjectSettings).not.toHaveBeenCalled();
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+    expect(databaseUnsafe).not.toHaveBeenCalled();
+  });
+
+  test("PATCH applies only requested settings before persisting metadata", async () => {
+    const events: string[] = [];
+    databaseUnsafe.mockImplementation(async (query) => {
+      if (query.includes("pg_db_role_setting")) return [];
+      if (query.includes("ALTER DATABASE")) {
+        events.push(query);
+        return [];
+      }
+      return liveSettings();
+    });
+    updateProjectSettings.mockImplementation(async (_ref, settings) => {
+      events.push("persist");
+      return settings as never;
+    });
+
+    const response = await request("PATCH", { statement_timeout: "2500" });
+
+    expect(response.status).toBe(200);
+    expect(events).toEqual([
+      'ALTER DATABASE "supa_proj_1" SET statement_timeout = 2500',
+      "persist",
+    ]);
+    expect(updateProjectSettings).toHaveBeenCalledWith(
+      "proj_1",
+      expect.objectContaining({
+        database: expect.objectContaining({ statement_timeout: 2500 }),
+      }),
+    );
+  });
+
+  test("PATCH keeps PgBouncer metadata compatible without ALTER DATABASE", async () => {
+    const response = await request("PATCH", {
+      pgbouncer_enabled: false,
+      pgbouncer_settings: { pool_mode: "session" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(databaseUnsafe).toHaveBeenCalledTimes(1);
+    expect(databaseUnsafe.mock.calls[0]?.[0]).toContain("FROM pg_settings");
+    expect(updateProjectSettings).toHaveBeenCalledWith(
+      "proj_1",
+      expect.objectContaining({
+        database: expect.objectContaining({
+          pgbouncer_enabled: false,
+          pgbouncer_settings: { pool_mode: "session" },
+        }),
+      }),
+    );
+  });
+
+  test("PATCH returns 503 and does not persist when PostgreSQL apply fails", async () => {
+    databaseUnsafe.mockImplementation(async (query) => {
+      if (query.includes("pg_db_role_setting")) return [];
+      throw new Error("database rejected setting");
+    });
+
+    const response = await request("PATCH", { statement_timeout: 2500 });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      code: "DATABASE_SETTINGS_APPLY_FAILED",
+    });
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+  });
+
+  test("PATCH maps project database resolution failures to apply failure", async () => {
+    resolveDbNameSpy.mockRejectedValueOnce(new Error("control database unavailable"));
+
+    const response = await request("PATCH", { statement_timeout: 2500 });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      code: "DATABASE_SETTINGS_APPLY_FAILED",
+      rollback: { attempted: false, succeeded: null },
+    });
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+    expect(databaseUnsafe).not.toHaveBeenCalled();
+  });
+
+  test("PATCH returns 500 and restores the prior override when persistence fails", async () => {
+    const statements: string[] = [];
+    databaseUnsafe.mockImplementation(async (query) => {
+      if (query.includes("pg_db_role_setting")) {
+        return [{ name: "statement_timeout", setting: "2s" }];
+      }
+      statements.push(query);
+      return [];
+    });
+    updateProjectSettings.mockRejectedValue(new Error("metadata unavailable"));
+
+    const response = await request("PATCH", { statement_timeout: 2500 });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      code: "DATABASE_SETTINGS_PERSIST_FAILED",
+      rollback: { attempted: true, succeeded: true, failed_settings: [] },
+    });
+    expect(statements).toEqual([
+      'ALTER DATABASE "supa_proj_1" SET statement_timeout = 2500',
+      'ALTER DATABASE "supa_proj_1" SET statement_timeout = \'2s\'',
+    ]);
+  });
+});

--- a/packages/management-api/tests/unit/project-database-config.service.test.ts
+++ b/packages/management-api/tests/unit/project-database-config.service.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  DatabaseConfigValidationError,
+  liveSettingNumber,
+  parseDatabaseConfigPatch,
+  quoteDatabaseIdentifier,
+  readLiveDatabaseSettings,
+  updateDatabaseSettings,
+} from "../../src/services/project-database-config.service";
+
+describe("project database config validation", () => {
+  test("accepts timeout boundaries and pure numeric strings", () => {
+    expect(parseDatabaseConfigPatch({
+      statement_timeout: "0",
+      idle_in_transaction_session_timeout: 2_147_483_647,
+    })).toEqual({
+      statement_timeout: 0,
+      idle_in_transaction_session_timeout: 2_147_483_647,
+    });
+  });
+
+  test("preserves typed PgBouncer metadata without treating it as SQL", () => {
+    expect(parseDatabaseConfigPatch({
+      pgbouncer_enabled: true,
+      pgbouncer_settings: { pool_mode: "transaction", default_pool_size: 15 },
+    })).toEqual({
+      pgbouncer_enabled: true,
+      pgbouncer_settings: { pool_mode: "transaction", default_pool_size: 15 },
+    });
+    expect(() => parseDatabaseConfigPatch({ pgbouncer_enabled: "yes" }))
+      .toThrow("pgbouncer_enabled must be a boolean");
+    expect(() => parseDatabaseConfigPatch({ pgbouncer_settings: [] }))
+      .toThrow("pgbouncer_settings must be an object");
+  });
+
+  test.each([
+    -1,
+    2_147_483_648,
+    1.5,
+    "1s",
+    "0; DROP DATABASE postgres",
+    true,
+    null,
+  ])("rejects an unsafe timeout value: %p", (setting) => {
+    expect(() => parseDatabaseConfigPatch({ statement_timeout: setting }))
+      .toThrow(DatabaseConfigValidationError);
+  });
+
+  test("rejects max_connections before any other setting", () => {
+    try {
+      parseDatabaseConfigPatch({
+        max_connections: 200,
+        statement_timeout: 10,
+      });
+      throw new Error("Expected validation to fail");
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(DatabaseConfigValidationError);
+      expect((error as DatabaseConfigValidationError).code).toBe(
+        "INVALID_SETTING_SCOPE",
+      );
+    }
+  });
+
+  test.each([
+    {},
+    { work_mem: 1024 },
+    { statement_timeout: 10, injected_setting: "on" },
+  ])("rejects empty or unknown setting patches", (patch) => {
+    expect(() => parseDatabaseConfigPatch(patch))
+      .toThrow(DatabaseConfigValidationError);
+  });
+
+  test("quotes valid database names and rejects unsafe identifiers", () => {
+    expect(quoteDatabaseIdentifier("supa_project-1")).toBe(
+      '"supa_project-1"',
+    );
+    expect(() => quoteDatabaseIdentifier('supa_bad" RESET ALL --'))
+      .toThrow("Invalid PostgreSQL database identifier");
+    expect(() => quoteDatabaseIdentifier("x".repeat(64)))
+      .toThrow("Invalid PostgreSQL database identifier");
+  });
+});
+
+describe("project database config live reads", () => {
+  test("returns PostgreSQL context and pending_restart without defaults", async () => {
+    const database = {
+      unsafe: mock(async () => [{
+        name: "statement_timeout",
+        setting: "2500",
+        unit: "ms",
+        context: "user",
+        pending_restart: false,
+      }]),
+    };
+
+    const settings = await readLiveDatabaseSettings(database);
+
+    expect(settings).toEqual([{
+      name: "statement_timeout",
+      setting: "2500",
+      unit: "ms",
+      context: "user",
+      pending_restart: false,
+    }]);
+    expect(liveSettingNumber(settings, "statement_timeout")).toBe(2500);
+    expect(liveSettingNumber(settings, "max_connections")).toBeNull();
+  });
+});
+
+describe("project database config updates", () => {
+  test("applies only request fields before persistence", async () => {
+    const events: string[] = [];
+    const database = {
+      unsafe: mock(async (query: string) => {
+        events.push(query.includes("pg_db_role_setting") ? "read-overrides" : query.trim());
+        return [];
+      }),
+    };
+
+    const update = await updateDatabaseSettings({
+      database,
+      databaseName: "supa_project_1",
+      patch: { statement_timeout: 5000 },
+      persist: async () => {
+        events.push("persist");
+        return { database: { statement_timeout: 5000 } };
+      },
+    });
+
+    expect(update.ok).toBe(true);
+    expect(events).toEqual([
+      "read-overrides",
+      'ALTER DATABASE "supa_project_1" SET statement_timeout = 5000',
+      "persist",
+    ]);
+    expect(events.join("\n")).not.toContain(
+      "idle_in_transaction_session_timeout =",
+    );
+  });
+
+  test("does not persist and restores already-applied fields after apply failure", async () => {
+    const statements: string[] = [];
+    const persist = mock(async () => ({}));
+    const database = {
+      unsafe: mock(async (query: string) => {
+        if (query.includes("pg_db_role_setting")) return [];
+        statements.push(query);
+        if (query.includes("idle_in_transaction_session_timeout = 20")) {
+          throw new Error("database rejected setting");
+        }
+        return [];
+      }),
+    };
+
+    const update = await updateDatabaseSettings({
+      database,
+      databaseName: "supa_project_1",
+      patch: {
+        statement_timeout: 10,
+        idle_in_transaction_session_timeout: 20,
+      },
+      persist,
+    });
+
+    expect(update).toMatchObject({ ok: false, stage: "apply" });
+    expect(persist).not.toHaveBeenCalled();
+    expect(statements).toEqual([
+      'ALTER DATABASE "supa_project_1" SET statement_timeout = 10',
+      'ALTER DATABASE "supa_project_1" SET idle_in_transaction_session_timeout = 20',
+      'ALTER DATABASE "supa_project_1" RESET statement_timeout',
+      'ALTER DATABASE "supa_project_1" RESET idle_in_transaction_session_timeout',
+    ]);
+  });
+
+  test("persists PgBouncer metadata without reading or mutating PostgreSQL", async () => {
+    const database = { unsafe: mock(async () => []) };
+    const persist = mock(async () => ({
+      database: { pgbouncer_enabled: true },
+    }));
+
+    const update = await updateDatabaseSettings({
+      database,
+      databaseName: "supa_project_1",
+      patch: { pgbouncer_enabled: true },
+      persist,
+    });
+
+    expect(update.ok).toBe(true);
+    expect(database.unsafe).not.toHaveBeenCalled();
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects an unsafe database identifier before SQL or persistence", async () => {
+    const database = { unsafe: mock(async () => []) };
+    const persist = mock(async () => ({}));
+
+    const update = await updateDatabaseSettings({
+      database,
+      databaseName: 'supa_bad" RESET ALL --',
+      patch: { statement_timeout: 1000 },
+      persist,
+    });
+
+    expect(update).toMatchObject({
+      ok: false,
+      stage: "apply",
+      restoreAttempted: false,
+    });
+    expect(database.unsafe).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  test("restores the prior database-level override after persistence failure", async () => {
+    const statements: string[] = [];
+    const database = {
+      unsafe: mock(async (query: string) => {
+        if (query.includes("pg_db_role_setting")) {
+          return [{ name: "statement_timeout", setting: "2s" }];
+        }
+        statements.push(query);
+        return [];
+      }),
+    };
+
+    const update = await updateDatabaseSettings({
+      database,
+      databaseName: "supa_project_1",
+      patch: { statement_timeout: 1000 },
+      persist: async () => {
+        throw new Error("metadata unavailable");
+      },
+    });
+
+    expect(update).toMatchObject({
+      ok: false,
+      stage: "persist",
+      restoreFailures: [],
+    });
+    expect(statements).toEqual([
+      'ALTER DATABASE "supa_project_1" SET statement_timeout = 1000',
+      'ALTER DATABASE "supa_project_1" SET statement_timeout = \'2s\'',
+    ]);
+  });
+
+  test("reports restoration failures explicitly", async () => {
+    const database = {
+      unsafe: mock(async (query: string) => {
+        if (query.includes("pg_db_role_setting")) return [];
+        if (query.includes(" RESET ")) throw new Error("restore failed");
+        return [];
+      }),
+    };
+
+    const update = await updateDatabaseSettings({
+      database,
+      databaseName: "supa_project_1",
+      patch: { statement_timeout: 1000 },
+      persist: async () => {
+        throw new Error("metadata unavailable");
+      },
+    });
+
+    expect(update).toMatchObject({
+      ok: false,
+      stage: "persist",
+      restoreFailures: [{ name: "statement_timeout" }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- return live PostgreSQL setting metadata and fail closed when pg_settings cannot be read
- reject per-project max_connections and validate the two supported timeout settings
- apply PostgreSQL changes before metadata persistence and restore prior database-level overrides on failure
- preserve typed PgBouncer metadata updates without emitting database setting SQL

## Validation

- bun run typecheck
- bun run sql:check
- bun test tests/unit/project-database-config.service.test.ts tests/unit/project-database-config.routes.test.ts
- bun run test:unit