### PR TITLE
fix(runtime): use capacity-safe database pools

### DIFF
--- a/docs/multi-tenant-management.md
+++ b/docs/multi-tenant-management.md
@@ -297,6 +297,9 @@ SCRIPTS_PATH=/opt/supacloud/scripts/lib
 # Capacity-safe defaults; omit both unless an operator has measured headroom.
 POSTGREST_DB_POOL=3
 MANAGEMENT_DB_POOL=5
+MANAGEMENT_PROJECT_DB_POOL=1
+MANAGEMENT_PROJECT_ROLE_DB_POOL=1
+MANAGEMENT_PROJECT_POOL_CACHE_SIZE=5
 ```
 
 `POSTGREST_DB_POOL` is also honored by the legacy tenant runtime generator,
@@ -310,6 +313,12 @@ off that pool version for one hour, preventing a cross-tenant restart storm.
 Stopped projects and unmanaged configuration files are not changed. These
 pool settings budget connections within the existing PostgreSQL capacity;
 they do not change PostgreSQL `max_connections`.
+
+`MANAGEMENT_DB_POOL` limits the `supacloud_meta` pool. Project database access
+uses separate admin and tenant-role pools capped by
+`MANAGEMENT_PROJECT_DB_POOL` and `MANAGEMENT_PROJECT_ROLE_DB_POOL`. At most
+`MANAGEMENT_PROJECT_POOL_CACHE_SIZE` pools of each kind remain cached, so the
+defaults bound cached project access to ten potential connections in total.
 
 ---
 

--- a/docs/multi-tenant-management.md
+++ b/docs/multi-tenant-management.md
@@ -294,7 +294,20 @@ PORT=9090
 DATABASE_URL=postgresql://postgres:password@localhost:5432/supacloud_meta
 MASTER_TOKEN=your-secure-master-token
 SCRIPTS_PATH=/opt/supacloud/scripts/lib
+# Capacity-safe defaults; omit both unless an operator has measured headroom.
+POSTGREST_DB_POOL=3
+MANAGEMENT_DB_POOL=5
 ```
+
+`POSTGREST_DB_POOL` is also honored by the legacy tenant runtime generator,
+which uses the same default of `3`. The Management API runtime reconciler
+rolls this setting through active, running, Management-API-managed tenant
+`.conf` files one tenant at a time after an upgrade. It restarts PostgREST and
+waits for health; if the candidate is unhealthy, it restores the exact prior
+file ownership, mode, and content before restarting the prior configuration.
+Stopped projects and unmanaged configuration files are not changed. These
+pool settings budget connections within the existing PostgreSQL capacity;
+they do not change PostgreSQL `max_connections`.
 
 ---
 

--- a/docs/multi-tenant-management.md
+++ b/docs/multi-tenant-management.md
@@ -305,6 +305,8 @@ rolls this setting through active, running, Management-API-managed tenant
 `.conf` files one tenant at a time after an upgrade. It restarts PostgREST and
 waits for health; if the candidate is unhealthy, it restores the exact prior
 file ownership, mode, and content before restarting the prior configuration.
+The first failed migration stops further pool changes in that sweep and backs
+off that pool version for one hour, preventing a cross-tenant restart storm.
 Stopped projects and unmanaged configuration files are not changed. These
 pool settings budget connections within the existing PostgreSQL capacity;
 they do not change PostgreSQL `max_connections`.

--- a/docs/multi-tenant-management.md
+++ b/docs/multi-tenant-management.md
@@ -297,7 +297,7 @@ SCRIPTS_PATH=/opt/supacloud/scripts/lib
 # Capacity-safe defaults; omit both unless an operator has measured headroom.
 POSTGREST_DB_POOL=3
 MANAGEMENT_DB_POOL=5
-MANAGEMENT_PROJECT_DB_POOL=1
+MANAGEMENT_PROJECT_DB_POOL=2
 MANAGEMENT_PROJECT_ROLE_DB_POOL=1
 MANAGEMENT_PROJECT_POOL_CACHE_SIZE=5
 ```
@@ -318,7 +318,9 @@ they do not change PostgreSQL `max_connections`.
 uses separate admin and tenant-role pools capped by
 `MANAGEMENT_PROJECT_DB_POOL` and `MANAGEMENT_PROJECT_ROLE_DB_POOL`. At most
 `MANAGEMENT_PROJECT_POOL_CACHE_SIZE` pools of each kind remain cached, so the
-defaults bound cached project access to ten potential connections in total.
+defaults bound cached project access to fifteen potential connections in total.
+The admin pool retains two slots so one long-running tenant operation cannot
+starve every other Management API query for that project.
 
 ---
 

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -132,6 +132,9 @@ export interface Config {
   postgrestCpuWeight: number;
   postgrestDbPool: number;
   managementDbPool: number;
+  managementProjectDbPool: number;
+  managementProjectRoleDbPool: number;
+  managementProjectPoolCacheSize: number;
   gotrueBin: string;
   pgrstPortBase: number;
   gotruePortBase: number;
@@ -323,6 +326,9 @@ export const config: Config = {
   postgrestCpuWeight: Number(getEnv("POSTGREST_CPU_WEIGHT", "40")),
   postgrestDbPool: Number(getEnv("POSTGREST_DB_POOL", "3")),
   managementDbPool: Number(getEnv("MANAGEMENT_DB_POOL", "5")),
+  managementProjectDbPool: Number(getEnv("MANAGEMENT_PROJECT_DB_POOL", "1")),
+  managementProjectRoleDbPool: Number(getEnv("MANAGEMENT_PROJECT_ROLE_DB_POOL", "1")),
+  managementProjectPoolCacheSize: Number(getEnv("MANAGEMENT_PROJECT_POOL_CACHE_SIZE", "5")),
   gotrueBin: getEnv("GOTRUE_BIN", "/usr/local/bin/gotrue"),
   pgrstPortBase: Number(getEnv("PGRST_PORT_BASE", "3100")),
   gotruePortBase: Number(getEnv("GOTRUE_PORT_BASE", "3200")),
@@ -410,6 +416,15 @@ function validateConfig() {
   }
   if (!Number.isInteger(config.managementDbPool) || config.managementDbPool <= 0) {
     throw new Error("Invalid MANAGEMENT_DB_POOL configuration. Must be a positive integer.");
+  }
+  if (!Number.isInteger(config.managementProjectDbPool) || config.managementProjectDbPool <= 0) {
+    throw new Error("Invalid MANAGEMENT_PROJECT_DB_POOL configuration. Must be a positive integer.");
+  }
+  if (!Number.isInteger(config.managementProjectRoleDbPool) || config.managementProjectRoleDbPool <= 0) {
+    throw new Error("Invalid MANAGEMENT_PROJECT_ROLE_DB_POOL configuration. Must be a positive integer.");
+  }
+  if (!Number.isInteger(config.managementProjectPoolCacheSize) || config.managementProjectPoolCacheSize <= 0) {
+    throw new Error("Invalid MANAGEMENT_PROJECT_POOL_CACHE_SIZE configuration. Must be a positive integer.");
   }
 
   const isDevelopment = DEVELOPMENT_ENVS.has(config.nodeEnv) || process.env.BUN_ENV === "test" || config.isGithubActions;

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -326,7 +326,7 @@ export const config: Config = {
   postgrestCpuWeight: Number(getEnv("POSTGREST_CPU_WEIGHT", "40")),
   postgrestDbPool: Number(getEnv("POSTGREST_DB_POOL", "3")),
   managementDbPool: Number(getEnv("MANAGEMENT_DB_POOL", "5")),
-  managementProjectDbPool: Number(getEnv("MANAGEMENT_PROJECT_DB_POOL", "1")),
+  managementProjectDbPool: Number(getEnv("MANAGEMENT_PROJECT_DB_POOL", "2")),
   managementProjectRoleDbPool: Number(getEnv("MANAGEMENT_PROJECT_ROLE_DB_POOL", "1")),
   managementProjectPoolCacheSize: Number(getEnv("MANAGEMENT_PROJECT_POOL_CACHE_SIZE", "5")),
   gotrueBin: getEnv("GOTRUE_BIN", "/usr/local/bin/gotrue"),

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -131,6 +131,7 @@ export interface Config {
   postgrestMemoryMax: string;
   postgrestCpuWeight: number;
   postgrestDbPool: number;
+  managementDbPool: number;
   gotrueBin: string;
   pgrstPortBase: number;
   gotruePortBase: number;
@@ -320,7 +321,8 @@ export const config: Config = {
   postgrestRts: getEnv("POSTGREST_RTS", "-N1 -M256m -I0.5 -A4m"),
   postgrestMemoryMax: getEnv("POSTGREST_MEMORY_MAX", "384M"),
   postgrestCpuWeight: Number(getEnv("POSTGREST_CPU_WEIGHT", "40")),
-  postgrestDbPool: Number(getEnv("POSTGREST_DB_POOL", "10")),
+  postgrestDbPool: Number(getEnv("POSTGREST_DB_POOL", "3")),
+  managementDbPool: Number(getEnv("MANAGEMENT_DB_POOL", "5")),
   gotrueBin: getEnv("GOTRUE_BIN", "/usr/local/bin/gotrue"),
   pgrstPortBase: Number(getEnv("PGRST_PORT_BASE", "3100")),
   gotruePortBase: Number(getEnv("GOTRUE_PORT_BASE", "3200")),
@@ -402,6 +404,12 @@ function validateConfig() {
   }
   if (!Number.isFinite(config.restProxyTimeoutMs) || config.restProxyTimeoutMs <= 0) {
     throw new Error("Invalid REST_PROXY_TIMEOUT_MS configuration. Must be a positive integer.");
+  }
+  if (!Number.isInteger(config.postgrestDbPool) || config.postgrestDbPool <= 0) {
+    throw new Error("Invalid POSTGREST_DB_POOL configuration. Must be a positive integer.");
+  }
+  if (!Number.isInteger(config.managementDbPool) || config.managementDbPool <= 0) {
+    throw new Error("Invalid MANAGEMENT_DB_POOL configuration. Must be a positive integer.");
   }
 
   const isDevelopment = DEVELOPMENT_ENVS.has(config.nodeEnv) || process.env.BUN_ENV === "test" || config.isGithubActions;

--- a/packages/management-api/src/db/index.ts
+++ b/packages/management-api/src/db/index.ts
@@ -37,7 +37,7 @@ export const sql = new SQL({
   connectTimeout: 5000,
 });
 
-const MAX_CACHED_CONNECTIONS = 50;
+const MAX_CACHED_PROJECT_POOLS = config.managementProjectPoolCacheSize;
 
 const projectConnections: Map<string, { sql: SQL; lastUsed: number }> = new Map();
 const projectRoleConnections: Map<string, { sql: SQL; lastUsed: number }> = new Map();
@@ -88,7 +88,7 @@ setInterval(() => {
 }, IDLE_SWEEP_INTERVAL).unref();
 
 function evictOldestConnection(connections: Map<string, { sql: SQL; lastUsed: number }>, label: string) {
-  if (connections.size < MAX_CACHED_CONNECTIONS) return;
+  if (connections.size < MAX_CACHED_PROJECT_POOLS) return;
 
   let oldestKey = "";
   let oldestTime = Infinity;
@@ -123,7 +123,7 @@ export function getProjectDb(dbName: string): SQL {
     dbName,
     username: dbConfig.username,
     password: dbConfig.password,
-    max: 10,
+    max: config.managementProjectDbPool,
   });
 
   projectConnections.set(dbName, { sql: projectSql, lastUsed: Date.now() });
@@ -144,7 +144,7 @@ export function getProjectRoleDb(dbName: string, username: string, password: str
     dbName,
     username,
     password,
-    max: 5,
+    max: config.managementProjectRoleDbPool,
   });
 
   projectRoleConnections.set(key, { sql: projectSql, lastUsed: Date.now() });

--- a/packages/management-api/src/db/index.ts
+++ b/packages/management-api/src/db/index.ts
@@ -32,7 +32,7 @@ export const sql = new SQL({
   database: dbConfig.database,
   username: dbConfig.username,
   password: dbConfig.password,
-  max: 20,
+  max: config.managementDbPool,
   idleTimeout: 30,
   connectTimeout: 5000,
 });

--- a/packages/management-api/src/services/postgrest-pool-reconcile.ts
+++ b/packages/management-api/src/services/postgrest-pool-reconcile.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join } from "node:path";
 
 const MANAGED_CONFIG_PREFIX = "# Managed by SupaCloud Management API.";
 const DB_POOL_LINE_PATTERN = /^(\s*db-pool\s*=\s*)(\d+)(\s*(?:#.*)?)$/gm;
+export const POSTGREST_POOL_RETRY_BACKOFF_MS = 60 * 60 * 1000;
 
 interface PostgrestPoolReconcileRequest {
   configPath: string;
@@ -37,6 +38,38 @@ export class PostgrestPoolReconcileError extends AggregateError {
       "PostgREST pool update failed and the previous configuration could not be restored healthy",
     );
     this.name = "PostgrestPoolReconcileError";
+  }
+}
+
+export class PostgrestPoolMigrationGate {
+  private failedDesiredPool: number | null = null;
+  private retryAt = 0;
+  private sweepBlocked = false;
+
+  constructor(
+    private readonly retryBackoffMs = POSTGREST_POOL_RETRY_BACKOFF_MS,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  beginSweep(desiredPool: number): boolean {
+    assertDesiredPool(desiredPool);
+    if (this.failedDesiredPool !== desiredPool) {
+      this.failedDesiredPool = null;
+      this.retryAt = 0;
+    }
+    this.sweepBlocked = this.failedDesiredPool === desiredPool && this.now() < this.retryAt;
+    return !this.sweepBlocked;
+  }
+
+  recordFailure(desiredPool: number): void {
+    assertDesiredPool(desiredPool);
+    this.failedDesiredPool = desiredPool;
+    this.retryAt = this.now() + this.retryBackoffMs;
+    this.sweepBlocked = true;
+  }
+
+  canAttempt(): boolean {
+    return !this.sweepBlocked;
   }
 }
 
@@ -113,6 +146,16 @@ async function writeConfigSnapshot(
   if (cleanupError) throw cleanupError;
 }
 
+async function assertCurrentConfig(
+  configPath: string,
+  expectedContent: string,
+): Promise<void> {
+  const currentContent = await readFile(configPath, "utf8");
+  if (currentContent !== expectedContent) {
+    throw new Error("PostgREST config changed concurrently; refusing to overwrite it during rollback");
+  }
+}
+
 function isEligible(request: PostgrestPoolReconcileRequest): boolean {
   return request.projectStatus === "active" && request.desiredState === "running";
 }
@@ -137,6 +180,7 @@ export async function reconcileManagedPostgrestPool(
     return { state: "updated" };
   } catch (updateError: unknown) {
     try {
+      await assertCurrentConfig(request.configPath, candidateContent);
       await writeConfigSnapshot(request.configPath, original);
       await request.restartAndWait();
       return {

--- a/packages/management-api/src/services/postgrest-pool-reconcile.ts
+++ b/packages/management-api/src/services/postgrest-pool-reconcile.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import { chmod, chown, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+const MANAGED_CONFIG_PREFIX = "# Managed by SupaCloud Management API.";
+const DB_POOL_LINE_PATTERN = /^(\s*db-pool\s*=\s*)(\d+)(\s*(?:#.*)?)$/gm;
+
+interface PostgrestPoolReconcileRequest {
+  configPath: string;
+  desiredPool: number;
+  projectStatus: string;
+  desiredState: "running" | "stopped";
+  restartAndWait: () => Promise<void>;
+}
+
+interface PostgrestConfigSnapshot {
+  content: string;
+  mode: number;
+  uid: number;
+  gid: number;
+}
+
+export type PostgrestPoolReconcileResult =
+  | { state: "skipped" | "unchanged" | "updated" }
+  | {
+      state: "rolled_back";
+      error: "POSTGREST_POOL_UPDATE_ROLLED_BACK";
+      cause: unknown;
+    };
+
+export class PostgrestPoolReconcileError extends AggregateError {
+  readonly code = "POSTGREST_POOL_ROLLBACK_FAILED";
+
+  constructor(updateError: unknown, rollbackError: unknown) {
+    super(
+      [updateError, rollbackError],
+      "PostgREST pool update failed and the previous configuration could not be restored healthy",
+    );
+    this.name = "PostgrestPoolReconcileError";
+  }
+}
+
+function assertDesiredPool(desiredPool: number): void {
+  if (!Number.isInteger(desiredPool) || desiredPool <= 0) {
+    throw new Error("PostgREST database pool must be a positive integer");
+  }
+}
+
+export function renderManagedPostgrestDbPool(
+  content: string,
+  desiredPool: number,
+): string | null {
+  assertDesiredPool(desiredPool);
+  if (!content.startsWith(MANAGED_CONFIG_PREFIX)) return null;
+  const matches = [...content.matchAll(DB_POOL_LINE_PATTERN)];
+  if (matches.length !== 1) {
+    throw new Error("Managed PostgREST config must contain exactly one db-pool setting");
+  }
+  const [match] = matches;
+  if (Number(match[2]) === desiredPool) return null;
+  const start = match.index;
+  const replacement = `${match[1]}${desiredPool}${match[3]}`;
+  return `${content.slice(0, start)}${replacement}${content.slice(start + match[0].length)}`;
+}
+
+async function readConfigSnapshot(configPath: string): Promise<PostgrestConfigSnapshot> {
+  const [content, metadata] = await Promise.all([
+    readFile(configPath, "utf8"),
+    stat(configPath),
+  ]);
+  return {
+    content,
+    mode: metadata.mode & 0o7777,
+    uid: metadata.uid,
+    gid: metadata.gid,
+  };
+}
+
+async function writeConfigSnapshot(
+  configPath: string,
+  snapshot: PostgrestConfigSnapshot,
+): Promise<void> {
+  const temporaryPath = join(
+    dirname(configPath),
+    `.${basename(configPath)}.${randomUUID()}.tmp`,
+  );
+  let writeError: unknown;
+  try {
+    await writeFile(temporaryPath, snapshot.content, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: snapshot.mode,
+    });
+    await chown(temporaryPath, snapshot.uid, snapshot.gid);
+    await chmod(temporaryPath, snapshot.mode);
+    await rename(temporaryPath, configPath);
+  } catch (error: unknown) {
+    writeError = error;
+  }
+  let cleanupError: unknown;
+  try {
+    await rm(temporaryPath, { force: true });
+  } catch (error: unknown) {
+    cleanupError = error;
+  }
+  if (writeError && cleanupError) {
+    throw new AggregateError(
+      [writeError, cleanupError],
+      "PostgREST config write and temporary file cleanup both failed",
+    );
+  }
+  if (writeError) throw writeError;
+  if (cleanupError) throw cleanupError;
+}
+
+function isEligible(request: PostgrestPoolReconcileRequest): boolean {
+  return request.projectStatus === "active" && request.desiredState === "running";
+}
+
+export async function reconcileManagedPostgrestPool(
+  request: PostgrestPoolReconcileRequest,
+): Promise<PostgrestPoolReconcileResult> {
+  if (!isEligible(request)) return { state: "skipped" };
+  const original = await readConfigSnapshot(request.configPath);
+  const candidateContent = renderManagedPostgrestDbPool(
+    original.content,
+    request.desiredPool,
+  );
+  if (candidateContent === null) return { state: "unchanged" };
+
+  await writeConfigSnapshot(request.configPath, {
+    ...original,
+    content: candidateContent,
+  });
+  try {
+    await request.restartAndWait();
+    return { state: "updated" };
+  } catch (updateError: unknown) {
+    try {
+      await writeConfigSnapshot(request.configPath, original);
+      await request.restartAndWait();
+      return {
+        state: "rolled_back",
+        error: "POSTGREST_POOL_UPDATE_ROLLED_BACK",
+        cause: updateError,
+      };
+    } catch (rollbackError: unknown) {
+      throw new PostgrestPoolReconcileError(updateError, rollbackError);
+    }
+  }
+}

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -41,6 +41,10 @@ import { authConfigChangesPostgrestVerifier } from "./auth-runtime-impact";
 import { runtimeCacheService } from "./runtime-cache.service";
 import { projectControlSecretsService } from "./project-control-secrets.service";
 import { installManagedSystemdUnit } from "./systemd-unit-broker";
+import {
+    reconcileManagedPostgrestPool,
+    type PostgrestPoolReconcileResult,
+} from "./postgrest-pool-reconcile";
 
 export {
     renderGoTrueAuthEnv,
@@ -2528,6 +2532,29 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         }
     }
 
+    private async restartPostgrestForPoolUpdate(ref: string): Promise<void> {
+        const pgrstPort = await this.getTenantPort(ref, "pgrst");
+        await this.postgrestController.restart(ref);
+        const status = await this.postgrestController.waitForHealthy(ref, pgrstPort, 20, 500);
+        if (status.health !== "healthy") {
+            throw new Error("PostgREST did not become healthy after the pool update");
+        }
+    }
+
+    private async reconcilePostgrestPool(
+        ref: string,
+        projectStatus: string,
+        desired: RuntimeDesiredState,
+    ): Promise<PostgrestPoolReconcileResult> {
+        return reconcileManagedPostgrestPool({
+            configPath: path.join(this.TENANT_CONFIG_DIR, `${ref}.conf`),
+            desiredPool: this.POSTGREST_DB_POOL,
+            projectStatus,
+            desiredState: desired,
+            restartAndWait: () => this.restartPostgrestForPoolUpdate(ref),
+        });
+    }
+
     private async refreshProjectPostgrestVerifier(ref: string, pgrstPort: number): Promise<void> {
         const jwtPolicy = await this.getTenantCredentials(ref);
         await this.ensurePostgrestPrerequest(
@@ -2693,7 +2720,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 }
 
                 const desired = this.getPostgrestDesiredState(project);
-                const actual = await this.statusPostgrest(ref);
+                let actual = await this.statusPostgrest(ref);
+                let postgrestPoolError: string | null = null;
 
                 // --- PostgREST reconcile ---
                 if (desired === "stopped" && actual.actual !== "stopped") {
@@ -2703,8 +2731,21 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                 }
 
                 if (desired === "running" && status === "active" && actual.health !== "healthy") {
-                    await this.resumePostgrest(ref);
+                    actual = await this.resumePostgrest(ref);
                     started++;
+                }
+
+                if (desired === "running" && status === "active" && actual.health === "healthy") {
+                    const poolReconcile = await this.reconcilePostgrestPool(ref, status, desired);
+                    if (poolReconcile.state === "updated" || poolReconcile.state === "rolled_back") {
+                        actual = await this.statusPostgrest(ref);
+                    }
+                    if (poolReconcile.state === "rolled_back") {
+                        postgrestPoolError = poolReconcile.error;
+                        logger.error(`[TenantRuntime] PostgREST pool update rolled back for ${ref}`, {
+                            error: poolReconcile.error,
+                        });
+                    }
                 }
 
                 // --- GoTrue reconcile ---
@@ -2721,7 +2762,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                             actual: actual.actual,
                             health: actual.health,
                             port: actual.port,
-                            last_error: actual.health === "healthy" ? null : actual.last_error,
+                            last_error: postgrestPoolError
+                                || (actual.health === "healthy" ? null : actual.last_error),
                         }, { reconciled: true });
                         updated++;
                         continue;
@@ -2753,7 +2795,8 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                     actual: actual.actual,
                     health: actual.health,
                     port: actual.port,
-                    last_error: actual.health === "healthy" ? null : actual.last_error,
+                    last_error: postgrestPoolError
+                        || (actual.health === "healthy" ? null : actual.last_error),
                 }, { reconciled: true });
                 updated++;
             } catch (error: unknown) {

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -42,6 +42,7 @@ import { runtimeCacheService } from "./runtime-cache.service";
 import { projectControlSecretsService } from "./project-control-secrets.service";
 import { installManagedSystemdUnit } from "./systemd-unit-broker";
 import {
+    PostgrestPoolMigrationGate,
     reconcileManagedPostgrestPool,
     type PostgrestPoolReconcileResult,
 } from "./postgrest-pool-reconcile";
@@ -545,6 +546,23 @@ class TenantRuntimeService {
     private readonly GOTRUE_PORT_BASE = config.gotruePortBase;
     private readonly postgrestController = new PostgrestRuntimeController();
     private readonly gotrueController = new GotrueRuntimeController();
+    private readonly tenantConfigLocks = new Map<string, Promise<void>>();
+    private readonly postgrestPoolMigrationGate = new PostgrestPoolMigrationGate();
+
+    private async withTenantConfigLock<T>(ref: string, operation: () => Promise<T>): Promise<T> {
+        const predecessor = this.tenantConfigLocks.get(ref) || Promise.resolve();
+        let releaseLock: () => void = () => {};
+        const lock = new Promise<void>((resolve) => { releaseLock = resolve; });
+        const queuedLock = predecessor.then(() => lock);
+        this.tenantConfigLocks.set(ref, queuedLock);
+        await predecessor;
+        try {
+            return await operation();
+        } finally {
+            releaseLock();
+            if (this.tenantConfigLocks.get(ref) === queuedLock) this.tenantConfigLocks.delete(ref);
+        }
+    }
 
     private async effectiveGoTruePort(ref: string, localPort: number): Promise<number> {
         if (!isSharedAuthRuntime(ref)) return localPort;
@@ -961,6 +979,16 @@ class TenantRuntimeService {
         pgrstPort: number,
         gotruePort: number,
         systemctlMode: SystemctlExecutionMode = "best-effort",
+    ) {
+        return this.withTenantConfigLock(ref, () =>
+            this.generateTenantConfigUnlocked(ref, pgrstPort, gotruePort, systemctlMode));
+    }
+
+    private async generateTenantConfigUnlocked(
+        ref: string,
+        pgrstPort: number,
+        gotruePort: number,
+        systemctlMode: SystemctlExecutionMode,
     ) {
         const creds = await this.getTenantCredentials(ref);
         const runtimeUser = await this.ensureTenantRuntimeUser(ref);
@@ -2534,7 +2562,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
 
     private async restartPostgrestForPoolUpdate(ref: string): Promise<void> {
         const pgrstPort = await this.getTenantPort(ref, "pgrst");
-        await this.postgrestController.restart(ref);
+        await runSystemctlOrThrow("restart", this.postgrestController.unit(ref));
         const status = await this.postgrestController.waitForHealthy(ref, pgrstPort, 20, 500);
         if (status.health !== "healthy") {
             throw new Error("PostgREST did not become healthy after the pool update");
@@ -2546,13 +2574,14 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         projectStatus: string,
         desired: RuntimeDesiredState,
     ): Promise<PostgrestPoolReconcileResult> {
-        return reconcileManagedPostgrestPool({
-            configPath: path.join(this.TENANT_CONFIG_DIR, `${ref}.conf`),
-            desiredPool: this.POSTGREST_DB_POOL,
-            projectStatus,
-            desiredState: desired,
-            restartAndWait: () => this.restartPostgrestForPoolUpdate(ref),
-        });
+        return this.withTenantConfigLock(ref, () =>
+            reconcileManagedPostgrestPool({
+                configPath: path.join(this.TENANT_CONFIG_DIR, `${ref}.conf`),
+                desiredPool: this.POSTGREST_DB_POOL,
+                projectStatus,
+                desiredState: desired,
+                restartAndWait: () => this.restartPostgrestForPoolUpdate(ref),
+            }));
     }
 
     private async refreshProjectPostgrestVerifier(ref: string, pgrstPort: number): Promise<void> {
@@ -2700,6 +2729,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         let started = 0;
         let updated = 0;
         let errors = 0;
+        this.postgrestPoolMigrationGate.beginSweep(this.POSTGREST_DB_POOL);
         for (const ref of refs) {
             const status = projectStatus.get(ref);
             const project = projectByRef.get(ref);
@@ -2735,12 +2765,24 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
                     started++;
                 }
 
-                if (desired === "running" && status === "active" && actual.health === "healthy") {
-                    const poolReconcile = await this.reconcilePostgrestPool(ref, status, desired);
+                if (
+                    desired === "running"
+                    && status === "active"
+                    && actual.health === "healthy"
+                    && this.postgrestPoolMigrationGate.canAttempt()
+                ) {
+                    let poolReconcile: PostgrestPoolReconcileResult;
+                    try {
+                        poolReconcile = await this.reconcilePostgrestPool(ref, status, desired);
+                    } catch (error: unknown) {
+                        this.postgrestPoolMigrationGate.recordFailure(this.POSTGREST_DB_POOL);
+                        throw error;
+                    }
                     if (poolReconcile.state === "updated" || poolReconcile.state === "rolled_back") {
                         actual = await this.statusPostgrest(ref);
                     }
                     if (poolReconcile.state === "rolled_back") {
+                        this.postgrestPoolMigrationGate.recordFailure(this.POSTGREST_DB_POOL);
                         postgrestPoolError = poolReconcile.error;
                         logger.error(`[TenantRuntime] PostgREST pool update rolled back for ${ref}`, {
                             error: poolReconcile.error,

--- a/packages/management-api/src/workers/runtime-reconcile.worker.ts
+++ b/packages/management-api/src/workers/runtime-reconcile.worker.ts
@@ -5,8 +5,9 @@ const RECONCILE_INTERVAL_MS = Number(process.env.RUNTIME_RECONCILE_INTERVAL_MS |
 const INITIAL_DELAY_MS = Number(process.env.RUNTIME_RECONCILE_INITIAL_DELAY_MS || 60 * 1000);
 
 let reconcileTimer: Timer | null = null;
+let reconciliationInFlight: Promise<void> | null = null;
 
-export async function runRuntimeReconciliation(): Promise<void> {
+async function performRuntimeReconciliation(): Promise<void> {
     try {
         const stats = await tenantRuntimeService.reconcileInactiveRuntimes();
         if (stats.stopped > 0 || stats.started > 0 || stats.updated > 0 || stats.errors > 0) {
@@ -19,6 +20,16 @@ export async function runRuntimeReconciliation(): Promise<void> {
             error: error instanceof Error ? error.message : String(error),
         });
     }
+}
+
+export function runRuntimeReconciliation(): Promise<void> {
+    if (reconciliationInFlight) return reconciliationInFlight;
+
+    const run = performRuntimeReconciliation().finally(() => {
+        if (reconciliationInFlight === run) reconciliationInFlight = null;
+    });
+    reconciliationInFlight = run;
+    return run;
 }
 
 export function startRuntimeReconcileWorker(): void {

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -33,6 +33,9 @@ function cleanEnv(overrides: Record<string, string>) {
     "SUPACLOUD_CADDY_TLS_ISSUER",
     "POSTGREST_DB_POOL",
     "MANAGEMENT_DB_POOL",
+    "MANAGEMENT_PROJECT_DB_POOL",
+    "MANAGEMENT_PROJECT_ROLE_DB_POOL",
+    "MANAGEMENT_PROJECT_POOL_CACHE_SIZE",
   ]) {
     delete env[key];
   }
@@ -77,7 +80,7 @@ function loadDatabaseUrl(env: Record<string, string>) {
 function loadDatabasePools(env: Record<string, string>) {
   const result = spawnSync("bun", ["-e", [
     'import { config } from "./src/config.ts";',
-    'console.log(`RESULT=${config.postgrestDbPool}:${config.managementDbPool}`);',
+    'console.log(`RESULT=${config.postgrestDbPool}:${config.managementDbPool}:${config.managementProjectDbPool}:${config.managementProjectRoleDbPool}:${config.managementProjectPoolCacheSize}`);',
   ].join(" ")], { cwd: packageRoot, env, encoding: "utf8" });
   expect(result.status, result.stderr).toBe(0);
   return result.stdout.match(/RESULT=([^\n]+)/)?.[1];
@@ -174,18 +177,24 @@ describe("production config loading boundaries", () => {
   });
 
   test("uses capacity-safe pool defaults and honors explicit overrides", () => {
-    expect(loadDatabasePools(cleanEnv({ NODE_ENV: "production" }))).toBe("3:5");
+    expect(loadDatabasePools(cleanEnv({ NODE_ENV: "production" }))).toBe("3:5:1:1:5");
     expect(loadDatabasePools(cleanEnv({
       NODE_ENV: "production",
       POSTGREST_DB_POOL: "7",
       MANAGEMENT_DB_POOL: "9",
-    }))).toBe("7:9");
+      MANAGEMENT_PROJECT_DB_POOL: "2",
+      MANAGEMENT_PROJECT_ROLE_DB_POOL: "3",
+      MANAGEMENT_PROJECT_POOL_CACHE_SIZE: "4",
+    }))).toBe("7:9:2:3:4");
   });
 
   test.each([
     { POSTGREST_DB_POOL: "0" },
     { POSTGREST_DB_POOL: "1.5" },
     { MANAGEMENT_DB_POOL: "not-a-number" },
+    { MANAGEMENT_PROJECT_DB_POOL: "0" },
+    { MANAGEMENT_PROJECT_ROLE_DB_POOL: "1.5" },
+    { MANAGEMENT_PROJECT_POOL_CACHE_SIZE: "not-a-number" },
   ])("rejects invalid database pool capacity: %p", (poolEnv) => {
     const result = spawnSync("bun", ["-e", 'import "./src/config.ts";'], {
       cwd: packageRoot,

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -31,6 +31,8 @@ function cleanEnv(overrides: Record<string, string>) {
     "DOCKER_HOST_IP",
     "INTERNAL_IP",
     "SUPACLOUD_CADDY_TLS_ISSUER",
+    "POSTGREST_DB_POOL",
+    "MANAGEMENT_DB_POOL",
   ]) {
     delete env[key];
   }
@@ -67,6 +69,15 @@ function loadDatabaseUrl(env: Record<string, string>) {
   const result = spawnSync("bun", ["-e", [
     'import { config } from "./src/config.ts";',
     'console.log(`RESULT=${config.databaseUrl}`);',
+  ].join(" ")], { cwd: packageRoot, env, encoding: "utf8" });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout.match(/RESULT=([^\n]+)/)?.[1];
+}
+
+function loadDatabasePools(env: Record<string, string>) {
+  const result = spawnSync("bun", ["-e", [
+    'import { config } from "./src/config.ts";',
+    'console.log(`RESULT=${config.postgrestDbPool}:${config.managementDbPool}`);',
   ].join(" ")], { cwd: packageRoot, env, encoding: "utf8" });
   expect(result.status, result.stderr).toBe(0);
   return result.stdout.match(/RESULT=([^\n]+)/)?.[1];
@@ -160,6 +171,30 @@ describe("production config loading boundaries", () => {
       expect(loadDatabaseUrl(cleanEnv({ NODE_ENV: "production", DATABASE_URL: databaseUrl })))
         .toBe(databaseUrl);
     }
+  });
+
+  test("uses capacity-safe pool defaults and honors explicit overrides", () => {
+    expect(loadDatabasePools(cleanEnv({ NODE_ENV: "production" }))).toBe("3:5");
+    expect(loadDatabasePools(cleanEnv({
+      NODE_ENV: "production",
+      POSTGREST_DB_POOL: "7",
+      MANAGEMENT_DB_POOL: "9",
+    }))).toBe("7:9");
+  });
+
+  test.each([
+    { POSTGREST_DB_POOL: "0" },
+    { POSTGREST_DB_POOL: "1.5" },
+    { MANAGEMENT_DB_POOL: "not-a-number" },
+  ])("rejects invalid database pool capacity: %p", (poolEnv) => {
+    const result = spawnSync("bun", ["-e", 'import "./src/config.ts";'], {
+      cwd: packageRoot,
+      env: cleanEnv({ NODE_ENV: "production", ...poolEnv }),
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("DB_POOL");
   });
 
   test("rejects a BFF signing secret shared with another privileged key", () => {

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -177,7 +177,7 @@ describe("production config loading boundaries", () => {
   });
 
   test("uses capacity-safe pool defaults and honors explicit overrides", () => {
-    expect(loadDatabasePools(cleanEnv({ NODE_ENV: "production" }))).toBe("3:5:1:1:5");
+    expect(loadDatabasePools(cleanEnv({ NODE_ENV: "production" }))).toBe("3:5:2:1:5");
     expect(loadDatabasePools(cleanEnv({
       NODE_ENV: "production",
       POSTGREST_DB_POOL: "7",

--- a/packages/management-api/tests/unit/config.test.ts
+++ b/packages/management-api/tests/unit/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { resolve } from "node:path";
 import { config } from "../../src/config";
+import { sql as managementSql } from "../../src/db";
 
 describe("Config", () => {
   test("should have port configured", () => {
@@ -47,7 +48,9 @@ describe("Config", () => {
     expect(config.postgrestRts).toContain("-M256m");
     expect(config.postgrestMemoryMax).toBe("384M");
     expect(config.postgrestCpuWeight).toBeGreaterThanOrEqual(40);
-    expect(config.postgrestDbPool).toBe(10);
+    expect(config.postgrestDbPool).toBe(3);
+    expect(config.managementDbPool).toBe(5);
+    expect(managementSql.options.max).toBe(config.managementDbPool);
   });
 
   test("empty PGPASSWORD falls back to PG_PASSWORD", () => {

--- a/packages/management-api/tests/unit/config.test.ts
+++ b/packages/management-api/tests/unit/config.test.ts
@@ -55,7 +55,7 @@ describe("Config", () => {
     expect(config.postgrestDbPool).toBe(3);
     expect(config.managementDbPool).toBe(5);
     expect(managementSql.options.max).toBe(config.managementDbPool);
-    expect(config.managementProjectDbPool).toBe(1);
+    expect(config.managementProjectDbPool).toBe(2);
     expect(config.managementProjectRoleDbPool).toBe(1);
     expect(config.managementProjectPoolCacheSize).toBe(5);
     expect(getProjectDb("capacity_test").options.max).toBe(config.managementProjectDbPool);

--- a/packages/management-api/tests/unit/config.test.ts
+++ b/packages/management-api/tests/unit/config.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect } from "bun:test";
 import { resolve } from "node:path";
 import { config } from "../../src/config";
-import { sql as managementSql } from "../../src/db";
+import {
+  getProjectDb,
+  getProjectRoleDb,
+  sql as managementSql,
+} from "../../src/db";
 
 describe("Config", () => {
   test("should have port configured", () => {
@@ -51,6 +55,12 @@ describe("Config", () => {
     expect(config.postgrestDbPool).toBe(3);
     expect(config.managementDbPool).toBe(5);
     expect(managementSql.options.max).toBe(config.managementDbPool);
+    expect(config.managementProjectDbPool).toBe(1);
+    expect(config.managementProjectRoleDbPool).toBe(1);
+    expect(config.managementProjectPoolCacheSize).toBe(5);
+    expect(getProjectDb("capacity_test").options.max).toBe(config.managementProjectDbPool);
+    expect(getProjectRoleDb("capacity_test", "role", "password").options.max)
+      .toBe(config.managementProjectRoleDbPool);
   });
 
   test("empty PGPASSWORD falls back to PG_PASSWORD", () => {

--- a/packages/management-api/tests/unit/postgrest-pool-reconcile.test.ts
+++ b/packages/management-api/tests/unit/postgrest-pool-reconcile.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PostgrestPoolReconcileError,
+  reconcileManagedPostgrestPool,
+  renderManagedPostgrestDbPool,
+} from "../../src/services/postgrest-pool-reconcile";
+
+const temporaryDirectories: string[] = [];
+const MANAGED_CONFIG = [
+  "# Managed by SupaCloud Management API. Legacy shell tooling must not overwrite this file.",
+  "db-uri = \"postgres://secret@example.invalid/database\"",
+  "db-pool = 10",
+  "log-level = \"warn\"",
+  "",
+].join("\n");
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true })
+    ),
+  );
+});
+
+async function temporaryConfig(content = MANAGED_CONFIG): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "supacloud-postgrest-pool-"));
+  temporaryDirectories.push(directory);
+  const configPath = join(directory, "tenant.conf");
+  await writeFile(configPath, content, { mode: 0o640 });
+  await chmod(configPath, 0o640);
+  return configPath;
+}
+
+function request(
+  configPath: string,
+  restartAndWait: () => Promise<void>,
+  overrides: Partial<{
+    desiredPool: number;
+    projectStatus: string;
+    desiredState: "running" | "stopped";
+  }> = {},
+) {
+  return {
+    configPath,
+    desiredPool: overrides.desiredPool ?? 3,
+    projectStatus: overrides.projectStatus ?? "active",
+    desiredState: overrides.desiredState ?? "running",
+    restartAndWait,
+  };
+}
+
+describe("managed PostgREST pool rendering", () => {
+  test("changes only the managed db-pool line", () => {
+    const candidate = renderManagedPostgrestDbPool(MANAGED_CONFIG, 3);
+
+    expect(candidate).toBe(MANAGED_CONFIG.replace("db-pool = 10", "db-pool = 3"));
+    expect(candidate).toContain("postgres://secret@example.invalid/database");
+  });
+
+  test("does not rewrite unmanaged, matching, or malformed config", () => {
+    expect(renderManagedPostgrestDbPool(MANAGED_CONFIG, 10)).toBeNull();
+    expect(renderManagedPostgrestDbPool("db-pool = 10\n", 3)).toBeNull();
+    expect(() => renderManagedPostgrestDbPool(
+      `${MANAGED_CONFIG}db-pool = 4\n`,
+      3,
+    )).toThrow("exactly one db-pool setting");
+  });
+});
+
+describe("managed PostgREST pool reconciliation", () => {
+  test("updates, health-checks, preserves metadata, and becomes idempotent", async () => {
+    const configPath = await temporaryConfig();
+    const before = await stat(configPath);
+    const restartAndWait = mock(async () => {});
+
+    const first = await reconcileManagedPostgrestPool(
+      request(configPath, restartAndWait),
+    );
+    const after = await stat(configPath);
+
+    expect(first).toEqual({ state: "updated" });
+    expect(await readFile(configPath, "utf8")).toContain("db-pool = 3");
+    expect(after.mode & 0o7777).toBe(before.mode & 0o7777);
+    expect(after.uid).toBe(before.uid);
+    expect(after.gid).toBe(before.gid);
+    expect(restartAndWait).toHaveBeenCalledTimes(1);
+
+    const second = await reconcileManagedPostgrestPool(
+      request(configPath, restartAndWait),
+    );
+    expect(second).toEqual({ state: "unchanged" });
+    expect(restartAndWait).toHaveBeenCalledTimes(1);
+  });
+
+  test("honors an explicit pool override without restarting", async () => {
+    const configPath = await temporaryConfig();
+    const restartAndWait = mock(async () => {});
+
+    const result = await reconcileManagedPostgrestPool(
+      request(configPath, restartAndWait, { desiredPool: 10 }),
+    );
+
+    expect(result).toEqual({ state: "unchanged" });
+    expect(restartAndWait).not.toHaveBeenCalled();
+  });
+
+  test("does not read or start a stopped project", async () => {
+    const restartAndWait = mock(async () => {});
+    const result = await reconcileManagedPostgrestPool(
+      request("/path/does/not/exist", restartAndWait, {
+        desiredState: "stopped",
+      }),
+    );
+
+    expect(result).toEqual({ state: "skipped" });
+    expect(restartAndWait).not.toHaveBeenCalled();
+  });
+
+  test("restores the exact previous config after candidate health failure", async () => {
+    const configPath = await temporaryConfig();
+    const before = await stat(configPath);
+    const restartAndWait = mock(async () => {});
+    restartAndWait.mockRejectedValueOnce(new Error("candidate unhealthy"));
+
+    const result = await reconcileManagedPostgrestPool(
+      request(configPath, restartAndWait),
+    );
+    const after = await stat(configPath);
+
+    expect(result).toEqual({
+      state: "rolled_back",
+      error: "POSTGREST_POOL_UPDATE_ROLLED_BACK",
+      cause: expect.any(Error),
+    });
+    expect(await readFile(configPath, "utf8")).toBe(MANAGED_CONFIG);
+    expect(after.mode & 0o7777).toBe(before.mode & 0o7777);
+    expect(after.uid).toBe(before.uid);
+    expect(after.gid).toBe(before.gid);
+    expect(restartAndWait).toHaveBeenCalledTimes(2);
+
+    const retry = await reconcileManagedPostgrestPool(
+      request(configPath, restartAndWait),
+    );
+    expect(retry).toEqual({ state: "updated" });
+    expect(restartAndWait).toHaveBeenCalledTimes(3);
+  });
+
+  test("fails explicitly when the restored runtime is still unhealthy", async () => {
+    const configPath = await temporaryConfig();
+    const restartAndWait = mock(async () => {
+      throw new Error("unhealthy");
+    });
+
+    await expect(
+      reconcileManagedPostgrestPool(request(configPath, restartAndWait)),
+    ).rejects.toBeInstanceOf(PostgrestPoolReconcileError);
+    expect(await readFile(configPath, "utf8")).toBe(MANAGED_CONFIG);
+    expect(restartAndWait).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not modify unmanaged or malformed managed files", async () => {
+    const unmanaged = "db-pool = 10\n";
+    const unmanagedPath = await temporaryConfig(unmanaged);
+    const unmanagedRestart = mock(async () => {});
+    expect(await reconcileManagedPostgrestPool(
+      request(unmanagedPath, unmanagedRestart),
+    )).toEqual({ state: "unchanged" });
+    expect(await readFile(unmanagedPath, "utf8")).toBe(unmanaged);
+    expect(unmanagedRestart).not.toHaveBeenCalled();
+
+    const malformed = `${MANAGED_CONFIG}db-pool = 4\n`;
+    const malformedPath = await temporaryConfig(malformed);
+    const malformedRestart = mock(async () => {});
+    await expect(
+      reconcileManagedPostgrestPool(request(malformedPath, malformedRestart)),
+    ).rejects.toThrow("exactly one db-pool setting");
+    expect(await readFile(malformedPath, "utf8")).toBe(malformed);
+    expect(malformedRestart).not.toHaveBeenCalled();
+
+    const missingPoolPath = await temporaryConfig(
+      MANAGED_CONFIG.replace("db-pool = 10\n", ""),
+    );
+    const missingPoolRestart = mock(async () => {});
+    await expect(
+      reconcileManagedPostgrestPool(request(missingPoolPath, missingPoolRestart)),
+    ).rejects.toThrow("exactly one db-pool setting");
+    expect(missingPoolRestart).not.toHaveBeenCalled();
+  });
+
+  test("preserves both candidate and rollback causes", async () => {
+    const configPath = await temporaryConfig();
+    const candidateError = new Error("candidate unhealthy");
+    const rollbackError = new Error("rollback unhealthy");
+    const restartAndWait = mock(async () => {
+      throw restartAndWait.mock.calls.length === 1 ? candidateError : rollbackError;
+    });
+
+    const failure = await reconcileManagedPostgrestPool(request(configPath, restartAndWait))
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(PostgrestPoolReconcileError);
+    expect((failure as PostgrestPoolReconcileError).errors).toEqual([
+      candidateError,
+      rollbackError,
+    ]);
+  });
+});

--- a/packages/management-api/tests/unit/postgrest-pool-reconcile.test.ts
+++ b/packages/management-api/tests/unit/postgrest-pool-reconcile.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  PostgrestPoolMigrationGate,
   PostgrestPoolReconcileError,
   reconcileManagedPostgrestPool,
   renderManagedPostgrestDbPool,
@@ -206,5 +207,45 @@ describe("managed PostgREST pool reconciliation", () => {
       candidateError,
       rollbackError,
     ]);
+  });
+
+  test("does not roll back over a concurrently regenerated config", async () => {
+    const configPath = await temporaryConfig();
+    const regeneratedConfig = MANAGED_CONFIG.replace(
+      "log-level = \"warn\"",
+      "log-level = \"info\"",
+    );
+    const restartAndWait = mock(async () => {
+      await writeFile(configPath, regeneratedConfig);
+      throw new Error("restart failed");
+    });
+
+    await expect(
+      reconcileManagedPostgrestPool(request(configPath, restartAndWait)),
+    ).rejects.toBeInstanceOf(PostgrestPoolReconcileError);
+    expect(await readFile(configPath, "utf8")).toBe(regeneratedConfig);
+    expect(restartAndWait).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PostgREST pool migration circuit breaker", () => {
+  test("stops the current multi-tenant sweep and backs off the failed pool version", () => {
+    let now = 1_000;
+    const gate = new PostgrestPoolMigrationGate(10_000, () => now);
+    const restartedRefs: string[] = [];
+
+    gate.beginSweep(3);
+    for (const ref of ["tenant-a", "tenant-b", "tenant-c"]) {
+      if (!gate.canAttempt()) continue;
+      restartedRefs.push(ref);
+      gate.recordFailure(3);
+    }
+    expect(restartedRefs).toEqual(["tenant-a"]);
+
+    expect(gate.beginSweep(3)).toBe(false);
+    now += 10_000;
+    expect(gate.beginSweep(3)).toBe(true);
+    gate.recordFailure(3);
+    expect(gate.beginSweep(4)).toBe(true);
   });
 });

--- a/packages/management-api/tests/unit/tenant-runtime.env.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.env.test.ts
@@ -465,4 +465,31 @@ describe("TenantRuntimeService auth-only apply boundary", () => {
     expect(authApplySection).toContain('runSystemctlOrThrow("restart", this.postgrestController.unit(ref))');
     expect(authApplySection).toContain("waitForHealthy");
   });
+
+  test("uses checked restart and serializes PostgREST pool config changes", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../../src/services/tenant-runtime.service.ts"),
+      "utf8",
+    );
+    const poolUpdateSection = source.slice(
+      source.indexOf("private async restartPostgrestForPoolUpdate"),
+      source.indexOf("private async refreshProjectPostgrestVerifier"),
+    );
+
+    expect(poolUpdateSection).toContain(
+      'runSystemctlOrThrow("restart", this.postgrestController.unit(ref))',
+    );
+    expect(poolUpdateSection).toContain("withTenantConfigLock");
+    expect(source).toContain("generateTenantConfigUnlocked");
+  });
+
+  test("prevents overlapping runtime reconciliation runs", () => {
+    const workerSource = readFileSync(
+      join(import.meta.dir, "../../src/workers/runtime-reconcile.worker.ts"),
+      "utf8",
+    );
+
+    expect(workerSource).toContain("if (reconciliationInFlight) return reconciliationInFlight");
+    expect(workerSource).toContain("performRuntimeReconciliation().finally");
+  });
 });

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -248,6 +248,15 @@ get_tenant_port() {
 }
 
 # ========== Query tenant credentials from supacloud_meta ==========
+
+resolve_postgrest_db_pool() {
+    local pool="${POSTGREST_DB_POOL:-3}"
+    if ! [[ "$pool" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: POSTGREST_DB_POOL must be a positive integer" >&2
+        return 1
+    fi
+    printf '%s' "$pool"
+}
 get_tenant_credentials() {
     local ref="$1"
     local field="$2"
@@ -803,7 +812,8 @@ generate_tenant_config() {
     local auth_db_uri="postgres://${encoded_admin_user}:${encoded_admin_password}@${PG_HOST}:${PG_PORT}/${encoded_db_name}"
 
     # 1. Generate PostgREST .env and .conf
-    local pgrst_env
+    local postgrest_db_pool pgrst_env
+    postgrest_db_pool=$(resolve_postgrest_db_pool) || return 1
     pgrst_env=$(cat <<EOF
 # SupaCloud Tenant PostgREST Runtime: ${ref}
 PGRST_DB_URI=$(systemd_env_quote "$tenant_db_uri")
@@ -812,7 +822,7 @@ PGRST_DB_EXTRA_SEARCH_PATH="public"
 PGRST_DB_ANON_ROLE="anon"
 PGRST_JWT_SECRET=$(systemd_env_quote "$jwt_secret")
 PGRST_SERVER_PORT=${pgrst_port}
-PGRST_DB_POOL=3
+PGRST_DB_POOL=${postgrest_db_pool}
 PGRST_DB_POOL_ACQUISITION_TIMEOUT=10
 PGRST_LOG_LEVEL="warn"
 EOF
@@ -831,7 +841,7 @@ jwt-secret = $(toml_basic_string "$jwt_secret")
 server-port = ${pgrst_port}
 # Bind to 0.0.0.0 so the host gateway can reach the tenant runtime.
 server-host = "0.0.0.0"
-db-pool = 3
+db-pool = ${postgrest_db_pool}
 db-pool-acquisition-timeout = 10
 log-level = "warn"
 db-channel = $(toml_basic_string "pgrst_${ref}")

--- a/scripts/lib/tenant_runtime.test.sh
+++ b/scripts/lib/tenant_runtime.test.sh
@@ -50,6 +50,17 @@ trap 'rm -rf "$tmp_dir"' EXIT
 source "$RUNTIME_SCRIPT"
 export SECRETS_ENCRYPTION_KEY='tenant-runtime-test-encryption-key-0123456789abcdef'
 
+unset POSTGREST_DB_POOL
+[[ "$(resolve_postgrest_db_pool)" == "3" ]]
+POSTGREST_DB_POOL=7
+[[ "$(resolve_postgrest_db_pool)" == "7" ]]
+POSTGREST_DB_POOL=0
+if resolve_postgrest_db_pool >/dev/null 2>&1; then
+    echo "POSTGREST_DB_POOL accepted a non-positive value" >&2
+    exit 1
+fi
+unset POSTGREST_DB_POOL
+
 special=$'p@:/#?% space \'"\\'
 encoded_special='p%40%3A%2F%23%3F%25%20space%20%27%22%5C'
 [[ "$(uri_percent_encode "$special")" == "$encoded_special" ]]
@@ -254,7 +265,9 @@ grep -Fq 'mv -f "$install_tmp" "$target_path"' "$RUNTIME_SCRIPT"
 )
 
 grep -Fqx "PGRST_DB_URI=\"postgres://authenticator_abc123:${encoded_special}@localhost:6432/supa_abc123\"" "$tmp_dir/tenants/abc123.env"
+grep -Fqx "PGRST_DB_POOL=3" "$tmp_dir/tenants/abc123.env"
 grep -Fqx "db-uri = \"postgres://authenticator_abc123:${encoded_special}@localhost:6432/supa_abc123\"" "$tmp_dir/tenants/abc123.conf"
+grep -Fqx "db-pool = 3" "$tmp_dir/tenants/abc123.conf"
 grep -Fqx "GOTRUE_DB_DATABASE_URL=\"postgres://supabase_auth_admin:${encoded_special}@localhost:6432/supa_abc123\"" "$tmp_dir/tenants/abc123_gotrue.env"
 grep -Fq 'PGRST_JWT_SECRET="p@:/#?% space '\''\"\\"' "$tmp_dir/tenants/abc123.env"
 grep -Fq 'GOTRUE_SMTP_USER="p@:/#?% space '\''\"\\"' "$tmp_dir/tenants/abc123_gotrue.env"


### PR DESCRIPTION
## Summary
- lower the default per-tenant PostgREST pool to 3 and make the Management API pool configurable with a default of 5
- reconcile managed active PostgREST configs one tenant at a time with health-checked rollback
- keep explicit overrides, stopped projects, and unmanaged configs unchanged
- document the connection-budget boundary without changing PostgreSQL max_connections

## Validation
- `bun run typecheck`
- `bun run test:unit`
- `bun test tests/unit/postgrest-pool-reconcile.test.ts tests/unit/config.test.ts tests/unit/config-loading.test.ts tests/unit/tenant-runtime.env.test.ts` (83 pass)
- `bash scripts/lib/tenant_runtime.test.sh`
- `git diff --check`