### PR TITLE
fix(runtime): bound gotrue database pool

### DIFF
--- a/docs/multi-tenant-management.md
+++ b/docs/multi-tenant-management.md
@@ -296,6 +296,7 @@ MASTER_TOKEN=your-secure-master-token
 SCRIPTS_PATH=/opt/supacloud/scripts/lib
 # Capacity-safe defaults; omit both unless an operator has measured headroom.
 POSTGREST_DB_POOL=3
+GOTRUE_DB_MAX_POOL_SIZE=2
 MANAGEMENT_DB_POOL=5
 MANAGEMENT_PROJECT_DB_POOL=2
 MANAGEMENT_PROJECT_ROLE_DB_POOL=1
@@ -313,6 +314,11 @@ off that pool version for one hour, preventing a cross-tenant restart storm.
 Stopped projects and unmanaged configuration files are not changed. These
 pool settings budget connections within the existing PostgreSQL capacity;
 they do not change PostgreSQL `max_connections`.
+
+`GOTRUE_DB_MAX_POOL_SIZE` bounds each tenant GoTrue runtime's direct auth
+database connections. It is rendered by both the Management API runtime
+generator and the legacy shell generator so auth tenants do not fall back to
+GoTrue's unlimited pool default after provisioning or repair.
 
 `MANAGEMENT_DB_POOL` limits the `supacloud_meta` pool. Project database access
 uses separate admin and tenant-role pools capped by

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -131,6 +131,7 @@ export interface Config {
   postgrestMemoryMax: string;
   postgrestCpuWeight: number;
   postgrestDbPool: number;
+  gotrueDbPool: number;
   managementDbPool: number;
   managementProjectDbPool: number;
   managementProjectRoleDbPool: number;
@@ -325,6 +326,7 @@ export const config: Config = {
   postgrestMemoryMax: getEnv("POSTGREST_MEMORY_MAX", "384M"),
   postgrestCpuWeight: Number(getEnv("POSTGREST_CPU_WEIGHT", "40")),
   postgrestDbPool: Number(getEnv("POSTGREST_DB_POOL", "3")),
+  gotrueDbPool: Number(getEnv("GOTRUE_DB_MAX_POOL_SIZE", "2")),
   managementDbPool: Number(getEnv("MANAGEMENT_DB_POOL", "5")),
   managementProjectDbPool: Number(getEnv("MANAGEMENT_PROJECT_DB_POOL", "2")),
   managementProjectRoleDbPool: Number(getEnv("MANAGEMENT_PROJECT_ROLE_DB_POOL", "1")),
@@ -413,6 +415,9 @@ function validateConfig() {
   }
   if (!Number.isInteger(config.postgrestDbPool) || config.postgrestDbPool <= 0) {
     throw new Error("Invalid POSTGREST_DB_POOL configuration. Must be a positive integer.");
+  }
+  if (!Number.isInteger(config.gotrueDbPool) || config.gotrueDbPool <= 0) {
+    throw new Error("Invalid GOTRUE_DB_MAX_POOL_SIZE configuration. Must be a positive integer.");
   }
   if (!Number.isInteger(config.managementDbPool) || config.managementDbPool <= 0) {
     throw new Error("Invalid MANAGEMENT_DB_POOL configuration. Must be a positive integer.");

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -1187,6 +1187,7 @@ db-channel = ${quoteTomlBasicString(resolvePgrstChannel(ref))}
             renderSystemdEnvLine("GOTRUE_URI_ALLOW_LIST", redirectOrigins.join(",")),
             renderSystemdEnvLine("GOTRUE_DB_DRIVER", "postgres"),
             renderSystemdEnvLine("GOTRUE_DB_DATABASE_URL", authDbUri),
+            `GOTRUE_DB_MAX_POOL_SIZE=${config.gotrueDbPool}`,
             renderSystemdEnvLine("GOTRUE_JWT_SECRET", creds.jwtSecret),
             `
 GOTRUE_JWT_AUD=authenticated

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -32,6 +32,7 @@ function cleanEnv(overrides: Record<string, string>) {
     "INTERNAL_IP",
     "SUPACLOUD_CADDY_TLS_ISSUER",
     "POSTGREST_DB_POOL",
+    "GOTRUE_DB_MAX_POOL_SIZE",
     "MANAGEMENT_DB_POOL",
     "MANAGEMENT_PROJECT_DB_POOL",
     "MANAGEMENT_PROJECT_ROLE_DB_POOL",
@@ -80,7 +81,7 @@ function loadDatabaseUrl(env: Record<string, string>) {
 function loadDatabasePools(env: Record<string, string>) {
   const result = spawnSync("bun", ["-e", [
     'import { config } from "./src/config.ts";',
-    'console.log(`RESULT=${config.postgrestDbPool}:${config.managementDbPool}:${config.managementProjectDbPool}:${config.managementProjectRoleDbPool}:${config.managementProjectPoolCacheSize}`);',
+    'console.log(`RESULT=${config.postgrestDbPool}:${config.gotrueDbPool}:${config.managementDbPool}:${config.managementProjectDbPool}:${config.managementProjectRoleDbPool}:${config.managementProjectPoolCacheSize}`);',
   ].join(" ")], { cwd: packageRoot, env, encoding: "utf8" });
   expect(result.status, result.stderr).toBe(0);
   return result.stdout.match(/RESULT=([^\n]+)/)?.[1];
@@ -177,20 +178,22 @@ describe("production config loading boundaries", () => {
   });
 
   test("uses capacity-safe pool defaults and honors explicit overrides", () => {
-    expect(loadDatabasePools(cleanEnv({ NODE_ENV: "production" }))).toBe("3:5:2:1:5");
+    expect(loadDatabasePools(cleanEnv({ NODE_ENV: "production" }))).toBe("3:2:5:2:1:5");
     expect(loadDatabasePools(cleanEnv({
       NODE_ENV: "production",
       POSTGREST_DB_POOL: "7",
+      GOTRUE_DB_MAX_POOL_SIZE: "8",
       MANAGEMENT_DB_POOL: "9",
       MANAGEMENT_PROJECT_DB_POOL: "2",
       MANAGEMENT_PROJECT_ROLE_DB_POOL: "3",
       MANAGEMENT_PROJECT_POOL_CACHE_SIZE: "4",
-    }))).toBe("7:9:2:3:4");
+    }))).toBe("7:8:9:2:3:4");
   });
 
   test.each([
     { POSTGREST_DB_POOL: "0" },
     { POSTGREST_DB_POOL: "1.5" },
+    { GOTRUE_DB_MAX_POOL_SIZE: "0" },
     { MANAGEMENT_DB_POOL: "not-a-number" },
     { MANAGEMENT_PROJECT_DB_POOL: "0" },
     { MANAGEMENT_PROJECT_ROLE_DB_POOL: "1.5" },
@@ -203,7 +206,7 @@ describe("production config loading boundaries", () => {
     });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("DB_POOL");
+    expect(result.stderr).toContain("POOL");
   });
 
   test("rejects a BFF signing secret shared with another privileged key", () => {

--- a/packages/management-api/tests/unit/config.test.ts
+++ b/packages/management-api/tests/unit/config.test.ts
@@ -53,6 +53,7 @@ describe("Config", () => {
     expect(config.postgrestMemoryMax).toBe("384M");
     expect(config.postgrestCpuWeight).toBeGreaterThanOrEqual(40);
     expect(config.postgrestDbPool).toBe(3);
+    expect(config.gotrueDbPool).toBe(2);
     expect(config.managementDbPool).toBe(5);
     expect(managementSql.options.max).toBe(config.managementDbPool);
     expect(config.managementProjectDbPool).toBe(2);

--- a/packages/management-api/tests/unit/tenant-runtime.env.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.env.test.ts
@@ -483,6 +483,22 @@ describe("TenantRuntimeService auth-only apply boundary", () => {
     expect(source).toContain("generateTenantConfigUnlocked");
   });
 
+  test("renders a bounded GoTrue database pool", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../../src/services/tenant-runtime.service.ts"),
+      "utf8",
+    );
+    const gotrueEnvStart = source.indexOf("const gotrueEnvLines = [");
+    const gotrueEnvSection = source.slice(
+      gotrueEnvStart,
+      source.indexOf("const oauthServerConfig = normalizeOAuthServerConfig", gotrueEnvStart),
+    );
+
+    expect(gotrueEnvSection).toContain("GOTRUE_DB_DATABASE_URL");
+    expect(gotrueEnvSection).toContain("GOTRUE_DB_MAX_POOL_SIZE");
+    expect(gotrueEnvSection).toContain("config.gotrueDbPool");
+  });
+
   test("prevents overlapping runtime reconciliation runs", () => {
     const workerSource = readFileSync(
       join(import.meta.dir, "../../src/workers/runtime-reconcile.worker.ts"),

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -257,6 +257,15 @@ resolve_postgrest_db_pool() {
     fi
     printf '%s' "$pool"
 }
+
+resolve_gotrue_db_pool() {
+    local pool="${GOTRUE_DB_MAX_POOL_SIZE:-2}"
+    if ! [[ "$pool" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: GOTRUE_DB_MAX_POOL_SIZE must be a positive integer" >&2
+        return 1
+    fi
+    printf '%s' "$pool"
+}
 get_tenant_credentials() {
     local ref="$1"
     local field="$2"
@@ -869,7 +878,8 @@ EOF
     chown "$runtime_user:$runtime_user" "$gotrue_config_dir" || return 1
     chmod 700 "$gotrue_config_dir" || return 1
 
-    local gotrue_env
+    local gotrue_db_pool gotrue_env
+    gotrue_db_pool=$(resolve_gotrue_db_pool) || return 1
     gotrue_env=$(cat <<EOF
 # SupaCloud Tenant GoTrue Runtime: ${ref}
 # Bind to 0.0.0.0 so the host gateway can reach the tenant runtime.
@@ -881,6 +891,7 @@ API_EXTERNAL_URL=$(systemd_env_quote "$auth_api_external_url")
 GOTRUE_SITE_URL=$(systemd_env_quote "$api_external_url")
 GOTRUE_DB_DRIVER="postgres"
 GOTRUE_DB_DATABASE_URL=$(systemd_env_quote "$auth_db_uri")
+GOTRUE_DB_MAX_POOL_SIZE=${gotrue_db_pool}
 
 GOTRUE_JWT_SECRET=$(systemd_env_quote "$jwt_secret")
 GOTRUE_JWT_EXP=3600

--- a/scripts/lib/tenant_runtime.test.sh
+++ b/scripts/lib/tenant_runtime.test.sh
@@ -61,6 +61,17 @@ if resolve_postgrest_db_pool >/dev/null 2>&1; then
 fi
 unset POSTGREST_DB_POOL
 
+unset GOTRUE_DB_MAX_POOL_SIZE
+[[ "$(resolve_gotrue_db_pool)" == "2" ]]
+GOTRUE_DB_MAX_POOL_SIZE=4
+[[ "$(resolve_gotrue_db_pool)" == "4" ]]
+GOTRUE_DB_MAX_POOL_SIZE=0
+if resolve_gotrue_db_pool >/dev/null 2>&1; then
+    echo "GOTRUE_DB_MAX_POOL_SIZE accepted a non-positive value" >&2
+    exit 1
+fi
+unset GOTRUE_DB_MAX_POOL_SIZE
+
 special=$'p@:/#?% space \'"\\'
 encoded_special='p%40%3A%2F%23%3F%25%20space%20%27%22%5C'
 [[ "$(uri_percent_encode "$special")" == "$encoded_special" ]]
@@ -269,6 +280,7 @@ grep -Fqx "PGRST_DB_POOL=3" "$tmp_dir/tenants/abc123.env"
 grep -Fqx "db-uri = \"postgres://authenticator_abc123:${encoded_special}@localhost:6432/supa_abc123\"" "$tmp_dir/tenants/abc123.conf"
 grep -Fqx "db-pool = 3" "$tmp_dir/tenants/abc123.conf"
 grep -Fqx "GOTRUE_DB_DATABASE_URL=\"postgres://supabase_auth_admin:${encoded_special}@localhost:6432/supa_abc123\"" "$tmp_dir/tenants/abc123_gotrue.env"
+grep -Fqx "GOTRUE_DB_MAX_POOL_SIZE=2" "$tmp_dir/tenants/abc123_gotrue.env"
 grep -Fq 'PGRST_JWT_SECRET="p@:/#?% space '\''\"\\"' "$tmp_dir/tenants/abc123.env"
 grep -Fq 'GOTRUE_SMTP_USER="p@:/#?% space '\''\"\\"' "$tmp_dir/tenants/abc123_gotrue.env"
 grep -Fqx 'GOTRUE_SMTP_SENDER_NAME="SupaCloud"' "$tmp_dir/tenants/abc123_gotrue.env"


### PR DESCRIPTION
## Summary
- bound each tenant GoTrue runtime's database pool to a finite default of 2
- propagate the pool cap through the management API generator, legacy shell generator, docs, and config validation
- add regression coverage for config loading, generated env files, and shell generation

## Validation
- `bun test tests/unit/config.test.ts tests/unit/config-loading.test.ts tests/unit/tenant-runtime.env.test.ts`
- `bash scripts/lib/tenant_runtime.test.sh`
- `bun run typecheck`
- `bun run test:unit`
- `git diff --check origin/main...HEAD`
