### PR TITLE
fix: baseline migrations through authorized ledger API

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { cliToolResultIsError } from "./shared/cli";
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const CONTEXT_KEYS = new Set([
@@ -54,6 +55,13 @@ async function runProjectCli(
 }
 
 describe("supacloud-cli process contract", () => {
+    test("treats failure text as an error even when isError is false", () => {
+        expect(cliToolResultIsError({
+            isError: false,
+            content: [{ type: "text", text: "❌ Failed (400)" }],
+        })).toBe(true);
+    });
+
     test("shows branch action flags even before project context is configured", async () => {
         const result = await runProjectCli(["branch", "promotion_plan", "--help"]);
 
@@ -116,6 +124,40 @@ describe("supacloud-cli process contract", () => {
         expect(result.exitCode).toBe(0);
         expect(requestedUrl).toContain("/v1/projects/abc123/logs?");
         expect(requestedUrl).toContain("service=database");
+    });
+
+    test("returns non-zero when an HTTP tool result reports an explicit failure", async () => {
+        const migrationRoot = mkdtempSync(join(tmpdir(), "supacloud-cli-baseline-"));
+        temporaryDirectories.push(migrationRoot);
+        writeFileSync(join(migrationRoot, "20260729090000_create_orders.sql"), "CREATE TABLE orders (id uuid);\n");
+        const requestedPaths: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                const path = new URL(request.url).pathname;
+                requestedPaths.push(path);
+                if (request.method === "GET") return Response.json([]);
+                return Response.json({ code: "migration_baseline_rejected" }, { status: 400 });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(
+            ["database", "baseline_migrations", "--dir", migrationRoot],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toContain("❌ Failed (400)");
+        expect(requestedPaths).toEqual([
+            "/v1/projects/abc123/database/migrations",
+            "/v1/projects/abc123/database/migrations/baseline",
+        ]);
     });
 
     test("status reports missing configuration and exits non-zero", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { Type } from "@sinclair/typebox";
 import { stringEnum } from "./shared/schema";
-import { runCli } from "./shared/cli";
+import { cliToolResultIsError, runCli } from "./shared/cli";
 import { resolveSupaCloudContext, type ResolvedContext } from "./shared/context";
 import { HttpTransport } from "./shared/transports/http";
 import { registerDatabaseTools } from "./shared/tools/database-tools";
@@ -363,7 +363,7 @@ async function main() {
                     console.log(chunk.text);
                 }
             }
-            if (result.isError === true) process.exitCode = 1;
+            if (cliToolResultIsError(result)) process.exitCode = 1;
             return;
         }
         console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/shared/cli.ts
+++ b/packages/cli/src/shared/cli.ts
@@ -16,6 +16,13 @@ interface CliToolResult {
     isError?: boolean;
 }
 
+export function cliToolResultIsError(toolResult: CliToolResult): boolean {
+    if (toolResult.isError === true) return true;
+    return toolResult.content?.some((chunk) =>
+        chunk.type === "text" && chunk.text?.trimStart().startsWith("❌") === true
+    ) ?? false;
+}
+
 function coerceCliValue(value: string): string | number | boolean {
     if (value === "true") return true;
     if (value === "false") return false;
@@ -156,7 +163,7 @@ export async function runCli(
         } else {
             console.log(JSON.stringify(result, null, 2));
         }
-        process.exit(result && typeof result === "object" && "isError" in result && result.isError === true ? 1 : 0);
+        process.exit(cliToolResultIsError(result) ? 1 : 0);
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`❌ Error: ${message}`);

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -394,7 +394,7 @@ describe("database migration helpers", () => {
         }
     });
 
-  test("baselines missing migrations through migration-mode SQL", async () => {
+  test("baselines missing migrations through the dedicated ledger endpoint", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         const posts: Array<{ path: string; body: any }> = [];
         try {
@@ -408,7 +408,7 @@ describe("database migration helpers", () => {
                 },
                 post: async (path: string, body: unknown) => {
                     posts.push({ path, body });
-                    return { ok: true, status: 200, data: { rows: [] } };
+                    return { ok: true, status: 200, data: { marked: 2, already_applied: 0 } };
                 },
             });
 
@@ -422,13 +422,13 @@ describe("database migration helpers", () => {
             expect(text).toContain("Migration baseline completed");
             expect(text).toContain("Marked applied: 2");
             expect(posts).toHaveLength(1);
-            expect(posts[0].path).toBe("/v1/projects/proj/database/sql");
-            expect(posts[0].body.mode).toBe("migration");
-            expect(posts[0].body.sql).toContain("CREATE SCHEMA IF NOT EXISTS supabase_migrations");
-            expect(posts[0].body.sql).toContain("CREATE TABLE IF NOT EXISTS public.schema_migrations");
-            expect(posts[0].body.sql).toContain("20260425123000_create_users");
-            expect(posts[0].body.sql).toContain("20260425124000_create_tasks");
-            expect(posts[0].body.sql).toContain("ON CONFLICT (version) DO UPDATE");
+            expect(posts[0].path).toBe("/v1/projects/proj/database/migrations/baseline");
+            expect(posts[0].body).toEqual({
+                migrations: [
+                    { name: "20260425123000_create_users", version: "20260425123000" },
+                    { name: "20260425124000_create_tasks", version: "20260425124000" },
+                ],
+            });
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -492,8 +492,10 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const baselineSql = buildMigrationBaselineSql(missing);
-                    const baselineResult = await execSql(baselineSql, "migration");
+                    const baselineResult = await http.post(
+                        `/v1/projects/${ref}/database/migrations/baseline`,
+                        { migrations: missing.map(({ name, version }) => ({ name, version })) },
+                    );
                     text = baselineResult.ok
                         ? [
                             `✅ Migration baseline completed for ${dir}`,
@@ -572,52 +574,6 @@ function buildRlsPolicySql(
       CREATE POLICY "SupaCloud owner insert" ON ${qualifiedTable} FOR INSERT TO authenticated WITH CHECK (${predicate});
       CREATE POLICY "SupaCloud owner update" ON ${qualifiedTable} FOR UPDATE TO authenticated USING (${predicate}) WITH CHECK (${predicate});
       CREATE POLICY "SupaCloud owner delete" ON ${qualifiedTable} FOR DELETE TO authenticated USING (${predicate});`;
-}
-
-function sqlString(value: string): string {
-    return `'${value.replace(/'/g, "''")}'`;
-}
-
-function buildMigrationBaselineSql(migrations: Array<{ name: string; version: string }>): string {
-    const values = migrations
-        .map(({ name, version }) => `(${version}, ${sqlString(name)}, ARRAY[${sqlString(`baseline:${name}`)}]::text[])`)
-        .join(",\n    ");
-
-    return `
-CREATE SCHEMA IF NOT EXISTS supabase_migrations;
-
-CREATE TABLE IF NOT EXISTS supabase_migrations.schema_migrations (
-  version BIGINT PRIMARY KEY,
-  statements TEXT[],
-  name TEXT
-);
-
-CREATE TABLE IF NOT EXISTS public.schema_migrations (
-  version VARCHAR(255) PRIMARY KEY,
-  statements TEXT[],
-  name TEXT
-);
-
-WITH baseline(version, name, statements) AS (
-  VALUES
-    ${values}
-)
-INSERT INTO supabase_migrations.schema_migrations (version, statements, name)
-SELECT version, statements, name FROM baseline
-ON CONFLICT (version) DO UPDATE
-SET statements = EXCLUDED.statements,
-    name = EXCLUDED.name;
-
-WITH baseline(version, name, statements) AS (
-  VALUES
-    ${values}
-)
-INSERT INTO public.schema_migrations (version, statements, name)
-SELECT version::text, statements, name FROM baseline
-ON CONFLICT (version) DO UPDATE
-SET statements = EXCLUDED.statements,
-    name = EXCLUDED.name;
-`.trim();
 }
 
 // ── Format Helpers ──

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -594,6 +594,20 @@ interface MigrationExecutionPlan {
   statements: readonly string[];
 }
 
+interface MigrationBaseline {
+  version: string;
+  name: string;
+}
+
+interface RecordedBaseline extends MigrationBaseline {
+  checksum: string;
+}
+
+interface MigrationBaselineSummary {
+  marked: RecordedBaseline[];
+  alreadyApplied: MigrationBaseline[];
+}
+
 export const MIGRATION_SESSION_RESET_SQL = "RESET ALL; DISCARD TEMP; DISCARD PLANS";
 
 function existingMigrationChecksum(
@@ -616,6 +630,23 @@ function normalizedMigrationStatements(value: unknown): string[] {
     .filter((statement): statement is string => typeof statement === "string")
     .map((statement) => statement.replace(/\r\n?/g, "\n").trim())
     .filter(Boolean);
+}
+
+function normalizeMigrationBaselines(
+  rawMigrations: ReadonlyArray<{ version: unknown; name: unknown }>,
+): MigrationBaseline[] {
+  const versions = new Set<string>();
+  const names = new Set<string>();
+  return rawMigrations.map((migration) => {
+    const version = normalizeMigrationVersion(migration.version);
+    const name = normalizeMigrationName(migration.name, version);
+    if (versions.has(version) || names.has(name)) {
+      throw new MigrationRouteError(400, "duplicate_migration_baseline", "Migration baseline versions and names must be unique");
+    }
+    versions.add(version);
+    names.add(name);
+    return { version, name };
+  });
 }
 
 /**
@@ -683,6 +714,20 @@ async function insertMigrationLedger(
   `;
 }
 
+async function releaseMigrationLeaseSafely(
+  adminDb: ProjectSql,
+  lease: Awaited<ReturnType<typeof issueMigrationLedgerLease>>,
+  projectRef: string,
+): Promise<void> {
+  try {
+    await releaseMigrationLedgerLease(adminDb, lease.tokenHash);
+  } catch (error: unknown) {
+    logger.warn(`[database] failed to clean migration ledger lease for ${projectRef}`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 async function executeMigrationTransaction(
   connection: ReservedProjectSql,
   adminDb: ProjectSql,
@@ -720,14 +765,48 @@ async function executeMigrationTransaction(
     });
   } finally {
     const lease = leaseHolder.current;
-    if (lease) {
-      try {
-        await releaseMigrationLedgerLease(adminDb, lease.tokenHash);
-      } catch (error: unknown) {
-        logger.warn(`[database] failed to clean migration ledger lease for ${input.projectRef}`, {
-          error: error instanceof Error ? error.message : String(error),
-        });
+    if (lease) await releaseMigrationLeaseSafely(adminDb, lease, input.projectRef);
+  }
+}
+
+function existingBaselineIsApplied(
+  existing: Record<string, unknown>[],
+  input: RecordedMigrationInput,
+): boolean {
+  if (existing.length === 0) return false;
+  if (existing.every((row) => migrationLedgerEntryMatches(row, input))) return true;
+  throw new MigrationRouteError(
+    409,
+    "migration_baseline_conflict",
+    `Migration ${input.name} conflicts with an existing version or name`,
+  );
+}
+
+async function recordBaselineTransaction(
+  connection: ReservedProjectSql,
+  adminDb: ProjectSql,
+  inputs: RecordedMigrationInput[],
+): Promise<MigrationBaselineSummary> {
+  const leases: Array<Awaited<ReturnType<typeof issueMigrationLedgerLease>>> = [];
+  try {
+    return await connection.begin(async (tx) => {
+      const summary: MigrationBaselineSummary = { marked: [], alreadyApplied: [] };
+      for (const input of inputs) {
+        if (existingBaselineIsApplied(await findExistingMigration(tx, input), input)) {
+          summary.alreadyApplied.push({ version: input.version, name: input.name });
+          continue;
+        }
+        const checksum = calculateMigrationChecksum(input);
+        const lease = await issueMigrationLedgerLease(adminDb, input.version, checksum);
+        leases.push(lease);
+        await insertMigrationLedger(tx, input, checksum, lease.token);
+        summary.marked.push({ version: input.version, name: input.name, checksum });
       }
+      return summary;
+    });
+  } finally {
+    for (const lease of leases) {
+      await releaseMigrationLeaseSafely(adminDb, lease, inputs[0]!.projectRef);
     }
   }
 }
@@ -770,6 +849,40 @@ async function applyRecordedMigration(input: RecordedMigrationInput): Promise<{
       return { checksum, alreadyApplied };
     });
   });
+}
+
+async function recordMigrationBaselines(
+  projectRef: string,
+  credentials: ProjectMigrationCredentials,
+  migrations: readonly MigrationBaseline[],
+): Promise<MigrationBaselineSummary> {
+  const inputs = migrations.map(({ version, name }) => ({
+    projectRef,
+    credentials,
+    version,
+    name,
+    statements: [`baseline:${name}`],
+    conflictOnName: true,
+  }));
+  return withProjectMigrationLocks({ projectRefs: [projectRef] }, async () => {
+    await branchReplacementJournal.assertInactive([projectRef]);
+    return withMigrationRoleSession(inputs[0]!, (connection, adminDb) =>
+      recordBaselineTransaction(connection, adminDb, inputs));
+  });
+}
+
+function migrationRouteFailure(error: unknown) {
+  if (error instanceof MigrationRouteError || error instanceof ProjectMigrationLockError
+    || error instanceof BranchReplacementJournalActiveError) {
+    return { message: error.message, code: error.code, status: error.httpStatus };
+  }
+  const { errorMessage } = databaseErrorDetails(error);
+  return {
+    message: "Migration failed",
+    detail: errorMessage,
+    code: "500",
+    status: 500 as const,
+  };
 }
 
 function projectAuthResponse(authError: { status: number; body: { error: string } }, set: { status?: number | string }) {
@@ -1496,6 +1609,48 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
         }
     )
     .post(
+        "/migrations/baseline",
+        async ({ params, body, request, set }) => {
+            const authError = await requireProjectOrAdminAuth(request, params.ref);
+            if (authError) return projectAuthResponse(authError, set);
+
+            const project = await projectService.getProject(params.ref);
+            if (!project) {
+                set.status = 404;
+                return { message: "Project not found", code: "404", status: 404 };
+            }
+
+            try {
+                const migrations = normalizeMigrationBaselines(body.migrations);
+                const credentials = await getProjectDatabaseCredentials(params.ref);
+                if (!credentials) {
+                    set.status = 404;
+                    return { message: "Project database credentials not found", code: "404", status: 404 };
+                }
+                const summary = await recordMigrationBaselines(params.ref, credentials, migrations);
+                return {
+                    marked: summary.marked.length,
+                    already_applied: summary.alreadyApplied.length,
+                    migrations: summary.marked,
+                };
+            } catch (error: unknown) {
+                const failure = migrationRouteFailure(error);
+                set.status = failure.status;
+                return failure;
+            }
+        },
+        {
+            params: t.Object({ ref: t.String({ minLength: 1 }) }),
+            body: t.Object({
+                migrations: t.Array(t.Object({
+                    version: t.String({ minLength: 1, maxLength: 19, pattern: "^[0-9]+$" }),
+                    name: t.String({ minLength: 1, maxLength: 255 }),
+                }), { minItems: 1, maxItems: 1000 }),
+            }),
+            detail: { tags: ["projects"], summary: "Record schema-equivalent migrations without executing DDL" },
+        },
+    )
+    .post(
         "/migrations",
         async ({ params, body, request, set }) => {
             const authError = await requireProjectOrAdminAuth(request, params.ref);
@@ -1544,26 +1699,9 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
                 }
                 return { version, ...(isStructuredFormat ? { name } : {}), statements, checksum: result.checksum };
             } catch (error: unknown) {
-                if (error instanceof MigrationRouteError) {
-                    set.status = error.httpStatus;
-                    return { message: error.message, code: error.code, status: error.httpStatus };
-                }
-                if (error instanceof ProjectMigrationLockError) {
-                    set.status = error.httpStatus;
-                    return { message: error.message, code: error.code, status: error.httpStatus };
-                }
-                if (error instanceof BranchReplacementJournalActiveError) {
-                    set.status = error.httpStatus;
-                    return { message: error.message, code: error.code, status: error.httpStatus };
-                }
-                set.status = 500;
-                const detail = error instanceof Error ? error.message : String(error);
-                return {
-                    message: "Migration failed",
-                    detail,
-                    code: "500",
-                    status: 500,
-                };
+                const failure = migrationRouteFailure(error);
+                set.status = failure.status;
+                return failure;
             }
         },
         {

--- a/packages/management-api/tests/unit/database-migration-baseline.routes.test.ts
+++ b/packages/management-api/tests/unit/database-migration-baseline.routes.test.ts
@@ -1,0 +1,243 @@
+// @supacloud-test-isolate — mocks project database sessions and migration leases.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+
+interface QueryCall {
+  text: string;
+  values: unknown[];
+}
+
+const transactionCalls: QueryCall[] = [];
+let existingMigrationRows: Array<Record<string, unknown>> = [];
+let transactionFailure: Error | null = null;
+
+const transaction = Object.assign(
+  mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join("?");
+    transactionCalls.push({ text, values });
+    if (text.includes("FROM supabase_migrations.schema_migrations")) {
+      return Promise.resolve(existingMigrationRows);
+    }
+    if (text.includes("record_schema_migration") && transactionFailure) {
+      return Promise.reject(transactionFailure);
+    }
+    return Promise.resolve([]);
+  }),
+  { array: (values: unknown[]) => values },
+);
+const connection = {
+  begin: mock(async (operation: (sql: typeof transaction) => Promise<unknown>) => operation(transaction)),
+  unsafe: mock(async () => []),
+  release: mock(() => undefined),
+};
+const roleDb = { reserve: mock(async () => connection) };
+const adminDb = Object.assign(mock(async () => []), { unsafe: mock(async () => []) });
+const managementDb = mock((strings: TemplateStringsArray) => {
+  if (strings.join("?").includes("SELECT db_name, db_user, db_password")) {
+    return Promise.resolve([{
+      db_name: "tenant_db",
+      db_user: "tenant_user",
+      db_password: "test-password",
+    }]);
+  }
+  return Promise.resolve([]);
+});
+
+const getProject = mock(async () => ({ ref: "proj_1" }));
+const requireProjectOrAdminAuth = mock(async () => undefined);
+const issueMigrationLedgerLease = mock(async (_database: unknown, version: string) => ({
+  token: `token-${version}`,
+  tokenHash: `token-hash-${version}`,
+}));
+const releaseMigrationLedgerLease = mock(async () => undefined);
+const prepareProjectMigrationRole = mock(async () => undefined);
+const withProjectMigrationLocks = mock(async (_scope: unknown, operation: () => Promise<unknown>) => operation());
+const assertInactive = mock(async () => undefined);
+
+const actualDb = await import("../../src/db");
+mock.module("../../src/db", () => ({
+  ...actualDb,
+  sql: managementDb,
+  getProjectDb: mock(() => adminDb),
+  getProjectRoleDb: mock(() => roleDb),
+  removeProjectDbCache: mock(async () => undefined),
+}));
+mock.module("../../src/services", () => ({ projectService: { getProject } }));
+mock.module("../../src/middleware/auth", () => ({
+  requireAdminAuth: mock(async () => undefined),
+  requireProjectOrAdminAuth,
+}));
+
+const actualLedger = await import("../../src/services/migration-ledger");
+mock.module("../../src/services/migration-ledger", () => ({
+  ...actualLedger,
+  ensureMigrationLedgerMetadata: mock(async () => undefined),
+  reconcileMigrationLedgerVersions: mock(async () => undefined),
+}));
+const actualLock = await import("../../src/services/migration-lock");
+mock.module("../../src/services/migration-lock", () => ({
+  ...actualLock,
+  withProjectMigrationLocks,
+}));
+const actualJournal = await import("../../src/services/branch-replacement-journal");
+mock.module("../../src/services/branch-replacement-journal", () => ({
+  ...actualJournal,
+  branchReplacementJournal: { assertInactive },
+}));
+mock.module("../../src/services/project-migration-role", () => ({ prepareProjectMigrationRole }));
+mock.module("../../src/services/migration-ledger-lease", () => ({
+  issueMigrationLedgerLease,
+  releaseMigrationLedgerLease,
+}));
+mock.module("../../src/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { databaseRoutes, resetEnsuredMigrationTablesForTests } = await import(
+  new URL("../../src/routes/database.ts?database-migration-baseline-routes-test", import.meta.url).href,
+);
+const app = new Elysia().use(databaseRoutes);
+
+function baselineRequest(migrations: Array<{ version: string; name: string }>) {
+  return app.handle(new Request("http://localhost/v1/projects/proj_1/database/migrations/baseline", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ migrations }),
+  }));
+}
+
+describe("database migration baseline route", () => {
+  beforeEach(() => {
+    resetEnsuredMigrationTablesForTests();
+    transactionCalls.length = 0;
+    existingMigrationRows = [];
+    transactionFailure = null;
+    transaction.mockClear();
+    connection.begin.mockClear();
+    connection.unsafe.mockClear();
+    connection.release.mockClear();
+    managementDb.mockClear();
+    getProject.mockClear();
+    requireProjectOrAdminAuth.mockClear();
+    issueMigrationLedgerLease.mockClear();
+    releaseMigrationLedgerLease.mockClear();
+    prepareProjectMigrationRole.mockClear();
+    withProjectMigrationLocks.mockClear();
+    assertInactive.mockClear();
+  });
+
+  test("records baseline markers atomically without executing migration SQL", async () => {
+    const migrations = [
+      { version: "20260729090000", name: "20260729090000_create_orders" },
+      { version: "20260729090100", name: "20260729090100_create_reports" },
+    ];
+
+    const response = await baselineRequest(migrations);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body.marked).toBe(2);
+    expect(body.already_applied).toBe(0);
+    expect(connection.begin).toHaveBeenCalledTimes(1);
+    expect(connection.unsafe.mock.calls).toEqual([["RESET ALL; DISCARD TEMP; DISCARD PLANS"]]);
+    const recordCalls = transactionCalls.filter(({ text }) => text.includes("record_schema_migration"));
+    expect(recordCalls).toHaveLength(2);
+    expect(recordCalls[0]?.values[1]).toEqual(["baseline:20260729090000_create_orders"]);
+    expect(issueMigrationLedgerLease).toHaveBeenCalledTimes(2);
+    expect(releaseMigrationLedgerLease).toHaveBeenCalledTimes(2);
+  });
+
+  test("is idempotent for an identical baseline marker", async () => {
+    existingMigrationRows = [{
+      version: "20260729090000",
+      name: "20260729090000_create_orders",
+      statements: ["baseline:20260729090000_create_orders"],
+    }];
+
+    const response = await baselineRequest([{
+      version: "20260729090000",
+      name: "20260729090000_create_orders",
+    }]);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body.marked).toBe(0);
+    expect(body.already_applied).toBe(1);
+    expect(issueMigrationLedgerLease).not.toHaveBeenCalled();
+  });
+
+  test("rejects ledger conflicts instead of overwriting history", async () => {
+    existingMigrationRows = [{
+      version: "20260729090000",
+      name: "20260729090000_create_orders",
+      statements: ["CREATE TABLE orders (id uuid)"],
+    }];
+
+    const response = await baselineRequest([{
+      version: "20260729090000",
+      name: "20260729090000_create_orders",
+    }]);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("migration_baseline_conflict");
+    expect(issueMigrationLedgerLease).not.toHaveBeenCalled();
+  });
+
+  test("rejects a mixed exact match and conflicting migration identity", async () => {
+    existingMigrationRows = [
+      {
+        version: "20260729090000",
+        name: "20260729090000_create_orders",
+        statements: ["baseline:20260729090000_create_orders"],
+      },
+      {
+        version: "20260729090100",
+        name: "20260729090000_create_orders",
+        statements: ["baseline:20260729090000_create_orders"],
+      },
+    ];
+
+    const response = await baselineRequest([{
+      version: "20260729090000",
+      name: "20260729090000_create_orders",
+    }]);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("migration_baseline_conflict");
+    expect(issueMigrationLedgerLease).not.toHaveBeenCalled();
+  });
+
+  test("releases the lease and redacts details when ledger insertion fails", async () => {
+    transactionFailure = new Error("connection failed password=top-secret");
+
+    const response = await baselineRequest([{
+      version: "20260729090000",
+      name: "20260729090000_create_orders",
+    }]);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(500);
+    expect(body.detail).toBe("connection failed password=[REDACTED]");
+    expect(JSON.stringify(body)).not.toContain("top-secret");
+    expect(releaseMigrationLedgerLease).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects duplicate normalized migration identities before opening a transaction", async () => {
+    const response = await baselineRequest([
+      { version: "0001", name: "first_name" },
+      { version: "1", name: "second_name" },
+    ]);
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("duplicate_migration_baseline");
+    expect(connection.begin).not.toHaveBeenCalled();
+  });
+});

--- a/packages/management-api/tests/unit/delegated-project-authorization.test.ts
+++ b/packages/management-api/tests/unit/delegated-project-authorization.test.ts
@@ -118,6 +118,7 @@ describe("delegated project authorization", () => {
       ["GET", "/tasks", "operations.read"],
       ["POST", "/pipelines", "operations.manage"],
       ["POST", "/database/migrations", "database.migrations.manage"],
+      ["POST", "/database/migrations/baseline", "database.migrations.manage"],
       ["GET", "", "project.read"],
     ] as const;
 


### PR DESCRIPTION
## What changed

- Add an authorized `POST /v1/projects/:ref/database/migrations/baseline` route that records migration ledger entries through the existing migration role, lock, branch-replacement gate, and lease protocol.
- Switch `database baseline_migrations` from migration-mode SQL to the dedicated route, so SQL policy no longer rejects the operation and existing ledger history is never overwritten.
- Make CLI process exit status honor both `isError: true` and explicit failure text such as `❌ Failed (400)`.
- Reject duplicate and conflicting baselines, preserve idempotency, redact unexpected migration errors, and extend delegated capability coverage.

## Validation

- CLI full suite: 89 pass, 0 fail.
- Baseline route unit suite: 6 pass, 0 fail.
- Delegated authorization suite: 6 pass, 0 fail.
- CLI and Management API typechecks: pass; CLI build: pass; staged diff check: pass.
- Management API shared unit run: 1111 pass; 20 unrelated installer/runtime sandbox tests timed out on this macOS run and do not touch the changed files.

## Deployment

Not deployed to SupaCloud production. This PR is review-only.