### PR TITLE
fix(runtime): migrate canonical legacy PostgREST pools

### DIFF
--- a/packages/management-api/src/services/postgrest-pool-reconcile.ts
+++ b/packages/management-api/src/services/postgrest-pool-reconcile.ts
@@ -4,10 +4,50 @@ import { basename, dirname, join } from "node:path";
 
 const MANAGED_CONFIG_PREFIX = "# Managed by SupaCloud Management API.";
 const DB_POOL_LINE_PATTERN = /^(\s*db-pool\s*=\s*)(\d+)(\s*(?:#.*)?)$/gm;
+const CONFIG_ASSIGNMENT_PATTERN = /^([a-z][a-z0-9-]*)\s*=\s*(.+)$/;
+const CANONICAL_INTEGER_PATTERN = /^[1-9]\d*$/;
+const LEGACY_OPTIONAL_CONFIG_KEY = "jwt-aud";
+const LEGACY_REQUIRED_CONFIG_KEYS = new Set([
+  "db-uri",
+  "db-schemas",
+  "db-extra-search-path",
+  "db-anon-role",
+  "jwt-secret",
+  "server-port",
+  "server-host",
+  "db-pool",
+  "db-pool-acquisition-timeout",
+  "log-level",
+  "openapi-mode",
+  "openapi-server-proxy-uri",
+  "db-pre-request",
+  "db-max-rows",
+  "server-cors-allowed-origins",
+  "db-channel",
+]);
+const LEGACY_DYNAMIC_STRING_KEYS = [
+  "db-uri",
+  "db-schemas",
+  "jwt-secret",
+  "openapi-server-proxy-uri",
+  "server-cors-allowed-origins",
+  LEGACY_OPTIONAL_CONFIG_KEY,
+] as const;
+const LEGACY_STATIC_CONFIG_VALUES = new Map([
+  ["db-extra-search-path", '"public, extensions, auth"'],
+  ["db-anon-role", '"anon"'],
+  ["server-host", '"0.0.0.0"'],
+  ["db-pool-acquisition-timeout", "10"],
+  ["log-level", '"warn"'],
+  ["openapi-mode", '"follow-privileges"'],
+  ["db-pre-request", '"public.set_request_context"'],
+  ["db-max-rows", "1000"],
+]);
 export const POSTGREST_POOL_RETRY_BACKOFF_MS = 60 * 60 * 1000;
 
 interface PostgrestPoolReconcileRequest {
   configPath: string;
+  projectRef: string;
   desiredPool: number;
   projectStatus: string;
   desiredState: "running" | "stopped";
@@ -79,21 +119,118 @@ function assertDesiredPool(desiredPool: number): void {
   }
 }
 
-export function renderManagedPostgrestDbPool(
-  content: string,
-  desiredPool: number,
-): string | null {
-  assertDesiredPool(desiredPool);
-  if (!content.startsWith(MANAGED_CONFIG_PREFIX)) return null;
-  const matches = [...content.matchAll(DB_POOL_LINE_PATTERN)];
-  if (matches.length !== 1) {
-    throw new Error("Managed PostgREST config must contain exactly one db-pool setting");
+function tomlValueWithoutInlineComment(candidate: string): string {
+  let insideString = false;
+  let escaped = false;
+  for (let index = 0; index < candidate.length; index += 1) {
+    const character = candidate[index];
+    if (escaped) {
+      escaped = false;
+    } else if (insideString && character === "\\") {
+      escaped = true;
+    } else if (character === '"') {
+      insideString = !insideString;
+    } else if (!insideString && character === "#") {
+      return candidate.slice(0, index).trimEnd();
+    }
   }
-  const [match] = matches;
+  return candidate;
+}
+
+function parseConfigAssignments(content: string): Map<string, string> | null {
+  const assignments = new Map<string, string>();
+  for (const line of content.split(/\r?\n/).slice(1)) {
+    const trimmedLine = line.trim();
+    if (!trimmedLine || trimmedLine.startsWith("#")) continue;
+    const match = trimmedLine.match(CONFIG_ASSIGNMENT_PATTERN);
+    if (!match || assignments.has(match[1])) return null;
+    assignments.set(match[1], tomlValueWithoutInlineComment(match[2].trim()));
+  }
+  return assignments;
+}
+
+function hasCanonicalLegacyKeys(assignments: Map<string, string>): boolean {
+  for (const key of LEGACY_REQUIRED_CONFIG_KEYS) {
+    if (!assignments.has(key)) return false;
+  }
+  return [...assignments].every(([key]) =>
+    LEGACY_REQUIRED_CONFIG_KEYS.has(key) || key === LEGACY_OPTIONAL_CONFIG_KEY
+  );
+}
+
+function isCanonicalNonEmptyTomlString(candidate: string): boolean {
+  try {
+    const parsed = JSON.parse(candidate);
+    return typeof parsed === "string"
+      && parsed.length > 0
+      && JSON.stringify(parsed) === candidate;
+  } catch (error: unknown) {
+    if (error instanceof SyntaxError) return false;
+    throw error;
+  }
+}
+
+function isCanonicalPositiveSafeInteger(candidate: string): boolean {
+  return CANONICAL_INTEGER_PATTERN.test(candidate)
+    && Number.isSafeInteger(Number(candidate));
+}
+
+function hasCanonicalDynamicValues(assignments: Map<string, string>): boolean {
+  const stringsValid = LEGACY_DYNAMIC_STRING_KEYS.every((key) => {
+    const candidate = assignments.get(key);
+    return candidate === undefined
+      ? key === LEGACY_OPTIONAL_CONFIG_KEY
+      : isCanonicalNonEmptyTomlString(candidate);
+  });
+  if (!stringsValid) return false;
+  const serverPort = assignments.get("server-port") || "";
+  const databasePool = assignments.get("db-pool") || "";
+  return isCanonicalPositiveSafeInteger(serverPort)
+    && Number(serverPort) <= 65535
+    && isCanonicalPositiveSafeInteger(databasePool);
+}
+
+function hasCanonicalStaticValues(
+  assignments: Map<string, string>,
+  projectRef: string,
+): boolean {
+  for (const [key, expected] of LEGACY_STATIC_CONFIG_VALUES) {
+    if (assignments.get(key) !== expected) return false;
+  }
+  return assignments.get("db-channel") === JSON.stringify(`pgrst_${projectRef}`);
+}
+
+function isCanonicalLegacyConfig(content: string, projectRef: string): boolean {
+  const [header] = content.split(/\r?\n/, 1);
+  if (header !== `# PostgREST config for tenant: ${projectRef}`) return false;
+  const assignments = parseConfigAssignments(content);
+  return assignments !== null
+    && hasCanonicalLegacyKeys(assignments)
+    && hasCanonicalDynamicValues(assignments)
+    && hasCanonicalStaticValues(assignments, projectRef);
+}
+
+function renderDbPoolMatch(content: string, match: RegExpExecArray, desiredPool: number): string | null {
   if (Number(match[2]) === desiredPool) return null;
   const start = match.index;
   const replacement = `${match[1]}${desiredPool}${match[3]}`;
   return `${content.slice(0, start)}${replacement}${content.slice(start + match[0].length)}`;
+}
+
+export function renderManagedPostgrestDbPool(
+  content: string,
+  desiredPool: number,
+  projectRef: string,
+): string | null {
+  assertDesiredPool(desiredPool);
+  const managed = content.startsWith(MANAGED_CONFIG_PREFIX);
+  if (!managed && !isCanonicalLegacyConfig(content, projectRef)) return null;
+  const matches = [...content.matchAll(DB_POOL_LINE_PATTERN)];
+  if (matches.length !== 1) {
+    if (!managed) return null;
+    throw new Error("Managed PostgREST config must contain exactly one db-pool setting");
+  }
+  return renderDbPoolMatch(content, matches[0], desiredPool);
 }
 
 async function readConfigSnapshot(configPath: string): Promise<PostgrestConfigSnapshot> {
@@ -168,6 +305,7 @@ export async function reconcileManagedPostgrestPool(
   const candidateContent = renderManagedPostgrestDbPool(
     original.content,
     request.desiredPool,
+    request.projectRef,
   );
   if (candidateContent === null) return { state: "unchanged" };
 

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -2578,6 +2578,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         return this.withTenantConfigLock(ref, () =>
             reconcileManagedPostgrestPool({
                 configPath: path.join(this.TENANT_CONFIG_DIR, `${ref}.conf`),
+                projectRef: ref,
                 desiredPool: this.POSTGREST_DB_POOL,
                 projectStatus,
                 desiredState: desired,

--- a/packages/management-api/tests/unit/postgrest-pool-reconcile.test.ts
+++ b/packages/management-api/tests/unit/postgrest-pool-reconcile.test.ts
@@ -10,12 +10,43 @@ import {
 } from "../../src/services/postgrest-pool-reconcile";
 
 const temporaryDirectories: string[] = [];
+const PROJECT_REF = "afemibrarjkvzuuawjfi";
 const MANAGED_CONFIG = [
   "# Managed by SupaCloud Management API. Legacy shell tooling must not overwrite this file.",
   "db-uri = \"postgres://secret@example.invalid/database\"",
   "db-pool = 10",
   "log-level = \"warn\"",
   "",
+].join("\n");
+const LEGACY_CONFIG = [
+  `# PostgREST config for tenant: ${PROJECT_REF}`,
+  "db-uri = \"postgres://authenticator:secret@example.invalid/database\"",
+  "db-schemas = \"public, storage, graphql_public\"",
+  "db-extra-search-path = \"public, extensions, auth\"",
+  "db-anon-role = \"anon\"",
+  "jwt-secret = \"sensitive-jwt-secret\"",
+  "",
+  "server-port = 54321",
+  "server-host = \"0.0.0.0\"",
+  "db-pool = 10",
+  "db-pool-acquisition-timeout = 10",
+  "log-level = \"warn\"",
+  "",
+  "# P0-10: OpenAPI spec generation (required by Studio Table Editor & API Docs)",
+  "openapi-mode = \"follow-privileges\"",
+  "openapi-server-proxy-uri = \"https://api.example.invalid/rest/v1\"",
+  "",
+  "# P0-11: Pre-request function for RLS context injection",
+  "db-pre-request = \"public.set_request_context\"",
+  "",
+  "# P1-7: Row limit protection",
+  "db-max-rows = 1000",
+  "",
+  "# P2-3: Restrict CORS to the tenant's API domain",
+  "server-cors-allowed-origins = \"https://api.example.invalid\"",
+  "",
+  "# P2-4: Tenant-specific listen channel for schema cache invalidation",
+  `db-channel = \"pgrst_${PROJECT_REF}\"`,
 ].join("\n");
 
 afterEach(async () => {
@@ -39,6 +70,7 @@ function request(
   configPath: string,
   restartAndWait: () => Promise<void>,
   overrides: Partial<{
+    projectRef: string;
     desiredPool: number;
     projectStatus: string;
     desiredState: "running" | "stopped";
@@ -46,6 +78,7 @@ function request(
 ) {
   return {
     configPath,
+    projectRef: overrides.projectRef ?? PROJECT_REF,
     desiredPool: overrides.desiredPool ?? 3,
     projectStatus: overrides.projectStatus ?? "active",
     desiredState: overrides.desiredState ?? "running",
@@ -55,23 +88,117 @@ function request(
 
 describe("managed PostgREST pool rendering", () => {
   test("changes only the managed db-pool line", () => {
-    const candidate = renderManagedPostgrestDbPool(MANAGED_CONFIG, 3);
+    const candidate = renderManagedPostgrestDbPool(MANAGED_CONFIG, 3, PROJECT_REF);
 
     expect(candidate).toBe(MANAGED_CONFIG.replace("db-pool = 10", "db-pool = 3"));
     expect(candidate).toContain("postgres://secret@example.invalid/database");
   });
 
   test("does not rewrite unmanaged, matching, or malformed config", () => {
-    expect(renderManagedPostgrestDbPool(MANAGED_CONFIG, 10)).toBeNull();
-    expect(renderManagedPostgrestDbPool("db-pool = 10\n", 3)).toBeNull();
+    expect(renderManagedPostgrestDbPool(MANAGED_CONFIG, 10, PROJECT_REF)).toBeNull();
+    expect(renderManagedPostgrestDbPool("db-pool = 10\n", 3, PROJECT_REF)).toBeNull();
     expect(() => renderManagedPostgrestDbPool(
       `${MANAGED_CONFIG}db-pool = 4\n`,
       3,
+      PROJECT_REF,
     )).toThrow("exactly one db-pool setting");
+  });
+
+  test("changes only the canonical legacy db-pool bytes", () => {
+    const candidate = renderManagedPostgrestDbPool(LEGACY_CONFIG, 3, PROJECT_REF);
+
+    expect(candidate).toBe(LEGACY_CONFIG.replace("db-pool = 10", "db-pool = 3"));
+    expect(candidate).toContain("authenticator:secret@example.invalid");
+    expect(candidate).toContain("sensitive-jwt-secret");
+    expect(candidate).toContain("P0-10: OpenAPI spec generation");
+  });
+
+  test("accepts the optional canonical jwt-aud setting", () => {
+    const withAudience = LEGACY_CONFIG.replace(
+      'jwt-secret = "sensitive-jwt-secret"',
+      'jwt-secret = "sensitive-jwt-secret"\njwt-aud = "authenticated"',
+    );
+
+    expect(renderManagedPostgrestDbPool(withAudience, 3, PROJECT_REF))
+      .toBe(withAudience.replace("db-pool = 10", "db-pool = 3"));
+  });
+
+  test("skips non-canonical legacy ownership candidates without throwing", () => {
+    const candidates = [
+      LEGACY_CONFIG.replace(PROJECT_REF, "wrong-project-ref"),
+      LEGACY_CONFIG.replace("db-max-rows = 1000\n", ""),
+      `${LEGACY_CONFIG}\ncustom-setting = \"user-owned\"`,
+      `${LEGACY_CONFIG}\ndb-pool = 4`,
+      LEGACY_CONFIG.replace(`pgrst_${PROJECT_REF}`, "pgrst_wrong-project-ref"),
+      LEGACY_CONFIG.replace('log-level = "warn"', 'log-level = "info"'),
+      LEGACY_CONFIG.replace('jwt-secret = "sensitive-jwt-secret"', "jwt-secret = unquoted"),
+      LEGACY_CONFIG.replace('db-schemas = "public, storage, graphql_public"', 'db-schemas = ""'),
+      LEGACY_CONFIG.replace("server-port = 54321", "server-port = 054321"),
+      LEGACY_CONFIG.replace("server-port = 54321", "server-port = 65536"),
+      LEGACY_CONFIG.replace("db-pool = 10", "db-pool = 9007199254740992"),
+      LEGACY_CONFIG.replace(
+        'db-pool = 10',
+        'db-pool = 10\njwt-aud = "authenticated"\njwt-aud = "other"',
+      ),
+      `# PostgREST config for tenant: ${PROJECT_REF}\ndb-pool = 10\n`,
+    ];
+
+    for (const candidate of candidates) {
+      expect(renderManagedPostgrestDbPool(candidate, 3, PROJECT_REF)).toBeNull();
+    }
+  });
+
+  test("preserves reordered comments, CRLF, and missing final newline", () => {
+    const movedPool = LEGACY_CONFIG
+      .replace("\ndb-pool = 10\n", "\n")
+      + "\n# User comment\ndb-pool = 10 # operator note";
+    const crlf = movedPool.replaceAll("\n", "\r\n");
+
+    expect(renderManagedPostgrestDbPool(crlf, 3, PROJECT_REF))
+      .toBe(crlf.replace("db-pool = 10", "db-pool = 3"));
+    expect(renderManagedPostgrestDbPool(movedPool, 3, PROJECT_REF))
+      .toBe(movedPool.replace("db-pool = 10", "db-pool = 3"));
+  });
+
+  test("distinguishes inline comments from hashes inside quoted values", () => {
+    const commented = LEGACY_CONFIG
+      .replace('jwt-secret = "sensitive-jwt-secret"', 'jwt-secret = "sensitive#jwt-secret" # secret note')
+      .replace("db-pool = 10", "db-pool = 10 # pool note");
+
+    expect(renderManagedPostgrestDbPool(commented, 3, PROJECT_REF))
+      .toBe(commented.replace("db-pool = 10", "db-pool = 3"));
   });
 });
 
 describe("managed PostgREST pool reconciliation", () => {
+  test("reconciles canonical legacy config once and remains idempotent", async () => {
+    const configPath = await temporaryConfig(LEGACY_CONFIG);
+    const restartAndWait = mock(async () => {});
+
+    expect(await reconcileManagedPostgrestPool(request(configPath, restartAndWait)))
+      .toEqual({ state: "updated" });
+    expect(await readFile(configPath, "utf8"))
+      .toBe(LEGACY_CONFIG.replace("db-pool = 10", "db-pool = 3"));
+    expect(await reconcileManagedPostgrestPool(request(configPath, restartAndWait)))
+      .toEqual({ state: "unchanged" });
+    expect(restartAndWait).toHaveBeenCalledTimes(1);
+  });
+
+  test("restores the exact canonical legacy config after health failure", async () => {
+    const configPath = await temporaryConfig(LEGACY_CONFIG);
+    const restartAndWait = mock(async () => {});
+    restartAndWait.mockRejectedValueOnce(new Error("candidate unhealthy"));
+
+    expect(await reconcileManagedPostgrestPool(request(configPath, restartAndWait)))
+      .toEqual({
+        state: "rolled_back",
+        error: "POSTGREST_POOL_UPDATE_ROLLED_BACK",
+        cause: expect.any(Error),
+      });
+    expect(await readFile(configPath, "utf8")).toBe(LEGACY_CONFIG);
+    expect(restartAndWait).toHaveBeenCalledTimes(2);
+  });
+
   test("updates, health-checks, preserves metadata, and becomes idempotent", async () => {
     const configPath = await temporaryConfig();
     const before = await stat(configPath);


### PR DESCRIPTION
## 背景

0.50.5 的 pool reconciler 只识别新的 managed marker。由旧版 Management API 生成、但仍是 canonical 的 PostgREST `.conf` 会被永久跳过，导致升级后部分租户不会自动收敛到安全的 `db-pool`。

## 变更

- 为 reconcile request 显式传入 `projectRef`。
- 严格识别旧版 canonical 配置：header 必须匹配租户 ref；完整 required key set、静态值和 `db-channel` 必须匹配；只允许可选 `jwt-aud`；拒绝未知、缺失、重复、错误 ref 和非法动态值。
- managed marker 的原有行为、原子写、checked restart、CAS rollback、熔断和幂等行为保持不变。
- 只替换唯一 `db-pool` 数字；URI、JWT、注释、CRLF、行尾注释和其它字节原样保留。

## 验证

- focused PostgREST pool tests: 18 pass / 0 fail
- Management API typecheck: pass
- Management API full unit suite: 1138 pass / 0 fail, 138 files, 4621 assertions
- `git diff --check`: pass

本 PR 只包含代码和单元测试，不代表已发布或已部署；生产当前仍运行正式 release `management-api-v0.50.5`。