### PR TITLE
fix: stabilize Lite shutdown and Studio interactions

### DIFF
--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -176,6 +176,7 @@ async function main(): Promise<void> {
 `)
 
   await waitForShutdown(() => project.close())
+  process.exitCode = 0
 }
 
 async function runDbCommand(options: CliOptions): Promise<void> {
@@ -307,16 +308,17 @@ function timestamp(): string {
 
 function quietLog(): void {}
 
-function waitForShutdown(closeProject: () => Promise<void>): Promise<void> {
-  return new Promise<void>((resolveShutdown, rejectShutdown) => {
-    const closeOnSignal = () => {
-      process.off('SIGINT', closeOnSignal)
-      process.off('SIGTERM', closeOnSignal)
-      void closeProject().then(resolveShutdown, rejectShutdown)
+async function waitForShutdown(closeProject: () => Promise<void>): Promise<void> {
+  await new Promise<void>((resolveShutdown) => {
+    const resolveOnSignal = () => {
+      process.off('SIGINT', resolveOnSignal)
+      process.off('SIGTERM', resolveOnSignal)
+      resolveShutdown()
     }
-    process.once('SIGINT', closeOnSignal)
-    process.once('SIGTERM', closeOnSignal)
+    process.once('SIGINT', resolveOnSignal)
+    process.once('SIGTERM', resolveOnSignal)
   })
+  await closeProject()
 }
 
 function printHelp(): void {

--- a/packages/supacloud-lite/src/launcher.cjs
+++ b/packages/supacloud-lite/src/launcher.cjs
@@ -6,6 +6,18 @@ const { join } = require('node:path')
 
 const cliPath = join(__dirname, 'cli.js')
 const bunProcess = spawn('bun', [cliPath, ...process.argv.slice(2)], { shell: false, stdio: 'inherit' })
+let requestedShutdownSignal = null
+
+function forwardShutdownSignal(signal) {
+  if (requestedShutdownSignal || bunProcess.exitCode !== null || bunProcess.signalCode !== null) return
+  requestedShutdownSignal = signal
+  bunProcess.kill(signal)
+}
+
+const forwardSigint = () => forwardShutdownSignal('SIGINT')
+const forwardSigterm = () => forwardShutdownSignal('SIGTERM')
+process.once('SIGINT', forwardSigint)
+process.once('SIGTERM', forwardSigterm)
 
 bunProcess.once('error', (error) => {
   if (error.code === 'ENOENT') {
@@ -17,6 +29,7 @@ bunProcess.once('error', (error) => {
 })
 
 bunProcess.once('exit', (exitCode, signal) => {
-  if (signal) process.kill(process.pid, signal)
-  else process.exitCode = exitCode ?? 1
+  process.off('SIGINT', forwardSigint)
+  process.off('SIGTERM', forwardSigterm)
+  process.exitCode = exitCode ?? (requestedShutdownSignal === signal ? 0 : 1)
 })

--- a/packages/supacloud-lite/test/cli-shutdown.test.ts
+++ b/packages/supacloud-lite/test/cli-shutdown.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { access, mkdtemp, rm } from 'node:fs/promises'
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
@@ -31,6 +31,7 @@ test('closes the project and releases its data lock on SIGINT', async () => {
     await access(lockPath)
     expect(await stopCli(restartedRun, 'SIGINT')).toBe(0)
     restartedStopped = true
+    await expect(access(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
   } finally {
     await Promise.all([
       firstStopped ? undefined : stopCli(firstRun, 'SIGTERM'),
@@ -38,7 +39,36 @@ test('closes the project and releases its data lock on SIGINT', async () => {
     ])
     await rm(projectDir, { recursive: true, force: true })
   }
+}, 120_000)
+
+test('closes the project and releases its data lock on SIGTERM', async () => {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-cli-shutdown-'))
+  const lockPath = join(projectDir, '.supacloud-lite', 'db.supacloud-lite.lock')
+  const cliRun = startCli(projectDir)
+  let stopped = false
+
+  try {
+    await cliRun.ready
+    await access(lockPath)
+    expect(await stopCli(cliRun, 'SIGTERM')).toBe(0)
+    stopped = true
+    await expect(access(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  } finally {
+    if (!stopped) await stopCli(cliRun, 'SIGTERM')
+    await rm(projectDir, { recursive: true, force: true })
+  }
 }, 60_000)
+
+test('marks direct CLI shutdown success only after close resolves', async () => {
+  const source = await readFile(cliPath, 'utf8')
+  const shutdownCall = source.indexOf("await waitForShutdown(() => project.close())")
+  const successfulExit = source.indexOf('process.exitCode = 0', shutdownCall)
+
+  expect(shutdownCall).toBeGreaterThan(-1)
+  expect(source.indexOf('await closeProject()')).toBeGreaterThan(shutdownCall)
+  expect(successfulExit).toBeGreaterThan(shutdownCall)
+  expect(source).toContain('process.exitCode = 1')
+})
 
 function startCli(projectDir: string) {
   const bunExecutable = Bun.which('bun')

--- a/packages/supacloud-lite/test/launcher-shutdown.test.ts
+++ b/packages/supacloud-lite/test/launcher-shutdown.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from 'bun:test'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
+
+const launcherSourcePath = resolve(import.meta.dir, '../src/launcher.cjs')
+
+test('waits for a SIGINT-shutdown child and preserves its successful exit code', async () => {
+  const nodeExecutable = Bun.which('node')
+  if (!nodeExecutable) throw new Error('Node is required to exercise the npm launcher')
+
+  const packageDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-launcher-'))
+  const fakeBinDir = join(packageDir, 'bin')
+  const launcherPath = join(packageDir, 'launcher.cjs')
+  const cliPath = join(packageDir, 'cli.js')
+  let launcher: Bun.Subprocess | undefined
+  let launcherStopped = false
+
+  try {
+    await mkdir(fakeBinDir)
+    await Bun.write(launcherPath, Bun.file(launcherSourcePath))
+    await writeFile(cliPath, `
+process.stdout.write('ready\\n')
+process.once('SIGINT', () => setTimeout(() => process.exit(0), 10))
+setInterval(() => {}, 1_000)
+`)
+    await Bun.write(join(fakeBinDir, 'bun.cjs'), `require(process.argv[2])\n`)
+    await writeFakeBunCommand(fakeBinDir, nodeExecutable)
+
+    launcher = Bun.spawn({
+      cmd: [nodeExecutable, launcherPath, 'start'],
+      cwd: packageDir,
+      env: withFakeBunPath(fakeBinDir),
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const launcherOutput = launcher.stdout
+    if (!launcherOutput || typeof launcherOutput === 'number') throw new Error('launcher stdout is unavailable')
+    await waitForOutput(launcherOutput as ReadableStream<Uint8Array>, 'ready')
+
+    process.kill(launcher.pid, 'SIGINT')
+    expect(await launcher.exited).toBe(0)
+    launcherStopped = true
+  } finally {
+    if (launcher && !launcherStopped) {
+      try {
+        process.kill(launcher.pid, 'SIGTERM')
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
+      }
+      await launcher.exited
+    }
+    await rm(packageDir, { recursive: true, force: true })
+  }
+}, 20_000)
+
+async function writeFakeBunCommand(fakeBinDir: string, nodeExecutable: string): Promise<void> {
+  if (process.platform === 'win32') {
+    await writeFile(join(fakeBinDir, 'bun.cmd'), `@"${nodeExecutable}" "%~dp0bun.cjs" %*\r\n`)
+    return
+  }
+
+  const commandPath = join(fakeBinDir, 'bun')
+  await writeFile(commandPath, `#!${nodeExecutable}\nrequire(__dirname + '/bun.cjs')\n`)
+  await chmod(commandPath, 0o755)
+}
+
+function withFakeBunPath(fakeBinDir: string): NodeJS.ProcessEnv {
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
+  return { ...process.env, [pathKey]: `${fakeBinDir}${delimiter}${process.env[pathKey] ?? ''}` }
+}
+
+async function waitForOutput(output: ReadableStream<Uint8Array>, expected: string): Promise<void> {
+  const reader = output.getReader()
+  const decoder = new TextDecoder()
+  let logs = ''
+  try {
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) throw new Error(`launcher exited before ${expected}:\n${logs}`)
+      logs += decoder.decode(chunk.value, { stream: true })
+      if (logs.includes(expected)) return
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}

--- a/packages/supacloud-lite/test/project-runtime.test.ts
+++ b/packages/supacloud-lite/test/project-runtime.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, parse } from 'node:path'
 import { decodeJwt } from '../src/vendor/tinbase/jwt.js'
+import { createSymlinkIfPermitted } from './support/symlink.js'
 import { loadSupabaseProject } from '../src/vendor/tinbase/node/project.js'
 import {
   createProjectBackend,
@@ -63,10 +64,11 @@ describe('project runtime', () => {
 
     const externalDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-reset-external-'))
     temporaryDirectories.push(externalDir)
-    await symlink(externalDir, join(safePaths.stateDir, 'linked'))
-    await expect(
-      assertResetPathsSafe({ ...safePaths, storageDir: join(safePaths.stateDir, 'linked', 'storage') })
-    ).rejects.toThrow('symbolic link')
+    if (await createSymlinkIfPermitted(externalDir, join(safePaths.stateDir, 'linked'))) {
+      await expect(
+        assertResetPathsSafe({ ...safePaths, storageDir: join(safePaths.stateDir, 'linked', 'storage') })
+      ).rejects.toThrow('symbolic link')
+    }
 
     const root = parse(projectDir).root
     await expect(

--- a/packages/supacloud-lite/test/snapshot.test.ts
+++ b/packages/supacloud-lite/test/snapshot.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdir, mkdtemp, readFile, readdir, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { ensureProjectSecrets, resolveProjectPaths } from '../src/project-runtime.js'
 import { createSnapshot, restoreSnapshot } from '../src/snapshot.js'
+import { createSymlinkIfPermitted } from './support/symlink.js'
 
 const temporaryDirectories: string[] = []
 
@@ -106,10 +107,11 @@ describe('Lite snapshots', () => {
     ).rejects.toThrow('storage backend')
 
     const external = await temporaryProject('supacloud-lite-snapshot-link-target-')
-    await symlink(external, join(paths.storageDir, 'linked'))
-    await expect(
-      createSnapshot({ paths, packageVersion: 'test-version', storageBackend: 'fs', output: join(projectDir, 'linked.tar.gz') })
-    ).rejects.toThrow('symbolic link')
+    if (await createSymlinkIfPermitted(external, join(paths.storageDir, 'linked'))) {
+      await expect(
+        createSnapshot({ paths, packageVersion: 'test-version', storageBackend: 'fs', output: join(projectDir, 'linked.tar.gz') })
+      ).rejects.toThrow('symbolic link')
+    }
   })
 
   test('restores empty database and storage directories', async () => {

--- a/packages/supacloud-lite/test/support/symlink.ts
+++ b/packages/supacloud-lite/test/support/symlink.ts
@@ -1,0 +1,12 @@
+import { symlink } from 'node:fs/promises'
+
+export async function createSymlinkIfPermitted(target: string, linkPath: string): Promise<boolean> {
+  try {
+    await symlink(target, linkPath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'EPERM' || code === 'EACCES') return false
+    throw error
+  }
+}

--- a/packages/web-console/src/routes/navigation.test.ts
+++ b/packages/web-console/src/routes/navigation.test.ts
@@ -50,11 +50,13 @@ describe("console navigation information architecture", () => {
     expect(authLayoutSource).toContain("AuthNav.security");
     expect(authLayoutSource).toContain("AuthNav.messaging");
     expect(databaseLayoutSource).toContain('name="database-navigation"');
-    expect(authLayoutSource).toContain('name="auth-navigation"');
+    expect(authLayoutSource).toContain('aria-haspopup="menu"');
+    expect(authLayoutSource).toContain('aria-expanded={openMenu === group.labelKey}');
     expect(databaseLayoutSource).toContain("closeMenusOnOutsideClick");
     expect(authLayoutSource).toContain("closeMenusOnOutsideClick");
     expect(databaseLayoutSource).toContain("closeMenuFromLink");
     expect(authLayoutSource).toContain("closeMenuFromLink");
+    expect(authLayoutSource).toContain("closeMenuOnEscape");
     expect(authLayoutSource).toContain("AuthNav.tabs.providers");
     expect(authLayoutSource).not.toContain('name: "提供者"');
   });

--- a/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/+layout.svelte
@@ -82,6 +82,7 @@
     authRuntime?.mode === "shared" && !currentPath.endsWith("/policies"),
   );
   let menuBar = $state<HTMLDivElement>();
+  let openMenu = $state<string | null>(null);
 
   onMount(() => {
     let cancelled = false;
@@ -116,25 +117,26 @@
   }
 
   function closeMenusOnOutsideClick(event: MouseEvent) {
-    if (!(event.target instanceof Node)) return;
-    for (const details of menuBar?.querySelectorAll<HTMLDetailsElement>("details[open]") ?? []) {
-      if (!details.contains(event.target)) details.open = false;
-    }
+    if (!(event.target instanceof Node) || !menuBar?.contains(event.target)) openMenu = null;
   }
 
-  function handleMenuKeydown(event: KeyboardEvent) {
-    if (event.key !== "Escape" || !(event.currentTarget instanceof HTMLElement)) return;
-    const details = event.currentTarget.closest("details");
-    if (!(details instanceof HTMLDetailsElement)) return;
+  function toggleMenu(menuKey: string): void {
+    openMenu = openMenu === menuKey ? null : menuKey;
+  }
+
+  function menuTriggerId(menuKey: string): string {
+    return `auth-menu-trigger-${menuKey}`;
+  }
+
+  function closeMenuOnEscape(event: KeyboardEvent, menuKey: string): void {
+    if (event.key !== "Escape") return;
     event.preventDefault();
-    details.open = false;
-    event.currentTarget.focus();
+    openMenu = null;
+    document.getElementById(menuTriggerId(menuKey))?.focus();
   }
 
-  function closeMenuFromLink(event: MouseEvent) {
-    if (!(event.currentTarget instanceof HTMLElement)) return;
-    const details = event.currentTarget.closest("details");
-    if (details instanceof HTMLDetailsElement) details.open = false;
+  function closeMenuFromLink(): void {
+    openMenu = null;
   }
 
   let { children } = $props();
@@ -146,21 +148,32 @@
   <!-- 按用户任务分组，避免十多个认证入口在窄屏横向溢出。 -->
   <div bind:this={menuBar} class="flex flex-wrap items-center gap-2 border-b border-border/30 px-1 pb-3">
     {#each visibleGroups as group (group.labelKey)}
-      <details name="auth-navigation" class="group/details relative">
-        <summary onkeydown={handleMenuKeydown} class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors [&::-webkit-details-marker]:hidden {groupIsActive(group.tabs) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}">
+      <div class="relative">
+        <button
+          type="button"
+          id={menuTriggerId(group.labelKey)}
+          aria-haspopup="menu"
+          aria-controls={`auth-menu-${group.labelKey}`}
+          aria-expanded={openMenu === group.labelKey}
+          onclick={() => toggleMenu(group.labelKey)}
+          onkeydown={(event) => closeMenuOnEscape(event, group.labelKey)}
+          class="flex cursor-pointer list-none items-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition-colors {groupIsActive(group.tabs) ? 'border-brand/30 bg-brand/10 text-brand' : 'bg-background text-muted-foreground hover:bg-muted hover:text-foreground'}"
+        >
           {$t(group.labelKey)}
-          <ChevronDown class="h-3.5 w-3.5 transition-transform group-open/details:rotate-180" />
-        </summary>
-        <div class="absolute left-0 z-30 mt-2 w-56 overflow-hidden rounded-xl border bg-popover p-1.5 text-popover-foreground shadow-xl">
-          {#each group.tabs as tab (tab.path)}
-            {@const Icon = tab.icon}
-            <a href={resolve(tab.route, { ref: projectRef })} onclick={closeMenuFromLink} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {isActive(tab.path) ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
-              <Icon class="h-4 w-4" />
-              {$t(tab.labelKey)}
-            </a>
-          {/each}
-        </div>
-      </details>
+          <ChevronDown class="h-3.5 w-3.5 transition-transform {openMenu === group.labelKey ? 'rotate-180' : ''}" />
+        </button>
+        {#if openMenu === group.labelKey}
+          <div id={`auth-menu-${group.labelKey}`} role="menu" tabindex="-1" onkeydown={(event) => closeMenuOnEscape(event, group.labelKey)} class="absolute left-0 z-30 mt-2 w-56 overflow-hidden rounded-xl border bg-popover p-1.5 text-popover-foreground shadow-xl">
+            {#each group.tabs as tab (tab.path)}
+              {@const Icon = tab.icon}
+              <a role="menuitem" href={resolve(tab.route, { ref: projectRef })} onclick={closeMenuFromLink} class="flex items-center gap-2.5 rounded-lg px-3 py-2 text-xs font-medium transition-colors {isActive(tab.path) ? 'bg-brand/10 text-brand' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}">
+                <Icon class="h-4 w-4" />
+                {$t(tab.labelKey)}
+              </a>
+            {/each}
+          </div>
+        {/if}
+      </div>
     {/each}
   </div>
 

--- a/packages/web-console/src/routes/project/[ref]/auth/navigation.test-entry.ts
+++ b/packages/web-console/src/routes/project/[ref]/auth/navigation.test-entry.ts
@@ -1,0 +1,10 @@
+import { mount, unmount } from "svelte";
+import Harness from "./navigation.test-harness.svelte";
+
+export function mountHarness(target: HTMLElement) {
+  return mount(Harness, { target });
+}
+
+export function unmountHarness(component: ReturnType<typeof mountHarness>) {
+  return unmount(component);
+}

--- a/packages/web-console/src/routes/project/[ref]/auth/navigation.test-harness.svelte
+++ b/packages/web-console/src/routes/project/[ref]/auth/navigation.test-harness.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import AuthLayout from "./+layout.svelte";
+</script>
+
+<AuthLayout>
+  <div data-testid="auth-layout-content">Auth layout content</div>
+</AuthLayout>

--- a/packages/web-console/src/routes/project/[ref]/auth/navigation.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/auth/navigation.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import { JSDOM } from "jsdom";
+import { randomUUID } from "node:crypto";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { compile, compileModule, preprocess } from "svelte/compiler";
+
+let browserDom: JSDOM;
+const runsInIsolatedProcess = process.env.SUPACLOUD_AUTH_NAVIGATION_TEST === "1";
+
+function svelteTestCompiler() {
+  const typescript = new Bun.Transpiler({ loader: "ts" });
+  return {
+    name: "auth-navigation-component-tests",
+    setup(builder) {
+      builder.onResolve({ filter: /^\$app\/paths$/ }, () => ({ path: "app-paths", namespace: "auth-navigation-stub" }));
+      builder.onResolve({ filter: /^\$app\/state$/ }, () => ({ path: "app-state", namespace: "auth-navigation-stub" }));
+      builder.onResolve({ filter: /^\$lib\/api$/ }, () => ({ path: "api", namespace: "auth-navigation-stub" }));
+      builder.onResolve({ filter: /^svelte-i18n$/ }, () => ({ path: "i18n", namespace: "auth-navigation-stub" }));
+      builder.onLoad({ filter: /.*/, namespace: "auth-navigation-stub" }, ({ path }) => {
+        const stubSources: Record<string, string> = {
+          "app-paths": "export const resolve = (route, params) => route.replace('[ref]', params.ref);",
+          "app-state": "export const page = { params: { ref: 'project-ref' }, url: { pathname: '/project/project-ref/auth' } };",
+          "api": `export async function apiClient() {
+            return new Response(JSON.stringify({
+              project_ref: 'project-ref', mode: 'local', authority_project_ref: 'project-ref', owner_project_ref: null,
+              local_gotrue_enabled: true, public_auth_route: 'local_gotrue', user_management: 'local',
+              configuration_management: 'local', local_membership_source: 'project_database', realtime_auth_supported: true,
+              owner_management_path: null,
+            }), { status: 200 });
+          }`,
+          "i18n": "export const t = { subscribe(run) { run((key) => String(key)); return () => {}; } };",
+        };
+        return { contents: stubSources[path], loader: "js" };
+      });
+      builder.onLoad({ filter: /\.svelte$/ }, async ({ path }) => {
+        const source = await Bun.file(path).text();
+        const preprocessed = await preprocess(source, vitePreprocess(), { filename: path });
+        const compiled = compile(preprocessed.code, { filename: path, generate: "client", css: "injected" });
+        return { contents: compiled.js.code, loader: "js" };
+      });
+      builder.onLoad({ filter: /\.svelte\.ts$/ }, async ({ path }) => {
+        const source = await Bun.file(path).text();
+        const javascript = typescript.transformSync(source);
+        const compiled = compileModule(javascript, { filename: path, generate: "client" });
+        return { contents: compiled.js.code, loader: "js" };
+      });
+    },
+  };
+}
+
+async function authNavigationHarness() {
+  const harnessBuild = await Bun.build({
+    entrypoints: [fileURLToPath(new URL("navigation.test-entry.ts", import.meta.url))],
+    target: "browser",
+    format: "esm",
+    conditions: ["svelte", "browser"],
+    plugins: [svelteTestCompiler()],
+  });
+  if (!harnessBuild.success) throw new AggregateError(harnessBuild.logs, "Failed to bundle the auth navigation harness");
+
+  const bundlePath = join(tmpdir(), `supacloud-auth-navigation-${randomUUID()}.mjs`);
+  await Bun.write(bundlePath, harnessBuild.outputs[0]!);
+  try {
+    const harness = await import(pathToFileURL(bundlePath).href) as {
+      mountHarness: (target: HTMLElement) => object;
+      unmountHarness: (component: object) => Promise<void>;
+    };
+    return { ...harness, cleanup: () => rm(bundlePath, { force: true }) };
+  } catch (error) {
+    await rm(bundlePath, { force: true });
+    throw error;
+  }
+}
+
+function installBrowserGlobals(): void {
+  browserDom = new JSDOM("<!doctype html><html><body></body></html>", {
+    pretendToBeVisual: true,
+    url: "http://localhost/",
+  });
+  const browserWindow = browserDom.window;
+  const browserGlobals = {
+    window: browserWindow,
+    document: browserWindow.document,
+    navigator: browserWindow.navigator,
+    location: browserWindow.location,
+    history: browserWindow.history,
+    HTMLElement: browserWindow.HTMLElement,
+    Element: browserWindow.Element,
+    Node: browserWindow.Node,
+    Text: browserWindow.Text,
+    Comment: browserWindow.Comment,
+    Event: browserWindow.Event,
+    CustomEvent: browserWindow.CustomEvent,
+    MouseEvent: browserWindow.MouseEvent,
+    KeyboardEvent: browserWindow.KeyboardEvent,
+    MutationObserver: browserWindow.MutationObserver,
+    getComputedStyle: browserWindow.getComputedStyle.bind(browserWindow),
+    requestAnimationFrame: browserWindow.requestAnimationFrame.bind(browserWindow),
+    cancelAnimationFrame: browserWindow.cancelAnimationFrame.bind(browserWindow),
+  };
+  Object.assign(globalThis, browserGlobals);
+}
+
+async function eventually(assertion: () => void): Promise<void> {
+  const deadline = performance.now() + 3_000;
+  let lastError: unknown;
+  while (performance.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await Bun.sleep(10);
+    }
+  }
+  throw lastError;
+}
+
+function messagingButton(): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>("button"))
+    .find((candidate) => candidate.textContent?.trim() === "AuthNav.messaging");
+  if (!button) throw new Error("Messaging menu trigger is unavailable");
+  return button;
+}
+
+function openMessagingMenu(): HTMLButtonElement {
+  const button = messagingButton();
+  button.click();
+  return button;
+}
+
+if (runsInIsolatedProcess) describe("auth navigation", () => {
+  test("opens and closes Email and Links reliably while preserving its navigation link", async () => {
+    installBrowserGlobals();
+    let target: HTMLElement | undefined;
+    let component: object | undefined;
+    let unmountHarness: ((component: object) => Promise<void>) | undefined;
+    let cleanup: (() => Promise<void>) | undefined;
+
+    try {
+      const harness = await authNavigationHarness();
+      unmountHarness = harness.unmountHarness;
+      cleanup = harness.cleanup;
+      target = document.body.appendChild(document.createElement("div"));
+      component = harness.mountHarness(target);
+      await eventually(() => expect(messagingButton()).toBeTruthy());
+
+      const trigger = openMessagingMenu();
+      await eventually(() => expect(trigger.getAttribute("aria-expanded")).toBe("true"));
+      const menu = document.querySelector<HTMLElement>('[role="menu"]');
+      if (!menu) throw new Error("Messaging menu is unavailable");
+      const urlConfiguration = menu.querySelector<HTMLAnchorElement>('a[href="/project/project-ref/auth/url-configuration"]');
+      if (!urlConfiguration) throw new Error("URL configuration link is unavailable");
+      let navigationPreventedByMenu: boolean | undefined;
+      urlConfiguration.addEventListener("click", (event) => {
+        navigationPreventedByMenu = event.defaultPrevented;
+        event.preventDefault();
+      });
+      const navigationEvent = new MouseEvent("click", { bubbles: true, cancelable: true });
+      urlConfiguration.dispatchEvent(navigationEvent);
+      expect(navigationPreventedByMenu).toBe(false);
+      await eventually(() => expect(document.querySelector('[role="menu"]')).toBeNull());
+
+      const escapeTrigger = openMessagingMenu();
+      await eventually(() => expect(escapeTrigger.getAttribute("aria-expanded")).toBe("true"));
+      escapeTrigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
+      await eventually(() => expect(document.querySelector('[role="menu"]')).toBeNull());
+      expect(document.activeElement).toBe(escapeTrigger);
+
+      openMessagingMenu();
+      await eventually(() => expect(document.querySelector('[role="menu"]')).toBeTruthy());
+      document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await eventually(() => expect(document.querySelector('[role="menu"]')).toBeNull());
+    } finally {
+      if (component && unmountHarness) await unmountHarness(component);
+      target?.remove();
+      await cleanup?.();
+      browserDom.window.close();
+    }
+  }, 30_000);
+});
+
+if (!runsInIsolatedProcess) {
+  test("auth navigation regression runs in an isolated browser process", async () => {
+    const bunExecutable = Bun.which("bun");
+    if (!bunExecutable) throw new Error("Bun is required to run the auth navigation regression");
+    const testPath = fileURLToPath(import.meta.url);
+    const childProcess = Bun.spawn({
+      cmd: [bunExecutable, "test", testPath],
+      cwd: process.cwd(),
+      env: { ...process.env, SUPACLOUD_AUTH_NAVIGATION_TEST: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      childProcess.exited,
+      new Response(childProcess.stdout).text(),
+      new Response(childProcess.stderr).text(),
+    ]);
+    expect(exitCode, `${stdout}\n${stderr}`).toBe(0);
+  }, 40_000);
+}

--- a/packages/web-console/src/routes/project/[ref]/tables/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/tables/+page.svelte
@@ -156,7 +156,7 @@
               <Plus size={13} /> {$t("Tables.add_column")}
             </button>
           </div>
-          {#each columns as column, index (index)}
+          {#each columns as column, index (column)}
             <div class="grid grid-cols-[minmax(0,1fr)_112px_auto] gap-2 items-center">
               <input bind:value={column.name} required maxlength="63" pattern="[A-Za-z_][A-Za-z0-9_]*" class="min-w-0 px-2.5 py-2 rounded-md border bg-background text-xs font-mono" aria-label={$t("Tables.column_name_aria", { values: { index: index + 1 } })} />
               <select bind:value={column.type} disabled={index === 0} class="px-2 py-2 rounded-md border bg-background text-xs font-mono disabled:opacity-70" aria-label={$t("Tables.column_type_aria", { values: { index: index + 1 } })}>

--- a/packages/web-console/src/routes/project/[ref]/tables/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/tables/page.test.ts
@@ -230,4 +230,11 @@ describe("database tables column visibility", () => {
     expect(autoTablePatch).toContain("whitespace-nowrap");
     expect(autoTablePatch).toContain("gap-3 px-1 py-2");
   });
+
+  test("keeps each create-table draft bound to its own DOM row", async () => {
+    const source = await Bun.file(new URL("+page.svelte", import.meta.url)).text();
+
+    expect(source).toContain("{#each columns as column, index (column)}");
+    expect(source).not.toContain("{#each columns as column, index (index)}");
+  });
 });


### PR DESCRIPTION
## Summary
- make direct Lite CLI and npm launcher shutdown wait for cleanup before reporting success
- keep Windows symlink-permission limitations scoped to symlink-specific test assertions
- preserve create-table draft input identity across column changes
- replace fragile native auth menu state with an accessible controlled menu and DOM regression coverage

## Verification
- `bun test --timeout 20000` in `packages/supacloud-lite`: 72 pass, 0 fail
- `bun run typecheck` in `packages/supacloud-lite`: pass
- focused Web Console navigation tests: 11 pass, 0 fail
- `bun run check` in `packages/web-console`: 0 errors, 0 warnings
- `git diff --check`: pass

Tracks CNB issues #88, #89, #90, and #91. Windows-native CI must confirm direct Bun signal behavior before closing #88 and #89.