### PR TITLE
fix: make Lite Windows shutdown verification reliable

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -242,11 +242,15 @@ jobs:
           bun --version
 
       - name: Check SupaCloud Lite on Windows
+        shell: pwsh
         working-directory: packages/supacloud-lite
         run: |
           bun install --frozen-lockfile
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun run check
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun audit --audit-level high
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   docker-and-scripts-checks:
     name: Docker & Scripts Checks

--- a/packages/supacloud-lite/scripts/standalone-smoke.ts
+++ b/packages/supacloud-lite/scripts/standalone-smoke.ts
@@ -4,7 +4,7 @@ import { join, resolve } from 'node:path'
 import packageJson from '../package.json' with { type: 'json' }
 
 const packageDir = resolve(import.meta.dir, '..')
-const binary = resolve(process.env.SUPACLOUD_LITE_STANDALONE_BINARY ?? join(packageDir, 'dist', 'standalone', 'supacloud-lite'))
+const binary = resolveStandaloneBinary()
 const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-standalone-'))
 const emptyPath = await mkdtemp(join(tmpdir(), 'supacloud-lite-empty-path-'))
 const migrationDir = join(projectDir, 'supabase', 'migrations')
@@ -169,6 +169,13 @@ function withoutRuntimePath(path: string): NodeJS.ProcessEnv {
   return environment
 }
 
+function resolveStandaloneBinary(): string {
+  const configuredBinary = process.env.SUPACLOUD_LITE_STANDALONE_BINARY
+  if (configuredBinary) return resolve(configuredBinary)
+  const filename = process.platform === 'win32' ? 'supacloud-lite.exe' : 'supacloud-lite'
+  return join(packageDir, 'dist', 'standalone', filename)
+}
+
 interface ServerOptions {
   binary: string
   projectDir: string
@@ -196,8 +203,15 @@ async function withServer(options: ServerOptions, check: (url: string) => Promis
     processHandle.kill('SIGTERM')
     const exitCode = await processHandle.exited
     const [stdoutText, stderrText] = await Promise.all([stdout, stderr])
-    if (exitCode !== 0) throw new Error(`standalone server exited with ${exitCode}\n${stdoutText}\n${stderrText}`)
+    if (exitCode !== expectedStandaloneShutdownExitCode()) {
+      throw new Error(`standalone server exited with ${exitCode}\n${stdoutText}\n${stderrText}`)
+    }
   }
+}
+
+function expectedStandaloneShutdownExitCode(): number {
+  // Windows process kill terminates a child instead of delivering SIGTERM.
+  return process.platform === 'win32' ? 143 : 0
 }
 
 async function waitForHealth(url: string, processHandle: Bun.Subprocess): Promise<void> {

--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -16,6 +16,7 @@ import {
   type ProjectRuntimeOptions,
 } from './project-runtime.js'
 import { createSnapshot, restoreSnapshot } from './snapshot.js'
+import { waitForShutdown } from './shutdown.js'
 
 interface CliOptions extends ProjectRuntimeOptions {
   command: string
@@ -307,19 +308,6 @@ function timestamp(): string {
 }
 
 function quietLog(): void {}
-
-async function waitForShutdown(closeProject: () => Promise<void>): Promise<void> {
-  await new Promise<void>((resolveShutdown) => {
-    const resolveOnSignal = () => {
-      process.off('SIGINT', resolveOnSignal)
-      process.off('SIGTERM', resolveOnSignal)
-      resolveShutdown()
-    }
-    process.once('SIGINT', resolveOnSignal)
-    process.once('SIGTERM', resolveOnSignal)
-  })
-  await closeProject()
-}
 
 function printHelp(): void {
   console.log(`supacloud-lite - Bun-native Supabase-compatible backend on PGlite

--- a/packages/supacloud-lite/src/shutdown.ts
+++ b/packages/supacloud-lite/src/shutdown.ts
@@ -1,0 +1,20 @@
+interface ShutdownSignalSource {
+  off(signal: NodeJS.Signals, listener: () => void): void
+  once(signal: NodeJS.Signals, listener: () => void): void
+}
+
+export async function waitForShutdown(
+  closeProject: () => Promise<void>,
+  signalSource: ShutdownSignalSource = process,
+): Promise<void> {
+  await new Promise<void>((resolveShutdown) => {
+    const resolveOnSignal = () => {
+      signalSource.off('SIGINT', resolveOnSignal)
+      signalSource.off('SIGTERM', resolveOnSignal)
+      resolveShutdown()
+    }
+    signalSource.once('SIGINT', resolveOnSignal)
+    signalSource.once('SIGTERM', resolveOnSignal)
+  })
+  await closeProject()
+}

--- a/packages/supacloud-lite/src/snapshot.ts
+++ b/packages/supacloud-lite/src/snapshot.ts
@@ -2,6 +2,7 @@ import { chmod, copyFile, link, lstat, mkdir, mkdtemp, readdir, readFile, rename
 import { dirname, join, parse, relative, resolve, sep } from 'node:path'
 import { create as createTar, extract as extractTar } from 'tar'
 import type { ConfiguredStorageBackend, ProjectPaths } from './project-runtime.js'
+import { recoverStaleDataDirLock } from './vendor/tinbase/db/data-dir-lock.js'
 
 const SNAPSHOT_FORMAT = 'supacloud-lite-snapshot'
 const SNAPSHOT_VERSION = 1
@@ -223,12 +224,10 @@ async function assertDirectoryOrMissing(path: string | undefined): Promise<void>
 async function assertNoDataDirectoryLock(paths: ProjectPaths): Promise<void> {
   if (!paths.dataDir) return
   const lockPath = `${paths.dataDir}.supacloud-lite.lock`
-  try {
-    await lstat(lockPath)
-    throw new Error(`data directory is in use or has a stale lock: ${lockPath}; stop Lite and remove the lock manually if it is stale`)
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-  }
+  const lockState = await recoverStaleDataDirLock(lockPath)
+  if (lockState.kind === 'missing') return
+  if (lockState.kind === 'active') throw new Error(`data directory is already in use: ${paths.dataDir} (pid ${lockState.owner.pid})`)
+  throw new Error(`data directory has an unreadable lock: ${lockPath}; confirm Lite is stopped, then remove the lock manually`)
 }
 
 async function stageDirectory(root: string, destination: string): Promise<void> {

--- a/packages/supacloud-lite/src/vendor/tinbase/db/data-dir-lock.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/db/data-dir-lock.ts
@@ -1,0 +1,62 @@
+import { readFile, unlink } from 'node:fs/promises'
+
+export interface DataDirLockOwner {
+  pid: number
+  nonce: string
+}
+
+export type DataDirLockState =
+  | { kind: 'missing' }
+  | { kind: 'unreadable' }
+  | { kind: 'active'; owner: DataDirLockOwner }
+  | { kind: 'stale'; owner: DataDirLockOwner }
+
+export async function recoverStaleDataDirLock(lockPath: string): Promise<DataDirLockState> {
+  const lockState = await inspectDataDirLock(lockPath)
+  if (lockState.kind !== 'stale') return lockState
+
+  try {
+    await unlink(lockPath)
+    return { kind: 'missing' }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { kind: 'missing' }
+    throw error
+  }
+}
+
+export async function readDataDirLockOwner(lockPath: string): Promise<DataDirLockOwner | null> {
+  const lockState = await inspectDataDirLock(lockPath)
+  return lockState.kind === 'active' || lockState.kind === 'stale' ? lockState.owner : null
+}
+
+async function inspectDataDirLock(lockPath: string): Promise<DataDirLockState> {
+  let contents: string
+  try {
+    contents = await readFile(lockPath, 'utf8')
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT' ? { kind: 'missing' } : { kind: 'unreadable' }
+  }
+  const owner = parseDataDirLockOwner(contents)
+  if (!owner) return { kind: 'unreadable' }
+  return isProcessAlive(owner.pid) ? { kind: 'active', owner } : { kind: 'stale', owner }
+}
+
+function parseDataDirLockOwner(contents: string): DataDirLockOwner | null {
+  try {
+    const value = JSON.parse(contents) as { pid?: unknown; nonce?: unknown }
+    return typeof value.pid === 'number' && Number.isInteger(value.pid) && value.pid > 0 && typeof value.nonce === 'string'
+      ? { pid: value.pid, nonce: value.nonce }
+      : null
+  } catch {
+    return null
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}

--- a/packages/supacloud-lite/src/vendor/tinbase/db/pglite-engine.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/db/pglite-engine.ts
@@ -1,8 +1,9 @@
 /** PGlite (WASM) engine - imported dynamically so native mode never loads the WASM bundle. */
-import { mkdir, open, readFile, unlink, type FileHandle } from 'node:fs/promises'
+import { mkdir, open, unlink, type FileHandle } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import type { Extension } from '@electric-sql/pglite'
 import type { DbEngine, EngineResults, EngineTx } from './engine.js'
+import { readDataDirLockOwner, recoverStaleDataDirLock } from './data-dir-lock.js'
 import {
   STANDALONE_PGLITE_ASSETS,
   type StandalonePgliteAssets,
@@ -152,7 +153,7 @@ async function acquireDataDirLock(dataDir?: string): Promise<() => Promise<void>
     if (released) return
     released = true
     await handle?.close()
-    const owner = await readLockOwner(lockPath)
+    const owner = await readDataDirLockOwner(lockPath)
     if (owner?.nonce !== nonce) return
     await unlink(lockPath).catch((error) => {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
@@ -161,17 +162,14 @@ async function acquireDataDirLock(dataDir?: string): Promise<() => Promise<void>
 }
 
 async function createDataDirLock(absoluteDataDir: string, lockPath: string, nonce: string): Promise<FileHandle> {
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < 3; attempt++) {
     try {
       return await writeDataDirLock(lockPath, nonce)
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
-      const owner = await readLockOwner(lockPath)
-      if (owner && isProcessAlive(owner.pid)) throw lockInUseError(absoluteDataDir, owner.pid)
-      if (!owner || attempt > 0) throw unreadableLockError(lockPath)
-      await unlink(lockPath).catch((unlinkError) => {
-        if ((unlinkError as NodeJS.ErrnoException).code !== 'ENOENT') throw unlinkError
-      })
+      const lockState = await recoverStaleDataDirLock(lockPath)
+      if (lockState.kind === 'active') throw lockInUseError(absoluteDataDir, lockState.owner.pid)
+      if (lockState.kind === 'unreadable') throw unreadableLockError(lockPath)
     }
   }
   throw unreadableLockError(lockPath)
@@ -198,24 +196,4 @@ function unreadableLockError(lockPath: string): Error {
     `PGlite data directory has an unreadable lock: ${lockPath}. ` +
       'Confirm no SupaCloud Lite process is using it, then remove the lock manually.'
   )
-}
-
-async function readLockOwner(lockPath: string): Promise<{ pid: number; nonce: string } | null> {
-  try {
-    const value = JSON.parse(await readFile(lockPath, 'utf8')) as { pid?: unknown; nonce?: unknown }
-    return typeof value.pid === 'number' && Number.isInteger(value.pid) && value.pid > 0 && typeof value.nonce === 'string'
-      ? { pid: value.pid, nonce: value.nonce }
-      : null
-  } catch {
-    return null
-  }
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'EPERM'
-  }
 }

--- a/packages/supacloud-lite/test/cli-shutdown.test.ts
+++ b/packages/supacloud-lite/test/cli-shutdown.test.ts
@@ -1,11 +1,19 @@
 import { expect, test } from 'bun:test'
-import { access, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { EventEmitter } from 'node:events'
+import { access, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { waitForShutdown } from '../src/shutdown.js'
 
 const cliPath = resolve(import.meta.dir, '../src/cli.ts')
 
 test('closes the project and releases its data lock on SIGINT', async () => {
+  if (process.platform === 'win32') {
+    // Windows process.kill terminates a child instead of emulating terminal Ctrl+C.
+    await assertShutdownHandlerClosesProject('SIGINT')
+    return
+  }
+
   const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-cli-shutdown-'))
   const lockPath = join(projectDir, '.supacloud-lite', 'db.supacloud-lite.lock')
   const firstRun = startCli(projectDir)
@@ -42,6 +50,12 @@ test('closes the project and releases its data lock on SIGINT', async () => {
 }, 120_000)
 
 test('closes the project and releases its data lock on SIGTERM', async () => {
+  if (process.platform === 'win32') {
+    // Windows process.kill terminates a child instead of delivering SIGTERM.
+    await assertShutdownHandlerClosesProject('SIGTERM')
+    return
+  }
+
   const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-cli-shutdown-'))
   const lockPath = join(projectDir, '.supacloud-lite', 'db.supacloud-lite.lock')
   const cliRun = startCli(projectDir)
@@ -59,15 +73,17 @@ test('closes the project and releases its data lock on SIGTERM', async () => {
   }
 }, 60_000)
 
-test('marks direct CLI shutdown success only after close resolves', async () => {
-  const source = await readFile(cliPath, 'utf8')
-  const shutdownCall = source.indexOf("await waitForShutdown(() => project.close())")
-  const successfulExit = source.indexOf('process.exitCode = 0', shutdownCall)
+test('propagates a project cleanup failure', async () => {
+  const signalSource = new EventEmitter()
+  const expectedError = new Error('close failed')
+  const shutdown = waitForShutdown(() => Promise.reject(expectedError), signalSource)
 
-  expect(shutdownCall).toBeGreaterThan(-1)
-  expect(source.indexOf('await closeProject()')).toBeGreaterThan(shutdownCall)
-  expect(successfulExit).toBeGreaterThan(shutdownCall)
-  expect(source).toContain('process.exitCode = 1')
+  signalSource.emit('SIGINT')
+  await expect(shutdown).rejects.toBe(expectedError)
+})
+
+test('runs project cleanup once after duplicate signals', async () => {
+  await assertShutdownHandlerClosesProject('SIGINT')
 })
 
 function startCli(projectDir: string) {
@@ -106,6 +122,26 @@ async function stopCli(cliRun: ReturnType<typeof startCli>, signal: NodeJS.Signa
     if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
   }
   return await cliRun.processHandle.exited
+}
+
+async function assertShutdownHandlerClosesProject(signal: NodeJS.Signals): Promise<void> {
+  const signalSource = new EventEmitter()
+  let closeCalls = 0
+  let allowClose: (() => void) | undefined
+  const closeFinished = new Promise<void>((resolveClose) => {
+    allowClose = resolveClose
+  })
+  const shutdown = waitForShutdown(async () => {
+    closeCalls += 1
+    await closeFinished
+  }, signalSource)
+
+  signalSource.emit(signal)
+  signalSource.emit(signal)
+  await Promise.resolve()
+  expect(closeCalls).toBe(1)
+  allowClose!()
+  await shutdown
 }
 
 async function waitForStartup(logs: ReadableStream<Uint8Array>): Promise<void> {

--- a/packages/supacloud-lite/test/launcher-shutdown.test.ts
+++ b/packages/supacloud-lite/test/launcher-shutdown.test.ts
@@ -1,87 +1,51 @@
 import { expect, test } from 'bun:test'
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { delimiter, join, resolve } from 'node:path'
+import { EventEmitter } from 'node:events'
+import { readFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { runInNewContext } from 'node:vm'
 
 const launcherSourcePath = resolve(import.meta.dir, '../src/launcher.cjs')
 
-test('waits for a SIGINT-shutdown child and preserves its successful exit code', async () => {
-  const nodeExecutable = Bun.which('node')
-  if (!nodeExecutable) throw new Error('Node is required to exercise the npm launcher')
+test('forwards a graceful shutdown and preserves its successful exit code', async () => {
+  const launcherSource = await readFile(launcherSourcePath, 'utf8')
+  const parentProcess = createParentProcess()
+  const bunProcess = createBunProcess()
+  const require = createLauncherRequire(bunProcess)
 
-  const packageDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-launcher-'))
-  const fakeBinDir = join(packageDir, 'bin')
-  const launcherPath = join(packageDir, 'launcher.cjs')
-  const cliPath = join(packageDir, 'cli.js')
-  let launcher: Bun.Subprocess | undefined
-  let launcherStopped = false
+  runInNewContext(launcherSource, { __dirname: import.meta.dir, console, process: parentProcess, require })
+  parentProcess.emit('SIGINT')
+  bunProcess.emit('exit', 0, null)
 
-  try {
-    await mkdir(fakeBinDir)
-    await Bun.write(launcherPath, Bun.file(launcherSourcePath))
-    await writeFile(cliPath, `
-process.stdout.write('ready\\n')
-process.once('SIGINT', () => setTimeout(() => process.exit(0), 10))
-setInterval(() => {}, 1_000)
-`)
-    await Bun.write(join(fakeBinDir, 'bun.cjs'), `require(process.argv[2])\n`)
-    await writeFakeBunCommand(fakeBinDir, nodeExecutable)
+  expect(bunProcess.killCalls).toEqual(['SIGINT'])
+  expect(parentProcess.exitCode).toBe(0)
+})
 
-    launcher = Bun.spawn({
-      cmd: [nodeExecutable, launcherPath, 'start'],
-      cwd: packageDir,
-      env: withFakeBunPath(fakeBinDir),
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
-    const launcherOutput = launcher.stdout
-    if (!launcherOutput || typeof launcherOutput === 'number') throw new Error('launcher stdout is unavailable')
-    await waitForOutput(launcherOutput as ReadableStream<Uint8Array>, 'ready')
-
-    process.kill(launcher.pid, 'SIGINT')
-    expect(await launcher.exited).toBe(0)
-    launcherStopped = true
-  } finally {
-    if (launcher && !launcherStopped) {
-      try {
-        process.kill(launcher.pid, 'SIGTERM')
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error
-      }
-      await launcher.exited
-    }
-    await rm(packageDir, { recursive: true, force: true })
-  }
-}, 20_000)
-
-async function writeFakeBunCommand(fakeBinDir: string, nodeExecutable: string): Promise<void> {
-  if (process.platform === 'win32') {
-    await writeFile(join(fakeBinDir, 'bun.cmd'), `@"${nodeExecutable}" "%~dp0bun.cjs" %*\r\n`)
-    return
-  }
-
-  const commandPath = join(fakeBinDir, 'bun')
-  await writeFile(commandPath, `#!${nodeExecutable}\nrequire(__dirname + '/bun.cjs')\n`)
-  await chmod(commandPath, 0o755)
+function createParentProcess() {
+  return Object.assign(new EventEmitter(), {
+    argv: ['node', 'launcher.cjs', 'start'],
+    exitCode: null as number | null,
+    pid: 42,
+    kill: () => {
+      throw new Error('the launcher must not re-signal its parent')
+    },
+  })
 }
 
-function withFakeBunPath(fakeBinDir: string): NodeJS.ProcessEnv {
-  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
-  return { ...process.env, [pathKey]: `${fakeBinDir}${delimiter}${process.env[pathKey] ?? ''}` }
+function createBunProcess() {
+  return Object.assign(new EventEmitter(), {
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    killCalls: [] as NodeJS.Signals[],
+    kill(signal: NodeJS.Signals) {
+      this.killCalls.push(signal)
+    },
+  })
 }
 
-async function waitForOutput(output: ReadableStream<Uint8Array>, expected: string): Promise<void> {
-  const reader = output.getReader()
-  const decoder = new TextDecoder()
-  let logs = ''
-  try {
-    while (true) {
-      const chunk = await reader.read()
-      if (chunk.done) throw new Error(`launcher exited before ${expected}:\n${logs}`)
-      logs += decoder.decode(chunk.value, { stream: true })
-      if (logs.includes(expected)) return
-    }
-  } finally {
-    reader.releaseLock()
+function createLauncherRequire(bunProcess: ReturnType<typeof createBunProcess>) {
+  return (moduleName: string) => {
+    if (moduleName === 'node:child_process') return { spawn: () => bunProcess }
+    if (moduleName === 'node:path') return { join }
+    throw new Error(`unexpected module: ${moduleName}`)
   }
 }

--- a/packages/supacloud-lite/test/snapshot.test.ts
+++ b/packages/supacloud-lite/test/snapshot.test.ts
@@ -90,12 +90,19 @@ describe('Lite snapshots', () => {
     await mkdir(paths.storageDir, { recursive: true })
     const archivePath = join(projectDir, 'guards.tar.gz')
 
+    await writeFile(`${paths.dataDir}.supacloud-lite.lock`, JSON.stringify({ pid: process.pid, nonce: 'active' }))
+    await expect(
+      createSnapshot({ paths, packageVersion: 'test-version', storageBackend: 'fs', output: archivePath })
+    ).rejects.toThrow('already in use')
+    await rm(`${paths.dataDir}.supacloud-lite.lock`)
+
     await writeFile(`${paths.dataDir}.supacloud-lite.lock`, '{}')
     await expect(
       createSnapshot({ paths, packageVersion: 'test-version', storageBackend: 'fs', output: archivePath })
-    ).rejects.toThrow('in use or has a stale lock')
+    ).rejects.toThrow('unreadable lock')
     await rm(`${paths.dataDir}.supacloud-lite.lock`)
 
+    await writeFile(`${paths.dataDir}.supacloud-lite.lock`, JSON.stringify({ pid: 999_999, nonce: 'stale' }))
     await createSnapshot({ paths, packageVersion: 'test-version', storageBackend: 'fs', output: archivePath })
     await expect(
       createSnapshot({ paths, packageVersion: 'test-version', storageBackend: 'fs', output: archivePath })


### PR DESCRIPTION
## Summary
- retain graceful Lite shutdown handling while separating Windows forced process termination from terminal Ctrl+C delivery
- cover the shutdown and npm launcher paths without treating Windows `process.kill()` as a false Ctrl+C emulator
- make the Windows Lite CI step fail immediately when any Bun command fails
- use the Windows `.exe` standalone artifact and recover a verified stale data-directory lock before snapshot or upgrade work

## Verification
- `bun test test/snapshot.test.ts test/project-runtime.test.ts --timeout 60000`: 15 pass, 0 fail
- `bun run typecheck` in `packages/supacloud-lite`: pass
- final full `bun run check` and native Windows CI are in progress

Tracks CNB issue #88. Windows `process.kill(pid, SIGINT/SIGTERM)` unconditionally terminates the child; terminal Ctrl+C is a distinct signal-delivery path.