### PR TITLE
fix(ci): dispatch release-please after auto-merge to main

### DIFF
--- a/.github/workflows/ai-review-merge.yml
+++ b/.github/workflows/ai-review-merge.yml
@@ -16,6 +16,7 @@ permissions:
   pull-requests: write
   checks: read
   statuses: read
+  actions: write
 
 concurrency:
   group: ai-review-merge-${{ github.event.workflow_run.pull_requests[0].number || inputs.pr_number || github.event.workflow_run.head_sha || github.run_id }}
@@ -149,3 +150,26 @@ jobs:
           GITHUB_HEAD_REF: ${{ steps.pr-info.outputs.head_ref }}
           HEAD_SHA: ${{ steps.pr-info.outputs.head_sha }}
         run: node .github/scripts/ai-review-merge.mjs
+
+      # GITHUB_TOKEN 合并产生的 push 事件不会触发依赖 on.push 的 workflow
+      # （GitHub 对默认 token 的硬性限制）。auto-merge 合入 main 后显式
+      # dispatch release-please，确保发版 PR 正常生成；dev 分支不触发。
+      - name: Trigger release-please after auto-merge
+        if: steps.pr-info.outputs.pr_number != '' && steps.pr-info.outputs.base_ref == 'main'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MERGED=$(curl -fsS \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUMBER}" \
+            | jq -r '.merged // false')
+          if [ "$MERGED" = "true" ]; then
+            echo "PR #${PR_NUMBER} was auto-merged. Dispatching release-please."
+            gh workflow run release-please.yml --repo "${REPOSITORY}" --ref main
+          else
+            echo "PR #${PR_NUMBER} was not merged (AI did not approve, or merge failed). Skipping release-please dispatch."
+          fi


### PR DESCRIPTION
## 根因

PR #652 由 AI Review & Auto-Merge workflow 用 `GITHUB_TOKEN` squash 合并，但 GitHub 对默认 token 有硬性限制：**由 `GITHUB_TOKEN` 产生的事件不会触发后续 workflow run**。因此合入 main 的 push 没有唤醒 `release-please.yml`（监听 `on.push.branches:[main]`），发版 PR 缺失。

对照：release-please 自己的 PR 用 `RELEASE_PLEASE_TOKEN` 合并，能正常触发后续 workflow，所以之前的发版 PR 链路一直正常。

## 修复

在 `ai-review-merge.yml` 成功合并后新增一步 `Trigger release-please after auto-merge`：

- 仅当 `base_ref == 'main'` 时触发（dev 分支跳过）
- 通过 GitHub API 复核 PR `merged == true`，未合并则跳过
- 显式 `gh workflow run release-please.yml` 补偿触发发版流程
- 新增 `actions: write` 权限以支持 workflow dispatch

不改动 AI review 脚本的安全模型（5 层防护不变），不引入新 token/secrets。

## 验证

- `python3 -c 'import yaml; yaml.safe_load(...)' ` 语法 OK
- `node --test .github/scripts/ai-review-merge.test.mjs` 13/13 通过
- 改动仅限 workflow yml，脚本未动