### PR TITLE
fix(health): read Patroni cluster config

### DIFF
--- a/packages/management-api/src/infra/cluster.test.ts
+++ b/packages/management-api/src/infra/cluster.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { PATRONI_CONFIG_PATH, parsePatroniNodes, patronictlListArguments } from "./cluster";
+
+describe("patronictl cluster status command", () => {
+    test("uses the installed Patroni configuration when it is available", () => {
+        expect(patronictlListArguments(true)).toEqual([
+            "-c",
+            PATRONI_CONFIG_PATH,
+            "list",
+            "--format",
+            "json",
+        ]);
+    });
+
+    test("keeps the default Patroni lookup for installations without that configuration path", () => {
+        expect(patronictlListArguments(false)).toEqual(["list", "--format", "json"]);
+    });
+
+    test("treats a successful command with no cluster output as an unavailable cluster", () => {
+        expect(parsePatroniNodes("   \n")).toEqual([]);
+    });
+
+    test("normalizes Patroni's formatted member fields", () => {
+        expect(parsePatroniNodes('[{"Role":"Leader","State":"running","Member":"pg-meta-1"}]')).toEqual([
+            { role: "Leader", state: "running", member: "pg-meta-1" },
+        ]);
+    });
+});

--- a/packages/management-api/src/infra/cluster.ts
+++ b/packages/management-api/src/infra/cluster.ts
@@ -1,15 +1,30 @@
-/**
- * Stub module for the planned cluster module.
- * The actual implementation will be added when HA cluster support is built.
- * Currently returns empty arrays so health checks can proceed gracefully.
- */
 import { $ } from "bun";
 import { logger } from "../utils/logger";
+
+export const PATRONI_CONFIG_PATH = "/etc/patroni/patroni.yml";
 
 export interface ClusterNode {
     role: string;
     state: string;
     member: string;
+}
+
+export function patronictlListArguments(hasPatroniConfig: boolean): string[] {
+    return hasPatroniConfig
+        ? ["-c", PATRONI_CONFIG_PATH, "list", "--format", "json"]
+        : ["list", "--format", "json"];
+}
+
+export function parsePatroniNodes(commandOutput: string): ClusterNode[] {
+    const output = commandOutput.trim();
+    // patronictl exits successfully with no stdout when it cannot resolve a cluster name.
+    if (!output) return [];
+    const nodes = JSON.parse(output);
+    return Array.isArray(nodes) ? nodes.map((node: Record<string, string>) => ({
+        role: node.Role || node.role || "unknown",
+        state: node.State || node.state || "unknown",
+        member: node.Member || node.member || "unknown",
+    })) : [];
 }
 
 export class ClusterManager {
@@ -19,14 +34,10 @@ export class ClusterManager {
      */
     static async getStatus(): Promise<ClusterNode[]> {
         try {
-            const result = await $`patronictl list --format json`.nothrow().quiet();
+            const commandArguments = patronictlListArguments(await Bun.file(PATRONI_CONFIG_PATH).exists());
+            const result = await $`patronictl ${commandArguments}`.nothrow().quiet();
             if (result.exitCode !== 0) return [];
-            const data = JSON.parse(result.stdout.toString());
-            return Array.isArray(data) ? data.map((n: Record<string, string>) => ({
-                role: n.Role || n.role || "unknown",
-                state: n.State || n.state || "unknown",
-                member: n.Member || n.member || "unknown",
-            })) : [];
+            return parsePatroniNodes(result.stdout.toString());
         } catch (err: unknown) {
             logger.debug("[ClusterManager] Patroni not available, skipping HA detection", {
                 error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary

Fixes HA health detection when Patroni is installed with the standard `/etc/patroni/patroni.yml` configuration.

`patronictl list --format json` can exit successfully with no stdout when it cannot discover a cluster name. On the verified test host this caused a JSON EOF, so Studio fell back to reporting a single-node database even though Patroni reported `pg-meta-1` as Leader.

- Pass the installed Patroni configuration to `patronictl` when present.
- Preserve the default Patroni lookup for installations without that configuration path.
- Treat successful empty output as an unavailable cluster rather than a JSON parse failure.
- Add unit coverage for both command paths, empty output, and Patroni member normalization.

## Verification

- Test host: `patronictl -c /etc/patroni/patroni.yml list --format json` returned the `pg-meta-1` Leader.
- `bun test src/infra/cluster.test.ts`: 4 pass, 0 fail.
- `bun run typecheck`
- Management API Linux compilation completed successfully.
- `git diff --check`