### PR TITLE
fix: address release-blocking review findings

### DIFF
--- a/infrastructure/systemd/supacloud-realtime.service
+++ b/infrastructure/systemd/supacloud-realtime.service
@@ -30,35 +30,12 @@ Environment=REALTIME_IMAGE=public.ecr.aws/supabase/realtime:v2.121.1
 Environment=REALTIME_CONTAINER_NAME=supacloud-realtime
 Environment=REALTIME_DB_USER=supabase_admin
 Environment=PG_DATABASE=supacloud_meta
+Environment=REALTIME_CONTAINER_ENV_FILE=/etc/supabase/realtime-container.env
 EnvironmentFile=-/etc/supabase/management-api.env
 
 ExecStartPre=/bin/sh -c 'test -n "$$REALTIME_SECRET_KEY_BASE" && test -n "$$REALTIME_DB_ENC_KEY" && test "$${#REALTIME_DB_ENC_KEY}" -eq 16 && test -n "$$SUPACLOUD_JWT_SECRET" && test -n "$$REALTIME_IMAGE" && test -n "$$REALTIME_CONTAINER_NAME" && test -n "$$REALTIME_DB_USER" && test -n "$$PGPASSWORD"'
 ExecStartPre=-/usr/bin/podman rm -f ${REALTIME_CONTAINER_NAME}
-ExecStart=/usr/bin/podman run --replace --name ${REALTIME_CONTAINER_NAME} --network host \
-  -e PORT=4000 \
-  -e DB_HOST=${PG_HOST} \
-  -e DB_PORT=${PG_PORT} \
-  -e DB_USER=${REALTIME_DB_USER} \
-  -e DB_NAME=${PG_DATABASE} \
-  -e DB_PASSWORD=${PGPASSWORD} \
-  -e DB_USER_REALTIME=${REALTIME_DB_USER} \
-  -e DB_PASS_REALTIME=${PGPASSWORD} \
-  -e SECRET_KEY_BASE=${REALTIME_SECRET_KEY_BASE} \
-  -e JWT_SECRET=${SUPACLOUD_JWT_SECRET} \
-  -e API_JWT_SECRET=${SUPACLOUD_JWT_SECRET} \
-  -e METRICS_JWT_SECRET=${SUPACLOUD_JWT_SECRET} \
-  -e DB_SSL=false \
-  -e RLS_ENABLED=true \
-  -e MAX_HEADER_LENGTH=8192 \
-  -e RLIMIT_NOFILE=10000 \
-  -e APP_NAME=realtime \
-  -e DB_ENC_KEY=${REALTIME_DB_ENC_KEY} \
-  -e SEED_SELF_HOST=false \
-  -e RUN_JANITOR=false \
-  -e SECURE_CHANNELS=false \
-  -e REGION=us-east-1 \
-  -e DISABLE_HEALTHCHECK_LOGGING=true \
-  ${REALTIME_IMAGE}
+ExecStart=/usr/bin/podman run --replace --name ${REALTIME_CONTAINER_NAME} --network host --env-file ${REALTIME_CONTAINER_ENV_FILE} ${REALTIME_IMAGE}
 
 ExecStop=/usr/bin/podman stop -t 10 ${REALTIME_CONTAINER_NAME}
 

--- a/install.sh
+++ b/install.sh
@@ -3662,21 +3662,11 @@ import sys
 source, target, env_file = map(Path, sys.argv[1:])
 lines = source.read_text().splitlines()
 result = []
-skipping = False
 for line in lines:
-    if line.startswith("ExecStart=/usr/bin/podman run"):
-        result.append(
-            "ExecStart=/usr/bin/podman run --replace "
-            "--name ${REALTIME_CONTAINER_NAME} --network host "
-            f"--env-file {env_file} ${{REALTIME_IMAGE}}"
-        )
-        skipping = True
-        continue
-    if skipping:
-        if line.strip() == "${REALTIME_IMAGE}":
-            skipping = False
-        continue
-    result.append(line)
+    if line.startswith("Environment=REALTIME_CONTAINER_ENV_FILE="):
+        result.append(f"Environment=REALTIME_CONTAINER_ENV_FILE={env_file}")
+    else:
+        result.append(line)
 target.write_text("\n".join(result) + "\n")
 PY
 }

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -435,4 +435,34 @@ describe("ssh admin tool", () => {
         expect(output).toContain("Migration failed");
         expect(output).not.toContain("Migration done");
     });
+
+    test("tenant migration rejects schema lists containing shell metacharacters or newlines", async () => {
+        const ssh = new FakeSsh();
+        const tool = captureSshTool(ssh);
+
+        for (const schemas of ["public\nreboot\npublic", "public;drop", "public$(id)", "pub lic", "public,'auth"]) {
+            await expect(tool.invoke({
+                action: "tenant_migrate",
+                source_ref: "source1",
+                target_ref: "target1",
+                schemas,
+            })).rejects.toThrow(/Invalid schema identifier/);
+        }
+        // 注入载荷从未进入远程命令流
+        expect(ssh.commands.join("\n")).not.toContain("reboot");
+    });
+
+    test("tenant migration quotes validated schema identifiers", async () => {
+        const ssh = new FakeSsh();
+        const tool = captureSshTool(ssh);
+
+        await tool.invoke({
+            action: "tenant_migrate",
+            source_ref: "source1",
+            target_ref: "target1",
+            schemas: "public, auth, tenant_data",
+        });
+        const command = ssh.commands.find(candidate => candidate.includes("pg_dump")) ?? "";
+        expect(command).toContain("-n 'public' -n 'auth' -n 'tenant_data'");
+    });
 });

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -9,6 +9,7 @@ import type { SshTransport } from "../transports/ssh";
 
 const SAFE_CONTAINER_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/;
 const SAFE_PROJECT_REF = /^[a-z0-9-]{1,20}$/;
+const SAFE_SCHEMA_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
 const SAFE_RELEASE_TAG = /^[a-zA-Z0-9._-]{1,80}$/;
 const SAFE_TIMEOUT_SECONDS = 300;
 const SAFE_HOSTNAME = /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$/;
@@ -520,10 +521,16 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
                     const targetRef = assertSafeProjectRef(args.target_ref, "target_ref");
                     if (sourceRef === targetRef) throw new Error("source_ref and target_ref must be different");
                     const s = args.schemas || "public,auth,storage";
-                    if (!/^[a-z_,\s]+$/.test(s)) throw new Error("Invalid schemas");
                     const schemas = s.split(",").map((x: string) => x.trim()).filter(Boolean);
                     if (schemas.length === 0) throw new Error("At least one schema is required");
-                    const schemaArgs = schemas.map((schema: string) => `-n ${schema}`).join(" ");
+                    // 逐项按 PostgreSQL 标识符规则校验：\s 允许换行会把 "public\nreboot"
+                    // 这类输入拆成独立的远程 shell 命令
+                    for (const schema of schemas) {
+                        if (!SAFE_SCHEMA_IDENTIFIER.test(schema)) {
+                            throw new Error(`Invalid schema identifier: ${JSON.stringify(schema)}`);
+                        }
+                    }
+                    const schemaArgs = schemas.map((schema: string) => `-n '${schema}'`).join(" ");
                     const df = args.data_only ? "--data-only" : "";
                     const cmd = [
                         "set -euo pipefail",

--- a/packages/admin/src/shared/transports/http.test.ts
+++ b/packages/admin/src/shared/transports/http.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { HttpTransport } from "./http";
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+
+let clearedTimerIds: Array<ReturnType<typeof setTimeout> | undefined> = [];
+let nextTimerId = 0;
+
+beforeEach(() => {
+    clearedTimerIds = [];
+    nextTimerId = 0;
+    globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+        const timerId = ++nextTimerId as unknown as ReturnType<typeof setTimeout>;
+        if (delay !== 30_000) queueMicrotask(() => callback(...args));
+        return timerId;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = ((timerId?: ReturnType<typeof setTimeout>) => {
+        clearedTimerIds.push(timerId);
+    }) as typeof clearTimeout;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+});
+
+function createTransport(): HttpTransport {
+    return new HttpTransport({ baseUrl: "https://api.example.test", token: "test-token" });
+}
+
+function retryableNetworkError(kind: "AbortError" | "ECONNREFUSED" | "ECONNRESET"): Error {
+    const error = new Error(kind);
+    if (kind === "AbortError") error.name = kind;
+    else Object.assign(error, { code: kind });
+    return error;
+}
+
+describe("HttpTransport retry policy", () => {
+    test("retries GET after a 5xx response without waiting for backoff", async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return fetchCalls === 1
+                ? Response.json({ error: "temporary" }, { status: 503 })
+                : Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+
+        const response = await createTransport().get<{ ok: boolean }>("/v1/projects");
+
+        expect(response.ok).toBe(true);
+        expect(fetchCalls).toBe(2);
+        expect(clearedTimerIds).toHaveLength(2);
+    });
+
+    test.each(["AbortError", "ECONNREFUSED", "ECONNRESET"] as const)(
+        "retries GET after %s",
+        async errorKind => {
+            let fetchCalls = 0;
+            globalThis.fetch = (async () => {
+                fetchCalls++;
+                if (fetchCalls === 1) throw retryableNetworkError(errorKind);
+                return Response.json({ ok: true });
+            }) as unknown as typeof fetch;
+
+            const response = await createTransport().get<{ ok: boolean }>("/v1/projects");
+
+            expect(response.ok).toBe(true);
+            expect(fetchCalls).toBe(2);
+            expect(clearedTimerIds).toHaveLength(2);
+        },
+    );
+
+    const unsafeRequests = [
+        ["POST", (transport: HttpTransport) => transport.post("/resource", { name: "test" })],
+        ["multipart POST", (transport: HttpTransport) => transport.postMultipart("/resource", new FormData())],
+        ["PATCH", (transport: HttpTransport) => transport.patch("/resource", { name: "test" })],
+        ["PUT", (transport: HttpTransport) => transport.put("/resource", { name: "test" })],
+        ["DELETE", (transport: HttpTransport) => transport.delete("/resource")],
+    ] as const;
+
+    test.each(unsafeRequests)("does not retry %s after a 5xx response", async (_method, request) => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return Response.json({ error: "temporary" }, { status: 503 });
+        }) as unknown as typeof fetch;
+
+        const response = await request(createTransport());
+
+        expect(response.status).toBe(503);
+        expect(fetchCalls).toBe(1);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+
+    test.each(unsafeRequests)("does not retry %s after a retryable network error", async (_method, request) => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            throw retryableNetworkError("ECONNRESET");
+        }) as unknown as typeof fetch;
+
+        const response = await request(createTransport());
+
+        expect(response.status).toBe(500);
+        expect(fetchCalls).toBe(1);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+});

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -20,34 +20,54 @@ const DEFAULT_TIMEOUT = 30_000;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
 
+function isRetryableMethod(method?: string): boolean {
+    const normalizedMethod = (method ?? "GET").toUpperCase();
+    return normalizedMethod === "GET" || normalizedMethod === "HEAD";
+}
+
+function isRetryableError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const networkError = error as Error & { code?: string };
+    return networkError.name === "AbortError"
+        || networkError.code === "ECONNREFUSED"
+        || networkError.code === "ECONNRESET";
+}
+
+async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+    try {
+        return await fetch(url, {
+            ...options,
+            signal: controller.signal,
+        });
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
 async function fetchWithRetry(
     url: string,
     options: RequestInit,
-    retries = MAX_RETRIES,
 ): Promise<Response> {
+    const retries = isRetryableMethod(options.method) ? MAX_RETRIES : 0;
     for (let attempt = 0; attempt <= retries; attempt++) {
         try {
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
-            const res = await fetch(url, {
-                ...options,
-                signal: controller.signal,
-            });
-            clearTimeout(timeout);
+            const res = await fetchWithTimeout(url, options);
 
-            if (res.status >= 500 && attempt < retries) {
+            if (res.status >= 500 && res.status < 600 && attempt < retries) {
                 const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
                 await new Promise(r => setTimeout(r, delay));
                 continue;
             }
             return res;
-        } catch (err: any) {
-            if (attempt < retries && (err.name === "AbortError" || err.code === "ECONNREFUSED" || err.code === "ECONNRESET")) {
+        } catch (error: unknown) {
+            if (attempt < retries && isRetryableError(error)) {
                 const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
                 await new Promise(r => setTimeout(r, delay));
                 continue;
             }
-            throw err;
+            throw error;
         }
     }
     throw new Error("Unreachable");

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { HttpTransport } from "./http";
+
+const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+
+let clearedTimerIds: Array<ReturnType<typeof setTimeout> | undefined> = [];
+let nextTimerId = 0;
+
+beforeEach(() => {
+    clearedTimerIds = [];
+    nextTimerId = 0;
+    globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
+        const timerId = ++nextTimerId as unknown as ReturnType<typeof setTimeout>;
+        if (delay !== 30_000) queueMicrotask(() => callback(...args));
+        return timerId;
+    }) as typeof setTimeout;
+    globalThis.clearTimeout = ((timerId?: ReturnType<typeof setTimeout>) => {
+        clearedTimerIds.push(timerId);
+    }) as typeof clearTimeout;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+});
+
+function createTransport(): HttpTransport {
+    return new HttpTransport({ baseUrl: "https://api.example.test", token: "test-token" });
+}
+
+function retryableNetworkError(kind: "AbortError" | "ECONNREFUSED" | "ECONNRESET"): Error {
+    const error = new Error(kind);
+    if (kind === "AbortError") error.name = kind;
+    else Object.assign(error, { code: kind });
+    return error;
+}
+
+describe("HttpTransport retry policy", () => {
+    test("retries GET after a 5xx response without waiting for backoff", async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return fetchCalls === 1
+                ? Response.json({ error: "temporary" }, { status: 503 })
+                : Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+
+        const response = await createTransport().get<{ ok: boolean }>("/v1/projects");
+
+        expect(response.ok).toBe(true);
+        expect(fetchCalls).toBe(2);
+        expect(clearedTimerIds).toHaveLength(2);
+    });
+
+    test.each(["AbortError", "ECONNREFUSED", "ECONNRESET"] as const)(
+        "retries GET after %s",
+        async errorKind => {
+            let fetchCalls = 0;
+            globalThis.fetch = (async () => {
+                fetchCalls++;
+                if (fetchCalls === 1) throw retryableNetworkError(errorKind);
+                return Response.json({ ok: true });
+            }) as unknown as typeof fetch;
+
+            const response = await createTransport().get<{ ok: boolean }>("/v1/projects");
+
+            expect(response.ok).toBe(true);
+            expect(fetchCalls).toBe(2);
+            expect(clearedTimerIds).toHaveLength(2);
+        },
+    );
+
+    const unsafeRequests = [
+        ["POST", (transport: HttpTransport) => transport.post("/resource", { name: "test" })],
+        ["multipart POST", (transport: HttpTransport) => transport.postMultipart("/resource", new FormData())],
+        ["PATCH", (transport: HttpTransport) => transport.patch("/resource", { name: "test" })],
+        ["PUT", (transport: HttpTransport) => transport.put("/resource", { name: "test" })],
+        ["DELETE", (transport: HttpTransport) => transport.delete("/resource")],
+    ] as const;
+
+    test.each(unsafeRequests)("does not retry %s after a 5xx response", async (_method, request) => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return Response.json({ error: "temporary" }, { status: 503 });
+        }) as unknown as typeof fetch;
+
+        const response = await request(createTransport());
+
+        expect(response.status).toBe(503);
+        expect(fetchCalls).toBe(1);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+
+    test.each(unsafeRequests)("does not retry %s after a retryable network error", async (_method, request) => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            throw retryableNetworkError("ECONNRESET");
+        }) as unknown as typeof fetch;
+
+        const response = await request(createTransport());
+
+        expect(response.status).toBe(500);
+        expect(fetchCalls).toBe(1);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+});

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -20,34 +20,54 @@ const DEFAULT_TIMEOUT = 30_000;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
 
+function isRetryableMethod(method?: string): boolean {
+    const normalizedMethod = (method ?? "GET").toUpperCase();
+    return normalizedMethod === "GET" || normalizedMethod === "HEAD";
+}
+
+function isRetryableError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const networkError = error as Error & { code?: string };
+    return networkError.name === "AbortError"
+        || networkError.code === "ECONNREFUSED"
+        || networkError.code === "ECONNRESET";
+}
+
+async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+    try {
+        return await fetch(url, {
+            ...options,
+            signal: controller.signal,
+        });
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
 async function fetchWithRetry(
     url: string,
     options: RequestInit,
-    retries = MAX_RETRIES,
 ): Promise<Response> {
+    const retries = isRetryableMethod(options.method) ? MAX_RETRIES : 0;
     for (let attempt = 0; attempt <= retries; attempt++) {
         try {
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
-            const res = await fetch(url, {
-                ...options,
-                signal: controller.signal,
-            });
-            clearTimeout(timeout);
+            const res = await fetchWithTimeout(url, options);
 
-            if (res.status >= 500 && attempt < retries) {
+            if (res.status >= 500 && res.status < 600 && attempt < retries) {
                 const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
                 await new Promise(r => setTimeout(r, delay));
                 continue;
             }
             return res;
-        } catch (err: any) {
-            if (attempt < retries && (err.name === "AbortError" || err.code === "ECONNREFUSED" || err.code === "ECONNRESET")) {
+        } catch (error: unknown) {
+            if (attempt < retries && isRetryableError(error)) {
                 const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
                 await new Promise(r => setTimeout(r, delay));
                 continue;
             }
-            throw err;
+            throw error;
         }
     }
     throw new Error("Unreachable");

--- a/packages/edge-runtime/deno-compat.command.test.ts
+++ b/packages/edge-runtime/deno-compat.command.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { syncBuiltinESMExports } from "node:module";
+import {
+  disableSubprocessApis,
+  FILESYSTEM_DISABLED_MESSAGE,
+  NATIVE_LOADER_DISABLED_MESSAGE,
+  setProjectRoot,
+} from "./deno-compat";
+
+test("Deno.Command fails closed for every subprocess command", () => {
+  const DenoCompat = (globalThis as any).Deno;
+
+  for (const command of ["dash", "awk", "sed", "echo"]) {
+    expect(() => new DenoCompat.Command(command, { args: ["--version"] }))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+  }
+});
+
+test("the worker subprocess guard disables and restores process creation APIs", async () => {
+  const bun = globalThis.Bun as unknown as Record<string, unknown>;
+  const childProcess = require("node:child_process") as Record<string, unknown>;
+  const fs = require("node:fs") as Record<string, unknown>;
+  const fsPromises = require("node:fs/promises") as Record<string, unknown>;
+  const ffiModule = require("bun:ffi") as Record<string, unknown>;
+  const moduleApi = require("node:module") as Record<string, unknown>;
+  const workerThreads = require("node:worker_threads") as Record<string, unknown>;
+  const cluster = require("node:cluster") as Record<string, unknown>;
+  const originalShell = bun.$;
+  const originalSpawn = bun.spawn;
+  const originalSpawnSync = bun.spawnSync;
+  const originalBunFile = bun.file;
+  const originalBunWrite = bun.write;
+  const originalBunDlopen = bun.dlopen;
+  const originalFfi = { ...(bun.FFI as Record<string, unknown>) };
+  const originalFfiModule = { ...ffiModule };
+  const originalNativeFfi = { ...(ffiModule.native as Record<string, unknown>) };
+  const originalWorker = (globalThis as Record<string, unknown>).Worker;
+  const originalWorkerThread = workerThreads.Worker;
+  const originalClusterFork = cluster.fork;
+  const originalFs = Object.fromEntries(
+    Object.entries(fs).filter(([, value]) => typeof value === "function"),
+  );
+  const originalFsPromises = Object.fromEntries(
+    Object.entries(fsPromises).filter(([, value]) => typeof value === "function"),
+  );
+  const originalProcessLoaders = Object.fromEntries(
+    ["dlopen", "binding", "_linkedBinding", "getBuiltinModule"]
+      .map((name) => [name, (process as unknown as Record<string, unknown>)[name]]),
+  );
+  const originalModuleCreateRequire = moduleApi.createRequire;
+  const originalModuleLoad = moduleApi._load;
+  const modulePrototype = (moduleApi.Module as { prototype?: Record<string, unknown> } | undefined)?.prototype
+    || (moduleApi as { prototype?: Record<string, unknown> }).prototype;
+  const originalModuleRequire = modulePrototype?.require;
+  const originalChildProcess = Object.fromEntries(
+    ["exec", "execFile", "execFileSync", "execSync", "fork", "spawn", "spawnSync"]
+      .map((name) => [name, childProcess[name]]),
+  );
+
+  try {
+    disableSubprocessApis();
+    setProjectRoot(import.meta.dir);
+    expect(() => Bun.$`true`)
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+    expect(() => Bun.spawn(["true"]))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+    expect(() => Bun.spawnSync(["true"]))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+    expect(() => Bun.file("/etc/hosts"))
+      .toThrow("outside the project directory");
+    expect(() => fs.readFileSync("/etc/hosts", "utf8"))
+      .toThrow(FILESYSTEM_DISABLED_MESSAGE);
+    expect(() => (process as unknown as Record<string, () => unknown>).binding())
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => {
+      const tenantRequire = (moduleApi.createRequire as (url: string) => (id: string) => unknown)(import.meta.url);
+      tenantRequire("node:fs");
+    })
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => new (globalThis.Worker as unknown as new (url: string) => Worker)("data:text/javascript,"))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+    expect(() => new (workerThreads.Worker as new (code: string) => unknown)("", { eval: true }))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+    expect(() => cluster.fork())
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+
+    const ffi = await import("bun:ffi");
+    expect(() => ffi.dlopen("libc.so.6", {}))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+    expect(() => ffi.cc({ source: "ignored.c", symbols: {} }))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+    expect(() => ffi.CFunction({ ptr: 1, args: [], returns: ffi.FFIType.i32 }))
+      .toThrow("Subprocess execution is disabled in the multi-tenant Edge Runtime.");
+  } finally {
+    setProjectRoot(null);
+    bun.$ = originalShell;
+    bun.spawn = originalSpawn;
+    bun.spawnSync = originalSpawnSync;
+    bun.file = originalBunFile;
+    bun.write = originalBunWrite;
+    if (originalBunDlopen !== undefined) bun.dlopen = originalBunDlopen;
+    Object.assign(bun.FFI as Record<string, unknown>, originalFfi);
+    Object.assign(ffiModule, originalFfiModule);
+    Object.assign(ffiModule.native as Record<string, unknown>, originalNativeFfi);
+    (globalThis as Record<string, unknown>).Worker = originalWorker;
+    workerThreads.Worker = originalWorkerThread;
+    cluster.fork = originalClusterFork;
+    Object.assign(childProcess, originalChildProcess);
+    Object.assign(fs, originalFs);
+    Object.assign(fsPromises, originalFsPromises);
+    Object.assign(process as unknown as Record<string, unknown>, originalProcessLoaders);
+    moduleApi.createRequire = originalModuleCreateRequire;
+    moduleApi._load = originalModuleLoad;
+    if (modulePrototype && originalModuleRequire) modulePrototype.require = originalModuleRequire;
+    syncBuiltinESMExports();
+  }
+});

--- a/packages/edge-runtime/deno-compat.ts
+++ b/packages/edge-runtime/deno-compat.ts
@@ -1,6 +1,43 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import path from "path";
+import { syncBuiltinESMExports } from "node:module";
+import { fileURLToPath } from "node:url";
 
-let capturedServeHandler: Function | null = null;
+export type CapturedServeHandler = (
+  request: Request,
+) => Response | Promise<Response>;
+
+let capturedServeHandler: CapturedServeHandler | null = null;
+export const SUBPROCESS_DISABLED_MESSAGE =
+  "Subprocess execution is disabled in the multi-tenant Edge Runtime.";
+export const FILESYSTEM_DISABLED_MESSAGE =
+  "Direct file system module access is disabled in the multi-tenant Edge Runtime.";
+export const NATIVE_LOADER_DISABLED_MESSAGE =
+  "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.";
+
+const nodeFs = require("node:fs") as typeof import("node:fs");
+const nodeFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+const runtimeFs = {
+  lstatSync: nodeFs.lstatSync.bind(nodeFs),
+  realpathSync: nodeFs.realpathSync.bind(nodeFs),
+  readFileSync: nodeFs.readFileSync.bind(nodeFs),
+  writeFileSync: nodeFs.writeFileSync.bind(nodeFs),
+  statSync: nodeFs.statSync.bind(nodeFs),
+  readdirSync: nodeFs.readdirSync.bind(nodeFs),
+  rmSync: nodeFs.rmSync.bind(nodeFs),
+  mkdirSync: nodeFs.mkdirSync.bind(nodeFs),
+  stat: nodeFsPromises.stat.bind(nodeFsPromises),
+  readdir: nodeFsPromises.readdir.bind(nodeFsPromises),
+  mkdir: nodeFsPromises.mkdir.bind(nodeFsPromises),
+  rm: nodeFsPromises.rm.bind(nodeFsPromises),
+};
+const runtimeBunFile = Bun.file.bind(Bun);
+const runtimeBunWrite = Bun.write.bind(Bun);
+
+export function runtimeFile(path: string | URL): ReturnType<typeof Bun.file> {
+  return runtimeBunFile(path);
+}
+
 export function getCapturedServeHandler() {
   return capturedServeHandler;
 }
@@ -8,11 +45,256 @@ export function clearCapturedServeHandler() {
   capturedServeHandler = null;
 }
 
-let currentProjectRoot: string | null = null;
+export function disableSubprocessApis(): void {
+  const subprocessDisabled = () => {
+    throw new Error(SUBPROCESS_DISABLED_MESSAGE);
+  };
+  const nativeLoaderDisabled = () => {
+    throw new Error(NATIVE_LOADER_DISABLED_MESSAGE);
+  };
+  const DisabledWorker = class {
+    constructor() {
+      subprocessDisabled();
+    }
+  };
+  if (globalThis.Bun) {
+    const bun = globalThis.Bun as unknown as Record<string, unknown>;
+    bun.$ = subprocessDisabled;
+    bun.spawn = subprocessDisabled;
+    bun.spawnSync = subprocessDisabled;
+    if (typeof bun.dlopen === "function") bun.dlopen = nativeLoaderDisabled;
+    bun.file = (...args: unknown[]) => {
+      assertPathInProject(args[0]);
+      return (runtimeBunFile as unknown as (...fileArgs: unknown[]) => unknown)(...args);
+    };
+    bun.write = (...args: unknown[]) => {
+      assertPathInProject(args[0]);
+      return (runtimeBunWrite as unknown as (...writeArgs: unknown[]) => unknown)(...args);
+    };
+
+    // bun:ffi 的命名导出在首次导入时会绑定 Bun.FFI 的底层入口。
+    // 必须在加载租户模块前禁用，否则可绕过 Bun.spawn 直接调用 libc system()。
+    const ffi = bun.FFI as Record<string, unknown> | undefined;
+    if (ffi) {
+      for (const name of ["callback", "dlopen", "linkSymbols"]) {
+        ffi[name] = subprocessDisabled;
+      }
+    }
+  }
+
+  const ffiModule = require("bun:ffi") as Record<string, unknown>;
+  for (const name of ["CFunction", "JSCallback", "cc", "dlopen", "linkSymbols"]) {
+    ffiModule[name] = subprocessDisabled;
+  }
+  const nativeFfi = ffiModule.native as Record<string, unknown> | undefined;
+  if (nativeFfi) {
+    nativeFfi.dlopen = subprocessDisabled;
+    nativeFfi.callback = subprocessDisabled;
+  }
+
+  // 新 Worker 有独立全局对象，不会继承本 worker 安装的 guard。
+  // 若允许租户创建 Worker，便可在子 worker 中重新调用未打补丁的 Bun.spawn。
+  (globalThis as Record<string, unknown>).Worker = DisabledWorker;
+  const workerThreads = require("node:worker_threads") as Record<string, unknown>;
+  workerThreads.Worker = DisabledWorker;
+
+  const childProcess = require("node:child_process") as Record<string, unknown>;
+  for (const name of ["exec", "execFile", "execFileSync", "execSync", "fork", "spawn", "spawnSync"]) {
+    childProcess[name] = subprocessDisabled;
+  }
+  const cluster = require("node:cluster") as Record<string, unknown>;
+  cluster.fork = subprocessDisabled;
+
+  guardFunctionExports(
+    nodeFs as unknown as Record<string, unknown>,
+  );
+  guardFunctionExports(
+    nodeFsPromises as unknown as Record<string, unknown>,
+  );
+
+  const processApi = process as unknown as Record<string, unknown>;
+  for (const name of ["dlopen", "binding", "_linkedBinding", "getBuiltinModule"]) {
+    if (typeof processApi[name] === "function") processApi[name] = nativeLoaderDisabled;
+  }
+
+  const moduleApi = require("node:module") as Record<string, unknown>;
+  for (const name of ["createRequire", "_load"]) {
+    if (typeof moduleApi[name] === "function") moduleApi[name] = nativeLoaderDisabled;
+  }
+  const modulePrototype = (moduleApi.Module as { prototype?: Record<string, unknown> } | undefined)?.prototype
+    || (moduleApi as { prototype?: Record<string, unknown> }).prototype;
+  if (modulePrototype && typeof modulePrototype.require === "function") {
+    modulePrototype.require = nativeLoaderDisabled;
+  }
+  syncBuiltinESMExports();
+}
+
+function guardFunctionExports(
+  target: Record<string, unknown>,
+): void {
+  for (const name of Object.getOwnPropertyNames(target)) {
+    const original = target[name];
+    if (typeof original !== "function") continue;
+    if (FILESYSTEM_VALUE_CONSTRUCTORS.has(name)) continue;
+
+    const guarded = function (this: unknown, ...args: unknown[]) {
+      assertFilesystemOperation(name, args);
+      if (new.target) return Reflect.construct(original, args, original);
+      return Reflect.apply(original, this, args);
+    };
+    target[name] = guarded;
+  }
+}
+
+function capturedHandler(candidate: unknown): CapturedServeHandler | null {
+  return typeof candidate === "function"
+    ? candidate as CapturedServeHandler
+    : null;
+}
+
+type ProjectPathContext = {
+  lexicalRoot: string;
+  realRoot: string;
+};
+
+const runtimeDependencyContext: ProjectPathContext = (() => {
+  const lexicalRoot = path.resolve(import.meta.dir, "node_modules");
+  let realRoot = lexicalRoot;
+  try {
+    realRoot = runtimeFs.realpathSync(lexicalRoot);
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
+  }
+  return {
+    lexicalRoot,
+    realRoot,
+  };
+})();
+
+const FILESYSTEM_VALUE_CONSTRUCTORS = new Set([
+  "Dir",
+  "Dirent",
+  "Stats",
+  "_toUnixTimestamp",
+]);
+
+const READ_PATH_OPERATIONS = new Map<string, readonly number[]>([
+  ["access", [0]],
+  ["accessSync", [0]],
+  ["createReadStream", [0]],
+  ["exists", [0]],
+  ["existsSync", [0]],
+  ["glob", [0]],
+  ["globSync", [0]],
+  ["lstat", [0]],
+  ["lstatSync", [0]],
+  ["openAsBlob", [0]],
+  ["opendir", [0]],
+  ["opendirSync", [0]],
+  ["readFile", [0]],
+  ["readFileSync", [0]],
+  ["readdir", [0]],
+  ["readdirSync", [0]],
+  ["readlink", [0]],
+  ["readlinkSync", [0]],
+  ["realpath", [0]],
+  ["realpathSync", [0]],
+  ["stat", [0]],
+  ["statSync", [0]],
+  ["statfs", [0]],
+  ["statfsSync", [0]],
+  ["unwatchFile", [0]],
+  ["watch", [0]],
+  ["watchFile", [0]],
+  ["ReadStream", [0]],
+  ["FileReadStream", [0]],
+]);
+
+const WRITE_PATH_OPERATIONS = new Map<string, readonly number[]>([
+  ["appendFile", [0]],
+  ["appendFileSync", [0]],
+  ["chmod", [0]],
+  ["chmodSync", [0]],
+  ["chown", [0]],
+  ["chownSync", [0]],
+  ["copyFile", [0, 1]],
+  ["copyFileSync", [0, 1]],
+  ["cp", [0, 1]],
+  ["cpSync", [0, 1]],
+  ["createWriteStream", [0]],
+  ["lchmod", [0]],
+  ["lchmodSync", [0]],
+  ["lchown", [0]],
+  ["lchownSync", [0]],
+  ["link", [0, 1]],
+  ["linkSync", [0, 1]],
+  ["lutimes", [0]],
+  ["lutimesSync", [0]],
+  ["mkdir", [0]],
+  ["mkdirSync", [0]],
+  ["mkdtemp", [0]],
+  ["mkdtempSync", [0]],
+  ["rename", [0, 1]],
+  ["renameSync", [0, 1]],
+  ["rm", [0]],
+  ["rmSync", [0]],
+  ["rmdir", [0]],
+  ["rmdirSync", [0]],
+  ["truncate", [0]],
+  ["truncateSync", [0]],
+  ["unlink", [0]],
+  ["unlinkSync", [0]],
+  ["utimes", [0]],
+  ["utimesSync", [0]],
+  ["writeFile", [0]],
+  ["writeFileSync", [0]],
+  ["WriteStream", [0]],
+  ["FileWriteStream", [0]],
+]);
+
+const FILE_DESCRIPTOR_OPERATIONS = new Set([
+  "close",
+  "closeSync",
+  "fchmod",
+  "fchmodSync",
+  "fchown",
+  "fchownSync",
+  "fdatasync",
+  "fdatasyncSync",
+  "fstat",
+  "fstatSync",
+  "fsync",
+  "fsyncSync",
+  "ftruncate",
+  "ftruncateSync",
+  "futimes",
+  "futimesSync",
+  "read",
+  "readSync",
+  "readv",
+  "readvSync",
+  "write",
+  "writeSync",
+  "writev",
+  "writevSync",
+]);
+
+const projectPathContext = new AsyncLocalStorage<ProjectPathContext | null>();
+let activeProjectPathContext: ProjectPathContext | null = null;
 let injectedEnvRef: Record<string, string> = {};
 
 export function setProjectRoot(root: string | null) {
-  currentProjectRoot = root;
+  if (!root) {
+    activeProjectPathContext = null;
+    projectPathContext.enterWith(null);
+    return;
+  }
+  const lexicalRoot = path.resolve(root);
+  activeProjectPathContext = {
+    lexicalRoot,
+    realRoot: runtimeFs.realpathSync(lexicalRoot),
+  };
+  projectPathContext.enterWith(activeProjectPathContext);
 }
 
 export function setInjectedEnv(env: Record<string, string>) {
@@ -24,35 +306,126 @@ function isPathInside(candidate: string, base: string): boolean {
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
-function assertPathInProject(p: string): void {
-  if (!currentProjectRoot) return;
-  const resolved = path.resolve(p);
-  if (!isPathInside(resolved, currentProjectRoot)) {
-    throw new Error(`Access denied: path "${p}" is outside the project directory`);
+function filesystemPath(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof URL) {
+    if (value.protocol !== "file:") {
+      throw new Error(`Access denied: URL protocol "${value.protocol}" is not a local project file`);
+    }
+    return fileURLToPath(value);
+  }
+  if (value && typeof value === "object" && typeof (value as { name?: unknown }).name === "string") {
+    return (value as { name: string }).name;
+  }
+  throw new Error("Access denied: file descriptors and unverifiable file targets are not supported");
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function currentProjectPathContext(): ProjectPathContext | null {
+  return projectPathContext.getStore() || activeProjectPathContext;
+}
+
+function assertPathInContext(value: unknown, context: ProjectPathContext): void {
+  const requestedPath = filesystemPath(value);
+  const resolved = path.resolve(requestedPath);
+  if (!isPathInside(resolved, context.lexicalRoot)) {
+    throw new Error(`Access denied: path "${requestedPath}" is outside the allowed directory`);
+  }
+
+  const relative = path.relative(context.lexicalRoot, resolved);
+  let prefix = context.lexicalRoot;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    prefix = path.join(prefix, segment);
+    try {
+      runtimeFs.lstatSync(prefix);
+      const realPrefix = runtimeFs.realpathSync(prefix);
+      if (!isPathInside(realPrefix, context.realRoot)) {
+        throw new Error(`Access denied: path "${requestedPath}" escapes through a symbolic link`);
+      }
+    } catch (error) {
+      if (isMissingPathError(error)) break;
+      throw error;
+    }
   }
 }
 
-const BLOCKED_COMMANDS = new Set([
-  "mkfs", "shutdown", "reboot", "init",
-  "fdisk", "parted", "dd",
-  "cat", "head", "tail", "less", "more",
-  "curl", "wget", "nc", "ncat", "netcat",
-  "ssh", "scp", "sftp", "telnet",
-  "env", "printenv", "export",
-  "ps", "top", "htop", "lsof", "ss", "netstat",
-  "whoami", "id", "hostname", "uname",
-  "crontab", "at", "batch",
-  "passwd", "su", "sudo", "doas",
-  "chmod", "chown", "chgrp",
-  "kill", "killall", "pkill",
-  "docker", "podman", "kubectl",
-  "python", "python3", "perl", "ruby", "node", "bun", "bash", "sh", "zsh", "fish",
-  "rm", "rmdir",
-]);
+function isPathAllowed(value: unknown, context: ProjectPathContext): boolean {
+  try {
+    assertPathInContext(value, context);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
-function isCommandBlocked(cmd: string): boolean {
-  const base = cmd.split("/").pop() || cmd;
-  return BLOCKED_COMMANDS.has(base);
+function assertFilesystemReadPath(value: unknown, context: ProjectPathContext): void {
+  if (isPathAllowed(value, context) || isPathAllowed(value, runtimeDependencyContext)) return;
+  throw new Error(FILESYSTEM_DISABLED_MESSAGE);
+}
+
+export function assertRuntimeDependencyPath(value: unknown): void {
+  try {
+    assertPathInContext(value, runtimeDependencyContext);
+  } catch {
+    throw new Error("Access denied: module is outside the trusted runtime dependency directory");
+  }
+}
+
+function isReadOnlyOpen(flags: unknown): boolean {
+  return flags === undefined
+    || flags === "r"
+    || flags === "rs"
+    || flags === "sr"
+    || flags === nodeFs.constants.O_RDONLY;
+}
+
+function assertFilesystemOperation(name: string, args: unknown[]): void {
+  const context = currentProjectPathContext();
+  if (!context) return;
+
+  if (name === "symlink" || name === "symlinkSync") {
+    throw new Error(FILESYSTEM_DISABLED_MESSAGE);
+  }
+  if (name === "open" || name === "openSync") {
+    if (isReadOnlyOpen(args[1])) assertFilesystemReadPath(args[0], context);
+    else assertPathInProject(args[0]);
+    return;
+  }
+
+  const readPathIndexes = READ_PATH_OPERATIONS.get(name);
+  if (readPathIndexes) {
+    for (const index of readPathIndexes) assertFilesystemReadPath(args[index], context);
+    return;
+  }
+
+  const writePathIndexes = WRITE_PATH_OPERATIONS.get(name);
+  if (writePathIndexes) {
+    for (const index of writePathIndexes) assertPathInProject(args[index]);
+    return;
+  }
+
+  if (FILE_DESCRIPTOR_OPERATIONS.has(name)) return;
+  throw new Error(FILESYSTEM_DISABLED_MESSAGE);
+}
+
+export function assertPathInProject(value: unknown): void {
+  const context = currentProjectPathContext();
+  const requestedPath = filesystemPath(value);
+  if (!context) {
+    throw new Error(`Access denied: no active project for path "${requestedPath}"`);
+  }
+
+  try {
+    assertPathInContext(requestedPath, context);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("symbolic link")) throw error;
+    throw new Error(`Access denied: path "${requestedPath}" is outside the project directory`);
+  }
 }
 
 const envWriteLog: Set<string> = new Set();
@@ -76,26 +449,25 @@ const envWriteLog: Set<string> = new Set();
 
   readTextFile: (p: string) => {
     assertPathInProject(p);
-    return Bun.file(p).text();
+    return runtimeBunFile(p).text();
   },
   readFile: (p: string) => {
     assertPathInProject(p);
-    return Bun.file(p)
+    return runtimeBunFile(p)
       .arrayBuffer()
       .then((b: ArrayBuffer) => new Uint8Array(b));
   },
   writeTextFile: (p: string, d: string) => {
     assertPathInProject(p);
-    return Bun.write(p, d).then(() => {});
+    return runtimeBunWrite(p, d).then(() => {});
   },
   writeFile: (p: string, d: Uint8Array) => {
     assertPathInProject(p);
-    return Bun.write(p, d).then(() => {});
+    return runtimeBunWrite(p, d).then(() => {});
   },
   stat: async (p: string) => {
     assertPathInProject(p);
-    const { stat } = await import("fs/promises");
-    const s = await stat(p);
+    const s = await runtimeFs.stat(p);
     return {
       isFile: s.isFile(),
       isDirectory: s.isDirectory(),
@@ -105,8 +477,7 @@ const envWriteLog: Set<string> = new Set();
   },
   readDir: async function* (p: string) {
     assertPathInProject(p);
-    const { readdir } = await import("fs/promises");
-    const entries = await readdir(p, { withFileTypes: true });
+    const entries = await runtimeFs.readdir(p, { withFileTypes: true });
     for (const e of entries) {
       yield {
         name: e.name,
@@ -118,33 +489,28 @@ const envWriteLog: Set<string> = new Set();
   },
   mkdir: (p: string, opts?: { recursive?: boolean }) => {
     assertPathInProject(p);
-    const fs = require("fs/promises");
-    return fs.mkdir(p, opts);
+    return runtimeFs.mkdir(p, opts);
   },
   remove: (p: string, opts?: { recursive?: boolean }) => {
     assertPathInProject(p);
-    const fs = require("fs/promises");
-    return fs.rm(p, opts);
+    return runtimeFs.rm(p, opts);
   },
 
   readTextFileSync: (p: string) => {
     assertPathInProject(p);
-    const fs = require("fs");
-    return fs.readFileSync(p, "utf-8");
+    return runtimeFs.readFileSync(p, "utf-8");
   },
   writeFileSync: (p: string, d: string | Uint8Array) => {
     assertPathInProject(p);
-    const fs = require("fs");
     if (typeof d === "string") {
-      fs.writeFileSync(p, d, "utf-8");
+      runtimeFs.writeFileSync(p, d, "utf-8");
     } else {
-      fs.writeFileSync(p, d);
+      runtimeFs.writeFileSync(p, d);
     }
   },
   statSync: (p: string) => {
     assertPathInProject(p);
-    const fs = require("fs");
-    const s = fs.statSync(p);
+    const s = runtimeFs.statSync(p);
     return {
       isFile: s.isFile(),
       isDirectory: s.isDirectory(),
@@ -158,8 +524,7 @@ const envWriteLog: Set<string> = new Set();
   },
   readDirSync: function* (p: string) {
     assertPathInProject(p);
-    const fs = require("fs");
-    const entries = fs.readdirSync(p, { withFileTypes: true });
+    const entries = runtimeFs.readdirSync(p, { withFileTypes: true });
     for (const e of entries) {
       yield {
         name: e.name,
@@ -171,17 +536,15 @@ const envWriteLog: Set<string> = new Set();
   },
   removeSync: (p: string, opts?: { recursive?: boolean }) => {
     assertPathInProject(p);
-    const fs = require("fs");
     if (opts?.recursive) {
-      fs.rmSync(p, { recursive: true });
+      runtimeFs.rmSync(p, { recursive: true });
     } else {
-      fs.rmSync(p);
+      runtimeFs.rmSync(p);
     }
   },
   mkdirSync: (p: string, opts?: { recursive?: boolean }) => {
     assertPathInProject(p);
-    const fs = require("fs");
-    fs.mkdirSync(p, opts);
+    runtimeFs.mkdirSync(p, opts);
   },
 
   exit: (c?: number) => process.exit(c),
@@ -207,13 +570,9 @@ const envWriteLog: Set<string> = new Set();
     throw new Error("Deno.connect() not supported, use fetch/Bun.connect");
   },
   Command: class Command {
-    private cmd: string;
-    private args: string[];
-    private opts: any;
-
     constructor(
-      cmd: string,
-      opts?: {
+      _cmd: string,
+      _opts?: {
         args?: string[];
         cwd?: string;
         env?: Record<string, string>;
@@ -222,112 +581,19 @@ const envWriteLog: Set<string> = new Set();
         stderr?: "inherit" | "piped" | "null";
       },
     ) {
-      if (isCommandBlocked(cmd)) {
-        throw new Error(
-          `Deno.Command("${cmd}") is blocked for security reasons.`,
-        );
-      }
-      this.cmd = cmd;
-      this.args = opts?.args || [];
-      this.opts = opts || {};
-    }
-
-    async output() {
-      const proc = Bun.spawn([this.cmd, ...this.args], {
-        cwd: this.opts.cwd,
-        env: this.opts.env
-          ? { ...process.env, ...this.opts.env }
-          : process.env,
-        stdout:
-          this.opts.stdout === "piped"
-            ? "pipe"
-            : this.opts.stdout === "null"
-              ? "ignore"
-              : "inherit",
-        stderr:
-          this.opts.stderr === "piped"
-            ? "pipe"
-            : this.opts.stderr === "null"
-              ? "ignore"
-              : "inherit",
-      });
-      const exitCode = await proc.exited;
-      const stdout = proc.stdout
-        ? await new Response(proc.stdout)
-            .arrayBuffer()
-            .then((b) => new Uint8Array(b))
-        : new Uint8Array(0);
-      const stderr = proc.stderr
-        ? await new Response(proc.stderr)
-            .arrayBuffer()
-            .then((b) => new Uint8Array(b))
-        : new Uint8Array(0);
-      return { stdout, stderr, code: exitCode, success: exitCode === 0 };
-    }
-
-    outputSync() {
-      const proc = Bun.spawnSync([this.cmd, ...this.args], {
-        cwd: this.opts.cwd,
-        env: this.opts.env
-          ? { ...process.env, ...this.opts.env }
-          : process.env,
-        stdout:
-          this.opts.stdout === "piped"
-            ? "pipe"
-            : this.opts.stdout === "null"
-              ? "ignore"
-              : "inherit",
-        stderr:
-          this.opts.stderr === "piped"
-            ? "pipe"
-            : this.opts.stderr === "null"
-              ? "ignore"
-              : "inherit",
-      });
-      return {
-        stdout: new Uint8Array(proc.stdout?.buffer || new ArrayBuffer(0)),
-        stderr: new Uint8Array(proc.stderr?.buffer || new ArrayBuffer(0)),
-        code: proc.exitCode ?? 1,
-        success: proc.exitCode === 0,
-      };
-    }
-
-    spawn() {
-      return Bun.spawn([this.cmd, ...this.args], {
-        cwd: this.opts.cwd,
-        env: this.opts.env
-          ? { ...process.env, ...this.opts.env }
-          : process.env,
-        stdin:
-          this.opts.stdin === "piped"
-            ? "pipe"
-            : this.opts.stdin === "null"
-              ? "ignore"
-              : "inherit",
-        stdout:
-          this.opts.stdout === "piped"
-            ? "pipe"
-            : this.opts.stdout === "null"
-              ? "ignore"
-              : "inherit",
-        stderr:
-          this.opts.stderr === "piped"
-            ? "pipe"
-            : this.opts.stderr === "null"
-              ? "ignore"
-              : "inherit",
-      });
+      throw new Error(
+        SUBPROCESS_DISABLED_MESSAGE,
+      );
     }
   },
-  serve: (handlerOrOpts: any, maybeHandler?: any) => {
-    if (typeof handlerOrOpts === "function") {
-      capturedServeHandler = handlerOrOpts;
-    } else if (typeof maybeHandler === "function") {
-      capturedServeHandler = maybeHandler;
-    } else if (handlerOrOpts && typeof handlerOrOpts === "object") {
-      capturedServeHandler =
-        handlerOrOpts.handler || handlerOrOpts.fetch || null;
-    }
+  serve: (handlerOrOpts: unknown, maybeHandler?: unknown) => {
+    const options = handlerOrOpts && typeof handlerOrOpts === "object"
+      ? handlerOrOpts as Record<string, unknown>
+      : {};
+    capturedServeHandler = capturedHandler(handlerOrOpts)
+      || capturedHandler(maybeHandler)
+      || capturedHandler(options.handler)
+      || capturedHandler(options.fetch);
     const mockServer = {
       finished: Promise.resolve(),
       shutdown: async () => {},

--- a/packages/edge-runtime/fetch-tls-policy.ts
+++ b/packages/edge-runtime/fetch-tls-policy.ts
@@ -1,3 +1,5 @@
+import { runtimeFile } from "./deno-compat";
+
 type FetchLike = typeof globalThis.fetch;
 
 export type EdgeFetchTlsPolicy = {
@@ -35,7 +37,7 @@ export async function resolveEdgeFetchTlsPolicy(
 
   const caFile = pickString(hostEnv.SUPACLOUD_EDGE_TLS_CA_FILE);
   if (caFile) {
-    return { ca: await Bun.file(caFile).text(), source: "ca-file" };
+    return { ca: await runtimeFile(caFile).text(), source: "ca-file" };
   }
 
   return { source: "none" };

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -1,9 +1,22 @@
-import { parentPort } from "worker_threads";
 import path from "path";
-import { getCapturedServeHandler, clearCapturedServeHandler, setProjectRoot, setInjectedEnv, envWriteLog } from "./deno-compat";
+import {
+  assertPathInProject,
+  assertRuntimeDependencyPath,
+  clearCapturedServeHandler,
+  disableSubprocessApis,
+  envWriteLog,
+  FILESYSTEM_DISABLED_MESSAGE,
+  getCapturedServeHandler,
+  NATIVE_LOADER_DISABLED_MESSAGE,
+  setInjectedEnv,
+  setProjectRoot,
+  SUBPROCESS_DISABLED_MESSAGE,
+} from "./deno-compat";
 import { installEdgeFetchTlsPolicy, resolveEdgeFetchTlsPolicy } from "./fetch-tls-policy";
 import type { EdgeFetchTlsPolicy } from "./fetch-tls-policy";
 import { runWithPgredisBinding } from "./internal-bindings";
+
+const { parentPort } = require("node:worker_threads") as typeof import("node:worker_threads");
 import type { PgredisRuntimeBindingConfig } from "./internal-bindings";
 
 export function getInjectedEnv(): Record<string, string> {
@@ -11,18 +24,19 @@ export function getInjectedEnv(): Record<string, string> {
 }
 
 if (!parentPort) throw new Error("This file must be run as a Worker");
+disableSubprocessApis();
 
 const MAX_MODULE_CACHE = 20;
 
 type ModuleCacheEntry = {
-  module: any;
+  handler: unknown;
   functionId: string;
   projectRef: string | null;
   lastUsed: number;
 };
 
 type LoadModuleResult = {
-  handler: any;
+  handler: unknown;
   cacheHit: boolean;
   moduleCacheSize: number;
 };
@@ -96,6 +110,87 @@ function invalidateCachedModules(predicate: (entry: ModuleCacheEntry) => boolean
     }
   }
   return invalidated;
+}
+
+async function importModuleHandler(importUrl: string): Promise<unknown> {
+  clearCapturedServeHandler();
+  try {
+    const moduleNamespace = await import(importUrl) as Record<string, unknown>;
+    const serveHandler = getCapturedServeHandler();
+    return moduleNamespace.default
+      || moduleNamespace.handler
+      || serveHandler
+      || moduleNamespace;
+  } finally {
+    clearCapturedServeHandler();
+  }
+}
+
+const DISABLED_TENANT_MODULES = new Map([
+  ["bun:ffi", SUBPROCESS_DISABLED_MESSAGE],
+  ["child_process", SUBPROCESS_DISABLED_MESSAGE],
+  ["cluster", SUBPROCESS_DISABLED_MESSAGE],
+  ["node:child_process", SUBPROCESS_DISABLED_MESSAGE],
+  ["node:cluster", SUBPROCESS_DISABLED_MESSAGE],
+  ["node:worker_threads", SUBPROCESS_DISABLED_MESSAGE],
+  ["worker_threads", SUBPROCESS_DISABLED_MESSAGE],
+  ["fs", FILESYSTEM_DISABLED_MESSAGE],
+  ["fs/promises", FILESYSTEM_DISABLED_MESSAGE],
+  ["node:fs", FILESYSTEM_DISABLED_MESSAGE],
+  ["node:fs/promises", FILESYSTEM_DISABLED_MESSAGE],
+  ["module", NATIVE_LOADER_DISABLED_MESSAGE],
+  ["node:module", NATIVE_LOADER_DISABLED_MESSAGE],
+]);
+
+function moduleLoader(filePath: string): "js" | "jsx" | "ts" | "tsx" | null {
+  if (filePath.endsWith(".tsx")) return "tsx";
+  if (filePath.endsWith(".jsx")) return "jsx";
+  if (filePath.endsWith(".ts") || filePath.endsWith(".mts") || filePath.endsWith(".cts")) return "ts";
+  if (filePath.endsWith(".js") || filePath.endsWith(".mjs") || filePath.endsWith(".cjs")) return "js";
+  return null;
+}
+
+async function assertTenantModuleGraphSafe(
+  entryPath: string,
+  projectRoot: string,
+  visited = new Set<string>(),
+): Promise<void> {
+  const resolvedEntry = path.resolve(entryPath);
+  if (visited.has(resolvedEntry)) return;
+  visited.add(resolvedEntry);
+
+  assertPathInProject(resolvedEntry);
+  const loader = moduleLoader(resolvedEntry);
+  if (!loader) return;
+  const source = await Bun.file(resolvedEntry).text();
+  const imports = new Bun.Transpiler({ loader })
+    .scanImports(source);
+  for (const imported of imports) {
+    const disabledMessage = DISABLED_TENANT_MODULES.get(imported.path);
+    if (disabledMessage) {
+      throw new Error(disabledMessage);
+    }
+    if (!imported.path.startsWith(".") && !path.isAbsolute(imported.path)) continue;
+
+    let dependencyPath = imported.path;
+    if (!path.isAbsolute(dependencyPath)) {
+      try {
+        dependencyPath = Bun.resolveSync(imported.path, path.dirname(resolvedEntry));
+      } catch {
+        continue;
+      }
+    }
+    const relative = path.relative(projectRoot, dependencyPath);
+    if (relative !== "" && (relative.startsWith("..") || path.isAbsolute(relative))) {
+      try {
+        assertRuntimeDependencyPath(dependencyPath);
+      } catch {
+        throw new Error(`Access denied: module "${imported.path}" is outside the project directory`);
+      }
+      continue;
+    }
+    await assertTenantModuleGraphSafe(dependencyPath, projectRoot, visited);
+  }
 }
 
 const originalProcessEnv = process.env;
@@ -220,6 +315,7 @@ function clearEdgeRuntimeCompat() {
 async function loadModule(input: {
   functionId: string;
   functionPath: string;
+  projectRoot: string;
   moduleVersion?: string;
   projectRef?: string | null;
 }): Promise<LoadModuleResult> {
@@ -228,15 +324,17 @@ async function loadModule(input: {
   const cached = moduleCache.get(cacheKey);
   if (cached) {
     cached.lastUsed = Date.now();
-    return { handler: cached.module, cacheHit: true, moduleCacheSize: moduleCache.size };
+    return { handler: cached.handler, cacheHit: true, moduleCacheSize: moduleCache.size };
   }
 
   evictOldestModule();
 
-  const mod = await import(buildModuleImportUrl(input.functionPath, moduleVersion));
-  const handler = mod.default || mod.handler || mod;
+  await assertTenantModuleGraphSafe(input.functionPath, input.projectRoot);
+  const handler = await importModuleHandler(
+    buildModuleImportUrl(input.functionPath, moduleVersion),
+  );
   moduleCache.set(cacheKey, {
-    module: handler,
+    handler,
     functionId: input.functionId,
     projectRef: input.projectRef || null,
     lastUsed: Date.now(),
@@ -244,9 +342,7 @@ async function loadModule(input: {
   return { handler, cacheHit: false, moduleCacheSize: moduleCache.size };
 }
 
-async function executeFunction(handler: any, request: Request): Promise<Response> {
-  clearCapturedServeHandler();
-
+async function executeFunction(handler: unknown, request: Request): Promise<Response> {
   if (typeof handler === "function") {
     const result = await handler(request);
     if (result instanceof Response) return result;
@@ -256,32 +352,27 @@ async function executeFunction(handler: any, request: Request): Promise<Response
   }
 
   if (handler && typeof handler === "object") {
-    if (typeof handler.handle === "function") {
-      const result = await handler.handle(request);
+    const objectHandler = handler as Record<string, unknown>;
+    if (typeof objectHandler.handle === "function") {
+      const result = await objectHandler.handle(request);
       if (result instanceof Response) return result;
       return new Response(JSON.stringify(result), {
         headers: { "Content-Type": "application/json" },
       });
     }
 
-    if (typeof handler.fetch === "function") {
-      const result = await handler.fetch(request);
+    if (typeof objectHandler.fetch === "function") {
+      const result = await objectHandler.fetch(request);
       if (result instanceof Response) return result;
       return new Response(JSON.stringify(result), {
         headers: { "Content-Type": "application/json" },
       });
     }
-  }
-
-  const captured = getCapturedServeHandler();
-  if (captured) {
-    const result = await captured(request);
-    if (result instanceof Response) return result;
   }
 
   throw new Error(
-    "Function must export a default function, an object with handle(), or an object with fetch(). " +
-    "For Bun.serve() / Deno.serve(), use the fetch pattern: export default { fetch(req) { return new Response('ok') } }",
+    "Function must export a default function, an object with handle()/fetch(), " +
+    "or register a handler with Deno.serve().",
   );
 }
 
@@ -431,6 +522,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
         const moduleLoad = await loadModule({
           functionId: msg.functionId,
           functionPath: msg.functionPath,
+          projectRoot: msg.projectRoot,
           moduleVersion: msg.moduleVersion,
           projectRef: ref,
         });
@@ -480,6 +572,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
     const moduleLoad = await loadModule({
       functionId,
       functionPath,
+      projectRoot,
       moduleVersion: msg.moduleVersion,
       projectRef,
     });

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -81,6 +81,389 @@ describe("WorkerPool EdgeRuntime.waitUntil", () => {
       expect(response.status).toBe(202);
       expect(await response.text()).toBe("queued");
       expect(await waitForFile(outputPath)).toBe("http://tenant.local");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("WorkerPool subprocess guard", () => {
+  test("blocks direct and computed imports for every fs module alias", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-filesystem-module-"));
+    const dynamicPath = join(projectRoot, "dynamic.ts");
+    await Bun.write(dynamicPath, `
+      export default async function () {
+        Error.prepareStackTrace = () => "";
+        const moduleName = process.env.FS_MODULE;
+        const fs = await import(moduleName);
+        const contents = fs.readFileSync
+          ? fs.readFileSync("/etc/hosts", "utf8")
+          : await fs.readFile("/etc/hosts", "utf8");
+        return new Response(contents);
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const dispatch = (functionId: string, functionPath: string, fsModule: string) => pool.dispatch({
+      functionId,
+      functionPath,
+      projectRoot,
+      env: { FS_MODULE: fsModule },
+      request: new Request(`http://edge.local/functions/v1/${functionId}`),
+    });
+
+    try {
+      for (const [index, fsModule] of [
+        "fs",
+        "node:fs",
+        "fs/promises",
+        "node:fs/promises",
+      ].entries()) {
+        const directPath = join(projectRoot, `direct-${index}.ts`);
+        await Bun.write(directPath, `
+          import * as fs from ${JSON.stringify(fsModule)};
+          export default () => new Response(String(fs));
+        `);
+        for (const response of [
+          await dispatch(`proj_fs_direct_${index}`, directPath, fsModule),
+          await dispatch(`proj_fs_dynamic_${index}`, dynamicPath, fsModule),
+        ]) {
+          expect(response.status).toBe(500);
+          expect(await response.json()).toEqual({
+            error: "Direct file system module access is disabled in the multi-tenant Edge Runtime.",
+            name: "Error",
+          });
+        }
+      }
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allows only the explicit runtime dependency root for read-only module access", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-runtime-read-root-"));
+    const functionPath = join(projectRoot, "runtime-read.ts");
+    const dependencyPath = Bun.resolveSync("elysia", import.meta.dir);
+    const runtimePath = join(import.meta.dir, "package.json");
+    await Bun.write(functionPath, `
+      export default async function () {
+        const moduleName = ["node", "fs"].join(":");
+        const fs = await import(moduleName);
+        let runtime;
+        try {
+          runtime = fs.readFileSync(process.env.RUNTIME_PATH, "utf8");
+        } catch (error) {
+          runtime = error.message;
+        }
+        return Response.json({
+          dependency: fs.readFileSync(process.env.DEPENDENCY_PATH, "utf8"),
+          runtime,
+        });
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_runtime_read_root",
+        functionPath,
+        projectRoot,
+        env: { DEPENDENCY_PATH: dependencyPath, RUNTIME_PATH: runtimePath },
+        request: new Request("http://edge.local/functions/v1/runtime-read"),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as { dependency: string; runtime: string };
+      expect(body.dependency.length).toBeGreaterThan(100);
+      expect(body.runtime).toBe(
+        "Direct file system module access is disabled in the multi-tenant Edge Runtime.",
+      );
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects project-external modules under untrusted node_modules directories", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-module-root-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "supacloud-untrusted-module-"));
+    const outsideModule = join(outsideRoot, "node_modules", "untrusted", "index.ts");
+    const functionPath = join(projectRoot, "entry.ts");
+    await mkdir(join(outsideRoot, "node_modules", "untrusted"), { recursive: true });
+    await Bun.write(outsideModule, `export default "outside";`);
+    await Bun.write(functionPath, `
+      import outside from ${JSON.stringify(outsideModule)};
+      export default () => new Response(outside);
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_untrusted_module_root",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/untrusted-module"),
+      });
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: `Access denied: module "${outsideModule}" is outside the project directory`,
+        name: "Error",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("confines Bun file APIs to the active project including symlinks", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-bun-file-project-"));
+    const siblingRoot = await mkdtemp(join(tmpdir(), "supacloud-bun-file-sibling-"));
+    const functionPath = join(projectRoot, "files.ts");
+    const projectAsset = join(projectRoot, "asset.txt");
+    const siblingAsset = join(siblingRoot, "secret.txt");
+    const symlinkPath = join(projectRoot, "escape");
+    const symlinkAsset = join(symlinkPath, "secret.txt");
+    const symlinkWrite = join(symlinkPath, "written.txt");
+    await Bun.write(projectAsset, "project-asset");
+    await Bun.write(siblingAsset, "sibling-secret");
+    await symlink(siblingRoot, symlinkPath, "dir");
+    await Bun.write(functionPath, `
+      import { file, write } from "bun";
+
+      async function capture(read) {
+        try {
+          return await read();
+        } catch (error) {
+          return error.message;
+        }
+      }
+
+      export default async function () {
+        return Response.json({
+          project: await file(process.env.PROJECT_ASSET).text(),
+          hosts: await capture(() => file("/etc/hosts").text()),
+          sibling: await capture(() => file(process.env.SIBLING_ASSET).text()),
+          symlink: await capture(() => file(process.env.SYMLINK_ASSET).text()),
+          symlinkWrite: await capture(() => write(process.env.SYMLINK_WRITE, "escaped")),
+        });
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_bun_file_boundary",
+        functionPath,
+        projectRoot,
+        env: {
+          PROJECT_ASSET: projectAsset,
+          SIBLING_ASSET: siblingAsset,
+          SYMLINK_ASSET: symlinkAsset,
+          SYMLINK_WRITE: symlinkWrite,
+        },
+        request: new Request("http://edge.local/functions/v1/files"),
+      });
+      expect(response.status).toBe(200);
+      const result = await response.json() as Record<string, string>;
+      expect(result.project).toBe("project-asset");
+      expect(result.hosts).toContain("outside the project directory");
+      expect(result.sibling).toContain("outside the project directory");
+      expect(result.symlink).toContain("escapes through a symbolic link");
+      expect(result.symlinkWrite).toContain("escapes through a symbolic link");
+      expect(await Bun.file(siblingAsset).text()).toBe("sibling-secret");
+      expect(await Bun.file(symlinkWrite).exists()).toBe(false);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(siblingRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks process native loaders and computed createRequire access", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-native-loader-"));
+    const functionPath = join(projectRoot, "native.ts");
+    await Bun.write(functionPath, `
+      function capture(call) {
+        try {
+          call();
+          return "allowed";
+        } catch (error) {
+          return error.message;
+        }
+      }
+
+      export default async function () {
+        const moduleName = ["node", "module"].join(":");
+        const moduleApi = await import(moduleName);
+        return Response.json({
+          dlopen: capture(() => process.dlopen()),
+          binding: capture(() => process.binding()),
+          linkedBinding: capture(() => process._linkedBinding()),
+          getBuiltinModule: capture(() => process.getBuiltinModule("node:fs")),
+          createRequire: capture(() => moduleApi.createRequire(import.meta.url)("node:fs")),
+        });
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_native_loader",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/native"),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        dlopen: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
+        binding: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
+        linkedBinding: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
+        getBuiltinModule: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
+        createRequire: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks Bun spawn imported by tenant code", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-subprocess-"));
+    const functionPath = join(projectRoot, "spawn.ts");
+    await Bun.write(functionPath, `
+      import { spawn } from "bun";
+      export default async function () {
+        const child = spawn(["true"]);
+        await child.exited;
+        return new Response("spawned");
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_subprocess",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/spawn"),
+      });
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Subprocess execution is disabled in the multi-tenant Edge Runtime.",
+        name: "Error",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks tenant workers before they can regain subprocess APIs", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-worker-subprocess-"));
+    const functionPath = join(projectRoot, "worker-spawn.ts");
+    await Bun.write(functionPath, `
+      export default async function () {
+        const moduleName = ["node", "worker_threads"].join(":");
+        const { Worker } = await import(moduleName);
+        const worker = new Worker(
+          'postMessage(Bun.spawnSync(["true"]).exitCode)',
+          { eval: true },
+        );
+        return new Response(String(await new Promise((resolve) => {
+          worker.once("message", resolve);
+        })));
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_worker_subprocess",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/worker-spawn"),
+      });
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Subprocess execution is disabled in the multi-tenant Edge Runtime.",
+        name: "Error",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks bun:ffi before tenant code can call native process APIs", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-ffi-subprocess-"));
+    const functionPath = join(projectRoot, "ffi.ts");
+    await Bun.write(functionPath, `
+      export default async function () {
+        const moduleName = ["bun", "ffi"].join(":");
+        const { dlopen, FFIType } = await import(moduleName);
+        const libc = dlopen("libc.so.6", {
+          system: { args: [FFIType.cstring], returns: FFIType.i32 },
+        });
+        return new Response(String(libc.symbols.system(Buffer.from("true\\0"))));
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_ffi_subprocess",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/ffi"),
+      });
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Subprocess execution is disabled in the multi-tenant Edge Runtime.",
+        name: "Error",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allows Bun text assets while scanning tenant module imports", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-text-import-"));
+    const functionPath = join(projectRoot, "asset.ts");
+    await Bun.write(join(projectRoot, "message.txt"), "asset-loaded");
+    await Bun.write(functionPath, `
+      import message from "./message.txt" with { type: "text" };
+      export default function () {
+        return new Response(message);
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_text_import",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/text-import"),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("asset-loaded");
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -1012,6 +1395,111 @@ describe("WorkerPool module cache", () => {
       }
     `;
   }
+
+  test("executes Deno.serve on first load and keeps explicit exports authoritative", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-deno-serve-first-"));
+    const servePath = join(projectRoot, "serve.ts");
+    const exportedPath = join(projectRoot, "exported.ts");
+    await Bun.write(servePath, `Deno.serve(() => new Response("serve-first"));`);
+    await Bun.write(exportedPath, `
+      Deno.serve(() => new Response("captured"));
+      export default () => new Response("exported");
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const serveResponse = await pool.dispatch({
+        functionId: "proj_serve_first",
+        functionPath: servePath,
+        projectRoot,
+        moduleVersion: "v1",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/serve-first"),
+      });
+      expect(serveResponse.status).toBe(200);
+      expect(await serveResponse.text()).toBe("serve-first");
+
+      const exportedResponse = await pool.dispatch({
+        functionId: "proj_serve_exported",
+        functionPath: exportedPath,
+        projectRoot,
+        moduleVersion: "v1",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/serve-exported"),
+      });
+      expect(await exportedResponse.text()).toBe("exported");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("caches a Deno.serve handler loaded during preheat", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-deno-serve-preheat-"));
+    const functionPath = join(projectRoot, "serve.ts");
+    await Bun.write(functionPath, `Deno.serve(() => new Response("preheated-serve"));`);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      expect(await pool.preheat(
+        "proj_serve_preheat",
+        functionPath,
+        projectRoot,
+        {},
+        { moduleVersion: "v1" },
+      )).toBe(true);
+
+      const response = await pool.dispatch({
+        functionId: "proj_serve_preheat",
+        functionPath,
+        projectRoot,
+        moduleVersion: "v1",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/serve-preheat"),
+      });
+      expect(await response.text()).toBe("preheated-serve");
+
+      const metrics = pool.snapshotMetrics("serve_preheat");
+      expect(metrics["serve_preheat_total_module_cache_hits"]).toBe(1);
+      expect(metrics["serve_preheat_total_module_cache_misses"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps each cached Deno.serve handler isolated from later imports", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-deno-serve-cache-"));
+    const functionAPath = join(projectRoot, "serve-a.ts");
+    const functionBPath = join(projectRoot, "serve-b.ts");
+    await Bun.write(functionAPath, `Deno.serve(() => new Response("serve-a"));`);
+    await Bun.write(functionBPath, `Deno.serve(() => new Response("serve-b"));`);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const dispatch = (functionId: string, functionPath: string) => pool.dispatch({
+      functionId,
+      functionPath,
+      projectRoot,
+      moduleVersion: "v1",
+      env: {},
+      request: new Request(`http://edge.local/functions/v1/${functionId}`),
+    });
+
+    try {
+      expect(await (await dispatch("proj_serve_a", functionAPath)).text()).toBe("serve-a");
+      expect(await (await dispatch("proj_serve_b", functionBPath)).text()).toBe("serve-b");
+      expect(await (await dispatch("proj_serve_a", functionAPath)).text()).toBe("serve-a");
+
+      const metrics = pool.snapshotMetrics("serve_cache");
+      expect(metrics["serve_cache_total_module_cache_hits"]).toBe(1);
+      expect(metrics["serve_cache_total_module_cache_misses"]).toBe(2);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
 
   test("reuses stable module versions and reloads when moduleVersion changes", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-module-cache-"));

--- a/packages/management-api/src/db/init.ts
+++ b/packages/management-api/src/db/init.ts
@@ -13,6 +13,7 @@ import {
 import {
   ensurePlatformV2Schema,
   migrateLegacyControlSecrets,
+  migrateLegacyDeploymentHistory,
   migrateLegacyProviderLinkingConfig,
   migrateLegacyProjectWebhooks,
   migrateWebhookSecretsToControlStore,
@@ -728,30 +729,6 @@ export async function initDatabase() {
         description: "project_tasks FK cascade",
         swallowError: true,
       },
-      {
-        statement: `DO $$
-          BEGIN
-            IF EXISTS (
-              SELECT 1 FROM information_schema.columns
-              WHERE table_schema = 'public' AND table_name = 'deployment_history' AND column_name = 'project_ref'
-            ) THEN
-              DROP TABLE IF EXISTS deployment_history CASCADE;
-              CREATE TABLE deployment_history (
-                id TEXT PRIMARY KEY,
-                app TEXT NOT NULL,
-                tenant TEXT NOT NULL,
-                version TEXT NOT NULL,
-                status TEXT NOT NULL DEFAULT 'success',
-                deployed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                triggered_by TEXT NOT NULL DEFAULT 'api',
-                config JSONB NOT NULL DEFAULT '{}'::jsonb,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-              );
-            END IF;
-          END
-        $$;`,
-        description: "deployment_history schema migration (legacy project_ref -> new app/tenant schema)",
-      },
     ];
 
     for (const migration of migrationStatements) {
@@ -765,6 +742,7 @@ export async function initDatabase() {
     await sql.begin(async (transaction) => {
       await ensurePlatformV2Schema(transaction);
       await migrateAuditChainSequences(transaction);
+      await migrateLegacyDeploymentHistory(transaction);
       await migrateLegacyControlSecrets(transaction);
       await migrateLegacyProjectWebhooks(transaction);
       await migrateLegacyProviderLinkingConfig(transaction);

--- a/packages/management-api/src/db/platform-v2.ts
+++ b/packages/management-api/src/db/platform-v2.ts
@@ -600,6 +600,108 @@ async function persistLegacyWebhook(db: SQL, projectRef: string, webhook: Migrat
   `;
 }
 
+function requiredLegacyText(value: unknown, field: string): string {
+  if (typeof value === "string" && value.trim() !== "") return value;
+  throw new Error(`deployment_history migration blocked: legacy ${field} is missing or invalid`);
+}
+
+function requiredLegacyTimestamp(value: unknown, field: string): Date {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  throw new Error(`deployment_history migration blocked: legacy ${field} is missing or invalid`);
+}
+
+function parseLegacyDeploymentConfig(value: unknown): Record<string, unknown> {
+  if (value === null || value === undefined) return {};
+  const parsed = typeof value === "string"
+    ? (() => {
+      try {
+        return JSON.parse(value) as unknown;
+      } catch {
+        throw new Error("deployment_history migration blocked: legacy config is invalid JSON");
+      }
+    })()
+    : value;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("deployment_history migration blocked: legacy config must be an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Legacy deployment_history（id UUID, project_ref, deploy_type, description, ...）
+ * 与当前 schema（id TEXT, app, tenant, version, ...）不兼容。
+ * 旧实现直接 DROP TABLE ... CASCADE，升级启动即永久丢失全部历史。
+ * 改为在同一事务内：归档旧表（RENAME 保留全部原始数据与依赖对象）、
+ * 建立新表、逐行回填、核对行数；行数不符则抛错回滚，阻断升级。
+ */
+export async function migrateLegacyDeploymentHistory(db: SQL): Promise<number> {
+  const legacy = await db`
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'deployment_history' AND column_name = 'project_ref'
+    LIMIT 1
+  `;
+  if (legacy.length === 0) return 0;
+
+  await db`ALTER TABLE deployment_history RENAME TO deployment_history_legacy`;
+  await db`
+    CREATE TABLE deployment_history (
+      id TEXT PRIMARY KEY,
+      app TEXT NOT NULL,
+      tenant TEXT NOT NULL,
+      version TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'success',
+      deployed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      triggered_by TEXT NOT NULL DEFAULT 'api',
+      config JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `;
+
+  const rows = await db`
+    SELECT * FROM deployment_history_legacy
+  ` as Array<Record<string, unknown>>;
+
+  for (const row of rows) {
+    if (row.id === undefined || row.id === null) {
+      throw new Error("deployment_history migration blocked: legacy row without id cannot be mapped");
+    }
+    await db`
+      INSERT INTO deployment_history (id, app, tenant, version, status, deployed_at, triggered_by, config, created_at)
+      VALUES (
+        ${String(row.id)},
+        ${requiredLegacyText(row.deploy_type, "deploy_type")},
+        ${requiredLegacyText(row.project_ref, "project_ref")},
+        ${requiredLegacyText(row.version ?? row.description, "version/description")},
+        ${row.status === undefined || row.status === null
+          ? "success"
+          : requiredLegacyText(row.status, "status")},
+        ${requiredLegacyTimestamp(row.deployed_at ?? row.created_at, "deployed_at/created_at")},
+        ${typeof row.triggered_by === "string" && row.triggered_by.trim() !== ""
+          ? row.triggered_by
+          : "legacy-migration"},
+        ${parseLegacyDeploymentConfig(row.config)}::jsonb,
+        ${requiredLegacyTimestamp(row.created_at ?? row.deployed_at, "created_at/deployed_at")}
+      )
+    `;
+  }
+
+  const [{ count }] = await db`SELECT COUNT(*) AS count FROM deployment_history`;
+  if (Number(count) !== rows.length) {
+    throw new Error(
+      `deployment_history migration backfill mismatch: ${rows.length} legacy rows vs ${count} migrated rows`,
+    );
+  }
+
+  logger.info(
+    `[PlatformV2] Migrated ${rows.length} legacy deployment_history row(s); original data archived in deployment_history_legacy`,
+  );
+  return rows.length;
+}
+
 /** Move old config-embedded webhook definitions into durable metadata and managed secret storage. */
 export async function migrateLegacyProjectWebhooks(db: SQL): Promise<number> {
   const projects = await db`

--- a/packages/management-api/src/routes/frontend.ts
+++ b/packages/management-api/src/routes/frontend.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { frontendService } from "../services/frontend.service";
 import type { FrontendFramework } from "../types/frontend";
 import { FRAMEWORK_DEFAULTS } from "../types/frontend";
+import { requireProjectOrAdminAuth } from "../middleware/auth";
 
 const FRONTEND_UPLOAD_MAX_BYTES = Number(process.env.FRONTEND_UPLOAD_MAX_BYTES || 100 * 1024 * 1024);
 const FRONTEND_UPLOAD_MAX_FILES = Number(process.env.FRONTEND_UPLOAD_MAX_FILES || 10_000);
@@ -115,6 +116,11 @@ async function readUploadedZip(request: Request, body: unknown): Promise<Uint8Ar
 }
 
 export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" })
+  // 组级守卫：委托 proof 必须通过 operations 能力检查，防止越权创建部署/修改环境变量
+  .onBeforeHandle(async ({ params, request }) => {
+    const authError = await requireProjectOrAdminAuth(request, params.ref);
+    if (authError) return status(authError.status, authError.body);
+  })
   .get(
     "/deployments",
     async ({ params }) => {

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -135,14 +135,10 @@ function addConfigRoutes(section: string) {
       async ({
         params,
         body,
-        request,
       }: {
         params: { ref: string };
         body: Record<string, unknown>;
-        request: Request;
       }) => {
-        const authError = await requireProjectOrAdminAuth(request, params.ref);
-        if (authError) return status(authError.status, authError.body);
         const settings = await projectService.getProjectSettings(params.ref);
         if (!settings)
           return status(404, { message: "Project not found", code: "404" });
@@ -523,6 +519,7 @@ async function buildAuthConfigResponse(ref: string, settings: Record<string, unk
     uri_allow_list: authConfig.uri_allow_list ?? authConfig.URI_ALLOW_LIST ?? null,
     site_url: authConfig.site_url ?? authConfig.SITE_URL ?? null,
     password_min_length: sessionPolicy.password_min_length,
+    password_required_characters: sessionPolicy.password_required_characters,
     refresh_token_rotation_enabled:
       sessionPolicy.refresh_token_rotation_enabled,
     security_refresh_token_reuse_interval:
@@ -653,12 +650,18 @@ async function buildProjectSettingsResponse(
 }
 
 export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
+  // 组级守卫：统一保护所有 project-scoped 路由（含 addConfigRoutes 工厂与各 .use 子路由），
+  // 避免逐接口手工遗漏导致委托 member/viewer 绕过 tenant.config.read / operations.read
+  .onBeforeHandle(async ({ params, request }) => {
+    const ref = (params as { ref?: string }).ref;
+    if (!ref) return;
+    const authError = await requireProjectOrAdminAuth(request, ref);
+    if (authError) return status(authError.status, authError.body);
+  })
   // Get project settings
   .get(
     "/:ref/settings",
-    async ({ params, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params }) => {
       const settings = await projectService.getProjectSettings(params.ref);
       if (settings === null) {
         return status(404, { message: "Project not found", code: "404" });
@@ -684,9 +687,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Update project settings
   .put(
     "/:ref/settings",
-    async ({ params, body, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params, body }) => {
       const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
       if (managedError && Object.prototype.hasOwnProperty.call(body, "auth")) {
         return status(409, managedError);
@@ -724,9 +725,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get project API keys
   .get(
     "/:ref/api-keys",
-    async ({ params, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params }) => {
       const keys = await projectService.getApiKeys(params.ref);
       if (!keys) {
         return status(404, { message: "Project not found", code: "404" });
@@ -918,9 +917,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get Auth config (Studio compatible format)
   .get(
     "/:ref/config/auth",
-    async ({ params, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params }) => {
       const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
       if (managedError) return status(409, managedError);
       const settings = await projectService.getProjectSettings(params.ref);
@@ -942,9 +939,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Modify Auth config (supports deep copy override for third-party Providers)
   .patch(
     "/:ref/config/auth",
-    async ({ params, body, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params, body }) => {
       const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
       if (managedError) return status(409, managedError);
       const settings = await projectService.getProjectSettings(params.ref);
@@ -1305,9 +1300,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
 
   .patch(
     "/:ref/config/pooler",
-    async ({ params, body, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params, body }) => {
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings)
         return status(404, { message: "Project not found", code: "404" });
@@ -1332,9 +1325,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
 
   .get(
     "/:ref/database/replication",
-    async ({ params, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params }) => {
       const { getProjectDb, resolveDbName } = await import("../db");
       const dbName = await resolveDbName(params.ref);
       const db = getProjectDb(dbName);
@@ -1359,9 +1350,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
 
   .get(
     "/:ref/types/python",
-    async ({ params, query, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params, query }) => {
       const { getProjectDb, resolveDbName } = await import("../db");
       const dbName = await resolveDbName(params.ref);
       const db = getProjectDb(dbName);
@@ -1412,10 +1401,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   )
   .patch(
     "/:ref/config/database",
-    async ({ params, body, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
-
+    async ({ params, body }) => {
       let patch;
       try {
         patch = parseDatabaseConfigPatch(body);
@@ -1536,9 +1522,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   )
   .patch(
     "/:ref/config/storage",
-    async ({ params, body, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params, body }) => {
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings)
         return status(404, { message: "Project not found", code: "404" });
@@ -1591,9 +1575,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   )
   .patch(
     "/:ref/config/realtime",
-    async ({ params, body, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params, body }) => {
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings)
         return status(404, { message: "Project not found", code: "404" });
@@ -1632,9 +1614,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get PgBouncer config (for Studio display)
   .get(
     "/:ref/pgbouncer",
-    async ({ params, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params }) => {
       const settings = await projectService.getProjectSettings(params.ref);
       if (!settings)
         return status(404, { message: "Project not found", code: "404" });
@@ -1869,9 +1849,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   // Get Typescript Types — Real schema reflection (P0-5)
   .get(
     "/:ref/types/typescript",
-    async ({ params, query, request }) => {
-      const authError = await requireProjectOrAdminAuth(request, params.ref);
-      if (authError) return status(authError.status, authError.body);
+    async ({ params, query }) => {
       const { getProjectDb, resolveDbName } = await import("../db");
       const dbName = await resolveDbName(params.ref);
 

--- a/packages/management-api/src/routes/storage-s3.ts
+++ b/packages/management-api/src/routes/storage-s3.ts
@@ -36,6 +36,21 @@ interface S3Credentials {
   secret_key: string;
 }
 
+function readS3Credentials(projectConfig: unknown): S3Credentials | null {
+  const config = normalizeProjectConfig(projectConfig);
+  const credentials = config.s3_credentials as Record<string, unknown> | undefined;
+  if (
+    typeof credentials?.access_key !== "string" ||
+    typeof credentials.secret_key !== "string"
+  ) {
+    return null;
+  }
+  return {
+    access_key: credentials.access_key,
+    secret_key: credentials.secret_key,
+  };
+}
+
 function generateS3AccessKey(ref: string): string {
   return `supac_${ref}_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
 }
@@ -52,15 +67,8 @@ async function getOrCreateS3Credentials(ref: string): Promise<S3Credentials | nu
   const project = await projectRepository.findByRef(ref);
   if (!project) return null;
 
-  const cfg = normalizeProjectConfig(project.config);
-  const s3Creds = cfg.s3_credentials as Record<string, unknown> | undefined;
-  if (
-    s3Creds &&
-    typeof s3Creds.access_key === "string" &&
-    typeof s3Creds.secret_key === "string"
-  ) {
-    return { access_key: s3Creds.access_key, secret_key: s3Creds.secret_key };
-  }
+  const existingCredentials = readS3Credentials(project.config);
+  if (existingCredentials) return existingCredentials;
 
   // Auto-provision on first use.
   const credentials: S3Credentials = {
@@ -73,6 +81,11 @@ async function getOrCreateS3Credentials(ref: string): Promise<S3Credentials | nu
   );
   logger.info(`[storage-s3] provisioned S3 credentials for ${ref}`);
   return credentials;
+}
+
+async function getS3Credentials(ref: string): Promise<S3Credentials | null> {
+  const project = await projectRepository.findByRef(ref);
+  return project ? readS3Credentials(project.config) : null;
 }
 
 function xmlEscape(s: string): string {
@@ -134,7 +147,7 @@ async function authenticate(request: Request, ref: string): Promise<boolean> {
     const parsed = parseSigV4Header(authHeader);
     if (!parsed) return false;
 
-    const credentials = await getOrCreateS3Credentials(ref);
+    const credentials = await getS3Credentials(ref);
     if (!credentials) return false;
 
     // The access key in the credential scope must match the project's S3 access key.

--- a/packages/management-api/src/services/auth-session-policy.ts
+++ b/packages/management-api/src/services/auth-session-policy.ts
@@ -1,9 +1,12 @@
+import { renderSystemdEnvLine } from "../utils/systemd-env";
+
 export const AUTH_SESSION_POLICY_DEFAULTS = Object.freeze({
     jwt_expiry: 3600,
     refresh_token_rotation_enabled: true,
     security_refresh_token_reuse_interval: 10,
     security_update_password_require_reauthentication: true,
     password_min_length: 8,
+    password_required_characters: "",
     sessions_inactivity_timeout: null as number | null,
     sessions_single_per_user: false,
     sessions_timebox: null as number | null,
@@ -15,6 +18,7 @@ export type AuthSessionPolicy = {
     security_refresh_token_reuse_interval: number;
     security_update_password_require_reauthentication: boolean;
     password_min_length: number;
+    password_required_characters: string;
     sessions_inactivity_timeout: number | null;
     sessions_single_per_user: boolean;
     sessions_timebox: number | null;
@@ -22,7 +26,7 @@ export type AuthSessionPolicy = {
 
 export type AuthSessionPolicyKey = keyof AuthSessionPolicy;
 
-type AuthSessionPolicyPatchValue = number | boolean | null;
+type AuthSessionPolicyPatchValue = number | boolean | string | null;
 
 export type AuthSessionPolicyPatch = {
     values: Partial<Record<AuthSessionPolicyKey, AuthSessionPolicyPatchValue>>;
@@ -47,6 +51,7 @@ const AUTH_SESSION_POLICY_ALIASES: Record<AuthSessionPolicyKey, readonly string[
     security_refresh_token_reuse_interval: ["security_refresh_token_rotation_reuse_interval"],
     security_update_password_require_reauthentication: [],
     password_min_length: [],
+    password_required_characters: [],
     sessions_inactivity_timeout: [],
     sessions_single_per_user: [],
     sessions_timebox: [],
@@ -158,6 +163,20 @@ function parseDurationPolicyValue(
     return normalized;
 }
 
+function parseRequiredCharactersPolicyValue(
+    field: AuthSessionPolicyKey,
+    value: unknown,
+): string | null {
+    if (value === null) return null;
+    if (typeof value !== "string") {
+        return invalidPolicyValue(field, "must be a string or null");
+    }
+    if (CONFIG_CONTROL_CHARACTERS.test(value)) {
+        return invalidPolicyValue(field, "contains a forbidden control character");
+    }
+    return value;
+}
+
 function parseAuthSessionPolicyValue(
     field: AuthSessionPolicyKey,
     value: unknown,
@@ -170,6 +189,8 @@ function parseAuthSessionPolicyValue(
             return parseIntegerPolicyValue(field, value, { min: 0, max: 2_147_483_647 });
         case "password_min_length":
             return parseIntegerPolicyValue(field, value, { min: 6, max: 32_767 });
+        case "password_required_characters":
+            return parseRequiredCharactersPolicyValue(field, value);
         case "refresh_token_rotation_enabled":
         case "security_update_password_require_reauthentication":
         case "sessions_single_per_user":
@@ -262,6 +283,9 @@ export function renderGoTrueSessionPolicyEnv(authConfig: Record<string, unknown>
         `GOTRUE_JWT_EXP=${policy.jwt_expiry}`,
         `GOTRUE_SECURITY_UPDATE_PASSWORD_REQUIRE_REAUTHENTICATION=${policy.security_update_password_require_reauthentication}`,
         `GOTRUE_PASSWORD_MIN_LENGTH=${policy.password_min_length}`,
+        policy.password_required_characters === ""
+            ? ""
+            : renderSystemdEnvLine("GOTRUE_PASSWORD_REQUIRED_CHARACTERS", policy.password_required_characters),
         `GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_ENABLED=${policy.refresh_token_rotation_enabled}`,
         `GOTRUE_SECURITY_REFRESH_TOKEN_REUSE_INTERVAL=${policy.security_refresh_token_reuse_interval}`,
         `GOTRUE_SESSIONS_SINGLE_PER_USER=${policy.sessions_single_per_user}`,

--- a/packages/management-api/src/services/storage.adapter.ts
+++ b/packages/management-api/src/services/storage.adapter.ts
@@ -4,6 +4,7 @@ import { normalizeCiS3Endpoint } from "../utils/sdk-parity";
 import { shellService } from "./shell.service";
 import { resolveBucketName } from "../db";
 import * as fs from "node:fs/promises";
+import * as syncFs from "node:fs";
 import * as path from "node:path";
 import { S3Client } from "bun";
 import { AwsClient } from "aws4fetch";
@@ -17,6 +18,38 @@ function normalizeObjectKey(key: string): string {
     throw new Error("Invalid object key");
   }
   return normalized;
+}
+
+const BUCKET_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+const DOT_ONLY_PATTERN = /^\.+$/;
+
+function normalizeBucketId(bucket: string): string {
+  if (!BUCKET_ID_PATTERN.test(bucket) || DOT_ONLY_PATTERN.test(bucket)) {
+    throw new Error("Invalid bucket identifier");
+  }
+  return bucket;
+}
+
+function isOutsideRoot(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative);
+}
+
+function resolveRealPath(p: string): string {
+  const rest: string[] = [];
+  let candidate = p;
+  for (;;) {
+    try {
+      const real = syncFs.realpathSync(candidate);
+      return rest.length > 0 ? path.join(real, ...rest) : real;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(candidate);
+      if (parent === candidate) return candidate;
+      rest.unshift(path.basename(candidate));
+      candidate = parent;
+    }
+  }
 }
 
 export interface StorageDriver {
@@ -61,17 +94,23 @@ export class JuiceFSDriver implements StorageDriver {
     bucket?: string,
     key?: string,
   ): string {
-    const root = path.resolve(
-      config.storageMountPoint,
-      resolveBucketName(projectRef),
-    );
+    const mountRoot = path.resolve(config.storageMountPoint);
+    const realMountRoot = resolveRealPath(mountRoot);
+    const root = path.resolve(mountRoot, resolveBucketName(projectRef));
+    const realRoot = resolveRealPath(root);
+    if (isOutsideRoot(realMountRoot, realRoot)) {
+      throw new Error(`Path traversal blocked: ${realRoot} escapes ${realMountRoot}`);
+    }
     let p = root;
-    if (bucket) p = path.join(p, bucket);
+    if (bucket) p = path.join(p, normalizeBucketId(bucket));
     if (key) p = path.join(p, normalizeObjectKey(key));
-    // Resolve to absolute path and ensure it stays within the project root (prevent .. traversal)
     const resolved = path.resolve(p);
-    if (!resolved.startsWith(root)) {
+    if (isOutsideRoot(root, resolved)) {
       throw new Error(`Path traversal blocked: ${resolved} escapes ${root}`);
+    }
+    const realResolved = resolveRealPath(resolved);
+    if (isOutsideRoot(realRoot, realResolved)) {
+      throw new Error(`Path traversal blocked: ${realResolved} escapes ${realRoot}`);
     }
     return resolved;
   }

--- a/packages/management-api/src/services/storage.service.ts
+++ b/packages/management-api/src/services/storage.service.ts
@@ -120,10 +120,13 @@ export class StorageService {
 
         job.logs.push(`[${new Date().toISOString()}] Starting juicefs sync to ${s3Url}...`);
         
-        const proc = Bun.spawn([scriptPath, 'migrate_to_s3', s3Url, options], {
+        const proc = Bun.spawn([scriptPath, 'migrate_to_s3', s3Url], {
+          stdin: 'pipe',
           stdout: 'pipe',
           stderr: 'pipe'
         });
+        proc.stdin.write(options);
+        proc.stdin.end();
 
         // Function to process a single pipe stream, extracting progress strings
         const processStream = async (stream: ReadableStream<Uint8Array>) => {

--- a/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
@@ -569,6 +569,7 @@ describe("SupAuth auth config boundary", () => {
       security_refresh_token_reuse_interval: 10,
       security_update_password_require_reauthentication: true,
       password_min_length: 8,
+      password_required_characters: "",
       sessions_inactivity_timeout: null,
       sessions_single_per_user: false,
       sessions_timebox: null,
@@ -583,6 +584,7 @@ describe("SupAuth auth config boundary", () => {
         security_refresh_token_rotation_reuse_interval: 17,
         security_update_password_require_reauthentication: false,
         password_min_length: 12,
+        password_required_characters: "lower:upper:digits",
         sessions_inactivity_timeout: "30m",
         sessions_single_per_user: true,
         sessions_timebox: 86_400,
@@ -599,6 +601,7 @@ describe("SupAuth auth config boundary", () => {
       security_refresh_token_reuse_interval: 17,
       security_update_password_require_reauthentication: false,
       password_min_length: 12,
+      password_required_characters: "lower:upper:digits",
       sessions_inactivity_timeout: 1800,
       sessions_single_per_user: true,
       sessions_timebox: 86_400,
@@ -607,11 +610,19 @@ describe("SupAuth auth config boundary", () => {
       jwt_expiry: 7200,
       refresh_token_rotation_enabled: false,
       security_refresh_token_reuse_interval: 17,
+      password_required_characters: "lower:upper:digits",
       sessions_inactivity_timeout: 1800,
       sessions_timebox: 86_400,
     });
     expect((settings.auth as Record<string, unknown>).jwt_exp).toBeUndefined();
     expect((settings.auth as Record<string, unknown>).security_refresh_token_rotation_reuse_interval).toBeUndefined();
+
+    const readBack = await request("/v1/projects/tenant-a/config/auth");
+    expect(readBack.status).toBe(200);
+    expect(await readBack.json()).toMatchObject({
+      password_min_length: 12,
+      password_required_characters: "lower:upper:digits",
+    });
   });
 
   test("rejects invalid session policy before persistence or runtime apply", async () => {

--- a/packages/management-api/tests/unit/delegated-project-authorization.test.ts
+++ b/packages/management-api/tests/unit/delegated-project-authorization.test.ts
@@ -115,6 +115,8 @@ describe("delegated project authorization", () => {
       ["PUT", "/domains/example.test", "tenant.domains.manage"],
       ["GET", "/cache", "operations.read"],
       ["POST", "/cache/operations", "operations.manage"],
+      ["GET", "/frontend/deployments", "operations.read"],
+      ["POST", "/frontend/deployments", "operations.manage"],
       ["GET", "/tasks", "operations.read"],
       ["POST", "/pipelines", "operations.manage"],
       ["POST", "/database/migrations", "database.migrations.manage"],
@@ -146,6 +148,21 @@ describe("delegated project authorization", () => {
       "proj_1",
     );
     expect(organizationWrite?.body.error).toContain("organizations.manage");
+
+    // viewer 不具备 operations.read/manage，frontend 部署读写均被拒绝
+    const frontendRead = await requireProjectOrAdminAuth(
+      delegatedRequest("/v1/projects/proj_1/frontend/deployments", "GET", "viewer-one"),
+      "proj_1",
+    );
+    expect(frontendRead?.status).toBe(403);
+    expect(frontendRead?.body.error).toContain("operations.read");
+
+    const frontendWrite = await requireProjectOrAdminAuth(
+      delegatedRequest("/v1/projects/proj_1/frontend/deployments", "POST", "viewer-one"),
+      "proj_1",
+    );
+    expect(frontendWrite?.status).toBe(403);
+    expect(frontendWrite?.body.error).toContain("operations.manage");
   });
 
   test("allows owner and admin reads and writes across new capability families", async () => {

--- a/packages/management-api/tests/unit/frontend.routes.test.ts
+++ b/packages/management-api/tests/unit/frontend.routes.test.ts
@@ -1,15 +1,25 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
-import { frontendRoutes } from "../../src/routes/frontend";
 import { frontendService } from "../../src/services/frontend.service";
 import { rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+const authModule = await import("../../src/middleware/auth");
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const { frontendRoutes } = await import("../../src/routes/frontend");
+
 describe("Frontend deployment upload routes", () => {
   let app: Elysia;
   let testZipBytes: Uint8Array;
   let tempZipPath: string;
+
+  afterAll(() => {
+    requireProjectOrAdminAuthSpy.mockRestore();
+  });
 
   beforeAll(async () => {
     app = new Elysia().use(frontendRoutes);
@@ -30,6 +40,9 @@ describe("Frontend deployment upload routes", () => {
   });
 
   beforeEach(() => {
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+
     // Mock getDeployment 保证存在该部署
     spyOn(frontendService, "getDeployment").mockImplementation(async (ref, id) => {
       return {
@@ -191,5 +204,27 @@ describe("Frontend deployment upload routes", () => {
     const data = await res.json() as any;
     expect(data.success).toBe(false);
     expect(data.message).toBe("Invalid zip archive");
+  });
+
+  test("denies the request when project authorization fails and skips the service", async () => {
+    requireProjectOrAdminAuth.mockResolvedValue({
+      status: 403,
+      body: { error: "Missing capability: operations.manage" },
+    });
+    const createDeployment = spyOn(frontendService, "createDeployment");
+    createDeployment.mockClear();
+
+    const res = await app.handle(new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "denied-site", framework: "static" }),
+      },
+    ));
+
+    expect(res.status).toBe(403);
+    expect(requireProjectOrAdminAuth).toHaveBeenCalledWith(expect.any(Request), "proj123");
+    expect(createDeployment).not.toHaveBeenCalled();
   });
 });

--- a/packages/management-api/tests/unit/platform-v2.migration.test.ts
+++ b/packages/management-api/tests/unit/platform-v2.migration.test.ts
@@ -3,6 +3,7 @@ import type { SQL } from "bun";
 import {
   ensurePlatformV2Schema,
   migrateLegacyControlSecrets,
+  migrateLegacyDeploymentHistory,
   migrateLegacyProviderLinkingConfig,
   migrateLegacyProjectWebhooks,
   migrateWebhookSecretsToControlStore,
@@ -84,6 +85,123 @@ describe("platform v2 migrations", () => {
     expect(storedSecrets.at(-1)?.encrypted).toStartWith("enc:v1:");
     expect(await migrateLegacyControlSecrets(database)).toBe(0);
     expect(await migrateLegacyProjectWebhooks(database)).toBe(0);
+  });
+
+  test("archives and backfills legacy deployment_history without dropping data", async () => {
+    const legacyRows = [
+      {
+        id: "22222222-2222-4222-8222-222222222222",
+        project_ref: "proj_1",
+        deploy_type: "frontend",
+        description: "v1.2.3",
+        // 真实旧 schema 没有 status/deployed_at，只有 created_at。
+        created_at: new Date("2026-05-01T00:00:00.000Z"),
+      },
+      {
+        id: "33333333-3333-4333-8333-333333333333",
+        project_ref: "proj_2",
+        deploy_type: "backend",
+        version: "v2.0.0",
+        status: "failed",
+        deployed_at: new Date("2026-05-02T00:00:00.000Z"),
+      },
+    ];
+    const migrated: Array<Record<string, unknown>> = [];
+    const statements: string[] = [];
+    const database = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+      const query = strings.join("?");
+      statements.push(query);
+      if (query.includes("information_schema.columns")) {
+        return Promise.resolve([{ "?column?": 1 }]);
+      }
+      if (query.includes("SELECT * FROM deployment_history_legacy")) {
+        return Promise.resolve(legacyRows);
+      }
+      if (query.includes("INSERT INTO deployment_history")) {
+        migrated.push({
+          id: values[0], app: values[1], tenant: values[2], version: values[3],
+          status: values[4], deployed_at: values[5], triggered_by: values[6], config: values[7],
+          created_at: values[8],
+        });
+        return Promise.resolve([]);
+      }
+      if (query.includes("SELECT COUNT(*) AS count FROM deployment_history")) {
+        return Promise.resolve([{ count: migrated.length }]);
+      }
+      return Promise.resolve([]);
+    }) as unknown as SQL;
+
+    expect(await migrateLegacyDeploymentHistory(database)).toBe(2);
+
+    // 旧表被归档而不是 DROP CASCADE，新表重新建立
+    expect(statements.some((query) => query.includes("RENAME TO deployment_history_legacy"))).toBe(true);
+    expect(statements.some((query) => query.includes("DROP TABLE"))).toBe(false);
+    expect(statements.some((query) => query.includes("CREATE TABLE deployment_history"))).toBe(true);
+
+    expect(migrated).toHaveLength(2);
+    expect(migrated[0]).toMatchObject({
+      id: "22222222-2222-4222-8222-222222222222",
+      app: "frontend",
+      tenant: "proj_1",
+      version: "v1.2.3",
+      status: "success",
+      deployed_at: new Date("2026-05-01T00:00:00.000Z"),
+      triggered_by: "legacy-migration",
+      created_at: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    expect(migrated[1]).toMatchObject({ app: "backend", tenant: "proj_2", version: "v2.0.0", status: "failed" });
+  });
+
+  test("skips deployment_history migration when the table already uses the new schema", async () => {
+    const database = mock((strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("information_schema.columns")) return Promise.resolve([]);
+      throw new Error(`unexpected query: ${query}`);
+    }) as unknown as SQL;
+
+    expect(await migrateLegacyDeploymentHistory(database)).toBe(0);
+  });
+
+  test("blocks the upgrade when backfill row counts do not match", async () => {
+    const database = mock((strings: TemplateStringsArray) => {
+      const query = strings.join("?");
+      if (query.includes("information_schema.columns")) return Promise.resolve([{ "?column?": 1 }]);
+      if (query.includes("SELECT * FROM deployment_history_legacy")) {
+        return Promise.resolve([{
+          id: "row-1",
+          project_ref: "proj_1",
+          deploy_type: "frontend",
+          description: "v1.0.0",
+          status: "success",
+          deployed_at: new Date("2026-05-01T00:00:00.000Z"),
+        }]);
+      }
+      if (query.includes("SELECT COUNT(*)")) return Promise.resolve([{ count: 2 }]);
+      return Promise.resolve([]);
+    }) as unknown as SQL;
+
+    await expect(migrateLegacyDeploymentHistory(database)).rejects.toThrow(/backfill mismatch/);
+  });
+
+  test("blocks migration when a legacy row cannot be mapped reliably", async () => {
+    const database = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+      const query = strings.join("?");
+      if (query.includes("information_schema.columns")) return Promise.resolve([{ "?column?": 1 }]);
+      if (query.includes("SELECT * FROM deployment_history_legacy")) {
+        return Promise.resolve([{
+          id: "row-1",
+          project_ref: "proj_1",
+          deploy_type: "frontend",
+          description: "v1.0.0",
+          status: "success",
+          deployed_at: new Date("2026-05-01T00:00:00.000Z"),
+          config: "not-json",
+        }]);
+      }
+      return Promise.resolve([]);
+    }) as unknown as SQL;
+
+    await expect(migrateLegacyDeploymentHistory(database)).rejects.toThrow(/invalid JSON/);
   });
 
   test("seeds owners only from verifiable organization members", async () => {

--- a/packages/management-api/tests/unit/project-storage-config.routes.test.ts
+++ b/packages/management-api/tests/unit/project-storage-config.routes.test.ts
@@ -64,6 +64,19 @@ describe("project storage config routes", () => {
     updateProjectSettings.mockImplementation(async (_ref, settings) => settings as never);
   });
 
+  test("GET rejects failed project authorization before reading settings", async () => {
+    requireProjectOrAdminAuth.mockResolvedValue({
+      status: 403,
+      body: { error: "Missing capability: tenant.config.read" },
+    });
+
+    const res = await request("/v1/projects/proj_1/config/storage");
+
+    expect(res.status).toBe(403);
+    expect(requireProjectOrAdminAuth).toHaveBeenCalledTimes(1);
+    expect(getProjectSettings).not.toHaveBeenCalled();
+  });
+
   test("GET advertises vectors while keeping Iceberg unavailable", async () => {
     const res = await request("/v1/projects/proj_1/config/storage");
     expect(res.status).toBe(200);
@@ -110,6 +123,7 @@ describe("project storage config routes", () => {
       maxValuesPerIndex: 1_000_000,
     });
     expect(body.capabilities.storage_vectors).toBe(true);
+    expect(requireProjectOrAdminAuth).toHaveBeenCalledTimes(1);
     expect(requireProjectOrAdminAuth).toHaveBeenCalledWith(expect.any(Request), "proj_1");
   });
 });

--- a/packages/management-api/tests/unit/realtime-systemd.test.ts
+++ b/packages/management-api/tests/unit/realtime-systemd.test.ts
@@ -63,13 +63,13 @@ describe("Realtime systemd deployment", () => {
     expect(unit).toContain("Environment=REALTIME_CONTAINER_NAME=supacloud-realtime");
     expect(unit).toContain("Environment=REALTIME_DB_USER=supabase_admin");
     expect(unit).toContain("Environment=PG_DATABASE=supacloud_meta");
+    expect(unit).toContain("Environment=REALTIME_CONTAINER_ENV_FILE=/etc/supabase/realtime-container.env");
     expect(unit).toContain("$${#REALTIME_DB_ENC_KEY}");
     expect(unit).toContain("test -n \"$$PGPASSWORD\"");
-    expect(unit).toContain("-e DB_USER_REALTIME=${REALTIME_DB_USER}");
-    expect(unit).toContain("-e DB_PASS_REALTIME=${PGPASSWORD}");
-    expect(unit).toContain("-e SEED_SELF_HOST=false");
-    expect(unit).toContain("-e REGION=us-east-1");
-    expect(unit).toContain("-e RUN_JANITOR=false");
+    expect(unit).toContain("--env-file ${REALTIME_CONTAINER_ENV_FILE}");
+    expect(unit).not.toContain("-e DB_PASS_REALTIME=");
+    expect(unit).not.toContain("-e JWT_SECRET=");
+    expect(unit).not.toContain("-e SECRET_KEY_BASE=");
     expect(unit).not.toContain("SystemCallFilter=");
     expect(unit).not.toContain("DB_AFTER_CONNECT_QUERY");
   });

--- a/packages/management-api/tests/unit/storage-s3.routes.test.ts
+++ b/packages/management-api/tests/unit/storage-s3.routes.test.ts
@@ -326,6 +326,25 @@ describe("storageS3Routes", () => {
 // --- SigV4 auth tests ----------------------------------------------------
 
 describe("storageS3Routes SigV4 auth", () => {
+  test("SigV4 authentication never provisions credentials", async () => {
+    mockFindByRef.mockResolvedValue({
+      ref: "testproj",
+      service_role_key: "test-service-key",
+      config: {},
+    } as never);
+
+    const res = await app.handle(
+      new Request("http://localhost/v1/storage/testproj/s3/", {
+        headers: {
+          authorization: "AWS4-HMAC-SHA256 Credential=forged/20260801/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=00",
+        },
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
   test("GET /credentials provisions and returns S3 credentials", async () => {
     // Simulate project without pre-existing s3_credentials (auto-provision)
     mockFindByRef.mockResolvedValue({ ref: "testproj", service_role_key: "test-service-key", config: {} } as never);

--- a/packages/management-api/tests/unit/storage.adapter.test.ts
+++ b/packages/management-api/tests/unit/storage.adapter.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { JuiceFSDriver, S3Driver } from "../../src/services/storage.adapter";
 import { shellService } from "../../src/services/shell.service";
+import { config } from "../../src/config";
 
 function textStream(value: string): ReadableStream<Uint8Array> {
   return new ReadableStream<Uint8Array>({
@@ -136,5 +137,88 @@ describe("JuiceFSDriver uploadFile", () => {
     } finally {
       await rm(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("JuiceFSDriver path traversal protection", () => {
+  async function withTempMount<T>(fn: (mount: string) => Promise<T>): Promise<T> {
+    const mount = await mkdtemp(join(tmpdir(), "supacloud-mount-"));
+    const original = config.storageMountPoint;
+    config.storageMountPoint = mount;
+    try {
+      return await fn(mount);
+    } finally {
+      config.storageMountPoint = original;
+      await rm(mount, { recursive: true, force: true });
+    }
+  }
+
+  test("rejects dot-segment and prefixed sibling bucket identifiers", async () => {
+    await withTempMount(async (mount) => {
+      const driver = new JuiceFSDriver();
+      // 相邻项目目录已存在时，../supa-victim 也不能通过边界校验
+      await mkdir(join(mount, "supa-victim"), { recursive: true });
+
+      for (const bucket of ["..", ".", "...", "../supa-victim", "a/b", "a\\b"]) {
+        expect(await driver.createBucket("proj", bucket)).toBe(false);
+        expect(await driver.uploadFile("proj", bucket, "x.txt", new TextEncoder().encode("x"), "text/plain")).toBe(false);
+      }
+      // 相邻项目目录未被写入
+      expect(await driver.isBucketEmpty("proj", "gallery").catch(() => true)).toBe(true);
+    });
+  });
+
+  test("accepts normal bucket identifiers within the project root", async () => {
+    await withTempMount(async () => {
+      const driver = new JuiceFSDriver();
+      expect(await driver.createBucket("proj", "gallery-1")).toBe(true);
+      const uploaded = await driver.uploadFile(
+        "proj",
+        "gallery-1",
+        "docs/a.txt",
+        new TextEncoder().encode("hello"),
+        "text/plain",
+      );
+      expect(uploaded).toBe(true);
+    });
+  });
+
+  test("blocks symlink escape inside a bucket directory", async () => {
+    await withTempMount(async (mount) => {
+      const outside = await mkdtemp(join(tmpdir(), "supacloud-outside-"));
+      try {
+        await writeFile(join(outside, "secret.txt"), "top-secret");
+        const bucketDir = join(mount, "supa-proj", "gallery");
+        await mkdir(bucketDir, { recursive: true });
+        await symlink(outside, join(bucketDir, "link"));
+
+        const driver = new JuiceFSDriver();
+        await expect(driver.getDownloadResponse("proj", "gallery", "link/secret.txt"))
+          .rejects.toThrow(/Path traversal blocked/);
+        // 通过符号链接写出桶外也必须失败
+        expect(
+          await driver.uploadFile("proj", "gallery", "link/evil.txt", new TextEncoder().encode("x"), "text/plain"),
+        ).toBe(false);
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
+  test("blocks a project root symlink that points outside the storage mount", async () => {
+    await withTempMount(async (mount) => {
+      const outside = await mkdtemp(join(tmpdir(), "supacloud-outside-root-"));
+      try {
+        await writeFile(join(outside, "secret.txt"), "outside-root-secret");
+        await symlink(outside, join(mount, "supa-proj"));
+
+        const driver = new JuiceFSDriver();
+        await expect(driver.getDownloadResponse("proj", "gallery", "secret.txt"))
+          .rejects.toThrow(/Path traversal blocked/);
+        expect(await driver.createBucket("proj", "gallery")).toBe(false);
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/management-api/tests/unit/storage.service.test.ts
+++ b/packages/management-api/tests/unit/storage.service.test.ts
@@ -65,9 +65,33 @@ describe("StorageService (using adapter)", () => {
   });
 
   describe("JuiceFS Methods / Status", () => {
-    test("startMigration should trigger async sync and return a jobId", async () => {
-      const result = await service.startMigration("s3://bucket", { access_key: "ak", secret_key: "sk", endpoint: "ep" });
-      expect(result).toHaveProperty("jobId");
+    test("startMigration sends credentials over stdin instead of argv", async () => {
+      let writtenCredentials = "";
+      const spawnSpy = spyOn(Bun, "spawn").mockImplementation((() => ({
+        stdin: {
+          write(chunk: string) {
+            writtenCredentials += chunk;
+          },
+          end() {},
+        },
+        stdout: new ReadableStream({ start(controller) { controller.close(); } }),
+        stderr: new ReadableStream({ start(controller) { controller.close(); } }),
+        exited: Promise.resolve(0),
+      })) as typeof Bun.spawn);
+
+      const credentials = { access_key: "ak", secret_key: "sk", endpoint: "ep" };
+      try {
+        const result = await service.startMigration("s3://bucket", credentials);
+
+        expect(result).toHaveProperty("jobId");
+        const command = spawnSpy.mock.calls[0]?.[0] as string[];
+        expect(command).toHaveLength(3);
+        expect(command.join(" ")).not.toContain(credentials.access_key);
+        expect(command.join(" ")).not.toContain(credentials.secret_key);
+        expect(JSON.parse(writtenCredentials)).toEqual(credentials);
+      } finally {
+        spawnSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/management-api/tests/unit/tenant-runtime.env.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.env.test.ts
@@ -152,6 +152,20 @@ describe("TenantRuntimeService GoTrue auth env rendering", () => {
     expect(env).not.toContain("GOTRUE_SECURITY_REFRESH_TOKEN_ROTATION_REUSE_INTERVAL");
     expect(env).not.toContain("GOTRUE_SESSIONS_INACTIVITY_TIMEOUT");
     expect(env).not.toContain("GOTRUE_SESSIONS_TIMEBOX");
+    expect(env).not.toContain("GOTRUE_PASSWORD_REQUIRED_CHARACTERS");
+  });
+
+  test("renders GOTRUE_PASSWORD_REQUIRED_CHARACTERS with systemd-safe quoting", () => {
+    const env = renderGoTrueSessionPolicyEnv({
+      password_required_characters: "lower:upper:!@#$%",
+    });
+    expect(env).toContain('GOTRUE_PASSWORD_REQUIRED_CHARACTERS="lower:upper:!@#$%"');
+
+    // 冒号转义与空格值必须原样传入 GoTrue 的 Decode 契约
+    const escaped = renderGoTrueSessionPolicyEnv({
+      password_required_characters: "abc\\:def:xy z",
+    });
+    expect(escaped).toContain('GOTRUE_PASSWORD_REQUIRED_CHARACTERS="abc\\\\:def:xy z"');
   });
 
   test("maps canonical policy fields and compatibility aliases into GoTrue env", () => {
@@ -212,6 +226,34 @@ describe("TenantRuntimeService GoTrue auth env rendering", () => {
       jwt_expiry: 3600,
       jwt_exp: 7200,
     })).toThrow(/conflicting values/);
+  });
+
+  test("validates password_required_characters and round-trips through the stored config", () => {
+    const patch = normalizeAuthSessionPolicyPatch({
+      password_required_characters: "lower:upper:digits",
+    });
+    const auth = applyAuthSessionPolicyPatch({ password_required_characters: "digits" }, patch);
+    expect(auth).toEqual({ password_required_characters: "lower:upper:digits" });
+    expect(readAuthSessionPolicy(auth).password_required_characters).toBe("lower:upper:digits");
+
+    // null 与空字符串都恢复为无要求
+    const reset = applyAuthSessionPolicyPatch(auth, normalizeAuthSessionPolicyPatch({
+      password_required_characters: null,
+    }));
+    expect(readAuthSessionPolicy(reset).password_required_characters).toBe("");
+    const emptied = applyAuthSessionPolicyPatch(auth, normalizeAuthSessionPolicyPatch({
+      password_required_characters: "",
+    }));
+    expect(readAuthSessionPolicy(emptied).password_required_characters).toBe("");
+
+    expect(() => normalizeAuthSessionPolicyPatch({ password_required_characters: 42 }))
+      .toThrow(/password_required_characters.*string or null/);
+    expect(readAuthSessionPolicy({ password_required_characters: "::" }).password_required_characters)
+      .toBe("::");
+    expect(readAuthSessionPolicy({ password_required_characters: "x".repeat(200) }).password_required_characters)
+      .toBe("x".repeat(200));
+    expect(() => normalizeAuthSessionPolicyPatch({ password_required_characters: "ab\ncd" }))
+      .toThrow(/password_required_characters.*control character/);
   });
 
   test("defaults signup-related runtime flags to the current permissive behavior", () => {

--- a/packages/supacloud-js/src/index.test.ts
+++ b/packages/supacloud-js/src/index.test.ts
@@ -587,7 +587,7 @@ describe("@supacloud/js", () => {
     expect(new Headers(calls[0]?.init?.headers).get("authorization")).toBe("Bearer token-123");
   });
 
-  test("wait polls until a terminal task status is reached", async () => {
+  test("wait polls until a terminal task status is reached and cleans each delay", async () => {
     const { supabase } = createFakeSupabase();
     const client = createSupaCloudClient({
       supabase: supabase as never,
@@ -595,15 +595,88 @@ describe("@supacloud/js", () => {
       projectRef: "proj_1",
       pollingIntervalMs: 1,
     });
+    const controller = new AbortController();
+    const addListenerSpy = spyOn(controller.signal, "addEventListener");
+    const removeListenerSpy = spyOn(controller.signal, "removeEventListener");
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
 
     const getSpy = spyOn(client.tasks, "get")
       .mockResolvedValueOnce({ id: "tsk_123", status: "running" })
+      .mockResolvedValueOnce({ id: "tsk_123", status: "running" })
       .mockResolvedValueOnce({ id: "tsk_123", status: "completed" });
 
-    const task = await client.tasks.wait("tsk_123");
+    const task = await client.tasks.wait("tsk_123", {
+      signal: controller.signal,
+    });
 
     expect(task.status).toBe("completed");
-    expect(getSpy).toHaveBeenCalledTimes(2);
+    expect(getSpy).toHaveBeenCalledTimes(3);
+    expect(addListenerSpy).toHaveBeenCalledTimes(2);
+    expect(removeListenerSpy).toHaveBeenCalledTimes(2);
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("wait preserves polling errors after cleaning the completed delay", async () => {
+    const { supabase } = createFakeSupabase();
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com",
+      projectRef: "proj_1",
+      pollingIntervalMs: 1,
+    });
+    const controller = new AbortController();
+    const removeListenerSpy = spyOn(controller.signal, "removeEventListener");
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+    const pollingError = new Error("poll failed");
+    let rejectedWith: unknown;
+
+    spyOn(client.tasks, "get")
+      .mockResolvedValueOnce({ id: "tsk_123", status: "running" })
+      .mockImplementation(() => Promise.reject(pollingError));
+
+    try {
+      await client.tasks.wait("tsk_123", { signal: controller.signal });
+    } catch (error) {
+      rejectedWith = error;
+    }
+    expect(rejectedWith).toBe(pollingError);
+    expect(removeListenerSpy).toHaveBeenCalledTimes(1);
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("wait preserves the abort reason and cleans the active delay", async () => {
+    const { supabase } = createFakeSupabase();
+    const client = createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "https://admin.example.com",
+      projectRef: "proj_1",
+      pollingIntervalMs: 1000,
+    });
+    const controller = new AbortController();
+    const addListenerSpy = spyOn(controller.signal, "addEventListener");
+    const removeListenerSpy = spyOn(controller.signal, "removeEventListener");
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+    const abortReason = new Error("stop waiting");
+    const getSpy = spyOn(client.tasks, "get")
+      .mockResolvedValue({ id: "tsk_123", status: "running" });
+    let rejectedWith: unknown;
+
+    const waitPromise = client.tasks.wait("tsk_123", {
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort(abortReason);
+
+    try {
+      await waitPromise;
+    } catch (error) {
+      rejectedWith = error;
+    }
+    expect(rejectedWith).toBe(abortReason);
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(addListenerSpy).toHaveBeenCalledTimes(1);
+    expect(removeListenerSpy).toHaveBeenCalledTimes(1);
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
   });
 
   test("subscribe falls back to polling on channel error", async () => {

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -446,6 +446,29 @@ const TERMINAL_STATUSES = new Set<string>([
   "completed",
 ]);
 
+function waitForPollingInterval(
+  intervalMs: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (settle: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      settle();
+    };
+    const onAbort = () => finish(() => {
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    });
+    const timer = setTimeout(() => finish(resolve), intervalMs);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+}
+
 function normalizeBaseUrl(url: string): string {
   return url.replace(/\/+$/, "");
 }
@@ -733,19 +756,7 @@ class SupaCloudTasksClient<TClient extends SupabaseClient = SupabaseClient> exte
       const task = await this.get(taskId);
       if (TERMINAL_STATUSES.has(String(task.status))) return task;
 
-      await new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(resolve, intervalMs);
-
-        if (options.signal) {
-          const onAbort = () => {
-            clearTimeout(timer);
-            options.signal?.removeEventListener("abort", onAbort);
-            reject(options.signal?.reason ?? new DOMException("Aborted", "AbortError"));
-          };
-
-          options.signal.addEventListener("abort", onAbort, { once: true });
-        }
-      });
+      await waitForPollingInterval(intervalMs, options.signal);
     }
   }
 

--- a/packages/web-console/src/lib/admin/auth.test.ts
+++ b/packages/web-console/src/lib/admin/auth.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { authProvider } from "./auth";
+
+const originalFetch = globalThis.fetch;
+
+describe("admin auth provider", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("does not redirect when backend logout fails", async () => {
+    globalThis.fetch = async () => Response.json(
+      { error: "Unable to revoke session" },
+      { status: 502 },
+    );
+
+    const logout = await authProvider.logout();
+
+    expect(logout.success).toBeFalse();
+    expect(logout.redirectTo).toBeUndefined();
+    expect(logout.error?.message).toBe("Unable to revoke session");
+  });
+
+  test("redirects after backend logout succeeds", async () => {
+    globalThis.fetch = async () => Response.json({ success: true });
+
+    await expect(authProvider.logout()).resolves.toEqual({
+      success: true,
+      redirectTo: "/login",
+    });
+  });
+});

--- a/packages/web-console/src/lib/admin/auth.ts
+++ b/packages/web-console/src/lib/admin/auth.ts
@@ -18,7 +18,13 @@ export const authProvider: AuthProvider = {
   },
   
   logout: async () => {
-    await logoutStudio();
+    const result = await logoutStudio();
+    if (!result.success) {
+      return {
+        success: false,
+        error: new Error(result.error)
+      };
+    }
     return {
       success: true,
       redirectTo: '/login'

--- a/packages/web-console/src/lib/api.test.ts
+++ b/packages/web-console/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { apiClient, getStudioSession, loginStudio, logoutStudio } from "./api";
+import { apiClient, ensureMutationSucceeded, getStudioSession, loginStudio, logoutStudio } from "./api";
 
 const originalFetch = globalThis.fetch;
 const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
@@ -13,6 +13,23 @@ describe("apiClient", () => {
     } else {
       Reflect.deleteProperty(globalThis, "window");
     }
+  });
+
+  test("mutation helper rejects HTTP and business-level failures", async () => {
+    await expect(ensureMutationSucceeded(
+      Response.json({ message: "Delete denied" }, { status: 403 }),
+      "Delete failed",
+    )).rejects.toThrow("Delete denied");
+    await expect(ensureMutationSucceeded(
+      new Response("Storage unavailable", { status: 503 }),
+      "Delete failed",
+    )).rejects.toThrow("Storage unavailable");
+    await expect(ensureMutationSucceeded(
+      Response.json({ success: false, error: "Operation rejected" }),
+      "Delete failed",
+    )).rejects.toThrow("Operation rejected");
+    await expect(ensureMutationSucceeded(new Response(null, { status: 204 }), "Delete failed"))
+      .resolves.toBeUndefined();
   });
 
   test("normalizes empty error responses to JSON", async () => {
@@ -73,6 +90,33 @@ describe("apiClient", () => {
     });
   });
 
+  test("removes merged AbortSignal listeners after a normal request", async () => {
+    const controller = new AbortController();
+    const signal = controller.signal as AbortSignal & {
+      addEventListener: AbortSignal["addEventListener"];
+      removeEventListener: AbortSignal["removeEventListener"];
+    };
+    const originalAdd = signal.addEventListener.bind(signal);
+    const originalRemove = signal.removeEventListener.bind(signal);
+    let adds = 0;
+    let removes = 0;
+    signal.addEventListener = ((...args: Parameters<AbortSignal["addEventListener"]>) => {
+      adds += 1;
+      return originalAdd(...args);
+    }) as AbortSignal["addEventListener"];
+    signal.removeEventListener = ((...args: Parameters<AbortSignal["removeEventListener"]>) => {
+      removes += 1;
+      return originalRemove(...args);
+    }) as AbortSignal["removeEventListener"];
+    globalThis.fetch = async () => Response.json({ ok: true });
+
+    const response = await apiClient("/v1/projects", { signal });
+
+    expect(response.ok).toBeTrue();
+    expect(adds).toBe(1);
+    expect(removes).toBe(1);
+  });
+
   test("allows SQL requests to disable the client timeout", async () => {
     globalThis.fetch = async (_input, init) => new Promise<Response>((resolve, reject) => {
       const completion = setTimeout(() => resolve(Response.json({ ok: true })), 5);
@@ -114,13 +158,61 @@ describe("apiClient", () => {
       username: "admin",
       expiresAt: "2026-07-24T03:00:00.000Z",
     });
-    expect(logout).toBe(true);
+    expect(logout).toEqual({ success: true });
     expect(calls.map(call => [call.input, call.init?.method, call.init?.credentials])).toEqual([
       ["/auth/login", "POST", "include"],
       ["/auth/session", "GET", "include"],
       ["/auth/logout", "POST", "include"],
     ]);
     expect(JSON.stringify(login)).not.toContain("token");
+  });
+
+  test("preserves the local session state and reports the backend logout error", async () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: { pathname: "/projects", href: "https://console.example.com/projects" } },
+    });
+    const calls: string[] = [];
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      calls.push(url);
+      if (url === "/auth/session") {
+        return Response.json({
+          valid: true,
+          expires_at: new Date(Date.now() + 30_000).toISOString(),
+        });
+      }
+      if (url === "/auth/logout") {
+        return Response.json({ message: "Session store unavailable" }, { status: 503 });
+      }
+      if (url === "/auth/refresh") {
+        return Response.json({
+          success: true,
+          expires_at: new Date(Date.now() + 15 * 60_000).toISOString(),
+        });
+      }
+      return Response.json({ ok: true });
+    };
+
+    await getStudioSession();
+    const logout = await logoutStudio();
+    const response = await apiClient("/v1/projects");
+
+    expect(logout).toEqual({ success: false, error: "Session store unavailable" });
+    expect(response.ok).toBeTrue();
+    expect(calls).toEqual(["/auth/session", "/auth/logout", "/auth/refresh", "/v1/projects"]);
+  });
+
+  test("reports a plain-text backend logout error", async () => {
+    globalThis.fetch = async () => new Response("Logout service unavailable", {
+      status: 503,
+      headers: { "Content-Type": "text/plain" },
+    });
+
+    await expect(logoutStudio()).resolves.toEqual({
+      success: false,
+      error: "Logout service unavailable",
+    });
   });
 
   test("preserves a managed API 401 when the cookie session remains valid", async () => {

--- a/packages/web-console/src/lib/api.ts
+++ b/packages/web-console/src/lib/api.ts
@@ -13,6 +13,10 @@ export type StudioLoginResult =
   | { success: true; username?: string }
   | { success: false; error: string };
 
+export type StudioLogoutResult =
+  | { success: true }
+  | { success: false; error: string };
+
 export interface StudioSessionState {
   authenticated: boolean;
   username?: string;
@@ -21,6 +25,21 @@ export interface StudioSessionState {
 
 export interface ApiRequestInit extends RequestInit {
   timeoutMs?: number;
+}
+
+export async function ensureMutationSucceeded(response: Response, fallback: string): Promise<void> {
+  const [payload, rawBody] = await Promise.all([
+    readJsonObject(response.clone()),
+    response.text().catch(() => ""),
+  ]);
+  if (response.ok && payload.success !== false) return;
+
+  const message = typeof payload.message === "string"
+    ? payload.message
+    : typeof payload.error === "string"
+      ? payload.error
+      : rawBody.trim() || fallback;
+  throw new Error(message);
 }
 
 async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
@@ -40,6 +59,18 @@ function rememberStudioSessionExpiry(candidate: unknown): string | undefined {
 
 function clearStudioSessionExpiry(): void {
   studioSessionExpiresAtMs = 0;
+}
+
+async function logoutErrorMessage(response: Response): Promise<string> {
+  const [payload, rawBody] = await Promise.all([
+    readJsonObject(response.clone()),
+    response.text().catch(() => ""),
+  ]);
+  return typeof payload.error === "string"
+    ? payload.error
+    : typeof payload.message === "string"
+      ? payload.message
+      : rawBody.trim() || response.statusText || "Logout failed";
 }
 
 export async function loginStudio(username: string, password: string): Promise<StudioLoginResult> {
@@ -99,14 +130,17 @@ export async function refreshStudioSession(): Promise<StudioSessionState> {
   };
 }
 
-export async function logoutStudio(): Promise<boolean> {
+export async function logoutStudio(): Promise<StudioLogoutResult> {
   const response = await fetch("/auth/logout", {
     method: "POST",
     credentials: "include",
     headers: { "Accept": "application/json" },
   });
+  if (!response.ok) {
+    return { success: false, error: await logoutErrorMessage(response) };
+  }
   clearStudioSessionExpiry();
-  return response.ok;
+  return { success: true };
 }
 
 async function refreshExpiringStudioSession(): Promise<void> {
@@ -131,12 +165,16 @@ async function refreshExpiringStudioSession(): Promise<void> {
   }
 }
 
-function mergeAbortSignals(signals: Array<AbortSignal | null | undefined>): AbortSignal | undefined {
+function mergeAbortSignals(signals: Array<AbortSignal | null | undefined>): {
+  signal: AbortSignal | undefined;
+  cleanup: () => void;
+} {
   const validSignals = signals.filter(Boolean) as AbortSignal[];
-  if (validSignals.length === 0) return undefined;
-  if (validSignals.length === 1) return validSignals[0];
+  if (validSignals.length === 0) return { signal: undefined, cleanup: () => {} };
+  if (validSignals.length === 1) return { signal: validSignals[0], cleanup: () => {} };
 
   const controller = new AbortController();
+  const listeningSignals: AbortSignal[] = [];
   const abort = () => {
     if (!controller.signal.aborted) controller.abort();
   };
@@ -147,9 +185,15 @@ function mergeAbortSignals(signals: Array<AbortSignal | null | undefined>): Abor
       break;
     }
     signal.addEventListener("abort", abort, { once: true });
+    listeningSignals.push(signal);
   }
 
-  return controller.signal;
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const signal of listeningSignals) signal.removeEventListener("abort", abort);
+    },
+  };
 }
 
 async function normalizeErrorResponse(response: Response): Promise<Response> {
@@ -185,14 +229,14 @@ export async function apiClient(url: string, options: ApiRequestInit = {}): Prom
   const timeout = timeoutController
     ? setTimeout(() => timeoutController.abort(), timeoutMs)
     : undefined;
-  const signal = mergeAbortSignals([requestInit.signal, timeoutController?.signal]);
+  const mergedSignal = mergeAbortSignals([requestInit.signal, timeoutController?.signal]);
 
   let response: Response;
   try {
     response = await fetch(url, {
       ...requestInit,
       headers,
-      signal,
+      signal: mergedSignal.signal,
       credentials: requestInit.credentials ?? "include",
     });
   } catch (error) {
@@ -210,6 +254,7 @@ export async function apiClient(url: string, options: ApiRequestInit = {}): Prom
     throw error;
   } finally {
     if (timeout !== undefined) clearTimeout(timeout);
+    mergedSignal.cleanup();
   }
 
   response = await normalizeErrorResponse(response);

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -147,9 +147,14 @@
 
   async function handleLogout() {
     try {
-      await logoutStudio();
-    } finally {
+      const result = await logoutStudio();
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
       window.location.href = "/login";
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
     }
   }
 

--- a/packages/web-console/src/routes/layout.test.ts
+++ b/packages/web-console/src/routes/layout.test.ts
@@ -22,4 +22,11 @@ describe("root layout source guards", () => {
     expect(loginPageSource).not.toContain('window.location.replace("/")');
     expect(loginPageSource).not.toContain('window.location.href = "/"');
   });
+
+  test("logout redirects only after the backend confirms success", () => {
+    expect(layoutSource).toContain("const result = await logoutStudio();");
+    expect(layoutSource).toContain("if (!result.success)");
+    expect(layoutSource).toContain("toast.error(result.error);");
+    expect(layoutSource).not.toContain("await logoutStudio();\n    } finally {");
+  });
 });

--- a/packages/web-console/src/routes/project/[ref]/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
   import { apiClient } from "$lib/api";
+  import {
+    createProjectLoadToken,
+    isCurrentProjectLoad,
+    type ProjectLoadToken,
+  } from "$lib/project-load-guard";
 
   import { onMount } from "svelte";
   import { resolve } from "$app/paths";
@@ -16,6 +21,16 @@
     status: string;
   }
 
+  type TaskStats = {
+    running: number;
+    retryScheduled: number;
+    deadLettered: number;
+    failedLast24h: number;
+    cancelledLast24h: number;
+    topFailures: Array<{ message: string; count: number }>;
+    failedTrend: Array<{ bucket: string; failures: number }>;
+  };
+
   let isLoading = $state(true);
   let dbSize = $state("-");
   let connections = $state(0);
@@ -31,16 +46,10 @@
   let activeQueries = $state<Record<string, unknown>[]>([]);
   let services = $state<ServiceInfo[]>([]);
   let servicesLoading = $state(true);
-  let taskStats = $state<{
-    running: number;
-    retryScheduled: number;
-    deadLettered: number;
-    failedLast24h: number;
-    cancelledLast24h: number;
-    topFailures: Array<{ message: string; count: number }>;
-    failedTrend: Array<{ bucket: string; failures: number }>;
-  } | null>(null);
+  let taskStats = $state<TaskStats | null>(null);
   let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  let loadRevision = 0;
+  let loadedProjectRef = "";
 
   const projectRef = $derived(page.params.ref ?? "");
 
@@ -65,13 +74,17 @@
     functions?: {
       count?: number;
     };
-    tasks?: typeof taskStats;
+    tasks?: TaskStats | null;
     active_queries?: Record<string, unknown>[];
   };
 
-  async function runSql(sql: string): Promise<Record<string, unknown>[]> {
+  function isCurrentLoad(loadToken: ProjectLoadToken): boolean {
+    return isCurrentProjectLoad(loadToken, projectRef, loadRevision);
+  }
+
+  async function runSql(ref: string, sql: string): Promise<Record<string, unknown>[]> {
     try {
-      const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
+      const res = await apiClient(`/v1/projects/${ref}/database/sql`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ sql })
@@ -103,9 +116,9 @@
     taskStats = summary.tasks || null;
   }
 
-  async function fetchFunctionsCountLegacy() {
+  async function fetchFunctionsCountLegacy(ref: string): Promise<number> {
     try {
-      const res = await apiClient(`/v1/projects/${projectRef}/functions`);
+      const res = await apiClient(`/v1/projects/${ref}/functions`);
       if (!res.ok) return 0;
       const data = await res.json();
       return Array.isArray(data) ? data.length : 0;
@@ -114,39 +127,44 @@
     }
   }
 
-  async function refreshAuthRuntimeOwner(): Promise<boolean> {
+  async function refreshAuthRuntimeOwner(ref: string, loadToken: ProjectLoadToken): Promise<boolean> {
     try {
-      const response = await apiClient(`/v1/projects/${projectRef}/auth/runtime`);
-      if (!response.ok) return false;
+      const response = await apiClient(`/v1/projects/${ref}/auth/runtime`);
+      if (!response.ok || !isCurrentLoad(loadToken)) return false;
       const runtime = await response.json() as {
         mode?: "local" | "owner" | "shared";
         authority_project_ref?: string;
       };
+      if (!isCurrentLoad(loadToken)) return false;
       authManagedByRef = runtime.mode === "shared" && runtime.authority_project_ref
         ? runtime.authority_project_ref
         : null;
       return true;
     } catch {
-      // Dashboard summary remains the primary source; this is only a safe fallback.
       return false;
     }
   }
 
-  async function fetchDashboardLegacy(authRuntimeKnown: boolean) {
+  async function fetchDashboardLegacy(
+    ref: string,
+    loadToken: ProjectLoadToken,
+    authRuntimeKnown: boolean,
+  ): Promise<void> {
     const canReadLocalAuth = authRuntimeKnown && !authManagedByRef;
     const [dbInfo, connInfo, userInfo, tableInfo, indexInfo, storageInfo, recentUserInfo, activeInfo] = await Promise.all([
-      runSql(`SELECT pg_size_pretty(pg_database_size(current_database())) as size,
+      runSql(ref, `SELECT pg_size_pretty(pg_database_size(current_database())) as size,
               (SELECT round(100.0 * blks_hit / NULLIF(blks_hit + blks_read, 0), 1) FROM pg_stat_database WHERE datname = current_database()) as cache_ratio;`),
-      runSql(`SELECT count(*) as active FROM pg_stat_activity WHERE backend_type = 'client backend';`),
-      canReadLocalAuth ? runSql(`SELECT count(*) as total FROM auth.users;`) : Promise.resolve([]),
-      runSql(`SELECT count(*) as cnt FROM pg_stat_user_tables;`),
-      runSql(`SELECT count(*) as cnt FROM pg_stat_user_indexes;`),
-      runSql(`SELECT pg_size_pretty(coalesce(sum(CASE WHEN metadata->>'size' ~ '^[0-9]+$' THEN (metadata->>'size')::bigint ELSE 0 END), 0)) as size FROM storage.objects;`),
+      runSql(ref, `SELECT count(*) as active FROM pg_stat_activity WHERE backend_type = 'client backend';`),
+      canReadLocalAuth ? runSql(ref, `SELECT count(*) as total FROM auth.users;`) : Promise.resolve([]),
+      runSql(ref, `SELECT count(*) as cnt FROM pg_stat_user_tables;`),
+      runSql(ref, `SELECT count(*) as cnt FROM pg_stat_user_indexes;`),
+      runSql(ref, `SELECT pg_size_pretty(coalesce(sum(CASE WHEN metadata->>'size' ~ '^[0-9]+$' THEN (metadata->>'size')::bigint ELSE 0 END), 0)) as size FROM storage.objects;`),
       canReadLocalAuth
-        ? runSql(`SELECT email, created_at::text FROM auth.users ORDER BY created_at DESC LIMIT 5;`)
+        ? runSql(ref, `SELECT email, created_at::text FROM auth.users ORDER BY created_at DESC LIMIT 5;`)
         : Promise.resolve([]),
-      runSql(`SELECT pid, usename, state, left(query, 80) as query FROM pg_stat_activity WHERE backend_type = 'client backend' AND state = 'active' LIMIT 5;`),
+      runSql(ref, `SELECT pid, usename, state, left(query, 80) as query FROM pg_stat_activity WHERE backend_type = 'client backend' AND state = 'active' LIMIT 5;`),
     ]);
+    if (!isCurrentLoad(loadToken)) return;
 
     if (dbInfo[0]) {
       dbSize = String(dbInfo[0].size || "-");
@@ -159,58 +177,97 @@
     if (storageInfo[0]) storageSize = String(storageInfo[0].size || "0 bytes");
     recentUsers = authManagedByRef ? [] : recentUserInfo;
     activeQueries = activeInfo;
-    functionsCount = await fetchFunctionsCountLegacy();
-    await fetchTaskStats();
+
+    const nextFunctionsCount = await fetchFunctionsCountLegacy(ref);
+    if (!isCurrentLoad(loadToken)) return;
+    functionsCount = nextFunctionsCount;
+    await fetchTaskStats(ref, loadToken);
   }
 
-  async function fetchDashboard() {
-    isLoading = true;
+  async function fetchDashboard(ref: string, loadToken: ProjectLoadToken): Promise<void> {
     try {
-      const res = await apiClient(`/v1/projects/${projectRef}/dashboard/summary`);
+      const res = await apiClient(`/v1/projects/${ref}/dashboard/summary`);
       if (!res.ok) throw new Error("summary unavailable");
-      applyDashboardSummary(await res.json());
+      const summary = await res.json() as DashboardSummary;
+      if (isCurrentLoad(loadToken)) applyDashboardSummary(summary);
     } catch {
-      const authRuntimeKnown = await refreshAuthRuntimeOwner();
-      await fetchDashboardLegacy(authRuntimeKnown);
+      const authRuntimeKnown = await refreshAuthRuntimeOwner(ref, loadToken);
+      if (!isCurrentLoad(loadToken)) return;
+      await fetchDashboardLegacy(ref, loadToken, authRuntimeKnown);
     } finally {
-      isLoading = false;
+      if (isCurrentLoad(loadToken)) isLoading = false;
     }
   }
 
-  async function fetchServices() {
-    servicesLoading = true;
+  async function fetchServices(ref: string, loadToken: ProjectLoadToken): Promise<void> {
     try {
-      const res = await apiClient(`/v1/projects/${projectRef}/services`);
+      const res = await apiClient(`/v1/projects/${ref}/services`);
       if (res.ok) {
         const data = await res.json();
-        services = Array.isArray(data) ? data : (data.services || []);
+        if (isCurrentLoad(loadToken)) {
+          services = Array.isArray(data) ? data : (data.services || []);
+        }
       }
-    } catch {}
-    servicesLoading = false;
+    } catch {
+      // 服务状态是次要信息；请求失败时保留最近一次可用状态。
+    }
+    if (isCurrentLoad(loadToken)) servicesLoading = false;
   }
 
-  async function fetchTaskStats() {
+  async function fetchTaskStatsValue(ref: string): Promise<TaskStats | null> {
     try {
-      const res = await apiClient(`/v1/projects/${projectRef}/tasks/stats`);
-      if (res.ok) {
-        taskStats = await res.json();
-      }
-    } catch {}
+      const res = await apiClient(`/v1/projects/${ref}/tasks/stats`);
+      return res.ok ? await res.json() as TaskStats : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function fetchTaskStats(ref: string, loadToken: ProjectLoadToken): Promise<void> {
+    const nextTaskStats = await fetchTaskStatsValue(ref);
+    if (nextTaskStats && isCurrentLoad(loadToken)) taskStats = nextTaskStats;
+  }
+
+  function resetProjectDashboardState(): void {
+    dbSize = "-";
+    connections = 0;
+    maxConnections = 100;
+    totalUsers = 0;
+    cacheHitRatio = 0;
+    storageSize = "0 bytes";
+    functionsCount = 0;
+    tableCount = 0;
+    indexCount = 0;
+    recentUsers = [];
+    activeQueries = [];
+    services = [];
+    taskStats = null;
+    authManagedByRef = null;
+  }
+
+  function loadProject(ref: string): void {
+    if (ref !== loadedProjectRef) {
+      loadedProjectRef = ref;
+      resetProjectDashboardState();
+    }
+    loadRevision += 1;
+    const loadToken = createProjectLoadToken(ref, loadRevision);
+    isLoading = true;
+    servicesLoading = true;
+    void fetchDashboard(ref, loadToken);
+    void fetchServices(ref, loadToken);
   }
 
   $effect(() => {
-    // Explicitly reference projectRef to trigger re-fetch on URL change
-    const _currentRef = projectRef;
-    if (_currentRef) {
-      fetchDashboard();
-      fetchServices();
-    }
+    const ref = projectRef;
+    if (ref) loadProject(ref);
   });
 
   onMount(() => {
     autoRefreshTimer = setInterval(() => {
       if (projectRef) {
-        fetchTaskStats();
+        const loadToken = createProjectLoadToken(projectRef, loadRevision);
+        void fetchTaskStats(projectRef, loadToken);
       }
     }, 30000);
 
@@ -262,7 +319,7 @@
       <h1 class="text-2xl font-bold">{$t("Dashboard.project_dashboard")}</h1>
       <p class="text-sm text-muted-foreground mt-1">{$t("Dashboard.subtitle") || '项目概览和快速访问导航'}</p>
     </div>
-    <button onclick={() => { fetchDashboard(); fetchServices(); }}
+    <button onclick={() => loadProject(projectRef)}
       class="flex items-center gap-2 px-3 py-2 text-xs rounded-lg border hover:bg-muted/50 transition-colors">
       <RefreshCw size={12} />
       {$t("Logs.refresh") || '刷新'}

--- a/packages/web-console/src/routes/project/[ref]/hosting/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/hosting/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { apiClient } from "$lib/api";
+  import { apiClient, ensureMutationSucceeded } from "$lib/api";
 
   import { page } from "$app/state";
   import { goto } from "$app/navigation";
@@ -30,9 +30,8 @@
 
   const redeployMutation = createMutation(() => ({
     mutationFn: async (id: string) => {
-      const res = await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${id}/redeploy`, { method: "POST" });
-      const data = await res.json();
-      if (data.success === false) throw new Error(data.error || '部署失败');
+      const response = await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${id}/redeploy`, { method: "POST" });
+      await ensureMutationSucceeded(response, "部署失败");
       return true;
     },
     onSuccess: () => {
@@ -55,7 +54,8 @@
 
   const deleteMutation = createMutation(() => ({
     mutationFn: async (id: string) => {
-      await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${id}`, { method: "DELETE" });
+      const response = await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${id}`, { method: "DELETE" });
+      await ensureMutationSucceeded(response, "删除部署失败");
       return true;
     },
     onMutate: (id) => {
@@ -64,6 +64,9 @@
     onSuccess: () => {
       actionMsg = "✅ 部署已删除";
       query.refetch();
+    },
+    onError: (error: unknown) => {
+      actionMsg = `❌ ${error instanceof Error ? error.message : String(error)}`;
     },
     onSettled: () => {
       deletingId = null;

--- a/packages/web-console/src/routes/project/[ref]/hosting/[id]/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/hosting/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { apiClient } from "$lib/api";
+  import { apiClient, ensureMutationSucceeded } from "$lib/api";
 
   import { page } from "$app/state";
   import { Loader2, Save, Key, Globe, GitBranch, Terminal, Copy, RefreshCw, Trash2, Plus, ExternalLink, Upload } from "lucide-svelte";
@@ -212,11 +212,16 @@
 
   const removeDomainMutation = createMutation(() => ({
     mutationFn: async (domain: string) => {
-      await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${deployId}/domains/${domain}`, { method: "DELETE" });
+      const response = await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${deployId}/domains/${domain}`, { method: "DELETE" });
+      await ensureMutationSucceeded(response, "删除域名失败");
       return true;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["deployment", projectRef, deployId] });
+    },
+    onError: (error: unknown) => {
+      actionMsg = `❌ ${error instanceof Error ? error.message : String(error)}`;
+      setTimeout(() => actionMsg = null, 4000);
     }
   }));
 
@@ -248,11 +253,16 @@
 
   const deleteTokenMutation = createMutation(() => ({
     mutationFn: async (tokenId: string) => {
-      await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${deployId}/tokens/${tokenId}`, { method: "DELETE" });
+      const response = await apiClient(`/v1/projects/${projectRef}/frontend/deployments/${deployId}/tokens/${tokenId}`, { method: "DELETE" });
+      await ensureMutationSucceeded(response, "删除访问令牌失败");
       return true;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["deployment_tokens", projectRef, deployId] });
+    },
+    onError: (error: unknown) => {
+      actionMsg = `❌ ${error instanceof Error ? error.message : String(error)}`;
+      setTimeout(() => actionMsg = null, 4000);
     }
   }));
 

--- a/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
@@ -29,4 +29,17 @@ describe("hosting deployment entrypoints", () => {
     expect(pageSource).toContain('$t("Hosting.webhook_trigger")');
     expect(pageSource).toContain('/v1/webhooks/{github|gitlab|gitee|gitcode}');
   });
+
+  test("reports backend deployment deletion failures without showing false success", () => {
+    expect(pageSource).toContain('import { apiClient, ensureMutationSucceeded } from "$lib/api";');
+    expect(pageSource).toContain('await ensureMutationSucceeded(response, "删除部署失败");');
+    expect(pageSource).toContain("onError: (error: unknown) => {");
+    expect(pageSource).toContain("error instanceof Error ? error.message : String(error)");
+  });
+
+  test("checks domain and token deletion responses in deployment settings", () => {
+    expect(settingsSource).toContain('await ensureMutationSucceeded(response, "删除域名失败");');
+    expect(settingsSource).toContain('await ensureMutationSucceeded(response, "删除访问令牌失败");');
+    expect(settingsSource.match(/onError: \(error: unknown\)/g) ?? []).toHaveLength(2);
+  });
 });

--- a/packages/web-console/src/routes/project/[ref]/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/page.test.ts
@@ -9,4 +9,17 @@ describe("project dashboard", () => {
     expect(pageSource).toContain("<!-- Quick Links -->");
     expect(pageSource).not.toContain("<!-- Quick Access Cards -->");
   });
+
+  test("rejects stale dashboard responses after project changes or refreshes", () => {
+    expect(pageSource).toContain("createProjectLoadToken");
+    expect(pageSource).toContain("isCurrentProjectLoad(loadToken, projectRef, loadRevision)");
+    expect(pageSource).toContain("loadRevision += 1;");
+    expect(pageSource).toContain("if (isCurrentLoad(loadToken)) applyDashboardSummary(summary);");
+    expect(pageSource).toContain("if (isCurrentLoad(loadToken)) servicesLoading = false;");
+    expect(pageSource).toContain("if (nextTaskStats && isCurrentLoad(loadToken)) taskStats = nextTaskStats;");
+    expect(pageSource).toContain("resetProjectDashboardState();");
+    expect(pageSource).toContain("services = [];");
+    expect(pageSource).toContain("authManagedByRef = null;");
+    expect(pageSource).toContain("onclick={() => loadProject(projectRef)}");
+  });
 });

--- a/scripts/lib/storage_manager.sh
+++ b/scripts/lib/storage_manager.sh
@@ -7,7 +7,6 @@ set -e
 
 COMMAND=$1
 TARGET=$2
-OPTIONS=$3
 
 MOUNT_POINT="/mnt/juicefs"
 # Default points to local Supabase-specific JuiceFS metadata database
@@ -30,7 +29,8 @@ case $COMMAND in
     migrate_to_s3)
         # Migrate to S3
         # TARGET: S3_URL (e.g., s3://mybucket)
-        # OPTIONS: JSON string with access_key and secret_key
+        # Credentials are read from stdin so they never appear in process arguments.
+        OPTIONS=$(cat)
         S3_URL=$TARGET
         ACCESS_KEY=$(echo "$OPTIONS" | jq -r .access_key)
         SECRET_KEY=$(echo "$OPTIONS" | jq -r .secret_key)
@@ -64,7 +64,7 @@ case $COMMAND in
         ;;
 
     *)
-        echo "Usage: $0 {status|migrate_to_s3} [target] [options]"
+        echo "Usage: $0 {status|migrate_to_s3} [target]"
         exit 1
         ;;
 esac

--- a/scripts/test_supacloud_caddy_edge_proxy.sh
+++ b/scripts/test_supacloud_caddy_edge_proxy.sh
@@ -25,6 +25,7 @@ edge_log="$work_dir/edge-runtime.log"
 caddy_log="$work_dir/caddy.log"
 edge_pid=""
 caddy_pid=""
+slow_client_pid=""
 
 terminate_process() {
   local pid="$1"
@@ -44,6 +45,7 @@ terminate_process() {
 }
 
 cleanup() {
+  terminate_process "$slow_client_pid"
   terminate_process "$caddy_pid"
   terminate_process "$edge_pid"
   rm -rf "$work_dir"
@@ -175,15 +177,29 @@ if [[ "$caddy_ready" != true ]]; then
   exit 1
 fi
 
-if curl -fsS --max-time 0.2 -H "Host: auth.edge.test" \
-  "http://127.0.0.1:$CADDY_PORT/api/v1/slow" >/dev/null 2>&1; then
-  echo "Expected the client-side timeout probe to disconnect" >&2
-  exit 1
-fi
-if [[ ! -s "$cancel_started_path" ]]; then
+curl -fsS --max-time 10 -H "Host: auth.edge.test" \
+  "http://127.0.0.1:$CADDY_PORT/api/v1/slow" >/dev/null 2>&1 &
+slow_client_pid=$!
+
+slow_started=false
+for _ in $(seq 1 100); do
+  if [[ -s "$cancel_started_path" ]]; then
+    slow_started=true
+    break
+  fi
+  if ! kill -0 "$slow_client_pid" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+if [[ "$slow_started" != true ]]; then
   echo "Client disconnected before the slow Edge Function started" >&2
+  cat "$caddy_log" >&2
+  cat "$edge_log" >&2
   exit 1
 fi
+terminate_process "$slow_client_pid"
+slow_client_pid=""
 
 cancel_released_worker=false
 for _ in $(seq 1 20); do

--- a/scripts/test_supacloud_caddy_edge_proxy.sh
+++ b/scripts/test_supacloud_caddy_edge_proxy.sh
@@ -20,7 +20,7 @@ fi
 work_dir="$(mktemp -d)"
 functions_dir="$work_dir/functions"
 tenants_dir="$work_dir/tenants"
-cancel_started_path="$work_dir/slow-request-started"
+cancel_started_path=""
 edge_log="$work_dir/edge-runtime.log"
 caddy_log="$work_dir/caddy.log"
 edge_pid=""
@@ -53,6 +53,7 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$functions_dir/$PROJECT_REF" "$tenants_dir"
+cancel_started_path="$(cd "$functions_dir/$PROJECT_REF" && pwd -P)/slow-request-started"
 cat >"$tenants_dir/$PROJECT_REF.env" <<EOF
 CANCEL_STARTED_PATH=$cancel_started_path
 EOF


### PR DESCRIPTION
## Summary\n- enforce project-scoped authorization, password policy propagation, lossless deployment history migration, and storage/secret boundaries\n- harden the Bun Edge Runtime against subprocess, native-loader, and filesystem escapes while preserving Deno.serve caching\n- prevent write-request replay, false-success UI flows, stale project responses, and AbortSignal listener leaks\n\n## Validation\n- Management API full local suite, typecheck, and macOS ARM64 compile\n- Edge Runtime: 95 tests, strict typecheck, macOS ARM64 compile, compiled /health smoke\n- Web Console: 163 tests, svelte-check, production build\n- Admin: 48 tests, typecheck, build\n- CLI: 103 tests, typecheck, build\n- SDK: 22 tests, all typechecks, build\n- bash -n install.sh scripts/lib/storage_manager.sh\n- git diff --check\n\n## Runtime note\nSupaCloud Edge Runtime remains BunJS. The public.ecr.aws/supabase/realtime:v2.121.1 image is only used by Realtime.\n\nNo production deployment is included in this PR.