### PR TITLE
fix(edge-runtime): close dynamic import sandbox escapes

### DIFF
--- a/packages/edge-runtime/bun.lock
+++ b/packages/edge-runtime/bun.lock
@@ -9,6 +9,7 @@
         "@sinclair/typebox": "^0.34.52",
         "@supabase/supabase-js": "^2.110.9",
         "elysia": "^1.4.29",
+        "es-module-lexer": "2.3.1",
         "jose": "^6.2.4",
       },
       "devDependencies": {
@@ -104,6 +105,8 @@
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "https://registry.npmmirror.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "elysia": ["elysia@1.4.29", "https://registry.npmmirror.com/elysia/-/elysia-1.4.29.tgz", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.1", "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.3.1.tgz", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
     "exact-mirror": ["exact-mirror@0.2.7", "https://registry.npmmirror.com/exact-mirror/-/exact-mirror-0.2.7.tgz", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 

--- a/packages/edge-runtime/deno-compat.command.test.ts
+++ b/packages/edge-runtime/deno-compat.command.test.ts
@@ -3,9 +3,11 @@ import { syncBuiltinESMExports } from "node:module";
 import {
   disableSubprocessApis,
   FILESYSTEM_DISABLED_MESSAGE,
+  initializeProjectRootControl,
   NATIVE_LOADER_DISABLED_MESSAGE,
-  setProjectRoot,
 } from "./deno-compat";
+
+const setProjectRoot = initializeProjectRootControl();
 
 test("Deno.Command fails closed for every subprocess command", () => {
   const DenoCompat = (globalThis as any).Deno;
@@ -18,6 +20,7 @@ test("Deno.Command fails closed for every subprocess command", () => {
 
 test("the worker subprocess guard disables and restores process creation APIs", async () => {
   const bun = globalThis.Bun as unknown as Record<string, unknown>;
+  const originalBunProperties = Object.getOwnPropertyDescriptors(bun);
   const childProcess = require("node:child_process") as Record<string, unknown>;
   const fs = require("node:fs") as Record<string, unknown>;
   const fsPromises = require("node:fs/promises") as Record<string, unknown>;
@@ -32,6 +35,8 @@ test("the worker subprocess guard disables and restores process creation APIs", 
   const originalBunWrite = bun.write;
   const originalBunDlopen = bun.dlopen;
   const originalFfi = { ...(bun.FFI as Record<string, unknown>) };
+  const ffiRead = (bun.FFI as Record<string, unknown>).read as Record<string, unknown>;
+  const originalFfiRead = { ...ffiRead };
   const originalFfiModule = { ...ffiModule };
   const originalNativeFfi = { ...(ffiModule.native as Record<string, unknown>) };
   const originalWorker = (globalThis as Record<string, unknown>).Worker;
@@ -100,6 +105,7 @@ test("the worker subprocess guard disables and restores process creation APIs", 
     bun.write = originalBunWrite;
     if (originalBunDlopen !== undefined) bun.dlopen = originalBunDlopen;
     Object.assign(bun.FFI as Record<string, unknown>, originalFfi);
+    Object.assign(ffiRead, originalFfiRead);
     Object.assign(ffiModule, originalFfiModule);
     Object.assign(ffiModule.native as Record<string, unknown>, originalNativeFfi);
     (globalThis as Record<string, unknown>).Worker = originalWorker;
@@ -112,6 +118,9 @@ test("the worker subprocess guard disables and restores process creation APIs", 
     moduleApi.createRequire = originalModuleCreateRequire;
     moduleApi._load = originalModuleLoad;
     if (modulePrototype && originalModuleRequire) modulePrototype.require = originalModuleRequire;
+    for (const [name, descriptor] of Object.entries(originalBunProperties)) {
+      if ("value" in descriptor && descriptor.writable) bun[name] = descriptor.value;
+    }
     syncBuiltinESMExports();
   }
 });

--- a/packages/edge-runtime/deno-compat.ts
+++ b/packages/edge-runtime/deno-compat.ts
@@ -14,6 +14,10 @@ export const FILESYSTEM_DISABLED_MESSAGE =
   "Direct file system module access is disabled in the multi-tenant Edge Runtime.";
 export const NATIVE_LOADER_DISABLED_MESSAGE =
   "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.";
+export const DYNAMIC_CODE_DISABLED_MESSAGE =
+  "Dynamic code generation is disabled in the multi-tenant Edge Runtime.";
+export const HOST_RUNTIME_DISABLED_MESSAGE =
+  "Host runtime capabilities are disabled in the multi-tenant Edge Runtime.";
 
 const nodeFs = require("node:fs") as typeof import("node:fs");
 const nodeFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
@@ -33,9 +37,27 @@ const runtimeFs = {
 };
 const runtimeBunFile = Bun.file.bind(Bun);
 const runtimeBunWrite = Bun.write.bind(Bun);
+const DISABLED_BUN_HOST_CAPABILITIES = [
+  "Archive",
+  "FileSystemRouter",
+  "Glob",
+  "Terminal",
+  "cron",
+  "generateHeapSnapshot",
+  "listen",
+  "openInEditor",
+  "serve",
+  "udpSocket",
+];
 
-export function runtimeFile(path: string | URL): ReturnType<typeof Bun.file> {
-  return runtimeBunFile(path);
+let projectRootControlInitialized = false;
+
+export function initializeProjectRootControl(): (root: string | null) => void {
+  if (projectRootControlInitialized) {
+    throw new Error("Project root control is already initialized.");
+  }
+  projectRootControlInitialized = true;
+  return setProjectRoot;
 }
 
 export function getCapturedServeHandler() {
@@ -62,7 +84,10 @@ export function disableSubprocessApis(): void {
     bun.$ = subprocessDisabled;
     bun.spawn = subprocessDisabled;
     bun.spawnSync = subprocessDisabled;
+    bun.build = dynamicCodeDisabled;
+    if (typeof bun.mmap === "function") bun.mmap = filesystemDisabled;
     if (typeof bun.dlopen === "function") bun.dlopen = nativeLoaderDisabled;
+    disableBunHostCapabilities(bun);
     bun.file = (...args: unknown[]) => {
       assertPathInProject(args[0]);
       return (runtimeBunFile as unknown as (...fileArgs: unknown[]) => unknown)(...args);
@@ -76,8 +101,14 @@ export function disableSubprocessApis(): void {
     // 必须在加载租户模块前禁用，否则可绕过 Bun.spawn 直接调用 libc system()。
     const ffi = bun.FFI as Record<string, unknown> | undefined;
     if (ffi) {
-      for (const name of ["callback", "dlopen", "linkSymbols"]) {
-        ffi[name] = subprocessDisabled;
+      for (const name of Object.getOwnPropertyNames(ffi)) {
+        if (typeof ffi[name] === "function") ffi[name] = nativeLoaderDisabled;
+      }
+      const ffiRead = ffi.read as Record<string, unknown> | undefined;
+      if (ffiRead) {
+        for (const name of Object.getOwnPropertyNames(ffiRead)) {
+          if (typeof ffiRead[name] === "function") ffiRead[name] = nativeLoaderDisabled;
+        }
       }
     }
   }
@@ -127,6 +158,68 @@ export function disableSubprocessApis(): void {
     modulePrototype.require = nativeLoaderDisabled;
   }
   syncBuiltinESMExports();
+}
+
+function disableBunHostCapabilities(bun: Record<string, unknown>): void {
+  for (const name of DISABLED_BUN_HOST_CAPABILITIES) {
+    if (Object.getOwnPropertyDescriptor(bun, name)?.writable) {
+      bun[name] = hostRuntimeDisabled;
+    }
+  }
+}
+
+export function guardDynamicCodeApis(validateSource: (source: string) => void): void {
+  const constructors: Function[] = [
+    Function,
+    Object.getPrototypeOf(async function () {}).constructor,
+    Object.getPrototypeOf(function* () {}).constructor,
+    Object.getPrototypeOf(async function* () {}).constructor,
+  ];
+
+  Object.defineProperty(globalThis, "eval", {
+    configurable: false,
+    value: dynamicCodeDisabled,
+    writable: false,
+  });
+  for (const originalConstructor of constructors) {
+    installGuardedCodeConstructor(originalConstructor, validateSource);
+  }
+}
+
+function installGuardedCodeConstructor(
+  originalConstructor: Function,
+  validateSource: (source: string) => void,
+): void {
+  const guardedConstructor = function (this: unknown, ...args: unknown[]) {
+    for (const argument of args) validateSource(String(argument));
+    return Reflect.apply(originalConstructor, this, args);
+  };
+  Object.setPrototypeOf(guardedConstructor, Object.getPrototypeOf(originalConstructor));
+  Object.defineProperty(guardedConstructor, "prototype", { value: originalConstructor.prototype });
+  Object.defineProperty(originalConstructor.prototype, "constructor", {
+    configurable: false,
+    value: guardedConstructor,
+    writable: false,
+  });
+  if (originalConstructor === Function) {
+    Object.defineProperty(globalThis, "Function", {
+      configurable: false,
+      value: guardedConstructor,
+      writable: false,
+    });
+  }
+}
+
+function dynamicCodeDisabled(): never {
+  throw new Error(DYNAMIC_CODE_DISABLED_MESSAGE);
+}
+
+function filesystemDisabled(): never {
+  throw new Error(FILESYSTEM_DISABLED_MESSAGE);
+}
+
+function hostRuntimeDisabled(): never {
+  throw new Error(HOST_RUNTIME_DISABLED_MESSAGE);
 }
 
 function guardFunctionExports(
@@ -283,7 +376,7 @@ const projectPathContext = new AsyncLocalStorage<ProjectPathContext | null>();
 let activeProjectPathContext: ProjectPathContext | null = null;
 let injectedEnvRef: Record<string, string> = {};
 
-export function setProjectRoot(root: string | null) {
+function setProjectRoot(root: string | null) {
   if (!root) {
     activeProjectPathContext = null;
     projectPathContext.enterWith(null);
@@ -333,12 +426,17 @@ function currentProjectPathContext(): ProjectPathContext | null {
 function assertPathInContext(value: unknown, context: ProjectPathContext): void {
   const requestedPath = filesystemPath(value);
   const resolved = path.resolve(requestedPath);
-  if (!isPathInside(resolved, context.lexicalRoot)) {
+  const base = isPathInside(resolved, context.lexicalRoot)
+    ? context.lexicalRoot
+    : isPathInside(resolved, context.realRoot)
+      ? context.realRoot
+      : null;
+  if (!base) {
     throw new Error(`Access denied: path "${requestedPath}" is outside the allowed directory`);
   }
 
-  const relative = path.relative(context.lexicalRoot, resolved);
-  let prefix = context.lexicalRoot;
+  const relative = path.relative(base, resolved);
+  let prefix = base;
   for (const segment of relative.split(path.sep).filter(Boolean)) {
     prefix = path.join(prefix, segment);
     try {

--- a/packages/edge-runtime/fetch-tls-policy.test.ts
+++ b/packages/edge-runtime/fetch-tls-policy.test.ts
@@ -63,7 +63,7 @@ describe("Edge fetch TLS policy", () => {
         SUPACLOUD_EDGE_TLS_CA_FILE: "/tenant/ca-file-is-ignored.pem",
       }, {
         SUPACLOUD_EDGE_TLS_CA_FILE: caPath,
-      });
+      }, (path) => Bun.file(path).text());
       const init = await captureFetchInit(policy);
       expect(init.tls?.ca).toContain("file");
     } finally {

--- a/packages/edge-runtime/fetch-tls-policy.ts
+++ b/packages/edge-runtime/fetch-tls-policy.ts
@@ -1,5 +1,3 @@
-import { runtimeFile } from "./deno-compat";
-
 type FetchLike = typeof globalThis.fetch;
 
 export type EdgeFetchTlsPolicy = {
@@ -22,6 +20,7 @@ function pickString(value: string | undefined): string | undefined {
 export async function resolveEdgeFetchTlsPolicy(
   env: Record<string, string | undefined>,
   hostEnv: Record<string, string | undefined> = {},
+  readCaFile?: (path: string) => Promise<string>,
 ): Promise<EdgeFetchTlsPolicy> {
   if (
     enabled(env.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY) ||
@@ -37,7 +36,8 @@ export async function resolveEdgeFetchTlsPolicy(
 
   const caFile = pickString(hostEnv.SUPACLOUD_EDGE_TLS_CA_FILE);
   if (caFile) {
-    return { ca: await runtimeFile(caFile).text(), source: "ca-file" };
+    if (!readCaFile) throw new Error("Host CA file reader is unavailable.");
+    return { ca: await readCaFile(caFile), source: "ca-file" };
   }
 
   return { source: "none" };

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -19,6 +19,7 @@
     "@sinclair/typebox": "^0.34.52",
     "@supabase/supabase-js": "^2.110.9",
     "elysia": "^1.4.29",
+    "es-module-lexer": "2.3.1",
     "jose": "^6.2.4"
   },
   "devDependencies": {

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -1,15 +1,22 @@
 import path from "path";
+import { fileURLToPath } from "node:url";
+import {
+  initSync as initModuleLexerSync,
+  parse as parseModuleImports,
+} from "es-module-lexer";
 import {
   assertPathInProject,
   assertRuntimeDependencyPath,
   clearCapturedServeHandler,
+  DYNAMIC_CODE_DISABLED_MESSAGE,
+  guardDynamicCodeApis,
   disableSubprocessApis,
   envWriteLog,
   FILESYSTEM_DISABLED_MESSAGE,
   getCapturedServeHandler,
+  initializeProjectRootControl,
   NATIVE_LOADER_DISABLED_MESSAGE,
   setInjectedEnv,
-  setProjectRoot,
   SUBPROCESS_DISABLED_MESSAGE,
 } from "./deno-compat";
 import { installEdgeFetchTlsPolicy, resolveEdgeFetchTlsPolicy } from "./fetch-tls-policy";
@@ -19,12 +26,20 @@ import { runWithPgredisBinding } from "./internal-bindings";
 const { parentPort } = require("node:worker_threads") as typeof import("node:worker_threads");
 import type { PgredisRuntimeBindingConfig } from "./internal-bindings";
 
+const runtimeBunFile = Bun.file.bind(Bun);
+const setProjectRoot = initializeProjectRootControl();
+
 export function getInjectedEnv(): Record<string, string> {
   return currentInjectedEnv;
 }
 
 if (!parentPort) throw new Error("This file must be run as a Worker");
+initModuleLexerSync();
 disableSubprocessApis();
+guardDynamicCodeApis((source) => {
+  const [generatedImports] = parseModuleImports(source);
+  if (generatedImports.length > 0) throw new Error(DYNAMIC_CODE_DISABLED_MESSAGE);
+});
 
 const MAX_MODULE_CACHE = 20;
 
@@ -138,9 +153,30 @@ const DISABLED_TENANT_MODULES = new Map([
   ["fs/promises", FILESYSTEM_DISABLED_MESSAGE],
   ["node:fs", FILESYSTEM_DISABLED_MESSAGE],
   ["node:fs/promises", FILESYSTEM_DISABLED_MESSAGE],
+  ["bun:jsc", NATIVE_LOADER_DISABLED_MESSAGE],
+  ["inspector", NATIVE_LOADER_DISABLED_MESSAGE],
   ["module", NATIVE_LOADER_DISABLED_MESSAGE],
+  ["node:inspector", NATIVE_LOADER_DISABLED_MESSAGE],
   ["node:module", NATIVE_LOADER_DISABLED_MESSAGE],
+  ["node:v8", NATIVE_LOADER_DISABLED_MESSAGE],
+  ["node:vm", NATIVE_LOADER_DISABLED_MESSAGE],
+  ["v8", NATIVE_LOADER_DISABLED_MESSAGE],
+  ["vm", NATIVE_LOADER_DISABLED_MESSAGE],
 ]);
+
+const COMPUTED_DYNAMIC_IMPORT_DISABLED_MESSAGE =
+  "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.";
+const UNSUPPORTED_MODULE_PROTOCOL_MESSAGE =
+  "Unsupported module URL protocol in the multi-tenant Edge Runtime.";
+const RUNTIME_RESOLVED_MODULE_PREFIXES = [
+  "node:",
+  "bun:",
+  "npm:",
+  "jsr:",
+  "https://deno.land/std",
+  "https://esm.sh/",
+  "https://cdn.skypack.dev/",
+];
 
 function moduleLoader(filePath: string): "js" | "jsx" | "ts" | "tsx" | null {
   if (filePath.endsWith(".tsx")) return "tsx";
@@ -150,9 +186,31 @@ function moduleLoader(filePath: string): "js" | "jsx" | "ts" | "tsx" | null {
   return null;
 }
 
+function isDynamicImportLiteral(source: string, start: number, end: number): boolean {
+  const expression = source.slice(start, end).trim();
+  const quote = expression[0];
+  if ((quote !== "\"" && quote !== "'" && quote !== "`") || expression.length < 2) {
+    return false;
+  }
+
+  for (let index = 1; index < expression.length; index++) {
+    const character = expression[index];
+    if (character === "\\") {
+      index++;
+      continue;
+    }
+    if (quote === "`" && character === "$" && expression[index + 1] === "{") {
+      return false;
+    }
+    if (character === quote) {
+      return expression.slice(index + 1).trim() === "";
+    }
+  }
+  return false;
+}
+
 async function assertTenantModuleGraphSafe(
   entryPath: string,
-  projectRoot: string,
   visited = new Set<string>(),
 ): Promise<void> {
   const resolvedEntry = path.resolve(entryPath);
@@ -163,6 +221,12 @@ async function assertTenantModuleGraphSafe(
   const loader = moduleLoader(resolvedEntry);
   if (!loader) return;
   const source = await Bun.file(resolvedEntry).text();
+  const [moduleImports] = parseModuleImports(source);
+  if (moduleImports.some((imported) => (
+    imported.d >= 0 && !isDynamicImportLiteral(source, imported.s, imported.e)
+  ))) {
+    throw new Error(COMPUTED_DYNAMIC_IMPORT_DISABLED_MESSAGE);
+  }
   const imports = new Bun.Transpiler({ loader })
     .scanImports(source);
   for (const imported of imports) {
@@ -170,18 +234,26 @@ async function assertTenantModuleGraphSafe(
     if (disabledMessage) {
       throw new Error(disabledMessage);
     }
-    if (!imported.path.startsWith(".") && !path.isAbsolute(imported.path)) continue;
-
     let dependencyPath = imported.path;
-    if (!path.isAbsolute(dependencyPath)) {
+    if (dependencyPath.startsWith("file:")) {
+      dependencyPath = fileURLToPath(dependencyPath);
+    } else if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(dependencyPath)) {
+      if (RUNTIME_RESOLVED_MODULE_PREFIXES.some((prefix) => dependencyPath.startsWith(prefix))) {
+        continue;
+      }
+      throw new Error(UNSUPPORTED_MODULE_PROTOCOL_MESSAGE);
+    } else if (!dependencyPath.startsWith(".") && !path.isAbsolute(dependencyPath)) {
+      continue;
+    } else if (!path.isAbsolute(dependencyPath)) {
       try {
         dependencyPath = Bun.resolveSync(imported.path, path.dirname(resolvedEntry));
       } catch {
         continue;
       }
     }
-    const relative = path.relative(projectRoot, dependencyPath);
-    if (relative !== "" && (relative.startsWith("..") || path.isAbsolute(relative))) {
+    try {
+      assertPathInProject(dependencyPath);
+    } catch {
       try {
         assertRuntimeDependencyPath(dependencyPath);
       } catch {
@@ -189,7 +261,7 @@ async function assertTenantModuleGraphSafe(
       }
       continue;
     }
-    await assertTenantModuleGraphSafe(dependencyPath, projectRoot, visited);
+    await assertTenantModuleGraphSafe(dependencyPath, visited);
   }
 }
 
@@ -205,7 +277,11 @@ let retiring = false;
 async function resolveMessageTlsPolicy(
   tlsPolicy: EdgeFetchTlsPolicy | undefined,
 ): Promise<EdgeFetchTlsPolicy> {
-  return tlsPolicy ?? await resolveEdgeFetchTlsPolicy(currentInjectedEnv, originalProcessEnv);
+  return tlsPolicy ?? await resolveEdgeFetchTlsPolicy(
+    currentInjectedEnv,
+    originalProcessEnv,
+    (caFile) => runtimeBunFile(caFile).text(),
+  );
 }
 
 function injectEnv(env: Record<string, string>) {
@@ -329,7 +405,7 @@ async function loadModule(input: {
 
   evictOldestModule();
 
-  await assertTenantModuleGraphSafe(input.functionPath, input.projectRoot);
+  await assertTenantModuleGraphSafe(input.functionPath);
   const handler = await importModuleHandler(
     buildModuleImportUrl(input.functionPath, moduleVersion),
   );

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -634,6 +634,8 @@ async function onParentMessage(msg: unknown): Promise<void> {
   const { functionId, functionPath, projectRoot, env, tlsPolicy, url, method, headers, body, internalBindings } = msg;
 
   const projectRef = msg.projectRef || extractProjectRef(functionId);
+  const requestAbortController = new AbortController();
+  currentAbortController = requestAbortController;
   let restoreFetchTlsPolicy = () => {};
 
   try {
@@ -652,9 +654,15 @@ async function onParentMessage(msg: unknown): Promise<void> {
       moduleVersion: msg.moduleVersion,
       projectRef,
     });
+    // Retirement may arrive while module loading is suspended. Do not enter
+    // tenant code after the worker has already closed its parent port.
+    if (requestAbortController.signal.aborted) {
+      const abortReason = requestAbortController.signal.reason;
+      throw abortReason instanceof Error
+        ? abortReason
+        : new DOMException("Task cancelled", "AbortError");
+    }
     const handler = moduleLoad.handler;
-    const requestAbortController = new AbortController();
-    currentAbortController = requestAbortController;
     await runWithPgredisBinding(internalBindings
       ? { ...internalBindings, signal: requestAbortController.signal }
       : undefined, async () => {

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -1318,7 +1318,7 @@ describe("WorkerPool cooperative retirement", () => {
       expect(exceeded).toEqual(["count"]);
       expect(pool.snapshotMetrics("retirement")["retirement_retirement_budget_exceeded"]).toBe(1);
       expect((await dispatchSlow()).status).toBe(503);
-      await waitForMetric(pool, "total_natural_worker_exits", 2);
+      await waitForMetric(pool, "total_natural_worker_exits", 2, 5_000);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -1364,7 +1364,7 @@ describe("WorkerPool cooperative retirement", () => {
       expect(exceeded).toEqual(["age"]);
       await Bun.sleep(50);
       expect(exceeded).toEqual(["age"]);
-      await waitForMetric(pool, "total_natural_worker_exits", 1);
+      await waitForMetric(pool, "total_natural_worker_exits", 1, 5_000);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -34,7 +34,8 @@ async function waitForMetric(
     if (pool.snapshotMetrics("test")[`test_${metric}`] === expected) return;
     await Bun.sleep(10);
   }
-  throw new Error(`Timed out waiting for ${metric}=${expected}`);
+  const currentMetricValue = pool.snapshotMetrics("test")[`test_${metric}`];
+  throw new Error(`Timed out waiting for ${metric}=${expected}; current=${currentMetricValue}`);
 }
 
 async function waitForResponse(
@@ -1036,6 +1037,45 @@ describe("WorkerPool cancellation and replacement", () => {
     }
   });
 
+  test("cancels a request while its module is initializing", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-load-cancel-"));
+    const loadingPath = join(projectRoot, "loading.txt");
+    const handlerPath = join(projectRoot, "handler.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      await Bun.write(process.env.LOADING_PATH, "loading");
+      await Bun.sleep(100);
+      export default async function fetch() {
+        await Bun.write(process.env.HANDLER_PATH, "entered");
+        return new Response("late", { status: 200 });
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    const controller = new AbortController();
+    pools.push(pool);
+
+    try {
+      const responsePromise = pool.dispatch({
+        functionId: "proj_load_cancel",
+        functionPath,
+        projectRoot,
+        env: { HANDLER_PATH: handlerPath, LOADING_PATH: loadingPath },
+        request: new Request("http://edge.local/functions/v1/load-cancel", {
+          signal: controller.signal,
+        }),
+      });
+      await waitForFile(loadingPath);
+      controller.abort();
+
+      expect((await responsePromise).status).toBe(499);
+      expect(existsSync(handlerPath)).toBe(false);
+      expect(pool.snapshotMetrics("cancel")["cancel_idle_workers"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("isolates HTTP aborts when requests share an external cancel key", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-duplicate-cancel-key-"));
     const firstStartedPath = join(projectRoot, "first-started.txt");
@@ -1278,6 +1318,42 @@ describe("WorkerPool cancellation and replacement", () => {
 });
 
 describe("WorkerPool cooperative retirement", () => {
+  test("retires a worker that times out during module initialization", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-retirement-load-"));
+    const functionPath = join(projectRoot, "slow-load.ts");
+    await Bun.write(functionPath, `
+      await Bun.sleep(100);
+      export default async function fetch(request) {
+        await new Promise((resolve) => {
+          const keepAlive = setInterval(() => {}, 10);
+          request.signal.addEventListener("abort", () => {
+            clearInterval(keepAlive);
+            resolve();
+          }, { once: true });
+        });
+        return new Response("retired");
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 25 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_retirement_load",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/slow-load"),
+      });
+      expect(response.status).toBe(504);
+      await waitForMetric(pool, "total_natural_worker_exits", 1);
+      expect(pool.snapshotMetrics("retirement")["retirement_retired_workers"]).toBe(0);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("triggers the count budget once and stops accepting requests", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-retirement-count-"));
     const functionPath = join(projectRoot, "slow.ts");
@@ -1318,7 +1394,7 @@ describe("WorkerPool cooperative retirement", () => {
       expect(exceeded).toEqual(["count"]);
       expect(pool.snapshotMetrics("retirement")["retirement_retirement_budget_exceeded"]).toBe(1);
       expect((await dispatchSlow()).status).toBe(503);
-      await waitForMetric(pool, "total_natural_worker_exits", 2, 5_000);
+      await waitForMetric(pool, "total_natural_worker_exits", 2);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -1364,7 +1440,7 @@ describe("WorkerPool cooperative retirement", () => {
       expect(exceeded).toEqual(["age"]);
       await Bun.sleep(50);
       expect(exceeded).toEqual(["age"]);
-      await waitForMetric(pool, "total_natural_worker_exits", 1, 5_000);
+      await waitForMetric(pool, "total_natural_worker_exits", 1);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
 import { WorkerPool } from "./worker-pool";
 
 const pools: WorkerPool[] = [];
@@ -125,23 +126,26 @@ describe("WorkerPool subprocess guard", () => {
           import * as fs from ${JSON.stringify(fsModule)};
           export default () => new Response(String(fs));
         `);
-        for (const response of [
-          await dispatch(`proj_fs_direct_${index}`, directPath, fsModule),
-          await dispatch(`proj_fs_dynamic_${index}`, dynamicPath, fsModule),
-        ]) {
-          expect(response.status).toBe(500);
-          expect(await response.json()).toEqual({
-            error: "Direct file system module access is disabled in the multi-tenant Edge Runtime.",
-            name: "Error",
-          });
-        }
+        const directResponse = await dispatch(`proj_fs_direct_${index}`, directPath, fsModule);
+        expect(directResponse.status).toBe(500);
+        expect(await directResponse.json()).toEqual({
+          error: "Direct file system module access is disabled in the multi-tenant Edge Runtime.",
+          name: "Error",
+        });
+
+        const dynamicResponse = await dispatch(`proj_fs_dynamic_${index}`, dynamicPath, fsModule);
+        expect(dynamicResponse.status).toBe(500);
+        expect(await dynamicResponse.json()).toEqual({
+          error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
+          name: "Error",
+        });
       }
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
   });
 
-  test("allows only the explicit runtime dependency root for read-only module access", async () => {
+  test("blocks computed filesystem imports before runtime dependency reads", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-runtime-read-root-"));
     const functionPath = join(projectRoot, "runtime-read.ts");
     const dependencyPath = Bun.resolveSync("elysia", import.meta.dir);
@@ -174,12 +178,11 @@ describe("WorkerPool subprocess guard", () => {
         env: { DEPENDENCY_PATH: dependencyPath, RUNTIME_PATH: runtimePath },
         request: new Request("http://edge.local/functions/v1/runtime-read"),
       });
-      expect(response.status).toBe(200);
-      const body = await response.json() as { dependency: string; runtime: string };
-      expect(body.dependency.length).toBeGreaterThan(100);
-      expect(body.runtime).toBe(
-        "Direct file system module access is disabled in the multi-tenant Edge Runtime.",
-      );
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
+        name: "Error",
+      });
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -212,6 +215,257 @@ describe("WorkerPool subprocess guard", () => {
       expect(await response.json()).toEqual({
         error: `Access denied: module "${outsideModule}" is outside the project directory`,
         name: "Error",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allows literal dynamic imports and blocks computed module targets", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-dynamic-module-project-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "supacloud-dynamic-module-outside-"));
+    const localModulePath = join(projectRoot, "local.ts");
+    const outsideModulePath = join(outsideRoot, "outside.ts");
+    const literalFunctionPath = join(projectRoot, "literal-import.ts");
+    const computedFunctionPath = join(projectRoot, "computed-import.ts");
+    await Bun.write(localModulePath, `export default "project-module";`);
+    await Bun.write(outsideModulePath, `export default "outside-module";`);
+    await Bun.write(literalFunctionPath, `
+      export default async function () {
+        const imported = await import("./local.ts");
+        return new Response(imported.default);
+      }
+    `);
+    await Bun.write(computedFunctionPath, `
+      export default async function () {
+        const imported = await import(process.env.MODULE_PATH);
+        return new Response(imported.default);
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const dispatch = (functionId: string, functionPath: string, modulePath: string) => pool.dispatch({
+      functionId,
+      functionPath,
+      projectRoot,
+      env: { MODULE_PATH: modulePath },
+      request: new Request(`http://edge.local/functions/v1/${functionId}`),
+    });
+
+    try {
+      const localResponse = await dispatch("proj_dynamic_local", literalFunctionPath, localModulePath);
+      expect(localResponse.status).toBe(200);
+      expect(await localResponse.text()).toBe("project-module");
+
+      const outsideResponse = await dispatch("proj_dynamic_outside", computedFunctionPath, outsideModulePath);
+      expect(outsideResponse.status).toBe(500);
+      expect(await outsideResponse.json()).toEqual({
+        error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
+        name: "Error",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks computed imports from exposing runtime filesystem capabilities", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-runtime-module-project-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "supacloud-runtime-module-outside-"));
+    const outsideAssetPath = join(outsideRoot, "secret.txt");
+    const runtimeModulePath = join(import.meta.dir, "deno-compat.ts");
+    const functionPath = join(projectRoot, "runtime-import.ts");
+    await Bun.write(outsideAssetPath, "outside-secret");
+    await Bun.write(functionPath, `
+      export default async function () {
+        const runtime = await import(process.env.RUNTIME_MODULE_PATH);
+        const direct = await runtime.runtimeFile(process.env.OUTSIDE_ASSET_PATH).text();
+        runtime.setProjectRoot(process.env.OUTSIDE_ROOT);
+        const rerooted = await Bun.file(process.env.OUTSIDE_ASSET_PATH).text();
+        return Response.json({ direct, rerooted });
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_runtime_module_escape",
+        functionPath,
+        projectRoot,
+        env: {
+          OUTSIDE_ASSET_PATH: outsideAssetPath,
+          OUTSIDE_ROOT: outsideRoot,
+          RUNTIME_MODULE_PATH: runtimeModulePath,
+        },
+        request: new Request("http://edge.local/functions/v1/runtime-import"),
+      });
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
+        name: "Error",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks file URL imports and hidden dynamic code generation", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-module-protocol-project-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "supacloud-module-protocol-outside-"));
+    const outsideModulePath = join(outsideRoot, "outside.ts");
+    const fileUrlFunctionPath = join(projectRoot, "file-url.ts");
+    const unsupportedUrlFunctionPath = join(projectRoot, "unsupported-url.ts");
+    const generatedImportFunctionPath = join(projectRoot, "generated-import.ts");
+    const outsideModuleUrl = pathToFileURL(outsideModulePath).href;
+    await Bun.write(outsideModulePath, `export default "outside-module";`);
+    await Bun.write(fileUrlFunctionPath, `
+      import outside from ${JSON.stringify(outsideModuleUrl)};
+      export default () => new Response(outside);
+    `);
+    await Bun.write(unsupportedUrlFunctionPath, `
+      import outside from "data:text/javascript,export default 'outside'";
+      export default () => new Response(outside);
+    `);
+    await Bun.write(generatedImportFunctionPath, `
+      function capture(create) {
+        try {
+          create();
+          return "allowed";
+        } catch (error) {
+          return error.message;
+        }
+      }
+
+      export default function () {
+        return Response.json({
+          eval: capture(() => eval("import(process.env.MODULE_PATH)")),
+          function: capture(() => Function("return import(process.env.MODULE_PATH)")),
+          constructor: capture(() => (() => {}).constructor("return import(process.env.MODULE_PATH)")),
+        });
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const dispatch = (functionId: string, functionPath: string) => pool.dispatch({
+      functionId,
+      functionPath,
+      projectRoot,
+      env: { MODULE_PATH: outsideModulePath },
+      request: new Request(`http://edge.local/functions/v1/${functionId}`),
+    });
+
+    try {
+      const fileUrlResponse = await dispatch("proj_file_url", fileUrlFunctionPath);
+      expect(fileUrlResponse.status).toBe(500);
+      expect(await fileUrlResponse.json()).toEqual({
+        error: `Access denied: module "${outsideModuleUrl}" is outside the project directory`,
+        name: "Error",
+      });
+
+      const unsupportedUrlResponse = await dispatch(
+        "proj_unsupported_url",
+        unsupportedUrlFunctionPath,
+      );
+      expect(unsupportedUrlResponse.status).toBe(500);
+      expect(await unsupportedUrlResponse.json()).toEqual({
+        error: "Unsupported module URL protocol in the multi-tenant Edge Runtime.",
+        name: "Error",
+      });
+
+      const generatedImportResponse = await dispatch(
+        "proj_generated_import",
+        generatedImportFunctionPath,
+      );
+      expect(generatedImportResponse.status).toBe(200);
+      expect(await generatedImportResponse.json()).toEqual({
+        eval: "Dynamic code generation is disabled in the multi-tenant Edge Runtime.",
+        function: "Dynamic code generation is disabled in the multi-tenant Edge Runtime.",
+        constructor: "Dynamic code generation is disabled in the multi-tenant Edge Runtime.",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allows project-local file URL imports", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-local-file-url-project-"));
+    const localModulePath = join(projectRoot, "local.ts");
+    const functionPath = join(projectRoot, "file-url.ts");
+    await Bun.write(localModulePath, `export default "project-module";`);
+    await Bun.write(functionPath, `
+      import local from ${JSON.stringify(pathToFileURL(localModulePath).href)};
+      export default () => new Response(local);
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_local_file_url",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/local-file-url"),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("project-module");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("blocks Bun host capabilities that bypass project guards", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-host-capability-project-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "supacloud-host-capability-outside-"));
+    const outsideAssetPath = join(outsideRoot, "secret.txt");
+    const functionPath = join(projectRoot, "host-capabilities.ts");
+    await Bun.write(outsideAssetPath, "outside-secret");
+    await Bun.write(functionPath, `
+      async function capture(call) {
+        try {
+          await call();
+          return "allowed";
+        } catch (error) {
+          return error.message;
+        }
+      }
+
+      export default async function () {
+        return Response.json({
+          build: await capture(() => Bun.build({ entrypoints: [process.env.OUTSIDE_ASSET] })),
+          mmap: await capture(() => Bun.mmap(process.env.OUTSIDE_ASSET)),
+          heap: await capture(() => Bun.generateHeapSnapshot()),
+          listen: await capture(() => Bun.listen({ hostname: "127.0.0.1", port: 0, socket: {} })),
+          ffi: await capture(() => Bun.FFI.ptr(new ArrayBuffer(8))),
+        });
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_host_capabilities",
+        functionPath,
+        projectRoot,
+        env: { OUTSIDE_ASSET: outsideAssetPath },
+        request: new Request("http://edge.local/functions/v1/host-capabilities"),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        build: "Dynamic code generation is disabled in the multi-tenant Edge Runtime.",
+        mmap: "Direct file system module access is disabled in the multi-tenant Edge Runtime.",
+        heap: "Host runtime capabilities are disabled in the multi-tenant Edge Runtime.",
+        listen: "Host runtime capabilities are disabled in the multi-tenant Edge Runtime.",
+        ffi: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
       });
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
@@ -284,7 +538,7 @@ describe("WorkerPool subprocess guard", () => {
     }
   });
 
-  test("blocks process native loaders and computed createRequire access", async () => {
+  test("blocks computed native loader imports", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-native-loader-"));
     const functionPath = join(projectRoot, "native.ts");
     await Bun.write(functionPath, `
@@ -321,13 +575,10 @@ describe("WorkerPool subprocess guard", () => {
         env: {},
         request: new Request("http://edge.local/functions/v1/native"),
       });
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(500);
       expect(await response.json()).toEqual({
-        dlopen: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
-        binding: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
-        linkedBinding: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
-        getBuiltinModule: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
-        createRequire: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
+        error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
+        name: "Error",
       });
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
@@ -397,7 +648,7 @@ describe("WorkerPool subprocess guard", () => {
       });
       expect(response.status).toBe(500);
       expect(await response.json()).toEqual({
-        error: "Subprocess execution is disabled in the multi-tenant Edge Runtime.",
+        error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
         name: "Error",
       });
     } finally {
@@ -432,7 +683,7 @@ describe("WorkerPool subprocess guard", () => {
       });
       expect(response.status).toBe(500);
       expect(await response.json()).toEqual({
-        error: "Subprocess execution is disabled in the multi-tenant Edge Runtime.",
+        error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
         name: "Error",
       });
     } finally {
@@ -1158,7 +1409,7 @@ describe("WorkerPool cooperative retirement", () => {
 });
 
 describe("WorkerPool TLS policy handoff", () => {
-  test("passes host TLS policy into smol workers for HTTPS fetch", async () => {
+  test("passes a host CA file policy into smol workers for HTTPS fetch", async () => {
     const openssl = Bun.spawnSync(["openssl", "version"], { stdout: "pipe", stderr: "pipe" });
     if (!openssl.success) {
       return;
@@ -1169,6 +1420,7 @@ describe("WorkerPool TLS policy handoff", () => {
     const certPath = join(projectRoot, "cert.pem");
     const functionPath = join(projectRoot, "fn.ts");
     const previousSkipVerify = process.env.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY;
+    const previousCaFile = process.env.SUPACLOUD_EDGE_TLS_CA_FILE;
     let server: ReturnType<typeof Bun.serve> | undefined;
 
     try {
@@ -1213,7 +1465,8 @@ describe("WorkerPool TLS policy handoff", () => {
         }
       `);
 
-      process.env.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY = "true";
+      delete process.env.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY;
+      process.env.SUPACLOUD_EDGE_TLS_CA_FILE = certPath;
       const pool = new WorkerPool({ size: 1, requestTimeout: 5_000 });
       pools.push(pool);
 
@@ -1232,6 +1485,11 @@ describe("WorkerPool TLS policy handoff", () => {
         delete process.env.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY;
       } else {
         process.env.SUPACLOUD_EDGE_TLS_INSECURE_SKIP_VERIFY = previousSkipVerify;
+      }
+      if (previousCaFile === undefined) {
+        delete process.env.SUPACLOUD_EDGE_TLS_CA_FILE;
+      } else {
+        process.env.SUPACLOUD_EDGE_TLS_CA_FILE = previousCaFile;
       }
       server?.stop(true);
       await rm(projectRoot, { recursive: true, force: true });

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -223,7 +223,11 @@ export class WorkerPool {
   private resolveTlsPolicy(env: Record<string, string>): Promise<EdgeFetchTlsPolicy> {
     // Bun smol workers do not reliably inherit the parent process env. Resolve
     // host-controlled TLS policy in the main process and pass it as message data.
-    return resolveEdgeFetchTlsPolicy(env, process.env);
+    return resolveEdgeFetchTlsPolicy(
+      env,
+      process.env,
+      (caFile) => Bun.file(caFile).text(),
+    );
   }
 
   async dispatch(opts: DispatchOptions): Promise<Response> {


### PR DESCRIPTION
## Summary
- reject computed dynamic imports and untrusted module URL protocols before tenant code loads
- keep literal local imports and Elysia code generation compatible while blocking hidden import generation
- remove importable runtime filesystem/root capabilities and guard Bun host/native APIs
- preserve host CA file loading through private trusted readers in both WorkerPool and workers

## Compatibility
Computed dynamic imports are now intentionally rejected in the multi-tenant Edge Runtime. Literal relative imports, project-local file URLs, trusted runtime dependency imports, and Elysia routing remain supported.

## Validation
- `bun test` (100 pass, 0 fail)
- `bun run typecheck`
- `bun install --frozen-lockfile`
- `git diff --check`
- `bun run build:macos-arm64`
- compiled binary `/health` smoke: `{"status":"ok","instanceId":null}`