### PR TITLE
test(edge-runtime): stabilize retirement budget checks

### DIFF
--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -1356,18 +1356,22 @@ describe("WorkerPool cooperative retirement", () => {
 
   test("triggers the count budget once and stops accepting requests", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-retirement-count-"));
+    const firstStartedPath = join(projectRoot, "first-started.txt");
+    const secondStartedPath = join(projectRoot, "second-started.txt");
     const functionPath = join(projectRoot, "slow.ts");
     await Bun.write(functionPath, `
       export default async function fetch(request) {
-        await new Promise((resolve) => {
+        const aborted = new Promise((resolve) => {
           const keepAlive = setInterval(() => {}, 10);
           request.signal.addEventListener("abort", () => {
             setTimeout(() => {
               clearInterval(keepAlive);
               resolve();
-            }, 150);
+            }, 500);
           }, { once: true });
         });
+        await Bun.write(process.env.STARTED_PATH, "started");
+        await aborted;
         return new Response("retired");
       }
     `);
@@ -1375,25 +1379,44 @@ describe("WorkerPool cooperative retirement", () => {
     const exceeded: string[] = [];
     const pool = new WorkerPool({
       size: 1,
-      requestTimeout: 25,
+      requestTimeout: 100,
       retirementBudget: { maxRetiredWorkers: 1, maxRetirementAgeMs: 1_000 },
       onRetirementBudgetExceeded: (event) => exceeded.push(event.limit),
     });
     pools.push(pool);
 
     try {
-      const dispatchSlow = () => pool.dispatch({
+      const preheatReplacement = () => pool.preheat(
+        "proj_retirement_count",
+        functionPath,
+        projectRoot,
+        {},
+      );
+      const dispatchSlow = async (startedPath: string) => {
+        const responsePromise = pool.dispatch({
+          functionId: "proj_retirement_count",
+          functionPath,
+          projectRoot,
+          env: { STARTED_PATH: startedPath },
+          request: new Request("http://edge.local/functions/v1/slow"),
+        });
+        await waitForFile(startedPath);
+        return responsePromise;
+      };
+
+      expect(await preheatReplacement()).toBe(true);
+      expect((await dispatchSlow(firstStartedPath)).status).toBe(504);
+      expect(await preheatReplacement()).toBe(true);
+      expect((await dispatchSlow(secondStartedPath)).status).toBe(504);
+      expect(exceeded).toEqual(["count"]);
+      expect(pool.snapshotMetrics("retirement")["retirement_retirement_budget_exceeded"]).toBe(1);
+      expect((await pool.dispatch({
         functionId: "proj_retirement_count",
         functionPath,
         projectRoot,
         env: {},
         request: new Request("http://edge.local/functions/v1/slow"),
-      });
-      expect((await dispatchSlow()).status).toBe(504);
-      expect((await dispatchSlow()).status).toBe(504);
-      expect(exceeded).toEqual(["count"]);
-      expect(pool.snapshotMetrics("retirement")["retirement_retirement_budget_exceeded"]).toBe(1);
-      expect((await dispatchSlow()).status).toBe(503);
+      })).status).toBe(503);
       await waitForMetric(pool, "total_natural_worker_exits", 2);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
@@ -1402,10 +1425,11 @@ describe("WorkerPool cooperative retirement", () => {
 
   test("triggers the age budget once for a worker that cannot drain promptly", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-retirement-age-"));
+    const startedPath = join(projectRoot, "started.txt");
     const functionPath = join(projectRoot, "slow.ts");
     await Bun.write(functionPath, `
       export default async function fetch(request) {
-        await new Promise((resolve) => {
+        const aborted = new Promise((resolve) => {
           const keepAlive = setInterval(() => {}, 10);
           request.signal.addEventListener("abort", () => {
             setTimeout(() => {
@@ -1414,6 +1438,8 @@ describe("WorkerPool cooperative retirement", () => {
             }, 150);
           }, { once: true });
         });
+        await Bun.write(process.env.STARTED_PATH, "started");
+        await aborted;
         return new Response("retired");
       }
     `);
@@ -1421,21 +1447,28 @@ describe("WorkerPool cooperative retirement", () => {
     const exceeded: string[] = [];
     const pool = new WorkerPool({
       size: 1,
-      requestTimeout: 25,
+      requestTimeout: 100,
       retirementBudget: { maxRetiredWorkers: 8, maxRetirementAgeMs: 30 },
       onRetirementBudgetExceeded: (event) => exceeded.push(event.limit),
     });
     pools.push(pool);
 
     try {
-      const response = await pool.dispatch({
+      expect(await pool.preheat(
+        "proj_retirement_age",
+        functionPath,
+        projectRoot,
+        {},
+      )).toBe(true);
+      const responsePromise = pool.dispatch({
         functionId: "proj_retirement_age",
         functionPath,
         projectRoot,
-        env: {},
+        env: { STARTED_PATH: startedPath },
         request: new Request("http://edge.local/functions/v1/slow"),
       });
-      expect(response.status).toBe(504);
+      await waitForFile(startedPath);
+      expect((await responsePromise).status).toBe(504);
       await waitForMetric(pool, "retirement_budget_exceeded", 1);
       expect(exceeded).toEqual(["age"]);
       await Bun.sleep(50);

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "supacloud",
       "dependencies": {
-        "@supacloud/admin": "^0.7.0",
-        "@supacloud/cli": "^0.14.1",
+        "@supacloud/admin": "^0.7.1",
+        "@supacloud/cli": "^0.14.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -17,9 +17,9 @@
   "packages": {
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supacloud/admin": ["@supacloud/admin@0.7.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.7.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-L3b0LbPacF2p1nzuFHJ7OCPhME11TF+tVXeJuqmVo5sgUo+G0f/s5BUDbWW3veYrzHPEyXS04HZU4mgenjiZIg=="],
+    "@supacloud/admin": ["@supacloud/admin@0.7.1", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.7.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-7DRZXIaKSv4x4SEj3dVzx1B+ei+l4ZaQj/UqdY0pjvgOpdg1r1xoIZlkhIxvQI8QcGbmPI3P/ABml9CRgq4FEQ=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.14.1", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-GujMrbxg791R7YFMB8US+3Hi/qNuedQ7iU/QA5Imnt/Tv8TQK7EddKQaGm6Bcy0RPZl1Z7rA6DORoxa2UH8mvA=="],
+    "@supacloud/cli": ["@supacloud/cli@0.14.2", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.2.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-sBAk+tam1cL0RsOZr9Lgv7S4qGMBYls1HIbwq+EpclN+ZFn/GT7W+wYm5cRgqzeerHv0jd9cy3AyvbSRY0cxEA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary

- preheat replacement workers before exercising retirement budgets
- wait for each fixture handler to register its abort listener before timeout
- preserve count/age budget assertions and natural-exit coverage
- refresh the unified package lock for the versions released by #667

## Follow-up context

- Parent: #670
- Source: main workflow run 30730919817
- Reason: the age-budget test did not establish that the tenant handler had started, so a valid module-load timeout could bypass the age-budget path

The lockfile refresh is included because ordinary PRs after #667 fail `bun install --frozen-lockfile`, while a lock-only PR still runs the flaky main retirement tests. The two fixes form a CI dependency cycle and must land together without bypassing checks.

## Verification

- Edge `bun run typecheck`
- Edge CI test set: 53 pass
- count/age stress: 20/20 locally and 10/10 on linux/amd64
- unified package ordinary PR mode resolves to `frozen`
- unified package frozen install, typecheck, 19 tests, build, npm audit
- `git diff --check`
- independent Edge critic and lockfile verifier: PASS

Windows standalone smoke passed on this PR; its earlier intermittent hang remains a separate diagnostic scope.