### PR TITLE
chore(supacloud): refresh unified package lock

### DIFF
--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "supacloud",
       "dependencies": {
-        "@supacloud/admin": "^0.7.0",
-        "@supacloud/cli": "^0.14.1",
+        "@supacloud/admin": "^0.7.1",
+        "@supacloud/cli": "^0.14.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -17,9 +17,9 @@
   "packages": {
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supacloud/admin": ["@supacloud/admin@0.7.0", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.7.0.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-L3b0LbPacF2p1nzuFHJ7OCPhME11TF+tVXeJuqmVo5sgUo+G0f/s5BUDbWW3veYrzHPEyXS04HZU4mgenjiZIg=="],
+    "@supacloud/admin": ["@supacloud/admin@0.7.1", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.7.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-7DRZXIaKSv4x4SEj3dVzx1B+ei+l4ZaQj/UqdY0pjvgOpdg1r1xoIZlkhIxvQI8QcGbmPI3P/ABml9CRgq4FEQ=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.14.1", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-GujMrbxg791R7YFMB8US+3Hi/qNuedQ7iU/QA5Imnt/Tv8TQK7EddKQaGm6Bcy0RPZl1Z7rA6DORoxa2UH8mvA=="],
+    "@supacloud/cli": ["@supacloud/cli@0.14.2", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.2.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-sBAk+tam1cL0RsOZr9Lgv7S4qGMBYls1HIbwq+EpclN+ZFn/GT7W+wYm5cRgqzeerHv0jd9cy3AyvbSRY0cxEA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary

- refresh the unified package lock for `@supacloud/admin@0.7.1`
- refresh the unified package lock for `@supacloud/cli@0.14.2`
- restore frozen installs for ordinary pull requests after release PR #667

## Context

PR #672 exposed that the main push release exception passed while ordinary PRs deterministically failed `bun install --frozen-lockfile`. This PR is kept separate so #672 remains an Edge-only follow-up.

## Verification

- ordinary PR install mode resolves to `frozen`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test src/index.test.ts` (19 pass)
- `bun run build`
- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org bun audit --audit-level high`
- `git diff --check`