### PR TITLE
fix(lite): drain active background services before shutdown

### DIFF
--- a/packages/supacloud-lite/src/vendor/tinbase/cron/service.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/cron/service.ts
@@ -38,9 +38,7 @@ export class CronService {
   /** Begin polling for due jobs on the tick interval; no-op if already running. */
   start(): void {
     if (this.timer) return
-    this.timer = setInterval(() => {
-      this.inFlight = this.tick()
-    }, this.tickMs)
+    this.timer = setInterval(() => void this.tick(), this.tickMs)
     if (typeof this.timer === 'object' && 'unref' in this.timer) (this.timer as { unref: () => void }).unref()
   }
 
@@ -57,7 +55,18 @@ export class CronService {
   }
 
   /** Run any due jobs once (also callable directly in tests). */
-  async tick(): Promise<void> {
+  tick(): Promise<void> {
+    if (this.inFlight) return this.inFlight
+    const inFlight = Promise.resolve()
+      .then(() => this.runTick())
+      .finally(() => {
+        if (this.inFlight === inFlight) this.inFlight = null
+      })
+    this.inFlight = inFlight
+    return inFlight
+  }
+
+  private async runTick(): Promise<void> {
     let jobs: JobRow[]
     try {
       jobs = (await this.db.query<JobRow>(`select jobid, schedule, command, jobname, active from cron.job where active`)).rows

--- a/packages/supacloud-lite/src/vendor/tinbase/net/service.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/net/service.ts
@@ -112,7 +112,6 @@ export interface NetDelivery {
  */
 export class NetService {
   private timer: ReturnType<typeof setInterval> | null = null
-  private draining = false
   /** The in-flight tick, tracked so stop() can drain it before db.close(). */
   private inFlight: Promise<void> | null = null
 
@@ -127,9 +126,7 @@ export class NetService {
   /** Begin draining the queue on the tick interval; no-op if already running. */
   start(): void {
     if (this.timer) return
-    this.timer = setInterval(() => {
-      this.inFlight = this.tick()
-    }, this.tickMs)
+    this.timer = setInterval(() => void this.tick(), this.tickMs)
     if (typeof this.timer === 'object' && 'unref' in this.timer) (this.timer as { unref: () => void }).unref()
   }
 
@@ -146,33 +143,38 @@ export class NetService {
   }
 
   /** Drain any queued requests once (also callable directly in tests). */
-  async tick(): Promise<void> {
-    if (this.draining) return // never overlap drains - one writer at a time
-    this.draining = true
+  tick(): Promise<void> {
+    if (this.inFlight) return this.inFlight
+    const inFlight = Promise.resolve()
+      .then(() => this.drainQueue())
+      .finally(() => {
+        if (this.inFlight === inFlight) this.inFlight = null
+      })
+    this.inFlight = inFlight
+    return inFlight
+  }
+
+  private async drainQueue(): Promise<void> {
+    let rows: RequestRow[]
     try {
-      let rows: RequestRow[]
+      rows = (
+        await this.db.query<RequestRow>(
+          `select id, method, url, headers, body, timeout_milliseconds from net.http_request_queue order by id limit 20`
+        )
+      ).rows
+    } catch {
+      return // net.* not present (e.g. the pg-mem subset engine)
+    }
+    for (const row of rows) {
       try {
-        rows = (
-          await this.db.query<RequestRow>(
-            `select id, method, url, headers, body, timeout_milliseconds from net.http_request_queue order by id limit 20`
-          )
-        ).rows
-      } catch {
-        return // net.* not present (e.g. the pg-mem subset engine)
+        await this.deliver(row)
+      } catch (e) {
+        // A malformed row must never poison the loop or reject out of the
+        // setInterval callback - dequeue it with the error recorded instead.
+        const msg = e instanceof Error ? e.message : String(e)
+        await this.record(row.id, null, null, null, null, false, msg)
+        this.onDeliver?.({ id: row.id, method: row.method, url: row.url, timedOut: false, error: msg })
       }
-      for (const row of rows) {
-        try {
-          await this.deliver(row)
-        } catch (e) {
-          // A malformed row must never poison the loop or reject out of the
-          // setInterval callback - dequeue it with the error recorded instead.
-          const msg = e instanceof Error ? e.message : String(e)
-          await this.record(row.id, null, null, null, null, false, msg)
-          this.onDeliver?.({ id: row.id, method: row.method, url: row.url, timedOut: false, error: msg })
-        }
-      }
-    } finally {
-      this.draining = false
     }
   }
 

--- a/packages/supacloud-lite/src/vendor/tinbase/retention/service.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/retention/service.ts
@@ -28,7 +28,7 @@ export class RetentionService {
   // run un-awaited, but stop() must be able to drain the in-flight one before
   // the caller closes the database: PGlite has a single connection, and calling
   // close() while a sweep query is still queued busy-loops the shutdown.
-  private inFlight: Promise<void> = Promise.resolve()
+  private inFlight: Promise<void> | null = null
   private readonly intervalMs: number
   private readonly auditLogDays: number
   private readonly refreshTokenDays: number
@@ -46,11 +46,8 @@ export class RetentionService {
   /** Sweep once at boot, then on the configured interval; no-op if already running. */
   start(): void {
     if (this.timer) return
-    // run once at boot, then on the interval (tracking the in-flight sweep)
-    this.inFlight = this.sweep()
-    this.timer = setInterval(() => {
-      this.inFlight = this.sweep()
-    }, this.intervalMs)
+    void this.sweep()
+    this.timer = setInterval(() => void this.sweep(), this.intervalMs)
     if (typeof this.timer === 'object' && 'unref' in this.timer) (this.timer as { unref: () => void }).unref()
   }
 
@@ -61,11 +58,22 @@ export class RetentionService {
   async stop(): Promise<void> {
     if (this.timer) clearInterval(this.timer)
     this.timer = null
-    await this.inFlight.catch(() => {})
+    await this.inFlight?.catch(() => {})
   }
 
   /** Run a single retention pass (also callable directly in tests). */
-  async sweep(): Promise<void> {
+  sweep(): Promise<void> {
+    if (this.inFlight) return this.inFlight
+    const inFlight = Promise.resolve()
+      .then(() => this.runSweep())
+      .finally(() => {
+        if (this.inFlight === inFlight) this.inFlight = null
+      })
+    this.inFlight = inFlight
+    return inFlight
+  }
+
+  private async runSweep(): Promise<void> {
     const now = this.now()
     await this.run(`delete from auth.one_time_tokens where expires_at < now()`)
     await this.run(`delete from auth.mfa_challenges where expires_at < now()`)

--- a/packages/supacloud-lite/test/background-services-shutdown.test.ts
+++ b/packages/supacloud-lite/test/background-services-shutdown.test.ts
@@ -1,0 +1,216 @@
+import { expect, test } from 'bun:test'
+import { CronService } from '../src/vendor/tinbase/cron/service.js'
+import type { Database } from '../src/vendor/tinbase/db/database.js'
+import { NetService } from '../src/vendor/tinbase/net/service.js'
+import { RetentionService } from '../src/vendor/tinbase/retention/service.js'
+
+test('waits for a public net tick while later interval ticks are skipped', async () => {
+  const queryGate = createGatedDatabase()
+  const service = new NetService(queryGate.database, fetch, 1)
+
+  const tickPromise = service.tick()
+  service.start()
+  try {
+    await queryGate.queryStarted
+    expect(service.tick()).toBe(tickPromise)
+    await Bun.sleep(50)
+    expect(queryGate.queryCalls()).toBe(1)
+    expect(queryGate.maxConcurrentQueries()).toBe(1)
+
+    let stopFinished = false
+    const stopPromise = service.stop().then(() => {
+      stopFinished = true
+    })
+    await Bun.sleep(10)
+    expect(stopFinished).toBeFalse()
+
+    queryGate.releaseQuery()
+    await Promise.all([tickPromise, stopPromise])
+    const stoppedQueryCalls = queryGate.queryCalls()
+    await Bun.sleep(10)
+    expect(queryGate.queryCalls()).toBe(stoppedQueryCalls)
+  } finally {
+    queryGate.releaseQuery()
+    await service.stop()
+  }
+})
+
+test('retries cron after a job-list failure and drains the active tick during stop', async () => {
+  const queryGate = createGatedDatabase(1)
+  const service = new CronService(queryGate.database, 1)
+
+  service.start()
+  try {
+    await queryGate.queryStarted
+    await Bun.sleep(50)
+    expect(queryGate.queryCalls()).toBe(2)
+    expect(queryGate.maxConcurrentQueries()).toBe(1)
+
+    let stopFinished = false
+    const stopPromise = service.stop().then(() => {
+      stopFinished = true
+    })
+    await Bun.sleep(10)
+    expect(stopFinished).toBeFalse()
+
+    queryGate.releaseQuery()
+    await stopPromise
+    const stoppedQueryCalls = queryGate.queryCalls()
+    await Bun.sleep(10)
+    expect(queryGate.queryCalls()).toBe(stoppedQueryCalls)
+  } finally {
+    queryGate.releaseQuery()
+    await service.stop()
+  }
+})
+
+test('waits for a public due-job cron tick while interval ticks are skipped', async () => {
+  const queryGate = createGatedCronDatabase()
+  const service = new CronService(queryGate.database, 1, () => new Date(2_000))
+
+  const tickPromise = service.tick()
+  service.start()
+  try {
+    await queryGate.commandStarted
+    expect(service.tick()).toBe(tickPromise)
+    await Bun.sleep(50)
+    expect(queryGate.jobListCalls()).toBe(1)
+    expect(queryGate.commandCalls()).toBe(1)
+    expect(queryGate.maxConcurrentQueries()).toBe(1)
+
+    let stopFinished = false
+    const stopPromise = service.stop().then(() => {
+      stopFinished = true
+    })
+    await Bun.sleep(10)
+    expect(stopFinished).toBeFalse()
+
+    queryGate.releaseCommand()
+    await Promise.all([tickPromise, stopPromise])
+    const stoppedQueryCalls = queryGate.queryCalls()
+    await Bun.sleep(10)
+    expect(queryGate.queryCalls()).toBe(stoppedQueryCalls)
+  } finally {
+    queryGate.releaseCommand()
+    await service.stop()
+  }
+})
+
+test('waits for a public retention sweep while interval sweeps are skipped', async () => {
+  const queryGate = createGatedDatabase()
+  const service = new RetentionService(queryGate.database, {
+    intervalMs: 1,
+    auditLogDays: 0,
+    refreshTokenDays: 0,
+  })
+
+  const sweepPromise = service.sweep()
+  service.start()
+  try {
+    await queryGate.queryStarted
+    expect(service.sweep()).toBe(sweepPromise)
+    await Bun.sleep(50)
+    expect(queryGate.queryCalls()).toBe(1)
+    expect(queryGate.maxConcurrentQueries()).toBe(1)
+
+    let stopFinished = false
+    const stopPromise = service.stop().then(() => {
+      stopFinished = true
+    })
+    await Bun.sleep(10)
+    expect(stopFinished).toBeFalse()
+
+    queryGate.releaseQuery()
+    await Promise.all([sweepPromise, stopPromise])
+    const stoppedQueryCalls = queryGate.queryCalls()
+    await Bun.sleep(10)
+    expect(queryGate.queryCalls()).toBe(stoppedQueryCalls)
+  } finally {
+    queryGate.releaseQuery()
+    await service.stop()
+  }
+})
+
+test('releases retention single-flight state after an unexpected failure', async () => {
+  let clockCalls = 0
+  const database = { query: async () => ({ rows: [], affectedRows: 0 }) } as unknown as Database
+  const service = new RetentionService(database, { auditLogDays: 0, refreshTokenDays: 0 }, () => {
+    clockCalls += 1
+    if (clockCalls === 1) throw new Error('planned clock failure')
+    return new Date(0)
+  })
+
+  await expect(service.sweep()).rejects.toThrow('planned clock failure')
+  await service.sweep()
+  expect(clockCalls).toBe(2)
+})
+
+function createGatedDatabase(failuresBeforeGate = 0) {
+  const queryStarted = Promise.withResolvers<void>()
+  const queryGate = Promise.withResolvers<void>()
+  let queryCalls = 0
+  let activeQueries = 0
+  let maxConcurrentQueries = 0
+  const database = {
+    async query() {
+      queryCalls += 1
+      activeQueries += 1
+      maxConcurrentQueries = Math.max(maxConcurrentQueries, activeQueries)
+      try {
+        if (queryCalls <= failuresBeforeGate) throw new Error('planned query failure')
+        queryStarted.resolve()
+        await queryGate.promise
+        return { rows: [], affectedRows: 0 }
+      } finally {
+        activeQueries -= 1
+      }
+    },
+  } as unknown as Database
+  return {
+    database,
+    queryStarted: queryStarted.promise,
+    releaseQuery: queryGate.resolve,
+    queryCalls: () => queryCalls,
+    maxConcurrentQueries: () => maxConcurrentQueries,
+  }
+}
+
+function createGatedCronDatabase() {
+  const commandStarted = Promise.withResolvers<void>()
+  const commandGate = Promise.withResolvers<void>()
+  let queryCalls = 0
+  let jobListCalls = 0
+  let commandCalls = 0
+  let activeQueries = 0
+  let maxConcurrentQueries = 0
+  const database = {
+    async query(sql: string) {
+      queryCalls += 1
+      activeQueries += 1
+      maxConcurrentQueries = Math.max(maxConcurrentQueries, activeQueries)
+      try {
+        if (sql.startsWith('select jobid')) {
+          jobListCalls += 1
+          return { rows: [{ jobid: 1, schedule: '1 seconds', command: 'select 1', jobname: 'gate', active: true }] }
+        }
+        if (sql === 'select 1') {
+          commandCalls += 1
+          commandStarted.resolve()
+          await commandGate.promise
+        }
+        return { rows: [], affectedRows: 0 }
+      } finally {
+        activeQueries -= 1
+      }
+    },
+  } as unknown as Database
+  return {
+    database,
+    commandStarted: commandStarted.promise,
+    releaseCommand: commandGate.resolve,
+    queryCalls: () => queryCalls,
+    jobListCalls: () => jobListCalls,
+    commandCalls: () => commandCalls,
+    maxConcurrentQueries: () => maxConcurrentQueries,
+  }
+}

--- a/packages/supacloud-lite/test/background-services-shutdown.test.ts
+++ b/packages/supacloud-lite/test/background-services-shutdown.test.ts
@@ -41,8 +41,8 @@ test('retries cron after a job-list failure and drains the active tick during st
 
   service.start()
   try {
-    await queryGate.queryStarted
     await Bun.sleep(50)
+    await queryGate.queryStarted
     expect(queryGate.queryCalls()).toBe(2)
     expect(queryGate.maxConcurrentQueries()).toBe(1)
 


### PR DESCRIPTION
## Summary
- Keep Lite Net, Cron, and Retention background work single-flight across public entry points, boot work, and interval callbacks.
- Make shutdown drain the actual active database promise before PGlite closes.
- Add gated regressions for interval overlap, public-entry joining, stop pending/completion, Cron command teardown, retry after failure, and unexpected rejection cleanup.

## Context
- parent: PR #672
- source: main run 30733804109, Windows Lite snapshot CLI attempt 1/2
- reason: `backend.close()` was waiting on a replaced Promise while an older background database query remained in flight; the test harness then killed the dangling CLI process.

## Verification
- `bun run typecheck`
- `bun test test/background-services-shutdown.test.ts --timeout 20000 --rerun-each 20` — 100/100
- `bun test test/snapshot.test.ts --timeout 20000 --rerun-each 5` — 25/25
- `bun run check` — 78/78, build, package smoke, host standalone smoke
- `git diff --check`

The Windows amd64 binary smoke is intentionally left to CI for this PR.