### PR TITLE
fix(lite): ignore stale background timer callbacks

### DIFF
--- a/packages/supacloud-lite/src/vendor/tinbase/cron/service.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/cron/service.ts
@@ -23,6 +23,7 @@ interface JobRow {
  */
 export class CronService {
   private timer: ReturnType<typeof setInterval> | null = null
+  private timerGeneration = 0
   private lastRun = new Map<number, number>() // jobid → epoch ms of last run
   private lastMinute = new Map<number, number>() // jobid → minute bucket last run
   /** The in-flight tick, tracked so stop() can drain it before db.close(). */
@@ -37,9 +38,14 @@ export class CronService {
 
   /** Begin polling for due jobs on the tick interval; no-op if already running. */
   start(): void {
-    if (this.timer) return
-    this.timer = setInterval(() => void this.tick(), this.tickMs)
-    if (typeof this.timer === 'object' && 'unref' in this.timer) (this.timer as { unref: () => void }).unref()
+    if (this.timer !== null) return
+    const generation = ++this.timerGeneration
+    let timer: ReturnType<typeof setInterval>
+    timer = setInterval(() => {
+      if (this.timer === timer && this.timerGeneration === generation) void this.tick()
+    }, this.tickMs)
+    this.timer = timer
+    if (typeof timer === 'object' && 'unref' in timer) (timer as { unref: () => void }).unref()
   }
 
   /**
@@ -48,10 +54,12 @@ export class CronService {
    * while a job query is still queued.
    */
   async stop(): Promise<void> {
-    if (this.timer) clearInterval(this.timer)
+    const timer = this.timer
     this.timer = null
-    await this.inFlight?.catch(() => {})
-    this.inFlight = null
+    this.timerGeneration += 1
+    if (timer !== null) clearInterval(timer)
+    const inFlight = this.inFlight
+    await inFlight?.catch(() => {})
   }
 
   /** Run any due jobs once (also callable directly in tests). */

--- a/packages/supacloud-lite/src/vendor/tinbase/db/database.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/db/database.ts
@@ -14,7 +14,7 @@ import { rewriteMigrationSql } from './sql-compat.js'
 // migration's own `SET search_path` can't leak across our single connection.
 const DEFAULT_SEARCH_PATH_SQL = `set search_path to "$user", public, extensions`
 import { createPgliteEngine } from './pglite-engine.js'
-import type { DbEngine, EngineResults, EngineTx } from './engine.js'
+import type { DbEngine, EngineResults, EngineTx, EngineUnsubscribe } from './engine.js'
 import type { MigrationFile, RequestContext } from '../types.js'
 
 /** One column of an introspected table. */
@@ -109,7 +109,9 @@ export class Database {
   private schemaCache = new Map<string, SchemaInfo>()
   private fnCache = new Map<string, FunctionInfo[]>()
   private cdcListeners = new Set<(e: CdcEvent) => void>()
-  private cdcStarted = false
+  private cdcStarting: Promise<void> | null = null
+  private cdcStopping: Promise<void> | null = null
+  private cdcUnsubscribe: EngineUnsubscribe | null = null
 
   private constructor(public engine: DbEngine) {}
 
@@ -490,20 +492,54 @@ export class Database {
    * Register a CDC listener; the first call starts the single LISTEN on the
    * shared `tinbase_cdc` channel. Returns an unsubscribe fn.
    */
-  async onCdcEvent(cb: (e: CdcEvent) => void): Promise<() => void> {
+  async onCdcEvent(cb: (e: CdcEvent) => void): Promise<() => Promise<void>> {
     this.cdcListeners.add(cb)
-    if (!this.cdcStarted) {
-      this.cdcStarted = true
-      await this.engine.listen('tinbase_cdc', (payload: string) => {
-        try {
-          const event = JSON.parse(payload) as CdcEvent
-          for (const listener of this.cdcListeners) listener(event)
-        } catch {
-          // malformed payload - drop
-        }
-      })
+    try {
+      await this.startCdcListener()
+    } catch (error) {
+      this.cdcListeners.delete(cb)
+      throw error
     }
-    return () => this.cdcListeners.delete(cb)
+    return async () => {
+      if (!this.cdcListeners.delete(cb) || this.cdcListeners.size > 0) return
+      await this.stopCdcListener()
+    }
+  }
+
+  private async startCdcListener(): Promise<void> {
+    if (this.cdcStopping) await this.cdcStopping
+    if (this.cdcUnsubscribe) return
+    const starting = this.cdcStarting ?? this.attachCdcListener()
+    this.cdcStarting = starting
+    try {
+      await starting
+    } finally {
+      if (this.cdcStarting === starting) this.cdcStarting = null
+    }
+  }
+
+  private async attachCdcListener(): Promise<void> {
+    this.cdcUnsubscribe = await this.engine.listen('tinbase_cdc', (payload) => {
+      try {
+        const event = JSON.parse(payload) as CdcEvent
+        for (const listener of this.cdcListeners) listener(event)
+      } catch {
+        // malformed payload - drop
+      }
+    })
+  }
+
+  private async stopCdcListener(): Promise<void> {
+    const unsubscribe = this.cdcUnsubscribe
+    if (!unsubscribe) return
+    this.cdcUnsubscribe = null
+    const stopping = Promise.resolve().then(unsubscribe)
+    this.cdcStopping = stopping
+    try {
+      await stopping
+    } finally {
+      if (this.cdcStopping === stopping) this.cdcStopping = null
+    }
   }
 
   /**

--- a/packages/supacloud-lite/src/vendor/tinbase/db/engine.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/db/engine.ts
@@ -21,6 +21,9 @@ export interface EngineTx {
   exec(sql: string): Promise<void>
 }
 
+/** Detach a database listener; some engines issue an asynchronous UNLISTEN. */
+export type EngineUnsubscribe = () => void | Promise<void>
+
 /**
  * The single database interface the rest of tinbase talks to, regardless of
  * whether it's backed by PGlite, native embedded Postgres, or the pg-mem subset.
@@ -35,7 +38,7 @@ export interface DbEngine {
   /** serialized transaction; implementations must guarantee mutual exclusion */
   transaction<T>(fn: (tx: EngineTx) => Promise<T>): Promise<T>
   /** subscribe to pg_notify on a channel; returns an unsubscribe function */
-  listen(channel: string, cb: (payload: string) => void): Promise<() => void>
+  listen(channel: string, cb: (payload: string) => void): Promise<EngineUnsubscribe>
   /** close the underlying connection/instance */
   close(): Promise<void>
 }

--- a/packages/supacloud-lite/src/vendor/tinbase/db/pglite-engine.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/db/pglite-engine.ts
@@ -2,7 +2,7 @@
 import { mkdir, open, unlink, type FileHandle } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import type { Extension } from '@electric-sql/pglite'
-import type { DbEngine, EngineResults, EngineTx } from './engine.js'
+import type { DbEngine, EngineResults, EngineTx, EngineUnsubscribe } from './engine.js'
 import { readDataDirLockOwner, recoverStaleDataDirLock } from './data-dir-lock.js'
 import {
   STANDALONE_PGLITE_ASSETS,
@@ -101,7 +101,7 @@ export async function createPgliteEngine(dataDir?: string): Promise<DbEngine> {
         })
       }) as Promise<T>
     },
-    async listen(channel: string, cb: (payload: string) => void): Promise<() => void> {
+    async listen(channel: string, cb: (payload: string) => void): Promise<EngineUnsubscribe> {
       return pg.listen(channel, cb)
     },
     close: async () => {

--- a/packages/supacloud-lite/src/vendor/tinbase/net/service.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/net/service.ts
@@ -112,6 +112,7 @@ export interface NetDelivery {
  */
 export class NetService {
   private timer: ReturnType<typeof setInterval> | null = null
+  private timerGeneration = 0
   /** The in-flight tick, tracked so stop() can drain it before db.close(). */
   private inFlight: Promise<void> | null = null
 
@@ -125,9 +126,14 @@ export class NetService {
 
   /** Begin draining the queue on the tick interval; no-op if already running. */
   start(): void {
-    if (this.timer) return
-    this.timer = setInterval(() => void this.tick(), this.tickMs)
-    if (typeof this.timer === 'object' && 'unref' in this.timer) (this.timer as { unref: () => void }).unref()
+    if (this.timer !== null) return
+    const generation = ++this.timerGeneration
+    let timer: ReturnType<typeof setInterval>
+    timer = setInterval(() => {
+      if (this.timer === timer && this.timerGeneration === generation) void this.tick()
+    }, this.tickMs)
+    this.timer = timer
+    if (typeof timer === 'object' && 'unref' in timer) (timer as { unref: () => void }).unref()
   }
 
   /**
@@ -136,10 +142,12 @@ export class NetService {
    * while a query is still queued.
    */
   async stop(): Promise<void> {
-    if (this.timer) clearInterval(this.timer)
+    const timer = this.timer
     this.timer = null
-    await this.inFlight?.catch(() => {})
-    this.inFlight = null
+    this.timerGeneration += 1
+    if (timer !== null) clearInterval(timer)
+    const inFlight = this.inFlight
+    await inFlight?.catch(() => {})
   }
 
   /** Drain any queued requests once (also callable directly in tests). */

--- a/packages/supacloud-lite/src/vendor/tinbase/realtime/engine.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/realtime/engine.ts
@@ -10,6 +10,7 @@
  */
 import type { CdcEvent, Database } from '../db/database.js'
 import { quoteIdent } from '../db/database.js'
+import type { EngineUnsubscribe } from '../db/engine.js'
 import { verifyJwt } from '../jwt.js'
 import type { RequestContext } from '../types.js'
 
@@ -89,8 +90,8 @@ export class RealtimeEngine {
   private phxRefCounter = 1
   /** topic → key → metas */
   private presence = new Map<string, Map<string, PresenceMetas>>()
-  private stopCdc: (() => void) | null = null
-  private stopDbBroadcast: (() => void) | null = null
+  private stopCdc: EngineUnsubscribe | null = null
+  private stopDbBroadcast: EngineUnsubscribe | null = null
 
   constructor(
     private db: Database,
@@ -184,13 +185,19 @@ export class RealtimeEngine {
   }
 
   /** Detach listeners and close every open socket (server shutdown). */
-  stop(): void {
-    this.stopCdc?.()
+  async stop(): Promise<void> {
+    const stopCdc = this.stopCdc
+    const stopDbBroadcast = this.stopDbBroadcast
     this.stopCdc = null
-    this.stopDbBroadcast?.()
     this.stopDbBroadcast = null
     for (const conn of this.connections) conn.socket.close(1001, 'server shutting down')
     this.connections.clear()
+    const [cdcStop, broadcastStop] = await Promise.allSettled([
+      Promise.resolve().then(() => stopCdc?.()),
+      Promise.resolve().then(() => stopDbBroadcast?.()),
+    ])
+    if (cdcStop.status === 'rejected') throw cdcStop.reason
+    if (broadcastStop.status === 'rejected') throw broadcastStop.reason
   }
 
   /** Attach a socket. Returns callbacks the transport must wire up. */

--- a/packages/supacloud-lite/src/vendor/tinbase/retention/service.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/retention/service.ts
@@ -24,6 +24,7 @@ const DAY_MS = 24 * 60 * 60 * 1000
 /** Periodically purges expired/stale auth rows so those tables can't grow unbounded. */
 export class RetentionService {
   private timer: ReturnType<typeof setInterval> | null = null
+  private timerGeneration = 0
   // Tracks the sweep currently in flight. The boot sweep and interval sweeps
   // run un-awaited, but stop() must be able to drain the in-flight one before
   // the caller closes the database: PGlite has a single connection, and calling
@@ -45,10 +46,15 @@ export class RetentionService {
 
   /** Sweep once at boot, then on the configured interval; no-op if already running. */
   start(): void {
-    if (this.timer) return
+    if (this.timer !== null) return
     void this.sweep()
-    this.timer = setInterval(() => void this.sweep(), this.intervalMs)
-    if (typeof this.timer === 'object' && 'unref' in this.timer) (this.timer as { unref: () => void }).unref()
+    const generation = ++this.timerGeneration
+    let timer: ReturnType<typeof setInterval>
+    timer = setInterval(() => {
+      if (this.timer === timer && this.timerGeneration === generation) void this.sweep()
+    }, this.intervalMs)
+    this.timer = timer
+    if (typeof timer === 'object' && 'unref' in timer) (timer as { unref: () => void }).unref()
   }
 
   /**
@@ -56,9 +62,12 @@ export class RetentionService {
    * can safely close the database without racing a queued sweep query.
    */
   async stop(): Promise<void> {
-    if (this.timer) clearInterval(this.timer)
+    const timer = this.timer
     this.timer = null
-    await this.inFlight?.catch(() => {})
+    this.timerGeneration += 1
+    if (timer !== null) clearInterval(timer)
+    const inFlight = this.inFlight
+    await inFlight?.catch(() => {})
   }
 
   /** Run a single retention pass (also callable directly in tests). */

--- a/packages/supacloud-lite/src/vendor/tinbase/webhooks/service.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/webhooks/service.ts
@@ -6,6 +6,7 @@
  * webhook payload exactly: { type, table, schema, record, old_record }.
  */
 import type { CdcEvent, Database } from '../db/database.js'
+import type { EngineUnsubscribe } from '../db/engine.js'
 import { guardedFetch } from '../net/service.js'
 
 /** A registered database webhook: which changes to watch and where to POST them. */
@@ -42,7 +43,7 @@ export interface WebhookDelivery {
 /** Watches the CDC stream and POSTs matching row changes to registered webhooks. */
 export class WebhooksService {
   private hooks: WebhookConfig[] = []
-  private stop: (() => void) | null = null
+  private stop: EngineUnsubscribe | null = null
   private started = false
 
   constructor(
@@ -85,10 +86,11 @@ export class WebhooksService {
   }
 
   /** Unsubscribe from the CDC stream; registered hooks are retained. */
-  stopService(): void {
-    this.stop?.()
+  async stopService(): Promise<void> {
+    const stop = this.stop
     this.stop = null
     this.started = false
+    await stop?.()
   }
 
   private dispatch(event: CdcEvent): void {

--- a/packages/supacloud-lite/test/background-services-shutdown.test.ts
+++ b/packages/supacloud-lite/test/background-services-shutdown.test.ts
@@ -145,6 +145,114 @@ test('releases retention single-flight state after an unexpected failure', async
   expect(clockCalls).toBe(2)
 })
 
+for (const { name, create, hasBootSweep } of getBackgroundServices()) {
+  test(`${name} ignores a queued interval callback after stop`, async () => {
+    const intervals = installManualIntervals()
+    const database = createCountingDatabase()
+    const service = create(database.database)
+    try {
+      service.start()
+      if (hasBootSweep) await (service as RetentionService).sweep()
+      const oldCallback = intervals.callbackAt(0)
+
+      await service.stop()
+      const callsAfterStop = database.queryCalls()
+      oldCallback()
+      await flushMicrotasks()
+
+      expect(database.queryCalls()).toBe(callsAfterStop)
+    } finally {
+      await service.stop()
+      intervals.restore()
+    }
+  })
+
+  test(`${name} ignores an old callback after restart when timer handles are reused`, async () => {
+    const intervals = installManualIntervals()
+    const database = createCountingDatabase()
+    const service = create(database.database)
+    try {
+      service.start()
+      if (hasBootSweep) await (service as RetentionService).sweep()
+      const oldCallback = intervals.callbackAt(0)
+      await service.stop()
+
+      service.start()
+      if (hasBootSweep) await (service as RetentionService).sweep()
+      const newCallback = intervals.callbackAt(1)
+      const callsBeforeCallbacks = database.queryCalls()
+
+      oldCallback()
+      await flushMicrotasks()
+      expect(database.queryCalls()).toBe(callsBeforeCallbacks)
+
+      newCallback()
+      await flushMicrotasks()
+      expect(database.queryCalls()).toBeGreaterThan(callsBeforeCallbacks)
+    } finally {
+      await service.stop()
+      intervals.restore()
+    }
+  })
+}
+
+function getBackgroundServices(): Array<{
+  name: string
+  create: (database: Database) => { start(): void; stop(): Promise<void> }
+  hasBootSweep: boolean
+}> {
+  return [
+    { name: 'net', create: (database) => new NetService(database, fetch, 1), hasBootSweep: false },
+    { name: 'cron', create: (database) => new CronService(database, 1), hasBootSweep: false },
+    {
+      name: 'retention',
+      create: (database) => new RetentionService(database, { auditLogDays: 0, refreshTokenDays: 0 }),
+      hasBootSweep: true,
+    },
+  ]
+}
+
+function createCountingDatabase() {
+  let queryCalls = 0
+  return {
+    database: {
+      async query() {
+        queryCalls += 1
+        return { rows: [], affectedRows: 0 }
+      },
+    } as unknown as Database,
+    queryCalls: () => queryCalls,
+  }
+}
+
+function installManualIntervals() {
+  const setInterval = globalThis.setInterval
+  const clearInterval = globalThis.clearInterval
+  const callbacks: Array<() => void> = []
+  const reusedHandle = {} as ReturnType<typeof setInterval>
+  globalThis.setInterval = ((callback: () => void) => {
+    callbacks.push(callback)
+    return reusedHandle
+  }) as typeof setInterval
+  globalThis.clearInterval = (() => {}) as typeof clearInterval
+  return {
+    callbackAt: (index: number) => {
+      const callback = callbacks[index]
+      if (!callback) throw new Error(`missing interval callback ${index}`)
+      return callback
+    },
+    restore: () => {
+      globalThis.setInterval = setInterval
+      globalThis.clearInterval = clearInterval
+    },
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 function createGatedDatabase(failuresBeforeGate = 0) {
   const queryStarted = Promise.withResolvers<void>()
   const queryGate = Promise.withResolvers<void>()

--- a/packages/supacloud-lite/test/listener-shutdown.test.ts
+++ b/packages/supacloud-lite/test/listener-shutdown.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from 'bun:test'
+import { Database as TinbaseDatabase } from '../src/vendor/tinbase/db/database.js'
+import type { DbEngine, EngineResults, EngineTx, EngineUnsubscribe } from '../src/vendor/tinbase/db/engine.js'
+import { RealtimeEngine } from '../src/vendor/tinbase/realtime/engine.js'
+
+test('shares CDC LISTEN and awaits the final asynchronous unsubscribe', async () => {
+  const unsubscribeGate = Promise.withResolvers<void>()
+  let listenCalls = 0
+  let unsubscribeCalls = 0
+  const engine = createListenerEngine(async (channel) => {
+    listenCalls += 1
+    return async () => {
+      expect(channel).toBe('tinbase_cdc')
+      unsubscribeCalls += 1
+      await unsubscribeGate.promise
+    }
+  })
+  const database = await TinbaseDatabase.create(engine)
+  const firstStop = await database.onCdcEvent(() => {})
+  const secondStop = await database.onCdcEvent(() => {})
+
+  expect(listenCalls).toBe(1)
+  await firstStop()
+  expect(unsubscribeCalls).toBe(0)
+
+  let stopped = false
+  const stopPromise = secondStop().then(() => {
+    stopped = true
+  })
+  await flushMicrotasks()
+  expect(unsubscribeCalls).toBe(1)
+  expect(stopped).toBeFalse()
+
+  const restartPromise = database.onCdcEvent(() => {})
+  await flushMicrotasks()
+  expect(listenCalls).toBe(1)
+  unsubscribeGate.resolve()
+  await stopPromise
+  const restartStop = await restartPromise
+  expect(listenCalls).toBe(2)
+  await restartStop()
+  await database.close()
+})
+
+test('Realtime stop waits for both unsubscriptions and propagates the first error', async () => {
+  const cdcGate = Promise.withResolvers<void>()
+  const broadcastGate = Promise.withResolvers<void>()
+  const cdcError = new Error('cdc unsubscribe failed')
+  const broadcastError = new Error('broadcast unsubscribe failed')
+  const unsubscribeCalls: string[] = []
+  const engine = createListenerEngine(async (channel) => {
+    if (channel === 'tinbase_cdc') {
+      return async () => {
+        unsubscribeCalls.push(channel)
+        await cdcGate.promise
+      }
+    }
+    return async () => {
+      unsubscribeCalls.push(channel)
+      await broadcastGate.promise
+    }
+  })
+  const database = await TinbaseDatabase.create(engine)
+  const realtime = new RealtimeEngine(database)
+  await realtime.start()
+
+  let settled = false
+  const stopPromise = realtime.stop().finally(() => {
+    settled = true
+  })
+  await flushMicrotasks()
+  expect(unsubscribeCalls.toSorted()).toEqual(['tinbase_cdc', 'tinbase_realtime_broadcast'])
+  expect(settled).toBeFalse()
+
+  cdcGate.reject(cdcError)
+  await flushMicrotasks()
+  expect(settled).toBeFalse()
+  broadcastGate.reject(broadcastError)
+  await expect(stopPromise).rejects.toBe(cdcError)
+  expect(settled).toBeTrue()
+})
+
+function createListenerEngine(onListen: (channel: string) => Promise<EngineUnsubscribe>): DbEngine {
+  return {
+    minimalBootstrap: true,
+    async query<T>(): Promise<EngineResults<T>> {
+      return { rows: [] }
+    },
+    async exec(): Promise<void> {},
+    async transaction<T>(fn: (tx: EngineTx) => Promise<T>): Promise<T> {
+      return fn({
+        async query<R>(): Promise<EngineResults<R>> {
+          return { rows: [] }
+        },
+        async exec(): Promise<void> {},
+      })
+    },
+    listen: onListen,
+    async close(): Promise<void> {},
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}


### PR DESCRIPTION
## Summary

- invalidate queued Net, Cron, and Retention interval callbacks before database shutdown
- preserve in-flight single-flight state across stop/restart races
- add deterministic coverage for stale callbacks and reused timer handles

## Verification

- bun run typecheck
- bun test test/background-services-shutdown.test.ts test/cli-shutdown.test.ts --timeout 20000
- background shutdown test: 20/20 rounds, 220/220 tests
- snapshot test: 20/20 rounds, 100/100 tests
- bun run check: 84 tests, builds, package smoke, standalone smoke
- git diff --check

This follow-up fixes the shutdown race exposed by the Windows Lite checks on #663.