### PR TITLE
fix(lite): skip runtime services for utility commands

### DIFF
--- a/packages/supacloud-lite/scripts/standalone-smoke.ts
+++ b/packages/supacloud-lite/scripts/standalone-smoke.ts
@@ -52,15 +52,24 @@ Deno.serve(() => Response.json({ ok: true, runtime: 'standalone' }))
 `)
 
   const isolatedEnvironment = withoutRuntimePath(emptyPath)
-  const version = (await runCommand([binary, 'version'], projectDir, isolatedEnvironment)).trim()
+  const version = (
+    await runCommand('version', [binary, 'version'], projectDir, isolatedEnvironment)
+  ).trim()
   assert(version === packageJson.version, `unexpected standalone version: ${version}`)
 
-  await runCommand([binary, 'migrate', '--project-dir', projectDir], projectDir, isolatedEnvironment)
-  const statusV1 = await runCommand([binary, 'status', '--project-dir', projectDir], projectDir, isolatedEnvironment)
+  await runCommand('migrate v1', [binary, 'migrate', '--project-dir', projectDir], projectDir, isolatedEnvironment)
+  const statusV1 = await runCommand(
+    'status v1',
+    [binary, 'status', '--project-dir', projectDir],
+    projectDir,
+    isolatedEnvironment,
+  )
   assertMigrationStatus(statusV1, [v1], [v2], 'v1')
 
-  const anonKey = parseAnonKey(await runCommand([binary, 'keys', '--project-dir', projectDir], projectDir, isolatedEnvironment))
-  await withServer({ binary, projectDir, environment: isolatedEnvironment }, async (url) => {
+  const anonKey = parseAnonKey(
+    await runCommand('keys', [binary, 'keys', '--project-dir', projectDir], projectDir, isolatedEnvironment),
+  )
+  await withServer({ phaseLabel: 'server v1', binary, projectDir, environment: isolatedEnvironment }, async (url) => {
     const health = await fetch(`${url}/health`)
     assert(health.status === 200, `health returned HTTP ${health.status}`)
     assert((await health.json() as { status?: string }).status === 'healthy', 'health payload was not healthy')
@@ -87,7 +96,12 @@ end $$;
 alter table public.upgrade_probe
   add column upgraded boolean not null default true;
 `)
-  const upgradeOutput = await runCommand([binary, 'upgrade', '--project-dir', projectDir], projectDir, isolatedEnvironment)
+  const upgradeOutput = await runCommand(
+    'upgrade v2',
+    [binary, 'upgrade', '--project-dir', projectDir],
+    projectDir,
+    isolatedEnvironment,
+  )
   const snapshotMarker = 'Pre-upgrade snapshot: '
   const completionMarker = 'Upgrade complete on @supacloud/lite'
   assert(upgradeOutput.indexOf(snapshotMarker) >= 0, 'upgrade did not report its pre-upgrade snapshot')
@@ -98,7 +112,7 @@ alter table public.upgrade_probe
   assert(snapshotInfo.isFile() && snapshotInfo.size > 0, 'pre-upgrade snapshot is empty')
 
   const restoredStateDir = join(projectDir, '.restored-v1')
-  await runCommand([
+  await runCommand('snapshot restore pre-upgrade', [
     binary,
     'snapshot',
     'restore',
@@ -108,7 +122,7 @@ alter table public.upgrade_probe
     '--state-dir',
     restoredStateDir,
   ], projectDir, isolatedEnvironment)
-  const restoredStatus = await runCommand([
+  const restoredStatus = await runCommand('status restored v1', [
     binary,
     'status',
     '--project-dir',
@@ -126,6 +140,7 @@ alter table public.upgrade_probe
     'pre-upgrade snapshot did not preserve project secrets',
   )
   await withServer({
+    phaseLabel: 'server restored v1',
     binary,
     projectDir,
     environment: isolatedEnvironment,
@@ -139,11 +154,16 @@ alter table public.upgrade_probe
     assert(rows[0]?.body === 'preserved-v1', 'pre-upgrade snapshot did not preserve v1 data')
   })
 
-  const statusV2 = await runCommand([binary, 'status', '--project-dir', projectDir], projectDir, isolatedEnvironment)
+  const statusV2 = await runCommand(
+    'status v2',
+    [binary, 'status', '--project-dir', projectDir],
+    projectDir,
+    isolatedEnvironment,
+  )
   assertMigrationStatus(statusV2, [v1, v2], [], 'v2')
   assert(await readFile(storageSentinel, 'utf8') === 'preserved-storage-v1', 'upgrade changed local storage')
 
-  await withServer({ binary, projectDir, environment: isolatedEnvironment }, async (url) => {
+  await withServer({ phaseLabel: 'server v2', binary, projectDir, environment: isolatedEnvironment }, async (url) => {
     const response = await fetch(`${url}/rest/v1/upgrade_probe?select=id,body,upgraded&id=eq.1`, {
       headers: { apikey: anonKey },
     })
@@ -177,6 +197,7 @@ function resolveStandaloneBinary(): string {
 }
 
 interface ServerOptions {
+  phaseLabel: string
   binary: string
   projectDir: string
   environment: NodeJS.ProcessEnv
@@ -186,6 +207,7 @@ interface ServerOptions {
 async function withServer(options: ServerOptions, check: (url: string) => Promise<void>): Promise<void> {
   const port = await findEphemeralPort()
   const stateArgs = options.stateDir ? ['--state-dir', options.stateDir] : []
+  console.log(`[standalone-smoke] ${options.phaseLabel}: start`)
   const processHandle = Bun.spawn({
     cmd: [options.binary, 'start', '--project-dir', options.projectDir, '--host', '127.0.0.1', '--port', String(port), ...stateArgs],
     cwd: options.projectDir,
@@ -198,12 +220,18 @@ async function withServer(options: ServerOptions, check: (url: string) => Promis
   const url = `http://127.0.0.1:${port}`
   try {
     await waitForHealth(url, processHandle)
+    console.log(`[standalone-smoke] ${options.phaseLabel}: healthy`)
     await check(url)
   } finally {
+    console.log(`[standalone-smoke] ${options.phaseLabel}: stop`)
     processHandle.kill('SIGTERM')
     const exitCode = await processHandle.exited
+    const expectedExitCode = expectedStandaloneShutdownExitCode()
+    console.log(
+      `[standalone-smoke] ${options.phaseLabel}: ${exitCode === expectedExitCode ? 'ok' : 'failed'} (exit ${exitCode})`,
+    )
     const [stdoutText, stderrText] = await Promise.all([stdout, stderr])
-    if (exitCode !== expectedStandaloneShutdownExitCode()) {
+    if (exitCode !== expectedExitCode) {
       throw new Error(`standalone server exited with ${exitCode}\n${stdoutText}\n${stderrText}`)
     }
   }
@@ -238,14 +266,20 @@ async function findEphemeralPort(): Promise<number> {
   return port
 }
 
-async function runCommand(command: string[], cwd: string, env: NodeJS.ProcessEnv): Promise<string> {
+async function runCommand(
+  commandLabel: string,
+  command: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  console.log(`[standalone-smoke] ${commandLabel}: start`)
   const processHandle = Bun.spawn({ cmd: command, cwd, env, stdout: 'pipe', stderr: 'pipe' })
-  const [exitCode, stdout, stderr] = await Promise.all([
-    processHandle.exited,
-    new Response(processHandle.stdout).text(),
-    new Response(processHandle.stderr).text(),
-  ])
-  if (exitCode !== 0) throw new Error(`${command.join(' ')} failed (${exitCode})\n${stdout}\n${stderr}`)
+  const stdoutPromise = new Response(processHandle.stdout).text()
+  const stderrPromise = new Response(processHandle.stderr).text()
+  const exitCode = await processHandle.exited
+  console.log(`[standalone-smoke] ${commandLabel}: ${exitCode === 0 ? 'ok' : 'failed'} (exit ${exitCode})`)
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise])
+  if (exitCode !== 0) throw new Error(`standalone command "${commandLabel}" failed (${exitCode})\n${stdout}\n${stderr}`)
   return stdout
 }
 

--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -114,7 +114,13 @@ async function main(): Promise<void> {
     if (options.positionals[0] && options.positionals[0] !== 'types' && options.positionals[0] !== 'typescript') {
       throw new Error(`unknown gen subcommand: ${options.positionals[0]}`)
     }
-    const project = await createProjectBackend({ ...options, includeFunctions: false, includeWebhooks: false, log: quietLog })
+    const project = await createProjectBackend({
+      ...options,
+      includeFunctions: false,
+      includeWebhooks: false,
+      startRuntimeServices: false,
+      log: quietLog,
+    })
     try {
       const source = await generateTypes(project.backend.db, 'public')
       if (options.output) {
@@ -129,7 +135,13 @@ async function main(): Promise<void> {
   }
 
   if (options.command === 'inspect') {
-    const project = await createProjectBackend({ ...options, includeFunctions: false, includeWebhooks: false, log: quietLog })
+    const project = await createProjectBackend({
+      ...options,
+      includeFunctions: false,
+      includeWebhooks: false,
+      startRuntimeServices: false,
+      log: quietLog,
+    })
     try {
       printInspection(await inspectDb(project.backend.db, 'public'))
     } finally {
@@ -145,6 +157,7 @@ async function main(): Promise<void> {
       includeFunctions: false,
       includeWebhooks: false,
       includeSeed: options.command === 'migrate',
+      startRuntimeServices: false,
       log: quietLog,
     })
     try {
@@ -190,7 +203,13 @@ async function runDbCommand(options: CliOptions): Promise<void> {
     await assertResetPathsSafe(paths)
     if (paths.dataDir) await rm(paths.dataDir, { recursive: true, force: true })
     await rm(paths.storageDir, { recursive: true, force: true })
-    const project = await createProjectBackend({ ...options, includeFunctions: false, includeWebhooks: false, log: quietLog })
+    const project = await createProjectBackend({
+      ...options,
+      includeFunctions: false,
+      includeWebhooks: false,
+      startRuntimeServices: false,
+      log: quietLog,
+    })
     try {
       const applied = await project.backend.db.listAppliedMigrations()
       console.log(`reset complete: ${applied.length} migration(s) applied`)
@@ -277,6 +296,7 @@ async function runUpgradeCommand(options: CliOptions): Promise<void> {
       includeFunctions: false,
       includeWebhooks: false,
       includeSeed: true,
+      startRuntimeServices: false,
       log: quietLog,
     })
     try {

--- a/packages/supacloud-lite/src/project-runtime.ts
+++ b/packages/supacloud-lite/src/project-runtime.ts
@@ -42,6 +42,7 @@ export interface ProjectRuntimeOptions {
   includeFunctions?: boolean
   includeWebhooks?: boolean
   includeSeed?: boolean
+  startRuntimeServices?: boolean
   log?: (message: string) => void
 }
 
@@ -257,6 +258,7 @@ export async function createProjectBackend(options: ProjectRuntimeOptions = {}):
     ),
     functionEnv,
     webhooks,
+    startRuntimeServices: options.startRuntimeServices,
     storageDriver: options.storageDriver ?? createStorageDriver(configuredStorageBackend, paths.storageDir, options.s3),
     log: options.log,
   })
@@ -298,7 +300,7 @@ function createStorageDriver(
 
 export async function startProjectServer(options: ProjectRuntimeOptions = {}): Promise<RunningProjectServer> {
   const resolvedOptions = options.port === 0 ? { ...options, port: await findEphemeralPort(options.host) } : options
-  const project = await createProjectBackend(resolvedOptions)
+  const project = await createProjectBackend({ ...resolvedOptions, startRuntimeServices: true })
   try {
     const server = await serveBun(project.backend, { host: project.host, port: project.port })
     let closePromise: Promise<void> | null = null

--- a/packages/supacloud-lite/src/vendor/tinbase/index.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/index.ts
@@ -226,19 +226,21 @@ export async function createBackend(config: BackendConfig = {}): Promise<Tinbase
     log(`[net] ${d.method} ${d.url} -> ${d.timedOut ? 'TIMEOUT' : d.error ? 'FAILED ' + d.error : d.status}`)
   )
 
-  try {
-    await realtime.start()
-    cleanup.push(() => realtime.stop())
-    if (config.webhooks?.length) await webhooks.start(config.webhooks)
-    cleanup.push(() => webhooks.stopService())
-    cron.start()
-    cleanup.push(() => cron.stop())
-    retention.start()
-    cleanup.push(() => retention.stop())
-    net.start()
-    cleanup.push(() => net.stop())
-  } catch (e) {
-    await failStartup(e)
+  if (config.startRuntimeServices !== false) {
+    try {
+      await realtime.start()
+      cleanup.push(() => realtime.stop())
+      if (config.webhooks?.length) await webhooks.start(config.webhooks)
+      cleanup.push(() => webhooks.stopService())
+      cron.start()
+      cleanup.push(() => cron.stop())
+      retention.start()
+      cleanup.push(() => retention.stop())
+      net.start()
+      cleanup.push(() => net.stop())
+    } catch (e) {
+      await failStartup(e)
+    }
   }
 
   const fnMap =

--- a/packages/supacloud-lite/src/vendor/tinbase/node/db-diff.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/node/db-diff.ts
@@ -36,6 +36,7 @@ export async function computeDbDiff(opts: DbDiffOptions): Promise<string[]> {
   const shadow: TinbaseBackend = await createBackend({
     engine: opts.makeShadowEngine ? await opts.makeShadowEngine() : undefined,
     migrations: opts.migrations,
+    startRuntimeServices: false,
     // no seed: seed is data, not schema
   })
   let live: TinbaseBackend | undefined
@@ -48,6 +49,7 @@ export async function computeDbDiff(opts: DbDiffOptions): Promise<string[]> {
       engine: opts.liveEngine,
       dataDir: opts.liveEngine ? undefined : opts.liveDataDir,
       migrations: opts.migrations,
+      startRuntimeServices: false,
     })
     const shadowSnap = await snapshotSchema(shadow.db, schema)
     const liveSnap = await snapshotSchema(live.db, schema)
@@ -101,6 +103,7 @@ export async function pullSchema(opts: DbPullOptions): Promise<DbPullResult> {
   const shadow: TinbaseBackend = await createBackend({
     engine: opts.makeShadowEngine ? await opts.makeShadowEngine() : undefined,
     migrations: opts.migrations,
+    startRuntimeServices: false,
   })
   let live: TinbaseBackend | undefined
   let operationFailed = false
@@ -109,6 +112,7 @@ export async function pullSchema(opts: DbPullOptions): Promise<DbPullResult> {
       engine: opts.liveEngine,
       dataDir: opts.liveEngine ? undefined : opts.liveDataDir,
       migrations: opts.migrations,
+      startRuntimeServices: false,
     })
     const ddl = diffSchemas(await snapshotSchema(shadow.db, schema), await snapshotSchema(live.db, schema), schema)
     if (ddl.length === 0) return { ddl, version: null, path: null }

--- a/packages/supacloud-lite/src/vendor/tinbase/types.ts
+++ b/packages/supacloud-lite/src/vendor/tinbase/types.ts
@@ -119,6 +119,8 @@ export interface BackendConfig {
   authRateLimits?: Record<string, import('./auth/rate-limit.js').RateLimitRule>
   /** Mount the auth service. Default true; config.toml auth.enabled = false turns /auth/v1 off. */
   authEnabled?: boolean
+  /** Start Realtime and background services. Disable for short-lived maintenance commands. Default true. */
+  startRuntimeServices?: boolean
 }
 
 /** A rendered outbound email (OTP code, magic link, recovery, etc.). */

--- a/packages/supacloud-lite/test/listener-shutdown.test.ts
+++ b/packages/supacloud-lite/test/listener-shutdown.test.ts
@@ -1,7 +1,44 @@
 import { expect, test } from 'bun:test'
 import { Database as TinbaseDatabase } from '../src/vendor/tinbase/db/database.js'
 import type { DbEngine, EngineResults, EngineTx, EngineUnsubscribe } from '../src/vendor/tinbase/db/engine.js'
+import { createBackend } from '../src/vendor/tinbase/index.js'
+import { computeDbDiff, pullSchema } from '../src/vendor/tinbase/node/db-diff.js'
 import { RealtimeEngine } from '../src/vendor/tinbase/realtime/engine.js'
+
+test('utility backends do not attach database listeners', async () => {
+  let listenCalls = 0
+  const engine = createListenerEngine(async () => {
+    listenCalls += 1
+    return () => {}
+  })
+  const backend = await createBackend({ engine, startRuntimeServices: false, log: () => {} })
+
+  expect(listenCalls).toBe(0)
+  await backend.close()
+  expect(listenCalls).toBe(0)
+})
+
+test('schema diff utilities keep shadow and live engines listener-free', async () => {
+  const listenCalls = { diffShadow: 0, diffLive: 0, pullShadow: 0, pullLive: 0 }
+  const createCountingEngine = (backendName: keyof typeof listenCalls) =>
+    createListenerEngine(async () => {
+      listenCalls[backendName] += 1
+      return () => {}
+    })
+
+  await computeDbDiff({
+    migrations: [],
+    makeShadowEngine: async () => createCountingEngine('diffShadow'),
+    liveEngine: createCountingEngine('diffLive'),
+  })
+  await pullSchema({
+    migrations: [],
+    makeShadowEngine: async () => createCountingEngine('pullShadow'),
+    liveEngine: createCountingEngine('pullLive'),
+  })
+
+  expect(listenCalls).toEqual({ diffShadow: 0, diffLive: 0, pullShadow: 0, pullLive: 0 })
+})
 
 test('shares CDC LISTEN and awaits the final asynchronous unsubscribe', async () => {
   const unsubscribeGate = Promise.withResolvers<void>()


### PR DESCRIPTION
## Summary

- keep Realtime, webhooks, cron, retention, and net disabled for short-lived CLI maintenance commands
- preserve runtime services for server mode and default backend consumers
- cover schema diff/pull shadow and live backends with listener-free lifecycle tests

## Root cause

One-shot commands such as `status` created the full long-running backend even though they only needed database access. On Windows, shutdown could then stall after printing the migration state because unnecessary PGlite listener/background services had been started.

## Verification

- `bun run check` (88 tests, typecheck, build, package smoke, standalone smoke)
- `git diff --check origin/main`
- independent lifecycle/call-site review
- `clean-code-guard: clean`

## Compatibility

`createBackend()` keeps runtime services enabled by default, and `startProjectServer()` explicitly forces them on.