### PR TITLE
fix(management-api): use setpriv for backup commands in sandbox

### DIFF
--- a/infrastructure/systemd/supacloud.service
+++ b/infrastructure/systemd/supacloud.service
@@ -48,7 +48,7 @@ ReadWritePaths=/etc/supabase /run/supacloud-unit-requests /etc/supacloud/caddy /
 SystemCallFilter=@system-service @chown
 SystemCallFilter=~@mount @reboot @swap @raw-io @keyring
 SystemCallArchitectures=native
-CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID
 
 MemoryMax=4G
 MemoryHigh=3G

--- a/install.sh
+++ b/install.sh
@@ -2929,6 +2929,7 @@ RestartSec=10
 StartLimitBurst=5
 StartLimitIntervalSec=60
 LimitNOFILE=65536
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID
 
 [Install]
 WantedBy=multi-user.target
@@ -3064,8 +3065,21 @@ CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUI
 EOF
 }
 
+ensure_management_privilege_tools_available() {
+    local tool
+    for tool in setpriv id; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            log_error "Management API backup privilege separation requires ${tool}"
+            return 1
+        fi
+    done
+    return 0
+}
+
 install_management_api() {
     log_step "Preparing to deploy SupaCloud Control Plane binary..."
+
+    ensure_management_privilege_tools_available || return 1
 
     local BIN_NAME="supacloud"
     local BIN_TARGET="/usr/local/bin/${BIN_NAME}"

--- a/packages/management-api/src/services/backup.service.ts
+++ b/packages/management-api/src/services/backup.service.ts
@@ -16,6 +16,8 @@ const BACKUP_TIMEOUT_MS = 30 * 60_000;
 const PITR_TIMEOUT_MS = 30 * 60_000;
 const TIMEOUT_KILL_AFTER = "--kill-after=30s";
 const SETPRIV_PATH = ["/usr/bin/setpriv", "/bin/setpriv"].find(existsSync) ?? "/usr/bin/setpriv";
+const ID_PATH = ["/usr/bin/id", "/bin/id"].find(existsSync) ?? "/usr/bin/id";
+const PRIMARY_GID_PATTERN = /^\d+$/;
 
 interface PgBackRestCommandResult {
   exitCode: number;
@@ -68,30 +70,52 @@ export function isPitrEnabled(environment: Record<string, string | undefined> = 
   return environment.SUPACLOUD_PITR_ENABLED === "true" || environment.PITR_ENABLED === "true";
 }
 
-function privilegeDropCommand(user: string, command: string[]): string[] {
+async function primaryGid(user: string): Promise<string> {
+  const identityProcess = Bun.spawn([
+    "timeout",
+    TIMEOUT_KILL_AFTER,
+    String(Math.ceil(INFO_TIMEOUT_MS / 1000)),
+    ID_PATH,
+    "-g",
+    user,
+  ], { stdout: "pipe", stderr: "pipe" });
+  const [exitCode, stdout] = await Promise.all([
+    identityProcess.exited,
+    new Response(identityProcess.stdout).text(),
+    new Response(identityProcess.stderr).text(),
+  ]);
+  const gid = stdout.trim();
+  if (exitCode !== 0 || !PRIMARY_GID_PATTERN.test(gid)) {
+    throw new Error("Backup user primary GID lookup failed");
+  }
+  return gid;
+}
+
+function privilegeDropCommand(user: string, gid: string, command: string[]): string[] {
   return [
     SETPRIV_PATH,
     "--reuid",
     user,
     "--regid",
-    user,
-    "--clear-groups",
+    gid,
+    "--init-groups",
     "--",
     ...command,
   ];
 }
 
-function pgBackRestCommand(
+async function pgBackRestCommand(
   pgBackRestArguments: string[],
   timeoutMs = pgBackRestArguments.includes("backup") ? BACKUP_TIMEOUT_MS : INFO_TIMEOUT_MS,
-): string[] {
+): Promise<string[]> {
   const configuration = readPgBackRestConfiguration();
   const configurationArgument = configuration.config ? [`--config=${configuration.config}`] : [];
+  const gid = await primaryGid(configuration.user);
   return [
     "timeout",
     TIMEOUT_KILL_AFTER,
     String(Math.ceil(timeoutMs / 1000)),
-    ...privilegeDropCommand(configuration.user, [
+    ...privilegeDropCommand(configuration.user, gid, [
       configuration.binary,
       ...configurationArgument,
       `--stanza=${configuration.stanza}`,
@@ -102,7 +126,8 @@ function pgBackRestCommand(
 
 async function runPgBackRest(pgBackRestArguments: string[], timeoutMs: number): Promise<PgBackRestCommandResult> {
   try {
-    const pgBackRestProcess = Bun.spawn(pgBackRestCommand(pgBackRestArguments, timeoutMs), { stdout: "pipe", stderr: "pipe" });
+    const command = await pgBackRestCommand(pgBackRestArguments, timeoutMs);
+    const pgBackRestProcess = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
     const [exitCode, stdout] = await Promise.all([
       pgBackRestProcess.exited,
       new Response(pgBackRestProcess.stdout).text(),
@@ -304,11 +329,12 @@ export async function restore(request: RestoreRequest): Promise<{ message: strin
   try {
     let exitCode: number;
     try {
+      const postgresGid = await primaryGid("postgres");
       const restoreProcess = Bun.spawn([
         "timeout",
         TIMEOUT_KILL_AFTER,
         String(Math.ceil(PITR_TIMEOUT_MS / 1000)),
-        ...privilegeDropCommand("postgres", [
+        ...privilegeDropCommand("postgres", postgresGid, [
           "pig",
           "pitr",
           "-s",

--- a/packages/management-api/src/services/backup.service.ts
+++ b/packages/management-api/src/services/backup.service.ts
@@ -1,4 +1,5 @@
 import { $ } from 'bun';
+import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import { logger } from "../utils/logger";
@@ -14,6 +15,7 @@ const INFO_TIMEOUT_MS = 5_000;
 const BACKUP_TIMEOUT_MS = 30 * 60_000;
 const PITR_TIMEOUT_MS = 30 * 60_000;
 const TIMEOUT_KILL_AFTER = "--kill-after=30s";
+const SETPRIV_PATH = ["/usr/bin/setpriv", "/bin/setpriv"].find(existsSync) ?? "/usr/bin/setpriv";
 
 interface PgBackRestCommandResult {
   exitCode: number;
@@ -66,6 +68,19 @@ export function isPitrEnabled(environment: Record<string, string | undefined> = 
   return environment.SUPACLOUD_PITR_ENABLED === "true" || environment.PITR_ENABLED === "true";
 }
 
+function privilegeDropCommand(user: string, command: string[]): string[] {
+  return [
+    SETPRIV_PATH,
+    "--reuid",
+    user,
+    "--regid",
+    user,
+    "--clear-groups",
+    "--",
+    ...command,
+  ];
+}
+
 function pgBackRestCommand(
   pgBackRestArguments: string[],
   timeoutMs = pgBackRestArguments.includes("backup") ? BACKUP_TIMEOUT_MS : INFO_TIMEOUT_MS,
@@ -76,14 +91,12 @@ function pgBackRestCommand(
     "timeout",
     TIMEOUT_KILL_AFTER,
     String(Math.ceil(timeoutMs / 1000)),
-    "sudo",
-    "-n",
-    "-u",
-    configuration.user,
-    configuration.binary,
-    ...configurationArgument,
-    `--stanza=${configuration.stanza}`,
-    ...pgBackRestArguments,
+    ...privilegeDropCommand(configuration.user, [
+      configuration.binary,
+      ...configurationArgument,
+      `--stanza=${configuration.stanza}`,
+      ...pgBackRestArguments,
+    ]),
   ];
 }
 
@@ -295,17 +308,15 @@ export async function restore(request: RestoreRequest): Promise<{ message: strin
         "timeout",
         TIMEOUT_KILL_AFTER,
         String(Math.ceil(PITR_TIMEOUT_MS / 1000)),
-        "sudo",
-        "-n",
-        "-u",
-        "postgres",
-        "pig",
-        "pitr",
-        "-s",
-        getPgBackRestStanza(),
-        "-t",
-        request.target,
-        "-y",
+        ...privilegeDropCommand("postgres", [
+          "pig",
+          "pitr",
+          "-s",
+          getPgBackRestStanza(),
+          "-t",
+          request.target,
+          "-y",
+        ]),
       ], { stdout: "pipe", stderr: "pipe" });
       [exitCode] = await Promise.all([
         restoreProcess.exited,

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -26,6 +26,7 @@ const WEB_CONSOLE_ROOT = "/opt/supacloud/web-console";
 const WEB_CONSOLE_RELEASES_DIR = `${WEB_CONSOLE_ROOT}/releases`;
 const WEB_CONSOLE_CURRENT_LINK = WEB_CONSOLE_CURRENT_DIR;
 const DEFAULT_EDGE_RUNTIME_CAPACITY_DROPIN = "/etc/systemd/system/supacloud-edge-runtime.service.d/50-edge-runtime-capacity.conf";
+const DEFAULT_MANAGEMENT_PRIVILEGE_DROPIN = "/etc/systemd/system/supacloud.service.d/40-management-privilege.conf";
 const DEFAULT_EMBEDDED_EDGE_PRIVILEGE_DROPIN = "/etc/systemd/system/supacloud.service.d/50-embedded-edge-privilege.conf";
 const DEFAULT_EDGE_WORKER_POOL_SIZE = 20;
 const DEFAULT_EDGE_BACKGROUND_WORKER_POOL_SIZE = 20;
@@ -360,6 +361,15 @@ export async function verifyManagementUpgradePreflight(
     const snapshot = await inspectActiveManagementBinary(options);
     assertCanonicalManagementBinary(snapshot, "Refusing to migrate");
     return snapshot;
+}
+
+export function verifyBackupPrivilegeDropPreflight(
+    pathExists: (filePath: string) => boolean = existsSync,
+): void {
+    const setprivPath = ["/usr/bin/setpriv", "/bin/setpriv"].find(pathExists);
+    const idPath = ["/usr/bin/id", "/bin/id"].find(pathExists);
+    if (!setprivPath) throw new Error("Management upgrade requires setpriv for backup privilege separation");
+    if (!idPath) throw new Error("Management upgrade requires id for backup account resolution");
 }
 
 export async function verifyActivatedManagementBinary(
@@ -698,6 +708,18 @@ CPUWeight=60
 TasksMax=${config.tasksMax}
 OOMPolicy=stop
 `;
+}
+
+export function buildManagementPrivilegeDropIn() {
+    return `[Service]
+# Backup and PITR commands use setpriv from the root Management API process.
+CapabilityBoundingSet=
+CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID
+`;
+}
+
+function ensureManagementPrivilegeDropIn(filePath = DEFAULT_MANAGEMENT_PRIVILEGE_DROPIN) {
+    writeFileAtomically(filePath, buildManagementPrivilegeDropIn(), 0o644);
 }
 
 export function buildEmbeddedEdgePrivilegeDropIn() {
@@ -1266,14 +1288,35 @@ async function reloadSystemdUnits() {
     }
 }
 
-async function reconcileEmbeddedEdgePrivilegeDropIn(mode: "embedded" | "external", identity: EdgeRuntimeIdentity) {
+async function reconcileEmbeddedPrivilegeDropIn(
+    mode: "embedded" | "external",
+    identity: EdgeRuntimeIdentity,
+    filePath: string,
+) {
     if (mode === "embedded") {
         await ensureEmbeddedEdgeRuntimeSourceAccess(identity);
-        writeFileAtomically(embeddedEdgePrivilegeDropIn(), buildEmbeddedEdgePrivilegeDropIn(), 0o644);
+        writeFileAtomically(filePath, buildEmbeddedEdgePrivilegeDropIn(), 0o644);
     } else {
-        rmSync(embeddedEdgePrivilegeDropIn(), { force: true });
+        rmSync(filePath, { force: true });
     }
-    await reloadSystemdUnits();
+}
+
+export async function reconcileManagementPrivilegeDropIns(
+    mode: "embedded" | "external",
+    identity: EdgeRuntimeIdentity,
+    options: {
+        managementDropInPath?: string;
+        embeddedDropInPath?: string;
+        reloadSystemd?: () => Promise<void>;
+    } = {},
+) {
+    await reconcileEmbeddedPrivilegeDropIn(
+        mode,
+        identity,
+        options.embeddedDropInPath ?? embeddedEdgePrivilegeDropIn(),
+    );
+    ensureManagementPrivilegeDropIn(options.managementDropInPath);
+    await (options.reloadSystemd ?? reloadSystemdUnits)();
 }
 
 async function edgeRuntimeServiceIsInstalled(): Promise<boolean> {
@@ -1402,6 +1445,7 @@ type UpgradeActivationState = {
     managementEnvState: FileState | null;
     edgeRuntimeEnvState: FileState | null;
     edgeRuntimeDropInState: FileState | null;
+    managementPrivilegeDropInState: FileState | null;
     embeddedEdgePrivilegeDropInState: FileState | null;
 };
 
@@ -1449,6 +1493,9 @@ async function rollbackArtifacts(state: UpgradeActivationState, stagedWeb: Stage
     }
     if (state.edgeRuntimeDropInState) {
         restoreFileState(state.edgeRuntimeDropInState);
+    }
+    if (state.managementPrivilegeDropInState) {
+        restoreFileState(state.managementPrivilegeDropInState);
     }
     if (state.embeddedEdgePrivilegeDropInState) {
         restoreFileState(state.embeddedEdgePrivilegeDropInState);
@@ -1504,6 +1551,7 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
         await executeUpgradeTransaction({
             preflight: async () => {
                 s.start(`Verifying ${MANAGEMENT_SERVICE_UNIT} uses the canonical upgrade target`);
+                verifyBackupPrivilegeDropPreflight();
                 await verifyManagementUpgradePreflight();
             },
             stage: async () => {
@@ -1529,6 +1577,7 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                     managementEnvState: null,
                     edgeRuntimeEnvState: null,
                     edgeRuntimeDropInState: null,
+                    managementPrivilegeDropInState: null,
                     embeddedEdgePrivilegeDropInState: null,
                 };
                 await activateArtifacts(stagedBinary, stagedWeb, activationState);
@@ -1539,12 +1588,13 @@ export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: 
                 activationState.managementEnvState = captureFileState(managementEnvFile());
                 activationState.edgeRuntimeEnvState = captureFileState(edgeRuntimeEnvFile());
                 activationState.edgeRuntimeDropInState = captureFileState(edgeRuntimeCapacityDropIn());
+                activationState.managementPrivilegeDropInState = captureFileState(DEFAULT_MANAGEMENT_PRIVILEGE_DROPIN);
                 activationState.embeddedEdgePrivilegeDropInState = captureFileState(embeddedEdgePrivilegeDropIn());
                 const edgeRuntimeIdentity = await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
                 upsertPersistedEdgeRuntimePort(managementEnvFile(), edgeRuntimeEnvFile());
                 const edgeRuntimeMode = await runtimeModeForBinaryUpgrade();
                 activatedEdgeRuntimeMode = edgeRuntimeMode;
-                await reconcileEmbeddedEdgePrivilegeDropIn(edgeRuntimeMode, edgeRuntimeIdentity);
+                await reconcileManagementPrivilegeDropIns(edgeRuntimeMode, edgeRuntimeIdentity);
                 if (edgeRuntimeMode === "external") {
                     await ensureEdgeRuntimeCapacityDropIn(env);
                 }

--- a/packages/management-api/tests/unit/backup.service.test.ts
+++ b/packages/management-api/tests/unit/backup.service.test.ts
@@ -9,12 +9,20 @@ interface CommandOutcome {
 }
 
 const commandOutcomes: CommandOutcome[] = [];
+const identityOutcomes: CommandOutcome[] = [];
 const spawnedCommands: string[][] = [];
+const identityCommands: string[][] = [];
 const spawnSpy = spyOn(Bun, "spawn").mockImplementation((command) => {
-  const commandOutcome = commandOutcomes.shift();
+  const commandArguments = command as string[];
+  const isIdentityLookup = commandArguments[0] === "timeout"
+    && commandArguments[3] === "/usr/bin/id"
+    && commandArguments[4] === "-g";
+  const commandOutcome = isIdentityLookup
+    ? identityOutcomes.shift() ?? { exitCode: 0, stdout: commandArguments[5] === "pgbackrest" ? "4321\n" : "26\n" }
+    : commandOutcomes.shift();
   if (!commandOutcome) throw new Error("Unexpected pgBackRest command");
+  (isIdentityLookup ? identityCommands : spawnedCommands).push(commandArguments);
   if (commandOutcome.startError) throw commandOutcome.startError;
-  spawnedCommands.push(command as string[]);
   return {
     exited: Promise.resolve(commandOutcome.exitCode ?? 0),
     stdout: new Blob([commandOutcome.stdout || ""]).stream(),
@@ -46,7 +54,9 @@ function fullBackup(label = "20260722-120000F", error = false) {
 describe("BackupService", () => {
   beforeEach(() => {
     commandOutcomes.length = 0;
+    identityOutcomes.length = 0;
     spawnedCommands.length = 0;
+    identityCommands.length = 0;
   });
 
   afterAll(() => spawnSpy.mockRestore());
@@ -57,7 +67,7 @@ describe("BackupService", () => {
 
     expect(spawnedCommands).toEqual([[
       "timeout", "--kill-after=30s", "5", "/usr/bin/setpriv", "--reuid", "postgres", "--regid",
-      "postgres", "--clear-groups", "--", "pgbackrest",
+      "26", "--init-groups", "--", "pgbackrest",
       "--stanza=db-main", "info", "--output=json",
     ]]);
     expect(backups).toEqual([{
@@ -148,8 +158,27 @@ describe("BackupService", () => {
   });
 
   test("fails closed when the pgBackRest command cannot start", async () => {
-    commandOutcomes.push({ startError: new Error("timeout is not installed") });
+    commandOutcomes.push({ startError: new Error("setpriv is not installed") });
     await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest command is unavailable");
+    expect(spawnedCommands[0]).toContain("/usr/bin/setpriv");
+  });
+
+  test("fails closed when the backup user primary GID lookup fails, times out, or is not numeric", async () => {
+    identityOutcomes.push({ exitCode: 1, stderr: "unknown user" });
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest command is unavailable");
+    expect(spawnedCommands).toEqual([]);
+
+    identityOutcomes.push({ exitCode: 0, stdout: "postgres\n" });
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest command is unavailable");
+    expect(spawnedCommands).toEqual([]);
+
+    identityOutcomes.push({ startError: new Error("id is unavailable") });
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest command is unavailable");
+    expect(spawnedCommands).toEqual([]);
+
+    identityOutcomes.push({ exitCode: 124 });
+    await expect(listBackups("supa_project_a")).rejects.toThrow("pgBackRest command is unavailable");
+    expect(spawnedCommands).toEqual([]);
   });
 
   test("fails closed when the completed backup does not appear in inventory", async () => {
@@ -168,7 +197,7 @@ describe("BackupService", () => {
     await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore failed");
     expect(spawnedCommands.at(-1)).toEqual([
       "timeout", "--kill-after=30s", "1800", "/usr/bin/setpriv", "--reuid", "postgres", "--regid",
-      "postgres", "--clear-groups", "--", "pig", "pitr",
+      "26", "--init-groups", "--", "pig", "pitr",
       "-s", "db-main", "-t", "2026-07-22T01:30:00Z", "-y",
     ]);
   });
@@ -186,6 +215,9 @@ describe("BackupService", () => {
     await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore timed out");
 
     commandOutcomes.push({ startError: new Error("pig is not installed") });
+    await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore command is unavailable");
+
+    identityOutcomes.push({ exitCode: 1, stderr: "unknown user" });
     await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore command is unavailable");
   });
 
@@ -222,17 +254,19 @@ describe("BackupService", () => {
     try {
       commandOutcomes.push({ exitCode: 0, stdout: inventory([], 0, "cluster-main") });
       await listBackups("supa_project_a");
+      expect(identityCommands[0]).toEqual(["timeout", "--kill-after=30s", "5", "/usr/bin/id", "-g", "pgbackrest"]);
       expect(spawnedCommands).toEqual([[
         "timeout", "--kill-after=30s", "5", "/usr/bin/setpriv", "--reuid", "pgbackrest", "--regid",
-        "pgbackrest", "--clear-groups", "--", "/usr/bin/pgbackrest",
+        "4321", "--init-groups", "--", "/usr/bin/pgbackrest",
         "--config=/etc/supabase/pgbackrest.conf", "--stanza=cluster-main", "info", "--output=json",
       ]]);
 
       commandOutcomes.push({ exitCode: 0 });
       await restore({ target: "2026-07-22T01:30:00Z" });
+      expect(identityCommands[1]).toEqual(["timeout", "--kill-after=30s", "5", "/usr/bin/id", "-g", "postgres"]);
       expect(spawnedCommands[1]).toEqual([
         "timeout", "--kill-after=30s", "1800", "/usr/bin/setpriv", "--reuid", "postgres", "--regid",
-        "postgres", "--clear-groups", "--", "pig", "pitr",
+        "26", "--init-groups", "--", "pig", "pitr",
         "-s", "cluster-main", "-t", "2026-07-22T01:30:00Z", "-y",
       ]);
     } finally {

--- a/packages/management-api/tests/unit/backup.service.test.ts
+++ b/packages/management-api/tests/unit/backup.service.test.ts
@@ -56,7 +56,8 @@ describe("BackupService", () => {
     const backups = await listBackups("supa_project_a");
 
     expect(spawnedCommands).toEqual([[
-      "timeout", "--kill-after=30s", "5", "sudo", "-n", "-u", "postgres", "pgbackrest",
+      "timeout", "--kill-after=30s", "5", "/usr/bin/setpriv", "--reuid", "postgres", "--regid",
+      "postgres", "--clear-groups", "--", "pgbackrest",
       "--stanza=db-main", "info", "--output=json",
     ]]);
     expect(backups).toEqual([{
@@ -166,7 +167,8 @@ describe("BackupService", () => {
 
     await expect(restore({ target: "2026-07-22T01:30:00Z" })).rejects.toThrow("PITR restore failed");
     expect(spawnedCommands.at(-1)).toEqual([
-      "timeout", "--kill-after=30s", "1800", "sudo", "-n", "-u", "postgres", "pig", "pitr",
+      "timeout", "--kill-after=30s", "1800", "/usr/bin/setpriv", "--reuid", "postgres", "--regid",
+      "postgres", "--clear-groups", "--", "pig", "pitr",
       "-s", "db-main", "-t", "2026-07-22T01:30:00Z", "-y",
     ]);
   });
@@ -221,14 +223,16 @@ describe("BackupService", () => {
       commandOutcomes.push({ exitCode: 0, stdout: inventory([], 0, "cluster-main") });
       await listBackups("supa_project_a");
       expect(spawnedCommands).toEqual([[
-        "timeout", "--kill-after=30s", "5", "sudo", "-n", "-u", "pgbackrest", "/usr/bin/pgbackrest",
+        "timeout", "--kill-after=30s", "5", "/usr/bin/setpriv", "--reuid", "pgbackrest", "--regid",
+        "pgbackrest", "--clear-groups", "--", "/usr/bin/pgbackrest",
         "--config=/etc/supabase/pgbackrest.conf", "--stanza=cluster-main", "info", "--output=json",
       ]]);
 
       commandOutcomes.push({ exitCode: 0 });
       await restore({ target: "2026-07-22T01:30:00Z" });
       expect(spawnedCommands[1]).toEqual([
-        "timeout", "--kill-after=30s", "1800", "sudo", "-n", "-u", "postgres", "pig", "pitr",
+        "timeout", "--kill-after=30s", "1800", "/usr/bin/setpriv", "--reuid", "postgres", "--regid",
+        "postgres", "--clear-groups", "--", "pig", "pitr",
         "-s", "cluster-main", "-t", "2026-07-22T01:30:00Z", "-y",
       ]);
     } finally {

--- a/packages/management-api/tests/unit/install-config.test.ts
+++ b/packages/management-api/tests/unit/install-config.test.ts
@@ -1107,6 +1107,34 @@ describe("installer configuration persistence", () => {
     expect(resolveMode().status).not.toBe(0);
   });
 
+  test("management install preflight fails closed when privilege tools are unavailable", () => {
+    const dir = makeTempDir();
+    const emptyBin = join(dir, "empty-bin");
+    mkdirSync(emptyBin);
+
+    const missing = runBash(
+      'source install.sh; PATH="$EMPTY_BIN"; ensure_management_privilege_tools_available',
+      { EMPTY_BIN: emptyBin },
+    );
+    expect(missing.status).not.toBe(0);
+    expect(missing.stdout).toContain("requires setpriv");
+
+    writeFileSync(join(emptyBin, "setpriv"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    const missingId = runBash(
+      'source install.sh; PATH="$EMPTY_BIN"; ensure_management_privilege_tools_available',
+      { EMPTY_BIN: emptyBin },
+    );
+    expect(missingId.status).not.toBe(0);
+    expect(missingId.stdout).toContain("requires id");
+
+    writeFileSync(join(emptyBin, "id"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    const available = runBash(
+      'source install.sh; PATH="$EMPTY_BIN"; ensure_management_privilege_tools_available',
+      { EMPTY_BIN: emptyBin },
+    );
+    expect(available.status, available.stderr).toBe(0);
+  });
+
   test("management recovery reconciles the privilege drop-in when the committed mode changes", () => {
     const runRecovery = (runtimeMode: "embedded" | "external", priorDropIn: "present" | "absent") => {
       const dir = makeTempDir();

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -351,6 +351,7 @@ describe("runtime companion version assets", () => {
 
   test("production units use dedicated runtime env files and pinned compiled Edge Runtime commands", () => {
     const installer = readRepoFile("install.sh");
+    const upgrade = readRepoFile("packages/management-api/src/upgrade.ts");
     const managementUnit = readRepoFile("infrastructure/systemd/supacloud.service");
     const edgeUnit = readRepoFile("infrastructure/systemd/supacloud-edge-runtime.service");
     const realtimeUnit = readRepoFile("infrastructure/systemd/supacloud-realtime.service");
@@ -398,8 +399,12 @@ describe("runtime companion version assets", () => {
     expect(selfHostEdgeDockerfile).toContain("EXPOSE 9005");
     expect(managementUnit).not.toContain("ReadWritePaths=/etc/supabase /etc/systemd/system ");
     expect(managementUnit).toContain("/run/supacloud-unit-requests");
-    expect(managementUnit).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER");
-    expect(managementUnit).not.toContain("CAP_SETUID");
+    expect(managementUnit).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID");
+    expect(installer).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID");
+    expect(installer).toContain("ensure_management_privilege_tools_available");
+    expect(installer).toContain("for tool in setpriv id");
+    expect(upgrade).toContain("verifyBackupPrivilegeDropPreflight();");
+    expect(upgrade).toContain("40-management-privilege.conf");
     expect(installer).toContain("configure_management_edge_privilege_dropin");
     expect(installer).toContain(
       'MANAGEMENT_EDGE_PRIVILEGE_DROPIN="${SUPACLOUD_EMBEDDED_EDGE_PRIVILEGE_DROPIN:-/etc/systemd/system/supacloud.service.d/50-embedded-edge-privilege.conf}"',

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
     buildEdgeRuntimeCapacityDropIn,
     buildEmbeddedEdgePrivilegeDropIn,
+    buildManagementPrivilegeDropIn,
     buildCheckpointDatabaseOptions,
     backupCurrentBinary,
     buildRuntimeServiceRestartPlan,
@@ -27,6 +28,7 @@ import {
     resolvePersistedEdgeRuntimePort,
     resolvePersistedEdgeRuntimeMode,
     resolveUpgradeEnvironment,
+    reconcileManagementPrivilegeDropIns,
     runStagedDatabaseMigration,
     restoreCurrentBinary,
     restoreFileState,
@@ -39,6 +41,7 @@ import {
     verifyActivatedManagementBinary,
     verifyArtifactChecksum,
     verifyManagementUpgradePreflight,
+    verifyBackupPrivilegeDropPreflight,
     waitForManagementHealth,
     waitForEdgeRuntimeHealth,
     waitForUpgradeHealth,
@@ -520,6 +523,15 @@ describe("upgrade release selection", () => {
     }))).rejects.toThrow("MainPID changed from 4242 to 4343");
   });
 
+  test("upgrade preflight requires setpriv and id before staging", () => {
+    const installedPaths = new Set(["/usr/bin/setpriv", "/usr/bin/id"]);
+    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => installedPaths.has(filePath))).not.toThrow();
+    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => filePath.endsWith("/id")))
+      .toThrow("requires setpriv");
+    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => filePath.endsWith("/setpriv")))
+      .toThrow("requires id");
+  });
+
   test("rejects a deleted active executable", async () => {
     await expect(verifyManagementUpgradePreflight(managementBinaryFixture({
       executablePath: `${canonicalManagementBinary} (deleted)`,
@@ -920,10 +932,40 @@ describe("embedded Edge Runtime source access", () => {
 });
 
 describe("upgrade edge-runtime capacity defaults", () => {
-  test("grants only the capabilities needed for embedded privilege drop", () => {
+  test("keeps privilege-drop capabilities in the canonical unit and embedded drop-in", () => {
+    const managementUnit = readFileSync(
+      join(import.meta.dir, "../../../..", "infrastructure/systemd/supacloud.service"),
+      "utf8",
+    );
     const dropIn = buildEmbeddedEdgePrivilegeDropIn();
+    expect(managementUnit).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID");
     expect(dropIn).toContain("CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID");
     expect(dropIn).not.toContain("@keyring");
+  });
+
+  test("external upgrades retain Management privilege capabilities after removing the embedded drop-in", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-privilege-"));
+    const managementDropIn = join(dir, "40-management-privilege.conf");
+    const embeddedDropIn = join(dir, "50-embedded-edge-privilege.conf");
+    let reloadCount = 0;
+    try {
+      writeFileSync(embeddedDropIn, "legacy embedded policy\n");
+      await reconcileManagementPrivilegeDropIns("external", {
+        user: "supacloud-edge",
+        group: "supacloud-edge",
+      }, {
+        managementDropInPath: managementDropIn,
+        embeddedDropInPath: embeddedDropIn,
+        reloadSystemd: async () => { reloadCount += 1; },
+      });
+
+      expect(readFileSync(managementDropIn, "utf8")).toBe(buildManagementPrivilegeDropIn());
+      expect(statSync(managementDropIn).mode & 0o777).toBe(0o644);
+      expect(existsSync(embeddedDropIn)).toBe(false);
+      expect(reloadCount).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("sizes systemd limits to sixty percent of a two-core node", () => {


### PR DESCRIPTION
## Summary

CNB issue: https://cnb.cool/aizhuliren/xgic/supacloud/-/issues/118

Management API currently invokes `sudo -n -u postgres` for pgBackRest inventory/backup and PITR. Under the canonical systemd sandbox (`NoNewPrivileges`, capability bounding, syscall filters), sudo fails through PAM/seccomp (exit 159), so the authenticated backup inventory endpoint returns 503 even when the configured pgBackRest stanza is readable.

This change:

- uses the repository's existing `setpriv` privilege-drop pattern;
- resolves and validates the configured user's numeric primary GID, then uses `--init-groups`;
- keeps `CAP_SETUID`/`CAP_SETGID` in the canonical Management unit and installer fallback;
- preflights `setpriv` and `id` before staging an upgrade;
- writes a separately rollback-tracked Management privilege drop-in so external Edge upgrades retain the capability policy after removing the embedded-only drop-in.

Timeouts, input validation, exit-code checks, rollback, and fail-closed behavior remain unchanged. No systemd sandbox relaxation was made.

## Validation

- `bun test tests/unit/backup.service.test.ts tests/unit/install-config.test.ts tests/unit/runtime-version-assets.test.ts tests/unit/upgrade.test.ts tests/unit/edge-runtime-manager.security.test.ts` — 146 pass, 0 fail
- `bun run typecheck` — pass
- `bash -n install.sh` — pass
- `git diff --check` — pass
- Test host `root@192.168.200.112`: effective capability set includes `cap_setgid cap_setuid`; `setpriv --init-groups` reports postgres UID/GID; authenticated `/v1/projects/lhevaxecbonjjdbardgi/database/backups` returns HTTP 200 `[]`
- No backup, restore, or PITR operation was executed

The CNB issue will be closed after this PR is merged and the released build is revalidated.