### PR TITLE
fix(systemd): preserve PostgreSQL pid ownership

### DIFF
--- a/packages/management-api/tests/unit/pre-start-recovery.test.ts
+++ b/packages/management-api/tests/unit/pre-start-recovery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -58,6 +58,43 @@ describe("Management pre-start recovery sandbox", () => {
     expect(preStart).not.toContain("kill_edge_runtime_zombies");
     expect(preStart).not.toContain("lsof -iTCP");
     expect(preStart).not.toContain("kill -9");
+  });
+
+  test("leaves postmaster.pid untouched when process liveness is ambiguous", () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-postmaster-pid-"));
+    temporaryDirectories.push(directory);
+    const pgData = join(directory, "pgdata");
+    const pidFile = join(pgData, "postmaster.pid");
+    const psMarker = join(directory, "ps-called");
+
+    mkdirSync(pgData, { recursive: true });
+    writeFileSync(pidFile, "424242\n");
+    writeExecutable(
+      join(directory, "ps"),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "${psMarker}"\nexit 1\n`,
+    );
+    writeExecutable(join(directory, "psql"), "#!/usr/bin/env bash\nprintf 'search_path=auth, public\\n'\n");
+    writeExecutable(join(directory, "systemctl"), "#!/usr/bin/env bash\nexit 0\n");
+
+    const run = Bun.spawnSync(["bash", join(repoRoot, "scripts/pre_start_recovery.sh")], {
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH || ""}`,
+        PGDATA: pgData,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(run.exitCode, run.stderr.toString()).toBe(0);
+    expect(existsSync(psMarker)).toBe(true);
+    expect(readFileSync(pidFile, "utf8")).toBe("424242\n");
+    expect(run.stdout.toString()).toContain("leaving");
+    expect(run.stdout.toString()).toContain("untouched");
+
+    const preStart = readRepoFile("scripts/pre_start_recovery.sh");
+    expect(preStart).not.toContain("kill -0");
+    expect(preStart).not.toContain('rm -f "$pid_file"');
   });
 
   test("keeps container ownership outside the management sandbox", () => {

--- a/scripts/pre_start_recovery.sh
+++ b/scripts/pre_start_recovery.sh
@@ -14,24 +14,28 @@ log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
-fix_stale_postmaster_pid() {
+check_postmaster_pid_liveness() {
     local pg_data="${PGDATA:-/pg/data}"
     local pid_file="${pg_data}/postmaster.pid"
-    
-    if [[ -f "$pid_file" ]]; then
-        local pid
-        pid=$(head -1 "$pid_file" 2>/dev/null || echo "")
-        
-        if [[ -n "$pid" ]]; then
-            if ! kill -0 "$pid" 2>/dev/null; then
-                log_warn "Found stale postmaster.pid (PID: $pid), removing..."
-                rm -f "$pid_file"
-                log_info "Stale PID file removed"
-            else
-                log_info "PostgreSQL PID $pid is still running"
-            fi
-        fi
+
+    [[ -f "$pid_file" ]] || return 0
+
+    local pid
+    pid=$(head -1 "$pid_file" 2>/dev/null || echo "")
+
+    if [[ ! "$pid" =~ ^[1-9][0-9]*$ ]]; then
+        log_warn "Invalid PostgreSQL PID in $pid_file; leaving the file untouched"
+        return
     fi
+
+    if ps -p "$pid" -o pid= >/dev/null 2>&1; then
+        log_info "PostgreSQL PID $pid is still running"
+        return
+    fi
+
+    # The Management API unit intentionally has no CAP_KILL. A denied probe
+    # must not become proof that PostgreSQL is dead; its owner handles recovery.
+    log_warn "Unable to confirm PostgreSQL PID $pid; leaving $pid_file untouched for PostgreSQL/Patroni recovery"
 }
 
 fix_gotrue_search_path() {
@@ -116,7 +120,7 @@ main() {
     echo "=========================================="
     echo ""
     
-    fix_stale_postmaster_pid
+    check_postmaster_pid_liveness
     fix_gotrue_search_path
     ensure_gateway_running
     # Container recovery stays outside this sandbox. Realtime has a dedicated


### PR DESCRIPTION
## Summary

- make the Management pre-start hook treat ambiguous PostgreSQL liveness as live/owned state
- replace the capability-sensitive `kill -0` probe with a read-only process lookup
- stop the Management service from deleting `postmaster.pid`; PostgreSQL/Patroni remains the sole recovery owner
- add a regression test proving an unobservable PID file is preserved

## Root cause

The hardened `supacloud.service` capability bounding set intentionally excludes `CAP_KILL`. Its pre-start hook used `kill -0` against the PostgreSQL process, so an `EPERM` result was indistinguishable from `ESRCH` and was interpreted as a stale PID. The hook then deleted the live cluster's `postmaster.pid`.

During a v0.50.13 test upgrade this produced the following sequence:

1. Management pre-start logged that PostgreSQL PID 5078 was stale and removed the PID file.
2. Patroni continued reporting leader health briefly, then detected PostgreSQL as not running at 08:15:24 and started the primary after failure.
3. The database interruption caused the Realtime unit to restart once.

The fix fails closed: an invalid or unobservable PID is reported, but the database-owned file is never mutated by Management.

## Validation

- `bun test packages/management-api/tests/unit/pre-start-recovery.test.ts` — 4 pass, 0 fail
- `bun run test:unit` — passed
- `bun run typecheck` — passed
- `bash -n scripts/pre_start_recovery.sh` — passed
- `git diff --check` — passed
