### PR TITLE
fix(edge-runtime): allow guarded builtin CJS imports

### DIFF
--- a/packages/edge-runtime/deno-compat.command.test.ts
+++ b/packages/edge-runtime/deno-compat.command.test.ts
@@ -77,6 +77,31 @@ test("the worker subprocess guard disables and restores process creation APIs", 
       .toThrow(FILESYSTEM_DISABLED_MESSAGE);
     expect(() => (process as unknown as Record<string, () => unknown>).binding())
       .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    const loadBuiltin = moduleApi._load as (request: unknown, ...args: unknown[]) => unknown;
+    expect(() => loadBuiltin.call(moduleApi, "node:crypto")).not.toThrow();
+    expect(() => loadBuiltin.call(moduleApi, "crypto")).not.toThrow();
+    expect(() => loadBuiltin.call(moduleApi, "node:fs"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => loadBuiltin.call(moduleApi, "./relative"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => loadBuiltin.call(moduleApi, "/tmp/untrusted.cjs"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => loadBuiltin.call(moduleApi, "untrusted-package"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => loadBuiltin.call(moduleApi, "bun")).not.toThrow();
+    expect(() => loadBuiltin.call(moduleApi, "bun:sqlite"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => loadBuiltin.call(moduleApi, "wasi"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => loadBuiltin.call(moduleApi, { computed: "node:crypto" }))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    const tenantModule = new (moduleApi.Module as new (id: string) => unknown)("tenant");
+    const tenantRequire = modulePrototype?.require as (this: unknown, request: unknown) => unknown;
+    expect(tenantRequire.call(tenantModule, "node:crypto")).toBeDefined();
+    expect(tenantRequire.call(tenantModule, "crypto")).toBeDefined();
+    expect(tenantRequire.call(tenantModule, "bun")).toBeDefined();
+    expect(() => tenantRequire.call(tenantModule, "node:module"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
     expect(() => {
       const tenantRequire = (moduleApi.createRequire as (url: string) => (id: string) => unknown)(import.meta.url);
       tenantRequire("node:fs");

--- a/packages/edge-runtime/deno-compat.ts
+++ b/packages/edge-runtime/deno-compat.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import path from "path";
-import { syncBuiltinESMExports } from "node:module";
+import { builtinModules, syncBuiltinESMExports } from "node:module";
 import { fileURLToPath } from "node:url";
 
 export type CapturedServeHandler = (
@@ -18,6 +18,60 @@ export const DYNAMIC_CODE_DISABLED_MESSAGE =
   "Dynamic code generation is disabled in the multi-tenant Edge Runtime.";
 export const HOST_RUNTIME_DISABLED_MESSAGE =
   "Host runtime capabilities are disabled in the multi-tenant Edge Runtime.";
+
+const KNOWN_RUNTIME_BUILTINS = new Set(
+  builtinModules.map((specifier) => specifier.replace(/^node:/, "")),
+);
+// Bun exposes host-specific and future builtins through builtinModules, so tenant
+// compatibility must remain an explicit allowlist and fail closed on upgrades.
+const TENANT_NODE_BUILTINS = new Set([
+  "assert",
+  "assert/strict",
+  "async_hooks",
+  "buffer",
+  "constants",
+  "crypto",
+  "dns",
+  "dns/promises",
+  "events",
+  "http",
+  "https",
+  "net",
+  "os",
+  "path",
+  "path/posix",
+  "path/win32",
+  "perf_hooks",
+  "punycode",
+  "querystring",
+  "stream",
+  "stream/consumers",
+  "stream/promises",
+  "stream/web",
+  "string_decoder",
+  "timers",
+  "timers/promises",
+  "tls",
+  "tty",
+  "url",
+  "util",
+  "util/types",
+  "zlib",
+]);
+export function tenantBuiltinSpecifier(request: unknown): string | null {
+  if (typeof request !== "string") return null;
+  // The bare Bun namespace is patched before tenant modules load, so preserving
+  // this entry keeps guarded file/spawn APIs without exposing bun:* host modules.
+  if (request === "bun") return request;
+  const bareSpecifier = request.replace(/^node:/, "");
+  if (!TENANT_NODE_BUILTINS.has(bareSpecifier)) return null;
+  return `node:${bareSpecifier}`;
+}
+
+export function isKnownRuntimeBuiltinSpecifier(request: string): boolean {
+  return request === "bun"
+    || KNOWN_RUNTIME_BUILTINS.has(request.replace(/^node:/, ""));
+}
 
 const nodeFs = require("node:fs") as typeof import("node:fs");
 const nodeFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
@@ -149,13 +203,24 @@ export function disableSubprocessApis(): void {
   }
 
   const moduleApi = require("node:module") as Record<string, unknown>;
-  for (const name of ["createRequire", "_load"]) {
-    if (typeof moduleApi[name] === "function") moduleApi[name] = nativeLoaderDisabled;
+  moduleApi.createRequire = nativeLoaderDisabled;
+  const originalModuleLoad = moduleApi._load as ((...args: unknown[]) => unknown) | undefined;
+  if (originalModuleLoad) {
+    moduleApi._load = function (this: unknown, request: unknown, ...args: unknown[]) {
+      const builtinSpecifier = tenantBuiltinSpecifier(request);
+      if (!builtinSpecifier) return nativeLoaderDisabled();
+      return Reflect.apply(originalModuleLoad, this, [builtinSpecifier, ...args]);
+    };
   }
   const modulePrototype = (moduleApi.Module as { prototype?: Record<string, unknown> } | undefined)?.prototype
     || (moduleApi as { prototype?: Record<string, unknown> }).prototype;
-  if (modulePrototype && typeof modulePrototype.require === "function") {
-    modulePrototype.require = nativeLoaderDisabled;
+  const originalModuleRequire = modulePrototype?.require as ((...args: unknown[]) => unknown) | undefined;
+  if (modulePrototype && originalModuleRequire) {
+    modulePrototype.require = function (this: unknown, request: unknown, ...args: unknown[]) {
+      const builtinSpecifier = tenantBuiltinSpecifier(request);
+      if (!builtinSpecifier) return nativeLoaderDisabled();
+      return Reflect.apply(originalModuleRequire, this, [builtinSpecifier, ...args]);
+    };
   }
   syncBuiltinESMExports();
 }

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -15,9 +15,11 @@ import {
   FILESYSTEM_DISABLED_MESSAGE,
   getCapturedServeHandler,
   initializeProjectRootControl,
+  isKnownRuntimeBuiltinSpecifier,
   NATIVE_LOADER_DISABLED_MESSAGE,
   setInjectedEnv,
   SUBPROCESS_DISABLED_MESSAGE,
+  tenantBuiltinSpecifier,
 } from "./deno-compat";
 import { installEdgeFetchTlsPolicy, resolveEdgeFetchTlsPolicy } from "./fetch-tls-policy";
 import type { EdgeFetchTlsPolicy } from "./fetch-tls-policy";
@@ -233,6 +235,16 @@ async function assertTenantModuleGraphSafe(
     const disabledMessage = DISABLED_TENANT_MODULES.get(imported.path);
     if (disabledMessage) {
       throw new Error(disabledMessage);
+    }
+    if (tenantBuiltinSpecifier(imported.path)) {
+      continue;
+    }
+    if (
+      isKnownRuntimeBuiltinSpecifier(imported.path)
+      || imported.path.startsWith("node:")
+      || imported.path.startsWith("bun:")
+    ) {
+      throw new Error(NATIVE_LOADER_DISABLED_MESSAGE);
     }
     let dependencyPath = imported.path;
     if (dependencyPath.startsWith("file:")) {

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -90,6 +90,81 @@ describe("WorkerPool EdgeRuntime.waitUntil", () => {
 });
 
 describe("WorkerPool subprocess guard", () => {
+  test("allows CJS dependencies to load explicitly allowed Node builtins", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-safe-builtin-module-"));
+    const dependencyPath = join(projectRoot, "dependency.cjs");
+    const functionPath = join(projectRoot, "entry.ts");
+    await Bun.write(dependencyPath, `
+      const nodeCrypto = require("node:crypto");
+      const bareCrypto = require("crypto");
+      const ttyModule = require("tty");
+      const utilModule = require("util");
+      module.exports = () => {
+        const digest = nodeCrypto.createHash("sha256").update("safe").digest("hex");
+        const formatted = utilModule.format("%s", digest);
+        const hasTtyApi = typeof ttyModule.isatty === "function";
+        return bareCrypto.timingSafeEqual(Buffer.from(digest), Buffer.from(digest))
+          && hasTtyApi
+          && formatted === digest
+          ? digest
+          : "mismatch";
+      };
+    `);
+    await Bun.write(functionPath, `
+      import hash from "./dependency.cjs";
+      export default () => new Response(hash());
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_safe_builtin_module",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/safe-builtin-module"),
+      });
+      expect({ status: response.status, body: await response.text() }).toEqual({
+        status: 200,
+        body: "8b3369944dd2a3fab39e32d1aeb1f763946a458ae3e6368a46432adc8f3a0860",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects non-allowlisted runtime builtins", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-denied-builtin-module-"));
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      for (const [index, builtinSpecifier] of ["bun:sqlite", "node:sqlite", "wasi"].entries()) {
+        const functionPath = join(projectRoot, `denied-${index}.ts`);
+        await Bun.write(functionPath, `
+          import * as denied from ${JSON.stringify(builtinSpecifier)};
+          export default () => new Response(String(denied));
+        `);
+        const response = await pool.dispatch({
+          functionId: `proj_denied_builtin_${index}`,
+          functionPath,
+          projectRoot,
+          env: {},
+          request: new Request(`http://edge.local/functions/v1/denied-builtin-${index}`),
+        });
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({
+          error: "Native and builtin module loaders are disabled in the multi-tenant Edge Runtime.",
+          name: "Error",
+        });
+      }
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("blocks direct and computed imports for every fs module alias", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-filesystem-module-"));
     const dynamicPath = join(projectRoot, "dynamic.ts");


### PR DESCRIPTION
## Summary
- keep multi-tenant CJS loading compatible with explicitly allowed Node builtins
- share the fail-closed builtin policy between module graph validation and runtime loaders
- keep createRequire, file system, subprocess, native, Bun host modules, paths, and packages blocked

## Root cause
The module graph allowed safe builtins such as tty and util, but disableSubprocessApis replaced Module._load and Module.prototype.require with an unconditional denial. Bun-generated CJS wrappers therefore failed while loading otherwise allowed dependencies.

## Validation
- focused Edge Runtime tests: 54 passed
- exact SupAuth dependency shape: require tty and util passed
- Edge Runtime typecheck: passed
- Linux amd64 compiled build: passed
- git diff check: passed
- full Edge Runtime suite completed successfully in one run; the existing cooperative-retirement stress test also reproduced an intermittent 504 on clean HEAD and passed in isolation

## Security boundary
Only an explicit fail-closed allowlist is accepted. fs, module, child_process, cluster, worker_threads, vm, v8, inspector, wasi, bun:* modules, unknown node:* modules, relative or absolute paths, arbitrary packages, createRequire, and getBuiltinModule remain disabled. The guarded bare bun namespace remains compatible with the existing host-capability patches.