### PR TITLE
fix(edge-runtime): allow guarded uv binding for net

### DIFF
--- a/packages/edge-runtime/deno-compat.command.test.ts
+++ b/packages/edge-runtime/deno-compat.command.test.ts
@@ -61,6 +61,11 @@ test("the worker subprocess guard disables and restores process creation APIs", 
     ["exec", "execFile", "execFileSync", "execSync", "fork", "spawn", "spawnSync"]
       .map((name) => [name, childProcess[name]]),
   );
+  const rawProcessBinding = (process as unknown as Record<string, unknown>).binding as
+    (...args: unknown[]) => unknown;
+  const rawUvBinding = rawProcessBinding("uv") as Record<string, unknown>;
+  const rawErrname = rawUvBinding.errname as (...args: unknown[]) => unknown;
+  const rawErrorMap = rawUvBinding.getErrorMap as () => Map<unknown, unknown>;
 
   try {
     disableSubprocessApis();
@@ -75,7 +80,44 @@ test("the worker subprocess guard disables and restores process creation APIs", 
       .toThrow("outside the project directory");
     expect(() => fs.readFileSync("/etc/hosts", "utf8"))
       .toThrow(FILESYSTEM_DISABLED_MESSAGE);
-    expect(() => (process as unknown as Record<string, () => unknown>).binding())
+    const guardedProcessBinding = (process as unknown as Record<string, unknown>).binding as
+      (...args: unknown[]) => unknown;
+    const uvBinding = guardedProcessBinding("uv") as Record<string, unknown>;
+    expect(typeof uvBinding.errname).toBe("function");
+    expect(typeof uvBinding.getErrorMap).toBe("function");
+    expect(uvBinding.errname).not.toBe(rawErrname);
+    expect(uvBinding.getErrorMap).not.toBe(rawErrorMap);
+    expect(Object.isFrozen(uvBinding.errname)).toBe(true);
+    expect(Object.isFrozen(uvBinding.getErrorMap)).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(uvBinding.errname, "prototype")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(uvBinding.getErrorMap, "prototype")).toBe(false);
+    const errnameProbe = "__supacloud_uv_wrapper_probe__";
+    expect(Reflect.set(uvBinding.errname as object, errnameProbe, true)).toBe(false);
+    expect((rawErrname as Record<string, unknown>)[errnameProbe]).toBeUndefined();
+    expect((uvBinding.errname as (...args: unknown[]) => unknown)(-2)).toBe("ENOENT");
+    const copiedErrorMap = (uvBinding.getErrorMap as () => Map<unknown, unknown>)();
+    expect(copiedErrorMap).toBeInstanceOf(Map);
+    expect(copiedErrorMap).not.toBe(rawErrorMap());
+    expect(copiedErrorMap.size).toBe(rawErrorMap().size);
+    const copiedErrorDetails = [...copiedErrorMap.values()];
+    expect(copiedErrorDetails.length).toBeGreaterThan(0);
+    expect(copiedErrorDetails.every((details) => Array.isArray(details) && Object.isFrozen(details)))
+      .toBe(true);
+    expect(Object.keys(uvBinding).some((name) => name.startsWith("UV_"))).toBe(true);
+    expect(Object.keys(uvBinding).every((name) => (
+      name === "errname" || name === "getErrorMap" || name.startsWith("UV_")
+    ))).toBe(true);
+    expect(Object.isFrozen(uvBinding)).toBe(true);
+    expect(Reflect.set(uvBinding, "UV_EACCES", 0)).toBe(false);
+    expect(() => guardedProcessBinding("uv", "unexpected"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => guardedProcessBinding("fs"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => guardedProcessBinding("spawn_sync"))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => guardedProcessBinding({ computed: "uv" }))
+      .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
+    expect(() => guardedProcessBinding())
       .toThrow(NATIVE_LOADER_DISABLED_MESSAGE);
     const loadBuiltin = moduleApi._load as (request: unknown, ...args: unknown[]) => unknown;
     expect(() => loadBuiltin.call(moduleApi, "node:crypto")).not.toThrow();

--- a/packages/edge-runtime/deno-compat.ts
+++ b/packages/edge-runtime/deno-compat.ts
@@ -75,6 +75,9 @@ export function isKnownRuntimeBuiltinSpecifier(request: string): boolean {
 
 const nodeFs = require("node:fs") as typeof import("node:fs");
 const nodeFsPromises = require("node:fs/promises") as typeof import("node:fs/promises");
+const runtimeProcessBinding = (process as unknown as Record<string, unknown>).binding as
+  ((...args: unknown[]) => unknown) | undefined;
+const tenantUvBinding = createTenantUvBinding(runtimeProcessBinding);
 const runtimeFs = {
   lstatSync: nodeFs.lstatSync.bind(nodeFs),
   realpathSync: nodeFs.realpathSync.bind(nodeFs),
@@ -198,9 +201,14 @@ export function disableSubprocessApis(): void {
   );
 
   const processApi = process as unknown as Record<string, unknown>;
-  for (const name of ["dlopen", "binding", "_linkedBinding", "getBuiltinModule"]) {
+  for (const name of ["dlopen", "_linkedBinding", "getBuiltinModule"]) {
     if (typeof processApi[name] === "function") processApi[name] = nativeLoaderDisabled;
   }
+  // node:net 和 node:tls 首次加载依赖 uv 的错误映射；其他原生 binding 仍保持关闭。
+  processApi.binding = function (request: unknown, ...args: unknown[]) {
+    if (request !== "uv" || args.length > 0 || !tenantUvBinding) return nativeLoaderDisabled();
+    return tenantUvBinding;
+  };
 
   const moduleApi = require("node:module") as Record<string, unknown>;
   moduleApi.createRequire = nativeLoaderDisabled;
@@ -223,6 +231,43 @@ export function disableSubprocessApis(): void {
     };
   }
   syncBuiltinESMExports();
+}
+
+function createTenantUvBinding(
+  processBinding: ((...args: unknown[]) => unknown) | undefined,
+): Readonly<Record<string, unknown>> | null {
+  if (!processBinding) return null;
+  const rawUvBinding = Reflect.apply(processBinding, process, ["uv"]) as Record<string, unknown>;
+  const safeEntries: Array<[string, unknown]> = [];
+  for (const [name, value] of Object.entries(rawUvBinding)) {
+    if (name.startsWith("UV_") && typeof value === "number") safeEntries.push([name, value]);
+  }
+  for (const name of ["errname", "getErrorMap"] as const) {
+    const wrapped = createTenantUvFunction(name, rawUvBinding);
+    if (wrapped) safeEntries.push([name, wrapped]);
+  }
+  return Object.freeze(Object.fromEntries(safeEntries));
+}
+
+function createTenantUvFunction(
+  name: "errname" | "getErrorMap",
+  rawUvBinding: Record<string, unknown>,
+): ((...args: unknown[]) => unknown) | null {
+  const rawFunction = rawUvBinding[name];
+  if (typeof rawFunction !== "function") return null;
+  const wrapped = (...args: unknown[]) => {
+    const rawResult = Reflect.apply(rawFunction, rawUvBinding, args);
+    if (name !== "getErrorMap" || !(rawResult instanceof Map)) return rawResult;
+    const copiedEntries: Array<[unknown, unknown]> = [];
+    for (const [code, details] of rawResult) {
+      copiedEntries.push([
+        code,
+        Array.isArray(details) ? Object.freeze([...details]) : details,
+      ]);
+    }
+    return new Map(copiedEntries);
+  };
+  return Object.freeze(wrapped);
 }
 
 function disableBunHostCapabilities(bun: Record<string, unknown>): void {

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -90,6 +90,73 @@ describe("WorkerPool EdgeRuntime.waitUntil", () => {
 });
 
 describe("WorkerPool subprocess guard", () => {
+  test("allows import.meta.require aliases to load safe Node builtins", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-import-meta-require-"));
+    const functionPath = join(projectRoot, "entry.js");
+    await Bun.write(functionPath, `
+      var __require = import.meta.require;
+      var ttyModule = __require("tty");
+      var utilModule = __require("util");
+      export default () => {
+        const supported = typeof ttyModule.isatty === "function"
+          && utilModule.format("%s", "safe") === "safe";
+        return new Response(supported ? "safe" : "mismatch");
+      };
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_import_meta_require",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/import-meta-require"),
+      });
+      expect({ status: response.status, body: await response.text() }).toEqual({
+        status: 200,
+        body: "safe",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("allows safe Node builtins that use internal bindings during initialization", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-internal-builtin-"));
+    const functionPath = join(projectRoot, "entry.js");
+    await Bun.write(functionPath, `
+      import * as netModule from "net";
+      import * as tlsModule from "tls";
+      export default () => {
+        const supported = typeof netModule.createServer === "function"
+          && typeof tlsModule.createServer === "function";
+        return new Response(supported ? "safe" : "mismatch");
+      };
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_internal_builtin",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/internal-builtin"),
+      });
+      expect({ status: response.status, body: await response.text() }).toEqual({
+        status: 200,
+        body: "safe",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("allows CJS dependencies to load explicitly allowed Node builtins", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-safe-builtin-module-"));
     const dependencyPath = join(projectRoot, "dependency.cjs");


### PR DESCRIPTION
## Summary
- allow only process.binding("uv") with exactly one argument so Node net and tls can initialize
- expose a frozen tenant facade containing numeric UV constants plus isolated errname and getErrorMap wrappers
- keep every other native binding and host capability fail closed

## Root cause
SupAuth v26 imports net and tls. Their Node builtin initialization calls process.binding("uv"), but the Edge Runtime security guard disabled process.binding unconditionally. That made the compiled Function return HTTP 500 even after the CJS builtin loader compatibility fix in #685.

## Security boundary
- only the exact single-argument uv request is accepted
- fs, spawn_sync, object arguments, missing arguments, extra arguments, and every other binding remain denied
- tenant code never receives the raw UV binding or its function objects
- the facade and wrappers are frozen; wrappers have no mutable prototype
- getErrorMap returns a new Map with copied, frozen detail arrays

## Validation
- focused Edge Runtime tests: 56 passed, 0 failed, 321 assertions
- Edge Runtime typecheck: passed
- git diff check: passed
- independent security verifier: passed
- compiled macOS smoke: exact import.meta.require, net, tls, and all SupAuth builtins returned HTTP 200
- Linux amd64 compiled build SHA-256: 5062c7a5e6f20820fe1be4a35d16a83a79c3858788bae06da86bbd63f3bef3bb
- full Edge Runtime suite: 105 passed, 1 existing worker-retirement stress 504; the same failure reproduces outside this diff and the test was not changed or weakened

## Scope
Follow-up to #685, which was merged before this UV root cause commit was ready. This PR contains only the UV compatibility and regression coverage commit.