### PR TITLE
fix(functions): preserve versions after rollback

### DIFF
--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -102,6 +102,8 @@ const BUNDLED_SOURCE_RUNTIME_ENTRY = ".supacloud-entry.js";
 const SAFE_REF_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
 const SAFE_SLUG_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 const EXTERNAL_PACKAGE_REGEX = /^(?:@[a-zA-Z0-9._-]+\/)?[a-zA-Z0-9._-]+$/;
+const CANONICAL_VERSION_REGEX = /^(?:0|[1-9]\d*)$/;
+const functionDeployLocks = new Map<string, Promise<void>>();
 const deployMetrics: EdgeFunctionDeployMetrics = {
   total_deploys: 0,
   total_bundle_size_bytes: 0,
@@ -161,6 +163,32 @@ function validateSlug(slug: string): string {
     throw new Error("Invalid function slug");
   }
   return slug;
+}
+
+function parseVersionNumber(value: unknown): number | null {
+  if (typeof value !== "string" || !CANONICAL_VERSION_REGEX.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error("Function version exceeds the safe integer range");
+  return parsed;
+}
+
+async function acquireFunctionDeployLock(
+  ref: string,
+  slug: string,
+): Promise<() => void> {
+  const key = JSON.stringify([ref, slug]);
+  const previous = functionDeployLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queueTail = previous.then(() => current);
+  functionDeployLocks.set(key, queueTail);
+  await previous;
+  return () => {
+    release();
+    if (functionDeployLocks.get(key) === queueTail) functionDeployLocks.delete(key);
+  };
 }
 
 function getFunctionsRoot(): string {
@@ -487,16 +515,45 @@ async function invalidateCache(ref: string, slug: string): Promise<void> {
   }
 }
 
-async function computeNextFunctionVersion(ref: string, slug: string): Promise<string> {
+async function readConfiguredFunctionVersion(ref: string, slug: string): Promise<number> {
   try {
     const raw = await Bun.file(getConfigPath(ref, slug)).text();
     const parsed = JSON.parse(raw) as EdgeFunctionConfig;
-    const current = Number.parseInt(parsed.version || "0", 10);
-    if (Number.isFinite(current)) return String(current + 1);
-  } catch {
-    // no existing config
+    if (parsed.version === undefined) return 0;
+    const version = parseVersionNumber(parsed.version);
+    if (version === null) throw new Error("Function config contains an invalid version");
+    return version;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return 0;
   }
-  return "1";
+}
+
+async function maxHistoricalFunctionVersion(ref: string, slug: string): Promise<number> {
+  const history = await listVersionDirectories(ref, slug);
+  return history.reduce((maximum, version) => Math.max(maximum, Number(version)), 0);
+}
+
+async function assertFunctionVersionAvailable(ref: string, slug: string, version: number): Promise<void> {
+  const candidate = assertInside(
+    getFuncDir(ref),
+    path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), String(version)),
+  );
+  try {
+    await fs.access(candidate);
+    throw new Error(`Function version directory already exists: ${version}`);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+async function computeNextFunctionVersion(ref: string, slug: string): Promise<string> {
+  const configured = await readConfiguredFunctionVersion(ref, slug);
+  const historical = await maxHistoricalFunctionVersion(ref, slug);
+  const next = Math.max(configured, historical) + 1;
+  if (!Number.isSafeInteger(next)) throw new Error("Function version exceeds the safe integer range");
+  await assertFunctionVersionAvailable(ref, slug, next);
+  return String(next);
 }
 
 async function readVersionedFunctionCode(ref: string, slug: string, version: string): Promise<string | null> {
@@ -538,11 +595,12 @@ async function listVersionDirectories(ref: string, slug: string): Promise<string
   try {
     const entries = await fs.readdir(dir, { withFileTypes: true });
     return entries
-      .filter((entry) => entry.isDirectory())
+      .filter((entry) => entry.isDirectory() && parseVersionNumber(entry.name) !== null)
       .map((entry) => entry.name)
-      .sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
-  } catch {
-    return [];
+      .sort((a, b) => Number(a) - Number(b));
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
   }
 }
 
@@ -672,6 +730,7 @@ export const edgeFunctionService = {
     code: string,
     minify: boolean = false,
   ): Promise<EdgeFunctionDeployResult> {
+    const releaseLock = await acquireFunctionDeployLock(ref, slug);
     try {
       const validation = validateFunctionCode(code);
       if (!validation.valid) {
@@ -744,6 +803,8 @@ export const edgeFunctionService = {
         success: false,
         error: err instanceof Error ? err.message : String(err),
       };
+    } finally {
+      releaseLock();
     }
   },
 
@@ -779,6 +840,7 @@ export const edgeFunctionService = {
     entrypoint: string = "index.ts",
     minify: boolean = false,
   ): Promise<EdgeFunctionDeployResult> {
+    const releaseLock = await acquireFunctionDeployLock(ref, slug);
     try {
       if (!files[entrypoint]) {
         const error = `Entrypoint '${entrypoint}' not found in file map`;
@@ -918,6 +980,8 @@ export const edgeFunctionService = {
         success: false,
         error: err instanceof Error ? err.message : String(err),
       };
+    } finally {
+      releaseLock();
     }
   },
 

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -45,6 +46,116 @@ afterAll(async () => {
 });
 
 describe("edgeFunctionService bundle metadata", () => {
+  test("allocates after retained history instead of overwriting a rolled-back version", async () => {
+    const ref = "proj_rollback_history";
+    const slug = "history-safe";
+    globalThis.fetch = (() => Promise.resolve(Response.json({ success: true }))) as typeof fetch;
+
+    const v1 = await edgeFunctionService.deployBundleDetailed(ref, slug, {
+      "index.ts": "export default { fetch: () => new Response('v1') };",
+    });
+    const v2 = await edgeFunctionService.deployBundleDetailed(ref, slug, {
+      "index.ts": "export default { fetch: () => new Response('retained-v2') };",
+    });
+
+    expect(v1).toMatchObject({ success: true, version: "1" });
+    expect(v2).toMatchObject({ success: true, version: "2" });
+
+    const v2Bundle = await readFile(v2.content_path!);
+    const v2SourcePath = join(functionsRoot, ref, ".versions", slug, "2", "src", "index.ts");
+    const v2Source = await readFile(v2SourcePath);
+    const v2BundleHash = createHash("sha256").update(v2Bundle).digest("hex");
+    const v2SourceHash = createHash("sha256").update(v2Source).digest("hex");
+
+    await edgeFunctionService.activateVersion(ref, slug, "1");
+
+    const result = await edgeFunctionService.deployBundleDetailed(ref, slug, {
+      "index.ts": "export default { fetch: () => new Response('new-v3') };",
+    });
+
+    expect(result).toMatchObject({ success: true, version: "3" });
+    expect(createHash("sha256").update(await readFile(v2.content_path!)).digest("hex")).toBe(v2BundleHash);
+    expect(createHash("sha256").update(await readFile(v2SourcePath)).digest("hex")).toBe(v2SourceHash);
+    expect(existsSync(join(functionsRoot, ref, ".versions", slug, "3", "src", "index.ts"))).toBe(true);
+  });
+
+  test("starts at version 1 when neither config nor version history exists", async () => {
+    const result = await edgeFunctionService.deployBundleDetailed("proj_first_version", "first", {
+      "index.ts": "export default { fetch: () => new Response('first') };",
+    });
+
+    expect(result).toMatchObject({ success: true, version: "1" });
+  });
+
+  test("ignores malformed history directory names", async () => {
+    const ref = "proj_bad_history";
+    const slug = "bad-history";
+    const versionDir = join(functionsRoot, ref, ".versions", slug);
+    await Promise.all([
+      mkdir(join(versionDir, "not-a-version"), { recursive: true }),
+      mkdir(join(versionDir, "01"), { recursive: true }),
+    ]);
+    await edgeFunctionService.updateConfig(ref, slug, { version: "1" });
+
+    const result = await edgeFunctionService.deployBundleDetailed(ref, slug, {
+      "index.ts": "export default { fetch: () => new Response('next') };",
+    });
+
+    expect(result).toMatchObject({ success: true, version: "2" });
+    expect(existsSync(join(versionDir, "not-a-version"))).toBe(true);
+    expect(existsSync(join(versionDir, "01"))).toBe(true);
+  });
+
+  test("fails closed for unsafe numeric history and config versions", async () => {
+    const unsafeVersion = "9007199254740992";
+    const historyRef = "proj_unsafe_history";
+    const historySlug = "unsafe-history";
+    await mkdir(join(functionsRoot, historyRef, ".versions", historySlug, unsafeVersion), { recursive: true });
+
+    const historyResult = await edgeFunctionService.deployBundleDetailed(historyRef, historySlug, {
+      "index.ts": "export default { fetch: () => new Response('blocked') };",
+    });
+
+    expect(historyResult).toMatchObject({ success: false, error: "Function version exceeds the safe integer range" });
+
+    const configRef = "proj_unsafe_config";
+    const configSlug = "unsafe-config";
+    await edgeFunctionService.updateConfig(configRef, configSlug, { version: unsafeVersion });
+
+    const configResult = await edgeFunctionService.deployBundleDetailed(configRef, configSlug, {
+      "index.ts": "export default { fetch: () => new Response('blocked') };",
+    });
+
+    expect(configResult).toMatchObject({ success: false, error: "Function version exceeds the safe integer range" });
+  });
+
+  test("serializes single-file and bundle deployments for the same function", async () => {
+    const ref = "proj_concurrent";
+    const slug = "same-function";
+    const [bundleResult, singleResult] = await Promise.all([
+      edgeFunctionService.deployBundleDetailed(ref, slug, {
+        "index.ts": "export default { fetch: () => new Response('bundle-marker') };",
+      }),
+      edgeFunctionService.deployDetailed(
+        ref,
+        slug,
+        "export default { fetch: () => new Response('single-marker') };",
+      ),
+    ]);
+
+    expect(bundleResult).toMatchObject({ success: true });
+    expect(singleResult).toMatchObject({ success: true });
+    expect([bundleResult.version, singleResult.version].sort()).toEqual(["1", "2"]);
+    expect(await Bun.file(bundleResult.content_path!).text()).toContain("bundle-marker");
+    expect(await Bun.file(singleResult.content_path!).text()).toContain("single-marker");
+    expect(
+      await Bun.file(join(functionsRoot, ref, ".versions", slug, bundleResult.version!, "src", "index.ts")).text(),
+    ).toContain("bundle-marker");
+    expect(
+      await Bun.file(join(functionsRoot, ref, ".versions", slug, singleResult.version!, "index.src.ts")).text(),
+    ).toContain("single-marker");
+  });
+
   test("keeps multi-file runtime code beside its static assets", async () => {
     globalThis.fetch = (() => Promise.resolve(Response.json({ ok: true }))) as typeof fetch;
 


### PR DESCRIPTION
## Summary

- allocate new Function versions after the maximum retained historical version, not only the active config version
- serialize same-process deployments per project/function so single-file and bundle uploads cannot share a staging/version slot
- fail closed on unsafe versions, unreadable history, or an existing candidate directory

## Live reproduction

On the isolated test server, Function v24 was retained while v23 was reactivated. The next bundle upload incorrectly returned v24 again instead of creating v25. The deployment gate stopped and restored v23; production was not touched.

## Verification

- `bun test tests/unit/edge-function.service.bundle-metadata.test.ts` (8 pass)
- `bun run typecheck`
- `bun run test:unit`
- `git diff --check`

Regression coverage verifies rollback v1/v2 to v1 allocates v3 without changing v2 bundle/source hashes, and concurrent single-file/bundle deployments keep distinct versions and content.