### PR TITLE
fix(functions): fail closed on activation readiness

### DIFF
--- a/packages/edge-runtime/server-cache.test.ts
+++ b/packages/edge-runtime/server-cache.test.ts
@@ -18,4 +18,15 @@ describe("Edge Runtime auth material invalidation", () => {
     expect(source).toContain("if (authRuntime.mode === \"shared\")");
     expect(source).toContain("Refusing local fallback secrets for SupAuth dependent");
   });
+
+  test("preheats an explicitly requested inactive function version", () => {
+    const endpoint = source.slice(
+      source.indexOf('.post("/preheat/:ref/:slug"'),
+      source.indexOf('.post("/internal/background/:ref/:functionName/*"'),
+    );
+    expect(endpoint).toContain('headers.get("x-supacloud-function-version")');
+    expect(endpoint).toContain("requestedVersion,");
+    expect(endpoint).toContain("`_v${requestedVersion}`");
+    expect(endpoint).toContain("version: requestedVersion");
+  });
 });

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -749,8 +749,14 @@ const app = new Elysia()
     if (authError) return authError;
 
     try {
-      const { functionPath, projectRoot, moduleVersion } = await resolveFunctionPath(c.params.ref, c.params.slug);
-      const functionId = `${c.params.ref}_${c.params.slug}`;
+      const requestedVersion = c.request.headers.get("x-supacloud-function-version") || null;
+      const { functionPath, projectRoot, moduleVersion } = await resolveFunctionPath(
+        c.params.ref,
+        c.params.slug,
+        requestedVersion,
+      );
+      const versionSuffix = requestedVersion ? `_v${requestedVersion}` : "";
+      const functionId = `${c.params.ref}_${c.params.slug}${versionSuffix}`;
       const tenantEnv = await loadTenantEnv(c.params.ref);
       const [foreground, background] = await Promise.all([
         pool.preheatIdleWorkers(functionId, functionPath, projectRoot, tenantEnv, {
@@ -765,6 +771,7 @@ const app = new Elysia()
       ]);
       return {
         preheated: functionId,
+        version: requestedVersion,
         success: foreground.succeeded > 0 || background.succeeded > 0,
         foreground,
         background,

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -1,5 +1,6 @@
 import { logger } from "../utils/logger";
 import { config } from "../config";
+import { ServiceUnavailableError } from "../utils/errors";
 import path from "path";
 import fs from "fs/promises";
 
@@ -142,6 +143,12 @@ type BundleFunctionResult = {
   importCount: number;
   bunArtifactHash: string | null;
   metafile: BuildMetafile | null;
+};
+
+type EdgeFunctionRuntimeControlResult = {
+  ok: boolean;
+  status?: number;
+  error?: string;
 };
 
 function resolveExternalPackages(): string[] {
@@ -438,27 +445,46 @@ function normalizePreheatPool(value: unknown): EdgeFunctionPreheatPoolResult {
   };
 }
 
-async function preheatRuntimeFunction(ref: string, slug: string): Promise<EdgeFunctionPreheatResult> {
+async function readRuntimeControlBody(response: Response): Promise<Record<string, unknown>> {
+  const bodyText = await response.text();
+  if (!bodyText) return {};
+  try {
+    const parsed = JSON.parse(bodyText);
+    return parsed && typeof parsed === "object"
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function preheatRuntimeFunction(
+  ref: string,
+  slug: string,
+  requestedVersion?: string,
+): Promise<EdgeFunctionPreheatResult> {
   const start = performance.now();
   try {
     const runtimeUrl = `http://${config.edgeRuntimeInternal}`;
+    const headers = runtimeInternalHeaders();
+    if (requestedVersion) {
+      headers["x-supacloud-function-version"] = requestedVersion;
+    }
     const preheatRes = await fetch(`${runtimeUrl}/preheat/${ref}/${slug}`, {
       method: "POST",
-      headers: runtimeInternalHeaders(),
+      headers,
       signal: AbortSignal.timeout(10_000),
     });
     const durationMs = Math.round(performance.now() - start);
-    let body: unknown = null;
-    try {
-      body = await preheatRes.json();
-    } catch {
-      body = await preheatRes.text();
-    }
-    const bodyRecord = body && typeof body === "object" ? body as Record<string, unknown> : {};
+    const bodyRecord = await readRuntimeControlBody(preheatRes);
     const foreground = normalizePreheatPool(bodyRecord.foreground);
     const background = normalizePreheatPool(bodyRecord.background);
+    const acknowledgedVersion = typeof bodyRecord.version === "string"
+      ? bodyRecord.version
+      : undefined;
+    const versionReady = requestedVersion === undefined || acknowledgedVersion === requestedVersion;
     return {
-      ok: preheatRes.ok && Boolean(bodyRecord.success ?? true),
+      ok: preheatRes.ok && Boolean(bodyRecord.success ?? true) && versionReady,
       status: preheatRes.status,
       duration_ms: durationMs,
       attempted: foreground.attempted + background.attempted,
@@ -467,6 +493,9 @@ async function preheatRuntimeFunction(ref: string, slug: string): Promise<EdgeFu
       cache_misses: foreground.cacheMisses + background.cacheMisses,
       foreground,
       background,
+      error: versionReady
+        ? undefined
+        : "Edge Runtime did not confirm the requested function version",
     };
   } catch (error) {
     return {
@@ -488,7 +517,34 @@ function runtimeInternalHeaders(): Record<string, string> {
   return { "x-supacloud-internal-auth": config.edgeRuntimeMasterKey || config.masterToken };
 }
 
-async function invalidateCache(ref: string, slug: string): Promise<void> {
+async function invalidateRuntimeFunction(
+  ref: string,
+  slug: string,
+): Promise<EdgeFunctionRuntimeControlResult> {
+  try {
+    const runtimeUrl = `http://${config.edgeRuntimeInternal}`;
+    const res = await fetch(`${runtimeUrl}/invalidate/${ref}/${slug}`, {
+      method: "POST",
+      headers: runtimeInternalHeaders(),
+      signal: AbortSignal.timeout(2000),
+    });
+    const bodyRecord = await readRuntimeControlBody(res);
+    return {
+      ok: res.ok && bodyRecord.success !== false,
+      status: res.status,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function invalidateCache(
+  ref: string,
+  slug: string,
+): Promise<EdgeFunctionRuntimeControlResult> {
   // 1. Clear the transform file cache
   const cacheDir = path.join(getFunctionsRoot(), ".cache", ref);
   for (const ext of [".ts", ".js"]) {
@@ -500,18 +556,49 @@ async function invalidateCache(ref: string, slug: string): Promise<void> {
   }
 
   // 2. Notify Edge Runtime to evict the module from Worker thread caches
-  try {
-    const runtimeUrl = `http://${config.edgeRuntimeInternal}`;
-    const res = await fetch(`${runtimeUrl}/invalidate/${ref}/${slug}`, {
-      method: "POST",
-      headers: runtimeInternalHeaders(),
-      signal: AbortSignal.timeout(2000),
+  const result = await invalidateRuntimeFunction(ref, slug);
+  if (!result.ok) {
+    logger.warn(`[EdgeFunction] Runtime invalidate failed`, {
+      ref,
+      slug,
+      status: result.status,
+      error: result.error,
     });
-    if (!res.ok) {
-      logger.warn(`[EdgeFunction] Runtime invalidate failed`, { ref, slug, status: res.status });
-    }
-  } catch {
-    // Edge Runtime may not be running — modules will load fresh on next start
+  }
+  return result;
+}
+
+function requireRuntimeControl(
+  control: EdgeFunctionRuntimeControlResult,
+  operation: string,
+): void {
+  if (control.ok) return;
+  const status = control.status ? ` (HTTP ${control.status})` : "";
+  throw new ServiceUnavailableError(
+    "Edge Runtime function activation",
+    `${operation}${status}: ${control.error || "control request failed"}`,
+  );
+}
+
+async function applyActiveVersionArtifacts(
+  ref: string,
+  slug: string,
+  detail: EdgeFunctionVersionDetail,
+  bundleCode: string,
+): Promise<void> {
+  const dir = getFuncDir(ref);
+  const safeSlug = validateSlug(slug);
+  await fs.mkdir(dir, { recursive: true });
+  await Bun.write(getFuncPath(ref, safeSlug), bundleCode);
+
+  const sourceCode = detail.source_code
+    ?? (detail.has_source ? await readVersionedFunctionSource(ref, slug, detail.version) : null);
+  if (sourceCode != null) await Bun.write(getSrcPath(ref, safeSlug), sourceCode);
+
+  if (detail.has_source_dir && detail.source_dir_path) {
+    const srcDir = assertInside(dir, path.join(dir, `.src-${safeSlug}`));
+    await fs.rm(srcDir, { recursive: true, force: true });
+    await fs.cp(detail.source_dir_path, srcDir, { recursive: true });
   }
 }
 
@@ -1167,52 +1254,29 @@ export const edgeFunctionService = {
   },
 
   async activateVersion(ref: string, slug: string, version: string): Promise<EdgeFunctionConfig | null> {
-    const detail = await this.getVersion(ref, slug, version);
-    if (!detail || !detail.has_bundle) return null;
-
-    const bundleCode = detail.bundle_code ?? (await readVersionedFunctionCode(ref, slug, version));
-    if (bundleCode == null) return null;
-
-    const dir = getFuncDir(ref);
-    const safeSlug = validateSlug(slug);
-    await fs.mkdir(dir, { recursive: true });
-    await Bun.write(getFuncPath(ref, safeSlug), bundleCode);
-
-    const sourceCode =
-      detail.source_code ?? (detail.has_source ? await readVersionedFunctionSource(ref, slug, version) : null);
-    if (sourceCode != null) {
-      await Bun.write(getSrcPath(ref, safeSlug), sourceCode);
-    }
-
-    if (detail.has_source_dir && detail.source_dir_path) {
-      const srcDir = assertInside(dir, path.join(dir, `.src-${safeSlug}`));
-      await fs.rm(srcDir, { recursive: true, force: true }).catch(() => {});
-      await fs.cp(detail.source_dir_path, srcDir, { recursive: true });
-    }
-
-    await invalidateCache(ref, slug);
-
+    const releaseLock = await acquireFunctionDeployLock(ref, slug);
     try {
-      const runtimeUrl = `http://${config.edgeRuntimeInternal}`;
-      const preheatRes = await fetch(`${runtimeUrl}/preheat/${ref}/${slug}`, {
-        method: "POST",
-        headers: runtimeInternalHeaders(),
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!preheatRes.ok) {
-        logger.warn("[EdgeFunction] Runtime preheat failed during version activation", { ref, slug, version, status: preheatRes.status });
-      }
-    } catch {
-      logger.debug("[EdgeFunction] Preheat skipped during version activation", {
-        ref,
-        slug,
-        version,
-      });
-    }
+      const detail = await this.getVersion(ref, slug, version);
+      if (!detail || !detail.has_bundle) return null;
 
-    const updated = await this.updateConfig(ref, slug, { version });
-    logger.info(`[EdgeFunction] Activated version ${version} for ${slug}@${ref}`);
-    return updated;
+      const bundleCode = detail.bundle_code ?? (await readVersionedFunctionCode(ref, slug, version));
+      if (bundleCode == null) return null;
+
+      // Validate the inactive artifact before changing any live file or config.
+      const readiness = await preheatRuntimeFunction(ref, slug, version);
+      requireRuntimeControl(readiness, "version readiness");
+
+      const invalidation = await invalidateCache(ref, slug);
+      requireRuntimeControl(invalidation, "cache invalidation");
+
+      await applyActiveVersionArtifacts(ref, slug, detail, bundleCode);
+
+      const updated = await this.updateConfig(ref, slug, { version });
+      logger.info(`[EdgeFunction] Activated version ${version} for ${slug}@${ref}`);
+      return updated;
+    } finally {
+      releaseLock();
+    }
   },
 
   /** List all function slugs for a project */

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -450,12 +450,28 @@ async function readRuntimeControlBody(response: Response): Promise<Record<string
   if (!bodyText) return {};
   try {
     const parsed = JSON.parse(bodyText);
-    return parsed && typeof parsed === "object"
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
       ? parsed as Record<string, unknown>
       : {};
   } catch {
     return {};
   }
+}
+
+function preheatAcknowledgementError(
+  body: Record<string, unknown>,
+  requestedVersion?: string,
+): string | undefined {
+  if (requestedVersion === undefined) {
+    return body.success === false ? "Edge Runtime reported preheat failure" : undefined;
+  }
+  if (body.success !== true) {
+    return "Edge Runtime did not report successful version readiness";
+  }
+  if (body.version !== requestedVersion) {
+    return "Edge Runtime did not confirm the requested function version";
+  }
+  return undefined;
 }
 
 async function preheatRuntimeFunction(
@@ -479,12 +495,9 @@ async function preheatRuntimeFunction(
     const bodyRecord = await readRuntimeControlBody(preheatRes);
     const foreground = normalizePreheatPool(bodyRecord.foreground);
     const background = normalizePreheatPool(bodyRecord.background);
-    const acknowledgedVersion = typeof bodyRecord.version === "string"
-      ? bodyRecord.version
-      : undefined;
-    const versionReady = requestedVersion === undefined || acknowledgedVersion === requestedVersion;
+    const acknowledgementError = preheatAcknowledgementError(bodyRecord, requestedVersion);
     return {
-      ok: preheatRes.ok && Boolean(bodyRecord.success ?? true) && versionReady,
+      ok: preheatRes.ok && acknowledgementError === undefined,
       status: preheatRes.status,
       duration_ms: durationMs,
       attempted: foreground.attempted + background.attempted,
@@ -493,9 +506,7 @@ async function preheatRuntimeFunction(
       cache_misses: foreground.cacheMisses + background.cacheMisses,
       foreground,
       background,
-      error: versionReady
-        ? undefined
-        : "Edge Runtime did not confirm the requested function version",
+      error: acknowledgementError,
     };
   } catch (error) {
     return {
@@ -517,6 +528,32 @@ function runtimeInternalHeaders(): Record<string, string> {
   return { "x-supacloud-internal-auth": config.edgeRuntimeMasterKey || config.masterToken };
 }
 
+function isRuntimeInvalidationPoolAck(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const pool = value as Record<string, unknown>;
+  if (![pool.attempted, pool.succeeded, pool.invalidated].every(
+    (metric) => Number.isSafeInteger(metric) && Number(metric) >= 0,
+  )) return false;
+  return pool.succeeded === pool.attempted;
+}
+
+function runtimeInvalidationAckError(
+  body: Record<string, unknown>,
+  expectedFunctionId: string,
+): string | undefined {
+  if (body.invalidated !== expectedFunctionId) {
+    return "Edge Runtime did not confirm the invalidation target";
+  }
+  if (body.success !== undefined && body.success !== true) {
+    return "Edge Runtime reported invalidation failure";
+  }
+  if (!isRuntimeInvalidationPoolAck(body.foreground)
+    || !isRuntimeInvalidationPoolAck(body.background)) {
+    return "Edge Runtime returned an invalid invalidation acknowledgement";
+  }
+  return undefined;
+}
+
 async function invalidateRuntimeFunction(
   ref: string,
   slug: string,
@@ -529,9 +566,14 @@ async function invalidateRuntimeFunction(
       signal: AbortSignal.timeout(2000),
     });
     const bodyRecord = await readRuntimeControlBody(res);
+    const acknowledgementError = runtimeInvalidationAckError(
+      bodyRecord,
+      `${ref}_${slug}`,
+    );
     return {
-      ok: res.ok && bodyRecord.success !== false,
+      ok: res.ok && acknowledgementError === undefined,
       status: res.status,
+      error: acknowledgementError,
     };
   } catch (error) {
     return {

--- a/packages/management-api/tests/unit/edge-function.service.activation.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.activation.test.ts
@@ -18,8 +18,30 @@ type FetchStep = {
   response: Response;
 };
 
+const successfulPoolAck = {
+  attempted: 1,
+  succeeded: 1,
+  invalidated: 0,
+};
+
+function successfulInvalidationAck(ref: string, slug: string) {
+  return {
+    invalidated: `${ref}_${slug}`,
+    foreground: successfulPoolAck,
+    background: successfulPoolAck,
+  };
+}
+
 function runtimeSuccessFetch(): typeof fetch {
-  return ((_input, init) => {
+  return ((input, init) => {
+    const runtimeUrl = new URL(String(input));
+    if (runtimeUrl.pathname.includes("/invalidate/")) {
+      const pathSegments = runtimeUrl.pathname.split("/");
+      return Promise.resolve(Response.json(successfulInvalidationAck(
+        pathSegments.at(-2)!,
+        pathSegments.at(-1)!,
+      )));
+    }
     const requestedVersion = new Headers(init?.headers).get("x-supacloud-function-version");
     return Promise.resolve(Response.json({ success: true, version: requestedVersion }));
   }) as typeof fetch;
@@ -118,7 +140,65 @@ describe("edgeFunctionService version activation readiness", () => {
       { path: "/preheat/", response: Response.json({ success: false, version: "2" }) },
     ]);
 
-    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow("control request failed");
+    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow(
+      "did not report successful version readiness",
+    );
+    await expectRollbackUnchanged(ref, slug, before);
+  });
+
+  test.each([
+    ["missing success", { version: "2" }],
+    ["non-boolean success", { success: "true", version: "2" }],
+    ["missing version", { success: true }],
+    ["wrong version", { success: true, version: "1" }],
+  ])("fails closed when preheat has %s acknowledgement", async (ackCase, responseBody) => {
+    const ref = `proj_preheat_ack_${ackCase.replaceAll(" ", "_")}`;
+    const slug = "activate-preheat-ack";
+    const before = await prepareRollback(ref, slug);
+    globalThis.fetch = sequenceFetch([
+      { path: "/preheat/", response: Response.json(responseBody) },
+    ]);
+
+    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow(
+      "Edge Runtime function activation unavailable",
+    );
+    await expectRollbackUnchanged(ref, slug, before);
+  });
+
+  test.each([
+    ["empty response", {}],
+    ["missing pool acknowledgement", { invalidated: "TARGET" }],
+    [
+      "partial pool acknowledgement",
+      {
+        invalidated: "TARGET",
+        foreground: { attempted: 2, succeeded: 1, invalidated: 1 },
+        background: successfulPoolAck,
+      },
+    ],
+    [
+      "wrong target",
+      {
+        invalidated: "another_function",
+        foreground: successfulPoolAck,
+        background: successfulPoolAck,
+      },
+    ],
+  ])("fails closed when invalidation has %s", async (ackCase, responseBody) => {
+    const ref = `proj_invalidate_ack_${ackCase.replaceAll(" ", "_")}`;
+    const slug = "activate-invalidate-ack";
+    const before = await prepareRollback(ref, slug);
+    const acknowledgedBody = responseBody.invalidated === "TARGET"
+      ? { ...responseBody, invalidated: `${ref}_${slug}` }
+      : responseBody;
+    globalThis.fetch = sequenceFetch([
+      { path: "/preheat/", response: Response.json({ success: true, version: "2" }) },
+      { path: "/invalidate/", response: Response.json(acknowledgedBody) },
+    ]);
+
+    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow(
+      "Edge Runtime function activation unavailable",
+    );
     await expectRollbackUnchanged(ref, slug, before);
   });
 
@@ -128,7 +208,10 @@ describe("edgeFunctionService version activation readiness", () => {
     await prepareRollback(ref, slug);
     const steps: FetchStep[] = [
       { path: "/preheat/", response: Response.json({ success: true, version: "2" }) },
-      { path: "/invalidate/", response: Response.json({ success: true }) },
+      {
+        path: "/invalidate/",
+        response: Response.json(successfulInvalidationAck(ref, slug)),
+      },
     ];
     globalThis.fetch = sequenceFetch(steps);
 

--- a/packages/management-api/tests/unit/edge-function.service.activation.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.activation.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const functionsRoot = await mkdtemp(join(tmpdir(), "supacloud-function-activation-"));
+const originalFunctionsDir = process.env.EDGE_FUNCTIONS_DIR;
+const originalRuntimeInternal = process.env.EDGE_RUNTIME_INTERNAL;
+const originalFetch = globalThis.fetch;
+
+process.env.EDGE_FUNCTIONS_DIR = functionsRoot;
+process.env.EDGE_RUNTIME_INTERNAL = "127.0.0.1:65535";
+
+const { edgeFunctionService } = await import("../../src/services/edge-function.service");
+
+type FetchStep = {
+  path: "/preheat/" | "/invalidate/";
+  response: Response;
+};
+
+function runtimeSuccessFetch(): typeof fetch {
+  return ((_input, init) => {
+    const requestedVersion = new Headers(init?.headers).get("x-supacloud-function-version");
+    return Promise.resolve(Response.json({ success: true, version: requestedVersion }));
+  }) as typeof fetch;
+}
+
+function sequenceFetch(steps: FetchStep[]): typeof fetch {
+  return ((input, init) => {
+    const step = steps.shift();
+    if (!step) throw new Error(`Unexpected runtime request: ${String(input)}`);
+    expect(String(input)).toContain(step.path);
+    if (step.path === "/preheat/") {
+      expect(new Headers(init?.headers).get("x-supacloud-function-version")).toBe("2");
+    }
+    return Promise.resolve(step.response);
+  }) as typeof fetch;
+}
+
+async function prepareRollback(ref: string, slug: string) {
+  globalThis.fetch = runtimeSuccessFetch();
+  await edgeFunctionService.deployBundleDetailed(ref, slug, {
+    "index.ts": "export default { fetch: () => new Response('version-one') };",
+    "public/version.txt": "version-one",
+  });
+  await edgeFunctionService.deployBundleDetailed(ref, slug, {
+    "index.ts": "export default { fetch: () => new Response('version-two') };",
+    "public/version.txt": "version-two",
+  });
+  await edgeFunctionService.activateVersion(ref, slug, "1");
+
+  return {
+    config: await edgeFunctionService.getConfig(ref, slug),
+    artifact: await readFile(join(functionsRoot, ref, `${slug}.js`), "utf8"),
+    sourceAsset: await readFile(
+      join(functionsRoot, ref, `.src-${slug}`, "public", "version.txt"),
+      "utf8",
+    ),
+  };
+}
+
+async function expectRollbackUnchanged(
+  ref: string,
+  slug: string,
+  before: Awaited<ReturnType<typeof prepareRollback>>,
+) {
+  expect(await edgeFunctionService.getConfig(ref, slug)).toEqual(before.config);
+  expect(await readFile(join(functionsRoot, ref, `${slug}.js`), "utf8")).toBe(before.artifact);
+  expect(
+    await readFile(join(functionsRoot, ref, `.src-${slug}`, "public", "version.txt"), "utf8"),
+  ).toBe(before.sourceAsset);
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(async () => {
+  if (originalFunctionsDir === undefined) delete process.env.EDGE_FUNCTIONS_DIR;
+  else process.env.EDGE_FUNCTIONS_DIR = originalFunctionsDir;
+  if (originalRuntimeInternal === undefined) delete process.env.EDGE_RUNTIME_INTERNAL;
+  else process.env.EDGE_RUNTIME_INTERNAL = originalRuntimeInternal;
+  globalThis.fetch = originalFetch;
+  await rm(functionsRoot, { recursive: true, force: true });
+});
+
+describe("edgeFunctionService version activation readiness", () => {
+  test("fails closed when version preheat is unauthorized", async () => {
+    const ref = "proj_activation_preheat_401";
+    const slug = "activate-preheat-401";
+    const before = await prepareRollback(ref, slug);
+    globalThis.fetch = sequenceFetch([
+      { path: "/preheat/", response: Response.json({ message: "Unauthorized" }, { status: 401 }) },
+    ]);
+
+    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow("HTTP 401");
+    await expectRollbackUnchanged(ref, slug, before);
+  });
+
+  test("fails closed when cache invalidation is unauthorized", async () => {
+    const ref = "proj_activation_invalidate_401";
+    const slug = "activate-invalidate-401";
+    const before = await prepareRollback(ref, slug);
+    globalThis.fetch = sequenceFetch([
+      { path: "/preheat/", response: Response.json({ success: true, version: "2" }) },
+      { path: "/invalidate/", response: Response.json({ message: "Unauthorized" }, { status: 401 }) },
+    ]);
+
+    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow("HTTP 401");
+    await expectRollbackUnchanged(ref, slug, before);
+  });
+
+  test("fails closed when preheat reports success false", async () => {
+    const ref = "proj_activation_preheat_false";
+    const slug = "activate-preheat-false";
+    const before = await prepareRollback(ref, slug);
+    globalThis.fetch = sequenceFetch([
+      { path: "/preheat/", response: Response.json({ success: false, version: "2" }) },
+    ]);
+
+    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow("control request failed");
+    await expectRollbackUnchanged(ref, slug, before);
+  });
+
+  test("activates only after target readiness and invalidation succeed", async () => {
+    const ref = "proj_activation_success";
+    const slug = "activate-success";
+    await prepareRollback(ref, slug);
+    const steps: FetchStep[] = [
+      { path: "/preheat/", response: Response.json({ success: true, version: "2" }) },
+      { path: "/invalidate/", response: Response.json({ success: true }) },
+    ];
+    globalThis.fetch = sequenceFetch(steps);
+
+    const config = await edgeFunctionService.activateVersion(ref, slug, "2");
+
+    expect(config?.version).toBe("2");
+    expect(await readFile(join(functionsRoot, ref, `${slug}.js`), "utf8")).toContain("version-two");
+    expect(
+      await readFile(join(functionsRoot, ref, `.src-${slug}`, "public", "version.txt"), "utf8"),
+    ).toBe("version-two");
+    expect(steps).toHaveLength(0);
+  });
+});

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -49,7 +49,10 @@ describe("edgeFunctionService bundle metadata", () => {
   test("allocates after retained history instead of overwriting a rolled-back version", async () => {
     const ref = "proj_rollback_history";
     const slug = "history-safe";
-    globalThis.fetch = (() => Promise.resolve(Response.json({ success: true }))) as typeof fetch;
+    globalThis.fetch = ((_input, init) => {
+      const requestedVersion = new Headers(init?.headers).get("x-supacloud-function-version");
+      return Promise.resolve(Response.json({ success: true, version: requestedVersion }));
+    }) as typeof fetch;
 
     const v1 = await edgeFunctionService.deployBundleDetailed(ref, slug, {
       "index.ts": "export default { fetch: () => new Response('v1') };",

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -49,7 +49,14 @@ describe("edgeFunctionService bundle metadata", () => {
   test("allocates after retained history instead of overwriting a rolled-back version", async () => {
     const ref = "proj_rollback_history";
     const slug = "history-safe";
-    globalThis.fetch = ((_input, init) => {
+    globalThis.fetch = ((input, init) => {
+      if (String(input).includes("/invalidate/")) {
+        return Promise.resolve(Response.json({
+          invalidated: `${ref}_${slug}`,
+          foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
+          background: { attempted: 0, succeeded: 0, invalidated: 0 },
+        }));
+      }
       const requestedVersion = new Headers(init?.headers).get("x-supacloud-function-version");
       return Promise.resolve(Response.json({ success: true, version: requestedVersion }));
     }) as typeof fetch;
@@ -160,7 +167,15 @@ describe("edgeFunctionService bundle metadata", () => {
   });
 
   test("keeps multi-file runtime code beside its static assets", async () => {
-    globalThis.fetch = (() => Promise.resolve(Response.json({ ok: true }))) as typeof fetch;
+    globalThis.fetch = ((input) => Promise.resolve(Response.json(
+      String(input).includes("/invalidate/")
+        ? {
+            invalidated: "proj_assets_asset-reader",
+            foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
+            background: { attempted: 0, succeeded: 0, invalidated: 0 },
+          }
+        : { success: true },
+    ))) as typeof fetch;
 
     const deployResult = await edgeFunctionService.deployBundleDetailed(
       "proj_assets",
@@ -242,7 +257,11 @@ describe("edgeFunctionService bundle metadata", () => {
           },
         }));
       }
-      return Promise.resolve(Response.json({ ok: true }));
+      return Promise.resolve(Response.json({
+        invalidated: "proj_meta_hello",
+        foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
+        background: { attempted: 0, succeeded: 0, invalidated: 0 },
+      }));
     }) as typeof fetch;
     process.env.EDGE_FUNCTION_EXTERNAL_PACKAGES = "left-pad,@scope/pkg,invalid/pkg/name";
 


### PR DESCRIPTION
## Summary

- preheat the immutable target Function version before changing active artifacts or config
- require successful internal preheat and cache invalidation responses, including explicit version acknowledgement
- serialize activation with Function deployments and preserve legacy version artifact lookup

## Root cause

Version activation updated the live artifact and config even when Edge Runtime internal control requests returned unauthorized responses or reported unsuccessful preheat. The API could therefore report activation success without runtime readiness.

## Tests

- unauthorized target-version preheat keeps the prior config and active bundle/source tree
- unauthorized cache invalidation keeps the prior config and active bundle/source tree
- HTTP 200 with `success: false` fails closed
- successful readiness and invalidation activate the requested version
- focused Management/Edge tests and both package typechecks pass