### PR TITLE
fix(deps): align dompurify override

### DIFF
--- a/packages/web-console/bun.lock
+++ b/packages/web-console/bun.lock
@@ -53,7 +53,7 @@
   },
   "overrides": {
     "cookie": "0.7.2",
-    "dompurify": "3.4.11",
+    "dompurify": "3.4.12",
     "esbuild": "0.28.1",
     "joi": "17.13.4",
   },
@@ -374,7 +374,7 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
-    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
 
     "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -55,7 +55,7 @@
   },
   "overrides": {
     "cookie": "0.7.2",
-    "dompurify": "3.4.11",
+    "dompurify": "3.4.12",
     "esbuild": "0.28.1",
     "joi": "17.13.4"
   },


### PR DESCRIPTION
## Follow-up provenance

- Parent: #696
- Source: independent verifier P2 finding on #696
- Reason: #696 auto-merged before the follow-up commit could be attached; the merged tree still forced DOMPurify 3.4.11 while isomorphic-dompurify 3.21.0 requires ^3.4.12.

## Summary

- bump the existing flat DOMPurify override from 3.4.11 to 3.4.12
- update the single lock node with registry-generated integrity metadata
- keep all consumers on one DOMPurify 3.4.12 node without adding a direct dependency or nested 3.4.11 residue

GitHub Advisory Database reports GHSA-c2j3-45gr-mqc4 affects DOMPurify <=3.4.11 and identifies 3.4.12 as the first patched version.

## Validation

- official-registry bun audit --audit-level high
- official-registry frozen install
- bun test src: 163 pass, 0 fail
- svelte-check: 0 errors, 0 warnings
- production build
- dependency-tree read-back: isomorphic-dompurify 3.21.0, jsdom 30.0.0, undici 8.10.0, DOMPurify 3.4.12
- git diff --check

No server was updated or deployed.