### PR TITLE
fix(functions): activate code and JWT policy atomically

### DIFF
--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -110,16 +110,16 @@ describe("edge_functions CLI tool", () => {
         expect(result.content[0].text).toContain("Function render config updated");
     });
 
-    test("patches config after bundle deployment when config flags are provided", async () => {
+    test("sends bundle config inline without a follow-up PATCH", async () => {
         const calls: Array<{ method: string; path: string; body: unknown }> = [];
         const { callback } = captureEdgeFunctionsTool({
             post: async (path: string, body: unknown) => {
                 calls.push({ method: "post", path, body });
-                return { ok: true, status: 200, data: { success: true } };
-            },
-            patch: async (path: string, body: unknown) => {
-                calls.push({ method: "patch", path, body });
-                return { ok: true, status: 200, data: { verify_jwt: true, background_routes: ["/work/*"] } };
+                return {
+                    ok: true,
+                    status: 200,
+                    data: { success: true, verify_jwt: true, background_routes: ["/work/*"] },
+                };
             },
         });
 
@@ -136,16 +136,95 @@ describe("edge_functions CLI tool", () => {
             {
                 method: "post",
                 path: "/v1/projects/proj/functions/worker/bundle",
-                body: { files: { "index.ts": "export default {}" }, entrypoint: undefined, minify: undefined },
-            },
-            {
-                method: "patch",
-                path: "/v1/projects/proj/functions/worker/config",
-                body: { verify_jwt: true, background_routes: ["/work/*"] },
+                body: {
+                    files: { "index.ts": "export default {}" },
+                    entrypoint: undefined,
+                    minify: undefined,
+                    verify_jwt: true,
+                    background_routes: ["/work/*"],
+                },
             },
         ]);
         expect(result.content[0].text).toContain("Function worker bundle deployed");
-        expect(result.content[0].text).toContain("Function worker config updated");
+    });
+
+    test("sends single-file config inline without a follow-up PATCH", async () => {
+        const calls: Array<{ method: string; path: string; body: unknown }> = [];
+        const { callback } = captureEdgeFunctionsTool({
+            post: async (path: string, body: unknown) => {
+                calls.push({ method: "post", path, body });
+                return { ok: true, status: 200, data: { success: true, verify_jwt: false } };
+            },
+        });
+
+        const result = await callback({
+            action: "deploy",
+            ref: "proj",
+            slug: "public-hook",
+            code: "export default { fetch: () => new Response('ok') }",
+            verify_jwt: false,
+        });
+
+        expect(calls).toEqual([{
+            method: "post",
+            path: "/v1/projects/proj/functions/public-hook",
+            body: {
+                code: "export default { fetch: () => new Response('ok') }",
+                minify: undefined,
+                verify_jwt: false,
+            },
+        }]);
+        expect(result.content[0].text).toContain("Function public-hook deployed");
+    });
+
+    test("uses an explicitly labelled legacy PATCH when an old server omits policy confirmation", async () => {
+        const calls: Array<{ method: string; path: string; body: unknown }> = [];
+        const { callback } = captureEdgeFunctionsTool({
+            post: async (path: string, body: unknown) => {
+                calls.push({ method: "post", path, body });
+                return { ok: true, status: 200, data: { success: true } };
+            },
+            patch: async (path: string, body: unknown) => {
+                calls.push({ method: "patch", path, body });
+                return { ok: true, status: 200, data: { verify_jwt: false } };
+            },
+        });
+
+        const response = await callback({
+            action: "deploy_bundle",
+            ref: "proj",
+            slug: "legacy-hook",
+            files: { "index.ts": "export default {}" },
+            verify_jwt: false,
+        });
+
+        expect(calls.map(({ method, path }) => ({ method, path }))).toEqual([
+            { method: "post", path: "/v1/projects/proj/functions/legacy-hook/bundle" },
+            { method: "patch", path: "/v1/projects/proj/functions/legacy-hook/config" },
+        ]);
+        expect(response.content[0].text).toContain("Legacy non-atomic compatibility path");
+    });
+
+    test("reports an unsafe partial deployment when legacy policy PATCH cannot be confirmed", async () => {
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => ({ ok: true, status: 200, data: { success: true } }),
+            patch: async () => ({ ok: false, status: 503, data: { message: "unavailable" } }),
+        });
+
+        const response = await callback({
+            action: "deploy_bundle",
+            ref: "proj",
+            slug: "legacy-hook-fail",
+            files: { "index.ts": "export default {}" },
+            verify_jwt: false,
+        });
+
+        expect(response.content[0].text).toContain("Partial deployment (unsafe)");
+        expect(response.content[0].text).toContain("POST succeeded");
+        expect(response.content[0].text).toContain("code/bundle was deployed");
+        expect(response.content[0].text).toContain("function policy was not confirmed");
+        expect(response.content[0].text).toContain("legacy PATCH fallback failed");
+        expect(response.content[0].text).not.toContain("Deployment failed");
     });
 });
 

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -108,6 +108,17 @@ type EdgeFunctionConfigInput = {
     background_routes?: string[];
 };
 
+function confirmedFunctionConfig(payload: unknown, expected: EdgeFunctionConfigInput): boolean {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+    const response = payload as Record<string, unknown>;
+    if (expected.verify_jwt !== undefined && response.verify_jwt !== expected.verify_jwt) return false;
+    if (expected.background_routes !== undefined) {
+        if (!Array.isArray(response.background_routes)) return false;
+        if (JSON.stringify(response.background_routes) !== JSON.stringify(expected.background_routes)) return false;
+    }
+    return true;
+}
+
 export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
 
     // ═══ Edge Functions (5→1) ═══
@@ -152,6 +163,23 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
                     : `❌ Config update failed (${cr.status}): ${JSON.stringify(cr.data)}`;
             };
 
+            const confirmedDeploymentText = async (
+                successText: string,
+                responsePayload: unknown,
+            ): Promise<string> => {
+                if (!hasFunctionConfig() || confirmedFunctionConfig(responsePayload, functionConfig())) {
+                    return successText;
+                }
+                const fallback = await http.patch(
+                    `/v1/projects/${ref}/functions/${slug}/config`,
+                    functionConfig(),
+                );
+                if (!fallback.ok || !confirmedFunctionConfig(fallback.data, functionConfig())) {
+                    return `❌ Partial deployment (unsafe): POST succeeded and the code/bundle was deployed, but the function policy was not confirmed; legacy PATCH fallback failed (${fallback.status}): ${JSON.stringify(fallback.data)}`;
+                }
+                return `${successText}\n⚠️ Legacy non-atomic compatibility path: policy applied with follow-up PATCH`;
+            };
+
             const checkSyntax = async (sourceCode: string): Promise<{ ok: boolean; err?: string }> => {
                 const tmpDir = mkdtempSync(join(tmpdir(), "supacloud-edge-check-"));
                 const tmpFile = join(tmpDir, "index.ts");
@@ -194,25 +222,33 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
                         text = `❌ Deployment aborted. Syntax check failed:\n${deployCheck.err}`;
                         break;
                     }
-                    const dr = await http.post(`/v1/projects/${ref}/functions/${slug}`, { code, minify });
+                    const dr = await http.post(`/v1/projects/${ref}/functions/${slug}`, {
+                        code,
+                        minify,
+                        ...functionConfig(),
+                    });
                     if (!dr.ok) {
                         text = `❌ Failed (${dr.status}): ${JSON.stringify(dr.data)}`;
                         break;
                     }
-                    text = hasFunctionConfig()
-                        ? `✅ Function ${slug} deployed\n${await updateFunctionConfig()}`
-                        : `✅ Function ${slug} deployed`;
+                    text = await confirmedDeploymentText(`✅ Function ${slug} deployed`, dr.data);
                     break;
                 case "deploy_bundle":
                     need("slug", slug); need("files", files);
-                    const br = await http.post(`/v1/projects/${ref}/functions/${slug}/bundle`, { files, entrypoint, minify });
+                    const br = await http.post(`/v1/projects/${ref}/functions/${slug}/bundle`, {
+                        files,
+                        entrypoint,
+                        minify,
+                        ...functionConfig(),
+                    });
                     if (!br.ok) {
                         text = `❌ Failed (${br.status}): ${JSON.stringify(br.data)}`;
                         break;
                     }
-                    text = hasFunctionConfig()
-                        ? `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)\n${await updateFunctionConfig()}`
-                        : `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)`;
+                    text = await confirmedDeploymentText(
+                        `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)`,
+                        br.data,
+                    );
                     break;
                 case "config":
                     text = await updateFunctionConfig();

--- a/packages/edge-runtime/function-source.test.ts
+++ b/packages/edge-runtime/function-source.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import path from "path";
-import { BUNDLED_SOURCE_RUNTIME_ENTRY, functionPathCandidates } from "./function-source";
+import {
+  activeFunctionPathCandidates,
+  BUNDLED_SOURCE_RUNTIME_ENTRY,
+  functionPathCandidates,
+} from "./function-source";
 
 describe("multi-file function runtime source", () => {
   test("loads the active source-dir entry before the legacy bundle", () => {
@@ -15,6 +19,24 @@ describe("multi-file function runtime source", () => {
     expect(functionPathCandidates("/functions/project", "supauth", "7")).toEqual([
       path.join("/functions/project", ".versions", "supauth", "7", "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
       "/functions/project/.versions/supauth/7/index.js",
+    ]);
+  });
+
+  test("falls back from a configured version only to frozen legacy aliases", () => {
+    expect(activeFunctionPathCandidates("/functions/project", "supauth", "7")).toEqual([
+      path.join("/functions/project", ".versions", "supauth", "7", "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
+      "/functions/project/.versions/supauth/7/index.js",
+      path.join("/functions/project", ".src-supauth", BUNDLED_SOURCE_RUNTIME_ENTRY),
+      "/functions/project/supauth.js",
+      "/functions/project/supauth.ts",
+    ]);
+  });
+
+  test("uses mutable aliases only for a legacy activation without a version", () => {
+    expect(activeFunctionPathCandidates("/functions/project", "supauth", null)).toEqual([
+      path.join("/functions/project", ".src-supauth", BUNDLED_SOURCE_RUNTIME_ENTRY),
+      "/functions/project/supauth.js",
+      "/functions/project/supauth.ts",
     ]);
   });
 });

--- a/packages/edge-runtime/function-source.ts
+++ b/packages/edge-runtime/function-source.ts
@@ -21,3 +21,16 @@ export function functionPathCandidates(
     path.join(projectRoot, `${functionName}.ts`),
   ];
 }
+
+export function activeFunctionPathCandidates(
+  projectRoot: string,
+  functionName: string,
+  activeVersion: string | null,
+): string[] {
+  return activeVersion
+    ? [
+        ...functionPathCandidates(projectRoot, functionName, activeVersion),
+        ...functionPathCandidates(projectRoot, functionName),
+      ]
+    : functionPathCandidates(projectRoot, functionName);
+}

--- a/packages/edge-runtime/server-cache.test.ts
+++ b/packages/edge-runtime/server-cache.test.ts
@@ -29,4 +29,33 @@ describe("Edge Runtime auth material invalidation", () => {
     expect(endpoint).toContain("`_v${requestedVersion}`");
     expect(endpoint).toContain("version: requestedVersion");
   });
+
+  test("function invalidation evicts policy config and active dispatch identities include version", () => {
+    const invalidationEndpoint = source.slice(
+      source.indexOf('.post("/invalidate/:ref/:slug"'),
+      source.indexOf('.post("/invalidate-env/:ref"'),
+    );
+    expect(invalidationEndpoint).toContain("configCache.delete(`${c.params.ref}/${c.params.slug}`)");
+    expect(invalidationEndpoint).toContain('module_scope: "legacy-base-only"');
+    expect(invalidationEndpoint).toContain("immutable_versions_retained: true");
+    expect(invalidationEndpoint).toContain("config_cache_evicted: true");
+    expect(source).toContain('const versionSuffix = activeVersion ? `_v${activeVersion}` : ""');
+    expect(source).toContain('`active:${activeVersion || "legacy"}`');
+  });
+
+  test("external requests use one resolved activation snapshot and ignore version headers", () => {
+    const requestHandler = source.slice(
+      source.indexOf("async function handleFunctionRequest("),
+      source.indexOf("const app = new Elysia()"),
+    );
+    const dispatcher = source.slice(
+      source.indexOf("async function dispatchFunction("),
+      source.indexOf("async function appendFunctionRuntimeLog("),
+    );
+    expect(requestHandler).toContain("activation = await resolveFunctionPath(projectRef, functionName)");
+    expect(requestHandler).toContain("activation.verifyJwt");
+    expect(requestHandler).toContain("activation,");
+    expect(requestHandler).not.toContain("x-supacloud-function-version");
+    expect(dispatcher).not.toContain("x-supacloud-function-version");
+  });
 });

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -20,7 +20,7 @@ import {
 import {
   buildBackgroundForwardDispatch,
 } from "./background-forward";
-import { functionPathCandidates } from "./function-source";
+import { activeFunctionPathCandidates, functionPathCandidates } from "./function-source";
 import path from "path";
 import fs from "fs/promises";
 import type { PgredisRuntimeEndpointConfig } from "./internal-bindings";
@@ -281,16 +281,19 @@ async function resolveProjectRoot(projectRef: string): Promise<string> {
   return realProjectRoot;
 }
 
+type FunctionActivationSnapshot = {
+  functionPath: string;
+  projectRoot: string;
+  activeVersion: string | null;
+  verifyJwt: boolean;
+  moduleVersion: string;
+};
+
 async function resolveFunctionPath(
   projectRef: string,
   functionName: string,
   requestedVersion?: string | null,
-): Promise<{
-  functionPath: string;
-  projectRoot: string;
-  activeVersion: string | null;
-  moduleVersion: string;
-}> {
+): Promise<FunctionActivationSnapshot> {
   if (!isSafeFunctionSlug(functionName)) {
     throw new Error("Invalid function slug");
   }
@@ -301,7 +304,9 @@ async function resolveFunctionPath(
   const projectRoot = await resolveProjectRoot(projectRef);
   const resolvedConfig = await getFunctionConfig(projectRef, functionName, projectRoot);
   const activeVersion = requestedVersion || resolvedConfig.version || null;
-  const candidates = functionPathCandidates(projectRoot, functionName, requestedVersion);
+  const candidates = requestedVersion
+    ? functionPathCandidates(projectRoot, functionName, requestedVersion)
+    : activeFunctionPathCandidates(projectRoot, functionName, resolvedConfig.version);
 
   for (const candidate of candidates) {
     if (!isPathInside(candidate, projectRoot)) {
@@ -321,7 +326,9 @@ async function resolveFunctionPath(
         functionPath: realCandidate,
         projectRoot,
         activeVersion,
+        verifyJwt: resolvedConfig.verify_jwt,
         moduleVersion: [
+          `active:${activeVersion || "legacy"}`,
           `env:${getProjectModuleEpoch(projectRef)}`,
           `mtime:${stat.mtimeMs}`,
           `ctime:${stat.ctimeMs}`,
@@ -336,29 +343,57 @@ async function resolveFunctionPath(
   throw new Error("Function not found");
 }
 
-async function dispatchFunction(
-  projectRef: string,
-  functionName: string,
-  request: Request,
-  setHeaders: Record<string, string>,
-  opts?: {
-    background?: boolean;
-    backgroundInternalToken?: string;
-    tenantEnv?: Record<string, string>;
-    cancelKey?: string;
-    onLog?: (entry: {
-      timestamp: string;
-      stream: "stdout" | "stderr";
-      level: string;
-      message: string;
-    }) => void;
-  },
-) {
-  const requestedVersion = request.headers.get("x-supacloud-function-version") || null;
+type FunctionDispatchOptions = {
+  background?: boolean;
+  backgroundInternalToken?: string;
+  tenantEnv?: Record<string, string>;
+  cancelKey?: string;
+  onLog?: (entry: {
+    timestamp: string;
+    stream: "stdout" | "stderr";
+    level: string;
+    message: string;
+  }) => void;
+};
 
+type FunctionDispatchInput = {
+  projectRef: string;
+  functionName: string;
+  request: Request;
+  setHeaders: Record<string, string>;
+  activation: FunctionActivationSnapshot;
+};
+
+function functionDispatchError(
+  error: unknown,
+  setHeaders: Record<string, string>,
+): Response {
+  const message = error instanceof Error ? error.message : "Internal Error";
+  setHeaders["x-relay-error"] = "true";
+  const statusCode = message.includes("not found") || message.includes("ENOENT")
+    ? 404
+    : message.includes("timeout") || message.includes("Timeout")
+      ? 504
+      : 500;
+  const safeMessage = statusCode === 404
+    ? "Function not found"
+    : statusCode === 504
+      ? "Function execution timed out"
+      : "Internal Server Error";
+  return new Response(JSON.stringify({ error: safeMessage }), {
+    status: statusCode,
+    headers: { "Content-Type": "application/json", "x-relay-error": "true" },
+  });
+}
+
+async function dispatchFunction(
+  input: FunctionDispatchInput,
+  opts?: FunctionDispatchOptions,
+) {
+  const { projectRef, functionName, request, setHeaders, activation } = input;
   try {
-    const { functionPath, projectRoot, activeVersion, moduleVersion } = await resolveFunctionPath(projectRef, functionName, requestedVersion);
-    const versionSuffix = requestedVersion ? `_v${requestedVersion}` : "";
+    const { functionPath, projectRoot, activeVersion, moduleVersion } = activation;
+    const versionSuffix = activeVersion ? `_v${activeVersion}` : "";
     const functionId = `${projectRef}_${functionName}${versionSuffix}`;
     const targetPool = opts?.background ? backgroundPool : pool;
     const tenantEnv = opts?.tenantEnv || await loadTenantEnv(projectRef);
@@ -396,28 +431,8 @@ async function dispatchFunction(
         opts?.onLog?.(entry);
       },
     });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : "Internal Error";
-
-    setHeaders["x-relay-error"] = "true";
-
-    const statusCode =
-      message.includes("not found") || message.includes("ENOENT")
-        ? 404
-        : message.includes("timeout") || message.includes("Timeout")
-          ? 504
-          : 500;
-
-    const safeMessage = statusCode === 404
-      ? "Function not found"
-      : statusCode === 504
-        ? "Function execution timed out"
-        : "Internal Server Error";
-
-    return new Response(JSON.stringify({ error: safeMessage }), {
-      status: statusCode,
-      headers: { "Content-Type": "application/json", "x-relay-error": "true" },
-    });
+  } catch (error: unknown) {
+    return functionDispatchError(error, setHeaders);
   }
 }
 
@@ -651,10 +666,15 @@ async function handleFunctionRequest(
     return blockedResponse;
   }
 
-  const projectRoot = await resolveProjectRoot(projectRef);
-  const fnConfig = await getFunctionConfig(projectRef, functionName, projectRoot);
+  const setHeaders = c.set.headers as Record<string, string>;
+  let activation: FunctionActivationSnapshot;
+  try {
+    activation = await resolveFunctionPath(projectRef, functionName);
+  } catch (error) {
+    return functionDispatchError(error, setHeaders);
+  }
   let verifiedSubject: string | undefined;
-  if (c.request.method !== "OPTIONS" && fnConfig.verify_jwt) {
+  if (c.request.method !== "OPTIONS" && activation.verifyJwt) {
     const verification = await verifyJwt(
       projectRef,
       authHeader,
@@ -679,10 +699,13 @@ async function handleFunctionRequest(
   const functionRequest = withVerifiedJwtContext(c.request, verifiedSubject);
   c.set.headers["x-sb-execution-id"] = crypto.randomUUID();
   const response = await dispatchFunction(
-    projectRef,
-    functionName,
-    functionRequest,
-    c.set.headers as Record<string, string>,
+    {
+      projectRef,
+      functionName,
+      request: functionRequest,
+      setHeaders,
+      activation,
+    },
   );
 
   if (response.status === 401) {
@@ -720,12 +743,20 @@ const app = new Elysia()
     }
 
     const functionId = `${c.params.ref}_${c.params.slug}`;
+    configCache.delete(`${c.params.ref}/${c.params.slug}`);
     invalidateTenantEnvCache(c.params.ref);
     const [foreground, background] = await Promise.all([
       pool.invalidateModule(functionId),
       backgroundPool.invalidateModule(functionId),
     ]);
-    return { invalidated: functionId, foreground, background };
+    return {
+      invalidated: functionId,
+      module_scope: "legacy-base-only",
+      immutable_versions_retained: true,
+      config_cache_evicted: true,
+      foreground,
+      background,
+    };
   })
 
   .post("/invalidate-env/:ref", async (c) => {
@@ -799,11 +830,16 @@ const app = new Elysia()
       c.request,
       await loadTenantEnv(c.params.ref),
     );
+    const requestedVersion = backgroundDispatch.forwardedRequest.headers.get("x-supacloud-function-version");
+    const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
     const response = await dispatchFunction(
-      c.params.ref,
-      c.params.functionName,
-      backgroundDispatch.forwardedRequest,
-      setHeaders,
+      {
+        projectRef: c.params.ref,
+        functionName: c.params.functionName,
+        request: backgroundDispatch.forwardedRequest,
+        setHeaders,
+        activation,
+      },
       {
         background: true,
         backgroundInternalToken: backgroundDispatch.backgroundInternalToken,
@@ -850,11 +886,16 @@ const app = new Elysia()
       c.request,
       await loadTenantEnv(c.params.ref),
     );
+    const requestedVersion = backgroundDispatch.forwardedRequest.headers.get("x-supacloud-function-version");
+    const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
     const response = await dispatchFunction(
-      c.params.ref,
-      c.params.functionName,
-      backgroundDispatch.forwardedRequest,
-      setHeaders,
+      {
+        projectRef: c.params.ref,
+        functionName: c.params.functionName,
+        request: backgroundDispatch.forwardedRequest,
+        setHeaders,
+        activation,
+      },
       {
         background: true,
         backgroundInternalToken: backgroundDispatch.backgroundInternalToken,

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -2,6 +2,7 @@ import { Elysia, t, status } from "elysia";
 import { projectService } from "../services";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { isUserManagedFunctionSecretName } from "../utils/project-secret-visibility";
+import type { EdgeFunctionDeploymentConfig } from "../services/edge-function.service";
 
 async function requireFunctionManagementAuth(request: Request, ref: string) {
   const authError = await requireProjectOrAdminAuth(request, ref);
@@ -27,6 +28,22 @@ function normalizeLimitOffset(
     ? Math.max(0, Math.floor(rawOffset))
     : defaults.offset;
   return { limit, offset };
+}
+
+function deploymentConfig(
+  verifyJwt: boolean | undefined,
+  backgroundRoutes: string[] | undefined,
+): EdgeFunctionDeploymentConfig {
+  return {
+    ...(typeof verifyJwt === "boolean" ? { verify_jwt: verifyJwt } : {}),
+    ...(backgroundRoutes ? { background_routes: backgroundRoutes } : {}),
+  };
+}
+
+function normalizedBackgroundRoutes(routes: unknown): string[] | undefined {
+  return Array.isArray(routes)
+    ? routes.filter((route): route is string => typeof route === "string" && route.trim().length > 0)
+    : undefined;
 }
 
 export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
@@ -110,58 +127,43 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         fileMap[entrypoint] = await fileList[0].text();
       }
 
-      const result = await projectService.deployFunctionBundleDetailed(
-        params.ref,
+      const backgroundRoutes = normalizedBackgroundRoutes(metadata.background_routes);
+      const deployment = await projectService.deployFunctionRelease({
+        ref: params.ref,
         slug,
-        fileMap,
+        files: fileMap,
         entrypoint,
-        false,
-      );
-      if (!result.success) {
+        config: deploymentConfig(metadata.verify_jwt, backgroundRoutes),
+      });
+      if (!deployment.success) {
         return status(500, {
-          message: result.error || "Failed to deploy function bundle",
+          message: deployment.error || "Failed to deploy function bundle",
           code: "500",
-          details: result,
+          details: deployment,
         });
       }
 
-      // Persist JWT setting from metadata
       const { edgeFunctionService } =
         await import("../services/edge-function.service");
-      if (typeof metadata.verify_jwt === "boolean") {
-        await edgeFunctionService.updateConfig(params.ref, slug, {
-          verify_jwt: metadata.verify_jwt,
-        });
-      }
-
-      if (Array.isArray(metadata.background_routes)) {
-        await edgeFunctionService.updateConfig(params.ref, slug, {
-          background_routes: metadata.background_routes.filter(
-            (route): route is string =>
-              typeof route === "string" && route.trim().length > 0,
-          ),
-        });
-      }
-
-      const funcConfig = await edgeFunctionService.getConfig(params.ref, slug);
+      const funcConfig = deployment.config ?? await edgeFunctionService.getConfig(params.ref, slug);
       const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
       const now = new Date().toISOString();
       return {
         id: slug,
         slug,
         name: metadata.name || slug,
-        version: Number.parseInt(result.version || String(version), 10) || version,
+        version: Number.parseInt(deployment.version || String(version), 10) || version,
         status: "ACTIVE",
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         entrypoint_path: entrypoint,
-        import_map: result.import_map != null || !!metadata.import_map_path,
-        import_map_path: result.import_map ?? metadata.import_map_path ?? null,
-        bundle_hash: result.bundle_hash ?? null,
-        bundle_size_bytes: result.bundle_size_bytes ?? null,
-        import_count: result.import_count ?? null,
-        external_packages: result.external_packages ?? [],
-        preheat: result.preheat ?? null,
+        import_map: deployment.import_map != null || !!metadata.import_map_path,
+        import_map_path: deployment.import_map ?? metadata.import_map_path ?? null,
+        bundle_hash: deployment.bundle_hash ?? null,
+        bundle_size_bytes: deployment.bundle_size_bytes ?? null,
+        import_count: deployment.import_count ?? null,
+        external_packages: deployment.external_packages ?? [],
+        preheat: deployment.preheat ?? null,
         created_at: now,
         updated_at: now,
       };
@@ -190,32 +192,26 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const slug = body?.slug || (query as Record<string, string>).slug;
       const code = body?.body || body?.code || "";
       const name = body?.name || (query as Record<string, string>).name;
-      const verifyJwt =
-        body?.verify_jwt ??
-        ((query as Record<string, string>).verify_jwt === "false"
-          ? false
-          : true);
-      const backgroundRoutes = Array.isArray(body?.background_routes)
-        ? body.background_routes.filter(
-            (route): route is string =>
-              typeof route === "string" && route.trim().length > 0,
-          )
-        : undefined;
+      const queryVerifyJwt = (query as Record<string, string>).verify_jwt;
+      const verifyJwt = body?.verify_jwt ?? (
+        queryVerifyJwt === undefined ? undefined : queryVerifyJwt !== "false"
+      );
+      const backgroundRoutes = normalizedBackgroundRoutes(body?.background_routes);
 
       if (!slug) {
         return status(400, { message: "slug is required", code: "400" });
       }
       let deployResult:
-        | Awaited<ReturnType<typeof projectService.deployFunctionDetailed>>
+        | Awaited<ReturnType<typeof projectService.deployFunctionRelease>>
         | null = null;
       // Allow empty code for metadata-only creation
       if (code) {
-        deployResult = await projectService.deployFunctionDetailed(
-          params.ref,
+        deployResult = await projectService.deployFunctionRelease({
+          ref: params.ref,
           slug,
           code,
-          false,
-        );
+          config: deploymentConfig(verifyJwt, backgroundRoutes),
+        });
         if (!deployResult.success) {
           return status(500, {
             message: deployResult.error || "Failed to deploy function",
@@ -227,11 +223,12 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
 
       const { edgeFunctionService } =
         await import("../services/edge-function.service");
-      await edgeFunctionService.updateConfig(params.ref, slug, {
-        verify_jwt: verifyJwt,
-        ...(backgroundRoutes ? { background_routes: backgroundRoutes } : {}),
-      });
-      const funcConfig = await edgeFunctionService.getConfig(params.ref, slug);
+      const configPatch = deploymentConfig(verifyJwt, backgroundRoutes);
+      const funcConfig = deployResult?.config ?? (
+        Object.keys(configPatch).length > 0
+          ? await edgeFunctionService.updateConfig(params.ref, slug, configPatch)
+          : await edgeFunctionService.getConfig(params.ref, slug)
+      );
       const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
 
       const now = new Date().toISOString();
@@ -240,7 +237,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         slug,
         name: name || slug,
         version,
-        verify_jwt: verifyJwt,
+        verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         status: "ACTIVE",
         created_at: now,
@@ -296,40 +293,28 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         code?: string;
         name?: string;
         verify_jwt?: boolean;
+        background_routes?: string[];
       }>) {
         const code = fn.body || fn.code || "";
         if (!fn.slug || !code) continue;
 
-        const success = await projectService.deployFunction(
-          params.ref,
-          fn.slug,
+        const deployResult = await projectService.deployFunctionRelease({
+          ref: params.ref,
+          slug: fn.slug,
           code,
-          false,
-        );
-        if (success && typeof fn.verify_jwt === "boolean") {
-          const { edgeFunctionService } =
-            await import("../services/edge-function.service");
-          await edgeFunctionService.updateConfig(params.ref, fn.slug, {
-            verify_jwt: fn.verify_jwt,
-          });
-        }
-
-        if (success && Array.isArray((fn as { background_routes?: unknown[] }).background_routes)) {
-          const { edgeFunctionService } =
-            await import("../services/edge-function.service");
-          await edgeFunctionService.updateConfig(params.ref, fn.slug, {
-            background_routes: ((fn as { background_routes?: unknown[] }).background_routes || []).filter(
-              (route): route is string =>
-                typeof route === "string" && route.trim().length > 0,
-            ),
-          });
-        }
+          config: deploymentConfig(
+            fn.verify_jwt,
+            normalizedBackgroundRoutes(fn.background_routes),
+          ),
+        });
 
         const now = new Date().toISOString();
         results.push({
           slug: fn.slug,
           name: fn.name || fn.slug,
-          success,
+          success: deployResult.success,
+          verify_jwt: deployResult.config?.verify_jwt,
+          background_routes: deployResult.config?.background_routes || [],
           updated_at: now,
         });
       }
@@ -570,28 +555,34 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
       const code = body.code || body.body || "";
-      const result = await projectService.deployFunctionDetailed(
-        params.ref,
-        params.slug,
+      const deployment = await projectService.deployFunctionRelease({
+        ref: params.ref,
+        slug: params.slug,
         code,
-        body.minify ?? false,
-      );
-      if (!result.success) {
+        minify: body.minify ?? false,
+        config: deploymentConfig(
+          body.verify_jwt,
+          normalizedBackgroundRoutes(body.background_routes),
+        ),
+      });
+      if (!deployment.success) {
         return status(500, {
-          message: result.error || "Failed to deploy function",
+          message: deployment.error || "Failed to deploy function",
           code: "500",
-          details: result,
+          details: deployment,
         });
       }
       return {
         success: true,
-        bundled: result.bundled ?? true,
-        version: result.version ?? null,
-        bundle_hash: result.bundle_hash ?? null,
-        bundle_size_bytes: result.bundle_size_bytes ?? null,
-        import_count: result.import_count ?? null,
-        external_packages: result.external_packages ?? [],
-        preheat: result.preheat ?? null,
+        bundled: deployment.bundled ?? true,
+        version: deployment.version ?? null,
+        bundle_hash: deployment.bundle_hash ?? null,
+        bundle_size_bytes: deployment.bundle_size_bytes ?? null,
+        import_count: deployment.import_count ?? null,
+        external_packages: deployment.external_packages ?? [],
+        preheat: deployment.preheat ?? null,
+        verify_jwt: deployment.config?.verify_jwt ?? true,
+        background_routes: deployment.config?.background_routes || [],
       };
     },
     {
@@ -600,6 +591,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         code: t.Optional(t.String()),
         body: t.Optional(t.String()),
         minify: t.Optional(t.Boolean()),
+        verify_jwt: t.Optional(t.Boolean()),
+        background_routes: t.Optional(t.Array(t.String())),
       }),
       detail: { tags: ["frontend"], summary: "Deploy function code by slug" },
     },
@@ -616,15 +609,19 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       // Update code if provided
       const code = body.code || body.body;
       let deployResult:
-        | Awaited<ReturnType<typeof projectService.deployFunctionDetailed>>
+        | Awaited<ReturnType<typeof projectService.deployFunctionRelease>>
         | null = null;
+      const configPatch = deploymentConfig(
+        body.verify_jwt,
+        normalizedBackgroundRoutes(body.background_routes),
+      );
       if (code) {
-        deployResult = await projectService.deployFunctionDetailed(
-          params.ref,
-          params.slug,
+        deployResult = await projectService.deployFunctionRelease({
+          ref: params.ref,
+          slug: params.slug,
           code,
-          false,
-        );
+          config: configPatch,
+        });
         if (!deployResult.success) {
           return status(500, {
             message: deployResult.error || "Failed to deploy function",
@@ -634,26 +631,10 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         }
       }
 
-      // Update config if verify_jwt provided
-      if (typeof body.verify_jwt === "boolean") {
-        await edgeFunctionService.updateConfig(params.ref, params.slug, {
-          verify_jwt: body.verify_jwt,
-        });
-      }
-
-      if (Array.isArray(body.background_routes)) {
-        await edgeFunctionService.updateConfig(params.ref, params.slug, {
-          background_routes: body.background_routes.filter(
-            (route): route is string =>
-              typeof route === "string" && route.trim().length > 0,
-          ),
-        });
-      }
-
-      // Return updated function info
-      const funcConfig = await edgeFunctionService.getConfig(
-        params.ref,
-        params.slug,
+      const funcConfig = deployResult?.config ?? (
+        Object.keys(configPatch).length > 0
+          ? await edgeFunctionService.updateConfig(params.ref, params.slug, configPatch)
+          : await edgeFunctionService.getConfig(params.ref, params.slug)
       );
       const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
       const now = new Date().toISOString();
@@ -692,31 +673,37 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
-      const result = await projectService.deployFunctionBundleDetailed(
-        params.ref,
-        params.slug,
-        body.files,
-        body.entrypoint ?? "index.ts",
-        body.minify ?? false,
-      );
-      if (!result.success) {
+      const deployment = await projectService.deployFunctionRelease({
+        ref: params.ref,
+        slug: params.slug,
+        files: body.files,
+        entrypoint: body.entrypoint ?? "index.ts",
+        minify: body.minify ?? false,
+        config: deploymentConfig(
+          body.verify_jwt,
+          normalizedBackgroundRoutes(body.background_routes),
+        ),
+      });
+      if (!deployment.success) {
         return status(500, {
-          message: result.error || "Failed to deploy function bundle",
+          message: deployment.error || "Failed to deploy function bundle",
           code: "500",
-          details: result,
+          details: deployment,
         });
       }
       return {
         success: true,
         bundled: true,
-        files: result.files ?? Object.keys(body.files).length,
-        version: result.version ?? null,
-        import_map: result.import_map ?? null,
-        bundle_hash: result.bundle_hash ?? null,
-        bundle_size_bytes: result.bundle_size_bytes ?? null,
-        import_count: result.import_count ?? null,
-        external_packages: result.external_packages ?? [],
-        preheat: result.preheat ?? null,
+        files: deployment.files ?? Object.keys(body.files).length,
+        version: deployment.version ?? null,
+        import_map: deployment.import_map ?? null,
+        bundle_hash: deployment.bundle_hash ?? null,
+        bundle_size_bytes: deployment.bundle_size_bytes ?? null,
+        import_count: deployment.import_count ?? null,
+        external_packages: deployment.external_packages ?? [],
+        preheat: deployment.preheat ?? null,
+        verify_jwt: deployment.config?.verify_jwt ?? true,
+        background_routes: deployment.config?.background_routes || [],
       };
     },
     {
@@ -725,6 +712,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         files: t.Record(t.String(), t.String()),
         entrypoint: t.Optional(t.String()),
         minify: t.Optional(t.Boolean()),
+        verify_jwt: t.Optional(t.Boolean()),
+        background_routes: t.Optional(t.Array(t.String())),
       }),
       detail: { tags: ["frontend"], summary: "Deploy function bundle" },
     },

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -8,6 +8,7 @@ import fs from "fs/promises";
 export interface EdgeFunctionConfig {
   verify_jwt: boolean;
   import_map?: string;
+  entrypoint?: string;
   version?: string;
   background_routes?: string[];
 }
@@ -42,8 +43,24 @@ export interface EdgeFunctionDeployResult {
   content_path?: string | null;
   external_packages?: string[];
   preheat?: EdgeFunctionPreheatResult;
+  config?: EdgeFunctionConfig;
   error?: string;
 }
+
+export type EdgeFunctionDeploymentConfig = Pick<
+  Partial<EdgeFunctionConfig>,
+  "verify_jwt" | "background_routes"
+>;
+
+export type EdgeFunctionDeploymentRequest = {
+  ref: string;
+  slug: string;
+  minify?: boolean;
+  config?: EdgeFunctionDeploymentConfig;
+} & (
+  | { code: string; files?: never; entrypoint?: never }
+  | { files: Record<string, string>; entrypoint?: string; code?: never }
+);
 
 export interface EdgeFunctionPreheatPoolResult {
   attempted: number;
@@ -100,6 +117,7 @@ const DEFAULT_FUNCTION_CONFIG: EdgeFunctionConfig = {
 
 const VERSIONED_DIR = ".versions";
 const BUNDLED_SOURCE_RUNTIME_ENTRY = ".supacloud-entry.js";
+const FUNCTION_VERSION_METADATA_FILE = ".supacloud-version.json";
 const SAFE_REF_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
 const SAFE_SLUG_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 const EXTERNAL_PACKAGE_REGEX = /^(?:@[a-zA-Z0-9._-]+\/)?[a-zA-Z0-9._-]+$/;
@@ -141,7 +159,6 @@ type BundleFunctionResult = {
   code: string;
   sizeBytes: number;
   importCount: number;
-  bunArtifactHash: string | null;
   metafile: BuildMetafile | null;
 };
 
@@ -233,10 +250,6 @@ function getVersionedFuncPath(ref: string, slug: string, version: string): strin
   return assertInside(getFuncDir(ref), path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), version, "index.js"));
 }
 
-function getVersionedContentFuncPath(ref: string, slug: string, version: string, hash: string): string {
-  return assertInside(getFuncDir(ref), path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), version, `index.${hash}.js`));
-}
-
 function getSrcPath(ref: string, slug: string): string {
   return assertInside(getFuncDir(ref), path.join(getFuncDir(ref), `${validateSlug(slug)}.src.ts`));
 }
@@ -249,12 +262,75 @@ function getConfigPath(ref: string, slug: string): string {
   return assertInside(getFuncDir(ref), path.join(getFuncDir(ref), `${validateSlug(slug)}.config.json`));
 }
 
+function getVersionRoot(ref: string, slug: string): string {
+  const dir = getFuncDir(ref);
+  return assertInside(dir, path.join(dir, VERSIONED_DIR, validateSlug(slug)));
+}
+
+function getLegacySourceDir(ref: string, slug: string): string {
+  const dir = getFuncDir(ref);
+  return assertInside(dir, path.join(dir, `.src-${validateSlug(slug)}`));
+}
+
+async function frozenLegacyRuntimePath(ref: string, slug: string): Promise<string | null> {
+  const candidates = [
+    path.join(getLegacySourceDir(ref, slug), BUNDLED_SOURCE_RUNTIME_ENTRY),
+    getFuncPath(ref, slug),
+  ];
+  for (const candidate of candidates) {
+    if (await fileExists(candidate)) return candidate;
+  }
+  return null;
+}
+
 async function fileExists(filePath: string): Promise<boolean> {
   try {
     await fs.access(filePath);
     return true;
-  } catch {
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    throw error;
+  }
+}
+
+async function readFunctionConfig(ref: string, slug: string): Promise<EdgeFunctionConfig> {
+  try {
+    const raw = await Bun.file(getConfigPath(ref, slug)).text();
+    return { ...DEFAULT_FUNCTION_CONFIG, ...JSON.parse(raw) };
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return { ...DEFAULT_FUNCTION_CONFIG };
+  }
+}
+
+async function functionConfigExists(ref: string, slug: string): Promise<boolean> {
+  try {
+    await fs.access(getConfigPath(ref, slug));
+    return true;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     return false;
+  }
+}
+
+async function writeFunctionConfigManifest(
+  ref: string,
+  slug: string,
+  functionConfig: EdgeFunctionConfig,
+): Promise<void> {
+  const dir = getFuncDir(ref);
+  const configPath = getConfigPath(ref, slug);
+  const pendingPath = assertInside(
+    dir,
+    path.join(dir, `.${validateSlug(slug)}.config.${crypto.randomUUID()}.tmp`),
+  );
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await Bun.write(pendingPath, JSON.stringify(functionConfig, null, 2));
+    await fs.rename(pendingPath, configPath);
+  } finally {
+    await fs.rm(pendingPath, { force: true }).catch(() => {});
   }
 }
 
@@ -325,7 +401,6 @@ async function bundleFunction(
       code,
       sizeBytes: typeof artifact.size === "number" ? artifact.size : bundleSizeBytes(code),
       importCount: countMetafileImports(metafile) ?? countImports(code),
-      bunArtifactHash: typeof artifact.hash === "string" ? artifact.hash : null,
       metafile,
     };
   } catch (err) {
@@ -414,21 +489,487 @@ function countFileImports(files: Record<string, string>): number {
   return specs.size;
 }
 
-async function writeVersionedBundleArtifacts(
+type PreparedFunctionVersion = {
+  version: string;
+  bundled: boolean;
+  files?: number;
+  entrypoint: string | null;
+  importMap: string | null;
+  bundleHash: string;
+  bundleSizeBytes: number;
+  importCount: number;
+  contentPath: string;
+};
+
+type FunctionVersionMetadata = {
+  version: string;
+  verify_jwt: boolean;
+  background_routes: string[];
+  import_map: string | null;
+  entrypoint: string | null;
+};
+
+type PreparedFunctionRelease = {
+  prepared: PreparedFunctionVersion;
+  config: EdgeFunctionConfig;
+};
+
+type LegacyVersionSnapshotRequest = {
+  ref: string;
+  slug: string;
+  version: string;
+  functionConfig: EdgeFunctionConfig;
+  runtimePath: string;
+};
+
+type CurrentRollbackSnapshotRequest = {
+  ref: string;
+  slug: string;
+  currentConfig: EdgeFunctionConfig;
+  hadManifest: boolean;
+};
+
+async function writePreparedBundle(
+  stageDir: string,
+  finalDir: string,
+  code: string,
+  artifactSizeBytes?: number,
+): Promise<Pick<PreparedFunctionVersion, "bundleHash" | "bundleSizeBytes" | "contentPath">> {
+  const bundleHash = (await sha256Hex(code)).slice(0, 16);
+  const sizeBytes = artifactSizeBytes ?? bundleSizeBytes(code);
+  await Bun.write(path.join(stageDir, "index.js"), code);
+  await Bun.write(path.join(stageDir, `index.${bundleHash}.js`), code);
+  return {
+    bundleHash,
+    bundleSizeBytes: sizeBytes,
+    contentPath: path.join(finalDir, `index.${bundleHash}.js`),
+  };
+}
+
+async function prepareSingleFunctionVersion(
+  request: EdgeFunctionDeploymentRequest & { code: string },
+  version: string,
+  stageDir: string,
+  finalDir: string,
+): Promise<PreparedFunctionVersion> {
+  const validation = validateFunctionCode(request.code);
+  if (!validation.valid) throw new Error(validation.error);
+  await fs.mkdir(stageDir, { recursive: true });
+  const sourcePath = path.join(stageDir, "index.src.ts");
+  const buildDir = path.join(stageDir, ".build");
+  await Bun.write(sourcePath, request.code);
+  const bundle = await bundleFunction(sourcePath, buildDir, "index", request.minify ?? false);
+  const deployedCode = bundle?.code ?? request.code;
+  const artifact = await writePreparedBundle(stageDir, finalDir, deployedCode, bundle?.sizeBytes);
+  await fs.rm(buildDir, { recursive: true, force: true });
+  return {
+    version,
+    bundled: bundle !== null,
+    entrypoint: null,
+    importMap: null,
+    importCount: bundle?.importCount ?? countImports(request.code),
+    ...artifact,
+  };
+}
+
+async function detectedImportMap(sourceDir: string): Promise<string | null> {
+  for (const candidate of ["import_map.json", "import_map", "deno.json", "deno.jsonc"]) {
+    if (await fileExists(resolveInside(sourceDir, candidate))) return candidate;
+  }
+  return null;
+}
+
+function validatedBundleEntrypoint(
+  request: EdgeFunctionDeploymentRequest & { files: Record<string, string> },
+): string {
+  const entrypoint = request.entrypoint ?? "index.ts";
+  if (!request.files[entrypoint]) throw new Error(`Entrypoint '${entrypoint}' not found in file map`);
+  if (Object.hasOwn(request.files, BUNDLED_SOURCE_RUNTIME_ENTRY)) {
+    throw new Error(`Bundle path '${BUNDLED_SOURCE_RUNTIME_ENTRY}' is reserved by the runtime`);
+  }
+  const validation = validateFunctionCode(request.files[entrypoint]);
+  if (!validation.valid) throw new Error(validation.error);
+  return entrypoint;
+}
+
+async function writeBundleSources(
+  sourceDir: string,
+  files: Record<string, string>,
+): Promise<void> {
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = resolveInside(sourceDir, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await Bun.write(filePath, content);
+  }
+}
+
+async function prepareBundleFunctionVersion(
+  request: EdgeFunctionDeploymentRequest & { files: Record<string, string> },
+  version: string,
+  stageDir: string,
+  finalDir: string,
+): Promise<PreparedFunctionVersion> {
+  const entrypoint = validatedBundleEntrypoint(request);
+  const sourceDir = path.join(stageDir, "src");
+  await writeBundleSources(sourceDir, request.files);
+  const importMap = await detectedImportMap(sourceDir);
+  const buildDir = path.join(stageDir, ".build");
+  const bundle = await bundleFunction(
+    resolveInside(sourceDir, entrypoint),
+    buildDir,
+    "index",
+    request.minify ?? false,
+    importMap ? resolveInside(sourceDir, importMap) : undefined,
+  );
+  if (!bundle) throw new Error("Bun.build() failed while bundling the function");
+  await Bun.write(path.join(sourceDir, BUNDLED_SOURCE_RUNTIME_ENTRY), bundle.code);
+  const artifact = await writePreparedBundle(stageDir, finalDir, bundle.code, bundle.sizeBytes);
+  await fs.rm(buildDir, { recursive: true, force: true });
+  return {
+    version,
+    bundled: true,
+    files: Object.keys(request.files).length,
+    entrypoint,
+    importMap,
+    importCount: bundle.importCount ?? countFileImports(request.files),
+    ...artifact,
+  };
+}
+
+function functionVersionMetadata(
+  version: string,
+  functionConfig: EdgeFunctionConfig,
+): FunctionVersionMetadata {
+  if (typeof functionConfig.verify_jwt !== "boolean") {
+    throw new Error("Function version config contains an invalid verify_jwt policy");
+  }
+  const backgroundRoutes = functionConfig.background_routes ?? [];
+  if (!backgroundRoutes.every((route) => typeof route === "string" && route.trim().length > 0)) {
+    throw new Error("Function version config contains invalid background routes");
+  }
+  return {
+    version,
+    verify_jwt: functionConfig.verify_jwt,
+    background_routes: backgroundRoutes,
+    import_map: functionConfig.import_map ?? null,
+    entrypoint: functionConfig.entrypoint ?? null,
+  };
+}
+
+async function writeFunctionVersionMetadata(
+  stageDir: string,
+  metadata: FunctionVersionMetadata,
+): Promise<void> {
+  await Bun.write(
+    path.join(stageDir, FUNCTION_VERSION_METADATA_FILE),
+    JSON.stringify(metadata, null, 2),
+  );
+}
+
+async function replaceFunctionVersionMetadata(
+  versionDir: string,
+  metadata: FunctionVersionMetadata,
+): Promise<void> {
+  const metadataPath = path.join(versionDir, FUNCTION_VERSION_METADATA_FILE);
+  const pendingPath = path.join(
+    versionDir,
+    `.${FUNCTION_VERSION_METADATA_FILE}.${crypto.randomUUID()}.tmp`,
+  );
+  try {
+    await Bun.write(pendingPath, JSON.stringify(metadata, null, 2));
+    await fs.rename(pendingPath, metadataPath);
+  } finally {
+    await fs.rm(pendingPath, { force: true }).catch(() => {});
+  }
+}
+
+function nullableMetadataPath(
+  metadataRecord: Record<string, unknown>,
+  field: "import_map" | "entrypoint",
+): string | null {
+  const metadataPath = metadataRecord[field];
+  if (metadataPath === null) return null;
+  if (typeof metadataPath !== "string" || metadataPath.trim().length === 0) {
+    throw new Error(`Function version metadata contains an invalid ${field}`);
+  }
+  return metadataPath;
+}
+
+async function validateFunctionVersionMetadataPaths(
+  versionDir: string,
+  metadata: FunctionVersionMetadata,
+): Promise<void> {
+  if (metadata.entrypoint === null) {
+    if (metadata.import_map !== null) {
+      throw new Error("Single-file function version metadata cannot define an import map");
+    }
+    return;
+  }
+  const sourceDir = path.join(versionDir, "src");
+  if (!(await fileExists(resolveInside(sourceDir, metadata.entrypoint)))) {
+    throw new Error("Function version metadata references a missing entrypoint");
+  }
+  if (metadata.import_map && !(await fileExists(resolveInside(sourceDir, metadata.import_map)))) {
+    throw new Error("Function version metadata references a missing import map");
+  }
+}
+
+async function readFunctionVersionMetadata(
   ref: string,
   slug: string,
   version: string,
-  code: string,
-  artifactSizeBytes?: number,
-): Promise<{ hash: string; sizeBytes: number; contentPath: string }> {
-  const hash = (await sha256Hex(code)).slice(0, 16);
-  const sizeBytes = typeof artifactSizeBytes === "number" ? artifactSizeBytes : bundleSizeBytes(code);
-  const indexPath = getVersionedFuncPath(ref, slug, version);
-  const contentPath = getVersionedContentFuncPath(ref, slug, version, hash);
-  await fs.mkdir(path.dirname(indexPath), { recursive: true });
-  await Bun.write(indexPath, code);
-  await Bun.write(contentPath, code);
-  return { hash, sizeBytes, contentPath };
+): Promise<FunctionVersionMetadata> {
+  const versionDir = assertInside(getVersionRoot(ref, slug), path.join(getVersionRoot(ref, slug), version));
+  const metadataPath = path.join(versionDir, FUNCTION_VERSION_METADATA_FILE);
+  const metadataRecord = JSON.parse(await Bun.file(metadataPath).text()) as Record<string, unknown>;
+  if (!metadataRecord || typeof metadataRecord !== "object" || Array.isArray(metadataRecord)) {
+    throw new Error("Function version metadata must be an object");
+  }
+  if (metadataRecord.version !== version || typeof metadataRecord.verify_jwt !== "boolean") {
+    throw new Error("Function version metadata does not match the requested version and policy");
+  }
+  if (!Array.isArray(metadataRecord.background_routes)
+    || !metadataRecord.background_routes.every(
+      (route) => typeof route === "string" && route.trim().length > 0,
+    )) {
+    throw new Error("Function version metadata contains invalid background routes");
+  }
+  const metadata: FunctionVersionMetadata = {
+    version,
+    verify_jwt: metadataRecord.verify_jwt,
+    background_routes: metadataRecord.background_routes as string[],
+    import_map: nullableMetadataPath(metadataRecord, "import_map"),
+    entrypoint: nullableMetadataPath(metadataRecord, "entrypoint"),
+  };
+  await validateFunctionVersionMetadataPaths(versionDir, metadata);
+  return metadata;
+}
+
+async function inferredVersionEntrypoint(
+  sourceDir: string,
+  configuredEntrypoint?: string,
+): Promise<string | null> {
+  if (configuredEntrypoint
+    && await fileExists(resolveInside(sourceDir, configuredEntrypoint))) {
+    return configuredEntrypoint;
+  }
+  if (await fileExists(path.join(sourceDir, "index.ts"))) return "index.ts";
+  if (await fileExists(path.join(sourceDir, BUNDLED_SOURCE_RUNTIME_ENTRY))) {
+    return BUNDLED_SOURCE_RUNTIME_ENTRY;
+  }
+  return null;
+}
+
+async function sourceMetadataConfig(
+  functionConfig: EdgeFunctionConfig,
+  version: string,
+  versionDir: string,
+): Promise<EdgeFunctionConfig> {
+  const versionConfig = { ...functionConfig, version };
+  if (await fileExists(path.join(versionDir, "index.src.ts"))) {
+    delete versionConfig.entrypoint;
+    delete versionConfig.import_map;
+    return versionConfig;
+  }
+  const sourceDir = path.join(versionDir, "src");
+  const entrypoint = await inferredVersionEntrypoint(sourceDir, functionConfig.entrypoint);
+  if (entrypoint === null) {
+    delete versionConfig.entrypoint;
+    delete versionConfig.import_map;
+    return versionConfig;
+  }
+  versionConfig.entrypoint = entrypoint;
+  versionConfig.import_map = await detectedImportMap(sourceDir) ?? undefined;
+  return versionConfig;
+}
+
+async function backfillActiveVersionMetadata(
+  ref: string,
+  slug: string,
+  version: string,
+  functionConfig: EdgeFunctionConfig,
+): Promise<void> {
+  const versionDir = assertInside(getVersionRoot(ref, slug), path.join(getVersionRoot(ref, slug), version));
+  let existingMetadata: FunctionVersionMetadata | null = null;
+  try {
+    existingMetadata = await readFunctionVersionMetadata(ref, slug, version);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const sourceConfig = existingMetadata
+    ? restoredFunctionConfig(functionConfig, {
+        ...existingMetadata,
+        verify_jwt: functionConfig.verify_jwt,
+        background_routes: functionConfig.background_routes ?? [],
+      })
+    : await sourceMetadataConfig(functionConfig, version, versionDir);
+  await replaceFunctionVersionMetadata(
+    versionDir,
+    functionVersionMetadata(version, sourceConfig),
+  );
+}
+
+async function snapshotFrozenLegacyVersion(
+  snapshot: LegacyVersionSnapshotRequest,
+): Promise<EdgeFunctionConfig> {
+  const versionRoot = getVersionRoot(snapshot.ref, snapshot.slug);
+  const finalDir = assertInside(versionRoot, path.join(versionRoot, snapshot.version));
+  if (await fileExists(finalDir)) {
+    return completeFrozenLegacyVersionSnapshot(snapshot, finalDir);
+  }
+  const stageDir = assertInside(
+    versionRoot,
+    path.join(versionRoot, `.pending-legacy-${snapshot.version}-${crypto.randomUUID()}`),
+  );
+  await fs.mkdir(stageDir, { recursive: true });
+  try {
+    const runtimeCode = await Bun.file(snapshot.runtimePath).text();
+    await writePreparedBundle(stageDir, finalDir, runtimeCode);
+    await copyFrozenLegacySource(snapshot.ref, snapshot.slug, stageDir);
+    const snapshotConfig = await sourceMetadataConfig(
+      snapshot.functionConfig,
+      snapshot.version,
+      stageDir,
+    );
+    await writeFunctionVersionMetadata(
+      stageDir,
+      functionVersionMetadata(snapshot.version, snapshotConfig),
+    );
+    await fs.rename(stageDir, finalDir);
+    return snapshotConfig;
+  } finally {
+    await fs.rm(stageDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function copyFrozenLegacySource(
+  ref: string,
+  slug: string,
+  targetDir: string,
+): Promise<void> {
+  if (await fileExists(path.join(targetDir, "src"))
+    || await fileExists(path.join(targetDir, "index.src.ts"))) return;
+  const legacySourceDir = getLegacySourceDir(ref, slug);
+  if (await fileExists(legacySourceDir)) {
+    await fs.cp(legacySourceDir, path.join(targetDir, "src"), { recursive: true });
+    return;
+  }
+  const legacySourcePath = getSrcPath(ref, slug);
+  if (await fileExists(legacySourcePath)) {
+    await fs.copyFile(legacySourcePath, path.join(targetDir, "index.src.ts"));
+  }
+}
+
+async function completeFrozenLegacyVersionSnapshot(
+  snapshot: LegacyVersionSnapshotRequest,
+  versionDir: string,
+): Promise<EdgeFunctionConfig> {
+  const pendingDir = assertInside(
+    getVersionRoot(snapshot.ref, snapshot.slug),
+    path.join(
+      getVersionRoot(snapshot.ref, snapshot.slug),
+      `.pending-artifact-${snapshot.version}-${crypto.randomUUID()}`,
+    ),
+  );
+  await fs.mkdir(pendingDir, { recursive: true });
+  try {
+    const runtimeCode = await Bun.file(snapshot.runtimePath).text();
+    const artifact = await writePreparedBundle(pendingDir, versionDir, runtimeCode);
+    await fs.rename(
+      path.join(pendingDir, path.basename(artifact.contentPath)),
+      artifact.contentPath,
+    );
+    await fs.rename(path.join(pendingDir, "index.js"), path.join(versionDir, "index.js"));
+    await copyFrozenLegacySource(snapshot.ref, snapshot.slug, versionDir);
+    const snapshotConfig = await sourceMetadataConfig(
+      snapshot.functionConfig,
+      snapshot.version,
+      versionDir,
+    );
+    await replaceFunctionVersionMetadata(
+      versionDir,
+      functionVersionMetadata(snapshot.version, snapshotConfig),
+    );
+    return snapshotConfig;
+  } finally {
+    await fs.rm(pendingDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function ensureConfiguredRollbackSnapshot(
+  ref: string,
+  slug: string,
+  currentConfig: EdgeFunctionConfig,
+  legacyRuntimePath: string | null,
+): Promise<EdgeFunctionConfig> {
+  const version = currentConfig.version!;
+  if (parseVersionNumber(version) === null) {
+    throw new Error("Function config contains an invalid version");
+  }
+  if (await getVersionedArtifactPath(ref, slug, version)) {
+    await backfillActiveVersionMetadata(ref, slug, version, currentConfig);
+    return currentConfig;
+  }
+  if (!legacyRuntimePath) {
+    throw new Error("Active function version artifact is missing and no frozen legacy alias exists");
+  }
+  return snapshotFrozenLegacyVersion({
+    ref,
+    slug,
+    version,
+    functionConfig: currentConfig,
+    runtimePath: legacyRuntimePath,
+  });
+}
+
+async function ensureLegacyVersionZeroSnapshot(
+  snapshot: CurrentRollbackSnapshotRequest,
+  legacyRuntimePath: string,
+): Promise<EdgeFunctionConfig> {
+  const versionZeroArtifact = await getVersionedArtifactPath(snapshot.ref, snapshot.slug, "0");
+  const versionZeroConfig = versionZeroArtifact
+    ? await sourceMetadataConfig(
+        snapshot.currentConfig,
+        "0",
+        path.join(getVersionRoot(snapshot.ref, snapshot.slug), "0"),
+      )
+    : await snapshotFrozenLegacyVersion({
+        ref: snapshot.ref,
+        slug: snapshot.slug,
+        version: "0",
+        functionConfig: snapshot.currentConfig,
+        runtimePath: legacyRuntimePath,
+      });
+  if (versionZeroArtifact) {
+    await replaceFunctionVersionMetadata(
+      path.join(getVersionRoot(snapshot.ref, snapshot.slug), "0"),
+      functionVersionMetadata("0", versionZeroConfig),
+    );
+  }
+  await commitFunctionActivation({
+    ref: snapshot.ref,
+    slug: snapshot.slug,
+    previousConfig: snapshot.currentConfig,
+    hadManifest: snapshot.hadManifest,
+    nextConfig: versionZeroConfig,
+  });
+  return versionZeroConfig;
+}
+
+async function ensureCurrentRollbackSnapshot(
+  snapshot: CurrentRollbackSnapshotRequest,
+): Promise<EdgeFunctionConfig> {
+  const legacyRuntimePath = await frozenLegacyRuntimePath(snapshot.ref, snapshot.slug);
+  if (snapshot.currentConfig.version) {
+    return ensureConfiguredRollbackSnapshot(
+      snapshot.ref,
+      snapshot.slug,
+      snapshot.currentConfig,
+      legacyRuntimePath,
+    );
+  }
+  if (!legacyRuntimePath) return snapshot.currentConfig;
+  return ensureLegacyVersionZeroSnapshot(snapshot, legacyRuntimePath);
 }
 
 function normalizePreheatPool(value: unknown): EdgeFunctionPreheatPoolResult {
@@ -547,6 +1088,12 @@ function runtimeInvalidationAckError(
   if (body.success !== undefined && body.success !== true) {
     return "Edge Runtime reported invalidation failure";
   }
+  if (body.config_cache_evicted !== true) {
+    return "Edge Runtime did not confirm function config eviction";
+  }
+  if (body.module_scope !== "legacy-base-only" || body.immutable_versions_retained !== true) {
+    return "Edge Runtime returned an unsafe module invalidation scope";
+  }
   if (!isRuntimeInvalidationPoolAck(body.foreground)
     || !isRuntimeInvalidationPoolAck(body.background)) {
     return "Edge Runtime returned an invalid invalidation acknowledgement";
@@ -622,28 +1169,6 @@ function requireRuntimeControl(
   );
 }
 
-async function applyActiveVersionArtifacts(
-  ref: string,
-  slug: string,
-  detail: EdgeFunctionVersionDetail,
-  bundleCode: string,
-): Promise<void> {
-  const dir = getFuncDir(ref);
-  const safeSlug = validateSlug(slug);
-  await fs.mkdir(dir, { recursive: true });
-  await Bun.write(getFuncPath(ref, safeSlug), bundleCode);
-
-  const sourceCode = detail.source_code
-    ?? (detail.has_source ? await readVersionedFunctionSource(ref, slug, detail.version) : null);
-  if (sourceCode != null) await Bun.write(getSrcPath(ref, safeSlug), sourceCode);
-
-  if (detail.has_source_dir && detail.source_dir_path) {
-    const srcDir = assertInside(dir, path.join(dir, `.src-${safeSlug}`));
-    await fs.rm(srcDir, { recursive: true, force: true });
-    await fs.cp(detail.source_dir_path, srcDir, { recursive: true });
-  }
-}
-
 async function readConfiguredFunctionVersion(ref: string, slug: string): Promise<number> {
   try {
     const raw = await Bun.file(getConfigPath(ref, slug)).text();
@@ -692,10 +1217,22 @@ async function readVersionedFunctionCode(ref: string, slug: string, version: str
   return await Bun.file(candidate).text();
 }
 
-async function readVersionedFunctionSource(ref: string, slug: string, version: string): Promise<string | null> {
-  const candidate = getVersionedSrcPath(ref, slug, version);
-  if (!(await fileExists(candidate))) return null;
-  return await Bun.file(candidate).text();
+async function readVersionedFunctionSource(
+  ref: string,
+  slug: string,
+  version: string,
+  entrypoint: string = "index.ts",
+): Promise<string | null> {
+  const versionRoot = path.join(getVersionRoot(ref, slug), version);
+  const candidates = [
+    getVersionedSrcPath(ref, slug, version),
+    resolveInside(path.join(versionRoot, "src"), entrypoint),
+    path.join(versionRoot, "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
+  ];
+  for (const candidate of candidates) {
+    if (await fileExists(candidate)) return Bun.file(candidate).text();
+  }
+  return null;
 }
 
 export async function getVersionedArtifactPath(
@@ -763,6 +1300,36 @@ function parseLegacyVersionedSourceDir(entry: string): { slug: string; version: 
   return { slug: match[1], version: match[2] };
 }
 
+async function directoryEntries(dir: string): Promise<string[]> {
+  try {
+    return await fs.readdir(dir);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+async function removeFunctionArtifacts(ref: string, slug: string): Promise<void> {
+  const dir = getFuncDir(ref);
+  const safeSlug = validateSlug(slug);
+  const entries = await directoryEntries(dir);
+  const legacyArtifacts = entries.filter((entry) =>
+    parseLegacyVersionedFile(entry)?.slug === safeSlug
+    || parseLegacyVersionedSourceDir(entry)?.slug === safeSlug
+  );
+  const exactTargets = [
+    getFuncPath(ref, safeSlug),
+    getSrcPath(ref, safeSlug),
+    getConfigPath(ref, safeSlug),
+    getLegacySourceDir(ref, safeSlug),
+    getVersionRoot(ref, safeSlug),
+    ...legacyArtifacts.map((entry) => resolveInside(dir, entry)),
+  ];
+  await Promise.all(exactTargets.map((target) =>
+    fs.rm(target, { recursive: true, force: true })
+  ));
+}
+
 export async function migrateLegacyVersionArtifacts(): Promise<{ moved: number }> {
   let moved = 0;
   const projectDirs = await fs.readdir(getFunctionsRoot(), { withFileTypes: true }).catch(() => []);
@@ -811,32 +1378,197 @@ export async function migrateLegacyVersionArtifacts(): Promise<{ moved: number }
   return { moved };
 }
 
+async function immutableFunctionVersion(
+  request: EdgeFunctionDeploymentRequest,
+  version: string,
+  currentConfig: EdgeFunctionConfig,
+): Promise<PreparedFunctionRelease> {
+  const versionRoot = getVersionRoot(request.ref, request.slug);
+  const finalDir = assertInside(versionRoot, path.join(versionRoot, version));
+  const stageDir = assertInside(
+    versionRoot,
+    path.join(versionRoot, `.pending-${version}-${crypto.randomUUID()}`),
+  );
+  await fs.mkdir(versionRoot, { recursive: true });
+  try {
+    const prepared = request.code !== undefined
+      ? await prepareSingleFunctionVersion(request, version, stageDir, finalDir)
+      : await prepareBundleFunctionVersion(request, version, stageDir, finalDir);
+    const functionConfig = activatedFunctionConfig(currentConfig, request.config, prepared);
+    await writeFunctionVersionMetadata(
+      stageDir,
+      functionVersionMetadata(version, functionConfig),
+    );
+    await fs.rename(stageDir, finalDir);
+    return { prepared, config: functionConfig };
+  } finally {
+    await fs.rm(stageDir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function activatedFunctionConfig(
+  current: EdgeFunctionConfig,
+  configPatch: EdgeFunctionDeploymentConfig | undefined,
+  prepared: PreparedFunctionVersion,
+): EdgeFunctionConfig {
+  const next = { ...current, ...configPatch, version: prepared.version };
+  if (prepared.importMap === null) delete next.import_map;
+  else next.import_map = prepared.importMap;
+  if (prepared.entrypoint === null) delete next.entrypoint;
+  else next.entrypoint = prepared.entrypoint;
+  return next;
+}
+
+function restoredFunctionConfig(
+  current: EdgeFunctionConfig,
+  metadata: FunctionVersionMetadata,
+): EdgeFunctionConfig {
+  const restored: EdgeFunctionConfig = {
+    ...current,
+    verify_jwt: metadata.verify_jwt,
+    background_routes: metadata.background_routes,
+    version: metadata.version,
+  };
+  if (metadata.import_map === null) delete restored.import_map;
+  else restored.import_map = metadata.import_map;
+  if (metadata.entrypoint === null) delete restored.entrypoint;
+  else restored.entrypoint = metadata.entrypoint;
+  return restored;
+}
+
+type FunctionActivationCommit = {
+  ref: string;
+  slug: string;
+  previousConfig: EdgeFunctionConfig;
+  hadManifest: boolean;
+  nextConfig: EdgeFunctionConfig;
+};
+
+async function restoreFunctionManifest(commit: FunctionActivationCommit): Promise<void> {
+  if (commit.hadManifest) {
+    await writeFunctionConfigManifest(commit.ref, commit.slug, commit.previousConfig);
+  } else {
+    await fs.rm(getConfigPath(commit.ref, commit.slug), { force: true });
+  }
+}
+
+async function commitFunctionActivation(commit: FunctionActivationCommit): Promise<void> {
+  await writeFunctionConfigManifest(commit.ref, commit.slug, commit.nextConfig);
+  const invalidation = await invalidateCache(commit.ref, commit.slug);
+  if (invalidation.ok) return;
+  await restoreFunctionManifest(commit);
+  const rollbackInvalidation = await invalidateCache(commit.ref, commit.slug);
+  if (!rollbackInvalidation.ok) {
+    const status = rollbackInvalidation.status ? `HTTP ${rollbackInvalidation.status}: ` : "";
+    throw new ServiceUnavailableError(
+      "Edge Runtime function activation",
+      `activation manifest was restored but runtime state is uncertain; rollback invalidation failed (${status}${rollbackInvalidation.error || "control request failed"})`,
+    );
+  }
+  requireRuntimeControl(invalidation, "cache invalidation");
+}
+
+function releaseResult(
+  prepared: PreparedFunctionVersion,
+  readiness: EdgeFunctionPreheatResult,
+  functionConfig: EdgeFunctionConfig,
+): EdgeFunctionDeployResult {
+  return {
+    success: true,
+    version: prepared.version,
+    bundled: prepared.bundled,
+    files: prepared.files,
+    import_map: prepared.importMap,
+    bundle_hash: prepared.bundleHash,
+    bundle_size_bytes: prepared.bundleSizeBytes,
+    import_count: prepared.importCount,
+    content_path: prepared.contentPath,
+    external_packages: resolveExternalPackages(),
+    preheat: readiness,
+    config: functionConfig,
+  };
+}
+
+async function deployFunctionRelease(
+  request: EdgeFunctionDeploymentRequest,
+): Promise<EdgeFunctionDeployResult> {
+  let currentConfig = await readFunctionConfig(request.ref, request.slug);
+  const hadManifest = await functionConfigExists(request.ref, request.slug);
+  currentConfig = await ensureCurrentRollbackSnapshot({
+    ref: request.ref,
+    slug: request.slug,
+    currentConfig,
+    hadManifest,
+  });
+  const version = await computeNextFunctionVersion(request.ref, request.slug);
+  const release = await immutableFunctionVersion(request, version, currentConfig);
+  const readiness = await preheatRuntimeFunction(request.ref, request.slug, version);
+  requireRuntimeControl(readiness, "version readiness");
+
+  await commitFunctionActivation({
+    ref: request.ref,
+    slug: request.slug,
+    previousConfig: currentConfig,
+    hadManifest: hadManifest || currentConfig.version === "0",
+    nextConfig: release.config,
+  });
+  recordDeployMetrics(release.prepared.bundleSizeBytes, release.prepared.importCount, readiness);
+  return releaseResult(release.prepared, readiness, release.config);
+}
+
 export const edgeFunctionService = {
   /** Read function config (verify_jwt, etc.) */
   async getConfig(ref: string, slug: string): Promise<EdgeFunctionConfig> {
-    try {
-      const raw = await Bun.file(getConfigPath(ref, slug)).text();
-      return { ...DEFAULT_FUNCTION_CONFIG, ...JSON.parse(raw) };
-    } catch {
-      return { ...DEFAULT_FUNCTION_CONFIG };
-    }
+    return readFunctionConfig(ref, slug);
   },
 
   /** Update function config */
   async updateConfig(
     ref: string,
     slug: string,
-    config: Partial<EdgeFunctionConfig>,
+    configPatch: Partial<EdgeFunctionConfig>,
   ): Promise<EdgeFunctionConfig> {
-    const current = await this.getConfig(ref, slug);
-    const merged = { ...current, ...config };
-    const dir = getFuncDir(ref);
-    await fs.mkdir(dir, { recursive: true });
-    await Bun.write(getConfigPath(ref, slug), JSON.stringify(merged, null, 2));
-    logger.info(
-      `[EdgeFunction] Config updated for ${slug}@${ref}: verify_jwt=${merged.verify_jwt}, background_routes=${(merged.background_routes || []).length}`,
-    );
-    return merged;
+    const releaseLock = await acquireFunctionDeployLock(ref, slug);
+    try {
+      const currentConfig = await readFunctionConfig(ref, slug);
+      const merged = { ...currentConfig, ...configPatch };
+      await commitFunctionActivation({
+        ref,
+        slug,
+        previousConfig: currentConfig,
+        hadManifest: await functionConfigExists(ref, slug),
+        nextConfig: merged,
+      });
+      logger.info(
+        `[EdgeFunction] Config updated for ${slug}@${ref}: verify_jwt=${merged.verify_jwt}, background_routes=${(merged.background_routes || []).length}`,
+      );
+      return merged;
+    } finally {
+      releaseLock();
+    }
+  },
+
+  async deployRelease(request: EdgeFunctionDeploymentRequest): Promise<EdgeFunctionDeployResult> {
+    const releaseLock = await acquireFunctionDeployLock(request.ref, request.slug);
+    try {
+      const deployed = await deployFunctionRelease(request);
+      logger.info(
+        `[EdgeFunction] Deployed ${request.slug} for ${request.ref} (version=${deployed.version}, verify_jwt=${deployed.config?.verify_jwt}, size=${deployed.bundle_size_bytes}, imports=${deployed.import_count})`,
+      );
+      return deployed;
+    } catch (error) {
+      logger.error("[EdgeFunction] Deploy failed", {
+        ref: request.ref,
+        slug: request.slug,
+        error,
+      });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      releaseLock();
+    }
   },
 
   /**
@@ -859,82 +1591,7 @@ export const edgeFunctionService = {
     code: string,
     minify: boolean = false,
   ): Promise<EdgeFunctionDeployResult> {
-    const releaseLock = await acquireFunctionDeployLock(ref, slug);
-    try {
-      const validation = validateFunctionCode(code);
-      if (!validation.valid) {
-        logger.error(`[EdgeFunction] Validation failed: ${validation.error}`, {
-          ref,
-          slug,
-        });
-        return { success: false, error: validation.error };
-      }
-
-      const dir = getFuncDir(ref);
-      const safeSlug = validateSlug(slug);
-      await fs.mkdir(dir, { recursive: true });
-      const version = await computeNextFunctionVersion(ref, safeSlug);
-      await fs.mkdir(path.dirname(getVersionedFuncPath(ref, safeSlug, version)), {
-        recursive: true,
-      });
-
-      // 1. Preserve source for debugging
-      const srcPath = getSrcPath(ref, safeSlug);
-      await Bun.write(srcPath, code);
-      await Bun.write(getVersionedSrcPath(ref, safeSlug, version), code);
-
-      // 2. Bundle with Bun.build()
-      const bundle = await bundleFunction(srcPath, dir, safeSlug, minify);
-      const deployedCode = bundle?.code || code;
-      if (!bundle) {
-        // Fallback: if bundling fails (e.g., missing relative imports),
-        // write the raw code directly as .js so at least simple functions work
-        logger.warn(
-          `[EdgeFunction] Bundle failed, falling back to raw deploy`,
-          { ref, slug },
-        );
-        await Bun.write(getFuncPath(ref, safeSlug), code);
-      } else {
-        await Bun.write(getFuncPath(ref, safeSlug), bundle.code);
-      }
-      const bundleMeta = await writeVersionedBundleArtifacts(ref, safeSlug, version, deployedCode, bundle?.sizeBytes);
-      const importCount = bundle?.importCount ?? countImports(code);
-
-      // 3. Invalidate runtime caches
-      await invalidateCache(ref, slug);
-
-      // 4. Pre-heat the function in the worker pool (zero cold-start)
-      const preheat = await preheatRuntimeFunction(ref, slug);
-      if (!preheat.ok) {
-        logger.warn(`[EdgeFunction] Runtime preheat failed`, { ref, slug, status: preheat.status, error: preheat.error });
-      }
-      recordDeployMetrics(bundleMeta.sizeBytes, importCount, preheat);
-
-      await this.updateConfig(ref, safeSlug, { version });
-
-      logger.info(
-        `[EdgeFunction] Deployed ${slug} for ${ref} (bundled=${!!bundle}, minify=${minify}, version=${version}, size=${bundleMeta.sizeBytes}, imports=${importCount}, bun_hash=${bundle?.bunArtifactHash || "none"}, externals=${resolveExternalPackages().join(",") || "none"}, preheat_ms=${preheat.duration_ms}, preheat=${preheat.succeeded}/${preheat.attempted})`,
-      );
-      return {
-        success: true,
-        bundled: !!bundle,
-        version,
-        bundle_hash: bundleMeta.hash,
-        bundle_size_bytes: bundleMeta.sizeBytes,
-        import_count: importCount,
-        content_path: bundleMeta.contentPath,
-        external_packages: resolveExternalPackages(),
-        preheat,
-      };
-    } catch (err) {
-      logger.error(`[EdgeFunction] Deploy failed`, { ref, slug, error: err });
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : String(err),
-      };
-    } finally {
-      releaseLock();
-    }
+    return this.deployRelease({ ref, slug, code, minify });
   },
 
   /**
@@ -969,149 +1626,7 @@ export const edgeFunctionService = {
     entrypoint: string = "index.ts",
     minify: boolean = false,
   ): Promise<EdgeFunctionDeployResult> {
-    const releaseLock = await acquireFunctionDeployLock(ref, slug);
-    try {
-      if (!files[entrypoint]) {
-        const error = `Entrypoint '${entrypoint}' not found in file map`;
-        logger.error(
-          `[EdgeFunction] ${error}`,
-          { ref, slug },
-        );
-        return { success: false, error };
-      }
-
-      // Validate the entrypoint
-      if (Object.prototype.hasOwnProperty.call(files, BUNDLED_SOURCE_RUNTIME_ENTRY)) {
-        return {
-          success: false,
-          error: `Bundle path '${BUNDLED_SOURCE_RUNTIME_ENTRY}' is reserved by the runtime`,
-        };
-      }
-      const validation = validateFunctionCode(files[entrypoint]);
-      if (!validation.valid) {
-        logger.error(`[EdgeFunction] Validation failed: ${validation.error}`, {
-          ref,
-          slug,
-        });
-        return { success: false, error: validation.error };
-      }
-
-      const dir = getFuncDir(ref);
-      const safeSlug = validateSlug(slug);
-      const version = await computeNextFunctionVersion(ref, safeSlug);
-      // Use a staging subdirectory to write the full file tree
-      const stageDir = assertInside(dir, path.join(dir, `.staging-${safeSlug}`));
-      await fs.rm(stageDir, { recursive: true, force: true }).catch(() => {});
-      await fs.mkdir(stageDir, { recursive: true });
-
-      // 1. Write all files to staging
-      for (const [relPath, content] of Object.entries(files)) {
-        const filePath = resolveInside(stageDir, relPath);
-        await fs.mkdir(path.dirname(filePath), { recursive: true });
-        await Bun.write(filePath, content);
-      }
-
-      // 2. Resolve import_map if present
-      let importMapPath: string | undefined;
-      const importMapCandidates = [
-        "import_map.json",
-        "import_map",
-        "deno.json",
-        "deno.jsonc",
-      ];
-      for (const candidate of importMapCandidates) {
-        const candidatePath = resolveInside(stageDir, candidate);
-        try {
-          await fs.access(candidatePath);
-          importMapPath = candidatePath;
-          break;
-        } catch {
-          /* not found */
-        }
-      }
-
-      // 3. Bundle from entrypoint
-      const entrypointPath = resolveInside(stageDir, entrypoint);
-      const bundle = await bundleFunction(
-        entrypointPath,
-        dir,
-        slug,
-        minify,
-        importMapPath,
-      );
-
-      if (!bundle) {
-        // Cleanup staging on failure
-        await fs.rm(stageDir, { recursive: true, force: true });
-        logger.error(`[EdgeFunction] Bundle deploy failed`, { ref, slug });
-        return {
-          success: false,
-          error:
-            "Bun.build() failed while bundling the function. Check Management API logs for [EdgeFunction] Bun.build() details.",
-        };
-      }
-
-      // 3. Preserve the source tree (rename staging → .src-{slug})
-      const srcDir = assertInside(dir, path.join(dir, `.src-${safeSlug}`));
-      await fs.rm(srcDir, { recursive: true, force: true }).catch(() => {});
-      await fs.rename(stageDir, srcDir);
-      await Bun.write(path.join(srcDir, BUNDLED_SOURCE_RUNTIME_ENTRY), bundle.code);
-      const versionedSrcDir = assertInside(dir, path.join(dir, VERSIONED_DIR, safeSlug, version, "src"));
-      await fs.rm(versionedSrcDir, {
-        recursive: true,
-        force: true,
-      }).catch(() => {});
-      await fs.mkdir(path.dirname(versionedSrcDir), { recursive: true });
-      await fs.cp(srcDir, versionedSrcDir, {
-        recursive: true,
-      });
-      await Bun.write(getFuncPath(ref, slug), bundle.code);
-      const bundleMeta = await writeVersionedBundleArtifacts(ref, slug, version, bundle.code, bundle.sizeBytes);
-      const importCount = bundle.importCount ?? countFileImports(files);
-
-      // 4. Invalidate runtime caches
-      await invalidateCache(ref, slug);
-
-      const preheat = await preheatRuntimeFunction(ref, slug);
-      if (!preheat.ok) {
-        logger.warn(`[EdgeFunction] Runtime preheat failed`, { ref, slug, status: preheat.status, error: preheat.error });
-      }
-      recordDeployMetrics(bundleMeta.sizeBytes, importCount, preheat);
-
-      await this.updateConfig(ref, slug, {
-        version,
-        import_map: importMapPath ? path.basename(importMapPath) : undefined,
-      });
-
-      logger.info(
-        `[EdgeFunction] Bundle deployed ${slug} for ${ref} (${Object.keys(files).length} files, minify=${minify}, version=${version}, size=${bundleMeta.sizeBytes}, imports=${importCount}, bun_hash=${bundle.bunArtifactHash || "none"}, externals=${resolveExternalPackages().join(",") || "none"}, preheat_ms=${preheat.duration_ms}, preheat=${preheat.succeeded}/${preheat.attempted})`,
-      );
-      return {
-        success: true,
-        bundled: true,
-        version,
-        files: Object.keys(files).length,
-        import_map: importMapPath ? path.basename(importMapPath) : null,
-        bundle_hash: bundleMeta.hash,
-        bundle_size_bytes: bundleMeta.sizeBytes,
-        import_count: importCount,
-        content_path: bundleMeta.contentPath,
-        external_packages: resolveExternalPackages(),
-        preheat,
-      };
-    } catch (err) {
-      logger.error(`[EdgeFunction] Bundle deploy failed`, {
-        ref,
-        slug,
-        error: err,
-      });
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : String(err),
-      };
-    } finally {
-      releaseLock();
-    }
+    return this.deployRelease({ ref, slug, files, entrypoint, minify });
   },
 
   async runtimeCheck(
@@ -1221,7 +1736,7 @@ export const edgeFunctionService = {
     try {
       const cfg = await this.getConfig(ref, slug);
       if (cfg.version) {
-        const versioned = await readVersionedFunctionSource(ref, slug, cfg.version);
+        const versioned = await readVersionedFunctionSource(ref, slug, cfg.version, cfg.entrypoint);
         if (versioned !== null) return versioned;
       }
       return await Bun.file(getSrcPath(ref, slug)).text();
@@ -1301,19 +1816,20 @@ export const edgeFunctionService = {
       const detail = await this.getVersion(ref, slug, version);
       if (!detail || !detail.has_bundle) return null;
 
-      const bundleCode = detail.bundle_code ?? (await readVersionedFunctionCode(ref, slug, version));
-      if (bundleCode == null) return null;
-
-      // Validate the inactive artifact before changing any live file or config.
+      const versionMetadata = await readFunctionVersionMetadata(ref, slug, version);
       const readiness = await preheatRuntimeFunction(ref, slug, version);
       requireRuntimeControl(readiness, "version readiness");
 
-      const invalidation = await invalidateCache(ref, slug);
-      requireRuntimeControl(invalidation, "cache invalidation");
-
-      await applyActiveVersionArtifacts(ref, slug, detail, bundleCode);
-
-      const updated = await this.updateConfig(ref, slug, { version });
+      const currentConfig = await readFunctionConfig(ref, slug);
+      const hadManifest = await functionConfigExists(ref, slug);
+      const updated = restoredFunctionConfig(currentConfig, versionMetadata);
+      await commitFunctionActivation({
+        ref,
+        slug,
+        previousConfig: currentConfig,
+        hadManifest,
+        nextConfig: updated,
+      });
       logger.info(`[EdgeFunction] Activated version ${version} for ${slug}@${ref}`);
       return updated;
     } finally {
@@ -1355,52 +1871,11 @@ export const edgeFunctionService = {
 
   /** Delete a function (both bundled and source) */
   async remove(ref: string, slug: string): Promise<boolean> {
+    const releaseLock = await acquireFunctionDeployLock(ref, slug);
     try {
-      // Remove bundled output
-      await fs.unlink(getFuncPath(ref, slug)).catch(() => {});
-      const dir = getFuncDir(ref);
-      const safeSlug = validateSlug(slug);
-      const entries = await fs.readdir(dir).catch(() => []);
-      const versions = await listVersionDirectories(ref, safeSlug);
-      await Promise.all(
-        versions.map((version) =>
-          fs.rm(assertInside(dir, path.join(dir, VERSIONED_DIR, safeSlug, version)), {
-            recursive: true,
-            force: true,
-          }).catch(() => {}),
-        ),
-      );
-      await Promise.all(
-        entries
-          .filter((entry) => entry.startsWith(`${safeSlug}.v`) && (entry.endsWith(".js") || entry.endsWith(".src.ts")))
-          .map((entry) => fs.unlink(resolveInside(dir, entry)).catch(() => {})),
-      );
-      // Remove source file
-      await fs.unlink(getSrcPath(ref, slug)).catch(() => {});
-      // Remove source directory (bundle deploys)
-      await fs
-        .rm(assertInside(dir, path.join(dir, `.src-${safeSlug}`)), {
-          recursive: true,
-          force: true,
-        })
-        .catch(() => {});
-      await Promise.all(
-        entries
-          .filter((entry) => entry.startsWith(`.src-${safeSlug}-v`))
-          .map((entry) =>
-            fs.rm(resolveInside(dir, entry), {
-              recursive: true,
-              force: true,
-            }).catch(() => {}),
-          ),
-      );
-      await fs.rm(assertInside(dir, path.join(dir, VERSIONED_DIR, safeSlug)), {
-        recursive: true,
-        force: true,
-      }).catch(() => {});
-
-      await invalidateCache(ref, slug);
-
+      await removeFunctionArtifacts(ref, slug);
+      const invalidation = await invalidateCache(ref, slug);
+      requireRuntimeControl(invalidation, "function deletion invalidation");
       logger.info(`[EdgeFunction] Deleted ${slug} for ${ref}`);
       return true;
     } catch (err: unknown) {
@@ -1411,6 +1886,8 @@ export const edgeFunctionService = {
         });
       }
       return false;
+    } finally {
+      releaseLock();
     }
   },
 

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -9,6 +9,7 @@ import type { Project, ProjectStatus } from "../db";
 import { resolveBucketName, resolveDbName, resolveRoleName, generateDbName } from "../db";
 import { edgeFunctionService } from "./edge-function.service";
 import { getVersionedArtifactPath } from "./edge-function.service";
+import type { EdgeFunctionDeploymentRequest } from "./edge-function.service";
 import { logger } from "../utils/logger";
 import { config } from "../config";
 import { $ } from "bun";
@@ -859,6 +860,12 @@ export class ProjectService {
     if (!project) return false;
 
     return await edgeFunctionService.deploy(ref, slug, code, minify);
+  }
+
+  async deployFunctionRelease(request: EdgeFunctionDeploymentRequest) {
+    const project = await projectRepository.findByRef(request.ref);
+    if (!project) return { success: false, error: "Project not found" };
+    return edgeFunctionService.deployRelease(request);
   }
 
   async deployFunctionDetailed(

--- a/packages/management-api/tests/unit/edge-function.service.activation.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.activation.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -27,6 +27,9 @@ const successfulPoolAck = {
 function successfulInvalidationAck(ref: string, slug: string) {
   return {
     invalidated: `${ref}_${slug}`,
+    module_scope: "legacy-base-only",
+    immutable_versions_retained: true,
+    config_cache_evicted: true,
     foreground: successfulPoolAck,
     background: successfulPoolAck,
   };
@@ -73,11 +76,8 @@ async function prepareRollback(ref: string, slug: string) {
 
   return {
     config: await edgeFunctionService.getConfig(ref, slug),
-    artifact: await readFile(join(functionsRoot, ref, `${slug}.js`), "utf8"),
-    sourceAsset: await readFile(
-      join(functionsRoot, ref, `.src-${slug}`, "public", "version.txt"),
-      "utf8",
-    ),
+    artifact: await edgeFunctionService.read(ref, slug),
+    source: await edgeFunctionService.readSource(ref, slug),
   };
 }
 
@@ -87,10 +87,8 @@ async function expectRollbackUnchanged(
   before: Awaited<ReturnType<typeof prepareRollback>>,
 ) {
   expect(await edgeFunctionService.getConfig(ref, slug)).toEqual(before.config);
-  expect(await readFile(join(functionsRoot, ref, `${slug}.js`), "utf8")).toBe(before.artifact);
-  expect(
-    await readFile(join(functionsRoot, ref, `.src-${slug}`, "public", "version.txt"), "utf8"),
-  ).toBe(before.sourceAsset);
+  expect(await edgeFunctionService.read(ref, slug)).toBe(before.artifact);
+  expect(await edgeFunctionService.readSource(ref, slug)).toBe(before.source);
 }
 
 afterEach(() => {
@@ -126,6 +124,7 @@ describe("edgeFunctionService version activation readiness", () => {
     globalThis.fetch = sequenceFetch([
       { path: "/preheat/", response: Response.json({ success: true, version: "2" }) },
       { path: "/invalidate/", response: Response.json({ message: "Unauthorized" }, { status: 401 }) },
+      { path: "/invalidate/", response: Response.json(successfulInvalidationAck(ref, slug)) },
     ]);
 
     await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow("HTTP 401");
@@ -194,6 +193,7 @@ describe("edgeFunctionService version activation readiness", () => {
     globalThis.fetch = sequenceFetch([
       { path: "/preheat/", response: Response.json({ success: true, version: "2" }) },
       { path: "/invalidate/", response: Response.json(acknowledgedBody) },
+      { path: "/invalidate/", response: Response.json(successfulInvalidationAck(ref, slug)) },
     ]);
 
     await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow(
@@ -218,10 +218,49 @@ describe("edgeFunctionService version activation readiness", () => {
     const config = await edgeFunctionService.activateVersion(ref, slug, "2");
 
     expect(config?.version).toBe("2");
-    expect(await readFile(join(functionsRoot, ref, `${slug}.js`), "utf8")).toContain("version-two");
-    expect(
-      await readFile(join(functionsRoot, ref, `.src-${slug}`, "public", "version.txt"), "utf8"),
-    ).toBe("version-two");
+    expect(await edgeFunctionService.read(ref, slug)).toContain("version-two");
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("version-two");
     expect(steps).toHaveLength(0);
+  });
+
+  test("restores the target version source metadata and authorization policy", async () => {
+    const ref = "proj_activation_full_metadata";
+    const slug = "metadata-rollback";
+    globalThis.fetch = runtimeSuccessFetch();
+    const versionOne = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      files: {
+        "version-one.ts": "export default { fetch: () => new Response('source-version-one') };",
+        "import_map.json": JSON.stringify({ imports: {} }),
+      },
+      entrypoint: "version-one.ts",
+      config: { verify_jwt: false, background_routes: ["/version-one/*"] },
+    });
+    const versionTwo = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      files: {
+        "version-two.ts": "export default { fetch: () => new Response('source-version-two') };",
+        "deno.json": JSON.stringify({ imports: {} }),
+      },
+      entrypoint: "version-two.ts",
+      config: { verify_jwt: true, background_routes: ["/version-two/*"] },
+    });
+
+    expect(versionOne).toMatchObject({ success: true, version: "1" });
+    expect(versionTwo).toMatchObject({ success: true, version: "2" });
+
+    const restored = await edgeFunctionService.activateVersion(ref, slug, "1");
+
+    expect(restored).toMatchObject({
+      version: "1",
+      verify_jwt: false,
+      background_routes: ["/version-one/*"],
+      entrypoint: "version-one.ts",
+      import_map: "import_map.json",
+    });
+    expect(await edgeFunctionService.getConfig(ref, slug)).toEqual(restored!);
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("source-version-one");
   });
 });

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -19,6 +19,33 @@ process.env.EDGE_RUNTIME_INTERNAL = "127.0.0.1:65535";
 const { edgeFunctionService, getVersionedArtifactPath } = await import(
   "../../src/services/edge-function.service"
 );
+
+const runtimeInvalidationProtocol = {
+  module_scope: "legacy-base-only",
+  immutable_versions_retained: true,
+  config_cache_evicted: true,
+};
+
+function runtimeSuccessFetch(): typeof fetch {
+  return ((input, init) => {
+    const url = String(input);
+    if (url.includes("/invalidate/")) {
+      const segments = new URL(url).pathname.split("/");
+      return Promise.resolve(Response.json({
+        invalidated: `${segments.at(-2)}_${segments.at(-1)}`,
+        ...runtimeInvalidationProtocol,
+        foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
+        background: { attempted: 0, succeeded: 0, invalidated: 0 },
+      }));
+    }
+    const version = new Headers(init?.headers).get("x-supacloud-function-version");
+    return Promise.resolve(Response.json({ success: true, version }));
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  globalThis.fetch = runtimeSuccessFetch();
+});
 
 afterEach(() => {
   process.env.EDGE_FUNCTION_EXTERNAL_PACKAGES = originalExternalPackages ?? "";
@@ -46,6 +73,304 @@ afterAll(async () => {
 });
 
 describe("edgeFunctionService bundle metadata", () => {
+  test("commits verify_jwt=false with the activated version before invalidation", async () => {
+    const ref = "proj_atomic_false";
+    const slug = "public-hook";
+    let configAtInvalidation: unknown;
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+      if (url.includes("/invalidate/")) {
+        configAtInvalidation = await edgeFunctionService.getConfig(ref, slug);
+        return Response.json({
+          invalidated: `${ref}_${slug}`,
+          ...runtimeInvalidationProtocol,
+          foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
+          background: { attempted: 0, succeeded: 0, invalidated: 0 },
+        });
+      }
+      return Response.json({
+        success: true,
+        version: new Headers(init?.headers).get("x-supacloud-function-version"),
+      });
+    }) as typeof fetch;
+
+    const deployed = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('public') };",
+      config: { verify_jwt: false },
+    });
+
+    expect(deployed).toMatchObject({
+      success: true,
+      version: "1",
+      config: { verify_jwt: false, version: "1" },
+    });
+    expect(configAtInvalidation).toMatchObject({ verify_jwt: false, version: "1" });
+  });
+
+  test("preserves an existing false policy when a later deploy omits policy", async () => {
+    const ref = "proj_preserve_false";
+    const slug = "public-hook";
+    await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('v1') };",
+      config: { verify_jwt: false },
+    });
+
+    const deployed = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('v2') };",
+    });
+
+    expect(deployed.config).toMatchObject({ verify_jwt: false, version: "2" });
+    expect(await edgeFunctionService.getConfig(ref, slug)).toMatchObject({
+      verify_jwt: false,
+      version: "2",
+    });
+  });
+
+  test("clears bundle source metadata when a single-file version becomes active", async () => {
+    const ref = "proj_single_metadata";
+    const slug = "metadata-clear";
+    await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      files: {
+        "worker.ts": "export default { fetch: () => new Response('bundle') };",
+        "import_map.json": JSON.stringify({ imports: {} }),
+      },
+      entrypoint: "worker.ts",
+    });
+
+    const singleFile = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('single-file') };",
+    });
+
+    expect(singleFile).toMatchObject({ success: true, version: "2" });
+    expect(Object.hasOwn(singleFile.config!, "entrypoint")).toBe(false);
+    expect(Object.hasOwn(singleFile.config!, "import_map")).toBe(false);
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("single-file");
+  });
+
+  test("defaults a new function policy to verify_jwt=true", async () => {
+    const deployed = await edgeFunctionService.deployRelease({
+      ref: "proj_default_true",
+      slug: "secured",
+      code: "export default { fetch: () => new Response('secured') };",
+    });
+
+    expect(deployed.config).toMatchObject({ verify_jwt: true, version: "1" });
+  });
+
+  test("snapshots frozen legacy aliases before first deploy and restores version zero", async () => {
+    const ref = "proj_legacy_migration";
+    const slug = "legacy-hook";
+    await edgeFunctionService.updateConfig(ref, slug, {
+      verify_jwt: false,
+      background_routes: ["/legacy/*"],
+    });
+    const legacyBundlePath = join(functionsRoot, ref, `${slug}.js`);
+    const legacySourcePath = join(functionsRoot, ref, `${slug}.src.ts`);
+    await Bun.write(legacyBundlePath, "export default { fetch: () => new Response('legacy') };");
+    await Bun.write(legacySourcePath, "export default { fetch: () => new Response('legacy-source') };");
+    const legacyBundleBefore = await readFile(legacyBundlePath, "utf8");
+    const legacySourceBefore = await readFile(legacySourcePath, "utf8");
+
+    const deployed = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('immutable-v1') };",
+    });
+
+    expect(deployed.config).toMatchObject({ verify_jwt: false, version: "1" });
+    expect(await readFile(legacyBundlePath, "utf8")).toBe(legacyBundleBefore);
+    expect(await readFile(legacySourcePath, "utf8")).toBe(legacySourceBefore);
+    expect(await edgeFunctionService.read(ref, slug)).toContain("immutable-v1");
+    expect(await edgeFunctionService.list(ref)).toContain(slug);
+
+    const restored = await edgeFunctionService.activateVersion(ref, slug, "0");
+
+    expect(restored).toMatchObject({
+      version: "0",
+      verify_jwt: false,
+      background_routes: ["/legacy/*"],
+    });
+    expect(Object.hasOwn(restored!, "entrypoint")).toBe(false);
+    expect(Object.hasOwn(restored!, "import_map")).toBe(false);
+    expect(await edgeFunctionService.read(ref, slug)).toContain("legacy");
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("legacy-source");
+  });
+
+  test("repairs a configured version with missing artifacts from frozen aliases", async () => {
+    const ref = "proj_missing_active_artifact";
+    const slug = "missing-active-artifact";
+    const projectDir = join(functionsRoot, ref);
+    const versionDir = join(projectDir, ".versions", slug, "7");
+    const legacyBundlePath = join(projectDir, `${slug}.js`);
+    const legacySourcePath = join(projectDir, `${slug}.src.ts`);
+    const legacyBundle = "export default { fetch: () => new Response('legacy-seven') };";
+    await mkdir(versionDir, { recursive: true });
+    await Promise.all([
+      Bun.write(legacyBundlePath, legacyBundle),
+      Bun.write(legacySourcePath, "export default { fetch: () => new Response('source-seven') };"),
+      Bun.write(join(projectDir, `${slug}.config.json`), JSON.stringify({
+        verify_jwt: false,
+        background_routes: ["/seven/*"],
+        version: "7",
+      })),
+    ]);
+
+    const deployed = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('version-eight') };",
+      config: { verify_jwt: true, background_routes: ["/eight/*"] },
+    });
+
+    expect(deployed).toMatchObject({ success: true, version: "8" });
+    expect(await Bun.file(legacyBundlePath).text()).toBe(legacyBundle);
+    const restored = await edgeFunctionService.activateVersion(ref, slug, "7");
+    expect(restored).toMatchObject({
+      version: "7",
+      verify_jwt: false,
+      background_routes: ["/seven/*"],
+    });
+    expect(await edgeFunctionService.read(ref, slug)).toContain("legacy-seven");
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("source-seven");
+  });
+
+  test("backfills full metadata for an existing active version before deployment", async () => {
+    const ref = "proj_active_metadata_backfill";
+    const slug = "active-metadata-backfill";
+    const projectDir = join(functionsRoot, ref);
+    const versionDir = join(projectDir, ".versions", slug, "3");
+    await mkdir(versionDir, { recursive: true });
+    await Promise.all([
+      Bun.write(
+        join(versionDir, "index.js"),
+        "export default { fetch: () => new Response('runtime-three') };",
+      ),
+      Bun.write(
+        join(versionDir, "index.src.ts"),
+        "export default { fetch: () => new Response('source-three') };",
+      ),
+      Bun.write(join(projectDir, `${slug}.config.json`), JSON.stringify({
+        verify_jwt: false,
+        background_routes: ["/three/*"],
+        version: "3",
+      })),
+    ]);
+
+    const deployed = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('version-four') };",
+      config: { verify_jwt: true, background_routes: ["/four/*"] },
+    });
+
+    expect(deployed).toMatchObject({ success: true, version: "4" });
+    const restored = await edgeFunctionService.activateVersion(ref, slug, "3");
+    expect(restored).toMatchObject({
+      version: "3",
+      verify_jwt: false,
+      background_routes: ["/three/*"],
+    });
+    expect(await edgeFunctionService.read(ref, slug)).toContain("runtime-three");
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("source-three");
+  });
+
+  test("does not replace a corrupted manifest when deploy policy is omitted", async () => {
+    const ref = "proj_corrupt_manifest";
+    const slug = "corrupt-hook";
+    await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('v1') };",
+      config: { verify_jwt: false },
+    });
+    const manifestPath = join(functionsRoot, ref, `${slug}.config.json`);
+    const corruptedManifest = '{"verify_jwt": false';
+    await Bun.write(manifestPath, corruptedManifest);
+
+    const failed = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('v2') };",
+    });
+
+    expect(failed.success).toBe(false);
+    expect(await readFile(manifestPath, "utf8")).toBe(corruptedManifest);
+  });
+
+  test("rolls back config-only updates when runtime invalidation fails", async () => {
+    const ref = "proj_config_rollback";
+    const slug = "config-hook";
+    await edgeFunctionService.updateConfig(ref, slug, { verify_jwt: false });
+    const manifestPath = join(functionsRoot, ref, `${slug}.config.json`);
+    const manifestBefore = await readFile(manifestPath, "utf8");
+    let invalidationCalls = 0;
+    globalThis.fetch = ((input) => {
+      invalidationCalls += 1;
+      if (invalidationCalls === 1) {
+        return Promise.resolve(Response.json({ message: "unavailable" }, { status: 503 }));
+      }
+      const segments = new URL(String(input)).pathname.split("/");
+      return Promise.resolve(Response.json({
+        invalidated: `${segments.at(-2)}_${segments.at(-1)}`,
+        ...runtimeInvalidationProtocol,
+        foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
+        background: { attempted: 0, succeeded: 0, invalidated: 0 },
+      }));
+    }) as typeof fetch;
+
+    await expect(edgeFunctionService.updateConfig(ref, slug, { verify_jwt: true })).rejects.toThrow(
+      "cache invalidation",
+    );
+    expect(await readFile(manifestPath, "utf8")).toBe(manifestBefore);
+    expect(invalidationCalls).toBe(2);
+  });
+
+  test("reports uncertain runtime state when activation and rollback invalidation both fail", async () => {
+    const ref = "proj_manifest_rollback";
+    const slug = "public-hook";
+    await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('v1') };",
+      config: { verify_jwt: false },
+    });
+    const manifestPath = join(functionsRoot, ref, `${slug}.config.json`);
+    const manifestBefore = await readFile(manifestPath, "utf8");
+    let invalidationCalls = 0;
+    globalThis.fetch = ((input, init) => {
+      if (String(input).includes("/preheat/")) {
+        return Promise.resolve(Response.json({
+          success: true,
+          version: new Headers(init?.headers).get("x-supacloud-function-version"),
+        }));
+      }
+      invalidationCalls += 1;
+      return Promise.resolve(Response.json({ message: "unavailable" }, { status: 503 }));
+    }) as typeof fetch;
+
+    const failed = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('v2') };",
+      config: { verify_jwt: true },
+    });
+
+    expect(failed.success).toBe(false);
+    expect(failed.error).toContain("runtime state is uncertain");
+    expect(await readFile(manifestPath, "utf8")).toBe(manifestBefore);
+    expect(invalidationCalls).toBe(2);
+  });
+
   test("allocates after retained history instead of overwriting a rolled-back version", async () => {
     const ref = "proj_rollback_history";
     const slug = "history-safe";
@@ -53,6 +378,7 @@ describe("edgeFunctionService bundle metadata", () => {
       if (String(input).includes("/invalidate/")) {
         return Promise.resolve(Response.json({
           invalidated: `${ref}_${slug}`,
+          ...runtimeInvalidationProtocol,
           foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
           background: { attempted: 0, succeeded: 0, invalidated: 0 },
         }));
@@ -100,12 +426,14 @@ describe("edgeFunctionService bundle metadata", () => {
   test("ignores malformed history directory names", async () => {
     const ref = "proj_bad_history";
     const slug = "bad-history";
+    await edgeFunctionService.deployBundleDetailed(ref, slug, {
+      "index.ts": "export default { fetch: () => new Response('current') };",
+    });
     const versionDir = join(functionsRoot, ref, ".versions", slug);
     await Promise.all([
       mkdir(join(versionDir, "not-a-version"), { recursive: true }),
       mkdir(join(versionDir, "01"), { recursive: true }),
     ]);
-    await edgeFunctionService.updateConfig(ref, slug, { version: "1" });
 
     const result = await edgeFunctionService.deployBundleDetailed(ref, slug, {
       "index.ts": "export default { fetch: () => new Response('next') };",
@@ -167,14 +495,18 @@ describe("edgeFunctionService bundle metadata", () => {
   });
 
   test("keeps multi-file runtime code beside its static assets", async () => {
-    globalThis.fetch = ((input) => Promise.resolve(Response.json(
+    globalThis.fetch = ((input, init) => Promise.resolve(Response.json(
       String(input).includes("/invalidate/")
         ? {
             invalidated: "proj_assets_asset-reader",
+            ...runtimeInvalidationProtocol,
             foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
             background: { attempted: 0, succeeded: 0, invalidated: 0 },
           }
-        : { success: true },
+        : {
+            success: true,
+            version: new Headers(init?.headers).get("x-supacloud-function-version"),
+          },
     ))) as typeof fetch;
 
     const deployResult = await edgeFunctionService.deployBundleDetailed(
@@ -194,12 +526,7 @@ describe("edgeFunctionService bundle metadata", () => {
     );
 
     expect(deployResult.success).toBe(true);
-    const runtimeEntry = join(
-      functionsRoot,
-      "proj_assets",
-      ".src-asset-reader",
-      ".supacloud-entry.js",
-    );
+    const legacyRuntimeEntry = join(functionsRoot, "proj_assets", ".src-asset-reader", ".supacloud-entry.js");
     const versionedRuntimeEntry = join(
       functionsRoot,
       "proj_assets",
@@ -209,11 +536,12 @@ describe("edgeFunctionService bundle metadata", () => {
       "src",
       ".supacloud-entry.js",
     );
-    expect(existsSync(runtimeEntry)).toBe(true);
+    expect(existsSync(legacyRuntimeEntry)).toBe(false);
     expect(existsSync(versionedRuntimeEntry)).toBe(true);
-    const runtimeModule = await import(`${pathToFileURL(runtimeEntry).href}?test=${Date.now()}`);
+    const runtimeModule = await import(`${pathToFileURL(versionedRuntimeEntry).href}?test=${Date.now()}`);
     const runtimeResponse = await runtimeModule.default.fetch(new Request("http://localhost/"));
     expect(await runtimeResponse.text()).toBe("asset-from-source-dir");
+    expect(await edgeFunctionService.readSource("proj_assets", "asset-reader")).toContain("/public/message.txt");
   });
 
   test("rejects a bundle upload that collides with the runtime entry", async () => {
@@ -232,15 +560,60 @@ describe("edgeFunctionService bundle metadata", () => {
     });
   });
 
+  test("deletes only the target manifest and immutable artifacts after runtime ACK", async () => {
+    const ref = "proj_delete_exact";
+    const targetSlug = "delete-target";
+    const siblingSlug = "delete-sibling";
+    await edgeFunctionService.deployDetailed(
+      ref,
+      targetSlug,
+      "export default { fetch: () => new Response('target') };",
+    );
+    await edgeFunctionService.deployDetailed(
+      ref,
+      siblingSlug,
+      "export default { fetch: () => new Response('sibling') };",
+    );
+
+    expect(await edgeFunctionService.remove(ref, targetSlug)).toBe(true);
+    expect(existsSync(join(functionsRoot, ref, `${targetSlug}.config.json`))).toBe(false);
+    expect(existsSync(join(functionsRoot, ref, ".versions", targetSlug))).toBe(false);
+    expect(existsSync(join(functionsRoot, ref, `${siblingSlug}.config.json`))).toBe(true);
+    expect(existsSync(join(functionsRoot, ref, ".versions", siblingSlug))).toBe(true);
+    expect(await edgeFunctionService.getConfig(ref, targetSlug)).toEqual({ verify_jwt: true });
+  });
+
+  test("reports deletion failure when runtime invalidation is not acknowledged", async () => {
+    const ref = "proj_delete_unconfirmed";
+    const slug = "delete-unconfirmed";
+    await edgeFunctionService.deployDetailed(
+      ref,
+      slug,
+      "export default { fetch: () => new Response('delete-me') };",
+    );
+    let invalidationCalls = 0;
+    globalThis.fetch = ((input) => {
+      expect(String(input)).toContain(`/invalidate/${ref}/${slug}`);
+      invalidationCalls += 1;
+      return Promise.resolve(Response.json({ message: "unavailable" }, { status: 503 }));
+    }) as typeof fetch;
+
+    expect(await edgeFunctionService.remove(ref, slug)).toBe(false);
+    expect(invalidationCalls).toBe(1);
+    expect(existsSync(join(functionsRoot, ref, `${slug}.config.json`))).toBe(false);
+    expect(existsSync(join(functionsRoot, ref, ".versions", slug))).toBe(false);
+  });
+
   test("writes content-addressed version artifacts and returns deploy preheat metadata", async () => {
     const metricsBefore = edgeFunctionService.deployMetrics();
     const fetchCalls: string[] = [];
-    globalThis.fetch = ((input: string | URL | Request) => {
+    globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
       const url = String(input);
       fetchCalls.push(url);
       if (url.includes("/preheat/")) {
         return Promise.resolve(Response.json({
           success: true,
+          version: new Headers(init?.headers).get("x-supacloud-function-version"),
           foreground: {
             attempted: 2,
             succeeded: 2,
@@ -259,6 +632,7 @@ describe("edgeFunctionService bundle metadata", () => {
       }
       return Promise.resolve(Response.json({
         invalidated: "proj_meta_hello",
+        ...runtimeInvalidationProtocol,
         foreground: { attempted: 0, succeeded: 0, invalidated: 0 },
         background: { attempted: 0, succeeded: 0, invalidated: 0 },
       }));

--- a/packages/management-api/tests/unit/final-security-regression.test.ts
+++ b/packages/management-api/tests/unit/final-security-regression.test.ts
@@ -154,7 +154,7 @@ describe("final security regressions", () => {
   });
 
   test("function deploy response exposes bundle and preheat metadata", async () => {
-    const deploySpy = spyOn(projectService, "deployFunctionDetailed").mockResolvedValue({
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockResolvedValue({
       success: true,
       version: "3",
       bundled: true,
@@ -170,14 +170,23 @@ describe("final security regressions", () => {
         cache_hits: 1,
         cache_misses: 2,
       },
-    } as Awaited<ReturnType<typeof projectService.deployFunctionDetailed>>);
+      config: {
+        verify_jwt: false,
+        version: "3",
+        background_routes: ["/queue/*"],
+      },
+    } as Awaited<ReturnType<typeof projectService.deployFunctionRelease>>);
     const request = appWith(projectFunctionsRoutes);
 
     try {
       const response = await request("/v1/projects/proj_1/functions/hello", {
         method: "POST",
         headers: { ...masterHeaders, "Content-Type": "application/json" },
-        body: JSON.stringify({ code: "export default { fetch() { return new Response('ok') } }" }),
+        body: JSON.stringify({
+          code: "export default { fetch() { return new Response('ok') } }",
+          verify_jwt: false,
+          background_routes: ["/queue/*"],
+        }),
       });
 
       expect(response.status).toBe(200);
@@ -189,6 +198,8 @@ describe("final security regressions", () => {
         bundle_size_bytes: 4096,
         import_count: 2,
         external_packages: ["left-pad"],
+        verify_jwt: false,
+        background_routes: ["/queue/*"],
         preheat: {
           ok: true,
           attempted: 3,
@@ -197,12 +208,80 @@ describe("final security regressions", () => {
           cache_misses: 2,
         },
       });
-      expect(deploySpy).toHaveBeenCalledWith(
-        "proj_1",
-        "hello",
-        "export default { fetch() { return new Response('ok') } }",
-        false,
-      );
+      expect(deploySpy).toHaveBeenCalledWith({
+        ref: "proj_1",
+        slug: "hello",
+        code: "export default { fetch() { return new Response('ok') } }",
+        minify: false,
+        config: { verify_jwt: false, background_routes: ["/queue/*"] },
+      });
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test("all code deploy routes pass policy through the atomic release primitive", async () => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockImplementation(async (release) => ({
+      success: true,
+      version: "4",
+      bundled: "files" in release,
+      files: "files" in release ? Object.keys(release.files).length : undefined,
+      config: {
+        verify_jwt: release.config?.verify_jwt ?? true,
+        background_routes: release.config?.background_routes ?? [],
+        version: "4",
+      },
+    }));
+    const request = appWith(projectFunctionsRoutes);
+    const jsonHeaders = { ...masterHeaders, "Content-Type": "application/json" };
+
+    try {
+      const bundleResponse = await request("/v1/projects/proj_1/functions/bundle-fn/bundle", {
+        method: "POST",
+        headers: jsonHeaders,
+        body: JSON.stringify({
+          files: { "index.ts": "export default { fetch() { return new Response('bundle') } }" },
+          verify_jwt: false,
+        }),
+      });
+      const patchResponse = await request("/v1/projects/proj_1/functions/patch-fn", {
+        method: "PATCH",
+        headers: jsonHeaders,
+        body: JSON.stringify({
+          code: "export default { fetch() { return new Response('patch') } }",
+          verify_jwt: false,
+        }),
+      });
+      const bulkResponse = await request("/v1/projects/proj_1/functions", {
+        method: "PUT",
+        headers: jsonHeaders,
+        body: JSON.stringify([{
+          slug: "bulk-fn",
+          code: "export default { fetch() { return new Response('bulk') } }",
+          verify_jwt: false,
+        }]),
+      });
+      const multipart = new FormData();
+      multipart.set("metadata", JSON.stringify({ entrypoint_path: "index.ts", verify_jwt: false }));
+      multipart.set("file", new File([
+        "export default { fetch() { return new Response('multipart') } }",
+      ], "index.ts", { type: "application/typescript" }));
+      const multipartResponse = await request("/v1/projects/proj_1/functions/deploy?slug=multipart-fn", {
+        method: "POST",
+        headers: masterHeaders,
+        body: multipart,
+      });
+
+      expect([
+        bundleResponse.status,
+        patchResponse.status,
+        bulkResponse.status,
+        multipartResponse.status,
+      ]).toEqual([200, 200, 200, 200]);
+      expect(deploySpy).toHaveBeenCalledTimes(4);
+      for (const call of deploySpy.mock.calls) {
+        expect(call[0].config).toMatchObject({ verify_jwt: false });
+      }
     } finally {
       deploySpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

- make the per-function manifest the atomic activation point for code version and authorization policy
- preheat immutable version artifacts before activation and require Runtime invalidation acknowledgements with strict rollback
- resolve one activation snapshot per external request so JWT decisions and dispatched code cannot tear
- freeze legacy aliases, backfill version-zero rollback snapshots, and restore full version policy/source metadata
- inline Function policy in Management API and CLI deploy requests, with explicit legacy compatibility reporting
- make config-only updates and Function deletion fail closed

## Verification

- Management focused tests: 45 passed
- Edge Runtime focused tests: 9 passed
- CLI focused tests: 11 passed
- ProjectService comprehensive tests: 34 passed
- Management API, Edge Runtime, and CLI typechecks passed
- git diff --check passed
- independent review: PASS with 0 P0/P1/P2

## Rollout

Deploy Edge Runtime before Management API and CLI. No production deployment is included in this PR.

## Remaining operational validation

- real rolling-upgrade smoke
- multi-instance shared-storage concurrency smoke; the current release lock is process-local