### PR TITLE
fix(edge-runtime): fail closed function activation

### DIFF
--- a/packages/edge-runtime/function-source.test.ts
+++ b/packages/edge-runtime/function-source.test.ts
@@ -22,13 +22,10 @@ describe("multi-file function runtime source", () => {
     ]);
   });
 
-  test("falls back from a configured version only to frozen legacy aliases", () => {
+  test("uses only immutable artifacts for a configured version", () => {
     expect(activeFunctionPathCandidates("/functions/project", "supauth", "7")).toEqual([
       path.join("/functions/project", ".versions", "supauth", "7", "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
       "/functions/project/.versions/supauth/7/index.js",
-      path.join("/functions/project", ".src-supauth", BUNDLED_SOURCE_RUNTIME_ENTRY),
-      "/functions/project/supauth.js",
-      "/functions/project/supauth.ts",
     ]);
   });
 

--- a/packages/edge-runtime/function-source.ts
+++ b/packages/edge-runtime/function-source.ts
@@ -28,9 +28,6 @@ export function activeFunctionPathCandidates(
   activeVersion: string | null,
 ): string[] {
   return activeVersion
-    ? [
-        ...functionPathCandidates(projectRoot, functionName, activeVersion),
-        ...functionPathCandidates(projectRoot, functionName),
-      ]
+    ? functionPathCandidates(projectRoot, functionName, activeVersion)
     : functionPathCandidates(projectRoot, functionName);
 }

--- a/packages/edge-runtime/server-cache.test.ts
+++ b/packages/edge-runtime/server-cache.test.ts
@@ -58,4 +58,37 @@ describe("Edge Runtime auth material invalidation", () => {
     expect(requestHandler).not.toContain("x-supacloud-function-version");
     expect(dispatcher).not.toContain("x-supacloud-function-version");
   });
+
+  test("active versions resolve only immutable artifacts", () => {
+    const resolver = source.slice(
+      source.indexOf("async function resolveFunctionPath("),
+      source.indexOf("function functionDispatchError("),
+    );
+    expect(resolver).toContain(
+      "activeFunctionPathCandidates(projectRoot, functionName, resolvedConfig.version)",
+    );
+  });
+
+  test("background routes envelope function resolution failures", () => {
+    const wildcardRoute = source.slice(
+      source.indexOf('.post("/internal/background/:ref/:functionName/*"'),
+      source.indexOf('.post("/internal/background/:ref/:functionName"'),
+    );
+    const exactRoute = source.slice(
+      source.indexOf('.post("/internal/background/:ref/:functionName"'),
+      source.indexOf('.post("/internal/background/cancel/:taskId"'),
+    );
+
+    for (const route of [wildcardRoute, exactRoute]) {
+      expect(route).toContain("let response: Response;");
+      expect(route).toContain("try {");
+      expect(route).toContain(
+        "resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion)",
+      );
+      expect(route).toContain("catch (error)");
+      expect(route).toContain("functionDispatchError(error, setHeaders)");
+      expect(route).toContain('status: 200');
+      expect(route).toContain('"x-supacloud-background-envelope": "true"');
+    }
+  });
 });

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -831,26 +831,31 @@ const app = new Elysia()
       await loadTenantEnv(c.params.ref),
     );
     const requestedVersion = backgroundDispatch.forwardedRequest.headers.get("x-supacloud-function-version");
-    const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
-    const response = await dispatchFunction(
-      {
-        projectRef: c.params.ref,
-        functionName: c.params.functionName,
-        request: backgroundDispatch.forwardedRequest,
-        setHeaders,
-        activation,
-      },
-      {
-        background: true,
-        backgroundInternalToken: backgroundDispatch.backgroundInternalToken,
-        tenantEnv: backgroundDispatch.tenantEnv,
-        cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
-        onLog: (entry) => {
-          logs.push(entry);
-          if (logs.length > 200) logs.shift();
+    let response: Response;
+    try {
+      const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
+      response = await dispatchFunction(
+        {
+          projectRef: c.params.ref,
+          functionName: c.params.functionName,
+          request: backgroundDispatch.forwardedRequest,
+          setHeaders,
+          activation,
         },
-      },
-    );
+        {
+          background: true,
+          backgroundInternalToken: backgroundDispatch.backgroundInternalToken,
+          tenantEnv: backgroundDispatch.tenantEnv,
+          cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
+          onLog: (entry) => {
+            logs.push(entry);
+            if (logs.length > 200) logs.shift();
+          },
+        },
+      );
+    } catch (error) {
+      response = functionDispatchError(error, setHeaders);
+    }
     const bodyText = await response.text();
     return new Response(
       JSON.stringify({
@@ -887,26 +892,31 @@ const app = new Elysia()
       await loadTenantEnv(c.params.ref),
     );
     const requestedVersion = backgroundDispatch.forwardedRequest.headers.get("x-supacloud-function-version");
-    const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
-    const response = await dispatchFunction(
-      {
-        projectRef: c.params.ref,
-        functionName: c.params.functionName,
-        request: backgroundDispatch.forwardedRequest,
-        setHeaders,
-        activation,
-      },
-      {
-        background: true,
-        backgroundInternalToken: backgroundDispatch.backgroundInternalToken,
-        tenantEnv: backgroundDispatch.tenantEnv,
-        cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
-        onLog: (entry) => {
-          logs.push(entry);
-          if (logs.length > 200) logs.shift();
+    let response: Response;
+    try {
+      const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
+      response = await dispatchFunction(
+        {
+          projectRef: c.params.ref,
+          functionName: c.params.functionName,
+          request: backgroundDispatch.forwardedRequest,
+          setHeaders,
+          activation,
         },
-      },
-    );
+        {
+          background: true,
+          backgroundInternalToken: backgroundDispatch.backgroundInternalToken,
+          tenantEnv: backgroundDispatch.tenantEnv,
+          cancelKey: c.request.headers.get("x-supacloud-task-id") || undefined,
+          onLog: (entry) => {
+            logs.push(entry);
+            if (logs.length > 200) logs.shift();
+          },
+        },
+      );
+    } catch (error) {
+      response = functionDispatchError(error, setHeaders);
+    }
     const bodyText = await response.text();
     return new Response(
       JSON.stringify({


### PR DESCRIPTION
## Summary

- stop active version resolution from falling back to mutable legacy aliases
- preserve the background execution envelope when function activation resolution fails
- add focused regressions for both contracts

## Verification

- `bun test function-source.test.ts server-cache.test.ts`
- `bun run typecheck`
- manual HTTP smoke for both background route variants
- independent review

## Scope

No deployment is included. A separate full-suite worker-retirement stress test still reports a 504 in the worker-pool fixture; it is outside these changed modules and is not remediated in this PR.