### PR TITLE
test(lite): avoid Windows subprocess exit hangs

### DIFF
--- a/packages/supacloud-lite/test/snapshot.test.ts
+++ b/packages/supacloud-lite/test/snapshot.test.ts
@@ -8,6 +8,8 @@ import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
 import { createSymlinkIfPermitted } from './support/symlink.js'
 
 const temporaryDirectories: string[] = []
+const WINDOWS_CLI_TIMEOUT_MS = 20_000
+const WINDOWS_CLI_MAX_BUFFER_BYTES = 8 * 1024 * 1024
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
@@ -201,13 +203,8 @@ async function temporaryProject(prefix: string): Promise<string> {
 }
 
 async function runCli(args: string[]): Promise<string> {
-  const processHandle = Bun.spawn({
-    cmd: [process.execPath, 'run', join(import.meta.dir, '..', 'src', 'cli.ts'), ...args],
-    cwd: join(import.meta.dir, '..'),
-    stdout: 'pipe',
-    stderr: 'pipe',
-    env: process.env,
-  })
+  if (process.platform === 'win32') return runWindowsCli(args)
+  const processHandle = Bun.spawn(cliSpawnOptions(args))
   return await withWindowsSubprocessRef(async () => {
     const [exitCode, stdout, stderr] = await Promise.all([
       processHandle.exited,
@@ -217,4 +214,30 @@ async function runCli(args: string[]): Promise<string> {
     if (exitCode !== 0) throw new Error(`CLI failed (${exitCode}): ${stderr || stdout}`)
     return stdout
   })
+}
+
+function runWindowsCli(args: string[]): string {
+  const completed = Bun.spawnSync({
+    ...cliSpawnOptions(args),
+    timeout: WINDOWS_CLI_TIMEOUT_MS,
+    maxBuffer: WINDOWS_CLI_MAX_BUFFER_BYTES,
+  })
+  const stdout = completed.stdout.toString('utf8')
+  const stderr = completed.stderr.toString('utf8')
+  if (completed.exitedDueToTimeout) {
+    throw new Error(`CLI timed out after ${WINDOWS_CLI_TIMEOUT_MS}ms: ${stderr || stdout}`)
+  }
+  if (completed.exitedDueToMaxBuffer) throw new Error(`CLI output exceeded ${WINDOWS_CLI_MAX_BUFFER_BYTES} bytes`)
+  if (!completed.success) throw new Error(`CLI failed (${completed.exitCode}): ${stderr || stdout}`)
+  return stdout
+}
+
+function cliSpawnOptions(args: string[]) {
+  return {
+    cmd: [process.execPath, 'run', join(import.meta.dir, '..', 'src', 'cli.ts'), ...args],
+    cwd: join(import.meta.dir, '..'),
+    stdout: 'pipe' as const,
+    stderr: 'pipe' as const,
+    env: process.env,
+  }
 }


### PR DESCRIPTION
## Summary

- use `Bun.spawnSync` for short-lived snapshot CLI commands on Windows
- bound each Windows invocation with a 20 second timeout and an 8 MiB output buffer
- preserve the asynchronous subprocess path on non-Windows platforms
- report timeout, max-buffer, and non-zero exit failures separately

## Context

Bun 1.3.14 can intermittently stop polling Windows IOCP while a subprocess exit notification is pending. The affected snapshot tests had already consumed stdout/stderr (including output above 64 KiB) but could still hang on `.exited` until the outer 60 second test timeout killed the child.

This change is limited to the test harness and does not change SupaCloud Lite production runtime behavior. It preserves the second status invocation, lock-release assertion, large-output assertion, PGlite cleanup, and the outer test timeout.

## Verification

- `bun test --timeout 20000 test/snapshot.test.ts` (6 pass)
- `bun test --timeout 20000 test/cli-shutdown.test.ts` (5 pass)
- `bun run typecheck`
- full `bun run check` (90 pass, including build/package/standalone smoke)
- `git diff --check`
- independent review: P0/P1/P2 = 0

Windows CI on Bun 1.3.14 is the merge gate.