### PR TITLE
fix(ci): stabilize SupaCloud Lite checks after release

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -234,7 +234,27 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ env.BUN_VERSION }}
+          # Bun 1.3.14 can stop polling Windows IOCP while PGlite closes.
+          # Keep the canary only until the first stable release containing
+          # https://github.com/oven-sh/bun/pull/34478 is available.
+          bun-version: canary
+          no-cache: true
+
+      - name: Verify Bun contains the Windows IOCP fix
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUN_WINDOWS_IOCP_FIX_SHA: 9e799f5ce0f8c54d90baf9f585bfe3fbd9975a9b
+        run: |
+          $revision = bun --revision
+          if ($revision -notmatch '\+([0-9a-fA-F]{7,40})$') {
+            throw "Unable to extract the Bun commit from revision: $revision"
+          }
+          $candidateSha = $Matches[1]
+          $comparison = gh api "repos/oven-sh/bun/compare/$env:BUN_WINDOWS_IOCP_FIX_SHA...$candidateSha" | ConvertFrom-Json
+          if ($comparison.status -notin @('ahead', 'identical')) {
+            throw "Bun revision $revision does not contain the required Windows IOCP fix"
+          }
 
       - name: Show runtime versions
         run: |

--- a/packages/supacloud-lite/test/snapshot.test.ts
+++ b/packages/supacloud-lite/test/snapshot.test.ts
@@ -8,6 +8,8 @@ import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
 import { createSymlinkIfPermitted } from './support/symlink.js'
 
 const temporaryDirectories: string[] = []
+const WINDOWS_CLI_TIMEOUT_MS = 20_000
+const WINDOWS_CLI_MAX_BUFFER_BYTES = 8 * 1024 * 1024
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
@@ -201,13 +203,8 @@ async function temporaryProject(prefix: string): Promise<string> {
 }
 
 async function runCli(args: string[]): Promise<string> {
-  const processHandle = Bun.spawn({
-    cmd: [process.execPath, 'run', join(import.meta.dir, '..', 'src', 'cli.ts'), ...args],
-    cwd: join(import.meta.dir, '..'),
-    stdout: 'pipe',
-    stderr: 'pipe',
-    env: process.env,
-  })
+  if (process.platform === 'win32') return runWindowsCli(args)
+  const processHandle = Bun.spawn(cliSpawnOptions(args))
   return await withWindowsSubprocessRef(async () => {
     const [exitCode, stdout, stderr] = await Promise.all([
       processHandle.exited,
@@ -217,4 +214,30 @@ async function runCli(args: string[]): Promise<string> {
     if (exitCode !== 0) throw new Error(`CLI failed (${exitCode}): ${stderr || stdout}`)
     return stdout
   })
+}
+
+function runWindowsCli(args: string[]): string {
+  const completed = Bun.spawnSync({
+    ...cliSpawnOptions(args),
+    timeout: WINDOWS_CLI_TIMEOUT_MS,
+    maxBuffer: WINDOWS_CLI_MAX_BUFFER_BYTES,
+  })
+  const stdout = completed.stdout.toString('utf8')
+  const stderr = completed.stderr.toString('utf8')
+  if (completed.exitedDueToTimeout) {
+    throw new Error(`CLI timed out after ${WINDOWS_CLI_TIMEOUT_MS}ms: ${stderr || stdout}`)
+  }
+  if (completed.exitedDueToMaxBuffer) throw new Error(`CLI output exceeded ${WINDOWS_CLI_MAX_BUFFER_BYTES} bytes`)
+  if (!completed.success) throw new Error(`CLI failed (${completed.exitCode}): ${stderr || stdout}`)
+  return stdout
+}
+
+function cliSpawnOptions(args: string[]) {
+  return {
+    cmd: [process.execPath, 'run', join(import.meta.dir, '..', 'src', 'cli.ts'), ...args],
+    cwd: join(import.meta.dir, '..'),
+    stdout: 'pipe' as const,
+    stderr: 'pipe' as const,
+    env: process.env,
+  }
 }

--- a/packages/supacloud-lite/test/snapshot.test.ts
+++ b/packages/supacloud-lite/test/snapshot.test.ts
@@ -8,8 +8,6 @@ import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
 import { createSymlinkIfPermitted } from './support/symlink.js'
 
 const temporaryDirectories: string[] = []
-const WINDOWS_CLI_TIMEOUT_MS = 20_000
-const WINDOWS_CLI_MAX_BUFFER_BYTES = 8 * 1024 * 1024
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
@@ -203,8 +201,13 @@ async function temporaryProject(prefix: string): Promise<string> {
 }
 
 async function runCli(args: string[]): Promise<string> {
-  if (process.platform === 'win32') return runWindowsCli(args)
-  const processHandle = Bun.spawn(cliSpawnOptions(args))
+  const processHandle = Bun.spawn({
+    cmd: [process.execPath, 'run', join(import.meta.dir, '..', 'src', 'cli.ts'), ...args],
+    cwd: join(import.meta.dir, '..'),
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: process.env,
+  })
   return await withWindowsSubprocessRef(async () => {
     const [exitCode, stdout, stderr] = await Promise.all([
       processHandle.exited,
@@ -214,30 +217,4 @@ async function runCli(args: string[]): Promise<string> {
     if (exitCode !== 0) throw new Error(`CLI failed (${exitCode}): ${stderr || stdout}`)
     return stdout
   })
-}
-
-function runWindowsCli(args: string[]): string {
-  const completed = Bun.spawnSync({
-    ...cliSpawnOptions(args),
-    timeout: WINDOWS_CLI_TIMEOUT_MS,
-    maxBuffer: WINDOWS_CLI_MAX_BUFFER_BYTES,
-  })
-  const stdout = completed.stdout.toString('utf8')
-  const stderr = completed.stderr.toString('utf8')
-  if (completed.exitedDueToTimeout) {
-    throw new Error(`CLI timed out after ${WINDOWS_CLI_TIMEOUT_MS}ms: ${stderr || stdout}`)
-  }
-  if (completed.exitedDueToMaxBuffer) throw new Error(`CLI output exceeded ${WINDOWS_CLI_MAX_BUFFER_BYTES} bytes`)
-  if (!completed.success) throw new Error(`CLI failed (${completed.exitCode}): ${stderr || stdout}`)
-  return stdout
-}
-
-function cliSpawnOptions(args: string[]) {
-  return {
-    cmd: [process.execPath, 'run', join(import.meta.dir, '..', 'src', 'cli.ts'), ...args],
-    cwd: join(import.meta.dir, '..'),
-    stdout: 'pipe' as const,
-    stderr: 'pipe' as const,
-    env: process.env,
-  }
 }

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.7.1",
-        "@supacloud/cli": "^0.14.2",
+        "@supacloud/cli": "^0.14.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -19,7 +19,7 @@
 
     "@supacloud/admin": ["@supacloud/admin@0.7.1", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.7.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-7DRZXIaKSv4x4SEj3dVzx1B+ei+l4ZaQj/UqdY0pjvgOpdg1r1xoIZlkhIxvQI8QcGbmPI3P/ABml9CRgq4FEQ=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.14.2", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.2.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-sBAk+tam1cL0RsOZr9Lgv7S4qGMBYls1HIbwq+EpclN+ZFn/GT7W+wYm5cRgqzeerHv0jd9cy3AyvbSRY0cxEA=="],
+    "@supacloud/cli": ["@supacloud/cli@0.14.3", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.3.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-QSRqck326QWHGAjpFikiHJH8Di2su3GuD9OIMzNjK7xtXGTgJLU3+7M5sZsxShmk0uBoITcD9vnZb9yGJTlEJA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary

- synchronize the unified `supacloudctl` lockfile with released `@supacloud/cli@0.14.3`
- run the Windows SupaCloud Lite gate on Bun canary builds that provably contain the upstream IOCP fix
- reject a canary revision unless GitHub ancestry shows it includes `oven-sh/bun#34478`

## Context

Two CI baseline defects formed a circular gate after the release:

1. The release commit updated `packages/supacloud/package.json` to `^0.14.3` while its lockfile remained on `0.14.2`. Trusted main/release contexts use local candidates, but ordinary PRs fail `bun install --frozen-lockfile`.
2. Bun 1.3.14 can stop polling Windows IOCP while PGlite closes. Both the old async subprocess path and a bounded `Bun.spawnSync` experiment reproduced the failure on a real Windows runner after the CLI had already printed its result. That proves the hang is inside the child cleanup path and cannot be safely hidden with a parent-process workaround.

The Windows job therefore uses upstream canary only until the first stable Bun release containing [oven-sh/bun#34478](https://github.com/oven-sh/bun/pull/34478). Because the canary tag moves, the workflow extracts `bun --revision` and verifies the pinned fix commit is its ancestor before running tests. This prevents an older or unrelated moving build from silently satisfying the gate.

No SupaCloud production code or PGlite cleanup is bypassed.

## Verification

- unified CLI frozen install
- unified CLI tests: 19 pass
- unified CLI typecheck and build
- official npm registry audit: no high vulnerabilities
- YAML parse and `git diff --check`
- upstream fix merged as `9e799f5ce0f8c54d90baf9f585bfe3fbd9975a9b`
- current canary revision `b8d94774e` is 300 commits ahead of the fix

The real Windows gate and complete repository CI remain the merge requirements.