### PR TITLE
fix(backup): use configured postgres target

### DIFF
--- a/packages/management-api/src/services/backup.service.ts
+++ b/packages/management-api/src/services/backup.service.ts
@@ -6,6 +6,7 @@ import { logger } from "../utils/logger";
 import type { BackupInfo, RestoreRequest } from '../types/backup';
 import { projectRepository } from '../repositories/project.repository';
 import { resolveDbName, resolveRoleName } from '../db';
+import { config } from "../config";
 
 const PGBACKREST_NAME_PATTERN = /^[A-Za-z0-9_.-]{1,128}$/;
 const BACKUP_USER_PATTERN = /^[a-z_][a-z0-9_-]{0,31}$/;
@@ -367,6 +368,24 @@ export async function restore(request: RestoreRequest): Promise<{ message: strin
 const LOGICAL_BACKUP_DIR = process.env.SUPACLOUD_LOGICAL_BACKUP_DIR || "/tmp/supacloud-backups";
 const LOGICAL_BACKUP_FILE_PATTERN = /^backup_[A-Za-z0-9_-]{1,64}_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.sql\.gz$/;
 
+async function runLogicalDatabaseCommand(
+  command: "pg_dump" | "pg_restore",
+  commandArguments: string[],
+  password: string,
+): Promise<void> {
+  const databaseProcess = Bun.spawn({
+    cmd: [command, "-h", config.pgHost, "-p", String(config.pgPort), ...commandArguments],
+    env: { ...process.env, PGPASSWORD: password },
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [exitCode] = await Promise.all([
+    databaseProcess.exited,
+    new Response(databaseProcess.stderr).text(),
+  ]);
+  if (exitCode !== 0) throw new Error(`${command} exited with code ${exitCode}`);
+}
+
 async function ensureLogicalBackupDir(): Promise<string> {
         const baseDir = resolve(LOGICAL_BACKUP_DIR);
         await mkdir(baseDir, { recursive: true, mode: 0o700 });
@@ -399,12 +418,17 @@ export async function createLogicalBackup(projectRef: string): Promise<{ success
 
         try {
             // Use tenant role, export as Custom archive format with default gzip compression
-            const tenantHost = `localhost:5432`;
             const tenantDb = await resolveDbName(projectRef);
             const tenantUser = resolveRoleName(projectRef);
 
             logger.info(`[LogicalBackup] Starting dump for ${projectRef} -> ${backupPath}`);
-            await $`PGPASSWORD=${project.db_password} pg_dump -h localhost -p 5432 -U ${tenantUser} -d ${tenantDb} -F c -Z 6 -f ${backupPath}`.quiet();
+            await runLogicalDatabaseCommand("pg_dump", [
+                "-U", tenantUser,
+                "-d", tenantDb,
+                "-F", "c",
+                "-Z", "6",
+                "-f", backupPath,
+            ], project.db_password);
 
             // Try to upload to tenant's hidden backup prefix via AWS CLI (MinIO/Garage compatible)
             if (project.s3_access_key && project.s3_secret_key) {
@@ -460,7 +484,13 @@ export async function restoreLogicalBackup(projectRef: string, backupId: string)
             const tenantUser = resolveRoleName(projectRef);
             logger.info(`[LogicalBackup] Starting restore for ${projectRef} from ${backupPath}`);
 
-            await $`PGPASSWORD=${project.db_password} pg_restore -h localhost -p 5432 -U ${tenantUser} -d ${tenantDb} -c -1 ${backupPath}`.quiet();
+            await runLogicalDatabaseCommand("pg_restore", [
+                "-U", tenantUser,
+                "-d", tenantDb,
+                "-c",
+                "-1",
+                backupPath,
+            ], project.db_password);
 
             logger.info(`[LogicalBackup] Restore complete for ${projectRef}`);
             return { success: true, message: "Logical restore completed successfully" };

--- a/packages/management-api/tests/unit/logical-backup.service.test.ts
+++ b/packages/management-api/tests/unit/logical-backup.service.test.ts
@@ -1,0 +1,111 @@
+// @supacloud-test-isolate — mocks tenant lookup and database subprocesses.
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+interface SpawnInvocation {
+  cmd: string[];
+  env?: Record<string, string | undefined>;
+}
+
+const projectPassword = "tenant-secret";
+const findByRef = mock(async () => ({
+  ref: "project-a",
+  db_password: projectPassword,
+  s3_access_key: null,
+  s3_secret_key: null,
+}));
+const resolveDbName = mock(async () => "tenant_database");
+const resolveRoleName = mock(() => "tenant_role");
+const logicalBackupDirectory = await mkdtemp(join(tmpdir(), "supacloud-logical-backup-test-"));
+const previousLogicalBackupDirectory = process.env.SUPACLOUD_LOGICAL_BACKUP_DIR;
+process.env.SUPACLOUD_LOGICAL_BACKUP_DIR = logicalBackupDirectory;
+
+mock.module("../../src/repositories/project.repository", () => ({
+  projectRepository: { findByRef },
+}));
+mock.module("../../src/db", () => ({ resolveDbName, resolveRoleName }));
+mock.module("../../src/config", () => ({
+  config: { pgHost: "database.internal", pgPort: 6432 },
+}));
+mock.module("../../src/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { createLogicalBackup, restoreLogicalBackup } = await import(
+  new URL("../../src/services/backup.service.ts?logical-backup-service-test", import.meta.url).href,
+);
+
+const spawnInvocations: SpawnInvocation[] = [];
+let databaseProcessExitCode = 0;
+const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((options: SpawnInvocation) => {
+  spawnInvocations.push(options);
+  return {
+    exited: Promise.resolve(databaseProcessExitCode),
+    stderr: new Blob([]).stream(),
+  } as never;
+}) as typeof Bun.spawn);
+
+describe("logical backup database endpoint", () => {
+  beforeEach(() => {
+    databaseProcessExitCode = 0;
+    spawnInvocations.length = 0;
+    findByRef.mockClear();
+    resolveDbName.mockClear();
+    resolveRoleName.mockClear();
+  });
+
+  afterAll(async () => {
+    spawnSpy.mockRestore();
+    await rm(logicalBackupDirectory, { recursive: true, force: true });
+    if (previousLogicalBackupDirectory === undefined) delete process.env.SUPACLOUD_LOGICAL_BACKUP_DIR;
+    else process.env.SUPACLOUD_LOGICAL_BACKUP_DIR = previousLogicalBackupDirectory;
+  });
+
+  test("uses the configured PostgreSQL endpoint for dump and restore", async () => {
+    const backup = await createLogicalBackup("project-a");
+    expect(backup.success).toBe(true);
+
+    const backupId = "backup_project-a_2026-08-04T00-00-00-000Z.sql.gz";
+    await writeFile(join(logicalBackupDirectory, backupId), "archive");
+    await expect(restoreLogicalBackup("project-a", backupId)).resolves.toMatchObject({ success: true });
+
+    expect(spawnInvocations.map(({ cmd }) => cmd.slice(0, 5))).toEqual([
+      ["pg_dump", "-h", "database.internal", "-p", "6432"],
+      ["pg_restore", "-h", "database.internal", "-p", "6432"],
+    ]);
+    expect(spawnInvocations[0]?.cmd).toEqual(expect.arrayContaining([
+      "-U", "tenant_role", "-d", "tenant_database", "-F", "c", "-Z", "6", "-f",
+    ]));
+    expect(spawnInvocations[1]?.cmd).toEqual(expect.arrayContaining([
+      "-U", "tenant_role", "-d", "tenant_database", "-c", "-1",
+    ]));
+    expect(spawnInvocations.every(({ env }) => env?.PGPASSWORD === projectPassword)).toBe(true);
+    expect(JSON.stringify(spawnInvocations.map(({ cmd }) => cmd))).not.toContain(projectPassword);
+  });
+
+  test("does not report a failed database subprocess as a successful backup", async () => {
+    databaseProcessExitCode = 9;
+
+    await expect(createLogicalBackup("project-a")).resolves.toMatchObject({
+      success: false,
+      message: expect.stringContaining("pg_dump exited with code 9"),
+    });
+  });
+
+  test("does not report a failed database subprocess as a successful restore", async () => {
+    const backupId = "backup_project-a_2026-08-04T00-00-00-001Z.sql.gz";
+    await writeFile(join(logicalBackupDirectory, backupId), "archive");
+    databaseProcessExitCode = 8;
+
+    await expect(restoreLogicalBackup("project-a", backupId)).resolves.toMatchObject({
+      success: false,
+      message: expect.stringContaining("pg_restore exited with code 8"),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- use the configured PostgreSQL host and port for logical backup and restore
- execute pg_dump and pg_restore with discrete argv while keeping PGPASSWORD only in the child environment
- add public-entry regression coverage for both commands and fail-closed subprocess behavior

## Validation

- bun test tests/unit/backup.service.test.ts tests/unit/logical-backup.service.test.ts (21 pass, 0 fail)
- bun run typecheck
- bun run test:local (SQL sync, complete unit suite, 39 integration tests; 0 fail)
- git diff --check

## Scope

- Management API logical backup/restore only
- no S3, pgBackRest, physical backup, FA, menu, route, or navigation changes