### PR TITLE
fix(lite): actionable hint when storage upload is denied by RLS

### DIFF
--- a/packages/supacloud-lite/src/runtime/storage/handler.ts
+++ b/packages/supacloud-lite/src/runtime/storage/handler.ts
@@ -74,6 +74,36 @@ function storageError(status: number, error: string, message: string): Response 
   return json(status, { statusCode: String(status), error, message })
 }
 
+/**
+ * Raised when an object write is denied by storage.objects RLS. Callers map
+ * this to a 403 with an actionable hint, because the raw Postgres message
+ * ("new row violates row-level security policy") does not tell the developer
+ * that their project is missing a storage.objects policy.
+ */
+const RLS_POLICY_HINT =
+  'Upload denied by storage.objects RLS. Create a policy in supabase/migrations, e.g. ' +
+  '`create policy "objects insert" on storage.objects for insert to authenticated with check (bucket_id = \'<bucket>\');`. ' +
+  'Without a policy, RLS blocks every write by default.'
+
+class RlsPolicyError extends Error {
+  constructor(public cause: unknown) {
+    super('storage.objects row-level security policy denied the write')
+    this.name = 'RlsPolicyError'
+  }
+}
+
+function rlsDeniedResponse(): Response {
+  return storageError(403, 'Unauthorized', RLS_POLICY_HINT)
+}
+
+function isRlsDenied(error: unknown): boolean {
+  if (!error) return false
+  const pg = error as { code?: string; message?: string }
+  if (pg.code === '42501') return true
+  if (error instanceof Error && /row-level security|permission denied/i.test(error.message)) return true
+  return false
+}
+
 function json(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -415,6 +445,7 @@ export class StorageHandler {
       const id = await this.persistObject(ctx, bucketId, key, bytes, contentType, cacheControl, upsert)
       return json(200, { Key: `${bucketId}/${key}`, Id: id })
     } catch (e) {
+      if (e instanceof RlsPolicyError) return rlsDeniedResponse()
       const pg = e as { code?: string }
       if (pg.code === '23505') {
         return storageError(409, 'Duplicate', 'The resource already exists')
@@ -471,6 +502,12 @@ export class StorageHandler {
       )
       inserted = result.rows[0] as ObjectRow | undefined
     } catch (error) {
+      if (isRlsDenied(error)) {
+        // Clean up the staged bytes, then surface an actionable RLS hint
+        // instead of the bare Postgres "row-level security" message.
+        try { await this.driver.delete(stagedKey) } catch { /* best-effort */ }
+        throw new RlsPolicyError(error)
+      }
       await this.discardStagedBytes(stagedKey, error)
     }
     if (!inserted) return this.discardStagedBytes(stagedKey, new Error('storage metadata insert returned no row'))
@@ -545,6 +582,7 @@ export class StorageHandler {
             upsert
           )
         } catch (error) {
+          if (error instanceof RlsPolicyError) return rlsDeniedResponse()
           const pg = error as { code?: string }
           if (pg.code === '23505') return storageError(409, 'Duplicate', 'The resource already exists')
           throw error
@@ -689,6 +727,7 @@ export class StorageHandler {
       )
     } catch (e) {
       this.tusUploads.delete(id)
+      if (e instanceof RlsPolicyError) return rlsDeniedResponse()
       const pg = e as { code?: string }
       if (pg.code === '23505') return storageError(409, 'Duplicate', 'The resource already exists')
       throw e
@@ -752,7 +791,7 @@ export class StorageHandler {
         pg.code === '42501' ||
         (error instanceof Error && /row-level security|permission denied/i.test(error.message))
       ) {
-        return storageError(403, 'Unauthorized', 'new row violates row-level security policy')
+        return rlsDeniedResponse()
       }
       throw error
     }

--- a/packages/supacloud-lite/test/storage-default-rls-error.test.ts
+++ b/packages/supacloud-lite/test/storage-default-rls-error.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { startProjectServer, type RunningProjectServer } from '../src/project-runtime.js'
+
+/**
+ * A fresh Lite project that declares a bucket in config.toml but ships no
+ * storage.objects RLS policy must reject uploads with an actionable 403 that
+ * points the developer at the missing policy — not a bare Postgres
+ * "row-level security" message. Official Supabase leaves storage.objects
+ * locked down by default; Lite matches that, but surfaces a clearer hint.
+ */
+describe('Storage default RLS error message (no user-authored objects policy)', () => {
+  let rootDir: string
+  let project: RunningProjectServer
+  let anonClient: SupabaseClient
+  let userAccessToken: string
+
+  beforeAll(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-storage-rls-msg-'))
+    await mkdir(join(rootDir, 'supabase', 'migrations'), { recursive: true })
+    await writeFile(
+      join(rootDir, 'supabase', 'migrations', '0001_notes.sql'),
+      'create table public.notes (id int primary key, body text);\nalter table public.notes enable row level security;\ncreate policy notes_read on public.notes for select using (true);\n',
+    )
+    await writeFile(
+      join(rootDir, 'supabase', 'config.toml'),
+      '[auth.email]\nenable_confirmations = false\n\n[storage]\nfile_size_limit = "1MiB"\n\n[storage.buckets.images]\npublic = true\nallowed_mime_types = ["text/plain"]\n',
+    )
+    project = await startProjectServer({ projectDir: rootDir, port: 0, log: () => {} })
+    const opts = { auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false } }
+    anonClient = createClient(project.url, project.backend.anonKey, opts)
+    const signUpClient = createClient(project.url, project.backend.anonKey, opts)
+    const { data, error } = await signUpClient.auth.signUp({ email: 'rls-msg@example.com', password: 'correct-horse-battery-staple' })
+    expect(error).toBeNull()
+    userAccessToken = data.session!.access_token
+  }, 60_000)
+
+  afterAll(async () => {
+    await project?.close()
+    if (rootDir) await rm(rootDir, { recursive: true, force: true })
+  })
+
+  test('authenticated upload is denied with an actionable policy hint', async () => {
+    const userClient = createClient(project.url, project.backend.anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+      global: { headers: { Authorization: `Bearer ${userAccessToken}` } },
+    })
+    const upload = await userClient.storage.from('images').upload('no-policy.txt', new TextEncoder().encode('blocked'), { contentType: 'text/plain' })
+    expect(upload.error).not.toBeNull()
+    expect(upload.error!.statusCode).toBe('403')
+    // The hint must point at the missing storage.objects policy and must not
+    // be the bare Postgres message that gave no guidance.
+    expect(upload.error!.message).toContain('storage.objects RLS')
+    expect(upload.error!.message).toContain('create policy')
+    expect(upload.error!.message).not.toContain('new row violates row-level security policy')
+  })
+
+  test('anonymous upload is also denied with the same hint', async () => {
+    const upload = await anonClient.storage.from('images').upload('anon.txt', new TextEncoder().encode('x'), { contentType: 'text/plain' })
+    expect(upload.error).not.toBeNull()
+    expect(upload.error!.statusCode).toBe('403')
+    expect(upload.error!.message).toContain('storage.objects RLS')
+  })
+})


### PR DESCRIPTION
Supersedes #708 (rejected as a security conflict — it widened storage permissions and reintroduced forbidden naming).

## Problem

A fresh Lite project that declares a bucket in `config.toml` but ships no user-authored `storage.objects` RLS policy rejects **every** upload with a bare Postgres message:

```
new row violates row-level security policy for table "objects"
```

This gives no guidance that the project is simply missing a storage policy. Official Supabase leaves `storage.objects` locked down by default; Lite matches that posture — but the error surface should say so.

## Fix (security posture unchanged, no permissions widened)

**No RLS policies are added. No permissions are widened.** This changes only the error message.

- Detect RLS / permission-denied (`42501` or `/row-level security|permission denied/i`) on the object INSERT path and rethrow as `RlsPolicyError`, so all write paths map it consistently.
- Return `403` with an actionable hint pointing at the missing policy + a copy-paste `create policy` example, instead of the raw Postgres message.
- Cover all object-write paths: regular upload, TUS zero-length upload, TUS completion, and TUS preflight.
- Staged bytes are still cleaned up before the error is raised.

### Why not add default policies (#708 did, and was blocked)

Default policies that auto-grant writes **widen** the security posture — that decision belongs to the maintainer, and #708's `for all to authenticated` additionally let any logged-in user overwrite/delete other users' objects in public buckets. This PR takes the conservative route: keep the lock-down, fix the message.

## Verification

- New `test/storage-default-rls-error.test.ts` (2 tests): authenticated and anonymous uploads both get `403` whose message contains `storage.objects RLS` + `create policy`, and does **not** contain the bare Postgres message.
- `test/integration.test.ts` (incl. user-authored storage policy upload/download/list/remove) — 10/10 pass, unaffected.
- Full suite: **94/94 pass**.
- `tsc --noEmit` clean.
- `clean-code-guard` self-check passed: no broad catch-all error swallowing (RLS is a specific recoverable case → mapped to 403), error type follows existing `StorageValidationError` pattern, DRY violation removed via `rlsDeniedResponse()` helper, no forbidden naming, no new dependency.

## Scope

1 file changed (`src/runtime/storage/handler.ts`, +42/-1) + 1 test file. Based on `origin/main` (`runtime/` path). Squash on merge.