### PR TITLE
fix(management-api): harden logical backup recovery

### DIFF
--- a/packages/management-api/src/routes/backups.ts
+++ b/packages/management-api/src/routes/backups.ts
@@ -59,21 +59,37 @@ const projectBackupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
         const authError = await requireAdminAuth(request);
         if (authError) return status(authError.status, authError.body);
 
-        return await createLogicalBackup(ref);
+        const backup = await createLogicalBackup(ref);
+        if (!backup.success) return status(503, { message: backup.message });
+        return backup;
     }, {
-        response: { 200: t.Any() },
+        response: { 200: t.Any(), 503: ErrorResponse },
         detail: { tags: ["backups"], summary: "Create a logical backup" },
     })
     .post('/logical/restore', async ({ params: { ref }, body, request }) => {
         const authError = await requireAdminAuth(request);
         if (authError) return status(authError.status, authError.body);
         if (!body.backupId) return status(400, { message: "backupId is required", code: "400" });
-        return await restoreLogicalBackup(ref, body.backupId);
+        if (body.confirmation !== `RESTORE_PROJECT:${ref}:${body.backupId}`) {
+            return status(400, { message: "Exact project restore confirmation is required" });
+        }
+        const restoreResult = await restoreLogicalBackup(ref, body.backupId);
+        if (restoreResult.success) return restoreResult;
+        if (restoreResult.reason === "project_not_paused") return status(409, { message: restoreResult.message });
+        if (restoreResult.reason === "backup_not_found") return status(404, { message: restoreResult.message });
+        if (restoreResult.reason === "invalid_backup_id") return status(400, { message: restoreResult.message });
+        return status(503, { message: restoreResult.message });
     }, {
-        body: t.Object({ backupId: t.Optional(t.String()) }),
+        body: t.Object({
+            backupId: t.Optional(t.String()),
+            confirmation: t.Optional(t.String()),
+        }),
         response: {
             200: t.Any(),
             400: ErrorResponse,
+            404: ErrorResponse,
+            409: ErrorResponse,
+            503: ErrorResponse,
         },
         detail: { tags: ["backups"], summary: "Restore from logical backup" },
     });

--- a/packages/management-api/src/services/backup.service.ts
+++ b/packages/management-api/src/services/backup.service.ts
@@ -1,11 +1,10 @@
-import { $ } from 'bun';
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir, open, rm, stat } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import { logger } from "../utils/logger";
 import type { BackupInfo, RestoreRequest } from '../types/backup';
 import { projectRepository } from '../repositories/project.repository';
-import { resolveDbName, resolveRoleName } from '../db';
+import { resolveDbName } from '../db';
 import { config } from "../config";
 
 const PGBACKREST_NAME_PATTERN = /^[A-Za-z0-9_.-]{1,128}$/;
@@ -365,17 +364,31 @@ export async function restore(request: RestoreRequest): Promise<{ message: strin
   }
 }
 
-const LOGICAL_BACKUP_DIR = process.env.SUPACLOUD_LOGICAL_BACKUP_DIR || "/tmp/supacloud-backups";
+const LOGICAL_BACKUP_DIR = process.env.SUPACLOUD_LOGICAL_BACKUP_DIR || "/var/lib/supacloud/backups";
 const LOGICAL_BACKUP_FILE_PATTERN = /^backup_[A-Za-z0-9_-]{1,64}_\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.sql\.gz$/;
+
+type LogicalBackupResult = {
+  success: boolean;
+  message: string;
+  file?: string;
+  reason?: "backup_failed" | "invalid_backup_id" | "project_not_paused" | "backup_not_found" | "restore_failed";
+};
 
 async function runLogicalDatabaseCommand(
   command: "pg_dump" | "pg_restore",
+  database: string,
   commandArguments: string[],
-  password: string,
 ): Promise<void> {
   const databaseProcess = Bun.spawn({
-    cmd: [command, "-h", config.pgHost, "-p", String(config.pgPort), ...commandArguments],
-    env: { ...process.env, PGPASSWORD: password },
+    cmd: [
+      command,
+      "-h", config.pgHost,
+      "-p", String(config.pgPort),
+      "-U", config.pgUser,
+      "-d", database,
+      ...commandArguments,
+    ],
+    env: { ...process.env, PGPASSWORD: config.pgPassword },
     stdout: "ignore",
     stderr: "pipe",
   });
@@ -386,119 +399,105 @@ async function runLogicalDatabaseCommand(
   if (exitCode !== 0) throw new Error(`${command} exited with code ${exitCode}`);
 }
 
+async function validateLogicalBackup(backupPath: string): Promise<void> {
+  const validationProcess = Bun.spawn({
+    cmd: ["pg_restore", "--list", backupPath],
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [exitCode] = await Promise.all([
+    validationProcess.exited,
+    new Response(validationProcess.stderr).text(),
+  ]);
+  const backupFile = await stat(backupPath);
+  if (exitCode !== 0 || backupFile.size === 0) {
+    throw new Error("Logical backup archive validation failed");
+  }
+}
+
 async function ensureLogicalBackupDir(): Promise<string> {
-        const baseDir = resolve(LOGICAL_BACKUP_DIR);
-        await mkdir(baseDir, { recursive: true, mode: 0o700 });
-        return baseDir;
-    }
+  const baseDir = resolve(LOGICAL_BACKUP_DIR);
+  await mkdir(baseDir, { recursive: true, mode: 0o700 });
+  await chmod(baseDir, 0o700);
+  return baseDir;
+}
 
 async function resolveLogicalBackupPath(filename: string): Promise<string> {
-        if (filename !== basename(filename) || !LOGICAL_BACKUP_FILE_PATTERN.test(filename)) {
-            throw new Error("Invalid backup id");
-        }
-        const baseDir = await ensureLogicalBackupDir();
-        const fullPath = resolve(baseDir, filename);
-        if (!fullPath.startsWith(`${baseDir}/`)) {
-            throw new Error("Invalid backup path");
-        }
-        return fullPath;
-    }
+  if (!isLogicalBackupId(filename)) throw new Error("Invalid backup id");
+  const baseDir = await ensureLogicalBackupDir();
+  const fullPath = resolve(baseDir, filename);
+  if (!fullPath.startsWith(`${baseDir}/`)) throw new Error("Invalid backup path");
+  return fullPath;
+}
 
-    /**
-     * Execute logical backup per tenant level (pg_dump)
-     * Export dedicated data and upload to corresponding S3 bucket
-     */
-export async function createLogicalBackup(projectRef: string): Promise<{ success: boolean; message: string; file?: string }> {
-        const project = await projectRepository.findByRef(projectRef);
-        if (!project) throw new Error("Project not found");
+function isLogicalBackupId(filename: string): boolean {
+  return filename === basename(filename) && LOGICAL_BACKUP_FILE_PATTERN.test(filename);
+}
 
-        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-        const filename = `backup_${projectRef}_${timestamp}.sql.gz`;
-        const backupPath = await resolveLogicalBackupPath(filename);
+async function dumpLogicalBackup(projectRef: string, backupPath: string): Promise<void> {
+  const tenantDatabase = await resolveDbName(projectRef);
+  logger.info(`[LogicalBackup] Starting dump for ${projectRef} -> ${backupPath}`);
+  await runLogicalDatabaseCommand("pg_dump", tenantDatabase, [
+    "-F", "c", "-Z", "6", "-f", backupPath,
+  ]);
+  await validateLogicalBackup(backupPath);
+}
 
-        try {
-            // Use tenant role, export as Custom archive format with default gzip compression
-            const tenantDb = await resolveDbName(projectRef);
-            const tenantUser = resolveRoleName(projectRef);
+async function restoreLogicalBackupArchive(projectRef: string, backupPath: string): Promise<void> {
+  const tenantDatabase = await resolveDbName(projectRef);
+  logger.info(`[LogicalBackup] Starting restore for ${projectRef} from ${backupPath}`);
+  await runLogicalDatabaseCommand("pg_restore", tenantDatabase, [
+    "-c", "--if-exists", "--exit-on-error", "-1", backupPath,
+  ]);
+  logger.info(`[LogicalBackup] Restore complete for ${projectRef}`);
+}
 
-            logger.info(`[LogicalBackup] Starting dump for ${projectRef} -> ${backupPath}`);
-            await runLogicalDatabaseCommand("pg_dump", [
-                "-U", tenantUser,
-                "-d", tenantDb,
-                "-F", "c",
-                "-Z", "6",
-                "-f", backupPath,
-            ], project.db_password);
+/** Create a complete project-database archive with control-plane credentials. */
+export async function createLogicalBackup(projectRef: string): Promise<LogicalBackupResult> {
+  if (!await projectRepository.findByRef(projectRef)) throw new Error("Project not found");
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `backup_${projectRef}_${timestamp}.sql.gz`;
+  const backupPath = await resolveLogicalBackupPath(filename);
+  let reservedArchive = false;
+  try {
+    const archiveFile = await open(backupPath, "wx", 0o600);
+    await archiveFile.close();
+    reservedArchive = true;
+    await dumpLogicalBackup(projectRef, backupPath);
+    return { success: true, message: "Logical backup completed", file: filename };
+  } catch (error: unknown) {
+    if (reservedArchive) await rm(backupPath, { force: true });
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("[LogicalBackup] failed:", { error: message });
+    return { success: false, message: `Logical backup failed: ${message}`, reason: "backup_failed" };
+  }
+}
 
-            // Try to upload to tenant's hidden backup prefix via AWS CLI (MinIO/Garage compatible)
-            if (project.s3_access_key && project.s3_secret_key) {
-                try {
-                    await $`AWS_ACCESS_KEY_ID=${project.s3_access_key} AWS_SECRET_ACCESS_KEY=${project.s3_secret_key} aws --endpoint-url http://localhost:9000 s3 cp ${backupPath} s3://${project.s3_bucket}/_backups/${filename}`.quiet();
-                    logger.info(`[LogicalBackup] Uploaded ${filename} to S3.`);
-                    await $`rm -f ${backupPath}`.quiet(); // Cleanup local after successful upload
-                } catch (uploadErr: unknown) {
-                    logger.warn('[LogicalBackup] S3 Upload failed (Ensure awscli is installed). Kept local copy at', backupPath);
-                }
-            }
-
-            return { success: true, message: "Logical backup completed", file: filename };
-        } catch (err: unknown) {
-            logger.error("[LogicalBackup] failed:", { error: err instanceof Error ? err.message : String(err) });
-            return { success: false, message: "Logical backup failed: " + (err instanceof Error ? err.message : String(err)) };
-        }
-    }
-
-    /**
-     * Execute logical restore per tenant level (pg_restore)
-     */
-export async function restoreLogicalBackup(projectRef: string, backupId: string): Promise<{ success: boolean; message: string }> {
-        let backupPath: string;
-        try {
-            backupPath = await resolveLogicalBackupPath(backupId);
-        } catch {
-            return { success: false, message: "Invalid backup id" };
-        }
-
-        const project = await projectRepository.findByRef(projectRef);
-        if (!project) throw new Error("Project not found");
-
-        try {
-            // Try downloading from S3 first
-            if (project.s3_access_key && project.s3_secret_key) {
-                try {
-                    await $`AWS_ACCESS_KEY_ID=${project.s3_access_key} AWS_SECRET_ACCESS_KEY=${project.s3_secret_key} aws --endpoint-url http://localhost:9000 s3 cp s3://${project.s3_bucket}/_backups/${backupId} ${backupPath}`.quiet();
-                    logger.info(`[LogicalBackup] Downloaded ${backupId} from S3.`);
-                } catch (dlErr: unknown) {
-                    logger.warn('[LogicalBackup] Could not download from S3, assuming local file exists.');
-                }
-            }
-
-            // Check file exists
-            const fileExists = await $`test -f ${backupPath}`.nothrow();
-            if (fileExists.exitCode !== 0) {
-                return { success: false, message: "Backup file not found: " + backupId };
-            }
-
-            // Execute pg_restore (force clean old objects and complete in single transaction)
-            const tenantDb = await resolveDbName(projectRef);
-            const tenantUser = resolveRoleName(projectRef);
-            logger.info(`[LogicalBackup] Starting restore for ${projectRef} from ${backupPath}`);
-
-            await runLogicalDatabaseCommand("pg_restore", [
-                "-U", tenantUser,
-                "-d", tenantDb,
-                "-c",
-                "-1",
-                backupPath,
-            ], project.db_password);
-
-            logger.info(`[LogicalBackup] Restore complete for ${projectRef}`);
-            return { success: true, message: "Logical restore completed successfully" };
-        } catch (err: unknown) {
-            logger.error("[LogicalBackup] Restore failed:", { error: err instanceof Error ? err.message : String(err) });
-            return { success: false, message: "Restore process error: " + (err instanceof Error ? err.message : String(err)) };
-        } finally {
-            // Cleanup local temp file
-            await $`rm -f ${backupPath}`.nothrow().quiet();
-        }
-    }
+/** Restore a project database only while its application runtime is paused. */
+export async function restoreLogicalBackup(projectRef: string, backupId: string): Promise<LogicalBackupResult> {
+  if (!isLogicalBackupId(backupId)) {
+    return { success: false, message: "Invalid backup id", reason: "invalid_backup_id" };
+  }
+  const backupPath = await resolveLogicalBackupPath(backupId);
+  const project = await projectRepository.findByRef(projectRef);
+  if (!project) throw new Error("Project not found");
+  if (project.status !== "paused") {
+    return {
+      success: false,
+      message: "Project must be paused before logical restore",
+      reason: "project_not_paused",
+    };
+  }
+  if (!existsSync(backupPath)) {
+    return { success: false, message: `Backup file not found: ${backupId}`, reason: "backup_not_found" };
+  }
+  try {
+    await validateLogicalBackup(backupPath);
+    await restoreLogicalBackupArchive(projectRef, backupPath);
+    return { success: true, message: "Logical restore completed successfully" };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("[LogicalBackup] Restore failed:", { error: message });
+    return { success: false, message: `Restore process error: ${message}`, reason: "restore_failed" };
+  }
+}

--- a/packages/management-api/tests/unit/backup.routes.test.ts
+++ b/packages/management-api/tests/unit/backup.routes.test.ts
@@ -6,6 +6,8 @@ const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
 const resolveDbName = mock((ref: string) => Promise.resolve(`supa_${ref}`));
 const listBackups = mock(() => Promise.resolve([]));
 const createBackup = mock(() => Promise.resolve({ message: "full backup completed" }));
+const createLogicalBackup = mock(() => Promise.resolve({ success: true, message: "Logical backup completed", file: "backup_project_a_2026-08-05T00-00-00-000Z.sql.gz" }));
+const restoreLogicalBackup = mock(() => Promise.resolve({ success: true, message: "Logical restore completed successfully" }));
 const restore = mock(() => Promise.resolve({ message: "PITR restore completed" }));
 
 const authModule = await import("../../src/middleware/auth");
@@ -26,6 +28,12 @@ const listBackupsSpy = spyOn(backupModule, "listBackups").mockImplementation(
 );
 const createBackupSpy = spyOn(backupModule, "createBackup").mockImplementation(
   createBackup as typeof backupModule.createBackup,
+);
+const createLogicalBackupSpy = spyOn(backupModule, "createLogicalBackup").mockImplementation(
+  createLogicalBackup as typeof backupModule.createLogicalBackup,
+);
+const restoreLogicalBackupSpy = spyOn(backupModule, "restoreLogicalBackup").mockImplementation(
+  restoreLogicalBackup as typeof backupModule.restoreLogicalBackup,
 );
 const restoreSpy = spyOn(backupModule, "restore").mockImplementation(
   restore as typeof backupModule.restore,
@@ -58,6 +66,14 @@ describe("physical backup routes", () => {
     listBackups.mockResolvedValue([]);
     createBackup.mockReset();
     createBackup.mockResolvedValue({ message: "full backup completed" });
+    createLogicalBackup.mockReset();
+    createLogicalBackup.mockResolvedValue({
+      success: true,
+      message: "Logical backup completed",
+      file: "backup_project_a_2026-08-05T00-00-00-000Z.sql.gz",
+    });
+    restoreLogicalBackup.mockReset();
+    restoreLogicalBackup.mockResolvedValue({ success: true, message: "Logical restore completed successfully" });
     restore.mockReset();
     restore.mockResolvedValue({ message: "PITR restore completed" });
     delete process.env.SUPACLOUD_PITR_ENABLED;
@@ -70,6 +86,8 @@ describe("physical backup routes", () => {
     resolveDbNameSpy.mockRestore();
     listBackupsSpy.mockRestore();
     createBackupSpy.mockRestore();
+    createLogicalBackupSpy.mockRestore();
+    restoreLogicalBackupSpy.mockRestore();
     restoreSpy.mockRestore();
   });
 
@@ -188,6 +206,42 @@ describe("physical backup routes", () => {
     expect(response.status).toBe(401);
     expect(listBackups).not.toHaveBeenCalled();
     expect(restore).not.toHaveBeenCalled();
+  });
+
+  test("returns a service error instead of HTTP 200 when logical backup fails", async () => {
+    createLogicalBackup.mockResolvedValueOnce({ success: false, message: "Logical backup failed" });
+
+    const response = await request("/v1/projects/project_a/database/backups/logical", {
+      method: "POST",
+      body: "{}",
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ message: "Logical backup failed" });
+  });
+
+  test("requires exact confirmation and a paused project outcome for logical restore", async () => {
+    const backupId = "backup_project_a_2026-08-05T00-00-00-000Z.sql.gz";
+    const unconfirmed = await request("/v1/projects/project_a/database/backups/logical/restore", {
+      method: "POST",
+      body: JSON.stringify({ backupId, confirmation: "RESTORE_PROJECT" }),
+    });
+    expect(unconfirmed.status).toBe(400);
+    expect(restoreLogicalBackup).not.toHaveBeenCalled();
+
+    restoreLogicalBackup.mockResolvedValueOnce({
+      success: false,
+      message: "Project must be paused before logical restore",
+      reason: "project_not_paused",
+    });
+    const pausedRequired = await request("/v1/projects/project_a/database/backups/logical/restore", {
+      method: "POST",
+      body: JSON.stringify({
+        backupId,
+        confirmation: `RESTORE_PROJECT:project_a:${backupId}`,
+      }),
+    });
+    expect(pausedRequired.status).toBe(409);
   });
 
   test("does not leave a second backup or restore contract in project config routes", () => {

--- a/packages/management-api/tests/unit/logical-backup.service.test.ts
+++ b/packages/management-api/tests/unit/logical-backup.service.test.ts
@@ -1,6 +1,6 @@
 // @supacloud-test-isolate — mocks tenant lookup and database subprocesses.
 import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -9,15 +9,13 @@ interface SpawnInvocation {
   env?: Record<string, string | undefined>;
 }
 
-const projectPassword = "tenant-secret";
+const adminPassword = "admin-secret";
+let projectStatus = "paused";
 const findByRef = mock(async () => ({
   ref: "project-a",
-  db_password: projectPassword,
-  s3_access_key: null,
-  s3_secret_key: null,
+  status: projectStatus,
 }));
 const resolveDbName = mock(async () => "tenant_database");
-const resolveRoleName = mock(() => "tenant_role");
 const logicalBackupDirectory = await mkdtemp(join(tmpdir(), "supacloud-logical-backup-test-"));
 const previousLogicalBackupDirectory = process.env.SUPACLOUD_LOGICAL_BACKUP_DIR;
 process.env.SUPACLOUD_LOGICAL_BACKUP_DIR = logicalBackupDirectory;
@@ -25,9 +23,14 @@ process.env.SUPACLOUD_LOGICAL_BACKUP_DIR = logicalBackupDirectory;
 mock.module("../../src/repositories/project.repository", () => ({
   projectRepository: { findByRef },
 }));
-mock.module("../../src/db", () => ({ resolveDbName, resolveRoleName }));
+mock.module("../../src/db", () => ({ resolveDbName }));
 mock.module("../../src/config", () => ({
-  config: { pgHost: "database.internal", pgPort: 6432 },
+  config: {
+    pgHost: "database.internal",
+    pgPort: 6432,
+    pgUser: "postgres-admin",
+    pgPassword: adminPassword,
+  },
 }));
 mock.module("../../src/utils/logger", () => ({
   logger: {
@@ -42,22 +45,27 @@ const { createLogicalBackup, restoreLogicalBackup } = await import(
 );
 
 const spawnInvocations: SpawnInvocation[] = [];
-let databaseProcessExitCode = 0;
+const commandExitCodes: number[] = [];
 const spawnSpy = spyOn(Bun, "spawn").mockImplementation(((options: SpawnInvocation) => {
   spawnInvocations.push(options);
+  const exitCode = commandExitCodes.shift() ?? 0;
+  const outputPathIndex = options.cmd.indexOf("-f");
+  const writeArchive = options.cmd[0] === "pg_dump" && exitCode === 0 && outputPathIndex >= 0
+    ? writeFile(options.cmd[outputPathIndex + 1] || "", "archive")
+    : Promise.resolve();
   return {
-    exited: Promise.resolve(databaseProcessExitCode),
+    exited: writeArchive.then(() => exitCode),
     stderr: new Blob([]).stream(),
   } as never;
 }) as typeof Bun.spawn);
 
 describe("logical backup database endpoint", () => {
   beforeEach(() => {
-    databaseProcessExitCode = 0;
+    projectStatus = "paused";
+    commandExitCodes.length = 0;
     spawnInvocations.length = 0;
     findByRef.mockClear();
     resolveDbName.mockClear();
-    resolveRoleName.mockClear();
   });
 
   afterAll(async () => {
@@ -67,30 +75,34 @@ describe("logical backup database endpoint", () => {
     else process.env.SUPACLOUD_LOGICAL_BACKUP_DIR = previousLogicalBackupDirectory;
   });
 
-  test("uses the configured PostgreSQL endpoint for dump and restore", async () => {
+  test("uses the control-plane PostgreSQL identity and validates the archive", async () => {
     const backup = await createLogicalBackup("project-a");
     expect(backup.success).toBe(true);
+    const createdBackupPath = join(logicalBackupDirectory, String(backup.file));
+    expect((await stat(createdBackupPath)).mode & 0o777).toBe(0o600);
 
     const backupId = "backup_project-a_2026-08-04T00-00-00-000Z.sql.gz";
     await writeFile(join(logicalBackupDirectory, backupId), "archive");
     await expect(restoreLogicalBackup("project-a", backupId)).resolves.toMatchObject({ success: true });
 
-    expect(spawnInvocations.map(({ cmd }) => cmd.slice(0, 5))).toEqual([
-      ["pg_dump", "-h", "database.internal", "-p", "6432"],
-      ["pg_restore", "-h", "database.internal", "-p", "6432"],
+    expect(spawnInvocations.map(({ cmd }) => cmd[0])).toEqual([
+      "pg_dump", "pg_restore", "pg_restore", "pg_restore",
     ]);
     expect(spawnInvocations[0]?.cmd).toEqual(expect.arrayContaining([
-      "-U", "tenant_role", "-d", "tenant_database", "-F", "c", "-Z", "6", "-f",
+      "-h", "database.internal", "-p", "6432", "-U", "postgres-admin",
+      "-d", "tenant_database", "-F", "c", "-Z", "6", "-f",
     ]));
-    expect(spawnInvocations[1]?.cmd).toEqual(expect.arrayContaining([
-      "-U", "tenant_role", "-d", "tenant_database", "-c", "-1",
+    expect(spawnInvocations[3]?.cmd).toEqual(expect.arrayContaining([
+      "-U", "postgres-admin", "-d", "tenant_database", "-c", "--if-exists",
+      "--exit-on-error", "-1",
     ]));
-    expect(spawnInvocations.every(({ env }) => env?.PGPASSWORD === projectPassword)).toBe(true);
-    expect(JSON.stringify(spawnInvocations.map(({ cmd }) => cmd))).not.toContain(projectPassword);
+    expect(spawnInvocations[1]?.cmd).toEqual(["pg_restore", "--list", createdBackupPath]);
+    expect(spawnInvocations.filter(({ env }) => env).every(({ env }) => env?.PGPASSWORD === adminPassword)).toBe(true);
+    expect(JSON.stringify(spawnInvocations.map(({ cmd }) => cmd))).not.toContain(adminPassword);
   });
 
   test("does not report a failed database subprocess as a successful backup", async () => {
-    databaseProcessExitCode = 9;
+    commandExitCodes.push(9);
 
     await expect(createLogicalBackup("project-a")).resolves.toMatchObject({
       success: false,
@@ -101,11 +113,25 @@ describe("logical backup database endpoint", () => {
   test("does not report a failed database subprocess as a successful restore", async () => {
     const backupId = "backup_project-a_2026-08-04T00-00-00-001Z.sql.gz";
     await writeFile(join(logicalBackupDirectory, backupId), "archive");
-    databaseProcessExitCode = 8;
+    commandExitCodes.push(0, 8);
 
     await expect(restoreLogicalBackup("project-a", backupId)).resolves.toMatchObject({
       success: false,
       message: expect.stringContaining("pg_restore exited with code 8"),
     });
+    expect(await Bun.file(join(logicalBackupDirectory, backupId)).exists()).toBe(true);
+  });
+
+  test("requires a paused project before starting a destructive restore", async () => {
+    const backupId = "backup_project-a_2026-08-04T00-00-00-002Z.sql.gz";
+    await writeFile(join(logicalBackupDirectory, backupId), "archive");
+    projectStatus = "active";
+
+    await expect(restoreLogicalBackup("project-a", backupId)).resolves.toEqual({
+      success: false,
+      message: "Project must be paused before logical restore",
+      reason: "project_not_paused",
+    });
+    expect(spawnInvocations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- dump and restore complete project databases with control-plane PostgreSQL credentials
- validate 0600 custom archives and keep recovery points after failed restores
- require exact confirmation plus paused project state, and return non-2xx failures
- keep full logical archives in the platform-owned backup directory instead of tenant S3 credentials

## Verification
- `bun test ./tests/unit/logical-backup.service.test.ts`
- `bun test ./tests/unit/backup.routes.test.ts`
- `bun run typecheck`
- `bun run test:unit`