### PR TITLE
fix(auth): preserve GoTrue SAML provider contract

### DIFF
--- a/packages/management-api/src/routes/auth-sso.ts
+++ b/packages/management-api/src/routes/auth-sso.ts
@@ -2,8 +2,6 @@ import { Elysia, t, status } from "elysia";
 import { projectService } from "../services";
 import { logger } from "../utils/logger";
 import { resolveProjectServiceRoleKey } from "../utils/service-role";
-import { requireProjectOrAdminAuth } from "../middleware/auth";
-import { sql as metaSql } from "../db";
 import { resolveTenantPorts, normalizeProjectRoutingConfig } from "../utils/project-routing";
 import { normalizeProjectConfig } from "../utils/project-config";
 import { requireAuthRuntimeManagement } from "./auth-runtime";
@@ -11,24 +9,15 @@ import { requireAuthRuntimeManagement } from "./auth-runtime";
 async function getGoTrueHeaders(ref: string) {
   const project = await projectService.getProject(ref);
   if (!project) return null;
-  const serviceRoleKey = await resolveProjectServiceRoleKey(ref);
+  const serviceRoleKey = await resolveProjectServiceRoleKey(project);
   if (!serviceRoleKey) return null;
   const { config } = await import("../config");
-
-  let apiUrl: string;
-  try {
-    const rows = await metaSql`
-      SELECT config FROM projects WHERE ref = ${ref} AND deleted_at IS NULL LIMIT 1
-    `;
-    const projectConfig = normalizeProjectConfig(rows[0]?.config);
-    const routingConfig = normalizeProjectRoutingConfig(projectConfig);
-    const ports = resolveTenantPorts(routingConfig);
-    apiUrl = ports?.gotruePort
-      ? `http://127.0.0.1:${ports.gotruePort}`
-      : `http://${config.managementApiInternal}/auth/v1`;
-  } catch {
-    apiUrl = `http://${config.managementApiInternal}/auth/v1`;
-  }
+  const projectConfig = normalizeProjectConfig(project.config);
+  const routingConfig = normalizeProjectRoutingConfig(projectConfig);
+  const ports = resolveTenantPorts(routingConfig);
+  const apiUrl = ports?.gotruePort
+    ? `http://127.0.0.1:${ports.gotruePort}`
+    : `http://${config.managementApiInternal}/auth/v1`;
 
   return { apiUrl, serviceRoleKey, ref };
 }
@@ -100,12 +89,9 @@ export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
       body: t.Object({
         type: t.Literal("saml"),
         resource_id: t.Optional(t.String()),
-        saml_provider_name: t.Optional(t.String()),
         domains: t.Optional(t.Array(t.String())),
         metadata_xml: t.Optional(t.String()),
         metadata_url: t.Optional(t.String()),
-        metadata_attribute_url: t.Optional(t.String()),
-        entity_id: t.Optional(t.String()),
         attribute_mapping: t.Optional(t.Record(t.String(), t.Unknown())),
         name_id_format: t.Optional(t.String()),
         disabled: t.Optional(t.Boolean()),
@@ -173,11 +159,9 @@ export const authSsoRoutes = new Elysia({ prefix: "/v1/projects" })
       body: t.Object({
         type: t.Optional(t.Literal("saml")),
         resource_id: t.Optional(t.String()),
-        saml_provider_name: t.Optional(t.String()),
         domains: t.Optional(t.Array(t.String())),
         metadata_xml: t.Optional(t.String()),
         metadata_url: t.Optional(t.String()),
-        metadata_attribute_url: t.Optional(t.String()),
         attribute_mapping: t.Optional(t.Record(t.String(), t.Unknown())),
         name_id_format: t.Optional(t.String()),
         disabled: t.Optional(t.Boolean()),

--- a/packages/management-api/src/routes/auth-sso.ts
+++ b/packages/management-api/src/routes/auth-sso.ts
@@ -9,7 +9,7 @@ import { requireAuthRuntimeManagement } from "./auth-runtime";
 async function getGoTrueHeaders(ref: string) {
   const project = await projectService.getProject(ref);
   if (!project) return null;
-  const serviceRoleKey = await resolveProjectServiceRoleKey(project);
+  const serviceRoleKey = await resolveProjectServiceRoleKey(ref);
   if (!serviceRoleKey) return null;
   const { config } = await import("../config");
   const projectConfig = normalizeProjectConfig(project.config);

--- a/packages/management-api/tests/unit/auth-sso.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-sso.routes.test.ts
@@ -2,15 +2,12 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { Elysia } from "elysia";
 
-const getProject = mock(async () => ({ ref: "proj_1" }));
+const project = { ref: "proj_1", config: { gotrue_port: 4321 } };
+const getProject = mock(async () => project);
 const resolveProjectServiceRoleKey = mock(async () => "service-role");
-const requireProjectOrAdminAuth = mock(async () => null);
-const metaSql = mock(async () => [{ config: { postgrest_port: 3321, gotrue_port: 4321 } }]);
 
 mock.module("../../src/services", () => ({ projectService: { getProject } }));
 mock.module("../../src/utils/service-role", () => ({ resolveProjectServiceRoleKey }));
-mock.module("../../src/middleware/auth", () => ({ requireProjectOrAdminAuth }));
-mock.module("../../src/db", () => ({ sql: metaSql }));
 
 const { authSsoRoutes } = await import("../../src/routes/auth-sso");
 const app = new Elysia().use(authSsoRoutes);
@@ -21,18 +18,29 @@ afterEach(() => {
   mock.clearAllMocks();
 });
 
-function request(path: string, method: "POST" | "PUT", body: Record<string, unknown>) {
+function request(path: string, init: RequestInit = {}) {
   return app.handle(new Request(`http://localhost${path}`, {
-    method,
-    headers: {
-      Authorization: "Bearer dev-master-token",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(body),
+    ...init,
+    headers: { Authorization: "Bearer dev-master-token", ...(init.headers || {}) },
   }));
 }
 
 describe("SAML provider management", () => {
+  test("preserves the GoTrue list envelope and nullable disabled state", async () => {
+    const provider = {
+      id: "11111111-1111-4111-8111-111111111111",
+      disabled: null,
+      saml: { entity_id: "https://idp.example.test/entity" },
+    };
+    globalThis.fetch = mock(async () => Response.json({ items: [provider] })) as typeof fetch;
+
+    const response = await request("/v1/projects/proj_1/auth/sso/providers");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ items: [provider] });
+    expect(resolveProjectServiceRoleKey).toHaveBeenCalledWith("proj_1");
+  });
+
   test("forwards canonical create and update fields without stripping false or empty values", async () => {
     const upstreamRequests: Array<{ url: string; body: unknown }> = [];
     globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
@@ -50,9 +58,10 @@ describe("SAML provider management", () => {
       name_id_format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
       disabled: false,
     };
-    const created = await request("/v1/projects/proj_1/auth/sso/providers", "POST", {
-      ...expectedCreateBody,
-      ignored: "strip-me",
+    const created = await request("/v1/projects/proj_1/auth/sso/providers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...expectedCreateBody, ignored: "strip-me" }),
     });
     expect(created.status).toBe(200);
     expect(upstreamRequests[0]).toEqual({
@@ -61,7 +70,11 @@ describe("SAML provider management", () => {
     });
 
     const updateBody = { type: "saml", disabled: true, name_id_format: "" };
-    const updated = await request("/v1/projects/proj_1/auth/sso/providers/saml-provider", "PUT", updateBody);
+    const updated = await request("/v1/projects/proj_1/auth/sso/providers/saml-provider", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(updateBody),
+    });
     expect(updated.status).toBe(200);
     expect(upstreamRequests[1]).toEqual({
       url: "http://127.0.0.1:4321/admin/sso/providers/saml-provider",
@@ -73,12 +86,15 @@ describe("SAML provider management", () => {
     const upstreamFetch = mock(async () => Response.json({ id: "unexpected" }));
     globalThis.fetch = upstreamFetch as typeof fetch;
 
-    const missingType = await request("/v1/projects/proj_1/auth/sso/providers", "POST", {
-      metadata_url: "https://idp.example.com/metadata",
+    const missingType = await request("/v1/projects/proj_1/auth/sso/providers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ metadata_url: "https://idp.example.com/metadata" }),
     });
-    const invalidType = await request("/v1/projects/proj_1/auth/sso/providers", "POST", {
-      type: "oidc",
-      metadata_url: "https://idp.example.com/metadata",
+    const invalidType = await request("/v1/projects/proj_1/auth/sso/providers", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "oidc", metadata_url: "https://idp.example.com/metadata" }),
     });
 
     expect(missingType.status).toBe(422);

--- a/packages/management-api/tests/unit/auth-sso.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-sso.routes.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { Elysia } from "elysia";
 
-const project = { ref: "proj_1", config: { gotrue_port: 4321 } };
+const project = { ref: "proj_1", config: { postgrest_port: 3321, gotrue_port: 4321 } };
 const getProject = mock(async () => project);
 const resolveProjectServiceRoleKey = mock(async () => "service-role");
 


### PR DESCRIPTION
## Summary
- align the Management API SAML provider create and update payloads with pinned GoTrue v2.194.0
- preserve type, disabled, name_id_format, resource_id, domains, metadata, and attribute mapping fields instead of stripping them at the Elysia boundary
- preserve the GoTrue list envelope and nullable disabled state
- resolve tenant routing from the public project detail while loading the private service-role material by project ref

## Verification
- focused SAML route tests: 3 passed, including a ProjectDetail-shaped legacy JWT regression fixture
- Management API typecheck: passed
- full Management API unit suite: passed after rebasing latest main
- git diff check: passed

## Dependency context
This is the SupaCloud facade prerequisite for typed SAML connectors in zuohuadong/supauth#45 and its contract follow-up zuohuadong/supauth#46. This PR does not deploy or merge runtime changes.
