### PR TITLE
fix(management-api): list role assignments

### DIFF
--- a/packages/management-api/src/routes/project-rbac.ts
+++ b/packages/management-api/src/routes/project-rbac.ts
@@ -111,6 +111,16 @@ export const projectRbacRoutes = new Elysia({ prefix: "/v1/projects/:ref" })
   }, {
     detail: { tags: ["rbac"], summary: "Delete project RBAC permission" },
   })
+  .get("/rbac/roles/:roleId/assign", async ({ params }) => {
+    try {
+      const assignments = await projectRbacService.listRoleAssignments(params.ref, params.roleId);
+      return { items: assignments, total: assignments.length };
+    } catch (error) {
+      return toHttpError(error);
+    }
+  }, {
+    detail: { tags: ["rbac"], summary: "List project RBAC role assignments" },
+  })
   .post("/rbac/roles/:roleId/assign", async ({ params, body, request }) => {
     try {
       return await projectRbacService.assignRole(params.ref, params.roleId, body, await actorId(request));

--- a/packages/management-api/src/services/project-rbac.service.ts
+++ b/packages/management-api/src/services/project-rbac.service.ts
@@ -946,6 +946,13 @@ export const projectRbacService = {
     return getRoleOrThrow(readRbacConfig(project.config), roleId).permissions;
   },
 
+  async listRoleAssignments(ref: string, roleId: string): Promise<ProjectRbacAssignment[]> {
+    const project = await getProjectOrThrow(ref);
+    const rbac = readRbacConfig(project.config);
+    getRoleOrThrow(rbac, roleId);
+    return rbac.assignments.filter((assignment) => assignment.role_id === roleId);
+  },
+
   async createPermission(ref: string, roleId: string, input: PermissionInput): Promise<ProjectRbacPermission> {
     const name = input.name?.trim();
     if (!name) throw Object.assign(new Error("name is required"), { statusCode: 400 });

--- a/packages/management-api/tests/unit/project-rbac.routes.test.ts
+++ b/packages/management-api/tests/unit/project-rbac.routes.test.ts
@@ -535,6 +535,34 @@ describe("projectRbacRoutes", () => {
     expect("current_org_id" in revokedProject).toBe(false);
   });
 
+  test("lists only assignments for the requested project and role", async () => {
+    storedConfig = seededRbacConfig(2);
+    const otherProjectConfig = seededRbacConfig(1);
+    const otherAssignments = (otherProjectConfig.rbac as { assignments: Array<{ id: string }> }).assignments;
+    otherAssignments[0].id = "other-project-assignment";
+    findByRef.mockImplementation(async (ref) => makeProject(
+      ref === "proj_1" ? storedConfig : otherProjectConfig,
+      ref,
+    ) as never);
+
+    const selectedRole = await request("/v1/projects/proj_1/rbac/roles/role-0/assign");
+    expect(selectedRole.status).toBe(200);
+    expect(await selectedRole.json()).toEqual({
+      items: [expect.objectContaining({ id: "assignment-0", role_id: "role-0", user_id: "user-one" })],
+      total: 1,
+    });
+
+    const otherProject = await request("/v1/projects/proj_2/rbac/roles/role-0/assign");
+    expect(await otherProject.json()).toMatchObject({
+      items: [{ id: "other-project-assignment", role_id: "role-0" }],
+      total: 1,
+    });
+
+    const missingRole = await request("/v1/projects/proj_1/rbac/roles/missing/assign");
+    expect(missingRole.status).toBe(404);
+    expect(await missingRole.json()).toMatchObject({ message: "Role not found", code: "404" });
+  });
+
   test("rolls back an assignment when its transactional outbox write fails", async () => {
     const role = await (await request("/v1/projects/proj_1/rbac/roles", {
       method: "POST",


### PR DESCRIPTION
## Summary

- add the missing role-assignment list route used by SupAuth
- validate the requested project and role before filtering assignments
- preserve project and role isolation with focused route coverage

## Verification

- `bun test tests/unit/project-rbac.routes.test.ts` (28/28)
- SupAuth facade/adapter/role tests (49/49)
- `bun run typecheck`
- `git diff --check`

Related CNB issue: SupAuth #13