### PR TITLE
fix(management-api): verify GoTrue hook runtime safely

### DIFF
--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -1060,6 +1060,8 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
             hook_send_email_uri: "send_email_hook",
             hook_send_sms_enabled: "send_sms_hook",
             hook_send_sms_uri: "send_sms_hook",
+            hook_before_user_created_enabled: "before_user_created_hook",
+            hook_before_user_created_uri: "before_user_created_hook",
             hook_custom_access_token_secrets: "custom_access_token_hook",
             hook_mfa_verification_attempt_secrets: "mfa_verification_hook",
             hook_password_verification_attempt_secrets: "password_verification_hook",
@@ -1071,7 +1073,11 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
           if (hookName) {
             const currentHooks =
               (currentAuth.hooks as Record<string, any>) || {};
-            const currentHook = currentHooks[hookName] || {};
+            const pendingHooks = (otherUpdates.hooks as Record<string, any>) || {};
+            const currentHook = {
+              ...(currentHooks[hookName] || {}),
+              ...(pendingHooks[hookName] || {}),
+            };
             if (key.endsWith("_enabled")) {
               otherUpdates.hooks = {
                 ...((otherUpdates.hooks as Record<string, any>) || {}),

--- a/packages/management-api/src/services/gotrue-auth-hook-runtime.service.ts
+++ b/packages/management-api/src/services/gotrue-auth-hook-runtime.service.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { getAuthRuntimeDescriptor } from "./auth-runtime.service";
 import { projectRepository } from "../repositories/project.repository";
 import { normalizeProjectConfig } from "../utils/project-config";
@@ -44,6 +44,24 @@ type HookRuntimeConfiguration = {
   configuredSecrets: string;
 };
 
+type RuntimeCommandOutput = {
+  exitCode: number;
+  stdout: Buffer;
+};
+
+export type GoTrueEnvironmentRuntime = {
+  setprivPath: string | null;
+  systemctlPath: string | null;
+  sedPath: string | null;
+  run: (command: string[]) => Promise<RuntimeCommandOutput>;
+};
+
+type GoTrueProcessIdentity = {
+  pid: number;
+  uid: number;
+  gid: number;
+};
+
 const HOOK_CONFIGURATION: Record<GoTrueHttpHookName, { envPrefix: string; endpoint: string }> = {
   "before-user-created": {
     envPrefix: "BEFORE_USER_CREATED",
@@ -56,6 +74,39 @@ const HOOK_CONFIGURATION: Record<GoTrueHttpHookName, { envPrefix: string; endpoi
 };
 const PROBE_FIELD = "supaoauth_hook_probe";
 const PROBE_TIMEOUT_MS = 3_000;
+const PROJECT_REF_PATTERN = /^[a-z0-9-]{1,20}$/;
+
+class RuntimeInspectionUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super("GoTrue runtime inspection command is unavailable", { cause });
+    this.name = "RuntimeInspectionUnavailableError";
+  }
+}
+
+async function runRuntimeCommand(command: string[]): Promise<RuntimeCommandOutput> {
+  try {
+    const child = Bun.spawn(command, {
+      env: { LANG: "C" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).arrayBuffer(),
+      new Response(child.stderr).arrayBuffer(),
+    ]);
+    return { exitCode, stdout: Buffer.from(stdout) };
+  } catch (cause) {
+    throw new RuntimeInspectionUnavailableError(cause);
+  }
+}
+
+const HOST_ENVIRONMENT_RUNTIME: GoTrueEnvironmentRuntime = {
+  setprivPath: ["/usr/bin/setpriv", "/bin/setpriv"].find(existsSync) ?? null,
+  systemctlPath: ["/usr/bin/systemctl", "/bin/systemctl"].find(existsSync) ?? null,
+  sedPath: ["/usr/bin/sed", "/bin/sed"].find(existsSync) ?? null,
+  run: runRuntimeCommand,
+};
 
 function reasonCode(hookName: GoTrueHttpHookName, reason: string): string {
   return `gotrue_${hookName.replaceAll("-", "_")}_hook_${reason}`;
@@ -215,28 +266,78 @@ export async function goTrueAuthHookStatusFromRuntime(
     : configuration;
 }
 
-function processEnvironment(rawEnvironment: Buffer): Record<string, string> {
-  return Object.fromEntries(rawEnvironment.toString("utf8")
-    .split("\0")
-    .filter(Boolean)
-    .map((entry) => {
-      const separator = entry.indexOf("=");
-      return separator < 1 ? [entry, ""] : [entry.slice(0, separator), entry.slice(separator + 1)];
+function systemdProperties(rawProperties: Buffer): Record<string, string> {
+  return Object.fromEntries(rawProperties.toString("utf8")
+    .split(/\r?\n/)
+    .filter((property) => property.includes("="))
+    .map((property) => {
+      const separator = property.indexOf("=");
+      return [property.slice(0, separator), property.slice(separator + 1)];
     }));
 }
 
-async function activeGoTrueEnvironment(authorityProjectRef: string): Promise<Record<string, string> | null> {
-  const child = Bun.spawn(
-    ["systemctl", "show", `supacloud-gotrue@${authorityProjectRef}`, "--property=MainPID", "--value"],
-    { stdout: "pipe", stderr: "pipe" },
-  );
-  const [exitCode, output] = await Promise.all([
-    child.exited,
-    new Response(child.stdout).text(),
+function positiveSystemdInteger(rawInteger: string | undefined): number | null {
+  if (!rawInteger || !/^\d+$/.test(rawInteger)) return null;
+  const parsedInteger = Number(rawInteger);
+  return Number.isSafeInteger(parsedInteger) && parsedInteger > 1 ? parsedInteger : null;
+}
+
+function goTrueProcessIdentity(
+  authorityProjectRef: string,
+  properties: Record<string, string>,
+): GoTrueProcessIdentity | null {
+  const expectedIdentity = `supacloud-${authorityProjectRef}`;
+  if (properties.User !== expectedIdentity || properties.Group !== expectedIdentity) return null;
+  const pid = positiveSystemdInteger(properties.MainPID);
+  const uid = positiveSystemdInteger(properties.UID);
+  const gid = positiveSystemdInteger(properties.GID);
+  return pid && uid && gid ? { pid, uid, gid } : null;
+}
+
+async function activeGoTrueIdentity(
+  authorityProjectRef: string,
+  runtime: GoTrueEnvironmentRuntime,
+): Promise<GoTrueProcessIdentity | null> {
+  if (!runtime.systemctlPath) return null;
+  const unit = `supacloud-gotrue@${authorityProjectRef}`;
+  const commandOutput = await runtime.run([
+    runtime.systemctlPath, "show", unit, "--property=MainPID,User,Group,UID,GID", "--no-pager",
   ]);
-  const pid = Number(output.trim());
-  if (exitCode !== 0 || !Number.isSafeInteger(pid) || pid <= 1) return null;
-  return processEnvironment(await readFile(`/proc/${pid}/environ`));
+  return commandOutput.exitCode === 0
+    ? goTrueProcessIdentity(authorityProjectRef, systemdProperties(commandOutput.stdout))
+    : null;
+}
+
+function hookEnvironment(rawEnvironment: Buffer, hookName: GoTrueHttpHookName): Record<string, string> {
+  const envPrefix = HOOK_CONFIGURATION[hookName].envPrefix;
+  const allowedNames = new Set(["ENABLED", "URI", "SECRETS"].map(
+    (suffix) => `GOTRUE_HOOK_${envPrefix}_${suffix}`,
+  ));
+  const environment: Record<string, string> = {};
+  for (const entry of rawEnvironment.toString("utf8").split("\0")) {
+    const separator = entry.indexOf("=");
+    const name = separator > 0 ? entry.slice(0, separator) : "";
+    if (allowedNames.has(name)) environment[name] = entry.slice(separator + 1);
+  }
+  return environment;
+}
+
+export async function readActiveGoTrueHookEnvironment(
+  authorityProjectRef: string,
+  hookName: GoTrueHttpHookName,
+  runtime: GoTrueEnvironmentRuntime = HOST_ENVIRONMENT_RUNTIME,
+): Promise<Record<string, string> | null> {
+  if (!PROJECT_REF_PATTERN.test(authorityProjectRef)
+    || !runtime.setprivPath || !runtime.systemctlPath || !runtime.sedPath) return null;
+  const identity = await activeGoTrueIdentity(authorityProjectRef, runtime);
+  if (!identity) return null;
+  const envPrefix = HOOK_CONFIGURATION[hookName].envPrefix;
+  const commandOutput = await runtime.run([
+    runtime.setprivPath, "--reuid", String(identity.uid), "--regid", String(identity.gid),
+    "--clear-groups", "--", runtime.sedPath, "-z", "-n", "-E",
+    `/^GOTRUE_HOOK_${envPrefix}_(ENABLED|URI|SECRETS)=/p`, `/proc/${identity.pid}/environ`,
+  ]);
+  return commandOutput.exitCode === 0 ? hookEnvironment(commandOutput.stdout, hookName) : null;
 }
 
 async function authorityRoutingConfig(
@@ -257,10 +358,14 @@ async function authorityRoutingConfig(
   }
 }
 
-async function liveGoTrueEnvironment(authorityRef: string): Promise<Record<string, string> | null> {
+async function liveGoTrueEnvironment(
+  authorityRef: string,
+  hookName: GoTrueHttpHookName,
+): Promise<Record<string, string> | null> {
   try {
-    return await activeGoTrueEnvironment(authorityRef);
-  } catch {
+    return await readActiveGoTrueHookEnvironment(authorityRef, hookName);
+  } catch (error) {
+    if (!(error instanceof RuntimeInspectionUnavailableError)) throw error;
     return null;
   }
 }
@@ -289,7 +394,7 @@ export async function detectGoTrueAuthHookStatus(
   if (!routing.found) {
     return authorityStatus(unavailable(hookName, "authority_project_unavailable"), authority);
   }
-  const environment = await liveGoTrueEnvironment(authorityRef);
+  const environment = await liveGoTrueEnvironment(authorityRef, hookName);
   if (!environment) return authorityStatus(unavailable(hookName, "process_unavailable"), authority);
   const status = await goTrueAuthHookStatusFromRuntime({
     projectRef: authorityRef,

--- a/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
+++ b/packages/management-api/tests/unit/auth-config-boundary.routes.test.ts
@@ -546,6 +546,46 @@ describe("SupAuth auth config boundary", () => {
     expect(persistedHooks.before_user_created_hook.secrets).toBeUndefined();
   });
 
+  test("round-trips flat before-user-created hook registration fields", async () => {
+    config.authRuntimeOwnerRef = "";
+    let settings: Record<string, unknown> = {
+      auth: { hooks: { before_user_created_hook: { enabled: false, uri: null } } },
+    };
+    let appliedAuth: Record<string, unknown> | null = null;
+    projectService.getProjectSettings = async () => settings as never;
+    projectService.updateProjectSettings = async (_ref, next) => {
+      settings = next as Record<string, unknown>;
+      return settings as never;
+    };
+    tenantRuntimeService.applyAuthConfig = async (_ref, _previousAuth, nextAuth) => {
+      appliedAuth = nextAuth;
+      return {} as never;
+    };
+    const hookUri = "https://auth.tenant.example/v1/auth-hooks/before-user-created";
+
+    const response = await request("/v1/projects/tenant-a/config/auth", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        hook_before_user_created_enabled: true,
+        hook_before_user_created_uri: hookUri,
+      }),
+    });
+    const responseBody = await response.json();
+    const persistedHooks = (settings.auth as Record<string, unknown>).hooks as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(persistedHooks.before_user_created_hook).toEqual({ enabled: true, uri: hookUri });
+    expect((appliedAuth?.hooks as Record<string, unknown>).before_user_created_hook).toEqual({
+      enabled: true,
+      uri: hookUri,
+    });
+    expect(responseBody).toMatchObject({
+      hook_before_user_created_enabled: true,
+      hook_before_user_created_uri: hookUri,
+    });
+  });
+
   test("returns effective defaults and round-trips canonical session policy values", async () => {
     config.authRuntimeOwnerRef = "";
     let settings: Record<string, unknown> = { auth: {} };

--- a/packages/management-api/tests/unit/gotrue-auth-hook-runtime.service.test.ts
+++ b/packages/management-api/tests/unit/gotrue-auth-hook-runtime.service.test.ts
@@ -1,6 +1,10 @@
 import { createHmac } from "node:crypto";
 import { describe, expect, mock, test } from "bun:test";
-import { goTrueAuthHookStatusFromRuntime } from "../../src/services/gotrue-auth-hook-runtime.service";
+import {
+  goTrueAuthHookStatusFromRuntime,
+  readActiveGoTrueHookEnvironment,
+  type GoTrueEnvironmentRuntime,
+} from "../../src/services/gotrue-auth-hook-runtime.service";
 
 const firstKey = Buffer.from("standard-webhooks-first-key");
 const secondKey = Buffer.from("standard-webhooks-second-key");
@@ -19,6 +23,33 @@ function beforeUserCreatedEnvironment() {
     GOTRUE_HOOK_BEFORE_USER_CREATED_URI:
       "https://auth.project.example/functions/v1/supauth/api/v1/auth-hooks/before-user-created",
     GOTRUE_HOOK_BEFORE_USER_CREATED_SECRETS: `${secret(firstKey)}|${secret(secondKey)}`,
+  };
+}
+
+function commandOutput(stdout: string, exitCode = 0) {
+  return { exitCode, stdout: Buffer.from(stdout) };
+}
+
+function processIdentity(overrides: Record<string, string> = {}) {
+  return Object.entries({
+    MainPID: "4321",
+    User: "supacloud-proj-1",
+    Group: "supacloud-proj-1",
+    UID: "980",
+    GID: "980",
+    ...overrides,
+  }).map(([name, setting]) => `${name}=${setting}`).join("\n");
+}
+
+function inspectionRuntime(
+  run: GoTrueEnvironmentRuntime["run"],
+  setprivPath: string | null = "/usr/bin/setpriv",
+): GoTrueEnvironmentRuntime {
+  return {
+    run,
+    setprivPath,
+    systemctlPath: "/usr/bin/systemctl",
+    sedPath: "/usr/bin/sed",
   };
 }
 
@@ -70,5 +101,85 @@ describe("live GoTrue HTTP Auth Hook verification", () => {
       verified: false,
       reason_code: "gotrue_before_user_created_hook_probe_response_invalid",
     });
+  });
+
+  test("reads only active hook keys through the GoTrue tenant identity", async () => {
+    const run = mock(async (command: string[]) => command[0] === "/usr/bin/systemctl"
+      ? commandOutput(processIdentity())
+      : commandOutput([
+          "JWT_SECRET=must-not-be-returned",
+          ...Object.entries(beforeUserCreatedEnvironment()).map(
+            ([name, setting]) => `${name}=${setting}`,
+          ),
+          "GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED=true",
+        ].join("\0")));
+
+    const environment = await readActiveGoTrueHookEnvironment(
+      "proj-1", "before-user-created", inspectionRuntime(run),
+    );
+
+    expect(environment).toEqual(beforeUserCreatedEnvironment());
+    expect(run).toHaveBeenNthCalledWith(1, [
+      "/usr/bin/systemctl", "show", "supacloud-gotrue@proj-1",
+      "--property=MainPID,User,Group,UID,GID", "--no-pager",
+    ]);
+    expect(run).toHaveBeenNthCalledWith(2, [
+      "/usr/bin/setpriv", "--reuid", "980", "--regid", "980", "--clear-groups", "--",
+      "/usr/bin/sed", "-z", "-n", "-E",
+      "/^GOTRUE_HOOK_BEFORE_USER_CREATED_(ENABLED|URI|SECRETS)=/p", "/proc/4321/environ",
+    ]);
+    expect(environment).not.toHaveProperty("JWT_SECRET");
+    expect(environment).not.toHaveProperty("GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED");
+  });
+
+  test("returns unavailable when the GoTrue unit has no active MainPID", async () => {
+    const run = mock(async () => commandOutput(processIdentity({ MainPID: "0" })));
+
+    expect(await readActiveGoTrueHookEnvironment(
+      "proj-1", "before-user-created", inspectionRuntime(run),
+    )).toBeNull();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a GoTrue unit whose runtime identity does not match the project", async () => {
+    const run = mock(async () => commandOutput(processIdentity({ User: "root", Group: "root" })));
+
+    expect(await readActiveGoTrueHookEnvironment(
+      "proj-1", "before-user-created", inspectionRuntime(run),
+    )).toBeNull();
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns unavailable when tenant-scoped process environment reading fails", async () => {
+    const run = mock(async (command: string[]) => command[0] === "/usr/bin/systemctl"
+      ? commandOutput(processIdentity())
+      : commandOutput("", 1));
+
+    expect(await readActiveGoTrueHookEnvironment(
+      "proj-1", "before-user-created", inspectionRuntime(run),
+    )).toBeNull();
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  test("treats a readable process with no target hook keys as not enabled", async () => {
+    const run = mock(async (command: string[]) => command[0] === "/usr/bin/systemctl"
+      ? commandOutput(processIdentity())
+      : commandOutput(""));
+
+    expect(await readActiveGoTrueHookEnvironment(
+      "proj-1", "before-user-created", inspectionRuntime(run),
+    )).toEqual({});
+  });
+
+  test("rejects invalid project refs and unavailable privilege separation", async () => {
+    const run = mock(async () => commandOutput(processIdentity()));
+
+    expect(await readActiveGoTrueHookEnvironment(
+      "../proj-1", "before-user-created", inspectionRuntime(run),
+    )).toBeNull();
+    expect(await readActiveGoTrueHookEnvironment(
+      "proj-1", "before-user-created", inspectionRuntime(run, null),
+    )).toBeNull();
+    expect(run).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- inspect the active GoTrue hook environment through the tenant UID/GID without granting CAP_SYS_PTRACE
- validate the systemd unit identity and expose only the selected hook keys to the management process
- preserve flat before-user-created hook fields when enabled and URI arrive in one patch

## Security

- uses fixed absolute paths for systemctl, setpriv, and sed
- clears supplementary groups and the inherited management environment
- fails closed on invalid project refs, identities, commands, or process reads

## Verification

- bun test --isolate tests/unit (1689 pass, 0 fail)
- bun run typecheck
- git diff --check
- test-host tenant-identity read probe with no environment values printed

Tracks CNB SupAuth issue #12; final closure is gated on merged test-site verification.