### PR TITLE
fix(management-api): bind organization JIT domains as arrays

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -402,6 +402,12 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
         run: bun test tests/integration/audit-chain-migration.test.ts
 
+      - name: Verify organization array binding on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: bun test tests/integration/project-organization-array-binding.test.ts
+
       - name: Verify Realtime payload safety on PostgreSQL 18
         working-directory: packages/management-api
         env:

--- a/packages/management-api/src/services/project-organization.service.ts
+++ b/packages/management-api/src/services/project-organization.service.ts
@@ -328,12 +328,13 @@ export const projectOrganizationService = {
     const domains = [...new Set((input.jit_domains || []).map((item) => item.trim().toLowerCase()).filter(Boolean))];
     try {
       return sql.begin(async (transaction) => {
+        const jitDomains = transaction.array(domains, "TEXT");
         const [organization] = await transaction`
           INSERT INTO project_business_organizations (
             project_ref, name, slug, description, branding, jit_enabled, jit_domains, created_by
           ) VALUES (
             ${ref}, ${name}, ${slug}, ${input.description ?? null}, ${JSON.stringify(input.branding || {})}::jsonb,
-            ${input.jit_enabled ?? false}, ${domains}, ${actor}
+            ${input.jit_enabled ?? false}, ${jitDomains}, ${actor}
           ) RETURNING *
         `;
         await enqueueWebhookEventInTransaction(transaction, {
@@ -364,6 +365,7 @@ export const projectOrganizationService = {
     const domains = input.jit_domains === undefined
       ? null
       : [...new Set(input.jit_domains.map((item) => item.trim().toLowerCase()).filter(Boolean))];
+    const jitDomains = domains === null ? null : sql.array(domains, "TEXT");
     const [row] = await sql`
       UPDATE project_business_organizations SET
         name = COALESCE(${name ?? null}, name),
@@ -371,7 +373,7 @@ export const projectOrganizationService = {
         description = CASE WHEN ${input.description !== undefined} THEN ${input.description ?? null} ELSE description END,
         branding = CASE WHEN ${input.branding !== undefined} THEN ${JSON.stringify(input.branding || {})}::jsonb ELSE branding END,
         jit_enabled = CASE WHEN ${input.jit_enabled !== undefined} THEN ${input.jit_enabled ?? false} ELSE jit_enabled END,
-        jit_domains = CASE WHEN ${domains !== null} THEN ${domains || []}::text[] ELSE jit_domains END,
+        jit_domains = CASE WHEN ${jitDomains !== null} THEN ${jitDomains} ELSE jit_domains END,
         updated_at = NOW()
       WHERE project_ref = ${ref} AND id = ${organizationId}
       RETURNING *

--- a/packages/management-api/tests/integration/project-organization-array-binding.test.ts
+++ b/packages/management-api/tests/integration/project-organization-array-binding.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { SQL, type ReservedSQL } from "bun";
+
+interface OrganizationDomainsRow {
+  jit_domains: string[];
+}
+
+const database = new SQL({
+  url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+  max: 1,
+});
+
+async function withRollback(operation: (transaction: ReservedSQL) => Promise<void>): Promise<void> {
+  const connection = await database.reserve();
+  await connection.unsafe("BEGIN");
+  try {
+    await operation(connection);
+  } finally {
+    await connection.unsafe("ROLLBACK");
+    connection.release();
+  }
+}
+
+async function insertDomains(transaction: ReservedSQL, fixtureId: string, domains: string[]): Promise<string[]> {
+  const jitDomains = transaction.array(domains, "TEXT");
+  const [organization] = await transaction<OrganizationDomainsRow[]>`
+    INSERT INTO project_organization_array_binding (fixture_id, jit_domains)
+    VALUES (${fixtureId}, ${jitDomains})
+    RETURNING jit_domains
+  `;
+  return organization.jit_domains;
+}
+
+async function updateDomains(transaction: ReservedSQL, fixtureId: string, domains: string[]): Promise<string[]> {
+  const jitDomains = transaction.array(domains, "TEXT");
+  const [organization] = await transaction<OrganizationDomainsRow[]>`
+    UPDATE project_organization_array_binding
+    SET jit_domains = ${jitDomains}
+    WHERE fixture_id = ${fixtureId}
+    RETURNING jit_domains
+  `;
+  return organization.jit_domains;
+}
+
+afterAll(async () => {
+  await database.close();
+}, 30_000);
+
+describe("project organization TEXT[] binding", () => {
+  test("round trips empty, non-empty, and escaped domain arrays", async () => {
+    await withRollback(async (transaction) => {
+      await transaction`
+        CREATE TEMPORARY TABLE project_organization_array_binding (
+          fixture_id TEXT PRIMARY KEY,
+          jit_domains TEXT[] NOT NULL
+        ) ON COMMIT DROP
+      `;
+
+      expect(await insertDomains(transaction, "empty", [])).toEqual([]);
+      expect(await insertDomains(transaction, "non-empty", ["example.com", "second.test"]))
+        .toEqual(["example.com", "second.test"]);
+      expect(await insertDomains(transaction, "escaped", ["comma,domain.test", "back\\slash.test"]))
+        .toEqual(["comma,domain.test", "back\\slash.test"]);
+      expect(await updateDomains(transaction, "empty", ["example.com", "second.test"]))
+        .toEqual(["example.com", "second.test"]);
+      expect(await updateDomains(transaction, "empty", [])).toEqual([]);
+    });
+  }, 30_000);
+});

--- a/packages/management-api/tests/unit/project-organization.service.test.ts
+++ b/packages/management-api/tests/unit/project-organization.service.test.ts
@@ -6,6 +6,8 @@ let controlQueries: Array<{ query: string; values: unknown[] }> = [];
 let storedMembers: Array<Record<string, unknown>> = [];
 let rejectOutboxInsert = false;
 let memberMutationVersion = 0;
+const controlArray = mock((values: string[], type: string) => ({ values, type }));
+const transactionArray = mock((values: string[], type: string) => ({ values, type }));
 
 const authorityDb = mock((strings: TemplateStringsArray) => {
   const query = strings.join("?");
@@ -99,11 +101,16 @@ const controlQuery = mock((strings: TemplateStringsArray, ...values: unknown[]) 
   }
   return Promise.resolve([]);
 });
+const transactionQuery = Object.assign(
+  mock((strings: TemplateStringsArray, ...values: unknown[]) => controlQuery(strings, ...values)),
+  { array: transactionArray },
+);
 const controlDb = Object.assign(controlQuery, {
-  begin: mock(async (callback: (transaction: typeof controlQuery) => Promise<unknown>) => {
+  array: controlArray,
+  begin: mock(async (callback: (transaction: typeof transactionQuery) => Promise<unknown>) => {
     const memberSnapshot = structuredClone(storedMembers);
     try {
-      return await callback(controlQuery);
+      return await callback(transactionQuery);
     } catch (error) {
       storedMembers = memberSnapshot;
       throw error;
@@ -135,7 +142,46 @@ describe("project organization GoTrue authority", () => {
     storedMembers = [];
     rejectOutboxInsert = false;
     memberMutationVersion = 0;
+    controlArray.mockClear();
+    transactionArray.mockClear();
+    transactionQuery.mockClear();
     config.authRuntimeOwnerRef = "auth-owner";
+  });
+
+  test("binds omitted, empty, and normalized create domains as typed arrays", async () => {
+    await projectOrganizationService.create("business-project", { name: "Omitted domains" }, "admin");
+    await projectOrganizationService.create("business-project", { name: "Empty domains", jit_domains: [] }, "admin");
+    await projectOrganizationService.create("business-project", {
+      name: "Normalized domains",
+      jit_domains: [" Example.COM ", "example.com", "second.test"],
+    }, "admin");
+
+    expect(transactionArray.mock.calls).toEqual([
+      [[], "TEXT"],
+      [[], "TEXT"],
+      [["example.com", "second.test"], "TEXT"],
+    ]);
+  });
+
+  test("binds explicit update domains as typed arrays", async () => {
+    await projectOrganizationService.update("business-project", "org-one", { jit_domains: [] });
+    await projectOrganizationService.update("business-project", "org-one", {
+      jit_domains: [" Example.COM ", "example.com", "second.test"],
+    });
+
+    expect(controlArray.mock.calls).toEqual([
+      [[], "TEXT"],
+      [["example.com", "second.test"], "TEXT"],
+    ]);
+  });
+
+  test("preserves stored update domains when jit_domains is omitted", async () => {
+    await projectOrganizationService.update("business-project", "org-one", { name: "Renamed" });
+
+    expect(controlArray).not.toHaveBeenCalled();
+    expect(controlQueries.some(({ query }) => (
+      query.includes("UPDATE project_business_organizations") && query.includes("ELSE jit_domains END")
+    ))).toBe(true);
   });
 
   test("validates users and OAuth applications against the shared auth authority", async () => {


### PR DESCRIPTION
## Summary
- bind organization JIT domains with Bun SQL typed `TEXT[]` parameters
- preserve omitted update semantics while supporting explicit empty arrays
- add unit and PostgreSQL 18 regression coverage for empty, non-empty, escaped, and cleared arrays

## Verification
- `bun test tests/unit/project-organization.service.test.ts`
- PostgreSQL 18.4: `bun test tests/integration/project-organization-array-binding.test.ts`
- `bun run typecheck`
- `git diff --check`

Upstream prerequisite for SupAuth CNB issue #15.