### PR TITLE
fix(management-api): validate explicit organization slugs

### DIFF
--- a/packages/management-api/src/services/project-organization.service.ts
+++ b/packages/management-api/src/services/project-organization.service.ts
@@ -44,6 +44,7 @@ type OrganizationMemberMutation = {
 
 const MEMBER_ROLES = new Set(["member", "admin"]);
 const MAX_JIT_MEMBERSHIPS = 50;
+const ORGANIZATION_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const SENSITIVE_BRANDING_KEYS = new Set([
   "authorization",
   "cookie",
@@ -89,6 +90,13 @@ function normalizedSlug(value: string): string {
   const slug = value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
   if (slug.length < 2 || slug.length > 120) throw new ValidationError("slug must contain 2 to 120 URL-safe characters");
   return slug;
+}
+
+function validatedOrganizationSlug(value: string): string {
+  if (value.length < 2 || value.length > 120 || !ORGANIZATION_SLUG_PATTERN.test(value)) {
+    throw new ValidationError("slug must be 2 to 120 lowercase letters or numbers separated by single hyphens");
+  }
+  return value;
 }
 
 function hashToken(token: string): string {
@@ -323,7 +331,8 @@ export const projectOrganizationService = {
     if (!(await projectExists(ref))) throw new NotFoundError("Project", ref);
     const name = input.name.trim();
     if (!name) throw new ValidationError("name is required");
-    const slug = normalizedSlug(input.slug || name);
+    const explicitSlug = input.slug === undefined ? null : validatedOrganizationSlug(input.slug);
+    const slug = explicitSlug ?? normalizedSlug(name);
     validateBrandingValue(input.branding || {});
     const domains = [...new Set((input.jit_domains || []).map((item) => item.trim().toLowerCase()).filter(Boolean))];
     try {
@@ -360,7 +369,7 @@ export const projectOrganizationService = {
     await organizationOrThrow(ref, organizationId);
     const name = input.name?.trim();
     if (input.name !== undefined && !name) throw new ValidationError("name must not be empty");
-    const slug = input.slug !== undefined ? normalizedSlug(input.slug) : null;
+    const slug = input.slug === undefined ? null : validatedOrganizationSlug(input.slug);
     if (input.branding !== undefined) validateBrandingValue(input.branding);
     const domains = input.jit_domains === undefined
       ? null

--- a/packages/management-api/tests/unit/project-organization.service.test.ts
+++ b/packages/management-api/tests/unit/project-organization.service.test.ts
@@ -6,8 +6,14 @@ let controlQueries: Array<{ query: string; values: unknown[] }> = [];
 let storedMembers: Array<Record<string, unknown>> = [];
 let rejectOutboxInsert = false;
 let memberMutationVersion = 0;
+let projectExistsInControlDb = true;
+let organizationExistsInControlDb = true;
 const controlArray = mock((values: string[], type: string) => ({ values, type }));
 const transactionArray = mock((values: string[], type: string) => ({ values, type }));
+
+function organizationWriteQueries() {
+  return controlQueries.filter(({ query }) => /^\s*(?:INSERT|UPDATE|DELETE)\b/.test(query));
+}
 
 const authorityDb = mock((strings: TemplateStringsArray) => {
   const query = strings.join("?");
@@ -19,9 +25,13 @@ const authorityDb = mock((strings: TemplateStringsArray) => {
 const controlQuery = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
   const query = strings.join("?");
   controlQueries.push({ query, values });
-  if (query.includes("FROM projects")) return Promise.resolve([{ ref: "business-project" }]);
+  if (query.includes("FROM projects")) {
+    return Promise.resolve(projectExistsInControlDb ? [{ ref: "business-project" }] : []);
+  }
   if (query.includes("FROM project_business_organizations")) {
-    return Promise.resolve([{ id: "org-one", project_ref: "business-project" }]);
+    return Promise.resolve(organizationExistsInControlDb
+      ? [{ id: "org-one", project_ref: "business-project" }]
+      : []);
   }
   if (query.includes("INSERT INTO project_business_organizations")) {
     return Promise.resolve([{ id: "org-one", project_ref: "business-project", name: values[1], slug: values[2] }]);
@@ -142,10 +152,116 @@ describe("project organization GoTrue authority", () => {
     storedMembers = [];
     rejectOutboxInsert = false;
     memberMutationVersion = 0;
+    projectExistsInControlDb = true;
+    organizationExistsInControlDb = true;
     controlArray.mockClear();
     transactionArray.mockClear();
     transactionQuery.mockClear();
     config.authRuntimeOwnerRef = "auth-owner";
+  });
+
+  test("generates omitted create slugs and preserves valid explicit slugs", async () => {
+    const generated = await projectOrganizationService.create(
+      "business-project",
+      { name: "Generated Organization" },
+      "admin",
+    );
+    const explicit = await projectOrganizationService.create(
+      "business-project",
+      { name: "Explicit Organization", slug: "explicit-organization-2" },
+      "admin",
+    );
+    await projectOrganizationService.update(
+      "business-project",
+      "org-one",
+      { slug: "updated-organization-3" },
+    );
+
+    const organizationInserts = controlQueries.filter(({ query }) => (
+      query.includes("INSERT INTO project_business_organizations")
+    ));
+    const organizationUpdate = controlQueries.find(({ query }) => (
+      query.includes("UPDATE project_business_organizations")
+    ));
+    expect(generated.slug).toBe("generated-organization");
+    expect(explicit.slug).toBe("explicit-organization-2");
+    expect(organizationInserts.map(({ values }) => values[2])).toEqual([
+      "generated-organization",
+      "explicit-organization-2",
+    ]);
+    expect(organizationUpdate?.values[1]).toBe("updated-organization-3");
+  });
+
+  test("accepts explicit organization slugs at both length boundaries", async () => {
+    const validSlugs = ["ab", "a".repeat(120)];
+
+    for (const slug of validSlugs) {
+      await projectOrganizationService.create("business-project", { name: "Boundary", slug }, "admin");
+      await projectOrganizationService.update("business-project", "org-one", { slug });
+    }
+
+    const insertedSlugs = controlQueries
+      .filter(({ query }) => query.includes("INSERT INTO project_business_organizations"))
+      .map(({ values }) => values[2]);
+    const updatedSlugs = controlQueries
+      .filter(({ query }) => query.includes("UPDATE project_business_organizations"))
+      .map(({ values }) => values[1]);
+    expect(insertedSlugs).toEqual(validSlugs);
+    expect(updatedSlugs).toEqual(validSlugs);
+  });
+
+  test("rejects invalid explicit organization slugs before create or update writes", async () => {
+    const invalidSlugError = {
+      name: "ValidationError",
+      statusCode: 400,
+      code: "VALIDATION_ERROR",
+      message: "slug must be 2 to 120 lowercase letters or numbers separated by single hyphens",
+    };
+    const invalidSlugs = [
+      "",
+      "a",
+      "a".repeat(121),
+      "Uppercase",
+      "contains space",
+      "contains.dot",
+      "contains_underscore",
+      "-leading",
+      "trailing-",
+      "double--hyphen",
+    ];
+
+    for (const slug of invalidSlugs) {
+      await expect(projectOrganizationService.create(
+        "business-project",
+        { name: "Invalid slug", slug },
+        "admin",
+      )).rejects.toMatchObject(invalidSlugError);
+      await expect(projectOrganizationService.update(
+        "business-project",
+        "org-one",
+        { slug },
+      )).rejects.toMatchObject(invalidSlugError);
+      expect(organizationWriteQueries()).toEqual([]);
+    }
+  });
+
+  test("preserves not-found precedence over explicit slug validation", async () => {
+    projectExistsInControlDb = false;
+    await expect(projectOrganizationService.create(
+      "missing-project",
+      { name: "Missing project", slug: "Invalid" },
+      "admin",
+    )).rejects.toThrow("Project not found: missing-project");
+
+    projectExistsInControlDb = true;
+    organizationExistsInControlDb = false;
+    await expect(projectOrganizationService.update(
+      "business-project",
+      "missing-organization",
+      { slug: "Invalid" },
+    )).rejects.toThrow("Business organization not found: missing-organization");
+
+    expect(organizationWriteQueries()).toEqual([]);
   });
 
   test("binds omitted, empty, and normalized create domains as typed arrays", async () => {


### PR DESCRIPTION
## Summary

- keep generated slugs when create omits the slug field
- reject explicit create and update slugs unless they match the lowercase hyphenated contract and are 2 to 120 characters
- preserve valid explicit slugs unchanged, existing not-found precedence, and the typed PostgreSQL jit_domains array behavior

## Verification

- `bun test tests/unit/project-organization.service.test.ts` (14 tests, 63 assertions)
- `bun run typecheck`
- `bun test tests/unit/project-organizations.routes.test.ts` (7 tests, 27 assertions)
- PostgreSQL 18.4 `project-organization-array-binding.test.ts` (1 test, 5 assertions)
- `git diff --check`

External acceptance context: SupAuth CNB issue #15.
