### PR TITLE
fix(management-api): bind webhook event arrays

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -408,6 +408,12 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
         run: bun test tests/integration/project-organization-array-binding.test.ts
 
+      - name: Verify webhook array binding on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: bun test tests/integration/project-webhook-array-binding.test.ts
+
       - name: Verify Realtime payload safety on PostgreSQL 18
         working-directory: packages/management-api
         env:

--- a/packages/management-api/src/db/platform-v2.ts
+++ b/packages/management-api/src/db/platform-v2.ts
@@ -580,11 +580,12 @@ function normalizedLegacyWebhook(rawWebhook: LegacyWebhook): MigratedLegacyWebho
 
 async function persistLegacyWebhook(db: SQL, projectRef: string, webhook: MigratedLegacyWebhook): Promise<void> {
   const webhookId = crypto.randomUUID();
+  const eventArray = db.array(webhook.events, "TEXT");
   const [storedWebhook] = await db`
     INSERT INTO project_webhooks (
       id, project_ref, legacy_id, url, events, enabled, created_at, updated_at
     ) VALUES (
-      ${webhookId}, ${projectRef}, ${webhook.legacyId}, ${webhook.url}, ${webhook.events},
+      ${webhookId}, ${projectRef}, ${webhook.legacyId}, ${webhook.url}, ${eventArray},
       ${webhook.enabled}, ${webhook.createdAt}, ${webhook.updatedAt}
     )
     ON CONFLICT (project_ref, legacy_id) DO UPDATE SET legacy_id = EXCLUDED.legacy_id

--- a/packages/management-api/src/services/webhook-delivery.service.ts
+++ b/packages/management-api/src/services/webhook-delivery.service.ts
@@ -166,11 +166,12 @@ async function assertWebhookCapacity(database: SQL, projectRef: string): Promise
 }
 
 async function insertWebhookMetadata(database: SQL, input: NewWebhook): Promise<WebhookRow> {
+  const eventArray = database.array(input.events, "TEXT");
   const [webhookMetadata] = await database`
     INSERT INTO project_webhooks (
       id, project_ref, url, events, enabled, api_version, created_by
     ) VALUES (
-      ${input.id}, ${input.projectRef}, ${input.url}, ${input.events},
+      ${input.id}, ${input.projectRef}, ${input.url}, ${eventArray},
       ${input.enabled}, ${SIGNATURE_API_VERSION}, ${input.actor}
     ) RETURNING *
   ` as WebhookRow[];
@@ -405,9 +406,10 @@ export const webhookDeliveryService = {
     }
     const events = input.events === undefined ? current.events : normalizeEvents(input.events);
     if (events.length === 0) throw new ValidationError("events must not be empty");
+    const eventArray = sql.array(events, "TEXT");
     await sql`
       UPDATE project_webhooks SET
-        url = ${url}, events = ${events}, enabled = ${input.enabled ?? current.enabled}, updated_at = NOW()
+        url = ${url}, events = ${eventArray}, enabled = ${input.enabled ?? current.enabled}, updated_at = NOW()
       WHERE project_ref = ${ref} AND id = ${webhookId}
     `;
     return activePublicWebhook(ref, webhookId);

--- a/packages/management-api/tests/integration/project-webhook-array-binding.test.ts
+++ b/packages/management-api/tests/integration/project-webhook-array-binding.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { SQL, type ReservedSQL } from "bun";
+
+interface WebhookEventsRow {
+  events: string[];
+}
+
+const database = new SQL({
+  url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+  max: 1,
+});
+
+async function withRollback(operation: (transaction: ReservedSQL) => Promise<void>): Promise<void> {
+  const connection = await database.reserve();
+  await connection.unsafe("BEGIN");
+  try {
+    await operation(connection);
+  } finally {
+    await connection.unsafe("ROLLBACK");
+    connection.release();
+  }
+}
+
+async function insertEvents(transaction: ReservedSQL, fixtureId: string, events: string[]): Promise<string[]> {
+  const eventArray = transaction.array(events, "TEXT");
+  const [webhook] = await transaction<WebhookEventsRow[]>`
+    INSERT INTO project_webhook_array_binding (fixture_id, events)
+    VALUES (${fixtureId}, ${eventArray})
+    RETURNING events
+  `;
+  return webhook.events;
+}
+
+async function updateEvents(transaction: ReservedSQL, fixtureId: string, events: string[]): Promise<string[]> {
+  const eventArray = transaction.array(events, "TEXT");
+  const [webhook] = await transaction<WebhookEventsRow[]>`
+    UPDATE project_webhook_array_binding
+    SET events = ${eventArray}
+    WHERE fixture_id = ${fixtureId}
+    RETURNING events
+  `;
+  return webhook.events;
+}
+
+afterAll(async () => {
+  await database.close();
+}, 30_000);
+
+describe("project webhook TEXT[] binding", () => {
+  test("round trips single, multiple, wildcard, and escaped event arrays", async () => {
+    await withRollback(async (transaction) => {
+      await transaction`
+        CREATE TEMPORARY TABLE project_webhook_array_binding (
+          fixture_id TEXT PRIMARY KEY,
+          events TEXT[] NOT NULL
+        ) ON COMMIT DROP
+      `;
+
+      expect(await insertEvents(transaction, "single", ["user.created"]))
+        .toEqual(["user.created"]);
+      expect(await insertEvents(transaction, "multiple", ["user.created", "organization.updated"]))
+        .toEqual(["user.created", "organization.updated"]);
+      expect(await insertEvents(transaction, "wildcard", ["*"])).toEqual(["*"]);
+      expect(await insertEvents(transaction, "escaped", ["comma,event", "back\\slash.event"]))
+        .toEqual(["comma,event", "back\\slash.event"]);
+      expect(await updateEvents(transaction, "single", ["organization.created", "organization.deleted"]))
+        .toEqual(["organization.created", "organization.deleted"]);
+    });
+  }, 30_000);
+});

--- a/packages/management-api/tests/unit/platform-v2.migration.test.ts
+++ b/packages/management-api/tests/unit/platform-v2.migration.test.ts
@@ -16,8 +16,14 @@ type ProjectState = {
 
 function migrationDatabase(project: ProjectState) {
   const storedSecrets: Array<{ scope: string; name: string; encrypted: string }> = [];
-  const storedWebhooks: Array<{ id: string; legacyId: string; secretEncrypted?: string | null }> = [];
-  const database = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+  const storedWebhooks: Array<{
+    id: string;
+    legacyId: string;
+    eventBinding: unknown;
+    secretEncrypted?: string | null;
+  }> = [];
+  const databaseArray = mock((values: string[], type: string) => ({ values, type }));
+  const databaseQuery = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
     const query = strings.join("?");
     if (query.includes("SELECT ref, config")) return Promise.resolve([{ ...project }]);
     if (query.includes("INSERT INTO project_control_secrets")) {
@@ -38,12 +44,17 @@ function migrationDatabase(project: ProjectState) {
       return Promise.resolve(Array.isArray(config.webhooks) ? [{ ...project }] : []);
     }
     if (query.includes("INSERT INTO project_webhooks")) {
-      storedWebhooks.push({ id: String(values[0]), legacyId: String(values[2]) });
+      storedWebhooks.push({
+        id: String(values[0]),
+        legacyId: String(values[2]),
+        eventBinding: values[4],
+      });
       return Promise.resolve([{ id: values[0] }]);
     }
     return Promise.resolve([]);
   });
-  return { database: database as unknown as SQL, storedSecrets, storedWebhooks };
+  const database = Object.assign(databaseQuery, { array: databaseArray });
+  return { database: database as unknown as SQL, databaseArray, storedSecrets, storedWebhooks };
 }
 
 describe("platform v2 migrations", () => {
@@ -60,7 +71,7 @@ describe("platform v2 migrations", () => {
         webhooks: [{ id: "legacy-webhook", url: "https://hooks.example.test", events: ["user.created"], secret: "webhook-secret" }],
       },
     };
-    const { database, storedSecrets, storedWebhooks } = migrationDatabase(project);
+    const { database, databaseArray, storedSecrets, storedWebhooks } = migrationDatabase(project);
 
     expect(await migrateLegacyControlSecrets(database)).toBe(3);
     expect(typeof project.config).toBe("object");
@@ -80,6 +91,8 @@ describe("platform v2 migrations", () => {
     expect(typeof project.config).toBe("object");
     expect((project.config as Record<string, unknown>).webhooks).toBeUndefined();
     expect(storedWebhooks).toHaveLength(1);
+    expect(databaseArray).toHaveBeenCalledWith(["user.created"], "TEXT");
+    expect(storedWebhooks[0]?.eventBinding).toEqual({ values: ["user.created"], type: "TEXT" });
     expect(storedWebhooks[0]?.secretEncrypted).toBeUndefined();
     expect(storedSecrets.at(-1)).toMatchObject({ scope: "webhook" });
     expect(storedSecrets.at(-1)?.encrypted).toStartWith("enc:v1:");

--- a/packages/management-api/tests/unit/webhook-delivery.service.test.ts
+++ b/packages/management-api/tests/unit/webhook-delivery.service.test.ts
@@ -7,6 +7,8 @@ let persistedQueries: Array<{ text: string; values: unknown[] }> = [];
 let unfinishedOutboxCount = 0;
 let matchingSubscriptionCount = 1;
 let managedSecretAvailable = true;
+const transactionArray = mock((values: string[], type: string) => ({ values, type }));
+const controlArray = mock((values: string[], type: string) => ({ values, type }));
 
 const webhookRow = {
   id: "11111111-1111-4111-8111-111111111111",
@@ -42,7 +44,7 @@ const originalDelivery = {
   api_version: "2026-07-01",
 };
 
-const txMock = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
+const transactionQuery = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
   const text = strings.join("?");
   persistedQueries.push({ text, values });
   if (text.includes("FROM webhook_outbox") && text.includes("FOR UPDATE")) return Promise.resolve([claimed()]);
@@ -67,6 +69,7 @@ const txMock = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
   if (text.includes("UPDATE project_webhooks")) return Promise.resolve([{ id: webhookRow.id, deleted_at: new Date() }]);
   return Promise.resolve([]);
 });
+const txMock = Object.assign(transactionQuery, { array: transactionArray });
 const sqlQueryMock = mock((strings: TemplateStringsArray, ...values: unknown[]) => {
   const text = strings.join("?");
   persistedQueries.push({ text, values });
@@ -83,6 +86,7 @@ const sqlQueryMock = mock((strings: TemplateStringsArray, ...values: unknown[]) 
   return Promise.resolve([]);
 });
 const sqlMock = Object.assign(sqlQueryMock, {
+  array: controlArray,
   begin: mock((callback: (tx: typeof txMock) => Promise<unknown>) => callback(txMock)),
 });
 
@@ -112,7 +116,9 @@ describe("durable webhook delivery processing", () => {
     matchingSubscriptionCount = 1;
     managedSecretAvailable = true;
     txMock.mockClear();
+    transactionArray.mockClear();
     sqlQueryMock.mockClear();
+    controlArray.mockClear();
     sqlMock.begin.mockClear();
   });
 
@@ -147,6 +153,8 @@ describe("durable webhook delivery processing", () => {
     expect(created).not.toHaveProperty("secret");
     const webhookInsert = persistedQueries.find(({ text }) => text.includes("INSERT INTO project_webhooks"));
     expect(webhookInsert?.text).not.toContain("secret_encrypted");
+    expect(transactionArray).toHaveBeenCalledWith(["user.created"], "TEXT");
+    expect(webhookInsert?.values).toContainEqual({ values: ["user.created"], type: "TEXT" });
     const managedInsert = persistedQueries.find(({ text }) => text.includes("INSERT INTO project_control_secrets"));
     expect(managedInsert?.values).toContain("webhook");
     expect(managedInsert?.values.some((storedValue) => String(storedValue).startsWith("encrypted:whsec_"))).toBe(true);
@@ -157,6 +165,41 @@ describe("durable webhook delivery processing", () => {
     expect(rotated).not.toHaveProperty("secret");
     expect(persistedQueries.some(({ text }) => text.includes("previous_secret_encrypted"))).toBe(false);
     expect(persistedQueries.some(({ text }) => text.includes("INSERT INTO project_control_secrets"))).toBe(true);
+  });
+
+  test("updates webhook events with a typed array binding", async () => {
+    await webhookDeliveryService.updateWebhook("proj_1", webhookRow.id, {
+      events: ["user.created", "organization.created"],
+    });
+
+    expect(controlArray).toHaveBeenCalledWith(["user.created", "organization.created"], "TEXT");
+    const webhookUpdate = persistedQueries.find(({ text }) => (
+      text.includes("UPDATE project_webhooks") && text.includes("events =")
+    ));
+    expect(webhookUpdate?.values).toContainEqual({
+      values: ["user.created", "organization.created"],
+      type: "TEXT",
+    });
+  });
+
+  test("preserves and binds stored events when events are omitted", async () => {
+    await webhookDeliveryService.updateWebhook("proj_1", webhookRow.id, { enabled: false });
+
+    expect(controlArray).toHaveBeenCalledWith(webhookRow.events, "TEXT");
+    const webhookUpdate = persistedQueries.find(({ text }) => text.includes("UPDATE project_webhooks"));
+    expect(webhookUpdate?.text).toContain("events =");
+    expect(webhookUpdate?.values).toContainEqual({ values: webhookRow.events, type: "TEXT" });
+  });
+
+  test("rejects empty webhook events before binding or updating", async () => {
+    await expect(webhookDeliveryService.updateWebhook(
+      "proj_1",
+      webhookRow.id,
+      { events: [] },
+    )).rejects.toThrow("events must not be empty");
+
+    expect(controlArray).not.toHaveBeenCalled();
+    expect(persistedQueries.some(({ text }) => text.includes("UPDATE project_webhooks"))).toBe(false);
   });
 
   test("reports managed secret status without reading or exposing the value", async () => {


### PR DESCRIPTION
## Summary

- bind webhook event arrays with Bun SQL typed `TEXT[]` values on create, update, and legacy migration writes
- preserve webhook validation, managed-secret transaction, rotation, and soft-delete contracts
- add unit coverage plus a PostgreSQL 18 array round-trip regression and CI gate

## Verification

- `bun test tests/unit/webhook-delivery.service.test.ts` (15 pass)
- `bun test tests/unit/platform-v2.migration.test.ts` (10 pass)
- `bun test tests/unit/project-webhooks.routes.test.ts` (9 pass)
- `bun run typecheck`
- PostgreSQL 18.4: `project-webhook-array-binding.test.ts` (1 pass, 5 assertions)
- PostgreSQL 18.4: `project-organization-array-binding.test.ts` (1 pass, 5 assertions)
- `bun run build:amd64`
- workflow YAML parse and `git diff --check`

## Scope

Upstream Management API fix for SupAuth CNB issue #18. No deployment or issue-state change is included.