### PR TITLE
fix(task-worker): re-queue failed provisioning tasks and continue pipeline after realtime failure

### DIFF
--- a/packages/management-api/src/services/task.worker.ts
+++ b/packages/management-api/src/services/task.worker.ts
@@ -402,29 +402,32 @@ export class TaskWorker {
     private async handleTaskFailure(task: ProjectTask) {
         const { project_ref, task_type, retries } = task;
 
-        // Cleanup tasks get more retries (10) to ensure resources are freed
-        const maxRetries = task_type.startsWith("cleanup_") ? 10 : 3;
-
-        if (retries < maxRetries) {
-            logger.warn(`[TaskWorker] Task ${task_type} for ${project_ref} failed but has retries left (${retries}/${maxRetries})`);
-            // Re-queue cleanup tasks with exponential backoff via a new pending task
-            if (task_type.startsWith("cleanup_") && retries >= 3) {
-                logger.info(`[TaskWorker] Re-queuing cleanup task ${task_type} for ${project_ref} (retry ${retries + 1})`);
-                await taskRepository.createTask(project_ref, task_type, task.payload);
-            }
-            return;
-        }
-
-        logger.error(`[TaskWorker] Saga compensation triggered for ${project_ref} failed permanently at ${task_type}`);
-
+        // Realtime is optional for the current tenant model. Preserve DB/runtime
+        // and continue the remaining provisioning pipeline instead of blocking on
+        // retries or destroying the tenant database after a later-stage addon failure.
         if (task_type === "provision_realtime") {
-            // Realtime is optional for the current tenant model. Preserve DB/runtime
-            // and continue the remaining provisioning pipeline instead of destroying
-            // the tenant database after a later-stage addon failure.
             logger.warn(`[TaskWorker] Realtime provisioning failed for ${project_ref}. Preserving core resources and continuing without realtime.`);
             await taskRepository.createTask(project_ref, "provision_router");
             return;
         }
+
+        // Cleanup tasks get more retries (10) to ensure resources are freed
+        const maxRetries = task_type.startsWith("cleanup_") ? 10 : 3;
+
+        if (retries < maxRetries) {
+            // Re-queue the failed task with exponential backoff so it is actually
+            // retried. Without this the task stays in FAILED forever and the saga
+            // compensation below is never reached, stalling the whole pipeline.
+            const baseDelayMs = 5_000;
+            const cappedAttempt = Math.min(Math.max(retries, 1), 6);
+            const nextRunAt = new Date(Date.now() + baseDelayMs * Math.pow(2, cappedAttempt - 1));
+            logger.warn(`[TaskWorker] Task ${task_type} for ${project_ref} failed, scheduling retry ${retries + 1}/${maxRetries} at ${nextRunAt.toISOString()}`);
+            await taskRepository.scheduleRetry(task.id, task.error || "Task execution failed", nextRunAt);
+            broadcastTaskUpdate({ taskId: task.id, projectRef: project_ref, taskType: task_type, status: TaskStatus.RETRY_SCHEDULED, error: task.error || "Task execution failed" });
+            return;
+        }
+
+        logger.error(`[TaskWorker] Saga compensation triggered for ${project_ref} failed permanently at ${task_type}`);
 
         // Mark project as paused/error (Only for critical creation tasks)
         if (task_type === "provision_db" || task_type === "provision_s3" || task_type === "provision_runtime") {

--- a/packages/management-api/tests/unit/task.worker.test.ts
+++ b/packages/management-api/tests/unit/task.worker.test.ts
@@ -51,13 +51,40 @@ describe("TaskWorker failure handling", () => {
       status: "failed",
       payload: {},
       error: "boom",
-      retries: 3,
+      retries: 1,
       created_at: new Date(),
       updated_at: new Date(),
     });
 
+    // Realtime is optional: failure continues the pipeline immediately regardless of retry budget
     expect(createTaskSpy).toHaveBeenCalledTimes(1);
     expect(createTaskSpy).toHaveBeenCalledWith("proj-ref", "provision_router");
+    expect(updateStatusSpy).not.toHaveBeenCalled();
+  });
+
+  test("provision failure with retries left schedules a retry instead of stalling", async () => {
+    const worker = new TaskWorker();
+    const scheduleRetrySpy = spyOn(taskRepository, "scheduleRetry").mockResolvedValue({} as any);
+    const createTaskSpy = spyOn(taskRepository, "createTask").mockResolvedValue({} as any);
+    const updateStatusSpy = spyOn(projectRepository, "updateStatus").mockResolvedValue(undefined as any);
+
+    await (worker as any).handleTaskFailure({
+      id: "task-retry-1",
+      project_ref: "proj-ref",
+      task_type: "provision_router",
+      status: "failed",
+      payload: {},
+      error: "boom",
+      retries: 1,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    expect(scheduleRetrySpy).toHaveBeenCalledTimes(1);
+    expect(scheduleRetrySpy.mock.calls[0][0]).toBe("task-retry-1");
+    expect(scheduleRetrySpy.mock.calls[0][2]).toBeInstanceOf(Date);
+    // Must not trigger saga compensation while retries remain
+    expect(createTaskSpy).not.toHaveBeenCalled();
     expect(updateStatusSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Problem

Project provisioning stalls permanently at the first transient task failure. On the test server, the Zhiji project `jbknfiwdgbatcxfbiopo` is stuck in `creating` because `provision_realtime` failed, and the pipeline never proceeds to `provision_router` → `provision_gateway` → `provision_secrets`. The configured `studio-zhiji.xai.xigu.team` / `api-zhiji.xai.xigu.team` routes are therefore never established.

## Root cause

`TaskWorker.handleTaskFailure` has two defects:

1. **Retries never happen.** When `retries < maxRetries`, the handler only logs a warning and returns. The task stays in `FAILED` (set by `markTaskFailed`), and since `claimNextTask` only picks up `PENDING` / `RETRY_SCHEDULED` tasks, the failed task is never re-claimed. The saga compensation branch (`retries >= maxRetries`) is unreachable, so the pipeline is permanently stuck.
2. **Realtime blocks the pipeline.** `provision_realtime` failure only continues to `provision_router` after exhausting all retries. Realtime is optional, so this needlessly blocks on a deterministic failure (e.g. the `realtime.apply_rls` signature conflict from realtime v2.121.0 migrations).

## Fix

- Call `taskRepository.scheduleRetry` with exponential backoff when retries remain, so the task is actually re-queued (`RETRY_SCHEDULED`) and re-claimed by the worker. This mirrors the retry path already used by `background-function-worker`.
- Move `provision_realtime` handling to the top of `handleTaskFailure` so the pipeline continues to `provision_router` immediately, regardless of the retry budget.

## Testing

- `bun test tests/unit/task.worker.test.ts` → 6 pass / 0 fail
- `tsc --noEmit` → clean
- Existing realtime test updated to `retries: 1` (continues immediately); new test asserts a retryable provision failure calls `scheduleRetry` without triggering saga compensation.