### PR TITLE
fix(task-worker): avoid transient FAILED state for retryable task failures

### DIFF
--- a/packages/management-api/src/services/task.worker.ts
+++ b/packages/management-api/src/services/task.worker.ts
@@ -134,8 +134,6 @@ export class TaskWorker {
                 broadcastTaskUpdate({ taskId: task.id, projectRef: task.project_ref, taskType: task.task_type, status: TaskStatus.SUCCEEDED });
                 await this.handleTaskCompletion(task);
             } else {
-                await taskRepository.markTaskFailed(task.id, "Task execution failed");
-                broadcastTaskUpdate({ taskId: task.id, projectRef: task.project_ref, taskType: task.task_type, status: TaskStatus.FAILED, error: "Task execution failed" });
                 await this.handleTaskFailure(task);
             }
         } catch (err: unknown) {
@@ -401,11 +399,13 @@ export class TaskWorker {
 
     private async handleTaskFailure(task: ProjectTask) {
         const { project_ref, task_type, retries } = task;
+        const failureMessage = "Task execution failed";
 
         // Realtime is optional for the current tenant model. Preserve DB/runtime
         // and continue the remaining provisioning pipeline instead of blocking on
         // retries or destroying the tenant database after a later-stage addon failure.
         if (task_type === "provision_realtime") {
+            await this.recordTerminalFailure(task, failureMessage);
             logger.warn(`[TaskWorker] Realtime provisioning failed for ${project_ref}. Preserving core resources and continuing without realtime.`);
             await taskRepository.createTask(project_ref, "provision_router");
             return;
@@ -422,11 +422,12 @@ export class TaskWorker {
             const cappedAttempt = Math.min(Math.max(retries, 1), 6);
             const nextRunAt = new Date(Date.now() + baseDelayMs * Math.pow(2, cappedAttempt - 1));
             logger.warn(`[TaskWorker] Task ${task_type} for ${project_ref} failed, scheduling retry ${retries + 1}/${maxRetries} at ${nextRunAt.toISOString()}`);
-            await taskRepository.scheduleRetry(task.id, task.error || "Task execution failed", nextRunAt);
-            broadcastTaskUpdate({ taskId: task.id, projectRef: project_ref, taskType: task_type, status: TaskStatus.RETRY_SCHEDULED, error: task.error || "Task execution failed" });
+            await taskRepository.scheduleRetry(task.id, failureMessage, nextRunAt);
+            broadcastTaskUpdate({ taskId: task.id, projectRef: project_ref, taskType: task_type, status: TaskStatus.RETRY_SCHEDULED, error: failureMessage });
             return;
         }
 
+        await this.recordTerminalFailure(task, failureMessage);
         logger.error(`[TaskWorker] Saga compensation triggered for ${project_ref} failed permanently at ${task_type}`);
 
         // Mark project as paused/error (Only for critical creation tasks)
@@ -449,6 +450,17 @@ export class TaskWorker {
             // Admin can manually troubleshoot and retry, or trigger cleanup via API
             logger.warn(`[TaskWorker] ${task_type} failed for ${project_ref}. DB and S3 resources preserved for manual intervention.`);
         }
+    }
+
+    private async recordTerminalFailure(task: ProjectTask, failureMessage: string): Promise<void> {
+        await taskRepository.markTaskFailed(task.id, failureMessage);
+        broadcastTaskUpdate({
+            taskId: task.id,
+            projectRef: task.project_ref,
+            taskType: task.task_type,
+            status: TaskStatus.FAILED,
+            error: failureMessage,
+        });
     }
 }
 

--- a/packages/management-api/tests/unit/task.worker.test.ts
+++ b/packages/management-api/tests/unit/task.worker.test.ts
@@ -1,9 +1,47 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type { ProjectTask } from "../../src/db";
+import { TaskStatus } from "../../src/db";
 import { taskRepository } from "../../src/repositories/task.repository";
 import { projectRepository } from "../../src/repositories/project.repository";
 import { TaskWorker } from "../../src/services/task.worker";
 import { databaseService } from "../../src/services/database.service";
 import { jwtService } from "../../src/services/jwt.service";
+import * as wsModule from "../../src/routes/ws";
+
+function failedTask(overrides: Partial<ProjectTask> = {}): ProjectTask {
+  const now = new Date();
+  return {
+    id: "task-retry-1",
+    project_ref: "proj-ref",
+    task_type: "provision_router",
+    status: TaskStatus.FAILED,
+    payload: {},
+    error: "Task execution failed",
+    retries: 1,
+    attempt: 1,
+    max_attempts: 3,
+    next_run_at: null,
+    lease_until: null,
+    started_at: now,
+    completed_at: null,
+    timeout_sec: null,
+    idempotency_key: null,
+    trace_id: null,
+    cancel_requested_at: null,
+    cancellation_reason: null,
+    correlation_id: null,
+    business_task_id: null,
+    invoker_user_id: null,
+    auth_authority_ref: "proj-ref",
+    metadata: null,
+    function_slug: null,
+    function_version: null,
+    result: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
 
 describe("TaskWorker delayed retry wakeup", () => {
   afterEach(() => {
@@ -41,6 +79,7 @@ describe("TaskWorker failure handling", () => {
 
   test("provision_realtime failure preserves project resources and continues provisioning", async () => {
     const worker = new TaskWorker();
+    const markTaskFailedSpy = spyOn(taskRepository, "markTaskFailed").mockResolvedValue(null);
     const createTaskSpy = spyOn(taskRepository, "createTask").mockResolvedValue({} as any);
     const updateStatusSpy = spyOn(projectRepository, "updateStatus").mockResolvedValue(undefined as any);
 
@@ -59,37 +98,68 @@ describe("TaskWorker failure handling", () => {
     // Realtime is optional: failure continues the pipeline immediately regardless of retry budget
     expect(createTaskSpy).toHaveBeenCalledTimes(1);
     expect(createTaskSpy).toHaveBeenCalledWith("proj-ref", "provision_router");
+    expect(markTaskFailedSpy).toHaveBeenCalledWith("task-1", "Task execution failed");
     expect(updateStatusSpy).not.toHaveBeenCalled();
   });
 
   test("provision failure with retries left schedules a retry instead of stalling", async () => {
+    const task = failedTask();
     const worker = new TaskWorker();
-    const scheduleRetrySpy = spyOn(taskRepository, "scheduleRetry").mockResolvedValue({} as any);
-    const createTaskSpy = spyOn(taskRepository, "createTask").mockResolvedValue({} as any);
-    const updateStatusSpy = spyOn(projectRepository, "updateStatus").mockResolvedValue(undefined as any);
+    const workerHarness = worker as unknown as {
+      handleTaskFailure(task: ProjectTask): Promise<void>;
+    };
+    const markTaskFailedSpy = spyOn(taskRepository, "markTaskFailed").mockResolvedValue(null);
+    const scheduleRetrySpy = spyOn(taskRepository, "scheduleRetry").mockResolvedValue(task);
+    const createTaskSpy = spyOn(taskRepository, "createTask").mockResolvedValue(task);
+    const updateStatusSpy = spyOn(projectRepository, "updateStatus").mockResolvedValue(null);
+    const beforeRetry = Date.now();
 
-    await (worker as any).handleTaskFailure({
-      id: "task-retry-1",
-      project_ref: "proj-ref",
-      task_type: "provision_router",
-      status: "failed",
-      payload: {},
-      error: "boom",
-      retries: 1,
-      created_at: new Date(),
-      updated_at: new Date(),
-    });
+    await workerHarness.handleTaskFailure(task);
 
     expect(scheduleRetrySpy).toHaveBeenCalledTimes(1);
     expect(scheduleRetrySpy.mock.calls[0][0]).toBe("task-retry-1");
-    expect(scheduleRetrySpy.mock.calls[0][2]).toBeInstanceOf(Date);
+    expect(scheduleRetrySpy.mock.calls[0][1]).toBe("Task execution failed");
+    expect(scheduleRetrySpy.mock.calls[0][2].getTime()).toBeGreaterThanOrEqual(beforeRetry + 5_000);
+    expect(scheduleRetrySpy.mock.calls[0][2].getTime()).toBeLessThanOrEqual(Date.now() + 5_000);
     // Must not trigger saga compensation while retries remain
+    expect(markTaskFailedSpy).not.toHaveBeenCalled();
     expect(createTaskSpy).not.toHaveBeenCalled();
     expect(updateStatusSpy).not.toHaveBeenCalled();
   });
 
+  test("retryable poll failure transitions directly to retry_scheduled", async () => {
+    const task = failedTask();
+    const worker = new TaskWorker();
+    const workerHarness = worker as unknown as {
+      isRunning: boolean;
+      poll(): Promise<void>;
+      executeTask(task: ProjectTask): Promise<boolean>;
+    };
+    workerHarness.isRunning = true;
+
+    spyOn(taskRepository, "claimNextTask").mockResolvedValue(task);
+    spyOn(taskRepository, "markTaskRunning").mockResolvedValue(task);
+    const markTaskFailedSpy = spyOn(taskRepository, "markTaskFailed").mockResolvedValue(task);
+    const scheduleRetrySpy = spyOn(taskRepository, "scheduleRetry").mockResolvedValue({
+      ...task,
+      status: TaskStatus.RETRY_SCHEDULED,
+    });
+    spyOn(workerHarness, "executeTask").mockResolvedValue(false);
+    const broadcastTaskUpdateSpy = spyOn(wsModule, "broadcastTaskUpdate").mockImplementation(() => {});
+
+    await workerHarness.poll();
+
+    expect(markTaskFailedSpy).not.toHaveBeenCalled();
+    expect(scheduleRetrySpy).toHaveBeenCalledTimes(1);
+    expect(broadcastTaskUpdateSpy.mock.calls.map(([update]) => update.status)).toEqual([
+      TaskStatus.RUNNING,
+      TaskStatus.RETRY_SCHEDULED,
+    ]);
+  });
+
   test("provision_runtime failure still rolls back runtime, storage, and database", async () => {
     const worker = new TaskWorker();
+    const markTaskFailedSpy = spyOn(taskRepository, "markTaskFailed").mockResolvedValue(null);
     const createTaskSpy = spyOn(taskRepository, "createTask").mockResolvedValue({} as any);
     const updateStatusSpy = spyOn(projectRepository, "updateStatus").mockResolvedValue(undefined as any);
 
@@ -105,6 +175,7 @@ describe("TaskWorker failure handling", () => {
       updated_at: new Date(),
     });
 
+    expect(markTaskFailedSpy).toHaveBeenCalledWith("task-2", "Task execution failed");
     expect(updateStatusSpy).toHaveBeenCalledWith("proj-ref", "paused");
     expect(createTaskSpy.mock.calls.map((call) => call[1])).toEqual([
       "cleanup_runtime",


### PR DESCRIPTION
## 背景

PR #720 审查中发现一个真实问题（独立 verifier 判为 P1）：`poll()` 在失败处理时先把任务持久化并广播为终态 `FAILED`，随后才调用 `scheduleRetry` 改为 `RETRY_SCHEDULED`。后果：

- 等待重试的任务携带终态 `completed_at` 时间戳
- 订阅者会收到一次伪终态失败事件（之后又是 retry），状态机不自洽

#720 已先行合并，本 PR 作为后续修复。

## 变更

- 可重试失败直接从 `RUNNING` 进入 `RETRY_SCHEDULED`，只广播 retry，不再经过终态 `FAILED`
- 终态 `FAILED` 的持久化/广播保留给：重试预算耗尽、Realtime 可选能力降级（继续 pipeline）
- 补充完整 `poll()` 路径回归测试（此前直接调私有方法的测试捕获不到该问题）

## 验证

- `bun test tests/unit/task.worker.test.ts` 7/7 通过
- `tsc --noEmit` 通过
- `git diff --check` 通过