### PR TITLE
fix(management-api): tolerate bigint version columns in migration ledger

### DIFF
--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -686,13 +686,13 @@ async function findExistingMigration(
     return tx<Record<string, unknown>[]>`
       SELECT version, statements, name, checksum
       FROM supabase_migrations.schema_migrations
-      WHERE version = ${input.version} OR name = ${input.name}
+      WHERE version::text = ${input.version} OR name = ${input.name}
     `;
   }
   return tx<Record<string, unknown>[]>`
     SELECT version, statements, name, checksum
     FROM supabase_migrations.schema_migrations
-    WHERE version = ${input.version}
+    WHERE version::text = ${input.version}
   `;
 }
 

--- a/packages/management-api/src/services/project-migration-role.ts
+++ b/packages/management-api/src/services/project-migration-role.ts
@@ -64,11 +64,13 @@ export function renderProjectMigrationRoleSql(dbName: string, dbUser: string): s
       INSERT INTO supabase_migrations.schema_migrations
         (version, statements, name, checksum, inserted_at)
       VALUES
-        (migration_version, migration_statements, migration_name, migration_checksum, applied_at);
+        -- 线上台账表的 version 可能是 bigint（Supabase CLI 约定）或 text，
+        -- ::bigint 在两种列类型下均可写入（bigint→text 为赋值转换）。
+        (migration_version::bigint, migration_statements, migration_name, migration_checksum, applied_at);
       INSERT INTO public.schema_migrations
         (version, statements, name, checksum, inserted_at)
       VALUES
-        (migration_version, migration_statements, migration_name, migration_checksum, applied_at);
+        (migration_version::bigint, migration_statements, migration_name, migration_checksum, applied_at);
     END
     $record_migration$;
     REVOKE ALL ON FUNCTION supabase_migrations.record_schema_migration(TEXT, TEXT[], TEXT, TEXT, TEXT)


### PR DESCRIPTION
## 问题

项目库中 `supabase_migrations.schema_migrations.version` 为 **bigint**（Supabase CLI 约定）时，`POST /v1/projects/:ref/database/migrations` 全流程失败：

```
{"message":"Migration failed","detail":"operator does not exist: bigint = text"}
```

noop 迁移（`CREATE TABLE IF NOT EXISTS`）同样失败，即该端点对这类项目库完全不可用，所有项目迁移被阻断。实际影响：seagoo-ai 的 `20260806120000_fix_unsupported_llm_model_alias` 迁移无法应用。

## 根因

- `findExistingMigration` 用 `WHERE version = ${input.version}`（text 参数）比较 bigint 列 → 42883
- `record_schema_migration` 向 bigint 列插入 text 版本值也会在下一步失败

## 修复

- `findExistingMigration` 改为 `version::text = ${...}`，兼容 text/bigint 两种列类型
- `record_schema_migration` 插入时 `migration_version::bigint`（bigint 列直接匹配；text 列经赋值转换兼容）

## 验证

- `tests/unit/project-migration-role`、`migration-ledger(-lease)`、`database-migration-baseline.routes`、`migration-lock`、`database-routes`、`sql-policy`、`supabase-schema`、`migration-promotion`、`sql-query-execution` 逐文件全过（0 fail）
- 注：`project-migration-role + migration-ledger*` 等多文件组合并跑时在 HEAD 上同样存在既有失败（模块隔离问题），与本改动无关（HEAD 复现一致）