### PR TITLE
fix(management-api): make ledger reconcile type-agnostic for bigint version columns

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -23,6 +23,13 @@ Edge Function .logs
 - 内置采集器在持久化前只保留日志正文、时间与 systemd unit，并脱敏 Authorization、Cookie、JWT、token 和数据库 DSN；不得绕过该采集器直接写入日志库。
 - 采集游标和函数文件偏移保存于 `/var/lib/supacloud/log-collector/state.json`。写入成功后才前移游标；管理进程重启会从该位置续传。首次启用只回填最近 15 分钟 journald 和每个函数日志文件末尾最多 1 MiB，避免意外全量回灌。
 
+## Grafana 子路径服务
+
+管理 API 通过公网 `/grafana` 前缀反向代理 Grafana（`GRAFANA_URL`，默认 `http://127.0.0.1:3000/grafana`）。Grafana 必须以相同子路径提供服务，否则其 HTML 中的 `<base href>` 与静态资源 URL 会指向错误前缀，出现 "Grafana has failed to load its application files" 与连续 404。
+
+- `grafana.ini` 必须设置 `root_url = https://<studio 域名>/grafana/` 且 `serve_from_sub_path = true`。
+- 安装器在 Pigsty 安装完成后自动写入上述配置（`configure_grafana_subpath`），并同步修补 Pigsty 的 `grafana.ini.j2` 模板，避免 infra playbook 重跑后回退到 Pigsty 默认的 `/ui/`。
+
 ## 默认配置
 
 `config.env` 中的默认值：

--- a/install.sh
+++ b/install.sh
@@ -2431,6 +2431,40 @@ install_pigsty() {
         log_info "Skipping Pigsty legacy Supabase compose stack; SupaCloud uses multi-project runtime services."
         run_legacy_supabase_compose_migration_if_requested
     fi
+
+    configure_grafana_subpath
+}
+
+# ========== Configure Grafana Subpath ==========
+# The management API reverse-proxies Grafana under the public /grafana prefix,
+# so Grafana must serve from that same subpath (root_url + serve_from_sub_path).
+# Pigsty renders grafana.ini from a template that hardcodes root_url = /ui/;
+# patch both the live config and the template so playbook re-runs do not revert it.
+configure_grafana_subpath() {
+    log_step "Configuring Grafana subpath serving..."
+
+    local root_url="/grafana/"
+    if [[ -n "${SUPABASE_STUDIO_DOMAIN:-}" ]]; then
+        root_url="https://${SUPABASE_STUDIO_DOMAIN}/grafana/"
+    fi
+
+    local grafana_ini="/etc/grafana/grafana.ini"
+    local grafana_template="${HOME}/pigsty/roles/infra/templates/grafana/grafana.ini.j2"
+    local target
+    for target in "$grafana_template" "$grafana_ini"; do
+        [[ -f "$target" ]] || continue
+        sed -i "s|^root_url = .*|root_url = ${root_url}|" "$target"
+        if grep -q "^serve_from_sub_path" "$target"; then
+            sed -i "s|^serve_from_sub_path = .*|serve_from_sub_path = true|" "$target"
+        else
+            sed -i "/^root_url = /a serve_from_sub_path = true" "$target"
+        fi
+    done
+
+    if [[ -f "$grafana_ini" ]] && systemctl is-active --quiet grafana-server; then
+        systemctl restart grafana-server || log_warn "grafana-server restart failed after subpath configuration"
+    fi
+    log_info "Grafana root_url set to ${root_url} with serve_from_sub_path=true"
 }
 
 # ========== Update Pigsty Configuration ==========
@@ -2796,7 +2830,7 @@ save_all_credentials() {
         POSTGRES_DB postgres \
         POSTGRES_USER postgres \
         POSTGRES_PASSWORD "$POSTGRES_PASSWORD" \
-        GRAFANA_URL "http://${INTERNAL_IP}:3000" \
+        GRAFANA_URL "http://${INTERNAL_IP}:3000/grafana" \
         GRAFANA_USER admin \
         GRAFANA_PASSWORD "${GRAFANA_PASSWORD:-pigsty}" \
         JWT_SECRET "$JWT_SECRET" \
@@ -3248,6 +3282,7 @@ install_management_api() {
         PIGSTY_PATH "${HOME}/pigsty" \
         BASE_DOMAIN "$BASE_DOMAIN_VALUE" \
         INTERNAL_IP "$INTERNAL_IP" \
+        GRAFANA_URL "http://127.0.0.1:3000/grafana" \
         DOCKER_HOST_IP "${DOCKER_HOST_IP:-$INTERNAL_IP}" \
         DASHBOARD_USERNAME "${DASHBOARD_USERNAME:-supabase}" \
         DASHBOARD_PASSWORD "$DASHBOARD_PASSWORD" \

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -277,7 +277,7 @@ export const config: Config = {
       : "/var/lib/supacloud/caddy",
   ),
   caddyBinaryPath: getEnv("CADDY_BINARY_PATH", "/usr/local/bin/supacloud-caddy"),
-  grafanaUrl: getEnv("GRAFANA_URL", "http://127.0.0.1:3000"),
+  grafanaUrl: getEnv("GRAFANA_URL", "http://127.0.0.1:3000/grafana"),
   victoriaMetricsUrl: getEnv("VICTORIAMETRICS_URL", "http://127.0.0.1:8428"),
   realtimeAdminUrl: getEnv("REALTIME_ADMIN_URL", "http://127.0.0.1:4000"),
   realtimeApiSecret: getEnv("REALTIME_API_SECRET", ""),

--- a/packages/management-api/src/services/migration-ledger.ts
+++ b/packages/management-api/src/services/migration-ledger.ts
@@ -164,10 +164,10 @@ export async function reconcileMigrationLedgerVersions(database: MigrationLedger
         checksum = legacy.checksum,
         inserted_at = COALESCE(legacy.inserted_at, canonical.inserted_at, now())
     FROM public.schema_migrations legacy
-    WHERE canonical.version = legacy.version::text
+    WHERE canonical.version::text = legacy.version::text
       AND canonical.checksum IS NULL
       AND COALESCE(cardinality(canonical.statements), 0) = 0
-      AND (canonical.name IS NULL OR canonical.name = canonical.version)
+      AND (canonical.name IS NULL OR canonical.name = canonical.version::text)
   `);
   await database.unsafe(`
     UPDATE public.schema_migrations legacy
@@ -176,7 +176,7 @@ export async function reconcileMigrationLedgerVersions(database: MigrationLedger
         checksum = canonical.checksum,
         inserted_at = canonical.inserted_at
     FROM supabase_migrations.schema_migrations canonical
-    WHERE legacy.version::text = canonical.version
+    WHERE legacy.version::text = canonical.version::text
       AND legacy.checksum IS NULL
       AND COALESCE(cardinality(legacy.statements), 0) = 0
       AND (legacy.name IS NULL OR legacy.name = legacy.version::text)
@@ -184,7 +184,7 @@ export async function reconcileMigrationLedgerVersions(database: MigrationLedger
   await database.unsafe(`
     INSERT INTO supabase_migrations.schema_migrations
       (version, statements, name, checksum, inserted_at)
-    SELECT version::text, statements, name, checksum, COALESCE(inserted_at, now())
+    SELECT version::bigint, statements, name, checksum, COALESCE(inserted_at, now())
     FROM public.schema_migrations
     ON CONFLICT (version) DO NOTHING
   `);

--- a/packages/management-api/tests/unit/grafana.routes.test.ts
+++ b/packages/management-api/tests/unit/grafana.routes.test.ts
@@ -27,12 +27,12 @@ afterEach(() => {
 });
 
 describe("grafana proxy routes", () => {
-  test("strips the /grafana mount prefix when proxying to the local Grafana root", () => {
+  test("forwards the /grafana subpath to the local Grafana subpath upstream", () => {
     const target = grafanaProxyInternals.buildGrafanaTargetUrl(
       "https://studio.example.com/grafana/d/pgsql-overview?orgId=1",
     );
 
-    expect(target.toString()).toBe("http://127.0.0.1:3000/d/pgsql-overview?orgId=1");
+    expect(target.toString()).toBe("http://127.0.0.1:3000/grafana/d/pgsql-overview?orgId=1");
   });
 
   test("proxies Grafana responses delegated from the SPA catch-all", async () => {
@@ -57,7 +57,7 @@ describe("grafana proxy routes", () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("grafana");
-    expect(seen[0].url).toBe("http://127.0.0.1:3000/api/search?query=pgsql");
+    expect(seen[0].url).toBe("http://127.0.0.1:3000/grafana/api/search?query=pgsql");
     expect(seen[0].headers.get("accept-encoding")).toBe("identity");
     expect(response.headers.get("content-encoding")).toBeNull();
     expect(response.headers.get("content-length")).toBeNull();

--- a/packages/management-api/tests/unit/migration-ledger.test.ts
+++ b/packages/management-api/tests/unit/migration-ledger.test.ts
@@ -45,6 +45,30 @@ describe("migration ledger compatibility", () => {
     expect(legacyInsertSeen).toBe(true);
   });
 
+  test("reconcile statements tolerate BIGINT canonical version columns", async () => {
+    const calls: string[] = [];
+
+    await ensureMigrationLedgerMetadata({
+      unsafe: async (query: string) => {
+        calls.push(query);
+        return [];
+      },
+    });
+
+    const canonicalUpdate = calls.find((query) => query.includes("UPDATE supabase_migrations.schema_migrations canonical"));
+    expect(canonicalUpdate).toBeDefined();
+    expect(canonicalUpdate).toContain("canonical.version::text = legacy.version::text");
+    expect(canonicalUpdate).toContain("canonical.name = canonical.version::text");
+
+    const legacyUpdate = calls.find((query) => query.includes("UPDATE public.schema_migrations legacy"));
+    expect(legacyUpdate).toBeDefined();
+    expect(legacyUpdate).toContain("legacy.version::text = canonical.version::text");
+
+    const canonicalInsert = calls.find((query) => query.includes("INSERT INTO supabase_migrations.schema_migrations"));
+    expect(canonicalInsert).toBeDefined();
+    expect(canonicalInsert).toContain("SELECT version::bigint");
+  });
+
   test("backfills missing legacy timestamps for the canonical ledger", async () => {
     let canonicalInsertSeen = false;
     let canonicalUpdateSeen = false;


### PR DESCRIPTION
## 问题
升级 0.50.22（含 #723）后 `POST /database/migrations` 仍报 `operator does not exist: bigint = text`。

根因：`withMigrationRoleSession` 先调 `ensureMigrationTables` → `reconcileMigrationLedgerVersions`，其 UPDATE 用 `canonical.version = legacy.version::text` 比较；线上项目库 `supabase_migrations.schema_migrations.version` 为 bigint（Supabase CLI 约定），比较即失败，迁移在 `prepareProjectMigrationRole` 之前被阻断（0.50.22 直连 9090 复现确认）。

## 修复
- 两个 reconcile UPDATE 的版本/name 比较双侧 `::text`
- canonical 台账 INSERT 改 `SELECT version::bigint`（bigint 列直接匹配，text 列经赋值转换兼容；版本号契约本即数字）
- 新增回归测试：reconcile 语句对 bigint canonical 列类型无关

## 验证
- `bun test tests/unit/migration-ledger.test.ts`：10 pass
- `bun test tests/unit/database-migration-baseline.routes.test.ts`：6 pass
- `tsc --noEmit`：通过
- 待合并发布后到 vm1 直连 9090 重放 noop 迁移验证