### PR TITLE
fix(edge-runtime): bound memory across function activations

### DIFF
--- a/packages/edge-runtime/server-cache.test.ts
+++ b/packages/edge-runtime/server-cache.test.ts
@@ -28,6 +28,26 @@ describe("Edge Runtime auth material invalidation", () => {
     expect(endpoint).toContain("requestedVersion,");
     expect(endpoint).toContain("`_v${requestedVersion}`");
     expect(endpoint).toContain("version: requestedVersion");
+    expect(endpoint).toContain("preheatVersionedIdleWorkers");
+    expect(endpoint).toContain("preheatIdleWorkers");
+    const regularBranchStart = endpoint.indexOf(": await Promise.all");
+    const versionedBranch = endpoint.slice(endpoint.indexOf("? await Promise.all"), regularBranchStart);
+    const regularBranch = endpoint.slice(regularBranchStart, endpoint.indexOf("return {"));
+    expect(versionedBranch).toContain("preheatVersionedIdleWorkers");
+    expect(versionedBranch).not.toContain("preheatIdleWorkers");
+    expect(regularBranch).toContain("preheatIdleWorkers");
+    expect(regularBranch).not.toContain("preheatVersionedIdleWorkers");
+    expect(endpoint).toContain("foreground,");
+    expect(endpoint).toContain("background,");
+  });
+
+  test("recycles the whole runtime after bounded worker churn", () => {
+    expect(source.match(/onWorkerRecycleRequired: requestRuntimeRecycle/g)).toHaveLength(2);
+    expect(source).toContain('gracefulShutdown("worker replacement budget", 1)');
+    expect(source).toContain("queueMicrotask");
+    expect(source).toContain("const gracefulShutdown = async (signal: string, exitCode = 0)");
+    expect(source).toContain("await Bun.sleep(WORKER_RECYCLE_RESPONSE_GRACE_MS)");
+    expect(source).toContain("process.exit(exitCode)");
   });
 
   test("function invalidation evicts policy config and active dispatch identities include version", () => {

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -44,6 +44,7 @@ const FUNCTIONS_BASE_DIR = path.resolve(process.env.EDGE_FUNCTIONS_BASE_DIR || F
 const MGMT_API = process.env.MANAGEMENT_API_URL || "http://127.0.0.1:9090";
 const FUNCTION_REQUEST_TIMEOUT_MS = Number(process.env.EDGE_FUNCTION_TIMEOUT_MS) || 60_000;
 const BACKGROUND_FUNCTION_TIMEOUT_MS = Number(process.env.EDGE_BACKGROUND_FUNCTION_TIMEOUT_MS) || 300_000;
+const WORKER_RECYCLE_RESPONSE_GRACE_MS = 100;
 const INTERNAL_TOKEN = process.env.EDGE_RUNTIME_MASTER_KEY || process.env.MASTER_TOKEN || "";
 const PROJECT_REF_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 const FUNCTION_SLUG_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
@@ -251,16 +252,29 @@ if (!process.env.EDGE_RUNTIME_VERSION) {
   process.env.EDGE_RUNTIME_VERSION = "1.58.3";
 }
 
+let shuttingDown = false;
+let workerRecycleScheduled = false;
+
+function requestRuntimeRecycle(): void {
+  if (workerRecycleScheduled || shuttingDown) return;
+  workerRecycleScheduled = true;
+  queueMicrotask(() => {
+    void gracefulShutdown("worker replacement budget", 1);
+  });
+}
+
 const pool = new WorkerPool({
   size: POOL_SIZE,
   requestTimeout: FUNCTION_REQUEST_TIMEOUT_MS,
   smol: FOREGROUND_WORKER_SMOL,
+  onWorkerRecycleRequired: requestRuntimeRecycle,
 });
 
 const backgroundPool = new WorkerPool({
   size: BACKGROUND_POOL_SIZE,
   requestTimeout: BACKGROUND_FUNCTION_TIMEOUT_MS,
   smol: BACKGROUND_WORKER_SMOL,
+  onWorkerRecycleRequired: requestRuntimeRecycle,
 });
 
 async function resolveProjectRoot(projectRef: string): Promise<string> {
@@ -789,17 +803,37 @@ const app = new Elysia()
       const versionSuffix = requestedVersion ? `_v${requestedVersion}` : "";
       const functionId = `${c.params.ref}_${c.params.slug}${versionSuffix}`;
       const tenantEnv = await loadTenantEnv(c.params.ref);
-      const [foreground, background] = await Promise.all([
-        pool.preheatIdleWorkers(functionId, functionPath, projectRoot, tenantEnv, {
-          projectRef: c.params.ref,
-          moduleVersion,
-        }),
-        backgroundPool.preheatIdleWorkers(functionId, functionPath, projectRoot, tenantEnv, {
-          projectRef: c.params.ref,
-          moduleVersion,
-          maxWorkers: resolveBackgroundPreheatWorkers(),
-        }),
-      ]);
+      const [foreground, background] = requestedVersion
+        ? await Promise.all([
+            pool.preheatVersionedIdleWorkers({
+              functionId,
+              functionPath,
+              projectRoot,
+              env: tenantEnv,
+              projectRef: c.params.ref,
+              moduleVersion,
+            }),
+            backgroundPool.preheatVersionedIdleWorkers({
+              functionId,
+              functionPath,
+              projectRoot,
+              env: tenantEnv,
+              projectRef: c.params.ref,
+              moduleVersion,
+              maxWorkers: resolveBackgroundPreheatWorkers(),
+            }),
+          ])
+        : await Promise.all([
+            pool.preheatIdleWorkers(functionId, functionPath, projectRoot, tenantEnv, {
+              projectRef: c.params.ref,
+              moduleVersion,
+            }),
+            backgroundPool.preheatIdleWorkers(functionId, functionPath, projectRoot, tenantEnv, {
+              projectRef: c.params.ref,
+              moduleVersion,
+              maxWorkers: resolveBackgroundPreheatWorkers(),
+            }),
+          ]);
       return {
         preheated: functionId,
         version: requestedVersion,
@@ -974,8 +1008,7 @@ const app = new Elysia()
 
 console.log(`🚀 Edge Runtime on ${HOST}:${PORT} (${POOL_SIZE} workers)`);
 
-let shuttingDown = false;
-const gracefulShutdown = async (signal: string) => {
+const gracefulShutdown = async (signal: string, exitCode = 0) => {
   if (shuttingDown) return;
   shuttingDown = true;
   console.log(`[EdgeRuntime] Received ${signal}, shutting down gracefully...`);
@@ -1003,7 +1036,10 @@ const gracefulShutdown = async (signal: string) => {
     console.error("[EdgeRuntime] Drain timed out, forcing exit");
   }
 
-  process.exit(0);
+  // Bulk preheats are drained above; leave time for their control responses to flush.
+  if (exitCode !== 0) await Bun.sleep(WORKER_RECYCLE_RESPONSE_GRACE_MS);
+
+  process.exit(exitCode);
 };
 
 process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -1415,6 +1415,40 @@ describe("WorkerPool cancellation and replacement", () => {
     }
   });
 
+  test("drain waits for an in-progress bulk preheat", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-drain-preheat-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      await Bun.sleep(120);
+      export default () => new Response("ready");
+    `);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const preheatPromise = pool.preheatIdleWorkers(
+        "proj_drain_preheat",
+        functionPath,
+        projectRoot,
+        {},
+      );
+      await Bun.sleep(20);
+      let drained = false;
+      const drainPromise = pool.drain().then(() => {
+        drained = true;
+      });
+
+      await Bun.sleep(40);
+      expect(drained).toBe(false);
+      expect((await preheatPromise).succeeded).toBe(1);
+      await drainPromise;
+      expect(drained).toBe(true);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("drain waits for EdgeRuntime.waitUntil after the response", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-drain-waituntil-"));
     const completedPath = join(projectRoot, "waituntil-complete.txt");
@@ -2054,6 +2088,348 @@ describe("WorkerPool module cache", () => {
     }
   });
 
+  test("rotates idle workers before an explicit version preheat", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-version-rotation-idle-"));
+    const counterPath = join(projectRoot, "counter.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, moduleLoadCounterSource(counterPath));
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const dispatch = () => pool.dispatch({
+      functionId: "proj_rotation_fn_v1",
+      functionPath,
+      projectRoot,
+      projectRef: "proj_rotation",
+      moduleVersion: "v1",
+      env: {},
+      request: new Request("http://edge.local/functions/v1/fn"),
+    });
+
+    try {
+      expect(await (await dispatch()).text()).toBe("1");
+      const preheat = await pool.preheatVersionedIdleWorkers({
+        functionId: "proj_rotation_fn_v1",
+        functionPath,
+        projectRoot,
+        projectRef: "proj_rotation",
+        moduleVersion: "v1",
+        env: {},
+      });
+
+      expect(preheat.rotation).toEqual({
+        generation: 1,
+        attempted: 1,
+        idleRetired: 1,
+        busyTainted: 0,
+        alreadyTainted: 0,
+        immediateReplacements: 1,
+      });
+      expect(preheat.cacheMisses).toBe(1);
+      expect(await Bun.file(counterPath).text()).toBe("2");
+      expect(await (await dispatch()).text()).toBe("2");
+      await waitForMetric(pool, "total_natural_worker_exits", 1);
+      const metrics = pool.snapshotMetrics("rotation");
+      expect(metrics["rotation_total_worker_replacements"]).toBe(1);
+      expect(metrics["rotation_total_generation_rotations"]).toBe(1);
+      expect(metrics["rotation_worker_generation"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("lets busy work finish before retiring its old generation", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-version-rotation-busy-"));
+    const startedPath = join(projectRoot, "started.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default async function fetch() {
+        await Bun.write(process.env.STARTED_PATH, "started");
+        await Bun.sleep(150);
+        return new Response("completed");
+      }
+    `);
+
+    const pool = new WorkerPool({ size: 2, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const initialPreheat = await pool.preheatIdleWorkers(
+        "proj_rotation_busy_v1",
+        functionPath,
+        projectRoot,
+        { STARTED_PATH: startedPath },
+        { projectRef: "proj_rotation", moduleVersion: "v1" },
+      );
+      expect(initialPreheat.succeeded).toBe(2);
+
+      const responsePromise = pool.dispatch({
+        functionId: "proj_rotation_busy_v1",
+        functionPath,
+        projectRoot,
+        projectRef: "proj_rotation",
+        moduleVersion: "v1",
+        env: { STARTED_PATH: startedPath },
+        request: new Request("http://edge.local/functions/v1/busy"),
+      });
+      await waitForFile(startedPath);
+
+      const versionPreheat = await pool.preheatVersionedIdleWorkers({
+        functionId: "proj_rotation_busy_v2",
+        functionPath,
+        projectRoot,
+        projectRef: "proj_rotation",
+        moduleVersion: "v2",
+        env: { STARTED_PATH: startedPath },
+      });
+      expect(versionPreheat.rotation).toEqual({
+        generation: 1,
+        attempted: 2,
+        idleRetired: 1,
+        busyTainted: 1,
+        alreadyTainted: 0,
+        immediateReplacements: 1,
+      });
+      expect(versionPreheat.succeeded).toBe(1);
+
+      const response = await responsePromise;
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("completed");
+      await waitForMetric(pool, "total_natural_worker_exits", 2);
+      const metrics = pool.snapshotMetrics("rotation");
+      expect(metrics["rotation_total_worker_replacements"]).toBe(2);
+      expect(metrics["rotation_total_generation_busy_taints"]).toBe(1);
+      expect(metrics["rotation_tainted_workers"]).toBe(0);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("serializes ordinary bulk preheat before explicit version rotation", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-version-rotation-queued-"));
+    const slowFunctionPath = join(projectRoot, "slow.ts");
+    const versionedFunctionPath = join(projectRoot, "versioned.ts");
+    await Bun.write(slowFunctionPath, `
+      await Bun.sleep(150);
+      export default () => new Response("ordinary");
+    `);
+    await Bun.write(versionedFunctionPath, `export default () => new Response("versioned");`);
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const ordinaryPreheat = pool.preheatIdleWorkers(
+        "proj_rotation_ordinary",
+        slowFunctionPath,
+        projectRoot,
+        {},
+        { projectRef: "proj_rotation", moduleVersion: "ordinary" },
+      );
+      const versionedPreheat = pool.preheatVersionedIdleWorkers({
+        functionId: "proj_rotation_versioned_v1",
+        functionPath: versionedFunctionPath,
+        projectRoot,
+        projectRef: "proj_rotation",
+        moduleVersion: "v1",
+        env: {},
+      });
+
+      const [ordinary, versioned] = await Promise.all([ordinaryPreheat, versionedPreheat]);
+      expect(ordinary.succeeded).toBe(1);
+      expect(versioned.succeeded).toBe(1);
+      expect(versioned.rotation).toEqual({
+        generation: 1,
+        attempted: 1,
+        idleRetired: 1,
+        busyTainted: 0,
+        alreadyTainted: 0,
+        immediateReplacements: 1,
+      });
+      await waitForMetric(pool, "total_natural_worker_exits", 1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("serializes concurrent explicit version preheats by generation", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-version-rotation-ordered-"));
+    const counterPath = join(projectRoot, "counter.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, moduleLoadCounterSource(counterPath));
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const preheatVersion = (version: string) => pool.preheatVersionedIdleWorkers({
+      functionId: `proj_rotation_ordered_v${version}`,
+      functionPath,
+      projectRoot,
+      projectRef: "proj_rotation",
+      moduleVersion: version,
+      env: {},
+    });
+
+    try {
+      const preheats = await Promise.all([
+        preheatVersion("1"),
+        preheatVersion("2"),
+        preheatVersion("3"),
+      ]);
+      expect(preheats.map((preheat) => preheat.rotation.generation)).toEqual([1, 2, 3]);
+      expect(preheats.map((preheat) => preheat.succeeded)).toEqual([1, 1, 1]);
+      expect(await Bun.file(counterPath).text()).toBe("3");
+      await waitForMetric(pool, "total_natural_worker_exits", 3);
+      const metrics = pool.snapshotMetrics("ordered");
+      expect(metrics["ordered_total_worker_replacements"]).toBe(3);
+      expect(metrics["ordered_retired_workers"]).toBe(0);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("reloads rollback versions and drains repeated generation rotations", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-version-rotation-rollback-"));
+    const counterPath = join(projectRoot, "counter.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, moduleLoadCounterSource(counterPath));
+
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const preheatVersion = (version: string) => pool.preheatVersionedIdleWorkers({
+      functionId: `proj_rotation_rollback_v${version}`,
+      functionPath,
+      projectRoot,
+      projectRef: "proj_rotation",
+      moduleVersion: version,
+      env: {},
+    });
+
+    try {
+      for (const version of ["1", "2", "1", "3", "4", "5"]) {
+        const preheat = await preheatVersion(version);
+        expect(preheat.succeeded).toBe(1);
+        expect(preheat.cacheMisses).toBe(1);
+      }
+      expect(await Bun.file(counterPath).text()).toBe("6");
+      await waitForMetric(pool, "total_natural_worker_exits", 6);
+      const metrics = pool.snapshotMetrics("rollback");
+      expect(metrics["rollback_worker_generation"]).toBe(6);
+      expect(metrics["rollback_total_worker_replacements"]).toBe(6);
+      expect(metrics["rollback_retired_workers"]).toBe(0);
+      expect(metrics["rollback_tainted_workers"]).toBe(0);
+      expect(metrics["rollback_idle_workers"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("requests one process recycle after the worker replacement budget", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-worker-recycle-budget-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `export default () => new Response("ready");`);
+
+    const recycleEvents: Array<{ workerReplacements: number; maxWorkerReplacements: number }> = [];
+    const succeededAtRecycle: number[] = [];
+    let pool: WorkerPool;
+    pool = new WorkerPool({
+      size: 1,
+      requestTimeout: 2_000,
+      maxWorkerReplacementsBeforeRecycle: 2,
+      onWorkerRecycleRequired: (event) => {
+        recycleEvents.push(event);
+        const metrics = pool.snapshotMetrics("during_recycle");
+        succeededAtRecycle.push(metrics["during_recycle_total_preheat_succeeded"]);
+      },
+    });
+    pools.push(pool);
+
+    try {
+      for (const version of ["1", "2", "3"]) {
+        const preheat = await pool.preheatVersionedIdleWorkers({
+          functionId: `proj_recycle_v${version}`,
+          functionPath,
+          projectRoot,
+          projectRef: "proj_recycle",
+          moduleVersion: version,
+          env: {},
+        });
+        expect(preheat.succeeded).toBe(1);
+      }
+
+      expect(recycleEvents).toEqual([{ workerReplacements: 2, maxWorkerReplacements: 2 }]);
+      expect(succeededAtRecycle).toEqual([2]);
+      await waitForMetric(pool, "total_natural_worker_exits", 3);
+      const metrics = pool.snapshotMetrics("recycle");
+      expect(metrics["recycle_total_worker_replacements"]).toBe(3);
+      expect(metrics["recycle_max_worker_replacements_before_recycle"]).toBe(2);
+      expect(metrics["recycle_worker_recycle_required"]).toBe(1);
+      expect(metrics["recycle_retired_workers"]).toBe(0);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("shared recycle coordination waits for slow and fast pool preheats", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-recycle-two-pools-"));
+    const slowFunctionPath = join(projectRoot, "slow.ts");
+    const fastFunctionPath = join(projectRoot, "fast.ts");
+    await Bun.write(slowFunctionPath, `
+      await Bun.sleep(150);
+      export default () => new Response("slow");
+    `);
+    await Bun.write(fastFunctionPath, `export default () => new Response("fast");`);
+
+    let foreground: WorkerPool;
+    let background: WorkerPool;
+    let coordinatorStarts = 0;
+    let coordinatedDrain: Promise<void> | undefined;
+    const requestRecycle = () => {
+      if (coordinatedDrain) return;
+      coordinatorStarts++;
+      coordinatedDrain = Promise.all([foreground.drain(), background.drain()]).then(() => undefined);
+    };
+    foreground = new WorkerPool({
+      size: 1,
+      requestTimeout: 2_000,
+      maxWorkerReplacementsBeforeRecycle: 1,
+      onWorkerRecycleRequired: requestRecycle,
+    });
+    background = new WorkerPool({
+      size: 1,
+      requestTimeout: 2_000,
+      maxWorkerReplacementsBeforeRecycle: 1,
+      onWorkerRecycleRequired: requestRecycle,
+    });
+    pools.push(foreground, background);
+
+    try {
+      const preheat = (pool: WorkerPool, functionId: string, functionPath: string) =>
+        pool.preheatVersionedIdleWorkers({
+          functionId,
+          functionPath,
+          projectRoot,
+          projectRef: "proj_recycle_two_pools",
+          moduleVersion: "1",
+          env: {},
+        });
+      const [foregroundResult, backgroundResult] = await Promise.all([
+        preheat(foreground, "proj_recycle_foreground_v1", slowFunctionPath),
+        preheat(background, "proj_recycle_background_v1", fastFunctionPath),
+      ]);
+      await coordinatedDrain;
+
+      expect(foregroundResult.succeeded).toBe(1);
+      expect(backgroundResult.succeeded).toBe(1);
+      expect(coordinatorStarts).toBe(1);
+      const foregroundMetrics = foreground.snapshotMetrics("foreground");
+      const backgroundMetrics = background.snapshotMetrics("background");
+      expect(foregroundMetrics["foreground_total_preheat_succeeded"]).toBe(1);
+      expect(backgroundMetrics["background_total_preheat_succeeded"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("invalidates only the target function cache entry", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-module-invalidate-"));
     const functionAPath = join(projectRoot, "a.ts");
@@ -2313,6 +2689,8 @@ describe("WorkerPool module cache", () => {
       expect(metrics["preheat_total_preheat_attempts"]).toBe(3);
       expect(metrics["preheat_total_preheat_succeeded"]).toBe(3);
       expect(metrics["preheat_total_preheat_ms"]).toBeGreaterThanOrEqual(0);
+      expect(metrics["preheat_total_generation_rotations"]).toBe(0);
+      expect(metrics["preheat_total_worker_replacements"]).toBe(0);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -53,6 +53,8 @@ const WAIT_UNTIL_TIMEOUT_MS = Number(process.env.EDGE_WAIT_UNTIL_TIMEOUT_MS) || 
 const CONTROL_MESSAGE_TIMEOUT_MS = Number(process.env.EDGE_CONTROL_MESSAGE_TIMEOUT_MS) || 1_000;
 const DEFAULT_MAX_RETIREMENT_AGE_MS = 60_000;
 const DEFAULT_PREHEAT_TIMEOUT_MS = 10_000;
+// Bun/JSC retains fixed host memory after Worker exit, so bound churn before recycling the process.
+const DEFAULT_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE = 128;
 
 function cancelledResponse(): Response {
   return new Response(JSON.stringify({ error: "Task cancelled" }), {
@@ -83,6 +85,24 @@ type PreheatOptions = {
   maxWorkers?: number;
 };
 
+type BulkPreheatRequest = {
+  functionId: string;
+  functionPath: string;
+  projectRoot: string;
+  env: Record<string, string>;
+  options: PreheatOptions;
+};
+
+export type VersionedPreheatRequest = {
+  functionId: string;
+  functionPath: string;
+  projectRoot: string;
+  env: Record<string, string>;
+  projectRef?: string;
+  moduleVersion: string;
+  maxWorkers?: number;
+};
+
 type WorkerPreheatResult = {
   success: boolean;
   cacheHit: boolean | null;
@@ -95,6 +115,24 @@ export type WorkerPoolPreheatResult = {
   cacheHits: number;
   cacheMisses: number;
   durationMs: number;
+};
+
+export type WorkerPoolGenerationRotationResult = {
+  generation: number;
+  attempted: number;
+  idleRetired: number;
+  busyTainted: number;
+  alreadyTainted: number;
+  immediateReplacements: number;
+};
+
+export type WorkerPoolVersionPreheatResult = WorkerPoolPreheatResult & {
+  rotation: WorkerPoolGenerationRotationResult;
+};
+
+type WorkerPoolRecycleRequired = {
+  workerReplacements: number;
+  maxWorkerReplacements: number;
 };
 
 type RetirementBudgetExceeded = {
@@ -113,12 +151,16 @@ type WorkerPoolConfig = {
     maxRetirementAgeMs: number;
   };
   onRetirementBudgetExceeded?: (exceeded: RetirementBudgetExceeded) => void;
+  maxWorkerReplacementsBeforeRecycle?: number;
+  onWorkerRecycleRequired?: (event: WorkerPoolRecycleRequired) => void;
 };
 
 type RetiredWorker = {
   retiredAt: number;
   ageTimer: ReturnType<typeof setTimeout>;
 };
+
+type GenerationRotationDisposition = "idle-retired" | "busy-tainted" | "already-tainted";
 
 function extractProjectRef(functionId: string): string | null {
   const idx = functionId.indexOf("_");
@@ -174,12 +216,21 @@ export class WorkerPool {
   private totalPreheatMs = 0;
   private totalWorkerRetirements = 0;
   private totalNaturalWorkerExits = 0;
+  private workerGeneration = 0;
+  private totalGenerationRotations = 0;
+  private totalGenerationIdleRetirements = 0;
+  private totalGenerationBusyTaints = 0;
+  private bulkPreheatTail: Promise<void> | null = null;
   private retirementBudgetExceeded = false;
+  private workerRecycleRequired = false;
+  private workerRecycleNotificationSent = false;
+  private workerRecycleNotificationDeferred = false;
   private activeWorkers = new Set<Worker>();
   private retiredWorkers = new Map<Worker, RetiredWorker>();
   private workerMetadata = new Map<
     Worker,
     {
+      generation: number;
       replacementTimer?: ReturnType<typeof setTimeout>;
       isCancelling?: boolean;
     }
@@ -192,6 +243,8 @@ export class WorkerPool {
     maxRetirementAgeMs: number;
   };
   private readonly onRetirementBudgetExceeded: (exceeded: RetirementBudgetExceeded) => void;
+  private readonly maxWorkerReplacementsBeforeRecycle: number;
+  private readonly onWorkerRecycleRequired: (event: WorkerPoolRecycleRequired) => void;
 
   constructor(private config: WorkerPoolConfig) {
     this.retirementBudget = config.retirementBudget ?? {
@@ -202,6 +255,9 @@ export class WorkerPool {
       console.error("[Pool] Worker retirement budget exceeded; restarting Edge Runtime", exceeded);
       process.exit(1);
     });
+    this.maxWorkerReplacementsBeforeRecycle = config.maxWorkerReplacementsBeforeRecycle
+      ?? DEFAULT_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE;
+    this.onWorkerRecycleRequired = config.onWorkerRecycleRequired ?? (() => process.exit(1));
     for (let i = 0; i < config.size; i++) {
       const w = this.createWorker();
       this.idle.push(w);
@@ -215,7 +271,7 @@ export class WorkerPool {
       ...(this.config.smol ? { smol: true } : {}),
     } as any);
     this.workers.push(w);
-    this.workerMetadata.set(w, {});
+    this.workerMetadata.set(w, { generation: this.workerGeneration });
     w.once("exit", () => this.onWorkerExit(w));
     return w;
   }
@@ -338,7 +394,7 @@ export class WorkerPool {
     const cleanupInFlight = () => {
       this.inFlight.delete(opts.executionKey);
     };
-    const metadata = this.workerMetadata.get(worker) || {};
+    const metadata = this.workerMetadata.get(worker) || { generation: this.workerGeneration };
     metadata.isCancelling = false;
     if (metadata.replacementTimer) {
       clearTimeout(metadata.replacementTimer);
@@ -740,7 +796,7 @@ export class WorkerPool {
     worker.unref();
 
     if (!this.draining) {
-      this.totalWorkerReplacements++;
+      this.recordWorkerReplacement();
       const replacement = this.createWorker();
       this.activeWorkers.add(replacement);
       this.schedule(replacement);
@@ -770,10 +826,34 @@ export class WorkerPool {
     this.removeWorkerReferences(worker);
     if (!this.activeWorkers.delete(worker) || this.draining) return;
 
-    this.totalWorkerReplacements++;
+    this.recordWorkerReplacement();
     const replacement = this.createWorker();
     this.activeWorkers.add(replacement);
     this.schedule(replacement);
+  }
+
+  private recordWorkerReplacement(): void {
+    this.totalWorkerReplacements++;
+    if (this.totalWorkerReplacements >= this.maxWorkerReplacementsBeforeRecycle) {
+      this.workerRecycleRequired = true;
+    }
+    this.notifyWorkerRecycleRequired();
+  }
+
+  private notifyWorkerRecycleRequired(): void {
+    if (
+      !this.workerRecycleRequired ||
+      this.workerRecycleNotificationSent ||
+      this.workerRecycleNotificationDeferred
+    ) return;
+
+    this.workerRecycleNotificationSent = true;
+    const event = {
+      workerReplacements: this.totalWorkerReplacements,
+      maxWorkerReplacements: this.maxWorkerReplacementsBeforeRecycle,
+    };
+    console.warn("[Pool] Worker replacement budget reached; recycling Edge Runtime", event);
+    this.onWorkerRecycleRequired(event);
   }
 
   private removeWorkerReferences(worker: Worker) {
@@ -917,6 +997,38 @@ export class WorkerPool {
     return this.invalidateWorkers({ type: "invalidate_project", projectRef });
   }
 
+  private rotateWorkerForGeneration(worker: Worker): GenerationRotationDisposition {
+    if (this.idle.includes(worker)) {
+      this.retireWorker(worker);
+      return "idle-retired";
+    }
+    if (this.tainted.has(worker)) return "already-tainted";
+    this.tainted.add(worker);
+    return "busy-tainted";
+  }
+
+  private rotateGeneration(): WorkerPoolGenerationRotationResult {
+    this.workerGeneration++;
+    this.totalGenerationRotations++;
+    const workers = [...this.activeWorkers].filter(
+      (worker) => (this.workerMetadata.get(worker)?.generation ?? -1) < this.workerGeneration,
+    );
+    const dispositions = workers.map((worker) => this.rotateWorkerForGeneration(worker));
+    const idleRetired = dispositions.filter((value) => value === "idle-retired").length;
+    const busyTainted = dispositions.filter((value) => value === "busy-tainted").length;
+    const alreadyTainted = dispositions.filter((value) => value === "already-tainted").length;
+    this.totalGenerationIdleRetirements += idleRetired;
+    this.totalGenerationBusyTaints += busyTainted;
+    return {
+      generation: this.workerGeneration,
+      attempted: workers.length,
+      idleRetired,
+      busyTainted,
+      alreadyTainted,
+      immediateReplacements: idleRetired,
+    };
+  }
+
   private async preheatWorker(
     worker: Worker,
     functionId: string,
@@ -997,48 +1109,132 @@ export class WorkerPool {
       .then((result) => result.success)
       .finally(() => {
         if (!this.draining && this.activeWorkers.has(worker)) {
-          this.schedule(worker);
+          this.recycle(worker);
         }
       });
   }
 
-  async preheatIdleWorkers(
+  preheatVersionedIdleWorkers(
+    request: VersionedPreheatRequest,
+  ): Promise<WorkerPoolVersionPreheatResult> {
+    return this.enqueueBulkPreheat(() => this.rotateAndPreheatVersion(request));
+  }
+
+  private async rotateAndPreheatVersion(
+    request: VersionedPreheatRequest,
+  ): Promise<WorkerPoolVersionPreheatResult> {
+    const rotation = this.rotateGeneration();
+    const preheat = await this.preheatIdleWorkersNow({
+      functionId: request.functionId,
+      functionPath: request.functionPath,
+      projectRoot: request.projectRoot,
+      env: request.env,
+      options: {
+        projectRef: request.projectRef,
+        moduleVersion: request.moduleVersion,
+        maxWorkers: request.maxWorkers,
+      },
+    });
+    return { ...preheat, rotation };
+  }
+
+  preheatIdleWorkers(
     functionId: string,
     functionPath: string,
     projectRoot: string,
     env: Record<string, string>,
     options: PreheatOptions = {},
   ): Promise<WorkerPoolPreheatResult> {
+    return this.enqueueBulkPreheat(() => this.preheatIdleWorkersNow({
+      functionId,
+      functionPath,
+      projectRoot,
+      env,
+      options,
+    }));
+  }
+
+  private enqueueBulkPreheat<T>(operation: () => Promise<T>): Promise<T> {
+    const deferredOperation = () => this.runWithDeferredRecycleNotification(operation);
+    const queuedOperation = this.bulkPreheatTail
+      ? this.bulkPreheatTail.then(deferredOperation)
+      : deferredOperation();
+    const settledOperation = queuedOperation.then(() => undefined, () => undefined);
+    this.bulkPreheatTail = settledOperation;
+    void settledOperation.then(() => {
+      if (this.bulkPreheatTail === settledOperation) this.bulkPreheatTail = null;
+    });
+    return queuedOperation;
+  }
+
+  private async runWithDeferredRecycleNotification<T>(operation: () => Promise<T>): Promise<T> {
+    this.workerRecycleNotificationDeferred = true;
+    try {
+      return await operation();
+    } finally {
+      this.workerRecycleNotificationDeferred = false;
+      this.notifyWorkerRecycleRequired();
+    }
+  }
+
+  private async preheatIdleWorkersNow(request: BulkPreheatRequest): Promise<WorkerPoolPreheatResult> {
     const start = performance.now();
-    const requested = options.maxWorkers && options.maxWorkers > 0
-      ? Math.min(options.maxWorkers, this.idle.length)
-      : this.idle.length;
-    const workers = this.idle.splice(0, requested);
+    const workers = this.takeIdleWorkers(request.options.maxWorkers);
     if (workers.length === 0) {
       return { attempted: 0, succeeded: 0, cacheHits: 0, cacheMisses: 0, durationMs: 0 };
     }
 
     try {
-      const results = await Promise.all(
-        workers.map((worker) => this.preheatWorker(worker, functionId, functionPath, projectRoot, env, options)),
-      );
-      const durationMs = Math.round(performance.now() - start);
-      this.totalPreheatAttempts += workers.length;
-      this.totalPreheatSucceeded += results.filter((result) => result.success).length;
-      this.totalPreheatMs += durationMs;
-      return {
-        attempted: workers.length,
-        succeeded: results.filter((result) => result.success).length,
-        cacheHits: results.filter((result) => result.cacheHit === true).length,
-        cacheMisses: results.filter((result) => result.cacheHit === false).length,
-        durationMs,
-      };
+      const results = await this.preheatWorkers(request, workers);
+      return this.recordBulkPreheatResults(results, start);
     } finally {
-      if (!this.draining) {
-        for (const worker of workers) {
-          if (this.activeWorkers.has(worker)) this.schedule(worker);
-        }
-      }
+      this.recycleBulkPreheatWorkers(workers);
+    }
+  }
+
+  private preheatWorkers(
+    request: BulkPreheatRequest,
+    workers: Worker[],
+  ): Promise<WorkerPreheatResult[]> {
+    return Promise.all(workers.map((worker) => this.preheatWorker(
+      worker,
+      request.functionId,
+      request.functionPath,
+      request.projectRoot,
+      request.env,
+      request.options,
+    )));
+  }
+
+  private takeIdleWorkers(maxWorkers?: number): Worker[] {
+    const requested = maxWorkers && maxWorkers > 0
+      ? Math.min(maxWorkers, this.idle.length)
+      : this.idle.length;
+    return this.idle.splice(0, requested);
+  }
+
+  private recordBulkPreheatResults(
+    results: WorkerPreheatResult[],
+    start: number,
+  ): WorkerPoolPreheatResult {
+    const durationMs = Math.round(performance.now() - start);
+    const succeeded = results.filter((result) => result.success).length;
+    this.totalPreheatAttempts += results.length;
+    this.totalPreheatSucceeded += succeeded;
+    this.totalPreheatMs += durationMs;
+    return {
+      attempted: results.length,
+      succeeded,
+      cacheHits: results.filter((result) => result.cacheHit === true).length,
+      cacheMisses: results.filter((result) => result.cacheHit === false).length,
+      durationMs,
+    };
+  }
+
+  private recycleBulkPreheatWorkers(workers: Worker[]): void {
+    if (this.draining) return;
+    for (const worker of workers) {
+      if (this.activeWorkers.has(worker)) this.recycle(worker);
     }
   }
 
@@ -1059,9 +1255,15 @@ export class WorkerPool {
       [`${prefix}_total_module_cache_invalidated`]: this.totalModuleCacheInvalidated,
       [`${prefix}_module_cache_entries_last_worker`]: this.lastModuleCacheEntries,
       [`${prefix}_total_worker_replacements`]: this.totalWorkerReplacements,
+      [`${prefix}_max_worker_replacements_before_recycle`]: this.maxWorkerReplacementsBeforeRecycle,
+      [`${prefix}_worker_recycle_required`]: this.workerRecycleRequired ? 1 : 0,
       [`${prefix}_retired_workers`]: this.retiredWorkers.size,
       [`${prefix}_total_worker_retirements`]: this.totalWorkerRetirements,
       [`${prefix}_total_natural_worker_exits`]: this.totalNaturalWorkerExits,
+      [`${prefix}_worker_generation`]: this.workerGeneration,
+      [`${prefix}_total_generation_rotations`]: this.totalGenerationRotations,
+      [`${prefix}_total_generation_idle_retirements`]: this.totalGenerationIdleRetirements,
+      [`${prefix}_total_generation_busy_taints`]: this.totalGenerationBusyTaints,
       [`${prefix}_oldest_retired_worker_age_ms`]: this.oldestRetirementAgeMs(),
       [`${prefix}_retirement_budget_exceeded`]: this.retirementBudgetExceeded ? 1 : 0,
       [`${prefix}_total_preheat_attempts`]: this.totalPreheatAttempts,
@@ -1123,10 +1325,15 @@ export class WorkerPool {
     return this.inFlight.size;
   }
 
-  drain(): Promise<void> {
+  async drain(): Promise<void> {
     this.stopDispatching();
+    while (this.bulkPreheatTail) {
+      await this.bulkPreheatTail;
+    }
 
-    return new Promise((resolve) => {
+    if (this.inFlight.size === 0) return;
+
+    await new Promise<void>((resolve) => {
       const check = () => {
         if (this.inFlight.size === 0) {
           resolve();

--- a/packages/web-console/src/routes/page.test.ts
+++ b/packages/web-console/src/routes/page.test.ts
@@ -58,12 +58,12 @@ describe("SupaCloud root dashboard", () => {
   });
 
   test("locks the released svadmin adapters and Vite compatibility rule", () => {
-    expect(packageJson.dependencies["@svadmin/core"]).toBe("^0.32.2");
-    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.38.7");
+    expect(packageJson.dependencies["@svadmin/core"]).toBe("^0.34.1");
+    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.40.3");
     expect(packageJson.dependencies["@svadmin/sveltekit"]).toBe("^0.9.6");
     expect(packageJson.dependencies["@svadmin/elysia"]).toBe("^0.10.7");
-    expect(lockSource).toContain('"@svadmin/core@0.32.2"');
-    expect(lockSource).toContain('"@svadmin/ui@0.38.7"');
+    expect(lockSource).toContain('"@svadmin/core@0.34.1"');
+    expect(lockSource).toContain('"@svadmin/ui@0.40.3"');
     expect(lockSource).toContain('"@svadmin/sveltekit@0.9.6"');
     expect(viteSource).toContain("'@svadmin/core'");
   });

--- a/packages/web-console/src/routes/project/[ref]/tables/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/tables/page.test.ts
@@ -212,24 +212,24 @@ describe("database tables column visibility", () => {
     secondTarget.remove();
   }, 30_000);
 
-  test("pins the patched SvAdmin UI dependency exactly", async () => {
+  test("pins the released SvAdmin UI dependency exactly", async () => {
     const packageJson = await Bun.file(new URL("package.json", packageRoot)).json();
     const lockSource = await Bun.file(new URL("bun.lock", packageRoot)).text();
 
-    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.38.7");
-    expect(packageJson.patchedDependencies["@svadmin/ui@0.38.7"])
-      .toBe("patches/@svadmin%2Fui@0.38.7.patch");
-    expect(lockSource).toContain('"@svadmin/ui": "0.38.7"');
-    expect(lockSource).toContain('"@svadmin/ui@0.38.7": "patches/@svadmin%2Fui@0.38.7.patch"');
+    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.40.3");
+    expect(lockSource).toContain('"@svadmin/ui": "0.40.3"');
+    expect(lockSource).toContain('"@svadmin/ui@0.40.3"');
   });
 
   test("keeps unavailable row estimates from rendering as negative counts", async () => {
     const source = await Bun.file(new URL("+page.svelte", import.meta.url)).text();
-    const autoTablePatch = await Bun.file(join(fileURLToPath(packageRoot), "patches", "@svadmin%2Fui@0.38.7.patch")).text();
+    const autoTableSource = await Bun.file(
+      fileURLToPath(import.meta.resolve("@svadmin/ui/components/AutoTable.svelte")),
+    ).text();
     expect(source).toContain("count >= 0");
     expect(source).toContain('count === null ? "—"');
-    expect(autoTablePatch).toContain("whitespace-nowrap");
-    expect(autoTablePatch).toContain("gap-3 px-1 py-2");
+    expect(autoTableSource).toContain("whitespace-nowrap");
+    expect(autoTableSource).toContain("gap-3 px-1 py-2");
   });
 
   test("keeps each create-table draft bound to its own DOM row", async () => {


### PR DESCRIPTION
## Summary
- rotate Worker generations only for explicit version preheats so stale Bun/JSC module registries leave the active pool
- serialize bulk preheats and retire busy workers cooperatively after their requests finish
- request a supervised process recycle after 128 Worker replacements per pool, draining requests and preheats before exit 1
- expose generation and recycle metrics and cover idle, busy, concurrent, rollback, dual-pool, and drain behavior

## Root cause
Function versions use immutable dynamic import identities. Invalidating the application cache does not release Bun/JSC ESM registrations. Repeated activation retained old module state, and Worker churn itself leaves a smaller fixed host RSS residue until the entire runtime process exits.

## Verification
- `bun test packages/edge-runtime/worker-pool.test.ts packages/edge-runtime/server-cache.test.ts` — 70 pass, 0 fail
- `bun test packages/edge-runtime` — 121 pass, 1 known baseline fixture failure (`worker-retirement-stress`, existing 35 ms timeout)
- `bun run typecheck`
- `bun run build:amd64`
- `git diff --check`
- Linux amd64 SHA-256: `32dff842bccc55cc720ef5138428f6e3a98affbb4b09a06ca1dc276320cc5574`

## Rollout
Deploy to the test environment first and validate production-shaped SupAuth activation, RSS bounds, response completion, and the supervised recycle path before production.