### PR TITLE
fix(edge-functions): align CLI bundles with runtime policy

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -255,6 +255,17 @@ Use a direct Postgres DSN with `pg`, `postgres.js`, or equivalent drivers for ap
 - `diagnostics`
 - `gateway` (requires an admin-capable token)
 
+`edge_functions deploy --path <file-or-directory>` uses Bun to bundle local
+TypeScript and dependencies and runs a local syntax check before upload. The
+Management API applies the Edge Runtime module policy to the final server-side
+artifact for CLI, Web Console, and direct API deployments alike. For
+`deploy_bundle`, pass the file map as JSON, for example
+`--files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}'`.
+Use `edge_functions source --slug <name> --output <file>` to read back large
+Function sources without depending on terminal capture limits. The CLI writes
+the complete original TS/JS source code and refuses to overwrite an existing
+destination.
+
 ### Deliberately excluded
 
 - Server installation

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,7 +68,19 @@ supacloud-cli frontend list --ref abc123
 supacloud-cli branch create --name feature-orders --data_mode schema_only
 supacloud-cli branch promotion_plan --branch_ref preview123
 supacloud-cli branch promote --branch_ref preview123 --plan_checksum <sha256>
+supacloud-cli edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
+supacloud-cli edge_functions deploy_bundle --ref abc123 --slug hello --files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}'
+supacloud-cli edge_functions source --ref abc123 --slug hello --output ./hello.ts
 ```
+
+`edge_functions deploy --path` bundles local TypeScript and dependencies with
+Bun and runs a local syntax check before upload. The Management API validates and
+normalizes the final server-side artifact against the multi-tenant Edge Runtime
+module policy consistently for CLI, Web Console, and direct API deployments.
+`deploy_bundle --files` accepts a JSON object in shell usage.
+Use `source --output <file>` for large Functions so terminal or automation output
+limits cannot truncate the original TS/JS source code. The destination must not
+already exist.
 
 Branch promotion is migration-first. `branch promotion_plan` prints pending
 versions, names, statement counts, and checksums without echoing SQL into terminal

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,6 +20,9 @@ const CONTEXT_KEYS = new Set([
 
 const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
 const temporaryDirectories: string[] = [];
+const LARGE_FUNCTION_SOURCE = "export const payload = "
+    + JSON.stringify("x".repeat(80 * 1024))
+    + ";\n";
 
 afterEach(() => {
     for (const server of servers.splice(0)) server.stop(true);
@@ -54,7 +57,86 @@ async function runProjectCli(
     return { exitCode, stdout, stderr };
 }
 
+function serveFunctionSource(sourceCode: string): string {
+    const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: () => Response.json({ code: sourceCode }),
+    });
+    servers.push(server);
+    return `http://127.0.0.1:${server.port}`;
+}
+
 describe("supacloud-cli process contract", () => {
+    test("flushes a Function source response larger than 64 KiB to stdout", async () => {
+        const apiUrl = serveFunctionSource(LARGE_FUNCTION_SOURCE);
+
+        const response = await runProjectCli(
+            ["edge_functions", "source", "--ref", "abc123", "--slug", "large-function"],
+            {
+                SUPACLOUD_API_URL: apiUrl,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stdout.length).toBeGreaterThan(64 * 1024);
+        expect(JSON.parse(response.stdout)).toEqual({ code: LARGE_FUNCTION_SOURCE });
+    });
+
+    test("writes a Function source response larger than 64 KiB without stdout truncation", async () => {
+        const outputDirectory = mkdtempSync(join(tmpdir(), "supacloud-cli-source-"));
+        temporaryDirectories.push(outputDirectory);
+        const outputPath = join(outputDirectory, "large-function.ts");
+        const apiUrl = serveFunctionSource(LARGE_FUNCTION_SOURCE);
+
+        const response = await runProjectCli(
+            [
+                "edge_functions", "source",
+                "--ref", "abc123",
+                "--slug", "large-function",
+                "--output", outputPath,
+            ],
+            {
+                SUPACLOUD_API_URL: apiUrl,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stdout).toContain("source written");
+        expect(response.stdout.length).toBeLessThan(1024);
+        expect(readFileSync(outputPath, "utf8")).toBe(LARGE_FUNCTION_SOURCE);
+    });
+
+    test("does not overwrite an existing Function source output", async () => {
+        const outputDirectory = mkdtempSync(join(tmpdir(), "supacloud-cli-source-existing-"));
+        temporaryDirectories.push(outputDirectory);
+        const outputPath = join(outputDirectory, "existing-function.ts");
+        writeFileSync(outputPath, "preserve-existing-source\n");
+        const apiUrl = serveFunctionSource(LARGE_FUNCTION_SOURCE);
+
+        const response = await runProjectCli(
+            [
+                "edge_functions", "source",
+                "--ref", "abc123",
+                "--slug", "large-function",
+                "--output", outputPath,
+            ],
+            {
+                SUPACLOUD_API_URL: apiUrl,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stderr).toContain("EEXIST");
+        expect(readFileSync(outputPath, "utf8")).toBe("preserve-existing-source\n");
+    });
+
     test("treats failure text as an error even when isError is false", () => {
         expect(cliToolResultIsError({
             isError: false,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -351,7 +351,8 @@ async function main() {
     const args = process.argv.slice(2);
     if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
         printHelp();
-        process.exit(0);
+        process.exitCode = 0;
+        return;
     }
 
     const cliTools = createCliTools();
@@ -374,5 +375,5 @@ async function main() {
 
 main().catch((error) => {
     console.error(`${commandName} failed:`, error);
-    process.exit(1);
+    process.exitCode = 1;
 });

--- a/packages/cli/src/shared/cli.ts
+++ b/packages/cli/src/shared/cli.ts
@@ -108,12 +108,14 @@ export async function runCli(
     if (!tool) {
         console.error(`❌ Unknown command: ${toolName}`);
         console.error(`Available commands: \n  ${formatAvailableCommands()}`);
-        process.exit(1);
+        process.exitCode = 1;
+        return;
     }
 
     if (args.length === 1 || args[1] === "--help" || args[1] === "-h") {
         console.error(formatToolHelp(toolName, tool));
-        process.exit(0);
+        process.exitCode = 0;
+        return;
     }
 
     if (
@@ -122,7 +124,8 @@ export async function runCli(
         (args[2] === "--help" || args[2] === "-h")
     ) {
         console.error(formatActionHelp(toolName, args[1], tool));
-        process.exit(0);
+        process.exitCode = 0;
+        return;
     }
     
     const parsedArgs: Record<string, any> = {};
@@ -163,13 +166,13 @@ export async function runCli(
         } else {
             console.log(JSON.stringify(result, null, 2));
         }
-        process.exit(cliToolResultIsError(result) ? 1 : 0);
+        process.exitCode = cliToolResultIsError(result) ? 1 : 0;
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`❌ Error: ${message}`);
         if (message.includes("required")) {
             console.error(`Hint: Pass arguments like --ref YOUR_REF`);
         }
-        process.exit(1);
+        process.exitCode = 1;
     }
 }

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -49,6 +49,31 @@ function captureTaskEventsTool(http: Record<string, unknown>) {
 }
 
 describe("edge_functions CLI tool", () => {
+    test("parses a bundle file map from a CLI JSON string", () => {
+        const { schema } = captureEdgeFunctionsTool({});
+        const parsed = parseToolArguments(schema, {
+            action: "deploy_bundle",
+            ref: "proj",
+            slug: "worker",
+            files: '{"index.ts":"export default {}","_shared/http.ts":"export const ok = true"}',
+        });
+
+        expect(parsed.files).toEqual({
+            "index.ts": "export default {}",
+            "_shared/http.ts": "export const ok = true",
+        });
+    });
+
+    test("returns a friendly error for invalid bundle file JSON", () => {
+        const { schema } = captureEdgeFunctionsTool({});
+        expect(() => parseToolArguments(schema, {
+            action: "deploy_bundle",
+            ref: "proj",
+            slug: "worker",
+            files: "{invalid",
+        })).toThrow("Invalid files JSON object");
+    });
+
     test("parses background routes from CLI-friendly comma-separated input", () => {
         const { schema } = captureEdgeFunctionsTool({});
         const parsed = parseToolArguments(schema, {

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -73,6 +73,24 @@ const backgroundRoutesSchema = Type.Optional(decodedSchema(
     parseBackgroundRoutes,
 ));
 
+const functionFilesRecordSchema = Type.Record(Type.String(), Type.String());
+
+function parseFunctionFiles(input: string | Record<string, string>): unknown {
+    if (typeof input !== "string") return input;
+    try {
+        return JSON.parse(input);
+    } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+        throw new Error("Invalid files JSON object");
+    }
+}
+
+const functionFilesSchema = decodedSchema(
+    Type.Union([Type.String(), functionFilesRecordSchema]),
+    functionFilesRecordSchema,
+    parseFunctionFiles,
+);
+
 const secretListSchema = Type.Array(Type.Object({ name: Type.String(), value: Type.String() }));
 
 function parseSecrets(value: string | Array<{ name: string; value: string }>): unknown {
@@ -119,6 +137,12 @@ function confirmedFunctionConfig(payload: unknown, expected: EdgeFunctionConfigI
     return true;
 }
 
+function functionSourceCode(payload: unknown): string | null {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+    const code = (payload as Record<string, unknown>).code;
+    return typeof code === "string" ? code : null;
+}
+
 export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
 
     // ═══ Edge Functions (5→1) ═══
@@ -132,14 +156,15 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
             slug: optional(Type.String(), "[deploy/deploy_bundle/config/source/delete/check] Function name"),
             code: optional(Type.String(), "[deploy/check] Function source code (TypeScript)"),
             path: optional(Type.String(), "[deploy/check] Local file path to read code from (alternative to code)"),
-            files: optional(Type.Record(Type.String(), Type.String()), "[deploy_bundle] File map: { 'index.ts': '...', '_shared/x.ts': '...' }"),
+            output: optional(Type.String(), "[source] Write source to this local file instead of stdout; the file must not already exist"),
+            files: optional(functionFilesSchema, "[deploy_bundle] File map as a JSON object: { 'index.ts': '...', '_shared/x.ts': '...' }"),
             entrypoint: optional(Type.String(), "[deploy_bundle] Entrypoint file (default: index.ts)"),
             minify: optional(Type.Boolean(), "[deploy/deploy_bundle] Minify bundle"),
             verify_jwt: optional(Type.Boolean(), "[deploy/deploy_bundle/config] Set JWT verification for this function"),
             background_routes: withDescription(backgroundRoutesSchema, "[deploy/deploy_bundle/config] Background route paths; pass comma-separated or JSON array in CLI"),
         },
         async (args: any) => {
-            const { action, ref, slug, path: pathArg, files, entrypoint, minify, verify_jwt, background_routes } = args;
+            const { action, ref, slug, path: pathArg, output, files, entrypoint, minify, verify_jwt, background_routes } = args;
             let code = args.code as string | undefined;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
 
@@ -197,8 +222,9 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
             if (pathArg && !code) {
                 try {
                     code = await bundleEdgeFunctionPath(pathArg);
-                } catch (e: any) {
-                    throw new Error(`Failed to bundle/read path ${pathArg}: ${e.message}`);
+                } catch (error: unknown) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    throw new Error(`Failed to bundle/read path ${pathArg}: ${message}`);
                 }
             }
 
@@ -256,7 +282,22 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
                 case "source":
                     need("slug", slug);
                     const sr = await http.get(`/v1/projects/${ref}/functions/${slug}/source`);
-                    text = sr.ok ? JSON.stringify(sr.data, null, 2) : `❌ Not found (${sr.status})`;
+                    if (!sr.ok) {
+                        text = `❌ Not found (${sr.status})`;
+                        break;
+                    }
+                    if (!output) {
+                        text = JSON.stringify(sr.data, null, 2);
+                        break;
+                    }
+                    const sourceCode = functionSourceCode(sr.data);
+                    if (sourceCode === null) {
+                        text = "❌ Source response did not contain a string code field";
+                        break;
+                    }
+                    const outputPath = resolve(output);
+                    writeFileSync(outputPath, sourceCode, { flag: "wx" });
+                    text = `✅ Function ${slug} source written to ${outputPath} (${Buffer.byteLength(sourceCode)} bytes)`;
                     break;
                 case "delete":
                     need("slug", slug);

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -414,6 +414,33 @@ describe("WorkerPool subprocess guard", () => {
     }
   });
 
+  test("reports the worker error when preheat rejects a computed dynamic import", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-import-project-"));
+    const functionPath = join(projectRoot, "computed-import.ts");
+    await Bun.write(functionPath, `
+      const moduleName = process.env.MODULE_PATH;
+      export default async function () {
+        return new Response(String(await import(moduleName)));
+      }
+    `);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const preheat = await pool.preheatIdleWorkers(
+        "proj_preheat_computed",
+        functionPath,
+        projectRoot,
+        { MODULE_PATH: "./local.ts" },
+      );
+
+      expect(preheat.succeeded).toBe(0);
+      expect(preheat.error).toBe("Computed dynamic imports are disabled in the multi-tenant Edge Runtime.");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("blocks computed imports from exposing runtime filesystem capabilities", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-runtime-module-project-"));
     const outsideRoot = await mkdtemp(join(tmpdir(), "supacloud-runtime-module-outside-"));

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -107,6 +107,7 @@ type WorkerPreheatResult = {
   success: boolean;
   cacheHit: boolean | null;
   moduleCacheSize: number;
+  error?: string;
 };
 
 export type WorkerPoolPreheatResult = {
@@ -115,6 +116,7 @@ export type WorkerPoolPreheatResult = {
   cacheHits: number;
   cacheMisses: number;
   durationMs: number;
+  error?: string;
 };
 
 export type WorkerPoolGenerationRotationResult = {
@@ -1043,7 +1045,12 @@ export class WorkerPool {
       const timeout = setTimeout(() => {
         worker.removeListener("message", onMsg);
         this.retireWorker(worker);
-        resolve({ success: false, cacheHit: null, moduleCacheSize: this.lastModuleCacheEntries });
+        resolve({
+          success: false,
+          cacheHit: null,
+          moduleCacheSize: this.lastModuleCacheEntries,
+          error: "Worker preheat timed out",
+        });
       }, this.config.preheatTimeoutMs ?? DEFAULT_PREHEAT_TIMEOUT_MS);
 
       const onMsg = (msg: {
@@ -1051,6 +1058,7 @@ export class WorkerPool {
         functionId?: string;
         moduleCacheHit?: boolean;
         moduleCacheSize?: number;
+        error?: string;
       }) => {
         if (msg.type === "preheat_done" && msg.functionId === functionId) {
           clearTimeout(timeout);
@@ -1067,7 +1075,12 @@ export class WorkerPool {
         ) {
           clearTimeout(timeout);
           worker.removeListener("message", onMsg);
-          resolve({ success: false, cacheHit: null, moduleCacheSize: this.lastModuleCacheEntries });
+          resolve({
+            success: false,
+            cacheHit: null,
+            moduleCacheSize: this.lastModuleCacheEntries,
+            error: typeof msg.error === "string" ? msg.error : "Worker preheat failed",
+          });
         }
       };
 
@@ -1088,7 +1101,12 @@ export class WorkerPool {
         worker.removeListener("message", onMsg);
         console.warn("[Pool] Failed to dispatch worker preheat", error);
         this.retireWorker(worker);
-        resolve({ success: false, cacheHit: null, moduleCacheSize: this.lastModuleCacheEntries });
+        resolve({
+          success: false,
+          cacheHit: null,
+          moduleCacheSize: this.lastModuleCacheEntries,
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     });
   }
@@ -1228,6 +1246,7 @@ export class WorkerPool {
       cacheHits: results.filter((result) => result.cacheHit === true).length,
       cacheMisses: results.filter((result) => result.cacheHit === false).length,
       durationMs,
+      error: results.find((result) => !result.success && result.error)?.error,
     };
   }
 

--- a/packages/management-api/bun.lock
+++ b/packages/management-api/bun.lock
@@ -11,6 +11,7 @@
         "@sinclair/typebox": "^0.34.52",
         "@svadmin/core": "^0.34.1",
         "@svadmin/elysia": "^0.10.7",
+        "acorn": "^8.18.0",
         "aws4fetch": "^1.0.20",
         "elysia": "^1.4.29",
         "jose": "^6.2.8",
@@ -75,6 +76,8 @@
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -37,6 +37,7 @@
     "@sinclair/typebox": "^0.34.52",
     "@svadmin/core": "^0.34.1",
     "@svadmin/elysia": "^0.10.7",
+    "acorn": "^8.18.0",
     "aws4fetch": "^1.0.20",
     "elysia": "^1.4.29",
     "jose": "^6.2.8",

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -1,6 +1,7 @@
 import { logger } from "../utils/logger";
 import { config } from "../config";
 import { ServiceUnavailableError } from "../utils/errors";
+import { normalizeEdgeRuntimeBundle } from "./edge-runtime-bundle";
 import path from "path";
 import fs from "fs/promises";
 
@@ -68,6 +69,7 @@ export interface EdgeFunctionPreheatPoolResult {
   cacheHits: number;
   cacheMisses: number;
   durationMs: number;
+  error?: string;
 }
 
 export interface EdgeFunctionPreheatResult {
@@ -137,29 +139,17 @@ const deployMetrics: EdgeFunctionDeployMetrics = {
   total_preheat_cache_misses: 0,
 };
 
-type BuildMetafileImport = {
-  path?: string;
-  original?: string;
-  kind?: string;
-  external?: boolean;
-};
-
-type BuildMetafile = {
-  inputs?: Record<string, {
-    bytes?: number;
-    imports?: BuildMetafileImport[];
-  }>;
-  outputs?: Record<string, {
-    bytes?: number;
-    imports?: BuildMetafileImport[];
-  }>;
-};
-
 type BundleFunctionResult = {
   code: string;
   sizeBytes: number;
   importCount: number;
-  metafile: BuildMetafile | null;
+};
+
+type BundleFunctionRequest = {
+  entrypoint: string;
+  outdir: string;
+  minify: boolean;
+  importMapPath?: string;
 };
 
 type EdgeFunctionRuntimeControlResult = {
@@ -352,61 +342,40 @@ function validateFunctionCode(code: string): {
   return { valid: true };
 }
 
-/**
- * Bundle a TypeScript entrypoint into a single self-contained .js file using Bun.build().
- * Returns the bundled code string, or null on failure.
- */
-async function bundleFunction(
-  entrypoint: string,
-  outdir: string,
-  outName: string,
-  minify: boolean = false,
-  importMapPath?: string,
-): Promise<BundleFunctionResult | null> {
-  try {
-    const buildOptions: Parameters<typeof Bun.build>[0] & {
-      importMap?: string;
-      metafile?: boolean;
-    } = {
-      entrypoints: [entrypoint],
-      outdir,
-      naming: `${outName}.[ext]`,
-      target: "bun",
-      minify,
-      external: resolveExternalPackages(),
-      metafile: true,
-    };
-    if (importMapPath) {
-      buildOptions.importMap = importMapPath;
-    }
-    const result = await Bun.build(buildOptions);
-
-    if (!result.success) {
-      const messages = result.logs
-        .map((l: { message?: string }) => l.message || String(l))
-        .join("\n");
-      logger.error(`[EdgeFunction] Bun.build() failed:\n${messages}`);
-      return null;
-    }
-
-    const artifact = result.outputs.find((output) => output.kind === "entry-point") ?? result.outputs[0];
-    if (!artifact) {
-      logger.error(`[EdgeFunction] Bun.build() produced no output`, { entrypoint });
-      return null;
-    }
-
-    const code = await artifact.text();
-    const metafile = normalizeBuildMetafile((result as { metafile?: unknown }).metafile);
-    return {
-      code,
-      sizeBytes: typeof artifact.size === "number" ? artifact.size : bundleSizeBytes(code),
-      importCount: countMetafileImports(metafile) ?? countImports(code),
-      metafile,
-    };
-  } catch (err) {
-    logger.error(`[EdgeFunction] Bundle error`, { error: err });
-    return null;
+// Build and final artifact policy failures must escape before a version can be written or preheated.
+async function buildFunctionCode(request: BundleFunctionRequest): Promise<string> {
+  const buildOptions: Parameters<typeof Bun.build>[0] & { importMap?: string } = {
+    entrypoints: [request.entrypoint],
+    outdir: request.outdir,
+    naming: "index.[ext]",
+    target: "bun",
+    minify: request.minify,
+    external: resolveExternalPackages(),
+  };
+  if (request.importMapPath) buildOptions.importMap = request.importMapPath;
+  const buildResult = await Bun.build(buildOptions);
+  if (!buildResult.success) {
+    const messages = buildResult.logs
+      .map((logEntry: { message?: string }) => logEntry.message || String(logEntry))
+      .join("\n");
+    logger.error(`[EdgeFunction] Bun.build() failed:\n${messages}`);
+    throw new Error("Bun.build() failed while bundling the function");
   }
+
+  const artifact = buildResult.outputs.find((output) => output.kind === "entry-point")
+    ?? buildResult.outputs[0];
+  if (!artifact) throw new Error("Bun.build() produced no function artifact");
+  return artifact.text();
+}
+
+async function bundleFunction(request: BundleFunctionRequest): Promise<BundleFunctionResult> {
+  const builtCode = await buildFunctionCode(request);
+  const normalizedBundle = normalizeEdgeRuntimeBundle(builtCode);
+  return {
+    code: normalizedBundle.code,
+    sizeBytes: bundleSizeBytes(normalizedBundle.code),
+    importCount: normalizedBundle.importCount,
+  };
 }
 
 async function sha256Hex(content: string): Promise<string> {
@@ -418,27 +387,6 @@ async function sha256Hex(content: string): Promise<string> {
 
 function bundleSizeBytes(content: string): number {
   return new TextEncoder().encode(content).byteLength;
-}
-
-function normalizeBuildMetafile(value: unknown): BuildMetafile | null {
-  if (!value || typeof value !== "object") return null;
-  const record = value as BuildMetafile;
-  return {
-    inputs: record.inputs && typeof record.inputs === "object" ? record.inputs : undefined,
-    outputs: record.outputs && typeof record.outputs === "object" ? record.outputs : undefined,
-  };
-}
-
-function countMetafileImports(metafile: BuildMetafile | null): number | null {
-  if (!metafile?.inputs) return null;
-  const specs = new Set<string>();
-  for (const input of Object.values(metafile.inputs)) {
-    for (const importEntry of input.imports || []) {
-      const specifier = importEntry.original || importEntry.path;
-      if (specifier) specs.add(specifier);
-    }
-  }
-  return specs.size;
 }
 
 function recordDeployMetrics(sizeBytes: number, importCount: number, preheat: EdgeFunctionPreheatResult): void {
@@ -457,36 +405,6 @@ function recordDeployMetrics(sizeBytes: number, importCount: number, preheat: Ed
 
 function snapshotDeployMetrics(): EdgeFunctionDeployMetrics {
   return { ...deployMetrics };
-}
-
-function countImports(code: string): number {
-  const specs = new Set<string>();
-  for (const match of code.matchAll(/\bimport\s+(?:[^"'()]*?\s+from\s+)?["']([^"']+)["']/g)) {
-    specs.add(match[1]);
-  }
-  for (const match of code.matchAll(/\bimport\s*\(\s*["']([^"']+)["']\s*\)/g)) {
-    specs.add(match[1]);
-  }
-  for (const match of code.matchAll(/\bexport\s+[^"'()]*?\s+from\s+["']([^"']+)["']/g)) {
-    specs.add(match[1]);
-  }
-  return specs.size;
-}
-
-function countFileImports(files: Record<string, string>): number {
-  const specs = new Set<string>();
-  for (const code of Object.values(files)) {
-    for (const match of code.matchAll(/\bimport\s+(?:[^"'()]*?\s+from\s+)?["']([^"']+)["']/g)) {
-      specs.add(match[1]);
-    }
-    for (const match of code.matchAll(/\bimport\s*\(\s*["']([^"']+)["']\s*\)/g)) {
-      specs.add(match[1]);
-    }
-    for (const match of code.matchAll(/\bexport\s+[^"'()]*?\s+from\s+["']([^"']+)["']/g)) {
-      specs.add(match[1]);
-    }
-  }
-  return specs.size;
 }
 
 type PreparedFunctionVersion = {
@@ -558,16 +476,19 @@ async function prepareSingleFunctionVersion(
   const sourcePath = path.join(stageDir, "index.src.ts");
   const buildDir = path.join(stageDir, ".build");
   await Bun.write(sourcePath, request.code);
-  const bundle = await bundleFunction(sourcePath, buildDir, "index", request.minify ?? false);
-  const deployedCode = bundle?.code ?? request.code;
-  const artifact = await writePreparedBundle(stageDir, finalDir, deployedCode, bundle?.sizeBytes);
+  const bundle = await bundleFunction({
+    entrypoint: sourcePath,
+    outdir: buildDir,
+    minify: request.minify ?? false,
+  });
+  const artifact = await writePreparedBundle(stageDir, finalDir, bundle.code, bundle.sizeBytes);
   await fs.rm(buildDir, { recursive: true, force: true });
   return {
     version,
-    bundled: bundle !== null,
+    bundled: true,
     entrypoint: null,
     importMap: null,
-    importCount: bundle?.importCount ?? countImports(request.code),
+    importCount: bundle.importCount,
     ...artifact,
   };
 }
@@ -614,14 +535,12 @@ async function prepareBundleFunctionVersion(
   await writeBundleSources(sourceDir, request.files);
   const importMap = await detectedImportMap(sourceDir);
   const buildDir = path.join(stageDir, ".build");
-  const bundle = await bundleFunction(
-    resolveInside(sourceDir, entrypoint),
-    buildDir,
-    "index",
-    request.minify ?? false,
-    importMap ? resolveInside(sourceDir, importMap) : undefined,
-  );
-  if (!bundle) throw new Error("Bun.build() failed while bundling the function");
+  const bundle = await bundleFunction({
+    entrypoint: resolveInside(sourceDir, entrypoint),
+    outdir: buildDir,
+    minify: request.minify ?? false,
+    importMapPath: importMap ? resolveInside(sourceDir, importMap) : undefined,
+  });
   await Bun.write(path.join(sourceDir, BUNDLED_SOURCE_RUNTIME_ENTRY), bundle.code);
   const artifact = await writePreparedBundle(stageDir, finalDir, bundle.code, bundle.sizeBytes);
   await fs.rm(buildDir, { recursive: true, force: true });
@@ -631,7 +550,7 @@ async function prepareBundleFunctionVersion(
     files: Object.keys(request.files).length,
     entrypoint,
     importMap,
-    importCount: bundle.importCount ?? countFileImports(request.files),
+    importCount: bundle.importCount,
     ...artifact,
   };
 }
@@ -983,7 +902,18 @@ function normalizePreheatPool(value: unknown): EdgeFunctionPreheatPoolResult {
     cacheHits: Number(record.cacheHits) || 0,
     cacheMisses: Number(record.cacheMisses) || 0,
     durationMs: Number(record.durationMs) || 0,
+    error: typeof record.error === "string" ? record.error : undefined,
   };
+}
+
+function runtimePreheatError(body: Record<string, unknown>): string | undefined {
+  for (const poolName of ["foreground", "background"] as const) {
+    const pool = body[poolName];
+    if (!pool || typeof pool !== "object" || Array.isArray(pool)) continue;
+    const error = (pool as Record<string, unknown>).error;
+    if (typeof error === "string" && error.trim()) return error;
+  }
+  return undefined;
 }
 
 async function readRuntimeControlBody(response: Response): Promise<Record<string, unknown>> {
@@ -1003,11 +933,14 @@ function preheatAcknowledgementError(
   body: Record<string, unknown>,
   requestedVersion?: string,
 ): string | undefined {
+  const runtimeError = runtimePreheatError(body);
   if (requestedVersion === undefined) {
-    return body.success === false ? "Edge Runtime reported preheat failure" : undefined;
+    return body.success === false
+      ? runtimeError ?? "Edge Runtime reported preheat failure"
+      : undefined;
   }
   if (body.success !== true) {
-    return "Edge Runtime did not report successful version readiness";
+    return runtimeError ?? "Edge Runtime did not report successful version readiness";
   }
   if (body.version !== requestedVersion) {
     return "Edge Runtime did not confirm the requested function version";

--- a/packages/management-api/src/services/edge-runtime-bundle.ts
+++ b/packages/management-api/src/services/edge-runtime-bundle.ts
@@ -1,0 +1,288 @@
+import { parse } from "acorn";
+
+type SyntaxNode = {
+  type: string;
+  start: number;
+  end: number;
+  loc?: { start: { line: number } };
+  [property: string]: unknown;
+};
+
+type StaticStringBinding = {
+  moduleSpecifier: string;
+  declarations: number;
+  writes: number;
+};
+
+type SourceReplacement = {
+  start: number;
+  end: number;
+  code: string;
+};
+
+export type EdgeRuntimeBundleNormalization = {
+  code: string;
+  importCount: number;
+};
+
+function isSyntaxNode(candidate: unknown): candidate is SyntaxNode {
+  return !!candidate
+    && typeof candidate === "object"
+    && "type" in candidate
+    && typeof candidate.type === "string"
+    && "start" in candidate
+    && typeof candidate.start === "number"
+    && "end" in candidate
+    && typeof candidate.end === "number";
+}
+
+function syntaxChildren(node: SyntaxNode): SyntaxNode[] {
+  const children: SyntaxNode[] = [];
+  for (const property of Object.values(node)) {
+    if (isSyntaxNode(property)) children.push(property);
+    if (Array.isArray(property)) children.push(...property.filter(isSyntaxNode));
+  }
+  return children;
+}
+
+function walkSyntax(node: SyntaxNode, visit: (syntaxNode: SyntaxNode) => void): void {
+  visit(node);
+  for (const child of syntaxChildren(node)) walkSyntax(child, visit);
+}
+
+function objectPatternIdentifiers(property: unknown): string[] {
+  if (!isSyntaxNode(property)) return [];
+  if (property.type === "RestElement") return patternIdentifiers(property.argument);
+  return property.type === "Property" ? patternIdentifiers(property.value) : [];
+}
+
+function patternIdentifiers(pattern: unknown): string[] {
+  if (!isSyntaxNode(pattern)) return [];
+  if (pattern.type === "Identifier") return [String(pattern.name)];
+  if (pattern.type === "RestElement") return patternIdentifiers(pattern.argument);
+  if (pattern.type === "AssignmentPattern") return patternIdentifiers(pattern.left);
+  if (pattern.type === "ArrayPattern") return (pattern.elements as unknown[]).flatMap(patternIdentifiers);
+  if (pattern.type === "ObjectPattern") {
+    return (pattern.properties as unknown[]).flatMap(objectPatternIdentifiers);
+  }
+  return [];
+}
+
+function declarationIdentifiers(node: SyntaxNode): string[] {
+  if (node.type === "VariableDeclarator") return patternIdentifiers(node.id);
+  if (["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].includes(node.type)) {
+    const parameters = Array.isArray(node.params) ? node.params.flatMap(patternIdentifiers) : [];
+    return [...patternIdentifiers(node.id), ...parameters];
+  }
+  if (["ClassDeclaration", "ClassExpression"].includes(node.type)) return patternIdentifiers(node.id);
+  if (["ImportSpecifier", "ImportDefaultSpecifier", "ImportNamespaceSpecifier"].includes(node.type)) {
+    return patternIdentifiers(node.local);
+  }
+  return node.type === "CatchClause" ? patternIdentifiers(node.param) : [];
+}
+
+function assignedIdentifiers(node: SyntaxNode): string[] {
+  if (node.type === "AssignmentExpression") return patternIdentifiers(node.left);
+  if (node.type === "UpdateExpression") return patternIdentifiers(node.argument);
+  if (["ForInStatement", "ForOfStatement"].includes(node.type)
+    && isSyntaxNode(node.left)
+    && node.left.type !== "VariableDeclaration") {
+    return patternIdentifiers(node.left);
+  }
+  return [];
+}
+
+function parseBundle(code: string): SyntaxNode {
+  return parse(code, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    allowHashBang: true,
+    locations: true,
+  }) as unknown as SyntaxNode;
+}
+
+function staticStringBinding(declaration: SyntaxNode): [string, StaticStringBinding] | null {
+  if (!isSyntaxNode(declaration.id) || declaration.id.type !== "Identifier") return null;
+  if (!isSyntaxNode(declaration.init) || declaration.init.type !== "Literal") return null;
+  if (typeof declaration.init.value !== "string") return null;
+  return [
+    String(declaration.id.name),
+    {
+      moduleSpecifier: declaration.init.value,
+      declarations: 0,
+      writes: 0,
+    },
+  ];
+}
+
+function topLevelStringBindings(program: SyntaxNode): Map<string, StaticStringBinding> {
+  const bindings = new Map<string, StaticStringBinding>();
+  const statements = Array.isArray(program.body) ? program.body.filter(isSyntaxNode) : [];
+  for (const statement of statements.filter((entry) => entry.type === "VariableDeclaration")) {
+    // An uninitialized top-level var resolves to undefined; lexical bindings would throw in TDZ.
+    if (statement.kind !== "var") continue;
+    const declarations = Array.isArray(statement.declarations) ? statement.declarations : [];
+    for (const declaration of declarations.filter(isSyntaxNode)) {
+      const binding = staticStringBinding(declaration);
+      if (binding) bindings.set(...binding);
+    }
+  }
+  return bindings;
+}
+
+function recordBindingUsage(program: SyntaxNode, bindings: Map<string, StaticStringBinding>): void {
+  walkSyntax(program, (node) => {
+    for (const name of declarationIdentifiers(node)) {
+      const binding = bindings.get(name);
+      if (binding) binding.declarations++;
+    }
+    for (const name of assignedIdentifiers(node)) {
+      const binding = bindings.get(name);
+      if (binding) binding.writes++;
+    }
+  });
+}
+
+function dynamicImports(program: SyntaxNode): SyntaxNode[] {
+  const foundImports: SyntaxNode[] = [];
+  walkSyntax(program, (node) => {
+    if (node.type === "ImportExpression") foundImports.push(node);
+  });
+  return foundImports;
+}
+
+function computedDynamicImports(program: SyntaxNode): SyntaxNode[] {
+  return dynamicImports(program)
+    .filter((dynamicImport) => !isLiteralModuleSpecifier(dynamicImport.source));
+}
+
+function directEval(program: SyntaxNode): SyntaxNode | undefined {
+  let call: SyntaxNode | undefined;
+  walkSyntax(program, (node) => {
+    if (call || node.type !== "CallExpression" || !isSyntaxNode(node.callee)) return;
+    if (node.callee.type === "Identifier" && node.callee.name === "eval") call = node;
+  });
+  return call;
+}
+
+function isLiteralModuleSpecifier(source: unknown): boolean {
+  if (!isSyntaxNode(source)) return false;
+  if (source.type === "Literal") return typeof source.value === "string";
+  return source.type === "TemplateLiteral"
+    && Array.isArray(source.expressions)
+    && source.expressions.length === 0;
+}
+
+function literalModuleSpecifier(source: unknown): string | null {
+  if (!isSyntaxNode(source)) return null;
+  if (source.type === "Literal") return typeof source.value === "string" ? source.value : null;
+  if (!isLiteralModuleSpecifier(source) || !Array.isArray(source.quasis)) return null;
+  const quasi = source.quasis.find(isSyntaxNode);
+  if (!quasi || !quasi.value || typeof quasi.value !== "object") return null;
+  const cooked = (quasi.value as Record<string, unknown>).cooked;
+  return typeof cooked === "string" ? cooked : null;
+}
+
+function finalBundleImportCount(program: SyntaxNode): number {
+  const moduleSpecifiers = new Set<string>();
+  walkSyntax(program, (node) => {
+    if (!["ImportDeclaration", "ImportExpression", "ExportNamedDeclaration", "ExportAllDeclaration"]
+      .includes(node.type)) return;
+    const moduleSpecifier = literalModuleSpecifier(node.source);
+    if (moduleSpecifier !== null) moduleSpecifiers.add(moduleSpecifier);
+  });
+  return moduleSpecifiers.size;
+}
+
+function compatibilityError(node: SyntaxNode, detail: string): Error {
+  const line = node.loc?.start.line;
+  const location = line ? ` at bundle line ${line}` : "";
+  return new Error(`Edge Runtime compatibility check failed${location}: ${detail}`);
+}
+
+function literalDynamicImport(
+  code: string,
+  dynamicImport: SyntaxNode,
+  moduleSpecifier: string,
+): string {
+  const source = dynamicImport.source as SyntaxNode;
+  return code.slice(dynamicImport.start, source.start)
+    + JSON.stringify(moduleSpecifier)
+    + code.slice(source.end, dynamicImport.end);
+}
+
+function provenImportBinding(
+  dynamicImport: SyntaxNode,
+  bindings: Map<string, StaticStringBinding>,
+): { name: string; binding: StaticStringBinding } {
+  if (!isSyntaxNode(dynamicImport.source) || dynamicImport.source.type !== "Identifier") {
+    throw compatibilityError(dynamicImport, "computed dynamic imports are disabled");
+  }
+  const name = String(dynamicImport.source.name);
+  const binding = bindings.get(name);
+  if (!binding
+    || binding.declarations !== 1
+    || binding.writes !== 0) {
+    throw compatibilityError(dynamicImport, "computed dynamic imports are disabled");
+  }
+  return { name, binding };
+}
+
+function computedImportReplacement(
+  dynamicImport: SyntaxNode,
+  bindings: Map<string, StaticStringBinding>,
+  code: string,
+): SourceReplacement {
+  const { name, binding } = provenImportBinding(dynamicImport, bindings);
+  const literalSpecifier = JSON.stringify(binding.moduleSpecifier);
+  const literalImport = literalDynamicImport(code, dynamicImport, binding.moduleSpecifier);
+  // import(undefined) resolves the same "undefined" specifier before this var is initialized.
+  const uninitializedImport = literalDynamicImport(code, dynamicImport, "undefined");
+  return {
+    start: dynamicImport.start,
+    end: dynamicImport.end,
+    code: `(${name} === ${literalSpecifier} ? ${literalImport} : ${uninitializedImport})`,
+  };
+}
+
+function applyReplacements(code: string, replacements: SourceReplacement[]): string {
+  return [...replacements]
+    .sort((left, right) => right.start - left.start)
+    .reduce(
+      (normalizedCode, replacement) => normalizedCode.slice(0, replacement.start)
+        + replacement.code
+        + normalizedCode.slice(replacement.end),
+      code,
+    );
+}
+
+function validatedFinalProgram(code: string): SyntaxNode {
+  const program = parseBundle(code);
+  const unsupported = dynamicImports(program)
+    .find((dynamicImport) => !isLiteralModuleSpecifier(dynamicImport.source));
+  if (unsupported) throw compatibilityError(unsupported, "computed dynamic imports are disabled");
+  return program;
+}
+
+export function normalizeEdgeRuntimeBundle(code: string): EdgeRuntimeBundleNormalization {
+  const program = parseBundle(code);
+  const computedImports = computedDynamicImports(program);
+  const evalCall = computedImports.length > 0 ? directEval(program) : undefined;
+  if (evalCall) {
+    throw compatibilityError(
+      evalCall,
+      "direct eval prevents proving computed dynamic import bindings are immutable",
+    );
+  }
+  const bindings = topLevelStringBindings(program);
+  recordBindingUsage(program, bindings);
+  const replacements = computedImports.map((dynamicImport) => (
+    computedImportReplacement(dynamicImport, bindings, code)
+  ));
+  const normalizedCode = applyReplacements(code, replacements);
+  const finalProgram = validatedFinalProgram(normalizedCode);
+  return {
+    code: normalizedCode,
+    importCount: finalBundleImportCount(finalProgram),
+  };
+}

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -73,6 +73,118 @@ afterAll(async () => {
 });
 
 describe("edgeFunctionService bundle metadata", () => {
+  test("returns the Edge Runtime preheat error when version readiness fails", async () => {
+    globalThis.fetch = (async () => Response.json({
+      success: false,
+      version: "1",
+      foreground: {
+        attempted: 1,
+        succeeded: 0,
+        cacheHits: 0,
+        cacheMisses: 0,
+        durationMs: 1,
+        error: "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
+      },
+      background: {
+        attempted: 0,
+        succeeded: 0,
+        cacheHits: 0,
+        cacheMisses: 0,
+        durationMs: 0,
+      },
+    })) as typeof fetch;
+
+    const deployed = await edgeFunctionService.deployRelease({
+      ref: "proj_preheat_diagnostic",
+      slug: "computed-import",
+      code: "export default { fetch: () => new Response('unreachable') };",
+    });
+
+    expect(deployed.success).toBe(false);
+    expect(deployed.error).toContain(
+      "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
+    );
+  });
+
+  test("normalizes computed imports in final single-file and bundle artifacts", async () => {
+    const functionCode = `
+      var optionalPackage = "optional-runtime-package";
+      export default {
+        fetch: async () => Response.json(await import(optionalPackage).catch(() => null)),
+      };
+    `;
+    const singleFile = await edgeFunctionService.deployDetailed(
+      "proj_normalized_single",
+      "normalized-single",
+      functionCode,
+    );
+    const bundle = await edgeFunctionService.deployBundleDetailed(
+      "proj_normalized_bundle",
+      "normalized-bundle",
+      { "index.ts": functionCode },
+    );
+
+    for (const deployment of [singleFile, bundle]) {
+      expect(deployment).toMatchObject({ success: true, import_count: 2 });
+      const artifactCode = await readFile(deployment.content_path!, "utf8");
+      expect(artifactCode).toContain('import("optional-runtime-package")');
+      expect(artifactCode).toContain('import("undefined")');
+      expect(artifactCode).not.toContain("import(optionalPackage)");
+      expect(deployment.bundle_size_bytes).toBe(Buffer.byteLength(artifactCode));
+      expect(deployment.bundle_hash).toBe(
+        createHash("sha256").update(artifactCode).digest("hex").slice(0, 16),
+      );
+    }
+  });
+
+  test("rejects unresolved computed imports without activating a new version", async () => {
+    const ref = "proj_computed_import_rejected";
+    const slug = "computed-import-rejected";
+    const first = await edgeFunctionService.deployDetailed(
+      ref,
+      slug,
+      "export default { fetch: () => new Response('version-one') };",
+    );
+    const rejected = await edgeFunctionService.deployDetailed(
+      ref,
+      slug,
+      "export default { fetch: async () => Response.json(await import(process.env.RUNTIME_PACKAGE)) };",
+    );
+
+    expect(first).toMatchObject({ success: true, version: "1" });
+    expect(rejected).toMatchObject({ success: false });
+    expect(rejected.error).toContain("computed dynamic imports are disabled");
+    expect(await edgeFunctionService.getConfig(ref, slug)).toMatchObject({ version: "1" });
+    expect((await edgeFunctionService.listVersions(ref, slug)).map((version) => version.version))
+      .toEqual(["1"]);
+  });
+
+  test("does not write or preheat a single-file version when Bun.build fails", async () => {
+    const ref = "proj_single_build_failure";
+    const slug = "single-build-failure";
+    let runtimeCalls = 0;
+    globalThis.fetch = (async () => {
+      runtimeCalls += 1;
+      return Response.json({ success: true, version: "1" });
+    }) as typeof fetch;
+
+    const rejected = await edgeFunctionService.deployDetailed(
+      ref,
+      slug,
+      `
+        import "./missing-build-input.ts";
+        export default { fetch: () => new Response("unreachable") };
+      `,
+    );
+
+    expect(rejected).toMatchObject({ success: false });
+    expect(rejected.error).toMatch(/bundle/i);
+    expect(runtimeCalls).toBe(0);
+    expect(await edgeFunctionService.getConfig(ref, slug)).toEqual({ verify_jwt: true });
+    expect(await edgeFunctionService.listVersions(ref, slug)).toEqual([]);
+    expect(existsSync(join(functionsRoot, ref, ".versions", slug, "1"))).toBe(false);
+  });
+
   test("commits verify_jwt=false with the activated version before invalidation", async () => {
     const ref = "proj_atomic_false";
     const slug = "public-hook";
@@ -662,7 +774,7 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(result.version).toBe("1");
     expect(result.bundle_hash).toMatch(/^[a-f0-9]{16}$/);
     expect(result.bundle_size_bytes).toBeGreaterThan(0);
-    expect(result.import_count).toBe(2);
+    expect(result.import_count).toBe(1);
     expect(result.external_packages).toEqual(["left-pad", "@scope/pkg"]);
     expect(result.preheat).toMatchObject({
       ok: true,
@@ -687,8 +799,8 @@ describe("edgeFunctionService bundle metadata", () => {
       total_deploys: metricsBefore.total_deploys + 1,
       total_bundle_size_bytes: metricsBefore.total_bundle_size_bytes + result.bundle_size_bytes!,
       last_bundle_size_bytes: result.bundle_size_bytes,
-      total_import_count: metricsBefore.total_import_count + 2,
-      last_import_count: 2,
+      total_import_count: metricsBefore.total_import_count + 1,
+      last_import_count: 1,
       total_preheat_duration_ms: metricsBefore.total_preheat_duration_ms + result.preheat!.duration_ms,
       last_preheat_duration_ms: result.preheat?.duration_ms,
       total_preheat_attempted: metricsBefore.total_preheat_attempted + 3,

--- a/packages/management-api/tests/unit/edge-runtime-bundle.test.ts
+++ b/packages/management-api/tests/unit/edge-runtime-bundle.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeEdgeRuntimeBundle } from "../../src/services/edge-runtime-bundle";
+
+const computedImportRejectionCases = [
+  ["a reassigned binding", `
+    var optionalPackage = "first-package";
+    optionalPackage = "second-package";
+    export const modulePromise = import(optionalPackage);
+  `],
+  ["duplicate top-level declarations", `
+    var optionalPackage = "first-package";
+    var optionalPackage = "second-package";
+    export const modulePromise = import(optionalPackage);
+  `],
+  ["duplicate declarators in one declaration", `
+    var optionalPackage = "first-package", optionalPackage = "second-package";
+    export const modulePromise = import(optionalPackage);
+  `],
+  ["an update expression", `
+    var optionalPackage = "optional-runtime-package";
+    optionalPackage++;
+    export const modulePromise = import(optionalPackage);
+  `],
+  ["a logical assignment", `
+    var optionalPackage = "optional-runtime-package";
+    optionalPackage ||= "fallback-package";
+    export const modulePromise = import(optionalPackage);
+  `],
+  ["a destructuring assignment", `
+    var optionalPackage = "optional-runtime-package";
+    ({ optionalPackage } = { optionalPackage: "different-package" });
+    export const modulePromise = import(optionalPackage);
+  `],
+  ["a for-of write", `
+    var optionalPackage = "optional-runtime-package";
+    for (optionalPackage of ["different-package"]) {}
+    export const modulePromise = import(optionalPackage);
+  `],
+  ["a shadowed binding", `
+    var optionalPackage = "optional-runtime-package";
+    export function loadOptionalPackage(optionalPackage) {
+      return import(optionalPackage);
+    }
+  `],
+  ["an environment expression", `
+    export const modulePromise = import(process.env.RUNTIME_PACKAGE);
+  `],
+  ["an interpolated template", `
+    const packageScope = "optional";
+    export const modulePromise = import(\`\${packageScope}/runtime-package\`);
+  `],
+  ["a lexical binding", `
+    const optionalPackage = "optional-runtime-package";
+    export const modulePromise = import(optionalPackage);
+  `],
+] as const;
+
+async function moduleEvaluation(code: string): Promise<"loaded" | "rejected"> {
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(code).toString("base64")}`;
+  try {
+    await import(moduleUrl);
+    return "loaded";
+  } catch {
+    return "rejected";
+  }
+}
+
+describe("Edge Runtime final bundle compatibility", () => {
+  test("normalizes an immutable top-level string dynamic import", () => {
+    const normalization = normalizeEdgeRuntimeBundle(`
+      var optionalPackage = "optional-runtime-package";
+      export async function loadOptionalPackage() {
+        return import(optionalPackage).catch(() => null);
+      }
+    `);
+
+    expect(normalization.code).toContain('import("optional-runtime-package")');
+    expect(normalization.code).toContain('import("undefined")');
+    expect(normalization.code).not.toContain("import(optionalPackage)");
+    expect(normalization.code).toContain('optionalPackage === "optional-runtime-package"');
+    expect(normalization.importCount).toBe(2);
+  });
+
+  test("preserves rejection when a closure is called before its binding initializes", async () => {
+    const sourceCode = `
+      await loadOptionalPackage();
+      var optionalPackage = "node:path";
+      function loadOptionalPackage() {
+        return import(optionalPackage);
+      }
+    `;
+    const normalization = normalizeEdgeRuntimeBundle(sourceCode);
+
+    expect(normalization.code).toContain('import("node:path")');
+    expect(normalization.code).toContain('import("undefined")');
+    expect(normalization.code).not.toContain("import(optionalPackage)");
+    expect(await moduleEvaluation(sourceCode)).toBe("rejected");
+    expect(await moduleEvaluation(normalization.code)).toBe("rejected");
+  });
+
+  test("preserves loading after the binding initializes", async () => {
+    const sourceCode = `
+      var optionalPackage = "node:path";
+      await loadOptionalPackage();
+      function loadOptionalPackage() {
+        return import(optionalPackage);
+      }
+    `;
+    const normalization = normalizeEdgeRuntimeBundle(sourceCode);
+
+    expect(await moduleEvaluation(sourceCode)).toBe("loaded");
+    expect(await moduleEvaluation(normalization.code)).toBe("loaded");
+  });
+
+  test("preserves import options in both proven literal branches", () => {
+    const normalization = normalizeEdgeRuntimeBundle(`
+      var optionalPackage = "./optional-runtime-package.json";
+      export const modulePromise = import(optionalPackage, { with: { type: "json" } });
+    `);
+
+    expect(normalization.code).toContain(
+      'import("./optional-runtime-package.json", { with: { type: "json" } })',
+    );
+    expect(normalization.code).toContain(
+      'import("undefined", { with: { type: "json" } })',
+    );
+  });
+
+  test("keeps literal dynamic imports unchanged", () => {
+    const sourceCode = 'export const modulePromise = import("optional-runtime-package");';
+
+    expect(normalizeEdgeRuntimeBundle(sourceCode)).toEqual({ code: sourceCode, importCount: 1 });
+  });
+
+  test("counts unique imports from the normalized final artifact", () => {
+    const sourceCode = `
+      import "first-package";
+      export { value } from "second-package";
+      export const third = import(\`third-package\`);
+      export const duplicate = import("first-package");
+    `;
+
+    expect(normalizeEdgeRuntimeBundle(sourceCode).importCount).toBe(3);
+  });
+
+  test.each(computedImportRejectionCases)("rejects %s", (_caseName, sourceCode) => {
+    expect(() => normalizeEdgeRuntimeBundle(sourceCode))
+      .toThrow("computed dynamic imports are disabled");
+  });
+
+  test("rejects direct eval when normalizing a computed dynamic import", () => {
+    expect(() => normalizeEdgeRuntimeBundle(`
+      var optionalPackage = "optional-runtime-package";
+      eval('optionalPackage = "different-package"');
+      export const modulePromise = import(optionalPackage);
+    `)).toThrow("direct eval prevents proving computed dynamic import bindings are immutable");
+  });
+});


### PR DESCRIPTION
## Summary

- normalize only provably static dynamic-import bindings at the Management API final-artifact boundary for CLI, Web Console, and direct API deployments
- fail closed before immutable version creation when Bun bundling or the Edge Runtime module policy fails, while preserving the existing Runtime computed-import guard
- propagate Runtime preheat diagnostics and fix official CLI bundle JSON input, large source output, and stdout/stderr flush behavior

## Root cause

The official CLI successfully bundled current Supabase JS locally, but the final server-side Bun artifact retained `import(OTEL_PKG)`. Edge Runtime correctly rejects computed module targets, so local syntax validation passed while remote readiness failed.

The Management API now rewrites only a unique, unmodified, unshadowed top-level `var name = "literal"` binding. It preserves the pre-initialization `import(undefined)` behavior with a literal `"undefined"` branch, preserves import options, and rejects lexical bindings, writes, shadowing, direct eval, or any unresolved expression. Hash, byte size, and import count are computed from the normalized final artifact.

## CLI behavior

- `edge_functions deploy_bundle --files` accepts a JSON object string in shell usage
- `edge_functions source --output` writes complete original TS/JS without overwriting an existing file
- CLI exits naturally through `process.exitCode`, preventing output truncation above 64 KiB
- local `deploy --path` remains Bun-based; no CLI-side AST rewrite or third-party source special case was added

## Validation

- Management API focused: 42 pass, 0 fail; full shared unit: 1222 pass, 0 fail; all isolated suites passed; typecheck passed
- CLI full: 111 pass, 0 fail; focused 27 pass; typecheck and build passed
- Edge Runtime full: 63 pass, 0 fail; typecheck passed
- standalone Management build: 651 modules compiled
- real FA/Supabase JS double-bundle smoke removed the computed OTEL import and produced literal runtime-safe branches
- independent semantic checks covered pre/post initialization, Promise behavior, import options order/count, a resolvable `undefined` package, comments/parentheses, multiple imports, and let/const fail-closed
- `git diff --check` passed

## Security and rollout

This does not relax the multi-tenant Runtime module policy. Unproven computed imports still fail closed, and Runtime validation remains the second enforcement layer. This PR has not been deployed to test or production.