### PR TITLE
fix(upgrade): verify external runtime asset transactions

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -206,7 +206,30 @@ source /etc/profile.d/supacloud.sh
 
 **Actualizaciones de producción**
 
-Los servidores de producción se actualizan reemplazando el binario Linux publicado en `/usr/local/bin/supacloud`; no necesitan `git pull` el código fuente de la aplicación durante las actualizaciones normales.
+Usa la CLI de administración para una actualización de producción verificada de
+varios componentes. Fija versiones exactas de Management y Edge Runtime para
+verificar y activar Management, Web Console y un Edge Runtime externo como una
+transacción con capacidad de reversión:
+
+```bash
+npx @supacloud/admin ssh upgrade \
+  --version 0.50.27 \
+  --edge_runtime_version 0.16.7 \
+  --github_proxy direct
+```
+
+La transacción requiere `EDGE_RUNTIME_MODE=external` persistido; el modo
+embedded se rechaza antes de modificar artefactos de release o servicios.
+Conserva la ruta del ejecutable systemd, el puerto, el modo y el estado enabled
+de Edge Runtime, y verifica cada componente con su propio SHA256 y attestation
+de GitHub. Caddy y GoTrue quedan fuera de esta transacción y no se reemplazan.
+
+Omite `--edge_runtime_version` solo cuando quieras actualizar Management y Web
+Console sin cambiar Edge Runtime; la CLI de administración informa ese límite.
+
+El binario de servidor `/usr/local/bin/supacloud` conserva la ruta local que
+solo actualiza Management/Web Console. Los servidores de producción no necesitan
+hacer `git pull` del código fuente durante las actualizaciones normales.
 
 ```bash
 sudo supacloud upgrade --yes
@@ -532,7 +555,8 @@ Para operadores humanos, la división de CLI ahora es:
 - `supacloudctl cli ...`: punto de entrada local unificado. El despacho normal es solo local y no contacta npm; usa `supacloudctl check-update cli` explícitamente cuando sea necesario.
 - `@supacloud/admin` / `supacloud-admin`: CLI de administración de servidor y plataforma
 - `supacloudctl admin ...`: punto de entrada local unificado con el mismo comportamiento offline-por-defecto; usa `supacloudctl check-update admin` explícitamente.
-- En servidores instalados, `/usr/local/bin/supacloud` sigue siendo el binario del servidor compilado; las actualizaciones del servidor siguen usando `sudo supacloud upgrade --yes`.
+- Usa `npx @supacloud/admin ssh upgrade --version <management-version> --edge_runtime_version <edge-version>` para la transacción verificada de Management, Web Console y Edge Runtime externo.
+- En servidores instalados, `/usr/local/bin/supacloud` sigue siendo el binario del servidor compilado; `sudo supacloud upgrade --yes` se limita a Management/Web Console salvo que el flujo Admin compatible reciba un objetivo exacto de Edge Runtime.
 
 
 ### Estructura del Proyecto

--- a/README.md
+++ b/README.md
@@ -208,7 +208,30 @@ source /etc/profile.d/supacloud.sh
 
 **Production Upgrades**
 
-Production servers upgrade by replacing the released Linux binary at `/usr/local/bin/supacloud`; they do not need to `git pull` application source during normal upgrades.
+Use the Admin CLI for a verified multi-component production upgrade. Pin exact
+Management and Edge Runtime versions so the command can verify and activate
+Management, Web Console, and an external Edge Runtime as one rollback-capable
+transaction:
+
+```bash
+npx @supacloud/admin ssh upgrade \
+  --version 0.50.27 \
+  --edge_runtime_version 0.16.7 \
+  --github_proxy direct
+```
+
+This transaction requires persisted `EDGE_RUNTIME_MODE=external`; embedded
+mode is rejected before release artifacts or services are changed. It preserves
+the Edge Runtime systemd executable path, port, mode, and enabled state, and
+verifies each released component against its own SHA256 checksum and GitHub
+attestation. Caddy and GoTrue are outside this transaction and are not replaced.
+
+Omit `--edge_runtime_version` only when intentionally upgrading Management and
+Web Console without changing Edge Runtime; the Admin CLI reports that boundary.
+
+The installed `/usr/local/bin/supacloud` server binary still provides the
+Management/Web Console-only local upgrade path. Production servers do not need
+to `git pull` application source during normal upgrades.
 
 ```bash
 sudo supacloud upgrade --yes
@@ -534,7 +557,8 @@ For human operators, the CLI split is now:
 - `supacloudctl cli ...`: unified local entrypoint. Normal dispatch is local-only and does not contact npm; use `supacloudctl check-update cli` explicitly when needed.
 - `@supacloud/admin` / `supacloud-admin`: server and platform administration CLI
 - `supacloudctl admin ...`: unified local entrypoint with the same offline-by-default behavior; use `supacloudctl check-update admin` explicitly.
-- On installed servers, `/usr/local/bin/supacloud` remains the compiled server binary; server upgrades still use `sudo supacloud upgrade --yes`.
+- Use `npx @supacloud/admin ssh upgrade --version <management-version> --edge_runtime_version <edge-version>` for the verified Management, Web Console, and external Edge Runtime transaction.
+- On installed servers, `/usr/local/bin/supacloud` remains the compiled server binary; `sudo supacloud upgrade --yes` is limited to the Management/Web Console path unless an exact Edge Runtime target is supplied through the supported Admin flow.
 
 
 ### Project Structure

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -206,7 +206,28 @@ source /etc/profile.d/supacloud.sh
 
 **生产环境升级**
 
-生产服务器升级时直接替换 `/usr/local/bin/supacloud` 中的 Linux Release 二进制文件，常规升级不需要在服务器上 `git pull` 源码。
+生产环境的多组件升级应使用 Admin CLI。固定 Management 和 Edge Runtime
+的精确版本后，命令会把 Management、Web Console 和外置 Edge Runtime
+作为一个支持回滚的事务进行校验和启用：
+
+```bash
+npx @supacloud/admin ssh upgrade \
+  --version 0.50.27 \
+  --edge_runtime_version 0.16.7 \
+  --github_proxy direct
+```
+
+该事务要求持久化配置为 `EDGE_RUNTIME_MODE=external`；embedded 模式会在
+改动 Release 制品或服务前被拒绝。命令会保留 Edge Runtime 的 systemd
+可执行文件路径、端口、模式和 enabled 状态，并分别使用各组件自己的
+SHA256 与 GitHub attestation 做校验。Caddy 和 GoTrue 不属于该事务，
+不会被替换。
+
+只有明确只升级 Management 和 Web Console、不改 Edge Runtime 时，才省略
+`--edge_runtime_version`；Admin CLI 会明确报告这个边界。
+
+已安装的 `/usr/local/bin/supacloud` 服务端二进制仍提供只覆盖 Management/
+Web Console 的本机升级路径。生产服务器常规升级不需要 `git pull` 源码。
 
 ```bash
 sudo supacloud upgrade --yes
@@ -477,7 +498,8 @@ desired state 保存在项目专用元数据列里（`postgrest_desired`、`post
 - `supacloudctl cli ...`：统一本地入口，普通分发默认离线且不访问 npm；需要时显式运行 `supacloudctl check-update cli`
 - `@supacloud/admin` / `supacloud-admin`：服务器管理员 CLI，处理 SSH、安装、升级、租户运维
 - `supacloudctl admin ...`：统一本地入口，同样默认离线；需要时显式运行 `supacloudctl check-update admin`
-- 已安装服务器上的 `/usr/local/bin/supacloud` 仍是编译后的服务端二进制，服务端升级继续使用 `sudo supacloud upgrade --yes`
+- Management、Web Console 与外置 Edge Runtime 的受校验事务使用 `npx @supacloud/admin ssh upgrade --version <management-version> --edge_runtime_version <edge-version>`
+- 已安装服务器上的 `/usr/local/bin/supacloud` 仍是编译后的服务端二进制；除非通过受支持的 Admin 流程提供精确 Edge Runtime 目标，否则 `sudo supacloud upgrade --yes` 只覆盖 Management/Web Console
 
 
 ### 项目结构

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -32,6 +32,37 @@ npx @supacloud/admin project create --name my-app
 npx @supacloud/admin project list
 ```
 
+## Verified platform upgrades
+
+Use one explicit Admin command to upgrade Management, Web Console, and an
+external Edge Runtime as a single rollback-capable transaction:
+
+```bash
+npx @supacloud/admin ssh upgrade \
+  --version 0.50.27 \
+  --edge_runtime_version 0.16.7 \
+  --github_proxy direct
+```
+
+The command supports direct root SSH and passwordless `sudo -n`. It installs
+the pinned GitHub provenance verifier when needed, verifies each component
+against its own release checksum and attestation, and preserves the Edge
+Runtime systemd `ExecStart`, port, mode, and enabled state. Component upgrades
+require persisted `EDGE_RUNTIME_MODE=external`; embedded mode is rejected
+before release artifacts or services are changed.
+
+Omitting `--edge_runtime_version` retains the Management and Web Console-only
+upgrade behavior and reports that Edge Runtime was not upgraded. Caddy and
+GoTrue are outside this transaction and are not replaced. After a capable
+Management release is active, an exact rollback can use that active upgrader
+with explicit older targets, for example:
+
+```bash
+npx @supacloud/admin ssh upgrade \
+  --version 0.50.26 \
+  --edge_runtime_version 0.16.6
+```
+
 Project commands owned by this CLI:
 
 - `project list`

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "node:url";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createAdminTools } from "./index";
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -28,6 +31,48 @@ function cleanEnvironment(): Record<string, string> {
 
 async function runAdminCli(args: string[]): Promise<{ exitCode: number; output: string }> {
     const processHandle = Bun.spawn([process.execPath, "src/index.ts", ...args], {
+        cwd: PACKAGE_ROOT,
+        env: cleanEnvironment(),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        processHandle.exited,
+        new Response(processHandle.stdout).text(),
+        new Response(processHandle.stderr).text(),
+    ]);
+    return { exitCode, output: stdout + stderr };
+}
+
+async function runAdminCliPath(entryPath: string, args: string[]): Promise<{ exitCode: number; output: string }> {
+    const processHandle = Bun.spawn([entryPath, ...args], {
+        cwd: PACKAGE_ROOT,
+        env: cleanEnvironment(),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        processHandle.exited,
+        new Response(processHandle.stdout).text(),
+        new Response(processHandle.stderr).text(),
+    ]);
+    return { exitCode, output: stdout + stderr };
+}
+
+async function runAggregateFailureCli(): Promise<{ exitCode: number; output: string }> {
+    const source = [
+        'import { Type } from "@sinclair/typebox";',
+        'import { runCli } from "./src/shared/cli.ts";',
+        'const tools = { fixture: {',
+        '  schema: { action: Type.Literal("run") },',
+        '  callback: async () => { throw new AggregateError([',
+        '    new Error("Remote upgrade failed (exit 42): transaction failed DATABASE_URL=postgresql://admin:database-password@localhost/db"),',
+        '    new Error("Failed to remove remote upgrade helper: permission denied"),',
+        '  ], "Remote upgrade failed and helper cleanup did not complete"); },',
+        '} };',
+        'await runCli(tools, ["fixture", "run"], { commandName: "fixture-cli" });',
+    ].join("\n");
+    const processHandle = Bun.spawn([process.execPath, "-e", source], {
         cwd: PACKAGE_ROOT,
         env: cleanEnvironment(),
         stdout: "pipe",
@@ -77,10 +122,38 @@ describe("admin SSH registration gate", () => {
 });
 
 describe("supacloud-admin process contract", () => {
+    test("runs through an npm-style bin symlink", async () => {
+        const build = Bun.spawnSync([process.execPath, "run", "build"], { cwd: PACKAGE_ROOT });
+        expect(build.exitCode).toBe(0);
+        const sandbox = mkdtempSync(join(tmpdir(), "supacloud-admin-bin-"));
+        const binDir = join(sandbox, "node_modules/.bin");
+        mkdirSync(binDir, { recursive: true });
+        const linkedEntry = join(binDir, "supacloud-admin");
+        symlinkSync(join(PACKAGE_ROOT, "dist/index.js"), linkedEntry);
+        try {
+            const result = await runAdminCliPath(linkedEntry, ["--help"]);
+            expect(result.exitCode).toBe(0);
+            expect(result.output).toContain("Platform administration CLI");
+        } finally {
+            rmSync(sandbox, { recursive: true, force: true });
+        }
+    });
+
     test("returns a non-zero exit code when a project command has no API context", async () => {
         const result = await runAdminCli(["project", "list"]);
 
         expect(result.exitCode).toBe(1);
         expect(result.output).toContain("SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN");
+    });
+
+    test("surfaces every sanitized cause when an operation and cleanup both fail", async () => {
+        const result = await runAggregateFailureCli();
+
+        expect(result.exitCode).toBe(1);
+        expect(result.output).toContain("Remote upgrade failed and helper cleanup did not complete");
+        expect(result.output).toContain("Remote upgrade failed (exit 42): transaction failed");
+        expect(result.output).toContain("DATABASE_URL=postgresql://admin:[REDACTED]@localhost/db");
+        expect(result.output).toContain("Failed to remove remote upgrade helper: permission denied");
+        expect(result.output).not.toContain("database-password");
     });
 });

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -3,7 +3,8 @@
 import { Type } from "@sinclair/typebox";
 import { stringEnum } from "./shared/schema";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 import { runCli } from "./shared/cli";
 import { resolveSupaCloudContext, type ResolvedContext } from "./shared/context";
 import { HttpTransport } from "./shared/transports/http";
@@ -276,7 +277,12 @@ async function main() {
 }
 
 function isDirectRun(): boolean {
-    return Boolean(process.argv[1]) && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+    if (!process.argv[1]) return false;
+    try {
+        return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(resolve(process.argv[1]));
+    } catch {
+        return false;
+    }
 }
 
 if (isDirectRun()) {

--- a/packages/admin/src/shared/cli.ts
+++ b/packages/admin/src/shared/cli.ts
@@ -6,6 +6,7 @@ import {
     schemaProperties,
 } from "./schema";
 import type { ToolSchema } from "./schema";
+import { redactSshOutput } from "./transports/ssh";
 
 interface CliRunOptions {
     commandName?: string;
@@ -21,6 +22,28 @@ function coerceCliValue(value: string): string | number | boolean {
     if (value === "false") return false;
     if (value.trim() !== "" && !Number.isNaN(Number(value))) return Number(value);
     return value;
+}
+
+function sanitizedCliDiagnostic(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return redactSshOutput(message)
+        .replace(/[\r\n\t]+/g, " ")
+        .trim()
+        .slice(0, 1_000);
+}
+
+function nestedCliDiagnostics(error: unknown): string[] {
+    if (error instanceof AggregateError) {
+        return error.errors.flatMap(candidate => nestedCliDiagnostics(candidate));
+    }
+    return [sanitizedCliDiagnostic(error)];
+}
+
+export function formatCliError(error: unknown): string {
+    const summary = sanitizedCliDiagnostic(error);
+    const diagnostics = [...new Set(nestedCliDiagnostics(error))].filter(message => message && message !== summary);
+    if (diagnostics.length === 0) return summary;
+    return `${summary}\nDetails:\n${diagnostics.map(message => `  - ${message}`).join("\n")}`;
 }
 
 export async function runCli(
@@ -156,7 +179,7 @@ export async function runCli(
         }
         process.exit(result && typeof result === "object" && "isError" in result && result.isError === true ? 1 : 0);
     } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = formatCliError(error);
         console.error(`❌ Error: ${message}`);
         if (message.includes("required")) {
             console.error(`Hint: Pass arguments like --ref YOUR_REF`);

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -18,6 +18,7 @@ class FakeSsh {
     upgradeExecFails = false;
     cleanupExecFails = false;
     uploadThrows = false;
+    partialUploadThrows = false;
 
     async ping(): Promise<boolean> {
         return true;
@@ -66,6 +67,7 @@ class FakeSsh {
     async uploadText(remotePath: string, content: string, mode = 0o600): Promise<void> {
         if (this.uploadThrows) throw new Error("upload failed");
         this.uploads.push({ remotePath, content, mode });
+        if (this.partialUploadThrows) throw new Error("partial upload failed");
     }
 }
 
@@ -238,14 +240,43 @@ describe("ssh admin tool", () => {
         expect(ssh.commands.at(-1)).toBe(`rm -f '${ssh.uploads[0]?.remotePath}'`);
     });
 
-    test("failed helper upload does not issue cleanup for a path that was never created", async () => {
+    test("failed helper upload still cleans its generated remote path", async () => {
         const ssh = new FakeSsh();
         ssh.uploadThrows = true;
 
         await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
             .rejects.toThrow("upload failed");
         expect(ssh.uploads).toHaveLength(0);
-        expect(ssh.commands).toHaveLength(0);
+        expect(ssh.commands).toHaveLength(1);
+        expect(ssh.commands[0]).toMatch(/^rm -f '\/tmp\/\.supacloud-release-assets-[0-9a-f-]+\.sh'$/);
+    });
+
+    test("partial helper upload cleans the exact remote path", async () => {
+        const ssh = new FakeSsh();
+        ssh.partialUploadThrows = true;
+
+        await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
+            .rejects.toThrow("partial upload failed");
+        expect(ssh.uploads).toHaveLength(1);
+        expect(ssh.commands).toEqual([`rm -f '${ssh.uploads[0]?.remotePath}'`]);
+    });
+
+    test("partial upload and helper cleanup failures preserve both diagnostics", async () => {
+        const ssh = new FakeSsh();
+        ssh.partialUploadThrows = true;
+        ssh.cleanupExecFails = true;
+
+        let failure: unknown;
+        try {
+            await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+
+        expect(failure).toBeInstanceOf(AggregateError);
+        const diagnostics = (failure as AggregateError).errors.map(candidate => String(candidate));
+        expect(diagnostics.some(message => message.includes("partial upload failed"))).toBe(true);
+        expect(diagnostics.some(message => message.includes("Failed to remove remote upgrade helper"))).toBe(true);
     });
 
     test("helper cleanup failures are reported instead of swallowed", async () => {

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -14,6 +14,10 @@ class FakeSsh {
     installEarlyFails = false;
     bootstrapDepsFail = false;
     bootstrapCloneFail = false;
+    upgradeExecThrows = false;
+    upgradeExecFails = false;
+    cleanupExecFails = false;
+    uploadThrows = false;
 
     async ping(): Promise<boolean> {
         return true;
@@ -21,6 +25,15 @@ class FakeSsh {
 
     async exec(command: string): Promise<{ success: boolean; stdout: string; stderr: string; code: number }> {
         this.commands.push(command);
+        if (this.upgradeExecThrows && command.includes("UPGRADE_RUNNER")) {
+            throw new Error("connection dropped");
+        }
+        if (this.upgradeExecFails && command.includes("UPGRADE_RUNNER")) {
+            return { success: false, stdout: "", stderr: "transaction failed", code: 42 };
+        }
+        if (this.cleanupExecFails && command.startsWith("rm -f '/tmp/.supacloud-release-assets-")) {
+            return { success: false, stdout: "", stderr: "permission denied", code: 1 };
+        }
         if (command.includes("BOOTSTRAP_DEPS_OK")) {
             if (this.bootstrapDepsFail) {
                 return { success: false, stdout: "", stderr: "package install failed", code: 1 };
@@ -51,6 +64,7 @@ class FakeSsh {
     }
 
     async uploadText(remotePath: string, content: string, mode = 0o600): Promise<void> {
+        if (this.uploadThrows) throw new Error("upload failed");
         this.uploads.push({ remotePath, content, mode });
     }
 }
@@ -142,16 +156,136 @@ describe("ssh admin tool", () => {
     });
 
     test("upgrade proxy rejects URL credentials, query strings, and fragments", async () => {
-        const tool = captureSshTool(new FakeSsh());
-
         for (const github_proxy of [
             "http://proxy.example.com/",
             "https://user:password@proxy.example.com/",
             "https://proxy.example.com/?target=evil",
             "https://proxy.example.com/#fragment",
         ]) {
+            const ssh = new FakeSsh();
+            const tool = captureSshTool(ssh);
             await expect(tool.invoke({ action: "upgrade", github_proxy })).rejects.toThrow("Invalid github_proxy");
+            expect(ssh.uploads).toHaveLength(0);
+            expect(ssh.commands).toHaveLength(0);
         }
+    });
+
+    test("component upgrade validates both exact versions before upload", async () => {
+        for (const args of [
+            { action: "upgrade", version: "0.50.27;id", edge_runtime_version: "0.16.7" },
+            { action: "upgrade", version: "0.50.27", edge_runtime_version: "0.16.7;id" },
+            { action: "upgrade", edge_runtime_version: "0.16.7" },
+            { action: "upgrade", version: "latest", edge_runtime_version: "0.16.7" },
+            { action: "upgrade", version: "0.50.27", edge_runtime_version: "latest" },
+        ]) {
+            const ssh = new FakeSsh();
+            await expect(captureSshTool(ssh).invoke(args)).rejects.toThrow();
+            expect(ssh.uploads).toHaveLength(0);
+            expect(ssh.commands).toHaveLength(0);
+        }
+    });
+
+    test("direct proxy mode is represented by an unset helper proxy", async () => {
+        const ssh = new FakeSsh();
+        await captureSshTool(ssh).invoke({ action: "upgrade", github_proxy: "direct" });
+        expect(ssh.commands[0]).toContain("unset SUPACLOUD_GITHUB_PROXY");
+        expect(ssh.commands[0]).not.toContain("SUPACLOUD_GITHUB_PROXY='direct'");
+    });
+
+    test("component upgrade bootstraps pinned verification and one capable transaction", async () => {
+        const ssh = new FakeSsh();
+        const tool = captureSshTool(ssh);
+
+        await tool.invoke({ action: "upgrade", version: "0.50.27", edge_runtime_version: "0.16.7" });
+
+        expect(ssh.commands).toHaveLength(2);
+        const command = ssh.commands[0] ?? "";
+        expect(command).toContain("sudo -n true");
+        expect(ssh.uploads).toHaveLength(1);
+        expect(ssh.uploads[0]?.remotePath).toMatch(/^\/tmp\/\.supacloud-release-assets-[0-9a-f-]+\.sh$/);
+        expect(ssh.uploads[0]?.mode).toBe(0o600);
+        expect(ssh.uploads[0]?.content).toContain("supacloud_install_pinned_gh");
+        expect(ssh.uploads[0]?.content).toContain('SUPACLOUD_GH_VERSION="${SUPACLOUD_GH_VERSION:-2.96.0}"');
+        expect(ssh.uploads[0]?.content).toContain("83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60");
+        expect(ssh.uploads[0]?.content).toContain("06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909");
+        expect(command).toContain("supacloud_install_pinned_gh");
+        expect(command).toContain("/usr/local/bin/supacloud --version");
+        expect(command).toContain("0.50.27");
+        expect(command).toContain("supacloud_fetch_component_release");
+        expect(command).toContain("supacloud_download_release_asset");
+        expect(command).toContain('chmod 0755 "$STAGED_MANAGEMENT"');
+        expect(command).toContain("SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG=");
+        expect(command).toContain("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE");
+        expect(command).not.toContain("/opt/supacloud/scripts");
+        expect(command).toContain("trap 'rm -f /tmp/.supacloud-release-assets-");
+        expect(command).not.toMatch(/\/usr\/local\/bin\/supacloud upgrade --yes/);
+        expect(Bun.spawnSync(["bash", "-n", "-c", command]).exitCode).toBe(0);
+        expect(ssh.commands[1]).toBe(`rm -f '${ssh.uploads[0]?.remotePath}'`);
+    });
+
+    test("component upgrade cleans its exact helper path when SSH execution throws", async () => {
+        const ssh = new FakeSsh();
+        ssh.upgradeExecThrows = true;
+        const tool = captureSshTool(ssh);
+
+        await expect(tool.invoke({
+            action: "upgrade",
+            version: "0.50.27",
+            edge_runtime_version: "0.16.7",
+        })).rejects.toThrow("connection dropped");
+
+        expect(ssh.uploads).toHaveLength(1);
+        expect(ssh.commands.at(-1)).toBe(`rm -f '${ssh.uploads[0]?.remotePath}'`);
+    });
+
+    test("failed helper upload does not issue cleanup for a path that was never created", async () => {
+        const ssh = new FakeSsh();
+        ssh.uploadThrows = true;
+
+        await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
+            .rejects.toThrow("upload failed");
+        expect(ssh.uploads).toHaveLength(0);
+        expect(ssh.commands).toHaveLength(0);
+    });
+
+    test("helper cleanup failures are reported instead of swallowed", async () => {
+        const ssh = new FakeSsh();
+        ssh.cleanupExecFails = true;
+
+        await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
+            .rejects.toThrow("Failed to remove remote upgrade helper");
+    });
+
+    test("remote and helper cleanup failures preserve both diagnostics", async () => {
+        const ssh = new FakeSsh();
+        ssh.upgradeExecFails = true;
+        ssh.cleanupExecFails = true;
+
+        let failure: unknown;
+        try {
+            await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+
+        expect(failure).toBeInstanceOf(AggregateError);
+        const diagnostics = (failure as AggregateError).errors.map(candidate => String(candidate));
+        expect(diagnostics.some(message => message.includes("exit 42") && message.includes("transaction failed"))).toBe(true);
+        expect(diagnostics.some(message => message.includes("Failed to remove remote upgrade helper"))).toBe(true);
+    });
+
+    test("remote upgrade failures reach the CLI error boundary", async () => {
+        const ssh = new FakeSsh();
+        ssh.upgradeExecFails = true;
+
+        await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
+            .rejects.toThrow("Remote upgrade failed (exit 42): transaction failed");
+    });
+
+    test("Management-only upgrade reports that Edge Runtime is unchanged", async () => {
+        const tool = captureSshTool(new FakeSsh());
+        const result = await tool.invoke({ action: "upgrade", version: "0.50.27" });
+        expect(result.content[0]?.text).toContain("Edge Runtime was not upgraded");
     });
 
     test("install rejects unsafe hostnames and control characters in secrets", () => {

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -200,10 +200,10 @@ async function executeOfficialUpgrade(
     helperPath: string,
     command: string,
 ): Promise<Awaited<ReturnType<SshTransport["exec"]>>> {
-    await ssh.uploadText(helperPath, releaseAssetsScript, 0o600);
     let execution: OfficialUpgradeExecution | undefined;
     let executionError: unknown;
     try {
+        await ssh.uploadText(helperPath, releaseAssetsScript, 0o600);
         execution = await ssh.exec(command, 600_000);
     } catch (error: unknown) {
         executionError = error;

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import type { SshTransport } from "../transports/ssh";
+import releaseAssetsScript from "../../../../../scripts/lib/release_assets.sh" with { type: "text" };
 
 const SAFE_CONTAINER_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/;
 const SAFE_PROJECT_REF = /^[a-z0-9-]{1,20}$/;
@@ -15,6 +16,7 @@ const SAFE_TIMEOUT_SECONDS = 300;
 const SAFE_HOSTNAME = /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$/;
 const SAFE_SYSTEMD_UNIT = /^[a-zA-Z0-9][a-zA-Z0-9_.@:-]{0,127}$/;
 const SAFE_DB_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_-]{0,62}$/;
+const MINIMUM_COMPONENT_UPGRADE_VERSION = "0.50.27";
 
 function hostnameSchema(fieldName: string) {
     return decodedSchema(Type.String(), Type.String({ minLength: 1, maxLength: 253 }), (value) => {
@@ -76,6 +78,144 @@ function assertSafeReleaseTag(value: string): string {
         throw new Error("Invalid release version");
     }
     return value;
+}
+
+function assertExactStableVersion(value: string, fieldName: string): string {
+    if (!/^v?\d+\.\d+\.\d+$/.test(value)) {
+        throw new Error(`${fieldName} must be an exact stable semantic version`);
+    }
+    return value;
+}
+
+type UpgradeRequest = {
+    version?: string;
+    edgeRuntimeVersion?: string;
+    githubProxy?: string;
+    helperPath: string;
+};
+
+function upgradeEnvAssignments(request: UpgradeRequest): string {
+    return [
+        request.version ? `SUPACLOUD_UPGRADE_TAG=${quoteEnvValue(request.version)}` : "",
+        request.edgeRuntimeVersion ? `SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG=${quoteEnvValue(request.edgeRuntimeVersion)}` : "",
+        request.githubProxy ? `SUPACLOUD_GITHUB_PROXY=${quoteEnvValue(request.githubProxy)}` : "",
+    ].filter(Boolean).join(" ");
+}
+
+function componentBootstrapCommands(request: UpgradeRequest): string[] {
+    if (!request.edgeRuntimeVersion) return [`UPGRADE_RUNNER=${quoteEnvValue("/usr/local/bin/supacloud")}`];
+    const managementVersion = request.version || "latest";
+    return [
+        `ACTIVE_VERSION=$(/usr/local/bin/supacloud --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
+        `UPGRADE_RUNNER=${quoteEnvValue("/usr/local/bin/supacloud")}`,
+        `if ! supacloud_version_at_least "$ACTIVE_VERSION" ${quoteEnvValue(MINIMUM_COMPONENT_UPGRADE_VERSION)}; then`,
+        `  case "$(uname -m)" in x86_64|amd64) MANAGEMENT_ASSET=supacloud-linux-amd64 ;; aarch64|arm64) MANAGEMENT_ASSET=supacloud-linux-arm64 ;; *) echo 'Unsupported Management architecture' >&2; exit 1 ;; esac`,
+        `  STAGED_MANAGEMENT=$(mktemp /tmp/supacloud-management-upgrade.XXXXXX)`,
+        `  MANAGEMENT_RELEASE=$(supacloud_fetch_component_release management-api ${quoteEnvValue(managementVersion)} "$MANAGEMENT_ASSET" web-console-build.tar.gz)`,
+        `  supacloud_download_release_asset "$MANAGEMENT_RELEASE" "$MANAGEMENT_ASSET" "$STAGED_MANAGEMENT" binary`,
+        `  chmod 0755 "$STAGED_MANAGEMENT"`,
+        `  STAGED_VERSION=$("$STAGED_MANAGEMENT" --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
+        `  supacloud_version_at_least "$STAGED_VERSION" ${quoteEnvValue(MINIMUM_COMPONENT_UPGRADE_VERSION)} || { echo 'Target Management release lacks Edge Runtime transaction capability' >&2; exit 1; }`,
+        `  UPGRADE_RUNNER="$STAGED_MANAGEMENT"`,
+        "fi",
+    ];
+}
+
+function componentPreflightCommands(request: UpgradeRequest): string[] {
+    return request.edgeRuntimeVersion ? [
+        "test -f /etc/supabase/management-api.env || { echo 'EDGE_RUNTIME_MODE is unavailable; component upgrade requires external mode' >&2; exit 1; }",
+        "EDGE_RUNTIME_MODE_VALUE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\\"'\"']+|[[:space:]\\\"'\"']+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
+        "test \"$EDGE_RUNTIME_MODE_VALUE\" = external || { echo 'Edge Runtime component upgrade supports persisted external mode only' >&2; exit 1; }",
+    ] : [];
+}
+
+function buildRootUpgradeScript(request: UpgradeRequest): string {
+    const envAssignments = upgradeEnvAssignments(request);
+    return [
+        "set -euo pipefail",
+        "umask 077",
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "export PATH",
+        "unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE SUPACLOUD_GITHUB_REPOSITORY SUPACLOUD_RELEASES_API SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW SUPACLOUD_GH_VERSION SUPACLOUD_GH_MIN_VERSION SUPACLOUD_GH_AMD64_SHA256 SUPACLOUD_GH_ARM64_SHA256 GH_PROXY",
+        request.githubProxy ? `export SUPACLOUD_GITHUB_PROXY=${quoteEnvValue(request.githubProxy)}` : "unset SUPACLOUD_GITHUB_PROXY",
+        "for tool in curl jq file sha256sum tar; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "test -x /usr/local/bin/supacloud || { echo 'SupaCloud binary not found at /usr/local/bin/supacloud; run ssh install first.' >&2; exit 127; }",
+        ...componentPreflightCommands(request),
+        "STAGED_MANAGEMENT=''",
+        "trap 'test -z \"$STAGED_MANAGEMENT\" || rm -f \"$STAGED_MANAGEMENT\"' EXIT HUP INT TERM",
+        `source ${quoteEnvValue(request.helperPath)}`,
+        "if ! supacloud_attestation_verifier_available; then supacloud_install_pinned_gh /usr/local/bin/gh; fi",
+        "supacloud_attestation_verifier_available || { echo 'Pinned GitHub attestation verifier is unavailable' >&2; exit 1; }",
+        ...componentBootstrapCommands(request),
+        `${envAssignments ? `env ${envAssignments} ` : ""}"$UPGRADE_RUNNER" upgrade --yes`,
+    ].join("; ");
+}
+
+export function buildOfficialUpgradeCommand(request: UpgradeRequest): string {
+    const rootScript = buildRootUpgradeScript(request);
+    return `set -e; trap 'rm -f ${request.helperPath}' EXIT HUP INT TERM; ` +
+        "if [ \"$(id -u)\" -eq 0 ]; then " +
+        `bash -c ${quoteEnvValue(rootScript)}; ` +
+        "else sudo -n true; " +
+        `sudo -n bash -c ${quoteEnvValue(rootScript)}; fi`;
+}
+
+async function removeRemoteUpgradeHelper(ssh: SshTransport, helperPath: string): Promise<void> {
+    const cleanup = await ssh.exec(`rm -f ${quoteEnvValue(helperPath)}`);
+    if (!cleanup.success) {
+        throw new Error(`Failed to remove remote upgrade helper (exit ${cleanup.code}): ${cleanup.stderr.slice(-300)}`);
+    }
+}
+
+type OfficialUpgradeExecution = Awaited<ReturnType<SshTransport["exec"]>>;
+
+function remoteUpgradeFailure(execution: OfficialUpgradeExecution): Error {
+    const diagnostic = execution.stderr.trim() || execution.stdout.trim() || "no remote diagnostic";
+    return new Error(`Remote upgrade failed (exit ${execution.code}): ${diagnostic.slice(-500)}`);
+}
+
+function officialUpgradeOutcome(
+    execution: OfficialUpgradeExecution | undefined,
+    executionError: unknown,
+    cleanupError: unknown,
+): OfficialUpgradeExecution {
+    if (executionError && cleanupError) {
+        throw new AggregateError([executionError, cleanupError], "Upgrade execution failed and helper cleanup did not complete");
+    }
+    if (executionError) throw executionError;
+    if (!execution) throw new Error("Upgrade execution did not return a result");
+    if (cleanupError && !execution.success) {
+        throw new AggregateError(
+            [remoteUpgradeFailure(execution), cleanupError],
+            "Remote upgrade failed and helper cleanup did not complete",
+        );
+    }
+    if (cleanupError) throw cleanupError;
+    if (!execution.success) throw remoteUpgradeFailure(execution);
+    return execution;
+}
+
+async function executeOfficialUpgrade(
+    ssh: SshTransport,
+    helperPath: string,
+    command: string,
+): Promise<Awaited<ReturnType<SshTransport["exec"]>>> {
+    await ssh.uploadText(helperPath, releaseAssetsScript, 0o600);
+    let execution: OfficialUpgradeExecution | undefined;
+    let executionError: unknown;
+    try {
+        execution = await ssh.exec(command, 600_000);
+    } catch (error: unknown) {
+        executionError = error;
+    }
+
+    let cleanupError: unknown;
+    try {
+        await removeRemoteUpgradeHelper(ssh, helperPath);
+    } catch (error: unknown) {
+        cleanupError = error;
+    }
+    return officialUpgradeOutcome(execution, executionError, cleanupError);
 }
 
 function assertSafeGithubProxy(value: string): string {
@@ -226,6 +366,7 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
             edge_runtime: optional(stringEnum(["bun"]), "[install] Runtime (default: bun)"),
             storage_type: optional(stringEnum(["juicefs", "minio"]), "[install] Storage backend configurable through Admin"),
             version: optional(Type.String(), "[upgrade] Specific version"),
+            edge_runtime_version: optional(Type.String(), "[upgrade] Exact independent Edge Runtime version"),
             github_proxy: optional(Type.String(), "[install/upgrade] Explicit GitHub proxy prefix, or direct/none"),
             focus: optional(stringEnum(["all", "containers", "database", "network", "disk", "logs"]), "[troubleshoot] Focus area"),
             container: optional(Type.String(), "[container_logs] Container name"),
@@ -383,16 +524,31 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
                     break;
                 }
                 case "upgrade": {
-                    const envParts = [
-                        args.version ? `SUPACLOUD_UPGRADE_TAG=${assertSafeReleaseTag(args.version)}` : "",
-                        args.github_proxy ? `SUPACLOUD_GITHUB_PROXY=${quoteEnvValue(assertSafeGithubProxy(args.github_proxy))}` : "",
-                    ].filter(Boolean);
-                    const envPrefix = envParts.length > 0 ? `${envParts.join(" ")} ` : "";
-                    const cmd = "if [ ! -x /usr/local/bin/supacloud ]; then " +
-                        "echo 'SupaCloud binary not found at /usr/local/bin/supacloud; run ssh install first.' >&2; exit 127; " +
-                        `fi; ${envPrefix}/usr/local/bin/supacloud upgrade --yes`;
-                    const r = await ssh.exec(cmd, 600_000);
-                    text = r.success ? `✅ Upgrade done\n${r.stdout.slice(-300)}` : `❌ Failed (exit ${r.code})\n${r.stderr.slice(-500)}`;
+                    const version = args.version ? assertSafeReleaseTag(args.version) : undefined;
+                    const edgeRuntimeVersion = args.edge_runtime_version
+                        ? assertSafeReleaseTag(args.edge_runtime_version)
+                        : undefined;
+                    if (edgeRuntimeVersion && !version) {
+                        throw new Error("'version' is required with 'edge_runtime_version'");
+                    }
+                    if (edgeRuntimeVersion && version) {
+                        assertExactStableVersion(version, "version");
+                        assertExactStableVersion(edgeRuntimeVersion, "edge_runtime_version");
+                    }
+                    const validatedProxy = args.github_proxy ? assertSafeGithubProxy(args.github_proxy) : undefined;
+                    const githubProxy = validatedProxy && !["direct", "none"].includes(validatedProxy.toLowerCase())
+                        ? validatedProxy
+                        : undefined;
+                    const helperPath = `/tmp/.supacloud-release-assets-${randomUUID()}.sh`;
+                    const cmd = buildOfficialUpgradeCommand({
+                        version,
+                        edgeRuntimeVersion,
+                        githubProxy,
+                        helperPath,
+                    });
+                    const upgradeExecution = await executeOfficialUpgrade(ssh, helperPath, cmd);
+                    const edgeBoundary = edgeRuntimeVersion ? "" : "\n⚠️ Edge Runtime was not upgraded; provide --edge_runtime_version for a component transaction.";
+                    text = `✅ Upgrade done\n${upgradeExecution.stdout.slice(-300)}${edgeBoundary}`;
                     break;
                 }
                 case "diagnose": {

--- a/packages/admin/src/types.d.ts
+++ b/packages/admin/src/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.sh" {
+    const source: string;
+    export default source;
+}

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -129,8 +129,14 @@ export function backupCurrentBinary(
 
 export function restoreCurrentBinary(state: BinaryBackupState) {
     if (state.backupReady && existsSync(state.backupPath)) {
-        copyFileSync(state.backupPath, state.targetPath);
-        chmodSync(state.targetPath, 0o755);
+        const restorePath = `${state.targetPath}.restore-${process.pid}-${randomUUID()}`;
+        try {
+            copyFileSync(state.backupPath, restorePath);
+            chmodSync(restorePath, 0o755);
+            renameSync(restorePath, state.targetPath);
+        } finally {
+            rmSync(restorePath, { force: true });
+        }
     } else if (!state.hadTarget && state.activated) {
         rmSync(state.targetPath, { force: true });
     }

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -13,6 +13,11 @@ const RELEASE_REPOSITORY = "zuohuadong/supacloud";
 const RELEASE_SIGNER_WORKFLOW = `${RELEASE_REPOSITORY}/.github/workflows/release-please.yml`;
 const BIN_TARGET = "/usr/local/bin/supacloud";
 const MANAGEMENT_SERVICE_UNIT = "supacloud.service";
+const EDGE_RUNTIME_SERVICE_UNIT = "supacloud-edge-runtime.service";
+const EDGE_RUNTIME_BINARY_TARGETS = new Set([
+    "/usr/local/bin/supacloud-edge-runtime",
+    "/opt/supacloud/bin/supacloud-edge-runtime",
+]);
 const DEFAULT_MANAGEMENT_ENV_FILE = "/etc/supabase/management-api.env";
 const DEFAULT_EDGE_RUNTIME_USER = "supacloud-edge";
 const DEFAULT_EDGE_RUNTIME_GROUP = "supacloud-edge";
@@ -67,7 +72,7 @@ export type BinaryBackupState = {
     activated: boolean;
 };
 
-type HostIdentityCommandResult = {
+export type HostIdentityCommandResult = {
     exitCode: number;
     stdout: string;
     stderr: string;
@@ -75,7 +80,7 @@ type HostIdentityCommandResult = {
 
 type HostIdentityCommandRunner = (command: string[]) => Promise<HostIdentityCommandResult>;
 
-export type ActiveManagementBinary = {
+export type ActiveSystemdBinary = {
     unit: string;
     execStartPath: string;
     pid: number;
@@ -83,7 +88,7 @@ export type ActiveManagementBinary = {
     sha256: string;
 };
 
-type ManagementBinaryInspectorOptions = {
+type SystemdBinaryInspectorOptions = {
     run?: HostIdentityCommandRunner;
     readlink?: (filePath: string) => string;
     sha256?: (filePath: string) => string;
@@ -133,6 +138,13 @@ export function restoreCurrentBinary(state: BinaryBackupState) {
 
 export function cleanupBinaryBackup(state: BinaryBackupState) {
     rmSync(state.backupPath, { force: true });
+}
+
+export function activateStagedBinary(stagedPath: string, state: BinaryBackupState): void {
+    backupCurrentBinary(state);
+    renameSync(stagedPath, state.targetPath);
+    state.activated = true;
+    chmodSync(state.targetPath, 0o755);
 }
 
 export function captureFileState(filePath: string): FileState {
@@ -199,9 +211,28 @@ export function normalizeManagementReleaseTag(tag: string) {
     return `management-api-v${trimmed}`;
 }
 
+export function normalizeEdgeRuntimeReleaseTag(tag: string) {
+    const trimmed = tag.trim();
+    const version = trimmed.replace(/^edge-runtime-v/, "").replace(/^v/, "");
+    if (!/^\d+\.\d+\.\d+$/.test(version)) {
+        throw new Error("An exact stable Edge Runtime version is required");
+    }
+    return `edge-runtime-v${version}`;
+}
+
 function resolveReleaseApiUrl(targetVersion?: string) {
     const tag = normalizeManagementReleaseTag(targetVersion || process.env.SUPACLOUD_UPGRADE_TAG || process.env.SUPACLOUD_UPGRADE_VERSION || "");
     return tag ? `${RELEASES_API}/tags/${encodeURIComponent(tag)}` : `${RELEASES_API}?per_page=100`;
+}
+
+function resolveEdgeRuntimeReleaseApiUrl(version: string) {
+    return `${RELEASES_API}/tags/${encodeURIComponent(normalizeEdgeRuntimeReleaseTag(version))}`;
+}
+
+function resolveEdgeRuntimeBinaryName(managementBinaryName: string) {
+    return managementBinaryName.endsWith("arm64")
+        ? "supacloud-edge-runtime-linux-arm64"
+        : "supacloud-edge-runtime-linux-amd64";
 }
 
 function hasReleaseAsset(release: GithubRelease, assetName: string) {
@@ -222,6 +253,18 @@ export function selectManagementRelease(data: GithubRelease | GithubRelease[], b
         throw new Error(`No Management API release contains ${binaryName}, ${WEB_CONSOLE_ASSET}, and SHA256SUMS`);
     }
     return release;
+}
+
+export function selectEdgeRuntimeRelease(
+    releaseMetadata: GithubRelease,
+    expectedTag: string,
+    binaryName: string,
+): GithubRelease {
+    if (releaseMetadata.draft || releaseMetadata.prerelease || releaseMetadata.tag_name !== expectedTag
+        || !hasReleaseAsset(releaseMetadata, binaryName) || !hasReleaseAsset(releaseMetadata, "SHA256SUMS")) {
+        throw new Error(`Edge Runtime release ${expectedTag} must contain ${binaryName} and SHA256SUMS`);
+    }
+    return releaseMetadata;
 }
 
 export function verifyArtifactChecksum(filePath: string, assetName: string, checksums: string) {
@@ -272,6 +315,34 @@ export function parseSystemdMainPid(value: string): number {
     return pid;
 }
 
+export type SystemdEnabledState = "enabled" | "disabled";
+
+export function parseSystemdEnabledState(commandResult: HostIdentityCommandResult): SystemdEnabledState {
+    const state = commandResult.stdout.trim();
+    if ((commandResult.exitCode === 0 || commandResult.exitCode === 1)
+        && (state === "enabled" || state === "disabled")) {
+        return state;
+    }
+    throw new Error(`Unsupported systemd enabled state: ${state || commandResult.stderr.trim() || commandResult.exitCode}`);
+}
+
+export function assertEdgeRuntimeBinaryTarget(targetPath: string): void {
+    if (!EDGE_RUNTIME_BINARY_TARGETS.has(targetPath)) {
+        throw new Error(`Unsafe Edge Runtime upgrade target: ${targetPath}`);
+    }
+}
+
+export async function readSystemdEnabledState(
+    unit: string,
+    run: HostIdentityCommandRunner = runHostIdentityCommand,
+): Promise<SystemdEnabledState> {
+    try {
+        return parseSystemdEnabledState(await run(["systemctl", "is-enabled", unit]));
+    } catch (error: unknown) {
+        throw new Error(`Cannot verify ${unit} enabled state: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+
 async function readSystemdProperty(
     unit: string,
     property: "ExecStart" | "MainPID",
@@ -289,64 +360,71 @@ async function readSystemdProperty(
     return result.stdout;
 }
 
-async function readManagementExecStartPath(run: HostIdentityCommandRunner): Promise<string> {
+async function readExecStartPath(unit: string, run: HostIdentityCommandRunner): Promise<string> {
     try {
-        const rawExecStart = await readSystemdProperty(MANAGEMENT_SERVICE_UNIT, "ExecStart", run);
+        const rawExecStart = await readSystemdProperty(unit, "ExecStart", run);
         return parseSystemdExecStartPath(rawExecStart);
     } catch (error: unknown) {
-        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} ExecStart: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(`Cannot verify ${unit} ExecStart: ${error instanceof Error ? error.message : String(error)}`);
     }
 }
 
-async function readManagementMainPid(run: HostIdentityCommandRunner): Promise<number> {
+async function readMainPid(unit: string, run: HostIdentityCommandRunner): Promise<number> {
     try {
-        const rawMainPid = await readSystemdProperty(MANAGEMENT_SERVICE_UNIT, "MainPID", run);
+        const rawMainPid = await readSystemdProperty(unit, "MainPID", run);
         return parseSystemdMainPid(rawMainPid);
     } catch (error: unknown) {
-        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} MainPID: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(`Cannot verify ${unit} MainPID: ${error instanceof Error ? error.message : String(error)}`);
     }
 }
 
-function resolveActiveExecutablePath(procExecutablePath: string, readlink: (filePath: string) => string): string {
+function resolveActiveExecutablePath(unit: string, procExecutablePath: string, readlink: (filePath: string) => string): string {
     try {
         return readlink(procExecutablePath).trim();
     } catch (error: unknown) {
-        throw new Error(`Cannot resolve ${MANAGEMENT_SERVICE_UNIT} active executable at ${procExecutablePath}: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(`Cannot resolve ${unit} active executable at ${procExecutablePath}: ${error instanceof Error ? error.message : String(error)}`);
     }
 }
 
-function hashActiveExecutable(procExecutablePath: string, sha256: (filePath: string) => string): string {
+function hashActiveExecutable(unit: string, procExecutablePath: string, sha256: (filePath: string) => string): string {
     let digest: string;
     try {
         digest = sha256(procExecutablePath).trim().toLowerCase();
     } catch (error: unknown) {
-        throw new Error(`Cannot hash ${MANAGEMENT_SERVICE_UNIT} active executable at ${procExecutablePath}: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(`Cannot hash ${unit} active executable at ${procExecutablePath}: ${error instanceof Error ? error.message : String(error)}`);
     }
     if (!/^[0-9a-f]{64}$/.test(digest)) {
-        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} active executable: invalid SHA-256 digest`);
+        throw new Error(`Cannot verify ${unit} active executable: invalid SHA-256 digest`);
     }
     return digest;
 }
 
-export async function inspectActiveManagementBinary(
-    options: ManagementBinaryInspectorOptions = {},
-): Promise<ActiveManagementBinary> {
+export async function inspectActiveSystemdBinary(
+    unit: string,
+    options: SystemdBinaryInspectorOptions = {},
+): Promise<ActiveSystemdBinary> {
     const run = options.run ?? runHostIdentityCommand;
     const readlink = options.readlink ?? ((filePath: string) => readlinkSync(filePath, "utf8"));
     const sha256 = options.sha256 ?? sha256File;
-    const execStartPath = await readManagementExecStartPath(run);
-    const pid = await readManagementMainPid(run);
+    const execStartPath = await readExecStartPath(unit, run);
+    const pid = await readMainPid(unit, run);
     const procExecutablePath = `/proc/${pid}/exe`;
-    const executablePath = resolveActiveExecutablePath(procExecutablePath, readlink);
-    const digest = hashActiveExecutable(procExecutablePath, sha256);
-    const stablePid = await readManagementMainPid(run);
+    const executablePath = resolveActiveExecutablePath(unit, procExecutablePath, readlink);
+    const digest = hashActiveExecutable(unit, procExecutablePath, sha256);
+    const stablePid = await readMainPid(unit, run);
     if (stablePid !== pid) {
-        throw new Error(`Cannot verify ${MANAGEMENT_SERVICE_UNIT} active executable: MainPID changed from ${pid} to ${stablePid}`);
+        throw new Error(`Cannot verify ${unit} active executable: MainPID changed from ${pid} to ${stablePid}`);
     }
-    return { unit: MANAGEMENT_SERVICE_UNIT, execStartPath, pid, executablePath, sha256: digest };
+    return { unit, execStartPath, pid, executablePath, sha256: digest };
 }
 
-function assertCanonicalManagementBinary(snapshot: ActiveManagementBinary, phase: string): void {
+export async function inspectActiveManagementBinary(
+    options: SystemdBinaryInspectorOptions = {},
+): Promise<ActiveSystemdBinary> {
+    return inspectActiveSystemdBinary(MANAGEMENT_SERVICE_UNIT, options);
+}
+
+function assertCanonicalManagementBinary(snapshot: ActiveSystemdBinary, phase: string): void {
     if (snapshot.execStartPath !== BIN_TARGET) {
         throw new Error(`${phase}: ${snapshot.unit} ExecStart is ${snapshot.execStartPath}; upgrade target is ${BIN_TARGET}`);
     }
@@ -356,8 +434,8 @@ function assertCanonicalManagementBinary(snapshot: ActiveManagementBinary, phase
 }
 
 export async function verifyManagementUpgradePreflight(
-    options: ManagementBinaryInspectorOptions = {},
-): Promise<ActiveManagementBinary> {
+    options: SystemdBinaryInspectorOptions = {},
+): Promise<ActiveSystemdBinary> {
     const snapshot = await inspectActiveManagementBinary(options);
     assertCanonicalManagementBinary(snapshot, "Refusing to migrate");
     return snapshot;
@@ -374,8 +452,8 @@ export function verifyBackupPrivilegeDropPreflight(
 
 export async function verifyActivatedManagementBinary(
     expectedSha256: string,
-    options: ManagementBinaryInspectorOptions = {},
-): Promise<ActiveManagementBinary> {
+    options: SystemdBinaryInspectorOptions = {},
+): Promise<ActiveSystemdBinary> {
     const normalizedExpected = expectedSha256.trim().toLowerCase();
     if (!/^[0-9a-f]{64}$/.test(normalizedExpected)) {
         throw new Error("Post-upgrade binary verification requires a valid staged SHA-256 digest");
@@ -384,6 +462,26 @@ export async function verifyActivatedManagementBinary(
     assertCanonicalManagementBinary(snapshot, "Post-upgrade binary verification failed");
     if (snapshot.sha256 !== normalizedExpected) {
         throw new Error(`Post-upgrade binary verification failed: ${snapshot.unit} is running a binary whose SHA-256 does not match the staged release binary`);
+    }
+    return snapshot;
+}
+
+export async function verifyActivatedSystemdBinary(
+    unit: string,
+    targetPath: string,
+    expectedSha256: string,
+    options: SystemdBinaryInspectorOptions = {},
+): Promise<ActiveSystemdBinary> {
+    const normalizedExpected = expectedSha256.trim().toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(normalizedExpected)) {
+        throw new Error(`Post-upgrade ${unit} verification requires a valid staged SHA-256 digest`);
+    }
+    const snapshot = await inspectActiveSystemdBinary(unit, options);
+    if (snapshot.execStartPath !== targetPath || snapshot.executablePath !== targetPath) {
+        throw new Error(`Post-upgrade ${unit} verification failed: expected active target ${targetPath}`);
+    }
+    if (snapshot.sha256 !== normalizedExpected) {
+        throw new Error(`Post-upgrade ${unit} verification failed: active SHA-256 does not match the staged release`);
     }
     return snapshot;
 }
@@ -411,7 +509,23 @@ export type UpgradeTransactionOperations = {
     cleanup?: () => Promise<void>;
 };
 
-export async function executeUpgradeTransaction(operations: UpgradeTransactionOperations) {
+export type UpgradeFailureKind =
+    | "rollback-incomplete"
+    | "cleanup-incomplete-after-commit"
+    | "cleanup-incomplete-after-failure";
+
+export class UpgradeTransactionError extends AggregateError {
+    constructor(
+        readonly kind: UpgradeFailureKind,
+        errors: unknown[],
+        message: string,
+    ) {
+        super(errors, message);
+        this.name = "UpgradeTransactionError";
+    }
+}
+
+async function executeUpgradePhases(operations: UpgradeTransactionOperations): Promise<void> {
     let activationStarted = false;
     try {
         await operations.preflight();
@@ -424,13 +538,60 @@ export async function executeUpgradeTransaction(operations: UpgradeTransactionOp
         await operations.restart();
         await operations.healthCheck();
     } catch (error: unknown) {
-        if (activationStarted) {
-            await operations.rollback();
-        }
+        if (activationStarted) await rethrowAfterUpgradeRollback(operations, error);
         throw error;
-    } finally {
-        await operations.cleanup?.();
     }
+}
+
+async function rethrowAfterUpgradeRollback(
+    operations: UpgradeTransactionOperations,
+    upgradeError: unknown,
+): Promise<never> {
+    try {
+        await operations.rollback();
+    } catch (rollbackError: unknown) {
+        throw new UpgradeTransactionError(
+            "rollback-incomplete",
+            [upgradeError, rollbackError],
+            "Upgrade failed and rollback did not complete",
+        );
+    }
+    throw upgradeError;
+}
+
+function throwUpgradeOutcome(transactionError: unknown, cleanupError: unknown): void {
+    if (transactionError && cleanupError) {
+        throw new UpgradeTransactionError(
+            "cleanup-incomplete-after-failure",
+            [transactionError, cleanupError],
+            "Upgrade failed and cleanup did not complete",
+        );
+    }
+    if (transactionError) throw transactionError;
+    if (cleanupError) {
+        throw new UpgradeTransactionError(
+            "cleanup-incomplete-after-commit",
+            [cleanupError],
+            "Upgrade committed but cleanup did not complete",
+        );
+    }
+}
+
+export async function executeUpgradeTransaction(operations: UpgradeTransactionOperations) {
+    let transactionError: unknown;
+    try {
+        await executeUpgradePhases(operations);
+    } catch (error: unknown) {
+        transactionError = error;
+    }
+
+    let cleanupError: unknown;
+    try {
+        await operations.cleanup?.();
+    } catch (error: unknown) {
+        cleanupError = error;
+    }
+    throwUpgradeOutcome(transactionError, cleanupError);
 }
 
 function normalizeProxyPrefix(value: string) {
@@ -804,7 +965,7 @@ async function verifyArtifactAttestation(filePath: string) {
     recordIntegrityMode("break-glass:same-release-sha256-only");
 }
 
-async function validateBinaryArtifact(filePath: string, binaryName: string) {
+async function validateElfBinaryArtifact(filePath: string, binaryName: string) {
     const inspected = await $`file -b ${filePath}`.nothrow().quiet();
     const description = inspected.stdout.toString().trim();
     if (inspected.exitCode !== 0 || !description.includes("ELF")) {
@@ -816,6 +977,10 @@ async function validateBinaryArtifact(filePath: string, binaryName: string) {
     }
 
     await $`chmod 0755 ${filePath}`;
+}
+
+async function validateManagementBinaryArtifact(filePath: string, binaryName: string) {
+    await validateElfBinaryArtifact(filePath, binaryName);
     const smoke = Bun.spawn([filePath, "--version"], { stdout: "pipe", stderr: "pipe" });
     if (await smoke.exited !== 0) {
         throw new Error(`${binaryName} failed the --version smoke check`);
@@ -838,25 +1003,29 @@ type StagedBinary = {
     sha256: string;
 };
 
-async function stageBinary(
-    downloadUrl: string,
-    binaryName: string,
-    checksums: string,
-    preferredEndpoint: GithubEndpoint,
-    forceYes?: boolean,
-): Promise<StagedBinary> {
-    const tmpBinary = path.join(os.tmpdir(), `${binaryName}-${process.pid}-${Date.now()}`);
-    const stagedBinary = `${BIN_TARGET}.new-${process.pid}`;
+type StageBinaryRequest = {
+    downloadUrl: string;
+    binaryName: string;
+    checksums: string;
+    preferredEndpoint: GithubEndpoint;
+    targetPath: string;
+    validate: (filePath: string, binaryName: string) => Promise<void>;
+    forceYes?: boolean;
+};
+
+async function stageBinary(request: StageBinaryRequest): Promise<StagedBinary> {
+    const tmpBinary = path.join(os.tmpdir(), `${request.binaryName}-${process.pid}-${Date.now()}`);
+    const stagedBinary = `${request.targetPath}.new-${process.pid}`;
     try {
-        const endpoint = await downloadAsset(downloadUrl, tmpBinary, preferredEndpoint, forceYes);
-        const releaseSha256 = verifyArtifactChecksum(tmpBinary, binaryName, checksums);
+        const endpoint = await downloadAsset(request.downloadUrl, tmpBinary, request.preferredEndpoint, request.forceYes);
+        const releaseSha256 = verifyArtifactChecksum(tmpBinary, request.binaryName, request.checksums);
         await verifyArtifactAttestation(tmpBinary);
-        await validateBinaryArtifact(tmpBinary, binaryName);
+        await request.validate(tmpBinary, request.binaryName);
         await $`install -m 0755 ${tmpBinary} ${stagedBinary}`;
         const stagedSha256 = sha256File(stagedBinary);
         if (stagedSha256 !== releaseSha256) {
             await $`rm -f ${stagedBinary}`.nothrow().quiet();
-            throw new Error(`SHA256 mismatch for staged ${binaryName}`);
+            throw new Error(`SHA256 mismatch for staged ${request.binaryName}`);
         }
         return { path: stagedBinary, endpoint, sha256: stagedSha256 };
     } catch (error: unknown) {
@@ -1281,6 +1450,20 @@ export function resolvePersistedEdgeRuntimeMode(persistedMode?: string): EdgeRun
     throw new Error(`Invalid persisted EDGE_RUNTIME_MODE: ${persistedMode}`);
 }
 
+export function assertExternalEdgeRuntimeUpgradeMode(mode: EdgeRuntimeMode): void {
+    if (mode !== "external") {
+        throw new Error("Edge Runtime component upgrade supports persisted external mode only");
+    }
+}
+
+export function shouldCleanupUpgradeArtifacts(state: {
+    committed: boolean;
+    rollbackSucceeded: boolean;
+    activationStarted: boolean;
+}): boolean {
+    return state.committed || state.rollbackSucceeded || !state.activationStarted;
+}
+
 async function reloadSystemdUnits() {
     const reload = await $`systemctl daemon-reload`.nothrow().quiet();
     if (reload.exitCode !== 0) {
@@ -1440,6 +1623,7 @@ export async function waitForUpgradeHealth() {
 
 type UpgradeActivationState = {
     binary: BinaryBackupState;
+    edgeBinary: BinaryBackupState | null;
     oldWebTarget: string | null;
     oldWebBackup: string | null;
     managementEnvState: FileState | null;
@@ -1449,11 +1633,74 @@ type UpgradeActivationState = {
     embeddedEdgePrivilegeDropInState: FileState | null;
 };
 
-async function activateArtifacts(stagedBinary: StagedBinary, stagedWeb: StagedWebConsole | null, state: UpgradeActivationState) {
-    backupCurrentBinary(state.binary);
-    renameSync(stagedBinary.path, BIN_TARGET);
-    state.binary.activated = true;
-    chmodSync(BIN_TARGET, 0o755);
+type RunUpgradeOptions = {
+    forceYes?: boolean;
+    targetVersion?: string;
+    edgeRuntimeVersion?: string;
+};
+
+type EdgeRuntimeUpgradePlan = {
+    binaryName: string;
+    enabledState: SystemdEnabledState;
+    endpoint: GithubEndpoint;
+    release: GithubRelease;
+    targetPath: string;
+};
+
+type EdgeRuntimeReleasePlanRequest = {
+    binaryName: string;
+    forceYes?: boolean;
+    preflight: ActiveSystemdBinary | null;
+    requestedVersion: string;
+};
+
+type UpgradeReleasePlan = {
+    binaryName: string;
+    endpoint: GithubEndpoint;
+    edgeRuntime: EdgeRuntimeUpgradePlan | null;
+    release: GithubRelease;
+    remoteVersion: string;
+};
+
+type UpgradeExecutionState = {
+    activatedEdgeRuntimeMode: EdgeRuntimeMode | null;
+    activation: UpgradeActivationState | null;
+    committed: boolean;
+    downloadEndpointLabel: string;
+    edgeRuntimeEndpointLabel: string | null;
+    rollbackSucceeded: boolean;
+    stagedEdgeRuntime: StagedBinary | null;
+    stagedManagement: StagedBinary | null;
+    stagedWebConsole: StagedWebConsole | null;
+    webConsoleEndpointLabel: string | null;
+};
+
+type UpgradeExecutionContext = {
+    checksums: string;
+    edgeRuntimeChecksums: string | null;
+    options: RunUpgradeOptions;
+    plan: UpgradeReleasePlan;
+    preparedSecrets: PreparedUpgradeSecrets;
+    spinner: ReturnType<typeof p.spinner>;
+    state: UpgradeExecutionState;
+};
+
+type UpgradeCleanupAction = {
+    description: string;
+    run: () => void;
+};
+
+async function activateArtifacts(
+    stagedBinary: StagedBinary,
+    stagedEdgeBinary: StagedBinary | null,
+    stagedWeb: StagedWebConsole | null,
+    state: UpgradeActivationState,
+) {
+    activateStagedBinary(stagedBinary.path, state.binary);
+
+    if (stagedEdgeBinary && state.edgeBinary) {
+        activateStagedBinary(stagedEdgeBinary.path, state.edgeBinary);
+    }
 
     if (stagedWeb) {
         await $`mkdir -p ${WEB_CONSOLE_ROOT}`;
@@ -1475,9 +1722,10 @@ async function activateArtifacts(stagedBinary: StagedBinary, stagedWeb: StagedWe
 
 async function rollbackArtifacts(state: UpgradeActivationState, stagedWeb: StagedWebConsole | null) {
     restoreCurrentBinary(state.binary);
+    if (state.edgeBinary) restoreCurrentBinary(state.edgeBinary);
 
     if (stagedWeb) {
-        await $`rm -rf ${WEB_CONSOLE_CURRENT_LINK}`.nothrow().quiet();
+        rmSync(WEB_CONSOLE_CURRENT_LINK, { force: true, recursive: true });
         if (state.oldWebBackup) {
             await $`mv ${state.oldWebBackup} ${WEB_CONSOLE_CURRENT_LINK}`;
         } else if (state.oldWebTarget) {
@@ -1506,130 +1754,417 @@ async function rollbackArtifacts(state: UpgradeActivationState, stagedWeb: Stage
     await waitForUpgradeHealth();
 }
 
-export async function runUpgrade(options: { forceYes?: boolean; targetVersion?: string } = {}) {
+function createActivationState(edgeRuntimeTarget: string | null): UpgradeActivationState {
+    return {
+        binary: createBinaryBackupState(BIN_TARGET),
+        edgeBinary: edgeRuntimeTarget ? createBinaryBackupState(edgeRuntimeTarget) : null,
+        oldWebTarget: null,
+        oldWebBackup: null,
+        managementEnvState: null,
+        edgeRuntimeEnvState: null,
+        edgeRuntimeDropInState: null,
+        managementPrivilegeDropInState: null,
+        embeddedEdgePrivilegeDropInState: null,
+    };
+}
+
+async function inspectEdgeRuntimeUpgradeTarget(requestedVersion: string): Promise<ActiveSystemdBinary | null> {
+    if (!requestedVersion) return null;
+    assertExternalEdgeRuntimeUpgradeMode(await runtimeModeForBinaryUpgrade());
+    const preflight = await inspectActiveSystemdBinary(EDGE_RUNTIME_SERVICE_UNIT);
+    assertEdgeRuntimeBinaryTarget(preflight.execStartPath);
+    if (preflight.executablePath !== preflight.execStartPath) {
+        throw new Error(`${EDGE_RUNTIME_SERVICE_UNIT} runs ${preflight.executablePath}; expected ${preflight.execStartPath}`);
+    }
+    return preflight;
+}
+
+async function resolveEdgeRuntimeUpgradePlan(
+    request: EdgeRuntimeReleasePlanRequest,
+): Promise<EdgeRuntimeUpgradePlan | null> {
+    const { binaryName, forceYes, preflight, requestedVersion } = request;
+    if (!preflight) return null;
+    const metadata = await fetchReleaseMetadata(resolveEdgeRuntimeReleaseApiUrl(requestedVersion), forceYes);
+    const expectedTag = normalizeEdgeRuntimeReleaseTag(requestedVersion);
+    return {
+        binaryName,
+        enabledState: await readSystemdEnabledState(EDGE_RUNTIME_SERVICE_UNIT),
+        endpoint: metadata.endpoint,
+        release: selectEdgeRuntimeRelease(metadata.data as GithubRelease, expectedTag, binaryName),
+        targetPath: preflight.execStartPath,
+    };
+}
+
+async function resolveUpgradeReleasePlan(options: RunUpgradeOptions): Promise<UpgradeReleasePlan> {
+    const requestedEdgeVersion = options.edgeRuntimeVersion
+        || process.env.SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG
+        || "";
+    const edgePreflight = await inspectEdgeRuntimeUpgradeTarget(requestedEdgeVersion);
+    const binaryName = resolveLinuxBinaryName();
+    const metadata = await fetchReleaseMetadata(resolveReleaseApiUrl(options.targetVersion), options.forceYes);
+    const release = selectManagementRelease(metadata.data as GithubRelease | GithubRelease[], binaryName);
+    const edgeRuntime = await resolveEdgeRuntimeUpgradePlan({
+        binaryName: resolveEdgeRuntimeBinaryName(binaryName),
+        forceYes: options.forceYes,
+        preflight: edgePreflight,
+        requestedVersion: requestedEdgeVersion,
+    });
+    return { binaryName, endpoint: metadata.endpoint, edgeRuntime, release, remoteVersion: release.tag_name || "unknown" };
+}
+
+function upgradeConfirmationMessage(plan: UpgradeReleasePlan): string {
+    const edgeSummary = plan.edgeRuntime
+        ? ` and ${plan.edgeRuntime.targetPath} with ${plan.edgeRuntime.binaryName} from ${plan.edgeRuntime.release.tag_name}`
+        : "";
+    return `Replace ${BIN_TARGET} with ${plan.binaryName} from ${plan.remoteVersion}${edgeSummary}?`;
+}
+
+async function confirmUpgrade(plan: UpgradeReleasePlan, forceYes?: boolean): Promise<boolean> {
+    if (forceYes) return true;
+    const confirmation = await p.confirm({ message: upgradeConfirmationMessage(plan), initialValue: true });
+    return !p.isCancel(confirmation) && confirmation;
+}
+
+function createUpgradeExecutionState(plan: UpgradeReleasePlan): UpgradeExecutionState {
+    return {
+        activatedEdgeRuntimeMode: null,
+        activation: null,
+        committed: false,
+        downloadEndpointLabel: plan.endpoint.label,
+        edgeRuntimeEndpointLabel: null,
+        rollbackSucceeded: false,
+        stagedEdgeRuntime: null,
+        stagedManagement: null,
+        stagedWebConsole: null,
+        webConsoleEndpointLabel: null,
+    };
+}
+
+async function createUpgradeExecutionContext(
+    plan: UpgradeReleasePlan,
+    options: RunUpgradeOptions,
+    spinner: ReturnType<typeof p.spinner>,
+): Promise<UpgradeExecutionContext> {
+    const preparedSecrets = prepareUpgradeSecrets(await resolveUpgradeEnvironment());
+    const checksums = await downloadReleaseChecksums(plan.release, plan.endpoint, options.forceYes);
+    const edgeRuntimeChecksums = plan.edgeRuntime
+        ? await downloadReleaseChecksums(plan.edgeRuntime.release, plan.edgeRuntime.endpoint, options.forceYes)
+        : null;
+    return {
+        checksums,
+        edgeRuntimeChecksums,
+        options,
+        plan,
+        preparedSecrets,
+        spinner,
+        state: createUpgradeExecutionState(plan),
+    };
+}
+
+async function verifyUpgradePreflight(context: UpgradeExecutionContext): Promise<void> {
+    context.spinner.start(`Verifying ${MANAGEMENT_SERVICE_UNIT} uses the canonical upgrade target`);
+    verifyBackupPrivilegeDropPreflight();
+    await verifyManagementUpgradePreflight();
+    const edgeRuntime = context.plan.edgeRuntime;
+    if (!edgeRuntime) return;
+    const current = await inspectActiveSystemdBinary(EDGE_RUNTIME_SERVICE_UNIT);
+    if (current.execStartPath !== edgeRuntime.targetPath || current.executablePath !== edgeRuntime.targetPath) {
+        throw new Error(`${EDGE_RUNTIME_SERVICE_UNIT} target changed during upgrade preflight`);
+    }
+}
+
+async function stageManagementUpgrade(context: UpgradeExecutionContext): Promise<void> {
+    const { plan, state } = context;
+    context.spinner.start(`Downloading, verifying, and staging ${plan.binaryName}`);
+    state.stagedManagement = await stageBinary({
+        downloadUrl: releaseAssetUrl(plan.release, plan.binaryName),
+        binaryName: plan.binaryName,
+        checksums: context.checksums,
+        preferredEndpoint: plan.endpoint,
+        targetPath: BIN_TARGET,
+        validate: validateManagementBinaryArtifact,
+        forceYes: context.options.forceYes,
+    });
+    state.downloadEndpointLabel = state.stagedManagement.endpoint.label;
+}
+
+async function stageEdgeRuntimeUpgrade(context: UpgradeExecutionContext): Promise<void> {
+    const edgeRuntime = context.plan.edgeRuntime;
+    if (!edgeRuntime || !context.edgeRuntimeChecksums) return;
+    context.spinner.start(`Downloading, verifying, and staging ${edgeRuntime.binaryName}`);
+    context.state.stagedEdgeRuntime = await stageBinary({
+        downloadUrl: releaseAssetUrl(edgeRuntime.release, edgeRuntime.binaryName),
+        binaryName: edgeRuntime.binaryName,
+        checksums: context.edgeRuntimeChecksums,
+        preferredEndpoint: edgeRuntime.endpoint,
+        targetPath: edgeRuntime.targetPath,
+        validate: validateElfBinaryArtifact,
+        forceYes: context.options.forceYes,
+    });
+    context.state.edgeRuntimeEndpointLabel = context.state.stagedEdgeRuntime.endpoint.label;
+}
+
+async function stageWebConsoleUpgrade(context: UpgradeExecutionContext): Promise<void> {
+    const { plan, state } = context;
+    context.spinner.start(`Downloading, verifying, and staging ${WEB_CONSOLE_ASSET}`);
+    state.stagedWebConsole = await stageWebConsoleBuild(
+        releaseAssetUrl(plan.release, WEB_CONSOLE_ASSET),
+        plan.remoteVersion,
+        context.checksums,
+        plan.endpoint,
+        context.options.forceYes,
+    );
+    state.webConsoleEndpointLabel = state.stagedWebConsole.endpoint.label;
+}
+
+async function stageUpgradeArtifacts(context: UpgradeExecutionContext): Promise<void> {
+    await stageManagementUpgrade(context);
+    await stageEdgeRuntimeUpgrade(context);
+    await stageWebConsoleUpgrade(context);
+}
+
+async function migrateUpgradeMetadata(context: UpgradeExecutionContext): Promise<void> {
+    const stagedManagement = context.state.stagedManagement;
+    if (!stagedManagement) throw new Error("Upgrade binary was not staged");
+    context.spinner.start("Applying backward-compatible metadata database migrations with the staged binary");
+    await runStagedDatabaseMigration(stagedManagement.path, context.preparedSecrets);
+}
+
+async function activateUpgradeArtifacts(context: UpgradeExecutionContext): Promise<void> {
+    const { plan, state } = context;
+    if (!state.stagedManagement) throw new Error("Upgrade binary was not staged");
+    context.spinner.start("Atomically activating staged SupaCloud artifacts");
+    state.activation = createActivationState(plan.edgeRuntime?.targetPath || null);
+    await activateArtifacts(
+        state.stagedManagement,
+        state.stagedEdgeRuntime,
+        state.stagedWebConsole,
+        state.activation,
+    );
+}
+
+function captureUpgradeRuntimeFiles(activation: UpgradeActivationState): void {
+    activation.managementEnvState = captureFileState(managementEnvFile());
+    activation.edgeRuntimeEnvState = captureFileState(edgeRuntimeEnvFile());
+    activation.edgeRuntimeDropInState = captureFileState(edgeRuntimeCapacityDropIn());
+    activation.managementPrivilegeDropInState = captureFileState(DEFAULT_MANAGEMENT_PRIVILEGE_DROPIN);
+    activation.embeddedEdgePrivilegeDropInState = captureFileState(embeddedEdgePrivilegeDropIn());
+}
+
+async function applyUpgradeRuntimeSettings(context: UpgradeExecutionContext): Promise<void> {
+    const activation = context.state.activation;
+    if (!activation) throw new Error("Upgrade activation state is unavailable");
+    context.spinner.start("Applying runtime settings and restarting SupaCloud services");
+    captureUpgradeRuntimeFiles(activation);
+    const edgeRuntimeIdentity = await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
+    upsertPersistedEdgeRuntimePort(managementEnvFile(), edgeRuntimeEnvFile());
+    const edgeRuntimeMode = await runtimeModeForBinaryUpgrade();
+    context.state.activatedEdgeRuntimeMode = edgeRuntimeMode;
+    await reconcileManagementPrivilegeDropIns(edgeRuntimeMode, edgeRuntimeIdentity);
+    if (edgeRuntimeMode === "external") await ensureEdgeRuntimeCapacityDropIn(context.preparedSecrets.runtimeEnv);
+    upsertManagementWebConsoleDir(managementEnvFile());
+    await restartServices(edgeRuntimeMode);
+}
+
+async function verifyEdgeRuntimeUpgrade(context: UpgradeExecutionContext): Promise<void> {
+    const { edgeRuntime } = context.plan;
+    const stagedEdgeRuntime = context.state.stagedEdgeRuntime;
+    if (!edgeRuntime || !stagedEdgeRuntime) return;
+    await verifyActivatedSystemdBinary(
+        EDGE_RUNTIME_SERVICE_UNIT,
+        edgeRuntime.targetPath,
+        stagedEdgeRuntime.sha256,
+    );
+    const enabledState = await readSystemdEnabledState(EDGE_RUNTIME_SERVICE_UNIT);
+    if (enabledState !== edgeRuntime.enabledState) {
+        throw new Error(`${EDGE_RUNTIME_SERVICE_UNIT} enabled state changed from ${edgeRuntime.enabledState} to ${enabledState}`);
+    }
+}
+
+async function verifyUpgradeActivation(context: UpgradeExecutionContext): Promise<void> {
+    const stagedManagement = context.state.stagedManagement;
+    if (!context.state.activatedEdgeRuntimeMode) throw new Error("Edge Runtime mode was not resolved");
+    if (!stagedManagement) throw new Error("Upgrade binary was not staged");
+    context.spinner.start("Waiting for the SupaCloud health endpoint");
+    await waitForUpgradeHealth();
+    await verifyActivatedManagementBinary(stagedManagement.sha256);
+    await verifyEdgeRuntimeUpgrade(context);
+    context.state.committed = true;
+}
+
+async function rollbackUpgradeActivation(context: UpgradeExecutionContext): Promise<void> {
+    const activation = context.state.activation;
+    if (!activation) return;
+    p.log.warn("Upgrade activation failed; restoring the previous binary and Web Console target.");
+    await rollbackArtifacts(activation, context.state.stagedWebConsole);
+    context.state.rollbackSucceeded = true;
+}
+
+function stagedArtifactCleanupActions(state: UpgradeExecutionState): UpgradeCleanupAction[] {
+    const actions: UpgradeCleanupAction[] = [];
+    const management = state.stagedManagement;
+    if (management) actions.push({
+        description: `remove staged Management binary ${management.path}`,
+        run: () => rmSync(management.path, { force: true }),
+    });
+    const edgeRuntime = state.stagedEdgeRuntime;
+    if (edgeRuntime) actions.push({
+        description: `remove staged Edge Runtime binary ${edgeRuntime.path}`,
+        run: () => rmSync(edgeRuntime.path, { force: true }),
+    });
+    const webConsole = state.stagedWebConsole;
+    if (!state.committed && webConsole) actions.push({
+        description: `remove staged Web Console ${webConsole.releaseDir}`,
+        run: () => rmSync(webConsole.releaseDir, { force: true, recursive: true }),
+    });
+    return actions;
+}
+
+function activatedBackupCleanupActions(state: UpgradeExecutionState): UpgradeCleanupAction[] {
+    const activation = state.activation;
+    if (!activation) return [];
+    const actions: UpgradeCleanupAction[] = [];
+    const oldWebBackup = activation.oldWebBackup;
+    if (state.committed && oldWebBackup) actions.push({
+        description: `remove previous Web Console backup ${oldWebBackup}`,
+        run: () => rmSync(oldWebBackup, { force: true, recursive: true }),
+    });
+    actions.push({
+        description: `remove Management backup ${activation.binary.backupPath}`,
+        run: () => cleanupBinaryBackup(activation.binary),
+    });
+    const edgeRuntimeBackup = activation.edgeBinary;
+    if (edgeRuntimeBackup) actions.push({
+        description: `remove Edge Runtime backup ${edgeRuntimeBackup.backupPath}`,
+        run: () => cleanupBinaryBackup(edgeRuntimeBackup),
+    });
+    return actions;
+}
+
+function upgradeCleanupActions(context: UpgradeExecutionContext): UpgradeCleanupAction[] {
+    return [
+        ...stagedArtifactCleanupActions(context.state),
+        ...activatedBackupCleanupActions(context.state),
+    ];
+}
+
+function executeUpgradeCleanupActions(actions: UpgradeCleanupAction[]): void {
+    const failures: Error[] = [];
+    for (const action of actions) {
+        try {
+            action.run();
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            failures.push(new Error(`${action.description}: ${message}`));
+        }
+    }
+    if (failures.length > 0) throw new AggregateError(failures, "Upgrade artifact cleanup did not complete");
+}
+
+async function cleanupUpgradeArtifacts(context: UpgradeExecutionContext): Promise<void> {
+    const { state } = context;
+    const recoveryComplete = shouldCleanupUpgradeArtifacts({
+        committed: state.committed,
+        rollbackSucceeded: state.rollbackSucceeded,
+        activationStarted: Boolean(state.activation),
+    });
+    if (recoveryComplete) executeUpgradeCleanupActions(upgradeCleanupActions(context));
+}
+
+function upgradeTransactionOperations(context: UpgradeExecutionContext): UpgradeTransactionOperations {
+    return {
+        preflight: () => verifyUpgradePreflight(context),
+        stage: () => stageUpgradeArtifacts(context),
+        migrate: () => migrateUpgradeMetadata(context),
+        activate: () => activateUpgradeArtifacts(context),
+        restart: () => applyUpgradeRuntimeSettings(context),
+        healthCheck: () => verifyUpgradeActivation(context),
+        rollback: () => rollbackUpgradeActivation(context),
+        cleanup: () => cleanupUpgradeArtifacts(context),
+    };
+}
+
+function upgradeRecoveryPaths(context: UpgradeExecutionContext | null): string[] {
+    if (!context) return [];
+    const { state } = context;
+    const candidates = [
+        state.activation?.binary.backupReady ? state.activation.binary.backupPath : null,
+        state.activation?.edgeBinary?.backupReady ? state.activation.edgeBinary.backupPath : null,
+        state.activation?.oldWebBackup,
+        state.stagedManagement?.path,
+        state.stagedEdgeRuntime?.path,
+        state.stagedWebConsole?.releaseDir,
+    ];
+    return [...new Set(candidates.filter((candidate): candidate is string => Boolean(candidate && existsSync(candidate))))];
+}
+
+function sanitizedUpgradeDiagnostic(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error);
+    return message
+        .replace(/(\b(?:[A-Z0-9_]*(?:PASSWORD|PASS|SECRET|TOKEN|KEY|CREDENTIAL)[A-Z0-9_]*|DATABASE_URL|DB_URI|DSN)=)(?:"[^"]*"|'[^']*'|[^\s;]+)/gi, "$1[REDACTED]")
+        .replace(/(postgres(?:ql)?:\/\/[^:\s/]+:)[^@\s]+@/gi, "$1[REDACTED]@")
+        .replace(/[\r\n\t]+/g, " ")
+        .trim()
+        .slice(0, 500);
+}
+
+function nestedUpgradeDiagnostics(error: unknown): string[] {
+    if (error instanceof AggregateError) {
+        return error.errors.flatMap(candidate => nestedUpgradeDiagnostics(candidate));
+    }
+    return [sanitizedUpgradeDiagnostic(error)];
+}
+
+function upgradeFailureHeading(error: unknown): string {
+    if (!(error instanceof UpgradeTransactionError)) return "Upgrade failed";
+    if (error.kind === "rollback-incomplete") return "Upgrade failed and rollback is incomplete";
+    if (error.kind === "cleanup-incomplete-after-commit") return "Upgrade committed, but cleanup is incomplete";
+    return "Upgrade failed and cleanup is incomplete";
+}
+
+export function formatUpgradeFailure(error: unknown, recoveryPaths: string[] = []): string {
+    const summary = sanitizedUpgradeDiagnostic(error);
+    const diagnostics = [...new Set(nestedUpgradeDiagnostics(error))].filter(message => message && message !== summary);
+    const lines = [`${upgradeFailureHeading(error)}: ${summary}`];
+    if (diagnostics.length > 0) lines.push(`Causes: ${diagnostics.join(" | ")}`);
+    if (recoveryPaths.length > 0) lines.push(`Retained recovery paths: ${recoveryPaths.join(", ")}`);
+    return lines.join("\n");
+}
+
+function upgradeSuccessMessage(context: UpgradeExecutionContext): string {
+    const { plan, state } = context;
+    const webSummary = state.webConsoleEndpointLabel
+        ? ` and ${WEB_CONSOLE_ASSET} (${state.webConsoleEndpointLabel})`
+        : "";
+    const edgeSummary = plan.edgeRuntime
+        ? `; Edge Runtime upgraded to ${plan.edgeRuntime.release.tag_name} at ${plan.edgeRuntime.targetPath} (${state.edgeRuntimeEndpointLabel})`
+        : "; Edge Runtime was not upgraded";
+    return `SupaCloud upgraded to ${plan.remoteVersion} via ${plan.binaryName} (${state.downloadEndpointLabel})${webSummary}${edgeSummary}`;
+}
+
+export async function runUpgrade(options: RunUpgradeOptions = {}) {
     p.intro("\x1b[46m SupaCloud Binary Upgrade \x1b[0m");
 
     const s = p.spinner();
     s.start("Retrieving GitHub release metadata");
+    let executionContext: UpgradeExecutionContext | null = null;
 
     try {
         if (os.userInfo().uid !== 0) {
             throw new Error("Please run the upgrade with root privileges (sudo).");
         }
-
-        const binaryName = resolveLinuxBinaryName();
-        const { data, endpoint } = await fetchReleaseMetadata(resolveReleaseApiUrl(options.targetVersion), options.forceYes);
-        const release = selectManagementRelease(data as GithubRelease | GithubRelease[], binaryName);
-        const remoteVersion = release.tag_name || "unknown";
-        const releaseUrl = releaseAssetUrl(release, binaryName);
-        const webConsoleUrl = releaseAssetUrl(release, WEB_CONSOLE_ASSET);
-
-        s.stop(`Latest binary available: ${remoteVersion} (${binaryName}, via ${endpoint.label})`);
+        const plan = await resolveUpgradeReleasePlan(options);
+        s.stop(`Latest binary available: ${plan.remoteVersion} (${plan.binaryName}, via ${plan.endpoint.label})`);
         p.log.warn("Database migrations must be backward compatible. Automatic rollback restores the binary and Web Console target, not committed schema changes.");
-
-        const confirm = options.forceYes || await p.confirm({
-            message: `Replace ${BIN_TARGET} with ${binaryName} from ${remoteVersion}?`,
-            initialValue: true,
-        });
-
-        if (!confirm || p.isCancel(confirm)) {
+        if (!await confirmUpgrade(plan, options.forceYes)) {
             p.cancel("Upgrade cancelled.");
             return;
         }
-
-        const preparedSecrets = prepareUpgradeSecrets(await resolveUpgradeEnvironment());
-        const env = preparedSecrets.runtimeEnv;
-        const checksums = await downloadReleaseChecksums(release, endpoint, options.forceYes);
-        let stagedBinary: StagedBinary | null = null;
-        let stagedWeb: StagedWebConsole | null = null;
-        let activationState: UpgradeActivationState | null = null;
-        let committed = false;
-        let downloadEndpointLabel = endpoint.label;
-        let webConsoleEndpointLabel: string | null = null;
-        let activatedEdgeRuntimeMode: EdgeRuntimeMode | null = null;
-
-        await executeUpgradeTransaction({
-            preflight: async () => {
-                s.start(`Verifying ${MANAGEMENT_SERVICE_UNIT} uses the canonical upgrade target`);
-                verifyBackupPrivilegeDropPreflight();
-                await verifyManagementUpgradePreflight();
-            },
-            stage: async () => {
-                s.start(`Downloading, verifying, and staging ${binaryName}`);
-                stagedBinary = await stageBinary(releaseUrl, binaryName, checksums, endpoint, options.forceYes);
-                downloadEndpointLabel = stagedBinary.endpoint.label;
-                s.start(`Downloading, verifying, and staging ${WEB_CONSOLE_ASSET}`);
-                stagedWeb = await stageWebConsoleBuild(webConsoleUrl, remoteVersion, checksums, endpoint, options.forceYes);
-                webConsoleEndpointLabel = stagedWeb.endpoint.label;
-            },
-            migrate: async () => {
-                if (!stagedBinary) throw new Error("Upgrade binary was not staged");
-                s.start("Applying backward-compatible metadata database migrations with the staged binary");
-                await runStagedDatabaseMigration(stagedBinary.path, preparedSecrets);
-            },
-            activate: async () => {
-                if (!stagedBinary) throw new Error("Upgrade binary was not staged");
-                s.start("Atomically activating staged SupaCloud artifacts");
-                activationState = {
-                    binary: createBinaryBackupState(BIN_TARGET),
-                    oldWebTarget: null,
-                    oldWebBackup: null,
-                    managementEnvState: null,
-                    edgeRuntimeEnvState: null,
-                    edgeRuntimeDropInState: null,
-                    managementPrivilegeDropInState: null,
-                    embeddedEdgePrivilegeDropInState: null,
-                };
-                await activateArtifacts(stagedBinary, stagedWeb, activationState);
-            },
-            restart: async () => {
-                s.start("Applying runtime settings and restarting SupaCloud services");
-                if (!activationState) throw new Error("Upgrade activation state is unavailable");
-                activationState.managementEnvState = captureFileState(managementEnvFile());
-                activationState.edgeRuntimeEnvState = captureFileState(edgeRuntimeEnvFile());
-                activationState.edgeRuntimeDropInState = captureFileState(edgeRuntimeCapacityDropIn());
-                activationState.managementPrivilegeDropInState = captureFileState(DEFAULT_MANAGEMENT_PRIVILEGE_DROPIN);
-                activationState.embeddedEdgePrivilegeDropInState = captureFileState(embeddedEdgePrivilegeDropIn());
-                const edgeRuntimeIdentity = await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
-                upsertPersistedEdgeRuntimePort(managementEnvFile(), edgeRuntimeEnvFile());
-                const edgeRuntimeMode = await runtimeModeForBinaryUpgrade();
-                activatedEdgeRuntimeMode = edgeRuntimeMode;
-                await reconcileManagementPrivilegeDropIns(edgeRuntimeMode, edgeRuntimeIdentity);
-                if (edgeRuntimeMode === "external") {
-                    await ensureEdgeRuntimeCapacityDropIn(env);
-                }
-                upsertManagementWebConsoleDir(managementEnvFile());
-                await restartServices(edgeRuntimeMode);
-            },
-            healthCheck: async () => {
-                s.start("Waiting for the SupaCloud health endpoint");
-                if (!activatedEdgeRuntimeMode) throw new Error("Edge Runtime mode was not resolved");
-                await waitForUpgradeHealth();
-                if (!stagedBinary) throw new Error("Upgrade binary was not staged");
-                await verifyActivatedManagementBinary(stagedBinary.sha256);
-                committed = true;
-            },
-            rollback: async () => {
-                if (!activationState) return;
-                p.log.warn("Upgrade activation failed; restoring the previous binary and Web Console target.");
-                await rollbackArtifacts(activationState, stagedWeb);
-            },
-            cleanup: async () => {
-                if (stagedBinary) {
-                    await $`rm -f ${stagedBinary.path}`.nothrow().quiet();
-                }
-                if (!committed && stagedWeb) {
-                    await $`rm -rf ${stagedWeb.releaseDir}`.nothrow().quiet();
-                }
-                if (activationState) {
-                    cleanupBinaryBackup(activationState.binary);
-                }
-            },
-        });
-
-        p.outro(`SupaCloud upgraded to ${remoteVersion} via ${binaryName} (${downloadEndpointLabel})${webConsoleEndpointLabel ? ` and ${WEB_CONSOLE_ASSET} (${webConsoleEndpointLabel})` : ""}`);
+        executionContext = await createUpgradeExecutionContext(plan, options, s);
+        await executeUpgradeTransaction(upgradeTransactionOperations(executionContext));
+        p.outro(upgradeSuccessMessage(executionContext));
     } catch (error: unknown) {
-        s.stop(`Upgrade failed: ${error instanceof Error ? error.message : String(error)}`);
+        s.stop(formatUpgradeFailure(error, upgradeRecoveryPaths(executionContext)));
         process.exit(1);
     }
 }

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -9,7 +9,10 @@ import {
     buildManagementPrivilegeDropIn,
     buildCheckpointDatabaseOptions,
     backupCurrentBinary,
+    activateStagedBinary,
     buildRuntimeServiceRestartPlan,
+    assertExternalEdgeRuntimeUpgradeMode,
+    assertEdgeRuntimeBinaryTarget,
     captureFileState,
     cleanupBinaryBackup,
     createBinaryBackupState,
@@ -17,9 +20,13 @@ import {
     ensureEdgeRuntimeIdentity,
     ensureEmbeddedEdgeRuntimeSourceAccess,
     ensurePersistedEdgeRuntimeIdentity,
+    formatUpgradeFailure,
     inspectActiveManagementBinary,
+    inspectActiveSystemdBinary,
+    normalizeEdgeRuntimeReleaseTag,
     normalizeManagementReleaseTag,
     parseSystemdExecStartPath,
+    parseSystemdEnabledState,
     parseSystemdMainPid,
     prepareUpgradeSecrets,
     resolveArtifactVerificationMode,
@@ -29,14 +36,18 @@ import {
     resolvePersistedEdgeRuntimeMode,
     resolveUpgradeEnvironment,
     reconcileManagementPrivilegeDropIns,
+    readSystemdEnabledState,
     runStagedDatabaseMigration,
     restoreCurrentBinary,
     restoreFileState,
+    selectEdgeRuntimeRelease,
     selectManagementRelease,
+    shouldCleanupUpgradeArtifacts,
     stopManagementService,
     upsertManagementWebConsoleDir,
     upsertPersistedEdgeRuntimePort,
     upsertEdgeRuntimeIdentityDefaults,
+    UpgradeTransactionError,
     validateWebConsoleArchiveEntries,
     verifyActivatedManagementBinary,
     verifyArtifactChecksum,
@@ -439,6 +450,37 @@ describe("upgrade release selection", () => {
     expect(selected.tag_name).toBe("management-api-v0.37.0");
   });
 
+  test("selects only the explicitly pinned Edge Runtime release with its own checksum", () => {
+    expect(normalizeEdgeRuntimeReleaseTag("0.16.7")).toBe("edge-runtime-v0.16.7");
+    expect(normalizeEdgeRuntimeReleaseTag("v0.16.7")).toBe("edge-runtime-v0.16.7");
+    expect(normalizeEdgeRuntimeReleaseTag("edge-runtime-v0.16.7")).toBe("edge-runtime-v0.16.7");
+    for (const invalidVersion of ["latest", "", "0.16", "0.16.7-beta.1"]) {
+      expect(() => normalizeEdgeRuntimeReleaseTag(invalidVersion)).toThrow("exact stable");
+    }
+
+    const selected = selectEdgeRuntimeRelease({
+      tag_name: "edge-runtime-v0.16.7",
+      draft: false,
+      prerelease: false,
+      assets: [
+        { name: "supacloud-edge-runtime-linux-amd64" },
+        { name: "SHA256SUMS" },
+      ],
+    }, "edge-runtime-v0.16.7", "supacloud-edge-runtime-linux-amd64");
+
+    expect(selected.tag_name).toBe("edge-runtime-v0.16.7");
+    expect(() => selectEdgeRuntimeRelease({
+      tag_name: "edge-runtime-v0.16.6",
+      draft: false,
+      prerelease: false,
+      assets: [
+        { name: "supacloud-edge-runtime-linux-amd64" },
+        { name: "SHA256SUMS" },
+      ],
+    }, "edge-runtime-v0.16.7", "supacloud-edge-runtime-linux-amd64"))
+      .toThrow("edge-runtime-v0.16.7");
+  });
+
   test("release verification is fail-closed unless break-glass is explicitly enabled", () => {
     expect(resolveArtifactVerificationMode(true, {})).toBe("attested");
     expect(() => resolveArtifactVerificationMode(false, {})).toThrow("attestation verification is required");
@@ -500,6 +542,62 @@ describe("upgrade release selection", () => {
       executablePath: canonicalManagementBinary,
       sha256: currentBinarySha256,
     });
+  });
+
+  test("inspects an external Edge Runtime through its real systemd target", async () => {
+    const edgeTarget = "/opt/supacloud/bin/supacloud-edge-runtime";
+    const fixture = managementBinaryFixture({
+      execStartPath: edgeTarget,
+      executablePath: edgeTarget,
+    });
+    await expect(inspectActiveSystemdBinary("supacloud-edge-runtime.service", fixture)).resolves.toEqual({
+      unit: "supacloud-edge-runtime.service",
+      execStartPath: edgeTarget,
+      pid: 4242,
+      executablePath: edgeTarget,
+      sha256: currentBinarySha256,
+    });
+  });
+
+  test("rejects Edge Runtime targets that could overwrite another executable", () => {
+    expect(() => assertEdgeRuntimeBinaryTarget("/usr/local/bin/supacloud-edge-runtime")).not.toThrow();
+    expect(() => assertEdgeRuntimeBinaryTarget("/opt/supacloud/bin/supacloud-edge-runtime")).not.toThrow();
+    for (const unsafeTarget of [
+      "/usr/local/bin/supacloud",
+      "/usr/local/bin/edge-runtime",
+      "/opt/supacloud/bin/supacloud-edge-runtime.backup",
+      "/tmp/supacloud-edge-runtime",
+    ]) {
+      expect(() => assertEdgeRuntimeBinaryTarget(unsafeTarget)).toThrow("Unsafe Edge Runtime upgrade target");
+    }
+  });
+
+  test("accepts only the enabled states that the component transaction preserves", () => {
+    expect(parseSystemdEnabledState({ exitCode: 0, stdout: "enabled\n", stderr: "" })).toBe("enabled");
+    expect(parseSystemdEnabledState({ exitCode: 1, stdout: "disabled\n", stderr: "" })).toBe("disabled");
+    expect(() => parseSystemdEnabledState({ exitCode: 0, stdout: "static\n", stderr: "" })).toThrow();
+    expect(() => parseSystemdEnabledState({ exitCode: 1, stdout: "", stderr: "not found" })).toThrow();
+  });
+
+  test("reads enabled and disabled Edge unit states without normalizing them", async () => {
+    for (const state of ["enabled", "disabled"] as const) {
+      const exitCode = state === "enabled" ? 0 : 1;
+      await expect(readSystemdEnabledState("supacloud-edge-runtime.service", async command => {
+        expect(command).toEqual(["systemctl", "is-enabled", "supacloud-edge-runtime.service"]);
+        return { exitCode, stdout: `${state}\n`, stderr: "" };
+      })).resolves.toBe(state);
+    }
+    await expect(readSystemdEnabledState("supacloud-edge-runtime.service", async () => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "unit missing",
+    }))).rejects.toThrow("supacloud-edge-runtime.service enabled state");
+  });
+
+  test("component upgrade rejects embedded mode before artifact work", () => {
+    expect(() => assertExternalEdgeRuntimeUpgradeMode("embedded"))
+      .toThrow("persisted external mode only");
+    expect(() => assertExternalEdgeRuntimeUpgradeMode("external")).not.toThrow();
   });
 
   test("fails closed when systemd, procfs, hashing, or PID stability cannot be verified", async () => {
@@ -660,6 +758,108 @@ describe("upgrade release selection", () => {
     ]);
   });
 
+  test("preserves recovery evidence and both errors when rollback fails", async () => {
+    const events: string[] = [];
+    let failure: unknown;
+    try {
+      await executeUpgradeTransaction({
+        preflight: async () => { events.push("preflight"); },
+        stage: async () => { events.push("stage"); },
+        migrate: async () => { events.push("migrate"); },
+        activate: async () => { events.push("activate"); },
+        restart: async () => { throw new Error("restart failed"); },
+        healthCheck: async () => { events.push("health"); },
+        rollback: async () => { throw new Error("rollback failed"); },
+        cleanup: async () => { events.push("cleanup"); },
+      });
+    } catch (error: unknown) {
+      failure = error;
+    }
+    expect(failure).toBeInstanceOf(UpgradeTransactionError);
+    const rollbackFailure = failure as UpgradeTransactionError;
+    expect(rollbackFailure.kind).toBe("rollback-incomplete");
+    expect(rollbackFailure.errors.some(candidate => String(candidate).includes("restart failed"))).toBe(true);
+    expect(rollbackFailure.errors.some(candidate => String(candidate).includes("rollback failed"))).toBe(true);
+    const output = formatUpgradeFailure(rollbackFailure, ["/usr/local/bin/supacloud.bak-run"]);
+    expect(output).toContain("rollback is incomplete");
+    expect(output).toContain("restart failed");
+    expect(output).toContain("rollback failed");
+    expect(output).toContain("/usr/local/bin/supacloud.bak-run");
+    expect(events).toContain("cleanup");
+    expect(shouldCleanupUpgradeArtifacts({
+      committed: false,
+      rollbackSucceeded: false,
+      activationStarted: true,
+    })).toBe(false);
+  });
+
+  test("reports a committed upgrade with incomplete cleanup distinctly", async () => {
+    let failure: unknown;
+    try {
+      await executeUpgradeTransaction({
+        preflight: async () => {},
+        stage: async () => {},
+        migrate: async () => {},
+        activate: async () => {},
+        restart: async () => {},
+        healthCheck: async () => {},
+        rollback: async () => {},
+        cleanup: async () => { throw new Error("backup removal denied"); },
+      });
+    } catch (error: unknown) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(UpgradeTransactionError);
+    expect((failure as UpgradeTransactionError).kind).toBe("cleanup-incomplete-after-commit");
+    const output = formatUpgradeFailure(failure, ["/opt/supacloud/web-console/current.bak-run"]);
+    expect(output).toContain("Upgrade committed, but cleanup is incomplete");
+    expect(output).toContain("backup removal denied");
+    expect(output).toContain("current.bak-run");
+  });
+
+  test("preserves upgrade and cleanup diagnostics after a successful rollback", async () => {
+    let failure: unknown;
+    try {
+      await executeUpgradeTransaction({
+        preflight: async () => {},
+        stage: async () => {},
+        migrate: async () => {},
+        activate: async () => {},
+        restart: async () => { throw new Error("restart failed"); },
+        healthCheck: async () => {},
+        rollback: async () => {},
+        cleanup: async () => { throw new Error("staged file removal denied"); },
+      });
+    } catch (error: unknown) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(UpgradeTransactionError);
+    expect((failure as UpgradeTransactionError).kind).toBe("cleanup-incomplete-after-failure");
+    const output = formatUpgradeFailure(failure);
+    expect(output).toContain("Upgrade failed and cleanup is incomplete");
+    expect(output).toContain("restart failed");
+    expect(output).toContain("staged file removal denied");
+  });
+
+  test("redacts secrets from nested CLI failure diagnostics", () => {
+    const failure = new UpgradeTransactionError(
+      "rollback-incomplete",
+      [
+        new Error("DATABASE_URL=postgresql://admin:database-password@localhost/supacloud"),
+        new Error("API_TOKEN=raw-token"),
+      ],
+      "Upgrade failed and rollback did not complete",
+    );
+
+    const output = formatUpgradeFailure(failure);
+    expect(output).toContain("DATABASE_URL=[REDACTED]");
+    expect(output).toContain("API_TOKEN=[REDACTED]");
+    expect(output).not.toContain("database-password");
+    expect(output).not.toContain("raw-token");
+  });
+
   test("rejects Web Console archives with path traversal entries", () => {
     expect(() => validateWebConsoleArchiveEntries("index.html\n../escape\n"))
       .toThrow("unsafe path");
@@ -738,6 +938,31 @@ describe("upgrade release selection", () => {
       expect(readFileSync(target, "utf8")).toBe("old-binary");
       cleanupBinaryBackup(state);
       expect(existsSync(state.backupPath)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("restores both Management and Edge binaries after partial activation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-binaries-"));
+    const managementTarget = join(dir, "supacloud");
+    const edgeTarget = join(dir, "supacloud-edge-runtime");
+    const stagedManagement = join(dir, "staged-management");
+    const stagedEdge = join(dir, "staged-edge");
+    writeFileSync(managementTarget, "old-management");
+    writeFileSync(edgeTarget, "old-edge");
+    writeFileSync(stagedManagement, "new-management");
+    writeFileSync(stagedEdge, "new-edge");
+    const managementState = createBinaryBackupState(managementTarget, "transaction");
+    const edgeState = createBinaryBackupState(edgeTarget, "transaction");
+
+    try {
+      activateStagedBinary(stagedManagement, managementState);
+      activateStagedBinary(stagedEdge, edgeState);
+      restoreCurrentBinary(managementState);
+      restoreCurrentBinary(edgeState);
+      expect(readFileSync(managementTarget, "utf8")).toBe("old-management");
+      expect(readFileSync(edgeTarget, "utf8")).toBe("old-edge");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { SQL } from "bun";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -939,6 +939,38 @@ describe("upgrade release selection", () => {
       cleanupBinaryBackup(state);
       expect(existsSync(state.backupPath)).toBe(false);
     } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("atomically restores a binary while its current executable is still running", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-upgrade-running-binary-"));
+    const target = join(dir, "supacloud");
+    copyFileSync(process.execPath, target);
+    chmodSync(target, 0o755);
+    const state = createBinaryBackupState(target, "running-binary");
+    backupCurrentBinary(state);
+    chmodSync(state.backupPath, 0o600);
+    const runningBinary = Bun.spawn([target, "-e", "setInterval(() => {}, 1000)"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    try {
+      await Bun.sleep(100);
+      process.kill(runningBinary.pid, 0);
+      const runningInode = statSync(target).ino;
+
+      restoreCurrentBinary(state);
+
+      expect(statSync(target).ino).not.toBe(runningInode);
+      expect(statSync(target).mode & 0o777).toBe(0o755);
+      expect(readFileSync(target)).toEqual(readFileSync(state.backupPath));
+      expect(readdirSync(dir).some(name => name.includes(".restore-"))).toBe(false);
+    } finally {
+      runningBinary.kill();
+      await runningBinary.exited;
+      cleanupBinaryBackup(state);
       rmSync(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

- make the published Admin CLI execute correctly through npm bin symlinks
- support root SSH and passwordless sudo for verified platform upgrades
- embed the controlled release helper and install the pinned GitHub attestation verifier when absent
- upgrade Management, Web Console, and an external Edge Runtime as one rollback-capable transaction
- preserve the Edge Runtime systemd binary path, port, mode, architecture, hash, health, and enabled state
- surface remote, rollback, and cleanup failures with sanitized nested diagnostics and retained recovery paths

## Safety boundaries

- combined upgrades require exact stable Management and Edge Runtime versions
- embedded Edge Runtime mode is rejected before artifact download or service mutation
- the official path clears break-glass and release-source override environment variables
- Edge Runtime replacement is restricted to the two supported systemd binary paths
- Management and Edge assets use independent release metadata, SHA256 checksums, attestations, and architecture validation
- Caddy, GoTrue, tenant data, and database schema rollback are outside this artifact transaction

## Verification

- Admin full suite: 59 pass, 0 fail
- Admin typecheck and build: pass
- Management upgrade suite: 63 pass, 0 fail
- Management shared unit runner and typecheck: pass
- standalone Linux amd64 and arm64 builds: pass
- real npm pack/install/bin symlink smoke: pass
- real runCli child-process dual-failure smoke: exit 1, both causes visible, credentials redacted
- git diff check: pass
- independent review: pass

## Release expectation

Release Please should produce Management API 0.50.27 and Admin 0.7.2. Edge Runtime remains independently pinned at 0.16.7 for the first supported combined upgrade.
