### PR TITLE
fix(ci): enforce main required checks

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -24,29 +24,9 @@ on:
       - ".github/workflows/release-please.yml"
       - "release-please-config.json"
       - ".release-please-manifest.json"
+  # Branch protection requires a result for every PR, so do not add path filters here.
   pull_request:
     branches: ["main", "dev"]
-    paths:
-      - "packages/management-api/**"
-      - "packages/web-console/**"
-      - "packages/supacloud-js/**"
-      - "packages/edge-runtime/**"
-      - "packages/pgredis-runtime/**"
-      - "packages/supacloud-lite/**"
-      - "packages/admin/**"
-      - "packages/cli/**"
-      - "packages/supacloud/**"
-      - "docker/**"
-      - "scripts/**"
-      - "install.sh"
-      - "setup.sh"
-      - "switch.sh"
-      - ".github/scripts/**"
-      - ".github/workflows/ai-review-merge.yml"
-      - ".github/workflows/management-api.yml"
-      - ".github/workflows/release-please.yml"
-      - "release-please-config.json"
-      - ".release-please-manifest.json"
   workflow_dispatch:
 
 permissions:
@@ -758,6 +738,52 @@ jobs:
 
       - name: Test Caddy to Edge Runtime cancellation and proxying
         run: CADDY_BINARY=packages/management-api/dist/supacloud-caddy-linux-amd64 bash scripts/test_supacloud_caddy_edge_proxy.sh
+
+  # Keep this aggregate name stable: main branch protection requires it.
+  required-checks:
+    name: Required Checks
+    if: ${{ always() }}
+    needs:
+      - lint-and-typecheck
+      - package-checks
+      - supacloud-lite-windows
+      - docker-and-scripts-checks
+      - unit-test
+      - postgres-18-compatibility
+      - integration-test
+      - shell-scripts-lint
+      - caddy-edge-proxy-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Verify required jobs
+        env:
+          LINT_AND_TYPECHECK: ${{ needs.lint-and-typecheck.result }}
+          PACKAGE_CHECKS: ${{ needs.package-checks.result }}
+          SUPACLOUD_LITE_WINDOWS: ${{ needs.supacloud-lite-windows.result }}
+          DOCKER_AND_SCRIPTS: ${{ needs.docker-and-scripts-checks.result }}
+          UNIT_TESTS: ${{ needs.unit-test.result }}
+          POSTGRES_18: ${{ needs.postgres-18-compatibility.result }}
+          INTEGRATION_TESTS: ${{ needs.integration-test.result }}
+          SHELL_SCRIPTS_LINT: ${{ needs.shell-scripts-lint.result }}
+          CADDY_EDGE_PROXY: ${{ needs.caddy-edge-proxy-smoke.result }}
+        run: |
+          for result in \
+            "$LINT_AND_TYPECHECK" \
+            "$PACKAGE_CHECKS" \
+            "$SUPACLOUD_LITE_WINDOWS" \
+            "$DOCKER_AND_SCRIPTS" \
+            "$UNIT_TESTS" \
+            "$POSTGRES_18" \
+            "$INTEGRATION_TESTS" \
+            "$SHELL_SCRIPTS_LINT" \
+            "$CADDY_EDGE_PROXY"; do
+            if [[ "$result" != "success" ]]; then
+              echo "Required CI job did not succeed: $result" >&2
+              exit 1
+            fi
+          done
 
   build-binaries:
     name: Build Binaries

--- a/packages/supacloud/bun.lock
+++ b/packages/supacloud/bun.lock
@@ -6,7 +6,7 @@
       "name": "supacloud",
       "dependencies": {
         "@supacloud/admin": "^0.7.1",
-        "@supacloud/cli": "^0.14.3",
+        "@supacloud/cli": "^0.14.4",
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
@@ -19,7 +19,7 @@
 
     "@supacloud/admin": ["@supacloud/admin@0.7.1", "https://registry.npmmirror.com/@supacloud/admin/-/admin-0.7.1.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52", "ssh2": "^1.17.0" }, "bin": { "supacloud-admin": "dist/index.js" } }, "sha512-7DRZXIaKSv4x4SEj3dVzx1B+ei+l4ZaQj/UqdY0pjvgOpdg1r1xoIZlkhIxvQI8QcGbmPI3P/ABml9CRgq4FEQ=="],
 
-    "@supacloud/cli": ["@supacloud/cli@0.14.3", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.3.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-QSRqck326QWHGAjpFikiHJH8Di2su3GuD9OIMzNjK7xtXGTgJLU3+7M5sZsxShmk0uBoITcD9vnZb9yGJTlEJA=="],
+    "@supacloud/cli": ["@supacloud/cli@0.14.4", "https://registry.npmmirror.com/@supacloud/cli/-/cli-0.14.4.tgz", { "dependencies": { "@sinclair/typebox": "^0.34.52" }, "bin": { "supacloud-cli": "dist/index.js" } }, "sha512-V8yL+/6CPImMMhYy1hysjhPFpec19C83oEjq8SmKRKT5roBoyr757jEpm2uKpua1DgEe/bE5M3KErgT3nVivkA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "https://registry.npmmirror.com/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 


### PR DESCRIPTION
## Summary

- synchronize the umbrella CLI lockfile with published `@supacloud/cli@0.14.4`
- run Management API CI for every pull request so required checks cannot remain pending because of path filters
- add a stable fail-closed `Required Checks` aggregate for branch protection

## Verification

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun test src/index.test.ts` (19 pass)
- `bun run build`
- actionlint workflow validation
- YAML parse and `git diff --check`
- independent verifier: PASS

After this PR produces a successful `Required Checks` result, main protection will require that GitHub Actions context with strict updates and admin enforcement.