### PR TITLE
fix(admin): execute verified upgrade shell safely

### DIFF
--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { registerSshTools } from "./ssh-tools";
+import { buildRootUpgradeScript, registerSshTools } from "./ssh-tools";
 import { parseToolArguments } from "../schema";
 import type { ToolSchema } from "../schema";
 
@@ -19,9 +19,11 @@ class FakeSsh {
     cleanupExecFails = false;
     uploadThrows = false;
     partialUploadThrows = false;
+    pingResult = true;
+    diagnosticExecFails = false;
 
     async ping(): Promise<boolean> {
-        return true;
+        return this.pingResult;
     }
 
     async exec(command: string): Promise<{ success: boolean; stdout: string; stderr: string; code: number }> {
@@ -61,6 +63,9 @@ class FakeSsh {
                 ? { success: false, stdout: "", stderr: "restore failed", code: 1 }
                 : { success: true, stdout: "Migration complete\n", stderr: "", code: 0 };
         }
+        if (this.diagnosticExecFails && command === "hostname") {
+            return { success: false, stdout: "", stderr: "diagnostic failed", code: 3 };
+        }
         return { success: true, stdout: "SSH_SESSION_OK\n", stderr: "", code: 0 };
     }
 
@@ -99,6 +104,14 @@ function captureSshTool(ssh: FakeSsh): {
 }
 
 describe("ssh admin tool", () => {
+    test("ping fails instead of returning a successful process result", async () => {
+        const ssh = new FakeSsh();
+        ssh.pingResult = false;
+
+        await expect(captureSshTool(ssh).invoke({ action: "ping" }))
+            .rejects.toThrow("SSH ping failed");
+    });
+
     test("setup verifies the active SSH session without weakening sshd", async () => {
         const ssh = new FakeSsh();
         const tool = captureSshTool(ssh);
@@ -129,10 +142,19 @@ describe("ssh admin tool", () => {
             "cat /etc/os-release",
             "pg_isready -h localhost -p 5432",
             "hostname -f",
+            "hostname -I",
         ]) {
             const result = await tool.invoke({ action: "exec", command });
             expect(result.content[0]?.text).toContain("exit: 0");
         }
+    });
+
+    test("generic exec propagates a remote diagnostic failure", async () => {
+        const ssh = new FakeSsh();
+        ssh.diagnosticExecFails = true;
+
+        await expect(captureSshTool(ssh).invoke({ action: "exec", command: "hostname" }))
+            .rejects.toThrow("Remote diagnostic command failed (exit 3): diagnostic failed");
     });
 
     test("generic exec rejects filesystem, network, mutation, and secret-reading escapes", async () => {
@@ -221,6 +243,12 @@ describe("ssh admin tool", () => {
         expect(command).not.toContain("/opt/supacloud/scripts");
         expect(command).toContain("trap 'rm -f /tmp/.supacloud-release-assets-");
         expect(command).not.toMatch(/\/usr\/local\/bin\/supacloud upgrade --yes/);
+        const rootScript = buildRootUpgradeScript({
+            version: "0.50.27",
+            edgeRuntimeVersion: "0.16.7",
+            helperPath: ssh.uploads[0]?.remotePath ?? "",
+        });
+        expect(Bun.spawnSync(["bash", "-n", "-c", rootScript]).exitCode).toBe(0);
         expect(Bun.spawnSync(["bash", "-n", "-c", command]).exitCode).toBe(0);
         expect(ssh.commands[1]).toBe(`rm -f '${ssh.uploads[0]?.remotePath}'`);
     });

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -129,7 +129,7 @@ function componentPreflightCommands(request: UpgradeRequest): string[] {
     ] : [];
 }
 
-function buildRootUpgradeScript(request: UpgradeRequest): string {
+export function buildRootUpgradeScript(request: UpgradeRequest): string {
     const envAssignments = upgradeEnvAssignments(request);
     return [
         "set -euo pipefail",
@@ -148,7 +148,7 @@ function buildRootUpgradeScript(request: UpgradeRequest): string {
         "supacloud_attestation_verifier_available || { echo 'Pinned GitHub attestation verifier is unavailable' >&2; exit 1; }",
         ...componentBootstrapCommands(request),
         `${envAssignments ? `env ${envAssignments} ` : ""}"$UPGRADE_RUNNER" upgrade --yes`,
-    ].join("; ");
+    ].join("\n");
 }
 
 export function buildOfficialUpgradeCommand(request: UpgradeRequest): string {
@@ -321,7 +321,7 @@ function assertSafeExecCommand(command: string): string {
     if (commandName === "free" && ["free", "free -h", "free -m"].includes(trimmed)) return trimmed;
     if (commandName === "uname" && ["uname", "uname -a", "uname -r", "uname -m"].includes(trimmed)) return trimmed;
     if (trimmed === "cat /etc/os-release") return trimmed;
-    if (commandName === "hostname" && ["hostname", "hostname -f"].includes(trimmed)) return trimmed;
+    if (commandName === "hostname" && ["hostname", "hostname -f", "hostname -I"].includes(trimmed)) return trimmed;
 
     if (commandName === "pg_isready") {
         const seen = new Set<string>();
@@ -385,7 +385,8 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
             switch (action) {
                 case "ping": {
                     const ok = await ssh.ping();
-                    text = ok ? "✅ Server reachable" : "❌ Server unreachable";
+                    if (!ok) throw new Error("SSH ping failed: server returned an unexpected response");
+                    text = "✅ Server reachable";
                     break;
                 }
                 case "setup": {
@@ -568,6 +569,10 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
                     if (!args.command) throw new Error("'command' required");
                     const command = assertSafeExecCommand(args.command);
                     const r = await ssh.exec(command, getExecTimeoutMs(args.timeout_seconds));
+                    if (!r.success) {
+                        const diagnostic = (r.stderr || r.stdout).trim() || "no remote diagnostic";
+                        throw new Error(`Remote diagnostic command failed (exit ${r.code}): ${diagnostic.slice(-500)}`);
+                    }
                     text = `exit: ${r.code}\n\nstdout:\n${r.stdout.slice(-2000)}\n\nstderr:\n${r.stderr.slice(-500)}`;
                     break;
                 }

--- a/packages/admin/src/shared/transports/ssh.test.ts
+++ b/packages/admin/src/shared/transports/ssh.test.ts
@@ -9,12 +9,13 @@ const TEST_HOST_FINGERPRINT = `SHA256:${createHash("sha256").update(TEST_HOST_KE
 
 class FakeSshClient extends EventEmitter {
     connectOptions: Record<string, unknown> | undefined;
+    connectError: Error | undefined;
     stdout = Buffer.from("ok\n");
     stderrOutput = Buffer.alloc(0);
 
     connect(options: Record<string, unknown>): this {
         this.connectOptions = options;
-        queueMicrotask(() => this.emit("ready"));
+        queueMicrotask(() => this.connectError ? this.emit("error", this.connectError) : this.emit("ready"));
         return this;
     }
 
@@ -33,6 +34,40 @@ class FakeSshClient extends EventEmitter {
 }
 
 describe("SshTransport audit safety", () => {
+    test("ping propagates connection errors", async () => {
+        const failedClient = new FakeSshClient();
+        failedClient.connectError = new Error("authentication failed");
+        const failedTransport = new SshTransport({
+            host: "server.example.com",
+            port: 22,
+            username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => failedClient as never });
+
+        try {
+            await expect(failedTransport.ping()).rejects.toThrow("authentication failed");
+        } finally {
+            failedTransport.close();
+        }
+    });
+
+    test("ping rejects unexpected output", async () => {
+        const unexpectedClient = new FakeSshClient();
+        unexpectedClient.stdout = Buffer.from("not-pong\n");
+        const unexpectedTransport = new SshTransport({
+            host: "server.example.com",
+            port: 22,
+            username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => unexpectedClient as never });
+
+        try {
+            expect(await unexpectedTransport.ping()).toBe(false);
+        } finally {
+            unexpectedTransport.close();
+        }
+    });
+
     test("redacts secrets from arbitrary command output", () => {
         const output = redactSshOutput([
             "POSTGRES_PASSWORD=database-password",

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -350,8 +350,8 @@ export class SshTransport {
     }
 
     async ping(): Promise<boolean> {
-        const result = await this.exec("echo pong", 10_000).catch(() => null);
-        return result?.stdout.trim() === "pong";
+        const result = await this.exec("echo pong", 10_000);
+        return result.success && result.stdout.trim() === "pong";
     }
 
     close() {


### PR DESCRIPTION
## Summary

- preserve shell control-flow syntax by joining the verified root upgrade script with newlines
- validate the inner root script directly with `bash -n`, not only the outer `bash -c` wrapper
- propagate SSH ping and diagnostic command failures as non-zero CLI failures
- allow the exact read-only `hostname -I` identity check

## Production evidence

The released Admin 0.7.2 command failed with remote exit 2 before any component switch because the generated script contained `then;`. The helper cleanup completed and the target remained on its prior Management version with both services active and zero restarts. No manual deployment path was used.

## Verification

- Admin tests: 65 pass, 0 fail
- Admin typecheck: pass
- Admin build: pass
- `git diff --check`: pass
