### PR TITLE
fix(admin): preserve SSH diagnostic failures

### DIFF
--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -21,6 +21,8 @@ class FakeSsh {
     partialUploadThrows = false;
     pingResult = true;
     diagnosticExecFails = false;
+    diagnosticFailureStdout = "";
+    diagnosticFailureStderr = "diagnostic failed";
 
     async ping(): Promise<boolean> {
         return this.pingResult;
@@ -64,7 +66,12 @@ class FakeSsh {
                 : { success: true, stdout: "Migration complete\n", stderr: "", code: 0 };
         }
         if (this.diagnosticExecFails && command === "hostname") {
-            return { success: false, stdout: "", stderr: "diagnostic failed", code: 3 };
+            return {
+                success: false,
+                stdout: this.diagnosticFailureStdout,
+                stderr: this.diagnosticFailureStderr,
+                code: 3,
+            };
         }
         return { success: true, stdout: "SSH_SESSION_OK\n", stderr: "", code: 0 };
     }
@@ -155,6 +162,30 @@ describe("ssh admin tool", () => {
 
         await expect(captureSshTool(ssh).invoke({ action: "exec", command: "hostname" }))
             .rejects.toThrow("Remote diagnostic command failed (exit 3): diagnostic failed");
+    });
+
+    test("generic exec uses stdout when failure stderr contains only whitespace", async () => {
+        const ssh = new FakeSsh();
+        ssh.diagnosticExecFails = true;
+        ssh.diagnosticFailureStdout = "stdout diagnostic";
+        ssh.diagnosticFailureStderr = " \n";
+
+        await expect(captureSshTool(ssh).invoke({ action: "exec", command: "hostname" }))
+            .rejects.toThrow("Remote diagnostic command failed (exit 3): stdout diagnostic");
+    });
+
+    test("hostname address diagnostics require the exact allowlisted command", async () => {
+        const tool = captureSshTool(new FakeSsh());
+
+        for (const command of [
+            "hostname -I extra",
+            "hostname -Ifoo",
+            "hostname -I; id",
+            "hostname -I\nid",
+        ]) {
+            await expect(tool.invoke({ action: "exec", command }))
+                .rejects.toThrow("outside the allowed read-only diagnostic grammar");
+        }
     });
 
     test("generic exec rejects filesystem, network, mutation, and secret-reading escapes", async () => {

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -570,7 +570,7 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
                     const command = assertSafeExecCommand(args.command);
                     const r = await ssh.exec(command, getExecTimeoutMs(args.timeout_seconds));
                     if (!r.success) {
-                        const diagnostic = (r.stderr || r.stdout).trim() || "no remote diagnostic";
+                        const diagnostic = r.stderr.trim() || r.stdout.trim() || "no remote diagnostic";
                         throw new Error(`Remote diagnostic command failed (exit ${r.code}): ${diagnostic.slice(-500)}`);
                     }
                     text = `exit: ${r.code}\n\nstdout:\n${r.stdout.slice(-2000)}\n\nstderr:\n${r.stderr.slice(-500)}`;


### PR DESCRIPTION
Parent: #755
Source: independent clean-code review after #755
Reason: #755 merged before review-edge patch could be applied

## Summary
- Preserve stdout diagnostics when a failed SSH command returns whitespace-only stderr.
- Lock `hostname -I` to the exact read-only allowlist grammar with injection regression coverage.

## Verification
- `bun test src/shared/tools/ssh-tools.test.ts` (34 passed)
- `bun test` (67 passed)
- `bun run typecheck`
- `bun run build`
- Inner and outer upgrade scripts pass `bash -n`
- `git diff --check`
- clean-code-guard: clean

This follow-up contains no production deployment.