### PR TITLE
fix(upgrade): verify public attestations offline

### DIFF
--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -734,8 +734,17 @@ describe("runtime companion version assets", () => {
     const dir = mkdtempSync(join(tmpdir(), "supacloud-gh-404-"));
     const fakeBin = join(dir, "bin");
     const gh = join(fakeBin, "gh");
+    const curl = join(fakeBin, "curl");
+    const artifact = join(dir, "artifact");
     try {
       spawnSync("mkdir", ["-p", fakeBin]);
+      writeFileSync(artifact, "verified artifact fixture");
+      writeFileSync(curl, [
+        "#!/bin/sh",
+        "printf '%s\\n' '{\"attestations\":[{\"bundle\":{\"mediaType\":\"application/vnd.dev.sigstore.bundle.v0.3+json\"}}]}'",
+        "",
+      ].join("\n"));
+      chmodSync(curl, 0o755);
       writeFileSync(gh, [
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
@@ -745,11 +754,12 @@ describe("runtime companion version assets", () => {
         "",
       ].join("\n"));
       chmodSync(gh, 0o755);
-      const result = spawnSync("bash", ["-c", "source scripts/lib/release_assets.sh && supacloud_verify_attestation /tmp/artifact"], {
+      const result = spawnSync("bash", ["-c", "source scripts/lib/release_assets.sh && supacloud_verify_attestation \"$ARTIFACT\""], {
         cwd: repoRoot,
         env: {
           ...process.env,
           PATH: `${fakeBin}:${process.env.PATH}`,
+          ARTIFACT: artifact,
           SUPACLOUD_INTEGRITY_MODE_RECORD: join(dir, "integrity-mode"),
         },
         encoding: "utf8",
@@ -757,6 +767,52 @@ describe("runtime companion version assets", () => {
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("404");
       expect(() => readFileSync(join(dir, "integrity-mode"), "utf8")).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("artifact verification downloads a public bundle before invoking gh offline", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-gh-offline-"));
+    const fakeBin = join(dir, "bin");
+    const artifact = join(dir, "artifact");
+    const calls = join(dir, "gh-calls.txt");
+    try {
+      spawnSync("mkdir", ["-p", fakeBin]);
+      writeFileSync(artifact, "verified artifact fixture");
+      writeFileSync(join(fakeBin, "curl"), [
+        "#!/bin/sh",
+        "printf '%s\\n' '{\"attestations\":[{\"bundle\":{\"mediaType\":\"application/vnd.dev.sigstore.bundle.v0.3+json\"}}]}'",
+        "",
+      ].join("\n"));
+      chmodSync(join(fakeBin, "curl"), 0o755);
+      writeFileSync(join(fakeBin, "gh"), [
+        "#!/bin/sh",
+        'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
+        'if [ "$1 $2 $3" = "attestation verify --help" ]; then echo "--signer-workflow"; exit 0; fi',
+        'printf "%s\\n" "$*" > "$GH_CALLS"',
+        'case " $* " in *" --bundle "*) exit 0 ;; esac',
+        'echo "missing offline bundle" >&2',
+        "exit 1",
+        "",
+      ].join("\n"));
+      chmodSync(join(fakeBin, "gh"), 0o755);
+
+      const integrityMode = join(dir, "integrity-mode");
+      const result = spawnSync("bash", ["-c", "source scripts/lib/release_assets.sh && supacloud_verify_attestation \"$ARTIFACT\""], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+          ARTIFACT: artifact,
+          GH_CALLS: calls,
+          SUPACLOUD_INTEGRITY_MODE_RECORD: integrityMode,
+        },
+        encoding: "utf8",
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(calls, "utf8")).toContain("--bundle");
+      expect(readFileSync(integrityMode, "utf8").trim()).toBe("github-attestation+same-release-sha256");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/lib/release_assets.sh
+++ b/scripts/lib/release_assets.sh
@@ -333,16 +333,51 @@ supacloud_record_integrity_mode() {
     chmod 600 "$record_file" 2>/dev/null || true
 }
 
+supacloud_fetch_attestation_bundle() {
+    local artifact_file="$1"
+    local bundle_file="$2"
+    local digest response
+    digest=$(sha256sum "$artifact_file" | awk '{print $1}') || return 1
+    [[ "$digest" =~ ^[0-9a-fA-F]{64}$ ]] || {
+        echo "Unable to calculate the artifact digest for attestation lookup" >&2
+        return 1
+    }
+    digest=$(printf '%s' "$digest" | tr '[:upper:]' '[:lower:]')
+    response=$(supacloud_fetch_release_json \
+        "https://api.github.com/repos/${SUPACLOUD_GITHUB_REPOSITORY}/attestations/sha256:${digest}") || {
+        echo "Unable to download the public GitHub artifact attestation bundle" >&2
+        return 1
+    }
+    if ! jq -ce '
+        .attestations
+        | if type != "array" or length == 0 or any(.[]; (.bundle | type) != "object")
+          then error("no valid attestation bundles returned")
+          else .[].bundle
+          end
+    ' <<< "$response" > "$bundle_file"; then
+        echo "GitHub artifact attestation response did not contain a valid bundle" >&2
+        return 1
+    fi
+}
+
 supacloud_verify_attestation() {
     local artifact_file="$1"
     if supacloud_attestation_verifier_available; then
-        local verification_output
+        local verification_output bundle_file
+        bundle_file=$(mktemp "${TMPDIR:-/tmp}/supacloud-attestation.XXXXXX") || return 1
+        if ! supacloud_fetch_attestation_bundle "$artifact_file" "$bundle_file"; then
+            rm -f "$bundle_file"
+            return 1
+        fi
         if ! verification_output=$(gh attestation verify "$artifact_file" \
+            --bundle "$bundle_file" \
             --repo "$SUPACLOUD_GITHUB_REPOSITORY" \
             --signer-workflow "$SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW" 2>&1); then
+            rm -f "$bundle_file"
             echo "GitHub artifact attestation verification failed: ${verification_output}" >&2
             return 1
         fi
+        rm -f "$bundle_file"
         supacloud_record_integrity_mode "github-attestation+same-release-sha256"
         return
     fi


### PR DESCRIPTION
## Summary

- download public GitHub attestation bundles by the already verified artifact SHA-256
- pass the downloaded bundle to `gh attestation verify --bundle`, so public release verification does not require persistent `gh auth login` or a remote token
- retain signer-workflow verification, same-release SHA-256 verification, and fail-closed behavior

## Production reproduction

Official Admin 0.7.3 reached attestation verification before any component switch, then failed because `gh attestation verify` attempted authenticated API lookup and the server intentionally has no GitHub credentials. The upgrade rolled back/cleaned its helper and services remained active.

## Verification

- `bun test packages/management-api/tests/unit/runtime-version-assets.test.ts` (25 pass)
- `bun test packages/admin/src` (65 pass)
- `bun run --cwd packages/admin typecheck`
- `shellcheck scripts/lib/release_assets.sh`
- `bash -n scripts/lib/release_assets.sh`
- real public `management-api-v0.50.27/SHA256SUMS` verification with an empty `GH_CONFIG_DIR`, producing `github-attestation+same-release-sha256`

No token is sent to or persisted on the target server, and break-glass verification remains disabled by default.