### PR TITLE
fix(upgrade): use a JSONL attestation bundle

### DIFF
--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -263,6 +263,10 @@ describe("ssh admin tool", () => {
         expect(ssh.uploads[0]?.content).toContain('SUPACLOUD_GH_VERSION="${SUPACLOUD_GH_VERSION:-2.96.0}"');
         expect(ssh.uploads[0]?.content).toContain("83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60");
         expect(ssh.uploads[0]?.content).toContain("06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909");
+        expect(ssh.uploads[0]?.content).toContain('bundle_dir=$(mktemp -d "${TMPDIR:-/tmp}/supacloud-attestation.XXXXXX")');
+        expect(ssh.uploads[0]?.content).toContain('bundle_file="${bundle_dir}/bundle.jsonl"');
+        expect(ssh.uploads[0]?.content).toContain('trap \'rm -rf -- "$bundle_dir"\' EXIT');
+        expect(ssh.uploads[0]?.content).toContain('trap \'trap - EXIT HUP INT TERM; rm -rf -- "$bundle_dir"; exit 1\' HUP INT TERM');
         expect(command).toContain("supacloud_install_pinned_gh");
         expect(command).toContain("/usr/local/bin/supacloud --version");
         expect(command).toContain("0.50.27");

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -1,6 +1,6 @@
 // @supacloud-test-isolate — compiles and validates multiple release fixtures.
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -736,6 +736,7 @@ describe("runtime companion version assets", () => {
     const gh = join(fakeBin, "gh");
     const curl = join(fakeBin, "curl");
     const artifact = join(dir, "artifact");
+    const bundleArgumentRecord = join(dir, "gh-bundle-argument.txt");
     try {
       spawnSync("mkdir", ["-p", fakeBin]);
       writeFileSync(artifact, "verified artifact fixture");
@@ -749,6 +750,7 @@ describe("runtime companion version assets", () => {
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
         'if [ "$1 $2 $3" = "attestation verify --help" ]; then echo "--signer-workflow"; exit 0; fi',
+        'while [ "$#" -gt 0 ]; do if [ "$1" = "--bundle" ]; then shift; printf "%s\\n" "$1" > "$GH_BUNDLE_ARGUMENT_RECORD"; break; fi; shift; done',
         'echo "HTTP 404: attestation not found" >&2',
         "exit 22",
         "",
@@ -760,6 +762,8 @@ describe("runtime companion version assets", () => {
           ...process.env,
           PATH: `${fakeBin}:${process.env.PATH}`,
           ARTIFACT: artifact,
+          GH_BUNDLE_ARGUMENT_RECORD: bundleArgumentRecord,
+          TMPDIR: dir,
           SUPACLOUD_INTEGRITY_MODE_RECORD: join(dir, "integrity-mode"),
         },
         encoding: "utf8",
@@ -767,16 +771,19 @@ describe("runtime companion version assets", () => {
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("404");
       expect(() => readFileSync(join(dir, "integrity-mode"), "utf8")).toThrow();
+      const bundlePath = readFileSync(bundleArgumentRecord, "utf8").trim();
+      expect(bundlePath.endsWith("/bundle.jsonl")).toBe(true);
+      expect(readdirSync(dir).filter(name => name.startsWith("supacloud-attestation."))).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("artifact verification downloads a public bundle before invoking gh offline", () => {
+  test("artifact verification gives gh a temporary JSONL bundle and removes it after success", () => {
     const dir = mkdtempSync(join(tmpdir(), "supacloud-gh-offline-"));
     const fakeBin = join(dir, "bin");
     const artifact = join(dir, "artifact");
-    const calls = join(dir, "gh-calls.txt");
+    const bundleArgumentRecord = join(dir, "gh-bundle-argument.txt");
     try {
       spawnSync("mkdir", ["-p", fakeBin]);
       writeFileSync(artifact, "verified artifact fixture");
@@ -790,9 +797,11 @@ describe("runtime companion version assets", () => {
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
         'if [ "$1 $2 $3" = "attestation verify --help" ]; then echo "--signer-workflow"; exit 0; fi',
-        'printf "%s\\n" "$*" > "$GH_CALLS"',
-        'case " $* " in *" --bundle "*) exit 0 ;; esac',
-        'echo "missing offline bundle" >&2',
+        'bundle=""',
+        'while [ "$#" -gt 0 ]; do if [ "$1" = "--bundle" ]; then shift; bundle="$1"; break; fi; shift; done',
+        'printf "%s\\n" "$bundle" > "$GH_BUNDLE_ARGUMENT_RECORD"',
+        'case "$bundle" in */bundle.jsonl) test -f "$bundle" && exit 0 ;; esac',
+        'echo "offline bundle must be an existing bundle.jsonl file" >&2',
         "exit 1",
         "",
       ].join("\n"));
@@ -805,13 +814,15 @@ describe("runtime companion version assets", () => {
           ...process.env,
           PATH: `${fakeBin}:${process.env.PATH}`,
           ARTIFACT: artifact,
-          GH_CALLS: calls,
+          GH_BUNDLE_ARGUMENT_RECORD: bundleArgumentRecord,
+          TMPDIR: dir,
           SUPACLOUD_INTEGRITY_MODE_RECORD: integrityMode,
         },
         encoding: "utf8",
       });
       expect(result.status, result.stderr).toBe(0);
-      expect(readFileSync(calls, "utf8")).toContain("--bundle");
+      expect(readFileSync(bundleArgumentRecord, "utf8").trim().endsWith("/bundle.jsonl")).toBe(true);
+      expect(readdirSync(dir).filter(name => name.startsWith("supacloud-attestation."))).toEqual([]);
       expect(readFileSync(integrityMode, "utf8").trim()).toBe("github-attestation+same-release-sha256");
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/scripts/lib/release_assets.sh
+++ b/scripts/lib/release_assets.sh
@@ -360,24 +360,24 @@ supacloud_fetch_attestation_bundle() {
     fi
 }
 
-supacloud_verify_attestation() {
+supacloud_verify_attestation() (
     local artifact_file="$1"
     if supacloud_attestation_verifier_available; then
-        local verification_output bundle_file
-        bundle_file=$(mktemp "${TMPDIR:-/tmp}/supacloud-attestation.XXXXXX") || return 1
+        local verification_output bundle_dir bundle_file
+        bundle_dir=$(mktemp -d "${TMPDIR:-/tmp}/supacloud-attestation.XXXXXX") || return 1
+        trap 'rm -rf -- "$bundle_dir"' EXIT
+        trap 'trap - EXIT HUP INT TERM; rm -rf -- "$bundle_dir"; exit 1' HUP INT TERM
+        bundle_file="${bundle_dir}/bundle.jsonl"
         if ! supacloud_fetch_attestation_bundle "$artifact_file" "$bundle_file"; then
-            rm -f "$bundle_file"
             return 1
         fi
         if ! verification_output=$(gh attestation verify "$artifact_file" \
             --bundle "$bundle_file" \
             --repo "$SUPACLOUD_GITHUB_REPOSITORY" \
             --signer-workflow "$SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW" 2>&1); then
-            rm -f "$bundle_file"
             echo "GitHub artifact attestation verification failed: ${verification_output}" >&2
             return 1
         fi
-        rm -f "$bundle_file"
         supacloud_record_integrity_mode "github-attestation+same-release-sha256"
         return
     fi
@@ -390,7 +390,7 @@ supacloud_verify_attestation() {
 
     echo "Artifact attestation verification is required, but gh attestation verify is unavailable. Install GitHub CLI or explicitly set SUPACLOUD_ALLOW_UNVERIFIED_RELEASE=true for emergency break-glass use." >&2
     return 1
-}
+)
 
 supacloud_attestation_verifier_available() {
     local version


### PR DESCRIPTION
## Summary

- create an isolated attestation directory and pass a fixed bundle.jsonl path to GitHub CLI
- clean the exact directory on success, verification failure, and HUP/INT/TERM
- make the Management test double enforce the real GitHub CLI filename contract and verify cleanup
- assert that Admin uploads the corrected release asset helper so the consumer package receives the fix

## Reproduction

GitHub CLI 2.94.0 rejects the extensionless temporary path produced by the merged implementation:

Error: bundle file extension not supported, must be json or jsonl

The failure reproduces with management-api-v0.50.25/web-console-build.tar.gz.

## Verification

- bun test packages/management-api/tests/unit/runtime-version-assets.test.ts (25 pass)
- bun test src/shared/tools/ssh-tools.test.ts from packages/admin (34 pass)
- bash -n scripts/lib/release_assets.sh
- shellcheck scripts/lib/release_assets.sh
- git diff --check
- real GitHub CLI 2.94.0 attestation verification against the v0.50.25 Web Console asset records github-attestation+same-release-sha256
- TERM smoke exits non-zero and leaves no attestation directory residue