### PR TITLE
fix(management-api): represent external auth runtime status

### DIFF
--- a/packages/management-api/src/routes/auth-users.ts
+++ b/packages/management-api/src/routes/auth-users.ts
@@ -7,7 +7,7 @@ import { resolveProjectServiceRoleKey } from "../utils/service-role";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { getProjectDb, resolveDbName, sql as metaSql } from "../db";
 import { resolveTenantPorts, normalizeProjectRoutingConfig } from "../utils/project-routing";
-import { normalizeProjectConfig, normalizeThirdPartyAuthConfig } from "../utils/project-config";
+import { normalizeProjectConfig, resolveProjectExternalAuthEndpointConfig } from "../utils/project-config";
 import { requireAuthRuntimeManagement } from "./auth-runtime";
 import { gotrueGrantsService } from "../services/gotrue-grants.service";
 import { CapabilityUnavailableError, isAppError } from "../utils/errors";
@@ -51,15 +51,7 @@ function trustedDirectGoTrueUrl(request: Request): string | null {
 }
 
 function usesExternalAuthEndpoint(rawConfig: unknown): boolean {
-  const projectConfig = normalizeProjectConfig(rawConfig);
-  const auth = projectConfig.auth;
-  if (!auth || typeof auth !== "object" || Array.isArray(auth)) return false;
-  const thirdPartyAuth = normalizeThirdPartyAuthConfig(
-    (auth as Record<string, unknown>).third_party_auth,
-  );
-  return thirdPartyAuth.enabled
-    && thirdPartyAuth.auth_endpoint_mode === "external"
-    && Boolean(thirdPartyAuth.auth_upstream);
+  return resolveProjectExternalAuthEndpointConfig(rawConfig) !== null;
 }
 
 async function getGoTrueAdminContext(ref: string, directApiUrl?: string | null) {

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -267,7 +267,7 @@ async function buildProjectResponse(
     connectionCount = connectionResult[0]?.count || 0;
   } catch {}
 
-  const serviceStatuses = await tenantRuntimeService.getProjectServiceStatuses(ref, "detail");
+  const serviceStatuses = await tenantRuntimeService.getProjectServiceStatuses(ref, project.config, "detail");
 
   return {
     ...base,

--- a/packages/management-api/src/routes/project-services.ts
+++ b/packages/management-api/src/routes/project-services.ts
@@ -27,7 +27,11 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
         return status(404, { message: "Project not found", code: "404" });
       }
       try {
-        const servicesData = await tenantRuntimeService.getProjectServiceStatuses(params.ref, "studio");
+        const servicesData = await tenantRuntimeService.getProjectServiceStatuses(
+          params.ref,
+          project.config,
+          "studio",
+        );
         return { status: "healthy", services: servicesData || [] };
       } catch {
         return { status: "healthy", services: [] };
@@ -202,7 +206,7 @@ export const projectServiceRoutes = new Elysia({ prefix: "/v1/projects" })
         return status(404, { message: "Project not found" });
       }
 
-      return tenantRuntimeService.getProjectServiceStatuses(params.ref, "studio");
+      return tenantRuntimeService.getProjectServiceStatuses(params.ref, project.config, "studio");
     },
     {
       params: t.Object({ ref: t.String() }),

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -9,7 +9,7 @@ import {
     resolveProjectAuthHost,
     resolveProjectStudioHost,
 } from "../utils/project-routing";
-import { normalizeProjectConfig, normalizeThirdPartyAuthConfig } from "../utils/project-config";
+import { normalizeProjectConfig, resolveExternalAuthEndpointConfig } from "../utils/project-config";
 import { uniqueStrings } from "../utils/strings";
 import { GOTRUE_USER_ID_POSTGRES_PATTERN } from "../utils/project-user-lifecycle";
 import { assertUniqueCaddyIds, runCaddyStartupPreflight } from "./caddy-startup-preflight";
@@ -1114,9 +1114,9 @@ export class CaddyGatewayProvider implements GatewayProvider {
             const authConfig = projectConfig.auth && typeof projectConfig.auth === "object" && !Array.isArray(projectConfig.auth)
                 ? projectConfig.auth as Record<string, unknown>
                 : {};
-            const thirdPartyAuth = normalizeThirdPartyAuthConfig(authConfig.third_party_auth);
-            const externalAuthUpstream = thirdPartyAuth.enabled && thirdPartyAuth.auth_endpoint_mode === "external" && thirdPartyAuth.auth_upstream
-                ? normalizeCustomUpstream(thirdPartyAuth.auth_upstream)
+            const externalAuth = resolveExternalAuthEndpointConfig(authConfig.third_party_auth);
+            const externalAuthUpstream = externalAuth
+                ? normalizeCustomUpstream(externalAuth.auth_upstream)
                 : null;
             let sharedAuthPort: number | null = null;
             if (config.authRuntimeOwnerRef && config.authRuntimeOwnerRef !== projectRef) {
@@ -1140,13 +1140,13 @@ export class CaddyGatewayProvider implements GatewayProvider {
                 : directAuthUpstream;
             const authHeaders = sharedAuthPort !== null
                     ? [`X-Project-Ref:${config.authRuntimeOwnerRef}`, `x-project-ref:${config.authRuntimeOwnerRef}`]
-                    : externalAuthUpstream && thirdPartyAuth.auth_host_header
-                        ? [`Host:${thirdPartyAuth.auth_host_header}`, `X-Forwarded-Host:${thirdPartyAuth.auth_host_header}`]
-                    : undefined;
+                    : externalAuthUpstream && externalAuth?.auth_host_header
+                        ? [`Host:${externalAuth.auth_host_header}`, `X-Forwarded-Host:${externalAuth.auth_host_header}`]
+                        : undefined;
             const authProxyHeaders = sharedAuthProxy ? undefined : authHeaders;
             const authUpstreamTls = sharedAuthPort === null ? externalAuthUpstream?.tls : false;
             const authUpstreamTlsInsecureSkipVerify = sharedAuthPort === null
-                && thirdPartyAuth.auth_upstream_tls_insecure_skip_verify;
+                && externalAuth?.auth_upstream_tls_insecure_skip_verify;
             const hosts = uniqueStrings(resolveProjectApiHosts(projectRef, routingConfig));
             const hostSet = new Set(hosts.map(normalizeCaddyHost));
             const authHosts = uniqueStrings([resolveProjectAuthHost(projectRef, routingConfig)])

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -192,10 +192,10 @@ export class ProjectService {
     }
   }
 
-  private async checkProjectStorageHealth(ref: string): Promise<boolean> {
+  private async checkProjectStorageHealth(ref: string, projectConfig: unknown): Promise<boolean> {
     try {
       const { tenantRuntimeService } = await import("./tenant-runtime.service");
-      const services = await tenantRuntimeService.getProjectServiceStatuses(ref, "studio");
+      const services = await tenantRuntimeService.getProjectServiceStatuses(ref, projectConfig, "studio");
       const storage = services.find((service) => service.id === "storage" || service.name.toLowerCase() === "storage");
       if (storage?.healthy || storage?.status === "ACTIVE_HEALTHY") return true;
     } catch {
@@ -560,7 +560,7 @@ export class ProjectService {
     return {
       status: project.status,
       database: dbStatus.success ? "healthy" : "unhealthy",
-      storage: (await this.checkProjectStorageHealth(ref)) ? "healthy" : "unhealthy",
+      storage: (await this.checkProjectStorageHealth(ref, project.config)) ? "healthy" : "unhealthy",
     };
   }
 

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -9,7 +9,11 @@ import type { OAuthProvider, OAuthProviderConfig } from "../types/oauth";
 import { OAUTH_ENV_MAPPINGS } from "../types/oauth";
 import { tenantOAuthService } from "./tenant-oauth.service";
 import { resolveProjectApiUrl, resolveProjectAuthUrl, resolveProjectStudioUrl } from "../utils/project-routing";
-import { normalizeOAuthServerConfig, normalizeProjectConfig } from "../utils/project-config";
+import {
+    normalizeOAuthServerConfig,
+    normalizeProjectConfig,
+    resolveProjectExternalAuthEndpointConfig,
+} from "../utils/project-config";
 import {
     buildSharedProjectJwtVerificationMaterial,
     normalizeProjectJwtKeys,
@@ -36,7 +40,11 @@ import {
 } from "./tenant-runtime-config";
 import type { PostgresConnectionConfig } from "./tenant-runtime-config";
 import { decryptSecretIfNeeded } from "../utils/secret-crypto";
-import { getAuthRuntimeDescriptor, isSharedAuthRuntime } from "./auth-runtime.service";
+import {
+    getAuthRuntimeDescriptor,
+    isSharedAuthRuntime,
+    type AuthRuntimeMode,
+} from "./auth-runtime.service";
 import { authConfigChangesPostgrestVerifier } from "./auth-runtime-impact";
 import { runtimeCacheService } from "./runtime-cache.service";
 import { projectControlSecretsService } from "./project-control-secrets.service";
@@ -265,9 +273,35 @@ export interface ProjectServiceStatus {
     last_error?: string | null;
     updated_at?: string | null;
     last_reconciled_at?: string | null;
-    runtime_mode?: "local" | "owner" | "shared";
+    runtime_mode?: AuthRuntimeMode | "external";
     managed_by_ref?: string;
     local_runtime_enabled?: boolean;
+}
+
+type AuthServiceRuntimeDescriptor = Pick<
+    ReturnType<typeof getAuthRuntimeDescriptor>,
+    "project_ref" | "mode" | "authority_project_ref" | "local_gotrue_enabled"
+>;
+
+export function projectAuthServiceEntry(
+    rawAuth: ProjectServiceStatus,
+    authRuntime: AuthServiceRuntimeDescriptor,
+    projectConfig: unknown,
+): ProjectServiceStatus {
+    const externalAuth = authRuntime.mode === "local"
+        ? resolveProjectExternalAuthEndpointConfig(projectConfig)
+        : null;
+    const status = externalAuth && rawAuth.status === "UNHEALTHY" ? "INACTIVE" : rawAuth.status;
+    return {
+        ...rawAuth,
+        status,
+        healthy: status === "ACTIVE_HEALTHY",
+        service_host_ids: [`${authRuntime.authority_project_ref}-${rawAuth.id}`],
+        unit: `supacloud-gotrue@${authRuntime.authority_project_ref}`,
+        runtime_mode: externalAuth ? "external" : authRuntime.mode,
+        managed_by_ref: authRuntime.mode === "local" ? undefined : authRuntime.authority_project_ref,
+        local_runtime_enabled: externalAuth ? false : authRuntime.local_gotrue_enabled,
+    };
 }
 
 const POSTGREST_HEALTH_PATHS = ["/"] as const;
@@ -2399,6 +2433,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
 
     public async getProjectServiceStatuses(
         ref: string,
+        projectConfig: unknown,
         mode: "studio" | "detail" = "studio",
     ): Promise<ProjectServiceStatus[]> {
         const authRuntime = getAuthRuntimeDescriptor(ref);
@@ -2463,14 +2498,7 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = pg_catalog;
         const authId = mode === "studio" ? "auth" : "gotrue";
         const authName = mode === "studio" ? "auth" : "GoTrue";
         const rawAuth = rawAuthCandidate ?? this.unhealthyService(ref, authId, authName);
-        const authEntry: ProjectServiceStatus = {
-            ...rawAuth,
-            service_host_ids: [`${authRuntimeRef}-${authId}`],
-            unit: `supacloud-gotrue@${authRuntimeRef}`,
-            runtime_mode: authRuntime.mode,
-            managed_by_ref: authRuntime.mode === "local" ? undefined : authRuntimeRef,
-            local_runtime_enabled: authRuntime.local_gotrue_enabled,
-        };
+        const authEntry = projectAuthServiceEntry(rawAuth, authRuntime, projectConfig);
 
         if (mode === "studio") {
             const db = this.systemServiceEntry(ref, "db", "db", dbStatus);

--- a/packages/management-api/src/utils/project-config.ts
+++ b/packages/management-api/src/utils/project-config.ts
@@ -51,6 +51,12 @@ export interface ThirdPartyAuthConfig {
   claim_mapping: Record<string, string>;
 }
 
+export type ExternalAuthEndpointConfig = ThirdPartyAuthConfig & {
+  enabled: true;
+  auth_endpoint_mode: "external";
+  auth_upstream: string;
+};
+
 export function normalizeThirdPartyAuthConfig(value: unknown): ThirdPartyAuthConfig {
   const config = isRecord(value) ? { ...value } : {};
   const authUpstream = pickString(config.auth_upstream) || pickString(config.authUpstream);
@@ -71,6 +77,18 @@ export function normalizeThirdPartyAuthConfig(value: unknown): ThirdPartyAuthCon
     auth_upstream_tls_insecure_skip_verify: config.auth_upstream_tls_insecure_skip_verify === true || config.authUpstreamTlsInsecureSkipVerify === true,
     claim_mapping: normalizeClaimMapping(config.claim_mapping ?? config.claimMapping),
   };
+}
+
+export function resolveExternalAuthEndpointConfig(value: unknown): ExternalAuthEndpointConfig | null {
+  const config = normalizeThirdPartyAuthConfig(value);
+  if (!config.enabled || config.auth_endpoint_mode !== "external" || !config.auth_upstream) return null;
+  return { ...config, enabled: true, auth_endpoint_mode: "external", auth_upstream: config.auth_upstream };
+}
+
+export function resolveProjectExternalAuthEndpointConfig(value: unknown): ExternalAuthEndpointConfig | null {
+  const projectConfig = normalizeProjectConfig(value);
+  const authConfig = isRecord(projectConfig.auth) ? projectConfig.auth : {};
+  return resolveExternalAuthEndpointConfig(authConfig.third_party_auth);
 }
 
 function pickString(value: unknown): string | undefined {

--- a/packages/management-api/tests/unit/project-config.test.ts
+++ b/packages/management-api/tests/unit/project-config.test.ts
@@ -3,6 +3,7 @@ import {
   mergeProjectConfig,
   normalizeOAuthServerConfig,
   normalizeProjectConfig,
+  resolveProjectExternalAuthEndpointConfig,
 } from "../../src/utils/project-config";
 
 describe("project-config utils", () => {
@@ -42,5 +43,32 @@ describe("project-config utils", () => {
       enabled: true,
       authorization_path: "/authorize.html",
     });
+  });
+
+  test("resolves only an enabled external Auth endpoint with an upstream", () => {
+    const configuredEndpoint = resolveProjectExternalAuthEndpointConfig(JSON.stringify({
+      auth: {
+        third_party_auth: {
+          enabled: true,
+          auth_endpoint_mode: "external",
+          auth_upstream: "127.0.0.1:3367",
+        },
+      },
+    }));
+
+    expect(configuredEndpoint).toMatchObject({
+      enabled: true,
+      auth_endpoint_mode: "external",
+      auth_upstream: "127.0.0.1:3367",
+    });
+    expect(resolveProjectExternalAuthEndpointConfig({
+      auth: { third_party_auth: { enabled: false, auth_upstream: "127.0.0.1:3367" } },
+    })).toBeNull();
+    expect(resolveProjectExternalAuthEndpointConfig({
+      auth: { third_party_auth: { enabled: true, auth_endpoint_mode: "local", auth_upstream: "127.0.0.1:3367" } },
+    })).toBeNull();
+    expect(resolveProjectExternalAuthEndpointConfig({
+      auth: { third_party_auth: { enabled: true, auth_endpoint_mode: "external" } },
+    })).toBeNull();
   });
 });

--- a/packages/management-api/tests/unit/project-services.runtime.test.ts
+++ b/packages/management-api/tests/unit/project-services.runtime.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { Elysia } from "elysia";
 import { projectServiceRoutes } from "../../src/routes/project-services";
 import { projectService } from "../../src/services";
-import { tenantRuntimeService, type PostgrestRuntimeStatus } from "../../src/services/tenant-runtime.service";
+import {
+  projectAuthServiceEntry,
+  tenantRuntimeService,
+  type PostgrestRuntimeStatus,
+  type ProjectServiceStatus,
+} from "../../src/services/tenant-runtime.service";
 
 const app = new Elysia().use(projectServiceRoutes);
 const authHeaders = { Authorization: "Bearer dev-master-token" };
@@ -42,6 +47,76 @@ function postgrestStatus(overrides: Partial<PostgrestRuntimeStatus> = {}): Postg
     ...overrides,
   };
 }
+
+const externalAuthProjectConfig = {
+  auth: {
+    third_party_auth: {
+      enabled: true,
+      auth_endpoint_mode: "external",
+      auth_upstream: "127.0.0.1:3367",
+    },
+  },
+};
+
+const inactiveGoTrueService: ProjectServiceStatus = {
+  id: "gotrue",
+  name: "GoTrue",
+  status: "UNHEALTHY",
+  healthy: false,
+  service_host_ids: ["proj_1-gotrue"],
+};
+
+describe("project external Auth service status", () => {
+  test("reports expected local GoTrue shutdown as inactive", () => {
+    expect(projectAuthServiceEntry(inactiveGoTrueService, {
+      project_ref: "proj_1",
+      mode: "local",
+      authority_project_ref: "proj_1",
+      local_gotrue_enabled: true,
+    }, externalAuthProjectConfig)).toMatchObject({
+      status: "INACTIVE",
+      healthy: false,
+      runtime_mode: "external",
+      local_runtime_enabled: false,
+      unit: "supacloud-gotrue@proj_1",
+    });
+  });
+
+  test("keeps an unexpectedly active local GoTrue visible", () => {
+    const activeEntry = projectAuthServiceEntry({
+      ...inactiveGoTrueService,
+      status: "ACTIVE_HEALTHY",
+      healthy: true,
+    }, {
+      project_ref: "proj_1",
+      mode: "local",
+      authority_project_ref: "proj_1",
+      local_gotrue_enabled: true,
+    }, externalAuthProjectConfig);
+
+    expect(activeEntry).toMatchObject({
+      status: "ACTIVE_HEALTHY",
+      healthy: true,
+      runtime_mode: "external",
+      local_runtime_enabled: false,
+    });
+  });
+
+  test("keeps SupaCloud shared Auth ownership authoritative", () => {
+    expect(projectAuthServiceEntry(inactiveGoTrueService, {
+      project_ref: "proj_1",
+      mode: "shared",
+      authority_project_ref: "auth_owner",
+      local_gotrue_enabled: false,
+    }, externalAuthProjectConfig)).toMatchObject({
+      status: "UNHEALTHY",
+      runtime_mode: "shared",
+      managed_by_ref: "auth_owner",
+      local_runtime_enabled: false,
+      unit: "supacloud-gotrue@auth_owner",
+    });
+  });
+});
 
 describe("project service PostgREST runtime controls", () => {
   test("returns PostgREST desired and actual runtime status", async () => {


### PR DESCRIPTION
## Summary

- centralize the enabled external Auth endpoint contract used by gateway and user-management paths
- pass persisted project config into service-status aggregation
- report the intentionally disabled local GoTrue as `INACTIVE` with `runtime_mode=external`
- preserve SupaCloud owner/shared precedence and keep unexpectedly active local GoTrue visible

## Root cause

Projects such as FA use `auth.third_party_auth.enabled=true`, `auth_endpoint_mode=external`, and an external upstream. The service-status aggregator only modeled SupaCloud local/owner/shared runtime ownership, so it interpreted the intentionally stopped local GoTrue unit as an unhealthy required runtime.

## Validation

- affected Management API tests: 107 pass, 0 fail
- complete Management API shared unit gate passed before the final main sync; the final sync commit only changes upgrade attestation bundling
- `bun run typecheck`
- `bun run sql:check`
- `git diff --check`
- clean-code-guard: clean

No server or project configuration was changed by this PR.