### PR TITLE
fix(upgrade): verify public attestations offline

### DIFF
--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -2,7 +2,7 @@ import { $, SQL } from "bun";
 import * as p from "@clack/prompts";
 import os from "node:os";
 import path from "node:path";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, readlinkSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { logger } from "./utils/logger";
 import { WEB_CONSOLE_CURRENT_DIR } from "./utils/web-console-path";
@@ -11,6 +11,7 @@ import { hasSecretEncryptionCheckpoint } from "./db/secret-key-migration";
 const RELEASES_API = "https://api.github.com/repos/zuohuadong/supacloud/releases";
 const RELEASE_REPOSITORY = "zuohuadong/supacloud";
 const RELEASE_SIGNER_WORKFLOW = `${RELEASE_REPOSITORY}/.github/workflows/release-please.yml`;
+const RELEASE_SOURCE_REF = "refs/heads/main";
 const BIN_TARGET = "/usr/local/bin/supacloud";
 const MANAGEMENT_SERVICE_UNIT = "supacloud.service";
 const EDGE_RUNTIME_SERVICE_UNIT = "supacloud-edge-runtime.service";
@@ -653,7 +654,7 @@ async function promptForGithubProxy(lastError: string) {
     return String(value);
 }
 
-async function fetchReleaseMetadata(apiUrl: string, forceYes?: boolean) {
+async function fetchGithubApiJson(apiUrl: string, forceYes?: boolean) {
     let lastError = "";
     let endpoints = buildGithubEndpoints();
 
@@ -678,7 +679,7 @@ async function fetchReleaseMetadata(apiUrl: string, forceYes?: boolean) {
         }
 
         if (forceYes) {
-            throw new Error(`Unable to retrieve GitHub release metadata. Last error: ${lastError}`);
+            throw new Error(`Unable to retrieve GitHub API JSON. Last error: ${lastError}`);
         }
 
         const customProxy = await promptForGithubProxy(lastError);
@@ -955,14 +956,120 @@ export function resolveArtifactVerificationMode(
     );
 }
 
-async function verifyArtifactAttestation(filePath: string) {
-    const capability = await $`gh attestation verify --help`.nothrow().quiet();
-    const mode = resolveArtifactVerificationMode(capability.exitCode === 0, process.env);
-    if (mode === "attested") {
-        const verification = await $`gh attestation verify ${filePath} --repo ${RELEASE_REPOSITORY} --signer-workflow ${RELEASE_SIGNER_WORKFLOW}`.nothrow().quiet();
-        if (verification.exitCode !== 0) {
-            throw new Error(`GitHub artifact attestation verification failed: ${verification.stderr.toString().slice(-500)}`);
+export function supportsGithubOfflineAttestationVerification(exitCode: number, helpText: string): boolean {
+    const helpTokens = helpText.split(/\s+/);
+    return exitCode === 0
+        && ["--bundle", "--signer-workflow", "--source-ref"].every(flag => (
+            helpTokens.some(token => token === flag || token.startsWith(`${flag}=`))
+        ));
+}
+
+function isJsonObject(candidate: unknown): candidate is Record<string, unknown> {
+    return candidate !== null && typeof candidate === "object" && !Array.isArray(candidate);
+}
+
+export function serializeGithubAttestationBundles(payload: unknown): string {
+    if (!isJsonObject(payload) || !Array.isArray(payload.attestations) || payload.attestations.length === 0) {
+        throw new Error("GitHub artifact attestation response did not contain a non-empty attestations array");
+    }
+    const bundles = payload.attestations.map((attestation, index) => {
+        const bundle = isJsonObject(attestation) ? attestation.bundle : undefined;
+        if (!isJsonObject(bundle)) {
+            throw new Error(`GitHub artifact attestation ${index} did not contain a valid bundle object`);
         }
+        return bundle;
+    });
+    return `${bundles.map(bundle => JSON.stringify(bundle)).join("\n")}\n`;
+}
+
+function throwAttestationVerificationOutcome(verificationError: unknown, cleanupError: unknown): void {
+    if (verificationError && cleanupError) {
+        throw new AggregateError(
+            [verificationError, cleanupError],
+            "GitHub artifact attestation verification failed and temporary bundle cleanup did not complete",
+        );
+    }
+    if (verificationError) throw verificationError;
+    if (cleanupError) {
+        throw new AggregateError([cleanupError], "Temporary GitHub attestation bundle cleanup did not complete");
+    }
+}
+
+type GithubCliCommandResult = {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+};
+
+async function runGithubCli(githubArguments: string[]): Promise<GithubCliCommandResult> {
+    const executable = Bun.which("gh", { PATH: process.env.PATH });
+    if (!executable) return { exitCode: 127, stdout: "", stderr: "gh not found" };
+    const child = Bun.spawn([executable, ...githubArguments], {
+        env: process.env,
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr };
+}
+
+async function runGithubAttestationVerification(filePath: string, bundlePath: string): Promise<void> {
+    const verification = await runGithubCli([
+        "attestation", "verify", filePath,
+        "--bundle", bundlePath,
+        "--repo", RELEASE_REPOSITORY,
+        "--signer-workflow", RELEASE_SIGNER_WORKFLOW,
+        "--source-ref", RELEASE_SOURCE_REF,
+    ]);
+    if (verification.exitCode !== 0) {
+        throw new Error(`GitHub artifact attestation verification failed: ${verification.stderr.slice(-500)}`);
+    }
+}
+
+async function verifyGithubAttestationBundle(filePath: string, bundleJsonl: string): Promise<void> {
+    const bundleDirectory = mkdtempSync(path.join(os.tmpdir(), "supacloud-attestation-"));
+    const bundlePath = path.join(bundleDirectory, "bundle.jsonl");
+    let verificationError: unknown;
+    try {
+        writeFileSync(bundlePath, bundleJsonl, { mode: 0o600 });
+        await runGithubAttestationVerification(filePath, bundlePath);
+    } catch (error: unknown) {
+        verificationError = error;
+    }
+
+    let cleanupError: unknown;
+    try {
+        rmSync(bundleDirectory, { recursive: true });
+    } catch (error: unknown) {
+        cleanupError = error;
+    }
+    throwAttestationVerificationOutcome(verificationError, cleanupError);
+}
+
+export type VerifyArtifactAttestationRequest = {
+    filePath: string;
+    forceYes?: boolean;
+};
+
+async function downloadGithubAttestationBundle(request: VerifyArtifactAttestationRequest): Promise<string> {
+    const digest = sha256File(request.filePath);
+    const apiUrl = `https://api.github.com/repos/${RELEASE_REPOSITORY}/attestations/sha256:${digest}`;
+    const metadata = await fetchGithubApiJson(apiUrl, request.forceYes);
+    return serializeGithubAttestationBundles(metadata.data);
+}
+
+export async function verifyArtifactAttestation(request: VerifyArtifactAttestationRequest) {
+    const capability = await runGithubCli(["attestation", "verify", "--help"]);
+    const helpText = `${capability.stdout}\n${capability.stderr}`;
+    const verifierAvailable = supportsGithubOfflineAttestationVerification(capability.exitCode, helpText);
+    const mode = resolveArtifactVerificationMode(verifierAvailable, process.env);
+    if (mode === "attested") {
+        const bundleJsonl = await downloadGithubAttestationBundle(request);
+        await verifyGithubAttestationBundle(request.filePath, bundleJsonl);
         recordIntegrityMode("github-attestation+same-release-sha256");
         return;
     }
@@ -1025,7 +1132,7 @@ async function stageBinary(request: StageBinaryRequest): Promise<StagedBinary> {
     try {
         const endpoint = await downloadAsset(request.downloadUrl, tmpBinary, request.preferredEndpoint, request.forceYes);
         const releaseSha256 = verifyArtifactChecksum(tmpBinary, request.binaryName, request.checksums);
-        await verifyArtifactAttestation(tmpBinary);
+        await verifyArtifactAttestation({ filePath: tmpBinary, forceYes: request.forceYes });
         await request.validate(tmpBinary, request.binaryName);
         await $`install -m 0755 ${tmpBinary} ${stagedBinary}`;
         const stagedSha256 = sha256File(stagedBinary);
@@ -1061,7 +1168,7 @@ async function stageWebConsoleBuild(
     try {
         const endpoint = await downloadAsset(downloadUrl, archivePath, preferredEndpoint, forceYes);
         verifyArtifactChecksum(archivePath, WEB_CONSOLE_ASSET, checksums);
-        await verifyArtifactAttestation(archivePath);
+        await verifyArtifactAttestation({ filePath: archivePath, forceYes });
 
         const listed = await $`tar -tzf ${archivePath}`.nothrow().quiet();
         if (listed.exitCode !== 0) {
@@ -1790,7 +1897,7 @@ async function resolveEdgeRuntimeUpgradePlan(
 ): Promise<EdgeRuntimeUpgradePlan | null> {
     const { binaryName, forceYes, preflight, requestedVersion } = request;
     if (!preflight) return null;
-    const metadata = await fetchReleaseMetadata(resolveEdgeRuntimeReleaseApiUrl(requestedVersion), forceYes);
+    const metadata = await fetchGithubApiJson(resolveEdgeRuntimeReleaseApiUrl(requestedVersion), forceYes);
     const expectedTag = normalizeEdgeRuntimeReleaseTag(requestedVersion);
     return {
         binaryName,
@@ -1807,7 +1914,7 @@ async function resolveUpgradeReleasePlan(options: RunUpgradeOptions): Promise<Up
         || "";
     const edgePreflight = await inspectEdgeRuntimeUpgradeTarget(requestedEdgeVersion);
     const binaryName = resolveLinuxBinaryName();
-    const metadata = await fetchReleaseMetadata(resolveReleaseApiUrl(options.targetVersion), options.forceYes);
+    const metadata = await fetchGithubApiJson(resolveReleaseApiUrl(options.targetVersion), options.forceYes);
     const release = selectManagementRelease(metadata.data as GithubRelease | GithubRelease[], binaryName);
     const edgeRuntime = await resolveEdgeRuntimeUpgradePlan({
         binaryName: resolveEdgeRuntimeBinaryName(binaryName),

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -638,13 +638,53 @@ describe("runtime companion version assets", () => {
     expect(helper).toContain("83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60");
     expect(helper).toContain("06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909");
     expect(helper).toContain("supacloud_install_pinned_gh");
-    expect(helper).toContain("2.51.0");
+    expect(helper).toContain("2.68.0");
     const versionCheck = spawnSync("bash", ["-c", [
       "source scripts/lib/release_assets.sh",
-      "supacloud_version_at_least 2.51.0 2.51.0",
-      "! supacloud_version_at_least 2.50.9 2.51.0",
+      "supacloud_version_at_least 2.68.0 2.68.0",
+      "! supacloud_version_at_least 2.67.9 2.68.0",
     ].join(" && ")], { cwd: repoRoot, encoding: "utf8" });
     expect(versionCheck.status, versionCheck.stderr).toBe(0);
+  });
+
+  test("attestation verification requires a new enough gh with every offline flag", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-gh-capability-"));
+    const gh = join(dir, "gh");
+    try {
+      writeFileSync(gh, [
+        "#!/bin/sh",
+        'if [ "$1" = "--version" ]; then echo "gh version ${GH_FAKE_VERSION}"; exit 0; fi',
+        'if [ "$1 $2 $3" = "attestation verify --help" ]; then printf "%b" "$GH_HELP_TEXT"; exit 0; fi',
+        "exit 1",
+        "",
+      ].join("\n"));
+      chmodSync(gh, 0o755);
+      const invoke = (version: string, helpText: string) => spawnSync("bash", ["-c", [
+        "source scripts/lib/release_assets.sh",
+        "supacloud_attestation_verifier_available",
+      ].join(" && ")], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          PATH: `${dir}:${process.env.PATH}`,
+          GH_FAKE_VERSION: version,
+          GH_HELP_TEXT: helpText,
+        },
+        encoding: "utf8",
+      });
+      const flags = ["--bundle", "--signer-workflow", "--source-ref"];
+
+      expect(invoke("2.68.0", `${flags.join("\n")}\n`).status).toBe(0);
+      expect(invoke("2.67.9", `${flags.join("\n")}\n`).status).not.toBe(0);
+      for (const omittedFlag of flags) {
+        expect(invoke("2.96.0", `${flags.filter(flag => flag !== omittedFlag).join("\n")}\n`).status)
+          .not.toBe(0);
+      }
+      expect(invoke("2.96.0", "--bundle-from-oci\n--signer-workflow-repository\n--source-ref-pattern\n").status)
+        .not.toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("pinned GitHub CLI archive requires the exact member, checksum, ELF shape, and version", () => {
@@ -749,7 +789,7 @@ describe("runtime companion version assets", () => {
       writeFileSync(gh, [
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
-        'if [ "$1 $2 $3" = "attestation verify --help" ]; then echo "--signer-workflow"; exit 0; fi',
+        'if [ "$1 $2 $3" = "attestation verify --help" ]; then printf "%s\\n" "--bundle" "--signer-workflow" "--source-ref"; exit 0; fi',
         'while [ "$#" -gt 0 ]; do if [ "$1" = "--bundle" ]; then shift; printf "%s\\n" "$1" > "$GH_BUNDLE_ARGUMENT_RECORD"; break; fi; shift; done',
         'echo "HTTP 404: attestation not found" >&2',
         "exit 22",
@@ -784,6 +824,7 @@ describe("runtime companion version assets", () => {
     const fakeBin = join(dir, "bin");
     const artifact = join(dir, "artifact");
     const bundleArgumentRecord = join(dir, "gh-bundle-argument.txt");
+    const sourceRefArgumentRecord = join(dir, "gh-source-ref-argument.txt");
     try {
       spawnSync("mkdir", ["-p", fakeBin]);
       writeFileSync(artifact, "verified artifact fixture");
@@ -796,9 +837,9 @@ describe("runtime companion version assets", () => {
       writeFileSync(join(fakeBin, "gh"), [
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
-        'if [ "$1 $2 $3" = "attestation verify --help" ]; then echo "--signer-workflow"; exit 0; fi',
+        'if [ "$1 $2 $3" = "attestation verify --help" ]; then printf "%s\\n" "--bundle" "--signer-workflow" "--source-ref"; exit 0; fi',
         'bundle=""',
-        'while [ "$#" -gt 0 ]; do if [ "$1" = "--bundle" ]; then shift; bundle="$1"; break; fi; shift; done',
+        'while [ "$#" -gt 0 ]; do case "$1" in --bundle) shift; bundle="$1" ;; --source-ref) shift; printf "%s\\n" "$1" > "$GH_SOURCE_REF_ARGUMENT_RECORD" ;; esac; shift; done',
         'printf "%s\\n" "$bundle" > "$GH_BUNDLE_ARGUMENT_RECORD"',
         'case "$bundle" in */bundle.jsonl) test -f "$bundle" && exit 0 ;; esac',
         'echo "offline bundle must be an existing bundle.jsonl file" >&2',
@@ -815,6 +856,7 @@ describe("runtime companion version assets", () => {
           PATH: `${fakeBin}:${process.env.PATH}`,
           ARTIFACT: artifact,
           GH_BUNDLE_ARGUMENT_RECORD: bundleArgumentRecord,
+          GH_SOURCE_REF_ARGUMENT_RECORD: sourceRefArgumentRecord,
           TMPDIR: dir,
           SUPACLOUD_INTEGRITY_MODE_RECORD: integrityMode,
         },
@@ -822,6 +864,7 @@ describe("runtime companion version assets", () => {
       });
       expect(result.status, result.stderr).toBe(0);
       expect(readFileSync(bundleArgumentRecord, "utf8").trim().endsWith("/bundle.jsonl")).toBe(true);
+      expect(readFileSync(sourceRefArgumentRecord, "utf8").trim()).toBe("refs/heads/main");
       expect(readdirSync(dir).filter(name => name.startsWith("supacloud-attestation."))).toEqual([]);
       expect(readFileSync(integrityMode, "utf8").trim()).toBe("github-attestation+same-release-sha256");
     } finally {

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { SQL } from "bun";
-import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -42,13 +43,16 @@ import {
     restoreFileState,
     selectEdgeRuntimeRelease,
     selectManagementRelease,
+    serializeGithubAttestationBundles,
     shouldCleanupUpgradeArtifacts,
     stopManagementService,
+    supportsGithubOfflineAttestationVerification,
     upsertManagementWebConsoleDir,
     upsertPersistedEdgeRuntimePort,
     upsertEdgeRuntimeIdentityDefaults,
     UpgradeTransactionError,
     validateWebConsoleArchiveEntries,
+    verifyArtifactAttestation,
     verifyActivatedManagementBinary,
     verifyArtifactChecksum,
     verifyManagementUpgradePreflight,
@@ -59,6 +63,22 @@ import {
 } from "../../src/upgrade";
 
 const originalFetch = globalThis.fetch;
+const attestationEnvironmentKeys = [
+  "GH_ARGUMENT_RECORD",
+  "GH_BUNDLE_RECORD",
+  "GH_LOCK_TMPDIR",
+  "GH_OMIT_SOURCE_REF",
+  "GH_VERIFY_EXIT_CODE",
+  "PATH",
+  "SUPACLOUD_ALLOW_UNVERIFIED_RELEASE",
+  "SUPACLOUD_GITHUB_PROXIES",
+  "SUPACLOUD_GITHUB_PROXY",
+  "SUPACLOUD_INTEGRITY_MODE_RECORD",
+  "TMPDIR",
+] as const;
+const originalAttestationEnvironment = Object.fromEntries(
+  attestationEnvironmentKeys.map(key => [key, process.env[key]]),
+);
 
 const originalUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS;
 const originalEdgeUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS;
@@ -97,6 +117,42 @@ function managementBinaryFixture(input: ManagementBinaryFixture = {}) {
   };
 }
 
+function installFakeGithubCli(binDirectory: string): void {
+  const executable = join(binDirectory, "gh");
+  writeFileSync(executable, [
+    "#!/bin/sh",
+    'if [ "$1 $2 $3" = "attestation verify --help" ]; then',
+    '  printf "%s\\n" "--bundle" "--signer-workflow"',
+    '  [ "${GH_OMIT_SOURCE_REF:-false}" = "true" ] || printf "%s\\n" "--source-ref"',
+    "  exit 0",
+    "fi",
+    'printf "%s\\n" "$*" > "$GH_ARGUMENT_RECORD"',
+    'bundle=""',
+    'while [ "$#" -gt 0 ]; do [ "$1" = "--bundle" ] && { shift; bundle="$1"; break; }; shift; done',
+    'case "$bundle" in */bundle.jsonl) test -f "$bundle" || exit 88 ;; *) exit 89 ;; esac',
+    'cp "$bundle" "$GH_BUNDLE_RECORD"',
+    '[ "${GH_LOCK_TMPDIR:-false}" = "true" ] && chmod 0555 "$TMPDIR"',
+    'exit "${GH_VERIFY_EXIT_CODE:-0}"',
+    "",
+  ].join("\n"));
+  chmodSync(executable, 0o755);
+}
+
+function createAttestationFixture() {
+  const directory = mkdtempSync(join(tmpdir(), "supacloud-upgrade-attestation-"));
+  const binDirectory = join(directory, "bin");
+  mkdirSync(binDirectory);
+  installFakeGithubCli(binDirectory);
+  const artifact = join(directory, "artifact");
+  writeFileSync(artifact, "verified artifact fixture");
+  process.env.PATH = `${binDirectory}:${originalAttestationEnvironment.PATH ?? ""}`;
+  process.env.TMPDIR = directory;
+  process.env.GH_ARGUMENT_RECORD = join(directory, "gh-arguments.txt");
+  process.env.GH_BUNDLE_RECORD = join(directory, "bundle-copy.jsonl");
+  process.env.SUPACLOUD_INTEGRITY_MODE_RECORD = join(directory, "integrity-mode");
+  return { artifact, directory };
+}
+
 const ensureHealthTimeout = () => {
   process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS = "1";
   process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS = "1";
@@ -104,6 +160,11 @@ const ensureHealthTimeout = () => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  for (const key of attestationEnvironmentKeys) {
+    const originalValue = originalAttestationEnvironment[key];
+    if (originalValue === undefined) delete process.env[key];
+    else process.env[key] = originalValue;
+  }
   if (originalUpgradeHealthAttempts === undefined) {
     delete process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS;
   } else {
@@ -494,6 +555,139 @@ describe("upgrade release selection", () => {
     expect(resolveGithubEndpointPrefixes({
       SUPACLOUD_GITHUB_PROXY: "https://proxy.example.test",
     })).toEqual(["", "https://proxy.example.test/"]);
+  });
+
+  test("offline attestation capability requires every gh verification flag", () => {
+    const requiredFlags = ["--bundle", "--signer-workflow", "--source-ref"];
+    expect(supportsGithubOfflineAttestationVerification(0, requiredFlags.join("\n"))).toBe(true);
+    expect(supportsGithubOfflineAttestationVerification(0, requiredFlags.map(flag => `${flag}=value`).join("\n"))).toBe(true);
+    expect(supportsGithubOfflineAttestationVerification(1, requiredFlags.join("\n"))).toBe(false);
+    for (const omittedFlag of requiredFlags) {
+      expect(supportsGithubOfflineAttestationVerification(
+        0,
+        requiredFlags.filter(flag => flag !== omittedFlag).join("\n"),
+      )).toBe(false);
+    }
+    expect(supportsGithubOfflineAttestationVerification(
+      0,
+      ["--bundle-from-oci", "--signer-workflow-repository", "--source-ref-pattern"].join("\n"),
+    )).toBe(false);
+  });
+
+  test("serializes every validated GitHub attestation bundle as JSONL", () => {
+    expect(serializeGithubAttestationBundles({
+      attestations: [
+        { bundle: { mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json" } },
+        { bundle: { verificationMaterial: { tlogEntries: [] } } },
+      ],
+    })).toBe([
+      '{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}',
+      '{"verificationMaterial":{"tlogEntries":[]}}',
+      "",
+    ].join("\n"));
+
+    for (const invalidPayload of [
+      null,
+      {},
+      { attestations: [] },
+      { attestations: [{ bundle: null }] },
+      { attestations: [{ bundle: [] }] },
+      { attestations: [{ bundle: "invalid" }] },
+    ]) {
+      expect(() => serializeGithubAttestationBundles(invalidPayload)).toThrow("attestation");
+    }
+  });
+
+  test("downloads a public digest bundle direct-first and verifies the pinned source ref", async () => {
+    const fixture = createAttestationFixture();
+    const requests: string[] = [];
+    process.env.SUPACLOUD_GITHUB_PROXY = "https://proxy.example.test/";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const requestUrl = String(input);
+      requests.push(requestUrl);
+      if (requests.length === 1) return new Response("unavailable", { status: 503 });
+      return Response.json({ attestations: [{ bundle: { mediaType: "sigstore" } }] });
+    }) as typeof fetch;
+
+    try {
+      await expect(verifyArtifactAttestation({ filePath: fixture.artifact, forceYes: true })).resolves.toBeUndefined();
+      const digest = createHash("sha256").update(readFileSync(fixture.artifact)).digest("hex");
+      const apiUrl = `https://api.github.com/repos/zuohuadong/supacloud/attestations/sha256:${digest}`;
+      expect(requests).toEqual([apiUrl, `https://proxy.example.test/${apiUrl}`]);
+      const ghArguments = readFileSync(process.env.GH_ARGUMENT_RECORD!, "utf8");
+      expect(ghArguments).toContain("--bundle");
+      expect(ghArguments).toContain("/bundle.jsonl");
+      expect(ghArguments).toContain("--repo zuohuadong/supacloud");
+      expect(ghArguments).toContain("--signer-workflow zuohuadong/supacloud/.github/workflows/release-please.yml");
+      expect(ghArguments).toContain("--source-ref refs/heads/main");
+      expect(readFileSync(process.env.GH_BUNDLE_RECORD!, "utf8")).toBe('{"mediaType":"sigstore"}\n');
+      expect(readdirSync(fixture.directory).filter(name => name.startsWith("supacloud-attestation-"))).toEqual([]);
+      expect(readFileSync(process.env.SUPACLOUD_INTEGRITY_MODE_RECORD!, "utf8").trim())
+        .toBe("github-attestation+same-release-sha256");
+    } finally {
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates gh verification failure and removes the temporary bundle", async () => {
+    const fixture = createAttestationFixture();
+    process.env.GH_VERIFY_EXIT_CODE = "9";
+    globalThis.fetch = (async () => Response.json({
+      attestations: [{ bundle: { mediaType: "sigstore" } }],
+    })) as typeof fetch;
+
+    try {
+      await expect(verifyArtifactAttestation({ filePath: fixture.artifact, forceYes: true }))
+        .rejects.toThrow("GitHub artifact attestation verification failed");
+      expect(readdirSync(fixture.directory).filter(name => name.startsWith("supacloud-attestation-"))).toEqual([]);
+      expect(existsSync(process.env.SUPACLOUD_INTEGRITY_MODE_RECORD!)).toBe(false);
+    } finally {
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves verification and cleanup errors together", async () => {
+    const fixture = createAttestationFixture();
+    process.env.GH_VERIFY_EXIT_CODE = "9";
+    process.env.GH_LOCK_TMPDIR = "true";
+    globalThis.fetch = (async () => Response.json({
+      attestations: [{ bundle: { mediaType: "sigstore" } }],
+    })) as typeof fetch;
+    let failure: unknown;
+
+    try {
+      await verifyArtifactAttestation({ filePath: fixture.artifact, forceYes: true });
+    } catch (error: unknown) {
+      failure = error;
+    } finally {
+      chmodSync(fixture.directory, 0o700);
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    const errors = (failure as AggregateError).errors;
+    expect(errors.some(error => String(error).includes("verification failed"))).toBe(true);
+    expect(errors.some(error => String(error).includes("EACCES") || String(error).includes("permission"))).toBe(true);
+  });
+
+  test("missing offline capability only permits the existing explicit break-glass", async () => {
+    const fixture = createAttestationFixture();
+    process.env.GH_OMIT_SOURCE_REF = "true";
+    process.env.SUPACLOUD_ALLOW_UNVERIFIED_RELEASE = "true";
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      throw new Error("attestation API must not be called in break-glass mode");
+    }) as typeof fetch;
+
+    try {
+      await expect(verifyArtifactAttestation({ filePath: fixture.artifact, forceYes: true })).resolves.toBeUndefined();
+      expect(fetchCalled).toBe(false);
+      expect(readFileSync(process.env.SUPACLOUD_INTEGRITY_MODE_RECORD!, "utf8").trim())
+        .toBe("break-glass:same-release-sha256-only");
+    } finally {
+      rmSync(fixture.directory, { recursive: true, force: true });
+    }
   });
 
   test("rejects an artifact whose digest differs from the same-release checksum", () => {

--- a/scripts/lib/release_assets.sh
+++ b/scripts/lib/release_assets.sh
@@ -4,7 +4,7 @@ SUPACLOUD_GITHUB_REPOSITORY="${SUPACLOUD_GITHUB_REPOSITORY:-zuohuadong/supacloud
 SUPACLOUD_RELEASES_API="${SUPACLOUD_RELEASES_API:-https://api.github.com/repos/${SUPACLOUD_GITHUB_REPOSITORY}/releases}"
 SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW="${SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW:-${SUPACLOUD_GITHUB_REPOSITORY}/.github/workflows/release-please.yml}"
 SUPACLOUD_GH_VERSION="${SUPACLOUD_GH_VERSION:-2.96.0}"
-SUPACLOUD_GH_MIN_VERSION="${SUPACLOUD_GH_MIN_VERSION:-2.51.0}"
+SUPACLOUD_GH_MIN_VERSION="${SUPACLOUD_GH_MIN_VERSION:-2.68.0}"
 SUPACLOUD_GH_AMD64_SHA256="${SUPACLOUD_GH_AMD64_SHA256:-83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60}"
 SUPACLOUD_GH_ARM64_SHA256="${SUPACLOUD_GH_ARM64_SHA256:-06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909}"
 
@@ -374,7 +374,8 @@ supacloud_verify_attestation() (
         if ! verification_output=$(gh attestation verify "$artifact_file" \
             --bundle "$bundle_file" \
             --repo "$SUPACLOUD_GITHUB_REPOSITORY" \
-            --signer-workflow "$SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW" 2>&1); then
+            --signer-workflow "$SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW" \
+            --source-ref "refs/heads/main" 2>&1); then
             echo "GitHub artifact attestation verification failed: ${verification_output}" >&2
             return 1
         fi
@@ -393,12 +394,15 @@ supacloud_verify_attestation() (
 )
 
 supacloud_attestation_verifier_available() {
-    local version
+    local version help
     command -v gh >/dev/null 2>&1 || return 1
     version=$(supacloud_gh_version)
     [[ -n "$version" ]] || return 1
     supacloud_version_at_least "$version" "$SUPACLOUD_GH_MIN_VERSION" || return 1
-    gh attestation verify --help 2>&1 | grep -q -- '--signer-workflow'
+    help=$(gh attestation verify --help 2>&1) || return 1
+    grep -Eq -- '(^|[[:space:]])--bundle([=[:space:]]|$)' <<< "$help" || return 1
+    grep -Eq -- '(^|[[:space:]])--signer-workflow([=[:space:]]|$)' <<< "$help" || return 1
+    grep -Eq -- '(^|[[:space:]])--source-ref([=[:space:]]|$)' <<< "$help"
 }
 
 supacloud_download_release_asset() (


### PR DESCRIPTION
## Root cause

The Management self-upgrade path still invoked gh attestation verification through its authenticated online lookup, and the shared release helper accepted incomplete CLI capability/source constraints. This could block public upgrades without GitHub authentication and did not pin provenance to main.

## Changes

- fetch public attestations by the local artifact SHA-256 and serialize validated bundles as JSONL
- verify the fixed bundle.jsonl with repository, release workflow, and refs/heads/main constraints
- require exact bundle, signer-workflow, and source-ref capabilities and gh >= 2.68 in the shared shell helper
- preserve fail-closed and explicit break-glass behavior, direct-first/proxy behavior, and both verification/cleanup errors
- keep the diff scoped to Management API and its shared release helper; no Admin package files are changed

## Verification

- focused Management/runtime tests: 96 pass, 0 fail, 528 assertions
- Management typecheck: pass
- Management Linux amd64 and arm64 builds: pass
- bash -n, ShellCheck 0.11, git diff --check: pass
- real gh 2.94 smoke with empty GH_CONFIG_DIR: shared shell helper and Management TypeScript path both verified public SHA256SUMS offline

## Release scope

The final diff contains only packages/management-api paths plus scripts/lib/release_assets.sh. It contains no packages/admin path, so the configured packages/admin Release Please component is not selected by this PR.

## Risk

Verification remains fail-closed unless the existing explicit emergency break-glass is set. Temporary bundle cleanup is exact-directory scoped, and cleanup failures cannot hide verification failures.