### PR TITLE
fix(upgrade): bound stalled bootstrap transfers

### DIFF
--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -11,6 +11,7 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{
 
 class FakeSsh {
     readonly commands: string[] = [];
+    readonly timeouts: Array<number | undefined> = [];
     readonly uploads: Array<{ remotePath: string; content: string; mode: number }> = [];
     tenantInspectOutput = "";
     migrationFails = false;
@@ -31,8 +32,9 @@ class FakeSsh {
         return this.pingResult;
     }
 
-    async exec(command: string): Promise<{ success: boolean; stdout: string; stderr: string; code: number }> {
+    async exec(command: string, timeoutMs?: number): Promise<{ success: boolean; stdout: string; stderr: string; code: number }> {
         this.commands.push(command);
+        this.timeouts.push(timeoutMs);
         if (this.upgradeExecThrows && command.includes("UPGRADE_RUNNER")) {
             throw new Error("connection dropped");
         }
@@ -152,6 +154,18 @@ function rootScriptThroughHelperSource(rootScript: string, continuationPath: str
         throw new Error("Root upgrade script lacks staged Management setup");
     }
     return [scriptLines[0], ...scriptLines.slice(stagedSetupIndex, helperSourceIndex + 1),
+        `touch '${continuationPath}'`].join("\n");
+}
+
+function rootScriptThroughBootstrap(rootScript: string, continuationPath: string): string {
+    const scriptLines = rootScript.split("\n");
+    const stagedSetupIndex = scriptLines.indexOf("STAGED_MANAGEMENT=''");
+    const stagedRunnerIndex = scriptLines.indexOf('  UPGRADE_RUNNER="$STAGED_MANAGEMENT"');
+    const bootstrapEndIndex = scriptLines.indexOf("fi", stagedRunnerIndex);
+    if (stagedSetupIndex < 0 || stagedRunnerIndex < stagedSetupIndex || bootstrapEndIndex < stagedRunnerIndex) {
+        throw new Error("Root upgrade script lacks Management bootstrap boundaries");
+    }
+    return [scriptLines[0], ...scriptLines.slice(stagedSetupIndex, bootstrapEndIndex + 1),
         `touch '${continuationPath}'`].join("\n");
 }
 
@@ -314,6 +328,17 @@ describe("ssh admin tool", () => {
         expect(execution.exitCode).toBe(0);
     });
 
+    test("explicit upgrade proxy leaves time for direct-first and proxy transfer budgets", async () => {
+        const ssh = new FakeSsh();
+        await captureSshTool(ssh).invoke({
+            action: "upgrade",
+            version: "0.50.29",
+            github_proxy: "https://proxy.example.test/",
+        });
+
+        expect(ssh.timeouts).toEqual([1_320_000, undefined]);
+    });
+
     test("outer upgrade signals remove the helper and stop command continuation", () => {
         for (const upgradeSignal of UPGRADE_SIGNALS) {
             const fixtureDir = mkdtempSync(join(tmpdir(), "supacloud-admin-outer-signal-"));
@@ -363,6 +388,41 @@ describe("ssh admin tool", () => {
             } finally {
                 rmSync(fixtureDir, { recursive: true, force: true });
             }
+        }
+    });
+
+    test("failed Management bootstrap removes the staged binary and stops continuation", async () => {
+        const fixtureDir = mkdtempSync(join(tmpdir(), "supacloud-admin-bootstrap-failure-"));
+        const helperPath = join(fixtureDir, "release-assets.sh");
+        const stagedPathRecord = join(fixtureDir, "staged-path");
+        const continuationPath = join(fixtureDir, "continued");
+        try {
+            writeFileSync(helperPath, [
+                "supacloud_attestation_verifier_available() { return 0; }",
+                "supacloud_version_at_least() { return 1; }",
+                "supacloud_fetch_component_release() { printf '%s\\n' '{}'; }",
+                "supacloud_download_release_asset() {",
+                "  printf '%s\\n' \"$3\" > \"$STAGED_PATH_RECORD\"",
+                "  printf '%s\\n' partial > \"$3\"",
+                "  return 28",
+                "}",
+            ].join("\n"));
+            const rootScript = buildRootUpgradeScript({
+                version: "0.50.29",
+                edgeRuntimeVersion: "0.16.7",
+                helperPath,
+            });
+            const execution = Bun.spawnSync(["/bin/bash", "-c",
+                rootScriptThroughBootstrap(rootScript, continuationPath)], {
+                env: { ...process.env, STAGED_PATH_RECORD: stagedPathRecord },
+            });
+
+            expect(execution.exitCode).not.toBe(0);
+            const stagedPath = (await Bun.file(stagedPathRecord).text()).trim();
+            expect(existsSync(stagedPath)).toBe(false);
+            expect(existsSync(continuationPath)).toBe(false);
+        } finally {
+            rmSync(fixtureDir, { recursive: true, force: true });
         }
     });
 
@@ -447,6 +507,7 @@ describe("ssh admin tool", () => {
         expect(Bun.spawnSync(["bash", "-n", "-c", rootScript]).exitCode).toBe(0);
         expect(Bun.spawnSync(["bash", "-n", "-c", command]).exitCode).toBe(0);
         expect(ssh.commands[1]).toBe(`rm -f '${ssh.uploads[0]?.remotePath}'`);
+        expect(ssh.timeouts).toEqual([720_000, undefined]);
     });
 
     test("component upgrade cleans its exact helper path when SSH execution throws", async () => {

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -17,6 +17,10 @@ const SAFE_HOSTNAME = /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0
 const SAFE_SYSTEMD_UNIT = /^[a-zA-Z0-9][a-zA-Z0-9_.@:-]{0,127}$/;
 const SAFE_DB_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_-]{0,62}$/;
 const MINIMUM_COMPONENT_UPGRADE_VERSION = "0.50.27";
+// Keep helper verification and cleanup outside the bounded direct transfer budget.
+const DIRECT_UPGRADE_SSH_TIMEOUT_MS = 720_000;
+// Proxy mode can exhaust each transfer once direct-first and once through the proxy.
+const PROXIED_UPGRADE_SSH_TIMEOUT_MS = 1_320_000;
 
 function hostnameSchema(fieldName: string) {
     return decodedSchema(Type.String(), Type.String({ minLength: 1, maxLength: 253 }), (value) => {
@@ -211,12 +215,13 @@ async function executeOfficialUpgrade(
     ssh: SshTransport,
     helperPath: string,
     command: string,
+    timeoutMs: number,
 ): Promise<Awaited<ReturnType<SshTransport["exec"]>>> {
     let execution: OfficialUpgradeExecution | undefined;
     let executionError: unknown;
     try {
         await ssh.uploadText(helperPath, releaseAssetsScript, 0o600);
-        execution = await ssh.exec(command, 600_000);
+        execution = await ssh.exec(command, timeoutMs);
     } catch (error: unknown) {
         executionError = error;
     }
@@ -559,7 +564,10 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
                         githubProxy,
                         helperPath,
                     });
-                    const upgradeExecution = await executeOfficialUpgrade(ssh, helperPath, cmd);
+                    const upgradeTimeoutMs = githubProxy
+                        ? PROXIED_UPGRADE_SSH_TIMEOUT_MS
+                        : DIRECT_UPGRADE_SSH_TIMEOUT_MS;
+                    const upgradeExecution = await executeOfficialUpgrade(ssh, helperPath, cmd, upgradeTimeoutMs);
                     const edgeBoundary = edgeRuntimeVersion ? "" : "\n⚠️ Edge Runtime was not upgraded; provide --edge_runtime_version for a component transaction.";
                     text = `✅ Upgrade done\n${upgradeExecution.stdout.slice(-300)}${edgeBoundary}`;
                     break;

--- a/packages/admin/src/shared/transports/ssh.test.ts
+++ b/packages/admin/src/shared/transports/ssh.test.ts
@@ -12,6 +12,8 @@ class FakeSshClient extends EventEmitter {
     connectError: Error | undefined;
     stdout = Buffer.from("ok\n");
     stderrOutput = Buffer.alloc(0);
+    stallCommand = false;
+    endCalls = 0;
 
     connect(options: Record<string, unknown>): this {
         this.connectOptions = options;
@@ -23,6 +25,7 @@ class FakeSshClient extends EventEmitter {
         const stream = new EventEmitter() as EventEmitter & { stderr: EventEmitter };
         stream.stderr = new EventEmitter();
         callback(undefined, stream);
+        if (this.stallCommand) return;
         queueMicrotask(() => {
             if (this.stdout.length > 0) stream.emit("data", this.stdout);
             if (this.stderrOutput.length > 0) stream.stderr.emit("data", this.stderrOutput);
@@ -30,7 +33,9 @@ class FakeSshClient extends EventEmitter {
         });
     }
 
-    end(): void {}
+    end(): void {
+        this.endCalls++;
+    }
 }
 
 describe("SshTransport audit safety", () => {
@@ -138,6 +143,34 @@ describe("SshTransport audit safety", () => {
             const verifier = client.connectOptions?.hostVerifier as ((hash: string) => boolean);
             expect(verifier(createHash("sha256").update(TEST_HOST_KEY).digest("hex"))).toBe(true);
             expect(verifier(createHash("sha256").update("different-key").digest("hex"))).toBe(false);
+        } finally {
+            transport.close();
+        }
+    });
+
+    test("discards a timed-out connection before the next cleanup command", async () => {
+        const stalledClient = new FakeSshClient();
+        stalledClient.stallCommand = true;
+        const cleanupClient = new FakeSshClient();
+        const clients = [stalledClient, cleanupClient];
+        let clientIndex = 0;
+        const transport = new SshTransport({
+            host: "server.example.com",
+            port: 22,
+            username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => clients[clientIndex++] as never });
+
+        try {
+            await expect(transport.exec("long-running-upgrade", 10)).rejects.toThrow(
+                "SSH command timed out after 10ms",
+            );
+            expect(stalledClient.endCalls).toBe(1);
+
+            const cleanup = await transport.exec("remove-upgrade-helper");
+            expect(cleanup.success).toBe(true);
+            expect(clientIndex).toBe(2);
+            expect(cleanupClient.connectOptions?.host).toBe("server.example.com");
         } finally {
             transport.close();
         }

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -6,7 +6,7 @@
  */
 import { timingSafeEqual } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { Client } from "ssh2";
+import { Client, type ClientChannel } from "ssh2";
 type SftpClient = {
     fastPut: (localPath: string, remotePath: string, cb: (err?: Error | null) => void) => void;
     writeFile: (
@@ -233,6 +233,10 @@ class SshConnectionPool {
         }
     }
 
+    discard(conn: Client) {
+        try { conn.end(); } catch { /* ignore */ }
+    }
+
     closeAll() {
         for (const conn of this.pool) {
             try { conn.end(); } catch { /* ignore */ }
@@ -270,6 +274,7 @@ export class SshTransport {
         auditCommand(command, this.config.host, false);
 
         const conn = await this.pool.acquire();
+        let connectionReusable = true;
         try {
             return await new Promise<SshResult>((resolve, reject) => {
                 const outputLimit = this.config.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
@@ -277,11 +282,12 @@ export class SshTransport {
                 const stderr = new BoundedOutputCollector(outputLimit);
 
                 const timer = setTimeout(() => {
-                    conn.end();
+                    connectionReusable = false;
+                    this.pool.discard(conn);
                     reject(new Error(`SSH command timed out after ${timeoutMs}ms`));
                 }, timeoutMs);
 
-                conn.exec(command, (err: Error | undefined, stream: any) => {
+                conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
                     if (err) {
                         clearTimeout(timer);
                         return reject(err);
@@ -307,7 +313,7 @@ export class SshTransport {
                 });
             });
         } finally {
-            this.pool.release(conn);
+            if (connectionReusable) this.pool.release(conn);
         }
     }
 

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -1,6 +1,6 @@
 // @supacloud-test-isolate — compiles and validates multiple release fixtures.
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -872,7 +872,7 @@ describe("runtime companion version assets", () => {
     }
   });
 
-  test("release downloads try GitHub directly and only use an explicitly configured proxy", () => {
+  test("release transfers are bounded and try GitHub directly before an explicit proxy", () => {
     const dir = mkdtempSync(join(tmpdir(), "supacloud-curl-order-"));
     const calls = join(dir, "calls.txt");
     try {
@@ -882,16 +882,27 @@ describe("runtime companion version assets", () => {
           "-c",
           [
             "source scripts/lib/release_assets.sh",
-            "curl() { printf '%s\\n' \"$*\" >> \"$CALLS\"; return 0; }",
+            "curl() {",
+            "  printf '%s\\n' \"$*\" >> \"$CALLS\"",
+            "  output=''",
+            "  while [ \"$#\" -gt 0 ]; do",
+            "    if [ \"$1\" = -o ]; then shift; output=\"$1\"; fi",
+            "    shift",
+            "  done",
+            "  test -z \"$output\" || printf '%s\\n' '{}' > \"$output\"",
+            "}",
             "export -f curl",
+            'supacloud_fetch_release_json "https://api.github.com/repos/acme/releases"',
+            'supacloud_download_release_metadata_url "https://github.com/acme/SHA256SUMS" "$METADATA_OUTPUT"',
             'supacloud_download_url "https://github.com/acme/release" "$OUTPUT"',
-          ].join("; "),
+          ].join("\n"),
         ],
         {
           cwd: repoRoot,
           env: {
             ...process.env,
             CALLS: calls,
+            METADATA_OUTPUT: join(dir, "SHA256SUMS"),
             OUTPUT: join(dir, "artifact"),
             GH_PROXY: "https://proxy.example.test",
           },
@@ -900,9 +911,101 @@ describe("runtime companion version assets", () => {
       );
       expect(result.status, result.stderr).toBe(0);
       const invocations = readFileSync(calls, "utf8").trim().split("\n");
-      expect(invocations).toHaveLength(1);
-      expect(invocations[0]).toContain("https://github.com/acme/release");
-      expect(invocations[0]).not.toContain("proxy.example.test");
+      expect(invocations).toHaveLength(3);
+      for (const metadataInvocation of invocations.slice(0, 2)) {
+        expect(metadataInvocation).toContain("--retry 1 --retry-delay 2 --retry-max-time 60");
+        expect(metadataInvocation).toContain("--connect-timeout 15 --max-time 30");
+        expect(metadataInvocation).toContain("--speed-limit 128 --speed-time 10");
+        expect(metadataInvocation).toContain("--proto =https --proto-redir =https");
+      }
+      expect(invocations[2]).toContain("--retry 1 --retry-delay 2 --retry-max-time 180");
+      expect(invocations[2]).toContain("--connect-timeout 15 --max-time 90");
+      expect(invocations[2]).toContain("--speed-limit 128 --speed-time 60");
+      expect(invocations[2]).toContain("--proto =https --proto-redir =https");
+      expect(invocations[2]).toContain("https://github.com/acme/release");
+      expect(invocations.join("\n")).not.toContain("proxy.example.test");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("release metadata falls back to the explicit proxy without exposing a partial direct response", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-curl-proxy-"));
+    const calls = join(dir, "calls.txt");
+    try {
+      const result = spawnSync("/bin/bash", ["-c", [
+        "source scripts/lib/release_assets.sh",
+        "curl() {",
+        "  printf '%s\\n' \"$*\" >> \"$CALLS\"",
+        "  curl_arguments=\"$*\"",
+        "  output=''",
+        "  while [ \"$#\" -gt 0 ]; do",
+        "    if [ \"$1\" = -o ]; then shift; output=\"$1\"; fi",
+        "    shift",
+        "  done",
+        "  case \"$curl_arguments\" in *proxy.example.test*) printf '%s\\n' '{}' > \"$output\"; return 0 ;; esac",
+        "  printf '%s' '{partial' > \"$output\"",
+        "  return 28",
+        "}",
+        "export -f curl",
+        'supacloud_fetch_release_json "https://api.github.com/repos/acme/releases"',
+      ].join("\n")], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          CALLS: calls,
+          GH_PROXY: "https://proxy.example.test",
+          SUPACLOUD_GITHUB_PROXY: "",
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toBe("{}\n");
+      const invocations = readFileSync(calls, "utf8").trim().split("\n");
+      expect(invocations).toHaveLength(2);
+      expect(invocations[0]).toContain("https://api.github.com/repos/acme/releases");
+      expect(invocations[1]).toContain("https://proxy.example.test/https://api.github.com/repos/acme/releases");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("release download signals remove partial files and stop continuation", () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-release-signal-"));
+    const destination = join(dir, "staged-management");
+    const continuation = join(dir, "continued");
+    const release = JSON.stringify({
+      tag_name: "management-api-v0.50.29",
+      assets: [
+        { name: "supacloud-linux-amd64", browser_download_url: "https://example.test/management" },
+        { name: "SHA256SUMS", browser_download_url: "https://example.test/SHA256SUMS" },
+      ],
+    });
+    try {
+      const result = spawnSync("/bin/bash", ["-c", [
+        "set -e",
+        "source scripts/lib/release_assets.sh",
+        "supacloud_download_url() { printf '%s\\n' partial > \"$2\"; /bin/sh -c 'kill -TERM \"$PPID\"'; }",
+        'supacloud_download_release_asset "$RELEASE" supacloud-linux-amd64 "$DESTINATION" binary',
+        'touch "$CONTINUATION"',
+      ].join("\n")], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          RELEASE: release,
+          DESTINATION: destination,
+          CONTINUATION: continuation,
+          GH_PROXY: "",
+          SUPACLOUD_GITHUB_PROXY: "",
+        },
+        encoding: "utf8",
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(existsSync(destination)).toBe(false);
+      expect(existsSync(continuation)).toBe(false);
+      expect(readdirSync(dir).filter(name => name.startsWith("staged-management."))).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/scripts/lib/release_assets.sh
+++ b/scripts/lib/release_assets.sh
@@ -8,6 +8,24 @@ SUPACLOUD_GH_MIN_VERSION="${SUPACLOUD_GH_MIN_VERSION:-2.68.0}"
 SUPACLOUD_GH_AMD64_SHA256="${SUPACLOUD_GH_AMD64_SHA256:-83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60}"
 SUPACLOUD_GH_ARM64_SHA256="${SUPACLOUD_GH_ARM64_SHA256:-06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909}"
 
+supacloud_curl_release_json() {
+    local url="$1"
+    local output="$2"
+    curl -fsSL --proto '=https' --proto-redir '=https' \
+        --retry 1 --retry-delay 2 --retry-max-time 60 \
+        --connect-timeout 15 --max-time 30 --speed-limit 128 --speed-time 10 \
+        -o "$output" "$url"
+}
+
+supacloud_curl_release_asset() {
+    local url="$1"
+    local output="$2"
+    curl -fL --proto '=https' --proto-redir '=https' \
+        --retry 1 --retry-delay 2 --retry-max-time 180 \
+        --connect-timeout 15 --max-time 90 --speed-limit 128 --speed-time 60 \
+        -o "$output" "$url"
+}
+
 supacloud_component_tag() {
     local component="$1"
     local version="$2"
@@ -73,18 +91,15 @@ supacloud_fetch_component_release() {
     supacloud_select_release "$component" "${required_assets[@]}" <<< "$response"
 }
 
-supacloud_fetch_release_json() {
+supacloud_fetch_release_json() (
     local url="$1"
-    local proxy="${SUPACLOUD_GITHUB_PROXY:-${GH_PROXY:-}}"
-    if curl -fsSL --retry 3 --connect-timeout 15 "$url"; then
-        return 0
-    fi
-    if [[ -n "$proxy" ]]; then
-        curl -fsSL --retry 3 --connect-timeout 15 "${proxy%/}/${url}"
-        return
-    fi
-    return 1
-}
+    local response_file
+    response_file=$(mktemp) || return 1
+    trap 'rm -f "$response_file"' EXIT
+    trap 'trap - EXIT HUP INT TERM; rm -f "$response_file"; exit 1' HUP INT TERM
+    supacloud_download_release_metadata_url "$url" "$response_file" || return 1
+    cat "$response_file"
+)
 
 supacloud_release_asset_url() {
     local release_json="$1"
@@ -100,11 +115,26 @@ supacloud_download_url() {
     local output="$2"
     local proxy="${SUPACLOUD_GITHUB_PROXY:-${GH_PROXY:-}}"
 
-    if curl -fL --retry 3 --connect-timeout 15 -o "$output" "$url"; then
+    if supacloud_curl_release_asset "$url" "$output"; then
         return 0
     fi
     if [[ -n "$proxy" ]]; then
-        curl -fL --retry 3 --connect-timeout 15 -o "$output" "${proxy%/}/${url}"
+        supacloud_curl_release_asset "${proxy%/}/${url}" "$output"
+        return
+    fi
+    return 1
+}
+
+supacloud_download_release_metadata_url() {
+    local url="$1"
+    local output="$2"
+    local proxy="${SUPACLOUD_GITHUB_PROXY:-${GH_PROXY:-}}"
+
+    if supacloud_curl_release_json "$url" "$output"; then
+        return 0
+    fi
+    if [[ -n "$proxy" ]]; then
+        supacloud_curl_release_json "${proxy%/}/${url}" "$output"
         return
     fi
     return 1
@@ -185,7 +215,8 @@ supacloud_install_pinned_tar_xz_binary() (
     fi
 
     extract_dir=$(mktemp -d)
-    trap 'rm -rf "$extract_dir"; [[ -z "${staged_target:-}" ]] || rm -f "$staged_target"' EXIT HUP INT TERM
+    trap 'rm -rf "$extract_dir"; [[ -z "${staged_target:-}" ]] || rm -f "$staged_target"' EXIT
+    trap 'trap - EXIT HUP INT TERM; rm -rf "$extract_dir"; [[ -z "${staged_target:-}" ]] || rm -f "$staged_target"; exit 1' HUP INT TERM
     if ! tar --no-same-owner --no-same-permissions -xJf "$archive" -C "$extract_dir" "$member"; then
         return 1
     fi
@@ -417,10 +448,11 @@ supacloud_download_release_asset() (
     mkdir -p "$(dirname "$destination")"
     temporary_artifact=$(mktemp "${destination}.tmp.XXXXXX")
     temporary_checksums=$(mktemp "${destination}.SHA256SUMS.tmp.XXXXXX")
-    trap 'rm -f "${temporary_artifact:-}" "${temporary_checksums:-}"' EXIT HUP INT TERM
+    trap 'rm -f "${temporary_artifact:-}" "${temporary_checksums:-}"' EXIT
+    trap 'trap - EXIT HUP INT TERM; rm -f "${temporary_artifact:-}" "${temporary_checksums:-}"; exit 1' HUP INT TERM
 
     if ! supacloud_download_url "$asset_url" "$temporary_artifact" \
-        || ! supacloud_download_url "$checksum_url" "$temporary_checksums" \
+        || ! supacloud_download_release_metadata_url "$checksum_url" "$temporary_checksums" \
         || ! supacloud_verify_checksum "$temporary_artifact" "$asset_name" "$temporary_checksums"; then
         rm -f "$temporary_artifact" "$temporary_checksums"
         return 1


### PR DESCRIPTION
## Summary
- bound release metadata and asset downloads with HTTPS-only redirects, retry budgets, low-speed detection, and total deadlines
- discard timed-out SSH connections so helper cleanup always uses a fresh connection
- preserve signal cleanup for staged bootstrap files and cover direct/proxied client timeout margins

## Scope
This fixes the observed pre-transaction Admin bootstrap stall. It does not claim that Management 0.50.29's internal network download phase is globally bounded; the separate offline-bundle work will remove that deployment dependency.

## Verification
- `bun test src/shared/transports/ssh.test.ts src/shared/tools/ssh-tools.test.ts` (46 pass)
- `bun test tests/unit/runtime-version-assets.test.ts` (28 pass)
- Admin `bun run typecheck`
- Admin `bun run build`
- `bash -n scripts/lib/release_assets.sh`
- `shellcheck scripts/lib/release_assets.sh`
- `git diff --check origin/main...HEAD`

clean-code-guard: clean