### PR TITLE
fix(upgrade): add verified offline release bundles

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -115,10 +115,23 @@ jobs:
           cd release-assets
           sha256sum * > SHA256SUMS
 
+      - name: Generate strict Management release manifest
+        working-directory: packages/management-api
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.management_api_tag_name }}
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: bun run release:manifest --assets-dir ../../release-assets --tag "$RELEASE_TAG" --source-commit "$SOURCE_COMMIT"
+
       - name: Attest management release artifacts
+        id: attest-management-release
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: release-assets/*
+
+      - name: Stage offline Management attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest-management-release.outputs.bundle-path }}
+        run: install -m 0600 "$ATTESTATION_BUNDLE" release-assets/SUPACLOUD-RELEASE.attestation.jsonl
 
       - name: Upload binaries to GitHub Release
         env:
@@ -194,10 +207,23 @@ jobs:
         working-directory: packages/edge-runtime/dist
         run: sha256sum * > SHA256SUMS
 
+      - name: Generate strict Edge Runtime release manifest
+        working-directory: packages/edge-runtime
+        env:
+          RELEASE_TAG: ${{ needs.release-please.outputs.edge_runtime_tag_name }}
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: bun run release:manifest --assets-dir dist --tag "$RELEASE_TAG" --source-commit "$SOURCE_COMMIT"
+
       - name: Attest Edge Runtime release artifacts
+        id: attest-edge-runtime-release
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: packages/edge-runtime/dist/*
+
+      - name: Stage offline Edge Runtime attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest-edge-runtime-release.outputs.bundle-path }}
+        run: install -m 0600 "$ATTESTATION_BUNDLE" packages/edge-runtime/dist/SUPACLOUD-RELEASE.attestation.jsonl
 
       - name: Upload binaries to GitHub Release
         env:

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -299,6 +299,48 @@ Verify that fingerprint through a trusted out-of-band channel before setting
 it. Without it, `supacloud-admin` keeps HTTP administration available but leaves
 all executable SSH actions disabled.
 
+### Protected offline upgrade handoff
+
+The installed server binary provides the supported handoff for a release bundle
+that an administrator has already placed on the server. Pin both component
+versions; do not use `latest` or an inferred Edge Runtime version:
+
+```bash
+sudo /usr/local/bin/supacloud upgrade --yes \
+  --target-version 0.50.31 \
+  --edge-runtime-version 0.16.8 \
+  --asset-bundle-dir /var/lib/supacloud/upgrade-bundles/release-20260810
+```
+
+The bundle root and both component directories must be canonical, root-owned
+directories with mode `0700`. Every file must be a root-owned direct regular
+file with mode `0600`, one link, and no symlink traversal. The fixed layout is:
+
+```text
+<bundle>/
+  management-api/
+    SUPACLOUD-RELEASE.json
+    SUPACLOUD-RELEASE.attestation.jsonl
+    SHA256SUMS
+    supacloud-linux-<arch>
+    web-console-build.tar.gz
+  edge-runtime/
+    SUPACLOUD-RELEASE.json
+    SUPACLOUD-RELEASE.attestation.jsonl
+    SHA256SUMS
+    supacloud-edge-runtime-linux-<arch>
+```
+
+Omit `edge-runtime/` and `--edge-runtime-version` together for a
+Management/Web Console-only transaction. When an Edge Runtime version is
+specified, both are mandatory. The offline path reads no GitHub release
+metadata and downloads no release asset. It verifies the supplied provenance
+bundles locally with `gh attestation verify`, then checks the signed manifest,
+`SHA256SUMS`, exact asset size and digest before staging anything. A missing or
+outdated verifier, an extra file, or a component/version mismatch fails before
+the upgrade transaction. Management and Edge Runtime may come from different
+valid release commits; each component proves its own source commit.
+
 ### Owned command areas
 
 - `ssh`

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -12,6 +12,7 @@
     "build:macos-amd64": "bun run scripts/build-compiled.ts --target bun-macos-x64 --outfile supacloud-edge-runtime-macos-amd64",
     "build:macos-arm64": "bun run scripts/build-compiled.ts --target bun-macos-arm64 --outfile supacloud-edge-runtime-macos-arm64",
     "build:macos": "bun run build:macos-amd64 && bun run build:macos-arm64",
+    "release:manifest": "bun run ../../scripts/generate_release_manifest.ts --component edge-runtime --package-json package.json",
     "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts worker-executor.ts worker-pool.ts internal-bindings.ts pgredis-capability.ts auto-deps.ts deno-compat.ts fetch-tls-policy.ts url-import-plugin.ts shims/*.ts"
   },
   "dependencies": {

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "bun test tests/e2e",
     "test:sdk": "bun test tests/integration/sdk.automation.test.ts",
     "test:compat": "bun test tests/integration/sdk-parity.test.ts && bun run tests/scripts/run-official-sdk-compliance.ts && bun run tests/scripts/run-official-cli-compliance.ts && bun run tests/scripts/run-openapi-compliance.ts",
+    "release:manifest": "bun run ../../scripts/generate_release_manifest.ts --component management-api --package-json package.json",
     "prebuild": "bun run sql:check && bun run scripts/patch-dependencies.ts && cd ../web-console && bun install --frozen-lockfile && bun run build",
     "build:amd64": "bun build src/standalone.ts --compile --target=bun-linux-x64 --outfile=supacloud-linux-amd64",
     "build:arm64": "bun build src/standalone.ts --compile --target=bun-linux-arm64 --outfile=supacloud-linux-arm64",

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -961,8 +961,16 @@ async function bootstrap() {
     const { runUpgrade } = await import("./upgrade");
     const forceYes = args.includes("--yes") || args.includes("-y");
     const targetVersion = readArgValue("--target-version", "--release", "--version");
+    const edgeRuntimeVersion = readArgValue("--edge-runtime-version");
+    const assetBundleDir = readArgValue("--asset-bundle-dir");
     try {
-      await runUpgrade({ forceYes, targetVersion });
+      if (args.includes("--edge-runtime-version") && !edgeRuntimeVersion) {
+        throw new Error("--edge-runtime-version requires an exact stable version");
+      }
+      if (args.includes("--asset-bundle-dir") && !assetBundleDir) {
+        throw new Error("--asset-bundle-dir requires an absolute protected directory");
+      }
+      await runUpgrade({ forceYes, targetVersion, edgeRuntimeVersion, assetBundleDir });
       process.exit(0);
     } catch (err: unknown) {
       logger.error("Upgrade aborted:", {

--- a/packages/management-api/src/offline-upgrade-bundle.ts
+++ b/packages/management-api/src/offline-upgrade-bundle.ts
@@ -1,0 +1,382 @@
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, readdirSync, realpathSync, type Stats } from "node:fs";
+import path from "node:path";
+import {
+  RELEASE_ATTESTATION_NAME,
+  RELEASE_BUNDLE_SIZE_LIMITS,
+  RELEASE_CHECKSUMS_NAME,
+  RELEASE_MANIFEST_NAME,
+  RELEASE_REPOSITORY,
+  RELEASE_SIGNER_WORKFLOW,
+  RELEASE_SOURCE_REF,
+  type ReleaseComponent,
+  type ReleaseManifest,
+  manifestArtifact,
+  parseReleaseChecksums,
+  parseReleaseManifest,
+  releaseAssetSizeLimit,
+} from "./release-manifest";
+
+const GH_CAPABILITY_TIMEOUT_MS = 10_000;
+const GH_VERIFICATION_TIMEOUT_MS = 60_000;
+
+type BundleOwner = {
+  uid: number;
+  gid: number;
+};
+
+export type OfflineReleaseBundle = {
+  directory: string;
+  manifest: ReleaseManifest;
+  checksums: string;
+  assetPaths: Map<string, string>;
+};
+
+export type OfflineUpgradeBundle = {
+  management: OfflineReleaseBundle;
+  edgeRuntime: OfflineReleaseBundle | null;
+};
+
+export type OfflineUpgradeBundleRequest = {
+  assetBundleDir: string;
+  management: { version: string; binaryName: string };
+  edgeRuntime?: { version: string; binaryName: string };
+};
+
+type OfflineReleaseRequest = {
+  bundleRoot: string;
+  component: ReleaseComponent;
+  version: string;
+  binaryName: string;
+  owner: BundleOwner;
+};
+
+type PreparedOfflineRelease = {
+  component: ReleaseComponent;
+  version: string;
+  directory: string;
+  manifestText: string;
+  sourceCommit: string;
+  selectedAssetNames: string[];
+  assetPaths: Map<string, string>;
+};
+
+type GithubCliResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+function effectiveBundleOwner(): BundleOwner {
+  const uid = process.geteuid?.() ?? process.getuid?.();
+  const gid = process.getegid?.() ?? process.getgid?.();
+  if (uid === undefined || gid === undefined) {
+    throw new Error("Offline upgrade bundles require POSIX effective ownership checks");
+  }
+  return { uid, gid };
+}
+
+function exactEntries(directory: string, expectedEntries: string[], label: string): void {
+  const actualEntries = readdirSync(directory).sort();
+  const expected = [...expectedEntries].sort();
+  if (actualEntries.length !== expected.length
+    || actualEntries.some((name, index) => name !== expected[index])) {
+    throw new Error(`${label} does not match the strict bundle allowlist`);
+  }
+}
+
+function assertOwner(stats: Stats, owner: BundleOwner, label: string): void {
+  if (stats.uid !== owner.uid || stats.gid !== owner.gid) {
+    throw new Error(`${label} must be owned by uid ${owner.uid} and gid ${owner.gid}`);
+  }
+}
+
+export function assertExactBundleMode(
+  mode: number,
+  expectedMode: 0o600 | 0o700,
+  label: string,
+): void {
+  if ((mode & 0o7777) !== expectedMode) {
+    throw new Error(`${label} mode must be exactly 0${expectedMode.toString(8)}`);
+  }
+}
+
+function assertSecureDirectory(directory: string, owner: BundleOwner, label: string): void {
+  const resolved = path.resolve(directory);
+  const stats = lstatSync(resolved);
+  if (!path.isAbsolute(directory) || !stats.isDirectory() || stats.isSymbolicLink()
+    || realpathSync(resolved) !== resolved) {
+    throw new Error(`${label} must be a canonical directory without symlinks`);
+  }
+  assertOwner(stats, owner, label);
+  assertExactBundleMode(stats.mode, 0o700, label);
+}
+
+function assertSecureFile(filePath: string, owner: BundleOwner, label: string): Stats {
+  const stats = lstatSync(filePath);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1
+    || realpathSync(filePath) !== filePath) {
+    throw new Error(`${label} must be a direct regular file without links`);
+  }
+  assertOwner(stats, owner, label);
+  assertExactBundleMode(stats.mode, 0o600, label);
+  return stats;
+}
+
+function readBoundedFile(filePath: string, limit: number, label: string): string {
+  const size = lstatSync(filePath).size;
+  if (size <= 0 || size > limit) throw new Error(`${label} exceeds its size limit`);
+  return readFileSync(filePath, "utf8");
+}
+
+function assertBoundedFile(filePath: string, limit: number, label: string): void {
+  const size = lstatSync(filePath).size;
+  if (size <= 0 || size > limit) throw new Error(`${label} exceeds its size limit`);
+}
+
+function sourceCommitFromUntrustedManifest(text: string): string {
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(text);
+  } catch {
+    throw new Error("Release manifest is not valid JSON");
+  }
+  const commit = (candidate as { source?: { commit?: unknown } } | null)?.source?.commit;
+  if (typeof commit !== "string" || !/^[0-9a-f]{40}$/.test(commit)) {
+    throw new Error("Release manifest source commit is invalid");
+  }
+  return commit;
+}
+
+export async function runGithubCliWithTimeout(
+  githubArguments: string[],
+  timeoutMs: number,
+): Promise<GithubCliResult> {
+  const executable = Bun.which("gh", { PATH: process.env.PATH });
+  if (!executable) return { exitCode: 127, stdout: "", stderr: "gh not found" };
+  const child = Bun.spawn([executable, ...githubArguments], {
+    env: process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGKILL");
+  }, timeoutMs);
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    return timedOut
+      ? { exitCode: 124, stdout, stderr: `gh command timed out after ${timeoutMs}ms` }
+      : { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function supportsStrictOfflineVerification(capabilityResult: GithubCliResult): boolean {
+  const helpTokens = `${capabilityResult.stdout}\n${capabilityResult.stderr}`.split(/\s+/);
+  const requiredFlags = [
+    "--bundle",
+    "--signer-workflow",
+    "--source-ref",
+    "--source-digest",
+    "--deny-self-hosted-runners",
+  ];
+  return capabilityResult.exitCode === 0 && requiredFlags.every((flag) => (
+    helpTokens.some((token) => token === flag || token.startsWith(`${flag}=`))
+  ));
+}
+
+async function assertStrictOfflineVerifier(): Promise<void> {
+  const capability = await runGithubCliWithTimeout(
+    ["attestation", "verify", "--help"], GH_CAPABILITY_TIMEOUT_MS,
+  );
+  if (!supportsStrictOfflineVerification(capability)) {
+    throw new Error("Offline release bundle verification requires a current gh attestation verifier");
+  }
+}
+
+async function verifyOfflineAttestation(prepared: PreparedOfflineRelease, artifactPath: string): Promise<void> {
+  const attestationPath = requiredPath(prepared.assetPaths, RELEASE_ATTESTATION_NAME);
+  const verification = await runGithubCliWithTimeout([
+    "attestation", "verify", artifactPath,
+    "--bundle", attestationPath,
+    "--repo", RELEASE_REPOSITORY,
+    "--signer-workflow", RELEASE_SIGNER_WORKFLOW,
+    "--source-ref", RELEASE_SOURCE_REF,
+    "--source-digest", prepared.sourceCommit,
+    "--deny-self-hosted-runners",
+  ], GH_VERIFICATION_TIMEOUT_MS);
+  if (verification.exitCode !== 0) {
+    throw new Error(`Offline GitHub artifact attestation verification failed: ${verification.stderr.slice(-500)}`);
+  }
+}
+
+function sha256File(filePath: string): string {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function assertManifestArtifact(filePath: string, manifest: ReleaseManifest, name: string): void {
+  const expected = manifestArtifact(manifest, name);
+  const stats = lstatSync(filePath);
+  if (stats.size !== expected.size || sha256File(filePath) !== expected.sha256) {
+    throw new Error(`${name} does not match the signed release manifest`);
+  }
+}
+
+function selectedAssetNames(component: ReleaseComponent, binaryName: string): string[] {
+  return component === "management-api"
+    ? [binaryName, "web-console-build.tar.gz"]
+    : [binaryName];
+}
+
+function componentFileNames(selectedNames: string[]): string[] {
+  return [RELEASE_MANIFEST_NAME, RELEASE_ATTESTATION_NAME, RELEASE_CHECKSUMS_NAME, ...selectedNames];
+}
+
+function secureComponentPaths(request: OfflineReleaseRequest, selectedNames: string[]): Map<string, string> {
+  const directory = path.join(request.bundleRoot, request.component);
+  const fileNames = componentFileNames(selectedNames);
+  assertSecureDirectory(directory, request.owner, `${request.component} bundle directory`);
+  exactEntries(directory, fileNames, `${request.component} bundle directory`);
+  return new Map(fileNames.map((name) => {
+    const filePath = path.join(directory, name);
+    assertSecureFile(filePath, request.owner, `${request.component} bundle file ${name}`);
+    return [name, filePath];
+  }));
+}
+
+function requiredPath(assetPaths: Map<string, string>, name: string): string {
+  const filePath = assetPaths.get(name);
+  if (!filePath) throw new Error(`Offline release bundle does not contain ${name}`);
+  return filePath;
+}
+
+function assertReleaseFileSizes(
+  component: ReleaseComponent,
+  assetPaths: Map<string, string>,
+  selectedNames: string[],
+): void {
+  const fixedLimits = [
+    [RELEASE_ATTESTATION_NAME, RELEASE_BUNDLE_SIZE_LIMITS.attestation],
+    [RELEASE_CHECKSUMS_NAME, RELEASE_BUNDLE_SIZE_LIMITS.checksums],
+  ] as const;
+  for (const [name, limit] of fixedLimits) {
+    assertBoundedFile(requiredPath(assetPaths, name), limit, name);
+  }
+  for (const name of selectedNames) {
+    assertBoundedFile(requiredPath(assetPaths, name), releaseAssetSizeLimit(component, name), name);
+  }
+}
+
+function prepareOfflineRelease(request: OfflineReleaseRequest): PreparedOfflineRelease {
+  const selectedNames = selectedAssetNames(request.component, request.binaryName);
+  const assetPaths = secureComponentPaths(request, selectedNames);
+  const manifestPath = requiredPath(assetPaths, RELEASE_MANIFEST_NAME);
+  const manifestText = readBoundedFile(
+    manifestPath, RELEASE_BUNDLE_SIZE_LIMITS.manifest, RELEASE_MANIFEST_NAME,
+  );
+  assertReleaseFileSizes(request.component, assetPaths, selectedNames);
+  return {
+    component: request.component,
+    version: request.version,
+    directory: path.join(request.bundleRoot, request.component),
+    manifestText,
+    sourceCommit: sourceCommitFromUntrustedManifest(manifestText),
+    selectedAssetNames: selectedNames,
+    assetPaths,
+  };
+}
+
+function assertTotalBundleSize(preparedReleases: PreparedOfflineRelease[]): void {
+  const paths = new Set(preparedReleases.flatMap((prepared) => [...prepared.assetPaths.values()]));
+  const totalSize = [...paths].reduce((sum, filePath) => sum + lstatSync(filePath).size, 0);
+  if (!Number.isSafeInteger(totalSize) || totalSize > RELEASE_BUNDLE_SIZE_LIMITS.total) {
+    throw new Error("Offline upgrade bundle exceeds its total size limit");
+  }
+}
+
+async function verifiedChecksums(
+  prepared: PreparedOfflineRelease,
+  manifest: ReleaseManifest,
+): Promise<{ text: string; byName: Map<string, string> }> {
+  const checksumsPath = requiredPath(prepared.assetPaths, RELEASE_CHECKSUMS_NAME);
+  assertManifestArtifact(checksumsPath, manifest, RELEASE_CHECKSUMS_NAME);
+  await verifyOfflineAttestation(prepared, checksumsPath);
+  const text = readFileSync(checksumsPath, "utf8");
+  return { text, byName: parseReleaseChecksums(text, manifest) };
+}
+
+async function verifySelectedAssets(
+  prepared: PreparedOfflineRelease,
+  manifest: ReleaseManifest,
+  checksums: Map<string, string>,
+): Promise<void> {
+  for (const name of prepared.selectedAssetNames) {
+    const assetPath = requiredPath(prepared.assetPaths, name);
+    assertManifestArtifact(assetPath, manifest, name);
+    if (checksums.get(name) !== manifestArtifact(manifest, name).sha256) {
+      throw new Error(`${name} does not match SHA256SUMS`);
+    }
+    await verifyOfflineAttestation(prepared, assetPath);
+  }
+}
+
+async function loadOfflineRelease(prepared: PreparedOfflineRelease): Promise<OfflineReleaseBundle> {
+  const manifestPath = requiredPath(prepared.assetPaths, RELEASE_MANIFEST_NAME);
+  await verifyOfflineAttestation(prepared, manifestPath);
+  const manifest = parseReleaseManifest(prepared.manifestText, {
+    component: prepared.component,
+    version: prepared.version,
+  });
+  const checksums = await verifiedChecksums(prepared, manifest);
+  await verifySelectedAssets(prepared, manifest, checksums.byName);
+  return {
+    directory: prepared.directory,
+    manifest,
+    checksums: checksums.text,
+    assetPaths: prepared.assetPaths,
+  };
+}
+
+function prepareUpgradeReleases(
+  request: OfflineUpgradeBundleRequest,
+  owner: BundleOwner,
+): { management: PreparedOfflineRelease; edgeRuntime: PreparedOfflineRelease | null } {
+  const management = prepareOfflineRelease({
+    bundleRoot: request.assetBundleDir,
+    component: "management-api",
+    ...request.management,
+    owner,
+  });
+  const edgeRuntime = request.edgeRuntime ? prepareOfflineRelease({
+    bundleRoot: request.assetBundleDir,
+    component: "edge-runtime",
+    ...request.edgeRuntime,
+    owner,
+  }) : null;
+  return { management, edgeRuntime };
+}
+
+export async function loadOfflineUpgradeBundle(request: OfflineUpgradeBundleRequest): Promise<OfflineUpgradeBundle> {
+  const owner = effectiveBundleOwner();
+  assertSecureDirectory(request.assetBundleDir, owner, "Offline upgrade bundle directory");
+  exactEntries(
+    request.assetBundleDir,
+    request.edgeRuntime ? ["management-api", "edge-runtime"] : ["management-api"],
+    "Offline upgrade bundle directory",
+  );
+  const prepared = prepareUpgradeReleases(request, owner);
+  assertTotalBundleSize([prepared.management, ...(prepared.edgeRuntime ? [prepared.edgeRuntime] : [])]);
+  await assertStrictOfflineVerifier();
+  const management = await loadOfflineRelease(prepared.management);
+  const edgeRuntime = prepared.edgeRuntime
+    ? await loadOfflineRelease(prepared.edgeRuntime)
+    : null;
+  return { management, edgeRuntime };
+}

--- a/packages/management-api/src/release-manifest.ts
+++ b/packages/management-api/src/release-manifest.ts
@@ -1,0 +1,203 @@
+export const RELEASE_MANIFEST_NAME = "SUPACLOUD-RELEASE.json";
+export const RELEASE_ATTESTATION_NAME = "SUPACLOUD-RELEASE.attestation.jsonl";
+export const RELEASE_CHECKSUMS_NAME = "SHA256SUMS";
+export const RELEASE_REPOSITORY = "zuohuadong/supacloud";
+export const RELEASE_SOURCE_REF = "refs/heads/main";
+export const RELEASE_SIGNER_WORKFLOW = `${RELEASE_REPOSITORY}/.github/workflows/release-please.yml`;
+const MEBIBYTE = 1024 * 1024;
+
+export const RELEASE_BUNDLE_SIZE_LIMITS = {
+  manifest: MEBIBYTE,
+  checksums: MEBIBYTE,
+  attestation: 32 * MEBIBYTE,
+  managementBinary: 160 * MEBIBYTE,
+  edgeRuntimeBinary: 160 * MEBIBYTE,
+  webConsole: 64 * MEBIBYTE,
+  caddy: 96 * MEBIBYTE,
+  total: 384 * MEBIBYTE,
+} as const;
+
+export type ReleaseComponent = "management-api" | "edge-runtime";
+
+const RELEASE_ASSETS: Record<ReleaseComponent, readonly string[]> = {
+  "management-api": [
+    "SHA256SUMS",
+    "SHA256SUMS.caddy",
+    "supacloud-caddy-linux-amd64",
+    "supacloud-caddy-linux-arm64",
+    "supacloud-linux-amd64",
+    "supacloud-linux-arm64",
+    "supacloud-macos-amd64",
+    "supacloud-macos-arm64",
+    "web-console-build.tar.gz",
+  ],
+  "edge-runtime": [
+    "SHA256SUMS",
+    "supacloud-edge-runtime-linux-amd64",
+    "supacloud-edge-runtime-linux-arm64",
+    "supacloud-edge-runtime-macos-amd64",
+    "supacloud-edge-runtime-macos-arm64",
+  ],
+};
+
+export type ReleaseManifestArtifact = {
+  name: string;
+  sha256: string;
+  size: number;
+};
+
+export type ReleaseManifest = {
+  schemaVersion: 1;
+  repository: typeof RELEASE_REPOSITORY;
+  source: {
+    ref: typeof RELEASE_SOURCE_REF;
+    commit: string;
+  };
+  workflow: typeof RELEASE_SIGNER_WORKFLOW;
+  release: {
+    component: ReleaseComponent;
+    version: string;
+    tag: string;
+  };
+  artifacts: ReleaseManifestArtifact[];
+};
+
+export type ExpectedReleaseManifest = {
+  component: ReleaseComponent;
+  version: string;
+};
+
+function manifestObject(candidate: unknown, label: string): Record<string, unknown> {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return candidate as Record<string, unknown>;
+}
+
+function assertExactKeys(record: Record<string, unknown>, keys: string[], label: string): void {
+  const actual = Object.keys(record).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error(`${label} contains unsupported or missing fields`);
+  }
+}
+
+function exactStableVersion(version: unknown): string {
+  if (typeof version !== "string" || !/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error("Release manifest version must be an exact stable version");
+  }
+  return version;
+}
+
+export function releaseTag(component: ReleaseComponent, version: string): string {
+  exactStableVersion(version);
+  return `${component}-v${version}`;
+}
+
+export function releaseAssetNames(component: ReleaseComponent): readonly string[] {
+  return RELEASE_ASSETS[component];
+}
+
+export function releaseAssetSizeLimit(component: ReleaseComponent, name: string): number {
+  if (name === "SHA256SUMS" || name === "SHA256SUMS.caddy") {
+    return RELEASE_BUNDLE_SIZE_LIMITS.checksums;
+  }
+  if (name === "web-console-build.tar.gz") return RELEASE_BUNDLE_SIZE_LIMITS.webConsole;
+  if (name.startsWith("supacloud-caddy-")) return RELEASE_BUNDLE_SIZE_LIMITS.caddy;
+  return component === "management-api"
+    ? RELEASE_BUNDLE_SIZE_LIMITS.managementBinary
+    : RELEASE_BUNDLE_SIZE_LIMITS.edgeRuntimeBinary;
+}
+
+function parseSource(candidate: unknown): ReleaseManifest["source"] {
+  const source = manifestObject(candidate, "Release manifest source");
+  assertExactKeys(source, ["ref", "commit"], "Release manifest source");
+  if (source.ref !== RELEASE_SOURCE_REF || typeof source.commit !== "string"
+    || !/^[0-9a-f]{40}$/.test(source.commit)) {
+    throw new Error("Release manifest source is invalid");
+  }
+  return { ref: RELEASE_SOURCE_REF, commit: source.commit };
+}
+
+function parseRelease(candidate: unknown, expected: ExpectedReleaseManifest): ReleaseManifest["release"] {
+  const release = manifestObject(candidate, "Release manifest release");
+  assertExactKeys(release, ["component", "version", "tag"], "Release manifest release");
+  const version = exactStableVersion(release.version);
+  if (release.component !== expected.component || version !== expected.version
+    || release.tag !== releaseTag(expected.component, expected.version)) {
+    throw new Error("Release manifest component, version, or tag does not match the requested release");
+  }
+  return { component: expected.component, version, tag: release.tag as string };
+}
+
+function parseArtifact(candidate: unknown, index: number): ReleaseManifestArtifact {
+  const artifact = manifestObject(candidate, `Release manifest artifact ${index}`);
+  assertExactKeys(artifact, ["name", "sha256", "size"], `Release manifest artifact ${index}`);
+  if (typeof artifact.name !== "string" || !/^[A-Za-z0-9._-]+$/.test(artifact.name)
+    || typeof artifact.sha256 !== "string" || !/^[0-9a-f]{64}$/.test(artifact.sha256)
+    || !Number.isSafeInteger(artifact.size) || (artifact.size as number) <= 0) {
+    throw new Error(`Release manifest artifact ${index} is invalid`);
+  }
+  return artifact as ReleaseManifestArtifact;
+}
+
+function parseArtifacts(candidate: unknown, component: ReleaseComponent): ReleaseManifestArtifact[] {
+  if (!Array.isArray(candidate)) throw new Error("Release manifest artifacts must be an array");
+  const artifacts = candidate.map(parseArtifact);
+  const expectedNames = releaseAssetNames(component);
+  const actualNames = artifacts.map((artifact) => artifact.name);
+  if (actualNames.length !== expectedNames.length
+    || actualNames.some((name, index) => name !== expectedNames[index])) {
+    throw new Error(`Release manifest artifacts do not match the ${component} allowlist`);
+  }
+  const oversized = artifacts.find((artifact) => artifact.size > releaseAssetSizeLimit(component, artifact.name));
+  if (oversized) throw new Error(`Release manifest artifact ${oversized.name} exceeds its size limit`);
+  return artifacts;
+}
+
+export function parseReleaseManifest(text: string, expected: ExpectedReleaseManifest): ReleaseManifest {
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(text);
+  } catch {
+    throw new Error("Release manifest is not valid JSON");
+  }
+  const manifest = manifestObject(candidate, "Release manifest");
+  assertExactKeys(manifest, ["schemaVersion", "repository", "source", "workflow", "release", "artifacts"], "Release manifest");
+  if (manifest.schemaVersion !== 1 || manifest.repository !== RELEASE_REPOSITORY
+    || manifest.workflow !== RELEASE_SIGNER_WORKFLOW) {
+    throw new Error("Release manifest identity is invalid");
+  }
+  return {
+    schemaVersion: 1,
+    repository: RELEASE_REPOSITORY,
+    source: parseSource(manifest.source),
+    workflow: RELEASE_SIGNER_WORKFLOW,
+    release: parseRelease(manifest.release, expected),
+    artifacts: parseArtifacts(manifest.artifacts, expected.component),
+  };
+}
+
+export function manifestArtifact(manifest: ReleaseManifest, name: string): ReleaseManifestArtifact {
+  const artifact = manifest.artifacts.find((candidate) => candidate.name === name);
+  if (!artifact) throw new Error(`Release manifest does not contain ${name}`);
+  return artifact;
+}
+
+export function parseReleaseChecksums(text: string, manifest: ReleaseManifest): Map<string, string> {
+  const lines = text.endsWith("\n") ? text.slice(0, -1).split("\n") : text.split("\n");
+  const expectedNames = releaseAssetNames(manifest.release.component)
+    .filter((name) => name !== RELEASE_CHECKSUMS_NAME);
+  if (lines.length !== expectedNames.length) throw new Error("SHA256SUMS has an unexpected number of entries");
+  const checksums = new Map<string, string>();
+  lines.forEach((line, index) => {
+    const match = line.match(/^([0-9a-f]{64})  ([A-Za-z0-9._-]+)$/);
+    if (!match || match[2] !== expectedNames[index]) throw new Error("SHA256SUMS is not strict or sorted");
+    const [digest, name] = [match[1] as string, match[2] as string];
+    if (manifestArtifact(manifest, name).sha256 !== digest) {
+      throw new Error(`SHA256SUMS and release manifest disagree for ${name}`);
+    }
+    checksums.set(name, digest);
+  });
+  return checksums;
+}

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -7,11 +7,19 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { logger } from "./utils/logger";
 import { WEB_CONSOLE_CURRENT_DIR } from "./utils/web-console-path";
 import { hasSecretEncryptionCheckpoint } from "./db/secret-key-migration";
+import {
+    RELEASE_REPOSITORY,
+    RELEASE_SIGNER_WORKFLOW,
+    RELEASE_SOURCE_REF,
+    manifestArtifact,
+} from "./release-manifest";
+import {
+    loadOfflineUpgradeBundle,
+    type OfflineReleaseBundle,
+    type OfflineUpgradeBundle,
+} from "./offline-upgrade-bundle";
 
 const RELEASES_API = "https://api.github.com/repos/zuohuadong/supacloud/releases";
-const RELEASE_REPOSITORY = "zuohuadong/supacloud";
-const RELEASE_SIGNER_WORKFLOW = `${RELEASE_REPOSITORY}/.github/workflows/release-please.yml`;
-const RELEASE_SOURCE_REF = "refs/heads/main";
 const BIN_TARGET = "/usr/local/bin/supacloud";
 const MANAGEMENT_SERVICE_UNIT = "supacloud.service";
 const EDGE_RUNTIME_SERVICE_UNIT = "supacloud-edge-runtime.service";
@@ -40,6 +48,10 @@ const DEFAULT_EDGE_RESOURCE_RATIO = 0.6;
 const DEFAULT_EDGE_TASKS_MAX = 256;
 const WEB_CONSOLE_DIR_ENV_KEY = "WEB_CONSOLE_DIR";
 const LINUX_ACCOUNT_NAME = /^[a-z_][a-z0-9_-]{0,30}\$?$/;
+const OFFLINE_BUNDLE_ENDPOINT: GithubEndpoint = {
+    label: "verified offline bundle",
+    proxyPrefix: "",
+};
 
 type GithubEndpoint = {
     label: string;
@@ -216,6 +228,14 @@ export function normalizeManagementReleaseTag(tag: string) {
     if (trimmed.startsWith("management-api-v")) return trimmed;
     if (trimmed.startsWith("v")) return `management-api-${trimmed}`;
     return `management-api-v${trimmed}`;
+}
+
+export function normalizeExactManagementVersion(tag: string): string {
+    const version = tag.trim().replace(/^management-api-v/, "").replace(/^v/, "");
+    if (!/^\d+\.\d+\.\d+$/.test(version)) {
+        throw new Error("An exact stable Management API version is required for an offline bundle");
+    }
+    return version;
 }
 
 export function normalizeEdgeRuntimeReleaseTag(tag: string) {
@@ -959,7 +979,7 @@ export function resolveArtifactVerificationMode(
 export function supportsGithubOfflineAttestationVerification(exitCode: number, helpText: string): boolean {
     const helpTokens = helpText.split(/\s+/);
     return exitCode === 0
-        && ["--bundle", "--signer-workflow", "--source-ref"].every(flag => (
+        && ["--bundle", "--signer-workflow", "--source-ref", "--deny-self-hosted-runners"].every(flag => (
             helpTokens.some(token => token === flag || token.startsWith(`${flag}=`))
         ));
 }
@@ -1024,6 +1044,7 @@ async function runGithubAttestationVerification(filePath: string, bundlePath: st
         "--repo", RELEASE_REPOSITORY,
         "--signer-workflow", RELEASE_SIGNER_WORKFLOW,
         "--source-ref", RELEASE_SOURCE_REF,
+        "--deny-self-hosted-runners",
     ]);
     if (verification.exitCode !== 0) {
         throw new Error(`GitHub artifact attestation verification failed: ${verification.stderr.slice(-500)}`);
@@ -1092,11 +1113,41 @@ async function validateElfBinaryArtifact(filePath: string, binaryName: string) {
     await $`chmod 0755 ${filePath}`;
 }
 
-async function validateManagementBinaryArtifact(filePath: string, binaryName: string) {
+export function parseManagementVersionOutput(stdout: string): string {
+    const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+    if (lines.length !== 1) throw new Error("Management --version output must contain exactly one line");
+    let message = lines[0] as string;
+    if (message.startsWith("{")) {
+        const payload = JSON.parse(message) as { message?: unknown };
+        if (typeof payload.message !== "string") throw new Error("Management --version JSON is invalid");
+        message = payload.message;
+    }
+    const match = message.match(/^SupaCloud Version: (\d+\.\d+\.\d+)$/);
+    if (!match) throw new Error("Management --version output is invalid");
+    return match[1] as string;
+}
+
+async function validateManagementBinaryArtifact(filePath: string, binaryName: string, expectedVersion: string) {
     await validateElfBinaryArtifact(filePath, binaryName);
     const smoke = Bun.spawn([filePath, "--version"], { stdout: "pipe", stderr: "pipe" });
-    if (await smoke.exited !== 0) {
+    const timeout = setTimeout(() => smoke.kill("SIGKILL"), 5_000);
+    let smokeOutput: [number, string, string];
+    try {
+        smokeOutput = await Promise.all([
+            smoke.exited,
+            new Response(smoke.stdout).text(),
+            new Response(smoke.stderr).text(),
+        ]);
+    } finally {
+        clearTimeout(timeout);
+    }
+    const [exitCode, stdout, stderr] = smokeOutput;
+    if (exitCode !== 0 || stderr.trim()) {
         throw new Error(`${binaryName} failed the --version smoke check`);
+    }
+    const actualVersion = parseManagementVersionOutput(stdout);
+    if (actualVersion !== expectedVersion) {
+        throw new Error(`${binaryName} reports ${actualVersion}; expected ${expectedVersion}`);
     }
 }
 
@@ -1149,37 +1200,57 @@ async function stageBinary(request: StageBinaryRequest): Promise<StagedBinary> {
     }
 }
 
+type StageBundledBinaryRequest = {
+    sourcePath: string;
+    binaryName: string;
+    expectedSha256: string;
+    targetPath: string;
+    validate: (filePath: string, binaryName: string) => Promise<void>;
+};
+
+async function stageBundledBinary(request: StageBundledBinaryRequest): Promise<StagedBinary> {
+    const stagedBinary = `${request.targetPath}.new-${process.pid}`;
+    try {
+        copyFileSync(request.sourcePath, stagedBinary);
+        chmodSync(stagedBinary, 0o755);
+        await request.validate(stagedBinary, request.binaryName);
+        const stagedSha256 = sha256File(stagedBinary);
+        if (stagedSha256 !== request.expectedSha256) {
+            throw new Error(`SHA256 mismatch for staged ${request.binaryName}`);
+        }
+        return { path: stagedBinary, endpoint: OFFLINE_BUNDLE_ENDPOINT, sha256: stagedSha256 };
+    } catch (error: unknown) {
+        rmSync(stagedBinary, { force: true });
+        throw error;
+    }
+}
+
 type StagedWebConsole = {
     releaseDir: string;
     endpoint: GithubEndpoint;
 };
 
-async function stageWebConsoleBuild(
-    downloadUrl: string,
+async function validateWebConsoleArchive(archivePath: string): Promise<void> {
+    const listed = await $`tar -tzf ${archivePath}`.nothrow().quiet();
+    if (listed.exitCode !== 0) throw new Error(`${WEB_CONSOLE_ASSET} is not a readable gzip tarball`);
+    validateWebConsoleArchiveEntries(listed.stdout.toString());
+    const verboseListing = await $`tar -tvzf ${archivePath}`.nothrow().quiet();
+    const hasUnsafeEntry = verboseListing.stdout.toString().split(/\r?\n/)
+        .filter(Boolean).some(line => !["-", "d"].includes(line[0] || ""));
+    if (verboseListing.exitCode !== 0 || hasUnsafeEntry) {
+        throw new Error(`${WEB_CONSOLE_ASSET} contains links or special files`);
+    }
+}
+
+async function extractWebConsoleArchive(
+    archivePath: string,
     version: string,
-    checksums: string,
-    preferredEndpoint: GithubEndpoint,
-    forceYes?: boolean,
+    endpoint: GithubEndpoint,
 ): Promise<StagedWebConsole> {
     const safeVersion = version.replace(/[^a-zA-Z0-9._-]/g, "_");
-    const archivePath = path.join(os.tmpdir(), `${WEB_CONSOLE_ASSET}-${Date.now()}`);
     const releaseDir = path.join(WEB_CONSOLE_RELEASES_DIR, `${safeVersion}-${process.pid}-${Date.now()}`);
-
     try {
-        const endpoint = await downloadAsset(downloadUrl, archivePath, preferredEndpoint, forceYes);
-        verifyArtifactChecksum(archivePath, WEB_CONSOLE_ASSET, checksums);
-        await verifyArtifactAttestation({ filePath: archivePath, forceYes });
-
-        const listed = await $`tar -tzf ${archivePath}`.nothrow().quiet();
-        if (listed.exitCode !== 0) {
-            throw new Error(`${WEB_CONSOLE_ASSET} is not a readable gzip tarball`);
-        }
-        validateWebConsoleArchiveEntries(listed.stdout.toString());
-        const verboseListing = await $`tar -tvzf ${archivePath}`.nothrow().quiet();
-        if (verboseListing.exitCode !== 0 || verboseListing.stdout.toString().split(/\r?\n/).filter(Boolean).some(line => !["-", "d"].includes(line[0] || ""))) {
-            throw new Error(`${WEB_CONSOLE_ASSET} contains links or special files`);
-        }
-
+        await validateWebConsoleArchive(archivePath);
         await $`rm -rf ${releaseDir}`.nothrow().quiet();
         await $`mkdir -p ${releaseDir} ${WEB_CONSOLE_RELEASES_DIR}`;
         const extract = await $`tar --no-same-owner --no-same-permissions -xzf ${archivePath} -C ${releaseDir}`.nothrow().quiet();
@@ -1189,11 +1260,31 @@ async function stageWebConsoleBuild(
         if (!existsSync(path.join(releaseDir, "index.html"))) {
             throw new Error(`${WEB_CONSOLE_ASSET} is invalid: index.html not found at archive root`);
         }
-
         return { releaseDir, endpoint };
     } catch (error: unknown) {
         await $`rm -rf ${releaseDir}`.nothrow().quiet();
         throw error;
+    }
+}
+
+type StageWebConsoleBuildRequest = {
+    downloadUrl: string;
+    version: string;
+    checksums: string;
+    preferredEndpoint: GithubEndpoint;
+    forceYes?: boolean;
+};
+
+async function stageWebConsoleBuild(request: StageWebConsoleBuildRequest): Promise<StagedWebConsole> {
+    const archivePath = path.join(os.tmpdir(), `${WEB_CONSOLE_ASSET}-${Date.now()}`);
+
+    try {
+        const endpoint = await downloadAsset(
+            request.downloadUrl, archivePath, request.preferredEndpoint, request.forceYes,
+        );
+        verifyArtifactChecksum(archivePath, WEB_CONSOLE_ASSET, request.checksums);
+        await verifyArtifactAttestation({ filePath: archivePath, forceYes: request.forceYes });
+        return await extractWebConsoleArchive(archivePath, request.version, endpoint);
     } finally {
         await $`rm -f ${archivePath}`.nothrow().quiet();
     }
@@ -1750,6 +1841,7 @@ type RunUpgradeOptions = {
     forceYes?: boolean;
     targetVersion?: string;
     edgeRuntimeVersion?: string;
+    assetBundleDir?: string;
 };
 
 type EdgeRuntimeUpgradePlan = {
@@ -1771,6 +1863,7 @@ type UpgradeReleasePlan = {
     binaryName: string;
     endpoint: GithubEndpoint;
     edgeRuntime: EdgeRuntimeUpgradePlan | null;
+    offlineBundle: OfflineUpgradeBundle | null;
     release: GithubRelease;
     remoteVersion: string;
 };
@@ -1908,12 +2001,63 @@ async function resolveEdgeRuntimeUpgradePlan(
     };
 }
 
+function offlineReleaseMetadata(bundle: OfflineReleaseBundle): GithubRelease {
+    return {
+        tag_name: bundle.manifest.release.tag,
+        draft: false,
+        prerelease: false,
+        assets: [...bundle.assetPaths.keys()].map(name => ({ name })),
+    };
+}
+
+async function resolveOfflineUpgradeReleasePlan(
+    options: RunUpgradeOptions,
+    binaryName: string,
+    edgePreflight: ActiveSystemdBinary | null,
+    requestedEdgeVersion: string,
+): Promise<UpgradeReleasePlan> {
+    const requestedManagementVersion = options.targetVersion
+        || process.env.SUPACLOUD_UPGRADE_TAG
+        || process.env.SUPACLOUD_UPGRADE_VERSION
+        || "";
+    const managementVersion = normalizeExactManagementVersion(requestedManagementVersion);
+    const edgeVersion = requestedEdgeVersion
+        ? normalizeEdgeRuntimeReleaseTag(requestedEdgeVersion).slice("edge-runtime-v".length)
+        : "";
+    const offlineBundle = await loadOfflineUpgradeBundle({
+        assetBundleDir: options.assetBundleDir as string,
+        management: { version: managementVersion, binaryName },
+        ...(edgePreflight ? {
+            edgeRuntime: { version: edgeVersion, binaryName: resolveEdgeRuntimeBinaryName(binaryName) },
+        } : {}),
+    });
+    recordIntegrityMode("github-attestation+same-release-sha256");
+    const edgeRuntime = edgePreflight && offlineBundle.edgeRuntime ? {
+        binaryName: resolveEdgeRuntimeBinaryName(binaryName),
+        enabledState: await readSystemdEnabledState(EDGE_RUNTIME_SERVICE_UNIT),
+        endpoint: OFFLINE_BUNDLE_ENDPOINT,
+        release: offlineReleaseMetadata(offlineBundle.edgeRuntime),
+        targetPath: edgePreflight.execStartPath,
+    } : null;
+    return {
+        binaryName,
+        endpoint: OFFLINE_BUNDLE_ENDPOINT,
+        edgeRuntime,
+        offlineBundle,
+        release: offlineReleaseMetadata(offlineBundle.management),
+        remoteVersion: offlineBundle.management.manifest.release.tag,
+    };
+}
+
 async function resolveUpgradeReleasePlan(options: RunUpgradeOptions): Promise<UpgradeReleasePlan> {
     const requestedEdgeVersion = options.edgeRuntimeVersion
         || process.env.SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG
         || "";
     const edgePreflight = await inspectEdgeRuntimeUpgradeTarget(requestedEdgeVersion);
     const binaryName = resolveLinuxBinaryName();
+    if (options.assetBundleDir) {
+        return resolveOfflineUpgradeReleasePlan(options, binaryName, edgePreflight, requestedEdgeVersion);
+    }
     const metadata = await fetchGithubApiJson(resolveReleaseApiUrl(options.targetVersion), options.forceYes);
     const release = selectManagementRelease(metadata.data as GithubRelease | GithubRelease[], binaryName);
     const edgeRuntime = await resolveEdgeRuntimeUpgradePlan({
@@ -1922,7 +2066,14 @@ async function resolveUpgradeReleasePlan(options: RunUpgradeOptions): Promise<Up
         preflight: edgePreflight,
         requestedVersion: requestedEdgeVersion,
     });
-    return { binaryName, endpoint: metadata.endpoint, edgeRuntime, release, remoteVersion: release.tag_name || "unknown" };
+    return {
+        binaryName,
+        endpoint: metadata.endpoint,
+        edgeRuntime,
+        offlineBundle: null,
+        release,
+        remoteVersion: release.tag_name || "unknown",
+    };
 }
 
 function upgradeConfirmationMessage(plan: UpgradeReleasePlan): string {
@@ -1959,10 +2110,12 @@ async function createUpgradeExecutionContext(
     spinner: ReturnType<typeof p.spinner>,
 ): Promise<UpgradeExecutionContext> {
     const preparedSecrets = prepareUpgradeSecrets(await resolveUpgradeEnvironment());
-    const checksums = await downloadReleaseChecksums(plan.release, plan.endpoint, options.forceYes);
-    const edgeRuntimeChecksums = plan.edgeRuntime
-        ? await downloadReleaseChecksums(plan.edgeRuntime.release, plan.edgeRuntime.endpoint, options.forceYes)
-        : null;
+    const checksums = plan.offlineBundle?.management.checksums
+        ?? await downloadReleaseChecksums(plan.release, plan.endpoint, options.forceYes);
+    const edgeRuntimeChecksums = plan.offlineBundle?.edgeRuntime?.checksums
+        ?? (plan.edgeRuntime
+            ? await downloadReleaseChecksums(plan.edgeRuntime.release, plan.edgeRuntime.endpoint, options.forceYes)
+            : null);
     return {
         checksums,
         edgeRuntimeChecksums,
@@ -1986,47 +2139,82 @@ async function verifyUpgradePreflight(context: UpgradeExecutionContext): Promise
     }
 }
 
+function offlineAssetPath(bundle: OfflineReleaseBundle, name: string): string {
+    const assetPath = bundle.assetPaths.get(name);
+    if (!assetPath) throw new Error(`Offline release bundle does not contain ${name}`);
+    return assetPath;
+}
+
 async function stageManagementUpgrade(context: UpgradeExecutionContext): Promise<void> {
     const { plan, state } = context;
-    context.spinner.start(`Downloading, verifying, and staging ${plan.binaryName}`);
-    state.stagedManagement = await stageBinary({
-        downloadUrl: releaseAssetUrl(plan.release, plan.binaryName),
-        binaryName: plan.binaryName,
-        checksums: context.checksums,
-        preferredEndpoint: plan.endpoint,
-        targetPath: BIN_TARGET,
-        validate: validateManagementBinaryArtifact,
-        forceYes: context.options.forceYes,
-    });
+    context.spinner.start(`Verifying and staging ${plan.binaryName}`);
+    const offlineRelease = plan.offlineBundle?.management;
+    const expectedVersion = normalizeExactManagementVersion(plan.remoteVersion);
+    const validateManagementReleaseBinary = (filePath: string, binaryName: string) => (
+        validateManagementBinaryArtifact(filePath, binaryName, expectedVersion)
+    );
+    state.stagedManagement = offlineRelease
+        ? await stageBundledBinary({
+            sourcePath: offlineAssetPath(offlineRelease, plan.binaryName),
+            binaryName: plan.binaryName,
+            expectedSha256: manifestArtifact(offlineRelease.manifest, plan.binaryName).sha256,
+            targetPath: BIN_TARGET,
+            validate: validateManagementReleaseBinary,
+        })
+        : await stageBinary({
+            downloadUrl: releaseAssetUrl(plan.release, plan.binaryName),
+            binaryName: plan.binaryName,
+            checksums: context.checksums,
+            preferredEndpoint: plan.endpoint,
+            targetPath: BIN_TARGET,
+            validate: validateManagementReleaseBinary,
+            forceYes: context.options.forceYes,
+        });
     state.downloadEndpointLabel = state.stagedManagement.endpoint.label;
 }
 
 async function stageEdgeRuntimeUpgrade(context: UpgradeExecutionContext): Promise<void> {
     const edgeRuntime = context.plan.edgeRuntime;
     if (!edgeRuntime || !context.edgeRuntimeChecksums) return;
-    context.spinner.start(`Downloading, verifying, and staging ${edgeRuntime.binaryName}`);
-    context.state.stagedEdgeRuntime = await stageBinary({
-        downloadUrl: releaseAssetUrl(edgeRuntime.release, edgeRuntime.binaryName),
-        binaryName: edgeRuntime.binaryName,
-        checksums: context.edgeRuntimeChecksums,
-        preferredEndpoint: edgeRuntime.endpoint,
-        targetPath: edgeRuntime.targetPath,
-        validate: validateElfBinaryArtifact,
-        forceYes: context.options.forceYes,
-    });
+    context.spinner.start(`Verifying and staging ${edgeRuntime.binaryName}`);
+    const offlineRelease = context.plan.offlineBundle?.edgeRuntime;
+    context.state.stagedEdgeRuntime = offlineRelease
+        ? await stageBundledBinary({
+            sourcePath: offlineAssetPath(offlineRelease, edgeRuntime.binaryName),
+            binaryName: edgeRuntime.binaryName,
+            expectedSha256: manifestArtifact(offlineRelease.manifest, edgeRuntime.binaryName).sha256,
+            targetPath: edgeRuntime.targetPath,
+            validate: validateElfBinaryArtifact,
+        })
+        : await stageBinary({
+            downloadUrl: releaseAssetUrl(edgeRuntime.release, edgeRuntime.binaryName),
+            binaryName: edgeRuntime.binaryName,
+            checksums: context.edgeRuntimeChecksums,
+            preferredEndpoint: edgeRuntime.endpoint,
+            targetPath: edgeRuntime.targetPath,
+            validate: validateElfBinaryArtifact,
+            forceYes: context.options.forceYes,
+        });
     context.state.edgeRuntimeEndpointLabel = context.state.stagedEdgeRuntime.endpoint.label;
 }
 
 async function stageWebConsoleUpgrade(context: UpgradeExecutionContext): Promise<void> {
     const { plan, state } = context;
-    context.spinner.start(`Downloading, verifying, and staging ${WEB_CONSOLE_ASSET}`);
-    state.stagedWebConsole = await stageWebConsoleBuild(
-        releaseAssetUrl(plan.release, WEB_CONSOLE_ASSET),
-        plan.remoteVersion,
-        context.checksums,
-        plan.endpoint,
-        context.options.forceYes,
-    );
+    context.spinner.start(`Verifying and staging ${WEB_CONSOLE_ASSET}`);
+    const offlineRelease = plan.offlineBundle?.management;
+    state.stagedWebConsole = offlineRelease
+        ? await extractWebConsoleArchive(
+            offlineAssetPath(offlineRelease, WEB_CONSOLE_ASSET),
+            plan.remoteVersion,
+            OFFLINE_BUNDLE_ENDPOINT,
+        )
+        : await stageWebConsoleBuild({
+            downloadUrl: releaseAssetUrl(plan.release, WEB_CONSOLE_ASSET),
+            version: plan.remoteVersion,
+            checksums: context.checksums,
+            preferredEndpoint: plan.endpoint,
+            forceYes: context.options.forceYes,
+        });
     state.webConsoleEndpointLabel = state.stagedWebConsole.endpoint.label;
 }
 
@@ -2259,7 +2447,9 @@ export async function runUpgrade(options: RunUpgradeOptions = {}) {
     p.intro("\x1b[46m SupaCloud Binary Upgrade \x1b[0m");
 
     const s = p.spinner();
-    s.start("Retrieving GitHub release metadata");
+    s.start(options.assetBundleDir
+        ? "Verifying the protected offline release bundle"
+        : "Retrieving GitHub release metadata");
     let executionContext: UpgradeExecutionContext | null = null;
 
     try {

--- a/packages/management-api/tests/unit/offline-upgrade-bundle.test.ts
+++ b/packages/management-api/tests/unit/offline-upgrade-bundle.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  truncateSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assertExactBundleMode,
+  loadOfflineUpgradeBundle,
+  runGithubCliWithTimeout,
+} from "../../src/offline-upgrade-bundle";
+import {
+  RELEASE_ATTESTATION_NAME,
+  RELEASE_BUNDLE_SIZE_LIMITS,
+  RELEASE_CHECKSUMS_NAME,
+  RELEASE_MANIFEST_NAME,
+  RELEASE_REPOSITORY,
+  RELEASE_SIGNER_WORKFLOW,
+  RELEASE_SOURCE_REF,
+  type ReleaseComponent,
+  type ReleaseManifest,
+  releaseAssetNames,
+  releaseTag,
+} from "../../src/release-manifest";
+
+const originalPath = process.env.PATH;
+const originalFetch = globalThis.fetch;
+const fixtureRoots: string[] = [];
+const owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+const managementVersion = "9.8.7";
+const edgeVersion = "1.2.3";
+const managementBinary = "supacloud-linux-amd64";
+const edgeBinary = "supacloud-edge-runtime-linux-amd64";
+
+type BundleFixture = {
+  root: string;
+  recordPath: string;
+  managementDir: string;
+  edgeDir: string;
+};
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+  delete process.env.GH_OFFLINE_RECORD;
+  globalThis.fetch = originalFetch;
+  for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function writeSecureFile(filePath: string, content: string): void {
+  writeFileSync(filePath, content, { mode: 0o600 });
+  chmodSync(filePath, 0o600);
+}
+
+function releaseAssetContent(component: ReleaseComponent, version: string, name: string): string {
+  return `${component}:${version}:${name}\n`;
+}
+
+function manifestFixture(component: ReleaseComponent, version: string, commit: string): {
+  manifest: ReleaseManifest;
+  checksums: string;
+} {
+  const nonChecksumArtifacts = releaseAssetNames(component)
+    .filter((name) => name !== RELEASE_CHECKSUMS_NAME)
+    .map((name) => {
+      const content = releaseAssetContent(component, version, name);
+      return { name, sha256: sha256(content), size: Buffer.byteLength(content) };
+    });
+  const checksums = `${nonChecksumArtifacts.map(({ name, sha256 }) => `${sha256}  ${name}`).join("\n")}\n`;
+  const checksumArtifact = {
+    name: RELEASE_CHECKSUMS_NAME,
+    sha256: sha256(checksums),
+    size: Buffer.byteLength(checksums),
+  };
+  const artifacts = [checksumArtifact, ...nonChecksumArtifacts]
+    .sort((left, right) => left.name.localeCompare(right.name, "en"));
+  return {
+    manifest: {
+      schemaVersion: 1,
+      repository: RELEASE_REPOSITORY,
+      source: { ref: RELEASE_SOURCE_REF, commit },
+      workflow: RELEASE_SIGNER_WORKFLOW,
+      release: { component, version, tag: releaseTag(component, version) },
+      artifacts,
+    },
+    checksums,
+  };
+}
+
+function writeComponentBundle(
+  root: string,
+  component: ReleaseComponent,
+  version: string,
+  binaryName: string,
+  commit: string,
+): string {
+  const directory = join(root, component);
+  mkdirSync(directory, { mode: 0o700 });
+  chmodSync(directory, 0o700);
+  const { manifest, checksums } = manifestFixture(component, version, commit);
+  writeSecureFile(join(directory, RELEASE_MANIFEST_NAME), `${JSON.stringify(manifest)}\n`);
+  writeSecureFile(join(directory, RELEASE_ATTESTATION_NAME), '{"mediaType":"sigstore"}\n');
+  writeSecureFile(join(directory, RELEASE_CHECKSUMS_NAME), checksums);
+  writeSecureFile(join(directory, binaryName), releaseAssetContent(component, version, binaryName));
+  if (component === "management-api") {
+    writeSecureFile(
+      join(directory, "web-console-build.tar.gz"),
+      releaseAssetContent(component, version, "web-console-build.tar.gz"),
+    );
+  }
+  return directory;
+}
+
+function installFakeGithubCli(root: string): string {
+  const binDirectory = join(root, "bin");
+  mkdirSync(binDirectory, { mode: 0o700 });
+  const executable = join(binDirectory, "gh");
+  writeFileSync(executable, [
+    "#!/bin/sh",
+    'if [ "$1 $2 $3" = "attestation verify --help" ]; then',
+    '  printf "%s\\n" "--bundle --signer-workflow --source-ref --source-digest --deny-self-hosted-runners"',
+    "  exit 0",
+    "fi",
+    'printf "%s\\n" "$*" >> "$GH_OFFLINE_RECORD"',
+    "exit 0",
+    "",
+  ].join("\n"));
+  chmodSync(executable, 0o755);
+  process.env.PATH = `${binDirectory}:${originalPath ?? ""}`;
+  return join(root, "gh-calls.txt");
+}
+
+function bundleFixture(): BundleFixture {
+  const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-offline-bundle-")));
+  fixtureRoots.push(fixtureRoot);
+  const root = join(fixtureRoot, "bundle");
+  mkdirSync(root, { mode: 0o700 });
+  chmodSync(root, 0o700);
+  const commit = "a".repeat(40);
+  const managementDir = writeComponentBundle(root, "management-api", managementVersion, managementBinary, commit);
+  const edgeDir = writeComponentBundle(root, "edge-runtime", edgeVersion, edgeBinary, commit);
+  const recordPath = installFakeGithubCli(fixtureRoot);
+  process.env.GH_OFFLINE_RECORD = recordPath;
+  return { root, recordPath, managementDir, edgeDir };
+}
+
+function loadFixture(fixture: BundleFixture) {
+  return loadOfflineUpgradeBundle({
+    assetBundleDir: fixture.root,
+    management: { version: managementVersion, binaryName: managementBinary },
+    edgeRuntime: { version: edgeVersion, binaryName: edgeBinary },
+  });
+}
+
+describe("offline upgrade bundle", () => {
+  test("verifies the exact local bundle without calling fetch", async () => {
+    const fixture = bundleFixture();
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      throw new Error("offline bundle must not call fetch");
+    }) as typeof fetch;
+    const bundle = await loadFixture(fixture);
+    expect(fetchCalls).toBe(0);
+    expect(bundle.management.manifest.release.version).toBe(managementVersion);
+    expect(bundle.edgeRuntime?.manifest.release.version).toBe(edgeVersion);
+    const calls = readFileSync(fixture.recordPath, "utf8").trim().split("\n");
+    expect(calls).toHaveLength(7);
+    for (const call of calls) {
+      expect(call).toContain("--bundle");
+      expect(call).toContain("--repo zuohuadong/supacloud");
+      expect(call).toContain("--source-ref refs/heads/main");
+      expect(call).toContain(`--source-digest ${"a".repeat(40)}`);
+      expect(call).toContain("--deny-self-hosted-runners");
+    }
+  });
+
+  test("rejects extra files, unsafe modes, symlinks, hardlinks, and wrong ownership", async () => {
+    const extra = bundleFixture();
+    writeSecureFile(join(extra.root, "unexpected"), "unexpected");
+    await expect(loadFixture(extra)).rejects.toThrow("allowlist");
+
+    const unsafeMode = bundleFixture();
+    chmodSync(join(unsafeMode.managementDir, managementBinary), 0o644);
+    await expect(loadFixture(unsafeMode)).rejects.toThrow("mode must be exactly 0600");
+
+    const unsafeDirectoryMode = bundleFixture();
+    chmodSync(unsafeDirectoryMode.edgeDir, 0o755);
+    await expect(loadFixture(unsafeDirectoryMode)).rejects.toThrow("mode must be exactly 0700");
+
+    const symlink = bundleFixture();
+    const web = join(symlink.managementDir, "web-console-build.tar.gz");
+    const externalRoot = mkdtempSync(join(tmpdir(), "supacloud-bundle-link-target-"));
+    fixtureRoots.push(externalRoot);
+    const target = join(externalRoot, "web-target");
+    writeSecureFile(target, "target");
+    unlinkSync(web);
+    symlinkSync(target, web);
+    await expect(loadFixture(symlink)).rejects.toThrow("without links");
+
+    const hardlink = bundleFixture();
+    const hardlinkRoot = mkdtempSync(join(tmpdir(), "supacloud-bundle-hardlink-"));
+    fixtureRoots.push(hardlinkRoot);
+    linkSync(join(hardlink.edgeDir, edgeBinary), join(hardlinkRoot, "linked-edge"));
+    await expect(loadFixture(hardlink)).rejects.toThrow("without links");
+
+    const wrongOwner = bundleFixture();
+    const originalGeteuid = process.geteuid;
+    const originalGetegid = process.getegid;
+    try {
+      Object.defineProperty(process, "geteuid", { configurable: true, value: () => owner.uid + 1 });
+      Object.defineProperty(process, "getegid", { configurable: true, value: () => owner.gid });
+      await expect(loadOfflineUpgradeBundle({
+        assetBundleDir: wrongOwner.root,
+        management: { version: managementVersion, binaryName: managementBinary },
+      })).rejects.toThrow("must be owned");
+    } finally {
+      Object.defineProperty(process, "geteuid", { configurable: true, value: originalGeteuid });
+      Object.defineProperty(process, "getegid", { configurable: true, value: originalGetegid });
+    }
+  });
+
+  test("rejects special permission bits independently of filesystem support", () => {
+    for (const mode of [0o4600, 0o2600, 0o1600]) {
+      expect(() => assertExactBundleMode(mode, 0o600, "Bundle file"))
+        .toThrow("mode must be exactly 0600");
+    }
+    for (const mode of [0o4700, 0o2700, 0o1700]) {
+      expect(() => assertExactBundleMode(mode, 0o700, "Bundle directory"))
+        .toThrow("mode must be exactly 0700");
+    }
+    expect(() => assertExactBundleMode(0o100600, 0o600, "Bundle file")).not.toThrow();
+    expect(() => assertExactBundleMode(0o040700, 0o700, "Bundle directory")).not.toThrow();
+  });
+
+  test("rejects digest and version mixing while allowing separately released components", async () => {
+    const digestDrift = bundleFixture();
+    writeSecureFile(join(digestDrift.managementDir, managementBinary), "substituted release binary\n");
+    await expect(loadFixture(digestDrift)).rejects.toThrow("signed release manifest");
+
+    const versionDrift = bundleFixture();
+    await expect(loadOfflineUpgradeBundle({
+      assetBundleDir: versionDrift.root,
+      management: { version: "9.8.6", binaryName: managementBinary },
+      edgeRuntime: { version: edgeVersion, binaryName: edgeBinary },
+    })).rejects.toThrow("does not match");
+
+    const mixed = bundleFixture();
+    const edgeManifestPath = join(mixed.edgeDir, RELEASE_MANIFEST_NAME);
+    const edgeManifest = JSON.parse(readFileSync(edgeManifestPath, "utf8")) as ReleaseManifest;
+    edgeManifest.source.commit = "b".repeat(40);
+    writeSecureFile(edgeManifestPath, `${JSON.stringify(edgeManifest)}\n`);
+    await expect(loadFixture(mixed)).resolves.toMatchObject({
+      management: { manifest: { source: { commit: "a".repeat(40) } } },
+      edgeRuntime: { manifest: { source: { commit: "b".repeat(40) } } },
+    });
+  });
+
+  test("rejects oversized Management, Edge, Web, and total bundles before attestation", async () => {
+    const management = bundleFixture();
+    truncateSync(
+      join(management.managementDir, managementBinary),
+      RELEASE_BUNDLE_SIZE_LIMITS.managementBinary + 1,
+    );
+    await expect(loadFixture(management)).rejects.toThrow(`${managementBinary} exceeds its size limit`);
+    expect(existsSync(management.recordPath)).toBe(false);
+
+    const edge = bundleFixture();
+    truncateSync(join(edge.edgeDir, edgeBinary), RELEASE_BUNDLE_SIZE_LIMITS.edgeRuntimeBinary + 1);
+    await expect(loadFixture(edge)).rejects.toThrow(`${edgeBinary} exceeds its size limit`);
+    expect(existsSync(edge.recordPath)).toBe(false);
+
+    const web = bundleFixture();
+    truncateSync(
+      join(web.managementDir, "web-console-build.tar.gz"),
+      RELEASE_BUNDLE_SIZE_LIMITS.webConsole + 1,
+    );
+    await expect(loadFixture(web)).rejects.toThrow("web-console-build.tar.gz exceeds its size limit");
+    expect(existsSync(web.recordPath)).toBe(false);
+
+    const total = bundleFixture();
+    truncateSync(join(total.managementDir, managementBinary), RELEASE_BUNDLE_SIZE_LIMITS.managementBinary);
+    truncateSync(join(total.edgeDir, edgeBinary), RELEASE_BUNDLE_SIZE_LIMITS.edgeRuntimeBinary);
+    truncateSync(join(total.managementDir, "web-console-build.tar.gz"), RELEASE_BUNDLE_SIZE_LIMITS.webConsole);
+    await expect(loadFixture(total)).rejects.toThrow("total size limit");
+    expect(existsSync(total.recordPath)).toBe(false);
+  });
+
+  test("terminates a stuck gh verification within its per-command timeout", async () => {
+    const fixture = bundleFixture();
+    const gh = Bun.which("gh", { PATH: process.env.PATH });
+    if (!gh) throw new Error("Missing fake gh fixture");
+    writeFileSync(gh, "#!/bin/sh\nexec sleep 10\n");
+    chmodSync(gh, 0o755);
+    const startedAt = Date.now();
+    const githubTimeoutResult = await runGithubCliWithTimeout(["attestation", "verify", "--help"], 50);
+    expect(githubTimeoutResult.exitCode).toBe(124);
+    expect(githubTimeoutResult.stderr).toContain("timed out after 50ms");
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    expect(existsSync(fixture.recordPath)).toBe(false);
+  });
+});

--- a/packages/management-api/tests/unit/release-manifest.test.ts
+++ b/packages/management-api/tests/unit/release-manifest.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  RELEASE_CHECKSUMS_NAME,
+  RELEASE_BUNDLE_SIZE_LIMITS,
+  RELEASE_MANIFEST_NAME,
+  type ReleaseComponent,
+  type ReleaseManifest,
+  parseReleaseChecksums,
+  parseReleaseManifest,
+  releaseAssetNames,
+  releaseTag,
+} from "../../src/release-manifest";
+
+const repoRoot = join(import.meta.dir, "../../../..");
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function releaseFixture(component: ReleaseComponent, version = "1.2.3") {
+  const root = mkdtempSync(join(tmpdir(), `supacloud-${component}-manifest-`));
+  temporaryDirectories.push(root);
+  const assetsDir = join(root, "assets");
+  mkdirSync(assetsDir);
+  const checksums: string[] = [];
+  for (const name of releaseAssetNames(component)) {
+    if (name === RELEASE_CHECKSUMS_NAME) continue;
+    const content = `${component}:${version}:${name}\n`;
+    writeFileSync(join(assetsDir, name), content);
+    checksums.push(`${sha256(content)}  ${name}`);
+  }
+  writeFileSync(join(assetsDir, RELEASE_CHECKSUMS_NAME), `${checksums.join("\n")}\n`);
+  const packageJson = join(root, "package.json");
+  writeFileSync(packageJson, JSON.stringify({ version }));
+  return { assetsDir, packageJson, version };
+}
+
+function sourceCommit(): string {
+  const command = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repoRoot });
+  expect(command.exitCode).toBe(0);
+  return command.stdout.toString().trim();
+}
+
+function generateManifest(component: ReleaseComponent): ReleaseManifest {
+  const fixture = releaseFixture(component);
+  const command = Bun.spawnSync([
+    "bun", "run", "scripts/generate_release_manifest.ts",
+    "--component", component,
+    "--package-json", fixture.packageJson,
+    "--assets-dir", fixture.assetsDir,
+    "--tag", releaseTag(component, fixture.version),
+    "--source-commit", sourceCommit(),
+  ], { cwd: repoRoot });
+  expect(command.exitCode, command.stderr.toString()).toBe(0);
+  return parseReleaseManifest(
+    readFileSync(join(fixture.assetsDir, RELEASE_MANIFEST_NAME), "utf8"),
+    { component, version: fixture.version },
+  );
+}
+
+describe("signed release manifest", () => {
+  test("generates complete strict manifests for both independently released components", () => {
+    for (const component of ["management-api", "edge-runtime"] as const) {
+      const manifest = generateManifest(component);
+      expect(manifest.release.tag).toBe(releaseTag(component, "1.2.3"));
+      expect(manifest.artifacts.map((artifact) => artifact.name)).toEqual(releaseAssetNames(component));
+      expect(manifest.source.commit).toBe(sourceCommit());
+    }
+  });
+
+  test("rejects identity drift, extra fields, and reordered release assets", () => {
+    const manifest = generateManifest("management-api");
+    const expected = { component: "management-api" as const, version: "1.2.3" };
+    expect(() => parseReleaseManifest(JSON.stringify({ ...manifest, extra: true }), expected))
+      .toThrow("unsupported or missing fields");
+    expect(() => parseReleaseManifest(JSON.stringify({ ...manifest, repository: "other/repo" }), expected))
+      .toThrow("identity");
+    expect(() => parseReleaseManifest(JSON.stringify({
+      ...manifest,
+      artifacts: [...manifest.artifacts].reverse(),
+    }), expected)).toThrow("allowlist");
+    const oversized = structuredClone(manifest);
+    const web = oversized.artifacts.find((artifact) => artifact.name === "web-console-build.tar.gz");
+    if (!web) throw new Error("Missing Web Console fixture");
+    web.size = RELEASE_BUNDLE_SIZE_LIMITS.webConsole + 1;
+    expect(() => parseReleaseManifest(JSON.stringify(oversized), expected)).toThrow("size limit");
+    expect(() => parseReleaseManifest(JSON.stringify(manifest), { ...expected, version: "1.2.4" }))
+      .toThrow("does not match");
+  });
+
+  test("requires SHA256SUMS to agree exactly with the signed manifest", () => {
+    const manifest = generateManifest("edge-runtime");
+    const valid = manifest.artifacts
+      .filter((artifact) => artifact.name !== RELEASE_CHECKSUMS_NAME)
+      .map((artifact) => `${artifact.sha256}  ${artifact.name}`)
+      .join("\n");
+    expect(parseReleaseChecksums(`${valid}\n`, manifest).size).toBe(manifest.artifacts.length - 1);
+    expect(() => parseReleaseChecksums(`${"0".repeat(64)}${valid.slice(64)}\n`, manifest))
+      .toThrow("disagree");
+  });
+
+  test("release workflow publishes a manifest and offline bundle for Management and Edge", () => {
+    const workflow = readFileSync(join(repoRoot, ".github/workflows/release-please.yml"), "utf8");
+    const managementPackage = readFileSync(join(repoRoot, "packages/management-api/package.json"), "utf8");
+    const edgePackage = readFileSync(join(repoRoot, "packages/edge-runtime/package.json"), "utf8");
+    expect(workflow).toContain("Generate strict Management release manifest");
+    expect(workflow).toContain("Generate strict Edge Runtime release manifest");
+    expect(workflow.match(/SUPACLOUD-RELEASE\.attestation\.jsonl/g)).toHaveLength(2);
+    expect(workflow.match(/id: attest-(?:management|edge-runtime)-release/g)).toHaveLength(2);
+    expect(managementPackage).toContain('"release:manifest"');
+    expect(edgePackage).toContain('"release:manifest"');
+  });
+
+  test("Management CLI exposes the exact offline component contract without probing Edge version", () => {
+    const index = readFileSync(join(repoRoot, "packages/management-api/src/index.ts"), "utf8");
+    const upgrade = readFileSync(join(repoRoot, "packages/management-api/src/upgrade.ts"), "utf8");
+    expect(index).toContain('readArgValue("--edge-runtime-version")');
+    expect(index).toContain('readArgValue("--asset-bundle-dir")');
+    const edgeStage = upgrade.slice(
+      upgrade.indexOf("async function stageEdgeRuntimeUpgrade"),
+      upgrade.indexOf("async function stageWebConsoleUpgrade"),
+    );
+    expect(edgeStage).toContain("validateElfBinaryArtifact");
+    expect(edgeStage).not.toContain('"--version"');
+  });
+});

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -25,7 +25,9 @@ import {
     inspectActiveManagementBinary,
     inspectActiveSystemdBinary,
     normalizeEdgeRuntimeReleaseTag,
+    normalizeExactManagementVersion,
     normalizeManagementReleaseTag,
+    parseManagementVersionOutput,
     parseSystemdExecStartPath,
     parseSystemdEnabledState,
     parseSystemdMainPid,
@@ -122,7 +124,7 @@ function installFakeGithubCli(binDirectory: string): void {
   writeFileSync(executable, [
     "#!/bin/sh",
     'if [ "$1 $2 $3" = "attestation verify --help" ]; then',
-    '  printf "%s\\n" "--bundle" "--signer-workflow"',
+    '  printf "%s\\n" "--bundle" "--signer-workflow" "--deny-self-hosted-runners"',
     '  [ "${GH_OMIT_SOURCE_REF:-false}" = "true" ] || printf "%s\\n" "--source-ref"',
     "  exit 0",
     "fi",
@@ -473,6 +475,9 @@ describe("upgrade release selection", () => {
   });
 
   test("normalizes explicit versions and ignores unrelated latest component releases", () => {
+    expect(normalizeExactManagementVersion("0.50.30")).toBe("0.50.30");
+    expect(normalizeExactManagementVersion("management-api-v0.50.30")).toBe("0.50.30");
+    expect(() => normalizeExactManagementVersion("latest")).toThrow("exact stable");
     expect(normalizeManagementReleaseTag("0.38.0")).toBe("management-api-v0.38.0");
     expect(normalizeManagementReleaseTag("v0.38.0")).toBe("management-api-v0.38.0");
     expect(normalizeManagementReleaseTag("management-api-v0.38.0")).toBe("management-api-v0.38.0");
@@ -509,6 +514,18 @@ describe("upgrade release selection", () => {
     );
 
     expect(selected.tag_name).toBe("management-api-v0.37.0");
+  });
+
+  test("requires Management --version to report one exact stable version", () => {
+    expect(parseManagementVersionOutput("SupaCloud Version: 0.50.30\n")).toBe("0.50.30");
+    expect(parseManagementVersionOutput('{"message":"SupaCloud Version: 0.50.30"}\n')).toBe("0.50.30");
+    for (const invalid of [
+      "SupaCloud Version: 0.50.30-beta.1\n",
+      "SupaCloud Version: 0.50.29\nextra\n",
+      '{"message":"Edge Runtime Version: 0.16.8"}\n',
+    ]) {
+      expect(() => parseManagementVersionOutput(invalid)).toThrow();
+    }
   });
 
   test("selects only the explicitly pinned Edge Runtime release with its own checksum", () => {
@@ -558,7 +575,7 @@ describe("upgrade release selection", () => {
   });
 
   test("offline attestation capability requires every gh verification flag", () => {
-    const requiredFlags = ["--bundle", "--signer-workflow", "--source-ref"];
+    const requiredFlags = ["--bundle", "--signer-workflow", "--source-ref", "--deny-self-hosted-runners"];
     expect(supportsGithubOfflineAttestationVerification(0, requiredFlags.join("\n"))).toBe(true);
     expect(supportsGithubOfflineAttestationVerification(0, requiredFlags.map(flag => `${flag}=value`).join("\n"))).toBe(true);
     expect(supportsGithubOfflineAttestationVerification(1, requiredFlags.join("\n"))).toBe(false);
@@ -620,6 +637,7 @@ describe("upgrade release selection", () => {
       expect(ghArguments).toContain("--repo zuohuadong/supacloud");
       expect(ghArguments).toContain("--signer-workflow zuohuadong/supacloud/.github/workflows/release-please.yml");
       expect(ghArguments).toContain("--source-ref refs/heads/main");
+      expect(ghArguments).toContain("--deny-self-hosted-runners");
       expect(readFileSync(process.env.GH_BUNDLE_RECORD!, "utf8")).toBe('{"mediaType":"sigstore"}\n');
       expect(readdirSync(fixture.directory).filter(name => name.startsWith("supacloud-attestation-"))).toEqual([]);
       expect(readFileSync(process.env.SUPACLOUD_INTEGRITY_MODE_RECORD!, "utf8").trim())

--- a/scripts/generate_release_manifest.ts
+++ b/scripts/generate_release_manifest.ts
@@ -1,0 +1,121 @@
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, readdirSync, realpathSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  RELEASE_CHECKSUMS_NAME,
+  RELEASE_MANIFEST_NAME,
+  RELEASE_REPOSITORY,
+  RELEASE_SIGNER_WORKFLOW,
+  RELEASE_SOURCE_REF,
+  type ReleaseComponent,
+  type ReleaseManifest,
+  type ReleaseManifestArtifact,
+  parseReleaseChecksums,
+  parseReleaseManifest,
+  releaseAssetNames,
+  releaseTag,
+} from "../packages/management-api/src/release-manifest";
+
+type GeneratorOptions = {
+  component: ReleaseComponent;
+  packageJson: string;
+  assetsDir: string;
+  tag: string;
+  sourceCommit: string;
+};
+
+function argument(name: string): string {
+  const index = process.argv.indexOf(name);
+  const candidate = index >= 0 ? process.argv[index + 1] : undefined;
+  if (!candidate || candidate.startsWith("--")) throw new Error(`Missing required argument ${name}`);
+  return candidate;
+}
+
+function generatorOptions(): GeneratorOptions {
+  const component = argument("--component");
+  if (component !== "management-api" && component !== "edge-runtime") {
+    throw new Error("--component must be management-api or edge-runtime");
+  }
+  return {
+    component,
+    packageJson: resolve(argument("--package-json")),
+    assetsDir: resolve(argument("--assets-dir")),
+    tag: argument("--tag"),
+    sourceCommit: argument("--source-commit"),
+  };
+}
+
+function packageVersion(packageJsonPath: string): string {
+  const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version?: unknown };
+  if (typeof parsed.version !== "string" || !/^\d+\.\d+\.\d+$/.test(parsed.version)) {
+    throw new Error("Package version must be an exact stable version");
+  }
+  return parsed.version;
+}
+
+function assertSourceCommit(sourceCommit: string): void {
+  if (!/^[0-9a-f]{40}$/.test(sourceCommit)) throw new Error("Source commit must be a lowercase Git SHA");
+  const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: process.cwd() });
+  if (head.exitCode !== 0 || head.stdout.toString().trim() !== sourceCommit) {
+    throw new Error("Source commit does not match the checked out release commit");
+  }
+}
+
+function assertAssetDirectory(options: GeneratorOptions): void {
+  const expected = releaseAssetNames(options.component);
+  const actual = readdirSync(options.assetsDir).sort();
+  if (actual.length !== expected.length || actual.some((name, index) => name !== expected[index])) {
+    throw new Error(`${options.component} release assets do not match the strict allowlist`);
+  }
+}
+
+function releaseArtifact(assetsDir: string, name: string): ReleaseManifestArtifact {
+  const filePath = resolve(realpathSync(assetsDir), name);
+  const stats = lstatSync(filePath);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1 || realpathSync(filePath) !== filePath) {
+    throw new Error(`Release asset is not a direct regular file: ${name}`);
+  }
+  return {
+    name,
+    sha256: createHash("sha256").update(readFileSync(filePath)).digest("hex"),
+    size: stats.size,
+  };
+}
+
+function releaseManifest(options: GeneratorOptions): ReleaseManifest {
+  const version = packageVersion(options.packageJson);
+  if (options.tag !== releaseTag(options.component, version)) {
+    throw new Error("Release tag does not match the package version");
+  }
+  const manifest: ReleaseManifest = {
+    schemaVersion: 1,
+    repository: RELEASE_REPOSITORY,
+    source: { ref: RELEASE_SOURCE_REF, commit: options.sourceCommit },
+    workflow: RELEASE_SIGNER_WORKFLOW,
+    release: { component: options.component, version, tag: options.tag },
+    artifacts: releaseAssetNames(options.component).map((name) => releaseArtifact(options.assetsDir, name)),
+  };
+  return parseReleaseManifest(JSON.stringify(manifest), { component: options.component, version });
+}
+
+function writeReleaseManifest(options: GeneratorOptions): string {
+  assertSourceCommit(options.sourceCommit);
+  assertAssetDirectory(options);
+  const manifest = releaseManifest(options);
+  parseReleaseChecksums(
+    readFileSync(resolve(options.assetsDir, RELEASE_CHECKSUMS_NAME), "utf8"),
+    manifest,
+  );
+  const outputPath = resolve(options.assetsDir, RELEASE_MANIFEST_NAME);
+  writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
+  return outputPath;
+}
+
+if (import.meta.main) {
+  try {
+    console.log(writeReleaseManifest(generatorOptions()));
+  } catch (error: unknown) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- publish deterministic Management and Edge offline upgrade bundles from the official release workflow
- bind every bundle to component version, source ref, source digest, checksums, size limits, and GitHub artifact attestation
- add the Management offline activation path while preserving the existing transactional preflight, stage, migrate, activate, health-check, rollback, and cleanup lifecycle

## Security and compatibility

- fail closed on wrong owner, symlinks, hardlinks, non-canonical paths, and unexpected permission or special mode bits
- verify attestations locally with the official GitHub CLI and deny self-hosted runners
- keep Management and Edge source commits independent and make no network request from the offline bundle loader
- retain the supported online upgrade path unchanged

## Verification

- 83 focused and upgrade regression tests pass
- Management API and Edge Runtime type checks pass
- release workflow YAML parses successfully
- `git diff --check` passes
- independent review: P0/P1/P2 = 0
- clean-code-guard: clean

## Release impact

This changes both `@supacloud/management-api` and `@supacloud/edge-runtime`, so Release Please should publish both components and attach each component offline bundle plus `SUPACLOUD-RELEASE.json`, `SUPACLOUD-RELEASE.attestation.jsonl`, and `SHA256SUMS`.
