### PR TITLE
fix(admin): add verified local upgrade transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,26 @@ transaction:
 
 ```bash
 npx @supacloud/admin ssh upgrade \
-  --version 0.50.27 \
-  --edge_runtime_version 0.16.7 \
+  --version 0.50.31 \
+  --edge_runtime_version 0.16.8 \
+  --artifact_transport local \
   --github_proxy direct
 ```
+
+`--artifact_transport local` downloads exact releases directly on the Admin
+host, verifies the signed manifest, SHA256 checksums, sizes, source commit, and
+architecture, then uploads an atomic SFTP staging tree. After root ownership is
+established, the server repeats offline verification and uses the uploaded
+target Management binary for the Management/Edge/Web transaction. The server
+does not need GitHub egress, a third-party proxy, or a permanent verifier. Local
+transport accepts only `direct` or `none`. A compatible installed `gh` is
+reused; only a server without the required strict attestation flags receives a
+pinned temporary verifier inside the removable staging tree.
+
+The transaction runs in a uniquely named transient systemd unit and publishes a
+protected atomic status record. Admin polls that record through short SSH calls;
+it does not blindly stop a transaction that may have entered activation. The
+legacy server-download path remains available as `--artifact_transport remote`.
 
 This transaction requires persisted `EDGE_RUNTIME_MODE=external`; embedded
 mode is rejected before release artifacts or services are changed. It preserves

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -212,10 +212,24 @@ source /etc/profile.d/supacloud.sh
 
 ```bash
 npx @supacloud/admin ssh upgrade \
-  --version 0.50.27 \
-  --edge_runtime_version 0.16.7 \
+  --version 0.50.31 \
+  --edge_runtime_version 0.16.8 \
+  --artifact_transport local \
   --github_proxy direct
 ```
+
+`--artifact_transport local` 会在 Admin 所在机器直连官方 GitHub，验证精确
+Release 的签名 manifest、SHA256、文件大小、来源提交和目标架构，再通过原子
+SFTP staging 上传。服务器接管为 root 所有后会离线重复验证，并使用上传的目标
+Management 执行同一个 Management/Edge/Web 事务；服务器无需访问 GitHub，也
+不会使用第三方代理或为了升级永久安装 verifier。远端已有支持全部严格
+attestation 参数的 `gh` 时直接复用；仅缺少合格 `gh` 时，才在可清理的 staging
+中传入固定版本的临时 verifier。该模式只接受 `direct` 或 `none`。
+
+升级事务运行在唯一命名的 transient systemd unit 中，使用受保护的原子状态文件
+轮询，因此不会依赖一个长时间保持的 SSH channel，也不会在状态未知时强杀已经
+进入 activation 的事务。原服务器下载路径仍可通过 `--artifact_transport remote`
+显式使用。
 
 该事务要求持久化配置为 `EDGE_RUNTIME_MODE=external`；embedded 模式会在
 改动 Release 制品或服务前被拒绝。命令会保留 Edge Runtime 的 systemd

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -39,17 +39,32 @@ external Edge Runtime as a single rollback-capable transaction:
 
 ```bash
 npx @supacloud/admin ssh upgrade \
-  --version 0.50.27 \
-  --edge_runtime_version 0.16.7 \
+  --version 0.50.31 \
+  --edge_runtime_version 0.16.8 \
+  --artifact_transport local \
   --github_proxy direct
 ```
 
-The command supports direct root SSH and passwordless `sudo -n`. It installs
-the pinned GitHub provenance verifier when needed, verifies each component
-against its own release checksum and attestation, and preserves the Edge
-Runtime systemd `ExecStart`, port, mode, and enabled state. Component upgrades
-require persisted `EDGE_RUNTIME_MODE=external`; embedded mode is rejected
-before release artifacts or services are changed.
+Local artifact transport downloads exact releases directly on the Admin host,
+verifies their signed release manifests, checksums, sizes, provenance, source
+commit, and architecture, then transfers them through an atomic SFTP staging
+directory. The server takes root ownership, repeats offline verification, and
+runs the uploaded target Management binary without GitHub egress or a
+third-party proxy. The server reuses an installed `gh` only when it supports all
+required strict attestation flags. Otherwise Admin transfers a pinned temporary
+Linux `gh` verifier that is removed with the staging directory and never
+replaces `/usr/local/bin/gh`.
+
+The command supports direct root SSH and passwordless `sudo -n`. The transaction
+runs in a uniquely named transient systemd unit with protected atomic status
+records; Admin polls that record without tying the transaction to a long-lived
+SSH channel. It preserves the Edge Runtime systemd `ExecStart`, port, mode, and
+enabled state. Component upgrades require persisted `EDGE_RUNTIME_MODE=external`;
+embedded mode is rejected before release artifacts or services are changed.
+
+`--artifact_transport local` accepts only `--github_proxy direct` or `none` and
+clears proxy environment variables on both hosts. The legacy server-download
+path remains available as `--artifact_transport remote`.
 
 Omitting `--edge_runtime_version` retains the Management and Web Console-only
 upgrade behavior and reports that Edge Runtime was not upgraded. Caddy and

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "node:url";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createAdminTools } from "./index";
+import packageMetadata from "../package.json" with { type: "json" };
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const ADMIN_CONTEXT_KEYS = new Set([
@@ -122,6 +123,13 @@ describe("admin SSH registration gate", () => {
 });
 
 describe("supacloud-admin process contract", () => {
+    test("prints the exact package version", async () => {
+        const execution = await runAdminCli(["--version"]);
+
+        expect(execution.exitCode).toBe(0);
+        expect(execution.output.trim()).toBe(packageMetadata.version);
+    });
+
     test("runs through an npm-style bin symlink", async () => {
         const build = Bun.spawnSync([process.execPath, "run", "build"], { cwd: PACKAGE_ROOT });
         expect(build.exitCode).toBe(0);
@@ -134,6 +142,25 @@ describe("supacloud-admin process contract", () => {
             const result = await runAdminCliPath(linkedEntry, ["--help"]);
             expect(result.exitCode).toBe(0);
             expect(result.output).toContain("Platform administration CLI");
+            const version = await runAdminCliPath(linkedEntry, ["--version"]);
+            expect(version.exitCode).toBe(0);
+            expect(version.output.trim()).toBe(packageMetadata.version);
+        } finally {
+            rmSync(sandbox, { recursive: true, force: true });
+        }
+    });
+
+    test("build output bundles the shared release-manifest contract", async () => {
+        const build = Bun.spawnSync([process.execPath, "run", "build"], { cwd: PACKAGE_ROOT });
+        expect(build.exitCode).toBe(0);
+        const sandbox = mkdtempSync(join(tmpdir(), "supacloud-admin-standalone-dist-"));
+        const isolatedEntry = join(sandbox, "supacloud-admin");
+        copyFileSync(join(PACKAGE_ROOT, "dist/index.js"), isolatedEntry);
+        chmodSync(isolatedEntry, 0o755);
+        try {
+            const execution = await runAdminCliPath(isolatedEntry, ["--version"]);
+            expect(execution.exitCode).toBe(0);
+            expect(execution.output.trim()).toBe(packageMetadata.version);
         } finally {
             rmSync(sandbox, { recursive: true, force: true });
         }

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -13,6 +13,7 @@ import { registerSshTools } from "./shared/tools/ssh-tools";
 import { registerAdvancedTools } from "./shared/tools/advanced-tools";
 import { registerAdminProjectCliTools } from "./shared/tools/project-cli-tools";
 import { registerGatewayTools } from "./shared/tools/gateway-tools";
+import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
 type ToolMap = Record<string, ToolEntry>;
@@ -60,6 +61,7 @@ USAGE
   supacloud-admin <module> <action> [--flags]
   supacloud-admin status
   supacloud-admin --help
+  supacloud-admin --version
 
 EXPECTED CONTEXT
 
@@ -256,6 +258,10 @@ async function main() {
     if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
         printHelp();
         process.exit(0);
+    }
+    if (args.length === 1 && args[0] === "--version") {
+        console.log(packageMetadata.version);
+        return;
     }
 
     const cliTools = createAdminTools();

--- a/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+    assertLocalGithubVerifier,
+    assertLocalUpgradeBundleSize,
+    assertSignedArtifact,
+    parseGithubReleaseMetadata,
+    runGithubCli,
+    serializeAttestationBundles,
+    settleLocalBundleDownloads,
+    type LocalUpgradeFile,
+} from "./local-upgrade-bundle";
+import { RELEASE_BUNDLE_SIZE_LIMITS } from "../../../../management-api/src/release-manifest";
+
+const RELEASE_TAG = "management-api-v0.50.31";
+
+function releaseMetadata(downloadUrl: string): unknown {
+    return {
+        tag_name: RELEASE_TAG,
+        draft: false,
+        prerelease: false,
+        assets: [{
+            name: "SUPACLOUD-RELEASE.json",
+            browser_download_url: downloadUrl,
+        }],
+    };
+}
+
+function withFakeGithubCli(script: string, run: () => Promise<void>, mode = 0o700): Promise<void> {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-admin-gh-"));
+    const executable = join(directory, "gh");
+    const previousPath = process.env.PATH;
+    writeFileSync(executable, script, { mode });
+    chmodSync(executable, mode);
+    process.env.PATH = `${directory}:${previousPath || ""}`;
+    return run().finally(() => {
+        if (previousPath === undefined) delete process.env.PATH;
+        else process.env.PATH = previousPath;
+        rmSync(directory, { recursive: true, force: true });
+    });
+}
+
+describe("local upgrade download trust boundary", () => {
+    test("accepts only the exact official GitHub release asset path", () => {
+        const official = `https://github.com/zuohuadong/supacloud/releases/download/${RELEASE_TAG}/SUPACLOUD-RELEASE.json`;
+
+        expect(parseGithubReleaseMetadata(releaseMetadata(official), RELEASE_TAG).assets[0]?.name)
+            .toBe("SUPACLOUD-RELEASE.json");
+        expect(() => parseGithubReleaseMetadata(
+            releaseMetadata(`https://proxy.example.com/${RELEASE_TAG}/SUPACLOUD-RELEASE.json`), RELEASE_TAG,
+        )).toThrow("approved official GitHub endpoint");
+        expect(() => parseGithubReleaseMetadata(
+            releaseMetadata(`https://github.com/zuohuadong/other/releases/download/${RELEASE_TAG}/SUPACLOUD-RELEASE.json`),
+            RELEASE_TAG,
+        )).toThrow("official GitHub release path");
+    });
+
+    test("serializes every GitHub attestation bundle as bounded JSONL input", () => {
+        const serialized = serializeAttestationBundles({
+            attestations: [{ bundle: { mediaType: "one" } }, { bundle: { mediaType: "two" } }],
+        });
+
+        expect(serialized).toBe('{"mediaType":"one"}\n{"mediaType":"two"}\n');
+        expect(() => serializeAttestationBundles({ attestations: [] })).toThrow("did not contain attestations");
+    });
+
+    test("counts the optional verifier archive against the shared bundle limit", () => {
+        const componentFiles: LocalUpgradeFile[] = [{
+            localPath: "/tmp/component",
+            relativePath: "bundle/management-api/component",
+            sha256: "0".repeat(64),
+            size: RELEASE_BUNDLE_SIZE_LIMITS.total - 1,
+        }];
+        const verifierArchive: LocalUpgradeFile = {
+            localPath: "/tmp/verifier",
+            relativePath: "verifier/gh.tar.gz",
+            sha256: "1".repeat(64),
+            size: 2,
+        };
+
+        expect(() => assertLocalUpgradeBundleSize(componentFiles)).not.toThrow();
+        expect(() => assertLocalUpgradeBundleSize([...componentFiles, verifierArchive])).toThrow("total size limit");
+    });
+
+    test("waits for every parallel bundle download before preserving the first failure", async () => {
+        const firstFailure = new Error("management download failed");
+        let resolveEdgeDownload!: (files: LocalUpgradeFile[]) => void;
+        const edgeDownload = new Promise<LocalUpgradeFile[]>((resolve) => { resolveEdgeDownload = resolve; });
+        let completed = false;
+        const settlement = settleLocalBundleDownloads([
+            Promise.reject(firstFailure),
+            edgeDownload,
+            Promise.resolve(null),
+        ]).catch((error: unknown) => {
+            completed = true;
+            return error;
+        });
+
+        await Bun.sleep(10);
+        expect(completed).toBe(false);
+        resolveEdgeDownload([]);
+        expect(await settlement).toBe(firstFailure);
+        expect(completed).toBe(true);
+    });
+
+    test("rejects a downloaded artifact whose signed digest no longer matches", () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-admin-artifact-"));
+        const artifactPath = join(directory, "artifact.bin");
+        const contents = "verified release artifact";
+        writeFileSync(artifactPath, contents);
+        const manifest = {
+            artifacts: [{
+                name: "artifact.bin",
+                size: Buffer.byteLength(contents),
+                sha256: createHash("sha256").update(contents).digest("hex"),
+            }],
+        } as never;
+        try {
+            chmodSync(artifactPath, 0o600);
+            expect(assertSignedArtifact(artifactPath, manifest)).toHaveLength(64);
+            writeFileSync(artifactPath, "tampered release artifact");
+            expect(() => assertSignedArtifact(artifactPath, manifest)).toThrow("signed release hashes");
+
+            if (process.platform === "linux") {
+                writeFileSync(artifactPath, contents);
+                chmodSync(artifactPath, 0o4600);
+                expect(() => assertSignedArtifact(artifactPath, manifest)).toThrow("exact mode 0600");
+            }
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    test("requires every strict offline verification flag from the local gh", async () => {
+        await withFakeGithubCli([
+            "#!/usr/bin/env bash",
+            "printf '%s\\n' --bundle --signer-workflow --source-ref --source-digest --deny-self-hosted-runners",
+        ].join("\n"), async () => {
+            await expect(assertLocalGithubVerifier()).resolves.toBeUndefined();
+        });
+    });
+
+    test("rejects a local gh verifier carrying special permission bits", async () => {
+        if (process.platform !== "linux") return;
+        await withFakeGithubCli("#!/bin/sh\nexit 0\n", async () => {
+            await expect(assertLocalGithubVerifier()).rejects.toThrow("special permission bits");
+        }, 0o4700);
+    });
+
+    test("waits for a timed-out gh process to exit after the kill grace", async () => {
+        await withFakeGithubCli([
+            "#!/usr/bin/env node",
+            "process.on('SIGTERM', () => {});",
+            "console.log(process.pid);",
+            "setInterval(() => {}, 1000);",
+        ].join("\n"), async () => {
+            const execution = await runGithubCli(["hang"], 1_500);
+            const pid = Number(execution.stdout.trim());
+
+            expect(execution.exitCode).toBe(124);
+            expect(Number.isSafeInteger(pid) && pid > 1).toBe(true);
+            expect(Bun.spawnSync(["kill", "-0", String(pid)]).exitCode).not.toBe(0);
+        });
+    });
+});

--- a/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -17,6 +17,21 @@ import {
 import { RELEASE_BUNDLE_SIZE_LIMITS } from "../../../../management-api/src/release-manifest";
 
 const RELEASE_TAG = "management-api-v0.50.31";
+
+function setFixtureMode(filePath: string, mode: number): void {
+    if ((mode & 0o7000) === 0) {
+        chmodSync(filePath, mode);
+        return;
+    }
+    const chmod = Bun.spawnSync(["chmod", mode.toString(8), filePath]);
+    if (chmod.exitCode !== 0) {
+        throw new Error(`Unable to set fixture mode ${mode.toString(8)}: ${chmod.stderr.toString().trim()}`);
+    }
+    const actualMode = statSync(filePath).mode & 0o7777;
+    if (actualMode !== mode) {
+        throw new Error(`Fixture mode is ${actualMode.toString(8)}, expected ${mode.toString(8)}`);
+    }
+}
 
 function releaseMetadata(downloadUrl: string): unknown {
     return {
@@ -35,7 +50,7 @@ function withFakeGithubCli(script: string, run: () => Promise<void>, mode = 0o70
     const executable = join(directory, "gh");
     const previousPath = process.env.PATH;
     writeFileSync(executable, script, { mode });
-    chmodSync(executable, mode);
+    setFixtureMode(executable, mode);
     process.env.PATH = `${directory}:${previousPath || ""}`;
     return run().finally(() => {
         if (previousPath === undefined) delete process.env.PATH;
@@ -127,7 +142,7 @@ describe("local upgrade download trust boundary", () => {
 
             if (process.platform === "linux") {
                 writeFileSync(artifactPath, contents);
-                chmodSync(artifactPath, 0o4600);
+                setFixtureMode(artifactPath, 0o4600);
                 expect(() => assertSignedArtifact(artifactPath, manifest)).toThrow("exact mode 0600");
             }
         } finally {

--- a/packages/admin/src/shared/releases/local-upgrade-bundle.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.ts
@@ -1,0 +1,613 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { accessSync, chmodSync, constants as fsConstants, createWriteStream, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import type { IncomingMessage } from "node:http";
+import { get } from "node:https";
+import { tmpdir } from "node:os";
+import { basename, delimiter, join } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { Transform } from "node:stream";
+
+import {
+    RELEASE_ATTESTATION_NAME,
+    RELEASE_BUNDLE_SIZE_LIMITS,
+    RELEASE_CHECKSUMS_NAME,
+    RELEASE_MANIFEST_NAME,
+    RELEASE_REPOSITORY,
+    RELEASE_SIGNER_WORKFLOW,
+    RELEASE_SOURCE_REF,
+    manifestArtifact,
+    parseReleaseChecksums,
+    parseReleaseManifest,
+    releaseAssetSizeLimit,
+    releaseTag,
+    type ReleaseComponent,
+    type ReleaseManifest,
+} from "../../../../management-api/src/release-manifest";
+
+export type UpgradeArchitecture = "amd64" | "arm64";
+
+export type LocalUpgradeFile = {
+    localPath: string;
+    relativePath: string;
+    sha256: string;
+    size: number;
+};
+
+export type PreparedLocalUpgradeBundle = {
+    directory: string;
+    files: LocalUpgradeFile[];
+    verifierArchive: LocalUpgradeFile | null;
+    managementBinaryName: string;
+    edgeRuntimeBinaryName: string;
+};
+
+export type PrepareLocalUpgradeBundleRequest = {
+    architecture: UpgradeArchitecture;
+    managementVersion: string;
+    edgeRuntimeVersion: string;
+    verifierProvisioning: "installed" | "bundled";
+};
+
+type GithubReleaseAsset = {
+    name: string;
+    browser_download_url: string;
+};
+
+type GithubRelease = {
+    tag_name: string;
+    draft: boolean;
+    prerelease: boolean;
+    assets: GithubReleaseAsset[];
+};
+
+type ComponentDownloadRequest = {
+    component: ReleaseComponent;
+    version: string;
+    assetNames: string[];
+    destination: string;
+};
+
+type HttpsDownloadRequest = {
+    url: URL;
+    destination: string;
+    maxBytes: number;
+    redirects: number;
+    deadline: number;
+};
+
+type LocalBundleLayout = {
+    directory: string;
+    managementDirectory: string;
+    edgeDirectory: string;
+    verifierDirectory: string;
+    managementBinaryName: string;
+    edgeRuntimeBinaryName: string;
+};
+
+type LocalBundleDownloadPromises = [
+    Promise<LocalUpgradeFile[]>,
+    Promise<LocalUpgradeFile[]>,
+    Promise<LocalUpgradeFile | null>,
+];
+
+type LocalBundleDownloads = [LocalUpgradeFile[], LocalUpgradeFile[], LocalUpgradeFile | null];
+
+const RELEASES_API = `https://api.github.com/repos/${RELEASE_REPOSITORY}/releases`;
+const ATTESTATIONS_API = `https://api.github.com/repos/${RELEASE_REPOSITORY}/attestations`;
+const GH_VERSION = "2.96.0";
+const GH_ARCHIVE_SHA256: Record<UpgradeArchitecture, string> = {
+    amd64: "83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60",
+    arm64: "06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909",
+};
+const MAX_GH_ARCHIVE_BYTES = 64 * 1024 * 1024;
+const DOWNLOAD_TIMEOUT_MS = 10 * 60_000;
+const DOWNLOAD_IDLE_TIMEOUT_MS = 30_000;
+const GH_CAPABILITY_TIMEOUT_MS = 30_000;
+const GH_VERIFICATION_TIMEOUT_MS = 2 * 60_000;
+const GH_TERMINATION_GRACE_MS = 2_000;
+const MAX_REDIRECTS = 6;
+const RETRYABLE_DOWNLOAD_CODES = new Set([
+    "EAI_AGAIN", "ECONNREFUSED", "ECONNRESET", "ENETUNREACH", "EPIPE", "ETIMEDOUT",
+]);
+const OFFICIAL_DOWNLOAD_HOSTS = new Set([
+    "api.github.com",
+    "github.com",
+    "release-assets.githubusercontent.com",
+]);
+export const STRICT_GITHUB_CAPABILITY_FLAGS = [
+    "--bundle",
+    "--signer-workflow",
+    "--source-ref",
+    "--source-digest",
+    "--deny-self-hosted-runners",
+] as const;
+
+class RetryableDownloadError extends Error {}
+
+export type GithubCliArchiveIdentity = {
+    archiveName: string;
+    member: string;
+    sha256: string;
+    version: string;
+};
+
+export function githubCliArchiveIdentity(architecture: UpgradeArchitecture): GithubCliArchiveIdentity {
+    const directory = `gh_${GH_VERSION}_linux_${architecture}`;
+    return {
+        archiveName: `${directory}.tar.gz`,
+        member: `${directory}/bin/gh`,
+        sha256: GH_ARCHIVE_SHA256[architecture],
+        version: GH_VERSION,
+    };
+}
+
+function sha256File(filePath: string): string {
+    return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function assertPrivateLocalFileMode(mode: number, label: string): void {
+    if (process.platform !== "win32" && (mode & 0o7777) !== 0o600) {
+        throw new Error(`${label} must use exact mode 0600 without special permission bits`);
+    }
+}
+
+function localUpgradeFile(localPath: string, relativePath: string): LocalUpgradeFile {
+    const stats = statSync(localPath);
+    if (!stats.isFile()) throw new Error(`Local upgrade artifact is not a regular file: ${relativePath}`);
+    assertPrivateLocalFileMode(stats.mode, relativePath);
+    return { localPath, relativePath, sha256: sha256File(localPath), size: stats.size };
+}
+
+function assertExactStableVersion(version: string, field: string): void {
+    if (!/^\d+\.\d+\.\d+$/.test(version)) {
+        throw new Error(`${field} must be an exact stable semantic version`);
+    }
+}
+
+function directChildPath(directory: string, name: string): string {
+    if (basename(name) !== name || !/^[A-Za-z0-9._-]+$/.test(name)) {
+        throw new Error(`Unsafe release asset name: ${name}`);
+    }
+    return join(directory, name);
+}
+
+function assertOfficialDownloadUrl(url: URL): void {
+    if (url.protocol !== "https:" || url.username || url.password
+        || url.port || !OFFICIAL_DOWNLOAD_HOSTS.has(url.hostname)) {
+        throw new Error(`Release download URL is not an approved official GitHub endpoint: ${url.hostname}`);
+    }
+}
+
+function boundedWriter(maxBytes: number): Transform {
+    let receivedBytes = 0;
+    return new Transform({
+        transform(chunk: Buffer, _encoding, callback) {
+            receivedBytes += chunk.length;
+            if (receivedBytes > maxBytes) callback(new Error(`Download exceeded ${maxBytes} bytes`));
+            else callback(null, chunk);
+        },
+    });
+}
+
+function responseLocation(currentUrl: URL, location: string | undefined): URL {
+    if (!location) throw new Error(`HTTPS redirect from ${currentUrl.hostname} did not include Location`);
+    const redirected = new URL(location, currentUrl);
+    assertOfficialDownloadUrl(redirected);
+    return redirected;
+}
+
+function downloadCanRetry(error: unknown): boolean {
+    return error instanceof RetryableDownloadError
+        || RETRYABLE_DOWNLOAD_CODES.has((error as NodeJS.ErrnoException).code || "");
+}
+
+async function consumeDownloadResponse(response: IncomingMessage, download: HttpsDownloadRequest): Promise<void> {
+    if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400) {
+        response.resume();
+        await downloadHttpsResponse({
+            ...download,
+            url: responseLocation(download.url, response.headers.location),
+            redirects: download.redirects + 1,
+        });
+        return;
+    }
+    if (response.statusCode !== 200) {
+        response.resume();
+        const message = `HTTPS download returned HTTP ${response.statusCode ?? "unknown"}`;
+        if (response.statusCode && response.statusCode >= 500) throw new RetryableDownloadError(message);
+        throw new Error(message);
+    }
+    const contentLength = Number(response.headers["content-length"] || 0);
+    if (contentLength > download.maxBytes) {
+        response.resume();
+        throw new Error(`Download Content-Length exceeded ${download.maxBytes} bytes`);
+    }
+    response.setTimeout(DOWNLOAD_IDLE_TIMEOUT_MS, () => response.destroy(new RetryableDownloadError("Release download stalled")));
+    await pipeline(response, boundedWriter(download.maxBytes),
+        createWriteStream(download.destination, { flags: "wx", mode: 0o600 }));
+}
+
+function requestDownloadResponse(download: HttpsDownloadRequest, remainingTime: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const request = get(download.url, { headers: { "User-Agent": "SupaCloud-Admin" } }, (response) => {
+            consumeDownloadResponse(response, download).then(resolve, reject);
+        });
+        request.setTimeout(DOWNLOAD_IDLE_TIMEOUT_MS, () => request.destroy(new RetryableDownloadError("Release download connection stalled")));
+        request.on("error", reject);
+        const totalTimer = setTimeout(() => request.destroy(new RetryableDownloadError("Release download timed out")), remainingTime);
+        request.on("close", () => clearTimeout(totalTimer));
+    });
+}
+
+async function downloadHttpsResponse(download: HttpsDownloadRequest): Promise<void> {
+    if (download.redirects > MAX_REDIRECTS) throw new Error("Release download exceeded the redirect limit");
+    const remainingTime = download.deadline - Date.now();
+    if (remainingTime <= 0) throw new Error("Release download timed out");
+    await requestDownloadResponse(download, remainingTime);
+}
+
+async function downloadDirect(url: string, destination: string, maxBytes: number): Promise<void> {
+    const parsed = new URL(url);
+    assertOfficialDownloadUrl(parsed);
+    const deadline = Date.now() + DOWNLOAD_TIMEOUT_MS;
+    const retryFailures: unknown[] = [];
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+        rmSync(destination, { force: true });
+        try {
+            await downloadHttpsResponse({ url: parsed, destination, maxBytes, redirects: 0, deadline });
+            chmodSync(destination, 0o600);
+            return;
+        } catch (error: unknown) {
+            if (!downloadCanRetry(error)) throw error;
+            retryFailures.push(error);
+        }
+    }
+    throw new AggregateError(retryFailures, `Unable to download ${parsed.hostname}${parsed.pathname}`);
+}
+
+function parseJsonFile(filePath: string, label: string): unknown {
+    const contents = readFileSync(filePath, "utf8");
+    try {
+        return JSON.parse(contents);
+    } catch (error: unknown) {
+        if (!(error instanceof SyntaxError)) throw error;
+        throw new Error(`${label} is not valid JSON`);
+    }
+}
+
+export function parseGithubReleaseMetadata(candidate: unknown, expectedTag: string): GithubRelease {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error("GitHub release metadata must be an object");
+    }
+    const release = candidate as Record<string, unknown>;
+    if (release.tag_name !== expectedTag || release.draft !== false || release.prerelease !== false || !Array.isArray(release.assets)) {
+        throw new Error(`GitHub release metadata does not describe stable release ${expectedTag}`);
+    }
+    const assets = release.assets.map((asset) => githubReleaseAsset(asset, expectedTag));
+    if (new Set(assets.map((asset) => asset.name)).size !== assets.length) {
+        throw new Error(`GitHub release ${expectedTag} contains duplicate asset names`);
+    }
+    return { tag_name: expectedTag, draft: false, prerelease: false, assets };
+}
+
+function githubReleaseAsset(candidate: unknown, expectedTag: string): GithubReleaseAsset {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error("GitHub release asset metadata must be an object");
+    }
+    const asset = candidate as Record<string, unknown>;
+    if (typeof asset.name !== "string" || typeof asset.browser_download_url !== "string") {
+        throw new Error("GitHub release asset metadata is incomplete");
+    }
+    const downloadUrl = new URL(asset.browser_download_url);
+    assertOfficialDownloadUrl(downloadUrl);
+    const expectedPath = `/${RELEASE_REPOSITORY}/releases/download/${expectedTag}/${asset.name}`;
+    if (!/^[A-Za-z0-9._-]+$/.test(asset.name) || downloadUrl.hostname !== "github.com"
+        || downloadUrl.pathname !== expectedPath
+        || downloadUrl.search || downloadUrl.hash) {
+        throw new Error(`Release asset ${asset.name} does not use its official GitHub release path`);
+    }
+    return { name: asset.name, browser_download_url: downloadUrl.toString() };
+}
+
+function releaseAssetUrl(release: GithubRelease, name: string): string {
+    const matching = release.assets.find((asset) => asset.name === name);
+    if (!matching) throw new Error(`Release ${release.tag_name} does not contain ${name}`);
+    return matching.browser_download_url;
+}
+
+export function serializeAttestationBundles(candidate: unknown): string {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error("GitHub attestation response must be an object");
+    }
+    const attestations = (candidate as Record<string, unknown>).attestations;
+    if (!Array.isArray(attestations) || attestations.length === 0) {
+        throw new Error("GitHub attestation response did not contain attestations");
+    }
+    const bundles = attestations.map((attestation) => {
+        if (!attestation || typeof attestation !== "object" || Array.isArray(attestation)) {
+            throw new Error("GitHub attestation entry is invalid");
+        }
+        const bundle = (attestation as Record<string, unknown>).bundle;
+        if (!bundle || typeof bundle !== "object" || Array.isArray(bundle)) {
+            throw new Error("GitHub attestation entry did not contain a bundle");
+        }
+        return JSON.stringify(bundle);
+    });
+    return `${bundles.join("\n")}\n`;
+}
+
+function directEnvironment(): NodeJS.ProcessEnv {
+    const environment = { ...process.env };
+    for (const key of Object.keys(environment)) {
+        if (/(?:^|_)proxy$/i.test(key)
+            || /^(?:SUPACLOUD_GITHUB_PROXIES|NODE_USE_ENV_PROXY)$/.test(key)) {
+            delete environment[key];
+        }
+    }
+    return environment;
+}
+
+function githubCliExecutable(environment: NodeJS.ProcessEnv): string {
+    for (const directory of (environment.PATH || "").split(delimiter).filter(Boolean)) {
+        const candidate = join(directory, "gh");
+        try {
+            accessSync(candidate, fsConstants.X_OK);
+            const stats = statSync(candidate);
+            if (stats.isFile()) {
+                if (process.platform !== "win32" && (stats.mode & 0o7777) > 0o777) {
+                    throw new Error(`GitHub CLI executable has special permission bits: ${candidate}`);
+                }
+                return candidate;
+            }
+        } catch (error: unknown) {
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT"
+                && (error as NodeJS.ErrnoException).code !== "EACCES"
+                && (error as NodeJS.ErrnoException).code !== "ENOTDIR") throw error;
+        }
+    }
+    throw new Error("GitHub CLI executable was not found in PATH");
+}
+
+type GithubCliResult = { exitCode: number; stdout: string; stderr: string };
+
+export async function runGithubCli(arguments_: string[], timeoutMs: number): Promise<GithubCliResult> {
+    return await new Promise<GithubCliResult>((resolve, reject) => {
+        const environment = directEnvironment();
+        const child = spawn(githubCliExecutable(environment), arguments_, {
+            env: environment,
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        let stdout = "";
+        let stderr = "";
+        let timedOut = false;
+        let settled = false;
+        let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+        const timeout = setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGTERM");
+            forceKillTimer = setTimeout(() => child.kill("SIGKILL"), GH_TERMINATION_GRACE_MS);
+        }, timeoutMs);
+        const settleExecution = (error: Error | undefined, exitCode: number) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            if (forceKillTimer) clearTimeout(forceKillTimer);
+            if (error) reject(error);
+            else resolve({ exitCode: timedOut ? 124 : exitCode, stdout, stderr });
+        };
+        child.stdout.on("data", (chunk: Buffer) => { stdout = `${stdout}${chunk.toString()}`.slice(-8_000); });
+        child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-8_000); });
+        child.once("error", (error) => settleExecution(error, 127));
+        child.once("close", (code) => settleExecution(undefined, code ?? 1));
+    });
+}
+
+function supportsStrictGithubVerification(execution: GithubCliResult): boolean {
+    const tokens = `${execution.stdout}\n${execution.stderr}`.split(/\s+/);
+    return execution.exitCode === 0 && STRICT_GITHUB_CAPABILITY_FLAGS.every((flag) => (
+        tokens.some((token) => token === flag || token.startsWith(`${flag}=`))
+    ));
+}
+
+export async function assertLocalGithubVerifier(): Promise<void> {
+    const help = await runGithubCli(["attestation", "verify", "--help"], GH_CAPABILITY_TIMEOUT_MS);
+    if (!supportsStrictGithubVerification(help)) {
+        throw new Error("Local artifact transport requires a current gh attestation verifier");
+    }
+}
+
+async function verifyManifestAttestation(manifestPath: string, bundlePath: string, manifest: ReleaseManifest): Promise<void> {
+    const verification = await runGithubCli([
+        "attestation", "verify", manifestPath,
+        "--bundle", bundlePath,
+        "--repo", RELEASE_REPOSITORY,
+        "--signer-workflow", RELEASE_SIGNER_WORKFLOW,
+        "--source-ref", RELEASE_SOURCE_REF,
+        "--source-digest", manifest.source.commit,
+        "--deny-self-hosted-runners",
+    ], GH_VERIFICATION_TIMEOUT_MS);
+    if (verification.exitCode !== 0) {
+        throw new Error(`gh attestation verify failed: ${verification.stderr.trim().slice(-1_000) || verification.exitCode}`);
+    }
+}
+
+export function assertSignedArtifact(filePath: string, manifest: ReleaseManifest): string {
+    const artifact = manifestArtifact(manifest, basename(filePath));
+    const fileStats = statSync(filePath);
+    if (!fileStats.isFile() || fileStats.size !== artifact.size) {
+        throw new Error(`${artifact.name} does not match the signed release size`);
+    }
+    assertPrivateLocalFileMode(fileStats.mode, artifact.name);
+    const digest = sha256File(filePath);
+    if (digest !== artifact.sha256) {
+        throw new Error(`${artifact.name} does not match the signed release hashes`);
+    }
+    return digest;
+}
+
+function verifyDownloadedFile(filePath: string, manifest: ReleaseManifest, checksums: Map<string, string>): void {
+    const digest = assertSignedArtifact(filePath, manifest);
+    if (checksums.get(basename(filePath)) !== digest) {
+        throw new Error(`${basename(filePath)} does not match SHA256SUMS`);
+    }
+}
+
+async function downloadReleaseMetadata(component: ReleaseComponent, version: string, directory: string): Promise<GithubRelease> {
+    const expectedTag = releaseTag(component, version);
+    const metadataPath = join(directory, `.release-${randomUUID()}.json`);
+    try {
+        await downloadDirect(`${RELEASES_API}/tags/${expectedTag}`, metadataPath, RELEASE_BUNDLE_SIZE_LIMITS.manifest);
+        return parseGithubReleaseMetadata(parseJsonFile(metadataPath, "GitHub release metadata"), expectedTag);
+    } finally {
+        rmSync(metadataPath, { force: true });
+    }
+}
+
+async function downloadManifestAttestation(manifestPath: string, destination: string): Promise<void> {
+    const responsePath = `${destination}.response`;
+    try {
+        await downloadDirect(
+            `${ATTESTATIONS_API}/sha256:${sha256File(manifestPath)}`,
+            responsePath,
+            RELEASE_BUNDLE_SIZE_LIMITS.attestation,
+        );
+        const bundles = serializeAttestationBundles(parseJsonFile(responsePath, "GitHub attestation response"));
+        writeFileSync(destination, bundles, { mode: 0o600, flag: "wx" });
+        chmodSync(destination, 0o600);
+    } finally {
+        rmSync(responsePath, { force: true });
+    }
+}
+
+async function downloadComponent(request: ComponentDownloadRequest): Promise<LocalUpgradeFile[]> {
+    const release = await downloadReleaseMetadata(request.component, request.version, request.destination);
+    const manifestPath = directChildPath(request.destination, RELEASE_MANIFEST_NAME);
+    const attestationPath = directChildPath(request.destination, RELEASE_ATTESTATION_NAME);
+    await downloadDirect(
+        releaseAssetUrl(release, RELEASE_MANIFEST_NAME), manifestPath, RELEASE_BUNDLE_SIZE_LIMITS.manifest,
+    );
+    const manifest = parseReleaseManifest(readFileSync(manifestPath, "utf8"), request);
+    await downloadManifestAttestation(manifestPath, attestationPath);
+    await verifyManifestAttestation(manifestPath, attestationPath, manifest);
+
+    const checksumsPath = directChildPath(request.destination, RELEASE_CHECKSUMS_NAME);
+    await downloadDirect(
+        releaseAssetUrl(release, RELEASE_CHECKSUMS_NAME), checksumsPath, RELEASE_BUNDLE_SIZE_LIMITS.checksums,
+    );
+    assertSignedArtifact(checksumsPath, manifest);
+    const checksums = parseReleaseChecksums(readFileSync(checksumsPath, "utf8"), manifest);
+    for (const assetName of request.assetNames) {
+        const assetPath = directChildPath(request.destination, assetName);
+        await downloadDirect(
+            releaseAssetUrl(release, assetName), assetPath, releaseAssetSizeLimit(request.component, assetName),
+        );
+        verifyDownloadedFile(assetPath, manifest, checksums);
+    }
+    return [RELEASE_MANIFEST_NAME, RELEASE_ATTESTATION_NAME, RELEASE_CHECKSUMS_NAME, ...request.assetNames]
+        .map((name) => localUpgradeFile(
+            directChildPath(request.destination, name), `bundle/${request.component}/${name}`,
+        ));
+}
+
+async function downloadPinnedGithubCli(directory: string, architecture: UpgradeArchitecture): Promise<LocalUpgradeFile> {
+    const identity = githubCliArchiveIdentity(architecture);
+    const archivePath = directChildPath(directory, identity.archiveName);
+    const url = `https://github.com/cli/cli/releases/download/v${identity.version}/${identity.archiveName}`;
+    await downloadDirect(url, archivePath, MAX_GH_ARCHIVE_BYTES);
+    if (sha256File(archivePath) !== identity.sha256) {
+        throw new Error("Pinned GitHub CLI archive SHA256 mismatch");
+    }
+    return localUpgradeFile(archivePath, `verifier/${identity.archiveName}`);
+}
+
+export function cleanupLocalUpgradeBundle(bundle: PreparedLocalUpgradeBundle): void {
+    rmSync(bundle.directory, { recursive: true, force: true });
+}
+
+export function assertLocalUpgradeBundleSize(files: readonly LocalUpgradeFile[]): void {
+    const totalBytes = files.reduce((sum, file) => sum + file.size, 0);
+    if (!Number.isSafeInteger(totalBytes) || totalBytes > RELEASE_BUNDLE_SIZE_LIMITS.total) {
+        throw new Error("Local upgrade bundle exceeds its total size limit");
+    }
+}
+
+async function observeDownloadFailure<T>(download: Promise<T>, failures: unknown[]): Promise<T> {
+    try {
+        return await download;
+    } catch (error: unknown) {
+        failures.push(error);
+        throw error;
+    }
+}
+
+function fulfilledDownload<T>(settlement: PromiseSettledResult<T>): T {
+    if (settlement.status === "rejected") throw settlement.reason;
+    return settlement.value;
+}
+
+export async function settleLocalBundleDownloads(downloads: LocalBundleDownloadPromises): Promise<LocalBundleDownloads> {
+    const failures: unknown[] = [];
+    const settlements = await Promise.allSettled([
+        observeDownloadFailure(downloads[0], failures),
+        observeDownloadFailure(downloads[1], failures),
+        observeDownloadFailure(downloads[2], failures),
+    ]);
+    if (failures.length > 0) throw failures[0];
+    return [
+        fulfilledDownload(settlements[0]),
+        fulfilledDownload(settlements[1]),
+        fulfilledDownload(settlements[2]),
+    ];
+}
+
+function createLocalBundleLayout(request: PrepareLocalUpgradeBundleRequest): LocalBundleLayout {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-admin-upgrade-"));
+    chmodSync(directory, 0o700);
+    const bundleDirectory = join(directory, "bundle");
+    const managementDirectory = join(bundleDirectory, "management-api");
+    const edgeDirectory = join(bundleDirectory, "edge-runtime");
+    const verifierDirectory = join(directory, "verifier");
+    for (const createdDirectory of [bundleDirectory, managementDirectory, edgeDirectory, verifierDirectory]) {
+        mkdirSync(createdDirectory, { recursive: true, mode: 0o700 });
+        chmodSync(createdDirectory, 0o700);
+    }
+    return {
+        directory, managementDirectory, edgeDirectory, verifierDirectory,
+        managementBinaryName: `supacloud-linux-${request.architecture}`,
+        edgeRuntimeBinaryName: `supacloud-edge-runtime-linux-${request.architecture}`,
+    };
+}
+
+async function downloadLocalBundle(request: PrepareLocalUpgradeBundleRequest, layout: LocalBundleLayout): Promise<PreparedLocalUpgradeBundle> {
+    const { managementBinaryName, edgeRuntimeBinaryName } = layout;
+    const [managementFiles, edgeFiles, verifierArchive] = await settleLocalBundleDownloads([
+        downloadComponent({
+            component: "management-api", version: request.managementVersion,
+            assetNames: [managementBinaryName, "web-console-build.tar.gz"], destination: layout.managementDirectory,
+        }),
+        downloadComponent({
+            component: "edge-runtime", version: request.edgeRuntimeVersion,
+            assetNames: [edgeRuntimeBinaryName], destination: layout.edgeDirectory,
+        }),
+        request.verifierProvisioning === "bundled"
+            ? downloadPinnedGithubCli(layout.verifierDirectory, request.architecture)
+            : Promise.resolve(null),
+    ]);
+    const files = [...managementFiles, ...edgeFiles];
+    assertLocalUpgradeBundleSize([...files, ...(verifierArchive ? [verifierArchive] : [])]);
+    return { directory: layout.directory, files, verifierArchive, managementBinaryName, edgeRuntimeBinaryName };
+}
+
+export async function prepareLocalUpgradeBundle(request: PrepareLocalUpgradeBundleRequest): Promise<PreparedLocalUpgradeBundle> {
+    assertExactStableVersion(request.managementVersion, "version");
+    assertExactStableVersion(request.edgeRuntimeVersion, "edge_runtime_version");
+    await assertLocalGithubVerifier();
+    const layout = createLocalBundleLayout(request);
+    try {
+        return await downloadLocalBundle(request, layout);
+    } catch (error: unknown) {
+        rmSync(layout.directory, { recursive: true, force: true });
+        throw error;
+    }
+}

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+    awaitRemoteUpgrade,
+    buildAdoptDropScript,
+    buildCleanupUnstartedUpgradeScript,
+    buildLocalUpgradeRunScript,
+    buildRemotePreflightScript,
+    parseRemotePreflight,
+    remoteUpgradePreflight,
+    startRemoteUpgrade,
+} from "./local-upgrade-transfer";
+import { githubCliArchiveIdentity, type LocalUpgradeFile, type PreparedLocalUpgradeBundle } from "./local-upgrade-bundle";
+
+const paths = {
+    drop: "/tmp/.supacloud-upgrade-upload-11111111-1111-4111-8111-111111111111",
+    stage: "/var/lib/supacloud/upgrade-staging/11111111-1111-4111-8111-111111111111",
+    status: "/var/lib/supacloud/upgrade-runs/11111111-1111-4111-8111-111111111111.status",
+    log: "/var/log/supacloud/upgrade-11111111-1111-4111-8111-111111111111.log",
+    unit: "supacloud-upgrade-11111111-1111-4111-8111-111111111111.service",
+};
+
+type ScriptedResult = { success: boolean; stdout: string; stderr: string; code: number };
+
+class ScriptedSsh {
+    readonly commands: string[] = [];
+
+    constructor(private readonly responses: ScriptedResult[]) {}
+
+    async exec(command: string): Promise<ScriptedResult> {
+        this.commands.push(command);
+        const response = this.responses.shift();
+        if (!response) throw new Error("Unexpected SSH command in lifecycle test");
+        return response;
+    }
+}
+
+function remoteResult(stdout = "", success = true): ScriptedResult {
+    return { success, stdout, stderr: success ? "" : "remote failure", code: success ? 0 : 1 };
+}
+
+function fixtureFile(relativePath: string, index: number): LocalUpgradeFile {
+    return {
+        localPath: `/tmp/local-bundle/${relativePath}`,
+        relativePath,
+        sha256: index.toString(16).padStart(64, "0"),
+        size: 1_000 + index,
+    };
+}
+
+function preparedBundle(architecture: "amd64" | "arm64", verifier: "installed" | "bundled"): PreparedLocalUpgradeBundle {
+    const managementBinaryName = `supacloud-linux-${architecture}`;
+    const edgeRuntimeBinaryName = `supacloud-edge-runtime-linux-${architecture}`;
+    const componentPaths = [
+        "bundle/management-api/SUPACLOUD-RELEASE.json",
+        "bundle/management-api/SUPACLOUD-RELEASE.attestation.jsonl",
+        "bundle/management-api/SHA256SUMS",
+        `bundle/management-api/${managementBinaryName}`,
+        "bundle/management-api/web-console-build.tar.gz",
+        "bundle/edge-runtime/SUPACLOUD-RELEASE.json",
+        "bundle/edge-runtime/SUPACLOUD-RELEASE.attestation.jsonl",
+        "bundle/edge-runtime/SHA256SUMS",
+        `bundle/edge-runtime/${edgeRuntimeBinaryName}`,
+    ];
+    const identity = githubCliArchiveIdentity(architecture);
+    return {
+        directory: "/tmp/local-bundle",
+        files: componentPaths.map((relativePath, index) => fixtureFile(relativePath, index + 1)),
+        verifierArchive: verifier === "bundled" ? {
+            localPath: `/tmp/local-bundle/verifier/${identity.archiveName}`,
+            relativePath: `verifier/${identity.archiveName}`,
+            sha256: identity.sha256,
+            size: 10_000,
+        } : null,
+        managementBinaryName,
+        edgeRuntimeBinaryName,
+    };
+}
+
+function runScript(bundle: PreparedLocalUpgradeBundle, architecture: "amd64" | "arm64"): string {
+    return buildLocalUpgradeRunScript(paths, bundle, {
+        managementVersion: "0.50.31",
+        edgeRuntimeVersion: "0.16.8",
+    }, architecture);
+}
+
+function shellFunctionDefinition(script: string, functionName: string): string {
+    const lines = script.split("\n");
+    const start = lines.findIndex((line) => line.startsWith(`${functionName}()`));
+    if (start < 0) throw new Error(`Generated script does not define ${functionName}`);
+    let braceDepth = 0;
+    for (let index = start; index < lines.length; index += 1) {
+        const currentLine = lines[index] || "";
+        braceDepth += (currentLine.match(/{/g) || []).length - (currentLine.match(/}/g) || []).length;
+        if (braceDepth === 0) return lines.slice(start, index + 1).join("\n");
+    }
+    throw new Error(`Generated shell function ${functionName} is incomplete`);
+}
+
+describe("local upgrade remote runner", () => {
+    test("preflights strict verifier capability without requiring the old jq parser", () => {
+        const script = buildRemotePreflightScript();
+
+        expect(Bun.spawnSync(["bash", "-n", "-c", script]).exitCode).toBe(0);
+        expect(script).toContain("--deny-self-hosted-runners");
+        expect(script).toContain("timeout 15s \"$GH\" attestation verify --help");
+        expect(script).toContain("mode=$(stat -c '%a' \"$verifier\")");
+        expect(script).toContain("trusted_installed_gh \"$GH\"");
+        expect(script).not.toContain("Required local-upgrade tool is missing: jq");
+        expect(parseRemotePreflight("ARCH=arm64\nVERIFIER=installed\n")).toEqual({
+            architecture: "arm64",
+            verifierProvisioning: "installed",
+        });
+    });
+
+    test("trusts only root-owned installed verifiers without writable or special permission bits", () => {
+        const trustFunction = shellFunctionDefinition(buildRemotePreflightScript(), "trusted_installed_gh");
+        const fixtureDirectory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-remote-gh-")));
+        const executable = join(fixtureDirectory, "gh");
+        const symlink = join(fixtureDirectory, "gh-link");
+        writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+        chmodSync(executable, 0o755);
+        symlinkSync(executable, symlink);
+        const gateScript = [
+            "stat() { case \"$2\" in '%u:%g') printf '%s\\n' \"$GH_OWNER\" ;; '%a') printf '%s\\n' \"$GH_MODE\" ;; *) return 1 ;; esac; }",
+            trustFunction,
+            "trusted_installed_gh \"$GH\"",
+        ].join("\n");
+        const runGate = (gh: string, owner: string, mode: string) => Bun.spawnSync({
+            cmd: ["bash", "-c", gateScript],
+            env: { ...process.env, GH: gh, GH_OWNER: owner, GH_MODE: mode },
+        }).exitCode;
+        try {
+            expect(runGate(executable, "0:0", "755")).toBe(0);
+            expect(runGate(executable, "0:0", "750")).toBe(0);
+            expect(runGate(executable, "1000:1000", "755")).not.toBe(0);
+            expect(runGate(executable, "0:0", "775")).not.toBe(0);
+            expect(runGate(executable, "0:0", "757")).not.toBe(0);
+            expect(runGate(executable, "0:0", "4755")).not.toBe(0);
+            expect(runGate(symlink, "0:0", "755")).not.toBe(0);
+        } finally {
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    });
+
+    test("executes and parses the remote preflight before preparing artifacts", async () => {
+        const ssh = new ScriptedSsh([remoteResult("ARCH=amd64\nVERIFIER=bundled\n")]);
+
+        await expect(remoteUpgradePreflight(ssh as never)).resolves.toEqual({
+            architecture: "amd64",
+            verifierProvisioning: "bundled",
+        });
+        expect(ssh.commands).toHaveLength(1);
+        expect(ssh.commands[0]).toContain("sudo -n /bin/bash -c");
+        expect(ssh.commands[0]).toContain("EDGE_RUNTIME_MODE");
+
+        const failedSsh = new ScriptedSsh([remoteResult("", false)]);
+        await expect(remoteUpgradePreflight(failedSsh as never)).rejects.toThrow("preflight failed");
+    });
+
+    test("uses a syntax-valid transfer check before the target Management offline verifier", () => {
+        const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
+        const syntax = Bun.spawnSync(["bash", "-n", "-c", script]);
+
+        expect(syntax.exitCode).toBe(0);
+        expect(script).toContain("verify_transfer 'bundle/management-api/SUPACLOUD-RELEASE.json'");
+        expect(script).toContain("verify_transfer 'bundle/edge-runtime/supacloud-edge-runtime-linux-amd64'");
+        expect(script).toContain("--deny-self-hosted-runners");
+        expect(script).toContain("--asset-bundle-dir \"$BUNDLE\"");
+        expect(script).toContain("--target-version '0.50.31'");
+        expect(script).toContain("--edge-runtime-version '0.16.8'");
+        expect(script).not.toContain("verify_manifest()");
+        expect(script).not.toContain("MANAGEMENT_COMMIT");
+        expect(script).not.toContain("jq ");
+    });
+
+    test("keeps the signed bundle immutable and reports cleanup failures as failures", () => {
+        const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
+
+        expect(script).toContain("install -m 0755 \"$RUNNER_ASSET\" \"$RUNNER\"");
+        expect(script).not.toContain("chmod 0755 \"$RUNNER_ASSET\"");
+        expect(script).toContain("stat -c '%u:%g:%h'");
+        expect(script).toContain("stat -c '%a' \"$path\")\" = '600'");
+        expect(script).toContain("stat -c '%a' \"$path\")\" = '700'");
+        expect(script).not.toContain("stat -c '%u:%g:%a'");
+        expect(script).toContain("trap finish_upgrade EXIT");
+        expect(script).toContain("write_status CLEANING");
+        expect(script).toContain("FAILED:1:CLEANUP_AFTER_TRANSACTION");
+        expect(script).toContain([
+            "write_status CLEANING || { echo 'Unable to publish cleanup state' >&2; exit 1; }",
+            "  if ! rm -rf -- \"$STAGE\"; then",
+            "    write_status 'FAILED:1:CLEANUP_AFTER_TRANSACTION' || true",
+            "    exit 1",
+            "  fi",
+            "  write_status SUCCEEDED || exit 1",
+        ].join("\n"));
+        expect(script).not.toContain("RuntimeMaxSec");
+        expect(script).not.toContain("curl ");
+        expect(script).not.toContain("wget ");
+        expect(script).not.toContain("systemctl stop");
+    });
+
+    test("rejects special permission bits in the remote staging tree", () => {
+        const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
+        const modeGateDefinitions = script.split("\n")
+            .filter((line) => line.startsWith("assert_directory()") || line.startsWith("assert_file()"))
+            .join("\n");
+        const fixtureDirectory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-remote-mode-")));
+        const fixtureFile = join(fixtureDirectory, "artifact");
+        writeFileSync(fixtureFile, "verified");
+        const gateScript = [
+            "set -e",
+            "stat() { case \"$2\" in '%u:%g') printf '0:0\\n' ;; '%u:%g:%h') printf '0:0:1\\n' ;; '%a') if [ \"$3\" = \"$FILE\" ]; then printf '%s\\n' \"$FILE_MODE\"; else printf '%s\\n' \"$DIRECTORY_MODE\"; fi ;; *) return 1 ;; esac; }",
+            modeGateDefinitions,
+            "assert_directory \"$DIRECTORY\"",
+            "assert_file \"$FILE\" \"$DIRECTORY\"",
+        ].join("\n");
+        const runGate = (directoryMode: string, fileMode: string) => Bun.spawnSync({
+            cmd: ["bash", "-c", gateScript],
+            env: { ...process.env, DIRECTORY: fixtureDirectory, FILE: fixtureFile, DIRECTORY_MODE: directoryMode, FILE_MODE: fileMode },
+        }).exitCode;
+        try {
+            expect(runGate("700", "600")).toBe(0);
+            expect(runGate("1700", "600")).not.toBe(0);
+            expect(runGate("700", "4600")).not.toBe(0);
+        } finally {
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    });
+
+    test("publishes terminal status directly from the generated cleanup lifecycle", () => {
+        const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
+        const lifecycleFunctions = [
+            shellFunctionDefinition(script, "write_status"),
+            shellFunctionDefinition(script, "finish_upgrade"),
+        ].join("\n");
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-lifecycle-")));
+        const runLifecycle = (caseName: string, transactionCode: number, cleanupMode: "normal" | "fail") => {
+            const stage = join(fixtureRoot, `${caseName}.stage`);
+            const status = join(fixtureRoot, `${caseName}.status`);
+            mkdirSync(stage, { mode: 0o700 });
+            const cleanupOverride = cleanupMode === "fail"
+                ? "rm() { if [ \"$1 $2 $3\" = \"-rf -- $STAGE\" ]; then return 1; fi; command rm \"$@\"; }"
+                : "";
+            const execution = Bun.spawnSync({
+                cmd: ["bash", "-c", ["set -euo pipefail", lifecycleFunctions, cleanupOverride,
+                    "trap finish_upgrade EXIT", `exit ${transactionCode}`].filter(Boolean).join("\n")],
+                env: { ...process.env, STAGE: stage, STATUS: status },
+            });
+            return { exitCode: execution.exitCode, stageExists: existsSync(stage), status: readFileSync(status, "utf8").trim() };
+        };
+        try {
+            expect(runLifecycle("success", 0, "normal")).toEqual({ exitCode: 0, stageExists: false, status: "SUCCEEDED" });
+            expect(runLifecycle("transaction", 9, "normal")).toEqual({ exitCode: 9, stageExists: false, status: "FAILED:9:TRANSACTION" });
+            expect(runLifecycle("cleanup", 0, "fail")).toEqual({ exitCode: 1, stageExists: true, status: "FAILED:1:CLEANUP_AFTER_TRANSACTION" });
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("uses a remote verifier when capable and uploads the pinned verifier only when needed", () => {
+        const installed = runScript(preparedBundle("amd64", "installed"), "amd64");
+        const bundled = runScript(preparedBundle("amd64", "bundled"), "amd64");
+
+        expect(installed).toContain("GH=$(type -P gh)");
+        expect(installed).toContain("trusted_installed_gh \"$GH\"");
+        expect(installed).toContain("Installed GitHub verifier has special permission bits");
+        expect(installed).not.toContain("gh_2.96.0_linux_amd64.tar.gz");
+        expect(bundled).toContain("gh_2.96.0_linux_amd64.tar.gz");
+        expect(bundled).toContain("83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60");
+        expect(bundled).toContain("tar --no-same-owner --same-permissions");
+        expect(bundled).toContain("stat -c '%a' \"$VERIFIER_ROOT/$GH_MEMBER\")\" = '755'");
+        expect(bundled).not.toContain("--no-same-permissions");
+    });
+
+    test("rolls back stage and records when adoption fails after the move", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-adopt-rollback-")));
+        const fixturePaths = {
+            drop: join(fixtureRoot, "drop"),
+            stage: join(fixtureRoot, "stage"),
+            status: join(fixtureRoot, "run.status"),
+            log: join(fixtureRoot, "run.log"),
+            unit: "supacloud-upgrade-test.service",
+        };
+        mkdirSync(fixturePaths.drop, { mode: 0o700 });
+        const execution = Bun.spawnSync(["bash", "-c", [
+            "install() { return 0; }",
+            "systemctl() { return 1; }",
+            "chown() { return 0; }",
+            "chmod() { return 42; }",
+            buildAdoptDropScript(fixturePaths),
+        ].join("\n")]);
+        try {
+            expect(execution.exitCode).not.toBe(0);
+            expect(execution.stderr.toString()).toContain("transferred state was rolled back");
+            expect(existsSync(fixturePaths.stage)).toBe(false);
+            expect(existsSync(fixturePaths.status)).toBe(false);
+            expect(existsSync(fixturePaths.log)).toBe(false);
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("reports both adoption and rollback failure diagnostics", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-adopt-cleanup-")));
+        const fixturePaths = {
+            drop: join(fixtureRoot, "drop"), stage: join(fixtureRoot, "stage"),
+            status: join(fixtureRoot, "run.status"), log: join(fixtureRoot, "run.log"),
+            unit: "supacloud-upgrade-test.service",
+        };
+        mkdirSync(fixturePaths.drop, { mode: 0o700 });
+        const execution = Bun.spawnSync({
+            cmd: ["bash", "-c", [
+                "install() { return 0; }", "systemctl() { return 1; }", "chown() { return 0; }",
+                "chmod() { return 42; }",
+                "rm() { if [ \"$1 $2 $3\" = \"-rf -- $STAGE\" ]; then return 77; fi; command rm \"$@\"; }",
+                buildAdoptDropScript(fixturePaths),
+            ].join("\n")],
+        });
+        try {
+            expect(execution.exitCode).not.toBe(0);
+            expect(execution.stderr.toString()).toContain("adoption failed");
+            expect(execution.stderr.toString()).toContain("rollback did not complete");
+            expect(existsSync(fixturePaths.stage)).toBe(true);
+            expect(existsSync(fixturePaths.status)).toBe(false);
+            expect(existsSync(fixturePaths.log)).toBe(false);
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("pins the temporary Linux GitHub verifier by architecture", () => {
+        const arm64 = runScript(preparedBundle("arm64", "bundled"), "arm64");
+
+        expect(arm64).toContain("gh_2.96.0_linux_arm64.tar.gz");
+        expect(arm64).toContain("06f86ec7103d41993b76cd78072f43595c34aaa56506d971d9860e67140bf909");
+    });
+
+    test("does not delete an adopted stage while systemd is still activating", async () => {
+        const ssh = new ScriptedSsh([
+            remoteResult("", false),
+            remoteResult("STATUS=PREPARED\nUNIT=activating\n"),
+        ]);
+
+        await expect(startRemoteUpgrade(ssh as never, paths)).resolves.toBeUndefined();
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes("rm -rf --") && command.includes(paths.stage))).toBe(false);
+    });
+
+    test("preserves start and cleanup failures when an unstarted unit cannot be removed", async () => {
+        const ssh = new ScriptedSsh([
+            remoteResult("", false),
+            remoteResult("STATUS=PREPARED\nUNIT=inactive\n"),
+            remoteResult("", false),
+        ]);
+
+        const failure = await startRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(AggregateError);
+        const diagnostics = (failure as AggregateError).errors.map(String).join("\n");
+        expect(diagnostics).toContain("Unable to start the transient upgrade unit");
+        expect(diagnostics).toContain("Unable to clean an unstarted local upgrade");
+    });
+
+    test("reports stage cleanup failure after still removing unstarted records", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-start-cleanup-")));
+        const fixturePaths = {
+            drop: join(fixtureRoot, "drop"), stage: join(fixtureRoot, "stage"),
+            status: join(fixtureRoot, "run.status"), log: join(fixtureRoot, "run.log"),
+            unit: "supacloud-upgrade-test.service",
+        };
+        mkdirSync(fixturePaths.stage, { mode: 0o700 });
+        writeFileSync(fixturePaths.status, "PREPARED\n");
+        writeFileSync(fixturePaths.log, "start failed\n");
+        const execution = Bun.spawnSync(["bash", "-c", [
+            "rm() { if [ \"$1 $2 $3\" = \"-rf -- $STAGE_PATH\" ]; then return 77; fi; command rm \"$@\"; }",
+            buildCleanupUnstartedUpgradeScript(fixturePaths),
+        ].join("\n")], { env: { ...process.env, STAGE_PATH: fixturePaths.stage } });
+        try {
+            expect(execution.exitCode).not.toBe(0);
+            expect(existsSync(fixturePaths.stage)).toBe(true);
+            expect(existsSync(fixturePaths.status)).toBe(false);
+            expect(existsSync(fixturePaths.log)).toBe(false);
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("retains status and logs when a successful transaction cannot clean its stage", async () => {
+        const ssh = new ScriptedSsh([
+            remoteResult("STATUS=FAILED:1:CLEANUP_AFTER_TRANSACTION\nUNIT=failed\n"),
+            remoteResult("transaction completed; stage cleanup failed\n"),
+        ]);
+
+        await expect(awaitRemoteUpgrade(ssh as never, paths)).rejects.toThrow(`retained status=${paths.status}`);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes(`rm -f -- '${paths.status}'`))).toBe(false);
+    });
+
+    test("removes terminal records only after a completed unit publishes success", async () => {
+        const ssh = new ScriptedSsh([
+            remoteResult("STATUS=SUCCEEDED\nUNIT=inactive\n"),
+            remoteResult("upgrade committed\n"),
+            remoteResult(),
+        ]);
+
+        await expect(awaitRemoteUpgrade(ssh as never, paths)).resolves.toContain("Upgrade done");
+        expect(ssh.commands).toHaveLength(3);
+        expect(ssh.commands[2]).toContain(paths.status);
+        expect(ssh.commands[2]).toContain(paths.log);
+    });
+});

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+    adoptRemoteDrop,
     awaitRemoteUpgrade,
     buildAdoptDropScript,
     buildCleanupUnstartedUpgradeScript,
@@ -24,16 +25,18 @@ const paths = {
 };
 
 type ScriptedResult = { success: boolean; stdout: string; stderr: string; code: number };
+type ScriptedResponse = Error | ScriptedResult;
 
 class ScriptedSsh {
     readonly commands: string[] = [];
 
-    constructor(private readonly responses: ScriptedResult[]) {}
+    constructor(private readonly responses: ScriptedResponse[]) {}
 
     async exec(command: string): Promise<ScriptedResult> {
         this.commands.push(command);
         const response = this.responses.shift();
         if (!response) throw new Error("Unexpected SSH command in lifecycle test");
+        if (response instanceof Error) throw response;
         return response;
     }
 }
@@ -261,6 +264,56 @@ describe("local upgrade remote runner", () => {
         }
     });
 
+    test("converts TERM into a failed transaction and runs stage cleanup", () => {
+        const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
+        const lifecycleFunctions = [
+            shellFunctionDefinition(script, "write_status"),
+            shellFunctionDefinition(script, "finish_upgrade"),
+        ].join("\n");
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-runtime-term-")));
+        const stage = join(fixtureRoot, "stage");
+        const status = join(fixtureRoot, "run.status");
+        mkdirSync(stage, { mode: 0o700 });
+        const execution = Bun.spawnSync({
+            cmd: ["bash", "-c", [
+                "set -euo pipefail", lifecycleFunctions,
+                "trap finish_upgrade EXIT", "trap 'exit 143' TERM", "kill -TERM $$",
+            ].join("\n")],
+            env: { ...process.env, STAGE: stage, STATUS: status },
+        });
+        try {
+            expect(execution.exitCode).toBe(143);
+            expect(existsSync(stage)).toBe(false);
+            expect(readFileSync(status, "utf8").trim()).toBe("FAILED:143:TRANSACTION");
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("ignores a second TERM while the finalizer publishes success", () => {
+        const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
+        const finishFunction = shellFunctionDefinition(script, "finish_upgrade");
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-finalizer-term-")));
+        const stage = join(fixtureRoot, "stage");
+        const status = join(fixtureRoot, "run.status");
+        mkdirSync(stage, { mode: 0o700 });
+        const execution = Bun.spawnSync({
+            cmd: ["bash", "-c", [
+                "set -euo pipefail",
+                "write_status() { printf '%s\\n' \"$1\" > \"$STATUS\"; if [ \"$1\" = SUCCEEDED ]; then kill -TERM \"$$\"; fi; }",
+                finishFunction, "trap finish_upgrade EXIT", "trap 'exit 143' TERM", "exit 0",
+            ].join("\n")],
+            env: { ...process.env, STAGE: stage, STATUS: status },
+        });
+        try {
+            expect(execution.exitCode).toBe(0);
+            expect(existsSync(stage)).toBe(false);
+            expect(readFileSync(status, "utf8").trim()).toBe("SUCCEEDED");
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
     test("uses a remote verifier when capable and uploads the pinned verifier only when needed", () => {
         const installed = runScript(preparedBundle("amd64", "installed"), "amd64");
         const bundled = runScript(preparedBundle("amd64", "bundled"), "amd64");
@@ -332,6 +385,138 @@ describe("local upgrade remote runner", () => {
         }
     });
 
+    test("rolls back an adopted stage and preserves signal exit codes", () => {
+        for (const [signal, expectedCode] of [["HUP", 129], ["INT", 130], ["TERM", 143]] as const) {
+            const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), `supacloud-adopt-${signal.toLowerCase()}-`)));
+            const fixturePaths = {
+                drop: join(fixtureRoot, "drop"), stage: join(fixtureRoot, "stage"),
+                status: join(fixtureRoot, "run.status"), log: join(fixtureRoot, "run.log"),
+                unit: "supacloud-upgrade-test.service",
+            };
+            mkdirSync(fixturePaths.drop, { mode: 0o700 });
+            const execution = Bun.spawnSync(["bash", "-c", [
+                "install() { return 0; }", "systemctl() { return 1; }",
+                `chown() { kill -${signal} \"$$\"; }`,
+                buildAdoptDropScript(fixturePaths),
+            ].join("\n")]);
+            try {
+                expect(execution.exitCode).toBe(expectedCode);
+                expect(execution.stderr.toString()).toContain(`exit ${expectedCode}`);
+                expect(existsSync(fixturePaths.stage)).toBe(false);
+                expect(existsSync(fixturePaths.status)).toBe(false);
+                expect(existsSync(fixturePaths.log)).toBe(false);
+            } finally {
+                rmSync(fixtureRoot, { recursive: true, force: true });
+            }
+        }
+    });
+
+    test("disables adoption rollback after publishing PREPARED", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-adopt-success-")));
+        const fixturePaths = {
+            drop: join(fixtureRoot, "drop"), stage: join(fixtureRoot, "stage"),
+            status: join(fixtureRoot, "run.status"), log: join(fixtureRoot, "run.log"),
+            unit: "supacloud-upgrade-test.service",
+        };
+        mkdirSync(fixturePaths.drop, { mode: 0o700 });
+        const execution = Bun.spawnSync(["bash", "-c", [
+            "install() { return 0; }", "systemctl() { return 1; }", "chown() { return 0; }",
+            buildAdoptDropScript(fixturePaths),
+        ].join("\n")]);
+        try {
+            expect(execution.exitCode).toBe(0);
+            expect(existsSync(fixturePaths.drop)).toBe(false);
+            expect(existsSync(fixturePaths.stage)).toBe(true);
+            expect(readFileSync(fixturePaths.status, "utf8").trim()).toBe("PREPARED");
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("cleans a prepared inactive adoption after its SSH response is lost", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH response lost after remote adoption"),
+            remoteResult("STAGE=present\nSTATUS=PREPARED\nUNIT=inactive\nUNIT_LOAD=not-found\n"),
+            remoteResult(),
+        ]);
+
+        await expect(adoptRemoteDrop(ssh as never, paths)).rejects.toThrow("SSH response lost after remote adoption");
+        expect(ssh.commands).toHaveLength(3);
+        expect(ssh.commands[2]).toContain(paths.stage);
+        expect(ssh.commands[2]).toContain(paths.status);
+        expect(ssh.commands[2]).toContain(paths.log);
+    });
+
+    test("cleans the upload drop when failed adoption state proves the move did not persist", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH response lost before remote adoption"),
+            remoteResult("STAGE=absent\nSTATUS=\nUNIT=inactive\nUNIT_LOAD=not-found\n"),
+            remoteResult(),
+        ]);
+
+        await expect(adoptRemoteDrop(ssh as never, paths)).rejects.toThrow("SSH response lost before remote adoption");
+        expect(ssh.commands).toHaveLength(3);
+        expect(ssh.commands[2]).toContain(`rm -rf -- '${paths.drop}'`);
+        expect(ssh.commands[2]).not.toContain(paths.stage);
+    });
+
+    test("preserves adoption and upload-drop cleanup failures", async () => {
+        const ssh = new ScriptedSsh([
+            remoteResult("", false),
+            remoteResult("STAGE=absent\nSTATUS=\nUNIT=inactive\nUNIT_LOAD=not-found\n"),
+            remoteResult("", false),
+        ]);
+
+        const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(AggregateError);
+        const diagnostics = (failure as AggregateError).errors.map(String).join("\n");
+        expect(diagnostics).toContain("Unable to adopt the verified upgrade bundle");
+        expect(diagnostics).toContain("Unable to remove remote upload drop");
+        expect((failure as Error).message).toContain(`retained drop=${paths.drop}`);
+    });
+
+    test("continues observing when failed adoption reporting finds a running upgrade", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH response lost after remote adoption"),
+            remoteResult("STAGE=present\nSTATUS=RUNNING\nUNIT=active\nUNIT_LOAD=loaded\n"),
+        ]);
+
+        await expect(adoptRemoteDrop(ssh as never, paths)).resolves.toBe("already-started");
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.slice(1).some((command) => command.includes("rm -rf --"))).toBe(false);
+    });
+
+    test("retains all evidence when failed adoption state cannot be read", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH response lost after remote adoption"),
+            new Error("SSH reconnect failed"),
+        ]);
+
+        const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect((failure as AggregateError).errors.map(String).join("\n")).toContain("SSH response lost after remote adoption");
+        expect((failure as AggregateError).errors.map(String).join("\n")).toContain("SSH reconnect failed");
+        expect((failure as Error).message).toContain("do not retry blindly");
+        for (const retainedPath of [paths.drop, paths.stage, paths.status, paths.log, paths.unit]) {
+            expect((failure as Error).message).toContain(retainedPath);
+        }
+        expect(ssh.commands).toHaveLength(2);
+    });
+
+    test("retains all evidence when failed adoption state is ambiguous", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH response lost after remote adoption"),
+            remoteResult("STAGE=unsafe\nSTATUS=\nUNIT=unknown\nUNIT_LOAD=unknown\n"),
+        ]);
+
+        const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect((failure as Error).message).toContain("observed stage=unsafe status=empty unit=unknown load=unknown");
+        expect((failure as Error).message).toContain("do not retry blindly");
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.slice(1).some((command) => command.includes("rm -rf --"))).toBe(false);
+    });
+
     test("pins the temporary Linux GitHub verifier by architecture", () => {
         const arm64 = runScript(preparedBundle("arm64", "bundled"), "arm64");
 
@@ -348,6 +533,14 @@ describe("local upgrade remote runner", () => {
         await expect(startRemoteUpgrade(ssh as never, paths)).resolves.toBeUndefined();
         expect(ssh.commands).toHaveLength(2);
         expect(ssh.commands.some((command) => command.includes("rm -rf --") && command.includes(paths.stage))).toBe(false);
+    });
+
+    test("bounds the transient upgrade unit with the established maximum upgrade budget", async () => {
+        const ssh = new ScriptedSsh([remoteResult()]);
+
+        await expect(startRemoteUpgrade(ssh as never, paths)).resolves.toBeUndefined();
+        expect(ssh.commands[0]).toContain("--property=RuntimeMaxSec=1320s");
+        expect(ssh.commands[0]).toContain("--property=TimeoutStopSec=30s");
     });
 
     test("preserves start and cleanup failures when an unstarted unit cannot be removed", async () => {
@@ -401,7 +594,7 @@ describe("local upgrade remote runner", () => {
 
     test("removes terminal records only after a completed unit publishes success", async () => {
         const ssh = new ScriptedSsh([
-            remoteResult("STATUS=SUCCEEDED\nUNIT=inactive\n"),
+            remoteResult("STATUS=SUCCEEDED\nUNIT=inactive\nUNIT_LOAD=loaded\n"),
             remoteResult("upgrade committed\n"),
             remoteResult(),
         ]);
@@ -410,5 +603,60 @@ describe("local upgrade remote runner", () => {
         expect(ssh.commands).toHaveLength(3);
         expect(ssh.commands[2]).toContain(paths.status);
         expect(ssh.commands[2]).toContain(paths.log);
+    });
+
+    test("accepts success after a transient unit has been collected", async () => {
+        const ssh = new ScriptedSsh([
+            remoteResult("STATUS=SUCCEEDED\nUNIT=unknown\nUNIT_LOAD=not-found\n"),
+            remoteResult("upgrade committed\n"),
+            remoteResult(),
+        ]);
+
+        await expect(awaitRemoteUpgrade(ssh as never, paths)).resolves.toContain("Upgrade done");
+        expect(ssh.commands).toHaveLength(3);
+    });
+
+    test("rejects SUCCEEDED when systemd reports an abnormal or ambiguous stop", async () => {
+        for (const [serviceState, loadState] of [
+            ["failed", "loaded"],
+            ["maintenance", "loaded"],
+            ["unknown", "loaded"],
+            ["inactive", "unknown"],
+        ] as const) {
+            const ssh = new ScriptedSsh([
+                remoteResult(`STATUS=SUCCEEDED\nUNIT=${serviceState}\nUNIT_LOAD=${loadState}\n`),
+            ]);
+
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failure).toBeInstanceOf(Error);
+            expect((failure as Error).message).toContain(`state=${serviceState} load=${loadState}`);
+            for (const retainedPath of [paths.stage, paths.status, paths.log, paths.unit]) {
+                expect((failure as Error).message).toContain(retainedPath);
+            }
+            expect(ssh.commands).toHaveLength(1);
+        }
+    });
+
+    test("stops waiting at the total deadline without stopping or cleaning the remote unit", async () => {
+        const ssh = new ScriptedSsh([
+            remoteResult("STAGE=present\nSTATUS=RUNNING\nUNIT=active\nUNIT_LOAD=loaded\n"),
+        ]);
+        const originalNow = Date.now;
+        const timestamps = [0, 0, 1_365_000];
+        Date.now = () => timestamps.shift() ?? 1_365_000;
+        try {
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failure).toBeInstanceOf(Error);
+            expect((failure as Error).message).toContain("1320-second runtime limit");
+            expect((failure as Error).message).toContain("45-second observation grace");
+            for (const retainedPath of [paths.stage, paths.status, paths.log, paths.unit]) {
+                expect((failure as Error).message).toContain(retainedPath);
+            }
+            expect(ssh.commands).toHaveLength(1);
+            expect(ssh.commands[0]).not.toContain("systemctl stop");
+            expect(ssh.commands[0]).not.toContain("rm -rf --");
+        } finally {
+            Date.now = originalNow;
+        }
     });
 });

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -26,8 +26,12 @@ export type RemoteUpgradePaths = {
 
 type RemoteUpgradeState = {
     serviceState: string;
+    stageState: "absent" | "present" | "unsafe" | "unknown";
     status: string;
+    unitLoadState: string;
 };
+
+type AdoptionOutcome = "already-started" | "ready-to-start";
 
 export type RemoteUpgradePreflight = {
     architecture: UpgradeArchitecture;
@@ -38,6 +42,12 @@ const REMOTE_STAGE_ROOT = "/var/lib/supacloud/upgrade-staging";
 const REMOTE_RUN_ROOT = "/var/lib/supacloud/upgrade-runs";
 const REMOTE_LOG_ROOT = "/var/log/supacloud";
 const POLL_INTERVAL_MS = 2_000;
+// Match the longest existing upgrade budget, then allow systemd's stop grace and one final state read.
+const REMOTE_UPGRADE_RUNTIME_SECONDS = 22 * 60;
+const REMOTE_UPGRADE_STOP_GRACE_MS = 30_000;
+const REMOTE_STATE_READ_TIMEOUT_MS = 15_000;
+const REMOTE_UPGRADE_OBSERVATION_GRACE_MS = REMOTE_UPGRADE_STOP_GRACE_MS + REMOTE_STATE_READ_TIMEOUT_MS;
+const REMOTE_UPGRADE_WAIT_TIMEOUT_MS = REMOTE_UPGRADE_RUNTIME_SECONDS * 1_000 + REMOTE_UPGRADE_OBSERVATION_GRACE_MS;
 
 function quoteShell(shellText: string): string {
     return `'${shellText.split("'").join("'\\''")}'`;
@@ -187,7 +197,8 @@ function finishUpgradeFunction(): string {
     return [
         "finish_upgrade() {",
         "  local code=$?",
-        "  trap - EXIT HUP INT TERM",
+        "  trap '' HUP INT TERM",
+        "  trap - EXIT",
         "  set +e",
         "  if [ \"$code\" -ne 0 ]; then",
         "    write_status \"FAILED:${code}:TRANSACTION\" || true",
@@ -348,7 +359,7 @@ function failedAdoptionRollbackFunction(): string {
     return [
         "rollback_failed_adoption() {",
         "  local code=$? cleanup_failed=false",
-        "  trap - ERR",
+        "  trap - EXIT HUP INT TERM",
         "  if [ \"$ADOPTION_ACTIVE\" != true ]; then exit \"$code\"; fi",
         "  set +e",
         "  rm -rf -- \"$STAGE\" || cleanup_failed=true",
@@ -371,7 +382,10 @@ export function buildAdoptDropScript(paths: RemoteUpgradePaths): string {
         `UNIT=${quoteShell(paths.unit)}`,
         "ADOPTION_ACTIVE=false",
         failedAdoptionRollbackFunction(),
-        "trap rollback_failed_adoption ERR",
+        "trap rollback_failed_adoption EXIT",
+        "trap 'exit 129' HUP",
+        "trap 'exit 130' INT",
+        "trap 'exit 143' TERM",
         `install -d -o root -g root -m 700 ${quoteShell(REMOTE_STAGE_ROOT)} ${quoteShell(REMOTE_RUN_ROOT)} ${quoteShell(REMOTE_LOG_ROOT)}`,
         "test ! -e \"$STAGE\" && test ! -e \"$STATUS\" && test ! -e \"$LOG\"",
         "systemctl status \"$UNIT\" >/dev/null 2>&1 && { echo 'Upgrade unit already exists' >&2; exit 1; } || true",
@@ -380,19 +394,115 @@ export function buildAdoptDropScript(paths: RemoteUpgradePaths): string {
         "chown -hR root:root \"$STAGE\"",
         ": > \"$STATUS\"; : > \"$LOG\"; chmod 600 \"$STATUS\" \"$LOG\"",
         "printf 'PREPARED\\n' > \"${STATUS}.next\"; chmod 600 \"${STATUS}.next\"; mv -f \"${STATUS}.next\" \"$STATUS\"",
-        "trap - ERR",
+        "ADOPTION_ACTIVE=false",
+        "trap - EXIT HUP INT TERM",
     ].join("\n");
 }
 
-async function adoptRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
-    const adopted = await ssh.exec(rootCommand(buildAdoptDropScript(paths)), 60_000);
-    if (!adopted.success) throw remoteFailure("Unable to adopt the verified upgrade bundle", adopted);
+function adoptionHasStarted(state: RemoteUpgradeState): boolean {
+    return unitIsRunning(state.serviceState) || /^(?:RUNNING|CLEANING|SUCCEEDED|FAILED:)/.test(state.status);
+}
+
+function unitNeverStarted(state: RemoteUpgradeState): boolean {
+    return state.unitLoadState === "not-found" || state.serviceState === "inactive";
+}
+
+function adoptionCanBeRolledBack(state: RemoteUpgradeState): boolean {
+    return state.stageState === "present" && state.status === "PREPARED" && unitNeverStarted(state);
+}
+
+function adoptionDidNotPersist(state: RemoteUpgradeState): boolean {
+    return state.stageState === "absent" && !state.status && unitNeverStarted(state);
+}
+
+function retainedUpgradeEvidence(paths: RemoteUpgradePaths): string {
+    return `stage=${paths.stage} status=${paths.status} log=${paths.log} unit=${paths.unit}`;
+}
+
+function retainedAdoptionEvidence(paths: RemoteUpgradePaths): string {
+    return `drop=${paths.drop} ${retainedUpgradeEvidence(paths)}`;
+}
+
+function ambiguousAdoptionError(
+    paths: RemoteUpgradePaths,
+    failures: unknown[],
+    state?: RemoteUpgradeState,
+): AggregateError {
+    const observedState = state
+        ? ` observed stage=${state.stageState} status=${state.status || "empty"} unit=${state.serviceState} load=${state.unitLoadState};`
+        : "";
+    return new AggregateError(
+        failures,
+        `Unable to determine whether remote upgrade adoption completed; do not retry blindly;${observedState} retained ${retainedAdoptionEvidence(paths)}`,
+    );
+}
+
+async function rollbackPreparedAdoption(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    adoptionFailure: unknown,
+    state: RemoteUpgradeState,
+): Promise<never> {
+    try {
+        await cleanupUnstartedUpgrade(ssh, paths);
+    } catch (cleanupFailure: unknown) {
+        throw ambiguousAdoptionError(paths, [adoptionFailure, cleanupFailure], state);
+    }
+    throw adoptionFailure;
+}
+
+async function cleanupUnadoptedDrop(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    adoptionFailure: unknown,
+): Promise<never> {
+    try {
+        await cleanupRemoteDrop(ssh, paths);
+    } catch (cleanupFailure: unknown) {
+        throw new AggregateError(
+            [adoptionFailure, cleanupFailure],
+            `Remote upgrade adoption failed and upload-drop cleanup did not complete; retained ${retainedAdoptionEvidence(paths)}`,
+        );
+    }
+    throw adoptionFailure;
+}
+
+async function reconcileFailedAdoption(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    adoptionFailure: unknown,
+): Promise<AdoptionOutcome> {
+    let state: RemoteUpgradeState;
+    try {
+        state = await readRemoteState(ssh, paths);
+    } catch (stateFailure: unknown) {
+        throw ambiguousAdoptionError(paths, [adoptionFailure, stateFailure]);
+    }
+    if (adoptionHasStarted(state)) return "already-started";
+    if (adoptionDidNotPersist(state)) return await cleanupUnadoptedDrop(ssh, paths, adoptionFailure);
+    if (!adoptionCanBeRolledBack(state)) throw ambiguousAdoptionError(paths, [adoptionFailure], state);
+    return await rollbackPreparedAdoption(ssh, paths, adoptionFailure, state);
+}
+
+export async function adoptRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<AdoptionOutcome> {
+    let adopted: SshResult;
+    try {
+        adopted = await ssh.exec(rootCommand(buildAdoptDropScript(paths)), 60_000);
+    } catch (adoptionFailure: unknown) {
+        return await reconcileFailedAdoption(ssh, paths, adoptionFailure);
+    }
+    if (adopted.success) return "ready-to-start";
+    return await reconcileFailedAdoption(
+        ssh,
+        paths,
+        remoteFailure("Unable to adopt the verified upgrade bundle", adopted),
+    );
 }
 
 function startUnitScript(paths: RemoteUpgradePaths): string {
     return [
         "set -euo pipefail",
-        `systemd-run --quiet --collect --unit=${quoteShell(paths.unit)} --property=Type=exec --property=KillMode=control-group --property=TimeoutStopSec=30s /bin/bash ${quoteShell(`${paths.stage}/run.sh`)}`,
+        `systemd-run --quiet --collect --unit=${quoteShell(paths.unit)} --property=Type=exec --property=KillMode=control-group --property=RuntimeMaxSec=${REMOTE_UPGRADE_RUNTIME_SECONDS}s --property=TimeoutStopSec=${REMOTE_UPGRADE_STOP_GRACE_MS / 1_000}s /bin/bash ${quoteShell(`${paths.stage}/run.sh`)}`,
         `systemctl is-active --quiet ${quoteShell(paths.unit)}`,
     ].join("\n");
 }
@@ -401,7 +511,7 @@ export async function startRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
     const started = await ssh.exec(rootCommand(startUnitScript(paths)), 30_000);
     if (started.success) return;
     const state = await readRemoteState(ssh, paths);
-    if (unitIsRunning(state.serviceState) || /^(?:RUNNING|CLEANING|SUCCEEDED|FAILED:)/.test(state.status)) return;
+    if (adoptionHasStarted(state)) return;
     const startFailure = remoteFailure("Unable to start the transient upgrade unit", started);
     try {
         await cleanupUnstartedUpgrade(ssh, paths);
@@ -414,19 +524,29 @@ export async function startRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
 function readStateScript(paths: RemoteUpgradePaths): string {
     return [
         "set -euo pipefail",
+        `STAGE=${quoteShell(paths.stage)}`,
         `STATUS=${quoteShell(paths.status)}`,
         `UNIT=${quoteShell(paths.unit)}`,
+        "if test -d \"$STAGE\" && test ! -L \"$STAGE\"; then echo STAGE=present; elif test -e \"$STAGE\" || test -L \"$STAGE\"; then echo STAGE=unsafe; else echo STAGE=absent; fi",
         "printf 'STATUS=%s\\n' \"$(sed -n '1p' \"$STATUS\" 2>/dev/null || true)\"",
         "printf 'UNIT=%s\\n' \"$(systemctl is-active \"$UNIT\" 2>/dev/null || true)\"",
+        "printf 'UNIT_LOAD=%s\\n' \"$(systemctl show \"$UNIT\" --property=LoadState --value 2>/dev/null || true)\"",
     ].join("\n");
 }
 
-async function readRemoteState(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<RemoteUpgradeState> {
-    const state = await ssh.exec(rootCommand(readStateScript(paths)), 15_000);
+async function readRemoteState(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    timeoutMs = REMOTE_STATE_READ_TIMEOUT_MS,
+): Promise<RemoteUpgradeState> {
+    const state = await ssh.exec(rootCommand(readStateScript(paths)), timeoutMs);
     if (!state.success) throw remoteFailure("Unable to read remote upgrade state", state);
+    const stageState = state.stdout.match(/^STAGE=(absent|present|unsafe)$/m)?.[1] || "unknown";
     return {
         status: state.stdout.match(/^STATUS=(.*)$/m)?.[1]?.trim() || "",
         serviceState: state.stdout.match(/^UNIT=(.*)$/m)?.[1]?.trim() || "unknown",
+        stageState: stageState as RemoteUpgradeState["stageState"],
+        unitLoadState: state.stdout.match(/^UNIT_LOAD=(.*)$/m)?.[1]?.trim() || "unknown",
     };
 }
 
@@ -474,6 +594,19 @@ function unitIsRunning(serviceState: string): boolean {
     return ["active", "activating", "deactivating", "reloading"].includes(serviceState);
 }
 
+function unitStoppedNormally(state: RemoteUpgradeState): boolean {
+    return (state.serviceState === "inactive" && ["loaded", "not-found"].includes(state.unitLoadState))
+        || (state.serviceState === "unknown" && state.unitLoadState === "not-found");
+}
+
+function assertSuccessfulUnitStoppedNormally(state: RemoteUpgradeState, paths: RemoteUpgradePaths): void {
+    if (unitStoppedNormally(state)) return;
+    throw new Error(
+        `Remote upgrade published SUCCEEDED but the unit stopped abnormally or ambiguously `
+        + `(state=${state.serviceState} load=${state.unitLoadState}); retained ${retainedUpgradeEvidence(paths)}`,
+    );
+}
+
 async function completedUpgradeOutput(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
     const log = await remoteLogTail(ssh, paths);
     await cleanupRemoteRecords(ssh, paths);
@@ -502,23 +635,67 @@ function assertObservableUpgradeState(state: RemoteUpgradeState, unitRunning: bo
     }
 }
 
+function remoteUpgradeTimeout(paths: RemoteUpgradePaths, state?: RemoteUpgradeState): Error {
+    const observation = state
+        ? ` last status=${state.status || "empty"} unit_state=${state.serviceState};`
+        : "";
+    return new Error(
+        `Remote local upgrade exceeded the ${REMOTE_UPGRADE_RUNTIME_SECONDS}-second runtime limit and `
+        + `${REMOTE_UPGRADE_OBSERVATION_GRACE_MS / 1_000}-second observation grace;${observation} remote unit was not stopped; `
+        + `retained ${retainedUpgradeEvidence(paths)}; do not retry blindly`,
+    );
+}
+
+async function readRemoteStateBeforeDeadline(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    deadline: number,
+): Promise<RemoteUpgradeState> {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) throw remoteUpgradeTimeout(paths);
+    try {
+        return await readRemoteState(ssh, paths, Math.min(REMOTE_STATE_READ_TIMEOUT_MS, remainingMs));
+    } catch (stateFailure: unknown) {
+        if (Date.now() < deadline) throw stateFailure;
+        throw new AggregateError(
+            [remoteUpgradeTimeout(paths), stateFailure],
+            `Remote upgrade observation reached its deadline while reading state; retained ${retainedUpgradeEvidence(paths)}`,
+        );
+    }
+}
+
+function nextStoppedObservationCount(
+    state: RemoteUpgradeState,
+    unitRunning: boolean,
+    previousCount: number,
+    paths: RemoteUpgradePaths,
+): number {
+    const stoppedCount = unitRunning ? 0 : previousCount + 1;
+    if (stoppedCount >= 3 && ["PREPARED", "RUNNING", "CLEANING"].includes(state.status)) {
+        throw new Error(`Remote upgrade unit stopped before publishing a terminal status; retained ${retainedUpgradeEvidence(paths)}`);
+    }
+    return stoppedCount;
+}
+
 export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
+    const deadline = Date.now() + REMOTE_UPGRADE_WAIT_TIMEOUT_MS;
     let stoppedObservations = 0;
     while (true) {
-        const state = await readRemoteState(ssh, paths);
+        const state = await readRemoteStateBeforeDeadline(ssh, paths, deadline);
+        if (Date.now() >= deadline) throw remoteUpgradeTimeout(paths, state);
         const unitRunning = unitIsRunning(state.serviceState);
         if (state.status === "SUCCEEDED" && !unitRunning) {
+            assertSuccessfulUnitStoppedNormally(state, paths);
             return await completedUpgradeOutput(ssh, paths);
         }
         if (state.status.startsWith("FAILED:") && !unitRunning) {
             await throwRemoteUpgradeFailure(ssh, paths, state.status);
         }
         assertObservableUpgradeState(state, unitRunning, paths);
-        stoppedObservations = unitRunning ? 0 : stoppedObservations + 1;
-        if (stoppedObservations >= 3 && ["PREPARED", "RUNNING", "CLEANING"].includes(state.status)) {
-            throw new Error(`Remote upgrade unit stopped before publishing a terminal status; retained status=${paths.status} log=${paths.log}`);
-        }
-        await delay(POLL_INTERVAL_MS);
+        stoppedObservations = nextStoppedObservationCount(state, unitRunning, stoppedObservations, paths);
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) throw remoteUpgradeTimeout(paths, state);
+        await delay(Math.min(POLL_INTERVAL_MS, remainingMs));
     }
 }
 
@@ -527,20 +704,20 @@ export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: Lo
     const paths = remotePaths(runId);
     const preflight = await remoteUpgradePreflight(ssh);
     const bundle = await prepareLocalUpgradeBundle({ ...preflight, ...request });
-    let adopted = false;
+    let adoptionCommandSent = false;
     let transferError: unknown;
     try {
         try {
             await prepareRemoteDrop(ssh, paths, bundle);
             await uploadBundleFiles(ssh, paths, bundle);
             await uploadRunScript(ssh, paths, bundle, request, preflight.architecture);
-            await adoptRemoteDrop(ssh, paths);
-            adopted = true;
-            await startRemoteUpgrade(ssh, paths);
+            adoptionCommandSent = true;
+            const adoption = await adoptRemoteDrop(ssh, paths);
+            if (adoption === "ready-to-start") await startRemoteUpgrade(ssh, paths);
             return await awaitRemoteUpgrade(ssh, paths);
         } catch (error: unknown) {
             transferError = error;
-            if (!adopted) {
+            if (!adoptionCommandSent) {
                 try {
                     await cleanupRemoteDrop(ssh, paths);
                 } catch (cleanupError: unknown) {

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -1,0 +1,565 @@
+import { randomUUID } from "node:crypto";
+import { basename } from "node:path";
+
+import type { SshResult, SshTransport } from "../transports/ssh";
+import {
+    cleanupLocalUpgradeBundle,
+    githubCliArchiveIdentity,
+    prepareLocalUpgradeBundle,
+    STRICT_GITHUB_CAPABILITY_FLAGS,
+    type PreparedLocalUpgradeBundle,
+    type UpgradeArchitecture,
+} from "./local-upgrade-bundle";
+
+export type LocalUpgradeTransferRequest = {
+    managementVersion: string;
+    edgeRuntimeVersion: string;
+};
+
+export type RemoteUpgradePaths = {
+    drop: string;
+    log: string;
+    stage: string;
+    status: string;
+    unit: string;
+};
+
+type RemoteUpgradeState = {
+    serviceState: string;
+    status: string;
+};
+
+export type RemoteUpgradePreflight = {
+    architecture: UpgradeArchitecture;
+    verifierProvisioning: "installed" | "bundled";
+};
+
+const REMOTE_STAGE_ROOT = "/var/lib/supacloud/upgrade-staging";
+const REMOTE_RUN_ROOT = "/var/lib/supacloud/upgrade-runs";
+const REMOTE_LOG_ROOT = "/var/log/supacloud";
+const POLL_INTERVAL_MS = 2_000;
+
+function quoteShell(shellText: string): string {
+    return `'${shellText.split("'").join("'\\''")}'`;
+}
+
+function rootCommand(script: string): string {
+    return [
+        "if [ \"$(id -u)\" -eq 0 ]; then",
+        `  /bin/bash -c ${quoteShell(script)}`,
+        "else",
+        "  sudo -n true",
+        `  sudo -n /bin/bash -c ${quoteShell(script)}`,
+        "fi",
+    ].join("\n");
+}
+
+function trustedInstalledGithubFunction(): string {
+    return [
+        "trusted_installed_gh() {",
+        "  local verifier=$1 mode",
+        "  test -f \"$verifier\" && test ! -L \"$verifier\" && test -x \"$verifier\" || { echo 'Installed GitHub verifier is not a regular executable file' >&2; return 1; }",
+        "  test \"$(stat -c '%u:%g' \"$verifier\")\" = '0:0' || { echo 'Installed GitHub verifier is not owned by root:root' >&2; return 1; }",
+        "  mode=$(stat -c '%a' \"$verifier\")",
+        "  case \"$mode\" in [0-7]|[0-7][0-7]|[0-7][0-7][0-7]) ;; *) echo 'Installed GitHub verifier has special permission bits' >&2; return 1 ;; esac",
+        "  (( (8#$mode & 0022) == 0 )) || { echo 'Installed GitHub verifier is group/other writable' >&2; return 1; }",
+        "}",
+    ].join("\n");
+}
+
+function remotePaths(runId: string): RemoteUpgradePaths {
+    return {
+        drop: `/tmp/.supacloud-upgrade-upload-${runId}`,
+        stage: `${REMOTE_STAGE_ROOT}/${runId}`,
+        status: `${REMOTE_RUN_ROOT}/${runId}.status`,
+        log: `${REMOTE_LOG_ROOT}/upgrade-${runId}.log`,
+        unit: `supacloud-upgrade-${runId}.service`,
+    };
+}
+
+export function parseRemotePreflight(output: string): RemoteUpgradePreflight {
+    const architecture = output.match(/^ARCH=(amd64|arm64)$/m)?.[1];
+    const verifierProvisioning = output.match(/^VERIFIER=(installed|bundled)$/m)?.[1];
+    if (!architecture || !verifierProvisioning) {
+        throw new Error("Remote upgrade preflight did not return its architecture and verifier capability");
+    }
+    return {
+        architecture: architecture as UpgradeArchitecture,
+        verifierProvisioning: verifierProvisioning as RemoteUpgradePreflight["verifierProvisioning"],
+    };
+}
+
+export function buildRemotePreflightScript(): string {
+    const capabilityFlags = STRICT_GITHUB_CAPABILITY_FLAGS.join(" ");
+    return [
+        "set -euo pipefail",
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "export PATH",
+        trustedInstalledGithubFunction(),
+        "test -d /run/systemd/system || { echo 'systemd is not the active init system' >&2; exit 1; }",
+        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep timeout; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "systemd-run --help | grep -Eq -- '(^|[[:space:]])--collect([=[:space:]]|$)' || { echo 'systemd-run --collect is required' >&2; exit 1; }",
+        "test -d /var/lib/supacloud || { echo '/var/lib/supacloud is unavailable' >&2; exit 1; }",
+        "test -f /etc/supabase/management-api.env || { echo 'EDGE_RUNTIME_MODE is unavailable' >&2; exit 1; }",
+        "EDGE_MODE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\\"'\"']+|[[:space:]\\\"'\"']+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
+        "test \"$EDGE_MODE\" = external || { echo 'Local component upgrade requires persisted external Edge Runtime mode' >&2; exit 1; }",
+        "case \"$(uname -m)\" in x86_64|amd64) echo ARCH=amd64 ;; aarch64|arm64) echo ARCH=arm64 ;; *) echo 'Unsupported remote architecture' >&2; exit 1 ;; esac",
+        "VERIFIER=bundled",
+        "GH=$(type -P gh || true)",
+        "if [ -n \"$GH\" ] && trusted_installed_gh \"$GH\"; then",
+        "  if GH_HELP=$(timeout 15s \"$GH\" attestation verify --help 2>&1); then",
+        "    GH_CAPABLE=true",
+        `    for flag in ${capabilityFlags}; do printf '%s\\n' \"$GH_HELP\" | grep -Eq -- \"(^|[[:space:]])${"$"}{flag}([=[:space:]]|$)\" || GH_CAPABLE=false; done`,
+        "    if [ \"$GH_CAPABLE\" = true ]; then VERIFIER=installed; fi",
+        "  fi",
+        "fi",
+        "echo VERIFIER=$VERIFIER",
+    ].join("\n");
+}
+
+export async function remoteUpgradePreflight(ssh: SshTransport): Promise<RemoteUpgradePreflight> {
+    const preflight = await ssh.exec(rootCommand(buildRemotePreflightScript()), 30_000);
+    if (!preflight.success) throw remoteFailure("Remote local-upgrade preflight failed", preflight);
+    return parseRemotePreflight(preflight.stdout);
+}
+
+function requiredRemoteBytes(bundle: PreparedLocalUpgradeBundle): number {
+    const transferBytes = [...bundle.files, ...(bundle.verifierArchive ? [bundle.verifierArchive] : [])]
+        .reduce((total, upload) => total + upload.size, 0);
+    return transferBytes * 3 + 512 * 1024 * 1024;
+}
+
+function prepareDropCommand(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): string {
+    const directories = [
+        paths.drop,
+        `${paths.drop}/bundle`,
+        `${paths.drop}/bundle/management-api`,
+        `${paths.drop}/bundle/edge-runtime`,
+    ];
+    if (bundle.verifierArchive) directories.push(`${paths.drop}/verifier`);
+    const requiredBytes = requiredRemoteBytes(bundle);
+    return [
+        "set -euo pipefail",
+        "umask 077",
+        `test ! -e ${quoteShell(paths.drop)} || { echo 'Remote upload drop already exists' >&2; exit 1; }`,
+        "TMP_AVAILABLE_KB=$(df -Pk /tmp | awk 'NR == 2 { print $4 }')",
+        "VAR_AVAILABLE_KB=$(df -Pk /var/lib/supacloud | awk 'NR == 2 { print $4 }')",
+        `test \"${"$"}TMP_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} && test \"${"$"}VAR_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} || { echo 'Insufficient remote disk space for verified upgrade staging' >&2; exit 1; }`,
+        `install -d -m 700 ${directories.map(quoteShell).join(" ")}`,
+    ].join("\n");
+}
+
+async function prepareRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): Promise<void> {
+    const prepared = await ssh.exec(prepareDropCommand(paths, bundle), 30_000);
+    if (!prepared.success) throw remoteFailure("Unable to prepare remote upload drop", prepared);
+}
+
+async function uploadBundleFiles(ssh: SshTransport, paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): Promise<void> {
+    const uploads = [...bundle.files, ...(bundle.verifierArchive ? [bundle.verifierArchive] : [])];
+    for (const upload of uploads) {
+        await ssh.upload(upload.localPath, `${paths.drop}/${upload.relativePath}`, { mode: 0o600, timeoutMs: 10 * 60_000 });
+    }
+}
+
+function expectedComponentFiles(bundle: PreparedLocalUpgradeBundle): { management: string[]; edge: string[] } {
+    return {
+        management: [
+            "SHA256SUMS",
+            "SUPACLOUD-RELEASE.attestation.jsonl",
+            "SUPACLOUD-RELEASE.json",
+            bundle.managementBinaryName,
+            "web-console-build.tar.gz",
+        ],
+        edge: [
+            "SHA256SUMS",
+            "SUPACLOUD-RELEASE.attestation.jsonl",
+            "SUPACLOUD-RELEASE.json",
+            bundle.edgeRuntimeBinaryName,
+        ],
+    };
+}
+
+function shellArray(name: string, entries: string[]): string {
+    return `${name}=(${entries.map(quoteShell).join(" ")})`;
+}
+
+function finishUpgradeFunction(): string {
+    return [
+        "finish_upgrade() {",
+        "  local code=$?",
+        "  trap - EXIT HUP INT TERM",
+        "  set +e",
+        "  if [ \"$code\" -ne 0 ]; then",
+        "    write_status \"FAILED:${code}:TRANSACTION\" || true",
+        "    if ! rm -rf -- \"$STAGE\"; then write_status \"FAILED:${code}:TRANSACTION_AND_CLEANUP\" || true; fi",
+        "    exit \"$code\"",
+        "  fi",
+        "  write_status CLEANING || { echo 'Unable to publish cleanup state' >&2; exit 1; }",
+        "  if ! rm -rf -- \"$STAGE\"; then",
+        "    write_status 'FAILED:1:CLEANUP_AFTER_TRANSACTION' || true",
+        "    exit 1",
+        "  fi",
+        "  write_status SUCCEEDED || exit 1",
+        "  exit 0",
+        "}",
+    ].join("\n");
+}
+
+function upgradeScriptSetup(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): string[] {
+    const bundleDirectory = `${paths.stage}/bundle`;
+    return [
+        "#!/usr/bin/env bash", "set -euo pipefail", "umask 077",
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "export PATH",
+        `STAGE=${quoteShell(paths.stage)}`, `STATUS=${quoteShell(paths.status)}`, `LOG=${quoteShell(paths.log)}`,
+        `BUNDLE=${quoteShell(bundleDirectory)}`,
+        `MANAGEMENT_DIR=${quoteShell(`${bundleDirectory}/management-api`)}`,
+        `EDGE_DIR=${quoteShell(`${bundleDirectory}/edge-runtime`)}`,
+        "write_status() { local next=\"${STATUS}.next\"; printf '%s\\n' \"$1\" > \"$next\"; chmod 600 \"$next\"; mv -f \"$next\" \"$STATUS\"; }",
+        finishUpgradeFunction(),
+        "trap finish_upgrade EXIT", "trap 'exit 129' HUP", "trap 'exit 130' INT", "trap 'exit 143' TERM",
+        "exec >>\"$LOG\" 2>&1", "write_status RUNNING",
+        "while IFS='=' read -r variable _; do case \"$variable\" in *PROXY*|*Proxy*|*proxy*) unset \"$variable\" ;; esac; done < <(env)",
+        "unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE SUPACLOUD_GITHUB_REPOSITORY SUPACLOUD_RELEASES_API SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW NODE_USE_ENV_PROXY",
+    ];
+}
+
+function upgradeScriptFilesystemChecks(bundle: PreparedLocalUpgradeBundle): string[] {
+    const componentFiles = expectedComponentFiles(bundle);
+    const stageEntries = ["bundle", "run.sh", ...(bundle.verifierArchive ? ["verifier"] : [])];
+    const checks = [
+        shellArray("MANAGEMENT_FILES", componentFiles.management), shellArray("EDGE_FILES", componentFiles.edge),
+        "assert_directory() { local path=$1; test -d \"$path\" && test ! -L \"$path\"; test \"$(stat -c '%u:%g' \"$path\")\" = '0:0'; test \"$(stat -c '%a' \"$path\")\" = '700'; }",
+        "assert_file() { local path=$1 parent=$2; test -f \"$path\" && test ! -L \"$path\"; test \"$(stat -c '%u:%g:%h' \"$path\")\" = '0:0:1'; test \"$(stat -c '%a' \"$path\")\" = '600'; test \"$(dirname \"$(realpath \"$path\")\")\" = \"$parent\"; }",
+        "assert_entries() { local directory=$1; shift; local actual expected; actual=$(find \"$directory\" -mindepth 1 -maxdepth 1 -printf '%f\\n' | LC_ALL=C sort); expected=$(printf '%s\\n' \"$@\" | LC_ALL=C sort); test \"$actual\" = \"$expected\"; }",
+        "assert_directory \"$STAGE\"", shellArray("STAGE_FILES", stageEntries),
+        "assert_entries \"$STAGE\" \"${STAGE_FILES[@]}\"", "assert_file \"$STAGE/run.sh\" \"$STAGE\"",
+        "assert_directory \"$BUNDLE\"",
+        "assert_entries \"$BUNDLE\" edge-runtime management-api",
+        "assert_directory \"$MANAGEMENT_DIR\"", "assert_directory \"$EDGE_DIR\"",
+        "assert_entries \"$MANAGEMENT_DIR\" \"${MANAGEMENT_FILES[@]}\"",
+        "assert_entries \"$EDGE_DIR\" \"${EDGE_FILES[@]}\"",
+        "for name in \"${MANAGEMENT_FILES[@]}\"; do assert_file \"$MANAGEMENT_DIR/$name\" \"$MANAGEMENT_DIR\"; done",
+        "for name in \"${EDGE_FILES[@]}\"; do assert_file \"$EDGE_DIR/$name\" \"$EDGE_DIR\"; done",
+    ];
+    if (bundle.verifierArchive) {
+        const archiveName = basename(bundle.verifierArchive.relativePath);
+        checks.push(
+            "assert_directory \"$STAGE/verifier\"",
+            `assert_entries \"$STAGE/verifier\" ${quoteShell(archiveName)}`,
+            `assert_file \"$STAGE/verifier/${archiveName}\" \"$STAGE/verifier\"`,
+        );
+    }
+    return checks;
+}
+
+function upgradeScriptTransferVerification(bundle: PreparedLocalUpgradeBundle): string[] {
+    const files = [...bundle.files, ...(bundle.verifierArchive ? [bundle.verifierArchive] : [])];
+    return [
+        "verify_transfer() { local relative=$1 expected_size=$2 expected_sha=$3 path=$STAGE/$relative; test \"$(stat -c '%s' \"$path\")\" = \"$expected_size\"; test \"$(sha256sum \"$path\" | awk '{print $1}')\" = \"$expected_sha\"; }",
+        ...files.map((file) => (
+            `verify_transfer ${quoteShell(file.relativePath)} ${file.size} ${quoteShell(file.sha256)}`
+        )),
+    ];
+}
+
+function upgradeScriptVerifier(
+    paths: RemoteUpgradePaths,
+    bundle: PreparedLocalUpgradeBundle,
+    architecture: UpgradeArchitecture,
+): string[] {
+    const setup = bundle.verifierArchive
+        ? bundledVerifierSetup(paths, architecture)
+        : [
+            trustedInstalledGithubFunction(),
+            "GH=$(type -P gh)",
+            "trusted_installed_gh \"$GH\" || { echo 'Installed GitHub verifier trust check failed' >&2; exit 1; }",
+        ];
+    const capabilityFlags = STRICT_GITHUB_CAPABILITY_FLAGS.join(" ");
+    return [
+        ...setup,
+        "GH_HELP=$(timeout 15s \"$GH\" attestation verify --help 2>&1) || { echo 'GitHub verifier capability check failed' >&2; exit 1; }",
+        `for flag in ${capabilityFlags}; do printf '%s\\n' \"$GH_HELP\" | grep -Eq -- \"(^|[[:space:]])${"$"}{flag}([=[:space:]]|$)\" || { echo \"GitHub verifier lacks $flag\" >&2; exit 1; }; done`,
+        "VERIFIER_PATH=$(dirname \"$GH\")",
+    ];
+}
+
+function bundledVerifierSetup(paths: RemoteUpgradePaths, architecture: UpgradeArchitecture): string[] {
+    const verifier = githubCliArchiveIdentity(architecture);
+    return [
+        `GH_ARCHIVE=${quoteShell(`${paths.stage}/verifier/${verifier.archiveName}`)}`,
+        `GH_MEMBER=${quoteShell(verifier.member)}`,
+        "test \"$(tar -tzf \"$GH_ARCHIVE\" | grep -Fxc \"$GH_MEMBER\")\" = 1",
+        "test \"$(tar -tvzf \"$GH_ARCHIVE\" \"$GH_MEMBER\" | cut -c1)\" = '-'",
+        "VERIFIER_ROOT=$(mktemp -d \"${STAGE}/verifier/gh.XXXXXX\")",
+        "tar --no-same-owner --same-permissions -xzf \"$GH_ARCHIVE\" -C \"$VERIFIER_ROOT\" \"$GH_MEMBER\"",
+        "test \"$(stat -c '%a' \"$VERIFIER_ROOT/$GH_MEMBER\")\" = '755'",
+        "install -m 0755 \"$VERIFIER_ROOT/$GH_MEMBER\" \"${STAGE}/verifier/gh\"",
+        "rm -rf -- \"$VERIFIER_ROOT\"",
+        "GH=${STAGE}/verifier/gh",
+        `case \"$(\"$GH\" --version | head -1)\" in 'gh version ${verifier.version}'*) ;; *) echo 'Pinned GitHub verifier version mismatch' >&2; exit 1 ;; esac`,
+    ];
+}
+
+function upgradeScriptExecution(
+    paths: RemoteUpgradePaths,
+    bundle: PreparedLocalUpgradeBundle,
+    request: LocalUpgradeTransferRequest,
+): string[] {
+    const runnerAsset = `${paths.stage}/bundle/management-api/${bundle.managementBinaryName}`;
+    const runner = `${paths.stage}/runner`;
+    return [
+        `MANAGEMENT_VERSION=${quoteShell(request.managementVersion)}`,
+        `RUNNER_ASSET=${quoteShell(runnerAsset)}`,
+        `RUNNER=${quoteShell(runner)}`,
+        "file -b \"$RUNNER_ASSET\" | grep -q ELF",
+        "install -m 0755 \"$RUNNER_ASSET\" \"$RUNNER\"",
+        "test \"$(sha256sum \"$RUNNER\"|awk '{print $1}')\" = \"$(sha256sum \"$RUNNER_ASSET\"|awk '{print $1}')\"",
+        "\"$RUNNER\" --version | grep -Eq \"(^|[^0-9])${MANAGEMENT_VERSION//./\\.}([^0-9]|$)\"",
+        `env PATH=\"$VERIFIER_PATH:$PATH\" \"$RUNNER\" upgrade --yes --target-version ${quoteShell(request.managementVersion)} --edge-runtime-version ${quoteShell(request.edgeRuntimeVersion)} --asset-bundle-dir \"$BUNDLE\"`,
+    ];
+}
+
+export function buildLocalUpgradeRunScript(
+    paths: RemoteUpgradePaths,
+    bundle: PreparedLocalUpgradeBundle,
+    request: LocalUpgradeTransferRequest,
+    architecture: UpgradeArchitecture,
+): string {
+    return [
+        ...upgradeScriptSetup(paths, bundle),
+        ...upgradeScriptFilesystemChecks(bundle),
+        ...upgradeScriptTransferVerification(bundle),
+        ...upgradeScriptVerifier(paths, bundle, architecture),
+        ...upgradeScriptExecution(paths, bundle, request),
+    ].join("\n");
+}
+
+async function uploadRunScript(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    bundle: PreparedLocalUpgradeBundle,
+    request: LocalUpgradeTransferRequest,
+    architecture: UpgradeArchitecture,
+): Promise<void> {
+    await ssh.uploadText(`${paths.drop}/run.sh`, buildLocalUpgradeRunScript(paths, bundle, request, architecture), 0o600);
+}
+
+function failedAdoptionRollbackFunction(): string {
+    return [
+        "rollback_failed_adoption() {",
+        "  local code=$? cleanup_failed=false",
+        "  trap - ERR",
+        "  if [ \"$ADOPTION_ACTIVE\" != true ]; then exit \"$code\"; fi",
+        "  set +e",
+        "  rm -rf -- \"$STAGE\" || cleanup_failed=true",
+        "  rm -f -- \"$STATUS\" \"${STATUS}.next\" \"$LOG\" || cleanup_failed=true",
+        "  if [ \"$cleanup_failed\" = true ]; then echo \"Upgrade adoption failed (exit $code) and rollback did not complete\" >&2; exit 1; fi",
+        "  echo \"Upgrade adoption failed (exit $code); transferred state was rolled back\" >&2",
+        "  exit \"$code\"",
+        "}",
+    ].join("\n");
+}
+
+export function buildAdoptDropScript(paths: RemoteUpgradePaths): string {
+    return [
+        "set -euo pipefail",
+        "umask 077",
+        `DROP=${quoteShell(paths.drop)}`,
+        `STAGE=${quoteShell(paths.stage)}`,
+        `STATUS=${quoteShell(paths.status)}`,
+        `LOG=${quoteShell(paths.log)}`,
+        `UNIT=${quoteShell(paths.unit)}`,
+        "ADOPTION_ACTIVE=false",
+        failedAdoptionRollbackFunction(),
+        "trap rollback_failed_adoption ERR",
+        `install -d -o root -g root -m 700 ${quoteShell(REMOTE_STAGE_ROOT)} ${quoteShell(REMOTE_RUN_ROOT)} ${quoteShell(REMOTE_LOG_ROOT)}`,
+        "test ! -e \"$STAGE\" && test ! -e \"$STATUS\" && test ! -e \"$LOG\"",
+        "systemctl status \"$UNIT\" >/dev/null 2>&1 && { echo 'Upgrade unit already exists' >&2; exit 1; } || true",
+        "ADOPTION_ACTIVE=true",
+        "mv \"$DROP\" \"$STAGE\"",
+        "chown -hR root:root \"$STAGE\"",
+        ": > \"$STATUS\"; : > \"$LOG\"; chmod 600 \"$STATUS\" \"$LOG\"",
+        "printf 'PREPARED\\n' > \"${STATUS}.next\"; chmod 600 \"${STATUS}.next\"; mv -f \"${STATUS}.next\" \"$STATUS\"",
+        "trap - ERR",
+    ].join("\n");
+}
+
+async function adoptRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
+    const adopted = await ssh.exec(rootCommand(buildAdoptDropScript(paths)), 60_000);
+    if (!adopted.success) throw remoteFailure("Unable to adopt the verified upgrade bundle", adopted);
+}
+
+function startUnitScript(paths: RemoteUpgradePaths): string {
+    return [
+        "set -euo pipefail",
+        `systemd-run --quiet --collect --unit=${quoteShell(paths.unit)} --property=Type=exec --property=KillMode=control-group --property=TimeoutStopSec=30s /bin/bash ${quoteShell(`${paths.stage}/run.sh`)}`,
+        `systemctl is-active --quiet ${quoteShell(paths.unit)}`,
+    ].join("\n");
+}
+
+export async function startRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
+    const started = await ssh.exec(rootCommand(startUnitScript(paths)), 30_000);
+    if (started.success) return;
+    const state = await readRemoteState(ssh, paths);
+    if (unitIsRunning(state.serviceState) || /^(?:RUNNING|CLEANING|SUCCEEDED|FAILED:)/.test(state.status)) return;
+    const startFailure = remoteFailure("Unable to start the transient upgrade unit", started);
+    try {
+        await cleanupUnstartedUpgrade(ssh, paths);
+    } catch (cleanupError: unknown) {
+        throw new AggregateError([startFailure, cleanupError], "Remote upgrade start and cleanup both failed");
+    }
+    throw startFailure;
+}
+
+function readStateScript(paths: RemoteUpgradePaths): string {
+    return [
+        "set -euo pipefail",
+        `STATUS=${quoteShell(paths.status)}`,
+        `UNIT=${quoteShell(paths.unit)}`,
+        "printf 'STATUS=%s\\n' \"$(sed -n '1p' \"$STATUS\" 2>/dev/null || true)\"",
+        "printf 'UNIT=%s\\n' \"$(systemctl is-active \"$UNIT\" 2>/dev/null || true)\"",
+    ].join("\n");
+}
+
+async function readRemoteState(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<RemoteUpgradeState> {
+    const state = await ssh.exec(rootCommand(readStateScript(paths)), 15_000);
+    if (!state.success) throw remoteFailure("Unable to read remote upgrade state", state);
+    return {
+        status: state.stdout.match(/^STATUS=(.*)$/m)?.[1]?.trim() || "",
+        serviceState: state.stdout.match(/^UNIT=(.*)$/m)?.[1]?.trim() || "unknown",
+    };
+}
+
+async function remoteLogTail(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
+    const output = await ssh.exec(rootCommand(`tail -80 ${quoteShell(paths.log)} 2>/dev/null || true`), 15_000);
+    if (!output.success) throw remoteFailure("Unable to read the remote upgrade log", output);
+    return output.stdout.slice(-4_000);
+}
+
+async function cleanupRemoteRecords(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
+    const cleanup = await ssh.exec(rootCommand(`rm -f -- ${quoteShell(paths.status)} ${quoteShell(paths.log)}`), 15_000);
+    if (!cleanup.success) throw remoteFailure("Unable to remove remote upgrade status records", cleanup);
+}
+
+export function buildCleanupUnstartedUpgradeScript(paths: RemoteUpgradePaths): string {
+    return [
+        "set -euo pipefail",
+        "cleanup_failed=false",
+        `rm -rf -- ${quoteShell(paths.stage)} || cleanup_failed=true`,
+        `rm -f -- ${quoteShell(paths.status)} ${quoteShell(paths.log)} || cleanup_failed=true`,
+        "test \"$cleanup_failed\" = false",
+    ].join("\n");
+}
+
+async function cleanupUnstartedUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
+    const cleanup = await ssh.exec(rootCommand(buildCleanupUnstartedUpgradeScript(paths)), 15_000);
+    if (!cleanup.success) throw remoteFailure("Unable to clean an unstarted local upgrade", cleanup);
+}
+
+async function cleanupRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
+    const cleanup = await ssh.exec(`rm -rf -- ${quoteShell(paths.drop)}`, 15_000);
+    if (!cleanup.success) throw remoteFailure("Unable to remove remote upload drop", cleanup);
+}
+
+function remoteFailure(message: string, execution: SshResult): Error {
+    const diagnostic = execution.stderr.trim() || execution.stdout.trim() || `exit ${execution.code}`;
+    return new Error(`${message}: ${diagnostic.slice(-500)}`);
+}
+
+function delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function unitIsRunning(serviceState: string): boolean {
+    return ["active", "activating", "deactivating", "reloading"].includes(serviceState);
+}
+
+async function completedUpgradeOutput(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
+    const log = await remoteLogTail(ssh, paths);
+    await cleanupRemoteRecords(ssh, paths);
+    return `✅ Upgrade done\n${log.slice(-1_500)}`;
+}
+
+async function throwRemoteUpgradeFailure(ssh: SshTransport, paths: RemoteUpgradePaths, status: string): Promise<never> {
+    const log = await remoteLogTail(ssh, paths);
+    const failure = new Error(`Remote local upgrade failed (${status}): ${log.slice(-1_500)}`);
+    if (status.includes("CLEANUP")) {
+        throw new Error(`${failure.message}; retained status=${paths.status} log=${paths.log}`);
+    }
+    try {
+        await cleanupRemoteRecords(ssh, paths);
+    } catch (cleanupError: unknown) {
+        throw new AggregateError([failure, cleanupError], "Remote local upgrade failed and status cleanup did not complete");
+    }
+    throw failure;
+}
+
+function assertObservableUpgradeState(state: RemoteUpgradeState, unitRunning: boolean, paths: RemoteUpgradePaths): void {
+    const knownStatus = ["PREPARED", "RUNNING", "CLEANING", "SUCCEEDED"].includes(state.status)
+        || state.status.startsWith("FAILED:");
+    if (!unitRunning && !knownStatus) {
+        throw new Error(`Remote upgrade stopped without a terminal status; retained status=${paths.status} log=${paths.log}`);
+    }
+}
+
+export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
+    let stoppedObservations = 0;
+    while (true) {
+        const state = await readRemoteState(ssh, paths);
+        const unitRunning = unitIsRunning(state.serviceState);
+        if (state.status === "SUCCEEDED" && !unitRunning) {
+            return await completedUpgradeOutput(ssh, paths);
+        }
+        if (state.status.startsWith("FAILED:") && !unitRunning) {
+            await throwRemoteUpgradeFailure(ssh, paths, state.status);
+        }
+        assertObservableUpgradeState(state, unitRunning, paths);
+        stoppedObservations = unitRunning ? 0 : stoppedObservations + 1;
+        if (stoppedObservations >= 3 && ["PREPARED", "RUNNING", "CLEANING"].includes(state.status)) {
+            throw new Error(`Remote upgrade unit stopped before publishing a terminal status; retained status=${paths.status} log=${paths.log}`);
+        }
+        await delay(POLL_INTERVAL_MS);
+    }
+}
+
+export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: LocalUpgradeTransferRequest): Promise<string> {
+    const runId = randomUUID();
+    const paths = remotePaths(runId);
+    const preflight = await remoteUpgradePreflight(ssh);
+    const bundle = await prepareLocalUpgradeBundle({ ...preflight, ...request });
+    let adopted = false;
+    let transferError: unknown;
+    try {
+        try {
+            await prepareRemoteDrop(ssh, paths, bundle);
+            await uploadBundleFiles(ssh, paths, bundle);
+            await uploadRunScript(ssh, paths, bundle, request, preflight.architecture);
+            await adoptRemoteDrop(ssh, paths);
+            adopted = true;
+            await startRemoteUpgrade(ssh, paths);
+            return await awaitRemoteUpgrade(ssh, paths);
+        } catch (error: unknown) {
+            transferError = error;
+            if (!adopted) {
+                try {
+                    await cleanupRemoteDrop(ssh, paths);
+                } catch (cleanupError: unknown) {
+                    transferError = new AggregateError(
+                        [transferError, cleanupError],
+                        "Local upgrade failed and upload-drop cleanup did not complete",
+                    );
+                }
+            }
+            throw transferError;
+        }
+    } finally {
+        try {
+            cleanupLocalUpgradeBundle(bundle);
+        } catch (cleanupError: unknown) {
+            if (transferError) {
+                throw new AggregateError([transferError, cleanupError], "Local upgrade and local bundle cleanup both failed");
+            }
+            throw new AggregateError([cleanupError], "Remote local upgrade completed but local bundle cleanup did not complete");
+        }
+    }
+}

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { buildOfficialUpgradeCommand, buildRootUpgradeScript, registerSshTools } from "./ssh-tools";
 import { parseToolArguments } from "../schema";
@@ -41,7 +41,7 @@ class FakeSsh {
         if (this.upgradeExecFails && command.includes("UPGRADE_RUNNER")) {
             return { success: false, stdout: "", stderr: "transaction failed", code: 42 };
         }
-        if (this.cleanupExecFails && command.startsWith("rm -f '/tmp/.supacloud-release-assets-")) {
+        if (this.cleanupExecFails && command.includes("sudo -n rm -rf -- '/tmp/.supacloud-release-assets-")) {
             return { success: false, stdout: "", stderr: "permission denied", code: 1 };
         }
         if (command.includes("BOOTSTRAP_DEPS_OK")) {
@@ -127,7 +127,7 @@ function writeFakeGh(filePath: string, version: string): void {
     writeExecutableShell(filePath, [
         "#!/bin/sh",
         `if [ \"$1\" = \"--version\" ]; then echo \"gh version ${version}\"; exit 0; fi`,
-        "if [ \"$1 $2 $3\" = \"attestation verify --help\" ]; then echo '--bundle --signer-workflow --source-ref'; exit 0; fi",
+        "if [ \"$1 $2 $3\" = \"attestation verify --help\" ]; then echo '--bundle --signer-workflow --source-ref --deny-self-hosted-runners'; exit 0; fi",
         "exit 1",
         "",
     ].join("\n"));
@@ -297,6 +297,39 @@ describe("ssh admin tool", () => {
         }
     });
 
+    test("local artifact transport requires two exact versions before remote access", async () => {
+        for (const args of [
+            { action: "upgrade", artifact_transport: "local" },
+            { action: "upgrade", artifact_transport: "local", version: "0.50.30" },
+            { action: "upgrade", artifact_transport: "local", version: "latest", edge_runtime_version: "0.16.8" },
+        ]) {
+            const ssh = new FakeSsh();
+            await expect(captureSshTool(ssh).invoke(args)).rejects.toThrow();
+            expect(ssh.uploads).toHaveLength(0);
+            expect(ssh.commands).toHaveLength(0);
+        }
+    });
+
+    test("local artifact transport refuses third-party GitHub proxies", async () => {
+        const ssh = new FakeSsh();
+        await expect(captureSshTool(ssh).invoke({
+            action: "upgrade",
+            artifact_transport: "local",
+            version: "0.50.30",
+            edge_runtime_version: "0.16.8",
+            github_proxy: "https://proxy.example.com/",
+        })).rejects.toThrow("only supports direct GitHub downloads");
+        expect(ssh.uploads).toHaveLength(0);
+        expect(ssh.commands).toHaveLength(0);
+    });
+
+    test("artifact transport schema accepts only local or remote", () => {
+        const tool = captureSshTool(new FakeSsh());
+        expect(tool.parse({ action: "upgrade", artifact_transport: "local" }).artifact_transport).toBe("local");
+        expect(tool.parse({ action: "upgrade", artifact_transport: "remote" }).artifact_transport).toBe("remote");
+        expect(() => tool.parse({ action: "upgrade", artifact_transport: "automatic" })).toThrow();
+    });
+
     test("component upgrade validates both exact versions before upload", async () => {
         for (const args of [
             { action: "upgrade", version: "0.50.27;id", edge_runtime_version: "0.16.7" },
@@ -315,9 +348,10 @@ describe("ssh admin tool", () => {
     test("direct proxy mode clears singular and plural remote proxy fallbacks", async () => {
         const ssh = new FakeSsh();
         await captureSshTool(ssh).invoke({ action: "upgrade", github_proxy: "direct" });
-        expect(ssh.commands[0]).toContain("unset SUPACLOUD_GITHUB_PROXY");
-        expect(ssh.commands[0]).toContain("SUPACLOUD_GITHUB_PROXIES");
-        expect(ssh.commands[0]).not.toContain("SUPACLOUD_GITHUB_PROXY='direct'");
+        const upgradeCommand = ssh.commands.find((command) => command.includes("UPGRADE_RUNNER")) ?? "";
+        expect(upgradeCommand).toContain("unset SUPACLOUD_GITHUB_PROXY");
+        expect(upgradeCommand).toContain("SUPACLOUD_GITHUB_PROXIES");
+        expect(upgradeCommand).not.toContain("SUPACLOUD_GITHUB_PROXY='direct'");
 
         const rootScript = buildRootUpgradeScript({ helperPath: "/tmp/release-assets.sh" });
         const proxyProbe = [rootScriptThroughProxySetup(rootScript),
@@ -336,7 +370,7 @@ describe("ssh admin tool", () => {
             github_proxy: "https://proxy.example.test/",
         });
 
-        expect(ssh.timeouts).toEqual([1_320_000, undefined]);
+        expect(ssh.timeouts).toEqual([30_000, 1_320_000, 30_000]);
     });
 
     test("outer upgrade signals remove the helper and stop command continuation", () => {
@@ -474,11 +508,11 @@ describe("ssh admin tool", () => {
 
         await tool.invoke({ action: "upgrade", version: "0.50.27", edge_runtime_version: "0.16.7" });
 
-        expect(ssh.commands).toHaveLength(2);
-        const command = ssh.commands[0] ?? "";
+        expect(ssh.commands).toHaveLength(3);
+        const command = ssh.commands[1] ?? "";
         expect(command).toContain("sudo -n true");
         expect(ssh.uploads).toHaveLength(1);
-        expect(ssh.uploads[0]?.remotePath).toMatch(/^\/tmp\/\.supacloud-release-assets-[0-9a-f-]+\.sh$/);
+        expect(ssh.uploads[0]?.remotePath).toMatch(/^\/tmp\/\.supacloud-release-assets-[0-9a-f-]+\/release_assets\.sh$/);
         expect(ssh.uploads[0]?.mode).toBe(0o600);
         expect(ssh.uploads[0]?.content).toContain("supacloud_install_pinned_gh");
         expect(ssh.uploads[0]?.content).toContain('SUPACLOUD_GH_VERSION="${SUPACLOUD_GH_VERSION:-2.96.0}"');
@@ -497,7 +531,8 @@ describe("ssh admin tool", () => {
         expect(command).toContain("SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG=");
         expect(command).toContain("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE");
         expect(command).not.toContain("/opt/supacloud/scripts");
-        expect(command).toContain("trap 'rm -f /tmp/.supacloud-release-assets-");
+        expect(command).toContain("rm -rf --");
+        expect(command).toContain("/tmp/.supacloud-release-assets-");
         expect(command).not.toMatch(/\/usr\/local\/bin\/supacloud upgrade --yes/);
         const rootScript = buildRootUpgradeScript({
             version: "0.50.27",
@@ -506,8 +541,10 @@ describe("ssh admin tool", () => {
         });
         expect(Bun.spawnSync(["bash", "-n", "-c", rootScript]).exitCode).toBe(0);
         expect(Bun.spawnSync(["bash", "-n", "-c", command]).exitCode).toBe(0);
-        expect(ssh.commands[1]).toBe(`rm -f '${ssh.uploads[0]?.remotePath}'`);
-        expect(ssh.timeouts).toEqual([720_000, undefined]);
+        expect(ssh.commands[0]).toMatch(/^set -e; umask 077; test ! -e '\/tmp\/\.supacloud-release-assets-[0-9a-f-]+'; install -d -m 700 --/);
+        expect(ssh.commands[2]).toContain(`rm -rf -- '${ssh.uploads[0]?.remotePath.replace(/\/release_assets\.sh$/, "")}'`);
+        expect(ssh.commands[2]).toContain("sudo -n rm -rf --");
+        expect(ssh.timeouts).toEqual([30_000, 720_000, 30_000]);
     });
 
     test("component upgrade cleans its exact helper path when SSH execution throws", async () => {
@@ -522,7 +559,22 @@ describe("ssh admin tool", () => {
         })).rejects.toThrow("connection dropped");
 
         expect(ssh.uploads).toHaveLength(1);
-        expect(ssh.commands.at(-1)).toBe(`rm -f '${ssh.uploads[0]?.remotePath}'`);
+        expect(ssh.commands.at(-1)).toContain(`rm -rf -- '${ssh.uploads[0]?.remotePath.replace(/\/release_assets\.sh$/, "")}'`);
+    });
+
+    test("stages the sudo helper in a private user directory and cleans that directory with fallback privilege", async () => {
+        const ssh = new FakeSsh();
+
+        await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.30" });
+
+        const helperPath = ssh.uploads[0]?.remotePath ?? "";
+        const helperDirectory = dirname(helperPath);
+        expect(helperPath).toBe(`${helperDirectory}/release_assets.sh`);
+        expect(ssh.commands[0]).toContain(`install -d -m 700 -- '${helperDirectory}'`);
+        expect(buildRootUpgradeScript({ helperPath })).toContain(`source '${helperPath}'`);
+        expect(ssh.commands[1]).toContain(helperDirectory);
+        expect(ssh.commands[1]).toContain("rm -rf --");
+        expect(ssh.commands[2]).toContain(`rm -rf -- '${helperDirectory}' || sudo -n rm -rf -- '${helperDirectory}'`);
     });
 
     test("failed helper upload still cleans its generated remote path", async () => {
@@ -532,8 +584,9 @@ describe("ssh admin tool", () => {
         await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
             .rejects.toThrow("upload failed");
         expect(ssh.uploads).toHaveLength(0);
-        expect(ssh.commands).toHaveLength(1);
-        expect(ssh.commands[0]).toMatch(/^rm -f '\/tmp\/\.supacloud-release-assets-[0-9a-f-]+\.sh'$/);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands[0]).toContain("install -d -m 700 -- '/tmp/.supacloud-release-assets-");
+        expect(ssh.commands[1]).toContain("sudo -n rm -rf -- '/tmp/.supacloud-release-assets-");
     });
 
     test("partial helper upload cleans the exact remote path", async () => {
@@ -543,7 +596,8 @@ describe("ssh admin tool", () => {
         await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
             .rejects.toThrow("partial upload failed");
         expect(ssh.uploads).toHaveLength(1);
-        expect(ssh.commands).toEqual([`rm -f '${ssh.uploads[0]?.remotePath}'`]);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.at(-1)).toContain(`rm -rf -- '${ssh.uploads[0]?.remotePath.replace(/\/release_assets\.sh$/, "")}'`);
     });
 
     test("partial upload and helper cleanup failures preserve both diagnostics", async () => {

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -3,9 +3,11 @@
  * Install, upgrade, diagnose, exec, tenant mgmt — all via SSH
  */
 import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import type { SshTransport } from "../transports/ssh";
+import { executeLocalUpgradeTransfer } from "../releases/local-upgrade-transfer";
 import releaseAssetsScript from "../../../../../scripts/lib/release_assets.sh" with { type: "text" };
 
 const SAFE_CONTAINER_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/;
@@ -135,8 +137,8 @@ function componentPreflightCommands(request: UpgradeRequest): string[] {
 
 function signalSafeCleanupTraps(cleanupCommand: string): string[] {
     return [
-        `trap '${cleanupCommand}' EXIT`,
-        `trap 'trap - EXIT HUP INT TERM; ${cleanupCommand}; exit 1' HUP INT TERM`,
+        `trap ${quoteEnvValue(cleanupCommand)} EXIT`,
+        `trap ${quoteEnvValue(`trap - EXIT HUP INT TERM; ${cleanupCommand}; exit 1`)} HUP INT TERM`,
     ];
 }
 
@@ -166,9 +168,10 @@ export function buildRootUpgradeScript(request: UpgradeRequest): string {
 
 export function buildOfficialUpgradeCommand(request: UpgradeRequest): string {
     const rootScript = buildRootUpgradeScript(request);
+    const cleanupCommand = `rm -rf -- ${quoteEnvValue(dirname(request.helperPath))}`;
     return [
         "set -e",
-        ...signalSafeCleanupTraps(`rm -f ${request.helperPath}`),
+        ...signalSafeCleanupTraps(cleanupCommand),
         "if [ \"$(id -u)\" -eq 0 ]; then " +
             `bash -c ${quoteEnvValue(rootScript)}; ` +
             "else sudo -n true; " +
@@ -176,8 +179,31 @@ export function buildOfficialUpgradeCommand(request: UpgradeRequest): string {
     ].join("; ");
 }
 
+async function prepareRemoteUpgradeHelperDirectory(ssh: SshTransport, helperPath: string): Promise<void> {
+    const helperDirectory = dirname(helperPath);
+    const command = [
+        "set -e",
+        "umask 077",
+        `test ! -e ${quoteEnvValue(helperDirectory)}`,
+        `install -d -m 700 -- ${quoteEnvValue(helperDirectory)}`,
+    ].join("; ");
+    const preparation = await ssh.exec(command, 30_000);
+    if (!preparation.success) {
+        throw new Error(`Failed to prepare remote upgrade helper directory (exit ${preparation.code}): ${preparation.stderr.slice(-300)}`);
+    }
+}
+
 async function removeRemoteUpgradeHelper(ssh: SshTransport, helperPath: string): Promise<void> {
-    const cleanup = await ssh.exec(`rm -f ${quoteEnvValue(helperPath)}`);
+    const helperDirectory = dirname(helperPath);
+    const removeCommand = `rm -rf -- ${quoteEnvValue(helperDirectory)}`;
+    const command = [
+        "if [ \"$(id -u)\" -eq 0 ]; then",
+        `  ${removeCommand}`,
+        "else",
+        `  ${removeCommand} || sudo -n ${removeCommand}`,
+        "fi",
+    ].join("\n");
+    const cleanup = await ssh.exec(command, 30_000);
     if (!cleanup.success) {
         throw new Error(`Failed to remove remote upgrade helper (exit ${cleanup.code}): ${cleanup.stderr.slice(-300)}`);
     }
@@ -219,7 +245,10 @@ async function executeOfficialUpgrade(
 ): Promise<Awaited<ReturnType<SshTransport["exec"]>>> {
     let execution: OfficialUpgradeExecution | undefined;
     let executionError: unknown;
+    let helperPrepared = false;
     try {
+        await prepareRemoteUpgradeHelperDirectory(ssh, helperPath);
+        helperPrepared = true;
         await ssh.uploadText(helperPath, releaseAssetsScript, 0o600);
         execution = await ssh.exec(command, timeoutMs);
     } catch (error: unknown) {
@@ -227,10 +256,12 @@ async function executeOfficialUpgrade(
     }
 
     let cleanupError: unknown;
-    try {
-        await removeRemoteUpgradeHelper(ssh, helperPath);
-    } catch (error: unknown) {
-        cleanupError = error;
+    if (helperPrepared) {
+        try {
+            await removeRemoteUpgradeHelper(ssh, helperPath);
+        } catch (error: unknown) {
+            cleanupError = error;
+        }
     }
     return officialUpgradeOutcome(execution, executionError, cleanupError);
 }
@@ -384,6 +415,7 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
             storage_type: optional(stringEnum(["juicefs", "minio"]), "[install] Storage backend configurable through Admin"),
             version: optional(Type.String(), "[upgrade] Specific version"),
             edge_runtime_version: optional(Type.String(), "[upgrade] Exact independent Edge Runtime version"),
+            artifact_transport: optional(stringEnum(["local", "remote"]), "[upgrade] Download verified release assets locally or on the server (default: remote)"),
             github_proxy: optional(Type.String(), "[install/upgrade] Explicit GitHub proxy prefix, or direct/none"),
             focus: optional(stringEnum(["all", "containers", "database", "network", "disk", "logs"]), "[troubleshoot] Focus area"),
             container: optional(Type.String(), "[container_logs] Container name"),
@@ -554,10 +586,25 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
                         assertExactStableVersion(edgeRuntimeVersion, "edge_runtime_version");
                     }
                     const validatedProxy = args.github_proxy ? assertSafeGithubProxy(args.github_proxy) : undefined;
+                    if (args.artifact_transport === "local") {
+                        if (!version || !edgeRuntimeVersion) {
+                            throw new Error("Local artifact transport requires exact 'version' and 'edge_runtime_version'");
+                        }
+                        assertExactStableVersion(version, "version");
+                        assertExactStableVersion(edgeRuntimeVersion, "edge_runtime_version");
+                        if (validatedProxy && !["direct", "none"].includes(validatedProxy.toLowerCase())) {
+                            throw new Error("Local artifact transport only supports direct GitHub downloads");
+                        }
+                        text = await executeLocalUpgradeTransfer(ssh, {
+                            managementVersion: version.replace(/^v/, ""),
+                            edgeRuntimeVersion: edgeRuntimeVersion.replace(/^v/, ""),
+                        });
+                        break;
+                    }
                     const githubProxy = validatedProxy && !["direct", "none"].includes(validatedProxy.toLowerCase())
                         ? validatedProxy
                         : undefined;
-                    const helperPath = `/tmp/.supacloud-release-assets-${randomUUID()}.sh`;
+                    const helperPath = `/tmp/.supacloud-release-assets-${randomUUID()}/release_assets.sh`;
                     const cmd = buildOfficialUpgradeCommand({
                         version,
                         edgeRuntimeVersion,

--- a/packages/admin/src/shared/transports/ssh.test.ts
+++ b/packages/admin/src/shared/transports/ssh.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { getAuditLog, redactSshOutput, SshTransport } from "./ssh";
 
@@ -14,6 +17,7 @@ class FakeSshClient extends EventEmitter {
     stderrOutput = Buffer.alloc(0);
     stallCommand = false;
     endCalls = 0;
+    sftpClient: FakeSftpClient | undefined;
 
     connect(options: Record<string, unknown>): this {
         this.connectOptions = options;
@@ -33,8 +37,44 @@ class FakeSshClient extends EventEmitter {
         });
     }
 
+    sftp(callback: (error: Error | undefined, sftp: FakeSftpClient) => void): void {
+        if (!this.sftpClient) return callback(new Error("SFTP unavailable"), undefined as never);
+        callback(undefined, this.sftpClient);
+    }
+
     end(): void {
-        this.endCalls++;
+        this.endCalls += 1;
+    }
+}
+
+class FakeSftpClient {
+    readonly operations: string[] = [];
+    failChmod = false;
+    hangFastPut = false;
+
+    fastPut(_localPath: string, remotePath: string, callback: (error?: Error | null) => void): void {
+        this.operations.push(`put:${remotePath}`);
+        if (!this.hangFastPut) queueMicrotask(() => callback());
+    }
+
+    writeFile(remotePath: string, _content: string | Buffer, options: { mode: number }, callback: (error?: Error | null) => void): void {
+        this.operations.push(`write:${remotePath}:${options.mode}`);
+        queueMicrotask(() => callback());
+    }
+
+    chmod(remotePath: string, mode: number, callback: (error?: Error | null) => void): void {
+        this.operations.push(`chmod:${remotePath}:${mode}`);
+        queueMicrotask(() => callback(this.failChmod ? new Error("chmod failed") : undefined));
+    }
+
+    rename(sourcePath: string, destinationPath: string, callback: (error?: Error | null) => void): void {
+        this.operations.push(`rename:${sourcePath}:${destinationPath}`);
+        queueMicrotask(() => callback());
+    }
+
+    unlink(remotePath: string, callback: (error?: Error | null) => void): void {
+        this.operations.push(`unlink:${remotePath}`);
+        queueMicrotask(() => callback());
     }
 }
 
@@ -200,6 +240,106 @@ describe("SshTransport audit safety", () => {
             expect(result.stderr).not.toContain("discarded-error-secret");
         } finally {
             transport.close();
+        }
+    });
+
+    test("uploads through a protected partial path before chmod and atomic rename", async () => {
+        const fixtureDirectory = mkdtempSync(join(tmpdir(), "supacloud-sftp-upload-"));
+        const localPath = join(fixtureDirectory, "artifact");
+        writeFileSync(localPath, "release artifact");
+        const client = new FakeSshClient();
+        const sftp = new FakeSftpClient();
+        client.sftpClient = sftp;
+        const transport = new SshTransport({
+            host: "server.example.com", port: 22, username: "root", hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => client as never });
+
+        try {
+            await transport.upload(localPath, "/tmp/release/artifact", { mode: 0o600, timeoutMs: 1_000 });
+            expect(sftp.operations[0]).toMatch(/^put:\/tmp\/release\/artifact\.part-[0-9a-f-]+$/);
+            const partialPath = sftp.operations[0]!.slice("put:".length);
+            expect(sftp.operations).toEqual([
+                `put:${partialPath}`,
+                `chmod:${partialPath}:384`,
+                `rename:${partialPath}:/tmp/release/artifact`,
+            ]);
+            expect(getAuditLog().at(-1)?.command).not.toContain(localPath);
+        } finally {
+            transport.close();
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    });
+
+    test("uploads generated scripts through the same protected atomic path", async () => {
+        const client = new FakeSshClient();
+        const sftp = new FakeSftpClient();
+        client.sftpClient = sftp;
+        const transport = new SshTransport({
+            host: "server.example.com", port: 22, username: "ubuntu", hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => client as never });
+
+        try {
+            await transport.uploadText("/tmp/private/run.sh", "#!/bin/sh\nexit 0\n", 0o600);
+            expect(sftp.operations[0]).toMatch(/^write:\/tmp\/private\/run\.sh\.part-[0-9a-f-]+:384$/);
+            const partialPath = sftp.operations[0]!.slice("write:".length, -":384".length);
+            expect(sftp.operations).toEqual([
+                `write:${partialPath}:384`,
+                `chmod:${partialPath}:384`,
+                `rename:${partialPath}:/tmp/private/run.sh`,
+            ]);
+        } finally {
+            transport.close();
+        }
+    });
+
+    test("removes a partial upload and discards the connection after an SFTP error", async () => {
+        const fixtureDirectory = mkdtempSync(join(tmpdir(), "supacloud-sftp-failure-"));
+        const localPath = join(fixtureDirectory, "artifact");
+        writeFileSync(localPath, "release artifact");
+        const failedClient = new FakeSshClient();
+        const failedSftp = new FakeSftpClient();
+        failedSftp.failChmod = true;
+        failedClient.sftpClient = failedSftp;
+        const replacementClient = new FakeSshClient();
+        const clients = [failedClient, replacementClient];
+        const transport = new SshTransport({
+            host: "server.example.com", port: 22, username: "root", hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => clients.shift() as never });
+
+        try {
+            await expect(transport.upload(localPath, "/tmp/release/artifact")).rejects.toThrow("chmod failed");
+            expect(failedSftp.operations.at(-1)).toMatch(/^unlink:\/tmp\/release\/artifact\.part-/);
+            expect(failedClient.endCalls).toBeGreaterThan(0);
+            expect(await transport.ping()).toBe(false);
+            expect(replacementClient.connectOptions).toBeDefined();
+        } finally {
+            transport.close();
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    });
+
+    test("bounds an SFTP upload and does not return its timed-out connection to the pool", async () => {
+        const fixtureDirectory = mkdtempSync(join(tmpdir(), "supacloud-sftp-timeout-"));
+        const localPath = join(fixtureDirectory, "artifact");
+        writeFileSync(localPath, "release artifact");
+        const timedOutClient = new FakeSshClient();
+        const stalledSftp = new FakeSftpClient();
+        stalledSftp.hangFastPut = true;
+        timedOutClient.sftpClient = stalledSftp;
+        const replacementClient = new FakeSshClient();
+        const clients = [timedOutClient, replacementClient];
+        const transport = new SshTransport({
+            host: "server.example.com", port: 22, username: "root", hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => clients.shift() as never });
+
+        try {
+            await expect(transport.upload(localPath, "/tmp/release/artifact", { timeoutMs: 10 })).rejects.toThrow("SFTP upload timed out");
+            expect(timedOutClient.endCalls).toBeGreaterThan(0);
+            expect(await transport.ping()).toBe(false);
+            expect(replacementClient.connectOptions).toBeDefined();
+        } finally {
+            transport.close();
+            rmSync(fixtureDirectory, { recursive: true, force: true });
         }
     });
 });

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -4,7 +4,7 @@
  * When SupaCloud is not yet installed, execute ops tasks on target server via SSH.
  * Includes command auditing, allowlist enforcement, and connection pooling.
  */
-import { timingSafeEqual } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { Client, type ClientChannel } from "ssh2";
 type SftpClient = {
@@ -16,6 +16,8 @@ type SftpClient = {
         cb: (err?: Error | null) => void,
     ) => void;
     chmod: (remotePath: string, mode: number, cb: (err?: Error | null) => void) => void;
+    rename: (sourcePath: string, destinationPath: string, cb: (err?: Error | null) => void) => void;
+    unlink: (remotePath: string, cb: (err?: Error | null) => void) => void;
 };
 
 export interface SshConfig {
@@ -41,8 +43,15 @@ export interface SshTransportOptions {
     clientFactory?: () => Client;
 }
 
+export type SshUploadOptions = {
+    mode?: number;
+    timeoutMs?: number;
+};
+
 const DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024;
 const MAX_CONFIGURABLE_OUTPUT_BYTES = 16 * 1024 * 1024;
+const DEFAULT_UPLOAD_TIMEOUT_MS = 10 * 60_000;
+const DEFAULT_TEXT_UPLOAD_TIMEOUT_MS = 60_000;
 
 export function normalizeSshHostFingerprint(value: string): string {
     const trimmed = value.trim();
@@ -283,13 +292,13 @@ export class SshTransport {
 
                 const timer = setTimeout(() => {
                     connectionReusable = false;
-                    this.pool.discard(conn);
                     reject(new Error(`SSH command timed out after ${timeoutMs}ms`));
                 }, timeoutMs);
 
                 conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
                     if (err) {
                         clearTimeout(timer);
+                        connectionReusable = false;
                         return reject(err);
                     }
                     stream
@@ -304,6 +313,11 @@ export class SshTransport {
                                 stderrTruncated: stderr.truncated,
                             });
                         })
+                        .on("error", (streamError: Error) => {
+                            clearTimeout(timer);
+                            connectionReusable = false;
+                            reject(streamError);
+                        })
                         .on("data", (data: Buffer) => {
                             stdout.append(data);
                         })
@@ -314,44 +328,61 @@ export class SshTransport {
             });
         } finally {
             if (connectionReusable) this.pool.release(conn);
+            else this.pool.discard(conn);
         }
     }
 
-    async upload(localPath: string, remotePath: string): Promise<void> {
-        const conn = await this.pool.acquire();
-        try {
-            return await new Promise<void>((resolve, reject) => {
-                conn.sftp((err: Error | undefined, sftp: SftpClient) => {
-                    if (err) return reject(err);
-                    sftp.fastPut(localPath, remotePath, (err2: Error | null | undefined) => {
-                        if (err2) return reject(err2);
-                        resolve();
-                    });
-                });
-            });
-        } finally {
-            this.pool.release(conn);
-        }
+    async upload(localPath: string, remotePath: string, options: SshUploadOptions = {}): Promise<void> {
+        const mode = normalizeUploadMode(options.mode);
+        const timeoutMs = normalizeUploadTimeout(options.timeoutMs, DEFAULT_UPLOAD_TIMEOUT_MS);
+        const partialPath = `${remotePath}.part-${randomUUID()}`;
+        auditCommand(`upload ${remotePath} (local content redacted)`, this.config.host, false);
+        await this.runSftpOperation(timeoutMs, async (sftp) => {
+            try {
+                await sftpFastPut(sftp, localPath, partialPath);
+                await sftpChmod(sftp, partialPath, mode);
+                await sftpRename(sftp, partialPath, remotePath);
+            } catch (error: unknown) {
+                await removePartialUpload(sftp, partialPath, error);
+            }
+        });
     }
 
     async uploadText(remotePath: string, content: string, mode = 0o600): Promise<void> {
         auditCommand(`upload ${remotePath} (${Buffer.byteLength(content)} bytes; content redacted)`, this.config.host, false);
+        const normalizedMode = normalizeUploadMode(mode);
+        const partialPath = `${remotePath}.part-${randomUUID()}`;
+        await this.runSftpOperation(DEFAULT_TEXT_UPLOAD_TIMEOUT_MS, async (sftp) => {
+            try {
+                await sftpWriteFile(sftp, partialPath, content, normalizedMode);
+                await sftpChmod(sftp, partialPath, normalizedMode);
+                await sftpRename(sftp, partialPath, remotePath);
+            } catch (error: unknown) {
+                await removePartialUpload(sftp, partialPath, error);
+            }
+        });
+    }
+
+    private async runSftpOperation(timeoutMs: number, operation: (sftp: SftpClient) => Promise<void>): Promise<void> {
         const conn = await this.pool.acquire();
+        let connectionReusable = true;
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
         try {
-            await new Promise<void>((resolve, reject) => {
-                conn.sftp((err: Error | undefined, sftp: SftpClient) => {
-                    if (err) return reject(err);
-                    sftp.writeFile(remotePath, content, { mode }, (writeError) => {
-                        if (writeError) return reject(writeError);
-                        sftp.chmod(remotePath, mode, (chmodError) => {
-                            if (chmodError) return reject(chmodError);
-                            resolve();
-                        });
-                    });
-                });
-            });
+            const operationPromise = openSftp(conn).then(operation);
+            await Promise.race([
+                operationPromise,
+                new Promise<never>((_resolve, reject) => { timeoutHandle = setTimeout(() => {
+                    connectionReusable = false;
+                    reject(new Error(`SFTP upload timed out after ${timeoutMs}ms`));
+                }, timeoutMs); }),
+            ]);
+        } catch (error: unknown) {
+            connectionReusable = false;
+            throw error;
         } finally {
-            this.pool.release(conn);
+            if (timeoutHandle) clearTimeout(timeoutHandle);
+            if (connectionReusable) this.pool.release(conn);
+            else this.pool.discard(conn);
         }
     }
 
@@ -363,4 +394,63 @@ export class SshTransport {
     close() {
         this.pool.closeAll();
     }
+}
+
+function normalizeUploadMode(mode = 0o600): number {
+    if (!Number.isInteger(mode) || mode < 0 || mode > 0o777) throw new Error("Upload mode must be an octal permission between 000 and 777");
+    return mode;
+}
+
+function normalizeUploadTimeout(timeoutMs: number | undefined, fallback: number): number {
+    const resolved = timeoutMs ?? fallback;
+    if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > 60 * 60_000) {
+        throw new Error("Upload timeout must be between 1ms and 1 hour");
+    }
+    return resolved;
+}
+
+function openSftp(conn: Client): Promise<SftpClient> {
+    return new Promise((resolve, reject) => {
+        conn.sftp((error: Error | undefined, sftp: SftpClient) => error ? reject(error) : resolve(sftp));
+    });
+}
+
+function sftpFastPut(sftp: SftpClient, localPath: string, remotePath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        sftp.fastPut(localPath, remotePath, (error) => error ? reject(error) : resolve());
+    });
+}
+
+function sftpWriteFile(sftp: SftpClient, remotePath: string, content: string, mode: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        sftp.writeFile(remotePath, content, { mode }, (error) => error ? reject(error) : resolve());
+    });
+}
+
+function sftpChmod(sftp: SftpClient, remotePath: string, mode: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        sftp.chmod(remotePath, mode, (error) => error ? reject(error) : resolve());
+    });
+}
+
+function sftpRename(sftp: SftpClient, sourcePath: string, destinationPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        sftp.rename(sourcePath, destinationPath, (error) => error ? reject(error) : resolve());
+    });
+}
+
+function sftpUnlink(sftp: SftpClient, remotePath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        sftp.unlink(remotePath, (error) => error ? reject(error) : resolve());
+    });
+}
+
+async function removePartialUpload(sftp: SftpClient, partialPath: string, uploadError: unknown): Promise<never> {
+    try {
+        await sftpUnlink(sftp, partialPath);
+    } catch (cleanupError: unknown) {
+        if ((cleanupError as { code?: number }).code === 2) throw uploadError;
+        throw new AggregateError([uploadError, cleanupError], `SFTP upload failed and partial cleanup did not complete: ${partialPath}`);
+    }
+    throw uploadError;
 }

--- a/packages/admin/tsconfig.json
+++ b/packages/admin/tsconfig.json
@@ -5,9 +5,10 @@
     "moduleResolution": "bundler",
     "strict": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "..",
     "declaration": true,
     "types": [
       "bun"

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -672,7 +672,7 @@ describe("runtime companion version assets", () => {
         },
         encoding: "utf8",
       });
-      const flags = ["--bundle", "--signer-workflow", "--source-ref"];
+      const flags = ["--bundle", "--signer-workflow", "--source-ref", "--deny-self-hosted-runners"];
 
       expect(invoke("2.68.0", `${flags.join("\n")}\n`).status).toBe(0);
       expect(invoke("2.67.9", `${flags.join("\n")}\n`).status).not.toBe(0);
@@ -735,6 +735,7 @@ describe("runtime companion version assets", () => {
     expect(workflow).toContain("subject-path: release-assets/*");
     expect(workflow).toContain("subject-path: packages/edge-runtime/dist/*");
     expect(readRepoFile("scripts/lib/release_assets.sh")).toContain("--signer-workflow");
+    expect(readRepoFile("scripts/lib/release_assets.sh")).toContain("--deny-self-hosted-runners");
   });
 
   test("artifact verification fails closed by default and only allows an explicit break-glass", () => {
@@ -789,7 +790,7 @@ describe("runtime companion version assets", () => {
       writeFileSync(gh, [
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
-        'if [ "$1 $2 $3" = "attestation verify --help" ]; then printf "%s\\n" "--bundle" "--signer-workflow" "--source-ref"; exit 0; fi',
+        'if [ "$1 $2 $3" = "attestation verify --help" ]; then printf "%s\\n" "--bundle" "--signer-workflow" "--source-ref" "--deny-self-hosted-runners"; exit 0; fi',
         'while [ "$#" -gt 0 ]; do if [ "$1" = "--bundle" ]; then shift; printf "%s\\n" "$1" > "$GH_BUNDLE_ARGUMENT_RECORD"; break; fi; shift; done',
         'echo "HTTP 404: attestation not found" >&2',
         "exit 22",
@@ -837,11 +838,11 @@ describe("runtime companion version assets", () => {
       writeFileSync(join(fakeBin, "gh"), [
         "#!/bin/sh",
         'if [ "$1" = "--version" ]; then echo "gh version 2.96.0"; exit 0; fi',
-        'if [ "$1 $2 $3" = "attestation verify --help" ]; then printf "%s\\n" "--bundle" "--signer-workflow" "--source-ref"; exit 0; fi',
-        'bundle=""',
-        'while [ "$#" -gt 0 ]; do case "$1" in --bundle) shift; bundle="$1" ;; --source-ref) shift; printf "%s\\n" "$1" > "$GH_SOURCE_REF_ARGUMENT_RECORD" ;; esac; shift; done',
+        'if [ "$1 $2 $3" = "attestation verify --help" ]; then printf "%s\\n" "--bundle" "--signer-workflow" "--source-ref" "--deny-self-hosted-runners"; exit 0; fi',
+        'bundle=""; deny_self_hosted=false',
+        'while [ "$#" -gt 0 ]; do case "$1" in --bundle) shift; bundle="$1" ;; --source-ref) shift; printf "%s\\n" "$1" > "$GH_SOURCE_REF_ARGUMENT_RECORD" ;; --deny-self-hosted-runners) deny_self_hosted=true ;; esac; shift; done',
         'printf "%s\\n" "$bundle" > "$GH_BUNDLE_ARGUMENT_RECORD"',
-        'case "$bundle" in */bundle.jsonl) test -f "$bundle" && exit 0 ;; esac',
+        'case "$bundle" in */bundle.jsonl) test -f "$bundle" && test "$deny_self_hosted" = true && exit 0 ;; esac',
         'echo "offline bundle must be an existing bundle.jsonl file" >&2',
         "exit 1",
         "",

--- a/scripts/lib/release_assets.sh
+++ b/scripts/lib/release_assets.sh
@@ -406,7 +406,8 @@ supacloud_verify_attestation() (
             --bundle "$bundle_file" \
             --repo "$SUPACLOUD_GITHUB_REPOSITORY" \
             --signer-workflow "$SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW" \
-            --source-ref "refs/heads/main" 2>&1); then
+            --source-ref "refs/heads/main" \
+            --deny-self-hosted-runners 2>&1); then
             echo "GitHub artifact attestation verification failed: ${verification_output}" >&2
             return 1
         fi
@@ -433,7 +434,8 @@ supacloud_attestation_verifier_available() {
     help=$(gh attestation verify --help 2>&1) || return 1
     grep -Eq -- '(^|[[:space:]])--bundle([=[:space:]]|$)' <<< "$help" || return 1
     grep -Eq -- '(^|[[:space:]])--signer-workflow([=[:space:]]|$)' <<< "$help" || return 1
-    grep -Eq -- '(^|[[:space:]])--source-ref([=[:space:]]|$)' <<< "$help"
+    grep -Eq -- '(^|[[:space:]])--source-ref([=[:space:]]|$)' <<< "$help" || return 1
+    grep -Eq -- '(^|[[:space:]])--deny-self-hosted-runners([=[:space:]]|$)' <<< "$help"
 }
 
 supacloud_download_release_asset() (


### PR DESCRIPTION
## Summary

- add the supported `--artifact_transport local` upgrade path to the official Admin CLI
- download Management, Edge, Web Console, manifests, checksums, and attestations only from official GitHub endpoints on the Admin host
- verify exact stable versions, signed source commit/ref, SLSA bundles, checksums, sizes, and architecture assets before any remote upload
- transfer the verified bundle through bounded SFTP and execute the existing transactional Management upgrade lifecycle in a transient systemd unit
- add `supacloud-admin --version`

## Security and lifecycle boundaries

- require the local and remote GitHub verifier to support strict offline attestation flags including `--source-digest` and `--deny-self-hosted-runners`
- use a pinned GitHub CLI 2.96.0 archive only when the remote has no trusted capable verifier
- fail closed on non-official host/path redirects, draft/prerelease releases, wrong owners, symlinks, hardlinks, unexpected entries, sizes, hashes, and special permission bits
- re-check an installed remote verifier as a regular root-owned executable without group/other write access immediately before privileged execution
- preserve terminal status/log evidence for cleanup failures and never treat a non-terminal unit state as success
- roll back partially adopted staging state; aggregate original and cleanup failures instead of masking either
- wait for all parallel downloads to settle before local cleanup

## Verification

- focused local transport: 24/24, 104 assertions
- Admin full suite: 107/107, 507 assertions
- Management runtime assets: 28/28
- Admin typecheck and production build: PASS
- npm pack/install/bin `--version` smoke: PASS
- shell syntax and `git diff --check`: PASS
- independent final review: no P0/P1/P2
- clean-code-guard: 5 fixed, 0 flagged for author

## Release and deployment

This PR requires a new Admin release. It also hardens the shared shell attestation verifier used by Management, so the Release Please output is authoritative for whether a Management patch is emitted. Deployment will use only the exact versions published from the merged release PR and the official npm registry, test server first and production only after complete test acceptance.
