### PR TITLE
fix(release): skip compatible umbrella dependency updates

### DIFF
--- a/.github/scripts/sync-supacloud-dependencies.mjs
+++ b/.github/scripts/sync-supacloud-dependencies.mjs
@@ -17,6 +17,53 @@ function packageVersion(candidatePackage, packageName) {
   return version;
 }
 
+function stableVersionPrecedence(version, packageName) {
+  const precedence = version.split('+', 1)[0];
+  if (precedence.includes('-')) {
+    throw new Error(`${packageName} prerelease versions are not supported for automatic synchronization`);
+  }
+  return precedence.split('.').map((identifier) => BigInt(identifier));
+}
+
+function comparePrecedence(leftVersion, rightVersion) {
+  for (let index = 0; index < leftVersion.length; index += 1) {
+    if (leftVersion[index] < rightVersion[index]) return -1;
+    if (leftVersion[index] > rightVersion[index]) return 1;
+  }
+  return 0;
+}
+
+// Caret compatibility ends at the next major for 1.x, next minor for 0.x, and next patch for 0.0.x.
+function caretUpperBound([major, minor, patch]) {
+  if (major > 0n) return [major + 1n, 0n, 0n];
+  if (minor > 0n) return [0n, minor + 1n, 0n];
+  return [0n, 0n, patch + 1n];
+}
+
+function caretLowerBound(range, dependencyName) {
+  if (typeof range !== 'string' || !range.startsWith('^')) {
+    throw new Error(`${dependencyName} has an unsupported dependency range`);
+  }
+  const lowerVersion = range.slice(1);
+  if (!SEMVER_PATTERN.test(lowerVersion)) {
+    throw new Error(`${dependencyName} has an unsupported dependency range`);
+  }
+  return stableVersionPrecedence(lowerVersion, `${dependencyName} dependency range`);
+}
+
+function synchronizedRange(currentRange, candidatePackage, dependencyName) {
+  const candidateVersion = packageVersion(candidatePackage, dependencyName);
+  const candidatePrecedence = stableVersionPrecedence(candidateVersion, dependencyName);
+  const lowerBound = caretLowerBound(currentRange, dependencyName);
+  if (comparePrecedence(candidatePrecedence, lowerBound) < 0) {
+    throw new Error(`${dependencyName} candidate ${candidateVersion} is below current lower bound ${currentRange}`);
+  }
+  if (comparePrecedence(candidatePrecedence, caretUpperBound(lowerBound)) < 0) {
+    return currentRange;
+  }
+  return `^${candidateVersion}`;
+}
+
 export function syncSupacloudDependencies({ supacloudPackage, cliPackage, adminPackage }) {
   if (!supacloudPackage?.dependencies || typeof supacloudPackage.dependencies !== 'object') {
     throw new Error('supacloud package has no dependencies object');
@@ -27,7 +74,8 @@ export function syncSupacloudDependencies({ supacloudPackage, cliPackage, adminP
   let changed = false;
 
   for (const [dependencyName, candidateName] of MANAGED_DEPENDENCIES) {
-    const nextRange = `^${packageVersion(candidates[candidateName], dependencyName)}`;
+    const currentRange = nextPackage.dependencies[dependencyName];
+    const nextRange = synchronizedRange(currentRange, candidates[candidateName], dependencyName);
     if (nextPackage.dependencies[dependencyName] !== nextRange) {
       nextPackage.dependencies[dependencyName] = nextRange;
       changed = true;
@@ -64,7 +112,7 @@ if (isMainModule()) {
     if (synchronization.changed) {
       await writeFile(repository.supacloudPath, `${JSON.stringify(synchronization.package, null, 2)}\n`);
     }
-    console.log(synchronization.changed ? 'updated' : 'already-synchronized');
+    console.log(`changed=${synchronization.changed}`);
   } catch (error) {
     console.error(`Failed to sync SupaCloud dependencies: ${error.message}`);
     process.exitCode = 1;

--- a/.github/scripts/sync-supacloud-dependencies.test.mjs
+++ b/.github/scripts/sync-supacloud-dependencies.test.mjs
@@ -7,9 +7,10 @@ import { syncSupacloudDependencies } from './sync-supacloud-dependencies.mjs';
 const currentPackages = {
   supacloudPackage: {
     name: 'supacloud',
+    private: false,
     dependencies: {
-      '@supacloud/cli': '^0.14.3',
-      '@supacloud/admin': '^0.7.1',
+      '@supacloud/cli': '^0.13.3',
+      '@supacloud/admin': '^0.6.1',
       preserved: '^1.2.3',
     },
   },
@@ -17,8 +18,24 @@ const currentPackages = {
   adminPackage: { name: '@supacloud/admin', version: '0.7.2' },
 };
 
+function packagesWithRanges(cliRange, adminRange, cliVersion, adminVersion) {
+  return {
+    supacloudPackage: {
+      name: 'supacloud',
+      dependencies: {
+        '@supacloud/cli': cliRange,
+        '@supacloud/admin': adminRange,
+        preserved: '^1.2.3',
+      },
+    },
+    cliPackage: { version: cliVersion },
+    adminPackage: { version: adminVersion },
+  };
+}
+
 describe('SupaCloud umbrella dependency sync', () => {
   test('updates both managed ranges and preserves unrelated package content', () => {
+    const originalPackages = structuredClone(currentPackages);
     const synchronization = syncSupacloudDependencies(currentPackages);
 
     assert.equal(synchronization.changed, true);
@@ -27,23 +44,77 @@ describe('SupaCloud umbrella dependency sync', () => {
       '@supacloud/admin': '^0.7.2',
       preserved: '^1.2.3',
     });
-    assert.equal(currentPackages.supacloudPackage.dependencies['@supacloud/cli'], '^0.14.3');
+    assert.equal(synchronization.package.private, false);
+    assert.deepEqual(currentPackages, originalPackages);
   });
 
-  test('is idempotent when both dependency ranges are synchronized', () => {
-    const synchronized = {
-      ...currentPackages,
-      supacloudPackage: {
-        ...currentPackages.supacloudPackage,
-        dependencies: {
-          ...currentPackages.supacloudPackage.dependencies,
-          '@supacloud/cli': '^0.14.4',
-          '@supacloud/admin': '^0.7.2',
-        },
-      },
-    };
+  test('skips CLI patch releases covered by ^0.14.4', () => {
+    for (const version of ['0.14.4', '0.14.5']) {
+      const packages = packagesWithRanges('^0.14.4', '^0.7.6', version, '0.7.6');
+      assert.equal(syncSupacloudDependencies(packages).changed, false);
+    }
+  });
 
-    assert.equal(syncSupacloudDependencies(synchronized).changed, false);
+  test('updates CLI only when it crosses the ^0.14.4 compatibility boundary', () => {
+    const packages = packagesWithRanges('^0.14.4', '^0.7.6', '0.15.0', '0.7.6');
+    const synchronization = syncSupacloudDependencies(packages);
+
+    assert.equal(synchronization.changed, true);
+    assert.equal(synchronization.package.dependencies['@supacloud/cli'], '^0.15.0');
+    assert.equal(packages.supacloudPackage.dependencies['@supacloud/cli'], '^0.14.4');
+  });
+
+  test('rejects a CLI candidate below the ^0.14.4 lower bound', () => {
+    const packages = packagesWithRanges('^0.14.4', '^0.7.6', '0.14.3', '0.7.6');
+    assert.throws(() => syncSupacloudDependencies(packages), /candidate 0\.14\.3 is below current lower bound \^0\.14\.4/);
+  });
+
+  test('skips Admin patch releases covered by ^0.7.6', () => {
+    for (const version of ['0.7.7', '0.7.8']) {
+      const packages = packagesWithRanges('^0.14.4', '^0.7.6', '0.14.4', version);
+      assert.equal(syncSupacloudDependencies(packages).changed, false);
+    }
+  });
+
+  test('updates Admin only when it crosses the ^0.7.6 compatibility boundary', () => {
+    const packages = packagesWithRanges('^0.14.4', '^0.7.6', '0.14.4', '0.8.0');
+    const synchronization = syncSupacloudDependencies(packages);
+
+    assert.equal(synchronization.changed, true);
+    assert.equal(synchronization.package.dependencies['@supacloud/admin'], '^0.8.0');
+  });
+
+  test('rejects an Admin candidate below the ^0.7.6 lower bound', () => {
+    const packages = packagesWithRanges('^0.14.4', '^0.7.6', '0.14.4', '0.7.5');
+    assert.throws(() => syncSupacloudDependencies(packages), /candidate 0\.7\.5 is below current lower bound \^0\.7\.6/);
+  });
+
+  test('applies caret boundaries for 1.x and 0.0.x versions', () => {
+    assert.equal(syncSupacloudDependencies(
+      packagesWithRanges('^1.2.3', '^0.7.6', '1.99.0', '0.7.6'),
+    ).changed, false);
+
+    const nextMajor = syncSupacloudDependencies(
+      packagesWithRanges('^1.2.3', '^0.7.6', '2.0.0', '0.7.6'),
+    );
+    assert.equal(nextMajor.package.dependencies['@supacloud/cli'], '^2.0.0');
+    assert.throws(
+      () => syncSupacloudDependencies(packagesWithRanges('^1.2.3', '^0.7.6', '1.2.2', '0.7.6')),
+      /candidate 1\.2\.2 is below current lower bound \^1\.2\.3/,
+    );
+
+    assert.equal(syncSupacloudDependencies(
+      packagesWithRanges('^0.0.4', '^0.7.6', '0.0.4', '0.7.6'),
+    ).changed, false);
+
+    const nextPatch = syncSupacloudDependencies(
+      packagesWithRanges('^0.0.4', '^0.7.6', '0.0.5', '0.7.6'),
+    );
+    assert.equal(nextPatch.package.dependencies['@supacloud/cli'], '^0.0.5');
+    assert.throws(
+      () => syncSupacloudDependencies(packagesWithRanges('^0.0.4', '^0.7.6', '0.0.3', '0.7.6')),
+      /candidate 0\.0\.3 is below current lower bound \^0\.0\.4/,
+    );
   });
 
   test('rejects malformed candidate versions', () => {
@@ -68,15 +139,31 @@ describe('SupaCloud umbrella dependency sync', () => {
     }
   });
 
-  test('accepts valid prerelease and build metadata', () => {
-    const synchronization = syncSupacloudDependencies({
-      ...currentPackages,
-      cliPackage: { version: '1.2.3-alpha.1+build.5' },
-      adminPackage: { version: '0.7.2+sha.5114f85' },
-    });
+  test('ignores build metadata when comparing precedence', () => {
+    const packages = packagesWithRanges(
+      '^0.14.4+base.1',
+      '^0.7.6',
+      '0.14.4+build.5',
+      '0.7.6+sha.5114f85',
+    );
 
-    assert.equal(synchronization.package.dependencies['@supacloud/cli'], '^1.2.3-alpha.1+build.5');
-    assert.equal(synchronization.package.dependencies['@supacloud/admin'], '^0.7.2+sha.5114f85');
+    assert.equal(syncSupacloudDependencies(packages).changed, false);
+  });
+
+  test('fails closed for unsupported ranges and prerelease versions', () => {
+    for (const cliRange of ['~0.14.4', '0.14.4', 'workspace:*', '^0.14']) {
+      const packages = packagesWithRanges(cliRange, '^0.7.6', '0.14.5', '0.7.6');
+      assert.throws(() => syncSupacloudDependencies(packages), /unsupported dependency range/);
+    }
+
+    assert.throws(
+      () => syncSupacloudDependencies(packagesWithRanges('^0.14.4-beta.1', '^0.7.6', '0.14.5', '0.7.6')),
+      /prerelease versions are not supported/,
+    );
+    assert.throws(
+      () => syncSupacloudDependencies(packagesWithRanges('^0.14.4', '^0.7.6', '0.14.5-beta.1', '0.7.6')),
+      /prerelease versions are not supported/,
+    );
   });
 
   test('keeps Release Please and the post-publish sync workflow separated', () => {
@@ -87,9 +174,23 @@ describe('SupaCloud umbrella dependency sync', () => {
     assert.equal(config.packages['packages/admin']['extra-files'], undefined);
     assert.match(workflow, /sync-supacloud-dependencies:\n/);
     assert.match(workflow, /needs: \[release-please, publish-npm\]/);
-    assert.match(workflow, /node \.github\/scripts\/sync-supacloud-dependencies\.mjs/);
+    assert.match(workflow, /id: synchronize/);
+    assert.match(workflow, /if ! sync_output="\$\(node \.github\/scripts\/sync-supacloud-dependencies\.mjs\)"; then\n\s+echo "Dependency synchronization failed\." >&2\n\s+exit 1\n\s+fi/);
+    assert.match(workflow, /changed=true\|changed=false/);
+    assert.match(workflow, /printf '%s\\n' "\$sync_output" >> "\$GITHUB_OUTPUT"/);
+    assert.match(workflow, /- name: Wait for published dependencies\n\s+if: \$\{\{ steps\.synchronize\.outputs\.changed == 'true' \}\}/);
+    assert.match(workflow, /- name: Regenerate and verify umbrella lockfile\n\s+if: \$\{\{ steps\.synchronize\.outputs\.changed == 'true' \}\}/);
+    assert.match(workflow, /- name: Open dependency synchronization PR\n\s+if: \$\{\{ steps\.synchronize\.outputs\.changed == 'true' \}\}/);
+    const synchronizeIndex = workflow.indexOf('- name: Synchronize umbrella dependencies');
+    const waitIndex = workflow.indexOf('- name: Wait for published dependencies');
+    const lockIndex = workflow.indexOf('- name: Regenerate and verify umbrella lockfile');
+    const pullRequestIndex = workflow.indexOf('- name: Open dependency synchronization PR');
+    assert.ok(synchronizeIndex < waitIndex);
+    assert.ok(waitIndex < lockIndex);
+    assert.ok(lockIndex < pullRequestIndex);
     assert.match(workflow, /bun install --lockfile-only --registry https:\/\/registry\.npmjs\.org/);
     assert.match(workflow, /git add packages\/supacloud\/package\.json packages\/supacloud\/bun\.lock/);
+    assert.doesNotMatch(workflow, /sync-supacloud-dependencies\.mjs \|\| true/);
     assert.doesNotMatch(workflow, /bun add --no-save '@supacloud\/cli@file:\.\.\/cli'/);
 
     const packageChecks = readFileSync(new URL('../workflows/management-api.yml', import.meta.url), 'utf8');

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -459,7 +459,24 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Synchronize umbrella dependencies
+        id: synchronize
+        run: |
+          if ! sync_output="$(node .github/scripts/sync-supacloud-dependencies.mjs)"; then
+            echo "Dependency synchronization failed." >&2
+            exit 1
+          fi
+          case "$sync_output" in
+            changed=true|changed=false) ;;
+            *)
+              echo "Unexpected dependency synchronization output: $sync_output" >&2
+              exit 1
+              ;;
+          esac
+          printf '%s\n' "$sync_output" >> "$GITHUB_OUTPUT"
+
       - name: Wait for published dependencies
+        if: ${{ steps.synchronize.outputs.changed == 'true' }}
         run: |
           cli_version="$(node -p "require('./packages/cli/package.json').version")"
           admin_version="$(node -p "require('./packages/admin/package.json').version")"
@@ -480,21 +497,22 @@ jobs:
             fi
           done
 
-      - name: Synchronize umbrella dependencies and lockfile
+      - name: Regenerate and verify umbrella lockfile
+        if: ${{ steps.synchronize.outputs.changed == 'true' }}
+        working-directory: packages/supacloud
         run: |
-          node .github/scripts/sync-supacloud-dependencies.mjs
-          cd packages/supacloud
           bun install --lockfile-only --registry https://registry.npmjs.org
           bun install --frozen-lockfile --registry https://registry.npmjs.org
           git diff --check -- package.json bun.lock
 
       - name: Open dependency synchronization PR
+        if: ${{ steps.synchronize.outputs.changed == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
         run: |
           if git diff --quiet -- packages/supacloud/package.json packages/supacloud/bun.lock; then
-            echo "SupaCloud umbrella dependencies are already synchronized."
-            exit 0
+            echo "Dependency synchronization reported a change but produced no diff." >&2
+            exit 1
           fi
 
           branch="automation/sync-supacloud-dependencies"


### PR DESCRIPTION
## Summary

- keep existing caret dependency ranges when they already include the newly published CLI or Admin version
- update only when a release crosses the caret compatibility boundary
- fail closed on downgrades, unsupported ranges, and prereleases
- skip registry polling, lockfile work, and dependency PR creation when synchronization reports no change

This prevents compatible Admin patch releases such as 0.7.7 or 0.7.8 from creating another umbrella release cycle. It supersedes the closed, unmerged #772.

## Verification

- dependency synchronization tests: 12/12
- all GitHub script tests: 31/31
- Node syntax, YAML parse, changed shell blocks, shellcheck, and git diff check: PASS
- independent verifier: PASS, P0/P1/P2 = 0/0/0
- no-op smoke: changed=false with unchanged package and lock hashes
- changed path smoke: package and Bun lockfile update successfully