### PR TITLE
fix(admin): harden local upgrade reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ The transaction runs in a uniquely named transient systemd unit and publishes a
 protected atomic status record. Admin polls that record through short SSH calls;
 it does not blindly stop a transaction that may have entered activation. The
 legacy server-download path remains available as `--artifact_transport remote`.
+Local, remote, and direct server upgrades share one nonblocking host-wide lock.
+
+Admin observes the remote transaction for up to 30 minutes. Reaching that
+deadline stops only local observation; it does not stop, clean up, or mark the
+remote transaction as failed. The CLI reports the unit, stage, status, log, and
+upload-drop paths for reconciliation. Inspect that evidence before retrying and
+do not retry blindly while the remote transaction may still be running.
 
 This transaction requires persisted `EDGE_RUNTIME_MODE=external`; embedded
 mode is rejected before release artifacts or services are changed. It preserves
@@ -242,8 +249,10 @@ the Edge Runtime systemd executable path, port, mode, and enabled state, and
 verifies each released component against its own SHA256 checksum and GitHub
 attestation. Caddy and GoTrue are outside this transaction and are not replaced.
 
-Omit `--edge_runtime_version` only when intentionally upgrading Management and
-Web Console without changing Edge Runtime; the Admin CLI reports that boundary.
+With `--artifact_transport remote` (the default), omit
+`--edge_runtime_version` only when intentionally upgrading Management and Web
+Console without changing Edge Runtime. Local transport requires exact
+Management and Edge Runtime versions.
 
 The installed `/usr/local/bin/supacloud` server binary still provides the
 Management/Web Console-only local upgrade path. Production servers do not need

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -61,16 +61,25 @@ records; Admin polls that record without tying the transaction to a long-lived
 SSH channel. It preserves the Edge Runtime systemd `ExecStart`, port, mode, and
 enabled state. Component upgrades require persisted `EDGE_RUNTIME_MODE=external`;
 embedded mode is rejected before release artifacts or services are changed.
+Local, remote, and direct server upgrades share one nonblocking host-wide lock.
+
+Admin observes the remote transaction for up to 30 minutes. Reaching that
+deadline stops only local observation; it does not stop, clean up, or mark the
+remote transaction as failed. The CLI reports the unit, stage, status, log, and
+upload-drop paths for reconciliation. Inspect that evidence before retrying and
+do not retry blindly while the remote transaction may still be running.
 
 `--artifact_transport local` accepts only `--github_proxy direct` or `none` and
 clears proxy environment variables on both hosts. The legacy server-download
 path remains available as `--artifact_transport remote`.
 
-Omitting `--edge_runtime_version` retains the Management and Web Console-only
-upgrade behavior and reports that Edge Runtime was not upgraded. Caddy and
-GoTrue are outside this transaction and are not replaced. After a capable
-Management release is active, an exact rollback can use that active upgrader
-with explicit older targets, for example:
+With `--artifact_transport remote` (the default), omitting
+`--edge_runtime_version` retains the Management and Web Console-only upgrade
+behavior and reports that Edge Runtime was not upgraded. Local transport
+requires exact Management and Edge Runtime versions. Caddy and GoTrue are
+outside this transaction and are not replaced. After a capable Management
+release is active, an exact rollback can use that active upgrader with explicit
+older targets, for example:
 
 ```bash
 npx @supacloud/admin ssh upgrade \

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -4,6 +4,7 @@ import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } 
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createAdminTools } from "./index";
+import { formatCliError } from "./shared/cli";
 import packageMetadata from "../package.json" with { type: "json" };
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -182,5 +183,23 @@ describe("supacloud-admin process contract", () => {
         expect(result.output).toContain("DATABASE_URL=postgresql://admin:[REDACTED]@localhost/db");
         expect(result.output).toContain("Failed to remove remote upgrade helper: permission denied");
         expect(result.output).not.toContain("database-password");
+    });
+
+    test("preserves nested reconciliation summaries alongside cleanup failures", () => {
+        const reconciliation = new AggregateError(
+            [new Error("SSH stream closed")],
+            "Reconcile unit=upgrade.service stage=/stage status=/status log=/log drop=/drop; do not retry blindly",
+        );
+        const failure = new AggregateError(
+            [reconciliation, new Error("Local bundle cleanup failed")],
+            "Local upgrade and local bundle cleanup both failed",
+        );
+
+        const formatted = formatCliError(failure);
+        expect(formatted).toContain("Local upgrade and local bundle cleanup both failed");
+        expect(formatted).toContain("unit=upgrade.service stage=/stage status=/status log=/log drop=/drop");
+        expect(formatted).toContain("do not retry blindly");
+        expect(formatted).toContain("SSH stream closed");
+        expect(formatted).toContain("Local bundle cleanup failed");
     });
 });

--- a/packages/admin/src/shared/cli.ts
+++ b/packages/admin/src/shared/cli.ts
@@ -34,7 +34,10 @@ function sanitizedCliDiagnostic(error: unknown): string {
 
 function nestedCliDiagnostics(error: unknown): string[] {
     if (error instanceof AggregateError) {
-        return error.errors.flatMap(candidate => nestedCliDiagnostics(candidate));
+        return [
+            sanitizedCliDiagnostic(error),
+            ...error.errors.flatMap(candidate => nestedCliDiagnostics(candidate)),
+        ];
     }
     return [sanitizedCliDiagnostic(error)];
 }

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -251,6 +251,31 @@ describe("local upgrade remote runner", () => {
         expect(script).not.toContain("jq ");
     });
 
+    test("executes transfer verification with nounset enabled", () => {
+        const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
+        const verifyTransfer = shellFunctionDefinition(script, "verify_transfer");
+        const execution = Bun.spawnSync({
+            cmd: ["bash", "-c", [
+                "set -euo pipefail",
+                "stat() { test \"$3\" = \"$EXPECTED_PATH\"; printf '%s\\n' \"$FILE_SIZE\"; }",
+                "sha256sum() { test \"$1\" = \"$EXPECTED_PATH\"; printf '%s  %s\\n' \"$FILE_SHA\" \"$1\"; }",
+                verifyTransfer,
+                "verify_transfer \"$RELATIVE\" \"$FILE_SIZE\" \"$FILE_SHA\"",
+            ].join("\n")],
+            env: {
+                ...process.env,
+                EXPECTED_PATH: "/stage/bundle/management-api/artifact",
+                FILE_SHA: "a".repeat(64),
+                FILE_SIZE: "1234",
+                RELATIVE: "bundle/management-api/artifact",
+                STAGE: "/stage",
+            },
+        });
+
+        expect(execution.exitCode).toBe(0);
+        expect(execution.stderr.toString()).toBe("");
+    });
+
     test("keeps the signed bundle immutable and reports cleanup failures as failures", () => {
         const script = runScript(preparedBundle("amd64", "bundled"), "amd64");
 

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,6 +10,8 @@ import {
     buildCleanupUnstartedUpgradeScript,
     buildLocalUpgradeRunScript,
     buildRemotePreflightScript,
+    buildUpgradeLockScript,
+    failureRequiresRemoteReconciliation,
     parseRemotePreflight,
     remoteUpgradePreflight,
     startRemoteUpgrade,
@@ -25,15 +27,17 @@ const paths = {
 };
 
 type ScriptedResult = { success: boolean; stdout: string; stderr: string; code: number };
-type ScriptedResponse = Error | ScriptedResult;
+type ScriptedResponse = ScriptedResult | Error;
 
 class ScriptedSsh {
     readonly commands: string[] = [];
+    readonly timeouts: number[] = [];
 
     constructor(private readonly responses: ScriptedResponse[]) {}
 
-    async exec(command: string): Promise<ScriptedResult> {
+    async exec(command: string, timeoutMs: number): Promise<ScriptedResult> {
         this.commands.push(command);
+        this.timeouts.push(timeoutMs);
         const response = this.responses.shift();
         if (!response) throw new Error("Unexpected SSH command in lifecycle test");
         if (response instanceof Error) throw response;
@@ -43,6 +47,38 @@ class ScriptedSsh {
 
 function remoteResult(stdout = "", success = true): ScriptedResult {
     return { success, stdout, stderr: success ? "" : "remote failure", code: success ? 0 : 1 };
+}
+
+type RemoteStateFixture = {
+    dropExists?: boolean;
+    logExists?: boolean;
+    serviceState: string;
+    stageExists?: boolean;
+    stageIsDirectory?: boolean;
+    status: string;
+    statusExists?: boolean;
+    unitExists?: boolean;
+    unitLoadState?: string;
+};
+
+function remoteState(fixture: RemoteStateFixture): ScriptedResult {
+    const statusExists = fixture.statusExists ?? fixture.status.length > 0;
+    const logExists = fixture.logExists ?? statusExists;
+    const unitExists = fixture.unitExists
+        ?? !["inactive", "unknown"].includes(fixture.serviceState);
+    const unitLoadState = fixture.unitLoadState ?? (unitExists ? "loaded" : "not-found");
+    return remoteResult([
+        `STATUS=${fixture.status}`,
+        `UNIT=${fixture.serviceState}`,
+        `STAGE_EXISTS=${fixture.stageExists ? "yes" : "no"}`,
+        `STAGE_DIRECTORY=${fixture.stageIsDirectory ?? fixture.stageExists ? "yes" : "no"}`,
+        `DROP_EXISTS=${fixture.dropExists ? "yes" : "no"}`,
+        `STATUS_EXISTS=${statusExists ? "yes" : "no"}`,
+        `LOG_EXISTS=${logExists ? "yes" : "no"}`,
+        `UNIT_EXISTS=${unitExists ? "yes" : "no"}`,
+        `UNIT_LOAD=${unitLoadState}`,
+        "",
+    ].join("\n"));
 }
 
 function fixtureFile(relativePath: string, index: number): LocalUpgradeFile {
@@ -112,11 +148,46 @@ describe("local upgrade remote runner", () => {
         expect(script).toContain("timeout 15s \"$GH\" attestation verify --help");
         expect(script).toContain("mode=$(stat -c '%a' \"$verifier\")");
         expect(script).toContain("trusted_installed_gh \"$GH\"");
+        expect(script).toContain("timeout flock");
         expect(script).not.toContain("Required local-upgrade tool is missing: jq");
         expect(parseRemotePreflight("ARCH=arm64\nVERIFIER=installed\n")).toEqual({
             architecture: "arm64",
             verifierProvisioning: "installed",
         });
+    });
+
+    test("serializes independent run IDs with one host-wide upgrade lock", () => {
+        const firstRun = runScript(preparedBundle("amd64", "installed"), "amd64");
+        const secondRun = buildLocalUpgradeRunScript({
+            ...paths,
+            stage: "/var/lib/supacloud/upgrade-staging/22222222-2222-4222-8222-222222222222",
+            status: "/var/lib/supacloud/upgrade-runs/22222222-2222-4222-8222-222222222222.status",
+            log: "/var/log/supacloud/upgrade-22222222-2222-4222-8222-222222222222.log",
+            unit: "supacloud-upgrade-22222222-2222-4222-8222-222222222222.service",
+        }, preparedBundle("amd64", "installed"), {
+            managementVersion: "0.50.31", edgeRuntimeVersion: "0.16.8",
+        }, "amd64");
+        expect(firstRun).toContain("/run/lock/supacloud-upgrade.lock");
+        expect(secondRun).toContain("/run/lock/supacloud-upgrade.lock");
+        if (!Bun.which("flock")) return;
+
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-upgrade-lock-")));
+        const lockPath = join(fixtureRoot, "upgrade.lock");
+        const execution = Bun.spawnSync(["bash", "-c", [
+            "umask 077",
+            `exec 8>${JSON.stringify(lockPath)}`,
+            "flock -n 8",
+            "set +e",
+            `( ${buildUpgradeLockScript(lockPath)} )`,
+            "code=$?",
+            "test \"$code\" -eq 75",
+        ].join("\n")]);
+        try {
+            expect(execution.exitCode).toBe(0);
+            expect(execution.stderr.toString()).toContain("already running");
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
     });
 
     test("trusts only root-owned installed verifiers without writable or special permission bits", () => {
@@ -396,7 +467,7 @@ describe("local upgrade remote runner", () => {
             mkdirSync(fixturePaths.drop, { mode: 0o700 });
             const execution = Bun.spawnSync(["bash", "-c", [
                 "install() { return 0; }", "systemctl() { return 1; }",
-                `chown() { kill -${signal} \"$$\"; }`,
+                `chown() { kill -${signal} "$$"; }`,
                 buildAdoptDropScript(fixturePaths),
             ].join("\n")]);
             try {
@@ -411,110 +482,72 @@ describe("local upgrade remote runner", () => {
         }
     });
 
-    test("disables adoption rollback after publishing PREPARED", () => {
-        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-adopt-success-")));
-        const fixturePaths = {
-            drop: join(fixtureRoot, "drop"), stage: join(fixtureRoot, "stage"),
-            status: join(fixtureRoot, "run.status"), log: join(fixtureRoot, "run.log"),
-            unit: "supacloud-upgrade-test.service",
-        };
-        mkdirSync(fixturePaths.drop, { mode: 0o700 });
-        const execution = Bun.spawnSync(["bash", "-c", [
-            "install() { return 0; }", "systemctl() { return 1; }", "chown() { return 0; }",
-            buildAdoptDropScript(fixturePaths),
-        ].join("\n")]);
-        try {
-            expect(execution.exitCode).toBe(0);
-            expect(existsSync(fixturePaths.drop)).toBe(false);
-            expect(existsSync(fixturePaths.stage)).toBe(true);
-            expect(readFileSync(fixturePaths.status, "utf8").trim()).toBe("PREPARED");
-        } finally {
-            rmSync(fixtureRoot, { recursive: true, force: true });
+    test("continues from PREPARED when the adoption SSH result is ambiguous", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH stream closed after adoption"),
+            remoteState({ status: "PREPARED", serviceState: "inactive", stageExists: true }),
+        ]);
+
+        await expect(adoptRemoteDrop(ssh as never, paths)).resolves.toBeUndefined();
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands[1]).toContain(paths.stage);
+        expect(ssh.commands[1]).toContain(paths.drop);
+    });
+
+    test("retains remote evidence when interrupted adoption cannot be reconciled", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH stream closed after adoption"),
+            new Error("read-back connection failed"),
+            new Error("read-back connection failed"),
+            new Error("read-back connection failed"),
+        ]);
+
+        const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("do not retry blindly");
+        for (const retainedPath of [paths.stage, paths.status, paths.log, paths.drop, paths.unit]) {
+            expect(String(failure)).toContain(retainedPath);
         }
     });
 
-    test("cleans a prepared inactive adoption after its SSH response is lost", async () => {
+    test("does not clean a drop after an interrupted adoption reads back pre-operation state", async () => {
         const ssh = new ScriptedSsh([
-            new Error("SSH response lost after remote adoption"),
-            remoteResult("STAGE=present\nSTATUS=PREPARED\nUNIT=inactive\nUNIT_LOAD=not-found\n"),
-            remoteResult(),
+            new Error("SSH stream closed before adoption returned"),
+            remoteState({
+                status: "",
+                serviceState: "inactive",
+                dropExists: true,
+                statusExists: false,
+                logExists: false,
+                unitExists: false,
+            }),
         ]);
 
-        await expect(adoptRemoteDrop(ssh as never, paths)).rejects.toThrow("SSH response lost after remote adoption");
-        expect(ssh.commands).toHaveLength(3);
-        expect(ssh.commands[2]).toContain(paths.stage);
-        expect(ssh.commands[2]).toContain(paths.status);
-        expect(ssh.commands[2]).toContain(paths.log);
+        const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("outcome is still uncertain");
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes(`rm -rf -- '${paths.drop}'`))).toBe(false);
     });
 
-    test("cleans the upload drop when failed adoption state proves the move did not persist", async () => {
-        const ssh = new ScriptedSsh([
-            new Error("SSH response lost before remote adoption"),
-            remoteResult("STAGE=absent\nSTATUS=\nUNIT=inactive\nUNIT_LOAD=not-found\n"),
-            remoteResult(),
-        ]);
-
-        await expect(adoptRemoteDrop(ssh as never, paths)).rejects.toThrow("SSH response lost before remote adoption");
-        expect(ssh.commands).toHaveLength(3);
-        expect(ssh.commands[2]).toContain(`rm -rf -- '${paths.drop}'`);
-        expect(ssh.commands[2]).not.toContain(paths.stage);
-    });
-
-    test("preserves adoption and upload-drop cleanup failures", async () => {
+    test("requires reconciliation when adoption rollback leaves remote records", async () => {
         const ssh = new ScriptedSsh([
             remoteResult("", false),
-            remoteResult("STAGE=absent\nSTATUS=\nUNIT=inactive\nUNIT_LOAD=not-found\n"),
-            remoteResult("", false),
+            remoteState({
+                status: "",
+                serviceState: "inactive",
+                dropExists: true,
+                statusExists: true,
+                logExists: false,
+                unitExists: false,
+            }),
         ]);
 
         const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
-        expect(failure).toBeInstanceOf(AggregateError);
-        const diagnostics = (failure as AggregateError).errors.map(String).join("\n");
-        expect(diagnostics).toContain("Unable to adopt the verified upgrade bundle");
-        expect(diagnostics).toContain("Unable to remove remote upload drop");
-        expect((failure as Error).message).toContain(`retained drop=${paths.drop}`);
-    });
-
-    test("continues observing when failed adoption reporting finds a running upgrade", async () => {
-        const ssh = new ScriptedSsh([
-            new Error("SSH response lost after remote adoption"),
-            remoteResult("STAGE=present\nSTATUS=RUNNING\nUNIT=active\nUNIT_LOAD=loaded\n"),
-        ]);
-
-        await expect(adoptRemoteDrop(ssh as never, paths)).resolves.toBe("already-started");
-        expect(ssh.commands).toHaveLength(2);
-        expect(ssh.commands.slice(1).some((command) => command.includes("rm -rf --"))).toBe(false);
-    });
-
-    test("retains all evidence when failed adoption state cannot be read", async () => {
-        const ssh = new ScriptedSsh([
-            new Error("SSH response lost after remote adoption"),
-            new Error("SSH reconnect failed"),
-        ]);
-
-        const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
-        expect(failure).toBeInstanceOf(AggregateError);
-        expect((failure as AggregateError).errors.map(String).join("\n")).toContain("SSH response lost after remote adoption");
-        expect((failure as AggregateError).errors.map(String).join("\n")).toContain("SSH reconnect failed");
-        expect((failure as Error).message).toContain("do not retry blindly");
-        for (const retainedPath of [paths.drop, paths.stage, paths.status, paths.log, paths.unit]) {
-            expect((failure as Error).message).toContain(retainedPath);
-        }
-        expect(ssh.commands).toHaveLength(2);
-    });
-
-    test("retains all evidence when failed adoption state is ambiguous", async () => {
-        const ssh = new ScriptedSsh([
-            new Error("SSH response lost after remote adoption"),
-            remoteResult("STAGE=unsafe\nSTATUS=\nUNIT=unknown\nUNIT_LOAD=unknown\n"),
-        ]);
-
-        const failure = await adoptRemoteDrop(ssh as never, paths).catch((error: unknown) => error);
-        expect(failure).toBeInstanceOf(AggregateError);
-        expect((failure as Error).message).toContain("observed stage=unsafe status=empty unit=unknown load=unknown");
-        expect((failure as Error).message).toContain("do not retry blindly");
-        expect(ssh.commands).toHaveLength(2);
-        expect(ssh.commands.slice(1).some((command) => command.includes("rm -rf --"))).toBe(false);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain(paths.status);
+        expect(String(failure)).toContain("do not retry blindly");
     });
 
     test("pins the temporary Linux GitHub verifier by architecture", () => {
@@ -527,7 +560,9 @@ describe("local upgrade remote runner", () => {
     test("does not delete an adopted stage while systemd is still activating", async () => {
         const ssh = new ScriptedSsh([
             remoteResult("", false),
-            remoteResult("STATUS=PREPARED\nUNIT=activating\n"),
+            remoteState({
+                status: "PREPARED", serviceState: "activating", stageExists: true, unitExists: true,
+            }),
         ]);
 
         await expect(startRemoteUpgrade(ssh as never, paths)).resolves.toBeUndefined();
@@ -535,18 +570,58 @@ describe("local upgrade remote runner", () => {
         expect(ssh.commands.some((command) => command.includes("rm -rf --") && command.includes(paths.stage))).toBe(false);
     });
 
-    test("bounds the transient upgrade unit with the established maximum upgrade budget", async () => {
-        const ssh = new ScriptedSsh([remoteResult()]);
+    test("continues monitoring when start disconnects after the unit begins", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH stream closed after systemd-run"),
+            remoteState({ status: "RUNNING", serviceState: "active", stageExists: true }),
+        ]);
 
         await expect(startRemoteUpgrade(ssh as never, paths)).resolves.toBeUndefined();
-        expect(ssh.commands[0]).toContain("--property=RuntimeMaxSec=1320s");
-        expect(ssh.commands[0]).toContain("--property=TimeoutStopSec=30s");
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes("rm -rf --") && command.includes(paths.stage))).toBe(false);
+    });
+
+    test("does not clean PREPARED state while an inactive transient unit still exists", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH stream closed during systemd-run"),
+            remoteState({
+                status: "PREPARED",
+                serviceState: "inactive",
+                stageExists: true,
+                unitExists: true,
+            }),
+        ]);
+
+        const failure = await startRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes("rm -rf --") && command.includes(paths.stage))).toBe(false);
+    });
+
+    test("does not clean PREPARED state after an interrupted start remains inactive", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH stream closed before systemd-run returned"),
+            remoteState({
+                status: "PREPARED",
+                serviceState: "inactive",
+                stageExists: true,
+                unitExists: false,
+            }),
+        ]);
+
+        const failure = await startRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("outcome is still uncertain");
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes("rm -rf --") && command.includes(paths.stage))).toBe(false);
     });
 
     test("preserves start and cleanup failures when an unstarted unit cannot be removed", async () => {
         const ssh = new ScriptedSsh([
             remoteResult("", false),
-            remoteResult("STATUS=PREPARED\nUNIT=inactive\n"),
+            remoteState({
+                status: "PREPARED", serviceState: "inactive", stageExists: true, unitExists: false,
+            }),
             remoteResult("", false),
         ]);
 
@@ -555,6 +630,9 @@ describe("local upgrade remote runner", () => {
         const diagnostics = (failure as AggregateError).errors.map(String).join("\n");
         expect(diagnostics).toContain("Unable to start the transient upgrade unit");
         expect(diagnostics).toContain("Unable to clean an unstarted local upgrade");
+        for (const retainedPath of [paths.stage, paths.status, paths.log, paths.drop, paths.unit]) {
+            expect(String(failure)).toContain(retainedPath);
+        }
     });
 
     test("reports stage cleanup failure after still removing unstarted records", () => {
@@ -581,20 +659,78 @@ describe("local upgrade remote runner", () => {
         }
     });
 
+    test("reconnects after a transient lifecycle observation failure", async () => {
+        const ssh = new ScriptedSsh([
+            new Error("SSH connection reset while monitoring"),
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
+            remoteResult("transaction complete\n"),
+            remoteResult(),
+        ]);
+
+        await expect(awaitRemoteUpgrade(ssh as never, paths)).resolves.toContain("Upgrade done");
+        expect(ssh.commands).toHaveLength(4);
+    });
+
     test("retains status and logs when a successful transaction cannot clean its stage", async () => {
         const ssh = new ScriptedSsh([
-            remoteResult("STATUS=FAILED:1:CLEANUP_AFTER_TRANSACTION\nUNIT=failed\n"),
+            remoteState({
+                status: "FAILED:1:CLEANUP_AFTER_TRANSACTION",
+                serviceState: "failed",
+                stageExists: true,
+            }),
             remoteResult("transaction completed; stage cleanup failed\n"),
         ]);
 
-        await expect(awaitRemoteUpgrade(ssh as never, paths)).rejects.toThrow(`retained status=${paths.status}`);
+        const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("transaction completed but staging cleanup is incomplete");
+        for (const retainedPath of [paths.stage, paths.status, paths.log, paths.drop, paths.unit]) {
+            expect(String(failure)).toContain(retainedPath);
+        }
         expect(ssh.commands).toHaveLength(2);
         expect(ssh.commands.some((command) => command.includes(`rm -f -- '${paths.status}'`))).toBe(false);
     });
 
+    test("retains evidence when a failed transaction log cannot be read", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "FAILED:9:TRANSACTION",
+                serviceState: "failed",
+                stageExists: false,
+            }),
+            new Error("SSH stream closed while reading the failed transaction log"),
+        ]);
+
+        const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("retained log could not be read");
+        expect(String(failure)).toContain(paths.status);
+        expect(String(failure)).toContain(paths.log);
+        expect(String(failure)).toContain("do not retry blindly");
+        expect(ssh.commands).toHaveLength(2);
+    });
+
+    test("waits for a failed finalizer to stop before validating its stage", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "FAILED:9:TRANSACTION", serviceState: "active", stageExists: true,
+            }),
+            remoteState({
+                status: "FAILED:9:TRANSACTION", serviceState: "failed", stageExists: false,
+            }),
+            remoteResult("transaction failed\n"),
+            remoteResult(),
+        ]);
+
+        const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(false);
+        expect(String(failure)).toContain("FAILED:9:TRANSACTION");
+        expect(ssh.commands).toHaveLength(4);
+    });
+
     test("removes terminal records only after a completed unit publishes success", async () => {
         const ssh = new ScriptedSsh([
-            remoteResult("STATUS=SUCCEEDED\nUNIT=inactive\nUNIT_LOAD=loaded\n"),
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
             remoteResult("upgrade committed\n"),
             remoteResult(),
         ]);
@@ -605,58 +741,127 @@ describe("local upgrade remote runner", () => {
         expect(ssh.commands[2]).toContain(paths.log);
     });
 
-    test("accepts success after a transient unit has been collected", async () => {
-        const ssh = new ScriptedSsh([
-            remoteResult("STATUS=SUCCEEDED\nUNIT=unknown\nUNIT_LOAD=not-found\n"),
-            remoteResult("upgrade committed\n"),
-            remoteResult(),
-        ]);
+    test("accepts success after a normal stop or collected transient unit", async () => {
+        for (const [serviceState, unitLoadState, unitExists] of [
+            ["inactive", "loaded", true],
+            ["unknown", "not-found", false],
+        ] as const) {
+            const ssh = new ScriptedSsh([
+                remoteState({ status: "SUCCEEDED", serviceState, unitLoadState, unitExists }),
+                remoteResult("upgrade committed\n"),
+                remoteResult(),
+            ]);
 
-        await expect(awaitRemoteUpgrade(ssh as never, paths)).resolves.toContain("Upgrade done");
-        expect(ssh.commands).toHaveLength(3);
+            await expect(awaitRemoteUpgrade(ssh as never, paths)).resolves.toContain("Upgrade done");
+            expect(ssh.commands).toHaveLength(3);
+        }
     });
 
-    test("rejects SUCCEEDED when systemd reports an abnormal or ambiguous stop", async () => {
-        for (const [serviceState, loadState] of [
+    test("requires reconciliation for abnormal or ambiguous SUCCEEDED unit states", async () => {
+        for (const [serviceState, unitLoadState] of [
             ["failed", "loaded"],
             ["maintenance", "loaded"],
             ["unknown", "loaded"],
             ["inactive", "unknown"],
         ] as const) {
             const ssh = new ScriptedSsh([
-                remoteResult(`STATUS=SUCCEEDED\nUNIT=${serviceState}\nUNIT_LOAD=${loadState}\n`),
+                remoteState({ status: "SUCCEEDED", serviceState, unitLoadState }),
             ]);
 
             const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
-            expect(failure).toBeInstanceOf(Error);
-            expect((failure as Error).message).toContain(`state=${serviceState} load=${loadState}`);
-            for (const retainedPath of [paths.stage, paths.status, paths.log, paths.unit]) {
-                expect((failure as Error).message).toContain(retainedPath);
-            }
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+            expect(String(failure)).toContain(`state=${serviceState} load=${unitLoadState}`);
+            expect(String(failure)).toContain("do not retry blindly");
             expect(ssh.commands).toHaveLength(1);
         }
     });
 
-    test("stops waiting at the total deadline without stopping or cleaning the remote unit", async () => {
+    test("requires reconciliation before reading or deleting incomplete terminal evidence", async () => {
+        for (const state of [
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", logExists: false }),
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", stageExists: true }),
+            remoteState({ status: "FAILED:9:TRANSACTION", serviceState: "failed", logExists: false }),
+            remoteState({ status: "FAILED:9:TRANSACTION", serviceState: "failed", stageExists: true }),
+        ]) {
+            const ssh = new ScriptedSsh([state]);
+
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+            expect(String(failure)).toContain("terminal evidence is incomplete or inconsistent");
+            expect(String(failure)).toContain("do not retry blindly");
+            expect(ssh.commands).toHaveLength(1);
+        }
+    });
+
+    test("requires reconciliation when successful record cleanup disconnects", async () => {
         const ssh = new ScriptedSsh([
-            remoteResult("STAGE=present\nSTATUS=RUNNING\nUNIT=active\nUNIT_LOAD=loaded\n"),
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
+            remoteResult("upgrade committed\n"),
+            new Error("SSH stream closed during record cleanup"),
         ]);
-        const originalNow = Date.now;
-        const timestamps = [0, 0, 1_365_000];
-        Date.now = () => timestamps.shift() ?? 1_365_000;
+
+        const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("cleanup could not be confirmed");
+        expect(String(failure)).toContain(paths.status);
+        expect(String(failure)).toContain(paths.log);
+    });
+
+    test("requires reconciliation when a successful log disappears after state read-back", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
+            remoteResult("", false),
+        ]);
+
+        const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("retained log could not be read");
+        expect(String(failure)).toContain("do not retry blindly");
+        expect(ssh.commands).toHaveLength(2);
+    });
+
+    test("stops observing a nonterminal unit without stopping the remote transaction", async () => {
+        const now = spyOn(Date, "now")
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(30 * 60_000 - 1_000)
+            .mockReturnValue(30 * 60_000);
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "RUNNING", serviceState: "active", stageExists: true }),
+        ]);
+
         try {
             const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
-            expect(failure).toBeInstanceOf(Error);
-            expect((failure as Error).message).toContain("1320-second runtime limit");
-            expect((failure as Error).message).toContain("45-second observation grace");
-            for (const retainedPath of [paths.stage, paths.status, paths.log, paths.unit]) {
-                expect((failure as Error).message).toContain(retainedPath);
-            }
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+            expect(String(failure)).toContain("observation deadline");
             expect(ssh.commands).toHaveLength(1);
+            expect(ssh.timeouts).toEqual([1_000]);
             expect(ssh.commands[0]).not.toContain("systemctl stop");
-            expect(ssh.commands[0]).not.toContain("rm -rf --");
         } finally {
-            Date.now = originalNow;
+            now.mockRestore();
+        }
+    });
+
+    test("caps the final poll delay at the remaining observation window", async () => {
+        const timeout = spyOn(globalThis, "setTimeout");
+        const now = spyOn(Date, "now")
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(0)
+            .mockReturnValueOnce(30 * 60_000 - 1)
+            .mockReturnValueOnce(30 * 60_000 - 1)
+            .mockReturnValue(30 * 60_000);
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "RUNNING", serviceState: "active", stageExists: true }),
+        ]);
+
+        try {
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+            expect(String(failure)).toContain("observation deadline");
+            expect(ssh.commands).toHaveLength(1);
+            expect(timeout.mock.calls.some((call) => call[1] === 1)).toBe(true);
+        } finally {
+            now.mockRestore();
+            timeout.mockRestore();
         }
     });
 });

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -3,6 +3,10 @@ import { basename } from "node:path";
 
 import type { SshResult, SshTransport } from "../transports/ssh";
 import {
+    buildUpgradeLockScript,
+    SUPACLOUD_UPGRADE_LOCK_PATH,
+} from "../../../../management-api/src/upgrade-lock";
+import {
     cleanupLocalUpgradeBundle,
     githubCliArchiveIdentity,
     prepareLocalUpgradeBundle,
@@ -10,6 +14,8 @@ import {
     type PreparedLocalUpgradeBundle,
     type UpgradeArchitecture,
 } from "./local-upgrade-bundle";
+
+export { buildUpgradeLockScript, SUPACLOUD_UPGRADE_LOCK_PATH };
 
 export type LocalUpgradeTransferRequest = {
     managementVersion: string;
@@ -25,13 +31,16 @@ export type RemoteUpgradePaths = {
 };
 
 type RemoteUpgradeState = {
+    dropExists: boolean;
+    logExists: boolean;
     serviceState: string;
-    stageState: "absent" | "present" | "unsafe" | "unknown";
+    stageExists: boolean;
+    stageIsDirectory: boolean;
     status: string;
+    statusExists: boolean;
+    unitExists: boolean;
     unitLoadState: string;
 };
-
-type AdoptionOutcome = "already-started" | "ready-to-start";
 
 export type RemoteUpgradePreflight = {
     architecture: UpgradeArchitecture;
@@ -42,12 +51,11 @@ const REMOTE_STAGE_ROOT = "/var/lib/supacloud/upgrade-staging";
 const REMOTE_RUN_ROOT = "/var/lib/supacloud/upgrade-runs";
 const REMOTE_LOG_ROOT = "/var/log/supacloud";
 const POLL_INTERVAL_MS = 2_000;
-// Match the longest existing upgrade budget, then allow systemd's stop grace and one final state read.
-const REMOTE_UPGRADE_RUNTIME_SECONDS = 22 * 60;
-const REMOTE_UPGRADE_STOP_GRACE_MS = 30_000;
+const STATE_READ_ATTEMPTS = 3;
 const REMOTE_STATE_READ_TIMEOUT_MS = 15_000;
-const REMOTE_UPGRADE_OBSERVATION_GRACE_MS = REMOTE_UPGRADE_STOP_GRACE_MS + REMOTE_STATE_READ_TIMEOUT_MS;
-const REMOTE_UPGRADE_WAIT_TIMEOUT_MS = REMOTE_UPGRADE_RUNTIME_SECONDS * 1_000 + REMOTE_UPGRADE_OBSERVATION_GRACE_MS;
+const UPGRADE_OBSERVATION_TIMEOUT_MS = 30 * 60_000;
+
+class RemoteUpgradeReconciliationError extends AggregateError {}
 
 function quoteShell(shellText: string): string {
     return `'${shellText.split("'").join("'\\''")}'`;
@@ -107,8 +115,9 @@ export function buildRemotePreflightScript(): string {
         "export PATH",
         trustedInstalledGithubFunction(),
         "test -d /run/systemd/system || { echo 'systemd is not the active init system' >&2; exit 1; }",
-        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep timeout; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep timeout flock; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
         "systemd-run --help | grep -Eq -- '(^|[[:space:]])--collect([=[:space:]]|$)' || { echo 'systemd-run --collect is required' >&2; exit 1; }",
+        "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
         "test -d /var/lib/supacloud || { echo '/var/lib/supacloud is unavailable' >&2; exit 1; }",
         "test -f /etc/supabase/management-api.env || { echo 'EDGE_RUNTIME_MODE is unavailable' >&2; exit 1; }",
         "EDGE_MODE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\\"'\"']+|[[:space:]\\\"'\"']+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
@@ -229,6 +238,7 @@ function upgradeScriptSetup(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgr
         finishUpgradeFunction(),
         "trap finish_upgrade EXIT", "trap 'exit 129' HUP", "trap 'exit 130' INT", "trap 'exit 143' TERM",
         "exec >>\"$LOG\" 2>&1", "write_status RUNNING",
+        buildUpgradeLockScript(SUPACLOUD_UPGRADE_LOCK_PATH),
         "while IFS='=' read -r variable _; do case \"$variable\" in *PROXY*|*Proxy*|*proxy*) unset \"$variable\" ;; esac; done < <(env)",
         "unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE SUPACLOUD_GITHUB_REPOSITORY SUPACLOUD_RELEASES_API SUPACLOUD_ATTESTATION_SIGNER_WORKFLOW NODE_USE_ENV_PROXY",
     ];
@@ -359,7 +369,8 @@ function failedAdoptionRollbackFunction(): string {
     return [
         "rollback_failed_adoption() {",
         "  local code=$? cleanup_failed=false",
-        "  trap - EXIT HUP INT TERM",
+        "  trap '' HUP INT TERM",
+        "  trap - EXIT",
         "  if [ \"$ADOPTION_ACTIVE\" != true ]; then exit \"$code\"; fi",
         "  set +e",
         "  rm -rf -- \"$STAGE\" || cleanup_failed=true",
@@ -399,124 +410,73 @@ export function buildAdoptDropScript(paths: RemoteUpgradePaths): string {
     ].join("\n");
 }
 
-function adoptionHasStarted(state: RemoteUpgradeState): boolean {
-    return unitIsRunning(state.serviceState) || /^(?:RUNNING|CLEANING|SUCCEEDED|FAILED:)/.test(state.status);
-}
-
-function unitNeverStarted(state: RemoteUpgradeState): boolean {
-    return state.unitLoadState === "not-found" || state.serviceState === "inactive";
-}
-
-function adoptionCanBeRolledBack(state: RemoteUpgradeState): boolean {
-    return state.stageState === "present" && state.status === "PREPARED" && unitNeverStarted(state);
-}
-
-function adoptionDidNotPersist(state: RemoteUpgradeState): boolean {
-    return state.stageState === "absent" && !state.status && unitNeverStarted(state);
-}
-
-function retainedUpgradeEvidence(paths: RemoteUpgradePaths): string {
-    return `stage=${paths.stage} status=${paths.status} log=${paths.log} unit=${paths.unit}`;
-}
-
-function retainedAdoptionEvidence(paths: RemoteUpgradePaths): string {
-    return `drop=${paths.drop} ${retainedUpgradeEvidence(paths)}`;
-}
-
-function ambiguousAdoptionError(
-    paths: RemoteUpgradePaths,
-    failures: unknown[],
-    state?: RemoteUpgradeState,
-): AggregateError {
-    const observedState = state
-        ? ` observed stage=${state.stageState} status=${state.status || "empty"} unit=${state.serviceState} load=${state.unitLoadState};`
-        : "";
-    return new AggregateError(
-        failures,
-        `Unable to determine whether remote upgrade adoption completed; do not retry blindly;${observedState} retained ${retainedAdoptionEvidence(paths)}`,
-    );
-}
-
-async function rollbackPreparedAdoption(
-    ssh: SshTransport,
-    paths: RemoteUpgradePaths,
-    adoptionFailure: unknown,
-    state: RemoteUpgradeState,
-): Promise<never> {
+export async function adoptRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
+    let adoptionFailure: Error;
+    let adoptionOutcomeUncertain = false;
     try {
-        await cleanupUnstartedUpgrade(ssh, paths);
-    } catch (cleanupFailure: unknown) {
-        throw ambiguousAdoptionError(paths, [adoptionFailure, cleanupFailure], state);
+        const adopted = await ssh.exec(rootCommand(buildAdoptDropScript(paths)), 60_000);
+        if (adopted.success) return;
+        adoptionFailure = remoteFailure("Unable to adopt the verified upgrade bundle", adopted);
+    } catch (error: unknown) {
+        adoptionOutcomeUncertain = true;
+        adoptionFailure = operationError(error, "Unable to adopt the verified upgrade bundle");
     }
-    throw adoptionFailure;
-}
-
-async function cleanupUnadoptedDrop(
-    ssh: SshTransport,
-    paths: RemoteUpgradePaths,
-    adoptionFailure: unknown,
-): Promise<never> {
-    try {
-        await cleanupRemoteDrop(ssh, paths);
-    } catch (cleanupFailure: unknown) {
-        throw new AggregateError(
-            [adoptionFailure, cleanupFailure],
-            `Remote upgrade adoption failed and upload-drop cleanup did not complete; retained ${retainedAdoptionEvidence(paths)}`,
+    const state = await observeRemoteState(ssh, paths, {
+        failureMessage: "Unable to reconcile the interrupted upgrade adoption",
+        precedingFailures: [adoptionFailure],
+    });
+    if (isFullyPreparedUnstartedState(state)) return;
+    if (adoptionOutcomeUncertain) {
+        throw remoteReconciliationFailure(
+            "Upgrade adoption outcome is still uncertain after SSH interruption", [adoptionFailure], paths,
         );
     }
-    throw adoptionFailure;
-}
-
-async function reconcileFailedAdoption(
-    ssh: SshTransport,
-    paths: RemoteUpgradePaths,
-    adoptionFailure: unknown,
-): Promise<AdoptionOutcome> {
-    let state: RemoteUpgradeState;
-    try {
-        state = await readRemoteState(ssh, paths);
-    } catch (stateFailure: unknown) {
-        throw ambiguousAdoptionError(paths, [adoptionFailure, stateFailure]);
-    }
-    if (adoptionHasStarted(state)) return "already-started";
-    if (adoptionDidNotPersist(state)) return await cleanupUnadoptedDrop(ssh, paths, adoptionFailure);
-    if (!adoptionCanBeRolledBack(state)) throw ambiguousAdoptionError(paths, [adoptionFailure], state);
-    return await rollbackPreparedAdoption(ssh, paths, adoptionFailure, state);
-}
-
-export async function adoptRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<AdoptionOutcome> {
-    let adopted: SshResult;
-    try {
-        adopted = await ssh.exec(rootCommand(buildAdoptDropScript(paths)), 60_000);
-    } catch (adoptionFailure: unknown) {
-        return await reconcileFailedAdoption(ssh, paths, adoptionFailure);
-    }
-    if (adopted.success) return "ready-to-start";
-    return await reconcileFailedAdoption(
-        ssh,
-        paths,
-        remoteFailure("Unable to adopt the verified upgrade bundle", adopted),
+    const noAdoptedStateRemains = !state.stageExists && !state.statusExists
+        && !state.logExists && !state.unitExists;
+    if (noAdoptedStateRemains) throw adoptionFailure;
+    throw remoteReconciliationFailure(
+        "Upgrade adoption stopped in an ambiguous state", [adoptionFailure], paths,
     );
 }
 
 function startUnitScript(paths: RemoteUpgradePaths): string {
     return [
         "set -euo pipefail",
-        `systemd-run --quiet --collect --unit=${quoteShell(paths.unit)} --property=Type=exec --property=KillMode=control-group --property=RuntimeMaxSec=${REMOTE_UPGRADE_RUNTIME_SECONDS}s --property=TimeoutStopSec=${REMOTE_UPGRADE_STOP_GRACE_MS / 1_000}s /bin/bash ${quoteShell(`${paths.stage}/run.sh`)}`,
+        `systemd-run --quiet --collect --unit=${quoteShell(paths.unit)} --property=Type=exec --property=KillMode=control-group --property=TimeoutStopSec=30s /bin/bash ${quoteShell(`${paths.stage}/run.sh`)}`,
         `systemctl is-active --quiet ${quoteShell(paths.unit)}`,
     ].join("\n");
 }
 
 export async function startRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<void> {
-    const started = await ssh.exec(rootCommand(startUnitScript(paths)), 30_000);
-    if (started.success) return;
-    const state = await readRemoteState(ssh, paths);
-    if (adoptionHasStarted(state)) return;
-    const startFailure = remoteFailure("Unable to start the transient upgrade unit", started);
+    let startFailure: Error;
+    let startOutcomeUncertain = false;
+    try {
+        const started = await ssh.exec(rootCommand(startUnitScript(paths)), 30_000);
+        if (started.success) return;
+        startFailure = remoteFailure("Unable to start the transient upgrade unit", started);
+    } catch (error: unknown) {
+        startOutcomeUncertain = true;
+        startFailure = operationError(error, "Unable to start the transient upgrade unit");
+    }
+    const state = await observeRemoteState(ssh, paths, {
+        failureMessage: "Unable to reconcile the interrupted upgrade start",
+        precedingFailures: [startFailure],
+    });
+    if (unitIsRunning(state.serviceState) || /^(?:RUNNING|CLEANING|SUCCEEDED|FAILED:)/.test(state.status)) return;
+    if (startOutcomeUncertain) {
+        throw remoteReconciliationFailure(
+            "Upgrade start outcome is still uncertain after SSH interruption", [startFailure], paths,
+        );
+    }
+    if (!isFullyPreparedUnstartedState(state)) {
+        throw remoteReconciliationFailure("Upgrade start stopped in an ambiguous state", [startFailure], paths);
+    }
     try {
         await cleanupUnstartedUpgrade(ssh, paths);
     } catch (cleanupError: unknown) {
-        throw new AggregateError([startFailure, cleanupError], "Remote upgrade start and cleanup both failed");
+        throw remoteReconciliationFailure(
+            "Remote upgrade start and cleanup both failed", [startFailure, cleanupError], paths,
+        );
     }
     throw startFailure;
 }
@@ -524,14 +484,37 @@ export async function startRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
 function readStateScript(paths: RemoteUpgradePaths): string {
     return [
         "set -euo pipefail",
+        `DROP=${quoteShell(paths.drop)}`,
+        `LOG=${quoteShell(paths.log)}`,
         `STAGE=${quoteShell(paths.stage)}`,
         `STATUS=${quoteShell(paths.status)}`,
         `UNIT=${quoteShell(paths.unit)}`,
-        "if test -d \"$STAGE\" && test ! -L \"$STAGE\"; then echo STAGE=present; elif test -e \"$STAGE\" || test -L \"$STAGE\"; then echo STAGE=unsafe; else echo STAGE=absent; fi",
         "printf 'STATUS=%s\\n' \"$(sed -n '1p' \"$STATUS\" 2>/dev/null || true)\"",
         "printf 'UNIT=%s\\n' \"$(systemctl is-active \"$UNIT\" 2>/dev/null || true)\"",
-        "printf 'UNIT_LOAD=%s\\n' \"$(systemctl show \"$UNIT\" --property=LoadState --value 2>/dev/null || true)\"",
+        "if [ -e \"$STAGE\" ]; then echo STAGE_EXISTS=yes; else echo STAGE_EXISTS=no; fi",
+        "if [ -d \"$STAGE\" ] && [ ! -L \"$STAGE\" ]; then echo STAGE_DIRECTORY=yes; else echo STAGE_DIRECTORY=no; fi",
+        "if [ -e \"$DROP\" ]; then echo DROP_EXISTS=yes; else echo DROP_EXISTS=no; fi",
+        "if [ -e \"$STATUS\" ]; then echo STATUS_EXISTS=yes; else echo STATUS_EXISTS=no; fi",
+        "if [ -e \"$LOG\" ]; then echo LOG_EXISTS=yes; else echo LOG_EXISTS=no; fi",
+        "UNIT_LOAD_STATE=$(systemctl show --property=LoadState --value \"$UNIT\" 2>/dev/null || true)",
+        "test -n \"$UNIT_LOAD_STATE\" || { echo 'Unable to read remote upgrade unit load state' >&2; exit 1; }",
+        "printf 'UNIT_LOAD=%s\\n' \"$UNIT_LOAD_STATE\"",
+        "if [ -n \"$UNIT_LOAD_STATE\" ] && [ \"$UNIT_LOAD_STATE\" != not-found ]; then echo UNIT_EXISTS=yes; else echo UNIT_EXISTS=no; fi",
     ].join("\n");
+}
+
+function remoteStateValue(output: string, field: string): string {
+    const match = output.match(new RegExp(`^${field}=(.*)$`, "m"));
+    if (!match) throw new Error(`Remote upgrade state is missing ${field}`);
+    return match[1]?.trim() || "";
+}
+
+function remoteStatePresence(output: string, field: string): boolean {
+    const presence = remoteStateValue(output, field);
+    if (presence !== "yes" && presence !== "no") {
+        throw new Error(`Remote upgrade state has invalid ${field}`);
+    }
+    return presence === "yes";
 }
 
 async function readRemoteState(
@@ -541,17 +524,73 @@ async function readRemoteState(
 ): Promise<RemoteUpgradeState> {
     const state = await ssh.exec(rootCommand(readStateScript(paths)), timeoutMs);
     if (!state.success) throw remoteFailure("Unable to read remote upgrade state", state);
-    const stageState = state.stdout.match(/^STAGE=(absent|present|unsafe)$/m)?.[1] || "unknown";
     return {
-        status: state.stdout.match(/^STATUS=(.*)$/m)?.[1]?.trim() || "",
-        serviceState: state.stdout.match(/^UNIT=(.*)$/m)?.[1]?.trim() || "unknown",
-        stageState: stageState as RemoteUpgradeState["stageState"],
-        unitLoadState: state.stdout.match(/^UNIT_LOAD=(.*)$/m)?.[1]?.trim() || "unknown",
+        dropExists: remoteStatePresence(state.stdout, "DROP_EXISTS"),
+        logExists: remoteStatePresence(state.stdout, "LOG_EXISTS"),
+        serviceState: remoteStateValue(state.stdout, "UNIT") || "unknown",
+        stageExists: remoteStatePresence(state.stdout, "STAGE_EXISTS"),
+        stageIsDirectory: remoteStatePresence(state.stdout, "STAGE_DIRECTORY"),
+        status: remoteStateValue(state.stdout, "STATUS"),
+        statusExists: remoteStatePresence(state.stdout, "STATUS_EXISTS"),
+        unitExists: remoteStatePresence(state.stdout, "UNIT_EXISTS"),
+        unitLoadState: remoteStateValue(state.stdout, "UNIT_LOAD"),
     };
 }
 
+type RemoteStateObservation = {
+    deadline?: number;
+    failureMessage: string;
+    precedingFailures?: readonly unknown[];
+};
+
+function observationDeadlineFailure(paths: RemoteUpgradePaths, failures: readonly unknown[]): Error {
+    return remoteReconciliationFailure(
+        "Remote upgrade is still nonterminal after the observation deadline",
+        failures,
+        paths,
+    );
+}
+
+async function observeRemoteState(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    observation: RemoteStateObservation,
+): Promise<RemoteUpgradeState> {
+    const readFailures: unknown[] = [];
+    for (let attempt = 1; attempt <= STATE_READ_ATTEMPTS; attempt += 1) {
+        const remainingMs = observation.deadline === undefined
+            ? REMOTE_STATE_READ_TIMEOUT_MS
+            : observation.deadline - Date.now();
+        if (remainingMs <= 0) {
+            throw observationDeadlineFailure(paths, readFailures);
+        }
+        try {
+            return await readRemoteState(ssh, paths, Math.min(REMOTE_STATE_READ_TIMEOUT_MS, remainingMs));
+        } catch (error: unknown) {
+            readFailures.push(error);
+            if (attempt < STATE_READ_ATTEMPTS) {
+                const retryDelay = observation.deadline === undefined
+                    ? POLL_INTERVAL_MS
+                    : Math.min(POLL_INTERVAL_MS, observation.deadline - Date.now());
+                if (retryDelay <= 0) throw observationDeadlineFailure(paths, readFailures);
+                await delay(retryDelay);
+            }
+        }
+    }
+    throw remoteReconciliationFailure(
+        observation.failureMessage,
+        [...(observation.precedingFailures ?? []), ...readFailures],
+        paths,
+    );
+}
+
 async function remoteLogTail(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
-    const output = await ssh.exec(rootCommand(`tail -80 ${quoteShell(paths.log)} 2>/dev/null || true`), 15_000);
+    const script = [
+        `LOG=${quoteShell(paths.log)}`,
+        "test -f \"$LOG\" && test ! -L \"$LOG\" || { echo 'Remote upgrade log is not a regular file' >&2; exit 1; }",
+        "tail -80 -- \"$LOG\"",
+    ].join("\n");
+    const output = await ssh.exec(rootCommand(script), 15_000);
     if (!output.success) throw remoteFailure("Unable to read the remote upgrade log", output);
     return output.stdout.slice(-4_000);
 }
@@ -586,12 +625,41 @@ function remoteFailure(message: string, execution: SshResult): Error {
     return new Error(`${message}: ${diagnostic.slice(-500)}`);
 }
 
+function operationError(error: unknown, message: string): Error {
+    return error instanceof Error ? error : new Error(`${message}: ${String(error)}`);
+}
+
+function remoteEvidence(paths: RemoteUpgradePaths): string {
+    return `unit=${paths.unit} stage=${paths.stage} status=${paths.status} log=${paths.log} drop=${paths.drop}`;
+}
+
+function remoteReconciliationFailure(
+    message: string,
+    failures: readonly unknown[],
+    paths: RemoteUpgradePaths,
+): RemoteUpgradeReconciliationError {
+    return new RemoteUpgradeReconciliationError(
+        failures.map((failure) => operationError(failure, message)),
+        `${message}; reconcile remote evidence at ${remoteEvidence(paths)}; do not retry blindly`,
+    );
+}
+
+export function failureRequiresRemoteReconciliation(error: unknown): boolean {
+    return error instanceof RemoteUpgradeReconciliationError;
+}
+
 function delay(milliseconds: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function unitIsRunning(serviceState: string): boolean {
     return ["active", "activating", "deactivating", "reloading"].includes(serviceState);
+}
+
+function isFullyPreparedUnstartedState(state: RemoteUpgradeState): boolean {
+    return state.stageExists && state.stageIsDirectory && state.statusExists && state.logExists
+        && !state.dropExists && !state.unitExists && state.unitLoadState === "not-found"
+        && state.status === "PREPARED";
 }
 
 function unitStoppedNormally(state: RemoteUpgradeState): boolean {
@@ -601,28 +669,77 @@ function unitStoppedNormally(state: RemoteUpgradeState): boolean {
 
 function assertSuccessfulUnitStoppedNormally(state: RemoteUpgradeState, paths: RemoteUpgradePaths): void {
     if (unitStoppedNormally(state)) return;
-    throw new Error(
+    throw remoteReconciliationFailure(
         `Remote upgrade published SUCCEEDED but the unit stopped abnormally or ambiguously `
-        + `(state=${state.serviceState} load=${state.unitLoadState}); retained ${retainedUpgradeEvidence(paths)}`,
+        + `(state=${state.serviceState} load=${state.unitLoadState})`,
+        [],
+        paths,
+    );
+}
+
+function assertTerminalEvidence(state: RemoteUpgradeState, paths: RemoteUpgradePaths): void {
+    if (state.status !== "SUCCEEDED" && !state.status.startsWith("FAILED:")) return;
+    const evidenceIssues: string[] = [];
+    if (!state.statusExists) evidenceIssues.push("status record is missing");
+    if (!state.logExists) evidenceIssues.push("log is missing");
+    if (state.dropExists) evidenceIssues.push("upload drop still exists");
+    if (state.status === "SUCCEEDED" && state.stageExists) evidenceIssues.push("successful stage still exists");
+    if (state.status.startsWith("FAILED:") && !state.status.includes("CLEANUP") && state.stageExists) {
+        evidenceIssues.push("failed stage still exists without a cleanup failure status");
+    }
+    if (evidenceIssues.length === 0) return;
+    throw remoteReconciliationFailure(
+        `Remote upgrade terminal evidence is incomplete or inconsistent (${evidenceIssues.join(", ")})`,
+        [],
+        paths,
     );
 }
 
 async function completedUpgradeOutput(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
-    const log = await remoteLogTail(ssh, paths);
-    await cleanupRemoteRecords(ssh, paths);
+    let log: string;
+    try {
+        log = await remoteLogTail(ssh, paths);
+    } catch (error: unknown) {
+        throw remoteReconciliationFailure(
+            "Upgrade succeeded but its retained log could not be read", [error], paths,
+        );
+    }
+    try {
+        await cleanupRemoteRecords(ssh, paths);
+    } catch (error: unknown) {
+        throw remoteReconciliationFailure(
+            "Upgrade succeeded but remote evidence cleanup could not be confirmed", [error], paths,
+        );
+    }
     return `✅ Upgrade done\n${log.slice(-1_500)}`;
 }
 
 async function throwRemoteUpgradeFailure(ssh: SshTransport, paths: RemoteUpgradePaths, status: string): Promise<never> {
-    const log = await remoteLogTail(ssh, paths);
+    let log: string;
+    try {
+        log = await remoteLogTail(ssh, paths);
+    } catch (error: unknown) {
+        throw remoteReconciliationFailure(
+            "Remote upgrade failed but its retained log could not be read", [error], paths,
+        );
+    }
     const failure = new Error(`Remote local upgrade failed (${status}): ${log.slice(-1_500)}`);
+    if (status.endsWith(":CLEANUP_AFTER_TRANSACTION")) {
+        throw remoteReconciliationFailure(
+            "Upgrade transaction completed but staging cleanup is incomplete", [failure], paths,
+        );
+    }
     if (status.includes("CLEANUP")) {
-        throw new Error(`${failure.message}; retained status=${paths.status} log=${paths.log}`);
+        throw remoteReconciliationFailure(
+            "Upgrade transaction and staging cleanup both failed", [failure], paths,
+        );
     }
     try {
         await cleanupRemoteRecords(ssh, paths);
     } catch (cleanupError: unknown) {
-        throw new AggregateError([failure, cleanupError], "Remote local upgrade failed and status cleanup did not complete");
+        throw remoteReconciliationFailure(
+            "Remote local upgrade failed and status cleanup did not complete", [failure, cleanupError], paths,
+        );
     }
     throw failure;
 }
@@ -631,59 +748,20 @@ function assertObservableUpgradeState(state: RemoteUpgradeState, unitRunning: bo
     const knownStatus = ["PREPARED", "RUNNING", "CLEANING", "SUCCEEDED"].includes(state.status)
         || state.status.startsWith("FAILED:");
     if (!unitRunning && !knownStatus) {
-        throw new Error(`Remote upgrade stopped without a terminal status; retained status=${paths.status} log=${paths.log}`);
+        throw remoteReconciliationFailure("Remote upgrade stopped without a terminal status", [], paths);
     }
-}
-
-function remoteUpgradeTimeout(paths: RemoteUpgradePaths, state?: RemoteUpgradeState): Error {
-    const observation = state
-        ? ` last status=${state.status || "empty"} unit_state=${state.serviceState};`
-        : "";
-    return new Error(
-        `Remote local upgrade exceeded the ${REMOTE_UPGRADE_RUNTIME_SECONDS}-second runtime limit and `
-        + `${REMOTE_UPGRADE_OBSERVATION_GRACE_MS / 1_000}-second observation grace;${observation} remote unit was not stopped; `
-        + `retained ${retainedUpgradeEvidence(paths)}; do not retry blindly`,
-    );
-}
-
-async function readRemoteStateBeforeDeadline(
-    ssh: SshTransport,
-    paths: RemoteUpgradePaths,
-    deadline: number,
-): Promise<RemoteUpgradeState> {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) throw remoteUpgradeTimeout(paths);
-    try {
-        return await readRemoteState(ssh, paths, Math.min(REMOTE_STATE_READ_TIMEOUT_MS, remainingMs));
-    } catch (stateFailure: unknown) {
-        if (Date.now() < deadline) throw stateFailure;
-        throw new AggregateError(
-            [remoteUpgradeTimeout(paths), stateFailure],
-            `Remote upgrade observation reached its deadline while reading state; retained ${retainedUpgradeEvidence(paths)}`,
-        );
-    }
-}
-
-function nextStoppedObservationCount(
-    state: RemoteUpgradeState,
-    unitRunning: boolean,
-    previousCount: number,
-    paths: RemoteUpgradePaths,
-): number {
-    const stoppedCount = unitRunning ? 0 : previousCount + 1;
-    if (stoppedCount >= 3 && ["PREPARED", "RUNNING", "CLEANING"].includes(state.status)) {
-        throw new Error(`Remote upgrade unit stopped before publishing a terminal status; retained ${retainedUpgradeEvidence(paths)}`);
-    }
-    return stoppedCount;
 }
 
 export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
-    const deadline = Date.now() + REMOTE_UPGRADE_WAIT_TIMEOUT_MS;
+    const observationDeadline = Date.now() + UPGRADE_OBSERVATION_TIMEOUT_MS;
     let stoppedObservations = 0;
     while (true) {
-        const state = await readRemoteStateBeforeDeadline(ssh, paths, deadline);
-        if (Date.now() >= deadline) throw remoteUpgradeTimeout(paths, state);
+        const state = await observeRemoteState(ssh, paths, {
+            deadline: observationDeadline,
+            failureMessage: "Unable to observe the remote upgrade lifecycle",
+        });
         const unitRunning = unitIsRunning(state.serviceState);
+        if (!unitRunning) assertTerminalEvidence(state, paths);
         if (state.status === "SUCCEEDED" && !unitRunning) {
             assertSuccessfulUnitStoppedNormally(state, paths);
             return await completedUpgradeOutput(ssh, paths);
@@ -691,11 +769,19 @@ export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
         if (state.status.startsWith("FAILED:") && !unitRunning) {
             await throwRemoteUpgradeFailure(ssh, paths, state.status);
         }
+        if (Date.now() >= observationDeadline) {
+            throw observationDeadlineFailure(paths, []);
+        }
         assertObservableUpgradeState(state, unitRunning, paths);
-        stoppedObservations = nextStoppedObservationCount(state, unitRunning, stoppedObservations, paths);
-        const remainingMs = deadline - Date.now();
-        if (remainingMs <= 0) throw remoteUpgradeTimeout(paths, state);
-        await delay(Math.min(POLL_INTERVAL_MS, remainingMs));
+        stoppedObservations = unitRunning ? 0 : stoppedObservations + 1;
+        if (stoppedObservations >= 3 && ["PREPARED", "RUNNING", "CLEANING"].includes(state.status)) {
+            throw remoteReconciliationFailure(
+                "Remote upgrade unit stopped before publishing a terminal status", [], paths,
+            );
+        }
+        const remainingObservationMs = observationDeadline - Date.now();
+        if (remainingObservationMs <= 0) throw observationDeadlineFailure(paths, []);
+        await delay(Math.min(POLL_INTERVAL_MS, remainingObservationMs));
     }
 }
 
@@ -704,20 +790,20 @@ export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: Lo
     const paths = remotePaths(runId);
     const preflight = await remoteUpgradePreflight(ssh);
     const bundle = await prepareLocalUpgradeBundle({ ...preflight, ...request });
-    let adoptionCommandSent = false;
+    let adopted = false;
     let transferError: unknown;
     try {
         try {
             await prepareRemoteDrop(ssh, paths, bundle);
             await uploadBundleFiles(ssh, paths, bundle);
             await uploadRunScript(ssh, paths, bundle, request, preflight.architecture);
-            adoptionCommandSent = true;
-            const adoption = await adoptRemoteDrop(ssh, paths);
-            if (adoption === "ready-to-start") await startRemoteUpgrade(ssh, paths);
+            await adoptRemoteDrop(ssh, paths);
+            adopted = true;
+            await startRemoteUpgrade(ssh, paths);
             return await awaitRemoteUpgrade(ssh, paths);
         } catch (error: unknown) {
             transferError = error;
-            if (!adoptionCommandSent) {
+            if (!adopted && !failureRequiresRemoteReconciliation(error)) {
                 try {
                     await cleanupRemoteDrop(ssh, paths);
                 } catch (cleanupError: unknown) {

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -225,7 +225,7 @@ function finishUpgradeFunction(): string {
     ].join("\n");
 }
 
-function upgradeScriptSetup(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): string[] {
+function upgradeScriptSetup(paths: RemoteUpgradePaths): string[] {
     const bundleDirectory = `${paths.stage}/bundle`;
     return [
         "#!/usr/bin/env bash", "set -euo pipefail", "umask 077",
@@ -276,7 +276,7 @@ function upgradeScriptFilesystemChecks(bundle: PreparedLocalUpgradeBundle): stri
 function upgradeScriptTransferVerification(bundle: PreparedLocalUpgradeBundle): string[] {
     const files = [...bundle.files, ...(bundle.verifierArchive ? [bundle.verifierArchive] : [])];
     return [
-        "verify_transfer() { local relative=$1 expected_size=$2 expected_sha=$3 path=$STAGE/$relative; test \"$(stat -c '%s' \"$path\")\" = \"$expected_size\"; test \"$(sha256sum \"$path\" | awk '{print $1}')\" = \"$expected_sha\"; }",
+        "verify_transfer() { local relative=$1 expected_size=$2 expected_sha=$3; local path=$STAGE/$relative; test \"$(stat -c '%s' \"$path\")\" = \"$expected_size\"; test \"$(sha256sum \"$path\" | awk '{print $1}')\" = \"$expected_sha\"; }",
         ...files.map((file) => (
             `verify_transfer ${quoteShell(file.relativePath)} ${file.size} ${quoteShell(file.sha256)}`
         )),
@@ -347,7 +347,7 @@ export function buildLocalUpgradeRunScript(
     architecture: UpgradeArchitecture,
 ): string {
     return [
-        ...upgradeScriptSetup(paths, bundle),
+        ...upgradeScriptSetup(paths),
         ...upgradeScriptFilesystemChecks(bundle),
         ...upgradeScriptTransferVerification(bundle),
         ...upgradeScriptVerifier(paths, bundle, architecture),

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -330,6 +330,14 @@ describe("ssh admin tool", () => {
         expect(() => tool.parse({ action: "upgrade", artifact_transport: "automatic" })).toThrow();
     });
 
+    test("remote artifact transport uses the host-wide upgrade lock", () => {
+        const rootScript = buildRootUpgradeScript({ helperPath: "/tmp/release-assets.sh" });
+
+        expect(rootScript).toContain("/run/lock/supacloud-upgrade.lock");
+        expect(rootScript).toContain("flock -E 75 -n 9");
+        expect(rootScript).toContain("Another SupaCloud upgrade is already running");
+    });
+
     test("component upgrade validates both exact versions before upload", async () => {
         for (const args of [
             { action: "upgrade", version: "0.50.27;id", edge_runtime_version: "0.16.7" },

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -7,7 +7,11 @@ import { dirname } from "node:path";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import type { SshTransport } from "../transports/ssh";
-import { executeLocalUpgradeTransfer } from "../releases/local-upgrade-transfer";
+import {
+    buildUpgradeLockScript,
+    executeLocalUpgradeTransfer,
+    SUPACLOUD_UPGRADE_LOCK_PATH,
+} from "../releases/local-upgrade-transfer";
 import releaseAssetsScript from "../../../../../scripts/lib/release_assets.sh" with { type: "text" };
 
 const SAFE_CONTAINER_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/;
@@ -153,8 +157,10 @@ export function buildRootUpgradeScript(request: UpgradeRequest): string {
         request.githubProxy
             ? `export SUPACLOUD_GITHUB_PROXY=${quoteEnvValue(request.githubProxy)}`
             : "unset SUPACLOUD_GITHUB_PROXY SUPACLOUD_GITHUB_PROXIES",
-        "for tool in curl jq file sha256sum tar; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "for tool in curl jq file sha256sum stat tar flock; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
         "test -x /usr/local/bin/supacloud || { echo 'SupaCloud binary not found at /usr/local/bin/supacloud; run ssh install first.' >&2; exit 127; }",
+        buildUpgradeLockScript(SUPACLOUD_UPGRADE_LOCK_PATH),
         ...componentPreflightCommands(request),
         "STAGED_MANAGEMENT=''",
         ...signalSafeCleanupTraps('test -z "$STAGED_MANAGEMENT" || rm -f "$STAGED_MANAGEMENT"'),

--- a/packages/management-api/src/upgrade-lock.ts
+++ b/packages/management-api/src/upgrade-lock.ts
@@ -1,0 +1,110 @@
+import { spawnSync, type StdioOptions } from "node:child_process";
+import { closeSync, constants as fsConstants, fchmodSync, fstatSync, lstatSync, openSync } from "node:fs";
+
+export const SUPACLOUD_UPGRADE_LOCK_PATH = "/run/lock/supacloud-upgrade.lock";
+
+const INHERITED_UPGRADE_LOCK_FD = 9;
+const UPGRADE_LOCK_FD_ENV = "SUPACLOUD_UPGRADE_LOCK_FD";
+
+export type SupaCloudUpgradeLock = {
+    release: () => void;
+};
+
+export function buildUpgradeLockScript(lockPath: string): string {
+    return [
+        `UPGRADE_LOCK=${quoteShell(lockPath)}`,
+        "test ! -L \"$UPGRADE_LOCK\" || { echo 'SupaCloud upgrade lock must not be a symlink' >&2; exit 1; }",
+        "if [ ! -e \"$UPGRADE_LOCK\" ]; then (umask 077; : >> \"$UPGRADE_LOCK\"); fi",
+        "test -f \"$UPGRADE_LOCK\" && test ! -L \"$UPGRADE_LOCK\" || { echo 'SupaCloud upgrade lock must be a regular file' >&2; exit 1; }",
+        "test \"$(stat -c '%u:%g' \"$UPGRADE_LOCK\")\" = \"$(id -u):$(id -g)\" || { echo 'SupaCloud upgrade lock has an unexpected owner' >&2; exit 1; }",
+        "LOCK_MODE=$(stat -c '%a' \"$UPGRADE_LOCK\")",
+        "case \"$LOCK_MODE\" in [0-7]|[0-7][0-7]|[0-7][0-7][0-7]) ;; *) echo 'SupaCloud upgrade lock has special permission bits' >&2; exit 1 ;; esac",
+        "(( (8#$LOCK_MODE & 0022) == 0 )) || { echo 'SupaCloud upgrade lock is group/other writable' >&2; exit 1; }",
+        `exec ${INHERITED_UPGRADE_LOCK_FD}<>"$UPGRADE_LOCK"`,
+        `flock -E 75 -n ${INHERITED_UPGRADE_LOCK_FD} || { echo 'Another SupaCloud upgrade is already running' >&2; exit 75; }`,
+        `export ${UPGRADE_LOCK_FD_ENV}=${INHERITED_UPGRADE_LOCK_FD}`,
+    ].join("\n");
+}
+
+function quoteShell(shellText: string): string {
+    return `'${shellText.split("'").join("'\\''")}'`;
+}
+
+function expectedMissingDescriptor(error: unknown): boolean {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "EBADF" || code === "ENOENT";
+}
+
+function inheritedUpgradeLockMatches(lockPath: string): boolean {
+    if (process.env[UPGRADE_LOCK_FD_ENV] !== String(INHERITED_UPGRADE_LOCK_FD)) return false;
+    try {
+        const descriptorState = fstatSync(INHERITED_UPGRADE_LOCK_FD);
+        const lockPathState = lstatSync(lockPath);
+        return descriptorState.isFile() && lockPathState.isFile()
+            && descriptorState.dev === lockPathState.dev
+            && descriptorState.ino === lockPathState.ino;
+    } catch (error: unknown) {
+        if (expectedMissingDescriptor(error)) return false;
+        throw error;
+    }
+}
+
+function openUpgradeLockFile(lockPath: string): number {
+    const descriptor = openSync(
+        lockPath,
+        fsConstants.O_CREAT | fsConstants.O_RDWR | fsConstants.O_NOFOLLOW,
+        0o600,
+    );
+    try {
+        const state = fstatSync(descriptor);
+        if (!state.isFile()) throw new Error("SupaCloud upgrade lock is not a regular file");
+        const effectiveUid = process.geteuid?.();
+        if (effectiveUid !== undefined && state.uid !== effectiveUid) {
+            throw new Error("SupaCloud upgrade lock is owned by another user");
+        }
+        fchmodSync(descriptor, 0o600);
+        return descriptor;
+    } catch (error: unknown) {
+        closeSync(descriptor);
+        throw error;
+    }
+}
+
+function inheritedLockStdio(descriptor: number): StdioOptions {
+    const stdio: Array<"ignore" | "pipe" | number> = Array.from(
+        { length: descriptor + 1 },
+        () => "ignore",
+    );
+    stdio[2] = "pipe";
+    stdio[descriptor] = descriptor;
+    return stdio;
+}
+
+function acquireDescriptorLock(descriptor: number): void {
+    const attempt = spawnSync(
+        "flock",
+        ["-E", "75", "-n", String(descriptor)],
+        { stdio: inheritedLockStdio(descriptor) },
+    );
+    if (attempt.status === 0) return;
+    if (attempt.status === 75) throw new Error("Another SupaCloud upgrade is already running");
+    const diagnostic = attempt.error?.message
+        || attempt.stderr?.toString("utf8").trim()
+        || `exit ${attempt.status ?? "unknown"}`;
+    throw new Error(`Unable to acquire the SupaCloud upgrade lock: ${diagnostic.slice(-300)}`);
+}
+
+export function acquireSupaCloudUpgradeLock(lockPath: string): SupaCloudUpgradeLock {
+    if (inheritedUpgradeLockMatches(lockPath)) {
+        acquireDescriptorLock(INHERITED_UPGRADE_LOCK_FD);
+        return { release: () => {} };
+    }
+    const descriptor = openUpgradeLockFile(lockPath);
+    try {
+        acquireDescriptorLock(descriptor);
+    } catch (error: unknown) {
+        closeSync(descriptor);
+        throw error;
+    }
+    return { release: () => closeSync(descriptor) };
+}

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -18,6 +18,10 @@ import {
     type OfflineReleaseBundle,
     type OfflineUpgradeBundle,
 } from "./offline-upgrade-bundle";
+import {
+    acquireSupaCloudUpgradeLock,
+    SUPACLOUD_UPGRADE_LOCK_PATH,
+} from "./upgrade-lock";
 
 const RELEASES_API = "https://api.github.com/repos/zuohuadong/supacloud/releases";
 const BIN_TARGET = "/usr/local/bin/supacloud";
@@ -2463,8 +2467,13 @@ export async function runUpgrade(options: RunUpgradeOptions = {}) {
             p.cancel("Upgrade cancelled.");
             return;
         }
-        executionContext = await createUpgradeExecutionContext(plan, options, s);
-        await executeUpgradeTransaction(upgradeTransactionOperations(executionContext));
+        const upgradeLock = acquireSupaCloudUpgradeLock(SUPACLOUD_UPGRADE_LOCK_PATH);
+        try {
+            executionContext = await createUpgradeExecutionContext(plan, options, s);
+            await executeUpgradeTransaction(upgradeTransactionOperations(executionContext));
+        } finally {
+            upgradeLock.release();
+        }
         p.outro(upgradeSuccessMessage(executionContext));
     } catch (error: unknown) {
         s.stop(formatUpgradeFailure(error, upgradeRecoveryPaths(executionContext)));

--- a/packages/management-api/tests/unit/upgrade-lock.test.ts
+++ b/packages/management-api/tests/unit/upgrade-lock.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+    acquireSupaCloudUpgradeLock,
+    buildUpgradeLockScript,
+} from "../../src/upgrade-lock";
+
+async function waitForFile(filePath: string): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+        if (existsSync(filePath)) return;
+        await Bun.sleep(20);
+    }
+    throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+describe("SupaCloud upgrade lock", () => {
+    test("uses a nonblocking conflict exit for the inherited shell descriptor", () => {
+        const script = buildUpgradeLockScript("/run/lock/supacloud-upgrade.lock");
+
+        expect(script).toContain("exec 9<>");
+        expect(script).toContain("flock -E 75 -n 9");
+        expect(script).toContain("export SUPACLOUD_UPGRADE_LOCK_FD=9");
+        expect(script).toContain("Another SupaCloud upgrade is already running");
+        expect(Bun.spawnSync(["bash", "-n", "-c", script]).exitCode).toBe(0);
+    });
+
+    test("serializes direct Management upgrade processes", () => {
+        if (process.platform !== "linux" || !Bun.which("flock")) return;
+        const fixtureRoot = mkdtempSync(join(tmpdir(), "supacloud-management-lock-"));
+        const lockPath = join(fixtureRoot, "upgrade.lock");
+        const firstLock = acquireSupaCloudUpgradeLock(lockPath);
+        try {
+            expect(() => acquireSupaCloudUpgradeLock(lockPath))
+                .toThrow("Another SupaCloud upgrade is already running");
+        } finally {
+            firstLock.release();
+        }
+
+        const nextLock = acquireSupaCloudUpgradeLock(lockPath);
+        nextLock.release();
+        rmSync(fixtureRoot, { recursive: true, force: true });
+    });
+
+    test("reuses the Admin shell lock in a compiled Management executable", async () => {
+        if (process.platform !== "linux" || !Bun.which("flock")) return;
+        const fixtureRoot = mkdtempSync(join(tmpdir(), "supacloud-inherited-lock-"));
+        const lockPath = join(fixtureRoot, "upgrade.lock");
+        const readyPath = join(fixtureRoot, "ready");
+        const releasePath = join(fixtureRoot, "release");
+        const helperSourcePath = join(fixtureRoot, "lock-helper.ts");
+        const helperBinaryPath = join(fixtureRoot, "lock-helper");
+        const modulePath = join(import.meta.dir, "../../src/upgrade-lock.ts");
+        writeFileSync(helperSourcePath, [
+            `import { acquireSupaCloudUpgradeLock } from ${JSON.stringify(modulePath)};`,
+            'import { existsSync, writeFileSync } from "node:fs";',
+            "const upgradeLock = acquireSupaCloudUpgradeLock(process.env.LOCK_PATH!);",
+            'writeFileSync(process.env.READY_PATH!, "ready");',
+            "for (let attempt = 0; attempt < 500; attempt += 1) {",
+            "    if (existsSync(process.env.RELEASE_PATH!)) break;",
+            "    if (attempt === 499) throw new Error(\"Timed out waiting for lock release\");",
+            "    await Bun.sleep(20);",
+            "}",
+            "upgradeLock.release();",
+        ].join("\n"));
+        const compilation = Bun.spawnSync([
+            "bun", "build", helperSourcePath, "--compile", "--outfile", helperBinaryPath,
+        ]);
+        const shell = [
+            buildUpgradeLockScript(lockPath),
+            '"$LOCK_HELPER"',
+        ].join("\n");
+        const execution = Bun.spawn(["bash", "-c", shell], {
+            env: {
+                ...process.env,
+                LOCK_HELPER: helperBinaryPath,
+                LOCK_PATH: lockPath,
+                READY_PATH: readyPath,
+                RELEASE_PATH: releasePath,
+            },
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        try {
+            expect(compilation.exitCode).toBe(0);
+            await waitForFile(readyPath);
+            expect(() => acquireSupaCloudUpgradeLock(lockPath))
+                .toThrow("Another SupaCloud upgrade is already running");
+            writeFileSync(releasePath, "release");
+            expect(await execution.exited).toBe(0);
+            expect(await new Response(execution.stderr).text()).toBe("");
+        } finally {
+            writeFileSync(releasePath, "release");
+            execution.kill("SIGTERM");
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- make local, remote, and direct server upgrades share one nonblocking host-wide lock
- distinguish explicit remote failures from uncertain SSH outcomes and preserve unit, stage, status, log, and drop evidence for reconciliation
- stop only local observation after 30 minutes without stopping or timing out the remote transaction
- make signal finalization, terminal evidence, log reads, transfer verification, and nested CLI diagnostics fail closed
- document exact Management and Edge version requirements for local artifact transport

## Context

PR #775 was merged from head f1db8ffe while the final independent review fixes were still in progress. This follow-up contains only the reviewed delta missing from that merge.

## Verification

- Admin full suite: 131/131 PASS, 645 assertions
- Admin typecheck and production build: PASS
- generated installed and bundled run scripts: bash syntax PASS, ShellCheck 0 warnings
- npm pack, official-registry temporary install, bin version/help smoke: PASS
- Management full unit: 1783/1783 PASS; integration: 39/39 PASS
- Management upgrade-focused: 108/108 PASS; typecheck, SQL sync, compile/version smoke: PASS
- Linux compiled Management fd9 lock inheritance: 3/3 PASS
- independent final review: MERGE, no remaining findings
- git diff check and clean worktree read-back: PASS

## Release safety

Release PR #777 is intentionally held as Draft until this PR merges and Release Please refreshes it. The old release candidate contains the pre-review implementation and must not be published.