### PR TITLE
fix(admin): harden local upgrade state checks

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,7 +9,9 @@ import {
     buildAdoptDropScript,
     buildCleanupUnstartedUpgradeScript,
     buildLocalUpgradeRunScript,
+    buildPrepareDropCommand,
     buildRemotePreflightScript,
+    buildRemoteStateScript,
     buildUpgradeLockScript,
     failureRequiresRemoteReconciliation,
     parseRemotePreflight,
@@ -425,6 +427,73 @@ describe("local upgrade remote runner", () => {
         expect(bundled).not.toContain("--no-same-permissions");
     });
 
+    test("rejects a dangling upload-drop symlink before creating directories", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-prepare-drop-")));
+        const fixturePaths = { ...paths, drop: join(fixtureRoot, "drop") };
+        symlinkSync(join(fixtureRoot, "missing-drop-target"), fixturePaths.drop);
+
+        const execution = Bun.spawnSync([
+            "bash", "-c", buildPrepareDropCommand(fixturePaths, preparedBundle("amd64", "installed")),
+        ]);
+        try {
+            expect(execution.exitCode).not.toBe(0);
+            expect(execution.stderr.toString()).toContain("Remote upload drop already exists");
+            expect(lstatSync(fixturePaths.drop).isSymbolicLink()).toBe(true);
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects dangling adoption targets before moving the upload drop", () => {
+        for (const blockedPath of ["stage", "status", "log"] as const) {
+            const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), `supacloud-adopt-${blockedPath}-`)));
+            const fixturePaths = {
+                drop: join(fixtureRoot, "drop"), stage: join(fixtureRoot, "stage"),
+                status: join(fixtureRoot, "run.status"), log: join(fixtureRoot, "run.log"),
+                unit: "supacloud-upgrade-test.service",
+            };
+            mkdirSync(fixturePaths.drop, { mode: 0o700 });
+            symlinkSync(join(fixtureRoot, `missing-${blockedPath}-target`), fixturePaths[blockedPath]);
+            const execution = Bun.spawnSync(["bash", "-c", [
+                "install() { return 0; }", "systemctl() { return 1; }",
+                buildAdoptDropScript(fixturePaths),
+            ].join("\n")]);
+            try {
+                expect(execution.exitCode).not.toBe(0);
+                expect(existsSync(fixturePaths.drop)).toBe(true);
+                expect(lstatSync(fixturePaths[blockedPath]).isSymbolicLink()).toBe(true);
+            } finally {
+                rmSync(fixtureRoot, { recursive: true, force: true });
+            }
+        }
+    });
+
+    test("reports dangling remote evidence without treating a stage symlink as a directory", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-state-symlinks-")));
+        const fixturePaths = {
+            drop: join(fixtureRoot, "drop"), stage: join(fixtureRoot, "stage"),
+            status: join(fixtureRoot, "run.status"), log: join(fixtureRoot, "run.log"),
+            unit: "supacloud-upgrade-test.service",
+        };
+        for (const evidencePath of [fixturePaths.drop, fixturePaths.stage, fixturePaths.status, fixturePaths.log]) {
+            symlinkSync(join(fixtureRoot, `missing-${evidencePath.split("/").at(-1)}-target`), evidencePath);
+        }
+        const execution = Bun.spawnSync(["bash", "-c", [
+            "systemctl() { if [ \"$1\" = is-active ]; then echo inactive; return 3; fi; echo loaded; }",
+            buildRemoteStateScript(fixturePaths),
+        ].join("\n")]);
+        try {
+            expect(execution.exitCode).toBe(0);
+            const output = execution.stdout.toString();
+            for (const field of ["STAGE_EXISTS", "DROP_EXISTS", "STATUS_EXISTS", "LOG_EXISTS"]) {
+                expect(output).toContain(`${field}=yes`);
+            }
+            expect(output).toContain("STAGE_DIRECTORY=no");
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
     test("rolls back stage and records when adoption fails after the move", () => {
         const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-adopt-rollback-")));
         const fixturePaths = {
@@ -751,6 +820,52 @@ describe("local upgrade remote runner", () => {
         expect(failureRequiresRemoteReconciliation(failure)).toBe(false);
         expect(String(failure)).toContain("FAILED:9:TRANSACTION");
         expect(ssh.commands).toHaveLength(4);
+    });
+
+    test("reads and cleans failed transaction evidence after an unambiguous unit stop", async () => {
+        for (const [serviceState, unitLoadState, unitExists] of [
+            ["failed", "loaded", true],
+            ["unknown", "not-found", false],
+        ] as const) {
+            const ssh = new ScriptedSsh([
+                remoteState({ status: "FAILED:9:TRANSACTION", serviceState, unitLoadState, unitExists }),
+                remoteResult("transaction failed\n"),
+                remoteResult(),
+            ]);
+
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(false);
+            expect(String(failure)).toContain("FAILED:9:TRANSACTION");
+            expect(ssh.commands).toHaveLength(3);
+            expect(ssh.commands[1]).toContain("tail -80");
+            expect(ssh.commands[2]).toContain("rm -f --");
+            expect(ssh.commands[2]).toContain(paths.status);
+            expect(ssh.commands[2]).toContain(paths.log);
+        }
+    });
+
+    test("retains all evidence for ambiguous FAILED unit states", async () => {
+        for (const [serviceState, unitLoadState] of [
+            ["unknown", "loaded"],
+            ["maintenance", "loaded"],
+            ["inactive", "unknown"],
+        ] as const) {
+            const ssh = new ScriptedSsh([
+                remoteState({
+                    status: "FAILED:9:TRANSACTION",
+                    serviceState,
+                    unitLoadState,
+                }),
+            ]);
+
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+            expect(String(failure)).toContain(`state=${serviceState} load=${unitLoadState}`);
+            for (const retainedPath of [paths.stage, paths.status, paths.log, paths.drop, paths.unit]) {
+                expect(String(failure)).toContain(retainedPath);
+            }
+            expect(ssh.commands).toHaveLength(1);
+        }
     });
 
     test("removes terminal records only after a completed unit publishes success", async () => {

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -148,7 +148,7 @@ function requiredRemoteBytes(bundle: PreparedLocalUpgradeBundle): number {
     return transferBytes * 3 + 512 * 1024 * 1024;
 }
 
-function prepareDropCommand(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): string {
+export function buildPrepareDropCommand(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): string {
     const directories = [
         paths.drop,
         `${paths.drop}/bundle`,
@@ -160,7 +160,7 @@ function prepareDropCommand(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgr
     return [
         "set -euo pipefail",
         "umask 077",
-        `test ! -e ${quoteShell(paths.drop)} || { echo 'Remote upload drop already exists' >&2; exit 1; }`,
+        `test ! -e ${quoteShell(paths.drop)} && test ! -L ${quoteShell(paths.drop)} || { echo 'Remote upload drop already exists' >&2; exit 1; }`,
         "TMP_AVAILABLE_KB=$(df -Pk /tmp | awk 'NR == 2 { print $4 }')",
         "VAR_AVAILABLE_KB=$(df -Pk /var/lib/supacloud | awk 'NR == 2 { print $4 }')",
         `test \"${"$"}TMP_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} && test \"${"$"}VAR_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} || { echo 'Insufficient remote disk space for verified upgrade staging' >&2; exit 1; }`,
@@ -169,7 +169,7 @@ function prepareDropCommand(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgr
 }
 
 async function prepareRemoteDrop(ssh: SshTransport, paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): Promise<void> {
-    const prepared = await ssh.exec(prepareDropCommand(paths, bundle), 30_000);
+    const prepared = await ssh.exec(buildPrepareDropCommand(paths, bundle), 30_000);
     if (!prepared.success) throw remoteFailure("Unable to prepare remote upload drop", prepared);
 }
 
@@ -398,7 +398,10 @@ export function buildAdoptDropScript(paths: RemoteUpgradePaths): string {
         "trap 'exit 130' INT",
         "trap 'exit 143' TERM",
         `install -d -o root -g root -m 700 ${quoteShell(REMOTE_STAGE_ROOT)} ${quoteShell(REMOTE_RUN_ROOT)} ${quoteShell(REMOTE_LOG_ROOT)}`,
-        "test ! -e \"$STAGE\" && test ! -e \"$STATUS\" && test ! -e \"$LOG\"",
+        "if [ -e \"$STAGE\" ] || [ -L \"$STAGE\" ] || [ -e \"$STATUS\" ] || [ -L \"$STATUS\" ] || [ -e \"$LOG\" ] || [ -L \"$LOG\" ]; then",
+        "  echo 'Upgrade adoption target already exists' >&2",
+        "  exit 1",
+        "fi",
         "systemctl status \"$UNIT\" >/dev/null 2>&1 && { echo 'Upgrade unit already exists' >&2; exit 1; } || true",
         "ADOPTION_ACTIVE=true",
         "mv \"$DROP\" \"$STAGE\"",
@@ -481,7 +484,7 @@ export async function startRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
     throw startFailure;
 }
 
-function readStateScript(paths: RemoteUpgradePaths): string {
+export function buildRemoteStateScript(paths: RemoteUpgradePaths): string {
     return [
         "set -euo pipefail",
         `DROP=${quoteShell(paths.drop)}`,
@@ -491,11 +494,11 @@ function readStateScript(paths: RemoteUpgradePaths): string {
         `UNIT=${quoteShell(paths.unit)}`,
         "printf 'STATUS=%s\\n' \"$(sed -n '1p' \"$STATUS\" 2>/dev/null || true)\"",
         "printf 'UNIT=%s\\n' \"$(systemctl is-active \"$UNIT\" 2>/dev/null || true)\"",
-        "if [ -e \"$STAGE\" ]; then echo STAGE_EXISTS=yes; else echo STAGE_EXISTS=no; fi",
+        "if [ -e \"$STAGE\" ] || [ -L \"$STAGE\" ]; then echo STAGE_EXISTS=yes; else echo STAGE_EXISTS=no; fi",
         "if [ -d \"$STAGE\" ] && [ ! -L \"$STAGE\" ]; then echo STAGE_DIRECTORY=yes; else echo STAGE_DIRECTORY=no; fi",
-        "if [ -e \"$DROP\" ]; then echo DROP_EXISTS=yes; else echo DROP_EXISTS=no; fi",
-        "if [ -e \"$STATUS\" ]; then echo STATUS_EXISTS=yes; else echo STATUS_EXISTS=no; fi",
-        "if [ -e \"$LOG\" ]; then echo LOG_EXISTS=yes; else echo LOG_EXISTS=no; fi",
+        "if [ -e \"$DROP\" ] || [ -L \"$DROP\" ]; then echo DROP_EXISTS=yes; else echo DROP_EXISTS=no; fi",
+        "if [ -e \"$STATUS\" ] || [ -L \"$STATUS\" ]; then echo STATUS_EXISTS=yes; else echo STATUS_EXISTS=no; fi",
+        "if [ -e \"$LOG\" ] || [ -L \"$LOG\" ]; then echo LOG_EXISTS=yes; else echo LOG_EXISTS=no; fi",
         "UNIT_LOAD_STATE=$(systemctl show --property=LoadState --value \"$UNIT\" 2>/dev/null || true)",
         "test -n \"$UNIT_LOAD_STATE\" || { echo 'Unable to read remote upgrade unit load state' >&2; exit 1; }",
         "printf 'UNIT_LOAD=%s\\n' \"$UNIT_LOAD_STATE\"",
@@ -522,7 +525,7 @@ async function readRemoteState(
     paths: RemoteUpgradePaths,
     timeoutMs = REMOTE_STATE_READ_TIMEOUT_MS,
 ): Promise<RemoteUpgradeState> {
-    const state = await ssh.exec(rootCommand(readStateScript(paths)), timeoutMs);
+    const state = await ssh.exec(rootCommand(buildRemoteStateScript(paths)), timeoutMs);
     if (!state.success) throw remoteFailure("Unable to read remote upgrade state", state);
     return {
         dropExists: remoteStatePresence(state.stdout, "DROP_EXISTS"),
@@ -677,6 +680,21 @@ function assertSuccessfulUnitStoppedNormally(state: RemoteUpgradeState, paths: R
     );
 }
 
+function failedUnitReachedTerminalState(state: RemoteUpgradeState): boolean {
+    return unitStoppedNormally(state)
+        || (state.serviceState === "failed" && state.unitLoadState === "loaded");
+}
+
+function assertFailedUnitReachedTerminalState(state: RemoteUpgradeState, paths: RemoteUpgradePaths): void {
+    if (failedUnitReachedTerminalState(state)) return;
+    throw remoteReconciliationFailure(
+        `Remote upgrade published FAILED but the unit state is ambiguous `
+        + `(state=${state.serviceState} load=${state.unitLoadState})`,
+        [],
+        paths,
+    );
+}
+
 function assertTerminalEvidence(state: RemoteUpgradeState, paths: RemoteUpgradePaths): void {
     if (state.status !== "SUCCEEDED" && !state.status.startsWith("FAILED:")) return;
     const evidenceIssues: string[] = [];
@@ -767,6 +785,7 @@ export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
             return await completedUpgradeOutput(ssh, paths);
         }
         if (state.status.startsWith("FAILED:") && !unitRunning) {
+            assertFailedUnitReachedTerminalState(state, paths);
             await throwRemoteUpgradeFailure(ssh, paths, state.status);
         }
         if (Date.now() >= observationDeadline) {


### PR DESCRIPTION
## Summary

- treat dangling upload and evidence symlinks as existing unsafe paths
- reject ambiguous FAILED systemd terminal states without reading or deleting retained evidence
- preserve normal failed and collected-unit cleanup behavior

## Verification

- transfer tests: 43 pass
- five related Admin files: 114 pass
- Admin full suite: 136 pass
- typecheck and production build pass
- generated prepare/adopt/state scripts pass bash -n and ShellCheck
- clean-code-guard: clean