### PR TITLE
fix(admin): close SFTP channels after uploads

### DIFF
--- a/packages/admin/src/shared/transports/ssh.test.ts
+++ b/packages/admin/src/shared/transports/ssh.test.ts
@@ -19,6 +19,7 @@ class FakeSshClient extends EventEmitter {
     endCalls = 0;
     activeChannels = 0;
     maxConcurrentChannels = Number.POSITIVE_INFINITY;
+    peakActiveChannels = 0;
     sftpClient: FakeSftpClient | undefined;
 
     connect(options: Record<string, unknown>): this {
@@ -50,6 +51,7 @@ class FakeSshClient extends EventEmitter {
             return;
         }
         this.activeChannels += 1;
+        this.peakActiveChannels = Math.max(this.peakActiveChannels, this.activeChannels);
         let channelOpen = true;
         this.sftpClient.onEnd = () => {
             if (!channelOpen) return;
@@ -287,6 +289,7 @@ describe("SshTransport audit safety", () => {
                 `chmod:${partialPath}:384`,
                 `rename:${partialPath}:/tmp/release/artifact`,
             ]);
+            expect(sftp.endCalls).toBe(1);
             expect(getAuditLog().at(-1)?.command).not.toContain(localPath);
         } finally {
             transport.close();
@@ -311,6 +314,7 @@ describe("SshTransport audit safety", () => {
                 `chmod:${partialPath}:384`,
                 `rename:${partialPath}:/tmp/private/run.sh`,
             ]);
+            expect(sftp.endCalls).toBe(1);
         } finally {
             transport.close();
         }
@@ -338,6 +342,7 @@ describe("SshTransport audit safety", () => {
             expect((await transport.exec("hostname")).success).toBe(true);
             expect(sftp.endCalls).toBe(10);
             expect(client.activeChannels).toBe(0);
+            expect(client.peakActiveChannels).toBe(1);
         } finally {
             transport.close();
             rmSync(fixtureDirectory, { recursive: true, force: true });

--- a/packages/admin/src/shared/transports/ssh.test.ts
+++ b/packages/admin/src/shared/transports/ssh.test.ts
@@ -17,6 +17,8 @@ class FakeSshClient extends EventEmitter {
     stderrOutput = Buffer.alloc(0);
     stallCommand = false;
     endCalls = 0;
+    activeChannels = 0;
+    maxConcurrentChannels = Number.POSITIVE_INFINITY;
     sftpClient: FakeSftpClient | undefined;
 
     connect(options: Record<string, unknown>): this {
@@ -26,6 +28,10 @@ class FakeSshClient extends EventEmitter {
     }
 
     exec(_command: string, callback: (error: Error | undefined, stream: EventEmitter & { stderr: EventEmitter }) => void): void {
+        if (this.activeChannels >= this.maxConcurrentChannels) {
+            callback(new Error("open failed: administratively prohibited: open failed"), undefined as never);
+            return;
+        }
         const stream = new EventEmitter() as EventEmitter & { stderr: EventEmitter };
         stream.stderr = new EventEmitter();
         callback(undefined, stream);
@@ -39,6 +45,17 @@ class FakeSshClient extends EventEmitter {
 
     sftp(callback: (error: Error | undefined, sftp: FakeSftpClient) => void): void {
         if (!this.sftpClient) return callback(new Error("SFTP unavailable"), undefined as never);
+        if (this.activeChannels >= this.maxConcurrentChannels) {
+            callback(new Error("open failed: administratively prohibited: open failed"), undefined as never);
+            return;
+        }
+        this.activeChannels += 1;
+        let channelOpen = true;
+        this.sftpClient.onEnd = () => {
+            if (!channelOpen) return;
+            channelOpen = false;
+            this.activeChannels -= 1;
+        };
         callback(undefined, this.sftpClient);
     }
 
@@ -51,6 +68,8 @@ class FakeSftpClient {
     readonly operations: string[] = [];
     failChmod = false;
     hangFastPut = false;
+    endCalls = 0;
+    onEnd: (() => void) | undefined;
 
     fastPut(_localPath: string, remotePath: string, callback: (error?: Error | null) => void): void {
         this.operations.push(`put:${remotePath}`);
@@ -75,6 +94,11 @@ class FakeSftpClient {
     unlink(remotePath: string, callback: (error?: Error | null) => void): void {
         this.operations.push(`unlink:${remotePath}`);
         queueMicrotask(() => callback());
+    }
+
+    end(): void {
+        this.endCalls += 1;
+        this.onEnd?.();
     }
 }
 
@@ -289,6 +313,34 @@ describe("SshTransport audit safety", () => {
             ]);
         } finally {
             transport.close();
+        }
+    });
+
+    test("closes every SFTP upload channel before a later exec session", async () => {
+        const fixtureDirectory = mkdtempSync(join(tmpdir(), "supacloud-sftp-channels-"));
+        const localPath = join(fixtureDirectory, "artifact");
+        writeFileSync(localPath, "release artifact");
+        const client = new FakeSshClient();
+        const sftp = new FakeSftpClient();
+        client.sftpClient = sftp;
+        client.maxConcurrentChannels = 10;
+        const transport = new SshTransport({
+            host: "server.example.com", port: 22, username: "root", hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => client as never });
+
+        try {
+            for (let uploadIndex = 0; uploadIndex < 10; uploadIndex += 1) {
+                const remotePath = `/tmp/release/artifact-${uploadIndex}`;
+                if (uploadIndex % 2 === 0) await transport.upload(localPath, remotePath);
+                else await transport.uploadText(remotePath, "release artifact");
+            }
+
+            expect((await transport.exec("hostname")).success).toBe(true);
+            expect(sftp.endCalls).toBe(10);
+            expect(client.activeChannels).toBe(0);
+        } finally {
+            transport.close();
+            rmSync(fixtureDirectory, { recursive: true, force: true });
         }
     });
 

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -18,6 +18,7 @@ type SftpClient = {
     chmod: (remotePath: string, mode: number, cb: (err?: Error | null) => void) => void;
     rename: (sourcePath: string, destinationPath: string, cb: (err?: Error | null) => void) => void;
     unlink: (remotePath: string, cb: (err?: Error | null) => void) => void;
+    end: () => void;
 };
 
 export interface SshConfig {
@@ -368,7 +369,13 @@ export class SshTransport {
         let connectionReusable = true;
         let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
         try {
-            const operationPromise = openSftp(conn).then(operation);
+            const operationPromise = openSftp(conn).then(async (sftp) => {
+                try {
+                    await operation(sftp);
+                } finally {
+                    sftp.end();
+                }
+            });
             await Promise.race([
                 operationPromise,
                 new Promise<never>((_resolve, reject) => { timeoutHandle = setTimeout(() => {

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -370,11 +370,8 @@ export class SshTransport {
         let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
         try {
             const operationPromise = openSftp(conn).then(async (sftp) => {
-                try {
-                    await operation(sftp);
-                } finally {
-                    sftp.end();
-                }
+                await operation(sftp);
+                sftp.end();
             });
             await Promise.race([
                 operationPromise,


### PR DESCRIPTION
## Summary

- close the ssh2 SFTP channel after every successful `upload` and `uploadText` operation before returning the underlying SSH connection to the pool
- retain the existing atomic partial-upload cleanup, timeout, connection discard, and error propagation behavior; failed or timed-out operations continue to close the channel by discarding the whole connection
- add a regression that alternates ten file/text uploads under a simulated OpenSSH `MaxSessions=10` limit and proves a later exec channel remains available

## Test-server reproduction

During a supported local-artifact upgrade on the test server, ten sequential SFTP uploads completed, but the following SSH channel open failed with `open failed: administratively prohibited: open failed`. The pooled connection remained alive while each completed SFTP subsystem channel remained open, exhausting the server session limit. This description intentionally omits hostnames, credentials, paths containing identifiers, and customer data.

## Verification

- `bun test src/shared/transports/ssh.test.ts` — 12 pass, 0 fail, 54 assertions
- `bun test` — 132 pass, 0 fail, 651 assertions across 9 files
- `bun run typecheck` — pass
- `bun run build` — pass
- `git diff --check` — pass
- `clean-code-guard` — clean

The new regression was also run against the pre-fix implementation and failed on the post-upload exec with the reproduced channel-open error. Success-path tests assert one channel close per upload, while existing failure and timeout tests confirm the connection-discard semantics remain intact.

## Risk and rollback

This is scoped to closing a completed SFTP subsystem channel. Roll back the complete change by reverting the eventual PR merge commit. Before merge, revert `f4534165` and `fe87d0cb` in reverse order if the branch itself must be undone.
