### PR TITLE
fix(admin): support non-root local upgrade uploads

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -11,7 +11,9 @@ import {
     buildLocalUpgradeRunScript,
     buildPrepareDropCommand,
     buildRemotePreflightScript,
+    buildRemoteUpgradePaths,
     buildRemoteStateScript,
+    buildUploadDropCleanupFailure,
     buildUpgradeLockScript,
     failureRequiresRemoteReconciliation,
     parseRemotePreflight,
@@ -21,7 +23,7 @@ import {
 import { githubCliArchiveIdentity, type LocalUpgradeFile, type PreparedLocalUpgradeBundle } from "./local-upgrade-bundle";
 
 const paths = {
-    drop: "/tmp/.supacloud-upgrade-upload-11111111-1111-4111-8111-111111111111",
+    drop: "/var/tmp/.supacloud-upgrade-upload-11111111-1111-4111-8111-111111111111",
     stage: "/var/lib/supacloud/upgrade-staging/11111111-1111-4111-8111-111111111111",
     status: "/var/lib/supacloud/upgrade-runs/11111111-1111-4111-8111-111111111111.status",
     log: "/var/log/supacloud/upgrade-11111111-1111-4111-8111-111111111111.log",
@@ -141,7 +143,31 @@ function shellFunctionDefinition(script: string, functionName: string): string {
     throw new Error(`Generated shell function ${functionName} is incomplete`);
 }
 
+function prepareDropFixtureShell(command: string, overrides: string[] = []): string {
+    return [
+        "stat() {",
+        "  if [ \"$3\" = /var/tmp ]; then",
+        "    case \"$2\" in %u) printf '%s\\n' \"$UPLOAD_ROOT_UID\" ;; %a) printf '%s\\n' \"$UPLOAD_ROOT_MODE\" ;; esac",
+        "    return",
+        "  fi",
+        "  command stat \"$@\"",
+        "}",
+        "df() { printf 'Filesystem 1024-blocks Used Available Capacity Mounted-on\\n/dev/test 9999999 0 9999999 0%% %s\\n' \"$2\"; }",
+        ...overrides,
+        command,
+    ].join("\n");
+}
+
+function prepareDropFixtureEnv(overrides: Record<string, string> = {}): Record<string, string> {
+    return { ...process.env, UPLOAD_ROOT_UID: "0", UPLOAD_ROOT_MODE: "1777", ...overrides } as Record<string, string>;
+}
+
 describe("local upgrade remote runner", () => {
+    test("places SFTP upload drops under the shared sticky temporary root", () => {
+        expect(buildRemoteUpgradePaths("11111111-1111-4111-8111-111111111111").drop)
+            .toBe(paths.drop);
+    });
+
     test("preflights strict verifier capability without requiring the old jq parser", () => {
         const script = buildRemotePreflightScript();
 
@@ -432,16 +458,114 @@ describe("local upgrade remote runner", () => {
         const fixturePaths = { ...paths, drop: join(fixtureRoot, "drop") };
         symlinkSync(join(fixtureRoot, "missing-drop-target"), fixturePaths.drop);
 
-        const execution = Bun.spawnSync([
-            "bash", "-c", buildPrepareDropCommand(fixturePaths, preparedBundle("amd64", "installed")),
-        ]);
+        const prepareCommand = buildPrepareDropCommand(fixturePaths, preparedBundle("amd64", "installed"));
+        const fixtureCommand = prepareDropFixtureShell(prepareCommand);
+
+        const execution = Bun.spawnSync({ cmd: ["bash", "-c", fixtureCommand], env: prepareDropFixtureEnv() });
         try {
             expect(execution.exitCode).not.toBe(0);
-            expect(execution.stderr.toString()).toContain("Remote upload drop already exists");
+            expect(execution.stderr.toString()).toContain("Unable to create exclusive remote upload drop");
             expect(lstatSync(fixturePaths.drop).isSymbolicLink()).toBe(true);
+            expect(prepareCommand).toContain("UPLOAD_ROOT='/var/tmp'");
+            expect(prepareCommand).toContain("stat -c '%u' \"$UPLOAD_ROOT\"");
+            expect(prepareCommand).toContain("8#$UPLOAD_ROOT_MODE & 01000");
+            expect(prepareCommand).toContain("df -Pk \"$UPLOAD_ROOT\"");
+            expect(prepareCommand).toContain("mkdir -m 700 -- \"$DROP\"");
+            expect(prepareCommand).not.toContain(`install -d -m 700 '${fixturePaths.drop}'`);
         } finally {
             rmSync(fixtureRoot, { recursive: true, force: true });
         }
+    });
+
+    test("requires a root-owned sticky upload root", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-upload-root-gate-")));
+        const fixturePaths = { ...paths, drop: join(fixtureRoot, "drop") };
+        const command = prepareDropFixtureShell(
+            buildPrepareDropCommand(fixturePaths, preparedBundle("amd64", "installed")),
+        );
+        try {
+            const wrongOwner = Bun.spawnSync({
+                cmd: ["bash", "-c", command],
+                env: prepareDropFixtureEnv({ UPLOAD_ROOT_UID: "1001" }),
+            });
+            expect(wrongOwner.exitCode).not.toBe(0);
+            expect(wrongOwner.stderr.toString()).toContain("Remote upload root must be owned by root");
+
+            const missingStickyBit = Bun.spawnSync({
+                cmd: ["bash", "-c", command],
+                env: prepareDropFixtureEnv({ UPLOAD_ROOT_MODE: "0777" }),
+            });
+            expect(missingStickyBit.exitCode).not.toBe(0);
+            expect(missingStickyBit.stderr.toString()).toContain("Remote upload root must set the sticky bit");
+            expect(existsSync(fixturePaths.drop)).toBe(false);
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("creates a private drop atomically after the upload-root gate", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-private-drop-")));
+        const fixturePaths = { ...paths, drop: join(fixtureRoot, "drop") };
+        const command = prepareDropFixtureShell(
+            buildPrepareDropCommand(fixturePaths, preparedBundle("amd64", "bundled")),
+        );
+        const execution = Bun.spawnSync({ cmd: ["bash", "-c", command], env: prepareDropFixtureEnv() });
+        try {
+            expect(execution.exitCode).toBe(0);
+            for (const directory of [
+                fixturePaths.drop,
+                `${fixturePaths.drop}/bundle`,
+                `${fixturePaths.drop}/bundle/management-api`,
+                `${fixturePaths.drop}/bundle/edge-runtime`,
+                `${fixturePaths.drop}/verifier`,
+            ]) {
+                expect(lstatSync(directory).mode & 0o777).toBe(0o700);
+            }
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("does not follow a symlink injected at atomic drop creation", () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-drop-race-")));
+        const raceTarget = join(fixtureRoot, "race-target");
+        const sentinel = join(raceTarget, "sentinel");
+        const fixturePaths = { ...paths, drop: join(fixtureRoot, "drop") };
+        mkdirSync(raceTarget, { mode: 0o700 });
+        writeFileSync(sentinel, "unchanged\n");
+        const command = prepareDropFixtureShell(
+            buildPrepareDropCommand(fixturePaths, preparedBundle("amd64", "installed")),
+            ["mkdir() { ln -s \"$RACE_TARGET\" \"$DROP\"; command mkdir \"$@\"; }"],
+        );
+        const execution = Bun.spawnSync({
+            cmd: ["bash", "-c", command],
+            env: prepareDropFixtureEnv({ RACE_TARGET: raceTarget }),
+        });
+        try {
+            expect(execution.exitCode).not.toBe(0);
+            expect(execution.stderr.toString()).toContain("Unable to create exclusive remote upload drop");
+            expect(lstatSync(fixturePaths.drop).isSymbolicLink()).toBe(true);
+            expect(readFileSync(sentinel, "utf8")).toBe("unchanged\n");
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("requires reconciliation when a failed upload drop cannot be cleaned", () => {
+        const failure = buildUploadDropCleanupFailure(
+            new Error("SFTP upload failed"),
+            new Error("remote drop cleanup failed"),
+            paths,
+        );
+
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("do not retry blindly");
+        for (const evidencePath of [paths.drop, paths.stage, paths.status, paths.log, paths.unit]) {
+            expect(String(failure)).toContain(evidencePath);
+        }
+        const diagnostics = (failure as AggregateError).errors.map(String).join("\n");
+        expect(diagnostics).toContain("SFTP upload failed");
+        expect(diagnostics).toContain("remote drop cleanup failed");
     });
 
     test("rejects dangling adoption targets before moving the upload drop", () => {

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -50,6 +50,7 @@ export type RemoteUpgradePreflight = {
 const REMOTE_STAGE_ROOT = "/var/lib/supacloud/upgrade-staging";
 const REMOTE_RUN_ROOT = "/var/lib/supacloud/upgrade-runs";
 const REMOTE_LOG_ROOT = "/var/log/supacloud";
+const REMOTE_UPLOAD_ROOT = "/var/tmp";
 const POLL_INTERVAL_MS = 2_000;
 const STATE_READ_ATTEMPTS = 3;
 const REMOTE_STATE_READ_TIMEOUT_MS = 15_000;
@@ -85,9 +86,9 @@ function trustedInstalledGithubFunction(): string {
     ].join("\n");
 }
 
-function remotePaths(runId: string): RemoteUpgradePaths {
+export function buildRemoteUpgradePaths(runId: string): RemoteUpgradePaths {
     return {
-        drop: `/tmp/.supacloud-upgrade-upload-${runId}`,
+        drop: `${REMOTE_UPLOAD_ROOT}/.supacloud-upgrade-upload-${runId}`,
         stage: `${REMOTE_STAGE_ROOT}/${runId}`,
         status: `${REMOTE_RUN_ROOT}/${runId}.status`,
         log: `${REMOTE_LOG_ROOT}/upgrade-${runId}.log`,
@@ -148,9 +149,20 @@ function requiredRemoteBytes(bundle: PreparedLocalUpgradeBundle): number {
     return transferBytes * 3 + 512 * 1024 * 1024;
 }
 
+function remoteUploadRootGate(): string[] {
+    return [
+        `UPLOAD_ROOT=${quoteShell(REMOTE_UPLOAD_ROOT)}`,
+        "test -d \"$UPLOAD_ROOT\" && test ! -L \"$UPLOAD_ROOT\" || { echo 'Remote upload root must be a directory, not a symlink' >&2; exit 1; }",
+        "test \"$(stat -c '%u' \"$UPLOAD_ROOT\")\" = 0 || { echo 'Remote upload root must be owned by root' >&2; exit 1; }",
+        "UPLOAD_ROOT_MODE=$(stat -c '%a' \"$UPLOAD_ROOT\")",
+        "case \"$UPLOAD_ROOT_MODE\" in [0-7]|[0-7][0-7]|[0-7][0-7][0-7]|[0-7][0-7][0-7][0-7]) ;; *) echo 'Remote upload root has invalid permission bits' >&2; exit 1 ;; esac",
+        "(( (8#$UPLOAD_ROOT_MODE & 01000) != 0 )) || { echo 'Remote upload root must set the sticky bit' >&2; exit 1; }",
+        "test -w \"$UPLOAD_ROOT\" && test -x \"$UPLOAD_ROOT\" || { echo 'Remote upload root is not writable and searchable by the SSH user' >&2; exit 1; }",
+    ];
+}
+
 export function buildPrepareDropCommand(paths: RemoteUpgradePaths, bundle: PreparedLocalUpgradeBundle): string {
     const directories = [
-        paths.drop,
         `${paths.drop}/bundle`,
         `${paths.drop}/bundle/management-api`,
         `${paths.drop}/bundle/edge-runtime`,
@@ -160,10 +172,12 @@ export function buildPrepareDropCommand(paths: RemoteUpgradePaths, bundle: Prepa
     return [
         "set -euo pipefail",
         "umask 077",
-        `test ! -e ${quoteShell(paths.drop)} && test ! -L ${quoteShell(paths.drop)} || { echo 'Remote upload drop already exists' >&2; exit 1; }`,
-        "TMP_AVAILABLE_KB=$(df -Pk /tmp | awk 'NR == 2 { print $4 }')",
+        ...remoteUploadRootGate(),
+        `DROP=${quoteShell(paths.drop)}`,
+        "UPLOAD_AVAILABLE_KB=$(df -Pk \"$UPLOAD_ROOT\" | awk 'NR == 2 { print $4 }')",
         "VAR_AVAILABLE_KB=$(df -Pk /var/lib/supacloud | awk 'NR == 2 { print $4 }')",
-        `test \"${"$"}TMP_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} && test \"${"$"}VAR_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} || { echo 'Insufficient remote disk space for verified upgrade staging' >&2; exit 1; }`,
+        `test \"${"$"}UPLOAD_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} && test \"${"$"}VAR_AVAILABLE_KB\" -ge ${Math.ceil(requiredBytes / 1024)} || { echo 'Insufficient remote disk space for verified upgrade staging' >&2; exit 1; }`,
+        "mkdir -m 700 -- \"$DROP\" || { echo 'Unable to create exclusive remote upload drop' >&2; exit 1; }",
         `install -d -m 700 ${directories.map(quoteShell).join(" ")}`,
     ].join("\n");
 }
@@ -647,6 +661,18 @@ function remoteReconciliationFailure(
     );
 }
 
+export function buildUploadDropCleanupFailure(
+    transferFailure: unknown,
+    cleanupFailure: unknown,
+    paths: RemoteUpgradePaths,
+): Error {
+    return remoteReconciliationFailure(
+        "Local upgrade failed and upload-drop cleanup did not complete",
+        [transferFailure, cleanupFailure],
+        paths,
+    );
+}
+
 export function failureRequiresRemoteReconciliation(error: unknown): boolean {
     return error instanceof RemoteUpgradeReconciliationError;
 }
@@ -806,7 +832,7 @@ export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
 
 export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: LocalUpgradeTransferRequest): Promise<string> {
     const runId = randomUUID();
-    const paths = remotePaths(runId);
+    const paths = buildRemoteUpgradePaths(runId);
     const preflight = await remoteUpgradePreflight(ssh);
     const bundle = await prepareLocalUpgradeBundle({ ...preflight, ...request });
     let adopted = false;
@@ -826,10 +852,7 @@ export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: Lo
                 try {
                     await cleanupRemoteDrop(ssh, paths);
                 } catch (cleanupError: unknown) {
-                    transferError = new AggregateError(
-                        [transferError, cleanupError],
-                        "Local upgrade failed and upload-drop cleanup did not complete",
-                    );
+                    transferError = buildUploadDropCleanupFailure(transferError, cleanupError, paths);
                 }
             }
             throw transferError;


### PR DESCRIPTION
## Summary

- move verified local-upgrade SFTP drops from hardened /tmp to the standard sticky /var/tmp upload root
- validate root ownership, sticky permissions, and SSH-user write/search access at the creation boundary
- create the private drop atomically with mode 0700 and classify cleanup failures as reconciliation-required
- add owner, sticky-bit, dangling-symlink, injected-race, private-mode, and cleanup-evidence regressions

## Production evidence

The production host uses ubuntu with passwordless sudo, /tmp mode 0700 owned by root, and /var/tmp mode 1777 owned by root. Admin 0.7.9 completed download verification but failed before adoption because its non-root SFTP drop was fixed under /tmp. Read-back confirmed no drop, stage, status, log, or transient unit remained and the active Management version stayed 0.50.25.

## Validation

- Admin tests: 142 passed, 0 failed
- local upgrade transfer tests: 48 passed, 0 failed
- TypeScript typecheck: passed
- Admin production build: passed
- git diff --check: passed
- independent review: PASS
- clean-code-guard: clean