### PR TITLE
fix(edge-runtime): handle version CLI without starting the server

### DIFF
--- a/packages/edge-runtime/cli.test.ts
+++ b/packages/edge-runtime/cli.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import packageMetadata from "./package.json";
+import { edgeRuntimeVersionOutput, parseEdgeRuntimeCli } from "./cli";
+
+describe("edge runtime CLI", () => {
+  test("starts the service only when no command-line arguments are present", () => {
+    expect(parseEdgeRuntimeCli([])).toEqual({ kind: "serve" });
+  });
+
+  test("reports the package version without selecting the server command", () => {
+    expect(parseEdgeRuntimeCli(["--version"])).toEqual({
+      kind: "version",
+      output: `supacloud-edge-runtime ${packageMetadata.version}`,
+    });
+    expect(edgeRuntimeVersionOutput()).toContain(packageMetadata.version);
+  });
+
+  test("rejects unknown and mixed arguments", () => {
+    expect(parseEdgeRuntimeCli(["--unknown"])).toEqual({
+      kind: "error",
+      message: "Unknown argument: --unknown",
+    });
+    expect(parseEdgeRuntimeCli(["--version", "--unknown"]).kind).toBe("error");
+  });
+});

--- a/packages/edge-runtime/cli.ts
+++ b/packages/edge-runtime/cli.ts
@@ -1,0 +1,40 @@
+import packageMetadata from "./package.json";
+
+export type EdgeRuntimeCliCommand =
+  | { kind: "serve" }
+  | { kind: "version"; output: string }
+  | { kind: "error"; message: string };
+
+export function edgeRuntimeVersionOutput(): string {
+  return `supacloud-edge-runtime ${packageMetadata.version}`;
+}
+
+export function parseEdgeRuntimeCli(args: readonly string[]): EdgeRuntimeCliCommand {
+  if (args.length === 0) return { kind: "serve" };
+  if (args.length === 1 && args[0] === "--version") {
+    return { kind: "version", output: edgeRuntimeVersionOutput() };
+  }
+  return {
+    kind: "error",
+    message: `Unknown argument: ${args.join(" ")}`,
+  };
+}
+
+export async function runEdgeRuntimeCli(args: readonly string[]): Promise<number> {
+  const command = parseEdgeRuntimeCli(args);
+  if (command.kind === "version") {
+    console.log(command.output);
+    return 0;
+  }
+  if (command.kind === "error") {
+    console.error(command.message);
+    return 2;
+  }
+  await import("./server");
+  return 0;
+}
+
+if (import.meta.main) {
+  const exitCode = await runEdgeRuntimeCli(Bun.argv.slice(2));
+  if (exitCode !== 0) process.exit(exitCode);
+}

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -13,7 +13,7 @@
     "build:macos-arm64": "bun run scripts/build-compiled.ts --target bun-macos-arm64 --outfile supacloud-edge-runtime-macos-arm64",
     "build:macos": "bun run build:macos-amd64 && bun run build:macos-arm64",
     "release:manifest": "bun run ../../scripts/generate_release_manifest.ts --component edge-runtime --package-json package.json",
-    "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict server.ts worker-executor.ts worker-pool.ts internal-bindings.ts pgredis-capability.ts auto-deps.ts deno-compat.ts fetch-tls-policy.ts url-import-plugin.ts shims/*.ts"
+    "typecheck": "bun x tsc --noEmit --skipLibCheck --allowImportingTsExtensions --moduleResolution bundler --module esnext --target esnext --types bun --strict cli.ts server.ts worker-executor.ts worker-pool.ts internal-bindings.ts pgredis-capability.ts auto-deps.ts deno-compat.ts fetch-tls-policy.ts url-import-plugin.ts shims/*.ts"
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.2",

--- a/packages/edge-runtime/scripts/build-compiled.ts
+++ b/packages/edge-runtime/scripts/build-compiled.ts
@@ -64,7 +64,7 @@ try {
     ].join("\n"),
   );
 
-  await $`bun build server.ts --compile --target=${target} --outfile=${outfile}`.cwd(root);
+  await $`bun build cli.ts --compile --target=${target} --outfile=${outfile}`.cwd(root);
 } finally {
   await writeFile(generatedPath, originalGenerated);
   rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- compile the Edge Runtime through a thin CLI entrypoint
- start the server only when no command-line arguments are supplied
- make --version exit successfully without binding a listener
- reject unknown arguments with exit code 2

## Verification
- bun test packages/edge-runtime/cli.test.ts: 3 passed
- edge-runtime typecheck
- macOS arm64 compiled --version and unknown-argument smoke
- Linux x64 candidate compiled and exercised natively on the test host without changing the installed service binary
- git diff --check

clean-code-guard: 1 fixed, 0 flagged for author