### PR TITLE
fix(upgrade): harden offline verification lifecycle

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -177,6 +177,7 @@ describe("local upgrade remote runner", () => {
         expect(script).toContain("mode=$(stat -c '%a' \"$verifier\")");
         expect(script).toContain("trusted_installed_gh \"$GH\"");
         expect(script).toContain("timeout flock");
+        expect(script).toContain("tail -n 0 -- /dev/null");
         expect(script).not.toContain("Required local-upgrade tool is missing: jq");
         expect(parseRemotePreflight("ARCH=arm64\nVERIFIER=installed\n")).toEqual({
             architecture: "arm64",
@@ -961,7 +962,9 @@ describe("local upgrade remote runner", () => {
             expect(failureRequiresRemoteReconciliation(failure)).toBe(false);
             expect(String(failure)).toContain("FAILED:9:TRANSACTION");
             expect(ssh.commands).toHaveLength(3);
-            expect(ssh.commands[1]).toContain("tail -80");
+            expect(ssh.commands[1]).toContain("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
+            expect(ssh.commands[1]).toContain('tail -n 80 -- "$LOG"');
+            expect(ssh.commands[1]).not.toContain("tail -80 --");
             expect(ssh.commands[2]).toContain("rm -f --");
             expect(ssh.commands[2]).toContain(paths.status);
             expect(ssh.commands[2]).toContain(paths.log);
@@ -1001,6 +1004,8 @@ describe("local upgrade remote runner", () => {
 
         await expect(awaitRemoteUpgrade(ssh as never, paths)).resolves.toContain("Upgrade done");
         expect(ssh.commands).toHaveLength(3);
+        expect(ssh.commands[1]).toContain("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
+        expect(ssh.commands[1]).toContain('tail -n 80 -- "$LOG"');
         expect(ssh.commands[2]).toContain(paths.status);
         expect(ssh.commands[2]).toContain(paths.log);
     });

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -51,6 +51,7 @@ const REMOTE_STAGE_ROOT = "/var/lib/supacloud/upgrade-staging";
 const REMOTE_RUN_ROOT = "/var/lib/supacloud/upgrade-runs";
 const REMOTE_LOG_ROOT = "/var/log/supacloud";
 const REMOTE_UPLOAD_ROOT = "/var/tmp";
+const REMOTE_COMMAND_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const POLL_INTERVAL_MS = 2_000;
 const STATE_READ_ATTEMPTS = 3;
 const REMOTE_STATE_READ_TIMEOUT_MS = 15_000;
@@ -112,11 +113,12 @@ export function buildRemotePreflightScript(): string {
     const capabilityFlags = STRICT_GITHUB_CAPABILITY_FLAGS.join(" ");
     return [
         "set -euo pipefail",
-        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        `PATH=${REMOTE_COMMAND_PATH}`,
         "export PATH",
         trustedInstalledGithubFunction(),
         "test -d /run/systemd/system || { echo 'systemd is not the active init system' >&2; exit 1; }",
-        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep timeout flock; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep tail timeout flock; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "tail -n 0 -- /dev/null >/dev/null 2>&1 || { echo 'A tail implementation with -n and -- support is required' >&2; exit 1; }",
         "systemd-run --help | grep -Eq -- '(^|[[:space:]])--collect([=[:space:]]|$)' || { echo 'systemd-run --collect is required' >&2; exit 1; }",
         "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
         "test -d /var/lib/supacloud || { echo '/var/lib/supacloud is unavailable' >&2; exit 1; }",
@@ -243,7 +245,7 @@ function upgradeScriptSetup(paths: RemoteUpgradePaths): string[] {
     const bundleDirectory = `${paths.stage}/bundle`;
     return [
         "#!/usr/bin/env bash", "set -euo pipefail", "umask 077",
-        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "export PATH",
+        `PATH=${REMOTE_COMMAND_PATH}`, "export PATH",
         `STAGE=${quoteShell(paths.stage)}`, `STATUS=${quoteShell(paths.status)}`, `LOG=${quoteShell(paths.log)}`,
         `BUNDLE=${quoteShell(bundleDirectory)}`,
         `MANAGEMENT_DIR=${quoteShell(`${bundleDirectory}/management-api`)}`,
@@ -603,9 +605,11 @@ async function observeRemoteState(
 
 async function remoteLogTail(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
     const script = [
+        `PATH=${REMOTE_COMMAND_PATH}`,
+        "export PATH",
         `LOG=${quoteShell(paths.log)}`,
         "test -f \"$LOG\" && test ! -L \"$LOG\" || { echo 'Remote upgrade log is not a regular file' >&2; exit 1; }",
-        "tail -80 -- \"$LOG\"",
+        "tail -n 80 -- \"$LOG\"",
     ].join("\n");
     const output = await ssh.exec(rootCommand(script), 15_000);
     if (!output.success) throw remoteFailure("Unable to read the remote upgrade log", output);

--- a/packages/management-api/src/offline-upgrade-bundle.ts
+++ b/packages/management-api/src/offline-upgrade-bundle.ts
@@ -18,7 +18,8 @@ import {
 } from "./release-manifest";
 
 const GH_CAPABILITY_TIMEOUT_MS = 10_000;
-const GH_VERIFICATION_TIMEOUT_MS = 60_000;
+// Released binaries can take more than a minute to hash on production storage.
+const GH_VERIFICATION_TIMEOUT_MS = 2 * 60_000;
 
 type BundleOwner = {
   uid: number;

--- a/packages/management-api/tests/unit/offline-upgrade-bundle.test.ts
+++ b/packages/management-api/tests/unit/offline-upgrade-bundle.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -187,6 +187,17 @@ describe("offline upgrade bundle", () => {
       expect(call).toContain("--source-ref refs/heads/main");
       expect(call).toContain(`--source-digest ${"a".repeat(40)}`);
       expect(call).toContain("--deny-self-hosted-runners");
+    }
+  });
+
+  test("allows two minutes for each bounded offline attestation verification", async () => {
+    const fixture = bundleFixture();
+    const timeout = spyOn(globalThis, "setTimeout");
+    try {
+      await loadFixture(fixture);
+      expect(timeout.mock.calls.filter((call) => call[1] === 2 * 60_000)).toHaveLength(7);
+    } finally {
+      timeout.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

- give target-side offline GitHub attestation verification the same bounded two-minute per-artifact budget as the Admin host
- read terminal upgrade logs with portable `tail -n 80 --` syntax under the same pinned PATH used by preflight and the runner
- preflight the exact tail capability before any transaction starts

## Production evidence

Production run `21d27368-3a69-40ab-8f50-640f64d3a17c` stopped before activation with `FAILED:1:TRANSACTION` because the target verifier exceeded the fixed 60000 ms limit. Admin then could not read the retained log because uutils coreutils 0.8.0 rejects `tail -80 -- FILE`. The failed stage and upload drop were removed; Management remains 0.50.25 and Management/Edge remain active. Status and log evidence are retained.

## Safety

- attestation identity, digest, workflow, source-ref, source-digest, and self-hosted-runner checks are unchanged
- verification stays fail-closed and bounded; seven worst-case verifications fit within the existing 30-minute observer
- cleanup and reconciliation behavior is unchanged

## Verification

- Admin full suite: 142 pass, 0 fail
- Management full unit suite: pass
- focused Management offline bundle: 7 pass, 0 fail
- Admin and Management typecheck: pass
- Admin production build: pass
- git diff --check: pass
- independent review: PASS
- clean-code-guard: clean