### PR TITLE
fix(lite): delegate Edge Function CORS preflights

### DIFF
--- a/packages/supacloud-lite/src/runtime/index.ts
+++ b/packages/supacloud-lite/src/runtime/index.ts
@@ -302,6 +302,9 @@ export async function createBackend(config: BackendConfig = {}): Promise<SupaClo
     const url = new URL(req.url)
     const path = url.pathname
 
+    if (req.method === 'OPTIONS' && (path === '/functions/v1' || path.startsWith('/functions/v1/'))) {
+      return functions.handle(req, { role: 'anon', claims: null }, url)
+    }
     if (req.method === 'OPTIONS') {
       return new Response(null, { status: 204, headers: CORS_HEADERS })
     }

--- a/packages/supacloud-lite/test/functions-cors.test.ts
+++ b/packages/supacloud-lite/test/functions-cors.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'bun:test'
+import { createBackend } from '../src/runtime/index.js'
+
+test('delegates function preflights while keeping default CORS for non-function routes', async () => {
+  const functionOrigin = 'https://app.example'
+  const observedMethods: string[] = []
+  const backend = await createBackend({
+    startRuntimeServices: false,
+    log: () => {},
+    functions: new Map([
+      [
+        'cors-owned',
+        (request) => {
+          observedMethods.push(request.method)
+          if (request.headers.get('origin') !== functionOrigin) {
+            return new Response(null, { status: 403 })
+          }
+          return new Response(null, {
+            status: 204,
+            headers: {
+              'access-control-allow-origin': functionOrigin,
+              'access-control-allow-methods': 'POST, OPTIONS',
+            },
+          })
+        },
+      ],
+    ]),
+  })
+  const requestFunctionPreflight = (origin: string) =>
+    backend.fetch(
+      new Request('http://localhost/functions/v1/cors-owned', {
+        method: 'OPTIONS',
+        headers: { origin, 'access-control-request-method': 'POST' },
+      })
+    )
+
+  try {
+    const functionPreflight = await requestFunctionPreflight(functionOrigin)
+    expect(observedMethods).toEqual(['OPTIONS'])
+    expect(functionPreflight.status).toBe(204)
+    expect(functionPreflight.headers.get('access-control-allow-origin')).toBe(functionOrigin)
+    expect(functionPreflight.headers.get('access-control-allow-headers')).toBeNull()
+
+    const rejectedPreflight = await requestFunctionPreflight('https://evil.example')
+    expect(observedMethods).toEqual(['OPTIONS', 'OPTIONS'])
+    expect(rejectedPreflight.status).toBe(403)
+    expect(rejectedPreflight.headers.get('access-control-allow-origin')).toBeNull()
+
+    const restPreflight = await backend.fetch(
+      new Request('http://localhost/rest/v1/todos', {
+        method: 'OPTIONS',
+        headers: { origin: functionOrigin, 'access-control-request-method': 'POST' },
+      })
+    )
+    expect(restPreflight.status).toBe(204)
+    expect(restPreflight.headers.get('access-control-allow-origin')).toBe('*')
+    expect(restPreflight.headers.get('access-control-allow-methods')).toContain('POST')
+  } finally {
+    await backend.close()
+  }
+})


### PR DESCRIPTION
## Summary

- dispatch `OPTIONS` requests under `/functions/v1` to the registered Edge Function before API-key resolution
- preserve the function's own CORS response instead of replacing it with Lite's permissive global preflight
- keep the existing `204` plus wildcard CORS behavior for non-Function routes

## Bug

SupaCloud Lite intercepted every `OPTIONS` request before route dispatch. An Edge Function with an exact origin allowlist therefore never saw browser preflights: both an allowed origin and an untrusted origin received `204` with `Access-Control-Allow-Origin: *`, even though the same function rejected the untrusted `POST` with `403 origin_not_allowed`.

## Verification

- TDD red on `origin/main`: the registered function observed no `OPTIONS` call
- focused Functions/REST/Realtime/CORS suite: 12 tests, 83 assertions passed
- `bun run check`: typecheck passed; 95 tests and 428 assertions passed; JS/types build, package smoke, host standalone build, and standalone lifecycle smoke passed
- independent security verifier: PASS with no blocking findings

## Compatibility note

Edge Functions now receive unauthenticated preflights with an anonymous request context, matching function-owned CORS. Function handlers remain responsible for making their `OPTIONS` branch side-effect-free. Other Lite routes retain the existing global preflight response.
