### PR TITLE
fix(lite): default PGlite timezone to UTC

### DIFF
--- a/packages/supacloud-lite/src/runtime/db/pglite-engine.ts
+++ b/packages/supacloud-lite/src/runtime/db/pglite-engine.ts
@@ -9,6 +9,26 @@ import {
   type StandalonePgliteAssets,
 } from '../../standalone-assets-protocol.js'
 
+const INITIALIZE_TIMEZONE_SQL = `
+do $$
+declare configured_timezone text;
+begin
+  select split_part(setting, '=', 2) into configured_timezone
+  from pg_db_role_setting
+  cross join lateral unnest(setconfig) as setting
+  where setdatabase = (select oid from pg_database where datname = current_database())
+    and setrole = 0
+    and lower(split_part(setting, '=', 1)) = 'timezone'
+  limit 1;
+
+  if configured_timezone is null then
+    configured_timezone := 'UTC';
+    execute format('alter database %I set timezone to %L', current_database(), configured_timezone);
+  end if;
+  perform set_config('TimeZone', configured_timezone, false);
+end $$;
+`
+
 /**
  * Build a {@link DbEngine} backed by PGlite (WASM Postgres) at `dataDir`, or an
  * in-memory database when `dataDir` is omitted. Loads the bundled contrib
@@ -72,6 +92,17 @@ export async function createPgliteEngine(dataDir?: string): Promise<DbEngine> {
         : {}),
     })
     await pg.waitReady
+    // PGlite inherits the host timezone at initdb, and its current session does
+    // not apply ALTER DATABASE settings.
+    try {
+      await pg.exec(INITIALIZE_TIMEZONE_SQL)
+    } catch (error) {
+      const [cleanup] = await Promise.allSettled([pg.close()])
+      if (cleanup.status === 'rejected') {
+        throw new AggregateError([error, cleanup.reason], 'PGlite timezone initialization and cleanup failed')
+      }
+      throw error
+    }
   } catch (error) {
     await releaseLock()
     throw error

--- a/packages/supacloud-lite/test/helpers/timezone-probe.ts
+++ b/packages/supacloud-lite/test/helpers/timezone-probe.ts
@@ -1,0 +1,137 @@
+import { PGlite } from '@electric-sql/pglite'
+import { createBackend } from '../../src/runtime/index.js'
+import { Database } from '../../src/runtime/db/database.js'
+import { createPgliteEngine } from '../../src/runtime/db/pglite-engine.js'
+
+interface TimezoneRow {
+  session_timezone: string
+  observed_at: string
+}
+
+const TIMESTAMP_PROBE_SQL = `
+  select current_setting('TimeZone') as session_timezone,
+         to_json('2026-08-10T00:00:00Z'::timestamptz) as observed_at
+`
+const TIMEZONE_PROBE_MIGRATION = {
+  name: '20260811000000_timezone_probe.sql',
+  sql: `
+    create table public.timezone_probes (observed_at timestamptz not null);
+    insert into public.timezone_probes values ('2026-08-10T00:00:00Z');
+    create function public.timezone_probe() returns timestamptz
+      language sql stable as $$ select '2026-08-10T00:00:00Z'::timestamptz $$;
+    grant select on public.timezone_probes to service_role;
+    grant execute on function public.timezone_probe() to service_role;
+  `,
+}
+const dataDir = process.env.SUPACLOUD_LITE_TIMEZONE_DATA_DIR
+const probeMode = process.env.SUPACLOUD_LITE_TIMEZONE_PROBE_MODE
+
+if (!dataDir) throw new Error('SUPACLOUD_LITE_TIMEZONE_DATA_DIR is required')
+
+switch (probeMode) {
+  case 'create-legacy':
+    await probeLegacyDatabase(dataDir)
+    break
+  case 'minimal':
+    await probeMinimalDatabase(dataDir)
+    break
+  case 'set-custom-timezone':
+    await setCustomDatabaseTimezone(dataDir)
+    break
+  case 'full':
+    await probeFullDataApi(dataDir)
+    break
+  default:
+    throw new Error(`unsupported timezone probe mode: ${probeMode ?? '<missing>'}`)
+}
+
+async function probeLegacyDatabase(probeDataDir: string): Promise<void> {
+  const pg = new PGlite({ dataDir: probeDataDir })
+  await pg.waitReady
+  try {
+    emitEngineProbe((await pg.query<TimezoneRow>(TIMESTAMP_PROBE_SQL)).rows[0])
+  } finally {
+    await pg.close()
+  }
+}
+
+async function probeMinimalDatabase(probeDataDir: string): Promise<void> {
+  const engine = await createPgliteEngine(probeDataDir)
+  engine.minimalBootstrap = true
+  const database = await Database.create(engine)
+  try {
+    emitEngineProbe((await database.query<TimezoneRow>(TIMESTAMP_PROBE_SQL)).rows[0])
+  } finally {
+    await database.close()
+  }
+}
+
+async function setCustomDatabaseTimezone(probeDataDir: string): Promise<void> {
+  const engine = await createPgliteEngine(probeDataDir)
+  try {
+    await engine.exec(`alter database postgres set timezone to 'Asia/Shanghai'`)
+    emitEngineProbe((await engine.query<TimezoneRow>(TIMESTAMP_PROBE_SQL)).rows[0])
+  } finally {
+    await engine.close()
+  }
+}
+
+async function probeFullDataApi(probeDataDir: string): Promise<void> {
+  const backend = await createBackend({
+    dataDir: probeDataDir,
+    log: () => {},
+    migrations: [TIMEZONE_PROBE_MIGRATION],
+    startRuntimeServices: false,
+  })
+  try {
+    const headers = {
+      apikey: backend.serviceRoleKey,
+      authorization: `Bearer ${backend.serviceRoleKey}`,
+    }
+    const session = await backend.db.query<{ session_timezone: string }>(
+      `select current_setting('TimeZone') as session_timezone`
+    )
+    console.log(JSON.stringify({
+      kind: 'data-api',
+      session_timezone: session.rows[0].session_timezone,
+      table_observed_at: await readTableTimestamp(backend.fetch, headers),
+      rpc_observed_at: await readRpcTimestamp(backend.fetch, headers),
+    }))
+  } finally {
+    await backend.close()
+  }
+}
+
+async function readTableTimestamp(fetchHandler: typeof fetch, headers: Record<string, string>): Promise<string> {
+  const response = await fetchHandler(new Request(
+    'http://localhost/rest/v1/timezone_probes?select=observed_at',
+    { headers }
+  ))
+  if (!response.ok) throw new Error(`timezone table probe failed with HTTP ${response.status}`)
+  const tablePayload: unknown = await response.json()
+  if (!Array.isArray(tablePayload) || !isTimestampRecord(tablePayload[0])) {
+    throw new Error('timezone table probe returned an invalid payload')
+  }
+  return tablePayload[0].observed_at
+}
+
+async function readRpcTimestamp(fetchHandler: typeof fetch, headers: Record<string, string>): Promise<string> {
+  const response = await fetchHandler(new Request(
+    'http://localhost/rest/v1/rpc/timezone_probe',
+    { method: 'POST', headers, body: '{}' }
+  ))
+  if (!response.ok) throw new Error(`timezone RPC probe failed with HTTP ${response.status}`)
+  const rpcPayload: unknown = await response.json()
+  if (typeof rpcPayload !== 'string') throw new Error('timezone RPC probe returned an invalid payload')
+  return rpcPayload
+}
+
+function isTimestampRecord(candidate: unknown): candidate is { observed_at: string } {
+  return typeof candidate === 'object'
+    && candidate !== null
+    && typeof (candidate as Record<string, unknown>).observed_at === 'string'
+}
+
+function emitEngineProbe(timezoneRow: TimezoneRow): void {
+  console.log(JSON.stringify({ kind: 'engine', ...timezoneRow }))
+}

--- a/packages/supacloud-lite/test/pglite-engine.test.ts
+++ b/packages/supacloud-lite/test/pglite-engine.test.ts
@@ -2,11 +2,27 @@ import { expect, test } from 'bun:test'
 import { access, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { PGlite } from '@electric-sql/pglite'
 import {
   STANDALONE_PGLITE_ASSETS,
   type StandalonePgliteAssets,
 } from '../src/standalone-assets-protocol.js'
 import { createPgliteEngine } from '../src/runtime/db/pglite-engine.js'
+
+interface EngineTimezoneProbe {
+  kind: 'engine'
+  session_timezone: string
+  observed_at: string
+}
+
+interface DataApiTimezoneProbe {
+  kind: 'data-api'
+  session_timezone: string
+  table_observed_at: string
+  rpc_observed_at: string
+}
+
+type TimezoneProbe = EngineTimezoneProbe | DataApiTimezoneProbe
 
 const emptyWasmModule = new WebAssembly.Module(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]))
 
@@ -33,3 +49,139 @@ test('preserves standalone extension preparation errors and releases the data lo
     await rm(projectDir, { recursive: true, force: true })
   }
 })
+
+test('defaults fresh and reopened databases to UTC while preserving an explicit database timezone', async () => {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-timezone-'))
+  try {
+    const freshFull = await runTimezoneProbe(join(projectDir, 'fresh-full'), 'full', 'Asia/Shanghai')
+    expectFullUtcProbe(freshFull)
+
+    const reopenedFullDir = join(projectDir, 'reopened-full')
+    expectLegacyHostTimezone(await runTimezoneProbe(reopenedFullDir, 'create-legacy', 'Asia/Shanghai'))
+    expectFullUtcProbe(await runTimezoneProbe(reopenedFullDir, 'full', 'UTC'))
+
+    const freshMinimal = await runTimezoneProbe(join(projectDir, 'fresh-minimal'), 'minimal', 'Asia/Shanghai')
+    expectMinimalUtcProbe(freshMinimal)
+
+    const reopenedMinimalDir = join(projectDir, 'reopened-minimal')
+    expectLegacyHostTimezone(await runTimezoneProbe(reopenedMinimalDir, 'create-legacy', 'Asia/Shanghai'))
+    expectMinimalUtcProbe(await runTimezoneProbe(reopenedMinimalDir, 'minimal', 'UTC'))
+
+    const customTimezoneDir = join(projectDir, 'custom-timezone')
+    await runTimezoneProbe(customTimezoneDir, 'set-custom-timezone', 'UTC')
+    expectCustomTimezone(await runTimezoneProbe(customTimezoneDir, 'full', 'UTC'))
+  } finally {
+    await rm(projectDir, { recursive: true, force: true })
+  }
+}, 60_000)
+
+test('closes a ready PGlite instance when timezone initialization fails', async () => {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-timezone-failure-'))
+  const dataDir = join(projectDir, 'db')
+  const lockPath = `${dataDir}.supacloud-lite.lock`
+  const initializationError = new Error('forced timezone initialization failure')
+  const originalExec = PGlite.prototype.exec
+  let failedInstance: PGlite | undefined
+  PGlite.prototype.exec = async function (query, options) {
+    if (query.includes('declare configured_timezone')) {
+      failedInstance = this
+      throw initializationError
+    }
+    return originalExec.call(this, query, options)
+  }
+  try {
+    await expect(createPgliteEngine(dataDir)).rejects.toBe(initializationError)
+    expect(failedInstance?.closed).toBe(true)
+    await expect(access(lockPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  } finally {
+    PGlite.prototype.exec = originalExec
+    if (failedInstance && !failedInstance.closed) await failedInstance.close()
+    await rm(projectDir, { recursive: true, force: true })
+  }
+}, 30_000)
+
+async function runTimezoneProbe(
+  dataDir: string,
+  probeMode:
+    | 'create-legacy'
+    | 'full'
+    | 'minimal'
+    | 'set-custom-timezone',
+  timezone: string
+): Promise<TimezoneProbe> {
+  const child = Bun.spawn([process.execPath, 'test/helpers/timezone-probe.ts'], {
+    cwd: join(import.meta.dir, '..'),
+    env: {
+      ...process.env,
+      TZ: timezone,
+      SUPACLOUD_LITE_TIMEZONE_DATA_DIR: dataDir,
+      SUPACLOUD_LITE_TIMEZONE_PROBE_MODE: probeMode,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  expect(exitCode, stderr).toBe(0)
+  return parseTimezoneProbe(stdout)
+}
+
+function expectLegacyHostTimezone(probe: TimezoneProbe): void {
+  expect(probe.kind).toBe('engine')
+  if (probe.kind !== 'engine') throw new Error('legacy timezone probe did not use the engine path')
+  expect(probe.session_timezone).not.toBe('UTC')
+  expect(probe.observed_at).toBe('2026-08-10T08:00:00+08:00')
+}
+
+function expectFullUtcProbe(probe: TimezoneProbe): void {
+  expect(probe.kind).toBe('data-api')
+  if (probe.kind !== 'data-api') throw new Error('full timezone probe did not use the Data API path')
+  expect(probe.session_timezone).toBe('UTC')
+  expect(probe.table_observed_at).toBe('2026-08-10T00:00:00+00:00')
+  expect(probe.rpc_observed_at).toBe('2026-08-10T00:00:00+00:00')
+}
+
+function expectMinimalUtcProbe(probe: TimezoneProbe): void {
+  expect(probe.kind).toBe('engine')
+  if (probe.kind !== 'engine') throw new Error('minimal timezone probe did not use the engine path')
+  expect(probe.session_timezone).toBe('UTC')
+  expect(probe.observed_at).toBe('2026-08-10T00:00:00+00:00')
+}
+
+function expectCustomTimezone(probe: TimezoneProbe): void {
+  expect(probe.kind).toBe('data-api')
+  if (probe.kind !== 'data-api') throw new Error('custom timezone probe did not use the Data API path')
+  expect(probe.session_timezone).toBe('Asia/Shanghai')
+  expect(probe.table_observed_at).toBe('2026-08-10T08:00:00+08:00')
+  expect(probe.rpc_observed_at).toBe('2026-08-10T08:00:00+08:00')
+}
+
+function parseTimezoneProbe(serializedProbe: string): TimezoneProbe {
+  const parsedProbe: unknown = JSON.parse(serializedProbe)
+  if (typeof parsedProbe !== 'object' || parsedProbe === null) throw new Error('timezone probe returned no object')
+  const probeRecord = parsedProbe as Record<string, unknown>
+  if (typeof probeRecord.session_timezone !== 'string') throw new Error('timezone probe omitted session timezone')
+  if (probeRecord.kind === 'engine' && typeof probeRecord.observed_at === 'string') {
+    return {
+      kind: 'engine',
+      session_timezone: probeRecord.session_timezone,
+      observed_at: probeRecord.observed_at,
+    }
+  }
+  if (
+    probeRecord.kind === 'data-api'
+    && typeof probeRecord.table_observed_at === 'string'
+    && typeof probeRecord.rpc_observed_at === 'string'
+  ) {
+    return {
+      kind: 'data-api',
+      session_timezone: probeRecord.session_timezone,
+      table_observed_at: probeRecord.table_observed_at,
+      rpc_observed_at: probeRecord.rpc_observed_at,
+    }
+  }
+  throw new Error('timezone probe returned an invalid shape')
+}


### PR DESCRIPTION
## Summary

- default SupaCloud Lite PGlite databases to UTC instead of inheriting the host timezone
- persist the UTC database default for fresh and upgraded data directories
- preserve an explicit ALTER DATABASE timezone and restore it to PGlite's current single-user session
- close a ready PGlite instance before releasing its data lock when timezone initialization fails

## Root cause

PGlite initdb persisted the host timezone. A project first opened on an Asia/Shanghai host therefore kept serializing timestamptz values as +08:00, even after reopening the process with TZ=UTC. Lite builds REST and RPC JSON inside PostgreSQL, so the session timezone leaked directly into PostgREST-compatible responses.

Supabase databases default to UTC while allowing an explicit database-level override: https://supabase.com/docs/guides/database/postgres/configuration

## TDD evidence

- Before the fix, the regression probe received Etc/GMT-8 and 2026-08-10T08:00:00+08:00.
- The matrix covers fresh/reopen x full/minimal bootstraps.
- Full probes exercise both the REST table endpoint and scalar RPC endpoint.
- A separate case verifies an explicit Asia/Shanghai database timezone remains effective.
- An injected initialization failure first reproduced closed=false; after the fix the ready instance is closed before its lock is released.

## Verification

- TZ=UTC bun test test/pglite-engine.test.ts --timeout 60000: 3 passed, 37 assertions
- related integration and runtime-upgrade tests: 14 passed, 104 assertions
- bun run typecheck
- bun run check (full tests, build, package smoke, host standalone build, standalone smoke)
- git diff --check
- independent verifier: PASS, no blocking findings
