### PR TITLE
feat(admin): report deployed platform versions

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -27,10 +27,18 @@ Examples:
 ```bash
 npx @supacloud/admin status
 npx @supacloud/admin ssh ping
+npx @supacloud/admin ssh versions
 npx @supacloud/admin ssh diagnose
 npx @supacloud/admin project create --name my-app
 npx @supacloud/admin project list
 ```
+
+`ssh versions` emits JSON with `schema_version: 1` and fixed
+`management_api`, `edge_runtime`, `caddy`, and `web_console` component fields.
+Each component reports `status` as `ok`, `unknown`, or `error`; a failed probe
+never substitutes a guessed version. Binary evidence is bound to the active
+systemd `ExecStart`, and Web Console evidence comes from its component marker
+plus an explicit `tree_sha256` digest.
 
 ## Verified platform upgrades
 

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createAdminTools } from "./index";
 import { formatCliError } from "./shared/cli";
+import { schemaEnumValues } from "./shared/schema";
 import packageMetadata from "../package.json" with { type: "json" };
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
@@ -105,6 +106,12 @@ const baseContext = {
 };
 
 describe("admin SSH registration gate", () => {
+    test("keeps the versions action in the disabled SSH schema", () => {
+        const tools = createAdminTools(baseContext);
+
+        expect(schemaEnumValues(tools.ssh.schema.action)).toContain("versions");
+    });
+
     test("does not register executable SSH tools without a verified host fingerprint", () => {
         const tools = createAdminTools(baseContext);
         expect(tools.project.schema.name).toBeDefined();

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -29,7 +29,7 @@ const platformActionSchema = stringEnum([
     "list_orgs", "get_org",
 ]);
 const sshActionSchema = stringEnum([
-    "ping", "setup", "install", "upgrade", "diagnose", "exec",
+    "ping", "setup", "install", "upgrade", "versions", "diagnose", "exec",
     "troubleshoot", "container_logs",
     "tenant_manage", "tenant_list", "tenant_inspect", "tenant_diagnose", "tenant_migrate",
 ]);
@@ -79,6 +79,7 @@ EXAMPLES
 
   supacloud-admin status
   supacloud-admin ssh ping
+  supacloud-admin ssh versions
   supacloud-admin ssh install --public_domain api.example.com --studio_domain studio.example.com
   supacloud-admin project create --name my-app
   supacloud-admin project list

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../../management-api/src/sigstore-trusted-root";
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+type FakeExecResult = { success: boolean; stdout: string; stderr: string; code: number };
 
 class FakeSsh {
     readonly commands: string[] = [];
@@ -36,6 +37,7 @@ class FakeSsh {
     diagnosticExecFails = false;
     diagnosticFailureStdout = "";
     diagnosticFailureStderr = "diagnostic failed";
+    readonly matchingExecResults: Array<{ fragment: string; execution: FakeExecResult }> = [];
 
     async ping(): Promise<boolean> {
         return this.pingResult;
@@ -44,6 +46,8 @@ class FakeSsh {
     async exec(command: string, timeoutMs?: number): Promise<{ success: boolean; stdout: string; stderr: string; code: number }> {
         this.commands.push(command);
         this.timeouts.push(timeoutMs);
+        const fixedExecution = this.matchingExecResults.find(candidate => command.includes(candidate.fragment));
+        if (fixedExecution) return fixedExecution.execution;
         if (this.upgradeExecThrows && command.includes("UPGRADE_RUNNER")) {
             throw new Error("connection dropped");
         }
@@ -128,6 +132,48 @@ function captureSshTool(ssh: FakeSsh): {
         parse: (args) => parseToolArguments(registeredSchema, args),
         invoke: (args) => handler!(parseToolArguments(registeredSchema, args)),
     };
+}
+
+function fakeSuccess(stdout: string): FakeExecResult {
+    return { success: true, stdout, stderr: "", code: 0 };
+}
+
+function addFakeExecution(ssh: FakeSsh, fragment: string, execution: FakeExecResult): void {
+    ssh.matchingExecResults.push({ fragment, execution });
+}
+
+function addBinaryVersionFixture(
+    ssh: FakeSsh,
+    fixture: { unit: string; executablePath: string; versionOutput: string; sha256: string },
+): void {
+    const { unit, executablePath, versionOutput, sha256 } = fixture;
+    addFakeExecution(ssh, `-- ${unit}`, fakeSuccess([
+        "LoadState=loaded",
+        `ExecStart={ path=${executablePath} ; argv[]=${executablePath} ; ignore_errors=no ; }`,
+        "",
+    ].join("\n")));
+    const versionArgument = unit === "supacloud-caddy.service" ? "version" : "--version";
+    addFakeExecution(ssh, `${executablePath} ${versionArgument} 2>&1`, fakeSuccess(`${versionOutput}\n`));
+    addFakeExecution(ssh, `sha256sum -- ${executablePath}`, fakeSuccess(`${sha256}\n`));
+}
+
+function addPlatformVersionFixture(ssh: FakeSsh): void {
+    addBinaryVersionFixture(ssh, {
+        unit: "supacloud.service", executablePath: "/usr/local/bin/supacloud",
+        versionOutput: "SupaCloud Version: 0.50.34", sha256: "1".repeat(64),
+    });
+    addBinaryVersionFixture(ssh, {
+        unit: "supacloud-edge-runtime.service", executablePath: "/usr/local/bin/supacloud-edge-runtime",
+        versionOutput: "supacloud-edge-runtime 0.16.9", sha256: "2".repeat(64),
+    });
+    addBinaryVersionFixture(ssh, {
+        unit: "supacloud-caddy.service", executablePath: "/usr/local/bin/supacloud-caddy",
+        versionOutput: "v2.11.4", sha256: "3".repeat(64),
+    });
+    addFakeExecution(ssh, "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'", fakeSuccess(
+        '{"schema_version":1,"component":"web-console","version":"0.28.8","future":true}\n',
+    ));
+    addFakeExecution(ssh, 'find -H "$ROOT"', fakeSuccess(`${"4".repeat(64)}\n`));
 }
 
 const UPGRADE_SIGNALS = ["HUP", "INT", "TERM"] as const;
@@ -325,6 +371,8 @@ describe("ssh admin tool", () => {
             { action: "upgrade", artifact_transport: "local" },
             { action: "upgrade", artifact_transport: "local", version: "0.50.30" },
             { action: "upgrade", artifact_transport: "local", version: "latest", edge_runtime_version: "0.16.8" },
+            { action: "upgrade", artifact_transport: "local", version: "01.50.30", edge_runtime_version: "0.16.8" },
+            { action: "upgrade", artifact_transport: "local", version: "0.50.30\n", edge_runtime_version: "0.16.8" },
         ]) {
             const ssh = new FakeSsh();
             await expect(captureSshTool(ssh).invoke(args)).rejects.toThrow();
@@ -405,6 +453,8 @@ describe("ssh admin tool", () => {
             { action: "upgrade", edge_runtime_version: "0.16.7" },
             { action: "upgrade", version: "latest", edge_runtime_version: "0.16.7" },
             { action: "upgrade", version: "0.50.27", edge_runtime_version: "latest" },
+            { action: "upgrade", version: "01.50.27", edge_runtime_version: "0.16.7" },
+            { action: "upgrade", version: "0.50.27", edge_runtime_version: "0.16.7\n" },
         ]) {
             const ssh = new FakeSsh();
             await expect(captureSshTool(ssh).invoke(args)).rejects.toThrow();
@@ -984,14 +1034,222 @@ describe("ssh admin tool", () => {
         expect(command).not.toContain("/tmp/supacloud-install.log");
     });
 
-    test("diagnose probes the unauthenticated Management API health endpoint", async () => {
+    test("versions returns stable evidence for canonical platform paths", async () => {
         const ssh = new FakeSsh();
+        addPlatformVersionFixture(ssh);
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const report = JSON.parse(response.content[0]?.text ?? "") as any;
+
+        expect(report.schema_version).toBe(1);
+        expect(Object.keys(report.components)).toEqual([
+            "management_api", "edge_runtime", "caddy", "web_console",
+        ]);
+        expect(report.components.management_api).toEqual({
+            status: "ok",
+            version: "0.50.34",
+            sha256: "1".repeat(64),
+            path: "/usr/local/bin/supacloud",
+            source: "systemd:supacloud.service:ExecStart",
+            error: null,
+        });
+        expect(report.components.edge_runtime.version).toBe("0.16.9");
+        expect(report.components.caddy.version).toBe("2.11.4");
+        expect(report.components.web_console).toEqual({
+            status: "ok",
+            version: "0.28.8",
+            tree_sha256: "4".repeat(64),
+            path: "/opt/supacloud/web-console/current",
+            source: "component_marker_and_tree_sha256",
+            error: null,
+        });
+        for (const command of ssh.commands) {
+            expect(Bun.spawnSync(["bash", "-n", "-c", command]).exitCode).toBe(0);
+        }
+    });
+
+    test("versions supports only repository-confirmed opt binary paths", async () => {
+        const ssh = new FakeSsh();
+        addBinaryVersionFixture(ssh, {
+            unit: "supacloud.service", executablePath: "/opt/supacloud/bin/supacloud",
+            versionOutput: "SupaCloud Version: 0.50.34", sha256: "a".repeat(64),
+        });
+        addBinaryVersionFixture(ssh, {
+            unit: "supacloud-edge-runtime.service", executablePath: "/opt/supacloud/bin/supacloud-edge-runtime",
+            versionOutput: "supacloud-edge-runtime 0.16.9", sha256: "b".repeat(64),
+        });
+        addBinaryVersionFixture(ssh, {
+            unit: "supacloud-caddy.service", executablePath: "/usr/local/bin/supacloud-caddy",
+            versionOutput: "v2.11.4", sha256: "c".repeat(64),
+        });
+        addFakeExecution(ssh, "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'", fakeSuccess(
+            '{"schema_version":1,"component":"web-console","version":"0.28.8"}',
+        ));
+        addFakeExecution(ssh, 'find -H "$ROOT"', fakeSuccess("d".repeat(64)));
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const components = JSON.parse(response.content[0]?.text ?? "").components;
+
+        expect(components.management_api.path).toBe("/opt/supacloud/bin/supacloud");
+        expect(components.edge_runtime.path).toBe("/opt/supacloud/bin/supacloud-edge-runtime");
+        expect(components.management_api.status).toBe("ok");
+        expect(components.edge_runtime.status).toBe("ok");
+    });
+
+    test("versions rejects an unapproved ExecStart without executing it", async () => {
+        const ssh = new FakeSsh();
+        addFakeExecution(ssh, "-- supacloud.service", fakeSuccess([
+            "LoadState=loaded",
+            "ExecStart={ path=/tmp/hostile-supacloud ; argv[]=/tmp/hostile-supacloud ; }",
+        ].join("\n")));
+        addPlatformVersionFixture(ssh);
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const management = JSON.parse(response.content[0]?.text ?? "").components.management_api;
+
+        expect(management.status).toBe("error");
+        expect(management.error).toBe("exec_start_not_allowed");
+        expect(management.path).toBe("/tmp/hostile-supacloud");
+        expect(ssh.commands.some(command => command.startsWith("/tmp/hostile-supacloud"))).toBe(false);
+    });
+
+    test("versions rejects shell syntax embedded in ExecStart", async () => {
+        const ssh = new FakeSsh();
+        addFakeExecution(ssh, "-- supacloud.service", fakeSuccess([
+            "LoadState=loaded",
+            "ExecStart={ path=/usr/local/bin/supacloud$(touch/tmp/owned) ; argv[]=/usr/local/bin/supacloud ; }",
+        ].join("\n")));
+        addPlatformVersionFixture(ssh);
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const management = JSON.parse(response.content[0]?.text ?? "").components.management_api;
+
+        expect(management).toMatchObject({ status: "error", path: null, error: "exec_start_invalid" });
+        expect(ssh.commands.join("\n")).not.toContain("touch/tmp/owned");
+    });
+
+    test("versions distinguishes missing units from malformed systemd output", async () => {
+        const missing = new FakeSsh();
+        addFakeExecution(missing, "-- supacloud.service", fakeSuccess("LoadState=not-found\nExecStart=\n"));
+        addPlatformVersionFixture(missing);
+        const missingResponse = await captureSshTool(missing).invoke({ action: "versions" });
+        expect(JSON.parse(missingResponse.content[0]?.text ?? "").components.management_api).toMatchObject({
+            status: "unknown", path: null, error: "unit_not_loaded",
+        });
+
+        const malformed = new FakeSsh();
+        addFakeExecution(malformed, "-- supacloud.service", fakeSuccess(
+            "LoadState=loaded\nExecStart={ path=/usr/local/bin/supacloud ; }; { path=/tmp/other ; }\n",
+        ));
+        addPlatformVersionFixture(malformed);
+        const malformedResponse = await captureSshTool(malformed).invoke({ action: "versions" });
+        expect(JSON.parse(malformedResponse.content[0]?.text ?? "").components.management_api).toMatchObject({
+            status: "error", path: null, error: "exec_start_invalid",
+        });
+    });
+
+    test("versions preserves successful fields when one fixed probe fails", async () => {
+        const ssh = new FakeSsh();
+        addFakeExecution(ssh, "sha256sum -- /usr/local/bin/supacloud |", {
+            success: false,
+            stdout: "",
+            stderr: "sha256sum failed",
+            code: 1,
+        });
+        addPlatformVersionFixture(ssh);
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const components = JSON.parse(response.content[0]?.text ?? "").components;
+
+        expect(components.management_api).toMatchObject({
+            status: "error",
+            version: "0.50.34",
+            sha256: null,
+            error: "sha256_probe_failed",
+        });
+        expect(components.edge_runtime.status).toBe("ok");
+        expect(components.caddy.status).toBe("ok");
+        expect(components.web_console.status).toBe("ok");
+    });
+
+    test("versions rejects prerelease and build-metadata version output", async () => {
+        for (const versionOutput of ["supacloud-edge-runtime 0.16.9-rc.1", "supacloud-edge-runtime 0.16.9+build.4"]) {
+            const ssh = new FakeSsh();
+            addFakeExecution(
+                ssh,
+                "/usr/local/bin/supacloud-edge-runtime --version 2>&1",
+                fakeSuccess(`${versionOutput}\n`),
+            );
+            addPlatformVersionFixture(ssh);
+
+            const response = await captureSshTool(ssh).invoke({ action: "versions" });
+            const edgeRuntime = JSON.parse(response.content[0]?.text ?? "").components.edge_runtime;
+
+            expect(edgeRuntime).toMatchObject({
+                status: "error",
+                version: null,
+                error: "version_output_invalid",
+            });
+        }
+    });
+
+    test("versions distinguishes missing and malformed Web Console markers", async () => {
+        const missing = new FakeSsh();
+        addFakeExecution(missing, "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'", {
+            success: false, stdout: "", stderr: "", code: 44,
+        });
+        addPlatformVersionFixture(missing);
+        const missingResponse = await captureSshTool(missing).invoke({ action: "versions" });
+        const missingWeb = JSON.parse(missingResponse.content[0]?.text ?? "").components.web_console;
+        expect(missingWeb).toMatchObject({ status: "unknown", version: null, error: "marker_missing" });
+
+        for (const invalidMarker of [
+            '{"schema_version":2,"component":"web-console","version":"0.28.8"}',
+            '{"schema_version":1,"component":"web-console","version":"01.2.3"}',
+            '{"schema_version":1,"component":"web-console","version":"0.28.8-rc.1"}',
+            '{"schema_version":1,"component":"web-console","version":"0.28.8+build"}',
+            '{"schema_version":1,"component":"web-console","version":"0.28.8\\n"}',
+        ]) {
+            const invalid = new FakeSsh();
+            addFakeExecution(
+                invalid,
+                "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'",
+                fakeSuccess(invalidMarker),
+            );
+            addPlatformVersionFixture(invalid);
+
+            const invalidResponse = await captureSshTool(invalid).invoke({ action: "versions" });
+            const invalidWeb = JSON.parse(invalidResponse.content[0]?.text ?? "").components.web_console;
+
+            expect(invalidWeb).toMatchObject({ status: "error", version: null, error: "marker_invalid" });
+        }
+    });
+
+    test("diagnose returns bounded Management health bodies without assuming a PostgreSQL socket", async () => {
+        const ssh = new FakeSsh();
+        addFakeExecution(ssh, "set -o pipefail", fakeSuccess([
+            "=== Management API /health ===",
+            '{"status":"ok"}',
+            "=== Management API /monitor/health ===",
+            '{"status":"healthy"}',
+        ].join("\n")));
         const tool = captureSshTool(ssh);
 
-        await tool.invoke({ action: "diagnose" });
+        const response = await tool.invoke({ action: "diagnose" });
         const command = ssh.commands.at(-1) ?? "";
 
-        expect(command).toContain("http://localhost:9090/health");
+        expect(response.content[0]?.text).toContain('{"status":"ok"}');
+        expect(response.content[0]?.text).toContain('{"status":"healthy"}');
+        expect(command).toContain("set -o pipefail");
+        expect(command).toContain("http://127.0.0.1:9090/health");
+        expect(command).toContain("http://127.0.0.1:9090/monitor/health");
+        expect(command).toContain("--max-time 5 --max-filesize 4096");
+        expect(command).toContain("--max-time 15 --max-filesize 16384");
+        expect(command).toContain("head -c 4096");
+        expect(command).toContain("head -c 16384");
+        expect(command).not.toContain("pg_isready");
+        expect(command).not.toContain("Not detected");
+        expect(command).not.toContain("> /dev/null");
         expect(command).not.toContain("http://localhost:9090/v1/projects");
     });
 

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -16,6 +17,7 @@ import {
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
 type FakeExecResult = { success: boolean; stdout: string; stderr: string; code: number };
+type FakeExecPlan = { fragment: string; executions: FakeExecResult[]; calls: number };
 
 class FakeSsh {
     readonly commands: string[] = [];
@@ -37,7 +39,7 @@ class FakeSsh {
     diagnosticExecFails = false;
     diagnosticFailureStdout = "";
     diagnosticFailureStderr = "diagnostic failed";
-    readonly matchingExecResults: Array<{ fragment: string; execution: FakeExecResult }> = [];
+    readonly matchingExecResults: FakeExecPlan[] = [];
 
     async ping(): Promise<boolean> {
         return this.pingResult;
@@ -46,8 +48,12 @@ class FakeSsh {
     async exec(command: string, timeoutMs?: number): Promise<{ success: boolean; stdout: string; stderr: string; code: number }> {
         this.commands.push(command);
         this.timeouts.push(timeoutMs);
-        const fixedExecution = this.matchingExecResults.find(candidate => command.includes(candidate.fragment));
-        if (fixedExecution) return fixedExecution.execution;
+        const fixedPlan = this.matchingExecResults.find(candidate => command.includes(candidate.fragment));
+        if (fixedPlan) {
+            const executionIndex = Math.min(fixedPlan.calls, fixedPlan.executions.length - 1);
+            fixedPlan.calls += 1;
+            return fixedPlan.executions[executionIndex]!;
+        }
         if (this.upgradeExecThrows && command.includes("UPGRADE_RUNNER")) {
             throw new Error("connection dropped");
         }
@@ -139,7 +145,87 @@ function fakeSuccess(stdout: string): FakeExecResult {
 }
 
 function addFakeExecution(ssh: FakeSsh, fragment: string, execution: FakeExecResult): void {
-    ssh.matchingExecResults.push({ fragment, execution });
+    ssh.matchingExecResults.push({ fragment, executions: [execution], calls: 0 });
+}
+
+function addFakeExecutionSequence(
+    ssh: FakeSsh,
+    fragment: string,
+    executions: FakeExecResult[],
+): FakeExecPlan {
+    if (executions.length === 0) throw new Error("Fake execution sequence must not be empty");
+    const plan = { fragment, executions, calls: 0 };
+    ssh.matchingExecResults.push(plan);
+    return plan;
+}
+
+function fakeSystemdExecStart(executablePath: string): FakeExecResult {
+    return fakeSuccess([
+        "LoadState=loaded",
+        `ExecStart={ path=${executablePath} ; argv[]=${executablePath} ; ignore_errors=no ; }`,
+        "",
+    ].join("\n"));
+}
+
+function fakeBinaryProbeSuccess(
+    fixture: { versionOutput: string; sha256: string },
+): FakeExecResult {
+    return fakeSuccess([
+        `SUPACLOUD_BINARY_HASH_BEFORE=${fixture.sha256}`,
+        `SUPACLOUD_BINARY_VERSION_BASE64=${Buffer.from(fixture.versionOutput).toString("base64")}`,
+        `SUPACLOUD_BINARY_HASH_AFTER=${fixture.sha256}`,
+        "",
+    ].join("\n"));
+}
+
+function fakeBinaryProbeChanged(
+    fixture: { versionOutput: string; hashBefore: string; hashAfter: string },
+): FakeExecResult {
+    return {
+        success: false,
+        stdout: [
+            `SUPACLOUD_BINARY_HASH_BEFORE=${fixture.hashBefore}`,
+            `SUPACLOUD_BINARY_VERSION_BASE64=${Buffer.from(fixture.versionOutput).toString("base64")}`,
+            `SUPACLOUD_BINARY_HASH_AFTER=${fixture.hashAfter}`,
+            "",
+        ].join("\n"),
+        stderr: "",
+        code: 75,
+    };
+}
+
+function fakeBinaryProbeAfterHashFailure(versionOutput: string, hashBefore: string): FakeExecResult {
+    return {
+        success: false,
+        stdout: [
+            `SUPACLOUD_BINARY_HASH_BEFORE=${hashBefore}`,
+            `SUPACLOUD_BINARY_VERSION_BASE64=${Buffer.from(versionOutput).toString("base64")}`,
+            "",
+        ].join("\n"),
+        stderr: "sha256sum failed",
+        code: 72,
+    };
+}
+
+function fakeWebConsoleProbe(
+    markerOutput: string,
+    treeSha256: string,
+    changes: { root?: string; rootId?: string; marker?: string; tree?: string } = {},
+): FakeExecResult {
+    const rootBefore = "/opt/supacloud/web-console/releases/0.28.8-123-456";
+    const rootIdBefore = "1:2";
+    const markerBefore = Buffer.from(markerOutput).toString("base64");
+    return fakeSuccess([
+        `SUPACLOUD_WEB_ROOT_REAL_BEFORE=${rootBefore}`,
+        `SUPACLOUD_WEB_ROOT_ID_BEFORE=${rootIdBefore}`,
+        `SUPACLOUD_WEB_MARKER_BASE64_BEFORE=${markerBefore}`,
+        `SUPACLOUD_WEB_TREE_SHA256_BEFORE=${treeSha256}`,
+        `SUPACLOUD_WEB_TREE_SHA256_AFTER=${changes.tree ?? treeSha256}`,
+        `SUPACLOUD_WEB_MARKER_BASE64_AFTER=${Buffer.from(changes.marker ?? markerOutput).toString("base64")}`,
+        `SUPACLOUD_WEB_ROOT_REAL_AFTER=${changes.root ?? rootBefore}`,
+        `SUPACLOUD_WEB_ROOT_ID_AFTER=${changes.rootId ?? rootIdBefore}`,
+        "",
+    ].join("\n"));
 }
 
 function addBinaryVersionFixture(
@@ -147,14 +233,11 @@ function addBinaryVersionFixture(
     fixture: { unit: string; executablePath: string; versionOutput: string; sha256: string },
 ): void {
     const { unit, executablePath, versionOutput, sha256 } = fixture;
-    addFakeExecution(ssh, `-- ${unit}`, fakeSuccess([
-        "LoadState=loaded",
-        `ExecStart={ path=${executablePath} ; argv[]=${executablePath} ; ignore_errors=no ; }`,
-        "",
-    ].join("\n")));
-    const versionArgument = unit === "supacloud-caddy.service" ? "version" : "--version";
-    addFakeExecution(ssh, `${executablePath} ${versionArgument} 2>&1`, fakeSuccess(`${versionOutput}\n`));
-    addFakeExecution(ssh, `sha256sum -- ${executablePath}`, fakeSuccess(`${sha256}\n`));
+    addFakeExecution(ssh, `-- ${unit}`, fakeSystemdExecStart(executablePath));
+    addFakeExecution(ssh, `sha256sum -- '${executablePath}'`, fakeBinaryProbeSuccess({
+        versionOutput: `${versionOutput}\n`,
+        sha256,
+    }));
 }
 
 function addPlatformVersionFixture(ssh: FakeSsh): void {
@@ -170,10 +253,19 @@ function addPlatformVersionFixture(ssh: FakeSsh): void {
         unit: "supacloud-caddy.service", executablePath: "/usr/local/bin/supacloud-caddy",
         versionOutput: "v2.11.4", sha256: "3".repeat(64),
     });
-    addFakeExecution(ssh, "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'", fakeSuccess(
+    addFakeExecution(ssh, "ROOT='/opt/supacloud/web-console/current'", fakeWebConsoleProbe(
         '{"schema_version":1,"component":"web-console","version":"0.28.8","future":true}\n',
+        "4".repeat(64),
     ));
-    addFakeExecution(ssh, 'find -H "$ROOT"', fakeSuccess(`${"4".repeat(64)}\n`));
+}
+
+async function generatedPlatformProbeCommand(commandFragment: string): Promise<string> {
+    const ssh = new FakeSsh();
+    addPlatformVersionFixture(ssh);
+    await captureSshTool(ssh).invoke({ action: "versions" });
+    const command = ssh.commands.find(candidate => candidate.includes(commandFragment));
+    if (!command) throw new Error(`Generated platform probe is missing: ${commandFragment}`);
+    return command;
 }
 
 const UPGRADE_SIGNALS = ["HUP", "INT", "TERM"] as const;
@@ -182,6 +274,21 @@ const RELEASE_ASSETS_SCRIPT = join(import.meta.dir, "../../../../../scripts/lib/
 function writeExecutableShell(filePath: string, shellSource: string): void {
     writeFileSync(filePath, shellSource);
     chmodSync(filePath, 0o755);
+}
+
+function writeDarwinStatCompatibility(commandDir: string): void {
+    if (process.platform !== "darwin") return;
+    writeExecutableShell(join(commandDir, "stat"), [
+        "#!/bin/sh",
+        "if [ \"$1\" = '-c' ] && [ \"$3\" = '--' ]; then",
+        "  case \"$2\" in",
+        "    '%d:%i') exec /usr/bin/stat -f '%d:%i' \"$4\" ;;",
+        "    '%s') exec /usr/bin/stat -f '%z' \"$4\" ;;",
+        "  esac",
+        "fi",
+        "exit 64",
+        "",
+    ].join("\n"));
 }
 
 function writeFakeGh(filePath: string, version: string): void {
@@ -376,6 +483,16 @@ describe("ssh admin tool", () => {
         ]) {
             const ssh = new FakeSsh();
             await expect(captureSshTool(ssh).invoke(args)).rejects.toThrow();
+            expect(ssh.uploads).toHaveLength(0);
+            expect(ssh.commands).toHaveLength(0);
+        }
+    });
+
+    test("remote Management upgrades reject explicit non-stable versions before remote access", async () => {
+        for (const version of ["latest", "01.50.30", "0.50.30-rc.1", "0.50.30+build.4", "0.50.30\n"]) {
+            const ssh = new FakeSsh();
+            await expect(captureSshTool(ssh).invoke({ action: "upgrade", version }))
+                .rejects.toThrow();
             expect(ssh.uploads).toHaveLength(0);
             expect(ssh.commands).toHaveLength(0);
         }
@@ -1063,8 +1180,417 @@ describe("ssh admin tool", () => {
             source: "component_marker_and_tree_sha256",
             error: null,
         });
+        const managementProbe = ssh.commands.find(command => (
+            command.includes("HASH_BEFORE=$(sha256sum -- '/usr/local/bin/supacloud'")
+        )) ?? "";
+        const hashBeforeIndex = managementProbe.indexOf("HASH_BEFORE=$(sha256sum");
+        const versionIndex = managementProbe.indexOf("VERSION_BASE64=$(");
+        const hashAfterIndex = managementProbe.indexOf("HASH_AFTER=$(sha256sum");
+        expect(hashBeforeIndex).toBeGreaterThanOrEqual(0);
+        expect(versionIndex).toBeGreaterThan(hashBeforeIndex);
+        expect(hashAfterIndex).toBeGreaterThan(versionIndex);
+        expect(managementProbe.match(/sha256sum -- '\/usr\/local\/bin\/supacloud'/g)).toHaveLength(2);
+        expect(managementProbe).toContain("| head -c 2049 | base64 |");
+        const webProbe = ssh.commands.find(command => command.includes("web_tree_sha256()")) ?? "";
+        expect(webProbe.indexOf("ROOT_REAL_BEFORE=")).toBeLessThan(webProbe.indexOf("TREE_BEFORE="));
+        expect(webProbe.indexOf("TREE_BEFORE=")).toBeLessThan(webProbe.indexOf("TREE_AFTER="));
+        expect(webProbe.indexOf("TREE_AFTER=")).toBeLessThan(webProbe.indexOf("ROOT_REAL_AFTER="));
+        expect(webProbe.match(/head -c 4097 --/g)).toHaveLength(2);
         for (const command of ssh.commands) {
             expect(Bun.spawnSync(["bash", "-n", "-c", command]).exitCode).toBe(0);
+        }
+    });
+
+    test("the fixed Web Console probe executes a real stable release tree", async () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-probe-")));
+        const releaseRoot = join(fixtureRoot, "releases", "0.28.8-test");
+        const commandDir = join(fixtureRoot, "commands");
+        try {
+            mkdirSync(releaseRoot, { recursive: true });
+            mkdirSync(commandDir, { recursive: true });
+            writeDarwinStatCompatibility(commandDir);
+            const markerSource = '{"schema_version":1,"component":"web-console","version":"0.28.8"}\n';
+            const indexSource = "<!doctype html><title>SupaCloud</title>\n";
+            writeFileSync(join(releaseRoot, ".supacloud-component.json"), markerSource);
+            writeFileSync(join(releaseRoot, "index.html"), indexSource);
+            symlinkSync(releaseRoot, join(fixtureRoot, "current"));
+
+            const generatedProbe = await generatedPlatformProbeCommand("web_tree_sha256()");
+            const localProbe = generatedProbe.replaceAll("/opt/supacloud/web-console", fixtureRoot);
+            const execution = Bun.spawnSync(["bash", "-c", localProbe], {
+                env: { ...process.env, PATH: `${commandDir}:${process.env.PATH ?? ""}` },
+            });
+
+            expect(execution.exitCode).toBe(0);
+            expect(execution.stderr.toString()).toBe("");
+            const normalizedOutput = execution.stdout.toString().replaceAll(
+                fixtureRoot,
+                "/opt/supacloud/web-console",
+            );
+            const parserSsh = new FakeSsh();
+            addFakeExecution(
+                parserSsh,
+                "ROOT='/opt/supacloud/web-console/current'",
+                fakeSuccess(normalizedOutput),
+            );
+            addPlatformVersionFixture(parserSsh);
+
+            const response = await captureSshTool(parserSsh).invoke({ action: "versions" });
+            const webConsole = JSON.parse(response.content[0]?.text ?? "").components.web_console;
+
+            expect(webConsole).toMatchObject({
+                status: "ok",
+                version: "0.28.8",
+                error: null,
+            });
+            const markerSha256 = createHash("sha256").update(markerSource).digest("hex");
+            const indexSha256 = createHash("sha256").update(indexSource).digest("hex");
+            const treeInput = [
+                `${markerSha256}  ./.supacloud-component.json`,
+                `${indexSha256}  ./index.html`,
+                "",
+            ].join("\n");
+            expect(webConsole.tree_sha256).toBe(createHash("sha256").update(treeInput).digest("hex"));
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("the fixed Web Console probe rejects linked and special-file markers", async () => {
+        const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-invalid-marker-")));
+        const commandDir = join(fixtureRoot, "commands");
+        try {
+            mkdirSync(commandDir, { recursive: true });
+            writeDarwinStatCompatibility(commandDir);
+            const generatedProbe = await generatedPlatformProbeCommand("web_tree_sha256()");
+            const spawnProbe = (webRoot: string) => Bun.spawnSync([
+                "bash",
+                "-c",
+                generatedProbe.replaceAll("/opt/supacloud/web-console", webRoot),
+            ], {
+                env: { ...process.env, PATH: `${commandDir}:${process.env.PATH ?? ""}` },
+            });
+
+            const linkedRoot = join(fixtureRoot, "linked");
+            const linkedRelease = join(linkedRoot, "releases", "0.28.8-test");
+            mkdirSync(linkedRelease, { recursive: true });
+            symlinkSync(linkedRelease, join(linkedRoot, "current"));
+            const markerTarget = join(linkedRoot, "marker-target.json");
+            writeFileSync(markerTarget, '{"schema_version":1,"component":"web-console","version":"0.28.8"}\n');
+            symlinkSync(markerTarget, join(linkedRelease, ".supacloud-component.json"));
+            expect(spawnProbe(linkedRoot).exitCode).toBe(65);
+
+            const specialRoot = join(fixtureRoot, "special");
+            const specialRelease = join(specialRoot, "releases", "0.28.8-test");
+            mkdirSync(specialRelease, { recursive: true });
+            symlinkSync(specialRelease, join(specialRoot, "current"));
+            const fifoPath = join(specialRelease, ".supacloud-component.json");
+            const mkfifoPath = Bun.which("mkfifo");
+            if (!mkfifoPath) throw new Error("Required test command is unavailable: mkfifo");
+            expect(Bun.spawnSync([mkfifoPath, fifoPath]).exitCode).toBe(0);
+            expect(spawnProbe(specialRoot).exitCode).toBe(65);
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("versions rejects binary evidence when the executable changes during one probe", async () => {
+        const ssh = new FakeSsh();
+        addFakeExecution(
+            ssh,
+            "sha256sum -- '/usr/local/bin/supacloud'",
+            fakeBinaryProbeChanged({
+                versionOutput: "SupaCloud Version: 0.50.34\n",
+                hashBefore: "1".repeat(64),
+                hashAfter: "9".repeat(64),
+            }),
+        );
+        addPlatformVersionFixture(ssh);
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const components = JSON.parse(response.content[0]?.text ?? "").components;
+
+        expect(components.management_api).toMatchObject({
+            status: "error",
+            version: null,
+            sha256: null,
+            error: "binary_changed_during_probe",
+        });
+        expect(components.edge_runtime.status).toBe("ok");
+        expect(components.caddy.status).toBe("ok");
+        expect(components.web_console.status).toBe("ok");
+    });
+
+    test("the fixed binary probe exits 75 when version execution replaces its file", async () => {
+        const fixtureRoot = mkdtempSync(join(tmpdir(), "supacloud-binary-probe-race-"));
+        const executablePath = join(fixtureRoot, "supacloud");
+        try {
+            writeExecutableShell(executablePath, [
+                "#!/bin/bash",
+                "printf 'SupaCloud Version: 0.50.34\\n'",
+                "NEXT_PATH=\"${0}.next\"",
+                "printf '%s\\n' '#!/bin/sh' \"printf 'SupaCloud Version: 0.50.35\\\\n'\" > \"$NEXT_PATH\"",
+                "chmod 0755 \"$NEXT_PATH\"",
+                "mv -f \"$NEXT_PATH\" \"$0\"",
+                "",
+            ].join("\n"));
+            const ssh = new FakeSsh();
+            addPlatformVersionFixture(ssh);
+            await captureSshTool(ssh).invoke({ action: "versions" });
+            const fixedProbe = ssh.commands.find(command => (
+                command.includes("HASH_BEFORE=$(sha256sum -- '/usr/local/bin/supacloud'")
+            )) ?? "";
+            expect(executablePath).not.toContain("'");
+            const localProbe = fixedProbe.replaceAll(
+                "'/usr/local/bin/supacloud'",
+                `'${executablePath}'`,
+            );
+
+            const execution = Bun.spawnSync(["bash", "-c", localProbe]);
+            expect(execution.exitCode).toBe(75);
+        } finally {
+            rmSync(fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("versions clears binary evidence when systemd ExecStart changes after the probe", async () => {
+        const ssh = new FakeSsh();
+        const systemdPlan = addFakeExecutionSequence(ssh, "-- supacloud.service", [
+            fakeSystemdExecStart("/usr/local/bin/supacloud"),
+            fakeSystemdExecStart("/opt/supacloud/bin/supacloud"),
+        ]);
+        addFakeExecution(
+            ssh,
+            "sha256sum -- '/usr/local/bin/supacloud'",
+            fakeBinaryProbeSuccess({ versionOutput: "SupaCloud Version: 0.50.34\n", sha256: "1".repeat(64) }),
+        );
+        addPlatformVersionFixture(ssh);
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const management = JSON.parse(response.content[0]?.text ?? "").components.management_api;
+
+        expect(systemdPlan.calls).toBe(2);
+        expect(management).toMatchObject({
+            status: "error",
+            version: null,
+            sha256: null,
+            path: "/usr/local/bin/supacloud",
+            error: "exec_start_changed_during_probe",
+        });
+    });
+
+    test("versions rejects each Web Console snapshot change without cross-generation evidence", async () => {
+        const stableMarker = '{"schema_version":1,"component":"web-console","version":"0.28.8"}\n';
+        const changes = [
+            {
+                fixture: { root: "/opt/supacloud/web-console/releases/0.28.9-789-012" },
+                error: "web_console_root_changed_during_probe",
+            },
+            {
+                fixture: { marker: '{"schema_version":1,"component":"web-console","version":"0.28.9"}\n' },
+                error: "marker_changed_during_probe",
+            },
+            { fixture: { tree: "8".repeat(64) }, error: "tree_sha256_changed_during_probe" },
+        ];
+
+        for (const change of changes) {
+            const ssh = new FakeSsh();
+            addFakeExecution(
+                ssh,
+                "ROOT='/opt/supacloud/web-console/current'",
+                fakeWebConsoleProbe(stableMarker, "4".repeat(64), change.fixture),
+            );
+            addPlatformVersionFixture(ssh);
+
+            const response = await captureSshTool(ssh).invoke({ action: "versions" });
+            const webConsole = JSON.parse(response.content[0]?.text ?? "").components.web_console;
+
+            expect(webConsole).toMatchObject({
+                status: "error",
+                version: null,
+                tree_sha256: null,
+                error: change.error,
+            });
+        }
+    });
+
+    test("versions accepts 2048 binary-version bytes and rejects 2049", async () => {
+        const versionPrefix = "SupaCloud Version: 0.50.34";
+        for (const outputBytes of [2048, 2049]) {
+            const versionOutput = `${versionPrefix}${" ".repeat(outputBytes - versionPrefix.length)}`;
+            expect(Buffer.byteLength(versionOutput)).toBe(outputBytes);
+            const ssh = new FakeSsh();
+            addFakeExecution(
+                ssh,
+                "sha256sum -- '/usr/local/bin/supacloud'",
+                fakeBinaryProbeSuccess({ versionOutput, sha256: "1".repeat(64) }),
+            );
+            addPlatformVersionFixture(ssh);
+
+            const response = await captureSshTool(ssh).invoke({ action: "versions" });
+            const management = JSON.parse(response.content[0]?.text ?? "").components.management_api;
+
+            expect(management.status).toBe(outputBytes === 2048 ? "ok" : "error");
+            expect(management.version).toBe(outputBytes === 2048 ? "0.50.34" : null);
+        }
+    });
+
+    test("versions fails closed for malformed binary tagged output", async () => {
+        const hash = "1".repeat(64);
+        const versionBase64 = Buffer.from("SupaCloud Version: 0.50.34\n").toString("base64");
+        const validLines = [
+            `SUPACLOUD_BINARY_HASH_BEFORE=${hash}`,
+            `SUPACLOUD_BINARY_VERSION_BASE64=${versionBase64}`,
+            `SUPACLOUD_BINARY_HASH_AFTER=${hash}`,
+        ];
+        const hashLines = (invalidHash: string) => [
+            `SUPACLOUD_BINARY_HASH_BEFORE=${invalidHash}`,
+            validLines[1]!,
+            `SUPACLOUD_BINARY_HASH_AFTER=${invalidHash}`,
+        ];
+        const invalidUtf8 = Buffer.from([0xc3, 0x28]).toString("base64");
+        const invalidOutputs = [
+            { name: "missing label", output: `${validLines[0]}\n${validLines[2]}\n` },
+            { name: "duplicate label", output: `${[validLines[0], validLines[1], validLines[1], validLines[2]].join("\n")}\n` },
+            { name: "wrong order", output: `${[validLines[1], validLines[0], validLines[2]].join("\n")}\n` },
+            { name: "extra label", output: `${[...validLines, "SUPACLOUD_BINARY_EXTRA=1"].join("\n")}\n` },
+            { name: "empty base64", output: `${[validLines[0], "SUPACLOUD_BINARY_VERSION_BASE64=", validLines[2]].join("\n")}\n` },
+            { name: "invalid base64", output: `${[validLines[0], "SUPACLOUD_BINARY_VERSION_BASE64=%%%%", validLines[2]].join("\n")}\n` },
+            { name: "non-canonical base64", output: `${[validLines[0], "SUPACLOUD_BINARY_VERSION_BASE64=Zh==", validLines[2]].join("\n")}\n` },
+            { name: "invalid UTF-8", output: `${[validLines[0], `SUPACLOUD_BINARY_VERSION_BASE64=${invalidUtf8}`, validLines[2]].join("\n")}\n` },
+            { name: "short hash", output: `${hashLines("1".repeat(63)).join("\n")}\n` },
+            { name: "uppercase hash", output: `${hashLines("A".repeat(64)).join("\n")}\n` },
+            { name: "leading whitespace hash", output: `${hashLines(` ${hash}`).join("\n")}\n` },
+            { name: "trailing whitespace hash", output: `${hashLines(`${hash} `).join("\n")}\n` },
+            { name: "carriage return", output: `${validLines.join("\r\n")}\r\n` },
+        ];
+
+        for (const invalidOutput of invalidOutputs) {
+            const ssh = new FakeSsh();
+            addFakeExecution(
+                ssh,
+                "sha256sum -- '/usr/local/bin/supacloud'",
+                fakeSuccess(invalidOutput.output),
+            );
+            addPlatformVersionFixture(ssh);
+
+            const response = await captureSshTool(ssh).invoke({ action: "versions" });
+            const management = JSON.parse(response.content[0]?.text ?? "").components.management_api;
+
+            expect({ name: invalidOutput.name, status: management.status }).toEqual({
+                name: invalidOutput.name,
+                status: "error",
+            });
+        }
+    });
+
+    test("versions accepts 4096 Web marker bytes and rejects 4097", async () => {
+        const markerPrefix = '{"schema_version":1,"component":"web-console","version":"0.28.8"}';
+        for (const outputBytes of [4096, 4097]) {
+            const markerOutput = `${markerPrefix}${" ".repeat(outputBytes - markerPrefix.length)}`;
+            expect(Buffer.byteLength(markerOutput)).toBe(outputBytes);
+            const ssh = new FakeSsh();
+            addFakeExecution(
+                ssh,
+                "ROOT='/opt/supacloud/web-console/current'",
+                fakeWebConsoleProbe(markerOutput, "4".repeat(64)),
+            );
+            addPlatformVersionFixture(ssh);
+
+            const response = await captureSshTool(ssh).invoke({ action: "versions" });
+            const webConsole = JSON.parse(response.content[0]?.text ?? "").components.web_console;
+
+            expect(webConsole.status).toBe(outputBytes === 4096 ? "ok" : "error");
+            expect(webConsole.version).toBe(outputBytes === 4096 ? "0.28.8" : null);
+        }
+    });
+
+    test("versions fails closed for malformed Web Console tagged output", async () => {
+        const markerOutput = '{"schema_version":1,"component":"web-console","version":"0.28.8"}\n';
+        const validLines = fakeWebConsoleProbe(markerOutput, "4".repeat(64)).stdout.trimEnd().split("\n");
+        const webProbeOutputWith = (...replacements: Array<[number, string]>): string => {
+            const lines = [...validLines];
+            for (const [index, replacement] of replacements) lines[index] = replacement;
+            return `${lines.join("\n")}\n`;
+        };
+        const invalidUtf8 = Buffer.from([0xc3, 0x28]).toString("base64");
+        const invalidOutputs = [
+            { name: "missing label", output: `${validLines.slice(0, -1).join("\n")}\n` },
+            { name: "duplicate label", output: `${[validLines[0], ...validLines].join("\n")}\n` },
+            { name: "wrong order", output: webProbeOutputWith([0, validLines[1]!], [1, validLines[0]!]) },
+            { name: "extra label", output: `${[...validLines, "SUPACLOUD_WEB_EXTRA=1"].join("\n")}\n` },
+            { name: "empty base64", output: webProbeOutputWith([2, "SUPACLOUD_WEB_MARKER_BASE64_BEFORE="]) },
+            { name: "invalid base64", output: webProbeOutputWith([2, "SUPACLOUD_WEB_MARKER_BASE64_BEFORE=%%%%"]) },
+            { name: "non-canonical base64", output: webProbeOutputWith([2, "SUPACLOUD_WEB_MARKER_BASE64_BEFORE=Zh=="]) },
+            { name: "invalid UTF-8", output: webProbeOutputWith([2, `SUPACLOUD_WEB_MARKER_BASE64_BEFORE=${invalidUtf8}`]) },
+            {
+                name: "short hash",
+                output: webProbeOutputWith(
+                    [3, `SUPACLOUD_WEB_TREE_SHA256_BEFORE=${"4".repeat(63)}`],
+                    [4, `SUPACLOUD_WEB_TREE_SHA256_AFTER=${"4".repeat(63)}`],
+                ),
+            },
+            {
+                name: "uppercase hash",
+                output: webProbeOutputWith(
+                    [3, `SUPACLOUD_WEB_TREE_SHA256_BEFORE=${"A".repeat(64)}`],
+                    [4, `SUPACLOUD_WEB_TREE_SHA256_AFTER=${"A".repeat(64)}`],
+                ),
+            },
+            {
+                name: "leading whitespace hash",
+                output: webProbeOutputWith(
+                    [3, `SUPACLOUD_WEB_TREE_SHA256_BEFORE= ${"4".repeat(64)}`],
+                    [4, `SUPACLOUD_WEB_TREE_SHA256_AFTER= ${"4".repeat(64)}`],
+                ),
+            },
+            {
+                name: "trailing whitespace hash",
+                output: webProbeOutputWith(
+                    [3, `SUPACLOUD_WEB_TREE_SHA256_BEFORE=${"4".repeat(64)} `],
+                    [4, `SUPACLOUD_WEB_TREE_SHA256_AFTER=${"4".repeat(64)} `],
+                ),
+            },
+            {
+                name: "invalid root",
+                output: webProbeOutputWith(
+                    [0, "SUPACLOUD_WEB_ROOT_REAL_BEFORE=/tmp/web-console"],
+                    [6, "SUPACLOUD_WEB_ROOT_REAL_AFTER=/tmp/web-console"],
+                ),
+            },
+            {
+                name: "parent release segment",
+                output: webProbeOutputWith(
+                    [0, "SUPACLOUD_WEB_ROOT_REAL_BEFORE=/opt/supacloud/web-console/releases/.."],
+                    [6, "SUPACLOUD_WEB_ROOT_REAL_AFTER=/opt/supacloud/web-console/releases/.."],
+                ),
+            },
+            {
+                name: "invalid root ID",
+                output: webProbeOutputWith(
+                    [1, "SUPACLOUD_WEB_ROOT_ID_BEFORE=device:inode"],
+                    [7, "SUPACLOUD_WEB_ROOT_ID_AFTER=device:inode"],
+                ),
+            },
+            { name: "carriage return", output: `${validLines.join("\r\n")}\r\n` },
+        ];
+
+        for (const invalidOutput of invalidOutputs) {
+            const ssh = new FakeSsh();
+            addFakeExecution(
+                ssh,
+                "ROOT='/opt/supacloud/web-console/current'",
+                fakeSuccess(invalidOutput.output),
+            );
+            addPlatformVersionFixture(ssh);
+
+            const response = await captureSshTool(ssh).invoke({ action: "versions" });
+            const webConsole = JSON.parse(response.content[0]?.text ?? "").components.web_console;
+
+            expect({ name: invalidOutput.name, status: webConsole.status }).toEqual({
+                name: invalidOutput.name,
+                status: "error",
+            });
         }
     });
 
@@ -1082,10 +1608,10 @@ describe("ssh admin tool", () => {
             unit: "supacloud-caddy.service", executablePath: "/usr/local/bin/supacloud-caddy",
             versionOutput: "v2.11.4", sha256: "c".repeat(64),
         });
-        addFakeExecution(ssh, "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'", fakeSuccess(
+        addFakeExecution(ssh, "ROOT='/opt/supacloud/web-console/current'", fakeWebConsoleProbe(
             '{"schema_version":1,"component":"web-console","version":"0.28.8"}',
+            "d".repeat(64),
         ));
-        addFakeExecution(ssh, 'find -H "$ROOT"', fakeSuccess("d".repeat(64)));
 
         const response = await captureSshTool(ssh).invoke({ action: "versions" });
         const components = JSON.parse(response.content[0]?.text ?? "").components;
@@ -1150,12 +1676,11 @@ describe("ssh admin tool", () => {
 
     test("versions preserves successful fields when one fixed probe fails", async () => {
         const ssh = new FakeSsh();
-        addFakeExecution(ssh, "sha256sum -- /usr/local/bin/supacloud |", {
-            success: false,
-            stdout: "",
-            stderr: "sha256sum failed",
-            code: 1,
-        });
+        addFakeExecution(
+            ssh,
+            "sha256sum -- '/usr/local/bin/supacloud'",
+            fakeBinaryProbeAfterHashFailure("SupaCloud Version: 0.50.34\n", "1".repeat(64)),
+        );
         addPlatformVersionFixture(ssh);
 
         const response = await captureSshTool(ssh).invoke({ action: "versions" });
@@ -1172,13 +1697,24 @@ describe("ssh admin tool", () => {
         expect(components.web_console.status).toBe("ok");
     });
 
-    test("versions rejects prerelease and build-metadata version output", async () => {
-        for (const versionOutput of ["supacloud-edge-runtime 0.16.9-rc.1", "supacloud-edge-runtime 0.16.9+build.4"]) {
+    test("versions rejects every non-stable or mixed version output", async () => {
+        for (const versionOutput of [
+            "supacloud-edge-runtime 01.16.9",
+            "supacloud-edge-runtime 0.16.9-rc.1",
+            "supacloud-edge-runtime 0.16.9+build.4",
+            "supacloud-edge-runtime 0.16.9_rc.1",
+            "supacloud-edge-runtime 0.16.9~rc1",
+            "candidate 0.16.9-rc.1 fallback 0.16.9",
+            "candidate 0.16.9+build.4 fallback 0.16.9",
+            "candidate 0.16.9_rc.1 fallback 0.16.9",
+            "candidate 0.16.9~rc1 fallback 0.16.9",
+            "candidate 0.16.9/rc1 fallback 0.16.9",
+        ]) {
             const ssh = new FakeSsh();
             addFakeExecution(
                 ssh,
-                "/usr/local/bin/supacloud-edge-runtime --version 2>&1",
-                fakeSuccess(`${versionOutput}\n`),
+                "sha256sum -- '/usr/local/bin/supacloud-edge-runtime'",
+                fakeBinaryProbeSuccess({ versionOutput: `${versionOutput}\n`, sha256: "2".repeat(64) }),
             );
             addPlatformVersionFixture(ssh);
 
@@ -1195,7 +1731,7 @@ describe("ssh admin tool", () => {
 
     test("versions distinguishes missing and malformed Web Console markers", async () => {
         const missing = new FakeSsh();
-        addFakeExecution(missing, "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'", {
+        addFakeExecution(missing, "ROOT='/opt/supacloud/web-console/current'", {
             success: false, stdout: "", stderr: "", code: 44,
         });
         addPlatformVersionFixture(missing);
@@ -1213,8 +1749,8 @@ describe("ssh admin tool", () => {
             const invalid = new FakeSsh();
             addFakeExecution(
                 invalid,
-                "MARKER='/opt/supacloud/web-console/current/.supacloud-component.json'",
-                fakeSuccess(invalidMarker),
+                "ROOT='/opt/supacloud/web-console/current'",
+                fakeWebConsoleProbe(invalidMarker, "4".repeat(64)),
             );
             addPlatformVersionFixture(invalid);
 

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+    chmodSync,
+    existsSync,
+    linkSync,
+    mkdirSync,
+    mkdtempSync,
+    realpathSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -207,6 +218,10 @@ function fakeBinaryProbeAfterHashFailure(versionOutput: string, hashBefore: stri
     };
 }
 
+function fixedBinaryProbeFragment(executablePath: string): string {
+    return `exec {BINARY_FD}<'${executablePath}'`;
+}
+
 function fakeWebConsoleProbe(
     markerOutput: string,
     treeSha256: string,
@@ -234,7 +249,7 @@ function addBinaryVersionFixture(
 ): void {
     const { unit, executablePath, versionOutput, sha256 } = fixture;
     addFakeExecution(ssh, `-- ${unit}`, fakeSystemdExecStart(executablePath));
-    addFakeExecution(ssh, `sha256sum -- '${executablePath}'`, fakeBinaryProbeSuccess({
+    addFakeExecution(ssh, fixedBinaryProbeFragment(executablePath), fakeBinaryProbeSuccess({
         versionOutput: `${versionOutput}\n`,
         sha256,
     }));
@@ -243,7 +258,7 @@ function addBinaryVersionFixture(
 function addPlatformVersionFixture(ssh: FakeSsh): void {
     addBinaryVersionFixture(ssh, {
         unit: "supacloud.service", executablePath: "/usr/local/bin/supacloud",
-        versionOutput: "SupaCloud Version: 0.50.34", sha256: "1".repeat(64),
+        versionOutput: '{"level":"INFO","message":"SupaCloud Version: 0.50.34"}', sha256: "1".repeat(64),
     });
     addBinaryVersionFixture(ssh, {
         unit: "supacloud-edge-runtime.service", executablePath: "/usr/local/bin/supacloud-edge-runtime",
@@ -266,6 +281,165 @@ async function generatedPlatformProbeCommand(commandFragment: string): Promise<s
     const command = ssh.commands.find(candidate => candidate.includes(commandFragment));
     if (!command) throw new Error(`Generated platform probe is missing: ${commandFragment}`);
     return command;
+}
+
+function bash32CompatibleDynamicFdSyntax(command: string): string {
+    if (process.platform !== "darwin") return command;
+    return command
+        .replaceAll("exec {BINARY_FD}<", "exec 9<")
+        .replaceAll("{BINARY_FD}<&-", "9<&-");
+}
+
+function localManagementProbeCommand(probeCommand: string, executablePath: string): string {
+    if (process.platform !== "darwin") return probeCommand;
+    if (executablePath.includes("'")) throw new Error("Local probe path must not contain a single quote");
+    return bash32CompatibleDynamicFdSyntax(probeCommand)
+        .replace("PINNED_EXECUTABLE=/proc/$$/fd/$BINARY_FD", `PINNED_EXECUTABLE='${executablePath}.pinned'`)
+        .replaceAll("stat -Lc '%d:%i' --", "stat -f '%d:%i'");
+}
+
+function prepareLocalPinnedExecutable(executablePath: string): void {
+    if (process.platform === "darwin") linkSync(executablePath, `${executablePath}.pinned`);
+}
+
+function uniqueTaggedOutputValue(output: string, label: string): string {
+    const matches = output.split(/\r?\n/).filter(line => line.startsWith(label));
+    if (matches.length !== 1) throw new Error(`Expected one tagged output line: ${label}`);
+    return matches[0]!.slice(label.length);
+}
+
+function binaryProbeOutputEvidence(output: string): {
+    hashBefore: string;
+    versionOutput: string;
+    hashAfter: string;
+} {
+    const encodedVersion = uniqueTaggedOutputValue(output, "SUPACLOUD_BINARY_VERSION_BASE64=");
+    return {
+        hashBefore: uniqueTaggedOutputValue(output, "SUPACLOUD_BINARY_HASH_BEFORE="),
+        versionOutput: Buffer.from(encodedVersion, "base64").toString(),
+        hashAfter: uniqueTaggedOutputValue(output, "SUPACLOUD_BINARY_HASH_AFTER="),
+    };
+}
+
+type BinaryProbeRaceFixture = {
+    fixtureRoot: string;
+    executablePath: string;
+    commandDir: string;
+    realSha256sum: string;
+    originalSha256: string;
+    originalIdentity: string;
+};
+
+function unsafePathBinaryProbeCommand(executablePath: string): string {
+    if (executablePath.includes("'")) throw new Error("Local probe path must not contain a single quote");
+    const executable = `'${executablePath}'`;
+    return [
+        "set -o pipefail",
+        `HASH_BEFORE=$(sha256sum -- ${executable} | awk '{print $1}') || exit 70`,
+        `printf 'SUPACLOUD_BINARY_HASH_BEFORE=%s\\n' "$HASH_BEFORE"`,
+        `VERSION_BASE64=$(${executable} --version 2>&1 | head -c 2049 | base64 | tr -d '\\n') || exit 71`,
+        `printf 'SUPACLOUD_BINARY_VERSION_BASE64=%s\\n' "$VERSION_BASE64"`,
+        `HASH_AFTER=$(sha256sum -- ${executable} | awk '{print $1}') || exit 72`,
+        `printf 'SUPACLOUD_BINARY_HASH_AFTER=%s\\n' "$HASH_AFTER"`,
+        `[ "$HASH_BEFORE" = "$HASH_AFTER" ] || exit 75`,
+    ].join("\n");
+}
+
+function writeHashSwapCommand(commandPath: string): void {
+    writeExecutableShell(commandPath, [
+        "#!/bin/bash",
+        "set -eu",
+        "CALL_COUNT=0",
+        "if [ -f \"$PROBE_SWAP_STATE\" ]; then read -r CALL_COUNT < \"$PROBE_SWAP_STATE\"; fi",
+        "if [ \"$CALL_COUNT\" = 0 ]; then",
+        "  \"$PROBE_REAL_SHA256SUM\" \"$@\"",
+        "  mv \"$PROBE_TARGET\" \"${PROBE_TARGET}.saved\"",
+        "  mv \"${PROBE_TARGET}.replacement\" \"$PROBE_TARGET\"",
+        "  printf '1\\n' > \"$PROBE_SWAP_STATE\"",
+        "  exit 0",
+        "fi",
+        "[ \"$CALL_COUNT\" = 1 ] || exit 64",
+        "if [ \"$PROBE_REPLACEMENT_OUTCOME\" = restore_original ]; then",
+        "  mv \"$PROBE_TARGET\" \"${PROBE_TARGET}.after\"",
+        "  mv \"${PROBE_TARGET}.saved\" \"$PROBE_TARGET\"",
+        "fi",
+        "printf '2\\n' > \"$PROBE_SWAP_STATE\"",
+        "exec \"$PROBE_REAL_SHA256SUM\" \"$@\"",
+        "",
+    ].join("\n"));
+}
+
+function fileIdentity(filePath: string): string {
+    const metadata = statSync(filePath);
+    return `${metadata.dev}:${metadata.ino}`;
+}
+
+function createBinaryProbeRaceFixture(): BinaryProbeRaceFixture {
+    const realSha256sum = Bun.which("sha256sum");
+    if (!realSha256sum) throw new Error("Required test command is unavailable: sha256sum");
+    const fixtureRoot = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-binary-probe-aba-")));
+    const executablePath = join(fixtureRoot, "supacloud");
+    const commandDir = join(fixtureRoot, "commands");
+    const originalSource = "#!/bin/sh\nprintf 'SupaCloud Version: 0.50.34\\n'\n";
+    mkdirSync(commandDir);
+    writeExecutableShell(executablePath, originalSource);
+    writeExecutableShell(`${executablePath}.replacement`, "#!/bin/sh\nprintf 'SupaCloud Version: 0.50.35\\n'\n");
+    writeHashSwapCommand(join(commandDir, "sha256sum"));
+    return {
+        fixtureRoot,
+        executablePath,
+        commandDir,
+        realSha256sum,
+        originalSha256: createHash("sha256").update(originalSource).digest("hex"),
+        originalIdentity: fileIdentity(executablePath),
+    };
+}
+
+function executeBinaryProbeRace(
+    fixture: BinaryProbeRaceFixture,
+    probeCommand: string,
+    replacementOutcome: "restore_original" | "keep_replacement",
+): FakeExecResult {
+    const execution = Bun.spawnSync(["bash", "-c", probeCommand], {
+        env: {
+            ...process.env,
+            PATH: `${fixture.commandDir}:${process.env.PATH ?? ""}`,
+            PROBE_REAL_SHA256SUM: fixture.realSha256sum,
+            PROBE_REPLACEMENT_OUTCOME: replacementOutcome,
+            PROBE_SWAP_STATE: join(fixture.fixtureRoot, "hash-calls"),
+            PROBE_TARGET: fixture.executablePath,
+        },
+    });
+    return {
+        success: execution.exitCode === 0,
+        stdout: execution.stdout.toString(),
+        stderr: execution.stderr.toString(),
+        code: execution.exitCode,
+    };
+}
+
+async function fixedLocalManagementProbe(executablePath: string): Promise<string> {
+    const generatedProbe = await generatedPlatformProbeCommand(
+        fixedBinaryProbeFragment("/usr/local/bin/supacloud"),
+    );
+    prepareLocalPinnedExecutable(executablePath);
+    return localManagementProbeCommand(
+        generatedProbe.replaceAll("'/usr/local/bin/supacloud'", `'${executablePath}'`),
+        executablePath,
+    );
+}
+
+async function managementEvidenceForProbe(execution: FakeExecResult): Promise<{
+    status: string;
+    version: string | null;
+    sha256: string | null;
+    error: string | null;
+}> {
+    const ssh = new FakeSsh();
+    addFakeExecution(ssh, fixedBinaryProbeFragment("/usr/local/bin/supacloud"), execution);
+    addPlatformVersionFixture(ssh);
+    const response = await captureSshTool(ssh).invoke({ action: "versions" });
+    return JSON.parse(response.content[0]?.text ?? "").components.management_api;
 }
 
 const UPGRADE_SIGNALS = ["HUP", "INT", "TERM"] as const;
@@ -1181,7 +1355,7 @@ describe("ssh admin tool", () => {
             error: null,
         });
         const managementProbe = ssh.commands.find(command => (
-            command.includes("HASH_BEFORE=$(sha256sum -- '/usr/local/bin/supacloud'")
+            command.includes(fixedBinaryProbeFragment("/usr/local/bin/supacloud"))
         )) ?? "";
         const hashBeforeIndex = managementProbe.indexOf("HASH_BEFORE=$(sha256sum");
         const versionIndex = managementProbe.indexOf("VERSION_BASE64=$(");
@@ -1189,7 +1363,9 @@ describe("ssh admin tool", () => {
         expect(hashBeforeIndex).toBeGreaterThanOrEqual(0);
         expect(versionIndex).toBeGreaterThan(hashBeforeIndex);
         expect(hashAfterIndex).toBeGreaterThan(versionIndex);
-        expect(managementProbe.match(/sha256sum -- '\/usr\/local\/bin\/supacloud'/g)).toHaveLength(2);
+        expect(managementProbe.match(/sha256sum -- "\$PINNED_EXECUTABLE"/g)).toHaveLength(2);
+        expect(managementProbe).not.toContain("sha256sum -- '/usr/local/bin/supacloud'");
+        expect(managementProbe).toContain('"$PINNED_EXECUTABLE" --version');
         expect(managementProbe).toContain("| head -c 2049 | base64 |");
         const webProbe = ssh.commands.find(command => command.includes("web_tree_sha256()")) ?? "";
         expect(webProbe.indexOf("ROOT_REAL_BEFORE=")).toBeLessThan(webProbe.indexOf("TREE_BEFORE="));
@@ -1197,7 +1373,8 @@ describe("ssh admin tool", () => {
         expect(webProbe.indexOf("TREE_AFTER=")).toBeLessThan(webProbe.indexOf("ROOT_REAL_AFTER="));
         expect(webProbe.match(/head -c 4097 --/g)).toHaveLength(2);
         for (const command of ssh.commands) {
-            expect(Bun.spawnSync(["bash", "-n", "-c", command]).exitCode).toBe(0);
+            const syntaxCommand = bash32CompatibleDynamicFdSyntax(command);
+            expect(Bun.spawnSync(["bash", "-n", "-c", syntaxCommand]).exitCode).toBe(0);
         }
     });
 
@@ -1298,7 +1475,7 @@ describe("ssh admin tool", () => {
         const ssh = new FakeSsh();
         addFakeExecution(
             ssh,
-            "sha256sum -- '/usr/local/bin/supacloud'",
+            fixedBinaryProbeFragment("/usr/local/bin/supacloud"),
             fakeBinaryProbeChanged({
                 versionOutput: "SupaCloud Version: 0.50.34\n",
                 hashBefore: "1".repeat(64),
@@ -1321,29 +1498,100 @@ describe("ssh admin tool", () => {
         expect(components.web_console.status).toBe("ok");
     });
 
+    test("the legacy path probe can join a replacement version to restored original hashes", () => {
+        const fixture = createBinaryProbeRaceFixture();
+        try {
+            const legacyProbe = unsafePathBinaryProbeCommand(fixture.executablePath);
+            const execution = executeBinaryProbeRace(fixture, legacyProbe, "restore_original");
+
+            expect(execution.code).toBe(0);
+            expect(execution.stderr).toBe("");
+            expect(binaryProbeOutputEvidence(execution.stdout)).toEqual({
+                hashBefore: fixture.originalSha256,
+                versionOutput: "SupaCloud Version: 0.50.35\n",
+                hashAfter: fixture.originalSha256,
+            });
+            expect(fileIdentity(fixture.executablePath)).toBe(fixture.originalIdentity);
+        } finally {
+            rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("the fixed binary probe pins one executable across an ABA path replacement", async () => {
+        const fixture = createBinaryProbeRaceFixture();
+        try {
+            const fixedProbe = await fixedLocalManagementProbe(fixture.executablePath);
+            const execution = executeBinaryProbeRace(fixture, fixedProbe, "restore_original");
+
+            expect(execution.code).toBe(0);
+            expect(execution.stderr).toBe("");
+            expect(binaryProbeOutputEvidence(execution.stdout)).toEqual({
+                hashBefore: fixture.originalSha256,
+                versionOutput: "SupaCloud Version: 0.50.34\n",
+                hashAfter: fixture.originalSha256,
+            });
+            expect(fileIdentity(fixture.executablePath)).toBe(fixture.originalIdentity);
+            expect(await managementEvidenceForProbe(execution)).toMatchObject({
+                status: "ok",
+                version: "0.50.34",
+                sha256: fixture.originalSha256,
+                error: null,
+            });
+        } finally {
+            rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("the fixed binary probe rejects a replacement left at the allowed path", async () => {
+        const fixture = createBinaryProbeRaceFixture();
+        try {
+            const fixedProbe = await fixedLocalManagementProbe(fixture.executablePath);
+            const execution = executeBinaryProbeRace(fixture, fixedProbe, "keep_replacement");
+
+            expect(execution.code).toBe(75);
+            expect(execution.stderr).toBe("");
+            expect(binaryProbeOutputEvidence(execution.stdout)).toEqual({
+                hashBefore: fixture.originalSha256,
+                versionOutput: "SupaCloud Version: 0.50.34\n",
+                hashAfter: fixture.originalSha256,
+            });
+            expect(fileIdentity(fixture.executablePath)).not.toBe(fixture.originalIdentity);
+            expect(await managementEvidenceForProbe(execution)).toMatchObject({
+                status: "error",
+                version: null,
+                sha256: null,
+                error: "binary_changed_during_probe",
+            });
+        } finally {
+            rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+        }
+    });
+
     test("the fixed binary probe exits 75 when version execution replaces its file", async () => {
         const fixtureRoot = mkdtempSync(join(tmpdir(), "supacloud-binary-probe-race-"));
         const executablePath = join(fixtureRoot, "supacloud");
         try {
+            expect(executablePath).not.toContain("'");
             writeExecutableShell(executablePath, [
                 "#!/bin/bash",
                 "printf 'SupaCloud Version: 0.50.34\\n'",
-                "NEXT_PATH=\"${0}.next\"",
+                `ORIGINAL_PATH='${executablePath}'`,
+                "NEXT_PATH=\"${ORIGINAL_PATH}.next\"",
                 "printf '%s\\n' '#!/bin/sh' \"printf 'SupaCloud Version: 0.50.35\\\\n'\" > \"$NEXT_PATH\"",
                 "chmod 0755 \"$NEXT_PATH\"",
-                "mv -f \"$NEXT_PATH\" \"$0\"",
+                "mv -f \"$NEXT_PATH\" \"$ORIGINAL_PATH\"",
                 "",
             ].join("\n"));
+            prepareLocalPinnedExecutable(executablePath);
             const ssh = new FakeSsh();
             addPlatformVersionFixture(ssh);
             await captureSshTool(ssh).invoke({ action: "versions" });
             const fixedProbe = ssh.commands.find(command => (
-                command.includes("HASH_BEFORE=$(sha256sum -- '/usr/local/bin/supacloud'")
+                command.includes(fixedBinaryProbeFragment("/usr/local/bin/supacloud"))
             )) ?? "";
-            expect(executablePath).not.toContain("'");
-            const localProbe = fixedProbe.replaceAll(
-                "'/usr/local/bin/supacloud'",
-                `'${executablePath}'`,
+            const localProbe = localManagementProbeCommand(
+                fixedProbe.replaceAll("'/usr/local/bin/supacloud'", `'${executablePath}'`),
+                executablePath,
             );
 
             const execution = Bun.spawnSync(["bash", "-c", localProbe]);
@@ -1361,7 +1609,7 @@ describe("ssh admin tool", () => {
         ]);
         addFakeExecution(
             ssh,
-            "sha256sum -- '/usr/local/bin/supacloud'",
+            fixedBinaryProbeFragment("/usr/local/bin/supacloud"),
             fakeBinaryProbeSuccess({ versionOutput: "SupaCloud Version: 0.50.34\n", sha256: "1".repeat(64) }),
         );
         addPlatformVersionFixture(ssh);
@@ -1422,7 +1670,7 @@ describe("ssh admin tool", () => {
             const ssh = new FakeSsh();
             addFakeExecution(
                 ssh,
-                "sha256sum -- '/usr/local/bin/supacloud'",
+                fixedBinaryProbeFragment("/usr/local/bin/supacloud"),
                 fakeBinaryProbeSuccess({ versionOutput, sha256: "1".repeat(64) }),
             );
             addPlatformVersionFixture(ssh);
@@ -1469,7 +1717,7 @@ describe("ssh admin tool", () => {
             const ssh = new FakeSsh();
             addFakeExecution(
                 ssh,
-                "sha256sum -- '/usr/local/bin/supacloud'",
+                fixedBinaryProbeFragment("/usr/local/bin/supacloud"),
                 fakeSuccess(invalidOutput.output),
             );
             addPlatformVersionFixture(ssh);
@@ -1678,7 +1926,7 @@ describe("ssh admin tool", () => {
         const ssh = new FakeSsh();
         addFakeExecution(
             ssh,
-            "sha256sum -- '/usr/local/bin/supacloud'",
+            fixedBinaryProbeFragment("/usr/local/bin/supacloud"),
             fakeBinaryProbeAfterHashFailure("SupaCloud Version: 0.50.34\n", "1".repeat(64)),
         );
         addPlatformVersionFixture(ssh);
@@ -1713,7 +1961,7 @@ describe("ssh admin tool", () => {
             const ssh = new FakeSsh();
             addFakeExecution(
                 ssh,
-                "sha256sum -- '/usr/local/bin/supacloud-edge-runtime'",
+                fixedBinaryProbeFragment("/usr/local/bin/supacloud-edge-runtime"),
                 fakeBinaryProbeSuccess({ versionOutput: `${versionOutput}\n`, sha256: "2".repeat(64) }),
             );
             addPlatformVersionFixture(ssh);

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -44,6 +44,7 @@ const WEB_CONSOLE_CURRENT_DIR = "/opt/supacloud/web-console/current";
 const STABLE_SEMVER_CORE = "(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)";
 const EXACT_STABLE_SEMVER = new RegExp(`^(?:${STABLE_SEMVER_CORE})(?![\\s\\S])`);
 const SEMVER_CORE_TOKEN = /\d+\.\d+\.\d+/;
+const VERSION_TOKEN_SEPARATOR = /[\s"'()\[\]{}:,;=]+/;
 const BINARY_HASH_BEFORE_FAILED = 70;
 const BINARY_VERSION_FAILED = 71;
 const BINARY_HASH_AFTER_FAILED = 72;
@@ -100,13 +101,19 @@ function fixedBinaryProbeCommand(executablePath: string, versionArgument: string
     const executable = quoteEnvValue(executablePath);
     return [
         "set -o pipefail",
-        `if HASH_BEFORE=$(sha256sum -- ${executable} | awk '{print $1}'); then :; else exit ${BINARY_HASH_BEFORE_FAILED}; fi`,
+        `if exec {BINARY_FD}<${executable}; then :; else exit ${BINARY_HASH_BEFORE_FAILED}; fi`,
+        "PINNED_EXECUTABLE=/proc/$$/fd/$BINARY_FD",
+        `if PINNED_ID=$(stat -Lc '%d:%i' -- "$PINNED_EXECUTABLE"); then :; else exit ${BINARY_HASH_BEFORE_FAILED}; fi`,
+        `if HASH_BEFORE=$(sha256sum -- "$PINNED_EXECUTABLE" | awk '{print $1}'); then :; else exit ${BINARY_HASH_BEFORE_FAILED}; fi`,
         `printf '${BINARY_HASH_BEFORE_LABEL}%s\\n' "$HASH_BEFORE"`,
-        `if VERSION_BASE64=$(${executable} ${versionArgument} 2>&1 | head -c ${BINARY_VERSION_MAX_BYTES + 1} | base64 | tr -d '\\n'); then :; else exit ${BINARY_VERSION_FAILED}; fi`,
+        `if VERSION_BASE64=$( (exec -a ${executable} "$PINNED_EXECUTABLE" ${versionArgument} {BINARY_FD}<&-) 2>&1 | head -c ${BINARY_VERSION_MAX_BYTES + 1} | base64 | tr -d '\\n'); then :; else exit ${BINARY_VERSION_FAILED}; fi`,
         `printf '${BINARY_VERSION_LABEL}%s\\n' "$VERSION_BASE64"`,
-        `if HASH_AFTER=$(sha256sum -- ${executable} | awk '{print $1}'); then :; else exit ${BINARY_HASH_AFTER_FAILED}; fi`,
+        `if HASH_AFTER=$(sha256sum -- "$PINNED_EXECUTABLE" | awk '{print $1}'); then :; else exit ${BINARY_HASH_AFTER_FAILED}; fi`,
         `printf '${BINARY_HASH_AFTER_LABEL}%s\\n' "$HASH_AFTER"`,
         `[ "$HASH_BEFORE" = "$HASH_AFTER" ] || exit ${PROBE_CHANGED_DURING_READ}`,
+        `if CURRENT_ID=$(stat -Lc '%d:%i' -- ${executable}); then :; else exit ${PROBE_CHANGED_DURING_READ}; fi`,
+        `[ "$PINNED_ID" = "$CURRENT_ID" ] || exit ${PROBE_CHANGED_DURING_READ}`,
+        "exec {BINARY_FD}<&-",
     ].join("\n");
 }
 
@@ -615,7 +622,7 @@ function execStartEvidence(output: string): ExecStartEvidence {
 
 function stableVersion(output: string): string | null {
     if (output.length > BINARY_VERSION_MAX_BYTES || /\0/.test(output)) return null;
-    const versionTokens = output.split(/\s+/).filter(token => SEMVER_CORE_TOKEN.test(token));
+    const versionTokens = output.split(VERSION_TOKEN_SEPARATOR).filter(token => SEMVER_CORE_TOKEN.test(token));
     const versions = versionTokens.map(token => token.startsWith("v") ? token.slice(1) : token);
     if (versions.length === 0 || versions.some(version => !EXACT_STABLE_SEMVER.test(version))) {
         return null;

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -2,8 +2,10 @@
  * SSH — Compound tool (13→1)
  * Install, upgrade, diagnose, exec, tenant mgmt — all via SSH
  */
+import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import { basename, dirname, join } from "node:path";
+import { TextDecoder } from "node:util";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import type { SshTransport } from "../transports/ssh";
@@ -35,10 +37,34 @@ const DIRECT_UPGRADE_SSH_TIMEOUT_MS = 720_000;
 const PROXIED_UPGRADE_SSH_TIMEOUT_MS = 1_320_000;
 const PLATFORM_PROBE_TIMEOUT_MS = 10_000;
 const PLATFORM_HASH_TIMEOUT_MS = 30_000;
+const WEB_CONSOLE_PROBE_TIMEOUT_MS = 60_000;
+const BINARY_VERSION_MAX_BYTES = 2048;
+const WEB_CONSOLE_MARKER_MAX_BYTES = 4096;
 const WEB_CONSOLE_CURRENT_DIR = "/opt/supacloud/web-console/current";
-const WEB_CONSOLE_MARKER = `${WEB_CONSOLE_CURRENT_DIR}/.supacloud-component.json`;
 const STABLE_SEMVER_CORE = "(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)";
 const EXACT_STABLE_SEMVER = new RegExp(`^(?:${STABLE_SEMVER_CORE})(?![\\s\\S])`);
+const SEMVER_CORE_TOKEN = /\d+\.\d+\.\d+/;
+const BINARY_HASH_BEFORE_FAILED = 70;
+const BINARY_VERSION_FAILED = 71;
+const BINARY_HASH_AFTER_FAILED = 72;
+const PROBE_CHANGED_DURING_READ = 75;
+const WEB_CONSOLE_ROOT_MISSING = 43;
+const WEB_CONSOLE_MARKER_MISSING = 44;
+const WEB_CONSOLE_ROOT_INVALID = 64;
+const WEB_CONSOLE_MARKER_INVALID = 65;
+const WEB_CONSOLE_TREE_INVALID = 66;
+const WEB_CONSOLE_TREE_FAILED = 67;
+const BINARY_HASH_BEFORE_LABEL = "SUPACLOUD_BINARY_HASH_BEFORE=";
+const BINARY_VERSION_LABEL = "SUPACLOUD_BINARY_VERSION_BASE64=";
+const BINARY_HASH_AFTER_LABEL = "SUPACLOUD_BINARY_HASH_AFTER=";
+const WEB_ROOT_REAL_BEFORE_LABEL = "SUPACLOUD_WEB_ROOT_REAL_BEFORE=";
+const WEB_ROOT_ID_BEFORE_LABEL = "SUPACLOUD_WEB_ROOT_ID_BEFORE=";
+const WEB_MARKER_BEFORE_LABEL = "SUPACLOUD_WEB_MARKER_BASE64_BEFORE=";
+const WEB_TREE_BEFORE_LABEL = "SUPACLOUD_WEB_TREE_SHA256_BEFORE=";
+const WEB_TREE_AFTER_LABEL = "SUPACLOUD_WEB_TREE_SHA256_AFTER=";
+const WEB_MARKER_AFTER_LABEL = "SUPACLOUD_WEB_MARKER_BASE64_AFTER=";
+const WEB_ROOT_REAL_AFTER_LABEL = "SUPACLOUD_WEB_ROOT_REAL_AFTER=";
+const WEB_ROOT_ID_AFTER_LABEL = "SUPACLOUD_WEB_ROOT_ID_AFTER=";
 
 type ComponentProbeStatus = "ok" | "unknown" | "error";
 
@@ -60,16 +86,29 @@ type WebConsoleEvidence = {
     error: string | null;
 };
 
-type FixedBinaryCommand = {
-    version: string;
-    sha256: string;
+type FixedBinaryProbe = {
+    command: string;
 };
 
 type BinaryProbeDefinition = {
     unit: string;
     source: string;
-    commands: Readonly<Record<string, FixedBinaryCommand>>;
+    commands: Readonly<Record<string, FixedBinaryProbe>>;
 };
+
+function fixedBinaryProbeCommand(executablePath: string, versionArgument: string): string {
+    const executable = quoteEnvValue(executablePath);
+    return [
+        "set -o pipefail",
+        `if HASH_BEFORE=$(sha256sum -- ${executable} | awk '{print $1}'); then :; else exit ${BINARY_HASH_BEFORE_FAILED}; fi`,
+        `printf '${BINARY_HASH_BEFORE_LABEL}%s\\n' "$HASH_BEFORE"`,
+        `if VERSION_BASE64=$(${executable} ${versionArgument} 2>&1 | head -c ${BINARY_VERSION_MAX_BYTES + 1} | base64 | tr -d '\\n'); then :; else exit ${BINARY_VERSION_FAILED}; fi`,
+        `printf '${BINARY_VERSION_LABEL}%s\\n' "$VERSION_BASE64"`,
+        `if HASH_AFTER=$(sha256sum -- ${executable} | awk '{print $1}'); then :; else exit ${BINARY_HASH_AFTER_FAILED}; fi`,
+        `printf '${BINARY_HASH_AFTER_LABEL}%s\\n' "$HASH_AFTER"`,
+        `[ "$HASH_BEFORE" = "$HASH_AFTER" ] || exit ${PROBE_CHANGED_DURING_READ}`,
+    ].join("\n");
+}
 
 const BINARY_PROBES = {
     management_api: {
@@ -77,12 +116,10 @@ const BINARY_PROBES = {
         source: "systemd:supacloud.service:ExecStart",
         commands: {
             "/usr/local/bin/supacloud": {
-                version: "/usr/local/bin/supacloud --version 2>&1",
-                sha256: "sha256sum -- /usr/local/bin/supacloud | awk '{print $1}'",
+                command: fixedBinaryProbeCommand("/usr/local/bin/supacloud", "--version"),
             },
             "/opt/supacloud/bin/supacloud": {
-                version: "/opt/supacloud/bin/supacloud --version 2>&1",
-                sha256: "sha256sum -- /opt/supacloud/bin/supacloud | awk '{print $1}'",
+                command: fixedBinaryProbeCommand("/opt/supacloud/bin/supacloud", "--version"),
             },
         },
     },
@@ -91,12 +128,10 @@ const BINARY_PROBES = {
         source: "systemd:supacloud-edge-runtime.service:ExecStart",
         commands: {
             "/usr/local/bin/supacloud-edge-runtime": {
-                version: "/usr/local/bin/supacloud-edge-runtime --version 2>&1",
-                sha256: "sha256sum -- /usr/local/bin/supacloud-edge-runtime | awk '{print $1}'",
+                command: fixedBinaryProbeCommand("/usr/local/bin/supacloud-edge-runtime", "--version"),
             },
             "/opt/supacloud/bin/supacloud-edge-runtime": {
-                version: "/opt/supacloud/bin/supacloud-edge-runtime --version 2>&1",
-                sha256: "sha256sum -- /opt/supacloud/bin/supacloud-edge-runtime | awk '{print $1}'",
+                command: fixedBinaryProbeCommand("/opt/supacloud/bin/supacloud-edge-runtime", "--version"),
             },
         },
     },
@@ -105,8 +140,7 @@ const BINARY_PROBES = {
         source: "systemd:supacloud-caddy.service:ExecStart",
         commands: {
             "/usr/local/bin/supacloud-caddy": {
-                version: "/usr/local/bin/supacloud-caddy version 2>&1",
-                sha256: "sha256sum -- /usr/local/bin/supacloud-caddy | awk '{print $1}'",
+                command: fixedBinaryProbeCommand("/usr/local/bin/supacloud-caddy", "version"),
             },
         },
     },
@@ -580,17 +614,18 @@ function execStartEvidence(output: string): ExecStartEvidence {
 }
 
 function stableVersion(output: string): string | null {
-    if (output.length > 2048 || /\0/.test(output)) return null;
-    const matches = Array.from(output.matchAll(
-        new RegExp(`(?:^|[^0-9A-Za-z.+-])v?(${STABLE_SEMVER_CORE})(?=$|[^0-9A-Za-z.+-])`, "g"),
-    ));
-    const versions = new Set(matches.map(match => match[1]).filter(Boolean));
-    return versions.size === 1 ? [...versions][0]! : null;
+    if (output.length > BINARY_VERSION_MAX_BYTES || /\0/.test(output)) return null;
+    const versionTokens = output.split(/\s+/).filter(token => SEMVER_CORE_TOKEN.test(token));
+    const versions = versionTokens.map(token => token.startsWith("v") ? token.slice(1) : token);
+    if (versions.length === 0 || versions.some(version => !EXACT_STABLE_SEMVER.test(version))) {
+        return null;
+    }
+    const uniqueVersions = new Set(versions);
+    return uniqueVersions.size === 1 ? [...uniqueVersions][0]! : null;
 }
 
 function stableSha256(output: string): string | null {
-    const normalized = output.trim();
-    return /^[0-9a-f]{64}$/.test(normalized) ? normalized : null;
+    return /^[0-9a-f]{64}$/.test(output) ? output : null;
 }
 
 function unavailableBinaryEvidence(
@@ -607,18 +642,93 @@ function unavailableBinaryEvidence(
     };
 }
 
-function binaryProbeError(
-    versionExecution: RemoteExecution | null,
-    version: string | null,
-    hashExecution: RemoteExecution | null,
-    sha256: string | null,
-): string | null {
-    if (!versionExecution) return "version_probe_transport_failed";
-    if (!versionExecution.success) return "version_probe_failed";
-    if (!version) return "version_output_invalid";
-    if (!hashExecution) return "sha256_probe_transport_failed";
-    if (!hashExecution.success) return "sha256_probe_failed";
-    return sha256 ? null : "sha256_output_invalid";
+function canonicalBase64Text(encoded: string, maximumBytes: number): string | null {
+    if (encoded.length > Math.ceil(maximumBytes / 3) * 4 || encoded.length % 4 !== 0) return null;
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(encoded)) return null;
+    const decodedBytes = Buffer.from(encoded, "base64");
+    if (decodedBytes.length > maximumBytes || decodedBytes.toString("base64") !== encoded) return null;
+    try {
+        return new TextDecoder("utf-8", { fatal: true }).decode(decodedBytes);
+    } catch {
+        return null;
+    }
+}
+
+function taggedProbeValue(line: string | undefined, label: string): string | null {
+    return line?.startsWith(label) ? line.slice(label.length) : null;
+}
+
+type BinaryProbeFields = {
+    versionOutput: string;
+    hashBefore: string;
+    hashAfter: string | null;
+};
+
+function binaryProbeFields(output: string): BinaryProbeFields | null {
+    if (output.length > 8192 || /[\r\0]/.test(output)) return null;
+    const lines = (output.endsWith("\n") ? output.slice(0, -1) : output).split("\n");
+    if (lines.length < 2 || lines.length > 3) return null;
+    const hashBefore = taggedProbeValue(lines[0], BINARY_HASH_BEFORE_LABEL);
+    const versionBase64 = taggedProbeValue(lines[1], BINARY_VERSION_LABEL);
+    const hashAfter = lines.length === 3
+        ? taggedProbeValue(lines[2], BINARY_HASH_AFTER_LABEL)
+        : null;
+    if (hashBefore === null || versionBase64 === null || (lines.length === 3 && hashAfter === null)) return null;
+    const versionOutput = canonicalBase64Text(versionBase64, BINARY_VERSION_MAX_BYTES);
+    return versionOutput === null ? null : { versionOutput, hashBefore, hashAfter };
+}
+
+type BinaryProbeValues = {
+    version: string | null;
+    sha256: string | null;
+    error: string | null;
+};
+
+function completedBinaryProbe(fields: BinaryProbeFields): BinaryProbeValues {
+    const version = stableVersion(fields.versionOutput);
+    const hashBefore = stableSha256(fields.hashBefore);
+    const hashAfter = fields.hashAfter === null ? null : stableSha256(fields.hashAfter);
+    if (hashBefore && hashAfter && hashBefore !== hashAfter) {
+        return { version: null, sha256: null, error: "binary_changed_during_probe" };
+    }
+    const sha256 = hashBefore && hashAfter ? hashBefore : null;
+    if (!version) return { version: null, sha256, error: "version_output_invalid" };
+    return sha256
+        ? { version, sha256, error: null }
+        : { version, sha256: null, error: "sha256_output_invalid" };
+}
+
+function reservedBinaryProbeFailure(
+    execution: RemoteExecution,
+    fields: BinaryProbeFields | null,
+): BinaryProbeValues | null {
+    if (execution.code === PROBE_CHANGED_DURING_READ) {
+        return { version: null, sha256: null, error: "binary_changed_during_probe" };
+    }
+    if (execution.code === BINARY_HASH_BEFORE_FAILED) {
+        return { version: null, sha256: null, error: "sha256_probe_failed" };
+    }
+    if (execution.code === BINARY_VERSION_FAILED) {
+        return { version: null, sha256: null, error: "version_probe_failed" };
+    }
+    if (execution.code === BINARY_HASH_AFTER_FAILED) {
+        const version = fields ? stableVersion(fields.versionOutput) : null;
+        return version
+            ? { version, sha256: null, error: "sha256_probe_failed" }
+            : { version: null, sha256: null, error: fields ? "version_output_invalid" : "binary_probe_output_invalid" };
+    }
+    return null;
+}
+
+function binaryProbeValues(execution: RemoteExecution | null): BinaryProbeValues {
+    if (!execution) return { version: null, sha256: null, error: "binary_probe_transport_failed" };
+    const fields = binaryProbeFields(execution.stdout);
+    const reservedFailure = reservedBinaryProbeFailure(execution, fields);
+    if (reservedFailure) return reservedFailure;
+    if (!execution.success) return { version: null, sha256: null, error: "binary_probe_failed" };
+    return fields
+        ? completedBinaryProbe(fields)
+        : { version: null, sha256: null, error: "binary_probe_output_invalid" };
 }
 
 async function binaryComponentEvidence(
@@ -627,11 +737,22 @@ async function binaryComponentEvidence(
 ): Promise<BinaryComponentEvidence> {
     const execStart = await systemdBinaryEvidence(ssh, definition);
     if (execStart.status !== "ok" || !execStart.path) return unavailableBinaryEvidence(definition, execStart);
-    const commands = definition.commands[execStart.path];
-    if (!commands) return unavailableBinaryEvidence(definition, {
+    const fixedProbe = definition.commands[execStart.path];
+    if (!fixedProbe) return unavailableBinaryEvidence(definition, {
         status: "error", path: execStart.path, error: "exec_start_not_allowed",
     });
-    return fixedBinaryEvidence(ssh, definition, execStart.path, commands);
+    const evidence = await fixedBinaryEvidence(ssh, definition, execStart.path, fixedProbe);
+    const verifiedExecStart = await systemdBinaryEvidence(ssh, definition);
+    if (verifiedExecStart.status !== "ok") {
+        return unavailableBinaryEvidence(definition, {
+            status: "error", path: execStart.path, error: "exec_start_recheck_failed",
+        });
+    }
+    return verifiedExecStart.path === execStart.path
+        ? evidence
+        : unavailableBinaryEvidence(definition, {
+            status: "error", path: execStart.path, error: "exec_start_changed_during_probe",
+        });
 }
 
 async function systemdBinaryEvidence(
@@ -649,27 +770,22 @@ async function fixedBinaryEvidence(
     ssh: SshTransport,
     definition: BinaryProbeDefinition,
     executablePath: string,
-    commands: FixedBinaryCommand,
+    fixedProbe: FixedBinaryProbe,
 ): Promise<BinaryComponentEvidence> {
-    const [versionExecution, hashExecution] = await Promise.all([
-        runFixedRemoteCommand(ssh, commands.version, PLATFORM_PROBE_TIMEOUT_MS),
-        runFixedRemoteCommand(ssh, commands.sha256, PLATFORM_HASH_TIMEOUT_MS),
-    ]);
-    const version = versionExecution?.success ? stableVersion(versionExecution.stdout) : null;
-    const sha256 = hashExecution?.success ? stableSha256(hashExecution.stdout) : null;
-    const error = binaryProbeError(versionExecution, version, hashExecution, sha256);
+    const execution = await runFixedRemoteCommand(ssh, fixedProbe.command, PLATFORM_HASH_TIMEOUT_MS);
+    const probe = binaryProbeValues(execution);
     return {
-        status: error ? "error" : "ok",
-        version,
-        sha256,
+        status: probe.error ? "error" : "ok",
+        version: probe.version,
+        sha256: probe.sha256,
         path: executablePath,
         source: definition.source,
-        error,
+        error: probe.error,
     };
 }
 
 function parseWebConsoleVersion(markerOutput: string): string | null {
-    if (markerOutput.length > 4096 || /\0/.test(markerOutput)) return null;
+    if (markerOutput.length > WEB_CONSOLE_MARKER_MAX_BYTES || /\0/.test(markerOutput)) return null;
     try {
         const marker = JSON.parse(markerOutput) as unknown;
         if (typeof marker !== "object" || marker === null || Array.isArray(marker)) return null;
@@ -683,48 +799,136 @@ function parseWebConsoleVersion(markerOutput: string): string | null {
     }
 }
 
-const WEB_MARKER_COMMAND = [
-    `MARKER=${quoteEnvValue(WEB_CONSOLE_MARKER)}`,
-    "test ! -L \"$MARKER\" || exit 65",
-    "test -e \"$MARKER\" || exit 44",
-    "test -f \"$MARKER\" || exit 65",
-    "test \"$(stat -c '%s' -- \"$MARKER\")\" -le 4096 || exit 65",
-    "cat -- \"$MARKER\"",
-].join("; ");
-
-const WEB_TREE_SHA256_COMMAND = [
+const WEB_CONSOLE_PROBE_COMMAND = [
     "set -o pipefail",
     `ROOT=${quoteEnvValue(WEB_CONSOLE_CURRENT_DIR)}`,
-    "test -d \"$ROOT\" || exit 44",
-    "test -f \"$ROOT/.supacloud-component.json\" && test ! -L \"$ROOT/.supacloud-component.json\" || exit 65",
-    "if find -H \"$ROOT\" -xdev ! -type d ! -type f -print -quit | grep -q .; then exit 65; fi",
-    "find -H \"$ROOT\" -xdev -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum -- | sha256sum | awk '{print $1}'",
-].join("; ");
+    "if [ ! -e \"$ROOT\" ] && [ ! -L \"$ROOT\" ]; then exit 43; fi",
+    `test -d "$ROOT" || exit ${WEB_CONSOLE_ROOT_INVALID}`,
+    `ROOT_REAL_BEFORE=$(readlink -f -- "$ROOT") || exit ${WEB_CONSOLE_ROOT_INVALID}`,
+    `case "$ROOT_REAL_BEFORE" in "$ROOT"|/opt/supacloud/web-console/releases/*) ;; *) exit ${WEB_CONSOLE_ROOT_INVALID} ;; esac`,
+    `ROOT_ID_BEFORE=$(stat -c '%d:%i' -- "$ROOT_REAL_BEFORE") || exit ${WEB_CONSOLE_ROOT_INVALID}`,
+    "MARKER_BEFORE=$ROOT_REAL_BEFORE/.supacloud-component.json",
+    `test ! -L "$MARKER_BEFORE" || exit ${WEB_CONSOLE_MARKER_INVALID}`,
+    `test -e "$MARKER_BEFORE" || exit ${WEB_CONSOLE_MARKER_MISSING}`,
+    `test -f "$MARKER_BEFORE" || exit ${WEB_CONSOLE_MARKER_INVALID}`,
+    `test "$(stat -c '%s' -- "$MARKER_BEFORE")" -le ${WEB_CONSOLE_MARKER_MAX_BYTES} || exit ${WEB_CONSOLE_MARKER_INVALID}`,
+    `MARKER_BASE64_BEFORE=$(head -c ${WEB_CONSOLE_MARKER_MAX_BYTES + 1} -- "$MARKER_BEFORE" | base64 | tr -d '\\n') || exit ${WEB_CONSOLE_MARKER_INVALID}`,
+    "web_tree_sha256() {",
+    "  local TREE_ROOT INVALID_ENTRY TREE_DIGEST",
+    "  TREE_ROOT=$1",
+    `  INVALID_ENTRY=$(cd -- "$TREE_ROOT" && find . -xdev ! -type d ! -type f -print -quit) || return ${WEB_CONSOLE_TREE_FAILED}`,
+    `  test -z "$INVALID_ENTRY" || return ${WEB_CONSOLE_TREE_INVALID}`,
+    `  TREE_DIGEST=$(cd -- "$TREE_ROOT" && find . -xdev -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum -- | sha256sum | awk '{print $1}') || return ${WEB_CONSOLE_TREE_FAILED}`,
+    "  printf '%s' \"$TREE_DIGEST\"",
+    "}",
+    "TREE_BEFORE=$(web_tree_sha256 \"$ROOT_REAL_BEFORE\")",
+    "TREE_STATUS=$?",
+    "test \"$TREE_STATUS\" -eq 0 || exit \"$TREE_STATUS\"",
+    "TREE_AFTER=$(web_tree_sha256 \"$ROOT_REAL_BEFORE\")",
+    "TREE_STATUS=$?",
+    `test "$TREE_STATUS" -eq 0 || exit ${PROBE_CHANGED_DURING_READ}`,
+    "MARKER_AFTER=$ROOT_REAL_BEFORE/.supacloud-component.json",
+    `test ! -L "$MARKER_AFTER" && test -f "$MARKER_AFTER" || exit ${PROBE_CHANGED_DURING_READ}`,
+    `test "$(stat -c '%s' -- "$MARKER_AFTER")" -le ${WEB_CONSOLE_MARKER_MAX_BYTES} || exit ${PROBE_CHANGED_DURING_READ}`,
+    `MARKER_BASE64_AFTER=$(head -c ${WEB_CONSOLE_MARKER_MAX_BYTES + 1} -- "$MARKER_AFTER" | base64 | tr -d '\\n') || exit ${PROBE_CHANGED_DURING_READ}`,
+    `test -d "$ROOT" || exit ${PROBE_CHANGED_DURING_READ}`,
+    `ROOT_REAL_AFTER=$(readlink -f -- "$ROOT") || exit ${PROBE_CHANGED_DURING_READ}`,
+    `ROOT_ID_AFTER=$(stat -c '%d:%i' -- "$ROOT_REAL_AFTER") || exit ${PROBE_CHANGED_DURING_READ}`,
+    `printf '${WEB_ROOT_REAL_BEFORE_LABEL}%s\\n' "$ROOT_REAL_BEFORE"`,
+    `printf '${WEB_ROOT_ID_BEFORE_LABEL}%s\\n' "$ROOT_ID_BEFORE"`,
+    `printf '${WEB_MARKER_BEFORE_LABEL}%s\\n' "$MARKER_BASE64_BEFORE"`,
+    `printf '${WEB_TREE_BEFORE_LABEL}%s\\n' "$TREE_BEFORE"`,
+    `printf '${WEB_TREE_AFTER_LABEL}%s\\n' "$TREE_AFTER"`,
+    `printf '${WEB_MARKER_AFTER_LABEL}%s\\n' "$MARKER_BASE64_AFTER"`,
+    `printf '${WEB_ROOT_REAL_AFTER_LABEL}%s\\n' "$ROOT_REAL_AFTER"`,
+    `printf '${WEB_ROOT_ID_AFTER_LABEL}%s\\n' "$ROOT_ID_AFTER"`,
+].join("\n");
+
+type WebConsoleProbeFields = {
+    markerOutput: string;
+    treeSha256: string | null;
+    consistencyError: string | null;
+};
+
+const WEB_CONSOLE_PROBE_LABELS = [
+    WEB_ROOT_REAL_BEFORE_LABEL,
+    WEB_ROOT_ID_BEFORE_LABEL,
+    WEB_MARKER_BEFORE_LABEL,
+    WEB_TREE_BEFORE_LABEL,
+    WEB_TREE_AFTER_LABEL,
+    WEB_MARKER_AFTER_LABEL,
+    WEB_ROOT_REAL_AFTER_LABEL,
+    WEB_ROOT_ID_AFTER_LABEL,
+] as const;
+
+type WebConsoleProbeValues = [string, string, string, string, string, string, string, string];
+
+function taggedWebConsoleProbeValues(output: string): WebConsoleProbeValues | null {
+    if (output.length > 16_384 || /[\r\0]/.test(output)) return null;
+    const lines = (output.endsWith("\n") ? output.slice(0, -1) : output).split("\n");
+    if (lines.length !== WEB_CONSOLE_PROBE_LABELS.length) return null;
+    const probeValues = WEB_CONSOLE_PROBE_LABELS.map((label, index) => taggedProbeValue(lines[index], label));
+    return probeValues.some(probeValue => probeValue === null)
+        ? null
+        : probeValues as WebConsoleProbeValues;
+}
+
+function webConsoleConsistencyError(probeValues: WebConsoleProbeValues): string | null {
+    const [rootBefore, rootIdBefore, markerBefore, treeBefore, treeAfter, markerAfter, rootAfter, rootIdAfter] = probeValues;
+    if (rootBefore !== rootAfter || rootIdBefore !== rootIdAfter) {
+        return "web_console_root_changed_during_probe";
+    }
+    if (markerBefore !== markerAfter) return "marker_changed_during_probe";
+    return treeBefore !== treeAfter ? "tree_sha256_changed_during_probe" : null;
+}
+
+function webConsoleProbeFields(output: string): WebConsoleProbeFields | null {
+    const probeValues = taggedWebConsoleProbeValues(output);
+    if (!probeValues) return null;
+    const [rootBefore, rootIdBefore, markerBefore, treeBefore, , markerAfter, rootAfter, rootIdAfter] = probeValues;
+    const supportedRoot = /^\/opt\/supacloud\/web-console\/(?:current|releases\/[A-Za-z0-9][A-Za-z0-9._-]*)$/;
+    if (![rootBefore, rootAfter].every(root => supportedRoot.test(root))) return null;
+    if (![rootIdBefore, rootIdAfter].every(rootId => /^\d+:\d+$/.test(rootId))) return null;
+    const markerOutput = canonicalBase64Text(markerBefore, WEB_CONSOLE_MARKER_MAX_BYTES);
+    if (markerOutput === null || canonicalBase64Text(markerAfter, WEB_CONSOLE_MARKER_MAX_BYTES) === null) return null;
+    const consistencyError = webConsoleConsistencyError(probeValues);
+    return {
+        markerOutput,
+        treeSha256: consistencyError ? null : stableSha256(treeBefore),
+        consistencyError,
+    };
+}
 
 function webConsoleProbeError(
-    markerExecution: RemoteExecution | null,
+    execution: RemoteExecution | null,
+    fields: WebConsoleProbeFields | null,
     version: string | null,
-    treeHashExecution: RemoteExecution | null,
     treeSha256: string | null,
 ): { status: ComponentProbeStatus; error: string | null } {
-    if (!markerExecution) return { status: "error", error: "marker_probe_transport_failed" };
-    if (markerExecution.code === 44) return { status: "unknown", error: "marker_missing" };
-    if (!markerExecution.success) return { status: "error", error: "marker_probe_failed" };
+    if (!execution) return { status: "error", error: "web_console_probe_transport_failed" };
+    if (execution.code === WEB_CONSOLE_ROOT_MISSING) return { status: "unknown", error: "web_console_missing" };
+    if (execution.code === WEB_CONSOLE_MARKER_MISSING) return { status: "unknown", error: "marker_missing" };
+    if (execution.code === PROBE_CHANGED_DURING_READ) {
+        return { status: "error", error: "web_console_changed_during_probe" };
+    }
+    if (execution.code === WEB_CONSOLE_ROOT_INVALID || execution.code === WEB_CONSOLE_TREE_INVALID) {
+        return { status: "error", error: "web_console_invalid_file" };
+    }
+    if (execution.code === WEB_CONSOLE_MARKER_INVALID) return { status: "error", error: "marker_invalid" };
+    if (execution.code === WEB_CONSOLE_TREE_FAILED) return { status: "error", error: "tree_sha256_probe_failed" };
+    if (!execution.success) return { status: "error", error: "web_console_probe_failed" };
+    if (!fields) return { status: "error", error: "web_console_probe_output_invalid" };
+    if (fields.consistencyError) return { status: "error", error: fields.consistencyError };
     if (!version) return { status: "error", error: "marker_invalid" };
-    if (!treeHashExecution) return { status: "error", error: "tree_sha256_probe_transport_failed" };
-    if (treeHashExecution.code === 44) return { status: "unknown", error: "web_console_missing" };
-    if (!treeHashExecution.success) return { status: "error", error: "tree_sha256_probe_failed" };
     return treeSha256 ? { status: "ok", error: null } : { status: "error", error: "tree_sha256_output_invalid" };
 }
 
 async function webConsoleEvidence(ssh: SshTransport): Promise<WebConsoleEvidence> {
-    const [markerExecution, treeHashExecution] = await Promise.all([
-        runFixedRemoteCommand(ssh, WEB_MARKER_COMMAND, PLATFORM_PROBE_TIMEOUT_MS),
-        runFixedRemoteCommand(ssh, WEB_TREE_SHA256_COMMAND, PLATFORM_HASH_TIMEOUT_MS),
-    ]);
-    const version = markerExecution?.success ? parseWebConsoleVersion(markerExecution.stdout) : null;
-    const treeSha256 = treeHashExecution?.success ? stableSha256(treeHashExecution.stdout) : null;
-    const state = webConsoleProbeError(markerExecution, version, treeHashExecution, treeSha256);
+    const execution = await runFixedRemoteCommand(ssh, WEB_CONSOLE_PROBE_COMMAND, WEB_CONSOLE_PROBE_TIMEOUT_MS);
+    const fields = execution?.success ? webConsoleProbeFields(execution.stdout) : null;
+    const version = fields && !fields.consistencyError ? parseWebConsoleVersion(fields.markerOutput) : null;
+    const treeSha256 = fields?.treeSha256 ?? null;
+    const state = webConsoleProbeError(execution, fields, version, treeSha256);
     return {
         status: state.status,
         version,
@@ -933,24 +1137,23 @@ Actions: ping, setup, install, upgrade, versions, diagnose, exec, troubleshoot, 
                     break;
                 }
                 case "upgrade": {
-                    const version = args.version ? assertSafeReleaseTag(args.version) : undefined;
+                    const version = args.version
+                        ? assertExactStableVersion(assertSafeReleaseTag(args.version), "version")
+                        : undefined;
                     const edgeRuntimeVersion = args.edge_runtime_version
-                        ? assertSafeReleaseTag(args.edge_runtime_version)
+                        ? assertExactStableVersion(
+                            assertSafeReleaseTag(args.edge_runtime_version),
+                            "edge_runtime_version",
+                        )
                         : undefined;
                     if (edgeRuntimeVersion && !version) {
                         throw new Error("'version' is required with 'edge_runtime_version'");
-                    }
-                    if (edgeRuntimeVersion && version) {
-                        assertExactStableVersion(version, "version");
-                        assertExactStableVersion(edgeRuntimeVersion, "edge_runtime_version");
                     }
                     const validatedProxy = args.github_proxy ? assertSafeGithubProxy(args.github_proxy) : undefined;
                     if (args.artifact_transport === "local") {
                         if (!version || !edgeRuntimeVersion) {
                             throw new Error("Local artifact transport requires exact 'version' and 'edge_runtime_version'");
                         }
-                        assertExactStableVersion(version, "version");
-                        assertExactStableVersion(edgeRuntimeVersion, "edge_runtime_version");
                         if (validatedProxy && !["direct", "none"].includes(validatedProxy.toLowerCase())) {
                             throw new Error("Local artifact transport only supports direct GitHub downloads");
                         }

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -33,6 +33,84 @@ const MINIMUM_COMPONENT_UPGRADE_VERSION = "0.50.27";
 const DIRECT_UPGRADE_SSH_TIMEOUT_MS = 720_000;
 // Proxy mode can exhaust each transfer once direct-first and once through the proxy.
 const PROXIED_UPGRADE_SSH_TIMEOUT_MS = 1_320_000;
+const PLATFORM_PROBE_TIMEOUT_MS = 10_000;
+const PLATFORM_HASH_TIMEOUT_MS = 30_000;
+const WEB_CONSOLE_CURRENT_DIR = "/opt/supacloud/web-console/current";
+const WEB_CONSOLE_MARKER = `${WEB_CONSOLE_CURRENT_DIR}/.supacloud-component.json`;
+const STABLE_SEMVER_CORE = "(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)";
+const EXACT_STABLE_SEMVER = new RegExp(`^(?:${STABLE_SEMVER_CORE})(?![\\s\\S])`);
+
+type ComponentProbeStatus = "ok" | "unknown" | "error";
+
+type BinaryComponentEvidence = {
+    status: ComponentProbeStatus;
+    version: string | null;
+    sha256: string | null;
+    path: string | null;
+    source: string;
+    error: string | null;
+};
+
+type WebConsoleEvidence = {
+    status: ComponentProbeStatus;
+    version: string | null;
+    tree_sha256: string | null;
+    path: string;
+    source: "component_marker_and_tree_sha256";
+    error: string | null;
+};
+
+type FixedBinaryCommand = {
+    version: string;
+    sha256: string;
+};
+
+type BinaryProbeDefinition = {
+    unit: string;
+    source: string;
+    commands: Readonly<Record<string, FixedBinaryCommand>>;
+};
+
+const BINARY_PROBES = {
+    management_api: {
+        unit: "supacloud.service",
+        source: "systemd:supacloud.service:ExecStart",
+        commands: {
+            "/usr/local/bin/supacloud": {
+                version: "/usr/local/bin/supacloud --version 2>&1",
+                sha256: "sha256sum -- /usr/local/bin/supacloud | awk '{print $1}'",
+            },
+            "/opt/supacloud/bin/supacloud": {
+                version: "/opt/supacloud/bin/supacloud --version 2>&1",
+                sha256: "sha256sum -- /opt/supacloud/bin/supacloud | awk '{print $1}'",
+            },
+        },
+    },
+    edge_runtime: {
+        unit: "supacloud-edge-runtime.service",
+        source: "systemd:supacloud-edge-runtime.service:ExecStart",
+        commands: {
+            "/usr/local/bin/supacloud-edge-runtime": {
+                version: "/usr/local/bin/supacloud-edge-runtime --version 2>&1",
+                sha256: "sha256sum -- /usr/local/bin/supacloud-edge-runtime | awk '{print $1}'",
+            },
+            "/opt/supacloud/bin/supacloud-edge-runtime": {
+                version: "/opt/supacloud/bin/supacloud-edge-runtime --version 2>&1",
+                sha256: "sha256sum -- /opt/supacloud/bin/supacloud-edge-runtime | awk '{print $1}'",
+            },
+        },
+    },
+    caddy: {
+        unit: "supacloud-caddy.service",
+        source: "systemd:supacloud-caddy.service:ExecStart",
+        commands: {
+            "/usr/local/bin/supacloud-caddy": {
+                version: "/usr/local/bin/supacloud-caddy version 2>&1",
+                sha256: "sha256sum -- /usr/local/bin/supacloud-caddy | awk '{print $1}'",
+            },
+        },
+    },
+} as const satisfies Record<string, BinaryProbeDefinition>;
 
 function hostnameSchema(fieldName: string) {
     return decodedSchema(Type.String(), Type.String({ minLength: 1, maxLength: 253 }), (value) => {
@@ -97,7 +175,8 @@ function assertSafeReleaseTag(value: string): string {
 }
 
 function assertExactStableVersion(value: string, fieldName: string): string {
-    if (!/^v?\d+\.\d+\.\d+$/.test(value)) {
+    const normalized = value.startsWith("v") ? value.slice(1) : value;
+    if (!EXACT_STABLE_SEMVER.test(normalized)) {
         throw new Error(`${fieldName} must be an exact stable semantic version`);
     }
     return value;
@@ -448,14 +527,240 @@ function assertSafeExecCommand(command: string): string {
     return reject();
 }
 
+type RemoteExecution = Awaited<ReturnType<SshTransport["exec"]>>;
+
+type ExecStartEvidence = {
+    status: ComponentProbeStatus;
+    path: string | null;
+    error: string | null;
+};
+
+async function runFixedRemoteCommand(
+    ssh: SshTransport,
+    command: string,
+    timeoutMs: number,
+): Promise<RemoteExecution | null> {
+    try {
+        return await ssh.exec(command, timeoutMs);
+    } catch {
+        return null;
+    }
+}
+
+function singleSystemdProperty(output: string, property: string): string | null {
+    const prefix = `${property}=`;
+    const matches = output.split(/\r?\n/).filter(line => line.startsWith(prefix));
+    return matches.length === 1 ? matches[0]!.slice(prefix.length) : null;
+}
+
+function strictExecStartPath(execStart: string): string | null {
+    if (execStart.length > 4096 || /[\r\n\0]/.test(execStart)) return null;
+    const matches = Array.from(execStart.matchAll(/(?:^|[{;]\s*)path=([^;}]+?)\s*(?=;|}|$)/g));
+    if (matches.length !== 1) return null;
+    const executablePath = matches[0]?.[1]?.trim() || "";
+    return /^\/[a-zA-Z0-9._/-]+$/.test(executablePath) ? executablePath : null;
+}
+
+function execStartEvidence(output: string): ExecStartEvidence {
+    if (output.length > 8192 || /\0/.test(output)) {
+        return { status: "error", path: null, error: "systemd_output_invalid" };
+    }
+    if (!output.trim()) return { status: "unknown", path: null, error: "unit_missing" };
+    const loadState = singleSystemdProperty(output, "LoadState");
+    const execStart = singleSystemdProperty(output, "ExecStart");
+    if (loadState === null || execStart === null) {
+        return { status: "error", path: null, error: "systemd_output_invalid" };
+    }
+    if (loadState !== "loaded") return { status: "unknown", path: null, error: "unit_not_loaded" };
+    if (execStart === "") return { status: "unknown", path: null, error: "exec_start_missing" };
+    const executablePath = strictExecStartPath(execStart);
+    return executablePath
+        ? { status: "ok", path: executablePath, error: null }
+        : { status: "error", path: null, error: "exec_start_invalid" };
+}
+
+function stableVersion(output: string): string | null {
+    if (output.length > 2048 || /\0/.test(output)) return null;
+    const matches = Array.from(output.matchAll(
+        new RegExp(`(?:^|[^0-9A-Za-z.+-])v?(${STABLE_SEMVER_CORE})(?=$|[^0-9A-Za-z.+-])`, "g"),
+    ));
+    const versions = new Set(matches.map(match => match[1]).filter(Boolean));
+    return versions.size === 1 ? [...versions][0]! : null;
+}
+
+function stableSha256(output: string): string | null {
+    const normalized = output.trim();
+    return /^[0-9a-f]{64}$/.test(normalized) ? normalized : null;
+}
+
+function unavailableBinaryEvidence(
+    definition: BinaryProbeDefinition,
+    evidence: ExecStartEvidence,
+): BinaryComponentEvidence {
+    return {
+        status: evidence.status,
+        version: null,
+        sha256: null,
+        path: evidence.path,
+        source: definition.source,
+        error: evidence.error,
+    };
+}
+
+function binaryProbeError(
+    versionExecution: RemoteExecution | null,
+    version: string | null,
+    hashExecution: RemoteExecution | null,
+    sha256: string | null,
+): string | null {
+    if (!versionExecution) return "version_probe_transport_failed";
+    if (!versionExecution.success) return "version_probe_failed";
+    if (!version) return "version_output_invalid";
+    if (!hashExecution) return "sha256_probe_transport_failed";
+    if (!hashExecution.success) return "sha256_probe_failed";
+    return sha256 ? null : "sha256_output_invalid";
+}
+
+async function binaryComponentEvidence(
+    ssh: SshTransport,
+    definition: BinaryProbeDefinition,
+): Promise<BinaryComponentEvidence> {
+    const execStart = await systemdBinaryEvidence(ssh, definition);
+    if (execStart.status !== "ok" || !execStart.path) return unavailableBinaryEvidence(definition, execStart);
+    const commands = definition.commands[execStart.path];
+    if (!commands) return unavailableBinaryEvidence(definition, {
+        status: "error", path: execStart.path, error: "exec_start_not_allowed",
+    });
+    return fixedBinaryEvidence(ssh, definition, execStart.path, commands);
+}
+
+async function systemdBinaryEvidence(
+    ssh: SshTransport,
+    definition: BinaryProbeDefinition,
+): Promise<ExecStartEvidence> {
+    const systemdCommand = `systemctl show --property=LoadState --property=ExecStart -- ${definition.unit}`;
+    const systemdExecution = await runFixedRemoteCommand(ssh, systemdCommand, PLATFORM_PROBE_TIMEOUT_MS);
+    if (!systemdExecution) return { status: "error", path: null, error: "systemd_probe_transport_failed" };
+    if (!systemdExecution.success) return { status: "error", path: null, error: "systemd_probe_failed" };
+    return execStartEvidence(systemdExecution.stdout);
+}
+
+async function fixedBinaryEvidence(
+    ssh: SshTransport,
+    definition: BinaryProbeDefinition,
+    executablePath: string,
+    commands: FixedBinaryCommand,
+): Promise<BinaryComponentEvidence> {
+    const [versionExecution, hashExecution] = await Promise.all([
+        runFixedRemoteCommand(ssh, commands.version, PLATFORM_PROBE_TIMEOUT_MS),
+        runFixedRemoteCommand(ssh, commands.sha256, PLATFORM_HASH_TIMEOUT_MS),
+    ]);
+    const version = versionExecution?.success ? stableVersion(versionExecution.stdout) : null;
+    const sha256 = hashExecution?.success ? stableSha256(hashExecution.stdout) : null;
+    const error = binaryProbeError(versionExecution, version, hashExecution, sha256);
+    return {
+        status: error ? "error" : "ok",
+        version,
+        sha256,
+        path: executablePath,
+        source: definition.source,
+        error,
+    };
+}
+
+function parseWebConsoleVersion(markerOutput: string): string | null {
+    if (markerOutput.length > 4096 || /\0/.test(markerOutput)) return null;
+    try {
+        const marker = JSON.parse(markerOutput) as unknown;
+        if (typeof marker !== "object" || marker === null || Array.isArray(marker)) return null;
+        const fields = marker as Record<string, unknown>;
+        if (fields.schema_version !== 1 || fields.component !== "web-console") return null;
+        return typeof fields.version === "string" && EXACT_STABLE_SEMVER.test(fields.version)
+            ? fields.version
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+const WEB_MARKER_COMMAND = [
+    `MARKER=${quoteEnvValue(WEB_CONSOLE_MARKER)}`,
+    "test ! -L \"$MARKER\" || exit 65",
+    "test -e \"$MARKER\" || exit 44",
+    "test -f \"$MARKER\" || exit 65",
+    "test \"$(stat -c '%s' -- \"$MARKER\")\" -le 4096 || exit 65",
+    "cat -- \"$MARKER\"",
+].join("; ");
+
+const WEB_TREE_SHA256_COMMAND = [
+    "set -o pipefail",
+    `ROOT=${quoteEnvValue(WEB_CONSOLE_CURRENT_DIR)}`,
+    "test -d \"$ROOT\" || exit 44",
+    "test -f \"$ROOT/.supacloud-component.json\" && test ! -L \"$ROOT/.supacloud-component.json\" || exit 65",
+    "if find -H \"$ROOT\" -xdev ! -type d ! -type f -print -quit | grep -q .; then exit 65; fi",
+    "find -H \"$ROOT\" -xdev -type f -print0 | LC_ALL=C sort -z | xargs -0 -r sha256sum -- | sha256sum | awk '{print $1}'",
+].join("; ");
+
+function webConsoleProbeError(
+    markerExecution: RemoteExecution | null,
+    version: string | null,
+    treeHashExecution: RemoteExecution | null,
+    treeSha256: string | null,
+): { status: ComponentProbeStatus; error: string | null } {
+    if (!markerExecution) return { status: "error", error: "marker_probe_transport_failed" };
+    if (markerExecution.code === 44) return { status: "unknown", error: "marker_missing" };
+    if (!markerExecution.success) return { status: "error", error: "marker_probe_failed" };
+    if (!version) return { status: "error", error: "marker_invalid" };
+    if (!treeHashExecution) return { status: "error", error: "tree_sha256_probe_transport_failed" };
+    if (treeHashExecution.code === 44) return { status: "unknown", error: "web_console_missing" };
+    if (!treeHashExecution.success) return { status: "error", error: "tree_sha256_probe_failed" };
+    return treeSha256 ? { status: "ok", error: null } : { status: "error", error: "tree_sha256_output_invalid" };
+}
+
+async function webConsoleEvidence(ssh: SshTransport): Promise<WebConsoleEvidence> {
+    const [markerExecution, treeHashExecution] = await Promise.all([
+        runFixedRemoteCommand(ssh, WEB_MARKER_COMMAND, PLATFORM_PROBE_TIMEOUT_MS),
+        runFixedRemoteCommand(ssh, WEB_TREE_SHA256_COMMAND, PLATFORM_HASH_TIMEOUT_MS),
+    ]);
+    const version = markerExecution?.success ? parseWebConsoleVersion(markerExecution.stdout) : null;
+    const treeSha256 = treeHashExecution?.success ? stableSha256(treeHashExecution.stdout) : null;
+    const state = webConsoleProbeError(markerExecution, version, treeHashExecution, treeSha256);
+    return {
+        status: state.status,
+        version,
+        tree_sha256: treeSha256,
+        path: WEB_CONSOLE_CURRENT_DIR,
+        source: "component_marker_and_tree_sha256",
+        error: state.error,
+    };
+}
+
+async function platformVersions(ssh: SshTransport) {
+    const [managementApi, edgeRuntime, caddy, webConsole] = await Promise.all([
+        binaryComponentEvidence(ssh, BINARY_PROBES.management_api),
+        binaryComponentEvidence(ssh, BINARY_PROBES.edge_runtime),
+        binaryComponentEvidence(ssh, BINARY_PROBES.caddy),
+        webConsoleEvidence(ssh),
+    ]);
+    return {
+        schema_version: 1,
+        components: {
+            management_api: managementApi,
+            edge_runtime: edgeRuntime,
+            caddy,
+            web_console: webConsole,
+        },
+    };
+}
+
 export function registerSshTools(server: { tool: (...args: any[]) => void }, ssh: SshTransport): void {
     server.tool(
         "ssh",
         `Server management via SSH. Available before & after SupaCloud installation.
-Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_logs, tenant_manage, tenant_list, tenant_inspect, tenant_diagnose, tenant_migrate`,
+Actions: ping, setup, install, upgrade, versions, diagnose, exec, troubleshoot, container_logs, tenant_manage, tenant_list, tenant_inspect, tenant_diagnose, tenant_migrate`,
         {
             action: withDescription(stringEnum([
-                "ping", "setup", "install", "upgrade", "diagnose", "exec",
+                "ping", "setup", "install", "upgrade", "versions", "diagnose", "exec",
                 "troubleshoot", "container_logs",
                 "tenant_manage", "tenant_list", "tenant_inspect", "tenant_diagnose", "tenant_migrate",
             ]), "Action to perform"),
@@ -673,17 +978,26 @@ Actions: ping, setup, install, upgrade, diagnose, exec, troubleshoot, container_
                     text = `✅ Upgrade done\n${upgradeExecution.stdout.slice(-300)}${edgeBoundary}`;
                     break;
                 }
+                case "versions": {
+                    text = JSON.stringify(await platformVersions(ssh), null, 2);
+                    break;
+                }
                 case "diagnose": {
                     const cmds = [
+                        "set -o pipefail",
                         "echo '=== OS ===' && uname -a",
                         "echo '=== Memory ===' && free -h",
                         "echo '=== Disk ===' && df -h /",
                         "echo '=== Docker ===' && (docker ps --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null || echo 'Not found')",
-                        "echo '=== PostgreSQL ===' && (pg_isready 2>/dev/null && echo 'Running' || echo 'Not detected')",
-                        "echo '=== Management API ===' && (curl -sf http://localhost:9090/health > /dev/null && echo 'Running' || echo 'Not running')",
+                        "echo '=== Management API /health ==='",
+                        "(curl --fail --silent --show-error --max-time 5 --max-filesize 4096 http://127.0.0.1:9090/health 2>&1 | head -c 4096) || echo 'Probe failed'",
+                        "printf '\\n'",
+                        "echo '=== Management API /monitor/health ==='",
+                        "(curl --fail --silent --show-error --max-time 15 --max-filesize 16384 http://127.0.0.1:9090/monitor/health 2>&1 | head -c 16384) || echo 'Probe failed'",
+                        "printf '\\n'",
                     ];
-                    const r = await ssh.exec(cmds.join(" && "));
-                    text = r.stdout || r.stderr;
+                    const r = await ssh.exec(cmds.join("\n"), 30_000);
+                    text = redactTenantConfig((r.stdout || r.stderr).slice(0, 32_768));
                     break;
                 }
                 case "exec": {

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -262,6 +262,7 @@ describe("runtime companion version assets", () => {
       copyFileSync(elf, join(edgePackage, edgeAsset));
       copyFileSync(elf, join(dir, caddyAsset));
       writeFileSync(join(webBuild, "index.html"), "local web build");
+      writeFileSync(join(webBuild, ".supacloud-component.json"), "{}\n");
 
       const invoke = (command: string, extraEnv: Record<string, string> = {}) => spawnSync(
         "bash",
@@ -323,6 +324,11 @@ describe("runtime companion version assets", () => {
         "-czf", join(dist, "web-console-build.tar.gz"), "-C", webBuild, ".",
       ], { encoding: "utf8" });
       expect(tarResult.status, tarResult.stderr).toBe(0);
+      const archivedWebFiles = spawnSync("tar", [
+        "-tzf", join(dist, "web-console-build.tar.gz"),
+      ], { encoding: "utf8" });
+      expect(archivedWebFiles.status, archivedWebFiles.stderr).toBe(0);
+      expect(archivedWebFiles.stdout.split(/\r?\n/)).toContain("./.supacloud-component.json");
 
       const selected = [
         invoke('select_management_binary_source "$MANAGEMENT_ASSET"'),

--- a/packages/web-console/component-marker.test.ts
+++ b/packages/web-console/component-marker.test.ts
@@ -22,6 +22,14 @@ describe('web console component marker', () => {
 		);
 	});
 
+	test('rejects non-stable package versions before emitting a release marker', () => {
+		for (const version of ['01.2.3', '0.28.8-rc.1', '0.28.8+build.4', '0.28.8\n']) {
+			expect(() => webConsoleComponentMarkerSource({ version })).toThrow(
+				'exact stable semantic version'
+			);
+		}
+	});
+
 	test('registers a build plugin that emits the marker at the build root', () => {
 		const configuredPluginNames = viteConfig.plugins
 			?.flat()

--- a/packages/web-console/component-marker.test.ts
+++ b/packages/web-console/component-marker.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import packageJson from './package.json' with { type: 'json' };
+import viteConfig from './vite.config';
+import {
+	WEB_CONSOLE_COMPONENT_MARKER_PLUGIN,
+	webConsoleComponentMarker,
+	webConsoleComponentMarkerSource
+} from './component-marker';
+
+type EmittedMarker = {
+	type: 'asset';
+	fileName: string;
+	source: string;
+};
+
+describe('web console component marker', () => {
+	test('uses the package version and stable component schema', () => {
+		const markerSource = webConsoleComponentMarkerSource(packageJson);
+
+		expect(markerSource).toBe(
+			`{\n  "schema_version": 1,\n  "component": "web-console",\n  "version": "${packageJson.version}"\n}\n`
+		);
+	});
+
+	test('registers a build plugin that emits the marker at the build root', () => {
+		const configuredPluginNames = viteConfig.plugins
+			?.flat()
+			.filter((plugin) => plugin && typeof plugin === 'object')
+			.map((plugin) => plugin.name);
+		expect(configuredPluginNames).toContain(WEB_CONSOLE_COMPONENT_MARKER_PLUGIN);
+
+		const emittedMarkers: EmittedMarker[] = [];
+		const plugin = webConsoleComponentMarker(packageJson);
+		const generateBundle = plugin.generateBundle;
+		if (typeof generateBundle !== 'function') {
+			throw new Error('Web Console marker plugin must define generateBundle');
+		}
+		Reflect.apply(generateBundle, {
+			emitFile(marker: EmittedMarker) {
+				emittedMarkers.push(marker);
+				return marker.fileName;
+			}
+		}, []);
+
+		expect(emittedMarkers).toEqual([{
+			type: 'asset',
+			fileName: '.supacloud-component.json',
+			source: webConsoleComponentMarkerSource(packageJson)
+		}]);
+	});
+});

--- a/packages/web-console/component-marker.ts
+++ b/packages/web-console/component-marker.ts
@@ -2,17 +2,25 @@ import type { Plugin } from 'vite';
 
 const WEB_CONSOLE_COMPONENT_MARKER = '.supacloud-component.json';
 export const WEB_CONSOLE_COMPONENT_MARKER_PLUGIN = 'supacloud-web-console-component-marker';
+const EXACT_STABLE_SEMVER = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
 
 type WebConsolePackage = {
 	version: string;
 };
+
+function exactStableWebConsoleVersion(version: string): string {
+	if (!EXACT_STABLE_SEMVER.test(version)) {
+		throw new Error('Web Console package version must be an exact stable semantic version');
+	}
+	return version;
+}
 
 export function webConsoleComponentMarkerSource(packageJson: WebConsolePackage): string {
 	return `${JSON.stringify(
 		{
 			schema_version: 1,
 			component: 'web-console',
-			version: packageJson.version
+			version: exactStableWebConsoleVersion(packageJson.version)
 		},
 		null,
 		2

--- a/packages/web-console/component-marker.ts
+++ b/packages/web-console/component-marker.ts
@@ -1,0 +1,34 @@
+import type { Plugin } from 'vite';
+
+const WEB_CONSOLE_COMPONENT_MARKER = '.supacloud-component.json';
+export const WEB_CONSOLE_COMPONENT_MARKER_PLUGIN = 'supacloud-web-console-component-marker';
+
+type WebConsolePackage = {
+	version: string;
+};
+
+export function webConsoleComponentMarkerSource(packageJson: WebConsolePackage): string {
+	return `${JSON.stringify(
+		{
+			schema_version: 1,
+			component: 'web-console',
+			version: packageJson.version
+		},
+		null,
+		2
+	)}\n`;
+}
+
+export function webConsoleComponentMarker(packageJson: WebConsolePackage): Plugin {
+	return {
+		name: WEB_CONSOLE_COMPONENT_MARKER_PLUGIN,
+		apply: 'build',
+		generateBundle() {
+			this.emitFile({
+				type: 'asset',
+				fileName: WEB_CONSOLE_COMPONENT_MARKER,
+				source: webConsoleComponentMarkerSource(packageJson)
+			});
+		}
+	};
+}

--- a/packages/web-console/vite.config.ts
+++ b/packages/web-console/vite.config.ts
@@ -1,9 +1,11 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+import packageJson from './package.json' with { type: 'json' };
+import { webConsoleComponentMarker } from './component-marker.ts';
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()],
+	plugins: [tailwindcss(), sveltekit(), webConsoleComponentMarker(packageJson)],
 	ssr: {
 		noExternal: ['lucide-svelte'],
 		external: ['bun', 'bun:sql', 'monaco-editor']


### PR DESCRIPTION
## 变更

- 新增受支持的 `ssh versions`，以稳定 JSON 契约报告 Management API、Edge Runtime、Caddy 和 Web Console 的版本与 SHA-256 证据。
- 二进制探针只接受 systemd `ExecStart` 中仓库确认的绝对路径，再执行固定版本与哈希命令；远端输出不会回拼 shell。
- Web Console 构建在制品根生成 `.supacloud-component.json`，并随 `web-console-build.tar.gz` 的既有校验与 provenance 链发布；旧制品无 marker 时明确返回 `unknown / marker_missing`，不猜版本。
- `ssh diagnose` 保留 Management 健康正文，并通过 `/monitor/health` 使用实际 `DATABASE_URL` 拓扑检查数据库；移除默认本机 5432 的裸 `pg_isready` 误报。
- 统一精确稳定 SemVer 边界，拒绝前导零、prerelease、build metadata 与尾换行。

## 安全边界

- 未放宽通用 `ssh exec` allowlist。
- 路径不在固定 allowlist、systemd 输出畸形、marker 非普通文件/软链/过大/字段无效、部分探针失败时均 fail closed，并保留组件级 `unknown` 或 `error`。
- 本 PR 未执行服务器写入或部署。

## 验证

- Admin 定向：63/63
- Admin 全量：157/157
- Admin typecheck / build：PASS
- Management runtime-version-assets：30/30
- Web marker：2/2
- Web check：0 errors / 0 warnings
- Web production build：PASS，marker 位于 build 根
- Release tar 回归：包含 `./.supacloud-component.json`
- `git diff --check`：PASS
- 独立 `clean-code-guard`：P0/P1/P2 = 0/0/0

## 只读实机验证

- Management `0.50.34`、Edge Runtime `0.16.9`、Caddy `2.11.4` 均返回 `status=ok`，哈希与既有部署验收一致。
- 当前旧 Web 制品无 marker，准确返回 `unknown / marker_missing`。
- `ssh diagnose` 返回有界的 Management 与数据库健康正文，不再出现默认 PostgreSQL socket 误报。