### PR TITLE
fix(lite): respect project function execution grants

### DIFF
--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -173,6 +173,22 @@ bunx supacloud-lite upgrade
 
 替换程序文件与数据库迁移是两个独立动作。`upgrade` 不会联网、自我替换二进制或修改 `package.json`；它默认先把升级前快照写入 `.supacloud-lite/backups/pre-upgrade-<timestamp>.tar.gz`，快照成功后才执行尚未记录的 migrations 和 seed。升级失败时快照会保留，并打印恢复命令。需要回滚时，停止候选进程，用升级前快照恢复状态，再重新启动上一个已验证版本。
 
+旧版 Lite 曾在 `public` schema 中直接给 `anon`、`authenticated` 和 `service_role` 授予函数执行权。已有持久化项目可能仍保留这些 ACL 和默认 ACL。升级不会自动批量撤销，因为 PostgreSQL 不能可靠区分旧版 Lite 注入的权限与项目显式授权。升级后应先创建快照，再审计 `pg_proc.proacl` 和 `pg_default_acl`。如果确认三个角色的默认函数权限不是项目意图，请先在新 migration 中撤销它们，再为需要收紧的每个已有函数增加带完整签名的显式 `REVOKE` / `GRANT`。不要对整个 schema 的已有函数执行无差别 `REVOKE`。可丢弃的本地项目可以使用 `supacloud-lite db reset` 在新的默认权限上重放 migrations；仅重启旧状态不会清理历史 ACL。
+
+```sql
+select n.nspname, p.proname, pg_get_function_identity_arguments(p.oid), p.proacl
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+order by p.proname, pg_get_function_identity_arguments(p.oid);
+
+select defaclrole, defaclnamespace, defaclobjtype, defaclacl
+from pg_default_acl;
+
+alter default privileges in schema public
+  revoke execute on functions from anon, authenticated, service_role;
+```
+
 也可以单独创建可移植快照：
 
 ```bash
@@ -484,6 +500,22 @@ For single-binary installs, download and verify the candidate file first, then h
 ```
 
 Replacing the program file and migrating the database are two separate actions. `upgrade` does not go online, self-replace the binary, or modify `package.json`; it first writes a pre-upgrade snapshot to `.supacloud-lite/backups/pre-upgrade-<timestamp>.tar.gz` by default, and only after the snapshot succeeds does it apply the unrecorded migrations and seed. If the upgrade fails, the snapshot is retained and a restore command is printed. To roll back, stop the candidate process, restore state from the pre-upgrade snapshot, and restart the last verified version.
+
+Older Lite versions directly granted function execution in the `public` schema to `anon`, `authenticated`, and `service_role`. Existing persistent projects may retain those ACLs and default ACLs. Upgrades do not revoke them in bulk because PostgreSQL cannot reliably distinguish an old Lite-injected grant from an intentional project grant. After taking a snapshot, audit `pg_proc.proacl` and `pg_default_acl`. If the three roles' default function privileges are not project intent, revoke them in a new migration, then add an explicit `REVOKE` / `GRANT` with the complete signature for each existing function that needs tighter access. Do not issue an indiscriminate schema-wide `REVOKE` against existing functions. Disposable local projects can use `supacloud-lite db reset` to replay migrations on the corrected defaults; merely restarting an old state does not remove historical ACLs.
+
+```sql
+select n.nspname, p.proname, pg_get_function_identity_arguments(p.oid), p.proacl
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public'
+order by p.proname, pg_get_function_identity_arguments(p.oid);
+
+select defaclrole, defaclnamespace, defaclobjtype, defaclacl
+from pg_default_acl;
+
+alter default privileges in schema public
+  revoke execute on functions from anon, authenticated, service_role;
+```
 
 You can also create a portable snapshot separately:
 

--- a/packages/supacloud-lite/src/runtime/db/bootstrap.ts
+++ b/packages/supacloud-lite/src/runtime/db/bootstrap.ts
@@ -228,14 +228,15 @@ alter role service_role set search_path to "$user", public, extensions;
 grant usage on schema public to anon, authenticated, service_role;
 grant all on all tables in schema public to anon, authenticated, service_role;
 grant all on all sequences in schema public to anon, authenticated, service_role;
-grant execute on all functions in schema public to anon, authenticated, service_role;
 
 alter default privileges in schema public
   grant all on tables to anon, authenticated, service_role;
 alter default privileges in schema public
   grant all on sequences to anon, authenticated, service_role;
-alter default privileges in schema public
-  grant execute on functions to anon, authenticated, service_role;
+
+-- PostgreSQL already grants EXECUTE on new functions to PUBLIC. Keep that
+-- default so project migrations can revoke PUBLIC and grant only selected
+-- roles without hidden direct grants from Lite. Existing ACLs are left intact.
 
 -- ── Auth schema (GoTrue-compatible subset) ───────────────────────────────
 create schema if not exists auth;

--- a/packages/supacloud-lite/test/integration.test.ts
+++ b/packages/supacloud-lite/test/integration.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createClient, type RealtimeChannel, type SupabaseClient } from '@supabase/supabase-js'
 import { startProjectServer, type RunningProjectServer } from '../src/project-runtime.js'
+import { BOOTSTRAP_SQL } from '../src/runtime/db/bootstrap.js'
 
 const migration = `
 create table public.todos (
@@ -66,6 +67,13 @@ grant usage on schema public to anon, authenticated, service_role;
 grant all on public.todos to authenticated, service_role;
 grant all on public.realtime_secrets to authenticated, service_role;
 grant usage, select on sequence public.todos_id_seq to authenticated, service_role;
+
+create function public.authenticated_only_rpc() returns boolean
+  language sql stable
+  as $$ select true $$;
+
+revoke all on function public.authenticated_only_rpc() from public;
+grant execute on function public.authenticated_only_rpc() to authenticated;
 `
 
 const functionSource = `
@@ -143,6 +151,32 @@ describe('SupaCloud Lite supabase-js compatibility', () => {
     expect(error).toBeNull()
     expect(data.user?.email).toBe('lite@example.com')
     expect(data.session?.access_token).toBeString()
+  })
+
+  test('honors project-defined RPC execution grants', async () => {
+    await expectRpcAllowed(userClient)
+    await expectRpcDenied(anonClient)
+    await expectRpcDenied(serviceClient)
+  })
+
+  test('preserves explicit RPC grants when bootstrapping persistent state', async () => {
+    await project.backend.db.exec(`
+      revoke all on function public.authenticated_only_rpc() from public, anon, authenticated, service_role;
+      grant execute on function public.authenticated_only_rpc() to anon;
+    `)
+    try {
+      await project.backend.db.exec(BOOTSTRAP_SQL)
+      project.backend.db.invalidateSchemaCache()
+
+      await expectRpcAllowed(anonClient)
+      await expectRpcDenied(userClient)
+      await expectRpcDenied(serviceClient)
+    } finally {
+      await project.backend.db.exec(`
+        revoke all on function public.authenticated_only_rpc() from public, anon, authenticated, service_role;
+        grant execute on function public.authenticated_only_rpc() to authenticated;
+      `)
+    }
   })
 
   test('supports PostgREST CRUD and PostgreSQL RLS', async () => {
@@ -439,6 +473,18 @@ function clientOptions(storageKey: string) {
     auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false, storageKey },
     realtime: { params: { eventsPerSecond: 20 } },
   }
+}
+
+async function expectRpcAllowed(client: SupabaseClient): Promise<void> {
+  const call = await client.rpc('authenticated_only_rpc')
+  expect(call.error).toBeNull()
+  expect(call.data).toBe(true)
+}
+
+async function expectRpcDenied(client: SupabaseClient): Promise<void> {
+  const call = await client.rpc('authenticated_only_rpc')
+  expect(call.data).toBeNull()
+  expect(call.error?.code).toBe('42501')
 }
 
 function createTusUpload(length: number, token: string, key: string, contentType = 'text/plain'): Promise<Response> {


### PR DESCRIPTION
## Summary

- stop SupaCloud Lite bootstrap from adding direct `EXECUTE` grants for `anon`, `authenticated`, and `service_role` to existing and future `public` functions
- preserve PostgreSQL native `PUBLIC EXECUTE` defaults so project migrations can restrict an RPC with `REVOKE ... FROM PUBLIC` followed by role-specific grants
- preserve explicit ACLs when an existing state is bootstrapped again
- document snapshot-first auditing and explicit remediation for historical function and default ACLs

## Root cause

Lite added both `GRANT EXECUTE ON ALL FUNCTIONS` and `ALTER DEFAULT PRIVILEGES ... GRANT EXECUTE` for all three API roles. A normal Supabase/PostgreSQL migration that revoked `PUBLIC` and granted only `authenticated` therefore left hidden direct grants for `anon` and `service_role`.

PostgreSQL already grants function execution to `PUBLIC` by default and allows the owner to revoke it in the function creation transaction: https://www.postgresql.org/docs/16/ddl-priv.html

## Persistent-state safety

This change intentionally does not blanket-revoke existing ACLs because Lite cannot distinguish a historical bootstrap grant from an intentional project grant. The README now explains how to snapshot, inspect `pg_proc.proacl` and `pg_default_acl`, remove unwanted historical default privileges in a migration, and update existing functions by complete signature. Disposable local states can use `db reset`.

## Verification

- TDD RED before the fix: anonymous RPC returned `true`; bootstrap rerun also re-enabled authenticated access to an anon-only RPC
- `bun run check`: 96 tests, 430 assertions; typecheck, build, package consumer smoke, standalone build, upgrade/snapshot/restore smoke all passed
- independent verifier: integration suite 12/12 and three repeated runs 36/36; catalog probes confirmed fresh ACLs, bootstrap reruns, and historical default-ACL preservation
- `git diff --check`

This PR is intentionally isolated from #787, #788, #790, #792, and #793.
