### PR TITLE
fix(cli): require atomic function policy receipts

### DIFF
--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -202,7 +202,7 @@ describe("edge_functions CLI tool", () => {
         expect(result.content[0].text).toContain("Function public-hook deployed");
     });
 
-    test("uses an explicitly labelled legacy PATCH when an old server omits policy confirmation", async () => {
+    test("rejects an unconfirmed bundle policy without a follow-up PATCH", async () => {
         const calls: Array<{ method: string; path: string; body: unknown }> = [];
         const { callback } = captureEdgeFunctionsTool({
             post: async (path: string, body: unknown) => {
@@ -211,7 +211,7 @@ describe("edge_functions CLI tool", () => {
             },
             patch: async (path: string, body: unknown) => {
                 calls.push({ method: "patch", path, body });
-                return { ok: true, status: 200, data: { verify_jwt: false } };
+                throw new Error("deploy must not patch policy after activation");
             },
         });
 
@@ -225,31 +225,39 @@ describe("edge_functions CLI tool", () => {
 
         expect(calls.map(({ method, path }) => ({ method, path }))).toEqual([
             { method: "post", path: "/v1/projects/proj/functions/legacy-hook/bundle" },
-            { method: "patch", path: "/v1/projects/proj/functions/legacy-hook/config" },
         ]);
-        expect(response.content[0].text).toContain("Legacy non-atomic compatibility path");
+        expect(response.content[0].text).toStartWith("❌ Unsafe deployment receipt");
+        expect(response.content[0].text).toContain("did not confirm the requested function policy");
+        expect(response.content[0].text).toContain("No follow-up PATCH was attempted");
+        expect(response.content[0].text).toContain("code and policy must be activated atomically");
     });
 
-    test("reports an unsafe partial deployment when legacy policy PATCH cannot be confirmed", async () => {
+    test("rejects a mismatched single-file policy without a follow-up PATCH", async () => {
+        const calls: Array<{ method: string; path: string }> = [];
         const { callback } = captureEdgeFunctionsTool({
-            post: async () => ({ ok: true, status: 200, data: { success: true } }),
-            patch: async () => ({ ok: false, status: 503, data: { message: "unavailable" } }),
+            post: async (path: string) => {
+                calls.push({ method: "post", path });
+                return { ok: true, status: 200, data: { success: true, verify_jwt: true } };
+            },
+            patch: async (path: string) => {
+                calls.push({ method: "patch", path });
+                throw new Error("deploy must not patch policy after activation");
+            },
         });
 
         const response = await callback({
-            action: "deploy_bundle",
+            action: "deploy",
             ref: "proj",
-            slug: "legacy-hook-fail",
-            files: { "index.ts": "export default {}" },
+            slug: "public-hook-mismatch",
+            code: "export default { fetch: () => new Response('ok') }",
             verify_jwt: false,
         });
 
-        expect(response.content[0].text).toContain("Partial deployment (unsafe)");
-        expect(response.content[0].text).toContain("POST succeeded");
-        expect(response.content[0].text).toContain("code/bundle was deployed");
-        expect(response.content[0].text).toContain("function policy was not confirmed");
-        expect(response.content[0].text).toContain("legacy PATCH fallback failed");
-        expect(response.content[0].text).not.toContain("Deployment failed");
+        expect(calls).toEqual([
+            { method: "post", path: "/v1/projects/proj/functions/public-hook-mismatch" },
+        ]);
+        expect(response.content[0].text).toStartWith("❌ Unsafe deployment receipt");
+        expect(response.content[0].text).toContain("No follow-up PATCH was attempted");
     });
 });
 

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -188,21 +188,14 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
                     : `❌ Config update failed (${cr.status}): ${JSON.stringify(cr.data)}`;
             };
 
-            const confirmedDeploymentText = async (
+            const deploymentPolicyReceiptText = (
                 successText: string,
                 responsePayload: unknown,
-            ): Promise<string> => {
+            ): string => {
                 if (!hasFunctionConfig() || confirmedFunctionConfig(responsePayload, functionConfig())) {
                     return successText;
                 }
-                const fallback = await http.patch(
-                    `/v1/projects/${ref}/functions/${slug}/config`,
-                    functionConfig(),
-                );
-                if (!fallback.ok || !confirmedFunctionConfig(fallback.data, functionConfig())) {
-                    return `❌ Partial deployment (unsafe): POST succeeded and the code/bundle was deployed, but the function policy was not confirmed; legacy PATCH fallback failed (${fallback.status}): ${JSON.stringify(fallback.data)}`;
-                }
-                return `${successText}\n⚠️ Legacy non-atomic compatibility path: policy applied with follow-up PATCH`;
+                return "❌ Unsafe deployment receipt: POST succeeded but did not confirm the requested function policy. No follow-up PATCH was attempted because code and policy must be activated atomically.";
             };
 
             const checkSyntax = async (sourceCode: string): Promise<{ ok: boolean; err?: string }> => {
@@ -257,7 +250,7 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
                         text = `❌ Failed (${dr.status}): ${JSON.stringify(dr.data)}`;
                         break;
                     }
-                    text = await confirmedDeploymentText(`✅ Function ${slug} deployed`, dr.data);
+                    text = deploymentPolicyReceiptText(`✅ Function ${slug} deployed`, dr.data);
                     break;
                 case "deploy_bundle":
                     need("slug", slug); need("files", files);
@@ -271,7 +264,7 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
                         text = `❌ Failed (${br.status}): ${JSON.stringify(br.data)}`;
                         break;
                     }
-                    text = await confirmedDeploymentText(
+                    text = deploymentPolicyReceiptText(
                         `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)`,
                         br.data,
                     );


### PR DESCRIPTION
## Summary

- remove the legacy follow-up PATCH from `edge_functions deploy` and `deploy_bundle`
- fail closed when a successful POST receipt does not exactly confirm the requested `verify_jwt` and `background_routes` policy
- preserve the explicit `edge_functions config` PATCH action

## Why

Function code and its runtime policy must be activated by the same deployment request. The compatibility fallback could expose newly deployed code under an unconfirmed policy and still report a successful compatibility path.

## Verification

- `bun test src` (111 passed)
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- independent review: P0/P1/P2 = 0/0/0