### PR TITLE
fix(admin): support project create domain flags

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -29,7 +29,7 @@ npx @supacloud/admin status
 npx @supacloud/admin ssh ping
 npx @supacloud/admin ssh versions
 npx @supacloud/admin ssh diagnose
-npx @supacloud/admin project create --name my-app
+npx @supacloud/admin project create --name my-app --domain example.com
 npx @supacloud/admin project list
 ```
 

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -181,6 +181,16 @@ describe("supacloud-admin process contract", () => {
         expect(result.output).toContain("SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN");
     });
 
+    test("documents every project create domain flag without API context", async () => {
+        const execution = await runAdminCli(["project", "create", "--help"]);
+
+        expect(execution.exitCode).toBe(0);
+        expect(execution.output).toContain("--domain");
+        expect(execution.output).toContain("--api_domain");
+        expect(execution.output).toContain("--auth_domain");
+        expect(execution.output).toContain("--studio_domain");
+    });
+
     test("surfaces every sanitized cause when an operation and cleanup both fail", async () => {
         const result = await runAggregateFailureCli();
 

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -18,11 +18,6 @@ import packageMetadata from "../package.json" with { type: "json" };
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
 type ToolMap = Record<string, ToolEntry>;
 
-const adminProjectActionSchema = stringEnum([
-    "list", "create", "get", "delete", "pause", "restore",
-    "restart", "settings", "update_settings", "api_keys",
-    "health", "logs", "tasks",
-]);
 const platformActionSchema = stringEnum([
     "metrics", "list_backups", "create_backup",
     "network", "update_network",
@@ -81,7 +76,7 @@ EXAMPLES
   supacloud-admin ssh ping
   supacloud-admin ssh versions
   supacloud-admin ssh install --public_domain api.example.com --studio_domain studio.example.com
-  supacloud-admin project create --name my-app
+  supacloud-admin project create --name my-app --domain example.com
   supacloud-admin project list
   supacloud-admin platform metrics
   supacloud-admin gateway routes --ref abc123
@@ -119,8 +114,11 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
     };
 
     const registerAdminHelp = () => {
+        const projectHelpTool = captureTools((server) =>
+            registerAdminProjectCliTools(server as any, {} as HttpTransport)
+        ).project;
         tools.project = {
-            schema: { action: adminProjectActionSchema },
+            schema: projectHelpTool.schema,
             callback: async () => ({
                 isError: true,
                 content: [

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { registerAdminProjectCliTools } from "./project-cli-tools";
+
+type ProjectCallback = (
+    args: Record<string, unknown>,
+) => Promise<{ content: Array<{ text: string }> }>;
+
+function captureAdminProjectTool(http: Record<string, unknown>): ProjectCallback {
+    let projectCallback: ProjectCallback | undefined;
+    registerAdminProjectCliTools({
+        tool(name: string, _description: string, _schema: Record<string, unknown>, callback: ProjectCallback) {
+            if (name === "project") projectCallback = callback;
+        },
+    }, http as any);
+
+    if (!projectCallback) throw new Error("admin project tool was not registered");
+    return projectCallback;
+}
+
+describe("admin project create", () => {
+    test("forwards every non-empty custom domain unchanged", async () => {
+        const requests: Array<{ path: string; body: unknown }> = [];
+        const projectCallback = captureAdminProjectTool({
+            post: async (path: string, body: unknown) => {
+                requests.push({ path, body });
+                return { ok: true, status: 201, data: { ref: "project-ref" } };
+            },
+        });
+
+        await projectCallback({
+            action: "create",
+            name: "domain-project",
+            region: "ap-southeast-1",
+            organization_id: "organization-id",
+            domain: "Example.COM",
+            api_domain: "API.Example.COM",
+            auth_domain: "Auth.Example.COM",
+            studio_domain: "Studio.Example.COM",
+        });
+
+        expect(requests).toEqual([{
+            path: "/v1/projects",
+            body: {
+                name: "domain-project",
+                region: "ap-southeast-1",
+                organization_id: "organization-id",
+                domain: "Example.COM",
+                api_domain: "API.Example.COM",
+                auth_domain: "Auth.Example.COM",
+                studio_domain: "Studio.Example.COM",
+            },
+        }]);
+    });
+
+    test("omits empty custom domain flags from the create request", async () => {
+        let createRequest: Record<string, unknown> | undefined;
+        const projectCallback = captureAdminProjectTool({
+            post: async (_path: string, body: Record<string, unknown>) => {
+                createRequest = body;
+                return { ok: true, status: 201, data: { ref: "project-ref" } };
+            },
+        });
+
+        await projectCallback({
+            action: "create",
+            name: "default-domain-project",
+            domain: "",
+            api_domain: "",
+            auth_domain: "",
+            studio_domain: "",
+        });
+
+        if (!createRequest) throw new Error("project create request was not captured");
+        expect(createRequest.name).toBe("default-domain-project");
+        expect(createRequest.region).toBe("local");
+        expect("domain" in createRequest).toBe(false);
+        expect("api_domain" in createRequest).toBe(false);
+        expect("auth_domain" in createRequest).toBe(false);
+        expect("studio_domain" in createRequest).toBe(false);
+    });
+});

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -109,20 +109,46 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
             name: optional(Type.String(), "[create] Project name"),
             region: optional(Type.String(), "[create] Region (default: local)"),
             organization_id: optional(Type.String(), "[create] Organization ID"),
+            domain: optional(Type.String(), "[create] Base custom domain"),
+            api_domain: optional(Type.String(), "[create] Explicit API domain"),
+            auth_domain: optional(Type.String(), "[create] Explicit Auth/OIDC domain"),
+            studio_domain: optional(Type.String(), "[create] Explicit Studio domain"),
             settings: optional(Type.Record(Type.String(), Type.Unknown()), "[update_settings] Config fields to update"),
             log_type: optional(stringEnum(["all", "auth", "database", "api"]), "[logs] Filter by service"),
         },
-        async ({ action, ref, name, region, organization_id, settings, log_type }) => {
+        async ({
+            action,
+            ref,
+            name,
+            region,
+            organization_id,
+            domain,
+            api_domain,
+            auth_domain,
+            studio_domain,
+            settings,
+            log_type,
+        }) => {
             let text: string;
 
             switch (action) {
                 case "list":
                     text = ok(await http.get("/v1/projects"));
                     break;
-                case "create":
+                case "create": {
                     if (!name) throw new Error("'name' is required for create");
-                    text = ok(await http.post("/v1/projects", { name, region: region || "local", organization_id }));
+                    const createRequest: Record<string, string | undefined> = {
+                        name,
+                        region: region || "local",
+                        organization_id,
+                    };
+                    if (domain) createRequest.domain = domain;
+                    if (api_domain) createRequest.api_domain = api_domain;
+                    if (auth_domain) createRequest.auth_domain = auth_domain;
+                    if (studio_domain) createRequest.studio_domain = studio_domain;
+                    text = ok(await http.post("/v1/projects", createRequest));
                     break;
+                }
                 case "get":
                     text = ok(await http.get(`/v1/projects/${resolveRef(ref)}`));
                     break;

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -179,6 +179,22 @@ describe("supacloud-cli process contract", () => {
         expect(result.stdout + result.stderr).toContain("project-scoped API context");
     });
 
+    test("does not expose admin project creation through the project CLI", async () => {
+        const response = await runProjectCli(
+            ["project", "create", "--name", "unauthorized-project", "--domain", "example.com"],
+            {
+                SUPACLOUD_API_URL: "http://127.0.0.1:1",
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stderr).toContain("Invalid arguments");
+        expect(response.stderr).toContain("action");
+        expect(response.stdout).toBe("");
+    });
+
     test.each([
         ["separate flag value", ["--log_type", "database"]],
         ["equals flag value", ["--log_type=database"]],

--- a/packages/cli/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { registerUserProjectCliTools } from "./project-cli-tools";
+import { schemaEnumValues, type ToolSchema } from "../schema";
+import { registerAdminProjectCliTools, registerUserProjectCliTools } from "./project-cli-tools";
 
 function captureProjectTool(http: Record<string, unknown>, projectRef = "proj") {
     let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
@@ -11,6 +12,18 @@ function captureProjectTool(http: Record<string, unknown>, projectRef = "proj") 
     }, http as any, { projectRef });
 
     if (!callback) throw new Error("project tool was not registered");
+    return callback;
+}
+
+function captureAdminProjectTool(http: Record<string, unknown>) {
+    let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+    registerAdminProjectCliTools({
+        tool(name: string, _description: string, _schema: Record<string, unknown>, toolCallback: typeof callback) {
+            if (name === "project") callback = toolCallback;
+        },
+    }, http as any);
+
+    if (!callback) throw new Error("admin project tool was not registered");
     return callback;
 }
 
@@ -55,5 +68,55 @@ describe("project CLI task actions", () => {
 
         expect(calls).toEqual(["/v1/projects/proj/tasks/stats"]);
         expect(result.content[0].text).toContain("Task Stats");
+    });
+});
+
+describe("admin project create compatibility", () => {
+    test("forwards custom domains through the retained admin registration", async () => {
+        const requests: Array<{ path: string; body: unknown }> = [];
+        const callback = captureAdminProjectTool({
+            post: async (path: string, body: unknown) => {
+                requests.push({ path, body });
+                return { ok: true, status: 201, data: { ref: "project-ref" } };
+            },
+        });
+
+        await callback({
+            action: "create",
+            name: "domain-project",
+            domain: "Example.COM",
+            api_domain: "API.Example.COM",
+            auth_domain: "Auth.Example.COM",
+            studio_domain: "Studio.Example.COM",
+        });
+
+        expect(requests).toEqual([{
+            path: "/v1/projects",
+            body: {
+                name: "domain-project",
+                region: "local",
+                organization_id: undefined,
+                domain: "Example.COM",
+                api_domain: "API.Example.COM",
+                auth_domain: "Auth.Example.COM",
+                studio_domain: "Studio.Example.COM",
+            },
+        }]);
+    });
+
+    test("does not expose admin create fields through the user project registration", () => {
+        let userProjectSchema: ToolSchema | undefined;
+        registerUserProjectCliTools({
+            tool(name: string, _description: string, schema: ToolSchema) {
+                if (name === "project") userProjectSchema = schema;
+            },
+        }, {} as any, { projectRef: "proj" });
+
+        if (!userProjectSchema) throw new Error("user project tool was not registered");
+        expect(schemaEnumValues(userProjectSchema.action)).not.toContain("create");
+        expect(userProjectSchema.domain).toBeUndefined();
+        expect(userProjectSchema.api_domain).toBeUndefined();
+        expect(userProjectSchema.auth_domain).toBeUndefined();
+        expect(userProjectSchema.studio_domain).toBeUndefined();
     });
 });

--- a/packages/cli/src/shared/tools/project-cli-tools.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.ts
@@ -240,6 +240,10 @@ Actions: list, create, get, delete, pause, restore, restart, settings, update_se
             name: optional(Type.String(), "[create] Project name"),
             region: optional(Type.String(), "[create] Region (default: local)"),
             organization_id: optional(Type.String(), "[create] Organization ID"),
+            domain: optional(Type.String(), "[create] Base custom domain"),
+            api_domain: optional(Type.String(), "[create] Explicit API domain"),
+            auth_domain: optional(Type.String(), "[create] Explicit Auth/OIDC domain"),
+            studio_domain: optional(Type.String(), "[create] Explicit Studio domain"),
             settings: optional(Type.Record(Type.String(), Type.Unknown()), "[update_settings] Config fields to update"),
             log_type: optional(stringEnum(["all", "auth", "database", "api"]), "[logs] Filter by service"),
             task_id: optional(Type.String(), "[task_detail/task_cancel/task_retry] Task ID"),
@@ -247,17 +251,43 @@ Actions: list, create, get, delete, pause, restore, restart, settings, update_se
             concurrency: optional(Type.Number(), "[update_background_settings] Max concurrent background tasks"),
             max_attempts: optional(Type.Number(), "[update_background_settings] Max attempts for background tasks"),
         },
-        async ({ action, ref, name, region, organization_id, settings, log_type, task_id, limit, concurrency, max_attempts }) => {
+        async ({
+            action,
+            ref,
+            name,
+            region,
+            organization_id,
+            domain,
+            api_domain,
+            auth_domain,
+            studio_domain,
+            settings,
+            log_type,
+            task_id,
+            limit,
+            concurrency,
+            max_attempts,
+        }) => {
             let text: string;
 
             switch (action) {
                 case "list":
                     text = ok(await http.get("/v1/projects"));
                     break;
-                case "create":
+                case "create": {
                     if (!name) throw new Error("'name' is required for create");
-                    text = ok(await http.post("/v1/projects", { name, region: region || "local", organization_id }));
+                    const createRequest: Record<string, string | undefined> = {
+                        name,
+                        region: region || "local",
+                        organization_id,
+                    };
+                    if (domain) createRequest.domain = domain;
+                    if (api_domain) createRequest.api_domain = api_domain;
+                    if (auth_domain) createRequest.auth_domain = auth_domain;
+                    if (studio_domain) createRequest.studio_domain = studio_domain;
+                    text = ok(await http.post("/v1/projects", createRequest));
                     break;
+                }
                 case "get":
                     text = ok(await http.get(`/v1/projects/${resolveRef(ref)}`));
                     break;


### PR DESCRIPTION
## Summary
- expose domain, api_domain, auth_domain, and studio_domain on Admin project create
- forward only non-empty domain flags unchanged to POST /v1/projects
- keep project-scoped supacloud-cli creation unavailable and document Admin create flags without requiring API context

## Verification
- packages/admin: typecheck, 174 tests, build, audit
- packages/cli: typecheck, 114 tests, build, audit
- git diff --check
- clean-code-guard: 1 test-only redundancy fixed, 0 findings remaining

No deployment or release performed.
