### PR TITLE
fix(admin): propagate CLI failure exit codes

### DIFF
--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -4,7 +4,7 @@ import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } 
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createAdminTools } from "./index";
-import { formatCliError } from "./shared/cli";
+import { cliToolResultIsError, formatCliError } from "./shared/cli";
 import { schemaEnumValues } from "./shared/schema";
 import packageMetadata from "../package.json" with { type: "json" };
 
@@ -134,6 +134,11 @@ describe("admin SSH registration gate", () => {
 });
 
 describe("supacloud-admin process contract", () => {
+    test("classifies explicit tool errors without requiring content", () => {
+        expect(cliToolResultIsError({ isError: true })).toBe(true);
+        expect(cliToolResultIsError({})).toBe(false);
+    });
+
     test("prints the exact package version", async () => {
         const execution = await runAdminCli(["--version"]);
 

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -24,18 +24,21 @@ const ADMIN_CONTEXT_KEYS = new Set([
     "SUPACLOUD_SSH_HOST_FINGERPRINT",
 ]);
 
-function cleanEnvironment(): Record<string, string> {
+function cleanEnvironment(overrides: Record<string, string> = {}): Record<string, string> {
     const env: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
         if (value !== undefined && !ADMIN_CONTEXT_KEYS.has(key)) env[key] = value;
     }
-    return env;
+    return { ...env, ...overrides };
 }
 
-async function runAdminCli(args: string[]): Promise<{ exitCode: number; output: string }> {
+async function runAdminCli(
+    args: string[],
+    overrides: Record<string, string> = {},
+): Promise<{ exitCode: number; output: string }> {
     const processHandle = Bun.spawn([process.execPath, "src/index.ts", ...args], {
         cwd: PACKAGE_ROOT,
-        env: cleanEnvironment(),
+        env: cleanEnvironment(overrides),
         stdout: "pipe",
         stderr: "pipe",
     });
@@ -181,6 +184,17 @@ describe("supacloud-admin process contract", () => {
         expect(result.output).toContain("SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN");
     });
 
+    test("returns a non-zero exit code when a shortcut command reports failure text", async () => {
+        const execution = await runAdminCli(["project"], {
+            SUPACLOUD_API_URL: "http://127.0.0.1:1",
+            SUPACLOUD_API_TOKEN: "test-token",
+        });
+
+        expect(execution.exitCode).toBe(1);
+        expect(execution.output).toContain("❌ Unknown action: undefined");
+        expect(execution.output).not.toContain("test-token");
+    });
+
     test("documents every project create domain flag without API context", async () => {
         const execution = await runAdminCli(["project", "create", "--help"]);
 
@@ -189,6 +203,43 @@ describe("supacloud-admin process contract", () => {
         expect(execution.output).toContain("--api_domain");
         expect(execution.output).toContain("--auth_domain");
         expect(execution.output).toContain("--studio_domain");
+    });
+
+    test("returns a non-zero exit code when project creation is rejected", async () => {
+        const requests: Array<{ path: string; body: unknown }> = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requests.push({
+                    path: new URL(request.url).pathname,
+                    body: await request.json(),
+                });
+                return Response.json({ message: "invalid domain" }, { status: 400 });
+            },
+        });
+
+        try {
+            const execution = await runAdminCli(
+                ["project", "create", "--name", "rejected-project", "--domain", "invalid.example"],
+                {
+                    SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                    SUPACLOUD_API_TOKEN: "test-token",
+                },
+            );
+
+            expect(execution.exitCode).toBe(1);
+            expect(execution.output).toContain("❌ Failed (400)");
+            expect(requests).toEqual([{
+                path: "/v1/projects",
+                body: expect.objectContaining({
+                    name: "rejected-project",
+                    domain: "invalid.example",
+                }),
+            }]);
+        } finally {
+            server.stop(true);
+        }
     });
 
     test("surfaces every sanitized cause when an operation and cleanup both fail", async () => {

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -272,10 +272,10 @@ async function main() {
                     console.log(chunk.text);
                 }
             }
-            if (cliToolResultIsError(result)) process.exitCode = 1;
-            return;
+        } else {
+            console.log(JSON.stringify(result, null, 2));
         }
-        console.log(JSON.stringify(result, null, 2));
+        if (cliToolResultIsError(result)) process.exitCode = 1;
         return;
     }
     await runCli(cliTools, args, { commandName: "supacloud-admin" });

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -5,7 +5,7 @@ import { stringEnum } from "./shared/schema";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { realpathSync } from "node:fs";
-import { runCli } from "./shared/cli";
+import { cliToolResultIsError, runCli } from "./shared/cli";
 import { resolveSupaCloudContext, type ResolvedContext } from "./shared/context";
 import { HttpTransport } from "./shared/transports/http";
 import { SshTransport } from "./shared/transports/ssh";
@@ -272,7 +272,7 @@ async function main() {
                     console.log(chunk.text);
                 }
             }
-            if (result.isError === true) process.exitCode = 1;
+            if (cliToolResultIsError(result)) process.exitCode = 1;
             return;
         }
         console.log(JSON.stringify(result, null, 2));

--- a/packages/admin/src/shared/cli.ts
+++ b/packages/admin/src/shared/cli.ts
@@ -17,6 +17,13 @@ interface CliToolResult {
     isError?: boolean;
 }
 
+export function cliToolResultIsError(toolResult: CliToolResult): boolean {
+    if (toolResult.isError === true) return true;
+    return toolResult.content?.some((chunk) =>
+        chunk.type === "text" && chunk.text?.trimStart().startsWith("❌") === true
+    ) ?? false;
+}
+
 function coerceCliValue(value: string): string | number | boolean {
     if (value === "true") return true;
     if (value === "false") return false;
@@ -180,7 +187,7 @@ export async function runCli(
         } else {
             console.log(JSON.stringify(result, null, 2));
         }
-        process.exit(result && typeof result === "object" && "isError" in result && result.isError === true ? 1 : 0);
+        process.exit(cliToolResultIsError(result) ? 1 : 0);
     } catch (error: unknown) {
         const message = formatCliError(error);
         console.error(`❌ Error: ${message}`);


### PR DESCRIPTION
Follow-up to #800. The Admin CLI printed tool failure text while exiting 0 when a tool did not set `isError`, including Management API 400 responses and the single-command shortcut path.

This change:
- centralizes Admin tool-result failure detection;
- applies it to both normal and shortcut execution paths;
- adds real-process regressions for rejected project creation and shortcut failures.

Verification:
- Admin 176/176 tests
- Admin typecheck
- Admin build
- `git diff --check`
- independent review P0/P1/P2 = 0/0/0