### PR TITLE
feat(cli): add multi-environment env profiles

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **cli:** add atomic named and explicit environment profiles with secret-safe status output
+
+### Bug Fixes
+
+* **cli:** fail closed for production and read-only writes, and require exact production confirmation
+* **cli:** honor explicit project refs consistently while preventing production cross-ref writes
+
 ## [0.14.6](https://github.com/zuohuadong/supacloud/compare/cli-v0.14.5...cli-v0.14.6) (2026-08-10)
 
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -36,16 +36,102 @@ grants, extensions, and reference-data changes in migrations; use read-only SQL
 for ordinary inspection; dry-run remote migrations; and reconcile existing
 remote drift before touching migration history.
 
-`supacloud-cli` defaults to the current workspace's project context. If you do not pass explicit flags, it tries to auto-link from `.env`:
+## Environment profiles and production safety
+
+Use named environment files to keep test and production configuration separate.
+`--env test` reads `.env.supacloud.test` from the current working directory;
+`--env prod` reads `.env.supacloud.prod` and treats the profile as production.
+For example:
+
+```dotenv
+# .env.supacloud.test
+SUPACLOUD_ENV=test
+SUPACLOUD_API_URL=https://management.test.example.com
+SUPACLOUD_API_TOKEN=<test-management-api-token>
+SUPACLOUD_PROJECT_REF=test-ref
+```
+
+```dotenv
+# .env.supacloud.prod
+SUPACLOUD_ENV=production
+SUPACLOUD_API_URL=https://management.example.com
+SUPACLOUD_API_TOKEN=<production-management-api-token>
+SUPACLOUD_PROJECT_REF=production-ref
+```
+
+Run commands with the selected profile:
+
+```bash
+supacloud-cli --env test status
+supacloud-cli project get --env test
+supacloud-cli status --env-file ./config/supacloud.staging.env
+```
+
+Global flags may appear before or after the command. Both `--key value` and
+`--key=value` syntax are accepted. `--env` and `--env-file` are mutually
+exclusive. An explicit `--env-file` must declare `SUPACLOUD_ENV`.
+
+Environment files contain credentials. The repository root `.gitignore`
+already ignores `.env` and `.env.*`; do not force-add or commit these files.
+Restrict locally created files to the current user:
+
+```bash
+chmod 600 .env.supacloud.test .env.supacloud.prod
+```
+
+CI can provide one complete context through process environment variables
+instead of writing a file:
+
+```bash
+SUPACLOUD_ENV=test \
+SUPACLOUD_API_URL=https://management.test.example.com \
+SUPACLOUD_API_TOKEN="$CI_SUPACLOUD_API_TOKEN" \
+SUPACLOUD_PROJECT_REF=test-ref \
+supacloud-cli status
+```
+
+Project context is resolved from one atomic source: a named profile selected by
+`--env`, an explicit `--env-file`, a complete process environment, or the
+legacy `.env` fallback. Core URL, token, and project-ref values are not filled
+by mixing sources. If `SUPACLOUD_ENV` is set without a complete process context,
+it strictly selects `.env.supacloud.<value>`. For backward compatibility, when
+no selector and no core process variables are present, `supacloud-cli` still
+tries to auto-link from `.env` using:
 
 - `SUPABASE_URL` or `SUPACLOUD_API_URL`
 - `SUPABASE_SERVICE_ROLE_KEY` or `SUPACLOUD_API_TOKEN`
 - `SUPACLOUD_PROJECT_REF` when the project ref cannot be inferred from a managed `<ref>.api.*` hostname
 
-Both `--key value` and `--key=value` flag syntax are accepted. `--ref` can
-override the auto-linked project for an individual command. `status` checks
-configuration, Management API connectivity, and authentication; it exits
-non-zero when any required check fails.
+The legacy `.env` fallback is unclassified and therefore does not enable the
+production confirmation gate. Production automation must select a `prod` or
+`production` profile, or set `SUPACLOUD_ENV=production` together with a complete
+process context. Use `SUPACLOUD_READ_ONLY=true` when legacy workflows must be
+restricted to inspection only.
+
+`SUPACLOUD_READ_ONLY=true` is a safety override that blocks remote writes.
+Production writes require an explicit confirmation equal to the selected
+profile's project ref:
+
+```bash
+supacloud-cli database push_migrations --env prod \
+  --ref production-ref --dir supabase/migrations \
+  --confirm-production production-ref
+```
+
+Dry runs remain read operations. Production `diagnostics repair` is always
+forbidden, and unclassified actions fail closed in production or read-only
+contexts.
+
+For supported command groups, `--ref` overrides the profile's default project
+for one command. A production profile cannot target a different project with
+`--ref`; the requested ref and `--confirm-production` must both exactly match
+the profile's project ref.
+
+`status` checks configuration, Management API connectivity, and authentication;
+it exits non-zero when any required check fails. Its output includes
+`environment`, `source` (`kind` and `path`), `apiUrl`, `projectRef`, `readOnly`,
+`production`, and `hasApiToken`. It never prints the API token or service-role
+key.
 
 Examples:
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,6 +16,8 @@ const CONTEXT_KEYS = new Set([
     "SUPACLOUD_PROJECT_REF",
     "X_PROJECT_REF",
     "SUPACLOUD_HOST",
+    "SUPACLOUD_ENV",
+    "SUPACLOUD_READ_ONLY",
 ]);
 
 const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
@@ -42,9 +44,10 @@ function cleanEnvironment(overrides: Record<string, string> = {}): Record<string
 async function runProjectCli(
     args: string[],
     overrides: Record<string, string> = {},
+    workingDirectory = PACKAGE_ROOT,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-    const processHandle = Bun.spawn([process.execPath, "src/index.ts", ...args], {
-        cwd: PACKAGE_ROOT,
+    const processHandle = Bun.spawn([process.execPath, join(PACKAGE_ROOT, "src/index.ts"), ...args], {
+        cwd: workingDirectory,
         env: cleanEnvironment(overrides),
         stdout: "pipe",
         stderr: "pipe",
@@ -68,6 +71,89 @@ function serveFunctionSource(sourceCode: string): string {
 }
 
 describe("supacloud-cli process contract", () => {
+    test("documents global environment and production safety flags", async () => {
+        const response = await runProjectCli(["--help"]);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("--env <name>");
+        expect(response.stderr).toContain("--env-file <path>");
+        expect(response.stderr).toContain("--confirm-production <ref>");
+        expect(response.stderr).toContain("SUPACLOUD_READ_ONLY=true");
+    });
+
+    test("loads named environments with global flags after the command and keeps status secret-free", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-named-env-"));
+        temporaryDirectories.push(workspace);
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json({ status: "healthy" }),
+        });
+        servers.push(server);
+        const environmentPath = join(workspace, ".env.supacloud.test");
+        writeFileSync(environmentPath, [
+            "SUPACLOUD_ENV=test",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=named-secret-token",
+            "SUPACLOUD_PROJECT_REF=test-ref",
+        ].join("\n") + "\n");
+
+        const response = await runProjectCli(["status", "--env=test"], {}, workspace);
+        const status = JSON.parse(response.stdout);
+
+        expect(response.exitCode).toBe(0);
+        expect(status).toMatchObject({
+            environment: "test",
+            source: { kind: "named_env_file", path: realpathSync(environmentPath) },
+            apiUrl: `http://127.0.0.1:${server.port}`,
+            projectRef: "test-ref",
+            readOnly: false,
+            production: false,
+            hasApiToken: true,
+        });
+        expect(response.stdout).not.toContain("named-secret-token");
+    });
+
+    test("requires exact production confirmation and rejects cross-ref writes", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-production-env-"));
+        temporaryDirectories.push(workspace);
+        const requestedPaths: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requestedPaths.push(new URL(request.url).pathname);
+                return Response.json({ status: "cancelled" });
+            },
+        });
+        servers.push(server);
+        writeFileSync(join(workspace, ".env.supacloud.prod"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=prod-secret-token",
+            "SUPACLOUD_PROJECT_REF=prod-ref",
+        ].join("\n") + "\n");
+
+        const unconfirmed = await runProjectCli([
+            "--env", "prod", "project", "task_cancel", "--task_id", "task-1",
+        ], {}, workspace);
+        const confirmed = await runProjectCli([
+            "project", "task_cancel", "--task_id", "task-1",
+            "--env=prod", "--confirm-production=prod-ref",
+        ], {}, workspace);
+        const crossRef = await runProjectCli([
+            "project", "task_cancel", "--task_id", "task-1", "--ref", "other-ref",
+            "--env", "prod", "--confirm-production", "other-ref",
+        ], {}, workspace);
+
+        expect(unconfirmed.exitCode).toBe(1);
+        expect(unconfirmed.stderr).toContain("--confirm-production prod-ref");
+        expect(confirmed.exitCode).toBe(0);
+        expect(crossRef.exitCode).toBe(1);
+        expect(crossRef.stderr).toContain("cannot target a different project");
+        expect(requestedPaths).toEqual(["/v1/projects/prod-ref/tasks/task-1/cancel"]);
+    });
+
     test("flushes a Function source response larger than 64 KiB to stdout", async () => {
         const apiUrl = serveFunctionSource(LARGE_FUNCTION_SOURCE);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,8 @@ import { Type } from "@sinclair/typebox";
 import { stringEnum } from "./shared/schema";
 import { cliToolResultIsError, runCli } from "./shared/cli";
 import { resolveSupaCloudContext, type ResolvedContext } from "./shared/context";
+import { parseGlobalOptions } from "./shared/global-options";
+import { authorizeExecution, validateExecutionPolicyCoverage } from "./shared/execution-policy";
 import { HttpTransport } from "./shared/transports/http";
 import { registerDatabaseTools } from "./shared/tools/database-tools";
 import { registerAuthTools } from "./shared/tools/auth-tools";
@@ -111,9 +113,12 @@ async function createProjectStatusResult(context: ResolvedContext) {
     const checks = await collectProjectStatusChecks(context);
     const statusPayload = {
         mode: "project",
-        source: context.source,
+        environment: context.environment || null,
+        source: { kind: context.source, path: context.sourcePath },
         projectRef: context.projectRef || null,
         apiUrl: context.apiUrl || null,
+        readOnly: context.readOnly,
+        production: context.production,
         autoLinked: Boolean(context.inferredSupabaseUrl && context.inferredServiceRoleKey),
         hasApiToken: Boolean(context.apiToken),
         checks,
@@ -149,7 +154,7 @@ function captureTools(register: (server: { tool: (...args: any[]) => void }) => 
     return tools;
 }
 
-function printHelp(context = resolveSupaCloudContext()) {
+function printHelp(context: ResolvedContext) {
     const autoLink = context.inferredSupabaseUrl
         ? `Project context: ${context.inferredSupabaseUrl} (${context.source})`
         : "Project context: not detected";
@@ -162,17 +167,29 @@ function printHelp(context = resolveSupaCloudContext()) {
 
 USAGE
 
-  ${preferredCommand} <module> <action> [--flags]
-  ${preferredCommand} status
+  ${preferredCommand} [global flags] <module> <action> [--flags]
+  ${preferredCommand} [global flags] status
   ${preferredCommand} --help
+
+GLOBAL FLAGS
+
+  --env <name>                    Load .env.supacloud.<name> from the current directory.
+  --env-file <path>               Load an exact file that declares SUPACLOUD_ENV.
+  --confirm-production <ref>      Confirm a write to the selected production project.
+
+  Global flags may appear before or after the command. --env and --env-file are
+  mutually exclusive, and a selected source is never mixed with another source.
 
 DEFAULT CONTEXT
 
-  Unauthenticated runs default to the current project's .env.
+  Without a selector or project variables, runs use the current project's legacy .env.
   Supported auto-link variables:
     SUPABASE_URL / SUPACLOUD_API_URL
     SUPABASE_SERVICE_ROLE_KEY / SUPACLOUD_API_TOKEN
     SUPACLOUD_PROJECT_REF (when it cannot be inferred from <ref>.api.*)
+
+  SUPACLOUD_READ_ONLY=true blocks remote writes. Production writes require an
+  exact --confirm-production value, and cannot override the selected project ref.
 
   status checks configuration, Management API connectivity, and authentication.
   It exits non-zero when a required check fails.
@@ -216,8 +233,23 @@ SEPARATE ADMIN CLI
 `);
 }
 
-function createCliTools(): ToolMap {
-    const context = resolveSupaCloudContext();
+function authorizedToolMap(
+    tools: ToolMap,
+    context: ResolvedContext,
+    confirmProduction?: string,
+): ToolMap {
+    validateExecutionPolicyCoverage(tools);
+    for (const [moduleName, tool] of Object.entries(tools)) {
+        const callback = tool.callback;
+        tool.callback = async (args: Record<string, unknown>) => {
+            authorizeExecution(moduleName, args, { context, confirmProduction });
+            return callback(args);
+        };
+    }
+    return tools;
+}
+
+function createCliTools(context: ResolvedContext, confirmProduction?: string): ToolMap {
     let pushMigrations: ((args: Record<string, unknown>) => Promise<any>) | undefined;
     const tools: ToolMap = {
         status: {
@@ -245,6 +277,8 @@ function createCliTools(): ToolMap {
                             "⚠️ Project commands need a project-scoped API context.",
                             "",
                             "Provide one of these sources:",
+                            "  - --env <name> for .env.supacloud.<name>",
+                            "  - --env-file <path> for a file declaring SUPACLOUD_ENV",
                             "  - .env with SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY",
                             "  - SUPACLOUD_API_URL + SUPACLOUD_API_TOKEN",
                             "",
@@ -294,11 +328,14 @@ function createCliTools(): ToolMap {
                             `${preferredCommand} expects project-scoped credentials by default.`,
                             "Provide one of these sources:",
                             "",
-                            "  1. Current workspace .env",
+                            "  1. Named environment file",
+                            "     supacloud-cli --env test status",
+                            "",
+                            "  2. Current workspace .env",
                             "     SUPABASE_URL=https://your-project.example.com",
                             "     SUPABASE_SERVICE_ROLE_KEY=...",
                             "",
-                            "  2. Explicit environment variables",
+                            "  3. Explicit environment variables",
                             "     SUPACLOUD_API_URL=https://your-project.example.com",
                             "     SUPACLOUD_API_TOKEN=...",
                             "",
@@ -309,7 +346,7 @@ function createCliTools(): ToolMap {
                 ],
             }),
         };
-        return tools;
+        return authorizedToolMap(tools, context, confirmProduction);
     }
 
     const http = new HttpTransport({
@@ -344,18 +381,23 @@ function createCliTools(): ToolMap {
     })));
 
     delete tools.platform;
-    return tools;
+    return authorizedToolMap(tools, context, confirmProduction);
 }
 
 async function main() {
-    const args = process.argv.slice(2);
+    const globalOptions = parseGlobalOptions(process.argv.slice(2));
+    const args = globalOptions.args;
+    const context = resolveSupaCloudContext(process.env, process.cwd(), {
+        environmentName: globalOptions.environmentName,
+        envFile: globalOptions.envFile,
+    });
     if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
-        printHelp();
+        printHelp(context);
         process.exitCode = 0;
         return;
     }
 
-    const cliTools = createCliTools();
+    const cliTools = createCliTools(context, globalOptions.confirmProduction);
     if (args.length === 1 && !["ai", "supabase"].includes(args[0]) && cliTools[args[0]]) {
         const result = await cliTools[args[0]].callback({});
         if (result?.content && Array.isArray(result.content)) {

--- a/packages/cli/src/shared/context.test.ts
+++ b/packages/cli/src/shared/context.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { resolveSupaCloudContext } from "./context";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+function temporaryWorkspace(): string {
+    const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-context-"));
+    temporaryDirectories.push(workspace);
+    return workspace;
+}
+
+function writeEnvironment(workspace: string, filename: string, values: Record<string, string>): string {
+    const path = join(workspace, filename);
+    writeFileSync(path, Object.entries(values).map(([key, value]) => `${key}=${value}`).join("\n") + "\n");
+    return path;
+}
 
 describe("resolveSupaCloudContext", () => {
     test("infers management URL from custom project API domain", () => {
@@ -34,6 +57,17 @@ describe("resolveSupaCloudContext", () => {
         expect(context.apiToken).toBe("token");
     });
 
+    test("prefers SUPACLOUD_API_TOKEN within one atomic source", () => {
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_URL: "https://management.example.com",
+            SUPACLOUD_PROJECT_REF: "project-ref",
+            SUPACLOUD_API_TOKEN: "api-token",
+            SUPABASE_SERVICE_ROLE_KEY: "service-role",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.apiToken).toBe("api-token");
+    });
+
     test("explicit project ref wins over managed hostname inference", () => {
         const context = resolveSupaCloudContext({
             SUPABASE_URL: "https://inferred.api.example.com",
@@ -55,5 +89,152 @@ describe("resolveSupaCloudContext", () => {
         expect(context.host).toBe("");
         expect(context.inferredSupabaseUrl).toBe("");
         expect(context.apiToken).toBe("service-role");
+    });
+
+    test("strictly selects a named environment file without mixing process context", () => {
+        const workspace = temporaryWorkspace();
+        const path = writeEnvironment(workspace, ".env.supacloud.Test", {
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: "https://test-management.example.com",
+            SUPACLOUD_API_TOKEN: "file-token",
+            SUPACLOUD_PROJECT_REF: "test-ref",
+        });
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_TOKEN: "process-token",
+        }, workspace, { environmentName: "Test" });
+
+        expect(context).toMatchObject({
+            environment: "test",
+            source: "named_env_file",
+            sourcePath: path,
+            apiToken: "file-token",
+            projectRef: "test-ref",
+            production: false,
+        });
+    });
+
+    test("does not fall back when a named environment file is missing", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env", {
+            SUPACLOUD_API_URL: "https://legacy.example.com",
+            SUPACLOUD_API_TOKEN: "legacy-token",
+            SUPACLOUD_PROJECT_REF: "legacy-ref",
+        });
+
+        expect(() => resolveSupaCloudContext({}, workspace, { environmentName: "missing" }))
+            .toThrow(".env.supacloud.missing");
+    });
+
+    test("requires explicit files to declare SUPACLOUD_ENV", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, "custom.env", {
+            SUPACLOUD_API_URL: "https://management.example.com",
+        });
+
+        expect(() => resolveSupaCloudContext({}, workspace, { envFile: "custom.env" }))
+            .toThrow("SUPACLOUD_ENV is required");
+    });
+
+    test("loads quoted values from an explicit environment file", () => {
+        const workspace = temporaryWorkspace();
+        const path = join(workspace, "ci.env");
+        writeFileSync(path, [
+            'SUPACLOUD_ENV="production"',
+            "SUPACLOUD_API_URL='https://management.example.com/'",
+            'SUPACLOUD_API_TOKEN="file-token"',
+            "SUPACLOUD_PROJECT_REF='prod-ref'",
+        ].join("\n") + "\n");
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_TOKEN: "process-token",
+        }, workspace, { envFile: "ci.env" });
+
+        expect(context).toMatchObject({
+            environment: "production",
+            source: "explicit_env_file",
+            sourcePath: path,
+            apiUrl: "https://management.example.com",
+            apiToken: "file-token",
+            projectRef: "prod-ref",
+            production: true,
+        });
+    });
+
+    test("rejects a named file whose declared environment differs from its selector", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env.supacloud.test", { SUPACLOUD_ENV: "prod" });
+
+        expect(() => resolveSupaCloudContext({}, workspace, { environmentName: "test" }))
+            .toThrow("does not match selector test");
+    });
+
+    test("uses complete SUPACLOUD_ENV process context as one CI source", () => {
+        const workspace = temporaryWorkspace();
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_ENV: "production",
+            SUPACLOUD_API_URL: "https://management.example.com",
+            SUPACLOUD_API_TOKEN: "process-token",
+            SUPACLOUD_PROJECT_REF: "prod-ref",
+        }, workspace);
+
+        expect(context).toMatchObject({
+            environment: "production",
+            source: "process_env",
+            sourcePath: null,
+            projectRef: "prod-ref",
+            production: true,
+        });
+    });
+
+    test("uses SUPACLOUD_ENV as a strict named selector when process context is incomplete", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env.supacloud.test", {
+            SUPACLOUD_API_URL: "https://test.example.com",
+            SUPACLOUD_API_TOKEN: "file-token",
+            SUPACLOUD_PROJECT_REF: "test-ref",
+        });
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_TOKEN: "partial-process-token",
+        }, workspace);
+
+        expect(context.source).toBe("named_env_file");
+        expect(context.apiToken).toBe("file-token");
+    });
+
+    test("does not mix partial process context with legacy dotenv", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env", {
+            SUPACLOUD_API_TOKEN: "dotenv-token",
+            SUPACLOUD_PROJECT_REF: "dotenv-ref",
+        });
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_URL: "https://process.example.com",
+        }, workspace);
+
+        expect(context.source).toBe("process_env");
+        expect(context.apiUrl).toBe("https://process.example.com");
+        expect(context.apiToken).toBe("");
+        expect(context.projectRef).toBe("");
+    });
+
+    test("keeps legacy dotenv compatibility when process context is absent", () => {
+        const workspace = temporaryWorkspace();
+        const path = writeEnvironment(workspace, ".env", {
+            SUPACLOUD_API_URL: "https://legacy.example.com",
+            SUPACLOUD_API_TOKEN: "legacy-token",
+            SUPACLOUD_PROJECT_REF: "legacy-ref",
+        });
+
+        const context = resolveSupaCloudContext({}, workspace);
+
+        expect(context).toMatchObject({
+            source: "legacy_dotenv",
+            sourcePath: path,
+            projectRef: "legacy-ref",
+        });
     });
 });

--- a/packages/cli/src/shared/context.ts
+++ b/packages/cli/src/shared/context.ts
@@ -1,6 +1,14 @@
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { normalizeEnvironmentName } from "./global-options";
+
+export type ContextSourceKind = "process_env" | "named_env_file" | "explicit_env_file" | "legacy_dotenv" | "none";
+
+export interface ContextSelection {
+    environmentName?: string;
+    envFile?: string;
+}
 
 export interface ResolvedContext {
     host: string;
@@ -12,57 +20,64 @@ export interface ResolvedContext {
     apiToken: string;
     projectRef: string;
     readOnly: boolean;
+    environment: string;
+    production: boolean;
     inferredSupabaseUrl: string;
     inferredServiceRoleKey: string;
-    source: "env" | "dotenv" | "mixed" | "none";
+    source: ContextSourceKind;
+    sourcePath: string | null;
 }
 
-interface EnvLookupResult {
-    value: string;
-    source: "env" | "dotenv";
+interface ContextSource {
+    values: Record<string, string>;
+    kind: ContextSourceKind;
+    path: string | null;
+    environment: string;
 }
 
-function readDotEnvFile(cwd: string): Record<string, string> {
-    const envPath = resolve(cwd, ".env");
-    if (!existsSync(envPath)) return {};
+const CORE_CONTEXT_KEYS = [
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPACLOUD_API_URL",
+    "SUPACLOUD_MANAGEMENT_API_URL",
+    "MANAGEMENT_API_URL",
+    "SUPACLOUD_API_TOKEN",
+    "SUPACLOUD_PROJECT_REF",
+    "X_PROJECT_REF",
+    "SUPACLOUD_HOST",
+] as const;
 
+function unquotedEnvValue(rawValue: string): string {
+    const value = rawValue.trim();
+    const quote = value[0];
+    return quote && (quote === '"' || quote === "'") && value.endsWith(quote)
+        ? value.slice(1, -1)
+        : value;
+}
+
+function parseEnvFile(contents: string): Record<string, string> {
     const values: Record<string, string> = {};
-    try {
-        const envContent = readFileSync(envPath, "utf-8");
-        for (const line of envContent.split("\n")) {
-            const match = line.trim().match(/^([^=]+)=(.*)$/);
-            if (!match) continue;
-            const key = match[1].trim();
-            const value = match[2].trim().replace(/^["']|["']$/g, "");
-            values[key] = value;
-        }
-    } catch {
-        return {};
+    for (const rawLine of contents.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith("#")) continue;
+        const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+        if (!match) continue;
+        values[match[1]] = unquotedEnvValue(match[2]);
     }
     return values;
 }
 
-function pickValue(
-    env: NodeJS.ProcessEnv,
-    dotenv: Record<string, string>,
-    keys: string[],
-): EnvLookupResult {
-    for (const key of keys) {
-        const envValue = env[key];
-        if (envValue) return { value: envValue, source: "env" };
+function readEnvFile(path: string, required: boolean): Record<string, string> {
+    if (!existsSync(path)) {
+        if (required) throw new Error(`SupaCloud environment file not found: ${path}`);
+        return {};
     }
-    for (const key of keys) {
-        const dotenvValue = dotenv[key];
-        if (dotenvValue) return { value: dotenvValue, source: "dotenv" };
+    try {
+        return parseEnvFile(readFileSync(path, "utf8"));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to read SupaCloud environment file ${path}: ${message}`);
     }
-    return { value: "", source: "env" };
-}
-
-function detectSource(sources: Array<"env" | "dotenv" | "none">): ResolvedContext["source"] {
-    const present = new Set(sources.filter((value) => value !== "none"));
-    if (present.size === 0) return "none";
-    if (present.size === 1) return present.has("env") ? "env" : "dotenv";
-    return "mixed";
 }
 
 function normalizeUrl(value: string): string {
@@ -86,9 +101,7 @@ function hostFromUrl(value: string): string {
 function inferProjectRefFromSupabaseUrl(value: string): string {
     const normalized = normalizeUrl(value);
     if (!normalized) return "";
-
-    const match = new URL(normalized).hostname.match(/^([a-z0-9-]+)\.api\./i);
-    return match?.[1] ?? "";
+    return new URL(normalized).hostname.match(/^([a-z0-9-]+)\.api\./i)?.[1] ?? "";
 }
 
 function inferManagementApiUrlFromSupabaseUrl(value: string, projectRef = ""): string {
@@ -101,55 +114,117 @@ function inferManagementApiUrlFromSupabaseUrl(value: string, projectRef = ""): s
         url.hostname = `studio.${host.slice("api.".length)}`;
         return url.toString().replace(/\/+$/, "");
     }
-
     const ref = projectRef.trim();
     if (ref && host.startsWith(`${ref}.api.`)) {
         url.hostname = `studio-${ref}.${host.slice(`${ref}.api.`.length)}`;
         return url.toString().replace(/\/+$/, "");
     }
-
-    const managedHostMatch = host.match(/^([a-z0-9-]+)\.api\.(.+)$/i);
-    if (managedHostMatch) {
-        url.hostname = `studio-${managedHostMatch[1]}.${managedHostMatch[2]}`;
+    const managedHost = host.match(/^([a-z0-9-]+)\.api\.(.+)$/i);
+    if (managedHost) {
+        url.hostname = `studio-${managedHost[1]}.${managedHost[2]}`;
         return url.toString().replace(/\/+$/, "");
     }
-
     return normalized;
+}
+
+function sourceProjectCore(values: Record<string, string>) {
+    const supabaseUrl = normalizeUrl(values.SUPABASE_URL || "");
+    const projectRef = (values.SUPACLOUD_PROJECT_REF || values.X_PROJECT_REF || "").trim()
+        || inferProjectRefFromSupabaseUrl(supabaseUrl);
+    const explicitApiUrl = values.SUPACLOUD_API_URL
+        || values.SUPACLOUD_MANAGEMENT_API_URL
+        || values.MANAGEMENT_API_URL
+        || "";
+    const apiUrl = normalizeUrl(explicitApiUrl)
+        || inferManagementApiUrlFromSupabaseUrl(supabaseUrl, projectRef)
+        || (values.SUPACLOUD_HOST ? `http://${values.SUPACLOUD_HOST}:9090` : "");
+    const apiToken = values.SUPACLOUD_API_TOKEN || values.SUPABASE_SERVICE_ROLE_KEY || "";
+    return { apiUrl, apiToken, projectRef, supabaseUrl };
+}
+
+function processValues(env: NodeJS.ProcessEnv): Record<string, string> {
+    return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined));
+}
+
+function hasProcessContext(env: NodeJS.ProcessEnv): boolean {
+    return CORE_CONTEXT_KEYS.some((key) => Object.hasOwn(env, key));
+}
+
+function completeProjectContext(values: Record<string, string>): boolean {
+    const core = sourceProjectCore(values);
+    return Boolean(core.apiUrl && core.apiToken && core.projectRef);
+}
+
+function namedEnvironmentSource(cwd: string, selector: string): ContextSource {
+    const environment = normalizeEnvironmentName(selector);
+    const path = resolve(cwd, `.env.supacloud.${selector}`);
+    const values = readEnvFile(path, true);
+    if (values.SUPACLOUD_ENV && normalizeEnvironmentName(values.SUPACLOUD_ENV) !== environment) {
+        throw new Error(`SUPACLOUD_ENV in ${path} does not match selector ${selector}`);
+    }
+    return { values, kind: "named_env_file", path, environment };
+}
+
+function explicitEnvironmentSource(cwd: string, envFile: string): ContextSource {
+    const path = resolve(cwd, envFile);
+    const values = readEnvFile(path, true);
+    if (!values.SUPACLOUD_ENV) throw new Error(`SUPACLOUD_ENV is required in ${path}`);
+    return {
+        values,
+        kind: "explicit_env_file",
+        path,
+        environment: normalizeEnvironmentName(values.SUPACLOUD_ENV),
+    };
+}
+
+function contextSource(env: NodeJS.ProcessEnv, cwd: string, selection: ContextSelection): ContextSource {
+    if (selection.environmentName && selection.envFile) throw new Error("Environment selectors are mutually exclusive");
+    if (selection.environmentName) return namedEnvironmentSource(cwd, selection.environmentName);
+    if (selection.envFile) return explicitEnvironmentSource(cwd, selection.envFile);
+
+    if (env.SUPACLOUD_ENV) {
+        const environment = normalizeEnvironmentName(env.SUPACLOUD_ENV);
+        const values = processValues(env);
+        if (completeProjectContext(values)) {
+            return { values, kind: "process_env", path: null, environment };
+        }
+        return namedEnvironmentSource(cwd, env.SUPACLOUD_ENV);
+    }
+    if (hasProcessContext(env)) {
+        return { values: processValues(env), kind: "process_env", path: null, environment: "" };
+    }
+
+    const path = resolve(cwd, ".env");
+    const values = readEnvFile(path, false);
+    const environment = values.SUPACLOUD_ENV ? normalizeEnvironmentName(values.SUPACLOUD_ENV) : "";
+    return { values, kind: Object.keys(values).length ? "legacy_dotenv" : "none", path: existsSync(path) ? path : null, environment };
 }
 
 export function resolveSupaCloudContext(
     env: NodeJS.ProcessEnv = process.env,
     cwd: string = process.cwd(),
+    selection: ContextSelection = {},
 ): ResolvedContext {
-    const dotenv = readDotEnvFile(cwd);
-    const supabaseUrl = pickValue(env, dotenv, ["SUPABASE_URL"]);
-    const explicitApiUrl = pickValue(env, dotenv, ["SUPACLOUD_API_URL", "SUPACLOUD_MANAGEMENT_API_URL", "MANAGEMENT_API_URL"]);
-    const inferredToken = pickValue(env, dotenv, ["SUPABASE_SERVICE_ROLE_KEY", "SUPACLOUD_API_TOKEN"]);
-    const explicitProjectRef = pickValue(env, dotenv, ["SUPACLOUD_PROJECT_REF", "X_PROJECT_REF"]).value;
-
-    const hostFromEnv = env.SUPACLOUD_HOST;
-    const normalizedSupabaseUrl = normalizeUrl(supabaseUrl.value);
-    const projectRef = explicitProjectRef || inferProjectRefFromSupabaseUrl(normalizedSupabaseUrl);
-    const apiUrl = normalizeUrl(explicitApiUrl.value)
-        || inferManagementApiUrlFromSupabaseUrl(normalizedSupabaseUrl, projectRef)
-        || (hostFromEnv ? `http://${hostFromEnv}:9090` : "");
-    const resolvedHostFromUrl = hostFromUrl(apiUrl || normalizedSupabaseUrl);
+    const source = contextSource(env, cwd, selection);
+    const core = sourceProjectCore(source.values);
+    const host = source.values.SUPACLOUD_HOST || hostFromUrl(core.apiUrl || core.supabaseUrl);
+    const readOnly = env.SUPACLOUD_READ_ONLY === "true" || source.values.SUPACLOUD_READ_ONLY === "true";
 
     return {
-        host: hostFromEnv ?? resolvedHostFromUrl,
+        host,
         sshUser: env.SUPACLOUD_SSH_USER ?? "root",
         sshPort: parseInt(env.SUPACLOUD_SSH_PORT ?? "22", 10),
         sshKey: env.SUPACLOUD_SSH_KEY ?? resolve(homedir(), ".ssh", "id_rsa"),
         sshPass: env.SUPACLOUD_SSH_PASS ?? "",
-        apiUrl,
-        apiToken: env.SUPACLOUD_API_TOKEN ?? inferredToken.value,
-        projectRef,
-        readOnly: env.SUPACLOUD_READ_ONLY === "true",
-        inferredSupabaseUrl: normalizedSupabaseUrl,
-        inferredServiceRoleKey: inferredToken.value,
-        source: detectSource([
-            (supabaseUrl.value || explicitApiUrl.value) ? (supabaseUrl.value ? supabaseUrl.source : explicitApiUrl.source) : "none",
-            inferredToken.value ? inferredToken.source : "none",
-        ]),
+        apiUrl: core.apiUrl,
+        apiToken: core.apiToken,
+        projectRef: core.projectRef,
+        readOnly,
+        environment: source.environment,
+        production: source.environment === "prod" || source.environment === "production",
+        inferredSupabaseUrl: core.supabaseUrl,
+        inferredServiceRoleKey: source.values.SUPABASE_SERVICE_ROLE_KEY || "",
+        source: source.kind,
+        sourcePath: source.path,
     };
 }

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -1,7 +1,47 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { stringEnum } from "./schema";
 import { authorizeExecution, executionMode, validateExecutionPolicyCoverage } from "./execution-policy";
 import type { ResolvedContext } from "./context";
+
+const CLI_ENTRYPOINT = fileURLToPath(new URL("../index.ts", import.meta.url));
+const CONTEXT_ENVIRONMENT_KEYS = [
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPACLOUD_API_URL",
+    "SUPACLOUD_MANAGEMENT_API_URL",
+    "MANAGEMENT_API_URL",
+    "SUPACLOUD_API_TOKEN",
+    "SUPACLOUD_PROJECT_REF",
+    "X_PROJECT_REF",
+    "SUPACLOUD_HOST",
+    "SUPACLOUD_ENV",
+    "SUPACLOUD_READ_ONLY",
+];
+
+function cliEnvironment(): Record<string, string> {
+    const environment = Object.fromEntries(
+        Object.entries(process.env).filter(([key, value]) => value !== undefined && !CONTEXT_ENVIRONMENT_KEYS.includes(key)),
+    ) as Record<string, string>;
+    return environment;
+}
+
+async function runCli(args: string[], workingDirectory: string) {
+    const processHandle = Bun.spawn([process.execPath, CLI_ENTRYPOINT, ...args], {
+        cwd: workingDirectory,
+        env: cliEnvironment(),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stderr] = await Promise.all([
+        processHandle.exited,
+        new Response(processHandle.stderr).text(),
+    ]);
+    return { exitCode, stderr };
+}
 
 function context(overrides: Partial<ResolvedContext> = {}): ResolvedContext {
     return {
@@ -39,6 +79,50 @@ describe("CLI execution policy", () => {
             context: context(),
             confirmProduction: "other-ref",
         })).toThrow("cannot target a different project");
+    });
+
+    test("rejects cross-project production reads while preserving same-project and non-production reads", () => {
+        expect(() => authorizeExecution("project", { action: "api_keys", ref: "other-ref" }, {
+            context: context(),
+        })).toThrow("cannot target a different project");
+        expect(() => authorizeExecution("project", { action: "api_keys", ref: "prod-ref" }, {
+            context: context(),
+        })).not.toThrow();
+        expect(() => authorizeExecution("project", { action: "api_keys", ref: "other-ref" }, {
+            context: context({ production: false, environment: "test" }),
+        })).not.toThrow();
+    });
+
+    test("blocks cross-project production reads before the CLI sends HTTP", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-production-read-"));
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount++;
+                return Response.json([]);
+            },
+        });
+        writeFileSync(join(workspace, ".env.supacloud.prod"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=prod-secret-token",
+            "SUPACLOUD_PROJECT_REF=prod-ref",
+        ].join("\n") + "\n");
+
+        try {
+            const response = await runCli([
+                "--env", "prod", "project", "api_keys", "--ref", "other-ref",
+            ], workspace);
+
+            expect(response.exitCode).toBe(1);
+            expect(response.stderr).toContain("cannot target a different project");
+            expect(requestCount).toBe(0);
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
     });
 
     test("blocks every classified remote write in read-only mode", () => {

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { stringEnum } from "./schema";
+import { authorizeExecution, executionMode, validateExecutionPolicyCoverage } from "./execution-policy";
+import type { ResolvedContext } from "./context";
+
+function context(overrides: Partial<ResolvedContext> = {}): ResolvedContext {
+    return {
+        host: "management.example.com",
+        sshUser: "root",
+        sshPort: 22,
+        sshKey: "",
+        sshPass: "",
+        apiUrl: "https://management.example.com",
+        apiToken: "secret-token",
+        projectRef: "prod-ref",
+        readOnly: false,
+        environment: "production",
+        production: true,
+        inferredSupabaseUrl: "",
+        inferredServiceRoleKey: "",
+        source: "process_env",
+        sourcePath: null,
+        ...overrides,
+    };
+}
+
+describe("CLI execution policy", () => {
+    test("requires an exact production confirmation for remote writes", () => {
+        expect(() => authorizeExecution("project", { action: "task_cancel" }, { context: context() }))
+            .toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("project", { action: "task_cancel" }, {
+            context: context(),
+            confirmProduction: "prod-ref",
+        })).not.toThrow();
+    });
+
+    test("rejects cross-project production overrides even when confirmed", () => {
+        expect(() => authorizeExecution("queue", { action: "send", ref: "other-ref" }, {
+            context: context(),
+            confirmProduction: "other-ref",
+        })).toThrow("cannot target a different project");
+    });
+
+    test("blocks every classified remote write in read-only mode", () => {
+        expect(() => authorizeExecution("frontend", { action: "redeploy" }, {
+            context: context({ production: false, environment: "test", readOnly: true }),
+        })).toThrow("SUPACLOUD_READ_ONLY=true");
+    });
+
+    test("allows migration previews and local authoring without production confirmation", () => {
+        expect(executionMode("database", "push_migrations", { dry_run: true })).toBe("read");
+        expect(executionMode("supabase", "push", { dry_run: true })).toBe("read");
+        expect(() => authorizeExecution("supabase", { action: "db_dump" }, { context: context() }))
+            .not.toThrow();
+    });
+
+    test("always rejects diagnostics repair in production", () => {
+        expect(() => authorizeExecution("diagnostics", { action: "repair" }, {
+            context: context(),
+            confirmProduction: "prod-ref",
+        })).toThrow("forbidden in production");
+    });
+
+    test("fails closed for unknown production actions", () => {
+        expect(() => authorizeExecution("queue", { action: "future_mutation" }, { context: context() }))
+            .toThrow("no classification");
+    });
+
+    test("detects registered action catalog drift", () => {
+        expect(() => validateExecutionPolicyCoverage({
+            project: { schema: { action: stringEnum(["get", "future_mutation"]) } },
+        })).toThrow("project.future_mutation");
+        expect(() => validateExecutionPolicyCoverage({
+            project: { schema: { action: stringEnum(["get", "task_cancel"]) } },
+        })).not.toThrow();
+    });
+});

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -1,0 +1,129 @@
+import { schemaEnumValues, schemaProperties } from "./schema";
+import type { ToolSchema } from "./schema";
+import type { ResolvedContext } from "./context";
+
+export type ExecutionMode = "read" | "write" | "local";
+
+interface ModulePolicy {
+    read?: readonly string[];
+    write?: readonly string[];
+    local?: readonly string[];
+}
+
+const ACTION_POLICY: Record<string, ModulePolicy> = {
+    project: {
+        read: ["get", "health", "logs", "api_keys", "settings", "tasks", "task_detail", "task_stats", "dlq", "background_settings"],
+        write: ["task_cancel", "task_retry", "update_background_settings"],
+    },
+    database: {
+        read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "project_url", "generate_types"],
+        write: ["query", "apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"],
+    },
+    supabase: {
+        local: ["version", "migration_new", "db_diff", "db_reset", "db_pull", "db_dump", "migration_list", "gen_types"],
+        write: ["push"],
+    },
+    auth: {
+        read: ["list_providers", "get_provider", "supported_providers", "get_settings", "get_config"],
+        write: ["configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config"],
+    },
+    storage: {
+        read: ["status", "list_buckets", "list_files"],
+        write: ["upload_base64", "delete_file"],
+    },
+    edge_functions: {
+        read: ["list", "source"],
+        local: ["check"],
+        write: ["deploy", "deploy_bundle", "config", "delete"],
+    },
+    secrets: { read: ["list"], write: ["upsert", "delete"] },
+    frontend: {
+        read: ["list", "get", "build_logs", "list_frameworks", "list_records"],
+        write: ["create", "update", "delete", "deploy_git", "deploy_upload", "redeploy", "add_domain", "remove_domain", "set_env"],
+    },
+    task_events: { read: ["inspect_webhook"], write: ["register_webhook", "unregister_webhook"] },
+    diagnostics: { read: ["list_checks", "get_run"], write: ["run_checks", "repair"] },
+    gateway: {
+        read: ["routes", "get_certificate", "custom_hostname"],
+        write: ["upsert_route", "update_route", "delete_route", "config", "update_certificate", "issue_certificate", "deploy_certificate", "rebuild", "set_custom_hostname", "delete_custom_hostname", "verify_custom_hostname"],
+    },
+    branch: { read: ["list", "promotion_plan"], write: ["create", "delete", "promote"] },
+    queue: {
+        read: ["list", "stats", "list_messages", "dlq", "get_message", "get_settings"],
+        write: ["send", "receive", "ack", "release", "fail", "retry", "delete_message", "update_settings"],
+    },
+    ai: { local: ["show_skill", "install_skill"] },
+};
+
+export interface ExecutionAuthorization {
+    context: ResolvedContext;
+    confirmProduction?: string;
+}
+
+interface ToolCatalogEntry {
+    schema: ToolSchema;
+}
+
+function declaredMode(moduleName: string, action: string): ExecutionMode | undefined {
+    const policy = ACTION_POLICY[moduleName];
+    if (!policy) return undefined;
+    for (const mode of ["read", "write", "local"] as const) {
+        if (policy[mode]?.includes(action)) return mode;
+    }
+    return undefined;
+}
+
+export function executionMode(moduleName: string, action: string, args: Record<string, unknown>): ExecutionMode | undefined {
+    if (moduleName === "database"
+        && ["push_migrations", "baseline_migrations"].includes(action)
+        && args.dry_run === true) return "read";
+    if (moduleName === "supabase" && action === "push" && args.dry_run === true) return "read";
+    return declaredMode(moduleName, action);
+}
+
+export function authorizeExecution(
+    moduleName: string,
+    args: Record<string, unknown>,
+    authorization: ExecutionAuthorization,
+): void {
+    const action = typeof args.action === "string" ? args.action : "";
+    if (!action) return;
+    const mode = executionMode(moduleName, action, args);
+    const { context, confirmProduction } = authorization;
+
+    if (!mode && (context.production || context.readOnly)) {
+        throw new Error(`Execution policy has no classification for ${moduleName}.${action}`);
+    }
+    if (mode !== "write") return;
+    if (context.production && moduleName === "diagnostics" && action === "repair") {
+        throw new Error("diagnostics repair is forbidden in production environments");
+    }
+    if (context.readOnly) {
+        throw new Error(`Remote write ${moduleName}.${action} is blocked in read-only mode (SUPACLOUD_READ_ONLY=true)`);
+    }
+    if (!context.production) return;
+
+    const requestedRef = args.ref ?? context.projectRef;
+    if (typeof requestedRef !== "string" || !requestedRef) {
+        throw new Error(`Production write ${moduleName}.${action} requires a project ref`);
+    }
+    if (requestedRef !== context.projectRef) {
+        throw new Error("Production profiles cannot target a different project with --ref");
+    }
+    if (confirmProduction !== context.projectRef || confirmProduction !== requestedRef) {
+        throw new Error(`Production write requires --confirm-production ${context.projectRef}`);
+    }
+}
+
+export function validateExecutionPolicyCoverage(tools: Record<string, ToolCatalogEntry>): void {
+    for (const [moduleName, tool] of Object.entries(tools)) {
+        const actionSchema = schemaProperties(tool.schema).action;
+        if (!actionSchema) continue;
+        const actions = schemaEnumValues(actionSchema);
+        for (const action of actions) {
+            if (!declaredMode(moduleName, String(action))) {
+                throw new Error(`Execution policy has no classification for ${moduleName}.${String(action)}`);
+            }
+        }
+    }
+}

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -94,6 +94,13 @@ export function authorizeExecution(
     if (!mode && (context.production || context.readOnly)) {
         throw new Error(`Execution policy has no classification for ${moduleName}.${action}`);
     }
+    if (context.production
+        && mode === "read"
+        && typeof args.ref === "string"
+        && args.ref
+        && args.ref !== context.projectRef) {
+        throw new Error("Production profiles cannot target a different project with --ref");
+    }
     if (mode !== "write") return;
     if (context.production && moduleName === "diagnostics" && action === "repair") {
         throw new Error("diagnostics repair is forbidden in production environments");

--- a/packages/cli/src/shared/global-options.test.ts
+++ b/packages/cli/src/shared/global-options.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeEnvironmentName, parseGlobalOptions } from "./global-options";
+
+describe("global CLI options", () => {
+    test.each([
+        [["--env", "test", "project", "get"], "test"],
+        [["project", "get", "--env=test"], "test"],
+        [["project", "--env", "test", "get"], "test"],
+    ])("extracts environment selectors before TypeBox parsing", (args, environmentName) => {
+        const parsed = parseGlobalOptions(args);
+        expect(parsed.environmentName).toBe(environmentName);
+        expect(parsed.args).toEqual(["project", "get"]);
+    });
+
+    test("extracts explicit files and production confirmation in both syntaxes", () => {
+        expect(parseGlobalOptions([
+            "--env-file=./ci.env", "database", "query", "--confirm-production", "prod-ref",
+        ])).toEqual({
+            envFile: "./ci.env",
+            confirmProduction: "prod-ref",
+            args: ["database", "query"],
+        });
+    });
+
+    test.each([
+        [["--env", "test", "--env", "prod"], "--env may be provided only once"],
+        [["--env-file", "a", "--env-file=b"], "--env-file may be provided only once"],
+        [["--confirm-production", "a", "--confirm-production=a"], "--confirm-production may be provided only once"],
+        [["--env"], "--env requires a value"],
+        [["--env="], "--env requires a value"],
+        [["--env", "test", "--env-file", "file"], "mutually exclusive"],
+    ])("rejects invalid global option input", (args, message) => {
+        expect(() => parseGlobalOptions(args)).toThrow(message);
+    });
+
+    test("normalizes valid environment names and rejects unsafe selectors", () => {
+        expect(normalizeEnvironmentName("Prod_US-1")).toBe("prod_us-1");
+        expect(() => normalizeEnvironmentName("../prod")).toThrow("must match");
+        expect(() => normalizeEnvironmentName("a".repeat(65))).toThrow("must match");
+    });
+});

--- a/packages/cli/src/shared/global-options.ts
+++ b/packages/cli/src/shared/global-options.ts
@@ -1,0 +1,66 @@
+export interface GlobalCliOptions {
+    environmentName?: string;
+    envFile?: string;
+    confirmProduction?: string;
+    args: string[];
+}
+
+const GLOBAL_FLAGS = {
+    "--env": "environmentName",
+    "--env-file": "envFile",
+    "--confirm-production": "confirmProduction",
+} as const;
+
+const ENVIRONMENT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+
+type GlobalOptionKey = typeof GLOBAL_FLAGS[keyof typeof GLOBAL_FLAGS];
+
+function globalFlag(arg: string): keyof typeof GLOBAL_FLAGS | null {
+    return (Object.keys(GLOBAL_FLAGS) as Array<keyof typeof GLOBAL_FLAGS>)
+        .find((flag) => arg === flag || arg.startsWith(`${flag}=`)) ?? null;
+}
+
+function globalFlagValue(args: string[], index: number, flag: string): { value: string; consumed: number } {
+    const inlineValue = args[index].slice(flag.length + 1);
+    if (args[index].startsWith(`${flag}=`)) {
+        if (!inlineValue) throw new Error(`${flag} requires a value`);
+        return { value: inlineValue, consumed: 1 };
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+    return { value, consumed: 2 };
+}
+
+export function normalizeEnvironmentName(name: string): string {
+    if (!ENVIRONMENT_NAME_PATTERN.test(name)) {
+        throw new Error("--env and SUPACLOUD_ENV must match ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$");
+    }
+    const normalized = name.toLowerCase();
+    return normalized === "prod" || normalized === "production" ? "production" : normalized;
+}
+
+export function parseGlobalOptions(args: string[]): GlobalCliOptions {
+    const values: Partial<Record<GlobalOptionKey, string>> = {};
+    const remainingArgs: string[] = [];
+
+    for (let index = 0; index < args.length;) {
+        const flag = globalFlag(args[index]);
+        if (!flag) {
+            remainingArgs.push(args[index]);
+            index += 1;
+            continue;
+        }
+        const key = GLOBAL_FLAGS[flag];
+        if (values[key] !== undefined) throw new Error(`${flag} may be provided only once`);
+        const parsed = globalFlagValue(args, index, flag);
+        values[key] = parsed.value;
+        index += parsed.consumed;
+    }
+
+    if (values.environmentName && values.envFile) {
+        throw new Error("--env and --env-file are mutually exclusive");
+    }
+    if (values.environmentName) normalizeEnvironmentName(values.environmentName);
+
+    return { ...values, args: remainingArgs };
+}

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -5,20 +5,34 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { migrationVersionFromFilename, registerDatabaseTools, vectorWarningsForPendingMigrations } from "./database-tools";
 
-function captureDatabaseTool(http: Record<string, unknown>) {
+function captureDatabaseTool(http: Record<string, unknown>, projectRef?: string) {
     let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
     registerDatabaseTools({
         tool(name: string, _description: string, _schema: Record<string, unknown>, toolCallback: typeof callback) {
             if (name !== "database") return;
             callback = toolCallback;
         },
-    }, http as any);
+    }, http as any, { projectRef });
 
     if (!callback) throw new Error("database tool was not registered");
     return callback;
 }
 
 describe("database migration helpers", () => {
+    test("prefers an explicit ref over the auto-linked project", async () => {
+        const calls: string[] = [];
+        const callback = captureDatabaseTool({
+            get: async (path: string) => {
+                calls.push(path);
+                return { ok: true, status: 200, data: {} };
+            },
+        }, "default-ref");
+
+        await callback({ action: "project_url", ref: "override-ref" });
+
+        expect(calls).toEqual(["/v1/projects/override-ref"]);
+    });
+
     test("uses Supabase timestamp prefix as migration version", () => {
         expect(migrationVersionFromFilename("20260425123000_create_users.sql")).toBe("20260425123000");
     });

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -227,7 +227,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
         },
         async (args: any) => {
             const { action } = args;
-            const ref = projectRef || args.ref;
+            const ref = args.ref || projectRef;
             const schema = args.schema || "public";
             const schemas = args.schemas || ["public"];
 

--- a/packages/cli/src/shared/tools/gateway-tools.test.ts
+++ b/packages/cli/src/shared/tools/gateway-tools.test.ts
@@ -58,6 +58,20 @@ describe("gateway CLI tool — schema coercion", () => {
 });
 
 describe("gateway CLI tool — actions", () => {
+    test("prefers an explicit ref over the auto-linked project", async () => {
+        const calls: string[] = [];
+        const { callback } = captureGatewayTool({
+            get: async (path: string) => {
+                calls.push(path);
+                return { ok: true, status: 200, data: { routes: [] } };
+            },
+        }, "default-ref");
+
+        await callback({ action: "routes", ref: "override-ref" });
+
+        expect(calls).toEqual(["/v1/projects/override-ref/gateway/routes"]);
+    });
+
     test("lists custom gateway routes via GET", async () => {
         const calls: string[] = [];
         const { callback } = captureGatewayTool({

--- a/packages/cli/src/shared/tools/gateway-tools.ts
+++ b/packages/cli/src/shared/tools/gateway-tools.ts
@@ -137,7 +137,7 @@ Actions: routes, upsert_route, update_route, delete_route, config, get_certifica
         },
         async (args: any) => {
             const resolveRef = (override?: string) => {
-                const ref = projectRef || override;
+                const ref = override || projectRef;
                 if (!ref) throw new Error("'ref' is required for this action");
                 return ref;
             };

--- a/packages/cli/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.test.ts
@@ -28,6 +28,20 @@ function captureAdminProjectTool(http: Record<string, unknown>) {
 }
 
 describe("project CLI task actions", () => {
+    test("prefers an explicit ref over the auto-linked project", async () => {
+        const calls: string[] = [];
+        const callback = captureProjectTool({
+            get: async (path: string) => {
+                calls.push(path);
+                return { ok: true, status: 200, data: {} };
+            },
+        }, "default-ref");
+
+        await callback({ action: "get", ref: "override-ref" });
+
+        expect(calls).toEqual(["/v1/projects/override-ref"]);
+    });
+
     test("retrieves task detail and formats latest logs", async () => {
         const calls: string[] = [];
         const callback = captureProjectTool({

--- a/packages/cli/src/shared/tools/project-cli-tools.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.ts
@@ -102,7 +102,7 @@ function buildProjectLogsPath(ref: string, logType?: string): string {
 }
 
 function resolveRef(refFromArgs: string | undefined, defaultRef?: string): string {
-    const ref = defaultRef || refFromArgs;
+    const ref = refFromArgs || defaultRef;
     if (!ref) throw new Error("'ref' is required for this action");
     return ref;
 }

--- a/packages/cli/src/shared/tools/queue-tools.test.ts
+++ b/packages/cli/src/shared/tools/queue-tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { registerQueueTools } from "./queue-tools";
 
-function captureQueueTool(http: Record<string, unknown>) {
+function captureQueueTool(http: Record<string, unknown>, projectRef?: string) {
     let schema: Record<string, unknown> | undefined;
     let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
     registerQueueTools({
@@ -10,13 +10,27 @@ function captureQueueTool(http: Record<string, unknown>) {
             schema = toolSchema;
             callback = toolCallback;
         },
-    }, http as any);
+    }, http as any, { projectRef });
 
     if (!schema || !callback) throw new Error("queue tool was not registered");
     return { schema, callback };
 }
 
 describe("queue CLI tool", () => {
+    test("prefers an explicit ref over the auto-linked project", async () => {
+        const calls: string[] = [];
+        const { callback } = captureQueueTool({
+            get: async (path: string) => {
+                calls.push(path);
+                return { ok: true, status: 200, data: [] };
+            },
+        }, "default-ref");
+
+        await callback({ action: "list", ref: "override-ref", queue: "emails" });
+
+        expect(calls).toEqual(["/v1/projects/override-ref/tasks/queues/emails/messages"]);
+    });
+
     test("sends queue messages with tracing metadata", async () => {
         const calls: Array<{ method: string; path: string; body: unknown }> = [];
         const { callback } = captureQueueTool({

--- a/packages/cli/src/shared/tools/queue-tools.ts
+++ b/packages/cli/src/shared/tools/queue-tools.ts
@@ -58,7 +58,7 @@ function formatMessages(data: unknown, label = "Messages"): string {
 }
 
 function resolveRef(refFromArgs: string | undefined, defaultRef?: string): string {
-    const ref = defaultRef || refFromArgs;
+    const ref = refFromArgs || defaultRef;
     if (!ref) throw new Error("'ref' is required for this action");
     return ref;
 }


### PR DESCRIPTION
## Summary

- add atomic named and explicit environment profiles through `--env`, `--env-file`, and `SUPACLOUD_ENV`
- keep multiple management/service-role credentials isolated by source, prefer `SUPACLOUD_API_TOKEN`, and expose only secret-safe status metadata
- require exact confirmation for production writes, support a global read-only override, and fail closed for unclassified protected actions
- honor explicit project refs consistently while rejecting production cross-project overrides

## Compatibility and safety

- preserves the legacy `.env` fallback for existing workflows
- documents that production automation must explicitly select `prod`/`production` to enable the production confirmation gate
- does not include real environment files or credentials

## Verification

- `bun test packages/cli/src` (149 pass, 0 fail)
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli build`
- `git diff origin/main...HEAD --check`
- independent verifier: PASS