### PR TITLE
feat(admin): add project service controls

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -31,6 +31,8 @@ npx @supacloud/admin ssh versions
 npx @supacloud/admin ssh diagnose
 npx @supacloud/admin project create --name my-app --domain example.com
 npx @supacloud/admin project list
+npx @supacloud/admin project services --ref abc123
+npx @supacloud/admin project service_control --ref abc123 --service gotrue --service_action stop
 ```
 
 `ssh versions` emits JSON with `schema_version: 1` and fixed
@@ -106,6 +108,23 @@ Project commands owned by this CLI:
 - `project restore`
 - `project restart`
 - `project update_settings`
+- `project services` — read-only project service inventory
+- `project service_control` — constrained project service lifecycle control
+
+Service control accepts canonical service names only. `postgrest` supports
+`start`, `stop`, `restart`, `pause`, `resume`, and `status`; `gotrue`, `storage`,
+`postgresql`, `realtime`, and `gateway` support `start`, `stop`, and `restart`.
+The command calls only the Management API's existing
+`/v1/projects/{ref}/services` routes. A non-2xx response, a `success: false`
+receipt, or a response that does not match the requested service and action
+exits non-zero. Successful inventory and control responses are emitted as JSON
+with `project_ref` for strict read-back.
+
+The Management API remains authoritative for SupAuth ownership. Controlling
+GoTrue on a shared-auth project fails with `AUTH_RUNTIME_MANAGED_BY_OWNER`;
+the CLI does not redirect the operation to the owner project. Supply
+`SUPACLOUD_API_TOKEN` through the environment only; service-control commands do
+not accept credential flags.
 
 Gateway / Caddy commands (config is injected via the Caddy JSON Admin API; requires admin privileges):
 

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -32,10 +32,13 @@ function cleanEnvironment(): Record<string, string> {
     return env;
 }
 
-async function runAdminCli(args: string[]): Promise<{ exitCode: number; output: string }> {
+async function runAdminCli(
+    args: string[],
+    environment: Record<string, string> = {},
+): Promise<{ exitCode: number; output: string }> {
     const processHandle = Bun.spawn([process.execPath, "src/index.ts", ...args], {
         cwd: PACKAGE_ROOT,
-        env: cleanEnvironment(),
+        env: { ...cleanEnvironment(), ...environment },
         stdout: "pipe",
         stderr: "pipe",
     });
@@ -189,6 +192,60 @@ describe("supacloud-admin process contract", () => {
         expect(execution.output).toContain("--api_domain");
         expect(execution.output).toContain("--auth_domain");
         expect(execution.output).toContain("--studio_domain");
+    });
+
+    test("documents constrained project service control without credential flags", async () => {
+        const execution = await runAdminCli(["project", "service_control", "--help"]);
+
+        expect(execution.exitCode).toBe(0);
+        expect(execution.output).toContain("--ref");
+        expect(execution.output).toContain("--service");
+        expect(execution.output).toContain("--service_action");
+        expect(execution.output).not.toContain("--token");
+    });
+
+    test("returns non-zero when service control reports HTTP 200 with success false", async () => {
+        let authorizationHeader = "";
+        let requestMethod = "";
+        let requestedPath = "";
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                const requestUrl = new URL(request.url);
+                authorizationHeader = request.headers.get("authorization") || "";
+                requestMethod = request.method;
+                requestedPath = requestUrl.pathname;
+                return Response.json({
+                    service: "gotrue",
+                    action: "stop",
+                    success: false,
+                    message: "Service gotrue stop failed",
+                });
+            },
+        });
+        const fixtureToken = "fixture-api-token";
+
+        try {
+            const execution = await runAdminCli([
+                "project", "service_control",
+                "--ref", "project-ref",
+                "--service", "gotrue",
+                "--service_action", "stop",
+            ], {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                SUPACLOUD_API_TOKEN: fixtureToken,
+            });
+
+            expect(execution.exitCode).toBe(1);
+            expect(requestMethod).toBe("POST");
+            expect(requestedPath).toBe("/v1/projects/project-ref/services/gotrue/stop");
+            expect(authorizationHeader).toBe(`Bearer ${fixtureToken}`);
+            expect(execution.output).toContain("Project service control failed");
+            expect(execution.output).not.toContain(fixtureToken);
+        } finally {
+            apiServer.stop(true);
+        }
     });
 
     test("surfaces every sanitized cause when an operation and cleanup both fail", async () => {

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -92,6 +92,43 @@ async function runAggregateFailureCli(): Promise<{ exitCode: number; output: str
     return { exitCode, output: stdout + stderr };
 }
 
+function studioProcessInventory(): Array<Record<string, unknown>> {
+    return [
+        { id: "db", name: "db", status: "ACTIVE_HEALTHY", healthy: true, service_host_ids: ["project-ref-db"] },
+        { id: "rest", name: "rest", status: "COMING_UP", healthy: false, service_host_ids: ["project-ref-rest"] },
+        { id: "auth", name: "auth", status: "INACTIVE", healthy: false, service_host_ids: ["owner-ref-auth"] },
+        { id: "realtime", name: "realtime", status: "UNHEALTHY", healthy: false, service_host_ids: ["project-ref-realtime"] },
+        { id: "storage", name: "storage", status: "ACTIVE_HEALTHY", healthy: true, service_host_ids: ["project-ref-storage"] },
+    ];
+}
+
+function inventoryWithField(fieldName: string, fieldValue: unknown): Array<Record<string, unknown>> {
+    const inventory = studioProcessInventory();
+    inventory[0] = { ...inventory[0], [fieldName]: fieldValue };
+    return inventory;
+}
+
+function invalidProcessInventories(secretMarker: string, oversizedMarker: string): unknown[] {
+    const duplicate = studioProcessInventory();
+    duplicate[4] = { ...duplicate[0] };
+    const badStatus = studioProcessInventory();
+    badStatus[1] = { ...badStatus[1], status: "INACTIVE" };
+    const healthyMismatch = studioProcessInventory();
+    healthyMismatch[0] = { ...healthyMismatch[0], healthy: false };
+    const multipleHostIds = studioProcessInventory();
+    multipleHostIds[2] = { ...multipleHostIds[2], service_host_ids: ["owner-ref-auth", "project-ref-auth"] };
+    const oversizedInventory = Array.from({ length: 256 }, () => ({
+        id: oversizedMarker, name: oversizedMarker, status: oversizedMarker,
+        healthy: false, service_host_ids: [oversizedMarker],
+    }));
+    return [
+        inventoryWithField("id", secretMarker), inventoryWithField("name", secretMarker),
+        inventoryWithField("status", secretMarker), inventoryWithField("service_host_ids", [secretMarker]),
+        oversizedInventory, duplicate, studioProcessInventory().slice(0, 4),
+        badStatus, healthyMismatch, multipleHostIds,
+    ];
+}
+
 const baseContext = {
     host: "server.example.com",
     sshUser: "root",
@@ -268,6 +305,36 @@ describe("supacloud-admin process contract", () => {
             expect(execution.output).not.toContain("remote-response-secret");
             expect(execution.output).not.toContain("remote-response-authorization");
             expect(execution.output).not.toContain("hidden-project-ref");
+        } finally {
+            apiServer.stop(true);
+        }
+    });
+
+    test("returns non-zero for every invalid service inventory without reflection", async () => {
+        const secretMarker = "process-inventory-secret";
+        const oversizedMarker = "oversized-process-secret-".repeat(48);
+        const invalidInventories = invalidProcessInventories(secretMarker, oversizedMarker);
+        let responseIndex = 0;
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                return Response.json(invalidInventories[responseIndex++]);
+            },
+        });
+
+        try {
+            for (const _inventory of invalidInventories) {
+                const execution = await runAdminCli(["project", "services", "--ref", "project-ref"], {
+                    SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                    SUPACLOUD_API_TOKEN: "test-token",
+                });
+                expect(execution.exitCode).toBe(1);
+                expect(execution.output.trim()).toBe("❌ Project service inventory response is invalid");
+                expect(execution.output).not.toContain(secretMarker);
+                expect(execution.output).not.toContain(oversizedMarker);
+            }
+            expect(responseIndex).toBe(invalidInventories.length);
         } finally {
             apiServer.stop(true);
         }

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -78,6 +78,8 @@ EXAMPLES
   supacloud-admin ssh install --public_domain api.example.com --studio_domain studio.example.com
   supacloud-admin project create --name my-app --domain example.com
   supacloud-admin project list
+  supacloud-admin project services --ref abc123
+  supacloud-admin project service_control --ref abc123 --service gotrue --service_action stop
   supacloud-admin platform metrics
   supacloud-admin gateway routes --ref abc123
   supacloud-admin gateway upsert_route --ref abc123 --route_id webhook --hosts "api.example.com" --paths "/webhook/*" --upstream 10.0.0.5:8080

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -1,20 +1,31 @@
 import { describe, expect, test } from "bun:test";
 import { registerAdminProjectCliTools } from "./project-cli-tools";
+import { schemaEnumValues } from "../schema";
+import type { ToolSchema } from "../schema";
 
 type ProjectCallback = (
     args: Record<string, unknown>,
-) => Promise<{ content: Array<{ text: string }> }>;
+) => Promise<{ content: Array<{ text: string }>; isError?: boolean }>;
 
-function captureAdminProjectTool(http: Record<string, unknown>): ProjectCallback {
-    let projectCallback: ProjectCallback | undefined;
+type ProjectToolRegistration = {
+    callback: ProjectCallback;
+    schema: ToolSchema;
+};
+
+function captureAdminProjectRegistration(http: Record<string, unknown>): ProjectToolRegistration {
+    let registration: ProjectToolRegistration | undefined;
     registerAdminProjectCliTools({
-        tool(name: string, _description: string, _schema: Record<string, unknown>, callback: ProjectCallback) {
-            if (name === "project") projectCallback = callback;
+        tool(name: string, _description: string, schema: ToolSchema, callback: ProjectCallback) {
+            if (name === "project") registration = { callback, schema };
         },
     }, http as any);
 
-    if (!projectCallback) throw new Error("admin project tool was not registered");
-    return projectCallback;
+    if (!registration) throw new Error("admin project tool was not registered");
+    return registration;
+}
+
+function captureAdminProjectTool(http: Record<string, unknown>): ProjectCallback {
+    return captureAdminProjectRegistration(http).callback;
 }
 
 describe("admin project create", () => {
@@ -77,5 +88,234 @@ describe("admin project create", () => {
         expect("api_domain" in createRequest).toBe(false);
         expect("auth_domain" in createRequest).toBe(false);
         expect("studio_domain" in createRequest).toBe(false);
+    });
+});
+
+describe("admin project services", () => {
+    test("declares inventory and constrained service control actions", () => {
+        const { schema } = captureAdminProjectRegistration({});
+
+        expect(schemaEnumValues(schema.action)).toContain("services");
+        expect(schemaEnumValues(schema.action)).toContain("service_control");
+        expect(schemaEnumValues(schema.service)).toEqual([
+            "postgrest", "gotrue", "storage", "postgresql", "realtime", "gateway",
+        ]);
+        expect(schemaEnumValues(schema.service_action)).toEqual([
+            "start", "stop", "restart", "pause", "resume", "status",
+        ]);
+    });
+
+    test("lists a strictly validated project service inventory", async () => {
+        let requestedPath = "";
+        const projectCallback = captureAdminProjectTool({
+            get: async (path: string) => {
+                requestedPath = path;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: [{
+                        id: "auth",
+                        name: "auth",
+                        status: "INACTIVE",
+                        healthy: false,
+                        service_host_ids: ["project-ref-auth"],
+                    }],
+                };
+            },
+        });
+
+        const response = await projectCallback({ action: "services", ref: "project/ref" });
+        const output = JSON.parse(response.content[0].text);
+
+        expect(requestedPath).toBe("/v1/projects/project%2Fref/services");
+        expect(response.isError).not.toBe(true);
+        expect(output.project_ref).toBe("project/ref");
+        expect(output.services[0].id).toBe("auth");
+    });
+
+    test("fails closed when the inventory contract is malformed", async () => {
+        const projectCallback = captureAdminProjectTool({
+            get: async () => ({ ok: true, status: 200, data: [{ id: "auth" }] }),
+        });
+
+        const response = await projectCallback({ action: "services", ref: "project-ref" });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("inventory response is invalid");
+    });
+});
+
+describe("admin project service control", () => {
+    test("stops local GoTrue through the exact Management API route", async () => {
+        let requestedPath = "";
+        const projectCallback = captureAdminProjectTool({
+            post: async (path: string) => {
+                requestedPath = path;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        service: "gotrue",
+                        action: "stop",
+                        success: true,
+                        message: "Service gotrue stop succeeded",
+                    },
+                };
+            },
+        });
+
+        const response = await projectCallback({
+            action: "service_control",
+            ref: "project-ref",
+            service: "gotrue",
+            service_action: "stop",
+        });
+        const receipt = JSON.parse(response.content[0].text);
+
+        expect(requestedPath).toBe("/v1/projects/project-ref/services/gotrue/stop");
+        expect(response.isError).not.toBe(true);
+        expect(receipt).toMatchObject({
+            project_ref: "project-ref",
+            service: "gotrue",
+            action: "stop",
+            success: true,
+        });
+        expect(receipt.receipt.message).toContain("succeeded");
+    });
+
+    test("routes every Management API-supported canonical service and action pair", async () => {
+        const requestedPaths: string[] = [];
+        const projectCallback = captureAdminProjectTool({
+            post: async (path: string) => {
+                requestedPaths.push(path);
+                const [, , , , , service, serviceAction] = path.split("/");
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        service,
+                        action: serviceAction,
+                        success: true,
+                        message: `Service ${service} ${serviceAction} succeeded`,
+                    },
+                };
+            },
+        });
+        const supportedActions = {
+            postgrest: ["start", "stop", "restart", "pause", "resume", "status"],
+            gotrue: ["start", "stop", "restart"],
+            storage: ["start", "stop", "restart"],
+            postgresql: ["start", "stop", "restart"],
+            realtime: ["start", "stop", "restart"],
+            gateway: ["start", "stop", "restart"],
+        } as const;
+
+        for (const [service, serviceActions] of Object.entries(supportedActions)) {
+            for (const serviceAction of serviceActions) {
+                const response = await projectCallback({
+                    action: "service_control",
+                    ref: "project-ref",
+                    service,
+                    service_action: serviceAction,
+                });
+                expect(response.isError).not.toBe(true);
+            }
+        }
+
+        expect(requestedPaths).toHaveLength(21);
+        expect(requestedPaths).toContain("/v1/projects/project-ref/services/postgrest/status");
+        expect(requestedPaths).toContain("/v1/projects/project-ref/services/gateway/restart");
+    });
+
+    test("rejects unsupported service and action pairs before the request", async () => {
+        let requestCount = 0;
+        const projectCallback = captureAdminProjectTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        await expect(projectCallback({
+            action: "service_control",
+            ref: "project-ref",
+            service: "storage",
+            service_action: "pause",
+        })).rejects.toThrow("'pause' is not supported for service 'storage'");
+        expect(requestCount).toBe(0);
+    });
+
+    test("treats an HTTP 200 failure receipt as an error", async () => {
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    service: "gotrue",
+                    action: "stop",
+                    success: false,
+                    message: "Service gotrue stop failed",
+                },
+            }),
+        });
+
+        const response = await projectCallback({
+            action: "service_control",
+            ref: "project-ref",
+            service: "gotrue",
+            service_action: "stop",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("Project service control failed");
+    });
+
+    test("rejects a success receipt that does not match the request", async () => {
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    service: "storage",
+                    action: "stop",
+                    success: true,
+                    message: "Service storage stop succeeded",
+                },
+            }),
+        });
+
+        const response = await projectCallback({
+            action: "service_control",
+            ref: "project-ref",
+            service: "gotrue",
+            service_action: "stop",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("does not match the request");
+    });
+
+    test("preserves the shared Auth owner boundary as a non-zero CLI result", async () => {
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: false,
+                status: 409,
+                data: {
+                    code: "AUTH_RUNTIME_MANAGED_BY_OWNER",
+                    authority_project_ref: "supauth-owner",
+                },
+            }),
+        });
+
+        const response = await projectCallback({
+            action: "service_control",
+            ref: "shared-project",
+            service: "gotrue",
+            service_action: "stop",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("AUTH_RUNTIME_MANAGED_BY_OWNER");
+        expect(response.content[0].text).toContain("supauth-owner");
     });
 });

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -29,6 +29,38 @@ function expectNoRemoteResponseDetails(output: string): void {
     }
 }
 
+function studioServiceInventory(
+    projectRef = "project-ref",
+    authRuntimeRef = projectRef,
+): Array<Record<string, unknown>> {
+    return [
+        { id: "db", name: "db", status: "ACTIVE_HEALTHY", healthy: true,
+            service_host_ids: [`${projectRef}-db`] },
+        { id: "rest", name: "rest", status: "COMING_UP", healthy: false,
+            service_host_ids: [`${projectRef}-rest`] },
+        { id: "auth", name: "auth", status: "INACTIVE", healthy: false,
+            service_host_ids: [`${authRuntimeRef}-auth`] },
+        { id: "realtime", name: "realtime", status: "UNHEALTHY", healthy: false,
+            service_host_ids: [`${projectRef}-realtime`] },
+        { id: "storage", name: "storage", status: "ACTIVE_HEALTHY", healthy: true,
+            service_host_ids: [`${projectRef}-storage`] },
+    ];
+}
+
+async function expectInvalidInventory(
+    inventory: unknown,
+    projectRef = "project-ref",
+): Promise<void> {
+    const projectCallback = captureAdminProjectTool({
+        get: async () => ({ ok: true, status: 200, data: inventory }),
+    });
+
+    const response = await projectCallback({ action: "services", ref: projectRef });
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toBe("❌ Project service inventory response is invalid");
+}
+
 function captureAdminProjectRegistration(http: Record<string, unknown>): ProjectToolRegistration {
     let registration: ProjectToolRegistration | undefined;
     registerAdminProjectCliTools({
@@ -127,50 +159,108 @@ describe("admin project services", () => {
         const projectCallback = captureAdminProjectTool({
             get: async (path: string) => {
                 requestedPath = path;
+                const inventory = studioServiceInventory("project-ref", "owner-ref");
                 return {
                     ok: true,
                     status: 200,
-                    data: [{
-                        id: "auth",
-                        name: "auth",
-                        status: "INACTIVE",
-                        healthy: false,
-                        service_host_ids: ["project-ref-auth"],
+                    data: inventory.map((service) => ({
+                        ...service,
                         token: REMOTE_RESPONSE_DETAILS[0],
                         secret: REMOTE_RESPONSE_DETAILS[1],
                         Authorization: REMOTE_RESPONSE_DETAILS[2],
                         project_ref: REMOTE_RESPONSE_DETAILS[3],
                         message: REMOTE_RESPONSE_DETAILS[4],
-                    }],
+                    })),
                 };
             },
         });
 
-        const response = await projectCallback({ action: "services", ref: "project/ref" });
+        const response = await projectCallback({ action: "services", ref: "project-ref" });
         const output = JSON.parse(response.content[0].text);
 
-        expect(requestedPath).toBe("/v1/projects/project%2Fref/services");
+        expect(requestedPath).toBe("/v1/projects/project-ref/services");
         expect(response.isError).not.toBe(true);
-        expect(output.project_ref).toBe("project/ref");
-        expect(output.services).toEqual([{
-            id: "auth",
-            name: "auth",
-            status: "INACTIVE",
-            healthy: false,
-            service_host_ids: ["project-ref-auth"],
-        }]);
+        expect(output.project_ref).toBe("project-ref");
+        expect(output.services).toEqual(studioServiceInventory("project-ref", "owner-ref"));
         expectNoRemoteResponseDetails(response.content[0].text);
     });
 
-    test("fails closed when the inventory contract is malformed", async () => {
+    test("rejects secrets placed in every string-valued inventory field", async () => {
+        const secretMarker = "inventory-secret-marker";
+        const maliciousFields = [
+            { field: "id", value: secretMarker },
+            { field: "name", value: secretMarker },
+            { field: "status", value: secretMarker },
+            { field: "service_host_ids", value: [secretMarker] },
+        ] as const;
+
+        for (const maliciousField of maliciousFields) {
+            const inventory = studioServiceInventory();
+            inventory[0] = { ...inventory[0], [maliciousField.field]: maliciousField.value };
+            const projectCallback = captureAdminProjectTool({
+                get: async () => ({ ok: true, status: 200, data: inventory }),
+            });
+            const response = await projectCallback({ action: "services", ref: "project-ref" });
+
+            expect(response.isError).toBe(true);
+            expect(response.content[0].text).toBe("❌ Project service inventory response is invalid");
+            expect(response.content[0].text).not.toContain(secretMarker);
+        }
+    });
+
+    test("rejects an oversized inventory without reflecting its allowed fields", async () => {
+        const oversizedMarker = "oversized-secret-".repeat(64);
+        const oversizedInventory = Array.from({ length: 256 }, () => ({
+            id: oversizedMarker,
+            name: oversizedMarker,
+            status: oversizedMarker,
+            healthy: false,
+            service_host_ids: [oversizedMarker],
+        }));
         const projectCallback = captureAdminProjectTool({
-            get: async () => ({ ok: true, status: 200, data: [{ id: "auth" }] }),
+            get: async () => ({ ok: true, status: 200, data: oversizedInventory }),
         });
 
         const response = await projectCallback({ action: "services", ref: "project-ref" });
 
         expect(response.isError).toBe(true);
-        expect(response.content[0].text).toContain("inventory response is invalid");
+        expect(response.content[0].text).toBe("❌ Project service inventory response is invalid");
+        expect(response.content[0].text).not.toContain(oversizedMarker);
+        expect(JSON.stringify(oversizedInventory).length).toBeGreaterThan(1_000_000);
+    });
+
+    test("rejects duplicate, missing, inconsistent, and unbound service entries", async () => {
+        const duplicate = studioServiceInventory();
+        duplicate[4] = { ...duplicate[0] };
+        const badStatus = studioServiceInventory();
+        badStatus[1] = { ...badStatus[1], status: "INACTIVE" };
+        const healthyMismatch = studioServiceInventory();
+        healthyMismatch[0] = { ...healthyMismatch[0], healthy: false };
+        const multipleHostIds = studioServiceInventory();
+        multipleHostIds[2] = {
+            ...multipleHostIds[2],
+            service_host_ids: ["owner-ref-auth", "project-ref-auth"],
+        };
+        const invalidInventories = [
+            duplicate,
+            studioServiceInventory().slice(0, 4),
+            badStatus,
+            healthyMismatch,
+            multipleHostIds,
+        ];
+
+        for (const inventory of invalidInventories) await expectInvalidInventory(inventory);
+    });
+
+    test("rejects unsafe project refs and host bindings", async () => {
+        const badNonAuthHost = studioServiceInventory();
+        badNonAuthHost[0] = { ...badNonAuthHost[0], service_host_ids: ["other-ref-db"] };
+        const badAuthHost = studioServiceInventory();
+        badAuthHost[2] = { ...badAuthHost[2], service_host_ids: ["unsafe/owner-auth"] };
+
+        await expectInvalidInventory(badNonAuthHost);
+        await expectInvalidInventory(badAuthHost);
+        await expectInvalidInventory(studioServiceInventory(), "unsafe/project");
     });
 });
 
@@ -370,6 +460,39 @@ describe("admin project service control", () => {
         expect(response.isError).toBe(true);
         expect(response.content[0].text).toBe("❌ Project service control response is invalid");
         expectNoRemoteResponseDetails(response.content[0].text);
+    });
+
+    test("bounds the unused success receipt message", async () => {
+        let receiptMessage = "m".repeat(256);
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    service: "gotrue",
+                    action: "stop",
+                    success: true,
+                    message: receiptMessage,
+                },
+            }),
+        });
+        const request = {
+            action: "service_control",
+            ref: "project-ref",
+            service: "gotrue",
+            service_action: "stop",
+        };
+
+        const boundedResponse = await projectCallback(request);
+        expect(boundedResponse.isError).not.toBe(true);
+        expect(boundedResponse.content[0].text).not.toContain(receiptMessage);
+
+        receiptMessage = "oversized-message-secret-".repeat(11);
+        const oversizedResponse = await projectCallback(request);
+        expect(receiptMessage.length).toBeGreaterThan(256);
+        expect(oversizedResponse.isError).toBe(true);
+        expect(oversizedResponse.content[0].text).toBe("❌ Project service control response is invalid");
+        expect(oversizedResponse.content[0].text).not.toContain(receiptMessage);
     });
 
     test("reports generic HTTP failures using only the local status", async () => {

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -159,7 +159,7 @@ describe("admin project services", () => {
         const projectCallback = captureAdminProjectTool({
             get: async (path: string) => {
                 requestedPath = path;
-                const inventory = studioServiceInventory("project-ref", "owner-ref");
+                const inventory = studioServiceInventory("project-ref", "Legacy_Owner");
                 return {
                     ok: true,
                     status: 200,
@@ -181,7 +181,7 @@ describe("admin project services", () => {
         expect(requestedPath).toBe("/v1/projects/project-ref/services");
         expect(response.isError).not.toBe(true);
         expect(output.project_ref).toBe("project-ref");
-        expect(output.services).toEqual(studioServiceInventory("project-ref", "owner-ref"));
+        expect(output.services).toEqual(studioServiceInventory("project-ref", "Legacy_Owner"));
         expectNoRemoteResponseDetails(response.content[0].text);
     });
 
@@ -255,12 +255,20 @@ describe("admin project services", () => {
     test("rejects unsafe project refs and host bindings", async () => {
         const badNonAuthHost = studioServiceInventory();
         badNonAuthHost[0] = { ...badNonAuthHost[0], service_host_ids: ["other-ref-db"] };
-        const badAuthHost = studioServiceInventory();
-        badAuthHost[2] = { ...badAuthHost[2], service_host_ids: ["unsafe/owner-auth"] };
+        const unsafeAuthHosts = [
+            "unsafe/owner-auth",
+            "owner-ref-that-is-too-long-auth",
+            "owner\nref-auth",
+        ];
 
         await expectInvalidInventory(badNonAuthHost);
-        await expectInvalidInventory(badAuthHost);
+        for (const unsafeHost of unsafeAuthHosts) {
+            const badAuthHost = studioServiceInventory();
+            badAuthHost[2] = { ...badAuthHost[2], service_host_ids: [unsafeHost] };
+            await expectInvalidInventory(badAuthHost);
+        }
         await expectInvalidInventory(studioServiceInventory(), "unsafe/project");
+        await expectInvalidInventory(studioServiceInventory("Legacy_Owner"), "Legacy_Owner");
     });
 });
 
@@ -529,7 +537,7 @@ describe("admin project service control", () => {
                 status: 409,
                 data: {
                     code: "AUTH_RUNTIME_MANAGED_BY_OWNER",
-                    authority_project_ref: "supauth-owner",
+                    authority_project_ref: "Legacy_Owner",
                     message: REMOTE_RESPONSE_DETAILS[4],
                     token: REMOTE_RESPONSE_DETAILS[0],
                     secret: REMOTE_RESPONSE_DETAILS[1],
@@ -547,9 +555,9 @@ describe("admin project service control", () => {
         });
 
         expect(response.isError).toBe(true);
-        expect(response.content[0].text).toContain("AUTH_RUNTIME_MANAGED_BY_OWNER");
-        expect(response.content[0].text).toContain("supauth-owner");
-        expect(response.content[0].text).toContain('"status":409');
+        expect(response.content[0].text).toBe(
+            '❌ {"status":409,"code":"AUTH_RUNTIME_MANAGED_BY_OWNER","authority_project_ref":"Legacy_Owner"}',
+        );
         expectNoRemoteResponseDetails(response.content[0].text);
     });
 
@@ -559,6 +567,7 @@ describe("admin project service control", () => {
             { status: 409, code: "UNEXPECTED_CODE", authorityRef: "supauth-owner" },
             { status: 409, code: "AUTH_RUNTIME_MANAGED_BY_OWNER", authorityRef: "unsafe/project" },
             { status: 409, code: "AUTH_RUNTIME_MANAGED_BY_OWNER", authorityRef: "owner-ref-that-is-too-long" },
+            { status: 409, code: "AUTH_RUNTIME_MANAGED_BY_OWNER", authorityRef: "owner\nref" },
         ];
 
         for (const ownerResponse of unsafeOwnerResponses) {

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -25,8 +25,9 @@ const STUDIO_PROJECT_SERVICE_STATUSES = [
     "ACTIVE_HEALTHY", "COMING_UP", "UNHEALTHY",
 ] as const;
 const AUTH_RUNTIME_MANAGED_BY_OWNER = "AUTH_RUNTIME_MANAGED_BY_OWNER";
+const AUTH_SERVICE_HOST_SUFFIX = "-auth";
 const SAFE_PROJECT_REF = /^[a-z0-9-]{1,20}$/;
-const SAFE_AUTH_SERVICE_HOST_ID = /^[a-z0-9-]{1,20}-auth$/;
+const SAFE_AUTHORITY_PROJECT_REF = /^[A-Za-z0-9_-]{1,20}$/;
 const MAX_SERVICE_CONTROL_MESSAGE_LENGTH = 256;
 
 type ProjectServiceName = typeof PROJECT_SERVICE_NAMES[number];
@@ -75,7 +76,7 @@ function failedProjectServiceHttpResponse(response: HttpResult<unknown>): Projec
         && isRecordPayload(response.data)
         && response.data.code === AUTH_RUNTIME_MANAGED_BY_OWNER
         && typeof response.data.authority_project_ref === "string"
-        && SAFE_PROJECT_REF.test(response.data.authority_project_ref)
+        && SAFE_AUTHORITY_PROJECT_REF.test(response.data.authority_project_ref)
     ) {
         const ownerBoundary = {
             status: response.status,
@@ -112,7 +113,10 @@ function hasValidStudioServiceHost(
     hostIds: unknown,
 ): hostIds is [string] {
     if (!Array.isArray(hostIds) || hostIds.length !== 1 || typeof hostIds[0] !== "string") return false;
-    if (serviceId === "auth") return SAFE_AUTH_SERVICE_HOST_ID.test(hostIds[0]);
+    if (serviceId === "auth") {
+        if (!hostIds[0].endsWith(AUTH_SERVICE_HOST_SUFFIX)) return false;
+        return SAFE_AUTHORITY_PROJECT_REF.test(hostIds[0].slice(0, -AUTH_SERVICE_HOST_SUFFIX.length));
+    }
     return hostIds[0] === `${projectRef}-${serviceId}`;
 }
 

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -18,17 +18,27 @@ const PROJECT_SERVICE_NAMES = [
 const PROJECT_SERVICE_CONTROL_ACTIONS = [
     "start", "stop", "restart", "pause", "resume", "status",
 ] as const;
+const STUDIO_PROJECT_SERVICE_NAMES = [
+    "db", "rest", "auth", "realtime", "storage",
+] as const;
+const STUDIO_PROJECT_SERVICE_STATUSES = [
+    "ACTIVE_HEALTHY", "COMING_UP", "UNHEALTHY",
+] as const;
 const AUTH_RUNTIME_MANAGED_BY_OWNER = "AUTH_RUNTIME_MANAGED_BY_OWNER";
 const SAFE_PROJECT_REF = /^[a-z0-9-]{1,20}$/;
+const SAFE_AUTH_SERVICE_HOST_ID = /^[a-z0-9-]{1,20}-auth$/;
+const MAX_SERVICE_CONTROL_MESSAGE_LENGTH = 256;
 
 type ProjectServiceName = typeof PROJECT_SERVICE_NAMES[number];
 type ProjectServiceControlAction = typeof PROJECT_SERVICE_CONTROL_ACTIONS[number];
+type StudioProjectServiceName = typeof STUDIO_PROJECT_SERVICE_NAMES[number];
+type StudioProjectServiceStatus = typeof STUDIO_PROJECT_SERVICE_STATUSES[number] | "INACTIVE";
 type ProjectServiceStatus = {
-    id: string;
-    name: string;
-    status: string;
+    id: StudioProjectServiceName;
+    name: StudioProjectServiceName;
+    status: StudioProjectServiceStatus;
     healthy: boolean;
-    service_host_ids: string[];
+    service_host_ids: [string];
 };
 
 const SUPPORTED_PROJECT_SERVICE_ACTIONS: Record<
@@ -81,14 +91,36 @@ function isRecordPayload(payload: unknown): payload is Record<string, unknown> {
     return typeof payload === "object" && payload !== null && !Array.isArray(payload);
 }
 
-function isProjectServiceStatus(payload: unknown): payload is ProjectServiceStatus {
+function isStudioProjectServiceName(name: unknown): name is StudioProjectServiceName {
+    return typeof name === "string"
+        && STUDIO_PROJECT_SERVICE_NAMES.some((allowedName) => name === allowedName);
+}
+
+function hasValidStudioServiceHealth(
+    serviceId: StudioProjectServiceName,
+    status: unknown,
+    healthy: unknown,
+): status is StudioProjectServiceStatus {
+    if (status === "INACTIVE") return serviceId === "auth" && healthy === false;
+    const knownStatus = STUDIO_PROJECT_SERVICE_STATUSES.some((allowedStatus) => status === allowedStatus);
+    return knownStatus && healthy === (status === "ACTIVE_HEALTHY");
+}
+
+function hasValidStudioServiceHost(
+    serviceId: StudioProjectServiceName,
+    projectRef: string,
+    hostIds: unknown,
+): hostIds is [string] {
+    if (!Array.isArray(hostIds) || hostIds.length !== 1 || typeof hostIds[0] !== "string") return false;
+    if (serviceId === "auth") return SAFE_AUTH_SERVICE_HOST_ID.test(hostIds[0]);
+    return hostIds[0] === `${projectRef}-${serviceId}`;
+}
+
+function isProjectServiceStatus(payload: unknown, projectRef: string): payload is ProjectServiceStatus {
     if (!isRecordPayload(payload)) return false;
-    return typeof payload.id === "string"
-        && typeof payload.name === "string"
-        && typeof payload.status === "string"
-        && typeof payload.healthy === "boolean"
-        && Array.isArray(payload.service_host_ids)
-        && payload.service_host_ids.every((hostId) => typeof hostId === "string");
+    if (!isStudioProjectServiceName(payload.id) || payload.name !== payload.id) return false;
+    return hasValidStudioServiceHealth(payload.id, payload.status, payload.healthy)
+        && hasValidStudioServiceHost(payload.id, projectRef, payload.service_host_ids);
 }
 
 function projectServiceStatusOutput(status: ProjectServiceStatus): ProjectServiceStatus {
@@ -97,7 +129,7 @@ function projectServiceStatusOutput(status: ProjectServiceStatus): ProjectServic
         name: status.name,
         status: status.status,
         healthy: status.healthy,
-        service_host_ids: [...status.service_host_ids],
+        service_host_ids: [status.service_host_ids[0]],
     };
 }
 
@@ -106,7 +138,14 @@ function projectServicesResponse(
     response: HttpResult<unknown>,
 ): ProjectToolResponse {
     if (!response.ok) return failedProjectServiceHttpResponse(response);
-    if (!Array.isArray(response.data) || !response.data.every(isProjectServiceStatus)) {
+    if (!SAFE_PROJECT_REF.test(projectRef) || !Array.isArray(response.data) || response.data.length !== 5) {
+        return failedProjectServiceResponse("Project service inventory response is invalid");
+    }
+    if (!response.data.every((service) => isProjectServiceStatus(service, projectRef))) {
+        return failedProjectServiceResponse("Project service inventory response is invalid");
+    }
+    const serviceIds = new Set(response.data.map((service) => service.id));
+    if (serviceIds.size !== STUDIO_PROJECT_SERVICE_NAMES.length) {
         return failedProjectServiceResponse("Project service inventory response is invalid");
     }
     const services = response.data.map(projectServiceStatusOutput);
@@ -130,7 +169,11 @@ function projectServiceReceiptError(
         return "Project service control response does not match the request";
     }
     if (receipt.success === false) return "Project service control failed";
-    if (receipt.success !== true || typeof receipt.message !== "string") {
+    if (
+        receipt.success !== true
+        || typeof receipt.message !== "string"
+        || receipt.message.length > MAX_SERVICE_CONTROL_MESSAGE_LENGTH
+    ) {
         return "Project service control response is invalid";
     }
     return null;

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
-import type { HttpTransport } from "../transports/http";
+import type { HttpResult, HttpTransport } from "../transports/http";
 
 type ToolServer = {
     tool: (
@@ -11,6 +11,115 @@ type ToolServer = {
         callback: (args: any) => Promise<any>,
     ) => void;
 };
+
+const PROJECT_SERVICE_NAMES = [
+    "postgrest", "gotrue", "storage", "postgresql", "realtime", "gateway",
+] as const;
+const PROJECT_SERVICE_CONTROL_ACTIONS = [
+    "start", "stop", "restart", "pause", "resume", "status",
+] as const;
+
+type ProjectServiceName = typeof PROJECT_SERVICE_NAMES[number];
+type ProjectServiceControlAction = typeof PROJECT_SERVICE_CONTROL_ACTIONS[number];
+
+const SUPPORTED_PROJECT_SERVICE_ACTIONS: Record<
+    ProjectServiceName,
+    readonly ProjectServiceControlAction[]
+> = {
+    postgrest: ["start", "stop", "restart", "pause", "resume", "status"],
+    gotrue: ["start", "stop", "restart"],
+    storage: ["start", "stop", "restart"],
+    postgresql: ["start", "stop", "restart"],
+    realtime: ["start", "stop", "restart"],
+    gateway: ["start", "stop", "restart"],
+};
+
+type ProjectToolResponse = {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+};
+
+function projectToolResponse(text: string): ProjectToolResponse {
+    return { content: [{ type: "text", text }] };
+}
+
+function failedProjectServiceResponse(message: string): ProjectToolResponse {
+    return {
+        content: [{ type: "text", text: `❌ ${message}` }],
+        isError: true,
+    };
+}
+
+function failedProjectServiceHttpResponse(response: HttpResult<unknown>): ProjectToolResponse {
+    return failedProjectServiceResponse(
+        `Failed (${response.status}): ${JSON.stringify(response.data)}`,
+    );
+}
+
+function isRecordPayload(payload: unknown): payload is Record<string, unknown> {
+    return typeof payload === "object" && payload !== null && !Array.isArray(payload);
+}
+
+function isProjectServiceStatus(payload: unknown): boolean {
+    if (!isRecordPayload(payload)) return false;
+    return typeof payload.id === "string"
+        && typeof payload.name === "string"
+        && typeof payload.status === "string"
+        && typeof payload.healthy === "boolean"
+        && Array.isArray(payload.service_host_ids)
+        && payload.service_host_ids.every((hostId) => typeof hostId === "string");
+}
+
+function projectServicesResponse(
+    projectRef: string,
+    response: HttpResult<unknown>,
+): ProjectToolResponse {
+    if (!response.ok) return failedProjectServiceHttpResponse(response);
+    if (!Array.isArray(response.data) || !response.data.every(isProjectServiceStatus)) {
+        return failedProjectServiceResponse("Project service inventory response is invalid");
+    }
+    return projectToolResponse(JSON.stringify({ project_ref: projectRef, services: response.data }, null, 2));
+}
+
+function supportsProjectServiceAction(
+    service: ProjectServiceName,
+    action: ProjectServiceControlAction,
+): boolean {
+    return SUPPORTED_PROJECT_SERVICE_ACTIONS[service].includes(action);
+}
+
+function projectServiceReceiptError(
+    receipt: unknown,
+    requestedService: ProjectServiceName,
+    requestedAction: ProjectServiceControlAction,
+): string | null {
+    if (!isRecordPayload(receipt)) return "Project service control response is invalid";
+    if (receipt.service !== requestedService || receipt.action !== requestedAction) {
+        return "Project service control response does not match the request";
+    }
+    if (receipt.success !== true || typeof receipt.message !== "string") {
+        return `Project service control failed: ${JSON.stringify(receipt)}`;
+    }
+    return null;
+}
+
+function projectServiceControlResponse(
+    projectRef: string,
+    requestedService: ProjectServiceName,
+    requestedAction: ProjectServiceControlAction,
+    response: HttpResult<unknown>,
+): ProjectToolResponse {
+    if (!response.ok) return failedProjectServiceHttpResponse(response);
+    const receiptError = projectServiceReceiptError(response.data, requestedService, requestedAction);
+    if (receiptError) return failedProjectServiceResponse(receiptError);
+    return projectToolResponse(JSON.stringify({
+        project_ref: projectRef,
+        service: requestedService,
+        action: requestedAction,
+        success: true,
+        receipt: response.data,
+    }, null, 2));
+}
 
 const formatTasks = (data: unknown): string => {
     if (!Array.isArray(data)) return JSON.stringify(data, null, 2);
@@ -98,14 +207,14 @@ export function registerUserProjectCliTools(
 export function registerAdminProjectCliTools(server: ToolServer, http: HttpTransport): void {
     server.tool(
         "project",
-        "Platform-level project lifecycle management. Actions: list, create, get, delete, pause, restore, restart, settings, update_settings, api_keys, health, logs, tasks",
+        "Platform-level project lifecycle management. Actions: list, create, get, delete, pause, restore, restart, settings, update_settings, api_keys, health, logs, tasks, services, service_control",
         {
             action: withDescription(stringEnum([
                 "list", "create", "get", "delete", "pause", "restore",
                 "restart", "settings", "update_settings", "api_keys",
-                "health", "logs", "tasks",
+                "health", "logs", "tasks", "services", "service_control",
             ]), "Action to perform"),
-            ref: optional(Type.String(), "Project ref (required for most actions except 'list' and 'create')"),
+            ref: optional(Type.String(), "[*] Project ref (required for most actions except 'list' and 'create')"),
             name: optional(Type.String(), "[create] Project name"),
             region: optional(Type.String(), "[create] Region (default: local)"),
             organization_id: optional(Type.String(), "[create] Organization ID"),
@@ -115,6 +224,11 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
             studio_domain: optional(Type.String(), "[create] Explicit Studio domain"),
             settings: optional(Type.Record(Type.String(), Type.Unknown()), "[update_settings] Config fields to update"),
             log_type: optional(stringEnum(["all", "auth", "database", "api"]), "[logs] Filter by service"),
+            service: optional(stringEnum(PROJECT_SERVICE_NAMES), "[service_control] Canonical service name"),
+            service_action: optional(
+                stringEnum(PROJECT_SERVICE_CONTROL_ACTIONS),
+                "[service_control] Supported action for the selected service",
+            ),
         },
         async ({
             action,
@@ -128,6 +242,8 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
             studio_domain,
             settings,
             log_type,
+            service,
+            service_action,
         }) => {
             let text: string;
 
@@ -197,6 +313,32 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
                     const res = await http.get(`/v1/projects/${resolveRef(ref)}/tasks`);
                     text = res.ok ? formatTasks(res.data) : `❌ Failed (${res.status})`;
                     break;
+                }
+                case "services": {
+                    const resolvedRef = resolveRef(ref);
+                    return projectServicesResponse(
+                        resolvedRef,
+                        await http.get(`/v1/projects/${encodeURIComponent(resolvedRef)}/services`),
+                    );
+                }
+                case "service_control": {
+                    const resolvedRef = resolveRef(ref);
+                    if (!service) throw new Error("'service' is required for service_control");
+                    if (!service_action) throw new Error("'service_action' is required for service_control");
+                    if (!supportsProjectServiceAction(service, service_action)) {
+                        throw new Error(`'${service_action}' is not supported for service '${service}'`);
+                    }
+                    const encodedRef = encodeURIComponent(resolvedRef);
+                    const encodedService = encodeURIComponent(service);
+                    const encodedAction = encodeURIComponent(service_action);
+                    return projectServiceControlResponse(
+                        resolvedRef,
+                        service,
+                        service_action,
+                        await http.post(
+                            `/v1/projects/${encodedRef}/services/${encodedService}/${encodedAction}`,
+                        ),
+                    );
                 }
                 default:
                     text = `❌ Unknown action: ${action}`;


### PR DESCRIPTION
## Summary

- add read-only project service inventory via `supacloud-admin project services --ref REF`
- add constrained lifecycle control via `supacloud-admin project service_control --ref REF --service SERVICE --service_action ACTION`
- restrict service/action pairs to the existing Management API contract and preserve SupAuth owner/shared-auth enforcement
- fail closed on non-2xx responses, malformed or mismatched receipts, and HTTP 200 responses with `success: false`
- keep `SUPACLOUD_API_TOKEN` environment-only and emit project-bound JSON receipts for strict read-back

No Management API route or auth boundary is changed. The CLI uses only `GET /v1/projects/{ref}/services` and `POST /v1/projects/{ref}/services/{service}/{action}`.

## Verification

- `bun test` in `packages/admin`: 185 pass, 0 fail
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- independent contract review and focused 23/23 rerun: PASS

## Safety

- canonical service and action enums prevent arbitrary path or systemd target selection
- POST operations retain the existing no-retry transport policy
- shared-auth GoTrue control remains blocked by `AUTH_RUNTIME_MANAGED_BY_OWNER`; the CLI never redirects the action to the owner project