### PR TITLE
feat(cli): load project secrets from environment

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,6 +71,7 @@ supacloud-cli branch promote --branch_ref preview123 --plan_checksum <sha256>
 supacloud-cli edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
 supacloud-cli edge_functions deploy_bundle --ref abc123 --slug hello --files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}'
 supacloud-cli edge_functions source --ref abc123 --slug hello --output ./hello.ts
+supacloud-cli secrets upsert --ref abc123 --from-env API_KEY,WEBHOOK_SECRET
 ```
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
@@ -81,6 +82,13 @@ module policy consistently for CLI, Web Console, and direct API deployments.
 Use `source --output <file>` for large Functions so terminal or automation output
 limits cannot truncate the original TS/JS source code. The destination must not
 already exist.
+
+For secret writes, `--from-env` accepts a comma-separated list of environment
+variable names. The CLI reads each non-empty value from its own process
+environment, so command arguments contain names only and values are never
+printed. Names must be unique shell-style identifiers (`[A-Za-z_][A-Za-z0-9_]*`,
+up to 256 characters). Missing or empty values fail before any HTTP request.
+Do not combine `--from-env` with the compatibility `--secrets` input.
 
 Branch promotion is migration-first. `branch promotion_plan` prints pending
 versions, names, statement counts, and checksums without echoing SQL into terminal

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -235,6 +235,34 @@ describe("supacloud-cli process contract", () => {
         expect(response.stdout + response.stderr).not.toContain(secondarySecret);
     });
 
+    test("returns non-zero without echoing the response body when listing secrets fails", async () => {
+        const responseBodySentinel = "server-secret-shaped-error-sentinel";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                return Response.json(
+                    { error: responseBodySentinel },
+                    { status: 503 },
+                );
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["secrets", "list", "--ref", "abc123"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stdout).toContain("❌ Failed (503)");
+        expect(response.stdout + response.stderr).not.toContain(responseBodySentinel);
+    });
+
     test.each([
         ["missing value", "FA_CLI_FROM_ENV_MISSING", {}],
         ["empty value", "FA_CLI_FROM_ENV_EMPTY", { FA_CLI_FROM_ENV_EMPTY: "" }],

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -195,6 +195,128 @@ describe("supacloud-cli process contract", () => {
         expect(response.stdout).toBe("");
     });
 
+    test("loads secret values from its environment while argv and output contain names only", async () => {
+        const secretName = "FA_CLI_FROM_ENV_PRIMARY";
+        const secondSecretName = "FA_CLI_FROM_ENV_SECONDARY";
+        const primarySecret = "process-primary-secret-sentinel";
+        const secondarySecret = "process-secondary-secret-sentinel";
+        let requestBody: unknown;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestBody = await request.json();
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+        const commandArguments = [
+            "secrets", "upsert", "--ref", "abc123",
+            "--from-env", `${secretName},${secondSecretName}`,
+        ];
+
+        const response = await runProjectCli(commandArguments, {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            [secretName]: primarySecret,
+            [secondSecretName]: secondarySecret,
+        });
+
+        expect(response.exitCode).toBe(0);
+        expect(commandArguments.join("\0")).not.toContain(primarySecret);
+        expect(commandArguments.join("\0")).not.toContain(secondarySecret);
+        expect(requestBody).toEqual([
+            { name: secretName, value: primarySecret },
+            { name: secondSecretName, value: secondarySecret },
+        ]);
+        expect(response.stdout).toContain("Updated 2 secrets");
+        expect(response.stdout + response.stderr).not.toContain(primarySecret);
+        expect(response.stdout + response.stderr).not.toContain(secondarySecret);
+    });
+
+    test.each([
+        ["missing value", "FA_CLI_FROM_ENV_MISSING", {}],
+        ["empty value", "FA_CLI_FROM_ENV_EMPTY", { FA_CLI_FROM_ENV_EMPTY: "" }],
+        ["invalid name", "FA-CLI-INVALID", {}],
+        ["duplicate name", "FA_CLI_DUPLICATE,FA_CLI_DUPLICATE", { FA_CLI_DUPLICATE: "never-printed-secret" }],
+    ])("rejects from-env %s before HTTP", async (_label, names, secretEnvironment) => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["secrets", "upsert", "--ref", "abc123", "--from-env", names],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                ...secretEnvironment,
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stdout + response.stderr).not.toContain("never-printed-secret");
+    });
+
+    test("rejects mixed secret inputs before HTTP without echoing the inline value", async () => {
+        let requestCount = 0;
+        const inlineSecret = "mixed-inline-secret-sentinel";
+        const environmentSecret = "mixed-environment-secret-sentinel";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "secrets", "upsert", "--ref", "abc123",
+                "--from-env", "FA_CLI_MIXED_ENV",
+                "--secrets", `INLINE_KEY=${inlineSecret}`,
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                FA_CLI_MIXED_ENV: environmentSecret,
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("cannot be combined");
+        expect(response.stdout + response.stderr).not.toContain(inlineSecret);
+        expect(response.stdout + response.stderr).not.toContain(environmentSecret);
+    });
+
+    test("documents the exact kebab-case from-env flag in action help", async () => {
+        const response = await runProjectCli(
+            ["secrets", "upsert", "--help"],
+            {
+                SUPACLOUD_API_URL: "http://127.0.0.1:1",
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("--from-env");
+        expect(response.stderr).not.toContain("--from_env");
+    });
+
     test.each([
         ["separate flag value", ["--log_type", "database"]],
         ["equals flag value", ["--log_type=database"]],

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -154,6 +154,56 @@ describe("supacloud-cli process contract", () => {
         expect(requestedPaths).toEqual(["/v1/projects/prod-ref/tasks/task-1/cancel"]);
     });
 
+    test("requires production confirmation for secrets from environment before HTTP", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-production-secrets-"));
+        temporaryDirectories.push(workspace);
+        const productionSecretName = "FA_CLI_PRODUCTION_SECRET";
+        const productionSecret = "production-secret-sentinel";
+        const requestedPaths: string[] = [];
+        const requestedBodies: unknown[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestedPaths.push(new URL(request.url).pathname);
+                requestedBodies.push(await request.json());
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+        writeFileSync(join(workspace, ".env.supacloud.prod"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=prod-secret-token",
+            "SUPACLOUD_PROJECT_REF=prod-ref",
+        ].join("\n") + "\n");
+
+        const unconfirmed = await runProjectCli([
+            "secrets", "upsert", "--ref", "prod-ref", "--from-env", productionSecretName, "--env", "prod",
+        ], { [productionSecretName]: productionSecret }, workspace);
+        const crossRef = await runProjectCli([
+            "secrets", "upsert", "--ref", "other-ref", "--from-env", productionSecretName,
+            "--env", "prod", "--confirm-production", "other-ref",
+        ], { [productionSecretName]: productionSecret }, workspace);
+        const confirmed = await runProjectCli([
+            "secrets", "upsert", "--ref", "prod-ref", "--from-env", productionSecretName,
+            "--env", "prod", "--confirm-production", "prod-ref",
+        ], { [productionSecretName]: productionSecret }, workspace);
+
+        expect(unconfirmed.exitCode).toBe(1);
+        expect(unconfirmed.stderr).toContain("--confirm-production prod-ref");
+        expect(crossRef.exitCode).toBe(1);
+        expect(crossRef.stderr).toContain("cannot target a different project");
+        expect(confirmed.exitCode).toBe(0);
+        expect(requestedPaths).toEqual(["/v1/projects/prod-ref/secrets"]);
+        expect(requestedBodies).toEqual([[
+            { name: productionSecretName, value: productionSecret },
+        ]]);
+        for (const response of [unconfirmed, crossRef, confirmed]) {
+            expect(response.stdout + response.stderr).not.toContain(productionSecret);
+        }
+    });
+
     test("flushes a Function source response larger than 64 KiB to stdout", async () => {
         const apiUrl = serveFunctionSource(LARGE_FUNCTION_SOURCE);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -202,6 +202,7 @@ EXAMPLES
   ${preferredCommand} ai install_skill --dry_run
   ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
   ${preferredCommand} edge_functions config --ref abc123 --slug hello --verify_jwt false --background_routes "/queue/*,/render/*"
+  ${preferredCommand} secrets upsert --ref abc123 --from-env API_KEY,WEBHOOK_SECRET
   ${preferredCommand} gateway routes --ref abc123
   ${preferredCommand} gateway upsert_route --ref abc123 --route_id webhook --hosts "api.example.com" --paths "/webhook/*" --upstream 10.0.0.5:8080
   ${preferredCommand} gateway config --ref abc123 --rate_limit_tier pro

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -265,6 +265,22 @@ describe("edge_functions CLI tool", () => {
 });
 
 describe("secrets CLI tool", () => {
+    test("fails closed without echoing the response body when listing secrets fails", async () => {
+        const responseBodySentinel = "server-secret-shaped-error-sentinel";
+        const { callback } = captureSecretsTool({
+            get: async () => ({
+                ok: false,
+                status: 503,
+                data: { error: responseBodySentinel },
+            }),
+        });
+
+        const response = await callback({ action: "list", ref: "proj" });
+
+        expect(response.content[0].text).toBe("❌ Failed (503)");
+        expect(response.content[0].text).not.toContain(responseBodySentinel);
+    });
+
     test("parses JSON array secrets passed as a CLI string", () => {
         const { schema } = captureSecretsTool({});
         const parsed = parseToolArguments(schema, {

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -18,7 +18,10 @@ function captureEdgeFunctionsTool(http: Record<string, unknown>) {
     return { schema, callback };
 }
 
-function captureSecretsTool(http: Record<string, unknown>) {
+function captureSecretsTool(
+    http: Record<string, unknown>,
+    environment: NodeJS.ProcessEnv = {},
+) {
     let schema: ToolSchema | undefined;
     let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
     registerAdvancedTools({
@@ -27,7 +30,7 @@ function captureSecretsTool(http: Record<string, unknown>) {
             schema = toolSchema;
             callback = toolCallback;
         },
-    }, http as any);
+    }, http as any, environment);
 
     if (!schema || !callback) throw new Error("secrets tool was not registered");
     return { schema, callback };
@@ -285,6 +288,103 @@ describe("secrets CLI tool", () => {
             { name: "API_KEY", value: "secret" },
             { name: "OTHER", value: "value=with=equals" },
         ]);
+    });
+
+    test("parses explicit environment variable names from the kebab-case flag", () => {
+        const { schema } = captureSecretsTool({});
+        const parsed = parseToolArguments(schema, {
+            action: "upsert",
+            ref: "proj",
+            "from-env": " API_KEY,WEBHOOK_SECRET ",
+        });
+
+        expect(parsed["from-env"]).toEqual(["API_KEY", "WEBHOOK_SECRET"]);
+    });
+
+    test.each([
+        ["empty entries", "API_KEY,,WEBHOOK_SECRET", "non-empty comma-separated list"],
+        ["invalid names", "API-KEY", "Invalid environment secret name 'API-KEY'"],
+        ["overlong names", `A${"B".repeat(256)}`, "Invalid environment secret name"],
+        ["duplicate names", "API_KEY,API_KEY", "Duplicate environment secret name 'API_KEY'"],
+    ])("rejects %s before resolving environment values", (_label, names, expectedMessage) => {
+        const { schema } = captureSecretsTool({});
+
+        expect(() => parseToolArguments(schema, {
+            action: "upsert",
+            ref: "proj",
+            "from-env": names,
+        })).toThrow(expectedMessage);
+    });
+
+    test("reads secret values from the CLI environment without echoing them", async () => {
+        const requests: Array<{ path: string; body: unknown }> = [];
+        const primarySecret = "unit-primary-secret-sentinel";
+        const secondarySecret = "unit-secondary-secret-sentinel";
+        const { callback } = captureSecretsTool({
+            post: async (path: string, body: unknown) => {
+                requests.push({ path, body });
+                return { ok: true, status: 200, data: {} };
+            },
+        }, {
+            API_KEY: primarySecret,
+            WEBHOOK_SECRET: secondarySecret,
+        });
+
+        const response = await callback({
+            action: "upsert",
+            ref: "proj",
+            "from-env": ["API_KEY", "WEBHOOK_SECRET"],
+        });
+
+        expect(requests).toEqual([{
+            path: "/v1/projects/proj/secrets",
+            body: [
+                { name: "API_KEY", value: primarySecret },
+                { name: "WEBHOOK_SECRET", value: secondarySecret },
+            ],
+        }]);
+        expect(response.content[0].text).toBe("✅ Updated 2 secrets");
+        expect(response.content[0].text).not.toContain(primarySecret);
+        expect(response.content[0].text).not.toContain(secondarySecret);
+    });
+
+    test.each([
+        ["missing", {}],
+        ["empty", { API_KEY: "" }],
+    ])("fails closed when an environment value is %s", async (_label, environment) => {
+        let requestCount = 0;
+        const { callback } = captureSecretsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        }, environment);
+
+        await expect(callback({
+            action: "upsert",
+            ref: "proj",
+            "from-env": ["API_KEY"],
+        })).rejects.toThrow("Environment variable 'API_KEY' must be set to a non-empty value");
+        expect(requestCount).toBe(0);
+    });
+
+    test("rejects mixed from-env and inline inputs before HTTP", async () => {
+        let requestCount = 0;
+        const inlineSecret = "unit-inline-secret-sentinel";
+        const { callback } = captureSecretsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        }, { API_KEY: "unit-environment-secret-sentinel" });
+
+        await expect(callback({
+            action: "upsert",
+            ref: "proj",
+            secrets: [{ name: "INLINE_KEY", value: inlineSecret }],
+            "from-env": ["API_KEY"],
+        })).rejects.toThrow("'--from-env' cannot be combined with '--secrets'");
+        expect(requestCount).toBe(0);
     });
 });
 

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -379,9 +379,13 @@ Actions: list, upsert, delete`,
             const environmentNames = args["from-env"] as string[] | undefined;
             let text: string;
             switch (action) {
-                case "list":
-                    text = JSON.stringify((await http.get(`/v1/projects/${ref}/secrets`)).data, null, 2);
+                case "list": {
+                    const response = await http.get(`/v1/projects/${ref}/secrets`);
+                    text = response.ok
+                        ? JSON.stringify(response.data, null, 2)
+                        : `❌ Failed (${response.status})`;
                     break;
+                }
                 case "upsert":
                     const secretsToUpsert = secretsForUpsert(secrets, environmentNames, environment);
                     text = (await http.post(`/v1/projects/${ref}/secrets`, secretsToUpsert)).ok

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -92,6 +92,9 @@ const functionFilesSchema = decodedSchema(
 );
 
 const secretListSchema = Type.Array(Type.Object({ name: Type.String(), value: Type.String() }));
+const ENVIRONMENT_SECRET_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,255}$/;
+
+type SecretEntry = { name: string; value: string };
 
 function parseSecrets(value: string | Array<{ name: string; value: string }>): unknown {
     if (Array.isArray(value)) return value;
@@ -121,6 +124,56 @@ const secretsSchema = Type.Optional(decodedSchema(
     parseSecrets,
 ));
 
+function parseEnvironmentSecretNames(input: string): unknown {
+    const names = input.split(",").map((name) => name.trim());
+    if (names.some((name) => name.length === 0)) {
+        throw new Error("Environment secret names must be a non-empty comma-separated list");
+    }
+    const invalidName = names.find((name) => !ENVIRONMENT_SECRET_NAME_PATTERN.test(name));
+    if (invalidName) {
+        throw new Error(`Invalid environment secret name '${invalidName}'`);
+    }
+    const duplicateName = names.find((name, index) => names.indexOf(name) !== index);
+    if (duplicateName) {
+        throw new Error(`Duplicate environment secret name '${duplicateName}'`);
+    }
+    return names;
+}
+
+const environmentSecretNamesSchema = Type.Optional(decodedSchema(
+    Type.String(),
+    Type.Array(Type.String(), { minItems: 1, uniqueItems: true }),
+    parseEnvironmentSecretNames,
+));
+
+function secretsFromEnvironment(
+    names: string[],
+    environment: NodeJS.ProcessEnv,
+): SecretEntry[] {
+    return names.map((name) => {
+        const secretValue = environment[name];
+        if (!secretValue) {
+            throw new Error(`Environment variable '${name}' must be set to a non-empty value`);
+        }
+        return { name, value: secretValue };
+    });
+}
+
+function secretsForUpsert(
+    inlineSecrets: SecretEntry[] | undefined,
+    environmentNames: string[] | undefined,
+    environment: NodeJS.ProcessEnv,
+): SecretEntry[] {
+    if (inlineSecrets !== undefined && environmentNames !== undefined) {
+        throw new Error("'--from-env' cannot be combined with '--secrets'");
+    }
+    if (environmentNames !== undefined) {
+        return secretsFromEnvironment(environmentNames, environment);
+    }
+    if (!inlineSecrets?.length) throw new Error("'secrets' array required");
+    return inlineSecrets;
+}
+
 type EdgeFunctionConfigInput = {
     verify_jwt?: boolean;
     background_routes?: string[];
@@ -143,7 +196,11 @@ function functionSourceCode(payload: unknown): string | null {
     return typeof code === "string" ? code : null;
 }
 
-export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
+export function registerAdvancedTools(
+    server: { tool: (...args: any[]) => void },
+    http: HttpTransport,
+    environment: NodeJS.ProcessEnv = process.env,
+): void {
 
     // ═══ Edge Functions (5→1) ═══
     server.tool(
@@ -311,19 +368,24 @@ Actions: list, upsert, delete`,
             action: withDescription(stringEnum(["list", "upsert", "delete"]), "Action"),
             ref: withDescription(Type.String(), "Project ref"),
             secrets: withDescription(secretsSchema, "[upsert] Secret list as JSON array or KEY=VALUE,KEY2=VALUE2"),
+            "from-env": withDescription(
+                environmentSecretNamesSchema,
+                "[upsert] Comma-separated environment variable names; values are read from this CLI process",
+            ),
             name: optional(Type.String(), "[delete] Secret name to delete"),
         },
         async (args: any) => {
             const { action, ref, secrets, name } = args;
+            const environmentNames = args["from-env"] as string[] | undefined;
             let text: string;
             switch (action) {
                 case "list":
                     text = JSON.stringify((await http.get(`/v1/projects/${ref}/secrets`)).data, null, 2);
                     break;
                 case "upsert":
-                    if (!secrets?.length) throw new Error("'secrets' array required");
-                    text = (await http.post(`/v1/projects/${ref}/secrets`, secrets)).ok
-                        ? `✅ Updated ${secrets.length} secrets` : `❌ Failed`;
+                    const secretsToUpsert = secretsForUpsert(secrets, environmentNames, environment);
+                    text = (await http.post(`/v1/projects/${ref}/secrets`, secretsToUpsert)).ok
+                        ? `✅ Updated ${secretsToUpsert.length} secrets` : `❌ Failed`;
                     break;
                 case "delete":
                     if (!name) throw new Error("'name' required");


### PR DESCRIPTION
## Summary

- add `supacloud-cli secrets upsert --from-env NAME1,NAME2`
- resolve values only from the CLI process environment so secret values stay out of argv and CLI output
- reject empty, invalid, duplicate, missing, or mixed `--from-env`/`--secrets` inputs before HTTP
- make `secrets list` fail with a non-zero CLI exit on HTTP errors without echoing server response bodies
- retain the existing `--secrets` compatibility input and document the exact kebab-case flag

## Verification

- `cd packages/cli && bun test` (132 pass)
- `cd packages/cli && bun run typecheck`
- `cd packages/cli && bun run build`
- `git diff --check`

No release or deployment is included.