### PR TITLE
fix(cli): preserve auth mutation failure contract

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -174,6 +174,22 @@ USING hnsw (embedding vector_cosine_ops);
 
 Transaction boundary: SupaCloud supports transaction blocks inside one SQL request and transactional migrations. It does not expose long-lived HTTP transaction sessions; use a direct Postgres DSN for application-side long transactions.
 
+Auth configuration commands accept a JSON object from the CLI:
+
+```bash
+supacloud-cli auth update_settings --ref abc123 \
+  --config '{"disable_signup":true,"enable_signup":false}'
+supacloud-cli auth update_config --ref abc123 \
+  --config '{"third_party_auth":{"enabled":true}}'
+```
+
+Failed Auth mutations exit non-zero and print a JSON object containing the HTTP
+status plus an allowlisted subset of runtime-apply state. If Management API
+returns `503` with `persisted: true`, the desired configuration was saved but
+runtime propagation was incomplete; automation must read the affected settings
+back exactly before deciding whether it is safe to continue. Free-form server
+messages and request configuration are not echoed.
+
 Project commands owned by this CLI:
 
 - `project get`

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -258,6 +258,52 @@ describe("supacloud-cli process contract", () => {
         ]);
     });
 
+    test("returns a non-zero machine-readable Auth failure without echoing config secrets", async () => {
+        const configSecret = "auth-config-must-not-be-printed";
+        let requestedBody = "";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestedBody = await request.text();
+                return Response.json({
+                    code: "AUTH_RUNTIME_APPLY_FAILED",
+                    message: `runtime rejected ${configSecret}`,
+                    persisted: true,
+                    runtime_applied: false,
+                    runtime_mode: "local",
+                    echoed_config: configSecret,
+                }, { status: 503 });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "auth", "update_config",
+                "--ref", "abc123",
+                "--config", JSON.stringify({ private_key: configSecret }),
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(JSON.parse(response.stdout)).toEqual({
+            ok: false,
+            http_status: 503,
+            code: "AUTH_RUNTIME_APPLY_FAILED",
+            persisted: true,
+            runtime_applied: false,
+            runtime_mode: "local",
+        });
+        expect(requestedBody).toContain(configSecret);
+        expect(response.stdout + response.stderr).not.toContain(configSecret);
+    });
+
     test("status reports missing configuration and exits non-zero", async () => {
         const result = await runProjectCli(["status"]);
         const status = JSON.parse(result.stdout);

--- a/packages/cli/src/shared/tools/auth-tools.test.ts
+++ b/packages/cli/src/shared/tools/auth-tools.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { parseToolArguments, type ToolSchema } from "../schema";
+import { registerAuthTools } from "./auth-tools";
+
+type AuthToolCallback = (
+    args: Record<string, unknown>,
+) => Promise<{ isError?: boolean; content: Array<{ text: string }> }>;
+
+function captureAuthTool(http: Record<string, unknown>) {
+    let schema: ToolSchema | undefined;
+    let callback: AuthToolCallback | undefined;
+    registerAuthTools({
+        tool(name: string, _description: string, toolSchema: ToolSchema, toolCallback: AuthToolCallback) {
+            if (name !== "auth") return;
+            schema = toolSchema;
+            callback = toolCallback;
+        },
+    }, http as any);
+
+    if (!schema || !callback) throw new Error("auth tool was not registered");
+    return { schema, callback };
+}
+
+describe("auth CLI mutation contract", () => {
+    test("decodes a CLI JSON config before sending the PATCH request", async () => {
+        const requests: Array<{ path: string; body: unknown }> = [];
+        const { schema, callback } = captureAuthTool({
+            patch: async (path: string, body: unknown) => {
+                requests.push({ path, body });
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+        const parsed = parseToolArguments(schema, {
+            action: "update_config",
+            ref: "project-a",
+            config: '{"jwt_expiry":5400}',
+        });
+
+        const response = await callback(parsed);
+
+        expect(requests).toEqual([{
+            path: "/v1/projects/project-a/config/auth",
+            body: { jwt_expiry: 5400 },
+        }]);
+        expect(response.isError).toBeUndefined();
+        expect(response.content[0].text).toBe("✅ Auth config updated");
+    });
+
+    test.each([
+        ["update_settings", "/v1/projects/project-a/auth/config"],
+        ["update_config", "/v1/projects/project-a/config/auth"],
+    ])("returns a machine-readable persisted failure for %s", async (action, expectedPath) => {
+        const responseSecret = "must-not-be-printed";
+        const requests: string[] = [];
+        const { callback } = captureAuthTool({
+            patch: async (path: string) => {
+                requests.push(path);
+                return {
+                    ok: false,
+                    status: 503,
+                    data: {
+                        code: "AUTH_RUNTIME_APPLY_FAILED",
+                        message: `runtime rejected ${responseSecret}`,
+                        persisted: true,
+                        runtime_applied: false,
+                        runtime_mode: "local",
+                        request_body: { secret: responseSecret },
+                    },
+                };
+            },
+        });
+
+        const response = await callback({ action, ref: "project-a", config: { enabled: true } });
+        const failure = JSON.parse(response.content[0].text);
+
+        expect(requests).toEqual([expectedPath]);
+        expect(response.isError).toBe(true);
+        expect(failure).toEqual({
+            ok: false,
+            http_status: 503,
+            code: "AUTH_RUNTIME_APPLY_FAILED",
+            persisted: true,
+            runtime_applied: false,
+            runtime_mode: "local",
+        });
+        expect(response.content[0].text).not.toContain(responseSecret);
+        expect(response.content[0].text).not.toContain("request_body");
+    });
+
+    test("fails closed with only the HTTP status for an unrecognized error body", async () => {
+        const secretShapedCode = "TOKEN_SECRET_MUST_NOT_PRINT_123";
+        const { callback } = captureAuthTool({
+            patch: async () => ({
+                ok: false,
+                status: 400,
+                data: { code: secretShapedCode, message: "sensitive diagnostic" },
+            }),
+        });
+
+        const response = await callback({
+            action: "update_config",
+            ref: "project-a",
+            config: { enabled: true },
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text)).toEqual({ ok: false, http_status: 400 });
+        expect(response.content[0].text).not.toContain(secretShapedCode);
+        expect(response.content[0].text).not.toContain("sensitive diagnostic");
+    });
+
+    test("preserves the shared Auth runtime mode from a safe failure response", async () => {
+        const { callback } = captureAuthTool({
+            patch: async () => ({
+                ok: false,
+                status: 503,
+                data: { persisted: true, runtime_mode: "shared" },
+            }),
+        });
+
+        const response = await callback({
+            action: "update_settings",
+            ref: "project-a",
+            config: { enabled: true },
+        });
+
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            ok: false,
+            http_status: 503,
+            persisted: true,
+            runtime_mode: "shared",
+        });
+    });
+
+    test("preserves only safe owner dependent-refresh state", async () => {
+        const { callback } = captureAuthTool({
+            patch: async () => ({
+                ok: false,
+                status: 503,
+                data: {
+                    code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+                    persisted: true,
+                    runtime_applied: true,
+                    dependents_applied: false,
+                    dependent_status: "failed",
+                    runtime_mode: "owner",
+                    failed_dependents: ["customer-sensitive-ref"],
+                },
+            }),
+        });
+
+        const response = await callback({
+            action: "update_config",
+            ref: "project-a",
+            config: { enabled: true },
+        });
+
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            ok: false,
+            http_status: 503,
+            code: "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+            persisted: true,
+            runtime_applied: true,
+            dependents_applied: false,
+            dependent_status: "failed",
+            runtime_mode: "owner",
+        });
+        expect(response.content[0].text).not.toContain("customer-sensitive-ref");
+    });
+});

--- a/packages/cli/src/shared/tools/auth-tools.ts
+++ b/packages/cli/src/shared/tools/auth-tools.ts
@@ -2,8 +2,70 @@
  * Auth — Compound tool (10→1)
  */
 import { Type } from "@sinclair/typebox";
-import { optional, stringEnum, withDescription } from "../schema";
-import type { HttpTransport } from "../transports/http";
+import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
+import type { HttpResult, HttpTransport } from "../transports/http";
+
+const authConfigRecord = Type.Record(Type.String(), Type.Unknown());
+const safeAuthMutationCodes = new Set([
+    "AUTH_RUNTIME_APPLY_FAILED",
+    "SUPAUTH_DEPENDENT_REFRESH_FAILED",
+]);
+
+function parseAuthConfig(input: string | Record<string, unknown>): unknown {
+    if (typeof input !== "string") return input;
+    try {
+        return JSON.parse(input);
+    } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+        throw new Error("Invalid auth config JSON object");
+    }
+}
+
+const authConfigSchema = decodedSchema(
+    Type.Union([Type.String(), authConfigRecord]),
+    authConfigRecord,
+    parseAuthConfig,
+);
+
+function safeAuthFailureFields(payload: unknown): Record<string, unknown> {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return {};
+    const body = payload as Record<string, unknown>;
+    const fields: Record<string, unknown> = {};
+    if (typeof body.code === "string" && safeAuthMutationCodes.has(body.code)) {
+        fields.code = body.code;
+    }
+    for (const field of ["persisted", "runtime_applied", "dependents_applied"] as const) {
+        if (typeof body[field] === "boolean") fields[field] = body[field];
+    }
+    if (body.dependent_status === "failed" || body.dependent_status === "unknown") {
+        fields.dependent_status = body.dependent_status;
+    }
+    if (body.runtime_mode === "local" || body.runtime_mode === "owner" || body.runtime_mode === "shared") {
+        fields.runtime_mode = body.runtime_mode;
+    }
+    return fields;
+}
+
+function safeAuthMutationFailure(response: HttpResult<unknown>): Record<string, unknown> {
+    return {
+        ok: false,
+        http_status: response.status,
+        ...safeAuthFailureFields(response.data),
+    };
+}
+
+function authMutationResult(response: HttpResult<unknown>, successMessage: string) {
+    if (response.ok) {
+        return { content: [{ type: "text" as const, text: successMessage }] };
+    }
+    return {
+        isError: true,
+        content: [{
+            type: "text" as const,
+            text: JSON.stringify(safeAuthMutationFailure(response), null, 2),
+        }],
+    };
+}
 
 function formatProviders(data: unknown): string {
     if (!data || typeof data !== "object") return JSON.stringify(data, null, 2);
@@ -40,7 +102,7 @@ Actions: list_providers, get_provider, configure_provider, update_provider, disa
             url: optional(Type.String(), "[configure] Custom OAuth URL"),
             app_id: optional(Type.String(), "[wechat_*] WeChat App ID"),
             app_secret: optional(Type.String(), "[wechat_*] WeChat App Secret"),
-            config: optional(Type.Record(Type.String(), Type.Unknown()), "[update_settings/update_config] Config fields"),
+            config: optional(authConfigSchema, "[update_settings/update_config] Config fields as a JSON object"),
         },
         async (args: any) => {
             const { action, ref, provider, client_id, client_secret, redirect_uri, url, app_id, app_secret, config } = args;
@@ -100,15 +162,19 @@ Actions: list_providers, get_provider, configure_provider, update_provider, disa
                     break;
                 case "update_settings":
                     need("ref"); if (!config) throw new Error("'config' required");
-                    text = (await http.patch(`/v1/projects/${ref}/auth/config`, config)).ok ? `✅ Auth settings updated` : `❌ Failed`;
-                    break;
+                    return authMutationResult(
+                        await http.patch(`/v1/projects/${ref}/auth/config`, config),
+                        "✅ Auth settings updated",
+                    );
                 case "get_config":
                     need("ref"); text = ok(await http.get(`/v1/projects/${ref}/config/auth`));
                     break;
                 case "update_config":
                     need("ref"); if (!config) throw new Error("'config' required");
-                    text = (await http.patch(`/v1/projects/${ref}/config/auth`, config)).ok ? `✅ Auth config updated` : `❌ Failed`;
-                    break;
+                    return authMutationResult(
+                        await http.patch(`/v1/projects/${ref}/config/auth`, config),
+                        "✅ Auth config updated",
+                    );
                 default: text = `❌ Unknown action: ${action}`;
             }
             return { content: [{ type: "text" as const, text }] };


### PR DESCRIPTION
## Summary

- decode auth update_settings and update_config JSON config arguments before PATCH
- return a machine-readable Auth failure envelope while preserving non-zero CLI exits
- retain only allowlisted runtime propagation fields and document the 503 persisted contract

## Security

Free-form server messages, request configuration, project references, and unrecognized code values are not printed. Only the two known Auth propagation error codes and typed runtime state fields are retained.

## Verification

- bun test: 121 passed, 0 failed
- bun run typecheck
- bun run build
- git diff --check
- independent review: PASS

clean-code-guard: fixed the runtime_mode contract and replaced pattern-based code filtering with an exact allowlist; 0 findings remain.