### PR TITLE
feat(cli): add safe scheduled function release controls

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,6 +71,8 @@ supacloud-cli branch promote --branch_ref preview123 --plan_checksum <sha256>
 supacloud-cli edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
 supacloud-cli edge_functions deploy_bundle --ref abc123 --slug hello --files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}'
 supacloud-cli edge_functions source --ref abc123 --slug hello --output ./hello.ts
+supacloud-cli edge_functions activate --ref abc123 --slug hello --version 3
+supacloud-cli scheduled_functions list --ref abc123
 ```
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
@@ -81,6 +83,37 @@ module policy consistently for CLI, Web Console, and direct API deployments.
 Use `source --output <file>` for large Functions so terminal or automation output
 limits cannot truncate the original TS/JS source code. The destination must not
 already exist.
+
+`edge_functions activate` restores an existing immutable Function version and
+returns a machine-readable receipt containing the activated version and JWT
+policy. HTTP and malformed-response failures exit non-zero without echoing the
+server response body.
+
+Mutation receipts use schema `supacloud.cli.release-control.v1`. An
+`OUTCOME_UNKNOWN` error means the server may have committed the mutation before
+the response was lost or failed validation; read back current state before any
+retry.
+
+Scheduled Function lifecycle operations are also project-scoped:
+
+```bash
+supacloud-cli scheduled_functions create --ref abc123 --name nightly \
+  --slug cleanup --cron "0 2 * * *" --method POST
+supacloud-cli scheduled_functions update --ref abc123 --schedule_id <id> \
+  --cron "0 3 * * *"
+supacloud-cli scheduled_functions delete --ref abc123 --schedule_id <id>
+```
+
+Schedule IDs are canonical UUIDv4 values returned by create/list. Cron values
+use bounded numeric five-field syntax with wildcards, lists, ranges, and steps;
+out-of-range endpoints and steps are rejected before HTTP dispatch.
+
+Use `--body_file ./payload.json` for a JSON-object request body. Header values
+must come from environment variables: pass a JSON name mapping such as
+`--header_env '{"x-schedule-token":"SCHEDULE_TOKEN"}'`. Platform-owned
+`authorization`, `apikey`, and `x-project-ref` headers cannot be overridden. Receipts never
+include header values or body content; list and mutation receipts report only
+whether the body is empty and the configured header names.
 
 Branch promotion is migration-first. `branch promotion_plan` prints pending
 versions, names, statement counts, and checksums without echoing SQL into terminal

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -23,6 +23,10 @@ const temporaryDirectories: string[] = [];
 const LARGE_FUNCTION_SOURCE = "export const payload = "
     + JSON.stringify("x".repeat(80 * 1024))
     + ";\n";
+const SCHEDULE_ID = "00000000-0000-4000-8000-000000000001";
+const PATH_ESCAPE_INPUTS = [
+    ".", "..", "%2e", "%2e%2e", ".%2e", "%2e.", "%252e%252e", "a/b", "a?b", "a#b",
+];
 
 afterEach(() => {
     for (const server of servers.splice(0)) server.stop(true);
@@ -193,6 +197,449 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).toContain("Invalid arguments");
         expect(response.stderr).toContain("action");
         expect(response.stdout).toBe("");
+    });
+
+    test("activates a Function version through a secret-safe process contract", async () => {
+        const apiToken = "activation-api-token-sentinel";
+        const requested: Array<{ method: string; path: string; authorization: string | null }> = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requested.push({
+                    method: request.method,
+                    path: new URL(request.url).pathname,
+                    authorization: request.headers.get("authorization"),
+                });
+                return Response.json({
+                    success: true,
+                    version: "6",
+                    config: { version: "6", verify_jwt: false },
+                });
+            },
+        });
+        servers.push(server);
+        const commandArguments = [
+            "edge_functions", "activate", "--ref", "abc123",
+            "--slug", "public-hook", "--version", "6",
+        ];
+
+        const response = await runProjectCli(commandArguments, {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: apiToken,
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+        const receipt = JSON.parse(response.stdout);
+
+        expect(response.exitCode).toBe(0);
+        expect(receipt).toMatchObject({
+            ok: true,
+            operation: "edge_functions.activate",
+            slug: "public-hook",
+            version: "6",
+            verify_jwt: false,
+        });
+        expect(requested).toEqual([{
+            method: "POST",
+            path: "/v1/projects/abc123/functions/public-hook/versions/6/activate",
+            authorization: `Bearer ${apiToken}`,
+        }]);
+        expect(commandArguments.join("\0")).not.toContain(apiToken);
+        expect(response.stdout + response.stderr).not.toContain(apiToken);
+    });
+
+    test("returns structured non-zero Function activation failures without server text", async () => {
+        const responseBodySentinel = "private-activation-response-sentinel";
+        let activationCommitted = false;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => {
+                activationCommitted = true;
+                return Response.json({ error: responseBodySentinel }, { status: 503 });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+        const receipt = JSON.parse(response.stdout);
+
+        expect(activationCommitted).toBe(true);
+        expect(response.exitCode).toBe(1);
+        expect(receipt.error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 503 });
+        expect(response.stdout + response.stderr).not.toContain(responseBodySentinel);
+    });
+
+    test("reports an unknown Function activation outcome after malformed success", async () => {
+        let activationCommitted = false;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                activationCommitted = true;
+                return Response.json({ success: true });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(activationCommitted).toBe(true);
+        expect(response.exitCode).toBe(1);
+        expect(JSON.parse(response.stdout).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("rejects Function activation cross-action flags before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2",
+                "--verify_jwt", "false",
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("not supported for 'activate'");
+    });
+
+    test("rejects Function activation path before touching the file system or HTTP", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2",
+                "--path", "/definitely/not/exist/private-source.ts",
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("'path' is not supported for 'activate'");
+        expect(response.stdout + response.stderr).not.toContain("ENOENT");
+        expect(response.stdout + response.stderr).not.toContain("Failed to bundle/read path");
+    });
+
+    test("creates a schedule with body-file and environment-backed headers outside argv and output", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-cli-schedule-"));
+        temporaryDirectories.push(directory);
+        const bodyPath = join(directory, "body.json");
+        const bodySentinel = "private-schedule-body-sentinel";
+        const headerSentinel = "private-schedule-header-sentinel";
+        writeFileSync(bodyPath, JSON.stringify({ private: bodySentinel }));
+        let requestBody: Record<string, unknown> | null = null;
+        let requestId = "";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestBody = await request.json() as Record<string, unknown>;
+                requestId = String(requestBody.request_id);
+                const body = requestBody.body as Record<string, unknown>;
+                const headers = requestBody.headers as Record<string, string>;
+                return Response.json({
+                    created: true,
+                    project_ref: "abc123",
+                    request_id: requestBody.request_id,
+                    schedule: {
+                        id: SCHEDULE_ID,
+                        name: requestBody.name,
+                        slug: requestBody.slug,
+                        cron: requestBody.cron,
+                        method: requestBody.method,
+                        enabled: true,
+                        body_empty: Object.keys(body).length === 0,
+                        header_names: Object.keys(headers).sort(),
+                        created_at: "2026-08-11T00:00:00.000Z",
+                        updated_at: "2026-08-11T00:00:00.000Z",
+                    },
+                });
+            },
+        });
+        servers.push(server);
+        const commandArguments = [
+            "scheduled_functions", "create", "--ref", "abc123",
+            "--name", "Nightly", "--slug", "worker", "--cron", "0 2 * * *",
+            "--method", "POST", "--body_file", bodyPath,
+            "--header_env", '{"X-Schedule-Token":"SCHEDULE_TOKEN"}',
+        ];
+
+        const response = await runProjectCli(commandArguments, {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            SCHEDULE_TOKEN: headerSentinel,
+        });
+        const receipt = JSON.parse(response.stdout);
+
+        expect(response.exitCode).toBe(0);
+        expect(requestBody).toMatchObject({
+            body: { private: bodySentinel },
+            headers: { "x-schedule-token": headerSentinel },
+        });
+        expect(requestId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+        expect(receipt.schedule).toMatchObject({ body_empty: false, header_names: ["x-schedule-token"] });
+        expect(commandArguments.join("\0")).not.toContain(headerSentinel);
+        expect(commandArguments.join("\0")).not.toContain(bodySentinel);
+        expect(response.stdout + response.stderr).not.toContain(headerSentinel);
+        expect(response.stdout + response.stderr).not.toContain(bodySentinel);
+    });
+
+    test.each(PATH_ESCAPE_INPUTS)("rejects schedule path escape '%s' before any HTTP request", async (scheduleId) => {
+        let requestCount = 0;
+        let projectMutationCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requestCount += 1;
+                if (new URL(request.url).pathname === "/v1/projects/abc123") projectMutationCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+        const environment = {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        };
+
+        const updateResponse = await runProjectCli([
+            "scheduled_functions", "update", "--ref", "abc123",
+            "--schedule_id", scheduleId, "--name", "Safe Name",
+        ], environment);
+        const deleteResponse = await runProjectCli([
+            "scheduled_functions", "delete", "--ref", "abc123", "--schedule_id", scheduleId,
+        ], environment);
+
+        expect(updateResponse.exitCode).toBe(1);
+        expect(deleteResponse.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(projectMutationCount).toBe(0);
+    });
+
+    test("rejects a schedule dot-segment project ref before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["scheduled_functions", "list", "--ref", ".."],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+    });
+
+    test("reports an unknown schedule deletion outcome after malformed success", async () => {
+        let deletionCommitted = false;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                deletionCommitted = true;
+                return Response.json({ deleted: true });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["scheduled_functions", "delete", "--ref", "abc123", "--schedule_id", SCHEDULE_ID],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(deletionCommitted).toBe(true);
+        expect(response.exitCode).toBe(1);
+        expect(JSON.parse(response.stdout).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("reports an unknown schedule mutation outcome after commit followed by HTTP 503", async () => {
+        let scheduleCommitted = false;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                await request.json();
+                scheduleCommitted = true;
+                return Response.json({ error: "private-post-commit-sentinel" }, { status: 503 });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "scheduled_functions", "create", "--ref", "abc123", "--name", "Nightly",
+                "--slug", "worker", "--cron", "0 2 * * *", "--method", "POST",
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(scheduleCommitted).toBe(true);
+        expect(response.exitCode).toBe(1);
+        expect(JSON.parse(response.stdout).error).toEqual({
+            code: "OUTCOME_UNKNOWN",
+            http_status: 503,
+        });
+        expect(response.stdout + response.stderr).not.toContain("private-post-commit-sentinel");
+    });
+
+    test("rejects an adversarial schedule cron before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "scheduled_functions", "create", "--ref", "abc123", "--name", "Unsafe",
+                "--slug", "worker", "--cron", "0-999999999 * * * *", "--method", "POST",
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("'cron' is invalid");
+    });
+
+    test("rejects invalid environment-backed schedule headers without exposing values", async () => {
+        const headerSentinel = "private-invalid-process-header-sentinel\n";
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "scheduled_functions", "create", "--ref", "abc123", "--name", "Unsafe",
+                "--slug", "worker", "--cron", "* * * * *", "--method", "POST",
+                "--header_env", '{"x-schedule-token":"SCHEDULE_TOKEN"}',
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                SCHEDULE_TOKEN: headerSentinel,
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("SCHEDULE_HEADER_INVALID");
+        expect(response.stdout + response.stderr).not.toContain(headerSentinel.trim());
+    });
+
+    test("rejects platform schedule headers before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "scheduled_functions", "create", "--ref", "abc123", "--name", "Unsafe",
+                "--slug", "worker", "--cron", "* * * * *", "--method", "POST",
+                "--header_env", '{"X-Project-Ref":"SCHEDULE_TOKEN"}',
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                SCHEDULE_TOKEN: "private-platform-header-sentinel",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("SCHEDULE_HEADER_MAPPING_INVALID");
+        expect(response.stdout + response.stderr).not.toContain("private-platform-header-sentinel");
     });
 
     test.each([

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -14,6 +14,7 @@ const CONTEXT_KEYS = new Set([
     "MANAGEMENT_API_URL",
     "SUPACLOUD_API_TOKEN",
     "SUPACLOUD_PROJECT_REF",
+    "SUPACLOUD_READ_ONLY",
     "X_PROJECT_REF",
     "SUPACLOUD_HOST",
 ]);
@@ -361,6 +362,52 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).toContain("'path' is not supported for 'activate'");
         expect(response.stdout + response.stderr).not.toContain("ENOENT");
         expect(response.stdout + response.stderr).not.toContain("Failed to bundle/read path");
+    });
+
+    test("blocks scheduled writes and Function activation in read-only mode before local reads or HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+        const missingBodyFile = "/definitely/not/exist/schedule-body.json";
+        const missingSourceFile = "/definitely/not/exist/function-source.ts";
+        const commands = [
+            [
+                "scheduled_functions", "create", "--ref", "abc123", "--name", "Nightly",
+                "--slug", "worker", "--cron", "0 2 * * *", "--method", "POST",
+                "--body_file", missingBodyFile,
+            ],
+            [
+                "scheduled_functions", "update", "--ref", "abc123", "--schedule_id", SCHEDULE_ID,
+                "--body_file", missingBodyFile,
+            ],
+            ["scheduled_functions", "delete", "--ref", "abc123", "--schedule_id", SCHEDULE_ID],
+            [
+                "edge_functions", "activate", "--ref", "abc123", "--slug", "worker", "--version", "1",
+                "--path", missingSourceFile,
+            ],
+        ];
+
+        for (const command of commands) {
+            const response = await runProjectCli(command, {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                SUPACLOUD_READ_ONLY: "true",
+            });
+
+            expect(response.exitCode).toBe(1);
+            expect(response.stdout + response.stderr).toContain("read-only");
+            expect(response.stdout + response.stderr).not.toContain("ENOENT");
+        }
+
+        expect(requestCount).toBe(0);
     });
 
     test("creates a schedule with body-file and environment-backed headers outside argv and output", async () => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -455,8 +455,11 @@ describe("supacloud-cli process contract", () => {
         const server = Bun.serve({
             hostname: "127.0.0.1",
             port: 0,
-            fetch() {
+            fetch(request) {
                 requestCount += 1;
+                if (request.method === "GET") {
+                    return Response.json({ project_ref: "abc123", schedules: [] });
+                }
                 return Response.json({});
             },
         });
@@ -494,6 +497,16 @@ describe("supacloud-cli process contract", () => {
         }
 
         expect(requestCount).toBe(0);
+        const listResponse = await runProjectCli(["scheduled_functions", "list", "--ref", "abc123"], {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            SUPACLOUD_READ_ONLY: "true",
+        });
+
+        expect(listResponse.exitCode).toBe(0);
+        expect(JSON.parse(listResponse.stdout).schedules).toEqual([]);
+        expect(requestCount).toBe(1);
     });
 
     test("creates a schedule with body-file and environment-backed headers outside argv and output", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -333,8 +333,12 @@ function createCliTools(): ToolMap {
     assign(databaseTools);
     assign(captureTools((server) => registerAuthTools(server as any, http)));
     assign(captureTools((server) => registerStorageTools(server as any, http)));
-    assign(captureTools((server) => registerAdvancedTools(server as any, http)));
-    assign(captureTools((server) => registerScheduledFunctionTools(server as any, http)));
+    assign(captureTools((server) => registerAdvancedTools(server as any, http, {
+        readOnly: context.readOnly,
+    })));
+    assign(captureTools((server) => registerScheduledFunctionTools(server as any, http, process.env, {
+        readOnly: context.readOnly,
+    })));
     assign(captureTools((server) => registerFrontendTools(server as any, http)));
     assign(captureTools((server) => registerGatewayTools(server as any, http, {
         projectRef: context.projectRef || undefined,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import { registerGatewayTools } from "./shared/tools/gateway-tools";
 import { registerBranchTools } from "./shared/tools/branch-tools";
 import { registerSupabaseCliTools } from "./shared/tools/supabase-cli-tools";
 import { registerAiTools } from "./shared/tools/ai-tools";
+import { registerScheduledFunctionTools } from "./shared/tools/scheduled-function-tools";
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
 type ToolMap = Record<string, ToolEntry>;
@@ -201,6 +202,8 @@ EXAMPLES
   ${preferredCommand} ai show_skill
   ${preferredCommand} ai install_skill --dry_run
   ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
+  ${preferredCommand} edge_functions activate --ref abc123 --slug hello --version 3
+  ${preferredCommand} scheduled_functions list --ref abc123
   ${preferredCommand} edge_functions config --ref abc123 --slug hello --verify_jwt false --background_routes "/queue/*,/render/*"
   ${preferredCommand} gateway routes --ref abc123
   ${preferredCommand} gateway upsert_route --ref abc123 --route_id webhook --hosts "api.example.com" --paths "/webhook/*" --upstream 10.0.0.5:8080
@@ -256,7 +259,7 @@ function createCliTools(): ToolMap {
                 ],
             }),
         };
-        for (const name of ["database", "auth", "storage", "edge_functions", "secrets", "frontend", "queue", "task_events", "diagnostics", "gateway", "branch"]) {
+        for (const name of ["database", "auth", "storage", "edge_functions", "secrets", "frontend", "queue", "task_events", "scheduled_functions", "diagnostics", "gateway", "branch"]) {
             tools[name] = {
                 schema: { action: genericActionSchema },
                 callback: async () => ({
@@ -331,6 +334,7 @@ function createCliTools(): ToolMap {
     assign(captureTools((server) => registerAuthTools(server as any, http)));
     assign(captureTools((server) => registerStorageTools(server as any, http)));
     assign(captureTools((server) => registerAdvancedTools(server as any, http)));
+    assign(captureTools((server) => registerScheduledFunctionTools(server as any, http)));
     assign(captureTools((server) => registerFrontendTools(server as any, http)));
     assign(captureTools((server) => registerGatewayTools(server as any, http, {
         projectRef: context.projectRef || undefined,

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -131,6 +131,14 @@ describe("CLI execution policy", () => {
         })).toThrow("SUPACLOUD_READ_ONLY=true");
     });
 
+    test("classifies Function activation and Scheduled Function mutations as writes", () => {
+        expect(executionMode("edge_functions", "activate", {})).toBe("write");
+        expect(executionMode("scheduled_functions", "list", {})).toBe("read");
+        for (const action of ["create", "update", "delete"]) {
+            expect(executionMode("scheduled_functions", action, {})).toBe("write");
+        }
+    });
+
     test("allows migration previews and local authoring without production confirmation", () => {
         expect(executionMode("database", "push_migrations", { dry_run: true })).toBe("read");
         expect(executionMode("supabase", "push", { dry_run: true })).toBe("read");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -34,8 +34,9 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     edge_functions: {
         read: ["list", "source"],
         local: ["check"],
-        write: ["deploy", "deploy_bundle", "config", "delete"],
+        write: ["deploy", "deploy_bundle", "config", "activate", "delete"],
     },
+    scheduled_functions: { read: ["list"], write: ["create", "update", "delete"] },
     secrets: { read: ["list"], write: ["upsert", "delete"] },
     frontend: {
         read: ["list", "get", "build_logs", "list_frameworks", "list_records"],

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -5,7 +5,10 @@ import type { ToolSchema } from "../schema";
 
 function captureEdgeFunctionsTool(http: Record<string, unknown>) {
     let schema: ToolSchema | undefined;
-    let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<{
+        content: Array<{ text: string }>;
+        isError?: boolean;
+    }>) | undefined;
     registerAdvancedTools({
         tool(name: string, _description: string, toolSchema: ToolSchema, toolCallback: typeof callback) {
             if (name !== "edge_functions") return;
@@ -258,6 +261,126 @@ describe("edge_functions CLI tool", () => {
         ]);
         expect(response.content[0].text).toStartWith("❌ Unsafe deployment receipt");
         expect(response.content[0].text).toContain("No follow-up PATCH was attempted");
+    });
+
+    test("activates the immutable legacy Function version zero with a structured receipt", async () => {
+        const calls: string[] = [];
+        const { schema, callback } = captureEdgeFunctionsTool({
+            post: async (path: string) => {
+                calls.push(path);
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        success: true,
+                        version: "0",
+                        config: { version: "0", verify_jwt: false },
+                    },
+                };
+            },
+        });
+
+        const args = parseToolArguments(schema, {
+            action: "activate",
+            ref: "proj",
+            slug: "public-hook",
+            version: 0,
+        });
+        const response = await callback(args);
+
+        expect(calls).toEqual(["/v1/projects/proj/functions/public-hook/versions/0/activate"]);
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "edge_functions.activate",
+            slug: "public-hook",
+            version: "0",
+            verify_jwt: false,
+        });
+    });
+
+    test.each([
+        ["a negative", -1],
+        ["a fractional", 1.5],
+        ["an unsafe integer", "9007199254740992"],
+    ])("rejects %s Function version before dispatch", async (_label, version) => {
+        const { schema } = captureEdgeFunctionsTool({});
+
+        expect(() => parseToolArguments(schema, {
+            action: "activate",
+            ref: "proj",
+            slug: "public-hook",
+            version,
+        })).toThrow("Invalid arguments");
+    });
+
+    test.each([
+        ["HTTP 503 after possible commit", { ok: false, status: 503, data: { error: "private-server-detail" } }, "OUTCOME_UNKNOWN", 503],
+        ["HTTP 408 after possible commit", { ok: false, status: 408, data: { error: "private-server-detail" } }, "OUTCOME_UNKNOWN", 408],
+        ["explicit HTTP rejection", { ok: false, status: 409, data: { error: "private-server-detail" } }, "HTTP_ERROR", 409],
+        ["transport failure", {
+            ok: false,
+            status: 500,
+            data: { error: "private-server-detail" },
+            transportError: true,
+        }, "OUTCOME_UNKNOWN", null],
+        ["malformed success", {
+            ok: true,
+            status: 200,
+            data: { success: true, version: "5" },
+        }, "OUTCOME_UNKNOWN", 200],
+    ])("fails Function activation closed for %s without echoing response data", async (
+        _label,
+        activation,
+        expectedCode,
+        expectedStatus,
+    ) => {
+        const { callback } = captureEdgeFunctionsTool({ post: async () => activation });
+
+        const response = await callback({ action: "activate", ref: "proj", slug: "hook", version: "5" });
+        const payload = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(payload.error).toEqual({ code: expectedCode, http_status: expectedStatus });
+        expect(response.content[0].text).not.toContain("private-server-detail");
+    });
+
+    test("rejects activate-only policy flags before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        await expect(callback({
+            action: "activate",
+            ref: "proj",
+            slug: "hook",
+            version: "5",
+            verify_jwt: false,
+        })).rejects.toThrow("not supported for 'activate'");
+        expect(requestCount).toBe(0);
+    });
+
+    test("rejects activate path before any local bundle or HTTP work", async () => {
+        let requestCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        await expect(callback({
+            action: "activate",
+            ref: "proj",
+            slug: "hook",
+            version: "5",
+            path: "/definitely/not/exist/private-source.ts",
+        })).rejects.toThrow("'path' is not supported for 'activate'");
+        expect(requestCount).toBe(0);
     });
 });
 

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -3,7 +3,7 @@ import { registerAdvancedTools } from "./advanced-tools";
 import { parseToolArguments } from "../schema";
 import type { ToolSchema } from "../schema";
 
-function captureEdgeFunctionsTool(http: Record<string, unknown>) {
+function captureEdgeFunctionsTool(http: Record<string, unknown>, options: { readOnly?: boolean } = {}) {
     let schema: ToolSchema | undefined;
     let callback: ((args: Record<string, unknown>) => Promise<{
         content: Array<{ text: string }>;
@@ -15,7 +15,7 @@ function captureEdgeFunctionsTool(http: Record<string, unknown>) {
             schema = toolSchema;
             callback = toolCallback;
         },
-    }, http as any);
+    }, http as any, options);
 
     if (!schema || !callback) throw new Error("edge_functions tool was not registered");
     return { schema, callback };
@@ -380,6 +380,28 @@ describe("edge_functions CLI tool", () => {
             version: "5",
             path: "/definitely/not/exist/private-source.ts",
         })).rejects.toThrow("'path' is not supported for 'activate'");
+        expect(requestCount).toBe(0);
+    });
+
+    test("blocks activate in read-only mode before validation or HTTP dispatch", async () => {
+        let requestCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        }, { readOnly: true });
+
+        const response = await callback({
+            action: "activate",
+            ref: "../unsafe-ref",
+            slug: "../unsafe-slug",
+            version: "invalid",
+            path: "/definitely/not/exist/private-source.ts",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("read-only");
         expect(requestCount).toBe(0);
     });
 });

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -203,6 +203,13 @@ interface FunctionActivationTarget {
     version: string;
 }
 
+function readOnlyActivationResult(): ReleaseControlToolResponse {
+    return {
+        isError: true,
+        content: [{ type: "text", text: "⚠️ Edge Function activation blocked in read-only mode." }],
+    };
+}
+
 function functionActivationTarget(args: Record<string, unknown>): FunctionActivationTarget {
     const projectRef = typeof args.ref === "string" ? args.ref.trim() : "";
     const functionSlug = typeof args.slug === "string" ? args.slug.trim() : "";
@@ -219,7 +226,9 @@ function functionActivationTarget(args: Record<string, unknown>): FunctionActiva
 async function activateFunctionVersion(
     http: HttpTransport,
     args: Record<string, unknown>,
+    readOnly = false,
 ): Promise<ReleaseControlToolResponse> {
+    if (readOnly) return readOnlyActivationResult();
     const unsupported = Object.keys(args).filter((name) => !FUNCTION_ACTIVATION_ARGUMENTS.has(name));
     if (unsupported.length > 0) throw new Error(`'${unsupported[0]}' is not supported for 'activate'`);
     const { projectRef, functionSlug, version } = functionActivationTarget(args);
@@ -228,7 +237,11 @@ async function activateFunctionVersion(
     return activationResponse(functionSlug, version, await http.post(endpoint));
 }
 
-export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
+export function registerAdvancedTools(
+    server: { tool: (...args: any[]) => void },
+    http: HttpTransport,
+    options: { readOnly?: boolean } = {},
+): void {
 
     // ═══ Edge Functions (8→1) ═══
     server.tool(
@@ -250,7 +263,7 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
             background_routes: withDescription(backgroundRoutesSchema, "[deploy/deploy_bundle/config] Background route paths; pass comma-separated or JSON array in CLI"),
         },
         async (args: any) => {
-            if (args.action === "activate") return activateFunctionVersion(http, args);
+            if (args.action === "activate") return activateFunctionVersion(http, args, options.readOnly);
             const { action, ref, slug, path: pathArg, output, files, entrypoint, minify, verify_jwt, background_routes } = args;
             let code = args.code as string | undefined;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -8,7 +8,13 @@ import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
-import type { HttpTransport } from "../transports/http";
+import type { HttpResult, HttpTransport } from "../transports/http";
+import {
+    releaseControlFailure,
+    releaseControlMutationFailure,
+    releaseControlSuccess,
+    type ReleaseControlToolResponse,
+} from "./release-control-response";
 
 const execFileAsync = promisify(execFile);
 
@@ -91,6 +97,28 @@ const functionFilesSchema = decodedSchema(
     parseFunctionFiles,
 );
 
+function parseFunctionVersion(input: string | number): unknown {
+    const version = String(input);
+    if (!CANONICAL_FUNCTION_VERSION_PATTERN.test(version)
+        || !Number.isSafeInteger(Number(version))) {
+        throw new Error("Function version must be a canonical safe integer");
+    }
+    return version;
+}
+
+const CANONICAL_FUNCTION_VERSION_PATTERN = /^(?:0|[1-9][0-9]*)$/;
+const SAFE_FUNCTION_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const SAFE_FUNCTION_SLUG_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const FUNCTION_ACTIVATION_ARGUMENTS = new Set(["action", "ref", "slug", "version"]);
+const functionVersionSchema = Type.Optional(decodedSchema(
+    Type.Union([
+        Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+        Type.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+    ]),
+    Type.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+    parseFunctionVersion,
+));
+
 const secretListSchema = Type.Array(Type.Object({ name: Type.String(), value: Type.String() }));
 
 function parseSecrets(value: string | Array<{ name: string; value: string }>): unknown {
@@ -143,17 +171,75 @@ function functionSourceCode(payload: unknown): string | null {
     return typeof code === "string" ? code : null;
 }
 
+function objectRecord(candidate: unknown): Record<string, unknown> | null {
+    return candidate && typeof candidate === "object" && !Array.isArray(candidate)
+        ? candidate as Record<string, unknown>
+        : null;
+}
+
+function activationResponse(
+    slug: string,
+    version: string,
+    response: HttpResult<unknown>,
+): ReleaseControlToolResponse {
+    const operation = "edge_functions.activate";
+    if (!response.ok) return releaseControlMutationFailure(operation, response);
+    const receipt = objectRecord(response.data);
+    const config = objectRecord(receipt?.config);
+    if (receipt?.success !== true || receipt.version !== version
+        || config?.version !== version || typeof config.verify_jwt !== "boolean") {
+        return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status);
+    }
+    return releaseControlSuccess(operation, {
+        slug,
+        version,
+        verify_jwt: config.verify_jwt,
+    });
+}
+
+interface FunctionActivationTarget {
+    projectRef: string;
+    functionSlug: string;
+    version: string;
+}
+
+function functionActivationTarget(args: Record<string, unknown>): FunctionActivationTarget {
+    const projectRef = typeof args.ref === "string" ? args.ref.trim() : "";
+    const functionSlug = typeof args.slug === "string" ? args.slug.trim() : "";
+    const version = args.version;
+    if (!SAFE_FUNCTION_REF_PATTERN.test(projectRef)) throw new Error("'ref' is invalid for 'activate'");
+    if (!SAFE_FUNCTION_SLUG_PATTERN.test(functionSlug)) throw new Error("'slug' is invalid for 'activate'");
+    if (typeof version !== "string" || !CANONICAL_FUNCTION_VERSION_PATTERN.test(version)
+        || !Number.isSafeInteger(Number(version))) {
+        throw new Error("'version' is invalid for 'activate'");
+    }
+    return { projectRef, functionSlug, version };
+}
+
+async function activateFunctionVersion(
+    http: HttpTransport,
+    args: Record<string, unknown>,
+): Promise<ReleaseControlToolResponse> {
+    const unsupported = Object.keys(args).filter((name) => !FUNCTION_ACTIVATION_ARGUMENTS.has(name));
+    if (unsupported.length > 0) throw new Error(`'${unsupported[0]}' is not supported for 'activate'`);
+    const { projectRef, functionSlug, version } = functionActivationTarget(args);
+    const endpoint = `/v1/projects/${encodeURIComponent(projectRef)}/functions/${encodeURIComponent(functionSlug)}`
+        + `/versions/${encodeURIComponent(version)}/activate`;
+    return activationResponse(functionSlug, version, await http.post(endpoint));
+}
+
 export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
 
-    // ═══ Edge Functions (5→1) ═══
+    // ═══ Edge Functions (8→1) ═══
     server.tool(
         "edge_functions",
         `Edge Function management (Deno/Bun serverless). Server auto-bundles dependencies.
-Actions: list, deploy, deploy_bundle, config, source, delete, check`,
+Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
         {
-            action: withDescription(stringEnum(["list", "deploy", "deploy_bundle", "config", "source", "delete", "check"]), "Action"),
+            action: withDescription(stringEnum(["list", "deploy", "deploy_bundle", "config", "source", "activate", "delete", "check"]), "Action"),
             ref: withDescription(Type.String(), "Project ref"),
-            slug: optional(Type.String(), "[deploy/deploy_bundle/config/source/delete/check] Function name"),
+            slug: optional(Type.String(), "[deploy/deploy_bundle/config/source/activate/delete/check] Function name"),
+            version: withDescription(functionVersionSchema, "[activate] Existing Function version"),
             code: optional(Type.String(), "[deploy/check] Function source code (TypeScript)"),
             path: optional(Type.String(), "[deploy/check] Local file path to read code from (alternative to code)"),
             output: optional(Type.String(), "[source] Write source to this local file instead of stdout; the file must not already exist"),
@@ -164,6 +250,7 @@ Actions: list, deploy, deploy_bundle, config, source, delete, check`,
             background_routes: withDescription(backgroundRoutesSchema, "[deploy/deploy_bundle/config] Background route paths; pass comma-separated or JSON array in CLI"),
         },
         async (args: any) => {
+            if (args.action === "activate") return activateFunctionVersion(http, args);
             const { action, ref, slug, path: pathArg, output, files, entrypoint, minify, verify_jwt, background_routes } = args;
             let code = args.code as string | undefined;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };

--- a/packages/cli/src/shared/tools/release-control-response.ts
+++ b/packages/cli/src/shared/tools/release-control-response.ts
@@ -1,0 +1,57 @@
+import type { HttpResult } from "../transports/http";
+
+export const RELEASE_CONTROL_RESPONSE_SCHEMA = "supacloud.cli.release-control.v1";
+
+export interface ReleaseControlToolResponse {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+}
+
+export function releaseControlSuccess(
+    operation: string,
+    payload: Record<string, unknown>,
+): ReleaseControlToolResponse {
+    return releaseControlResponse({
+        schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
+        ok: true,
+        operation,
+        ...payload,
+    });
+}
+
+export function releaseControlFailure(
+    operation: string,
+    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "OUTCOME_UNKNOWN",
+    httpStatus: number | null,
+): ReleaseControlToolResponse {
+    return releaseControlErrorResponse({
+        schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
+        ok: false,
+        operation,
+        error: { code, http_status: httpStatus },
+    });
+}
+
+export function releaseControlMutationFailure(
+    operation: string,
+    response: HttpResult<unknown>,
+): ReleaseControlToolResponse {
+    const outcomeUnknown = response.transportError || response.status === 408 || response.status >= 500;
+    return outcomeUnknown
+        ? releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.transportError ? null : response.status)
+        : releaseControlFailure(operation, "HTTP_ERROR", response.status);
+}
+
+function releaseControlResponse(
+    payload: Record<string, unknown>,
+): ReleaseControlToolResponse {
+    return {
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    };
+}
+
+function releaseControlErrorResponse(
+    payload: Record<string, unknown>,
+): ReleaseControlToolResponse {
+    return { ...releaseControlResponse(payload), isError: true };
+}

--- a/packages/cli/src/shared/tools/scheduled-function-tools.test.ts
+++ b/packages/cli/src/shared/tools/scheduled-function-tools.test.ts
@@ -44,6 +44,7 @@ function scheduleReceipt(request: Record<string, unknown>, overrides: Record<str
 function captureScheduledFunctionsTool(
     http: Record<string, unknown>,
     environment: NodeJS.ProcessEnv = {},
+    options: { readOnly?: boolean } = {},
 ) {
     let schema: ToolSchema | undefined;
     let callback: ((args: Record<string, unknown>) => Promise<{
@@ -56,7 +57,7 @@ function captureScheduledFunctionsTool(
             schema = toolSchema;
             callback = toolCallback;
         },
-    }, http as never, environment);
+    }, http as never, environment, options);
     if (!schema || !callback) throw new Error("scheduled_functions tool was not registered");
     return { schema, callback };
 }
@@ -90,6 +91,51 @@ test("Scheduled Function list emits only safe machine-readable metadata", async 
     });
     expect(response.content[0].text).not.toContain(bodySentinel);
     expect(response.content[0].text).not.toContain(headerSentinel);
+});
+
+test("Scheduled Function read-only mode blocks writes before body-file reads or HTTP dispatch", async () => {
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        post: async () => { requestCount += 1; },
+        patch: async () => { requestCount += 1; },
+        delete: async () => { requestCount += 1; },
+    }, {}, { readOnly: true });
+
+    for (const args of [
+        {
+            action: "create",
+            ref: "proj",
+            body_file: "/definitely/not/exist/schedule-body.json",
+        },
+        {
+            action: "update",
+            ref: "proj",
+            schedule_id: SCHEDULE_ID,
+            body_file: "/definitely/not/exist/schedule-body.json",
+        },
+        { action: "delete", ref: "proj", schedule_id: SCHEDULE_ID },
+    ]) {
+        const response = await callback(args);
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("read-only");
+    }
+
+    expect(requestCount).toBe(0);
+});
+
+test("Scheduled Function read-only mode continues to allow list", async () => {
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        get: async () => {
+            requestCount += 1;
+            return { ok: true, status: 200, data: { project_ref: "proj", schedules: [] } };
+        },
+    }, {}, { readOnly: true });
+
+    const response = await callback({ action: "list", ref: "proj" });
+
+    expect(response.isError).not.toBe(true);
+    expect(requestCount).toBe(1);
 });
 
 test("Scheduled Function create reads body and header values outside argv", async () => {

--- a/packages/cli/src/shared/tools/scheduled-function-tools.test.ts
+++ b/packages/cli/src/shared/tools/scheduled-function-tools.test.ts
@@ -1,0 +1,491 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerScheduledFunctionTools } from "./scheduled-function-tools";
+import { parseToolArguments } from "../schema";
+import type { ToolSchema } from "../schema";
+
+const SCHEDULE_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_SCHEDULE_ID = "00000000-0000-4000-8000-000000000002";
+
+function scheduleRecord(overrides: Record<string, unknown> = {}) {
+    return {
+        id: SCHEDULE_ID,
+        name: "Nightly",
+        slug: "worker",
+        cron: "0 2 * * *",
+        method: "POST",
+        enabled: true,
+        body_empty: true,
+        header_names: [],
+        created_at: "2026-08-11T00:00:00.000Z",
+        updated_at: "2026-08-11T00:00:00.000Z",
+        ...overrides,
+    };
+}
+
+function scheduleReceipt(request: Record<string, unknown>, overrides: Record<string, unknown> = {}) {
+    const body = request.body as Record<string, unknown> | undefined;
+    const headers = request.headers as Record<string, string> | undefined;
+    const echoedFields = Object.fromEntries(
+        ["name", "slug", "cron", "method", "enabled"]
+            .filter((field) => request[field] !== undefined)
+            .map((field) => [field, request[field]]),
+    );
+    return scheduleRecord({
+        ...echoedFields,
+        body_empty: Object.keys(body ?? {}).length === 0,
+        header_names: Object.keys(headers ?? {}).sort(),
+        ...overrides,
+    });
+}
+
+function captureScheduledFunctionsTool(
+    http: Record<string, unknown>,
+    environment: NodeJS.ProcessEnv = {},
+) {
+    let schema: ToolSchema | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<{
+        content: Array<{ text: string }>;
+        isError?: boolean;
+    }>) | undefined;
+    registerScheduledFunctionTools({
+        tool(name, _description, toolSchema, toolCallback) {
+            if (name !== "scheduled_functions") return;
+            schema = toolSchema;
+            callback = toolCallback;
+        },
+    }, http as never, environment);
+    if (!schema || !callback) throw new Error("scheduled_functions tool was not registered");
+    return { schema, callback };
+}
+
+test("Scheduled Function list emits only safe machine-readable metadata", async () => {
+    const bodySentinel = "private-body-sentinel";
+    const headerSentinel = "private-header-sentinel";
+    const { callback } = captureScheduledFunctionsTool({
+        get: async () => ({
+            ok: true,
+            status: 200,
+            data: {
+                project_ref: "proj",
+                schedules: [scheduleRecord({
+                    body_empty: false,
+                    header_names: ["x-schedule-token"],
+                    body: { private: bodySentinel },
+                    headers: { "X-Schedule-Token": headerSentinel },
+                })],
+            },
+        }),
+    });
+
+    const response = await callback({ action: "list", ref: "proj" });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(payload.schedules[0]).toMatchObject({
+        id: SCHEDULE_ID,
+        body_empty: false,
+        header_names: ["x-schedule-token"],
+    });
+    expect(response.content[0].text).not.toContain(bodySentinel);
+    expect(response.content[0].text).not.toContain(headerSentinel);
+});
+
+test("Scheduled Function create reads body and header values outside argv", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-schedule-test-"));
+    const bodyPath = join(directory, "body.json");
+    const bodySentinel = "private-body-sentinel";
+    const headerSentinel = "private-header-sentinel";
+    writeFileSync(bodyPath, JSON.stringify({ private: bodySentinel }));
+    const requests: unknown[] = [];
+    const { schema, callback } = captureScheduledFunctionsTool({
+        post: async (_path: string, request: unknown) => {
+            requests.push(request);
+            const mutation = request as Record<string, unknown>;
+            return {
+                ok: true,
+                status: 200,
+                data: {
+                    created: true,
+                    project_ref: "proj",
+                    request_id: mutation.request_id,
+                    schedule: scheduleReceipt(mutation),
+                },
+            };
+        },
+    }, { SCHEDULE_TOKEN: headerSentinel });
+    try {
+        const parsed = parseToolArguments(schema, {
+            action: "create",
+            ref: "proj",
+            name: "Nightly",
+            slug: "worker",
+            cron: "0 2 * * *",
+            method: "POST",
+            body_file: bodyPath,
+            header_env: '{"X-Schedule-Token":"SCHEDULE_TOKEN"}',
+        });
+        const response = await callback(parsed);
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+            name: "Nightly",
+            slug: "worker",
+            cron: "0 2 * * *",
+            method: "POST",
+            body: { private: bodySentinel },
+            headers: { "x-schedule-token": headerSentinel },
+        });
+        expect((requests[0] as Record<string, unknown>).request_id).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+        expect(response.content[0].text).not.toContain(bodySentinel);
+        expect(response.content[0].text).not.toContain(headerSentinel);
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+test.each([
+    ["HTTP failure", { ok: false, status: 503, data: { error: "private-server-detail" } }, "HTTP_ERROR", 503],
+    ["malformed success", { ok: true, status: 200, data: { project_ref: "proj", schedules: {} } }, "INVALID_RESPONSE", null],
+    ["null body", {
+        ok: true,
+        status: 200,
+        data: { project_ref: "proj", schedules: [scheduleRecord({ body_empty: null })] },
+    }, "INVALID_RESPONSE", null],
+])("Scheduled Function list fails closed for %s", async (_label, result, expectedCode, expectedStatus) => {
+    const { callback } = captureScheduledFunctionsTool({ get: async () => result });
+
+    const response = await callback({ action: "list", ref: "proj" });
+    const payload = JSON.parse(response.content[0].text);
+
+    expect(response.isError).toBe(true);
+    expect(payload.error).toEqual({ code: expectedCode, http_status: expectedStatus });
+    expect(response.content[0].text).not.toContain("private-server-detail");
+});
+
+test("Scheduled Function update confirms the exact schedule and requested fields", async () => {
+    const requests: unknown[] = [];
+    const { callback } = captureScheduledFunctionsTool({
+        patch: async (_path: string, request: Record<string, unknown>) => {
+            requests.push(request);
+            return {
+                ok: true,
+                status: 200,
+                data: {
+                    updated: true,
+                    project_ref: "proj",
+                    request_id: request.request_id,
+                    schedule: scheduleReceipt(request, { id: SCHEDULE_ID }),
+                },
+            };
+        },
+    });
+
+    const response = await callback({
+        action: "update",
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        cron: "0 3 * * *",
+        enabled: false,
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ cron: "0 3 * * *", enabled: false });
+    expect((requests[0] as Record<string, unknown>).request_id).toBeString();
+    expect(JSON.parse(response.content[0].text)).toMatchObject({
+        ok: true,
+        schedule: { id: SCHEDULE_ID, cron: "0 3 * * *", enabled: false },
+    });
+});
+
+test("Scheduled Function update rejects a mismatched receipt without exposing response values", async () => {
+    const responseSentinel = "private-mismatched-response-sentinel";
+    const { callback } = captureScheduledFunctionsTool({
+        patch: async (_path: string, request: Record<string, unknown>) => ({
+            ok: true,
+            status: 200,
+            data: {
+                updated: true,
+                project_ref: "proj",
+                request_id: request.request_id,
+                schedule: scheduleRecord({
+                    id: OTHER_SCHEDULE_ID,
+                    cron: "0 3 * * *",
+                    body: { private: responseSentinel },
+                }),
+            },
+        }),
+    });
+
+    const response = await callback({
+        action: "update",
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        cron: "0 3 * * *",
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error).toEqual({
+        code: "OUTCOME_UNKNOWN",
+        http_status: 200,
+    });
+    expect(response.content[0].text).not.toContain(responseSentinel);
+});
+
+test("Scheduled Function list rejects duplicate schedule IDs", async () => {
+    const { callback } = captureScheduledFunctionsTool({
+        get: async () => ({
+            ok: true,
+            status: 200,
+            data: {
+                project_ref: "proj",
+                schedules: [scheduleRecord(), scheduleRecord({ name: "Duplicate" })],
+            },
+        }),
+    });
+
+    const response = await callback({ action: "list", ref: "proj" });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error.code).toBe("INVALID_RESPONSE");
+});
+
+test.each([
+    ["dot project ref", { action: "list", ref: "." }],
+    ["dot-dot project ref", { action: "list", ref: ".." }],
+    ["dot schedule ID", { action: "delete", ref: "proj", schedule_id: "." }],
+    ["dot-dot schedule ID", { action: "delete", ref: "proj", schedule_id: ".." }],
+    ["encoded dot", { action: "delete", ref: "proj", schedule_id: "%2e" }],
+    ["encoded dot-dot", { action: "delete", ref: "proj", schedule_id: "%2e%2e" }],
+    ["mixed encoded dot-dot", { action: "delete", ref: "proj", schedule_id: ".%2e" }],
+    ["double-encoded dot-dot", { action: "delete", ref: "proj", schedule_id: "%252e%252e" }],
+    ["slash", { action: "delete", ref: "proj", schedule_id: "a/b" }],
+    ["query", { action: "delete", ref: "proj", schedule_id: "a?b" }],
+    ["fragment", { action: "delete", ref: "proj", schedule_id: "a#b" }],
+    ["overlong", { action: "delete", ref: "proj", schedule_id: "a".repeat(161) }],
+])("Scheduled Function rejects %s before HTTP dispatch", async (_label, args) => {
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        get: async () => { requestCount += 1; },
+        delete: async () => { requestCount += 1; },
+    });
+
+    await expect(callback(args)).rejects.toThrow("invalid");
+    expect(requestCount).toBe(0);
+});
+
+test.each([
+    "authorization",
+    "APIKEY",
+    "X-Project-Ref",
+    "host",
+    "connection",
+    "content-length",
+    "transfer-encoding",
+    "te",
+    "trailer",
+    "upgrade",
+    "proxy-authorization",
+    "proxy-authenticate",
+    "forwarded",
+    "x-forwarded-host",
+])(
+    "Scheduled Function rejects reserved header %s before HTTP dispatch",
+    async (headerName) => {
+        let requestCount = 0;
+        const { callback } = captureScheduledFunctionsTool({
+            post: async () => { requestCount += 1; },
+        }, { SCHEDULE_TOKEN: "private-header-sentinel" });
+
+        await expect(callback({
+            action: "create",
+            ref: "proj",
+            name: "Unsafe",
+            slug: "worker",
+            cron: "* * * * *",
+            method: "POST",
+            header_env: { [headerName]: "SCHEDULE_TOKEN" },
+        })).rejects.toThrow("SCHEDULE_HEADER_MAPPING_INVALID");
+        expect(requestCount).toBe(0);
+    },
+);
+
+test("Scheduled Function rejects duplicate case-insensitive headers before HTTP dispatch", async () => {
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        post: async () => { requestCount += 1; },
+    }, { FIRST_TOKEN: "first", SECOND_TOKEN: "second" });
+
+    await expect(callback({
+        action: "create",
+        ref: "proj",
+        name: "Unsafe",
+        slug: "worker",
+        cron: "* * * * *",
+        method: "POST",
+        header_env: { "X-Schedule-Token": "FIRST_TOKEN", "x-schedule-token": "SECOND_TOKEN" },
+    })).rejects.toThrow("SCHEDULE_HEADER_INVALID");
+    expect(requestCount).toBe(0);
+});
+
+test("Scheduled Function rejects an invalid header value without exposing it", async () => {
+    const secretSentinel = "private-invalid-header-sentinel\n";
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        post: async () => { requestCount += 1; },
+    }, { SCHEDULE_TOKEN: secretSentinel });
+
+    let errorMessage = "";
+    try {
+        await callback({
+            action: "create",
+            ref: "proj",
+            name: "Unsafe",
+            slug: "worker",
+            cron: "* * * * *",
+            method: "POST",
+            header_env: { "x-schedule-token": "SCHEDULE_TOKEN" },
+        });
+    } catch (error) {
+        errorMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(errorMessage).toBe("SCHEDULE_HEADER_INVALID");
+    expect(errorMessage).not.toContain(secretSentinel.trim());
+    expect(requestCount).toBe(0);
+});
+
+test("Scheduled Function reports an unknown outcome after a transport failure", async () => {
+    const { callback } = captureScheduledFunctionsTool({
+        delete: async () => ({
+            ok: false,
+            status: 500,
+            data: { error: "private-network-detail" },
+            transportError: true,
+        }),
+    });
+
+    const response = await callback({ action: "delete", ref: "proj", schedule_id: SCHEDULE_ID });
+    const receipt = JSON.parse(response.content[0].text);
+
+    expect(response.isError).toBe(true);
+    expect(receipt.error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: null });
+    expect(response.content[0].text).not.toContain("private-network-detail");
+});
+
+test.each([408, 500, 503])(
+    "Scheduled Function reports an unknown mutation outcome after HTTP %s",
+    async (status) => {
+        const { callback } = captureScheduledFunctionsTool({
+            delete: async () => ({
+                ok: false,
+                status,
+                data: { error: "private-server-detail" },
+            }),
+        });
+
+        const response = await callback({ action: "delete", ref: "proj", schedule_id: SCHEDULE_ID });
+        const receipt = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(receipt.error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: status });
+        expect(response.content[0].text).not.toContain("private-server-detail");
+    },
+);
+
+test("Scheduled Function rejects a mismatched request receipt", async () => {
+    const { callback } = captureScheduledFunctionsTool({
+        patch: async (_path: string, request: Record<string, unknown>) => ({
+            ok: true,
+            status: 200,
+            data: {
+                updated: true,
+                project_ref: "proj",
+                request_id: "00000000-0000-4000-8000-000000000099",
+                schedule: scheduleReceipt(request, { id: SCHEDULE_ID }),
+            },
+        }),
+    });
+
+    const response = await callback({
+        action: "update",
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        enabled: false,
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error).toEqual({
+        code: "OUTCOME_UNKNOWN",
+        http_status: 200,
+    });
+});
+
+test.each([
+    "0-999999999 * * * *",
+    "*/999999999 * * * *",
+    "60 * * * *",
+    "59-0 * * * *",
+    "*/0 * * * *",
+])("Scheduled Function rejects unsafe cron %s before HTTP dispatch", async (cron) => {
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        post: async () => { requestCount += 1; },
+    });
+
+    await expect(callback({
+        action: "create",
+        ref: "proj",
+        name: "Unsafe",
+        slug: "worker",
+        cron,
+        method: "POST",
+    })).rejects.toThrow("'cron' is invalid");
+    expect(requestCount).toBe(0);
+});
+
+test("Scheduled Function delete validates the exact receipt", async () => {
+    const paths: string[] = [];
+    const { callback } = captureScheduledFunctionsTool({
+        delete: async (path: string) => {
+            paths.push(path);
+            return {
+                ok: true,
+                status: 200,
+                data: { deleted: true, project_ref: "proj", schedule_id: SCHEDULE_ID },
+            };
+        },
+    });
+
+    const response = await callback({ action: "delete", ref: "proj", schedule_id: SCHEDULE_ID });
+
+    expect(paths).toEqual([`/v1/projects/proj/scheduled-functions/${SCHEDULE_ID}`]);
+    expect(JSON.parse(response.content[0].text)).toMatchObject({ ok: true, deleted: true });
+});
+
+test("Scheduled Function rejects a body file over 1 MiB before HTTP dispatch", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-schedule-large-test-"));
+    const bodyPath = join(directory, "body.json");
+    writeFileSync(bodyPath, JSON.stringify({ payload: "x".repeat(1_048_576) }));
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        post: async () => { requestCount += 1; },
+    });
+    try {
+        await expect(callback({
+            action: "create",
+            ref: "proj",
+            name: "Oversized",
+            slug: "worker",
+            cron: "* * * * *",
+            method: "POST",
+            body_file: bodyPath,
+        })).rejects.toThrow("no larger than 1 MiB");
+        expect(requestCount).toBe(0);
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});

--- a/packages/cli/src/shared/tools/scheduled-function-tools.ts
+++ b/packages/cli/src/shared/tools/scheduled-function-tools.ts
@@ -24,6 +24,10 @@ type ToolServer = {
 
 type ScheduledFunctionAction = "list" | "create" | "update" | "delete";
 
+interface ScheduledFunctionToolsOptions {
+    readOnly?: boolean;
+}
+
 interface SafeScheduledFunction {
     id: string;
     name: string;
@@ -353,6 +357,13 @@ function deleteResponse(
     });
 }
 
+function readOnlyResult(): ReleaseControlToolResponse {
+    return {
+        isError: true,
+        content: [{ type: "text", text: "⚠️ Scheduled Function write blocked in read-only mode." }],
+    };
+}
+
 function createRequest(
     args: Record<string, unknown>,
     environment: NodeJS.ProcessEnv,
@@ -423,8 +434,10 @@ async function executeScheduleAction(
     http: HttpTransport,
     environment: NodeJS.ProcessEnv,
     args: Record<string, unknown>,
+    readOnly = false,
 ): Promise<ReleaseControlToolResponse> {
     const action = args.action as ScheduledFunctionAction;
+    if (readOnly && action !== "list") return readOnlyResult();
     assertActionArguments(action, args);
     const ref = requiredText(args, "ref", action);
     if (action === "list") return listResponse(ref, await http.get(schedulePath(ref)));
@@ -455,9 +468,10 @@ export function registerScheduledFunctionTools(
     server: ToolServer,
     http: HttpTransport,
     environment: NodeJS.ProcessEnv = process.env,
+    options: ScheduledFunctionToolsOptions = {},
 ): void {
     server.tool("scheduled_functions", SCHEDULE_TOOL_DESCRIPTION, SCHEDULE_TOOL_SCHEMA,
-        (args) => executeScheduleAction(http, environment, args));
+        (args) => executeScheduleAction(http, environment, args, options.readOnly));
 }
 
 const SCHEDULE_TOOL_DESCRIPTION = "Scheduled Edge Function lifecycle. Actions: list, create, update, delete";

--- a/packages/cli/src/shared/tools/scheduled-function-tools.ts
+++ b/packages/cli/src/shared/tools/scheduled-function-tools.ts
@@ -1,0 +1,478 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { Type } from "@sinclair/typebox";
+import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+import type { HttpResult, HttpTransport } from "../transports/http";
+import {
+    releaseControlFailure,
+    releaseControlMutationFailure,
+    releaseControlSuccess,
+    type ReleaseControlToolResponse,
+} from "./release-control-response";
+
+type ToolServer = {
+    tool: (
+        name: string,
+        description: string,
+        schema: ToolSchema,
+        callback: (args: Record<string, unknown>) => Promise<ReleaseControlToolResponse>,
+    ) => void;
+};
+
+type ScheduledFunctionAction = "list" | "create" | "update" | "delete";
+
+interface SafeScheduledFunction {
+    id: string;
+    name: string;
+    slug: string;
+    cron: string;
+    method: "GET" | "POST";
+    enabled: boolean;
+    body_empty: boolean;
+    header_names: string[];
+    created_at: string;
+    updated_at: string;
+}
+
+type ScheduleMutationExpectation = {
+    action: "create";
+    ref: string;
+    requestId: string;
+    expectedFields: Record<string, unknown>;
+} | {
+    action: "update";
+    ref: string;
+    scheduleId: string;
+    requestId: string;
+    expectedFields: Record<string, unknown>;
+};
+
+const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]{1,128}$/;
+const ENVIRONMENT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,255}$/;
+const FORBIDDEN_HEADER_NAMES = new Set([
+    "apikey",
+    "authorization",
+    "connection",
+    "content-length",
+    "forwarded",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "proxy-connection",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "via",
+    "x-project-ref",
+]);
+const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const SCHEDULE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SAFE_SLUG_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const CRON_PART_PATTERN = /^(\*|([0-9]+)(?:-([0-9]+))?)(?:\/([0-9]+))?$/;
+const CRON_FIELD_BOUNDS = [[0, 59], [0, 23], [1, 31], [1, 12], [0, 7]] as const;
+const MAX_CRON_EXPRESSION_LENGTH = 256;
+const MAX_BODY_FILE_BYTES = 1_048_576;
+const MAX_HEADER_COUNT = 64;
+const MAX_HEADER_VALUE_LENGTH = 8_192;
+const MAX_SCHEDULE_NAME_LENGTH = 120;
+const headerEnvironmentRecord = Type.Record(Type.String(), Type.String());
+const ACTION_ARGUMENTS: Record<ScheduledFunctionAction, ReadonlySet<string>> = {
+    list: new Set(["action", "ref"]),
+    create: new Set(["action", "ref", "name", "slug", "cron", "method", "body_file", "header_env"]),
+    update: new Set(["action", "ref", "schedule_id", "name", "cron", "method", "enabled", "body_file", "header_env"]),
+    delete: new Set(["action", "ref", "schedule_id"]),
+};
+
+function parseHeaderEnvironment(input: string | Record<string, string>): unknown {
+    if (typeof input !== "string") return input;
+    try {
+        return JSON.parse(input);
+    } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+        throw new Error("Invalid header_env JSON object");
+    }
+}
+
+const headerEnvironmentSchema = Type.Optional(decodedSchema(
+    Type.Union([Type.String(), headerEnvironmentRecord]),
+    headerEnvironmentRecord,
+    parseHeaderEnvironment,
+));
+
+function objectRecord(candidate: unknown): Record<string, unknown> | null {
+    return candidate && typeof candidate === "object" && !Array.isArray(candidate)
+        ? candidate as Record<string, unknown>
+        : null;
+}
+
+function boundedCronInteger(input: string, minimum: number, maximum: number): boolean {
+    const parsed = Number(input);
+    return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum;
+}
+
+function validCronPart(part: string, minimum: number, maximum: number): boolean {
+    const match = CRON_PART_PATTERN.exec(part);
+    if (!match) return false;
+    const start = match[1] === "*" ? minimum : Number(match[2]);
+    const end = match[1] === "*" ? maximum : Number(match[3] ?? match[2]);
+    const step = Number(match[4] ?? "1");
+    return boundedCronInteger(String(start), minimum, maximum)
+        && boundedCronInteger(String(end), minimum, maximum) && start <= end
+        && boundedCronInteger(String(step), 1, maximum - minimum + 1);
+}
+
+function validCronField(field: string, minimum: number, maximum: number): boolean {
+    const parts = field.split(",");
+    return parts.length <= maximum - minimum + 1
+        && parts.every((part) => part.length > 0 && validCronPart(part, minimum, maximum));
+}
+
+function validScheduledFunctionCron(expression: string): boolean {
+    if (!expression || expression.length > MAX_CRON_EXPRESSION_LENGTH) return false;
+    const fields = expression.trim().split(/\s+/);
+    return fields.length === CRON_FIELD_BOUNDS.length
+        && fields.every((field, index) => {
+            const [minimum, maximum] = CRON_FIELD_BOUNDS[index];
+            return validCronField(field, minimum, maximum);
+        });
+}
+
+function readScheduleBodyFile(bodyPathInput: string): Record<string, unknown> {
+    if (!bodyPathInput.trim()) throw new Error("'body_file' must be a path");
+    const bodyPath = resolve(bodyPathInput);
+    const bodyStat = statSync(bodyPath);
+    if (!bodyStat.isFile() || bodyStat.size > MAX_BODY_FILE_BYTES) {
+        throw new Error("Scheduled Function body file must be a regular file no larger than 1 MiB");
+    }
+    let payload: unknown;
+    try {
+        payload = JSON.parse(readFileSync(bodyPath, "utf8"));
+    } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+        throw new Error("Scheduled Function body file must contain exact JSON");
+    }
+    const body = objectRecord(payload);
+    if (!body) throw new Error("Scheduled Function body file must contain a JSON object");
+    return body;
+}
+
+function scheduleBody(bodyFile: unknown): Record<string, unknown> | undefined {
+    if (bodyFile === undefined) return undefined;
+    if (typeof bodyFile !== "string") throw new Error("'body_file' must be a path");
+    return readScheduleBodyFile(bodyFile);
+}
+
+function resolvedHeaderEntry(
+    headerName: string,
+    environmentName: unknown,
+    environment: NodeJS.ProcessEnv,
+): [string, string] {
+    const normalizedName = headerName.toLowerCase();
+    if (!HEADER_NAME_PATTERN.test(headerName) || forbiddenHeaderName(normalizedName)
+        || typeof environmentName !== "string" || !ENVIRONMENT_NAME_PATTERN.test(environmentName)) {
+        throw new Error("SCHEDULE_HEADER_MAPPING_INVALID");
+    }
+    const headerValue = environment[environmentName];
+    if (!headerValue) throw new Error("SCHEDULE_HEADER_ENV_MISSING");
+    if (!headerValueIsStable(normalizedName, headerValue)) throw new Error("SCHEDULE_HEADER_INVALID");
+    return [normalizedName, headerValue];
+}
+
+function forbiddenHeaderName(name: string): boolean {
+    return FORBIDDEN_HEADER_NAMES.has(name) || name.startsWith("x-forwarded-");
+}
+
+function headerValueIsStable(name: string, value: string): boolean {
+    if (!value || value.length > MAX_HEADER_VALUE_LENGTH) return false;
+    try {
+        const headers = new Headers();
+        headers.set(name, value);
+        return headers.get(name) === value;
+    } catch {
+        return false;
+    }
+}
+
+function scheduleHeaders(
+    mapping: unknown,
+    environment: NodeJS.ProcessEnv,
+): Record<string, string> | undefined {
+    if (mapping === undefined) return undefined;
+    const headerEnvironment = objectRecord(mapping);
+    if (!headerEnvironment) throw new Error("'header_env' must be a JSON object");
+    const entries = Object.entries(headerEnvironment).map(
+        ([headerName, environmentName]) => resolvedHeaderEntry(headerName, environmentName, environment),
+    );
+    const names = entries.map(([name]) => name);
+    if (entries.length > MAX_HEADER_COUNT || new Set(names).size !== names.length) {
+        throw new Error("SCHEDULE_HEADER_INVALID");
+    }
+    return Object.fromEntries(entries);
+}
+
+function validSafeSchedule(schedule: Record<string, unknown>): boolean {
+    return validScheduleIdentity(schedule)
+        && validScheduleDefinition(schedule)
+        && validScheduleMetadata(schedule);
+}
+
+function validScheduleIdentity(schedule: Record<string, unknown>): boolean {
+    return typeof schedule.id === "string" && SCHEDULE_ID_PATTERN.test(schedule.id)
+        && typeof schedule.name === "string" && schedule.name.trim().length > 0
+        && schedule.name.length <= MAX_SCHEDULE_NAME_LENGTH
+        && typeof schedule.slug === "string" && SAFE_SLUG_PATTERN.test(schedule.slug);
+}
+
+function validScheduleDefinition(schedule: Record<string, unknown>): boolean {
+    return typeof schedule.cron === "string" && validScheduledFunctionCron(schedule.cron)
+        && (schedule.method === "GET" || schedule.method === "POST")
+        && typeof schedule.enabled === "boolean";
+}
+
+function validScheduleMetadata(schedule: Record<string, unknown>): boolean {
+    return typeof schedule.created_at === "string" && typeof schedule.updated_at === "string";
+}
+
+function safeSchedulePayload(
+    schedule: Record<string, unknown>,
+): Pick<SafeScheduledFunction, "body_empty" | "header_names"> | null {
+    const headerNames = safeHeaderNames(schedule.header_names);
+    if (typeof schedule.body_empty !== "boolean" || !headerNames) return null;
+    return { body_empty: schedule.body_empty, header_names: headerNames };
+}
+
+function safeHeaderNames(candidate: unknown): string[] | null {
+    if (!Array.isArray(candidate) || candidate.length > MAX_HEADER_COUNT) return null;
+    const names = candidate.map((name) => typeof name === "string" ? name.toLowerCase() : "");
+    const valid = candidate.every((name, index) => typeof name === "string"
+        && HEADER_NAME_PATTERN.test(name) && !forbiddenHeaderName(names[index]));
+    return valid && new Set(names).size === names.length ? names.sort() : null;
+}
+
+function safeSchedule(candidate: unknown): SafeScheduledFunction | null {
+    const schedule = objectRecord(candidate);
+    if (!schedule || !validSafeSchedule(schedule)) return null;
+    const safePayload = safeSchedulePayload(schedule);
+    if (!safePayload) return null;
+    return {
+        id: schedule.id as string,
+        name: schedule.name as string,
+        slug: schedule.slug as string,
+        cron: schedule.cron as string,
+        method: schedule.method as "GET" | "POST",
+        enabled: schedule.enabled as boolean,
+        ...safePayload,
+        created_at: schedule.created_at as string,
+        updated_at: schedule.updated_at as string,
+    };
+}
+
+function requiredText(args: Record<string, unknown>, name: string, action: string): string {
+    const candidate = args[name];
+    if (typeof candidate !== "string" || !candidate.trim()) {
+        throw new Error(`'${name}' is required for '${action}'`);
+    }
+    return candidate.trim();
+}
+
+function assertActionArguments(action: ScheduledFunctionAction, args: Record<string, unknown>): void {
+    const unsupported = Object.keys(args).filter((name) => !ACTION_ARGUMENTS[action].has(name));
+    if (unsupported.length > 0) {
+        throw new Error(`'${unsupported[0]}' is not supported for '${action}'`);
+    }
+}
+
+function schedulePath(ref: string, scheduleId?: string): string {
+    if (!PROJECT_REF_PATTERN.test(ref)) throw new Error("'ref' is invalid for Scheduled Functions");
+    if (scheduleId !== undefined && !SCHEDULE_ID_PATTERN.test(scheduleId)) {
+        throw new Error("'schedule_id' is invalid");
+    }
+    const root = `/v1/projects/${encodeURIComponent(ref)}/scheduled-functions`;
+    return scheduleId ? `${root}/${encodeURIComponent(scheduleId)}` : root;
+}
+
+function scheduleFailure(operation: string, response: HttpResult<unknown>): ReleaseControlToolResponse {
+    return releaseControlFailure(operation, "HTTP_ERROR", response.transportError ? null : response.status);
+}
+
+function listResponse(ref: string, response: HttpResult<unknown>): ReleaseControlToolResponse {
+    const operation = "scheduled_functions.list";
+    if (!response.ok) return scheduleFailure(operation, response);
+    const payload = objectRecord(response.data);
+    const rawSchedules = payload?.schedules;
+    const schedules = Array.isArray(rawSchedules) ? rawSchedules.map(safeSchedule) : null;
+    if (payload?.project_ref !== ref || !schedules || schedules.some((schedule) => !schedule)) {
+        return releaseControlFailure(operation, "INVALID_RESPONSE", null);
+    }
+    const ids = schedules.map((schedule) => schedule!.id);
+    if (new Set(ids).size !== ids.length) return releaseControlFailure(operation, "INVALID_RESPONSE", null);
+    return releaseControlSuccess(operation, { project_ref: ref, schedules });
+}
+
+function mutationResponse(
+    expectation: ScheduleMutationExpectation,
+    response: HttpResult<unknown>,
+): ReleaseControlToolResponse {
+    const { action, ref, requestId, expectedFields } = expectation;
+    const scheduleId = action === "update" ? expectation.scheduleId : undefined;
+    const operation = `scheduled_functions.${action}`;
+    if (!response.ok) return releaseControlMutationFailure(operation, response);
+    const payload = objectRecord(response.data);
+    const schedule = safeSchedule(payload?.schedule);
+    const confirmsRequest = schedule && Object.entries(expectedFields).every(
+        ([field, expected]) => isDeepStrictEqual(schedule[field as keyof SafeScheduledFunction], expected),
+    );
+    if (payload?.project_ref !== ref || payload.request_id !== requestId
+        || payload?.[action === "create" ? "created" : "updated"] !== true
+        || !schedule || !confirmsRequest || (scheduleId !== undefined && schedule.id !== scheduleId)) {
+        return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status);
+    }
+    return releaseControlSuccess(operation, { project_ref: ref, request_id: requestId, schedule });
+}
+
+function deleteResponse(
+    ref: string,
+    scheduleId: string,
+    response: HttpResult<unknown>,
+): ReleaseControlToolResponse {
+    const operation = "scheduled_functions.delete";
+    if (!response.ok) return releaseControlMutationFailure(operation, response);
+    const payload = objectRecord(response.data);
+    if (payload?.deleted !== true || payload.project_ref !== ref || payload.schedule_id !== scheduleId) {
+        return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status);
+    }
+    return releaseControlSuccess(operation, {
+        project_ref: ref,
+        schedule_id: scheduleId,
+        deleted: true,
+    });
+}
+
+function createRequest(
+    args: Record<string, unknown>,
+    environment: NodeJS.ProcessEnv,
+): Record<string, unknown> {
+    return {
+        request_id: randomUUID(),
+        name: requiredName(args, "create"),
+        slug: requiredSlug(args, "create"),
+        cron: requiredCron(args, "create"),
+        method: requiredText(args, "method", "create"),
+        body: scheduleBody(args.body_file) ?? {},
+        headers: scheduleHeaders(args.header_env, environment) ?? {},
+    };
+}
+
+function safeMutationFields(request: Record<string, unknown>): Record<string, unknown> {
+    const safeFields = Object.fromEntries(
+        ["name", "slug", "cron", "method", "enabled"]
+            .filter((field) => request[field] !== undefined)
+            .map((field) => [field, request[field]]),
+    );
+    if (request.body !== undefined) {
+        safeFields.body_empty = Object.keys(request.body as Record<string, unknown>).length === 0;
+    }
+    if (request.headers !== undefined) {
+        safeFields.header_names = Object.keys(request.headers as Record<string, string>).sort();
+    }
+    return safeFields;
+}
+
+function requiredName(args: Record<string, unknown>, action: string): string {
+    const name = requiredText(args, "name", action);
+    if (name.length > MAX_SCHEDULE_NAME_LENGTH) throw new Error(`'name' is too long for '${action}'`);
+    return name;
+}
+
+function requiredSlug(args: Record<string, unknown>, action: string): string {
+    const slug = requiredText(args, "slug", action);
+    if (!SAFE_SLUG_PATTERN.test(slug)) throw new Error(`'slug' is invalid for '${action}'`);
+    return slug;
+}
+
+function requiredCron(args: Record<string, unknown>, action: string): string {
+    const cron = requiredText(args, "cron", action);
+    if (!validScheduledFunctionCron(cron)) throw new Error(`'cron' is invalid for '${action}'`);
+    return cron;
+}
+
+function updateRequest(
+    args: Record<string, unknown>,
+    environment: NodeJS.ProcessEnv,
+): Record<string, unknown> {
+    const body = scheduleBody(args.body_file);
+    const headers = scheduleHeaders(args.header_env, environment);
+    const cron = args.cron === undefined ? undefined : requiredCron(args, "update");
+    const name = args.name === undefined ? undefined : requiredName(args, "update");
+    const mutationFields = Object.fromEntries([
+        ["name", name], ["cron", cron], ["method", args.method],
+        ["enabled", args.enabled], ["body", body], ["headers", headers],
+    ].filter((entry) => entry[1] !== undefined));
+    if (Object.keys(mutationFields).length === 0) {
+        throw new Error("Scheduled Function update requires at least one field");
+    }
+    return { request_id: randomUUID(), ...mutationFields };
+}
+
+async function executeScheduleAction(
+    http: HttpTransport,
+    environment: NodeJS.ProcessEnv,
+    args: Record<string, unknown>,
+): Promise<ReleaseControlToolResponse> {
+    const action = args.action as ScheduledFunctionAction;
+    assertActionArguments(action, args);
+    const ref = requiredText(args, "ref", action);
+    if (action === "list") return listResponse(ref, await http.get(schedulePath(ref)));
+    if (action === "create") {
+        const request = createRequest(args, environment);
+        const requestId = request.request_id as string;
+        return mutationResponse({ action, ref, requestId, expectedFields: safeMutationFields(request) },
+            await http.post(schedulePath(ref), request));
+    }
+    const scheduleId = requiredText(args, "schedule_id", action);
+    if (action === "update") {
+        const request = updateRequest(args, environment);
+        const requestId = request.request_id as string;
+        return mutationResponse({
+            action,
+            ref,
+            scheduleId,
+            requestId,
+            expectedFields: safeMutationFields(request),
+        }, await http.patch(
+            schedulePath(ref, scheduleId), request,
+        ));
+    }
+    return deleteResponse(ref, scheduleId, await http.delete(schedulePath(ref, scheduleId)));
+}
+
+export function registerScheduledFunctionTools(
+    server: ToolServer,
+    http: HttpTransport,
+    environment: NodeJS.ProcessEnv = process.env,
+): void {
+    server.tool("scheduled_functions", SCHEDULE_TOOL_DESCRIPTION, SCHEDULE_TOOL_SCHEMA,
+        (args) => executeScheduleAction(http, environment, args));
+}
+
+const SCHEDULE_TOOL_DESCRIPTION = "Scheduled Edge Function lifecycle. Actions: list, create, update, delete";
+const SCHEDULE_TOOL_SCHEMA: ToolSchema = {
+    action: withDescription(stringEnum(["list", "create", "update", "delete"]), "Action"),
+    ref: withDescription(Type.String(), "Project ref"),
+    schedule_id: optional(Type.String(), "[update/delete] Schedule ID"),
+    name: optional(Type.String(), "[create/update] Display name"),
+    slug: optional(Type.String(), "[create] Edge Function slug"),
+    cron: optional(Type.String(), "[create/update] Five-field cron expression"),
+    method: optional(stringEnum(["GET", "POST"]), "[create/update] HTTP method"),
+    enabled: optional(Type.Boolean(), "[update] Enabled state"),
+    body_file: optional(Type.String(), "[create/update] Local JSON object file; content is never printed"),
+    header_env: withDescription(
+        headerEnvironmentSchema,
+        "[create/update] JSON map of HTTP header names to environment variable names",
+    ),
+};

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -106,7 +106,28 @@ describe("HttpTransport retry policy", () => {
         const response = await request(createTransport());
 
         expect(response.status).toBe(500);
+        expect(response.transportError).toBe(true);
         expect(fetchCalls).toBe(1);
         expect(clearedTimerIds).toHaveLength(1);
+    });
+
+    const transportFailureRequests = [
+        ["GET", (transport: HttpTransport) => transport.get("/resource")],
+        ...unsafeRequests,
+    ] as const;
+
+    test.each(transportFailureRequests)("redacts %s transport error messages", async (_method, request) => {
+        const errorSentinel = "private-transport-sentinel";
+        globalThis.fetch = (async () => {
+            throw new Error(errorSentinel);
+        }) as unknown as typeof fetch;
+
+        const response = await request(createTransport());
+        const serialized = JSON.stringify(response);
+
+        expect(response.transportError).toBe(true);
+        expect(response.data).toEqual({ error: "Network Error", code: "NETWORK_ERROR" });
+        expect(serialized).not.toContain(errorSentinel);
+        expect(serialized).not.toContain("details");
     });
 });

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -14,6 +14,7 @@ export interface HttpResult<T = unknown> {
     ok: boolean;
     status: number;
     data: T;
+    transportError?: boolean;
 }
 
 const DEFAULT_TIMEOUT = 30_000;
@@ -31,6 +32,19 @@ function isRetryableError(error: unknown): boolean {
     return networkError.name === "AbortError"
         || networkError.code === "ECONNREFUSED"
         || networkError.code === "ECONNRESET";
+}
+
+function transportFailure<T>(error: unknown): HttpResult<T> {
+    const networkError = error instanceof Error ? error as Error & { code?: string } : null;
+    const code = networkError?.name === "AbortError"
+        ? "TIMEOUT"
+        : networkError?.code === "ECONNRESET" ? "CONNECTION_RESET" : "NETWORK_ERROR";
+    return {
+        ok: false,
+        status: 500,
+        data: { error: "Network Error", code } as T,
+        transportError: true,
+    };
 }
 
 async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
@@ -97,8 +111,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -111,8 +125,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -126,8 +140,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -140,8 +154,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -154,8 +168,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -167,8 +181,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -66,6 +66,7 @@ import {
   readLiveDatabaseSettings,
   updateDatabaseSettings,
 } from "../services/project-database-config.service";
+import { publicScheduledFunctionProjectConfig } from "../utils/scheduled-function-config";
 
 /** Map PostgreSQL column types to TypeScript types */
 function pgTypeToTs(udtName: string, dataType: string): string {
@@ -626,7 +627,7 @@ function buildSharedSettingsResponse(
   settings: Record<string, unknown>,
   authorityProjectRef: unknown,
 ) {
-  const { auth: _auth, ...safeSettings } = settings;
+  const { auth: _auth, ...safeSettings } = publicScheduledFunctionProjectConfig(settings);
   return {
     ...safeSettings,
     auth_runtime: {
@@ -641,10 +642,11 @@ async function buildProjectSettingsResponse(
   ref: string,
   settings: Record<string, unknown>,
 ) {
-  const auth = settings.auth;
-  if (!auth || typeof auth !== "object" || Array.isArray(auth)) return settings;
+  const publicSettings = publicScheduledFunctionProjectConfig(settings);
+  const auth = publicSettings.auth;
+  if (!auth || typeof auth !== "object" || Array.isArray(auth)) return publicSettings;
   return {
-    ...settings,
+    ...publicSettings,
     auth: await safeProjectSettingsAuthConfig(ref, auth as Record<string, unknown>),
   };
 }
@@ -688,6 +690,12 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
   .put(
     "/:ref/settings",
     async ({ params, body }) => {
+      if (Object.prototype.hasOwnProperty.call(body, "scheduled_functions")) {
+        return status(400, {
+          code: "SCHEDULED_FUNCTION_API_REQUIRED",
+          message: "Scheduled functions must be managed through the dedicated scheduled-functions API",
+        });
+      }
       const managedError = getAuthRuntimeManagedError(params.ref, "configuration");
       if (managedError && Object.prototype.hasOwnProperty.call(body, "auth")) {
         return status(409, managedError);

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -7,6 +7,7 @@ import { logger } from "../utils/logger";
 import { projectService } from "../services";
 import { getProjectDb, resolveDbName, resolveRoleName } from "../db";
 import { normalizeProjectConfig } from "../utils/project-config";
+import { publicScheduledFunctionProjectConfig } from "../utils/scheduled-function-config";
 import { getAuthContext, requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
 import { tenantRuntimeService } from "../services/tenant-runtime.service";
 import {
@@ -128,7 +129,7 @@ export function toPublicV1ProjectWithDatabaseResponse(p: any) {
     },
     api: p.api,
     studio: p.studio,
-    config: p.config,
+    config: publicScheduledFunctionProjectConfig(p.config),
     anon_key: p.anon_key,
     services: p.services,
   };
@@ -289,7 +290,7 @@ async function buildProjectResponse(
     anon_key: project.anon_key,
     api: project.api,
     studio: project.studio,
-    config: normalizeProjectConfig(project.config),
+    config: publicScheduledFunctionProjectConfig(project.config),
   };
 }
 

--- a/packages/management-api/src/routes/scheduled-functions.ts
+++ b/packages/management-api/src/routes/scheduled-functions.ts
@@ -15,85 +15,128 @@ import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-con
 import { config } from "../config";
 import { logger } from "../utils/logger";
 import { scheduledFunctionWorker } from "../workers/scheduled-function.worker";
+import { isValidScheduledFunctionCron } from "../utils/scheduled-function-cron";
+import {
+  normalizedScheduledFunctionHeaders,
+  SCHEDULE_HEADERS_INVALID,
+} from "../utils/scheduled-function-headers";
+import {
+  isScheduledFunctionConfig,
+  MAX_SCHEDULE_NAME_LENGTH,
+  normalizedScheduledFunctionName,
+  normalizedScheduledFunctionSlug,
+  publicScheduledFunction,
+  scheduledFunctionBodyWithinLimit,
+  type ScheduledFunctionConfig,
+  type ScheduledFunctionMethod,
+} from "../utils/scheduled-function-config";
 
-export type ScheduledFunctionMethod = "GET" | "POST";
+export type { ScheduledFunctionConfig, ScheduledFunctionMethod } from "../utils/scheduled-function-config";
 
-export interface ScheduledFunctionConfig {
-  id: string;
+const ALLOWED_METHODS: ReadonlySet<ScheduledFunctionMethod> = new Set(["GET", "POST"]);
+const MAX_SCHEDULES_PER_PROJECT = 20;
+const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const SCHEDULE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SCHEDULE_BODY_INVALID = "SCHEDULE_BODY_INVALID";
+const SCHEDULE_PATCH_FIELDS = ["name", "cron", "method", "body", "headers", "enabled"] as const;
+
+interface ScheduleCreateInput {
+  request_id: string;
   name: string;
   slug: string;
   cron: string;
   method: ScheduledFunctionMethod;
   body?: Record<string, unknown>;
   headers?: Record<string, string>;
-  enabled: boolean;
-  created_at: string;
-  updated_at: string;
 }
 
-const ALLOWED_METHODS: ReadonlySet<ScheduledFunctionMethod> = new Set(["GET", "POST"]);
-const MAX_SCHEDULES_PER_PROJECT = 20;
-
-// Basic 5-field cron validation (does not validate semantic correctness like Feb 30).
-const CRON_RE = /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/;
-
-function isScheduledFunctionConfig(value: unknown): value is ScheduledFunctionConfig {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const item = value as Record<string, unknown>;
-  return (
-    typeof item.id === "string" &&
-    typeof item.name === "string" &&
-    typeof item.slug === "string" &&
-    typeof item.cron === "string" &&
-    typeof item.method === "string" &&
-    ALLOWED_METHODS.has(item.method as ScheduledFunctionMethod) &&
-    typeof item.enabled === "boolean"
-  );
-}
+type SchedulePatchInput = Partial<Pick<
+  ScheduledFunctionConfig,
+  "name" | "cron" | "method" | "body" | "headers" | "enabled"
+>> & { request_id: string };
 
 function readSchedules(projectConfig: unknown): ScheduledFunctionConfig[] {
-  const cfg = normalizeProjectConfig(projectConfig as Record<string, unknown> | null | undefined);
-  const raw = cfg.scheduled_functions;
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(isScheduledFunctionConfig);
+  const normalizedConfig = normalizeProjectConfig(projectConfig as Record<string, unknown> | null | undefined);
+  const scheduleCandidates = normalizedConfig.scheduled_functions;
+  if (!Array.isArray(scheduleCandidates)) return [];
+  return scheduleCandidates.filter(isScheduledFunctionConfig);
 }
 
-function validateScheduleInput(input: {
-  name?: string;
-  slug?: string;
-  cron?: string;
-  method?: string;
-}): string | null {
-  if (!input.name?.trim()) return "name is required";
-  if (!input.slug?.trim() || !/^[a-z0-9_-]+$/i.test(input.slug)) return "slug must be alphanumeric/dash/underscore";
-  if (!input.cron?.trim() || !CRON_RE.test(input.cron.trim())) return "cron must be a valid 5-field expression";
-  if (input.method && !ALLOWED_METHODS.has(input.method as ScheduledFunctionMethod)) {
-    return `method must be one of: ${[...ALLOWED_METHODS].join(", ")}`;
+function validatedScheduleCreateInput(
+  input: ScheduleCreateInput,
+): { error: string } | { name: string; slug: string; cron: string } {
+  if (!input.request_id || !SCHEDULE_ID_PATTERN.test(input.request_id)) {
+    return { error: "request_id must be a UUIDv4" };
   }
+  const name = normalizedScheduledFunctionName(input.name);
+  if (!name) return { error: `name must be 1-${MAX_SCHEDULE_NAME_LENGTH} characters` };
+  const slug = normalizedScheduledFunctionSlug(input.slug);
+  if (!slug) return { error: "slug must be 1-128 alphanumeric/dash/underscore characters" };
+  const cron = typeof input.cron === "string" ? input.cron.trim() : "";
+  if (!isValidScheduledFunctionCron(cron)) return { error: "cron must be a valid bounded 5-field expression" };
+  if (!ALLOWED_METHODS.has(input.method)) {
+    return { error: `method must be one of: ${[...ALLOWED_METHODS].join(", ")}` };
+  }
+  if (!scheduledFunctionBodyWithinLimit(input.body)) return { error: SCHEDULE_BODY_INVALID };
+  return { name, slug, cron };
+}
+
+function schedulePatchError(input: SchedulePatchInput): string | null {
+  if (!SCHEDULE_ID_PATTERN.test(input.request_id)) return "request_id must be a UUIDv4";
+  if (!SCHEDULE_PATCH_FIELDS.some((field) => input[field] !== undefined)) {
+    return "Scheduled function update requires at least one field";
+  }
+  if (input.name !== undefined && !normalizedScheduledFunctionName(input.name)) {
+    return `name must be 1-${MAX_SCHEDULE_NAME_LENGTH} characters`;
+  }
+  if (input.cron !== undefined && !isValidScheduledFunctionCron(input.cron.trim())) {
+    return "cron must be a valid bounded 5-field expression";
+  }
+  if (input.method !== undefined && !ALLOWED_METHODS.has(input.method)) return "method must be GET or POST";
+  if (!scheduledFunctionBodyWithinLimit(input.body)) return SCHEDULE_BODY_INVALID;
   return null;
 }
 
-function publicSafeSchedule(s: ScheduledFunctionConfig) {
-  return { ...s };
+function normalizedSchedulePatch(
+  input: SchedulePatchInput,
+  headers: Record<string, string> | undefined,
+): Partial<ScheduledFunctionConfig> {
+  return {
+    ...(input.name !== undefined ? { name: input.name.trim() } : {}),
+    ...(input.cron !== undefined ? { cron: input.cron.trim() } : {}),
+    ...(input.method !== undefined ? { method: input.method } : {}),
+    ...(input.body !== undefined ? { body: input.body } : {}),
+    ...(input.headers !== undefined && headers ? { headers } : {}),
+    ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+  };
+}
+
+function scheduleHeaders(
+  candidate: Record<string, string> | undefined,
+): Record<string, string> | null | undefined {
+  return candidate === undefined ? undefined : normalizedScheduledFunctionHeaders(candidate);
 }
 
 export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/scheduled-functions" })
   .onBeforeHandle(async ({ params, request }) => {
+    if (!PROJECT_REF_PATTERN.test(params.ref)) return status(400, { error: "Project ref is invalid" });
     const authError = await authMiddleware.requireProjectOrAdminAuth(request, params.ref);
     if (authError) return status(authError.status, authError.body);
   })
   .get("", async ({ params }) => {
     const project = await projectRepository.findByRef(params.ref);
     if (!project) return status(404, { error: "Project not found" });
-    const schedules = readSchedules(project.config).map(publicSafeSchedule);
+    const schedules = readSchedules(project.config).map(publicScheduledFunction);
     return { project_ref: params.ref, schedules };
   }, {
     detail: { tags: ["scheduled-functions"], summary: "List scheduled functions" },
   })
   .post("", async ({ params, body }) => {
-    const input = body as { name: string; slug: string; cron: string; method: ScheduledFunctionMethod; body?: Record<string, unknown>; headers?: Record<string, string> };
-    const err = validateScheduleInput(input);
-    if (err) return status(400, { error: err });
+    const input = body as ScheduleCreateInput;
+    const validation = validatedScheduleCreateInput(input);
+    if ("error" in validation) return status(400, validation);
+    const headers = scheduleHeaders(input.headers);
+    if (headers === null) return status(400, { error: SCHEDULE_HEADERS_INVALID });
 
     const project = await projectRepository.findByRef(params.ref);
     if (!project) return status(404, { error: "Project not found" });
@@ -102,19 +145,19 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     if (existing.length >= MAX_SCHEDULES_PER_PROJECT) {
       return status(400, { error: `A project can have at most ${MAX_SCHEDULES_PER_PROJECT} scheduled functions` });
     }
-    if (existing.some((s) => s.slug === input.slug)) {
-      return status(409, { error: `A schedule for slug '${input.slug}' already exists` });
+    if (existing.some((schedule) => schedule.slug === validation.slug)) {
+      return status(409, { error: `A schedule for slug '${validation.slug}' already exists` });
     }
 
     const now = new Date().toISOString();
     const schedule: ScheduledFunctionConfig = {
       id: crypto.randomUUID(),
-      name: input.name.trim().slice(0, 120),
-      slug: input.slug.trim(),
-      cron: input.cron.trim(),
+      name: validation.name,
+      slug: validation.slug,
+      cron: validation.cron,
       method: input.method,
       body: input.body,
-      headers: input.headers,
+      headers: headers ?? undefined,
       enabled: true,
       created_at: now,
       updated_at: now,
@@ -127,9 +170,15 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     if (!updated) return status(404, { error: "Project not found" });
 
     scheduledFunctionWorker.reload();
-    return { created: true, project_ref: params.ref, schedule: publicSafeSchedule(schedule) };
+    return {
+      created: true,
+      project_ref: params.ref,
+      request_id: input.request_id,
+      schedule: publicScheduledFunction(schedule),
+    };
   }, {
     body: t.Object({
+      request_id: t.String(),
       name: t.String(),
       slug: t.String(),
       cron: t.String(),
@@ -140,44 +189,43 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     detail: { tags: ["scheduled-functions"], summary: "Create a scheduled function" },
   })
   .patch("/:scheduleId", async ({ params, body }) => {
-    const input = body as Partial<Pick<ScheduledFunctionConfig, "name" | "cron" | "method" | "body" | "headers" | "enabled">>;
-
-    if (input.cron !== undefined && !CRON_RE.test(input.cron.trim())) {
-      return status(400, { error: "cron must be a valid 5-field expression" });
-    }
-    if (input.method !== undefined && !ALLOWED_METHODS.has(input.method as ScheduledFunctionMethod)) {
-      return status(400, { error: "method must be GET or POST" });
-    }
+    if (!SCHEDULE_ID_PATTERN.test(params.scheduleId)) return status(400, { error: "Scheduled function ID is invalid" });
+    const input = body as SchedulePatchInput;
+    const validationError = schedulePatchError(input);
+    if (validationError) return status(400, { error: validationError });
+    const headers = scheduleHeaders(input.headers);
+    if (headers === null) return status(400, { error: SCHEDULE_HEADERS_INVALID });
 
     const project = await projectRepository.findByRef(params.ref);
     if (!project) return status(404, { error: "Project not found" });
 
     const schedules = readSchedules(project.config);
-    const target = schedules.find((s) => s.id === params.scheduleId);
+    const target = schedules.find((schedule) => schedule.id === params.scheduleId);
     if (!target) return status(404, { error: "Scheduled function not found" });
 
     const updatedSchedule: ScheduledFunctionConfig = {
       ...target,
-      name: input.name !== undefined ? input.name.trim().slice(0, 120) : target.name,
-      cron: input.cron !== undefined ? input.cron.trim() : target.cron,
-      method: input.method !== undefined ? (input.method as ScheduledFunctionMethod) : target.method,
-      body: input.body !== undefined ? input.body : target.body,
-      headers: input.headers !== undefined ? input.headers : target.headers,
-      enabled: input.enabled !== undefined ? !!input.enabled : target.enabled,
+      ...normalizedSchedulePatch(input, headers),
       updated_at: new Date().toISOString(),
     };
 
-    const next = schedules.map((s) => (s.id === target.id ? updatedSchedule : s));
+    const nextSchedules = schedules.map((schedule) => schedule.id === target.id ? updatedSchedule : schedule);
     const updated = await projectRepository.updateConfig(
       params.ref,
-      mergeProjectConfig(project.config, { scheduled_functions: next }),
+      mergeProjectConfig(project.config, { scheduled_functions: nextSchedules }),
     );
     if (!updated) return status(404, { error: "Project not found" });
 
     scheduledFunctionWorker.reload();
-    return { updated: true, project_ref: params.ref, schedule: publicSafeSchedule(updatedSchedule) };
+    return {
+      updated: true,
+      project_ref: params.ref,
+      request_id: input.request_id,
+      schedule: publicScheduledFunction(updatedSchedule),
+    };
   }, {
     body: t.Object({
+      request_id: t.String(),
       name: t.Optional(t.String()),
       cron: t.Optional(t.String()),
       method: t.Optional(t.Union([t.Literal("GET"), t.Literal("POST")])),
@@ -188,16 +236,17 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     detail: { tags: ["scheduled-functions"], summary: "Update a scheduled function" },
   })
   .delete("/:scheduleId", async ({ params }) => {
+    if (!SCHEDULE_ID_PATTERN.test(params.scheduleId)) return status(400, { error: "Scheduled function ID is invalid" });
     const project = await projectRepository.findByRef(params.ref);
     if (!project) return status(404, { error: "Project not found" });
 
     const schedules = readSchedules(project.config);
-    const next = schedules.filter((s) => s.id !== params.scheduleId);
-    if (next.length === schedules.length) return status(404, { error: "Scheduled function not found" });
+    const nextSchedules = schedules.filter((schedule) => schedule.id !== params.scheduleId);
+    if (nextSchedules.length === schedules.length) return status(404, { error: "Scheduled function not found" });
 
     const updated = await projectRepository.updateConfig(
       params.ref,
-      mergeProjectConfig(project.config, { scheduled_functions: next }),
+      mergeProjectConfig(project.config, { scheduled_functions: nextSchedules }),
     );
     if (!updated) return status(404, { error: "Project not found" });
 
@@ -207,16 +256,17 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     detail: { tags: ["scheduled-functions"], summary: "Delete a scheduled function" },
   })
   .post("/:scheduleId/trigger", async ({ params }) => {
+    if (!SCHEDULE_ID_PATTERN.test(params.scheduleId)) return status(400, { error: "Scheduled function ID is invalid" });
     const project = await projectRepository.findByRef(params.ref);
     if (!project) return status(404, { error: "Project not found" });
 
     const schedules = readSchedules(project.config);
-    const target = schedules.find((s) => s.id === params.scheduleId);
+    const target = schedules.find((schedule) => schedule.id === params.scheduleId);
     if (!target) return status(404, { error: "Scheduled function not found" });
 
-    const result = await scheduledFunctionWorker.triggerOnce(params.ref, target);
-    if (!result.ok) return status(502, { error: result.error });
-    return { triggered: true, project_ref: params.ref, schedule_id: params.scheduleId, status: result.status };
+    const invocation = await scheduledFunctionWorker.triggerOnce(params.ref, target);
+    if (!invocation.ok) return status(502, { error: invocation.error });
+    return { triggered: true, project_ref: params.ref, schedule_id: params.scheduleId, status: invocation.status };
   }, {
     detail: { tags: ["scheduled-functions"], summary: "Manually trigger a scheduled function" },
   });

--- a/packages/management-api/src/utils/scheduled-function-config.ts
+++ b/packages/management-api/src/utils/scheduled-function-config.ts
@@ -1,0 +1,145 @@
+import { isValidScheduledFunctionCron } from "./scheduled-function-cron";
+import { normalizedScheduledFunctionHeaders } from "./scheduled-function-headers";
+import { normalizeProjectConfig } from "./project-config";
+
+export type ScheduledFunctionMethod = "GET" | "POST";
+
+export interface ScheduledFunctionConfig {
+  id: string;
+  name: string;
+  slug: string;
+  cron: string;
+  method: ScheduledFunctionMethod;
+  body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PublicScheduledFunction {
+  id: string;
+  name: string;
+  slug: string;
+  cron: string;
+  method: ScheduledFunctionMethod;
+  enabled: boolean;
+  body_empty: boolean;
+  header_names: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+type PublicScheduleCandidate = ScheduledFunctionConfig & Partial<Pick<
+  PublicScheduledFunction,
+  "body_empty" | "header_names"
+>>;
+
+export const MAX_SCHEDULE_BODY_BYTES = 1_048_576;
+export const MAX_SCHEDULE_NAME_LENGTH = 120;
+
+const FUNCTION_SLUG_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const SCHEDULE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function objectRecord(candidate: unknown): Record<string, unknown> | null {
+  return candidate && typeof candidate === "object" && !Array.isArray(candidate)
+    ? candidate as Record<string, unknown>
+    : null;
+}
+
+function stringRecord(candidate: unknown): candidate is Record<string, string> {
+  const record = objectRecord(candidate);
+  return record !== null && Object.values(record).every((entry) => typeof entry === "string");
+}
+
+export function normalizedScheduledFunctionName(candidate: unknown): string | null {
+  if (typeof candidate !== "string") return null;
+  const name = candidate.trim();
+  return name.length > 0 && name.length <= MAX_SCHEDULE_NAME_LENGTH ? name : null;
+}
+
+export function normalizedScheduledFunctionSlug(candidate: unknown): string | null {
+  if (typeof candidate !== "string") return null;
+  const slug = candidate.trim();
+  return FUNCTION_SLUG_PATTERN.test(slug) ? slug : null;
+}
+
+export function scheduledFunctionBodyWithinLimit(candidate: unknown): boolean {
+  if (candidate === undefined) return true;
+  if (!objectRecord(candidate)) return false;
+  try {
+    const serialized = JSON.stringify(candidate);
+    return new TextEncoder().encode(serialized).byteLength <= MAX_SCHEDULE_BODY_BYTES;
+  } catch {
+    return false;
+  }
+}
+
+function validScheduleIdentity(schedule: Record<string, unknown>): boolean {
+  return typeof schedule.id === "string" && SCHEDULE_ID_PATTERN.test(schedule.id)
+    && normalizedScheduledFunctionName(schedule.name) !== null
+    && normalizedScheduledFunctionSlug(schedule.slug) === schedule.slug;
+}
+
+function validScheduleDefinition(schedule: Record<string, unknown>): boolean {
+  return typeof schedule.cron === "string" && isValidScheduledFunctionCron(schedule.cron)
+    && (schedule.method === "GET" || schedule.method === "POST")
+    && typeof schedule.enabled === "boolean";
+}
+
+function validSchedulePayload(schedule: Record<string, unknown>): boolean {
+  return (schedule.body === undefined || objectRecord(schedule.body) !== null)
+    && (schedule.headers === undefined || stringRecord(schedule.headers));
+}
+
+export function isScheduledFunctionConfig(candidate: unknown): candidate is ScheduledFunctionConfig {
+  const schedule = objectRecord(candidate);
+  return schedule !== null && validScheduleIdentity(schedule) && validScheduleDefinition(schedule)
+    && validSchedulePayload(schedule)
+    && typeof schedule.created_at === "string" && typeof schedule.updated_at === "string";
+}
+
+function publicBodyEmpty(schedule: PublicScheduleCandidate): boolean {
+  if (Object.prototype.hasOwnProperty.call(schedule, "body")) {
+    return Object.keys(objectRecord(schedule.body) ?? {}).length === 0;
+  }
+  return typeof schedule.body_empty === "boolean" ? schedule.body_empty : true;
+}
+
+function publicHeaderNames(schedule: PublicScheduleCandidate): string[] {
+  if (Object.prototype.hasOwnProperty.call(schedule, "headers")) {
+    return Object.keys(objectRecord(schedule.headers) ?? {}).map((name) => name.toLowerCase()).sort();
+  }
+  if (!Array.isArray(schedule.header_names)
+    || !schedule.header_names.every((name) => typeof name === "string")) return [];
+  const placeholderHeaders = Object.fromEntries(
+    schedule.header_names.map((name) => [name, "redacted"]),
+  );
+  const normalizedHeaders = normalizedScheduledFunctionHeaders(placeholderHeaders);
+  return normalizedHeaders ? Object.keys(normalizedHeaders).sort() : [];
+}
+
+export function publicScheduledFunction(schedule: PublicScheduleCandidate): PublicScheduledFunction {
+  return {
+    id: schedule.id,
+    name: schedule.name,
+    slug: schedule.slug,
+    cron: schedule.cron,
+    method: schedule.method,
+    enabled: schedule.enabled,
+    body_empty: publicBodyEmpty(schedule),
+    header_names: publicHeaderNames(schedule),
+    created_at: schedule.created_at,
+    updated_at: schedule.updated_at,
+  };
+}
+
+export function publicScheduledFunctionProjectConfig(candidate: unknown): Record<string, unknown> {
+  const projectConfig = normalizeProjectConfig(candidate);
+  if (!Object.prototype.hasOwnProperty.call(projectConfig, "scheduled_functions")) return projectConfig;
+  const schedules = projectConfig.scheduled_functions;
+  projectConfig.scheduled_functions = Array.isArray(schedules)
+    ? schedules.filter(isScheduledFunctionConfig).map(publicScheduledFunction)
+    : [];
+  return projectConfig;
+}

--- a/packages/management-api/src/utils/scheduled-function-cron.ts
+++ b/packages/management-api/src/utils/scheduled-function-cron.ts
@@ -1,0 +1,89 @@
+const MAX_CRON_EXPRESSION_LENGTH = 256;
+const CRON_FIELD_BOUNDS = [
+  [0, 59],
+  [0, 23],
+  [1, 31],
+  [1, 12],
+  [0, 7],
+] as const;
+const CRON_PART_PATTERN = /^(\*|([0-9]+)(?:-([0-9]+))?)(?:\/([0-9]+))?$/;
+
+interface CronRange {
+  start: number;
+  end: number;
+  step: number;
+}
+
+interface ParsedCron {
+  fields: CronRange[][];
+  dayOfMonthWildcard: boolean;
+  dayOfWeekWildcard: boolean;
+}
+
+function boundedInteger(input: string, minimum: number, maximum: number): number | null {
+  const parsed = Number(input);
+  return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum
+    ? parsed
+    : null;
+}
+
+function cronRange(part: string, minimum: number, maximum: number): CronRange | null {
+  const match = CRON_PART_PATTERN.exec(part);
+  if (!match) return null;
+  const start = match[1] === "*" ? minimum : boundedInteger(match[2], minimum, maximum);
+  const end = match[1] === "*"
+    ? maximum
+    : match[3] === undefined ? start : boundedInteger(match[3], minimum, maximum);
+  const step = match[4] === undefined ? 1 : boundedInteger(match[4], 1, maximum - minimum + 1);
+  if (start === null || end === null || step === null || start > end) return null;
+  return { start, end, step };
+}
+
+function cronField(field: string, minimum: number, maximum: number): CronRange[] | null {
+  const parts = field.split(",");
+  if (parts.length > maximum - minimum + 1 || parts.some((part) => part.length === 0)) return null;
+  const ranges = parts.map((part) => cronRange(part, minimum, maximum));
+  return ranges.some((range) => range === null) ? null : ranges as CronRange[];
+}
+
+function parsedCron(expression: unknown): ParsedCron | null {
+  if (typeof expression !== "string" || !expression || expression.length > MAX_CRON_EXPRESSION_LENGTH) return null;
+  const rawFields = expression.trim().split(/\s+/);
+  if (rawFields.length !== CRON_FIELD_BOUNDS.length) return null;
+  const fields = rawFields.map((field, index) => {
+    const [minimum, maximum] = CRON_FIELD_BOUNDS[index];
+    return cronField(field, minimum, maximum);
+  });
+  if (fields.some((field) => field === null)) return null;
+  return {
+    fields: fields as CronRange[][],
+    dayOfMonthWildcard: rawFields[2] === "*",
+    dayOfWeekWildcard: rawFields[4] === "*",
+  };
+}
+
+function fieldMatches(ranges: CronRange[], value: number): boolean {
+  return ranges.some((range) => value >= range.start && value <= range.end
+    && (value - range.start) % range.step === 0);
+}
+
+export function isValidScheduledFunctionCron(expression: unknown): boolean {
+  return parsedCron(expression) !== null;
+}
+
+export function scheduledFunctionCronMatches(expression: unknown, date: Date): boolean {
+  const cron = parsedCron(expression);
+  if (!cron) return false;
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = cron.fields;
+  const minuteMatches = fieldMatches(minute, date.getMinutes());
+  const hourMatches = fieldMatches(hour, date.getHours());
+  const monthMatches = fieldMatches(month, date.getMonth() + 1);
+  const dayOfMonthMatches = fieldMatches(dayOfMonth, date.getDate());
+  const weekday = date.getDay();
+  const dayOfWeekMatches = fieldMatches(dayOfWeek, weekday)
+    || (weekday === 0 && fieldMatches(dayOfWeek, 7));
+  const dayMatches = !cron.dayOfMonthWildcard && !cron.dayOfWeekWildcard
+    ? dayOfMonthMatches || dayOfWeekMatches
+    : dayOfMonthMatches && dayOfWeekMatches;
+  return minuteMatches && hourMatches && monthMatches && dayMatches;
+}

--- a/packages/management-api/src/utils/scheduled-function-headers.ts
+++ b/packages/management-api/src/utils/scheduled-function-headers.ts
@@ -1,0 +1,55 @@
+export const SCHEDULE_HEADERS_INVALID = "SCHEDULE_HEADERS_INVALID";
+
+const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]{1,128}$/;
+const MAX_HEADER_COUNT = 64;
+const MAX_HEADER_VALUE_LENGTH = 8_192;
+const FORBIDDEN_HEADER_NAMES = new Set([
+  "apikey",
+  "authorization",
+  "connection",
+  "content-length",
+  "forwarded",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "via",
+  "x-project-ref",
+]);
+
+function isForbiddenHeaderName(name: string): boolean {
+  return FORBIDDEN_HEADER_NAMES.has(name) || name.startsWith("x-forwarded-");
+}
+
+function headerValueIsStable(name: string, value: string): boolean {
+  if (!value || value.length > MAX_HEADER_VALUE_LENGTH) return false;
+  try {
+    const headers = new Headers();
+    headers.set(name, value);
+    return headers.get(name) === value;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizedScheduledFunctionHeaders(candidate: unknown): Record<string, string> | null {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+  const entries = Object.entries(candidate);
+  if (entries.length > MAX_HEADER_COUNT) return null;
+  const normalized: Array<[string, string]> = [];
+  const names = new Set<string>();
+  for (const [name, value] of entries) {
+    const lowerName = name.toLowerCase();
+    if (typeof value !== "string" || !HEADER_NAME_PATTERN.test(name)
+      || isForbiddenHeaderName(lowerName) || names.has(lowerName)
+      || !headerValueIsStable(lowerName, value)) return null;
+    names.add(lowerName);
+    normalized.push([lowerName, value]);
+  }
+  return Object.fromEntries(normalized);
+}

--- a/packages/management-api/src/workers/scheduled-function.worker.ts
+++ b/packages/management-api/src/workers/scheduled-function.worker.ts
@@ -15,14 +15,33 @@ import { config } from "../config";
 import { logger } from "../utils/logger";
 import { normalizeProjectConfig } from "../utils/project-config";
 import { projectRepository } from "../repositories/project.repository";
-import type { ScheduledFunctionConfig } from "../routes/scheduled-functions";
+import { scheduledFunctionCronMatches } from "../utils/scheduled-function-cron";
+import {
+  normalizedScheduledFunctionHeaders,
+  SCHEDULE_HEADERS_INVALID,
+} from "../utils/scheduled-function-headers";
+import {
+  isScheduledFunctionConfig,
+  scheduledFunctionBodyWithinLimit,
+  type ScheduledFunctionConfig,
+} from "../utils/scheduled-function-config";
 
 const POLL_INTERVAL_MS = 60_000;
 const INVOKE_TIMEOUT_MS = 30_000;
+const SCHEDULE_LOAD_FAILED = "SCHEDULE_LOAD_FAILED";
+const SCHEDULE_CONFIG_INVALID = "SCHEDULE_CONFIG_INVALID";
+const SCHEDULE_PROJECT_NOT_FOUND = "SCHEDULE_PROJECT_NOT_FOUND";
+const SCHEDULE_INVOKE_FAILED = "SCHEDULE_INVOKE_FAILED";
+const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 
 interface DueSchedule {
   ref: string;
   schedule: ScheduledFunctionConfig;
+}
+
+function validInvocationSchedule(ref: string, schedule: unknown): schedule is ScheduledFunctionConfig {
+  return PROJECT_REF_PATTERN.test(ref)
+    && isScheduledFunctionConfig(schedule);
 }
 
 export function scheduledFunctionsDueAt(
@@ -34,77 +53,16 @@ export function scheduledFunctionsDueAt(
     const projectConfig = normalizeProjectConfig(row.config);
     const rawSchedules = projectConfig.scheduled_functions;
     if (!Array.isArray(rawSchedules)) continue;
-    for (const item of rawSchedules) {
-      if (!item || typeof item !== "object") continue;
-      const schedule = item as ScheduledFunctionConfig;
-      if (schedule.enabled === false || !schedule.cron || !schedule.slug) continue;
-      if (isDue(schedule.cron, now)) due.push({ ref: row.ref, schedule });
+    for (const candidate of rawSchedules) {
+      if (!validInvocationSchedule(row.ref, candidate) || !candidate.enabled) continue;
+      if (isDue(candidate.cron, now)) due.push({ ref: row.ref, schedule: candidate });
     }
   }
   return due;
 }
 
-function parseField(field: string, min: number, max: number): Set<number> {
-  const result = new Set<number>();
-  for (const part of field.split(",")) {
-    const trimmed = part.trim();
-    if (trimmed === "*") {
-      for (let i = min; i <= max; i++) result.add(i);
-      continue;
-    }
-    // step: a/b
-    const stepIdx = trimmed.indexOf("/");
-    let step = 1;
-    let rangePart = trimmed;
-    if (stepIdx > 0) {
-      step = parseInt(trimmed.slice(stepIdx + 1), 10);
-      if (!Number.isFinite(step) || step < 1) continue;
-      rangePart = trimmed.slice(0, stepIdx);
-    }
-    let start = min;
-    let end = max;
-    if (rangePart !== "*") {
-      const dashIdx = rangePart.indexOf("-");
-      if (dashIdx > 0) {
-        start = parseInt(rangePart.slice(0, dashIdx), 10);
-        end = parseInt(rangePart.slice(dashIdx + 1), 10);
-      } else {
-        start = end = parseInt(rangePart, 10);
-      }
-    }
-    if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
-    for (let i = start; i <= end; i += step) {
-      if (i >= min && i <= max) result.add(i);
-    }
-  }
-  return result;
-}
-
 export function isDue(cronExpr: string, date: Date): boolean {
-  const parts = cronExpr.trim().split(/\s+/);
-  if (parts.length !== 5) return false;
-  const [minute, hour, dom, month, dow] = parts;
-  const m = parseField(minute, 0, 59);
-  const h = parseField(hour, 0, 23);
-  const dayOfMonth = parseField(dom, 1, 31);
-  const monthField = parseField(month, 1, 12);
-  // 0 and 7 both mean Sunday in cron.
-  const dowSet = parseField(dow, 0, 7);
-  if (dowSet.has(7)) dowSet.add(0);
-
-  const minOk = m.has(date.getMinutes());
-  const hourOk = h.has(date.getHours());
-  const domOk = dayOfMonth.has(date.getDate());
-  const monthOk = monthField.has(date.getMonth() + 1);
-  const dowOk = dowSet.has(date.getDay());
-
-  // Standard cron: when both dom and dow are restricted (not '*'), fire on either match.
-  const domRestricted = dom !== "*";
-  const dowRestricted = dow !== "*";
-  if (domRestricted && dowRestricted) {
-    return minOk && hourOk && monthOk && (domOk || dowOk);
-  }
-  return minOk && hourOk && monthOk && domOk && dowOk;
+  return scheduledFunctionCronMatches(cronExpr, date);
 }
 
 async function loadAllSchedules(): Promise<DueSchedule[]> {
@@ -114,8 +72,8 @@ async function loadAllSchedules(): Promise<DueSchedule[]> {
       SELECT ref, config FROM projects
       WHERE deleted_at IS NULL
     `) as { ref: string; config: unknown }[];
-  } catch (err) {
-    logger.debug("[scheduled-functions] failed to load projects", { error: err instanceof Error ? err.message : String(err) });
+  } catch {
+    logger.debug("[scheduled-functions] failed to load projects", { error: SCHEDULE_LOAD_FAILED });
     return [];
   }
 
@@ -128,37 +86,48 @@ export interface TriggerResult {
   error?: string;
 }
 
+function invocationHeaders(
+  ref: string,
+  serviceRoleKey: string,
+  userHeaders: Record<string, string>,
+): Record<string, string> {
+  // Platform headers are applied last so tenant schedules cannot redirect or
+  // re-authenticate the internal runtime request.
+  return {
+    ...userHeaders,
+    "x-project-ref": ref,
+    "apikey": serviceRoleKey,
+    "authorization": `Bearer ${serviceRoleKey}`,
+  };
+}
+
+function invocationRequest(
+  schedule: ScheduledFunctionConfig,
+  headers: Record<string, string>,
+): RequestInit {
+  const sendsJsonBody = schedule.method === "POST" && schedule.body !== undefined;
+  return {
+    method: schedule.method,
+    headers: sendsJsonBody ? { ...headers, "content-type": "application/json" } : headers,
+    signal: AbortSignal.timeout(INVOKE_TIMEOUT_MS),
+    ...(sendsJsonBody ? { body: JSON.stringify(schedule.body) } : {}),
+  };
+}
+
 async function invokeEdgeFunction(ref: string, schedule: ScheduledFunctionConfig): Promise<TriggerResult> {
+  if (!validInvocationSchedule(ref, schedule)) return { ok: false, error: SCHEDULE_CONFIG_INVALID };
+  if (!scheduledFunctionBodyWithinLimit(schedule.body)) return { ok: false, error: SCHEDULE_CONFIG_INVALID };
   const url = `${config.edgeRuntimeUrl}/functions/v1/${encodeURIComponent(schedule.slug)}`;
+  const userHeaders = normalizedScheduledFunctionHeaders(schedule.headers ?? {});
+  if (!userHeaders) return { ok: false, error: SCHEDULE_HEADERS_INVALID };
   try {
-    // Load the project service_role_key so the edge runtime accepts the call
-    // even when verify_jwt is enabled. User-configured headers override defaults.
     const project = await projectRepository.findByRef(ref);
-    if (!project) {
-      return { ok: false, error: "Project not found" };
-    }
-    const defaultHeaders: Record<string, string> = {
-      "x-project-ref": ref,
-      "apikey": project.service_role_key,
-      "authorization": `Bearer ${project.service_role_key}`,
-    };
-    const headers: Record<string, string> = {
-      ...defaultHeaders,
-      ...schedule.headers,
-    };
-    const init: RequestInit = {
-      method: schedule.method,
-      headers,
-      signal: AbortSignal.timeout(INVOKE_TIMEOUT_MS),
-    };
-    if (schedule.method === "POST" && schedule.body) {
-      headers["content-type"] = "application/json";
-      init.body = JSON.stringify(schedule.body);
-    }
-    const res = await fetch(url, init);
-    return { ok: res.ok, status: res.status };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    if (!project) return { ok: false, error: SCHEDULE_PROJECT_NOT_FOUND };
+    const headers = invocationHeaders(ref, project.service_role_key, userHeaders);
+    const response = await fetch(url, invocationRequest(schedule, headers));
+    return { ok: response.ok, status: response.status };
+  } catch {
+    return { ok: false, error: SCHEDULE_INVOKE_FAILED };
   }
 }
 
@@ -202,11 +171,11 @@ class ScheduledFunctionWorker {
 
       await Promise.allSettled(
         due.map(async ({ ref, schedule }) => {
-          const result = await invokeEdgeFunction(ref, schedule);
-          if (!result.ok) {
+          const invocation = await invokeEdgeFunction(ref, schedule);
+          if (!invocation.ok) {
             logger.warn(`[scheduled-functions] invoke failed for ${ref}/${schedule.slug}`, {
-              status: result.status,
-              error: result.error,
+              status: invocation.status,
+              error: invocation.error,
             });
           }
         }),

--- a/packages/management-api/tests/unit/project-crud-public-config.test.ts
+++ b/packages/management-api/tests/unit/project-crud-public-config.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import { toPublicV1ProjectWithDatabaseResponse } from "../../src/routes/project-crud";
+import { publicScheduledFunctionProjectConfig } from "../../src/utils/scheduled-function-config";
+
+test("project detail serialization redacts scheduled Function payloads", () => {
+  const bodySentinel = "private-project-body-sentinel";
+  const headerSentinel = "private-project-header-sentinel";
+  const response = toPublicV1ProjectWithDatabaseResponse({
+    id: "project-id",
+    ref: "proj_1",
+    name: "Project",
+    config: {
+      unrelated: { enabled: true },
+      scheduled_functions: [{
+        id: "00000000-0000-4000-8000-000000000001",
+        name: "Nightly",
+        slug: "worker",
+        cron: "0 2 * * *",
+        method: "POST",
+        body: { token: bodySentinel },
+        headers: { "x-schedule-token": headerSentinel },
+        enabled: true,
+        created_at: "2026-08-11T00:00:00.000Z",
+        updated_at: "2026-08-11T00:00:00.000Z",
+      }],
+    },
+  });
+  const responseText = JSON.stringify(response);
+  const config = response.config as Record<string, unknown>;
+  const schedules = config.scheduled_functions as Array<Record<string, unknown>>;
+
+  expect(config.unrelated).toEqual({ enabled: true });
+  expect(schedules[0]).toMatchObject({
+    id: "00000000-0000-4000-8000-000000000001",
+    body_empty: false,
+    header_names: ["x-schedule-token"],
+  });
+  expect(schedules[0]).not.toHaveProperty("body");
+  expect(schedules[0]).not.toHaveProperty("headers");
+  expect(responseText).not.toContain(bodySentinel);
+  expect(responseText).not.toContain(headerSentinel);
+});
+
+test("project detail serialization preserves redaction metadata when applied twice", () => {
+  const firstPass = publicScheduledFunctionProjectConfig({
+    scheduled_functions: [{
+      id: "00000000-0000-4000-8000-000000000001",
+      name: "Nightly",
+      slug: "worker",
+      cron: "0 2 * * *",
+      method: "POST",
+      body: { enabled: true },
+      headers: { "X-Schedule-Token": "private-header-sentinel" },
+      enabled: true,
+      created_at: "2026-08-11T00:00:00.000Z",
+      updated_at: "2026-08-11T00:00:00.000Z",
+    }],
+  });
+
+  const response = toPublicV1ProjectWithDatabaseResponse({
+    id: "project-id",
+    ref: "proj_1",
+    name: "Project",
+    config: firstPass,
+  });
+  const config = response.config as Record<string, unknown>;
+  const schedules = config.scheduled_functions as Array<Record<string, unknown>>;
+
+  expect(schedules[0]).toMatchObject({
+    body_empty: false,
+    header_names: ["x-schedule-token"],
+  });
+});

--- a/packages/management-api/tests/unit/project-settings-scheduled-functions.routes.test.ts
+++ b/packages/management-api/tests/unit/project-settings-scheduled-functions.routes.test.ts
@@ -1,0 +1,138 @@
+// @supacloud-test-isolate
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const authModule = await import("../../src/middleware/auth");
+const servicesModule = await import("../../src/services");
+const { config } = await import("../../src/config");
+
+const requireProjectOrAdminAuth = mock(async () => null);
+const getProjectSettings = mock(async () => projectSettings());
+const updateProjectSettings = mock(async () => projectSettings());
+
+const authSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const getSettingsSpy = spyOn(
+  servicesModule.projectService,
+  "getProjectSettings",
+).mockImplementation(
+  getProjectSettings as typeof servicesModule.projectService.getProjectSettings,
+);
+const updateSettingsSpy = spyOn(
+  servicesModule.projectService,
+  "updateProjectSettings",
+).mockImplementation(
+  updateProjectSettings as typeof servicesModule.projectService.updateProjectSettings,
+);
+
+const { projectConfigRoutes } = await import(
+  "../../src/routes/project-config?project-settings-scheduled-functions-test"
+);
+const app = new Elysia().use(projectConfigRoutes);
+const originalOwnerRef = config.authRuntimeOwnerRef;
+
+function projectSettings() {
+  return {
+    api_domain: "tenant-a.api.example.com",
+    scheduled_functions: [{
+      id: "00000000-0000-4000-8000-000000000001",
+      name: "Nightly",
+      slug: "worker",
+      cron: "0 2 * * *",
+      method: "POST" as const,
+      body: { token: "private-settings-body-sentinel" },
+      headers: { "x-schedule-token": "private-settings-header-sentinel" },
+      enabled: true,
+      created_at: "2026-08-11T00:00:00.000Z",
+      updated_at: "2026-08-11T00:00:00.000Z",
+    }],
+  };
+}
+
+function request(method: "GET" | "PUT", body?: Record<string, unknown>) {
+  return app.handle(new Request("http://localhost/v1/projects/tenant-a/settings", {
+    method,
+    headers: {
+      authorization: "Bearer dev-master-token",
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  }));
+}
+
+function expectPublicSchedule(responseBody: Record<string, unknown>) {
+  const schedules = responseBody.scheduled_functions as Array<Record<string, unknown>>;
+  expect(schedules[0]).toMatchObject({
+    id: "00000000-0000-4000-8000-000000000001",
+    body_empty: false,
+    header_names: ["x-schedule-token"],
+  });
+  expect(schedules[0]).not.toHaveProperty("body");
+  expect(schedules[0]).not.toHaveProperty("headers");
+  expect(JSON.stringify(responseBody)).not.toContain("private-settings-body-sentinel");
+  expect(JSON.stringify(responseBody)).not.toContain("private-settings-header-sentinel");
+}
+
+afterAll(() => {
+  config.authRuntimeOwnerRef = originalOwnerRef;
+  authSpy.mockRestore();
+  getSettingsSpy.mockRestore();
+  updateSettingsSpy.mockRestore();
+});
+
+beforeEach(() => {
+  config.authRuntimeOwnerRef = "";
+  requireProjectOrAdminAuth.mockReset();
+  requireProjectOrAdminAuth.mockResolvedValue(null);
+  getProjectSettings.mockReset();
+  getProjectSettings.mockResolvedValue(projectSettings() as never);
+  updateProjectSettings.mockReset();
+  updateProjectSettings.mockResolvedValue(projectSettings() as never);
+});
+
+describe("project settings scheduled-function boundary", () => {
+  test.each([
+    ["local", ""],
+    ["shared", "auth-owner"],
+  ])("redacts GET and safe PUT responses in %s auth mode", async (_mode, ownerRef) => {
+    config.authRuntimeOwnerRef = ownerRef;
+
+    const getResponse = await request("GET");
+    const getBody = await getResponse.json() as Record<string, unknown>;
+    expect(getResponse.status).toBe(200);
+    expectPublicSchedule(getBody);
+
+    const putResponse = await request("PUT", { api_domain: "updated.api.example.com" });
+    const putBody = await putResponse.json() as Record<string, unknown>;
+    expect(putResponse.status).toBe(200);
+    expectPublicSchedule(putBody);
+  });
+
+  test.each([
+    ["local", ""],
+    ["shared", "auth-owner"],
+  ])("rejects generic scheduled-function writes with zero persistence in %s auth mode", async (_mode, ownerRef) => {
+    config.authRuntimeOwnerRef = ownerRef;
+    const bypassSchedules = Array.from({ length: 21 }, (_, index) => ({
+      id: `bypass-${index}`,
+      name: `Bypass ${index}`,
+      slug: `bypass-${index}`,
+      cron: "* * * * *",
+      method: "POST",
+      headers: { host: "attacker.invalid" },
+      enabled: true,
+      created_at: "2026-08-11T00:00:00.000Z",
+      updated_at: "2026-08-11T00:00:00.000Z",
+    }));
+
+    const response = await request("PUT", { scheduled_functions: bypassSchedules });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      code: "SCHEDULED_FUNCTION_API_REQUIRED",
+      message: "Scheduled functions must be managed through the dedicated scheduled-functions API",
+    });
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+  });
+});

--- a/packages/management-api/tests/unit/scheduled-function.worker.test.ts
+++ b/packages/management-api/tests/unit/scheduled-function.worker.test.ts
@@ -1,5 +1,32 @@
-import { describe, expect, test } from "bun:test";
-import { isDue, scheduledFunctionsDueAt } from "../../src/workers/scheduled-function.worker";
+import { describe, expect, spyOn, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import {
+  isDue,
+  scheduledFunctionsDueAt,
+  scheduledFunctionWorker,
+} from "../../src/workers/scheduled-function.worker";
+import { projectRepository } from "../../src/repositories/project.repository";
+import { MAX_SCHEDULE_BODY_BYTES } from "../../src/utils/scheduled-function-config";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("../..", import.meta.url));
+
+function scheduleConfig(
+  headers: Record<string, string>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    name: "Test",
+    slug: "worker",
+    cron: "* * * * *",
+    method: "POST" as const,
+    headers,
+    enabled: true,
+    created_at: "2026-08-11T00:00:00.000Z",
+    updated_at: "2026-08-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
 
 describe("scheduled-function cron parser (isDue)", () => {
   test("wildcard expression fires every minute", () => {
@@ -46,11 +73,50 @@ describe("scheduled-function cron parser (isDue)", () => {
     const date = new Date("2026-06-15T10:00:00Z");
     // dom=15 matches even though dow=2 (Tuesday) doesn't
     expect(isDue("0 10 15 * 2", date)).toBe(true);
-    // dom=99 won't match but dow=1 (Monday) does
-    expect(isDue("0 10 99 * 1", date)).toBe(true);
+    // dom=14 won't match but dow=1 (Monday) does
+    expect(isDue("0 10 14 * 1", date)).toBe(true);
     // neither matches
-    expect(isDue("0 10 99 * 3", date)).toBe(false);
+    expect(isDue("0 10 14 * 3", date)).toBe(false);
   });
+
+  test.each([
+    "60 * * * *",
+    "* 24 * * *",
+    "* * 0 * *",
+    "* * 32 * *",
+    "* * * 13 *",
+    "* * * * 8",
+    "0-999999999 * * * *",
+    "*/999999999 * * * *",
+    "59-0 * * * *",
+    "*/0 * * * *",
+    "0,,1 * * * *",
+  ])("rejects invalid or unbounded expression %s", (expression) => {
+    expect(isDue(expression, new Date("2026-06-15T10:00:00Z"))).toBe(false);
+  });
+
+  test("rejects an adversarial range within a hard process deadline", async () => {
+    let timedOut = false;
+    const child = Bun.spawn([
+      process.execPath,
+      "-e",
+      'import { isDue } from "./src/workers/scheduled-function.worker.ts";'
+        + 'if (isDue("0-999999999 * * * *", new Date())) process.exit(1);',
+    ], {
+      cwd: PACKAGE_ROOT,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, 1_000);
+    const exitCode = await child.exited;
+    clearTimeout(timeout);
+
+    expect(timedOut).toBe(false);
+    expect(exitCode).toBe(0);
+  }, 2_000);
 
   test("invalid expression returns false", () => {
     const date = new Date("2026-06-15T10:00:00Z");
@@ -60,23 +126,17 @@ describe("scheduled-function cron parser (isDue)", () => {
 });
 
 describe("scheduled-function selection", () => {
-  test("reads schedules from legacy JSON-string project config", () => {
+  test("reads canonical schedules from JSON-string project config", () => {
     const now = new Date("2026-06-15T10:30:00Z");
     const due = scheduledFunctionsDueAt([
       {
         ref: "proj_1",
         config: JSON.stringify({
           scheduled_functions: [
-            {
-              id: "schedule_1",
+            scheduleConfig({}, {
               name: "Every minute",
               slug: "cleanup",
-              cron: "* * * * *",
-              method: "POST",
-              enabled: true,
-              created_at: "",
-              updated_at: "",
-            },
+            }),
           ],
         }),
       },
@@ -84,5 +144,195 @@ describe("scheduled-function selection", () => {
 
     expect(due).toHaveLength(1);
     expect(due[0]).toMatchObject({ ref: "proj_1", schedule: { slug: "cleanup" } });
+  });
+
+  test("skips an invalid legacy schedule without blocking valid schedules", () => {
+    const due = scheduledFunctionsDueAt([{
+      ref: "proj_1",
+      config: {
+        scheduled_functions: [
+          scheduleConfig({}, {
+            id: "00000000-0000-4000-8000-000000000002",
+            name: "Invalid",
+            slug: "invalid",
+            cron: "0-999999999 * * * *",
+          }),
+          scheduleConfig({}, { name: "Valid", slug: "valid" }),
+        ],
+      },
+    }], new Date("2026-06-15T10:30:00Z"));
+
+    expect(due).toHaveLength(1);
+    expect(due[0].schedule.slug).toBe("valid");
+  });
+
+  test.each([
+    ["empty name", { name: "" }],
+    ["overlong name", { name: "x".repeat(121) }],
+    ["overlong slug", { slug: "x".repeat(129) }],
+  ])("skips a schedule with %s", (_label, invalidFields) => {
+    const due = scheduledFunctionsDueAt([{
+      ref: "proj_1",
+      config: {
+        scheduled_functions: [scheduleConfig({}, invalidFields)],
+      },
+    }], new Date("2026-06-15T10:30:00Z"));
+
+    expect(due).toEqual([]);
+  });
+
+  test("skips a non-UUID schedule instead of dispatching hidden legacy config", () => {
+    const due = scheduledFunctionsDueAt([{
+      ref: "proj_1",
+      config: {
+        scheduled_functions: [scheduleConfig({}, { id: "hidden-noncanonical" })],
+      },
+    }], new Date("2026-06-15T10:30:00Z"));
+
+    expect(due).toEqual([]);
+  });
+});
+
+describe("scheduled-function invocation boundary", () => {
+  test("rejects a non-UUID schedule before project lookup or fetch", async () => {
+    let fetchCount = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCount += 1;
+      return Response.json({});
+    }) as typeof fetch;
+    const findByRef = spyOn(projectRepository, "findByRef");
+    try {
+      const result = await scheduledFunctionWorker.triggerOnce(
+        "proj_a",
+        scheduleConfig({}, { id: "hidden-noncanonical" }),
+      );
+
+      expect(result).toEqual({ ok: false, error: "SCHEDULE_CONFIG_INVALID" });
+      expect(findByRef).not.toHaveBeenCalled();
+      expect(fetchCount).toBe(0);
+    } finally {
+      findByRef.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test.each([
+    "X-Project-Ref",
+    "APIKEY",
+    "authorization",
+    "host",
+    "connection",
+    "content-length",
+    "transfer-encoding",
+    "proxy-authorization",
+    "forwarded",
+    "x-forwarded-host",
+  ])(
+    "rejects platform header %s before project lookup or fetch",
+    async (headerName) => {
+      let fetchCount = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        fetchCount += 1;
+        return Response.json({});
+      }) as typeof fetch;
+      const findByRef = spyOn(projectRepository, "findByRef");
+      try {
+        const result = await scheduledFunctionWorker.triggerOnce(
+          "proj_a",
+          scheduleConfig({ [headerName]: "private-platform-sentinel" }),
+        );
+
+        expect(result).toEqual({ ok: false, error: "SCHEDULE_HEADERS_INVALID" });
+        expect(findByRef).not.toHaveBeenCalled();
+        expect(fetchCount).toBe(0);
+      } finally {
+        findByRef.mockRestore();
+        globalThis.fetch = originalFetch;
+      }
+    },
+  );
+
+  test("skips a body over 1 MiB before project lookup or fetch", async () => {
+    let fetchCount = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetchCount += 1;
+      return Response.json({});
+    }) as typeof fetch;
+    const findByRef = spyOn(projectRepository, "findByRef");
+    try {
+      const result = await scheduledFunctionWorker.triggerOnce(
+        "proj_a",
+        scheduleConfig({}, { body: { payload: "x".repeat(MAX_SCHEDULE_BODY_BYTES) } }),
+      );
+
+      expect(result).toEqual({ ok: false, error: "SCHEDULE_CONFIG_INVALID" });
+      expect(findByRef).not.toHaveBeenCalled();
+      expect(fetchCount).toBe(0);
+    } finally {
+      findByRef.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("keeps invalid header values out of invocation errors", async () => {
+    const secretSentinel = "private-invalid-worker-header-sentinel\n";
+    const result = await scheduledFunctionWorker.triggerOnce(
+      "proj_a",
+      scheduleConfig({ "x-schedule-token": secretSentinel }),
+    );
+
+    expect(result).toEqual({ ok: false, error: "SCHEDULE_HEADERS_INVALID" });
+    expect(result.error).not.toContain(secretSentinel.trim());
+  });
+
+  test("applies platform routing and auth headers after custom headers", async () => {
+    const serviceRole = "private-service-role-sentinel";
+    const originalFetch = globalThis.fetch;
+    let receivedHeaders: Headers | null = null;
+    globalThis.fetch = (async (_url, init) => {
+      receivedHeaders = new Headers(init?.headers);
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+    const findByRef = spyOn(projectRepository, "findByRef").mockResolvedValue({
+      service_role_key: serviceRole,
+    } as never);
+    try {
+      const result = await scheduledFunctionWorker.triggerOnce(
+        "proj_a",
+        scheduleConfig({ "x-schedule-token": "custom-token" }),
+      );
+
+      expect(result).toEqual({ ok: true, status: 200 });
+      expect(receivedHeaders?.get("x-project-ref")).toBe("proj_a");
+      expect(receivedHeaders?.get("apikey")).toBe(serviceRole);
+      expect(receivedHeaders?.get("authorization")).toBe(`Bearer ${serviceRole}`);
+      expect(receivedHeaders?.get("x-schedule-token")).toBe("custom-token");
+    } finally {
+      findByRef.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("redacts underlying fetch errors from invocation results", async () => {
+    const errorSentinel = "private-fetch-error-sentinel";
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error(errorSentinel);
+    }) as typeof fetch;
+    const findByRef = spyOn(projectRepository, "findByRef").mockResolvedValue({
+      service_role_key: "private-service-role-sentinel",
+    } as never);
+    try {
+      const result = await scheduledFunctionWorker.triggerOnce("proj_a", scheduleConfig({}));
+
+      expect(result).toEqual({ ok: false, error: "SCHEDULE_INVOKE_FAILED" });
+      expect(result.error).not.toContain(errorSentinel);
+    } finally {
+      findByRef.mockRestore();
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/management-api/tests/unit/scheduled-functions.routes.test.ts
+++ b/packages/management-api/tests/unit/scheduled-functions.routes.test.ts
@@ -21,7 +21,11 @@ const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAut
 const reloadSpy = spyOn(workerModule.scheduledFunctionWorker, "reload").mockImplementation(() => {});
 
 const { scheduledFunctionRoutes } = await import("../../src/routes/scheduled-functions");
+const { MAX_SCHEDULE_BODY_BYTES } = await import("../../src/utils/scheduled-function-config");
 const app = new Elysia().use(scheduledFunctionRoutes);
+const SCHEDULE_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_SCHEDULE_ID = "00000000-0000-4000-8000-000000000002";
+const REQUEST_ID = "00000000-0000-4000-8000-000000000003";
 
 function request(path: string, init: RequestInit = {}) {
   return app.handle(
@@ -30,6 +34,11 @@ function request(path: string, init: RequestInit = {}) {
       headers: { "content-type": "application/json", ...(init.headers || {}) },
     }),
   );
+}
+
+function bodyWithSerializedBytes(serializedBytes: number): Record<string, string> {
+  const emptyBodyBytes = new TextEncoder().encode(JSON.stringify({ payload: "" })).byteLength;
+  return { payload: "x".repeat(serializedBytes - emptyBodyBytes) };
 }
 
 describe("scheduledFunctionRoutes", () => {
@@ -55,6 +64,50 @@ describe("scheduledFunctionRoutes", () => {
     expect(body.schedules).toEqual([]);
   });
 
+  test("GET exposes schedule metadata without stored body or header values", async () => {
+    const bodySentinel = "private-body-sentinel";
+    const headerSentinel = "private-header-sentinel";
+    findByRef.mockResolvedValue({
+      ref: "proj_1",
+      config: {
+        scheduled_functions: [{
+          id: SCHEDULE_ID,
+          name: "Nightly",
+          slug: "worker",
+          cron: "0 2 * * *",
+          method: "POST",
+          body: { token: bodySentinel },
+          headers: { "x-schedule-token": headerSentinel },
+          enabled: true,
+          created_at: "2026-08-11T00:00:00.000Z",
+          updated_at: "2026-08-11T00:00:00.000Z",
+        }],
+      },
+    } as never);
+
+    const res = await request("/v1/projects/proj_1/scheduled-functions");
+    const responseText = await res.text();
+    const responseBody = JSON.parse(responseText);
+
+    expect(res.status).toBe(200);
+    expect(responseBody.schedules[0]).toMatchObject({
+      body_empty: false,
+      header_names: ["x-schedule-token"],
+    });
+    expect(responseBody.schedules[0]).not.toHaveProperty("body");
+    expect(responseBody.schedules[0]).not.toHaveProperty("headers");
+    expect(responseText).not.toContain(bodySentinel);
+    expect(responseText).not.toContain(headerSentinel);
+  });
+
+  test("GET rejects an invalid project ref before authorization or repository access", async () => {
+    const res = await request("/v1/projects/bad.ref/scheduled-functions");
+
+    expect(res.status).toBe(400);
+    expect(requireProjectOrAdminAuth).not.toHaveBeenCalled();
+    expect(findByRef).not.toHaveBeenCalled();
+  });
+
   test("POST creates a schedule and signals worker reload", async () => {
     findByRef.mockResolvedValue({ ref: "proj_1", config: {} } as never);
     updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
@@ -62,41 +115,111 @@ describe("scheduledFunctionRoutes", () => {
     const res = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
       body: JSON.stringify({
+        request_id: REQUEST_ID,
         name: "Nightly Cleanup",
         slug: "cleanup",
         cron: "0 2 * * *",
         method: "POST",
         body: { mode: "deep" },
+        headers: { "X-Schedule-Token": "token" },
       }),
     });
 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.created).toBe(true);
+    expect(body.request_id).toBe(REQUEST_ID);
     expect(body.schedule).toMatchObject({
       name: "Nightly Cleanup",
       slug: "cleanup",
       cron: "0 2 * * *",
       method: "POST",
       enabled: true,
+      body_empty: false,
+      header_names: ["x-schedule-token"],
     });
+    expect(body.schedule).not.toHaveProperty("body");
+    expect(body.schedule).not.toHaveProperty("headers");
     expect(reloadSpy).toHaveBeenCalledTimes(1);
     const stored = updateConfig.mock.calls[0][1];
     expect(stored.scheduled_functions[0].body).toEqual({ mode: "deep" });
+    expect(stored.scheduled_functions[0].headers).toEqual({ "x-schedule-token": "token" });
   });
 
   test("POST rejects invalid cron and slug", async () => {
     const badCron = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
-      body: JSON.stringify({ name: "x", slug: "fn", cron: "not-cron", method: "POST" }),
+      body: JSON.stringify({ request_id: REQUEST_ID, name: "x", slug: "fn", cron: "not-cron", method: "POST" }),
     });
     expect(badCron.status).toBe(400);
 
     const badSlug = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
-      body: JSON.stringify({ name: "x", slug: "bad slug!", cron: "* * * * *", method: "POST" }),
+      body: JSON.stringify({ request_id: REQUEST_ID, name: "x", slug: "bad slug!", cron: "* * * * *", method: "POST" }),
     });
     expect(badSlug.status).toBe(400);
+  });
+
+  test("POST rejects a slug the worker cannot invoke", async () => {
+    const res = await request("/v1/projects/proj_1/scheduled-functions", {
+      method: "POST",
+      body: JSON.stringify({
+        request_id: REQUEST_ID,
+        name: "x",
+        slug: "a".repeat(129),
+        cron: "* * * * *",
+        method: "POST",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "0-999999999 * * * *",
+    "*/999999999 * * * *",
+    "60 * * * *",
+    "*/0 * * * *",
+  ])("POST rejects unsafe cron %s before repository writes", async (cron) => {
+    const res = await request("/v1/projects/proj_1/scheduled-functions", {
+      method: "POST",
+      body: JSON.stringify({ request_id: REQUEST_ID, name: "x", slug: "fn", cron, method: "POST" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["reserved routing header", { "X-Project-Ref": "other-project" }],
+    ["reserved auth header", { Authorization: "private-auth-sentinel" }],
+    ["host header", { Host: "attacker.invalid" }],
+    ["hop-by-hop header", { Connection: "keep-alive" }],
+    ["framing header", { "Content-Length": "5" }],
+    ["transfer framing header", { "Transfer-Encoding": "chunked" }],
+    ["TE header", { TE: "trailers" }],
+    ["trailer header", { Trailer: "x-checksum" }],
+    ["upgrade header", { Upgrade: "websocket" }],
+    ["proxy auth header", { "Proxy-Authorization": "private-proxy-sentinel" }],
+    ["standard forwarded header", { Forwarded: "host=attacker.invalid" }],
+    ["forwarded header", { "X-Forwarded-Host": "attacker.invalid" }],
+    ["case-insensitive duplicate", { "X-Schedule-Token": "one", "x-schedule-token": "two" }],
+    ["invalid value", { "x-schedule-token": "private-invalid-sentinel\n" }],
+  ])("POST rejects %s without exposing header values", async (_label, headers) => {
+    const res = await request("/v1/projects/proj_1/scheduled-functions", {
+      method: "POST",
+      body: JSON.stringify({ request_id: REQUEST_ID, name: "x", slug: "fn", cron: "* * * * *", method: "POST", headers }),
+    });
+    const responseBody = await res.text();
+
+    expect(res.status).toBe(400);
+    expect(responseBody).toContain("SCHEDULE_HEADERS_INVALID");
+    expect(responseBody).not.toContain("private-");
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
   });
 
   test("POST rejects duplicate slug with 409", async () => {
@@ -104,16 +227,35 @@ describe("scheduledFunctionRoutes", () => {
       ref: "proj_1",
       config: {
         scheduled_functions: [
-          { id: "s1", name: "old", slug: "cleanup", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
+          { id: SCHEDULE_ID, name: "old", slug: "cleanup", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
         ],
       },
     } as never);
 
     const res = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
-      body: JSON.stringify({ name: "new", slug: "cleanup", cron: "0 1 * * *", method: "POST" }),
+      body: JSON.stringify({ request_id: REQUEST_ID, name: "new", slug: "cleanup", cron: "0 1 * * *", method: "POST" }),
     });
     expect(res.status).toBe(409);
+  });
+
+  test("POST checks duplicate slugs after normalization", async () => {
+    findByRef.mockResolvedValue({
+      ref: "proj_1",
+      config: {
+        scheduled_functions: [
+          { id: SCHEDULE_ID, name: "old", slug: "cleanup", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
+        ],
+      },
+    } as never);
+
+    const res = await request("/v1/projects/proj_1/scheduled-functions", {
+      method: "POST",
+      body: JSON.stringify({ request_id: REQUEST_ID, name: "dup", slug: " cleanup ", cron: "0 1 * * *", method: "POST" }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(updateConfig).not.toHaveBeenCalled();
   });
 
   test("PATCH toggles enabled", async () => {
@@ -121,19 +263,116 @@ describe("scheduledFunctionRoutes", () => {
       ref: "proj_1",
       config: {
         scheduled_functions: [
-          { id: "s1", name: "old", slug: "fn", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
+          { id: SCHEDULE_ID, name: "old", slug: "fn", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
         ],
       },
     } as never);
     updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
 
-    const res = await request("/v1/projects/proj_1/scheduled-functions/s1", {
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ enabled: false }),
+      body: JSON.stringify({ request_id: REQUEST_ID, enabled: false }),
     });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.schedule.enabled).toBe(false);
+    expect(body.request_id).toBe(REQUEST_ID);
+  });
+
+  test("PATCH rejects unsafe cron before repository writes", async () => {
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ request_id: REQUEST_ID, cron: "0-999999999 * * * *" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("PATCH rejects platform headers before repository writes", async () => {
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ request_id: REQUEST_ID, headers: { apikey: "private-api-key-sentinel" } }),
+    });
+    const responseBody = await res.text();
+
+    expect(res.status).toBe(400);
+    expect(responseBody).toContain("SCHEDULE_HEADERS_INVALID");
+    expect(responseBody).not.toContain("private-api-key-sentinel");
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test.each(["PATCH", "DELETE"])("%s rejects a non-canonical schedule ID before repository access", async (method) => {
+    const res = await request("/v1/projects/proj_1/scheduled-functions/not-a-uuid", {
+      method,
+      ...(method === "PATCH" ? { body: JSON.stringify({ request_id: REQUEST_ID, name: "Unsafe" }) } : {}),
+    });
+
+    expect(res.status).toBe(400);
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test.each(["", " ", "x".repeat(121)])("PATCH rejects invalid name %j before repository access", async (name) => {
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ request_id: REQUEST_ID, name }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("PATCH rejects a request ID without mutation fields", async () => {
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ request_id: REQUEST_ID }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  test("POST accepts a body exactly 1 MiB after JSON serialization", async () => {
+    findByRef.mockResolvedValue({ ref: "proj_1", config: {} } as never);
+    updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
+    const res = await request("/v1/projects/proj_1/scheduled-functions", {
+      method: "POST",
+      body: JSON.stringify({
+        request_id: REQUEST_ID,
+        name: "Boundary",
+        slug: "worker",
+        cron: "* * * * *",
+        method: "POST",
+        body: bodyWithSerializedBytes(MAX_SCHEDULE_BODY_BYTES),
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(updateConfig).toHaveBeenCalledTimes(1);
+  });
+
+  test("POST rejects a serialized body over 1 MiB without repository access", async () => {
+    const res = await request("/v1/projects/proj_1/scheduled-functions", {
+      method: "POST",
+      body: JSON.stringify({
+        request_id: REQUEST_ID,
+        name: "Oversized",
+        slug: "worker",
+        cron: "* * * * *",
+        method: "POST",
+        body: bodyWithSerializedBytes(MAX_SCHEDULE_BODY_BYTES + 1),
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("SCHEDULE_BODY_INVALID");
+    expect(findByRef).not.toHaveBeenCalled();
+    expect(updateConfig).not.toHaveBeenCalled();
   });
 
   test("DELETE removes schedule", async () => {
@@ -141,13 +380,13 @@ describe("scheduledFunctionRoutes", () => {
       ref: "proj_1",
       config: {
         scheduled_functions: [
-          { id: "s2", name: "old", slug: "fn", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
+          { id: OTHER_SCHEDULE_ID, name: "old", slug: "fn", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
         ],
       },
     } as never);
     updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
 
-    const res = await request("/v1/projects/proj_1/scheduled-functions/s2", { method: "DELETE" });
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${OTHER_SCHEDULE_ID}`, { method: "DELETE" });
     expect(res.status).toBe(200);
     const stored = updateConfig.mock.calls[0][1];
     expect(stored.scheduled_functions).toEqual([]);


### PR DESCRIPTION
## Summary

- add the supported scheduled_functions CLI lifecycle for list, create, update, and delete
- add exact receipt validation, UUIDv4 request correlation, mutation outcome-unknown semantics, and non-retrying mutation transport
- keep body and header values outside argv and CLI output while exposing only body_empty and header_names metadata
- harden Management API cron, name, slug, body-size, header, project settings, and worker execution boundaries
- add structured immutable Edge Function version activation and reject activate-only path input before file or HTTP access

## Safety contracts

- transport errors never expose underlying error messages
- HTTP 408, transport failures, and all 5xx mutation responses return OUTCOME_UNKNOWN
- generic project settings cannot write scheduled_functions; dedicated routes are required
- worker dispatch requires a complete canonical UUIDv4 schedule and rejects reserved routing/auth headers
- project and settings responses redact schedule body/header values idempotently

## Validation

- CLI: 201 pass, 0 fail; typecheck PASS; build PASS
- Management API: complete test:local PASS including SQL sync, unit, API, and integration suites; typecheck PASS
- focused release-control regression: 85 pass, 0 fail
- independent security review: PASS; all four real Elysia/worker bypass reproductions closed
- git diff --check PASS

No npm publication or server deployment was performed by this PR.