### PR TITLE
fix(cli): harden environment secret boundaries

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -75,6 +75,20 @@ function serveFunctionSource(sourceCode: string): string {
     return `http://127.0.0.1:${server.port}`;
 }
 
+function chunkedJsonResponse(body: string): Response {
+    const bytes = new TextEncoder().encode(body);
+    let offset = 0;
+    const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (offset >= bytes.byteLength) return controller.close();
+            const nextOffset = Math.min(offset + 256 * 1024, bytes.byteLength);
+            controller.enqueue(bytes.subarray(offset, nextOffset));
+            offset = nextOffset;
+        },
+    });
+    return new Response(stream, { headers: { "Content-Type": "application/json" } });
+}
+
 describe("supacloud-cli process contract", () => {
     test("documents global environment and production safety flags", async () => {
         const response = await runProjectCli(["--help"]);
@@ -468,6 +482,30 @@ describe("supacloud-cli process contract", () => {
         expect(response.exitCode).toBe(1);
         expect(response.stdout.trim()).toBe("❌ Project secret list response is invalid");
         expect(response.stdout + response.stderr).not.toContain("sentinel");
+    });
+
+    test("rejects a valid JSON secret list whose raw chunked body exceeds 1 MiB", async () => {
+        const oversizedBody = `${" ".repeat(1024 * 1024 + 1)}[]`;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => chunkedJsonResponse(oversizedBody),
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["secrets", "list", "--ref", "abc123"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(Buffer.byteLength(oversizedBody)).toBe(1_048_579);
+        expect(response.exitCode).toBe(1);
+        expect(response.stdout.trim()).toBe("❌ Project secret list response is invalid");
+        expect(response.stderr).toBe("");
     });
 
     test.each([

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -400,6 +400,75 @@ describe("supacloud-cli process contract", () => {
     });
 
     test.each([
+        ["masked projection", [
+            { name: "API_KEY", value: "********", internal: "projection-secret-sentinel" },
+        ], [{ name: "API_KEY", value: "********" }]],
+        ["empty list", [], []],
+    ])("prints only the local %s for a valid secret list", async (_label, payload, expected) => {
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json(payload),
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["secrets", "list", "--ref", "abc123"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toEqual(expected);
+        expect(response.stdout + response.stderr).not.toContain("projection-secret-sentinel");
+    });
+
+    test.each([
+        ["free text", "list-free-text-secret-sentinel"],
+        ["object", { error: "list-object-secret-sentinel" }],
+        ["plaintext value", [{ name: "API_KEY", value: "plaintext-secret-sentinel" }]],
+        ["non-string name", [{ name: 7, value: "********", leak: "non-string-name-sentinel" }]],
+        ["dangerous name", [{ name: "API-KEY", value: "********", leak: "dangerous-name-sentinel" }]],
+        ["duplicate name", [
+            { name: "API_KEY", value: "********" },
+            { name: "API_KEY", value: "********", leak: "duplicate-name-sentinel" },
+        ]],
+        ["too many entries", Array.from({ length: 1025 }, (_, index) => ({
+            name: `KEY_${index}`,
+            value: "********",
+            leak: index === 0 ? "too-many-entries-sentinel" : undefined,
+        }))],
+        ["oversized response", [{
+            name: "API_KEY",
+            value: "********",
+            leak: `oversized-list-sentinel-${"x".repeat(1024 * 1024)}`,
+        }]],
+    ])("rejects a 200 %s secret list without reflection", async (_label, payload) => {
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json(payload),
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["secrets", "list", "--ref", "abc123"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stdout.trim()).toBe("❌ Project secret list response is invalid");
+        expect(response.stdout + response.stderr).not.toContain("sentinel");
+    });
+
+    test.each([
         ["missing value", "FA_CLI_FROM_ENV_MISSING", {}],
         ["empty value", "FA_CLI_FROM_ENV_EMPTY", { FA_CLI_FROM_ENV_EMPTY: "" }],
         ["invalid name", "FA-CLI-INVALID", {}],
@@ -429,6 +498,71 @@ describe("supacloud-cli process contract", () => {
         expect(response.exitCode).toBe(1);
         expect(requestCount).toBe(0);
         expect(response.stdout + response.stderr).not.toContain("never-printed-secret");
+    });
+
+    test("rejects a repeated from-env flag before HTTP without reading its value", async () => {
+        let requestCount = 0;
+        const secretSentinel = "duplicate-flag-secret-sentinel";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "secrets", "upsert", "--ref", "abc123",
+                "--from-env", "API_KEY", "--from-env=API_KEY",
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                API_KEY: secretSentinel,
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("Duplicate CLI flag is not allowed");
+        expect(response.stdout + response.stderr).not.toContain(secretSentinel);
+    });
+
+    test("preserves string-shaped from-env names before generic CLI coercion", async () => {
+        let requestBody: unknown;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestBody = await request.json();
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            ["secrets", "upsert", "--ref", "abc123", "--from-env", "true,false,Infinity"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                true: "true-secret-sentinel",
+                false: "false-secret-sentinel",
+                Infinity: "infinity-secret-sentinel",
+            },
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(requestBody).toEqual([
+            { name: "true", value: "true-secret-sentinel" },
+            { name: "false", value: "false-secret-sentinel" },
+            { name: "Infinity", value: "infinity-secret-sentinel" },
+        ]);
+        expect(response.stdout + response.stderr).not.toContain("secret-sentinel");
     });
 
     test("rejects mixed secret inputs before HTTP without echoing the inline value", async () => {

--- a/packages/cli/src/shared/cli.ts
+++ b/packages/cli/src/shared/cli.ts
@@ -1,4 +1,5 @@
 import type { TSchema } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
 import {
     parseToolArguments,
     schemaDescription,
@@ -28,6 +29,48 @@ function coerceCliValue(value: string): string | number | boolean {
     if (value === "false") return false;
     if (value.trim() !== "" && !Number.isNaN(Number(value))) return Number(value);
     return value;
+}
+
+const DUPLICATE_CLI_FLAG_MESSAGE = "Duplicate CLI flag is not allowed";
+
+interface CliFlag {
+    name: string;
+    rawValue?: string;
+    nextIndex: number;
+}
+
+function cliFlagAt(args: string[], index: number): CliFlag | null {
+    const argument = args[index];
+    if (!argument.startsWith("--") || argument.length <= 2) return null;
+    const rawFlag = argument.slice(2);
+    const equalsIndex = rawFlag.indexOf("=");
+    if (equalsIndex >= 0) {
+        return { name: rawFlag.slice(0, equalsIndex), rawValue: rawFlag.slice(equalsIndex + 1), nextIndex: index };
+    }
+    const nextArgument = args[index + 1];
+    if (nextArgument !== undefined && !nextArgument.startsWith("--")) {
+        return { name: rawFlag, rawValue: nextArgument, nextIndex: index + 1 };
+    }
+    return { name: rawFlag, nextIndex: index };
+}
+
+function schemaCompatibleCliValue(field: TSchema | undefined, rawValue: string): string | number | boolean {
+    return field && Value.Check(field, rawValue) ? rawValue : coerceCliValue(rawValue);
+}
+
+function parseCliFlags(args: string[], startIndex: number, schema: ToolSchema): Record<string, unknown> {
+    const parsedFlags: Record<string, unknown> = Object.create(null);
+    const fields = schemaProperties(schema);
+    for (let index = startIndex; index < args.length; index++) {
+        const flag = cliFlagAt(args, index);
+        if (!flag) continue;
+        index = flag.nextIndex;
+        if (Object.hasOwn(parsedFlags, flag.name)) throw new Error(DUPLICATE_CLI_FLAG_MESSAGE);
+        parsedFlags[flag.name] = flag.rawValue === undefined
+            ? true
+            : schemaCompatibleCliValue(fields[flag.name], flag.rawValue);
+    }
+    return parsedFlags;
 }
 
 export async function runCli(
@@ -128,32 +171,16 @@ export async function runCli(
         return;
     }
     
-    const parsedArgs: Record<string, any> = {};
     let startIdx = 1;
 
     // Check if there is an action argument (assuming index 1 is action if not starting with '--')
     if (args.length > 1 && !args[1].startsWith("--")) {
-        parsedArgs.action = args[1];
         startIdx = 2;
     }
-    
-    for (let i = startIdx; i < args.length; i++) {
-        const arg = args[i];
-        if (arg.startsWith("--") && arg.length > 2) {
-            const rawFlag = arg.slice(2);
-            const equalsIndex = rawFlag.indexOf("=");
-            const key = equalsIndex >= 0 ? rawFlag.slice(0, equalsIndex) : rawFlag;
-            let val: string | number | boolean = true;
-            if (equalsIndex >= 0) {
-                val = coerceCliValue(rawFlag.slice(equalsIndex + 1));
-            } else if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
-                val = coerceCliValue(args[++i]);
-            }
-            parsedArgs[key] = val;
-        }
-    }
-    
+
     try {
+        const parsedArgs = parseCliFlags(args, startIdx, tool.schema);
+        if (startIdx === 2) parsedArgs.action = args[1];
         const validatedArgs = parseToolArguments(tool.schema, parsedArgs);
 
         const result = await tool.callback(validatedArgs) as CliToolResult;

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -281,6 +281,59 @@ describe("secrets CLI tool", () => {
         expect(response.content[0].text).not.toContain(responseBodySentinel);
     });
 
+    test("projects valid masked secret lists without unknown response fields", async () => {
+        const unknownFieldSentinel = "unknown-field-secret-sentinel";
+        const { callback } = captureSecretsTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: [
+                    { name: "API_KEY", value: "********", internal: unknownFieldSentinel },
+                    { name: "WEBHOOK_SECRET", value: "********" },
+                ],
+            }),
+        });
+
+        const response = await callback({ action: "list", ref: "proj" });
+
+        expect(JSON.parse(response.content[0].text)).toEqual([
+            { name: "API_KEY", value: "********" },
+            { name: "WEBHOOK_SECRET", value: "********" },
+        ]);
+        expect(response.content[0].text).not.toContain(unknownFieldSentinel);
+    });
+
+    test.each([
+        ["free text", "list-free-text-secret-sentinel"],
+        ["object", { error: "list-object-secret-sentinel" }],
+        ["plaintext value", [{ name: "API_KEY", value: "plaintext-secret-sentinel" }]],
+        ["non-string name", [{ name: 7, value: "********", leak: "non-string-name-sentinel" }]],
+        ["dangerous name", [{ name: "API-KEY", value: "********", leak: "dangerous-name-sentinel" }]],
+        ["duplicate name", [
+            { name: "API_KEY", value: "********" },
+            { name: "API_KEY", value: "********", leak: "duplicate-name-sentinel" },
+        ]],
+        ["too many entries", Array.from({ length: 1025 }, (_, index) => ({
+            name: `KEY_${index}`,
+            value: "********",
+            leak: index === 0 ? "too-many-entries-sentinel" : undefined,
+        }))],
+        ["oversized response", [{
+            name: "API_KEY",
+            value: "********",
+            leak: `oversized-list-sentinel-${"x".repeat(1024 * 1024)}`,
+        }]],
+    ])("rejects a 2xx %s secret list without reflecting it", async (_label, payload) => {
+        const { callback } = captureSecretsTool({
+            get: async () => ({ ok: true, status: 200, data: payload }),
+        });
+
+        const response = await callback({ action: "list", ref: "proj" });
+
+        expect(response.content[0].text).toBe("❌ Project secret list response is invalid");
+        expect(response.content[0].text).not.toContain("sentinel");
+    });
+
     test("parses JSON array secrets passed as a CLI string", () => {
         const { schema } = captureSecretsTool({});
         const parsed = parseToolArguments(schema, {
@@ -318,18 +371,25 @@ describe("secrets CLI tool", () => {
     });
 
     test.each([
-        ["empty entries", "API_KEY,,WEBHOOK_SECRET", "non-empty comma-separated list"],
-        ["invalid names", "API-KEY", "Invalid environment secret name 'API-KEY'"],
-        ["overlong names", `A${"B".repeat(256)}`, "Invalid environment secret name"],
-        ["duplicate names", "API_KEY,API_KEY", "Duplicate environment secret name 'API_KEY'"],
-    ])("rejects %s before resolving environment values", (_label, names, expectedMessage) => {
+        ["empty entries", "API_KEY,,WEBHOOK_SECRET"],
+        ["invalid names", "API-KEY-secret-name-sentinel"],
+        ["overlong names", `A${"B".repeat(256)}-secret-name-sentinel`],
+        ["duplicate names", "API_KEY,API_KEY"],
+        ["too many names", Array.from({ length: 1025 }, (_, index) => `KEY_${index}`).join(",")],
+    ])("rejects %s without reflecting input", (_label, names) => {
         const { schema } = captureSecretsTool({});
 
         expect(() => parseToolArguments(schema, {
             action: "upsert",
             ref: "proj",
             "from-env": names,
-        })).toThrow(expectedMessage);
+        })).toThrow("Environment secret names are invalid");
+
+        try {
+            parseToolArguments(schema, { action: "upsert", ref: "proj", "from-env": names });
+        } catch (error) {
+            expect(String(error)).not.toContain("secret-name-sentinel");
+        }
     });
 
     test("reads secret values from the CLI environment without echoing them", async () => {
@@ -380,7 +440,63 @@ describe("secrets CLI tool", () => {
             action: "upsert",
             ref: "proj",
             "from-env": ["API_KEY"],
-        })).rejects.toThrow("Environment variable 'API_KEY' must be set to a non-empty value");
+        })).rejects.toThrow("Environment secret values are missing or exceed safe limits");
+        expect(requestCount).toBe(0);
+    });
+
+    test("reads each requested environment value exactly once", async () => {
+        const reads = new Map<string, number>();
+        const environment = new Proxy({ API_KEY: "primary", WEBHOOK_SECRET: "secondary" }, {
+            get(target, name: string) {
+                reads.set(name, (reads.get(name) ?? 0) + 1);
+                return target[name as keyof typeof target];
+            },
+        });
+        const { callback } = captureSecretsTool({
+            post: async () => ({ ok: true, status: 200, data: {} }),
+        }, environment);
+
+        await callback({
+            action: "upsert",
+            ref: "proj",
+            "from-env": ["API_KEY", "WEBHOOK_SECRET"],
+        });
+
+        expect(Object.fromEntries(reads)).toEqual({ API_KEY: 1, WEBHOOK_SECRET: 1 });
+    });
+
+    test("accepts an environment value at the exact UTF-8 byte limit", async () => {
+        const boundarySecret = "界".repeat(8192);
+        let requestBody: unknown;
+        const { callback } = captureSecretsTool({
+            post: async (_path: string, body: unknown) => {
+                requestBody = body;
+                return { ok: true, status: 200, data: {} };
+            },
+        }, { API_KEY: boundarySecret });
+
+        await callback({ action: "upsert", ref: "proj", "from-env": ["API_KEY"] });
+
+        expect(Buffer.byteLength(boundarySecret)).toBe(24 * 1024);
+        expect(requestBody).toEqual([{ name: "API_KEY", value: boundarySecret }]);
+    });
+
+    test.each([
+        ["oversized value", ["API_KEY"], { API_KEY: "x".repeat(24 * 1024 + 1) }],
+        ["oversized multibyte value", ["API_KEY"], { API_KEY: "界".repeat(8193) }],
+        ["oversized request", Array.from({ length: 1024 }, (_, index) => `KEY_${index}`),
+            Object.fromEntries(Array.from({ length: 1024 }, (_, index) => [`KEY_${index}`, "x".repeat(1024)]))],
+    ])("rejects an %s before HTTP", async (_label, names, environment) => {
+        let requestCount = 0;
+        const { callback } = captureSecretsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        }, environment);
+
+        await expect(callback({ action: "upsert", ref: "proj", "from-env": names }))
+            .rejects.toThrow("Environment secret values are missing or exceed safe limits");
         expect(requestCount).toBe(0);
     });
 

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -527,7 +527,9 @@ Actions: list, upsert, delete`,
             let text: string;
             switch (action) {
                 case "list": {
-                    const response = await http.get(`/v1/projects/${ref}/secrets`);
+                    const response = await http.get(`/v1/projects/${ref}/secrets`, {
+                        maxResponseBytes: MAX_SECRET_JSON_BYTES,
+                    });
                     if (!response.ok) {
                         text = `❌ Failed (${response.status})`;
                         break;

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -93,6 +93,12 @@ const functionFilesSchema = decodedSchema(
 
 const secretListSchema = Type.Array(Type.Object({ name: Type.String(), value: Type.String() }));
 const ENVIRONMENT_SECRET_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,255}$/;
+const MAX_SECRET_COUNT = 1024;
+const MAX_ENVIRONMENT_SECRET_BYTES = 24 * 1024;
+const MAX_SECRET_JSON_BYTES = 1024 * 1024;
+const INVALID_ENVIRONMENT_SECRET_NAMES_MESSAGE = "Environment secret names are invalid";
+const INVALID_ENVIRONMENT_SECRET_VALUES_MESSAGE = "Environment secret values are missing or exceed safe limits";
+const INVALID_SECRET_LIST_RESPONSE = "❌ Project secret list response is invalid";
 
 type SecretEntry = { name: string; value: string };
 
@@ -124,39 +130,83 @@ const secretsSchema = Type.Optional(decodedSchema(
     parseSecrets,
 ));
 
+function validEnvironmentSecretNames(names: string[]): boolean {
+    if (names.length === 0 || names.length > MAX_SECRET_COUNT) return false;
+    const uniqueNames = new Set<string>();
+    for (const name of names) {
+        if (!ENVIRONMENT_SECRET_NAME_PATTERN.test(name) || uniqueNames.has(name)) return false;
+        uniqueNames.add(name);
+    }
+    return true;
+}
+
 function parseEnvironmentSecretNames(input: string): unknown {
-    const names = input.split(",").map((name) => name.trim());
-    if (names.some((name) => name.length === 0)) {
-        throw new Error("Environment secret names must be a non-empty comma-separated list");
-    }
-    const invalidName = names.find((name) => !ENVIRONMENT_SECRET_NAME_PATTERN.test(name));
-    if (invalidName) {
-        throw new Error(`Invalid environment secret name '${invalidName}'`);
-    }
-    const duplicateName = names.find((name, index) => names.indexOf(name) !== index);
-    if (duplicateName) {
-        throw new Error(`Duplicate environment secret name '${duplicateName}'`);
+    const names = input.split(",", MAX_SECRET_COUNT + 1).map((name) => name.trim());
+    if (!validEnvironmentSecretNames(names)) {
+        throw new Error(INVALID_ENVIRONMENT_SECRET_NAMES_MESSAGE);
     }
     return names;
 }
 
 const environmentSecretNamesSchema = Type.Optional(decodedSchema(
     Type.String(),
-    Type.Array(Type.String(), { minItems: 1, uniqueItems: true }),
+    Type.Array(Type.String({ pattern: ENVIRONMENT_SECRET_NAME_PATTERN.source }), {
+        minItems: 1,
+        maxItems: MAX_SECRET_COUNT,
+        uniqueItems: true,
+    }),
     parseEnvironmentSecretNames,
 ));
+
+function jsonWithinSecretLimit(payload: unknown): boolean {
+    try {
+        const serializedPayload = JSON.stringify(payload);
+        return serializedPayload !== undefined
+            && Buffer.byteLength(serializedPayload) <= MAX_SECRET_JSON_BYTES;
+    } catch (error) {
+        if (error instanceof TypeError) return false;
+        throw error;
+    }
+}
+
+function maskedSecretEntry(candidate: unknown): SecretEntry | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const { name, value } = candidate as Record<string, unknown>;
+    if (typeof name !== "string" || !ENVIRONMENT_SECRET_NAME_PATTERN.test(name)) return null;
+    if (value !== "********") return null;
+    return { name, value: "********" };
+}
+
+function projectedMaskedSecrets(payload: unknown): SecretEntry[] | null {
+    if (!Array.isArray(payload) || payload.length > MAX_SECRET_COUNT) return null;
+    if (!jsonWithinSecretLimit(payload)) return null;
+    const secretNames = new Set<string>();
+    const projectedSecrets: SecretEntry[] = [];
+    for (const candidate of payload) {
+        const secret = maskedSecretEntry(candidate);
+        if (!secret || secretNames.has(secret.name)) return null;
+        secretNames.add(secret.name);
+        projectedSecrets.push(secret);
+    }
+    return projectedSecrets;
+}
 
 function secretsFromEnvironment(
     names: string[],
     environment: NodeJS.ProcessEnv,
 ): SecretEntry[] {
-    return names.map((name) => {
+    const secrets = names.map((name) => {
         const secretValue = environment[name];
-        if (!secretValue) {
-            throw new Error(`Environment variable '${name}' must be set to a non-empty value`);
+        if (typeof secretValue !== "string" || secretValue.length === 0
+            || Buffer.byteLength(secretValue) > MAX_ENVIRONMENT_SECRET_BYTES) {
+            throw new Error(INVALID_ENVIRONMENT_SECRET_VALUES_MESSAGE);
         }
         return { name, value: secretValue };
     });
+    if (!jsonWithinSecretLimit(secrets)) {
+        throw new Error(INVALID_ENVIRONMENT_SECRET_VALUES_MESSAGE);
+    }
+    return secrets;
 }
 
 function secretsForUpsert(
@@ -381,9 +431,14 @@ Actions: list, upsert, delete`,
             switch (action) {
                 case "list": {
                     const response = await http.get(`/v1/projects/${ref}/secrets`);
-                    text = response.ok
-                        ? JSON.stringify(response.data, null, 2)
-                        : `❌ Failed (${response.status})`;
+                    if (!response.ok) {
+                        text = `❌ Failed (${response.status})`;
+                        break;
+                    }
+                    const maskedSecrets = projectedMaskedSecrets(response.data);
+                    text = maskedSecrets === null
+                        ? INVALID_SECRET_LIST_RESPONSE
+                        : JSON.stringify(maskedSecrets, null, 2);
                     break;
                 }
                 case "upsert":

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -5,9 +5,11 @@ import { HttpTransport } from "./http";
 const originalFetch = globalThis.fetch;
 const originalSetTimeout = globalThis.setTimeout;
 const originalClearTimeout = globalThis.clearTimeout;
+const MAX_TEST_RESPONSE_BYTES = 1024 * 1024;
 
 let clearedTimerIds: Array<ReturnType<typeof setTimeout> | undefined> = [];
 let nextTimerId = 0;
+const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
 
 beforeEach(() => {
     clearedTimerIds = [];
@@ -23,6 +25,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    for (const server of servers.splice(0)) server.stop(true);
     globalThis.fetch = originalFetch;
     globalThis.setTimeout = originalSetTimeout;
     globalThis.clearTimeout = originalClearTimeout;
@@ -37,6 +40,24 @@ function retryableNetworkError(kind: "AbortError" | "ECONNREFUSED" | "ECONNRESET
     if (kind === "AbortError") error.name = kind;
     else Object.assign(error, { code: kind });
     return error;
+}
+
+function whitespaceJson(totalBytes: number): string {
+    return `${" ".repeat(totalBytes - 2)}[]`;
+}
+
+function chunkedTextResponse(body: string): Response {
+    const bytes = new TextEncoder().encode(body);
+    let offset = 0;
+    const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (offset >= bytes.byteLength) return controller.close();
+            const nextOffset = Math.min(offset + 256 * 1024, bytes.byteLength);
+            controller.enqueue(bytes.subarray(offset, nextOffset));
+            offset = nextOffset;
+        },
+    });
+    return new Response(stream, { headers: { "Content-Type": "application/json" } });
 }
 
 describe("HttpTransport retry policy", () => {
@@ -129,5 +150,64 @@ describe("HttpTransport retry policy", () => {
         expect(response.data).toEqual({ error: "Network Error", code: "NETWORK_ERROR" });
         expect(serialized).not.toContain(errorSentinel);
         expect(serialized).not.toContain("details");
+    });
+});
+
+describe("HttpTransport bounded GET responses", () => {
+    test("accepts an exact 1 MiB UTF-8 JSON response", async () => {
+        const body = whitespaceJson(MAX_TEST_RESPONSE_BYTES);
+        globalThis.fetch = (async () => new Response(body, {
+            headers: { "Content-Length": String(MAX_TEST_RESPONSE_BYTES) },
+        })) as unknown as typeof fetch;
+
+        const response = await createTransport().get("/resource", {
+            maxResponseBytes: MAX_TEST_RESPONSE_BYTES,
+        });
+
+        expect(Buffer.byteLength(body)).toBe(MAX_TEST_RESPONSE_BYTES);
+        expect(response).toMatchObject({ ok: true, status: 200, data: [] });
+    });
+
+    test("rejects an advertised response one byte over 1 MiB", async () => {
+        const body = whitespaceJson(MAX_TEST_RESPONSE_BYTES + 1);
+        globalThis.fetch = (async () => new Response(body, {
+            headers: { "Content-Length": String(MAX_TEST_RESPONSE_BYTES + 1) },
+        })) as unknown as typeof fetch;
+
+        const response = await createTransport().get("/resource", {
+            maxResponseBytes: MAX_TEST_RESPONSE_BYTES,
+        });
+
+        expect(response).toMatchObject({ ok: true, status: 200, data: null });
+    });
+
+    test("rejects a chunked response over 1 MiB without Content-Length", async () => {
+        const body = whitespaceJson(MAX_TEST_RESPONSE_BYTES + 1);
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => chunkedTextResponse(body),
+        });
+        servers.push(server);
+        const transport = new HttpTransport({
+            baseUrl: `http://127.0.0.1:${server.port}`,
+            token: "test-token",
+        });
+
+        const response = await transport.get("/resource", {
+            maxResponseBytes: MAX_TEST_RESPONSE_BYTES,
+        });
+
+        expect(response).toMatchObject({ ok: true, status: 200, data: null });
+    });
+
+    test("rejects invalid UTF-8 within the byte limit", async () => {
+        globalThis.fetch = (async () => new Response(new Uint8Array([0xff]))) as unknown as typeof fetch;
+
+        const response = await createTransport().get("/resource", {
+            maxResponseBytes: MAX_TEST_RESPONSE_BYTES,
+        });
+
+        expect(response).toMatchObject({ ok: true, status: 200, data: null });
     });
 });

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -17,6 +17,10 @@ export interface HttpResult<T = unknown> {
     transportError?: boolean;
 }
 
+export interface HttpGetOptions {
+    maxResponseBytes?: number;
+}
+
 const DEFAULT_TIMEOUT = 30_000;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
@@ -87,6 +91,58 @@ async function fetchWithRetry(
     throw new Error("Unreachable");
 }
 
+function declaredResponseTooLarge(response: Response, maxBytes: number): boolean {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength === null || !/^\d+$/.test(contentLength)) return false;
+    return Number(contentLength) > maxBytes;
+}
+
+function joinedResponseBytes(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+    const responseBytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+        responseBytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return responseBytes;
+}
+
+async function responseBytesWithinLimit(response: Response, maxBytes: number): Promise<Uint8Array | null> {
+    if (declaredResponseTooLarge(response, maxBytes)) {
+        await response.body?.cancel();
+        return null;
+    }
+    if (!response.body) return new Uint8Array();
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) return joinedResponseBytes(chunks, totalBytes);
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+            await reader.cancel();
+            return null;
+        }
+        chunks.push(value);
+    }
+}
+
+function parsedUtf8Json(responseBytes: Uint8Array): unknown {
+    try {
+        const responseText = new TextDecoder("utf-8", { fatal: true }).decode(responseBytes);
+        return JSON.parse(responseText);
+    } catch (error) {
+        if (error instanceof SyntaxError || error instanceof TypeError) return null;
+        throw error;
+    }
+}
+
+async function boundedResponseJson(response: Response, maxBytes: number): Promise<unknown> {
+    const responseBytes = await responseBytesWithinLimit(response, maxBytes);
+    return responseBytes === null ? null : parsedUtf8Json(responseBytes);
+}
+
 export class HttpTransport {
     private baseUrl: string;
     private token: string;
@@ -103,13 +159,15 @@ export class HttpTransport {
         };
     }
 
-    async get<T = unknown>(path: string): Promise<HttpResult<T>> {
+    async get<T = unknown>(path: string, options: HttpGetOptions = {}): Promise<HttpResult<T>> {
         try {
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "GET",
                 headers: this.headers(),
             });
-            const data = (await res.json().catch(() => null)) as T;
+            const data = (options.maxResponseBytes === undefined
+                ? await res.json().catch(() => null)
+                : await boundedResponseJson(res, options.maxResponseBytes)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {
             return transportFailure<T>(error);


### PR DESCRIPTION
## Parent / Source / Reason

- Parent: #806
- Source merge: `f3952e003cd26f87419eec69a43127095ad13908`
- Reason: #806 was merged before its final security review fixes could be pushed. The merged tree still accepted and reflected untrusted 2xx secret-list payloads, allowed duplicate flags to overwrite earlier values while coercing string-shaped names, and reflected invalid environment names in errors.

## Fix

- Validate successful secret-list responses as at most 1024 unique shell identifiers with exact masked values and at most 1 MiB of serialized JSON; print only a locally constructed `{ name, value: "********" }` projection.
- Parse `--from-env` names with fixed non-reflective failures, linear duplicate detection, a 1024-name limit, one environment read per name, a 24 KiB UTF-8 limit per value, and a 1 MiB final request limit.
- Reject every duplicate CLI flag with one fixed error and preserve raw strings when the target TypeBox field accepts them before applying generic CLI coercion.

## Verification

- Focused unit and real-process tests: 77/77, 221 assertions.
- Full `@supacloud/cli` tests: 197/197, 535 assertions.
- Typecheck, production build, and `git diff --check`: PASS.
- Fresh source/dist harness: masked projection, invalid 200 payload, duplicate flag HTTP-zero, `true`/`false`/`Infinity` names, and oversized environment value all PASS without sentinel reflection.
- clean-code-guard: clean; new production functions are at most 20 lines with at most 3 parameters, no new dependency, and no swallowed broad error.

This PR does not publish, release, or deploy anything.
