### PR TITLE
feat(cli): expose installed package version

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -66,6 +66,24 @@ async function runProjectCli(
     return { exitCode, stdout, stderr };
 }
 
+async function runProjectCliPath(
+    entryPath: string,
+    args: string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const processHandle = Bun.spawn([entryPath, ...args], {
+        cwd: PACKAGE_ROOT,
+        env: cleanEnvironment(),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        processHandle.exited,
+        new Response(processHandle.stdout).text(),
+        new Response(processHandle.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr };
+}
+
 function serveFunctionSource(sourceCode: string): string {
     const server = Bun.serve({
         hostname: "127.0.0.1",
@@ -93,6 +111,41 @@ function chunkedJsonResponse(body: string): Response {
 describe("supacloud-cli process contract", () => {
     test("prints the installed package version without project context", async () => {
         const response = await runProjectCli(["--version"]);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stdout.trim()).toBe(packageMetadata.version);
+        expect(response.stderr).toBe("");
+    });
+
+    test("prints the installed package version with global options in either order", async () => {
+        const versionArgs = [
+            ["--env", "test", "--confirm-production", "project-ref", "--version"],
+            ["--version", "--env=test", "--confirm-production=project-ref"],
+            ["--version", "--env-file", "/definitely/not/a/project.env"],
+        ];
+
+        for (const args of versionArgs) {
+            const response = await runProjectCli(args);
+
+            expect(response.exitCode).toBe(0);
+            expect(response.stdout.trim()).toBe(packageMetadata.version);
+            expect(response.stderr).toBe("");
+        }
+    });
+
+    test("prints the installed package version through the npm-style bin", async () => {
+        const build = Bun.spawnSync([process.execPath, "run", "build"], { cwd: PACKAGE_ROOT });
+        expect(build.exitCode).toBe(0);
+        const sandbox = mkdtempSync(join(tmpdir(), "supacloud-cli-bin-"));
+        temporaryDirectories.push(sandbox);
+        const binDirectory = join(sandbox, "node_modules/.bin");
+        mkdirSync(binDirectory, { recursive: true });
+        const linkedEntry = join(binDirectory, "supacloud-cli");
+        symlinkSync(join(PACKAGE_ROOT, "dist/index.js"), linkedEntry);
+
+        const response = await runProjectCliPath(linkedEntry, [
+            "--version", "--env=test", "--confirm-production=project-ref",
+        ]);
 
         expect(response.exitCode).toBe(0);
         expect(response.stdout.trim()).toBe(packageMetadata.version);

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cliToolResultIsError } from "./shared/cli";
+import packageMetadata from "../package.json" with { type: "json" };
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
 const CONTEXT_KEYS = new Set([
@@ -76,6 +77,14 @@ function serveFunctionSource(sourceCode: string): string {
 }
 
 describe("supacloud-cli process contract", () => {
+    test("prints the installed package version without project context", async () => {
+        const response = await runProjectCli(["--version"]);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stdout.trim()).toBe(packageMetadata.version);
+        expect(response.stderr).toBe("");
+    });
+
     test("documents global environment and production safety flags", async () => {
         const response = await runProjectCli(["--help"]);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -396,13 +396,12 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
 }
 
 async function main() {
-    const rawArgs = process.argv.slice(2);
-    if (rawArgs.length === 1 && rawArgs[0] === "--version") {
+    const globalOptions = parseGlobalOptions(process.argv.slice(2));
+    const args = globalOptions.args;
+    if (args.length === 1 && args[0] === "--version") {
         console.log(packageMetadata.version);
         return;
     }
-    const globalOptions = parseGlobalOptions(rawArgs);
-    const args = globalOptions.args;
     const context = resolveSupaCloudContext(process.env, process.cwd(), {
         environmentName: globalOptions.environmentName,
         envFile: globalOptions.envFile,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { registerBranchTools } from "./shared/tools/branch-tools";
 import { registerSupabaseCliTools } from "./shared/tools/supabase-cli-tools";
 import { registerAiTools } from "./shared/tools/ai-tools";
 import { registerScheduledFunctionTools } from "./shared/tools/scheduled-function-tools";
+import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
 type ToolMap = Record<string, ToolEntry>;
@@ -171,6 +172,7 @@ USAGE
   ${preferredCommand} [global flags] <module> <action> [--flags]
   ${preferredCommand} [global flags] status
   ${preferredCommand} --help
+  ${preferredCommand} --version
 
 GLOBAL FLAGS
 
@@ -394,7 +396,12 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
 }
 
 async function main() {
-    const globalOptions = parseGlobalOptions(process.argv.slice(2));
+    const rawArgs = process.argv.slice(2);
+    if (rawArgs.length === 1 && rawArgs[0] === "--version") {
+        console.log(packageMetadata.version);
+        return;
+    }
+    const globalOptions = parseGlobalOptions(rawArgs);
     const args = globalOptions.args;
     const context = resolveSupaCloudContext(process.env, process.cwd(), {
         environmentName: globalOptions.environmentName,


### PR DESCRIPTION
## Summary
- add a context-free `supacloud-cli --version` contract backed by installed package metadata
- document the flag in CLI help
- cover exact stdout/stderr and exit behavior

## Verification
- `bun test ./src/index.test.ts` (52 pass)
- `bun test ./src` (270 pass)
- `bun run typecheck`
- `bun run build`
- built artifact verified under Node and Bun
- `git diff --check`
- independent verifier: PASS (P0-P3 = 0)