### PR TITLE
fix(lite): keep project API keys stable

### DIFF
--- a/packages/supacloud-lite/src/project-runtime.ts
+++ b/packages/supacloud-lite/src/project-runtime.ts
@@ -1,6 +1,7 @@
 import { chmod, link, lstat, mkdir, readFile, realpath, unlink, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join, parse, relative, resolve } from 'node:path'
-import { createBackend, signJwt, type SupaCloudLiteBackend } from './runtime/index.js'
+import { createBackend, type SupaCloudLiteBackend } from './runtime/index.js'
+import { mintProjectApiKeys } from './runtime/jwt.js'
 import type { WebhookConfig } from './runtime/webhooks/service.js'
 import { serveBun, type RunningServer } from './runtime/node/bun-server.js'
 import { FsStorageDriver } from './runtime/node/fs-driver.js'
@@ -199,13 +200,7 @@ export async function ensureProjectSecrets(paths: ProjectPaths): Promise<Project
 }
 
 export async function mintProjectKeys(jwtSecret: string): Promise<{ anonKey: string; serviceRoleKey: string }> {
-  const now = Math.floor(Date.now() / 1000)
-  const exp = now + 10 * 365 * 24 * 3600
-  const common = { iss: 'supabase', ref: 'local', iat: now, exp }
-  return {
-    anonKey: await signJwt({ ...common, role: 'anon' }, jwtSecret),
-    serviceRoleKey: await signJwt({ ...common, role: 'service_role' }, jwtSecret),
-  }
+  return await mintProjectApiKeys(jwtSecret)
 }
 
 export async function createProjectBackend(options: ProjectRuntimeOptions = {}): Promise<ProjectBackend> {

--- a/packages/supacloud-lite/src/runtime/index.ts
+++ b/packages/supacloud-lite/src/runtime/index.ts
@@ -17,7 +17,7 @@ import { FunctionsHandler, type EdgeFunction } from './functions/handler.js'
 import { installDenoShim } from './functions/deno-shim.js'
 import { installPgredisShim, PgredisCache } from './functions/pgredis.js'
 import { Database } from './db/database.js'
-import { signJwt, verifyJwt } from './jwt.js'
+import { mintProjectApiKeys, verifyJwt } from './jwt.js'
 import { RealtimeEngine } from './realtime/engine.js'
 import { RestHandler } from './rest/handler.js'
 import { MemoryStorageDriver } from './storage/driver.js'
@@ -164,13 +164,7 @@ export async function createBackend(config: BackendConfig = {}): Promise<SupaClo
 
   const pgredis = await PgredisCache.create(db).catch(failStartup)
 
-  const now = Math.floor(Date.now() / 1000)
-  const tenYears = 10 * 365 * 24 * 3600
-  const anonKey = await signJwt({ iss: 'supabase', ref: 'local', role: 'anon', iat: now, exp: now + tenYears }, jwtSecret)
-  const serviceRoleKey = await signJwt(
-    { iss: 'supabase', ref: 'local', role: 'service_role', iat: now, exp: now + tenYears },
-    jwtSecret
-  )
+  const { anonKey, serviceRoleKey } = await mintProjectApiKeys(jwtSecret)
 
   const exposedSchemas = [...new Set(config.dbSchemas ?? ['public', 'pgmq_public'])]
   const rest = new RestHandler(db, { exposedSchemas, maxRows: config.maxRows })

--- a/packages/supacloud-lite/src/runtime/jwt.ts
+++ b/packages/supacloud-lite/src/runtime/jwt.ts
@@ -5,6 +5,13 @@
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
+const PROJECT_API_KEY_ISSUED_AT = 1_641_769_200
+const PROJECT_API_KEY_EXPIRES_AT = 4_102_444_800
+
+export interface ProjectApiKeys {
+  anonKey: string
+  serviceRoleKey: string
+}
 
 function bytesToBase64Url(bytes: Uint8Array): string {
   let binary = ''
@@ -58,6 +65,20 @@ export async function signJwt(claims: JwtClaims, secret: string): Promise<string
   const key = await hmacKey(secret, 'sign')
   const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(data))
   return `${data}.${bytesToBase64Url(new Uint8Array(sig))}`
+}
+
+/** Keep project API keys canonical so CLI output and restarted runtimes remain byte-identical. */
+export async function mintProjectApiKeys(jwtSecret: string): Promise<ProjectApiKeys> {
+  const commonClaims = {
+    iss: 'supabase',
+    ref: 'local',
+    iat: PROJECT_API_KEY_ISSUED_AT,
+    exp: PROJECT_API_KEY_EXPIRES_AT,
+  }
+  return {
+    anonKey: await signJwt({ ...commonClaims, role: 'anon' }, jwtSecret),
+    serviceRoleKey: await signJwt({ ...commonClaims, role: 'service_role' }, jwtSecret),
+  }
 }
 
 /** Verifies signature and expiry. Returns claims, or null when invalid. */

--- a/packages/supacloud-lite/test/project-keys.test.ts
+++ b/packages/supacloud-lite/test/project-keys.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { createProjectBackend } from '../src/project-runtime.js'
+import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
+
+const cliPath = resolve(import.meta.dir, '../src/cli.ts')
+
+interface ProjectKeys {
+  anonKey: string
+  serviceRoleKey: string
+}
+
+test('keeps CLI and runtime keys stable for one project across restarts', async () => {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-stable-keys-'))
+  try {
+    const cliKeys = await readCliKeys(projectDir)
+    await Bun.sleep(2_100)
+    const firstRuntimeKeys = await readRuntimeKeys(projectDir)
+    expect(cliKeys.anonKey === firstRuntimeKeys.anonKey).toBe(true)
+    expect(cliKeys.serviceRoleKey === firstRuntimeKeys.serviceRoleKey).toBe(true)
+
+    await Bun.sleep(2_100)
+    const restartedRuntimeKeys = await readRuntimeKeys(projectDir)
+    expect(firstRuntimeKeys.anonKey === restartedRuntimeKeys.anonKey).toBe(true)
+    expect(firstRuntimeKeys.serviceRoleKey === restartedRuntimeKeys.serviceRoleKey).toBe(true)
+  } finally {
+    await rm(projectDir, { recursive: true, force: true })
+  }
+}, 30_000)
+
+async function readCliKeys(projectDir: string): Promise<ProjectKeys> {
+  const bunExecutable = Bun.which('bun')
+  if (!bunExecutable) throw new Error('Bun is required to run the Lite CLI test')
+  const cliProcess = Bun.spawn({
+    cmd: [bunExecutable, cliPath, 'keys', '--service-role', '--project-dir', projectDir],
+    cwd: projectDir,
+    env: withoutProjectSecretOverrides(),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, standardOutput, standardError] = await withWindowsSubprocessRef(() => Promise.all([
+    cliProcess.exited,
+    new Response(cliProcess.stdout).text(),
+    new Response(cliProcess.stderr).text(),
+  ]))
+  expect(exitCode).toBe(0)
+  expect(standardError).toBe('')
+  return parseProjectKeys(standardOutput)
+}
+
+async function readRuntimeKeys(projectDir: string): Promise<ProjectKeys> {
+  const project = await createProjectBackend({
+    projectDir,
+    includeFunctions: false,
+    includeWebhooks: false,
+    startRuntimeServices: false,
+  })
+  try {
+    return { anonKey: project.backend.anonKey, serviceRoleKey: project.backend.serviceRoleKey }
+  } finally {
+    await project.backend.close()
+  }
+}
+
+function parseProjectKeys(standardOutput: string): ProjectKeys {
+  const anonKey = standardOutput.match(/anon key:\n([^\n]+)/)?.[1]
+  const serviceRoleKey = standardOutput.match(/service_role key:\n([^\n]+)/)?.[1]
+  if (!anonKey || !serviceRoleKey) throw new Error('Lite CLI did not return both project key labels')
+  return { anonKey, serviceRoleKey }
+}
+
+function withoutProjectSecretOverrides(): Record<string, string | undefined> {
+  const environment = { ...process.env }
+  delete environment.SUPACLOUD_LITE_JWT_SECRET
+  delete environment.SUPACLOUD_LITE_VAULT_KEY
+  return environment
+}

--- a/packages/supacloud-lite/test/project-keys.test.ts
+++ b/packages/supacloud-lite/test/project-keys.test.ts
@@ -36,7 +36,7 @@ async function readCliKeys(projectDir: string): Promise<ProjectKeys> {
   const cliProcess = Bun.spawn({
     cmd: [bunExecutable, cliPath, 'keys', '--service-role', '--project-dir', projectDir],
     cwd: projectDir,
-    env: withoutProjectSecretOverrides(),
+    env: withoutProjectRuntimeOverrides(),
     stdout: 'pipe',
     stderr: 'pipe',
   })
@@ -53,6 +53,7 @@ async function readCliKeys(projectDir: string): Promise<ProjectKeys> {
 async function readRuntimeKeys(projectDir: string): Promise<ProjectKeys> {
   const project = await createProjectBackend({
     projectDir,
+    ...isolatedProjectRuntimePaths(projectDir),
     includeFunctions: false,
     includeWebhooks: false,
     startRuntimeServices: false,
@@ -64,6 +65,11 @@ async function readRuntimeKeys(projectDir: string): Promise<ProjectKeys> {
   }
 }
 
+function isolatedProjectRuntimePaths(projectDir: string): { stateDir: string; dataDir: string; storageDir: string } {
+  const stateDir = join(projectDir, '.supacloud-lite')
+  return { stateDir, dataDir: join(stateDir, 'db'), storageDir: join(stateDir, 'storage') }
+}
+
 function parseProjectKeys(standardOutput: string): ProjectKeys {
   const anonKey = standardOutput.match(/anon key:\n([^\n]+)/)?.[1]
   const serviceRoleKey = standardOutput.match(/service_role key:\n([^\n]+)/)?.[1]
@@ -71,9 +77,12 @@ function parseProjectKeys(standardOutput: string): ProjectKeys {
   return { anonKey, serviceRoleKey }
 }
 
-function withoutProjectSecretOverrides(): Record<string, string | undefined> {
+function withoutProjectRuntimeOverrides(): Record<string, string | undefined> {
   const environment = { ...process.env }
   delete environment.SUPACLOUD_LITE_JWT_SECRET
   delete environment.SUPACLOUD_LITE_VAULT_KEY
+  delete environment.SUPACLOUD_LITE_STATE_DIR
+  delete environment.SUPACLOUD_LITE_DATA_DIR
+  delete environment.SUPACLOUD_LITE_STORAGE_DIR
   return environment
 }


### PR DESCRIPTION
## Summary

- mint Lite anon and service-role API keys through one canonical shared helper
- keep CLI `keys` output byte-identical to the running backend across time and restarts
- add a real CLI/runtime regression test without exposing captured keys

## TDD evidence

- RED on `origin/main`: `test/project-keys.test.ts` failed the boolean CLI/runtime equality assertion after a 2.1 second delay
- GREEN after the shared mint implementation: the test passes across CLI, initial runtime, and restarted runtime
- independent verifier reran it three times: 3/3 pass, 18 assertions

## Compatibility and upgrade

- no `secrets.json` schema or state migration is required
- previously issued, unexpired JWT API keys remain accepted because signature and role verification still use the same project JWT secret
- Auth session token issuance and configured `jwtExpiry` are unchanged
- rotating the project JWT secret still changes the canonical keys and revokes old credentials

## Security boundary

- service-role output remains opt-in through `keys --service-role`
- the regression captures keys only in memory and compares booleans, so failure output does not reveal credentials
- canonical project API keys use fixed long-lived claims through 2100; operators must rotate the JWT secret to revoke a leaked API key

## Verification

- full package check: 137 tests, 733 assertions; typecheck, JS/types build, package smoke, host standalone build and standalone smoke passed
- post-rebase: typecheck passed; stable-key test 3/3; project/runtime/function/integration suites 24/24 with 123 assertions; build passed
- legacy time-based service-role token compatibility smoke passed
- independent verifier: PASS, 0 blockers
- `git diff --check`: passed
- clean-code-guard: clean