### PR TITLE
fix(cli): keep version command standalone

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -117,35 +117,22 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).toBe("");
     });
 
-    test("prints the installed package version with global options in either order", async () => {
-        const versionArgs = [
-            ["--env", "test", "--confirm-production", "project-ref", "--version"],
-            ["--version", "--env=test", "--confirm-production=project-ref"],
-            ["--version", "--env-file", "/definitely/not/a/project.env"],
-        ];
-
-        for (const args of versionArgs) {
-            const response = await runProjectCli(args);
-
-            expect(response.exitCode).toBe(0);
-            expect(response.stdout.trim()).toBe(packageMetadata.version);
-            expect(response.stderr).toBe("");
-        }
-    });
-
     test("prints the installed package version through the npm-style bin", async () => {
-        const build = Bun.spawnSync([process.execPath, "run", "build"], { cwd: PACKAGE_ROOT });
-        expect(build.exitCode).toBe(0);
         const sandbox = mkdtempSync(join(tmpdir(), "supacloud-cli-bin-"));
         temporaryDirectories.push(sandbox);
+        const buildDirectory = join(sandbox, "dist");
+        const build = Bun.spawnSync([
+            process.execPath, "build", "src/index.ts", "--outdir", buildDirectory, "--target", "node",
+        ], { cwd: PACKAGE_ROOT });
+        expect(build.exitCode).toBe(0);
+        const builtEntry = join(buildDirectory, "index.js");
+        expect(readFileSync(builtEntry, "utf8").split("\n", 1)[0]).toBe("#!/usr/bin/env node");
         const binDirectory = join(sandbox, "node_modules/.bin");
         mkdirSync(binDirectory, { recursive: true });
         const linkedEntry = join(binDirectory, "supacloud-cli");
-        symlinkSync(join(PACKAGE_ROOT, "dist/index.js"), linkedEntry);
+        symlinkSync(builtEntry, linkedEntry);
 
-        const response = await runProjectCliPath(linkedEntry, [
-            "--version", "--env=test", "--confirm-production=project-ref",
-        ]);
+        const response = await runProjectCliPath(linkedEntry, ["--version"]);
 
         expect(response.exitCode).toBe(0);
         expect(response.stdout.trim()).toBe(packageMetadata.version);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -396,12 +396,13 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
 }
 
 async function main() {
-    const globalOptions = parseGlobalOptions(process.argv.slice(2));
-    const args = globalOptions.args;
-    if (args.length === 1 && args[0] === "--version") {
+    const rawArgs = process.argv.slice(2);
+    if (rawArgs.length === 1 && rawArgs[0] === "--version") {
         console.log(packageMetadata.version);
         return;
     }
+    const globalOptions = parseGlobalOptions(rawArgs);
+    const args = globalOptions.args;
     const context = resolveSupaCloudContext(process.env, process.cwd(), {
         environmentName: globalOptions.environmentName,
         envFile: globalOptions.envFile,


### PR DESCRIPTION
## Summary

- keep the public version contract limited to the exact standalone --version argv
- run the version short-circuit before project/global-option resolution
- build the npm-style executable test in a temporary sandbox with the portable #!/usr/bin/env node shebang

## Context

Parent: #816
Source merge: 9081fdabd8cac373cb87d6d39226c42a20e424ea

Node 26 consumes --env-file before the CLI entrypoint runs, so the merged version-plus-global-options behavior cannot be implemented consistently by the application. A direct installed-bin reproduction exits 9 before CLI dispatch when that runtime option names a missing file. Using env -S in the shebang was rejected because BusyBox env on Alpine does not support it.

This follow-up removes the uncommitted cross-runtime promise and retains the stable standalone command in source, a fresh Node-targeted dist build, and an offline-installed package tarball.

## Verification

- CLI tests: 303 pass, 0 fail, 861 assertions
- focused version tests: 3 pass
- typecheck: pass
- build: pass
- git diff --check: pass
- fresh source and dist standalone --version: 0.14.6
- offline npm install from bun pm pack: installed bin reports 0.14.6
- clean-code-guard: clean
- independent verifier: 0 P0 / 0 P1 / 0 P2

## Non-goals

- no general fix for the Node --env-file option collision
- no manual publish, release, or deployment