### PR TITLE
feat(admin): deliver project credentials securely

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -169,17 +169,25 @@ supported only on Linux, where Admin holds the canonical parent directory open
 and performs create, verification, and cleanup through `/proc/self/fd`. macOS
 and Windows fail with `ENV_FILE_PLATFORM_UNSUPPORTED` before creating a file or
 requesting remote credentials. On Linux, the target is exclusively reserved at
-mode `0600` before the remote mutation; parent and file device/inode identities
-are checked before and after writing. The response API URL must have the exact
-canonical origin implied by `--api_domain` or `--domain`, including its port.
-Existing files, symlinks, replaced parents, non-canonical paths, and missing
-directories are rejected. The recommended name is
+mode `0600` before the remote mutation. Every path ancestor must be owned by
+root or the Admin process user and must not grant group/world write access;
+root/user-owned sticky directories such as `/tmp` retain their kernel entry
+protection. Parent and file device/inode identities are checked before and
+after writing, including through the held parent descriptor after the file is
+closed. The file and parent directory are synced before success is reported.
+The response API URL and project name must exactly match the request binding;
+the origin comparison includes the port. Existing files, symlinks, replaced
+parents, non-canonical paths, and missing or untrusted directories are rejected.
+The recommended name is
 `.env.project-credentials.<environment>`; verify that the target repository
 ignores it before running the command (SupaCloud's own `.env.*` rule does).
 This is an application credential file, not a SupaCloud Admin/Management
-profile: never select it with `supacloud-admin --env` or `--env-file`. It
-contains only `SUPACLOUD_ENV`, `SUPACLOUD_PROJECT_REF`, `SUPABASE_URL`, and
-`SUPABASE_SERVICE_ROLE_KEY`; the public project origin is deliberately not
+profile: Admin rejects it before registering HTTP tools, so never select it
+with `supacloud-admin --env` or `--env-file`. Selected Admin files that contain
+project application credentials must also contain an explicit Management API
+URL and `SUPACLOUD_API_TOKEN`; Admin never substitutes the service-role key.
+The generated file contains only `SUPACLOUD_ENV`, `SUPACLOUD_PROJECT_REF`,
+`SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY`; the public project origin is deliberately not
 written as `SUPACLOUD_API_URL`, which Admin reserves for the Management API.
 The success receipt marks `env_file_scope` as `project_application`. Standard
 output otherwise contains only credential-free fields. Supply

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -76,7 +76,8 @@ npx @supacloud/admin status
 npx @supacloud/admin ssh ping
 npx @supacloud/admin ssh versions
 npx @supacloud/admin ssh diagnose
-npx @supacloud/admin project create --name my-app --domain example.com
+npx @supacloud/admin project create --name my-app --domain example.com \
+  --env_file /secure/path/.env.project-credentials.test --environment test
 npx @supacloud/admin project list
 npx @supacloud/admin project services --ref abc123
 npx @supacloud/admin project service_control --ref abc123 --service gotrue --service_action stop
@@ -157,6 +158,43 @@ Project commands owned by this CLI:
 - `project update_settings`
 - `project services` — read-only project service inventory
 - `project service_control` — constrained project service lifecycle control
+
+`project create` never prints project credentials. Pass an absolute
+`--env_file` path to explicitly request one-time service-role delivery. This
+mode requires both a complete bare `--api_domain` (or bare base `--domain`)
+and an exact `--environment test|production`; invalid or missing bindings fail
+before the remote project mutation. `--environment` is used only in the local
+credential file and is never sent to the Management API. Credential delivery is
+supported only on Linux, where Admin holds the canonical parent directory open
+and performs create, verification, and cleanup through `/proc/self/fd`. macOS
+and Windows fail with `ENV_FILE_PLATFORM_UNSUPPORTED` before creating a file or
+requesting remote credentials. On Linux, the target is exclusively reserved at
+mode `0600` before the remote mutation; parent and file device/inode identities
+are checked before and after writing. The response API URL must have the exact
+canonical origin implied by `--api_domain` or `--domain`, including its port.
+Existing files, symlinks, replaced parents, non-canonical paths, and missing
+directories are rejected. The recommended name is
+`.env.project-credentials.<environment>`; verify that the target repository
+ignores it before running the command (SupaCloud's own `.env.*` rule does).
+This is an application credential file, not a SupaCloud Admin/Management
+profile: never select it with `supacloud-admin --env` or `--env-file`. It
+contains only `SUPACLOUD_ENV`, `SUPACLOUD_PROJECT_REF`, `SUPABASE_URL`, and
+`SUPABASE_SERVICE_ROLE_KEY`; the public project origin is deliberately not
+written as `SUPACLOUD_API_URL`, which Admin reserves for the Management API.
+The success receipt marks `env_file_scope` as `project_application`. Standard
+output otherwise contains only credential-free fields. Supply
+`SUPACLOUD_API_TOKEN` through the process environment, never as a command
+argument.
+
+If the remote project is created but local env writing fails, the error receipt
+retains only the safe project ref and API URL, sets `remote_created: true` and
+`retry_safe: false`, and never includes the credential. A
+`credential_file_state: "absent"` receipt confirms cleanup and includes
+`credentials_written: false`. A `credential_file_state: "unknown"` receipt
+omits `credentials_written`; treat the target path as secret-bearing until an
+operator securely removes it or completes credential recovery/rotation. Repair
+the local path only after reading back the existing project and following that
+recovery flow; never blindly retry project creation.
 
 Service control accepts canonical service names only. `postgrest` supports
 `start`, `stop`, `restart`, `pause`, `resume`, and `status`; `gotrue`, `storage`,

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -169,12 +169,13 @@ supported only on Linux, where Admin holds the canonical parent directory open
 and performs create, verification, and cleanup through `/proc/self/fd`. macOS
 and Windows fail with `ENV_FILE_PLATFORM_UNSUPPORTED` before creating a file or
 requesting remote credentials. On Linux, the target is exclusively reserved at
-mode `0600` before the remote mutation. Every path ancestor must be owned by
-root or the Admin process user and must not grant group/world write access;
-root/user-owned sticky directories such as `/tmp` retain their kernel entry
-protection. Parent and file device/inode identities are checked before and
-after writing, including through the held parent descriptor after the file is
-closed. The file and parent directory are synced before success is reported.
+mode `0600` before the remote mutation. The direct parent must be owned by the
+Admin process user. Every ancestor must be owned by root or that user and must
+not grant group/world write access; paths below writable sticky directories
+such as `/tmp` are rejected. Parent ownership, mode, and device/inode identity,
+plus file ownership, mode, and device/inode identity, are checked before and
+after writing through the held parent descriptor. The file and parent directory
+are synced before success is reported.
 The response API URL and project name must exactly match the request binding;
 the origin comparison includes the port. Existing files, symlinks, replaced
 parents, non-canonical paths, and missing or untrusted directories are rejected.

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -304,6 +304,42 @@ describe("supacloud-admin process contract", () => {
         }
     });
 
+    test("rejects a generated project env file before registering Admin HTTP tools", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-project-env-source-"));
+        const envFile = join(workspace, ".env.project-credentials.test");
+        const serviceRoleKey = "project-service-role-secret";
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json([]);
+            },
+        });
+        writeFileSync(envFile, [
+            "SUPACLOUD_ENV=test",
+            "SUPACLOUD_PROJECT_REF=abcdefghijklmnopqrst",
+            `SUPABASE_URL=http://127.0.0.1:${server.port}`,
+            `SUPABASE_SERVICE_ROLE_KEY=${serviceRoleKey}`,
+            "",
+        ].join("\n"));
+
+        try {
+            const execution = await runAdminCli([
+                "project", "list", "--env-file", envFile,
+            ], {}, workspace);
+
+            expect(execution.exitCode).not.toBe(0);
+            expect(execution.output).toContain("cannot be used as a SupaCloud Admin profile");
+            expect(execution.output).not.toContain(serviceRoleKey);
+            expect(requestCount).toBe(0);
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
     test("requires exact production project confirmation before HTTP and rejects cross-ref writes", async () => {
         const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-production-project-"));
         const requestedPaths: string[] = [];
@@ -919,6 +955,7 @@ describe("supacloud-admin process contract", () => {
             fetch() {
                 return Response.json({
                     ref: "abcdefghijklmnopqrst",
+                    name: "expired-credential",
                     api: { url: "https://api.example.test" },
                     credentials: { service_role_key: expiredServiceRoleKey },
                 }, { status: 201 });
@@ -976,6 +1013,7 @@ describe("supacloud-admin process contract", () => {
                 requestBody = await request.json() as Record<string, unknown>;
                 return Response.json({
                     ref: projectRef,
+                    name: "process-project",
                     api: { url: "https://api.example.test" },
                     credentials: {
                         service_role_key: serviceRoleKey,

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -3,10 +3,13 @@ import { fileURLToPath } from "node:url";
 import {
     chmodSync,
     copyFileSync,
+    existsSync,
     mkdirSync,
     mkdtempSync,
+    readFileSync,
     realpathSync,
     rmSync,
+    statSync,
     symlinkSync,
     writeFileSync,
 } from "node:fs";
@@ -494,7 +497,10 @@ describe("supacloud-admin process contract", () => {
             port: 0,
             fetch() {
                 requestCount += 1;
-                return Response.json({ ref: "created-ref" });
+                return Response.json({
+                    ref: "abcdefghijklmnopqrst",
+                    api: { url: "https://abcdefghijklmnopqrst.api.example.test" },
+                }, { status: 201 });
             },
         });
         writeFileSync(join(workspace, ".env.supacloud.production"), [
@@ -557,6 +563,8 @@ describe("supacloud-admin process contract", () => {
         expect(execution.output).toContain("--api_domain");
         expect(execution.output).toContain("--auth_domain");
         expect(execution.output).toContain("--studio_domain");
+        expect(execution.output).toContain("--env_file");
+        expect(execution.output).toContain("--environment");
     });
 
     test("documents every physical backup flag without API context", async () => {
@@ -839,7 +847,10 @@ describe("supacloud-admin process contract", () => {
             );
 
             expect(execution.exitCode).toBe(1);
-            expect(execution.output).toContain("❌ Failed (400)");
+            expect(JSON.parse(execution.output).error).toEqual({
+                code: "HTTP_ERROR",
+                http_status: 400,
+            });
             expect(requests).toEqual([{
                 path: "/v1/projects",
                 body: expect.objectContaining({
@@ -851,6 +862,207 @@ describe("supacloud-admin process contract", () => {
             server.stop(true);
         }
     });
+
+    test.each([
+        ["the API domain binding is missing", ["--environment", "test"], "API_DOMAIN_BINDING_REQUIRED"],
+        ["the environment binding is missing", ["--api_domain", "api.example.test"], "ENVIRONMENT_BINDING_REQUIRED"],
+    ] as const)("fails before remote project creation when %s", async (_label, bindingArgs, code) => {
+        let requestCount = 0;
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({ unexpected: "remote-secret" }, { status: 201 });
+            },
+        });
+        const sandbox = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-binding-")));
+        const envFile = join(sandbox, ".env.project-credentials.test");
+        const apiToken = "private-binding-api-token";
+
+        try {
+            const execution = await runAdminCli([
+                "project", "create",
+                "--name", "binding-required",
+                "--env_file", envFile,
+                ...bindingArgs,
+            ], {
+                SUPACLOUD_ENV: "test",
+                SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                SUPACLOUD_API_TOKEN: apiToken,
+            });
+
+            expect(execution.exitCode).toBe(1);
+            expect(JSON.parse(execution.output).error).toEqual({ code, http_status: null });
+            expect(requestCount).toBe(0);
+            expect(existsSync(envFile)).toBe(false);
+            expect(execution.output).not.toContain(apiToken);
+        } finally {
+            apiServer.stop(true);
+            rmSync(sandbox, { recursive: true, force: true });
+        }
+    });
+
+    test.skipIf(process.platform !== "linux")(
+        "rejects an expired service-role response without writing or reflecting it",
+        async () => {
+        const jwtSegment = (claims: Record<string, unknown>) =>
+            Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+        const expiredServiceRoleKey = [
+            jwtSegment({ alg: "HS256", typ: "JWT" }),
+            jwtSegment({ role: "service_role", iss: "supabase", exp: 1 }),
+            "s".repeat(43),
+        ].join(".");
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                return Response.json({
+                    ref: "abcdefghijklmnopqrst",
+                    api: { url: "https://api.example.test" },
+                    credentials: { service_role_key: expiredServiceRoleKey },
+                }, { status: 201 });
+            },
+        });
+        const sandbox = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-expired-")));
+        const envFile = join(sandbox, ".env.project-credentials.test");
+
+        try {
+            const execution = await runAdminCli([
+                "project", "create",
+                "--name", "expired-credential",
+                "--api_domain", "api.example.test",
+                "--env_file", envFile,
+                "--environment", "test",
+            ], {
+                SUPACLOUD_ENV: "test",
+                SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+            });
+
+            expect(execution.exitCode).toBe(1);
+            expect(JSON.parse(execution.output).error).toEqual({
+                code: "INVALID_RESPONSE",
+                http_status: 201,
+            });
+            expect(existsSync(envFile)).toBe(false);
+            expect(execution.output).not.toContain(expiredServiceRoleKey);
+        } finally {
+            apiServer.stop(true);
+            rmSync(sandbox, { recursive: true, force: true });
+        }
+        },
+    );
+
+    test.skipIf(process.platform !== "linux")(
+        "creates a project without printing one-time credentials and writes the env file as 0600",
+        async () => {
+        const projectRef = "abcdefghijklmnopqrst";
+        const jwtSegment = (claims: Record<string, unknown>) =>
+            Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+        const serviceRoleKey = [
+            jwtSegment({ alg: "HS256", typ: "JWT" }),
+            jwtSegment({ role: "service_role", iss: "supabase", exp: 4_102_444_800 }),
+            "s".repeat(43),
+        ].join(".");
+        const privateSentinel = "private-process-response-secret";
+        const sandbox = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-create-process-")));
+        const envFile = join(sandbox, ".env.project-credentials.test");
+        let requestBody: Record<string, unknown> | undefined;
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestBody = await request.json() as Record<string, unknown>;
+                return Response.json({
+                    ref: projectRef,
+                    api: { url: "https://api.example.test" },
+                    credentials: {
+                        service_role_key: serviceRoleKey,
+                        jwt_secret: privateSentinel,
+                    },
+                    db_password: privateSentinel,
+                    secret_key: privateSentinel,
+                }, { status: 201 });
+            },
+        });
+
+        try {
+            const execution = await runAdminCli([
+                "project", "create",
+                "--name", "process-project",
+                "--api_domain", "api.example.test",
+                "--env_file", envFile,
+                "--environment", "test",
+            ], {
+                SUPACLOUD_ENV: "test",
+                SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+            });
+
+            expect(execution.exitCode).toBe(0);
+            expect(requestBody).toEqual(expect.objectContaining({
+                name: "process-project",
+                credential_delivery: "response",
+            }));
+            expect(execution.output).toContain('"credentials_written": true');
+            expect(execution.output).toContain('"env_file_scope": "project_application"');
+            expect(execution.output).toContain(envFile);
+            expect(execution.output).not.toContain(serviceRoleKey);
+            expect(execution.output).not.toContain(privateSentinel);
+            expect(readFileSync(envFile, "utf8")).toBe([
+                "SUPACLOUD_ENV=test",
+                `SUPACLOUD_PROJECT_REF=${projectRef}`,
+                "SUPABASE_URL=https://api.example.test",
+                `SUPABASE_SERVICE_ROLE_KEY=${serviceRoleKey}`,
+                "",
+            ].join("\n"));
+            if (process.platform !== "win32") expect(statSync(envFile).mode & 0o777).toBe(0o600);
+        } finally {
+            apiServer.stop(true);
+            rmSync(sandbox, { recursive: true, force: true });
+        }
+        },
+    );
+
+    test.skipIf(process.platform === "linux")(
+        "rejects env-file credential delivery before the HTTP request on unsupported platforms",
+        async () => {
+            let requestCount = 0;
+            const apiServer = Bun.serve({
+                hostname: "127.0.0.1",
+                port: 0,
+                fetch() {
+                    requestCount += 1;
+                    return Response.json({ unexpected: true }, { status: 201 });
+                },
+            });
+            const sandbox = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-platform-")));
+            const envFile = join(sandbox, ".env.project-credentials.test");
+
+            try {
+                const execution = await runAdminCli([
+                    "project", "create",
+                    "--name", "unsupported-platform",
+                    "--api_domain", "api.example.test",
+                    "--env_file", envFile,
+                    "--environment", "test",
+                ], {
+                    SUPACLOUD_ENV: "test",
+                    SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                    SUPACLOUD_API_TOKEN: "test-token",
+                });
+
+                expect(execution.exitCode).toBe(1);
+                expect(JSON.parse(execution.output).error.code).toBe("ENV_FILE_PLATFORM_UNSUPPORTED");
+                expect(requestCount).toBe(0);
+                expect(existsSync(envFile)).toBe(false);
+            } finally {
+                apiServer.stop(true);
+                rmSync(sandbox, { recursive: true, force: true });
+            }
+        },
+    );
 
     test("surfaces every sanitized cause when an operation and cleanup both fail", async () => {
         const result = await runAggregateFailureCli();

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -340,6 +340,35 @@ describe("supacloud-admin process contract", () => {
         }
     });
 
+    test("rejects sourced project application credentials before registering Admin HTTP tools", async () => {
+        const serviceRoleKey = "project-service-role-secret";
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json([]);
+            },
+        });
+
+        try {
+            const execution = await runAdminCli(["project", "list"], {
+                SUPACLOUD_ENV: "test",
+                SUPACLOUD_PROJECT_REF: "abcdefghijklmnopqrst",
+                SUPABASE_URL: `http://127.0.0.1:${server.port}`,
+                SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+            });
+
+            expect(execution.exitCode).not.toBe(0);
+            expect(execution.output).toContain("cannot be used as a SupaCloud Admin profile");
+            expect(execution.output).not.toContain(serviceRoleKey);
+            expect(requestCount).toBe(0);
+        } finally {
+            server.stop(true);
+        }
+    });
+
     test("requires exact production project confirmation before HTTP and rejects cross-ref writes", async () => {
         const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-production-project-"));
         const requestedPaths: string[] = [];

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -14,7 +14,7 @@ import {
     writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { createAdminTools } from "./index";
 import { cliToolResultIsError, formatCliError } from "./shared/cli";
 import { schemaEnumValues } from "./shared/schema";
@@ -990,7 +990,7 @@ describe("supacloud-admin process contract", () => {
                 }, { status: 201 });
             },
         });
-        const sandbox = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-expired-")));
+        const sandbox = realpathSync(mkdtempSync(join(homedir(), ".supacloud-admin-expired-")));
         const envFile = join(sandbox, ".env.project-credentials.test");
 
         try {
@@ -1032,7 +1032,7 @@ describe("supacloud-admin process contract", () => {
             "s".repeat(43),
         ].join(".");
         const privateSentinel = "private-process-response-secret";
-        const sandbox = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-create-process-")));
+        const sandbox = realpathSync(mkdtempSync(join(homedir(), ".supacloud-admin-create-process-")));
         const envFile = join(sandbox, ".env.project-credentials.test");
         let requestBody: Record<string, unknown> | undefined;
         const apiServer = Bun.serve({

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -118,7 +118,7 @@ EXAMPLES
   supacloud-admin ssh ping
   supacloud-admin ssh versions
   supacloud-admin ssh install --public_domain api.example.com --studio_domain studio.example.com
-  supacloud-admin project create --name my-app --domain example.com
+  supacloud-admin project create --name my-app --domain example.com --env_file /secure/path/.env.project-credentials.test --environment test
   supacloud-admin project list
   supacloud-admin project services --ref abc123
   supacloud-admin project service_control --ref abc123 --service gotrue --service_action stop

--- a/packages/admin/src/shared/context.test.ts
+++ b/packages/admin/src/shared/context.test.ts
@@ -138,6 +138,40 @@ describe("resolveSupaCloudContext", () => {
         expect(String(failure)).not.toContain(serviceRoleKey);
     });
 
+    test("rejects complete project application credentials from the process environment", () => {
+        const serviceRoleKey = "project-service-role-secret";
+        let failure: unknown;
+        try {
+            resolveSupaCloudContext({
+                SUPACLOUD_ENV: "test",
+                SUPACLOUD_PROJECT_REF: "abcdefghijklmnopqrst",
+                SUPABASE_URL: "https://api.example.test",
+                SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+            }, "/nonexistent");
+        } catch (error: unknown) {
+            failure = error;
+        }
+        expect(failure).toBeInstanceOf(Error);
+        expect(String(failure)).toContain("cannot be used as a SupaCloud Admin profile");
+        expect(String(failure)).toContain("SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN are required");
+        expect(String(failure)).not.toContain(serviceRoleKey);
+    });
+
+    test("uses explicit Management credentials when process application credentials coexist", () => {
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: "https://management.example.test",
+            SUPACLOUD_API_TOKEN: "management-token",
+            SUPACLOUD_PROJECT_REF: "abcdefghijklmnopqrst",
+            SUPABASE_URL: "https://api.example.test",
+            SUPABASE_SERVICE_ROLE_KEY: "project-service-role-secret",
+        }, "/nonexistent");
+
+        expect(context.apiUrl).toBe("https://management.example.test");
+        expect(context.apiToken).toBe("management-token");
+        expect(context.source).toBe("process_env");
+    });
+
     test("requires explicit Management URL and token fields as a complete file pair", () => {
         const workspace = temporaryWorkspace();
         writeEnvironment(workspace, "missing-token.env", {

--- a/packages/admin/src/shared/context.test.ts
+++ b/packages/admin/src/shared/context.test.ts
@@ -116,6 +116,45 @@ describe("resolveSupaCloudContext", () => {
         });
     });
 
+    test("rejects project application credentials as an explicit Admin profile", () => {
+        const workspace = temporaryWorkspace();
+        const serviceRoleKey = "project-service-role-secret";
+        writeEnvironment(workspace, "project.env", {
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_PROJECT_REF: "abcdefghijklmnopqrst",
+            SUPABASE_URL: "https://api.example.test",
+            SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+        });
+
+        let failure: unknown;
+        try {
+            resolveSupaCloudContext({}, workspace, { envFile: "project.env" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+        expect(failure).toBeInstanceOf(Error);
+        expect(String(failure)).toContain("cannot be used as a SupaCloud Admin profile");
+        expect(String(failure)).toContain("SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN are required");
+        expect(String(failure)).not.toContain(serviceRoleKey);
+    });
+
+    test("requires explicit Management URL and token fields as a complete file pair", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, "missing-token.env", {
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: "https://management.example.test",
+        });
+        writeEnvironment(workspace, "missing-url.env", {
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_TOKEN: "management-token",
+        });
+
+        for (const envFile of ["missing-token.env", "missing-url.env"]) {
+            expect(() => resolveSupaCloudContext({}, workspace, { envFile }))
+                .toThrow("requires both SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN");
+        }
+    });
+
     test("uses SUPACLOUD_ENV as a named selector when process context is incomplete", () => {
         const workspace = temporaryWorkspace();
         writeEnvironment(workspace, ".env.supacloud.test", {

--- a/packages/admin/src/shared/context.ts
+++ b/packages/admin/src/shared/context.ts
@@ -105,6 +105,32 @@ function normalizeUrl(urlCandidate: string): string {
     }
 }
 
+function managementApiUrlCandidate(environment: Record<string, string>): string {
+    return environment.SUPACLOUD_API_URL
+        || environment.SUPACLOUD_MANAGEMENT_API_URL
+        || environment.MANAGEMENT_API_URL
+        || "";
+}
+
+function assertAdminFileContext(environment: Record<string, string>, path: string): void {
+    const hasProjectApplicationCredentials = Boolean(
+        environment.SUPABASE_URL?.trim() || environment.SUPABASE_SERVICE_ROLE_KEY?.trim(),
+    );
+    const hasManagementApiUrl = Boolean(normalizeUrl(managementApiUrlCandidate(environment)));
+    const hasManagementApiToken = Boolean(environment.SUPACLOUD_API_TOKEN?.trim());
+    if (hasProjectApplicationCredentials && (!hasManagementApiUrl || !hasManagementApiToken)) {
+        throw new Error(
+            `Project application credentials in ${path} cannot be used as a SupaCloud Admin profile; `
+            + "SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN are required",
+        );
+    }
+    if (hasManagementApiUrl !== hasManagementApiToken) {
+        throw new Error(
+            `SupaCloud Admin API context in ${path} requires both SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN`,
+        );
+    }
+}
+
 function hostFromUrl(urlCandidate: string): string {
     try {
         return new URL(urlCandidate).hostname;
@@ -146,10 +172,7 @@ function sourceAdminCore(environment: Record<string, string>) {
     const supabaseUrl = normalizeUrl(environment.SUPABASE_URL || "");
     const projectRef = (environment.SUPACLOUD_PROJECT_REF || environment.X_PROJECT_REF || "").trim()
         || inferProjectRefFromSupabaseUrl(supabaseUrl);
-    const explicitApiUrl = environment.SUPACLOUD_API_URL
-        || environment.SUPACLOUD_MANAGEMENT_API_URL
-        || environment.MANAGEMENT_API_URL
-        || "";
+    const explicitApiUrl = managementApiUrlCandidate(environment);
     const apiUrl = normalizeUrl(explicitApiUrl)
         || inferManagementApiUrlFromSupabaseUrl(supabaseUrl, projectRef)
         || normalizeUrl(environment.SUPACLOUD_HOST ? `http://${environment.SUPACLOUD_HOST}:9090` : "");
@@ -185,6 +208,7 @@ function namedEnvironmentSource(cwd: string, selector: string): ContextSource {
     if (normalizeEnvironmentName(selectedEnvironment.SUPACLOUD_ENV) !== environment) {
         throw new Error(`SUPACLOUD_ENV in ${path} does not match selector ${selector}`);
     }
+    assertAdminFileContext(selectedEnvironment, path);
     return {
         environment: selectedEnvironment,
         kind: "named_env_file",
@@ -197,6 +221,7 @@ function explicitEnvironmentSource(cwd: string, envFile: string): ContextSource 
     const path = resolve(cwd, envFile);
     const selectedEnvironment = readEnvFile(path, true);
     if (!selectedEnvironment.SUPACLOUD_ENV) throw new Error(`SUPACLOUD_ENV is required in ${path}`);
+    assertAdminFileContext(selectedEnvironment, path);
     return {
         environment: selectedEnvironment,
         kind: "explicit_env_file",
@@ -208,6 +233,7 @@ function explicitEnvironmentSource(cwd: string, envFile: string): ContextSource 
 function legacyEnvironmentSource(cwd: string): ContextSource {
     const path = resolve(cwd, ".env");
     const environment = readEnvFile(path, false);
+    if (Object.keys(environment).length > 0) assertAdminFileContext(environment, path);
     const environmentName = environment.SUPACLOUD_ENV
         ? normalizeEnvironmentName(environment.SUPACLOUD_ENV)
         : "";

--- a/packages/admin/src/shared/context.ts
+++ b/packages/admin/src/shared/context.ts
@@ -112,7 +112,7 @@ function managementApiUrlCandidate(environment: Record<string, string>): string 
         || "";
 }
 
-function assertAdminFileContext(environment: Record<string, string>, path: string): void {
+function assertAdminCredentialScope(environment: Record<string, string>, source: string): void {
     const hasProjectApplicationCredentials = Boolean(
         environment.SUPABASE_URL?.trim() || environment.SUPABASE_SERVICE_ROLE_KEY?.trim(),
     );
@@ -120,15 +120,29 @@ function assertAdminFileContext(environment: Record<string, string>, path: strin
     const hasManagementApiToken = Boolean(environment.SUPACLOUD_API_TOKEN?.trim());
     if (hasProjectApplicationCredentials && (!hasManagementApiUrl || !hasManagementApiToken)) {
         throw new Error(
-            `Project application credentials in ${path} cannot be used as a SupaCloud Admin profile; `
+            `Project application credentials in ${source} cannot be used as a SupaCloud Admin profile; `
             + "SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN are required",
         );
     }
+}
+
+function assertAdminFileContext(environment: Record<string, string>, path: string): void {
+    assertAdminCredentialScope(environment, path);
+    const hasManagementApiUrl = Boolean(normalizeUrl(managementApiUrlCandidate(environment)));
+    const hasManagementApiToken = Boolean(environment.SUPACLOUD_API_TOKEN?.trim());
     if (hasManagementApiUrl !== hasManagementApiToken) {
         throw new Error(
             `SupaCloud Admin API context in ${path} requires both SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN`,
         );
     }
+}
+
+function processContextSource(
+    environment: Record<string, string>,
+    environmentName: string,
+): ContextSource {
+    assertAdminCredentialScope(environment, "process environment");
+    return { environment, kind: "process_env", path: null, environmentName };
 }
 
 function hostFromUrl(urlCandidate: string): string {
@@ -250,12 +264,12 @@ function ambientContextSource(env: NodeJS.ProcessEnv, cwd: string): ContextSourc
     if (env.SUPACLOUD_ENV) {
         const environmentName = normalizeEnvironmentName(env.SUPACLOUD_ENV);
         if (completeAdminContext(environment)) {
-            return { environment, kind: "process_env", path: null, environmentName };
+            return processContextSource(environment, environmentName);
         }
         return namedEnvironmentSource(cwd, env.SUPACLOUD_ENV);
     }
     if (hasProcessContext(env)) {
-        return { environment, kind: "process_env", path: null, environmentName: "" };
+        return processContextSource(environment, "");
     }
     return legacyEnvironmentSource(cwd);
 }

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -1,7 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+    constants,
+    existsSync,
+    mkdtempSync,
+    readFileSync,
+    realpathSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { lstat, open, realpath, unlink } from "node:fs/promises";
 import { registerAdminProjectCliTools } from "./project-cli-tools";
 import { schemaEnumValues } from "../schema";
 import type { ToolSchema } from "../schema";
+import type { ProjectEnvFileOperations } from "./project-create-env";
 
 type ProjectCallback = (
     args: Record<string, unknown>,
@@ -11,6 +25,68 @@ type ProjectToolRegistration = {
     callback: ProjectCallback;
     schema: ToolSchema;
 };
+
+const CREATE_PROJECT_REF = "abcdefghijklmnopqrst";
+const CREATE_FUTURE_EXPIRATION = 4_102_444_800;
+const createSandboxes: string[] = [];
+
+function testProjectEnvFileOperations(): ProjectEnvFileOperations {
+    const directoryPaths = new WeakMap<object, string>();
+    return {
+        platform: "linux",
+        lstat,
+        realpath,
+        async openDirectory(path) {
+            const openDirectory = await open(path, constants.O_RDONLY);
+            const directoryHandle = {
+                fd: openDirectory.fd,
+                stat: () => openDirectory.stat(),
+                close: () => openDirectory.close(),
+            };
+            directoryPaths.set(directoryHandle, path);
+            return directoryHandle;
+        },
+        openExclusiveAt: (directory, filename, mode) =>
+            open(join(directoryPaths.get(directory)!, filename), "wx", mode),
+        lstatAt: (directory, filename) => lstat(join(directoryPaths.get(directory)!, filename)),
+        unlinkAt: (directory, filename) => unlink(join(directoryPaths.get(directory)!, filename)),
+    };
+}
+
+const defaultProjectEnvFileOperations = testProjectEnvFileOperations();
+
+function createJwtSegment(claims: Record<string, unknown>): string {
+    return Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+}
+
+const CREATE_SERVICE_ROLE_KEY = [
+    createJwtSegment({ alg: "HS256", typ: "JWT" }),
+    createJwtSegment({
+        role: "service_role",
+        iss: "supabase",
+        exp: CREATE_FUTURE_EXPIRATION,
+    }),
+    "s".repeat(43),
+].join(".");
+
+function createSandbox(): string {
+    const path = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-create-")));
+    createSandboxes.push(path);
+    return path;
+}
+
+function createResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        ref: CREATE_PROJECT_REF,
+        api: { url: "https://api.example.test" },
+        credentials: { service_role_key: CREATE_SERVICE_ROLE_KEY },
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    for (const path of createSandboxes.splice(0)) rmSync(path, { recursive: true, force: true });
+});
 
 const REMOTE_RESPONSE_DETAILS = [
     "remote-token-value",
@@ -61,23 +137,37 @@ async function expectInvalidInventory(
     expect(response.content[0].text).toBe("❌ Project service inventory response is invalid");
 }
 
-function captureAdminProjectRegistration(http: Record<string, unknown>): ProjectToolRegistration {
+function captureAdminProjectRegistration(
+    http: Record<string, unknown>,
+    options: { projectEnvFileOperations?: ProjectEnvFileOperations } = {},
+): ProjectToolRegistration {
     let registration: ProjectToolRegistration | undefined;
     registerAdminProjectCliTools({
         tool(name: string, _description: string, schema: ToolSchema, callback: ProjectCallback) {
             if (name === "project") registration = { callback, schema };
         },
-    }, http as any);
+    }, http as any, {
+        projectEnvFileOperations: options.projectEnvFileOperations ?? defaultProjectEnvFileOperations,
+    });
 
     if (!registration) throw new Error("admin project tool was not registered");
     return registration;
 }
 
-function captureAdminProjectTool(http: Record<string, unknown>): ProjectCallback {
-    return captureAdminProjectRegistration(http).callback;
+function captureAdminProjectTool(
+    http: Record<string, unknown>,
+    options: { projectEnvFileOperations?: ProjectEnvFileOperations } = {},
+): ProjectCallback {
+    return captureAdminProjectRegistration(http, options).callback;
 }
 
 describe("admin project create", () => {
+    test("declares only test and production for local credential profiles", () => {
+        const { schema } = captureAdminProjectRegistration({});
+
+        expect(schemaEnumValues(schema.environment)).toEqual(["test", "production"]);
+    });
+
     test("forwards every non-empty custom domain unchanged", async () => {
         const requests: Array<{ path: string; body: unknown }> = [];
         const projectCallback = captureAdminProjectTool({
@@ -137,6 +227,479 @@ describe("admin project create", () => {
         expect("api_domain" in createRequest).toBe(false);
         expect("auth_domain" in createRequest).toBe(false);
         expect("studio_domain" in createRequest).toBe(false);
+    });
+
+    test("writes one-time credentials to a new 0600 env file and emits only a safe receipt", async () => {
+        const remoteSecret = "remote-create-secret";
+        const directory = createSandbox();
+        const envFile = join(directory, ".env.project-credentials.test");
+        let createRequest: Record<string, unknown> | undefined;
+        const projectCallback = captureAdminProjectTool({
+            post: async (_path: string, body: Record<string, unknown>) => {
+                createRequest = body;
+                return {
+                    ok: true,
+                    status: 201,
+                    data: createResponse({
+                        jwt_secret: remoteSecret,
+                        db_password: remoteSecret,
+                        secret_key: remoteSecret,
+                        credentials: {
+                            service_role_key: CREATE_SERVICE_ROLE_KEY,
+                            jwt_secret: remoteSecret,
+                        },
+                    }),
+                };
+            },
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "secure-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+        const receipt = JSON.parse(response.content[0].text);
+
+        expect(response.isError).not.toBe(true);
+        expect(createRequest).toEqual(expect.objectContaining({
+            name: "secure-project",
+            credential_delivery: "response",
+        }));
+        expect(receipt).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "project.create",
+            project_ref: CREATE_PROJECT_REF,
+            api_url: "https://api.example.test",
+            credentials_written: true,
+            env_file: envFile,
+            env_file_scope: "project_application",
+        });
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(response.content[0].text).not.toContain(remoteSecret);
+        expect(readFileSync(envFile, "utf8")).toContain(
+            `SUPABASE_SERVICE_ROLE_KEY=${CREATE_SERVICE_ROLE_KEY}`,
+        );
+        expect(readFileSync(envFile, "utf8")).toContain("SUPACLOUD_ENV=test");
+        if (process.platform !== "win32") expect(statSync(envFile).mode & 0o777).toBe(0o600);
+    });
+
+    test("rejects a credential response on an unrequested non-default API port", async () => {
+        const directory = createSandbox();
+        const envFile = join(directory, "wrong-origin.env");
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: true,
+                status: 201,
+                data: createResponse({ api: { url: "https://api.example.test:8443" } }),
+            }),
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "wrong-origin-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error.code).toBe("OUTCOME_UNKNOWN");
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(() => readFileSync(envFile, "utf8")).toThrow();
+    });
+
+    test("keeps default create output credential-free without requesting delivery", async () => {
+        let createRequest: Record<string, unknown> | undefined;
+        const projectCallback = captureAdminProjectTool({
+            post: async (_path: string, body: Record<string, unknown>) => {
+                createRequest = body;
+                return {
+                    ok: true,
+                    status: 201,
+                    data: {
+                        ref: CREATE_PROJECT_REF,
+                        api: { url: `https://${CREATE_PROJECT_REF}.api.example.test` },
+                        jwt_secret: "ignored-secret",
+                    },
+                };
+            },
+        });
+
+        const response = await projectCallback({ action: "create", name: "safe-default" });
+        const receipt = JSON.parse(response.content[0].text);
+
+        expect(response.isError).not.toBe(true);
+        expect(createRequest).not.toHaveProperty("credential_delivery");
+        expect(receipt).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "project.create",
+            project_ref: CREATE_PROJECT_REF,
+            api_url: `https://${CREATE_PROJECT_REF}.api.example.test`,
+            credentials_written: false,
+        });
+        expect(response.content[0].text).not.toContain("ignored-secret");
+    });
+
+    test("fails closed if an unrequested response contains one-time credentials", async () => {
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({ ok: true, status: 201, data: createResponse() }),
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "unexpected-credential-project",
+            api_domain: "api.example.test",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "INVALID_RESPONSE",
+            http_status: 201,
+        });
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+    });
+
+    test.each([
+        {},
+        { api_domain: "" },
+        { api_domain: "api.example.test/path" },
+        { api_domain: "api..example.test" },
+        { api_domain: "-api.example.test" },
+        { api_domain: "_api.example.test" },
+        { api_domain: "api.example.test." },
+        { api_domain: "." },
+        { domain: "https://example.test" },
+    ])("requires a complete API domain before remote credential delivery", async domainArgs => {
+        let postCalls = 0;
+        const projectCallback = captureAdminProjectTool({
+            post: async () => {
+                postCalls += 1;
+                return { ok: true, status: 201, data: createResponse() };
+            },
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "domain-binding-required",
+            env_file: join(createSandbox(), "domain-binding.env"),
+            environment: "test",
+            ...domainArgs,
+        });
+
+        expect(postCalls).toBe(0);
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "API_DOMAIN_BINDING_REQUIRED",
+            http_status: null,
+        });
+    });
+
+    test.each([undefined, "", "staging", "prod", "production "])(
+        "requires an exact test or production environment before remote credential delivery",
+        async environment => {
+            let postCalls = 0;
+            const projectCallback = captureAdminProjectTool({
+                post: async () => {
+                    postCalls += 1;
+                    return { ok: true, status: 201, data: createResponse() };
+                },
+            });
+
+            const response = await projectCallback({
+                action: "create",
+                name: "environment-binding-required",
+                api_domain: "api.example.test",
+                env_file: join(createSandbox(), "environment-binding.env"),
+                environment,
+            });
+
+            expect(postCalls).toBe(0);
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text).error).toEqual({
+                code: "ENVIRONMENT_BINDING_REQUIRED",
+                http_status: null,
+            });
+        },
+    );
+
+    test("preflights the env path before creating a project", async () => {
+        const directory = createSandbox();
+        const envFile = join(directory, "existing.env");
+        writeFileSync(envFile, "keep-me");
+        let postCalls = 0;
+        const projectCallback = captureAdminProjectTool({
+            post: async () => {
+                postCalls += 1;
+                return { ok: true, status: 201, data: createResponse() };
+            },
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "must-not-run",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+
+        expect(postCalls).toBe(0);
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "ENV_FILE_EXISTS",
+            http_status: null,
+        });
+        expect(readFileSync(envFile, "utf8")).toBe("keep-me");
+    });
+
+    test.each(["darwin", "win32"] as const)(
+        "fails closed on %s before requesting remote credentials or creating a file",
+        async platform => {
+            let postCalls = 0;
+            const fileOperations = { ...testProjectEnvFileOperations(), platform };
+            const projectCallback = captureAdminProjectTool({
+                post: async () => {
+                    postCalls += 1;
+                    return { ok: true, status: 201, data: createResponse() };
+                },
+            }, { projectEnvFileOperations: fileOperations });
+            const directory = createSandbox();
+            const envFile = join(directory, `${platform}.env`);
+
+            const response = await projectCallback({
+                action: "create",
+                name: "unsupported-platform-project",
+                api_domain: "api.example.test",
+                env_file: envFile,
+                environment: "test",
+            });
+
+            expect(postCalls).toBe(0);
+            expect(JSON.parse(response.content[0].text).error.code)
+                .toBe("ENV_FILE_PLATFORM_UNSUPPORTED");
+            expect(() => readFileSync(envFile, "utf8")).toThrow();
+        },
+    );
+
+    test("reserves the env target before the remote credential request", async () => {
+        const directory = createSandbox();
+        const envFile = join(directory, "raced.env");
+        let exclusiveRaceBlocked = false;
+        const projectCallback = captureAdminProjectTool({
+            post: async () => {
+                try {
+                    writeFileSync(envFile, "created-during-request", { flag: "wx" });
+                } catch (error: unknown) {
+                    exclusiveRaceBlocked = (error as { code?: string }).code === "EEXIST";
+                }
+                return { ok: true, status: 201, data: createResponse() };
+            },
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "raced-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+        const receipt = JSON.parse(response.content[0].text);
+
+        expect(response.isError).not.toBe(true);
+        expect(exclusiveRaceBlocked).toBe(true);
+        expect(receipt).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "project.create",
+            project_ref: CREATE_PROJECT_REF,
+            api_url: "https://api.example.test",
+            credentials_written: true,
+            env_file: envFile,
+            env_file_scope: "project_application",
+        });
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(readFileSync(envFile, "utf8")).toContain(CREATE_SERVICE_ROLE_KEY);
+    });
+
+    test("reports unknown credential state when secure cleanup cannot be verified", async () => {
+        const directory = createSandbox();
+        const envFile = join(directory, "cleanup-unknown.env");
+        const baseOperations = testProjectEnvFileOperations();
+        let credentialsWritten = false;
+        const fileOperations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openExclusiveAt(parent, filename, mode) {
+                const openFile = await baseOperations.openExclusiveAt(parent, filename, mode);
+                return {
+                    chmod: requestedMode => openFile.chmod(requestedMode),
+                    writeFile: async contents => {
+                        await openFile.writeFile(contents);
+                        credentialsWritten = true;
+                    },
+                    sync: () => openFile.sync(),
+                    stat: async () => {
+                        const stat = await openFile.stat();
+                        return {
+                            dev: stat.dev,
+                            ino: stat.ino,
+                            mode: stat.mode,
+                            isDirectory: () => false,
+                            isFile: () => !credentialsWritten,
+                            isSymbolicLink: () => false,
+                        };
+                    },
+                    truncate: async () => { throw new Error("private-truncate-detail"); },
+                    close: () => openFile.close(),
+                };
+            },
+            unlinkAt: async () => { throw new Error("private-unlink-detail"); },
+        };
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({ ok: true, status: 201, data: createResponse() }),
+        }, { projectEnvFileOperations: fileOperations });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "cleanup-unknown-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "production",
+        });
+        const receipt = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(receipt).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "project.create",
+            project_ref: CREATE_PROJECT_REF,
+            api_url: "https://api.example.test",
+            remote_created: true,
+            credential_file_state: "unknown",
+            retry_safe: false,
+            error: { code: "ENV_FILE_CLEANUP_FAILED", http_status: 201 },
+        });
+        expect(receipt).not.toHaveProperty("credentials_written");
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(response.content[0].text).not.toContain("private-");
+        expect(readFileSync(envFile, "utf8")).toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(readFileSync(envFile, "utf8")).toContain("SUPACLOUD_ENV=production");
+    });
+
+    test.each([
+        [400, "HTTP_ERROR"],
+        [408, "OUTCOME_UNKNOWN"],
+        [500, "OUTCOME_UNKNOWN"],
+        [503, "OUTCOME_UNKNOWN"],
+    ] as const)("classifies HTTP %s without reflecting its response", async (status, code) => {
+        const remoteSecret = `remote-http-${status}-secret`;
+        const envFile = join(createSandbox(), `${status}.env`);
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: false,
+                status,
+                data: { error: remoteSecret, service_role_key: CREATE_SERVICE_ROLE_KEY },
+            }),
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "http-failure-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code, http_status: status });
+        expect(response.content[0].text).not.toContain(remoteSecret);
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(existsSync(envFile)).toBe(false);
+    });
+
+    test("classifies a transport failure as outcome unknown with no HTTP status", async () => {
+        const envFile = join(createSandbox(), "transport.env");
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: false,
+                status: 500,
+                transportError: true,
+                data: { error: "private-network-detail" },
+            }),
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "transport-failure-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "OUTCOME_UNKNOWN",
+            http_status: null,
+        });
+        expect(response.content[0].text).not.toContain("private-network-detail");
+        expect(existsSync(envFile)).toBe(false);
+    });
+
+    test("treats an unexpected successful HTTP status as outcome unknown", async () => {
+        const envFile = join(createSandbox(), "unexpected-status.env");
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({ ok: true, status: 200, data: createResponse() }),
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "unexpected-status-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "OUTCOME_UNKNOWN",
+            http_status: 200,
+        });
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(existsSync(envFile)).toBe(false);
+    });
+
+    test("rejects hostile 2xx payloads without reflecting their fields", async () => {
+        const remoteSecret = "hostile-success-secret";
+        const hostileResponses = [
+            { ref: remoteSecret, api: { url: "https://api.example.test" }, credentials: { service_role_key: CREATE_SERVICE_ROLE_KEY } },
+            { ref: CREATE_PROJECT_REF, api: { url: `https://${remoteSecret}.example.test` }, credentials: { service_role_key: CREATE_SERVICE_ROLE_KEY } },
+            { ref: CREATE_PROJECT_REF, api: { url: "https://api.example.test" }, credentials: { service_role_key: `${CREATE_SERVICE_ROLE_KEY}\n${remoteSecret}` } },
+            { ref: CREATE_PROJECT_REF, api: { url: "https://api.example.test" }, credentials: remoteSecret },
+        ];
+        let responseIndex = 0;
+        const directory = createSandbox();
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({ ok: true, status: 201, data: hostileResponses[responseIndex++] }),
+        });
+
+        for (let index = 0; index < hostileResponses.length; index++) {
+            const response = await projectCallback({
+                action: "create",
+                name: "hostile-project",
+                api_domain: "api.example.test",
+                env_file: join(directory, `${index}.env`),
+                environment: "test",
+            });
+            expect(response.isError).toBe(true);
+            const expectedCode = index < 2 ? "OUTCOME_UNKNOWN" : "INVALID_RESPONSE";
+            expect(JSON.parse(response.content[0].text).error.code).toBe(expectedCode);
+            expect(response.content[0].text).not.toContain(remoteSecret);
+            expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+            expect(existsSync(join(directory, `${index}.env`))).toBe(false);
+        }
     });
 });
 

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+    chmodSync,
     constants,
     existsSync,
+    mkdirSync,
     mkdtempSync,
     readFileSync,
     realpathSync,
@@ -34,6 +36,7 @@ function testProjectEnvFileOperations(): ProjectEnvFileOperations {
     const directoryPaths = new WeakMap<object, string>();
     return {
         platform: "linux",
+        effectiveUid: () => process.geteuid?.() ?? -1,
         lstat,
         realpath,
         async openDirectory(path) {
@@ -41,6 +44,7 @@ function testProjectEnvFileOperations(): ProjectEnvFileOperations {
             const directoryHandle = {
                 fd: openDirectory.fd,
                 stat: () => openDirectory.stat(),
+                sync: async () => {},
                 close: () => openDirectory.close(),
             };
             directoryPaths.set(directoryHandle, path);
@@ -78,6 +82,7 @@ function createSandbox(): string {
 function createResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
     return {
         ref: CREATE_PROJECT_REF,
+        name: "secure-project",
         api: { url: "https://api.example.test" },
         credentials: { service_role_key: CREATE_SERVICE_ROLE_KEY },
         ...overrides,
@@ -293,7 +298,10 @@ describe("admin project create", () => {
             post: async () => ({
                 ok: true,
                 status: 201,
-                data: createResponse({ api: { url: "https://api.example.test:8443" } }),
+                data: createResponse({
+                    name: "wrong-origin-project",
+                    api: { url: "https://api.example.test:8443" },
+                }),
             }),
         });
 
@@ -309,6 +317,31 @@ describe("admin project create", () => {
         expect(JSON.parse(response.content[0].text).error.code).toBe("OUTCOME_UNKNOWN");
         expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
         expect(() => readFileSync(envFile, "utf8")).toThrow();
+    });
+
+    test("rejects stale credentials for a different project name", async () => {
+        const directory = createSandbox();
+        const envFile = join(directory, "stale-name.env");
+        const projectCallback = captureAdminProjectTool({
+            post: async () => ({
+                ok: true,
+                status: 201,
+                data: createResponse({ name: "different-project" }),
+            }),
+        });
+
+        const response = await projectCallback({
+            action: "create",
+            name: "secure-project",
+            api_domain: "api.example.test",
+            env_file: envFile,
+            environment: "test",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error.code).toBe("INVALID_RESPONSE");
+        expect(response.content[0].text).not.toContain(CREATE_SERVICE_ROLE_KEY);
+        expect(existsSync(envFile)).toBe(false);
     });
 
     test("keeps default create output credential-free without requesting delivery", async () => {
@@ -455,6 +488,42 @@ describe("admin project create", () => {
         expect(readFileSync(envFile, "utf8")).toBe("keep-me");
     });
 
+    test.each(["direct parent", "ancestor"] as const)(
+        "rejects a group or world-writable %s before the remote create",
+        async unsafeLevel => {
+            const root = createSandbox();
+            const writableDirectory = join(root, "writable");
+            const targetParent = unsafeLevel === "direct parent"
+                ? writableDirectory
+                : join(writableDirectory, "protected");
+            mkdirSync(writableDirectory, { mode: 0o700 });
+            if (targetParent !== writableDirectory) mkdirSync(targetParent, { mode: 0o700 });
+            chmodSync(writableDirectory, 0o777);
+            const envFile = join(targetParent, "credentials.env");
+            let postCalls = 0;
+            const projectCallback = captureAdminProjectTool({
+                post: async () => {
+                    postCalls += 1;
+                    return { ok: true, status: 201, data: createResponse() };
+                },
+            });
+
+            const response = await projectCallback({
+                action: "create",
+                name: "unsafe-path-project",
+                api_domain: "api.example.test",
+                env_file: envFile,
+                environment: "test",
+            });
+
+            expect(postCalls).toBe(0);
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text).error.code)
+                .toBe("ENV_FILE_PARENT_INVALID");
+            expect(existsSync(envFile)).toBe(false);
+        },
+    );
+
     test.each(["darwin", "win32"] as const)(
         "fails closed on %s before requesting remote credentials or creating a file",
         async platform => {
@@ -495,7 +564,7 @@ describe("admin project create", () => {
                 } catch (error: unknown) {
                     exclusiveRaceBlocked = (error as { code?: string }).code === "EEXIST";
                 }
-                return { ok: true, status: 201, data: createResponse() };
+                return { ok: true, status: 201, data: createResponse({ name: "raced-project" }) };
             },
         });
 
@@ -546,6 +615,7 @@ describe("admin project create", () => {
                             dev: stat.dev,
                             ino: stat.ino,
                             mode: stat.mode,
+                            uid: stat.uid,
                             isDirectory: () => false,
                             isFile: () => !credentialsWritten,
                             isSymbolicLink: () => false,
@@ -558,7 +628,11 @@ describe("admin project create", () => {
             unlinkAt: async () => { throw new Error("private-unlink-detail"); },
         };
         const projectCallback = captureAdminProjectTool({
-            post: async () => ({ ok: true, status: 201, data: createResponse() }),
+            post: async () => ({
+                ok: true,
+                status: 201,
+                data: createResponse({ name: "cleanup-unknown-project" }),
+            }),
         }, { projectEnvFileOperations: fileOperations });
 
         const response = await projectCallback({

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -11,7 +11,7 @@ import {
     statSync,
     writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { lstat, open, realpath, unlink } from "node:fs/promises";
 import { registerAdminProjectCliTools } from "./project-cli-tools";
@@ -74,7 +74,7 @@ const CREATE_SERVICE_ROLE_KEY = [
 ].join(".");
 
 function createSandbox(): string {
-    const path = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-admin-create-")));
+    const path = realpathSync(mkdtempSync(join(homedir(), ".supacloud-admin-create-")));
     createSandboxes.push(path);
     return path;
 }
@@ -488,9 +488,14 @@ describe("admin project create", () => {
         expect(readFileSync(envFile, "utf8")).toBe("keep-me");
     });
 
-    test.each(["direct parent", "ancestor"] as const)(
-        "rejects a group or world-writable %s before the remote create",
-        async unsafeLevel => {
+    test.each([
+        ["mode 0777 direct parent", "direct parent", 0o777],
+        ["mode 1777 direct parent", "direct parent", 0o1777],
+        ["mode 0777 ancestor", "ancestor", 0o777],
+        ["mode 1777 ancestor", "ancestor", 0o1777],
+    ] as const)(
+        "rejects a %s before the remote create",
+        async (_scenario, unsafeLevel, unsafeMode) => {
             const root = createSandbox();
             const writableDirectory = join(root, "writable");
             const targetParent = unsafeLevel === "direct parent"
@@ -498,15 +503,24 @@ describe("admin project create", () => {
                 : join(writableDirectory, "protected");
             mkdirSync(writableDirectory, { mode: 0o700 });
             if (targetParent !== writableDirectory) mkdirSync(targetParent, { mode: 0o700 });
-            chmodSync(writableDirectory, 0o777);
+            chmodSync(writableDirectory, unsafeMode);
             const envFile = join(targetParent, "credentials.env");
             let postCalls = 0;
+            let reservationCalls = 0;
+            const baseFileOperations = testProjectEnvFileOperations();
+            const fileOperations: ProjectEnvFileOperations = {
+                ...baseFileOperations,
+                async openExclusiveAt(directory, filename, mode) {
+                    reservationCalls += 1;
+                    return baseFileOperations.openExclusiveAt(directory, filename, mode);
+                },
+            };
             const projectCallback = captureAdminProjectTool({
                 post: async () => {
                     postCalls += 1;
                     return { ok: true, status: 201, data: createResponse() };
                 },
-            });
+            }, { projectEnvFileOperations: fileOperations });
 
             const response = await projectCallback({
                 action: "create",
@@ -517,6 +531,7 @@ describe("admin project create", () => {
             });
 
             expect(postCalls).toBe(0);
+            expect(reservationCalls).toBe(0);
             expect(response.isError).toBe(true);
             expect(JSON.parse(response.content[0].text).error.code)
                 .toBe("ENV_FILE_PARENT_INVALID");

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -166,6 +166,11 @@ function projectCreateEnvironment(candidate: unknown): ProjectEnvironment | unde
     return candidate === "test" || candidate === "production" ? candidate : undefined;
 }
 
+interface ProjectCreateResponseBinding {
+    projectName: string;
+    apiOrigin?: string;
+}
+
 function projectCreateFileFailure(
     identity: ProjectCreateIdentity,
     credentialFileState: CredentialFileState,
@@ -260,19 +265,23 @@ async function discardProjectEnvReservation(
 async function projectCreateWithEnvResponse(
     response: HttpResult<unknown>,
     preparedEnvFile: PreparedProjectEnvFile,
-    expectedApiOrigin?: string,
+    binding: ProjectCreateResponseBinding,
     fileOperations?: ProjectEnvFileOperations,
 ): Promise<ProjectToolResponse> {
-    const credentials = parseProjectCreateCredentials(response.data, expectedApiOrigin);
+    const credentials = parseProjectCreateCredentials(
+        response.data,
+        binding.apiOrigin,
+        binding.projectName,
+    );
     if (!credentials) {
         const cleanupFailure = await discardProjectEnvReservation(
             preparedEnvFile,
             response,
-            expectedApiOrigin,
+            binding.apiOrigin,
             fileOperations,
         );
         return cleanupFailure
-            ?? invalidProjectCreateResponse(response.data, response.status, expectedApiOrigin);
+            ?? invalidProjectCreateResponse(response.data, response.status, binding.apiOrigin);
     }
     const writeFailure = await writeCreatedProjectEnv(
         preparedEnvFile,
@@ -286,7 +295,7 @@ async function projectCreateWithEnvResponse(
 async function projectCreateResponse(
     response: HttpResult<unknown>,
     preparedEnvFile: PreparedProjectEnvFile | undefined,
-    expectedApiOrigin: string | undefined,
+    binding: ProjectCreateResponseBinding,
     fileOperations?: ProjectEnvFileOperations,
 ): Promise<ProjectToolResponse> {
     if (!response.ok || response.status !== 201) {
@@ -294,7 +303,7 @@ async function projectCreateResponse(
             const cleanupFailure = await discardProjectEnvReservation(
                 preparedEnvFile,
                 response,
-                expectedApiOrigin,
+                binding.apiOrigin,
                 fileOperations,
             );
             if (cleanupFailure) return cleanupFailure;
@@ -304,8 +313,13 @@ async function projectCreateResponse(
             : projectCreateMutationFailure(response);
     }
     return preparedEnvFile
-        ? projectCreateWithEnvResponse(response, preparedEnvFile, expectedApiOrigin, fileOperations)
-        : projectCreateWithoutEnvResponse(response, expectedApiOrigin);
+        ? projectCreateWithEnvResponse(
+            response,
+            preparedEnvFile,
+            binding,
+            fileOperations,
+        )
+        : projectCreateWithoutEnvResponse(response, binding.apiOrigin);
 }
 
 function failedProjectServiceHttpResponse(response: HttpResult<unknown>): ProjectToolResponse {
@@ -621,7 +635,7 @@ export function registerAdminProjectCliTools(
                     return projectCreateResponse(
                         await http.post("/v1/projects", createRequest),
                         preparedEnvFile,
-                        boundApiOrigin,
+                        { projectName: name, apiOrigin: boundApiOrigin },
                         fileOperations,
                     );
                 }

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -2,6 +2,21 @@ import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
 import type { HttpResult, HttpTransport } from "../transports/http";
+import {
+    discardPreparedProjectEnvFile,
+    parseProjectCreateCredentials,
+    parseProjectCreateIdentity,
+    parseProjectCreateWithoutCredentials,
+    prepareProjectEnvFile,
+    ProjectCreateEnvError,
+    writeProjectEnvFile,
+    type CredentialFileState,
+    type ProjectCreateCredentials,
+    type ProjectCreateIdentity,
+    type ProjectEnvironment,
+    type ProjectEnvFileOperations,
+    type PreparedProjectEnvFile,
+} from "./project-create-env";
 
 type ToolServer = {
     tool: (
@@ -29,6 +44,10 @@ const AUTH_SERVICE_HOST_SUFFIX = "-auth";
 const SAFE_PROJECT_REF = /^[a-z0-9-]{1,20}$/;
 const SAFE_AUTHORITY_PROJECT_REF = /^[A-Za-z0-9_-]{1,20}$/;
 const MAX_SERVICE_CONTROL_MESSAGE_LENGTH = 256;
+const RELEASE_CONTROL_RESPONSE_SCHEMA = "supacloud.cli.release-control.v1";
+const PROJECT_CREATE_OPERATION = "project.create";
+const PROJECT_ENVIRONMENTS = ["test", "production"] as const satisfies readonly ProjectEnvironment[];
+const DNS_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
 type ProjectServiceName = typeof PROJECT_SERVICE_NAMES[number];
 type ProjectServiceControlAction = typeof PROJECT_SERVICE_CONTROL_ACTIONS[number];
@@ -68,6 +87,225 @@ function failedProjectServiceResponse(message: string): ProjectToolResponse {
         content: [{ type: "text", text: `❌ ${message}` }],
         isError: true,
     };
+}
+
+function projectCreateReceipt(payload: Record<string, unknown>): ProjectToolResponse {
+    return {
+        content: [{ type: "text", text: JSON.stringify({
+            schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
+            ...payload,
+        }, null, 2) }],
+    };
+}
+
+function projectCreateErrorReceipt(payload: Record<string, unknown>): ProjectToolResponse {
+    return { ...projectCreateReceipt(payload), isError: true };
+}
+
+function projectCreateFailure(
+    code: string,
+    httpStatus: number | null,
+): ProjectToolResponse {
+    return projectCreateErrorReceipt({
+        ok: false,
+        operation: PROJECT_CREATE_OPERATION,
+        error: { code, http_status: httpStatus },
+    });
+}
+
+function projectCreateMutationFailure(response: HttpResult<unknown>): ProjectToolResponse {
+    const outcomeUnknown = response.transportError || response.status === 408 || response.status >= 500;
+    return outcomeUnknown
+        ? projectCreateFailure("OUTCOME_UNKNOWN", response.transportError ? null : response.status)
+        : projectCreateFailure("HTTP_ERROR", response.status);
+}
+
+function isCompleteApiHostname(hostname: string): boolean {
+    if (hostname === "localhost") return true;
+    if (/^(?:\d{1,3}\.){3}\d{1,3}$/.test(hostname)) {
+        return hostname.split(".").every(octet => Number(octet) <= 255);
+    }
+    if (hostname.startsWith("[") && hostname.endsWith("]")) return true;
+    const labels = hostname.split(".");
+    return labels.length >= 2 && labels.every(label => DNS_LABEL.test(label));
+}
+
+function normalizedApiDomain(candidate?: string): string | undefined {
+    const normalized = candidate?.trim().toLowerCase();
+    if (!normalized || normalized.length > 253 || /[\s/@?#]/.test(normalized)) return undefined;
+    try {
+        const parsed = new URL(`https://${normalized}`);
+        const exactHostname = parsed.hostname === normalized && !parsed.port;
+        return exactHostname && isCompleteApiHostname(normalized) ? normalized : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function canonicalProjectApiOrigin(hostname: string): string {
+    const loopback = hostname === "localhost"
+        || hostname === "127.0.0.1"
+        || hostname === "[::1]";
+    return new URL(`${loopback ? "http" : "https"}://${hostname}`).origin;
+}
+
+function expectedProjectApiOrigin(domain?: string, apiDomain?: string): string | undefined {
+    if (apiDomain) {
+        const normalizedApi = normalizedApiDomain(apiDomain);
+        return normalizedApi ? canonicalProjectApiOrigin(normalizedApi) : undefined;
+    }
+    const normalizedDomain = normalizedApiDomain(domain);
+    if (!normalizedDomain) return undefined;
+    const hostname = normalizedDomain.startsWith("api.")
+        ? normalizedDomain
+        : `api.${normalizedDomain}`;
+    return canonicalProjectApiOrigin(hostname);
+}
+
+function projectCreateEnvironment(candidate: unknown): ProjectEnvironment | undefined {
+    return candidate === "test" || candidate === "production" ? candidate : undefined;
+}
+
+function projectCreateFileFailure(
+    identity: ProjectCreateIdentity,
+    credentialFileState: CredentialFileState,
+    code: string,
+    httpStatus: number,
+): ProjectToolResponse {
+    return projectCreateErrorReceipt({
+        ok: false,
+        operation: PROJECT_CREATE_OPERATION,
+        project_ref: identity.projectRef,
+        api_url: identity.apiUrl,
+        remote_created: true,
+        credential_file_state: credentialFileState,
+        ...(credentialFileState === "absent" ? { credentials_written: false } : {}),
+        retry_safe: false,
+        error: { code, http_status: httpStatus },
+    });
+}
+
+async function writeCreatedProjectEnv(
+    preparedEnvFile: PreparedProjectEnvFile,
+    credentials: ProjectCreateCredentials,
+    responseStatus: number,
+    fileOperations?: ProjectEnvFileOperations,
+): Promise<ProjectToolResponse | null> {
+    try {
+        await writeProjectEnvFile(preparedEnvFile, credentials, fileOperations);
+        return null;
+    } catch (error: unknown) {
+        const code = error instanceof ProjectCreateEnvError
+            ? error.code
+            : "ENV_FILE_WRITE_FAILED";
+        if (!(error instanceof ProjectCreateEnvError) || error.credentialFileState === "unknown") {
+            return projectCreateFileFailure(credentials, "unknown", code, responseStatus);
+        }
+        return projectCreateFileFailure(credentials, "absent", code, responseStatus);
+    }
+}
+
+function successfulProjectCreate(
+    identity: ProjectCreateIdentity,
+    preparedEnvFile?: PreparedProjectEnvFile,
+): ProjectToolResponse {
+    return projectCreateReceipt({
+        ok: true,
+        operation: PROJECT_CREATE_OPERATION,
+        project_ref: identity.projectRef,
+        api_url: identity.apiUrl,
+        credentials_written: Boolean(preparedEnvFile),
+        ...(preparedEnvFile ? {
+            env_file: preparedEnvFile.path,
+            env_file_scope: "project_application",
+        } : {}),
+    });
+}
+
+function invalidProjectCreateResponse(
+    responsePayload: unknown,
+    responseStatus: number,
+    expectedApiOrigin?: string,
+): ProjectToolResponse {
+    const identity = parseProjectCreateIdentity(responsePayload, expectedApiOrigin);
+    return identity
+        ? projectCreateFileFailure(identity, "absent", "INVALID_RESPONSE", responseStatus)
+        : projectCreateFailure("OUTCOME_UNKNOWN", responseStatus);
+}
+
+function projectCreateWithoutEnvResponse(
+    response: HttpResult<unknown>,
+    expectedApiOrigin?: string,
+): ProjectToolResponse {
+    const identity = parseProjectCreateWithoutCredentials(response.data, expectedApiOrigin);
+    return identity
+        ? successfulProjectCreate(identity)
+        : invalidProjectCreateResponse(response.data, response.status, expectedApiOrigin);
+}
+
+async function discardProjectEnvReservation(
+    preparedEnvFile: PreparedProjectEnvFile,
+    response: HttpResult<unknown>,
+    expectedApiOrigin: string | undefined,
+    fileOperations?: ProjectEnvFileOperations,
+): Promise<ProjectToolResponse | null> {
+    const credentialFileState = await discardPreparedProjectEnvFile(preparedEnvFile, fileOperations);
+    if (credentialFileState === "absent") return null;
+    const identity = parseProjectCreateIdentity(response.data, expectedApiOrigin);
+    return identity
+        ? projectCreateFileFailure(identity, "unknown", "ENV_FILE_CLEANUP_FAILED", response.status)
+        : projectCreateFailure("ENV_FILE_CLEANUP_FAILED", response.status);
+}
+
+async function projectCreateWithEnvResponse(
+    response: HttpResult<unknown>,
+    preparedEnvFile: PreparedProjectEnvFile,
+    expectedApiOrigin?: string,
+    fileOperations?: ProjectEnvFileOperations,
+): Promise<ProjectToolResponse> {
+    const credentials = parseProjectCreateCredentials(response.data, expectedApiOrigin);
+    if (!credentials) {
+        const cleanupFailure = await discardProjectEnvReservation(
+            preparedEnvFile,
+            response,
+            expectedApiOrigin,
+            fileOperations,
+        );
+        return cleanupFailure
+            ?? invalidProjectCreateResponse(response.data, response.status, expectedApiOrigin);
+    }
+    const writeFailure = await writeCreatedProjectEnv(
+        preparedEnvFile,
+        credentials,
+        response.status,
+        fileOperations,
+    );
+    return writeFailure ?? successfulProjectCreate(credentials, preparedEnvFile);
+}
+
+async function projectCreateResponse(
+    response: HttpResult<unknown>,
+    preparedEnvFile: PreparedProjectEnvFile | undefined,
+    expectedApiOrigin: string | undefined,
+    fileOperations?: ProjectEnvFileOperations,
+): Promise<ProjectToolResponse> {
+    if (!response.ok || response.status !== 201) {
+        if (preparedEnvFile) {
+            const cleanupFailure = await discardProjectEnvReservation(
+                preparedEnvFile,
+                response,
+                expectedApiOrigin,
+                fileOperations,
+            );
+            if (cleanupFailure) return cleanupFailure;
+        }
+        return response.ok
+            ? projectCreateFailure("OUTCOME_UNKNOWN", response.status)
+            : projectCreateMutationFailure(response);
+    }
+    return preparedEnvFile
+        ? projectCreateWithEnvResponse(response, preparedEnvFile, expectedApiOrigin, fileOperations)
+        : projectCreateWithoutEnvResponse(response, expectedApiOrigin);
 }
 
 function failedProjectServiceHttpResponse(response: HttpResult<unknown>): ProjectToolResponse {
@@ -283,7 +521,12 @@ export function registerUserProjectCliTools(
     );
 }
 
-export function registerAdminProjectCliTools(server: ToolServer, http: HttpTransport): void {
+export function registerAdminProjectCliTools(
+    server: ToolServer,
+    http: HttpTransport,
+    options: { projectEnvFileOperations?: ProjectEnvFileOperations } = {},
+): void {
+    const fileOperations = options.projectEnvFileOperations;
     server.tool(
         "project",
         "Platform-level project lifecycle management. Actions: list, create, get, delete, pause, restore, restart, settings, update_settings, api_keys, health, logs, tasks, services, service_control",
@@ -301,6 +544,14 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
             api_domain: optional(Type.String(), "[create] Explicit API domain"),
             auth_domain: optional(Type.String(), "[create] Explicit Auth/OIDC domain"),
             studio_domain: optional(Type.String(), "[create] Explicit Studio domain"),
+            env_file: optional(
+                Type.String(),
+                "[create] Linux-only absolute new application env path for parent-bound service-role delivery (0600)",
+            ),
+            environment: optional(
+                stringEnum(PROJECT_ENVIRONMENTS),
+                "[create] Required with env_file; application credential environment",
+            ),
             settings: optional(Type.Record(Type.String(), Type.Unknown()), "[update_settings] Config fields to update"),
             log_type: optional(stringEnum(["all", "auth", "database", "api"]), "[logs] Filter by service"),
             service: optional(stringEnum(PROJECT_SERVICE_NAMES), "[service_control] Canonical service name"),
@@ -319,6 +570,8 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
             api_domain,
             auth_domain,
             studio_domain,
+            env_file,
+            environment,
             settings,
             log_type,
             service,
@@ -332,6 +585,29 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
                     break;
                 case "create": {
                     if (!name) throw new Error("'name' is required for create");
+                    const boundApiOrigin = expectedProjectApiOrigin(domain, api_domain);
+                    if (env_file && !boundApiOrigin) {
+                        return projectCreateFailure("API_DOMAIN_BINDING_REQUIRED", null);
+                    }
+                    let preparedEnvFile: PreparedProjectEnvFile | undefined;
+                    if (env_file) {
+                        const boundEnvironment = projectCreateEnvironment(environment);
+                        if (!boundEnvironment) {
+                            return projectCreateFailure("ENVIRONMENT_BINDING_REQUIRED", null);
+                        }
+                        try {
+                            preparedEnvFile = await prepareProjectEnvFile(
+                                env_file,
+                                boundEnvironment,
+                                fileOperations,
+                            );
+                        } catch (error: unknown) {
+                            const code = error instanceof ProjectCreateEnvError
+                                ? error.code
+                                : "ENV_FILE_PATH_INVALID";
+                            return projectCreateFailure(code, null);
+                        }
+                    }
                     const createRequest: Record<string, string | undefined> = {
                         name,
                         region: region || "local",
@@ -341,8 +617,13 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
                     if (api_domain) createRequest.api_domain = api_domain;
                     if (auth_domain) createRequest.auth_domain = auth_domain;
                     if (studio_domain) createRequest.studio_domain = studio_domain;
-                    text = ok(await http.post("/v1/projects", createRequest));
-                    break;
+                    if (preparedEnvFile) createRequest.credential_delivery = "response";
+                    return projectCreateResponse(
+                        await http.post("/v1/projects", createRequest),
+                        preparedEnvFile,
+                        boundApiOrigin,
+                        fileOperations,
+                    );
                 }
                 case "get":
                     text = ok(await http.get(`/v1/projects/${resolveRef(ref)}`));

--- a/packages/admin/src/shared/tools/project-create-env.test.ts
+++ b/packages/admin/src/shared/tools/project-create-env.test.ts
@@ -622,6 +622,7 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
         const baseOperations = linuxTestOperations();
         const directory = sandbox();
         const target = join(directory, "close-race.env");
+        const displacedTarget = join(directory, "close-race-original.env");
         let replacementWritten = false;
         const operations: ProjectEnvFileOperations = {
             ...baseOperations,
@@ -637,7 +638,7 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
                         await openFile.close();
                         if (replacementWritten) return;
                         replacementWritten = true;
-                        rmSync(target, { force: true });
+                        renameSync(target, displacedTarget);
                         writeFileSync(target, "attacker replacement", { mode: 0o600 });
                     },
                 };
@@ -650,6 +651,7 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
             credentialFileState: "unknown",
         });
         expect(readFileSync(target, "utf8")).toBe("attacker replacement");
+        expect(readFileSync(displacedTarget, "utf8")).toContain(SERVICE_ROLE_KEY);
     });
 });
 

--- a/packages/admin/src/shared/tools/project-create-env.test.ts
+++ b/packages/admin/src/shared/tools/project-create-env.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+    chmodSync,
     constants,
+    existsSync,
     lstatSync,
     mkdirSync,
     mkdtempSync,
@@ -24,6 +26,7 @@ import {
 } from "./project-create-env";
 
 const PROJECT_REF = "abcdefghijklmnopqrst";
+const PROJECT_NAME = "secure-project";
 const API_URL = "https://api.example.test";
 const FUTURE_EXPIRATION = 4_102_444_800;
 const sandboxes: string[] = [];
@@ -35,6 +38,7 @@ function descriptorPath(directory: { fd: number }, filename: string): string {
 function linuxTestOperations(): ProjectEnvFileOperations {
     return {
         platform: "linux",
+        effectiveUid: () => process.geteuid?.() ?? -1,
         lstat,
         realpath,
         openDirectory: path => open(
@@ -57,6 +61,7 @@ async function fileStatWithMode(
         dev: stat.dev,
         ino: stat.ino,
         mode,
+        uid: stat.uid,
         isDirectory: () => stat.isDirectory(),
         isFile: () => stat.isFile(),
         isSymbolicLink: () => stat.isSymbolicLink(),
@@ -105,6 +110,7 @@ describe("project create response parsing", () => {
         const remoteSecret = "remote-secret-that-must-not-be-projected";
         const parsed = parseProjectCreateCredentials({
             ref: PROJECT_REF,
+            name: PROJECT_NAME,
             api: { url: API_URL, token: remoteSecret },
             credentials: {
                 service_role_key: SERVICE_ROLE_KEY,
@@ -114,7 +120,7 @@ describe("project create response parsing", () => {
             service_role_key: remoteSecret,
             secret_key: remoteSecret,
             message: remoteSecret.repeat(1_024),
-        }, "https://api.example.test");
+        }, "https://api.example.test", PROJECT_NAME);
 
         expect(parsed).toEqual(credentials());
         expect(JSON.stringify(parsed)).not.toContain(remoteSecret);
@@ -131,14 +137,16 @@ describe("project create response parsing", () => {
     test("rejects credential delivery without a complete expected API domain", () => {
         expect(parseProjectCreateCredentials({
             ref: PROJECT_REF,
+            name: PROJECT_NAME,
             api: { url: `https://${PROJECT_REF}.attacker.example` },
             credentials: { service_role_key: SERVICE_ROLE_KEY },
-        })).toBeNull();
+        }, undefined, PROJECT_NAME)).toBeNull();
     });
 
     test("binds credential delivery to the canonical API origin and port", () => {
         const response = (apiUrl: string) => ({
             ref: PROJECT_REF,
+            name: PROJECT_NAME,
             api: { url: apiUrl },
             credentials: { service_role_key: SERVICE_ROLE_KEY },
         });
@@ -146,11 +154,22 @@ describe("project create response parsing", () => {
         expect(parseProjectCreateCredentials(
             response("https://api.example.test:443"),
             "https://api.example.test",
+            PROJECT_NAME,
         )).toEqual(credentials());
         expect(parseProjectCreateCredentials(
             response("https://api.example.test:8443"),
             "https://api.example.test",
+            PROJECT_NAME,
         )).toBeNull();
+    });
+
+    test("binds one-time credentials to the exact requested project name", () => {
+        expect(parseProjectCreateCredentials({
+            ref: PROJECT_REF,
+            name: "stale-project",
+            api: { url: API_URL },
+            credentials: { service_role_key: SERVICE_ROLE_KEY },
+        }, API_URL, PROJECT_NAME)).toBeNull();
     });
 
     test.each([
@@ -172,8 +191,9 @@ describe("project create response parsing", () => {
         ["shell credential", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: "headerpart.payloadpart.$(private-command)" } }],
     ])("rejects %s without reflecting hostile fields", (_name, payload) => {
         expect(parseProjectCreateCredentials(
-            payload,
+            { name: PROJECT_NAME, ...payload },
             "https://api.example.test",
+            PROJECT_NAME,
         )).toBeNull();
     });
 
@@ -250,6 +270,28 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
             .rejects.toMatchObject({ code: "ENV_FILE_PATH_INVALID" });
     });
 
+    test("rejects group or world-writable target parents and ancestors", async () => {
+        const root = sandbox();
+        const writableParent = join(root, "writable-parent");
+        const writableAncestor = join(root, "writable-ancestor");
+        const protectedParent = join(writableAncestor, "protected-parent");
+        mkdirSync(writableParent, { mode: 0o700 });
+        mkdirSync(writableAncestor, { mode: 0o700 });
+        mkdirSync(protectedParent, { mode: 0o700 });
+        chmodSync(writableParent, 0o777);
+        chmodSync(writableAncestor, 0o777);
+
+        for (const target of [
+            join(writableParent, "direct.env"),
+            join(protectedParent, "ancestor.env"),
+        ]) {
+            await expect(prepareProjectEnvFile(target, "test"))
+                .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+        }
+        expect(readdirSync(writableParent)).toEqual([]);
+        expect(readdirSync(protectedParent)).toEqual([]);
+    });
+
     test.each(["chmod", "write", "sync", "stat", "close"] as const)(
         "sanitizes %s failures and removes the reserved target",
         async failureStage => {
@@ -291,9 +333,12 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
             const target = join(directory, `${failureStage}.env`);
             const prepared = await prepareProjectEnvFile(target, "test", operations);
 
-            await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject({
-                code: "ENV_FILE_WRITE_FAILED",
-            });
+            const cleanupUnknown = failureStage === "sync" || failureStage === "close";
+            await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject(
+                cleanupUnknown
+                    ? { code: "ENV_FILE_CLEANUP_FAILED", credentialFileState: "unknown" }
+                    : { code: "ENV_FILE_WRITE_FAILED", credentialFileState: "absent" },
+            );
             expect(readdirSync(directory)).toEqual([]);
         },
     );
@@ -389,6 +434,107 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
         expect(readFileSync(target, "utf8")).toContain(SERVICE_ROLE_KEY);
     });
 
+    test("reports unknown when the created directory entry cannot be synced", async () => {
+        const baseOperations = linuxTestOperations();
+        let directorySyncCalls = 0;
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openDirectory(path) {
+                const directory = await baseOperations.openDirectory(path);
+                return {
+                    fd: directory.fd,
+                    stat: () => directory.stat(),
+                    sync: async () => {
+                        directorySyncCalls += 1;
+                        if (directorySyncCalls === 1) throw new Error("private-directory-sync");
+                        await directory.sync();
+                    },
+                    close: () => directory.close(),
+                };
+            },
+        };
+        const directory = sandbox();
+        const target = join(directory, "directory-sync.env");
+        const prepared = await prepareProjectEnvFile(target, "test", operations);
+
+        await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject({
+            code: "ENV_FILE_CLEANUP_FAILED",
+            credentialFileState: "unknown",
+        });
+        expect(directorySyncCalls).toBe(2);
+        expect(existsSync(target)).toBe(false);
+    });
+
+    test("reports unknown when cleanup unlink cannot be synced", async () => {
+        const baseOperations = linuxTestOperations();
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openDirectory(path) {
+                const directory = await baseOperations.openDirectory(path);
+                return {
+                    fd: directory.fd,
+                    stat: () => directory.stat(),
+                    sync: async () => { throw new Error("private-cleanup-sync"); },
+                    close: () => directory.close(),
+                };
+            },
+            async openExclusiveAt(directory, filename, mode) {
+                const openFile = await baseOperations.openExclusiveAt(directory, filename, mode);
+                return {
+                    chmod: requestedMode => openFile.chmod(requestedMode),
+                    writeFile: async () => { throw new Error("private-write"); },
+                    sync: () => openFile.sync(),
+                    stat: () => openFile.stat(),
+                    truncate: length => openFile.truncate(length),
+                    close: () => openFile.close(),
+                };
+            },
+        };
+        const directory = sandbox();
+        const target = join(directory, "cleanup-sync.env");
+        const prepared = await prepareProjectEnvFile(target, "test", operations);
+
+        await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject({
+            code: "ENV_FILE_CLEANUP_FAILED",
+            credentialFileState: "unknown",
+        });
+        expect(existsSync(target)).toBe(false);
+    });
+
+    test("does not report absent when truncation fails before a durable unlink", async () => {
+        const baseOperations = linuxTestOperations();
+        let credentialsWritten = false;
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openExclusiveAt(directory, filename, mode) {
+                const openFile = await baseOperations.openExclusiveAt(directory, filename, mode);
+                return {
+                    chmod: requestedMode => openFile.chmod(requestedMode),
+                    writeFile: async contents => {
+                        await openFile.writeFile(contents);
+                        credentialsWritten = true;
+                    },
+                    sync: () => openFile.sync(),
+                    stat: () => fileStatWithMode(
+                        openFile,
+                        credentialsWritten ? 0o100644 : 0o100600,
+                    ),
+                    truncate: async () => { throw new Error("private-truncate"); },
+                    close: () => openFile.close(),
+                };
+            },
+        };
+        const directory = sandbox();
+        const target = join(directory, "truncate-unlink.env");
+        const prepared = await prepareProjectEnvFile(target, "test", operations);
+
+        await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject({
+            code: "ENV_FILE_CLEANUP_FAILED",
+            credentialFileState: "unknown",
+        });
+        expect(existsSync(target)).toBe(false);
+    });
+
     test("reserves the target before credential delivery and never overwrites it", async () => {
         const directory = sandbox();
         const target = join(directory, "reserved.env");
@@ -470,6 +616,40 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
             .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
         expect(readdirSync(parent)).toEqual([]);
         expect(readdirSync(movedParent)).toEqual([]);
+    });
+
+    test("rejects target replacement from the final file close before success", async () => {
+        const baseOperations = linuxTestOperations();
+        const directory = sandbox();
+        const target = join(directory, "close-race.env");
+        let replacementWritten = false;
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openExclusiveAt(parent, filename, mode) {
+                const openFile = await baseOperations.openExclusiveAt(parent, filename, mode);
+                return {
+                    chmod: requestedMode => openFile.chmod(requestedMode),
+                    writeFile: contents => openFile.writeFile(contents),
+                    sync: () => openFile.sync(),
+                    stat: () => openFile.stat(),
+                    truncate: length => openFile.truncate(length),
+                    close: async () => {
+                        await openFile.close();
+                        if (replacementWritten) return;
+                        replacementWritten = true;
+                        rmSync(target, { force: true });
+                        writeFileSync(target, "attacker replacement", { mode: 0o600 });
+                    },
+                };
+            },
+        };
+        const prepared = await prepareProjectEnvFile(target, "test", operations);
+
+        await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject({
+            code: "ENV_FILE_CLEANUP_FAILED",
+            credentialFileState: "unknown",
+        });
+        expect(readFileSync(target, "utf8")).toBe("attacker replacement");
     });
 });
 

--- a/packages/admin/src/shared/tools/project-create-env.test.ts
+++ b/packages/admin/src/shared/tools/project-create-env.test.ts
@@ -15,7 +15,7 @@ import {
     writeFileSync,
 } from "node:fs";
 import { lstat, open, realpath, unlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import {
     parseProjectCreateCredentials,
@@ -88,7 +88,7 @@ function roleKey(
 const SERVICE_ROLE_KEY = roleKey("service_role");
 
 function sandbox(): string {
-    const path = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-project-env-")));
+    const path = realpathSync(mkdtempSync(join(homedir(), ".supacloud-project-env-")));
     sandboxes.push(path);
     return path;
 }
@@ -270,26 +270,58 @@ describe.skipIf(process.platform !== "linux")("secure project env file", () => {
             .rejects.toMatchObject({ code: "ENV_FILE_PATH_INVALID" });
     });
 
-    test("rejects group or world-writable target parents and ancestors", async () => {
-        const root = sandbox();
-        const writableParent = join(root, "writable-parent");
-        const writableAncestor = join(root, "writable-ancestor");
-        const protectedParent = join(writableAncestor, "protected-parent");
-        mkdirSync(writableParent, { mode: 0o700 });
-        mkdirSync(writableAncestor, { mode: 0o700 });
-        mkdirSync(protectedParent, { mode: 0o700 });
-        chmodSync(writableParent, 0o777);
-        chmodSync(writableAncestor, 0o777);
+    test.each([
+        ["0777", 0o777],
+        ["1777", 0o1777],
+    ] as const)(
+        "rejects mode %s target parents and ancestors",
+        async (_modeName, unsafeMode) => {
+            const root = sandbox();
+            const writableParent = join(root, "writable-parent");
+            const writableAncestor = join(root, "writable-ancestor");
+            const protectedParent = join(writableAncestor, "protected-parent");
+            mkdirSync(writableParent, { mode: 0o700 });
+            mkdirSync(writableAncestor, { mode: 0o700 });
+            mkdirSync(protectedParent, { mode: 0o700 });
+            chmodSync(writableParent, unsafeMode);
+            chmodSync(writableAncestor, unsafeMode);
 
-        for (const target of [
-            join(writableParent, "direct.env"),
-            join(protectedParent, "ancestor.env"),
-        ]) {
-            await expect(prepareProjectEnvFile(target, "test"))
-                .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
-        }
-        expect(readdirSync(writableParent)).toEqual([]);
-        expect(readdirSync(protectedParent)).toEqual([]);
+            for (const target of [
+                join(writableParent, "direct.env"),
+                join(protectedParent, "ancestor.env"),
+            ]) {
+                await expect(prepareProjectEnvFile(target, "test"))
+                    .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+            }
+            expect(readdirSync(writableParent)).toEqual([]);
+            expect(readdirSync(protectedParent)).toEqual([]);
+        },
+    );
+
+    test("rejects a target parent not owned by the effective user", async () => {
+        const baseOperations = linuxTestOperations();
+        const directory = sandbox();
+        const effectiveUid = process.geteuid?.() ?? 0;
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async lstat(path) {
+                const pathStat = await baseOperations.lstat(path);
+                if (path !== directory) return pathStat;
+                return {
+                    dev: pathStat.dev,
+                    ino: pathStat.ino,
+                    mode: pathStat.mode,
+                    uid: effectiveUid === 0 ? 1 : effectiveUid + 1,
+                    isDirectory: () => pathStat.isDirectory(),
+                    isFile: () => pathStat.isFile(),
+                    isSymbolicLink: () => pathStat.isSymbolicLink(),
+                };
+            },
+        };
+
+        await expect(prepareProjectEnvFile(join(directory, "foreign.env"), "test", operations))
+            .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+        expect(readdirSync(directory)).toEqual([]);
     });
 
     test.each(["chmod", "write", "sync", "stat", "close"] as const)(

--- a/packages/admin/src/shared/tools/project-create-env.test.ts
+++ b/packages/admin/src/shared/tools/project-create-env.test.ts
@@ -1,0 +1,488 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+    constants,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    realpathSync,
+    renameSync,
+    rmSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { lstat, open, realpath, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    parseProjectCreateCredentials,
+    parseProjectCreateWithoutCredentials,
+    prepareProjectEnvFile,
+    writeProjectEnvFile,
+    type ProjectEnvFileOperations,
+} from "./project-create-env";
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const API_URL = "https://api.example.test";
+const FUTURE_EXPIRATION = 4_102_444_800;
+const sandboxes: string[] = [];
+
+function descriptorPath(directory: { fd: number }, filename: string): string {
+    return `/proc/self/fd/${directory.fd}/${filename}`;
+}
+
+function linuxTestOperations(): ProjectEnvFileOperations {
+    return {
+        platform: "linux",
+        lstat,
+        realpath,
+        openDirectory: path => open(
+            path,
+            constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+        ),
+        openExclusiveAt: (directory, filename, mode) =>
+            open(descriptorPath(directory, filename), "wx", mode),
+        lstatAt: (directory, filename) => lstat(descriptorPath(directory, filename)),
+        unlinkAt: (directory, filename) => unlink(descriptorPath(directory, filename)),
+    };
+}
+
+async function fileStatWithMode(
+    file: Awaited<ReturnType<ProjectEnvFileOperations["openExclusiveAt"]>>,
+    mode: number,
+) {
+    const stat = await file.stat();
+    return {
+        dev: stat.dev,
+        ino: stat.ino,
+        mode,
+        isDirectory: () => stat.isDirectory(),
+        isFile: () => stat.isFile(),
+        isSymbolicLink: () => stat.isSymbolicLink(),
+    };
+}
+
+function jwtSegment(claims: Record<string, unknown>): string {
+    return Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+}
+
+function roleKey(
+    role: string,
+    issuer = "supabase",
+    algorithm = "HS256",
+    claims: Record<string, unknown> = { exp: FUTURE_EXPIRATION },
+): string {
+    return [
+        jwtSegment({ alg: algorithm, typ: "JWT" }),
+        jwtSegment({ role, iss: issuer, ...claims }),
+        "s".repeat(43),
+    ].join(".");
+}
+
+const SERVICE_ROLE_KEY = roleKey("service_role");
+
+function sandbox(): string {
+    const path = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-project-env-")));
+    sandboxes.push(path);
+    return path;
+}
+
+function credentials() {
+    return {
+        projectRef: PROJECT_REF,
+        apiUrl: API_URL,
+        serviceRoleKey: SERVICE_ROLE_KEY,
+    };
+}
+
+afterEach(() => {
+    for (const path of sandboxes.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("project create response parsing", () => {
+    test("extracts only the fixed project and one-time credential fields", () => {
+        const remoteSecret = "remote-secret-that-must-not-be-projected";
+        const parsed = parseProjectCreateCredentials({
+            ref: PROJECT_REF,
+            api: { url: API_URL, token: remoteSecret },
+            credentials: {
+                service_role_key: SERVICE_ROLE_KEY,
+                jwt_secret: remoteSecret,
+                db_password: remoteSecret,
+            },
+            service_role_key: remoteSecret,
+            secret_key: remoteSecret,
+            message: remoteSecret.repeat(1_024),
+        }, "https://api.example.test");
+
+        expect(parsed).toEqual(credentials());
+        expect(JSON.stringify(parsed)).not.toContain(remoteSecret);
+    });
+
+    test("rejects a credential-bearing response when delivery was not requested", () => {
+        expect(parseProjectCreateWithoutCredentials({
+            ref: PROJECT_REF,
+            api: { url: API_URL },
+            credentials: { service_role_key: SERVICE_ROLE_KEY },
+        }, "https://api.example.test")).toBeNull();
+    });
+
+    test("rejects credential delivery without a complete expected API domain", () => {
+        expect(parseProjectCreateCredentials({
+            ref: PROJECT_REF,
+            api: { url: `https://${PROJECT_REF}.attacker.example` },
+            credentials: { service_role_key: SERVICE_ROLE_KEY },
+        })).toBeNull();
+    });
+
+    test("binds credential delivery to the canonical API origin and port", () => {
+        const response = (apiUrl: string) => ({
+            ref: PROJECT_REF,
+            api: { url: apiUrl },
+            credentials: { service_role_key: SERVICE_ROLE_KEY },
+        });
+
+        expect(parseProjectCreateCredentials(
+            response("https://api.example.test:443"),
+            "https://api.example.test",
+        )).toEqual(credentials());
+        expect(parseProjectCreateCredentials(
+            response("https://api.example.test:8443"),
+            "https://api.example.test",
+        )).toBeNull();
+    });
+
+    test.each([
+        ["invalid ref", { ref: "secret-ref", api: { url: API_URL }, credentials: { service_role_key: SERVICE_ROLE_KEY } }],
+        ["invalid API payload", { ref: PROJECT_REF, api: API_URL, credentials: { service_role_key: SERVICE_ROLE_KEY } }],
+        ["wrong API origin", { ref: PROJECT_REF, api: { url: "https://wrong.example.test" }, credentials: { service_role_key: SERVICE_ROLE_KEY } }],
+        ["credentialed URL", { ref: PROJECT_REF, api: { url: "https://secret@api.example.test" }, credentials: { service_role_key: SERVICE_ROLE_KEY } }],
+        ["URL query", { ref: PROJECT_REF, api: { url: `${API_URL}?secret=value` }, credentials: { service_role_key: SERVICE_ROLE_KEY } }],
+        ["external HTTP URL", { ref: PROJECT_REF, api: { url: "http://api.example.test" }, credentials: { service_role_key: SERVICE_ROLE_KEY } }],
+        ["missing credentials", { ref: PROJECT_REF, api: { url: API_URL } }],
+        ["short credential", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: "short" } }],
+        ["anon credential", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: roleKey("anon") } }],
+        ["wrong issuer", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: roleKey("service_role", "attacker") } }],
+        ["unsafe algorithm", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: roleKey("service_role", "supabase", "none") } }],
+        ["missing expiration", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: roleKey("service_role", "supabase", "HS256", {}) } }],
+        ["expired credential", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: roleKey("service_role", "supabase", "HS256", { exp: 1 }) } }],
+        ["non-numeric expiration", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: roleKey("service_role", "supabase", "HS256", { exp: "tomorrow" }) } }],
+        ["multiline credential", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: `${SERVICE_ROLE_KEY}\nsecret` } }],
+        ["shell credential", { ref: PROJECT_REF, api: { url: API_URL }, credentials: { service_role_key: "headerpart.payloadpart.$(private-command)" } }],
+    ])("rejects %s without reflecting hostile fields", (_name, payload) => {
+        expect(parseProjectCreateCredentials(
+            payload,
+            "https://api.example.test",
+        )).toBeNull();
+    });
+
+    test.each([
+        ["IPv4", "http://127.0.0.1"],
+        ["IPv6", "http://[::1]"],
+    ])("accepts %s loopback HTTP only for local development", (_family, apiUrl) => {
+        expect(parseProjectCreateWithoutCredentials({
+            ref: PROJECT_REF,
+            api: { url: apiUrl },
+        }, apiUrl)).toEqual({
+            projectRef: PROJECT_REF,
+            apiUrl,
+        });
+    });
+});
+
+describe.skipIf(process.platform !== "linux")("secure project env file", () => {
+    test.each(["test", "production"] as const)(
+        "exclusively writes four %s application settings with Unix mode 0600",
+        async environment => {
+            const directory = sandbox();
+            const target = join(directory, `.env.project-credentials.${environment}`);
+            const prepared = await prepareProjectEnvFile(target, environment);
+
+            await writeProjectEnvFile(prepared, credentials());
+
+            expect(readFileSync(target, "utf8")).toBe([
+                `SUPACLOUD_ENV=${environment}`,
+                `SUPACLOUD_PROJECT_REF=${PROJECT_REF}`,
+                `SUPABASE_URL=${API_URL}`,
+                `SUPABASE_SERVICE_ROLE_KEY=${SERVICE_ROLE_KEY}`,
+                "",
+            ].join("\n"));
+            expect(lstatSync(target).isFile()).toBe(true);
+            if (process.platform !== "win32") expect(lstatSync(target).mode & 0o777).toBe(0o600);
+            expect(readdirSync(directory)).toEqual([`.env.project-credentials.${environment}`]);
+        },
+    );
+
+    test("rejects existing files, directories, symlinks, and dangling symlinks", async () => {
+        const directory = sandbox();
+        const existingFile = join(directory, "existing.env");
+        const existingDirectory = join(directory, "existing-directory");
+        const symlink = join(directory, "linked.env");
+        const dangling = join(directory, "dangling.env");
+        writeFileSync(existingFile, "existing");
+        mkdirSync(existingDirectory);
+        symlinkSync(existingFile, symlink);
+        symlinkSync(join(directory, "missing.env"), dangling);
+
+        for (const target of [existingFile, existingDirectory, symlink, dangling]) {
+            await expect(prepareProjectEnvFile(target, "test")).rejects.toMatchObject({
+                code: "ENV_FILE_EXISTS",
+            });
+        }
+        expect(readFileSync(existingFile, "utf8")).toBe("existing");
+    });
+
+    test("rejects missing or symlinked parents and non-canonical paths", async () => {
+        const directory = sandbox();
+        const realDirectory = join(directory, "real-parent");
+        const linkedDirectory = join(directory, "linked-parent");
+        mkdirSync(realDirectory);
+        symlinkSync(realDirectory, linkedDirectory);
+
+        await expect(prepareProjectEnvFile(join(directory, "missing", ".env"), "test"))
+            .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+        await expect(prepareProjectEnvFile(join(linkedDirectory, ".env"), "test"))
+            .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+        await expect(prepareProjectEnvFile(`${directory}/real-parent/../.env`, "test"))
+            .rejects.toMatchObject({ code: "ENV_FILE_PATH_INVALID" });
+        await expect(prepareProjectEnvFile("relative.env", "test"))
+            .rejects.toMatchObject({ code: "ENV_FILE_PATH_INVALID" });
+    });
+
+    test.each(["chmod", "write", "sync", "stat", "close"] as const)(
+        "sanitizes %s failures and removes the reserved target",
+        async failureStage => {
+            const baseOperations = linuxTestOperations();
+            let chmodCalls = 0;
+            let credentialsWritten = false;
+            const operations: ProjectEnvFileOperations = {
+                ...baseOperations,
+                async openExclusiveAt(directory, filename, mode) {
+                    const handle = await baseOperations.openExclusiveAt(directory, filename, mode);
+                    return {
+                        chmod: async requestedMode => {
+                            chmodCalls += 1;
+                            if (failureStage === "chmod" && chmodCalls === 2) throw new Error("private-chmod");
+                            await handle.chmod(requestedMode);
+                        },
+                        writeFile: async contents => {
+                            if (failureStage === "write") throw new Error("private-write");
+                            await handle.writeFile(contents);
+                            credentialsWritten = true;
+                        },
+                        sync: async () => {
+                            if (failureStage === "sync" && credentialsWritten) throw new Error("private-sync");
+                            await handle.sync();
+                        },
+                        stat: async () => {
+                            if (failureStage === "stat" && credentialsWritten) throw new Error("private-stat");
+                            return handle.stat();
+                        },
+                        truncate: length => handle.truncate(length),
+                        close: async () => {
+                            await handle.close();
+                            if (failureStage === "close") throw new Error("private-close");
+                        },
+                    };
+                },
+            };
+            const directory = sandbox();
+            const target = join(directory, `${failureStage}.env`);
+            const prepared = await prepareProjectEnvFile(target, "test", operations);
+
+            await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject({
+                code: "ENV_FILE_WRITE_FAILED",
+            });
+            expect(readdirSync(directory)).toEqual([]);
+        },
+    );
+
+    test.each(["open", "chmod"] as const)(
+        "fails closed when secure reservation %s fails",
+        async failureStage => {
+            const baseOperations = linuxTestOperations();
+            const operations: ProjectEnvFileOperations = {
+                ...baseOperations,
+                async openExclusiveAt(directory, filename, mode) {
+                    if (failureStage === "open") throw new Error("private-open");
+                    const handle = await baseOperations.openExclusiveAt(directory, filename, mode);
+                    return {
+                        chmod: async () => { throw new Error("private-chmod"); },
+                        writeFile: contents => handle.writeFile(contents),
+                        sync: () => handle.sync(),
+                        stat: () => handle.stat(),
+                        truncate: length => handle.truncate(length),
+                        close: () => handle.close(),
+                    };
+                },
+            };
+            const directory = sandbox();
+
+            await expect(prepareProjectEnvFile(
+                join(directory, `${failureStage}.env`),
+                "test",
+                operations,
+            )).rejects.toMatchObject({ code: "ENV_FILE_WRITE_FAILED" });
+            expect(readdirSync(directory)).toEqual([]);
+        },
+    );
+
+    test("removes the reservation when its permission check fails", async () => {
+        const baseOperations = linuxTestOperations();
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openExclusiveAt(directory, filename, mode) {
+                const openFile = await baseOperations.openExclusiveAt(directory, filename, mode);
+                return {
+                    chmod: requestedMode => openFile.chmod(requestedMode),
+                    writeFile: contents => openFile.writeFile(contents),
+                    sync: () => openFile.sync(),
+                    stat: () => fileStatWithMode(openFile, 0o100644),
+                    truncate: length => openFile.truncate(length),
+                    close: () => openFile.close(),
+                };
+            },
+        };
+        const directory = sandbox();
+
+        await expect(prepareProjectEnvFile(
+            join(directory, "unsafe-mode.env"),
+            "test",
+            operations,
+        )).rejects.toMatchObject({ code: "ENV_FILE_VERIFY_FAILED" });
+        expect(readdirSync(directory)).toEqual([]);
+    });
+
+    test("reports unknown credential state when truncate and descriptor-relative unlink fail", async () => {
+        const baseOperations = linuxTestOperations();
+        let credentialsWritten = false;
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openExclusiveAt(directory, filename, mode) {
+                const openFile = await baseOperations.openExclusiveAt(directory, filename, mode);
+                return {
+                    chmod: requestedMode => openFile.chmod(requestedMode),
+                    writeFile: async contents => {
+                        await openFile.writeFile(contents);
+                        credentialsWritten = true;
+                    },
+                    sync: () => openFile.sync(),
+                    stat: () => fileStatWithMode(
+                        openFile,
+                        credentialsWritten ? 0o100644 : 0o100600,
+                    ),
+                    truncate: async () => { throw new Error("private-truncate-detail"); },
+                    close: () => openFile.close(),
+                };
+            },
+            unlinkAt: async () => { throw new Error("private-unlink-detail"); },
+        };
+        const directory = sandbox();
+        const target = join(directory, "cleanup-unknown.env");
+        const prepared = await prepareProjectEnvFile(target, "test", operations);
+
+        await expect(writeProjectEnvFile(prepared, credentials(), operations)).rejects.toMatchObject({
+            code: "ENV_FILE_CLEANUP_FAILED",
+            credentialFileState: "unknown",
+        });
+        expect(readFileSync(target, "utf8")).toContain(SERVICE_ROLE_KEY);
+    });
+
+    test("reserves the target before credential delivery and never overwrites it", async () => {
+        const directory = sandbox();
+        const target = join(directory, "reserved.env");
+        const prepared = await prepareProjectEnvFile(target, "test");
+
+        expect(() => writeFileSync(target, "raced", { flag: "wx" })).toThrow();
+        await writeProjectEnvFile(prepared, credentials());
+        expect(readFileSync(target, "utf8")).toContain(SERVICE_ROLE_KEY);
+    });
+
+    test("blocks a real parent rename and replacement between binding and create", async () => {
+        const baseOperations = linuxTestOperations();
+        const root = sandbox();
+        const parent = join(root, "parent");
+        const movedParent = join(root, "moved-parent");
+        mkdirSync(parent);
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openExclusiveAt(directory, filename, mode) {
+                renameSync(parent, movedParent);
+                mkdirSync(parent);
+                return baseOperations.openExclusiveAt(directory, filename, mode);
+            },
+        };
+
+        await expect(prepareProjectEnvFile(
+            join(parent, "credentials.env"),
+            "test",
+            operations,
+        )).rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+        expect(readdirSync(parent)).toEqual([]);
+        expect(readdirSync(movedParent)).toEqual([]);
+    });
+
+    test("cleans through the held descriptor when the parent changes before write", async () => {
+        const root = sandbox();
+        const parent = join(root, "write-parent");
+        const movedParent = join(root, "write-parent-moved");
+        const target = join(parent, "credentials.env");
+        mkdirSync(parent);
+        const prepared = await prepareProjectEnvFile(target, "test");
+        renameSync(parent, movedParent);
+        mkdirSync(parent);
+
+        await expect(writeProjectEnvFile(prepared, credentials()))
+            .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+        expect(readdirSync(parent)).toEqual([]);
+        expect(readdirSync(movedParent)).toEqual([]);
+    });
+
+    test("cleans through the held descriptor when the parent changes during write", async () => {
+        const baseOperations = linuxTestOperations();
+        const root = sandbox();
+        const parent = join(root, "write-race-parent");
+        const movedParent = join(root, "write-race-parent-moved");
+        const target = join(parent, "credentials.env");
+        mkdirSync(parent);
+        const operations: ProjectEnvFileOperations = {
+            ...baseOperations,
+            async openExclusiveAt(directory, filename, mode) {
+                const openFile = await baseOperations.openExclusiveAt(directory, filename, mode);
+                return {
+                    chmod: requestedMode => openFile.chmod(requestedMode),
+                    async writeFile(contents) {
+                        await openFile.writeFile(contents);
+                        renameSync(parent, movedParent);
+                        mkdirSync(parent);
+                    },
+                    sync: () => openFile.sync(),
+                    stat: () => openFile.stat(),
+                    truncate: length => openFile.truncate(length),
+                    close: () => openFile.close(),
+                };
+            },
+        };
+        const prepared = await prepareProjectEnvFile(target, "test", operations);
+
+        await expect(writeProjectEnvFile(prepared, credentials(), operations))
+            .rejects.toMatchObject({ code: "ENV_FILE_PARENT_INVALID" });
+        expect(readdirSync(parent)).toEqual([]);
+        expect(readdirSync(movedParent)).toEqual([]);
+    });
+});
+
+test.each(["darwin", "win32"] as const)(
+    "fails closed on %s before creating a credential reservation",
+    async platform => {
+        const directory = sandbox();
+        const target = join(directory, `${platform}.env`);
+        const operations = { ...linuxTestOperations(), platform };
+
+        await expect(prepareProjectEnvFile(target, "test", operations)).rejects.toMatchObject({
+            code: "ENV_FILE_PLATFORM_UNSUPPORTED",
+        });
+        expect(readdirSync(directory)).toEqual([]);
+    },
+);

--- a/packages/admin/src/shared/tools/project-create-env.ts
+++ b/packages/admin/src/shared/tools/project-create-env.ts
@@ -1,0 +1,542 @@
+import { constants } from "node:fs";
+import { isAbsolute, basename, dirname, normalize, resolve } from "node:path";
+import {
+    lstat,
+    open,
+    realpath,
+    unlink,
+    type FileHandle,
+} from "node:fs/promises";
+
+const PROJECT_REF = /^[a-z]{20}$/;
+const SERVICE_ROLE_KEY = /^[A-Za-z0-9_-]{8,2048}\.[A-Za-z0-9_-]{8,8192}\.[A-Za-z0-9_-]{8,2048}$/;
+const SERVICE_ROLE_ALGORITHMS = new Set(["HS256", "ES256"]);
+const MAX_ENV_FILE_PATH_BYTES = 4_096;
+const ENV_FILE_MODE = 0o600;
+const PROC_SELF_FD = "/proc/self/fd";
+
+export type ProjectCreateEnvErrorCode =
+    | "ENV_FILE_PATH_INVALID"
+    | "ENV_FILE_PLATFORM_UNSUPPORTED"
+    | "ENV_FILE_PARENT_INVALID"
+    | "ENV_FILE_EXISTS"
+    | "ENV_FILE_WRITE_FAILED"
+    | "ENV_FILE_VERIFY_FAILED"
+    | "ENV_FILE_CLEANUP_FAILED";
+
+export type CredentialFileState = "absent" | "unknown";
+export type ProjectEnvironment = "test" | "production";
+
+export class ProjectCreateEnvError extends Error {
+    constructor(
+        public readonly code: ProjectCreateEnvErrorCode,
+        public readonly credentialFileState: CredentialFileState = "absent",
+    ) {
+        super(code);
+        this.name = "ProjectCreateEnvError";
+    }
+}
+
+interface ProjectEnvFileStat {
+    dev: number;
+    ino: number;
+    mode: number;
+    isDirectory(): boolean;
+    isFile(): boolean;
+    isSymbolicLink(): boolean;
+}
+
+interface ProjectEnvFileHandle {
+    chmod(mode: number): Promise<void>;
+    writeFile(contents: string): Promise<void>;
+    sync(): Promise<void>;
+    stat(): Promise<ProjectEnvFileStat>;
+    truncate(length?: number): Promise<void>;
+    close(): Promise<void>;
+}
+
+interface ProjectEnvDirectoryHandle {
+    fd: number;
+    stat(): Promise<ProjectEnvFileStat>;
+    close(): Promise<void>;
+}
+
+export interface ProjectEnvFileOperations {
+    platform: NodeJS.Platform;
+    lstat(path: string): Promise<ProjectEnvFileStat>;
+    realpath(path: string): Promise<string>;
+    openDirectory(path: string): Promise<ProjectEnvDirectoryHandle>;
+    openExclusiveAt(
+        directory: ProjectEnvDirectoryHandle,
+        filename: string,
+        mode: number,
+    ): Promise<ProjectEnvFileHandle>;
+    lstatAt(directory: ProjectEnvDirectoryHandle, filename: string): Promise<ProjectEnvFileStat>;
+    unlinkAt(directory: ProjectEnvDirectoryHandle, filename: string): Promise<void>;
+}
+
+function descriptorRelativePath(directory: ProjectEnvDirectoryHandle, filename: string): string {
+    return `${PROC_SELF_FD}/${directory.fd}/${filename}`;
+}
+
+const nodeProjectEnvFileOperations: ProjectEnvFileOperations = {
+    platform: process.platform,
+    lstat,
+    realpath,
+    openDirectory: path => open(
+        path,
+        constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    ) as Promise<FileHandle>,
+    openExclusiveAt: (directory, filename, mode) => open(
+        descriptorRelativePath(directory, filename),
+        "wx",
+        mode,
+    ) as Promise<FileHandle>,
+    lstatAt: (directory, filename) => lstat(descriptorRelativePath(directory, filename)),
+    unlinkAt: (directory, filename) => unlink(descriptorRelativePath(directory, filename)),
+};
+
+interface ProjectEnvFileIdentity {
+    dev: number;
+    ino: number;
+}
+
+interface ProjectEnvParentIdentity extends ProjectEnvFileIdentity {
+    canonicalPath: string;
+}
+
+interface FailedProjectEnvFileCleanup {
+    directoryHandle: ProjectEnvDirectoryHandle;
+    filename: string;
+    openFile: ProjectEnvFileHandle | null;
+    fileIdentity: ProjectEnvFileIdentity | null;
+    operations: ProjectEnvFileOperations;
+}
+
+export interface PreparedProjectEnvFile {
+    path: string;
+    filename: string;
+    environment: ProjectEnvironment;
+    parentIdentity: ProjectEnvParentIdentity;
+    fileIdentity: ProjectEnvFileIdentity;
+    directoryHandle: ProjectEnvDirectoryHandle | null;
+    openFile: ProjectEnvFileHandle | null;
+}
+
+export interface ProjectCreateIdentity {
+    projectRef: string;
+    apiUrl: string;
+}
+
+export interface ProjectCreateCredentials extends ProjectCreateIdentity {
+    serviceRoleKey: string;
+}
+
+function fileSystemErrorCode(candidate: unknown): string | null {
+    if (!candidate || typeof candidate !== "object" || !("code" in candidate)) return null;
+    return typeof candidate.code === "string" ? candidate.code : null;
+}
+
+async function assertTargetAbsent(
+    path: string,
+    operations: ProjectEnvFileOperations,
+): Promise<void> {
+    try {
+        await operations.lstat(path);
+    } catch (error: unknown) {
+        if (fileSystemErrorCode(error) === "ENOENT") return;
+        throw new ProjectCreateEnvError("ENV_FILE_PATH_INVALID");
+    }
+    throw new ProjectCreateEnvError("ENV_FILE_EXISTS");
+}
+
+async function assertSafeParent(
+    directory: string,
+    operations: ProjectEnvFileOperations,
+): Promise<ProjectEnvParentIdentity> {
+    try {
+        const parentBeforeRealpath = await operations.lstat(directory);
+        const canonicalParent = await operations.realpath(directory);
+        const parentAfterRealpath = await operations.lstat(directory);
+        if (
+            !parentBeforeRealpath.isDirectory()
+            || parentBeforeRealpath.isSymbolicLink()
+            || !parentAfterRealpath.isDirectory()
+            || parentAfterRealpath.isSymbolicLink()
+            || canonicalParent !== directory
+            || !sameFileIdentity(parentBeforeRealpath, parentAfterRealpath)
+        ) {
+            throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+        }
+        return {
+            canonicalPath: canonicalParent,
+            dev: parentAfterRealpath.dev,
+            ino: parentAfterRealpath.ino,
+        };
+    } catch (error: unknown) {
+        if (error instanceof ProjectCreateEnvError) throw error;
+        throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+    }
+}
+
+function sameFileIdentity(
+    first: ProjectEnvFileIdentity,
+    second: ProjectEnvFileIdentity,
+): boolean {
+    return first.dev === second.dev && first.ino === second.ino;
+}
+
+function hasSafeRequestedPath(requestedPath: string): boolean {
+    return Boolean(requestedPath)
+        && isAbsolute(requestedPath)
+        && requestedPath === normalize(requestedPath)
+        && requestedPath === resolve(requestedPath)
+        && Buffer.byteLength(requestedPath, "utf8") <= MAX_ENV_FILE_PATH_BYTES
+        && !/[\0\r\n]/.test(requestedPath)
+        && ![".", ".."].includes(basename(requestedPath));
+}
+
+export async function prepareProjectEnvFile(
+    requestedPath: string,
+    environment: ProjectEnvironment,
+    operations: ProjectEnvFileOperations = nodeProjectEnvFileOperations,
+): Promise<PreparedProjectEnvFile> {
+    if (operations.platform !== "linux") {
+        throw new ProjectCreateEnvError("ENV_FILE_PLATFORM_UNSUPPORTED");
+    }
+    if (!hasSafeRequestedPath(requestedPath)) {
+        throw new ProjectCreateEnvError("ENV_FILE_PATH_INVALID");
+    }
+    const directory = dirname(requestedPath);
+    const filename = basename(requestedPath);
+    const parentIdentity = await assertSafeParent(directory, operations);
+    await assertTargetAbsent(requestedPath, operations);
+    let directoryHandle: ProjectEnvDirectoryHandle | null = null;
+    let openFile: ProjectEnvFileHandle | null = null;
+    let fileIdentity: ProjectEnvFileIdentity | null = null;
+    try {
+        directoryHandle = await operations.openDirectory(directory);
+        await assertDirectoryBinding(directory, directoryHandle, parentIdentity, operations);
+        openFile = await openProjectEnvFile(directoryHandle, filename, operations);
+        const openFileStat = await openFile.stat();
+        assertSecureFileType(openFileStat);
+        fileIdentity = { dev: openFileStat.dev, ino: openFileStat.ino };
+        await openFile.chmod(ENV_FILE_MODE);
+        const prepared = {
+            path: requestedPath,
+            filename,
+            environment,
+            parentIdentity,
+            fileIdentity,
+            directoryHandle,
+            openFile,
+        };
+        await assertPreparedFileBinding(prepared, operations);
+        return prepared;
+    } catch (error: unknown) {
+        if (directoryHandle) {
+            const credentialFileState = await removeFailedEnvFile(
+                { directoryHandle, filename, openFile, fileIdentity, operations },
+            );
+            if (credentialFileState === "unknown") {
+                throw new ProjectCreateEnvError("ENV_FILE_CLEANUP_FAILED", "unknown");
+            }
+        }
+        if (error instanceof ProjectCreateEnvError) throw error;
+        throw new ProjectCreateEnvError("ENV_FILE_WRITE_FAILED");
+    }
+}
+
+function environmentFileContent(
+    credentials: ProjectCreateCredentials,
+    environment: ProjectEnvironment,
+): string {
+    return [
+        `SUPACLOUD_ENV=${environment}`,
+        `SUPACLOUD_PROJECT_REF=${credentials.projectRef}`,
+        `SUPABASE_URL=${credentials.apiUrl}`,
+        `SUPABASE_SERVICE_ROLE_KEY=${credentials.serviceRoleKey}`,
+        "",
+    ].join("\n");
+}
+
+async function sanitizeAndClose(openFile: ProjectEnvFileHandle): Promise<boolean> {
+    let sanitized = true;
+    try {
+        await openFile.truncate(0);
+        await openFile.sync();
+    } catch {
+        sanitized = false;
+    }
+    try {
+        await openFile.close();
+    } catch {
+        // Unlink does not require the file descriptor to close successfully.
+    }
+    return sanitized;
+}
+
+async function removeFailedEnvFile(
+    cleanup: FailedProjectEnvFileCleanup,
+): Promise<CredentialFileState> {
+    const { directoryHandle, filename, openFile, fileIdentity, operations } = cleanup;
+    if (!openFile) {
+        try {
+            await directoryHandle.close();
+        } catch {
+            // No credential file was created, so descriptor cleanup cannot change its state.
+        }
+        return "absent";
+    }
+    const sanitized = await sanitizeAndClose(openFile);
+    let credentialFileState: CredentialFileState = "absent";
+    try {
+        const targetStat = await operations.lstatAt(directoryHandle, filename);
+        if (!fileIdentity || !sameFileIdentity(targetStat, fileIdentity)) {
+            credentialFileState = "unknown";
+        } else {
+            await operations.unlinkAt(directoryHandle, filename);
+        }
+    } catch (error: unknown) {
+        if (fileSystemErrorCode(error) !== "ENOENT" || !sanitized) {
+            credentialFileState = "unknown";
+        }
+    }
+    try {
+        await directoryHandle.close();
+    } catch {
+        // Closing the held directory does not change the verified credential file state.
+    }
+    return credentialFileState;
+}
+
+function assertSecureFileType(fileStat: ProjectEnvFileStat): void {
+    if (!fileStat.isFile() || fileStat.isSymbolicLink()) {
+        throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
+    }
+}
+
+function assertSecureOpenFile(fileStat: ProjectEnvFileStat): void {
+    assertSecureFileType(fileStat);
+    if ((fileStat.mode & 0o777) !== ENV_FILE_MODE) {
+        throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
+    }
+}
+
+async function openProjectEnvFile(
+    directory: ProjectEnvDirectoryHandle,
+    filename: string,
+    operations: ProjectEnvFileOperations,
+): Promise<ProjectEnvFileHandle> {
+    try {
+        return await operations.openExclusiveAt(directory, filename, ENV_FILE_MODE);
+    } catch (error: unknown) {
+        if (fileSystemErrorCode(error) === "EEXIST") {
+            throw new ProjectCreateEnvError("ENV_FILE_EXISTS");
+        }
+        throw error;
+    }
+}
+
+async function assertDirectoryBinding(
+    path: string,
+    directoryHandle: ProjectEnvDirectoryHandle,
+    expectedIdentity: ProjectEnvParentIdentity,
+    operations: ProjectEnvFileOperations,
+): Promise<void> {
+    const heldDirectoryStat = await directoryHandle.stat();
+    const currentPathIdentity = await assertSafeParent(path, operations);
+    if (
+        !heldDirectoryStat.isDirectory()
+        || !sameFileIdentity(heldDirectoryStat, expectedIdentity)
+        || !sameFileIdentity(currentPathIdentity, expectedIdentity)
+    ) {
+        throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+    }
+}
+
+async function assertPreparedFileBinding(
+    prepared: PreparedProjectEnvFile,
+    operations: ProjectEnvFileOperations,
+): Promise<void> {
+    if (!prepared.directoryHandle || !prepared.openFile) {
+        throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
+    }
+    await assertDirectoryBinding(
+        dirname(prepared.path),
+        prepared.directoryHandle,
+        prepared.parentIdentity,
+        operations,
+    );
+    const openFileStat = await prepared.openFile.stat();
+    const targetStat = await operations.lstatAt(prepared.directoryHandle, prepared.filename);
+    assertSecureOpenFile(openFileStat);
+    assertSecureFileType(targetStat);
+    if (
+        !sameFileIdentity(openFileStat, prepared.fileIdentity)
+        || !sameFileIdentity(targetStat, prepared.fileIdentity)
+    ) {
+        throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
+    }
+}
+
+export async function discardPreparedProjectEnvFile(
+    prepared: PreparedProjectEnvFile,
+    operations: ProjectEnvFileOperations = nodeProjectEnvFileOperations,
+): Promise<CredentialFileState> {
+    if (!prepared.directoryHandle) return "absent";
+    const directoryHandle = prepared.directoryHandle;
+    const openFile = prepared.openFile;
+    prepared.directoryHandle = null;
+    prepared.openFile = null;
+    return removeFailedEnvFile(
+        {
+            directoryHandle,
+            filename: prepared.filename,
+            openFile,
+            fileIdentity: prepared.fileIdentity,
+            operations,
+        },
+    );
+}
+
+export async function writeProjectEnvFile(
+    prepared: PreparedProjectEnvFile,
+    credentials: ProjectCreateCredentials,
+    operations: ProjectEnvFileOperations = nodeProjectEnvFileOperations,
+): Promise<void> {
+    if (!prepared.directoryHandle || !prepared.openFile) {
+        throw new ProjectCreateEnvError("ENV_FILE_WRITE_FAILED");
+    }
+    const directoryHandle = prepared.directoryHandle;
+    const openFile = prepared.openFile;
+    try {
+        await assertPreparedFileBinding(prepared, operations);
+        await openFile.chmod(ENV_FILE_MODE);
+        await assertPreparedFileBinding(prepared, operations);
+        await openFile.writeFile(environmentFileContent(credentials, prepared.environment));
+        await openFile.sync();
+        await assertPreparedFileBinding(prepared, operations);
+        await openFile.close();
+        prepared.openFile = null;
+        await directoryHandle.close();
+        prepared.directoryHandle = null;
+    } catch (error: unknown) {
+        prepared.directoryHandle = null;
+        prepared.openFile = null;
+        const credentialFileState = await removeFailedEnvFile(
+            {
+                directoryHandle,
+                filename: prepared.filename,
+                openFile,
+                fileIdentity: prepared.fileIdentity,
+                operations,
+            },
+        );
+        if (credentialFileState === "unknown") {
+            throw new ProjectCreateEnvError("ENV_FILE_CLEANUP_FAILED", "unknown");
+        }
+        if (error instanceof ProjectCreateEnvError) throw error;
+        throw new ProjectCreateEnvError("ENV_FILE_WRITE_FAILED");
+    }
+}
+
+function isRecord(candidate: unknown): candidate is Record<string, unknown> {
+    return typeof candidate === "object" && candidate !== null && !Array.isArray(candidate);
+}
+
+function decodedJwtPart(encodedPart: string): Record<string, unknown> | null {
+    try {
+        const decodedPart = JSON.parse(Buffer.from(encodedPart, "base64url").toString("utf8"));
+        return isRecord(decodedPart) ? decodedPart : null;
+    } catch {
+        return null;
+    }
+}
+
+function isServiceRoleKey(candidate: unknown): candidate is string {
+    if (typeof candidate !== "string" || !SERVICE_ROLE_KEY.test(candidate)) return false;
+    const [encodedHeader, encodedClaims] = candidate.split(".");
+    const jwtHeader = decodedJwtPart(encodedHeader);
+    const jwtClaims = decodedJwtPart(encodedClaims);
+    return jwtHeader?.typ === "JWT"
+        && typeof jwtHeader.alg === "string"
+        && SERVICE_ROLE_ALGORITHMS.has(jwtHeader.alg)
+        && jwtClaims?.role === "service_role"
+        && jwtClaims.iss === "supabase"
+        && typeof jwtClaims.exp === "number"
+        && Number.isFinite(jwtClaims.exp)
+        && jwtClaims.exp > Date.now() / 1_000;
+}
+
+function parsedProjectApiUrl(candidate: unknown): URL | null {
+    if (typeof candidate !== "string" || candidate.length > 2_048) return null;
+    try {
+        return new URL(candidate);
+    } catch {
+        return null;
+    }
+}
+
+function hasSafeProjectApiUrlShape(parsedUrl: URL): boolean {
+    const loopbackHttp = parsedUrl.protocol === "http:"
+        && ["localhost", "127.0.0.1", "::1", "[::1]"].includes(parsedUrl.hostname);
+    return (parsedUrl.protocol === "https:" || loopbackHttp)
+        && !parsedUrl.username
+        && !parsedUrl.password
+        && !parsedUrl.search
+        && !parsedUrl.hash
+        && (parsedUrl.pathname === "/" || parsedUrl.pathname === "");
+}
+
+function hasExpectedProjectApiOrigin(
+    parsedUrl: URL,
+    projectRef: string,
+    expectedApiOrigin?: string,
+): boolean {
+    const hostname = parsedUrl.hostname.toLowerCase();
+    if (expectedApiOrigin) return parsedUrl.origin === expectedApiOrigin;
+    return !parsedUrl.port && hostname.split(".")[0] === projectRef;
+}
+
+function projectApiUrl(
+    candidate: unknown,
+    projectRef: string,
+    expectedApiOrigin?: string,
+): string | null {
+    const parsedUrl = parsedProjectApiUrl(candidate);
+    if (!parsedUrl || !hasSafeProjectApiUrlShape(parsedUrl)) return null;
+    if (!hasExpectedProjectApiOrigin(parsedUrl, projectRef, expectedApiOrigin)) return null;
+    return parsedUrl.origin;
+}
+
+export function parseProjectCreateIdentity(
+    responsePayload: unknown,
+    expectedApiOrigin?: string,
+): ProjectCreateIdentity | null {
+    if (!isRecord(responsePayload) || typeof responsePayload.ref !== "string") return null;
+    if (!PROJECT_REF.test(responsePayload.ref) || !isRecord(responsePayload.api)) return null;
+    const apiUrl = projectApiUrl(responsePayload.api.url, responsePayload.ref, expectedApiOrigin);
+    return apiUrl ? { projectRef: responsePayload.ref, apiUrl } : null;
+}
+
+export function parseProjectCreateWithoutCredentials(
+    responsePayload: unknown,
+    expectedApiOrigin?: string,
+): ProjectCreateIdentity | null {
+    const identity = parseProjectCreateIdentity(responsePayload, expectedApiOrigin);
+    if (!identity || !isRecord(responsePayload)) return null;
+    return Object.hasOwn(responsePayload, "credentials") ? null : identity;
+}
+
+export function parseProjectCreateCredentials(
+    responsePayload: unknown,
+    expectedApiOrigin?: string,
+): ProjectCreateCredentials | null {
+    if (!expectedApiOrigin) return null;
+    const identity = parseProjectCreateIdentity(responsePayload, expectedApiOrigin);
+    if (!identity || !isRecord(responsePayload)) return null;
+    if (!isRecord(responsePayload.credentials)) return null;
+    const serviceRoleKey = responsePayload.credentials.service_role_key;
+    return isServiceRoleKey(serviceRoleKey) ? { ...identity, serviceRoleKey } : null;
+}

--- a/packages/admin/src/shared/tools/project-create-env.ts
+++ b/packages/admin/src/shared/tools/project-create-env.ts
@@ -14,7 +14,6 @@ const SERVICE_ROLE_ALGORITHMS = new Set(["HS256", "ES256"]);
 const MAX_ENV_FILE_PATH_BYTES = 4_096;
 const ENV_FILE_MODE = 0o600;
 const GROUP_OR_WORLD_WRITE_MODE = 0o022;
-const STICKY_DIRECTORY_MODE = 0o1000;
 const PROC_SELF_FD = "/proc/self/fd";
 
 export type ProjectCreateEnvErrorCode =
@@ -109,6 +108,8 @@ interface ProjectEnvFileIdentity {
 
 interface ProjectEnvParentIdentity extends ProjectEnvFileIdentity {
     canonicalPath: string;
+    mode: number;
+    uid: number;
 }
 
 interface FailedProjectEnvFileCleanup {
@@ -156,30 +157,58 @@ async function assertTargetAbsent(
     throw new ProjectCreateEnvError("ENV_FILE_EXISTS");
 }
 
+function hasStableCanonicalParent(
+    directory: string,
+    canonicalParent: string,
+    parentBeforeRealpath: ProjectEnvFileStat,
+    parentAfterRealpath: ProjectEnvFileStat,
+): boolean {
+    return parentBeforeRealpath.isDirectory()
+        && !parentBeforeRealpath.isSymbolicLink()
+        && parentAfterRealpath.isDirectory()
+        && !parentAfterRealpath.isSymbolicLink()
+        && canonicalParent === directory
+        && sameFileIdentity(parentBeforeRealpath, parentAfterRealpath);
+}
+
+function parentIdentity(
+    canonicalPath: string,
+    parentStat: ProjectEnvFileStat,
+): ProjectEnvParentIdentity {
+    return {
+        canonicalPath,
+        dev: parentStat.dev,
+        ino: parentStat.ino,
+        mode: parentStat.mode,
+        uid: parentStat.uid,
+    };
+}
+
+async function verifiedParentIdentity(
+    directory: string,
+    operations: ProjectEnvFileOperations,
+): Promise<ProjectEnvParentIdentity> {
+    const parentBeforeRealpath = await operations.lstat(directory);
+    const canonicalParent = await operations.realpath(directory);
+    await assertTrustedDirectoryChain(directory, operations);
+    const parentAfterRealpath = await operations.lstat(directory);
+    assertOwnedTargetParent(parentAfterRealpath, operations.effectiveUid());
+    const stableParent = hasStableCanonicalParent(
+        directory,
+        canonicalParent,
+        parentBeforeRealpath,
+        parentAfterRealpath,
+    );
+    if (!stableParent) throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+    return parentIdentity(canonicalParent, parentAfterRealpath);
+}
+
 async function assertSafeParent(
     directory: string,
     operations: ProjectEnvFileOperations,
 ): Promise<ProjectEnvParentIdentity> {
     try {
-        const parentBeforeRealpath = await operations.lstat(directory);
-        const canonicalParent = await operations.realpath(directory);
-        await assertTrustedDirectoryChain(directory, operations);
-        const parentAfterRealpath = await operations.lstat(directory);
-        if (
-            !parentBeforeRealpath.isDirectory()
-            || parentBeforeRealpath.isSymbolicLink()
-            || !parentAfterRealpath.isDirectory()
-            || parentAfterRealpath.isSymbolicLink()
-            || canonicalParent !== directory
-            || !sameFileIdentity(parentBeforeRealpath, parentAfterRealpath)
-        ) {
-            throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
-        }
-        return {
-            canonicalPath: canonicalParent,
-            dev: parentAfterRealpath.dev,
-            ino: parentAfterRealpath.ino,
-        };
+        return await verifiedParentIdentity(directory, operations);
     } catch (error: unknown) {
         if (error instanceof ProjectCreateEnvError) throw error;
         throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
@@ -197,12 +226,18 @@ function directoryChain(directory: string): string[] {
     return ancestors;
 }
 
-function assertTrustedDirectory(directoryStat: ProjectEnvFileStat, effectiveUid: number): void {
+function assertTrustedAncestor(directoryStat: ProjectEnvFileStat, effectiveUid: number): void {
     const ownerIsTrusted = directoryStat.uid === 0 || directoryStat.uid === effectiveUid;
     const hasUntrustedWriteAccess = Boolean(directoryStat.mode & GROUP_OR_WORLD_WRITE_MODE);
-    const stickyEntryProtection = Boolean(directoryStat.mode & STICKY_DIRECTORY_MODE);
     if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()
-        || !ownerIsTrusted || (hasUntrustedWriteAccess && !stickyEntryProtection)) {
+        || !ownerIsTrusted || hasUntrustedWriteAccess) {
+        throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+    }
+}
+
+function assertOwnedTargetParent(directoryStat: ProjectEnvFileStat, effectiveUid: number): void {
+    assertTrustedAncestor(directoryStat, effectiveUid);
+    if (directoryStat.uid !== effectiveUid) {
         throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
     }
 }
@@ -216,7 +251,7 @@ async function assertTrustedDirectoryChain(
         throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
     }
     for (const ancestor of directoryChain(directory)) {
-        assertTrustedDirectory(await operations.lstat(ancestor), effectiveUid);
+        assertTrustedAncestor(await operations.lstat(ancestor), effectiveUid);
     }
 }
 
@@ -225,6 +260,15 @@ function sameFileIdentity(
     second: ProjectEnvFileIdentity,
 ): boolean {
     return first.dev === second.dev && first.ino === second.ino;
+}
+
+function sameParentIdentity(
+    current: ProjectEnvFileIdentity & Pick<ProjectEnvFileStat, "mode" | "uid">,
+    expected: ProjectEnvParentIdentity,
+): boolean {
+    return sameFileIdentity(current, expected)
+        && current.mode === expected.mode
+        && current.uid === expected.uid;
 }
 
 function hasSafeRequestedPath(requestedPath: string): boolean {
@@ -400,10 +444,10 @@ async function assertDirectoryBinding(
 ): Promise<void> {
     const heldDirectoryStat = await directoryHandle.stat();
     const currentPathIdentity = await assertSafeParent(path, operations);
+    assertOwnedTargetParent(heldDirectoryStat, operations.effectiveUid());
     if (
-        !heldDirectoryStat.isDirectory()
-        || !sameFileIdentity(heldDirectoryStat, expectedIdentity)
-        || !sameFileIdentity(currentPathIdentity, expectedIdentity)
+        !sameParentIdentity(heldDirectoryStat, expectedIdentity)
+        || !sameParentIdentity(currentPathIdentity, expectedIdentity)
     ) {
         throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
     }

--- a/packages/admin/src/shared/tools/project-create-env.ts
+++ b/packages/admin/src/shared/tools/project-create-env.ts
@@ -1,5 +1,5 @@
 import { constants } from "node:fs";
-import { isAbsolute, basename, dirname, normalize, resolve } from "node:path";
+import { isAbsolute, basename, dirname, join, normalize, parse, resolve } from "node:path";
 import {
     lstat,
     open,
@@ -13,6 +13,8 @@ const SERVICE_ROLE_KEY = /^[A-Za-z0-9_-]{8,2048}\.[A-Za-z0-9_-]{8,8192}\.[A-Za-z
 const SERVICE_ROLE_ALGORITHMS = new Set(["HS256", "ES256"]);
 const MAX_ENV_FILE_PATH_BYTES = 4_096;
 const ENV_FILE_MODE = 0o600;
+const GROUP_OR_WORLD_WRITE_MODE = 0o022;
+const STICKY_DIRECTORY_MODE = 0o1000;
 const PROC_SELF_FD = "/proc/self/fd";
 
 export type ProjectCreateEnvErrorCode =
@@ -41,6 +43,7 @@ interface ProjectEnvFileStat {
     dev: number;
     ino: number;
     mode: number;
+    uid: number;
     isDirectory(): boolean;
     isFile(): boolean;
     isSymbolicLink(): boolean;
@@ -58,11 +61,13 @@ interface ProjectEnvFileHandle {
 interface ProjectEnvDirectoryHandle {
     fd: number;
     stat(): Promise<ProjectEnvFileStat>;
+    sync(): Promise<void>;
     close(): Promise<void>;
 }
 
 export interface ProjectEnvFileOperations {
     platform: NodeJS.Platform;
+    effectiveUid(): number;
     lstat(path: string): Promise<ProjectEnvFileStat>;
     realpath(path: string): Promise<string>;
     openDirectory(path: string): Promise<ProjectEnvDirectoryHandle>;
@@ -81,6 +86,7 @@ function descriptorRelativePath(directory: ProjectEnvDirectoryHandle, filename: 
 
 const nodeProjectEnvFileOperations: ProjectEnvFileOperations = {
     platform: process.platform,
+    effectiveUid: () => process.geteuid?.() ?? -1,
     lstat,
     realpath,
     openDirectory: path => open(
@@ -157,6 +163,7 @@ async function assertSafeParent(
     try {
         const parentBeforeRealpath = await operations.lstat(directory);
         const canonicalParent = await operations.realpath(directory);
+        await assertTrustedDirectoryChain(directory, operations);
         const parentAfterRealpath = await operations.lstat(directory);
         if (
             !parentBeforeRealpath.isDirectory()
@@ -176,6 +183,40 @@ async function assertSafeParent(
     } catch (error: unknown) {
         if (error instanceof ProjectCreateEnvError) throw error;
         throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+    }
+}
+
+function directoryChain(directory: string): string[] {
+    const root = parse(directory).root;
+    const ancestors = [root];
+    let current = root;
+    for (const component of directory.slice(root.length).split("/").filter(Boolean)) {
+        current = join(current, component);
+        ancestors.push(current);
+    }
+    return ancestors;
+}
+
+function assertTrustedDirectory(directoryStat: ProjectEnvFileStat, effectiveUid: number): void {
+    const ownerIsTrusted = directoryStat.uid === 0 || directoryStat.uid === effectiveUid;
+    const hasUntrustedWriteAccess = Boolean(directoryStat.mode & GROUP_OR_WORLD_WRITE_MODE);
+    const stickyEntryProtection = Boolean(directoryStat.mode & STICKY_DIRECTORY_MODE);
+    if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()
+        || !ownerIsTrusted || (hasUntrustedWriteAccess && !stickyEntryProtection)) {
+        throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+    }
+}
+
+async function assertTrustedDirectoryChain(
+    directory: string,
+    operations: ProjectEnvFileOperations,
+): Promise<void> {
+    const effectiveUid = operations.effectiveUid();
+    if (!Number.isSafeInteger(effectiveUid) || effectiveUid < 0) {
+        throw new ProjectCreateEnvError("ENV_FILE_PARENT_INVALID");
+    }
+    for (const ancestor of directoryChain(directory)) {
+        assertTrustedDirectory(await operations.lstat(ancestor), effectiveUid);
     }
 }
 
@@ -276,6 +317,31 @@ async function sanitizeAndClose(openFile: ProjectEnvFileHandle): Promise<boolean
     return sanitized;
 }
 
+async function directorySyncSucceeded(directoryHandle: ProjectEnvDirectoryHandle): Promise<boolean> {
+    try {
+        await directoryHandle.sync();
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function cleanedCredentialState(
+    cleanup: FailedProjectEnvFileCleanup,
+    sanitized: boolean,
+): Promise<CredentialFileState> {
+    const { directoryHandle, filename, fileIdentity, operations } = cleanup;
+    try {
+        const targetStat = await operations.lstatAt(directoryHandle, filename);
+        if (!fileIdentity || !sameFileIdentity(targetStat, fileIdentity)) return "unknown";
+        await operations.unlinkAt(directoryHandle, filename);
+    } catch (error: unknown) {
+        if (fileSystemErrorCode(error) !== "ENOENT") return "unknown";
+    }
+    if (!await directorySyncSucceeded(directoryHandle)) return "unknown";
+    return sanitized ? "absent" : "unknown";
+}
+
 async function removeFailedEnvFile(
     cleanup: FailedProjectEnvFileCleanup,
 ): Promise<CredentialFileState> {
@@ -289,19 +355,7 @@ async function removeFailedEnvFile(
         return "absent";
     }
     const sanitized = await sanitizeAndClose(openFile);
-    let credentialFileState: CredentialFileState = "absent";
-    try {
-        const targetStat = await operations.lstatAt(directoryHandle, filename);
-        if (!fileIdentity || !sameFileIdentity(targetStat, fileIdentity)) {
-            credentialFileState = "unknown";
-        } else {
-            await operations.unlinkAt(directoryHandle, filename);
-        }
-    } catch (error: unknown) {
-        if (fileSystemErrorCode(error) !== "ENOENT" || !sanitized) {
-            credentialFileState = "unknown";
-        }
-    }
+    const credentialFileState = await cleanedCredentialState(cleanup, sanitized);
     try {
         await directoryHandle.close();
     } catch {
@@ -316,9 +370,9 @@ function assertSecureFileType(fileStat: ProjectEnvFileStat): void {
     }
 }
 
-function assertSecureOpenFile(fileStat: ProjectEnvFileStat): void {
+function assertSecureOpenFile(fileStat: ProjectEnvFileStat, effectiveUid: number): void {
     assertSecureFileType(fileStat);
-    if ((fileStat.mode & 0o777) !== ENV_FILE_MODE) {
+    if ((fileStat.mode & 0o777) !== ENV_FILE_MODE || fileStat.uid !== effectiveUid) {
         throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
     }
 }
@@ -370,12 +424,31 @@ async function assertPreparedFileBinding(
     );
     const openFileStat = await prepared.openFile.stat();
     const targetStat = await operations.lstatAt(prepared.directoryHandle, prepared.filename);
-    assertSecureOpenFile(openFileStat);
-    assertSecureFileType(targetStat);
+    const effectiveUid = operations.effectiveUid();
+    assertSecureOpenFile(openFileStat, effectiveUid);
+    assertSecureOpenFile(targetStat, effectiveUid);
     if (
         !sameFileIdentity(openFileStat, prepared.fileIdentity)
         || !sameFileIdentity(targetStat, prepared.fileIdentity)
     ) {
+        throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
+    }
+}
+
+async function assertCompletedFileBinding(
+    prepared: PreparedProjectEnvFile,
+    operations: ProjectEnvFileOperations,
+): Promise<void> {
+    if (!prepared.directoryHandle) throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
+    await assertDirectoryBinding(
+        dirname(prepared.path),
+        prepared.directoryHandle,
+        prepared.parentIdentity,
+        operations,
+    );
+    const targetStat = await operations.lstatAt(prepared.directoryHandle, prepared.filename);
+    assertSecureOpenFile(targetStat, operations.effectiveUid());
+    if (!sameFileIdentity(targetStat, prepared.fileIdentity)) {
         throw new ProjectCreateEnvError("ENV_FILE_VERIFY_FAILED");
     }
 }
@@ -419,6 +492,8 @@ export async function writeProjectEnvFile(
         await assertPreparedFileBinding(prepared, operations);
         await openFile.close();
         prepared.openFile = null;
+        await assertCompletedFileBinding(prepared, operations);
+        await directoryHandle.sync();
         await directoryHandle.close();
         prepared.directoryHandle = null;
     } catch (error: unknown) {
@@ -531,11 +606,13 @@ export function parseProjectCreateWithoutCredentials(
 
 export function parseProjectCreateCredentials(
     responsePayload: unknown,
-    expectedApiOrigin?: string,
+    expectedApiOrigin: string | undefined,
+    expectedProjectName: string,
 ): ProjectCreateCredentials | null {
-    if (!expectedApiOrigin) return null;
+    if (!expectedApiOrigin || !expectedProjectName || !isRecord(responsePayload)) return null;
+    if (responsePayload.name !== expectedProjectName) return null;
     const identity = parseProjectCreateIdentity(responsePayload, expectedApiOrigin);
-    if (!identity || !isRecord(responsePayload)) return null;
+    if (!identity) return null;
     if (!isRecord(responsePayload.credentials)) return null;
     const serviceRoleKey = responsePayload.credentials.service_role_key;
     return isServiceRoleKey(serviceRoleKey) ? { ...identity, serviceRoleKey } : null;

--- a/packages/admin/src/shared/transports/http.test.ts
+++ b/packages/admin/src/shared/transports/http.test.ts
@@ -127,6 +127,11 @@ describe("HttpTransport retry policy", () => {
         const response = await request(createTransport());
 
         expect(response.status).toBe(500);
+        expect(response.transportError).toBe(true);
+        expect(response.data).toEqual({
+            error: "Network Error",
+            code: "CONNECTION_RESET",
+        });
         expect(fetchCalls).toBe(1);
         expect(clearedTimerIds).toHaveLength(1);
     });
@@ -168,7 +173,8 @@ describe("HttpTransport retry policy", () => {
         expect(response).toEqual({
             ok: false,
             status: 500,
-            data: { error: "Network Error", details: "request timed out" },
+            data: { error: "Network Error", code: "TIMEOUT" },
+            transportError: true,
         });
         expect(fetchCalls).toBe(1);
         expect(clearedTimerIds).toHaveLength(1);
@@ -185,5 +191,22 @@ describe("HttpTransport retry policy", () => {
             "HTTP request timeout must be between",
         );
         expect(fetchCalls).toBe(0);
+    });
+
+    test("never preserves an arbitrary transport error message", async () => {
+        const privateDetail = "Bearer private-transport-token";
+        globalThis.fetch = (async () => {
+            throw Object.assign(new Error(privateDetail), { code: "EHOSTUNREACH" });
+        }) as unknown as typeof fetch;
+
+        const response = await createTransport().post("/v1/projects", { name: "test" });
+
+        expect(response).toEqual({
+            ok: false,
+            status: 500,
+            data: { error: "Network Error", code: "NETWORK_ERROR" },
+            transportError: true,
+        });
+        expect(JSON.stringify(response)).not.toContain(privateDetail);
     });
 });

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -14,6 +14,7 @@ export interface HttpResult<T = unknown> {
     ok: boolean;
     status: number;
     data: T;
+    transportError?: boolean;
 }
 
 interface HttpPostOptions {
@@ -36,6 +37,19 @@ function isRetryableError(error: unknown): boolean {
     return networkError.name === "AbortError"
         || networkError.code === "ECONNREFUSED"
         || networkError.code === "ECONNRESET";
+}
+
+function transportFailure<T>(error: unknown): HttpResult<T> {
+    const networkError = error instanceof Error ? error as Error & { code?: string } : null;
+    const code = networkError?.name === "AbortError"
+        ? "TIMEOUT"
+        : networkError?.code === "ECONNRESET" ? "CONNECTION_RESET" : "NETWORK_ERROR";
+    return {
+        ok: false,
+        status: 500,
+        data: { error: "Network Error", code } as T,
+        transportError: true,
+    };
 }
 
 function validatedPostTimeout(options?: HttpPostOptions): number {
@@ -115,8 +129,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -134,8 +148,8 @@ export class HttpTransport {
             }, timeoutMs);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -149,8 +163,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -163,8 +177,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -177,8 +191,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 
@@ -190,8 +204,8 @@ export class HttpTransport {
             });
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
-        } catch (error: any) {
-            return { ok: false, status: 500, data: { error: "Network Error", details: error.message } as any };
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
         }
     }
 

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -41,6 +41,8 @@ const AVAILABLE_REGIONS = [
     continent: "apac",
   },
 ];
+const SERVICE_ROLE_JWT = /^[A-Za-z0-9_-]{8,2048}\.[A-Za-z0-9_-]{8,8192}\.[A-Za-z0-9_-]{8,2048}$/;
+const SERVICE_ROLE_JWT_ALGORITHMS = new Set(["HS256", "ES256"]);
 
 export const V1ProjectResponseSchema = t.Object(
   {
@@ -98,11 +100,50 @@ export const V1ProjectWithDatabaseResponseSchema = t.Object(
   { additionalProperties: true },
 );
 
+export const V1ProjectCreateResponseSchema = t.Object(
+  {
+    ...V1ProjectWithDatabaseResponseSchema.properties,
+    credentials: t.Optional(
+      t.Object(
+        { service_role_key: t.String({ minLength: 32 }) },
+        { additionalProperties: false },
+      ),
+    ),
+  },
+  { additionalProperties: false },
+);
+
 function normalizeTimestamp(value: unknown): string {
   if (typeof value === "string") return value;
   if (value instanceof Date) return value.toISOString();
   if (typeof value === "number") return new Date(value).toISOString();
   return new Date().toISOString();
+}
+
+function decodeJwtRecord(encodedPart: string): Record<string, unknown> | null {
+  try {
+    const decodedPart = JSON.parse(Buffer.from(encodedPart, "base64url").toString("utf8"));
+    return decodedPart && typeof decodedPart === "object" && !Array.isArray(decodedPart)
+      ? decodedPart as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isServiceRoleJwt(candidate: unknown): candidate is string {
+  if (typeof candidate !== "string" || !SERVICE_ROLE_JWT.test(candidate)) return false;
+  const [encodedHeader, encodedClaims] = candidate.split(".");
+  const jwtHeader = decodeJwtRecord(encodedHeader);
+  const jwtClaims = decodeJwtRecord(encodedClaims);
+  return jwtHeader?.typ === "JWT"
+    && typeof jwtHeader.alg === "string"
+    && SERVICE_ROLE_JWT_ALGORITHMS.has(jwtHeader.alg)
+    && jwtClaims?.role === "service_role"
+    && jwtClaims.iss === "supabase"
+    && typeof jwtClaims.exp === "number"
+    && Number.isFinite(jwtClaims.exp)
+    && jwtClaims.exp > Date.now() / 1_000;
 }
 
 export function toPublicV1ProjectResponse(p: any) {
@@ -132,6 +173,16 @@ export function toPublicV1ProjectWithDatabaseResponse(p: any) {
     config: publicScheduledFunctionProjectConfig(p.config),
     anon_key: p.anon_key,
     services: p.services,
+  };
+}
+
+export function toPublicV1ProjectCreateResponse(p: any, serviceRoleKey: unknown) {
+  if (!isServiceRoleJwt(serviceRoleKey)) {
+    throw new Error("Project creation credentials are unavailable");
+  }
+  return {
+    ...toPublicV1ProjectWithDatabaseResponse(p),
+    credentials: { service_role_key: serviceRoleKey },
   };
 }
 
@@ -371,14 +422,17 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
       const authError = await requireAdminAuth(request);
       if (authError) return status(authError.status as 401 | 403, { message: authError.body.error, code: String(authError.status) });
 
-      const project = await projectService.createProject(body);
+      const { credential_delivery: credentialDelivery, ...createRequest } = body;
+      const project = await projectService.createProject(createRequest);
       set.status = 201;
       const fullProject = await projectService.getProject(project.ref);
       const raw = await buildProjectResponse(fullProject || project, true);
-      return toPublicV1ProjectWithDatabaseResponse(raw);
+      return credentialDelivery === "response"
+        ? toPublicV1ProjectCreateResponse(raw, project.service_role_key)
+        : toPublicV1ProjectWithDatabaseResponse(raw);
     },
     {
-      response: { 201: V1ProjectWithDatabaseResponseSchema },
+      response: { 201: V1ProjectCreateResponseSchema },
       body: t.Object({
         name: t.String({ minLength: 1, maxLength: 100 }),
         region: t.Optional(t.String()),
@@ -410,6 +464,7 @@ export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
               "Explicit Studio domain (e.g., 'xg-studio.example.com')",
           }),
         ),
+        credential_delivery: t.Optional(t.Literal("response")),
       }),
       detail: { tags: ["projects"], summary: "Create project" },
     },

--- a/packages/management-api/tests/unit/project-crud-public-config.test.ts
+++ b/packages/management-api/tests/unit/project-crud-public-config.test.ts
@@ -1,6 +1,22 @@
 import { expect, test } from "bun:test";
-import { toPublicV1ProjectWithDatabaseResponse } from "../../src/routes/project-crud";
+import {
+  toPublicV1ProjectCreateResponse,
+  toPublicV1ProjectWithDatabaseResponse,
+} from "../../src/routes/project-crud";
 import { publicScheduledFunctionProjectConfig } from "../../src/utils/scheduled-function-config";
+
+function unsignedRoleKey(
+  role: string,
+  claims: Record<string, unknown> = { exp: 4_102_444_800 },
+): string {
+  const jwtSegment = (claims: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+  return [
+    jwtSegment({ alg: "HS256", typ: "JWT" }),
+    jwtSegment({ role, iss: "supabase", ...claims }),
+    "s".repeat(43),
+  ].join(".");
+}
 
 test("project detail serialization redacts scheduled Function payloads", () => {
   const bodySentinel = "private-project-body-sentinel";
@@ -70,4 +86,51 @@ test("project detail serialization preserves redaction metadata when applied twi
     body_empty: false,
     header_names: ["x-schedule-token"],
   });
+});
+
+test("project create serialization exposes only the explicitly delivered service role key", () => {
+  const serviceRoleKey = unsignedRoleKey("service_role");
+  const privateSentinel = "private-create-credential-sentinel";
+  const source = {
+    id: "project-id",
+    ref: "abcdefghijklmnopqrst",
+    name: "Project",
+    api: { url: "https://api.example.test" },
+    service_role_key: privateSentinel,
+    jwt_secret: privateSentinel,
+    db_password: privateSentinel,
+    publishable_key: privateSentinel,
+    secret_key: privateSentinel,
+  };
+
+  const ordinaryResponse = toPublicV1ProjectWithDatabaseResponse(source);
+  const createResponse = toPublicV1ProjectCreateResponse(source, serviceRoleKey);
+
+  expect(ordinaryResponse).not.toHaveProperty("credentials");
+  expect(JSON.stringify(ordinaryResponse)).not.toContain(privateSentinel);
+  expect(createResponse.credentials).toEqual({ service_role_key: serviceRoleKey });
+  expect(JSON.stringify(createResponse)).not.toContain(privateSentinel);
+  expect(createResponse).not.toHaveProperty("service_role_key");
+  expect(createResponse).not.toHaveProperty("jwt_secret");
+  expect(createResponse).not.toHaveProperty("db_password");
+  expect(createResponse).not.toHaveProperty("publishable_key");
+  expect(createResponse).not.toHaveProperty("secret_key");
+});
+
+test.each([
+  ["wrong role", unsignedRoleKey("anon")],
+  ["missing expiration", unsignedRoleKey("service_role", {})],
+  ["expired credential", unsignedRoleKey("service_role", { exp: 1 })],
+  ["nonnumeric expiration", unsignedRoleKey("service_role", { exp: "tomorrow" })],
+])("project create serialization fails without reflecting %s", (_label, invalidCredential) => {
+  let failure: unknown;
+  try {
+    toPublicV1ProjectCreateResponse({ id: "project-id", ref: "project-ref", name: "Project" }, invalidCredential);
+  } catch (error: unknown) {
+    failure = error;
+  }
+
+  expect(failure).toBeInstanceOf(Error);
+  expect((failure as Error).message).toBe("Project creation credentials are unavailable");
+  expect((failure as Error).message).not.toContain(invalidCredential);
 });


### PR DESCRIPTION
Summary

- Add opt-in, one-time service-role delivery for Admin project create through an exclusive 0600 application env file; ordinary project creation remains credential-free.
- Require an exact canonical API-origin binding and an explicit test or production environment before any remote mutation.
- On Linux, hold the canonical parent directory open with O_DIRECTORY and O_NOFOLLOW, reserve the target before credential delivery, and perform create, verification, and cleanup through /proc/self/fd with parent and file device/inode checks before and after sensitive writes.
- Fail closed on macOS and Windows with ENV_FILE_PLATFORM_UNSUPPORTED before file creation and before credential_delivery is requested.
- Write exactly SUPACLOUD_ENV, SUPACLOUD_PROJECT_REF, SUPABASE_URL, and SUPABASE_SERVICE_ROLE_KEY. Do not write the public project origin as SUPACLOUD_API_URL because Admin reserves that name for the Management API. Mark successful receipts with env_file_scope=project_application.
- Validate response ref, canonical origin and port, JWT type, algorithm, issuer, role, and future expiration; never reflect credentials or arbitrary remote fields.
- Remove empty reservations after HTTP failures, unexpected statuses, and invalid payloads. Partial-application receipts remain retry_safe=false and distinguish absent from unknown credential-file state.
- Add a Management API response projection that exposes only the explicitly requested service-role key.

Verification

- Admin full suite: 317 pass, 19 skip, 0 fail.
- Linux Docker security and process regression: 79 pass, 1 unsupported-platform skip, 0 fail, including real parent rename and replacement before and during writes.
- Management project-create credential regression: 7 pass, 0 fail.
- Admin and Management typechecks: pass.
- Admin production build: pass.
- Management SQL module synchronization check: pass.
- git diff --check: pass.
- Rebased on main e4c9b4c8998a1149a527d38c277bf3d77f0f7572.

Operational note

This changes both Management API and @supacloud/admin. Use the normal Release Please publication flow before relying on env_file against a deployed server. This PR does not merge, release, or deploy itself.
