### PR TITLE
feat(admin): add verified physical backup receipts

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -126,6 +126,21 @@ the CLI does not redirect the operation to the owner project. Supply
 `SUPACLOUD_API_TOKEN` through the environment only; service-control commands do
 not accept credential flags.
 
+Create a completed full physical backup before a release with:
+
+```bash
+supacloud-admin platform create_backup --ref abc123 --backup_type full
+```
+
+The command reads the physical backup inventory before the write and performs
+one bounded reconciliation read after every mutation attempt. It exits non-zero
+unless the API confirms success and the inventory contains exactly one new,
+completed full backup with a nonzero size. The Management API rejects unknown
+project refs and resolves inventory from the persisted project database name.
+The JSON receipt contains only the project ref, requested type, backup ID,
+database, timestamps, and size. `platform list_backups --ref abc123` applies the
+same strict, sanitized inventory validation without creating a backup.
+
 Gateway / Caddy commands (config is injected via the Caddy JSON Admin API; requires admin privileges):
 
 - `gateway routes` — list custom gateway routes

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -24,6 +24,22 @@ const ADMIN_CONTEXT_KEYS = new Set([
     "SUPACLOUD_SSH_HOST_FINGERPRINT",
 ]);
 
+const EXISTING_PHYSICAL_BACKUP = {
+    id: "20260811-010000F",
+    type: "full",
+    timestamp: { start: 1_786_400_000, stop: 1_786_400_030 },
+    size: 4096,
+    database: "supa_fa_staging",
+};
+
+const COMPLETED_PHYSICAL_BACKUP = {
+    id: "20260811-020000F",
+    type: "full",
+    timestamp: { start: 1_786_403_600, stop: 1_786_403_660 },
+    size: 8192,
+    database: "supa_fa_staging",
+};
+
 function cleanEnvironment(overrides: Record<string, string> = {}): Record<string, string> {
     const env: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
@@ -195,6 +211,10 @@ describe("supacloud-admin process contract", () => {
             const result = await runAdminCliPath(linkedEntry, ["--help"]);
             expect(result.exitCode).toBe(0);
             expect(result.output).toContain("Platform administration CLI");
+            const backupHelp = await runAdminCliPath(linkedEntry, ["platform", "create_backup", "--help"]);
+            expect(backupHelp.exitCode).toBe(0);
+            expect(backupHelp.output).toContain("--ref");
+            expect(backupHelp.output).toContain("--backup_type");
             const version = await runAdminCliPath(linkedEntry, ["--version"]);
             expect(version.exitCode).toBe(0);
             expect(version.output.trim()).toBe(packageMetadata.version);
@@ -245,6 +265,124 @@ describe("supacloud-admin process contract", () => {
         expect(execution.output).toContain("--api_domain");
         expect(execution.output).toContain("--auth_domain");
         expect(execution.output).toContain("--studio_domain");
+    });
+
+    test("documents every physical backup flag without API context", async () => {
+        const execution = await runAdminCli(["platform", "create_backup", "--help"]);
+
+        expect(execution.exitCode).toBe(0);
+        expect(execution.output).toContain("--ref");
+        expect(execution.output).toContain("--backup_type");
+    });
+
+    test("creates a full backup with a sanitized machine-readable receipt", async () => {
+        const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+        let inventoryRead = 0;
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const path = new URL(request.url).pathname;
+                if (request.method === "POST") {
+                    const body = await request.json();
+                    calls.push({ method: request.method, path, body });
+                    return Response.json({
+                        message: "full backup completed",
+                        token: "successful-mutation-secret",
+                    });
+                }
+                calls.push({ method: request.method, path });
+                inventoryRead += 1;
+                return Response.json(inventoryRead === 1
+                    ? [EXISTING_PHYSICAL_BACKUP]
+                    : [EXISTING_PHYSICAL_BACKUP, {
+                        ...COMPLETED_PHYSICAL_BACKUP,
+                        secret: "inventory-secret",
+                    }]);
+            },
+        });
+        const fixtureToken = "backup-api-token";
+
+        try {
+            const execution = await runAdminCli([
+                "platform", "create_backup", "--ref", "fa_staging", "--backup_type", "full",
+            ], {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                SUPACLOUD_API_TOKEN: fixtureToken,
+            });
+
+            expect(execution.exitCode).toBe(0);
+            expect(JSON.parse(execution.output)).toEqual({
+                project_ref: "fa_staging",
+                requested_type: "full",
+                backup: COMPLETED_PHYSICAL_BACKUP,
+            });
+            expect(calls).toEqual([
+                { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
+                {
+                    method: "POST",
+                    path: "/v1/projects/fa_staging/database/backups",
+                    body: { type: "full" },
+                },
+                { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
+            ]);
+            expect(execution.output).not.toContain(fixtureToken);
+            expect(execution.output).not.toContain("successful-mutation-secret");
+            expect(execution.output).not.toContain("inventory-secret");
+        } finally {
+            apiServer.stop(true);
+        }
+    });
+
+    test("exits nonzero after reconciling an uncertain backup mutation", async () => {
+        const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const path = new URL(request.url).pathname;
+                if (request.method === "POST") {
+                    const body = await request.json();
+                    calls.push({ method: request.method, path, body });
+                    return Response.json({
+                        message: "remote failure detail",
+                        token: "failed-mutation-secret",
+                    }, { status: 503 });
+                }
+                calls.push({ method: request.method, path });
+                return Response.json([EXISTING_PHYSICAL_BACKUP]);
+            },
+        });
+        const fixtureToken = "failed-backup-api-token";
+
+        try {
+            const execution = await runAdminCli([
+                "platform", "create_backup", "--ref", "fa_staging", "--backup_type", "full",
+            ], {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                SUPACLOUD_API_TOKEN: fixtureToken,
+            });
+
+            expect(execution.exitCode).toBe(1);
+            expect(JSON.parse(execution.output).error).toEqual({
+                code: "OUTCOME_UNKNOWN",
+                http_status: 503,
+            });
+            expect(calls).toEqual([
+                { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
+                {
+                    method: "POST",
+                    path: "/v1/projects/fa_staging/database/backups",
+                    body: { type: "full" },
+                },
+                { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
+            ]);
+            expect(execution.output).not.toContain(fixtureToken);
+            expect(execution.output).not.toContain("remote failure detail");
+            expect(execution.output).not.toContain("failed-mutation-secret");
+        } finally {
+            apiServer.stop(true);
+        }
     });
 
     test("documents constrained project service control without credential flags", async () => {

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -18,11 +18,6 @@ import packageMetadata from "../package.json" with { type: "json" };
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
 type ToolMap = Record<string, ToolEntry>;
 
-const platformActionSchema = stringEnum([
-    "metrics", "list_backups", "create_backup",
-    "network", "update_network",
-    "list_orgs", "get_org",
-]);
 const sshActionSchema = stringEnum([
     "ping", "setup", "install", "upgrade", "versions", "diagnose", "exec",
     "troubleshoot", "container_logs",
@@ -119,6 +114,9 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
         const projectHelpTool = captureTools((server) =>
             registerAdminProjectCliTools(server as any, {} as HttpTransport)
         ).project;
+        const platformHelpTool = captureTools((server) =>
+            registerAdvancedTools(server as any, {} as HttpTransport)
+        ).platform;
         tools.project = {
             schema: projectHelpTool.schema,
             callback: async () => ({
@@ -132,7 +130,7 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
             }),
         };
         tools.platform = {
-            schema: { action: platformActionSchema },
+            schema: platformHelpTool.schema,
             callback: async () => ({
                 isError: true,
                 content: [

--- a/packages/admin/src/shared/tools/advanced-tools.test.ts
+++ b/packages/admin/src/shared/tools/advanced-tools.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { parseToolArguments } from "../schema";
+import type { ToolSchema } from "../schema";
+import { registerAdvancedTools } from "./advanced-tools";
+
+type ToolResponse = { content: Array<{ text: string }>; isError?: boolean };
+
+function platformTool(http: Record<string, unknown>) {
+    let schema: ToolSchema | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<ToolResponse>) | undefined;
+    registerAdvancedTools({
+        tool(name, _description, toolSchema, toolCallback) {
+            if (name !== "platform") return;
+            schema = toolSchema;
+            callback = toolCallback;
+        },
+    }, http as never);
+    if (!schema || !callback) throw new Error("platform tool was not registered");
+    return { schema, callback };
+}
+
+describe("admin platform backup CLI", () => {
+    test("requires an explicit full physical backup type", async () => {
+        const { schema, callback } = platformTool({});
+
+        expect(parseToolArguments(schema, {
+            action: "create_backup",
+            ref: "fa_staging",
+            backup_type: "full",
+        }).backup_type).toBe("full");
+        expect(() => parseToolArguments(schema, {
+            action: "create_backup",
+            ref: "fa_staging",
+            backup_type: "incr",
+        })).toThrow("Invalid arguments");
+        await expect(callback({ action: "create_backup", ref: "fa_staging" }))
+            .rejects.toThrow("'backup_type' required for 'create_backup'");
+    });
+});

--- a/packages/admin/src/shared/tools/advanced-tools.ts
+++ b/packages/admin/src/shared/tools/advanced-tools.ts
@@ -4,6 +4,7 @@
 import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { HttpTransport } from "../transports/http";
+import { createFullPhysicalBackup, listPhysicalBackups } from "./backup-release-control";
 
 export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
 
@@ -170,12 +171,13 @@ Actions: metrics, list_backups, create_backup, network, update_network, list_org
                 "network", "update_network",
                 "list_orgs", "get_org",
             ]), "Action"),
-            ref: optional(Type.String(), "Project ref (for backup/network actions)"),
+            ref: optional(Type.String(), "[*] Project ref for project-scoped platform actions"),
+            backup_type: optional(stringEnum(["full"]), "[create_backup] Explicit physical backup type"),
             slug: optional(Type.String(), "[get_org] Organization slug"),
             allowed_cidrs: optional(Type.Array(Type.String()), "[update_network] Allowed CIDRs"),
         },
         async (args: any) => {
-            const { action, ref, slug, allowed_cidrs } = args;
+            const { action, ref, backup_type, slug, allowed_cidrs } = args;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
             let text: string;
             switch (action) {
@@ -184,13 +186,11 @@ Actions: metrics, list_backups, create_backup, network, update_network, list_org
                     break;
                 case "list_backups":
                     need("ref", ref);
-                    text = JSON.stringify((await http.get(`/v1/projects/${ref}/database/backups`)).data, null, 2);
-                    break;
+                    return listPhysicalBackups(http, ref);
                 case "create_backup": {
                     need("ref", ref);
-                    const r = await http.post(`/v1/projects/${ref}/database/backups`);
-                    text = r.ok ? `✅ Backup created\n${JSON.stringify(r.data, null, 2)}` : `❌ Failed (${r.status})`;
-                    break;
+                    need("backup_type", backup_type);
+                    return createFullPhysicalBackup(http, ref);
                 }
                 case "network":
                     need("ref", ref);

--- a/packages/admin/src/shared/tools/backup-release-control.test.ts
+++ b/packages/admin/src/shared/tools/backup-release-control.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+import { createFullPhysicalBackup, listPhysicalBackups } from "./backup-release-control";
+
+const EXISTING_BACKUP = {
+    id: "20260811-010000F",
+    type: "full",
+    timestamp: { start: 1_786_400_000, stop: 1_786_400_030 },
+    size: 4096,
+    database: "supa_fa_staging",
+};
+
+const NEW_BACKUP = {
+    id: "20260811-020000F",
+    type: "full",
+    timestamp: { start: 1_786_403_600, stop: 1_786_403_660 },
+    size: 8192,
+    database: "supa_fa_staging",
+};
+
+function parsed(response: { content: Array<{ text: string }> }): Record<string, unknown> {
+    return JSON.parse(response.content[0].text) as Record<string, unknown>;
+}
+
+describe("admin physical backup release control", () => {
+    test("creates an explicit full backup and returns exact completed evidence", async () => {
+        const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+        let inventoryRead = 0;
+        const http = {
+            get: async (path: string) => {
+                calls.push({ method: "GET", path });
+                inventoryRead += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: inventoryRead === 1 ? [EXISTING_BACKUP] : [EXISTING_BACKUP, {
+                        ...NEW_BACKUP,
+                        token: "remote-token-must-not-escape",
+                    }],
+                };
+            },
+            post: async (path: string, body: unknown) => {
+                calls.push({ method: "POST", path, body });
+                return { ok: true, status: 200, data: { message: "full backup completed" } };
+            },
+        };
+
+        const response = await createFullPhysicalBackup(http as never, "fa_staging");
+
+        expect(response.isError).not.toBe(true);
+        expect(parsed(response)).toEqual({
+            project_ref: "fa_staging",
+            requested_type: "full",
+            backup: NEW_BACKUP,
+        });
+        expect(response.content[0].text).not.toContain("remote-token-must-not-escape");
+        expect(calls).toEqual([
+            { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
+            { method: "POST", path: "/v1/projects/fa_staging/database/backups", body: { type: "full" } },
+            { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
+        ]);
+    });
+
+    test("fails before mutation when the initial inventory is malformed", async () => {
+        let postCount = 0;
+        let inventoryRead = 0;
+        const http = {
+            get: async () => {
+                inventoryRead += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: [{
+                        ...EXISTING_BACKUP,
+                        ...(inventoryRead === 1
+                            ? { size: -1 }
+                            : { timestamp: { start: 1_786_400_030, stop: 1_786_400_000 } }),
+                    }],
+                };
+            },
+            post: async () => {
+                postCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        };
+
+        const response = await createFullPhysicalBackup(http as never, "fa_staging");
+
+        expect(response.isError).toBe(true);
+        expect(parsed(response).error).toEqual({ code: "INVALID_RESPONSE", http_status: null });
+        expect(postCount).toBe(0);
+
+        const reversedTimestamp = await createFullPhysicalBackup(http as never, "fa_staging");
+        expect(parsed(reversedTimestamp).error).toEqual({ code: "INVALID_RESPONSE", http_status: null });
+        expect(postCount).toBe(0);
+    });
+
+    test("reconciles a failed mutation and reports an unknown server outcome without reflection", async () => {
+        const calls: string[] = [];
+        const http = {
+            get: async () => {
+                calls.push("GET");
+                return { ok: true, status: 200, data: [EXISTING_BACKUP] };
+            },
+            post: async () => {
+                calls.push("POST");
+                return {
+                    ok: false, status: 503,
+                    data: { token: "remote-backup-secret", message: "remote detail" },
+                };
+            },
+        };
+
+        const response = await createFullPhysicalBackup(http as never, "fa_staging");
+
+        expect(response.isError).toBe(true);
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 503 });
+        expect(calls).toEqual(["GET", "POST", "GET"]);
+        expect(response.content[0].text).not.toContain("remote-backup-secret");
+        expect(response.content[0].text).not.toContain("remote detail");
+    });
+
+    test.each([400, 401, 403, 409, 429])(
+        "reconciles deterministic client error %d and classifies it as an HTTP error",
+        async (statusCode) => {
+            const calls: string[] = [];
+            const response = await createFullPhysicalBackup({
+                get: async () => {
+                    calls.push("GET");
+                    return { ok: true, status: 200, data: [EXISTING_BACKUP] };
+                },
+                post: async () => {
+                    calls.push("POST");
+                    return { ok: false, status: statusCode, data: { secret: "client-error-secret" } };
+                },
+            } as never, "fa_staging");
+
+            expect(parsed(response).error).toEqual({ code: "HTTP_ERROR", http_status: statusCode });
+            expect(calls).toEqual(["GET", "POST", "GET"]);
+            expect(response.content[0].text).not.toContain("client-error-secret");
+        },
+    );
+
+    test("keeps a request-timeout mutation outcome unknown after reconciliation", async () => {
+        let inventoryReads = 0;
+        const response = await createFullPhysicalBackup({
+            get: async () => {
+                inventoryReads += 1;
+                return { ok: true, status: 200, data: [EXISTING_BACKUP] };
+            },
+            post: async () => ({ ok: false, status: 408, data: null }),
+        } as never, "fa_staging");
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 408 });
+        expect(inventoryReads).toBe(2);
+    });
+
+    test("reconciles malformed success before reporting an unknown outcome", async () => {
+        const calls: string[] = [];
+        const malformedReceipt = await createFullPhysicalBackup({
+            get: async () => {
+                calls.push("GET");
+                return { ok: true, status: 200, data: [EXISTING_BACKUP] };
+            },
+            post: async () => {
+                calls.push("POST");
+                return { ok: true, status: 200, data: { message: "started" } };
+            },
+        } as never, "fa_staging");
+
+        expect(parsed(malformedReceipt).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+        expect(calls).toEqual(["GET", "POST", "GET"]);
+    });
+
+    test("rejects zero-sized and ambiguous completed full backup evidence", async () => {
+        let inventoryRead = 0;
+        const zeroSizedBackup = await createFullPhysicalBackup({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: inventoryRead++ === 0
+                    ? [EXISTING_BACKUP]
+                    : [EXISTING_BACKUP, { ...NEW_BACKUP, size: 0 }],
+            }),
+            post: async () => ({ ok: true, status: 200, data: { message: "full backup completed" } }),
+        } as never, "fa_staging");
+        inventoryRead = 0;
+        const ambiguousInventory = await createFullPhysicalBackup({
+            get: async () => {
+                inventoryRead += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: inventoryRead === 1
+                        ? [EXISTING_BACKUP]
+                        : [EXISTING_BACKUP, NEW_BACKUP, { ...NEW_BACKUP, id: "20260811-030000F" }],
+                };
+            },
+            post: async () => ({ ok: true, status: 200, data: { message: "full backup completed" } }),
+        } as never, "fa_staging");
+
+        expect(parsed(zeroSizedBackup).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+        expect(parsed(ambiguousInventory).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("lists only sanitized, duplicate-free physical backup records", async () => {
+        const safeList = await listPhysicalBackups({
+            get: async () => ({ ok: true, status: 200, data: [{ ...EXISTING_BACKUP, secret: "hidden" }] }),
+        } as never, "fa_staging");
+        const duplicateList = await listPhysicalBackups({
+            get: async () => ({ ok: true, status: 200, data: [EXISTING_BACKUP, EXISTING_BACKUP] }),
+        } as never, "fa_staging");
+
+        expect(JSON.parse(safeList.content[0].text)).toEqual([EXISTING_BACKUP]);
+        expect(safeList.content[0].text).not.toContain("hidden");
+        expect(parsed(duplicateList).error).toEqual({ code: "INVALID_RESPONSE", http_status: null });
+    });
+
+    test("rejects unsafe project refs before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const http = {
+            get: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: [] };
+            },
+        };
+
+        await expect(listPhysicalBackups(http as never, "../fa")).rejects.toThrow("invalid for physical backup");
+        expect(requestCount).toBe(0);
+    });
+});

--- a/packages/admin/src/shared/tools/backup-release-control.test.ts
+++ b/packages/admin/src/shared/tools/backup-release-control.test.ts
@@ -23,7 +23,7 @@ function parsed(response: { content: Array<{ text: string }> }): Record<string, 
 
 describe("admin physical backup release control", () => {
     test("creates an explicit full backup and returns exact completed evidence", async () => {
-        const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+        const calls: Array<{ method: string; path: string; body?: unknown; timeoutMs?: number }> = [];
         let inventoryRead = 0;
         const http = {
             get: async (path: string) => {
@@ -38,8 +38,8 @@ describe("admin physical backup release control", () => {
                     }],
                 };
             },
-            post: async (path: string, body: unknown) => {
-                calls.push({ method: "POST", path, body });
+            post: async (path: string, body: unknown, options: { timeoutMs: number }) => {
+                calls.push({ method: "POST", path, body, timeoutMs: options.timeoutMs });
                 return { ok: true, status: 200, data: { message: "full backup completed" } };
             },
         };
@@ -55,7 +55,12 @@ describe("admin physical backup release control", () => {
         expect(response.content[0].text).not.toContain("remote-token-must-not-escape");
         expect(calls).toEqual([
             { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
-            { method: "POST", path: "/v1/projects/fa_staging/database/backups", body: { type: "full" } },
+            {
+                method: "POST",
+                path: "/v1/projects/fa_staging/database/backups",
+                body: { type: "full" },
+                timeoutMs: 35 * 60_000,
+            },
             { method: "GET", path: "/v1/projects/fa_staging/database/backups" },
         ]);
     });
@@ -152,6 +157,28 @@ describe("admin physical backup release control", () => {
 
         expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 408 });
         expect(inventoryReads).toBe(2);
+    });
+
+    test("keeps an unacknowledged timed-out outcome unknown even when reconciliation sees a completed backup", async () => {
+        let inventoryReads = 0;
+        let postCount = 0;
+        const response = await createFullPhysicalBackup({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: inventoryReads++ === 0
+                    ? [EXISTING_BACKUP]
+                    : [EXISTING_BACKUP, NEW_BACKUP],
+            }),
+            post: async () => {
+                postCount++;
+                return { ok: false, status: 500, data: null };
+            },
+        } as never, "fa_staging");
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 500 });
+        expect(inventoryReads).toBe(2);
+        expect(postCount).toBe(1);
     });
 
     test("reconciles malformed success before reporting an unknown outcome", async () => {

--- a/packages/admin/src/shared/tools/backup-release-control.ts
+++ b/packages/admin/src/shared/tools/backup-release-control.ts
@@ -1,0 +1,170 @@
+import type { HttpResult, HttpTransport } from "../transports/http";
+
+export type AdminBackupToolResponse = {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+};
+
+type BackupRecord = {
+    id: string;
+    type: "full" | "incr" | "diff";
+    timestamp: { start: number; stop: number };
+    size: number;
+    database: string;
+};
+
+type BackupInventoryRead = {
+    inventory?: BackupRecord[];
+    response: HttpResult<unknown>;
+};
+
+const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_-]{1,64}$/;
+const SAFE_BACKUP_FIELD = /^[A-Za-z0-9_.-]{1,128}$/;
+
+function nonnegativeSafeInteger(candidate: unknown): candidate is number {
+    return typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate >= 0;
+}
+
+function backupTimestamp(candidate: unknown): BackupRecord["timestamp"] | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const timestamp = candidate as Record<string, unknown>;
+    if (!nonnegativeSafeInteger(timestamp.start) || !nonnegativeSafeInteger(timestamp.stop)) return null;
+    if (timestamp.stop > 0 && timestamp.stop < timestamp.start) return null;
+    return { start: timestamp.start, stop: timestamp.stop };
+}
+
+function backupFailure(
+    operation: string,
+    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "OUTCOME_UNKNOWN",
+    httpStatus: number | null,
+): AdminBackupToolResponse {
+    return {
+        isError: true,
+        content: [{
+            type: "text",
+            text: JSON.stringify({
+                ok: false,
+                operation,
+                error: { code, http_status: httpStatus },
+            }),
+        }],
+    };
+}
+
+function backupRecord(candidate: unknown): BackupRecord | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const record = candidate as Record<string, unknown>;
+    const timestamp = backupTimestamp(record.timestamp);
+    if (!timestamp) return null;
+    if (typeof record.id !== "string" || !SAFE_BACKUP_FIELD.test(record.id)) return null;
+    if (record.type !== "full" && record.type !== "incr" && record.type !== "diff") return null;
+    if (!nonnegativeSafeInteger(record.size)) return null;
+    if (typeof record.database !== "string" || !SAFE_BACKUP_FIELD.test(record.database)) return null;
+    return {
+        id: record.id,
+        type: record.type,
+        timestamp,
+        size: record.size,
+        database: record.database,
+    };
+}
+
+function backupInventory(payload: unknown): BackupRecord[] | null {
+    if (!Array.isArray(payload)) return null;
+    const records = payload.map(backupRecord);
+    if (records.some((record) => record === null)) return null;
+    const inventory = records as BackupRecord[];
+    return new Set(inventory.map((record) => record.id)).size === inventory.length
+        ? inventory
+        : null;
+}
+
+function backupEndpoint(projectRef: string): string {
+    if (!SAFE_PATH_SEGMENT.test(projectRef)) throw new Error("'ref' is invalid for physical backup");
+    return `/v1/projects/${encodeURIComponent(projectRef)}/database/backups`;
+}
+
+async function readBackupInventory(
+    http: HttpTransport,
+    endpoint: string,
+): Promise<BackupInventoryRead> {
+    const response = await http.get(endpoint);
+    return { response, inventory: response.ok ? backupInventory(response.data) ?? undefined : undefined };
+}
+
+function successfulBackupResponse(payload: object): AdminBackupToolResponse {
+    return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function completedFullBackup(
+    before: readonly BackupRecord[],
+    after: readonly BackupRecord[],
+): BackupRecord | null {
+    const previousIds = new Set(before.map((backup) => backup.id));
+    const candidates = after.filter((backup) => (
+        !previousIds.has(backup.id)
+        && backup.type === "full"
+        && backup.timestamp.stop > 0
+        && backup.size > 0
+    ));
+    return candidates.length === 1 ? candidates[0] : null;
+}
+
+function mutationFailureCode(statusCode: number): "HTTP_ERROR" | "OUTCOME_UNKNOWN" {
+    return statusCode >= 400 && statusCode < 500 && statusCode !== 408
+        ? "HTTP_ERROR"
+        : "OUTCOME_UNKNOWN";
+}
+
+function confirmsFullBackup(payload: unknown): boolean {
+    return Boolean(payload)
+        && typeof payload === "object"
+        && !Array.isArray(payload)
+        && (payload as Record<string, unknown>).message === "full backup completed";
+}
+
+function reconciledCreationResponse(
+    projectRef: string,
+    before: readonly BackupRecord[],
+    creation: HttpResult<unknown>,
+    afterRead: BackupInventoryRead,
+): AdminBackupToolResponse {
+    if (!creation.ok) {
+        return backupFailure("platform.create_backup", mutationFailureCode(creation.status), creation.status);
+    }
+    if (!confirmsFullBackup(creation.data)) {
+        return backupFailure("platform.create_backup", "OUTCOME_UNKNOWN", creation.status);
+    }
+    if (!afterRead.response.ok || !afterRead.inventory) {
+        return backupFailure("platform.create_backup", "OUTCOME_UNKNOWN", afterRead.response.status);
+    }
+    const backup = completedFullBackup(before, afterRead.inventory);
+    if (!backup) return backupFailure("platform.create_backup", "OUTCOME_UNKNOWN", afterRead.response.status);
+    return successfulBackupResponse({ project_ref: projectRef, requested_type: "full", backup });
+}
+
+export async function listPhysicalBackups(
+    http: HttpTransport,
+    projectRef: string,
+): Promise<AdminBackupToolResponse> {
+    const { response, inventory } = await readBackupInventory(http, backupEndpoint(projectRef));
+    if (!response.ok) return backupFailure("platform.list_backups", "HTTP_ERROR", response.status);
+    if (!inventory) return backupFailure("platform.list_backups", "INVALID_RESPONSE", null);
+    return successfulBackupResponse(inventory);
+}
+
+export async function createFullPhysicalBackup(
+    http: HttpTransport,
+    projectRef: string,
+): Promise<AdminBackupToolResponse> {
+    const endpoint = backupEndpoint(projectRef);
+    const beforeRead = await readBackupInventory(http, endpoint);
+    if (!beforeRead.response.ok) {
+        return backupFailure("platform.create_backup", "HTTP_ERROR", beforeRead.response.status);
+    }
+    if (!beforeRead.inventory) return backupFailure("platform.create_backup", "INVALID_RESPONSE", null);
+
+    const creation = await http.post(endpoint, { type: "full" });
+    const afterRead = await readBackupInventory(http, endpoint);
+    return reconciledCreationResponse(projectRef, beforeRead.inventory, creation, afterRead);
+}

--- a/packages/admin/src/shared/tools/backup-release-control.ts
+++ b/packages/admin/src/shared/tools/backup-release-control.ts
@@ -1,6 +1,6 @@
 import type { HttpResult, HttpTransport } from "../transports/http";
 
-export type AdminBackupToolResponse = {
+type AdminBackupToolResponse = {
     content: Array<{ type: "text"; text: string }>;
     isError?: boolean;
 };
@@ -20,6 +20,7 @@ type BackupInventoryRead = {
 
 const SAFE_PATH_SEGMENT = /^[A-Za-z0-9_-]{1,64}$/;
 const SAFE_BACKUP_FIELD = /^[A-Za-z0-9_.-]{1,128}$/;
+const PHYSICAL_BACKUP_REQUEST_TIMEOUT_MS = 35 * 60_000;
 
 function nonnegativeSafeInteger(candidate: unknown): candidate is number {
     return typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate >= 0;
@@ -164,7 +165,11 @@ export async function createFullPhysicalBackup(
     }
     if (!beforeRead.inventory) return backupFailure("platform.create_backup", "INVALID_RESPONSE", null);
 
-    const creation = await http.post(endpoint, { type: "full" });
+    const creation = await http.post(
+        endpoint,
+        { type: "full" },
+        { timeoutMs: PHYSICAL_BACKUP_REQUEST_TIMEOUT_MS },
+    );
     const afterRead = await readBackupInventory(http, endpoint);
     return reconciledCreationResponse(projectRef, beforeRead.inventory, creation, afterRead);
 }

--- a/packages/admin/src/shared/transports/http.test.ts
+++ b/packages/admin/src/shared/transports/http.test.ts
@@ -7,14 +7,21 @@ const originalSetTimeout = globalThis.setTimeout;
 const originalClearTimeout = globalThis.clearTimeout;
 
 let clearedTimerIds: Array<ReturnType<typeof setTimeout> | undefined> = [];
+let scheduledTimers: Array<{
+    callback: (...args: unknown[]) => void;
+    delay: number | undefined;
+    args: unknown[];
+}> = [];
 let nextTimerId = 0;
 
 beforeEach(() => {
     clearedTimerIds = [];
+    scheduledTimers = [];
     nextTimerId = 0;
     globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
         const timerId = ++nextTimerId as unknown as ReturnType<typeof setTimeout>;
-        if (delay !== 30_000) queueMicrotask(() => callback(...args));
+        scheduledTimers.push({ callback, delay, args });
+        if (delay === 500 || delay === 1_000) queueMicrotask(() => callback(...args));
         return timerId;
     }) as typeof setTimeout;
     globalThis.clearTimeout = ((timerId?: ReturnType<typeof setTimeout>) => {
@@ -96,6 +103,20 @@ describe("HttpTransport retry policy", () => {
         expect(clearedTimerIds).toHaveLength(1);
     });
 
+    test("does not retry POST after an HTTP 408 response", async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return Response.json({ error: "request timeout" }, { status: 408 });
+        }) as unknown as typeof fetch;
+
+        const response = await createTransport().post("/resource", { name: "test" });
+
+        expect(response.status).toBe(408);
+        expect(fetchCalls).toBe(1);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+
     test.each(unsafeRequests)("does not retry %s after a retryable network error", async (_method, request) => {
         let fetchCalls = 0;
         globalThis.fetch = (async () => {
@@ -108,5 +129,61 @@ describe("HttpTransport retry policy", () => {
         expect(response.status).toBe(500);
         expect(fetchCalls).toBe(1);
         expect(clearedTimerIds).toHaveLength(1);
+    });
+
+    test("uses a bounded operation-specific timeout for one POST", async () => {
+        globalThis.fetch = (async () => Response.json({ ok: true })) as unknown as typeof fetch;
+
+        const response = await createTransport().post(
+            "/v1/projects/fa/database/backups",
+            { type: "full" },
+            { timeoutMs: 35 * 60_000 },
+        );
+
+        expect(response.ok).toBe(true);
+        expect(scheduledTimers.map(({ delay }) => delay)).toEqual([35 * 60_000]);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+
+    test("aborts a long POST at its cap without retrying", async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = ((_input, init) => {
+            fetchCalls++;
+            return new Promise((_resolve, reject) => {
+                init?.signal?.addEventListener("abort", () => {
+                    const error = new Error("request timed out");
+                    error.name = "AbortError";
+                    reject(error);
+                });
+                queueMicrotask(() => scheduledTimers[0].callback(...scheduledTimers[0].args));
+            });
+        }) as typeof fetch;
+
+        const response = await createTransport().post(
+            "/v1/projects/fa/database/backups",
+            { type: "full" },
+            { timeoutMs: 35 * 60_000 },
+        );
+
+        expect(response).toEqual({
+            ok: false,
+            status: 500,
+            data: { error: "Network Error", details: "request timed out" },
+        });
+        expect(fetchCalls).toBe(1);
+        expect(clearedTimerIds).toHaveLength(1);
+    });
+
+    test.each([0, 35 * 60_000 + 1, 1.5])("rejects invalid POST timeout %d before dispatch", async timeoutMs => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+
+        await expect(createTransport().post("/resource", {}, { timeoutMs })).rejects.toThrow(
+            "HTTP request timeout must be between",
+        );
+        expect(fetchCalls).toBe(0);
     });
 });

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -16,7 +16,12 @@ export interface HttpResult<T = unknown> {
     data: T;
 }
 
+interface HttpPostOptions {
+    timeoutMs: number;
+}
+
 const DEFAULT_TIMEOUT = 30_000;
+const MAX_POST_TIMEOUT_MS = 35 * 60_000;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
 
@@ -33,9 +38,21 @@ function isRetryableError(error: unknown): boolean {
         || networkError.code === "ECONNRESET";
 }
 
-async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+function validatedPostTimeout(options?: HttpPostOptions): number {
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_POST_TIMEOUT_MS) {
+        throw new RangeError(`HTTP request timeout must be between 1 and ${MAX_POST_TIMEOUT_MS} ms`);
+    }
+    return timeoutMs;
+}
+
+async function fetchWithTimeout(
+    url: string,
+    options: RequestInit,
+    timeoutMs = DEFAULT_TIMEOUT,
+): Promise<Response> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
         return await fetch(url, {
             ...options,
@@ -49,11 +66,12 @@ async function fetchWithTimeout(url: string, options: RequestInit): Promise<Resp
 async function fetchWithRetry(
     url: string,
     options: RequestInit,
+    timeoutMs = DEFAULT_TIMEOUT,
 ): Promise<Response> {
     const retries = isRetryableMethod(options.method) ? MAX_RETRIES : 0;
     for (let attempt = 0; attempt <= retries; attempt++) {
         try {
-            const res = await fetchWithTimeout(url, options);
+            const res = await fetchWithTimeout(url, options, timeoutMs);
 
             if (res.status >= 500 && res.status < 600 && attempt < retries) {
                 const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
@@ -102,13 +120,18 @@ export class HttpTransport {
         }
     }
 
-    async post<T = unknown>(path: string, body?: unknown): Promise<HttpResult<T>> {
+    async post<T = unknown>(
+        path: string,
+        body?: unknown,
+        options?: HttpPostOptions,
+    ): Promise<HttpResult<T>> {
+        const timeoutMs = validatedPostTimeout(options);
         try {
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "POST",
                 headers: this.headers(),
                 body: body ? JSON.stringify(body) : undefined,
-            });
+            }, timeoutMs);
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: any) {

--- a/packages/management-api/src/routes/backups.ts
+++ b/packages/management-api/src/routes/backups.ts
@@ -9,8 +9,8 @@ import {
     PitrRestoreUnavailableError,
     isPitrEnabled,
 } from '../services/backup.service';
-import { resolveDbName } from '../db';
 import { requireAdminAuth, requireProjectOrAdminAuth } from '../middleware/auth';
+import { projectRepository } from '../repositories/project.repository';
 
 const ErrorResponse = t.Object({ message: t.String() });
 
@@ -19,9 +19,10 @@ const projectBackupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
 
-        const dbName = await resolveDbName(params.ref);
+        const project = await projectRepository.findByRef(params.ref);
+        if (!project) return status(404, { message: "Project not found" });
         try {
-            return await listBackups(dbName);
+            return await listBackups(project.db_name);
         } catch (error) {
             if (error instanceof PgBackRestUnavailableError) {
                 return status(503, { message: "pgBackRest backup inventory is unavailable" });
@@ -29,13 +30,15 @@ const projectBackupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
             throw error;
         }
     }, {
-        response: { 200: t.Any(), 503: ErrorResponse },
+        response: { 200: t.Any(), 404: ErrorResponse, 503: ErrorResponse },
         detail: { tags: ["backups"], summary: "List project backups" },
     })
-    .post('/', async ({ body, request }) => {
+    .post('/', async ({ params, body, request }) => {
         const authError = await requireAdminAuth(request);
         if (authError) return status(authError.status, authError.body);
 
+        const project = await projectRepository.findByRef(params.ref);
+        if (!project) return status(404, { message: "Project not found" });
         try {
             return await createBackup(body.type);
         } catch (error) {
@@ -52,7 +55,7 @@ const projectBackupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
                 t.Literal('diff'),
             ])),
         }),
-        response: { 200: t.Any(), 503: ErrorResponse },
+        response: { 200: t.Any(), 404: ErrorResponse, 503: ErrorResponse },
         detail: { tags: ["backups"], summary: "Create a database backup" },
     })
     .post('/logical', async ({ params: { ref }, request }) => {

--- a/packages/management-api/tests/unit/backup.routes.test.ts
+++ b/packages/management-api/tests/unit/backup.routes.test.ts
@@ -3,7 +3,10 @@ import { Elysia } from "elysia";
 
 const requireAdminAuth = mock(() => Promise.resolve(null));
 const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
-const resolveDbName = mock((ref: string) => Promise.resolve(`supa_${ref}`));
+type BackupProject = { ref: string; db_name: string };
+const findByRef = mock((ref: string): Promise<BackupProject | null> => (
+  Promise.resolve({ ref, db_name: "canonical_project_database" })
+));
 const listBackups = mock(() => Promise.resolve([]));
 const createBackup = mock(() => Promise.resolve({ message: "full backup completed" }));
 const createLogicalBackup = mock(() => Promise.resolve({ success: true, message: "Logical backup completed", file: "backup_project_a_2026-08-05T00-00-00-000Z.sql.gz" }));
@@ -11,8 +14,8 @@ const restoreLogicalBackup = mock(() => Promise.resolve({ success: true, message
 const restore = mock(() => Promise.resolve({ message: "PITR restore completed" }));
 
 const authModule = await import("../../src/middleware/auth");
-const dbModule = await import("../../src/db");
 const backupModule = await import("../../src/services/backup.service");
+const { projectRepository } = await import("../../src/repositories/project.repository");
 
 const requireAdminAuthSpy = spyOn(authModule, "requireAdminAuth").mockImplementation(
   requireAdminAuth as typeof authModule.requireAdminAuth,
@@ -20,8 +23,8 @@ const requireAdminAuthSpy = spyOn(authModule, "requireAdminAuth").mockImplementa
 const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
   requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
 );
-const resolveDbNameSpy = spyOn(dbModule, "resolveDbName").mockImplementation(
-  resolveDbName as typeof dbModule.resolveDbName,
+const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(
+  findByRef as typeof projectRepository.findByRef,
 );
 const listBackupsSpy = spyOn(backupModule, "listBackups").mockImplementation(
   listBackups as typeof backupModule.listBackups,
@@ -60,8 +63,11 @@ describe("physical backup routes", () => {
     requireAdminAuth.mockResolvedValue(null);
     requireProjectOrAdminAuth.mockReset();
     requireProjectOrAdminAuth.mockResolvedValue(null);
-    resolveDbName.mockReset();
-    resolveDbName.mockImplementation((ref: string) => Promise.resolve(`supa_${ref}`));
+    findByRef.mockReset();
+    findByRef.mockImplementation((ref: string) => Promise.resolve({
+      ref,
+      db_name: "canonical_project_database",
+    }));
     listBackups.mockReset();
     listBackups.mockResolvedValue([]);
     createBackup.mockReset();
@@ -83,7 +89,7 @@ describe("physical backup routes", () => {
   afterAll(() => {
     requireAdminAuthSpy.mockRestore();
     requireProjectOrAdminAuthSpy.mockRestore();
-    resolveDbNameSpy.mockRestore();
+    findByRefSpy.mockRestore();
     listBackupsSpy.mockRestore();
     createBackupSpy.mockRestore();
     createLogicalBackupSpy.mockRestore();
@@ -91,19 +97,20 @@ describe("physical backup routes", () => {
     restoreSpy.mockRestore();
   });
 
-  test("lists cluster inventory under the requested project database", async () => {
+  test("lists cluster inventory under the persisted project database name", async () => {
     listBackups.mockResolvedValue([{
       id: "20260722-120000F",
       type: "full",
       timestamp: { start: 1_784_000_000, stop: 1_784_000_030 },
       size: 2048,
-      database: "supa_project_a",
+      database: "canonical_project_database",
     }]);
 
     const response = await request("/v1/projects/project_a/database/backups");
     expect(response.status).toBe(200);
     expect(await response.json()).toHaveLength(1);
-    expect(listBackups).toHaveBeenCalledWith("supa_project_a");
+    expect(findByRef).toHaveBeenCalledWith("project_a");
+    expect(listBackups).toHaveBeenCalledWith("canonical_project_database");
   });
 
   test("reports backup success only after the service returns a completed result", async () => {
@@ -114,7 +121,26 @@ describe("physical backup routes", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ message: "full backup completed" });
+    expect(findByRef).toHaveBeenCalledWith("project_a");
     expect(createBackup).toHaveBeenCalledWith("full");
+  });
+
+  test("rejects unknown project refs before physical backup reads or writes", async () => {
+    findByRef.mockResolvedValue(null);
+
+    const listResponse = await request("/v1/projects/missing/database/backups");
+    const createResponse = await request("/v1/projects/missing/database/backups", {
+      method: "POST",
+      body: JSON.stringify({ type: "full" }),
+    });
+
+    expect(listResponse.status).toBe(404);
+    expect(await listResponse.json()).toEqual({ message: "Project not found" });
+    expect(createResponse.status).toBe(404);
+    expect(await createResponse.json()).toEqual({ message: "Project not found" });
+    expect(findByRef).toHaveBeenCalledTimes(2);
+    expect(listBackups).not.toHaveBeenCalled();
+    expect(createBackup).not.toHaveBeenCalled();
   });
 
   test("returns 503 instead of an empty list or started response on pgBackRest failure", async () => {


### PR DESCRIPTION
## Summary

- add the supported Admin physical full-backup command with a sanitized machine-readable receipt
- require canonical project/database binding and unique completed non-empty backup evidence
- reconcile unacknowledged mutations without retrying unsafe POST requests
- bound the long-running physical backup request independently from ordinary Admin requests

## Verification

- `bun test packages/admin/src`: 221 pass, 0 fail
- Management backup routes/service: 27 pass, 0 fail
- Admin and Management typecheck: pass
- Admin build and Management linux-amd64 compile: pass
- `git diff --check`: pass
- independent failure-matrix review: P0/P1/P2 = 0/0/0

A post-rebase Management full-unit run reached 1317 pass and six unrelated installer-script timeout failures under local machine load. The same full suite passed before rebase; the intervening main commit is CLI-only and does not overlap this patch. Required CI remains the merge gate.
