### PR TITLE
feat(cli): add storage bucket lifecycle

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -387,6 +387,12 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
         run: bun test tests/integration/project-webhook-array-binding.test.ts
 
+      - name: Verify Storage bucket array binding on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: bun test tests/integration/storage-bucket-array-binding.test.ts
+
       - name: Verify Realtime payload safety on PostgreSQL 18
         working-directory: packages/management-api
         env:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -160,6 +160,13 @@ supacloud-cli edge_functions source --ref abc123 --slug hello --output ./hello.t
 supacloud-cli edge_functions activate --ref abc123 --slug hello --version 3
 supacloud-cli scheduled_functions list --ref abc123
 supacloud-cli secrets upsert --ref abc123 --from-env API_KEY,WEBHOOK_SECRET
+supacloud-cli storage list_buckets --ref abc123
+supacloud-cli storage get_bucket --ref abc123 --bucket reports
+supacloud-cli storage create_bucket --ref abc123 --bucket reports --public false \
+  --file_size_limit 10485760 --allowed_mime_types "application/pdf,image/png"
+supacloud-cli storage update_bucket --ref abc123 --bucket reports \
+  --allowed_mime_types '["application/pdf"]'
+supacloud-cli storage delete_bucket --ref abc123 --bucket reports
 ```
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -149,6 +149,22 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).toContain("SUPACLOUD_READ_ONLY=true");
     });
 
+    test("keeps complete Storage help without project configuration", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-storage-help-"));
+        temporaryDirectories.push(workspace);
+
+        const response = await runProjectCli(["storage", "--help"], {}, workspace);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("list_buckets");
+        expect(response.stderr).toContain("get_bucket");
+        expect(response.stderr).toContain("create_bucket");
+        expect(response.stderr).toContain("update_bucket");
+        expect(response.stderr).toContain("delete_bucket");
+        expect(response.stderr).toContain("--file_size_limit");
+        expect(response.stderr).toContain("--allowed_mime_types");
+    });
+
     test("loads named environments with global flags after the command and keeps status secret-free", async () => {
         const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-named-env-"));
         temporaryDirectories.push(workspace);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -310,6 +310,11 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
                 }),
             };
         }
+        const storageContextCallback = tools.storage.callback;
+        const storageHelpTool = captureTools((server) => registerStorageTools(server as any, {} as HttpTransport)).storage;
+        if (storageHelpTool) {
+            tools.storage = { schema: storageHelpTool.schema, callback: storageContextCallback };
+        }
         const branchContextCallback = tools.branch.callback;
         const branchHelpTool = captureTools((server) => registerBranchTools(server as any, {} as any, {
             readOnly: true,

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -131,11 +131,15 @@ describe("CLI execution policy", () => {
         })).toThrow("SUPACLOUD_READ_ONLY=true");
     });
 
-    test("classifies Function activation and Scheduled Function mutations as writes", () => {
+    test("classifies Function, Scheduled Function, and Storage lifecycle actions", () => {
         expect(executionMode("edge_functions", "activate", {})).toBe("write");
         expect(executionMode("scheduled_functions", "list", {})).toBe("read");
         for (const action of ["create", "update", "delete"]) {
             expect(executionMode("scheduled_functions", action, {})).toBe("write");
+        }
+        expect(executionMode("storage", "get_bucket", {})).toBe("read");
+        for (const action of ["create_bucket", "update_bucket", "delete_bucket"]) {
+            expect(executionMode("storage", action, {})).toBe("write");
         }
     });
 

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -28,8 +28,8 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         write: ["configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config"],
     },
     storage: {
-        read: ["status", "list_buckets", "list_files"],
-        write: ["upload_base64", "delete_file"],
+        read: ["status", "list_buckets", "get_bucket", "list_files"],
+        write: ["create_bucket", "update_bucket", "delete_bucket", "upload_base64", "delete_file"],
     },
     edge_functions: {
         read: ["list", "source"],

--- a/packages/cli/src/shared/tools/storage-tools.test.ts
+++ b/packages/cli/src/shared/tools/storage-tools.test.ts
@@ -8,6 +8,18 @@ type ToolResponse = {
     isError?: boolean;
 };
 
+const RELEASE_SCHEMA = "supacloud.cli.release-control.v1";
+
+function successReceipt(operation: string, payload: Record<string, unknown>) {
+    return {
+        schema: RELEASE_SCHEMA,
+        ok: true,
+        operation,
+        project_ref: "project-ref",
+        ...payload,
+    };
+}
+
 function storageBucket(overrides: Record<string, unknown> = {}) {
     return {
         id: "reports",
@@ -49,6 +61,12 @@ describe("Storage bucket CLI schema", () => {
             bucket: "artifacts",
             allowed_mime_types: '["text/csv"]',
         }).allowed_mime_types).toEqual(["text/csv"]);
+        expect(parseToolArguments(schema, {
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "artifacts",
+            allowed_mime_types: [],
+        }).allowed_mime_types).toEqual([]);
     });
 
     test("rejects malformed JSON MIME type arrays", () => {
@@ -75,6 +93,50 @@ describe("Storage bucket CLI schema", () => {
             })).toThrow("file_size_limit");
         },
     );
+
+    test.each([
+        ["empty MIME", [""]],
+        ["whitespace MIME", ["   "]],
+        ["trailing empty CSV MIME", "application/pdf,"],
+        ["overlong MIME", [`text/${"a".repeat(251)}`]],
+        ["too many MIME types", Array.from({ length: 101 }, (_, index) => `application/x-${index}`)],
+    ])("rejects %s", (_label, allowedMimeTypes) => {
+        const { schema } = captureStorageTool({});
+
+        expect(() => parseToolArguments(schema, {
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "artifacts",
+            allowed_mime_types: allowedMimeTypes,
+        })).toThrow("allowed_mime_types");
+    });
+
+    test("accepts exact upper boundaries", () => {
+        const { schema } = captureStorageTool({});
+        const allowedMimeTypes = Array.from({ length: 100 }, (_, index) => `application/x-${index}`);
+        allowedMimeTypes[0] = `x/${"a".repeat(253)}`;
+
+        const parsed = parseToolArguments(schema, {
+            action: "create_bucket",
+            ref: "r".repeat(64),
+            bucket: "b".repeat(100),
+            file_size_limit: Number.MAX_SAFE_INTEGER,
+            allowed_mime_types: allowedMimeTypes,
+        });
+
+        expect(parsed.file_size_limit).toBe(Number.MAX_SAFE_INTEGER);
+        expect(parsed.allowed_mime_types).toHaveLength(100);
+        expect((parsed.allowed_mime_types as string[])[0]).toHaveLength(255);
+    });
+
+    test.each([
+        ["invalid ref", { action: "list_buckets", ref: "bad.ref" }],
+        ["dot-only bucket", { action: "get_bucket", ref: "project-ref", bucket: "..." }],
+        ["overlong bucket", { action: "get_bucket", ref: "project-ref", bucket: "b".repeat(101) }],
+    ])("rejects %s in the CLI schema", (_label, args) => {
+        const { schema } = captureStorageTool({});
+        expect(() => parseToolArguments(schema, args)).toThrow("Invalid arguments");
+    });
 });
 
 describe("Storage bucket lifecycle", () => {
@@ -97,7 +159,7 @@ describe("Storage bucket lifecycle", () => {
         const response = await callback({ action: "list_buckets", ref: "project-ref" });
 
         expect(calls).toEqual(["/v1/projects/project-ref/storage/buckets"]);
-        expect(JSON.parse(response.content[0].text)).toEqual(buckets);
+        expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.list_buckets", { buckets }));
         expect(response.isError).not.toBe(true);
     });
 
@@ -113,7 +175,9 @@ describe("Storage bucket lifecycle", () => {
 
         const response = await callback({ action: "list_buckets", ref: "project-ref" });
 
-        expect(JSON.parse(response.content[0].text)).toEqual([storageBucket()]);
+        expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.list_buckets", {
+            buckets: [storageBucket()],
+        }));
         expect(response.content[0].text).not.toContain(secretMarker);
     });
 
@@ -130,13 +194,18 @@ describe("Storage bucket lifecycle", () => {
         const response = await callback({ action: "get_bucket", ref: "project_ref", bucket: "raw-data.v1" });
 
         expect(calls).toEqual(["/v1/projects/project_ref/storage/buckets/raw-data.v1"]);
-        expect(JSON.parse(response.content[0].text)).toEqual(bucket);
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            ...successReceipt("storage.get_bucket", { bucket }),
+            project_ref: "project_ref",
+        });
     });
 
     test.each([
         ["project ref", { action: "list_buckets", ref: "../project" }],
         ["slash bucket", { action: "get_bucket", ref: "project-ref", bucket: "raw/data" }],
-        ["dot bucket", { action: "delete_bucket", ref: "project-ref", bucket: ".." }],
+        ["dot bucket", { action: "delete_bucket", ref: "project-ref", bucket: "..." }],
+        ["long bucket", { action: "get_bucket", ref: "project-ref", bucket: "a".repeat(101) }],
+        ["long ref", { action: "list_buckets", ref: "a".repeat(65) }],
     ])("rejects invalid %s path input before HTTP dispatch", async (_label, args) => {
         let requestCount = 0;
         const request = async () => {
@@ -146,6 +215,24 @@ describe("Storage bucket lifecycle", () => {
         const { callback } = captureStorageTool({ get: request, delete: request });
 
         await expect(callback(args)).rejects.toThrow("invalid for Storage buckets");
+        expect(requestCount).toBe(0);
+    });
+
+    test.each([
+        ["list_buckets", { action: "list_buckets", ref: "project-ref", bucket: "reports" }],
+        ["get_bucket", { action: "get_bucket", ref: "project-ref", bucket: "reports", public: true }],
+        ["create_bucket", { action: "create_bucket", ref: "project-ref", bucket: "reports", filename: "x" }],
+        ["update_bucket", { action: "update_bucket", ref: "project-ref", bucket: "reports", base64_content: "eA==" }],
+        ["delete_bucket", { action: "delete_bucket", ref: "project-ref", bucket: "reports", file_size_limit: 1 }],
+    ])("rejects cross-action flags for %s before HTTP dispatch", async (action, args) => {
+        let requestCount = 0;
+        const request = async () => {
+            requestCount += 1;
+            return { ok: true, status: 200, data: {} };
+        };
+        const { callback } = captureStorageTool({ get: request, post: request, put: request, delete: request });
+
+        await expect(callback(args)).rejects.toThrow(`not supported for '${action}'`);
         expect(requestCount).toBe(0);
     });
 
@@ -189,15 +276,21 @@ describe("Storage bucket lifecycle", () => {
             },
             { method: "GET", path: "/v1/projects/project-ref/storage/buckets/reports" },
         ]);
-        expect(JSON.parse(response.content[0].text)).toEqual(readback);
+        expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.create_bucket", {
+            bucket: readback,
+        }));
     });
 
     test("updates only explicitly provided fields", async () => {
-        const calls: Array<{ path: string; body: unknown }> = [];
+        const calls: Array<{ method: "GET" | "PUT"; path: string; body?: unknown }> = [];
         const bucket = storageBucket({ public: true, file_size_limit: 1048576, allowed_mime_types: [] });
         const { callback } = captureStorageTool({
             put: async (path: string, body: unknown) => {
-                calls.push({ path, body });
+                calls.push({ method: "PUT", path, body });
+                return { ok: true, status: 200, data: bucket };
+            },
+            get: async (path: string) => {
+                calls.push({ method: "GET", path });
                 return { ok: true, status: 200, data: bucket };
             },
         });
@@ -211,16 +304,25 @@ describe("Storage bucket lifecycle", () => {
             allowed_mime_types: [],
         });
 
-        expect(calls).toEqual([{
-            path: "/v1/projects/project-ref/storage/buckets/reports",
-            body: { public: true, file_size_limit: 1048576, allowed_mime_types: [] },
-        }]);
-        expect(JSON.parse(response.content[0].text)).toEqual(bucket);
+        expect(calls).toEqual([
+            {
+                method: "PUT",
+                path: "/v1/projects/project-ref/storage/buckets/reports",
+                body: { public: true, file_size_limit: 1048576, allowed_mime_types: [] },
+            },
+            { method: "GET", path: "/v1/projects/project-ref/storage/buckets/reports" },
+        ]);
+        expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.update_bucket", { bucket }));
     });
 
     test("accepts the platform's null normalization when clearing MIME restrictions", async () => {
         const { callback } = captureStorageTool({
             put: async () => ({
+                ok: true,
+                status: 200,
+                data: storageBucket({ allowed_mime_types: null }),
+            }),
+            get: async () => ({
                 ok: true,
                 status: 200,
                 data: storageBucket({ allowed_mime_types: null }),
@@ -235,7 +337,7 @@ describe("Storage bucket lifecycle", () => {
         });
 
         expect(response.isError).not.toBe(true);
-        expect(JSON.parse(response.content[0].text).allowed_mime_types).toBeNull();
+        expect(JSON.parse(response.content[0].text).bucket.allowed_mime_types).toBeNull();
     });
 
     test("rejects an empty update before HTTP dispatch", async () => {
@@ -255,20 +357,30 @@ describe("Storage bucket lifecycle", () => {
         expect(requestCount).toBe(0);
     });
 
-    test("deletes a bucket and returns the complete API receipt", async () => {
-        const calls: string[] = [];
+    test("deletes a bucket and returns an independently reconciled safe receipt", async () => {
+        const calls: Array<{ method: "DELETE" | "GET"; path: string }> = [];
         const receipt = { id: "reports", deleted: true };
         const { callback } = captureStorageTool({
             delete: async (path: string) => {
-                calls.push(path);
+                calls.push({ method: "DELETE", path });
                 return { ok: true, status: 200, data: receipt };
+            },
+            get: async (path: string) => {
+                calls.push({ method: "GET", path });
+                return { ok: false, status: 404, data: { message: "not found" } };
             },
         });
 
         const response = await callback({ action: "delete_bucket", ref: "project-ref", bucket: "reports" });
 
-        expect(calls).toEqual(["/v1/projects/project-ref/storage/buckets/reports"]);
-        expect(JSON.parse(response.content[0].text)).toEqual(receipt);
+        expect(calls).toEqual([
+            { method: "DELETE", path: "/v1/projects/project-ref/storage/buckets/reports" },
+            { method: "GET", path: "/v1/projects/project-ref/storage/buckets/reports" },
+        ]);
+        expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.delete_bucket", {
+            bucket_id: "reports",
+            deleted: true,
+        }));
     });
 
     test("returns a structured non-success result for bucket read failures", async () => {
@@ -358,13 +470,23 @@ describe("Storage bucket lifecycle", () => {
 
     test.each([
         ["invalid list file_size_limit", "list_buckets", [storageBucket({ file_size_limit: 1.5 })]],
+        ["negative list file_size_limit", "list_buckets", [storageBucket({ file_size_limit: -1 })]],
+        ["overflowing list file_size_limit", "list_buckets", [storageBucket({ file_size_limit: Number.MAX_SAFE_INTEGER + 1 })]],
         ["invalid get allowed_mime_types", "get_bucket", storageBucket({ allowed_mime_types: "image/png" })],
+        ["empty get MIME", "get_bucket", storageBucket({ allowed_mime_types: [""] })],
+        ["too many list MIME types", "list_buckets", [storageBucket({
+            allowed_mime_types: Array.from({ length: 101 }, (_, index) => `application/x-${index}`),
+        })]],
+        ["dot-only bucket id", "get_bucket", storageBucket({ id: "...", name: "..." })],
     ])("rejects %s metadata shape", async (_label, action, apiPayload) => {
         const { callback } = captureStorageTool({
             get: async () => ({ ok: true, status: 200, data: apiPayload }),
         });
 
-        const response = await callback({ action, ref: "project-ref", bucket: "reports" });
+        const args = action === "get_bucket"
+            ? { action, ref: "project-ref", bucket: "reports" }
+            : { action, ref: "project-ref" };
+        const response = await callback(args);
 
         expect(response.isError).toBe(true);
         expect(JSON.parse(response.content[0].text).error).toEqual({ code: "INVALID_RESPONSE", http_status: null });
@@ -430,5 +552,42 @@ describe("Storage bucket lifecycle", () => {
 
         expect(response.isError).toBe(true);
         expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 404 });
+    });
+
+    test("reports an unknown update outcome when independent readback differs", async () => {
+        const { callback } = captureStorageTool({
+            put: async () => ({
+                ok: true,
+                status: 200,
+                data: storageBucket({ public: true }),
+            }),
+            get: async () => ({ ok: true, status: 200, data: storageBucket({ public: false }) }),
+        });
+
+        const response = await callback({
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            public: true,
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("reports an unknown delete outcome unless independent readback is a 404", async () => {
+        const { callback } = captureStorageTool({
+            delete: async () => ({
+                ok: true,
+                status: 200,
+                data: { id: "reports", deleted: true },
+            }),
+            get: async () => ({ ok: true, status: 200, data: storageBucket() }),
+        });
+
+        const response = await callback({ action: "delete_bucket", ref: "project-ref", bucket: "reports" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
     });
 });

--- a/packages/cli/src/shared/tools/storage-tools.test.ts
+++ b/packages/cli/src/shared/tools/storage-tools.test.ts
@@ -383,6 +383,27 @@ describe("Storage bucket lifecycle", () => {
         }));
     });
 
+    test("does not report deletion when the API rejects a concurrent write conflict", async () => {
+        let readbackRequested = false;
+        const { callback } = captureStorageTool({
+            delete: async () => ({
+                ok: false,
+                status: 409,
+                data: { message: "Bucket is not empty" },
+            }),
+            get: async () => {
+                readbackRequested = true;
+                return { ok: false, status: 404, data: { message: "not found" } };
+            },
+        });
+
+        const response = await callback({ action: "delete_bucket", ref: "project-ref", bucket: "reports" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "HTTP_ERROR", http_status: 409 });
+        expect(readbackRequested).toBe(false);
+    });
+
     test("returns a structured non-success result for bucket read failures", async () => {
         const { callback } = captureStorageTool({
             get: async () => ({ ok: false, status: 404, data: { message: "private-server-detail" } }),

--- a/packages/cli/src/shared/tools/storage-tools.test.ts
+++ b/packages/cli/src/shared/tools/storage-tools.test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, test } from "bun:test";
+import { parseToolArguments } from "../schema";
+import type { ToolSchema } from "../schema";
+import { registerStorageTools } from "./storage-tools";
+
+type ToolResponse = {
+    content: Array<{ text: string }>;
+    isError?: boolean;
+};
+
+function storageBucket(overrides: Record<string, unknown> = {}) {
+    return {
+        id: "reports",
+        name: "reports",
+        public: false,
+        file_size_limit: null,
+        allowed_mime_types: null,
+        ...overrides,
+    };
+}
+
+function captureStorageTool(http: Record<string, unknown>) {
+    let schema: ToolSchema | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<ToolResponse>) | undefined;
+    registerStorageTools({
+        tool(name, _description, toolSchema, toolCallback) {
+            if (name !== "storage") return;
+            schema = toolSchema;
+            callback = toolCallback;
+        },
+    }, http as never);
+    if (!schema || !callback) throw new Error("storage tool was not registered");
+    return { schema, callback };
+}
+
+describe("Storage bucket CLI schema", () => {
+    test("decodes comma-separated and JSON MIME type arrays", () => {
+        const { schema } = captureStorageTool({});
+
+        expect(parseToolArguments(schema, {
+            action: "create_bucket",
+            ref: "project-ref",
+            bucket: "artifacts",
+            allowed_mime_types: "application/pdf, image/png",
+        }).allowed_mime_types).toEqual(["application/pdf", "image/png"]);
+        expect(parseToolArguments(schema, {
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "artifacts",
+            allowed_mime_types: '["text/csv"]',
+        }).allowed_mime_types).toEqual(["text/csv"]);
+    });
+
+    test("rejects malformed JSON MIME type arrays", () => {
+        const { schema } = captureStorageTool({});
+
+        expect(() => parseToolArguments(schema, {
+            action: "create_bucket",
+            ref: "project-ref",
+            bucket: "artifacts",
+            allowed_mime_types: '["text/csv"',
+        })).toThrow("Invalid allowed_mime_types JSON array");
+    });
+
+    test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+        "rejects invalid file_size_limit %s",
+        (fileSizeLimit) => {
+            const { schema } = captureStorageTool({});
+
+            expect(() => parseToolArguments(schema, {
+                action: "update_bucket",
+                ref: "project-ref",
+                bucket: "artifacts",
+                file_size_limit: fileSizeLimit,
+            })).toThrow("file_size_limit");
+        },
+    );
+});
+
+describe("Storage bucket lifecycle", () => {
+    test("lists complete bucket JSON through the project route", async () => {
+        const calls: string[] = [];
+        const buckets = [{
+            id: "artifacts",
+            name: "artifacts",
+            public: false,
+            file_size_limit: 1048576,
+            allowed_mime_types: ["application/pdf"],
+        }];
+        const { callback } = captureStorageTool({
+            get: async (path: string) => {
+                calls.push(path);
+                return { ok: true, status: 200, data: buckets };
+            },
+        });
+
+        const response = await callback({ action: "list_buckets", ref: "project-ref" });
+
+        expect(calls).toEqual(["/v1/projects/project-ref/storage/buckets"]);
+        expect(JSON.parse(response.content[0].text)).toEqual(buckets);
+        expect(response.isError).not.toBe(true);
+    });
+
+    test("projects bucket metadata without reflecting unknown response fields", async () => {
+        const secretMarker = "remote-storage-secret";
+        const { callback } = captureStorageTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: [storageBucket({ token: secretMarker, credentials: secretMarker })],
+            }),
+        });
+
+        const response = await callback({ action: "list_buckets", ref: "project-ref" });
+
+        expect(JSON.parse(response.content[0].text)).toEqual([storageBucket()]);
+        expect(response.content[0].text).not.toContain(secretMarker);
+    });
+
+    test("gets a bucket through canonical project and bucket path segments", async () => {
+        const calls: string[] = [];
+        const bucket = storageBucket({ id: "raw-data.v1", name: "raw-data.v1" });
+        const { callback } = captureStorageTool({
+            get: async (path: string) => {
+                calls.push(path);
+                return { ok: true, status: 200, data: bucket };
+            },
+        });
+
+        const response = await callback({ action: "get_bucket", ref: "project_ref", bucket: "raw-data.v1" });
+
+        expect(calls).toEqual(["/v1/projects/project_ref/storage/buckets/raw-data.v1"]);
+        expect(JSON.parse(response.content[0].text)).toEqual(bucket);
+    });
+
+    test.each([
+        ["project ref", { action: "list_buckets", ref: "../project" }],
+        ["slash bucket", { action: "get_bucket", ref: "project-ref", bucket: "raw/data" }],
+        ["dot bucket", { action: "delete_bucket", ref: "project-ref", bucket: ".." }],
+    ])("rejects invalid %s path input before HTTP dispatch", async (_label, args) => {
+        let requestCount = 0;
+        const request = async () => {
+            requestCount += 1;
+            return { ok: true, status: 200, data: [] };
+        };
+        const { callback } = captureStorageTool({ get: request, delete: request });
+
+        await expect(callback(args)).rejects.toThrow("invalid for Storage buckets");
+        expect(requestCount).toBe(0);
+    });
+
+    test("creates a bucket with every supported option", async () => {
+        const calls: Array<{ method: "GET" | "POST"; path: string; body?: unknown }> = [];
+        const receipt = { id: "reports", name: "reports", public: false };
+        const readback = storageBucket({
+            file_size_limit: 5242880,
+            allowed_mime_types: ["application/pdf", "image/png"],
+        });
+        const { callback } = captureStorageTool({
+            post: async (path: string, body: unknown) => {
+                calls.push({ method: "POST", path, body });
+                return { ok: true, status: 201, data: receipt };
+            },
+            get: async (path: string) => {
+                calls.push({ method: "GET", path });
+                return { ok: true, status: 200, data: readback };
+            },
+        });
+
+        const response = await callback({
+            action: "create_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            public: false,
+            file_size_limit: 5242880,
+            allowed_mime_types: ["application/pdf", "image/png"],
+        });
+
+        expect(calls).toEqual([
+            {
+                method: "POST",
+                path: "/v1/projects/project-ref/storage/buckets",
+                body: {
+                    name: "reports",
+                    public: false,
+                    file_size_limit: 5242880,
+                    allowed_mime_types: ["application/pdf", "image/png"],
+                },
+            },
+            { method: "GET", path: "/v1/projects/project-ref/storage/buckets/reports" },
+        ]);
+        expect(JSON.parse(response.content[0].text)).toEqual(readback);
+    });
+
+    test("updates only explicitly provided fields", async () => {
+        const calls: Array<{ path: string; body: unknown }> = [];
+        const bucket = storageBucket({ public: true, file_size_limit: 1048576, allowed_mime_types: [] });
+        const { callback } = captureStorageTool({
+            put: async (path: string, body: unknown) => {
+                calls.push({ path, body });
+                return { ok: true, status: 200, data: bucket };
+            },
+        });
+
+        const response = await callback({
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            public: true,
+            file_size_limit: 1048576,
+            allowed_mime_types: [],
+        });
+
+        expect(calls).toEqual([{
+            path: "/v1/projects/project-ref/storage/buckets/reports",
+            body: { public: true, file_size_limit: 1048576, allowed_mime_types: [] },
+        }]);
+        expect(JSON.parse(response.content[0].text)).toEqual(bucket);
+    });
+
+    test("accepts the platform's null normalization when clearing MIME restrictions", async () => {
+        const { callback } = captureStorageTool({
+            put: async () => ({
+                ok: true,
+                status: 200,
+                data: storageBucket({ allowed_mime_types: null }),
+            }),
+        });
+
+        const response = await callback({
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            allowed_mime_types: [],
+        });
+
+        expect(response.isError).not.toBe(true);
+        expect(JSON.parse(response.content[0].text).allowed_mime_types).toBeNull();
+    });
+
+    test("rejects an empty update before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const { callback } = captureStorageTool({
+            put: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        await expect(callback({
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+        })).rejects.toThrow("requires at least one field");
+        expect(requestCount).toBe(0);
+    });
+
+    test("deletes a bucket and returns the complete API receipt", async () => {
+        const calls: string[] = [];
+        const receipt = { id: "reports", deleted: true };
+        const { callback } = captureStorageTool({
+            delete: async (path: string) => {
+                calls.push(path);
+                return { ok: true, status: 200, data: receipt };
+            },
+        });
+
+        const response = await callback({ action: "delete_bucket", ref: "project-ref", bucket: "reports" });
+
+        expect(calls).toEqual(["/v1/projects/project-ref/storage/buckets/reports"]);
+        expect(JSON.parse(response.content[0].text)).toEqual(receipt);
+    });
+
+    test("returns a structured non-success result for bucket read failures", async () => {
+        const { callback } = captureStorageTool({
+            get: async () => ({ ok: false, status: 404, data: { message: "private-server-detail" } }),
+        });
+
+        const response = await callback({ action: "get_bucket", ref: "project-ref", bucket: "missing" });
+        const payload = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(payload).toMatchObject({
+            ok: false,
+            operation: "storage.get_bucket",
+            error: { code: "HTTP_ERROR", http_status: 404 },
+        });
+        expect(response.content[0].text).not.toContain("private-server-detail");
+    });
+
+    test("reports an unknown outcome for transport failures during mutation", async () => {
+        const { callback } = captureStorageTool({
+            post: async () => ({
+                ok: false,
+                status: 500,
+                data: { error: "Network Error" },
+                transportError: true,
+            }),
+        });
+
+        const response = await callback({ action: "create_bucket", ref: "project-ref", bucket: "reports" });
+        const payload = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(payload.error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: null });
+    });
+
+    test("does not treat a malformed successful mutation response as success", async () => {
+        const { callback } = captureStorageTool({
+            put: async () => ({ ok: true, status: 200, data: {} }),
+        });
+
+        const response = await callback({
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            public: true,
+        });
+        const payload = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(payload.error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("does not accept an update receipt that omits the requested change", async () => {
+        const { callback } = captureStorageTool({
+            put: async () => ({
+                ok: true,
+                status: 200,
+                data: storageBucket(),
+            }),
+        });
+
+        const response = await callback({
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            public: true,
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test.each([
+        ["duplicate id", [storageBucket(), storageBucket({ name: "reports-copy" })]],
+        ["duplicate name", [storageBucket(), storageBucket({ id: "reports-copy" })]],
+    ])("rejects a bucket list with %s", async (_label, buckets) => {
+        const { callback } = captureStorageTool({
+            get: async () => ({ ok: true, status: 200, data: buckets }),
+        });
+
+        const response = await callback({ action: "list_buckets", ref: "project-ref" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "INVALID_RESPONSE", http_status: null });
+    });
+
+    test.each([
+        ["invalid list file_size_limit", "list_buckets", [storageBucket({ file_size_limit: 1.5 })]],
+        ["invalid get allowed_mime_types", "get_bucket", storageBucket({ allowed_mime_types: "image/png" })],
+    ])("rejects %s metadata shape", async (_label, action, apiPayload) => {
+        const { callback } = captureStorageTool({
+            get: async () => ({ ok: true, status: 200, data: apiPayload }),
+        });
+
+        const response = await callback({ action, ref: "project-ref", bucket: "reports" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "INVALID_RESPONSE", http_status: null });
+    });
+
+    test("requires an update receipt id to match the bucket path", async () => {
+        const { callback } = captureStorageTool({
+            put: async () => ({
+                ok: true,
+                status: 200,
+                data: storageBucket({ id: "other-bucket", name: "reports", public: true }),
+            }),
+        });
+
+        const response = await callback({
+            action: "update_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            public: true,
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("reports an unknown create outcome when canonical readback differs", async () => {
+        const { callback } = captureStorageTool({
+            post: async () => ({
+                ok: true,
+                status: 201,
+                data: { id: "reports", name: "reports", public: false },
+            }),
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: storageBucket({ file_size_limit: 1, allowed_mime_types: ["text/plain"] }),
+            }),
+        });
+
+        const response = await callback({
+            action: "create_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            file_size_limit: 1024,
+            allowed_mime_types: ["application/pdf"],
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("reports an unknown create outcome when canonical readback fails", async () => {
+        const { callback } = captureStorageTool({
+            post: async () => ({
+                ok: true,
+                status: 201,
+                data: { id: "reports", name: "reports", public: false },
+            }),
+            get: async () => ({ ok: false, status: 404, data: { message: "not found" } }),
+        });
+
+        const response = await callback({ action: "create_bucket", ref: "project-ref", bucket: "reports" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 404 });
+    });
+});

--- a/packages/cli/src/shared/tools/storage-tools.ts
+++ b/packages/cli/src/shared/tools/storage-tools.ts
@@ -1,73 +1,351 @@
-/**
- * Storage — Compound tool (5→1)
- */
 import { Type } from "@sinclair/typebox";
-import { optional, stringEnum, withDescription } from "../schema";
-import type { HttpTransport } from "../transports/http";
+import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+import type { HttpResult, HttpTransport } from "../transports/http";
+import {
+    releaseControlFailure,
+    releaseControlMutationFailure,
+    type ReleaseControlToolResponse,
+} from "./release-control-response";
 
-export function registerStorageTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
+type ToolServer = {
+    tool: (
+        name: string,
+        description: string,
+        schema: ToolSchema,
+        callback: (args: Record<string, unknown>) => Promise<ReleaseControlToolResponse>,
+    ) => void;
+};
+
+const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const BUCKET_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+function parseAllowedMimeTypes(input: string | string[]): unknown {
+    if (Array.isArray(input)) return input;
+    const trimmed = input.trim();
+    if (!trimmed) return [];
+    if (!trimmed.startsWith("[")) {
+        return trimmed.split(",").map((mimeType) => mimeType.trim()).filter(Boolean);
+    }
+    try {
+        return JSON.parse(trimmed);
+    } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+        throw new Error("Invalid allowed_mime_types JSON array");
+    }
+}
+
+const allowedMimeTypesSchema = Type.Optional(decodedSchema(
+    Type.Union([Type.String(), Type.Array(Type.String())]),
+    Type.Array(Type.String()),
+    parseAllowedMimeTypes,
+));
+const fileSizeLimitSchema = Type.Optional(Type.Integer({
+    minimum: 1,
+    maximum: Number.MAX_SAFE_INTEGER,
+}));
+
+function requiredText(args: Record<string, unknown>, field: string): string {
+    const text = args[field];
+    if (typeof text !== "string" || !text.trim()) {
+        throw new Error(`'${field}' required for '${String(args.action)}'`);
+    }
+    return text.trim();
+}
+
+function storageBucketPath(ref: string, bucket?: string): string {
+    if (!PROJECT_REF_PATTERN.test(ref)) throw new Error("'ref' is invalid for Storage buckets");
+    if (bucket !== undefined && (!BUCKET_ID_PATTERN.test(bucket) || bucket === "." || bucket === "..")) {
+        throw new Error("'bucket' is invalid for Storage buckets");
+    }
+    const root = `/v1/projects/${encodeURIComponent(ref)}/storage/buckets`;
+    return bucket === undefined ? root : `${root}/${encodeURIComponent(bucket)}`;
+}
+
+function bucketRecord(candidate: unknown): Record<string, unknown> | null {
+    return candidate && typeof candidate === "object" && !Array.isArray(candidate)
+        ? candidate as Record<string, unknown>
+        : null;
+}
+
+type SafeBucket = {
+    id: string;
+    name: string;
+    public: boolean;
+    file_size_limit: number | null;
+    allowed_mime_types: string[] | null;
+};
+
+function isFileSizeLimit(candidate: unknown): candidate is number | null {
+    return candidate === null
+        || (typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0);
+}
+
+function isAllowedMimeTypes(candidate: unknown): candidate is string[] | null {
+    return candidate === null
+        || (Array.isArray(candidate) && candidate.every((mimeType) => typeof mimeType === "string"));
+}
+
+function safeBucket(candidate: unknown, expectedBucket?: string): SafeBucket | null {
+    const bucket = bucketRecord(candidate);
+    if (bucket === null || typeof bucket.id !== "string" || typeof bucket.name !== "string"
+        || typeof bucket.public !== "boolean" || !isFileSizeLimit(bucket.file_size_limit)
+        || !isAllowedMimeTypes(bucket.allowed_mime_types)
+        || (expectedBucket !== undefined && bucket.id !== expectedBucket && bucket.name !== expectedBucket)) {
+        return null;
+    }
+    return {
+        id: bucket.id,
+        name: bucket.name,
+        public: bucket.public,
+        file_size_limit: bucket.file_size_limit,
+        allowed_mime_types: bucket.allowed_mime_types === null ? null : [...bucket.allowed_mime_types],
+    };
+}
+
+function safeExactBucket(candidate: unknown, expectedBucket: string): SafeBucket | null {
+    const bucket = safeBucket(candidate);
+    return bucket?.id === expectedBucket ? bucket : null;
+}
+
+function safeBucketList(candidate: unknown): SafeBucket[] | null {
+    if (!Array.isArray(candidate)) return null;
+    const buckets = candidate.map((bucket) => safeBucket(bucket));
+    if (buckets.some((bucket) => bucket === null)) return null;
+    const safeBuckets = buckets as SafeBucket[];
+    const ids = safeBuckets.map((bucket) => bucket.id);
+    const names = safeBuckets.map((bucket) => bucket.name);
+    return new Set(ids).size === ids.length && new Set(names).size === names.length
+        ? safeBuckets
+        : null;
+}
+
+function safeCreatedBucketReceipt(
+    candidate: unknown,
+    expectedBucket: string,
+    request: Record<string, unknown>,
+): Record<string, unknown> | null {
+    const bucket = bucketRecord(candidate);
+    if (bucket?.id !== expectedBucket || bucket.name !== expectedBucket
+        || bucket.public !== (request.public === true)) return null;
+    return { id: expectedBucket, name: expectedBucket, public: request.public === true };
+}
+
+function safeDeletedBucket(candidate: unknown, expectedBucket: string): Record<string, unknown> | null {
+    const receipt = bucketRecord(candidate);
+    return receipt?.id === expectedBucket && receipt.deleted === true
+        ? { id: expectedBucket, deleted: true }
+        : null;
+}
+
+function bucketSuccess(apiPayload: object): ReleaseControlToolResponse {
+    return { content: [{ type: "text", text: JSON.stringify(apiPayload, null, 2) }] };
+}
+
+function createReadbackResponse(
+    response: HttpResult<unknown>,
+    expectedBucket: string,
+    request: Record<string, unknown>,
+): ReleaseControlToolResponse {
+    const readback = safeExactBucket(response.data, expectedBucket);
+    const validReadback = readback?.name === expectedBucket
+        && readback.public === (request.public === true)
+        && bucketMatchesRequest(readback, request);
+    if (!response.ok || !validReadback || !readback) {
+        return releaseControlFailure("storage.create_bucket", "OUTCOME_UNKNOWN", response.transportError ? null : response.status);
+    }
+    return bucketSuccess(readback);
+}
+
+function bucketResponse(
+    operation: string,
+    response: HttpResult<unknown>,
+    operationKind: "read" | "mutation",
+    safePayload: (candidate: unknown) => object | null,
+): ReleaseControlToolResponse {
+    if (!response.ok) {
+        return operationKind === "mutation"
+            ? releaseControlMutationFailure(operation, response)
+            : releaseControlFailure(operation, "HTTP_ERROR", response.transportError ? null : response.status);
+    }
+    const payload = safePayload(response.data);
+    if (!payload) {
+        return operationKind === "mutation"
+            ? releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status)
+            : releaseControlFailure(operation, "INVALID_RESPONSE", null);
+    }
+    return bucketSuccess(payload);
+}
+
+function createBucketRequest(args: Record<string, unknown>): Record<string, unknown> {
+    const request: Record<string, unknown> = { name: requiredText(args, "bucket") };
+    if (args.public !== undefined) request.public = args.public;
+    if (args.file_size_limit !== undefined) request.file_size_limit = args.file_size_limit;
+    if (args.allowed_mime_types !== undefined) request.allowed_mime_types = args.allowed_mime_types;
+    return request;
+}
+
+function updateBucketRequest(args: Record<string, unknown>): Record<string, unknown> {
+    const request = Object.fromEntries(
+        ["public", "file_size_limit", "allowed_mime_types"]
+            .filter((field) => args[field] !== undefined)
+            .map((field) => [field, args[field]]),
+    );
+    if (Object.keys(request).length === 0) throw new Error("Bucket update requires at least one field");
+    return request;
+}
+
+function equalAllowedMimeTypes(candidate: unknown, expected: unknown): boolean {
+    if (!Array.isArray(expected)) return false;
+    if (expected.length === 0 && candidate === null) return true;
+    return Array.isArray(candidate)
+        && candidate.length === expected.length
+        && candidate.every((mimeType, index) => mimeType === expected[index]);
+}
+
+function bucketMatchesRequest(candidate: unknown, request: Record<string, unknown>): boolean {
+    const bucket = bucketRecord(candidate);
+    if (!bucket) return false;
+    if (request.public !== undefined && bucket.public !== request.public) return false;
+    if (request.file_size_limit !== undefined && bucket.file_size_limit !== request.file_size_limit) return false;
+    return request.allowed_mime_types === undefined
+        || equalAllowedMimeTypes(bucket.allowed_mime_types, request.allowed_mime_types);
+}
+
+async function listBuckets(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
+    const ref = requiredText(args, "ref");
+    return bucketResponse("storage.list_buckets", await http.get(storageBucketPath(ref)), "read", safeBucketList);
+}
+
+async function getBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
+    const ref = requiredText(args, "ref");
+    const bucket = requiredText(args, "bucket");
+    return bucketResponse("storage.get_bucket", await http.get(storageBucketPath(ref, bucket)), "read",
+        (apiPayload) => safeBucket(apiPayload, bucket));
+}
+
+async function createBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
+    const ref = requiredText(args, "ref");
+    const request = createBucketRequest(args);
+    const bucket = request.name as string;
+    const bucketPath = storageBucketPath(ref, bucket);
+    const receipt = bucketResponse("storage.create_bucket", await http.post(storageBucketPath(ref), request), "mutation",
+        (apiPayload) => safeCreatedBucketReceipt(apiPayload, bucket, request));
+    if (receipt.isError) return receipt;
+    return createReadbackResponse(await http.get(bucketPath), bucket, request);
+}
+
+async function updateBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
+    const ref = requiredText(args, "ref");
+    const bucket = requiredText(args, "bucket");
+    const request = updateBucketRequest(args);
+    return bucketResponse("storage.update_bucket", await http.put(storageBucketPath(ref, bucket), request), "mutation",
+        (apiPayload) => {
+            const updated = safeExactBucket(apiPayload, bucket);
+            return updated && bucketMatchesRequest(updated, request) ? updated : null;
+        });
+}
+
+async function deleteBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
+    const ref = requiredText(args, "ref");
+    const bucket = requiredText(args, "bucket");
+    return bucketResponse("storage.delete_bucket", await http.delete(storageBucketPath(ref, bucket)), "mutation",
+        (apiPayload) => safeDeletedBucket(apiPayload, bucket));
+}
+
+type BucketActionHandler = (
+    http: HttpTransport,
+    args: Record<string, unknown>,
+) => Promise<ReleaseControlToolResponse>;
+
+const BUCKET_ACTION_HANDLERS = {
+    list_buckets: listBuckets,
+    get_bucket: getBucket,
+    create_bucket: createBucket,
+    update_bucket: updateBucket,
+    delete_bucket: deleteBucket,
+} satisfies Record<string, BucketActionHandler>;
+
+type BucketAction = keyof typeof BUCKET_ACTION_HANDLERS;
+
+function executeBucketAction(
+    action: string,
+    http: HttpTransport,
+    args: Record<string, unknown>,
+): Promise<ReleaseControlToolResponse> | null {
+    if (!Object.hasOwn(BUCKET_ACTION_HANDLERS, action)) return null;
+    return BUCKET_ACTION_HANDLERS[action as BucketAction](http, args);
+}
+
+export function registerStorageTools(server: ToolServer, http: HttpTransport): void {
     server.tool(
         "storage",
         `S3/MinIO storage management.
-Actions: status, list_buckets, list_files, upload_base64, delete_file`,
+Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_bucket, list_files, upload_base64, delete_file`,
         {
-            action: withDescription(stringEnum(["status", "list_buckets", "list_files", "upload_base64", "delete_file"]), "Action"),
-            ref: optional(Type.String(), "Project ref (required except for 'status')"),
-            bucket: optional(Type.String(), "[list_files/upload/delete] Bucket name"),
-            filename: optional(Type.String(), "[upload/delete] File name/path"),
+            action: withDescription(stringEnum([
+                "status", "list_buckets", "get_bucket", "create_bucket", "update_bucket", "delete_bucket",
+                "list_files", "upload_base64", "delete_file",
+            ]), "Action"),
+            ref: optional(Type.String(), "[list_buckets/get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Project ref"),
+            bucket: optional(Type.String(), "[get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Bucket name or ID"),
+            public: optional(Type.Boolean(), "[create_bucket/update_bucket] Public bucket access"),
+            file_size_limit: withDescription(fileSizeLimitSchema, "[create_bucket/update_bucket] Positive safe-integer per-file size limit in bytes"),
+            allowed_mime_types: withDescription(allowedMimeTypesSchema, "[create_bucket/update_bucket] MIME types as a comma-separated or JSON array"),
+            filename: optional(Type.String(), "[upload_base64/delete_file] File name/path"),
             base64_content: optional(Type.String(), "[upload_base64] Base64 encoded content"),
             mime_type: optional(Type.String(), "[upload_base64] MIME type (default: application/octet-stream)"),
         },
-        async (args: any) => {
-            const { action, ref, bucket, filename, base64_content, mime_type } = args;
-            const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
-            const fmt = (data: unknown, label: string, fmtFn: (d: any) => string) => {
-                return Array.isArray(data) ? fmtFn(data) : JSON.stringify(data, null, 2);
-            };
+        async (args) => {
+            const action = String(args.action);
+            const bucketAction = executeBucketAction(action, http, args);
+            const bucketActionResponse = bucketAction ? await bucketAction : null;
+            if (bucketActionResponse) return bucketActionResponse;
 
             let text: string;
             switch (action) {
                 case "status":
                     text = JSON.stringify((await http.get("/v1/storage/status")).data, null, 2);
                     break;
-                case "list_buckets": {
-                    need("ref", ref);
-                    const res = await http.get(`/v1/storage/${ref}/buckets`);
-                    if (!res.ok) { text = `❌ Failed (${res.status})`; break; }
-                    const buckets = res.data as any[];
-                    if (!Array.isArray(buckets) || !buckets.length) { text = "No buckets found."; break; }
-                    text = `📦 Buckets (${buckets.length}):\n` + buckets.map((b: any) => `  - ${b.name} (${b.public ? "🔓 public" : "🔒 private"})`).join("\n");
-                    break;
-                }
                 case "list_files": {
-                    need("ref", ref); need("bucket", bucket);
-                    const res = await http.get(`/v1/storage/${ref}/buckets/${bucket}/files`);
-                    if (!res.ok) { text = `❌ Failed (${res.status})`; break; }
-                    const files = res.data as any[];
+                    const ref = requiredText(args, "ref");
+                    const bucket = requiredText(args, "bucket");
+                    const response = await http.get(`/v1/storage/${ref}/buckets/${bucket}/files`);
+                    if (!response.ok) { text = `❌ Failed (${response.status})`; break; }
+                    const files = response.data as any[];
                     if (!Array.isArray(files) || !files.length) { text = "No files."; break; }
-                    text = `📁 Files (${files.length}):\n` + files.map((f: any) => `  - ${f.name} (${f.size ? (f.size / 1024).toFixed(1) + "KB" : "?"})`).join("\n");
+                    text = `📁 Files (${files.length}):\n` + files.map((file: any) => `  - ${file.name} (${file.size ? (file.size / 1024).toFixed(1) + "KB" : "?"})`).join("\n");
                     break;
                 }
                 case "upload_base64": {
-                    need("ref", ref); need("bucket", bucket); need("filename", filename); need("base64_content", base64_content);
+                    const ref = requiredText(args, "ref");
+                    const bucket = requiredText(args, "bucket");
+                    const filename = requiredText(args, "filename");
+                    const base64Content = requiredText(args, "base64_content");
                     try {
-                        const buffer = Buffer.from(base64_content!, "base64");
-                        const blob = new Blob([buffer], { type: mime_type || "application/octet-stream" });
+                        const buffer = Buffer.from(base64Content, "base64");
+                        const blob = new Blob([buffer], { type: typeof args.mime_type === "string" ? args.mime_type : "application/octet-stream" });
                         const formData = new FormData();
-                        formData.append("file", blob, filename!);
-                        const res = await http.postMultipart(`/v1/storage/${ref}/buckets/${bucket}/upload`, formData);
-                        text = res.ok ? `✅ File ${filename} uploaded to ${bucket}` : `❌ Upload failed (${res.status})`;
-                    } catch (e: any) { text = `❌ Error: ${e.message}`; }
+                        formData.append("file", blob, filename);
+                        const response = await http.postMultipart(`/v1/storage/${ref}/buckets/${bucket}/upload`, formData);
+                        text = response.ok ? `✅ File ${filename} uploaded to ${bucket}` : `❌ Upload failed (${response.status})`;
+                    } catch (error: unknown) {
+                        text = `❌ Error: ${error instanceof Error ? error.message : String(error)}`;
+                    }
                     break;
                 }
-                case "delete_file":
-                    need("ref", ref); need("bucket", bucket); need("filename", filename);
+                case "delete_file": {
+                    const ref = requiredText(args, "ref");
+                    const bucket = requiredText(args, "bucket");
+                    const filename = requiredText(args, "filename");
                     text = (await http.delete(`/v1/storage/${ref}/buckets/${bucket}/files/${filename}`)).ok
-                        ? `✅ File ${filename} deleted` : `❌ Failed`;
+                        ? `✅ File ${filename} deleted` : "❌ Failed";
                     break;
-                default: text = `❌ Unknown action: ${action}`;
+                }
+                default:
+                    return releaseControlFailure(`storage.${action}`, "INVALID_RESPONSE", null);
             }
-            return { content: [{ type: "text" as const, text }] };
-        }
+            return { content: [{ type: "text", text }] };
+        },
     );
 }

--- a/packages/cli/src/shared/tools/storage-tools.ts
+++ b/packages/cli/src/shared/tools/storage-tools.ts
@@ -5,6 +5,7 @@ import type { HttpResult, HttpTransport } from "../transports/http";
 import {
     releaseControlFailure,
     releaseControlMutationFailure,
+    releaseControlSuccess,
     type ReleaseControlToolResponse,
 } from "./release-control-response";
 
@@ -17,18 +18,50 @@ type ToolServer = {
     ) => void;
 };
 
+type StorageAction =
+    | "status"
+    | "list_buckets"
+    | "get_bucket"
+    | "create_bucket"
+    | "update_bucket"
+    | "delete_bucket"
+    | "list_files"
+    | "upload_base64"
+    | "delete_file";
+
+const MAX_BUCKET_ID_LENGTH = 100;
+const MAX_MIME_TYPE_COUNT = 100;
+const MAX_MIME_TYPE_LENGTH = 255;
 const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
-const BUCKET_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+const BUCKET_ID_PATTERN = new RegExp(`^(?!\\.+$)[A-Za-z0-9._-]{1,${MAX_BUCKET_ID_LENGTH}}$`);
+const MIME_TYPE_PATTERN = /^(?=\S)(?=.*\S$)[^\u0000-\u001f\u007f]+$/;
+const ACTION_ARGUMENTS: Record<StorageAction, ReadonlySet<string>> = {
+    status: new Set(["action"]),
+    list_buckets: new Set(["action", "ref"]),
+    get_bucket: new Set(["action", "ref", "bucket"]),
+    create_bucket: new Set(["action", "ref", "bucket", "public", "file_size_limit", "allowed_mime_types"]),
+    update_bucket: new Set(["action", "ref", "bucket", "public", "file_size_limit", "allowed_mime_types"]),
+    delete_bucket: new Set(["action", "ref", "bucket"]),
+    list_files: new Set(["action", "ref", "bucket"]),
+    upload_base64: new Set(["action", "ref", "bucket", "filename", "base64_content", "mime_type"]),
+    delete_file: new Set(["action", "ref", "bucket", "filename"]),
+};
+
+function normalizedMimeTypes(candidate: unknown): unknown {
+    return Array.isArray(candidate)
+        ? candidate.map((mimeType) => typeof mimeType === "string" ? mimeType.trim() : mimeType)
+        : candidate;
+}
 
 function parseAllowedMimeTypes(input: string | string[]): unknown {
-    if (Array.isArray(input)) return input;
+    if (Array.isArray(input)) return normalizedMimeTypes(input);
     const trimmed = input.trim();
     if (!trimmed) return [];
     if (!trimmed.startsWith("[")) {
-        return trimmed.split(",").map((mimeType) => mimeType.trim()).filter(Boolean);
+        return normalizedMimeTypes(trimmed.split(","));
     }
     try {
-        return JSON.parse(trimmed);
+        return normalizedMimeTypes(JSON.parse(trimmed));
     } catch (error) {
         if (!(error instanceof SyntaxError)) throw error;
         throw new Error("Invalid allowed_mime_types JSON array");
@@ -37,7 +70,11 @@ function parseAllowedMimeTypes(input: string | string[]): unknown {
 
 const allowedMimeTypesSchema = Type.Optional(decodedSchema(
     Type.Union([Type.String(), Type.Array(Type.String())]),
-    Type.Array(Type.String()),
+    Type.Array(Type.String({
+        minLength: 1,
+        maxLength: MAX_MIME_TYPE_LENGTH,
+        pattern: MIME_TYPE_PATTERN.source,
+    }), { maxItems: MAX_MIME_TYPE_COUNT }),
     parseAllowedMimeTypes,
 ));
 const fileSizeLimitSchema = Type.Optional(Type.Integer({
@@ -53,9 +90,32 @@ function requiredText(args: Record<string, unknown>, field: string): string {
     return text.trim();
 }
 
+function validBucketId(bucket: string): boolean {
+    return BUCKET_ID_PATTERN.test(bucket);
+}
+
+function requiredProjectRef(args: Record<string, unknown>): string {
+    const ref = requiredText(args, "ref");
+    if (!PROJECT_REF_PATTERN.test(ref)) throw new Error("'ref' is invalid for Storage buckets");
+    return ref;
+}
+
+function requiredBucketId(args: Record<string, unknown>): string {
+    const bucket = requiredText(args, "bucket");
+    if (!validBucketId(bucket)) throw new Error("'bucket' is invalid for Storage buckets");
+    return bucket;
+}
+
+function assertActionArguments(action: StorageAction, args: Record<string, unknown>): void {
+    const allowedArguments = ACTION_ARGUMENTS[action];
+    if (!allowedArguments) throw new Error(`Unsupported Storage action '${action}'`);
+    const unsupported = Object.keys(args).filter((field) => !allowedArguments.has(field));
+    if (unsupported.length > 0) throw new Error(`'${unsupported[0]}' is not supported for '${action}'`);
+}
+
 function storageBucketPath(ref: string, bucket?: string): string {
     if (!PROJECT_REF_PATTERN.test(ref)) throw new Error("'ref' is invalid for Storage buckets");
-    if (bucket !== undefined && (!BUCKET_ID_PATTERN.test(bucket) || bucket === "." || bucket === "..")) {
+    if (bucket !== undefined && !validBucketId(bucket)) {
         throw new Error("'bucket' is invalid for Storage buckets");
     }
     const root = `/v1/projects/${encodeURIComponent(ref)}/storage/buckets`;
@@ -81,14 +141,28 @@ function isFileSizeLimit(candidate: unknown): candidate is number | null {
         || (typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0);
 }
 
+function assertBucketSettings(args: Record<string, unknown>): void {
+    if (args.file_size_limit !== undefined
+        && (args.file_size_limit === null || !isFileSizeLimit(args.file_size_limit))) {
+        throw new Error("'file_size_limit' must be a positive safe integer");
+    }
+    if (args.allowed_mime_types !== undefined
+        && (args.allowed_mime_types === null || !isAllowedMimeTypes(args.allowed_mime_types))) {
+        throw new Error("'allowed_mime_types' is invalid");
+    }
+}
+
 function isAllowedMimeTypes(candidate: unknown): candidate is string[] | null {
     return candidate === null
-        || (Array.isArray(candidate) && candidate.every((mimeType) => typeof mimeType === "string"));
+        || (Array.isArray(candidate) && candidate.length <= MAX_MIME_TYPE_COUNT
+            && candidate.every((mimeType) => typeof mimeType === "string"
+                && mimeType.length <= MAX_MIME_TYPE_LENGTH && MIME_TYPE_PATTERN.test(mimeType)));
 }
 
 function safeBucket(candidate: unknown, expectedBucket?: string): SafeBucket | null {
     const bucket = bucketRecord(candidate);
-    if (bucket === null || typeof bucket.id !== "string" || typeof bucket.name !== "string"
+    if (bucket === null || typeof bucket.id !== "string" || !validBucketId(bucket.id)
+        || typeof bucket.name !== "string" || !validBucketId(bucket.name)
         || typeof bucket.public !== "boolean" || !isFileSizeLimit(bucket.file_size_limit)
         || !isAllowedMimeTypes(bucket.allowed_mime_types)
         || (expectedBucket !== undefined && bucket.id !== expectedBucket && bucket.name !== expectedBucket)) {
@@ -128,41 +202,45 @@ function safeCreatedBucketReceipt(
     const bucket = bucketRecord(candidate);
     if (bucket?.id !== expectedBucket || bucket.name !== expectedBucket
         || bucket.public !== (request.public === true)) return null;
-    return { id: expectedBucket, name: expectedBucket, public: request.public === true };
+    return { bucket: { id: expectedBucket, name: expectedBucket, public: request.public === true } };
 }
 
 function safeDeletedBucket(candidate: unknown, expectedBucket: string): Record<string, unknown> | null {
     const receipt = bucketRecord(candidate);
     return receipt?.id === expectedBucket && receipt.deleted === true
-        ? { id: expectedBucket, deleted: true }
+        ? { bucket_id: expectedBucket, deleted: true }
         : null;
 }
 
-function bucketSuccess(apiPayload: object): ReleaseControlToolResponse {
-    return { content: [{ type: "text", text: JSON.stringify(apiPayload, null, 2) }] };
-}
+type MutationReadbackExpectation = {
+    operation: string;
+    ref: string;
+    response: HttpResult<unknown>;
+    expectedBucket: string;
+    request: Record<string, unknown>;
+};
 
-function createReadbackResponse(
-    response: HttpResult<unknown>,
-    expectedBucket: string,
-    request: Record<string, unknown>,
-): ReleaseControlToolResponse {
+function mutationReadbackResponse(expectation: MutationReadbackExpectation): ReleaseControlToolResponse {
+    const { operation, ref, response, expectedBucket, request } = expectation;
     const readback = safeExactBucket(response.data, expectedBucket);
     const validReadback = readback?.name === expectedBucket
-        && readback.public === (request.public === true)
         && bucketMatchesRequest(readback, request);
     if (!response.ok || !validReadback || !readback) {
-        return releaseControlFailure("storage.create_bucket", "OUTCOME_UNKNOWN", response.transportError ? null : response.status);
+        return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.transportError ? null : response.status);
     }
-    return bucketSuccess(readback);
+    return releaseControlSuccess(operation, { project_ref: ref, bucket: readback });
 }
 
-function bucketResponse(
-    operation: string,
-    response: HttpResult<unknown>,
-    operationKind: "read" | "mutation",
-    safePayload: (candidate: unknown) => object | null,
-): ReleaseControlToolResponse {
+type BucketResponseExpectation = {
+    operation: string;
+    ref: string;
+    response: HttpResult<unknown>;
+    operationKind: "read" | "mutation";
+    safePayload: (candidate: unknown) => Record<string, unknown> | null;
+};
+
+function bucketResponse(expectation: BucketResponseExpectation): ReleaseControlToolResponse {
+    const { operation, ref, response, operationKind, safePayload } = expectation;
     if (!response.ok) {
         return operationKind === "mutation"
             ? releaseControlMutationFailure(operation, response)
@@ -174,10 +252,11 @@ function bucketResponse(
             ? releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status)
             : releaseControlFailure(operation, "INVALID_RESPONSE", null);
     }
-    return bucketSuccess(payload);
+    return releaseControlSuccess(operation, { project_ref: ref, ...payload });
 }
 
 function createBucketRequest(args: Record<string, unknown>): Record<string, unknown> {
+    assertBucketSettings(args);
     const request: Record<string, unknown> = { name: requiredText(args, "bucket") };
     if (args.public !== undefined) request.public = args.public;
     if (args.file_size_limit !== undefined) request.file_size_limit = args.file_size_limit;
@@ -186,6 +265,7 @@ function createBucketRequest(args: Record<string, unknown>): Record<string, unkn
 }
 
 function updateBucketRequest(args: Record<string, unknown>): Record<string, unknown> {
+    assertBucketSettings(args);
     const request = Object.fromEntries(
         ["public", "file_size_limit", "allowed_mime_types"]
             .filter((field) => args[field] !== undefined)
@@ -212,45 +292,124 @@ function bucketMatchesRequest(candidate: unknown, request: Record<string, unknow
         || equalAllowedMimeTypes(bucket.allowed_mime_types, request.allowed_mime_types);
 }
 
+async function createBucketMutationReceipt(
+    http: HttpTransport,
+    ref: string,
+    bucket: string,
+    request: Record<string, unknown>,
+): Promise<ReleaseControlToolResponse> {
+    return bucketResponse({
+        operation: "storage.create_bucket",
+        ref,
+        response: await http.post(storageBucketPath(ref), request),
+        operationKind: "mutation",
+        safePayload: (candidate) => safeCreatedBucketReceipt(candidate, bucket, request),
+    });
+}
+
+type UpdateBucketReceiptExpectation = {
+    http: HttpTransport;
+    ref: string;
+    bucket: string;
+    bucketPath: string;
+    request: Record<string, unknown>;
+};
+
+async function updateBucketMutationReceipt(
+    expectation: UpdateBucketReceiptExpectation,
+): Promise<ReleaseControlToolResponse> {
+    const { http, ref, bucket, bucketPath, request } = expectation;
+    return bucketResponse({
+        operation: "storage.update_bucket",
+        ref,
+        response: await http.put(bucketPath, request),
+        operationKind: "mutation",
+        safePayload: (apiPayload) => {
+            const updated = safeExactBucket(apiPayload, bucket);
+            return updated && bucketMatchesRequest(updated, request) ? { bucket: updated } : null;
+        },
+    });
+}
+
 async function listBuckets(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
-    const ref = requiredText(args, "ref");
-    return bucketResponse("storage.list_buckets", await http.get(storageBucketPath(ref)), "read", safeBucketList);
+    const ref = requiredProjectRef(args);
+    return bucketResponse({
+        operation: "storage.list_buckets",
+        ref,
+        response: await http.get(storageBucketPath(ref)),
+        operationKind: "read",
+        safePayload: (candidate) => {
+            const buckets = safeBucketList(candidate);
+            return buckets ? { buckets } : null;
+        },
+    });
 }
 
 async function getBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
-    const ref = requiredText(args, "ref");
-    const bucket = requiredText(args, "bucket");
-    return bucketResponse("storage.get_bucket", await http.get(storageBucketPath(ref, bucket)), "read",
-        (apiPayload) => safeBucket(apiPayload, bucket));
+    const ref = requiredProjectRef(args);
+    const bucket = requiredBucketId(args);
+    return bucketResponse({
+        operation: "storage.get_bucket",
+        ref,
+        response: await http.get(storageBucketPath(ref, bucket)),
+        operationKind: "read",
+        safePayload: (candidate) => {
+            const safeReadback = safeBucket(candidate, bucket);
+            return safeReadback ? { bucket: safeReadback } : null;
+        },
+    });
 }
 
 async function createBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
-    const ref = requiredText(args, "ref");
+    const ref = requiredProjectRef(args);
     const request = createBucketRequest(args);
     const bucket = request.name as string;
     const bucketPath = storageBucketPath(ref, bucket);
-    const receipt = bucketResponse("storage.create_bucket", await http.post(storageBucketPath(ref), request), "mutation",
-        (apiPayload) => safeCreatedBucketReceipt(apiPayload, bucket, request));
+    const receipt = await createBucketMutationReceipt(http, ref, bucket, request);
     if (receipt.isError) return receipt;
-    return createReadbackResponse(await http.get(bucketPath), bucket, request);
+    const expectedReadback = { ...request, public: request.public === true };
+    return mutationReadbackResponse({
+        operation: "storage.create_bucket",
+        ref,
+        response: await http.get(bucketPath),
+        expectedBucket: bucket,
+        request: expectedReadback,
+    });
 }
 
 async function updateBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
-    const ref = requiredText(args, "ref");
-    const bucket = requiredText(args, "bucket");
+    const ref = requiredProjectRef(args);
+    const bucket = requiredBucketId(args);
     const request = updateBucketRequest(args);
-    return bucketResponse("storage.update_bucket", await http.put(storageBucketPath(ref, bucket), request), "mutation",
-        (apiPayload) => {
-            const updated = safeExactBucket(apiPayload, bucket);
-            return updated && bucketMatchesRequest(updated, request) ? updated : null;
-        });
+    const bucketPath = storageBucketPath(ref, bucket);
+    const receipt = await updateBucketMutationReceipt({ http, ref, bucket, bucketPath, request });
+    if (receipt.isError) return receipt;
+    return mutationReadbackResponse({
+        operation: "storage.update_bucket",
+        ref,
+        response: await http.get(bucketPath),
+        expectedBucket: bucket,
+        request,
+    });
 }
 
 async function deleteBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
-    const ref = requiredText(args, "ref");
-    const bucket = requiredText(args, "bucket");
-    return bucketResponse("storage.delete_bucket", await http.delete(storageBucketPath(ref, bucket)), "mutation",
-        (apiPayload) => safeDeletedBucket(apiPayload, bucket));
+    const ref = requiredProjectRef(args);
+    const bucket = requiredBucketId(args);
+    const bucketPath = storageBucketPath(ref, bucket);
+    const receipt = bucketResponse({
+        operation: "storage.delete_bucket",
+        ref,
+        response: await http.delete(bucketPath),
+        operationKind: "mutation",
+        safePayload: (candidate) => safeDeletedBucket(candidate, bucket),
+    });
+    if (receipt.isError) return receipt;
+    const readback = await http.get(bucketPath);
+    if (readback.ok || readback.transportError || readback.status !== 404) {
+        return releaseControlFailure("storage.delete_bucket", "OUTCOME_UNKNOWN", readback.transportError ? null : readback.status);
+    }
+    return receipt;
 }
 
 type BucketActionHandler = (
@@ -287,8 +446,8 @@ Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_
                 "status", "list_buckets", "get_bucket", "create_bucket", "update_bucket", "delete_bucket",
                 "list_files", "upload_base64", "delete_file",
             ]), "Action"),
-            ref: optional(Type.String(), "[list_buckets/get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Project ref"),
-            bucket: optional(Type.String(), "[get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Bucket name or ID"),
+            ref: optional(Type.String({ pattern: PROJECT_REF_PATTERN.source }), "[list_buckets/get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Project ref"),
+            bucket: optional(Type.String({ pattern: BUCKET_ID_PATTERN.source }), "[get_bucket/create_bucket/update_bucket/delete_bucket/list_files/upload_base64/delete_file] Bucket name or ID"),
             public: optional(Type.Boolean(), "[create_bucket/update_bucket] Public bucket access"),
             file_size_limit: withDescription(fileSizeLimitSchema, "[create_bucket/update_bucket] Positive safe-integer per-file size limit in bytes"),
             allowed_mime_types: withDescription(allowedMimeTypesSchema, "[create_bucket/update_bucket] MIME types as a comma-separated or JSON array"),
@@ -297,7 +456,8 @@ Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_
             mime_type: optional(Type.String(), "[upload_base64] MIME type (default: application/octet-stream)"),
         },
         async (args) => {
-            const action = String(args.action);
+            const action = String(args.action) as StorageAction;
+            assertActionArguments(action, args);
             const bucketAction = executeBucketAction(action, http, args);
             const bucketActionResponse = bucketAction ? await bucketAction : null;
             if (bucketActionResponse) return bucketActionResponse;
@@ -308,8 +468,8 @@ Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_
                     text = JSON.stringify((await http.get("/v1/storage/status")).data, null, 2);
                     break;
                 case "list_files": {
-                    const ref = requiredText(args, "ref");
-                    const bucket = requiredText(args, "bucket");
+                    const ref = requiredProjectRef(args);
+                    const bucket = requiredBucketId(args);
                     const response = await http.get(`/v1/storage/${ref}/buckets/${bucket}/files`);
                     if (!response.ok) { text = `❌ Failed (${response.status})`; break; }
                     const files = response.data as any[];
@@ -318,8 +478,8 @@ Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_
                     break;
                 }
                 case "upload_base64": {
-                    const ref = requiredText(args, "ref");
-                    const bucket = requiredText(args, "bucket");
+                    const ref = requiredProjectRef(args);
+                    const bucket = requiredBucketId(args);
                     const filename = requiredText(args, "filename");
                     const base64Content = requiredText(args, "base64_content");
                     try {
@@ -335,8 +495,8 @@ Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_
                     break;
                 }
                 case "delete_file": {
-                    const ref = requiredText(args, "ref");
-                    const bucket = requiredText(args, "bucket");
+                    const ref = requiredProjectRef(args);
+                    const bucket = requiredBucketId(args);
                     const filename = requiredText(args, "filename");
                     text = (await http.delete(`/v1/storage/${ref}/buckets/${bucket}/files/${filename}`)).ok
                         ? `✅ File ${filename} deleted` : "❌ Failed";

--- a/packages/management-api/src/routes/storage-compat.ts
+++ b/packages/management-api/src/routes/storage-compat.ts
@@ -62,6 +62,10 @@ const TUS_MAX_SIZE = Number(process.env.TUS_MAX_SIZE || DEFAULT_TUS_MAX_SIZE_BYT
 const TUS_MAX_CHUNK_SIZE = Number(process.env.TUS_MAX_CHUNK_SIZE || Math.min(TUS_MAX_SIZE, 16 * 1024 * 1024));
 const STORAGE_BATCH_CONCURRENCY = Math.max(1, Number(process.env.STORAGE_BATCH_CONCURRENCY || 12));
 
+function isBucketNotEmpty(error: unknown): error is Error {
+    return error instanceof Error && error.message === "Bucket is not empty";
+}
+
 // ── Imaginary Config ──────────────────────────────────────────────
 const IMAGINARY_URL = config.imaginaryUrl;
 
@@ -619,16 +623,38 @@ export const storageCompatRoutes = new Elysia({ prefix: "" })
         try {
             // 1. Dry run to ensure bucket can be deleted
             await StorageRLS.deleteLogicalBucket(ref, auth, params.id, true);
-        } catch (e: any) {
-            return status(403, { statusCode: "403", error: 'Forbidden', message: e.message || 'Access Denied' });
+        } catch (error: unknown) {
+            if (isBucketNotEmpty(error)) {
+                return status(409, { statusCode: "409", error: 'Conflict', message: error.message });
+            }
+            return status(403, { statusCode: "403", error: 'Forbidden', message: error instanceof Error ? error.message : 'Access Denied' });
         }
         
         // 2. Physical delete bucket
         const result = await StorageService.deleteBucket(ref, params.id);
-        if (!result.success) return status(500, { statusCode: "500", error: 'Internal', message: result.error || 'Failed to delete bucket' });
+        if (!result.success) {
+            const statusCode = result.error === "Bucket is not empty" ? 409 : 500;
+            return status(statusCode, {
+                statusCode: String(statusCode),
+                error: statusCode === 409 ? 'Conflict' : 'Internal',
+                message: result.error || 'Bucket deletion outcome is unknown',
+            });
+        }
         
         // 3. Logical delete bucket
-        await StorageRLS.deleteLogicalBucket(ref, auth, params.id, false);
+        try {
+            await StorageRLS.deleteLogicalBucket(ref, auth, params.id, false);
+        } catch (error: unknown) {
+            if (isBucketNotEmpty(error)) {
+                return status(409, { statusCode: "409", error: 'Conflict', message: error.message });
+            }
+            logger.error("Storage bucket metadata deletion outcome is unknown", {
+                ref,
+                bucketId: params.id,
+                error: error instanceof Error ? error.message : String(error),
+            });
+            return status(500, { statusCode: "500", error: 'Internal', message: 'Bucket deletion outcome is unknown' });
+        }
         return { message: "Successfully deleted" };
     }, {
         detail: { tags: ["storage"], summary: "Delete a bucket" },

--- a/packages/management-api/src/routes/storage-s3.ts
+++ b/packages/management-api/src/routes/storage-s3.ts
@@ -271,12 +271,11 @@ export const storageS3Routes = new Elysia({ prefix: "/v1/storage/:ref/s3" })
 
   // DELETE /:bucket -> DeleteBucket (only when empty)
   .delete("/:bucket", async ({ params, set }) => {
-    const objects = await StorageService.listFiles(params.ref, params.bucket).catch(() => []);
-    if (objects.length > 0) {
-      return s3Error("BucketNotEmpty", "The bucket you tried to delete is not empty", 409);
-    }
     const result = await StorageService.deleteBucket(params.ref, params.bucket);
     if (!result.success) {
+      if (result.error === "Bucket is not empty") {
+        return s3Error("BucketNotEmpty", "The bucket you tried to delete is not empty", 409);
+      }
       return s3Error("InternalError", result.error || "Failed to delete bucket", 500);
     }
     set.status = 204;

--- a/packages/management-api/src/routes/storage.ts
+++ b/packages/management-api/src/routes/storage.ts
@@ -204,19 +204,9 @@ async function listLegacyStorageBuckets(ref: string): Promise<Record<string, unk
     return await listStorageBuckets(ref);
 }
 
-async function assertStorageBucketDeletable(ref: string, bucketName: string): Promise<void> {
-    if (!await StorageService.isBucketEmpty(ref, bucketName)) throw new Error("Bucket is not empty");
-    await StorageRLS.assertLogicalBucketDeletableAsAdmin(ref, bucketName);
-}
-
 async function deleteStorageBucket(ref: string, bucketName: string) {
     const inputError = storageBucketInputError(ref, bucketName, {});
     if (inputError) return { success: false, error: inputError };
-    try {
-        await assertStorageBucketDeletable(ref, bucketName);
-    } catch (error: unknown) {
-        return { success: false, error: error instanceof Error ? error.message : "Failed to validate bucket" };
-    }
     const storageResult = await StorageService.deleteBucket(ref, bucketName);
     if (!storageResult.success) return storageResult;
 
@@ -224,12 +214,15 @@ async function deleteStorageBucket(ref: string, bucketName: string) {
         await StorageRLS.deleteLogicalBucketAsAdmin(ref, bucketName);
         return storageResult;
     } catch (error: unknown) {
+        if (error instanceof Error && error.message === "Bucket is not empty") {
+            return { success: false, error: error.message };
+        }
         logger.error("Failed to delete Studio storage bucket metadata", {
             ref,
             bucketName,
             error: error instanceof Error ? error.message : String(error),
         });
-        return { success: false, error: "Failed to delete bucket metadata" };
+        return { success: false, error: "Bucket deletion outcome is unknown" };
     }
 }
 

--- a/packages/management-api/src/routes/storage.ts
+++ b/packages/management-api/src/routes/storage.ts
@@ -1,5 +1,13 @@
 import { Elysia, t, status } from "elysia";
 import { StorageService, migrationJobs } from '../services/storage.service';
+import {
+    MAX_STORAGE_MIME_TYPE_COUNT,
+    MAX_STORAGE_MIME_TYPE_LENGTH,
+    STORAGE_BUCKET_ID_PATTERN_SOURCE,
+    STORAGE_MIME_TYPE_PATTERN_SOURCE,
+    STORAGE_PROJECT_REF_PATTERN_SOURCE,
+    storageBucketInputError,
+} from "../services/storage-bucket-contract";
 import { StorageRLS } from "../services/storage-rls";
 import { StorageVectorError, StorageVectorService } from "../services/storage-vector.service";
 import { logger } from "../utils/logger";
@@ -8,13 +16,29 @@ import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth"
 
 const ErrorResponse = t.Object({ message: t.String() });
 const SuccessResponse = t.Object({ success: t.Boolean(), message: t.String() });
-const StorageBucketCreateBody = t.Object({
-    name: t.String(),
-    id: t.Optional(t.String()),
-    public: t.Optional(t.Boolean()),
-    file_size_limit: t.Optional(t.Number()),
-    allowed_mime_types: t.Optional(t.Array(t.String())),
+const StorageProjectRef = t.String({ pattern: STORAGE_PROJECT_REF_PATTERN_SOURCE });
+const StorageBucketId = t.String({ pattern: STORAGE_BUCKET_ID_PATTERN_SOURCE });
+const StorageFileSizeLimit = t.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER });
+const StorageMimeType = t.String({
+    minLength: 1,
+    maxLength: MAX_STORAGE_MIME_TYPE_LENGTH,
+    pattern: STORAGE_MIME_TYPE_PATTERN_SOURCE,
 });
+const StorageAllowedMimeTypes = t.Array(StorageMimeType, { maxItems: MAX_STORAGE_MIME_TYPE_COUNT });
+const StorageProjectParams = t.Object({ ref: StorageProjectRef });
+const StorageBucketParams = t.Object({ ref: StorageProjectRef, id: StorageBucketId });
+const StorageBucketCreateBody = t.Object({
+    name: StorageBucketId,
+    id: t.Optional(StorageBucketId),
+    public: t.Optional(t.Boolean()),
+    file_size_limit: t.Optional(StorageFileSizeLimit),
+    allowed_mime_types: t.Optional(StorageAllowedMimeTypes),
+});
+const StorageBucketUpdateBody = t.Object({
+    public: t.Optional(t.Boolean()),
+    file_size_limit: t.Optional(StorageFileSizeLimit),
+    allowed_mime_types: t.Optional(StorageAllowedMimeTypes),
+}, { minProperties: 1 });
 
 type StorageBucketCreateInput = {
     name: string;
@@ -141,6 +165,8 @@ async function rollbackLogicalStorageBucket(ref: string, bucketName: string): Pr
 
 async function createStorageBucket(ref: string, input: StorageBucketCreateInput) {
     const bucketName = input.name || input.id || "";
+    const inputError = storageBucketInputError(ref, bucketName, input);
+    if (inputError) return { bucketName, storageResult: { success: false, error: inputError } };
     const logicalResult = await createLogicalStorageBucket(ref, bucketName, input);
     if (!logicalResult.success) return { bucketName, storageResult: logicalResult };
     const storageResult = await StorageService.createBucket(ref, bucketName);
@@ -158,7 +184,11 @@ function mergeStorageBuckets(
         const id = String(bucket.id);
         bucketsById.set(id, { ...bucketsById.get(id), ...bucket, id });
     }
-    return Array.from(bucketsById.values());
+    return Array.from(bucketsById.values()).map((bucket) => ({
+        ...bucket,
+        file_size_limit: bucket.file_size_limit ?? null,
+        allowed_mime_types: bucket.allowed_mime_types ?? null,
+    }));
 }
 
 async function listStorageBuckets(ref: string): Promise<Record<string, unknown>[]> {
@@ -180,6 +210,8 @@ async function assertStorageBucketDeletable(ref: string, bucketName: string): Pr
 }
 
 async function deleteStorageBucket(ref: string, bucketName: string) {
+    const inputError = storageBucketInputError(ref, bucketName, {});
+    if (inputError) return { success: false, error: inputError };
     try {
         await assertStorageBucketDeletable(ref, bucketName);
     } catch (error: unknown) {
@@ -201,6 +233,11 @@ async function deleteStorageBucket(ref: string, bucketName: string) {
     }
 }
 
+function storageMutationStatus(error: string | undefined): 400 | 409 | 500 {
+    if (error?.startsWith("Invalid ")) return 400;
+    return error === "Bucket already exists" || error === "Bucket is not empty" ? 409 : 500;
+}
+
 // ── Storage Routes ────────────────────────────────────────────────
 export const storageRoutes = new Elysia({ prefix: "/v1/storage" })
     .get('/status', async () => {
@@ -216,7 +253,7 @@ export const storageRoutes = new Elysia({ prefix: "/v1/storage" })
         if (authError) return status(authError.status, authError.body);
         const { bucketName, storageResult } = await createStorageBucket(params.ref, body);
         if (!storageResult.success) {
-            set.status = storageResult.error === "Bucket already exists" ? 409 : 500;
+            set.status = storageMutationStatus(storageResult.error);
             return { message: storageResult.error || "Failed to create bucket", code: String(set.status) };
         }
         return { id: bucketName, name: bucketName, public: body.public || false };
@@ -638,17 +675,21 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
         return await listStorageBuckets(params.ref);
-    }, { detail: { tags: ["storage"], summary: "List project storage buckets" } })
+    }, {
+        params: StorageProjectParams,
+        detail: { tags: ["storage"], summary: "List project storage buckets" },
+    })
     .post('/buckets', async ({ params, body, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
         const { bucketName, storageResult } = await createStorageBucket(params.ref, body);
         if (!storageResult.success) {
-            set.status = storageResult.error === "Bucket already exists" ? 409 : 500;
+            set.status = storageMutationStatus(storageResult.error);
             return { message: storageResult.error || "Failed to create bucket", code: String(set.status) };
         }
         return { id: bucketName, name: bucketName, public: body.public || false };
     }, {
+        params: StorageProjectParams,
         body: StorageBucketCreateBody,
         detail: { tags: ["storage"], summary: "Create a storage bucket" },
     })
@@ -662,7 +703,10 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
             return { message: "Bucket not found", code: "404" };
         }
         return bucket;
-    }, { detail: { tags: ["storage"], summary: "Get a storage bucket by ID" } })
+    }, {
+        params: StorageBucketParams,
+        detail: { tags: ["storage"], summary: "Get a storage bucket by ID" },
+    })
     .put('/buckets/:id', async ({ params, body, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
@@ -673,17 +717,14 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
         });
 
         if (!result.success) {
-            set.status = result.error === "Bucket not found" ? 404 : result.error === "Invalid bucket id" ? 400 : 500;
+            set.status = result.error === "Bucket not found" ? 404 : storageMutationStatus(result.error);
             return { message: result.error || "Failed to update bucket", code: String(set.status) };
         }
 
         return result.bucket;
     }, {
-        body: t.Object({
-            public: t.Optional(t.Boolean()),
-            file_size_limit: t.Optional(t.Number()),
-            allowed_mime_types: t.Optional(t.Array(t.String())),
-        }),
+        params: StorageBucketParams,
+        body: StorageBucketUpdateBody,
         detail: { tags: ["storage"], summary: "Update a storage bucket" },
     })
     .post('/vector/:operation', async ({ params, body, request, set }) => {
@@ -721,8 +762,11 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
         if (authError) return status(authError.status, authError.body);
         const result = await deleteStorageBucket(params.ref, params.id);
         if (!result.success) {
-            set.status = result.error === "Bucket is not empty" ? 409 : 500;
+            set.status = storageMutationStatus(result.error);
             return { message: result.error || "Failed to delete bucket", code: String(set.status) };
         }
         return { id: params.id, deleted: true };
-    }, { detail: { tags: ["storage"], summary: "Delete a storage bucket" } });
+    }, {
+        params: StorageBucketParams,
+        detail: { tags: ["storage"], summary: "Delete a storage bucket" },
+    });

--- a/packages/management-api/src/services/storage-bucket-contract.ts
+++ b/packages/management-api/src/services/storage-bucket-contract.ts
@@ -1,0 +1,50 @@
+const MAX_STORAGE_BUCKET_ID_LENGTH = 100;
+export const MAX_STORAGE_MIME_TYPE_COUNT = 100;
+export const MAX_STORAGE_MIME_TYPE_LENGTH = 255;
+export const STORAGE_PROJECT_REF_PATTERN_SOURCE = "^[A-Za-z0-9_-]{1,64}$";
+export const STORAGE_BUCKET_ID_PATTERN_SOURCE = `^(?!\\.+$)[A-Za-z0-9._-]{1,${MAX_STORAGE_BUCKET_ID_LENGTH}}$`;
+export const STORAGE_MIME_TYPE_PATTERN_SOURCE = "^(?=\\S)(?=.*\\S$)[^\\u0000-\\u001f\\u007f]+$";
+
+const storageProjectRefPattern = new RegExp(STORAGE_PROJECT_REF_PATTERN_SOURCE);
+const storageBucketIdPattern = new RegExp(STORAGE_BUCKET_ID_PATTERN_SOURCE);
+const storageMimeTypePattern = new RegExp(STORAGE_MIME_TYPE_PATTERN_SOURCE);
+
+export interface StorageBucketSettings {
+  public?: boolean;
+  file_size_limit?: number;
+  allowed_mime_types?: string[];
+}
+
+function validStorageProjectRef(ref: string): boolean {
+  return storageProjectRefPattern.test(ref);
+}
+
+function validStorageBucketId(bucketId: string): boolean {
+  return storageBucketIdPattern.test(bucketId);
+}
+
+function validStorageFileSizeLimit(fileSizeLimit: number): boolean {
+  return Number.isSafeInteger(fileSizeLimit) && fileSizeLimit > 0;
+}
+
+function validStorageMimeTypes(mimeTypes: string[]): boolean {
+  return mimeTypes.length <= MAX_STORAGE_MIME_TYPE_COUNT
+    && mimeTypes.every((mimeType) => mimeType.length <= MAX_STORAGE_MIME_TYPE_LENGTH
+      && storageMimeTypePattern.test(mimeType));
+}
+
+export function storageBucketInputError(
+  ref: string,
+  bucketId: string,
+  settings: StorageBucketSettings,
+): string | null {
+  if (!validStorageProjectRef(ref)) return "Invalid project ref";
+  if (!validStorageBucketId(bucketId)) return "Invalid bucket id";
+  if (settings.file_size_limit !== undefined && !validStorageFileSizeLimit(settings.file_size_limit)) {
+    return "Invalid file size limit";
+  }
+  if (settings.allowed_mime_types !== undefined && !validStorageMimeTypes(settings.allowed_mime_types)) {
+    return "Invalid allowed MIME types";
+  }
+  return null;
+}

--- a/packages/management-api/src/services/storage-rls.ts
+++ b/packages/management-api/src/services/storage-rls.ts
@@ -113,29 +113,26 @@ export class StorageRLS {
 
   static async deleteLogicalBucketAsAdmin(ref: string, bucketId: string): Promise<void> {
     if (ref === 'test_mock') {
+      if (Array.from(mockObjects.keys()).some((key) => key.startsWith(`${bucketId}/`))) {
+        throw new Error("Bucket is not empty");
+      }
       mockBuckets.delete(bucketId);
       return;
     }
     const dbName = await resolveDbName(ref);
     const db = getProjectDb(dbName);
-    await db`DELETE FROM storage.buckets WHERE id = ${bucketId}`;
-  }
-
-  static async assertLogicalBucketDeletableAsAdmin(ref: string, bucketId: string): Promise<void> {
-    if (ref === 'test_mock') {
-      if (Array.from(mockObjects.keys()).some((key) => key.startsWith(`${bucketId}/`))) {
-        throw new Error("Bucket is not empty");
-      }
-      return;
-    }
-    const dbName = await resolveDbName(ref);
-    const db = getProjectDb(dbName);
-    const [row] = await db`
-      SELECT EXISTS(
-        SELECT 1 FROM storage.objects WHERE bucket_id = ${bucketId}
-      ) AS has_objects
+    const deleted = await db`
+      DELETE FROM storage.buckets
+      WHERE id = ${bucketId}
+        AND NOT EXISTS (
+          SELECT 1 FROM storage.objects WHERE bucket_id = ${bucketId}
+        )
+      RETURNING id
     `;
-    if (row?.has_objects === true) throw new Error("Bucket is not empty");
+    if (deleted.length > 0) return;
+
+    const [bucket] = await db`SELECT id FROM storage.buckets WHERE id = ${bucketId}`;
+    if (bucket) throw new Error("Bucket is not empty");
   }
 
   

--- a/packages/management-api/src/services/storage.adapter.ts
+++ b/packages/management-api/src/services/storage.adapter.ts
@@ -54,7 +54,7 @@ function resolveRealPath(p: string): string {
 
 export interface StorageDriver {
   createBucket(projectRef: string, bucket: string): Promise<boolean>;
-  deleteBucket(projectRef: string, bucket: string): Promise<boolean>;
+  deleteBucket(projectRef: string, bucket: string): Promise<BucketDeletionResult>;
   emptyBucket(projectRef: string, bucket: string): Promise<boolean>;
   listBuckets(
     projectRef: string,
@@ -86,6 +86,33 @@ export interface StorageDriver {
     bucket: string,
     key: string,
   ): Promise<Response | null>;
+}
+
+export type BucketDeletionResult =
+  | { success: true }
+  | { success: false; reason: "not_empty" | "unknown" };
+
+function isDirectoryNotEmpty(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "ENOTEMPTY" || code === "EEXIST";
+}
+
+async function createObjectParent(bucketPath: string, objectKey: string): Promise<void> {
+  const bucket = await fs.lstat(bucketPath);
+  if (!bucket.isDirectory()) throw new Error("Storage bucket is unavailable");
+
+  let objectParent = bucketPath;
+  for (const segment of objectKey.split("/").slice(0, -1)) {
+    objectParent = path.join(objectParent, segment);
+    try {
+      await fs.mkdir(objectParent);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (!(await fs.lstat(objectParent)).isDirectory()) {
+        throw new Error("Storage object parent is unavailable");
+      }
+    }
+  }
 }
 
 export class JuiceFSDriver implements StorageDriver {
@@ -127,15 +154,18 @@ export class JuiceFSDriver implements StorageDriver {
     }
   }
 
-  async deleteBucket(projectRef: string, bucket: string): Promise<boolean> {
+  async deleteBucket(projectRef: string, bucket: string): Promise<BucketDeletionResult> {
     try {
-      await fs.rm(this.getBasePath(projectRef, bucket), {
-        recursive: true,
-        force: true,
+      await fs.rmdir(this.getBasePath(projectRef, bucket));
+      return { success: true };
+    } catch (error: unknown) {
+      if (isDirectoryNotEmpty(error)) return { success: false, reason: "not_empty" };
+      logger.warn("JuiceFS deleteBucket failed without deleting the bucket", {
+        projectRef,
+        bucket,
+        error: error instanceof Error ? error.message : String(error),
       });
-      return true;
-    } catch (e) {
-      return false;
+      return { success: false, reason: "unknown" };
     }
   }
 
@@ -180,8 +210,9 @@ export class JuiceFSDriver implements StorageDriver {
     contentType: string,
   ): Promise<boolean> {
     try {
-      const filePath = this.getBasePath(projectRef, bucket, key);
-      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      const cleanKey = normalizeObjectKey(key);
+      await createObjectParent(this.getBasePath(projectRef, bucket), cleanKey);
+      const filePath = this.getBasePath(projectRef, bucket, cleanKey);
       await Bun.write(filePath, await toUint8Array(data));
       return true;
     } catch (e: unknown) {
@@ -201,8 +232,9 @@ export class JuiceFSDriver implements StorageDriver {
   ): Promise<boolean> {
     try {
       const srcPath = this.getBasePath(projectRef, srcBucket, srcKey);
-      const destPath = this.getBasePath(projectRef, destBucket, destKey);
-      await fs.mkdir(path.dirname(destPath), { recursive: true });
+      const cleanDestKey = normalizeObjectKey(destKey);
+      await createObjectParent(this.getBasePath(projectRef, destBucket), cleanDestKey);
+      const destPath = this.getBasePath(projectRef, destBucket, cleanDestKey);
       await fs.copyFile(srcPath, destPath);
       return true;
     } catch (e) {
@@ -488,8 +520,8 @@ export class S3Driver implements StorageDriver {
     return true; // Buckets are logical prefixes in S3 for SupaCloud
   }
 
-  async deleteBucket(projectRef: string, bucket: string): Promise<boolean> {
-    return true; // No distinct deletion for logical prefix unless we rm -rf objects
+  async deleteBucket(_projectRef: string, _bucket: string): Promise<BucketDeletionResult> {
+    return { success: false, reason: "unknown" };
   }
 
   async emptyBucket(projectRef: string, bucket: string): Promise<boolean> {

--- a/packages/management-api/src/services/storage.service.ts
+++ b/packages/management-api/src/services/storage.service.ts
@@ -2,6 +2,7 @@ import { config } from "../config";
 import { shellService } from './shell.service';
 import { logger } from "../utils/logger";
 import { getStorageDriver } from "./storage.adapter";
+import { storageBucketInputError, type StorageBucketSettings } from "./storage-bucket-contract";
 import { statfs } from "node:fs/promises";
 
 export interface StorageStatus {
@@ -216,10 +217,9 @@ export class StorageService {
     return await getStorageDriver().isBucketEmpty(projectRef, bucketName);
   }
 
-  static async updateBucket(projectRef: string, bucketId: string, updates: { public?: boolean; file_size_limit?: number; allowed_mime_types?: string[] }): Promise<{ success: boolean; error?: string; bucket?: Record<string, unknown> }> {
-    if (!/^[a-zA-Z0-9._-]+$/.test(bucketId)) {
-      return { success: false, error: "Invalid bucket id" };
-    }
+  static async updateBucket(projectRef: string, bucketId: string, updates: StorageBucketSettings): Promise<{ success: boolean; error?: string; bucket?: Record<string, unknown> }> {
+    const inputError = storageBucketInputError(projectRef, bucketId, updates);
+    if (inputError) return { success: false, error: inputError };
 
     try {
       const { getProjectDb, resolveDbName } = await import("../db");
@@ -234,7 +234,7 @@ export class StorageService {
       }
       if (updates.allowed_mime_types !== undefined) {
         const allowedMimeTypes = updates.allowed_mime_types.length > 0
-          ? updates.allowed_mime_types
+          ? db.array(updates.allowed_mime_types, "TEXT")
           : null;
         await db`UPDATE storage.buckets SET allowed_mime_types = ${allowedMimeTypes} WHERE id = ${bucketId}`;
       }

--- a/packages/management-api/src/services/storage.service.ts
+++ b/packages/management-api/src/services/storage.service.ts
@@ -193,8 +193,14 @@ export class StorageService {
   }
 
   static async deleteBucket(projectRef: string, bucketName: string = ""): Promise<{ success: boolean; error?: string }> {
-    const success = await getStorageDriver().deleteBucket(projectRef, bucketName);
-    return { success };
+    const deletion = await getStorageDriver().deleteBucket(projectRef, bucketName);
+    if (deletion.success) return deletion;
+    return {
+      success: false,
+      error: deletion.reason === "not_empty"
+        ? "Bucket is not empty"
+        : "Bucket deletion outcome is unknown",
+    };
   }
 
   static async emptyBucket(projectRef: string, bucketName: string): Promise<{ success: boolean; error?: string }> {

--- a/packages/management-api/src/services/storage.service.ts
+++ b/packages/management-api/src/services/storage.service.ts
@@ -233,7 +233,10 @@ export class StorageService {
         await db`UPDATE storage.buckets SET file_size_limit = ${updates.file_size_limit} WHERE id = ${bucketId}`;
       }
       if (updates.allowed_mime_types !== undefined) {
-        await db`UPDATE storage.buckets SET allowed_mime_types = ${JSON.stringify(updates.allowed_mime_types)} WHERE id = ${bucketId}`;
+        const allowedMimeTypes = updates.allowed_mime_types.length > 0
+          ? updates.allowed_mime_types
+          : null;
+        await db`UPDATE storage.buckets SET allowed_mime_types = ${allowedMimeTypes} WHERE id = ${bucketId}`;
       }
 
       const [bucket] = await db`SELECT * FROM storage.buckets WHERE id = ${bucketId}`;

--- a/packages/management-api/src/services/task.worker.ts
+++ b/packages/management-api/src/services/task.worker.ts
@@ -318,8 +318,13 @@ export class TaskWorker {
 
                 case "cleanup_s3": {
                     if (process.env.TEST_FIXED_JWT_SECRET) return true;
-                    await storageService.deleteBucket(project_ref);
-                    return true;
+                    const result = await storageService.deleteBucket(project_ref);
+                    if (!result.success) {
+                        logger.error(`[TaskWorker] cleanup_s3 failed for ${project_ref}`, {
+                            outcome: result.error === "Bucket is not empty" ? "not_empty" : "unknown",
+                        });
+                    }
+                    return result.success;
                 }
 
                 case "cleanup_runtime": {

--- a/packages/management-api/tests/integration/storage-bucket-array-binding.test.ts
+++ b/packages/management-api/tests/integration/storage-bucket-array-binding.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { SQL, type ReservedSQL } from "bun";
+
+interface StorageBucketMimeRow {
+  allowed_mime_types: string[] | null;
+}
+
+const database = new SQL({
+  url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+  max: 1,
+});
+
+async function withRollback(operation: (transaction: ReservedSQL) => Promise<void>): Promise<void> {
+  const connection = await database.reserve();
+  await connection.unsafe("BEGIN");
+  try {
+    await operation(connection);
+  } finally {
+    await connection.unsafe("ROLLBACK");
+    connection.release();
+  }
+}
+
+async function storedMimeTypes(
+  transaction: ReservedSQL,
+  fixtureId: string,
+  mimeTypes: string[],
+): Promise<string[] | null> {
+  const mimeTypeBinding = mimeTypes.length > 0 ? transaction.array(mimeTypes, "TEXT") : null;
+  const [bucket] = await transaction<StorageBucketMimeRow[]>`
+    INSERT INTO storage_bucket_array_binding (fixture_id, allowed_mime_types)
+    VALUES (${fixtureId}, ${mimeTypeBinding})
+    ON CONFLICT (fixture_id) DO UPDATE
+      SET allowed_mime_types = EXCLUDED.allowed_mime_types
+    RETURNING allowed_mime_types
+  `;
+  return bucket.allowed_mime_types;
+}
+
+afterAll(async () => {
+  await database.close();
+}, 30_000);
+
+describe("storage bucket TEXT[] binding", () => {
+  test("round trips NULL clearing plus single and multiple MIME types", async () => {
+    await withRollback(async (transaction) => {
+      await transaction`
+        CREATE TEMPORARY TABLE storage_bucket_array_binding (
+          fixture_id TEXT PRIMARY KEY,
+          allowed_mime_types TEXT[]
+        ) ON COMMIT DROP
+      `;
+
+      expect(await storedMimeTypes(transaction, "reports", [])).toBeNull();
+      expect(await storedMimeTypes(transaction, "reports", ["application/pdf"]))
+        .toEqual(["application/pdf"]);
+      expect(await storedMimeTypes(transaction, "reports", ["application/pdf", "image/png"]))
+        .toEqual(["application/pdf", "image/png"]);
+      expect(await storedMimeTypes(transaction, "reports", [])).toBeNull();
+    });
+  }, 30_000);
+});

--- a/packages/management-api/tests/unit/storage-compat.sdk.test.ts
+++ b/packages/management-api/tests/unit/storage-compat.sdk.test.ts
@@ -47,6 +47,34 @@ afterEach(() => {
 });
 
 describe("storageCompatRoutes supabase-js compatibility", () => {
+  test("does not report bucket deletion when an object arrives after physical deletion", async () => {
+    const deleteBucketSpy = spyOn(StorageService, "deleteBucket").mockImplementation(async () => {
+      mockObjects.set("avatars/arrived-during-delete.txt", { metadata: {}, updated: new Date().toISOString() });
+      return { success: true };
+    });
+
+    try {
+      const response = await request("/storage/v1/bucket/avatars", {
+        method: "DELETE",
+        headers: {
+          "x-project-ref": "test_mock",
+          authorization: "Bearer test-token",
+        },
+      });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({
+        statusCode: "409",
+        error: "Conflict",
+        message: "Bucket is not empty",
+      });
+      expect(mockBuckets.has("avatars")).toBe(true);
+      expect(mockObjects.has("avatars/arrived-during-delete.txt")).toBe(true);
+    } finally {
+      deleteBucketSpy.mockRestore();
+    }
+  });
+
   test("iceberg surfaces expose an explicit unavailable capability", async () => {
     const icebergRes = await request("/storage/v1/iceberg/tables", {
       headers: { "x-project-ref": "test_mock", apikey: "test-token" },

--- a/packages/management-api/tests/unit/storage-routes.test.ts
+++ b/packages/management-api/tests/unit/storage-routes.test.ts
@@ -297,15 +297,8 @@ describe("storage management routes", () => {
     }
   });
 
-  test("Studio bucket deletion removes physical storage before logical metadata", async () => {
+  test("Studio bucket deletion removes the empty physical bucket before logical metadata", async () => {
     const callOrder: string[] = [];
-    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockImplementation(async () => {
-      callOrder.push("physical-preflight");
-      return true;
-    });
-    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockImplementation(async () => {
-      callOrder.push("logical-preflight");
-    });
     const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockImplementation(async () => {
       callOrder.push("physical");
       return { success: true };
@@ -320,22 +313,40 @@ describe("storage management routes", () => {
         headers: { Authorization: "Bearer dev-master-token" },
       });
       expect(response.status).toBe(200);
-      expect(callOrder).toEqual(["physical-preflight", "logical-preflight", "physical", "logical"]);
+      expect(callOrder).toEqual(["physical", "logical"]);
       expect(deleteLogicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
     } finally {
-      isBucketEmptySpy.mockRestore();
       deletePhysicalSpy.mockRestore();
       deleteLogicalSpy.mockRestore();
-      assertDeletableSpy.mockRestore();
     }
   });
 
-  test("Studio bucket deletion leaves physical data untouched when logical objects exist", async () => {
-    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockResolvedValue(true);
-    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockRejectedValue(
+  test("Studio bucket deletion reports a conflict when a logical object arrives after physical deletion", async () => {
+    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
+    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockRejectedValue(
       new Error("Bucket is not empty"),
     );
-    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
+        method: "DELETE",
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ message: "Bucket is not empty", code: "409" });
+      expect(deletePhysicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
+      expect(deleteLogicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
+    } finally {
+      deletePhysicalSpy.mockRestore();
+      deleteLogicalSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket deletion reports a conflict when the physical bucket is not empty", async () => {
+    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({
+      success: false,
+      error: "Bucket is not empty",
+    });
     const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
 
     try {
@@ -345,46 +356,19 @@ describe("storage management routes", () => {
       });
       expect(response.status).toBe(409);
       expect(await response.json()).toEqual({ message: "Bucket is not empty", code: "409" });
-      expect(deletePhysicalSpy).not.toHaveBeenCalled();
+      expect(deletePhysicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
       expect(deleteLogicalSpy).not.toHaveBeenCalled();
     } finally {
-      isBucketEmptySpy.mockRestore();
-      assertDeletableSpy.mockRestore();
       deletePhysicalSpy.mockRestore();
       deleteLogicalSpy.mockRestore();
     }
   });
 
-  test("Studio bucket deletion leaves physical data untouched when Studio files exist", async () => {
-    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockResolvedValue(false);
-    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockResolvedValue();
-    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
-    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
-
-    try {
-      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
-        method: "DELETE",
-        headers: { Authorization: "Bearer dev-master-token" },
-      });
-      expect(response.status).toBe(409);
-      expect(await response.json()).toEqual({ message: "Bucket is not empty", code: "409" });
-      expect(assertDeletableSpy).not.toHaveBeenCalled();
-      expect(deletePhysicalSpy).not.toHaveBeenCalled();
-      expect(deleteLogicalSpy).not.toHaveBeenCalled();
-    } finally {
-      isBucketEmptySpy.mockRestore();
-      assertDeletableSpy.mockRestore();
-      deletePhysicalSpy.mockRestore();
-      deleteLogicalSpy.mockRestore();
-    }
-  });
-
-  test("Studio bucket deletion fails closed when physical inspection fails", async () => {
-    const isBucketEmptySpy = spyOn(StorageService, "isBucketEmpty").mockRejectedValue(
-      new Error("storage unavailable"),
-    );
-    const assertDeletableSpy = spyOn(StorageRLS, "assertLogicalBucketDeletableAsAdmin").mockResolvedValue();
-    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
+  test("Studio bucket deletion fails closed when the physical outcome is unknown", async () => {
+    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({
+      success: false,
+      error: "Bucket deletion outcome is unknown",
+    });
     const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
 
     try {
@@ -393,12 +377,10 @@ describe("storage management routes", () => {
         headers: { Authorization: "Bearer dev-master-token" },
       });
       expect(response.status).toBe(500);
-      expect(assertDeletableSpy).not.toHaveBeenCalled();
-      expect(deletePhysicalSpy).not.toHaveBeenCalled();
+      expect(await response.json()).toEqual({ message: "Bucket deletion outcome is unknown", code: "500" });
+      expect(deletePhysicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
       expect(deleteLogicalSpy).not.toHaveBeenCalled();
     } finally {
-      isBucketEmptySpy.mockRestore();
-      assertDeletableSpy.mockRestore();
       deletePhysicalSpy.mockRestore();
       deleteLogicalSpy.mockRestore();
     }

--- a/packages/management-api/tests/unit/storage-routes.test.ts
+++ b/packages/management-api/tests/unit/storage-routes.test.ts
@@ -163,13 +163,119 @@ describe("storage management routes", () => {
       });
       expect(response.status).toBe(200);
       expect(await response.json()).toEqual([
-        { id: "public-assets", name: "public-assets", public: true, size: "-", file_size_limit: 1024 },
-        { id: "physical-only", name: "physical-only", public: false, size: "-" },
-        { id: "logical-only", name: "logical-only", public: false },
+        {
+          id: "public-assets",
+          name: "public-assets",
+          public: true,
+          size: "-",
+          file_size_limit: 1024,
+          allowed_mime_types: null,
+        },
+        {
+          id: "physical-only",
+          name: "physical-only",
+          public: false,
+          size: "-",
+          file_size_limit: null,
+          allowed_mime_types: null,
+        },
+        {
+          id: "logical-only",
+          name: "logical-only",
+          public: false,
+          file_size_limit: null,
+          allowed_mime_types: null,
+        },
       ]);
     } finally {
       listPhysicalSpy.mockRestore();
       listLogicalSpy.mockRestore();
+    }
+  });
+
+  test.each([
+    ["invalid project ref", "/v1/projects/bad.ref/storage/buckets", { name: "reports" }],
+    ["dot-only bucket", "/v1/projects/test-ref/storage/buckets", { name: "..." }],
+    ["negative file limit", "/v1/projects/test-ref/storage/buckets", { name: "reports", file_size_limit: -1 }],
+    ["fractional file limit", "/v1/projects/test-ref/storage/buckets", { name: "reports", file_size_limit: 1.5 }],
+    ["overflowing file limit", "/v1/projects/test-ref/storage/buckets", {
+      name: "reports",
+      file_size_limit: Number.MAX_SAFE_INTEGER + 1,
+    }],
+    ["empty MIME", "/v1/projects/test-ref/storage/buckets", { name: "reports", allowed_mime_types: [""] }],
+    ["overlong MIME", "/v1/projects/test-ref/storage/buckets", {
+      name: "reports",
+      allowed_mime_types: [`text/${"a".repeat(251)}`],
+    }],
+    ["too many MIME types", "/v1/projects/test-ref/storage/buckets", {
+      name: "reports",
+      allowed_mime_types: Array.from({ length: 101 }, (_, index) => `application/x-${index}`),
+    }],
+  ])("rejects %s before bucket creation", async (_label, path, body) => {
+    const createPhysicalSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
+    const createLogicalSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(true);
+
+    try {
+      const response = await request(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify(body),
+      });
+
+      expect(response.status).toBe(422);
+      expect(createPhysicalSpy).not.toHaveBeenCalled();
+      expect(createLogicalSpy).not.toHaveBeenCalled();
+    } finally {
+      createPhysicalSpy.mockRestore();
+      createLogicalSpy.mockRestore();
+    }
+  });
+
+  test("rejects an empty bucket update before Management dispatch", async () => {
+    const updateBucketSpy = spyOn(StorageService, "updateBucket");
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/reports", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: "{}",
+      });
+
+      expect(response.status).toBe(422);
+      expect(updateBucketSpy).not.toHaveBeenCalled();
+    } finally {
+      updateBucketSpy.mockRestore();
+    }
+  });
+
+  test("accepts exact Storage contract upper boundaries", async () => {
+    const createPhysicalSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
+    const createLogicalSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(true);
+    const allowedMimeTypes = Array.from({ length: 100 }, (_, index) => `application/x-${index}`);
+    allowedMimeTypes[0] = `x/${"a".repeat(253)}`;
+    const ref = "r".repeat(64);
+    const bucket = "b".repeat(100);
+
+    try {
+      const response = await request(`/v1/projects/${ref}/storage/buckets`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify({
+          name: bucket,
+          file_size_limit: Number.MAX_SAFE_INTEGER,
+          allowed_mime_types: allowedMimeTypes,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(createPhysicalSpy).toHaveBeenCalledWith(ref, bucket);
+      expect(createLogicalSpy).toHaveBeenCalledWith(ref, expect.objectContaining({
+        id: bucket,
+        fileSizeLimit: Number.MAX_SAFE_INTEGER,
+        allowedMimeTypes,
+      }));
+    } finally {
+      createPhysicalSpy.mockRestore();
+      createLogicalSpy.mockRestore();
     }
   });
 

--- a/packages/management-api/tests/unit/storage-s3.routes.test.ts
+++ b/packages/management-api/tests/unit/storage-s3.routes.test.ts
@@ -172,17 +172,16 @@ describe("storageS3Routes", () => {
   // --- DeleteBucket -------------------------------------------------------
 
   test("DELETE /:bucket deletes and returns 204 when empty", async () => {
-    mockListFiles.mockResolvedValue([]);
     mockDeleteBucket.mockResolvedValue({ success: true });
     const res = await authedRequest("/v1/storage/testproj/s3/mybucket", {
       method: "DELETE",
     });
     expect(res.status).toBe(204);
     expect(mockDeleteBucket).toHaveBeenCalledWith("testproj", "mybucket");
+    expect(mockListFiles).not.toHaveBeenCalled();
   });
 
   test("DELETE /:bucket returns InternalError when delete fails", async () => {
-    mockListFiles.mockResolvedValue([]);
     mockDeleteBucket.mockResolvedValue({ success: false, error: "driver error" });
     const res = await authedRequest("/v1/storage/testproj/s3/mybucket", {
       method: "DELETE",
@@ -193,7 +192,7 @@ describe("storageS3Routes", () => {
   });
 
   test("DELETE /:bucket returns BucketNotEmpty (409)", async () => {
-    mockListFiles.mockResolvedValue([{ name: "file1.txt", size: 100 }]);
+    mockDeleteBucket.mockResolvedValue({ success: false, error: "Bucket is not empty" });
     const res = await authedRequest("/v1/storage/testproj/s3/mybucket", {
       method: "DELETE",
     });

--- a/packages/management-api/tests/unit/storage.adapter.test.ts
+++ b/packages/management-api/tests/unit/storage.adapter.test.ts
@@ -16,6 +16,15 @@ function textStream(value: string): ReadableStream<Uint8Array> {
 }
 
 describe("S3Driver uploadFile", () => {
+  test("refuses prefix deletion without an atomic empty-prefix primitive", async () => {
+    const driver = new S3Driver();
+
+    expect(await driver.deleteBucket("testref", "gallery")).toEqual({
+      success: false,
+      reason: "unknown",
+    });
+  });
+
   test("materializes ReadableStream bodies before S3 writes", async () => {
     const previousNodeEnv = process.env.NODE_ENV;
     const previousCi = process.env.CI;
@@ -100,6 +109,7 @@ describe("JuiceFSDriver uploadFile", () => {
       (driver as unknown as { getBasePath: (...parts: string[]) => string }).getBasePath =
         (_projectRef: string, bucket?: string, key?: string) =>
           join(root, bucket || "", key || "");
+      expect(await driver.createBucket("testref", "gallery")).toBe(true);
 
       const uploaded = await driver.uploadFile(
         "testref",
@@ -124,6 +134,7 @@ describe("JuiceFSDriver uploadFile", () => {
       (driver as unknown as { getBasePath: (...parts: string[]) => string }).getBasePath =
         (_projectRef: string, bucket?: string, key?: string) =>
           join(root, bucket || "", key || "");
+      expect(await driver.createBucket("testref", "gallery")).toBe(true);
 
       const uploaded = await driver.uploadFile(
         "testref",
@@ -134,6 +145,74 @@ describe("JuiceFSDriver uploadFile", () => {
       );
 
       expect(uploaded).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects deletion and preserves an object written after an empty check", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-storage-"));
+    try {
+      const driver = new JuiceFSDriver();
+      (driver as unknown as { getBasePath: (...parts: string[]) => string }).getBasePath =
+        (_projectRef: string, bucket?: string, key?: string) =>
+          join(root, bucket || "", key || "");
+
+      expect(await driver.createBucket("testref", "gallery")).toBe(true);
+      expect(await driver.isBucketEmpty("testref", "gallery")).toBe(true);
+      expect(await driver.uploadFile(
+        "testref",
+        "gallery",
+        "arrived-after-check.txt",
+        new TextEncoder().encode("preserve me"),
+        "text/plain",
+      )).toBe(true);
+
+      expect(await driver.deleteBucket("testref", "gallery")).toEqual({
+        success: false,
+        reason: "not_empty",
+      });
+      expect(await readFile(join(root, "gallery", "arrived-after-check.txt"), "utf8")).toBe("preserve me");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("does not recreate a bucket after atomic deletion", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-storage-"));
+    try {
+      const driver = new JuiceFSDriver();
+      (driver as unknown as { getBasePath: (...parts: string[]) => string }).getBasePath =
+        (_projectRef: string, bucket?: string, key?: string) =>
+          join(root, bucket || "", key || "");
+
+      expect(await driver.createBucket("testref", "gallery")).toBe(true);
+      expect(await driver.deleteBucket("testref", "gallery")).toEqual({ success: true });
+      expect(await driver.uploadFile(
+        "testref",
+        "gallery",
+        "late.txt",
+        new TextEncoder().encode("must not reappear"),
+        "text/plain",
+      )).toBe(false);
+      await expect(readFile(join(root, "gallery", "late.txt"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("treats a missing bucket as an unknown deletion outcome", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-storage-"));
+    try {
+      const driver = new JuiceFSDriver();
+      (driver as unknown as { getBasePath: (...parts: string[]) => string }).getBasePath =
+        (_projectRef: string, bucket?: string, key?: string) =>
+          join(root, bucket || "", key || "");
+
+      expect(await driver.deleteBucket("testref", "missing")).toEqual({
+        success: false,
+        reason: "unknown",
+      });
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/management-api/tests/unit/storage.service.test.ts
+++ b/packages/management-api/tests/unit/storage.service.test.ts
@@ -66,9 +66,10 @@ describe("StorageService (using adapter)", () => {
   });
 
   describe("updateBucket", () => {
-    test("binds MIME types as a PostgreSQL array instead of serialized JSON", async () => {
+    test("binds single and multiple MIME types as PostgreSQL TEXT arrays and clears with NULL", async () => {
       const sqlParameters: unknown[][] = [];
-      const projectDatabase = (async (strings: TemplateStringsArray, ...parameters: unknown[]) => {
+      const textArrayCalls: Array<{ values: string[]; type: string }> = [];
+      const projectDatabaseTag = async (strings: TemplateStringsArray, ...parameters: unknown[]) => {
         sqlParameters.push(parameters);
         return strings.join("?").includes("SELECT * FROM storage.buckets")
           ? [{
@@ -79,20 +80,64 @@ describe("StorageService (using adapter)", () => {
               allowed_mime_types: ["application/pdf"],
             }]
           : [];
+      };
+      const projectDatabase = Object.assign(projectDatabaseTag, {
+        array(values: string[], type: string) {
+          textArrayCalls.push({ values, type });
+          return values;
+        },
       }) as never;
       const resolveDbName = spyOn(databaseModule, "resolveDbName").mockResolvedValue("supa_testref");
       const getProjectDb = spyOn(databaseModule, "getProjectDb").mockReturnValue(projectDatabase);
 
       try {
-        const response = await StorageService.updateBucket("testref", "reports", {
+        const singleResponse = await StorageService.updateBucket("testref", "reports", {
           allowed_mime_types: ["application/pdf"],
         });
+        const multipleResponse = await StorageService.updateBucket("testref", "reports", {
+          allowed_mime_types: ["application/pdf", "image/png"],
+        });
+        const clearedResponse = await StorageService.updateBucket("testref", "reports", {
+          allowed_mime_types: [],
+        });
 
-        expect(response.success).toBe(true);
+        expect(singleResponse.success).toBe(true);
+        expect(multipleResponse.success).toBe(true);
+        expect(clearedResponse.success).toBe(true);
         expect(sqlParameters[0]).toEqual([["application/pdf"], "reports"]);
+        expect(sqlParameters[2]).toEqual([["application/pdf", "image/png"], "reports"]);
+        expect(sqlParameters[4]).toEqual([null, "reports"]);
+        expect(textArrayCalls).toEqual([
+          { values: ["application/pdf"], type: "TEXT" },
+          { values: ["application/pdf", "image/png"], type: "TEXT" },
+        ]);
         expect(sqlParameters.flat().join(" ")).not.toContain('["application/pdf"]');
       } finally {
         resolveDbName.mockRestore();
+        getProjectDb.mockRestore();
+      }
+    });
+
+    test.each([
+      ["project ref", "bad.ref", "reports", { public: true }],
+      ["dot-only bucket", "testref", "...", { public: true }],
+      ["negative file limit", "testref", "reports", { file_size_limit: -1 }],
+      ["fractional file limit", "testref", "reports", { file_size_limit: 1.5 }],
+      ["overflowing file limit", "testref", "reports", { file_size_limit: Number.MAX_SAFE_INTEGER + 1 }],
+      ["empty MIME", "testref", "reports", { allowed_mime_types: [""] }],
+      ["overlong MIME", "testref", "reports", { allowed_mime_types: [`text/${"a".repeat(251)}`] }],
+      ["too many MIME types", "testref", "reports", {
+        allowed_mime_types: Array.from({ length: 101 }, (_, index) => `application/x-${index}`),
+      }],
+    ])("rejects invalid %s before opening a project database", async (_label, ref, bucket, updates) => {
+      const getProjectDb = spyOn(databaseModule, "getProjectDb");
+      try {
+        const response = await StorageService.updateBucket(ref, bucket, updates);
+
+        expect(response.success).toBe(false);
+        expect(response.error).toStartWith("Invalid ");
+        expect(getProjectDb).not.toHaveBeenCalled();
+      } finally {
         getProjectDb.mockRestore();
       }
     });

--- a/packages/management-api/tests/unit/storage.service.test.ts
+++ b/packages/management-api/tests/unit/storage.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, spyOn, mock } from "bun:test";
+import * as databaseModule from "../../src/db";
 import { storageService, StorageService } from "../../src/services/storage.service";
 
 // We must mock the adapter module since StorageService now uses it internally
@@ -61,6 +62,39 @@ describe("StorageService (using adapter)", () => {
     test("should preserve strict driver failures", async () => {
       mockStorageDriver.isBucketEmpty.mockRejectedValueOnce(new Error("storage unavailable"));
       await expect(StorageService.isBucketEmpty("myproj", "bucket")).rejects.toThrow("storage unavailable");
+    });
+  });
+
+  describe("updateBucket", () => {
+    test("binds MIME types as a PostgreSQL array instead of serialized JSON", async () => {
+      const sqlParameters: unknown[][] = [];
+      const projectDatabase = (async (strings: TemplateStringsArray, ...parameters: unknown[]) => {
+        sqlParameters.push(parameters);
+        return strings.join("?").includes("SELECT * FROM storage.buckets")
+          ? [{
+              id: "reports",
+              name: "reports",
+              public: false,
+              file_size_limit: null,
+              allowed_mime_types: ["application/pdf"],
+            }]
+          : [];
+      }) as never;
+      const resolveDbName = spyOn(databaseModule, "resolveDbName").mockResolvedValue("supa_testref");
+      const getProjectDb = spyOn(databaseModule, "getProjectDb").mockReturnValue(projectDatabase);
+
+      try {
+        const response = await StorageService.updateBucket("testref", "reports", {
+          allowed_mime_types: ["application/pdf"],
+        });
+
+        expect(response.success).toBe(true);
+        expect(sqlParameters[0]).toEqual([["application/pdf"], "reports"]);
+        expect(sqlParameters.flat().join(" ")).not.toContain('["application/pdf"]');
+      } finally {
+        resolveDbName.mockRestore();
+        getProjectDb.mockRestore();
+      }
     });
   });
 

--- a/packages/management-api/tests/unit/storage.service.test.ts
+++ b/packages/management-api/tests/unit/storage.service.test.ts
@@ -46,15 +46,33 @@ describe("StorageService (using adapter)", () => {
 
   describe("deleteBucket", () => {
     test("should return success when driver succeeds", async () => {
-      mockStorageDriver.deleteBucket.mockResolvedValueOnce(true);
+      mockStorageDriver.deleteBucket.mockResolvedValueOnce({ success: true });
       const result = await storageService.deleteBucket("testref");
       expect(result.success).toBe(true);
     });
 
     test("should pass correct params to driver", async () => {
-      mockStorageDriver.deleteBucket.mockResolvedValueOnce(true);
+      mockStorageDriver.deleteBucket.mockResolvedValueOnce({ success: true });
       await storageService.deleteBucket("myproj", "bucket");
       expect(mockStorageDriver.deleteBucket).toHaveBeenCalledWith("myproj", "bucket");
+    });
+
+    test("maps a non-empty directory result to a conflict without declaring deletion", async () => {
+      mockStorageDriver.deleteBucket.mockResolvedValueOnce({ success: false, reason: "not_empty" });
+
+      await expect(storageService.deleteBucket("myproj", "bucket")).resolves.toEqual({
+        success: false,
+        error: "Bucket is not empty",
+      });
+    });
+
+    test("maps an indeterminate driver result without declaring deletion", async () => {
+      mockStorageDriver.deleteBucket.mockResolvedValueOnce({ success: false, reason: "unknown" });
+
+      await expect(storageService.deleteBucket("myproj", "bucket")).resolves.toEqual({
+        success: false,
+        error: "Bucket deletion outcome is unknown",
+      });
     });
   });
 

--- a/packages/management-api/tests/unit/task.worker.test.ts
+++ b/packages/management-api/tests/unit/task.worker.test.ts
@@ -6,6 +6,7 @@ import { projectRepository } from "../../src/repositories/project.repository";
 import { TaskWorker } from "../../src/services/task.worker";
 import { databaseService } from "../../src/services/database.service";
 import { jwtService } from "../../src/services/jwt.service";
+import { storageService } from "../../src/services/storage.service";
 import * as wsModule from "../../src/routes/ws";
 
 function failedTask(overrides: Partial<ProjectTask> = {}): ProjectTask {
@@ -182,6 +183,43 @@ describe("TaskWorker failure handling", () => {
       "cleanup_s3",
       "cleanup_db",
     ]);
+  });
+});
+
+describe("TaskWorker cleanup_s3", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test.each([
+    ["successful", { success: true }, true],
+    ["non-empty", { success: false, error: "Bucket is not empty" }, false],
+    ["unknown", { success: false, error: "Bucket deletion outcome is unknown" }, false],
+  ])("returns %s storage cleanup results without declaring a false success", async (
+    _outcome,
+    deletion,
+    expected,
+  ) => {
+    const originalFixedJwtSecret = process.env.TEST_FIXED_JWT_SECRET;
+    delete process.env.TEST_FIXED_JWT_SECRET;
+    const worker = new TaskWorker();
+    const deleteBucketSpy = spyOn(storageService, "deleteBucket").mockResolvedValue(deletion);
+    spyOn(projectRepository, "findByRef").mockResolvedValue(null);
+
+    try {
+      const completed = await (worker as any).executeTask({
+        id: "cleanup-s3-task",
+        project_ref: "proj-ref",
+        task_type: "cleanup_s3",
+        payload: {},
+      });
+
+      expect(completed).toBe(expected);
+      expect(deleteBucketSpy).toHaveBeenCalledWith("proj-ref");
+    } finally {
+      if (originalFixedJwtSecret === undefined) delete process.env.TEST_FIXED_JWT_SECRET;
+      else process.env.TEST_FIXED_JWT_SECRET = originalFixedJwtSecret;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add project-scoped Storage bucket list, get, create, update, and delete actions to the supported CLI
- return safe supacloud.cli.release-control.v1 receipts and independently read back mutations
- align CLI and Management API validation for project refs, bucket ids, file limits, and MIME restrictions
- bind PostgreSQL MIME restrictions as TEXT arrays and verify the round trip in PostgreSQL 18 CI
- keep complete Storage help available when project context is not configured

## Verification
- packages/cli: bun test, 355 pass
- packages/management-api: Storage unit tests, 44 pass
- CLI and Management API typecheck
- CLI build
- source and built Storage help without project context
- git diff --check

clean-code-guard: clean