### PR TITLE
feat(cli): add migration inventory action

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -165,7 +165,8 @@ supacloud-cli secrets upsert --ref abc123 --from-env API_KEY,WEBHOOK_SECRET
 
 `database migration_inventory` reads the canonical migration ledger through the
 project-scoped Management API and prints only a validated JSON array. It rejects
-non-2xx responses, malformed entries, duplicate migration identities, checksum
+non-2xx responses, malformed entries, unsafe project refs, duplicate canonical
+migration versions, checksum
 drift, and statement-count mismatches instead of treating them as an empty
 ledger. `database list_migrations` remains available with its legacy SQL-backed,
 human-readable behavior.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -146,6 +146,7 @@ supacloud-cli queue dlq --queue emails --limit 20
 supacloud-cli task_events inspect_webhook --ref abc123
 supacloud-cli database query --sql "select now()"
 supacloud-cli database query --ref abc123 --file ./queries/vector-search.sql
+supacloud-cli database migration_inventory --ref abc123
 supacloud-cli database push_migrations --ref abc123 --dir supabase/migrations --dry_run
 supacloud-cli supabase migration_new --name add_accounts
 supacloud-cli supabase db_diff --schema public --name add_accounts
@@ -161,6 +162,13 @@ supacloud-cli edge_functions activate --ref abc123 --slug hello --version 3
 supacloud-cli scheduled_functions list --ref abc123
 supacloud-cli secrets upsert --ref abc123 --from-env API_KEY,WEBHOOK_SECRET
 ```
+
+`database migration_inventory` reads the canonical migration ledger through the
+project-scoped Management API and prints only a validated JSON array. It rejects
+non-2xx responses, malformed entries, duplicate migration identities, checksum
+drift, and statement-count mismatches instead of treating them as an empty
+ledger. `database list_migrations` remains available with its legacy SQL-backed,
+human-readable behavior.
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
 Bun and runs a local syntax check before upload. The Management API validates and

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -210,6 +210,7 @@ EXAMPLES
   ${preferredCommand} frontend list --ref abc123
   ${preferredCommand} database query --sql "select now()"
   ${preferredCommand} database query --ref abc123 --file ./queries/vector-search.sql
+  ${preferredCommand} database migration_inventory --ref abc123
   ${preferredCommand} database push_migrations --ref abc123 --dir supabase/migrations --dry_run
   ${preferredCommand} supabase migration_new --name add_accounts
   ${preferredCommand} supabase db_diff --schema public --name add_accounts

--- a/packages/cli/src/migration-inventory.integration.test.ts
+++ b/packages/cli/src/migration-inventory.integration.test.ts
@@ -146,6 +146,53 @@ describe("migration inventory CLI process contract", () => {
         expect(response.stderr).toBe("");
     });
 
+    test("keeps the migration ledger endpoint readable in read-only mode", async () => {
+        const requests: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requests.push(`${request.method} ${new URL(request.url).pathname}`);
+                return Response.json([]);
+            },
+        });
+        servers.push(server);
+
+        const response = await runCli(
+            ["database", "migration_inventory"],
+            { ...projectEnvironment(server.port, "read-only-token"), SUPACLOUD_READ_ONLY: "true" },
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toEqual([]);
+        expect(requests).toEqual(["GET /v1/projects/project-a/database/migrations"]);
+    });
+
+    test.each([".", "..", "project.name", "project/other", "project?other", "project#other", "%2e"])("rejects unsafe ref %s without dispatching or reflecting secrets", async (ref) => {
+        const token = "unsafe-ref-token-sentinel";
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json([]);
+            },
+        });
+        servers.push(server);
+
+        const response = await runCli(
+            ["database", "migration_inventory", "--ref", ref],
+            projectEnvironment(server.port, token),
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stdout + response.stderr).toContain("invalid for migration_inventory");
+        expect(response.stdout + response.stderr).not.toContain(token);
+        expect(response.stdout + response.stderr).not.toContain(ref);
+    });
+
     test.each([409, 503])("exits non-zero for HTTP %d without reflecting the response", async (status) => {
         const token = `http-${status}-token-sentinel`;
         const responseSecret = `http-${status}-response-sentinel`;
@@ -175,9 +222,9 @@ describe("migration inventory CLI process contract", () => {
             statements: ["SELECT 1;"],
             appliedAt: null,
         }), statement_count: 2 }]],
-        ["duplicate identity", (() => {
+        ["duplicate canonical version", (() => {
             const row = migrationRow({ version: "1", name: "one", statements: ["SELECT 1;"], appliedAt: null });
-            return [row, { ...row }];
+            return [row, migrationRow({ version: "1", name: "one-renamed", statements: ["SELECT 2;"], appliedAt: null })];
         })()],
     ])("exits non-zero for a %s success payload", async (_label, payload) => {
         const server = Bun.serve({

--- a/packages/cli/src/migration-inventory.integration.test.ts
+++ b/packages/cli/src/migration-inventory.integration.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const CLI_ENTRYPOINT = fileURLToPath(new URL("./index.ts", import.meta.url));
+const CONTEXT_KEYS = new Set([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPACLOUD_API_URL",
+    "SUPACLOUD_API_TOKEN",
+    "SUPACLOUD_PROJECT_REF",
+    "SUPACLOUD_ENV",
+    "SUPACLOUD_READ_ONLY",
+]);
+const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
+
+interface MigrationRow {
+    version: string;
+    name: string | null;
+    statements: string[];
+    statement_count: number;
+    checksum: string;
+    applied_at: string | null;
+}
+
+afterEach(() => {
+    for (const server of servers.splice(0)) server.stop(true);
+});
+
+function cliEnvironment(overrides: Record<string, string>): Record<string, string> {
+    const environment = Object.fromEntries(
+        Object.entries(process.env).filter(([key, value]) => value !== undefined && !CONTEXT_KEYS.has(key)),
+    ) as Record<string, string>;
+    return { ...environment, ...overrides };
+}
+
+async function runCli(args: string[], environment: Record<string, string>) {
+    const argv = [process.execPath, CLI_ENTRYPOINT, ...args];
+    const child = Bun.spawn(argv, {
+        cwd: PACKAGE_ROOT,
+        env: cliEnvironment(environment),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+    ]);
+    return { argv, exitCode, stdout, stderr };
+}
+
+function migrationRow(input: {
+    version: string;
+    name: string | null;
+    statements: string[];
+    appliedAt: string | null;
+}): MigrationRow {
+    const checksum = createHash("sha256").update(JSON.stringify({
+        version: input.version,
+        name: input.name,
+        statements: input.statements,
+    })).digest("hex");
+    return {
+        version: input.version,
+        name: input.name,
+        statements: input.statements,
+        statement_count: input.statements.length,
+        checksum,
+        applied_at: input.appliedAt,
+    };
+}
+
+function projectEnvironment(port: number | undefined, token: string): Record<string, string> {
+    if (port === undefined) throw new Error("Test server did not bind a port");
+    return {
+        SUPACLOUD_API_URL: `http://127.0.0.1:${port}`,
+        SUPACLOUD_API_TOKEN: token,
+        SUPACLOUD_PROJECT_REF: "project-a",
+    };
+}
+
+describe("migration inventory CLI process contract", () => {
+    test("prints only sorted inventory JSON and keeps the token out of argv and output", async () => {
+        const token = "migration-inventory-token-sentinel";
+        const requests: Array<{ method: string; path: string; authorization: string | null }> = [];
+        const later = {
+            ...migrationRow({ version: "9007199254740993001", name: "later", statements: ["SELECT 2;"], appliedAt: null }),
+            reflected_token: token,
+        };
+        const earlier = migrationRow({
+            version: "2",
+            name: null,
+            statements: ["SELECT 1;"],
+            appliedAt: "2026-08-11 09:00:00+00",
+        });
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requests.push({
+                    method: request.method,
+                    path: new URL(request.url).pathname,
+                    authorization: request.headers.get("authorization"),
+                });
+                return Response.json([later, earlier]);
+            },
+        });
+        servers.push(server);
+
+        const response = await runCli(
+            ["database", "migration_inventory", "--ref", "project-a"],
+            projectEnvironment(server.port, token),
+        );
+        const inventory = JSON.parse(response.stdout);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toBe("");
+        expect(inventory.map((entry: MigrationRow) => entry.version)).toEqual(["2", "9007199254740993001"]);
+        expect(inventory[1]).not.toHaveProperty("reflected_token");
+        expect(requests).toEqual([{
+            method: "GET",
+            path: "/v1/projects/project-a/database/migrations",
+            authorization: `Bearer ${token}`,
+        }]);
+        expect(response.argv.join(" ")).not.toContain(token);
+        expect(response.stdout + response.stderr).not.toContain(token);
+    });
+
+    test("prints an empty JSON array for a valid empty ledger", async () => {
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json([]),
+        });
+        servers.push(server);
+
+        const response = await runCli(
+            ["database", "migration_inventory"],
+            projectEnvironment(server.port, "empty-ledger-token"),
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toEqual([]);
+        expect(response.stderr).toBe("");
+    });
+
+    test.each([409, 503])("exits non-zero for HTTP %d without reflecting the response", async (status) => {
+        const token = `http-${status}-token-sentinel`;
+        const responseSecret = `http-${status}-response-sentinel`;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json({ message: responseSecret }, { status }),
+        });
+        servers.push(server);
+
+        const response = await runCli(
+            ["database", "migration_inventory"],
+            projectEnvironment(server.port, token),
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(JSON.parse(response.stdout).error).toEqual({ code: "HTTP_ERROR", http_status: status });
+        expect(response.stdout + response.stderr).not.toContain(token);
+        expect(response.stdout + response.stderr).not.toContain(responseSecret);
+    });
+
+    test.each([
+        ["non-array", { rows: [] }],
+        ["count mismatch", [{ ...migrationRow({
+            version: "1",
+            name: "one",
+            statements: ["SELECT 1;"],
+            appliedAt: null,
+        }), statement_count: 2 }]],
+        ["duplicate identity", (() => {
+            const row = migrationRow({ version: "1", name: "one", statements: ["SELECT 1;"], appliedAt: null });
+            return [row, { ...row }];
+        })()],
+    ])("exits non-zero for a %s success payload", async (_label, payload) => {
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json(payload),
+        });
+        servers.push(server);
+
+        const response = await runCli(
+            ["database", "migration_inventory"],
+            projectEnvironment(server.port, "invalid-shape-token"),
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(JSON.parse(response.stdout).error).toEqual({ code: "INVALID_RESPONSE", http_status: 200 });
+    });
+
+    test("lists the new read-only action in command help", async () => {
+        const response = await runCli(
+            ["database", "--help"],
+            projectEnvironment(1, "help-token"),
+        );
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("migration_inventory");
+        expect(response.stdout + response.stderr).not.toContain("help-token");
+    });
+});

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -140,6 +140,7 @@ describe("CLI execution policy", () => {
     });
 
     test("allows migration previews and local authoring without production confirmation", () => {
+        expect(executionMode("database", "migration_inventory", {})).toBe("read");
         expect(executionMode("database", "push_migrations", { dry_run: true })).toBe("read");
         expect(executionMode("supabase", "push", { dry_run: true })).toBe("read");
         expect(() => authorizeExecution("supabase", { action: "db_dump" }, { context: context() }))

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -16,7 +16,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         write: ["task_cancel", "task_retry", "update_background_settings"],
     },
     database: {
-        read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "project_url", "generate_types"],
+        read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "migration_inventory", "project_url", "generate_types"],
         write: ["query", "apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"],
     },
     supabase: {

--- a/packages/cli/src/shared/project-ref.ts
+++ b/packages/cli/src/shared/project-ref.ts
@@ -1,0 +1,8 @@
+const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+export function projectRefPathSegment(ref: unknown, operation: string): string {
+    if (typeof ref !== "string" || !PROJECT_REF_PATTERN.test(ref)) {
+        throw new Error(`'ref' is invalid for ${operation}`);
+    }
+    return encodeURIComponent(ref);
+}

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -5,8 +5,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { migrationVersionFromFilename, registerDatabaseTools, vectorWarningsForPendingMigrations } from "./database-tools";
 
+interface CapturedDatabaseToolResponse {
+    content: Array<{ text: string }>;
+    isError?: boolean;
+}
+
 function captureDatabaseTool(http: Record<string, unknown>, projectRef?: string) {
-    let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<CapturedDatabaseToolResponse>) | undefined;
     registerDatabaseTools({
         tool(name: string, _description: string, _schema: Record<string, unknown>, toolCallback: typeof callback) {
             if (name !== "database") return;
@@ -16,6 +21,22 @@ function captureDatabaseTool(http: Record<string, unknown>, projectRef?: string)
 
     if (!callback) throw new Error("database tool was not registered");
     return callback;
+}
+
+function migrationInventoryFixture(overrides: Record<string, unknown> = {}) {
+    const version = typeof overrides.version === "string" ? overrides.version : "20260811090000";
+    const name = overrides.name === undefined ? "20260811090000_create_inventory" : overrides.name;
+    const statements = Array.isArray(overrides.statements) ? overrides.statements : ["SELECT 1;"];
+    const checksum = createHash("sha256").update(JSON.stringify({ version, name, statements })).digest("hex");
+    return {
+        version,
+        name,
+        statements,
+        statement_count: statements.length,
+        checksum,
+        applied_at: "2026-08-11 09:00:00+00",
+        ...overrides,
+    };
 }
 
 describe("database migration helpers", () => {
@@ -31,6 +52,126 @@ describe("database migration helpers", () => {
         await callback({ action: "project_url", ref: "override-ref" });
 
         expect(calls).toEqual(["/v1/projects/override-ref"]);
+    });
+
+    test("returns a validated, projected, numerically sorted migration inventory", async () => {
+        const requests: Array<{ path: string; maxResponseBytes?: number }> = [];
+        const later = migrationInventoryFixture({
+            version: "9007199254740993001",
+            name: "later",
+            applied_at: null,
+            response_secret: "must-not-be-projected",
+        });
+        const earlier = migrationInventoryFixture({ version: "10", name: null });
+        const callback = captureDatabaseTool({
+            get: async (path: string, options: { maxResponseBytes?: number }) => {
+                requests.push({ path, maxResponseBytes: options.maxResponseBytes });
+                return { ok: true, status: 200, data: [later, earlier] };
+            },
+        });
+
+        const response = await callback({ action: "migration_inventory", ref: "proj" });
+        const inventory = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBeUndefined();
+        expect(requests).toEqual([{
+            path: "/v1/projects/proj/database/migrations",
+            maxResponseBytes: 64 * 1024 * 1024,
+        }]);
+        expect(inventory.map((entry: { version: string }) => entry.version)).toEqual(["10", "9007199254740993001"]);
+        expect(inventory[1]).not.toHaveProperty("response_secret");
+        expect(Object.keys(inventory[0])).toEqual([
+            "version", "name", "statements", "statement_count", "checksum", "applied_at",
+        ]);
+    });
+
+    test("represents a valid empty migration ledger as a JSON array", async () => {
+        const callback = captureDatabaseTool({
+            get: async () => ({ ok: true, status: 200, data: [] }),
+        });
+
+        const response = await callback({ action: "migration_inventory", ref: "proj" });
+
+        expect(response.isError).toBeUndefined();
+        expect(response.content[0].text).toBe("[]");
+    });
+
+    test.each([409, 503])("returns a secret-free error for HTTP %d", async (status) => {
+        const responseSecret = `migration-inventory-response-${status}`;
+        const callback = captureDatabaseTool({
+            get: async () => ({
+                ok: false,
+                status,
+                data: { message: responseSecret },
+            }),
+        });
+
+        const response = await callback({ action: "migration_inventory", ref: "proj" });
+        const failure = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(failure).toEqual({
+            ok: false,
+            operation: "database.migration_inventory",
+            error: { code: "HTTP_ERROR", http_status: status },
+        });
+        expect(response.content[0].text).not.toContain(responseSecret);
+    });
+
+    test.each([
+        ["non-array top level", { rows: [] }],
+        ["non-canonical version", [migrationInventoryFixture({ version: "01" })]],
+        ["missing name", [(() => {
+            const entry = migrationInventoryFixture();
+            delete (entry as Record<string, unknown>).name;
+            return entry;
+        })()]],
+        ["empty name", [migrationInventoryFixture({ name: "" })]],
+        ["non-array statements", [{ ...migrationInventoryFixture(), statements: "SELECT 1;" }]],
+        ["non-string statement", [{ ...migrationInventoryFixture(), statements: [1], statement_count: 1 }]],
+        ["statement count mismatch", [{ ...migrationInventoryFixture(), statement_count: 2 }]],
+        ["invalid checksum", [{ ...migrationInventoryFixture(), checksum: "invalid" }]],
+        ["semantic checksum mismatch", [{ ...migrationInventoryFixture(), checksum: "0".repeat(64) }]],
+        ["invalid applied timestamp", [{ ...migrationInventoryFixture(), applied_at: "not-a-timestamp" }]],
+        ["duplicate identity", (() => {
+            const entry = migrationInventoryFixture();
+            return [entry, { ...entry }];
+        })()],
+    ])("rejects %s instead of reporting an empty ledger", async (_label, payload) => {
+        const callback = captureDatabaseTool({
+            get: async () => ({ ok: true, status: 200, data: payload }),
+        });
+
+        const response = await callback({ action: "migration_inventory", ref: "proj" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            ok: false,
+            operation: "database.migration_inventory",
+            error: { code: "INVALID_RESPONSE", http_status: 200 },
+        });
+    });
+
+    test("preserves the SQL-backed, human-readable list_migrations behavior", async () => {
+        const posts: Array<{ path: string; body: { sql: string } }> = [];
+        const callback = captureDatabaseTool({
+            get: async () => { throw new Error("list_migrations must not use the inventory endpoint"); },
+            post: async (path: string, body: { sql: string }) => {
+                posts.push({ path, body });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: { rows: [{ version: "20260811090000", applied_at: "2026-08-11" }] },
+                };
+            },
+        });
+
+        const response = await callback({ action: "list_migrations", ref: "proj" });
+
+        expect(posts).toHaveLength(1);
+        expect(posts[0].path).toBe("/v1/projects/proj/database/sql");
+        expect(posts[0].body.sql).toContain("FROM schema_migrations");
+        expect(response.content[0].text).toContain("📝 Migrations:");
     });
 
     test("uses Supabase timestamp prefix as migration version", () => {

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -96,6 +96,19 @@ describe("database migration helpers", () => {
         expect(response.content[0].text).toBe("[]");
     });
 
+    test.each([".", "..", "project.name", "project/other", "project?other", "project#other", "%2e"])("rejects migration inventory ref %s before HTTP dispatch", async (ref) => {
+        let requestCount = 0;
+        const callback = captureDatabaseTool({
+            get: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: [] };
+            },
+        });
+
+        await expect(callback({ action: "migration_inventory", ref })).rejects.toThrow("invalid for migration_inventory");
+        expect(requestCount).toBe(0);
+    });
+
     test.each([409, 503])("returns a secret-free error for HTTP %d", async (status) => {
         const responseSecret = `migration-inventory-response-${status}`;
         const callback = captureDatabaseTool({
@@ -133,9 +146,9 @@ describe("database migration helpers", () => {
         ["invalid checksum", [{ ...migrationInventoryFixture(), checksum: "invalid" }]],
         ["semantic checksum mismatch", [{ ...migrationInventoryFixture(), checksum: "0".repeat(64) }]],
         ["invalid applied timestamp", [{ ...migrationInventoryFixture(), applied_at: "not-a-timestamp" }]],
-        ["duplicate identity", (() => {
+        ["duplicate canonical version", (() => {
             const entry = migrationInventoryFixture();
-            return [entry, { ...entry }];
+            return [entry, migrationInventoryFixture({ version: entry.version, name: "same-version-different-name" })];
         })()],
     ])("rejects %s instead of reporting an empty ledger", async (_label, payload) => {
         const callback = captureDatabaseTool({

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -7,7 +7,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
-import type { HttpTransport } from "../transports/http";
+import type { HttpResult, HttpTransport } from "../transports/http";
 
 export interface DatabaseToolsConfig {
     readOnly?: boolean;
@@ -18,6 +18,7 @@ const MAX_MIGRATION_VERSION = 9_223_372_036_854_775_807n;
 const FALLBACK_MIGRATION_VERSION_BASE = 8_000_000_000_000_000_000n;
 const FALLBACK_MIGRATION_VERSION_RANGE = 1_000_000_000_000_000_000n;
 const FALLBACK_MIGRATION_VERSION_LIMIT = FALLBACK_MIGRATION_VERSION_BASE + FALLBACK_MIGRATION_VERSION_RANGE;
+const MAX_MIGRATION_INVENTORY_BYTES = 64 * 1024 * 1024;
 
 interface MigrationFile {
     file: string;
@@ -25,6 +26,127 @@ interface MigrationFile {
     version: string;
     sql: string;
     rawBytes: Uint8Array;
+}
+
+interface MigrationInventoryEntry {
+    version: string;
+    name: string | null;
+    statements: string[];
+    statement_count: number;
+    checksum: string;
+    applied_at: string | null;
+}
+
+interface DatabaseToolResponse {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+}
+
+function isMigrationInventoryVersion(version: unknown): version is string {
+    if (typeof version !== "string" || !/^\d{1,19}$/.test(version)) return false;
+    const numericVersion = BigInt(version);
+    return numericVersion >= 1n
+        && numericVersion <= MAX_MIGRATION_VERSION
+        && numericVersion.toString() === version;
+}
+
+function isMigrationInventoryName(name: unknown): name is string | null {
+    return name === null
+        || (typeof name === "string" && name.length <= 255 && name.length > 0 && name.trim() === name);
+}
+
+function isMigrationInventoryStatements(statements: unknown): statements is string[] {
+    return Array.isArray(statements) && statements.every((statement) =>
+        typeof statement === "string"
+        && statement.length > 0
+        && statement.trim() === statement
+        && !statement.includes("\r")
+    );
+}
+
+function isMigrationInventoryAppliedAt(appliedAt: unknown): appliedAt is string | null {
+    return appliedAt === null
+        || (typeof appliedAt === "string"
+            && appliedAt.trim() === appliedAt
+            && appliedAt.length > 0
+            && !Number.isNaN(Date.parse(appliedAt)));
+}
+
+function migrationInventoryChecksum(entry: Pick<MigrationInventoryEntry, "version" | "name" | "statements">): string {
+    return createHash("sha256").update(JSON.stringify({
+        version: entry.version,
+        name: entry.name,
+        statements: entry.statements,
+    })).digest("hex");
+}
+
+function migrationInventoryEntry(rawEntry: unknown): MigrationInventoryEntry | null {
+    if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) return null;
+    const entry = rawEntry as Record<string, unknown>;
+    if (!isMigrationInventoryVersion(entry.version)) return null;
+    if (!isMigrationInventoryName(entry.name)) return null;
+    if (!isMigrationInventoryStatements(entry.statements)) return null;
+    if (typeof entry.statement_count !== "number" || !Number.isInteger(entry.statement_count)) return null;
+    if (entry.statement_count !== entry.statements.length) return null;
+    if (typeof entry.checksum !== "string" || !/^[0-9a-f]{64}$/.test(entry.checksum)) return null;
+    if (!isMigrationInventoryAppliedAt(entry.applied_at)) return null;
+    const migration: MigrationInventoryEntry = {
+        version: entry.version,
+        name: entry.name,
+        statements: entry.statements,
+        statement_count: entry.statement_count,
+        checksum: entry.checksum,
+        applied_at: entry.applied_at,
+    };
+    return migration.checksum === migrationInventoryChecksum(migration) ? migration : null;
+}
+
+function compareMigrationInventoryEntries(left: MigrationInventoryEntry, right: MigrationInventoryEntry): number {
+    const leftVersion = BigInt(left.version);
+    const rightVersion = BigInt(right.version);
+    if (leftVersion !== rightVersion) return leftVersion < rightVersion ? -1 : 1;
+    if (left.name === right.name) return 0;
+    if (left.name === null) return -1;
+    if (right.name === null) return 1;
+    return left.name < right.name ? -1 : 1;
+}
+
+function migrationInventory(payload: unknown): MigrationInventoryEntry[] | null {
+    if (!Array.isArray(payload)) return null;
+    const inventory: MigrationInventoryEntry[] = [];
+    const identities = new Set<string>();
+    for (const rawEntry of payload) {
+        const entry = migrationInventoryEntry(rawEntry);
+        if (!entry) return null;
+        const identity = JSON.stringify([entry.version, entry.name]);
+        if (identities.has(identity)) return null;
+        identities.add(identity);
+        inventory.push(entry);
+    }
+    return inventory.sort(compareMigrationInventoryEntries);
+}
+
+function migrationInventoryFailure(code: "HTTP_ERROR" | "INVALID_RESPONSE", httpStatus: number | null): DatabaseToolResponse {
+    return {
+        isError: true,
+        content: [{
+            type: "text",
+            text: JSON.stringify({
+                ok: false,
+                operation: "database.migration_inventory",
+                error: { code, http_status: httpStatus },
+            }, null, 2),
+        }],
+    };
+}
+
+function migrationInventoryResponse(response: HttpResult<unknown>): DatabaseToolResponse {
+    if (!response.ok) {
+        return migrationInventoryFailure("HTTP_ERROR", response.transportError ? null : response.status);
+    }
+    const inventory = migrationInventory(response.data);
+    if (!inventory) return migrationInventoryFailure("INVALID_RESPONSE", response.status);
+    return { content: [{ type: "text", text: JSON.stringify(inventory, null, 2) }] };
 }
 
 function readMigrationFile(dir: string, file: string): MigrationFile {
@@ -194,7 +316,7 @@ export function registerDatabaseTools(
         "list_extensions", "rls_status", "rls_policies",
         "list_auth_users", "get_auth_user",
         "connections", "stats", "slow_queries",
-        "list_migrations", "project_url", "generate_types",
+        "list_migrations", "migration_inventory", "project_url", "generate_types",
     ] as const;
     const writeActions = ["apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"] as const;
     const allActions = readOnly ? actions : [...actions, ...writeActions];
@@ -339,6 +461,13 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     const r = await execSql(`SELECT version, applied_at FROM schema_migrations ORDER BY version DESC LIMIT 50;`);
                     text = r.ok ? formatMigrations(r.data) : `❌ Failed (${r.status})`;
                     break;
+                }
+                case "migration_inventory": {
+                    const response = await http.get(
+                        `/v1/projects/${ref}/database/migrations`,
+                        { maxResponseBytes: MAX_MIGRATION_INVENTORY_BYTES },
+                    );
+                    return migrationInventoryResponse(response);
                 }
                 case "project_url": {
                     const r = await http.get(`/v1/projects/${ref}`);

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import { Type } from "@sinclair/typebox";
+import { projectRefPathSegment } from "../project-ref";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { HttpResult, HttpTransport } from "../transports/http";
 
@@ -104,26 +105,26 @@ function migrationInventoryEntry(rawEntry: unknown): MigrationInventoryEntry | n
 function compareMigrationInventoryEntries(left: MigrationInventoryEntry, right: MigrationInventoryEntry): number {
     const leftVersion = BigInt(left.version);
     const rightVersion = BigInt(right.version);
-    if (leftVersion !== rightVersion) return leftVersion < rightVersion ? -1 : 1;
-    if (left.name === right.name) return 0;
-    if (left.name === null) return -1;
-    if (right.name === null) return 1;
-    return left.name < right.name ? -1 : 1;
+    if (leftVersion === rightVersion) return 0;
+    return leftVersion < rightVersion ? -1 : 1;
 }
 
 function migrationInventory(payload: unknown): MigrationInventoryEntry[] | null {
     if (!Array.isArray(payload)) return null;
     const inventory: MigrationInventoryEntry[] = [];
-    const identities = new Set<string>();
+    const versions = new Set<string>();
     for (const rawEntry of payload) {
         const entry = migrationInventoryEntry(rawEntry);
         if (!entry) return null;
-        const identity = JSON.stringify([entry.version, entry.name]);
-        if (identities.has(identity)) return null;
-        identities.add(identity);
+        if (versions.has(entry.version)) return null;
+        versions.add(entry.version);
         inventory.push(entry);
     }
     return inventory.sort(compareMigrationInventoryEntries);
+}
+
+function migrationInventoryPath(ref: unknown): string {
+    return `/v1/projects/${projectRefPathSegment(ref, "migration_inventory")}/database/migrations`;
 }
 
 function migrationInventoryFailure(code: "HTTP_ERROR" | "INVALID_RESPONSE", httpStatus: number | null): DatabaseToolResponse {
@@ -464,7 +465,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                 }
                 case "migration_inventory": {
                     const response = await http.get(
-                        `/v1/projects/${ref}/database/migrations`,
+                        migrationInventoryPath(ref),
                         { maxResponseBytes: MAX_MIGRATION_INVENTORY_BYTES },
                     );
                     return migrationInventoryResponse(response);

--- a/packages/cli/src/shared/tools/scheduled-function-tools.ts
+++ b/packages/cli/src/shared/tools/scheduled-function-tools.ts
@@ -3,6 +3,7 @@ import { readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { Type } from "@sinclair/typebox";
+import { projectRefPathSegment } from "../project-ref";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
 import type { HttpResult, HttpTransport } from "../transports/http";
@@ -74,7 +75,6 @@ const FORBIDDEN_HEADER_NAMES = new Set([
     "via",
     "x-project-ref",
 ]);
-const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const SCHEDULE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const SAFE_SLUG_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const CRON_PART_PATTERN = /^(\*|([0-9]+)(?:-([0-9]+))?)(?:\/([0-9]+))?$/;
@@ -292,11 +292,11 @@ function assertActionArguments(action: ScheduledFunctionAction, args: Record<str
 }
 
 function schedulePath(ref: string, scheduleId?: string): string {
-    if (!PROJECT_REF_PATTERN.test(ref)) throw new Error("'ref' is invalid for Scheduled Functions");
+    const projectRefSegment = projectRefPathSegment(ref, "Scheduled Functions");
     if (scheduleId !== undefined && !SCHEDULE_ID_PATTERN.test(scheduleId)) {
         throw new Error("'schedule_id' is invalid");
     }
-    const root = `/v1/projects/${encodeURIComponent(ref)}/scheduled-functions`;
+    const root = `/v1/projects/${projectRefSegment}/scheduled-functions`;
     return scheduleId ? `${root}/${encodeURIComponent(scheduleId)}` : root;
 }
 


### PR DESCRIPTION
## Summary

- add the read-only `database migration_inventory` action over the canonical project migration endpoint
- validate and project the complete migration contract, reject duplicate identities and checksum/count drift, then emit stable JSON
- fail closed without reflecting HTTP response bodies or credentials while preserving legacy `list_migrations`

## Verification

- `bun test` (327 pass, 0 fail)
- `bun run typecheck`
- `bun run build`
- `git diff --check origin/main...HEAD`
- clean-code-guard: clean

No package publication or deployment is included.