### PR TITLE
feat(admin): gate production writes by environment

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -6,11 +6,51 @@ Platform administration CLI for SupaCloud operators.
 
 Typical environment variables:
 
+- `SUPACLOUD_ENV` — environment identity such as `test` or `production`
+- `SUPACLOUD_READ_ONLY=true` — block every remote write
 - `SUPACLOUD_HOST`
 - `SUPACLOUD_SSH_KEY` or `SUPACLOUD_SSH_PASS`
 - `SUPACLOUD_SSH_HOST_FINGERPRINT` — required for SSH actions, in OpenSSH `SHA256:<base64>` form
 - `SUPACLOUD_API_URL`
 - `SUPACLOUD_API_TOKEN`
+
+## Environment selection and production confirmation
+
+Use `--env <name>` to load `.env.supacloud.<name>` from the current directory,
+or `--env-file <path>` to load one exact file. An explicit file must declare
+`SUPACLOUD_ENV`; a named file may also declare it, but the declared value must
+match the selector. Global flags may appear before or after the command.
+
+Selected files are atomic context sources: Admin does not fill missing API,
+project, SSH, credential, or safety values from the process environment or a
+different dotenv file. Without a selector, a complete process context declaring
+`SUPACLOUD_ENV` is used as one source. If that process context is incomplete,
+`SUPACLOUD_ENV` selects `.env.supacloud.<value>` instead. The legacy `.env`
+fallback remains available only when no Admin context variables are present in
+the process.
+
+Production writes require `--confirm-production` before any HTTP or SSH action:
+
+- Project-scoped writes use the exact requested project ref. If the selected
+  profile declares `SUPACLOUD_PROJECT_REF`, an explicit different ref is
+  rejected for both reads and writes.
+- Platform API writes that genuinely have no project ref use
+  `platform:<API host>`, for example `platform:management.example.com`.
+- SSH writes that genuinely have no project ref use `host:<SSH host[:port]>`,
+  for example `host:production.example.com:2201`.
+
+A generic value such as `production` is never accepted. Project-scoped actions
+that omit a required ref do not fall back to a platform or host confirmation.
+`SUPACLOUD_READ_ONLY=true` blocks every remote write in every environment.
+
+```bash
+npx @supacloud/admin --env test status
+npx @supacloud/admin --env production project delete \
+  --ref abc123 --confirm-production abc123
+npx @supacloud/admin --env production ssh upgrade \
+  --version 0.50.31 --edge_runtime_version 0.16.8 \
+  --confirm-production host:production.example.com:2201
+```
 
 SSH host keys are fail-closed: setting `SUPACLOUD_HOST` and credentials is not
 enough to enable SSH actions. Obtain the fingerprint through a trusted channel,

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -17,9 +17,9 @@ Typical environment variables:
 ## Environment selection and production confirmation
 
 Use `--env <name>` to load `.env.supacloud.<name>` from the current directory,
-or `--env-file <path>` to load one exact file. An explicit file must declare
-`SUPACLOUD_ENV`; a named file may also declare it, but the declared value must
-match the selector. Global flags may appear before or after the command.
+or `--env-file <path>` to load one exact file. Every selected file must declare
+`SUPACLOUD_ENV`; a named file's declared value must match the selector. Global
+flags may appear before or after the command.
 
 Selected files are atomic context sources: Admin does not fill missing API,
 project, SSH, credential, or safety values from the process environment or a
@@ -41,7 +41,14 @@ Production writes require `--confirm-production` before any HTTP or SSH action:
 
 A generic value such as `production` is never accepted. Project-scoped actions
 that omit a required ref do not fall back to a platform or host confirmation.
-`SUPACLOUD_READ_ONLY=true` blocks every remote write in every environment.
+`SUPACLOUD_READ_ONLY=true` blocks every remote write in every environment,
+including when it is set only in the process environment. Remote writes also
+require an explicit `SUPACLOUD_ENV`; unclassified process and legacy dotenv
+contexts remain usable for read-only actions but cannot mutate remote state.
+
+Management API URLs must be origin-and-path URLs without credentials, query
+strings, or fragments. This prevents URL-embedded secrets from being sent to a
+remote target or displayed by `status` and `--help`.
 
 ```bash
 npx @supacloud/admin --env test status

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -365,6 +365,107 @@ describe("supacloud-admin process contract", () => {
         }
     });
 
+    test("keeps a process read-only guard when a named profile is selected", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-process-read-only-"));
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        writeFileSync(join(workspace, ".env.supacloud.test"), [
+            "SUPACLOUD_ENV=test",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=profile-secret-token",
+            "SUPACLOUD_PROJECT_REF=test-ref",
+        ].join("\n") + "\n");
+
+        try {
+            const execution = await runAdminCli([
+                "project", "delete", "--ref", "test-ref", "--env", "test",
+            ], { SUPACLOUD_READ_ONLY: "true" }, workspace);
+
+            expect(execution.exitCode).toBe(1);
+            expect(execution.output).toContain("SUPACLOUD_READ_ONLY=true");
+            expect(execution.output).not.toContain("profile-secret-token");
+            expect(requestCount).toBe(0);
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects unclassified process and legacy dotenv writes before HTTP", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-unclassified-write-"));
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        writeFileSync(join(workspace, ".env"), [
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=legacy-secret-token",
+            "SUPACLOUD_PROJECT_REF=legacy-ref",
+        ].join("\n") + "\n");
+
+        try {
+            const processContext = await runAdminCli([
+                "project", "delete", "--ref", "process-ref",
+            ], {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "process-secret-token",
+            }, workspace);
+            const legacyContext = await runAdminCli([
+                "project", "delete", "--ref", "legacy-ref",
+            ], {}, workspace);
+
+            for (const execution of [processContext, legacyContext]) {
+                expect(execution.exitCode).toBe(1);
+                expect(execution.output).toContain("requires an explicit SUPACLOUD_ENV");
+                expect(execution.output).not.toContain("process-secret-token");
+                expect(execution.output).not.toContain("legacy-secret-token");
+            }
+            expect(requestCount).toBe(0);
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects API URL query strings and fragments without reflecting them in status or help", async () => {
+        for (const apiUrl of [
+            "https://management.example.com/?query-secret",
+            "https://management.example.com/#fragment-secret",
+        ]) {
+            const [status, help] = await Promise.all([
+                runAdminCli(["status"], {
+                    SUPACLOUD_API_URL: apiUrl,
+                    SUPACLOUD_API_TOKEN: "api-secret-token",
+                }),
+                runAdminCli(["--help"], {
+                    SUPACLOUD_API_URL: apiUrl,
+                    SUPACLOUD_API_TOKEN: "api-secret-token",
+                }),
+            ]);
+
+            expect(status.exitCode).toBe(0);
+            expect(JSON.parse(status.output)).toMatchObject({ apiUrl: null, hasApiToken: true });
+            expect(help.exitCode).toBe(0);
+            for (const execution of [status, help]) {
+                expect(execution.output).not.toContain("query-secret");
+                expect(execution.output).not.toContain("fragment-secret");
+                expect(execution.output).not.toContain("api-secret-token");
+            }
+        }
+    });
+
     test("binds ref-less production writes to the exact API host", async () => {
         const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-production-platform-"));
         let requestCount = 0;
@@ -481,6 +582,7 @@ describe("supacloud-admin process contract", () => {
                 "--service", "gotrue",
                 "--service_action", "stop",
             ], {
+                SUPACLOUD_ENV: "test",
                 SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
                 SUPACLOUD_API_TOKEN: fixtureToken,
             });
@@ -554,6 +656,7 @@ describe("supacloud-admin process contract", () => {
                 "--service", "gotrue",
                 "--service_action", "stop",
             ], {
+                SUPACLOUD_ENV: "test",
                 SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
                 SUPACLOUD_API_TOKEN: fixtureToken,
             });
@@ -589,6 +692,7 @@ describe("supacloud-admin process contract", () => {
             const execution = await runAdminCli(
                 ["project", "create", "--name", "rejected-project", "--domain", "invalid.example"],
                 {
+                    SUPACLOUD_ENV: "test",
                     SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
                     SUPACLOUD_API_TOKEN: "test-token",
                 },

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -599,6 +599,7 @@ describe("supacloud-admin process contract", () => {
             const execution = await runAdminCli([
                 "platform", "create_backup", "--ref", "fa_staging", "--backup_type", "full",
             ], {
+                SUPACLOUD_ENV: "test",
                 SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
                 SUPACLOUD_API_TOKEN: fixtureToken,
             });
@@ -651,6 +652,7 @@ describe("supacloud-admin process contract", () => {
             const execution = await runAdminCli([
                 "platform", "create_backup", "--ref", "fa_staging", "--backup_type", "full",
             ], {
+                SUPACLOUD_ENV: "test",
                 SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
                 SUPACLOUD_API_TOKEN: fixtureToken,
             });

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { fileURLToPath } from "node:url";
-import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import {
+    chmodSync,
+    copyFileSync,
+    mkdirSync,
+    mkdtempSync,
+    realpathSync,
+    rmSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createAdminTools } from "./index";
@@ -9,6 +18,7 @@ import { schemaEnumValues } from "./shared/schema";
 import packageMetadata from "../package.json" with { type: "json" };
 
 const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const ADMIN_ENTRYPOINT = join(PACKAGE_ROOT, "src/index.ts");
 const ADMIN_CONTEXT_KEYS = new Set([
     "SUPABASE_URL",
     "SUPABASE_SERVICE_ROLE_KEY",
@@ -22,6 +32,10 @@ const ADMIN_CONTEXT_KEYS = new Set([
     "SUPACLOUD_SSH_KEY",
     "SUPACLOUD_SSH_PASS",
     "SUPACLOUD_SSH_HOST_FINGERPRINT",
+    "SUPACLOUD_SSH_USER",
+    "SUPACLOUD_SSH_PORT",
+    "SUPACLOUD_ENV",
+    "SUPACLOUD_READ_ONLY",
 ]);
 
 function cleanEnvironment(overrides: Record<string, string> = {}): Record<string, string> {
@@ -35,9 +49,10 @@ function cleanEnvironment(overrides: Record<string, string> = {}): Record<string
 async function runAdminCli(
     args: string[],
     overrides: Record<string, string> = {},
+    workingDirectory: string = PACKAGE_ROOT,
 ): Promise<{ exitCode: number; output: string }> {
-    const processHandle = Bun.spawn([process.execPath, "src/index.ts", ...args], {
-        cwd: PACKAGE_ROOT,
+    const processHandle = Bun.spawn([process.execPath, ADMIN_ENTRYPOINT, ...args], {
+        cwd: workingDirectory,
         env: cleanEnvironment(overrides),
         stdout: "pipe",
         stderr: "pipe",
@@ -140,9 +155,12 @@ const baseContext = {
     apiToken: "api-token",
     projectRef: "",
     readOnly: false,
+    environment: "",
+    production: false,
     inferredSupabaseUrl: "",
     inferredServiceRoleKey: "",
-    source: "env" as const,
+    source: "process_env" as const,
+    sourcePath: null,
 };
 
 describe("admin SSH registration gate", () => {
@@ -155,7 +173,7 @@ describe("admin SSH registration gate", () => {
     test("does not register executable SSH tools without a verified host fingerprint", () => {
         const tools = createAdminTools(baseContext);
         expect(tools.project.schema.name).toBeDefined();
-        expect(tools.ssh.schema.command).toBeUndefined();
+        expect(tools.ssh.schema.command).toBeDefined();
         return tools.ssh.callback({ action: "ping" }).then((result) => {
             expect(result.content[0]?.text).toContain("SUPACLOUD_SSH_HOST_FINGERPRINT");
         });
@@ -181,6 +199,18 @@ describe("supacloud-admin process contract", () => {
 
         expect(execution.exitCode).toBe(0);
         expect(execution.output.trim()).toBe(packageMetadata.version);
+    });
+
+    test("documents environment selection and production confirmation", async () => {
+        const execution = await runAdminCli(["--help"]);
+
+        expect(execution.exitCode).toBe(0);
+        expect(execution.output).toContain("--env <name>");
+        expect(execution.output).toContain("--env-file <path>");
+        expect(execution.output).toContain("--confirm-production <target>");
+        expect(execution.output).toContain("SUPACLOUD_READ_ONLY=true");
+        expect(execution.output).toContain("platform:<API host>");
+        expect(execution.output).toContain("host:<SSH host[:port]>");
     });
 
     test("runs through an npm-style bin symlink", async () => {
@@ -216,6 +246,167 @@ describe("supacloud-admin process contract", () => {
             expect(execution.output.trim()).toBe(packageMetadata.version);
         } finally {
             rmSync(sandbox, { recursive: true, force: true });
+        }
+    });
+
+    test("loads one named environment source and keeps status secret-free", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-named-env-"));
+        const environmentPath = join(workspace, ".env.supacloud.test");
+        writeFileSync(environmentPath, [
+            "SUPACLOUD_ENV=test",
+            "SUPACLOUD_API_URL=https://management.test.example.com",
+            "SUPACLOUD_API_TOKEN=file-secret-token",
+            "SUPACLOUD_PROJECT_REF=test-ref",
+        ].join("\n") + "\n");
+
+        try {
+            const execution = await runAdminCli(["status", "--env=test"], {
+                SUPACLOUD_API_TOKEN: "process-secret-token",
+            }, workspace);
+            const status = JSON.parse(execution.output);
+
+            expect(execution.exitCode).toBe(0);
+            expect(status).toMatchObject({
+                environment: "test",
+                production: false,
+                readOnly: false,
+                source: { kind: "named_env_file", path: realpathSync(environmentPath) },
+                apiUrl: "https://management.test.example.com",
+                hasApiToken: true,
+            });
+            expect(execution.output).not.toContain("file-secret-token");
+            expect(execution.output).not.toContain("process-secret-token");
+        } finally {
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
+    test("requires exact production project confirmation before HTTP and rejects cross-ref writes", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-production-project-"));
+        const requestedPaths: string[] = [];
+        const authorizationHeaders: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requestedPaths.push(new URL(request.url).pathname);
+                authorizationHeaders.push(request.headers.get("authorization") || "");
+                return Response.json({ deleted: true });
+            },
+        });
+        writeFileSync(join(workspace, ".env.supacloud.production"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=file-production-token",
+            "SUPACLOUD_PROJECT_REF=prod-ref",
+        ].join("\n") + "\n");
+
+        try {
+            const unconfirmed = await runAdminCli([
+                "project", "delete", "--ref", "prod-ref", "--env", "production",
+            ], { SUPACLOUD_API_TOKEN: "process-production-token" }, workspace);
+            const crossRef = await runAdminCli([
+                "project", "delete", "--ref", "other-ref", "--env=production",
+                "--confirm-production", "other-ref",
+            ], {}, workspace);
+            const confirmed = await runAdminCli([
+                "--confirm-production=prod-ref", "project", "delete", "--ref", "prod-ref",
+                "--env", "production",
+            ], {}, workspace);
+
+            expect(unconfirmed.exitCode).toBe(1);
+            expect(unconfirmed.output).toContain("--confirm-production prod-ref");
+            expect(crossRef.exitCode).toBe(1);
+            expect(crossRef.output).toContain("different project ref");
+            expect(confirmed.exitCode).toBe(0);
+            expect(requestedPaths).toEqual(["/v1/projects/prod-ref"]);
+            expect(authorizationHeaders).toEqual(["Bearer file-production-token"]);
+            for (const execution of [unconfirmed, crossRef, confirmed]) {
+                expect(execution.output).not.toContain("file-production-token");
+                expect(execution.output).not.toContain("process-production-token");
+            }
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
+    test("blocks read-only writes before HTTP without reflecting credentials", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-read-only-"));
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        writeFileSync(join(workspace, ".env.supacloud.audit"), [
+            "SUPACLOUD_ENV=audit",
+            "SUPACLOUD_READ_ONLY=true",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=read-only-secret-token",
+            "SUPACLOUD_PROJECT_REF=audit-ref",
+        ].join("\n") + "\n");
+
+        try {
+            const execution = await runAdminCli([
+                "project", "delete", "--ref", "audit-ref", "--env", "audit",
+            ], {}, workspace);
+
+            expect(execution.exitCode).toBe(1);
+            expect(execution.output).toContain("SUPACLOUD_READ_ONLY=true");
+            expect(execution.output).not.toContain("read-only-secret-token");
+            expect(requestCount).toBe(0);
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
+    test("binds ref-less production writes to the exact API host", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-production-platform-"));
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({ ref: "created-ref" });
+            },
+        });
+        writeFileSync(join(workspace, ".env.supacloud.production"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=platform-production-token",
+        ].join("\n") + "\n");
+        const confirmationTarget = `platform:127.0.0.1:${server.port}`;
+
+        try {
+            const unconfirmed = await runAdminCli([
+                "project", "create", "--name", "staging", "--env", "production",
+            ], {}, workspace);
+            const genericConfirmation = await runAdminCli([
+                "project", "create", "--name", "staging", "--env", "production",
+                "--confirm-production", "production",
+            ], {}, workspace);
+            const confirmed = await runAdminCli([
+                "project", "create", "--name", "staging", "--env", "production",
+                "--confirm-production", confirmationTarget,
+            ], {}, workspace);
+
+            expect(unconfirmed.exitCode).toBe(1);
+            expect(unconfirmed.output).toContain(`--confirm-production ${confirmationTarget}`);
+            expect(genericConfirmation.exitCode).toBe(1);
+            expect(confirmed.exitCode).toBe(0);
+            expect(requestCount).toBe(1);
+            for (const execution of [unconfirmed, genericConfirmation, confirmed]) {
+                expect(execution.output).not.toContain("platform-production-token");
+            }
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
         }
     });
 

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-import { Type } from "@sinclair/typebox";
-import { stringEnum } from "./shared/schema";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { realpathSync } from "node:fs";
 import { cliToolResultIsError, runCli } from "./shared/cli";
 import { resolveSupaCloudContext, type ResolvedContext } from "./shared/context";
+import { parseGlobalAdminOptions } from "./shared/global-options";
+import { authorizeExecution, validateExecutionPolicyCoverage } from "./shared/execution-policy";
 import { HttpTransport } from "./shared/transports/http";
 import { SshTransport } from "./shared/transports/ssh";
 import { registerSshTools } from "./shared/tools/ssh-tools";
@@ -17,17 +17,6 @@ import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
 type ToolMap = Record<string, ToolEntry>;
-
-const platformActionSchema = stringEnum([
-    "metrics", "list_backups", "create_backup",
-    "network", "update_network",
-    "list_orgs", "get_org",
-]);
-const sshActionSchema = stringEnum([
-    "ping", "setup", "install", "upgrade", "versions", "diagnose", "exec",
-    "troubleshoot", "container_logs",
-    "tenant_manage", "tenant_list", "tenant_inspect", "tenant_diagnose", "tenant_migrate",
-]);
 
 function captureTools(register: (server: { tool: (...args: any[]) => void }) => void): ToolMap {
     const tools: ToolMap = {};
@@ -44,6 +33,42 @@ function captureTools(register: (server: { tool: (...args: any[]) => void }) => 
     return tools;
 }
 
+function unavailableTool(schema: ToolEntry["schema"], message: string): ToolEntry {
+    return {
+        schema,
+        callback: async () => ({
+            isError: true,
+            content: [{ type: "text" as const, text: message }],
+        }),
+    };
+}
+
+function unavailableAdminSchemas(): Record<"project" | "platform" | "gateway" | "ssh", ToolEntry["schema"]> {
+    const schemaOnlyHttp = {} as HttpTransport;
+    return {
+        project: captureTools((server) =>
+            registerAdminProjectCliTools(server as any, schemaOnlyHttp)).project.schema,
+        platform: captureTools((server) =>
+            registerAdvancedTools(server as any, schemaOnlyHttp)).platform.schema,
+        gateway: captureTools((server) =>
+            registerGatewayTools(server as any, schemaOnlyHttp)).gateway.schema,
+        ssh: captureTools((server) =>
+            registerSshTools(server as any, {} as SshTransport)).ssh.schema,
+    };
+}
+
+function registerUnavailableAdminTools(tools: ToolMap): void {
+    const schemas = unavailableAdminSchemas();
+    tools.project = unavailableTool(schemas.project,
+        "⚠️ Project lifecycle commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN.");
+    tools.platform = unavailableTool(schemas.platform,
+        "⚠️ Platform commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN.");
+    tools.ssh = unavailableTool(schemas.ssh,
+        "⚠️ SSH commands require SUPACLOUD_HOST, SSH credentials, and SUPACLOUD_SSH_HOST_FINGERPRINT.");
+    tools.gateway = unavailableTool(schemas.gateway,
+        "⚠️ Gateway / Caddy commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN (admin privileges).");
+}
+
 function printHelp(context = resolveSupaCloudContext()) {
     console.error(`
 ╔═══════════════════════════════════════════════════════════╗
@@ -53,10 +78,19 @@ function printHelp(context = resolveSupaCloudContext()) {
 
 USAGE
 
-  supacloud-admin <module> <action> [--flags]
-  supacloud-admin status
+  supacloud-admin [global flags] <module> <action> [--flags]
+  supacloud-admin [global flags] status
   supacloud-admin --help
   supacloud-admin --version
+
+GLOBAL FLAGS
+
+  --env <name>                    Load .env.supacloud.<name> from the current directory.
+  --env-file <path>               Load an exact file that declares SUPACLOUD_ENV.
+  --confirm-production <target>   Confirm the exact production project or platform target.
+
+  Global flags may appear before or after the command. --env and --env-file are
+  mutually exclusive, and a selected source is never mixed with another source.
 
 EXPECTED CONTEXT
 
@@ -66,9 +100,17 @@ EXPECTED CONTEXT
     SUPACLOUD_SSH_HOST_FINGERPRINT=SHA256:...
     SUPACLOUD_API_URL
     SUPACLOUD_API_TOKEN
+    SUPACLOUD_ENV
+    SUPACLOUD_READ_ONLY
 
+  Environment: ${context.environment || "(unclassified)"}
+  Context source: ${context.source}${context.sourcePath ? ` (${context.sourcePath})` : ""}
   Detected host: ${context.host || "(none)"}
   Detected API URL: ${context.apiUrl || "(none)"}
+
+  SUPACLOUD_READ_ONLY=true blocks every remote write. Production project writes
+  require the exact project ref. Production writes without a project ref use
+  platform:<API host> or host:<SSH host[:port]> as the confirmation target.
 
 EXAMPLES
 
@@ -88,7 +130,26 @@ EXAMPLES
 `);
 }
 
-export function createAdminTools(context: ResolvedContext = resolveSupaCloudContext()): ToolMap {
+function authorizedToolMap(
+    tools: ToolMap,
+    context: ResolvedContext,
+    confirmProduction?: string,
+): ToolMap {
+    validateExecutionPolicyCoverage(tools);
+    for (const [moduleName, tool] of Object.entries(tools)) {
+        const callback = tool.callback;
+        tool.callback = async (args: Record<string, unknown>) => {
+            authorizeExecution(moduleName, args, { context, confirmProduction });
+            return callback(args);
+        };
+    }
+    return tools;
+}
+
+export function createAdminTools(
+    context: ResolvedContext = resolveSupaCloudContext(),
+    confirmProduction?: string,
+): ToolMap {
     const tools: ToolMap = {
         status: {
             schema: {},
@@ -104,7 +165,10 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
                                 hasApiToken: Boolean(context.apiToken),
                                 hasSshKey: Boolean(context.sshKey),
                                 hasSshHostFingerprint: Boolean(context.sshHostFingerprint),
-                                source: context.source,
+                                environment: context.environment || null,
+                                production: context.production,
+                                readOnly: context.readOnly,
+                                source: { kind: context.source, path: context.sourcePath },
                             },
                             null,
                             2,
@@ -115,61 +179,7 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
         },
     };
 
-    const registerAdminHelp = () => {
-        const projectHelpTool = captureTools((server) =>
-            registerAdminProjectCliTools(server as any, {} as HttpTransport)
-        ).project;
-        tools.project = {
-            schema: projectHelpTool.schema,
-            callback: async () => ({
-                isError: true,
-                content: [
-                    {
-                        type: "text" as const,
-                        text: "⚠️ Project lifecycle commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN.",
-                    },
-                ],
-            }),
-        };
-        tools.platform = {
-            schema: { action: platformActionSchema },
-            callback: async () => ({
-                isError: true,
-                content: [
-                    {
-                        type: "text" as const,
-                        text: "⚠️ Platform commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN.",
-                    },
-                ],
-            }),
-        };
-        tools.ssh = {
-            schema: { action: sshActionSchema },
-            callback: async () => ({
-                isError: true,
-                content: [
-                    {
-                        type: "text" as const,
-                        text: "⚠️ SSH commands require SUPACLOUD_HOST, SSH credentials, and SUPACLOUD_SSH_HOST_FINGERPRINT.",
-                    },
-                ],
-            }),
-        };
-        tools.gateway = {
-            schema: { action: Type.String() },
-            callback: async () => ({
-                isError: true,
-                content: [
-                    {
-                        type: "text" as const,
-                        text: "⚠️ Gateway / Caddy commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN (admin privileges).",
-                    },
-                ],
-            }),
-        };
-    };
-
-    registerAdminHelp();
+    registerUnavailableAdminTools(tools);
 
     if (context.host && context.sshHostFingerprint) {
         try {
@@ -185,7 +195,7 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             tools.ssh = {
-                schema: { action: sshActionSchema },
+                schema: tools.ssh.schema,
                 callback: async () => ({
                     isError: true,
                     content: [{
@@ -197,7 +207,7 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
         }
     } else if (context.host) {
         tools.ssh = {
-            schema: { action: sshActionSchema },
+            schema: tools.ssh.schema,
             callback: async () => ({
                 isError: true,
                 content: [{
@@ -251,33 +261,40 @@ export function createAdminTools(context: ResolvedContext = resolveSupaCloudCont
         };
     }
 
-    return tools;
+    return authorizedToolMap(tools, context, confirmProduction);
 }
 
 async function main() {
-    const args = process.argv.slice(2);
-    if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
-        printHelp();
-        process.exit(0);
-    }
-    if (args.length === 1 && args[0] === "--version") {
+    const rawArgs = process.argv.slice(2);
+    if (rawArgs.length === 1 && rawArgs[0] === "--version") {
         console.log(packageMetadata.version);
         return;
     }
+    const globalOptions = parseGlobalAdminOptions(rawArgs);
+    const args = globalOptions.args;
+    const context = resolveSupaCloudContext(process.env, process.cwd(), {
+        environmentName: globalOptions.environmentName,
+        envFile: globalOptions.envFile,
+    });
+    if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+        printHelp(context);
+        process.exitCode = 0;
+        return;
+    }
 
-    const cliTools = createAdminTools();
+    const cliTools = createAdminTools(context, globalOptions.confirmProduction);
     if (args.length === 1 && cliTools[args[0]]) {
-        const result = await cliTools[args[0]].callback({});
-        if (result?.content && Array.isArray(result.content)) {
-            for (const chunk of result.content) {
+        const toolResponse = await cliTools[args[0]].callback({});
+        if (toolResponse?.content && Array.isArray(toolResponse.content)) {
+            for (const chunk of toolResponse.content) {
                 if (chunk.type === "text") {
                     console.log(chunk.text);
                 }
             }
         } else {
-            console.log(JSON.stringify(result, null, 2));
+            console.log(JSON.stringify(toolResponse, null, 2));
         }
-        if (cliToolResultIsError(result)) process.exitCode = 1;
+        if (cliToolResultIsError(toolResponse)) process.exitCode = 1;
         return;
     }
     await runCli(cliTools, args, { commandName: "supacloud-admin" });

--- a/packages/admin/src/shared/context.test.ts
+++ b/packages/admin/src/shared/context.test.ts
@@ -76,7 +76,7 @@ describe("resolveSupaCloudContext", () => {
             apiToken: "file-api-token",
             sshPass: "file-ssh-password",
             projectRef: "test-ref",
-            readOnly: false,
+            readOnly: true,
         });
     });
 
@@ -119,6 +119,7 @@ describe("resolveSupaCloudContext", () => {
     test("uses SUPACLOUD_ENV as a named selector when process context is incomplete", () => {
         const workspace = temporaryWorkspace();
         writeEnvironment(workspace, ".env.supacloud.test", {
+            SUPACLOUD_ENV: "test",
             SUPACLOUD_API_URL: "https://test.example.com",
             SUPACLOUD_API_TOKEN: "file-token",
         });
@@ -132,10 +133,16 @@ describe("resolveSupaCloudContext", () => {
         expect(context.apiToken).toBe("file-token");
     });
 
-    test("rejects selector drift and unsafe environment names", () => {
+    test("requires selected profiles to declare a matching environment", () => {
         const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env.supacloud.audit", {
+            SUPACLOUD_API_URL: "https://management.example.com",
+            SUPACLOUD_API_TOKEN: "file-token",
+        });
         writeEnvironment(workspace, ".env.supacloud.test", { SUPACLOUD_ENV: "production" });
 
+        expect(() => resolveSupaCloudContext({}, workspace, { environmentName: "audit" }))
+            .toThrow("SUPACLOUD_ENV is required");
         expect(() => resolveSupaCloudContext({}, workspace, { environmentName: "test" }))
             .toThrow("does not match selector test");
         expect(() => resolveSupaCloudContext({ SUPACLOUD_ENV: "../production" }, workspace))
@@ -159,7 +166,7 @@ describe("resolveSupaCloudContext", () => {
         expect(context.projectRef).toBe("");
     });
 
-    test("rejects ambiguous SSH ports and credential-bearing management URLs", () => {
+    test("rejects ambiguous SSH ports and unsafe management URL components", () => {
         expect(() => resolveSupaCloudContext({
             SUPACLOUD_HOST: "server.example.com",
             SUPACLOUD_SSH_PORT: "2201junk",
@@ -169,11 +176,19 @@ describe("resolveSupaCloudContext", () => {
             SUPACLOUD_SSH_PORT: "65536",
         }, "/nonexistent")).toThrow("SUPACLOUD_SSH_PORT must be an integer");
 
-        const credentialUrl = resolveSupaCloudContext({
-            SUPACLOUD_API_URL: "https://operator:url-secret@management.example.com",
-            SUPACLOUD_API_TOKEN: "api-token",
-        }, "/nonexistent");
-        expect(credentialUrl.apiUrl).toBe("");
-        expect(JSON.stringify(credentialUrl)).not.toContain("url-secret");
+        for (const apiUrl of [
+            "https://operator:url-secret@management.example.com",
+            "https://management.example.com/?query-secret",
+            "https://management.example.com/#fragment-secret",
+        ]) {
+            const unsafeUrl = resolveSupaCloudContext({
+                SUPACLOUD_API_URL: apiUrl,
+                SUPACLOUD_API_TOKEN: "api-token",
+            }, "/nonexistent");
+            expect(unsafeUrl.apiUrl).toBe("");
+            expect(JSON.stringify(unsafeUrl)).not.toContain("url-secret");
+            expect(JSON.stringify(unsafeUrl)).not.toContain("query-secret");
+            expect(JSON.stringify(unsafeUrl)).not.toContain("fragment-secret");
+        }
     });
 });

--- a/packages/admin/src/shared/context.test.ts
+++ b/packages/admin/src/shared/context.test.ts
@@ -1,16 +1,179 @@
-import { describe, expect, test } from "bun:test";
-
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { resolveSupaCloudContext } from "./context";
 
-describe("admin SSH context", () => {
-    test("reads the explicit host fingerprint without inferring an insecure default", () => {
-        const empty = resolveSupaCloudContext({ SUPACLOUD_HOST: "server.example.com" }, "/nonexistent");
-        expect(empty.sshHostFingerprint).toBe("");
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});
+
+function temporaryWorkspace(): string {
+    const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-context-"));
+    temporaryDirectories.push(workspace);
+    return workspace;
+}
+
+function writeEnvironment(
+    workspace: string,
+    filename: string,
+    environment: Record<string, string>,
+): string {
+    const path = join(workspace, filename);
+    const contents = Object.entries(environment)
+        .map(([key, environmentValue]) => `${key}=${environmentValue}`)
+        .join("\n");
+    writeFileSync(path, `${contents}\n`);
+    return path;
+}
+
+describe("resolveSupaCloudContext", () => {
+    test("reads a complete SSH process context without inferring a fingerprint", () => {
+        const missingFingerprint = resolveSupaCloudContext({
+            SUPACLOUD_HOST: "server.example.com",
+        }, "/nonexistent");
+        expect(missingFingerprint.sshHostFingerprint).toBe("");
 
         const configured = resolveSupaCloudContext({
+            SUPACLOUD_ENV: "production",
             SUPACLOUD_HOST: "server.example.com",
             SUPACLOUD_SSH_HOST_FINGERPRINT: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
         }, "/nonexistent");
-        expect(configured.sshHostFingerprint).toBe("SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        expect(configured).toMatchObject({
+            host: "server.example.com",
+            environment: "production",
+            production: true,
+            source: "process_env",
+        });
+    });
+
+    test("strictly selects one named file without mixing process API or SSH secrets", () => {
+        const workspace = temporaryWorkspace();
+        const path = writeEnvironment(workspace, ".env.supacloud.test", {
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: "https://test-management.example.com",
+            SUPACLOUD_API_TOKEN: "file-api-token",
+            SUPACLOUD_PROJECT_REF: "test-ref",
+            SUPACLOUD_HOST: "test-host.example.com",
+            SUPACLOUD_SSH_PASS: "file-ssh-password",
+            SUPACLOUD_SSH_HOST_FINGERPRINT: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        });
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_TOKEN: "process-api-token",
+            SUPACLOUD_SSH_PASS: "process-ssh-password",
+            SUPACLOUD_READ_ONLY: "true",
+        }, workspace, { environmentName: "test" });
+
+        expect(context).toMatchObject({
+            source: "named_env_file",
+            sourcePath: path,
+            environment: "test",
+            apiToken: "file-api-token",
+            sshPass: "file-ssh-password",
+            projectRef: "test-ref",
+            readOnly: false,
+        });
+    });
+
+    test("requires an explicit file to declare its environment", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, "custom.env", {
+            SUPACLOUD_API_URL: "https://management.example.com",
+            SUPACLOUD_API_TOKEN: "file-token",
+        });
+
+        expect(() => resolveSupaCloudContext({}, workspace, { envFile: "custom.env" }))
+            .toThrow("SUPACLOUD_ENV is required");
+    });
+
+    test("loads quoted values from an explicit production file", () => {
+        const workspace = temporaryWorkspace();
+        const path = join(workspace, "production.env");
+        writeFileSync(path, [
+            'SUPACLOUD_ENV="production"',
+            "SUPACLOUD_API_URL='https://management.example.com/'",
+            'SUPACLOUD_API_TOKEN="file-token"',
+            "SUPACLOUD_PROJECT_REF='prod-ref'",
+        ].join("\n") + "\n");
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_TOKEN: "process-token",
+        }, workspace, { envFile: "production.env" });
+
+        expect(context).toMatchObject({
+            source: "explicit_env_file",
+            sourcePath: path,
+            environment: "production",
+            production: true,
+            apiUrl: "https://management.example.com",
+            apiToken: "file-token",
+            projectRef: "prod-ref",
+        });
+    });
+
+    test("uses SUPACLOUD_ENV as a named selector when process context is incomplete", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env.supacloud.test", {
+            SUPACLOUD_API_URL: "https://test.example.com",
+            SUPACLOUD_API_TOKEN: "file-token",
+        });
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_TOKEN: "partial-process-token",
+        }, workspace);
+
+        expect(context.source).toBe("named_env_file");
+        expect(context.apiToken).toBe("file-token");
+    });
+
+    test("rejects selector drift and unsafe environment names", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env.supacloud.test", { SUPACLOUD_ENV: "production" });
+
+        expect(() => resolveSupaCloudContext({}, workspace, { environmentName: "test" }))
+            .toThrow("does not match selector test");
+        expect(() => resolveSupaCloudContext({ SUPACLOUD_ENV: "../production" }, workspace))
+            .toThrow("must match");
+    });
+
+    test("does not combine partial process context with legacy dotenv", () => {
+        const workspace = temporaryWorkspace();
+        writeEnvironment(workspace, ".env", {
+            SUPACLOUD_API_TOKEN: "dotenv-token",
+            SUPACLOUD_PROJECT_REF: "dotenv-ref",
+        });
+
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_URL: "https://process.example.com",
+        }, workspace);
+
+        expect(context.source).toBe("process_env");
+        expect(context.apiUrl).toBe("https://process.example.com");
+        expect(context.apiToken).toBe("");
+        expect(context.projectRef).toBe("");
+    });
+
+    test("rejects ambiguous SSH ports and credential-bearing management URLs", () => {
+        expect(() => resolveSupaCloudContext({
+            SUPACLOUD_HOST: "server.example.com",
+            SUPACLOUD_SSH_PORT: "2201junk",
+        }, "/nonexistent")).toThrow("SUPACLOUD_SSH_PORT must be an integer");
+        expect(() => resolveSupaCloudContext({
+            SUPACLOUD_HOST: "server.example.com",
+            SUPACLOUD_SSH_PORT: "65536",
+        }, "/nonexistent")).toThrow("SUPACLOUD_SSH_PORT must be an integer");
+
+        const credentialUrl = resolveSupaCloudContext({
+            SUPACLOUD_API_URL: "https://operator:url-secret@management.example.com",
+            SUPACLOUD_API_TOKEN: "api-token",
+        }, "/nonexistent");
+        expect(credentialUrl.apiUrl).toBe("");
+        expect(JSON.stringify(credentialUrl)).not.toContain("url-secret");
     });
 });

--- a/packages/admin/src/shared/context.ts
+++ b/packages/admin/src/shared/context.ts
@@ -1,6 +1,19 @@
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { normalizeEnvironmentName } from "./global-options";
+
+export type ContextSourceKind =
+    | "process_env"
+    | "named_env_file"
+    | "explicit_env_file"
+    | "legacy_dotenv"
+    | "none";
+
+export interface ContextSelection {
+    environmentName?: string;
+    envFile?: string;
+}
 
 export interface ResolvedContext {
     host: string;
@@ -13,79 +26,100 @@ export interface ResolvedContext {
     apiToken: string;
     projectRef: string;
     readOnly: boolean;
+    environment: string;
+    production: boolean;
     inferredSupabaseUrl: string;
     inferredServiceRoleKey: string;
-    source: "env" | "dotenv" | "mixed" | "none";
+    source: ContextSourceKind;
+    sourcePath: string | null;
 }
 
-interface EnvLookupResult {
-    value: string;
-    source: "env" | "dotenv";
+interface ContextSource {
+    environment: Record<string, string>;
+    kind: ContextSourceKind;
+    path: string | null;
+    environmentName: string;
 }
 
-function readDotEnvFile(cwd: string): Record<string, string> {
-    const envPath = resolve(cwd, ".env");
-    if (!existsSync(envPath)) return {};
+const ADMIN_CONTEXT_KEYS = [
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPACLOUD_API_URL",
+    "SUPACLOUD_MANAGEMENT_API_URL",
+    "MANAGEMENT_API_URL",
+    "SUPACLOUD_API_TOKEN",
+    "SUPACLOUD_PROJECT_REF",
+    "X_PROJECT_REF",
+    "SUPACLOUD_HOST",
+    "SUPACLOUD_SSH_USER",
+    "SUPACLOUD_SSH_PORT",
+    "SUPACLOUD_SSH_KEY",
+    "SUPACLOUD_SSH_PASS",
+    "SUPACLOUD_SSH_HOST_FINGERPRINT",
+    "SUPACLOUD_READ_ONLY",
+] as const;
+const SOURCE_ENVIRONMENT_KEYS = [...ADMIN_CONTEXT_KEYS, "SUPACLOUD_ENV"] as const;
 
-    const values: Record<string, string> = {};
-    try {
-        const envContent = readFileSync(envPath, "utf-8");
-        for (const line of envContent.split("\n")) {
-            const match = line.trim().match(/^([^=]+)=(.*)$/);
-            if (!match) continue;
-            const key = match[1].trim();
-            const value = match[2].trim().replace(/^["']|["']$/g, "");
-            values[key] = value;
-        }
-    } catch {
+function unquotedEnvValue(rawValue: string): string {
+    const trimmedValue = rawValue.trim();
+    const quote = trimmedValue[0];
+    return quote && (quote === '"' || quote === "'") && trimmedValue.endsWith(quote)
+        ? trimmedValue.slice(1, -1)
+        : trimmedValue;
+}
+
+function parseEnvFile(contents: string): Record<string, string> {
+    const environment: Record<string, string> = {};
+    for (const rawLine of contents.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith("#")) continue;
+        const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+        if (match) environment[match[1]] = unquotedEnvValue(match[2]);
+    }
+    return environment;
+}
+
+function readEnvFile(path: string, required: boolean): Record<string, string> {
+    if (!existsSync(path)) {
+        if (required) throw new Error(`SupaCloud environment file not found: ${path}`);
         return {};
     }
-    return values;
-}
-
-function pickValue(
-    env: NodeJS.ProcessEnv,
-    dotenv: Record<string, string>,
-    keys: string[],
-): EnvLookupResult {
-    for (const key of keys) {
-        const envValue = env[key];
-        if (envValue) return { value: envValue, source: "env" };
+    try {
+        return parseEnvFile(readFileSync(path, "utf8"));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to read SupaCloud environment file ${path}: ${message}`);
     }
-    for (const key of keys) {
-        const dotenvValue = dotenv[key];
-        if (dotenvValue) return { value: dotenvValue, source: "dotenv" };
-    }
-    return { value: "", source: "env" };
 }
 
-function detectSource(sources: Array<"env" | "dotenv" | "none">): ResolvedContext["source"] {
-    const present = new Set(sources.filter((value) => value !== "none"));
-    if (present.size === 0) return "none";
-    if (present.size === 1) return present.has("env") ? "env" : "dotenv";
-    return "mixed";
-}
-
-function normalizeUrl(value: string): string {
-    const trimmed = value.trim().replace(/\/+$/, "");
+function normalizeUrl(urlCandidate: string): string {
+    const trimmed = urlCandidate.trim().replace(/\/+$/, "");
     if (!trimmed) return "";
     try {
-        return new URL(trimmed).toString().replace(/\/+$/, "");
+        const url = new URL(trimmed);
+        if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) return "";
+        return url.toString().replace(/\/+$/, "");
     } catch {
         return "";
     }
 }
 
-function hostFromUrl(value: string): string {
+function hostFromUrl(urlCandidate: string): string {
     try {
-        return new URL(value).hostname;
+        return new URL(urlCandidate).hostname;
     } catch {
         return "";
     }
 }
 
-function inferManagementApiUrlFromSupabaseUrl(value: string, projectRef = ""): string {
-    const normalized = normalizeUrl(value);
+function inferProjectRefFromSupabaseUrl(supabaseUrlCandidate: string): string {
+    const normalized = normalizeUrl(supabaseUrlCandidate);
+    if (!normalized) return "";
+    return new URL(normalized).hostname.match(/^([a-z0-9-]+)\.api\./i)?.[1] ?? "";
+}
+
+function inferManagementApiUrlFromSupabaseUrl(supabaseUrlCandidate: string, projectRef = ""): string {
+    const normalized = normalizeUrl(supabaseUrlCandidate);
     if (!normalized) return "";
 
     const url = new URL(normalized);
@@ -94,55 +128,161 @@ function inferManagementApiUrlFromSupabaseUrl(value: string, projectRef = ""): s
         url.hostname = `studio.${host.slice("api.".length)}`;
         return url.toString().replace(/\/+$/, "");
     }
-
     const ref = projectRef.trim();
     if (ref && host.startsWith(`${ref}.api.`)) {
         url.hostname = `studio-${ref}.${host.slice(`${ref}.api.`.length)}`;
         return url.toString().replace(/\/+$/, "");
     }
-
-    const managedHostMatch = host.match(/^([a-z0-9-]+)\.api\.(.+)$/i);
-    if (managedHostMatch) {
-        url.hostname = `studio-${managedHostMatch[1]}.${managedHostMatch[2]}`;
+    const managedHost = host.match(/^([a-z0-9-]+)\.api\.(.+)$/i);
+    if (managedHost) {
+        url.hostname = `studio-${managedHost[1]}.${managedHost[2]}`;
         return url.toString().replace(/\/+$/, "");
     }
-
     return normalized;
+}
+
+function sourceAdminCore(environment: Record<string, string>) {
+    const supabaseUrl = normalizeUrl(environment.SUPABASE_URL || "");
+    const projectRef = (environment.SUPACLOUD_PROJECT_REF || environment.X_PROJECT_REF || "").trim()
+        || inferProjectRefFromSupabaseUrl(supabaseUrl);
+    const explicitApiUrl = environment.SUPACLOUD_API_URL
+        || environment.SUPACLOUD_MANAGEMENT_API_URL
+        || environment.MANAGEMENT_API_URL
+        || "";
+    const apiUrl = normalizeUrl(explicitApiUrl)
+        || inferManagementApiUrlFromSupabaseUrl(supabaseUrl, projectRef)
+        || normalizeUrl(environment.SUPACLOUD_HOST ? `http://${environment.SUPACLOUD_HOST}:9090` : "");
+    const apiToken = environment.SUPACLOUD_API_TOKEN || environment.SUPABASE_SERVICE_ROLE_KEY || "";
+    return { apiUrl, apiToken, projectRef, supabaseUrl };
+}
+
+function processEnvironment(env: NodeJS.ProcessEnv): Record<string, string> {
+    return Object.fromEntries(SOURCE_ENVIRONMENT_KEYS.flatMap((key) => {
+        const environmentValue = env[key];
+        return environmentValue === undefined ? [] : [[key, environmentValue]];
+    }));
+}
+
+function hasProcessContext(env: NodeJS.ProcessEnv): boolean {
+    return ADMIN_CONTEXT_KEYS.some((key) => Object.hasOwn(env, key));
+}
+
+function completeAdminContext(environment: Record<string, string>): boolean {
+    const adminCore = sourceAdminCore(environment);
+    const hasApiContext = Boolean(adminCore.apiUrl && adminCore.apiToken);
+    const hasSshContext = Boolean(environment.SUPACLOUD_HOST && environment.SUPACLOUD_SSH_HOST_FINGERPRINT);
+    return hasApiContext || hasSshContext;
+}
+
+function namedEnvironmentSource(cwd: string, selector: string): ContextSource {
+    const environment = normalizeEnvironmentName(selector);
+    const path = resolve(cwd, `.env.supacloud.${selector}`);
+    const selectedEnvironment = readEnvFile(path, true);
+    if (selectedEnvironment.SUPACLOUD_ENV
+        && normalizeEnvironmentName(selectedEnvironment.SUPACLOUD_ENV) !== environment) {
+        throw new Error(`SUPACLOUD_ENV in ${path} does not match selector ${selector}`);
+    }
+    return {
+        environment: selectedEnvironment,
+        kind: "named_env_file",
+        path,
+        environmentName: environment,
+    };
+}
+
+function explicitEnvironmentSource(cwd: string, envFile: string): ContextSource {
+    const path = resolve(cwd, envFile);
+    const selectedEnvironment = readEnvFile(path, true);
+    if (!selectedEnvironment.SUPACLOUD_ENV) throw new Error(`SUPACLOUD_ENV is required in ${path}`);
+    return {
+        environment: selectedEnvironment,
+        kind: "explicit_env_file",
+        path,
+        environmentName: normalizeEnvironmentName(selectedEnvironment.SUPACLOUD_ENV),
+    };
+}
+
+function legacyEnvironmentSource(cwd: string): ContextSource {
+    const path = resolve(cwd, ".env");
+    const environment = readEnvFile(path, false);
+    const environmentName = environment.SUPACLOUD_ENV
+        ? normalizeEnvironmentName(environment.SUPACLOUD_ENV)
+        : "";
+    return {
+        environment,
+        kind: Object.keys(environment).length ? "legacy_dotenv" : "none",
+        path: existsSync(path) ? path : null,
+        environmentName,
+    };
+}
+
+function ambientContextSource(env: NodeJS.ProcessEnv, cwd: string): ContextSource {
+    const environment = processEnvironment(env);
+    if (env.SUPACLOUD_ENV) {
+        const environmentName = normalizeEnvironmentName(env.SUPACLOUD_ENV);
+        if (completeAdminContext(environment)) {
+            return { environment, kind: "process_env", path: null, environmentName };
+        }
+        return namedEnvironmentSource(cwd, env.SUPACLOUD_ENV);
+    }
+    if (hasProcessContext(env)) {
+        return { environment, kind: "process_env", path: null, environmentName: "" };
+    }
+    return legacyEnvironmentSource(cwd);
+}
+
+function contextSource(
+    env: NodeJS.ProcessEnv,
+    cwd: string,
+    selection: ContextSelection,
+): ContextSource {
+    if (selection.environmentName && selection.envFile) {
+        throw new Error("Environment selectors are mutually exclusive");
+    }
+    if (selection.environmentName) return namedEnvironmentSource(cwd, selection.environmentName);
+    if (selection.envFile) return explicitEnvironmentSource(cwd, selection.envFile);
+    return ambientContextSource(env, cwd);
+}
+
+function resolvedSshContext(environment: Record<string, string>) {
+    const rawPort = environment.SUPACLOUD_SSH_PORT || "22";
+    if (!/^\d+$/.test(rawPort)) {
+        throw new Error("SUPACLOUD_SSH_PORT must be an integer between 1 and 65535");
+    }
+    const sshPort = Number(rawPort);
+    if (!Number.isSafeInteger(sshPort) || sshPort < 1 || sshPort > 65_535) {
+        throw new Error("SUPACLOUD_SSH_PORT must be an integer between 1 and 65535");
+    }
+    return {
+        sshUser: environment.SUPACLOUD_SSH_USER || "root",
+        sshPort,
+        sshKey: environment.SUPACLOUD_SSH_KEY || resolve(homedir(), ".ssh", "id_rsa"),
+        sshPass: environment.SUPACLOUD_SSH_PASS || "",
+        sshHostFingerprint: environment.SUPACLOUD_SSH_HOST_FINGERPRINT || "",
+    };
 }
 
 export function resolveSupaCloudContext(
     env: NodeJS.ProcessEnv = process.env,
     cwd: string = process.cwd(),
+    selection: ContextSelection = {},
 ): ResolvedContext {
-    const dotenv = readDotEnvFile(cwd);
-    const supabaseUrl = pickValue(env, dotenv, ["SUPABASE_URL"]);
-    const explicitApiUrl = pickValue(env, dotenv, ["SUPACLOUD_API_URL", "SUPACLOUD_MANAGEMENT_API_URL", "MANAGEMENT_API_URL"]);
-    const inferredToken = pickValue(env, dotenv, ["SUPABASE_SERVICE_ROLE_KEY", "SUPACLOUD_API_TOKEN"]);
-    const projectRef = pickValue(env, dotenv, ["SUPACLOUD_PROJECT_REF", "X_PROJECT_REF"]).value;
-
-    const hostFromEnv = env.SUPACLOUD_HOST;
-    const normalizedSupabaseUrl = normalizeUrl(supabaseUrl.value);
-    const apiUrl = normalizeUrl(explicitApiUrl.value)
-        || inferManagementApiUrlFromSupabaseUrl(normalizedSupabaseUrl, projectRef)
-        || (hostFromEnv ? `http://${hostFromEnv}:9090` : "");
-    const resolvedHostFromUrl = hostFromUrl(apiUrl || normalizedSupabaseUrl);
+    const source = contextSource(env, cwd, selection);
+    const adminCore = sourceAdminCore(source.environment);
+    const host = source.environment.SUPACLOUD_HOST || hostFromUrl(adminCore.apiUrl || adminCore.supabaseUrl);
 
     return {
-        host: hostFromEnv ?? resolvedHostFromUrl,
-        sshUser: env.SUPACLOUD_SSH_USER ?? "root",
-        sshPort: parseInt(env.SUPACLOUD_SSH_PORT ?? "22", 10),
-        sshKey: env.SUPACLOUD_SSH_KEY ?? resolve(homedir(), ".ssh", "id_rsa"),
-        sshPass: env.SUPACLOUD_SSH_PASS ?? "",
-        sshHostFingerprint: env.SUPACLOUD_SSH_HOST_FINGERPRINT ?? "",
-        apiUrl,
-        apiToken: env.SUPACLOUD_API_TOKEN ?? inferredToken.value,
-        projectRef,
-        readOnly: env.SUPACLOUD_READ_ONLY === "true",
-        inferredSupabaseUrl: normalizedSupabaseUrl,
-        inferredServiceRoleKey: inferredToken.value,
-        source: detectSource([
-            (supabaseUrl.value || explicitApiUrl.value) ? (supabaseUrl.value ? supabaseUrl.source : explicitApiUrl.source) : "none",
-            inferredToken.value ? inferredToken.source : "none",
-        ]),
+        host,
+        ...resolvedSshContext(source.environment),
+        apiUrl: adminCore.apiUrl,
+        apiToken: adminCore.apiToken,
+        projectRef: adminCore.projectRef,
+        readOnly: source.environment.SUPACLOUD_READ_ONLY === "true",
+        environment: source.environmentName,
+        production: source.environmentName === "production",
+        inferredSupabaseUrl: adminCore.supabaseUrl,
+        inferredServiceRoleKey: source.environment.SUPABASE_SERVICE_ROLE_KEY || "",
+        source: source.kind,
+        sourcePath: source.path,
     };
 }

--- a/packages/admin/src/shared/context.ts
+++ b/packages/admin/src/shared/context.ts
@@ -93,11 +93,12 @@ function readEnvFile(path: string, required: boolean): Record<string, string> {
 }
 
 function normalizeUrl(urlCandidate: string): string {
-    const trimmed = urlCandidate.trim().replace(/\/+$/, "");
+    const trimmed = urlCandidate.trim();
     if (!trimmed) return "";
     try {
         const url = new URL(trimmed);
-        if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) return "";
+        if (!["http:", "https:"].includes(url.protocol)
+            || url.username || url.password || url.search || url.hash) return "";
         return url.toString().replace(/\/+$/, "");
     } catch {
         return "";
@@ -178,8 +179,10 @@ function namedEnvironmentSource(cwd: string, selector: string): ContextSource {
     const environment = normalizeEnvironmentName(selector);
     const path = resolve(cwd, `.env.supacloud.${selector}`);
     const selectedEnvironment = readEnvFile(path, true);
-    if (selectedEnvironment.SUPACLOUD_ENV
-        && normalizeEnvironmentName(selectedEnvironment.SUPACLOUD_ENV) !== environment) {
+    if (!selectedEnvironment.SUPACLOUD_ENV) {
+        throw new Error(`SUPACLOUD_ENV is required in ${path}`);
+    }
+    if (normalizeEnvironmentName(selectedEnvironment.SUPACLOUD_ENV) !== environment) {
         throw new Error(`SUPACLOUD_ENV in ${path} does not match selector ${selector}`);
     }
     return {
@@ -277,7 +280,8 @@ export function resolveSupaCloudContext(
         apiUrl: adminCore.apiUrl,
         apiToken: adminCore.apiToken,
         projectRef: adminCore.projectRef,
-        readOnly: source.environment.SUPACLOUD_READ_ONLY === "true",
+        readOnly: env.SUPACLOUD_READ_ONLY === "true"
+            || source.environment.SUPACLOUD_READ_ONLY === "true",
         environment: source.environmentName,
         production: source.environmentName === "production",
         inferredSupabaseUrl: adminCore.supabaseUrl,

--- a/packages/admin/src/shared/execution-policy.test.ts
+++ b/packages/admin/src/shared/execution-policy.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import { stringEnum } from "./schema";
+import { authorizeExecution, executionMode, validateExecutionPolicyCoverage } from "./execution-policy";
+import type { ResolvedContext } from "./context";
+
+function productionContext(overrides: Partial<ResolvedContext> = {}): ResolvedContext {
+    return {
+        host: "production.example.com",
+        sshUser: "root",
+        sshPort: 2201,
+        sshKey: "",
+        sshPass: "",
+        sshHostFingerprint: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        apiUrl: "https://management.example.com",
+        apiToken: "secret-token",
+        projectRef: "prod-ref",
+        readOnly: false,
+        environment: "production",
+        production: true,
+        inferredSupabaseUrl: "",
+        inferredServiceRoleKey: "",
+        source: "process_env",
+        sourcePath: null,
+        ...overrides,
+    };
+}
+
+describe("Admin execution policy", () => {
+    test("classifies the complete registered action catalog", () => {
+        const expectedModes = {
+            read: [
+                "project.list", "project.get", "project.settings", "project.api_keys",
+                "project.health", "project.logs", "project.tasks", "project.services",
+                "platform.metrics", "platform.list_backups", "platform.network",
+                "platform.list_orgs", "platform.get_org",
+                "gateway.routes", "gateway.get_certificate", "gateway.custom_hostname",
+                "ssh.ping", "ssh.versions", "ssh.diagnose", "ssh.exec",
+                "ssh.troubleshoot", "ssh.container_logs", "ssh.tenant_list",
+                "ssh.tenant_inspect", "ssh.tenant_diagnose",
+            ],
+            write: [
+                "project.create", "project.delete", "project.pause", "project.restore",
+                "project.restart", "project.update_settings",
+                "platform.create_backup", "platform.update_network",
+                "gateway.upsert_route", "gateway.update_route", "gateway.delete_route",
+                "gateway.config", "gateway.update_certificate", "gateway.issue_certificate",
+                "gateway.deploy_certificate", "gateway.rebuild", "gateway.set_custom_hostname",
+                "gateway.delete_custom_hostname", "gateway.verify_custom_hostname",
+                "ssh.setup", "ssh.install", "ssh.upgrade", "ssh.tenant_migrate",
+            ],
+        } as const;
+
+        for (const mode of ["read", "write"] as const) {
+            for (const qualifiedAction of expectedModes[mode]) {
+                const [moduleName, action] = qualifiedAction.split(".");
+                expect(executionMode(moduleName, action, {})).toBe(mode);
+            }
+        }
+    });
+
+    test("classifies conditional service status as read and lifecycle changes as write", () => {
+        expect(executionMode("project", "service_control", { service_action: "status" })).toBe("read");
+        expect(executionMode("project", "service_control", { service_action: "restart" })).toBe("write");
+        expect(executionMode("ssh", "tenant_manage", { tenant_action: "status" })).toBe("read");
+        expect(executionMode("ssh", "tenant_manage", { tenant_action: "stop" })).toBe("write");
+    });
+
+    test("blocks every classified remote write in read-only mode", () => {
+        expect(() => authorizeExecution("gateway", {
+            action: "rebuild",
+            ref: "test-ref",
+        }, {
+            context: productionContext({
+                environment: "test",
+                production: false,
+                readOnly: true,
+                projectRef: "test-ref",
+            }),
+        })).toThrow("SUPACLOUD_READ_ONLY=true");
+    });
+
+    test("requires exact production confirmation for project writes", () => {
+        const args = { action: "delete", ref: "prod-ref" };
+        expect(() => authorizeExecution("project", args, {
+            context: productionContext(),
+        })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("project", args, {
+            context: productionContext(),
+            confirmProduction: "prod-ref",
+        })).not.toThrow();
+    });
+
+    test("rejects cross-project production reads and writes", () => {
+        expect(() => authorizeExecution("project", {
+            action: "get",
+            ref: "other-ref",
+        }, {
+            context: productionContext(),
+        })).toThrow("different project ref");
+        expect(() => authorizeExecution("gateway", {
+            action: "rebuild",
+            ref: "other-ref",
+        }, {
+            context: productionContext(),
+            confirmProduction: "other-ref",
+        })).toThrow("different project ref");
+    });
+
+    test("binds ref-less production writes to exact API and SSH targets", () => {
+        expect(() => authorizeExecution("project", { action: "create" }, {
+            context: productionContext({ projectRef: "" }),
+        })).toThrow("--confirm-production platform:management.example.com");
+        expect(() => authorizeExecution("project", { action: "create" }, {
+            context: productionContext({ projectRef: "" }),
+            confirmProduction: "platform:management.example.com",
+        })).not.toThrow();
+
+        expect(() => authorizeExecution("ssh", { action: "upgrade" }, {
+            context: productionContext({ projectRef: "" }),
+        })).toThrow("--confirm-production host:production.example.com:2201");
+        expect(() => authorizeExecution("ssh", { action: "upgrade" }, {
+            context: productionContext({ projectRef: "" }),
+            confirmProduction: "host:production.example.com:2201",
+        })).not.toThrow();
+    });
+
+    test("ignores irrelevant ref flags when deriving platform and host confirmation targets", () => {
+        expect(() => authorizeExecution("project", {
+            action: "create",
+            ref: "prod-ref",
+        }, {
+            context: productionContext(),
+            confirmProduction: "prod-ref",
+        })).toThrow("--confirm-production platform:management.example.com");
+        expect(() => authorizeExecution("ssh", {
+            action: "upgrade",
+            project_ref: "prod-ref",
+        }, {
+            context: productionContext(),
+            confirmProduction: "prod-ref",
+        })).toThrow("--confirm-production host:production.example.com:2201");
+    });
+
+    test("does not substitute a platform target for a missing required project ref", () => {
+        expect(() => authorizeExecution("platform", { action: "create_backup" }, {
+            context: productionContext({ projectRef: "" }),
+            confirmProduction: "platform:management.example.com",
+        })).toThrow("requires --ref");
+        expect(() => authorizeExecution("ssh", {
+            action: "tenant_migrate",
+            source_ref: "source-ref",
+        }, {
+            context: productionContext({ projectRef: "" }),
+            confirmProduction: "host:production.example.com:2201",
+        })).toThrow("requires --target_ref");
+    });
+
+    test("fails closed for unknown actions in production or read-only profiles", () => {
+        expect(() => authorizeExecution("project", { action: "future_action" }, {
+            context: productionContext(),
+        })).toThrow("no classification");
+        expect(() => authorizeExecution("project", { action: "future_action" }, {
+            context: productionContext({ production: false, environment: "test", readOnly: true }),
+        })).toThrow("no classification");
+        expect(() => authorizeExecution("project", { action: "future_action" }, {
+            context: productionContext({ production: false, environment: "test" }),
+        })).not.toThrow();
+    });
+
+    test("detects top-level and conditional action catalog drift", () => {
+        expect(() => validateExecutionPolicyCoverage({
+            project: { schema: { action: {} as never } },
+        })).toThrow("cannot inspect project.action");
+        expect(() => validateExecutionPolicyCoverage({
+            project: { schema: { action: stringEnum(["list", "future_action"]) } },
+        })).toThrow("project.future_action");
+        expect(() => validateExecutionPolicyCoverage({
+            project: {
+                schema: {
+                    action: stringEnum(["service_control"]),
+                    service_action: stringEnum(["status", "future_action"]),
+                },
+            },
+        })).toThrow("project.service_control.future_action");
+    });
+});

--- a/packages/admin/src/shared/execution-policy.test.ts
+++ b/packages/admin/src/shared/execution-policy.test.ts
@@ -79,6 +79,25 @@ describe("Admin execution policy", () => {
         })).toThrow("SUPACLOUD_READ_ONLY=true");
     });
 
+    test("blocks unclassified remote writes while allowing reads", () => {
+        const unclassifiedContext = productionContext({
+            environment: "",
+            production: false,
+        });
+        expect(() => authorizeExecution("project", {
+            action: "delete",
+            ref: "prod-ref",
+        }, {
+            context: unclassifiedContext,
+        })).toThrow("requires an explicit SUPACLOUD_ENV");
+        expect(() => authorizeExecution("project", {
+            action: "get",
+            ref: "prod-ref",
+        }, {
+            context: unclassifiedContext,
+        })).not.toThrow();
+    });
+
     test("requires exact production confirmation for project writes", () => {
         const args = { action: "delete", ref: "prod-ref" };
         expect(() => authorizeExecution("project", args, {

--- a/packages/admin/src/shared/execution-policy.ts
+++ b/packages/admin/src/shared/execution-policy.ts
@@ -1,0 +1,248 @@
+import { schemaEnumValues, schemaProperties } from "./schema";
+import type { ToolSchema } from "./schema";
+import type { ResolvedContext } from "./context";
+
+export type ExecutionMode = "read" | "write" | "local";
+
+interface ModulePolicy {
+    read?: readonly string[];
+    write?: readonly string[];
+    local?: readonly string[];
+}
+
+const ACTION_POLICY: Record<string, ModulePolicy> = {
+    project: {
+        read: ["list", "get", "settings", "api_keys", "health", "logs", "tasks", "services"],
+        write: ["create", "delete", "pause", "restore", "restart", "update_settings"],
+    },
+    platform: {
+        read: ["metrics", "list_backups", "network", "list_orgs", "get_org"],
+        write: ["create_backup", "update_network"],
+    },
+    gateway: {
+        read: ["routes", "get_certificate", "custom_hostname"],
+        write: [
+            "upsert_route", "update_route", "delete_route", "config",
+            "update_certificate", "issue_certificate", "deploy_certificate", "rebuild",
+            "set_custom_hostname", "delete_custom_hostname", "verify_custom_hostname",
+        ],
+    },
+    ssh: {
+        read: [
+            "ping", "versions", "diagnose", "exec", "troubleshoot", "container_logs",
+            "tenant_list", "tenant_inspect", "tenant_diagnose",
+        ],
+        write: ["setup", "install", "upgrade", "tenant_migrate"],
+    },
+};
+
+const DYNAMIC_ACTION_FIELDS: Record<string, string> = {
+    "project.service_control": "service_action",
+    "ssh.tenant_manage": "tenant_action",
+};
+
+const REFLESS_WRITE_ACTIONS = new Set([
+    "project.create",
+    "ssh.setup",
+    "ssh.install",
+    "ssh.upgrade",
+]);
+const SSH_PROJECT_REF_ACTIONS = new Set(["tenant_manage", "tenant_inspect", "tenant_diagnose"]);
+const PLATFORM_PROJECT_REF_ACTIONS = new Set([
+    "list_backups", "create_backup", "network", "update_network",
+]);
+
+export interface ExecutionAuthorization {
+    context: ResolvedContext;
+    confirmProduction?: string;
+}
+
+interface ToolCatalogEntry {
+    schema: ToolSchema;
+}
+
+interface WriteAuthorizationRequest {
+    moduleName: string;
+    action: string;
+    args: Record<string, unknown>;
+    projectRef: string | null;
+    authorization: ExecutionAuthorization;
+}
+
+function declaredMode(moduleName: string, action: string): ExecutionMode | undefined {
+    const policy = ACTION_POLICY[moduleName];
+    if (!policy) return undefined;
+    for (const mode of ["read", "write", "local"] as const) {
+        if (policy[mode]?.includes(action)) return mode;
+    }
+    return undefined;
+}
+
+function serviceControlMode(serviceAction: unknown): ExecutionMode | undefined {
+    if (serviceAction === "status") return "read";
+    if (["start", "stop", "restart", "pause", "resume"].includes(String(serviceAction))) {
+        return "write";
+    }
+    return undefined;
+}
+
+export function executionMode(
+    moduleName: string,
+    action: string,
+    args: Record<string, unknown>,
+): ExecutionMode | undefined {
+    if (moduleName === "project" && action === "service_control") {
+        return serviceControlMode(args.service_action);
+    }
+    if (moduleName === "ssh" && action === "tenant_manage") {
+        return serviceControlMode(args.tenant_action);
+    }
+    return declaredMode(moduleName, action);
+}
+
+function stringArgument(args: Record<string, unknown>, field: string): string | null {
+    const candidate = args[field];
+    return typeof candidate === "string" && candidate ? candidate : null;
+}
+
+function sshRequestedProjectRef(action: string, args: Record<string, unknown>): string | null {
+    if (action === "tenant_migrate") return stringArgument(args, "target_ref");
+    return SSH_PROJECT_REF_ACTIONS.has(action) ? stringArgument(args, "project_ref") : null;
+}
+
+function requestedProjectRef(
+    moduleName: string,
+    action: string,
+    args: Record<string, unknown>,
+): string | null {
+    if (moduleName === "ssh") return sshRequestedProjectRef(action, args);
+    if (moduleName === "project") {
+        return ["list", "create"].includes(action) ? null : stringArgument(args, "ref");
+    }
+    if (moduleName === "platform") {
+        return PLATFORM_PROJECT_REF_ACTIONS.has(action) ? stringArgument(args, "ref") : null;
+    }
+    return moduleName === "gateway" ? stringArgument(args, "ref") : null;
+}
+
+function requiresProjectRef(moduleName: string, action: string): boolean {
+    return !REFLESS_WRITE_ACTIONS.has(`${moduleName}.${action}`);
+}
+
+function apiConfirmationTarget(context: ResolvedContext): string {
+    if (!context.apiUrl) {
+        throw new Error("Production platform write requires a configured SUPACLOUD_API_URL");
+    }
+    return `platform:${new URL(context.apiUrl).host}`;
+}
+
+function sshConfirmationTarget(context: ResolvedContext): string {
+    if (!context.host) {
+        throw new Error("Production SSH write requires a configured SUPACLOUD_HOST");
+    }
+    const portSuffix = context.sshPort === 22 ? "" : `:${context.sshPort}`;
+    return `host:${context.host}${portSuffix}`;
+}
+
+function productionConfirmationTarget(
+    moduleName: string,
+    action: string,
+    args: Record<string, unknown>,
+    context: ResolvedContext,
+): string {
+    const projectRef = requestedProjectRef(moduleName, action, args);
+    if (projectRef) return projectRef;
+    if (moduleName === "ssh") return sshConfirmationTarget(context);
+    return apiConfirmationTarget(context);
+}
+
+function assertProfileProjectBoundary(requestedRef: string | null, context: ResolvedContext): void {
+    if (requestedRef && context.projectRef && requestedRef !== context.projectRef) {
+        throw new Error("Production profiles cannot target a different project ref");
+    }
+}
+
+function requiredProjectRefFlag(moduleName: string, action: string): string {
+    if (moduleName !== "ssh") return "ref";
+    return action === "tenant_migrate" ? "target_ref" : "project_ref";
+}
+
+function authorizeWrite(request: WriteAuthorizationRequest): void {
+    const { moduleName, action, args, projectRef, authorization } = request;
+    const { context, confirmProduction } = authorization;
+    if (context.readOnly) {
+        throw new Error(`Remote write ${moduleName}.${action} is blocked in read-only mode (SUPACLOUD_READ_ONLY=true)`);
+    }
+    if (!context.production) return;
+    if (requiresProjectRef(moduleName, action) && !projectRef) {
+        throw new Error(
+            `Production write ${moduleName}.${action} requires --${requiredProjectRefFlag(moduleName, action)}`,
+        );
+    }
+    const confirmationTarget = productionConfirmationTarget(moduleName, action, args, context);
+    if (confirmProduction !== confirmationTarget) {
+        throw new Error(`Production write requires --confirm-production ${confirmationTarget}`);
+    }
+}
+
+function assertKnownMode(
+    moduleName: string,
+    action: string,
+    mode: ExecutionMode | undefined,
+    context: ResolvedContext,
+): void {
+    if (!mode && (context.production || context.readOnly)) {
+        throw new Error(`Execution policy has no classification for ${moduleName}.${action}`);
+    }
+}
+
+export function authorizeExecution(
+    moduleName: string,
+    args: Record<string, unknown>,
+    authorization: ExecutionAuthorization,
+): void {
+    const action = typeof args.action === "string" ? args.action : "";
+    if (!action) return;
+    const mode = executionMode(moduleName, action, args);
+    const { context } = authorization;
+    assertKnownMode(moduleName, action, mode, context);
+    if (!mode) return;
+
+    const projectRef = requestedProjectRef(moduleName, action, args);
+    if (context.production) assertProfileProjectBoundary(projectRef, context);
+    if (mode !== "write") return;
+    authorizeWrite({ moduleName, action, args, projectRef, authorization });
+}
+
+function validateDynamicAction(tool: ToolCatalogEntry, moduleName: string, action: string, field: string): void {
+    const fieldSchema = schemaProperties(tool.schema)[field];
+    const fieldActions = fieldSchema ? schemaEnumValues(fieldSchema) : [];
+    if (fieldActions.length === 0) {
+        throw new Error(`Execution policy cannot inspect ${moduleName}.${action}.${field}`);
+    }
+    for (const fieldAction of fieldActions) {
+        if (!executionMode(moduleName, action, { [field]: fieldAction })) {
+            throw new Error(`Execution policy has no classification for ${moduleName}.${action}.${fieldAction}`);
+        }
+    }
+}
+
+function validateRegisteredAction(tool: ToolCatalogEntry, moduleName: string, action: string): void {
+    const dynamicField = DYNAMIC_ACTION_FIELDS[`${moduleName}.${action}`];
+    if (dynamicField) return validateDynamicAction(tool, moduleName, action, dynamicField);
+    if (!declaredMode(moduleName, action)) {
+        throw new Error(`Execution policy has no classification for ${moduleName}.${action}`);
+    }
+}
+
+export function validateExecutionPolicyCoverage(tools: Record<string, ToolCatalogEntry>): void {
+    for (const [moduleName, tool] of Object.entries(tools)) {
+        const actionSchema = schemaProperties(tool.schema).action;
+        if (!actionSchema) continue;
+        const registeredActions = schemaEnumValues(actionSchema);
+        if (registeredActions.length === 0) {
+            throw new Error(`Execution policy cannot inspect ${moduleName}.action`);
+        }
+        for (const action of registeredActions) validateRegisteredAction(tool, moduleName, action);
+    }
+}

--- a/packages/admin/src/shared/execution-policy.ts
+++ b/packages/admin/src/shared/execution-policy.ts
@@ -173,6 +173,9 @@ function authorizeWrite(request: WriteAuthorizationRequest): void {
     if (context.readOnly) {
         throw new Error(`Remote write ${moduleName}.${action} is blocked in read-only mode (SUPACLOUD_READ_ONLY=true)`);
     }
+    if (!context.environment) {
+        throw new Error(`Remote write ${moduleName}.${action} requires an explicit SUPACLOUD_ENV`);
+    }
     if (!context.production) return;
     if (requiresProjectRef(moduleName, action) && !projectRef) {
         throw new Error(

--- a/packages/admin/src/shared/global-options.test.ts
+++ b/packages/admin/src/shared/global-options.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeEnvironmentName, parseGlobalAdminOptions } from "./global-options";
+
+describe("Admin global options", () => {
+    test.each([
+        [["--env", "test", "project", "list"], "test"],
+        [["project", "list", "--env=test"], "test"],
+        [["project", "--env", "test", "list"], "test"],
+    ])("extracts environment selectors before command parsing", (args, environmentName) => {
+        const parsed = parseGlobalAdminOptions(args);
+        expect(parsed.environmentName).toBe(environmentName);
+        expect(parsed.args).toEqual(["project", "list"]);
+    });
+
+    test("extracts an exact file and production confirmation in both syntaxes", () => {
+        expect(parseGlobalAdminOptions([
+            "--env-file=./ops.env", "project", "delete", "--confirm-production", "prod-ref",
+        ])).toEqual({
+            envFile: "./ops.env",
+            confirmProduction: "prod-ref",
+            args: ["project", "delete"],
+        });
+    });
+
+    test.each([
+        [["--env", "test", "--env", "production"], "--env may be provided only once"],
+        [["--env-file", "a", "--env-file=b"], "--env-file may be provided only once"],
+        [["--confirm-production", "a", "--confirm-production=a"], "--confirm-production may be provided only once"],
+        [["--env"], "--env requires a value"],
+        [["--env="], "--env requires a value"],
+        [["--env", "test", "--env-file", "file"], "mutually exclusive"],
+    ])("rejects invalid global option input", (args, message) => {
+        expect(() => parseGlobalAdminOptions(args)).toThrow(message);
+    });
+
+    test("normalizes production aliases and rejects unsafe selectors", () => {
+        expect(normalizeEnvironmentName("Prod")).toBe("production");
+        expect(normalizeEnvironmentName("TEST_US-1")).toBe("test_us-1");
+        expect(() => normalizeEnvironmentName("../production")).toThrow("must match");
+    });
+});

--- a/packages/admin/src/shared/global-options.ts
+++ b/packages/admin/src/shared/global-options.ts
@@ -1,0 +1,93 @@
+export interface GlobalAdminOptions {
+    environmentName?: string;
+    envFile?: string;
+    confirmProduction?: string;
+    args: string[];
+}
+
+const GLOBAL_FLAGS = {
+    "--env": "environmentName",
+    "--env-file": "envFile",
+    "--confirm-production": "confirmProduction",
+} as const;
+
+const ENVIRONMENT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
+
+type GlobalOptionKey = typeof GLOBAL_FLAGS[keyof typeof GLOBAL_FLAGS];
+
+interface ParsedGlobalArgument {
+    optionKey?: GlobalOptionKey;
+    optionValue?: string;
+    commandArgument?: string;
+    consumed: number;
+}
+
+function globalFlag(argument: string): keyof typeof GLOBAL_FLAGS | null {
+    return (Object.keys(GLOBAL_FLAGS) as Array<keyof typeof GLOBAL_FLAGS>)
+        .find((flag) => argument === flag || argument.startsWith(`${flag}=`)) ?? null;
+}
+
+function globalFlagValue(
+    args: string[],
+    index: number,
+    flag: string,
+): { flagValue: string; consumed: number } {
+    if (args[index].startsWith(`${flag}=`)) {
+        const inlineValue = args[index].slice(flag.length + 1);
+        if (!inlineValue) throw new Error(`${flag} requires a value`);
+        return { flagValue: inlineValue, consumed: 1 };
+    }
+    const followingValue = args[index + 1];
+    if (!followingValue || followingValue.startsWith("--")) {
+        throw new Error(`${flag} requires a value`);
+    }
+    return { flagValue: followingValue, consumed: 2 };
+}
+
+export function normalizeEnvironmentName(name: string): string {
+    if (!ENVIRONMENT_NAME_PATTERN.test(name)) {
+        throw new Error("--env and SUPACLOUD_ENV must match ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$");
+    }
+    const normalized = name.toLowerCase();
+    return normalized === "prod" || normalized === "production" ? "production" : normalized;
+}
+
+function parseGlobalArgument(
+    args: string[],
+    index: number,
+    selectedOptions: Partial<Record<GlobalOptionKey, string>>,
+): ParsedGlobalArgument {
+    const flag = globalFlag(args[index]);
+    if (!flag) return { commandArgument: args[index], consumed: 1 };
+    const optionKey = GLOBAL_FLAGS[flag];
+    if (selectedOptions[optionKey] !== undefined) {
+        throw new Error(`${flag} may be provided only once`);
+    }
+    const parsedFlag = globalFlagValue(args, index, flag);
+    return { optionKey, optionValue: parsedFlag.flagValue, consumed: parsedFlag.consumed };
+}
+
+function validateEnvironmentSelection(selectedOptions: Partial<Record<GlobalOptionKey, string>>): void {
+    if (selectedOptions.environmentName && selectedOptions.envFile) {
+        throw new Error("--env and --env-file are mutually exclusive");
+    }
+    if (selectedOptions.environmentName) normalizeEnvironmentName(selectedOptions.environmentName);
+}
+
+export function parseGlobalAdminOptions(args: string[]): GlobalAdminOptions {
+    const selectedOptions: Partial<Record<GlobalOptionKey, string>> = {};
+    const commandArgs: string[] = [];
+
+    for (let index = 0; index < args.length;) {
+        const parsedArgument = parseGlobalArgument(args, index, selectedOptions);
+        if (parsedArgument.commandArgument !== undefined) {
+            commandArgs.push(parsedArgument.commandArgument);
+        } else if (parsedArgument.optionKey && parsedArgument.optionValue !== undefined) {
+            selectedOptions[parsedArgument.optionKey] = parsedArgument.optionValue;
+        }
+        index += parsedArgument.consumed;
+    }
+
+    validateEnvironmentSelection(selectedOptions);
+    return { ...selectedOptions, args: commandArgs };
+}

--- a/packages/admin/src/shared/schema.ts
+++ b/packages/admin/src/shared/schema.ts
@@ -76,6 +76,9 @@ export function decodedSchema<TInput extends TSchema, TOutput extends TSchema>(
 }
 
 export function schemaEnumValues(schema: TSchema): string[] {
+    if (typeof schema.const === "string" || typeof schema.const === "number") {
+        return [String(schema.const)];
+    }
     if (!Array.isArray(schema.anyOf)) return [];
     return schema.anyOf.flatMap((branch: unknown) => {
         if (typeof branch !== "object" || branch === null || !("const" in branch)) return [];


### PR DESCRIPTION
## Summary

- Add self-contained global --env, --env-file, and SUPACLOUD_ENV selection with atomic context sources.
- Classify every registered Admin action as read or write, including conditional service and tenant status actions, and fail on catalog drift.
- Block all remote writes in read-only mode and require exact production confirmation for project, platform, and SSH targets.
- Reject cross-project production targeting and keep status, help, errors, and tests free of credential reflection.
- Document the supported environment and confirmation contracts.

## Safety

- Production project writes require the exact requested ref.
- Ref-less platform and SSH writes bind confirmation to the exact API or SSH host.
- Unknown actions fail closed in production and read-only contexts.
- Invalid SSH ports and credential-bearing Management URLs are rejected at the context boundary.

## Verification

- bun test: 230 pass, 0 fail, 1381 expectations
- bun run typecheck
- bun run build
- git diff --check
- clean-code-guard: 4 fixed, 0 flagged for author