### PR TITLE
fix(lite): guard db reset on uninitialized state

### DIFF
--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -109,6 +109,8 @@ supacloud-lite inspect
 supacloud-lite version
 ```
 
+首次初始化或 state 目录不存在/为空时，先运行 `supacloud-lite migrate`。`db reset` 只接受已经初始化且保留有效 `secrets.json` 标记的 state；它不会为 reset 创建或覆盖项目 secrets。
+
 通用参数：
 
 - `--project-dir`：包含 `supabase/` 的项目目录
@@ -257,7 +259,7 @@ RLS 表的 Realtime DELETE 无法在行删除后安全重放 SELECT policy，因
 应用代码、SQL migrations、RLS policy、Storage 调用和 Realtime 订阅可以保持原来的 Supabase 形状。迁移时仍需验证以下边界：
 
 1. 把现有 `supabase/migrations`、`config.toml`、Functions 和 seed 文件带到 Lite 项目。
-2. 用 `supacloud-lite db reset` 在空库重放 schema，再导入业务数据。
+2. 先用 `supacloud-lite migrate` 初始化空 state 并重放 schema；只有在已初始化的可丢弃 state 上需要再次重放时才使用 `supacloud-lite db reset`，然后导入业务数据。
 3. 对使用 PGlite 未提供扩展或 PostgREST 高级语法的 SQL/API 做替代处理。
 4. 通过真实 `@supabase/supabase-js` 集成测试验证关键查询、RLS、Storage 和 Realtime。
 
@@ -441,6 +443,8 @@ supacloud-lite inspect
 supacloud-lite version
 ```
 
+Run `supacloud-lite migrate` first when initializing a project or when the state directory is missing or empty. `db reset` only accepts initialized state with a valid `secrets.json` marker; it never creates or replaces project secrets for a reset.
+
 Common flags:
 
 - `--project-dir`: the project directory containing `supabase/`
@@ -589,7 +593,7 @@ Realtime DELETE on RLS tables cannot safely replay SELECT policies after a row i
 Application code, SQL migrations, RLS policies, Storage calls, and Realtime subscriptions can keep their original Supabase shape. When migrating, you still need to validate the following boundaries:
 
 1. Bring the existing `supabase/migrations`, `config.toml`, Functions, and seed files into the Lite project.
-2. Use `supacloud-lite db reset` to replay the schema on an empty database, then import business data.
+2. Use `supacloud-lite migrate` to initialize empty state and replay the schema. Use `supacloud-lite db reset` only when replaying an already initialized disposable state, then import business data.
 3. Provide alternatives for SQL/API that use extensions not offered by PGlite or advanced PostgREST syntax.
 4. Verify key queries, RLS, Storage, and Realtime through real `@supabase/supabase-js` integration tests.
 

--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -367,7 +367,7 @@ Commands:
   keys                  print the anon key
   keys --service-role   also print the privileged service_role key
   gen types             emit Supabase-shaped TypeScript database types
-  db reset              wipe database and storage, then re-run migrations
+  db reset              reset initialized database/storage and re-run migrations
   db diff               print schema changes outside migrations
   db pull [name]        write live schema changes as an applied migration
   snapshot create       create a compressed database/storage/secrets snapshot
@@ -375,6 +375,8 @@ Commands:
   upgrade               snapshot first, then apply pending migrations
   inspect               show table rows and sizes
   version               print the package version
+
+Fresh projects must run "supacloud-lite migrate" before "db reset".
 
 Options:
   -p, --port <n>          port (default 54321)

--- a/packages/supacloud-lite/src/project-runtime.ts
+++ b/packages/supacloud-lite/src/project-runtime.ts
@@ -12,6 +12,9 @@ import { MemoryStorageDriver } from './runtime/storage/driver.js'
 import { S3StorageDriver, type S3StorageDriverOptions } from './runtime/storage/s3-driver.js'
 import type { SmsSender, StorageDriver } from './runtime/types.js'
 
+const RESET_INITIALIZATION_ERROR = 'db reset requires initialized state; run "supacloud-lite migrate" first'
+const RESET_INVALID_SECRETS_ERROR = 'db reset requires a valid project secrets marker; restore the state before retrying'
+
 export interface ProjectSecrets {
   jwtSecret: string
   vaultKey: string
@@ -91,7 +94,7 @@ export function resolveProjectPaths(options: ProjectRuntimeOptions = {}): Projec
 export async function assertResetPathsSafe(paths: ProjectPaths): Promise<void> {
   const stateDir = resolve(paths.stateDir)
   if (stateDir === parse(stateDir).root) throw new Error('refusing to use the filesystem root as the state directory')
-  const stateInfo = await lstat(stateDir)
+  const stateInfo = await requiredResetEntry(stateDir)
   if (!stateInfo.isDirectory() || stateInfo.isSymbolicLink()) {
     throw new Error(`refusing to reset through an invalid state directory: ${stateDir}`)
   }
@@ -100,10 +103,11 @@ export async function assertResetPathsSafe(paths: ProjectPaths): Promise<void> {
   if (secretsFile !== join(stateDir, 'secrets.json')) {
     throw new Error(`refusing to reset a state directory with an invalid secrets marker path: ${secretsFile}`)
   }
-  const markerInfo = await lstat(secretsFile)
+  const markerInfo = await requiredResetEntry(secretsFile)
   if (!markerInfo.isFile() || markerInfo.isSymbolicLink()) {
     throw new Error(`refusing to reset a state directory without a valid secrets marker: ${stateDir}`)
   }
+  await assertResetSecretsValid(secretsFile)
   const targets = [
     ...(paths.dataDir ? [['database', paths.dataDir] as const] : []),
     ['storage', paths.storageDir] as const,
@@ -115,6 +119,31 @@ export async function assertResetPathsSafe(paths: ProjectPaths): Promise<void> {
       throw new Error(`refusing to reset ${label} path outside the state directory: ${target}`)
     }
     await assertResetTargetCanonical(stateDir, canonicalStateDir, target, label)
+  }
+}
+
+async function requiredResetEntry(path: string) {
+  try {
+    return await lstat(path)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') throw new Error(RESET_INITIALIZATION_ERROR)
+    throw error
+  }
+}
+
+async function assertResetSecretsValid(path: string): Promise<void> {
+  let serializedSecrets: string
+  try {
+    serializedSecrets = await readFile(path, 'utf8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') throw new Error(RESET_INITIALIZATION_ERROR)
+    throw error
+  }
+  // Persisted marker content is untrusted; collapse parse/shape failures before any destructive work.
+  try {
+    validateSecrets(JSON.parse(serializedSecrets) as Partial<ProjectSecrets>)
+  } catch {
+    throw new Error(RESET_INVALID_SECRETS_ERROR)
   }
 }
 

--- a/packages/supacloud-lite/src/project-runtime.ts
+++ b/packages/supacloud-lite/src/project-runtime.ts
@@ -105,7 +105,7 @@ export async function assertResetPathsSafe(paths: ProjectPaths): Promise<void> {
   }
   const markerInfo = await requiredResetEntry(secretsFile)
   if (!markerInfo.isFile() || markerInfo.isSymbolicLink()) {
-    throw new Error(`refusing to reset a state directory without a valid secrets marker: ${stateDir}`)
+    throw new Error(RESET_INVALID_SECRETS_ERROR)
   }
   await assertResetSecretsValid(secretsFile)
   const targets = [

--- a/packages/supacloud-lite/src/snapshot.ts
+++ b/packages/supacloud-lite/src/snapshot.ts
@@ -1,4 +1,4 @@
-import { chmod, copyFile, link, lstat, mkdir, mkdtemp, readdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { chmod, copyFile, lstat, mkdir, mkdtemp, readdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, parse, relative, resolve, sep } from 'node:path'
 import { create as createTar, extract as extractTar } from 'tar'
 import type { ConfiguredStorageBackend, ProjectPaths } from './project-runtime.js'
@@ -263,13 +263,7 @@ async function stageDirectory(root: string, destination: string): Promise<void> 
 
 async function stageFile(source: string, target: string): Promise<void> {
   await mkdir(dirname(target), { recursive: true })
-  try {
-    await link(source, target)
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code
-    if (code !== 'EXDEV' && code !== 'EPERM' && code !== 'EACCES') throw error
-    await copyFile(source, target)
-  }
+  await copyFile(source, target)
 }
 
 async function readManifest(payloadRoot: string): Promise<SnapshotManifest> {

--- a/packages/supacloud-lite/test/db-reset.test.ts
+++ b/packages/supacloud-lite/test/db-reset.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
+
+const cliPath = resolve(import.meta.dir, '../src/cli.ts')
+const initializationError = 'db reset requires initialized state; run "supacloud-lite migrate" first\n'
+const invalidMarkerError = 'db reset requires a valid project secrets marker; restore the state before retrying\n'
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('db reset CLI', () => {
+  // Boundary cases: missing state, empty state, and initialized state with a valid secrets marker.
+  test('rejects a missing state without creating it or leaking filesystem details', async () => {
+    const projectDir = await temporaryProject()
+    const reset = await runCli(projectDir, ['db', 'reset'])
+
+    expect(reset.exitCode).toBe(1)
+    expect(reset.stdout).toBe('')
+    expect(reset.stderr === initializationError).toBe(true)
+    expect(reset.stderr.includes(projectDir)).toBe(false)
+    expect(reset.stderr.includes('ENOENT')).toBe(false)
+    await expect(access(join(projectDir, '.supacloud-lite'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  test('rejects an empty state without creating a secrets marker', async () => {
+    const projectDir = await temporaryProject()
+    const stateDir = join(projectDir, '.supacloud-lite')
+    await mkdir(stateDir)
+
+    const reset = await runCli(projectDir, ['db', 'reset'])
+
+    expect(reset.exitCode).toBe(1)
+    expect(reset.stdout).toBe('')
+    expect(reset.stderr === initializationError).toBe(true)
+    expect(reset.stderr.includes(projectDir)).toBe(false)
+    expect(reset.stderr.includes('ENOENT')).toBe(false)
+    expect(await readdir(stateDir)).toEqual([])
+  })
+
+  test('resets initialized state without replacing its secrets', async () => {
+    const projectDir = await temporaryProject()
+    const migrationsDir = join(projectDir, 'supabase', 'migrations')
+    const migrationVersion = '20260811000000'
+    await mkdir(migrationsDir, { recursive: true })
+    await writeFile(
+      join(migrationsDir, `${migrationVersion}_reset_contract.sql`),
+      'create table public.reset_contract (id bigint primary key);\n'
+    )
+
+    const migrated = await runCli(projectDir, ['migrate'])
+    expect(migrated.exitCode).toBe(0)
+    expect(migrated.stderr).toBe('')
+    const secretsPath = join(projectDir, '.supacloud-lite', 'secrets.json')
+    const secretsBeforeReset = await readFile(secretsPath, 'utf8')
+
+    const reset = await runCli(projectDir, ['db', 'reset'])
+    expect(reset.exitCode).toBe(0)
+    expect(reset.stderr).toBe('')
+    expect(reset.stdout).toBe('reset complete: 1 migration(s) applied\n')
+    expect((await readFile(secretsPath, 'utf8')) === secretsBeforeReset).toBe(true)
+
+    const status = await runCli(projectDir, ['status'])
+    expect(status.exitCode).toBe(0)
+    expect(status.stdout.includes(migrationVersion)).toBe(true)
+  }, 30_000)
+
+  test('preserves database and storage when the secrets marker is invalid', async () => {
+    const projectDir = await temporaryProject()
+    const stateDir = join(projectDir, '.supacloud-lite')
+    const dataSentinel = join(stateDir, 'db', 'database.sentinel')
+    const storageSentinel = join(stateDir, 'storage', 'storage.sentinel')
+    const secretsPath = join(stateDir, 'secrets.json')
+    await mkdir(join(stateDir, 'db'), { recursive: true })
+    await mkdir(join(stateDir, 'storage'))
+    await writeFile(dataSentinel, 'database preserved')
+    await writeFile(storageSentinel, 'storage preserved')
+    await writeFile(secretsPath, '{}\n')
+
+    const reset = await runCli(projectDir, ['db', 'reset'])
+    expect(reset.exitCode).toBe(1)
+    expect(reset.stdout).toBe('')
+    expect(reset.stderr === invalidMarkerError).toBe(true)
+    expect(reset.stderr.includes(projectDir)).toBe(false)
+    expect(reset.stderr.includes('ENOENT')).toBe(false)
+    expect(await readFile(dataSentinel, 'utf8')).toBe('database preserved')
+    expect(await readFile(storageSentinel, 'utf8')).toBe('storage preserved')
+    expect(await readFile(secretsPath, 'utf8')).toBe('{}\n')
+  })
+
+  test('directs fresh projects to migrate in CLI help', async () => {
+    const help = await runCli(await temporaryProject(), ['--help'])
+    expect(help.exitCode).toBe(0)
+    expect(help.stderr).toBe('')
+    expect(help.stdout).toContain('Fresh projects must run "supacloud-lite migrate" before "db reset".')
+  })
+})
+
+async function temporaryProject(): Promise<string> {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-db-reset-'))
+  temporaryDirectories.push(projectDir)
+  return projectDir
+}
+
+async function runCli(projectDir: string, command: string[]) {
+  const bunExecutable = Bun.which('bun')
+  if (!bunExecutable) throw new Error('Bun is required to run the Lite CLI test')
+  const cliProcess = Bun.spawn({
+    cmd: [bunExecutable, cliPath, ...command, '--project-dir', projectDir],
+    cwd: projectDir,
+    env: isolatedProjectEnvironment(),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await withWindowsSubprocessRef(() => Promise.all([
+    cliProcess.exited,
+    new Response(cliProcess.stdout).text(),
+    new Response(cliProcess.stderr).text(),
+  ]))
+  return { exitCode, stdout, stderr }
+}
+
+function isolatedProjectEnvironment(): Record<string, string | undefined> {
+  const environment = { ...process.env }
+  delete environment.SUPACLOUD_LITE_JWT_SECRET
+  delete environment.SUPACLOUD_LITE_VAULT_KEY
+  delete environment.SUPACLOUD_LITE_STATE_DIR
+  delete environment.SUPACLOUD_LITE_DATA_DIR
+  delete environment.SUPACLOUD_LITE_STORAGE_DIR
+  delete environment.SUPACLOUD_LITE_STORAGE_BACKEND
+  return environment
+}

--- a/packages/supacloud-lite/test/db-reset.test.ts
+++ b/packages/supacloud-lite/test/db-reset.test.ts
@@ -3,6 +3,7 @@ import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:f
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
+import { createSymlinkIfPermitted } from './support/symlink.js'
 
 const cliPath = resolve(import.meta.dir, '../src/cli.ts')
 const initializationError = 'db reset requires initialized state; run "supacloud-lite migrate" first\n'
@@ -90,6 +91,60 @@ describe('db reset CLI', () => {
     expect(await readFile(dataSentinel, 'utf8')).toBe('database preserved')
     expect(await readFile(storageSentinel, 'utf8')).toBe('storage preserved')
     expect(await readFile(secretsPath, 'utf8')).toBe('{}\n')
+  })
+
+  test('preserves state and redacts paths when the secrets marker is a directory', async () => {
+    const projectDir = await temporaryProject()
+    const stateDir = join(projectDir, '.supacloud-lite')
+    const dataSentinel = join(stateDir, 'db', 'database.sentinel')
+    const storageSentinel = join(stateDir, 'storage', 'storage.sentinel')
+    const markerDirectory = join(stateDir, 'secrets.json')
+    const markerSentinel = join(markerDirectory, 'marker.sentinel')
+    await mkdir(join(stateDir, 'db'), { recursive: true })
+    await mkdir(join(stateDir, 'storage'))
+    await mkdir(markerDirectory)
+    await writeFile(dataSentinel, 'database preserved')
+    await writeFile(storageSentinel, 'storage preserved')
+    await writeFile(markerSentinel, 'directory marker preserved')
+
+    const reset = await runCli(projectDir, ['db', 'reset'])
+
+    expect(reset.exitCode).toBe(1)
+    expect(reset.stdout).toBe('')
+    expect(reset.stderr).toBe(invalidMarkerError)
+    expect(reset.stderr.includes(projectDir)).toBe(false)
+    expect(reset.stderr.includes('ENOENT')).toBe(false)
+    expect(await readFile(dataSentinel, 'utf8')).toBe('database preserved')
+    expect(await readFile(storageSentinel, 'utf8')).toBe('storage preserved')
+    expect(await readFile(markerSentinel, 'utf8')).toBe('directory marker preserved')
+  })
+
+  test('preserves state and redacts paths when the secrets marker is a symbolic link', async () => {
+    const projectDir = await temporaryProject()
+    const stateDir = join(projectDir, '.supacloud-lite')
+    const dataSentinel = join(stateDir, 'db', 'database.sentinel')
+    const storageSentinel = join(stateDir, 'storage', 'storage.sentinel')
+    const secretsPath = join(stateDir, 'secrets.json')
+    const externalMarker = join(projectDir, 'external-secrets.json')
+    const externalSecret = 'must-not-appear-in-reset-output'
+    await mkdir(join(stateDir, 'db'), { recursive: true })
+    await mkdir(join(stateDir, 'storage'))
+    await writeFile(dataSentinel, 'database preserved')
+    await writeFile(storageSentinel, 'storage preserved')
+    await writeFile(externalMarker, externalSecret)
+    if (!await createSymlinkIfPermitted(externalMarker, secretsPath)) return
+
+    const reset = await runCli(projectDir, ['db', 'reset'])
+
+    expect(reset.exitCode).toBe(1)
+    expect(reset.stdout).toBe('')
+    expect(reset.stderr).toBe(invalidMarkerError)
+    expect(reset.stderr.includes(projectDir)).toBe(false)
+    expect(reset.stderr.includes('ENOENT')).toBe(false)
+    expect(reset.stderr.includes(externalSecret)).toBe(false)
+    expect(await readFile(dataSentinel, 'utf8')).toBe('database preserved')
+    expect(await readFile(storageSentinel, 'utf8')).toBe('storage preserved')
+    expect(await readFile(externalMarker, 'utf8')).toBe(externalSecret)
   })
 
   test('directs fresh projects to migrate in CLI help', async () => {

--- a/packages/supacloud-lite/test/snapshot.test.ts
+++ b/packages/supacloud-lite/test/snapshot.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test'
-import { access, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { access, link, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { list as listTar } from 'tar'
 import { createProjectBackend, ensureProjectSecrets, resolveProjectPaths } from '../src/project-runtime.js'
 import { createSnapshot, restoreSnapshot } from '../src/snapshot.js'
 import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
@@ -136,6 +137,30 @@ describe('Lite snapshots', () => {
     await restoreSnapshot({ paths: targetPaths, storageBackend: 'fs', input: archivePath })
     expect(await readdir(targetPaths.dataDir!)).toEqual([])
     expect(await readdir(targetPaths.storageDir)).toEqual([])
+  })
+
+  test('creates portable snapshots from hard-linked state files', async () => {
+    const sourceProject = await temporaryProject('supacloud-lite-snapshot-hard-links-source-')
+    const sourcePaths = resolveProjectPaths({ projectDir: sourceProject })
+    await ensureProjectSecrets(sourcePaths)
+    await mkdir(sourcePaths.dataDir!, { recursive: true })
+    await mkdir(sourcePaths.storageDir, { recursive: true })
+    const primaryFile = join(sourcePaths.storageDir, 'primary.txt')
+    const linkedFile = join(sourcePaths.storageDir, 'linked.txt')
+    await writeFile(primaryFile, 'shared-storage-content')
+    await link(primaryFile, linkedFile)
+    const archivePath = join(sourceProject, 'hard-links.tar.gz')
+    await createSnapshot({ paths: sourcePaths, packageVersion: 'test-version', storageBackend: 'fs', output: archivePath })
+    const archiveEntryTypes: string[] = []
+    await listTar({ file: archivePath, onReadEntry: (entry) => archiveEntryTypes.push(entry.type) })
+    expect(archiveEntryTypes).not.toContain('Link')
+
+    const targetProject = await temporaryProject('supacloud-lite-snapshot-hard-links-target-')
+    const targetPaths = resolveProjectPaths({ projectDir: targetProject })
+    await restoreSnapshot({ paths: targetPaths, storageBackend: 'fs', input: archivePath })
+
+    expect(await readFile(join(targetPaths.storageDir, 'primary.txt'), 'utf8')).toBe('shared-storage-content')
+    expect(await readFile(join(targetPaths.storageDir, 'linked.txt'), 'utf8')).toBe('shared-storage-content')
   })
 
   test('exposes snapshot and upgrade through the CLI', async () => {


### PR DESCRIPTION
## Summary

- fail closed with an actionable CLI error when `db reset` is run against a missing or empty Lite state
- validate the persisted `secrets.json` marker before deleting database or storage data
- align CLI help and README guidance: initialize fresh projects with `supacloud-lite migrate`

## TDD evidence

RED 1:
- public CLI behavior tests for missing state and an empty state failed because the raw `ENOENT` and absolute path reached stderr

GREEN 1:
- both boundaries now exit 1 with the stable message:
  `db reset requires initialized state; run "supacloud-lite migrate" first`
- neither state nor secrets are created

Verifier RED:
- an ordinary but corrupt `secrets.json` marker passed the path checks, so database and storage sentinels were removed before parsing failed

Verifier GREEN:
- marker parsing and shape validation now happen before any destructive removal
- corrupt markers exit 1 with a sanitized error while database, storage, and marker bytes remain unchanged
- valid initialized reset still succeeds and preserves the existing secrets file byte-for-byte

## Compatibility and upgrade

- initialized projects keep the existing destructive reset behavior
- fresh/missing/empty states now receive deterministic migrate-first guidance instead of a low-level filesystem error
- no state schema migration and no automatic secret creation or replacement
- this PR is independent of #817 and contains only Lite reset/help/documentation changes

## Safety boundaries

- reset path containment and symlink checks remain in force
- missing and invalid markers fail before database or storage deletion
- stderr does not include absolute paths, low-level `ENOENT`, or secret material
- no secret values were written to tests, logs, or this PR

## Verification

- regression suite: 5 tests, 31 assertions
- package `bun run check`: 142 tests, 764 assertions
- typecheck, JS/type build, package smoke, standalone build, and standalone smoke: PASS
- independent read-only verifier: PASS, including missing/empty/corrupt markers, path/symlink boundaries, sentinel preservation, docs/help, and clean-code review
