### PR TITLE
fix(lite): prevent Windows standalone smoke pipe deadlock

### DIFF
--- a/packages/supacloud-lite/scripts/standalone-smoke.ts
+++ b/packages/supacloud-lite/scripts/standalone-smoke.ts
@@ -2,7 +2,7 @@ import { access, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/p
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import packageJson from '../package.json' with { type: 'json' }
-import { withWindowsSubprocessRef } from './subprocess.js'
+import { executeBufferedCommand, withWindowsSubprocessRef } from './subprocess.js'
 
 const packageDir = resolve(import.meta.dir, '..')
 const binary = resolveStandaloneBinary()
@@ -12,6 +12,7 @@ const migrationDir = join(projectDir, 'supabase', 'migrations')
 const functionDir = join(projectDir, 'supabase', 'functions', 'ping')
 const v1 = '20260729000000'
 const v2 = '20260729000001'
+const commandTimeoutMs = 120_000
 
 try {
   await access(binary)
@@ -274,12 +275,14 @@ async function runCommand(
   env: NodeJS.ProcessEnv,
 ): Promise<string> {
   console.log(`[standalone-smoke] ${commandLabel}: start`)
-  const processHandle = Bun.spawn({ cmd: command, cwd, env, stdout: 'pipe', stderr: 'pipe' })
-  const stdoutPromise = new Response(processHandle.stdout).text()
-  const stderrPromise = new Response(processHandle.stderr).text()
-  const exitCode = await withWindowsSubprocessRef(() => processHandle.exited)
+  const { exitCode, stdout, stderr, timedOut } = await executeBufferedCommand({
+    command,
+    cwd,
+    env,
+    timeoutMs: commandTimeoutMs,
+  })
   console.log(`[standalone-smoke] ${commandLabel}: ${exitCode === 0 ? 'ok' : 'failed'} (exit ${exitCode})`)
-  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise])
+  if (timedOut) throw new Error(`standalone command "${commandLabel}" timed out after ${commandTimeoutMs}ms\n${stdout}\n${stderr}`)
   if (exitCode !== 0) throw new Error(`standalone command "${commandLabel}" failed (${exitCode})\n${stdout}\n${stderr}`)
   return stdout
 }

--- a/packages/supacloud-lite/scripts/subprocess.ts
+++ b/packages/supacloud-lite/scripts/subprocess.ts
@@ -11,3 +11,53 @@ export async function withWindowsSubprocessRef<T>(operation: () => Promise<T>): 
     clearInterval(eventLoopRef)
   }
 }
+
+export interface BufferedCommandOptions {
+  command: string[]
+  cwd: string
+  env: NodeJS.ProcessEnv
+  timeoutMs: number
+}
+
+export interface BufferedCommandExecution {
+  exitCode: number
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
+export async function executeBufferedCommand(options: BufferedCommandOptions): Promise<BufferedCommandExecution> {
+  const timeoutController = new AbortController()
+  const processHandle = spawnBufferedCommand(options, timeoutController.signal)
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    timeoutController.abort()
+  }, options.timeoutMs)
+  try {
+    const [exitCode, stdout, stderr] = await collectBufferedCommand(processHandle)
+    return { exitCode, stdout, stderr, timedOut }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function spawnBufferedCommand(options: BufferedCommandOptions, signal: AbortSignal) {
+  return Bun.spawn({
+    cmd: options.command,
+    cwd: options.cwd,
+    env: options.env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    signal,
+    killSignal: 'SIGKILL',
+  })
+}
+
+async function collectBufferedCommand(processHandle: ReturnType<typeof spawnBufferedCommand>) {
+  return await withWindowsSubprocessRef(() => Promise.all([
+    processHandle.exited,
+    new Response(processHandle.stdout).text(),
+    new Response(processHandle.stderr).text(),
+  ]))
+}

--- a/packages/supacloud-lite/test/subprocess.test.ts
+++ b/packages/supacloud-lite/test/subprocess.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'bun:test'
+import { executeBufferedCommand } from '../scripts/subprocess.js'
+
+const bunExecutable = Bun.which('bun')
+if (!bunExecutable) throw new Error('Bun is required to run subprocess tests')
+
+test('drains both output pipes while waiting for a command to exit', async () => {
+  const outputBytes = 2 * 1024 * 1024
+  const execution = await executeBufferedCommand({
+    command: [bunExecutable, '-e', `
+      const output = 'x'.repeat(${outputBytes})
+      process.stdout.write(output)
+      process.stderr.write(output)
+    `],
+    cwd: import.meta.dir,
+    env: process.env,
+    timeoutMs: 5_000,
+  })
+
+  expect(execution.exitCode).toBe(0)
+  expect(execution.timedOut).toBe(false)
+  expect(execution.stdout).toHaveLength(outputBytes)
+  expect(execution.stderr).toHaveLength(outputBytes)
+}, 10_000)
+
+test('force-terminates a command at its bounded timeout', async () => {
+  const startedAt = performance.now()
+  const execution = await executeBufferedCommand({
+    command: [bunExecutable, '-e', 'await Bun.sleep(30_000)'],
+    cwd: import.meta.dir,
+    env: process.env,
+    timeoutMs: 100,
+  })
+
+  expect(execution.timedOut).toBe(true)
+  expect(execution.exitCode).not.toBe(0)
+  expect(performance.now() - startedAt).toBeLessThan(5_000)
+}, 10_000)


### PR DESCRIPTION
## Summary

- drain subprocess exit, stdout, and stderr concurrently in the Lite standalone smoke runner
- bound every one-shot standalone command to 120 seconds and force-terminate the direct child on timeout
- cover pipe-buffer backpressure and timeout cleanup with real subprocess tests

## Root cause

Windows CI run 31464026583 attempt 1 stalled after `snapshot restore pre-upgrade: start` until the job timeout cancelled it. The standalone runner awaited `process.exited` separately from stdout and stderr completion, which can deadlock when a Windows pipe fills before process exit.

## TDD

RED: `bun test test/subprocess.test.ts --timeout 10000` failed because the buffered command seam did not exist.

GREEN:
- buffered subprocess tests: 2 pass, 0 fail
- subprocess plus snapshot tests: 8 pass, 0 fail
- independent stress verification: 40 pass, 0 fail across 20 repetitions

## Verification

- `bun run typecheck`
- `TMPDIR=/Volumes/Data/workspace/.codex-task-tmp bun run check`
  - 139 tests, 740 assertions, 0 failures
  - JS and type builds passed
  - package smoke passed
  - host standalone build and smoke passed
- `git diff --check origin/main...HEAD`
- independent verifier: PASS, no blockers

## Scope

This PR is based on current `origin/main` and contains only the standalone subprocess runner, standalone smoke wiring, and its regression test. It does not include the db reset changes from #826 or any separate stable-key diff.

Native `windows-latest` CI on Bun 1.3.14 remains the required merge gate.