### PR TITLE
feat(cli): add scheduled Function revision CAS

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -202,21 +202,28 @@ Scheduled Function lifecycle operations are also project-scoped:
 ```bash
 supacloud-cli scheduled_functions create --ref abc123 --name nightly \
   --slug cleanup --cron "0 2 * * *" --method POST
+supacloud-cli scheduled_functions get --ref abc123 --schedule_id <id>
 supacloud-cli scheduled_functions update --ref abc123 --schedule_id <id> \
-  --cron "0 3 * * *"
-supacloud-cli scheduled_functions delete --ref abc123 --schedule_id <id>
+  --expected_updated_at <updated_at-from-list> --cron "0 3 * * *"
+supacloud-cli scheduled_functions delete --ref abc123 --schedule_id <id> \
+  --expected_updated_at <updated_at-from-list>
 ```
 
 Schedule IDs are canonical UUIDv4 values returned by create/list. Cron values
 use bounded numeric five-field syntax with wildcards, lists, ranges, and steps;
 out-of-range endpoints and steps are rejected before HTTP dispatch.
+Update and delete require the exact canonical UTC `updated_at` returned by list.
+A stale revision fails with HTTP 409 and performs no mutation; read the list
+again before deciding whether to issue a new write.
 
 Use `--body_file ./payload.json` for a JSON-object request body. Header values
 must come from environment variables: pass a JSON name mapping such as
 `--header_env '{"x-schedule-token":"SCHEDULE_TOKEN"}'`. Platform-owned
 `authorization`, `apikey`, and `x-project-ref` headers cannot be overridden. Receipts never
 include header values or body content; list and mutation receipts report only
-whether the body is empty and the configured header names.
+whether the body is empty and the configured header names. Update receipts bind
+`previous_updated_at` to the requested revision and return a newer `updated_at`;
+delete receipts return the matched revision as `deleted_updated_at`.
 
 For secret writes, `--from-env` accepts a comma-separated list of environment
 variable names. The CLI reads each non-empty value from its own process

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -28,6 +28,7 @@ const LARGE_FUNCTION_SOURCE = "export const payload = "
     + JSON.stringify("x".repeat(80 * 1024))
     + ";\n";
 const SCHEDULE_ID = "00000000-0000-4000-8000-000000000001";
+const SCHEDULE_UPDATED_AT = "2026-08-11T00:00:00.000Z";
 const PATH_ESCAPE_INPUTS = [
     ".", "..", "%2e", "%2e%2e", ".%2e", "%2e.", "%252e%252e", "a/b", "a?b", "a#b",
 ];
@@ -1010,6 +1011,80 @@ describe("supacloud-cli process contract", () => {
         expect(response.stdout + response.stderr).not.toContain(bodySentinel);
     });
 
+    test("gets, updates, and deletes a schedule with revision-bound receipts", async () => {
+        const nextUpdatedAt = "2026-08-11T00:00:00.001Z";
+        const requestedMethods: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestedMethods.push(request.method);
+                const requestUrl = new URL(request.url);
+                const schedule = {
+                    id: SCHEDULE_ID,
+                    name: "Nightly",
+                    slug: "worker",
+                    cron: "0 2 * * *",
+                    method: "POST",
+                    enabled: request.method === "PATCH" ? false : true,
+                    body_empty: true,
+                    header_names: [],
+                    created_at: SCHEDULE_UPDATED_AT,
+                    updated_at: request.method === "PATCH" ? nextUpdatedAt : SCHEDULE_UPDATED_AT,
+                };
+                if (request.method === "GET") {
+                    return Response.json({ project_ref: "abc123", schedule });
+                }
+                if (request.method === "PATCH") {
+                    const body = await request.json() as Record<string, unknown>;
+                    return Response.json({
+                        updated: true,
+                        project_ref: "abc123",
+                        request_id: body.request_id,
+                        previous_updated_at: body.expected_updated_at,
+                        schedule,
+                    });
+                }
+                return Response.json({
+                    deleted: true,
+                    project_ref: "abc123",
+                    schedule_id: SCHEDULE_ID,
+                    deleted_updated_at: requestUrl.searchParams.get("expected_updated_at"),
+                });
+            },
+        });
+        servers.push(server);
+        const environment = {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        };
+
+        const getResponse = await runProjectCli([
+            "scheduled_functions", "get", "--ref", "abc123", "--schedule_id", SCHEDULE_ID,
+        ], environment);
+        const updateResponse = await runProjectCli([
+            "scheduled_functions", "update", "--ref", "abc123", "--schedule_id", SCHEDULE_ID,
+            "--expected_updated_at", SCHEDULE_UPDATED_AT, "--enabled", "false",
+        ], environment);
+        const deleteResponse = await runProjectCli([
+            "scheduled_functions", "delete", "--ref", "abc123", "--schedule_id", SCHEDULE_ID,
+            "--expected_updated_at", nextUpdatedAt,
+        ], environment);
+
+        expect([getResponse.exitCode, updateResponse.exitCode, deleteResponse.exitCode]).toEqual([0, 0, 0]);
+        expect(JSON.parse(getResponse.stdout).schedule.updated_at).toBe(SCHEDULE_UPDATED_AT);
+        expect(JSON.parse(updateResponse.stdout)).toMatchObject({
+            previous_updated_at: SCHEDULE_UPDATED_AT,
+            schedule: { updated_at: nextUpdatedAt, enabled: false },
+        });
+        expect(JSON.parse(deleteResponse.stdout)).toMatchObject({
+            deleted: true,
+            deleted_updated_at: nextUpdatedAt,
+        });
+        expect(requestedMethods).toEqual(["GET", "PATCH", "DELETE"]);
+    });
+
     test.each(PATH_ESCAPE_INPUTS)("rejects schedule path escape '%s' before any HTTP request", async (scheduleId) => {
         let requestCount = 0;
         let projectMutationCount = 0;
@@ -1081,7 +1156,10 @@ describe("supacloud-cli process contract", () => {
         servers.push(server);
 
         const response = await runProjectCli(
-            ["scheduled_functions", "delete", "--ref", "abc123", "--schedule_id", SCHEDULE_ID],
+            [
+                "scheduled_functions", "delete", "--ref", "abc123", "--schedule_id", SCHEDULE_ID,
+                "--expected_updated_at", SCHEDULE_UPDATED_AT,
+            ],
             {
                 SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
                 SUPACLOUD_API_TOKEN: "test-token",

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -134,6 +134,7 @@ describe("CLI execution policy", () => {
     test("classifies Function, Scheduled Function, and Storage lifecycle actions", () => {
         expect(executionMode("edge_functions", "activate", {})).toBe("write");
         expect(executionMode("scheduled_functions", "list", {})).toBe("read");
+        expect(executionMode("scheduled_functions", "get", {})).toBe("read");
         for (const action of ["create", "update", "delete"]) {
             expect(executionMode("scheduled_functions", action, {})).toBe("write");
         }

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -36,7 +36,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         local: ["check"],
         write: ["deploy", "deploy_bundle", "config", "activate", "delete"],
     },
-    scheduled_functions: { read: ["list"], write: ["create", "update", "delete"] },
+    scheduled_functions: { read: ["list", "get"], write: ["create", "update", "delete"] },
     secrets: { read: ["list"], write: ["upsert", "delete"] },
     frontend: {
         read: ["list", "get", "build_logs", "list_frameworks", "list_records"],

--- a/packages/cli/src/shared/tools/scheduled-function-tools.test.ts
+++ b/packages/cli/src/shared/tools/scheduled-function-tools.test.ts
@@ -8,6 +8,8 @@ import type { ToolSchema } from "../schema";
 
 const SCHEDULE_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_SCHEDULE_ID = "00000000-0000-4000-8000-000000000002";
+const UPDATED_AT = "2026-08-11T00:00:00.000Z";
+const NEXT_UPDATED_AT = "2026-08-11T00:00:00.001Z";
 
 function scheduleRecord(overrides: Record<string, unknown> = {}) {
     return {
@@ -19,8 +21,8 @@ function scheduleRecord(overrides: Record<string, unknown> = {}) {
         enabled: true,
         body_empty: true,
         header_names: [],
-        created_at: "2026-08-11T00:00:00.000Z",
-        updated_at: "2026-08-11T00:00:00.000Z",
+        created_at: UPDATED_AT,
+        updated_at: UPDATED_AT,
         ...overrides,
     };
 }
@@ -88,6 +90,7 @@ test("Scheduled Function list emits only safe machine-readable metadata", async 
         id: SCHEDULE_ID,
         body_empty: false,
         header_names: ["x-schedule-token"],
+        updated_at: UPDATED_AT,
     });
     expect(response.content[0].text).not.toContain(bodySentinel);
     expect(response.content[0].text).not.toContain(headerSentinel);
@@ -136,6 +139,31 @@ test("Scheduled Function read-only mode continues to allow list", async () => {
 
     expect(response.isError).not.toBe(true);
     expect(requestCount).toBe(1);
+});
+
+test("Scheduled Function get preserves the exact canonical revision in read-only mode", async () => {
+    const paths: string[] = [];
+    const { callback } = captureScheduledFunctionsTool({
+        get: async (path: string) => {
+            paths.push(path);
+            return {
+                ok: true,
+                status: 200,
+                data: { project_ref: "proj", schedule: scheduleRecord() },
+            };
+        },
+    }, {}, { readOnly: true });
+
+    const response = await callback({ action: "get", ref: "proj", schedule_id: SCHEDULE_ID });
+    const receipt = JSON.parse(response.content[0].text);
+
+    expect(response.isError).not.toBe(true);
+    expect(paths).toEqual([`/v1/projects/proj/scheduled-functions/${SCHEDULE_ID}`]);
+    expect(receipt).toMatchObject({
+        ok: true,
+        operation: "scheduled_functions.get",
+        schedule: { id: SCHEDULE_ID, updated_at: UPDATED_AT },
+    });
 });
 
 test("Scheduled Function create reads body and header values outside argv", async () => {
@@ -212,6 +240,51 @@ test.each([
     expect(response.content[0].text).not.toContain("private-server-detail");
 });
 
+test.each([
+    ` ${UPDATED_AT}`,
+    "2026-08-11T00:00:00Z",
+    "2026-08-11T08:00:00.000+08:00",
+    "2026-02-30T00:00:00.000Z",
+])("Scheduled Function list rejects non-canonical updated_at %j", async (updatedAt) => {
+    const { callback } = captureScheduledFunctionsTool({
+        get: async () => ({
+            ok: true,
+            status: 200,
+            data: { project_ref: "proj", schedules: [scheduleRecord({ updated_at: updatedAt })] },
+        }),
+    });
+
+    const response = await callback({ action: "list", ref: "proj" });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error.code).toBe("INVALID_RESPONSE");
+});
+
+test.each([
+    ["update", undefined],
+    ["delete", undefined],
+    ["update", ` ${UPDATED_AT}`],
+    ["delete", "2026-08-11T00:00:00Z"],
+    ["update", "2026-08-11T08:00:00.000+08:00"],
+    ["delete", "2026-02-30T00:00:00.000Z"],
+] as const)("Scheduled Function %s requires canonical expected_updated_at before HTTP", async (action, expectedUpdatedAt) => {
+    let requestCount = 0;
+    const { callback } = captureScheduledFunctionsTool({
+        patch: async () => { requestCount += 1; },
+        delete: async () => { requestCount += 1; },
+    });
+    const args: Record<string, unknown> = {
+        action,
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        ...(action === "update" ? { enabled: false } : {}),
+        ...(expectedUpdatedAt === undefined ? {} : { expected_updated_at: expectedUpdatedAt }),
+    };
+
+    await expect(callback(args)).rejects.toThrow("canonical UTC timestamp");
+    expect(requestCount).toBe(0);
+});
+
 test("Scheduled Function update confirms the exact schedule and requested fields", async () => {
     const requests: unknown[] = [];
     const { callback } = captureScheduledFunctionsTool({
@@ -224,7 +297,8 @@ test("Scheduled Function update confirms the exact schedule and requested fields
                     updated: true,
                     project_ref: "proj",
                     request_id: request.request_id,
-                    schedule: scheduleReceipt(request, { id: SCHEDULE_ID }),
+                    previous_updated_at: request.expected_updated_at,
+                    schedule: scheduleReceipt(request, { id: SCHEDULE_ID, updated_at: NEXT_UPDATED_AT }),
                 },
             };
         },
@@ -234,15 +308,17 @@ test("Scheduled Function update confirms the exact schedule and requested fields
         action: "update",
         ref: "proj",
         schedule_id: SCHEDULE_ID,
+        expected_updated_at: UPDATED_AT,
         cron: "0 3 * * *",
         enabled: false,
     });
 
     expect(requests).toHaveLength(1);
-    expect(requests[0]).toMatchObject({ cron: "0 3 * * *", enabled: false });
+    expect(requests[0]).toMatchObject({ expected_updated_at: UPDATED_AT, cron: "0 3 * * *", enabled: false });
     expect((requests[0] as Record<string, unknown>).request_id).toBeString();
     expect(JSON.parse(response.content[0].text)).toMatchObject({
         ok: true,
+        previous_updated_at: UPDATED_AT,
         schedule: { id: SCHEDULE_ID, cron: "0 3 * * *", enabled: false },
     });
 });
@@ -257,9 +333,11 @@ test("Scheduled Function update rejects a mismatched receipt without exposing re
                 updated: true,
                 project_ref: "proj",
                 request_id: request.request_id,
+                previous_updated_at: request.expected_updated_at,
                 schedule: scheduleRecord({
                     id: OTHER_SCHEDULE_ID,
                     cron: "0 3 * * *",
+                    updated_at: NEXT_UPDATED_AT,
                     body: { private: responseSentinel },
                 }),
             },
@@ -270,6 +348,7 @@ test("Scheduled Function update rejects a mismatched receipt without exposing re
         action: "update",
         ref: "proj",
         schedule_id: SCHEDULE_ID,
+        expected_updated_at: UPDATED_AT,
         cron: "0 3 * * *",
     });
 
@@ -279,6 +358,36 @@ test("Scheduled Function update rejects a mismatched receipt without exposing re
         http_status: 200,
     });
     expect(response.content[0].text).not.toContain(responseSentinel);
+});
+
+test.each([
+    ["mismatched previous revision", "2026-08-10T23:59:59.999Z", NEXT_UPDATED_AT],
+    ["non-advancing revision", UPDATED_AT, UPDATED_AT],
+])("Scheduled Function update rejects %s receipt", async (_label, previousUpdatedAt, updatedAt) => {
+    const { callback } = captureScheduledFunctionsTool({
+        patch: async (_path: string, request: Record<string, unknown>) => ({
+            ok: true,
+            status: 200,
+            data: {
+                updated: true,
+                project_ref: "proj",
+                request_id: request.request_id,
+                previous_updated_at: previousUpdatedAt,
+                schedule: scheduleReceipt(request, { id: SCHEDULE_ID, updated_at: updatedAt }),
+            },
+        }),
+    });
+
+    const response = await callback({
+        action: "update",
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        expected_updated_at: UPDATED_AT,
+        enabled: false,
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error.code).toBe("OUTCOME_UNKNOWN");
 });
 
 test("Scheduled Function list rejects duplicate schedule IDs", async () => {
@@ -414,7 +523,12 @@ test("Scheduled Function reports an unknown outcome after a transport failure", 
         }),
     });
 
-    const response = await callback({ action: "delete", ref: "proj", schedule_id: SCHEDULE_ID });
+    const response = await callback({
+        action: "delete",
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        expected_updated_at: UPDATED_AT,
+    });
     const receipt = JSON.parse(response.content[0].text);
 
     expect(response.isError).toBe(true);
@@ -433,7 +547,12 @@ test.each([408, 500, 503])(
             }),
         });
 
-        const response = await callback({ action: "delete", ref: "proj", schedule_id: SCHEDULE_ID });
+        const response = await callback({
+            action: "delete",
+            ref: "proj",
+            schedule_id: SCHEDULE_ID,
+            expected_updated_at: UPDATED_AT,
+        });
         const receipt = JSON.parse(response.content[0].text);
 
         expect(response.isError).toBe(true);
@@ -451,7 +570,8 @@ test("Scheduled Function rejects a mismatched request receipt", async () => {
                 updated: true,
                 project_ref: "proj",
                 request_id: "00000000-0000-4000-8000-000000000099",
-                schedule: scheduleReceipt(request, { id: SCHEDULE_ID }),
+                previous_updated_at: request.expected_updated_at,
+                schedule: scheduleReceipt(request, { id: SCHEDULE_ID, updated_at: NEXT_UPDATED_AT }),
             },
         }),
     });
@@ -460,6 +580,7 @@ test("Scheduled Function rejects a mismatched request receipt", async () => {
         action: "update",
         ref: "proj",
         schedule_id: SCHEDULE_ID,
+        expected_updated_at: UPDATED_AT,
         enabled: false,
     });
 
@@ -501,15 +622,56 @@ test("Scheduled Function delete validates the exact receipt", async () => {
             return {
                 ok: true,
                 status: 200,
-                data: { deleted: true, project_ref: "proj", schedule_id: SCHEDULE_ID },
+                data: {
+                    deleted: true,
+                    project_ref: "proj",
+                    schedule_id: SCHEDULE_ID,
+                    deleted_updated_at: UPDATED_AT,
+                },
             };
         },
     });
 
-    const response = await callback({ action: "delete", ref: "proj", schedule_id: SCHEDULE_ID });
+    const response = await callback({
+        action: "delete",
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        expected_updated_at: UPDATED_AT,
+    });
 
-    expect(paths).toEqual([`/v1/projects/proj/scheduled-functions/${SCHEDULE_ID}`]);
-    expect(JSON.parse(response.content[0].text)).toMatchObject({ ok: true, deleted: true });
+    expect(paths).toEqual([
+        `/v1/projects/proj/scheduled-functions/${SCHEDULE_ID}?expected_updated_at=${encodeURIComponent(UPDATED_AT)}`,
+    ]);
+    expect(JSON.parse(response.content[0].text)).toMatchObject({
+        ok: true,
+        deleted: true,
+        deleted_updated_at: UPDATED_AT,
+    });
+});
+
+test("Scheduled Function delete rejects a receipt bound to another revision", async () => {
+    const { callback } = captureScheduledFunctionsTool({
+        delete: async () => ({
+            ok: true,
+            status: 200,
+            data: {
+                deleted: true,
+                project_ref: "proj",
+                schedule_id: SCHEDULE_ID,
+                deleted_updated_at: NEXT_UPDATED_AT,
+            },
+        }),
+    });
+
+    const response = await callback({
+        action: "delete",
+        ref: "proj",
+        schedule_id: SCHEDULE_ID,
+        expected_updated_at: UPDATED_AT,
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error.code).toBe("OUTCOME_UNKNOWN");
 });
 
 test("Scheduled Function rejects a body file over 1 MiB before HTTP dispatch", async () => {

--- a/packages/cli/src/shared/tools/scheduled-function-tools.ts
+++ b/packages/cli/src/shared/tools/scheduled-function-tools.ts
@@ -23,7 +23,7 @@ type ToolServer = {
     ) => void;
 };
 
-type ScheduledFunctionAction = "list" | "create" | "update" | "delete";
+type ScheduledFunctionAction = "list" | "get" | "create" | "update" | "delete";
 
 interface ScheduledFunctionToolsOptions {
     readOnly?: boolean;
@@ -52,6 +52,7 @@ type ScheduleMutationExpectation = {
     ref: string;
     scheduleId: string;
     requestId: string;
+    expectedUpdatedAt: string;
     expectedFields: Record<string, unknown>;
 };
 
@@ -84,12 +85,14 @@ const MAX_BODY_FILE_BYTES = 1_048_576;
 const MAX_HEADER_COUNT = 64;
 const MAX_HEADER_VALUE_LENGTH = 8_192;
 const MAX_SCHEDULE_NAME_LENGTH = 120;
+const CANONICAL_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const headerEnvironmentRecord = Type.Record(Type.String(), Type.String());
 const ACTION_ARGUMENTS: Record<ScheduledFunctionAction, ReadonlySet<string>> = {
     list: new Set(["action", "ref"]),
+    get: new Set(["action", "ref", "schedule_id"]),
     create: new Set(["action", "ref", "name", "slug", "cron", "method", "body_file", "header_env"]),
-    update: new Set(["action", "ref", "schedule_id", "name", "cron", "method", "enabled", "body_file", "header_env"]),
-    delete: new Set(["action", "ref", "schedule_id"]),
+    update: new Set(["action", "ref", "schedule_id", "expected_updated_at", "name", "cron", "method", "enabled", "body_file", "header_env"]),
+    delete: new Set(["action", "ref", "schedule_id", "expected_updated_at"]),
 };
 
 function parseHeaderEnvironment(input: string | Record<string, string>): unknown {
@@ -239,7 +242,13 @@ function validScheduleDefinition(schedule: Record<string, unknown>): boolean {
 }
 
 function validScheduleMetadata(schedule: Record<string, unknown>): boolean {
-    return typeof schedule.created_at === "string" && typeof schedule.updated_at === "string";
+    return typeof schedule.created_at === "string" && isCanonicalTimestamp(schedule.updated_at);
+}
+
+function isCanonicalTimestamp(candidate: unknown): candidate is string {
+    if (typeof candidate !== "string" || !CANONICAL_TIMESTAMP_PATTERN.test(candidate)) return false;
+    const milliseconds = Date.parse(candidate);
+    return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === candidate;
 }
 
 function safeSchedulePayload(
@@ -318,6 +327,21 @@ function listResponse(ref: string, response: HttpResult<unknown>): ReleaseContro
     return releaseControlSuccess(operation, { project_ref: ref, schedules });
 }
 
+function getResponse(
+    ref: string,
+    scheduleId: string,
+    response: HttpResult<unknown>,
+): ReleaseControlToolResponse {
+    const operation = "scheduled_functions.get";
+    if (!response.ok) return scheduleFailure(operation, response);
+    const payload = objectRecord(response.data);
+    const schedule = safeSchedule(payload?.schedule);
+    if (payload?.project_ref !== ref || !schedule || schedule.id !== scheduleId) {
+        return releaseControlFailure(operation, "INVALID_RESPONSE", null);
+    }
+    return releaseControlSuccess(operation, { project_ref: ref, schedule });
+}
+
 function mutationResponse(
     expectation: ScheduleMutationExpectation,
     response: HttpResult<unknown>,
@@ -331,28 +355,40 @@ function mutationResponse(
     const confirmsRequest = schedule && Object.entries(expectedFields).every(
         ([field, expected]) => isDeepStrictEqual(schedule[field as keyof SafeScheduledFunction], expected),
     );
+    const confirmsRevision = action === "create"
+        || (payload?.previous_updated_at === expectation.expectedUpdatedAt
+            && schedule !== null && schedule.updated_at > expectation.expectedUpdatedAt);
     if (payload?.project_ref !== ref || payload.request_id !== requestId
         || payload?.[action === "create" ? "created" : "updated"] !== true
-        || !schedule || !confirmsRequest || (scheduleId !== undefined && schedule.id !== scheduleId)) {
+        || !schedule || !confirmsRequest || !confirmsRevision
+        || (scheduleId !== undefined && schedule.id !== scheduleId)) {
         return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status);
     }
-    return releaseControlSuccess(operation, { project_ref: ref, request_id: requestId, schedule });
+    return releaseControlSuccess(operation, {
+        project_ref: ref,
+        request_id: requestId,
+        ...(action === "update" ? { previous_updated_at: expectation.expectedUpdatedAt } : {}),
+        schedule,
+    });
 }
 
 function deleteResponse(
     ref: string,
     scheduleId: string,
+    expectedUpdatedAt: string,
     response: HttpResult<unknown>,
 ): ReleaseControlToolResponse {
     const operation = "scheduled_functions.delete";
     if (!response.ok) return releaseControlMutationFailure(operation, response);
     const payload = objectRecord(response.data);
-    if (payload?.deleted !== true || payload.project_ref !== ref || payload.schedule_id !== scheduleId) {
+    if (payload?.deleted !== true || payload.project_ref !== ref || payload.schedule_id !== scheduleId
+        || payload.deleted_updated_at !== expectedUpdatedAt) {
         return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status);
     }
     return releaseControlSuccess(operation, {
         project_ref: ref,
         schedule_id: scheduleId,
+        deleted_updated_at: expectedUpdatedAt,
         deleted: true,
     });
 }
@@ -412,10 +448,19 @@ function requiredCron(args: Record<string, unknown>, action: string): string {
     return cron;
 }
 
+function requiredExpectedUpdatedAt(args: Record<string, unknown>, action: "update" | "delete"): string {
+    const candidate = args.expected_updated_at;
+    if (!isCanonicalTimestamp(candidate)) {
+        throw new Error(`'expected_updated_at' must be a canonical UTC timestamp for '${action}'`);
+    }
+    return candidate;
+}
+
 function updateRequest(
     args: Record<string, unknown>,
     environment: NodeJS.ProcessEnv,
 ): Record<string, unknown> {
+    const expectedUpdatedAt = requiredExpectedUpdatedAt(args, "update");
     const body = scheduleBody(args.body_file);
     const headers = scheduleHeaders(args.header_env, environment);
     const cron = args.cron === undefined ? undefined : requiredCron(args, "update");
@@ -427,7 +472,15 @@ function updateRequest(
     if (Object.keys(mutationFields).length === 0) {
         throw new Error("Scheduled Function update requires at least one field");
     }
-    return { request_id: randomUUID(), ...mutationFields };
+    return {
+        request_id: randomUUID(),
+        expected_updated_at: expectedUpdatedAt,
+        ...mutationFields,
+    };
+}
+
+function deletePath(schedulePathname: string, expectedUpdatedAt: string): string {
+    return `${schedulePathname}?expected_updated_at=${encodeURIComponent(expectedUpdatedAt)}`;
 }
 
 async function executeScheduleAction(
@@ -437,7 +490,7 @@ async function executeScheduleAction(
     readOnly = false,
 ): Promise<ReleaseControlToolResponse> {
     const action = args.action as ScheduledFunctionAction;
-    if (readOnly && action !== "list") return readOnlyResult();
+    if (readOnly && action !== "list" && action !== "get") return readOnlyResult();
     assertActionArguments(action, args);
     const ref = requiredText(args, "ref", action);
     if (action === "list") return listResponse(ref, await http.get(schedulePath(ref)));
@@ -448,20 +501,24 @@ async function executeScheduleAction(
             await http.post(schedulePath(ref), request));
     }
     const scheduleId = requiredText(args, "schedule_id", action);
+    const targetPath = schedulePath(ref, scheduleId);
+    if (action === "get") return getResponse(ref, scheduleId, await http.get(targetPath));
     if (action === "update") {
         const request = updateRequest(args, environment);
         const requestId = request.request_id as string;
+        const expectedUpdatedAt = request.expected_updated_at as string;
         return mutationResponse({
             action,
             ref,
             scheduleId,
             requestId,
+            expectedUpdatedAt,
             expectedFields: safeMutationFields(request),
-        }, await http.patch(
-            schedulePath(ref, scheduleId), request,
-        ));
+        }, await http.patch(targetPath, request));
     }
-    return deleteResponse(ref, scheduleId, await http.delete(schedulePath(ref, scheduleId)));
+    const expectedUpdatedAt = requiredExpectedUpdatedAt(args, "delete");
+    return deleteResponse(ref, scheduleId, expectedUpdatedAt,
+        await http.delete(deletePath(targetPath, expectedUpdatedAt)));
 }
 
 export function registerScheduledFunctionTools(
@@ -474,11 +531,12 @@ export function registerScheduledFunctionTools(
         (args) => executeScheduleAction(http, environment, args, options.readOnly));
 }
 
-const SCHEDULE_TOOL_DESCRIPTION = "Scheduled Edge Function lifecycle. Actions: list, create, update, delete";
+const SCHEDULE_TOOL_DESCRIPTION = "Scheduled Edge Function lifecycle. Actions: list, get, create, update, delete";
 const SCHEDULE_TOOL_SCHEMA: ToolSchema = {
-    action: withDescription(stringEnum(["list", "create", "update", "delete"]), "Action"),
+    action: withDescription(stringEnum(["list", "get", "create", "update", "delete"]), "Action"),
     ref: withDescription(Type.String(), "Project ref"),
-    schedule_id: optional(Type.String(), "[update/delete] Schedule ID"),
+    schedule_id: optional(Type.String(), "[get/update/delete] Schedule ID"),
+    expected_updated_at: optional(Type.String(), "[update/delete] Canonical updated_at from list"),
     name: optional(Type.String(), "[create/update] Display name"),
     slug: optional(Type.String(), "[create] Edge Function slug"),
     cron: optional(Type.String(), "[create/update] Five-field cron expression"),

--- a/packages/management-api/src/repositories/project.repository.ts
+++ b/packages/management-api/src/repositories/project.repository.ts
@@ -2,6 +2,7 @@ import { sql, type Project, type CreateProjectInput, type ProjectStatus } from "
 import { withRetry } from "../utils/retry";
 import { encryptSecretIfNeeded } from "../utils/secret-crypto";
 import { hashSecretApiKey } from "../utils/api-keys";
+import { normalizeProjectConfig } from "../utils/project-config";
 
 export async function findAll(): Promise<Project[]> {
   return withRetry("ProjectRepository.findAll", async () => {
@@ -90,14 +91,12 @@ export async function updateStatus(ref: string, status: ProjectStatus): Promise<
 
   // Update project config
 export async function updateConfig(ref: string, config: Record<string, unknown>): Promise<Project | null> {
+  const nextConfig = normalizeProjectConfig(config);
   return withRetry("ProjectRepository.updateConfig", async () => {
   const [project] = await sql`
     UPDATE projects
     SET config =
-          CASE jsonb_typeof(${JSON.stringify(config)}::jsonb)
-            WHEN 'object' THEN ${JSON.stringify(config)}::jsonb - 'scheduled_functions'
-            ELSE '{}'::jsonb
-          END
+          (${JSON.stringify(nextConfig)}::jsonb - 'scheduled_functions')
           || CASE
             WHEN jsonb_typeof(projects.config) = 'object'
               AND projects.config ? 'scheduled_functions'

--- a/packages/management-api/src/repositories/project.repository.ts
+++ b/packages/management-api/src/repositories/project.repository.ts
@@ -40,6 +40,7 @@ export async function findById(id: string): Promise<Project | null> {
 
   // Create project
 export async function create(input: CreateProjectInput): Promise<Project> {
+  const initialConfig = normalizeProjectConfig(input.config);
   return withRetry("ProjectRepository.create", async () => {
   const [project] = await sql`
     INSERT INTO projects (
@@ -64,7 +65,7 @@ export async function create(input: CreateProjectInput): Promise<Project> {
       ${input.s3_access_key || null},
       ${input.s3_secret_key || null},
       ${input.region || "local"},
-      ${input.config ? JSON.stringify(input.config) : "{}"}::jsonb,
+      ${initialConfig}::jsonb,
       ${encryptSecretIfNeeded(input.db_password)},
       ${encryptSecretIfNeeded(input.jwt_secret)},
       ${encryptSecretIfNeeded(input.service_role_key)},
@@ -96,7 +97,7 @@ export async function updateConfig(ref: string, config: Record<string, unknown>)
   const [project] = await sql`
     UPDATE projects
     SET config =
-          (${JSON.stringify(nextConfig)}::jsonb - 'scheduled_functions')
+          (${nextConfig}::jsonb - 'scheduled_functions')
           || CASE
             WHEN jsonb_typeof(projects.config) = 'object'
               AND projects.config ? 'scheduled_functions'

--- a/packages/management-api/src/repositories/project.repository.ts
+++ b/packages/management-api/src/repositories/project.repository.ts
@@ -94,10 +94,14 @@ export async function updateConfig(ref: string, config: Record<string, unknown>)
   const [project] = await sql`
     UPDATE projects
     SET config =
-          (${JSON.stringify(config)}::jsonb - 'scheduled_functions')
+          CASE jsonb_typeof(${JSON.stringify(config)}::jsonb)
+            WHEN 'object' THEN ${JSON.stringify(config)}::jsonb - 'scheduled_functions'
+            ELSE '{}'::jsonb
+          END
           || CASE
-            WHEN config ? 'scheduled_functions'
-            THEN jsonb_build_object('scheduled_functions', config -> 'scheduled_functions')
+            WHEN jsonb_typeof(projects.config) = 'object'
+              AND projects.config ? 'scheduled_functions'
+            THEN jsonb_build_object('scheduled_functions', projects.config -> 'scheduled_functions')
             ELSE '{}'::jsonb
           END,
         updated_at = NOW()

--- a/packages/management-api/src/repositories/project.repository.ts
+++ b/packages/management-api/src/repositories/project.repository.ts
@@ -93,7 +93,14 @@ export async function updateConfig(ref: string, config: Record<string, unknown>)
   return withRetry("ProjectRepository.updateConfig", async () => {
   const [project] = await sql`
     UPDATE projects
-    SET config = ${JSON.stringify(config)}::jsonb, updated_at = NOW()
+    SET config =
+          (${JSON.stringify(config)}::jsonb - 'scheduled_functions')
+          || CASE
+            WHEN config ? 'scheduled_functions'
+            THEN jsonb_build_object('scheduled_functions', config -> 'scheduled_functions')
+            ELSE '{}'::jsonb
+          END,
+        updated_at = NOW()
     WHERE ref = ${ref} AND deleted_at IS NULL
     RETURNING *
   `;

--- a/packages/management-api/src/routes/scheduled-functions.ts
+++ b/packages/management-api/src/routes/scheduled-functions.ts
@@ -11,9 +11,13 @@
 import { Elysia, status, t } from "elysia";
 import * as authMiddleware from "../middleware/auth";
 import { projectRepository } from "../repositories/project.repository";
-import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-config";
 import { config } from "../config";
 import { logger } from "../utils/logger";
+import {
+  MAX_SCHEDULES_PER_PROJECT,
+  scheduledFunctionService,
+  type ScheduledFunctionPatch,
+} from "../services/scheduled-function.service";
 import { scheduledFunctionWorker } from "../workers/scheduled-function.worker";
 import { isValidScheduledFunctionCron } from "../utils/scheduled-function-cron";
 import {
@@ -21,12 +25,13 @@ import {
   SCHEDULE_HEADERS_INVALID,
 } from "../utils/scheduled-function-headers";
 import {
-  isScheduledFunctionConfig,
+  isCanonicalScheduledFunctionTimestamp,
   MAX_SCHEDULE_NAME_LENGTH,
   normalizedScheduledFunctionName,
   normalizedScheduledFunctionSlug,
   publicScheduledFunction,
   scheduledFunctionBodyWithinLimit,
+  scheduledFunctionsFromProjectConfig,
   type ScheduledFunctionConfig,
   type ScheduledFunctionMethod,
 } from "../utils/scheduled-function-config";
@@ -34,7 +39,6 @@ import {
 export type { ScheduledFunctionConfig, ScheduledFunctionMethod } from "../utils/scheduled-function-config";
 
 const ALLOWED_METHODS: ReadonlySet<ScheduledFunctionMethod> = new Set(["GET", "POST"]);
-const MAX_SCHEDULES_PER_PROJECT = 20;
 const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const SCHEDULE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const SCHEDULE_BODY_INVALID = "SCHEDULE_BODY_INVALID";
@@ -53,14 +57,7 @@ interface ScheduleCreateInput {
 type SchedulePatchInput = Partial<Pick<
   ScheduledFunctionConfig,
   "name" | "cron" | "method" | "body" | "headers" | "enabled"
->> & { request_id: string };
-
-function readSchedules(projectConfig: unknown): ScheduledFunctionConfig[] {
-  const normalizedConfig = normalizeProjectConfig(projectConfig as Record<string, unknown> | null | undefined);
-  const scheduleCandidates = normalizedConfig.scheduled_functions;
-  if (!Array.isArray(scheduleCandidates)) return [];
-  return scheduleCandidates.filter(isScheduledFunctionConfig);
-}
+>> & { request_id: string; expected_updated_at: string };
 
 function validatedScheduleCreateInput(
   input: ScheduleCreateInput,
@@ -83,6 +80,9 @@ function validatedScheduleCreateInput(
 
 function schedulePatchError(input: SchedulePatchInput): string | null {
   if (!SCHEDULE_ID_PATTERN.test(input.request_id)) return "request_id must be a UUIDv4";
+  if (!isCanonicalScheduledFunctionTimestamp(input.expected_updated_at)) {
+    return "expected_updated_at must be a canonical UTC timestamp";
+  }
   if (!SCHEDULE_PATCH_FIELDS.some((field) => input[field] !== undefined)) {
     return "Scheduled function update requires at least one field";
   }
@@ -100,7 +100,7 @@ function schedulePatchError(input: SchedulePatchInput): string | null {
 function normalizedSchedulePatch(
   input: SchedulePatchInput,
   headers: Record<string, string> | undefined,
-): Partial<ScheduledFunctionConfig> {
+): ScheduledFunctionPatch {
   return {
     ...(input.name !== undefined ? { name: input.name.trim() } : {}),
     ...(input.cron !== undefined ? { cron: input.cron.trim() } : {}),
@@ -126,10 +126,21 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
   .get("", async ({ params }) => {
     const project = await projectRepository.findByRef(params.ref);
     if (!project) return status(404, { error: "Project not found" });
-    const schedules = readSchedules(project.config).map(publicScheduledFunction);
+    const schedules = scheduledFunctionsFromProjectConfig(project.config).map(publicScheduledFunction);
     return { project_ref: params.ref, schedules };
   }, {
     detail: { tags: ["scheduled-functions"], summary: "List scheduled functions" },
+  })
+  .get("/:scheduleId", async ({ params }) => {
+    if (!SCHEDULE_ID_PATTERN.test(params.scheduleId)) return status(400, { error: "Scheduled function ID is invalid" });
+    const project = await projectRepository.findByRef(params.ref);
+    if (!project) return status(404, { error: "Project not found" });
+    const schedule = scheduledFunctionsFromProjectConfig(project.config)
+      .find((candidate) => candidate.id === params.scheduleId);
+    if (!schedule) return status(404, { error: "Scheduled function not found" });
+    return { project_ref: params.ref, schedule: publicScheduledFunction(schedule) };
+  }, {
+    detail: { tags: ["scheduled-functions"], summary: "Get a scheduled function" },
   })
   .post("", async ({ params, body }) => {
     const input = body as ScheduleCreateInput;
@@ -137,17 +148,6 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     if ("error" in validation) return status(400, validation);
     const headers = scheduleHeaders(input.headers);
     if (headers === null) return status(400, { error: SCHEDULE_HEADERS_INVALID });
-
-    const project = await projectRepository.findByRef(params.ref);
-    if (!project) return status(404, { error: "Project not found" });
-
-    const existing = readSchedules(project.config);
-    if (existing.length >= MAX_SCHEDULES_PER_PROJECT) {
-      return status(400, { error: `A project can have at most ${MAX_SCHEDULES_PER_PROJECT} scheduled functions` });
-    }
-    if (existing.some((schedule) => schedule.slug === validation.slug)) {
-      return status(409, { error: `A schedule for slug '${validation.slug}' already exists` });
-    }
 
     const now = new Date().toISOString();
     const schedule: ScheduledFunctionConfig = {
@@ -162,19 +162,24 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
       created_at: now,
       updated_at: now,
     };
-
-    const updated = await projectRepository.updateConfig(
-      params.ref,
-      mergeProjectConfig(project.config, { scheduled_functions: [...existing, schedule] }),
-    );
-    if (!updated) return status(404, { error: "Project not found" });
+    const mutation = await scheduledFunctionService.create({ ref: params.ref, schedule });
+    if (mutation.kind === "project_not_found") return status(404, { error: "Project not found" });
+    if (mutation.kind === "limit_reached") {
+      return status(400, { error: `A project can have at most ${MAX_SCHEDULES_PER_PROJECT} scheduled functions` });
+    }
+    if (mutation.kind === "duplicate") {
+      return status(409, {
+        code: mutation.field === "name" ? "SCHEDULE_NAME_CONFLICT" : "SCHEDULE_SLUG_CONFLICT",
+        error: `A schedule with ${mutation.field} '${schedule[mutation.field]}' already exists`,
+      });
+    }
 
     scheduledFunctionWorker.reload();
     return {
       created: true,
       project_ref: params.ref,
       request_id: input.request_id,
-      schedule: publicScheduledFunction(schedule),
+      schedule: publicScheduledFunction(mutation.schedule),
     };
   }, {
     body: t.Object({
@@ -196,36 +201,33 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     const headers = scheduleHeaders(input.headers);
     if (headers === null) return status(400, { error: SCHEDULE_HEADERS_INVALID });
 
-    const project = await projectRepository.findByRef(params.ref);
-    if (!project) return status(404, { error: "Project not found" });
-
-    const schedules = readSchedules(project.config);
-    const target = schedules.find((schedule) => schedule.id === params.scheduleId);
-    if (!target) return status(404, { error: "Scheduled function not found" });
-
-    const updatedSchedule: ScheduledFunctionConfig = {
-      ...target,
-      ...normalizedSchedulePatch(input, headers),
-      updated_at: new Date().toISOString(),
-    };
-
-    const nextSchedules = schedules.map((schedule) => schedule.id === target.id ? updatedSchedule : schedule);
-    const updated = await projectRepository.updateConfig(
-      params.ref,
-      mergeProjectConfig(project.config, { scheduled_functions: nextSchedules }),
-    );
-    if (!updated) return status(404, { error: "Project not found" });
+    const mutation = await scheduledFunctionService.update({
+      ref: params.ref,
+      scheduleId: params.scheduleId,
+      expectedUpdatedAt: input.expected_updated_at,
+      patch: normalizedSchedulePatch(input, headers),
+    });
+    if (mutation.kind === "project_not_found") return status(404, { error: "Project not found" });
+    if (mutation.kind === "schedule_not_found") return status(404, { error: "Scheduled function not found" });
+    if (mutation.kind === "revision_conflict") {
+      return status(409, { code: "SCHEDULE_REVISION_CONFLICT", error: "Scheduled function revision conflict" });
+    }
+    if (mutation.kind === "duplicate") {
+      return status(409, { code: "SCHEDULE_NAME_CONFLICT", error: "A schedule with that name already exists" });
+    }
 
     scheduledFunctionWorker.reload();
     return {
       updated: true,
       project_ref: params.ref,
       request_id: input.request_id,
-      schedule: publicScheduledFunction(updatedSchedule),
+      previous_updated_at: input.expected_updated_at,
+      schedule: publicScheduledFunction(mutation.schedule),
     };
   }, {
     body: t.Object({
       request_id: t.String(),
+      expected_updated_at: t.String(),
       name: t.Optional(t.String()),
       cron: t.Optional(t.String()),
       method: t.Optional(t.Union([t.Literal("GET"), t.Literal("POST")])),
@@ -235,24 +237,31 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     }),
     detail: { tags: ["scheduled-functions"], summary: "Update a scheduled function" },
   })
-  .delete("/:scheduleId", async ({ params }) => {
+  .delete("/:scheduleId", async ({ params, query }) => {
     if (!SCHEDULE_ID_PATTERN.test(params.scheduleId)) return status(400, { error: "Scheduled function ID is invalid" });
-    const project = await projectRepository.findByRef(params.ref);
-    if (!project) return status(404, { error: "Project not found" });
-
-    const schedules = readSchedules(project.config);
-    const nextSchedules = schedules.filter((schedule) => schedule.id !== params.scheduleId);
-    if (nextSchedules.length === schedules.length) return status(404, { error: "Scheduled function not found" });
-
-    const updated = await projectRepository.updateConfig(
-      params.ref,
-      mergeProjectConfig(project.config, { scheduled_functions: nextSchedules }),
-    );
-    if (!updated) return status(404, { error: "Project not found" });
+    if (!isCanonicalScheduledFunctionTimestamp(query.expected_updated_at)) {
+      return status(400, { error: "expected_updated_at must be a canonical UTC timestamp" });
+    }
+    const mutation = await scheduledFunctionService.delete({
+      ref: params.ref,
+      scheduleId: params.scheduleId,
+      expectedUpdatedAt: query.expected_updated_at,
+    });
+    if (mutation.kind === "project_not_found") return status(404, { error: "Project not found" });
+    if (mutation.kind === "schedule_not_found") return status(404, { error: "Scheduled function not found" });
+    if (mutation.kind === "revision_conflict") {
+      return status(409, { code: "SCHEDULE_REVISION_CONFLICT", error: "Scheduled function revision conflict" });
+    }
 
     scheduledFunctionWorker.reload();
-    return { deleted: true, project_ref: params.ref, schedule_id: params.scheduleId };
+    return {
+      deleted: true,
+      project_ref: params.ref,
+      schedule_id: params.scheduleId,
+      deleted_updated_at: mutation.deletedUpdatedAt,
+    };
   }, {
+    query: t.Object({ expected_updated_at: t.String() }),
     detail: { tags: ["scheduled-functions"], summary: "Delete a scheduled function" },
   })
   .post("/:scheduleId/trigger", async ({ params }) => {
@@ -260,7 +269,7 @@ export const scheduledFunctionRoutes = new Elysia({ prefix: "/v1/projects/:ref/s
     const project = await projectRepository.findByRef(params.ref);
     if (!project) return status(404, { error: "Project not found" });
 
-    const schedules = readSchedules(project.config);
+    const schedules = scheduledFunctionsFromProjectConfig(project.config);
     const target = schedules.find((schedule) => schedule.id === params.scheduleId);
     if (!target) return status(404, { error: "Scheduled function not found" });
 

--- a/packages/management-api/src/services/scheduled-function.service.ts
+++ b/packages/management-api/src/services/scheduled-function.service.ts
@@ -1,0 +1,182 @@
+import type { SQL } from "bun";
+import { sql } from "../db";
+import {
+  isCanonicalScheduledFunctionTimestamp,
+  scheduledFunctionsFromProjectConfig,
+  type ScheduledFunctionConfig,
+} from "../utils/scheduled-function-config";
+
+export const MAX_SCHEDULES_PER_PROJECT = 20;
+
+export type ScheduledFunctionPatch = Partial<Pick<
+  ScheduledFunctionConfig,
+  "name" | "cron" | "method" | "body" | "headers" | "enabled"
+>>;
+
+interface CreateScheduledFunctionInput {
+  ref: string;
+  schedule: ScheduledFunctionConfig;
+}
+
+interface UpdateScheduledFunctionInput {
+  ref: string;
+  scheduleId: string;
+  expectedUpdatedAt: string;
+  patch: ScheduledFunctionPatch;
+}
+
+interface DeleteScheduledFunctionInput {
+  ref: string;
+  scheduleId: string;
+  expectedUpdatedAt: string;
+}
+
+type CreateScheduledFunctionOutcome =
+  | { kind: "created"; schedule: ScheduledFunctionConfig }
+  | { kind: "duplicate"; field: "name" | "slug" }
+  | { kind: "limit_reached" }
+  | { kind: "project_not_found" };
+
+type UpdateScheduledFunctionOutcome =
+  | { kind: "updated"; schedule: ScheduledFunctionConfig }
+  | { kind: "duplicate"; field: "name" }
+  | { kind: "revision_conflict" }
+  | { kind: "schedule_not_found" }
+  | { kind: "project_not_found" };
+
+type DeleteScheduledFunctionOutcome =
+  | { kind: "deleted"; deletedUpdatedAt: string }
+  | { kind: "revision_conflict" }
+  | { kind: "schedule_not_found" }
+  | { kind: "project_not_found" };
+
+type LockedProjectMutation<T> = (projectConfig: unknown, transaction: SQL) => Promise<T>;
+
+async function withLockedProject<T>(ref: string, mutation: LockedProjectMutation<T>): Promise<T | null> {
+  return sql.begin(async (transaction) => {
+    const [project] = await transaction`
+      SELECT config FROM projects
+      WHERE ref = ${ref} AND deleted_at IS NULL
+      FOR UPDATE
+    ` as Array<{ config: unknown }>;
+    return project ? mutation(project.config, transaction) : null;
+  });
+}
+
+async function writeScheduledFunctions(
+  transaction: SQL,
+  ref: string,
+  schedules: ScheduledFunctionConfig[],
+): Promise<void> {
+  const [updatedProject] = await transaction`
+    UPDATE projects
+    SET config = jsonb_set(
+          COALESCE(config, '{}'::jsonb),
+          '{scheduled_functions}',
+          ${JSON.stringify(schedules)}::jsonb,
+          true
+        ),
+        updated_at = NOW()
+    WHERE ref = ${ref} AND deleted_at IS NULL
+    RETURNING ref
+  ` as Array<{ ref: string }>;
+  if (!updatedProject) throw new Error("Locked Scheduled Function project disappeared before update");
+}
+
+function duplicateCreateField(
+  schedules: ScheduledFunctionConfig[],
+  candidate: ScheduledFunctionConfig,
+): "name" | "slug" | null {
+  if (schedules.some((schedule) => schedule.name === candidate.name)) return "name";
+  return schedules.some((schedule) => schedule.slug === candidate.slug) ? "slug" : null;
+}
+
+async function createInLockedProject(
+  projectConfig: unknown,
+  transaction: SQL,
+  input: CreateScheduledFunctionInput,
+): Promise<CreateScheduledFunctionOutcome> {
+  const schedules = scheduledFunctionsFromProjectConfig(projectConfig);
+  if (schedules.length >= MAX_SCHEDULES_PER_PROJECT) return { kind: "limit_reached" };
+  const duplicateField = duplicateCreateField(schedules, input.schedule);
+  if (duplicateField) return { kind: "duplicate", field: duplicateField };
+  await writeScheduledFunctions(transaction, input.ref, [...schedules, input.schedule]);
+  return { kind: "created", schedule: input.schedule };
+}
+
+function nextUpdatedAt(previousUpdatedAt: string): string {
+  const clockTimestamp = new Date().toISOString();
+  if (clockTimestamp > previousUpdatedAt) return clockTimestamp;
+  const incrementedTimestamp = new Date(Date.parse(previousUpdatedAt) + 1).toISOString();
+  if (!isCanonicalScheduledFunctionTimestamp(incrementedTimestamp)) {
+    throw new Error("Scheduled Function revision timestamp range exhausted");
+  }
+  return incrementedTimestamp;
+}
+
+function duplicateUpdateName(
+  schedules: ScheduledFunctionConfig[],
+  scheduleId: string,
+  name: string,
+): boolean {
+  return schedules.some((schedule) => schedule.id !== scheduleId && schedule.name === name);
+}
+
+async function updateInLockedProject(
+  projectConfig: unknown,
+  transaction: SQL,
+  input: UpdateScheduledFunctionInput,
+): Promise<UpdateScheduledFunctionOutcome> {
+  const schedules = scheduledFunctionsFromProjectConfig(projectConfig);
+  const target = schedules.find((schedule) => schedule.id === input.scheduleId);
+  if (!target) return { kind: "schedule_not_found" };
+  if (target.updated_at !== input.expectedUpdatedAt) return { kind: "revision_conflict" };
+  const updatedSchedule = { ...target, ...input.patch, updated_at: nextUpdatedAt(target.updated_at) };
+  if (duplicateUpdateName(schedules, target.id, updatedSchedule.name)) return { kind: "duplicate", field: "name" };
+  const nextSchedules = schedules.map((schedule) => schedule.id === target.id ? updatedSchedule : schedule);
+  await writeScheduledFunctions(transaction, input.ref, nextSchedules);
+  return { kind: "updated", schedule: updatedSchedule };
+}
+
+async function deleteInLockedProject(
+  projectConfig: unknown,
+  transaction: SQL,
+  input: DeleteScheduledFunctionInput,
+): Promise<DeleteScheduledFunctionOutcome> {
+  const schedules = scheduledFunctionsFromProjectConfig(projectConfig);
+  const target = schedules.find((schedule) => schedule.id === input.scheduleId);
+  if (!target) return { kind: "schedule_not_found" };
+  if (target.updated_at !== input.expectedUpdatedAt) return { kind: "revision_conflict" };
+  await writeScheduledFunctions(transaction, input.ref, schedules.filter((schedule) => schedule.id !== target.id));
+  return { kind: "deleted", deletedUpdatedAt: target.updated_at };
+}
+
+async function createScheduledFunction(
+  input: CreateScheduledFunctionInput,
+): Promise<CreateScheduledFunctionOutcome> {
+  const mutation = await withLockedProject(input.ref, (projectConfig, transaction) =>
+    createInLockedProject(projectConfig, transaction, input));
+  return mutation ?? { kind: "project_not_found" };
+}
+
+async function updateScheduledFunction(
+  input: UpdateScheduledFunctionInput,
+): Promise<UpdateScheduledFunctionOutcome> {
+  const mutation = await withLockedProject(input.ref, (projectConfig, transaction) =>
+    updateInLockedProject(projectConfig, transaction, input));
+  return mutation ?? { kind: "project_not_found" };
+}
+
+async function deleteScheduledFunction(
+  input: DeleteScheduledFunctionInput,
+): Promise<DeleteScheduledFunctionOutcome> {
+  const mutation = await withLockedProject(input.ref, (projectConfig, transaction) =>
+    deleteInLockedProject(projectConfig, transaction, input));
+  return mutation ?? { kind: "project_not_found" };
+}
+
+export const scheduledFunctionService = {
+  create: createScheduledFunction,
+  update: updateScheduledFunction,
+  delete: deleteScheduledFunction,
+};

--- a/packages/management-api/src/services/scheduled-function.service.ts
+++ b/packages/management-api/src/services/scheduled-function.service.ts
@@ -73,7 +73,7 @@ async function writeScheduledFunctions(
     SET config = jsonb_set(
           COALESCE(config, '{}'::jsonb),
           '{scheduled_functions}',
-          ${JSON.stringify(schedules)}::jsonb,
+          ${schedules}::jsonb,
           true
         ),
         updated_at = NOW()

--- a/packages/management-api/src/utils/scheduled-function-config.ts
+++ b/packages/management-api/src/utils/scheduled-function-config.ts
@@ -40,6 +40,7 @@ export const MAX_SCHEDULE_NAME_LENGTH = 120;
 
 const FUNCTION_SLUG_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const SCHEDULE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const CANONICAL_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 function objectRecord(candidate: unknown): Record<string, unknown> | null {
   return candidate && typeof candidate === "object" && !Array.isArray(candidate)
@@ -62,6 +63,12 @@ export function normalizedScheduledFunctionSlug(candidate: unknown): string | nu
   if (typeof candidate !== "string") return null;
   const slug = candidate.trim();
   return FUNCTION_SLUG_PATTERN.test(slug) ? slug : null;
+}
+
+export function isCanonicalScheduledFunctionTimestamp(candidate: unknown): candidate is string {
+  if (typeof candidate !== "string" || !CANONICAL_TIMESTAMP_PATTERN.test(candidate)) return false;
+  const milliseconds = Date.parse(candidate);
+  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === candidate;
 }
 
 export function scheduledFunctionBodyWithinLimit(candidate: unknown): boolean {
@@ -96,7 +103,14 @@ export function isScheduledFunctionConfig(candidate: unknown): candidate is Sche
   const schedule = objectRecord(candidate);
   return schedule !== null && validScheduleIdentity(schedule) && validScheduleDefinition(schedule)
     && validSchedulePayload(schedule)
-    && typeof schedule.created_at === "string" && typeof schedule.updated_at === "string";
+    && typeof schedule.created_at === "string"
+    && isCanonicalScheduledFunctionTimestamp(schedule.updated_at);
+}
+
+export function scheduledFunctionsFromProjectConfig(projectConfig: unknown): ScheduledFunctionConfig[] {
+  const normalizedConfig = normalizeProjectConfig(projectConfig);
+  const scheduleCandidates = normalizedConfig.scheduled_functions;
+  return Array.isArray(scheduleCandidates) ? scheduleCandidates.filter(isScheduledFunctionConfig) : [];
 }
 
 function publicBodyEmpty(schedule: PublicScheduleCandidate): boolean {

--- a/packages/management-api/tests/unit/project.repository.test.ts
+++ b/packages/management-api/tests/unit/project.repository.test.ts
@@ -147,6 +147,9 @@ describe("ProjectRepository", () => {
       };
       const project = await projectRepository.create(input);
       expect(project).toBeDefined();
+      const [, ...parameters] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
+      expect(parameters).toContainEqual({ custom: "value" });
+      expect(parameters).not.toContain(JSON.stringify(input.config));
     });
   });
 
@@ -180,12 +183,12 @@ describe("ProjectRepository", () => {
 
       await projectRepository.updateConfig("test123", inputConfig);
 
-      const [strings, serializedConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
+      const [strings, nextConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
       const query = (strings as TemplateStringsArray).join("?").replaceAll(/\s+/g, " ").trim();
       expect(query).toContain("jsonb_typeof(projects.config) = 'object'");
       expect(query).toContain("projects.config ? 'scheduled_functions'");
       expect(query).toContain("jsonb_build_object('scheduled_functions', projects.config -> 'scheduled_functions')");
-      expect(serializedConfig).toBe(JSON.stringify(inputConfig));
+      expect(nextConfig).toEqual(inputConfig);
     });
 
     test("normalizes unexpected scalar config before building the update query", async () => {
@@ -193,8 +196,8 @@ describe("ProjectRepository", () => {
 
       await projectRepository.updateConfig("test123", "legacy" as unknown as Record<string, unknown>);
 
-      const [, serializedConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
-      expect(serializedConfig).toBe("{}");
+      const [, nextConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
+      expect(nextConfig).toEqual({});
     });
 
     test("should return null when project not found", async () => {

--- a/packages/management-api/tests/unit/project.repository.test.ts
+++ b/packages/management-api/tests/unit/project.repository.test.ts
@@ -173,6 +173,21 @@ describe("ProjectRepository", () => {
       expect(project).toBeDefined();
     });
 
+    test("preserves the database-owned scheduled function config in the update SQL", async () => {
+      const staleSchedule = { id: "stale-schedule" };
+      const inputConfig = { key: "value", scheduled_functions: [staleSchedule] };
+      (mockSql as ReturnType<typeof mock>).mockResolvedValueOnce([mockProject]);
+
+      await projectRepository.updateConfig("test123", inputConfig);
+
+      const [strings, serializedConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
+      const query = (strings as TemplateStringsArray).join("?").replaceAll(/\s+/g, " ").trim();
+      expect(query).toContain("(?::jsonb - 'scheduled_functions')");
+      expect(query).toContain("config ? 'scheduled_functions'");
+      expect(query).toContain("jsonb_build_object('scheduled_functions', config -> 'scheduled_functions')");
+      expect(serializedConfig).toBe(JSON.stringify(inputConfig));
+    });
+
     test("should return null when project not found", async () => {
       (mockSql as ReturnType<typeof mock>).mockResolvedValueOnce([]);
       const project = await projectRepository.updateConfig("nonexistent", { key: "value" });

--- a/packages/management-api/tests/unit/project.repository.test.ts
+++ b/packages/management-api/tests/unit/project.repository.test.ts
@@ -182,11 +182,19 @@ describe("ProjectRepository", () => {
 
       const [strings, serializedConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
       const query = (strings as TemplateStringsArray).join("?").replaceAll(/\s+/g, " ").trim();
-      expect(query).toContain("WHEN 'object' THEN ?::jsonb - 'scheduled_functions'");
       expect(query).toContain("jsonb_typeof(projects.config) = 'object'");
       expect(query).toContain("projects.config ? 'scheduled_functions'");
       expect(query).toContain("jsonb_build_object('scheduled_functions', projects.config -> 'scheduled_functions')");
       expect(serializedConfig).toBe(JSON.stringify(inputConfig));
+    });
+
+    test("normalizes unexpected scalar config before building the update query", async () => {
+      (mockSql as ReturnType<typeof mock>).mockResolvedValueOnce([mockProject]);
+
+      await projectRepository.updateConfig("test123", "legacy" as unknown as Record<string, unknown>);
+
+      const [, serializedConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
+      expect(serializedConfig).toBe("{}");
     });
 
     test("should return null when project not found", async () => {

--- a/packages/management-api/tests/unit/project.repository.test.ts
+++ b/packages/management-api/tests/unit/project.repository.test.ts
@@ -182,9 +182,10 @@ describe("ProjectRepository", () => {
 
       const [strings, serializedConfig] = (mockSql as ReturnType<typeof mock>).mock.calls[0];
       const query = (strings as TemplateStringsArray).join("?").replaceAll(/\s+/g, " ").trim();
-      expect(query).toContain("(?::jsonb - 'scheduled_functions')");
-      expect(query).toContain("config ? 'scheduled_functions'");
-      expect(query).toContain("jsonb_build_object('scheduled_functions', config -> 'scheduled_functions')");
+      expect(query).toContain("WHEN 'object' THEN ?::jsonb - 'scheduled_functions'");
+      expect(query).toContain("jsonb_typeof(projects.config) = 'object'");
+      expect(query).toContain("projects.config ? 'scheduled_functions'");
+      expect(query).toContain("jsonb_build_object('scheduled_functions', projects.config -> 'scheduled_functions')");
       expect(serializedConfig).toBe(JSON.stringify(inputConfig));
     });
 

--- a/packages/management-api/tests/unit/scheduled-function.service.test.ts
+++ b/packages/management-api/tests/unit/scheduled-function.service.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const SCHEDULE_ID = "00000000-0000-4000-8000-000000000001";
+const OTHER_SCHEDULE_ID = "00000000-0000-4000-8000-000000000002";
+const UPDATED_AT = "2026-08-11T00:00:00.000Z";
+
+let projectExists = true;
+let projectConfig: Record<string, unknown> = {};
+let updateCount = 0;
+let transactionTail = Promise.resolve();
+const executedQueries: string[] = [];
+
+function queryText(strings: TemplateStringsArray): string {
+  return strings.join("?").replaceAll(/\s+/g, " ").trim();
+}
+
+const database = Object.assign(
+  mock(async (strings: TemplateStringsArray, ...parameters: unknown[]) => {
+    const query = queryText(strings);
+    executedQueries.push(query);
+    if (query.startsWith("SELECT config FROM projects")) {
+      return projectExists ? [{ config: structuredClone(projectConfig) }] : [];
+    }
+    if (query.startsWith("UPDATE projects")) {
+      updateCount += 1;
+      if (!query.includes("jsonb_set")) {
+        const nextConfig = JSON.parse(String(parameters[0])) as Record<string, unknown>;
+        if (Object.prototype.hasOwnProperty.call(projectConfig, "scheduled_functions")) {
+          nextConfig.scheduled_functions = structuredClone(projectConfig.scheduled_functions);
+        } else {
+          delete nextConfig.scheduled_functions;
+        }
+        projectConfig = nextConfig;
+        return projectExists ? [{ ref: String(parameters[1]), config: structuredClone(projectConfig) }] : [];
+      }
+      projectConfig = {
+        ...projectConfig,
+        scheduled_functions: JSON.parse(String(parameters[0])),
+      };
+      return projectExists ? [{ ref: String(parameters[1]) }] : [];
+    }
+    throw new Error(`Unexpected Scheduled Function query: ${query}`);
+  }),
+  {
+    begin: async (mutation: (transaction: unknown) => Promise<unknown>) => {
+      let releaseTransaction: () => void = () => {};
+      const previousTransaction = transactionTail;
+      transactionTail = new Promise<void>((resolve) => { releaseTransaction = resolve; });
+      await previousTransaction;
+      try {
+        return await mutation(database);
+      } finally {
+        releaseTransaction();
+      }
+    },
+  },
+);
+
+mock.module("../../src/db", () => ({ sql: database }));
+
+const { scheduledFunctionService } = await import(
+  new URL("../../src/services/scheduled-function.service.ts?scheduled-function-service-test", import.meta.url).href
+);
+const { projectRepository } = await import(
+  new URL("../../src/repositories/project.repository.ts?scheduled-function-service-test", import.meta.url).href
+);
+
+function schedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SCHEDULE_ID,
+    name: "Nightly",
+    slug: "worker",
+    cron: "0 2 * * *",
+    method: "POST" as const,
+    enabled: true,
+    created_at: UPDATED_AT,
+    updated_at: UPDATED_AT,
+    ...overrides,
+  };
+}
+
+function storedSchedules(): Array<Record<string, unknown>> {
+  return projectConfig.scheduled_functions as Array<Record<string, unknown>>;
+}
+
+describe("scheduledFunctionService", () => {
+  beforeEach(() => {
+    projectExists = true;
+    projectConfig = { unrelated_setting: "preserved" };
+    updateCount = 0;
+    transactionTail = Promise.resolve();
+    executedQueries.length = 0;
+    database.mockClear();
+  });
+
+  test("creates under a row lock and preserves unrelated project config", async () => {
+    const candidate = schedule();
+
+    const outcome = await scheduledFunctionService.create({ ref: "proj_1", schedule: candidate });
+
+    expect(outcome).toEqual({ kind: "created", schedule: candidate });
+    expect(executedQueries[0]).toContain("FOR UPDATE");
+    expect(executedQueries[1]).toContain("'{scheduled_functions}'");
+    expect(projectConfig.unrelated_setting).toBe("preserved");
+    expect(storedSchedules()).toEqual([candidate]);
+  });
+
+  test.each([
+    ["name", schedule(), schedule({ id: OTHER_SCHEDULE_ID, slug: "other-worker" })],
+    ["slug", schedule(), schedule({ id: OTHER_SCHEDULE_ID, name: "Other" })],
+  ] as const)("atomically rejects concurrent duplicate %s creates", async (field, first, second) => {
+    const outcomes = await Promise.all([
+      scheduledFunctionService.create({ ref: "proj_1", schedule: first }),
+      scheduledFunctionService.create({ ref: "proj_1", schedule: second }),
+    ]);
+
+    expect(outcomes.map((outcome) => outcome.kind).sort()).toEqual(["created", "duplicate"]);
+    expect(outcomes).toContainEqual({ kind: "duplicate", field });
+    expect(updateCount).toBe(1);
+    expect(storedSchedules()).toHaveLength(1);
+    expect(executedQueries.filter((query) => query.includes("FOR UPDATE"))).toHaveLength(2);
+  });
+
+  test("allows exactly one concurrent update for the same expected revision", async () => {
+    projectConfig.scheduled_functions = [schedule()];
+
+    const outcomes = await Promise.all([
+      scheduledFunctionService.update({
+        ref: "proj_1",
+        scheduleId: SCHEDULE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+        patch: { name: "First" },
+      }),
+      scheduledFunctionService.update({
+        ref: "proj_1",
+        scheduleId: SCHEDULE_ID,
+        expectedUpdatedAt: UPDATED_AT,
+        patch: { name: "Second" },
+      }),
+    ]);
+
+    expect(outcomes.map((outcome) => outcome.kind).sort()).toEqual(["revision_conflict", "updated"]);
+    expect(updateCount).toBe(1);
+    expect(storedSchedules()[0].updated_at).not.toBe(UPDATED_AT);
+  });
+
+  test("preserves a successful CAS revision when a stale generic config snapshot is written afterward", async () => {
+    projectConfig.scheduled_functions = [schedule()];
+    // A concurrent generic writer can capture this snapshot before the locked CAS and reach UPDATE after it.
+    const staleGenericConfig = structuredClone(projectConfig);
+
+    const scheduleOutcome = await scheduledFunctionService.update({
+      ref: "proj_1",
+      scheduleId: SCHEDULE_ID,
+      expectedUpdatedAt: UPDATED_AT,
+      patch: { enabled: false },
+    });
+    const genericOutcome = await projectRepository.updateConfig("proj_1", {
+      ...staleGenericConfig,
+      unrelated_setting: "updated",
+    });
+
+    expect(scheduleOutcome.kind).toBe("updated");
+    expect(genericOutcome).not.toBeNull();
+    expect(storedSchedules()[0].enabled).toBe(false);
+    expect(storedSchedules()[0].updated_at).not.toBe(UPDATED_AT);
+    expect(projectConfig.unrelated_setting).toBe("updated");
+    expect(updateCount).toBe(2);
+  });
+
+  test("rejects a duplicate update name without changing either schedule", async () => {
+    projectConfig.scheduled_functions = [
+      schedule(),
+      schedule({ id: OTHER_SCHEDULE_ID, name: "Other", slug: "other-worker" }),
+    ];
+    const before = structuredClone(projectConfig);
+
+    const outcome = await scheduledFunctionService.update({
+      ref: "proj_1",
+      scheduleId: SCHEDULE_ID,
+      expectedUpdatedAt: UPDATED_AT,
+      patch: { name: "Other" },
+    });
+
+    expect(outcome).toEqual({ kind: "duplicate", field: "name" });
+    expect(updateCount).toBe(0);
+    expect(projectConfig).toEqual(before);
+  });
+
+  test("advances updated_at even when the stored revision is ahead of the server clock", async () => {
+    const futureRevision = "2099-01-01T00:00:00.000Z";
+    projectConfig.scheduled_functions = [schedule({ updated_at: futureRevision })];
+
+    const outcome = await scheduledFunctionService.update({
+      ref: "proj_1",
+      scheduleId: SCHEDULE_ID,
+      expectedUpdatedAt: futureRevision,
+      patch: { enabled: false },
+    });
+
+    expect(outcome).toMatchObject({
+      kind: "updated",
+      schedule: { updated_at: "2099-01-01T00:00:00.001Z" },
+    });
+  });
+
+  test("rejects stale update and delete revisions with zero mutation", async () => {
+    projectConfig.scheduled_functions = [schedule()];
+    const before = structuredClone(projectConfig);
+    const staleRevision = "2026-08-10T23:59:59.999Z";
+
+    const updateOutcome = await scheduledFunctionService.update({
+      ref: "proj_1",
+      scheduleId: SCHEDULE_ID,
+      expectedUpdatedAt: staleRevision,
+      patch: { enabled: false },
+    });
+    const deleteOutcome = await scheduledFunctionService.delete({
+      ref: "proj_1",
+      scheduleId: SCHEDULE_ID,
+      expectedUpdatedAt: staleRevision,
+    });
+
+    expect(updateOutcome).toEqual({ kind: "revision_conflict" });
+    expect(deleteOutcome).toEqual({ kind: "revision_conflict" });
+    expect(updateCount).toBe(0);
+    expect(projectConfig).toEqual(before);
+  });
+
+  test("deletes only the schedule bound to the expected revision", async () => {
+    projectConfig.scheduled_functions = [schedule()];
+
+    const outcome = await scheduledFunctionService.delete({
+      ref: "proj_1",
+      scheduleId: SCHEDULE_ID,
+      expectedUpdatedAt: UPDATED_AT,
+    });
+
+    expect(outcome).toEqual({ kind: "deleted", deletedUpdatedAt: UPDATED_AT });
+    expect(storedSchedules()).toEqual([]);
+    expect(updateCount).toBe(1);
+  });
+
+  test("returns project_not_found without issuing an update", async () => {
+    projectExists = false;
+
+    const outcome = await scheduledFunctionService.create({ ref: "missing", schedule: schedule() });
+
+    expect(outcome).toEqual({ kind: "project_not_found" });
+    expect(updateCount).toBe(0);
+  });
+});

--- a/packages/management-api/tests/unit/scheduled-function.service.test.ts
+++ b/packages/management-api/tests/unit/scheduled-function.service.test.ts
@@ -24,7 +24,7 @@ const database = Object.assign(
     if (query.startsWith("UPDATE projects")) {
       updateCount += 1;
       if (!query.includes("jsonb_set")) {
-        const nextConfig = JSON.parse(String(parameters[0])) as Record<string, unknown>;
+        const nextConfig = structuredClone(parameters[0]) as Record<string, unknown>;
         if (Object.prototype.hasOwnProperty.call(projectConfig, "scheduled_functions")) {
           nextConfig.scheduled_functions = structuredClone(projectConfig.scheduled_functions);
         } else {
@@ -35,7 +35,7 @@ const database = Object.assign(
       }
       projectConfig = {
         ...projectConfig,
-        scheduled_functions: JSON.parse(String(parameters[0])),
+        scheduled_functions: structuredClone(parameters[0]),
       };
       return projectExists ? [{ ref: String(parameters[1]) }] : [];
     }

--- a/packages/management-api/tests/unit/scheduled-functions.routes.test.ts
+++ b/packages/management-api/tests/unit/scheduled-functions.routes.test.ts
@@ -2,18 +2,30 @@ import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:t
 import { Elysia } from "elysia";
 
 const findByRef = mock(() => Promise.resolve(null));
-const updateConfig = mock(() => Promise.resolve(null));
+const createSchedule = mock((input: { schedule: unknown }) => Promise.resolve({
+  kind: "created" as const,
+  schedule: input.schedule,
+}));
+const updateSchedule = mock(() => Promise.resolve({ kind: "schedule_not_found" as const }));
+const deleteSchedule = mock(() => Promise.resolve({ kind: "schedule_not_found" as const }));
 const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
 
 const { projectRepository } = await import("../../src/repositories/project.repository");
+const { scheduledFunctionService } = await import("../../src/services/scheduled-function.service");
 const authModule = await import("../../src/middleware/auth");
 const workerModule = await import("../../src/workers/scheduled-function.worker");
 
 const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(
   findByRef as typeof projectRepository.findByRef,
 );
-const updateConfigSpy = spyOn(projectRepository, "updateConfig").mockImplementation(
-  updateConfig as typeof projectRepository.updateConfig,
+const createScheduleSpy = spyOn(scheduledFunctionService, "create").mockImplementation(
+  createSchedule as typeof scheduledFunctionService.create,
+);
+const updateScheduleSpy = spyOn(scheduledFunctionService, "update").mockImplementation(
+  updateSchedule as typeof scheduledFunctionService.update,
+);
+const deleteScheduleSpy = spyOn(scheduledFunctionService, "delete").mockImplementation(
+  deleteSchedule as typeof scheduledFunctionService.delete,
 );
 const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
   requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
@@ -26,6 +38,22 @@ const app = new Elysia().use(scheduledFunctionRoutes);
 const SCHEDULE_ID = "00000000-0000-4000-8000-000000000001";
 const OTHER_SCHEDULE_ID = "00000000-0000-4000-8000-000000000002";
 const REQUEST_ID = "00000000-0000-4000-8000-000000000003";
+const UPDATED_AT = "2026-08-11T00:00:00.000Z";
+const NEXT_UPDATED_AT = "2026-08-11T00:00:00.001Z";
+
+function storedSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SCHEDULE_ID,
+    name: "Nightly",
+    slug: "worker",
+    cron: "0 2 * * *",
+    method: "POST" as const,
+    enabled: true,
+    created_at: UPDATED_AT,
+    updated_at: UPDATED_AT,
+    ...overrides,
+  };
+}
 
 function request(path: string, init: RequestInit = {}) {
   return app.handle(
@@ -44,16 +72,24 @@ function bodyWithSerializedBytes(serializedBytes: number): Record<string, string
 describe("scheduledFunctionRoutes", () => {
   afterAll(() => {
     findByRefSpy.mockRestore();
-    updateConfigSpy.mockRestore();
+    createScheduleSpy.mockRestore();
+    updateScheduleSpy.mockRestore();
+    deleteScheduleSpy.mockRestore();
     requireProjectOrAdminAuthSpy.mockRestore();
     reloadSpy.mockRestore();
   });
 
   beforeEach(() => {
     findByRef.mockReset();
-    updateConfig.mockReset();
+    createSchedule.mockReset();
+    createSchedule.mockImplementation(async (input) => ({ kind: "created", schedule: input.schedule }));
+    updateSchedule.mockReset();
+    updateSchedule.mockResolvedValue({ kind: "schedule_not_found" });
+    deleteSchedule.mockReset();
+    deleteSchedule.mockResolvedValue({ kind: "schedule_not_found" });
     requireProjectOrAdminAuth.mockReset();
     requireProjectOrAdminAuth.mockResolvedValue(null);
+    reloadSpy.mockClear();
   });
 
   test("GET returns empty list when no schedules", async () => {
@@ -93,11 +129,27 @@ describe("scheduledFunctionRoutes", () => {
     expect(responseBody.schedules[0]).toMatchObject({
       body_empty: false,
       header_names: ["x-schedule-token"],
+      updated_at: UPDATED_AT,
     });
     expect(responseBody.schedules[0]).not.toHaveProperty("body");
     expect(responseBody.schedules[0]).not.toHaveProperty("headers");
     expect(responseText).not.toContain(bodySentinel);
     expect(responseText).not.toContain(headerSentinel);
+  });
+
+  test("GET by ID returns the exact schedule revision without private payload values", async () => {
+    findByRef.mockResolvedValue({
+      ref: "proj_1",
+      config: { scheduled_functions: [storedSchedule({ body: { private: "sentinel" } })] },
+    } as never);
+
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`);
+    const responseText = await res.text();
+    const responseBody = JSON.parse(responseText);
+
+    expect(res.status).toBe(200);
+    expect(responseBody.schedule).toMatchObject({ id: SCHEDULE_ID, updated_at: UPDATED_AT });
+    expect(responseText).not.toContain("sentinel");
   });
 
   test("GET rejects an invalid project ref before authorization or repository access", async () => {
@@ -109,9 +161,6 @@ describe("scheduledFunctionRoutes", () => {
   });
 
   test("POST creates a schedule and signals worker reload", async () => {
-    findByRef.mockResolvedValue({ ref: "proj_1", config: {} } as never);
-    updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
-
     const res = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
       body: JSON.stringify({
@@ -141,9 +190,9 @@ describe("scheduledFunctionRoutes", () => {
     expect(body.schedule).not.toHaveProperty("body");
     expect(body.schedule).not.toHaveProperty("headers");
     expect(reloadSpy).toHaveBeenCalledTimes(1);
-    const stored = updateConfig.mock.calls[0][1];
-    expect(stored.scheduled_functions[0].body).toEqual({ mode: "deep" });
-    expect(stored.scheduled_functions[0].headers).toEqual({ "x-schedule-token": "token" });
+    const stored = createSchedule.mock.calls[0][0].schedule as Record<string, unknown>;
+    expect(stored.body).toEqual({ mode: "deep" });
+    expect(stored.headers).toEqual({ "x-schedule-token": "token" });
   });
 
   test("POST rejects invalid cron and slug", async () => {
@@ -174,7 +223,7 @@ describe("scheduledFunctionRoutes", () => {
 
     expect(res.status).toBe(400);
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(createSchedule).not.toHaveBeenCalled();
   });
 
   test.each([
@@ -190,7 +239,7 @@ describe("scheduledFunctionRoutes", () => {
 
     expect(res.status).toBe(400);
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(createSchedule).not.toHaveBeenCalled();
   });
 
   test.each([
@@ -219,18 +268,11 @@ describe("scheduledFunctionRoutes", () => {
     expect(responseBody).toContain("SCHEDULE_HEADERS_INVALID");
     expect(responseBody).not.toContain("private-");
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(createSchedule).not.toHaveBeenCalled();
   });
 
   test("POST rejects duplicate slug with 409", async () => {
-    findByRef.mockResolvedValue({
-      ref: "proj_1",
-      config: {
-        scheduled_functions: [
-          { id: SCHEDULE_ID, name: "old", slug: "cleanup", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
-        ],
-      },
-    } as never);
+    createSchedule.mockResolvedValue({ kind: "duplicate", field: "slug" });
 
     const res = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
@@ -240,14 +282,7 @@ describe("scheduledFunctionRoutes", () => {
   });
 
   test("POST checks duplicate slugs after normalization", async () => {
-    findByRef.mockResolvedValue({
-      ref: "proj_1",
-      config: {
-        scheduled_functions: [
-          { id: SCHEDULE_ID, name: "old", slug: "cleanup", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
-        ],
-      },
-    } as never);
+    createSchedule.mockResolvedValue({ kind: "duplicate", field: "slug" });
 
     const res = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
@@ -255,45 +290,97 @@ describe("scheduledFunctionRoutes", () => {
     });
 
     expect(res.status).toBe(409);
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect((createSchedule.mock.calls[0][0].schedule as Record<string, unknown>).slug).toBe("cleanup");
+  });
+
+  test("POST maps an atomic duplicate name outcome to 409 without worker reload", async () => {
+    createSchedule.mockResolvedValue({ kind: "duplicate", field: "name" });
+
+    const res = await request("/v1/projects/proj_1/scheduled-functions", {
+      method: "POST",
+      body: JSON.stringify({
+        request_id: REQUEST_ID,
+        name: "Nightly",
+        slug: "other-worker",
+        cron: "0 1 * * *",
+        method: "POST",
+      }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: "SCHEDULE_NAME_CONFLICT" });
+    expect(reloadSpy).not.toHaveBeenCalled();
   });
 
   test("PATCH toggles enabled", async () => {
-    findByRef.mockResolvedValue({
-      ref: "proj_1",
-      config: {
-        scheduled_functions: [
-          { id: SCHEDULE_ID, name: "old", slug: "fn", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
-        ],
-      },
-    } as never);
-    updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
+    updateSchedule.mockResolvedValue({
+      kind: "updated",
+      schedule: storedSchedule({ enabled: false, updated_at: NEXT_UPDATED_AT }),
+    });
 
     const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ request_id: REQUEST_ID, enabled: false }),
+      body: JSON.stringify({ request_id: REQUEST_ID, expected_updated_at: UPDATED_AT, enabled: false }),
     });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.schedule.enabled).toBe(false);
     expect(body.request_id).toBe(REQUEST_ID);
+    expect(body.previous_updated_at).toBe(UPDATED_AT);
+    expect(updateSchedule.mock.calls[0][0]).toMatchObject({
+      scheduleId: SCHEDULE_ID,
+      expectedUpdatedAt: UPDATED_AT,
+      patch: { enabled: false },
+    });
+  });
+
+  test.each([
+    ` ${UPDATED_AT}`,
+    "2026-08-11T00:00:00Z",
+    "2026-08-11T08:00:00.000+08:00",
+    "2026-02-30T00:00:00.000Z",
+  ])("PATCH rejects non-canonical expected_updated_at %j before mutation", async (expectedUpdatedAt) => {
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ request_id: REQUEST_ID, expected_updated_at: expectedUpdatedAt, enabled: false }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(updateSchedule).not.toHaveBeenCalled();
+  });
+
+  test("PATCH returns 409 for a stale revision without worker reload", async () => {
+    updateSchedule.mockResolvedValue({ kind: "revision_conflict" });
+
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
+      method: "PATCH",
+      body: JSON.stringify({ request_id: REQUEST_ID, expected_updated_at: UPDATED_AT, enabled: false }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: "SCHEDULE_REVISION_CONFLICT" });
+    expect(reloadSpy).not.toHaveBeenCalled();
   });
 
   test("PATCH rejects unsafe cron before repository writes", async () => {
     const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ request_id: REQUEST_ID, cron: "0-999999999 * * * *" }),
+      body: JSON.stringify({ request_id: REQUEST_ID, expected_updated_at: UPDATED_AT, cron: "0-999999999 * * * *" }),
     });
 
     expect(res.status).toBe(400);
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(updateSchedule).not.toHaveBeenCalled();
   });
 
   test("PATCH rejects platform headers before repository writes", async () => {
     const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ request_id: REQUEST_ID, headers: { apikey: "private-api-key-sentinel" } }),
+      body: JSON.stringify({
+        request_id: REQUEST_ID,
+        expected_updated_at: UPDATED_AT,
+        headers: { apikey: "private-api-key-sentinel" },
+      }),
     });
     const responseBody = await res.text();
 
@@ -301,45 +388,49 @@ describe("scheduledFunctionRoutes", () => {
     expect(responseBody).toContain("SCHEDULE_HEADERS_INVALID");
     expect(responseBody).not.toContain("private-api-key-sentinel");
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(updateSchedule).not.toHaveBeenCalled();
   });
 
   test.each(["PATCH", "DELETE"])("%s rejects a non-canonical schedule ID before repository access", async (method) => {
-    const res = await request("/v1/projects/proj_1/scheduled-functions/not-a-uuid", {
+    const revisionQuery = method === "DELETE"
+      ? `?expected_updated_at=${encodeURIComponent(UPDATED_AT)}`
+      : "";
+    const res = await request(`/v1/projects/proj_1/scheduled-functions/not-a-uuid${revisionQuery}`, {
       method,
-      ...(method === "PATCH" ? { body: JSON.stringify({ request_id: REQUEST_ID, name: "Unsafe" }) } : {}),
+      ...(method === "PATCH" ? {
+        body: JSON.stringify({ request_id: REQUEST_ID, expected_updated_at: UPDATED_AT, name: "Unsafe" }),
+      } : {}),
     });
 
     expect(res.status).toBe(400);
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(updateSchedule).not.toHaveBeenCalled();
+    expect(deleteSchedule).not.toHaveBeenCalled();
   });
 
   test.each(["", " ", "x".repeat(121)])("PATCH rejects invalid name %j before repository access", async (name) => {
     const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ request_id: REQUEST_ID, name }),
+      body: JSON.stringify({ request_id: REQUEST_ID, expected_updated_at: UPDATED_AT, name }),
     });
 
     expect(res.status).toBe(400);
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(updateSchedule).not.toHaveBeenCalled();
   });
 
   test("PATCH rejects a request ID without mutation fields", async () => {
     const res = await request(`/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}`, {
       method: "PATCH",
-      body: JSON.stringify({ request_id: REQUEST_ID }),
+      body: JSON.stringify({ request_id: REQUEST_ID, expected_updated_at: UPDATED_AT }),
     });
 
     expect(res.status).toBe(400);
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(updateSchedule).not.toHaveBeenCalled();
   });
 
   test("POST accepts a body exactly 1 MiB after JSON serialization", async () => {
-    findByRef.mockResolvedValue({ ref: "proj_1", config: {} } as never);
-    updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
     const res = await request("/v1/projects/proj_1/scheduled-functions", {
       method: "POST",
       body: JSON.stringify({
@@ -353,7 +444,7 @@ describe("scheduledFunctionRoutes", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(updateConfig).toHaveBeenCalledTimes(1);
+    expect(createSchedule).toHaveBeenCalledTimes(1);
   });
 
   test("POST rejects a serialized body over 1 MiB without repository access", async () => {
@@ -372,23 +463,49 @@ describe("scheduledFunctionRoutes", () => {
     expect(res.status).toBe(400);
     expect(await res.text()).toContain("SCHEDULE_BODY_INVALID");
     expect(findByRef).not.toHaveBeenCalled();
-    expect(updateConfig).not.toHaveBeenCalled();
+    expect(createSchedule).not.toHaveBeenCalled();
   });
 
   test("DELETE removes schedule", async () => {
-    findByRef.mockResolvedValue({
-      ref: "proj_1",
-      config: {
-        scheduled_functions: [
-          { id: OTHER_SCHEDULE_ID, name: "old", slug: "fn", cron: "0 0 * * *", method: "GET", enabled: true, created_at: "", updated_at: "" },
-        ],
-      },
-    } as never);
-    updateConfig.mockImplementation(async (ref, nextConfig) => ({ ref, config: nextConfig }) as never);
+    deleteSchedule.mockResolvedValue({ kind: "deleted", deletedUpdatedAt: UPDATED_AT });
 
-    const res = await request(`/v1/projects/proj_1/scheduled-functions/${OTHER_SCHEDULE_ID}`, { method: "DELETE" });
+    const res = await request(
+      `/v1/projects/proj_1/scheduled-functions/${OTHER_SCHEDULE_ID}?expected_updated_at=${encodeURIComponent(UPDATED_AT)}`,
+      { method: "DELETE" },
+    );
     expect(res.status).toBe(200);
-    const stored = updateConfig.mock.calls[0][1];
-    expect(stored.scheduled_functions).toEqual([]);
+    expect(await res.json()).toMatchObject({ deleted: true, deleted_updated_at: UPDATED_AT });
+    expect(deleteSchedule.mock.calls[0][0]).toEqual({
+      ref: "proj_1",
+      scheduleId: OTHER_SCHEDULE_ID,
+      expectedUpdatedAt: UPDATED_AT,
+    });
+  });
+
+  test.each([
+    ` ${UPDATED_AT}`,
+    "2026-08-11T00:00:00Z",
+    "2026-08-11T08:00:00.000+08:00",
+  ])("DELETE rejects non-canonical expected_updated_at %j before mutation", async (expectedUpdatedAt) => {
+    const res = await request(
+      `/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}?expected_updated_at=${encodeURIComponent(expectedUpdatedAt)}`,
+      { method: "DELETE" },
+    );
+
+    expect(res.status).toBe(400);
+    expect(deleteSchedule).not.toHaveBeenCalled();
+  });
+
+  test("DELETE returns 409 for a stale revision without worker reload", async () => {
+    deleteSchedule.mockResolvedValue({ kind: "revision_conflict" });
+
+    const res = await request(
+      `/v1/projects/proj_1/scheduled-functions/${SCHEDULE_ID}?expected_updated_at=${encodeURIComponent(UPDATED_AT)}`,
+      { method: "DELETE" },
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ code: "SCHEDULE_REVISION_CONFLICT" });
+    expect(reloadSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- add scheduled_functions get and require an exact canonical expected_updated_at revision for update and delete
- serialize create, update, and delete under a project row lock; stale revisions return HTTP 409 with zero mutation
- advance updated_at monotonically and bind update and delete receipts to the matched revision
- preserve unrelated project config with a path-scoped JSONB update and prevent stale generic config snapshots from overwriting the dedicated scheduled_functions key
- keep CLI responses secret-safe while allowing list and get in read-only mode

## Verification

- CLI full suite: 410 pass, 0 fail
- CLI typecheck and build: pass
- Management targeted repository, service, and route suite: 78 pass, 0 fail
- Management typecheck: pass
- Management test:local: pass, including SQL synchronization, 1341 shared unit tests, isolated unit batches, and 39 integration tests
- git diff --check: pass

clean-code-guard: 4 fixed, 0 flagged

This PR does not merge, release, or deploy the change.