### PR TITLE
feat(storage): add bucket revision CAS

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -393,6 +393,12 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
         run: bun test tests/integration/storage-bucket-array-binding.test.ts
 
+      - name: Verify Storage bucket revision CAS on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: bun test tests/integration/storage-bucket-cas.test.ts
+
       - name: Verify Realtime payload safety on PostgreSQL 18
         working-directory: packages/management-api
         env:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -166,8 +166,10 @@ supacloud-cli storage get_bucket --ref abc123 --bucket reports
 supacloud-cli storage create_bucket --ref abc123 --bucket reports --public false \
   --file_size_limit 10485760 --allowed_mime_types "application/pdf,image/png"
 supacloud-cli storage update_bucket --ref abc123 --bucket reports \
+  --expected_revision <revision-from-get_bucket> \
   --allowed_mime_types '["application/pdf"]'
-supacloud-cli storage delete_bucket --ref abc123 --bucket reports
+supacloud-cli storage delete_bucket --ref abc123 --bucket reports \
+  --expected_revision <revision-from-get_bucket> --require_empty true
 ```
 
 `database migration_inventory` reads the canonical migration ledger through the
@@ -177,6 +179,11 @@ migration versions, checksum
 drift, and statement-count mismatches instead of treating them as an empty
 ledger. `database list_migrations` remains available with its legacy SQL-backed,
 human-readable behavior.
+
+Bucket list/get output includes the metadata `revision`. Update and delete reject
+stale revisions with HTTP 409. Delete additionally requires `require_empty=true`;
+it never empties a bucket. Mutation receipts bind `project_ref`, `bucket_id`,
+`previous_revision`, and `new_revision` (`null` after delete).
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
 Bun and runs a local syntax check before upload. The Management API validates and

--- a/packages/cli/src/shared/tools/storage-tools.test.ts
+++ b/packages/cli/src/shared/tools/storage-tools.test.ts
@@ -9,6 +9,8 @@ type ToolResponse = {
 };
 
 const RELEASE_SCHEMA = "supacloud.cli.release-control.v1";
+const CURRENT_REVISION = "1786406400000000";
+const NEXT_REVISION = "1786406400000001";
 
 function successReceipt(operation: string, payload: Record<string, unknown>) {
     return {
@@ -27,7 +29,26 @@ function storageBucket(overrides: Record<string, unknown> = {}) {
         public: false,
         file_size_limit: null,
         allowed_mime_types: null,
+        revision: CURRENT_REVISION,
         ...overrides,
+    };
+}
+
+function updatedBucketReceipt(overrides: Record<string, unknown> = {}) {
+    return {
+        ...storageBucket({ revision: NEXT_REVISION, ...overrides }),
+        previous_revision: CURRENT_REVISION,
+        new_revision: NEXT_REVISION,
+    };
+}
+
+function deletedBucketReceipt() {
+    return {
+        id: "reports",
+        deleted: true,
+        require_empty: true,
+        previous_revision: CURRENT_REVISION,
+        new_revision: null,
     };
 }
 
@@ -148,6 +169,7 @@ describe("Storage bucket lifecycle", () => {
             public: false,
             file_size_limit: 1048576,
             allowed_mime_types: ["application/pdf"],
+            revision: CURRENT_REVISION,
         }];
         const { callback } = captureStorageTool({
             get: async (path: string) => {
@@ -277,17 +299,29 @@ describe("Storage bucket lifecycle", () => {
             { method: "GET", path: "/v1/projects/project-ref/storage/buckets/reports" },
         ]);
         expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.create_bucket", {
+            bucket_id: "reports",
+            previous_revision: null,
+            new_revision: CURRENT_REVISION,
             bucket: readback,
         }));
     });
 
     test("updates only explicitly provided fields", async () => {
         const calls: Array<{ method: "GET" | "PUT"; path: string; body?: unknown }> = [];
-        const bucket = storageBucket({ public: true, file_size_limit: 1048576, allowed_mime_types: [] });
+        const bucket = storageBucket({
+            public: true,
+            file_size_limit: 1048576,
+            allowed_mime_types: [],
+            revision: NEXT_REVISION,
+        });
         const { callback } = captureStorageTool({
             put: async (path: string, body: unknown) => {
                 calls.push({ method: "PUT", path, body });
-                return { ok: true, status: 200, data: bucket };
+                return {
+                    ok: true,
+                    status: 200,
+                    data: updatedBucketReceipt({ public: true, file_size_limit: 1048576, allowed_mime_types: [] }),
+                };
             },
             get: async (path: string) => {
                 calls.push({ method: "GET", path });
@@ -299,6 +333,7 @@ describe("Storage bucket lifecycle", () => {
             action: "update_bucket",
             ref: "project-ref",
             bucket: "reports",
+            expected_revision: CURRENT_REVISION,
             public: true,
             file_size_limit: 1048576,
             allowed_mime_types: [],
@@ -308,11 +343,21 @@ describe("Storage bucket lifecycle", () => {
             {
                 method: "PUT",
                 path: "/v1/projects/project-ref/storage/buckets/reports",
-                body: { public: true, file_size_limit: 1048576, allowed_mime_types: [] },
+                body: {
+                    expected_revision: CURRENT_REVISION,
+                    public: true,
+                    file_size_limit: 1048576,
+                    allowed_mime_types: [],
+                },
             },
             { method: "GET", path: "/v1/projects/project-ref/storage/buckets/reports" },
         ]);
-        expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.update_bucket", { bucket }));
+        expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.update_bucket", {
+            bucket_id: "reports",
+            previous_revision: CURRENT_REVISION,
+            new_revision: NEXT_REVISION,
+            bucket,
+        }));
     });
 
     test("accepts the platform's null normalization when clearing MIME restrictions", async () => {
@@ -320,12 +365,12 @@ describe("Storage bucket lifecycle", () => {
             put: async () => ({
                 ok: true,
                 status: 200,
-                data: storageBucket({ allowed_mime_types: null }),
+                data: updatedBucketReceipt({ allowed_mime_types: null }),
             }),
             get: async () => ({
                 ok: true,
                 status: 200,
-                data: storageBucket({ allowed_mime_types: null }),
+                data: storageBucket({ allowed_mime_types: null, revision: NEXT_REVISION }),
             }),
         });
 
@@ -333,6 +378,7 @@ describe("Storage bucket lifecycle", () => {
             action: "update_bucket",
             ref: "project-ref",
             bucket: "reports",
+            expected_revision: CURRENT_REVISION,
             allowed_mime_types: [],
         });
 
@@ -357,9 +403,30 @@ describe("Storage bucket lifecycle", () => {
         expect(requestCount).toBe(0);
     });
 
+    test.each([
+        ["update revision", { action: "update_bucket", ref: "project-ref", bucket: "reports", public: true }],
+        ["delete revision", { action: "delete_bucket", ref: "project-ref", bucket: "reports", require_empty: true }],
+        ["explicit empty check", {
+            action: "delete_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            expected_revision: CURRENT_REVISION,
+        }],
+    ])("requires %s before HTTP dispatch", async (_label, args) => {
+        let requestCount = 0;
+        const request = async () => {
+            requestCount += 1;
+            return { ok: true, status: 200, data: {} };
+        };
+        const { callback } = captureStorageTool({ put: request, delete: request });
+
+        await expect(callback(args)).rejects.toThrow("required");
+        expect(requestCount).toBe(0);
+    });
+
     test("deletes a bucket and returns an independently reconciled safe receipt", async () => {
         const calls: Array<{ method: "DELETE" | "GET"; path: string }> = [];
-        const receipt = { id: "reports", deleted: true };
+        const receipt = deletedBucketReceipt();
         const { callback } = captureStorageTool({
             delete: async (path: string) => {
                 calls.push({ method: "DELETE", path });
@@ -371,15 +438,27 @@ describe("Storage bucket lifecycle", () => {
             },
         });
 
-        const response = await callback({ action: "delete_bucket", ref: "project-ref", bucket: "reports" });
+        const response = await callback({
+            action: "delete_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            expected_revision: CURRENT_REVISION,
+            require_empty: true,
+        });
 
         expect(calls).toEqual([
-            { method: "DELETE", path: "/v1/projects/project-ref/storage/buckets/reports" },
+            {
+                method: "DELETE",
+                path: `/v1/projects/project-ref/storage/buckets/reports?expected_revision=${CURRENT_REVISION}&require_empty=true`,
+            },
             { method: "GET", path: "/v1/projects/project-ref/storage/buckets/reports" },
         ]);
         expect(JSON.parse(response.content[0].text)).toEqual(successReceipt("storage.delete_bucket", {
             bucket_id: "reports",
             deleted: true,
+            require_empty: true,
+            previous_revision: CURRENT_REVISION,
+            new_revision: null,
         }));
     });
 
@@ -397,7 +476,13 @@ describe("Storage bucket lifecycle", () => {
             },
         });
 
-        const response = await callback({ action: "delete_bucket", ref: "project-ref", bucket: "reports" });
+        const response = await callback({
+            action: "delete_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            expected_revision: CURRENT_REVISION,
+            require_empty: true,
+        });
 
         expect(response.isError).toBe(true);
         expect(JSON.parse(response.content[0].text).error).toEqual({ code: "HTTP_ERROR", http_status: 409 });
@@ -447,6 +532,7 @@ describe("Storage bucket lifecycle", () => {
             action: "update_bucket",
             ref: "project-ref",
             bucket: "reports",
+            expected_revision: CURRENT_REVISION,
             public: true,
         });
         const payload = JSON.parse(response.content[0].text);
@@ -460,7 +546,7 @@ describe("Storage bucket lifecycle", () => {
             put: async () => ({
                 ok: true,
                 status: 200,
-                data: storageBucket(),
+                data: updatedBucketReceipt(),
             }),
         });
 
@@ -468,6 +554,7 @@ describe("Storage bucket lifecycle", () => {
             action: "update_bucket",
             ref: "project-ref",
             bucket: "reports",
+            expected_revision: CURRENT_REVISION,
             public: true,
         });
 
@@ -518,7 +605,7 @@ describe("Storage bucket lifecycle", () => {
             put: async () => ({
                 ok: true,
                 status: 200,
-                data: storageBucket({ id: "other-bucket", name: "reports", public: true }),
+                data: updatedBucketReceipt({ id: "other-bucket", name: "reports", public: true }),
             }),
         });
 
@@ -526,6 +613,7 @@ describe("Storage bucket lifecycle", () => {
             action: "update_bucket",
             ref: "project-ref",
             bucket: "reports",
+            expected_revision: CURRENT_REVISION,
             public: true,
         });
 
@@ -580,15 +668,20 @@ describe("Storage bucket lifecycle", () => {
             put: async () => ({
                 ok: true,
                 status: 200,
-                data: storageBucket({ public: true }),
+                data: updatedBucketReceipt({ public: true }),
             }),
-            get: async () => ({ ok: true, status: 200, data: storageBucket({ public: false }) }),
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: storageBucket({ public: false, revision: NEXT_REVISION }),
+            }),
         });
 
         const response = await callback({
             action: "update_bucket",
             ref: "project-ref",
             bucket: "reports",
+            expected_revision: CURRENT_REVISION,
             public: true,
         });
 
@@ -601,12 +694,18 @@ describe("Storage bucket lifecycle", () => {
             delete: async () => ({
                 ok: true,
                 status: 200,
-                data: { id: "reports", deleted: true },
+                data: deletedBucketReceipt(),
             }),
             get: async () => ({ ok: true, status: 200, data: storageBucket() }),
         });
 
-        const response = await callback({ action: "delete_bucket", ref: "project-ref", bucket: "reports" });
+        const response = await callback({
+            action: "delete_bucket",
+            ref: "project-ref",
+            bucket: "reports",
+            expected_revision: CURRENT_REVISION,
+            require_empty: true,
+        });
 
         expect(response.isError).toBe(true);
         expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });

--- a/packages/cli/src/shared/tools/storage-tools.ts
+++ b/packages/cli/src/shared/tools/storage-tools.ts
@@ -35,13 +35,14 @@ const MAX_MIME_TYPE_LENGTH = 255;
 const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
 const BUCKET_ID_PATTERN = new RegExp(`^(?!\\.+$)[A-Za-z0-9._-]{1,${MAX_BUCKET_ID_LENGTH}}$`);
 const MIME_TYPE_PATTERN = /^(?=\S)(?=.*\S$)[^\u0000-\u001f\u007f]+$/;
+const BUCKET_REVISION_PATTERN = /^[0-9]{1,20}$/;
 const ACTION_ARGUMENTS: Record<StorageAction, ReadonlySet<string>> = {
     status: new Set(["action"]),
     list_buckets: new Set(["action", "ref"]),
     get_bucket: new Set(["action", "ref", "bucket"]),
     create_bucket: new Set(["action", "ref", "bucket", "public", "file_size_limit", "allowed_mime_types"]),
-    update_bucket: new Set(["action", "ref", "bucket", "public", "file_size_limit", "allowed_mime_types"]),
-    delete_bucket: new Set(["action", "ref", "bucket"]),
+    update_bucket: new Set(["action", "ref", "bucket", "expected_revision", "public", "file_size_limit", "allowed_mime_types"]),
+    delete_bucket: new Set(["action", "ref", "bucket", "expected_revision", "require_empty"]),
     list_files: new Set(["action", "ref", "bucket"]),
     upload_base64: new Set(["action", "ref", "bucket", "filename", "base64_content", "mime_type"]),
     delete_file: new Set(["action", "ref", "bucket", "filename"]),
@@ -106,6 +107,16 @@ function requiredBucketId(args: Record<string, unknown>): string {
     return bucket;
 }
 
+function requiredBucketRevision(args: Record<string, unknown>): string {
+    const revision = requiredText(args, "expected_revision");
+    if (!BUCKET_REVISION_PATTERN.test(revision)) throw new Error("'expected_revision' is invalid for Storage buckets");
+    return revision;
+}
+
+function assertEmptyBucketDeletion(args: Record<string, unknown>): void {
+    if (args.require_empty !== true) throw new Error("'require_empty=true' required for 'delete_bucket'");
+}
+
 function assertActionArguments(action: StorageAction, args: Record<string, unknown>): void {
     const allowedArguments = ACTION_ARGUMENTS[action];
     if (!allowedArguments) throw new Error(`Unsupported Storage action '${action}'`);
@@ -134,6 +145,7 @@ type SafeBucket = {
     public: boolean;
     file_size_limit: number | null;
     allowed_mime_types: string[] | null;
+    revision: string | null;
 };
 
 function isFileSizeLimit(candidate: unknown): candidate is number | null {
@@ -159,12 +171,18 @@ function isAllowedMimeTypes(candidate: unknown): candidate is string[] | null {
                 && mimeType.length <= MAX_MIME_TYPE_LENGTH && MIME_TYPE_PATTERN.test(mimeType)));
 }
 
+function isBucketRevision(candidate: unknown): candidate is string | null {
+    return candidate === null
+        || (typeof candidate === "string" && BUCKET_REVISION_PATTERN.test(candidate));
+}
+
 function safeBucket(candidate: unknown, expectedBucket?: string): SafeBucket | null {
     const bucket = bucketRecord(candidate);
     if (bucket === null || typeof bucket.id !== "string" || !validBucketId(bucket.id)
         || typeof bucket.name !== "string" || !validBucketId(bucket.name)
         || typeof bucket.public !== "boolean" || !isFileSizeLimit(bucket.file_size_limit)
         || !isAllowedMimeTypes(bucket.allowed_mime_types)
+        || !isBucketRevision(bucket.revision)
         || (expectedBucket !== undefined && bucket.id !== expectedBucket && bucket.name !== expectedBucket)) {
         return null;
     }
@@ -174,6 +192,7 @@ function safeBucket(candidate: unknown, expectedBucket?: string): SafeBucket | n
         public: bucket.public,
         file_size_limit: bucket.file_size_limit,
         allowed_mime_types: bucket.allowed_mime_types === null ? null : [...bucket.allowed_mime_types],
+        revision: bucket.revision,
     };
 }
 
@@ -205,10 +224,24 @@ function safeCreatedBucketReceipt(
     return { bucket: { id: expectedBucket, name: expectedBucket, public: request.public === true } };
 }
 
-function safeDeletedBucket(candidate: unknown, expectedBucket: string): Record<string, unknown> | null {
+function safeDeletedBucket(
+    candidate: unknown,
+    expectedBucket: string,
+    expectedRevision: string,
+): Record<string, unknown> | null {
     const receipt = bucketRecord(candidate);
-    return receipt?.id === expectedBucket && receipt.deleted === true
-        ? { bucket_id: expectedBucket, deleted: true }
+    return receipt?.id === expectedBucket
+        && receipt.deleted === true
+        && receipt.require_empty === true
+        && receipt.previous_revision === expectedRevision
+        && receipt.new_revision === null
+        ? {
+            bucket_id: expectedBucket,
+            deleted: true,
+            require_empty: true,
+            previous_revision: expectedRevision,
+            new_revision: null,
+        }
         : null;
 }
 
@@ -218,17 +251,27 @@ type MutationReadbackExpectation = {
     response: HttpResult<unknown>;
     expectedBucket: string;
     request: Record<string, unknown>;
+    previousRevision: string | null;
+    expectedNewRevision?: string;
 };
 
 function mutationReadbackResponse(expectation: MutationReadbackExpectation): ReleaseControlToolResponse {
-    const { operation, ref, response, expectedBucket, request } = expectation;
+    const { operation, ref, response, expectedBucket, request, previousRevision, expectedNewRevision } = expectation;
     const readback = safeExactBucket(response.data, expectedBucket);
     const validReadback = readback?.name === expectedBucket
+        && readback.revision !== null
+        && (expectedNewRevision === undefined || readback.revision === expectedNewRevision)
         && bucketMatchesRequest(readback, request);
     if (!response.ok || !validReadback || !readback) {
         return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.transportError ? null : response.status);
     }
-    return releaseControlSuccess(operation, { project_ref: ref, bucket: readback });
+    return releaseControlSuccess(operation, {
+        project_ref: ref,
+        bucket_id: expectedBucket,
+        previous_revision: previousRevision,
+        new_revision: readback.revision,
+        bucket: readback,
+    });
 }
 
 type BucketResponseExpectation = {
@@ -266,13 +309,13 @@ function createBucketRequest(args: Record<string, unknown>): Record<string, unkn
 
 function updateBucketRequest(args: Record<string, unknown>): Record<string, unknown> {
     assertBucketSettings(args);
-    const request = Object.fromEntries(
+    const settings = Object.fromEntries(
         ["public", "file_size_limit", "allowed_mime_types"]
             .filter((field) => args[field] !== undefined)
             .map((field) => [field, args[field]]),
     );
-    if (Object.keys(request).length === 0) throw new Error("Bucket update requires at least one field");
-    return request;
+    if (Object.keys(settings).length === 0) throw new Error("Bucket update requires at least one field");
+    return { expected_revision: requiredBucketRevision(args), ...settings };
 }
 
 function equalAllowedMimeTypes(candidate: unknown, expected: unknown): boolean {
@@ -307,28 +350,23 @@ async function createBucketMutationReceipt(
     });
 }
 
-type UpdateBucketReceiptExpectation = {
-    http: HttpTransport;
-    ref: string;
-    bucket: string;
-    bucketPath: string;
-    request: Record<string, unknown>;
-};
-
-async function updateBucketMutationReceipt(
-    expectation: UpdateBucketReceiptExpectation,
-): Promise<ReleaseControlToolResponse> {
-    const { http, ref, bucket, bucketPath, request } = expectation;
-    return bucketResponse({
-        operation: "storage.update_bucket",
-        ref,
-        response: await http.put(bucketPath, request),
-        operationKind: "mutation",
-        safePayload: (apiPayload) => {
-            const updated = safeExactBucket(apiPayload, bucket);
-            return updated && bucketMatchesRequest(updated, request) ? { bucket: updated } : null;
-        },
-    });
+function safeUpdatedBucket(
+    candidate: unknown,
+    expectedBucket: string,
+    expectedRevision: string,
+    request: Record<string, unknown>,
+): SafeBucket | null {
+    const receipt = bucketRecord(candidate);
+    const bucket = safeExactBucket(candidate, expectedBucket);
+    return bucket
+        && bucket.name === expectedBucket
+        && bucket.revision !== null
+        && bucket.revision !== expectedRevision
+        && receipt?.previous_revision === expectedRevision
+        && receipt.new_revision === bucket.revision
+        && bucketMatchesRequest(bucket, request)
+        ? bucket
+        : null;
 }
 
 async function listBuckets(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
@@ -374,6 +412,7 @@ async function createBucket(http: HttpTransport, args: Record<string, unknown>):
         response: await http.get(bucketPath),
         expectedBucket: bucket,
         request: expectedReadback,
+        previousRevision: null,
     });
 }
 
@@ -381,28 +420,36 @@ async function updateBucket(http: HttpTransport, args: Record<string, unknown>):
     const ref = requiredProjectRef(args);
     const bucket = requiredBucketId(args);
     const request = updateBucketRequest(args);
+    const expectedRevision = request.expected_revision as string;
     const bucketPath = storageBucketPath(ref, bucket);
-    const receipt = await updateBucketMutationReceipt({ http, ref, bucket, bucketPath, request });
-    if (receipt.isError) return receipt;
+    const mutation = await http.put(bucketPath, request);
+    if (!mutation.ok) return releaseControlMutationFailure("storage.update_bucket", mutation);
+    const updated = safeUpdatedBucket(mutation.data, bucket, expectedRevision, request);
+    if (!updated) return releaseControlFailure("storage.update_bucket", "OUTCOME_UNKNOWN", mutation.status);
     return mutationReadbackResponse({
         operation: "storage.update_bucket",
         ref,
         response: await http.get(bucketPath),
         expectedBucket: bucket,
         request,
+        previousRevision: expectedRevision,
+        expectedNewRevision: updated.revision ?? undefined,
     });
 }
 
 async function deleteBucket(http: HttpTransport, args: Record<string, unknown>): Promise<ReleaseControlToolResponse> {
     const ref = requiredProjectRef(args);
     const bucket = requiredBucketId(args);
+    const expectedRevision = requiredBucketRevision(args);
+    assertEmptyBucketDeletion(args);
     const bucketPath = storageBucketPath(ref, bucket);
+    const deletePath = `${bucketPath}?expected_revision=${encodeURIComponent(expectedRevision)}&require_empty=true`;
     const receipt = bucketResponse({
         operation: "storage.delete_bucket",
         ref,
-        response: await http.delete(bucketPath),
+        response: await http.delete(deletePath),
         operationKind: "mutation",
-        safePayload: (candidate) => safeDeletedBucket(candidate, bucket),
+        safePayload: (candidate) => safeDeletedBucket(candidate, bucket, expectedRevision),
     });
     if (receipt.isError) return receipt;
     const readback = await http.get(bucketPath);
@@ -451,6 +498,8 @@ Actions: status, list_buckets, get_bucket, create_bucket, update_bucket, delete_
             public: optional(Type.Boolean(), "[create_bucket/update_bucket] Public bucket access"),
             file_size_limit: withDescription(fileSizeLimitSchema, "[create_bucket/update_bucket] Positive safe-integer per-file size limit in bytes"),
             allowed_mime_types: withDescription(allowedMimeTypesSchema, "[create_bucket/update_bucket] MIME types as a comma-separated or JSON array"),
+            expected_revision: optional(Type.String({ pattern: BUCKET_REVISION_PATTERN.source }), "[update_bucket/delete_bucket] Exact revision from list_buckets/get_bucket"),
+            require_empty: optional(Type.Boolean(), "[delete_bucket] Must be true; deletion never empties a bucket"),
             filename: optional(Type.String(), "[upload_base64/delete_file] File name/path"),
             base64_content: optional(Type.String(), "[upload_base64] Base64 encoded content"),
             mime_type: optional(Type.String(), "[upload_base64] MIME type (default: application/octet-stream)"),

--- a/packages/management-api/src/routes/storage.ts
+++ b/packages/management-api/src/routes/storage.ts
@@ -4,8 +4,10 @@ import {
     MAX_STORAGE_MIME_TYPE_COUNT,
     MAX_STORAGE_MIME_TYPE_LENGTH,
     STORAGE_BUCKET_ID_PATTERN_SOURCE,
+    STORAGE_BUCKET_REVISION_PATTERN_SOURCE,
     STORAGE_MIME_TYPE_PATTERN_SOURCE,
     STORAGE_PROJECT_REF_PATTERN_SOURCE,
+    normalizedStorageFileSizeLimit,
     storageBucketInputError,
 } from "../services/storage-bucket-contract";
 import { StorageRLS } from "../services/storage-rls";
@@ -18,6 +20,7 @@ const ErrorResponse = t.Object({ message: t.String() });
 const SuccessResponse = t.Object({ success: t.Boolean(), message: t.String() });
 const StorageProjectRef = t.String({ pattern: STORAGE_PROJECT_REF_PATTERN_SOURCE });
 const StorageBucketId = t.String({ pattern: STORAGE_BUCKET_ID_PATTERN_SOURCE });
+const StorageBucketRevision = t.String({ pattern: STORAGE_BUCKET_REVISION_PATTERN_SOURCE });
 const StorageFileSizeLimit = t.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER });
 const StorageMimeType = t.String({
     minLength: 1,
@@ -35,10 +38,15 @@ const StorageBucketCreateBody = t.Object({
     allowed_mime_types: t.Optional(StorageAllowedMimeTypes),
 });
 const StorageBucketUpdateBody = t.Object({
+    expected_revision: StorageBucketRevision,
     public: t.Optional(t.Boolean()),
     file_size_limit: t.Optional(StorageFileSizeLimit),
     allowed_mime_types: t.Optional(StorageAllowedMimeTypes),
-}, { minProperties: 1 });
+}, { minProperties: 2 });
+const StorageBucketDeleteQuery = t.Object({
+    expected_revision: StorageBucketRevision,
+    require_empty: t.Literal("true"),
+});
 
 type StorageBucketCreateInput = {
     name: string;
@@ -186,8 +194,9 @@ function mergeStorageBuckets(
     }
     return Array.from(bucketsById.values()).map((bucket) => ({
         ...bucket,
-        file_size_limit: bucket.file_size_limit ?? null,
+        file_size_limit: normalizedStorageFileSizeLimit(bucket.file_size_limit),
         allowed_mime_types: bucket.allowed_mime_types ?? null,
+        revision: typeof bucket.revision === "string" ? bucket.revision : null,
     }));
 }
 
@@ -204,31 +213,18 @@ async function listLegacyStorageBuckets(ref: string): Promise<Record<string, unk
     return await listStorageBuckets(ref);
 }
 
-async function deleteStorageBucket(ref: string, bucketName: string) {
-    const inputError = storageBucketInputError(ref, bucketName, {});
-    if (inputError) return { success: false, error: inputError };
-    const storageResult = await StorageService.deleteBucket(ref, bucketName);
-    if (!storageResult.success) return storageResult;
-
-    try {
-        await StorageRLS.deleteLogicalBucketAsAdmin(ref, bucketName);
-        return storageResult;
-    } catch (error: unknown) {
-        if (error instanceof Error && error.message === "Bucket is not empty") {
-            return { success: false, error: error.message };
-        }
-        logger.error("Failed to delete Studio storage bucket metadata", {
-            ref,
-            bucketName,
-            error: error instanceof Error ? error.message : String(error),
-        });
-        return { success: false, error: "Bucket deletion outcome is unknown" };
-    }
+async function deleteStorageBucket(ref: string, bucketName: string, expectedRevision: string) {
+    return await StorageService.deleteEmptyBucketAtRevision(ref, bucketName, expectedRevision);
 }
 
-function storageMutationStatus(error: string | undefined): 400 | 409 | 500 {
+function storageMutationStatus(error: string | undefined): 400 | 404 | 409 | 500 {
     if (error?.startsWith("Invalid ")) return 400;
-    return error === "Bucket already exists" || error === "Bucket is not empty" ? 409 : 500;
+    if (error === "Bucket not found") return 404;
+    return error === "Bucket already exists"
+        || error === "Bucket is not empty"
+        || error === "Bucket revision conflict"
+        ? 409
+        : 500;
 }
 
 // ── Storage Routes ────────────────────────────────────────────────
@@ -707,14 +703,18 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
             public: body.public,
             file_size_limit: body.file_size_limit,
             allowed_mime_types: body.allowed_mime_types,
-        });
+        }, body.expected_revision);
 
         if (!result.success) {
             set.status = result.error === "Bucket not found" ? 404 : storageMutationStatus(result.error);
             return { message: result.error || "Failed to update bucket", code: String(set.status) };
         }
 
-        return result.bucket;
+        return {
+            ...result.bucket,
+            previous_revision: result.previousRevision,
+            new_revision: result.newRevision,
+        };
     }, {
         params: StorageBucketParams,
         body: StorageBucketUpdateBody,
@@ -750,16 +750,23 @@ export const projectStorageRoutes = new Elysia({ prefix: "/v1/projects/:ref/stor
             return status(500, { statusCode: "500", error: "InternalError", message: "Vector storage operation failed" });
         }
     }, { detail: { tags: ["storage", "vector"], summary: "Manage project vector storage" } })
-    .delete('/buckets/:id', async ({ params, set, request }) => {
+    .delete('/buckets/:id', async ({ params, query, set, request }) => {
         const authError = await requireProjectOrAdminAuth(request, params.ref);
         if (authError) return status(authError.status, authError.body);
-        const result = await deleteStorageBucket(params.ref, params.id);
+        const result = await deleteStorageBucket(params.ref, params.id, query.expected_revision);
         if (!result.success) {
             set.status = storageMutationStatus(result.error);
             return { message: result.error || "Failed to delete bucket", code: String(set.status) };
         }
-        return { id: params.id, deleted: true };
+        return {
+            id: params.id,
+            deleted: true,
+            require_empty: true,
+            previous_revision: result.previousRevision,
+            new_revision: null,
+        };
     }, {
         params: StorageBucketParams,
+        query: StorageBucketDeleteQuery,
         detail: { tags: ["storage"], summary: "Delete a storage bucket" },
     });

--- a/packages/management-api/src/services/storage-bucket-contract.ts
+++ b/packages/management-api/src/services/storage-bucket-contract.ts
@@ -4,10 +4,12 @@ export const MAX_STORAGE_MIME_TYPE_LENGTH = 255;
 export const STORAGE_PROJECT_REF_PATTERN_SOURCE = "^[A-Za-z0-9_-]{1,64}$";
 export const STORAGE_BUCKET_ID_PATTERN_SOURCE = `^(?!\\.+$)[A-Za-z0-9._-]{1,${MAX_STORAGE_BUCKET_ID_LENGTH}}$`;
 export const STORAGE_MIME_TYPE_PATTERN_SOURCE = "^(?=\\S)(?=.*\\S$)[^\\u0000-\\u001f\\u007f]+$";
+export const STORAGE_BUCKET_REVISION_PATTERN_SOURCE = "^[0-9]{1,20}$";
 
 const storageProjectRefPattern = new RegExp(STORAGE_PROJECT_REF_PATTERN_SOURCE);
 const storageBucketIdPattern = new RegExp(STORAGE_BUCKET_ID_PATTERN_SOURCE);
 const storageMimeTypePattern = new RegExp(STORAGE_MIME_TYPE_PATTERN_SOURCE);
+const storageBucketRevisionPattern = new RegExp(STORAGE_BUCKET_REVISION_PATTERN_SOURCE);
 
 export interface StorageBucketSettings {
   public?: boolean;
@@ -25,6 +27,19 @@ function validStorageBucketId(bucketId: string): boolean {
 
 function validStorageFileSizeLimit(fileSizeLimit: number): boolean {
   return Number.isSafeInteger(fileSizeLimit) && fileSizeLimit > 0;
+}
+
+export function normalizedStorageFileSizeLimit(fileSizeLimit: unknown): number | null {
+  if (fileSizeLimit === null || fileSizeLimit === undefined) return null;
+  const numericLimit = typeof fileSizeLimit === "bigint"
+    ? Number(fileSizeLimit)
+    : typeof fileSizeLimit === "string" && /^[0-9]+$/.test(fileSizeLimit)
+      ? Number(fileSizeLimit)
+      : fileSizeLimit;
+  if (typeof numericLimit !== "number" || !validStorageFileSizeLimit(numericLimit)) {
+    throw new Error("Stored bucket file size limit is invalid");
+  }
+  return numericLimit;
 }
 
 function validStorageMimeTypes(mimeTypes: string[]): boolean {
@@ -47,4 +62,8 @@ export function storageBucketInputError(
     return "Invalid allowed MIME types";
   }
   return null;
+}
+
+export function storageBucketRevisionError(revision: string): string | null {
+  return storageBucketRevisionPattern.test(revision) ? null : "Invalid bucket revision";
 }

--- a/packages/management-api/src/services/storage-bucket-mutation.ts
+++ b/packages/management-api/src/services/storage-bucket-mutation.ts
@@ -1,0 +1,140 @@
+import type { SQL } from "bun";
+import {
+  normalizedStorageFileSizeLimit,
+  type StorageBucketSettings,
+} from "./storage-bucket-contract";
+
+type BucketRow = Record<string, unknown> & { revision: string };
+
+type MutationFailure = {
+  success: false;
+  error: "Bucket not found" | "Bucket revision conflict" | "Bucket is not empty" | "Bucket deletion outcome is unknown";
+};
+
+export type BucketUpdateResult = MutationFailure | {
+  success: true;
+  bucket: BucketRow;
+  previousRevision: string;
+  newRevision: string;
+};
+
+export type BucketDeleteResult = MutationFailure | {
+  success: true;
+  previousRevision: string;
+};
+
+type BucketUpdateInput = {
+  bucketId: string;
+  expectedRevision: string;
+  updates: StorageBucketSettings;
+};
+
+type BucketDeleteInput = {
+  bucketId: string;
+  expectedRevision: string;
+  deletePhysicalBucket: () => Promise<{ success: boolean; error?: string }>;
+};
+
+async function lockedBucketRevision(database: SQL, bucketId: string): Promise<string | null> {
+  const [bucket] = await database`
+    SELECT FLOOR(EXTRACT(EPOCH FROM COALESCE(updated_at, created_at, TIMESTAMPTZ 'epoch')) * 1000000)::bigint::text AS revision
+    FROM storage.buckets
+    WHERE id = ${bucketId}
+    FOR UPDATE
+  ` as Array<{ revision: string }>;
+  return bucket?.revision ?? null;
+}
+
+function revisionFailure(currentRevision: string | null, expectedRevision: string): MutationFailure | null {
+  if (currentRevision === null) return { success: false, error: "Bucket not found" };
+  return currentRevision === expectedRevision
+    ? null
+    : { success: false, error: "Bucket revision conflict" };
+}
+
+async function updateLockedBucket(database: SQL, input: BucketUpdateInput): Promise<BucketRow | null> {
+  const mimeTypes = input.updates.allowed_mime_types?.length
+    ? database.array(input.updates.allowed_mime_types, "TEXT")
+    : null;
+  const [bucket] = await database`
+    UPDATE storage.buckets
+    SET public = CASE WHEN ${input.updates.public !== undefined} THEN ${input.updates.public ?? false} ELSE public END,
+        file_size_limit = CASE WHEN ${input.updates.file_size_limit !== undefined} THEN ${input.updates.file_size_limit ?? null} ELSE file_size_limit END,
+        allowed_mime_types = CASE WHEN ${input.updates.allowed_mime_types !== undefined} THEN ${mimeTypes} ELSE allowed_mime_types END,
+        updated_at = GREATEST(
+          clock_timestamp(),
+          COALESCE(updated_at, created_at, TIMESTAMPTZ 'epoch') + INTERVAL '1 microsecond'
+        )
+    WHERE id = ${input.bucketId}
+      AND FLOOR(EXTRACT(EPOCH FROM COALESCE(updated_at, created_at, TIMESTAMPTZ 'epoch')) * 1000000)::bigint::text = ${input.expectedRevision}
+    RETURNING id, name, public, created_at, updated_at, file_size_limit, allowed_mime_types,
+      FLOOR(EXTRACT(EPOCH FROM updated_at) * 1000000)::bigint::text AS revision
+  ` as BucketRow[];
+  return bucket
+    ? { ...bucket, file_size_limit: normalizedStorageFileSizeLimit(bucket.file_size_limit) }
+    : null;
+}
+
+export async function updateBucketAtRevision(database: SQL, input: BucketUpdateInput): Promise<BucketUpdateResult> {
+  return database.begin(async (transaction) => {
+    const currentRevision = await lockedBucketRevision(transaction, input.bucketId);
+    const failure = revisionFailure(currentRevision, input.expectedRevision);
+    if (failure) return failure;
+    const bucket = await updateLockedBucket(transaction, input);
+    if (!bucket) return { success: false, error: "Bucket revision conflict" };
+    return {
+      success: true,
+      bucket,
+      previousRevision: input.expectedRevision,
+      newRevision: bucket.revision,
+    };
+  });
+}
+
+async function bucketContainsEntries(database: SQL, bucketId: string): Promise<boolean> {
+  const [row] = await database`
+    SELECT EXISTS(
+      SELECT 1 FROM storage.objects WHERE bucket_id = ${bucketId}
+    ) OR EXISTS(
+      SELECT 1 FROM storage.s3_multipart_uploads WHERE bucket_id = ${bucketId}
+    ) AS has_entries
+  ` as Array<{ has_entries: boolean }>;
+  return row?.has_entries === true;
+}
+
+async function deleteLockedBucket(database: SQL, input: BucketDeleteInput): Promise<boolean> {
+  const deleted = await database`
+    DELETE FROM storage.buckets
+    WHERE id = ${input.bucketId}
+      AND FLOOR(EXTRACT(EPOCH FROM COALESCE(updated_at, created_at, TIMESTAMPTZ 'epoch')) * 1000000)::bigint::text = ${input.expectedRevision}
+    RETURNING id
+  `;
+  return deleted.length === 1;
+}
+
+function physicalDeletionFailure(deletion: { success: boolean; error?: string }): MutationFailure | null {
+  if (deletion.success) return null;
+  return {
+    success: false,
+    error: deletion.error === "Bucket is not empty"
+      ? "Bucket is not empty"
+      : "Bucket deletion outcome is unknown",
+  };
+}
+
+export async function deleteEmptyBucketAtRevision(database: SQL, input: BucketDeleteInput): Promise<BucketDeleteResult> {
+  return database.begin(async (transaction) => {
+    const currentRevision = await lockedBucketRevision(transaction, input.bucketId);
+    const failure = revisionFailure(currentRevision, input.expectedRevision);
+    if (failure) return failure;
+    if (await bucketContainsEntries(transaction, input.bucketId)) {
+      return { success: false, error: "Bucket is not empty" };
+    }
+    const physicalFailure = physicalDeletionFailure(await input.deletePhysicalBucket());
+    if (physicalFailure) return physicalFailure;
+    if (!await deleteLockedBucket(transaction, input)) {
+      return { success: false, error: "Bucket deletion outcome is unknown" };
+    }
+    return { success: true, previousRevision: input.expectedRevision };
+  });
+}

--- a/packages/management-api/src/services/storage-rls.ts
+++ b/packages/management-api/src/services/storage-rls.ts
@@ -105,7 +105,8 @@ export class StorageRLS {
     const dbName = await resolveDbName(ref);
     const db = getProjectDb(dbName);
     return await db`
-      SELECT id, name, public, created_at, updated_at, file_size_limit, allowed_mime_types
+      SELECT id, name, public, created_at, updated_at, file_size_limit, allowed_mime_types,
+        FLOOR(EXTRACT(EPOCH FROM COALESCE(updated_at, created_at, TIMESTAMPTZ 'epoch')) * 1000000)::bigint::text AS revision
       FROM storage.buckets
       ORDER BY name ASC
     `;

--- a/packages/management-api/src/services/storage.service.ts
+++ b/packages/management-api/src/services/storage.service.ts
@@ -2,7 +2,17 @@ import { config } from "../config";
 import { shellService } from './shell.service';
 import { logger } from "../utils/logger";
 import { getStorageDriver } from "./storage.adapter";
-import { storageBucketInputError, type StorageBucketSettings } from "./storage-bucket-contract";
+import {
+  storageBucketInputError,
+  storageBucketRevisionError,
+  type StorageBucketSettings,
+} from "./storage-bucket-contract";
+import {
+  deleteEmptyBucketAtRevision as deleteEmptyBucketMetadataAtRevision,
+  updateBucketAtRevision,
+  type BucketDeleteResult,
+  type BucketUpdateResult,
+} from "./storage-bucket-mutation";
 import { statfs } from "node:fs/promises";
 
 export interface StorageStatus {
@@ -223,34 +233,25 @@ export class StorageService {
     return await getStorageDriver().isBucketEmpty(projectRef, bucketName);
   }
 
-  static async updateBucket(projectRef: string, bucketId: string, updates: StorageBucketSettings): Promise<{ success: boolean; error?: string; bucket?: Record<string, unknown> }> {
+  static async updateBucket(
+    projectRef: string,
+    bucketId: string,
+    updates: StorageBucketSettings,
+    expectedRevision: string,
+  ): Promise<BucketUpdateResult | { success: false; error: string }> {
     const inputError = storageBucketInputError(projectRef, bucketId, updates);
     if (inputError) return { success: false, error: inputError };
+    const revisionError = storageBucketRevisionError(expectedRevision);
+    if (revisionError) return { success: false, error: revisionError };
+    if (Object.values(updates).every((setting) => setting === undefined)) {
+      return { success: false, error: "Invalid empty bucket update" };
+    }
 
     try {
       const { getProjectDb, resolveDbName } = await import("../db");
       const dbName = await resolveDbName(projectRef);
       const db = getProjectDb(dbName);
-
-      if (updates.public !== undefined) {
-        await db`UPDATE storage.buckets SET public = ${updates.public} WHERE id = ${bucketId}`;
-      }
-      if (updates.file_size_limit !== undefined) {
-        await db`UPDATE storage.buckets SET file_size_limit = ${updates.file_size_limit} WHERE id = ${bucketId}`;
-      }
-      if (updates.allowed_mime_types !== undefined) {
-        const allowedMimeTypes = updates.allowed_mime_types.length > 0
-          ? db.array(updates.allowed_mime_types, "TEXT")
-          : null;
-        await db`UPDATE storage.buckets SET allowed_mime_types = ${allowedMimeTypes} WHERE id = ${bucketId}`;
-      }
-
-      const [bucket] = await db`SELECT * FROM storage.buckets WHERE id = ${bucketId}`;
-      if (!bucket) {
-        return { success: false, error: "Bucket not found" };
-      }
-
-      return { success: true, bucket: bucket as Record<string, unknown> };
+      return await updateBucketAtRevision(db, { bucketId, expectedRevision, updates });
     } catch (error: unknown) {
       logger.error("Failed to update bucket", {
         projectRef,
@@ -258,6 +259,34 @@ export class StorageService {
         error: error instanceof Error ? error.message : String(error),
       });
       return { success: false, error: "Failed to update bucket" };
+    }
+  }
+
+  static async deleteEmptyBucketAtRevision(
+    projectRef: string,
+    bucketId: string,
+    expectedRevision: string,
+  ): Promise<BucketDeleteResult | { success: false; error: string }> {
+    const inputError = storageBucketInputError(projectRef, bucketId, {});
+    if (inputError) return { success: false, error: inputError };
+    const revisionError = storageBucketRevisionError(expectedRevision);
+    if (revisionError) return { success: false, error: revisionError };
+
+    try {
+      const { getProjectDb, resolveDbName } = await import("../db");
+      const database = getProjectDb(await resolveDbName(projectRef));
+      return await deleteEmptyBucketMetadataAtRevision(database, {
+        bucketId,
+        expectedRevision,
+        deletePhysicalBucket: () => this.deleteBucket(projectRef, bucketId),
+      });
+    } catch (error: unknown) {
+      logger.error("Failed to delete bucket at revision", {
+        projectRef,
+        bucketId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { success: false, error: "Bucket deletion outcome is unknown" };
     }
   }
 

--- a/packages/management-api/tests/integration/storage-bucket-cas.test.ts
+++ b/packages/management-api/tests/integration/storage-bucket-cas.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { SQL } from "bun";
+import {
+  deleteEmptyBucketAtRevision,
+  updateBucketAtRevision,
+} from "../../src/services/storage-bucket-mutation";
+
+const database = new SQL({
+  url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+  max: 5,
+});
+const fixturePrefix = `storage-cas-${process.pid}-${Date.now()}`;
+
+function fixtureBucket(suffix: string): string {
+  return `${fixturePrefix}-${suffix}`;
+}
+
+async function installStorageFixture(): Promise<void> {
+  await database`CREATE SCHEMA IF NOT EXISTS storage`;
+  await database`
+    CREATE TABLE IF NOT EXISTS storage.buckets (
+      id text PRIMARY KEY,
+      name text NOT NULL UNIQUE,
+      created_at timestamptz DEFAULT now(),
+      updated_at timestamptz DEFAULT now(),
+      public boolean DEFAULT false,
+      file_size_limit bigint,
+      allowed_mime_types text[]
+    )
+  `;
+  await database`
+    CREATE TABLE IF NOT EXISTS storage.objects (
+      id uuid PRIMARY KEY,
+      bucket_id text REFERENCES storage.buckets(id),
+      name text
+    )
+  `;
+  await database`
+    CREATE TABLE IF NOT EXISTS storage.s3_multipart_uploads (
+      id text PRIMARY KEY,
+      in_progress_size bigint NOT NULL DEFAULT 0,
+      upload_signature text NOT NULL,
+      bucket_id text NOT NULL REFERENCES storage.buckets(id),
+      key text NOT NULL,
+      version text NOT NULL
+    )
+  `;
+}
+
+async function createBucket(bucketId: string): Promise<string> {
+  const [bucket] = await database`
+    INSERT INTO storage.buckets (id, name, public, created_at, updated_at)
+    VALUES (${bucketId}, ${bucketId}, false, clock_timestamp(), clock_timestamp())
+    RETURNING FLOOR(EXTRACT(EPOCH FROM updated_at) * 1000000)::bigint::text AS revision
+  ` as Array<{ revision: string }>;
+  return bucket.revision;
+}
+
+async function bucketState(bucketId: string): Promise<Record<string, unknown> | null> {
+  const [bucket] = await database`
+    SELECT public, file_size_limit, allowed_mime_types,
+      FLOOR(EXTRACT(EPOCH FROM updated_at) * 1000000)::bigint::text AS revision
+    FROM storage.buckets
+    WHERE id = ${bucketId}
+  `;
+  return bucket ?? null;
+}
+
+async function deleteFixture(bucketId: string): Promise<void> {
+  await database`DELETE FROM storage.objects WHERE bucket_id = ${bucketId}`;
+  await database`DELETE FROM storage.s3_multipart_uploads WHERE bucket_id = ${bucketId}`;
+  await database`DELETE FROM storage.buckets WHERE id = ${bucketId}`;
+}
+
+beforeAll(installStorageFixture);
+
+afterAll(async () => {
+  const fixturePattern = `${fixturePrefix}-%`;
+  await database`
+    DELETE FROM storage.objects
+    WHERE bucket_id IN (SELECT id FROM storage.buckets WHERE id LIKE ${fixturePattern})
+  `;
+  await database`
+    DELETE FROM storage.s3_multipart_uploads
+    WHERE bucket_id IN (SELECT id FROM storage.buckets WHERE id LIKE ${fixturePattern})
+  `;
+  await database`DELETE FROM storage.buckets WHERE id LIKE ${fixturePattern}`;
+  await database.close();
+}, 30_000);
+
+describe("Storage bucket revision CAS", () => {
+  test("allows exactly one concurrent update at a shared revision", async () => {
+    const bucketId = fixtureBucket("concurrent-update");
+    const revision = await createBucket(bucketId);
+
+    const mutations = await Promise.all([
+      updateBucketAtRevision(database, { bucketId, expectedRevision: revision, updates: { public: true } }),
+      updateBucketAtRevision(database, { bucketId, expectedRevision: revision, updates: { file_size_limit: 2048 } }),
+    ]);
+    const successes = mutations.filter((mutation) => mutation.success);
+    const conflicts = mutations.filter((mutation) => !mutation.success);
+    const stored = await bucketState(bucketId);
+
+    expect(successes).toHaveLength(1);
+    expect(conflicts).toEqual([{ success: false, error: "Bucket revision conflict" }]);
+    expect(stored?.revision).not.toBe(revision);
+    expect([
+      { public: stored?.public, file_size_limit: Number(stored?.file_size_limit ?? 0) || null },
+    ]).toEqual(
+      stored?.public === true
+        ? [{ public: true, file_size_limit: null }]
+        : [{ public: false, file_size_limit: 2048 }],
+    );
+    await deleteFixture(bucketId);
+  }, 30_000);
+
+  test("rejects a stale list-to-write revision without changing the winner", async () => {
+    const bucketId = fixtureBucket("list-write-race");
+    const listedRevision = await createBucket(bucketId);
+    const winner = await updateBucketAtRevision(database, {
+      bucketId,
+      expectedRevision: listedRevision,
+      updates: { public: true },
+    });
+    const winnerState = await bucketState(bucketId);
+
+    const staleMutation = await updateBucketAtRevision(database, {
+      bucketId,
+      expectedRevision: listedRevision,
+      updates: { allowed_mime_types: ["application/pdf"] },
+    });
+
+    expect(winner.success).toBe(true);
+    expect(staleMutation).toEqual({ success: false, error: "Bucket revision conflict" });
+    expect(await bucketState(bucketId)).toEqual(winnerState);
+    await deleteFixture(bucketId);
+  }, 30_000);
+
+  test("rejects a non-empty bucket before any physical or logical deletion", async () => {
+    const bucketId = fixtureBucket("non-empty");
+    const revision = await createBucket(bucketId);
+    await database`
+      INSERT INTO storage.objects (id, bucket_id, name)
+      VALUES (${crypto.randomUUID()}, ${bucketId}, 'report.pdf')
+    `;
+    let physicalDeleteCount = 0;
+
+    const deletion = await deleteEmptyBucketAtRevision(database, {
+      bucketId,
+      expectedRevision: revision,
+      deletePhysicalBucket: async () => {
+        physicalDeleteCount += 1;
+        return { success: true };
+      },
+    });
+
+    expect(deletion).toEqual({ success: false, error: "Bucket is not empty" });
+    expect(physicalDeleteCount).toBe(0);
+    expect(await bucketState(bucketId)).not.toBeNull();
+    const [{ count }] = await database`SELECT count(*)::integer AS count FROM storage.objects WHERE bucket_id = ${bucketId}`;
+    expect(count).toBe(1);
+    await deleteFixture(bucketId);
+  }, 30_000);
+
+  test("rejects a stale delete revision with zero mutation", async () => {
+    const bucketId = fixtureBucket("stale-delete");
+    const revision = await createBucket(bucketId);
+    let physicalDeleteCount = 0;
+
+    const deletion = await deleteEmptyBucketAtRevision(database, {
+      bucketId,
+      expectedRevision: String(BigInt(revision) - 1n),
+      deletePhysicalBucket: async () => {
+        physicalDeleteCount += 1;
+        return { success: true };
+      },
+    });
+
+    expect(deletion).toEqual({ success: false, error: "Bucket revision conflict" });
+    expect(physicalDeleteCount).toBe(0);
+    expect(await bucketState(bucketId)).not.toBeNull();
+    await deleteFixture(bucketId);
+  }, 30_000);
+
+  test("treats an active multipart upload as a non-empty bucket", async () => {
+    const bucketId = fixtureBucket("multipart");
+    const revision = await createBucket(bucketId);
+    await database`
+      INSERT INTO storage.s3_multipart_uploads
+        (id, upload_signature, bucket_id, key, version)
+      VALUES (${`${bucketId}-upload`}, 'signature', ${bucketId}, 'report.pdf', 'v1')
+    `;
+    let physicalDeleteCount = 0;
+
+    const deletion = await deleteEmptyBucketAtRevision(database, {
+      bucketId,
+      expectedRevision: revision,
+      deletePhysicalBucket: async () => {
+        physicalDeleteCount += 1;
+        return { success: true };
+      },
+    });
+
+    expect(deletion).toEqual({ success: false, error: "Bucket is not empty" });
+    expect(physicalDeleteCount).toBe(0);
+    expect(await bucketState(bucketId)).not.toBeNull();
+    await deleteFixture(bucketId);
+  }, 30_000);
+
+  test("holds the bucket row lock across empty validation and deletion", async () => {
+    const bucketId = fixtureBucket("concurrent-object");
+    const revision = await createBucket(bucketId);
+    let objectInsertOutcome: Promise<{ success: boolean }> | undefined;
+
+    const deletion = await deleteEmptyBucketAtRevision(database, {
+      bucketId,
+      expectedRevision: revision,
+      deletePhysicalBucket: async () => {
+        objectInsertOutcome = database`
+          INSERT INTO storage.objects (id, bucket_id, name)
+          VALUES (${crypto.randomUUID()}, ${bucketId}, 'late-object.pdf')
+        `.then(
+          () => ({ success: true }),
+          () => ({ success: false }),
+        );
+        return { success: true };
+      },
+    });
+
+    expect(deletion).toEqual({ success: true, previousRevision: revision });
+    expect(await objectInsertOutcome).toEqual({ success: false });
+    expect(await bucketState(bucketId)).toBeNull();
+  }, 30_000);
+});

--- a/packages/management-api/tests/unit/storage-routes.test.ts
+++ b/packages/management-api/tests/unit/storage-routes.test.ts
@@ -7,6 +7,8 @@ import { mockBuckets, StorageRLS } from "../../src/services/storage-rls";
 import { storageVectorInternals } from "../../src/services/storage-vector.service";
 
 const BASE = "http://localhost";
+const CURRENT_REVISION = "1786406400000000";
+const NEXT_REVISION = "1786406400000001";
 const app = new Elysia().use(storageRoutes).use(projectStorageRoutes);
 
 function request(path: string, init?: RequestInit) {
@@ -153,8 +155,8 @@ describe("storage management routes", () => {
       { id: "physical-only", name: "physical-only", public: false, size: "-" },
     ]);
     const listLogicalSpy = spyOn(StorageRLS, "listLogicalBucketsAsAdmin").mockResolvedValue([
-      { id: "public-assets", name: "public-assets", public: true, file_size_limit: 1024 },
-      { id: "logical-only", name: "logical-only", public: false },
+      { id: "public-assets", name: "public-assets", public: true, file_size_limit: "1024", revision: CURRENT_REVISION },
+      { id: "logical-only", name: "logical-only", public: false, revision: NEXT_REVISION },
     ]);
 
     try {
@@ -170,6 +172,7 @@ describe("storage management routes", () => {
           size: "-",
           file_size_limit: 1024,
           allowed_mime_types: null,
+          revision: CURRENT_REVISION,
         },
         {
           id: "physical-only",
@@ -178,6 +181,7 @@ describe("storage management routes", () => {
           size: "-",
           file_size_limit: null,
           allowed_mime_types: null,
+          revision: null,
         },
         {
           id: "logical-only",
@@ -185,6 +189,7 @@ describe("storage management routes", () => {
           public: false,
           file_size_limit: null,
           allowed_mime_types: null,
+          revision: NEXT_REVISION,
         },
       ]);
     } finally {
@@ -247,6 +252,65 @@ describe("storage management routes", () => {
     }
   });
 
+  test("updates a bucket only at the requested revision and binds the response revisions", async () => {
+    const bucket = {
+      id: "reports",
+      name: "reports",
+      public: true,
+      file_size_limit: null,
+      allowed_mime_types: null,
+      revision: NEXT_REVISION,
+    };
+    const updateBucketSpy = spyOn(StorageService, "updateBucket").mockResolvedValue({
+      success: true,
+      bucket,
+      previousRevision: CURRENT_REVISION,
+      newRevision: NEXT_REVISION,
+    });
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/reports", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify({ expected_revision: CURRENT_REVISION, public: true }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(updateBucketSpy).toHaveBeenCalledWith("test-ref", "reports", {
+        public: true,
+        file_size_limit: undefined,
+        allowed_mime_types: undefined,
+      }, CURRENT_REVISION);
+      expect(await response.json()).toEqual({
+        ...bucket,
+        previous_revision: CURRENT_REVISION,
+        new_revision: NEXT_REVISION,
+      });
+    } finally {
+      updateBucketSpy.mockRestore();
+    }
+  });
+
+  test("maps a stale bucket update revision to 409", async () => {
+    const updateBucketSpy = spyOn(StorageService, "updateBucket").mockResolvedValue({
+      success: false,
+      error: "Bucket revision conflict",
+    });
+
+    try {
+      const response = await request("/v1/projects/test-ref/storage/buckets/reports", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer dev-master-token" },
+        body: JSON.stringify({ expected_revision: CURRENT_REVISION, public: true }),
+      });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ message: "Bucket revision conflict", code: "409" });
+    } finally {
+      updateBucketSpy.mockRestore();
+    }
+  });
+
   test("accepts exact Storage contract upper boundaries", async () => {
     const createPhysicalSpy = spyOn(StorageService, "createBucket").mockResolvedValue({ success: true });
     const createLogicalSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(true);
@@ -297,94 +361,70 @@ describe("storage management routes", () => {
     }
   });
 
-  test("Studio bucket deletion removes the empty physical bucket before logical metadata", async () => {
-    const callOrder: string[] = [];
-    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockImplementation(async () => {
-      callOrder.push("physical");
-      return { success: true };
-    });
-    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockImplementation(async () => {
-      callOrder.push("logical");
-    });
-
+  test("Studio bucket deletion requires revision and an explicit empty-bucket guard", async () => {
+    const deleteSpy = spyOn(StorageService, "deleteEmptyBucketAtRevision");
     try {
       const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
         method: "DELETE",
         headers: { Authorization: "Bearer dev-master-token" },
       });
+
+      expect(response.status).toBe(422);
+      expect(deleteSpy).not.toHaveBeenCalled();
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  });
+
+  test("Studio bucket deletion binds project, bucket, revision, and empty-bucket receipt", async () => {
+    const deleteSpy = spyOn(StorageService, "deleteEmptyBucketAtRevision").mockResolvedValue({
+      success: true,
+      previousRevision: CURRENT_REVISION,
+    });
+    const query = `expected_revision=${CURRENT_REVISION}&require_empty=true`;
+
+    try {
+      const response = await request(`/v1/projects/test-ref/storage/buckets/public-assets?${query}`, {
+        method: "DELETE",
+        headers: { Authorization: "Bearer dev-master-token" },
+      });
+
       expect(response.status).toBe(200);
-      expect(callOrder).toEqual(["physical", "logical"]);
-      expect(deleteLogicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
-    } finally {
-      deletePhysicalSpy.mockRestore();
-      deleteLogicalSpy.mockRestore();
-    }
-  });
-
-  test("Studio bucket deletion reports a conflict when a logical object arrives after physical deletion", async () => {
-    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({ success: true });
-    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockRejectedValue(
-      new Error("Bucket is not empty"),
-    );
-
-    try {
-      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
-        method: "DELETE",
-        headers: { Authorization: "Bearer dev-master-token" },
+      expect(deleteSpy).toHaveBeenCalledWith("test-ref", "public-assets", CURRENT_REVISION);
+      expect(await response.json()).toEqual({
+        id: "public-assets",
+        deleted: true,
+        require_empty: true,
+        previous_revision: CURRENT_REVISION,
+        new_revision: null,
       });
-      expect(response.status).toBe(409);
-      expect(await response.json()).toEqual({ message: "Bucket is not empty", code: "409" });
-      expect(deletePhysicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
-      expect(deleteLogicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
     } finally {
-      deletePhysicalSpy.mockRestore();
-      deleteLogicalSpy.mockRestore();
+      deleteSpy.mockRestore();
     }
   });
 
-  test("Studio bucket deletion reports a conflict when the physical bucket is not empty", async () => {
-    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({
-      success: false,
-      error: "Bucket is not empty",
-    });
-    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
-
-    try {
-      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
-        method: "DELETE",
-        headers: { Authorization: "Bearer dev-master-token" },
+  test.each(["Bucket revision conflict", "Bucket is not empty"])(
+    "Studio bucket deletion maps %s to 409 without a success receipt",
+    async (error) => {
+      const deleteSpy = spyOn(StorageService, "deleteEmptyBucketAtRevision").mockResolvedValue({
+        success: false,
+        error,
       });
-      expect(response.status).toBe(409);
-      expect(await response.json()).toEqual({ message: "Bucket is not empty", code: "409" });
-      expect(deletePhysicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
-      expect(deleteLogicalSpy).not.toHaveBeenCalled();
-    } finally {
-      deletePhysicalSpy.mockRestore();
-      deleteLogicalSpy.mockRestore();
-    }
-  });
+      const query = `expected_revision=${CURRENT_REVISION}&require_empty=true`;
 
-  test("Studio bucket deletion fails closed when the physical outcome is unknown", async () => {
-    const deletePhysicalSpy = spyOn(StorageService, "deleteBucket").mockResolvedValue({
-      success: false,
-      error: "Bucket deletion outcome is unknown",
-    });
-    const deleteLogicalSpy = spyOn(StorageRLS, "deleteLogicalBucketAsAdmin").mockResolvedValue();
+      try {
+        const response = await request(`/v1/projects/test-ref/storage/buckets/public-assets?${query}`, {
+          method: "DELETE",
+          headers: { Authorization: "Bearer dev-master-token" },
+        });
 
-    try {
-      const response = await request("/v1/projects/test-ref/storage/buckets/public-assets", {
-        method: "DELETE",
-        headers: { Authorization: "Bearer dev-master-token" },
-      });
-      expect(response.status).toBe(500);
-      expect(await response.json()).toEqual({ message: "Bucket deletion outcome is unknown", code: "500" });
-      expect(deletePhysicalSpy).toHaveBeenCalledWith("test-ref", "public-assets");
-      expect(deleteLogicalSpy).not.toHaveBeenCalled();
-    } finally {
-      deletePhysicalSpy.mockRestore();
-      deleteLogicalSpy.mockRestore();
-    }
-  });
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({ message: error, code: "409" });
+      } finally {
+        deleteSpy.mockRestore();
+      }
+    },
+  );
 
   test("Studio bucket creation preserves storage failures", async () => {
     const registerBucketSpy = spyOn(StorageRLS, "createLogicalBucketAsAdmin").mockResolvedValue(true);

--- a/packages/management-api/tests/unit/storage.service.test.ts
+++ b/packages/management-api/tests/unit/storage.service.test.ts
@@ -2,6 +2,9 @@ import { describe, test, expect, spyOn, mock } from "bun:test";
 import * as databaseModule from "../../src/db";
 import { storageService, StorageService } from "../../src/services/storage.service";
 
+const CURRENT_REVISION = "1786406400000000";
+const NEXT_REVISION = "1786406400000001";
+
 // We must mock the adapter module since StorageService now uses it internally
 const mockStorageDriver = {
   createBucket: mock().mockResolvedValue(true),
@@ -85,24 +88,29 @@ describe("StorageService (using adapter)", () => {
 
   describe("updateBucket", () => {
     test("binds single and multiple MIME types as PostgreSQL TEXT arrays and clears with NULL", async () => {
-      const sqlParameters: unknown[][] = [];
+      const sqlStatements: string[] = [];
       const textArrayCalls: Array<{ values: string[]; type: string }> = [];
       const projectDatabaseTag = async (strings: TemplateStringsArray, ...parameters: unknown[]) => {
-        sqlParameters.push(parameters);
-        return strings.join("?").includes("SELECT * FROM storage.buckets")
-          ? [{
-              id: "reports",
-              name: "reports",
-              public: false,
-              file_size_limit: null,
-              allowed_mime_types: ["application/pdf"],
-            }]
-          : [];
+        const statement = strings.join("?");
+        sqlStatements.push(statement);
+        if (statement.includes("FOR UPDATE")) return [{ revision: CURRENT_REVISION }];
+        if (!statement.includes("UPDATE storage.buckets")) return [];
+        return [{
+          id: "reports",
+          name: "reports",
+          public: false,
+          file_size_limit: null,
+          allowed_mime_types: ["application/pdf"],
+          revision: NEXT_REVISION,
+        }];
       };
       const projectDatabase = Object.assign(projectDatabaseTag, {
         array(values: string[], type: string) {
           textArrayCalls.push({ values, type });
           return values;
+        },
+        begin(operation: (transaction: typeof projectDatabaseTag) => Promise<unknown>) {
+          return operation(projectDatabase as never);
         },
       }) as never;
       const resolveDbName = spyOn(databaseModule, "resolveDbName").mockResolvedValue("supa_testref");
@@ -111,25 +119,25 @@ describe("StorageService (using adapter)", () => {
       try {
         const singleResponse = await StorageService.updateBucket("testref", "reports", {
           allowed_mime_types: ["application/pdf"],
-        });
+        }, CURRENT_REVISION);
         const multipleResponse = await StorageService.updateBucket("testref", "reports", {
           allowed_mime_types: ["application/pdf", "image/png"],
-        });
+        }, CURRENT_REVISION);
         const clearedResponse = await StorageService.updateBucket("testref", "reports", {
           allowed_mime_types: [],
-        });
+        }, CURRENT_REVISION);
 
         expect(singleResponse.success).toBe(true);
         expect(multipleResponse.success).toBe(true);
         expect(clearedResponse.success).toBe(true);
-        expect(sqlParameters[0]).toEqual([["application/pdf"], "reports"]);
-        expect(sqlParameters[2]).toEqual([["application/pdf", "image/png"], "reports"]);
-        expect(sqlParameters[4]).toEqual([null, "reports"]);
         expect(textArrayCalls).toEqual([
           { values: ["application/pdf"], type: "TEXT" },
           { values: ["application/pdf", "image/png"], type: "TEXT" },
         ]);
-        expect(sqlParameters.flat().join(" ")).not.toContain('["application/pdf"]');
+        expect(sqlStatements.filter((statement) => statement.includes("UPDATE storage.buckets"))).toHaveLength(3);
+        expect(sqlStatements.join("\n")).toContain("FOR UPDATE");
+        expect(sqlStatements.join("\n")).toContain("clock_timestamp()");
+        expect(sqlStatements.join("\n")).toContain("::bigint::text = ?");
       } finally {
         resolveDbName.mockRestore();
         getProjectDb.mockRestore();
@@ -150,7 +158,7 @@ describe("StorageService (using adapter)", () => {
     ])("rejects invalid %s before opening a project database", async (_label, ref, bucket, updates) => {
       const getProjectDb = spyOn(databaseModule, "getProjectDb");
       try {
-        const response = await StorageService.updateBucket(ref, bucket, updates);
+        const response = await StorageService.updateBucket(ref, bucket, updates, CURRENT_REVISION);
 
         expect(response.success).toBe(false);
         expect(response.error).toStartWith("Invalid ");

--- a/packages/web-console/src/routes/project/[ref]/storage/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/storage/+page.svelte
@@ -13,6 +13,7 @@
     id?: string;
     name: string;
     public: boolean;
+    revision: string | null;
   }
 
   interface StorageFile extends BaseRecord {
@@ -152,15 +153,16 @@
   }
 
   const deleteBucketMutation = createMutation(() => ({
-    mutationFn: async (bucketId: string) => {
-      const response = await apiClient(`/v1/projects/${encodeURIComponent(projectRef)}/storage/buckets/${encodeURIComponent(bucketId)}`, {
+    mutationFn: async ({ bucketId, expectedRevision }: { bucketId: string; expectedRevision: string }) => {
+      const query = new URLSearchParams({ expected_revision: expectedRevision, require_empty: "true" });
+      const response = await apiClient(`/v1/projects/${encodeURIComponent(projectRef)}/storage/buckets/${encodeURIComponent(bucketId)}?${query}`, {
         method: "DELETE",
       });
       return readJsonResponse(response);
     },
-    onSuccess: (_payload, deletedBucketId) => {
-      if (selectedBucketId === deletedBucketId) {
-        const nextBucket = buckets.find((bucket) => String(bucket.id || bucket.name) !== deletedBucketId);
+    onSuccess: (_payload, deletedBucket) => {
+      if (selectedBucketId === deletedBucket.bucketId) {
+        const nextBucket = buckets.find((bucket) => String(bucket.id || bucket.name) !== deletedBucket.bucketId);
         selectedBucketId = nextBucket ? String(nextBucket.id || nextBucket.name) : null;
       }
       bucketsQuery.refetch();
@@ -174,7 +176,12 @@
   function deleteBucket(bucket: Bucket) {
     const bucketId = String(bucket.id || bucket.name);
     if (!confirm($t("Storage.delete_bucket_confirm", { values: { name: bucket.name } }))) return;
-    deleteBucketMutation.mutate(bucketId);
+    if (!bucket.revision) {
+      bucketsQuery.refetch();
+      toast.error($t("Storage.delete_bucket_failed"));
+      return;
+    }
+    deleteBucketMutation.mutate({ bucketId, expectedRevision: bucket.revision });
   }
 
   const deleteMutation = createMutation(() => ({


### PR DESCRIPTION
## Summary

- expose a stable bucket revision from Storage list and get responses
- require expected_revision for bucket updates and enforce row-locked compare-and-swap semantics
- require expected_revision plus require_empty=true for bucket deletion
- reject stale, object-bearing, and multipart-bearing deletes before physical mutation
- return strictly validated CLI receipts bound to project, bucket, and previous/new revisions
- pass the current revision from Web Console bucket deletion without changing navigation

## Safety contract

Bucket deletion holds the logical bucket row lock while checking storage.objects and storage.s3_multipart_uploads, invoking empty physical-directory deletion, and removing logical metadata. Conflicts fail before the physical callback. Indeterminate physical or transaction outcomes never return a success receipt.

## Verification

- Management Storage unit tests: 48 passed, 0 failed
- PostgreSQL 18 Storage CAS integration: 6 passed, 0 failed
- Management full unit suite: passed
- Management SQL synchronization: passed
- Management TypeScript: passed
- Swagger route coverage: 302/302, 100%
- CLI full suite on latest main: 398 passed, 0 failed
- CLI typecheck and build: passed
- Web Console: 163 passed, 0 failed; Svelte 0 errors/0 warnings; production build passed
- git diff --check: passed

clean-code-guard: clean