### PR TITLE
feat(functions): add active version concurrency control

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,19 @@ supacloud-cli database push_migrations --ref <ref> --dir supabase/migrations --d
 supacloud-cli auth list_providers --ref <ref>
 supacloud-cli frontend list --ref <ref>
 supacloud-cli edge_functions list --ref <ref>
+supacloud-cli edge_functions source --ref <ref> --slug hello --version 1 --output ./hello-v1.ts
+supacloud-cli edge_functions deploy --ref <ref> --slug hello --path ./supabase/functions/hello --expected-active-version absent
+supacloud-cli edge_functions activate --ref <ref> --slug hello --version 2 --expected-active-version 3
 supacloud-cli storage list_buckets --ref <ref>
 ```
+
+Function deploy and activation commands require the active version observed via
+`edge_functions list`; `absent` is valid only for a new slug. Stale mutations
+return HTTP 409 and successful mutations emit a
+`supacloud.cli.release-control.v1` receipt. Pass the observed version to
+`edge_functions source --version <N>` for an immutable, ABA-safe source backup.
+Version `0` is reserved for service-internal legacy recovery and is not a valid
+public CLI/API activation target or expected active version.
 
 For complex SQL, pgvector queries, and single-request transaction blocks, prefer `--file` instead of shell-escaped inline SQL.
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -261,10 +261,31 @@ Management API applies the Edge Runtime module policy to the final server-side
 artifact for CLI, Web Console, and direct API deployments alike. For
 `deploy_bundle`, pass the file map as JSON, for example
 `--files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}'`.
-Use `edge_functions source --slug <name> --output <file>` to read back large
+Use `edge_functions source --slug <name> --version <N> --output <file>` to read back large
 Function sources without depending on terminal capture limits. The CLI writes
 the complete original TS/JS source code and refuses to overwrite an existing
-destination.
+destination. Supplying the positive version observed from `list` binds the read
+to that immutable release and remains safe if the active pointer changes A→B→A.
+
+Function release mutations use optimistic concurrency control. Before
+`deploy`, `deploy_bundle`, or `activate`, run `edge_functions list` and pass the
+observed positive integer version as `--expected-active-version <N>`. Pass
+`--expected-active-version absent` only for the first deployment of a new slug.
+A stale value returns HTTP 409 before build, preheat, version creation, or
+manifest activation. Successful mutations return the
+`supacloud.cli.release-control.v1` receipt with `project_ref`, `slug`,
+`previous_active_version`, `active_version`, `version`, and `verify_jwt`.
+Transport failures, HTTP 408/5xx responses, and malformed 2xx receipts exit
+non-zero as `OUTCOME_UNKNOWN`; read back `edge_functions list` before retrying.
+Version `0` remains an internal compatibility marker for legacy recovery. The
+public CLI and Management API reject it as an activation target or expected
+active version; all public release automation uses positive versions.
+
+The readback contract stays simple for automation: `edge_functions list`
+prints a JSON array whose entries have a string `slug` and a positive safe
+integer numeric `version`; `edge_functions source` prints exactly
+`{ "code": "..." }`. Release automation uses `source --version <N>` rather than
+the moving active source endpoint.
 
 ### Deliberately excluded
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -155,10 +155,10 @@ supacloud-cli frontend list --ref abc123
 supacloud-cli branch create --name feature-orders --data_mode schema_only
 supacloud-cli branch promotion_plan --branch_ref preview123
 supacloud-cli branch promote --branch_ref preview123 --plan_checksum <sha256>
-supacloud-cli edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
-supacloud-cli edge_functions deploy_bundle --ref abc123 --slug hello --files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}'
-supacloud-cli edge_functions source --ref abc123 --slug hello --output ./hello.ts
-supacloud-cli edge_functions activate --ref abc123 --slug hello --version 3
+supacloud-cli edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello --expected-active-version absent
+supacloud-cli edge_functions deploy_bundle --ref abc123 --slug hello --files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}' --expected-active-version 7
+supacloud-cli edge_functions source --ref abc123 --slug hello --version 7 --output ./hello-v7.ts
+supacloud-cli edge_functions activate --ref abc123 --slug hello --version 3 --expected-active-version 8
 supacloud-cli scheduled_functions list --ref abc123
 supacloud-cli secrets upsert --ref abc123 --from-env API_KEY,WEBHOOK_SECRET
 supacloud-cli storage list_buckets --ref abc123
@@ -185,7 +185,18 @@ module policy consistently for CLI, Web Console, and direct API deployments.
 `deploy_bundle --files` accepts a JSON object in shell usage.
 Use `source --output <file>` for large Functions so terminal or automation output
 limits cannot truncate the original TS/JS source code. The destination must not
-already exist.
+already exist. Add the positive version observed from `list` as
+`source --version <N>` to read the immutable release instead of the moving active
+pointer; this remains correct across an active-version A→B→A transition.
+
+`deploy`, `deploy_bundle`, and `activate` require
+`--expected-active-version <N|absent>`. Read the current positive integer
+version from `edge_functions list`; use `absent` only when creating a slug that
+does not yet exist. A stale value returns HTTP 409 without building, preheating,
+or activating another version. List output remains a JSON array with string
+`slug` and numeric `version` fields, while source output is exactly
+`{ "code": "..." }`. Release automation must use `source --version <N>` for a
+version-bound backup.
 
 `edge_functions activate` restores an existing immutable Function version and
 returns a machine-readable receipt containing the activated version and JWT
@@ -196,6 +207,22 @@ Mutation receipts use schema `supacloud.cli.release-control.v1`. An
 `OUTCOME_UNKNOWN` error means the server may have committed the mutation before
 the response was lost or failed validation; read back current state before any
 retry.
+Version `0` is reserved for service-internal legacy recovery and cannot be used
+as a public CLI/API activation target or expected active version.
+
+```json
+{
+  "schema": "supacloud.cli.release-control.v1",
+  "ok": true,
+  "operation": "edge_functions.deploy_bundle",
+  "project_ref": "abc123",
+  "slug": "hello",
+  "previous_active_version": "7",
+  "active_version": "8",
+  "version": "8",
+  "verify_jwt": true
+}
+```
 
 Scheduled Function lifecycle operations are also project-scoped:
 

--- a/packages/cli/skills/supacloud-cli/references/command-map.md
+++ b/packages/cli/skills/supacloud-cli/references/command-map.md
@@ -31,7 +31,7 @@ until a project-scoped context is resolved.
 - `supabase`: allowlisted official CLI adapter for migration authoring, local reset/diff, explicit-DSN inspection/backup/type generation, and SupaCloud-controlled migration push.
 - `auth`: provider and authentication configuration.
 - `storage`: buckets and object-management workflows.
-- `edge_functions`: deploy and configure Edge Functions.
+- `edge_functions`: list, read immutable source, deploy, activate, and configure Edge Functions. Pass the positive version read from `list` to `source --version` and as `--expected-active-version`; use `absent` only for a new slug. Version `0` is internal-only.
 - `frontend`: list, build/deploy, domain, and deployment workflows.
 - `secrets`: project secret management; never print values after write.
 - `queue`, `task_events`, `diagnostics`: asynchronous workload operations and bounded diagnostics.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -357,6 +357,101 @@ describe("supacloud-cli process contract", () => {
         expect(readFileSync(outputPath, "utf8")).toBe("preserve-existing-source\n");
     });
 
+    test("reads an immutable Function version to stdout or an exclusive output file", async () => {
+        const requestedPaths: string[] = [];
+        const immutableSource = "export const release = 40;\n";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requestedPaths.push(new URL(request.url).pathname);
+                return Response.json({ source_code: immutableSource, private: "immutable-source-sentinel" });
+            },
+        });
+        servers.push(server);
+        const environment = {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        };
+        const outputDirectory = mkdtempSync(join(tmpdir(), "supacloud-cli-version-source-"));
+        temporaryDirectories.push(outputDirectory);
+        const outputPath = join(outputDirectory, "fa-api-v40.ts");
+
+        const stdoutResponse = await runProjectCli([
+            "edge_functions", "source", "--ref", "abc123", "--slug", "fa-api", "--version", "40",
+        ], environment);
+        const fileResponse = await runProjectCli([
+            "edge_functions", "source", "--ref", "abc123", "--slug", "fa-api", "--version", "40",
+            "--output", outputPath,
+        ], environment);
+        const overwriteResponse = await runProjectCli([
+            "edge_functions", "source", "--ref", "abc123", "--slug", "fa-api", "--version", "40",
+            "--output", outputPath,
+        ], environment);
+
+        expect(stdoutResponse.exitCode).toBe(0);
+        expect(JSON.parse(stdoutResponse.stdout)).toEqual({ code: immutableSource });
+        expect(stdoutResponse.stdout).not.toContain("sentinel");
+        expect(fileResponse.exitCode).toBe(0);
+        expect(readFileSync(outputPath, "utf8")).toBe(immutableSource);
+        expect(overwriteResponse.exitCode).toBe(1);
+        expect(overwriteResponse.stderr).toContain("EEXIST");
+        expect(readFileSync(outputPath, "utf8")).toBe(immutableSource);
+        expect(requestedPaths).toEqual(Array(3).fill("/v1/projects/abc123/functions/fa-api/versions/40"));
+    });
+
+    test("prints a Function list with numeric active versions for release readback", async () => {
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json([{ slug: "fa-api", version: 40, verify_jwt: true }]),
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(["edge_functions", "list", "--ref", "abc123"], {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+        const functions = JSON.parse(response.stdout);
+
+        expect(response.exitCode).toBe(0);
+        expect(Array.isArray(functions)).toBe(true);
+        expect(functions[0]).toMatchObject({ slug: "fa-api", version: 40 });
+        expect(typeof functions[0].version).toBe("number");
+    });
+
+    test("rejects malformed Function readbacks without reflecting server fields", async () => {
+        const responseSentinel = "private-function-readback-sentinel";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                const path = new URL(request.url).pathname;
+                return path.endsWith("/source")
+                    ? Response.json({ code: 7, private: responseSentinel })
+                    : Response.json([{ slug: "fa-api", version: "40", private: responseSentinel }]);
+            },
+        });
+        servers.push(server);
+        const environment = {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        };
+
+        const listResponse = await runProjectCli(["edge_functions", "list", "--ref", "abc123"], environment);
+        const sourceResponse = await runProjectCli([
+            "edge_functions", "source", "--ref", "abc123", "--slug", "fa-api",
+        ], environment);
+
+        for (const response of [listResponse, sourceResponse]) {
+            expect(response.exitCode).toBe(1);
+            expect(response.stdout + response.stderr).not.toContain(responseSentinel);
+        }
+    });
+
     test("treats failure text as an error even when isError is false", () => {
         expect(cliToolResultIsError({
             isError: false,
@@ -720,20 +815,121 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).not.toContain("--from_env");
     });
 
-    test("activates a Function version through a secret-safe process contract", async () => {
-        const apiToken = "activation-api-token-sentinel";
-        const requested: Array<{ method: string; path: string; authorization: string | null }> = [];
+    test("documents the exact expected-active-version flag for Function mutations", async () => {
+        for (const action of ["deploy", "deploy_bundle", "activate"]) {
+            const response = await runProjectCli(["edge_functions", action, "--help"], {
+                SUPACLOUD_API_URL: "http://127.0.0.1:1",
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            });
+
+            expect(response.exitCode).toBe(0);
+            expect(response.stderr).toContain("--expected-active-version");
+            expect(response.stderr).not.toContain("--expected_active_version");
+        }
+    });
+
+    test("deploys a Function bundle with an identity-bound CAS receipt", async () => {
+        let requestBody: Record<string, unknown> | null = null;
         const server = Bun.serve({
             hostname: "127.0.0.1",
             port: 0,
-            fetch(request) {
+            async fetch(request) {
+                requestBody = await request.json() as Record<string, unknown>;
+                return Response.json({
+                    success: true,
+                    project_ref: "abc123",
+                    slug: "worker",
+                    previous_active_version: "7",
+                    active_version: "8",
+                    version: "8",
+                    config: { version: "8", verify_jwt: true },
+                });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli([
+            "edge_functions", "deploy_bundle", "--ref", "abc123", "--slug", "worker",
+            "--files", JSON.stringify({ "index.ts": "export default {}" }),
+            "--expected-active-version", "7",
+        ], {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toMatchObject({
+            ok: true,
+            operation: "edge_functions.deploy_bundle",
+            project_ref: "abc123",
+            slug: "worker",
+            previous_active_version: "7",
+            active_version: "8",
+        });
+        expect(requestBody).toMatchObject({ expected_active_version: "7" });
+    });
+
+    test("rejects Function mutations without expected-active-version before HTTP", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+        const commands = [
+            [
+                "edge_functions", "deploy", "--ref", "abc123", "--slug", "worker",
+                "--path", "/definitely/missing.ts",
+            ],
+            [
+                "edge_functions", "activate", "--ref", "abc123", "--slug", "worker",
+                "--version", "2",
+            ],
+        ];
+
+        for (const command of commands) {
+            const response = await runProjectCli(command, {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            });
+            expect(response.exitCode).toBe(1);
+            expect(response.stderr).toContain("--expected-active-version");
+            expect(response.stderr).not.toContain("ENOENT");
+        }
+        expect(requestCount).toBe(0);
+    });
+
+    test("activates a Function version through a secret-safe process contract", async () => {
+        const apiToken = "activation-api-token-sentinel";
+        const requested: Array<{
+            method: string;
+            path: string;
+            authorization: string | null;
+            body: unknown;
+        }> = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
                 requested.push({
                     method: request.method,
                     path: new URL(request.url).pathname,
                     authorization: request.headers.get("authorization"),
+                    body: await request.json(),
                 });
                 return Response.json({
                     success: true,
+                    project_ref: "abc123",
+                    slug: "public-hook",
+                    previous_active_version: "5",
+                    active_version: "6",
                     version: "6",
                     config: { version: "6", verify_jwt: false },
                 });
@@ -743,6 +939,7 @@ describe("supacloud-cli process contract", () => {
         const commandArguments = [
             "edge_functions", "activate", "--ref", "abc123",
             "--slug", "public-hook", "--version", "6",
+            "--expected-active-version", "5",
         ];
 
         const response = await runProjectCli(commandArguments, {
@@ -756,7 +953,10 @@ describe("supacloud-cli process contract", () => {
         expect(receipt).toMatchObject({
             ok: true,
             operation: "edge_functions.activate",
+            project_ref: "abc123",
             slug: "public-hook",
+            previous_active_version: "5",
+            active_version: "6",
             version: "6",
             verify_jwt: false,
         });
@@ -764,9 +964,39 @@ describe("supacloud-cli process contract", () => {
             method: "POST",
             path: "/v1/projects/abc123/functions/public-hook/versions/6/activate",
             authorization: `Bearer ${apiToken}`,
+            body: { expected_active_version: "5" },
         }]);
         expect(commandArguments.join("\0")).not.toContain(apiToken);
         expect(response.stdout + response.stderr).not.toContain(apiToken);
+    });
+
+    test("rejects public Function version zero before any HTTP request", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli(
+            [
+                "edge_functions", "activate", "--ref", "abc123", "--slug", "legacy-hook",
+                "--version", "0", "--expected-active-version", "2",
+            ],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(response.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(response.stderr).toContain("Invalid arguments");
     });
 
     test("returns structured non-zero Function activation failures without server text", async () => {
@@ -783,7 +1013,10 @@ describe("supacloud-cli process contract", () => {
         servers.push(server);
 
         const response = await runProjectCli(
-            ["edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2"],
+            [
+                "edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2",
+                "--expected-active-version", "1",
+            ],
             {
                 SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
                 SUPACLOUD_API_TOKEN: "test-token",
@@ -811,7 +1044,10 @@ describe("supacloud-cli process contract", () => {
         servers.push(server);
 
         const response = await runProjectCli(
-            ["edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2"],
+            [
+                "edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2",
+                "--expected-active-version", "1",
+            ],
             {
                 SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
                 SUPACLOUD_API_TOKEN: "test-token",
@@ -839,6 +1075,7 @@ describe("supacloud-cli process contract", () => {
         const response = await runProjectCli(
             [
                 "edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2",
+                "--expected-active-version", "1",
                 "--verify_jwt", "false",
             ],
             {
@@ -868,6 +1105,7 @@ describe("supacloud-cli process contract", () => {
         const response = await runProjectCli(
             [
                 "edge_functions", "activate", "--ref", "abc123", "--slug", "hook", "--version", "2",
+                "--expected-active-version", "1",
                 "--path", "/definitely/not/exist/private-source.ts",
             ],
             {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -221,8 +221,8 @@ EXAMPLES
   ${preferredCommand} branch promote --branch_ref preview123 --plan_checksum <sha256>
   ${preferredCommand} ai show_skill
   ${preferredCommand} ai install_skill --dry_run
-  ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello
-  ${preferredCommand} edge_functions activate --ref abc123 --slug hello --version 3
+  ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello --expected-active-version absent
+  ${preferredCommand} edge_functions activate --ref abc123 --slug hello --version 3 --expected-active-version 4
   ${preferredCommand} scheduled_functions list --ref abc123
   ${preferredCommand} edge_functions config --ref abc123 --slug hello --verify_jwt false --background_routes "/queue/*,/render/*"
   ${preferredCommand} secrets upsert --ref abc123 --from-env API_KEY,WEBHOOK_SECRET

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -144,6 +144,238 @@ describe("edge_functions CLI tool", () => {
         expect(result.content[0].text).toContain("Function render config updated");
     });
 
+    test("keeps the Function list as a JSON array with numeric active versions", async () => {
+        const functions = [{
+            slug: "fa-api",
+            version: 7,
+            verify_jwt: true,
+            status: "ACTIVE",
+        }];
+        const { callback } = captureEdgeFunctionsTool({
+            get: async () => ({ ok: true, status: 200, data: functions }),
+        });
+
+        const response = await callback({ action: "list", ref: "proj" });
+        const payload = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBeUndefined();
+        expect(payload).toEqual(functions);
+        expect(typeof payload[0].version).toBe("number");
+    });
+
+    test.each([
+        ["an object", { slug: "fa-api", version: 7 }],
+        ["a non-object entry", ["list-response-sentinel"]],
+        ["a missing slug", [{ version: 7, private: "list-response-sentinel" }]],
+        ["an invalid slug", [{ slug: "../fa-api", version: 7, private: "list-response-sentinel" }]],
+        ["a string version", [{ slug: "fa-api", version: "7", private: "list-response-sentinel" }]],
+        ["version zero", [{ slug: "fa-api", version: 0, private: "list-response-sentinel" }]],
+        ["a fractional version", [{ slug: "fa-api", version: 1.5, private: "list-response-sentinel" }]],
+        ["an unsafe version", [{ slug: "fa-api", version: Number.MAX_SAFE_INTEGER + 1, private: "list-response-sentinel" }]],
+        ["duplicate slugs", [{ slug: "fa-api", version: 7 }, { slug: "fa-api", version: 8 }]],
+    ])("rejects a Function list containing %s without reflecting it", async (_label, payload) => {
+        const { callback } = captureEdgeFunctionsTool({
+            get: async () => ({ ok: true, status: 200, data: payload }),
+        });
+
+        const response = await callback({ action: "list", ref: "proj" });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toBe("❌ Edge Function list response is invalid");
+        expect(response.content[0].text).not.toContain("sentinel");
+    });
+
+    test("projects an exact Function source object", async () => {
+        const { callback } = captureEdgeFunctionsTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { code: "export default {};", private: "source-response-sentinel" },
+            }),
+        });
+
+        const response = await callback({ action: "source", ref: "proj", slug: "fa-api" });
+
+        expect(response.isError).toBeUndefined();
+        expect(JSON.parse(response.content[0].text)).toEqual({ code: "export default {};" });
+        expect(response.content[0].text).not.toContain("sentinel");
+    });
+
+    test("binds source readback to an immutable version across an active-version ABA", async () => {
+        const requestedPaths: string[] = [];
+        const activeTransitions = [7];
+        let activeVersion = 7;
+        const { callback } = captureEdgeFunctionsTool({
+            get: async (path: string) => {
+                requestedPaths.push(path);
+                if (path.endsWith("/versions/7")) {
+                    activeVersion = 8;
+                    activeTransitions.push(activeVersion);
+                    activeVersion = 7;
+                    activeTransitions.push(activeVersion);
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: { source_code: "export const immutable = 7;", private: "source-response-sentinel" },
+                    };
+                }
+                return {
+                    ok: true,
+                    status: 200,
+                    data: [{ slug: "fa-api", version: activeVersion, verify_jwt: true }],
+                };
+            },
+        });
+
+        const before = await callback({ action: "list", ref: "proj" });
+        const source = await callback({ action: "source", ref: "proj", slug: "fa-api", version: "7" });
+        const after = await callback({ action: "list", ref: "proj" });
+
+        expect(JSON.parse(before.content[0].text)[0].version).toBe(7);
+        expect(JSON.parse(source.content[0].text)).toEqual({ code: "export const immutable = 7;" });
+        expect(JSON.parse(after.content[0].text)[0].version).toBe(7);
+        expect(activeTransitions).toEqual([7, 8, 7]);
+        expect(requestedPaths).toEqual([
+            "/v1/projects/proj/functions",
+            "/v1/projects/proj/functions/fa-api/versions/7",
+            "/v1/projects/proj/functions",
+        ]);
+        expect(source.content[0].text).not.toContain("sentinel");
+    });
+
+    test.each([-1, 0, "0", "01", 1.5, "9007199254740992", true, {}])(
+        "rejects invalid immutable source version %j before HTTP dispatch",
+        async (version) => {
+            let requestCount = 0;
+            const { callback } = captureEdgeFunctionsTool({
+                get: async () => {
+                    requestCount += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            await expect(callback({
+                action: "source",
+                ref: "proj",
+                slug: "fa-api",
+                version,
+            })).rejects.toThrow("canonical positive safe integer");
+            expect(requestCount).toBe(0);
+        },
+    );
+
+    test("rejects a malformed immutable source response without reflecting it", async () => {
+        const { callback } = captureEdgeFunctionsTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { code: "wrong-active-source", private: "version-source-response-sentinel" },
+            }),
+        });
+
+        const response = await callback({ action: "source", ref: "proj", slug: "fa-api", version: "7" });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toBe("❌ Edge Function source response is invalid");
+        expect(response.content[0].text).not.toContain("sentinel");
+    });
+
+    test.each([
+        ["free text", "source-response-sentinel"],
+        ["an array", [{ code: "source-response-sentinel" }]],
+        ["a missing code field", { private: "source-response-sentinel" }],
+        ["a non-string code field", { code: 7, private: "source-response-sentinel" }],
+    ])("rejects a Function source response containing %s without reflecting it", async (_label, payload) => {
+        const { callback } = captureEdgeFunctionsTool({
+            get: async () => ({ ok: true, status: 200, data: payload }),
+        });
+
+        const response = await callback({ action: "source", ref: "proj", slug: "fa-api" });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toBe("❌ Edge Function source response is invalid");
+        expect(response.content[0].text).not.toContain("sentinel");
+    });
+
+    test.each([
+        ["list", { action: "list", ref: "../proj" }],
+        ["deploy_bundle", {
+            action: "deploy_bundle",
+            ref: "proj",
+            slug: "../hook",
+            files: { "index.ts": "export default {}" },
+            "expected-active-version": "absent",
+        }],
+        ["source", { action: "source", ref: "proj", slug: "../hook" }],
+    ])("rejects %s path segments before HTTP dispatch", async (_action, args) => {
+        let requestCount = 0;
+        const request = async () => {
+            requestCount += 1;
+            return { ok: true, status: 200, data: {} };
+        };
+        const { callback } = captureEdgeFunctionsTool({ get: request, post: request });
+
+        await expect(callback(args)).rejects.toThrow("invalid");
+        expect(requestCount).toBe(0);
+    });
+
+    test.each(["deploy", "deploy_bundle", "activate"])(
+        "rejects %s without expected-active-version before HTTP dispatch",
+        async (action) => {
+            let requestCount = 0;
+            const { callback } = captureEdgeFunctionsTool({
+                post: async () => {
+                    requestCount += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+            const actionInput = action === "deploy"
+                ? { action, ref: "proj", slug: "hook", path: "/definitely/missing.ts" }
+                : action === "deploy_bundle"
+                    ? { action, ref: "proj", slug: "hook", files: { "index.ts": "export default {}" } }
+                    : { action, ref: "proj", slug: "hook", version: "2" };
+
+            await expect(callback(actionInput)).rejects.toThrow("--expected-active-version");
+            expect(requestCount).toBe(0);
+        },
+    );
+
+    test.each([0, "0", "01", "9007199254740992"])(
+        "rejects invalid expected active version %j during argument parsing",
+        (expectedActiveVersion) => {
+            const { schema } = captureEdgeFunctionsTool({});
+            expect(() => parseToolArguments(schema, {
+                action: "activate",
+                ref: "proj",
+                slug: "hook",
+                version: "2",
+                "expected-active-version": expectedActiveVersion,
+            })).toThrow("Invalid arguments");
+        },
+    );
+
+    test.each([0, "0", "01", "9007199254740992", true, {}])(
+        "rejects direct invalid expected active version %j before HTTP dispatch",
+        async (expectedActiveVersion) => {
+            let requestCount = 0;
+            const { callback } = captureEdgeFunctionsTool({
+                post: async () => {
+                    requestCount += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            await expect(callback({
+                action: "deploy_bundle",
+                ref: "proj",
+                slug: "hook",
+                files: { "index.ts": "export default {}" },
+                "expected-active-version": expectedActiveVersion,
+            })).rejects.toThrow("canonical positive safe integer");
+            expect(requestCount).toBe(0);
+        },
+    );
+
     test("sends bundle config inline without a follow-up PATCH", async () => {
         const calls: Array<{ method: string; path: string; body: unknown }> = [];
         const { callback } = captureEdgeFunctionsTool({
@@ -152,7 +384,15 @@ describe("edge_functions CLI tool", () => {
                 return {
                     ok: true,
                     status: 200,
-                    data: { success: true, verify_jwt: true, background_routes: ["/work/*"] },
+                    data: {
+                        success: true,
+                        project_ref: "proj",
+                        slug: "worker",
+                        previous_active_version: "absent",
+                        active_version: "1",
+                        version: "1",
+                        config: { version: "1", verify_jwt: true, background_routes: ["/work/*"] },
+                    },
                 };
             },
         });
@@ -164,6 +404,7 @@ describe("edge_functions CLI tool", () => {
             files: { "index.ts": "export default {}" },
             verify_jwt: true,
             background_routes: ["/work/*"],
+            "expected-active-version": "absent",
         });
 
         expect(calls).toEqual([
@@ -174,12 +415,20 @@ describe("edge_functions CLI tool", () => {
                     files: { "index.ts": "export default {}" },
                     entrypoint: undefined,
                     minify: undefined,
+                    expected_active_version: "absent",
                     verify_jwt: true,
                     background_routes: ["/work/*"],
                 },
             },
         ]);
-        expect(result.content[0].text).toContain("Function worker bundle deployed");
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+            ok: true,
+            operation: "edge_functions.deploy_bundle",
+            project_ref: "proj",
+            slug: "worker",
+            previous_active_version: "absent",
+            active_version: "1",
+        });
     });
 
     test("sends single-file config inline without a follow-up PATCH", async () => {
@@ -187,7 +436,19 @@ describe("edge_functions CLI tool", () => {
         const { callback } = captureEdgeFunctionsTool({
             post: async (path: string, body: unknown) => {
                 calls.push({ method: "post", path, body });
-                return { ok: true, status: 200, data: { success: true, verify_jwt: false } };
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        success: true,
+                        project_ref: "proj",
+                        slug: "public-hook",
+                        previous_active_version: "3",
+                        active_version: "4",
+                        version: "4",
+                        config: { version: "4", verify_jwt: false },
+                    },
+                };
             },
         });
 
@@ -197,6 +458,7 @@ describe("edge_functions CLI tool", () => {
             slug: "public-hook",
             code: "export default { fetch: () => new Response('ok') }",
             verify_jwt: false,
+            "expected-active-version": "3",
         });
 
         expect(calls).toEqual([{
@@ -205,10 +467,18 @@ describe("edge_functions CLI tool", () => {
             body: {
                 code: "export default { fetch: () => new Response('ok') }",
                 minify: undefined,
+                expected_active_version: "3",
                 verify_jwt: false,
             },
         }]);
-        expect(result.content[0].text).toContain("Function public-hook deployed");
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+            ok: true,
+            operation: "edge_functions.deploy",
+            project_ref: "proj",
+            slug: "public-hook",
+            previous_active_version: "3",
+            active_version: "4",
+        });
     });
 
     test("rejects an unconfirmed bundle policy without a follow-up PATCH", async () => {
@@ -230,15 +500,17 @@ describe("edge_functions CLI tool", () => {
             slug: "legacy-hook",
             files: { "index.ts": "export default {}" },
             verify_jwt: false,
+            "expected-active-version": "1",
         });
 
         expect(calls.map(({ method, path }) => ({ method, path }))).toEqual([
             { method: "post", path: "/v1/projects/proj/functions/legacy-hook/bundle" },
         ]);
-        expect(response.content[0].text).toStartWith("❌ Unsafe deployment receipt");
-        expect(response.content[0].text).toContain("did not confirm the requested function policy");
-        expect(response.content[0].text).toContain("No follow-up PATCH was attempted");
-        expect(response.content[0].text).toContain("code and policy must be activated atomically");
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "OUTCOME_UNKNOWN",
+            http_status: 200,
+        });
     });
 
     test("rejects a mismatched single-file policy without a follow-up PATCH", async () => {
@@ -260,52 +532,72 @@ describe("edge_functions CLI tool", () => {
             slug: "public-hook-mismatch",
             code: "export default { fetch: () => new Response('ok') }",
             verify_jwt: false,
+            "expected-active-version": "1",
         });
 
         expect(calls).toEqual([
             { method: "post", path: "/v1/projects/proj/functions/public-hook-mismatch" },
         ]);
-        expect(response.content[0].text).toStartWith("❌ Unsafe deployment receipt");
-        expect(response.content[0].text).toContain("No follow-up PATCH was attempted");
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "OUTCOME_UNKNOWN",
+            http_status: 200,
+        });
     });
 
-    test("activates the immutable legacy Function version zero with a structured receipt", async () => {
-        const calls: string[] = [];
-        const { schema, callback } = captureEdgeFunctionsTool({
-            post: async (path: string) => {
-                calls.push(path);
-                return {
-                    ok: true,
-                    status: 200,
-                    data: {
-                        success: true,
-                        version: "0",
-                        config: { version: "0", verify_jwt: false },
-                    },
-                };
+    test("rejects version zero in a deploy receipt", async () => {
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    success: true,
+                    project_ref: "proj",
+                    slug: "public-hook",
+                    previous_active_version: "absent",
+                    active_version: "0",
+                    version: "0",
+                    config: { version: "0", verify_jwt: true },
+                },
+            }),
+        });
+
+        const response = await callback({
+            action: "deploy_bundle",
+            ref: "proj",
+            slug: "public-hook",
+            files: { "index.ts": "export default {}" },
+            "expected-active-version": "absent",
+        });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({
+            code: "OUTCOME_UNKNOWN",
+            http_status: 200,
+        });
+    });
+
+    test("rejects legacy Function version zero before activation dispatch", async () => {
+        let requestCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
             },
         });
 
-        const args = parseToolArguments(schema, {
+        await expect(callback({
             action: "activate",
             ref: "proj",
             slug: "public-hook",
             version: 0,
-        });
-        const response = await callback(args);
-
-        expect(calls).toEqual(["/v1/projects/proj/functions/public-hook/versions/0/activate"]);
-        expect(JSON.parse(response.content[0].text)).toEqual({
-            schema: "supacloud.cli.release-control.v1",
-            ok: true,
-            operation: "edge_functions.activate",
-            slug: "public-hook",
-            version: "0",
-            verify_jwt: false,
-        });
+            "expected-active-version": 2,
+        })).rejects.toThrow("canonical positive safe integer");
+        expect(requestCount).toBe(0);
     });
 
     test.each([
+        ["zero", 0],
         ["a negative", -1],
         ["a fractional", 1.5],
         ["an unsafe integer", "9007199254740992"],
@@ -343,7 +635,13 @@ describe("edge_functions CLI tool", () => {
     ) => {
         const { callback } = captureEdgeFunctionsTool({ post: async () => activation });
 
-        const response = await callback({ action: "activate", ref: "proj", slug: "hook", version: "5" });
+        const response = await callback({
+            action: "activate",
+            ref: "proj",
+            slug: "hook",
+            version: "5",
+            "expected-active-version": "4",
+        });
         const payload = JSON.parse(response.content[0].text);
 
         expect(response.isError).toBe(true);
@@ -366,6 +664,7 @@ describe("edge_functions CLI tool", () => {
             slug: "hook",
             version: "5",
             verify_jwt: false,
+            "expected-active-version": "4",
         })).rejects.toThrow("not supported for 'activate'");
         expect(requestCount).toBe(0);
     });

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
+import { projectRefPathSegment } from "../project-ref";
 import type { HttpResult, HttpTransport } from "../transports/http";
 import {
     releaseControlFailure,
@@ -97,26 +98,48 @@ const functionFilesSchema = decodedSchema(
     parseFunctionFiles,
 );
 
-function parseFunctionVersion(input: string | number): unknown {
+function positiveFunctionVersion(input: unknown, label: string): string {
+    if (typeof input !== "string" && typeof input !== "number") {
+        throw new Error(`${label} must be a canonical positive safe integer`);
+    }
     const version = String(input);
-    if (!CANONICAL_FUNCTION_VERSION_PATTERN.test(version)
+    if (!POSITIVE_FUNCTION_VERSION_PATTERN.test(version)
         || !Number.isSafeInteger(Number(version))) {
-        throw new Error("Function version must be a canonical safe integer");
+        throw new Error(`${label} must be a canonical positive safe integer`);
     }
     return version;
 }
 
-const CANONICAL_FUNCTION_VERSION_PATTERN = /^(?:0|[1-9][0-9]*)$/;
-const SAFE_FUNCTION_REF_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+const POSITIVE_FUNCTION_VERSION_PATTERN = /^[1-9][0-9]*$/;
 const SAFE_FUNCTION_SLUG_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
-const FUNCTION_ACTIVATION_ARGUMENTS = new Set(["action", "ref", "slug", "version"]);
+const FUNCTION_ACTIVATION_ARGUMENTS = new Set([
+    "action", "ref", "slug", "version", "expected-active-version",
+]);
 const functionVersionSchema = Type.Optional(decodedSchema(
     Type.Union([
-        Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
-        Type.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+        Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+        Type.String({ pattern: POSITIVE_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
     ]),
-    Type.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
-    parseFunctionVersion,
+    Type.String({ pattern: POSITIVE_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+    (input) => positiveFunctionVersion(input, "Function version"),
+));
+
+function parseExpectedActiveVersion(input: unknown): unknown {
+    if (input === "absent") return input;
+    return positiveFunctionVersion(input, "Expected active version");
+}
+
+const expectedActiveVersionSchema = Type.Optional(decodedSchema(
+    Type.Union([
+        Type.Literal("absent"),
+        Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+        Type.String({ pattern: POSITIVE_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+    ]),
+    Type.Union([
+        Type.Literal("absent"),
+        Type.String({ pattern: POSITIVE_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+    ]),
+    parseExpectedActiveVersion,
 ));
 
 const secretListSchema = Type.Array(Type.Object({ name: Type.String(), value: Type.String() }));
@@ -257,9 +280,39 @@ type EdgeFunctionConfigInput = {
     background_routes?: string[];
 };
 
+const INVALID_FUNCTION_LIST_RESPONSE = "❌ Edge Function list response is invalid";
+const INVALID_FUNCTION_SOURCE_RESPONSE = "❌ Edge Function source response is invalid";
+
+function invalidFunctionReadResponse(message: string): ReleaseControlToolResponse {
+    return { isError: true, content: [{ type: "text", text: message }] };
+}
+
+function safeFunctionList(payload: unknown): Array<Record<string, unknown>> | null {
+    if (!Array.isArray(payload)) return null;
+    const functionSlugs = new Set<string>();
+    for (const candidate of payload) {
+        const edgeFunction = objectRecord(candidate);
+        const slug = edgeFunction?.slug;
+        const version = edgeFunction?.version;
+        if (typeof slug !== "string" || !SAFE_FUNCTION_SLUG_PATTERN.test(slug)
+            || typeof version !== "number" || !Number.isSafeInteger(version) || version < 1
+            || functionSlugs.has(slug)) return null;
+        functionSlugs.add(slug);
+    }
+    return payload as Array<Record<string, unknown>>;
+}
+
+function functionListResponse(response: HttpResult<unknown>): ReleaseControlToolResponse {
+    if (!response.ok) return invalidFunctionReadResponse(`❌ Failed (${response.status})`);
+    const functions = safeFunctionList(response.data);
+    return functions
+        ? { content: [{ type: "text", text: JSON.stringify(functions, null, 2) }] }
+        : invalidFunctionReadResponse(INVALID_FUNCTION_LIST_RESPONSE);
+}
+
 function confirmedFunctionConfig(payload: unknown, expected: EdgeFunctionConfigInput): boolean {
-    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
-    const response = payload as Record<string, unknown>;
+    const response = objectRecord(payload);
+    if (!response) return false;
     if (expected.verify_jwt !== undefined && response.verify_jwt !== expected.verify_jwt) return false;
     if (expected.background_routes !== undefined) {
         if (!Array.isArray(response.background_routes)) return false;
@@ -268,10 +321,34 @@ function confirmedFunctionConfig(payload: unknown, expected: EdgeFunctionConfigI
     return true;
 }
 
-function functionSourceCode(payload: unknown): string | null {
+function functionSourceCode(payload: unknown, field: "code" | "source_code" = "code"): string | null {
     if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
-    const code = (payload as Record<string, unknown>).code;
+    const code = (payload as Record<string, unknown>)[field];
     return typeof code === "string" ? code : null;
+}
+
+function requestedSourceVersion(candidate: unknown): string | undefined {
+    return candidate === undefined
+        ? undefined
+        : positiveFunctionVersion(candidate, "Function source version");
+}
+
+function functionSourceOutput(
+    slug: string,
+    sourceCode: string,
+    output?: string,
+): ReleaseControlToolResponse {
+    if (!output) {
+        return { content: [{ type: "text", text: JSON.stringify({ code: sourceCode }, null, 2) }] };
+    }
+    const outputPath = resolve(output);
+    writeFileSync(outputPath, sourceCode, { flag: "wx" });
+    return {
+        content: [{
+            type: "text",
+            text: `✅ Function ${slug} source written to ${outputPath} (${Buffer.byteLength(sourceCode)} bytes)`,
+        }],
+    };
 }
 
 function objectRecord(candidate: unknown): Record<string, unknown> | null {
@@ -280,23 +357,110 @@ function objectRecord(candidate: unknown): Record<string, unknown> | null {
         : null;
 }
 
-function activationResponse(
-    slug: string,
-    version: string,
+function edgeFunctionResourcePath(ref: unknown, slug?: unknown): string {
+    const root = `/v1/projects/${projectRefPathSegment(ref, "Edge Functions")}/functions`;
+    if (slug === undefined) return root;
+    if (typeof slug !== "string" || !SAFE_FUNCTION_SLUG_PATTERN.test(slug)) {
+        throw new Error("'slug' is invalid for Edge Functions");
+    }
+    return `${root}/${encodeURIComponent(slug)}`;
+}
+
+async function readFunctionSource(
+    http: HttpTransport,
+    request: { projectRef: unknown; slug: string; version?: unknown; output?: string },
+): Promise<ReleaseControlToolResponse> {
+    const sourceVersion = requestedSourceVersion(request.version);
+    const resourcePath = edgeFunctionResourcePath(request.projectRef, request.slug);
+    const sourcePath = sourceVersion === undefined
+        ? `${resourcePath}/source`
+        : `${resourcePath}/versions/${encodeURIComponent(sourceVersion)}`;
+    const response = await http.get(sourcePath);
+    if (!response.ok) return invalidFunctionReadResponse(`❌ Failed (${response.status})`);
+    const sourceCode = functionSourceCode(
+        response.data,
+        sourceVersion === undefined ? "code" : "source_code",
+    );
+    return sourceCode === null
+        ? invalidFunctionReadResponse(INVALID_FUNCTION_SOURCE_RESPONSE)
+        : functionSourceOutput(request.slug, sourceCode, request.output);
+}
+
+interface FunctionMutationExpectation {
+    operation: "edge_functions.deploy" | "edge_functions.deploy_bundle" | "edge_functions.activate";
+    projectRef: string;
+    slug: string;
+    expectedActiveVersion: string;
+    targetVersion?: string;
+    config?: EdgeFunctionConfigInput;
+}
+
+interface ConfirmedFunctionMutation {
+    activeVersion: string;
+    verifyJwt: boolean;
+}
+
+function mutationIdentityMatches(
+    receipt: Record<string, unknown>,
+    expectation: FunctionMutationExpectation,
+): boolean {
+    return receipt.success === true
+        && receipt.project_ref === expectation.projectRef
+        && receipt.slug === expectation.slug
+        && receipt.previous_active_version === expectation.expectedActiveVersion;
+}
+
+function validReceiptVersion(activeVersion: unknown): activeVersion is string {
+    return typeof activeVersion === "string"
+        && POSITIVE_FUNCTION_VERSION_PATTERN.test(activeVersion)
+        && Number.isSafeInteger(Number(activeVersion));
+}
+
+function confirmedMutationVersion(
+    receipt: Record<string, unknown>,
+    config: Record<string, unknown>,
+    expectation: FunctionMutationExpectation,
+): string | null {
+    const activeVersion = receipt.active_version;
+    if (!validReceiptVersion(activeVersion)
+        || receipt.version !== activeVersion
+        || config.version !== activeVersion
+        || (expectation.targetVersion !== undefined && activeVersion !== expectation.targetVersion)) {
+        return null;
+    }
+    return activeVersion;
+}
+
+function confirmedFunctionMutation(
+    expectation: FunctionMutationExpectation,
+    payload: unknown,
+): ConfirmedFunctionMutation | null {
+    const receipt = objectRecord(payload);
+    const config = objectRecord(receipt?.config);
+    if (!receipt || !config || !mutationIdentityMatches(receipt, expectation)) return null;
+    const activeVersion = confirmedMutationVersion(receipt, config, expectation);
+    if (activeVersion === null
+        || typeof config.verify_jwt !== "boolean"
+        || !confirmedFunctionConfig(config, expectation.config ?? {})) return null;
+    return { activeVersion, verifyJwt: config.verify_jwt };
+}
+
+function functionMutationResponse(
+    expectation: FunctionMutationExpectation,
     response: HttpResult<unknown>,
 ): ReleaseControlToolResponse {
-    const operation = "edge_functions.activate";
-    if (!response.ok) return releaseControlMutationFailure(operation, response);
-    const receipt = objectRecord(response.data);
-    const config = objectRecord(receipt?.config);
-    if (receipt?.success !== true || receipt.version !== version
-        || config?.version !== version || typeof config.verify_jwt !== "boolean") {
-        return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.status);
+    if (!response.ok) return releaseControlMutationFailure(expectation.operation, response);
+    const confirmed = confirmedFunctionMutation(expectation, response.data);
+    if (!confirmed) {
+        return releaseControlFailure(expectation.operation, "OUTCOME_UNKNOWN", response.status);
     }
-    return releaseControlSuccess(operation, {
-        slug,
-        version,
-        verify_jwt: config.verify_jwt,
+    return releaseControlSuccess(expectation.operation, {
+        project_ref: expectation.projectRef,
+        slug: expectation.slug,
+        previous_active_version: expectation.expectedActiveVersion,
+        active_version: confirmed.activeVersion,
+        version: confirmed.activeVersion,
+        verify_jwt: confirmed.verifyJwt,
     });
 }
 
@@ -304,6 +468,7 @@ interface FunctionActivationTarget {
     projectRef: string;
     functionSlug: string;
     version: string;
+    expectedActiveVersion: string;
 }
 
 function readOnlyActivationResult(): ReleaseControlToolResponse {
@@ -316,14 +481,21 @@ function readOnlyActivationResult(): ReleaseControlToolResponse {
 function functionActivationTarget(args: Record<string, unknown>): FunctionActivationTarget {
     const projectRef = typeof args.ref === "string" ? args.ref.trim() : "";
     const functionSlug = typeof args.slug === "string" ? args.slug.trim() : "";
-    const version = args.version;
-    if (!SAFE_FUNCTION_REF_PATTERN.test(projectRef)) throw new Error("'ref' is invalid for 'activate'");
+    const version = positiveFunctionVersion(args.version, "Function activation version");
+    projectRefPathSegment(projectRef, "Edge Function activation");
     if (!SAFE_FUNCTION_SLUG_PATTERN.test(functionSlug)) throw new Error("'slug' is invalid for 'activate'");
-    if (typeof version !== "string" || !CANONICAL_FUNCTION_VERSION_PATTERN.test(version)
-        || !Number.isSafeInteger(Number(version))) {
-        throw new Error("'version' is invalid for 'activate'");
+    const expectedActiveVersion = requiredExpectedActiveVersion(args, "activate");
+    return { projectRef, functionSlug, version, expectedActiveVersion };
+}
+
+function requiredExpectedActiveVersion(args: Record<string, unknown>, action: string): string {
+    const expected = args["expected-active-version"];
+    if (expected === undefined) {
+        throw new Error(`'--expected-active-version' required for '${action}'`);
     }
-    return { projectRef, functionSlug, version };
+    const parsed = parseExpectedActiveVersion(expected);
+    if (typeof parsed !== "string") throw new Error("Expected active version is invalid");
+    return parsed;
 }
 
 async function activateFunctionVersion(
@@ -334,10 +506,16 @@ async function activateFunctionVersion(
     if (readOnly) return readOnlyActivationResult();
     const unsupported = Object.keys(args).filter((name) => !FUNCTION_ACTIVATION_ARGUMENTS.has(name));
     if (unsupported.length > 0) throw new Error(`'${unsupported[0]}' is not supported for 'activate'`);
-    const { projectRef, functionSlug, version } = functionActivationTarget(args);
-    const endpoint = `/v1/projects/${encodeURIComponent(projectRef)}/functions/${encodeURIComponent(functionSlug)}`
+    const { projectRef, functionSlug, version, expectedActiveVersion } = functionActivationTarget(args);
+    const endpoint = edgeFunctionResourcePath(projectRef, functionSlug)
         + `/versions/${encodeURIComponent(version)}/activate`;
-    return activationResponse(functionSlug, version, await http.post(endpoint));
+    return functionMutationResponse({
+        operation: "edge_functions.activate",
+        projectRef,
+        slug: functionSlug,
+        expectedActiveVersion,
+        targetVersion: version,
+    }, await http.post(endpoint, { expected_active_version: expectedActiveVersion }));
 }
 
 export function registerAdvancedTools(
@@ -356,7 +534,7 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
             action: withDescription(stringEnum(["list", "deploy", "deploy_bundle", "config", "source", "activate", "delete", "check"]), "Action"),
             ref: withDescription(Type.String(), "Project ref"),
             slug: optional(Type.String(), "[deploy/deploy_bundle/config/source/activate/delete/check] Function name"),
-            version: withDescription(functionVersionSchema, "[activate] Existing Function version"),
+            version: withDescription(functionVersionSchema, "[source/activate] Existing immutable Function version; source requires a positive version"),
             code: optional(Type.String(), "[deploy/check] Function source code (TypeScript)"),
             path: optional(Type.String(), "[deploy/check] Local file path to read code from (alternative to code)"),
             output: optional(Type.String(), "[source] Write source to this local file instead of stdout; the file must not already exist"),
@@ -365,10 +543,17 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
             minify: optional(Type.Boolean(), "[deploy/deploy_bundle] Minify bundle"),
             verify_jwt: optional(Type.Boolean(), "[deploy/deploy_bundle/config] Set JWT verification for this function"),
             background_routes: withDescription(backgroundRoutesSchema, "[deploy/deploy_bundle/config] Background route paths; pass comma-separated or JSON array in CLI"),
+            "expected-active-version": withDescription(
+                expectedActiveVersionSchema,
+                "[deploy/deploy_bundle/activate] Required current active version, or 'absent' when none exists",
+            ),
         },
         async (args: any) => {
             if (args.action === "activate") return activateFunctionVersion(http, args, options.readOnly);
             const { action, ref, slug, path: pathArg, output, files, entrypoint, minify, verify_jwt, background_routes } = args;
+            const expectedActiveVersion = action === "deploy" || action === "deploy_bundle"
+                ? requiredExpectedActiveVersion(args, action)
+                : undefined;
             let code = args.code as string | undefined;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
 
@@ -386,20 +571,10 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
                 if (!hasFunctionConfig()) {
                     throw new Error("'verify_jwt' or 'background_routes' required for 'config'");
                 }
-                const cr = await http.patch(`/v1/projects/${ref}/functions/${slug}/config`, functionConfig());
+                const cr = await http.patch(`${edgeFunctionResourcePath(ref, slug)}/config`, functionConfig());
                 return cr.ok
                     ? `✅ Function ${slug} config updated\n${JSON.stringify(cr.data, null, 2)}`
                     : `❌ Config update failed (${cr.status}): ${JSON.stringify(cr.data)}`;
-            };
-
-            const deploymentPolicyReceiptText = (
-                successText: string,
-                responsePayload: unknown,
-            ): string => {
-                if (!hasFunctionConfig() || confirmedFunctionConfig(responsePayload, functionConfig())) {
-                    return successText;
-                }
-                return "❌ Unsafe deployment receipt: POST succeeded but did not confirm the requested function policy. No follow-up PATCH was attempted because code and policy must be activated atomically.";
             };
 
             const checkSyntax = async (sourceCode: string): Promise<{ ok: boolean; err?: string }> => {
@@ -427,8 +602,7 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
 
             switch (action) {
                 case "list":
-                    text = JSON.stringify((await http.get(`/v1/projects/${ref}/functions`)).data, null, 2);
-                    break;
+                    return functionListResponse(await http.get(edgeFunctionResourcePath(ref)));
                 case "check":
                     need("code (or path)", code);
                     const checkRes = await checkSyntax(code!);
@@ -445,60 +619,49 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
                         text = `❌ Deployment aborted. Syntax check failed:\n${deployCheck.err}`;
                         break;
                     }
-                    const dr = await http.post(`/v1/projects/${ref}/functions/${slug}`, {
+                    const deploymentResponse = await http.post(edgeFunctionResourcePath(ref, slug), {
                         code,
                         minify,
+                        expected_active_version: expectedActiveVersion,
                         ...functionConfig(),
                     });
-                    if (!dr.ok) {
-                        text = `❌ Failed (${dr.status}): ${JSON.stringify(dr.data)}`;
-                        break;
-                    }
-                    text = deploymentPolicyReceiptText(`✅ Function ${slug} deployed`, dr.data);
-                    break;
+                    return functionMutationResponse({
+                        operation: "edge_functions.deploy",
+                        projectRef: ref,
+                        slug,
+                        expectedActiveVersion: expectedActiveVersion!,
+                        config: functionConfig(),
+                    }, deploymentResponse);
                 case "deploy_bundle":
                     need("slug", slug); need("files", files);
-                    const br = await http.post(`/v1/projects/${ref}/functions/${slug}/bundle`, {
+                    const bundleResponse = await http.post(`${edgeFunctionResourcePath(ref, slug)}/bundle`, {
                         files,
                         entrypoint,
                         minify,
+                        expected_active_version: expectedActiveVersion,
                         ...functionConfig(),
                     });
-                    if (!br.ok) {
-                        text = `❌ Failed (${br.status}): ${JSON.stringify(br.data)}`;
-                        break;
-                    }
-                    text = deploymentPolicyReceiptText(
-                        `✅ Function ${slug} bundle deployed (${Object.keys(files!).length} files)`,
-                        br.data,
-                    );
-                    break;
+                    return functionMutationResponse({
+                        operation: "edge_functions.deploy_bundle",
+                        projectRef: ref,
+                        slug,
+                        expectedActiveVersion: expectedActiveVersion!,
+                        config: functionConfig(),
+                    }, bundleResponse);
                 case "config":
                     text = await updateFunctionConfig();
                     break;
                 case "source":
                     need("slug", slug);
-                    const sr = await http.get(`/v1/projects/${ref}/functions/${slug}/source`);
-                    if (!sr.ok) {
-                        text = `❌ Not found (${sr.status})`;
-                        break;
-                    }
-                    if (!output) {
-                        text = JSON.stringify(sr.data, null, 2);
-                        break;
-                    }
-                    const sourceCode = functionSourceCode(sr.data);
-                    if (sourceCode === null) {
-                        text = "❌ Source response did not contain a string code field";
-                        break;
-                    }
-                    const outputPath = resolve(output);
-                    writeFileSync(outputPath, sourceCode, { flag: "wx" });
-                    text = `✅ Function ${slug} source written to ${outputPath} (${Buffer.byteLength(sourceCode)} bytes)`;
-                    break;
+                    return readFunctionSource(http, {
+                        projectRef: ref,
+                        slug,
+                        version: args.version,
+                        output,
+                    });
                 case "delete":
                     need("slug", slug);
-                    text = (await http.delete(`/v1/projects/${ref}/functions/${slug}`)).ok ? `✅ Function ${slug} deleted` : `❌ Failed`;
+                    text = (await http.delete(edgeFunctionResourcePath(ref, slug))).ok ? `✅ Function ${slug} deleted` : `❌ Failed`;
                     break;
                 default: text = `❌ Unknown action`;
             }

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -2,7 +2,22 @@ import { Elysia, t, status } from "elysia";
 import { projectService } from "../services";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { isUserManagedFunctionSecretName } from "../utils/project-secret-visibility";
-import type { EdgeFunctionDeploymentConfig } from "../services/edge-function.service";
+import {
+  EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
+  EdgeFunctionActiveVersionConflictError,
+  type EdgeFunctionActiveVersion,
+  type EdgeFunctionDeploymentConfig,
+  type EdgeFunctionDeployResult,
+} from "../services/edge-function.service";
+
+const FUNCTION_VERSION_PATTERN = /^(?:0|[1-9][0-9]*)$/;
+const EXPECTED_ACTIVE_VERSION_PATTERN = /^[1-9][0-9]*$/;
+// Admit the reserved legacy zero at schema parsing so the handler returns the stable public HTTP 400 contract.
+const functionVersionSchema = t.String({ pattern: FUNCTION_VERSION_PATTERN.source, maxLength: 16 });
+const expectedActiveVersionSchema = t.Union([
+  t.Literal("absent"),
+  t.String({ pattern: EXPECTED_ACTIVE_VERSION_PATTERN.source, maxLength: 16 }),
+]);
 
 async function requireFunctionManagementAuth(request: Request, ref: string) {
   const authError = await requireProjectOrAdminAuth(request, ref);
@@ -46,6 +61,53 @@ function normalizedBackgroundRoutes(routes: unknown): string[] | undefined {
     : undefined;
 }
 
+function expectedActiveVersion(value: unknown): EdgeFunctionActiveVersion | null {
+  if (value === "absent") return value;
+  if (typeof value !== "string" || !EXPECTED_ACTIVE_VERSION_PATTERN.test(value)) {
+    return null;
+  }
+  return Number.isSafeInteger(Number(value)) ? value : null;
+}
+
+function functionVersion(value: unknown): string | null {
+  if (typeof value !== "string" || !EXPECTED_ACTIVE_VERSION_PATTERN.test(value)) return null;
+  return Number.isSafeInteger(Number(value)) ? value : null;
+}
+
+function invalidExpectedActiveVersion() {
+  return status(400, {
+    message: "expected_active_version must be a canonical positive safe integer or 'absent'",
+    code: "VALIDATION_ERROR",
+  });
+}
+
+function deploymentFailure(deployment: EdgeFunctionDeployResult) {
+  if (deployment.success) return null;
+  if (deployment.error_code === EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE) {
+    return status(409, {
+      message: deployment.error || "Function active version conflict",
+      code: deployment.error_code,
+      expected_active_version: deployment.expected_active_version,
+      active_version: deployment.active_version,
+    });
+  }
+  return status(500, {
+    message: deployment.error || "Failed to deploy function",
+    code: "500",
+    details: deployment,
+  });
+}
+
+function activationConflict(error: unknown) {
+  if (!(error instanceof EdgeFunctionActiveVersionConflictError)) return null;
+  return status(409, {
+    message: error.message,
+    code: error.code,
+    expected_active_version: error.expectedActiveVersion,
+    active_version: error.activeVersion,
+  });
+}
+
 export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
   .get(
     "/:ref/functions",
@@ -83,6 +145,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt?: boolean;
         background_routes?: string[];
         name?: string;
+        expected_active_version?: string;
       } = {};
       if (body.metadata) {
         try {
@@ -93,10 +156,14 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
                 ? await (body.metadata as Blob).text()
                 : JSON.stringify(body.metadata);
           Object.assign(metadata, JSON.parse(raw));
-        } catch {
-          /* ignore metadata parse errors */
+        } catch (error) {
+          if (!(error instanceof SyntaxError)) throw error;
+          return status(400, { message: "metadata must be valid JSON", code: "VALIDATION_ERROR" });
         }
       }
+
+      const expectedVersion = expectedActiveVersion(metadata.expected_active_version);
+      if (expectedVersion === null) return invalidExpectedActiveVersion();
 
       // Collect all uploaded files (the `file` field can be single or multiple)
       const rawFiles = body.file;
@@ -131,17 +198,13 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const deployment = await projectService.deployFunctionRelease({
         ref: params.ref,
         slug,
+        expectedActiveVersion: expectedVersion,
         files: fileMap,
         entrypoint,
         config: deploymentConfig(metadata.verify_jwt, backgroundRoutes),
       });
-      if (!deployment.success) {
-        return status(500, {
-          message: deployment.error || "Failed to deploy function bundle",
-          code: "500",
-          details: deployment,
-        });
-      }
+      const failure = deploymentFailure(deployment);
+      if (failure) return failure;
 
       const { edgeFunctionService } =
         await import("../services/edge-function.service");
@@ -149,10 +212,13 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
       const now = new Date().toISOString();
       return {
+        project_ref: params.ref,
         id: slug,
         slug,
         name: metadata.name || slug,
         version: Number.parseInt(deployment.version || String(version), 10) || version,
+        previous_active_version: deployment.previous_active_version,
+        active_version: deployment.active_version,
         status: "ACTIVE",
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
@@ -206,19 +272,22 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         | null = null;
       // Allow empty code for metadata-only creation
       if (code) {
+        const expectedVersion = expectedActiveVersion(body?.expected_active_version);
+        if (expectedVersion === null) {
+          return status(400, {
+            message: "expected_active_version is required when deploying code",
+            code: "VALIDATION_ERROR",
+          });
+        }
         deployResult = await projectService.deployFunctionRelease({
           ref: params.ref,
           slug,
+          expectedActiveVersion: expectedVersion,
           code,
           config: deploymentConfig(verifyJwt, backgroundRoutes),
         });
-        if (!deployResult.success) {
-          return status(500, {
-            message: deployResult.error || "Failed to deploy function",
-            code: "500",
-            details: deployResult,
-          });
-        }
+        const failure = deploymentFailure(deployResult);
+        if (failure) return failure;
       }
 
       const { edgeFunctionService } =
@@ -233,10 +302,13 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
 
       const now = new Date().toISOString();
       return {
+        project_ref: params.ref,
         id: slug,
         slug,
         name: name || slug,
         version,
+        previous_active_version: deployResult?.previous_active_version,
+        active_version: deployResult?.active_version,
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         status: "ACTIVE",
@@ -274,6 +346,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           code: t.Optional(t.String()),
           verify_jwt: t.Optional(t.Boolean()),
           background_routes: t.Optional(t.Array(t.String())),
+          expected_active_version: t.Optional(expectedActiveVersionSchema),
         }),
       ),
       detail: { tags: ["frontend"], summary: "Create or deploy an edge function" },
@@ -286,21 +359,27 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
-      const results = [];
-      for (const fn of body as Array<{
+      const functions = body as Array<{
         slug: string;
         body?: string;
         code?: string;
         name?: string;
         verify_jwt?: boolean;
         background_routes?: string[];
-      }>) {
+        expected_active_version: EdgeFunctionActiveVersion;
+      }>;
+      if (functions.some((fn) => expectedActiveVersion(fn.expected_active_version) === null)) {
+        return invalidExpectedActiveVersion();
+      }
+      const results = [];
+      for (const fn of functions) {
         const code = fn.body || fn.code || "";
         if (!fn.slug || !code) continue;
 
         const deployResult = await projectService.deployFunctionRelease({
           ref: params.ref,
           slug: fn.slug,
+          expectedActiveVersion: expectedActiveVersion(fn.expected_active_version)!,
           code,
           config: deploymentConfig(
             fn.verify_jwt,
@@ -313,12 +392,19 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           slug: fn.slug,
           name: fn.name || fn.slug,
           success: deployResult.success,
+          error_code: deployResult.error_code,
+          previous_active_version: deployResult.previous_active_version,
+          active_version: deployResult.active_version,
           verify_jwt: deployResult.config?.verify_jwt,
           background_routes: deployResult.config?.background_routes || [],
           updated_at: now,
         });
       }
-      return results;
+      return results.some((deployment) => (
+        deployment.error_code === EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE
+      ))
+        ? status(409, { functions: results })
+        : results;
     },
     {
       params: t.Object({ ref: t.String() }),
@@ -330,6 +416,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           code: t.Optional(t.String()),
           verify_jwt: t.Optional(t.Boolean()),
           background_routes: t.Optional(t.Array(t.String())),
+          expected_active_version: expectedActiveVersionSchema,
         }),
       ),
       detail: { tags: ["frontend"], summary: "Bulk upsert edge functions" },
@@ -487,31 +574,52 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
 
   .post(
     "/:ref/functions/:slug/versions/:version/activate",
-    async ({ params, request }) => {
+    async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
       const { edgeFunctionService } =
         await import("../services/edge-function.service");
-      const updated = await edgeFunctionService.activateVersion(
-        params.ref,
-        params.slug,
-        params.version,
-      );
-      if (!updated) {
-        return status(404, { message: "Function version not found", code: "404" });
+      const expectedVersion = expectedActiveVersion(body.expected_active_version);
+      if (expectedVersion === null) return invalidExpectedActiveVersion();
+      const targetVersion = functionVersion(params.version);
+      if (targetVersion === null) {
+        return status(400, {
+          message: "version must be a canonical positive safe integer",
+          code: "VALIDATION_ERROR",
+        });
       }
-      return {
-        success: true,
-        version: params.version,
-        config: updated,
-      };
+      try {
+        const activation = await edgeFunctionService.activateVersion(
+          params.ref,
+          params.slug,
+          targetVersion,
+          expectedVersion,
+        );
+        if (!activation) {
+          return status(404, { message: "Function version not found", code: "404" });
+        }
+        return {
+          success: true,
+          project_ref: params.ref,
+          slug: params.slug,
+          previous_active_version: activation.previous_active_version,
+          active_version: activation.active_version,
+          version: targetVersion,
+          config: activation.config,
+        };
+      } catch (error) {
+        const conflict = activationConflict(error);
+        if (conflict) return conflict;
+        throw error;
+      }
     },
     {
       params: t.Object({
         ref: t.String(),
         slug: t.String(),
-        version: t.String(),
+        version: functionVersionSchema,
       }),
+      body: t.Object({ expected_active_version: expectedActiveVersionSchema }),
       detail: { tags: ["frontend"], summary: "Activate a function version" },
     },
   )
@@ -555,9 +663,12 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
       const code = body.code || body.body || "";
+      const expectedVersion = expectedActiveVersion(body.expected_active_version);
+      if (expectedVersion === null) return invalidExpectedActiveVersion();
       const deployment = await projectService.deployFunctionRelease({
         ref: params.ref,
         slug: params.slug,
+        expectedActiveVersion: expectedVersion,
         code,
         minify: body.minify ?? false,
         config: deploymentConfig(
@@ -565,17 +676,16 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           normalizedBackgroundRoutes(body.background_routes),
         ),
       });
-      if (!deployment.success) {
-        return status(500, {
-          message: deployment.error || "Failed to deploy function",
-          code: "500",
-          details: deployment,
-        });
-      }
+      const failure = deploymentFailure(deployment);
+      if (failure) return failure;
       return {
         success: true,
+        project_ref: params.ref,
+        slug: params.slug,
         bundled: deployment.bundled ?? true,
         version: deployment.version ?? null,
+        previous_active_version: deployment.previous_active_version,
+        active_version: deployment.active_version,
         bundle_hash: deployment.bundle_hash ?? null,
         bundle_size_bytes: deployment.bundle_size_bytes ?? null,
         import_count: deployment.import_count ?? null,
@@ -583,6 +693,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         preheat: deployment.preheat ?? null,
         verify_jwt: deployment.config?.verify_jwt ?? true,
         background_routes: deployment.config?.background_routes || [],
+        config: deployment.config,
       };
     },
     {
@@ -593,6 +704,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         minify: t.Optional(t.Boolean()),
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
+        expected_active_version: expectedActiveVersionSchema,
       }),
       detail: { tags: ["frontend"], summary: "Deploy function code by slug" },
     },
@@ -616,19 +728,22 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         normalizedBackgroundRoutes(body.background_routes),
       );
       if (code) {
+        const expectedVersion = expectedActiveVersion(body.expected_active_version);
+        if (expectedVersion === null) {
+          return status(400, {
+            message: "expected_active_version is required when deploying code",
+            code: "VALIDATION_ERROR",
+          });
+        }
         deployResult = await projectService.deployFunctionRelease({
           ref: params.ref,
           slug: params.slug,
+          expectedActiveVersion: expectedVersion,
           code,
           config: configPatch,
         });
-        if (!deployResult.success) {
-          return status(500, {
-            message: deployResult.error || "Failed to deploy function",
-            code: "500",
-            details: deployResult,
-          });
-        }
+        const failure = deploymentFailure(deployResult);
+        if (failure) return failure;
       }
 
       const funcConfig = deployResult?.config ?? (
@@ -639,10 +754,13 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
       const now = new Date().toISOString();
       return {
+        project_ref: params.ref,
         id: params.slug,
         slug: params.slug,
         name: body.name || params.slug,
         version,
+        previous_active_version: deployResult?.previous_active_version,
+        active_version: deployResult?.active_version,
         status: "ACTIVE",
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
@@ -663,6 +781,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         code: t.Optional(t.String()),
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
+        expected_active_version: t.Optional(expectedActiveVersionSchema),
       }),
       detail: { tags: ["frontend"], summary: "Update function code or config" },
     },
@@ -673,9 +792,12 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, body, request }) => {
       const authError = await requireProjectOrAdminAuth(request, params.ref);
       if (authError) return status(authError.status, authError.body);
+      const expectedVersion = expectedActiveVersion(body.expected_active_version);
+      if (expectedVersion === null) return invalidExpectedActiveVersion();
       const deployment = await projectService.deployFunctionRelease({
         ref: params.ref,
         slug: params.slug,
+        expectedActiveVersion: expectedVersion,
         files: body.files,
         entrypoint: body.entrypoint ?? "index.ts",
         minify: body.minify ?? false,
@@ -684,18 +806,17 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           normalizedBackgroundRoutes(body.background_routes),
         ),
       });
-      if (!deployment.success) {
-        return status(500, {
-          message: deployment.error || "Failed to deploy function bundle",
-          code: "500",
-          details: deployment,
-        });
-      }
+      const failure = deploymentFailure(deployment);
+      if (failure) return failure;
       return {
         success: true,
+        project_ref: params.ref,
+        slug: params.slug,
         bundled: true,
         files: deployment.files ?? Object.keys(body.files).length,
         version: deployment.version ?? null,
+        previous_active_version: deployment.previous_active_version,
+        active_version: deployment.active_version,
         import_map: deployment.import_map ?? null,
         bundle_hash: deployment.bundle_hash ?? null,
         bundle_size_bytes: deployment.bundle_size_bytes ?? null,
@@ -704,6 +825,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         preheat: deployment.preheat ?? null,
         verify_jwt: deployment.config?.verify_jwt ?? true,
         background_routes: deployment.config?.background_routes || [],
+        config: deployment.config,
       };
     },
     {
@@ -714,6 +836,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         minify: t.Optional(t.Boolean()),
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
+        expected_active_version: expectedActiveVersionSchema,
       }),
       detail: { tags: ["frontend"], summary: "Deploy function bundle" },
     },

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -34,6 +34,8 @@ export interface EdgeFunctionVersionDetail extends EdgeFunctionVersionRecord {
 
 export interface EdgeFunctionDeployResult {
   success: boolean;
+  previous_active_version?: EdgeFunctionActiveVersion;
+  active_version?: string;
   version?: string;
   bundled?: boolean;
   files?: number;
@@ -45,7 +47,19 @@ export interface EdgeFunctionDeployResult {
   external_packages?: string[];
   preheat?: EdgeFunctionPreheatResult;
   config?: EdgeFunctionConfig;
+  error_code?: typeof EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE;
+  expected_active_version?: EdgeFunctionActiveVersion;
   error?: string;
+}
+
+export const EDGE_FUNCTION_ABSENT_ACTIVE_VERSION = "absent" as const;
+export const EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE = "FUNCTION_ACTIVE_VERSION_CONFLICT" as const;
+export type EdgeFunctionActiveVersion = string;
+
+export interface EdgeFunctionActivationResult {
+  previous_active_version: EdgeFunctionActiveVersion;
+  active_version: string;
+  config: EdgeFunctionConfig;
 }
 
 export type EdgeFunctionDeploymentConfig = Pick<
@@ -53,7 +67,7 @@ export type EdgeFunctionDeploymentConfig = Pick<
   "verify_jwt" | "background_routes"
 >;
 
-export type EdgeFunctionDeploymentRequest = {
+type EdgeFunctionReleaseRequest = {
   ref: string;
   slug: string;
   minify?: boolean;
@@ -62,6 +76,10 @@ export type EdgeFunctionDeploymentRequest = {
   | { code: string; files?: never; entrypoint?: never }
   | { files: Record<string, string>; entrypoint?: string; code?: never }
 );
+
+export type EdgeFunctionDeploymentRequest = EdgeFunctionReleaseRequest & {
+  expectedActiveVersion: EdgeFunctionActiveVersion;
+};
 
 export interface EdgeFunctionPreheatPoolResult {
   attempted: number;
@@ -186,6 +204,27 @@ function parseVersionNumber(value: unknown): number | null {
   return parsed;
 }
 
+function validatedExpectedActiveVersion(value: unknown): EdgeFunctionActiveVersion {
+  if (value === EDGE_FUNCTION_ABSENT_ACTIVE_VERSION) return value;
+  if (typeof value !== "string" || !CANONICAL_VERSION_REGEX.test(value)
+    || !Number.isSafeInteger(Number(value))) {
+    throw new Error("Expected active Function version must be a canonical safe integer or 'absent'");
+  }
+  return value;
+}
+
+export class EdgeFunctionActiveVersionConflictError extends Error {
+  readonly code = EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE;
+
+  constructor(
+    readonly expectedActiveVersion: EdgeFunctionActiveVersion,
+    readonly activeVersion: EdgeFunctionActiveVersion,
+  ) {
+    super("Function active version changed before the requested mutation");
+    this.name = "EdgeFunctionActiveVersionConflictError";
+  }
+}
+
 async function acquireFunctionDeployLock(
   ref: string,
   slug: string,
@@ -302,6 +341,33 @@ async function functionConfigExists(ref: string, slug: string): Promise<boolean>
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     return false;
   }
+}
+
+async function activeFunctionVersion(
+  ref: string,
+  slug: string,
+): Promise<EdgeFunctionActiveVersion> {
+  const functionConfig = await readFunctionConfig(ref, slug);
+  if (functionConfig.version !== undefined) {
+    if (parseVersionNumber(functionConfig.version) === null) {
+      throw new Error("Function config contains an invalid active version");
+    }
+    return functionConfig.version;
+  }
+  return await frozenLegacyRuntimePath(ref, slug) === null
+    ? EDGE_FUNCTION_ABSENT_ACTIVE_VERSION
+    : "0";
+}
+
+async function assertExpectedActiveVersion(
+  ref: string,
+  slug: string,
+  expectedVersion: unknown,
+): Promise<EdgeFunctionActiveVersion> {
+  const expected = validatedExpectedActiveVersion(expectedVersion);
+  const active = await activeFunctionVersion(ref, slug);
+  if (active !== expected) throw new EdgeFunctionActiveVersionConflictError(expected, active);
+  return active;
 }
 
 async function writeFunctionConfigManifest(
@@ -465,7 +531,7 @@ async function writePreparedBundle(
 }
 
 async function prepareSingleFunctionVersion(
-  request: EdgeFunctionDeploymentRequest & { code: string },
+  request: EdgeFunctionReleaseRequest & { code: string },
   version: string,
   stageDir: string,
   finalDir: string,
@@ -501,7 +567,7 @@ async function detectedImportMap(sourceDir: string): Promise<string | null> {
 }
 
 function validatedBundleEntrypoint(
-  request: EdgeFunctionDeploymentRequest & { files: Record<string, string> },
+  request: EdgeFunctionReleaseRequest & { files: Record<string, string> },
 ): string {
   const entrypoint = request.entrypoint ?? "index.ts";
   if (!request.files[entrypoint]) throw new Error(`Entrypoint '${entrypoint}' not found in file map`);
@@ -525,7 +591,7 @@ async function writeBundleSources(
 }
 
 async function prepareBundleFunctionVersion(
-  request: EdgeFunctionDeploymentRequest & { files: Record<string, string> },
+  request: EdgeFunctionReleaseRequest & { files: Record<string, string> },
   version: string,
   stageDir: string,
   finalDir: string,
@@ -1312,7 +1378,7 @@ export async function migrateLegacyVersionArtifacts(): Promise<{ moved: number }
 }
 
 async function immutableFunctionVersion(
-  request: EdgeFunctionDeploymentRequest,
+  request: EdgeFunctionReleaseRequest,
   version: string,
   currentConfig: EdgeFunctionConfig,
 ): Promise<PreparedFunctionRelease> {
@@ -1405,9 +1471,12 @@ function releaseResult(
   prepared: PreparedFunctionVersion,
   readiness: EdgeFunctionPreheatResult,
   functionConfig: EdgeFunctionConfig,
+  previousActiveVersion: EdgeFunctionActiveVersion,
 ): EdgeFunctionDeployResult {
   return {
     success: true,
+    previous_active_version: previousActiveVersion,
+    active_version: prepared.version,
     version: prepared.version,
     bundled: prepared.bundled,
     files: prepared.files,
@@ -1423,7 +1492,8 @@ function releaseResult(
 }
 
 async function deployFunctionRelease(
-  request: EdgeFunctionDeploymentRequest,
+  request: EdgeFunctionReleaseRequest,
+  previousActiveVersion: EdgeFunctionActiveVersion,
 ): Promise<EdgeFunctionDeployResult> {
   let currentConfig = await readFunctionConfig(request.ref, request.slug);
   const hadManifest = await functionConfigExists(request.ref, request.slug);
@@ -1446,7 +1516,32 @@ async function deployFunctionRelease(
     nextConfig: release.config,
   });
   recordDeployMetrics(release.prepared.bundleSizeBytes, release.prepared.importCount, readiness);
-  return releaseResult(release.prepared, readiness, release.config);
+  return releaseResult(release.prepared, readiness, release.config, previousActiveVersion);
+}
+
+function failedDeployResult(
+  request: EdgeFunctionReleaseRequest,
+  error: unknown,
+): EdgeFunctionDeployResult {
+  logger.error("[EdgeFunction] Deploy failed", { ref: request.ref, slug: request.slug, error });
+  return {
+    success: false,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
+async function deployLatestFunctionRelease(
+  request: EdgeFunctionReleaseRequest,
+): Promise<EdgeFunctionDeployResult> {
+  const releaseLock = await acquireFunctionDeployLock(request.ref, request.slug);
+  try {
+    const activeVersion = await activeFunctionVersion(request.ref, request.slug);
+    return await deployFunctionRelease(request, activeVersion);
+  } catch (error) {
+    return failedDeployResult(request, error);
+  } finally {
+    releaseLock();
+  }
 }
 
 export const edgeFunctionService = {
@@ -1484,21 +1579,27 @@ export const edgeFunctionService = {
   async deployRelease(request: EdgeFunctionDeploymentRequest): Promise<EdgeFunctionDeployResult> {
     const releaseLock = await acquireFunctionDeployLock(request.ref, request.slug);
     try {
-      const deployed = await deployFunctionRelease(request);
+      const previousActiveVersion = await assertExpectedActiveVersion(
+        request.ref,
+        request.slug,
+        request.expectedActiveVersion,
+      );
+      const deployed = await deployFunctionRelease(request, previousActiveVersion);
       logger.info(
         `[EdgeFunction] Deployed ${request.slug} for ${request.ref} (version=${deployed.version}, verify_jwt=${deployed.config?.verify_jwt}, size=${deployed.bundle_size_bytes}, imports=${deployed.import_count})`,
       );
       return deployed;
     } catch (error) {
-      logger.error("[EdgeFunction] Deploy failed", {
-        ref: request.ref,
-        slug: request.slug,
-        error,
-      });
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
+      if (error instanceof EdgeFunctionActiveVersionConflictError) {
+        return {
+          success: false,
+          error_code: error.code,
+          expected_active_version: error.expectedActiveVersion,
+          active_version: error.activeVersion,
+          error: error.message,
+        };
+      }
+      return failedDeployResult(request, error);
     } finally {
       releaseLock();
     }
@@ -1524,7 +1625,7 @@ export const edgeFunctionService = {
     code: string,
     minify: boolean = false,
   ): Promise<EdgeFunctionDeployResult> {
-    return this.deployRelease({ ref, slug, code, minify });
+    return deployLatestFunctionRelease({ ref, slug, code, minify });
   },
 
   /**
@@ -1559,7 +1660,7 @@ export const edgeFunctionService = {
     entrypoint: string = "index.ts",
     minify: boolean = false,
   ): Promise<EdgeFunctionDeployResult> {
-    return this.deployRelease({ ref, slug, files, entrypoint, minify });
+    return deployLatestFunctionRelease({ ref, slug, files, entrypoint, minify });
   },
 
   async runtimeCheck(
@@ -1743,9 +1844,19 @@ export const edgeFunctionService = {
     };
   },
 
-  async activateVersion(ref: string, slug: string, version: string): Promise<EdgeFunctionConfig | null> {
+  async activateVersion(
+    ref: string,
+    slug: string,
+    version: string,
+    expectedActiveVersion: EdgeFunctionActiveVersion,
+  ): Promise<EdgeFunctionActivationResult | null> {
     const releaseLock = await acquireFunctionDeployLock(ref, slug);
     try {
+      const previousActiveVersion = await assertExpectedActiveVersion(
+        ref,
+        slug,
+        expectedActiveVersion,
+      );
       const detail = await this.getVersion(ref, slug, version);
       if (!detail || !detail.has_bundle) return null;
 
@@ -1764,7 +1875,11 @@ export const edgeFunctionService = {
         nextConfig: updated,
       });
       logger.info(`[EdgeFunction] Activated version ${version} for ${slug}@${ref}`);
-      return updated;
+      return {
+        previous_active_version: previousActiveVersion,
+        active_version: version,
+        config: updated,
+      };
     } finally {
       releaseLock();
     }

--- a/packages/management-api/tests/unit/edge-function.service.activation.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.activation.test.ts
@@ -11,7 +11,22 @@ const originalFetch = globalThis.fetch;
 process.env.EDGE_FUNCTIONS_DIR = functionsRoot;
 process.env.EDGE_RUNTIME_INTERNAL = "127.0.0.1:65535";
 
-const { edgeFunctionService } = await import("../../src/services/edge-function.service");
+const {
+  EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
+  edgeFunctionService,
+} = await import("../../src/services/edge-function.service");
+
+async function deployConditionalRelease(
+  request: Omit<Parameters<typeof edgeFunctionService.deployRelease>[0], "expectedActiveVersion">,
+) {
+  const expectedActiveVersion = (await edgeFunctionService.getConfig(request.ref, request.slug)).version ?? "absent";
+  return edgeFunctionService.deployRelease({ ...request, expectedActiveVersion });
+}
+
+async function activateConditionalVersion(ref: string, slug: string, version: string) {
+  const expectedActiveVersion = (await edgeFunctionService.getConfig(ref, slug)).version ?? "absent";
+  return (await edgeFunctionService.activateVersion(ref, slug, version, expectedActiveVersion))?.config ?? null;
+}
 
 type FetchStep = {
   path: "/preheat/" | "/invalidate/";
@@ -72,7 +87,7 @@ async function prepareRollback(ref: string, slug: string) {
     "index.ts": "export default { fetch: () => new Response('version-two') };",
     "public/version.txt": "version-two",
   });
-  await edgeFunctionService.activateVersion(ref, slug, "1");
+  await activateConditionalVersion(ref, slug, "1");
 
   return {
     config: await edgeFunctionService.getConfig(ref, slug),
@@ -105,6 +120,27 @@ afterAll(async () => {
 });
 
 describe("edgeFunctionService version activation readiness", () => {
+  test("rejects stale activation before target preheat or manifest mutation", async () => {
+    const ref = "proj_activation_stale";
+    const slug = "activation-stale";
+    const before = await prepareRollback(ref, slug);
+    let runtimeCalls = 0;
+    globalThis.fetch = (async () => {
+      runtimeCalls += 1;
+      return Response.json({});
+    }) as typeof fetch;
+
+    await expect(
+      edgeFunctionService.activateVersion(ref, slug, "2", "2"),
+    ).rejects.toMatchObject({
+      code: EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
+      expectedActiveVersion: "2",
+      activeVersion: "1",
+    });
+    expect(runtimeCalls).toBe(0);
+    await expectRollbackUnchanged(ref, slug, before);
+  });
+
   test("fails closed when version preheat is unauthorized", async () => {
     const ref = "proj_activation_preheat_401";
     const slug = "activate-preheat-401";
@@ -113,7 +149,7 @@ describe("edgeFunctionService version activation readiness", () => {
       { path: "/preheat/", response: Response.json({ message: "Unauthorized" }, { status: 401 }) },
     ]);
 
-    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow("HTTP 401");
+    await expect(activateConditionalVersion(ref, slug, "2")).rejects.toThrow("HTTP 401");
     await expectRollbackUnchanged(ref, slug, before);
   });
 
@@ -127,7 +163,7 @@ describe("edgeFunctionService version activation readiness", () => {
       { path: "/invalidate/", response: Response.json(successfulInvalidationAck(ref, slug)) },
     ]);
 
-    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow("HTTP 401");
+    await expect(activateConditionalVersion(ref, slug, "2")).rejects.toThrow("HTTP 401");
     await expectRollbackUnchanged(ref, slug, before);
   });
 
@@ -139,7 +175,7 @@ describe("edgeFunctionService version activation readiness", () => {
       { path: "/preheat/", response: Response.json({ success: false, version: "2" }) },
     ]);
 
-    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow(
+    await expect(activateConditionalVersion(ref, slug, "2")).rejects.toThrow(
       "did not report successful version readiness",
     );
     await expectRollbackUnchanged(ref, slug, before);
@@ -158,7 +194,7 @@ describe("edgeFunctionService version activation readiness", () => {
       { path: "/preheat/", response: Response.json(responseBody) },
     ]);
 
-    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow(
+    await expect(activateConditionalVersion(ref, slug, "2")).rejects.toThrow(
       "Edge Runtime function activation unavailable",
     );
     await expectRollbackUnchanged(ref, slug, before);
@@ -196,7 +232,7 @@ describe("edgeFunctionService version activation readiness", () => {
       { path: "/invalidate/", response: Response.json(successfulInvalidationAck(ref, slug)) },
     ]);
 
-    await expect(edgeFunctionService.activateVersion(ref, slug, "2")).rejects.toThrow(
+    await expect(activateConditionalVersion(ref, slug, "2")).rejects.toThrow(
       "Edge Runtime function activation unavailable",
     );
     await expectRollbackUnchanged(ref, slug, before);
@@ -215,9 +251,13 @@ describe("edgeFunctionService version activation readiness", () => {
     ];
     globalThis.fetch = sequenceFetch(steps);
 
-    const config = await edgeFunctionService.activateVersion(ref, slug, "2");
+    const activation = await edgeFunctionService.activateVersion(ref, slug, "2", "1");
 
-    expect(config?.version).toBe("2");
+    expect(activation).toMatchObject({
+      previous_active_version: "1",
+      active_version: "2",
+      config: { version: "2" },
+    });
     expect(await edgeFunctionService.read(ref, slug)).toContain("version-two");
     expect(await edgeFunctionService.readSource(ref, slug)).toContain("version-two");
     expect(steps).toHaveLength(0);
@@ -227,7 +267,7 @@ describe("edgeFunctionService version activation readiness", () => {
     const ref = "proj_activation_full_metadata";
     const slug = "metadata-rollback";
     globalThis.fetch = runtimeSuccessFetch();
-    const versionOne = await edgeFunctionService.deployRelease({
+    const versionOne = await deployConditionalRelease({
       ref,
       slug,
       files: {
@@ -237,7 +277,7 @@ describe("edgeFunctionService version activation readiness", () => {
       entrypoint: "version-one.ts",
       config: { verify_jwt: false, background_routes: ["/version-one/*"] },
     });
-    const versionTwo = await edgeFunctionService.deployRelease({
+    const versionTwo = await deployConditionalRelease({
       ref,
       slug,
       files: {
@@ -251,7 +291,7 @@ describe("edgeFunctionService version activation readiness", () => {
     expect(versionOne).toMatchObject({ success: true, version: "1" });
     expect(versionTwo).toMatchObject({ success: true, version: "2" });
 
-    const restored = await edgeFunctionService.activateVersion(ref, slug, "1");
+    const restored = await activateConditionalVersion(ref, slug, "1");
 
     expect(restored).toMatchObject({
       version: "1",

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -16,9 +16,25 @@ mock.restore();
 process.env.EDGE_FUNCTIONS_DIR = functionsRoot;
 process.env.EDGE_RUNTIME_INTERNAL = "127.0.0.1:65535";
 
-const { edgeFunctionService, getVersionedArtifactPath } = await import(
+const {
+  EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
+  edgeFunctionService,
+  getVersionedArtifactPath,
+} = await import(
   "../../src/services/edge-function.service"
 );
+
+async function deployConditionalRelease(
+  request: Omit<Parameters<typeof edgeFunctionService.deployRelease>[0], "expectedActiveVersion">,
+) {
+  const expectedActiveVersion = (await edgeFunctionService.getConfig(request.ref, request.slug)).version ?? "absent";
+  return edgeFunctionService.deployRelease({ ...request, expectedActiveVersion });
+}
+
+async function activateConditionalVersion(ref: string, slug: string, version: string) {
+  const expectedActiveVersion = (await edgeFunctionService.getConfig(ref, slug)).version ?? "absent";
+  return (await edgeFunctionService.activateVersion(ref, slug, version, expectedActiveVersion))?.config ?? null;
+}
 
 const runtimeInvalidationProtocol = {
   module_scope: "legacy-base-only",
@@ -94,7 +110,7 @@ describe("edgeFunctionService bundle metadata", () => {
       },
     })) as typeof fetch;
 
-    const deployed = await edgeFunctionService.deployRelease({
+    const deployed = await deployConditionalRelease({
       ref: "proj_preheat_diagnostic",
       slug: "computed-import",
       code: "export default { fetch: () => new Response('unreachable') };",
@@ -206,7 +222,7 @@ describe("edgeFunctionService bundle metadata", () => {
       });
     }) as typeof fetch;
 
-    const deployed = await edgeFunctionService.deployRelease({
+    const deployed = await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('public') };",
@@ -224,14 +240,14 @@ describe("edgeFunctionService bundle metadata", () => {
   test("preserves an existing false policy when a later deploy omits policy", async () => {
     const ref = "proj_preserve_false";
     const slug = "public-hook";
-    await edgeFunctionService.deployRelease({
+    await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('v1') };",
       config: { verify_jwt: false },
     });
 
-    const deployed = await edgeFunctionService.deployRelease({
+    const deployed = await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('v2') };",
@@ -247,7 +263,7 @@ describe("edgeFunctionService bundle metadata", () => {
   test("clears bundle source metadata when a single-file version becomes active", async () => {
     const ref = "proj_single_metadata";
     const slug = "metadata-clear";
-    await edgeFunctionService.deployRelease({
+    await deployConditionalRelease({
       ref,
       slug,
       files: {
@@ -257,7 +273,7 @@ describe("edgeFunctionService bundle metadata", () => {
       entrypoint: "worker.ts",
     });
 
-    const singleFile = await edgeFunctionService.deployRelease({
+    const singleFile = await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('single-file') };",
@@ -270,7 +286,7 @@ describe("edgeFunctionService bundle metadata", () => {
   });
 
   test("defaults a new function policy to verify_jwt=true", async () => {
-    const deployed = await edgeFunctionService.deployRelease({
+    const deployed = await deployConditionalRelease({
       ref: "proj_default_true",
       slug: "secured",
       code: "export default { fetch: () => new Response('secured') };",
@@ -293,11 +309,11 @@ describe("edgeFunctionService bundle metadata", () => {
     const legacyBundleBefore = await readFile(legacyBundlePath, "utf8");
     const legacySourceBefore = await readFile(legacySourcePath, "utf8");
 
-    const deployed = await edgeFunctionService.deployRelease({
+    const deployed = await edgeFunctionService.deployDetailed(
       ref,
       slug,
-      code: "export default { fetch: () => new Response('immutable-v1') };",
-    });
+      "export default { fetch: () => new Response('immutable-v1') };",
+    );
 
     expect(deployed.config).toMatchObject({ verify_jwt: false, version: "1" });
     expect(await readFile(legacyBundlePath, "utf8")).toBe(legacyBundleBefore);
@@ -305,7 +321,7 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(await edgeFunctionService.read(ref, slug)).toContain("immutable-v1");
     expect(await edgeFunctionService.list(ref)).toContain(slug);
 
-    const restored = await edgeFunctionService.activateVersion(ref, slug, "0");
+    const restored = await activateConditionalVersion(ref, slug, "0");
 
     expect(restored).toMatchObject({
       version: "0",
@@ -316,6 +332,22 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(Object.hasOwn(restored!, "import_map")).toBe(false);
     expect(await edgeFunctionService.read(ref, slug)).toContain("legacy");
     expect(await edgeFunctionService.readSource(ref, slug)).toContain("legacy-source");
+
+    const continued = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      expectedActiveVersion: "0",
+      code: "export default { fetch: () => new Response('post-legacy-release') };",
+    });
+
+    expect(continued).toMatchObject({
+      success: true,
+      previous_active_version: "0",
+      active_version: "2",
+      version: "2",
+      config: { version: "2" },
+    });
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("post-legacy-release");
   });
 
   test("repairs a configured version with missing artifacts from frozen aliases", async () => {
@@ -337,7 +369,7 @@ describe("edgeFunctionService bundle metadata", () => {
       })),
     ]);
 
-    const deployed = await edgeFunctionService.deployRelease({
+    const deployed = await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('version-eight') };",
@@ -346,7 +378,7 @@ describe("edgeFunctionService bundle metadata", () => {
 
     expect(deployed).toMatchObject({ success: true, version: "8" });
     expect(await Bun.file(legacyBundlePath).text()).toBe(legacyBundle);
-    const restored = await edgeFunctionService.activateVersion(ref, slug, "7");
+    const restored = await activateConditionalVersion(ref, slug, "7");
     expect(restored).toMatchObject({
       version: "7",
       verify_jwt: false,
@@ -378,7 +410,7 @@ describe("edgeFunctionService bundle metadata", () => {
       })),
     ]);
 
-    const deployed = await edgeFunctionService.deployRelease({
+    const deployed = await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('version-four') };",
@@ -386,7 +418,7 @@ describe("edgeFunctionService bundle metadata", () => {
     });
 
     expect(deployed).toMatchObject({ success: true, version: "4" });
-    const restored = await edgeFunctionService.activateVersion(ref, slug, "3");
+    const restored = await activateConditionalVersion(ref, slug, "3");
     expect(restored).toMatchObject({
       version: "3",
       verify_jwt: false,
@@ -399,7 +431,7 @@ describe("edgeFunctionService bundle metadata", () => {
   test("does not replace a corrupted manifest when deploy policy is omitted", async () => {
     const ref = "proj_corrupt_manifest";
     const slug = "corrupt-hook";
-    await edgeFunctionService.deployRelease({
+    await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('v1') };",
@@ -409,11 +441,11 @@ describe("edgeFunctionService bundle metadata", () => {
     const corruptedManifest = '{"verify_jwt": false';
     await Bun.write(manifestPath, corruptedManifest);
 
-    const failed = await edgeFunctionService.deployRelease({
+    const failed = await edgeFunctionService.deployDetailed(
       ref,
       slug,
-      code: "export default { fetch: () => new Response('v2') };",
-    });
+      "export default { fetch: () => new Response('v2') };",
+    );
 
     expect(failed.success).toBe(false);
     expect(await readFile(manifestPath, "utf8")).toBe(corruptedManifest);
@@ -450,7 +482,7 @@ describe("edgeFunctionService bundle metadata", () => {
   test("reports uncertain runtime state when activation and rollback invalidation both fail", async () => {
     const ref = "proj_manifest_rollback";
     const slug = "public-hook";
-    await edgeFunctionService.deployRelease({
+    await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('v1') };",
@@ -470,7 +502,7 @@ describe("edgeFunctionService bundle metadata", () => {
       return Promise.resolve(Response.json({ message: "unavailable" }, { status: 503 }));
     }) as typeof fetch;
 
-    const failed = await edgeFunctionService.deployRelease({
+    const failed = await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('v2') };",
@@ -515,7 +547,7 @@ describe("edgeFunctionService bundle metadata", () => {
     const v2BundleHash = createHash("sha256").update(v2Bundle).digest("hex");
     const v2SourceHash = createHash("sha256").update(v2Source).digest("hex");
 
-    await edgeFunctionService.activateVersion(ref, slug, "1");
+    await activateConditionalVersion(ref, slug, "1");
 
     const result = await edgeFunctionService.deployBundleDetailed(ref, slug, {
       "index.ts": "export default { fetch: () => new Response('new-v3') };",
@@ -605,6 +637,95 @@ describe("edgeFunctionService bundle metadata", () => {
       await Bun.file(join(functionsRoot, ref, ".versions", slug, singleResult.version!, "index.src.ts")).text(),
     ).toContain("single-marker");
   });
+
+  test("rejects a stale deploy before creating, preheating, or activating a version", async () => {
+    const ref = "proj_stale_deploy";
+    const slug = "stale-deploy";
+    await edgeFunctionService.deployDetailed(
+      ref,
+      slug,
+      "export default { fetch: () => new Response('version-one') };",
+    );
+    let runtimeCalls = 0;
+    globalThis.fetch = (async () => {
+      runtimeCalls += 1;
+      return Response.json({});
+    }) as typeof fetch;
+    const buildSpy = spyOn(Bun, "build");
+
+    try {
+      const rejected = await edgeFunctionService.deployRelease({
+        ref,
+        slug,
+        expectedActiveVersion: "2",
+        code: "export default { fetch: () => new Response('must-not-build') };",
+      });
+
+      expect(rejected).toMatchObject({
+        success: false,
+        error_code: EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
+        expected_active_version: "2",
+        active_version: "1",
+      });
+      expect(buildSpy).not.toHaveBeenCalled();
+      expect(runtimeCalls).toBe(0);
+      expect((await edgeFunctionService.listVersions(ref, slug)).map(({ version }) => version))
+        .toEqual(["1"]);
+      expect(await edgeFunctionService.getConfig(ref, slug)).toMatchObject({ version: "1" });
+    } finally {
+      buildSpy.mockRestore();
+    }
+  });
+
+  test("allows only one concurrent deploy with the same expected active version", async () => {
+    const ref = "proj_cas_concurrent";
+    const slug = "cas-concurrent";
+    await edgeFunctionService.deployDetailed(
+      ref,
+      slug,
+      "export default { fetch: () => new Response('version-one') };",
+    );
+
+    const releases = await Promise.all([
+      edgeFunctionService.deployRelease({
+        ref,
+        slug,
+        expectedActiveVersion: "1",
+        code: "export default { fetch: () => new Response('candidate-a') };",
+      }),
+      edgeFunctionService.deployRelease({
+        ref,
+        slug,
+        expectedActiveVersion: "1",
+        code: "export default { fetch: () => new Response('candidate-b') };",
+      }),
+    ]);
+
+    expect(releases.filter(({ success }) => success)).toHaveLength(1);
+    expect(releases.filter(({ error_code }) =>
+      error_code === EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE)).toHaveLength(1);
+    expect((await edgeFunctionService.listVersions(ref, slug)).map(({ version }) => version))
+      .toEqual(["2", "1"]);
+    expect(await edgeFunctionService.getConfig(ref, slug)).toMatchObject({ version: "2" });
+  });
+
+  test.each(["01", "", "9007199254740992"])(
+    "rejects invalid expected active version %j without mutation",
+    async (expectedActiveVersion) => {
+      const ref = `proj_invalid_expected_${expectedActiveVersion || "empty"}`;
+      const slug = "invalid-expected";
+      const rejected = await edgeFunctionService.deployRelease({
+        ref,
+        slug,
+        expectedActiveVersion,
+        code: "export default { fetch: () => new Response('must-not-deploy') };",
+      });
+
+      expect(rejected.success).toBe(false);
+      expect(await edgeFunctionService.listVersions(ref, slug)).toEqual([]);
+      expect((await edgeFunctionService.getConfig(ref, slug)).version).toBeUndefined();
+    },
+  );
 
   test("keeps multi-file runtime code beside its static assets", async () => {
     globalThis.fetch = ((input, init) => Promise.resolve(Response.json(

--- a/packages/management-api/tests/unit/final-security-regression.test.ts
+++ b/packages/management-api/tests/unit/final-security-regression.test.ts
@@ -4,6 +4,10 @@ import { projectFunctionsRoutes } from "../../src/routes/project-functions";
 import { projectSecretsRoutes } from "../../src/routes/project-secrets";
 import { projectConfigRoutes } from "../../src/routes/project-config";
 import { projectService } from "../../src/services/project.service";
+import {
+  EdgeFunctionActiveVersionConflictError,
+  edgeFunctionService,
+} from "../../src/services/edge-function.service";
 import { runtimeEnvService } from "../../src/services/runtime-env.service";
 import { restoreLogicalBackup } from "../../src/services/backup.service";
 import { sdkProxyInternals } from "../../src/routes/sdk-proxy";
@@ -156,6 +160,8 @@ describe("final security regressions", () => {
   test("function deploy response exposes bundle and preheat metadata", async () => {
     const deploySpy = spyOn(projectService, "deployFunctionRelease").mockResolvedValue({
       success: true,
+      previous_active_version: "2",
+      active_version: "3",
       version: "3",
       bundled: true,
       bundle_hash: "0123456789abcdef",
@@ -184,6 +190,7 @@ describe("final security regressions", () => {
         headers: { ...masterHeaders, "Content-Type": "application/json" },
         body: JSON.stringify({
           code: "export default { fetch() { return new Response('ok') } }",
+          expected_active_version: "2",
           verify_jwt: false,
           background_routes: ["/queue/*"],
         }),
@@ -192,6 +199,10 @@ describe("final security regressions", () => {
       expect(response.status).toBe(200);
       expect(await response.json()).toMatchObject({
         success: true,
+        project_ref: "proj_1",
+        slug: "hello",
+        previous_active_version: "2",
+        active_version: "3",
         bundled: true,
         version: "3",
         bundle_hash: "0123456789abcdef",
@@ -211,6 +222,7 @@ describe("final security regressions", () => {
       expect(deploySpy).toHaveBeenCalledWith({
         ref: "proj_1",
         slug: "hello",
+        expectedActiveVersion: "2",
         code: "export default { fetch() { return new Response('ok') } }",
         minify: false,
         config: { verify_jwt: false, background_routes: ["/queue/*"] },
@@ -220,9 +232,209 @@ describe("final security regressions", () => {
     }
   });
 
+  test("function deploy requires an expected active version before service dispatch", async () => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease");
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/hello", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "export default { fetch() { return new Response('blocked') } }",
+        }),
+      });
+
+      expect(response.status).toBe(422);
+      expect(deploySpy).not.toHaveBeenCalled();
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test("function deploy rejects noncanonical expected active versions before service dispatch", async () => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockRejectedValue(
+      new Error("invalid expected version reached the deploy service"),
+    );
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      for (const expectedActiveVersion of [0, "0", "01", "", "9007199254740992", null]) {
+        const response = await request("/v1/projects/proj_1/functions/hello", {
+          method: "POST",
+          headers: { ...masterHeaders, "Content-Type": "application/json" },
+          body: JSON.stringify({
+            code: "export default { fetch() { return new Response('blocked') } }",
+            expected_active_version: expectedActiveVersion,
+          }),
+        });
+
+        expect(response.status).toBeGreaterThanOrEqual(400);
+      }
+      expect(deploySpy).not.toHaveBeenCalled();
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test("function deploy maps active version conflicts to HTTP 409", async () => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockResolvedValue({
+      success: false,
+      error_code: "FUNCTION_ACTIVE_VERSION_CONFLICT",
+      expected_active_version: "2",
+      active_version: "3",
+      error: "Function active version changed before the requested mutation",
+    });
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/hello", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "export default { fetch() { return new Response('blocked') } }",
+          expected_active_version: "2",
+        }),
+      });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toMatchObject({
+        code: "FUNCTION_ACTIVE_VERSION_CONFLICT",
+        expected_active_version: "2",
+        active_version: "3",
+      });
+      expect(deploySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test("bulk function deploy maps active version conflicts to HTTP 409", async () => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockResolvedValue({
+      success: false,
+      error_code: "FUNCTION_ACTIVE_VERSION_CONFLICT",
+      expected_active_version: "2",
+      active_version: "3",
+      error: "Function active version changed before the requested mutation",
+    });
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions", {
+        method: "PUT",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify([{
+          slug: "hello",
+          code: "export default { fetch() { return new Response('blocked') } }",
+          expected_active_version: "2",
+        }]),
+      });
+
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({
+        functions: [expect.objectContaining({
+          slug: "hello",
+          success: false,
+          error_code: "FUNCTION_ACTIVE_VERSION_CONFLICT",
+          active_version: "3",
+        })],
+      });
+      expect(deploySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test("function activation requires and enforces expected active version", async () => {
+    const activationSpy = spyOn(edgeFunctionService, "activateVersion");
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const missing = await request(
+        "/v1/projects/proj_1/functions/hello/versions/2/activate",
+        { method: "POST", headers: masterHeaders },
+      );
+      expect(missing.status).toBe(422);
+      expect(activationSpy).not.toHaveBeenCalled();
+
+      activationSpy.mockRejectedValueOnce(new EdgeFunctionActiveVersionConflictError("1", "2"));
+      const stale = await request(
+        "/v1/projects/proj_1/functions/hello/versions/3/activate",
+        {
+          method: "POST",
+          headers: { ...masterHeaders, "Content-Type": "application/json" },
+          body: JSON.stringify({ expected_active_version: "1" }),
+        },
+      );
+      expect(stale.status).toBe(409);
+      expect(await stale.json()).toMatchObject({
+        code: "FUNCTION_ACTIVE_VERSION_CONFLICT",
+        expected_active_version: "1",
+        active_version: "2",
+      });
+      expect(activationSpy).toHaveBeenCalledWith("proj_1", "hello", "3", "1");
+    } finally {
+      activationSpy.mockRestore();
+    }
+  });
+
+  test("function activation rejects noncanonical target versions before service dispatch", async () => {
+    const activationSpy = spyOn(edgeFunctionService, "activateVersion").mockRejectedValue(
+      new Error("invalid target version reached the activation service"),
+    );
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      for (const targetVersion of ["01", "9007199254740992"]) {
+        const response = await request(
+          `/v1/projects/proj_1/functions/hello/versions/${targetVersion}/activate`,
+          {
+            method: "POST",
+            headers: { ...masterHeaders, "Content-Type": "application/json" },
+            body: JSON.stringify({ expected_active_version: "1" }),
+          },
+        );
+
+        expect(response.status).toBeGreaterThanOrEqual(400);
+      }
+      expect(activationSpy).not.toHaveBeenCalled();
+    } finally {
+      activationSpy.mockRestore();
+    }
+  });
+
+  test("function activation rejects public version zero with HTTP 400 before service dispatch", async () => {
+    const activationSpy = spyOn(edgeFunctionService, "activateVersion").mockRejectedValue(
+      new Error("legacy target reached the public activation service"),
+    );
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request(
+        "/v1/projects/proj_1/functions/hello/versions/0/activate",
+        {
+          method: "POST",
+          headers: { ...masterHeaders, "Content-Type": "application/json" },
+          body: JSON.stringify({ expected_active_version: "1" }),
+        },
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        message: "version must be a canonical positive safe integer",
+        code: "VALIDATION_ERROR",
+      });
+      expect(activationSpy).not.toHaveBeenCalled();
+    } finally {
+      activationSpy.mockRestore();
+    }
+  });
+
   test("all code deploy routes pass policy through the atomic release primitive", async () => {
     const deploySpy = spyOn(projectService, "deployFunctionRelease").mockImplementation(async (release) => ({
       success: true,
+      previous_active_version: release.expectedActiveVersion,
+      active_version: "4",
       version: "4",
       bundled: "files" in release,
       files: "files" in release ? Object.keys(release.files).length : undefined,
@@ -241,6 +453,7 @@ describe("final security regressions", () => {
         headers: jsonHeaders,
         body: JSON.stringify({
           files: { "index.ts": "export default { fetch() { return new Response('bundle') } }" },
+          expected_active_version: "absent",
           verify_jwt: false,
         }),
       });
@@ -249,6 +462,7 @@ describe("final security regressions", () => {
         headers: jsonHeaders,
         body: JSON.stringify({
           code: "export default { fetch() { return new Response('patch') } }",
+          expected_active_version: "absent",
           verify_jwt: false,
         }),
       });
@@ -258,11 +472,16 @@ describe("final security regressions", () => {
         body: JSON.stringify([{
           slug: "bulk-fn",
           code: "export default { fetch() { return new Response('bulk') } }",
+          expected_active_version: "absent",
           verify_jwt: false,
         }]),
       });
       const multipart = new FormData();
-      multipart.set("metadata", JSON.stringify({ entrypoint_path: "index.ts", verify_jwt: false }));
+      multipart.set("metadata", JSON.stringify({
+        entrypoint_path: "index.ts",
+        expected_active_version: "absent",
+        verify_jwt: false,
+      }));
       multipart.set("file", new File([
         "export default { fetch() { return new Response('multipart') } }",
       ], "index.ts", { type: "application/typescript" }));

--- a/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
@@ -405,11 +405,22 @@ export async function waitForTask(
     }
   }
 
+  function activeVersionForSlug(slug: string): string {
+    const activeVersion = functions.find((fn) => fn.slug === slug)?.version;
+    if (typeof activeVersion !== "number" || !Number.isSafeInteger(activeVersion) || activeVersion < 1) {
+      throw new Error("当前函数激活版本无效，请刷新后重试");
+    }
+    return String(activeVersion);
+  }
+
   async function activateFunctionVersion(slug: string, version: string) {
     versionSwitching = version;
     try {
+      const expectedActiveVersion = activeVersionForSlug(slug);
       const res = await apiClient(`/v1/projects/${projectRef}/functions/${encodeURIComponent(slug)}/versions/${encodeURIComponent(version)}/activate`, {
         method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ expected_active_version: expectedActiveVersion }),
       });
       const payload = await res.json().catch(() => null);
       if (!res.ok) {
@@ -417,6 +428,9 @@ export async function waitForTask(
       }
 
       toast.success(`${slug} 已切换到 v${version}`);
+      if (selectedFunction?.slug === slug) {
+        selectedFunction = { ...selectedFunction, version: Number(version) };
+      }
       await Promise.all([
         loadFunctionVersions(slug),
         query.refetch(),
@@ -502,7 +516,7 @@ export async function waitForTask(
       const res = await apiClient(`/v1/projects/${projectRef}/functions/${newSlug}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code: newCode }),
+        body: JSON.stringify({ code: newCode, expected_active_version: "absent" }),
       });
       if (!res.ok) {
         const err = await res.json();
@@ -985,7 +999,8 @@ export async function waitForTask(
                         </button>
                         <button
                           onclick={() => activateFunctionVersion(currentDrawerSlug, versionRecord.version)}
-                          disabled={versionRecord.is_active || versionSwitching === versionRecord.version}
+                          disabled={versionRecord.version === "0" || versionRecord.is_active || versionSwitching === versionRecord.version}
+                          title={versionRecord.version === "0" ? "兼容版本 v0 仅供服务内部恢复" : "切换到此版本"}
                           class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-semibold hover:bg-muted/40 transition-colors disabled:opacity-50"
                         >
                           {#if versionSwitching === versionRecord.version}

--- a/packages/web-console/src/routes/project/[ref]/functions/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/functions/page.test.ts
@@ -24,4 +24,11 @@ describe("edge function JWT toggle", () => {
     expect(source).toContain('$t("Functions.endpoint")');
     expect(source).toContain('$t("Functions.last_deploy")');
   });
+
+  test("binds create and version activation requests to the observed active version", () => {
+    expect(source).toContain('expected_active_version: "absent"');
+    expect(source).toContain("activeVersionForSlug(slug)");
+    expect(source).toContain("expected_active_version: expectedActiveVersion");
+    expect(source).toContain('versionRecord.version === "0"');
+  });
 });


### PR DESCRIPTION
## Summary

- add active-version compare-and-set requirements to every public Function deploy and activation route
- add identity-bound, machine-readable CLI receipts and fail closed on stale, ambiguous, or malformed mutation outcomes
- add immutable `edge_functions source --version <N>` readback with exclusive output-file creation and A-to-B-to-A coverage
- keep legacy version `0` service-internal while rejecting it at the public CLI/API boundary
- bind Web Console create/activation requests to the observed active version

## Public contract

- `deploy`, `deploy_bundle`, and `activate` require `--expected-active-version <positive N|absent>`
- stale mutations return HTTP 409 with `FUNCTION_ACTIVE_VERSION_CONFLICT` before build, preheat, artifact creation, or manifest mutation
- successful CLI mutations emit the exact `supacloud.cli.release-control.v1` receipt with project, slug, previous/active version, version, and `verify_jwt`
- HTTP 408/5xx, transport failures, and malformed 2xx receipts return `OUTCOME_UNKNOWN` without reflecting server response bodies
- `source --version <positive N>` reads the immutable version endpoint; `--output` uses exclusive create and never overwrites

## Verification

- CLI full suite: 445 passed, 0 failed
- Management targeted Function suite: 62 passed, 0 failed
- Management full unit command: passed (shared batch 1319 passed; all isolated batches passed)
- Web Function tests: 4 passed, 0 failed
- CLI and Management typechecks: passed
- CLI build: passed
- Web `svelte-check`: 0 errors, 0 warnings
- Web production build: passed
- `git diff --check`: passed

## Scope

This PR does not merge, release, or deploy any component.
