### PR TITLE
fix(cli): fail early on migration identity conflicts

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -186,6 +186,11 @@ stale revisions with HTTP 409. Delete additionally requires `require_empty=true`
 it never empties a bucket. Mutation receipts bind `project_ref`, `bucket_id`,
 `previous_revision`, and `new_revision` (`null` after delete).
 
+`database push_migrations` rejects a remote row that reuses a local migration
+name with another version, or a local version with another name, before either
+dry-run reporting or apply can continue. This keeps the preview consistent with
+the server conflict that would otherwise occur after deployment starts.
+
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
 Bun and runs a local syntax check before upload. The Management API validates and
 normalizes the final server-side artifact against the multi-tenant Edge Runtime

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -313,6 +313,37 @@ describe("database migration helpers", () => {
         }
     });
 
+    test("rejects migration identity conflicts before dry-run or apply", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const postedNames: string[] = [];
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [
+                        { version: "1785220280", name: "20260425123000_create_users" },
+                        { version: "20260425124000", name: "20260425124000_renamed_tasks" },
+                    ],
+                }),
+                post: async (_path: string, body: { name: string }) => {
+                    postedNames.push(body.name);
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            await expect(callback({ action: "push_migrations", ref: "proj", dir, dry_run: true }))
+                .rejects.toThrow("Migration identity conflicts");
+            await expect(callback({ action: "push_migrations", ref: "proj", dir }))
+                .rejects.toThrow("20260425123000_create_users.sql (20260425123000) conflicts with remote");
+            expect(postedNames).toHaveLength(0);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     test("skips only the exact already-applied migration response", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         try {
@@ -431,9 +462,9 @@ describe("database migration helpers", () => {
                             statements: ["direct-apply:20260425123000_create_users"],
                         },
                         {
-                            version: "20260425125000",
-                            name: "20260425125000_renamed_reports",
-                            statements: ["direct-apply:20260425125000_renamed_reports"],
+                            version: "20260425125099",
+                            name: "20260425125099_renamed_reports",
+                            statements: ["direct-apply:20260425125099_renamed_reports"],
                         },
                         {
                             version: "20260425126000",
@@ -442,8 +473,8 @@ describe("database migration helpers", () => {
                         },
                         {
                             version: "20260425127001",
-                            name: "20260425127000_create_metrics",
-                            statements: ["direct-apply:20260425127000_create_metrics"],
+                            name: "20260425127001_renamed_metrics",
+                            statements: ["direct-apply:20260425127001_renamed_metrics"],
                         },
                         {
                             version: "20260425128000",

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -220,6 +220,45 @@ function migrationIdentityKey(version: string, name: string): string {
     return `${version}\u0000${name}`;
 }
 
+type MigrationIdentity = { name: string; version: string };
+type MigrationIdentityConflict = {
+    file: string;
+    local: MigrationIdentity;
+    remote: MigrationIdentity;
+};
+
+function migrationIdentities(data: unknown): MigrationIdentity[] {
+    return migrationRows(data).flatMap((row) => (
+        row.version == null || row.name == null
+            ? []
+            : [{ version: String(row.version), name: String(row.name) }]
+    ));
+}
+
+function identityConflicts(local: MigrationIdentity, remote: MigrationIdentity): boolean {
+    const reusesVersionOrName = local.version === remote.version || local.name === remote.name;
+    const exactlyMatches = local.version === remote.version && local.name === remote.name;
+    return reusesVersionOrName && !exactlyMatches;
+}
+
+function migrationIdentityConflicts(data: unknown, migrationFiles: MigrationFile[]): MigrationIdentityConflict[] {
+    const remoteMigrations = migrationIdentities(data);
+    return migrationFiles.flatMap((localMigration) => remoteMigrations
+        .filter((remoteMigration) => identityConflicts(localMigration, remoteMigration))
+        .map((remoteMigration) => ({ file: localMigration.file, local: localMigration, remote: remoteMigration })));
+}
+
+function assertNoMigrationIdentityConflicts(data: unknown, migrationFiles: MigrationFile[]): void {
+    const conflicts = migrationIdentityConflicts(data, migrationFiles);
+    if (!conflicts.length) return;
+    throw new Error([
+        "Migration identity conflicts:",
+        ...conflicts.map(({ file, local, remote }) => (
+            `- ${file} (${local.version}) conflicts with remote ${remote.name} (${remote.version})`
+        )),
+    ].join("\n"));
+}
+
 function nameBoundMigrationMarkerKeys(data: unknown): Set<string> {
     const keys = new Set<string>();
     for (const row of migrationRows(data)) {
@@ -509,6 +548,8 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         text = `❌ Failed to load applied migrations (${migrationsResult.status}): ${JSON.stringify(migrationsResult.data)}`;
                         break;
                     }
+
+                    assertNoMigrationIdentityConflicts(migrationsResult.data, migrationFiles);
 
                     if (args.dry_run) {
                         const appliedKeys = appliedMigrationKeys(migrationsResult.data);


### PR DESCRIPTION
## Summary

- detect remote migration rows that reuse a local name with another version, or a local version with another name
- fail both `database push_migrations --dry_run` and apply before any migration POST
- document the fail-closed behavior and keep conflict output limited to migration names/versions

This fixes a production-observed mismatch where dry-run reported a legacy same-name row as already applied, but apply later failed with `migration_checksum_conflict`.

## Validation

- `bun test packages/cli/src`: 396 pass / 0 fail
- `bun run --cwd packages/cli typecheck`: pass
- `bun run --cwd packages/cli build`: pass
- `git diff --check`: pass
- `clean-code-guard: clean`
