### PR TITLE
feat(functions): deploy exact prebuilt artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ supacloud-cli frontend list --ref <ref>
 supacloud-cli edge_functions list --ref <ref>
 supacloud-cli edge_functions source --ref <ref> --slug hello --version 1 --output ./hello-v1.ts
 supacloud-cli edge_functions deploy --ref <ref> --slug hello --path ./supabase/functions/hello --expected-active-version absent
+supacloud-cli edge_functions deploy --ref <ref> --slug hello --prebundled-path ./dist/hello.js --expected-sha256 <sha256> --expected-active-version 1
 supacloud-cli edge_functions activate --ref <ref> --slug hello --version 2 --expected-active-version 3
 supacloud-cli storage list_buckets --ref <ref>
 ```
@@ -330,6 +331,11 @@ Function deploy and activation commands require the active version observed via
 return HTTP 409 and successful mutations emit a
 `supacloud.cli.release-control.v1` receipt. Pass the observed version to
 `edge_functions source --version <N>` for an immutable, ABA-safe source backup.
+Use `deploy --prebundled-path` with the required lowercase
+`--expected-sha256` when a release pipeline must upload an already-built runtime
+artifact without local or server rebundling. The mode rejects caller-hash,
+file-stability, UTF-8, runtime-policy, and normalization mismatches before
+activation.
 Version `0` is reserved for service-internal legacy recovery and is not a valid
 public CLI/API activation target or expected active version.
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -261,6 +261,13 @@ Management API applies the Edge Runtime module policy to the final server-side
 artifact for CLI, Web Console, and direct API deployments alike. For
 `deploy_bundle`, pass the file map as JSON, for example
 `--files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}'`.
+Release automation that already has a final runtime artifact can use
+`edge_functions deploy --prebundled-path <file> --expected-sha256 <sha256>`.
+The lowercase SHA-256 binds the caller-approved bytes before any request. The
+CLI reads through a held regular-file descriptor and rejects file drift or
+non-round-trippable UTF-8; the server independently validates the digest and
+runtime policy and rejects any normalization change instead of rebundling.
+This mode cannot be combined with `--path`, `--code`, or `--minify`.
 Use `edge_functions source --slug <name> --version <N> --output <file>` to read back large
 Function sources without depending on terminal capture limits. The CLI writes
 the complete original TS/JS source code and refuses to overwrite an existing

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **cli:** add atomic named and explicit environment profiles with secret-safe status output
+* **functions:** deploy caller-hash-bound prebuilt runtime artifacts without rebundling
 
 ### Bug Fixes
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -156,6 +156,7 @@ supacloud-cli branch create --name feature-orders --data_mode schema_only
 supacloud-cli branch promotion_plan --branch_ref preview123
 supacloud-cli branch promote --branch_ref preview123 --plan_checksum <sha256>
 supacloud-cli edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello --expected-active-version absent
+supacloud-cli edge_functions deploy --ref abc123 --slug hello --prebundled-path ./dist/hello.js --expected-sha256 <sha256> --expected-active-version 4
 supacloud-cli edge_functions deploy_bundle --ref abc123 --slug hello --files '{"index.ts":"export default { fetch: () => new Response(\"ok\") }"}' --expected-active-version 7
 supacloud-cli edge_functions source --ref abc123 --slug hello --version 7 --output ./hello-v7.ts
 supacloud-cli edge_functions activate --ref abc123 --slug hello --version 3 --expected-active-version 8
@@ -189,6 +190,15 @@ it never empties a bucket. Mutation receipts bind `project_ref`, `bucket_id`,
 Bun and runs a local syntax check before upload. The Management API validates and
 normalizes the final server-side artifact against the multi-tenant Edge Runtime
 module policy consistently for CLI, Web Console, and direct API deployments.
+For an artifact already built and validated by release automation, use
+`deploy --prebundled-path <file> --expected-sha256 <64-lowercase-hex>`. The CLI
+holds the opened regular file while reading it, rejects metadata drift, invalid
+UTF-8, or a caller-hash mismatch before HTTP, and never passes the artifact in
+the process argument list. The Management API validates the hash and runtime
+policy again, rejects any normalization that would change the code, and stores
+the submitted bytes unchanged as both immutable source and runtime artifact.
+`--prebundled-path` is mutually exclusive with `--path`, `--code`, and
+`--minify`.
 `deploy_bundle --files` accepts a JSON object in shell usage.
 Use `source --output <file>` for large Functions so terminal or automation output
 limits cannot truncate the original TS/JS source code. The destination must not

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -828,6 +829,104 @@ describe("supacloud-cli process contract", () => {
             expect(response.stderr).toContain("--expected-active-version");
             expect(response.stderr).not.toContain("--expected_active_version");
         }
+    });
+
+    test("documents exact prebundled Function deployment flags", async () => {
+        const response = await runProjectCli(["edge_functions", "deploy", "--help"], {
+            SUPACLOUD_API_URL: "http://127.0.0.1:1",
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("--prebundled-path");
+        expect(response.stderr).toContain("--expected-sha256");
+        expect(response.stderr).not.toContain("--prebundled_path");
+        expect(response.stderr).not.toContain("--expected_sha256");
+    });
+
+    test("deploys exact verified prebundled Function bytes through the process CLI", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-cli-prebundled-"));
+        temporaryDirectories.push(directory);
+        const bundlePath = join(directory, "fa-api.js");
+        const code = "export default { fetch: () => new Response('exact-process-bytes') };\r\n";
+        const expectedSha256 = createHash("sha256").update(code).digest("hex");
+        writeFileSync(bundlePath, code);
+        let requestBody: Record<string, unknown> | undefined;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                requestBody = await request.json() as Record<string, unknown>;
+                return Response.json({
+                    success: true,
+                    project_ref: "abc123",
+                    slug: "fa-api",
+                    previous_active_version: "7",
+                    active_version: "8",
+                    version: "8",
+                    config: { version: "8", verify_jwt: true },
+                });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli([
+            "edge_functions", "deploy", "--ref", "abc123", "--slug", "fa-api",
+            "--prebundled-path", bundlePath,
+            "--expected-sha256", expectedSha256,
+            "--expected-active-version", "7",
+        ], {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            PATH: "",
+        });
+
+        expect(response.exitCode).toBe(0);
+        expect(requestBody).toEqual({
+            code,
+            prebundled: true,
+            expected_sha256: expectedSha256,
+            expected_active_version: "7",
+        });
+        expect(JSON.parse(response.stdout)).toMatchObject({
+            ok: true,
+            operation: "edge_functions.deploy",
+            active_version: "8",
+        });
+    });
+
+    test("rejects a prebundled hash mismatch before the process CLI sends HTTP", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-cli-prebundled-mismatch-"));
+        temporaryDirectories.push(directory);
+        const bundlePath = join(directory, "fa-api.js");
+        writeFileSync(bundlePath, "export default { fetch: () => new Response('replaced') };\n");
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli([
+            "edge_functions", "deploy", "--ref", "abc123", "--slug", "fa-api",
+            "--prebundled-path", bundlePath,
+            "--expected-sha256", createHash("sha256").update("approved-bytes").digest("hex"),
+            "--expected-active-version", "absent",
+        ], {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stderr).toContain("SHA-256 does not match");
+        expect(requestCount).toBe(0);
     });
 
     test("deploys a Function bundle with an identity-bound CAS receipt", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -222,6 +222,7 @@ EXAMPLES
   ${preferredCommand} ai show_skill
   ${preferredCommand} ai install_skill --dry_run
   ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello --expected-active-version absent
+  ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --prebundled-path ./dist/hello.js --expected-sha256 <sha256> --expected-active-version 4
   ${preferredCommand} edge_functions activate --ref abc123 --slug hello --version 3 --expected-active-version 4
   ${preferredCommand} scheduled_functions list --ref abc123
   ${preferredCommand} edge_functions config --ref abc123 --slug hello --verify_jwt false --background_routes "/queue/*,/render/*"

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { registerAdvancedTools } from "./advanced-tools";
 import { parseToolArguments } from "../schema";
 import type { ToolSchema } from "../schema";
@@ -375,6 +379,150 @@ describe("edge_functions CLI tool", () => {
             expect(requestCount).toBe(0);
         },
     );
+
+    test("uploads verified prebundled bytes without minify or local bundling fields", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-prebundled-cli-"));
+        const bundlePath = join(directory, "fa-api.js");
+        const code = "export default { fetch: () => new Response('精确字节') };\r\n";
+        const expectedSha256 = createHash("sha256").update(code).digest("hex");
+        writeFileSync(bundlePath, code);
+        let requestBody: Record<string, unknown> | undefined;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async (_path: string, body: Record<string, unknown>) => {
+                requestBody = body;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        success: true,
+                        project_ref: "proj",
+                        slug: "fa-api",
+                        previous_active_version: "3",
+                        active_version: "4",
+                        version: "4",
+                        config: { version: "4", verify_jwt: true },
+                    },
+                };
+            },
+        });
+
+        try {
+            const response = await callback({
+                action: "deploy",
+                ref: "proj",
+                slug: "fa-api",
+                "prebundled-path": bundlePath,
+                "expected-sha256": expectedSha256,
+                "expected-active-version": "3",
+            });
+
+            expect(requestBody).toEqual({
+                code,
+                prebundled: true,
+                expected_sha256: expectedSha256,
+                expected_active_version: "3",
+            });
+            expect(JSON.parse(response.content[0].text)).toMatchObject({
+                ok: true,
+                operation: "edge_functions.deploy",
+                active_version: "4",
+            });
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects a prebundled file replaced after caller hashing before HTTP dispatch", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-prebundled-replaced-"));
+        const bundlePath = join(directory, "fa-api.js");
+        const approvedCode = "export default { fetch: () => new Response('approved') };\n";
+        const expectedSha256 = createHash("sha256").update(approvedCode).digest("hex");
+        writeFileSync(bundlePath, "export default { fetch: () => new Response('replaced') };\n");
+        let requestCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        try {
+            await expect(callback({
+                action: "deploy",
+                ref: "proj",
+                slug: "fa-api",
+                "prebundled-path": bundlePath,
+                "expected-sha256": expectedSha256,
+                "expected-active-version": "absent",
+            })).rejects.toThrow("SHA-256 does not match");
+            expect(requestCount).toBe(0);
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects invalid UTF-8 and non-regular prebundled inputs before HTTP dispatch", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-prebundled-invalid-"));
+        const invalidUtf8Path = join(directory, "invalid.js");
+        const nestedDirectory = join(directory, "directory.js");
+        const invalidUtf8 = Buffer.from([0xc3, 0x28]);
+        writeFileSync(invalidUtf8Path, invalidUtf8);
+        mkdirSync(nestedDirectory);
+        let requestCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        try {
+            await expect(callback({
+                action: "deploy",
+                ref: "proj",
+                slug: "fa-api",
+                "prebundled-path": invalidUtf8Path,
+                "expected-sha256": createHash("sha256").update(invalidUtf8).digest("hex"),
+                "expected-active-version": "absent",
+            })).rejects.toThrow("valid UTF-8");
+            await expect(callback({
+                action: "deploy",
+                ref: "proj",
+                slug: "fa-api",
+                "prebundled-path": nestedDirectory,
+                "expected-sha256": "0".repeat(64),
+                "expected-active-version": "absent",
+            })).rejects.toThrow("regular file");
+            expect(requestCount).toBe(0);
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    test.each([
+        ["code and path", { code: "export default {};", path: "function.ts" }],
+        ["path and prebundled path", { path: "function.ts", "prebundled-path": "bundle.js", "expected-sha256": "0".repeat(64) }],
+        ["prebundled path without hash", { "prebundled-path": "bundle.js" }],
+        ["hash without prebundled path", { code: "export default {};", "expected-sha256": "0".repeat(64) }],
+        ["prebundled path with minify", { "prebundled-path": "bundle.js", "expected-sha256": "0".repeat(64), minify: false }],
+    ])("rejects %s before HTTP dispatch", async (_label, deploymentInput) => {
+        let requestCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        await expect(callback({
+            action: "deploy",
+            ref: "proj",
+            slug: "fa-api",
+            "expected-active-version": "absent",
+            ...deploymentInput,
+        })).rejects.toThrow();
+        expect(requestCount).toBe(0);
+    });
 
     test("sends bundle config inline without a follow-up PATCH", async () => {
         const calls: Array<{ method: string; path: string; body: unknown }> = [];

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -1,7 +1,19 @@
 /**
  * Advanced — Split into 3 compound tools: edge_functions, secrets, platform
  */
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createHash, timingSafeEqual } from "node:crypto";
+import {
+    closeSync,
+    constants as fsConstants,
+    existsSync,
+    fstatSync,
+    mkdtempSync,
+    openSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { promisify } from "node:util";
@@ -18,6 +30,77 @@ import {
 } from "./release-control-response";
 
 const execFileAsync = promisify(execFile);
+const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+
+type OpenFileIdentity = {
+    dev: bigint;
+    ino: bigint;
+    size: bigint;
+    mtimeNs: bigint;
+    ctimeNs: bigint;
+};
+
+function openFileIdentity(descriptor: number): OpenFileIdentity {
+    const state = fstatSync(descriptor, { bigint: true });
+    if (!state.isFile()) throw new Error("Prebundled path must be a regular file");
+    return {
+        dev: state.dev,
+        ino: state.ino,
+        size: state.size,
+        mtimeNs: state.mtimeNs,
+        ctimeNs: state.ctimeNs,
+    };
+}
+
+function sameOpenFile(left: OpenFileIdentity, right: OpenFileIdentity): boolean {
+    return left.dev === right.dev
+        && left.ino === right.ino
+        && left.size === right.size
+        && left.mtimeNs === right.mtimeNs
+        && left.ctimeNs === right.ctimeNs;
+}
+
+function verifiedUtf8Code(bytes: Buffer): string {
+    let code: string;
+    try {
+        code = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch (error) {
+        if (error instanceof TypeError) throw new Error("Prebundled file is not valid UTF-8");
+        throw error;
+    }
+    if (!Buffer.from(code, "utf8").equals(bytes)) {
+        throw new Error("Prebundled file does not round-trip as UTF-8");
+    }
+    return code;
+}
+
+function assertExpectedSha256(bytes: Buffer, expectedSha256: string): void {
+    if (!SHA256_HEX_PATTERN.test(expectedSha256)) {
+        throw new Error("'--expected-sha256' must be a lowercase 64-character SHA-256");
+    }
+    const actualDigest = createHash("sha256").update(bytes).digest();
+    const expectedDigest = Buffer.from(expectedSha256, "hex");
+    if (!timingSafeEqual(actualDigest, expectedDigest)) {
+        throw new Error("Prebundled file SHA-256 does not match --expected-sha256");
+    }
+}
+
+function readVerifiedPrebundledCode(pathArg: string, expectedSha256: string): string {
+    const descriptor = openSync(resolve(pathArg), fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
+    try {
+        const identityBeforeRead = openFileIdentity(descriptor);
+        const bytes = readFileSync(descriptor);
+        const identityAfterRead = openFileIdentity(descriptor);
+        if (BigInt(bytes.byteLength) !== identityBeforeRead.size
+            || !sameOpenFile(identityBeforeRead, identityAfterRead)) {
+            throw new Error("Prebundled file changed while it was being read");
+        }
+        assertExpectedSha256(bytes, expectedSha256);
+        return verifiedUtf8Code(bytes);
+    } finally {
+        closeSync(descriptor);
+    }
+}
 
 async function runBunBuild(args: string[]): Promise<{ stdout: string; stderr: string }> {
     try {
@@ -41,6 +124,64 @@ async function bundleEdgeFunctionPath(pathArg: string): Promise<string> {
         return readFileSync(outfile, "utf-8");
     } finally {
         rmSync(tmpDir, { recursive: true, force: true });
+    }
+}
+
+type PreparedDeployCode =
+    | { code: string; prebundled: false }
+    | { code: string; prebundled: true; expectedSha256: string };
+
+function prebundledDeployCode(
+    pathArg: string,
+    expectedSha256: unknown,
+    minify: unknown,
+): PreparedDeployCode {
+    if (typeof expectedSha256 !== "string") {
+        throw new Error("'--expected-sha256' required with '--prebundled-path'");
+    }
+    if (minify !== undefined) {
+        throw new Error("'--minify' cannot be combined with '--prebundled-path'");
+    }
+    return {
+        code: readVerifiedPrebundledCode(pathArg, expectedSha256),
+        prebundled: true,
+        expectedSha256,
+    };
+}
+
+async function preparedDeployCode(args: Record<string, unknown>): Promise<PreparedDeployCode> {
+    const codeArg = args.code;
+    const pathArg = args.path;
+    const prebundledPath = args["prebundled-path"];
+    const sources = [codeArg, pathArg, prebundledPath].filter((source) => source !== undefined);
+    if (sources.length !== 1) {
+        throw new Error("Exactly one of '--code', '--path', or '--prebundled-path' is required for 'deploy'");
+    }
+    if (typeof prebundledPath === "string") {
+        return prebundledDeployCode(prebundledPath, args["expected-sha256"], args.minify);
+    }
+    if (args["expected-sha256"] !== undefined) {
+        throw new Error("'--expected-sha256' requires '--prebundled-path'");
+    }
+    if (typeof codeArg === "string") return { code: codeArg, prebundled: false };
+    if (typeof pathArg !== "string") throw new Error("Function deploy source is invalid");
+    return bundledDeployCode(pathArg);
+}
+
+async function bundledDeployCode(pathArg: string): Promise<PreparedDeployCode> {
+    try {
+        return { code: await bundleEdgeFunctionPath(pathArg), prebundled: false };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to bundle/read path ${pathArg}: ${message}`);
+    }
+}
+
+function rejectPrebundledFlagsOutsideDeploy(action: string, args: Record<string, unknown>): void {
+    for (const flag of ["prebundled-path", "expected-sha256"]) {
+        if (action !== "deploy" && args[flag] !== undefined) {
+            throw new Error(`'--${flag}' is not supported for '${action}'`);
+        }
     }
 }
 
@@ -528,7 +669,7 @@ export function registerAdvancedTools(
     // ═══ Edge Functions (8→1) ═══
     server.tool(
         "edge_functions",
-        `Edge Function management (Deno/Bun serverless). Server auto-bundles dependencies.
+        `Edge Function management (Deno/Bun serverless). Source deploys are bundled; verified prebuilt artifacts stay byte-exact.
 Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
         {
             action: withDescription(stringEnum(["list", "deploy", "deploy_bundle", "config", "source", "activate", "delete", "check"]), "Action"),
@@ -537,6 +678,14 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
             version: withDescription(functionVersionSchema, "[source/activate] Existing immutable Function version; source requires a positive version"),
             code: optional(Type.String(), "[deploy/check] Function source code (TypeScript)"),
             path: optional(Type.String(), "[deploy/check] Local file path to read code from (alternative to code)"),
+            "prebundled-path": optional(
+                Type.String(),
+                "[deploy] Prebuilt runtime bundle to upload without rebuilding; requires expected-sha256",
+            ),
+            "expected-sha256": optional(
+                Type.String({ pattern: SHA256_HEX_PATTERN.source, minLength: 64, maxLength: 64 }),
+                "[deploy] Required lowercase SHA-256 of the exact prebundled-path bytes",
+            ),
             output: optional(Type.String(), "[source] Write source to this local file instead of stdout; the file must not already exist"),
             files: optional(functionFilesSchema, "[deploy_bundle] File map as a JSON object: { 'index.ts': '...', '_shared/x.ts': '...' }"),
             entrypoint: optional(Type.String(), "[deploy_bundle] Entrypoint file (default: index.ts)"),
@@ -551,6 +700,7 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
         async (args: any) => {
             if (args.action === "activate") return activateFunctionVersion(http, args, options.readOnly);
             const { action, ref, slug, path: pathArg, output, files, entrypoint, minify, verify_jwt, background_routes } = args;
+            rejectPrebundledFlagsOutsideDeploy(action, args);
             const expectedActiveVersion = action === "deploy" || action === "deploy_bundle"
                 ? requiredExpectedActiveVersion(args, action)
                 : undefined;
@@ -591,7 +741,7 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
                 }
             };
 
-            if (pathArg && !code) {
+            if (action === "check" && pathArg && !code) {
                 try {
                     code = await bundleEdgeFunctionPath(pathArg);
                 } catch (error: unknown) {
@@ -613,15 +763,20 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
                     }
                     break;
                 case "deploy":
-                    need("slug", slug); need("code", code);
-                    const deployCheck = await checkSyntax(code!);
-                    if (!deployCheck.ok) {
-                        text = `❌ Deployment aborted. Syntax check failed:\n${deployCheck.err}`;
-                        break;
+                    need("slug", slug);
+                    const deployCode = await preparedDeployCode(args);
+                    if (!deployCode.prebundled) {
+                        const deployCheck = await checkSyntax(deployCode.code);
+                        if (!deployCheck.ok) {
+                            text = `❌ Deployment aborted. Syntax check failed:\n${deployCheck.err}`;
+                            break;
+                        }
                     }
                     const deploymentResponse = await http.post(edgeFunctionResourcePath(ref, slug), {
-                        code,
-                        minify,
+                        code: deployCode.code,
+                        ...(deployCode.prebundled
+                            ? { prebundled: true, expected_sha256: deployCode.expectedSha256 }
+                            : { minify }),
                         expected_active_version: expectedActiveVersion,
                         ...functionConfig(),
                     });

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -4,7 +4,9 @@ import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { isUserManagedFunctionSecretName } from "../utils/project-secret-visibility";
 import {
   EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
+  EDGE_FUNCTION_SHA256_HEX_PATTERN,
   EdgeFunctionActiveVersionConflictError,
+  isCanonicalEdgeFunctionSha256,
   type EdgeFunctionActiveVersion,
   type EdgeFunctionDeploymentConfig,
   type EdgeFunctionDeployResult,
@@ -77,6 +79,31 @@ function functionVersion(value: unknown): string | null {
 function invalidExpectedActiveVersion() {
   return status(400, {
     message: "expected_active_version must be a canonical positive safe integer or 'absent'",
+    code: "VALIDATION_ERROR",
+  });
+}
+
+type FunctionCodeDeploymentOptions =
+  | { minify: boolean }
+  | { prebundled: true; expectedSha256: string };
+
+function functionCodeDeploymentOptions(body: {
+  prebundled?: boolean;
+  expected_sha256?: string;
+  minify?: boolean;
+}): FunctionCodeDeploymentOptions | null {
+  if (body.prebundled === true) {
+    if (body.minify !== undefined || !body.expected_sha256
+      || !isCanonicalEdgeFunctionSha256(body.expected_sha256)) return null;
+    return { prebundled: true, expectedSha256: body.expected_sha256 };
+  }
+  if (body.expected_sha256 !== undefined) return null;
+  return { minify: body.minify ?? false };
+}
+
+function invalidPrebundledDeployment() {
+  return status(400, {
+    message: "prebundled deploy requires expected_sha256 and does not accept minify",
     code: "VALIDATION_ERROR",
   });
 }
@@ -665,12 +692,14 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const code = body.code || body.body || "";
       const expectedVersion = expectedActiveVersion(body.expected_active_version);
       if (expectedVersion === null) return invalidExpectedActiveVersion();
+      const codeDeploymentOptions = functionCodeDeploymentOptions(body);
+      if (codeDeploymentOptions === null) return invalidPrebundledDeployment();
       const deployment = await projectService.deployFunctionRelease({
         ref: params.ref,
         slug: params.slug,
         expectedActiveVersion: expectedVersion,
         code,
-        minify: body.minify ?? false,
+        ...codeDeploymentOptions,
         config: deploymentConfig(
           body.verify_jwt,
           normalizedBackgroundRoutes(body.background_routes),
@@ -702,6 +731,12 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         code: t.Optional(t.String()),
         body: t.Optional(t.String()),
         minify: t.Optional(t.Boolean()),
+        prebundled: t.Optional(t.Boolean()),
+        expected_sha256: t.Optional(t.String({
+          pattern: EDGE_FUNCTION_SHA256_HEX_PATTERN,
+          minLength: 64,
+          maxLength: 64,
+        })),
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
         expected_active_version: expectedActiveVersionSchema,

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -54,6 +54,7 @@ export interface EdgeFunctionDeployResult {
 
 export const EDGE_FUNCTION_ABSENT_ACTIVE_VERSION = "absent" as const;
 export const EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE = "FUNCTION_ACTIVE_VERSION_CONFLICT" as const;
+export const EDGE_FUNCTION_SHA256_HEX_PATTERN = "^[a-f0-9]{64}$";
 export type EdgeFunctionActiveVersion = string;
 
 export interface EdgeFunctionActivationResult {
@@ -67,14 +68,37 @@ export type EdgeFunctionDeploymentConfig = Pick<
   "verify_jwt" | "background_routes"
 >;
 
-type EdgeFunctionReleaseRequest = {
+type EdgeFunctionReleaseBase = {
   ref: string;
   slug: string;
-  minify?: boolean;
   config?: EdgeFunctionDeploymentConfig;
-} & (
-  | { code: string; files?: never; entrypoint?: never }
-  | { files: Record<string, string>; entrypoint?: string; code?: never }
+};
+
+type EdgeFunctionReleaseRequest = EdgeFunctionReleaseBase & (
+  | {
+    code: string;
+    minify?: boolean;
+    prebundled?: false;
+    expectedSha256?: never;
+    files?: never;
+    entrypoint?: never;
+  }
+  | {
+    code: string;
+    prebundled: true;
+    expectedSha256: string;
+    minify?: never;
+    files?: never;
+    entrypoint?: never;
+  }
+  | {
+    files: Record<string, string>;
+    entrypoint?: string;
+    minify?: boolean;
+    code?: never;
+    prebundled?: never;
+    expectedSha256?: never;
+  }
 );
 
 export type EdgeFunctionDeploymentRequest = EdgeFunctionReleaseRequest & {
@@ -142,6 +166,7 @@ const SAFE_REF_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
 const SAFE_SLUG_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 const EXTERNAL_PACKAGE_REGEX = /^(?:@[a-zA-Z0-9._-]+\/)?[a-zA-Z0-9._-]+$/;
 const CANONICAL_VERSION_REGEX = /^(?:0|[1-9]\d*)$/;
+const SHA256_HEX_REGEX = new RegExp(EDGE_FUNCTION_SHA256_HEX_PATTERN);
 const functionDeployLocks = new Map<string, Promise<void>>();
 const deployMetrics: EdgeFunctionDeployMetrics = {
   total_deploys: 0,
@@ -404,8 +429,12 @@ function validateFunctionCode(code: string): {
   if (code.trim().length < 10) {
     return { valid: false, error: "Function code is too short to be valid" };
   }
-  // Accept any non-empty code - Bun.build() will validate syntax
+  // Keep syntax validation mode-specific so prebundled artifacts never pass through Bun.build().
   return { valid: true };
+}
+
+export function isCanonicalEdgeFunctionSha256(candidate: string): boolean {
+  return SHA256_HEX_REGEX.test(candidate);
 }
 
 // Build and final artifact policy failures must escape before a version can be written or preheated.
@@ -557,6 +586,52 @@ async function prepareSingleFunctionVersion(
     importCount: bundle.importCount,
     ...artifact,
   };
+}
+
+async function preparePrebundledFunctionVersion(
+  request: EdgeFunctionReleaseRequest & {
+    code: string;
+    prebundled: true;
+    expectedSha256: string;
+  },
+  version: string,
+  stageDir: string,
+  finalDir: string,
+): Promise<PreparedFunctionVersion> {
+  const normalization = await validatedPrebundledBundle(request);
+  await fs.mkdir(stageDir, { recursive: true });
+  await Bun.write(path.join(stageDir, "index.src.ts"), request.code);
+  const artifact = await writePreparedBundle(stageDir, finalDir, request.code);
+  return {
+    version,
+    bundled: true,
+    entrypoint: null,
+    importMap: null,
+    importCount: normalization.importCount,
+    ...artifact,
+  };
+}
+
+async function validatedPrebundledBundle(
+  request: EdgeFunctionReleaseRequest & {
+    code: string;
+    prebundled: true;
+    expectedSha256: string;
+  },
+) {
+  const validation = validateFunctionCode(request.code);
+  if (!validation.valid) throw new Error(validation.error);
+  if (!isCanonicalEdgeFunctionSha256(request.expectedSha256)) {
+    throw new Error("Prebundled function expected SHA-256 is invalid");
+  }
+  if (await sha256Hex(request.code) !== request.expectedSha256) {
+    throw new Error("Prebundled function SHA-256 does not match expected_sha256");
+  }
+  const normalization = normalizeEdgeRuntimeBundle(request.code);
+  if (normalization.code !== request.code) {
+    throw new Error("Prebundled function would be modified by Edge Runtime normalization");
+  }
+  return normalization;
 }
 
 async function detectedImportMap(sourceDir: string): Promise<string | null> {
@@ -1390,9 +1465,7 @@ async function immutableFunctionVersion(
   );
   await fs.mkdir(versionRoot, { recursive: true });
   try {
-    const prepared = request.code !== undefined
-      ? await prepareSingleFunctionVersion(request, version, stageDir, finalDir)
-      : await prepareBundleFunctionVersion(request, version, stageDir, finalDir);
+    const prepared = await prepareImmutableFunctionVersion(request, version, stageDir, finalDir);
     const functionConfig = activatedFunctionConfig(currentConfig, request.config, prepared);
     await writeFunctionVersionMetadata(
       stageDir,
@@ -1403,6 +1476,20 @@ async function immutableFunctionVersion(
   } finally {
     await fs.rm(stageDir, { recursive: true, force: true }).catch(() => {});
   }
+}
+
+async function prepareImmutableFunctionVersion(
+  request: EdgeFunctionReleaseRequest,
+  version: string,
+  stageDir: string,
+  finalDir: string,
+): Promise<PreparedFunctionVersion> {
+  if (request.code === undefined) {
+    return prepareBundleFunctionVersion(request, version, stageDir, finalDir);
+  }
+  return request.prebundled === true
+    ? preparePrebundledFunctionVersion(request, version, stageDir, finalDir)
+    : prepareSingleFunctionVersion(request, version, stageDir, finalDir);
 }
 
 function activatedFunctionConfig(

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -153,6 +153,118 @@ describe("edgeFunctionService bundle metadata", () => {
     }
   });
 
+  test("stores verified prebundled source and runtime artifacts as the exact submitted bytes", async () => {
+    const ref = "proj_prebundled_exact";
+    const slug = "fa-api";
+    const code = "export default { fetch: () => new Response('精确字节') };\r\n";
+    const expectedSha256 = createHash("sha256").update(code).digest("hex");
+    const buildSpy = spyOn(Bun, "build");
+
+    try {
+      const deployed = await edgeFunctionService.deployRelease({
+        ref,
+        slug,
+        expectedActiveVersion: "absent",
+        code,
+        prebundled: true,
+        expectedSha256,
+      });
+
+      expect(deployed).toMatchObject({
+        success: true,
+        previous_active_version: "absent",
+        active_version: "1",
+        version: "1",
+        bundle_hash: expectedSha256.slice(0, 16),
+        bundle_size_bytes: Buffer.byteLength(code),
+      });
+      expect(buildSpy).not.toHaveBeenCalled();
+      expect(await readFile(deployed.content_path!)).toEqual(Buffer.from(code));
+      expect(await readFile(join(
+        functionsRoot,
+        ref,
+        ".versions",
+        slug,
+        "1",
+        "index.src.ts",
+      ))).toEqual(Buffer.from(code));
+      expect(await edgeFunctionService.getVersion(ref, slug, "1")).toMatchObject({
+        bundle_code: code,
+        source_code: code,
+      });
+    } finally {
+      buildSpy.mockRestore();
+    }
+  });
+
+  test("rejects prebundled bytes that require runtime normalization before mutation", async () => {
+    const ref = "proj_prebundled_normalization";
+    const slug = "fa-api";
+    const code = [
+      'var runtimePackage = "optional-runtime-package";',
+      "export default { fetch: async () => Response.json(await import(runtimePackage)) };",
+      "",
+    ].join("\n");
+    let runtimeCalls = 0;
+    globalThis.fetch = (async () => {
+      runtimeCalls += 1;
+      return Response.json({ success: true });
+    }) as typeof fetch;
+    const buildSpy = spyOn(Bun, "build");
+
+    try {
+      const rejected = await edgeFunctionService.deployRelease({
+        ref,
+        slug,
+        expectedActiveVersion: "absent",
+        code,
+        prebundled: true,
+        expectedSha256: createHash("sha256").update(code).digest("hex"),
+      });
+
+      expect(rejected).toMatchObject({ success: false });
+      expect(rejected.error).toContain("would be modified");
+      expect(buildSpy).not.toHaveBeenCalled();
+      expect(runtimeCalls).toBe(0);
+      expect(await edgeFunctionService.listVersions(ref, slug)).toEqual([]);
+      expect(await edgeFunctionService.getConfig(ref, slug)).toEqual({ verify_jwt: true });
+    } finally {
+      buildSpy.mockRestore();
+    }
+  });
+
+  test("rejects a prebundled SHA-256 mismatch before mutation", async () => {
+    const ref = "proj_prebundled_hash_mismatch";
+    const slug = "fa-api";
+    const code = "export default { fetch: () => new Response('replaced') };\n";
+    let runtimeCalls = 0;
+    globalThis.fetch = (async () => {
+      runtimeCalls += 1;
+      return Response.json({ success: true });
+    }) as typeof fetch;
+    const buildSpy = spyOn(Bun, "build");
+
+    try {
+      const rejected = await edgeFunctionService.deployRelease({
+        ref,
+        slug,
+        expectedActiveVersion: "absent",
+        code,
+        prebundled: true,
+        expectedSha256: createHash("sha256").update("approved").digest("hex"),
+      });
+
+      expect(rejected).toMatchObject({ success: false });
+      expect(rejected.error).toContain("does not match expected_sha256");
+      expect(buildSpy).not.toHaveBeenCalled();
+      expect(runtimeCalls).toBe(0);
+      expect(await edgeFunctionService.listVersions(ref, slug)).toEqual([]);
+      expect(await edgeFunctionService.getConfig(ref, slug)).toEqual({ verify_jwt: true });
+    } finally {
+      buildSpy.mockRestore();
+    }
+  });
+
   test("rejects unresolved computed imports without activating a new version", async () => {
     const ref = "proj_computed_import_rejected";
     const slug = "computed-import-rejected";

--- a/packages/management-api/tests/unit/final-security-regression.test.ts
+++ b/packages/management-api/tests/unit/final-security-regression.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { Elysia } from "elysia";
 import { projectFunctionsRoutes } from "../../src/routes/project-functions";
 import { projectSecretsRoutes } from "../../src/routes/project-secrets";
@@ -227,6 +228,76 @@ describe("final security regressions", () => {
         minify: false,
         config: { verify_jwt: false, background_routes: ["/queue/*"] },
       });
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test("prebundled function deploy passes the exact-byte contract to the release primitive", async () => {
+    const code = "export default { fetch: () => new Response('exact-route-bytes') };\r\n";
+    const expectedSha256 = createHash("sha256").update(code).digest("hex");
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockResolvedValue({
+      success: true,
+      previous_active_version: "2",
+      active_version: "3",
+      version: "3",
+      bundled: true,
+      config: { verify_jwt: true, version: "3" },
+    } as Awaited<ReturnType<typeof projectService.deployFunctionRelease>>);
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/fa-api", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code,
+          prebundled: true,
+          expected_sha256: expectedSha256,
+          expected_active_version: "2",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(deploySpy).toHaveBeenCalledWith({
+        ref: "proj_1",
+        slug: "fa-api",
+        expectedActiveVersion: "2",
+        code,
+        prebundled: true,
+        expectedSha256,
+        config: {},
+      });
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test.each([
+    ["missing hash", { prebundled: true }],
+    ["minify requested", { prebundled: true, expected_sha256: "0".repeat(64), minify: false }],
+    ["hash without mode", { expected_sha256: "0".repeat(64) }],
+  ])("rejects prebundled deployment with %s before service dispatch", async (_label, fields) => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease");
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/fa-api", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "export default { fetch: () => new Response('blocked') };",
+          expected_active_version: "absent",
+          ...fields,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        message: "prebundled deploy requires expected_sha256 and does not accept minify",
+        code: "VALIDATION_ERROR",
+      });
+      expect(deploySpy).not.toHaveBeenCalled();
     } finally {
       deploySpy.mockRestore();
     }


### PR DESCRIPTION
Stacked on #831. Do not merge before #831.

## Summary
- add `edge_functions deploy --prebundled-path <file> --expected-sha256 <sha256>`
- bind caller-approved bytes with held-FD pre/post identity checks, fatal UTF-8 roundtrip, and SHA-256 verification before HTTP
- add Management prebundled mode that rechecks SHA-256 and runtime policy, rejects normalization changes, skips Bun.build, and stores identical immutable source/runtime bytes
- keep `--prebundled-path` mutually exclusive with `--code`, `--path`, and `--minify`

## Verification
- CLI full suite: 456 passed
- CLI typecheck and build: passed
- Management focused service/route suite: 55 passed
- Management full unit gate: passed
- Management typecheck: passed
- Web Console check: 0 errors, 0 warnings
- Web Console production build: passed
- `git diff --check`: passed

## Queue
No merge, release, or deployment is performed by this PR. The separate HTTP response-body deadline/size-cap and mutation provenance/idempotency blockers remain outside this change.
