### PR TITLE
fix(functions): support legacy v0 CAS and readback

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,15 +329,17 @@ supacloud-cli storage list_buckets --ref <ref>
 Function deploy and activation commands require the active version observed via
 `edge_functions list`; `absent` is valid only for a new slug. Stale mutations
 return HTTP 409 and successful mutations emit a
-`supacloud.cli.release-control.v1` receipt. Pass the observed version to
-`edge_functions source --version <N>` for an immutable, ABA-safe source backup.
+`supacloud.cli.release-control.v1` receipt. When the observed version is
+positive, pass it to `edge_functions source --version <N>` for an immutable,
+ABA-safe source backup.
 Use `deploy --prebundled-path` with the required lowercase
 `--expected-sha256` when a release pipeline must upload an already-built runtime
 artifact without local or server rebundling. The mode rejects caller-hash,
 file-stability, UTF-8, runtime-policy, and normalization mismatches before
 activation.
-Version `0` is reserved for service-internal legacy recovery and is not a valid
-public CLI/API activation target or expected active version.
+Version `0` is reserved for a listed legacy Function's active-version CAS token.
+It is valid only as `--expected-active-version 0`; immutable source reads and
+activation targets still require a positive version.
 
 For complex SQL, pgvector queries, and single-request transaction blocks, prefer `--file` instead of shell-escaped inline SQL.
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -276,20 +276,21 @@ to that immutable release and remains safe if the active pointer changes Aâ†’Bâ†
 
 Function release mutations use optimistic concurrency control. Before
 `deploy`, `deploy_bundle`, or `activate`, run `edge_functions list` and pass the
-observed positive integer version as `--expected-active-version <N>`. Pass
-`--expected-active-version absent` only for the first deployment of a new slug.
+observed non-negative integer version as `--expected-active-version <N>`. Use
+`0` only for a listed legacy Function, and pass `--expected-active-version absent`
+only for the first deployment of a new slug.
 A stale value returns HTTP 409 before build, preheat, version creation, or
 manifest activation. Successful mutations return the
 `supacloud.cli.release-control.v1` receipt with `project_ref`, `slug`,
 `previous_active_version`, `active_version`, `version`, and `verify_jwt`.
 Transport failures, HTTP 408/5xx responses, and malformed 2xx receipts exit
 non-zero as `OUTCOME_UNKNOWN`; read back `edge_functions list` before retrying.
-Version `0` remains an internal compatibility marker for legacy recovery. The
-public CLI and Management API reject it as an activation target or expected
-active version; all public release automation uses positive versions.
+Version `0` is reserved for a listed legacy Function's active-version CAS token.
+The public CLI and Management API accept it only as the expected active version;
+immutable source reads and activation targets still require positive versions.
 
 The readback contract stays simple for automation: `edge_functions list`
-prints a JSON array whose entries have a string `slug` and a positive safe
+prints a JSON array whose entries have a string `slug` and a non-negative safe
 integer numeric `version`; `edge_functions source` prints exactly
 `{ "code": "..." }`. Release automation uses `source --version <N>` rather than
 the moving active source endpoint.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -212,10 +212,10 @@ already exist. Add the positive version observed from `list` as
 pointer; this remains correct across an active-version A→B→A transition.
 
 `deploy`, `deploy_bundle`, and `activate` require
-`--expected-active-version <N|absent>`. Read the current positive integer
-version from `edge_functions list`; use `absent` only when creating a slug that
-does not yet exist. A stale value returns HTTP 409 without building, preheating,
-or activating another version. List output remains a JSON array with string
+`--expected-active-version <N|absent>`. Read the current non-negative integer
+version from `edge_functions list`; use `0` for a listed legacy Function and
+`absent` only when creating a slug that does not yet exist. A stale value returns
+HTTP 409 without building, preheating, or activating another version. List output remains a JSON array with string
 `slug` and numeric `version` fields, while source output is exactly
 `{ "code": "..." }`. Release automation must use `source --version <N>` for a
 version-bound backup.
@@ -229,8 +229,9 @@ Mutation receipts use schema `supacloud.cli.release-control.v1`. An
 `OUTCOME_UNKNOWN` error means the server may have committed the mutation before
 the response was lost or failed validation; read back current state before any
 retry.
-Version `0` is reserved for service-internal legacy recovery and cannot be used
-as a public CLI/API activation target or expected active version.
+Version `0` is reserved as the active-version CAS token for legacy Functions. It
+can be passed only as `--expected-active-version`; immutable source reads and
+activation targets still require a positive version.
 
 ```json
 {

--- a/packages/cli/skills/supacloud-cli/references/command-map.md
+++ b/packages/cli/skills/supacloud-cli/references/command-map.md
@@ -31,7 +31,7 @@ until a project-scoped context is resolved.
 - `supabase`: allowlisted official CLI adapter for migration authoring, local reset/diff, explicit-DSN inspection/backup/type generation, and SupaCloud-controlled migration push.
 - `auth`: provider and authentication configuration.
 - `storage`: buckets and object-management workflows.
-- `edge_functions`: list, read immutable source, deploy, activate, and configure Edge Functions. Pass the positive version read from `list` to `source --version` and as `--expected-active-version`; use `absent` only for a new slug. Version `0` is internal-only.
+- `edge_functions`: list, read immutable source, deploy, activate, and configure Edge Functions. Pass the non-negative version read from `list` as `--expected-active-version`; use `absent` only for a new slug. Version `0` is a legacy CAS token and cannot be used as a source or activation target.
 - `frontend`: list, build/deploy, domain, and deployment workflows.
 - `secrets`: project secret management; never print values after write.
 - `queue`, `task_events`, `diagnostics`: asynchronous workload operations and bounded diagnostics.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -407,7 +407,10 @@ describe("supacloud-cli process contract", () => {
         const server = Bun.serve({
             hostname: "127.0.0.1",
             port: 0,
-            fetch: () => Response.json([{ slug: "fa-api", version: 40, verify_jwt: true }]),
+            fetch: () => Response.json([
+                { slug: "legacy-hook", version: 0, verify_jwt: true },
+                { slug: "fa-api", version: 40, verify_jwt: true },
+            ]),
         });
         servers.push(server);
 
@@ -420,8 +423,10 @@ describe("supacloud-cli process contract", () => {
 
         expect(response.exitCode).toBe(0);
         expect(Array.isArray(functions)).toBe(true);
-        expect(functions[0]).toMatchObject({ slug: "fa-api", version: 40 });
-        expect(typeof functions[0].version).toBe("number");
+        expect(functions).toEqual([
+            { slug: "legacy-hook", version: 0, verify_jwt: true },
+            { slug: "fa-api", version: 40, verify_jwt: true },
+        ]);
     });
 
     test("rejects malformed Function readbacks without reflecting server fields", async () => {
@@ -929,7 +934,7 @@ describe("supacloud-cli process contract", () => {
         expect(requestCount).toBe(0);
     });
 
-    test("deploys a Function bundle with an identity-bound CAS receipt", async () => {
+    test("deploys over legacy Function v0 with an identity-bound CAS receipt", async () => {
         let requestBody: Record<string, unknown> | null = null;
         const server = Bun.serve({
             hostname: "127.0.0.1",
@@ -940,10 +945,10 @@ describe("supacloud-cli process contract", () => {
                     success: true,
                     project_ref: "abc123",
                     slug: "worker",
-                    previous_active_version: "7",
-                    active_version: "8",
-                    version: "8",
-                    config: { version: "8", verify_jwt: true },
+                    previous_active_version: "0",
+                    active_version: "1",
+                    version: "1",
+                    config: { version: "1", verify_jwt: true },
                 });
             },
         });
@@ -952,7 +957,7 @@ describe("supacloud-cli process contract", () => {
         const response = await runProjectCli([
             "edge_functions", "deploy_bundle", "--ref", "abc123", "--slug", "worker",
             "--files", JSON.stringify({ "index.ts": "export default {}" }),
-            "--expected-active-version", "7",
+            "--expected-active-version", "0",
         ], {
             SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
             SUPACLOUD_API_TOKEN: "test-token",
@@ -965,10 +970,10 @@ describe("supacloud-cli process contract", () => {
             operation: "edge_functions.deploy_bundle",
             project_ref: "abc123",
             slug: "worker",
-            previous_active_version: "7",
-            active_version: "8",
+            previous_active_version: "0",
+            active_version: "1",
         });
-        expect(requestBody).toMatchObject({ expected_active_version: "7" });
+        expect(requestBody).toMatchObject({ expected_active_version: "0" });
     });
 
     test("rejects Function mutations without expected-active-version before HTTP", async () => {
@@ -1006,7 +1011,7 @@ describe("supacloud-cli process contract", () => {
         expect(requestCount).toBe(0);
     });
 
-    test("activates a Function version through a secret-safe process contract", async () => {
+    test("activates a positive Function version from legacy v0 through a secret-safe process contract", async () => {
         const apiToken = "activation-api-token-sentinel";
         const requested: Array<{
             method: string;
@@ -1028,7 +1033,7 @@ describe("supacloud-cli process contract", () => {
                     success: true,
                     project_ref: "abc123",
                     slug: "public-hook",
-                    previous_active_version: "5",
+                    previous_active_version: "0",
                     active_version: "6",
                     version: "6",
                     config: { version: "6", verify_jwt: false },
@@ -1039,7 +1044,7 @@ describe("supacloud-cli process contract", () => {
         const commandArguments = [
             "edge_functions", "activate", "--ref", "abc123",
             "--slug", "public-hook", "--version", "6",
-            "--expected-active-version", "5",
+            "--expected-active-version", "0",
         ];
 
         const response = await runProjectCli(commandArguments, {
@@ -1055,7 +1060,7 @@ describe("supacloud-cli process contract", () => {
             operation: "edge_functions.activate",
             project_ref: "abc123",
             slug: "public-hook",
-            previous_active_version: "5",
+            previous_active_version: "0",
             active_version: "6",
             version: "6",
             verify_jwt: false,
@@ -1064,7 +1069,7 @@ describe("supacloud-cli process contract", () => {
             method: "POST",
             path: "/v1/projects/abc123/functions/public-hook/versions/6/activate",
             authorization: `Bearer ${apiToken}`,
-            body: { expected_active_version: "5" },
+            body: { expected_active_version: "0" },
         }]);
         expect(commandArguments.join("\0")).not.toContain(apiToken);
         expect(response.stdout + response.stderr).not.toContain(apiToken);

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -149,12 +149,10 @@ describe("edge_functions CLI tool", () => {
     });
 
     test("keeps the Function list as a JSON array with numeric active versions", async () => {
-        const functions = [{
-            slug: "fa-api",
-            version: 7,
-            verify_jwt: true,
-            status: "ACTIVE",
-        }];
+        const functions = [
+            { slug: "legacy-hook", version: 0, verify_jwt: true, status: "ACTIVE" },
+            { slug: "fa-api", version: 7, verify_jwt: true, status: "ACTIVE" },
+        ];
         const { callback } = captureEdgeFunctionsTool({
             get: async () => ({ ok: true, status: 200, data: functions }),
         });
@@ -164,7 +162,7 @@ describe("edge_functions CLI tool", () => {
 
         expect(response.isError).toBeUndefined();
         expect(payload).toEqual(functions);
-        expect(typeof payload[0].version).toBe("number");
+        expect(payload.map(({ version }: { version: number }) => version)).toEqual([0, 7]);
     });
 
     test.each([
@@ -173,7 +171,7 @@ describe("edge_functions CLI tool", () => {
         ["a missing slug", [{ version: 7, private: "list-response-sentinel" }]],
         ["an invalid slug", [{ slug: "../fa-api", version: 7, private: "list-response-sentinel" }]],
         ["a string version", [{ slug: "fa-api", version: "7", private: "list-response-sentinel" }]],
-        ["version zero", [{ slug: "fa-api", version: 0, private: "list-response-sentinel" }]],
+        ["a negative version", [{ slug: "fa-api", version: -1, private: "list-response-sentinel" }]],
         ["a fractional version", [{ slug: "fa-api", version: 1.5, private: "list-response-sentinel" }]],
         ["an unsafe version", [{ slug: "fa-api", version: Number.MAX_SAFE_INTEGER + 1, private: "list-response-sentinel" }]],
         ["duplicate slugs", [{ slug: "fa-api", version: 7 }, { slug: "fa-api", version: 8 }]],
@@ -344,7 +342,7 @@ describe("edge_functions CLI tool", () => {
         },
     );
 
-    test.each([0, "0", "01", "9007199254740992"])(
+    test.each([-1, "-1", "01", "9007199254740992"])(
         "rejects invalid expected active version %j during argument parsing",
         (expectedActiveVersion) => {
             const { schema } = captureEdgeFunctionsTool({});
@@ -358,7 +356,7 @@ describe("edge_functions CLI tool", () => {
         },
     );
 
-    test.each([0, "0", "01", "9007199254740992", true, {}])(
+    test.each([-1, "-1", "01", "9007199254740992", true, {}])(
         "rejects direct invalid expected active version %j before HTTP dispatch",
         async (expectedActiveVersion) => {
             let requestCount = 0;
@@ -375,7 +373,7 @@ describe("edge_functions CLI tool", () => {
                 slug: "hook",
                 files: { "index.ts": "export default {}" },
                 "expected-active-version": expectedActiveVersion,
-            })).rejects.toThrow("canonical positive safe integer");
+            })).rejects.toThrow("canonical non-negative safe integer");
             expect(requestCount).toBe(0);
         },
     );
@@ -523,6 +521,55 @@ describe("edge_functions CLI tool", () => {
         })).rejects.toThrow();
         expect(requestCount).toBe(0);
     });
+
+    test.each([0, "0"])(
+        "deploys over legacy active version %j with a confirmed CAS receipt",
+        async (expectedActiveVersion) => {
+            const calls: Array<{ path: string; body: unknown }> = [];
+            const { callback, schema } = captureEdgeFunctionsTool({
+                post: async (path: string, body: unknown) => {
+                    calls.push({ path, body });
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: {
+                            success: true,
+                            project_ref: "proj",
+                            slug: "legacy-hook",
+                            previous_active_version: "0",
+                            active_version: "1",
+                            version: "1",
+                            config: { version: "1", verify_jwt: true },
+                        },
+                    };
+                },
+            });
+            const args = parseToolArguments(schema, {
+                action: "deploy_bundle",
+                ref: "proj",
+                slug: "legacy-hook",
+                files: { "index.ts": "export default {}" },
+                "expected-active-version": expectedActiveVersion,
+            });
+
+            const response = await callback(args);
+
+            expect(calls).toEqual([{
+                path: "/v1/projects/proj/functions/legacy-hook/bundle",
+                body: {
+                    files: { "index.ts": "export default {}" },
+                    entrypoint: undefined,
+                    minify: undefined,
+                    expected_active_version: "0",
+                },
+            }]);
+            expect(JSON.parse(response.content[0].text)).toMatchObject({
+                ok: true,
+                previous_active_version: "0",
+                active_version: "1",
+            });
+        },
+    );
 
     test("sends bundle config inline without a follow-up PATCH", async () => {
         const calls: Array<{ method: string; path: string; body: unknown }> = [];

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -251,6 +251,18 @@ function positiveFunctionVersion(input: unknown, label: string): string {
     return version;
 }
 
+function activeFunctionVersionToken(input: unknown): string {
+    if (typeof input !== "string" && typeof input !== "number") {
+        throw new Error("Expected active version must be a canonical non-negative safe integer");
+    }
+    const version = String(input);
+    if (!CANONICAL_FUNCTION_VERSION_PATTERN.test(version) || !Number.isSafeInteger(Number(version))) {
+        throw new Error("Expected active version must be a canonical non-negative safe integer");
+    }
+    return version;
+}
+
+const CANONICAL_FUNCTION_VERSION_PATTERN = /^(?:0|[1-9][0-9]*)$/;
 const POSITIVE_FUNCTION_VERSION_PATTERN = /^[1-9][0-9]*$/;
 const SAFE_FUNCTION_SLUG_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const FUNCTION_ACTIVATION_ARGUMENTS = new Set([
@@ -267,18 +279,18 @@ const functionVersionSchema = Type.Optional(decodedSchema(
 
 function parseExpectedActiveVersion(input: unknown): unknown {
     if (input === "absent") return input;
-    return positiveFunctionVersion(input, "Expected active version");
+    return activeFunctionVersionToken(input);
 }
 
 const expectedActiveVersionSchema = Type.Optional(decodedSchema(
     Type.Union([
         Type.Literal("absent"),
-        Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
-        Type.String({ pattern: POSITIVE_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+        Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+        Type.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
     ]),
     Type.Union([
         Type.Literal("absent"),
-        Type.String({ pattern: POSITIVE_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
+        Type.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
     ]),
     parseExpectedActiveVersion,
 ));
@@ -436,7 +448,7 @@ function safeFunctionList(payload: unknown): Array<Record<string, unknown>> | nu
         const slug = edgeFunction?.slug;
         const version = edgeFunction?.version;
         if (typeof slug !== "string" || !SAFE_FUNCTION_SLUG_PATTERN.test(slug)
-            || typeof version !== "number" || !Number.isSafeInteger(version) || version < 1
+            || typeof version !== "number" || !Number.isSafeInteger(version) || version < 0
             || functionSlugs.has(slug)) return null;
         functionSlugs.add(slug);
     }

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -3,6 +3,7 @@ import { projectService } from "../services";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
 import { isUserManagedFunctionSecretName } from "../utils/project-secret-visibility";
 import {
+  activeFunctionVersionNumber,
   EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
   EDGE_FUNCTION_SHA256_HEX_PATTERN,
   EdgeFunctionActiveVersionConflictError,
@@ -12,13 +13,13 @@ import {
   type EdgeFunctionDeployResult,
 } from "../services/edge-function.service";
 
-const FUNCTION_VERSION_PATTERN = /^(?:0|[1-9][0-9]*)$/;
-const EXPECTED_ACTIVE_VERSION_PATTERN = /^[1-9][0-9]*$/;
+const CANONICAL_FUNCTION_VERSION_PATTERN = /^(?:0|[1-9][0-9]*)$/;
+const POSITIVE_FUNCTION_VERSION_PATTERN = /^[1-9][0-9]*$/;
 // Admit the reserved legacy zero at schema parsing so the handler returns the stable public HTTP 400 contract.
-const functionVersionSchema = t.String({ pattern: FUNCTION_VERSION_PATTERN.source, maxLength: 16 });
+const functionVersionSchema = t.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 });
 const expectedActiveVersionSchema = t.Union([
   t.Literal("absent"),
-  t.String({ pattern: EXPECTED_ACTIVE_VERSION_PATTERN.source, maxLength: 16 }),
+  t.String({ pattern: CANONICAL_FUNCTION_VERSION_PATTERN.source, maxLength: 16 }),
 ]);
 
 async function requireFunctionManagementAuth(request: Request, ref: string) {
@@ -65,20 +66,38 @@ function normalizedBackgroundRoutes(routes: unknown): string[] | undefined {
 
 function expectedActiveVersion(value: unknown): EdgeFunctionActiveVersion | null {
   if (value === "absent") return value;
-  if (typeof value !== "string" || !EXPECTED_ACTIVE_VERSION_PATTERN.test(value)) {
+  if (typeof value !== "string" || !CANONICAL_FUNCTION_VERSION_PATTERN.test(value)) {
     return null;
   }
   return Number.isSafeInteger(Number(value)) ? value : null;
 }
 
 function functionVersion(value: unknown): string | null {
-  if (typeof value !== "string" || !EXPECTED_ACTIVE_VERSION_PATTERN.test(value)) return null;
+  if (typeof value !== "string" || !POSITIVE_FUNCTION_VERSION_PATTERN.test(value)) return null;
   return Number.isSafeInteger(Number(value)) ? value : null;
+}
+
+async function functionResponseVersion(
+  ref: string,
+  slug: string,
+  reportedVersion?: string,
+): Promise<number | null> {
+  if (reportedVersion !== undefined) return activeFunctionVersionNumber(reportedVersion);
+  const { edgeFunctionService } = await import("../services/edge-function.service");
+  const activeVersion = await edgeFunctionService.getActiveVersion(ref, slug);
+  return activeFunctionVersionNumber(activeVersion);
 }
 
 function invalidExpectedActiveVersion() {
   return status(400, {
-    message: "expected_active_version must be a canonical positive safe integer or 'absent'",
+    message: "expected_active_version must be a canonical non-negative safe integer or 'absent'",
+    code: "VALIDATION_ERROR",
+  });
+}
+
+function invalidFunctionVersion() {
+  return status(400, {
+    message: "version must be a canonical positive safe integer",
     code: "VALIDATION_ERROR",
   });
 }
@@ -236,17 +255,21 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const { edgeFunctionService } =
         await import("../services/edge-function.service");
       const funcConfig = deployment.config ?? await edgeFunctionService.getConfig(params.ref, slug);
-      const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
+      const version = await functionResponseVersion(
+        params.ref,
+        slug,
+        deployment.version ?? deployment.active_version ?? funcConfig.version,
+      );
       const now = new Date().toISOString();
       return {
         project_ref: params.ref,
         id: slug,
         slug,
         name: metadata.name || slug,
-        version: Number.parseInt(deployment.version || String(version), 10) || version,
+        version,
         previous_active_version: deployment.previous_active_version,
         active_version: deployment.active_version,
-        status: "ACTIVE",
+        status: version === null ? "INACTIVE" : "ACTIVE",
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         entrypoint_path: entrypoint,
@@ -325,7 +348,11 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           ? await edgeFunctionService.updateConfig(params.ref, slug, configPatch)
           : await edgeFunctionService.getConfig(params.ref, slug)
       );
-      const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
+      const version = await functionResponseVersion(
+        params.ref,
+        slug,
+        deployResult?.version ?? deployResult?.active_version ?? funcConfig.version,
+      );
 
       const now = new Date().toISOString();
       return {
@@ -338,7 +365,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         active_version: deployResult?.active_version,
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
-        status: "ACTIVE",
+        status: version === null ? "INACTIVE" : "ACTIVE",
         created_at: now,
         updated_at: now,
         entrypoint_path:
@@ -468,14 +495,14 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         params.ref,
         params.slug,
       );
-      const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
+      const version = await functionResponseVersion(params.ref, params.slug, funcConfig.version);
       const now = new Date().toISOString();
       return {
         id: params.slug,
         slug: params.slug,
         name: params.slug,
         version,
-        status: "ACTIVE",
+        status: version === null ? "INACTIVE" : "ACTIVE",
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         entrypoint_path: `${params.slug}/index.ts`,
@@ -577,12 +604,14 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
     async ({ params, request }) => {
       const authError = await requireFunctionManagementAuth(request, params.ref);
       if (authError) return authError;
+      const targetVersion = functionVersion(params.version);
+      if (targetVersion === null) return invalidFunctionVersion();
       const { edgeFunctionService } =
         await import("../services/edge-function.service");
       const version = await edgeFunctionService.getVersion(
         params.ref,
         params.slug,
-        params.version,
+        targetVersion,
       );
       if (!version) {
         return status(404, { message: "Function version not found", code: "404" });
@@ -609,12 +638,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
       const expectedVersion = expectedActiveVersion(body.expected_active_version);
       if (expectedVersion === null) return invalidExpectedActiveVersion();
       const targetVersion = functionVersion(params.version);
-      if (targetVersion === null) {
-        return status(400, {
-          message: "version must be a canonical positive safe integer",
-          code: "VALIDATION_ERROR",
-        });
-      }
+      if (targetVersion === null) return invalidFunctionVersion();
       try {
         const activation = await edgeFunctionService.activateVersion(
           params.ref,
@@ -786,7 +810,11 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           ? await edgeFunctionService.updateConfig(params.ref, params.slug, configPatch)
           : await edgeFunctionService.getConfig(params.ref, params.slug)
       );
-      const version = Number.parseInt(funcConfig.version || "1", 10) || 1;
+      const version = await functionResponseVersion(
+        params.ref,
+        params.slug,
+        deployResult?.version ?? deployResult?.active_version ?? funcConfig.version,
+      );
       const now = new Date().toISOString();
       return {
         project_ref: params.ref,
@@ -796,7 +824,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         version,
         previous_active_version: deployResult?.previous_active_version,
         active_version: deployResult?.active_version,
-        status: "ACTIVE",
+        status: version === null ? "INACTIVE" : "ACTIVE",
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         bundle_hash: deployResult?.bundle_hash ?? null,

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -229,6 +229,13 @@ function parseVersionNumber(value: unknown): number | null {
   return parsed;
 }
 
+export function activeFunctionVersionNumber(version: EdgeFunctionActiveVersion): number | null {
+  if (version === EDGE_FUNCTION_ABSENT_ACTIVE_VERSION) return null;
+  const parsedVersion = parseVersionNumber(version);
+  if (parsedVersion === null) throw new Error("Function config contains an invalid active version");
+  return parsedVersion;
+}
+
 function validatedExpectedActiveVersion(value: unknown): EdgeFunctionActiveVersion {
   if (value === EDGE_FUNCTION_ABSENT_ACTIVE_VERSION) return value;
   if (typeof value !== "string" || !CANONICAL_VERSION_REGEX.test(value)
@@ -1322,8 +1329,8 @@ export async function getVersionedArtifactPath(
       .sort()
       .at(0);
     if (contentAddressed) return assertInside(dir, path.join(dir, contentAddressed));
-  } catch {
-    // Fall back to the compatibility index.js artifact below.
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
   const modern = getVersionedFuncPath(ref, slug, version);
   if (await fileExists(modern)) return modern;
@@ -1632,6 +1639,10 @@ async function deployLatestFunctionRelease(
 }
 
 export const edgeFunctionService = {
+  async getActiveVersion(ref: string, slug: string): Promise<EdgeFunctionActiveVersion> {
+    return activeFunctionVersion(ref, slug);
+  },
+
   /** Read function config (verify_jwt, etc.) */
   async getConfig(ref: string, slug: string): Promise<EdgeFunctionConfig> {
     return readFunctionConfig(ref, slug);
@@ -1972,36 +1983,40 @@ export const edgeFunctionService = {
     }
   },
 
-  /** List all function slugs for a project */
+  /** List active function slugs for a project */
   async list(ref: string): Promise<string[]> {
+    const dir = getFuncDir(ref);
+    const { Glob } = await import("bun");
+    const glob = new Glob("*.js");
+    let entries: string[];
     try {
-      const dir = getFuncDir(ref);
-      const { Glob } = await import("bun");
-      const glob = new Glob("*.js");
-      const entries = Array.from(glob.scanSync({ cwd: dir, onlyFiles: true }));
-      const slugs = new Set<string>();
-
-      for (const entry of entries) {
-        const parsedLegacy = parseLegacyVersionedFile(entry);
-        if (parsedLegacy) continue;
-        slugs.add(entry.replace(/\.js$/, ""));
-      }
-
-      const versionsRoot = path.join(dir, VERSIONED_DIR);
-      const versionedEntries = await fs.readdir(versionsRoot, { withFileTypes: true }).catch(() => []);
-      for (const entry of versionedEntries) {
-        if (entry.isDirectory()) slugs.add(entry.name);
-      }
-
-      return Array.from(slugs).sort();
-    } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        logger.warn(`[EdgeFunction] Failed to list functions for ${ref}`, {
-          error: err,
-        });
-      }
-      return [];
+      entries = Array.from(glob.scanSync({ cwd: dir, onlyFiles: true }));
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
     }
+    const slugs = new Set<string>();
+    for (const entry of entries) {
+      if (parseLegacyVersionedFile(entry)) continue;
+      slugs.add(entry.replace(/\.js$/, ""));
+    }
+
+    const versionsRoot = path.join(dir, VERSIONED_DIR);
+    const versionedEntries = await fs.readdir(versionsRoot, { withFileTypes: true })
+      .catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+        throw error;
+      });
+    for (const entry of versionedEntries) {
+      if (entry.isDirectory()) slugs.add(entry.name);
+    }
+
+    const activeSlugs = await Promise.all(Array.from(slugs, async (slug) =>
+      await activeFunctionVersion(ref, slug) === EDGE_FUNCTION_ABSENT_ACTIVE_VERSION
+        ? null
+        : slug
+    ));
+    return activeSlugs.filter((slug): slug is string => slug !== null).sort();
   },
 
   /** Delete a function (both bundled and source) */

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -7,12 +7,16 @@ import { gatewayService } from "./gateway.service";
 import { taskRepository } from "../repositories/task.repository";
 import type { Project, ProjectStatus } from "../db";
 import { resolveBucketName, resolveDbName, resolveRoleName, generateDbName } from "../db";
-import { edgeFunctionService } from "./edge-function.service";
-import { getVersionedArtifactPath } from "./edge-function.service";
-import type { EdgeFunctionDeploymentRequest } from "./edge-function.service";
+import {
+  activeFunctionVersionNumber,
+  edgeFunctionService,
+  getVersionedArtifactPath,
+  type EdgeFunctionDeploymentRequest,
+} from "./edge-function.service";
 import { logger } from "../utils/logger";
 import { config } from "../config";
 import { $ } from "bun";
+import * as fs from "node:fs/promises";
 import { projectLogService } from "./project-logs.service";
 import { projectOpsService } from "./project-ops.service";
 import {
@@ -811,27 +815,23 @@ export class ProjectService {
     const results: FunctionResponse[] = [];
     for (const slug of slugs) {
       const cfg = await edgeFunctionService.getConfig(ref, slug);
-      let created_at = new Date().toISOString();
-      let updated_at = created_at;
-      try {
-        const { stat } = await import("fs/promises");
-        const activePath = cfg.version
-          ? await getVersionedArtifactPath(ref, slug, cfg.version)
-          : null;
-        const fileStat = await stat(
-          activePath || `${config.edgeFunctionsDir}/${ref}/${slug}.js`,
-        );
-        updated_at = fileStat.mtime.toISOString();
-        created_at = fileStat.birthtime.toISOString();
-      } catch {
-        /* file may not exist yet */
-      }
+      const version = activeFunctionVersionNumber(
+        await edgeFunctionService.getActiveVersion(ref, slug),
+      );
+      if (version === null) throw new Error("Function became inactive while listing");
+      const activePath = cfg.version === undefined
+        ? `${config.edgeFunctionsDir}/${ref}/${slug}.js`
+        : await getVersionedArtifactPath(ref, slug, cfg.version);
+      if (activePath === null) throw new Error("Active function artifact is missing");
+      const fileStat = await fs.stat(activePath);
+      const updated_at = fileStat.mtime.toISOString();
+      const created_at = fileStat.birthtime.toISOString();
       results.push({
         id: slug,
         slug,
         name: slug,
         status: "ACTIVE",
-        version: Number.parseInt(cfg.version || "1", 10) || 1,
+        version,
         verify_jwt: cfg.verify_jwt,
         background_routes: cfg.background_routes || [],
         import_map: !!cfg.import_map,

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -90,6 +91,8 @@ afterAll(async () => {
 
 describe("edgeFunctionService bundle metadata", () => {
   test("returns the Edge Runtime preheat error when version readiness fails", async () => {
+    const ref = "proj_preheat_diagnostic";
+    const slug = "computed-import";
     globalThis.fetch = (async () => Response.json({
       success: false,
       version: "1",
@@ -111,8 +114,8 @@ describe("edgeFunctionService bundle metadata", () => {
     })) as typeof fetch;
 
     const deployed = await deployConditionalRelease({
-      ref: "proj_preheat_diagnostic",
-      slug: "computed-import",
+      ref,
+      slug,
       code: "export default { fetch: () => new Response('unreachable') };",
     });
 
@@ -120,6 +123,50 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(deployed.error).toContain(
       "Computed dynamic imports are disabled in the multi-tenant Edge Runtime.",
     );
+    expect((await edgeFunctionService.listVersions(ref, slug)).map(({ version }) => version))
+      .toEqual(["1"]);
+    expect((await edgeFunctionService.getConfig(ref, slug)).version).toBeUndefined();
+    expect(await edgeFunctionService.getActiveVersion(ref, slug)).toBe("absent");
+    expect(await edgeFunctionService.list(ref)).toEqual([]);
+  });
+
+  test("propagates corrupt candidate config without hiding valid active functions", async () => {
+    const ref = "proj_list_corrupt_config";
+    const projectDir = join(functionsRoot, ref);
+    await Promise.all([
+      mkdir(join(projectDir, ".versions", "configured", "1"), { recursive: true }),
+      mkdir(join(projectDir, ".versions", "orphan", "1"), { recursive: true }),
+      mkdir(join(projectDir, ".versions", "corrupt", "1"), { recursive: true }),
+    ]);
+    await Promise.all([
+      Bun.write(join(projectDir, "legacy.js"), "export default {};"),
+      Bun.write(join(projectDir, "configured.config.json"), JSON.stringify({ version: "1" })),
+      Bun.write(join(projectDir, "corrupt.config.json"), "{"),
+    ]);
+
+    await expect(edgeFunctionService.list(ref)).rejects.toThrow();
+
+    await rm(join(projectDir, "corrupt.config.json"));
+    expect(await edgeFunctionService.list(ref)).toEqual(["configured", "legacy"]);
+  });
+
+  test("propagates unreadable version artifact directories", async () => {
+    const versionDir = join(
+      functionsRoot,
+      "proj_artifact_io",
+      ".versions",
+      "hello",
+      "1",
+    );
+    await mkdir(versionDir, { recursive: true });
+    await fs.chmod(versionDir, 0o000);
+
+    try {
+      await expect(getVersionedArtifactPath("proj_artifact_io", "hello", "1"))
+        .rejects.toMatchObject({ code: "EACCES" });
+    } finally {
+      await fs.chmod(versionDir, 0o700);
+    }
   });
 
   test("normalizes computed imports in final single-file and bundle artifacts", async () => {
@@ -443,6 +490,25 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(Object.hasOwn(restored!, "entrypoint")).toBe(false);
     expect(Object.hasOwn(restored!, "import_map")).toBe(false);
     expect(await edgeFunctionService.read(ref, slug)).toContain("legacy");
+    expect(await edgeFunctionService.readSource(ref, slug)).toContain("legacy-source");
+    expect(await edgeFunctionService.getActiveVersion(ref, slug)).toBe("0");
+
+    const stale = await edgeFunctionService.deployRelease({
+      ref,
+      slug,
+      expectedActiveVersion: "1",
+      code: "export default { fetch: () => new Response('stale-release') };",
+    });
+
+    expect(stale).toMatchObject({
+      success: false,
+      error_code: EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE,
+      expected_active_version: "1",
+      active_version: "0",
+    });
+    expect((await edgeFunctionService.listVersions(ref, slug)).map(({ version }) => version))
+      .toEqual(["1", "0"]);
+    expect(await edgeFunctionService.getConfig(ref, slug)).toMatchObject({ version: "0" });
     expect(await edgeFunctionService.readSource(ref, slug)).toContain("legacy-source");
 
     const continued = await edgeFunctionService.deployRelease({

--- a/packages/management-api/tests/unit/final-security-regression.test.ts
+++ b/packages/management-api/tests/unit/final-security-regression.test.ts
@@ -24,7 +24,7 @@ function appWith(routes: Elysia) {
 describe("final security regressions", () => {
   test("function management read endpoints require auth but preserve authenticated access", async () => {
     const listFunctionsSpy = spyOn(projectService, "listFunctions").mockResolvedValue([
-      { slug: "hello", name: "hello" },
+      { slug: "hello", name: "hello", version: 0 },
     ] as Awaited<ReturnType<typeof projectService.listFunctions>>);
     const request = appWith(projectFunctionsRoutes);
 
@@ -49,9 +49,158 @@ describe("final security regressions", () => {
       expect(listFunctionsSpy).not.toHaveBeenCalled();
       const authenticated = await request("/v1/projects/proj_1/functions", { headers: masterHeaders });
       expect(authenticated.status).toBe(200);
-      expect(await authenticated.json()).toEqual([{ slug: "hello", name: "hello" }]);
+      expect(await authenticated.json()).toEqual([{ slug: "hello", name: "hello", version: 0 }]);
     } finally {
       listFunctionsSpy.mockRestore();
+    }
+  });
+
+  test("function list does not turn artifact IO failures into active results", async () => {
+    const ioError = Object.assign(new Error("synthetic function artifact failure"), {
+      code: "EIO",
+    });
+    const listFunctionsSpy = spyOn(projectService, "listFunctions").mockRejectedValue(ioError);
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions", {
+        headers: masterHeaders,
+      });
+
+      expect(response.status).toBe(500);
+      expect(await response.text()).not.toContain('"status":"ACTIVE"');
+    } finally {
+      listFunctionsSpy.mockRestore();
+    }
+  });
+
+  test("function detail resolves a manifest-less legacy alias as active version zero", async () => {
+    const codeSpy = spyOn(projectService, "getFunctionCode").mockResolvedValue("export default {};");
+    const configSpy = spyOn(edgeFunctionService, "getConfig").mockResolvedValue({ verify_jwt: true });
+    const activeVersionSpy = spyOn(edgeFunctionService, "getActiveVersion").mockResolvedValue("0");
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/legacy-hook", {
+        headers: masterHeaders,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        slug: "legacy-hook",
+        version: 0,
+        status: "ACTIVE",
+      });
+      expect(activeVersionSpy).toHaveBeenCalledWith("proj_1", "legacy-hook");
+    } finally {
+      codeSpy.mockRestore();
+      configSpy.mockRestore();
+      activeVersionSpy.mockRestore();
+    }
+  });
+
+  test("function version detail rejects legacy zero before service dispatch", async () => {
+    const getVersionSpy = spyOn(edgeFunctionService, "getVersion").mockRejectedValue(
+      new Error("legacy source version reached the service"),
+    );
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request(
+        "/v1/projects/proj_1/functions/legacy-hook/versions/0",
+        { headers: masterHeaders },
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        message: "version must be a canonical positive safe integer",
+        code: "VALIDATION_ERROR",
+      });
+      expect(getVersionSpy).not.toHaveBeenCalled();
+    } finally {
+      getVersionSpy.mockRestore();
+    }
+  });
+
+  test("metadata-only Function PATCH preserves the authoritative legacy version zero", async () => {
+    const updateConfigSpy = spyOn(edgeFunctionService, "updateConfig").mockResolvedValue({
+      verify_jwt: false,
+    });
+    const activeVersionSpy = spyOn(edgeFunctionService, "getActiveVersion").mockResolvedValue("0");
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/legacy-hook", {
+        method: "PATCH",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ verify_jwt: false }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        slug: "legacy-hook",
+        version: 0,
+        status: "ACTIVE",
+        verify_jwt: false,
+      });
+    } finally {
+      updateConfigSpy.mockRestore();
+      activeVersionSpy.mockRestore();
+    }
+  });
+
+  test("Function create readback uses release or filesystem truth without inventing version one", async () => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockResolvedValue({
+      success: true,
+      previous_active_version: "0",
+      active_version: "1",
+      config: { verify_jwt: true },
+    });
+    const configSpy = spyOn(edgeFunctionService, "getConfig").mockResolvedValue({ verify_jwt: true });
+    const activeVersionSpy = spyOn(edgeFunctionService, "getActiveVersion")
+      .mockResolvedValueOnce("0")
+      .mockResolvedValueOnce("absent");
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const multipart = new FormData();
+      multipart.set("metadata", JSON.stringify({ expected_active_version: "0" }));
+      multipart.set("file", new File(["export default {};"], "index.ts"));
+      const deployed = await request("/v1/projects/proj_1/functions/deploy?slug=legacy-hook", {
+        method: "POST",
+        headers: masterHeaders,
+        body: multipart,
+      });
+      const legacy = await request("/v1/projects/proj_1/functions", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "legacy-hook" }),
+      });
+      const absent = await request("/v1/projects/proj_1/functions", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "missing-hook" }),
+      });
+
+      expect(await deployed.json()).toMatchObject({
+        version: 1,
+        previous_active_version: "0",
+        status: "ACTIVE",
+      });
+      expect(await legacy.json()).toMatchObject({
+        slug: "legacy-hook",
+        version: 0,
+        status: "ACTIVE",
+      });
+      expect(await absent.json()).toMatchObject({
+        slug: "missing-hook",
+        version: null,
+        status: "INACTIVE",
+      });
+    } finally {
+      deploySpy.mockRestore();
+      configSpy.mockRestore();
+      activeVersionSpy.mockRestore();
     }
   });
 
@@ -330,7 +479,7 @@ describe("final security regressions", () => {
     const request = appWith(projectFunctionsRoutes);
 
     try {
-      for (const expectedActiveVersion of [0, "0", "01", "", "9007199254740992", null]) {
+      for (const expectedActiveVersion of [0, "01", "", "9007199254740992", null]) {
         const response = await request("/v1/projects/proj_1/functions/hello", {
           method: "POST",
           headers: { ...masterHeaders, "Content-Type": "application/json" },
@@ -343,6 +492,43 @@ describe("final security regressions", () => {
         expect(response.status).toBeGreaterThanOrEqual(400);
       }
       expect(deploySpy).not.toHaveBeenCalled();
+    } finally {
+      deploySpy.mockRestore();
+    }
+  });
+
+  test("function deploy accepts the canonical legacy version zero CAS token", async () => {
+    const deploySpy = spyOn(projectService, "deployFunctionRelease").mockResolvedValue({
+      success: true,
+      previous_active_version: "0",
+      active_version: "1",
+      version: "1",
+      config: { version: "1", verify_jwt: true },
+    });
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/legacy-hook", {
+        method: "POST",
+        headers: { ...masterHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "export default { fetch() { return new Response('upgraded') } }",
+          expected_active_version: "0",
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        slug: "legacy-hook",
+        previous_active_version: "0",
+        active_version: "1",
+        version: "1",
+      });
+      expect(deploySpy).toHaveBeenCalledWith(expect.objectContaining({
+        ref: "proj_1",
+        slug: "legacy-hook",
+        expectedActiveVersion: "0",
+      }));
     } finally {
       deploySpy.mockRestore();
     }
@@ -444,6 +630,36 @@ describe("final security regressions", () => {
         active_version: "2",
       });
       expect(activationSpy).toHaveBeenCalledWith("proj_1", "hello", "3", "1");
+    } finally {
+      activationSpy.mockRestore();
+    }
+  });
+
+  test("function activation accepts legacy version zero only as the CAS token", async () => {
+    const activationSpy = spyOn(edgeFunctionService, "activateVersion").mockResolvedValue({
+      previous_active_version: "0",
+      active_version: "2",
+      config: { version: "2", verify_jwt: true },
+    });
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request(
+        "/v1/projects/proj_1/functions/legacy-hook/versions/2/activate",
+        {
+          method: "POST",
+          headers: { ...masterHeaders, "Content-Type": "application/json" },
+          body: JSON.stringify({ expected_active_version: "0" }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        previous_active_version: "0",
+        active_version: "2",
+        version: "2",
+      });
+      expect(activationSpy).toHaveBeenCalledWith("proj_1", "legacy-hook", "2", "0");
     } finally {
       activationSpy.mockRestore();
     }

--- a/packages/management-api/tests/unit/project.service.comprehensive.test.ts
+++ b/packages/management-api/tests/unit/project.service.comprehensive.test.ts
@@ -1,10 +1,18 @@
 import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const functionsRoot = await fs.mkdtemp(join(tmpdir(), "supacloud-project-functions-"));
+const originalFunctionsDir = process.env.EDGE_FUNCTIONS_DIR;
+process.env.EDGE_FUNCTIONS_DIR = functionsRoot;
 
 const baseMock = mock(() => Promise.resolve([]));
 (baseMock as unknown as Record<string, unknown>).unsafe = mock(() => Promise.resolve([]));
 const actualDb = await import("../../src/db");
 const { jwtService } = await import("../../src/services/jwt.service");
 const { edgeFunctionService } = await import("../../src/services/edge-function.service");
+const { config } = await import("../../src/config");
 
 const jwtServiceMock = {
   generateProjectRef: spyOn(jwtService, "generateProjectRef"),
@@ -35,6 +43,9 @@ const routerServiceMock = {
 
 const edgeFunctionServiceMock = {
   read: spyOn(edgeFunctionService, "read"),
+  list: spyOn(edgeFunctionService, "list"),
+  getActiveVersion: spyOn(edgeFunctionService, "getActiveVersion"),
+  getConfig: spyOn(edgeFunctionService, "getConfig"),
   deploy: spyOn(edgeFunctionService, "deploy"),
   deployDetailed: spyOn(edgeFunctionService, "deployDetailed"),
   deployBundle: spyOn(edgeFunctionService, "deployBundle"),
@@ -162,6 +173,9 @@ describe("ProjectService - Comprehensive", () => {
     routerServiceMock.getProjectStudioUrl.mockReset();
     routerServiceMock.reload.mockReset();
     edgeFunctionServiceMock.read.mockReset();
+    edgeFunctionServiceMock.list.mockReset();
+    edgeFunctionServiceMock.getActiveVersion.mockReset();
+    edgeFunctionServiceMock.getConfig.mockReset();
     edgeFunctionServiceMock.deploy.mockReset();
     edgeFunctionServiceMock.deployDetailed.mockReset();
     edgeFunctionServiceMock.deployBundle.mockReset();
@@ -209,6 +223,9 @@ describe("ProjectService - Comprehensive", () => {
     routerServiceMock.getProjectStudioUrl.mockImplementation((ref: string) => `https://${ref}.studio.localhost`);
     routerServiceMock.reload.mockResolvedValue({ success: true });
     edgeFunctionServiceMock.read.mockResolvedValue("function code here");
+    edgeFunctionServiceMock.list.mockResolvedValue([]);
+    edgeFunctionServiceMock.getActiveVersion.mockResolvedValue("absent");
+    edgeFunctionServiceMock.getConfig.mockResolvedValue({ verify_jwt: true });
     edgeFunctionServiceMock.deploy.mockResolvedValue(true);
     edgeFunctionServiceMock.deployDetailed.mockResolvedValue({
       success: true,
@@ -630,6 +647,64 @@ describe("ProjectService - Comprehensive", () => {
     expect(await service.getFunctionCode("test123abc", "my-func")).toBe("function code here");
   });
 
+  test("listFunctions preserves the legacy active version zero", async () => {
+    const projectFunctionsDir = join(config.edgeFunctionsDir, "test123abc");
+    await fs.mkdir(projectFunctionsDir, { recursive: true });
+    await Bun.write(
+      join(projectFunctionsDir, "legacy-hook.js"),
+      "export default {};",
+    );
+    projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
+    edgeFunctionServiceMock.list.mockResolvedValueOnce(["legacy-hook"]);
+    edgeFunctionServiceMock.getActiveVersion.mockResolvedValueOnce("0");
+    edgeFunctionServiceMock.getConfig.mockResolvedValueOnce({ verify_jwt: true });
+
+    try {
+      const functions = await service.listFunctions("test123abc");
+
+      expect(functions).toHaveLength(1);
+      expect(functions[0]).toMatchObject({ slug: "legacy-hook", version: 0 });
+    } finally {
+      await fs.rm(projectFunctionsDir, { recursive: true, force: true });
+    }
+  });
+
+  test("listFunctions propagates missing and unreadable active artifacts", async () => {
+    projectRepositoryMock.findByRef.mockResolvedValue(mockProject);
+    edgeFunctionServiceMock.list.mockResolvedValue(["missing-active"]);
+    edgeFunctionServiceMock.getActiveVersion.mockResolvedValue("0");
+    edgeFunctionServiceMock.getConfig.mockResolvedValue({ verify_jwt: true });
+
+    await expect(service.listFunctions("test123abc")).rejects.toMatchObject({ code: "ENOENT" });
+
+    const permissionError = Object.assign(new Error("synthetic permission failure"), {
+      code: "EACCES",
+    });
+    const statSpy = spyOn(fs, "stat").mockRejectedValueOnce(permissionError);
+    try {
+      await expect(service.listFunctions("test123abc")).rejects.toBe(permissionError);
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  test("listFunctions rejects a missing versioned artifact despite a stale legacy alias", async () => {
+    const projectFunctionsDir = join(config.edgeFunctionsDir, "test123abc");
+    await fs.mkdir(projectFunctionsDir, { recursive: true });
+    await Bun.write(join(projectFunctionsDir, "upgraded-hook.js"), "stale legacy artifact");
+    projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
+    edgeFunctionServiceMock.list.mockResolvedValueOnce(["upgraded-hook"]);
+    edgeFunctionServiceMock.getActiveVersion.mockResolvedValueOnce("1");
+    edgeFunctionServiceMock.getConfig.mockResolvedValueOnce({ verify_jwt: true, version: "1" });
+
+    try {
+      await expect(service.listFunctions("test123abc"))
+        .rejects.toThrow("Active function artifact is missing");
+    } finally {
+      await fs.rm(projectFunctionsDir, { recursive: true, force: true });
+    }
+  });
+
   test("deployFunction delegates to edge function service", async () => {
     projectRepositoryMock.findByRef.mockResolvedValueOnce(mockProject);
     expect(await service.deployFunction("test123abc", "my-func", "code")).toBe(true);
@@ -667,6 +742,12 @@ describe("ProjectService - Comprehensive", () => {
   });
 });
 
-afterAll(() => {
+afterAll(async () => {
   mock.restore();
+  if (originalFunctionsDir === undefined) {
+    delete process.env.EDGE_FUNCTIONS_DIR;
+  } else {
+    process.env.EDGE_FUNCTIONS_DIR = originalFunctionsDir;
+  }
+  await fs.rm(functionsRoot, { recursive: true, force: true });
 });

--- a/packages/web-console/src/lib/function-version-details.test.ts
+++ b/packages/web-console/src/lib/function-version-details.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { requestImmutableFunctionVersion } from "./function-version-details";
+
+describe("immutable Function version detail requests", () => {
+  test("does not request legacy version zero", async () => {
+    const requestedPaths: string[] = [];
+    const response = await requestImmutableFunctionVersion(async (path) => {
+      requestedPaths.push(path);
+      return new Response();
+    }, {
+      projectRef: "proj_1",
+      slug: "legacy-hook",
+      version: "0",
+    });
+
+    expect(response).toBeNull();
+    expect(requestedPaths).toEqual([]);
+  });
+
+  test("rejects invalid versions and missing context without a request", async () => {
+    const requestedPaths: string[] = [];
+    const requester = async (path: string) => {
+      requestedPaths.push(path);
+      return new Response();
+    };
+
+    for (const version of ["", "00", "-1", "1.5", "9007199254740992"]) {
+      await expect(requestImmutableFunctionVersion(requester, {
+        projectRef: "proj_1",
+        slug: "hello",
+        version,
+      })).rejects.toThrow("函数版本详情请求无效，请刷新后重试");
+    }
+    await expect(requestImmutableFunctionVersion(requester, {
+      projectRef: "",
+      slug: "hello",
+      version: "1",
+    })).rejects.toThrow("函数版本详情上下文缺失，请刷新后重试");
+    await expect(requestImmutableFunctionVersion(requester, {
+      projectRef: undefined,
+      slug: "hello",
+      version: "1",
+    })).rejects.toThrow("函数版本详情上下文缺失，请刷新后重试");
+
+    expect(requestedPaths).toEqual([]);
+  });
+
+  test("requests a canonical positive version with encoded identifiers", async () => {
+    const requestedPaths: string[] = [];
+    const response = await requestImmutableFunctionVersion(async (path) => {
+      requestedPaths.push(path);
+      return new Response(null, { status: 200 });
+    }, {
+      projectRef: "proj/1",
+      slug: "hello world",
+      version: "12",
+    });
+
+    expect(response?.status).toBe(200);
+    expect(requestedPaths).toEqual([
+      "/v1/projects/proj%2F1/functions/hello%20world/versions/12",
+    ]);
+  });
+});

--- a/packages/web-console/src/lib/function-version-details.ts
+++ b/packages/web-console/src/lib/function-version-details.ts
@@ -1,0 +1,25 @@
+const POSITIVE_FUNCTION_VERSION_PATTERN = /^[1-9][0-9]*$/;
+
+interface FunctionVersionDetailRequest {
+  projectRef: string | undefined;
+  slug: string;
+  version: string;
+}
+
+export async function requestImmutableFunctionVersion(
+  requester: (path: string) => Promise<Response>,
+  request: FunctionVersionDetailRequest,
+): Promise<Response | null> {
+  if (request.version === "0") return null;
+  if (!POSITIVE_FUNCTION_VERSION_PATTERN.test(request.version)
+    || !Number.isSafeInteger(Number(request.version))) {
+    throw new Error("函数版本详情请求无效，请刷新后重试");
+  }
+  if (typeof request.projectRef !== "string" || request.projectRef.length === 0
+    || request.slug.length === 0) {
+    throw new Error("函数版本详情上下文缺失，请刷新后重试");
+  }
+  const projectRef = encodeURIComponent(request.projectRef);
+  const slug = encodeURIComponent(request.slug);
+  return requester(`/v1/projects/${projectRef}/functions/${slug}/versions/${request.version}`);
+}

--- a/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/functions/+page.svelte
@@ -19,6 +19,7 @@
     type FunctionTaskRecord,
   } from "$lib/function-snippets";
   import { getTaskLatestLogPreview, hasTaskLogPreview } from "$lib/function-task-details";
+  import { requestImmutableFunctionVersion } from "$lib/function-version-details";
   import {
     filterFunctionRuntimeLogs,
     getFunctionRuntimeErrorLogs,
@@ -387,7 +388,17 @@ export async function waitForTask(
     versionDetailLoading = version;
     versionDetailError = null;
     try {
-      const res = await apiClient(`/v1/projects/${projectRef}/functions/${encodeURIComponent(slug)}/versions/${encodeURIComponent(version)}`);
+      const res = await requestImmutableFunctionVersion(apiClient, {
+        projectRef,
+        slug,
+        version,
+      });
+      if (res === null) {
+        selectedVersion = null;
+        selectedVersionKey = null;
+        versionDetailError = "兼容版本 v0 仅作为并发控制标记，不提供不可变版本详情";
+        return;
+      }
       const payload = await res.json().catch(() => null);
       if (!res.ok) {
         throw new Error(payload?.message || "获取函数版本详情失败");
@@ -407,7 +418,7 @@ export async function waitForTask(
 
   function activeVersionForSlug(slug: string): string {
     const activeVersion = functions.find((fn) => fn.slug === slug)?.version;
-    if (typeof activeVersion !== "number" || !Number.isSafeInteger(activeVersion) || activeVersion < 1) {
+    if (typeof activeVersion !== "number" || !Number.isSafeInteger(activeVersion) || activeVersion < 0) {
       throw new Error("当前函数激活版本无效，请刷新后重试");
     }
     return String(activeVersion);
@@ -475,11 +486,11 @@ export async function waitForTask(
     selectedVersionKey = null;
     versionDetailError = null;
     await Promise.all([
-      loadFunctionTasks(fn.slug, String(fn.version || 1)),
-      loadFunctionRuntimeLogs(fn.slug, 20, String(fn.version || 1)),
+      loadFunctionTasks(fn.slug, String(fn.version)),
+      loadFunctionRuntimeLogs(fn.slug, 20, String(fn.version)),
       loadFunctionVersions(fn.slug),
     ]);
-    await loadVersionDetail(fn.slug, String(fn.version || 1));
+    await loadVersionDetail(fn.slug, String(fn.version));
   }
 
   function closeFunctionDrawer() {
@@ -920,7 +931,7 @@ export async function waitForTask(
         </div>
         <div class="rounded-xl border border-border/60 bg-muted/20 p-4">
           <div class="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">{$t("Functions.version")}</div>
-          <div class="mt-2 text-sm font-semibold">v{selectedFunction.version || 1}</div>
+          <div class="mt-2 text-sm font-semibold">v{selectedFunction.version}</div>
         </div>
         <div class="rounded-xl border border-border/60 bg-muted/20 p-4">
           <div class="text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground">{$t("Functions.jwt_verification")}</div>
@@ -950,7 +961,7 @@ export async function waitForTask(
             <p class="text-xs text-muted-foreground mt-1">查看历史版本、检查源码/编译产物，并将当前激活版本切换到任意历史版本。</p>
           </div>
           <div class="text-[11px] text-muted-foreground">
-            {$t("Functions.active_version", { values: { version: selectedFunction.version || 1 } })}
+            {$t("Functions.active_version", { values: { version: selectedFunction.version } })}
           </div>
         </div>
 
@@ -992,7 +1003,9 @@ export async function waitForTask(
                       <div class="flex items-center gap-2">
                         <button
                           onclick={() => loadVersionDetail(currentDrawerSlug, versionRecord.version)}
-                          class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-semibold hover:bg-muted/40 transition-colors"
+                          disabled={versionRecord.version === "0"}
+                          title={versionRecord.version === "0" ? "兼容版本 v0 不提供不可变版本详情" : "查看版本详情"}
+                          class="inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-semibold hover:bg-muted/40 transition-colors disabled:opacity-50"
                         >
                           <Bug size={13} />
                           查看详情

--- a/packages/web-console/src/routes/project/[ref]/functions/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/functions/page.test.ts
@@ -28,7 +28,17 @@ describe("edge function JWT toggle", () => {
   test("binds create and version activation requests to the observed active version", () => {
     expect(source).toContain('expected_active_version: "absent"');
     expect(source).toContain("activeVersionForSlug(slug)");
+    expect(source).toContain("activeVersion < 0");
     expect(source).toContain("expected_active_version: expectedActiveVersion");
     expect(source).toContain('versionRecord.version === "0"');
+    expect(source).not.toContain("fn.version || 1");
+    expect(source).not.toContain("selectedFunction.version || 1");
+  });
+
+  test("keeps legacy version zero out of immutable source detail requests", () => {
+    expect(source).toContain("requestImmutableFunctionVersion(apiClient");
+    expect(source).toContain("if (res === null)");
+    expect(source.match(/disabled=\{versionRecord\.version === "0"/g)).toHaveLength(2);
+    expect(source).toContain("兼容版本 v0 仅作为并发控制标记，不提供不可变版本详情");
   });
 });


### PR DESCRIPTION
## Summary

- accept canonical legacy active version 0 only as the optimistic-concurrency token for deploy and positive-version activation
- return the real active version in Management, CLI, and Web readbacks without inventing version 1 or treating orphan artifacts as active
- reject version 0 as an immutable-source or activation target and fail closed when active artifacts or filesystem reads are inconsistent
- align CLI documentation and Web legacy-version behavior with the public contract

## Verification

- Management unit suite: 192 test files; typecheck passed
- CLI: 477 tests; typecheck and build passed
- Web Console: 171 tests; svelte-check 0 errors/0 warnings; production build passed
- independent review: P0/P1/P2 = 0/0/0
- clean-code-guard: 2 fixed, 0 flagged for author

No release or deployment is included in this PR.