### PR TITLE
fix(functions): contain stored version artifact paths

### DIFF
--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -54,6 +54,7 @@ export interface EdgeFunctionDeployResult {
 
 export const EDGE_FUNCTION_ABSENT_ACTIVE_VERSION = "absent" as const;
 export const EDGE_FUNCTION_ACTIVE_VERSION_CONFLICT_CODE = "FUNCTION_ACTIVE_VERSION_CONFLICT" as const;
+export const EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE = "Active function artifact is missing";
 export const EDGE_FUNCTION_SHA256_HEX_PATTERN = "^[a-f0-9]{64}$";
 export type EdgeFunctionActiveVersion = string;
 
@@ -229,6 +230,12 @@ function parseVersionNumber(value: unknown): number | null {
   return parsed;
 }
 
+function canonicalFunctionVersion(value: unknown): string {
+  const parsedVersion = parseVersionNumber(value);
+  if (parsedVersion === null) throw new Error("Function config contains an invalid active version");
+  return String(parsedVersion);
+}
+
 export function activeFunctionVersionNumber(version: EdgeFunctionActiveVersion): number | null {
   if (version === EDGE_FUNCTION_ABSENT_ACTIVE_VERSION) return null;
   const parsedVersion = parseVersionNumber(version);
@@ -308,7 +315,8 @@ function getFuncPath(ref: string, slug: string): string {
 }
 
 function getVersionedFuncPath(ref: string, slug: string, version: string): string {
-  return assertInside(getFuncDir(ref), path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), version, "index.js"));
+  const versionDir = getFunctionVersionDir(ref, slug, version);
+  return assertInside(versionDir, path.join(versionDir, "index.js"));
 }
 
 function getSrcPath(ref: string, slug: string): string {
@@ -316,7 +324,8 @@ function getSrcPath(ref: string, slug: string): string {
 }
 
 function getVersionedSrcPath(ref: string, slug: string, version: string): string {
-  return assertInside(getFuncDir(ref), path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), version, "index.src.ts"));
+  const versionDir = getFunctionVersionDir(ref, slug, version);
+  return assertInside(versionDir, path.join(versionDir, "index.src.ts"));
 }
 
 function getConfigPath(ref: string, slug: string): string {
@@ -326,6 +335,11 @@ function getConfigPath(ref: string, slug: string): string {
 function getVersionRoot(ref: string, slug: string): string {
   const dir = getFuncDir(ref);
   return assertInside(dir, path.join(dir, VERSIONED_DIR, validateSlug(slug)));
+}
+
+function getFunctionVersionDir(ref: string, slug: string, version: string): string {
+  const versionRoot = getVersionRoot(ref, slug);
+  return assertInside(versionRoot, path.join(versionRoot, canonicalFunctionVersion(version)));
 }
 
 function getLegacySourceDir(ref: string, slug: string): string {
@@ -355,10 +369,32 @@ async function fileExists(filePath: string): Promise<boolean> {
   }
 }
 
+async function readOptionalFunctionFile(filePath: string): Promise<string | null> {
+  try {
+    return await Bun.file(filePath).text();
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function parsedFunctionConfig(raw: string): EdgeFunctionConfig {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)
+    || Object.getPrototypeOf(parsed) !== Object.prototype) {
+    throw new Error("Function config must be an object");
+  }
+  const functionConfig = { ...DEFAULT_FUNCTION_CONFIG, ...parsed } as EdgeFunctionConfig;
+  if (functionConfig.version !== undefined) {
+    functionConfig.version = canonicalFunctionVersion(functionConfig.version);
+  }
+  return functionConfig;
+}
+
 async function readFunctionConfig(ref: string, slug: string): Promise<EdgeFunctionConfig> {
   try {
     const raw = await Bun.file(getConfigPath(ref, slug)).text();
-    return { ...DEFAULT_FUNCTION_CONFIG, ...JSON.parse(raw) };
+    return parsedFunctionConfig(raw);
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     return { ...DEFAULT_FUNCTION_CONFIG };
@@ -381,9 +417,6 @@ async function activeFunctionVersion(
 ): Promise<EdgeFunctionActiveVersion> {
   const functionConfig = await readFunctionConfig(ref, slug);
   if (functionConfig.version !== undefined) {
-    if (parseVersionNumber(functionConfig.version) === null) {
-      throw new Error("Function config contains an invalid active version");
-    }
     return functionConfig.version;
   }
   return await frozenLegacyRuntimePath(ref, slug) === null
@@ -786,7 +819,7 @@ async function readFunctionVersionMetadata(
   slug: string,
   version: string,
 ): Promise<FunctionVersionMetadata> {
-  const versionDir = assertInside(getVersionRoot(ref, slug), path.join(getVersionRoot(ref, slug), version));
+  const versionDir = getFunctionVersionDir(ref, slug, version);
   const metadataPath = path.join(versionDir, FUNCTION_VERSION_METADATA_FILE);
   const metadataRecord = JSON.parse(await Bun.file(metadataPath).text()) as Record<string, unknown>;
   if (!metadataRecord || typeof metadataRecord !== "object" || Array.isArray(metadataRecord)) {
@@ -856,7 +889,7 @@ async function backfillActiveVersionMetadata(
   version: string,
   functionConfig: EdgeFunctionConfig,
 ): Promise<void> {
-  const versionDir = assertInside(getVersionRoot(ref, slug), path.join(getVersionRoot(ref, slug), version));
+  const versionDir = getFunctionVersionDir(ref, slug, version);
   let existingMetadata: FunctionVersionMetadata | null = null;
   try {
     existingMetadata = await readFunctionVersionMetadata(ref, slug, version);
@@ -880,7 +913,7 @@ async function snapshotFrozenLegacyVersion(
   snapshot: LegacyVersionSnapshotRequest,
 ): Promise<EdgeFunctionConfig> {
   const versionRoot = getVersionRoot(snapshot.ref, snapshot.slug);
-  const finalDir = assertInside(versionRoot, path.join(versionRoot, snapshot.version));
+  const finalDir = getFunctionVersionDir(snapshot.ref, snapshot.slug, snapshot.version);
   if (await fileExists(finalDir)) {
     return completeFrozenLegacyVersionSnapshot(snapshot, finalDir);
   }
@@ -1270,10 +1303,7 @@ async function maxHistoricalFunctionVersion(ref: string, slug: string): Promise<
 }
 
 async function assertFunctionVersionAvailable(ref: string, slug: string, version: number): Promise<void> {
-  const candidate = assertInside(
-    getFuncDir(ref),
-    path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), String(version)),
-  );
+  const candidate = getFunctionVersionDir(ref, slug, String(version));
   try {
     await fs.access(candidate);
     throw new Error(`Function version directory already exists: ${version}`);
@@ -1304,11 +1334,11 @@ async function readVersionedFunctionSource(
   version: string,
   entrypoint: string = "index.ts",
 ): Promise<string | null> {
-  const versionRoot = path.join(getVersionRoot(ref, slug), version);
+  const versionRoot = getFunctionVersionDir(ref, slug, version);
   const candidates = [
     getVersionedSrcPath(ref, slug, version),
     resolveInside(path.join(versionRoot, "src"), entrypoint),
-    path.join(versionRoot, "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
+    assertInside(versionRoot, path.join(versionRoot, "src", BUNDLED_SOURCE_RUNTIME_ENTRY)),
   ];
   for (const candidate of candidates) {
     if (await fileExists(candidate)) return Bun.file(candidate).text();
@@ -1321,7 +1351,7 @@ export async function getVersionedArtifactPath(
   slug: string,
   version: string,
 ): Promise<string | null> {
-  const dir = assertInside(getFuncDir(ref), path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), version));
+  const dir = getFunctionVersionDir(ref, slug, version);
   try {
     const entries = await fs.readdir(dir);
     const contentAddressed = entries
@@ -1465,7 +1495,7 @@ async function immutableFunctionVersion(
   currentConfig: EdgeFunctionConfig,
 ): Promise<PreparedFunctionRelease> {
   const versionRoot = getVersionRoot(request.ref, request.slug);
-  const finalDir = assertInside(versionRoot, path.join(versionRoot, version));
+  const finalDir = getFunctionVersionDir(request.ref, request.slug, version);
   const stageDir = assertInside(
     versionRoot,
     path.join(versionRoot, `.pending-${version}-${crypto.randomUUID()}`),
@@ -1845,36 +1875,22 @@ export const edgeFunctionService = {
 
   /** Read function bundled code (runtime version) */
   async read(ref: string, slug: string): Promise<string | null> {
-    try {
-      const cfg = await this.getConfig(ref, slug);
-      if (cfg.version) {
-        const versioned = await readVersionedFunctionCode(ref, slug, cfg.version);
-        if (versioned !== null) return versioned;
-      }
-      return await Bun.file(getFuncPath(ref, slug)).text();
-    } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        logger.error(`[EdgeFunction] Failed to read ${slug}`, {
-          ref,
-          error: err,
-        });
-      }
-      return null;
+    const cfg = await this.getConfig(ref, slug);
+    if (cfg.version !== undefined) {
+      const versioned = await readVersionedFunctionCode(ref, slug, cfg.version);
+      if (versioned === null) throw new Error(EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE);
+      return versioned;
     }
+    return readOptionalFunctionFile(getFuncPath(ref, slug));
   },
 
   /** Read function original source (for debugging) */
   async readSource(ref: string, slug: string): Promise<string | null> {
-    try {
-      const cfg = await this.getConfig(ref, slug);
-      if (cfg.version) {
-        const versioned = await readVersionedFunctionSource(ref, slug, cfg.version, cfg.entrypoint);
-        if (versioned !== null) return versioned;
-      }
-      return await Bun.file(getSrcPath(ref, slug)).text();
-    } catch {
-      return null;
+    const cfg = await this.getConfig(ref, slug);
+    if (cfg.version !== undefined) {
+      return readVersionedFunctionSource(ref, slug, cfg.version, cfg.entrypoint);
     }
+    return readOptionalFunctionFile(getSrcPath(ref, slug));
   },
 
   async listVersions(ref: string, slug: string): Promise<EdgeFunctionVersionRecord[]> {
@@ -1884,9 +1900,10 @@ export const edgeFunctionService = {
 
     const records = await Promise.all(
       versions.map(async (version) => {
+        const versionDir = getFunctionVersionDir(ref, slug, version);
         const bundlePath = await getVersionedArtifactPath(ref, slug, version);
         const sourcePath = getVersionedSrcPath(ref, slug, version);
-        const sourceDirPath = assertInside(getFuncDir(ref), path.join(getFuncDir(ref), VERSIONED_DIR, validateSlug(slug), version, "src"));
+        const sourceDirPath = assertInside(versionDir, path.join(versionDir, "src"));
         const [hasBundle, hasSource, hasSourceDir] = await Promise.all([
           bundlePath ? fileExists(bundlePath) : Promise.resolve(false),
           fileExists(sourcePath),

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -1000,7 +1000,6 @@ async function ensureConfiguredRollbackSnapshot(
   ref: string,
   slug: string,
   currentConfig: EdgeFunctionConfig,
-  legacyRuntimePath: string | null,
 ): Promise<EdgeFunctionConfig> {
   const version = currentConfig.version!;
   if (parseVersionNumber(version) === null) {
@@ -1010,16 +1009,7 @@ async function ensureConfiguredRollbackSnapshot(
     await backfillActiveVersionMetadata(ref, slug, version, currentConfig);
     return currentConfig;
   }
-  if (!legacyRuntimePath) {
-    throw new Error("Active function version artifact is missing and no frozen legacy alias exists");
-  }
-  return snapshotFrozenLegacyVersion({
-    ref,
-    slug,
-    version,
-    functionConfig: currentConfig,
-    runtimePath: legacyRuntimePath,
-  });
+  throw new Error("Active function version artifact is missing");
 }
 
 async function ensureLegacyVersionZeroSnapshot(
@@ -1059,15 +1049,14 @@ async function ensureLegacyVersionZeroSnapshot(
 async function ensureCurrentRollbackSnapshot(
   snapshot: CurrentRollbackSnapshotRequest,
 ): Promise<EdgeFunctionConfig> {
-  const legacyRuntimePath = await frozenLegacyRuntimePath(snapshot.ref, snapshot.slug);
   if (snapshot.currentConfig.version) {
     return ensureConfiguredRollbackSnapshot(
       snapshot.ref,
       snapshot.slug,
       snapshot.currentConfig,
-      legacyRuntimePath,
     );
   }
+  const legacyRuntimePath = await frozenLegacyRuntimePath(snapshot.ref, snapshot.slug);
   if (!legacyRuntimePath) return snapshot.currentConfig;
   return ensureLegacyVersionZeroSnapshot(snapshot, legacyRuntimePath);
 }

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -8,6 +8,7 @@ import { taskRepository } from "../repositories/task.repository";
 import type { Project, ProjectStatus } from "../db";
 import { resolveBucketName, resolveDbName, resolveRoleName, generateDbName } from "../db";
 import {
+  EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE,
   activeFunctionVersionNumber,
   edgeFunctionService,
   getVersionedArtifactPath,
@@ -822,7 +823,7 @@ export class ProjectService {
       const activePath = cfg.version === undefined
         ? `${config.edgeFunctionsDir}/${ref}/${slug}.js`
         : await getVersionedArtifactPath(ref, slug, cfg.version);
-      if (activePath === null) throw new Error("Active function artifact is missing");
+      if (activePath === null) throw new Error(EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE);
       const fileStat = await fs.stat(activePath);
       const updated_at = fileStat.mtime.toISOString();
       const created_at = fileStat.birthtime.toISOString();

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -616,7 +616,7 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(await edgeFunctionService.readSource(ref, slug)).toContain("post-legacy-release");
   });
 
-  test("keeps configured reads version-bound before repairing a rollback snapshot", async () => {
+  test("rejects deploy when a configured positive artifact is missing despite a legacy alias", async () => {
     const ref = "proj_missing_active_artifact";
     const slug = "missing-active-artifact";
     const projectDir = join(functionsRoot, ref);
@@ -634,6 +634,13 @@ describe("edgeFunctionService bundle metadata", () => {
         version: "7",
       })),
     ]);
+    const manifestPath = join(projectDir, `${slug}.config.json`);
+    const manifestBefore = await readFile(manifestPath, "utf8");
+    let runtimeRequests = 0;
+    globalThis.fetch = (async () => {
+      runtimeRequests += 1;
+      return Response.json({ success: true });
+    }) as typeof fetch;
 
     await expect(edgeFunctionService.read(ref, slug))
       .rejects.toThrow("Active function artifact is missing");
@@ -646,16 +653,14 @@ describe("edgeFunctionService bundle metadata", () => {
       config: { verify_jwt: true, background_routes: ["/eight/*"] },
     });
 
-    expect(deployed).toMatchObject({ success: true, version: "8" });
+    expect(deployed).toMatchObject({ success: false });
+    expect(deployed.error).toContain("Active function version artifact is missing");
+    expect(runtimeRequests).toBe(0);
+    expect(await readFile(manifestPath, "utf8")).toBe(manifestBefore);
+    expect(existsSync(join(versionDir, "index.js"))).toBe(false);
+    expect(existsSync(join(projectDir, ".versions", slug, "8"))).toBe(false);
     expect(await Bun.file(legacyBundlePath).text()).toBe(legacyBundle);
-    const restored = await activateConditionalVersion(ref, slug, "7");
-    expect(restored).toMatchObject({
-      version: "7",
-      verify_jwt: false,
-      background_routes: ["/seven/*"],
-    });
-    expect(await edgeFunctionService.read(ref, slug)).toContain("legacy-seven");
-    expect(await edgeFunctionService.readSource(ref, slug)).toContain("source-seven");
+    expect(await Bun.file(legacySourcePath).text()).toContain("source-seven");
   });
 
   test("backfills full metadata for an existing active version before deployment", async () => {

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
@@ -35,6 +36,26 @@ async function deployConditionalRelease(
 async function activateConditionalVersion(ref: string, slug: string, version: string) {
   const expectedActiveVersion = (await edgeFunctionService.getConfig(ref, slug)).version ?? "absent";
   return (await edgeFunctionService.activateVersion(ref, slug, version, expectedActiveVersion))?.config ?? null;
+}
+
+async function writeConfiguredAliases(ref: string, slug: string, version: string): Promise<void> {
+  const projectDir = join(functionsRoot, ref);
+  await mkdir(projectDir, { recursive: true });
+  await Promise.all([
+    Bun.write(join(projectDir, `${slug}.config.json`), JSON.stringify({ version })),
+    Bun.write(join(projectDir, `${slug}.js`), "stale-alias-bundle"),
+    Bun.write(join(projectDir, `${slug}.src.ts`), "stale-alias-source"),
+  ]);
+}
+
+async function writeCrossSlugFixture(ref: string): Promise<void> {
+  const otherVersionDir = join(functionsRoot, ref, ".versions", "other", "1");
+  await mkdir(otherVersionDir, { recursive: true });
+  await Promise.all([
+    Bun.write(join(otherVersionDir, "index.js"), "cross-slug-bundle"),
+    Bun.write(join(otherVersionDir, "index.src.ts"), "cross-slug-source"),
+    writeConfiguredAliases(ref, "traversal", "../other/1"),
+  ]);
 }
 
 const runtimeInvalidationProtocol = {
@@ -144,26 +165,93 @@ describe("edgeFunctionService bundle metadata", () => {
       Bun.write(join(projectDir, "corrupt.config.json"), "{"),
     ]);
 
+    await expect(edgeFunctionService.read(ref, "corrupt")).rejects.toThrow();
+    await expect(edgeFunctionService.readSource(ref, "corrupt")).rejects.toThrow();
     await expect(edgeFunctionService.list(ref)).rejects.toThrow();
 
     await rm(join(projectDir, "corrupt.config.json"));
     expect(await edgeFunctionService.list(ref)).toEqual(["configured", "legacy"]);
   });
 
+  test("rejects non-object function config documents at the read boundary", async () => {
+    const ref = "proj_non_object_config";
+    const projectDir = join(functionsRoot, ref);
+    await mkdir(projectDir, { recursive: true });
+
+    for (const [slug, document] of [["array", "[]"], ["null", "null"], ["scalar", '"value"']]) {
+      await Bun.write(join(projectDir, `${slug}.config.json`), document);
+      await expect(edgeFunctionService.read(ref, slug)).rejects.toThrow("Function config must be an object");
+      await expect(edgeFunctionService.readSource(ref, slug)).rejects.toThrow("Function config must be an object");
+    }
+  });
+
+  test("rejects noncanonical config versions without cross-function reads", async () => {
+    const ref = "proj_version_path_binding";
+    await writeCrossSlugFixture(ref);
+
+    for (const [slug, version] of [
+      ["traversal", "../other/1"],
+      ["leading-zero", "01"],
+      ["unsafe-integer", "9007199254740992"],
+    ]) {
+      if (slug !== "traversal") await writeConfiguredAliases(ref, slug, version);
+      await expect(edgeFunctionService.read(ref, slug)).rejects.toThrow();
+      await expect(edgeFunctionService.readSource(ref, slug)).rejects.toThrow();
+    }
+  });
+
+  test("function read routes reject cross-function version paths", async () => {
+    const ref = "proj_route_version_path_binding";
+    await writeCrossSlugFixture(ref);
+
+    const { projectFunctionsRoutes } = await import("../../src/routes/project-functions");
+    const { projectService } = await import("../../src/services/project.service");
+    const codeSpy = spyOn(projectService, "getFunctionCode")
+      .mockImplementation((requestedRef, requestedSlug) => (
+        edgeFunctionService.read(requestedRef, requestedSlug)
+      ));
+    const app = new Elysia().use(projectFunctionsRoutes);
+    const request = (path: string) => app.handle(new Request(`http://localhost${path}`, {
+      headers: { Authorization: "Bearer dev-master-token" },
+    }));
+
+    try {
+      for (const suffix of ["", "/source", "/body"]) {
+        const response = await request(`/v1/projects/${ref}/functions/traversal${suffix}`);
+        const body = await response.text();
+        expect(response.status).toBe(500);
+        expect(body).not.toContain("cross-slug");
+        expect(body).not.toContain("stale-alias");
+        expect(body).not.toContain('\"status\":\"ACTIVE\"');
+      }
+    } finally {
+      codeSpy.mockRestore();
+    }
+  });
+
   test("propagates unreadable version artifact directories", async () => {
+    const ref = "proj_artifact_io";
+    const slug = "hello";
+    const projectDir = join(functionsRoot, ref);
     const versionDir = join(
-      functionsRoot,
-      "proj_artifact_io",
+      projectDir,
       ".versions",
-      "hello",
+      slug,
       "1",
     );
     await mkdir(versionDir, { recursive: true });
+    await Promise.all([
+      Bun.write(join(projectDir, `${slug}.config.json`), JSON.stringify({ version: "1" })),
+      Bun.write(join(projectDir, `${slug}.js`), "stale alias bundle"),
+      Bun.write(join(projectDir, `${slug}.src.ts`), "stale alias source"),
+    ]);
     await fs.chmod(versionDir, 0o000);
 
     try {
-      await expect(getVersionedArtifactPath("proj_artifact_io", "hello", "1"))
+      await expect(getVersionedArtifactPath(ref, slug, "1"))
         .rejects.toMatchObject({ code: "EACCES" });
+      await expect(edgeFunctionService.read(ref, slug)).rejects.toMatchObject({ code: "EACCES" });
+      await expect(edgeFunctionService.readSource(ref, slug)).rejects.toMatchObject({ code: "EACCES" });
     } finally {
       await fs.chmod(versionDir, 0o700);
     }
@@ -528,7 +616,7 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(await edgeFunctionService.readSource(ref, slug)).toContain("post-legacy-release");
   });
 
-  test("repairs a configured version with missing artifacts from frozen aliases", async () => {
+  test("keeps configured reads version-bound before repairing a rollback snapshot", async () => {
     const ref = "proj_missing_active_artifact";
     const slug = "missing-active-artifact";
     const projectDir = join(functionsRoot, ref);
@@ -546,6 +634,10 @@ describe("edgeFunctionService bundle metadata", () => {
         version: "7",
       })),
     ]);
+
+    await expect(edgeFunctionService.read(ref, slug))
+      .rejects.toThrow("Active function artifact is missing");
+    expect(await edgeFunctionService.readSource(ref, slug)).toBeNull();
 
     const deployed = await deployConditionalRelease({
       ref,

--- a/packages/management-api/tests/unit/final-security-regression.test.ts
+++ b/packages/management-api/tests/unit/final-security-regression.test.ts
@@ -6,6 +6,7 @@ import { projectSecretsRoutes } from "../../src/routes/project-secrets";
 import { projectConfigRoutes } from "../../src/routes/project-config";
 import { projectService } from "../../src/services/project.service";
 import {
+  EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE,
   EdgeFunctionActiveVersionConflictError,
   edgeFunctionService,
 } from "../../src/services/edge-function.service";
@@ -96,6 +97,29 @@ describe("final security regressions", () => {
       codeSpy.mockRestore();
       configSpy.mockRestore();
       activeVersionSpy.mockRestore();
+    }
+  });
+
+  test("function detail does not report active metadata after an active artifact failure", async () => {
+    const codeSpy = spyOn(projectService, "getFunctionCode").mockRejectedValue(
+      new Error(EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE),
+    );
+    const configSpy = spyOn(edgeFunctionService, "getConfig");
+    const request = appWith(projectFunctionsRoutes);
+
+    try {
+      const response = await request("/v1/projects/proj_1/functions/upgraded-hook", {
+        headers: masterHeaders,
+      });
+      const body = await response.text();
+
+      expect(response.status).toBe(500);
+      expect(body).not.toContain("stale-positive-alias");
+      expect(body).not.toContain('"status":"ACTIVE"');
+      expect(configSpy).not.toHaveBeenCalled();
+    } finally {
+      codeSpy.mockRestore();
+      configSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

- validate deserialized Function config as a plain object
- require canonical non-negative safe-integer stored versions
- bind every versioned bundle, source, and metadata path to the current Function slug root and fail closed on missing positive artifacts

## Regression coverage

- cross-slug ../other/1 reads for read, readSource, detail, and source routes
- non-canonical 01 and unsafe 9007199254740992 versions
- legacy v0 migration, positive immutable reads, activation, and stale-alias rejection

## Verification

- Management targeted 105/105 and full 1958/1958 plus typecheck
- CLI 477/477 plus typecheck and build
- Web 171/171 plus check and build
- independent review P0/P1/P2 = 0/0/0
- clean-code-guard: clean

Base 48db1e2d; head 35575db0; tree a3149981; stable patch-id e73b85d0.