### PR TITLE
fix(release): require human merge for release PRs

### DIFF
--- a/.github/scripts/ai-review-merge.mjs
+++ b/.github/scripts/ai-review-merge.mjs
@@ -14,8 +14,8 @@
  *             workflow, or review-context file is force-blocked and requires
  *             human approval.
  *   Layer 5 — Submitter identity gate: Only repo members (OWNER/MEMBER/COLLABORATOR)
- *             or recognized bots (Dependabot, release-please, etc.) are eligible for
- *             auto-merge. External contributors get review-only.
+ *             or recognized bots are eligible for auto-merge. Release Please PRs
+ *             always require a human merge; external contributors get review-only.
  *
  * Required env vars:
  *   AI_API_KEY        - OpenAI-compatible API key (GitHub Secret)
@@ -170,6 +170,10 @@ const KNOWN_BOTS = new Set([
   "semantic-release[bot]",
 ]);
 
+const RELEASE_PLEASE_HEAD_PREFIX = 'release-please--branches--';
+const RELEASE_PLEASE_LABEL_PREFIX = 'autorelease:';
+const NO_AI_MERGE_LABEL = 'no-ai-merge';
+
 // --- Context & Skill config --------------------------------------------
 
 const CONTEXT_FILES = [
@@ -285,6 +289,22 @@ async function getPRDetails() {
   return ghFetch(`/pulls/${PR_NUM}`);
 }
 
+function pullRequestLabelNames(prDetails) {
+  return (prDetails?.labels || [])
+    .map((label) => typeof label === 'string' ? label : label?.name)
+    .filter((label) => typeof label === 'string');
+}
+
+export function isReleasePleasePullRequest(prDetails) {
+  const headRef = prDetails?.head?.ref || '';
+  return headRef.startsWith(RELEASE_PLEASE_HEAD_PREFIX)
+    || pullRequestLabelNames(prDetails).some((label) => label.startsWith(RELEASE_PLEASE_LABEL_PREFIX));
+}
+
+export function hasNoAiMergeLabel(prDetails) {
+  return pullRequestLabelNames(prDetails).includes(NO_AI_MERGE_LABEL);
+}
+
 export function validatePullRequestForMerge(prDetails, {
   expectedHeadSha,
   expectedHeadRef,
@@ -295,6 +315,12 @@ export function validatePullRequestForMerge(prDetails, {
   }
   if (prDetails.draft) {
     throw new Error('Pull request is still a draft.');
+  }
+  if (hasNoAiMergeLabel(prDetails)) {
+    throw new Error('Pull request has the no-ai-merge label.');
+  }
+  if (isReleasePleasePullRequest(prDetails)) {
+    throw new Error('Release Please pull requests require human merge approval.');
   }
 
   const headSha = prDetails.head?.sha;
@@ -707,14 +733,16 @@ async function main() {
     console.log('PR is a draft. Skipping.');
     return;
   }
+  if (isReleasePleasePullRequest(prDetails)) {
+    console.log('Release Please PR requires human merge approval. Skipping auto-merge.');
+    return;
+  }
   // 补充 BASE_REF / HEAD_REF
   const effectiveBaseRef = BASE_REF || prDetails.base?.ref || 'unknown';
   const effectiveHeadRef = HEAD_REF || prDetails.head?.ref || 'unknown';
   const sha = HEAD_SHA || prDetails.head?.sha;
 
-  // 检查 "no-ai-merge" label
-  const labels = (prDetails.labels || []).map((l) => l.name);
-  if (labels.includes('no-ai-merge')) {
+  if (hasNoAiMergeLabel(prDetails)) {
     console.log('PR has "no-ai-merge" label. Skipping auto-merge.');
     return;
   }

--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -7,7 +7,9 @@ import {
   buildMergeRequestBody,
   detectSelfModification,
   formatAiUnavailableComment,
+  hasNoAiMergeLabel,
   isAiProviderUnavailableError,
+  isReleasePleasePullRequest,
   isTrustedSubmitter,
   summarizeCIStatus,
   summarizeAiProviderError,
@@ -240,6 +242,35 @@ describe('atomic merge preconditions', () => {
       }),
       /single line/,
     );
+    assert.throws(
+      () => validatePullRequestForMerge({
+        ...openPullRequest,
+        head: { sha: 'head-sha', ref: 'release-please--branches--main' },
+      }, {
+        expectedHeadSha: 'head-sha',
+        expectedHeadRef: 'release-please--branches--main',
+        expectedBaseRef: 'main',
+      }),
+      /human merge approval/,
+    );
+    assert.throws(
+      () => validatePullRequestForMerge({
+        ...openPullRequest,
+        labels: [{ name: 'autorelease: pending' }],
+      }, {
+        expectedHeadSha: 'head-sha', expectedHeadRef: 'feature/harden-merge', expectedBaseRef: 'main',
+      }),
+      /human merge approval/,
+    );
+    assert.throws(
+      () => validatePullRequestForMerge({
+        ...openPullRequest,
+        labels: [{ name: 'no-ai-merge' }],
+      }, {
+        expectedHeadSha: 'head-sha', expectedHeadRef: 'feature/harden-merge', expectedBaseRef: 'main',
+      }),
+      /no-ai-merge label/,
+    );
   });
 
   test('preserves the conventional PR title and expected SHA for squash commits', () => {
@@ -251,6 +282,31 @@ describe('atomic merge preconditions', () => {
       merge_method: 'squash',
       sha: 'head-sha',
     });
+  });
+});
+
+describe('Release Please merge gate', () => {
+  test('detects release branches and labels independently', () => {
+    assert.equal(isReleasePleasePullRequest({
+      head: { ref: 'release-please--branches--main' },
+      labels: [],
+    }), true);
+    assert.equal(isReleasePleasePullRequest({
+      head: { ref: 'automation/prepare-release' },
+      labels: [{ name: 'autorelease: pending' }],
+    }), true);
+  });
+
+  test('keeps ordinary automation PRs eligible for the existing identity gate', () => {
+    assert.equal(isReleasePleasePullRequest({
+      head: { ref: 'automation/sync-supacloud-dependencies' },
+      labels: [{ name: 'dependencies' }],
+    }), false);
+  });
+
+  test('recognizes the manual merge freeze label at the final write boundary', () => {
+    assert.equal(hasNoAiMergeLabel({ labels: ['no-ai-merge'] }), true);
+    assert.equal(hasNoAiMergeLabel({ labels: [{ name: 'dependencies' }] }), false);
   });
 });
 


### PR DESCRIPTION
## Summary

- identify Release Please PRs from their stable branch prefix or autorelease labels
- require human merge approval for those PRs before any AI review or merge path
- revalidate both Release Please identity and no-ai-merge at the final merge write boundary
- preserve ordinary dependency and automation PR eligibility

## Incident closed

Release Please PR #838 was accepted by the generic trusted-bot path and created source-only release tags before its publish jobs were cancelled. This change makes release approval an explicit human boundary and closes the late-label race.

## Verification

- node syntax check
- ai-review-merge test suite 16/16
- branch-prefix, autorelease-label, ordinary automation, late no-ai-merge, and atomic final-write regressions
- git diff check
- clean-code-guard: 2 fixed, 0 flagged

Base 48db1e2d; head 839c6f05; tree 7bef39c7; stable patch-id 04a13b11.