### PR TITLE
fix(cli): bound release mutation response reads

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 * **cli:** fail closed for production and read-only writes, and require exact production confirmation
+* **functions:** bound release mutation response reads and report uncertain outcomes without response content
 * **cli:** honor explicit project refs consistently while preventing production cross-ref writes
 
 ## [0.17.1](https://github.com/zuohuadong/supacloud/compare/cli-v0.17.0...cli-v0.17.1) (2026-08-11)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -228,7 +228,10 @@ server response body.
 Mutation receipts use schema `supacloud.cli.release-control.v1`. An
 `OUTCOME_UNKNOWN` error means the server may have committed the mutation before
 the response was lost or failed validation; read back current state before any
-retry.
+retry. For Function deploy, bundle deploy, and activation, the CLI applies a
+separate 5-second, 64 KiB response-body boundary after receiving HTTP headers.
+A stalled, oversized, truncated, unreadable, or malformed body is always
+`OUTCOME_UNKNOWN` and its content is never included in CLI output.
 Version `0` is reserved as the active-version CAS token for legacy Functions. It
 can be passed only as `--expected-active-version`; immutable source reads and
 activation targets still require a positive version.

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -11,6 +11,9 @@ function captureEdgeFunctionsTool(
     http: Record<string, unknown>,
     options: { readOnly?: boolean } = {},
 ) {
+    const releaseMutationHttp = typeof http.postReleaseMutation === "function"
+        ? http
+        : { ...http, postReleaseMutation: http.post };
     let schema: ToolSchema | undefined;
     let callback: ((args: Record<string, unknown>) => Promise<{
         content: Array<{ text: string }>;
@@ -22,7 +25,7 @@ function captureEdgeFunctionsTool(
             schema = toolSchema;
             callback = toolCallback;
         },
-    }, http as any, process.env, options);
+    }, releaseMutationHttp as any, process.env, options);
 
     if (!schema || !callback) throw new Error("edge_functions tool was not registered");
     return { schema, callback };
@@ -807,10 +810,80 @@ describe("edge_functions CLI tool", () => {
         })).toThrow("Invalid arguments");
     });
 
+    test("routes every release-control Function mutation through the bounded response transport", async () => {
+        const releaseMutationPaths: string[] = [];
+        let ordinaryPostCount = 0;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async () => {
+                ordinaryPostCount += 1;
+                throw new Error("release mutation used the ordinary POST reader");
+            },
+            postReleaseMutation: async (path: string, body: Record<string, unknown>) => {
+                releaseMutationPaths.push(path);
+                const slug = path.split("/functions/")[1].split("/")[0];
+                const previousActiveVersion = String(body.expected_active_version);
+                const activeVersion = { single: "2", bundle: "3", restore: "1" }[slug];
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        success: true,
+                        project_ref: "proj",
+                        slug,
+                        previous_active_version: previousActiveVersion,
+                        active_version: activeVersion,
+                        version: activeVersion,
+                        config: { version: activeVersion, verify_jwt: true },
+                    },
+                };
+            },
+        });
+
+        const mutations = [
+            {
+                action: "deploy",
+                ref: "proj",
+                slug: "single",
+                code: "export default {};",
+                "expected-active-version": "1",
+            },
+            {
+                action: "deploy_bundle",
+                ref: "proj",
+                slug: "bundle",
+                files: { "index.ts": "export default {};" },
+                "expected-active-version": "2",
+            },
+            {
+                action: "activate",
+                ref: "proj",
+                slug: "restore",
+                version: "1",
+                "expected-active-version": "3",
+            },
+        ];
+        const responses = [];
+        for (const mutation of mutations) responses.push(await callback(mutation));
+
+        expect(responses.every((response) => response.isError !== true)).toBe(true);
+        expect(ordinaryPostCount).toBe(0);
+        expect(releaseMutationPaths).toEqual([
+            "/v1/projects/proj/functions/single",
+            "/v1/projects/proj/functions/bundle/bundle",
+            "/v1/projects/proj/functions/restore/versions/1/activate",
+        ]);
+    });
+
     test.each([
         ["HTTP 503 after possible commit", { ok: false, status: 503, data: { error: "private-server-detail" } }, "OUTCOME_UNKNOWN", 503],
         ["HTTP 408 after possible commit", { ok: false, status: 408, data: { error: "private-server-detail" } }, "OUTCOME_UNKNOWN", 408],
         ["explicit HTTP rejection", { ok: false, status: 409, data: { error: "private-server-detail" } }, "HTTP_ERROR", 409],
+        ["response read failure after HTTP 409", {
+            ok: false,
+            status: 409,
+            data: { error: "private-server-detail" },
+            responseReadError: true,
+        }, "OUTCOME_UNKNOWN", 409],
         ["transport failure", {
             ok: false,
             status: 500,

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -668,7 +668,7 @@ async function activateFunctionVersion(
         slug: functionSlug,
         expectedActiveVersion,
         targetVersion: version,
-    }, await http.post(endpoint, { expected_active_version: expectedActiveVersion }));
+    }, await http.postReleaseMutation(endpoint, { expected_active_version: expectedActiveVersion }));
 }
 
 export function registerAdvancedTools(
@@ -784,7 +784,7 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
                             break;
                         }
                     }
-                    const deploymentResponse = await http.post(edgeFunctionResourcePath(ref, slug), {
+                    const deploymentResponse = await http.postReleaseMutation(edgeFunctionResourcePath(ref, slug), {
                         code: deployCode.code,
                         ...(deployCode.prebundled
                             ? { prebundled: true, expected_sha256: deployCode.expectedSha256 }
@@ -801,7 +801,7 @@ Actions: list, deploy, deploy_bundle, config, source, activate, delete, check`,
                     }, deploymentResponse);
                 case "deploy_bundle":
                     need("slug", slug); need("files", files);
-                    const bundleResponse = await http.post(`${edgeFunctionResourcePath(ref, slug)}/bundle`, {
+                    const bundleResponse = await http.postReleaseMutation(`${edgeFunctionResourcePath(ref, slug)}/bundle`, {
                         files,
                         entrypoint,
                         minify,

--- a/packages/cli/src/shared/tools/release-control-response.ts
+++ b/packages/cli/src/shared/tools/release-control-response.ts
@@ -36,7 +36,10 @@ export function releaseControlMutationFailure(
     operation: string,
     response: HttpResult<unknown>,
 ): ReleaseControlToolResponse {
-    const outcomeUnknown = response.transportError || response.status === 408 || response.status >= 500;
+    const outcomeUnknown = response.transportError
+        || response.responseReadError
+        || response.status === 408
+        || response.status >= 500;
     return outcomeUnknown
         ? releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.transportError ? null : response.status)
         : releaseControlFailure(operation, "HTTP_ERROR", response.status);

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -6,6 +6,7 @@ const originalFetch = globalThis.fetch;
 const originalSetTimeout = globalThis.setTimeout;
 const originalClearTimeout = globalThis.clearTimeout;
 const MAX_TEST_RESPONSE_BYTES = 1024 * 1024;
+const RELEASE_MUTATION_RESPONSE_MAX_BYTES = 64 * 1024;
 
 let clearedTimerIds: Array<ReturnType<typeof setTimeout> | undefined> = [];
 let nextTimerId = 0;
@@ -16,7 +17,7 @@ beforeEach(() => {
     nextTimerId = 0;
     globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number, ...args: unknown[]) => {
         const timerId = ++nextTimerId as unknown as ReturnType<typeof setTimeout>;
-        if (delay !== 30_000) queueMicrotask(() => callback(...args));
+        if (delay === 500 || delay === 1_000) queueMicrotask(() => callback(...args));
         return timerId;
     }) as typeof setTimeout;
     globalThis.clearTimeout = ((timerId?: ReturnType<typeof setTimeout>) => {
@@ -46,18 +47,22 @@ function whitespaceJson(totalBytes: number): string {
     return `${" ".repeat(totalBytes - 2)}[]`;
 }
 
-function chunkedTextResponse(body: string): Response {
+function chunkedTextResponse(
+    body: string,
+    headers: HeadersInit = { "Content-Type": "application/json" },
+    chunkBytes = 256 * 1024,
+): Response {
     const bytes = new TextEncoder().encode(body);
     let offset = 0;
     const stream = new ReadableStream<Uint8Array>({
         pull(controller) {
             if (offset >= bytes.byteLength) return controller.close();
-            const nextOffset = Math.min(offset + 256 * 1024, bytes.byteLength);
+            const nextOffset = Math.min(offset + chunkBytes, bytes.byteLength);
             controller.enqueue(bytes.subarray(offset, nextOffset));
             offset = nextOffset;
         },
     });
-    return new Response(stream, { headers: { "Content-Type": "application/json" } });
+    return new Response(stream, { headers });
 }
 
 describe("HttpTransport retry policy", () => {
@@ -151,6 +156,26 @@ describe("HttpTransport retry policy", () => {
         expect(serialized).not.toContain(errorSentinel);
         expect(serialized).not.toContain("details");
     });
+
+    test("preserves the ordinary POST contract for request serialization failures", async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls += 1;
+            return Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+        const circularBody: Record<string, unknown> = {};
+        circularBody.self = circularBody;
+
+        const response = await createTransport().post("/resource", circularBody);
+
+        expect(response).toEqual({
+            ok: false,
+            status: 500,
+            data: { error: "Network Error", code: "NETWORK_ERROR" },
+            transportError: true,
+        });
+        expect(fetchCalls).toBe(0);
+    });
 });
 
 describe("HttpTransport bounded GET responses", () => {
@@ -209,5 +234,136 @@ describe("HttpTransport bounded GET responses", () => {
         });
 
         expect(response).toMatchObject({ ok: true, status: 200, data: null });
+    });
+});
+
+describe("HttpTransport release mutation response boundary", () => {
+    test("rejects an unserializable request before HTTP dispatch", async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls += 1;
+            return Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+        const circularBody: Record<string, unknown> = {};
+        circularBody.self = circularBody;
+
+        await expect(createTransport().postReleaseMutation("/resource", circularBody)).rejects.toThrow();
+
+        expect(fetchCalls).toBe(0);
+    });
+
+    test("accepts a chunked JSON response exactly at the byte cap", async () => {
+        const body = whitespaceJson(RELEASE_MUTATION_RESPONSE_MAX_BYTES);
+        globalThis.fetch = (async () => chunkedTextResponse(
+            body,
+            { "Content-Type": "application/json" },
+            1024,
+        )) as unknown as typeof fetch;
+
+        const response = await createTransport().postReleaseMutation("/resource", { expected: "1" });
+
+        expect(Buffer.byteLength(body)).toBe(RELEASE_MUTATION_RESPONSE_MAX_BYTES);
+        expect(response).toEqual({ ok: true, status: 200, data: [] });
+    });
+
+    test.each([
+        ["without Content-Length", {}],
+        ["with a false small Content-Length", { "Content-Length": "1" }],
+    ])("rejects a chunked response one byte over the cap %s", async (_label, headers) => {
+        const secretSentinel = "Bearer service-role-response-secret";
+        const structuredBody = JSON.stringify({ token: secretSentinel });
+        const body = `${" ".repeat(RELEASE_MUTATION_RESPONSE_MAX_BYTES + 1 - structuredBody.length)}${structuredBody}`;
+        globalThis.fetch = (async () => chunkedTextResponse(body, headers, 1024)) as unknown as typeof fetch;
+
+        const response = await createTransport().postReleaseMutation("/resource", { expected: "1" });
+        const serialized = JSON.stringify(response);
+
+        expect(Buffer.byteLength(body)).toBe(RELEASE_MUTATION_RESPONSE_MAX_BYTES + 1);
+        expect(response).toEqual({
+            ok: false,
+            status: 200,
+            data: { error: "Response body unavailable", code: "RESPONSE_READ_ERROR" },
+            responseReadError: true,
+        });
+        expect(serialized).not.toContain(secretSentinel);
+    });
+
+    test("rejects a response truncated below its declared Content-Length", async () => {
+        const secretSentinel = "service-role-truncated-response-secret";
+        const body = JSON.stringify({ token: secretSentinel });
+        globalThis.fetch = (async () => chunkedTextResponse(body, {
+            "Content-Length": String(Buffer.byteLength(body) + 10),
+            "Content-Type": "application/json",
+        }, 7)) as unknown as typeof fetch;
+
+        const response = await createTransport().postReleaseMutation("/resource", { expected: "1" });
+
+        expect(response.responseReadError).toBe(true);
+        expect(JSON.stringify(response)).not.toContain(secretSentinel);
+    });
+
+    test("rejects a chunked JSON response that ends mid-document", async () => {
+        const secretSentinel = "service-role-mid-document-secret";
+        const body = `{"token":"${secretSentinel}`;
+        globalThis.fetch = (async () => chunkedTextResponse(body, {}, 5)) as unknown as typeof fetch;
+
+        const response = await createTransport().postReleaseMutation("/resource", { expected: "1" });
+
+        expect(response.responseReadError).toBe(true);
+        expect(JSON.stringify(response)).not.toContain(secretSentinel);
+    });
+
+    test("redacts a secret-like body and reader exception", async () => {
+        const secretSentinel = "Bearer reader-failure-service-role-secret";
+        const stream = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(new TextEncoder().encode(`{"token":"${secretSentinel}`));
+                controller.error(new Error(secretSentinel));
+            },
+        });
+        globalThis.fetch = (async () => new Response(stream, {
+            headers: { "Content-Type": "application/json" },
+        })) as unknown as typeof fetch;
+
+        const response = await createTransport().postReleaseMutation("/resource", { expected: "1" });
+
+        expect(response.responseReadError).toBe(true);
+        expect(JSON.stringify(response)).not.toContain(secretSentinel);
+    });
+
+    test("times out a real response stream that stalls after headers", async () => {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+        const secretSentinel = "Bearer delayed-service-role-secret";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => new Response(new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode(`{"token":"${secretSentinel}`));
+                },
+            }), { headers: { "Content-Type": "application/json" } }),
+        });
+        servers.push(server);
+        const transport = new HttpTransport({
+            baseUrl: `http://127.0.0.1:${server.port}`,
+            token: "test-token",
+        });
+        const startedAt = Date.now();
+
+        const response = await transport.postReleaseMutation("/resource", { expected: "1" });
+
+        expect(Date.now() - startedAt).toBeLessThan(15_000);
+        expect(response).toMatchObject({ ok: false, status: 200, responseReadError: true });
+        expect(JSON.stringify(response)).not.toContain(secretSentinel);
+    }, 20_000);
+
+    test.each([400, 409])("preserves a normal structured HTTP %d response", async status => {
+        const responseBody = { error: "ACTIVE_VERSION_CONFLICT", current_active_version: "8" };
+        globalThis.fetch = (async () => Response.json(responseBody, { status })) as unknown as typeof fetch;
+
+        const response = await createTransport().postReleaseMutation("/resource", { expected: "7" });
+
+        expect(response).toEqual({ ok: false, status, data: responseBody });
     });
 });

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -15,6 +15,7 @@ export interface HttpResult<T = unknown> {
     status: number;
     data: T;
     transportError?: boolean;
+    responseReadError?: true;
 }
 
 export interface HttpGetOptions {
@@ -22,8 +23,18 @@ export interface HttpGetOptions {
 }
 
 const DEFAULT_TIMEOUT = 30_000;
+const RELEASE_MUTATION_RESPONSE_TIMEOUT = 5_000;
+const RELEASE_MUTATION_RESPONSE_MAX_BYTES = 64 * 1024;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
+
+type ResponseBytesRead =
+    | { ok: true; bytes: Uint8Array }
+    | { ok: false };
+
+type ResponseJsonRead<T = unknown> =
+    | { ok: true; parsedJson: T }
+    | { ok: false };
 
 function isRetryableMethod(method?: string): boolean {
     const normalizedMethod = (method ?? "GET").toUpperCase();
@@ -48,6 +59,15 @@ function transportFailure<T>(error: unknown): HttpResult<T> {
         status: 500,
         data: { error: "Network Error", code } as T,
         transportError: true,
+    };
+}
+
+function responseReadFailure<T>(status: number): HttpResult<T> {
+    return {
+        ok: false,
+        status,
+        data: { error: "Response body unavailable", code: "RESPONSE_READ_ERROR" } as T,
+        responseReadError: true,
     };
 }
 
@@ -107,6 +127,36 @@ function joinedResponseBytes(chunks: Uint8Array[], totalBytes: number): Uint8Arr
     return responseBytes;
 }
 
+function cancelResponseReader(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+    void reader.cancel().catch(() => undefined);
+}
+
+function serializedRequestBody(body: unknown): string | undefined {
+    return body ? JSON.stringify(body) : undefined;
+}
+
+async function responseBytesFromReader(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    maxBytes: number,
+    declaredBytes: number | null,
+): Promise<ResponseBytesRead> {
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+            if (declaredBytes !== null && totalBytes !== declaredBytes) return { ok: false };
+            return { ok: true, bytes: joinedResponseBytes(chunks, totalBytes) };
+        }
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+            cancelResponseReader(reader);
+            return { ok: false };
+        }
+        chunks.push(value);
+    }
+}
+
 async function responseBytesWithinLimit(response: Response, maxBytes: number): Promise<Uint8Array | null> {
     if (declaredResponseTooLarge(response, maxBytes)) {
         await response.body?.cancel();
@@ -114,33 +164,86 @@ async function responseBytesWithinLimit(response: Response, maxBytes: number): P
     }
     if (!response.body) return new Uint8Array();
     const reader = response.body.getReader();
-    const chunks: Uint8Array[] = [];
-    let totalBytes = 0;
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) return joinedResponseBytes(chunks, totalBytes);
-        totalBytes += value.byteLength;
-        if (totalBytes > maxBytes) {
-            await reader.cancel();
-            return null;
-        }
-        chunks.push(value);
-    }
+    const bodyRead = await responseBytesFromReader(reader, maxBytes, null);
+    return bodyRead.ok ? bodyRead.bytes : null;
 }
 
-function parsedUtf8Json(responseBytes: Uint8Array): unknown {
+function parsedUtf8Json(responseBytes: Uint8Array): ResponseJsonRead {
     try {
         const responseText = new TextDecoder("utf-8", { fatal: true }).decode(responseBytes);
-        return JSON.parse(responseText);
+        return { ok: true, parsedJson: JSON.parse(responseText) };
     } catch (error) {
-        if (error instanceof SyntaxError || error instanceof TypeError) return null;
+        if (error instanceof SyntaxError || error instanceof TypeError) return { ok: false };
         throw error;
     }
 }
 
 async function boundedResponseJson(response: Response, maxBytes: number): Promise<unknown> {
     const responseBytes = await responseBytesWithinLimit(response, maxBytes);
-    return responseBytes === null ? null : parsedUtf8Json(responseBytes);
+    if (responseBytes === null) return null;
+    const parsed = parsedUtf8Json(responseBytes);
+    return parsed.ok ? parsed.parsedJson : null;
+}
+
+function declaredIdentityResponseBytes(response: Response): number | null | "invalid" {
+    const contentEncoding = response.headers.get("content-encoding");
+    if (contentEncoding !== null && contentEncoding.toLowerCase() !== "identity") return null;
+    const contentLength = response.headers.get("content-length");
+    if (contentLength === null) return null;
+    if (!/^\d+$/.test(contentLength)) return "invalid";
+    const declaredBytes = Number(contentLength);
+    return Number.isSafeInteger(declaredBytes) ? declaredBytes : "invalid";
+}
+
+async function releaseMutationResponseBytes(response: Response): Promise<ResponseBytesRead> {
+    const declaredBytes = declaredIdentityResponseBytes(response);
+    if (declaredBytes === "invalid"
+        || (declaredBytes !== null && declaredBytes > RELEASE_MUTATION_RESPONSE_MAX_BYTES)) {
+        void response.body?.cancel().catch(() => undefined);
+        return { ok: false };
+    }
+    if (!response.body) {
+        return declaredBytes === null || declaredBytes === 0
+            ? { ok: true, bytes: new Uint8Array() }
+            : { ok: false };
+    }
+    return responseBytesBeforeDeadline(response.body.getReader(), declaredBytes);
+}
+
+async function responseBytesBeforeDeadline(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    declaredBytes: number | null,
+): Promise<ResponseBytesRead> {
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<ResponseBytesRead>((resolve) => {
+        deadlineTimer = setTimeout(() => {
+            cancelResponseReader(reader);
+            resolve({ ok: false });
+        }, RELEASE_MUTATION_RESPONSE_TIMEOUT);
+    });
+    try {
+        return await Promise.race([
+            responseBytesFromReader(reader, RELEASE_MUTATION_RESPONSE_MAX_BYTES, declaredBytes),
+            deadline,
+        ]);
+    } catch {
+        // A body read failure cannot prove whether the server committed the mutation.
+        cancelResponseReader(reader);
+        return { ok: false };
+    } finally {
+        clearTimeout(deadlineTimer);
+    }
+}
+
+async function releaseMutationResponseJson<T>(response: Response): Promise<ResponseJsonRead<T>> {
+    const responseBytes = await releaseMutationResponseBytes(response);
+    if (!responseBytes.ok) return { ok: false };
+    const parsed = parsedUtf8Json(responseBytes.bytes);
+    return parsed.ok ? { ok: true, parsedJson: parsed.parsedJson as T } : { ok: false };
+}
+
+async function responseJsonOrNull<T>(response: Response): Promise<ResponseJsonRead<T>> {
+    return { ok: true, parsedJson: (await response.json().catch(() => null)) as T };
 }
 
 export class HttpTransport {
@@ -157,6 +260,26 @@ export class HttpTransport {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
         };
+    }
+
+    private async postWithResponseReader<T>(
+        path: string,
+        serializedBody: string | undefined,
+        responseReader: (response: Response) => Promise<ResponseJsonRead<T>>,
+    ): Promise<HttpResult<T>> {
+        try {
+            const response = await fetchWithRetry(`${this.baseUrl}${path}`, {
+                method: "POST",
+                headers: this.headers(),
+                body: serializedBody,
+            });
+            const responseBody = await responseReader(response);
+            return responseBody.ok
+                ? { ok: response.ok, status: response.status, data: responseBody.parsedJson }
+                : responseReadFailure<T>(response.status);
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
+        }
     }
 
     async get<T = unknown>(path: string, options: HttpGetOptions = {}): Promise<HttpResult<T>> {
@@ -176,16 +299,14 @@ export class HttpTransport {
 
     async post<T = unknown>(path: string, body?: unknown): Promise<HttpResult<T>> {
         try {
-            const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
-                method: "POST",
-                headers: this.headers(),
-                body: body ? JSON.stringify(body) : undefined,
-            });
-            const data = (await res.json().catch(() => null)) as T;
-            return { ok: res.ok, status: res.status, data };
+            return await this.postWithResponseReader(path, serializedRequestBody(body), responseJsonOrNull<T>);
         } catch (error: unknown) {
             return transportFailure<T>(error);
         }
+    }
+
+    async postReleaseMutation<T = unknown>(path: string, body?: unknown): Promise<HttpResult<T>> {
+        return this.postWithResponseReader(path, serializedRequestBody(body), releaseMutationResponseJson<T>);
     }
 
     async postMultipart<T = unknown>(path: string, formData: FormData): Promise<HttpResult<T>> {


### PR DESCRIPTION
## Summary

- enforce a 5-second post-header deadline and 64 KiB body cap for Function deploy, bundle deploy, and activation responses
- fail closed on oversized, truncated, invalid UTF-8, malformed, stalled, or unreadable mutation responses
- map response-read failures to secret-free `OUTCOME_UNKNOWN` receipts while preserving structured HTTP 400/409 failures
- preserve the ordinary POST serialization-failure contract and document the release boundary

## Verification

- `bun test` in `packages/cli`: 490 passed, 0 failed
- `bun run typecheck`
- `bun run build`
- `git diff --check`

## Safety

- no response body or reader exception is reflected on uncertain outcomes
- mutation POSTs remain non-retryable
- no release, package publish, or deployment is part of this PR
