### PR TITLE
feat(edge-runtime): return resolved function versions

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           bun install --frozen-lockfile
           bun run typecheck
-          bun test internal-bindings.test.ts pgredis-capability.test.ts worker-pool.test.ts
+          bun test internal-bindings.test.ts pgredis-capability.test.ts function-version.test.ts function-source.test.ts server-cache.test.ts server-function-config.test.ts worker-pool.test.ts
           bun audit --audit-level high
 
       - name: Check pgredis runtime

--- a/packages/edge-runtime/function-source.test.ts
+++ b/packages/edge-runtime/function-source.test.ts
@@ -29,6 +29,13 @@ describe("multi-file function runtime source", () => {
     ]);
   });
 
+  test("keeps a legacy zero activation bound to its immutable artifact", () => {
+    expect(activeFunctionPathCandidates("/functions/project", "supauth", "0")).toEqual([
+      path.join("/functions/project", ".versions", "supauth", "0", "src", BUNDLED_SOURCE_RUNTIME_ENTRY),
+      "/functions/project/.versions/supauth/0/index.js",
+    ]);
+  });
+
   test("uses mutable aliases only for a legacy activation without a version", () => {
     expect(activeFunctionPathCandidates("/functions/project", "supauth", null)).toEqual([
       path.join("/functions/project", ".src-supauth", BUNDLED_SOURCE_RUNTIME_ENTRY),

--- a/packages/edge-runtime/function-version.test.ts
+++ b/packages/edge-runtime/function-version.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, test } from "bun:test";
 import {
+  assertCanonicalConfiguredFunctionVersion,
   assertCanonicalPositiveFunctionVersion,
   resolveFunctionVersionBinding,
   resolveTrustedBackgroundFunctionVersionBinding,
 } from "./function-version";
 
 describe("active function version validation", () => {
+  test("accepts canonical configured legacy-zero and positive versions", () => {
+    for (const version of ["0", "1", "12", String(Number.MAX_SAFE_INTEGER)]) {
+      expect(() => assertCanonicalConfiguredFunctionVersion(version)).not.toThrow();
+    }
+  });
+
+  test("rejects non-string, empty, non-canonical, and unsafe configured versions", () => {
+    for (const version of [1, null, "", "01", "-1", "9007199254740992"]) {
+      expect(() => assertCanonicalConfiguredFunctionVersion(version)).toThrow(
+        "Configured function version must be a canonical non-negative safe integer",
+      );
+    }
+  });
+
   test("accepts absent and canonical positive safe integer versions", () => {
     for (const version of [null, undefined, "1", "12", String(Number.MAX_SAFE_INTEGER)]) {
       expect(() => assertCanonicalPositiveFunctionVersion(version)).not.toThrow();
@@ -47,7 +62,7 @@ describe("active function version validation", () => {
       "Function version must be a canonical positive safe integer",
     );
     expect(() => resolveFunctionVersionBinding(undefined, "01")).toThrow(
-      "Function version must be a canonical positive safe integer",
+      "Configured function version must be a canonical non-negative safe integer",
     );
   });
 

--- a/packages/edge-runtime/function-version.test.ts
+++ b/packages/edge-runtime/function-version.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertCanonicalPositiveFunctionVersion,
+  resolveFunctionVersionBinding,
+  resolveTrustedBackgroundFunctionVersionBinding,
+} from "./function-version";
+
+describe("active function version validation", () => {
+  test("accepts absent and canonical positive safe integer versions", () => {
+    for (const version of [null, undefined, "1", "12", String(Number.MAX_SAFE_INTEGER)]) {
+      expect(() => assertCanonicalPositiveFunctionVersion(version)).not.toThrow();
+    }
+  });
+
+  test("rejects zero, non-canonical, unsafe, and overlong versions", () => {
+    const invalidVersions = [
+      "",
+      "0",
+      "01",
+      "-1",
+      "v12",
+      "9007199254740992",
+      "1".repeat(128),
+    ];
+
+    for (const version of invalidVersions) {
+      expect(() => assertCanonicalPositiveFunctionVersion(version)).toThrow(
+        "Function version must be a canonical positive safe integer",
+      );
+    }
+  });
+
+  test("binds legacy and requested versions without treating zero as a target", () => {
+    expect(resolveFunctionVersionBinding(undefined, null)).toEqual({
+      activeVersion: null,
+      responseVersion: null,
+    });
+    expect(resolveFunctionVersionBinding(undefined, "0")).toEqual({
+      activeVersion: "0",
+      responseVersion: null,
+    });
+    expect(resolveFunctionVersionBinding("12", "0")).toEqual({
+      activeVersion: "12",
+      responseVersion: "12",
+    });
+    expect(() => resolveFunctionVersionBinding("0", "12")).toThrow(
+      "Function version must be a canonical positive safe integer",
+    );
+    expect(() => resolveFunctionVersionBinding(undefined, "01")).toThrow(
+      "Function version must be a canonical positive safe integer",
+    );
+  });
+
+  test("keeps a queued legacy-zero background task bound after active version changes", () => {
+    expect(resolveTrustedBackgroundFunctionVersionBinding("0", "12")).toEqual({
+      activeVersion: "0",
+      responseVersion: null,
+    });
+    expect(resolveTrustedBackgroundFunctionVersionBinding("11", "12")).toEqual({
+      activeVersion: "11",
+      responseVersion: "11",
+    });
+    expect(() => resolveTrustedBackgroundFunctionVersionBinding("01", "12")).toThrow(
+      "Function version must be a canonical positive safe integer",
+    );
+  });
+});

--- a/packages/edge-runtime/function-version.ts
+++ b/packages/edge-runtime/function-version.ts
@@ -1,0 +1,37 @@
+const CANONICAL_ACTIVE_VERSION_PATTERN = /^[1-9]\d{0,15}$/;
+
+export function assertCanonicalPositiveFunctionVersion(
+  version: string | null | undefined,
+): void {
+  if (version === null || version === undefined) return;
+  if (
+    !CANONICAL_ACTIVE_VERSION_PATTERN.test(version) ||
+    !Number.isSafeInteger(Number(version))
+  ) {
+    throw new Error("Function version must be a canonical positive safe integer");
+  }
+}
+
+export function resolveFunctionVersionBinding(
+  requestedVersion: string | null | undefined,
+  configuredVersion: string | null,
+): { activeVersion: string | null; responseVersion: string | null } {
+  assertCanonicalPositiveFunctionVersion(requestedVersion);
+  const activeVersion = requestedVersion ?? configuredVersion;
+  if (activeVersion === "0") return { activeVersion, responseVersion: null };
+  assertCanonicalPositiveFunctionVersion(activeVersion);
+  return {
+    activeVersion,
+    responseVersion: activeVersion,
+  };
+}
+
+export function resolveTrustedBackgroundFunctionVersionBinding(
+  requestedVersion: string | null | undefined,
+  configuredVersion: string | null,
+): { activeVersion: string | null; responseVersion: string | null } {
+  if (requestedVersion === "0") {
+    return { activeVersion: "0", responseVersion: null };
+  }
+  return resolveFunctionVersionBinding(requestedVersion, configuredVersion);
+}

--- a/packages/edge-runtime/function-version.ts
+++ b/packages/edge-runtime/function-version.ts
@@ -1,4 +1,17 @@
 const CANONICAL_ACTIVE_VERSION_PATTERN = /^[1-9]\d{0,15}$/;
+const CANONICAL_CONFIGURED_VERSION_PATTERN = /^(?:0|[1-9]\d{0,15})$/;
+
+export function assertCanonicalConfiguredFunctionVersion(
+  version: unknown,
+): asserts version is string {
+  if (
+    typeof version !== "string" ||
+    !CANONICAL_CONFIGURED_VERSION_PATTERN.test(version) ||
+    !Number.isSafeInteger(Number(version))
+  ) {
+    throw new Error("Configured function version must be a canonical non-negative safe integer");
+  }
+}
 
 export function assertCanonicalPositiveFunctionVersion(
   version: string | null | undefined,
@@ -17,6 +30,9 @@ export function resolveFunctionVersionBinding(
   configuredVersion: string | null,
 ): { activeVersion: string | null; responseVersion: string | null } {
   assertCanonicalPositiveFunctionVersion(requestedVersion);
+  if (configuredVersion !== null) {
+    assertCanonicalConfiguredFunctionVersion(configuredVersion);
+  }
   const activeVersion = requestedVersion ?? configuredVersion;
   if (activeVersion === "0") return { activeVersion, responseVersion: null };
   assertCanonicalPositiveFunctionVersion(activeVersion);

--- a/packages/edge-runtime/server-cache.test.ts
+++ b/packages/edge-runtime/server-cache.test.ts
@@ -72,10 +72,19 @@ describe("Edge Runtime auth material invalidation", () => {
       source.indexOf("async function dispatchFunction("),
       source.indexOf("async function appendFunctionRuntimeLog("),
     );
+    const poolDispatch = dispatcher.slice(
+      dispatcher.indexOf("return await targetPool.dispatch({"),
+      dispatcher.indexOf(
+        "    });",
+        dispatcher.indexOf("return await targetPool.dispatch({"),
+      ),
+    );
     expect(requestHandler).toContain("activation = await resolveFunctionPath(projectRef, functionName)");
     expect(requestHandler).toContain("activation.verifyJwt");
     expect(requestHandler).toContain("activation,");
     expect(requestHandler).not.toContain("x-supacloud-function-version");
+    expect(poolDispatch).toContain("functionVersion: responseVersion");
+    expect(poolDispatch).not.toContain("functionVersion: activeVersion");
     expect(dispatcher).not.toContain("x-supacloud-function-version");
   });
 
@@ -85,8 +94,13 @@ describe("Edge Runtime auth material invalidation", () => {
       source.indexOf("function functionDispatchError("),
     );
     expect(resolver).toContain(
-      "activeFunctionPathCandidates(projectRoot, functionName, resolvedConfig.version)",
+      "activeFunctionPathCandidates(projectRoot, functionName, activeVersion)",
     );
+    expect(resolver).toContain("versionBindingResolver = resolveFunctionVersionBinding");
+    expect(resolver).toContain("versionBindingResolver(");
+    expect(resolver).toContain("requestedVersion,");
+    expect(resolver).toContain("resolvedConfig.version,");
+    expect(resolver).toContain("responseVersion,");
   });
 
   test("background routes envelope function resolution failures", () => {
@@ -102,13 +116,25 @@ describe("Edge Runtime auth material invalidation", () => {
     for (const route of [wildcardRoute, exactRoute]) {
       expect(route).toContain("let response: Response;");
       expect(route).toContain("try {");
-      expect(route).toContain(
-        "resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion)",
-      );
+      expect(route).toContain("resolveTrustedBackgroundFunctionVersionBinding,");
       expect(route).toContain("catch (error)");
       expect(route).toContain("functionDispatchError(error, setHeaders)");
       expect(route).toContain('status: 200');
       expect(route).toContain('"x-supacloud-background-envelope": "true"');
     }
+  });
+
+  test("only trusted background routes can resolve queued legacy-zero versions", () => {
+    const preheatSource = source.slice(
+      source.indexOf('.post("/preheat/:ref/:slug"'),
+      source.indexOf('.post("/internal/background/:ref/:functionName/*"'),
+    );
+    const backgroundSource = source.slice(
+      source.indexOf('.post("/internal/background/:ref/:functionName/*"'),
+      source.indexOf('.post("/internal/background/cancel/:taskId"'),
+    );
+
+    expect(preheatSource).not.toContain("resolveTrustedBackgroundFunctionVersionBinding,");
+    expect(backgroundSource.match(/resolveTrustedBackgroundFunctionVersionBinding,/g)).toHaveLength(2);
   });
 });

--- a/packages/edge-runtime/server-function-config.test.ts
+++ b/packages/edge-runtime/server-function-config.test.ts
@@ -1,0 +1,280 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+setDefaultTimeout(30_000);
+
+const PROJECT_REF = "configcontract";
+const INTERNAL_TOKEN = "edge-runtime-config-test-token";
+const SERVICE_ROLE_KEY = "edge-runtime-config-test-service-role";
+
+let fixtureRoot = "";
+let projectRoot = "";
+let edgeBaseUrl = "";
+let managementServer: Bun.Server<undefined> | undefined;
+let edgeProcess: Bun.Subprocess<"ignore", "pipe", "pipe"> | undefined;
+let edgeStdout: Promise<string> | undefined;
+let edgeStderr: Promise<string> | undefined;
+
+function functionSource(body: string): string {
+  return `export default () => new Response(${JSON.stringify(body)});\n`;
+}
+
+async function writeLegacyFunction(slug: string, body: string): Promise<void> {
+  await writeFile(join(projectRoot, `${slug}.ts`), functionSource(body));
+}
+
+async function writeVersionedFunction(
+  slug: string,
+  version: string,
+  body: string,
+): Promise<void> {
+  const versionRoot = join(projectRoot, ".versions", slug, version);
+  await mkdir(versionRoot, { recursive: true });
+  await writeFile(join(versionRoot, "index.js"), functionSource(body));
+}
+
+async function writeFunctionConfig(slug: string, raw: string): Promise<void> {
+  await writeFile(join(projectRoot, `${slug}.config.json`), raw);
+}
+
+function reserveEdgePort(): number {
+  const reservation = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Response("reserved"),
+  });
+  const port = reservation.port;
+  reservation.stop(true);
+  return port;
+}
+
+function isConnectionRefused(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  return error.code === "ConnectionRefused" || error.code === "ECONNREFUSED";
+}
+
+async function waitForEdgeRuntime(): Promise<void> {
+  const deadline = Date.now() + 8_000;
+  while (Date.now() < deadline) {
+    if (edgeProcess?.exitCode !== null) break;
+    try {
+      if ((await fetch(`${edgeBaseUrl}/health`)).ok) return;
+    } catch (error) {
+      if (!isConnectionRefused(error)) throw error;
+    }
+    await Bun.sleep(25);
+  }
+  throw new Error("Edge Runtime test server did not become healthy");
+}
+
+async function invokeForeground(slug: string): Promise<Response> {
+  return fetch(`${edgeBaseUrl}/functions/v1/${slug}`, {
+    headers: {
+      "x-project-ref": PROJECT_REF,
+      apikey: SERVICE_ROLE_KEY,
+    },
+  });
+}
+
+type BackgroundEnvelope = {
+  status: number;
+  headers: Record<string, string>;
+  bodyText: string;
+};
+
+async function invokeBackground(slug: string): Promise<BackgroundEnvelope> {
+  const response = await fetch(`${edgeBaseUrl}/internal/background/${PROJECT_REF}/${slug}`, {
+    method: "POST",
+    headers: { "x-supacloud-internal-auth": `Bearer ${INTERNAL_TOKEN}` },
+  });
+  expect(response.status).toBe(200);
+  return response.json() as Promise<BackgroundEnvelope>;
+}
+
+async function invalidateFunctionConfig(slug: string): Promise<void> {
+  const response = await fetch(`${edgeBaseUrl}/invalidate/${PROJECT_REF}/${slug}`, {
+    method: "POST",
+    headers: { "x-supacloud-internal-auth": `Bearer ${INTERNAL_TOKEN}` },
+  });
+  expect(response.status).toBe(200);
+}
+
+async function stopEdgeRuntime(): Promise<void> {
+  if (!edgeProcess) return;
+  if (edgeProcess.exitCode === null) edgeProcess.kill("SIGTERM");
+  const timeout = Symbol("timeout");
+  const exitCode = await Promise.race([
+    edgeProcess.exited,
+    Bun.sleep(3_000).then(() => timeout),
+  ]);
+  if (exitCode === timeout) {
+    edgeProcess.kill("SIGKILL");
+    await edgeProcess.exited;
+  }
+}
+
+function startManagementServer(): Bun.Server<undefined> {
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => Response.json({
+      SUPACLOUD_AUTH_RUNTIME_MODE: "local",
+      SUPABASE_SERVICE_ROLE_KEY: SERVICE_ROLE_KEY,
+    }),
+  });
+}
+
+function edgeRuntimeEnvironment(
+  edgePort: number,
+  managementPort: number,
+): Record<string, string | undefined> {
+  return {
+    ...process.env,
+    EDGE_RUNTIME_HOST: "127.0.0.1",
+    EDGE_RUNTIME_PORT: String(edgePort),
+    EDGE_RUNTIME_MASTER_KEY: INTERNAL_TOKEN,
+    EDGE_FUNCTIONS_DIR: join(fixtureRoot, "functions"),
+    EDGE_FUNCTIONS_BASE_DIR: join(fixtureRoot, "functions"),
+    MANAGEMENT_API_URL: `http://127.0.0.1:${managementPort}`,
+    TENANTS_DIR: join(fixtureRoot, "tenants"),
+    WORKER_POOL_SIZE: "1",
+    BACKGROUND_WORKER_POOL_SIZE: "1",
+  };
+}
+
+function startEdgeRuntime(managementPort: number): void {
+  const edgePort = reserveEdgePort();
+  edgeBaseUrl = `http://127.0.0.1:${edgePort}`;
+  edgeProcess = Bun.spawn([process.execPath, join(import.meta.dir, "server.ts")], {
+    cwd: import.meta.dir,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: edgeRuntimeEnvironment(edgePort, managementPort),
+  });
+  edgeStdout = new Response(edgeProcess.stdout).text();
+  edgeStderr = new Response(edgeProcess.stderr).text();
+}
+
+async function initializeServerFixture(): Promise<void> {
+  fixtureRoot = await mkdtemp(join(tmpdir(), "supacloud-edge-config-contract-"));
+  projectRoot = join(fixtureRoot, "functions", PROJECT_REF);
+  await mkdir(projectRoot, { recursive: true });
+  managementServer = startManagementServer();
+  startEdgeRuntime(managementServer.port);
+  await waitForEdgeRuntime();
+}
+
+async function expectInvalidConfigFailsClosed(slug: string, rawConfig: string): Promise<void> {
+  const staleBody = `stale-${slug}`;
+  await writeLegacyFunction(slug, staleBody);
+  await writeFunctionConfig(slug, rawConfig);
+
+  const foreground = await invokeForeground(slug);
+  expect(foreground.status).toBe(500);
+  expect(foreground.headers.has("x-supacloud-function-version")).toBe(false);
+  expect(await foreground.text()).not.toContain(staleBody);
+
+  const background = await invokeBackground(slug);
+  expect(background.status).toBe(500);
+  expect(background.headers["x-supacloud-function-version"]).toBeUndefined();
+  expect(background.bodyText).not.toContain(staleBody);
+}
+
+async function installValidFunction(
+  slug: string,
+  version: string | null,
+  body: string,
+): Promise<void> {
+  if (version === null) {
+    await writeLegacyFunction(slug, body);
+    return;
+  }
+  await writeVersionedFunction(slug, version, body);
+  await writeFunctionConfig(slug, JSON.stringify({ verify_jwt: false, version }));
+}
+
+async function expectValidFunctionResponse(
+  slug: string,
+  body: string,
+  responseVersion: string | null,
+): Promise<void> {
+  const foreground = await invokeForeground(slug);
+  expect(foreground.status).toBe(200);
+  expect(foreground.headers.get("x-supacloud-function-version")).toBe(responseVersion);
+  expect(await foreground.text()).toBe(body);
+
+  const background = await invokeBackground(slug);
+  expect(background.status).toBe(200);
+  expect(background.headers["x-supacloud-function-version"] ?? null).toBe(responseVersion);
+  expect(background.bodyText).toBe(body);
+}
+
+beforeAll(initializeServerFixture);
+
+afterAll(async () => {
+  await stopEdgeRuntime();
+  managementServer?.stop(true);
+  await Promise.all([edgeStdout, edgeStderr]);
+  if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true });
+});
+
+describe("Edge Runtime function config boundary", () => {
+  test("fails closed for malformed config without executing stale aliases", async () => {
+    const invalidConfigs = [
+      ["numeric", '{"verify_jwt":false,"version":1}'],
+      ["malformed", "{"],
+      ["array", "[]"],
+      ["null", "null"],
+      ["empty", '{"verify_jwt":false,"version":""}'],
+      ["leading_zero", '{"verify_jwt":false,"version":"01"}'],
+      ["unsafe", '{"verify_jwt":false,"version":"9007199254740992"}'],
+    ] as const;
+
+    for (const [slug, rawConfig] of invalidConfigs) {
+      await expectInvalidConfigFailsClosed(slug, rawConfig);
+    }
+  });
+
+  test("serves only the configured manifest-less, v0, and positive artifacts", async () => {
+    const fixtures = [
+      ["legacy", null, "legacy-body", null],
+      ["legacy_zero", "0", "legacy-zero-body", null],
+      ["positive", "7", "positive-body", "7"],
+    ] as const;
+
+    for (const [slug, version, body, responseVersion] of fixtures) {
+      await installValidFunction(slug, version, body);
+      await expectValidFunctionResponse(slug, body, responseVersion);
+    }
+  });
+
+  test("does not cache invalid config as a manifest-less activation", async () => {
+    const slug = "cache_recovery";
+    await writeLegacyFunction(slug, "stale-cache-alias");
+    await writeFunctionConfig(slug, '{"verify_jwt":false,"version":1}');
+    expect((await invokeForeground(slug)).status).toBe(500);
+
+    await writeVersionedFunction(slug, "3", "immutable-v3");
+    await writeFunctionConfig(slug, '{"verify_jwt":false,"version":"3"}');
+    const recovered = await invokeForeground(slug);
+    expect(recovered.status).toBe(200);
+    expect(recovered.headers.get("x-supacloud-function-version")).toBe("3");
+    expect(await recovered.text()).toBe("immutable-v3");
+
+    await writeFunctionConfig(slug, '{"verify_jwt":false,"version":"01"}');
+    await invalidateFunctionConfig(slug);
+    const invalidated = await invokeForeground(slug);
+    expect(invalidated.status).toBe(500);
+    expect(await invalidated.text()).not.toContain("stale-cache-alias");
+  });
+});

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -20,7 +20,11 @@ import {
 import {
   buildBackgroundForwardDispatch,
 } from "./background-forward";
-import { activeFunctionPathCandidates, functionPathCandidates } from "./function-source";
+import { activeFunctionPathCandidates } from "./function-source";
+import {
+  resolveFunctionVersionBinding,
+  resolveTrustedBackgroundFunctionVersionBinding,
+} from "./function-version";
 import path from "path";
 import fs from "fs/promises";
 import type { PgredisRuntimeEndpointConfig } from "./internal-bindings";
@@ -48,7 +52,6 @@ const WORKER_RECYCLE_RESPONSE_GRACE_MS = 100;
 const INTERNAL_TOKEN = process.env.EDGE_RUNTIME_MASTER_KEY || process.env.MASTER_TOKEN || "";
 const PROJECT_REF_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
 const FUNCTION_SLUG_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
-const VERSION_PATTERN = /^[a-zA-Z0-9._-]{1,128}$/;
 const AUTH_FAILURE_WINDOW_MS = Number(process.env.EDGE_AUTH_FAILURE_WINDOW_MS) || 30_000;
 const AUTH_FAILURE_LIMIT = Number(process.env.EDGE_AUTH_FAILURE_LIMIT) || 8;
 const AUTH_FAILURE_COOLDOWN_MS = Number(process.env.EDGE_AUTH_FAILURE_COOLDOWN_MS) || 60_000;
@@ -122,10 +125,6 @@ function isSafeProjectRef(value: string): boolean {
 
 function isSafeFunctionSlug(value: string): boolean {
   return FUNCTION_SLUG_PATTERN.test(value);
-}
-
-function isSafeVersion(value: string): boolean {
-  return VERSION_PATTERN.test(value);
 }
 
 function getProjectModuleEpoch(projectRef: string): number {
@@ -299,6 +298,7 @@ type FunctionActivationSnapshot = {
   functionPath: string;
   projectRoot: string;
   activeVersion: string | null;
+  responseVersion: string | null;
   verifyJwt: boolean;
   moduleVersion: string;
 };
@@ -307,20 +307,18 @@ async function resolveFunctionPath(
   projectRef: string,
   functionName: string,
   requestedVersion?: string | null,
+  versionBindingResolver = resolveFunctionVersionBinding,
 ): Promise<FunctionActivationSnapshot> {
   if (!isSafeFunctionSlug(functionName)) {
     throw new Error("Invalid function slug");
   }
-  if (requestedVersion && !isSafeVersion(requestedVersion)) {
-    throw new Error("Invalid function version");
-  }
-
   const projectRoot = await resolveProjectRoot(projectRef);
   const resolvedConfig = await getFunctionConfig(projectRef, functionName, projectRoot);
-  const activeVersion = requestedVersion || resolvedConfig.version || null;
-  const candidates = requestedVersion
-    ? functionPathCandidates(projectRoot, functionName, requestedVersion)
-    : activeFunctionPathCandidates(projectRoot, functionName, resolvedConfig.version);
+  const { activeVersion, responseVersion } = versionBindingResolver(
+    requestedVersion,
+    resolvedConfig.version,
+  );
+  const candidates = activeFunctionPathCandidates(projectRoot, functionName, activeVersion);
 
   for (const candidate of candidates) {
     if (!isPathInside(candidate, projectRoot)) {
@@ -340,6 +338,7 @@ async function resolveFunctionPath(
         functionPath: realCandidate,
         projectRoot,
         activeVersion,
+        responseVersion,
         verifyJwt: resolvedConfig.verify_jwt,
         moduleVersion: [
           `active:${activeVersion || "legacy"}`,
@@ -406,7 +405,7 @@ async function dispatchFunction(
 ) {
   const { projectRef, functionName, request, setHeaders, activation } = input;
   try {
-    const { functionPath, projectRoot, activeVersion, moduleVersion } = activation;
+    const { functionPath, projectRoot, activeVersion, responseVersion, moduleVersion } = activation;
     const versionSuffix = activeVersion ? `_v${activeVersion}` : "";
     const functionId = `${projectRef}_${functionName}${versionSuffix}`;
     const targetPool = opts?.background ? backgroundPool : pool;
@@ -422,6 +421,7 @@ async function dispatchFunction(
       functionPath,
       projectRoot,
       projectRef,
+      functionVersion: responseVersion,
       internalBindings: PGREDIS_RUNTIME_ENDPOINT
         ? {
             baseUrl: PGREDIS_RUNTIME_ENDPOINT.baseUrl,
@@ -867,7 +867,12 @@ const app = new Elysia()
     const requestedVersion = backgroundDispatch.forwardedRequest.headers.get("x-supacloud-function-version");
     let response: Response;
     try {
-      const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
+      const activation = await resolveFunctionPath(
+        c.params.ref,
+        c.params.functionName,
+        requestedVersion,
+        resolveTrustedBackgroundFunctionVersionBinding,
+      );
       response = await dispatchFunction(
         {
           projectRef: c.params.ref,
@@ -928,7 +933,12 @@ const app = new Elysia()
     const requestedVersion = backgroundDispatch.forwardedRequest.headers.get("x-supacloud-function-version");
     let response: Response;
     try {
-      const activation = await resolveFunctionPath(c.params.ref, c.params.functionName, requestedVersion);
+      const activation = await resolveFunctionPath(
+        c.params.ref,
+        c.params.functionName,
+        requestedVersion,
+        resolveTrustedBackgroundFunctionVersionBinding,
+      );
       response = await dispatchFunction(
         {
           projectRef: c.params.ref,

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -22,6 +22,7 @@ import {
 } from "./background-forward";
 import { activeFunctionPathCandidates } from "./function-source";
 import {
+  assertCanonicalConfiguredFunctionVersion,
   resolveFunctionVersionBinding,
   resolveTrustedBackgroundFunctionVersionBinding,
 } from "./function-version";
@@ -509,48 +510,74 @@ const configCache = new Map<
 >();
 const CONFIG_CACHE_TTL = 10_000;
 
+type FunctionConfig = { verify_jwt: boolean; version: string | null };
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function configuredVersion(config: Record<string, unknown>): string | null {
+  if (!Object.prototype.hasOwnProperty.call(config, "version")) return null;
+  assertCanonicalConfiguredFunctionVersion(config.version);
+  return config.version;
+}
+
+function parseFunctionConfig(raw: string): FunctionConfig {
+  const config: unknown = JSON.parse(raw);
+  if (!isPlainObject(config)) {
+    throw new Error("Function config must be a plain object");
+  }
+  return {
+    verify_jwt: config.verify_jwt !== false,
+    version: configuredVersion(config),
+  };
+}
+
+async function existingFunctionConfigPath(
+  configPath: string,
+  projectRoot: string,
+): Promise<string | null> {
+  try {
+    await fs.lstat(configPath);
+  } catch (error) {
+    if (isMissingFileError(error)) return null;
+    throw error;
+  }
+  const realConfigPath = await fs.realpath(configPath);
+  if (!isPathInside(realConfigPath, projectRoot)) {
+    throw new Error("Function config path escapes project root");
+  }
+  return realConfigPath;
+}
+
 async function getFunctionConfig(
   projectRef: string,
   functionName: string,
-  projectRoot?: string,
-): Promise<{ verify_jwt: boolean; version: string | null }> {
+  projectRoot: string,
+): Promise<FunctionConfig> {
   const key = `${projectRef}/${functionName}`;
   const cached = configCache.get(key);
   if (cached && cached.expiresAt > Date.now()) {
     return { verify_jwt: cached.verify_jwt, version: cached.version };
   }
 
-  try {
-    const root = projectRoot || await resolveProjectRoot(projectRef);
-    const configPath = path.resolve(root, `${functionName}.config.json`);
-    if (!isPathInside(configPath, root)) {
-      throw new Error("Function config path escapes project root");
-    }
-    const realConfigPath = await fs.realpath(configPath);
-    if (!isPathInside(realConfigPath, root)) {
-      throw new Error("Function config path escapes project root");
-    }
-    const raw = await Bun.file(realConfigPath).text();
-    const config = JSON.parse(raw);
-    const verify_jwt = config.verify_jwt !== false;
-    const version =
-      typeof config.version === "string" && config.version.trim().length > 0
-        ? config.version.trim()
-        : null;
-    configCache.set(key, {
-      verify_jwt,
-      version,
-      expiresAt: Date.now() + CONFIG_CACHE_TTL,
-    });
-    return { verify_jwt, version };
-  } catch {
-    configCache.set(key, {
-      verify_jwt: true,
-      version: null,
-      expiresAt: Date.now() + CONFIG_CACHE_TTL,
-    });
-    return { verify_jwt: true, version: null };
+  const configPath = path.resolve(projectRoot, `${functionName}.config.json`);
+  if (!isPathInside(configPath, projectRoot)) {
+    throw new Error("Function config path escapes project root");
   }
+  const realConfigPath = await existingFunctionConfigPath(configPath, projectRoot);
+  const config = realConfigPath === null
+    ? { verify_jwt: true, version: null }
+    : parseFunctionConfig(await fs.readFile(realConfigPath, "utf8"));
+  configCache.set(key, { ...config, expiresAt: Date.now() + CONFIG_CACHE_TTL });
+  return config;
 }
 
 interface ProjectSecrets {

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -14,6 +14,161 @@ afterEach(async () => {
   }
 });
 
+describe("WorkerPool runtime-owned response metadata", () => {
+  test("overwrites tenant version headers and removes them for legacy dispatches", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-function-version-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default (request) => new Response(
+        request.headers.get("x-supacloud-function-version") || "absent",
+        {
+          headers: { "x-supacloud-function-version": "tenant-forged" },
+        },
+      );
+    `);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const versioned = await pool.dispatch({
+        functionId: "proj_versioned_v12",
+        functionPath,
+        projectRoot,
+        functionVersion: "12",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/versioned", {
+          headers: { "x-supacloud-function-version": "client-spoof" },
+        }),
+      });
+      expect(versioned.headers.get("x-supacloud-function-version")).toBe("12");
+      expect(await versioned.text()).toBe("absent");
+
+      const legacy = await pool.dispatch({
+        functionId: "proj_versioned",
+        functionPath,
+        projectRoot,
+        functionVersion: null,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/versioned"),
+      });
+      expect(legacy.headers.has("x-supacloud-function-version")).toBe(false);
+
+      const omittedLegacy = await pool.dispatch({
+        functionId: "proj_versioned_omitted",
+        functionPath,
+        projectRoot,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/versioned"),
+      });
+      expect(omittedLegacy.headers.has("x-supacloud-function-version")).toBe(false);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects non-canonical active versions before worker dispatch", async () => {
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const invalidVersions = [
+      "0",
+      "01",
+      "-1",
+      "v12",
+      "9007199254740992",
+      "1".repeat(128),
+    ];
+
+    for (const functionVersion of invalidVersions) {
+      await expect(pool.dispatch({
+        functionId: "proj_invalid_version",
+        functionPath: "/unused/fn.ts",
+        projectRoot: "/unused",
+        functionVersion,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/versioned"),
+      })).rejects.toThrow("Function version must be a canonical positive safe integer");
+    }
+  });
+
+  test("marks tenant failures with the dispatched active version", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-function-version-error-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `export default () => { throw new Error("tenant failure"); };`);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_versioned_error_v13",
+        functionPath,
+        projectRoot,
+        functionVersion: "13",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/versioned-error"),
+      });
+      expect(response.status).toBe(500);
+      expect(response.headers.get("x-supacloud-function-version")).toBe("13");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps response metadata bound across active version ABA changes", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-function-version-aba-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `export default () => new Response("ok");`);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      for (const functionVersion of ["31", "32", "31"]) {
+        const response = await pool.dispatch({
+          functionId: `proj_versioned_v${functionVersion}`,
+          functionPath,
+          projectRoot,
+          functionVersion,
+          moduleVersion: functionVersion,
+          env: {},
+          request: new Request("http://edge.local/functions/v1/versioned"),
+        });
+        expect(response.headers.get("x-supacloud-function-version")).toBe(functionVersion);
+        expect(await response.text()).toBe("ok");
+      }
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("does not attach a version when postMessage fails synchronously", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-function-version-post-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `export default () => new Response("unused");`);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    const [worker] = (pool as unknown as {
+      idle: Array<{ postMessage: (message: unknown) => void }>;
+    }).idle;
+    worker.postMessage = () => {
+      throw new Error("postMessage failed");
+    };
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_versioned_post_v14",
+        functionPath,
+        projectRoot,
+        functionVersion: "14",
+        env: {},
+        request: new Request("http://edge.local/functions/v1/versioned-post"),
+      });
+      expect(response.status).toBe(500);
+      expect(response.headers.has("x-supacloud-function-version")).toBe(false);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 async function waitForFile(path: string, timeoutMs = 2_000): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -1121,7 +1276,7 @@ describe("WorkerPool cancellation and replacement", () => {
       }
     `);
 
-    const pool = new WorkerPool({ size: 1, requestTimeout: 100 });
+    const pool = new WorkerPool({ size: 1, requestTimeout: 500 });
     pools.push(pool);
 
     try {
@@ -1129,20 +1284,26 @@ describe("WorkerPool cancellation and replacement", () => {
         functionId: "proj_timeout_fn",
         functionPath,
         projectRoot,
+        functionVersion: "41",
         env: {},
         request: new Request("http://edge.local/functions/v1/fn/slow"),
       });
-      await Bun.sleep(20);
+      await Bun.sleep(50);
       const fastResponse = pool.dispatch({
         functionId: "proj_timeout_fn",
         functionPath,
         projectRoot,
+        functionVersion: "42",
         env: {},
         request: new Request("http://edge.local/functions/v1/fn/fast"),
       });
 
-      expect((await slowResponse).status).toBe(504);
-      expect(await (await fastResponse).text()).toBe("fast");
+      const timedOutResponse = await slowResponse;
+      expect(timedOutResponse.status).toBe(504);
+      expect(timedOutResponse.headers.get("x-supacloud-function-version")).toBe("41");
+      const recoveredResponse = await fastResponse;
+      expect(recoveredResponse.headers.get("x-supacloud-function-version")).toBe("42");
+      expect(await recoveredResponse.text()).toBe("fast");
       const metrics = pool.snapshotMetrics("timeout");
       expect(metrics["timeout_total_worker_replacements"]).toBe(1);
       expect(metrics["timeout_total_worker_retirements"]).toBe(1);
@@ -1150,6 +1311,42 @@ describe("WorkerPool cancellation and replacement", () => {
       expect(metrics["timeout_idle_workers"]).toBe(1);
       await waitForMetric(pool, "total_natural_worker_exits", 1);
       expect(pool.snapshotMetrics("timeout")["timeout_retired_workers"]).toBe(0);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the dispatched version on a worker crash error", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-worker-crash-version-"));
+    const startedPath = join(projectRoot, "started.txt");
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default async () => {
+        await Bun.write(process.env.STARTED_PATH, "started");
+        await new Promise(() => {});
+      };
+    `);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 5_000 });
+    pools.push(pool);
+
+    try {
+      const pendingResponse = pool.dispatch({
+        functionId: "proj_crash_fn_v45",
+        functionPath,
+        projectRoot,
+        functionVersion: "45",
+        env: { STARTED_PATH: startedPath },
+        request: new Request("http://edge.local/functions/v1/fn/crash"),
+      });
+      await waitForFile(startedPath, 5_000);
+      const [worker] = (pool as unknown as {
+        activeWorkers: Set<{ emit: (event: "error", error: Error) => boolean }>;
+      }).activeWorkers;
+      worker.emit("error", new Error("simulated worker crash"));
+
+      const crashedResponse = await pendingResponse;
+      expect(crashedResponse.status).toBe(500);
+      expect(crashedResponse.headers.get("x-supacloud-function-version")).toBe("45");
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
@@ -1182,6 +1379,7 @@ describe("WorkerPool cancellation and replacement", () => {
         functionId: "proj_cancel_fn",
         functionPath,
         projectRoot,
+        functionVersion: "43",
         env: { STARTED_PATH: startedPath },
         request: new Request("http://edge.local/functions/v1/fn/slow", {
           signal: controller.signal,
@@ -1198,7 +1396,9 @@ describe("WorkerPool cancellation and replacement", () => {
 
       controller.abort();
 
-      expect((await slowResponse).status).toBe(499);
+      const cancelled = await slowResponse;
+      expect(cancelled.status).toBe(499);
+      expect(cancelled.headers.get("x-supacloud-function-version")).toBe("43");
       expect(await (await fastResponse).text()).toBe("fast");
       expect(pool.snapshotMetrics("cancel")["cancel_idle_workers"]).toBe(1);
     } finally {
@@ -1379,9 +1579,11 @@ describe("WorkerPool cancellation and replacement", () => {
         functionId: "proj_stream_fn",
         functionPath,
         projectRoot,
+        functionVersion: "44",
         env: {},
         request: new Request("http://edge.local/functions/v1/fn/stream"),
       });
+      expect(streamResponse.headers.get("x-supacloud-function-version")).toBe("44");
       const reader = streamResponse.body!.getReader();
       expect((await reader.read()).done).toBe(false);
 
@@ -2751,11 +2953,13 @@ describe("WorkerPool body size limit", () => {
         functionId: "test_body_limit",
         functionPath,
         projectRoot,
+        functionVersion: "46",
         env: {},
         request: req,
       });
 
       expect(res.status).toBe(413);
+      expect(res.headers.has("x-supacloud-function-version")).toBe(false);
       const body = await res.json();
       expect(body.error).toContain("Request body too large");
       expect(body.error).toContain("30MB");

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -6,12 +6,14 @@ import { resolveEdgeFetchTlsPolicy } from "./fetch-tls-policy";
 import type { EdgeFetchTlsPolicy } from "./fetch-tls-policy";
 import type { PgredisRuntimeBindingConfig } from "./internal-bindings";
 import { EMBEDDED_WORKER_HASH, EMBEDDED_WORKER_SOURCE } from "./generated/embedded-worker";
+import { assertCanonicalPositiveFunctionVersion } from "./function-version";
 
 interface DispatchOptions {
   functionId: string;
   functionPath: string;
   projectRoot: string;
   projectRef?: string;
+  functionVersion?: string | null;
   moduleVersion?: string;
   env: Record<string, string>;
   internalBindings?: Omit<PgredisRuntimeBindingConfig, "signal">;
@@ -39,6 +41,8 @@ type QueuedDispatch = {
 };
 
 const DEFAULT_MAX_BODY_SIZE_MB = 30;
+const FUNCTION_VERSION_HEADER = "x-supacloud-function-version";
+
 function resolveMaxBodySizeBytes(value = process.env.EDGE_MAX_BODY_SIZE_MB): number {
   const configuredMb = Number(value);
   const maxBodySizeMb = Number.isFinite(configuredMb) && configuredMb > 0
@@ -60,6 +64,23 @@ function cancelledResponse(): Response {
   return new Response(JSON.stringify({ error: "Task cancelled" }), {
     status: 499,
     headers: { "Content-Type": "application/json" },
+  });
+}
+
+function withRuntimeFunctionVersion(
+  response: Response,
+  version: string | null | undefined,
+): Response {
+  const headers = new Headers(response.headers);
+  if (version === null || version === undefined) {
+    headers.delete(FUNCTION_VERSION_HEADER);
+  } else {
+    headers.set(FUNCTION_VERSION_HEADER, version);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
   });
 }
 
@@ -296,6 +317,8 @@ export class WorkerPool {
       });
     }
 
+    assertCanonicalPositiveFunctionVersion(opts.functionVersion);
+
     this.totalRequests++;
     if (opts.envLoadMs) this.totalEnvLoadMs += opts.envLoadMs;
     const executionKey = crypto.randomUUID();
@@ -381,17 +404,23 @@ export class WorkerPool {
     worker: Worker,
     opts: ScheduledDispatch,
     enqueuedAt: number,
-    resolve: (r: Response) => void,
+    resolve: (response: Response) => void,
   ) {
     const queueWaitMs = Math.round(performance.now() - enqueuedAt);
     this.totalQueueWaitMs += queueWaitMs;
     const cancelGraceMs = 3_000;
 
     let resolved = false;
-    const safeResolve = (r: Response) => {
+    let executionStarted = false;
+    let cancellationRequested = false;
+    const resolveOnce = (response: Response) => {
       if (resolved) return;
       resolved = true;
-      resolve(r);
+      resolve(
+        executionStarted
+          ? withRuntimeFunctionVersion(response, opts.functionVersion)
+          : response,
+      );
     };
     const cleanupInFlight = () => {
       this.inFlight.delete(opts.executionKey);
@@ -413,15 +442,13 @@ export class WorkerPool {
       }
     };
 
-    let executionStarted = false;
-    let cancellationRequested = false;
     let detachResponseListeners = () => {};
 
     const timeout = setTimeout(() => {
       detachResponseListeners();
       cleanupInFlight();
       clearCancellationState();
-      safeResolve(new Response("Gateway Timeout", { status: 504 }));
+      resolveOnce(new Response("Gateway Timeout", { status: 504 }));
       this.retireWorker(worker);
     }, this.config.requestTimeout);
 
@@ -429,7 +456,7 @@ export class WorkerPool {
       detachResponseListeners();
       cleanupInFlight();
       clearCancellationState();
-      safeResolve(cancelledResponse());
+      resolveOnce(cancelledResponse());
       this.retireWorker(worker);
     };
 
@@ -466,17 +493,15 @@ export class WorkerPool {
       if (resolved) return true;
       if (!cancellationRequested) return false;
       releaseBeforeExecution();
-      safeResolve(cancelledResponse());
+      resolveOnce(cancelledResponse());
       return true;
     };
 
     const headers: Record<string, string | string[]> = {};
     opts.request.headers.forEach((v, k) => {
       const lower = k.toLowerCase();
-      if (lower === "set-cookie") {
-      } else {
-        headers[k] = v;
-      }
+      if (lower === "set-cookie" || lower === FUNCTION_VERSION_HEADER) return;
+      headers[k] = v;
     });
     const cookies = (opts.request.headers as any).getSetCookie?.();
     if (cookies && cookies.length > 0) {
@@ -488,7 +513,7 @@ export class WorkerPool {
       const contentLength = opts.request.headers.get("content-length");
       if (contentLength && parseInt(contentLength) > MAX_BODY_SIZE) {
         releaseBeforeExecution();
-        safeResolve(
+        resolveOnce(
           new Response(
             JSON.stringify({
               error: `Request body too large (max ${MAX_BODY_SIZE / 1024 / 1024}MB)`,
@@ -511,7 +536,7 @@ export class WorkerPool {
       if (finishCancelledBeforeExecution()) return;
       if (body.byteLength > MAX_BODY_SIZE) {
         releaseBeforeExecution();
-        safeResolve(
+        resolveOnce(
           new Response(
             JSON.stringify({
               error: `Request body too large (max ${MAX_BODY_SIZE / 1024 / 1024}MB)`,
@@ -616,7 +641,6 @@ export class WorkerPool {
           resHeaders.set(k, v);
         }
       }
-
       if (msg.type === "stream_start" && msg.streamId) {
         const streamId = msg.streamId;
         let streamFinished = false;
@@ -667,14 +691,14 @@ export class WorkerPool {
           },
         });
 
-        safeResolve(
+        resolveOnce(
           new Response(bodyStream, {
             status: msg.status,
             headers: resHeaders,
           }),
         );
       } else {
-        safeResolve(
+        resolveOnce(
           new Response(msg.body, {
             status: msg.status,
             headers: resHeaders,
@@ -718,7 +742,7 @@ export class WorkerPool {
       cleanupInFlight();
       clearCancellationState();
       detachResponseListeners();
-      safeResolve(new Response("Internal Error", { status: 500 }));
+      resolveOnce(new Response("Internal Error", { status: 500 }));
       this.retireWorker(worker);
     };
 


### PR DESCRIPTION
## Summary

- bind response version metadata to the immutable artifact actually selected by Edge Runtime
- strip client and tenant-forged version headers and preserve queued legacy v0 behavior
- fail closed on malformed or non-canonical function activation config instead of executing mutable aliases
- add real foreground/background Edge Runtime regression coverage and required CI wiring

## Verification

- Edge Runtime CI test set: 95 pass, 0 fail, 545 assertions
- Edge Runtime typecheck: pass
- git diff --check: pass
- independent post-rebase review: P0=0, P1=0, P2=0
- clean-code-guard: clean

No release or deployment was performed by this PR creation.