### PR TITLE
fix(edge-runtime): bind artifacts to activation roots

### DIFF
--- a/packages/edge-runtime/server-function-config.test.ts
+++ b/packages/edge-runtime/server-function-config.test.ts
@@ -261,6 +261,24 @@ async function expectLegacySymlinkFailsClosed(): Promise<void> {
   await expectActivationFailsClosed(slug, forbiddenBody);
 }
 
+async function installInvalidPreferredArtifact(
+  slug: string,
+  fallbackBody: string,
+  artifactKind: "directory" | "fifo",
+): Promise<void> {
+  await writeVersionedFunction(slug, "7", fallbackBody);
+  const sourceRoot = join(projectRoot, ".versions", slug, "7", "src");
+  const preferredArtifact = join(sourceRoot, ".supacloud-entry.js");
+  await mkdir(sourceRoot, { recursive: true });
+  if (artifactKind === "directory") {
+    await mkdir(preferredArtifact);
+  } else {
+    const creation = Bun.spawnSync(["mkfifo", preferredArtifact], { stderr: "pipe" });
+    expect(creation.exitCode).toBe(0);
+  }
+  await writeFunctionConfig(slug, '{"verify_jwt":false,"version":"7"}');
+}
+
 beforeAll(initializeServerFixture);
 
 afterAll(async () => {
@@ -325,4 +343,19 @@ describe("Edge Runtime function config boundary", () => {
     await expectCrossSlugSymlinkFailsClosed();
     await expectLegacySymlinkFailsClosed();
   });
+
+  test("rejects a preferred artifact directory instead of executing a fallback", async () => {
+    const fallbackBody = "directory-fallback-must-not-run";
+    await installInvalidPreferredArtifact("preferred_directory", fallbackBody, "directory");
+    await expectActivationFailsClosed("preferred_directory", fallbackBody);
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "rejects a preferred artifact FIFO instead of executing a fallback",
+    async () => {
+      const fallbackBody = "fifo-fallback-must-not-run";
+      await installInvalidPreferredArtifact("preferred_fifo", fallbackBody, "fifo");
+      await expectActivationFailsClosed("preferred_fifo", fallbackBody);
+    },
+  );
 });

--- a/packages/edge-runtime/server-function-config.test.ts
+++ b/packages/edge-runtime/server-function-config.test.ts
@@ -6,7 +6,7 @@ import {
   setDefaultTimeout,
   test,
 } from "bun:test";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -179,15 +179,19 @@ async function expectInvalidConfigFailsClosed(slug: string, rawConfig: string): 
   await writeLegacyFunction(slug, staleBody);
   await writeFunctionConfig(slug, rawConfig);
 
+  await expectActivationFailsClosed(slug, staleBody);
+}
+
+async function expectActivationFailsClosed(slug: string, forbiddenBody: string): Promise<void> {
   const foreground = await invokeForeground(slug);
   expect(foreground.status).toBe(500);
   expect(foreground.headers.has("x-supacloud-function-version")).toBe(false);
-  expect(await foreground.text()).not.toContain(staleBody);
+  expect(await foreground.text()).not.toContain(forbiddenBody);
 
   const background = await invokeBackground(slug);
   expect(background.status).toBe(500);
   expect(background.headers["x-supacloud-function-version"]).toBeUndefined();
-  expect(background.bodyText).not.toContain(staleBody);
+  expect(background.bodyText).not.toContain(forbiddenBody);
 }
 
 async function installValidFunction(
@@ -217,6 +221,44 @@ async function expectValidFunctionResponse(
   expect(background.status).toBe(200);
   expect(background.headers["x-supacloud-function-version"] ?? null).toBe(responseVersion);
   expect(background.bodyText).toBe(body);
+}
+
+async function expectCrossVersionSymlinkFailsClosed(): Promise<void> {
+  const slug = "cross_version";
+  const forbiddenBody = "executed-v8";
+  await writeVersionedFunction(slug, "8", forbiddenBody);
+  const versionSevenRoot = join(projectRoot, ".versions", slug, "7");
+  await mkdir(versionSevenRoot, { recursive: true });
+  await symlink(
+    join(projectRoot, ".versions", slug, "8", "index.js"),
+    join(versionSevenRoot, "index.js"),
+  );
+  await writeFunctionConfig(slug, '{"verify_jwt":false,"version":"7"}');
+  await expectActivationFailsClosed(slug, forbiddenBody);
+}
+
+async function expectCrossSlugSymlinkFailsClosed(): Promise<void> {
+  const slug = "cross_slug";
+  const targetSlug = "cross_slug_target";
+  const forbiddenBody = "executed-other-slug";
+  await writeVersionedFunction(targetSlug, "7", forbiddenBody);
+  const versionRoot = join(projectRoot, ".versions", slug, "7");
+  await mkdir(versionRoot, { recursive: true });
+  await symlink(
+    join(projectRoot, ".versions", targetSlug, "7", "index.js"),
+    join(versionRoot, "index.js"),
+  );
+  await writeFunctionConfig(slug, '{"verify_jwt":false,"version":"7"}');
+  await expectActivationFailsClosed(slug, forbiddenBody);
+}
+
+async function expectLegacySymlinkFailsClosed(): Promise<void> {
+  const slug = "legacy_symlink";
+  const targetSlug = "legacy_symlink_target";
+  const forbiddenBody = "executed-legacy-target";
+  await writeLegacyFunction(targetSlug, forbiddenBody);
+  await symlink(join(projectRoot, `${targetSlug}.ts`), join(projectRoot, `${slug}.ts`));
+  await expectActivationFailsClosed(slug, forbiddenBody);
 }
 
 beforeAll(initializeServerFixture);
@@ -276,5 +318,11 @@ describe("Edge Runtime function config boundary", () => {
     const invalidated = await invokeForeground(slug);
     expect(invalidated.status).toBe(500);
     expect(await invalidated.text()).not.toContain("stale-cache-alias");
+  });
+
+  test("rejects cross-version and cross-slug artifact symlinks", async () => {
+    await expectCrossVersionSymlinkFailsClosed();
+    await expectCrossSlugSymlinkFailsClosed();
+    await expectLegacySymlinkFailsClosed();
   });
 });

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -304,6 +304,34 @@ type FunctionActivationSnapshot = {
   moduleVersion: string;
 };
 
+function functionArtifactBindingRoot(
+  projectRoot: string,
+  functionName: string,
+  activeVersion: string | null,
+  candidate: string,
+): string {
+  if (activeVersion !== null) {
+    return path.join(projectRoot, ".versions", functionName, activeVersion);
+  }
+  const sourceRoot = path.join(projectRoot, `.src-${functionName}`);
+  return isPathInside(candidate, sourceRoot) ? sourceRoot : candidate;
+}
+
+function isBoundFunctionArtifact(
+  candidate: string,
+  realCandidate: string,
+  bindingRoot: string,
+): boolean {
+  return bindingRoot === candidate
+    ? realCandidate === candidate
+    : isPathInside(realCandidate, bindingRoot);
+}
+
+function isMissingFunctionCandidate(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  return error.code === "ENOENT" || error.code === "ENOTDIR";
+}
+
 async function resolveFunctionPath(
   projectRef: string,
   functionName: string,
@@ -328,8 +356,14 @@ async function resolveFunctionPath(
 
     try {
       const realCandidate = await fs.realpath(candidate);
-      if (!isPathInside(realCandidate, projectRoot)) {
-        throw new Error("Function path escapes project root");
+      const bindingRoot = functionArtifactBindingRoot(
+        projectRoot,
+        functionName,
+        activeVersion,
+        candidate,
+      );
+      if (!isBoundFunctionArtifact(candidate, realCandidate, bindingRoot)) {
+        throw new Error("Function path escapes its activation root");
       }
       const stat = await fs.stat(realCandidate);
       if (!stat.isFile()) {
@@ -350,7 +384,7 @@ async function resolveFunctionPath(
         ].join(":"),
       };
     } catch (error) {
-      if (error instanceof Error && error.message.includes("escapes")) throw error;
+      if (!isMissingFunctionCandidate(error)) throw error;
     }
   }
 

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -367,7 +367,7 @@ async function resolveFunctionPath(
       }
       const stat = await fs.stat(realCandidate);
       if (!stat.isFile()) {
-        continue;
+        throw new Error("Function artifact is not a regular file");
       }
       return {
         functionPath: realCandidate,


### PR DESCRIPTION
## Summary

- bind versioned Edge artifacts to the exact `.versions/<slug>/<version>` activation root
- bind legacy source artifacts to their exact slug source root and reject cross-slug aliases
- only fall through candidate resolution for `ENOENT`/`ENOTDIR`
- reject an existing preferred artifact that is not a regular file instead of executing a lower-priority fallback

## Security contract

A configured function version must never execute code from another version or slug. Cross-version, cross-slug, legacy symlink, directory, and FIFO substitutions now fail closed for both foreground and background invocation.

## Verification

- Edge Runtime CI-equivalent suite: 7 files, 98 tests, 581 assertions
- TypeScript typecheck
- `git diff --check`
- `bun audit --audit-level high` was attempted locally but the registry audit endpoint returned HTTP 404; the new exact-head CI reruns the package audit
- clean-code-guard: 4 fixed, 0 flagged

## Coordination

This is the required follow-up to the prematurely merged #844. Release PR #841 and all release/deploy activity remain frozen until independent review and exact-head checks pass.