### PR TITLE
fix(admin): make upgrade preflight awk portable

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -186,6 +186,30 @@ describe("local upgrade remote runner", () => {
         });
     });
 
+    test("local-transfer preflight parses quoted Edge Runtime mode without awk escape warnings", () => {
+        const fixtureDirectory = mkdtempSync(join(tmpdir(), "supacloud-local-edge-mode-"));
+        const envFile = join(fixtureDirectory, "management-api.env");
+        const script = buildRemotePreflightScript();
+        const edgeModeAssignment = script.split("\n").find(line => line.startsWith("EDGE_MODE="));
+        if (!edgeModeAssignment) throw new Error("Generated local-transfer preflight does not read EDGE_RUNTIME_MODE");
+        const fixtureEdgeModeAssignment = edgeModeAssignment.replace("/etc/supabase/management-api.env", '"$ENV_FILE"');
+        expect(fixtureEdgeModeAssignment).toContain(String.raw`\042\047`);
+        expect(fixtureEdgeModeAssignment).not.toContain(String.raw`\"`);
+        try {
+            for (const configuredValue of ["external", '"external"', "'external'", "  external  "]) {
+                writeFileSync(envFile, `EDGE_RUNTIME_MODE=${configuredValue}\n`);
+                const execution = Bun.spawnSync(["bash", "-c", [
+                    "set -euo pipefail", fixtureEdgeModeAssignment, "printf '%s' \"$EDGE_MODE\"",
+                ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
+                expect(execution.exitCode).toBe(0);
+                expect(execution.stdout.toString()).toBe("external");
+                expect(execution.stderr.toString()).toBe("");
+            }
+        } finally {
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    });
+
     test("serializes independent run IDs with one host-wide upgrade lock", () => {
         const firstRun = runScript(preparedBundle("amd64", "installed"), "amd64");
         const secondRun = buildLocalUpgradeRunScript({

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -186,12 +186,14 @@ describe("local upgrade remote runner", () => {
         });
     });
 
-    test("local-transfer preflight parses quoted Edge Runtime mode without awk escape warnings", () => {
+    test("local-transfer preflight preserves the full Edge Runtime mode and rejects suffixes", () => {
         const fixtureDirectory = mkdtempSync(join(tmpdir(), "supacloud-local-edge-mode-"));
         const envFile = join(fixtureDirectory, "management-api.env");
         const script = buildRemotePreflightScript();
         const edgeModeAssignment = script.split("\n").find(line => line.startsWith("EDGE_MODE="));
         if (!edgeModeAssignment) throw new Error("Generated local-transfer preflight does not read EDGE_RUNTIME_MODE");
+        const edgeModeGate = script.split("\n").find(line => line.startsWith('test "$EDGE_MODE" = external'));
+        if (!edgeModeGate) throw new Error("Generated local-transfer preflight does not enforce exact external mode");
         const fixtureEdgeModeAssignment = edgeModeAssignment.replace("/etc/supabase/management-api.env", '"$ENV_FILE"');
         expect(fixtureEdgeModeAssignment).toContain(String.raw`\042\047`);
         expect(fixtureEdgeModeAssignment).not.toContain(String.raw`\"`);
@@ -199,12 +201,24 @@ describe("local upgrade remote runner", () => {
             for (const configuredValue of ["external", '"external"', "'external'", "  external  "]) {
                 writeFileSync(envFile, `EDGE_RUNTIME_MODE=${configuredValue}\n`);
                 const execution = Bun.spawnSync(["bash", "-c", [
-                    "set -euo pipefail", fixtureEdgeModeAssignment, "printf '%s' \"$EDGE_MODE\"",
+                    "set -euo pipefail", fixtureEdgeModeAssignment, edgeModeGate,
+                    "printf '%s' \"$EDGE_MODE\"",
                 ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
                 expect(execution.exitCode).toBe(0);
                 expect(execution.stdout.toString()).toBe("external");
                 expect(execution.stderr.toString()).toBe("");
             }
+            writeFileSync(envFile, "EDGE_RUNTIME_MODE=external=embedded\n");
+            const fullRhsProbe = Bun.spawnSync(["bash", "-c", [
+                "set -euo pipefail", fixtureEdgeModeAssignment, "printf '%s' \"$EDGE_MODE\"",
+            ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
+            expect(fullRhsProbe.exitCode).toBe(0);
+            expect(fullRhsProbe.stdout.toString()).toBe("external=embedded");
+            const suffixRejection = Bun.spawnSync(["bash", "-c", [
+                "set -euo pipefail", fixtureEdgeModeAssignment, edgeModeGate,
+            ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
+            expect(suffixRejection.exitCode).not.toBe(0);
+            expect(suffixRejection.stderr.toString()).toContain("requires persisted external Edge Runtime mode");
         } finally {
             rmSync(fixtureDirectory, { recursive: true, force: true });
         }

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -123,7 +123,7 @@ export function buildRemotePreflightScript(): string {
         "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
         "test -d /var/lib/supacloud || { echo '/var/lib/supacloud is unavailable' >&2; exit 1; }",
         "test -f /etc/supabase/management-api.env || { echo 'EDGE_RUNTIME_MODE is unavailable' >&2; exit 1; }",
-        "EDGE_MODE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\\"'\"']+|[[:space:]\\\"'\"']+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
+        "EDGE_MODE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\042\\047]+|[[:space:]\\042\\047]+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
         "test \"$EDGE_MODE\" = external || { echo 'Local component upgrade requires persisted external Edge Runtime mode' >&2; exit 1; }",
         "case \"$(uname -m)\" in x86_64|amd64) echo ARCH=amd64 ;; aarch64|arm64) echo ARCH=arm64 ;; *) echo 'Unsupported remote architecture' >&2; exit 1 ;; esac",
         "VERIFIER=bundled",

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -123,7 +123,7 @@ export function buildRemotePreflightScript(): string {
         "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
         "test -d /var/lib/supacloud || { echo '/var/lib/supacloud is unavailable' >&2; exit 1; }",
         "test -f /etc/supabase/management-api.env || { echo 'EDGE_RUNTIME_MODE is unavailable' >&2; exit 1; }",
-        "EDGE_MODE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\042\\047]+|[[:space:]\\042\\047]+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
+        "EDGE_MODE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=substr($0, index($0, \"=\") + 1) } END { gsub(/^[[:space:]\\042\\047]+|[[:space:]\\042\\047]+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
         "test \"$EDGE_MODE\" = external || { echo 'Local component upgrade requires persisted external Edge Runtime mode' >&2; exit 1; }",
         "case \"$(uname -m)\" in x86_64|amd64) echo ARCH=amd64 ;; aarch64|arm64) echo ARCH=arm64 ;; *) echo 'Unsupported remote architecture' >&2; exit 1 ;; esac",
         "VERIFIER=bundled",

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -700,6 +700,33 @@ describe("ssh admin tool", () => {
         expect(rootScript).toContain("Another SupaCloud upgrade is already running");
     });
 
+    test("remote component preflight parses quoted Edge Runtime mode without awk escape warnings", () => {
+        const fixtureDir = mkdtempSync(join(tmpdir(), "supacloud-admin-edge-mode-"));
+        const envFile = join(fixtureDir, "management-api.env");
+        const rootScript = buildRootUpgradeScript({
+            edgeRuntimeVersion: "0.17.1",
+            helperPath: "/tmp/release-assets.sh",
+        });
+        const edgeModeAssignment = rootScript.split("\n").find(line => line.startsWith("EDGE_RUNTIME_MODE_VALUE="));
+        if (!edgeModeAssignment) throw new Error("Generated upgrade script does not read EDGE_RUNTIME_MODE");
+        const fixtureEdgeModeAssignment = edgeModeAssignment.replace("/etc/supabase/management-api.env", '"$ENV_FILE"');
+        expect(fixtureEdgeModeAssignment).toContain(String.raw`\042\047`);
+        expect(fixtureEdgeModeAssignment).not.toContain(String.raw`\"`);
+        try {
+            for (const configuredValue of ["external", '"external"', "'external'", "  external  "]) {
+                writeFileSync(envFile, `EDGE_RUNTIME_MODE=${configuredValue}\n`);
+                const execution = Bun.spawnSync(["bash", "-c", [
+                    "set -euo pipefail", fixtureEdgeModeAssignment, "printf '%s' \"$EDGE_RUNTIME_MODE_VALUE\"",
+                ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
+                expect(execution.exitCode).toBe(0);
+                expect(execution.stdout.toString()).toBe("external");
+                expect(execution.stderr.toString()).toBe("");
+            }
+        } finally {
+            rmSync(fixtureDir, { recursive: true, force: true });
+        }
+    });
+
     test("remote trusted-root adoption rejects missing, altered, linked, and permissive files", () => {
         const fixtureRoot = mkdtempSync(join(tmpdir(), "supacloud-admin-remote-root-"));
         const helperPath = join(fixtureRoot, "release_assets.sh");

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -700,7 +700,7 @@ describe("ssh admin tool", () => {
         expect(rootScript).toContain("Another SupaCloud upgrade is already running");
     });
 
-    test("remote component preflight parses quoted Edge Runtime mode without awk escape warnings", () => {
+    test("remote component preflight preserves the full Edge Runtime mode and rejects suffixes", () => {
         const fixtureDir = mkdtempSync(join(tmpdir(), "supacloud-admin-edge-mode-"));
         const envFile = join(fixtureDir, "management-api.env");
         const rootScript = buildRootUpgradeScript({
@@ -709,6 +709,8 @@ describe("ssh admin tool", () => {
         });
         const edgeModeAssignment = rootScript.split("\n").find(line => line.startsWith("EDGE_RUNTIME_MODE_VALUE="));
         if (!edgeModeAssignment) throw new Error("Generated upgrade script does not read EDGE_RUNTIME_MODE");
+        const edgeModeGate = rootScript.split("\n").find(line => line.startsWith('test "$EDGE_RUNTIME_MODE_VALUE" = external'));
+        if (!edgeModeGate) throw new Error("Generated upgrade script does not enforce exact external mode");
         const fixtureEdgeModeAssignment = edgeModeAssignment.replace("/etc/supabase/management-api.env", '"$ENV_FILE"');
         expect(fixtureEdgeModeAssignment).toContain(String.raw`\042\047`);
         expect(fixtureEdgeModeAssignment).not.toContain(String.raw`\"`);
@@ -716,12 +718,24 @@ describe("ssh admin tool", () => {
             for (const configuredValue of ["external", '"external"', "'external'", "  external  "]) {
                 writeFileSync(envFile, `EDGE_RUNTIME_MODE=${configuredValue}\n`);
                 const execution = Bun.spawnSync(["bash", "-c", [
-                    "set -euo pipefail", fixtureEdgeModeAssignment, "printf '%s' \"$EDGE_RUNTIME_MODE_VALUE\"",
+                    "set -euo pipefail", fixtureEdgeModeAssignment, edgeModeGate,
+                    "printf '%s' \"$EDGE_RUNTIME_MODE_VALUE\"",
                 ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
                 expect(execution.exitCode).toBe(0);
                 expect(execution.stdout.toString()).toBe("external");
                 expect(execution.stderr.toString()).toBe("");
             }
+            writeFileSync(envFile, "EDGE_RUNTIME_MODE=external=embedded\n");
+            const fullRhsProbe = Bun.spawnSync(["bash", "-c", [
+                "set -euo pipefail", fixtureEdgeModeAssignment, "printf '%s' \"$EDGE_RUNTIME_MODE_VALUE\"",
+            ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
+            expect(fullRhsProbe.exitCode).toBe(0);
+            expect(fullRhsProbe.stdout.toString()).toBe("external=embedded");
+            const suffixRejection = Bun.spawnSync(["bash", "-c", [
+                "set -euo pipefail", fixtureEdgeModeAssignment, edgeModeGate,
+            ].join("\n")], { env: { ...process.env, ENV_FILE: envFile } });
+            expect(suffixRejection.exitCode).not.toBe(0);
+            expect(suffixRejection.stderr.toString()).toContain("supports persisted external mode only");
         } finally {
             rmSync(fixtureDir, { recursive: true, force: true });
         }

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -260,7 +260,7 @@ function componentBootstrapCommands(request: UpgradeRequest): string[] {
 function componentPreflightCommands(request: UpgradeRequest): string[] {
     return request.edgeRuntimeVersion ? [
         "test -f /etc/supabase/management-api.env || { echo 'EDGE_RUNTIME_MODE is unavailable; component upgrade requires external mode' >&2; exit 1; }",
-        "EDGE_RUNTIME_MODE_VALUE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\042\\047]+|[[:space:]\\042\\047]+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
+        "EDGE_RUNTIME_MODE_VALUE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=substr($0, index($0, \"=\") + 1) } END { gsub(/^[[:space:]\\042\\047]+|[[:space:]\\042\\047]+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
         "test \"$EDGE_RUNTIME_MODE_VALUE\" = external || { echo 'Edge Runtime component upgrade supports persisted external mode only' >&2; exit 1; }",
     ] : [];
 }

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -260,7 +260,7 @@ function componentBootstrapCommands(request: UpgradeRequest): string[] {
 function componentPreflightCommands(request: UpgradeRequest): string[] {
     return request.edgeRuntimeVersion ? [
         "test -f /etc/supabase/management-api.env || { echo 'EDGE_RUNTIME_MODE is unavailable; component upgrade requires external mode' >&2; exit 1; }",
-        "EDGE_RUNTIME_MODE_VALUE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\\"'\"']+|[[:space:]\\\"'\"']+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
+        "EDGE_RUNTIME_MODE_VALUE=$(awk -F= '$1 == \"EDGE_RUNTIME_MODE\" { value=$2 } END { gsub(/^[[:space:]\\042\\047]+|[[:space:]\\042\\047]+$/, \"\", value); print value }' /etc/supabase/management-api.env)",
         "test \"$EDGE_RUNTIME_MODE_VALUE\" = external || { echo 'Edge Runtime component upgrade supports persisted external mode only' >&2; exit 1; }",
     ] : [];
 }


### PR DESCRIPTION
## Summary

- make persisted EDGE_RUNTIME_MODE parsing portable across POSIX and GNU awk
- cover both remote artifact transport and local-transfer remote preflight
- preserve unquoted, single-quoted, double-quoted, and whitespace-padded values

## Why

Admin 0.10.0 generated an awk regular expression containing an invalid escaped double quote. GNU Awk 5.3.0 reports that escape on the supported remote upgrade path, causing the verified upgrade preflight to abort before the transaction starts.

## Validation

- focused Admin tests: 118 pass, 0 fail, 818 assertions
- full Admin test suite: pass
- Admin typecheck: pass
- git diff --check: pass
- GNU Awk 5.3.0 live preflight expression: no stderr, EDGE_MODE=external
- independent review: P0/P1/P2 = 0/0/0
- clean-code-guard: clean

## Scope

This PR does not change release download, verification, rollback, Release Please, package publishing, or deployment behavior.