### PR TITLE
fix(admin): reconcile remote upgrade timeout outcomes

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -137,9 +137,19 @@ With `--artifact_transport remote` (the default), omitting
 `--edge_runtime_version` retains the Management and Web Console-only upgrade
 behavior and reports that Edge Runtime was not upgraded. Local transport
 requires exact Management and Edge Runtime versions. Caddy and GoTrue are
-outside this transaction and are not replaced. After a capable Management
-release is active, an exact rollback can use that active upgrader with explicit
-older targets, for example:
+outside this transaction and are not replaced.
+
+The remote transport allows the same 30-minute transaction window plus bounded
+verifier/bootstrap downloads: 42 minutes for direct GitHub access, or 52
+minutes when each download may try direct GitHub before an explicit proxy. If
+the SSH command times out or its stream fails after dispatch, Admin reports
+`OUTCOME_UNKNOWN` and does not issue client-side helper cleanup. The remote
+command may finish later and then run its own cleanup. Reconcile the reported
+helper and trusted-root paths and read back deployed versions before deciding
+whether to retry.
+
+After a capable Management release is active, an exact rollback can use that
+active upgrader with explicit older targets, for example:
 
 ```bash
 npx @supacloud/admin ssh upgrade \

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -55,7 +55,7 @@ const REMOTE_COMMAND_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/
 const POLL_INTERVAL_MS = 2_000;
 const STATE_READ_ATTEMPTS = 3;
 const REMOTE_STATE_READ_TIMEOUT_MS = 15_000;
-const UPGRADE_OBSERVATION_TIMEOUT_MS = 30 * 60_000;
+export const UPGRADE_OBSERVATION_TIMEOUT_MS = 30 * 60_000;
 
 class RemoteUpgradeReconciliationError extends AggregateError {}
 

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
 import {
     chmodSync,
     existsSync,
@@ -17,8 +18,10 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { buildOfficialUpgradeCommand, buildRootUpgradeScript, registerSshTools } from "./ssh-tools";
+import { formatCliError } from "../cli";
 import { parseToolArguments } from "../schema";
 import type { ToolSchema } from "../schema";
+import { SshCommandOutcomeUnknownError, SshTransport } from "../transports/ssh";
 import {
     SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_FILENAME,
     SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_JSONL,
@@ -29,6 +32,41 @@ import {
 type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
 type FakeExecResult = { success: boolean; stdout: string; stderr: string; code: number };
 type FakeExecPlan = { fragment: string; executions: FakeExecResult[]; calls: number };
+type UpgradeTransportOutcome = "late_success" | "stream_error";
+
+const TEST_SSH_HOST_FINGERPRINT = `SHA256:${Buffer.alloc(32, 7).toString("base64").replace(/=+$/, "")}`;
+
+class UpgradeTransportClient extends EventEmitter {
+    endCalls = 0;
+    terminalCloseEmitted = false;
+
+    constructor(private readonly outcome: UpgradeTransportOutcome) {
+        super();
+    }
+
+    connect(): this {
+        queueMicrotask(() => this.emit("ready"));
+        return this;
+    }
+
+    exec(_command: string, callback: (error: Error | undefined, stream: EventEmitter & { stderr: EventEmitter }) => void): void {
+        const stream = new EventEmitter() as EventEmitter & { stderr: EventEmitter };
+        stream.stderr = new EventEmitter();
+        callback(undefined, stream);
+        if (this.outcome === "stream_error") {
+            queueMicrotask(() => stream.emit("error", new Error("TOKEN=stream-secret")));
+            return;
+        }
+        setTimeout(() => {
+            this.terminalCloseEmitted = true;
+            stream.emit("close", 0);
+        }, 20);
+    }
+
+    end(): void {
+        this.endCalls += 1;
+    }
+}
 
 class FakeSsh {
     readonly commands: string[] = [];
@@ -39,6 +77,9 @@ class FakeSsh {
     installEarlyFails = false;
     bootstrapDepsFail = false;
     bootstrapCloneFail = false;
+    prepareExecOutcomeUnknown = false;
+    upgradeTransportOutcome: UpgradeTransportOutcome | undefined;
+    upgradeTransportClient: UpgradeTransportClient | undefined;
     upgradeExecThrows = false;
     upgradeExecRejection: { value: unknown } | undefined;
     upgradeExecFails = false;
@@ -64,6 +105,22 @@ class FakeSsh {
             const executionIndex = Math.min(fixedPlan.calls, fixedPlan.executions.length - 1);
             fixedPlan.calls += 1;
             return fixedPlan.executions[executionIndex]!;
+        }
+        if (this.prepareExecOutcomeUnknown && command.includes("mkdir -m 700 --")) {
+            throw new SshCommandOutcomeUnknownError("SSH command timed out after 30000ms; remote outcome is unknown");
+        }
+        if (this.upgradeTransportOutcome && command.includes("UPGRADE_RUNNER")) {
+            const client = new UpgradeTransportClient(this.upgradeTransportOutcome);
+            this.upgradeTransportClient = client;
+            const transport = new SshTransport({
+                host: "server.example.com", port: 22, username: "root",
+                hostFingerprint: TEST_SSH_HOST_FINGERPRINT,
+            }, { clientFactory: () => client as never });
+            try {
+                return await transport.exec(command, 5);
+            } finally {
+                transport.close();
+            }
         }
         if (this.upgradeExecThrows && command.includes("UPGRADE_RUNNER")) {
             throw new Error("connection dropped");
@@ -812,7 +869,7 @@ describe("ssh admin tool", () => {
         expect(execution.exitCode).toBe(0);
     });
 
-    test("explicit upgrade proxy leaves time for direct-first and proxy transfer budgets", async () => {
+    test("proxy upgrade budget adds 30-minute observation to bounded dual-route downloads", async () => {
         const ssh = new FakeSsh();
         await captureSshTool(ssh).invoke({
             action: "upgrade",
@@ -820,7 +877,7 @@ describe("ssh admin tool", () => {
             github_proxy: "https://proxy.example.test/",
         });
 
-        expect(ssh.timeouts).toEqual([30_000, 1_320_000, 30_000]);
+        expect(ssh.timeouts).toEqual([30_000, (30 + 22) * 60_000, 30_000]);
     });
 
     test("outer upgrade signals remove the helper and stop command continuation", () => {
@@ -1009,7 +1066,59 @@ describe("ssh admin tool", () => {
         expect(ssh.commands[0]).not.toContain("install -d");
         expect(ssh.commands[2]).toContain(`rm -rf -- '${ssh.uploads[0]?.remotePath.replace(/\/release_assets\.sh$/, "")}'`);
         expect(ssh.commands[2]).toContain("sudo -n rm -rf --");
-        expect(ssh.timeouts).toEqual([30_000, 720_000, 30_000]);
+        expect(ssh.timeouts).toEqual([30_000, (30 + 12) * 60_000, 30_000]);
+    });
+
+    test("timeout preserves reconciliation evidence while the remote upgrade completes later", async () => {
+        const ssh = new FakeSsh();
+        ssh.upgradeTransportOutcome = "late_success";
+        let failure: unknown;
+
+        try {
+            await captureSshTool(ssh).invoke({
+                action: "upgrade",
+                version: "0.54.0",
+                edge_runtime_version: "0.17.1",
+            });
+        } catch (error: unknown) {
+            failure = error;
+        }
+        await new Promise(resolve => setTimeout(resolve, 25));
+
+        expect(failure).toBeInstanceOf(AggregateError);
+        expect((failure as { code?: string }).code).toBe("OUTCOME_UNKNOWN");
+        const diagnostic = formatCliError(failure);
+        const helperPath = ssh.uploads[0]?.remotePath ?? "";
+        expect(diagnostic).toContain("OUTCOME_UNKNOWN");
+        expect(diagnostic).toContain(`helper=${helperPath}`);
+        expect(diagnostic).toContain(`trusted_root=${dirname(helperPath)}/${SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_FILENAME}`);
+        expect(diagnostic).toContain("do not retry blindly");
+        expect(diagnostic.length).toBeLessThan(1_000);
+        expect(ssh.upgradeTransportClient?.terminalCloseEmitted).toBe(true);
+        expect(ssh.upgradeTransportClient?.endCalls).toBe(1);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some(command => command.includes("sudo -n rm -rf --"))).toBe(false);
+    });
+
+    test("post-dispatch stream errors preserve helpers without reflecting transport secrets", async () => {
+        const ssh = new FakeSsh();
+        ssh.upgradeTransportOutcome = "stream_error";
+        let failure: unknown;
+
+        try {
+            await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.54.0" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+
+        expect((failure as { code?: string }).code).toBe("OUTCOME_UNKNOWN");
+        const diagnostic = formatCliError(failure);
+        expect(diagnostic).toContain("client cleanup was suppressed");
+        expect(diagnostic).not.toContain("stream-secret");
+        expect(diagnostic.length).toBeLessThan(1_000);
+        expect(ssh.upgradeTransportClient?.endCalls).toBe(1);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some(command => command.includes("sudo -n rm -rf --"))).toBe(false);
     });
 
     test("component upgrade cleans its exact helper path when SSH execution throws", async () => {
@@ -1040,6 +1149,61 @@ describe("ssh admin tool", () => {
         expect(ssh.commands[1]).toContain(helperDirectory);
         expect(ssh.commands[1]).toContain("rm -rf --");
         expect(ssh.commands[2]).toContain(`rm -rf -- '${helperDirectory}' || sudo -n rm -rf -- '${helperDirectory}'`);
+    });
+
+    test("known helper setup failure still cleans the owned generated path", async () => {
+        const ssh = new FakeSsh();
+        addFakeExecution(ssh, "mkdir -m 700 --", {
+            success: false, stdout: "", stderr: "mkdir returned failure", code: 23,
+        });
+
+        await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.54.0" }))
+            .rejects.toThrow("Failed to prepare remote upgrade helper directory");
+        expect(ssh.uploads).toHaveLength(0);
+        expect(ssh.commands).toHaveLength(2);
+        const helperDirectory = ssh.commands[0]?.match(/mkdir -m 700 -- '([^']+)'/)?.[1] ?? "";
+        expect(ssh.commands[1]).toContain(`rm -rf -- '${helperDirectory}'`);
+    });
+
+    test("unknown helper setup reconciles its path after attempting cleanup", async () => {
+        const ssh = new FakeSsh();
+        ssh.prepareExecOutcomeUnknown = true;
+        let failure: unknown;
+
+        try {
+            await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.54.0" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+
+        const diagnostic = formatCliError(failure);
+        const helperDirectory = ssh.commands[0]?.match(/mkdir -m 700 -- '([^']+)'/)?.[1] ?? "";
+        expect((failure as { code?: string }).code).toBe("OUTCOME_UNKNOWN");
+        expect(diagnostic).toContain("Remote helper setup ended without terminal status");
+        expect(diagnostic).toContain("upgrade command was not dispatched");
+        expect(diagnostic).toContain(`helper=${helperDirectory}/release_assets.sh`);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands[1]).toContain(`rm -rf -- '${helperDirectory}'`);
+    });
+
+    test("unknown helper setup preserves cleanup failure and reconciliation paths", async () => {
+        const ssh = new FakeSsh();
+        ssh.prepareExecOutcomeUnknown = true;
+        ssh.cleanupExecFails = true;
+        let failure: unknown;
+
+        try {
+            await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.54.0" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+
+        const diagnostic = formatCliError(failure);
+        expect((failure as { code?: string }).code).toBe("OUTCOME_UNKNOWN");
+        expect(diagnostic).toContain("helper cleanup did not complete");
+        expect(diagnostic).toContain("Failed to remove remote upgrade helper");
+        expect(diagnostic).toContain("helper=/tmp/.supacloud-release-assets-");
+        expect((failure as AggregateError).errors).toHaveLength(2);
     });
 
     test("failed helper upload still cleans its generated remote path", async () => {
@@ -1089,6 +1253,48 @@ describe("ssh admin tool", () => {
 
         await expect(captureSshTool(ssh).invoke({ action: "upgrade", version: "0.50.27" }))
             .rejects.toThrow("Failed to remove remote upgrade helper");
+    });
+
+    test("successful upgrade preserves its terminal result when helper cleanup is unknown", async () => {
+        const ssh = new FakeSsh();
+        ssh.cleanupExecRejection = {
+            value: new SshCommandOutcomeUnknownError("SSH command timed out after 30000ms; remote outcome is unknown"),
+        };
+        let failure: unknown;
+
+        try {
+            await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.54.0" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+
+        const diagnostic = formatCliError(failure);
+        const helperPath = ssh.uploads[0]?.remotePath ?? "";
+        expect((failure as { code?: string }).code).toBe("OUTCOME_UNKNOWN");
+        expect(diagnostic).toContain("Remote upgrade succeeded, but helper cleanup outcome is unknown");
+        expect(diagnostic).toContain(`helper=${helperPath}`);
+        expect(diagnostic).not.toContain("Remote upgrade transport ended after dispatch");
+    });
+
+    test("failed upgrade preserves its terminal failure when helper cleanup is unknown", async () => {
+        const ssh = new FakeSsh();
+        ssh.upgradeExecFails = true;
+        ssh.cleanupExecRejection = {
+            value: new SshCommandOutcomeUnknownError("SSH command stream failed after dispatch; remote outcome is unknown"),
+        };
+        let failure: unknown;
+
+        try {
+            await captureSshTool(ssh).invoke({ action: "upgrade", version: "0.54.0" });
+        } catch (error: unknown) {
+            failure = error;
+        }
+
+        const diagnostic = formatCliError(failure);
+        expect((failure as { code?: string }).code).toBe("OUTCOME_UNKNOWN");
+        expect(diagnostic).toContain("Remote upgrade failed with a terminal result");
+        expect(diagnostic).toContain("Remote upgrade failed (exit 42): transaction failed");
+        expect(diagnostic).toContain(`helper=${ssh.uploads[0]?.remotePath ?? ""}`);
     });
 
     test("remote and helper cleanup failures preserve both diagnostics", async () => {

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -8,11 +8,12 @@ import { basename, dirname, join } from "node:path";
 import { TextDecoder } from "node:util";
 import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
-import type { SshTransport } from "../transports/ssh";
+import { redactSshOutput, SshCommandOutcomeUnknownError, type SshTransport } from "../transports/ssh";
 import {
     buildUpgradeLockScript,
     executeLocalUpgradeTransfer,
     SUPACLOUD_UPGRADE_LOCK_PATH,
+    UPGRADE_OBSERVATION_TIMEOUT_MS,
 } from "../releases/local-upgrade-transfer";
 import {
     SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_FILENAME,
@@ -31,10 +32,12 @@ const SAFE_HOSTNAME = /^(?=.{1,253}$)(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0
 const SAFE_SYSTEMD_UNIT = /^[a-zA-Z0-9][a-zA-Z0-9_.@:-]{0,127}$/;
 const SAFE_DB_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_-]{0,62}$/;
 const MINIMUM_COMPONENT_UPGRADE_VERSION = "0.50.27";
-// Keep helper verification and cleanup outside the bounded direct transfer budget.
-const DIRECT_UPGRADE_SSH_TIMEOUT_MS = 720_000;
-// Proxy mode can exhaust each transfer once direct-first and once through the proxy.
-const PROXIED_UPGRADE_SSH_TIMEOUT_MS = 1_320_000;
+const DIRECT_BOOTSTRAP_TRANSFER_BUDGET_MS = 12 * 60_000;
+const PROXIED_BOOTSTRAP_TRANSFER_BUDGET_MS = 22 * 60_000;
+const DIRECT_UPGRADE_SSH_TIMEOUT_MS = UPGRADE_OBSERVATION_TIMEOUT_MS
+    + DIRECT_BOOTSTRAP_TRANSFER_BUDGET_MS;
+const PROXIED_UPGRADE_SSH_TIMEOUT_MS = UPGRADE_OBSERVATION_TIMEOUT_MS
+    + PROXIED_BOOTSTRAP_TRANSFER_BUDGET_MS;
 const PLATFORM_PROBE_TIMEOUT_MS = 10_000;
 const PLATFORM_HASH_TIMEOUT_MS = 30_000;
 const WEB_CONSOLE_PROBE_TIMEOUT_MS = 60_000;
@@ -372,14 +375,117 @@ type OfficialUpgradeOutcomeState = {
     executionError: unknown;
     cleanupFailed: boolean;
     cleanupError: unknown;
+    helperPath: string;
+    upgradeExecutionRequested: boolean;
 };
+
+class RemoteUpgradeOutcomeUnknownError extends AggregateError {
+    readonly code = "OUTCOME_UNKNOWN";
+}
+
+function boundedUpgradeError(error: unknown): Error {
+    const message = error instanceof Error ? error.message : String(error);
+    const diagnostic = redactSshOutput(message)
+        .replace(/[\r\n\t]+/g, " ")
+        .trim()
+        .slice(0, 500);
+    return new Error(diagnostic || "Remote operation ended without a diagnostic");
+}
+
+function remoteUpgradeEvidence(helperPath: string): string {
+    const trustedRootPath = join(dirname(helperPath), SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_FILENAME);
+    return `helper=${helperPath} trusted_root=${trustedRootPath}`;
+}
+
+function remoteUpgradeReconciliationFailure(
+    message: string,
+    failures: readonly unknown[],
+    helperPath: string,
+): RemoteUpgradeOutcomeUnknownError {
+    return new RemoteUpgradeOutcomeUnknownError(
+        failures.map(boundedUpgradeError),
+        `${message} Reconcile ${remoteUpgradeEvidence(helperPath)}; do not retry blindly`,
+    );
+}
+
+function remoteUpgradeOutcomeUnknown(
+    transportError: SshCommandOutcomeUnknownError,
+    helperPath: string,
+): RemoteUpgradeOutcomeUnknownError {
+    return remoteUpgradeReconciliationFailure(
+        "OUTCOME_UNKNOWN: Remote upgrade transport ended after dispatch; client cleanup was suppressed "
+            + "because the remote command may still be running. Verify deployed versions before retrying.",
+        [transportError],
+        helperPath,
+    );
+}
 
 function remoteUpgradeFailure(execution: OfficialUpgradeExecution): Error {
     const diagnostic = execution.stderr.trim() || execution.stdout.trim() || "no remote diagnostic";
     return new Error(`Remote upgrade failed (exit ${execution.code}): ${diagnostic.slice(-500)}`);
 }
 
+function remoteHelperSetupOutcomeUnknown(
+    outcome: OfficialUpgradeOutcomeState,
+): RemoteUpgradeOutcomeUnknownError {
+    const cleanupStatus = outcome.cleanupFailed
+        ? "the helper cleanup did not complete"
+        : "the cleanup command completed, but setup may finish later";
+    const failures = outcome.cleanupFailed
+        ? [outcome.executionError, outcome.cleanupError]
+        : [outcome.executionError];
+    return remoteUpgradeReconciliationFailure(
+        `OUTCOME_UNKNOWN: Remote helper setup ended without terminal status; ${cleanupStatus}. `
+            + "The upgrade command was not dispatched.",
+        failures,
+        outcome.helperPath,
+    );
+}
+
+function completedUpgradeCleanupOutcomeUnknown(
+    outcome: OfficialUpgradeOutcomeState,
+): RemoteUpgradeOutcomeUnknownError {
+    if (!outcome.execution) {
+        return remoteUpgradeReconciliationFailure(
+            "OUTCOME_UNKNOWN: Upgrade execution returned no result, and helper cleanup outcome is unknown.",
+            [outcome.cleanupError], outcome.helperPath,
+        );
+    }
+    const message = outcome.execution.success
+        ? "OUTCOME_UNKNOWN: Remote upgrade succeeded, but helper cleanup outcome is unknown."
+        : "OUTCOME_UNKNOWN: Remote upgrade failed with a terminal result, and helper cleanup outcome is unknown.";
+    const failures = outcome.execution.success
+        ? [outcome.cleanupError]
+        : [remoteUpgradeFailure(outcome.execution), outcome.cleanupError];
+    return remoteUpgradeReconciliationFailure(message, failures, outcome.helperPath);
+}
+
+function remoteHelperCleanupOutcomeUnknown(
+    outcome: OfficialUpgradeOutcomeState,
+): RemoteUpgradeOutcomeUnknownError {
+    if (!outcome.upgradeExecutionRequested) {
+        return remoteUpgradeReconciliationFailure(
+            "OUTCOME_UNKNOWN: Remote helper setup failed, and helper cleanup outcome is unknown. "
+                + "The upgrade command was not dispatched.",
+            [outcome.executionError, outcome.cleanupError], outcome.helperPath,
+        );
+    }
+    if (outcome.executionFailed) {
+        return remoteUpgradeReconciliationFailure(
+            "OUTCOME_UNKNOWN: Upgrade execution request failed, and helper cleanup outcome is unknown.",
+            [outcome.executionError, outcome.cleanupError], outcome.helperPath,
+        );
+    }
+    return completedUpgradeCleanupOutcomeUnknown(outcome);
+}
+
 function officialUpgradeOutcome(outcome: OfficialUpgradeOutcomeState): OfficialUpgradeExecution {
+    if (!outcome.upgradeExecutionRequested && outcome.executionError instanceof SshCommandOutcomeUnknownError) {
+        throw remoteHelperSetupOutcomeUnknown(outcome);
+    }
+    if (outcome.cleanupFailed && outcome.cleanupError instanceof SshCommandOutcomeUnknownError) {
+        throw remoteHelperCleanupOutcomeUnknown(outcome);
+    }
     if (outcome.executionFailed && outcome.cleanupFailed) {
         throw new AggregateError(
             [outcome.executionError, outcome.cleanupError],
@@ -408,28 +514,29 @@ async function executeOfficialUpgrade(
     let execution: OfficialUpgradeExecution | undefined;
     let executionFailed = false;
     let executionError: unknown;
-    let helperPrepared = false;
+    let upgradeExecutionRequested = false;
     try {
         await prepareRemoteUpgradeHelperDirectory(ssh, helperPath);
-        helperPrepared = true;
         await ssh.uploadText(helperPath, releaseAssetsScript, 0o600);
         const trustedRootPath = join(dirname(helperPath), SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_FILENAME);
         await ssh.uploadText(trustedRootPath, SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_JSONL, 0o600);
+        upgradeExecutionRequested = true;
         execution = await ssh.exec(command, timeoutMs);
     } catch (error: unknown) {
+        if (upgradeExecutionRequested && error instanceof SshCommandOutcomeUnknownError) {
+            throw remoteUpgradeOutcomeUnknown(error, helperPath);
+        }
         executionFailed = true;
         executionError = error;
     }
 
     let cleanupFailed = false;
     let cleanupError: unknown;
-    if (helperPrepared) {
-        try {
-            await removeRemoteUpgradeHelper(ssh, helperPath);
-        } catch (error: unknown) {
-            cleanupFailed = true;
-            cleanupError = error;
-        }
+    try {
+        await removeRemoteUpgradeHelper(ssh, helperPath);
+    } catch (error: unknown) {
+        cleanupFailed = true;
+        cleanupError = error;
     }
     return officialUpgradeOutcome({
         execution,
@@ -437,6 +544,8 @@ async function executeOfficialUpgrade(
         executionError,
         cleanupFailed,
         cleanupError,
+        helperPath,
+        upgradeExecutionRequested,
     });
 }
 

--- a/packages/admin/src/shared/transports/ssh.test.ts
+++ b/packages/admin/src/shared/transports/ssh.test.ts
@@ -5,7 +5,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { getAuditLog, redactSshOutput, SshTransport } from "./ssh";
+import {
+    getAuditLog,
+    redactSshOutput,
+    SshCommandOutcomeUnknownError,
+    SshTransport,
+} from "./ssh";
 
 const TEST_HOST_KEY = Buffer.from("supacloud-test-host-key");
 const TEST_HOST_FINGERPRINT = `SHA256:${createHash("sha256").update(TEST_HOST_KEY).digest("base64").replace(/=+$/, "")}`;
@@ -16,6 +21,11 @@ class FakeSshClient extends EventEmitter {
     stdout = Buffer.from("ok\n");
     stderrOutput = Buffer.alloc(0);
     stallCommand = false;
+    closeWithoutExitStatus = false;
+    completionDelayMs = 0;
+    synchronousExecError: Error | undefined;
+    streamErrorAfterDispatch: Error | undefined;
+    terminalCloseEmitted = false;
     endCalls = 0;
     activeChannels = 0;
     maxConcurrentChannels = Number.POSITIVE_INFINITY;
@@ -29,6 +39,7 @@ class FakeSshClient extends EventEmitter {
     }
 
     exec(_command: string, callback: (error: Error | undefined, stream: EventEmitter & { stderr: EventEmitter }) => void): void {
+        if (this.synchronousExecError) throw this.synchronousExecError;
         if (this.activeChannels >= this.maxConcurrentChannels) {
             callback(new Error("open failed: administratively prohibited: open failed"), undefined as never);
             return;
@@ -37,11 +48,19 @@ class FakeSshClient extends EventEmitter {
         stream.stderr = new EventEmitter();
         callback(undefined, stream);
         if (this.stallCommand) return;
-        queueMicrotask(() => {
+        const complete = () => {
+            if (this.streamErrorAfterDispatch) {
+                stream.emit("error", this.streamErrorAfterDispatch);
+                return;
+            }
             if (this.stdout.length > 0) stream.emit("data", this.stdout);
             if (this.stderrOutput.length > 0) stream.stderr.emit("data", this.stderrOutput);
-            stream.emit("close", 0);
-        });
+            this.terminalCloseEmitted = true;
+            if (this.closeWithoutExitStatus) stream.emit("close");
+            else stream.emit("close", 0);
+        };
+        if (this.completionDelayMs > 0) setTimeout(complete, this.completionDelayMs);
+        else queueMicrotask(complete);
     }
 
     sftp(callback: (error: Error | undefined, sftp: FakeSftpClient) => void): void {
@@ -228,15 +247,105 @@ describe("SshTransport audit safety", () => {
         }, { clientFactory: () => clients[clientIndex++] as never });
 
         try {
-            await expect(transport.exec("long-running-upgrade", 10)).rejects.toThrow(
-                "SSH command timed out after 10ms",
-            );
+            const timedOut = transport.exec("long-running-upgrade", 10);
+            await expect(timedOut).rejects.toBeInstanceOf(SshCommandOutcomeUnknownError);
+            await expect(timedOut).rejects.toMatchObject({
+                code: "OUTCOME_UNKNOWN",
+                message: "SSH command timed out after 10ms; remote outcome is unknown",
+            });
             expect(stalledClient.endCalls).toBe(1);
 
             const cleanup = await transport.exec("remove-upgrade-helper");
             expect(cleanup.success).toBe(true);
             expect(clientIndex).toBe(2);
             expect(cleanupClient.connectOptions?.host).toBe("server.example.com");
+        } finally {
+            transport.close();
+        }
+    });
+
+    test("discards a connection when exec throws synchronously before dispatch", async () => {
+        const disconnectedClient = new FakeSshClient();
+        disconnectedClient.synchronousExecError = new Error("Not connected");
+        const cleanupClient = new FakeSshClient();
+        const clients = [disconnectedClient, cleanupClient];
+        let clientIndex = 0;
+        const transport = new SshTransport({
+            host: "server.example.com",
+            port: 22,
+            username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => clients[clientIndex++] as never });
+
+        try {
+            await expect(transport.exec("long-running-upgrade", 10)).rejects.toThrow("Not connected");
+            expect(disconnectedClient.endCalls).toBe(1);
+            expect((await transport.exec("remove-upgrade-helper")).success).toBe(true);
+            expect(clientIndex).toBe(2);
+        } finally {
+            transport.close();
+        }
+    });
+
+    test("keeps timeout unknown when the remote stream closes successfully later", async () => {
+        const client = new FakeSshClient();
+        client.completionDelayMs = 20;
+        const transport = new SshTransport({
+            host: "server.example.com", port: 22, username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => client as never });
+
+        try {
+            await expect(transport.exec("long-running-upgrade", 5)).rejects.toMatchObject({
+                code: "OUTCOME_UNKNOWN",
+            });
+            await new Promise(resolve => setTimeout(resolve, 25));
+            expect(client.terminalCloseEmitted).toBe(true);
+            expect(client.endCalls).toBe(1);
+        } finally {
+            transport.close();
+        }
+    });
+
+    test("keeps post-dispatch stream errors unknown without reflecting their message", async () => {
+        const client = new FakeSshClient();
+        client.streamErrorAfterDispatch = new Error("TOKEN=stream-secret");
+        const transport = new SshTransport({
+            host: "server.example.com", port: 22, username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => client as never });
+
+        try {
+            let failure: unknown;
+            try {
+                await transport.exec("long-running-upgrade");
+            } catch (error: unknown) {
+                failure = error;
+            }
+            expect(failure).toBeInstanceOf(SshCommandOutcomeUnknownError);
+            expect(String(failure)).not.toContain("stream-secret");
+            expect(client.endCalls).toBe(1);
+        } finally {
+            transport.close();
+        }
+    });
+
+    test("marks a dispatched command without terminal status as outcome unknown", async () => {
+        const client = new FakeSshClient();
+        client.closeWithoutExitStatus = true;
+        const transport = new SshTransport({
+            host: "server.example.com",
+            port: 22,
+            username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => client as never });
+
+        try {
+            await expect(transport.exec("long-running-upgrade")).rejects.toMatchObject({
+                code: "OUTCOME_UNKNOWN",
+                message: "SSH command stream closed without a terminal status; remote outcome is unknown",
+            });
+            expect(client.endCalls).toBe(1);
         } finally {
             transport.close();
         }

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -40,6 +40,15 @@ export interface SshResult {
     stderrTruncated?: boolean;
 }
 
+export class SshCommandOutcomeUnknownError extends Error {
+    readonly code = "OUTCOME_UNKNOWN";
+
+    constructor(message: string) {
+        super(message);
+        this.name = "SshCommandOutcomeUnknownError";
+    }
+}
+
 export interface SshTransportOptions {
     clientFactory?: () => Client;
 }
@@ -293,39 +302,56 @@ export class SshTransport {
 
                 const timer = setTimeout(() => {
                     connectionReusable = false;
-                    reject(new Error(`SSH command timed out after ${timeoutMs}ms`));
+                    reject(new SshCommandOutcomeUnknownError(
+                        `SSH command timed out after ${timeoutMs}ms; remote outcome is unknown`,
+                    ));
                 }, timeoutMs);
 
-                conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
-                    if (err) {
-                        clearTimeout(timer);
-                        connectionReusable = false;
-                        return reject(err);
-                    }
-                    stream
-                        .on("close", (code: number) => {
-                            clearTimeout(timer);
-                            resolve({
-                                success: code === 0,
-                                stdout: stdout.finalize(),
-                                stderr: stderr.finalize(),
-                                code,
-                                stdoutTruncated: stdout.truncated,
-                                stderrTruncated: stderr.truncated,
-                            });
-                        })
-                        .on("error", (streamError: Error) => {
+                try {
+                    conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
+                        if (err) {
                             clearTimeout(timer);
                             connectionReusable = false;
-                            reject(streamError);
-                        })
-                        .on("data", (data: Buffer) => {
-                            stdout.append(data);
-                        })
-                        .stderr.on("data", (data: Buffer) => {
-                            stderr.append(data);
-                        });
-                });
+                            return reject(err);
+                        }
+                        stream
+                            .on("close", (code?: number | null) => {
+                                clearTimeout(timer);
+                                if (code === undefined) {
+                                    connectionReusable = false;
+                                    reject(new SshCommandOutcomeUnknownError(
+                                        "SSH command stream closed without a terminal status; remote outcome is unknown",
+                                    ));
+                                    return;
+                                }
+                                resolve({
+                                    success: code === 0,
+                                    stdout: stdout.finalize(),
+                                    stderr: stderr.finalize(),
+                                    code: code ?? 128,
+                                    stdoutTruncated: stdout.truncated,
+                                    stderrTruncated: stderr.truncated,
+                                });
+                            })
+                            .on("error", () => {
+                                clearTimeout(timer);
+                                connectionReusable = false;
+                                reject(new SshCommandOutcomeUnknownError(
+                                    "SSH command stream failed after dispatch; remote outcome is unknown",
+                                ));
+                            })
+                            .on("data", (data: Buffer) => {
+                                stdout.append(data);
+                            })
+                            .stderr.on("data", (data: Buffer) => {
+                                stderr.append(data);
+                            });
+                    });
+                } catch (error: unknown) {
+                    clearTimeout(timer);
+                    connectionReusable = false;
+                    reject(error);
+                }
             });
         } finally {
             if (connectionReusable) this.pool.release(conn);


### PR DESCRIPTION
## Summary

- derive the remote SSH deadline from the canonical 30-minute observation window plus bounded direct or proxy bootstrap transfers
- classify timeouts and post-dispatch stream loss as OUTCOME_UNKNOWN, discard the connection, and avoid client cleanup while the remote upgrade may still be running
- preserve known upgrade success or failure when helper cleanup is uncertain, with bounded redacted reconciliation evidence
- clean generated helper paths on known setup or upload failures and document the operator reconciliation flow

## Verification

- bun test packages/admin/src/shared/tools/ssh-tools.test.ts packages/admin/src/shared/transports/ssh.test.ts (92 pass, 0 fail, 601 assertions)
- bun test packages/admin/src (342 pass, 26 platform skips, 0 fail, 1828 assertions)
- bun run --cwd packages/admin typecheck
- bun run --cwd packages/admin build
- git diff --check
- independent review: P0/P1/P2 = 0/0/0
- clean-code-guard: clean