### PR TITLE
test(cli): lock origin and redirect security contracts

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -101,7 +101,8 @@ only `SUPACLOUD_API_URL` + `SUPACLOUD_API_TOKEN`. An application profile using
 `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` can be auto-linked for `status`,
 but its service-role key is never substituted for a Management token and cannot
 enable Management-backed tools. Both URL types must be canonical HTTPS origins;
-HTTP is accepted only for literal loopback development origins. Use
+omit explicit default ports such as `:443`. HTTP is accepted only for literal
+loopback development origins, with the default `:80` likewise omitted. Use
 `SUPACLOUD_PROJECT_REF` when it cannot be inferred from a managed
 `<ref>.api.*` application hostname.
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2078,6 +2078,10 @@ describe("supacloud-cli process contract", () => {
         "https://management.example.test/%2e",
         "https://management.example.test?token=private-query",
         "https://management.example.test#private-fragment",
+        "https://management.example.test:443",
+        "https://management.example.test:443/",
+        "http://127.0.0.1:80",
+        "http://127.0.0.1:80/",
     ])("status rejects unsafe Management origin %s without reflection", async (managementUrl) => {
         const result = await runProjectCli(["status"], {
             SUPACLOUD_API_URL: managementUrl,
@@ -2090,6 +2094,8 @@ describe("supacloud-cli process contract", () => {
         expect(status.credentialScope).toBe("management");
         expect(status.apiUrl).toBeNull();
         expect(status.checks.configuration.missing).toEqual(["apiUrl"]);
+        expect(status.checks.connectivity.ok).toBeNull();
+        expect(status.checks.authentication.ok).toBeNull();
         expect(result.stdout + result.stderr).not.toContain("management-private-token");
         expect(result.stdout + result.stderr).not.toContain("private-password");
         expect(result.stdout + result.stderr).not.toContain("private-path");
@@ -2102,6 +2108,10 @@ describe("supacloud-cli process contract", () => {
         "https://api.example.test/untrusted-path",
         "https://api.example.test/%2e",
         "https://user:password@api.example.test",
+        "https://api.example.test:443",
+        "https://api.example.test:443/",
+        "http://127.0.0.1:80",
+        "http://127.0.0.1:80/",
     ])("status rejects unsafe application origin %s before sending credentials", async (supabaseUrl) => {
         const result = await runProjectCli(["status"], {
             SUPABASE_URL: supabaseUrl,

--- a/packages/cli/src/shared/context.test.ts
+++ b/packages/cli/src/shared/context.test.ts
@@ -131,6 +131,33 @@ describe("resolveSupaCloudContext", () => {
         expect(context.credentialScope).toBe("management");
     });
 
+    test.each([
+        "https://management.example.com:443",
+        "https://management.example.com:443/",
+        "http://127.0.0.1:80",
+        "http://[::1]:80/",
+    ])("rejects non-canonical explicit default port %s", (managementUrl) => {
+        const context = resolveSupaCloudContext({
+            SUPACLOUD_API_URL: managementUrl,
+            SUPACLOUD_API_TOKEN: "management-token",
+            SUPACLOUD_PROJECT_REF: "project-ref",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.apiUrl).toBe("");
+        expect(context.credentialScope).toBe("management");
+    });
+
+    test("rejects an explicit default port on an application origin", () => {
+        const context = resolveSupaCloudContext({
+            SUPABASE_URL: "https://abc123.api.example.com:443",
+            SUPABASE_SERVICE_ROLE_KEY: "service-role",
+        }, "/tmp/no-such-supacloud-context");
+
+        expect(context.inferredSupabaseUrl).toBe("");
+        expect(context.host).toBe("");
+        expect(context.credentialScope).toBe("project_application");
+    });
+
     test("allows HTTP only for literal loopback Management origins", () => {
         const context = resolveSupaCloudContext({
             SUPACLOUD_API_URL: "http://127.0.0.1:9090/",

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -71,6 +71,10 @@ const redirectedRequests = [
         "JSON POST",
         (transport: HttpTransport) => transport.post("/resource", { secret: "request-secret" }),
     ],
+    [
+        "release POST",
+        (transport: HttpTransport) => transport.postReleaseMutation("/resource", { secret: "request-secret" }),
+    ],
     ["multipart POST", (transport: HttpTransport) => {
         const form = new FormData();
         form.set("secret", "request-secret");
@@ -78,6 +82,7 @@ const redirectedRequests = [
     }],
     ["PATCH", (transport: HttpTransport) => transport.patch("/resource", { secret: "request-secret" })],
     ["PUT", (transport: HttpTransport) => transport.put("/resource", { secret: "request-secret" })],
+    ["DELETE", (transport: HttpTransport) => transport.delete("/resource")],
 ] as const;
 
 const redirectCases = redirectedRequests.flatMap(([requestName, sendRequest]) =>
@@ -183,6 +188,7 @@ describe("HttpTransport retry policy", () => {
     test.each(redirectCases)(
         "rejects %s redirects without reaching the target",
         async (_caseName, sendRequest, redirectStatus, redirectScope) => {
+            let sourceRequests = 0;
             const targetRequests: string[] = [];
             const crossOriginTarget = Bun.serve({
                 hostname: "127.0.0.1",
@@ -197,6 +203,7 @@ describe("HttpTransport retry policy", () => {
                 hostname: "127.0.0.1",
                 port: 0,
                 fetch(request) {
+                    sourceRequests += 1;
                     const pathname = new URL(request.url).pathname;
                     if (pathname === "/captured") {
                         targetRequests.push(pathname);
@@ -218,6 +225,7 @@ describe("HttpTransport retry policy", () => {
 
             expect(response.transportError).toBe(true);
             expect(response.data).toEqual({ error: "Network Error", code: "NETWORK_ERROR" });
+            expect(sourceRequests).toBe(1);
             expect(targetRequests).toEqual([]);
             expect(JSON.stringify(response)).not.toContain("request-secret");
             expect(JSON.stringify(response)).not.toContain("management-token");


### PR DESCRIPTION
## Summary

- document the fail-closed canonical-origin rule for explicit HTTPS :443 and literal-loopback HTTP :80
- lock the resolver and real CLI status contract to exit non-zero before connectivity/authentication and without reflecting credentials
- extend the shared redirect matrix to release POST and DELETE, and require exactly one source request plus zero same-origin/cross-origin target requests for 302/307

This is a test-and-documentation follow-up to #855; it does not change runtime behavior.

## Verification

- bun test packages/cli: 572 pass, 0 fail, 1769 assertions
- bun run typecheck: pass
- bun run build: pass
- git diff --check: pass
- independent clean-code-guard review: PASS, no P0-P3 findings
