### PR TITLE
fix(cli): harden project read responses

### DIFF
--- a/packages/admin/src/project-read-process.test.ts
+++ b/packages/admin/src/project-read-process.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const ADMIN_ENTRYPOINT = join(PACKAGE_ROOT, "src/index.ts");
+const CONTEXT_KEYS = new Set([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPACLOUD_API_URL",
+    "SUPACLOUD_MANAGEMENT_API_URL",
+    "MANAGEMENT_API_URL",
+    "SUPACLOUD_API_TOKEN",
+    "SUPACLOUD_PROJECT_REF",
+    "X_PROJECT_REF",
+    "SUPACLOUD_ENV",
+]);
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const PROJECT_SUMMARY = {
+    id: "11111111-1111-4111-8111-111111111111",
+    ref: PROJECT_REF,
+    organization_id: "22222222-2222-4222-8222-222222222222",
+    organization_slug: "example-organization",
+    name: "Example project",
+    region: "local",
+    created_at: "2026-08-12T00:00:00.000Z",
+    status: "ACTIVE_HEALTHY",
+};
+const PROJECT_DETAILS = {
+    ...PROJECT_SUMMARY,
+    database: {
+        host: "db.example.test",
+        version: "17.5",
+        postgres_engine: "17",
+        release_channel: "stable",
+    },
+    api: { url: "https://api.example.test" },
+    studio: { url: "https://studio.example.test" },
+};
+
+const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
+
+afterEach(() => {
+    for (const server of servers.splice(0)) server.stop(true);
+});
+function cleanEnvironment(overrides: Record<string, string>): Record<string, string> {
+    const environment: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+        if (value !== undefined && !CONTEXT_KEYS.has(key)) environment[key] = value;
+    }
+    return { ...environment, ...overrides };
+}
+
+async function runAdminProjectRead(
+    args: string[],
+    response: Response,
+): Promise<{ exitCode: number; output: string }> {
+    const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: () => response.clone(),
+    });
+    servers.push(server);
+    const apiToken = "admin-process-api-token-sentinel";
+    const processHandle = Bun.spawn([process.execPath, ADMIN_ENTRYPOINT, ...args], {
+        cwd: PACKAGE_ROOT,
+        env: cleanEnvironment({
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: apiToken,
+        }),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        processHandle.exited,
+        new Response(processHandle.stdout).text(),
+        new Response(processHandle.stderr).text(),
+    ]);
+    const output = stdout + stderr;
+    expect(output).not.toContain(apiToken);
+    return { exitCode, output };
+}
+
+describe("supacloud-admin project read process contract", () => {
+    test("prints only the fixed list and get projections for current Management responses", async () => {
+        const remoteSecret = "admin-known-private-sentinel";
+        const listRead = await runAdminProjectRead(
+            ["project", "list"],
+            Response.json([PROJECT_SUMMARY]),
+        );
+        const getRead = await runAdminProjectRead(
+            ["project", "get", "--ref", PROJECT_REF],
+            Response.json({
+                ...PROJECT_DETAILS,
+                config: { private_runtime_value: remoteSecret },
+                anon_key: remoteSecret,
+                services: [{ token: remoteSecret }],
+            }),
+        );
+
+        expect(listRead.exitCode).toBe(0);
+        expect(JSON.parse(listRead.output)).toEqual([PROJECT_SUMMARY]);
+        expect(getRead.exitCode).toBe(0);
+        expect(JSON.parse(getRead.output)).toEqual(PROJECT_DETAILS);
+        expect(listRead.output + getRead.output).not.toContain(remoteSecret);
+    });
+
+    test.each([
+        [
+            "HTTP failure",
+            ["project", "list"],
+            Response.json({ error: "admin-http-private-sentinel" }, { status: 404 }),
+            "Project list request failed (404)",
+            "admin-http-private-sentinel",
+        ],
+        [
+            "unknown list field",
+            ["project", "list"],
+            Response.json([{ ...PROJECT_SUMMARY, service_role_key: "admin-list-private-sentinel" }]),
+            "Invalid project list response",
+            "admin-list-private-sentinel",
+        ],
+        [
+            "nested database credential",
+            ["project", "get", "--ref", PROJECT_REF],
+            Response.json({
+                ...PROJECT_DETAILS,
+                database: { ...PROJECT_DETAILS.database, password: "admin-database-private-sentinel" },
+            }),
+            "Invalid project response",
+            "admin-database-private-sentinel",
+        ],
+        [
+            "oversized known field",
+            ["project", "get", "--ref", PROJECT_REF],
+            Response.json({
+                ...PROJECT_DETAILS,
+                config: { private_value: "admin-oversized-private-sentinel".repeat(50_000) },
+            }),
+            "Invalid project response",
+            "admin-oversized-private-sentinel",
+        ],
+    ] as const)("exits non-zero for %s without reflecting the response", async (
+        _label,
+        args,
+        response,
+        expectedMessage,
+        sentinel,
+    ) => {
+        const execution = await runAdminProjectRead([...args], response);
+
+        expect(execution.exitCode).toBe(1);
+        expect(execution.output).toContain(expectedMessage);
+        expect(execution.output).not.toContain(sentinel);
+    });
+});

--- a/packages/admin/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.test.ts
@@ -14,7 +14,7 @@ import {
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { lstat, open, realpath, unlink } from "node:fs/promises";
-import { registerAdminProjectCliTools } from "./project-cli-tools";
+import { registerAdminProjectCliTools, registerUserProjectCliTools } from "./project-cli-tools";
 import { schemaEnumValues } from "../schema";
 import type { ToolSchema } from "../schema";
 import type { ProjectEnvFileOperations } from "./project-create-env";
@@ -165,6 +165,125 @@ function captureAdminProjectTool(
 ): ProjectCallback {
     return captureAdminProjectRegistration(http, options).callback;
 }
+
+function captureUserProjectTool(http: Record<string, unknown>, projectRef: string): ProjectCallback {
+    let projectCallback: ProjectCallback | undefined;
+    registerUserProjectCliTools({
+        tool(name: string, _description: string, _schema: ToolSchema, callback: ProjectCallback) {
+            if (name === "project") projectCallback = callback;
+        },
+    }, http as any, { projectRef });
+    if (!projectCallback) throw new Error("user project tool was not registered");
+    return projectCallback;
+}
+
+describe("admin project reads", () => {
+    test("wires Admin and user reads through bounded credential-safe projections", async () => {
+        const remoteSecret = "wired-project-private-sentinel";
+        const summary = {
+            id: "11111111-1111-4111-8111-111111111111",
+            ref: CREATE_PROJECT_REF,
+            organization_id: "22222222-2222-4222-8222-222222222222",
+            organization_slug: "example-organization",
+            name: "Example project",
+            region: "local",
+            created_at: "2026-08-12T00:00:00.000Z",
+            status: "ACTIVE_HEALTHY",
+        };
+        const requests: Array<{ path: string; maxResponseBytes: number | undefined }> = [];
+        const http = {
+            get: async (path: string, options?: { maxResponseBytes?: number }) => {
+                requests.push({ path, maxResponseBytes: options?.maxResponseBytes });
+                return path === "/v1/projects"
+                    ? { ok: true, status: 200, data: [summary] }
+                    : {
+                        ok: true,
+                        status: 200,
+                        data: {
+                            ...summary,
+                            database: {
+                                host: "db.example.test",
+                                version: "17.5",
+                                postgres_engine: "17",
+                                release_channel: "stable",
+                            },
+                            api: { url: "https://api.example.test" },
+                            studio: { url: "https://studio.example.test" },
+                            config: { private_runtime_value: remoteSecret },
+                            anon_key: remoteSecret,
+                            services: [{ token: remoteSecret }],
+                        },
+                    };
+            },
+        };
+        const projectCallback = captureAdminProjectTool(http);
+        const userProjectCallback = captureUserProjectTool(http, CREATE_PROJECT_REF);
+
+        const listResponse = await projectCallback({ action: "list" });
+        const getResponse = await projectCallback({ action: "get", ref: CREATE_PROJECT_REF });
+        const userGetResponse = await userProjectCallback({ action: "get" });
+
+        expect(JSON.parse(listResponse.content[0].text)).toEqual([summary]);
+        expect(JSON.parse(getResponse.content[0].text)).toEqual({
+            ...summary,
+            database: {
+                host: "db.example.test",
+                version: "17.5",
+                postgres_engine: "17",
+                release_channel: "stable",
+            },
+            api: { url: "https://api.example.test" },
+            studio: { url: "https://studio.example.test" },
+        });
+        expect(userGetResponse.content[0].text).toBe(getResponse.content[0].text);
+        expect(requests).toEqual([
+            { path: "/v1/projects", maxResponseBytes: 1_048_576 },
+            { path: `/v1/projects/${CREATE_PROJECT_REF}`, maxResponseBytes: 1_048_576 },
+            { path: `/v1/projects/${CREATE_PROJECT_REF}`, maxResponseBytes: 1_048_576 },
+        ]);
+        expect(
+            listResponse.content[0].text + getResponse.content[0].text + userGetResponse.content[0].text,
+        ).not.toContain(remoteSecret);
+    });
+
+    test("marks malformed Admin and user reads as tool errors without reflection", async () => {
+        const remoteSecret = "invalid-wired-project-sentinel";
+        const http = {
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    id: "11111111-1111-4111-8111-111111111111",
+                    ref: CREATE_PROJECT_REF,
+                    organization_id: "22222222-2222-4222-8222-222222222222",
+                    organization_slug: "example-organization",
+                    name: "Example project",
+                    region: "local",
+                    created_at: "2026-08-12T00:00:00.000Z",
+                    status: "ACTIVE_HEALTHY",
+                    database: {
+                        host: "db.example.test",
+                        version: "17.5",
+                        postgres_engine: "17",
+                        release_channel: "stable",
+                    },
+                    credentials: { service_role_key: remoteSecret },
+                },
+            }),
+        };
+        const adminResponse = await captureAdminProjectTool(http)({
+            action: "get",
+            ref: CREATE_PROJECT_REF,
+        });
+        const userResponse = await captureUserProjectTool(http, CREATE_PROJECT_REF)({ action: "get" });
+
+        for (const response of [adminResponse, userResponse]) {
+            expect(response.isError).toBe(true);
+            expect(response.content[0].text).toBe("❌ Invalid project response");
+            expect(response.content[0].text).not.toContain(remoteSecret);
+        }
+    });
+});
 
 describe("admin project create", () => {
     test("declares only test and production for local credential profiles", () => {

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -17,6 +17,12 @@ import {
     type ProjectEnvFileOperations,
     type PreparedProjectEnvFile,
 } from "./project-create-env";
+import {
+    PROJECT_READ_RESPONSE_MAX_BYTES,
+    projectGetRead,
+    projectListRead,
+    type ProjectReadResult,
+} from "./project-read-projection";
 
 type ToolServer = {
     tool: (
@@ -80,6 +86,11 @@ type ProjectToolResponse = {
 
 function projectToolResponse(text: string): ProjectToolResponse {
     return { content: [{ type: "text", text }] };
+}
+
+function projectReadResponse(readResult: ProjectReadResult): ProjectToolResponse {
+    const response = projectToolResponse(readResult.text);
+    return readResult.isError ? { ...response, isError: true } : response;
 }
 
 function failedProjectServiceResponse(message: string): ProjectToolResponse {
@@ -505,8 +516,12 @@ export function registerUserProjectCliTools(
 
             switch (action) {
                 case "get":
-                    text = ok(await http.get(`/v1/projects/${resolvedRef}`));
-                    break;
+                    return projectReadResponse(projectGetRead(
+                        await http.get(`/v1/projects/${resolvedRef}`, {
+                            maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                        }),
+                        resolvedRef,
+                    ));
                 case "health":
                     text = ok(await http.get(`/v1/projects/${resolvedRef}/health`));
                     break;
@@ -595,8 +610,9 @@ export function registerAdminProjectCliTools(
 
             switch (action) {
                 case "list":
-                    text = ok(await http.get("/v1/projects"));
-                    break;
+                    return projectReadResponse(projectListRead(await http.get("/v1/projects", {
+                        maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                    })));
                 case "create": {
                     if (!name) throw new Error("'name' is required for create");
                     const boundApiOrigin = expectedProjectApiOrigin(domain, api_domain);
@@ -639,9 +655,15 @@ export function registerAdminProjectCliTools(
                         fileOperations,
                     );
                 }
-                case "get":
-                    text = ok(await http.get(`/v1/projects/${resolveRef(ref)}`));
-                    break;
+                case "get": {
+                    const resolvedRef = resolveRef(ref);
+                    return projectReadResponse(projectGetRead(
+                        await http.get(`/v1/projects/${resolvedRef}`, {
+                            maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                        }),
+                        resolvedRef,
+                    ));
+                }
                 case "delete": {
                     const resolvedRef = resolveRef(ref);
                     text = simple(await http.delete(`/v1/projects/${resolvedRef}`), `Project ${resolvedRef} deleted`);

--- a/packages/admin/src/shared/tools/project-read-projection.ts
+++ b/packages/admin/src/shared/tools/project-read-projection.ts
@@ -1,0 +1,1 @@
+export * from "../../../../cli/src/shared/tools/project-read-projection";

--- a/packages/admin/src/shared/transports/http.test.ts
+++ b/packages/admin/src/shared/transports/http.test.ts
@@ -13,6 +13,7 @@ let scheduledTimers: Array<{
     args: unknown[];
 }> = [];
 let nextTimerId = 0;
+const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
 
 beforeEach(() => {
     clearedTimerIds = [];
@@ -30,6 +31,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    for (const server of servers.splice(0)) server.stop(true);
     globalThis.fetch = originalFetch;
     globalThis.setTimeout = originalSetTimeout;
     globalThis.clearTimeout = originalClearTimeout;
@@ -45,6 +47,27 @@ function retryableNetworkError(kind: "AbortError" | "ECONNREFUSED" | "ECONNRESET
     else Object.assign(error, { code: kind });
     return error;
 }
+
+const redirectedRequests = [
+    ["GET", (transport: HttpTransport) => transport.get("/resource")],
+    ["JSON POST", (transport: HttpTransport) => transport.post("/resource", { secret: "request-secret" })],
+    ["multipart POST", (transport: HttpTransport) => {
+        const form = new FormData();
+        form.set("secret", "request-secret");
+        return transport.postMultipart("/resource", form);
+    }],
+    ["PATCH", (transport: HttpTransport) => transport.patch("/resource", { secret: "request-secret" })],
+    ["PUT", (transport: HttpTransport) => transport.put("/resource", { secret: "request-secret" })],
+    ["DELETE", (transport: HttpTransport) => transport.delete("/resource")],
+] as const;
+
+const redirectCases = redirectedRequests.flatMap(([requestName, sendRequest]) =>
+    ([302, 307] as const).flatMap((redirectStatus) =>
+        (["same-origin", "cross-origin"] as const).map((redirectScope) =>
+            [`${requestName} ${redirectStatus} ${redirectScope}`, sendRequest, redirectStatus, redirectScope] as const
+        )
+    )
+);
 
 describe("HttpTransport retry policy", () => {
     test("retries GET after a 5xx response without waiting for backoff", async () => {
@@ -136,6 +159,53 @@ describe("HttpTransport retry policy", () => {
         expect(clearedTimerIds).toHaveLength(1);
     });
 
+    test.each(redirectCases)(
+        "rejects %s redirects without reaching the target",
+        async (_caseName, sendRequest, redirectStatus, redirectScope) => {
+            let sourceRequests = 0;
+            const targetRequests: string[] = [];
+            const crossOriginTarget = Bun.serve({
+                hostname: "127.0.0.1",
+                port: 0,
+                fetch(request) {
+                    targetRequests.push(new URL(request.url).pathname);
+                    return Response.json({ ok: true });
+                },
+            });
+            servers.push(crossOriginTarget);
+            const source = Bun.serve({
+                hostname: "127.0.0.1",
+                port: 0,
+                fetch(request) {
+                    sourceRequests += 1;
+                    const pathname = new URL(request.url).pathname;
+                    if (pathname === "/captured") {
+                        targetRequests.push(pathname);
+                        return Response.json({ ok: true });
+                    }
+                    const targetOrigin = redirectScope === "same-origin"
+                        ? new URL(request.url).origin
+                        : `http://127.0.0.1:${crossOriginTarget.port}`;
+                    return Response.redirect(`${targetOrigin}/captured`, redirectStatus);
+                },
+            });
+            servers.push(source);
+            const transport = new HttpTransport({
+                baseUrl: `http://127.0.0.1:${source.port}`,
+                token: "management-token",
+            });
+
+            const response = await sendRequest(transport);
+
+            expect(response.transportError).toBe(true);
+            expect(response.data).toEqual({ error: "Network Error", code: "NETWORK_ERROR" });
+            expect(sourceRequests).toBe(1);
+            expect(targetRequests).toEqual([]);
+            expect(JSON.stringify(response)).not.toContain("request-secret");
+            expect(JSON.stringify(response)).not.toContain("management-token");
+        },
+    );
+
     test("uses a bounded operation-specific timeout for one POST", async () => {
         globalThis.fetch = (async () => Response.json({ ok: true })) as unknown as typeof fetch;
 
@@ -189,6 +259,43 @@ describe("HttpTransport retry policy", () => {
 
         await expect(createTransport().post("/resource", {}, { timeoutMs })).rejects.toThrow(
             "HTTP request timeout must be between",
+        );
+        expect(fetchCalls).toBe(0);
+    });
+
+    test("bounds selected GET response bodies before JSON projection", async () => {
+        const remoteSecret = "oversized-get-response-sentinel";
+        globalThis.fetch = (async () => new Response(JSON.stringify({
+            config: { private_value: remoteSecret.repeat(100) },
+        }), { headers: { "Content-Type": "application/json" } })) as unknown as typeof fetch;
+
+        const response = await createTransport().get("/v1/projects/project-ref", {
+            maxResponseBytes: 128,
+        });
+
+        expect(response).toEqual({ ok: true, status: 200, data: null });
+        expect(JSON.stringify(response)).not.toContain(remoteSecret);
+    });
+
+    test("parses a selected GET response within its byte limit", async () => {
+        globalThis.fetch = (async () => Response.json({ ref: "project-ref" })) as unknown as typeof fetch;
+
+        const response = await createTransport().get("/v1/projects/project-ref", {
+            maxResponseBytes: 1_024,
+        });
+
+        expect(response).toEqual({ ok: true, status: 200, data: { ref: "project-ref" } });
+    });
+
+    test.each([0, -1, 1.5])("rejects invalid GET response limit %d before dispatch", async maxResponseBytes => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls++;
+            return Response.json({});
+        }) as unknown as typeof fetch;
+
+        await expect(createTransport().get("/v1/projects", { maxResponseBytes })).rejects.toThrow(
+            "HTTP response limit must be a positive safe integer",
         );
         expect(fetchCalls).toBe(0);
     });

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -21,6 +21,10 @@ interface HttpPostOptions {
     timeoutMs: number;
 }
 
+export interface HttpGetOptions {
+    maxResponseBytes?: number;
+}
+
 const DEFAULT_TIMEOUT = 30_000;
 const MAX_POST_TIMEOUT_MS = 35 * 60_000;
 const MAX_RETRIES = 2;
@@ -60,6 +64,63 @@ function validatedPostTimeout(options?: HttpPostOptions): number {
     return timeoutMs;
 }
 
+function validatedGetResponseLimit(options: HttpGetOptions): number | undefined {
+    const maxBytes = options.maxResponseBytes;
+    if (maxBytes === undefined) return undefined;
+    if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+        throw new RangeError("HTTP response limit must be a positive safe integer");
+    }
+    return maxBytes;
+}
+
+function responseExceedsDeclaredLimit(response: Response, maxBytes: number): boolean {
+    const contentLength = response.headers.get("content-length");
+    return contentLength !== null && /^\d+$/u.test(contentLength) && Number(contentLength) > maxBytes;
+}
+
+function joinedResponseBytes(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+    const responseBytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+        responseBytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return responseBytes;
+}
+
+async function boundedResponseBytes(response: Response, maxBytes: number): Promise<Uint8Array | null> {
+    if (responseExceedsDeclaredLimit(response, maxBytes)) {
+        void response.body?.cancel().catch(() => undefined);
+        return null;
+    }
+    if (!response.body) return new Uint8Array();
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) return joinedResponseBytes(chunks, totalBytes);
+        totalBytes += value.byteLength;
+        if (totalBytes > maxBytes) {
+            void reader.cancel().catch(() => undefined);
+            return null;
+        }
+        chunks.push(value);
+    }
+}
+
+async function boundedResponseJson(response: Response, maxBytes: number): Promise<unknown> {
+    const responseBytes = await boundedResponseBytes(response, maxBytes);
+    if (responseBytes === null) return null;
+    try {
+        const responseText = new TextDecoder("utf-8", { fatal: true }).decode(responseBytes);
+        return JSON.parse(responseText);
+    } catch (error: unknown) {
+        if (error instanceof SyntaxError || error instanceof TypeError) return null;
+        throw error;
+    }
+}
+
 async function fetchWithTimeout(
     url: string,
     options: RequestInit,
@@ -70,6 +131,7 @@ async function fetchWithTimeout(
     try {
         return await fetch(url, {
             ...options,
+            redirect: "error",
             signal: controller.signal,
         });
     } finally {
@@ -121,13 +183,16 @@ export class HttpTransport {
         };
     }
 
-    async get<T = unknown>(path: string): Promise<HttpResult<T>> {
+    async get<T = unknown>(path: string, options: HttpGetOptions = {}): Promise<HttpResult<T>> {
+        const maxResponseBytes = validatedGetResponseLimit(options);
         try {
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "GET",
                 headers: this.headers(),
             });
-            const data = (await res.json().catch(() => null)) as T;
+            const data = (maxResponseBytes === undefined
+                ? await res.json().catch(() => null)
+                : await boundedResponseJson(res, maxResponseBytes)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {
             return transportFailure<T>(error);

--- a/packages/cli/src/project-read-process.test.ts
+++ b/packages/cli/src/project-read-process.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const CLI_ENTRYPOINT = join(PACKAGE_ROOT, "src/index.ts");
+const CONTEXT_KEYS = new Set([
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "SUPACLOUD_API_URL",
+    "SUPACLOUD_MANAGEMENT_API_URL",
+    "MANAGEMENT_API_URL",
+    "SUPACLOUD_API_TOKEN",
+    "SUPACLOUD_PROJECT_REF",
+    "X_PROJECT_REF",
+    "SUPACLOUD_ENV",
+]);
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const PROJECT_DETAILS = {
+    id: "11111111-1111-4111-8111-111111111111",
+    ref: PROJECT_REF,
+    organization_id: "22222222-2222-4222-8222-222222222222",
+    organization_slug: "example-organization",
+    name: "Example project",
+    region: "local",
+    created_at: "2026-08-12T00:00:00.000Z",
+    status: "ACTIVE_HEALTHY",
+    database: {
+        host: "db.example.test",
+        version: "17.5",
+        postgres_engine: "17",
+        release_channel: "stable",
+    },
+    api: { url: "https://api.example.test" },
+    studio: { url: "https://studio.example.test" },
+};
+
+const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
+
+afterEach(() => {
+    for (const server of servers.splice(0)) server.stop(true);
+});
+function cleanEnvironment(overrides: Record<string, string>): Record<string, string> {
+    const environment: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+        if (value !== undefined && !CONTEXT_KEYS.has(key)) environment[key] = value;
+    }
+    return { ...environment, ...overrides };
+}
+
+async function runUserProjectGet(response: Response): Promise<{ exitCode: number; output: string }> {
+    const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch: () => response.clone(),
+    });
+    servers.push(server);
+    const apiToken = "user-process-api-token-sentinel";
+    const processHandle = Bun.spawn([process.execPath, CLI_ENTRYPOINT, "project", "get"], {
+        cwd: PACKAGE_ROOT,
+        env: cleanEnvironment({
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: apiToken,
+            SUPACLOUD_PROJECT_REF: PROJECT_REF,
+        }),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        processHandle.exited,
+        new Response(processHandle.stdout).text(),
+        new Response(processHandle.stderr).text(),
+    ]);
+    const output = stdout + stderr;
+    expect(output).not.toContain(apiToken);
+    return { exitCode, output };
+}
+
+describe("supacloud-cli project get process contract", () => {
+    test("prints only the fixed projection for the current Management response", async () => {
+        const remoteSecret = "user-known-private-sentinel";
+        const execution = await runUserProjectGet(Response.json({
+            ...PROJECT_DETAILS,
+            config: { private_runtime_value: remoteSecret },
+            anon_key: remoteSecret,
+            services: [{ token: remoteSecret }],
+        }));
+
+        expect(execution.exitCode).toBe(0);
+        expect(JSON.parse(execution.output)).toEqual(PROJECT_DETAILS);
+        expect(execution.output).not.toContain(remoteSecret);
+    });
+
+    test.each([
+        [
+            "HTTP failure",
+            Response.json({ error: "user-http-private-sentinel" }, { status: 404 }),
+            "Project get request failed (404)",
+            "user-http-private-sentinel",
+        ],
+        [
+            "unknown nested credential",
+            Response.json({
+                ...PROJECT_DETAILS,
+                studio: { ...PROJECT_DETAILS.studio, token: "user-studio-private-sentinel" },
+            }),
+            "Invalid project response",
+            "user-studio-private-sentinel",
+        ],
+        [
+            "cross-project response",
+            Response.json({
+                ...PROJECT_DETAILS,
+                ref: "different-project",
+                config: { private_value: "user-cross-project-private-sentinel" },
+            }),
+            "Invalid project response",
+            "user-cross-project-private-sentinel",
+        ],
+        [
+            "oversized known field",
+            Response.json({
+                ...PROJECT_DETAILS,
+                config: { private_value: "user-oversized-private-sentinel".repeat(50_000) },
+            }),
+            "Invalid project response",
+            "user-oversized-private-sentinel",
+        ],
+    ] as const)("exits non-zero for %s without reflecting the response", async (
+        _label,
+        response,
+        expectedMessage,
+        sentinel,
+    ) => {
+        const execution = await runUserProjectGet(response);
+
+        expect(execution.exitCode).toBe(1);
+        expect(execution.output).toContain(expectedMessage);
+        expect(execution.output).not.toContain(sentinel);
+    });
+});

--- a/packages/cli/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { schemaEnumValues, type ToolSchema } from "../schema";
 import { registerAdminProjectCliTools, registerUserProjectCliTools } from "./project-cli-tools";
 
+type ProjectToolResult = {
+    content: Array<{ text: string }>;
+    isError?: boolean;
+};
+
 function captureProjectTool(http: Record<string, unknown>, projectRef = "proj") {
-    let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<ProjectToolResult>) | undefined;
     registerUserProjectCliTools({
         tool(name: string, _description: string, _schema: Record<string, unknown>, toolCallback: typeof callback) {
             if (name !== "project") return;
@@ -16,7 +21,7 @@ function captureProjectTool(http: Record<string, unknown>, projectRef = "proj") 
 }
 
 function captureAdminProjectTool(http: Record<string, unknown>) {
-    let callback: ((args: Record<string, unknown>) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+    let callback: ((args: Record<string, unknown>) => Promise<ProjectToolResult>) | undefined;
     registerAdminProjectCliTools({
         tool(name: string, _description: string, _schema: Record<string, unknown>, toolCallback: typeof callback) {
             if (name === "project") callback = toolCallback;
@@ -26,6 +31,80 @@ function captureAdminProjectTool(http: Record<string, unknown>) {
     if (!callback) throw new Error("admin project tool was not registered");
     return callback;
 }
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const PROJECT_SUMMARY = {
+    id: "11111111-1111-4111-8111-111111111111",
+    ref: PROJECT_REF,
+    organization_id: "22222222-2222-4222-8222-222222222222",
+    organization_slug: "example-organization",
+    name: "Example project",
+    region: "local",
+    created_at: "2026-08-12T00:00:00.000Z",
+    status: "ACTIVE_HEALTHY",
+};
+const PROJECT_DETAILS = {
+    ...PROJECT_SUMMARY,
+    database: {
+        host: "db.example.test",
+        version: "17.5",
+        postgres_engine: "17",
+        release_channel: "stable",
+    },
+    api: { url: "https://api.example.test" },
+    studio: { url: "https://studio.example.test" },
+};
+
+describe("project CLI reads", () => {
+    test("bounds and projects the user project get response", async () => {
+        const remoteSecret = "user-project-private-sentinel";
+        let request: { path: string; maxResponseBytes?: number } | undefined;
+        const callback = captureProjectTool({
+            get: async (path: string, options?: { maxResponseBytes?: number }) => {
+                request = { path, maxResponseBytes: options?.maxResponseBytes };
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        ...PROJECT_DETAILS,
+                        config: { private_runtime_value: remoteSecret },
+                        anon_key: remoteSecret,
+                        services: [{ token: remoteSecret }],
+                    },
+                };
+            },
+        }, PROJECT_REF);
+
+        const response = await callback({ action: "get" });
+
+        expect(request).toEqual({
+            path: `/v1/projects/${PROJECT_REF}`,
+            maxResponseBytes: 1_048_576,
+        });
+        expect(response.isError).not.toBe(true);
+        expect(JSON.parse(response.content[0].text)).toEqual(PROJECT_DETAILS);
+        expect(response.content[0].text).not.toContain(remoteSecret);
+    });
+
+    test("fails malformed user and retained Admin reads without reflection", async () => {
+        const remoteSecret = "invalid-project-read-sentinel";
+        const http = {
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { ...PROJECT_DETAILS, credentials: { service_role_key: remoteSecret } },
+            }),
+        };
+        const userResponse = await captureProjectTool(http, PROJECT_REF)({ action: "get" });
+        const adminResponse = await captureAdminProjectTool(http)({ action: "get", ref: PROJECT_REF });
+
+        for (const response of [userResponse, adminResponse]) {
+            expect(response.isError).toBe(true);
+            expect(response.content[0].text).toBe("❌ Invalid project response");
+            expect(response.content[0].text).not.toContain(remoteSecret);
+        }
+    });
+});
 
 describe("project CLI task actions", () => {
     test("prefers an explicit ref over the auto-linked project", async () => {

--- a/packages/cli/src/shared/tools/project-cli-tools.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.ts
@@ -2,6 +2,12 @@ import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
 import type { HttpTransport } from "../transports/http";
+import {
+    PROJECT_READ_RESPONSE_MAX_BYTES,
+    projectGetRead,
+    projectListRead,
+    type ProjectReadResult,
+} from "./project-read-projection";
 
 type ToolServer = {
     tool: (
@@ -11,6 +17,13 @@ type ToolServer = {
         callback: (args: any) => Promise<any>,
     ) => void;
 };
+
+function projectReadResponse(readResult: ProjectReadResult) {
+    return {
+        content: [{ type: "text" as const, text: readResult.text }],
+        ...(readResult.isError ? { isError: true } : {}),
+    };
+}
 
 const formatTasks = (data: unknown): string => {
     if (!Array.isArray(data)) return JSON.stringify(data, null, 2);
@@ -139,8 +152,12 @@ Actions: get, health, logs, api_keys, settings, tasks, task_detail, task_cancel,
 
             switch (action) {
                 case "get":
-                    text = ok(await http.get(`/v1/projects/${resolvedRef}`));
-                    break;
+                    return projectReadResponse(projectGetRead(
+                        await http.get(`/v1/projects/${resolvedRef}`, {
+                            maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                        }),
+                        resolvedRef,
+                    ));
                 case "health":
                     text = ok(await http.get(`/v1/projects/${resolvedRef}/health`));
                     break;
@@ -272,8 +289,9 @@ Actions: list, create, get, delete, pause, restore, restart, settings, update_se
 
             switch (action) {
                 case "list":
-                    text = ok(await http.get("/v1/projects"));
-                    break;
+                    return projectReadResponse(projectListRead(await http.get("/v1/projects", {
+                        maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                    })));
                 case "create": {
                     if (!name) throw new Error("'name' is required for create");
                     const createRequest: Record<string, string | undefined> = {
@@ -288,9 +306,15 @@ Actions: list, create, get, delete, pause, restore, restart, settings, update_se
                     text = ok(await http.post("/v1/projects", createRequest));
                     break;
                 }
-                case "get":
-                    text = ok(await http.get(`/v1/projects/${resolveRef(ref)}`));
-                    break;
+                case "get": {
+                    const resolvedRef = resolveRef(ref);
+                    return projectReadResponse(projectGetRead(
+                        await http.get(`/v1/projects/${resolvedRef}`, {
+                            maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                        }),
+                        resolvedRef,
+                    ));
+                }
                 case "delete": {
                     const resolvedRef = resolveRef(ref);
                     text = simple(await http.delete(`/v1/projects/${resolvedRef}`), `Project ${resolvedRef} deleted`);

--- a/packages/cli/src/shared/tools/project-read-projection.test.ts
+++ b/packages/cli/src/shared/tools/project-read-projection.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test";
+import {
+    PROJECT_READ_RESPONSE_MAX_BYTES,
+    projectGetRead,
+    projectListRead,
+    type ProjectReadResult,
+} from "./project-read-projection";
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const PROJECT_SUMMARY = {
+    id: "11111111-1111-4111-8111-111111111111",
+    ref: PROJECT_REF,
+    organization_id: "22222222-2222-4222-8222-222222222222",
+    organization_slug: "example-organization",
+    name: "Example project",
+    region: "local",
+    created_at: "2026-08-12T00:00:00.000Z",
+    status: "ACTIVE_HEALTHY",
+};
+const PROJECT_DETAILS = {
+    ...PROJECT_SUMMARY,
+    database: {
+        host: "db.example.test",
+        version: "17.5",
+        postgres_engine: "17",
+        release_channel: "stable",
+    },
+    api: { url: "https://api.example.test" },
+    studio: { url: "https://studio.example.test" },
+};
+
+function expectFailure(readResult: ProjectReadResult, message: string, sentinel?: string): void {
+    expect(readResult).toEqual({ text: `❌ ${message}`, isError: true });
+    if (sentinel) expect(readResult.text).not.toContain(sentinel);
+}
+
+describe("project read projection", () => {
+    test("projects exact list metadata and accepts an empty list", () => {
+        const listRead = projectListRead({ ok: true, status: 200, data: [PROJECT_SUMMARY] });
+        const emptyRead = projectListRead({ ok: true, status: 200, data: [] });
+
+        expect(listRead.isError).toBe(false);
+        expect(JSON.parse(listRead.text)).toEqual([PROJECT_SUMMARY]);
+        expect(emptyRead).toEqual({ text: "[]", isError: false });
+    });
+
+    test("projects the current Management get contract and drops known private sections", () => {
+        const remoteSecret = "known-private-section-sentinel";
+        const readResult = projectGetRead({
+            ok: true,
+            status: 200,
+            data: {
+                ...PROJECT_DETAILS,
+                config: { scheduled_functions: [], private_runtime_value: remoteSecret },
+                anon_key: remoteSecret,
+                services: [{ id: "db", token: remoteSecret }],
+            },
+        }, PROJECT_REF);
+
+        expect(readResult.isError).toBe(false);
+        expect(JSON.parse(readResult.text)).toEqual(PROJECT_DETAILS);
+        expect(readResult.text).not.toContain(remoteSecret);
+        expect(readResult.text).not.toContain("config");
+        expect(readResult.text).not.toContain("anon_key");
+        expect(readResult.text).not.toContain("services");
+    });
+
+    test("accepts optional endpoints only as canonical origin metadata", () => {
+        const withoutEndpoints = projectGetRead({
+            ok: true,
+            status: 200,
+            data: {
+                ...PROJECT_SUMMARY,
+                database: PROJECT_DETAILS.database,
+                config: {},
+                services: [],
+            },
+        }, PROJECT_REF);
+        const normalizedOrigins = projectGetRead({
+            ok: true,
+            status: 200,
+            data: {
+                ...PROJECT_DETAILS,
+                api: { url: "https://API.Example.Test:8443" },
+                studio: { url: "http://STUDIO.Example.Test" },
+            },
+        }, PROJECT_REF);
+
+        expect(JSON.parse(withoutEndpoints.text)).toEqual({
+            ...PROJECT_SUMMARY,
+            database: PROJECT_DETAILS.database,
+        });
+        expect(JSON.parse(normalizedOrigins.text)).toEqual({
+            ...PROJECT_DETAILS,
+            api: { url: "https://api.example.test:8443" },
+            studio: { url: "http://studio.example.test" },
+        });
+    });
+
+    test.each([
+        ["root path", "https://api.example.test/"],
+        ["path", "https://api.example.test/private-path"],
+        ["encoded path", "https://api.example.test/%2e"],
+        ["query", "https://api.example.test?token=private"],
+        ["fragment", "https://api.example.test#private"],
+        ["credentials", "https://user:password@api.example.test"],
+        ["backslash", "https://api.example.test\\private"],
+    ])("rejects an endpoint URL containing %s without reflection", (_label, endpointUrl) => {
+        const readResult = projectGetRead({
+            ok: true,
+            status: 200,
+            data: { ...PROJECT_DETAILS, api: { url: endpointUrl } },
+        }, PROJECT_REF);
+
+        expectFailure(readResult, "Invalid project response", endpointUrl);
+    });
+
+    test("rejects non-2xx and inconsistent HTTP results without reflecting bodies", () => {
+        const remoteSecret = "http-failure-private-sentinel";
+        const failures = [
+            projectListRead({
+                ok: false,
+                status: 404,
+                data: { error: remoteSecret, service_role_key: remoteSecret },
+            }),
+            projectGetRead({
+                ok: true,
+                status: 503,
+                data: { ...PROJECT_DETAILS, secret: remoteSecret },
+            }, PROJECT_REF),
+            projectGetRead({
+                ok: false,
+                status: 200,
+                data: { ...PROJECT_DETAILS, secret: remoteSecret },
+            }, PROJECT_REF),
+            projectListRead({
+                ok: false,
+                status: Number.NaN,
+                data: { error: remoteSecret },
+            }),
+        ];
+
+        expectFailure(failures[0], "Project list request failed (404)", remoteSecret);
+        expectFailure(failures[1], "Project get request failed (503)", remoteSecret);
+        expectFailure(failures[2], "Project get request failed (200)", remoteSecret);
+        expectFailure(failures[3], "Project list request failed", remoteSecret);
+    });
+
+    test("rejects malformed, duplicate, and cross-project payloads", () => {
+        const remoteSecret = "invalid-project-private-sentinel";
+        const malformed = projectListRead({
+            ok: true,
+            status: 200,
+            data: [{ ...PROJECT_SUMMARY, created_at: remoteSecret }],
+        });
+        const duplicateId = projectListRead({
+            ok: true,
+            status: 200,
+            data: [
+                PROJECT_SUMMARY,
+                { ...PROJECT_SUMMARY, ref: "different-project" },
+            ],
+        });
+        const duplicateRef = projectListRead({
+            ok: true,
+            status: 200,
+            data: [
+                PROJECT_SUMMARY,
+                { ...PROJECT_SUMMARY, id: "33333333-3333-4333-8333-333333333333" },
+            ],
+        });
+        const crossProject = projectGetRead({
+            ok: true,
+            status: 200,
+            data: { ...PROJECT_DETAILS, ref: "different-project" },
+        }, PROJECT_REF);
+
+        expectFailure(malformed, "Invalid project list response", remoteSecret);
+        expectFailure(duplicateId, "Invalid project list response");
+        expectFailure(duplicateRef, "Invalid project list response");
+        expectFailure(crossProject, "Invalid project response");
+    });
+
+    test.each([
+        ["list top level", [{ ...PROJECT_SUMMARY, credentials: { service_role_key: "unknown-field-sentinel" } }]],
+        ["get top level", { ...PROJECT_DETAILS, secret_key: "unknown-field-sentinel" }],
+        ["database", {
+            ...PROJECT_DETAILS,
+            database: { ...PROJECT_DETAILS.database, password: "unknown-field-sentinel" },
+        }],
+        ["api", {
+            ...PROJECT_DETAILS,
+            api: { ...PROJECT_DETAILS.api, token: "unknown-field-sentinel" },
+        }],
+        ["studio", {
+            ...PROJECT_DETAILS,
+            studio: { ...PROJECT_DETAILS.studio, token: "unknown-field-sentinel" },
+        }],
+    ])("rejects unknown %s fields without reflecting them", (location, payload) => {
+        const readResult = location === "list top level"
+            ? projectListRead({ ok: true, status: 200, data: payload })
+            : projectGetRead({ ok: true, status: 200, data: payload }, PROJECT_REF);
+
+        expectFailure(
+            readResult,
+            location === "list top level" ? "Invalid project list response" : "Invalid project response",
+            "unknown-field-sentinel",
+        );
+    });
+
+    test("rejects non-string and ill-formed Unicode fields", () => {
+        const numericRef = projectListRead({
+            ok: true,
+            status: 200,
+            data: [{ ...PROJECT_SUMMARY, ref: 12345 }],
+        });
+        const loneSurrogate = projectGetRead({
+            ok: true,
+            status: 200,
+            data: { ...PROJECT_DETAILS, name: "invalid-name-\uD800" },
+        }, PROJECT_REF);
+
+        expectFailure(numericRef, "Invalid project list response");
+        expectFailure(loneSurrogate, "Invalid project response");
+    });
+
+    test("rejects oversized list and detail payloads without reflecting allowed fields", () => {
+        const oversizedList = Array.from({ length: 5_000 }, (_, index) => ({
+            ...PROJECT_SUMMARY,
+            id: `project-id-${index}`,
+            ref: `project-${index}`,
+        }));
+        const oversizedSecret = "oversized-private-sentinel".repeat(50_000);
+        const listRead = projectListRead({ ok: true, status: 200, data: oversizedList });
+        const getRead = projectGetRead({
+            ok: true,
+            status: 200,
+            data: {
+                ...PROJECT_DETAILS,
+                config: { retained_contract_field: oversizedSecret },
+            },
+        }, PROJECT_REF);
+
+        expect(new TextEncoder().encode(JSON.stringify(oversizedList)).byteLength)
+            .toBeGreaterThan(PROJECT_READ_RESPONSE_MAX_BYTES);
+        expectFailure(listRead, "Invalid project list response");
+        expectFailure(getRead, "Invalid project response", "oversized-private-sentinel");
+    });
+});

--- a/packages/cli/src/shared/tools/project-read-projection.ts
+++ b/packages/cli/src/shared/tools/project-read-projection.ts
@@ -1,0 +1,262 @@
+import type { HttpResult } from "../transports/http";
+
+export const PROJECT_READ_RESPONSE_MAX_BYTES = 1_048_576;
+
+const PROJECT_REF_PATTERN = /^[a-z0-9-]{1,20}$/;
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const REGION_PATTERN = /^[A-Za-z0-9._-]{1,64}$/;
+const STATUS_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+const DNS_LABEL_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+const DATABASE_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
+const MAX_PROJECTS = 10_000;
+
+const PROJECT_SUMMARY_KEYS = new Set([
+    "id", "ref", "organization_id", "organization_slug",
+    "name", "region", "created_at", "status",
+]);
+const PROJECT_DETAILS_KEYS = new Set([
+    ...PROJECT_SUMMARY_KEYS,
+    "database", "api", "studio", "config", "anon_key", "services",
+]);
+const PROJECT_DATABASE_KEYS = new Set([
+    "host", "version", "postgres_engine", "release_channel",
+]);
+const PROJECT_ENDPOINT_KEYS = new Set(["url"]);
+
+export type ProjectReadResult = {
+    text: string;
+    isError: boolean;
+};
+
+interface SafeProjectSummary {
+    id: string;
+    ref: string;
+    organization_id: string;
+    organization_slug: string;
+    name: string;
+    region: string;
+    created_at: string;
+    status: string;
+}
+
+interface SafeProjectDetails extends SafeProjectSummary {
+    database: {
+        host: string;
+        version: string;
+        postgres_engine: string;
+        release_channel: string;
+    };
+    api?: { url: string };
+    studio?: { url: string };
+}
+
+function plainRecord(candidate: unknown): Record<string, unknown> | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const prototype = Object.getPrototypeOf(candidate);
+    return prototype === Object.prototype || prototype === null
+        ? candidate as Record<string, unknown>
+        : null;
+}
+
+function hasOnlyKeys(record: Record<string, unknown>, allowedKeys: ReadonlySet<string>): boolean {
+    return Object.keys(record).every(key => allowedKeys.has(key));
+}
+
+function hasWellFormedUnicode(text: string): boolean {
+    for (let index = 0; index < text.length; index++) {
+        const codeUnit = text.charCodeAt(index);
+        if (codeUnit >= 0xD800 && codeUnit <= 0xDBFF) {
+            if (index + 1 >= text.length) return false;
+            const lowSurrogate = text.charCodeAt(index + 1);
+            if (lowSurrogate < 0xDC00 || lowSurrogate > 0xDFFF) return false;
+            index++;
+        } else if (codeUnit >= 0xDC00 && codeUnit <= 0xDFFF) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function boundedText(candidate: unknown, maxLength: number): string | null {
+    return typeof candidate === "string" && candidate.length > 0 && candidate.length <= maxLength
+        && !/[\u0000-\u001f\u007f]/u.test(candidate) && hasWellFormedUnicode(candidate)
+        ? candidate
+        : null;
+}
+
+function matchingText(candidate: unknown, maxLength: number, pattern: RegExp): string | null {
+    const candidateText = boundedText(candidate, maxLength);
+    return candidateText && pattern.test(candidateText) ? candidateText : null;
+}
+
+function canonicalTimestamp(candidate: unknown): string | null {
+    const timestamp = boundedText(candidate, 64);
+    if (!timestamp) return null;
+    const milliseconds = Date.parse(timestamp);
+    return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === timestamp
+        ? timestamp
+        : null;
+}
+
+function projectedSummary(project: Record<string, unknown>): SafeProjectSummary | null {
+    const summary = {
+        id: matchingText(project.id, 128, SAFE_IDENTIFIER_PATTERN),
+        ref: matchingText(project.ref, 20, PROJECT_REF_PATTERN),
+        organization_id: matchingText(project.organization_id, 128, SAFE_IDENTIFIER_PATTERN),
+        organization_slug: matchingText(project.organization_slug, 128, SAFE_IDENTIFIER_PATTERN),
+        name: boundedText(project.name, 100),
+        region: matchingText(project.region, 64, REGION_PATTERN),
+        created_at: canonicalTimestamp(project.created_at),
+        status: matchingText(project.status, 64, STATUS_PATTERN),
+    };
+    return Object.values(summary).every(field => field !== null)
+        ? summary as SafeProjectSummary
+        : null;
+}
+
+function projectSummary(candidate: unknown): SafeProjectSummary | null {
+    const project = plainRecord(candidate);
+    return project && hasOnlyKeys(project, PROJECT_SUMMARY_KEYS)
+        ? projectedSummary(project)
+        : null;
+}
+
+function databaseHost(candidate: unknown): string | null {
+    const host = boundedText(candidate, 255);
+    if (!host) return null;
+    if (host.startsWith("[") && host.endsWith("]")) {
+        try {
+            const parsedHost = new URL(`http://${host}`);
+            return parsedHost.host === host ? host : null;
+        } catch (error: unknown) {
+            if (error instanceof TypeError) return null;
+            throw error;
+        }
+    }
+    const ipv4Parts = host.split(".");
+    if (ipv4Parts.length === 4 && ipv4Parts.every(part => /^\d{1,3}$/u.test(part))) {
+        return ipv4Parts.every(part => Number(part) <= 255) ? host : null;
+    }
+    return ipv4Parts.every(label => DNS_LABEL_PATTERN.test(label)) ? host : null;
+}
+
+function projectDatabase(candidate: unknown): SafeProjectDetails["database"] | null {
+    const database = plainRecord(candidate);
+    if (!database || !hasOnlyKeys(database, PROJECT_DATABASE_KEYS)) return null;
+    const host = databaseHost(database.host);
+    const version = matchingText(database.version, 64, DATABASE_VERSION_PATTERN);
+    const postgresEngine = matchingText(database.postgres_engine, 64, DATABASE_VERSION_PATTERN);
+    const releaseChannel = matchingText(database.release_channel, 64, DATABASE_VERSION_PATTERN);
+    return host && version && postgresEngine && releaseChannel
+        ? { host, version, postgres_engine: postgresEngine, release_channel: releaseChannel }
+        : null;
+}
+
+function rawUrlHasNoPath(candidate: string): boolean {
+    if (candidate.trim() !== candidate || candidate.includes("\\")) return false;
+    const schemeEnd = candidate.indexOf("://");
+    const pathStart = candidate.indexOf("/", schemeEnd + 3);
+    return pathStart === -1;
+}
+
+function projectEndpoint(candidate: unknown): { url: string } | null {
+    const endpoint = plainRecord(candidate);
+    if (!endpoint || !hasOnlyKeys(endpoint, PROJECT_ENDPOINT_KEYS)) return null;
+    const endpointUrl = boundedText(endpoint.url, 2_048);
+    if (!endpointUrl || !rawUrlHasNoPath(endpointUrl)) return null;
+    try {
+        const url = new URL(endpointUrl);
+        if (url.protocol !== "http:" && url.protocol !== "https:"
+            || url.username || url.password || url.search || url.hash || url.pathname !== "/") return null;
+        return { url: url.origin };
+    } catch (error: unknown) {
+        if (error instanceof TypeError) return null;
+        throw error;
+    }
+}
+
+function discardedDetailFieldsAreValid(project: Record<string, unknown>): boolean {
+    if (project.config !== undefined && plainRecord(project.config) === null) return false;
+    if (project.anon_key !== undefined && boundedText(project.anon_key, 16_384) === null) return false;
+    return project.services === undefined || Array.isArray(project.services);
+}
+
+function projectDetails(candidate: unknown, expectedRef: string): SafeProjectDetails | null {
+    const project = plainRecord(candidate);
+    if (!project || !hasOnlyKeys(project, PROJECT_DETAILS_KEYS)) return null;
+    const summary = projectedSummary(project);
+    const database = projectDatabase(project.database);
+    const api = project.api === undefined ? undefined : projectEndpoint(project.api);
+    const studio = project.studio === undefined ? undefined : projectEndpoint(project.studio);
+    if (!summary || summary.ref !== expectedRef || !database || !discardedDetailFieldsAreValid(project)
+        || project.api !== undefined && !api || project.studio !== undefined && !studio) return null;
+    return {
+        ...summary,
+        database,
+        ...(api ? { api } : {}),
+        ...(studio ? { studio } : {}),
+    };
+}
+
+function payloadWithinLimit(candidate: unknown): boolean {
+    try {
+        const serializedPayload = JSON.stringify(candidate);
+        return serializedPayload !== undefined
+            && new TextEncoder().encode(serializedPayload).byteLength <= PROJECT_READ_RESPONSE_MAX_BYTES;
+    } catch {
+        // Serialization failures make the untrusted remote payload invalid and must not reach diagnostics.
+        return false;
+    }
+}
+
+function safeProjectList(candidate: unknown): SafeProjectSummary[] | null {
+    if (!payloadWithinLimit(candidate) || !Array.isArray(candidate) || candidate.length > MAX_PROJECTS) return null;
+    const safeProjects: SafeProjectSummary[] = [];
+    const ids = new Set<string>();
+    const refs = new Set<string>();
+    for (const projectCandidate of candidate) {
+        const project = projectSummary(projectCandidate);
+        if (!project || ids.has(project.id) || refs.has(project.ref)) return null;
+        ids.add(project.id);
+        refs.add(project.ref);
+        safeProjects.push(project);
+    }
+    return safeProjects;
+}
+
+function validHttpStatus(status: number): boolean {
+    return Number.isSafeInteger(status) && status >= 100 && status <= 599;
+}
+
+function successfulResponse(response: HttpResult<unknown>): boolean {
+    return response.ok === true && validHttpStatus(response.status)
+        && response.status >= 200 && response.status <= 299;
+}
+
+function failedResult(message: string): ProjectReadResult {
+    return { text: `❌ ${message}`, isError: true };
+}
+
+function failedHttpResult(label: string, status: number): ProjectReadResult {
+    return failedResult(validHttpStatus(status) ? `${label} request failed (${status})` : `${label} request failed`);
+}
+
+function successfulResult(payload: SafeProjectSummary[] | SafeProjectDetails): ProjectReadResult {
+    return { text: JSON.stringify(payload, null, 2), isError: false };
+}
+
+export function projectListRead(response: HttpResult<unknown>): ProjectReadResult {
+    if (!successfulResponse(response)) return failedHttpResult("Project list", response.status);
+    const projects = safeProjectList(response.data);
+    return projects ? successfulResult(projects) : failedResult("Invalid project list response");
+}
+
+export function projectGetRead(
+    response: HttpResult<unknown>,
+    expectedRef: string,
+): ProjectReadResult {
+    if (!successfulResponse(response)) return failedHttpResult("Project get", response.status);
+    if (!payloadWithinLimit(response.data)) return failedResult("Invalid project response");
+    const project = projectDetails(response.data, expectedRef);
+    return project ? successfulResult(project) : failedResult("Invalid project response");
+}

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -254,6 +254,27 @@ describe("HttpTransport retry policy", () => {
 });
 
 describe("HttpTransport bounded GET responses", () => {
+    test.each([
+        0,
+        -1,
+        1.5,
+        Number.MAX_SAFE_INTEGER + 1,
+        Number.POSITIVE_INFINITY,
+        Number.NaN,
+    ])("rejects invalid response limit %s before dispatch", async maxResponseBytes => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls += 1;
+            return Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+
+        await expect(createTransport().get("/resource", { maxResponseBytes })).rejects.toThrow(
+            "HTTP response limit must be a positive safe integer",
+        );
+
+        expect(fetchCalls).toBe(0);
+    });
+
     test("accepts an exact 1 MiB UTF-8 JSON response", async () => {
         const body = whitespaceJson(MAX_TEST_RESPONSE_BYTES);
         globalThis.fetch = (async () => new Response(body, {

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -28,6 +28,15 @@ const RELEASE_MUTATION_RESPONSE_MAX_BYTES = 64 * 1024;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
 
+function validatedGetResponseLimit(options: HttpGetOptions): number | undefined {
+    const maxBytes = options.maxResponseBytes;
+    if (maxBytes === undefined) return undefined;
+    if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+        throw new RangeError("HTTP response limit must be a positive safe integer");
+    }
+    return maxBytes;
+}
+
 type ResponseBytesRead =
     | { ok: true; bytes: Uint8Array }
     | { ok: false };
@@ -284,14 +293,15 @@ export class HttpTransport {
     }
 
     async get<T = unknown>(path: string, options: HttpGetOptions = {}): Promise<HttpResult<T>> {
+        const maxResponseBytes = validatedGetResponseLimit(options);
         try {
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "GET",
                 headers: this.headers(),
             });
-            const data = (options.maxResponseBytes === undefined
+            const data = (maxResponseBytes === undefined
                 ? await res.json().catch(() => null)
-                : await boundedResponseJson(res, options.maxResponseBytes)) as T;
+                : await boundedResponseJson(res, maxResponseBytes)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {
             return transportFailure<T>(error);


### PR DESCRIPTION
## Summary

- bound Admin and user CLI project list/get responses to 1 MiB before JSON parsing
- project only the current Management V1 allowlist and discard `config`, `anon_key`, and `services`
- fail closed on malformed, oversized, cross-project, duplicate, or unknown fields without reflecting the remote body
- reject invalid response limits before HTTP dispatch
- make the Admin transport reject 302/307 redirects for GET, JSON POST, multipart POST, PATCH, PUT, and DELETE

## Why this is necessary

The published clients previously printed retained Management project detail fields directly. A malformed or expanded response could therefore expose fields outside the CLI contract. The Admin transport also followed redirects for credential-bearing requests, which could forward mutation bodies. This follow-up makes both boundaries explicit and fail closed.

## Security contract

- successful reads contain only the fixed V1 project summary/detail projection
- failures are non-zero and contain only local status/error text, never the response body or token
- raw reads are bounded before parsing; invalid limits cause zero HTTP requests
- redirects reach the source exactly once and the target zero times, with no token or request-body reflection
- no new dependency and no Management API or database change

## Verification

- Admin full: 378 pass, 26 platform-specific skip, 0 fail
- CLI full: 604 pass, 0 fail
- Management project serialization contract: 7/7
- Admin redirect matrix: 24/24 across 302/307, same/cross origin, and every transport method
- Admin and CLI typecheck + production build
- isolated packed Admin executable verified without sibling source files
- `git diff --check`

`clean-code-guard: 1 fixed, 0 flagged`
