### PR TITLE
fix(platform): harden durable project mutations

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -399,6 +399,12 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
         run: bun test tests/integration/storage-bucket-cas.test.ts
 
+      - name: Verify project mutation lease fencing on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: bun test tests/integration/project-mutation-lease.test.ts tests/integration/project-mutation-migration.test.ts
+
       - name: Verify Realtime payload safety on PostgreSQL 18
         working-directory: packages/management-api
         env:

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2130,4 +2130,54 @@ describe("supacloud-cli process contract", () => {
         expect(status.checks.authentication.ok).toBeNull();
         expect(result.stdout + result.stderr).not.toContain("application-service-role");
     });
+
+    test("mutation status exits non-zero for a durable non-success state", async () => {
+        const requestedPaths: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requestedPaths.push(new URL(request.url).pathname);
+                return Response.json({
+                    project_ref: "abc123",
+                    mutation: {
+                        project_ref: "abc123",
+                        mutation_id: SCHEDULE_ID,
+                        operation: "scheduled_functions.create",
+                        resource_key: null,
+                        request_fingerprint: "a".repeat(64),
+                        principal: { type: "project", id: "project:abc123" },
+                        status: "pending",
+                        checkpoint: {},
+                        receipt: null,
+                        response_status: null,
+                        failure_code: null,
+                        lease: { owner: null, expires_at: null, fencing_epoch: 0 },
+                        completed_at: null,
+                        created_at: "2026-08-12T00:00:00.000Z",
+                        updated_at: "2026-08-12T00:00:00.000Z",
+                    },
+                });
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli([
+            "mutations", "status", "--ref", "abc123", "--mutation_id", SCHEDULE_ID,
+        ], {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+        const payload = JSON.parse(response.stdout);
+
+        expect(response.exitCode).toBe(1);
+        expect(requestedPaths).toEqual([`/v1/projects/abc123/mutations/${SCHEDULE_ID}`]);
+        expect(payload).toMatchObject({
+            ok: false,
+            operation: "mutations.status",
+            mutation: { mutation_id: SCHEDULE_ID, status: "pending" },
+            error: { code: "MUTATION_NOT_SUCCEEDED", http_status: null },
+        });
+    });
 });

--- a/packages/cli/src/shared/mutation-protocol.test.ts
+++ b/packages/cli/src/shared/mutation-protocol.test.ts
@@ -8,7 +8,10 @@ const MUTATION_ID = "00000000-0000-4000-8000-000000000001";
 const CREATED_AT = "2026-08-11T00:00:00.000Z";
 const UPDATED_AT = "2026-08-11T00:00:00.001Z";
 
-function mutationStatus(principal: { type: string; id: string }) {
+function mutationStatus(
+    principal: { type: string; id: string },
+    overrides: Record<string, unknown> = {},
+) {
     return {
         project_ref: "proj",
         mutation_id: MUTATION_ID,
@@ -25,17 +28,25 @@ function mutationStatus(principal: { type: string; id: string }) {
         completed_at: UPDATED_AT,
         created_at: CREATED_AT,
         updated_at: UPDATED_AT,
+        ...overrides,
     };
 }
 
-function mutationHttp(principal: { type: string; id: string }) {
+function mutationHttp(
+    principal: { type: string; id: string },
+    overrides: Record<string, unknown> = {},
+) {
     return {
         get: async () => ({
             ok: true,
             status: 200,
-            data: { project_ref: "proj", mutation: mutationStatus(principal) },
+            data: { project_ref: "proj", mutation: mutationStatus(principal, overrides) },
         }),
     };
+}
+
+function canonicalResourceKey(resourceId: string): string {
+    return `v1/edge-function/${Buffer.from(resourceId, "utf8").toString("base64url")}`;
 }
 
 test("Mutation fingerprints are stable across object key order and cover exact values", () => {
@@ -94,6 +105,45 @@ test("Verified mutation readback binds the project CLI to its exact project prin
     });
 
     expect(readback.kind).toBe("available");
+});
+
+test.each([
+    ["a one-byte id", canonicalResourceKey("a")],
+    ["an ordinary Unicode id", canonicalResourceKey("夜班/worker")],
+    ["a 128-byte id", canonicalResourceKey("界".repeat(42) + "é")],
+])("Verified mutation readback accepts a canonical resource key with %s", async (_case, resourceKey) => {
+    const readback = await verifiedMutationReadback(mutationHttp({
+        type: "project", id: "project:proj",
+    }, { resource_key: resourceKey }) as never, {
+        ref: "proj",
+        mutationId: MUTATION_ID,
+        operation: "scheduled_functions.create",
+        requestFingerprint: "a".repeat(64),
+    });
+
+    expect(readback.kind).toBe("available");
+});
+
+test.each([
+    ["one-character encoding", "v1/edge-function/A"],
+    ["non-zero base64url trailing bits", "v1/edge-function/YR"],
+    ["non-UTF-8 decoded bytes", "v1/edge-function/_w"],
+    ["leading Unicode whitespace", canonicalResourceKey("\u00a0nightly")],
+    ["C1 control character", canonicalResourceKey("nightly\u0085")],
+    ["129-byte id", canonicalResourceKey("a".repeat(129))],
+    ["non-v1 key", "v2/edge-function/YQ"],
+    ["non-canonical resource type", "v1/Edge-function/YQ"],
+])("Verified mutation readback rejects a resource key with %s", async (_case, resourceKey) => {
+    const readback = await verifiedMutationReadback(mutationHttp({
+        type: "project", id: "project:proj",
+    }, { resource_key: resourceKey }) as never, {
+        ref: "proj",
+        mutationId: MUTATION_ID,
+        operation: "scheduled_functions.create",
+        requestFingerprint: "a".repeat(64),
+    });
+
+    expect(readback).toEqual({ kind: "invalid" });
 });
 
 test.each([

--- a/packages/cli/src/shared/mutation-protocol.ts
+++ b/packages/cli/src/shared/mutation-protocol.ts
@@ -5,12 +5,15 @@ import type { HttpTransport } from "./transports/http";
 const MUTATION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/;
 const OPERATION_PATTERN = /^[a-z0-9][a-z0-9._:-]{0,127}$/;
-const RESOURCE_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,254}$/;
+const RESOURCE_KEY_PATTERN = /^v1\/(?:[a-z0-9][a-z0-9._-]{0,63})\/([A-Za-z0-9_-]{2,171})$/;
+const RESOURCE_ID_CONTROL_PATTERN = /[\u0000-\u001f\u007f-\u009f]/u;
 const FAILURE_CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
 const LEASE_OWNER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,254}$/;
 const TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const MAX_STATUS_RESPONSE_BYTES = 196_608;
 const MAX_JSON_DEPTH = 32;
+const MAX_RESOURCE_ID_BYTES = 128;
+const FATAL_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 const MUTATION_STATUSES = new Set([
     "pending", "running", "succeeded", "failed_retryable", "failed_terminal", "outcome_unknown",
 ]);
@@ -177,11 +180,30 @@ function validMutationLifecycle(
     return true;
 }
 
+function canonicalMutationResourceKey(candidate: unknown): candidate is string {
+    if (typeof candidate !== "string") return false;
+    const match = RESOURCE_KEY_PATTERN.exec(candidate);
+    if (!match) return false;
+    const encodedResourceId = match[1]!;
+    const resourceIdBytes = Buffer.from(encodedResourceId, "base64url");
+    if (resourceIdBytes.byteLength < 1 || resourceIdBytes.byteLength > MAX_RESOURCE_ID_BYTES
+        || resourceIdBytes.toString("base64url") !== encodedResourceId) return false;
+    let resourceId: string;
+    try {
+        resourceId = FATAL_UTF8_DECODER.decode(resourceIdBytes);
+    } catch (decodeError) {
+        if (decodeError instanceof TypeError) return false;
+        throw decodeError;
+    }
+    return resourceId.trim() === resourceId
+        && !RESOURCE_ID_CONTROL_PATTERN.test(resourceId)
+        && Buffer.from(resourceId, "utf8").equals(resourceIdBytes);
+}
+
 function validMutationIdentity(mutation: Record<string, unknown>): boolean {
     if (!isMutationId(mutation.mutation_id) || typeof mutation.project_ref !== "string") return false;
     if (typeof mutation.operation !== "string" || !OPERATION_PATTERN.test(mutation.operation)) return false;
-    if (mutation.resource_key !== null
-        && (typeof mutation.resource_key !== "string" || !RESOURCE_KEY_PATTERN.test(mutation.resource_key))) return false;
+    if (mutation.resource_key !== null && !canonicalMutationResourceKey(mutation.resource_key)) return false;
     return typeof mutation.request_fingerprint === "string"
         && FINGERPRINT_PATTERN.test(mutation.request_fingerprint);
 }

--- a/packages/cli/src/shared/tools/mutation-tools.test.ts
+++ b/packages/cli/src/shared/tools/mutation-tools.test.ts
@@ -26,6 +26,27 @@ function mutationRecord(overrides: Record<string, unknown> = {}) {
     };
 }
 
+function nonSucceededMutation(status: string) {
+    if (status === "pending") {
+        return mutationRecord({
+            status, receipt: null, response_status: null, completed_at: null,
+            lease: { owner: null, expires_at: null, fencing_epoch: 0 },
+        });
+    }
+    if (status === "running") {
+        return mutationRecord({
+            status, receipt: null, response_status: null, completed_at: null,
+            lease: { owner: "worker-one", expires_at: "2099-08-11T00:00:00.000Z", fencing_epoch: 1 },
+        });
+    }
+    return mutationRecord({
+        status,
+        response_status: status === "failed_terminal" ? 400 : 503,
+        failure_code: "PROVIDER_FAILURE",
+        completed_at: ["failed_terminal", "outcome_unknown"].includes(status) ? UPDATED_AT : null,
+    });
+}
+
 function captureMutationTool(http: Record<string, unknown>) {
     let callback: ((args: Record<string, unknown>) => Promise<{
         content: Array<{ text: string }>;
@@ -76,6 +97,31 @@ test("Mutation status reads the exact bounded path and emits the fixed public pr
     });
 });
 
+test.each(["pending", "running", "failed_retryable", "failed_terminal", "outcome_unknown"])(
+    "Mutation status exits as an error for observed non-success state %s while preserving its safe projection",
+    async (status) => {
+        const callback = captureMutationTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { project_ref: "proj", mutation: nonSucceededMutation(status) },
+            }),
+        });
+
+        const response = await callback({ action: "status", ref: "proj", mutation_id: MUTATION_ID });
+        const payload = JSON.parse(response.content[0].text);
+
+        expect(response.isError).toBe(true);
+        expect(payload).toMatchObject({
+            ok: false,
+            operation: "mutations.status",
+            project_ref: "proj",
+            mutation: { mutation_id: MUTATION_ID, status },
+            error: { code: "MUTATION_NOT_SUCCEEDED", http_status: null },
+        });
+    },
+);
+
 test.each([
     ["non-empty checkpoint", { checkpoint: { phase: "private-checkpoint-sentinel" } }, "private-checkpoint-sentinel"],
     ["non-empty receipt", { receipt: { summary: "private-receipt-sentinel" } }, "private-receipt-sentinel"],
@@ -121,6 +167,27 @@ test("Mutation status rejects extra response fields without reflecting them", as
 
     expect(response.isError).toBe(true);
     expect(response.content[0].text).not.toContain(privateSentinel);
+});
+
+test.each([
+    ["non-canonical base64url", "v1/edge-function/YR"],
+    ["non-UTF-8 decoded", "v1/edge-function/_w"],
+])("Mutation status rejects a %s resource key without reflecting it", async (_case, resourceKey) => {
+    const callback = captureMutationTool({
+        get: async () => ({
+            ok: true,
+            status: 200,
+            data: { project_ref: "proj", mutation: mutationRecord({ resource_key: resourceKey }) },
+        }),
+    });
+
+    const response = await callback({ action: "status", ref: "proj", mutation_id: MUTATION_ID });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error).toEqual({
+        code: "INVALID_RESPONSE", http_status: null,
+    });
+    expect(response.content[0].text).not.toContain(resourceKey);
 });
 
 test("Mutation status reports HTTP failure without reflecting the server body", async () => {

--- a/packages/cli/src/shared/tools/mutation-tools.ts
+++ b/packages/cli/src/shared/tools/mutation-tools.ts
@@ -43,6 +43,12 @@ async function mutationStatus(
     if (readback.kind === "invalid") {
         return releaseControlFailure("mutations.status", "INVALID_RESPONSE", null);
     }
+    if (readback.mutation.status !== "succeeded") {
+        return releaseControlFailure("mutations.status", "MUTATION_NOT_SUCCEEDED", null, {
+            project_ref: ref,
+            mutation: readback.mutation,
+        });
+    }
     return releaseControlSuccess("mutations.status", { project_ref: ref, mutation: readback.mutation });
 }
 

--- a/packages/cli/src/shared/tools/release-control-response.test.ts
+++ b/packages/cli/src/shared/tools/release-control-response.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import {
+    RELEASE_CONTROL_RESPONSE_SCHEMA,
+    releaseControlFailure,
+    releaseControlSuccess,
+} from "./release-control-response";
+
+function responsePayload(response: { content: Array<{ text: string }> }): Record<string, unknown> {
+    return JSON.parse(response.content[0].text) as Record<string, unknown>;
+}
+
+test("release-control extensions cannot override success envelope invariants", () => {
+    const response = releaseControlSuccess("expected.operation", {
+        schema: "attacker-schema",
+        ok: false,
+        operation: "attacker.operation",
+    });
+
+    expect(responsePayload(response)).toMatchObject({
+        schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
+        ok: true,
+        operation: "expected.operation",
+    });
+});
+
+test("release-control safe state cannot override failure envelope invariants", () => {
+    const response = releaseControlFailure("expected.operation", "OUTCOME_UNKNOWN", 503, {
+        schema: "attacker-schema",
+        ok: true,
+        operation: "attacker.operation",
+        error: { code: "attacker-code", http_status: 200 },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(responsePayload(response)).toMatchObject({
+        schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
+        ok: false,
+        operation: "expected.operation",
+        error: { code: "OUTCOME_UNKNOWN", http_status: 503 },
+    });
+});

--- a/packages/cli/src/shared/tools/release-control-response.ts
+++ b/packages/cli/src/shared/tools/release-control-response.ts
@@ -12,19 +12,21 @@ export function releaseControlSuccess(
     payload: Record<string, unknown>,
 ): ReleaseControlToolResponse {
     return releaseControlResponse({
+        ...payload,
         schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
         ok: true,
         operation,
-        ...payload,
     });
 }
 
 export function releaseControlFailure(
     operation: string,
-    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "OUTCOME_UNKNOWN",
+    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "MUTATION_NOT_SUCCEEDED" | "OUTCOME_UNKNOWN",
     httpStatus: number | null,
+    safeState: Record<string, unknown> = {},
 ): ReleaseControlToolResponse {
     return releaseControlErrorResponse({
+        ...safeState,
         schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
         ok: false,
         operation,

--- a/packages/management-api/src/api.test.ts
+++ b/packages/management-api/src/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, mock } from "bun:test";
+import { describe, it, expect, beforeAll, mock, spyOn } from "bun:test";
 
 const mockSql = mock((strings: string | TemplateStringsArray) => {
     const sqlStr = Array.isArray(strings) ? strings.join("") : String(strings);
@@ -18,18 +18,92 @@ mock.module("../src/db", () => ({
     sql: mockSql,
 }));
 
-import { app as baseApp, registerAllRoutes } from "../src/index";
-
-import type { Elysia } from "elysia";
+import { app as baseApp } from "../src/index";
+import { logger } from "../src/utils/logger";
 
 describe("Management API Integration Tests", () => {
     const baseUrl = "http://localhost";
     const masterToken = "dev-master-token";
     let app: typeof baseApp;
 
-    beforeAll(async () => {
-        const routes = await registerAllRoutes();
-        app = baseApp.use(routes as unknown as typeof baseApp);
+    beforeAll(() => {
+        app = baseApp;
+    });
+
+    describe("validation error redaction", () => {
+        const loggerError = spyOn(logger, "error");
+
+        async function expectRedactedValidation(
+            target: Pick<typeof baseApp, "handle">,
+            request: Request,
+            sentinel: string,
+        ): Promise<void> {
+            loggerError.mockClear();
+            const response = await target.handle(request);
+            const responseText = await response.text();
+            const logged = JSON.stringify(loggerError.mock.calls);
+
+            expect({ status: response.status, body: responseText }).toEqual({
+                status: 400,
+                body: JSON.stringify({ message: "Validation failed", code: "VALIDATION_ERROR" }),
+            });
+            expect(JSON.parse(responseText)).toEqual({
+                message: "Validation failed",
+                code: "VALIDATION_ERROR",
+            });
+            expect(responseText).not.toContain(sentinel);
+            expect(logged).not.toContain(sentinel);
+        }
+
+        it("does not reflect an outer-route validation value into the response or logger", async () => {
+            const sentinel = "private-login-validation-sentinel";
+            await expectRedactedValidation(app, new Request(`${baseUrl}/auth/login`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ username: [sentinel], password: "irrelevant" }),
+            }), sentinel);
+        });
+
+        it("does not reflect an inner API validation value into the response or logger", async () => {
+            const sentinel = "private-type-validation-sentinel";
+            await expectRedactedValidation(app, new Request(
+                `${baseUrl}/v1/projects/proj_1/mutations/00000000-0000-4000-8000-000000000001/reconcile`,
+                {
+                    method: "POST",
+                    headers: {
+                        authorization: `Bearer ${masterToken}`,
+                        "content-type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        expected_fencing_epoch: 1,
+                        status: sentinel,
+                        response_status: 200,
+                        evidence: {
+                            source: "scheduled_functions.provider_readback",
+                            observed_at: "2026-08-12T00:00:00.000Z",
+                            evidence_code: "RESOURCE_PRESENT",
+                            evidence_fingerprint: "a".repeat(64),
+                        },
+                    }),
+                },
+            ), sentinel);
+        });
+
+        it("does not reflect a project-create validation value into the response or logger", async () => {
+            const sentinel = "private-project-create-validation-sentinel";
+            mockSql.mockClear();
+
+            await expectRedactedValidation(app, new Request(`${baseUrl}/v1/projects`, {
+                method: "POST",
+                headers: {
+                    authorization: `Bearer ${masterToken}`,
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({ name: [sentinel] }),
+            }), sentinel);
+
+            expect(mockSql).not.toHaveBeenCalled();
+        });
     });
 
     describe("GoTrue-only OpenAPI boundary", () => {

--- a/packages/management-api/src/db/init.ts
+++ b/packages/management-api/src/db/init.ts
@@ -19,6 +19,7 @@ import {
   migrateWebhookSecretsToControlStore,
 } from "./platform-v2";
 import { migrateAuditChainSequences } from "./audit-chain-migration";
+import { migrateProjectMutationJournal } from "./project-mutation-migration";
 import { migrateLegacyEncryptedSecretsInTransaction } from "./secret-key-migration";
 import { GOTRUE_USER_ID_POSTGRES_PATTERN } from "../utils/project-user-lifecycle";
 
@@ -741,6 +742,7 @@ export async function initDatabase() {
 
     await sql.begin(async (transaction) => {
       await ensurePlatformV2Schema(transaction);
+      await migrateProjectMutationJournal(transaction);
       await migrateAuditChainSequences(transaction);
       await migrateLegacyDeploymentHistory(transaction);
       await migrateLegacyControlSecrets(transaction);

--- a/packages/management-api/src/db/platform-v2.ts
+++ b/packages/management-api/src/db/platform-v2.ts
@@ -8,6 +8,7 @@ import {
   PROJECT_USER_LIFECYCLE_LOCK_NAMESPACE,
 } from "../utils/project-user-lifecycle";
 import { config } from "../config";
+import { migrateProjectMutationJournal } from "./project-mutation-migration";
 import { executeSqlStatements } from "./sql-statements";
 
 function configuredAuthAuthoritySql(): { backfill: string; constant: string } {
@@ -163,8 +164,7 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       project_ref VARCHAR(20) NOT NULL REFERENCES projects(ref) ON DELETE CASCADE,
       mutation_id UUID NOT NULL,
       operation VARCHAR(128) NOT NULL CHECK (operation ~ '^[a-z0-9][a-z0-9._:-]{0,127}$'),
-      resource_key VARCHAR(255)
-        CHECK (resource_key IS NULL OR resource_key ~ '^[A-Za-z0-9][A-Za-z0-9._:/-]{0,254}$'),
+      resource_key VARCHAR(255),
       request_fingerprint CHAR(64) NOT NULL CHECK (request_fingerprint ~ '^[0-9a-f]{64}$'),
       principal_type VARCHAR(20) NOT NULL
         CHECK (principal_type IN ('master', 'admin', 'project')),
@@ -186,7 +186,7 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       lease_token UUID,
       lease_expires_at TIMESTAMPTZ,
       fencing_epoch BIGINT NOT NULL DEFAULT 0 CHECK (fencing_epoch >= 0),
-      recovery_not_before TIMESTAMPTZ,
+      recovery_not_before TIMESTAMPTZ DEFAULT clock_timestamp(),
       completed_at TIMESTAMPTZ,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -199,18 +199,21 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       CHECK (
         (status IN ('succeeded', 'failed_terminal', 'outcome_unknown')) =
         (completed_at IS NOT NULL)
+      ),
+      CONSTRAINT project_mutations_succeeded_response_check CHECK (
+        status <> 'succeeded'
+        OR (response_status IS NOT NULL AND response_status BETWEEN 200 AND 299)
+      ),
+      CONSTRAINT project_mutations_recoverable_due_check CHECK (
+        status NOT IN ('pending', 'running', 'failed_retryable')
+        OR recovery_not_before IS NOT NULL
+      ),
+      CONSTRAINT project_mutations_fencing_epoch_safe_check CHECK (
+        fencing_epoch <= 9007199254740991
       )
     );
     ALTER TABLE project_mutations
       ADD COLUMN IF NOT EXISTS recovery_not_before TIMESTAMPTZ;
-    ALTER TABLE project_mutations
-      DROP CONSTRAINT IF EXISTS project_mutations_succeeded_response_check;
-    ALTER TABLE project_mutations
-      ADD CONSTRAINT project_mutations_succeeded_response_check
-      CHECK (
-        status <> 'succeeded'
-        OR (response_status IS NOT NULL AND response_status BETWEEN 200 AND 299)
-      );
     CREATE INDEX IF NOT EXISTS project_mutations_status_idx
       ON project_mutations(project_ref, status, updated_at DESC);
     CREATE INDEX IF NOT EXISTS project_mutations_recovery_idx
@@ -524,7 +527,10 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
 }
 
 export async function ensurePlatformV2SchemaInTransaction(controlPlaneDb: SQL): Promise<void> {
-  await controlPlaneDb.begin(async (transaction) => ensurePlatformV2Schema(transaction));
+  await controlPlaneDb.begin(async (transaction) => {
+    await ensurePlatformV2Schema(transaction);
+    await migrateProjectMutationJournal(transaction);
+  });
 }
 
 type LegacyWebhook = {

--- a/packages/management-api/src/db/project-mutation-migration.ts
+++ b/packages/management-api/src/db/project-mutation-migration.ts
@@ -1,0 +1,214 @@
+import type { SQL } from "bun";
+
+export const PROJECT_MUTATION_JOURNAL_MIGRATION_KEY = "20260812_project_mutation_journal_v3";
+
+const CANONICAL_RESOURCE_KEY_CONSTRAINT = "project_mutations_resource_key_canonical_v1_check";
+const FENCING_EPOCH_SAFE_CONSTRAINT = "project_mutations_fencing_epoch_safe_check";
+const CANONICAL_RESOURCE_KEY_PATTERN = "^v1/[a-z0-9][a-z0-9._-]{0,63}/[A-Za-z0-9_-]{2,171}$";
+const CANONICAL_RESOURCE_KEY_FUNCTION = "public.project_mutation_resource_key_is_canonical_v1";
+
+type ConstraintState = {
+  conname: string;
+  convalidated: boolean;
+};
+
+async function migrationIsCompleted(transaction: SQL): Promise<boolean> {
+  const [marker] = await transaction`
+    SELECT migration_key
+    FROM public.platform_schema_migrations
+    WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+  `;
+  return marker?.migration_key === PROJECT_MUTATION_JOURNAL_MIGRATION_KEY;
+}
+
+async function constraintState(transaction: SQL, name: string): Promise<ConstraintState | null> {
+  const [constraint] = await transaction`
+    SELECT conname, convalidated
+    FROM pg_catalog.pg_constraint
+    WHERE conrelid = 'public.project_mutations'::pg_catalog.regclass AND conname = ${name}
+  ` as ConstraintState[];
+  return constraint ?? null;
+}
+
+async function ensureSucceededResponseConstraint(transaction: SQL): Promise<void> {
+  const name = "project_mutations_succeeded_response_check";
+  const existing = await constraintState(transaction, name);
+  if (!existing) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      ADD CONSTRAINT project_mutations_succeeded_response_check
+      CHECK (
+        status <> 'succeeded'
+        OR (response_status IS NOT NULL AND response_status BETWEEN 200 AND 299)
+      ) NOT VALID
+    `);
+  }
+  if (!existing?.convalidated) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      VALIDATE CONSTRAINT project_mutations_succeeded_response_check
+    `);
+  }
+}
+
+async function ensureCanonicalResourceKeyFunction(transaction: SQL): Promise<void> {
+  await transaction.unsafe(`
+    CREATE OR REPLACE FUNCTION ${CANONICAL_RESOURCE_KEY_FUNCTION}(candidate TEXT)
+    RETURNS BOOLEAN
+    LANGUAGE plpgsql
+    IMMUTABLE
+    STRICT
+    SET search_path = pg_catalog
+    AS $$
+    DECLARE
+      encoded_id TEXT;
+      decoded_id BYTEA;
+      decoded_text TEXT;
+      canonical_id TEXT;
+    BEGIN
+      IF candidate !~ '${CANONICAL_RESOURCE_KEY_PATTERN}' THEN
+        RETURN FALSE;
+      END IF;
+      encoded_id := split_part(candidate, '/', 3);
+      IF length(encoded_id) % 4 = 1 THEN
+        RETURN FALSE;
+      END IF;
+      decoded_id := decode(
+        translate(encoded_id, '-_', '+/')
+          || repeat('=', (4 - length(encoded_id) % 4) % 4),
+        'base64'
+      );
+      canonical_id := translate(
+        rtrim(replace(encode(decoded_id, 'base64'), E'\\n', ''), '='),
+        '+/',
+        '-_'
+      );
+      IF canonical_id <> encoded_id OR octet_length(decoded_id) > 128 THEN
+        RETURN FALSE;
+      END IF;
+      decoded_text := convert_from(decoded_id, 'UTF8');
+      RETURN decoded_text = pg_catalog.btrim(
+        decoded_text,
+        U&'\\0009\\000A\\000B\\000C\\000D\\0020\\00A0\\1680\\2000\\2001\\2002\\2003\\2004\\2005\\2006\\2007\\2008\\2009\\200A\\2028\\2029\\202F\\205F\\3000\\FEFF'
+      )
+        AND decoded_text !~ '[[:cntrl:]]';
+    EXCEPTION
+      WHEN invalid_parameter_value OR character_not_in_repertoire THEN
+        -- Only malformed base64url and UTF-8 are recoverable validation failures.
+        RETURN FALSE;
+    END;
+    $$
+  `);
+}
+
+async function assertCanonicalResourceKeys(transaction: SQL): Promise<void> {
+  const [invalid] = await transaction`
+    SELECT mutation_id
+    FROM public.project_mutations AS mutation
+    WHERE mutation.resource_key IS NOT NULL
+      AND NOT public.project_mutation_resource_key_is_canonical_v1(mutation.resource_key)
+    LIMIT 1
+  ` as Array<{ mutation_id: string }>;
+  if (invalid) {
+    throw new Error("Project mutation migration requires canonical v1 resource keys");
+  }
+}
+
+async function ensureCanonicalResourceKeyConstraint(transaction: SQL): Promise<void> {
+  const existing = await constraintState(transaction, CANONICAL_RESOURCE_KEY_CONSTRAINT);
+  if (!existing) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      ADD CONSTRAINT ${CANONICAL_RESOURCE_KEY_CONSTRAINT}
+      CHECK (
+        resource_key IS NULL
+        OR ${CANONICAL_RESOURCE_KEY_FUNCTION}(resource_key)
+      ) NOT VALID
+    `);
+  }
+  if (!existing?.convalidated) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      VALIDATE CONSTRAINT ${CANONICAL_RESOURCE_KEY_CONSTRAINT}
+    `);
+  }
+}
+
+async function ensureFencingEpochSafeConstraint(transaction: SQL): Promise<void> {
+  const existing = await constraintState(transaction, FENCING_EPOCH_SAFE_CONSTRAINT);
+  if (!existing) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      ADD CONSTRAINT ${FENCING_EPOCH_SAFE_CONSTRAINT}
+      CHECK (fencing_epoch <= 9007199254740991) NOT VALID
+    `);
+  }
+  if (!existing?.convalidated) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      VALIDATE CONSTRAINT ${FENCING_EPOCH_SAFE_CONSTRAINT}
+    `);
+  }
+}
+
+async function backfillRecoverySchedule(transaction: SQL): Promise<number> {
+  const rows = await transaction`
+    UPDATE public.project_mutations
+    SET recovery_not_before = COALESCE(updated_at, created_at, clock_timestamp())
+    WHERE recovery_not_before IS NULL
+      AND status IN ('pending', 'running', 'failed_retryable')
+    RETURNING mutation_id
+  ` as Array<{ mutation_id: string }>;
+  return rows.length;
+}
+
+async function ensureRecoverableDueConstraint(transaction: SQL): Promise<void> {
+  const name = "project_mutations_recoverable_due_check";
+  const existing = await constraintState(transaction, name);
+  if (!existing) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      ADD CONSTRAINT project_mutations_recoverable_due_check
+      CHECK (
+        status NOT IN ('pending', 'running', 'failed_retryable')
+        OR recovery_not_before IS NOT NULL
+      ) NOT VALID
+    `);
+  }
+  if (!existing?.convalidated) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      VALIDATE CONSTRAINT project_mutations_recoverable_due_check
+    `);
+  }
+}
+
+async function recordMigration(transaction: SQL, backfilledRows: number): Promise<void> {
+  const details = JSON.stringify({ backfilled_recovery_rows: backfilledRows });
+  await transaction`
+    INSERT INTO public.platform_schema_migrations (migration_key, details)
+    VALUES (${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}, ${details}::jsonb)
+  `;
+}
+
+export async function migrateProjectMutationJournal(transaction: SQL): Promise<void> {
+  await transaction`
+    SELECT pg_catalog.pg_advisory_xact_lock(
+      pg_catalog.hashtext(${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY})
+    )
+  `;
+  if (await migrationIsCompleted(transaction)) return;
+
+  await ensureCanonicalResourceKeyFunction(transaction);
+  await assertCanonicalResourceKeys(transaction);
+  await transaction.unsafe(`
+    ALTER TABLE public.project_mutations
+    ALTER COLUMN recovery_not_before SET DEFAULT clock_timestamp()
+  `);
+  const backfilledRows = await backfillRecoverySchedule(transaction);
+  await ensureCanonicalResourceKeyConstraint(transaction);
+  await ensureFencingEpochSafeConstraint(transaction);
+  await ensureSucceededResponseConstraint(transaction);
+  await ensureRecoverableDueConstraint(transaction);
+  await recordMigration(transaction, backfilledRows);
+}

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -36,6 +36,7 @@ import { closeTaskWebSocket, messageTaskWebSocket, openTaskWebSocket } from "./r
 import { isS3DataPlaneRequest } from "./utils/storage-s3-paths";
 import { studioAuthRoutes } from "./routes/studio-auth";
 import { caddyAskRoutes } from "./routes/caddy-ask";
+import { validationErrorResponse } from "./utils/http-validation";
 
 function getWebConsoleDir(): string {
   return resolveWebConsoleDir();
@@ -302,6 +303,31 @@ async function ensureGatewayRoutesAfterServe(initialReady: boolean): Promise<voi
 }
 
 const app = new Elysia({ strictPath: false })
+  .onError({ as: "global" }, ({ code, error, set }) => {
+    if (code === "VALIDATION") {
+      return validationErrorResponse(set);
+    }
+    const { isAppError, toAppError } = require("./utils/errors") as typeof import("./utils/errors");
+
+    if (isAppError(error)) {
+      set.status = error.statusCode;
+      return error.toJSON();
+    }
+
+    logger.error(`Error [${code}]:`, error);
+
+    if (code === "NOT_FOUND") {
+      set.status = 404;
+      return { message: "Not found", code: "NOT_FOUND" };
+    }
+
+    const appError = toAppError(error);
+    set.status = appError.statusCode;
+    if (appError.statusCode === 503) {
+      set.headers["Retry-After"] = "5";
+    }
+    return appError.toJSON();
+  })
   // Swagger docs
   .use(
     swagger({
@@ -494,39 +520,6 @@ const app = new Elysia({ strictPath: false })
   .get("/monitor/health", async () => {
     const { HealthChecker } = await import("./infra/health");
     return await HealthChecker.runFullCheck();
-  })
-
-  // Error handling (with DB graceful degradation)
-  .onError(({ code, error, set }) => {
-    const { isAppError, toAppError } = require("./utils/errors") as typeof import("./utils/errors");
-
-    if (isAppError(error)) {
-      set.status = error.statusCode;
-      return error.toJSON();
-    }
-
-    logger.error(`Error [${code}]:`, error);
-
-    if (code === "VALIDATION") {
-      set.status = 400;
-      return {
-        message: "Validation failed",
-        code: "VALIDATION_ERROR",
-        details: error.message,
-      };
-    }
-
-    if (code === "NOT_FOUND") {
-      set.status = 404;
-      return { message: "Not found", code: "NOT_FOUND" };
-    }
-
-    const appError = toAppError(error);
-    set.status = appError.statusCode;
-    if (appError.statusCode === 503) {
-      set.headers["Retry-After"] = "5";
-    }
-    return appError.toJSON();
   });
 
 /**
@@ -774,7 +767,13 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
           await logAuditEvent({ request, status: Number(set.status || 200) });
         }
       })
-      .onError(async ({ request, code, error, set }) => {
+      .onError({ as: "global" }, async ({ request, code, error, set }) => {
+        if (code === "VALIDATION") {
+          if (shouldAuditRequest(request)) {
+            await logAuditEvent({ request, status: 400, action: "error:VALIDATION" });
+          }
+          return validationErrorResponse(set);
+        }
         if (shouldAuditRequest(request)) {
           await logAuditEvent({ request, status: Number(set.status || 500), action: `error:${code}` });
         }
@@ -784,10 +783,6 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
           return error.toJSON();
         }
         logger.error(`[API] Unhandled error [${code}]:`, error);
-        if (code === "VALIDATION") {
-          set.status = 400;
-          return { message: "Validation failed", code: "VALIDATION_ERROR", details: error.message };
-        }
         if (code === "NOT_FOUND") {
           set.status = 404;
           return { message: "Not found", code: "NOT_FOUND" };

--- a/packages/management-api/src/middleware/auth.ts
+++ b/packages/management-api/src/middleware/auth.ts
@@ -161,7 +161,7 @@ const CAPABILITY_FAMILY_RULES: readonly CapabilityFamilyRule[] = [
     prefixes: [
       "/auto-branching", "/backups", "/branches", "/dashboard", "/database", "/diagnostics",
       "/cache", "/extensions", "/frontend", "/functions", "/log-drains", "/logs", "/pg-meta", "/scaling",
-      "/pipelines", "/scheduled-functions", "/services", "/storage", "/task-events", "/tasks", "/types",
+      "/mutations", "/pipelines", "/scheduled-functions", "/services", "/storage", "/task-events", "/tasks", "/types",
     ],
     read: "operations.read",
     manage: "operations.manage",

--- a/packages/management-api/src/routes/project-crud.ts
+++ b/packages/management-api/src/routes/project-crud.ts
@@ -28,6 +28,7 @@ import {
   getAuthEmailTemplates,
   parseAuthEmailTemplatePatch,
 } from "../utils/auth-email-templates";
+import { validationErrorResponse } from "../utils/http-validation";
 
 // Available regions list
 const AVAILABLE_REGIONS = [
@@ -347,11 +348,8 @@ async function buildProjectResponse(
 
 export const projectCrudRoutes = new Elysia({ prefix: "/v1/projects" })
   .onError(({ code, error, set }) => {
+    if (code === "VALIDATION") return validationErrorResponse(set);
     logger.error(`[ProjectCRUD] Unhandled error [${code}]:`, error);
-    if (code === "VALIDATION") {
-      set.status = 400;
-      return { message: "Validation failed", code: "VALIDATION_ERROR", details: error.message };
-    }
     if (code === "NOT_FOUND") {
       set.status = 404;
       return { message: "Not found", code: "NOT_FOUND" };

--- a/packages/management-api/src/routes/project-mutations.ts
+++ b/packages/management-api/src/routes/project-mutations.ts
@@ -1,12 +1,111 @@
-import { Elysia, status } from "elysia";
-import { requireProjectOrAdminAuth } from "../middleware/auth";
+import { Elysia, status, t } from "elysia";
+import { getVerifiedRequestPrincipal, requireProjectOrAdminAuth } from "../middleware/auth";
+import { markRequestAuditCommitted } from "../services/audit.service";
 import {
+  isCanonicalMutationTimestamp,
   isProjectMutationId,
   publicProjectMutation,
   readProjectMutation,
+  type ReconcileProjectMutationInput,
+  type ReconcileProjectMutationResult,
 } from "../services/project-mutation.service";
+import { reconcileProjectMutationWithAudit } from "../services/project-mutation-reconciliation.service";
+import { resolveProxyClientIp } from "../utils/client-ip";
+import { VALIDATION_ERROR_BODY } from "../utils/http-validation";
 
 const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,20}$/;
+const EVIDENCE_SOURCE_PATTERN_TEXT = "^[a-z0-9][a-z0-9._:-]{0,127}$";
+const FAILURE_CODE_PATTERN_TEXT = "^[A-Z][A-Z0-9_]{0,63}$";
+const EVIDENCE_FINGERPRINT_PATTERN_TEXT = "^[0-9a-f]{64}$";
+const EVIDENCE_SOURCE_PATTERN = new RegExp(EVIDENCE_SOURCE_PATTERN_TEXT);
+const FAILURE_CODE_PATTERN = new RegExp(FAILURE_CODE_PATTERN_TEXT);
+const EVIDENCE_FINGERPRINT_PATTERN = new RegExp(EVIDENCE_FINGERPRINT_PATTERN_TEXT);
+const RECONCILIATION_KEYS = new Set([
+  "expected_fencing_epoch", "status", "response_status", "failure_code", "evidence",
+]);
+const EVIDENCE_KEYS = new Set(["source", "observed_at", "evidence_code", "evidence_fingerprint"]);
+
+type ReconciliationBody = {
+  expected_fencing_epoch: number;
+  status: "succeeded" | "failed_terminal";
+  response_status: number | null;
+  failure_code?: string | null;
+  evidence: {
+    source: string;
+    observed_at: string;
+    evidence_code: string;
+    evidence_fingerprint: string;
+  };
+};
+
+function reconciliationResponse(projectRef: string, reconciliation: ReconcileProjectMutationResult) {
+  if (reconciliation.kind === "updated") {
+    return { project_ref: projectRef, mutation: publicProjectMutation(reconciliation.mutation) };
+  }
+  if (reconciliation.kind === "not_found") return status(404, { error: "Mutation not found" });
+  if (reconciliation.kind === "forbidden") {
+    return status(403, { error: "Mutation reconciliation is not permitted" });
+  }
+  if (reconciliation.kind === "invalid_evidence_time") {
+    return status(400, { error: "Evidence timestamp is outside the reconciliation window" });
+  }
+  if (reconciliation.kind === "cas_conflict") {
+    return status(409, { error: "Mutation fencing epoch changed" });
+  }
+  return status(409, { error: `Mutation status '${reconciliation.mutation.status}' cannot be reconciled` });
+}
+
+function plainRecord(candidate: unknown): candidate is Record<string, unknown> {
+  return Boolean(candidate) && typeof candidate === "object" && !Array.isArray(candidate);
+}
+
+function hasOnlyKeys(record: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(record).every((key) => allowed.has(key));
+}
+
+function validReconciliationEvidence(candidate: unknown): boolean {
+  if (!plainRecord(candidate) || !hasOnlyKeys(candidate, EVIDENCE_KEYS)) return false;
+  return typeof candidate.source === "string" && EVIDENCE_SOURCE_PATTERN.test(candidate.source)
+    && typeof candidate.observed_at === "string" && isCanonicalMutationTimestamp(candidate.observed_at)
+    && typeof candidate.evidence_code === "string" && FAILURE_CODE_PATTERN.test(candidate.evidence_code)
+    && typeof candidate.evidence_fingerprint === "string"
+    && EVIDENCE_FINGERPRINT_PATTERN.test(candidate.evidence_fingerprint);
+}
+
+function validReconciliationBody(candidate: unknown): candidate is ReconciliationBody {
+  if (!plainRecord(candidate) || !hasOnlyKeys(candidate, RECONCILIATION_KEYS)) return false;
+  if (!Number.isSafeInteger(candidate.expected_fencing_epoch)
+    || Number(candidate.expected_fencing_epoch) < 1) return false;
+  if (candidate.status !== "succeeded" && candidate.status !== "failed_terminal") return false;
+  if (candidate.response_status !== null
+    && (!Number.isInteger(candidate.response_status)
+      || Number(candidate.response_status) < 100 || Number(candidate.response_status) > 599)) return false;
+  if (candidate.failure_code !== undefined && candidate.failure_code !== null
+    && (typeof candidate.failure_code !== "string" || !FAILURE_CODE_PATTERN.test(candidate.failure_code))) return false;
+  if (!validReconciliationEvidence(candidate.evidence)) return false;
+  if (candidate.status === "succeeded") {
+    return Number(candidate.response_status) >= 200 && Number(candidate.response_status) <= 299
+      && candidate.failure_code == null;
+  }
+  return typeof candidate.failure_code === "string";
+}
+
+function reconciliationInput(
+  projectRef: string,
+  mutationId: string,
+  body: ReconciliationBody,
+): ReconcileProjectMutationInput {
+  return {
+    projectRef, mutationId, expectedFencingEpoch: body.expected_fencing_epoch,
+    status: body.status, responseStatus: body.response_status, failureCode: body.failure_code,
+    evidence: {
+      source: body.evidence.source,
+      observedAt: body.evidence.observed_at,
+      evidenceCode: body.evidence.evidence_code,
+      evidenceFingerprint: body.evidence.evidence_fingerprint,
+    },
+  };
+}
 
 export const projectMutationRoutes = new Elysia({ prefix: "/v1/projects/:ref/mutations" })
   .onBeforeHandle(async ({ params, request }) => {
@@ -26,4 +125,27 @@ export const projectMutationRoutes = new Elysia({ prefix: "/v1/projects/:ref/mut
     return { project_ref: params.ref, mutation: publicProjectMutation(mutation) };
   }, {
     detail: { tags: ["mutations"], summary: "Read a durable project mutation" },
+  })
+  .post("/:mutationId/reconcile", async ({ params, body, request }) => {
+    if (!isProjectMutationId(params.mutationId)) {
+      return status(400, { error: "mutation_id must be a UUIDv4" });
+    }
+    if (!validReconciliationBody(body)) {
+      return status(400, VALIDATION_ERROR_BODY);
+    }
+    const input = reconciliationInput(params.ref, params.mutationId, body);
+    const actor = await getVerifiedRequestPrincipal(request);
+    if (!actor) return status(401, { error: "Authentication required" });
+    const reconciliation = await reconcileProjectMutationWithAudit({
+      mutation: input,
+      actor,
+      requestId: request.headers.get("x-request-id")?.trim() || crypto.randomUUID(),
+      ipAddress: resolveProxyClientIp(request),
+      userAgent: request.headers.get("user-agent"),
+    });
+    if (reconciliation.kind === "updated") markRequestAuditCommitted(request);
+    return reconciliationResponse(params.ref, reconciliation);
+  }, {
+    body: t.Unknown(),
+    detail: { tags: ["mutations"], summary: "Reconcile an outcome-unknown project mutation" },
   });

--- a/packages/management-api/src/services/audit.service.ts
+++ b/packages/management-api/src/services/audit.service.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import type { SQL } from "bun";
 import { sql } from "../db";
 import { acquireAuditChainAppendLock } from "../db/audit-chain-lock";
 import { getVerifiedRequestPrincipal } from "../middleware/auth";
@@ -12,18 +13,20 @@ const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const SENSITIVE_KEYS = new Set([
   "authorization", "cookie", "token", "accesstoken", "refreshtoken", "idtoken",
   "password", "smtppass", "secret", "secrets", "clientsecret", "apikey",
-  "privatekey", "code", "verifier", "codeverifier",
+  "privatekey", "code", "verifier", "codeverifier", "jwt", "session", "signingkey",
 ]);
 const SENSITIVE_NAME_PATTERN = [
   "authorization", "cookie", "access[_-]?token", "refresh[_-]?token", "id[_-]?token",
   "token", "password", "smtp[_-]?pass", "secrets?", "client[_-]?secret",
   "api[_-]?key", "private[_-]?key", "code[_-]?verifier", "verifier", "code",
+  "jwt", "session", "signing[_-]?key",
 ].join("|");
 const BEARER_PATTERN = /\b(bearer\s+)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)/gi;
 const SECRET_ASSIGNMENT_PATTERN = new RegExp(
   `((?:["']?(?:${SENSITIVE_NAME_PATTERN})["']?)\\s*[:=]\\s*)("(?:\\\\.|[^"\\\\])*"|'(?:\\\\.|[^'\\\\])*'|[^\\s,;&#}\\]]+)`,
   "gi",
 );
+const transactionallyAuditedRequests = new WeakSet<Request>();
 
 function isSensitiveKey(key: string): boolean {
   const normalized = key.replaceAll("_", "").replaceAll("-", "").toLowerCase();
@@ -251,72 +254,124 @@ export function verifyAuditChain(
 
 export function shouldAuditRequest(request: Request): boolean {
   const url = new URL(request.url);
-  return url.pathname.startsWith("/v1") && WRITE_METHODS.has(request.method.toUpperCase());
+  return !transactionallyAuditedRequests.has(request)
+    && url.pathname.startsWith("/v1")
+    && WRITE_METHODS.has(request.method.toUpperCase());
+}
+
+export function markRequestAuditCommitted(request: Request): void {
+  transactionallyAuditedRequests.add(request);
+}
+
+type PreparedAuditAppend = {
+  id: string;
+  projectChainKey: string;
+  metadata: Record<string, unknown>;
+  source: string;
+};
+
+type PreparedAuditRow = {
+  previousHash: string | null;
+  chainSequence: number;
+  createdAt: Date;
+  hash: string;
+};
+
+function prepareAuditAppend(input: AppendAuditEventInput): PreparedAuditAppend {
+  return {
+    id: crypto.randomUUID(),
+    projectChainKey: input.projectRef || "__platform__",
+    metadata: redactAuditValue(input.metadata || {}) as Record<string, unknown>,
+    source: input.source || "management-api",
+  };
+}
+
+async function lockedAuditCheckpoint(transaction: SQL, projectChainKey: string) {
+  await acquireAuditChainAppendLock(transaction);
+  await transaction`SELECT pg_advisory_xact_lock(hashtext(${`audit-chain:${projectChainKey}`}))`;
+  const [checkpoint] = await transaction`
+    SELECT last_event_hash, event_count
+    FROM audit_log_checkpoints
+    WHERE project_ref = ${projectChainKey}
+    FOR UPDATE
+  `;
+  return checkpoint;
+}
+
+function prepareAuditRow(
+  input: AppendAuditEventInput,
+  append: PreparedAuditAppend,
+  checkpoint: Record<string, unknown> | undefined,
+): PreparedAuditRow {
+  const previousHash = typeof checkpoint?.last_event_hash === "string"
+    ? checkpoint.last_event_hash
+    : null;
+  const chainSequence = Number(checkpoint?.event_count || 0) + 1;
+  const createdAt = new Date();
+  const hash = auditEventHash({
+    id: append.id, project_ref: input.projectRef, actor: input.actor, actor_type: input.actorType,
+    action: input.action, method: input.method, path: input.path, status: input.status ?? null,
+    request_id: input.requestId, source: append.source, metadata: append.metadata,
+    created_at: createdAt, previous_hash: previousHash, chain_sequence: chainSequence,
+  });
+  return { previousHash, chainSequence, createdAt, hash };
+}
+
+async function insertAuditRow(
+  transaction: SQL,
+  input: AppendAuditEventInput,
+  append: PreparedAuditAppend,
+  row: PreparedAuditRow,
+) {
+  const [inserted] = await transaction`
+    INSERT INTO audit_logs (
+      id, project_ref, actor, actor_type, action, method, path, status,
+      ip_address, user_agent, request_id, metadata, source,
+      previous_hash, event_hash, chain_sequence, created_at
+    ) VALUES (
+      ${append.id}, ${input.projectRef}, ${input.actor}, ${input.actorType}, ${input.action},
+      ${input.method}, ${input.path}, ${input.status ?? null}, ${input.ipAddress ?? null},
+      ${input.userAgent || ""}, ${input.requestId}, ${JSON.stringify(append.metadata)}::jsonb,
+      ${append.source}, ${row.previousHash}, ${row.hash}, ${row.chainSequence}, ${row.createdAt}
+    )
+    RETURNING *
+  `;
+  return inserted;
+}
+
+async function advanceAuditCheckpoint(
+  transaction: SQL,
+  append: PreparedAuditAppend,
+  row: PreparedAuditRow,
+): Promise<void> {
+  await transaction`
+    INSERT INTO audit_log_checkpoints (
+      project_ref, last_event_id, last_event_hash, event_count, updated_at
+    ) VALUES (
+      ${append.projectChainKey}, ${append.id}, ${row.hash}, ${row.chainSequence}, NOW()
+    )
+    ON CONFLICT (project_ref) DO UPDATE SET
+      last_event_id = EXCLUDED.last_event_id,
+      last_event_hash = EXCLUDED.last_event_hash,
+      event_count = EXCLUDED.event_count,
+      updated_at = NOW()
+  `;
+}
+
+export async function appendAuditEventInTransaction(
+  transaction: SQL,
+  input: AppendAuditEventInput,
+) {
+  const append = prepareAuditAppend(input);
+  const checkpoint = await lockedAuditCheckpoint(transaction, append.projectChainKey);
+  const row = prepareAuditRow(input, append, checkpoint);
+  const inserted = await insertAuditRow(transaction, input, append, row);
+  await advanceAuditCheckpoint(transaction, append, row);
+  return inserted;
 }
 
 export async function appendAuditEvent(input: AppendAuditEventInput) {
-  const id = crypto.randomUUID();
-  const projectChainKey = input.projectRef || "__platform__";
-  const metadata = redactAuditValue(input.metadata || {}) as Record<string, unknown>;
-  const source = input.source || "management-api";
-
-  return sql.begin(async (tx) => {
-    await acquireAuditChainAppendLock(tx);
-    await tx`SELECT pg_advisory_xact_lock(hashtext(${`audit-chain:${projectChainKey}`}))`;
-    const [checkpoint] = await tx`
-      SELECT last_event_hash, event_count
-      FROM audit_log_checkpoints
-      WHERE project_ref = ${projectChainKey}
-      FOR UPDATE
-    `;
-    const previousHash = typeof checkpoint?.last_event_hash === "string"
-      ? checkpoint.last_event_hash
-      : null;
-    const chainSequence = Number(checkpoint?.event_count || 0) + 1;
-    const createdAt = new Date();
-    const hash = auditEventHash({
-      id,
-      project_ref: input.projectRef,
-      actor: input.actor,
-      actor_type: input.actorType,
-      action: input.action,
-      method: input.method,
-      path: input.path,
-      status: input.status ?? null,
-      request_id: input.requestId,
-      source,
-      metadata,
-      created_at: createdAt,
-      previous_hash: previousHash,
-      chain_sequence: chainSequence,
-    });
-    const [row] = await tx`
-      INSERT INTO audit_logs (
-        id, project_ref, actor, actor_type, action, method, path, status,
-        ip_address, user_agent, request_id, metadata, source,
-        previous_hash, event_hash, chain_sequence, created_at
-      ) VALUES (
-        ${id}, ${input.projectRef}, ${input.actor}, ${input.actorType}, ${input.action},
-        ${input.method}, ${input.path}, ${input.status ?? null}, ${input.ipAddress ?? null},
-        ${input.userAgent || ""}, ${input.requestId}, ${JSON.stringify(metadata)}::jsonb,
-        ${source}, ${previousHash}, ${hash}, ${chainSequence}, ${createdAt}
-      )
-      RETURNING *
-    `;
-    await tx`
-      INSERT INTO audit_log_checkpoints (
-        project_ref, last_event_id, last_event_hash, event_count, updated_at
-      ) VALUES (
-        ${projectChainKey}, ${id}, ${hash}, ${chainSequence}, NOW()
-      )
-      ON CONFLICT (project_ref) DO UPDATE SET
-        last_event_id = EXCLUDED.last_event_id,
-        last_event_hash = EXCLUDED.last_event_hash,
-        event_count = EXCLUDED.event_count,
-        updated_at = NOW()
-    `;
-    return row;
-  });
+  return sql.begin((transaction) => appendAuditEventInTransaction(transaction, input));
 }
 
 export async function verifyProjectAuditIntegrity(projectRef: string): Promise<AuditIntegrityResult> {

--- a/packages/management-api/src/services/project-mutation-reconciliation.service.ts
+++ b/packages/management-api/src/services/project-mutation-reconciliation.service.ts
@@ -1,0 +1,57 @@
+import { sql } from "../db";
+import {
+  appendAuditEventInTransaction,
+  type AppendAuditEventInput,
+} from "./audit.service";
+import {
+  reconcileProjectMutation,
+  type MutationPrincipal,
+  type ReconcileProjectMutationInput,
+  type ReconcileProjectMutationResult,
+} from "./project-mutation.service";
+
+export interface ReconcileProjectMutationCommand {
+  mutation: ReconcileProjectMutationInput;
+  actor: MutationPrincipal;
+  requestId: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+}
+
+function reconciliationAuditEvent(
+  command: ReconcileProjectMutationCommand,
+): AppendAuditEventInput {
+  const mutation = command.mutation;
+  return {
+    projectRef: mutation.projectRef,
+    actor: command.actor.id,
+    actorType: command.actor.type,
+    action: "project_mutation.reconciled",
+    method: "POST",
+    path: `/v1/projects/${mutation.projectRef}/mutations/${mutation.mutationId}/reconcile`,
+    status: 200,
+    ipAddress: command.ipAddress,
+    userAgent: command.userAgent,
+    requestId: command.requestId,
+    metadata: {
+      mutation_id: mutation.mutationId,
+      target_status: mutation.status,
+      fencing_epoch: mutation.expectedFencingEpoch,
+    },
+  };
+}
+
+export async function reconcileProjectMutationWithAudit(
+  command: ReconcileProjectMutationCommand,
+): Promise<ReconcileProjectMutationResult> {
+  return sql.begin(async (transaction) => {
+    const reconciliation = await reconcileProjectMutation(
+      transaction,
+      command.actor,
+      command.mutation,
+    );
+    if (reconciliation.kind !== "updated") return reconciliation;
+    await appendAuditEventInTransaction(transaction, reconciliationAuditEvent(command));
+    return reconciliation;
+  });
+}

--- a/packages/management-api/src/services/project-mutation.service.ts
+++ b/packages/management-api/src/services/project-mutation.service.ts
@@ -5,19 +5,25 @@ import { stableSha256 } from "../utils/stable-json";
 const MUTATION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/;
 const OPERATION_PATTERN = /^[a-z0-9][a-z0-9._:-]{0,127}$/;
-const RESOURCE_KEY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,254}$/;
+const RESOURCE_TYPE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const RESOURCE_KEY_PATTERN = /^v1\/[a-z0-9][a-z0-9._-]{0,63}\/[A-Za-z0-9_-]{2,171}$/;
 const FAILURE_CODE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
 const LEASE_OWNER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,254}$/;
 const PRINCIPAL_ID_PATTERN = /^[^\u0000-\u001f\u007f]{1,320}$/u;
+const RESOURCE_ID_PATTERN = /^[^\u0000-\u001f\u007f-\u009f]+$/u;
+const CANONICAL_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const MAX_PUBLIC_PAYLOAD_BYTES = 65_536;
 const MAX_JSON_DEPTH = 32;
 const MAX_RECOVERY_OPERATIONS = 32;
 const MAX_RECOVERY_CLAIMS = 100;
+const MAX_RESOURCE_ID_BYTES = 128;
+const MAX_EVIDENCE_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const MAX_FENCING_EPOCH = Number.MAX_SAFE_INTEGER;
 const SENSITIVE_PROJECTION_KEYS = new Set([
   "authorization", "cookie", "body", "headers", "password", "secret", "secrets",
   "token", "accesstoken", "refreshtoken", "idtoken", "apikey", "servicerolekey",
   "privatekey", "code", "sourcecode", "codebytes", "bundle", "requestbody", "requestheaders",
-  "credential", "credentials", "credentialvalue",
+  "credential", "credentials", "credentialvalue", "jwt", "session", "signingkey",
 ]);
 
 export function isProjectMutationId(candidate: unknown): candidate is string {
@@ -34,6 +40,11 @@ export type ProjectMutationStatus =
 
 export interface MutationPrincipal {
   type: "master" | "admin" | "project";
+  id: string;
+}
+
+export interface ProjectMutationResource {
+  type: string;
   id: string;
 }
 
@@ -84,11 +95,15 @@ interface StoredMutationWithLeaseState extends StoredProjectMutationRow {
   lease_active: boolean;
 }
 
+interface StoredReconciliationRow extends StoredProjectMutationRow {
+  database_now: Date | string;
+}
+
 export interface BeginProjectMutationInput {
   projectRef: string;
   mutationId: string;
   operation: string;
-  resourceKey?: string;
+  resource?: ProjectMutationResource;
   requestFingerprint: string;
   principal: MutationPrincipal;
 }
@@ -124,7 +139,7 @@ export interface MutationLeaseInput {
 export interface CheckpointProjectMutationInput extends MutationLeaseInput {
   checkpoint: Record<string, unknown>;
   leaseSeconds: number;
-  recoveryNotBefore?: Date | string | null;
+  recoveryNotBefore?: Date | string;
 }
 
 export interface CompleteProjectMutationSuccessInput extends MutationLeaseInput {
@@ -137,8 +152,33 @@ export interface CompleteProjectMutationFailureInput extends MutationLeaseInput 
   failureCode: string;
   receipt?: Record<string, unknown>;
   responseStatus?: number;
-  recoveryNotBefore?: Date | string | null;
+  recoveryNotBefore?: Date | string;
 }
+
+export interface ProjectMutationReconciliationEvidence {
+  source: string;
+  observedAt: string;
+  evidenceCode: string;
+  evidenceFingerprint: string;
+}
+
+export interface ReconcileProjectMutationInput {
+  projectRef: string;
+  mutationId: string;
+  expectedFencingEpoch: number;
+  status: "succeeded" | "failed_terminal";
+  responseStatus: number | null;
+  failureCode?: string | null;
+  evidence: ProjectMutationReconciliationEvidence;
+}
+
+export type ReconcileProjectMutationResult =
+  | { kind: "updated"; mutation: ProjectMutationState }
+  | { kind: "not_found" }
+  | { kind: "forbidden" }
+  | { kind: "invalid_evidence_time" }
+  | { kind: "not_reconcilable"; mutation: ProjectMutationState }
+  | { kind: "cas_conflict"; mutation: ProjectMutationState };
 
 export interface ClaimRecoverableProjectMutationsInput {
   operations: readonly string[];
@@ -232,13 +272,46 @@ export function projectMutationFingerprint(normalizedRequest: unknown): string {
   return stableSha256(normalizedRequest);
 }
 
+export function isCanonicalMutationTimestamp(candidate: string): boolean {
+  if (!CANONICAL_TIMESTAMP_PATTERN.test(candidate)) return false;
+  const milliseconds = Date.parse(candidate);
+  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === candidate;
+}
+
+function canonicalResourceId(resourceId: string): string {
+  if (!RESOURCE_ID_PATTERN.test(resourceId) || resourceId.trim() !== resourceId) {
+    throw new Error("Mutation resource id is invalid");
+  }
+  const encoded = Buffer.from(resourceId, "utf8");
+  if (encoded.toString("utf8") !== resourceId) {
+    throw new Error("Mutation resource id must contain well-formed Unicode");
+  }
+  if (encoded.byteLength > MAX_RESOURCE_ID_BYTES) {
+    throw new Error("Mutation resource id exceeds 128 bytes");
+  }
+  return encoded.toString("base64url");
+}
+
+export function projectMutationResourceKey(resource: ProjectMutationResource): string {
+  if (!RESOURCE_TYPE_PATTERN.test(resource.type)) throw new Error("Mutation resource type is invalid");
+  return `v1/${resource.type}/${canonicalResourceId(resource.id)}`;
+}
+
 function timestamp(value: Date | string | null): string | null {
   if (value === null) return null;
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
 
-function recoveryTimestamp(value: Date | string | null | undefined): Date | null | undefined {
-  if (value === null || value === undefined) return value;
+function storedFencingEpoch(candidate: number | string, minimum: 0 | 1): number {
+  const epoch = Number(candidate);
+  if (!Number.isSafeInteger(epoch) || epoch < minimum || epoch > MAX_FENCING_EPOCH) {
+    throw new Error("Stored mutation fencing epoch is invalid");
+  }
+  return epoch;
+}
+
+function recoveryTimestamp(value: Date | string | undefined): Date | undefined {
+  if (value === undefined) return undefined;
   const parsed = value instanceof Date ? value : new Date(value);
   if (!Number.isFinite(parsed.getTime())) throw new Error("Mutation recovery timestamp is invalid");
   return parsed;
@@ -271,7 +344,7 @@ function projectMutationState(row: StoredProjectMutationRow): ProjectMutationSta
     failureCode: row.failure_code,
     leaseOwner: row.lease_owner,
     leaseExpiresAt: timestamp(row.lease_expires_at),
-    fencingEpoch: Number(row.fencing_epoch),
+    fencingEpoch: storedFencingEpoch(row.fencing_epoch, 0),
     completedAt: timestamp(row.completed_at),
     createdAt: timestamp(row.created_at)!,
     updatedAt: timestamp(row.updated_at)!,
@@ -292,9 +365,10 @@ function assertLeaseSeconds(leaseSeconds: number): void {
 function assertBeginInput(input: BeginProjectMutationInput): void {
   assertMutationIdentity(input.projectRef, input.mutationId);
   if (!OPERATION_PATTERN.test(input.operation)) throw new Error("Mutation operation is invalid");
-  if (input.resourceKey !== undefined && !RESOURCE_KEY_PATTERN.test(input.resourceKey)) {
-    throw new Error("Mutation resource key is invalid");
+  if (Object.hasOwn(input, "resourceKey")) {
+    throw new Error("Mutation resources must use the structured resource contract");
   }
+  if (input.resource) projectMutationResourceKey(input.resource);
   if (!FINGERPRINT_PATTERN.test(input.requestFingerprint)) throw new Error("Mutation fingerprint is invalid");
   if (!PRINCIPAL_ID_PATTERN.test(input.principal.id) || input.principal.id.trim() !== input.principal.id) {
     throw new Error("Mutation principal is invalid");
@@ -331,8 +405,8 @@ async function activeResourceMutation(
 function existingMutationResult(
   row: StoredProjectMutationRow,
   input: BeginProjectMutationInput,
+  resourceKey: string | null,
 ): BeginProjectMutationResult {
-  const resourceKey = input.resourceKey ?? null;
   if (row.request_fingerprint !== input.requestFingerprint
     || row.operation !== input.operation || row.resource_key !== resourceKey) {
     return { kind: "fingerprint_conflict" };
@@ -346,14 +420,15 @@ function existingMutationResult(
 async function insertProjectMutation(
   transaction: SQL,
   input: BeginProjectMutationInput,
+  resourceKey: string | null,
 ): Promise<StoredProjectMutationRow | null> {
   const [inserted] = await transaction`
     INSERT INTO project_mutations (
       project_ref, mutation_id, operation, resource_key, request_fingerprint,
-      principal_type, principal_id
+      principal_type, principal_id, recovery_not_before
     ) VALUES (
-      ${input.projectRef}, ${input.mutationId}, ${input.operation}, ${input.resourceKey ?? null},
-      ${input.requestFingerprint}, ${input.principal.type}, ${input.principal.id}
+      ${input.projectRef}, ${input.mutationId}, ${input.operation}, ${resourceKey},
+      ${input.requestFingerprint}, ${input.principal.type}, ${input.principal.id}, clock_timestamp()
     )
     ON CONFLICT DO NOTHING
     RETURNING *
@@ -366,13 +441,14 @@ export async function beginProjectMutation(
   input: BeginProjectMutationInput,
 ): Promise<BeginProjectMutationResult> {
   assertBeginInput(input);
-  const inserted = await insertProjectMutation(transaction, input);
+  const resourceKey = input.resource ? projectMutationResourceKey(input.resource) : null;
+  const inserted = await insertProjectMutation(transaction, input, resourceKey);
   if (inserted) return { kind: "started", mutation: projectMutationState(inserted) };
 
   const existing = await lockedMutation(transaction, input.projectRef, input.mutationId);
-  if (existing) return existingMutationResult(existing, input);
-  if (input.resourceKey) {
-    const blocker = await activeResourceMutation(transaction, input.projectRef, input.resourceKey);
+  if (existing) return existingMutationResult(existing, input, resourceKey);
+  if (resourceKey) {
+    const blocker = await activeResourceMutation(transaction, input.projectRef, resourceKey);
     if (blocker) return { kind: "resource_busy", mutationId: blocker.mutation_id, status: blocker.status };
   }
   throw new Error("Mutation insert conflicted without a durable conflicting record");
@@ -390,7 +466,7 @@ async function lockedMutationLeaseState(
   input: ClaimProjectMutationInput,
 ): Promise<StoredMutationWithLeaseState | null> {
   const [row] = await transaction`
-    SELECT *, COALESCE(lease_expires_at > NOW(), false) AS lease_active
+    SELECT *, COALESCE(lease_expires_at > clock_timestamp(), false) AS lease_active
     FROM project_mutations
     WHERE project_ref = ${input.projectRef} AND mutation_id = ${input.mutationId}
     FOR UPDATE
@@ -403,13 +479,16 @@ function unclaimedMutationResult(
   input: ClaimProjectMutationInput,
 ): ClaimProjectMutationResult {
   const mutation = projectMutationState(row);
-  if (row.status === "running" && row.lease_active
-    && row.lease_owner === input.leaseOwner && row.lease_token === input.leaseToken) {
-    return { kind: "claimed", mutation };
+  if (row.status === "running" && row.lease_active) {
+    return row.lease_owner === input.leaseOwner && row.lease_token === input.leaseToken
+      ? { kind: "claimed", mutation }
+      : { kind: "busy", mutation };
   }
-  if (row.status === "running") return { kind: "busy", mutation };
   if (["succeeded", "failed_terminal", "outcome_unknown"].includes(row.status)) {
     return { kind: "terminal", mutation };
+  }
+  if (Number(row.fencing_epoch) >= MAX_FENCING_EPOCH) {
+    throw new Error("Mutation fencing epoch is exhausted");
   }
   throw new Error(`Mutation status '${row.status}' could not be claimed`);
 }
@@ -422,11 +501,12 @@ export async function claimOrResumeProjectMutation(
   const [claimed] = await transaction`
     UPDATE project_mutations
     SET status = 'running', lease_owner = ${input.leaseOwner}, lease_token = ${input.leaseToken},
-        lease_expires_at = NOW() + (${input.leaseSeconds} * INTERVAL '1 second'),
-        fencing_epoch = fencing_epoch + 1, completed_at = NULL, updated_at = NOW()
+        lease_expires_at = clock_timestamp() + (${input.leaseSeconds} * INTERVAL '1 second'),
+        fencing_epoch = fencing_epoch + 1, completed_at = NULL, updated_at = clock_timestamp()
     WHERE project_ref = ${input.projectRef} AND mutation_id = ${input.mutationId}
+      AND fencing_epoch < 9007199254740991
       AND (status IN ('pending', 'failed_retryable')
-        OR (status = 'running' AND lease_expires_at <= NOW()))
+        OR (status = 'running' AND lease_expires_at <= clock_timestamp()))
     RETURNING *
   ` as StoredProjectMutationRow[];
   if (claimed) return { kind: "claimed", mutation: projectMutationState(claimed) };
@@ -453,10 +533,7 @@ function recoverableMutationClaim(row: StoredRecoverableMutationClaimRow): Recov
     throw new Error("Stored mutation resource key is invalid");
   }
   if (!isProjectMutationId(row.lease_token)) throw new Error("Stored mutation lease token is invalid");
-  const fencingEpoch = Number(row.fencing_epoch);
-  if (!Number.isSafeInteger(fencingEpoch) || fencingEpoch < 1) {
-    throw new Error("Stored mutation fencing epoch is invalid");
-  }
+  const fencingEpoch = storedFencingEpoch(row.fencing_epoch, 1);
   const checkpoint = publicJsonRecord(row.checkpoint);
   return {
     projectRef: row.project_ref, mutationId: row.mutation_id, operation: row.operation,
@@ -475,18 +552,19 @@ async function claimRecoverableRows(
       SELECT project_ref, mutation_id
       FROM project_mutations
       WHERE operation = ANY(${operations})
+        AND fencing_epoch < 9007199254740991
         AND recovery_not_before IS NOT NULL
-        AND recovery_not_before <= NOW()
+        AND recovery_not_before <= clock_timestamp()
         AND (status IN ('pending', 'failed_retryable')
-          OR (status = 'running' AND lease_expires_at <= NOW()))
+          OR (status = 'running' AND lease_expires_at <= clock_timestamp()))
       ORDER BY recovery_not_before ASC, updated_at ASC, project_ref ASC, mutation_id ASC
       FOR UPDATE SKIP LOCKED
       LIMIT ${input.limit}
     )
     UPDATE project_mutations AS mutation
     SET status = 'running', lease_owner = ${input.leaseOwner}, lease_token = gen_random_uuid(),
-        lease_expires_at = NOW() + (${input.leaseSeconds} * INTERVAL '1 second'),
-        fencing_epoch = mutation.fencing_epoch + 1, completed_at = NULL, updated_at = NOW()
+        lease_expires_at = clock_timestamp() + (${input.leaseSeconds} * INTERVAL '1 second'),
+        fencing_epoch = mutation.fencing_epoch + 1, completed_at = NULL, updated_at = clock_timestamp()
     FROM candidates
     WHERE mutation.project_ref = candidates.project_ref
       AND mutation.mutation_id = candidates.mutation_id
@@ -529,10 +607,12 @@ export async function checkpointProjectMutation(
     SET checkpoint = ${input.checkpoint}::jsonb,
         recovery_not_before = CASE WHEN ${preserveRecoveryTime}
           THEN recovery_not_before ELSE ${recoveryNotBefore ?? null}::timestamptz END,
-        lease_expires_at = NOW() + (${input.leaseSeconds} * INTERVAL '1 second'), updated_at = NOW()
+        lease_expires_at = clock_timestamp() + (${input.leaseSeconds} * INTERVAL '1 second'),
+        updated_at = clock_timestamp()
     WHERE project_ref = ${input.projectRef} AND mutation_id = ${input.mutationId}
       AND status = 'running' AND lease_token = ${input.leaseToken}
       AND fencing_epoch = ${input.fencingEpoch}
+      AND lease_expires_at > clock_timestamp()
     RETURNING mutation_id
   ` as Array<{ mutation_id: string }>;
   return updated ? "updated" : "lease_lost";
@@ -576,11 +656,12 @@ async function finishProjectMutation(
         recovery_not_before = CASE WHEN ${preserveRecoveryTime}
           THEN recovery_not_before ELSE ${input.recoveryNotBefore ?? null}::timestamptz END,
         completed_at = CASE WHEN ${input.status} IN ('succeeded', 'failed_terminal', 'outcome_unknown')
-          THEN NOW() ELSE NULL END,
-        updated_at = NOW()
+          THEN clock_timestamp() ELSE NULL END,
+        updated_at = clock_timestamp()
     WHERE project_ref = ${input.projectRef} AND mutation_id = ${input.mutationId}
       AND status = 'running' AND lease_token = ${input.leaseToken}
       AND fencing_epoch = ${input.fencingEpoch}
+      AND lease_expires_at > clock_timestamp()
     RETURNING mutation_id
   ` as Array<{ mutation_id: string }>;
   return updated ? "updated" : "lease_lost";
@@ -611,6 +692,102 @@ export async function completeProjectMutationFailure(
     receipt: input.receipt ?? {},
     responseStatus: input.responseStatus ?? null,
   });
+}
+
+function reconciliationReceipt(input: ReconcileProjectMutationInput): Record<string, unknown> {
+  const evidence = input.evidence;
+  if (!OPERATION_PATTERN.test(evidence.source)) throw new Error("Mutation evidence source is invalid");
+  if (!isCanonicalMutationTimestamp(evidence.observedAt)) throw new Error("Mutation evidence timestamp is invalid");
+  if (!FAILURE_CODE_PATTERN.test(evidence.evidenceCode)) throw new Error("Mutation evidence code is invalid");
+  if (!FINGERPRINT_PATTERN.test(evidence.evidenceFingerprint)) {
+    throw new Error("Mutation evidence fingerprint is invalid");
+  }
+  return {
+    reconciliation: {
+      source: evidence.source,
+      observed_at: evidence.observedAt,
+      evidence_code: evidence.evidenceCode,
+      evidence_fingerprint: evidence.evidenceFingerprint,
+      target_status: input.status,
+    },
+  };
+}
+
+function assertReconciliationInput(input: ReconcileProjectMutationInput): Record<string, unknown> {
+  assertMutationIdentity(input.projectRef, input.mutationId);
+  if (!Number.isSafeInteger(input.expectedFencingEpoch) || input.expectedFencingEpoch < 1) {
+    throw new Error("Mutation reconciliation fencing epoch is invalid");
+  }
+  if (!validCompletionResponseStatus(input.status, input.responseStatus)) {
+    throw new Error("Mutation response status is invalid");
+  }
+  if (input.status === "succeeded" && input.failureCode != null) {
+    throw new Error("Successful mutation reconciliation cannot set a failure code");
+  }
+  if (input.status === "failed_terminal" && !FAILURE_CODE_PATTERN.test(input.failureCode ?? "")) {
+    throw new Error("Terminal mutation reconciliation requires a failure code");
+  }
+  const receipt = reconciliationReceipt(input);
+  assertPublicMutationPayload(receipt);
+  return receipt;
+}
+
+async function lockedReconciliationMutation(
+  transaction: SQL,
+  input: ReconcileProjectMutationInput,
+): Promise<StoredReconciliationRow | null> {
+  const [row] = await transaction`
+    SELECT mutation.*, clock_timestamp() AS database_now
+    FROM project_mutations AS mutation
+    WHERE mutation.project_ref = ${input.projectRef}
+      AND mutation.mutation_id = ${input.mutationId}
+    FOR UPDATE
+  ` as StoredReconciliationRow[];
+  return row ?? null;
+}
+
+function reconciliationPrecondition(
+  row: StoredReconciliationRow | null,
+  actor: MutationPrincipal,
+  input: ReconcileProjectMutationInput,
+): ReconcileProjectMutationResult | null {
+  if (!row) return { kind: "not_found" };
+  if (row.principal_type !== actor.type || row.principal_id !== actor.id) return { kind: "forbidden" };
+  const mutation = projectMutationState(row);
+  if (row.status !== "outcome_unknown") return { kind: "not_reconcilable", mutation };
+  if (mutation.fencingEpoch !== input.expectedFencingEpoch) return { kind: "cas_conflict", mutation };
+  const unknownAt = timestamp(row.completed_at);
+  const databaseNow = timestamp(row.database_now);
+  if (!unknownAt || !databaseNow) throw new Error("Stored mutation reconciliation timestamps are invalid");
+  const observedAt = Date.parse(input.evidence.observedAt);
+  if (observedAt < Date.parse(unknownAt)
+    || observedAt > Date.parse(databaseNow) + MAX_EVIDENCE_CLOCK_SKEW_MS) {
+    return { kind: "invalid_evidence_time" };
+  }
+  return null;
+}
+
+export async function reconcileProjectMutation(
+  transaction: SQL,
+  actor: MutationPrincipal,
+  input: ReconcileProjectMutationInput,
+): Promise<ReconcileProjectMutationResult> {
+  const receipt = assertReconciliationInput(input);
+  const current = await lockedReconciliationMutation(transaction, input);
+  const precondition = reconciliationPrecondition(current, actor, input);
+  if (precondition) return precondition;
+  const [updated] = await transaction`
+    UPDATE project_mutations
+    SET status = ${input.status}, receipt = ${receipt}::jsonb,
+        response_status = ${input.responseStatus}, failure_code = ${input.failureCode ?? null},
+        recovery_not_before = NULL, completed_at = clock_timestamp(), updated_at = clock_timestamp()
+    WHERE project_ref = ${input.projectRef} AND mutation_id = ${input.mutationId}
+      AND principal_type = ${actor.type} AND principal_id = ${actor.id}
+      AND status = 'outcome_unknown' AND fencing_epoch = ${input.expectedFencingEpoch}
+    RETURNING *
+  ` as StoredProjectMutationRow[];
+  if (!updated) throw new Error("Locked mutation reconciliation changed unexpectedly");
+  return { kind: "updated", mutation: projectMutationState(updated) };
 }
 
 export async function readProjectMutation(input: {

--- a/packages/management-api/src/utils/http-validation.ts
+++ b/packages/management-api/src/utils/http-validation.ts
@@ -1,0 +1,11 @@
+import type { ErrorContext } from "elysia";
+
+export const VALIDATION_ERROR_BODY = {
+  message: "Validation failed",
+  code: "VALIDATION_ERROR",
+} as const;
+
+export function validationErrorResponse(set: ErrorContext["set"]) {
+  set.status = 400;
+  return VALIDATION_ERROR_BODY;
+}

--- a/packages/management-api/tests/integration/project-mutation-lease.test.ts
+++ b/packages/management-api/tests/integration/project-mutation-lease.test.ts
@@ -1,0 +1,254 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { SQL } from "bun";
+import {
+  beginProjectMutation,
+  checkpointProjectMutation,
+  claimOrResumeProjectMutation,
+  completeProjectMutationFailure,
+  completeProjectMutationSuccess,
+  projectMutationFingerprint,
+  projectMutationResourceKey,
+  reconcileProjectMutation,
+} from "../../src/services/project-mutation.service";
+import { appendAuditEventInTransaction } from "../../src/services/audit.service";
+
+const database = new SQL({
+  url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+  max: 5,
+});
+const projectRef = `mut${process.pid.toString(36)}${Date.now().toString(36)}`.slice(0, 20);
+const projectActor = { type: "project" as const, id: `project:${projectRef}` };
+
+async function installProjectFixture(): Promise<void> {
+  await database`
+    INSERT INTO projects (
+      ref, name, db_name, db_user, db_password, jwt_secret,
+      anon_key, service_role_key, s3_bucket, status
+    ) VALUES (
+      ${projectRef}, 'Mutation lease fixture', ${`db_${projectRef}`}, ${`user_${projectRef}`},
+      'fixture-password', 'fixture-jwt-secret', 'fixture-anon-key',
+      'fixture-service-role-key', ${`bucket-${projectRef}`}, 'active'
+    )
+  `;
+}
+
+async function beginAndClaim() {
+  const mutationId = crypto.randomUUID();
+  const leaseToken = crypto.randomUUID();
+  await database.begin((transaction) => beginProjectMutation(transaction, {
+    projectRef,
+    mutationId,
+    operation: "scheduled_functions.create",
+    resource: { type: "scheduled-function", id: mutationId },
+    requestFingerprint: projectMutationFingerprint({ project_ref: projectRef, mutation_id: mutationId }),
+    principal: projectActor,
+  }));
+  const claim = await database.begin((transaction) => claimOrResumeProjectMutation(transaction, {
+    projectRef, mutationId, leaseOwner: "original-worker", leaseToken, leaseSeconds: 30,
+  }));
+  if (claim.kind !== "claimed") throw new Error(`Fixture mutation was not claimed: ${claim.kind}`);
+  return { mutationId, leaseToken, fencingEpoch: claim.mutation.fencingEpoch };
+}
+
+async function expireLease(mutationId: string): Promise<void> {
+  await database`
+    UPDATE project_mutations
+    SET lease_expires_at = clock_timestamp() - INTERVAL '1 millisecond'
+    WHERE project_ref = ${projectRef} AND mutation_id = ${mutationId}
+  `;
+}
+
+beforeAll(installProjectFixture);
+
+afterAll(async () => {
+  await database`DELETE FROM projects WHERE ref = ${projectRef}`;
+  await database.close();
+}, 30_000);
+
+describe("project mutation PostgreSQL lease fencing", () => {
+  test("rejects an expired checkpoint racing a replacement claim", async () => {
+    const fixture = await beginAndClaim();
+    await expireLease(fixture.mutationId);
+    const replacementToken = crypto.randomUUID();
+
+    const [checkpoint, replacement] = await Promise.all([
+      database.begin((transaction) => checkpointProjectMutation(transaction, {
+        projectRef, mutationId: fixture.mutationId, leaseToken: fixture.leaseToken,
+        fencingEpoch: fixture.fencingEpoch, leaseSeconds: 30, checkpoint: { phase: "stale" },
+      })),
+      database.begin((transaction) => claimOrResumeProjectMutation(transaction, {
+        projectRef, mutationId: fixture.mutationId, leaseOwner: "replacement-worker",
+        leaseToken: replacementToken, leaseSeconds: 30,
+      })),
+    ]);
+    const [stored] = await database`
+      SELECT checkpoint, lease_token, fencing_epoch, recovery_not_before, resource_key
+      FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+
+    expect(checkpoint).toBe("lease_lost");
+    expect(replacement.kind).toBe("claimed");
+    expect(stored).toMatchObject({
+      checkpoint: {},
+      lease_token: replacementToken,
+      recovery_not_before: expect.any(Date),
+      resource_key: projectMutationResourceKey({ type: "scheduled-function", id: fixture.mutationId }),
+    });
+    expect(Number(stored.fencing_epoch)).toBe(fixture.fencingEpoch + 1);
+  }, 30_000);
+
+  test("rejects an expired success racing a replacement claim", async () => {
+    const fixture = await beginAndClaim();
+    await expireLease(fixture.mutationId);
+    const replacementToken = crypto.randomUUID();
+
+    const [completion, replacement] = await Promise.all([
+      database.begin((transaction) => completeProjectMutationSuccess(transaction, {
+        projectRef, mutationId: fixture.mutationId, leaseToken: fixture.leaseToken,
+        fencingEpoch: fixture.fencingEpoch, responseStatus: 200, receipt: { created: true },
+      })),
+      database.begin((transaction) => claimOrResumeProjectMutation(transaction, {
+        projectRef, mutationId: fixture.mutationId, leaseOwner: "replacement-worker",
+        leaseToken: replacementToken, leaseSeconds: 30,
+      })),
+    ]);
+    const [stored] = await database`
+      SELECT status, receipt, lease_token, fencing_epoch
+      FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+
+    expect(completion).toBe("lease_lost");
+    expect(replacement.kind).toBe("claimed");
+    expect(stored).toMatchObject({ status: "running", receipt: null, lease_token: replacementToken });
+    expect(Number(stored.fencing_epoch)).toBe(fixture.fencingEpoch + 1);
+  }, 30_000);
+
+  test("preserves an active ceiling lease and reports exhaustion after expiry", async () => {
+    const fixture = await beginAndClaim();
+    await database`
+      UPDATE project_mutations
+      SET fencing_epoch = 9007199254740991,
+          lease_expires_at = clock_timestamp() + INTERVAL '1 minute'
+      WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+
+    const resumed = await database.begin((transaction) => claimOrResumeProjectMutation(transaction, {
+      projectRef, mutationId: fixture.mutationId, leaseOwner: "original-worker",
+      leaseToken: fixture.leaseToken, leaseSeconds: 30,
+    }));
+    const competing = await database.begin((transaction) => claimOrResumeProjectMutation(transaction, {
+      projectRef, mutationId: fixture.mutationId, leaseOwner: "competing-worker",
+      leaseToken: crypto.randomUUID(), leaseSeconds: 30,
+    }));
+
+    expect(resumed.kind).toBe("claimed");
+    expect(competing.kind).toBe("busy");
+
+    await expireLease(fixture.mutationId);
+    await expect(database.begin((transaction) => claimOrResumeProjectMutation(transaction, {
+      projectRef, mutationId: fixture.mutationId, leaseOwner: "replacement-worker",
+      leaseToken: crypto.randomUUID(), leaseSeconds: 30,
+    }))).rejects.toThrow("fencing epoch is exhausted");
+    const [stored] = await database`
+      SELECT status, lease_token, fencing_epoch
+      FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+
+    expect(stored).toMatchObject({ status: "running", lease_token: fixture.leaseToken });
+    expect(Number(stored.fencing_epoch)).toBe(Number.MAX_SAFE_INTEGER);
+  }, 30_000);
+
+  test("allows exactly one reconciliation writer for an unknown outcome epoch", async () => {
+    const fixture = await beginAndClaim();
+    const unknownOutcome = await database.begin((transaction) => completeProjectMutationFailure(transaction, {
+      projectRef, mutationId: fixture.mutationId, leaseToken: fixture.leaseToken,
+      fencingEpoch: fixture.fencingEpoch, status: "outcome_unknown", failureCode: "PROVIDER_OUTCOME_UNKNOWN",
+    }));
+    expect(unknownOutcome).toBe("updated");
+    const [unknown] = await database`
+      SELECT completed_at
+      FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+    const baseEvidence = {
+      source: "scheduled_functions.provider_readback",
+      observedAt: new Date(unknown.completed_at).toISOString(),
+    };
+
+    const reconciliations = await Promise.all([
+      database.begin((transaction) => reconcileProjectMutation(transaction, projectActor, {
+        projectRef, mutationId: fixture.mutationId, expectedFencingEpoch: fixture.fencingEpoch,
+        status: "succeeded", responseStatus: 200,
+        evidence: { ...baseEvidence, evidenceCode: "RESOURCE_PRESENT", evidenceFingerprint: "a".repeat(64) },
+      })),
+      database.begin((transaction) => reconcileProjectMutation(transaction, projectActor, {
+        projectRef, mutationId: fixture.mutationId, expectedFencingEpoch: fixture.fencingEpoch,
+        status: "failed_terminal", responseStatus: 404, failureCode: "RESOURCE_NOT_FOUND",
+        evidence: { ...baseEvidence, evidenceCode: "RESOURCE_ABSENT", evidenceFingerprint: "b".repeat(64) },
+      })),
+    ]);
+    const [stored] = await database`
+      SELECT status, receipt, fencing_epoch
+      FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+
+    expect(reconciliations.map((entry) => entry.kind).sort()).toEqual(["not_reconcilable", "updated"]);
+    expect(["succeeded", "failed_terminal"]).toContain(stored.status);
+    expect(Number(stored.fencing_epoch)).toBe(fixture.fencingEpoch);
+    expect(stored.receipt.reconciliation.target_status).toBe(stored.status);
+  }, 30_000);
+
+  test("rolls reconciliation back when the audit insert fails", async () => {
+    const fixture = await beginAndClaim();
+    await database.begin((transaction) => completeProjectMutationFailure(transaction, {
+      projectRef, mutationId: fixture.mutationId, leaseToken: fixture.leaseToken,
+      fencingEpoch: fixture.fencingEpoch, status: "outcome_unknown",
+      failureCode: "PROVIDER_OUTCOME_UNKNOWN",
+    }));
+    const connection = await database.reserve();
+    await connection.unsafe("BEGIN");
+    try {
+      const [unknown] = await connection`
+        SELECT completed_at
+        FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+      `;
+      await connection.unsafe("SAVEPOINT before_reconciliation");
+      let auditFailure: unknown = null;
+      try {
+        await reconcileProjectMutation(connection as unknown as SQL, projectActor, {
+          projectRef, mutationId: fixture.mutationId, expectedFencingEpoch: fixture.fencingEpoch,
+          status: "succeeded", responseStatus: 200,
+          evidence: {
+            source: "scheduled_functions.provider_readback",
+            observedAt: new Date(unknown.completed_at).toISOString(),
+            evidenceCode: "RESOURCE_PRESENT",
+            evidenceFingerprint: "c".repeat(64),
+          },
+        });
+        await appendAuditEventInTransaction(connection as unknown as SQL, {
+          projectRef,
+          actor: projectActor.id,
+          actorType: projectActor.type,
+          action: "project_mutation.reconciled",
+          method: "AUDIT_INSERT_FAILPOINT",
+          path: `/v1/projects/${projectRef}/mutations/${fixture.mutationId}/reconcile`,
+          status: 200,
+          requestId: "audit-insert-failpoint",
+        });
+      } catch (error) {
+        auditFailure = error;
+        await connection.unsafe("ROLLBACK TO SAVEPOINT before_reconciliation");
+      }
+      const [stored] = await connection`
+        SELECT status, receipt
+        FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+      `;
+
+      expect(auditFailure).toBeInstanceOf(Error);
+      expect(stored.status).toBe("outcome_unknown");
+      expect(stored.receipt).toEqual({});
+    } finally {
+      await connection.unsafe("ROLLBACK");
+      connection.release();
+    }
+  }, 30_000);
+});

--- a/packages/management-api/tests/integration/project-mutation-migration.test.ts
+++ b/packages/management-api/tests/integration/project-mutation-migration.test.ts
@@ -1,0 +1,262 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { SQL } from "bun";
+import {
+  PROJECT_MUTATION_JOURNAL_MIGRATION_KEY,
+  migrateProjectMutationJournal,
+} from "../../src/db/project-mutation-migration";
+
+const database = new SQL({
+  url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
+  max: 1,
+});
+
+async function withRollback(operation: (transaction: SQL) => Promise<void>): Promise<void> {
+  const connection = await database.reserve();
+  await connection.unsafe("BEGIN");
+  try {
+    await operation(connection as unknown as SQL);
+  } finally {
+    await connection.unsafe("ROLLBACK");
+    connection.release();
+  }
+}
+
+async function insertProjectFixture(transaction: SQL, projectRef: string): Promise<void> {
+  await transaction`
+    INSERT INTO projects (
+      ref, name, db_name, db_user, db_password, jwt_secret,
+      anon_key, service_role_key, s3_bucket, status
+    ) VALUES (
+      ${projectRef}, 'Mutation migration fixture', ${`db_${projectRef}`}, ${`user_${projectRef}`},
+      'fixture-password', 'fixture-jwt-secret', 'fixture-anon-key',
+      'fixture-service-role-key', ${`bucket-${projectRef}`}, 'active'
+    )
+  `;
+}
+
+async function insertLegacyMutation(
+  transaction: SQL,
+  projectRef: string,
+  status: "pending" | "succeeded",
+  resourceKey: string | null = null,
+  recoveryNotBefore: Date | null = null,
+): Promise<string> {
+  const mutationId = crypto.randomUUID();
+  await transaction`
+    INSERT INTO project_mutations (
+      project_ref, mutation_id, operation, request_fingerprint,
+      principal_type, principal_id, resource_key, status, response_status,
+      recovery_not_before, completed_at
+    ) VALUES (
+      ${projectRef}, ${mutationId}, 'scheduled_functions.create', ${"a".repeat(64)},
+      'project', ${`project:${projectRef}`}, ${resourceKey}, ${status},
+      ${status === "succeeded" ? 200 : null}, ${recoveryNotBefore},
+      ${status === "succeeded" ? new Date() : null}
+    )
+  `;
+  return mutationId;
+}
+
+async function dropResourceKeyConstraints(transaction: SQL): Promise<void> {
+  await transaction.unsafe(`
+    ALTER TABLE project_mutations
+    DROP CONSTRAINT IF EXISTS project_mutations_resource_key_check
+  `);
+  await transaction.unsafe(`
+    ALTER TABLE project_mutations
+    DROP CONSTRAINT IF EXISTS project_mutations_resource_key_canonical_v1_check
+  `);
+}
+
+afterAll(async () => {
+  await database.close();
+}, 30_000);
+
+describe("project mutation PostgreSQL forward migration", () => {
+  test("backfills legacy active rows before enforcing the due-time invariant", async () => {
+    await withRollback(async (transaction) => {
+      await transaction.unsafe(`
+        ALTER TABLE project_mutations
+        DROP CONSTRAINT IF EXISTS project_mutations_recoverable_due_check
+      `);
+      await transaction.unsafe(`
+        ALTER TABLE project_mutations
+        ALTER COLUMN recovery_not_before DROP DEFAULT
+      `);
+      await transaction`
+        DELETE FROM platform_schema_migrations
+        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+      `;
+      const projectRef = `mm${process.pid.toString(36)}${Date.now().toString(36)}`.slice(0, 20);
+      await insertProjectFixture(transaction, projectRef);
+      const mutationId = await insertLegacyMutation(transaction, projectRef, "pending");
+
+      await migrateProjectMutationJournal(transaction);
+      await migrateProjectMutationJournal(transaction);
+
+      const [mutation] = await transaction`
+        SELECT recovery_not_before
+        FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${mutationId}
+      `;
+      const [constraint] = await transaction`
+        SELECT convalidated
+        FROM pg_constraint
+        WHERE conrelid = 'project_mutations'::regclass
+          AND conname = 'project_mutations_recoverable_due_check'
+      `;
+      const [marker] = await transaction`
+        SELECT count(*)::integer AS count
+        FROM platform_schema_migrations
+        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+      `;
+
+      expect(mutation.recovery_not_before).not.toBeNull();
+      expect(constraint.convalidated).toBe(true);
+      expect(marker.count).toBe(1);
+    });
+  }, 30_000);
+
+  test.each(["pending", "succeeded"] as const)(
+    "rejects a legacy raw resource key on a %s row before recording the marker",
+    async (status) => {
+      await withRollback(async (transaction) => {
+        await dropResourceKeyConstraints(transaction);
+        await transaction`
+          DELETE FROM platform_schema_migrations
+          WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+        `;
+        const projectRef = `mr${status[0]}${process.pid.toString(36)}${Date.now().toString(36)}`.slice(0, 20);
+        await insertProjectFixture(transaction, projectRef);
+        await insertLegacyMutation(
+          transaction,
+          projectRef,
+          status,
+          "scheduled-function:nightly",
+          status === "pending" ? new Date() : null,
+        );
+
+        await expect(migrateProjectMutationJournal(transaction))
+          .rejects.toThrow("requires canonical v1 resource keys");
+
+        const [marker] = await transaction`
+          SELECT count(*)::integer AS count
+          FROM platform_schema_migrations
+          WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+        `;
+        expect(marker.count).toBe(0);
+      });
+    },
+    30_000,
+  );
+
+  test.each([
+    ["length modulo four equals one", "v1/edge-function/A"],
+    ["non-zero trailing bits", "v1/edge-function/YR"],
+    ["decoded bytes are not UTF-8", "v1/edge-function/_w"],
+  ])("rejects a structurally valid but non-canonical key whose %s", async (_case, resourceKey) => {
+    await withRollback(async (transaction) => {
+      await dropResourceKeyConstraints(transaction);
+      await transaction`
+        DELETE FROM platform_schema_migrations
+        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+      `;
+      const projectRef = `mc${process.pid.toString(36)}${crypto.randomUUID().replaceAll("-", "").slice(0, 10)}`
+        .slice(0, 20);
+      await insertProjectFixture(transaction, projectRef);
+      await insertLegacyMutation(transaction, projectRef, "pending", resourceKey, new Date());
+
+      await expect(migrateProjectMutationJournal(transaction))
+        .rejects.toThrow("requires canonical v1 resource keys");
+
+      const [marker] = await transaction`
+        SELECT count(*)::integer AS count
+        FROM platform_schema_migrations
+        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+      `;
+      expect(marker.count).toBe(0);
+    });
+  }, 30_000);
+
+  test.each([
+    ["leading non-breaking space", `v1/edge-function/${Buffer.from("\u00a0nightly").toString("base64url")}`],
+    ["trailing em space", `v1/edge-function/${Buffer.from("nightly\u2003").toString("base64url")}`],
+    ["leading byte-order mark", `v1/edge-function/${Buffer.from("\ufeffnightly").toString("base64url")}`],
+    ["C0 control character", `v1/edge-function/${Buffer.from("nightly\u0001").toString("base64url")}`],
+    ["DEL control character", `v1/edge-function/${Buffer.from("nightly\u007f").toString("base64url")}`],
+    ["C1 control character", `v1/edge-function/${Buffer.from("nightly\u0085").toString("base64url")}`],
+  ])("rejects a canonical encoding whose decoded id has %s", async (_case, resourceKey) => {
+    await withRollback(async (transaction) => {
+      await transaction`
+        DELETE FROM public.platform_schema_migrations
+        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+      `;
+      await migrateProjectMutationJournal(transaction);
+
+      const [validation] = await transaction`
+        SELECT public.project_mutation_resource_key_is_canonical_v1(${resourceKey}) AS canonical
+      `;
+
+      expect(validation.canonical).toBe(false);
+    });
+  }, 30_000);
+
+  test("accepts a canonical encoding of an ordinary Unicode resource id", async () => {
+    await withRollback(async (transaction) => {
+      await transaction`
+        DELETE FROM public.platform_schema_migrations
+        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+      `;
+      await migrateProjectMutationJournal(transaction);
+      const resourceKey = `v1/edge-function/${Buffer.from("夜班/worker").toString("base64url")}`;
+
+      const [validation] = await transaction`
+        SELECT public.project_mutation_resource_key_is_canonical_v1(${resourceKey}) AS canonical
+      `;
+
+      expect(validation.canonical).toBe(true);
+    });
+  }, 30_000);
+
+  test("propagates a validator dependency permission failure", async () => {
+    await withRollback(async (transaction) => {
+      await transaction`
+        DELETE FROM public.platform_schema_migrations
+        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+      `;
+      await migrateProjectMutationJournal(transaction);
+      await transaction.unsafe("CREATE SCHEMA validator_dependency_failure");
+      await transaction.unsafe(
+        `
+          CREATE FUNCTION validator_dependency_failure.decode(TEXT, TEXT)
+          RETURNS BYTEA
+          LANGUAGE plpgsql
+          IMMUTABLE
+          AS $function$
+          BEGIN
+            RAISE EXCEPTION USING
+              ERRCODE = '42501',
+              MESSAGE = 'validator dependency permission failure';
+          END;
+          $function$
+        `,
+      );
+      await transaction.unsafe(`
+        ALTER FUNCTION public.project_mutation_resource_key_is_canonical_v1(TEXT)
+        SET search_path = validator_dependency_failure, pg_catalog
+      `);
+
+      let dependencyError: unknown = null;
+      try {
+        await transaction.unsafe(
+          "SELECT public.project_mutation_resource_key_is_canonical_v1('v1/edge-function/bmlnaHRseQ')",
+        );
+      } catch (error) {
+        dependencyError = error;
+      }
+
+      expect(dependencyError).toBeInstanceOf(Error);
+      expect((dependencyError as Error).message).toContain("validator dependency permission failure");
+      expect((dependencyError as { errno?: string }).errno).toBe("42501");
+    });
+  }, 30_000);
+});

--- a/packages/management-api/tests/unit/audit.service.test.ts
+++ b/packages/management-api/tests/unit/audit.service.test.ts
@@ -14,6 +14,9 @@ describe("audit redaction", () => {
         client_secret: "client-secret",
         clientSecret: "camel-secret",
         codeVerifier: "pkce-secret",
+        jwt: "jwt-secret",
+        session: "session-secret",
+        signing_key: "signing-key-secret",
         items: [{ password: "pass" }, { safe: "visible" }],
       },
     })).toEqual({
@@ -23,6 +26,9 @@ describe("audit redaction", () => {
         client_secret: "[REDACTED]",
         clientSecret: "[REDACTED]",
         codeVerifier: "[REDACTED]",
+        jwt: "[REDACTED]",
+        session: "[REDACTED]",
+        signing_key: "[REDACTED]",
         items: [{ password: "[REDACTED]" }, { safe: "visible" }],
       },
     });

--- a/packages/management-api/tests/unit/delegated-project-authorization.test.ts
+++ b/packages/management-api/tests/unit/delegated-project-authorization.test.ts
@@ -119,6 +119,8 @@ describe("delegated project authorization", () => {
       ["POST", "/frontend/deployments", "operations.manage"],
       ["GET", "/tasks", "operations.read"],
       ["POST", "/pipelines", "operations.manage"],
+      ["GET", "/mutations/00000000-0000-4000-8000-000000000001", "operations.read"],
+      ["POST", "/mutations/00000000-0000-4000-8000-000000000001/reconcile", "operations.manage"],
       ["POST", "/database/migrations", "database.migrations.manage"],
       ["POST", "/database/migrations/baseline", "database.migrations.manage"],
       ["GET", "", "project.read"],

--- a/packages/management-api/tests/unit/platform-v2-bootstrap.test.ts
+++ b/packages/management-api/tests/unit/platform-v2-bootstrap.test.ts
@@ -54,7 +54,7 @@ test("platform v2 bootstrap executes canonical DDL as individual statements in o
   const fixture = fakeControlPool();
   await ensurePlatformV2SchemaInTransaction(fixture.database);
 
-  expect(fixture.observations()).toEqual({ beginCalls: 1, taggedCalls: 1, rolledBack: false });
+  expect(fixture.observations()).toEqual({ beginCalls: 1, taggedCalls: 10, rolledBack: false });
   expect(fixture.transactionalStatements.length).toBeGreaterThan(30);
   for (const statement of fixture.transactionalStatements) {
     expect(splitSqlStatements(statement)).toHaveLength(1);

--- a/packages/management-api/tests/unit/platform-v2.schema.test.ts
+++ b/packages/management-api/tests/unit/platform-v2.schema.test.ts
@@ -6,6 +6,10 @@ const auditMigration = readFileSync(
   new URL("../../src/db/audit-chain-migration.ts", import.meta.url),
   "utf8",
 );
+const mutationMigration = readFileSync(
+  new URL("../../src/db/project-mutation-migration.ts", import.meta.url),
+  "utf8",
+);
 const databaseInit = readFileSync(new URL("../../src/db/init.ts", import.meta.url), "utf8");
 const serverEntrypoint = readFileSync(new URL("../../src/index.ts", import.meta.url), "utf8");
 const userSafetyService = readFileSync(
@@ -45,13 +49,29 @@ describe("platform v2 schema contract", () => {
       schema.indexOf("CREATE TABLE IF NOT EXISTS supaoauth_bff_proof_nonces"),
     );
     expect(mutationSchema).toContain("PRIMARY KEY (project_ref, mutation_id)");
-    expect(mutationSchema).toContain("recovery_not_before TIMESTAMPTZ");
+    expect(mutationSchema).toContain("recovery_not_before TIMESTAMPTZ DEFAULT clock_timestamp()");
     expect(mutationSchema).toContain("ADD COLUMN IF NOT EXISTS recovery_not_before TIMESTAMPTZ");
     expect(mutationSchema).toContain("project_mutations_succeeded_response_check");
+    expect(mutationSchema).toContain("project_mutations_recoverable_due_check");
+    expect(mutationSchema).toContain("project_mutations_fencing_epoch_safe_check");
+    expect(mutationSchema).toContain("fencing_epoch <= 9007199254740991");
     expect(mutationSchema).toContain("response_status IS NOT NULL AND response_status BETWEEN 200 AND 299");
     expect(mutationSchema).toContain("project_mutations_recovery_idx");
     expect(mutationSchema).toContain("status IN ('pending', 'running', 'failed_retryable')");
     expect(mutationSchema).toContain("project_mutations_active_resource_idx");
+    expect(mutationSchema).not.toContain("DROP CONSTRAINT");
+    expect(mutationMigration).toContain("INSERT INTO public.platform_schema_migrations");
+    expect(mutationMigration).toContain("ALTER COLUMN recovery_not_before SET DEFAULT clock_timestamp()");
+    expect(mutationMigration).toContain("COALESCE(updated_at, created_at, clock_timestamp())");
+    expect(mutationMigration).toContain("project_mutation_resource_key_is_canonical_v1");
+    expect(mutationMigration).toContain("canonical_id <> encoded_id");
+    expect(mutationMigration).toContain("convert_from(decoded_id, 'UTF8')");
+    expect(mutationMigration).toContain(
+      "NOT public.project_mutation_resource_key_is_canonical_v1(mutation.resource_key)",
+    );
+    expect(mutationMigration).toContain("VALIDATE CONSTRAINT ${CANONICAL_RESOURCE_KEY_CONSTRAINT}");
+    expect(mutationMigration).toContain("VALIDATE CONSTRAINT ${FENCING_EPOCH_SAFE_CONSTRAINT}");
+    expect(mutationMigration).not.toContain("DROP CONSTRAINT");
     for (const sensitiveColumn of [
       "request_body", "request_headers", "request_payload", "credential", "service_role", "secret",
     ]) expect(mutationSchema).not.toContain(sensitiveColumn);
@@ -92,6 +112,8 @@ describe("platform v2 schema contract", () => {
   });
 
   test("requires the durable audit migration marker before server startup continues", () => {
+    expect(databaseInit).toContain("await migrateProjectMutationJournal(transaction)");
+    expect(serverEntrypoint).toContain("await ensurePlatformV2SchemaInTransaction(controlPlaneSql)");
     expect(databaseInit).toContain("await migrateAuditChainSequences(transaction)");
     expect(serverEntrypoint).toContain("await assertPlatformMigrationCompleted(controlPlaneSql)");
     expect(serverEntrypoint.indexOf("await assertPlatformMigrationCompleted(controlPlaneSql)"))

--- a/packages/management-api/tests/unit/project-mutation-migration.test.ts
+++ b/packages/management-api/tests/unit/project-mutation-migration.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import type { SQL } from "bun";
+import {
+  PROJECT_MUTATION_JOURNAL_MIGRATION_KEY,
+  migrateProjectMutationJournal,
+} from "../../src/db/project-mutation-migration";
+
+type MigrationFixtureOptions = {
+  markerExists?: boolean;
+  constraints?: Record<string, boolean>;
+  backfilledRows?: number;
+  invalidResourceKeys?: number;
+};
+
+function migrationFixture(options: MigrationFixtureOptions = {}) {
+  let markerExists = options.markerExists ?? false;
+  const constraints = new Map(Object.entries(options.constraints ?? {}));
+  const taggedQueries: string[] = [];
+  const unsafeQueries: string[] = [];
+  const transaction = Object.assign(
+    async (strings: TemplateStringsArray, ...parameters: unknown[]) => {
+      const query = strings.join("?").replaceAll(/\s+/g, " ").trim();
+      taggedQueries.push(query);
+      if (query.includes("FROM public.platform_schema_migrations")) {
+        return markerExists ? [{ migration_key: PROJECT_MUTATION_JOURNAL_MIGRATION_KEY }] : [];
+      }
+      if (query.includes("FROM pg_catalog.pg_constraint")) {
+        const name = String(parameters[0]);
+        return constraints.has(name) ? [{ conname: name, convalidated: constraints.get(name) }] : [];
+      }
+      if (query.includes("NOT public.project_mutation_resource_key_is_canonical_v1(mutation.resource_key)")) {
+        return Array.from({ length: options.invalidResourceKeys ?? 0 }, (_, index) => ({ mutation_id: String(index) }));
+      }
+      if (query.startsWith("UPDATE public.project_mutations")) {
+        return Array.from({ length: options.backfilledRows ?? 0 }, (_, index) => ({ mutation_id: String(index) }));
+      }
+      if (query.startsWith("INSERT INTO public.platform_schema_migrations")) markerExists = true;
+      return [];
+    },
+    {
+      unsafe: async (query: string) => {
+        const normalized = query.replaceAll(/\s+/g, " ").trim();
+        unsafeQueries.push(normalized);
+        const added = normalized.match(/ADD CONSTRAINT (project_mutations_[a-z_]+)/)?.[1];
+        const validated = normalized.match(/VALIDATE CONSTRAINT (project_mutations_[a-z_]+)/)?.[1];
+        if (added) constraints.set(added, false);
+        if (validated) constraints.set(validated, true);
+      },
+    },
+  );
+  return { transaction: transaction as unknown as SQL, taggedQueries, unsafeQueries };
+}
+
+describe("project mutation journal migration", () => {
+  test("backfills active recovery schedules, validates constraints, and records one marker", async () => {
+    const fixture = migrationFixture({ backfilledRows: 2 });
+
+    await migrateProjectMutationJournal(fixture.transaction);
+    await migrateProjectMutationJournal(fixture.transaction);
+
+    expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
+      "ALTER COLUMN recovery_not_before SET DEFAULT clock_timestamp()",
+    ));
+    expect(fixture.unsafeQueries.filter((query) => query.includes("ADD CONSTRAINT"))).toHaveLength(4);
+    expect(fixture.unsafeQueries.filter((query) => query.includes("VALIDATE CONSTRAINT"))).toHaveLength(4);
+    expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
+      "ADD CONSTRAINT project_mutations_resource_key_canonical_v1_check",
+    ));
+    expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
+      "ADD CONSTRAINT project_mutations_fencing_epoch_safe_check",
+    ));
+    expect(fixture.unsafeQueries.some((query) => query.includes("DROP CONSTRAINT"))).toBe(false);
+    expect(fixture.taggedQueries.filter((query) => query.startsWith("UPDATE public.project_mutations"))).toHaveLength(1);
+    expect(fixture.taggedQueries.find((query) => query.startsWith("UPDATE public.project_mutations")))
+      .toContain("status IN ('pending', 'running', 'failed_retryable')");
+    expect(fixture.taggedQueries.filter((query) => query.startsWith("INSERT INTO public.platform_schema_migrations")))
+      .toHaveLength(1);
+    const validatorDdl = fixture.unsafeQueries.find((query) => query.startsWith(
+      "CREATE OR REPLACE FUNCTION public.project_mutation_resource_key_is_canonical_v1",
+    ));
+    expect(validatorDdl).toContain("SET search_path = pg_catalog");
+    expect(validatorDdl).toContain("WHEN invalid_parameter_value OR character_not_in_repertoire");
+    expect(validatorDdl).not.toContain("WHEN OTHERS");
+  });
+
+  test("skips all mutation DDL after the durable marker exists", async () => {
+    const fixture = migrationFixture({ markerExists: true });
+
+    await migrateProjectMutationJournal(fixture.transaction);
+
+    expect(fixture.unsafeQueries).toHaveLength(0);
+    expect(fixture.unsafeQueries.some((query) => query.startsWith("ALTER TABLE"))).toBe(false);
+    expect(fixture.taggedQueries).toHaveLength(2);
+    expect(fixture.taggedQueries[0]).toContain("pg_advisory_xact_lock");
+    expect(fixture.taggedQueries[1]).toContain("FROM public.platform_schema_migrations");
+  });
+
+  test("fails before backfill, constraints, or marker when a legacy raw resource key remains", async () => {
+    const fixture = migrationFixture({ invalidResourceKeys: 1 });
+
+    await expect(migrateProjectMutationJournal(fixture.transaction))
+      .rejects.toThrow("requires canonical v1 resource keys");
+
+    expect(fixture.unsafeQueries).toHaveLength(1);
+    expect(fixture.unsafeQueries[0]).toContain(
+      "CREATE OR REPLACE FUNCTION public.project_mutation_resource_key_is_canonical_v1",
+    );
+    expect(fixture.taggedQueries.some((query) => query.startsWith("UPDATE public.project_mutations"))).toBe(false);
+    expect(fixture.taggedQueries.some((query) => query.startsWith("INSERT INTO public.platform_schema_migrations")))
+      .toBe(false);
+  });
+});

--- a/packages/management-api/tests/unit/project-mutation.service.test.ts
+++ b/packages/management-api/tests/unit/project-mutation.service.test.ts
@@ -45,7 +45,7 @@ function insertedMutation(parameters: unknown[]): MutationRow[] {
     principal_type: String(principalType), principal_id: String(principalId), status: "pending",
     checkpoint: {}, receipt: null, response_status: null, failure_code: null,
     lease_owner: null, lease_token: null, lease_expires_at: null, fencing_epoch: 0,
-    recovery_not_before: null,
+    recovery_not_before: new Date().toISOString(),
     completed_at: null, created_at: CREATED_AT, updated_at: CREATED_AT,
   };
   mutationRows.set(key, row);
@@ -57,7 +57,8 @@ function claimedMutation(parameters: unknown[]): MutationRow[] {
   const row = mutationRows.get(mutationKey(String(projectRef), String(mutationId)));
   const leaseExpired = row?.status === "running"
     && Date.parse(String(row.lease_expires_at)) <= Date.now();
-  if (!row || (!["pending", "failed_retryable"].includes(row.status) && !leaseExpired)) return [];
+  if (!row || Number(row.fencing_epoch) >= Number.MAX_SAFE_INTEGER
+    || (!["pending", "failed_retryable"].includes(row.status) && !leaseExpired)) return [];
   Object.assign(row, {
     status: "running", lease_owner: leaseOwner, lease_token: leaseToken,
     lease_expires_at: new Date(Date.now() + Number(leaseSeconds) * 1000).toISOString(),
@@ -71,7 +72,8 @@ function checkpointedMutation(parameters: unknown[]): Array<{ mutation_id: strin
     projectRef, mutationId, leaseToken, fencingEpoch] = parameters;
   const row = mutationRows.get(mutationKey(String(projectRef), String(mutationId)));
   if (!row || row.status !== "running" || row.lease_token !== leaseToken
-    || Number(row.fencing_epoch) !== Number(fencingEpoch)) return [];
+    || Number(row.fencing_epoch) !== Number(fencingEpoch)
+    || Date.parse(String(row.lease_expires_at)) <= Date.now()) return [];
   row.checkpoint = structuredClone(checkpoint);
   if (!preserveRecoveryTime) row.recovery_not_before = recoveryNotBefore;
   row.lease_expires_at = new Date(Date.now() + Number(leaseSeconds) * 1000).toISOString();
@@ -83,7 +85,8 @@ function finishedMutation(parameters: unknown[]): Array<{ mutation_id: string }>
     projectRef, mutationId, leaseToken, fencingEpoch] = parameters;
   const row = mutationRows.get(mutationKey(String(projectRef), String(mutationId)));
   if (!row || row.status !== "running" || row.lease_token !== leaseToken
-    || Number(row.fencing_epoch) !== Number(fencingEpoch)) return [];
+    || Number(row.fencing_epoch) !== Number(fencingEpoch)
+    || Date.parse(String(row.lease_expires_at)) <= Date.now()) return [];
   Object.assign(row, {
     status, receipt: structuredClone(receipt), response_status: responseStatus, failure_code: failureCode,
     lease_owner: null, lease_token: null, lease_expires_at: null,
@@ -92,6 +95,21 @@ function finishedMutation(parameters: unknown[]): Array<{ mutation_id: string }>
       ? "2026-08-11T00:00:01.000Z" : null,
   });
   return [{ mutation_id: row.mutation_id }];
+}
+
+function reconciledMutation(parameters: unknown[]): MutationRow[] {
+  const [status, receipt, responseStatus, failureCode, projectRef, mutationId,
+    principalType, principalId, expectedEpoch] = parameters;
+  const row = mutationRows.get(mutationKey(String(projectRef), String(mutationId)));
+  if (!row || row.status !== "outcome_unknown"
+    || row.principal_type !== principalType || row.principal_id !== principalId
+    || Number(row.fencing_epoch) !== Number(expectedEpoch)) return [];
+  Object.assign(row, {
+    status, receipt: structuredClone(receipt), response_status: responseStatus,
+    failure_code: failureCode, recovery_not_before: null,
+    completed_at: "2026-08-11T00:00:02.000Z", updated_at: "2026-08-11T00:00:02.000Z",
+  });
+  return clonedRow(row);
 }
 
 function generatedLeaseToken(): string {
@@ -128,6 +146,7 @@ const database = mock(async (strings: TemplateStringsArray, ...parameters: unkno
   if (query.startsWith("WITH candidates AS")) return recoverableMutations(parameters);
   if (query.includes("SET status = 'running'")) return claimedMutation(parameters);
   if (query.includes("SET checkpoint =")) return checkpointedMutation(parameters);
+  if (query.includes("AND status = 'outcome_unknown'")) return reconciledMutation(parameters);
   if (query.includes("SET status = ?")) return finishedMutation(parameters);
   if (query.includes("resource_key = ?")) {
     const [projectRef, resourceKey] = parameters;
@@ -137,6 +156,9 @@ const database = mock(async (strings: TemplateStringsArray, ...parameters: unkno
   }
   const [projectRef, mutationId] = parameters;
   const row = mutationRows.get(mutationKey(String(projectRef), String(mutationId)));
+  if (query.startsWith("SELECT mutation.*, clock_timestamp() AS database_now")) {
+    return row ? [{ ...structuredClone(row), database_now: "2026-08-11T00:05:00.000Z" }] : [];
+  }
   if (query.includes("lease_active")) {
     return row ? [{ ...structuredClone(row), lease_active: Date.parse(String(row.lease_expires_at)) > Date.now() }] : [];
   }
@@ -145,7 +167,16 @@ const database = mock(async (strings: TemplateStringsArray, ...parameters: unkno
 });
 
 Object.assign(database, {
-  begin: async <T>(callback: (transaction: typeof database) => Promise<T>) => callback(database),
+  begin: async <T>(callback: (transaction: typeof database) => Promise<T>) => {
+    const snapshot = structuredClone([...mutationRows.entries()]);
+    try {
+      return await callback(database);
+    } catch (error) {
+      mutationRows.clear();
+      for (const [key, row] of snapshot) mutationRows.set(key, row);
+      throw error;
+    }
+  },
   array: (values: unknown[]) => values,
 });
 
@@ -175,6 +206,17 @@ async function beginAndClaim() {
     leaseToken: LEASE_TOKEN_A,
     leaseSeconds: 30,
   });
+}
+
+async function recordUnknownOutcome(): Promise<number> {
+  const claim = await beginAndClaim();
+  const fencingEpoch = claim.kind === "claimed" ? claim.mutation.fencingEpoch : 0;
+  await mutationService.completeProjectMutationFailure(database as never, {
+    projectRef: PROJECT_REF, mutationId: MUTATION_ID, leaseToken: LEASE_TOKEN_A,
+    fencingEpoch, status: "outcome_unknown", failureCode: "PROVIDER_OUTCOME_UNKNOWN",
+    responseStatus: 503,
+  });
+  return fencingEpoch;
 }
 
 describe("project mutation journal", () => {
@@ -211,7 +253,10 @@ describe("project mutation journal", () => {
     expect(first).toBe("4ea6441de7a05686e3dada9aa2ca3cde155a42d4d7b459a9137c557c11261b80");
   });
 
-  test.each(["body", "headers", "code", "secret", "token", "password", "credential_value"])(
+  test.each([
+    "body", "headers", "code", "secret", "token", "password", "credential_value",
+    "jwt", "session", "signing_key",
+  ])(
     "rejects nested sensitive projection key %s without reflecting its value",
     (sensitiveKey) => {
       const sentinel = "private-value-must-not-appear";
@@ -264,15 +309,73 @@ describe("project mutation journal", () => {
     expect(otherPrincipal).toEqual({ kind: "principal_conflict" });
   });
 
-  test("blocks a second active mutation for the same resource", async () => {
-    await mutationService.beginProjectMutation(database as never, beginInput({ resourceKey: "edge-function:worker" }));
+  test("serializes structured resource identities into one canonical lock key", async () => {
+    const resource = { type: "edge-function", id: "夜班/worker" };
+    const expectedKey = "v1/edge-function/5aSc54-tL3dvcmtlcg";
+    await mutationService.beginProjectMutation(database as never, beginInput({ resource }));
     const blocked = await mutationService.beginProjectMutation(database as never, beginInput({
       mutationId: OTHER_MUTATION_ID,
-      resourceKey: "edge-function:worker",
+      resource,
       requestFingerprint: "b".repeat(64),
     }));
 
+    expect(mutationService.projectMutationResourceKey(resource)).toBe(expectedKey);
+    expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))?.resource_key).toBe(expectedKey);
     expect(blocked).toEqual({ kind: "resource_busy", mutationId: MUTATION_ID, status: "pending" });
+  });
+
+  test.each(["\ud800", "\udfff"])(
+    "rejects the non-canonical UTF-8 resource id %p before persistence",
+    async (resourceId) => {
+      const queryCount = executedQueries.length;
+
+      await expect(mutationService.beginProjectMutation(database as never, beginInput({
+        resource: { type: "edge-function", id: resourceId },
+      }))).rejects.toThrow("well-formed Unicode");
+
+      expect(executedQueries).toHaveLength(queryCount);
+    },
+  );
+
+  test.each([
+    ["C0 control-character", "\u0001"],
+    ["DEL control-character", "\u007f"],
+    ["C1 NEL control-character", "\u0085"],
+    ["C1 APC control-character", "\u009f"],
+  ])(
+    "rejects the %s resource id before persistence",
+    async (_case, resourceId) => {
+      const queryCount = executedQueries.length;
+
+      await expect(mutationService.beginProjectMutation(database as never, beginInput({
+        resource: { type: "edge-function", id: `worker${resourceId}` },
+      }))).rejects.toThrow("Mutation resource id is invalid");
+
+      expect(executedQueries).toHaveLength(queryCount);
+    },
+  );
+
+  test("keeps well-formed Unicode resource ids injective through the 128-byte boundary", () => {
+    const replacementKey = mutationService.projectMutationResourceKey({ type: "edge-function", id: "\ufffd" });
+    const astralKey = mutationService.projectMutationResourceKey({ type: "edge-function", id: "😀" });
+    const boundaryId = "界".repeat(42) + "é";
+
+    expect(Buffer.byteLength(boundaryId, "utf8")).toBe(128);
+    expect(replacementKey).not.toBe(astralKey);
+    expect(mutationService.projectMutationResourceKey({ type: "edge-function", id: boundaryId }))
+      .toMatch(/^v1\/edge-function\/[A-Za-z0-9_-]{171}$/);
+    expect(() => mutationService.projectMutationResourceKey({ type: "edge-function", id: `${boundaryId}a` }))
+      .toThrow("exceeds 128 bytes");
+  });
+
+  test("rejects legacy raw resource keys before persistence", async () => {
+    const queryCount = executedQueries.length;
+
+    await expect(mutationService.beginProjectMutation(database as never, beginInput({
+      resourceKey: "edge-function:worker",
+    }))).rejects.toThrow("structured resource contract");
+
+    expect(executedQueries).toHaveLength(queryCount);
   });
 
   test("uses lease takeover fencing to reject a stale worker checkpoint", async () => {
@@ -301,16 +404,40 @@ describe("project mutation journal", () => {
     expect(currentWrite).toBe("updated");
   });
 
+  test("rejects checkpoint and completion after lease expiry before any takeover", async () => {
+    const firstClaim = await beginAndClaim();
+    const fencingEpoch = firstClaim.kind === "claimed" ? firstClaim.mutation.fencingEpoch : 0;
+    const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    row.lease_expires_at = "2026-08-10T00:00:00.000Z";
+
+    const checkpoint = await mutationService.checkpointProjectMutation(database as never, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, leaseToken: LEASE_TOKEN_A,
+      fencingEpoch, leaseSeconds: 30, checkpoint: { phase: "stale" },
+    });
+    const completion = await mutationService.completeProjectMutationSuccess(database as never, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, leaseToken: LEASE_TOKEN_A,
+      fencingEpoch, responseStatus: 200, receipt: { created: true },
+    });
+
+    expect(checkpoint).toBe("lease_lost");
+    expect(completion).toBe("lease_lost");
+    expect(row).toMatchObject({ status: "running", checkpoint: {}, receipt: null });
+    const leaseWrites = executedQueries.filter((query) =>
+      query.includes("SET checkpoint =") || query.includes("SET status = ?")
+    );
+    expect(leaseWrites.every((query) => query.includes("lease_expires_at > clock_timestamp()"))).toBe(true);
+  });
+
   test("atomically claims only due exact-operation rows within the requested limit", async () => {
     const exactFirst = "00000000-0000-4000-8000-000000000010";
     const exactSecond = "00000000-0000-4000-8000-000000000011";
     const prefixedOperation = "00000000-0000-4000-8000-000000000012";
     const unknownOutcome = "00000000-0000-4000-8000-000000000013";
-    const nullRecoveryTime = "00000000-0000-4000-8000-000000000014";
+    const immediateRecovery = "00000000-0000-4000-8000-000000000014";
     for (const [mutationId, operation] of [
       [exactFirst, "scheduled_functions.create"], [exactSecond, "scheduled_functions.create"],
       [prefixedOperation, "scheduled_functions.create.child"], [unknownOutcome, "scheduled_functions.create"],
-      [nullRecoveryTime, "scheduled_functions.create"],
+      [immediateRecovery, "scheduled_functions.create"],
     ]) {
       await mutationService.beginProjectMutation(database as never, beginInput({ mutationId, operation }));
     }
@@ -336,7 +463,10 @@ describe("project mutation journal", () => {
     expect(mutationRows.get(mutationKey(PROJECT_REF, exactSecond))?.status).toBe("pending");
     expect(mutationRows.get(mutationKey(PROJECT_REF, prefixedOperation))?.status).toBe("pending");
     expect(mutationRows.get(mutationKey(PROJECT_REF, unknownOutcome))?.status).toBe("outcome_unknown");
-    expect(mutationRows.get(mutationKey(PROJECT_REF, nullRecoveryTime))?.status).toBe("pending");
+    expect(mutationRows.get(mutationKey(PROJECT_REF, immediateRecovery))).toMatchObject({
+      status: "pending",
+      recovery_not_before: expect.any(String),
+    });
     const claimQuery = executedQueries.find((query) => query.startsWith("WITH candidates AS"))!;
     expect(claimQuery).toContain("operation = ANY(?)");
     expect(claimQuery).toContain("FOR UPDATE SKIP LOCKED");
@@ -513,5 +643,174 @@ describe("project mutation journal", () => {
     })).rejects.toThrow("body");
     expect(executedQueries).toHaveLength(queryCount);
     expect(JSON.stringify([...mutationRows.values()])).not.toContain(privateSentinel);
+  });
+
+  test("reconciles only an observed outcome-unknown epoch with hashed evidence", async () => {
+    const fencingEpoch = await recordUnknownOutcome();
+    const evidenceFingerprint = "c".repeat(64);
+
+    const reconciled = await mutationService.reconcileProjectMutation(database as never, beginInput().principal, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, expectedFencingEpoch: fencingEpoch,
+      status: "succeeded", responseStatus: 200,
+      evidence: {
+        source: "scheduled_functions.provider_readback",
+        observedAt: "2026-08-11T00:00:01.000Z",
+        evidenceCode: "RESOURCE_PRESENT",
+        evidenceFingerprint,
+      },
+    });
+
+    expect(reconciled.kind).toBe("updated");
+    expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))).toMatchObject({
+      status: "succeeded",
+      response_status: 200,
+      failure_code: null,
+      receipt: {
+        reconciliation: {
+          source: "scheduled_functions.provider_readback",
+          evidence_code: "RESOURCE_PRESENT",
+          evidence_fingerprint: evidenceFingerprint,
+          target_status: "succeeded",
+        },
+      },
+    });
+  });
+
+  test("rejects stale reconciliation epochs and non-unknown states without mutation", async () => {
+    const fencingEpoch = await recordUnknownOutcome();
+    const evidence = {
+      source: "scheduled_functions.provider_readback",
+      observedAt: "2026-08-11T00:00:01.000Z",
+      evidenceCode: "RESOURCE_ABSENT",
+      evidenceFingerprint: "d".repeat(64),
+    };
+    const stale = await mutationService.reconcileProjectMutation(database as never, beginInput().principal, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, expectedFencingEpoch: fencingEpoch + 1,
+      status: "failed_terminal", responseStatus: 404, failureCode: "RESOURCE_NOT_FOUND", evidence,
+    });
+    const current = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    current.status = "failed_terminal";
+    const repeated = await mutationService.reconcileProjectMutation(database as never, beginInput().principal, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, expectedFencingEpoch: fencingEpoch,
+      status: "failed_terminal", responseStatus: 404, failureCode: "RESOURCE_NOT_FOUND", evidence,
+    });
+
+    expect(stale.kind).toBe("cas_conflict");
+    expect(repeated.kind).toBe("not_reconcilable");
+    expect(current.receipt).toEqual({});
+  });
+
+  test.each([
+    [{ type: "admin" as const, id: "admin" }, { type: "project" as const, id: `project:${PROJECT_REF}` }],
+    [{ type: "master" as const, id: "master" }, { type: "admin" as const, id: "admin" }],
+  ])("allows only the exact %s journal principal to reconcile", async (owner, otherActor) => {
+    const fencingEpoch = await recordUnknownOutcome();
+    const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    Object.assign(row, { principal_type: owner.type, principal_id: owner.id });
+    const reconciliation = {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, expectedFencingEpoch: fencingEpoch,
+      status: "succeeded" as const, responseStatus: 200,
+      evidence: {
+        source: "scheduled_functions.provider_readback",
+        observedAt: "2026-08-11T00:00:01.000Z",
+        evidenceCode: "RESOURCE_PRESENT",
+        evidenceFingerprint: "e".repeat(64),
+      },
+    };
+
+    const forbidden = await mutationService.reconcileProjectMutation(database as never, otherActor, reconciliation);
+    const allowed = await mutationService.reconcileProjectMutation(database as never, owner, reconciliation);
+
+    expect(forbidden).toEqual({ kind: "forbidden" });
+    expect(allowed.kind).toBe("updated");
+  });
+
+  test.each([
+    "2026-08-11T00:00:00.999Z",
+    "2026-08-11T00:10:00.001Z",
+  ])("rejects reconciliation evidence outside the database-clock window: %s", async (observedAt) => {
+    const fencingEpoch = await recordUnknownOutcome();
+
+    const reconciliation = await mutationService.reconcileProjectMutation(
+      database as never,
+      beginInput().principal,
+      {
+        projectRef: PROJECT_REF, mutationId: MUTATION_ID, expectedFencingEpoch: fencingEpoch,
+        status: "succeeded", responseStatus: 200,
+        evidence: {
+          source: "scheduled_functions.provider_readback", observedAt,
+          evidenceCode: "RESOURCE_PRESENT", evidenceFingerprint: "f".repeat(64),
+        },
+      },
+    );
+
+    expect(reconciliation).toEqual({ kind: "invalid_evidence_time" });
+    expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))?.status).toBe("outcome_unknown");
+  });
+
+  test("fails closed instead of incrementing beyond the safe fencing epoch", async () => {
+    await mutationService.beginProjectMutation(database as never, beginInput());
+    const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    row.fencing_epoch = Number.MAX_SAFE_INTEGER;
+
+    await expect(mutationService.claimOrResumeProjectMutation(database as never, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, leaseOwner: "scanner-a",
+      leaseToken: LEASE_TOKEN_A, leaseSeconds: 30,
+    })).rejects.toThrow("fencing epoch is exhausted");
+
+    expect(row.fencing_epoch).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  test("preserves active lease ownership at the safe fencing epoch ceiling", async () => {
+    await beginAndClaim();
+    const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    row.fencing_epoch = Number.MAX_SAFE_INTEGER;
+    row.lease_expires_at = new Date(Date.now() + 60_000).toISOString();
+
+    const resumed = await mutationService.claimOrResumeProjectMutation(database as never, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, leaseOwner: "scheduled-worker",
+      leaseToken: LEASE_TOKEN_A, leaseSeconds: 30,
+    });
+    const competing = await mutationService.claimOrResumeProjectMutation(database as never, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, leaseOwner: "competing-worker",
+      leaseToken: LEASE_TOKEN_B, leaseSeconds: 30,
+    });
+
+    expect(resumed.kind).toBe("claimed");
+    expect(competing.kind).toBe("busy");
+    expect(row.fencing_epoch).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  test("reports an exhausted fencing epoch after a running lease expires", async () => {
+    await beginAndClaim();
+    const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    row.fencing_epoch = Number.MAX_SAFE_INTEGER;
+    row.lease_expires_at = "2026-08-10T00:00:00.000Z";
+
+    await expect(mutationService.claimOrResumeProjectMutation(database as never, {
+      projectRef: PROJECT_REF, mutationId: MUTATION_ID, leaseOwner: "replacement-worker",
+      leaseToken: LEASE_TOKEN_B, leaseSeconds: 30,
+    })).rejects.toThrow("fencing epoch is exhausted");
+
+    expect(row).toMatchObject({
+      status: "running",
+      fencing_epoch: Number.MAX_SAFE_INTEGER,
+      lease_token: LEASE_TOKEN_A,
+    });
+  });
+
+  test("rolls back a recovery scan that encounters a legacy raw resource key", async () => {
+    await mutationService.beginProjectMutation(database as never, beginInput());
+    const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    row.resource_key = "legacy:scheduled-function:nightly";
+    row.recovery_not_before = "2026-08-10T00:00:00.000Z";
+
+    await expect(mutationService.claimRecoverableProjectMutations({
+      operations: ["scheduled_functions.create"], leaseOwner: "scanner-a",
+      leaseSeconds: 30, limit: 1,
+    })).rejects.toThrow("Stored mutation resource key is invalid");
+
+    expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID)))
+      .toMatchObject({ status: "pending", fencing_epoch: 0, lease_token: null });
   });
 });

--- a/packages/management-api/tests/unit/project-mutations.routes.test.ts
+++ b/packages/management-api/tests/unit/project-mutations.routes.test.ts
@@ -5,18 +5,36 @@ const MUTATION_ID = "00000000-0000-4000-8000-000000000001";
 const LEASE_TOKEN_SENTINEL = "00000000-0000-4000-8000-000000000099";
 const JOURNAL_PAYLOAD_SENTINEL = "stored-journal-payload-must-not-be-public";
 const readMutation = mock(() => Promise.resolve(null));
+const reconcileMutation = mock(() => Promise.resolve({ kind: "not_found" as const }));
 const requireProjectOrAdminAuth = mock(() => Promise.resolve(undefined));
+const verifiedPrincipal = mock(() => Promise.resolve({ type: "project" as const, id: "project:proj_1" }));
 
 const mutationService = await import("../../src/services/project-mutation.service");
+const reconciliationService = await import("../../src/services/project-mutation-reconciliation.service");
 const authModule = await import("../../src/middleware/auth");
+const { logger } = await import("../../src/utils/logger");
+const { validationErrorResponse } = await import("../../src/utils/http-validation");
 const readMutationSpy = spyOn(mutationService, "readProjectMutation").mockImplementation(
   readMutation as typeof mutationService.readProjectMutation,
+);
+const reconcileMutationSpy = spyOn(reconciliationService, "reconcileProjectMutationWithAudit").mockImplementation(
+  reconcileMutation as typeof reconciliationService.reconcileProjectMutationWithAudit,
 );
 const authSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
   requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
 );
+const principalSpy = spyOn(authModule, "getVerifiedRequestPrincipal").mockImplementation(
+  verifiedPrincipal as typeof authModule.getVerifiedRequestPrincipal,
+);
+const loggerErrorSpy = spyOn(logger, "error");
 const { projectMutationRoutes } = await import("../../src/routes/project-mutations");
 const app = new Elysia().use(projectMutationRoutes);
+const validationApp = new Elysia()
+  .onError(({ code, error, set }) => {
+    if (code === "VALIDATION") return validationErrorResponse(set);
+    logger.error(`test error [${code}]`, error);
+  })
+  .use(projectMutationRoutes);
 
 function mutationState() {
   return {
@@ -41,23 +59,36 @@ function mutationState() {
   };
 }
 
-function request(path: string): Promise<Response> {
-  return app.handle(new Request(`http://localhost${path}`, {
-    headers: { authorization: "Bearer test" },
+function request(path: string, init: RequestInit = {}, target = app): Promise<Response> {
+  return target.handle(new Request(`http://localhost${path}`, {
+    ...init,
+    headers: {
+      ...Object.fromEntries(new Headers(init.headers)),
+      authorization: "Bearer test",
+      "x-request-id": "mutation-route-request",
+      "user-agent": "mutation-route-test",
+    },
   }));
 }
 
 describe("project mutation status route", () => {
   afterAll(() => {
     readMutationSpy.mockRestore();
+    reconcileMutationSpy.mockRestore();
     authSpy.mockRestore();
+    principalSpy.mockRestore();
+    loggerErrorSpy.mockRestore();
   });
 
   beforeEach(() => {
     readMutation.mockReset();
     readMutation.mockResolvedValue(null);
+    reconcileMutation.mockReset();
+    reconcileMutation.mockResolvedValue({ kind: "not_found" });
     requireProjectOrAdminAuth.mockReset();
     requireProjectOrAdminAuth.mockResolvedValue(undefined);
+    verifiedPrincipal.mockReset();
+    verifiedPrincipal.mockResolvedValue({ type: "project", id: "project:proj_1" });
   });
 
   test("returns only fixed metadata and empty journal projections", async () => {
@@ -105,5 +136,168 @@ describe("project mutation status route", () => {
 
     expect(response.status).toBe(403);
     expect(readMutation).not.toHaveBeenCalled();
+  });
+
+  test("reconciles an unknown outcome with fenced hashed evidence and a redacted response", async () => {
+    const succeeded = { ...mutationState(), receipt: { evidence: JOURNAL_PAYLOAD_SENTINEL } };
+    reconcileMutation.mockResolvedValue({ kind: "updated", mutation: succeeded });
+    const body = {
+      expected_fencing_epoch: 1,
+      status: "succeeded",
+      response_status: 200,
+      evidence: {
+        source: "scheduled_functions.provider_readback",
+        observed_at: "2026-08-11T00:00:01.000Z",
+        evidence_code: "RESOURCE_PRESENT",
+        evidence_fingerprint: "b".repeat(64),
+      },
+    };
+
+    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    });
+    const responseText = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(reconcileMutation).toHaveBeenCalledWith({
+      actor: { type: "project", id: "project:proj_1" },
+      requestId: "mutation-route-request",
+      ipAddress: "unknown",
+      userAgent: "mutation-route-test",
+      mutation: {
+        projectRef: "proj_1", mutationId: MUTATION_ID, expectedFencingEpoch: 1,
+        status: "succeeded", responseStatus: 200, failureCode: undefined,
+        evidence: {
+          source: body.evidence.source,
+          observedAt: body.evidence.observed_at,
+          evidenceCode: body.evidence.evidence_code,
+          evidenceFingerprint: body.evidence.evidence_fingerprint,
+        },
+      },
+    });
+    expect(responseText).toContain('"status":"succeeded"');
+    expect(responseText).not.toContain(JOURNAL_PAYLOAD_SENTINEL);
+  });
+
+  test("requires project authorization before reconciliation", async () => {
+    requireProjectOrAdminAuth.mockResolvedValue({ status: 403, body: { error: "forbidden" } });
+
+    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
+      method: "POST",
+      body: JSON.stringify({
+        expected_fencing_epoch: 1,
+        status: "failed_terminal",
+        response_status: 404,
+        failure_code: "RESOURCE_NOT_FOUND",
+        evidence: {
+          source: "scheduled_functions.provider_readback",
+          observed_at: "2026-08-11T00:00:01.000Z",
+          evidence_code: "RESOURCE_ABSENT",
+          evidence_fingerprint: "c".repeat(64),
+        },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(response.status).toBe(403);
+    expect(reconcileMutation).not.toHaveBeenCalled();
+  });
+
+  test("returns the same state-free 403 when the authenticated principal does not own the journal", async () => {
+    reconcileMutation.mockResolvedValue({ kind: "forbidden" });
+
+    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
+      method: "POST",
+      body: JSON.stringify({
+        expected_fencing_epoch: 1,
+        status: "failed_terminal",
+        response_status: 404,
+        failure_code: "RESOURCE_NOT_FOUND",
+        evidence: {
+          source: "scheduled_functions.provider_readback",
+          observed_at: "2026-08-11T00:00:01.000Z",
+          evidence_code: "RESOURCE_ABSENT",
+          evidence_fingerprint: "d".repeat(64),
+        },
+      }),
+      headers: { "content-type": "application/json" },
+    });
+    const responseText = await response.text();
+
+    expect(response.status).toBe(403);
+    expect(JSON.parse(responseText)).toEqual({ error: "Mutation reconciliation is not permitted" });
+    expect(responseText).not.toContain("outcome_unknown");
+    expect(responseText).not.toContain("failed_terminal");
+  });
+
+  test.each([
+    ["source", "private-source-sentinel", { evidence: { source: "private-source-sentinel/invalid" } }],
+    ["code", "private-code-sentinel", { evidence: { evidence_code: "private-code-sentinel" } }],
+    ["fingerprint", "private-fingerprint-sentinel", {
+      evidence: { evidence_fingerprint: "private-fingerprint-sentinel" },
+    }],
+    ["type", "private-type-sentinel", { status: "private-type-sentinel" }],
+    ["extra field", "private-extra-field-sentinel", { "private-extra-field-sentinel": true }],
+    ["extra evidence field", "private-evidence-extra-sentinel", {
+      evidence: { "private-evidence-extra-sentinel": true },
+    }],
+  ])("rejects an invalid reconciliation %s without response or log reflection", async (_field, sentinel, override) => {
+    const baseBody = {
+      expected_fencing_epoch: 1,
+      status: "succeeded",
+      response_status: 200,
+      evidence: {
+        source: "scheduled_functions.provider_readback",
+        observed_at: "2026-08-11T00:00:01.000Z",
+        evidence_code: "RESOURCE_PRESENT",
+        evidence_fingerprint: "e".repeat(64),
+      },
+    };
+    const evidenceOverride = "evidence" in override ? override.evidence : undefined;
+    const body = {
+      ...baseBody,
+      ...override,
+      evidence: { ...baseBody.evidence, ...evidenceOverride },
+    };
+    loggerErrorSpy.mockClear();
+    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }, validationApp);
+    const responseText = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(JSON.parse(responseText)).toEqual({ message: "Validation failed", code: "VALIDATION_ERROR" });
+    expect(responseText).not.toContain(sentinel);
+    expect(JSON.stringify(loggerErrorSpy.mock.calls)).not.toContain(sentinel);
+    expect(reconcileMutation).not.toHaveBeenCalled();
+  });
+
+  test("rejects an unsafe fencing epoch with a fixed response before reconciliation", async () => {
+    const unsafeEpoch = Number.MAX_SAFE_INTEGER + 1;
+    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        expected_fencing_epoch: unsafeEpoch,
+        status: "succeeded",
+        response_status: 200,
+        evidence: {
+          source: "scheduled_functions.provider_readback",
+          observed_at: "2026-08-11T00:00:01.000Z",
+          evidence_code: "RESOURCE_PRESENT",
+          evidence_fingerprint: "f".repeat(64),
+        },
+      }),
+    }, validationApp);
+    const responseText = await response.text();
+
+    expect(response.status).toBe(400);
+    expect(JSON.parse(responseText)).toEqual({ message: "Validation failed", code: "VALIDATION_ERROR" });
+    expect(responseText).not.toContain(String(unsafeEpoch));
+    expect(reconcileMutation).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #854.

- enforce canonical v1 resource identities across Management, PostgreSQL, and CLI readback
- fence expired leases, cap fencing epochs, schedule recovery durably, and add PostgreSQL 18 race coverage
- add principal-bound outcome reconciliation with transactional audit append
- make validation failures fixed and secret-free across nested routes
- keep CLI release-control envelopes invariant, reject non-success mutation status, and fail closed on malformed remote state

## Verification

- CLI affected contracts: 232 passed
- CLI full suite: 625 passed
- Management affected contracts: 108 passed
- Management local full gate: passed
- PostgreSQL 18.4 lease and migration integration: 19 passed
- CLI and Management typechecks: passed
- CLI bundle and Management Linux x64 compile: passed
- canonical SQL module sync: passed
- git diff checks: passed
- clean-code-guard: 1 fixed, 0 flagged

## Boundaries

No merge, release, deployment, production mutation, or credential change is included.