### PR TITLE
fix(management): disable external mutation reconciliation

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2131,53 +2131,61 @@ describe("supacloud-cli process contract", () => {
         expect(result.stdout + result.stderr).not.toContain("application-service-role");
     });
 
-    test("mutation status exits non-zero for a durable non-success state", async () => {
-        const requestedPaths: string[] = [];
-        const server = Bun.serve({
-            hostname: "127.0.0.1",
-            port: 0,
-            fetch(request) {
-                requestedPaths.push(new URL(request.url).pathname);
-                return Response.json({
-                    project_ref: "abc123",
-                    mutation: {
+    test.each(["pending", "outcome_unknown"] as const)(
+        "mutation status exits non-zero for durable %s state",
+        async (mutationStatus) => {
+            const requestedPaths: string[] = [];
+            const server = Bun.serve({
+                hostname: "127.0.0.1",
+                port: 0,
+                fetch(request) {
+                    requestedPaths.push(new URL(request.url).pathname);
+                    return Response.json({
                         project_ref: "abc123",
-                        mutation_id: SCHEDULE_ID,
-                        operation: "scheduled_functions.create",
-                        resource_key: null,
-                        request_fingerprint: "a".repeat(64),
-                        principal: { type: "project", id: "project:abc123" },
-                        status: "pending",
-                        checkpoint: {},
-                        receipt: null,
-                        response_status: null,
-                        failure_code: null,
-                        lease: { owner: null, expires_at: null, fencing_epoch: 0 },
-                        completed_at: null,
-                        created_at: "2026-08-12T00:00:00.000Z",
-                        updated_at: "2026-08-12T00:00:00.000Z",
-                    },
-                });
-            },
-        });
-        servers.push(server);
+                        mutation: {
+                            project_ref: "abc123",
+                            mutation_id: SCHEDULE_ID,
+                            operation: "scheduled_functions.create",
+                            resource_key: null,
+                            request_fingerprint: "a".repeat(64),
+                            principal: { type: "project", id: "project:abc123" },
+                            status: mutationStatus,
+                            checkpoint: {},
+                            receipt: mutationStatus === "outcome_unknown" ? {} : null,
+                            response_status: null,
+                            failure_code: mutationStatus === "outcome_unknown"
+                                ? "PROVIDER_OUTCOME_UNKNOWN"
+                                : null,
+                            lease: { owner: null, expires_at: null, fencing_epoch: 0 },
+                            completed_at: mutationStatus === "outcome_unknown"
+                                ? "2026-08-12T00:00:00.000Z"
+                                : null,
+                            created_at: "2026-08-12T00:00:00.000Z",
+                            updated_at: "2026-08-12T00:00:00.000Z",
+                        },
+                    });
+                },
+            });
+            servers.push(server);
 
-        const response = await runProjectCli([
-            "mutations", "status", "--ref", "abc123", "--mutation_id", SCHEDULE_ID,
-        ], {
-            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
-            SUPACLOUD_API_TOKEN: "test-token",
-            SUPACLOUD_PROJECT_REF: "abc123",
-        });
-        const payload = JSON.parse(response.stdout);
+            const response = await runProjectCli([
+                "mutations", "status", "--ref", "abc123", "--mutation_id", SCHEDULE_ID,
+            ], {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            });
+            const payload = JSON.parse(response.stdout);
 
-        expect(response.exitCode).toBe(1);
-        expect(requestedPaths).toEqual([`/v1/projects/abc123/mutations/${SCHEDULE_ID}`]);
-        expect(payload).toMatchObject({
-            ok: false,
-            operation: "mutations.status",
-            mutation: { mutation_id: SCHEDULE_ID, status: "pending" },
-            error: { code: "MUTATION_NOT_SUCCEEDED", http_status: null },
-        });
-    });
+            expect(response.exitCode).toBe(1);
+            expect(requestedPaths).toEqual([`/v1/projects/abc123/mutations/${SCHEDULE_ID}`]);
+            expect(payload).toMatchObject({
+                ok: false,
+                operation: "mutations.status",
+                mutation: { mutation_id: SCHEDULE_ID, status: mutationStatus },
+                error: { code: "MUTATION_NOT_SUCCEEDED", http_status: null },
+            });
+            expect(response.stdout).not.toMatch(/"ok"\s*:\s*true/);
+        },
+    );
 });

--- a/packages/management-api/src/api.test.ts
+++ b/packages/management-api/src/api.test.ts
@@ -19,6 +19,7 @@ mock.module("../src/db", () => ({
 }));
 
 import { app as baseApp } from "../src/index";
+import { buildBffProofHeaders } from "../src/services/bff-proof.service";
 import { logger } from "../src/utils/logger";
 
 describe("Management API Integration Tests", () => {
@@ -64,29 +65,69 @@ describe("Management API Integration Tests", () => {
             }), sentinel);
         });
 
-        it("does not reflect an inner API validation value into the response or logger", async () => {
-            const sentinel = "private-type-validation-sentinel";
-            await expectRedactedValidation(app, new Request(
-                `${baseUrl}/v1/projects/proj_1/mutations/00000000-0000-4000-8000-000000000001/reconcile`,
-                {
+        it.each([
+            "anonymous",
+            "project",
+            "admin",
+            "master",
+            "forged delegation",
+            "valid delegation",
+        ] as const)("short-circuits %s reconciliation before reading the request body", async (caller) => {
+            const sentinel = `private-${caller.replaceAll(" ", "-")}-body-sentinel`;
+            const bodyText = `{"${sentinel}"`;
+            const basePath = "/v1/projects/proj_1/mutations/00000000-0000-4000-8000-000000000001/reconcile";
+            const pathname = caller === "valid delegation" ? `${basePath}/` : basePath;
+            const headers = new Headers({ "content-type": "application/json" });
+            if (caller === "project") headers.set("authorization", "Bearer project.service.token");
+            if (caller === "admin") headers.set("authorization", "Bearer admin-token");
+            if (["master", "forged delegation", "valid delegation"].includes(caller)) {
+                headers.set("authorization", `Bearer ${masterToken}`);
+            }
+            if (caller === "forged delegation") {
+                headers.set("x-supaoauth-actor-signature", `v2=${"0".repeat(64)}`);
+            }
+            if (caller === "valid delegation") {
+                const proofHeaders = buildBffProofHeaders({
                     method: "POST",
-                    headers: {
-                        authorization: `Bearer ${masterToken}`,
-                        "content-type": "application/json",
-                    },
-                    body: JSON.stringify({
-                        expected_fencing_epoch: 1,
-                        status: sentinel,
-                        response_status: 200,
-                        evidence: {
-                            source: "scheduled_functions.provider_readback",
-                            observed_at: "2026-08-12T00:00:00.000Z",
-                            evidence_code: "RESOURCE_PRESENT",
-                            evidence_fingerprint: "a".repeat(64),
-                        },
-                    }),
+                    pathname,
+                    actorId: "user:integration-test",
+                    actorType: "user",
+                    requestId: "disabled-reconciliation-proof",
+                    body: bodyText,
+                });
+                for (const [name, value] of Object.entries(proofHeaders)) headers.set(name, value);
+            }
+            const bodyPull = mock(() => undefined);
+            const body = new ReadableStream({
+                type: "bytes",
+                pull(controller) {
+                    bodyPull();
+                    controller.enqueue(new TextEncoder().encode(bodyText));
+                    controller.close();
                 },
-            ), sentinel);
+            });
+            const cloneArrayBuffer = mock(() => Promise.resolve(new ArrayBuffer(0)));
+            const requestClone = mock(() => ({ arrayBuffer: cloneArrayBuffer }) as unknown as Request);
+            const requestArrayBuffer = mock(() => Promise.resolve(new ArrayBuffer(0)));
+            const request = new Request(`${baseUrl}${pathname}`, { method: "POST", headers, body });
+            Object.defineProperty(request, "clone", { value: requestClone });
+            Object.defineProperty(request, "arrayBuffer", { value: requestArrayBuffer });
+            loggerError.mockClear();
+            mockSql.mockClear();
+            const response = await app.handle(request);
+            const responseText = await response.text();
+
+            expect(response.status).toBe(403);
+            expect(JSON.parse(responseText)).toEqual({
+                error: "Mutation reconciliation is not permitted",
+            });
+            expect(responseText).not.toContain(sentinel);
+            expect(JSON.stringify(loggerError.mock.calls)).not.toContain(sentinel);
+            expect(bodyPull).not.toHaveBeenCalled();
+            expect(requestClone).not.toHaveBeenCalled();
+            expect(requestArrayBuffer).not.toHaveBeenCalled();
+            expect(cloneArrayBuffer).not.toHaveBeenCalled();
+            expect(mockSql).not.toHaveBeenCalled();
         });
 
         it("does not reflect a project-create validation value into the response or logger", async () => {

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -1,4 +1,4 @@
-import { Elysia, t } from "elysia";
+import { Elysia, status, t } from "elysia";
 import type { AnyElysia } from "elysia";
 import { logger } from "./utils/logger";
 import { runBootstrapOrExit } from "./runtime/bootstrap-fatal";
@@ -675,6 +675,13 @@ export function registerStaticAssets() {
 /**
  * Register all route modules
  */
+const DISABLED_MUTATION_RECONCILIATION_PATH = /^\/v1\/projects\/[^/]+\/mutations\/[^/]+\/reconcile\/?$/;
+
+function isDisabledMutationReconciliation(request: Request): boolean {
+  return request.method.toUpperCase() === "POST"
+    && DISABLED_MUTATION_RECONCILIATION_PATH.test(new URL(request.url).pathname);
+}
+
 export async function registerAllRoutes(): Promise<AnyElysia> {
   const {
     projectRoutes,
@@ -736,6 +743,11 @@ export async function registerAllRoutes(): Promise<AnyElysia> {
 
   return (
     new Elysia({ name: "api-routes" })
+      .onRequest(({ request }) => {
+        if (isDisabledMutationReconciliation(request)) {
+          return status(403, { error: "Mutation reconciliation is not permitted" });
+        }
+      })
       .use(bffProofBodyCapture)
       // Auth guard runs before every route in this group
       .onBeforeHandle(async ({ request, set }) => {

--- a/packages/management-api/src/routes/project-mutations.ts
+++ b/packages/management-api/src/routes/project-mutations.ts
@@ -1,118 +1,14 @@
-import { Elysia, status, t } from "elysia";
-import { getVerifiedRequestPrincipal, requireProjectOrAdminAuth } from "../middleware/auth";
-import { markRequestAuditCommitted } from "../services/audit.service";
+import { Elysia, status } from "elysia";
+import { requireProjectOrAdminAuth } from "../middleware/auth";
 import {
-  isCanonicalMutationTimestamp,
   isProjectMutationId,
   publicProjectMutation,
   readProjectMutation,
-  type ReconcileProjectMutationInput,
-  type ReconcileProjectMutationResult,
 } from "../services/project-mutation.service";
-import { reconcileProjectMutationWithAudit } from "../services/project-mutation-reconciliation.service";
-import { resolveProxyClientIp } from "../utils/client-ip";
-import { VALIDATION_ERROR_BODY } from "../utils/http-validation";
 
 const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,20}$/;
-const EVIDENCE_SOURCE_PATTERN_TEXT = "^[a-z0-9][a-z0-9._:-]{0,127}$";
-const FAILURE_CODE_PATTERN_TEXT = "^[A-Z][A-Z0-9_]{0,63}$";
-const EVIDENCE_FINGERPRINT_PATTERN_TEXT = "^[0-9a-f]{64}$";
-const EVIDENCE_SOURCE_PATTERN = new RegExp(EVIDENCE_SOURCE_PATTERN_TEXT);
-const FAILURE_CODE_PATTERN = new RegExp(FAILURE_CODE_PATTERN_TEXT);
-const EVIDENCE_FINGERPRINT_PATTERN = new RegExp(EVIDENCE_FINGERPRINT_PATTERN_TEXT);
-const RECONCILIATION_KEYS = new Set([
-  "expected_fencing_epoch", "status", "response_status", "failure_code", "evidence",
-]);
-const EVIDENCE_KEYS = new Set(["source", "observed_at", "evidence_code", "evidence_fingerprint"]);
-
-type ReconciliationBody = {
-  expected_fencing_epoch: number;
-  status: "succeeded" | "failed_terminal";
-  response_status: number | null;
-  failure_code?: string | null;
-  evidence: {
-    source: string;
-    observed_at: string;
-    evidence_code: string;
-    evidence_fingerprint: string;
-  };
-};
-
-function reconciliationResponse(projectRef: string, reconciliation: ReconcileProjectMutationResult) {
-  if (reconciliation.kind === "updated") {
-    return { project_ref: projectRef, mutation: publicProjectMutation(reconciliation.mutation) };
-  }
-  if (reconciliation.kind === "not_found") return status(404, { error: "Mutation not found" });
-  if (reconciliation.kind === "forbidden") {
-    return status(403, { error: "Mutation reconciliation is not permitted" });
-  }
-  if (reconciliation.kind === "invalid_evidence_time") {
-    return status(400, { error: "Evidence timestamp is outside the reconciliation window" });
-  }
-  if (reconciliation.kind === "cas_conflict") {
-    return status(409, { error: "Mutation fencing epoch changed" });
-  }
-  return status(409, { error: `Mutation status '${reconciliation.mutation.status}' cannot be reconciled` });
-}
-
-function plainRecord(candidate: unknown): candidate is Record<string, unknown> {
-  return Boolean(candidate) && typeof candidate === "object" && !Array.isArray(candidate);
-}
-
-function hasOnlyKeys(record: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
-  return Object.keys(record).every((key) => allowed.has(key));
-}
-
-function validReconciliationEvidence(candidate: unknown): boolean {
-  if (!plainRecord(candidate) || !hasOnlyKeys(candidate, EVIDENCE_KEYS)) return false;
-  return typeof candidate.source === "string" && EVIDENCE_SOURCE_PATTERN.test(candidate.source)
-    && typeof candidate.observed_at === "string" && isCanonicalMutationTimestamp(candidate.observed_at)
-    && typeof candidate.evidence_code === "string" && FAILURE_CODE_PATTERN.test(candidate.evidence_code)
-    && typeof candidate.evidence_fingerprint === "string"
-    && EVIDENCE_FINGERPRINT_PATTERN.test(candidate.evidence_fingerprint);
-}
-
-function validReconciliationBody(candidate: unknown): candidate is ReconciliationBody {
-  if (!plainRecord(candidate) || !hasOnlyKeys(candidate, RECONCILIATION_KEYS)) return false;
-  if (!Number.isSafeInteger(candidate.expected_fencing_epoch)
-    || Number(candidate.expected_fencing_epoch) < 1) return false;
-  if (candidate.status !== "succeeded" && candidate.status !== "failed_terminal") return false;
-  if (candidate.response_status !== null
-    && (!Number.isInteger(candidate.response_status)
-      || Number(candidate.response_status) < 100 || Number(candidate.response_status) > 599)) return false;
-  if (candidate.failure_code !== undefined && candidate.failure_code !== null
-    && (typeof candidate.failure_code !== "string" || !FAILURE_CODE_PATTERN.test(candidate.failure_code))) return false;
-  if (!validReconciliationEvidence(candidate.evidence)) return false;
-  if (candidate.status === "succeeded") {
-    return Number(candidate.response_status) >= 200 && Number(candidate.response_status) <= 299
-      && candidate.failure_code == null;
-  }
-  return typeof candidate.failure_code === "string";
-}
-
-function reconciliationInput(
-  projectRef: string,
-  mutationId: string,
-  body: ReconciliationBody,
-): ReconcileProjectMutationInput {
-  return {
-    projectRef, mutationId, expectedFencingEpoch: body.expected_fencing_epoch,
-    status: body.status, responseStatus: body.response_status, failureCode: body.failure_code,
-    evidence: {
-      source: body.evidence.source,
-      observedAt: body.evidence.observed_at,
-      evidenceCode: body.evidence.evidence_code,
-      evidenceFingerprint: body.evidence.evidence_fingerprint,
-    },
-  };
-}
 
 export const projectMutationRoutes = new Elysia({ prefix: "/v1/projects/:ref/mutations" })
-  .onBeforeHandle(async ({ params, request }) => {
-    if (!PROJECT_REF_PATTERN.test(params.ref)) return status(400, { error: "Project ref is invalid" });
-    const authError = await requireProjectOrAdminAuth(request, params.ref);
-    if (authError) return status(authError.status, authError.body);
-  })
   .get("/:mutationId", async ({ params }) => {
     if (!isProjectMutationId(params.mutationId)) {
       return status(400, { error: "mutation_id must be a UUIDv4" });
@@ -124,28 +20,16 @@ export const projectMutationRoutes = new Elysia({ prefix: "/v1/projects/:ref/mut
     if (!mutation) return status(404, { error: "Mutation not found" });
     return { project_ref: params.ref, mutation: publicProjectMutation(mutation) };
   }, {
+    beforeHandle: async ({ params, request }) => {
+      if (!PROJECT_REF_PATTERN.test(params.ref)) return status(400, { error: "Project ref is invalid" });
+      const authError = await requireProjectOrAdminAuth(request, params.ref);
+      if (authError) return status(authError.status, authError.body);
+    },
     detail: { tags: ["mutations"], summary: "Read a durable project mutation" },
   })
-  .post("/:mutationId/reconcile", async ({ params, body, request }) => {
-    if (!isProjectMutationId(params.mutationId)) {
-      return status(400, { error: "mutation_id must be a UUIDv4" });
-    }
-    if (!validReconciliationBody(body)) {
-      return status(400, VALIDATION_ERROR_BODY);
-    }
-    const input = reconciliationInput(params.ref, params.mutationId, body);
-    const actor = await getVerifiedRequestPrincipal(request);
-    if (!actor) return status(401, { error: "Authentication required" });
-    const reconciliation = await reconcileProjectMutationWithAudit({
-      mutation: input,
-      actor,
-      requestId: request.headers.get("x-request-id")?.trim() || crypto.randomUUID(),
-      ipAddress: resolveProxyClientIp(request),
-      userAgent: request.headers.get("user-agent"),
-    });
-    if (reconciliation.kind === "updated") markRequestAuditCommitted(request);
-    return reconciliationResponse(params.ref, reconciliation);
+  .post("/:mutationId/reconcile", () => {
+    return status(403, { error: "Mutation reconciliation is not permitted" });
   }, {
-    body: t.Unknown(),
-    detail: { tags: ["mutations"], summary: "Reconcile an outcome-unknown project mutation" },
+    parse: "none",
+    detail: { tags: ["mutations"], summary: "Reject external mutation reconciliation" },
   });

--- a/packages/management-api/tests/integration/project-mutation-lease.test.ts
+++ b/packages/management-api/tests/integration/project-mutation-lease.test.ts
@@ -12,6 +12,8 @@ import {
 } from "../../src/services/project-mutation.service";
 import { appendAuditEventInTransaction } from "../../src/services/audit.service";
 
+const { app: mutationApi } = await import("../../src/index");
+
 const database = new SQL({
   url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/postgres",
   max: 5,
@@ -156,6 +158,62 @@ describe("project mutation PostgreSQL lease fencing", () => {
 
     expect(stored).toMatchObject({ status: "running", lease_token: fixture.leaseToken });
     expect(Number(stored.fencing_epoch)).toBe(Number.MAX_SAFE_INTEGER);
+  }, 30_000);
+
+  test("external reconciliation cannot mutate an unknown outcome or release its resource", async () => {
+    const fixture = await beginAndClaim();
+    await database.begin((transaction) => completeProjectMutationFailure(transaction, {
+      projectRef, mutationId: fixture.mutationId, leaseToken: fixture.leaseToken,
+      fencingEpoch: fixture.fencingEpoch, status: "outcome_unknown",
+      failureCode: "PROVIDER_OUTCOME_UNKNOWN",
+    }));
+    const [mutationBefore] = await database`
+      SELECT status, fencing_epoch, resource_key, receipt, updated_at
+      FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+    const [auditBefore] = await database`
+      SELECT COUNT(*)::int AS audit_count
+      FROM audit_logs WHERE project_ref = ${projectRef}
+    `;
+
+    const response = await mutationApi.handle(new Request(
+      `http://localhost/v1/projects/${projectRef}/mutations/${fixture.mutationId}/reconcile`,
+      {
+        method: "POST",
+        headers: { authorization: "Bearer integration-test", "content-type": "application/json" },
+        body: JSON.stringify({ status: "succeeded", expected_fencing_epoch: fixture.fencingEpoch }),
+      },
+    ));
+    const [mutationAfter] = await database`
+      SELECT status, fencing_epoch, resource_key, receipt, updated_at
+      FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${fixture.mutationId}
+    `;
+    const [auditAfter] = await database`
+      SELECT COUNT(*)::int AS audit_count
+      FROM audit_logs WHERE project_ref = ${projectRef}
+    `;
+    const competingMutationId = crypto.randomUUID();
+    const competingMutation = await database.begin((transaction) => beginProjectMutation(transaction, {
+      projectRef,
+      mutationId: competingMutationId,
+      operation: "scheduled_functions.create",
+      resource: { type: "scheduled-function", id: fixture.mutationId },
+      requestFingerprint: projectMutationFingerprint({
+        project_ref: projectRef,
+        mutation_id: competingMutationId,
+      }),
+      principal: projectActor,
+    }));
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Mutation reconciliation is not permitted" });
+    expect(mutationAfter).toEqual(mutationBefore);
+    expect(Number(auditAfter.audit_count)).toBe(Number(auditBefore.audit_count));
+    expect(competingMutation).toEqual({
+      kind: "resource_busy",
+      mutationId: fixture.mutationId,
+      status: "outcome_unknown",
+    });
   }, 30_000);
 
   test("allows exactly one reconciliation writer for an unknown outcome epoch", async () => {

--- a/packages/management-api/tests/unit/project-mutations.routes.test.ts
+++ b/packages/management-api/tests/unit/project-mutations.routes.test.ts
@@ -7,7 +7,6 @@ const JOURNAL_PAYLOAD_SENTINEL = "stored-journal-payload-must-not-be-public";
 const readMutation = mock(() => Promise.resolve(null));
 const reconcileMutation = mock(() => Promise.resolve({ kind: "not_found" as const }));
 const requireProjectOrAdminAuth = mock(() => Promise.resolve(undefined));
-const verifiedPrincipal = mock(() => Promise.resolve({ type: "project" as const, id: "project:proj_1" }));
 
 const mutationService = await import("../../src/services/project-mutation.service");
 const reconciliationService = await import("../../src/services/project-mutation-reconciliation.service");
@@ -22,9 +21,6 @@ const reconcileMutationSpy = spyOn(reconciliationService, "reconcileProjectMutat
 );
 const authSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
   requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
-);
-const principalSpy = spyOn(authModule, "getVerifiedRequestPrincipal").mockImplementation(
-  verifiedPrincipal as typeof authModule.getVerifiedRequestPrincipal,
 );
 const loggerErrorSpy = spyOn(logger, "error");
 const { projectMutationRoutes } = await import("../../src/routes/project-mutations");
@@ -63,10 +59,10 @@ function request(path: string, init: RequestInit = {}, target = app): Promise<Re
   return target.handle(new Request(`http://localhost${path}`, {
     ...init,
     headers: {
-      ...Object.fromEntries(new Headers(init.headers)),
       authorization: "Bearer test",
       "x-request-id": "mutation-route-request",
       "user-agent": "mutation-route-test",
+      ...Object.fromEntries(new Headers(init.headers)),
     },
   }));
 }
@@ -76,7 +72,6 @@ describe("project mutation status route", () => {
     readMutationSpy.mockRestore();
     reconcileMutationSpy.mockRestore();
     authSpy.mockRestore();
-    principalSpy.mockRestore();
     loggerErrorSpy.mockRestore();
   });
 
@@ -87,8 +82,6 @@ describe("project mutation status route", () => {
     reconcileMutation.mockResolvedValue({ kind: "not_found" });
     requireProjectOrAdminAuth.mockReset();
     requireProjectOrAdminAuth.mockResolvedValue(undefined);
-    verifiedPrincipal.mockReset();
-    verifiedPrincipal.mockResolvedValue({ type: "project", id: "project:proj_1" });
   });
 
   test("returns only fixed metadata and empty journal projections", async () => {
@@ -138,166 +131,73 @@ describe("project mutation status route", () => {
     expect(readMutation).not.toHaveBeenCalled();
   });
 
-  test("reconciles an unknown outcome with fenced hashed evidence and a redacted response", async () => {
-    const succeeded = { ...mutationState(), receipt: { evidence: JOURNAL_PAYLOAD_SENTINEL } };
-    reconcileMutation.mockResolvedValue({ kind: "updated", mutation: succeeded });
-    const body = {
-      expected_fencing_epoch: 1,
-      status: "succeeded",
-      response_status: 200,
-      evidence: {
-        source: "scheduled_functions.provider_readback",
-        observed_at: "2026-08-11T00:00:01.000Z",
-        evidence_code: "RESOURCE_PRESENT",
-        evidence_fingerprint: "b".repeat(64),
-      },
-    };
-
+  test.each([
+    ["project", "project-service-role"],
+    ["admin", "admin-token"],
+    ["master", "master-token"],
+  ])("returns the same fixed 403 for an authenticated %s caller", async (_role, credential) => {
     const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
       method: "POST",
-      body: JSON.stringify(body),
-      headers: { "content-type": "application/json" },
-    });
-    const responseText = await response.text();
-
-    expect(response.status).toBe(200);
-    expect(reconcileMutation).toHaveBeenCalledWith({
-      actor: { type: "project", id: "project:proj_1" },
-      requestId: "mutation-route-request",
-      ipAddress: "unknown",
-      userAgent: "mutation-route-test",
-      mutation: {
-        projectRef: "proj_1", mutationId: MUTATION_ID, expectedFencingEpoch: 1,
-        status: "succeeded", responseStatus: 200, failureCode: undefined,
-        evidence: {
-          source: body.evidence.source,
-          observedAt: body.evidence.observed_at,
-          evidenceCode: body.evidence.evidence_code,
-          evidenceFingerprint: body.evidence.evidence_fingerprint,
-        },
+      body: JSON.stringify({ status: "succeeded" }),
+      headers: {
+        authorization: `Bearer ${credential}`,
+        "content-type": "application/json",
       },
-    });
-    expect(responseText).toContain('"status":"succeeded"');
-    expect(responseText).not.toContain(JOURNAL_PAYLOAD_SENTINEL);
-  });
-
-  test("requires project authorization before reconciliation", async () => {
-    requireProjectOrAdminAuth.mockResolvedValue({ status: 403, body: { error: "forbidden" } });
-
-    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
-      method: "POST",
-      body: JSON.stringify({
-        expected_fencing_epoch: 1,
-        status: "failed_terminal",
-        response_status: 404,
-        failure_code: "RESOURCE_NOT_FOUND",
-        evidence: {
-          source: "scheduled_functions.provider_readback",
-          observed_at: "2026-08-11T00:00:01.000Z",
-          evidence_code: "RESOURCE_ABSENT",
-          evidence_fingerprint: "c".repeat(64),
-        },
-      }),
-      headers: { "content-type": "application/json" },
     });
 
     expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Mutation reconciliation is not permitted" });
+    expect(requireProjectOrAdminAuth).not.toHaveBeenCalled();
+    expect(readMutation).not.toHaveBeenCalled();
     expect(reconcileMutation).not.toHaveBeenCalled();
   });
 
-  test("returns the same state-free 403 when the authenticated principal does not own the journal", async () => {
-    reconcileMutation.mockResolvedValue({ kind: "forbidden" });
+  test("returns the fixed denial without authenticating an anonymous caller", async () => {
+    const response = await app.handle(new Request(
+      `http://localhost/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
+        method: "POST",
+        body: "private-unauthenticated-body-sentinel",
+        headers: { "content-type": "application/json" },
+      },
+    ));
 
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Mutation reconciliation is not permitted" });
+    expect(requireProjectOrAdminAuth).not.toHaveBeenCalled();
+    expect(readMutation).not.toHaveBeenCalled();
+    expect(reconcileMutation).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["valid JSON", "private-valid-body-sentinel", '{"private-valid-body-sentinel":true}'],
+    ["malformed JSON", "private-malformed-body-sentinel", '{"private-malformed-body-sentinel"'],
+  ])("does not parse or reflect a %s reconciliation body", async (_shape, sentinel, body) => {
+    loggerErrorSpy.mockClear();
     const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
       method: "POST",
-      body: JSON.stringify({
-        expected_fencing_epoch: 1,
-        status: "failed_terminal",
-        response_status: 404,
-        failure_code: "RESOURCE_NOT_FOUND",
-        evidence: {
-          source: "scheduled_functions.provider_readback",
-          observed_at: "2026-08-11T00:00:01.000Z",
-          evidence_code: "RESOURCE_ABSENT",
-          evidence_fingerprint: "d".repeat(64),
-        },
-      }),
+      body,
       headers: { "content-type": "application/json" },
-    });
+    }, validationApp);
     const responseText = await response.text();
 
     expect(response.status).toBe(403);
     expect(JSON.parse(responseText)).toEqual({ error: "Mutation reconciliation is not permitted" });
-    expect(responseText).not.toContain("outcome_unknown");
-    expect(responseText).not.toContain("failed_terminal");
-  });
-
-  test.each([
-    ["source", "private-source-sentinel", { evidence: { source: "private-source-sentinel/invalid" } }],
-    ["code", "private-code-sentinel", { evidence: { evidence_code: "private-code-sentinel" } }],
-    ["fingerprint", "private-fingerprint-sentinel", {
-      evidence: { evidence_fingerprint: "private-fingerprint-sentinel" },
-    }],
-    ["type", "private-type-sentinel", { status: "private-type-sentinel" }],
-    ["extra field", "private-extra-field-sentinel", { "private-extra-field-sentinel": true }],
-    ["extra evidence field", "private-evidence-extra-sentinel", {
-      evidence: { "private-evidence-extra-sentinel": true },
-    }],
-  ])("rejects an invalid reconciliation %s without response or log reflection", async (_field, sentinel, override) => {
-    const baseBody = {
-      expected_fencing_epoch: 1,
-      status: "succeeded",
-      response_status: 200,
-      evidence: {
-        source: "scheduled_functions.provider_readback",
-        observed_at: "2026-08-11T00:00:01.000Z",
-        evidence_code: "RESOURCE_PRESENT",
-        evidence_fingerprint: "e".repeat(64),
-      },
-    };
-    const evidenceOverride = "evidence" in override ? override.evidence : undefined;
-    const body = {
-      ...baseBody,
-      ...override,
-      evidence: { ...baseBody.evidence, ...evidenceOverride },
-    };
-    loggerErrorSpy.mockClear();
-    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    }, validationApp);
-    const responseText = await response.text();
-
-    expect(response.status).toBe(400);
-    expect(JSON.parse(responseText)).toEqual({ message: "Validation failed", code: "VALIDATION_ERROR" });
     expect(responseText).not.toContain(sentinel);
     expect(JSON.stringify(loggerErrorSpy.mock.calls)).not.toContain(sentinel);
+    expect(requireProjectOrAdminAuth).not.toHaveBeenCalled();
+    expect(readMutation).not.toHaveBeenCalled();
     expect(reconcileMutation).not.toHaveBeenCalled();
   });
 
-  test("rejects an unsafe fencing epoch with a fixed response before reconciliation", async () => {
-    const unsafeEpoch = Number.MAX_SAFE_INTEGER + 1;
-    const response = await request(`/v1/projects/proj_1/mutations/${MUTATION_ID}/reconcile`, {
+  test("does not validate mutation IDs on the disabled reconciliation route", async () => {
+    const response = await request("/v1/projects/proj_1/mutations/not-a-uuid/reconcile", {
       method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        expected_fencing_epoch: unsafeEpoch,
-        status: "succeeded",
-        response_status: 200,
-        evidence: {
-          source: "scheduled_functions.provider_readback",
-          observed_at: "2026-08-11T00:00:01.000Z",
-          evidence_code: "RESOURCE_PRESENT",
-          evidence_fingerprint: "f".repeat(64),
-        },
-      }),
-    }, validationApp);
-    const responseText = await response.text();
+    });
 
-    expect(response.status).toBe(400);
-    expect(JSON.parse(responseText)).toEqual({ message: "Validation failed", code: "VALIDATION_ERROR" });
-    expect(responseText).not.toContain(String(unsafeEpoch));
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Mutation reconciliation is not permitted" });
+    expect(requireProjectOrAdminAuth).not.toHaveBeenCalled();
+    expect(readMutation).not.toHaveBeenCalled();
     expect(reconcileMutation).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Parent/source: #863 (merged old head 8230047300ad15f64370203b23f0f474ad36b2f7 as b59867c249fa8c25756149c7cb06c06f15217abf). Latest main also includes the release metadata merge from #862.

Reason: the public POST /v1/projects/:ref/mutations/:mutationId/reconcile endpoint must not let any external caller mutate an outcome-unknown journal. This follow-up was created after #863 merged, so it targets latest main rather than updating the closed PR.

Changes:
- short-circuit the exact disabled POST path before body capture, rate limiting, authentication, delegation, audit, or database access
- keep route-level parse:none fixed 403 defense and preserve authenticated GET mutation status
- retain the internal reconciliation service for a future server-owned adapter
- verify CLI outcome_unknown readback remains a non-success process result

Security contract:
- anonymous, project, admin, master, forged delegation, and valid-shaped delegation requests all receive fixed HTTP 403
- malformed streaming bodies are not pulled, cloned, parsed, reflected, or logged
- mutation state, fencing epoch, resource binding, receipt, updated_at, and audit count remain unchanged
- the resource remains busy and internal reconciliation concurrency/rollback contracts remain available

Verification:
- clean-code-guard: clean
- independent frozen diff review: PASS, 0 P0-P3
- Management route/API: 36 pass
- PostgreSQL 18.4 mutation integration/migration: 20 pass
- Management test:local: exit 0 (shared unit 1357 pass; isolated suites pass; integration 39 pass)
- CLI full suite: 626 pass
- CLI and Management typecheck/build: pass
- SQL module sync and git diff --check: pass

Frozen:
- base 8b745af77c4d36d49bec57e4b13f57cf65e6a795
- head c739ded4107ef18635b425630bebaeb60c24da86
- tree 2b69254d5d0dc36f75abff841400eb013211ab6a
- stable patch-id 106b7e82e772e9055e6c87fb13111e9fbe7b0c60
- staged diff SHA-256 8d0253f47ba656f2b6664f4bae5c798313cb2816772fa303b7e9f16575c37f09

No merge, release, deployment, migration, or production write is requested by this PR.
