### PR TITLE
fix(admin): fail closed on version probe errors

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -89,7 +89,9 @@ npx @supacloud/admin project service_control --ref abc123 --service gotrue --ser
 Each component reports `status` as `ok`, `unknown`, or `error`; a failed probe
 never substitutes a guessed version. Binary evidence is bound to the active
 systemd `ExecStart`, and Web Console evidence comes from its component marker
-plus an explicit `tree_sha256` digest.
+plus an explicit `tree_sha256` digest. An `unknown` component remains a valid
+inventory result, while any `error` component makes the CLI exit non-zero after
+printing the structured report.
 
 ## Verified platform upgrades
 

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -99,6 +99,21 @@ async function runAdminCliPath(entryPath: string, args: string[]): Promise<{ exi
     return { exitCode, output: stdout + stderr };
 }
 
+async function runInlineAdminCli(source: string): Promise<{ exitCode: number; output: string }> {
+    const processHandle = Bun.spawn([process.execPath, "-e", source], {
+        cwd: PACKAGE_ROOT,
+        env: cleanEnvironment(),
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        processHandle.exited,
+        new Response(processHandle.stdout).text(),
+        new Response(processHandle.stderr).text(),
+    ]);
+    return { exitCode, output: stdout + stderr };
+}
+
 async function runAggregateFailureCli(): Promise<{ exitCode: number; output: string }> {
     const source = [
         'import { Type } from "@sinclair/typebox";',
@@ -112,18 +127,20 @@ async function runAggregateFailureCli(): Promise<{ exitCode: number; output: str
         '} };',
         'await runCli(tools, ["fixture", "run"], { commandName: "fixture-cli" });',
     ].join("\n");
-    const processHandle = Bun.spawn([process.execPath, "-e", source], {
-        cwd: PACKAGE_ROOT,
-        env: cleanEnvironment(),
-        stdout: "pipe",
-        stderr: "pipe",
-    });
-    const [exitCode, stdout, stderr] = await Promise.all([
-        processHandle.exited,
-        new Response(processHandle.stdout).text(),
-        new Response(processHandle.stderr).text(),
-    ]);
-    return { exitCode, output: stdout + stderr };
+    return runInlineAdminCli(source);
+}
+
+async function runVersionTransportFailureCli(): Promise<{ exitCode: number; output: string }> {
+    const source = [
+        'import { runCli } from "./src/shared/cli.ts";',
+        'import { registerSshTools } from "./src/shared/tools/ssh-tools.ts";',
+        'let registered;',
+        'registerSshTools({ tool: (_name, _description, schema, callback) => { registered = { schema, callback }; } }, {',
+        '  exec: async () => { throw new Error("SUPACLOUD_API_TOKEN=admin-cli-private-sentinel"); },',
+        '});',
+        'await runCli({ ssh: registered }, ["ssh", "versions"], { commandName: "supacloud-admin" });',
+    ].join("\n");
+    return runInlineAdminCli(source);
 }
 
 function studioProcessInventory(): Array<Record<string, unknown>> {
@@ -647,6 +664,19 @@ describe("supacloud-admin process contract", () => {
         expect(execution.exitCode).toBe(1);
         expect(execution.output).toContain("❌ Unknown action: undefined");
         expect(execution.output).not.toContain("test-token");
+    });
+
+    test("returns a non-zero exit code when version probes lose SSH transport", async () => {
+        const execution = await runVersionTransportFailureCli();
+        const report = JSON.parse(execution.output) as {
+            components: Record<string, { status: string; error: string | null }>;
+        };
+
+        expect(execution.exitCode).toBe(1);
+        expect(Object.values(report.components).every(component => component.status === "error")).toBe(true);
+        expect(report.components.management_api.error).toBe("systemd_probe_transport_failed");
+        expect(report.components.web_console.error).toBe("web_console_probe_transport_failed");
+        expect(execution.output).not.toContain("admin-cli-private-sentinel");
     });
 
     test("documents every project create domain flag without API context", async () => {

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -29,7 +29,10 @@ import {
     SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_SIZE,
 } from "../../../../management-api/src/sigstore-trusted-root";
 
-type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: Array<{ type: "text"; text: string }> }>;
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+}>;
 type FakeExecResult = { success: boolean; stdout: string; stderr: string; code: number };
 type FakeExecPlan = { fragment: string; executions: FakeExecResult[]; calls: number };
 type UpgradeTransportOutcome = "late_success" | "stream_error";
@@ -91,6 +94,7 @@ class FakeSsh {
     diagnosticExecFails = false;
     diagnosticFailureStdout = "";
     diagnosticFailureStderr = "diagnostic failed";
+    probeExecRejection: { value: unknown } | undefined;
     readonly matchingExecResults: FakeExecPlan[] = [];
 
     async ping(): Promise<boolean> {
@@ -106,6 +110,7 @@ class FakeSsh {
             fixedPlan.calls += 1;
             return fixedPlan.executions[executionIndex]!;
         }
+        if (this.probeExecRejection) throw this.probeExecRejection.value;
         if (this.prepareExecOutcomeUnknown && command.includes("mkdir -m 700 --")) {
             throw new SshCommandOutcomeUnknownError("SSH command timed out after 30000ms; remote outcome is unknown");
         }
@@ -1579,6 +1584,7 @@ describe("ssh admin tool", () => {
         const response = await captureSshTool(ssh).invoke({ action: "versions" });
         const report = JSON.parse(response.content[0]?.text ?? "") as any;
 
+        expect(response.isError).not.toBe(true);
         expect(report.schema_version).toBe(1);
         expect(Object.keys(report.components)).toEqual([
             "management_api", "edge_runtime", "caddy", "web_console",
@@ -2167,6 +2173,41 @@ describe("ssh admin tool", () => {
         expect(JSON.parse(malformedResponse.content[0]?.text ?? "").components.management_api).toMatchObject({
             status: "error", path: null, error: "exec_start_invalid",
         });
+        expect(malformedResponse.isError).toBe(true);
+    });
+
+    test("versions marks transport failures as tool errors without reflecting diagnostics", async () => {
+        const ssh = new FakeSsh();
+        const privateDiagnostic = "SUPACLOUD_API_TOKEN=admin-version-private-sentinel";
+        ssh.probeExecRejection = { value: new Error(privateDiagnostic) };
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const output = response.content[0]?.text ?? "";
+        const components = JSON.parse(output).components;
+
+        expect(response.isError).toBe(true);
+        expect(components.management_api.error).toBe("systemd_probe_transport_failed");
+        expect(components.edge_runtime.error).toBe("systemd_probe_transport_failed");
+        expect(components.caddy.error).toBe("systemd_probe_transport_failed");
+        expect(components.web_console.error).toBe("web_console_probe_transport_failed");
+        expect(output).not.toContain(privateDiagnostic);
+    });
+
+    test("versions keeps unavailable components unknown without reporting a transport failure", async () => {
+        const ssh = new FakeSsh();
+        addFakeExecution(ssh, "systemctl show", fakeSuccess("LoadState=not-found\nExecStart=\n"));
+        addFakeExecution(ssh, "ROOT='/opt/supacloud/web-console/current'", {
+            success: false, stdout: "", stderr: "", code: 43,
+        });
+
+        const response = await captureSshTool(ssh).invoke({ action: "versions" });
+        const components = JSON.parse(response.content[0]?.text ?? "").components;
+
+        expect(response.isError).not.toBe(true);
+        expect(components.management_api).toMatchObject({ status: "unknown", error: "unit_not_loaded" });
+        expect(components.edge_runtime).toMatchObject({ status: "unknown", error: "unit_not_loaded" });
+        expect(components.caddy).toMatchObject({ status: "unknown", error: "unit_not_loaded" });
+        expect(components.web_console).toMatchObject({ status: "unknown", error: "web_console_missing" });
     });
 
     test("versions preserves successful fields when one fixed probe fails", async () => {

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -1073,6 +1073,14 @@ async function platformVersions(ssh: SshTransport) {
     };
 }
 
+function platformVersionsToolResult(report: Awaited<ReturnType<typeof platformVersions>>) {
+    const isError = Object.values(report.components).some(component => component.status === "error");
+    return {
+        content: [{ type: "text" as const, text: JSON.stringify(report, null, 2) }],
+        ...(isError ? { isError: true } : {}),
+    };
+}
+
 export function registerSshTools(server: { tool: (...args: any[]) => void }, ssh: SshTransport): void {
     server.tool(
         "ssh",
@@ -1298,8 +1306,7 @@ Actions: ping, setup, install, upgrade, versions, diagnose, exec, troubleshoot, 
                     break;
                 }
                 case "versions": {
-                    text = JSON.stringify(await platformVersions(ssh), null, 2);
-                    break;
+                    return platformVersionsToolResult(await platformVersions(ssh));
                 }
                 case "diagnose": {
                     const cmds = [


### PR DESCRIPTION
## Summary

- mark `ssh versions` as a tool error when any component probe has `status=error`
- preserve the structured, secret-free inventory for diagnostics
- keep genuinely unavailable components as `unknown` and a successful CLI result

## Why

`@supacloud/admin@0.12.0 ssh versions` can report all four production probes as transport failures while exiting 0. That is a false-success boundary for platform upgrade validation.

## Verification

- Admin full suite: 398 pass, 0 fail, 26 existing macOS skips
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- black-box CLI process: exit 1 with three `systemd_probe_transport_failed` and one `web_console_probe_transport_failed`; private diagnostic sentinel absent

clean-code-guard: 2 fixed, 0 flagged for author

This PR does not merge, release, or deploy anything.
