### PR TITLE
fix(cli): bind legacy migration identities to content

### DIFF
--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -344,6 +344,115 @@ describe("database migration helpers", () => {
         }
     });
 
+    test("accepts only content-bound legacy versions and skips them without a write", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const migrationName = "20260425123000_create_users";
+        const migrationSql = "CREATE TABLE users (id uuid);\n";
+        const postedNames: string[] = [];
+        try {
+            writeFileSync(join(dir, `${migrationName}.sql`), migrationSql);
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [{
+                        version: "1785220280",
+                        name: migrationName,
+                        statements: [`\n${migrationSql.trim()}\n`],
+                    }],
+                }),
+                post: async (_path: string, body: { name: string }) => {
+                    postedNames.push(body.name);
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            const dryRun = await callback({ action: "push_migrations", ref: "proj", dir, dry_run: true });
+            expect(dryRun.content[0].text).toContain(`Already applied:\n  - ${migrationName}.sql`);
+
+            const apply = await callback({ action: "push_migrations", ref: "proj", dir });
+            expect(apply.content[0].text).toContain("Applied: 0");
+            expect(apply.content[0].text).toContain("Skipped: 1");
+            expect(postedNames).toEqual([]);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test.each([
+        ["changed content", ["CREATE TABLE users (id text);"]],
+        ["multiple statements", ["CREATE TABLE users (id uuid);", "SELECT 1;"]],
+        ["missing statements", undefined],
+    ])("rejects a legacy migration name with %s", async (_case, statements) => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [{
+                        version: "1785220280",
+                        name: "20260425123000_create_users",
+                        statements,
+                    }],
+                }),
+            });
+
+            await expect(callback({ action: "push_migrations", ref: "proj", dir, dry_run: true }))
+                .rejects.toThrow("Migration identity conflicts");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("keeps same-version renamed migrations conflicting even when SQL matches", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [{
+                        version: "20260425123000",
+                        name: "20260425123000_renamed_users",
+                        statements: ["CREATE TABLE users (id uuid);"],
+                    }],
+                }),
+            });
+
+            await expect(callback({ action: "push_migrations", ref: "proj", dir, dry_run: true }))
+                .rejects.toThrow("Migration identity conflicts");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects ambiguous duplicate legacy names even when both contents match", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const migrationName = "20260425123000_create_users";
+        const migrationSql = "CREATE TABLE users (id uuid);";
+        try {
+            writeFileSync(join(dir, `${migrationName}.sql`), `${migrationSql}\n`);
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [
+                        { version: "1785220280", name: migrationName, statements: [migrationSql] },
+                        { version: "1785220281", name: migrationName, statements: [migrationSql] },
+                    ],
+                }),
+            });
+
+            await expect(callback({ action: "push_migrations", ref: "proj", dir, dry_run: true }))
+                .rejects.toThrow("Migration identity conflicts");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     test("skips only the exact already-applied migration response", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         try {

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -221,31 +221,63 @@ function migrationIdentityKey(version: string, name: string): string {
 }
 
 type MigrationIdentity = { name: string; version: string };
+type RemoteMigrationIdentity = MigrationIdentity & { statements: unknown };
 type MigrationIdentityConflict = {
     file: string;
     local: MigrationIdentity;
     remote: MigrationIdentity;
 };
 
-function migrationIdentities(data: unknown): MigrationIdentity[] {
+function migrationIdentities(data: unknown): RemoteMigrationIdentity[] {
     return migrationRows(data).flatMap((row) => (
         row.version == null || row.name == null
             ? []
-            : [{ version: String(row.version), name: String(row.name) }]
+            : [{ version: String(row.version), name: String(row.name), statements: row.statements }]
     ));
 }
 
-function identityConflicts(local: MigrationIdentity, remote: MigrationIdentity): boolean {
+function isLegacyNameBoundMigration(
+    local: MigrationFile,
+    remote: RemoteMigrationIdentity,
+    remoteMigrations: RemoteMigrationIdentity[],
+): boolean {
+    return remoteMigrations.filter((candidate) => candidate.name === local.name).length === 1
+        && local.name === remote.name
+        && local.version !== remote.version
+        && Array.isArray(remote.statements)
+        && remote.statements.length === 1
+        && typeof remote.statements[0] === "string"
+        && remote.statements[0].trim() === local.sql.trim();
+}
+
+function identityConflicts(
+    local: MigrationFile,
+    remote: RemoteMigrationIdentity,
+    remoteMigrations: RemoteMigrationIdentity[],
+): boolean {
     const reusesVersionOrName = local.version === remote.version || local.name === remote.name;
     const exactlyMatches = local.version === remote.version && local.name === remote.name;
-    return reusesVersionOrName && !exactlyMatches;
+    return reusesVersionOrName
+        && !exactlyMatches
+        && !isLegacyNameBoundMigration(local, remote, remoteMigrations);
 }
 
 function migrationIdentityConflicts(data: unknown, migrationFiles: MigrationFile[]): MigrationIdentityConflict[] {
     const remoteMigrations = migrationIdentities(data);
     return migrationFiles.flatMap((localMigration) => remoteMigrations
-        .filter((remoteMigration) => identityConflicts(localMigration, remoteMigration))
+        .filter((remoteMigration) => identityConflicts(localMigration, remoteMigration, remoteMigrations))
         .map((remoteMigration) => ({ file: localMigration.file, local: localMigration, remote: remoteMigration })));
+}
+
+function legacyNameBoundMigrationKeys(data: unknown, migrationFiles: MigrationFile[]): Set<string> {
+    const remoteMigrations = migrationIdentities(data);
+    return new Set(migrationFiles.flatMap((localMigration) => (
+        remoteMigrations.some((remoteMigration) => (
+            isLegacyNameBoundMigration(localMigration, remoteMigration, remoteMigrations)
+        ))
+            ? [migrationIdentityKey(localMigration.version, localMigration.name)]
+            : []
+    )));
 }
 
 function assertNoMigrationIdentityConflicts(data: unknown, migrationFiles: MigrationFile[]): void {
@@ -582,9 +614,12 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     const skipped: string[] = [];
                     const nameBoundMarkerKeys = nameBoundMigrationMarkerKeys(migrationsResult.data);
                     const historicalChecksumKeys = historicalChecksumMarkerKeys(migrationsResult.data, migrationFiles);
+                    const legacyNameBoundKeys = legacyNameBoundMigrationKeys(migrationsResult.data, migrationFiles);
                     for (const { file, name, version, sql } of migrationFiles) {
                         const migrationKey = migrationIdentityKey(version, name);
-                        if (nameBoundMarkerKeys.has(migrationKey) || historicalChecksumKeys.has(migrationKey)) {
+                        if (nameBoundMarkerKeys.has(migrationKey)
+                            || historicalChecksumKeys.has(migrationKey)
+                            || legacyNameBoundKeys.has(migrationKey)) {
                             skipped.push(file);
                             continue;
                         }


### PR DESCRIPTION
## Summary
- accept a legacy migration ledger version only when the unique remote name and single normalized SQL statement exactly match the local migration
- classify the content-bound legacy migration as already applied in dry-run and skip it without a migration POST during apply
- keep changed content, multiple statements, duplicate names, and same-version renames fail-closed

## Verification
- CLI full suite: 699 pass, 0 fail
- typecheck and production build pass
- live read-only migration dry-run: legacy identities recognized as already applied; only current unpublished migrations remain pending
- git diff --check

clean-code-guard: 2 fixed, 0 flagged