### PR TITLE
fix(cli): redact database mutation failures

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -200,7 +200,11 @@ dry-run reporting or apply can continue. This keeps the preview consistent with
 the server conflict that would otherwise occur after deployment starts.
 Mutation failures use the release-control receipt schema and never include the
 server response body. `OUTCOME_UNKNOWN` requires a fresh migration inventory
-read before deciding whether a retry is safe.
+read before deciding whether a retry is safe. A migration push failure also
+reports the local files applied or skipped before the failed file, so operators
+can reconcile a partially completed sequence without exposing SQL. Baseline
+success requires a bounded migration-inventory readback that confirms every
+requested version, name, baseline marker, and checksum.
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
 Bun and runs a local syntax check before upload. The Management API validates and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -198,6 +198,9 @@ it never empties a bucket. Mutation receipts bind `project_ref`, `bucket_id`,
 name with another version, or a local version with another name, before either
 dry-run reporting or apply can continue. This keeps the preview consistent with
 the server conflict that would otherwise occur after deployment starts.
+Mutation failures use the release-control receipt schema and never include the
+server response body. `OUTCOME_UNKNOWN` requires a fresh migration inventory
+read before deciding whether a retry is safe.
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
 Bun and runs a local syntax check before upload. The Management API validates and

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2078,6 +2078,9 @@ describe("supacloud-cli process contract", () => {
             schema: "supacloud.cli.release-control.v1",
             ok: false,
             operation: "database.push_migrations",
+            applied_before_failure: [],
+            skipped_before_failure: [],
+            failed_file: "20260729090000_create_orders.sql",
             error: { code: "OUTCOME_UNKNOWN", http_status: 503 },
         });
         expect(result.stdout + result.stderr).not.toContain(responseSecret);

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1991,7 +1991,7 @@ describe("supacloud-cli process contract", () => {
                 const path = new URL(request.url).pathname;
                 requestedPaths.push(path);
                 if (request.method === "GET") return Response.json([]);
-                return Response.json({ code: "migration_baseline_rejected" }, { status: 400 });
+                return Response.json({ code: "migration_baseline_rejected", secret: "baseline-response-secret" }, { status: 400 });
             },
         });
         servers.push(server);
@@ -2006,11 +2006,81 @@ describe("supacloud-cli process contract", () => {
         );
 
         expect(result.exitCode).toBe(1);
-        expect(result.stdout).toContain("❌ Failed (400)");
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "database.baseline_migrations",
+            error: { code: "HTTP_ERROR", http_status: 400 },
+        });
+        expect(result.stdout + result.stderr).not.toContain("baseline-response-secret");
         expect(requestedPaths).toEqual([
             "/v1/projects/abc123/database/migrations",
             "/v1/projects/abc123/database/migrations/baseline",
         ]);
+    });
+
+    test("returns a non-zero secret-free direct migration failure", async () => {
+        const responseSecret = "direct-migration-response-secret";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                return Response.json({ message: responseSecret }, { status: 503 });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(
+            ["database", "apply_migration", "--name", "safe_name", "--sql", "SELECT 1;"],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(result.exitCode).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "database.apply_migration",
+            error: { code: "OUTCOME_UNKNOWN", http_status: 503 },
+        });
+        expect(result.stdout + result.stderr).not.toContain(responseSecret);
+    });
+
+    test("returns a non-zero secret-free migration push failure", async () => {
+        const migrationRoot = mkdtempSync(join(tmpdir(), "supacloud-cli-push-"));
+        temporaryDirectories.push(migrationRoot);
+        writeFileSync(join(migrationRoot, "20260729090000_create_orders.sql"), "CREATE TABLE orders (id uuid);\n");
+        const responseSecret = "migration-push-response-secret";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                if (request.method === "GET") return Response.json([]);
+                return Response.json({ message: responseSecret }, { status: 503 });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(
+            ["database", "push_migrations", "--dir", migrationRoot],
+            {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+            },
+        );
+
+        expect(result.exitCode).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "database.push_migrations",
+            error: { code: "OUTCOME_UNKNOWN", http_status: 503 },
+        });
+        expect(result.stdout + result.stderr).not.toContain(responseSecret);
     });
 
     test("returns a non-zero machine-readable Auth failure without echoing config secrets", async () => {

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -43,6 +43,47 @@ function migrationInventoryFixture(overrides: Record<string, unknown> = {}) {
     };
 }
 
+function migrationMutationReceipt(name: string, sql: string, version = "20260425123000") {
+    const statements = [sql.trim()];
+    const normalizedStatements = [sql.replace(/\r\n?/g, "\n").trim()];
+    return {
+        version,
+        name,
+        statements,
+        checksum: createHash("sha256").update(JSON.stringify({ version, name, statements: normalizedStatements })).digest("hex"),
+    };
+}
+
+function baselineMutationReceipt(migrations: Array<{ version: string; name: string }>) {
+    return {
+        marked: migrations.length,
+        already_applied: 0,
+        migrations: migrations.map(({ version, name }) => {
+            const statements = [`baseline:${name}`];
+            return {
+                version,
+                name,
+                checksum: createHash("sha256").update(JSON.stringify({ version, name, statements })).digest("hex"),
+            };
+        }),
+    };
+}
+
+function baselineInventory(migrations: Array<{ version: string; name: string }>) {
+    return migrations.map(({ version, name }) => migrationInventoryFixture({
+        version,
+        name,
+        statements: [`baseline:${name}`],
+    }));
+}
+
+function sqlBatchReceipt(commands: string[]) {
+    return {
+        command: "BATCH",
+        statements: commands.map((command, index) => ({ index: index + 1, command, rowCount: 0, durationMs: 1 })),
+    };
+}
+
 describe("database migration helpers", () => {
     test.each([
         ["apply_migration", { action: "apply_migration", ref: "proj", name: "safe_name", sql: "SELECT 1;" }],
@@ -109,6 +150,65 @@ describe("database migration helpers", () => {
             error: { code: "OUTCOME_UNKNOWN", http_status: 409 },
         });
         expect(response.content[0].text).not.toContain(responseSecret);
+    });
+
+    test("accepts only a migration receipt bound to the direct-apply request", async () => {
+        const callback = captureDatabaseTool({
+            postReleaseMutation: async () => ({
+                ok: true,
+                status: 200,
+                data: migrationMutationReceipt("safe_name", "SELECT 1;", "1770000000"),
+            }),
+        });
+
+        const response = await callback({ action: "apply_migration", ref: "proj", name: "safe_name", sql: "SELECT 1;" });
+
+        expect(response.isError).toBeUndefined();
+        expect(response.content[0].text).toContain("Migration 'safe_name' applied");
+    });
+
+    test("accepts a direct-apply receipt normalized from CRLF input", async () => {
+        const sql = "CREATE TABLE safe_table (\r\n  id uuid\r\n);\r\n";
+        const callback = captureDatabaseTool({
+            postReleaseMutation: async () => ({
+                ok: true,
+                status: 200,
+                data: migrationMutationReceipt("safe_name", sql, "1770000000"),
+            }),
+        });
+
+        const response = await callback({ action: "apply_migration", ref: "proj", name: "safe_name", sql });
+
+        expect(response.isError).toBeUndefined();
+        expect(response.content[0].text).toContain("Migration 'safe_name' applied");
+    });
+
+    test.each([null, {}, { version: "1770000000", name: "other", statements: ["SELECT 1;"] }])(
+        "fails a malformed direct-apply success closed",
+        async (receiptPayload) => {
+            const callback = captureDatabaseTool({
+                postReleaseMutation: async () => ({ ok: true, status: 200, data: receiptPayload }),
+            });
+
+            const response = await callback({ action: "apply_migration", ref: "proj", name: "safe_name", sql: "SELECT 1;" });
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+        },
+    );
+
+    test.each([201, 202, 204])("does not treat HTTP %d as a completed direct apply", async (status) => {
+        const callback = captureDatabaseTool({
+            postReleaseMutation: async () => ({
+                ok: true,
+                status,
+                data: migrationMutationReceipt("safe_name", "SELECT 1;", "1770000000"),
+            }),
+        });
+
+        const response = await callback({ action: "apply_migration", ref: "proj", name: "safe_name", sql: "SELECT 1;" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: status });
     });
 
     test("prefers an explicit ref over the auto-linked project", async () => {
@@ -292,9 +392,13 @@ describe("database migration helpers", () => {
             writeFileSync(join(dir, "beta.sql"), "CREATE TABLE beta (id uuid);\n");
             const callback = captureDatabaseTool({
                 get: async () => ({ ok: true, status: 200, data: [] }),
-                post: async (_path: string, body: { name: string; version: string }) => {
+                postReleaseMutation: async (_path: string, body: { name: string; version: string; sql: string }) => {
                     posts.push({ name: body.name, version: body.version });
-                    return { ok: true, status: 200, data: {} };
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: migrationMutationReceipt(body.name, body.sql, body.version),
+                    };
                 },
             });
 
@@ -661,7 +765,15 @@ describe("database migration helpers", () => {
                 postReleaseMutation: async () => ({
                     ok: false,
                     status: 409,
-                    data: { code: "409", message: "Migration already applied" },
+                    data: {
+                        code: "409",
+                        message: "Migration already applied",
+                        ...migrationMutationReceipt(
+                            "20260425123000_create_users",
+                            "CREATE TABLE users (id uuid);",
+                        ),
+                        statements: undefined,
+                    },
                 }),
             });
 
@@ -669,6 +781,78 @@ describe("database migration helpers", () => {
             expect(toolResult.content[0].text).toContain("Migration push completed");
             expect(toolResult.content[0].text).toContain("Applied: 0");
             expect(toolResult.content[0].text).toContain("Skipped: 1");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("does not skip an unreadable already-applied migration response", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const responseSecret = "already-applied-private-response";
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                postReleaseMutation: async () => ({
+                    ok: false,
+                    status: 409,
+                    data: {
+                        code: "409",
+                        message: "Migration already applied",
+                        ...migrationMutationReceipt(
+                            "20260425123000_create_users",
+                            "CREATE TABLE users (id uuid);",
+                        ),
+                        private: responseSecret,
+                    },
+                    responseReadError: true,
+                }),
+            });
+
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text)).toMatchObject({
+                applied_before_failure: [],
+                skipped_before_failure: [],
+                failed_file: "20260425123000_create_users.sql",
+                error: { code: "OUTCOME_UNKNOWN", http_status: 409 },
+            });
+            expect(response.content[0].text).not.toContain(responseSecret);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("does not skip a contradictory successful already-applied response", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                postReleaseMutation: async () => ({
+                    ok: true,
+                    status: 409,
+                    data: {
+                        code: "409",
+                        message: "Migration already applied",
+                        ...migrationMutationReceipt(
+                            "20260425123000_create_users",
+                            "CREATE TABLE users (id uuid);",
+                        ),
+                    },
+                }),
+            });
+
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text)).toMatchObject({
+                applied_before_failure: [],
+                skipped_before_failure: [],
+                failed_file: "20260425123000_create_users.sql",
+                error: { code: "OUTCOME_UNKNOWN", http_status: 409 },
+            });
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -697,6 +881,9 @@ describe("database migration helpers", () => {
                 schema: "supacloud.cli.release-control.v1",
                 ok: false,
                 operation: "database.push_migrations",
+                applied_before_failure: [],
+                skipped_before_failure: [],
+                failed_file: "20260425123000_create_users.sql",
                 error: { code: "HTTP_ERROR", http_status: 409 },
             });
         } finally {
@@ -730,6 +917,11 @@ describe("database migration helpers", () => {
                 schema: "supacloud.cli.release-control.v1",
                 ok: false,
                 operation: "database.push_migrations",
+                ...(failedMethod === "postReleaseMutation" ? {
+                    applied_before_failure: [],
+                    skipped_before_failure: [],
+                    failed_file: "20260425123000_create_users.sql",
+                } : {}),
                 error: { code, http_status: status },
             });
             expect(response.content[0].text).not.toContain(responseSecret);
@@ -752,7 +944,14 @@ describe("database migration helpers", () => {
                 },
                 postReleaseMutation: async () => {
                     releaseMutationCount += 1;
-                    return { ok: true, status: 200, data: {} };
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: migrationMutationReceipt(
+                            "20260425123000_create_users",
+                            "CREATE TABLE users (id uuid);",
+                        ),
+                    };
                 },
             });
 
@@ -761,6 +960,132 @@ describe("database migration helpers", () => {
             expect(response.isError).not.toBe(true);
             expect(ordinaryPostCount).toBe(0);
             expect(releaseMutationCount).toBe(1);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("reports files committed before a later migration rejection", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            let postCount = 0;
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                postReleaseMutation: async () => {
+                    postCount += 1;
+                    return postCount === 1
+                        ? {
+                            ok: true,
+                            status: 200,
+                            data: migrationMutationReceipt(
+                                "20260425123000_create_users",
+                                "CREATE TABLE users (id uuid);",
+                            ),
+                        }
+                        : { ok: false, status: 409, data: { message: "private-response" } };
+                },
+            });
+
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+            const payload = JSON.parse(response.content[0].text);
+
+            expect(response.isError).toBe(true);
+            expect(payload).toMatchObject({
+                applied_before_failure: ["20260425123000_create_users.sql"],
+                skipped_before_failure: [],
+                failed_file: "20260425124000_create_tasks.sql",
+                error: { code: "HTTP_ERROR", http_status: 409 },
+            });
+            expect(response.content[0].text).not.toContain("private-response");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("reports only files encountered before the failed migration", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            writeFileSync(join(dir, "20260425125000_create_reports.sql"), "CREATE TABLE reports (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [
+                        {
+                            version: "20260425123000",
+                            name: "20260425123000_create_users",
+                            statements: ["CREATE TABLE users (id uuid);"],
+                        },
+                        {
+                            version: "20260425125000",
+                            name: "20260425125000_create_reports",
+                            statements: ["CREATE TABLE reports (id uuid);"],
+                        },
+                    ],
+                }),
+                postReleaseMutation: async () => ({ ok: false, status: 409, data: {} }),
+            });
+
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(JSON.parse(response.content[0].text)).toMatchObject({
+                applied_before_failure: [],
+                skipped_before_failure: ["20260425123000_create_users.sql"],
+                failed_file: "20260425124000_create_tasks.sql",
+            });
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("reports a malformed migration push success as outcome unknown", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                postReleaseMutation: async () => ({ ok: true, status: 200, data: {} }),
+            });
+
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+            const payload = JSON.parse(response.content[0].text);
+
+            expect(response.isError).toBe(true);
+            expect(payload).toMatchObject({
+                applied_before_failure: [],
+                skipped_before_failure: [],
+                failed_file: "20260425123000_create_users.sql",
+                error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+            });
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test.each([201, 202, 204])("does not treat HTTP %d as a completed migration push", async (status) => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                postReleaseMutation: async () => ({
+                    ok: true,
+                    status,
+                    data: migrationMutationReceipt(
+                        "20260425123000_create_users",
+                        "CREATE TABLE users (id uuid);",
+                    ),
+                }),
+            });
+
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: status });
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -924,7 +1249,11 @@ describe("database migration helpers", () => {
                     ok: true,
                     status: 200,
                     data: [
-                        { version: "20260425123000", name: "20260425123000_create_users" },
+                        {
+                            version: "20260425123000",
+                            name: "20260425123000_create_users",
+                            statements: ["baseline:20260425123000_create_users"],
+                        },
                     ],
                 }),
                 postReleaseMutation: async (path: string, body: unknown) => {
@@ -950,21 +1279,60 @@ describe("database migration helpers", () => {
         }
     });
 
-  test("baselines missing migrations through the dedicated ledger endpoint", async () => {
+    test("rejects a baseline identity without content evidence before mutation", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
-        const posts: Array<{ path: string; body: any }> = [];
+        let mutationCount = 0;
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [{ version: "20260425123000", name: "20260425123000_create_users" }],
+                }),
+                postReleaseMutation: async () => {
+                    mutationCount += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            await expect(callback({ action: "baseline_migrations", ref: "proj", dir }))
+                .rejects.toThrow("Migration identity conflicts");
+            expect(mutationCount).toBe(0);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("baselines missing migrations through the dedicated ledger endpoint", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        const posts: Array<{ path: string; body: unknown }> = [];
         try {
             writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
             writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            const baselines = [
+                { name: "20260425123000_create_users", version: "20260425123000" },
+                { name: "20260425124000_create_tasks", version: "20260425124000" },
+            ];
+            let inventoryReadCount = 0;
 
             const callback = captureDatabaseTool({
                 get: async (path: string) => {
                     expect(path).toBe("/v1/projects/proj/database/migrations");
-                    return { ok: true, status: 200, data: [] };
+                    inventoryReadCount += 1;
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: inventoryReadCount === 1 ? [] : baselineInventory(baselines),
+                    };
                 },
                 postReleaseMutation: async (path: string, body: unknown) => {
                     posts.push({ path, body });
-                    return { ok: true, status: 200, data: { marked: 2, already_applied: 0 } };
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: baselineMutationReceipt(baselines),
+                    };
                 },
             });
 
@@ -988,6 +1356,125 @@ describe("database migration helpers", () => {
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
+  });
+
+  test("accepts a baseline receipt completed concurrently by another caller", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+    try {
+      writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+      let inventoryReadCount = 0;
+      const callback = captureDatabaseTool({
+        get: async () => {
+          inventoryReadCount += 1;
+          return {
+            ok: true,
+            status: 200,
+            data: inventoryReadCount === 1
+              ? []
+              : baselineInventory([{ name: "20260425123000_create_users", version: "20260425123000" }]),
+          };
+        },
+        postReleaseMutation: async () => ({
+          ok: true,
+          status: 200,
+          data: { marked: 0, already_applied: 1, migrations: [] },
+        }),
+      });
+
+      const response = await callback({ action: "baseline_migrations", ref: "proj", dir });
+
+      expect(response.isError).toBeUndefined();
+      expect(response.content[0].text).toContain("Migration baseline completed");
+      expect(response.content[0].text).toContain("Marked applied: 0");
+      expect(response.content[0].text).toContain("Already applied: 1");
+      expect(response.content[0].text).not.toContain("Marked files:");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    { marked: 1 },
+    { marked: 0, already_applied: 0, migrations: [] },
+    { marked: 0, already_applied: 2, migrations: [] },
+    { marked: 1, already_applied: 0, migrations: [] },
+  ])("fails a malformed successful migration baseline closed", async (receiptPayload) => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+    try {
+      writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+      const callback = captureDatabaseTool({
+        get: async () => ({ ok: true, status: 200, data: [] }),
+        postReleaseMutation: async () => ({ ok: true, status: 200, data: receiptPayload }),
+      });
+
+      const response = await callback({ action: "baseline_migrations", ref: "proj", dir });
+      expect(response.isError).toBe(true);
+      expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([201, 202, 204])("does not treat HTTP %d as a completed baseline", async (status) => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+    try {
+      writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+      const callback = captureDatabaseTool({
+        get: async () => ({ ok: true, status: 200, data: [] }),
+        postReleaseMutation: async () => ({
+          ok: true,
+          status,
+          data: baselineMutationReceipt([
+            { name: "20260425123000_create_users", version: "20260425123000" },
+          ]),
+        }),
+      });
+
+      const response = await callback({ action: "baseline_migrations", ref: "proj", dir });
+
+      expect(response.isError).toBe(true);
+      expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: status });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    ["HTTP failure", { ok: false, status: 503, data: { private: "inventory-secret" } }],
+    ["identity mismatch", {
+      ok: true,
+      status: 200,
+      data: baselineInventory([{ name: "wrong_name", version: "20260425123000" }]),
+    }],
+  ])("fails a successful baseline closed when readback has %s", async (_case, readbackResponse) => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+    try {
+      writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+      let inventoryReadCount = 0;
+      const callback = captureDatabaseTool({
+        get: async () => {
+          inventoryReadCount += 1;
+          return inventoryReadCount === 1
+            ? { ok: true, status: 200, data: [] }
+            : readbackResponse;
+        },
+        postReleaseMutation: async () => ({
+          ok: true,
+          status: 200,
+          data: baselineMutationReceipt([
+            { name: "20260425123000_create_users", version: "20260425123000" },
+          ]),
+        }),
+      });
+
+      const response = await callback({ action: "baseline_migrations", ref: "proj", dir });
+
+      expect(response.isError).toBe(true);
+      expect(JSON.parse(response.content[0].text).error.code).toBe("OUTCOME_UNKNOWN");
+      expect(response.content[0].text).not.toContain("inventory-secret");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test.each([
@@ -1021,11 +1508,11 @@ describe("database migration helpers", () => {
   });
 
   test("create_table_rls defaults to deny-all and removes the legacy permissive policy", async () => {
-    const posts: Array<{ path: string; body: { sql?: string } }> = [];
+    const posts: Array<{ path: string; body: { sql?: string; mode?: string } }> = [];
     const callback = captureDatabaseTool({
-      postReleaseMutation: async (path: string, body: { sql?: string }) => {
+      postReleaseMutation: async (path: string, body: { sql?: string; mode?: string }) => {
         posts.push({ path, body });
-        return { ok: true, status: 200, data: { rows: [] } };
+        return { ok: true, status: 200, data: sqlBatchReceipt(["CREATE", "ALTER", ...Array(5).fill("DROP")]) };
       },
     });
 
@@ -1040,6 +1527,7 @@ describe("database migration helpers", () => {
     expect(result.content[0]?.text).toContain("deny-all");
     expect(posts).toHaveLength(1);
     const sql = posts[0]?.body.sql || "";
+    expect(posts[0]?.body.mode).toBe("migration");
     expect(sql).toContain("ENABLE ROW LEVEL SECURITY");
     expect(sql).toContain('DROP POLICY IF EXISTS "Enable ALL for authenticated"');
     expect(sql).not.toContain("USING (true)");
@@ -1051,7 +1539,11 @@ describe("database migration helpers", () => {
     const callback = captureDatabaseTool({
       postReleaseMutation: async (_path: string, body: { sql?: string }) => {
         posts.push({ body });
-        return { ok: true, status: 200, data: { rows: [] } };
+        return {
+          ok: true,
+          status: 200,
+          data: sqlBatchReceipt(["CREATE", "ALTER", ...Array(5).fill("DROP"), ...Array(4).fill("CREATE")]),
+        };
       },
     });
 
@@ -1072,6 +1564,41 @@ describe("database migration helpers", () => {
     expect(sql).toContain('FOR INSERT TO authenticated WITH CHECK (auth.uid() IS NOT NULL AND auth.uid() = "owner_id")');
     expect(sql).toContain('FOR UPDATE TO authenticated USING (auth.uid() IS NOT NULL AND auth.uid() = "owner_id") WITH CHECK (auth.uid() IS NOT NULL AND auth.uid() = "owner_id")');
     expect(sql).toContain('FOR DELETE TO authenticated USING (auth.uid() IS NOT NULL AND auth.uid() = "owner_id")');
+  });
+
+  test("fails a malformed successful table and RLS mutation closed", async () => {
+    const callback = captureDatabaseTool({
+      postReleaseMutation: async () => ({ ok: true, status: 200, data: { rows: [] } }),
+    });
+
+    const response = await callback({
+      action: "create_table_rls",
+      ref: "proj",
+      table: "todos",
+      columns: "id uuid primary key",
+    });
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+  });
+
+  test.each([201, 202, 204])("does not treat HTTP %d as a completed table and RLS mutation", async (status) => {
+    const callback = captureDatabaseTool({
+      postReleaseMutation: async () => ({
+        ok: true,
+        status,
+        data: sqlBatchReceipt(["CREATE", "ALTER", ...Array(5).fill("DROP")]),
+      }),
+    });
+
+    const response = await callback({
+      action: "create_table_rls",
+      ref: "proj",
+      table: "todos",
+      columns: "id uuid primary key",
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: status });
   });
 
   test("create_table_rls rejects unsafe identifiers and multi-statement column definitions", async () => {

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -11,13 +11,17 @@ interface CapturedDatabaseToolResponse {
 }
 
 function captureDatabaseTool(http: Record<string, unknown>, projectRef?: string) {
+    const releaseMutationHttp = {
+        ...http,
+        postReleaseMutation: http.postReleaseMutation ?? http.post,
+    };
     let callback: ((args: Record<string, unknown>) => Promise<CapturedDatabaseToolResponse>) | undefined;
     registerDatabaseTools({
         tool(name: string, _description: string, _schema: Record<string, unknown>, toolCallback: typeof callback) {
             if (name !== "database") return;
             callback = toolCallback;
         },
-    }, http as any, { projectRef });
+    }, releaseMutationHttp as any, { projectRef });
 
     if (!callback) throw new Error("database tool was not registered");
     return callback;
@@ -40,6 +44,73 @@ function migrationInventoryFixture(overrides: Record<string, unknown> = {}) {
 }
 
 describe("database migration helpers", () => {
+    test.each([
+        ["apply_migration", { action: "apply_migration", ref: "proj", name: "safe_name", sql: "SELECT 1;" }],
+        ["create_table_rls", {
+            action: "create_table_rls",
+            ref: "proj",
+            table: "safe_table",
+            columns: "id uuid primary key",
+        }],
+    ])("returns a secret-free release-control failure for %s", async (operation, arguments_) => {
+        const responseSecret = `${operation}-response-secret`;
+        const callback = captureDatabaseTool({
+            post: async () => {
+                throw new Error("database mutation used the ordinary POST reader");
+            },
+            postReleaseMutation: async () => ({
+                ok: false,
+                status: 503,
+                data: { message: responseSecret },
+            }),
+        });
+
+        const response = await callback(arguments_);
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: `database.${operation}`,
+            error: { code: "OUTCOME_UNKNOWN", http_status: 503 },
+        });
+        expect(response.content[0].text).not.toContain(responseSecret);
+    });
+
+    test.each([
+        ["apply_migration", { action: "apply_migration", ref: "proj", name: "safe_name", sql: "SELECT 1;" }],
+        ["create_table_rls", {
+            action: "create_table_rls",
+            ref: "proj",
+            table: "safe_table",
+            columns: "id uuid primary key",
+        }],
+    ])("treats an unreadable %s response as outcome unknown", async (operation, arguments_) => {
+        const responseSecret = `${operation}-unreadable-response-secret`;
+        const callback = captureDatabaseTool({
+            post: async () => {
+                throw new Error("database mutation used the ordinary POST reader");
+            },
+            postReleaseMutation: async () => ({
+                ok: false,
+                status: 409,
+                data: { message: responseSecret },
+                responseReadError: true,
+            }),
+        });
+
+        const response = await callback(arguments_);
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: `database.${operation}`,
+            error: { code: "OUTCOME_UNKNOWN", http_status: 409 },
+        });
+        expect(response.content[0].text).not.toContain(responseSecret);
+    });
+
     test("prefers an explicit ref over the auto-linked project", async () => {
         const calls: string[] = [];
         const callback = captureDatabaseTool({
@@ -587,7 +658,7 @@ describe("database migration helpers", () => {
             writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
             const callback = captureDatabaseTool({
                 get: async () => ({ ok: true, status: 200, data: [] }),
-                post: async () => ({
+                postReleaseMutation: async () => ({
                     ok: false,
                     status: 409,
                     data: { code: "409", message: "Migration already applied" },
@@ -603,13 +674,13 @@ describe("database migration helpers", () => {
         }
     });
 
-    test("fails migration pushes on checksum-conflict 409 responses", async () => {
+    test("returns a secret-free explicit rejection for a checksum-conflict response", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         try {
             writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
             const callback = captureDatabaseTool({
                 get: async () => ({ ok: true, status: 200, data: [] }),
-                post: async () => ({
+                postReleaseMutation: async () => ({
                     ok: false,
                     status: 409,
                     data: {
@@ -619,35 +690,77 @@ describe("database migration helpers", () => {
                 }),
             });
 
-            const toolResult = await callback({ action: "push_migrations", ref: "proj", dir });
-            expect(toolResult.content[0].text).toContain("Failed to apply 20260425123000_create_users.sql (409)");
-            expect(toolResult.content[0].text).toContain("Skipped before failure: 0");
-            expect(toolResult.content[0].text).not.toContain("Migration push completed");
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text)).toEqual({
+                schema: "supacloud.cli.release-control.v1",
+                ok: false,
+                operation: "database.push_migrations",
+                error: { code: "HTTP_ERROR", http_status: 409 },
+            });
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
     });
 
-    test("does not reflect migration inventory or apply failure bodies", async () => {
+    test.each([
+        ["inventory", "get", "HTTP_ERROR", 503],
+        ["mutation", "postReleaseMutation", "OUTCOME_UNKNOWN", 503],
+    ])("returns a secret-free push %s failure", async (_stage, failedMethod, code, status) => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
-        const inventorySecret = "inventory-response-secret";
-        const applySecret = "apply-response-secret";
+        const responseSecret = `push-${failedMethod}-response-secret`;
         try {
             writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
-            const inventoryFailure = captureDatabaseTool({
-                get: async () => ({ ok: false, status: 503, data: { token: inventorySecret } }),
+            const callback = captureDatabaseTool({
+                get: async () => failedMethod === "get"
+                    ? { ok: false, status, data: { token: responseSecret } }
+                    : { ok: true, status: 200, data: [] },
+                postReleaseMutation: async () => ({
+                    ok: false,
+                    status,
+                    data: { token: responseSecret },
+                }),
             });
-            const inventoryResult = await inventoryFailure({ action: "push_migrations", ref: "proj", dir });
-            expect(inventoryResult.content[0].text).toBe("❌ Failed to load applied migrations (503)");
-            expect(inventoryResult.content[0].text).not.toContain(inventorySecret);
 
-            const applyFailure = captureDatabaseTool({
-                get: async () => ({ ok: true, status: 200, data: [] }),
-                post: async () => ({ ok: false, status: 500, data: { token: applySecret } }),
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(response.isError).toBe(true);
+            expect(JSON.parse(response.content[0].text)).toEqual({
+                schema: "supacloud.cli.release-control.v1",
+                ok: false,
+                operation: "database.push_migrations",
+                error: { code, http_status: status },
             });
-            const applyResult = await applyFailure({ action: "push_migrations", ref: "proj", dir });
-            expect(applyResult.content[0].text).toContain("Failed to apply 20260425123000_create_users.sql (500)");
-            expect(applyResult.content[0].text).not.toContain(applySecret);
+            expect(response.content[0].text).not.toContain(responseSecret);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("uses the bounded release-mutation response path for migration pushes", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        let ordinaryPostCount = 0;
+        let releaseMutationCount = 0;
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({ ok: true, status: 200, data: [] }),
+                post: async () => {
+                    ordinaryPostCount += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+                postReleaseMutation: async () => {
+                    releaseMutationCount += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            });
+
+            const response = await callback({ action: "push_migrations", ref: "proj", dir });
+
+            expect(response.isError).not.toBe(true);
+            expect(ordinaryPostCount).toBe(0);
+            expect(releaseMutationCount).toBe(1);
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }
@@ -676,7 +789,7 @@ describe("database migration helpers", () => {
                         },
                     ],
                 }),
-                post: async (path: string, body: unknown) => {
+                postReleaseMutation: async (path: string, body: unknown) => {
                     posts.push({ path, body });
                     return { ok: true, status: 200, data: {} };
                 },
@@ -814,7 +927,7 @@ describe("database migration helpers", () => {
                         { version: "20260425123000", name: "20260425123000_create_users" },
                     ],
                 }),
-                post: async (path: string, body: unknown) => {
+                postReleaseMutation: async (path: string, body: unknown) => {
                     posts.push({ path, body });
                     return { ok: true, status: 200, data: { rows: [] } };
                 },
@@ -849,7 +962,7 @@ describe("database migration helpers", () => {
                     expect(path).toBe("/v1/projects/proj/database/migrations");
                     return { ok: true, status: 200, data: [] };
                 },
-                post: async (path: string, body: unknown) => {
+                postReleaseMutation: async (path: string, body: unknown) => {
                     posts.push({ path, body });
                     return { ok: true, status: 200, data: { marked: 2, already_applied: 0 } };
                 },
@@ -877,10 +990,40 @@ describe("database migration helpers", () => {
         }
   });
 
+  test.each([
+    ["inventory", "get", "HTTP_ERROR", 409],
+    ["mutation", "postReleaseMutation", "OUTCOME_UNKNOWN", 503],
+  ])("returns a secret-free baseline %s failure", async (_stage, failedMethod, code, status) => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+    const responseSecret = `baseline-${failedMethod}-response-secret`;
+    try {
+      writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+      const callback = captureDatabaseTool({
+        get: async () => failedMethod === "get"
+          ? { ok: false, status, data: { message: responseSecret } }
+          : { ok: true, status: 200, data: [] },
+        postReleaseMutation: async () => ({ ok: false, status, data: { message: responseSecret } }),
+      });
+
+      const response = await callback({ action: "baseline_migrations", ref: "proj", dir });
+
+      expect(response.isError).toBe(true);
+      expect(JSON.parse(response.content[0].text)).toEqual({
+        schema: "supacloud.cli.release-control.v1",
+        ok: false,
+        operation: "database.baseline_migrations",
+        error: { code, http_status: status },
+      });
+      expect(response.content[0].text).not.toContain(responseSecret);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("create_table_rls defaults to deny-all and removes the legacy permissive policy", async () => {
     const posts: Array<{ path: string; body: { sql?: string } }> = [];
     const callback = captureDatabaseTool({
-      post: async (path: string, body: { sql?: string }) => {
+      postReleaseMutation: async (path: string, body: { sql?: string }) => {
         posts.push({ path, body });
         return { ok: true, status: 200, data: { rows: [] } };
       },
@@ -906,7 +1049,7 @@ describe("database migration helpers", () => {
   test("create_table_rls owner mode creates idempotent auth.uid policies", async () => {
     const posts: Array<{ body: { sql?: string } }> = [];
     const callback = captureDatabaseTool({
-      post: async (_path: string, body: { sql?: string }) => {
+      postReleaseMutation: async (_path: string, body: { sql?: string }) => {
         posts.push({ body });
         return { ok: true, status: 200, data: { rows: [] } };
       },

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -9,6 +9,7 @@ import { Type } from "@sinclair/typebox";
 import { projectRefPathSegment } from "../project-ref";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { HttpResult, HttpTransport } from "../transports/http";
+import { releaseControlFailure, releaseControlMutationFailure } from "./release-control-response";
 
 export interface DatabaseToolsConfig {
     readOnly?: boolean;
@@ -527,8 +528,12 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                 }
                 case "apply_migration": {
                     if (!args.name || !args.sql) throw new Error("'name' and 'sql' required");
-                    const r = await http.post(`/v1/projects/${ref}/database/migrations`, { name: args.name, sql: args.sql });
-                    text = r.ok ? `✅ Migration '${args.name}' applied` : `❌ Failed (${r.status}): ${JSON.stringify(r.data)}`;
+                    const r = await http.postReleaseMutation(
+                        `/v1/projects/${ref}/database/migrations`,
+                        { name: args.name, sql: args.sql },
+                    );
+                    if (!r.ok) return releaseControlMutationFailure("database.apply_migration", r);
+                    text = `✅ Migration '${args.name}' applied`;
                     break;
                 }
                 case "push_migrations": {
@@ -550,8 +555,11 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
 
                     const migrationsResult = await http.get(`/v1/projects/${ref}/database/migrations`);
                     if (!migrationsResult.ok) {
-                        text = `❌ Failed to load applied migrations (${migrationsResult.status})`;
-                        break;
+                        return releaseControlFailure(
+                            "database.push_migrations",
+                            "HTTP_ERROR",
+                            migrationsResult.transportError ? null : migrationsResult.status,
+                        );
                     }
 
                     const migrationPlan = migrationPushPlan(migrationsResult.data, migrationFiles);
@@ -585,18 +593,16 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     const applied: string[] = [];
                     const skipped = migrationPlan.alreadyApplied.map(({ file }) => file);
                     for (const { file, name, version, sql } of migrationPlan.pending) {
-                        const r = await http.post(`/v1/projects/${ref}/database/migrations`, { name, sql, version });
+                        const r = await http.postReleaseMutation(
+                            `/v1/projects/${ref}/database/migrations`,
+                            { name, sql, version },
+                        );
                         if (r.ok) {
                             applied.push(file);
                         } else if (isAlreadyAppliedMigrationResponse(r)) {
                             skipped.push(file);
                         } else {
-                            text = [
-                                `❌ Failed to apply ${file} (${r.status})`,
-                                `Applied before failure: ${applied.length}`,
-                                `Skipped before failure: ${skipped.length}`,
-                            ].join("\n");
-                            return { content: [{ type: "text" as const, text }] };
+                            return releaseControlMutationFailure("database.push_migrations", r);
                         }
                     }
 
@@ -628,8 +634,11 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
 
                     const r = await http.get(`/v1/projects/${ref}/database/migrations`);
                     if (!r.ok) {
-                        text = `❌ Failed to load applied migrations (${r.status}): ${JSON.stringify(r.data)}`;
-                        break;
+                        return releaseControlFailure(
+                            "database.baseline_migrations",
+                            "HTTP_ERROR",
+                            r.transportError ? null : r.status,
+                        );
                     }
 
                     const appliedKeys = appliedMigrationKeys(r.data);
@@ -658,20 +667,21 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const baselineResult = await http.post(
+                    const baselineResult = await http.postReleaseMutation(
                         `/v1/projects/${ref}/database/migrations/baseline`,
                         { migrations: missing.map(({ name, version }) => ({ name, version })) },
                     );
-                    text = baselineResult.ok
-                        ? [
-                            `✅ Migration baseline completed for ${dir}`,
-                            `Marked applied: ${missing.length}`,
-                            `Already applied: ${alreadyApplied.length}`,
-                            "",
-                            "Marked files:",
-                            ...missing.map(({ file, version }) => `  - ${file} (${version})`),
-                        ].join("\n")
-                        : `❌ Failed (${baselineResult.status}): ${JSON.stringify(baselineResult.data)}`;
+                    if (!baselineResult.ok) {
+                        return releaseControlMutationFailure("database.baseline_migrations", baselineResult);
+                    }
+                    text = [
+                        `✅ Migration baseline completed for ${dir}`,
+                        `Marked applied: ${missing.length}`,
+                        `Already applied: ${alreadyApplied.length}`,
+                        "",
+                        "Marked files:",
+                        ...missing.map(({ file, version }) => `  - ${file} (${version})`),
+                    ].join("\n");
                     break;
                 }
                 case "create_table_rls": {
@@ -682,10 +692,12 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     if (policyMode !== "deny_all" && policyMode !== "owner") throw new Error("Invalid RLS policy mode");
                     const policySql = buildRlsPolicySql(qualifiedTable, policyMode, args.owner_column);
                     const sql = `BEGIN; CREATE TABLE IF NOT EXISTS ${qualifiedTable} (${columns}); ALTER TABLE ${qualifiedTable} ENABLE ROW LEVEL SECURITY; ${policySql} COMMIT;`;
-                    const r = await execSql(sql);
-                    text = r.ok
-                        ? `✅ Table '${schema}.${args.table}' created with RLS (${policyMode === "owner" ? "auth.uid() owner policy" : "deny-all by default"})`
-                        : `❌ Failed (${r.status}): ${JSON.stringify(r.data)}`;
+                    const r = await http.postReleaseMutation(
+                        `/v1/projects/${ref}/database/sql`,
+                        { sql },
+                    );
+                    if (!r.ok) return releaseControlMutationFailure("database.create_table_rls", r);
+                    text = `✅ Table '${schema}.${args.table}' created with RLS (${policyMode === "owner" ? "auth.uid() owner policy" : "deny-all by default"})`;
                     break;
                 }
                 default: text = `❌ Unknown action: ${action}`;

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -200,6 +200,12 @@ function sortMigrationFiles(migrations: MigrationFile[]): MigrationFile[] {
 
 type RemoteMigrationIdentity = { name: string | null; statements: unknown; version: string };
 type MigrationPushPlan = { alreadyApplied: MigrationFile[]; pending: MigrationFile[] };
+type MigrationReceiptExpectation = Pick<MigrationFile, "name" | "sql"> & { version?: string };
+type BaselineReceipt = { marked: MigrationFile[]; concurrentlyAlreadyApplied: number };
+
+function normalizedMigrationStatement(statement: string): string {
+    return statement.replace(/\r\n?/g, "\n").trim();
+}
 
 function migrationRows(data: unknown): unknown[] {
     if (Array.isArray(data)) return data;
@@ -232,15 +238,6 @@ function migrationIdentities(data: unknown): RemoteMigrationIdentity[] {
         if (identity.name !== null) names.add(identity.name);
     }
     return identities;
-}
-
-function appliedMigrationKeys(data: unknown): Set<string> {
-    const keys = new Set<string>();
-    for (const migration of migrationIdentities(data)) {
-        keys.add(migration.version);
-        if (migration.name !== null) keys.add(migration.name);
-    }
-    return keys;
 }
 
 function singleRemoteStatement(remote: RemoteMigrationIdentity): string | null {
@@ -297,10 +294,109 @@ function migrationPushPlan(data: unknown, migrationFiles: MigrationFile[]): Migr
     return plan;
 }
 
-function isAlreadyAppliedMigrationResponse(response: { status: number; data: unknown }): boolean {
-    if (response.status !== 409 || !response.data || typeof response.data !== "object") return false;
+function recordPayload(payload: unknown): Record<string, unknown> | null {
+    return payload && typeof payload === "object" && !Array.isArray(payload)
+        ? payload as Record<string, unknown>
+        : null;
+}
+
+function confirmedMigrationReceipt(payload: unknown, expected: MigrationReceiptExpectation): boolean {
+    const receipt = recordPayload(payload);
+    if (!receipt || !isMigrationInventoryVersion(receipt.version)) return false;
+    const responseStatements = [expected.sql.trim()];
+    const checksumStatements = [normalizedMigrationStatement(expected.sql)];
+    const name = expected.name.trim();
+    if (receipt.name !== name || JSON.stringify(receipt.statements) !== JSON.stringify(responseStatements)) return false;
+    if (expected.version !== undefined && receipt.version !== expected.version) return false;
+    return receipt.checksum === migrationInventoryChecksum({ version: receipt.version, name, statements: checksumStatements });
+}
+
+function isAlreadyAppliedMigrationResponse(
+    response: HttpResult<unknown>,
+    migration: Required<MigrationReceiptExpectation>,
+): boolean {
+    if (response.ok || response.status !== 409 || response.transportError || response.responseReadError) return false;
+    if (!response.data || typeof response.data !== "object" || Array.isArray(response.data)) return false;
     const body = response.data as Record<string, unknown>;
-    return body.code === "409" && body.message === "Migration already applied";
+    const name = migration.name.trim();
+    const statements = [normalizedMigrationStatement(migration.sql)];
+    return body.code === "409"
+        && body.message === "Migration already applied"
+        && body.version === migration.version
+        && body.name === name
+        && body.checksum === migrationInventoryChecksum({ version: migration.version, name, statements });
+}
+
+function expectedBaselineChecksum(migration: MigrationFile): string {
+    return migrationInventoryChecksum({
+        version: migration.version,
+        name: migration.name,
+        statements: [`baseline:${migration.name}`],
+    });
+}
+
+function confirmedBaselineReceipt(payload: unknown, migrations: MigrationFile[]): BaselineReceipt | null {
+    const receipt = recordPayload(payload);
+    if (!receipt || typeof receipt.marked !== "number" || typeof receipt.already_applied !== "number") return null;
+    if (!Number.isSafeInteger(receipt.marked) || !Number.isSafeInteger(receipt.already_applied)) return null;
+    if (receipt.marked < 0 || receipt.already_applied < 0) return null;
+    if (receipt.marked + receipt.already_applied !== migrations.length) return null;
+    if (!Array.isArray(receipt.migrations) || receipt.migrations.length !== receipt.marked) return null;
+    const expected = new Map(migrations.map((migration) => [migration.version, migration]));
+    const marked: MigrationFile[] = [];
+    for (const rawMigration of receipt.migrations) {
+        const migration = recordPayload(rawMigration);
+        if (!migration || typeof migration.version !== "string") return null;
+        const local = expected.get(migration.version);
+        if (!local || migration.name !== local.name || migration.checksum !== expectedBaselineChecksum(local)) return null;
+        expected.delete(migration.version);
+        marked.push(local);
+    }
+    return expected.size === receipt.already_applied
+        ? { marked, concurrentlyAlreadyApplied: receipt.already_applied }
+        : null;
+}
+
+function baselineInventoryIsApplied(payload: unknown, migrations: MigrationFile[]): boolean {
+    const inventory = migrationInventory(payload);
+    if (!inventory) return false;
+    const byVersion = new Map(inventory.map((migration) => [migration.version, migration]));
+    return migrations.every((migration) => {
+        const remote = byVersion.get(migration.version);
+        return remote?.name === migration.name
+            && remote.statements.length === 1
+            && remote.statements[0] === `baseline:${migration.name}`
+            && remote.checksum === expectedBaselineChecksum(migration);
+    });
+}
+
+function confirmedSqlBatchReceipt(payload: unknown, expectedCommands: string[]): boolean {
+    const receipt = recordPayload(payload);
+    if (!receipt || receipt.command !== "BATCH" || !Array.isArray(receipt.statements)) return false;
+    if (receipt.statements.length !== expectedCommands.length) return false;
+    return receipt.statements.every((rawStatement, index) => {
+        const statement = recordPayload(rawStatement);
+        if (!statement || statement.index !== index + 1 || statement.command !== expectedCommands[index]) return false;
+        if (typeof statement.rowCount !== "number" || !Number.isSafeInteger(statement.rowCount) || statement.rowCount < 0) return false;
+        if (typeof statement.durationMs !== "number" || !Number.isFinite(statement.durationMs) || statement.durationMs < 0) return false;
+        return true;
+    });
+}
+
+function rlsStatementCommands(policyMode: "deny_all" | "owner"): string[] {
+    return [
+        "CREATE", "ALTER",
+        ...Array.from({ length: 5 }, () => "DROP"),
+        ...(policyMode === "owner" ? Array.from({ length: 4 }, () => "CREATE") : []),
+    ];
+}
+
+function migrationPushFailureState(applied: string[], skipped: string[], failedFile: string) {
+    return {
+        applied_before_failure: [...applied],
+        skipped_before_failure: [...skipped],
+        failed_file: failedFile,
+    };
 }
 
 function sqlReferencesVector(sql: string): boolean {
@@ -533,6 +629,12 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         { name: args.name, sql: args.sql },
                     );
                     if (!r.ok) return releaseControlMutationFailure("database.apply_migration", r);
+                    if (r.status !== 200) {
+                        return releaseControlFailure("database.apply_migration", "OUTCOME_UNKNOWN", r.status);
+                    }
+                    if (!confirmedMigrationReceipt(r.data, { name: args.name, sql: args.sql })) {
+                        return releaseControlFailure("database.apply_migration", "OUTCOME_UNKNOWN", r.status);
+                    }
                     text = `✅ Migration '${args.name}' applied`;
                     break;
                 }
@@ -590,19 +692,28 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
+                    const pending = new Set(migrationPlan.pending.map(({ file }) => file));
                     const applied: string[] = [];
-                    const skipped = migrationPlan.alreadyApplied.map(({ file }) => file);
-                    for (const { file, name, version, sql } of migrationPlan.pending) {
+                    const skipped: string[] = [];
+                    for (const { file, name, version, sql } of migrationFiles) {
+                        if (!pending.has(file)) {
+                            skipped.push(file);
+                            continue;
+                        }
                         const r = await http.postReleaseMutation(
                             `/v1/projects/${ref}/database/migrations`,
                             { name, sql, version },
                         );
-                        if (r.ok) {
+                        if (r.ok && r.status === 200 && confirmedMigrationReceipt(r.data, { name, version, sql })) {
                             applied.push(file);
-                        } else if (isAlreadyAppliedMigrationResponse(r)) {
+                        } else if (isAlreadyAppliedMigrationResponse(r, { name, version, sql })) {
                             skipped.push(file);
                         } else {
-                            return releaseControlMutationFailure("database.push_migrations", r);
+                            const safeState = migrationPushFailureState(applied, skipped, file);
+                            if (r.ok) {
+                                return releaseControlFailure("database.push_migrations", "OUTCOME_UNKNOWN", r.status, safeState);
+                            }
+                            return releaseControlMutationFailure("database.push_migrations", r, safeState);
                         }
                     }
 
@@ -641,9 +752,9 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         );
                     }
 
-                    const appliedKeys = appliedMigrationKeys(r.data);
-                    const missing = migrationFiles.filter(({ name, version }) => !appliedKeys.has(name) && !appliedKeys.has(String(version)));
-                    const alreadyApplied = migrationFiles.filter(({ name, version }) => appliedKeys.has(name) || appliedKeys.has(String(version)));
+                    const migrationPlan = migrationPushPlan(r.data, migrationFiles);
+                    const missing = migrationPlan.pending;
+                    const alreadyApplied = migrationPlan.alreadyApplied;
 
                     if (args.dry_run) {
                         text = [
@@ -674,13 +785,31 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     if (!baselineResult.ok) {
                         return releaseControlMutationFailure("database.baseline_migrations", baselineResult);
                     }
+                    if (baselineResult.status !== 200) {
+                        return releaseControlFailure("database.baseline_migrations", "OUTCOME_UNKNOWN", baselineResult.status);
+                    }
+                    const receipt = confirmedBaselineReceipt(baselineResult.data, missing);
+                    if (!receipt) {
+                        return releaseControlFailure("database.baseline_migrations", "OUTCOME_UNKNOWN", baselineResult.status);
+                    }
+                    const inventoryResult = await http.get(
+                        `/v1/projects/${ref}/database/migrations`,
+                        { maxResponseBytes: MAX_MIGRATION_INVENTORY_BYTES },
+                    );
+                    if (!inventoryResult.ok || !baselineInventoryIsApplied(inventoryResult.data, missing)) {
+                        return releaseControlFailure(
+                            "database.baseline_migrations",
+                            "OUTCOME_UNKNOWN",
+                            inventoryResult.transportError ? null : inventoryResult.status,
+                        );
+                    }
                     text = [
                         `✅ Migration baseline completed for ${dir}`,
-                        `Marked applied: ${missing.length}`,
-                        `Already applied: ${alreadyApplied.length}`,
-                        "",
-                        "Marked files:",
-                        ...missing.map(({ file, version }) => `  - ${file} (${version})`),
+                        `Marked applied: ${receipt.marked.length}`,
+                        `Already applied: ${alreadyApplied.length + receipt.concurrentlyAlreadyApplied}`,
+                        ...(receipt.marked.length
+                            ? ["", "Marked files:", ...receipt.marked.map(({ file, version }) => `  - ${file} (${version})`)]
+                            : []),
                     ].join("\n");
                     break;
                 }
@@ -694,9 +823,15 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     const sql = `BEGIN; CREATE TABLE IF NOT EXISTS ${qualifiedTable} (${columns}); ALTER TABLE ${qualifiedTable} ENABLE ROW LEVEL SECURITY; ${policySql} COMMIT;`;
                     const r = await http.postReleaseMutation(
                         `/v1/projects/${ref}/database/sql`,
-                        { sql },
+                        { sql, mode: "migration" },
                     );
                     if (!r.ok) return releaseControlMutationFailure("database.create_table_rls", r);
+                    if (r.status !== 200) {
+                        return releaseControlFailure("database.create_table_rls", "OUTCOME_UNKNOWN", r.status);
+                    }
+                    if (!confirmedSqlBatchReceipt(r.data, rlsStatementCommands(policyMode))) {
+                        return releaseControlFailure("database.create_table_rls", "OUTCOME_UNKNOWN", r.status);
+                    }
                     text = `✅ Table '${schema}.${args.table}' created with RLS (${policyMode === "owner" ? "auth.uid() owner policy" : "deny-all by default"})`;
                     break;
                 }

--- a/packages/cli/src/shared/tools/release-control-response.ts
+++ b/packages/cli/src/shared/tools/release-control-response.ts
@@ -37,14 +37,15 @@ export function releaseControlFailure(
 export function releaseControlMutationFailure(
     operation: string,
     response: HttpResult<unknown>,
+    safeState: Record<string, unknown> = {},
 ): ReleaseControlToolResponse {
     const outcomeUnknown = response.transportError
         || response.responseReadError
         || response.status === 408
         || response.status >= 500;
     return outcomeUnknown
-        ? releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.transportError ? null : response.status)
-        : releaseControlFailure(operation, "HTTP_ERROR", response.status);
+        ? releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.transportError ? null : response.status, safeState)
+        : releaseControlFailure(operation, "HTTP_ERROR", response.status, safeState);
 }
 
 function releaseControlResponse(


### PR DESCRIPTION
## Summary

- route database mutation responses through the bounded release-mutation reader without reflecting remote bodies
- bind apply/push/already-applied/baseline/RLS success to exact synchronous HTTP 200 receipts
- preserve only ordered, secret-free partial push state when a later file fails
- require content-bound baseline preflight plus bounded exact inventory readback after mutation
- execute create-table RLS through the supported `mode=migration` path and validate the full SQL batch receipt

## Verification

- `bun test` in `packages/cli`: 747 pass, 0 fail, 2247 assertions
- `bun run typecheck` in `packages/cli`
- `bun run build` in `packages/cli`
- `git diff --check`
- independent exact-diff review: PASS (`c31aeaead83658c2d34becf662ba039f3f6f3e7199f78b71377f59023d4e49aa` before commit)

## Safety

- malformed 2xx and non-contract 201/202/204 results fail as `OUTCOME_UNKNOWN`
- unreadable or forged 409 responses cannot be treated as already applied
- baseline concurrency is accepted only after exact version/name/marker/checksum readback
- response bodies, SQL, and remote private fields are never reflected in failure receipts
- Release Please, package publication, merge, and deployment remain out of scope

clean-code-guard: clean
