### PR TITLE
feat(admin): add verified logical backup controls

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -249,6 +249,47 @@ The JSON receipt contains only the project ref, requested type, backup ID,
 database, timestamps, and size. `platform list_backups --ref abc123` applies the
 same strict, sanitized inventory validation without creating a backup.
 
+## Verified logical backups
+
+Use the official Admin CLI to list or create project-scoped verified logical
+backups:
+
+```bash
+supacloud-admin platform list_logical_backups --ref abc123
+supacloud-admin platform create_logical_backup --ref abc123
+```
+
+The create command reads the verified inventory before and after the one-shot
+request. It reports success only when the Management response and exactly one
+new inventory identity agree on the project, database, backup ID, kind,
+timestamps, byte count, and SHA-256. The fixed JSON projection never includes
+the server's receipt HMAC, archive path, subprocess output, or response-only
+fields. Do not retry an `OUTCOME_UNKNOWN` create until the inventory has been
+reconciled.
+
+Logical restore is destructive and Management also requires the project to be
+paused. Copy an exact identity from `list_logical_backups`, then bind all of its
+recovery-critical fields:
+
+```bash
+supacloud-admin platform restore_logical_backup \
+  --ref abc123 \
+  --backup_id logical-full_abc123_0123456789abcdef0123456789abcdef \
+  --expected_sha256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  --confirmation RESTORE_PROJECT:abc123:logical-full_abc123_0123456789abcdef0123456789abcdef:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+```
+
+Both create and restore are classified as remote writes. They require an
+explicit `SUPACLOUD_ENV`, honor `SUPACLOUD_READ_ONLY=true`, and in production
+also require the global exact project confirmation
+`--confirm-production abc123`. A timeout, transport loss, 5xx response, or
+malformed success receipt exits non-zero without reflecting the remote body.
+Logical mutation requests have a bounded 36-minute client deadline so the
+Management request has time to return a terminal response before the client
+gives up.
+Credentials remain environment-only; logical backup commands accept no token,
+password, or service-role flags.
+
 Gateway / Caddy commands (config is injected via the Caddy JSON Admin API; requires admin privileges):
 
 - `gateway routes` — list custom gateway routes

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -57,6 +57,26 @@ const COMPLETED_PHYSICAL_BACKUP = {
     database: "supa_fa_staging",
 };
 
+const VERIFIED_LOGICAL_BACKUP_ID = "logical-full_fa_staging_0123456789abcdef0123456789abcdef";
+const VERIFIED_LOGICAL_BACKUP_SHA256 = "a".repeat(64);
+const VERIFIED_LOGICAL_BACKUP = {
+    backup_id: VERIFIED_LOGICAL_BACKUP_ID,
+    project_ref: "fa_staging",
+    database: "supa_fa_staging",
+    kind: "logical-full",
+    created_at: "2026-08-12T00:00:00.000Z",
+    completed_at: "2026-08-12T00:00:01.000Z",
+    bytes: 8192,
+    sha256: VERIFIED_LOGICAL_BACKUP_SHA256,
+};
+
+const VERIFIED_LOGICAL_BACKUP_CONFIRMATION = [
+    "RESTORE_PROJECT",
+    "fa_staging",
+    VERIFIED_LOGICAL_BACKUP_ID,
+    VERIFIED_LOGICAL_BACKUP_SHA256,
+].join(":");
+
 function cleanEnvironment(overrides: Record<string, string> = {}): Record<string, string> {
     const env: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
@@ -294,6 +314,10 @@ describe("supacloud-admin process contract", () => {
             expect(backupHelp.exitCode).toBe(0);
             expect(backupHelp.output).toContain("--ref");
             expect(backupHelp.output).toContain("--backup_type");
+            const logicalHelp = await runAdminCliPath(linkedEntry, ["platform", "restore_logical_backup", "--help"]);
+            expect(logicalHelp.exitCode).toBe(0);
+            expect(logicalHelp.output).toContain("--expected_sha256");
+            expect(logicalHelp.output).toContain("--confirmation");
             const version = await runAdminCliPath(linkedEntry, ["--version"]);
             expect(version.exitCode).toBe(0);
             expect(version.output.trim()).toBe(packageMetadata.version);
@@ -697,6 +721,226 @@ describe("supacloud-admin process contract", () => {
         expect(execution.exitCode).toBe(0);
         expect(execution.output).toContain("--ref");
         expect(execution.output).toContain("--backup_type");
+    });
+
+    test("documents every verified logical backup flag without API context", async () => {
+        const listHelp = await runAdminCli(["platform", "list_logical_backups", "--help"]);
+        const createHelp = await runAdminCli(["platform", "create_logical_backup", "--help"]);
+        const restoreHelp = await runAdminCli(["platform", "restore_logical_backup", "--help"]);
+
+        expect(listHelp.exitCode).toBe(0);
+        expect(listHelp.output).toContain("--ref");
+        expect(createHelp.exitCode).toBe(0);
+        expect(createHelp.output).toContain("--ref");
+        expect(restoreHelp.exitCode).toBe(0);
+        expect(restoreHelp.output).toContain("--ref");
+        expect(restoreHelp.output).toContain("--backup_id");
+        expect(restoreHelp.output).toContain("--expected_sha256");
+        expect(restoreHelp.output).toContain("--confirmation");
+        expect(restoreHelp.output).not.toContain("--token");
+        expect(restoreHelp.output).not.toContain("--password");
+    });
+
+    test("lists, creates, and restores verified logical backups without argv credentials", async () => {
+        const calls: Array<{ method: string; path: string; body?: unknown; authorization: string }> = [];
+        let inventoryRead = 0;
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const path = new URL(request.url).pathname;
+                const authorization = request.headers.get("authorization") || "";
+                if (request.method === "GET") {
+                    calls.push({ method: "GET", path, authorization });
+                    inventoryRead += 1;
+                    return Response.json({
+                        backups: inventoryRead === 2
+                            ? []
+                            : [{ ...VERIFIED_LOGICAL_BACKUP, receipt_hmac_sha256: "inventory-secret" }],
+                    });
+                }
+                const body = await request.json();
+                calls.push({ method: "POST", path, body, authorization });
+                return path.endsWith("/restore")
+                    ? Response.json({
+                        restored_backup: VERIFIED_LOGICAL_BACKUP,
+                        internal: "restore-response-secret",
+                    })
+                    : Response.json({
+                        backup: VERIFIED_LOGICAL_BACKUP,
+                        archive_path: "/private/logical-backup.dump",
+                    });
+            },
+        });
+        const fixtureToken = "logical-backup-api-token";
+        const environment = {
+            SUPACLOUD_ENV: "test",
+            SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+            SUPACLOUD_API_TOKEN: fixtureToken,
+        };
+
+        try {
+            const listed = await runAdminCli([
+                "platform", "list_logical_backups", "--ref", "fa_staging",
+            ], environment);
+            const created = await runAdminCli([
+                "platform", "create_logical_backup", "--ref", "fa_staging",
+            ], environment);
+            const restored = await runAdminCli([
+                "platform", "restore_logical_backup", "--ref", "fa_staging",
+                "--backup_id", VERIFIED_LOGICAL_BACKUP_ID,
+                "--expected_sha256", VERIFIED_LOGICAL_BACKUP_SHA256,
+                "--confirmation", VERIFIED_LOGICAL_BACKUP_CONFIRMATION,
+            ], environment);
+
+            expect(listed.exitCode).toBe(0);
+            expect(JSON.parse(listed.output)).toMatchObject({
+                operation: "platform.list_logical_backups",
+                backups: [VERIFIED_LOGICAL_BACKUP],
+            });
+            expect(created.exitCode).toBe(0);
+            expect(JSON.parse(created.output)).toMatchObject({
+                operation: "platform.create_logical_backup",
+                backup: VERIFIED_LOGICAL_BACKUP,
+            });
+            expect(restored.exitCode).toBe(0);
+            expect(JSON.parse(restored.output)).toMatchObject({
+                operation: "platform.restore_logical_backup",
+                restored_backup: VERIFIED_LOGICAL_BACKUP,
+            });
+            expect(calls).toEqual([
+                {
+                    method: "GET",
+                    path: "/v1/projects/fa_staging/database/backups/logical",
+                    authorization: `Bearer ${fixtureToken}`,
+                },
+                {
+                    method: "GET",
+                    path: "/v1/projects/fa_staging/database/backups/logical",
+                    authorization: `Bearer ${fixtureToken}`,
+                },
+                {
+                    method: "POST",
+                    path: "/v1/projects/fa_staging/database/backups/logical",
+                    body: {},
+                    authorization: `Bearer ${fixtureToken}`,
+                },
+                {
+                    method: "GET",
+                    path: "/v1/projects/fa_staging/database/backups/logical",
+                    authorization: `Bearer ${fixtureToken}`,
+                },
+                {
+                    method: "GET",
+                    path: "/v1/projects/fa_staging/database/backups/logical",
+                    authorization: `Bearer ${fixtureToken}`,
+                },
+                {
+                    method: "POST",
+                    path: "/v1/projects/fa_staging/database/backups/logical/restore",
+                    body: {
+                        backup_id: VERIFIED_LOGICAL_BACKUP_ID,
+                        expected_sha256: VERIFIED_LOGICAL_BACKUP_SHA256,
+                        confirmation: VERIFIED_LOGICAL_BACKUP_CONFIRMATION,
+                    },
+                    authorization: `Bearer ${fixtureToken}`,
+                },
+            ]);
+            const output = listed.output + created.output + restored.output;
+            expect(output).not.toContain(fixtureToken);
+            expect(output).not.toContain("inventory-secret");
+            expect(output).not.toContain("restore-response-secret");
+            expect(output).not.toContain("/private/logical-backup.dump");
+        } finally {
+            apiServer.stop(true);
+        }
+    });
+
+    test("blocks unconfirmed production logical writes before HTTP", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-production-logical-backup-"));
+        let requestCount = 0;
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({ backups: [] });
+            },
+        });
+        writeFileSync(join(workspace, ".env.supacloud.production"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${apiServer.port}`,
+            "SUPACLOUD_API_TOKEN=production-logical-token",
+            "SUPACLOUD_PROJECT_REF=fa_staging",
+        ].join("\n") + "\n");
+
+        try {
+            const unconfirmed = await runAdminCli([
+                "platform", "create_logical_backup", "--ref", "fa_staging",
+                "--env", "production",
+            ], {}, workspace);
+            const confirmed = await runAdminCli([
+                "platform", "create_logical_backup", "--ref", "fa_staging",
+                "--env", "production", "--confirm-production", "fa_staging",
+            ], {}, workspace);
+
+            expect(unconfirmed.exitCode).toBe(1);
+            expect(unconfirmed.output).toContain("--confirm-production fa_staging");
+            expect(requestCount).toBe(3);
+            expect(confirmed.exitCode).toBe(1);
+            expect(JSON.parse(confirmed.output).error).toEqual({
+                code: "OUTCOME_UNKNOWN",
+                http_status: 200,
+            });
+            expect(unconfirmed.output + confirmed.output).not.toContain("production-logical-token");
+        } finally {
+            apiServer.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
+    test("returns a nonzero secret-free outcome for uncertain logical restore", async () => {
+        let requestCount = 0;
+        const apiServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                requestCount += 1;
+                if (request.method === "GET") {
+                    return Response.json({ backups: [VERIFIED_LOGICAL_BACKUP] });
+                }
+                return Response.json({
+                    message: "remote restore failure",
+                    token: "remote-restore-secret",
+                }, { status: 503 });
+            },
+        });
+        const fixtureToken = "uncertain-restore-api-token";
+
+        try {
+            const execution = await runAdminCli([
+                "platform", "restore_logical_backup", "--ref", "fa_staging",
+                "--backup_id", VERIFIED_LOGICAL_BACKUP_ID,
+                "--expected_sha256", VERIFIED_LOGICAL_BACKUP_SHA256,
+                "--confirmation", VERIFIED_LOGICAL_BACKUP_CONFIRMATION,
+            ], {
+                SUPACLOUD_ENV: "test",
+                SUPACLOUD_API_URL: `http://127.0.0.1:${apiServer.port}`,
+                SUPACLOUD_API_TOKEN: fixtureToken,
+            });
+
+            expect(execution.exitCode).toBe(1);
+            expect(JSON.parse(execution.output).error).toEqual({
+                code: "OUTCOME_UNKNOWN",
+                http_status: 503,
+            });
+            expect(requestCount).toBe(2);
+            expect(execution.output).not.toContain(fixtureToken);
+            expect(execution.output).not.toContain("remote restore failure");
+            expect(execution.output).not.toContain("remote-restore-secret");
+        } finally {
+            apiServer.stop(true);
+        }
     });
 
     test("creates a full backup with a sanitized machine-readable receipt", async () => {

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -124,6 +124,9 @@ EXAMPLES
   supacloud-admin project runtime_snapshot --ref abc123
   supacloud-admin project service_control --ref abc123 --service gotrue --service_action stop
   supacloud-admin platform metrics
+  supacloud-admin platform list_logical_backups --ref abc123
+  supacloud-admin platform create_logical_backup --ref abc123
+  supacloud-admin platform restore_logical_backup --ref abc123 --backup_id BACKUP_ID --expected_sha256 SHA256 --confirmation RESTORE_PROJECT:abc123:BACKUP_ID:SHA256
   supacloud-admin gateway routes --ref abc123
   supacloud-admin gateway upsert_route --ref abc123 --route_id webhook --hosts "api.example.com" --paths "/webhook/*" --upstream 10.0.0.5:8080
   supacloud-admin gateway config --ref abc123 --rate_limit_tier pro

--- a/packages/admin/src/shared/execution-policy.test.ts
+++ b/packages/admin/src/shared/execution-policy.test.ts
@@ -32,7 +32,7 @@ describe("Admin execution policy", () => {
                 "project.list", "project.get", "project.settings", "project.api_keys",
                 "project.health", "project.logs", "project.tasks", "project.services",
                 "project.runtime_snapshot",
-                "platform.metrics", "platform.list_backups", "platform.network",
+                "platform.metrics", "platform.list_backups", "platform.list_logical_backups", "platform.network",
                 "platform.list_orgs", "platform.get_org",
                 "gateway.routes", "gateway.get_certificate", "gateway.custom_hostname",
                 "ssh.ping", "ssh.versions", "ssh.diagnose", "ssh.exec",
@@ -42,7 +42,8 @@ describe("Admin execution policy", () => {
             write: [
                 "project.create", "project.delete", "project.pause", "project.restore",
                 "project.restart", "project.update_settings",
-                "platform.create_backup", "platform.update_network",
+                "platform.create_backup", "platform.create_logical_backup",
+                "platform.restore_logical_backup", "platform.update_network",
                 "gateway.upsert_route", "gateway.update_route", "gateway.delete_route",
                 "gateway.config", "gateway.update_certificate", "gateway.issue_certificate",
                 "gateway.deploy_certificate", "gateway.rebuild", "gateway.set_custom_hostname",
@@ -107,6 +108,29 @@ describe("Admin execution policy", () => {
         expect(() => authorizeExecution("project", args, {
             context: productionContext(),
             confirmProduction: "prod-ref",
+        })).not.toThrow();
+    });
+
+    test.each(["create_logical_backup", "restore_logical_backup"])(
+        "requires exact production project confirmation for platform.%s",
+        (action) => {
+            const args = { action, ref: "prod-ref" };
+            expect(() => authorizeExecution("platform", args, {
+                context: productionContext(),
+            })).toThrow("--confirm-production prod-ref");
+            expect(() => authorizeExecution("platform", args, {
+                context: productionContext(),
+                confirmProduction: "prod-ref",
+            })).not.toThrow();
+        },
+    );
+
+    test("classifies verified logical inventory as a production read", () => {
+        expect(() => authorizeExecution("platform", {
+            action: "list_logical_backups",
+            ref: "prod-ref",
+        }, {
+            context: productionContext(),
         })).not.toThrow();
     });
 

--- a/packages/admin/src/shared/execution-policy.ts
+++ b/packages/admin/src/shared/execution-policy.ts
@@ -18,8 +18,8 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         write: ["create", "delete", "pause", "restore", "restart", "update_settings"],
     },
     platform: {
-        read: ["metrics", "list_backups", "network", "list_orgs", "get_org"],
-        write: ["create_backup", "update_network"],
+        read: ["metrics", "list_backups", "list_logical_backups", "network", "list_orgs", "get_org"],
+        write: ["create_backup", "create_logical_backup", "restore_logical_backup", "update_network"],
     },
     gateway: {
         read: ["routes", "get_certificate", "custom_hostname"],
@@ -51,7 +51,9 @@ const REFLESS_WRITE_ACTIONS = new Set([
 ]);
 const SSH_PROJECT_REF_ACTIONS = new Set(["tenant_manage", "tenant_inspect", "tenant_diagnose"]);
 const PLATFORM_PROJECT_REF_ACTIONS = new Set([
-    "list_backups", "create_backup", "network", "update_network",
+    "list_backups", "create_backup",
+    "list_logical_backups", "create_logical_backup", "restore_logical_backup",
+    "network", "update_network",
 ]);
 
 export interface ExecutionAuthorization {

--- a/packages/admin/src/shared/tools/advanced-tools.test.ts
+++ b/packages/admin/src/shared/tools/advanced-tools.test.ts
@@ -36,4 +36,91 @@ describe("admin platform backup CLI", () => {
         await expect(callback({ action: "create_backup", ref: "fa_staging" }))
             .rejects.toThrow("'backup_type' required for 'create_backup'");
     });
+
+    test("requires the complete verified logical restore identity", async () => {
+        const { schema, callback } = platformTool({});
+        const backupId = "logical-full_fa_staging_0123456789abcdef0123456789abcdef";
+        const sha256 = "a".repeat(64);
+        const confirmation = `RESTORE_PROJECT:fa_staging:${backupId}:${sha256}`;
+
+        expect(parseToolArguments(schema, {
+            action: "restore_logical_backup",
+            ref: "fa_staging",
+            backup_id: backupId,
+            expected_sha256: sha256,
+            confirmation,
+        })).toMatchObject({ backup_id: backupId, expected_sha256: sha256, confirmation });
+        await expect(callback({ action: "create_logical_backup" }))
+            .rejects.toThrow("'ref' required for 'create_logical_backup'");
+        await expect(callback({ action: "restore_logical_backup", ref: "fa_staging" }))
+            .rejects.toThrow("'backup_id' required for 'restore_logical_backup'");
+        await expect(callback({
+            action: "restore_logical_backup", ref: "fa_staging", backup_id: backupId,
+        })).rejects.toThrow("'expected_sha256' required for 'restore_logical_backup'");
+        await expect(callback({
+            action: "restore_logical_backup", ref: "fa_staging", backup_id: backupId,
+            expected_sha256: sha256,
+        })).rejects.toThrow("'confirmation' required for 'restore_logical_backup'");
+    });
+
+    test("dispatches verified logical list, create, and restore through bounded contracts", async () => {
+        const backupId = "logical-full_fa_staging_0123456789abcdef0123456789abcdef";
+        const sha256 = "a".repeat(64);
+        const confirmation = `RESTORE_PROJECT:fa_staging:${backupId}:${sha256}`;
+        const backup = {
+            backup_id: backupId,
+            project_ref: "fa_staging",
+            database: "supa_fa_staging",
+            kind: "logical-full",
+            created_at: "2026-08-12T00:00:00.000Z",
+            completed_at: "2026-08-12T00:00:01.000Z",
+            bytes: 8192,
+            sha256,
+        };
+        const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+        let inventoryRead = 0;
+        const { callback } = platformTool({
+            get: async (path: string) => {
+                calls.push({ method: "GET", path });
+                inventoryRead += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: { backups: inventoryRead === 2 ? [] : [backup] },
+                };
+            },
+            post: async (path: string, body: unknown) => {
+                calls.push({ method: "POST", path, body });
+                return path.endsWith("/restore")
+                    ? { ok: true, status: 200, data: { restored_backup: backup } }
+                    : { ok: true, status: 200, data: { backup } };
+            },
+        });
+
+        const listed = await callback({ action: "list_logical_backups", ref: "fa_staging" });
+        const created = await callback({ action: "create_logical_backup", ref: "fa_staging" });
+        const restored = await callback({
+            action: "restore_logical_backup",
+            ref: "fa_staging",
+            backup_id: backupId,
+            expected_sha256: sha256,
+            confirmation,
+        });
+
+        expect(listed.isError).not.toBe(true);
+        expect(created.isError).not.toBe(true);
+        expect(restored.isError).not.toBe(true);
+        expect(calls).toEqual([
+            { method: "GET", path: "/v1/projects/fa_staging/database/backups/logical" },
+            { method: "GET", path: "/v1/projects/fa_staging/database/backups/logical" },
+            { method: "POST", path: "/v1/projects/fa_staging/database/backups/logical", body: {} },
+            { method: "GET", path: "/v1/projects/fa_staging/database/backups/logical" },
+            { method: "GET", path: "/v1/projects/fa_staging/database/backups/logical" },
+            {
+                method: "POST",
+                path: "/v1/projects/fa_staging/database/backups/logical/restore",
+                body: { backup_id: backupId, expected_sha256: sha256, confirmation },
+            },
+        ]);
+    });
 });

--- a/packages/admin/src/shared/tools/advanced-tools.ts
+++ b/packages/admin/src/shared/tools/advanced-tools.ts
@@ -5,6 +5,11 @@ import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { HttpTransport } from "../transports/http";
 import { createFullPhysicalBackup, listPhysicalBackups } from "./backup-release-control";
+import {
+    createVerifiedLogicalBackup,
+    listVerifiedLogicalBackups,
+    restoreVerifiedLogicalBackup,
+} from "./logical-backup-control";
 
 export function registerAdvancedTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
 
@@ -164,20 +169,27 @@ Actions: list, upsert, delete`,
     server.tool(
         "platform",
         `Platform monitoring, backups, network, and organizations.
-Actions: metrics, list_backups, create_backup, network, update_network, list_orgs, get_org`,
+Actions: metrics, list_backups, create_backup, list_logical_backups, create_logical_backup, restore_logical_backup, network, update_network, list_orgs, get_org`,
         {
             action: withDescription(stringEnum([
                 "metrics", "list_backups", "create_backup",
+                "list_logical_backups", "create_logical_backup", "restore_logical_backup",
                 "network", "update_network",
                 "list_orgs", "get_org",
             ]), "Action"),
             ref: optional(Type.String(), "[*] Project ref for project-scoped platform actions"),
             backup_type: optional(stringEnum(["full"]), "[create_backup] Explicit physical backup type"),
+            backup_id: optional(Type.String(), "[restore_logical_backup] Verified logical backup ID"),
+            expected_sha256: optional(Type.String(), "[restore_logical_backup] Exact lowercase backup SHA-256"),
+            confirmation: optional(Type.String(), "[restore_logical_backup] Exact RESTORE_PROJECT:<ref>:<backup_id>:<sha256> confirmation"),
             slug: optional(Type.String(), "[get_org] Organization slug"),
             allowed_cidrs: optional(Type.Array(Type.String()), "[update_network] Allowed CIDRs"),
         },
         async (args: any) => {
-            const { action, ref, backup_type, slug, allowed_cidrs } = args;
+            const {
+                action, ref, backup_type, backup_id, expected_sha256,
+                confirmation, slug, allowed_cidrs,
+            } = args;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
             let text: string;
             switch (action) {
@@ -192,6 +204,23 @@ Actions: metrics, list_backups, create_backup, network, update_network, list_org
                     need("backup_type", backup_type);
                     return createFullPhysicalBackup(http, ref);
                 }
+                case "list_logical_backups":
+                    need("ref", ref);
+                    return listVerifiedLogicalBackups(http, ref);
+                case "create_logical_backup":
+                    need("ref", ref);
+                    return createVerifiedLogicalBackup(http, ref);
+                case "restore_logical_backup":
+                    need("ref", ref);
+                    need("backup_id", backup_id);
+                    need("expected_sha256", expected_sha256);
+                    need("confirmation", confirmation);
+                    return restoreVerifiedLogicalBackup(http, {
+                        projectRef: ref,
+                        backupId: backup_id,
+                        expectedSha256: expected_sha256,
+                        confirmation,
+                    });
                 case "network":
                     need("ref", ref);
                     text = JSON.stringify((await http.get(`/v1/projects/${ref}/network-restrictions`)).data, null, 2);

--- a/packages/admin/src/shared/tools/logical-backup-control.test.ts
+++ b/packages/admin/src/shared/tools/logical-backup-control.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, test } from "bun:test";
+import {
+    createVerifiedLogicalBackup,
+    listVerifiedLogicalBackups,
+    restoreVerifiedLogicalBackup,
+} from "./logical-backup-control";
+
+const PROJECT_REF = "fa_staging";
+const BACKUP_ID = "logical-full_fa_staging_0123456789abcdef0123456789abcdef";
+const SHA256 = "a".repeat(64);
+const BACKUP = {
+    backup_id: BACKUP_ID,
+    project_ref: PROJECT_REF,
+    database: "supa_fa_staging",
+    kind: "logical-full",
+    created_at: "2026-08-12T00:00:00.000Z",
+    completed_at: "2026-08-12T00:00:01.000Z",
+    bytes: 8_192,
+    sha256: SHA256,
+};
+const PREVIOUS_BACKUP = {
+    ...BACKUP,
+    backup_id: "logical-full_fa_staging_fedcba9876543210fedcba9876543210",
+    created_at: "2026-08-11T00:00:00.000Z",
+    completed_at: "2026-08-11T00:00:01.000Z",
+    sha256: "b".repeat(64),
+};
+const CONFIRMATION = `RESTORE_PROJECT:${PROJECT_REF}:${BACKUP_ID}:${SHA256}`;
+
+function parsed(response: { content: Array<{ text: string }> }): Record<string, unknown> {
+    return JSON.parse(response.content[0]!.text) as Record<string, unknown>;
+}
+
+describe("Admin verified logical backup control", () => {
+    test("lists a fixed, duplicate-free identity projection", async () => {
+        let getOptions: unknown;
+        const response = await listVerifiedLogicalBackups({
+            get: async (_path: string, options: unknown) => {
+                getOptions = options;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: { backups: [{ ...BACKUP, receipt_hmac_sha256: "remote-secret" }] },
+                };
+            },
+        } as never, PROJECT_REF);
+
+        expect(response.isError).not.toBe(true);
+        expect(parsed(response)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "platform.list_logical_backups",
+            project_ref: PROJECT_REF,
+            backups: [BACKUP],
+        });
+        expect(getOptions).toEqual({ maxJsonBytes: 1024 * 1024 });
+        expect(response.content[0]!.text).not.toContain("remote-secret");
+    });
+
+    test.each([
+        { backups: [BACKUP, BACKUP] },
+        { backups: [{ ...BACKUP, project_ref: "other_project" }] },
+        { backups: [{ ...BACKUP, backup_id: `${BACKUP_ID}0` }] },
+        { backups: [{ ...BACKUP, sha256: SHA256.toUpperCase() }] },
+        { backups: [{ ...BACKUP, bytes: 0 }] },
+        { backups: [{ ...BACKUP, database: "unsafe\ndatabase" }] },
+        { backups: [{ ...BACKUP, completed_at: "2026-08-11T23:59:59.000Z" }] },
+        { backups: "remote-secret" },
+    ])("rejects malformed or duplicate inventory %# without reflection", async (payload) => {
+        const response = await listVerifiedLogicalBackups({
+            get: async () => ({ ok: true, status: 200, data: { ...payload, token: "remote-secret" } }),
+        } as never, PROJECT_REF);
+
+        expect(response.isError).toBe(true);
+        expect(parsed(response).error).toEqual({ code: "INVALID_RESPONSE", http_status: 200 });
+        expect(response.content[0]!.text).not.toContain("remote-secret");
+    });
+
+    test("creates only when the response and one new verified inventory identity agree", async () => {
+        const calls: Array<{ method: string; path: string; body?: unknown; options?: unknown }> = [];
+        let inventoryRead = 0;
+        const response = await createVerifiedLogicalBackup({
+            get: async (path: string, options: unknown) => {
+                calls.push({ method: "GET", path, options });
+                inventoryRead += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        backups: inventoryRead === 1
+                            ? [PREVIOUS_BACKUP]
+                            : [BACKUP, PREVIOUS_BACKUP],
+                    },
+                };
+            },
+            post: async (path: string, body: unknown, options: unknown) => {
+                calls.push({ method: "POST", path, body, options });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: { backup: { ...BACKUP, archive_path: "/private/archive" }, token: "remote-secret" },
+                };
+            },
+        } as never, PROJECT_REF);
+
+        expect(response.isError).not.toBe(true);
+        expect(parsed(response)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "platform.create_logical_backup",
+            project_ref: PROJECT_REF,
+            backup: BACKUP,
+        });
+        expect(calls).toEqual([
+            {
+                method: "GET",
+                path: `/v1/projects/${PROJECT_REF}/database/backups/logical`,
+                options: { maxJsonBytes: 1024 * 1024 },
+            },
+            {
+                method: "POST",
+                path: `/v1/projects/${PROJECT_REF}/database/backups/logical`,
+                body: {},
+                options: { timeoutMs: 36 * 60_000, maxJsonBytes: 64 * 1024 },
+            },
+            {
+                method: "GET",
+                path: `/v1/projects/${PROJECT_REF}/database/backups/logical`,
+                options: { maxJsonBytes: 1024 * 1024 },
+            },
+        ]);
+        expect(response.content[0]!.text).not.toContain("remote-secret");
+        expect(response.content[0]!.text).not.toContain("/private/archive");
+    });
+
+    test("fails closed when create evidence is missing, ambiguous, mismatched, or destructive", async () => {
+        const afterInventories = [
+            [PREVIOUS_BACKUP],
+            [PREVIOUS_BACKUP, BACKUP, { ...BACKUP, backup_id: "logical-full_fa_staging_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }],
+            [PREVIOUS_BACKUP, { ...BACKUP, sha256: "c".repeat(64) }],
+            [BACKUP],
+            [BACKUP, { ...PREVIOUS_BACKUP, bytes: PREVIOUS_BACKUP.bytes + 1 }],
+        ];
+        for (const afterInventory of afterInventories) {
+            let inventoryRead = 0;
+            const response = await createVerifiedLogicalBackup({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: { backups: inventoryRead++ === 0 ? [PREVIOUS_BACKUP] : afterInventory },
+                }),
+                post: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: { backup: BACKUP, internal: "create-secret" },
+                }),
+            } as never, PROJECT_REF);
+
+            expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+            expect(response.content[0]!.text).not.toContain("create-secret");
+        }
+    });
+
+    test("rejects a noncanonical successful HTTP status for create and restore", async () => {
+        let inventoryRead = 0;
+        const create = await createVerifiedLogicalBackup({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { backups: inventoryRead++ === 0 ? [PREVIOUS_BACKUP] : [PREVIOUS_BACKUP, BACKUP] },
+            }),
+            post: async () => ({ ok: true, status: 201, data: { backup: BACKUP } }),
+        } as never, PROJECT_REF);
+        const restore = await restoreVerifiedLogicalBackup({
+            get: async () => ({ ok: true, status: 200, data: { backups: [BACKUP] } }),
+            post: async () => ({ ok: true, status: 201, data: { restored_backup: BACKUP } }),
+        } as never, {
+            projectRef: PROJECT_REF,
+            backupId: BACKUP_ID,
+            expectedSha256: SHA256,
+            confirmation: CONFIRMATION,
+        });
+
+        expect(parsed(create).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 201 });
+        expect(parsed(restore).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 201 });
+    });
+
+    test("rejects noncanonical inventory statuses and strips transport status", async () => {
+        let createPostCount = 0;
+        const listed = await listVerifiedLogicalBackups({
+            get: async () => ({ ok: true, status: 201, data: { backups: [] } }),
+        } as never, PROJECT_REF);
+        const created = await createVerifiedLogicalBackup({
+            get: async () => ({
+                ok: false,
+                status: 500,
+                data: { token: "transport-secret" },
+                transportError: true,
+            }),
+            post: async () => {
+                createPostCount += 1;
+                return { ok: true, status: 200, data: { backup: BACKUP } };
+            },
+        } as never, PROJECT_REF);
+
+        expect(parsed(listed).error).toEqual({ code: "INVALID_RESPONSE", http_status: 201 });
+        expect(parsed(created).error).toEqual({ code: "HTTP_ERROR", http_status: null });
+        expect(created.content[0]!.text).not.toContain("transport-secret");
+        expect(createPostCount).toBe(0);
+    });
+
+    test("requires a canonical post-create inventory response", async () => {
+        let inventoryRead = 0;
+        const response = await createVerifiedLogicalBackup({
+            get: async () => ({
+                ok: true,
+                status: inventoryRead++ === 0 ? 200 : 201,
+                data: { backups: inventoryRead === 1 ? [PREVIOUS_BACKUP] : [PREVIOUS_BACKUP, BACKUP] },
+            }),
+            post: async () => ({ ok: true, status: 200, data: { backup: BACKUP } }),
+        } as never, PROJECT_REF);
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test.each([
+        [{ ok: false, status: 400, data: { message: "client-secret" } }, "HTTP_ERROR", 400],
+        [{ ok: false, status: 408, data: { message: "timeout-secret" } }, "OUTCOME_UNKNOWN", 408],
+        [{ ok: false, status: 503, data: { message: "server-secret" } }, "OUTCOME_UNKNOWN", 503],
+        [{ ok: false, status: 500, data: { message: "transport-secret" }, transportError: true }, "OUTCOME_UNKNOWN", null],
+        [{ ok: false, status: 200, data: { message: "read-secret" }, responseError: true }, "OUTCOME_UNKNOWN", 200],
+    ] as const)("classifies create mutation failure without remote reflection", async (mutation, code, status) => {
+        let inventoryRead = 0;
+        const response = await createVerifiedLogicalBackup({
+            get: async () => {
+                inventoryRead += 1;
+                return { ok: true, status: 200, data: { backups: [PREVIOUS_BACKUP] } };
+            },
+            post: async () => mutation,
+        } as never, PROJECT_REF);
+
+        expect(parsed(response).error).toEqual({ code, http_status: status });
+        expect(inventoryRead).toBe(2);
+        expect(response.content[0]!.text).not.toContain("secret");
+    });
+
+    test("restores an inventory-bound identity with the exact request contract", async () => {
+        const calls: Array<{ method: string; path: string; body?: unknown; options?: unknown }> = [];
+        const response = await restoreVerifiedLogicalBackup({
+            get: async (path: string, options: unknown) => {
+                calls.push({ method: "GET", path, options });
+                return { ok: true, status: 200, data: { backups: [BACKUP] } };
+            },
+            post: async (path: string, body: unknown, options: unknown) => {
+                calls.push({ method: "POST", path, body, options });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: { restored_backup: { ...BACKUP, receipt_hmac_sha256: "restore-secret" } },
+                };
+            },
+        } as never, {
+            projectRef: PROJECT_REF,
+            backupId: BACKUP_ID,
+            expectedSha256: SHA256,
+            confirmation: CONFIRMATION,
+        });
+
+        expect(response.isError).not.toBe(true);
+        expect(parsed(response)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "platform.restore_logical_backup",
+            project_ref: PROJECT_REF,
+            restored_backup: BACKUP,
+        });
+        expect(calls).toEqual([
+            {
+                method: "GET",
+                path: `/v1/projects/${PROJECT_REF}/database/backups/logical`,
+                options: { maxJsonBytes: 1024 * 1024 },
+            },
+            {
+                method: "POST",
+                path: `/v1/projects/${PROJECT_REF}/database/backups/logical/restore`,
+                body: {
+                    backup_id: BACKUP_ID,
+                    expected_sha256: SHA256,
+                    confirmation: CONFIRMATION,
+                },
+                options: { timeoutMs: 36 * 60_000, maxJsonBytes: 64 * 1024 },
+            },
+        ]);
+        expect(response.content[0]!.text).not.toContain("restore-secret");
+    });
+
+    test("rejects missing inventory identity and digest mismatch before restore POST", async () => {
+        let postCount = 0;
+        for (const backups of [[], [{ ...BACKUP, sha256: "c".repeat(64) }]]) {
+            const response = await restoreVerifiedLogicalBackup({
+                get: async () => ({ ok: true, status: 200, data: { backups } }),
+                post: async () => {
+                    postCount += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            } as never, {
+                projectRef: PROJECT_REF,
+                backupId: BACKUP_ID,
+                expectedSha256: SHA256,
+                confirmation: CONFIRMATION,
+            });
+
+            expect(parsed(response).error).toEqual({ code: "INVALID_RESPONSE", http_status: 200 });
+        }
+        expect(postCount).toBe(0);
+    });
+
+    test("treats a mismatched or malformed restore success as outcome unknown", async () => {
+        for (const restoredBackup of [
+            { ...BACKUP, backup_id: "logical-full_fa_staging_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+            { ...BACKUP, sha256: "c".repeat(64) },
+            null,
+        ]) {
+            const response = await restoreVerifiedLogicalBackup({
+                get: async () => ({ ok: true, status: 200, data: { backups: [BACKUP] } }),
+                post: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: { restored_backup: restoredBackup, internal: "restore-response-secret" },
+                }),
+            } as never, {
+                projectRef: PROJECT_REF,
+                backupId: BACKUP_ID,
+                expectedSha256: SHA256,
+                confirmation: CONFIRMATION,
+            });
+
+            expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+            expect(response.content[0]!.text).not.toContain("restore-response-secret");
+        }
+    });
+
+    test("rejects unsafe restore bindings before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const http = {
+            get: async () => { requestCount += 1; return { ok: true, status: 200, data: { backups: [] } }; },
+            post: async () => { requestCount += 1; return { ok: true, status: 200, data: {} }; },
+        };
+
+        await expect(listVerifiedLogicalBackups(http as never, "../fa"))
+            .rejects.toThrow("invalid for verified logical backup");
+        await expect(restoreVerifiedLogicalBackup(http as never, {
+            projectRef: PROJECT_REF,
+            backupId: "logical-full_fa_staging_extra_0123456789abcdef0123456789abcdef",
+            expectedSha256: SHA256,
+            confirmation: CONFIRMATION,
+        })).rejects.toThrow("must belong");
+        await expect(restoreVerifiedLogicalBackup(http as never, {
+            projectRef: PROJECT_REF,
+            backupId: BACKUP_ID,
+            expectedSha256: SHA256.toUpperCase(),
+            confirmation: CONFIRMATION,
+        })).rejects.toThrow("64 lowercase");
+        await expect(restoreVerifiedLogicalBackup(http as never, {
+            projectRef: PROJECT_REF,
+            backupId: BACKUP_ID,
+            expectedSha256: SHA256,
+            confirmation: "RESTORE_PROJECT",
+        })).rejects.toThrow("exactly bind");
+        expect(requestCount).toBe(0);
+    });
+});

--- a/packages/admin/src/shared/tools/logical-backup-control.ts
+++ b/packages/admin/src/shared/tools/logical-backup-control.ts
@@ -1,0 +1,371 @@
+import type { HttpResult, HttpTransport } from "../transports/http";
+
+type AdminLogicalBackupToolResponse = {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+};
+
+type LogicalBackupOperation =
+    | "platform.list_logical_backups"
+    | "platform.create_logical_backup"
+    | "platform.restore_logical_backup";
+
+type LogicalBackupIdentity = {
+    backup_id: string;
+    project_ref: string;
+    database: string;
+    kind: "logical-full";
+    created_at: string;
+    completed_at: string;
+    bytes: number;
+    sha256: string;
+};
+
+type LogicalBackupInventoryRead = {
+    inventory?: LogicalBackupIdentity[];
+    response: HttpResult<unknown>;
+};
+
+interface RestoreLogicalBackupRequest {
+    projectRef: string;
+    backupId: string;
+    expectedSha256: string;
+    confirmation: string;
+}
+
+const RELEASE_CONTROL_RESPONSE_SCHEMA = "supacloud.cli.release-control.v1";
+const SAFE_PROJECT_REF = /^[A-Za-z0-9_-]{1,64}$/;
+const BACKUP_ID = /^logical-full_[A-Za-z0-9_-]{1,64}_[a-f0-9]{32}$/;
+const BACKUP_ID_SUFFIX = /^[a-f0-9]{32}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const SAFE_DATABASE = /^[^\u0000-\u001f\u007f]{1,128}$/;
+const LOGICAL_BACKUP_REQUEST_TIMEOUT_MS = 36 * 60_000;
+const LOGICAL_BACKUP_INVENTORY_MAX_BYTES = 1024 * 1024;
+const LOGICAL_BACKUP_MUTATION_MAX_BYTES = 64 * 1024;
+
+function logicalBackupResponse(payload: Record<string, unknown>): AdminLogicalBackupToolResponse {
+    return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function logicalBackupSuccess(
+    operation: LogicalBackupOperation,
+    payload: Record<string, unknown>,
+): AdminLogicalBackupToolResponse {
+    return logicalBackupResponse({
+        ...payload,
+        schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
+        ok: true,
+        operation,
+    });
+}
+
+function logicalBackupFailure(
+    operation: LogicalBackupOperation,
+    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "OUTCOME_UNKNOWN",
+    httpStatus: number | null,
+): AdminLogicalBackupToolResponse {
+    return {
+        ...logicalBackupResponse({
+            schema: RELEASE_CONTROL_RESPONSE_SCHEMA,
+            ok: false,
+            operation,
+            error: { code, http_status: httpStatus },
+        }),
+        isError: true,
+    };
+}
+
+function isPlainRecord(candidate: unknown): candidate is Record<string, unknown> {
+    if (candidate === null || typeof candidate !== "object" || Array.isArray(candidate)) return false;
+    const prototype = Object.getPrototypeOf(candidate);
+    return prototype === Object.prototype || prototype === null;
+}
+
+function canonicalTimestamp(candidate: unknown): candidate is string {
+    if (typeof candidate !== "string") return false;
+    const timestamp = new Date(candidate);
+    return Number.isFinite(timestamp.valueOf()) && timestamp.toISOString() === candidate;
+}
+
+function backupBelongsToProject(backupId: string, projectRef: string): boolean {
+    const prefix = `logical-full_${projectRef}_`;
+    return BACKUP_ID.test(backupId)
+        && backupId.startsWith(prefix)
+        && BACKUP_ID_SUFFIX.test(backupId.slice(prefix.length));
+}
+
+function validBackupProject(
+    candidate: Record<string, unknown>,
+    projectRef: string,
+): candidate is Record<string, unknown> & { backup_id: string; project_ref: string } {
+    return typeof candidate.backup_id === "string"
+        && backupBelongsToProject(candidate.backup_id, projectRef)
+        && candidate.project_ref === projectRef;
+}
+
+function validBackupDatabase(
+    candidate: Record<string, unknown>,
+): candidate is Record<string, unknown> & { database: string } {
+    return typeof candidate.database === "string" && SAFE_DATABASE.test(candidate.database);
+}
+
+function validBackupTimestamps(
+    candidate: Record<string, unknown>,
+): candidate is Record<string, unknown> & { created_at: string; completed_at: string } {
+    return canonicalTimestamp(candidate.created_at)
+        && canonicalTimestamp(candidate.completed_at)
+        && new Date(candidate.completed_at).valueOf() >= new Date(candidate.created_at).valueOf();
+}
+
+function validBackupEvidence(
+    candidate: Record<string, unknown>,
+): candidate is Record<string, unknown> & { bytes: number; sha256: string } {
+    return Number.isSafeInteger(candidate.bytes)
+        && Number(candidate.bytes) > 0
+        && typeof candidate.sha256 === "string"
+        && SHA256.test(candidate.sha256);
+}
+
+function logicalBackupIdentity(
+    candidate: unknown,
+    projectRef: string,
+): LogicalBackupIdentity | null {
+    if (!isPlainRecord(candidate)) return null;
+    if (!validBackupProject(candidate, projectRef)
+        || !validBackupDatabase(candidate)
+        || candidate.kind !== "logical-full"
+        || !validBackupTimestamps(candidate)
+        || !validBackupEvidence(candidate)) {
+        return null;
+    }
+    return {
+        backup_id: candidate.backup_id,
+        project_ref: projectRef,
+        database: candidate.database,
+        kind: "logical-full",
+        created_at: candidate.created_at,
+        completed_at: candidate.completed_at,
+        bytes: Number(candidate.bytes),
+        sha256: candidate.sha256,
+    };
+}
+
+function logicalBackupInventory(payload: unknown, projectRef: string): LogicalBackupIdentity[] | null {
+    if (!isPlainRecord(payload) || !Array.isArray(payload.backups)) return null;
+    const backups = payload.backups.map((candidate) => logicalBackupIdentity(candidate, projectRef));
+    if (backups.some((backup) => backup === null)) return null;
+    const inventory = backups as LogicalBackupIdentity[];
+    if (new Set(inventory.map((backup) => backup.backup_id)).size !== inventory.length) return null;
+    return inventory;
+}
+
+function assertProjectRef(projectRef: string): void {
+    if (!SAFE_PROJECT_REF.test(projectRef)) {
+        throw new Error("'ref' is invalid for verified logical backup");
+    }
+}
+
+function logicalBackupEndpoint(projectRef: string): string {
+    assertProjectRef(projectRef);
+    return `/v1/projects/${encodeURIComponent(projectRef)}/database/backups/logical`;
+}
+
+async function readLogicalBackupInventory(
+    http: HttpTransport,
+    projectRef: string,
+): Promise<LogicalBackupInventoryRead> {
+    const response = await http.get(logicalBackupEndpoint(projectRef), {
+        maxJsonBytes: LOGICAL_BACKUP_INVENTORY_MAX_BYTES,
+    });
+    return {
+        response,
+        inventory: response.ok
+            ? logicalBackupInventory(response.data, projectRef) ?? undefined
+            : undefined,
+    };
+}
+
+function mutationFailureCode(response: HttpResult<unknown>): "HTTP_ERROR" | "OUTCOME_UNKNOWN" {
+    return response.transportError
+        || response.responseError
+        || response.status === 408
+        || response.status >= 500
+        ? "OUTCOME_UNKNOWN"
+        : "HTTP_ERROR";
+}
+
+function identicalBackup(
+    left: LogicalBackupIdentity,
+    right: LogicalBackupIdentity,
+): boolean {
+    return left.backup_id === right.backup_id
+        && left.project_ref === right.project_ref
+        && left.database === right.database
+        && left.kind === right.kind
+        && left.created_at === right.created_at
+        && left.completed_at === right.completed_at
+        && left.bytes === right.bytes
+        && left.sha256 === right.sha256;
+}
+
+function createdBackup(
+    previous: readonly LogicalBackupIdentity[],
+    current: readonly LogicalBackupIdentity[],
+): LogicalBackupIdentity | null {
+    const currentById = new Map(current.map((backup) => [backup.backup_id, backup]));
+    const previousIds = new Set<string>();
+    for (const previousBackup of previous) {
+        previousIds.add(previousBackup.backup_id);
+        const currentBackup = currentById.get(previousBackup.backup_id);
+        if (!currentBackup || !identicalBackup(previousBackup, currentBackup)) return null;
+    }
+    const additions = current.filter((backup) => !previousIds.has(backup.backup_id));
+    return additions.length === 1 ? additions[0]! : null;
+}
+
+function exactBackupEnvelope(
+    payload: unknown,
+    field: "backup" | "restored_backup",
+    projectRef: string,
+): LogicalBackupIdentity | null {
+    return isPlainRecord(payload) ? logicalBackupIdentity(payload[field], projectRef) : null;
+}
+
+function inventoryReadFailure(
+    operation: LogicalBackupOperation,
+    read: LogicalBackupInventoryRead,
+): AdminLogicalBackupToolResponse | null {
+    const { response, inventory } = read;
+    if (!response.ok || response.status !== 200) {
+        const code = response.ok || response.responseError ? "INVALID_RESPONSE" : "HTTP_ERROR";
+        const status = response.transportError ? null : response.status;
+        return logicalBackupFailure(operation, code, status);
+    }
+    return inventory ? null : logicalBackupFailure(operation, "INVALID_RESPONSE", response.status);
+}
+
+function createReceipt(
+    projectRef: string,
+    previous: readonly LogicalBackupIdentity[],
+    mutation: HttpResult<unknown>,
+    afterRead: LogicalBackupInventoryRead,
+): AdminLogicalBackupToolResponse {
+    const operation = "platform.create_logical_backup";
+    if (!mutation.ok) {
+        const status = mutation.transportError ? null : mutation.status;
+        return logicalBackupFailure(operation, mutationFailureCode(mutation), status);
+    }
+    if (mutation.status !== 200) return logicalBackupFailure(operation, "OUTCOME_UNKNOWN", mutation.status);
+    const responseBackup = exactBackupEnvelope(mutation.data, "backup", projectRef);
+    const addedBackup = afterRead.response.ok && afterRead.response.status === 200 && afterRead.inventory
+        ? createdBackup(previous, afterRead.inventory)
+        : null;
+    if (!responseBackup || !addedBackup || !identicalBackup(responseBackup, addedBackup)) {
+        return logicalBackupFailure(operation, "OUTCOME_UNKNOWN", mutation.status);
+    }
+    return logicalBackupSuccess(operation, { project_ref: projectRef, backup: addedBackup });
+}
+
+export async function listVerifiedLogicalBackups(
+    http: HttpTransport,
+    projectRef: string,
+): Promise<AdminLogicalBackupToolResponse> {
+    const operation = "platform.list_logical_backups";
+    const read = await readLogicalBackupInventory(http, projectRef);
+    const failure = inventoryReadFailure(operation, read);
+    return failure ?? logicalBackupSuccess(operation, {
+        project_ref: projectRef,
+        backups: read.inventory!,
+    });
+}
+
+export async function createVerifiedLogicalBackup(
+    http: HttpTransport,
+    projectRef: string,
+): Promise<AdminLogicalBackupToolResponse> {
+    const operation = "platform.create_logical_backup";
+    const beforeRead = await readLogicalBackupInventory(http, projectRef);
+    const failure = inventoryReadFailure(operation, beforeRead);
+    if (failure) return failure;
+    const mutation = await http.post(
+        logicalBackupEndpoint(projectRef),
+        {},
+        {
+            timeoutMs: LOGICAL_BACKUP_REQUEST_TIMEOUT_MS,
+            maxJsonBytes: LOGICAL_BACKUP_MUTATION_MAX_BYTES,
+        },
+    );
+    const afterRead = await readLogicalBackupInventory(http, projectRef);
+    return createReceipt(projectRef, beforeRead.inventory!, mutation, afterRead);
+}
+
+function expectedRestoreConfirmation(request: RestoreLogicalBackupRequest): string {
+    return [
+        "RESTORE_PROJECT",
+        request.projectRef,
+        request.backupId,
+        request.expectedSha256,
+    ].join(":");
+}
+
+function assertRestoreRequest(request: RestoreLogicalBackupRequest): void {
+    assertProjectRef(request.projectRef);
+    if (!backupBelongsToProject(request.backupId, request.projectRef)) {
+        throw new Error("'backup_id' must belong to the requested project");
+    }
+    if (!SHA256.test(request.expectedSha256)) {
+        throw new Error("'expected_sha256' must be exactly 64 lowercase hexadecimal characters");
+    }
+    if (request.confirmation !== expectedRestoreConfirmation(request)) {
+        throw new Error("'confirmation' must exactly bind the project ref, backup ID, and SHA-256");
+    }
+}
+
+function restoreReceipt(
+    request: RestoreLogicalBackupRequest,
+    requestedBackup: LogicalBackupIdentity,
+    mutation: HttpResult<unknown>,
+): AdminLogicalBackupToolResponse {
+    const operation = "platform.restore_logical_backup";
+    if (!mutation.ok) {
+        const status = mutation.transportError ? null : mutation.status;
+        return logicalBackupFailure(operation, mutationFailureCode(mutation), status);
+    }
+    if (mutation.status !== 200) return logicalBackupFailure(operation, "OUTCOME_UNKNOWN", mutation.status);
+    const restoredBackup = exactBackupEnvelope(mutation.data, "restored_backup", request.projectRef);
+    if (!restoredBackup || !identicalBackup(restoredBackup, requestedBackup)) {
+        return logicalBackupFailure(operation, "OUTCOME_UNKNOWN", mutation.status);
+    }
+    return logicalBackupSuccess(operation, {
+        project_ref: request.projectRef,
+        restored_backup: restoredBackup,
+    });
+}
+
+export async function restoreVerifiedLogicalBackup(
+    http: HttpTransport,
+    request: RestoreLogicalBackupRequest,
+): Promise<AdminLogicalBackupToolResponse> {
+    const operation = "platform.restore_logical_backup";
+    assertRestoreRequest(request);
+    const beforeRead = await readLogicalBackupInventory(http, request.projectRef);
+    const failure = inventoryReadFailure(operation, beforeRead);
+    if (failure) return failure;
+    const requestedBackup = beforeRead.inventory!.find((backup) => backup.backup_id === request.backupId);
+    if (!requestedBackup || requestedBackup.sha256 !== request.expectedSha256) {
+        return logicalBackupFailure(operation, "INVALID_RESPONSE", beforeRead.response.status);
+    }
+    const mutation = await http.post(
+        `${logicalBackupEndpoint(request.projectRef)}/restore`,
+        {
+            backup_id: request.backupId,
+            expected_sha256: request.expectedSha256,
+            confirmation: request.confirmation,
+        },
+        {
+            timeoutMs: LOGICAL_BACKUP_REQUEST_TIMEOUT_MS,
+            maxJsonBytes: LOGICAL_BACKUP_MUTATION_MAX_BYTES,
+        },
+    );
+    return restoreReceipt(request, requestedBackup, mutation);
+}

--- a/packages/admin/src/shared/transports/http.test.ts
+++ b/packages/admin/src/shared/transports/http.test.ts
@@ -250,7 +250,7 @@ describe("HttpTransport retry policy", () => {
         expect(clearedTimerIds).toHaveLength(1);
     });
 
-    test.each([0, 35 * 60_000 + 1, 1.5])("rejects invalid POST timeout %d before dispatch", async timeoutMs => {
+    test.each([0, 36 * 60_000 + 1, 1.5])("rejects invalid POST timeout %d before dispatch", async timeoutMs => {
         let fetchCalls = 0;
         globalThis.fetch = (async () => {
             fetchCalls++;
@@ -342,6 +342,21 @@ describe("HttpTransport bounded JSON responses", () => {
         expect(response.data.payload.length).toBeGreaterThan(64_000);
     });
 
+    test("bounds long-running POST success responses without changing the request timeout", async () => {
+        const body = jsonBodyWithByteLength(maxJsonBytes);
+        globalThis.fetch = (async () => new Response(Buffer.from(body))) as unknown as typeof fetch;
+
+        const response = await createTransport().post<{ payload: string }>(
+            "/v1/projects/project-ref/database/backups/logical",
+            {},
+            { timeoutMs: 36 * 60_000, maxJsonBytes },
+        );
+
+        expect(response.ok).toBe(true);
+        expect(response.data.payload.length).toBeGreaterThan(64_000);
+        expect(scheduledTimers.at(-1)?.delay).toBe(36 * 60_000);
+    });
+
     test("rejects a declared response larger than the byte limit", async () => {
         globalThis.fetch = (async () => new Response("{}", {
             headers: { "content-length": String(maxJsonBytes + 1) },
@@ -373,6 +388,25 @@ describe("HttpTransport bounded JSON responses", () => {
         expect(JSON.stringify(response)).not.toContain("x".repeat(128));
     });
 
+    test("marks an oversized POST response invalid without reflecting it", async () => {
+        const oversizedBody = jsonBodyWithByteLength(maxJsonBytes + 1);
+        globalThis.fetch = (async () => new Response(new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(oversizedBody);
+                controller.close();
+            },
+        }))) as unknown as typeof fetch;
+
+        const response = await createTransport().post(
+            "/v1/projects/project-ref/database/backups/logical",
+            {},
+            { timeoutMs: 36 * 60_000, maxJsonBytes },
+        );
+
+        expect(response.responseError).toBe(true);
+        expect(JSON.stringify(response)).not.toContain("x".repeat(128));
+    });
+
     test("rejects malformed UTF-8 and malformed JSON without reflection", async () => {
         const privateMarker = "private-response-marker";
         const invalidBodies = [
@@ -397,6 +431,8 @@ describe("HttpTransport bounded JSON responses", () => {
         }) as unknown as typeof fetch;
 
         await expect(createTransport().get("/runtime-snapshot", { maxJsonBytes: maxBytes }))
+            .rejects.toThrow("positive safe integer");
+        await expect(createTransport().post("/resource", {}, { timeoutMs: 1, maxJsonBytes: maxBytes }))
             .rejects.toThrow("positive safe integer");
         expect(fetchCalls).toBe(0);
     });

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -20,6 +20,7 @@ export interface HttpResult<T = unknown> {
 
 interface HttpPostOptions {
     timeoutMs: number;
+    maxJsonBytes?: number;
 }
 
 export interface HttpGetOptions {
@@ -28,7 +29,7 @@ export interface HttpGetOptions {
 }
 
 const DEFAULT_TIMEOUT = 30_000;
-const MAX_POST_TIMEOUT_MS = 35 * 60_000;
+const MAX_POST_TIMEOUT_MS = 36 * 60_000;
 const MAX_RETRIES = 2;
 const RETRY_BASE_DELAY = 500;
 
@@ -247,12 +248,21 @@ export class HttpTransport {
         options?: HttpPostOptions,
     ): Promise<HttpResult<T>> {
         const timeoutMs = validatedPostTimeout(options);
+        const maxJsonBytes = validatedStrictJsonLimit(options ?? {});
         try {
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "POST",
                 headers: this.headers(),
                 body: body ? JSON.stringify(body) : undefined,
             }, timeoutMs);
+            if (maxJsonBytes !== undefined) {
+                try {
+                    const data = await strictBoundedResponseJson(res, maxJsonBytes) as T;
+                    return { ok: res.ok, status: res.status, data };
+                } catch {
+                    return responseBodyFailure<T>(res.status);
+                }
+            }
             const data = (await res.json().catch(() => null)) as T;
             return { ok: res.ok, status: res.status, data };
         } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- add official Admin CLI list/create/restore consumers for verified project logical backups
- require exact production confirmation and read-only enforcement before remote writes
- validate fixed secret-free backup identities, bounded responses, one-shot mutations, and post-create inventory evidence

## Verification
- `bun test` in `packages/admin`: 432 pass, 26 platform-specific skips, 0 fail
- `bun run typecheck` in `packages/admin`
- `bun run build` in `packages/admin`
- `git diff --check`

## Safety
- no credentials accepted on argv
- no remote response bodies, receipt HMACs, archive paths, or subprocess output reflected
- no merge, release, or deployment requested by this PR

## Independent frozen-head review
- base: `85d7e8e070e0d6aad75ad17c0ab859dda47bcc81`
- head: `cfed182c09ee0080ae384ade0716a0b634c10f8c`
- tree: `4e3786223d9359289d191832a307e3d387776bcb`
- Required Checks: SUCCESS, run `31587260293`
- independent review: PASS, P0/P1/P2 = `0/0/0`
- independent focused verification: 139 pass, 2 platform skips, 0 fail
- `clean-code-guard: clean`