### PR TITLE
fix(management): disable idle timeout for logical backup mutations

### DIFF
--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -37,6 +37,7 @@ import { isS3DataPlaneRequest } from "./utils/storage-s3-paths";
 import { studioAuthRoutes } from "./routes/studio-auth";
 import { caddyAskRoutes } from "./routes/caddy-ask";
 import { validationErrorResponse } from "./utils/http-validation";
+import { withLogicalBackupMutationTimeoutController } from "./utils/logical-backup-request-timeout";
 
 function getWebConsoleDir(): string {
   return resolveWebConsoleDir();
@@ -1347,7 +1348,11 @@ async function bootstrap() {
         }
 
         // Everything else goes through Elysia
-        return app.fetch(request);
+        return withLogicalBackupMutationTimeoutController(
+          request,
+          server,
+          () => app.fetch(request),
+        );
       },
     });
     const { taskWorker } = await import("./services/task.worker");

--- a/packages/management-api/src/routes/backups.ts
+++ b/packages/management-api/src/routes/backups.ts
@@ -15,6 +15,7 @@ import {
 } from "../services/logical-backup.service";
 import { requireAdminAuth, requireProjectOrAdminAuth } from '../middleware/auth';
 import { projectRepository } from '../repositories/project.repository';
+import { disableLogicalBackupMutationIdleTimeout } from "../utils/logical-backup-request-timeout";
 
 const ErrorResponse = t.Object({ message: t.String() });
 
@@ -88,6 +89,7 @@ const projectBackupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
     .post('/logical', async ({ params: { ref }, request }) => {
         const authError = await requireAdminAuth(request);
         if (authError) return status(authError.status, authError.body);
+        disableLogicalBackupMutationIdleTimeout(request);
         try {
             return { backup: await createLogicalBackup(ref) };
         } catch (error: unknown) {
@@ -114,6 +116,7 @@ const projectBackupRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/bac
         if (body.confirmation !== expectedConfirmation) {
             return status(400, { message: "Exact logical backup restore confirmation is required" });
         }
+        disableLogicalBackupMutationIdleTimeout(request);
         try {
             const restoredBackup = await restoreLogicalBackup({
                 project_ref: ref,

--- a/packages/management-api/src/utils/logical-backup-request-timeout.ts
+++ b/packages/management-api/src/utils/logical-backup-request-timeout.ts
@@ -1,0 +1,44 @@
+interface RequestTimeoutController {
+  timeout(request: Request, seconds: number): void;
+}
+
+const LOGICAL_BACKUP_MUTATION_PATH =
+  /^\/v1\/projects\/([^/]+)\/database\/backups\/logical(?:\/restore)?\/?$/;
+const PROJECT_REF = /^[A-Za-z0-9_-]{1,64}$/;
+const timeoutControllers = new WeakMap<Request, RequestTimeoutController>();
+
+function hasValidProjectRef(pathname: string): boolean {
+  const rawProjectRef = LOGICAL_BACKUP_MUTATION_PATH.exec(pathname)?.[1];
+  if (!rawProjectRef) return false;
+  try {
+    return PROJECT_REF.test(decodeURIComponent(rawProjectRef));
+  } catch (error: unknown) {
+    if (error instanceof URIError) return false;
+    throw error;
+  }
+}
+
+function isLogicalBackupMutationRequest(request: Request): boolean {
+  return request.method === "POST"
+    && hasValidProjectRef(new URL(request.url).pathname);
+}
+
+export async function withLogicalBackupMutationTimeoutController<T>(
+  request: Request,
+  server: RequestTimeoutController,
+  action: () => T | Promise<T>,
+): Promise<T> {
+  if (!isLogicalBackupMutationRequest(request)) return action();
+  timeoutControllers.set(request, server);
+  try {
+    return await action();
+  } finally {
+    timeoutControllers.delete(request);
+  }
+}
+
+export function disableLogicalBackupMutationIdleTimeout(
+  request: Request,
+): void {
+  timeoutControllers.get(request)?.timeout(request, 0);
+}

--- a/packages/management-api/tests/unit/backup.routes.test.ts
+++ b/packages/management-api/tests/unit/backup.routes.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
+import { withLogicalBackupMutationTimeoutController } from "../../src/utils/logical-backup-request-timeout";
 
 const requireAdminAuth = mock(() => Promise.resolve(null));
 const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
@@ -61,15 +62,19 @@ const { backupRoutes } = await import("../../src/routes/backups");
 const { projectConfigRoutes } = await import("../../src/routes/project-config");
 const app = new Elysia().use(backupRoutes);
 
-function request(path: string, init: RequestInit = {}) {
-  return app.handle(new Request(`http://localhost${path}`, {
+function adminRequest(path: string, init: RequestInit = {}): Request {
+  return new Request(`http://localhost${path}`, {
     ...init,
     headers: {
       Authorization: "Bearer dev-master-token",
       "content-type": "application/json",
       ...(init.headers || {}),
     },
-  }));
+  });
+}
+
+function request(path: string, init: RequestInit = {}) {
+  return app.handle(adminRequest(path, init));
 }
 
 describe("physical backup routes", () => {
@@ -280,6 +285,74 @@ describe("physical backup routes", () => {
     const deniedResponse = await request("/v1/projects/project_a/database/backups/logical");
     expect(deniedResponse.status).toBe(403);
     expect(listLogicalBackups).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables the idle timeout for authorized logical mutations", async () => {
+    const timeout = mock(() => undefined);
+    const createRequest = adminRequest("/v1/projects/project%5Fa/database/backups/logical", {
+      method: "POST",
+      body: "{}",
+    });
+    const createResponse = await withLogicalBackupMutationTimeoutController(
+      createRequest,
+      { timeout },
+      () => app.handle(createRequest),
+    );
+    const backupId = logicalBackupIdentity.backup_id;
+    const expectedSha256 = logicalBackupIdentity.sha256;
+    const restoreRequest = adminRequest("/v1/projects/project%5Fa/database/backups/logical/restore", {
+      method: "POST",
+      body: JSON.stringify({
+        backup_id: backupId,
+        expected_sha256: expectedSha256,
+        confirmation: `RESTORE_PROJECT:project_a:${backupId}:${expectedSha256}`,
+      }),
+    });
+    const restoreResponse = await withLogicalBackupMutationTimeoutController(
+      restoreRequest,
+      { timeout },
+      () => app.handle(restoreRequest),
+    );
+
+    expect(createResponse.status).toBe(200);
+    expect(restoreResponse.status).toBe(200);
+    expect(timeout.mock.calls).toEqual([
+      [createRequest, 0],
+      [restoreRequest, 0],
+    ]);
+  });
+
+  test("keeps the idle timeout for unauthorized or unconfirmed logical mutations", async () => {
+    const timeout = mock(() => undefined);
+    requireAdminAuth.mockResolvedValueOnce({ status: 401, body: { error: "Unauthorized" } } as never);
+    const createRequest = adminRequest("/v1/projects/project_a/database/backups/logical", {
+      method: "POST",
+      body: "{}",
+    });
+    const createResponse = await withLogicalBackupMutationTimeoutController(
+      createRequest,
+      { timeout },
+      () => app.handle(createRequest),
+    );
+    const restoreRequest = adminRequest("/v1/projects/project_a/database/backups/logical/restore", {
+      method: "POST",
+      body: JSON.stringify({
+        backup_id: logicalBackupIdentity.backup_id,
+        expected_sha256: logicalBackupIdentity.sha256,
+        confirmation: "RESTORE_PROJECT",
+      }),
+    });
+    const restoreResponse = await withLogicalBackupMutationTimeoutController(
+      restoreRequest,
+      { timeout },
+      () => app.handle(restoreRequest),
+    );
+
+    expect(createResponse.status).toBe(401);
+    expect(restoreResponse.status).toBe(400);
+    expect(timeout).not.toHaveBeenCalled();
+    expect(createLogicalBackup).not.toHaveBeenCalled();
+    expect(restoreLogicalBackup).not.toHaveBeenCalled();
   });
 
   test("requires exact identity confirmation and maps paused restore to 409", async () => {

--- a/packages/management-api/tests/unit/logical-backup-request-timeout.test.ts
+++ b/packages/management-api/tests/unit/logical-backup-request-timeout.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  disableLogicalBackupMutationIdleTimeout,
+  withLogicalBackupMutationTimeoutController,
+} from "../../src/utils/logical-backup-request-timeout";
+
+function request(path: string, method = "POST"): Request {
+  return new Request(`http://localhost${path}`, { method });
+}
+
+describe("logical backup request timeout", () => {
+  test.each([
+    "/v1/projects/project_a/database/backups/logical",
+    "/v1/projects/project_a/database/backups/logical/",
+    "/v1/projects/project-a/database/backups/logical/restore",
+    "/v1/projects/project-a/database/backups/logical/restore/",
+    "/v1/projects/project%5Fa/database/backups/logical",
+    "/v1/projects/project%2Da/database/backups/logical/restore",
+    "/v1/projects/project_a/database/backups/logical?source=admin",
+  ])("disables the active-handler idle timeout for %s", async (path) => {
+    const timeout = mock(() => undefined);
+    const mutationRequest = request(path);
+
+    await withLogicalBackupMutationTimeoutController(
+      mutationRequest,
+      { timeout },
+      () => disableLogicalBackupMutationIdleTimeout(mutationRequest),
+    );
+
+    expect(timeout).toHaveBeenCalledTimes(1);
+    expect(timeout).toHaveBeenCalledWith(mutationRequest, 0);
+  });
+
+  test.each([
+    ["GET", "/v1/projects/project_a/database/backups/logical"],
+    ["GET", "/v1/projects/project_a/database/backups/logical/restore"],
+    ["PUT", "/v1/projects/project_a/database/backups/logical"],
+    ["POST", "/v1/projects/project_a/database/backups"],
+    ["POST", "/v1/projects/project_a/database/backups/restore"],
+    ["POST", "/v1/projects/project_a/database/backups/logical/create"],
+    ["POST", "/v1/projects/project_a/database/backups/logical/restore/extra"],
+    ["POST", "/v1/projects/project.a/database/backups/logical"],
+    ["POST", "/v1/projects/project%2Fa/database/backups/logical"],
+    ["POST", "/v1/projects/project%ZZ/database/backups/logical"],
+    ["POST", "/v1/platform/backups/logical"],
+  ])("keeps the global timeout for %s %s", async (method, path) => {
+    const timeout = mock(() => undefined);
+    const ordinaryRequest = request(path, method);
+
+    await withLogicalBackupMutationTimeoutController(
+      ordinaryRequest,
+      { timeout },
+      () => disableLogicalBackupMutationIdleTimeout(ordinaryRequest),
+    );
+
+    expect(timeout).not.toHaveBeenCalled();
+  });
+
+  test("retains the binding through async work and removes it after completion", async () => {
+    const timeout = mock(() => undefined);
+    const mutationRequest = request("/v1/projects/project_a/database/backups/logical");
+
+    await withLogicalBackupMutationTimeoutController(mutationRequest, { timeout }, async () => {
+      await Promise.resolve();
+      disableLogicalBackupMutationIdleTimeout(mutationRequest);
+    });
+    disableLogicalBackupMutationIdleTimeout(mutationRequest);
+
+    expect(timeout).toHaveBeenCalledTimes(1);
+  });
+
+  test("removes the binding when request handling fails", async () => {
+    const timeout = mock(() => undefined);
+    const mutationRequest = request("/v1/projects/project_a/database/backups/logical/restore");
+
+    await expect(withLogicalBackupMutationTimeoutController(
+      mutationRequest,
+      { timeout },
+      () => Promise.reject(new Error("route failed")),
+    )).rejects.toThrow("route failed");
+    disableLogicalBackupMutationIdleTimeout(mutationRequest);
+
+    expect(timeout).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- keep the global 255-second idle timeout for ordinary Management API requests
- disable Bun request idle timeout only after authorization for logical backup creation, and only after authorization plus exact confirmation for logical restore
- bind the active Bun server to the exact Request for the route lifetime and clean it in `finally`
- accept Elysia-compatible percent-encoded valid project refs while rejecting malformed encodings and encoded path separators

## Frozen review snapshot
- base: `85d7e8e070e0d6aad75ad17c0ab859dda47bcc81`
- cached diff SHA-256: `f16b273098a21d5e0754866fe8b4377c4b5814cfa8eb4167463d257e87f084c4`
- independent review: PASS, P0/P1/P2 = `0/0/0`
- `clean-code-guard: clean`

## Verification
- focused timeout and backup route tests: 32 pass, 0 fail
- full Management API unit suite: pass, exit 0
- Management API integration tests: 39 pass, 0 fail
- `bun run typecheck`
- `bun run sql:check`
- standalone compile: 677 modules
- `git diff --cached --check`

## Baseline noise comparison
The first full-unit run in the restricted sandbox reported permission failures while security fixtures tried to create directories under the user home and set setuid/setgid bits. The same failure class reproduced on a detached clean base at `85d7e8e0`; the affected files passed 36/36 in isolation, and the full suite passed outside that restricted fixture sandbox.

## Scope and safety
- no database, migration, CLI, Web Console, global timeout, release, or deployment changes
- GET inventory, physical backups, platform restore, and all non-exact routes retain the global timeout
- Draft only; no auto-merge requested