### PR TITLE
fix(edge-runtime): enforce activation artifact integrity

### DIFF
--- a/docs/edge-runtime-guide.md
+++ b/docs/edge-runtime-guide.md
@@ -60,6 +60,22 @@ Deploy flow:
   4. First request hits warm cache → 0ms cold-start
 ```
 
+### Activation Artifact Integrity
+
+Canonical activations identify an immutable `index.<digest-prefix>.js` artifact
+and record its full SHA-256 digest in the activation authority. The runtime
+checks that digest before evaluating the Function module; it does not fall back
+to the mutable legacy `index.js` path when attested authority is present.
+
+Attested imports currently require Linux. On Linux, the runtime holds the
+trusted directory chain and artifact file descriptors, then imports through
+`/proc/self/fd` so the evaluated module is the same inode that was verified.
+On macOS and Windows, the Edge Runtime binary can still start and run legacy,
+non-attested Functions. Loading an authoritative attested activation fails
+closed with `Attested Function imports require Linux descriptor binding`
+before the module loader evaluates user code. Production hosts that serve
+canonical activations must therefore run Linux.
+
 ## Dependency Management
 
 **Edge Runtime dependencies** (Elysia etc.) are declared in `packages/edge-runtime/package.json`.

--- a/packages/edge-runtime/function-activation.ts
+++ b/packages/edge-runtime/function-activation.ts
@@ -1,5 +1,5 @@
-import { readFile, realpath, stat } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { join, resolve } from "node:path";
+import { readFunctionFile } from "./trusted-function-files";
 
 export const EDGE_FUNCTION_ACTIVATION_SCHEMA = "supacloud.edge-function-activation.v1" as const;
 export const EDGE_FUNCTION_ACTIVATION_FIELD = "_supacloud_activation" as const;
@@ -144,10 +144,6 @@ export function isEdgeFunctionActivationId(candidate: unknown): candidate is str
   return typeof candidate === "string" && ACTIVATION_ID_PATTERN.test(candidate);
 }
 
-function isPathWithin(candidate: string, root: string): boolean {
-  return candidate === root || candidate.startsWith(`${root}/`);
-}
-
 export async function readEdgeFunctionActivationGeneration(
   projectRoot: string,
   functionSlug: string,
@@ -158,17 +154,8 @@ export async function readEdgeFunctionActivationGeneration(
     functionSlug,
     activationId,
   );
-  const generationRoot = resolve(projectRoot, ".activation-generations", functionSlug);
-  const [resolvedPath, metadata] = await Promise.all([
-    realpath(generationPath),
-    stat(generationPath),
-  ]);
-  if (!metadata.isFile()
-    || !isPathWithin(resolvedPath, generationRoot)
-    || dirname(resolvedPath) !== generationRoot) {
-    throw new Error("Function activation generation escapes its trusted directory");
-  }
-  const manifest = parseEdgeFunctionActivationManifest(await readFile(resolvedPath, "utf8"));
+  const generationFile = await readFunctionFile(generationPath);
+  const manifest = parseEdgeFunctionActivationManifest(generationFile.bytes.toString("utf8"));
   if (!manifest.authority || manifest.authority.activation_id !== activationId) {
     throw new Error("Function activation generation identity does not match its path");
   }

--- a/packages/edge-runtime/function-source.test.ts
+++ b/packages/edge-runtime/function-source.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import path from "path";
 import {
   activeFunctionPathCandidates,
+  attestedFunctionArtifactPath,
   BUNDLED_SOURCE_RUNTIME_ENTRY,
   functionPathCandidates,
 } from "./function-source";
@@ -42,5 +43,20 @@ describe("multi-file function runtime source", () => {
       "/functions/project/supauth.js",
       "/functions/project/supauth.ts",
     ]);
+  });
+
+  test("derives the content-addressed runtime entry from the full authority digest", () => {
+    expect(attestedFunctionArtifactPath(
+      "/functions/project",
+      "supauth",
+      "7",
+      "a".repeat(64),
+    )).toBe("/functions/project/.versions/supauth/7/index.aaaaaaaaaaaaaaaa.js");
+    expect(() => attestedFunctionArtifactPath(
+      "/functions/project",
+      "supauth",
+      "7",
+      "a".repeat(63),
+    )).toThrow("Function activation artifact digest is invalid");
   });
 });

--- a/packages/edge-runtime/function-source.test.ts
+++ b/packages/edge-runtime/function-source.test.ts
@@ -45,13 +45,13 @@ describe("multi-file function runtime source", () => {
     ]);
   });
 
-  test("derives the content-addressed runtime entry from the full authority digest", () => {
+  test("uses the immutable source runtime entry after validating the authority digest", () => {
     expect(attestedFunctionArtifactPath(
       "/functions/project",
       "supauth",
       "7",
       "a".repeat(64),
-    )).toBe("/functions/project/.versions/supauth/7/index.aaaaaaaaaaaaaaaa.js");
+    )).toBe("/functions/project/.versions/supauth/7/src/.supacloud-entry.js");
     expect(() => attestedFunctionArtifactPath(
       "/functions/project",
       "supauth",

--- a/packages/edge-runtime/function-source.ts
+++ b/packages/edge-runtime/function-source.ts
@@ -12,12 +12,15 @@ export function attestedFunctionArtifactPath(
   if (!ARTIFACT_SHA256_PATTERN.test(artifactSha256)) {
     throw new Error("Function activation artifact digest is invalid");
   }
+  // The digest attests this immutable source entry while its directory remains
+  // the base for bundled static assets resolved through import.meta.dir.
   return path.join(
     projectRoot,
     ".versions",
     functionName,
     version,
-    `index.${artifactSha256.slice(0, 16)}.js`,
+    "src",
+    BUNDLED_SOURCE_RUNTIME_ENTRY,
   );
 }
 

--- a/packages/edge-runtime/function-source.ts
+++ b/packages/edge-runtime/function-source.ts
@@ -1,6 +1,25 @@
 import path from "path";
 
 export const BUNDLED_SOURCE_RUNTIME_ENTRY = ".supacloud-entry.js";
+const ARTIFACT_SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+export function attestedFunctionArtifactPath(
+  projectRoot: string,
+  functionName: string,
+  version: string,
+  artifactSha256: string,
+): string {
+  if (!ARTIFACT_SHA256_PATTERN.test(artifactSha256)) {
+    throw new Error("Function activation artifact digest is invalid");
+  }
+  return path.join(
+    projectRoot,
+    ".versions",
+    functionName,
+    version,
+    `index.${artifactSha256.slice(0, 16)}.js`,
+  );
+}
 
 export function functionPathCandidates(
   projectRoot: string,

--- a/packages/edge-runtime/server-cache.test.ts
+++ b/packages/edge-runtime/server-cache.test.ts
@@ -95,9 +95,9 @@ describe("Edge Runtime auth material invalidation", () => {
       source.indexOf("async function resolvedFunctionPath("),
       source.indexOf("function functionDispatchError("),
     );
-    expect(resolver).toContain(
-      "activeFunctionPathCandidates(\n    projectRoot,\n    request.functionName,\n    activeVersion,\n  )",
-    );
+    expect(resolver).toContain("? [attestedFunctionArtifactPath(");
+    expect(resolver).toContain("resolvedConfig.artifactSha256!");
+    expect(resolver).toContain(": activeFunctionPathCandidates(");
     expect(resolver).toContain("versionBindingResolver = resolveFunctionVersionBinding");
     expect(resolver).toContain("versionBindingResolver(");
     expect(resolver).toContain("request.requestedVersion,");

--- a/packages/edge-runtime/server-function-config-race.preload.ts
+++ b/packages/edge-runtime/server-function-config-race.preload.ts
@@ -1,7 +1,10 @@
 import { appendFileSync } from "node:fs";
 import fs from "fs/promises";
+import { mock } from "bun:test";
 
 type InjectedFailureCode = "ENOENT" | "ENOTDIR";
+
+const DESCRIPTOR_PATH_PATTERN = /^\/proc\/self\/fd\/\d+\/(.+)$/;
 
 function configuredFailures(): Map<string, InjectedFailureCode> {
   const serialized = process.env.EDGE_TEST_REALPATH_STAT_FAILURES;
@@ -17,12 +20,12 @@ function configuredFailures(): Map<string, InjectedFailureCode> {
 }
 
 const failureByArtifact = configuredFailures();
-const pendingStatFailures = new Map<string, InjectedFailureCode>();
 const activationGenerationReadLog = process.env.EDGE_TEST_ACTIVATION_GENERATION_READ_LOG;
 const ACTIVATION_GENERATION_FILE_PATTERN =
   /[\\/][a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\.json$/;
 const actualRealpath = fs.realpath;
 const actualStat = fs.stat;
+const actualOpen = fs.open;
 
 function recordActivationGenerationRead(
   operation: "realpath" | "stat",
@@ -35,19 +38,32 @@ function recordActivationGenerationRead(
 
 async function interceptedRealpath(artifactPath: Parameters<typeof fs.realpath>[0]) {
   recordActivationGenerationRead("realpath", String(artifactPath));
-  const resolved = await actualRealpath(artifactPath);
-  const failureCode = failureByArtifact.get(String(artifactPath));
-  if (failureCode) pendingStatFailures.set(String(resolved), failureCode);
-  return resolved;
+  return actualRealpath(artifactPath);
 }
 
 async function interceptedStat(artifactPath: Parameters<typeof fs.stat>[0]) {
   recordActivationGenerationRead("stat", String(artifactPath));
-  const failureCode = pendingStatFailures.get(String(artifactPath));
-  if (!failureCode) return actualStat(artifactPath);
-  pendingStatFailures.delete(String(artifactPath));
-  throw Object.assign(new Error("Injected post-realpath stat failure"), { code: failureCode });
+  return actualStat(artifactPath);
 }
 
-fs.realpath = interceptedRealpath as typeof fs.realpath;
-fs.stat = interceptedStat as typeof fs.stat;
+async function interceptedOpen(...openArguments: Parameters<typeof fs.open>) {
+  const requestedPath = await requestedArtifactPath(String(openArguments[0]));
+  const failureCode = failureByArtifact.get(requestedPath);
+  if (!failureCode) return actualOpen(...openArguments);
+  failureByArtifact.delete(requestedPath);
+  throw Object.assign(new Error("Injected descriptor-bound open failure"), { code: failureCode });
+}
+
+async function requestedArtifactPath(candidatePath: string): Promise<string> {
+  const descriptorMatch = DESCRIPTOR_PATH_PATTERN.exec(candidatePath);
+  if (!descriptorMatch) return candidatePath;
+  const descriptorRoot = candidatePath.slice(0, candidatePath.length - descriptorMatch[1].length - 1);
+  return `${await actualRealpath(descriptorRoot)}/${descriptorMatch[1]}`;
+}
+
+mock.module("node:fs/promises", () => ({
+  ...fs,
+  realpath: interceptedRealpath,
+  stat: interceptedStat,
+  open: interceptedOpen,
+}));

--- a/packages/edge-runtime/server-function-config.test.ts
+++ b/packages/edge-runtime/server-function-config.test.ts
@@ -9,7 +9,7 @@ import {
 import { createHash, randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 setDefaultTimeout(30_000);
 
@@ -72,11 +72,13 @@ async function installActivationCandidate(
 ): Promise<ActivationCandidate> {
   const activationId = request.activationId ?? randomUUID();
   const versionRoot = join(projectRoot, ".versions", request.slug, request.version);
-  await mkdir(versionRoot, { recursive: true });
+  const sourceRoot = join(versionRoot, "src");
+  await mkdir(sourceRoot, { recursive: true });
   const artifactSha256 = createHash("sha256").update(request.source).digest("hex");
   await Promise.all([
     writeFile(join(versionRoot, "index.js"), request.source),
     writeFile(join(versionRoot, `index.${artifactSha256.slice(0, 16)}.js`), request.source),
+    writeFile(join(sourceRoot, ".supacloud-entry.js"), request.source),
   ]);
   const manifest = JSON.stringify({
     verify_jwt: request.verifyJwt ?? false,
@@ -134,6 +136,18 @@ async function invokeAnonymous(slug: string): Promise<Response> {
   return fetch(`${edgeBaseUrl}/functions/v1/${slug}`, {
     headers: { "x-project-ref": PROJECT_REF },
   });
+}
+
+async function installActivationCandidateWithStaticAsset(
+  slug: string,
+  source: string,
+  asset: string,
+): Promise<ActivationCandidate> {
+  const candidate = await installActivationCandidate({ slug, version: "1", source, verifyJwt: false });
+  const assetPath = join(projectRoot, ".versions", slug, "1", "src", "public", "message.txt");
+  await mkdir(dirname(assetPath), { recursive: true });
+  await writeFile(assetPath, asset);
+  return candidate;
 }
 
 function reserveEdgePort(): number {
@@ -569,6 +583,94 @@ describe("Edge Runtime function config boundary", () => {
         });
       }
     }
+    },
+  );
+
+  test.skipIf(process.platform !== "linux")(
+    "serves an attested multi-file Function static asset after activation",
+    async () => {
+      const slug = "activation_static_asset";
+      await resetActivationBaseline(slug);
+      const candidate = await installActivationCandidateWithStaticAsset(
+        slug,
+        `
+          export default async () => new Response(
+            await Bun.file(import.meta.dir + "/public/message.txt").text(),
+          );
+        `,
+        "asset-from-attested-source",
+      );
+      let committed = false;
+
+      try {
+        expect((await activationControl({
+          slug,
+          activationId: candidate.activationId,
+          action: "begin",
+        })).status).toBe(200);
+        expect((await activationControl({
+          slug,
+          activationId: candidate.activationId,
+          action: "preheat",
+          version: "1",
+        })).status).toBe(200);
+        await publishActivationCandidate(slug, candidate);
+        expect((await activationControl({
+          slug,
+          activationId: candidate.activationId,
+          action: "commit",
+        })).status).toBe(200);
+        committed = true;
+
+        const response = await invokeAnonymous(slug);
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe("asset-from-attested-source");
+      } finally {
+        if (!committed) {
+          await activationControl({ slug, activationId: candidate.activationId, action: "abort" });
+        }
+      }
+    },
+  );
+
+  test.skipIf(process.platform !== "linux").each(["replacement", "symlink"] as const)(
+    "rejects an attested source entry %s before activation",
+    async (mutation) => {
+      const slug = `activation_source_${mutation}`;
+      const authoritySource = functionSource("authority-must-not-be-replaced");
+      const candidate = await installActivationCandidate({
+        slug,
+        version: "1",
+        source: authoritySource,
+        verifyJwt: false,
+      });
+      const versionRoot = join(projectRoot, ".versions", slug, "1");
+      const sourceEntry = join(versionRoot, "src", ".supacloud-entry.js");
+
+      if (mutation === "replacement") {
+        await writeFile(sourceEntry, functionSource("replacement-must-not-run"));
+      } else {
+        await rm(sourceEntry);
+        await symlink(join(versionRoot, "index.js"), sourceEntry);
+      }
+
+      try {
+        expect((await activationControl({
+          slug,
+          activationId: candidate.activationId,
+          action: "begin",
+        })).status).toBe(200);
+        const preheat = await activationControl({
+          slug,
+          activationId: candidate.activationId,
+          action: "preheat",
+          version: "1",
+        });
+        expect(preheat.status).toBe(400);
+        expect(await preheat.text()).not.toContain("replacement-must-not-run");
+      } finally {
+        await activationControl({ slug, activationId: candidate.activationId, action: "abort" });
+      }
     },
   );
 

--- a/packages/edge-runtime/server-function-config.test.ts
+++ b/packages/edge-runtime/server-function-config.test.ts
@@ -8,7 +8,7 @@ import {
 } from "bun:test";
 import { createHash, randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 setDefaultTimeout(30_000);
@@ -73,8 +73,11 @@ async function installActivationCandidate(
   const activationId = request.activationId ?? randomUUID();
   const versionRoot = join(projectRoot, ".versions", request.slug, request.version);
   await mkdir(versionRoot, { recursive: true });
-  await writeFile(join(versionRoot, "index.js"), request.source);
   const artifactSha256 = createHash("sha256").update(request.source).digest("hex");
+  await Promise.all([
+    writeFile(join(versionRoot, "index.js"), request.source),
+    writeFile(join(versionRoot, `index.${artifactSha256.slice(0, 16)}.js`), request.source),
+  ]);
   const manifest = JSON.stringify({
     verify_jwt: request.verifyJwt ?? false,
     version: request.version,
@@ -120,6 +123,11 @@ async function activationControl(request: ActivationControlRequest): Promise<Res
 
 async function publishActivationCandidate(slug: string, candidate: ActivationCandidate): Promise<void> {
   await writeFunctionConfig(slug, candidate.manifest);
+}
+
+async function resetActivationBaseline(slug: string): Promise<void> {
+  await rm(join(projectRoot, `${slug}.config.json`), { force: true });
+  await invalidateFunctionConfig(slug);
 }
 
 async function invokeAnonymous(slug: string): Promise<Response> {
@@ -269,7 +277,7 @@ function startEdgeRuntime(managementPort: number): void {
 }
 
 async function initializeServerFixture(): Promise<void> {
-  fixtureRoot = await mkdtemp(join(tmpdir(), "supacloud-edge-config-contract-"));
+  fixtureRoot = await mkdtemp(join(homedir(), ".supacloud-edge-config-contract-"));
   projectRoot = join(fixtureRoot, "functions", PROJECT_REF);
   activationGenerationReadLog = join(fixtureRoot, "activation-generation-reads.log");
   await mkdir(projectRoot, { recursive: true });
@@ -490,18 +498,24 @@ describe("Edge Runtime function config boundary", () => {
     },
   );
 
-  test.each(STAT_RACE_FAILURES)(
-    "fails closed for %s when stat returns %s after realpath succeeds",
+  test.skipIf(process.platform !== "linux").each(STAT_RACE_FAILURES)(
+    "fails closed for %s when descriptor-bound open returns %s",
     async (slug) => {
       const fallbackBody = `${slug}-fallback-must-not-run`;
       await installStatRaceFunction(slug, fallbackBody);
-      await expectActivationFailsClosed(slug, fallbackBody);
+      const foreground = await invokeForeground(slug);
+      expect(foreground.status).toBe(500);
+      expect(foreground.headers.has("x-supacloud-function-version")).toBe(false);
+      expect(await foreground.text()).not.toContain(fallbackBody);
     },
   );
 
-  test("fences requests until the immutable candidate is preheated and committed", async () => {
+  test.skipIf(process.platform !== "linux")(
+    "fences requests until the immutable candidate is preheated and committed",
+    async () => {
     const slug = "activation_candidate";
     const candidateBody = "candidate-policy-visible-only-after-commit";
+    await resetActivationBaseline(slug);
     const candidate = await installActivationCandidate({
       slug,
       version: "1",
@@ -555,9 +569,16 @@ describe("Edge Runtime function config boundary", () => {
         });
       }
     }
-  });
+    },
+  );
 
-  test("rejects a foreign activation without replacing the global lease", async () => {
+  test.skipIf(process.platform !== "linux")(
+    "rejects a foreign activation without replacing the global lease",
+    async () => {
+    await Promise.all([
+      resetActivationBaseline("lease_first"),
+      resetActivationBaseline("lease_second"),
+    ]);
     const first = await installActivationCandidate({
       slug: "lease_first",
       version: "1",
@@ -599,9 +620,12 @@ describe("Edge Runtime function config boundary", () => {
         action: "abort",
       });
     }
-  });
+    },
+  );
 
-  test("cancels queued requests when an activation fence begins", async () => {
+  test.skipIf(process.platform !== "linux")(
+    "cancels queued requests when an activation fence begins",
+    async () => {
     const slug = "activation_queue";
     const slowSource = `
       export default async () => {
@@ -643,11 +667,15 @@ describe("Edge Runtime function config boundary", () => {
         action: "abort",
       });
     }
-  });
+    },
+  );
 
-  test("recovers committed activation identity after an Edge Runtime restart", async () => {
+  test.skipIf(process.platform !== "linux")(
+    "recovers committed activation identity after an Edge Runtime restart",
+    async () => {
     const slug = "activation_restart";
     const body = "committed-after-restart";
+    await resetActivationBaseline(slug);
     const candidate = await installActivationCandidate({
       slug,
       version: "1",
@@ -677,5 +705,6 @@ describe("Edge Runtime function config boundary", () => {
     const active = await invokeAnonymous(slug);
     expect(active.status).toBe(200);
     expect(await active.text()).toBe(body);
-  });
+    },
+  );
 });

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -31,7 +31,11 @@ import {
 import {
   buildBackgroundForwardDispatch,
 } from "./background-forward";
-import { activeFunctionPathCandidates } from "./function-source";
+import {
+  activeFunctionPathCandidates,
+  attestedFunctionArtifactPath,
+} from "./function-source";
+import { readFunctionFile, type TrustedFunctionFile } from "./trusted-function-files";
 import {
   assertCanonicalConfiguredFunctionVersion,
   resolveFunctionVersionBinding,
@@ -39,8 +43,6 @@ import {
 } from "./function-version";
 import path from "path";
 import fs from "fs/promises";
-import { createHash } from "node:crypto";
-import type { Stats } from "node:fs";
 import type { PgredisRuntimeEndpointConfig } from "./internal-bindings";
 import { createPgredisCapability } from "./pgredis-capability";
 import {
@@ -352,6 +354,8 @@ type FunctionActivationSnapshot = {
   moduleVersion: string;
   artifactSha256: string;
   activationId: string | null;
+  authorityKind: "active" | "historical" | "legacy";
+  attested: boolean;
 };
 
 type RuntimePreheatIdentityRequest = {
@@ -366,7 +370,8 @@ type RuntimePreheatIdentityRequest = {
 
 function runtimePreheatIdentity(
   request: RuntimePreheatIdentityRequest,
-): EdgeRuntimePreheatIdentity {
+): EdgeRuntimePreheatIdentity | null {
+  if (!request.activation.attested) return null;
   return {
     schema: EDGE_RUNTIME_PREHEAT_ATTESTATION_SCHEMA,
     project_ref: request.projectRef,
@@ -389,63 +394,6 @@ function runtimePreheatIdentity(
   };
 }
 
-function sameArtifactIdentity(left: Stats, right: Stats): boolean {
-  return left.dev === right.dev
-    && left.ino === right.ino
-    && left.size === right.size
-    && left.mtimeMs === right.mtimeMs
-    && left.ctimeMs === right.ctimeMs;
-}
-
-async function attestedArtifactSha256(
-  functionPath: string,
-  expected: Stats,
-): Promise<string> {
-  const artifact = await fs.open(functionPath, "r");
-  try {
-    const before = await artifact.stat();
-    if (!before.isFile() || !sameArtifactIdentity(before, expected)) {
-      throw new Error("Function artifact changed before hashing");
-    }
-    const digest = createHash("sha256").update(await artifact.readFile()).digest("hex");
-    const after = await artifact.stat();
-    if (!sameArtifactIdentity(before, after)) {
-      throw new Error("Function artifact changed while hashing");
-    }
-    return digest;
-  } finally {
-    await artifact.close();
-  }
-}
-
-function functionArtifactBindingRoot(
-  projectRoot: string,
-  functionName: string,
-  activeVersion: string | null,
-  candidate: string,
-): string {
-  if (activeVersion !== null) {
-    return path.join(projectRoot, ".versions", functionName, activeVersion);
-  }
-  const sourceRoot = path.join(projectRoot, `.src-${functionName}`);
-  return isPathInside(candidate, sourceRoot) ? sourceRoot : candidate;
-}
-
-function isBoundFunctionArtifact(
-  candidate: string,
-  realCandidate: string,
-  bindingRoot: string,
-): boolean {
-  return bindingRoot === candidate
-    ? realCandidate === candidate
-    : isPathInside(realCandidate, bindingRoot);
-}
-
-function isMissingFunctionCandidate(error: unknown): boolean {
-  if (!(error instanceof Error) || !("code" in error)) return false;
-  return error.code === "ENOENT" || error.code === "ENOTDIR";
-}
-
 type ResolveFunctionPathRequest = {
   projectRef: string;
   functionName: string;
@@ -464,59 +412,74 @@ async function resolvedFunctionPath(
   const resolvedConfig = request.configOverride
     ?? await getFunctionConfig(request.projectRef, request.functionName, projectRoot);
   if (resolvedConfig.targetState === "absent") throw new Error("Function not found");
+  if (request.configOverride === undefined && resolvedConfig.authorityKind === "active") {
+    const currentManifest = await activeActivationManifest(projectRoot, request.functionName);
+    const currentAuthority = currentManifest.authority;
+    if (!currentAuthority
+      || currentAuthority.activation_id !== resolvedConfig.activationId
+      || currentAuthority.target_state !== resolvedConfig.targetState
+      || currentAuthority.artifact_sha256 !== resolvedConfig.artifactSha256
+      || currentManifest.config.version !== resolvedConfig.version
+      || currentManifest.config.verify_jwt !== resolvedConfig.verify_jwt) {
+      configCache.delete(`${request.projectRef}/${request.functionName}`);
+      throw new Error("Runtime environment changed before artifact resolution");
+    }
+  }
   const versionBindingResolver = request.versionBindingResolver ?? resolveFunctionVersionBinding;
   const { activeVersion, responseVersion } = versionBindingResolver(
     request.requestedVersion,
     resolvedConfig.version,
   );
-  const candidates = activeFunctionPathCandidates(
-    projectRoot,
-    request.functionName,
-    activeVersion,
-  );
+  const authoritative = resolvedConfig.authorityKind !== "legacy";
+  if (authoritative && activeVersion === null) {
+    throw new Error("Authoritative Function activation must identify a version");
+  }
+  if (authoritative && resolvedConfig.artifactSha256 === null) {
+    throw new Error("Authoritative Function activation must identify an artifact digest");
+  }
+  const candidates = authoritative
+    ? [attestedFunctionArtifactPath(
+        projectRoot,
+        request.functionName,
+        activeVersion!,
+        resolvedConfig.artifactSha256!,
+      )]
+    : activeFunctionPathCandidates(projectRoot, request.functionName, activeVersion);
 
   for (const candidate of candidates) {
     if (!isPathInside(candidate, projectRoot)) {
       throw new Error("Function path escapes project root");
     }
 
-    let realCandidate: string;
+    let artifact: TrustedFunctionFile;
     try {
-      realCandidate = await fs.realpath(candidate);
+      artifact = await readFunctionFile(candidate);
     } catch (error) {
-      if (!isMissingFunctionCandidate(error)) throw error;
-      continue;
+      const code = error instanceof Error && "code" in error ? error.code : null;
+      if (!authoritative && (code === "ENOENT" || code === "ENOTDIR")) continue;
+      throw error;
     }
-    const bindingRoot = functionArtifactBindingRoot(
-      projectRoot,
-      request.functionName,
-      activeVersion,
-      candidate,
-    );
-    if (!isBoundFunctionArtifact(candidate, realCandidate, bindingRoot)) {
-      throw new Error("Function path escapes its activation root");
+    if (authoritative && artifact.sha256 !== resolvedConfig.artifactSha256) {
+      throw new Error("Function artifact SHA-256 does not match activation authority");
     }
-    const stat = await fs.stat(realCandidate);
-    if (!stat.isFile()) {
-      throw new Error("Function artifact is not a regular file");
-    }
-    const artifactSha256 = await attestedArtifactSha256(realCandidate, stat);
     return {
-      functionPath: realCandidate,
+      functionPath: candidate,
       projectRoot,
       activeVersion,
       responseVersion,
       verifyJwt: resolvedConfig.verify_jwt,
-      artifactSha256,
+      artifactSha256: artifact.sha256,
       activationId: resolvedConfig.activationId,
+      authorityKind: resolvedConfig.authorityKind,
+      attested: authoritative,
       moduleVersion: [
         `active:${activeVersion || "legacy"}`,
         `activation:${resolvedConfig.activationId ?? "legacy"}`,
         `env:${getProjectModuleEpoch(request.projectRef)}`,
-        `mtime:${stat.mtimeMs}`,
-        `ctime:${stat.ctimeMs}`,
-        `size:${stat.size}`,
-        `sha256:${artifactSha256}`,
+        `mtime:${artifact.metadata.mtimeMs}`,
+        `ctime:${artifact.metadata.ctimeMs}`,
+        `size:${artifact.metadata.size}`,
+        `sha256:${artifact.sha256}`,
       ].join(":"),
     };
   }
@@ -614,6 +577,7 @@ async function dispatchFunction(
     if (activationFences.has(activationFenceKey(projectRef, functionName))) {
       throw new Error("Runtime environment changed during Function activation");
     }
+    await assertDispatchAuthorityCurrent(projectRef, functionName, activation);
     const dispatchReservation = reserveTenantEnvDispatch(projectRef);
     const runtimeLogContext = {
       functionVersion: activeVersion,
@@ -638,7 +602,7 @@ async function dispatchFunction(
           }
         : undefined,
       moduleVersion,
-      artifactSha256: activation.artifactSha256,
+      artifactSha256: activation.attested ? activation.artifactSha256 : undefined,
       env: dispatchEnv,
       envProof: moduleEnvProof || undefined,
       request,
@@ -721,6 +685,8 @@ type FunctionConfig = {
   version: string | null;
   activationId: string | null;
   targetState: "active" | "absent" | null;
+  artifactSha256: string | null;
+  authorityKind: "active" | "historical" | "legacy";
 };
 
 type ActivationPoolControl = Awaited<ReturnType<WorkerPool["invalidateProject"]>>;
@@ -739,31 +705,20 @@ function isMissingFileError(error: unknown): boolean {
     && (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
-function parseFunctionConfig(raw: string): FunctionConfig {
-  const manifest = parseEdgeFunctionActivationManifest(raw);
-  return {
-    verify_jwt: manifest.config.verify_jwt,
-    version: manifest.config.version,
-    activationId: activationAuthorityId(manifest),
-    targetState: manifest.authority?.target_state ?? null,
-  };
-}
-
-async function existingFunctionConfigPath(
+async function readFunctionActivationManifest(
   configPath: string,
   projectRoot: string,
-): Promise<string | null> {
+): Promise<EdgeFunctionActivationManifest | null> {
+  if (!isPathInside(configPath, projectRoot)) {
+    throw new Error("Function config path escapes project root");
+  }
   try {
-    await fs.lstat(configPath);
-  } catch (error) {
+    const configFile = await readFunctionFile(configPath);
+    return parseEdgeFunctionActivationManifest(configFile.bytes.toString("utf8"));
+  } catch (error: unknown) {
     if (isMissingFileError(error)) return null;
     throw error;
   }
-  const realConfigPath = await fs.realpath(configPath);
-  if (!isPathInside(realConfigPath, projectRoot)) {
-    throw new Error("Function config path escapes project root");
-  }
-  return realConfigPath;
 }
 
 async function getFunctionConfig(
@@ -779,6 +734,8 @@ async function getFunctionConfig(
       version: cached.version,
       activationId: cached.activationId,
       targetState: cached.targetState,
+      artifactSha256: cached.artifactSha256,
+      authorityKind: cached.authorityKind,
     };
   }
 
@@ -786,10 +743,24 @@ async function getFunctionConfig(
   if (!isPathInside(configPath, projectRoot)) {
     throw new Error("Function config path escapes project root");
   }
-  const realConfigPath = await existingFunctionConfigPath(configPath, projectRoot);
-  const config = realConfigPath === null
-    ? { verify_jwt: true, version: null, activationId: null, targetState: null }
-    : parseFunctionConfig(await fs.readFile(realConfigPath, "utf8"));
+  const manifest = await readFunctionActivationManifest(configPath, projectRoot);
+  const config = manifest === null
+    ? {
+        verify_jwt: true,
+        version: null,
+        activationId: null,
+        targetState: null,
+        artifactSha256: null,
+        authorityKind: "legacy" as const,
+      }
+    : {
+        verify_jwt: manifest.config.verify_jwt,
+        version: manifest.config.version,
+        activationId: activationAuthorityId(manifest),
+        targetState: manifest.authority?.target_state ?? null,
+        artifactSha256: manifest.authority?.artifact_sha256 ?? null,
+        authorityKind: manifest.authority === null ? "legacy" as const : "active" as const,
+      };
   configCache.set(key, { ...config, expiresAt: Date.now() + CONFIG_CACHE_TTL });
   return config;
 }
@@ -806,12 +777,15 @@ async function immutableVersionConfig(
   if (!isPathInside(resolvedMetadataPath, versionRoot)) {
     throw new Error("Function version metadata escapes its immutable version directory");
   }
-  const metadata: unknown = JSON.parse(await fs.readFile(resolvedMetadataPath, "utf8"));
+  const metadataFile = await readFunctionFile(resolvedMetadataPath);
+  const metadata: unknown = JSON.parse(metadataFile.bytes.toString("utf8"));
   if (metadata === null || typeof metadata !== "object" || Array.isArray(metadata)) {
     throw new Error("Function version metadata must be an object");
   }
   const record = metadata as Record<string, unknown>;
-  if (record.version !== version || typeof record.verify_jwt !== "boolean") {
+  if (record.version !== version
+    || typeof record.verify_jwt !== "boolean"
+    || typeof record.artifact_sha256 !== "string") {
     throw new Error("Function version metadata does not match its immutable version");
   }
   return {
@@ -819,6 +793,51 @@ async function immutableVersionConfig(
     version,
     activationId: null,
     targetState: "active",
+    artifactSha256: record.artifact_sha256,
+    authorityKind: "historical",
+  };
+}
+
+async function assertDispatchAuthorityCurrent(
+  projectRef: string,
+  functionName: string,
+  activation: FunctionActivationSnapshot,
+): Promise<void> {
+  if (!activation.attested) return;
+  const current = activation.authorityKind === "active"
+    ? await activeFunctionConfig(activation.projectRoot, functionName)
+    : await immutableVersionConfig(
+        activation.projectRoot,
+        functionName,
+        activation.activeVersion!,
+      );
+  if (current.authorityKind !== activation.authorityKind
+    || current.activationId !== activation.activationId
+    || current.version !== activation.activeVersion
+    || current.verify_jwt !== activation.verifyJwt
+    || current.targetState !== "active"
+    || current.artifactSha256 !== activation.artifactSha256) {
+    configCache.delete(`${projectRef}/${functionName}`);
+    throw new Error("Runtime environment changed before dispatch");
+  }
+  const artifact = await readFunctionFile(activation.functionPath);
+  if (artifact.sha256 !== activation.artifactSha256) {
+    throw new Error("Function artifact SHA-256 does not match dispatch authority");
+  }
+}
+
+async function activeFunctionConfig(
+  projectRoot: string,
+  functionName: string,
+): Promise<FunctionConfig> {
+  const manifest = await activeActivationManifest(projectRoot, functionName);
+  return {
+    verify_jwt: manifest.config.verify_jwt,
+    version: manifest.config.version,
+    activationId: activationAuthorityId(manifest),
+    targetState: manifest.authority?.target_state ?? null,
+    artifactSha256: manifest.authority?.artifact_sha256 ?? null,
+    authorityKind: manifest.authority === null ? "legacy" : "active",
   };
 }
 
@@ -827,10 +846,8 @@ async function activeActivationManifest(
   functionName: string,
 ): Promise<EdgeFunctionActivationManifest> {
   const configPath = path.resolve(projectRoot, `${functionName}.config.json`);
-  const realConfigPath = await existingFunctionConfigPath(configPath, projectRoot);
-  return realConfigPath === null
-    ? parseEdgeFunctionActivationManifest("{}")
-    : parseEdgeFunctionActivationManifest(await fs.readFile(realConfigPath, "utf8"));
+  return await readFunctionActivationManifest(configPath, projectRoot)
+    ?? parseEdgeFunctionActivationManifest("{}");
 }
 
 async function preheatActivationSnapshot(
@@ -858,6 +875,8 @@ async function preheatActivationSnapshot(
         ...candidate.config,
         activationId: candidate.authority.activation_id,
         targetState: candidate.authority.target_state,
+        artifactSha256: candidate.authority.artifact_sha256,
+        authorityKind: "active",
       },
     });
     if (activation.artifactSha256 !== candidate.authority.artifact_sha256) {
@@ -1142,6 +1161,8 @@ async function commitFunctionActivationFence(
       ...current.config,
       activationId,
       targetState: current.authority?.target_state ?? null,
+      artifactSha256: current.authority?.artifact_sha256 ?? null,
+      authorityKind: current.authority === null ? "legacy" : "active",
       expiresAt: Date.now() + CONFIG_CACHE_TTL,
     });
     return state;
@@ -1159,6 +1180,8 @@ async function commitFunctionActivationFence(
     ...fence.candidate.config,
     activationId,
     targetState: fence.candidate.authority.target_state,
+    artifactSha256: fence.candidate.authority.artifact_sha256,
+    authorityKind: "active",
     expiresAt: Date.now() + CONFIG_CACHE_TTL,
   });
   activationFences.delete(key);
@@ -1503,7 +1526,7 @@ const app = new Elysia()
               projectRef: c.params.ref,
               moduleVersion,
               envProof: foregroundModuleEnvProof || undefined,
-              attestation: foregroundAttestation,
+              attestation: foregroundAttestation ?? undefined,
             }),
             backgroundPool.preheatVersionedIdleWorkers({
               functionId,
@@ -1513,7 +1536,7 @@ const app = new Elysia()
               projectRef: c.params.ref,
               moduleVersion,
               envProof: backgroundModuleEnvProof || undefined,
-              attestation: backgroundAttestation,
+              attestation: backgroundAttestation ?? undefined,
               maxWorkers: resolveBackgroundPreheatWorkers(),
             }),
           ])
@@ -1522,17 +1545,18 @@ const app = new Elysia()
               projectRef: c.params.ref,
               moduleVersion,
               envProof: foregroundModuleEnvProof || undefined,
-              attestation: foregroundAttestation,
+              attestation: foregroundAttestation ?? undefined,
             }),
             backgroundPool.preheatIdleWorkers(functionId, functionPath, projectRoot, tenantEnv, {
               projectRef: c.params.ref,
               moduleVersion,
               envProof: backgroundModuleEnvProof || undefined,
-              attestation: backgroundAttestation,
+              attestation: backgroundAttestation ?? undefined,
               maxWorkers: resolveBackgroundPreheatWorkers(),
             }),
           ]);
-      const complete = hasCompletePreheatAttestation(foreground)
+      const complete = activation.attested
+        && hasCompletePreheatAttestation(foreground)
         && hasCompletePreheatAttestation(background)
         && isTenantEnvLoadCurrent(c.params.ref, tenantEnvLoad)
         && (!activationId || activationFences.get(fenceKey) === activationFence);

--- a/packages/edge-runtime/trusted-function-files.test.ts
+++ b/packages/edge-runtime/trusted-function-files.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  assertTrustedFunctionArtifact,
+  readTrustedFunctionFile,
+  withTrustedFunctionArtifact,
+} from "./trusted-function-files";
+
+describe("trusted Function runtime files", () => {
+  const trustedTemporaryRoot = process.platform === "linux" ? homedir() : tmpdir();
+
+  test("reads a regular artifact through a trusted directory chain", async () => {
+    const root = await mkdtemp(join(trustedTemporaryRoot, ".supacloud-runtime-artifact-"));
+    const artifactPath = join(root, "index.aaaaaaaaaaaaaaaa.js");
+    await writeFile(artifactPath, "trusted artifact");
+    try {
+      if (process.platform === "linux") {
+        const artifact = await readTrustedFunctionFile(artifactPath);
+        expect(artifact.bytes.toString()).toBe("trusted artifact");
+        expect(await assertTrustedFunctionArtifact(artifactPath, artifact.sha256)).toBeUndefined();
+      } else {
+        await expect(readTrustedFunctionFile(artifactPath)).rejects.toThrow(
+          "Attested Function artifacts require Linux descriptor binding",
+        );
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "linux")(
+    "rejects attested imports before invoking the module loader",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "supacloud-runtime-attested-import-"));
+      const artifactPath = join(root, "index.aaaaaaaaaaaaaaaa.js");
+      await writeFile(artifactPath, "trusted artifact");
+      let moduleLoaderCalls = 0;
+      try {
+        await expect(withTrustedFunctionArtifact(
+          artifactPath,
+          "a".repeat(64),
+          async () => {
+            moduleLoaderCalls += 1;
+            return "must not load";
+          },
+        )).rejects.toThrow("Attested Function imports require Linux descriptor binding");
+        expect(moduleLoaderCalls).toBe(0);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  test.skipIf(process.platform !== "linux")(
+    "rejects a writable direct parent and artifact symlink",
+    async () => {
+      const root = await mkdtemp(join(trustedTemporaryRoot, ".supacloud-runtime-untrusted-"));
+      const outside = await mkdtemp(join(tmpdir(), "supacloud-runtime-outside-"));
+      const targetPath = join(outside, "target.js");
+      const artifactPath = join(root, "index.aaaaaaaaaaaaaaaa.js");
+      await writeFile(targetPath, "outside");
+      await symlink(targetPath, artifactPath);
+      try {
+        await expect(readTrustedFunctionFile(artifactPath)).rejects.toThrow(
+          "Function runtime file is not trusted",
+        );
+        await rm(artifactPath);
+        await writeFile(artifactPath, "writable parent");
+        await chmod(root, 0o777);
+        await expect(readTrustedFunctionFile(artifactPath)).rejects.toThrow(
+          "Function runtime directory is not trusted",
+        );
+      } finally {
+        await chmod(root, 0o700);
+        await Promise.all([
+          rm(root, { recursive: true, force: true }),
+          rm(outside, { recursive: true, force: true }),
+        ]);
+      }
+    },
+  );
+
+  test.skipIf(process.platform !== "linux")(
+    "rejects replacement through a writable ancestor",
+    async () => {
+      const root = await mkdtemp(join(trustedTemporaryRoot, ".supacloud-runtime-ancestor-"));
+      const trustedParent = join(root, "functions", "project");
+      await mkdir(trustedParent, { recursive: true, mode: 0o700 });
+      const artifactPath = join(trustedParent, "index.aaaaaaaaaaaaaaaa.js");
+      await writeFile(artifactPath, "artifact");
+      try {
+        await chmod(join(root, "functions"), 0o777);
+        await expect(readTrustedFunctionFile(artifactPath)).rejects.toThrow(
+          "Function runtime directory is not trusted",
+        );
+      } finally {
+        await chmod(join(root, "functions"), 0o700);
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  test.skipIf(process.platform !== "linux")(
+    "rejects a group-writable artifact in a trusted directory",
+    async () => {
+      const root = await mkdtemp(join(trustedTemporaryRoot, ".supacloud-runtime-writable-file-"));
+      const artifactPath = join(root, "index.aaaaaaaaaaaaaaaa.js");
+      await writeFile(artifactPath, "writable artifact");
+      await chmod(artifactPath, 0o660);
+      try {
+        await expect(readTrustedFunctionFile(artifactPath)).rejects.toThrow(
+          "Function runtime file is not trusted",
+        );
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/packages/edge-runtime/trusted-function-files.ts
+++ b/packages/edge-runtime/trusted-function-files.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import { constants, type Stats } from "node:fs";
+import { lstat, open, readlink, realpath, type FileHandle } from "node:fs/promises";
+import { basename, dirname, join, parse, relative, resolve, sep } from "node:path";
+
+const DIRECTORY_OPEN_FLAGS = constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW;
+const FILE_OPEN_FLAGS = constants.O_RDONLY | constants.O_NOFOLLOW;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+type HeldDirectory = {
+  descriptor: FileHandle;
+  path: string;
+  identity: Stats;
+};
+
+export type TrustedFunctionFile = {
+  path: string;
+  bytes: Buffer;
+  sha256: string;
+  metadata: Stats;
+};
+
+function sameIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function assertTrustedDirectory(metadata: Stats): void {
+  const effectiveUid = process.geteuid?.();
+  const trustedOwner = effectiveUid !== undefined
+    && (metadata.uid === 0 || metadata.uid === effectiveUid);
+  if (!metadata.isDirectory() || !trustedOwner || (metadata.mode & 0o022) !== 0) {
+    throw new Error("Function runtime directory is not trusted");
+  }
+}
+
+function assertTrustedRegularFile(metadata: Stats, requireTrustedOwner = true): void {
+  const effectiveUid = process.geteuid?.();
+  const trustedOwner = effectiveUid !== undefined
+    && (metadata.uid === 0 || metadata.uid === effectiveUid);
+  if (!metadata.isFile()
+    || (requireTrustedOwner && (!trustedOwner || (metadata.mode & 0o022) !== 0))) {
+    throw new Error("Function runtime file is not trusted");
+  }
+}
+
+function canonicalDirectoryChain(directoryPath: string): string[] {
+  const filesystemRoot = parse(directoryPath).root;
+  const pathSegments = relative(filesystemRoot, directoryPath).split(sep).filter(Boolean);
+  const chain = [filesystemRoot];
+  for (const pathSegment of pathSegments) chain.push(join(chain.at(-1)!, pathSegment));
+  return chain;
+}
+
+async function heldDirectory(directoryPath: string, openPath: string): Promise<HeldDirectory> {
+  const pathMetadata = await lstat(directoryPath);
+  assertTrustedDirectory(pathMetadata);
+  const descriptor = await open(openPath, DIRECTORY_OPEN_FLAGS);
+  try {
+    const descriptorMetadata = await descriptor.stat();
+    assertTrustedDirectory(descriptorMetadata);
+    if (!sameIdentity(pathMetadata, descriptorMetadata)) {
+      throw new Error("Function runtime directory identity changed");
+    }
+    return { descriptor, path: directoryPath, identity: descriptorMetadata };
+  } catch (error: unknown) {
+    await descriptor.close();
+    throw error;
+  }
+}
+
+async function heldTrustedDirectoryChain(directoryPath: string): Promise<HeldDirectory[]> {
+  if (process.platform !== "linux") {
+    throw new Error("Attested Function artifacts require Linux descriptor binding");
+  }
+  const canonicalPath = await realpath(directoryPath);
+  if (canonicalPath !== resolve(directoryPath)) {
+    throw new Error("Function runtime directory path is not canonical");
+  }
+  const heldDirectories: HeldDirectory[] = [];
+  try {
+    for (const pathEntry of canonicalDirectoryChain(canonicalPath)) {
+      const parent = heldDirectories.at(-1);
+      const openPath = parent
+        ? `/proc/self/fd/${parent.descriptor.fd}/${basename(pathEntry)}`
+        : pathEntry;
+      heldDirectories.push(await heldDirectory(pathEntry, openPath));
+    }
+    return heldDirectories;
+  } catch (error: unknown) {
+    await closeHeldDirectories(heldDirectories);
+    throw error;
+  }
+}
+
+async function closeHeldDirectories(heldDirectories: HeldDirectory[]): Promise<void> {
+  await Promise.all(heldDirectories.map(({ descriptor }) => descriptor.close()));
+}
+
+async function assertHeldDirectoryBindings(heldDirectories: HeldDirectory[]): Promise<void> {
+  for (const held of heldDirectories) {
+    const [descriptorMetadata, currentPath, pathMetadata] = await Promise.all([
+      held.descriptor.stat(),
+      readlink(`/proc/self/fd/${held.descriptor.fd}`),
+      lstat(held.path),
+    ]);
+    if (currentPath !== held.path
+      || !sameIdentity(held.identity, descriptorMetadata)
+      || !sameIdentity(held.identity, pathMetadata)) {
+      throw new Error("Function runtime directory binding changed");
+    }
+  }
+}
+
+async function assertPathBinding(filePath: string, expected: Stats): Promise<void> {
+  const current = await lstat(filePath);
+  if (!sameIdentity(expected, current)) {
+    throw new Error("Function runtime file path changed");
+  }
+}
+
+function fileChanged(before: Stats, after: Stats): boolean {
+  return !sameIdentity(before, after)
+    || before.size !== after.size
+    || before.mtimeMs !== after.mtimeMs
+    || before.ctimeMs !== after.ctimeMs;
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  return error.code === "ENOENT" || error.code === "ENOTDIR";
+}
+
+async function openBoundFunctionFile(filePath: string): Promise<FileHandle> {
+  try {
+    return await open(filePath, FILE_OPEN_FLAGS);
+  } catch (error: unknown) {
+    if (!isMissingPathError(error)) throw error;
+    throw new Error("Function runtime file changed before open", { cause: error });
+  }
+}
+
+async function readHeldFunctionFile(
+  filePath: string,
+  heldDirectories: HeldDirectory[],
+): Promise<TrustedFunctionFile> {
+  const parent = heldDirectories.at(-1);
+  if (!parent) throw new Error("Function runtime directory is unavailable");
+  const entryName = basename(filePath);
+  if (join(dirname(filePath), entryName) !== filePath) {
+    throw new Error("Function runtime file must be a direct child");
+  }
+  const boundPath = `/proc/self/fd/${parent.descriptor.fd}/${entryName}`;
+  const pathMetadata = await lstat(boundPath);
+  assertTrustedRegularFile(pathMetadata);
+  const file = await openBoundFunctionFile(boundPath);
+  try {
+    const before = await file.stat();
+    assertTrustedRegularFile(before);
+    if (!sameIdentity(pathMetadata, before)) {
+      throw new Error("Function runtime file identity changed before read");
+    }
+    const bytes = await file.readFile();
+    const after = await file.stat();
+    if (fileChanged(before, after)) throw new Error("Function runtime file changed while reading");
+    await assertPathBinding(filePath, after);
+    await assertHeldDirectoryBindings(heldDirectories);
+    return {
+      path: filePath,
+      bytes,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      metadata: after,
+    };
+  } finally {
+    await file.close();
+  }
+}
+
+export async function readTrustedFunctionFile(filePath: string): Promise<TrustedFunctionFile> {
+  const absolutePath = resolve(filePath);
+  const heldDirectories = await heldTrustedDirectoryChain(dirname(absolutePath));
+  try {
+    return await readHeldFunctionFile(absolutePath, heldDirectories);
+  } finally {
+    await closeHeldDirectories(heldDirectories);
+  }
+}
+
+export async function readFunctionFile(filePath: string): Promise<TrustedFunctionFile> {
+  if (process.platform === "linux") {
+    return readTrustedFunctionFile(filePath);
+  }
+  const absolutePath = resolve(filePath);
+  const pathMetadata = await lstat(absolutePath);
+  assertTrustedRegularFile(pathMetadata, false);
+  const file = await openBoundFunctionFile(absolutePath);
+  try {
+    const before = await file.stat();
+    assertTrustedRegularFile(before, false);
+    if (!sameIdentity(pathMetadata, before)) {
+      throw new Error("Function runtime file identity changed before read");
+    }
+    const bytes = await file.readFile();
+    const after = await file.stat();
+    if (fileChanged(before, after)) throw new Error("Function runtime file changed while reading");
+    await assertPathBinding(absolutePath, after);
+    return {
+      path: absolutePath,
+      bytes,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      metadata: after,
+    };
+  } finally {
+    await file.close();
+  }
+}
+
+export async function assertTrustedFunctionArtifact(
+  filePath: string,
+  expectedSha256: string,
+): Promise<void> {
+  if (!SHA256_PATTERN.test(expectedSha256)) {
+    throw new Error("Function artifact SHA-256 is invalid");
+  }
+  const artifact = await readFunctionFile(filePath);
+  if (artifact.sha256 !== expectedSha256) {
+    throw new Error("Function artifact SHA-256 does not match activation authority");
+  }
+}
+
+export async function withTrustedFunctionArtifact<T>(
+  filePath: string,
+  expectedSha256: string,
+  readArtifact: (descriptorPath: string) => Promise<T>,
+): Promise<T> {
+  if (!SHA256_PATTERN.test(expectedSha256)) {
+    throw new Error("Function artifact SHA-256 is invalid");
+  }
+  if (process.platform !== "linux") {
+    throw new Error("Attested Function imports require Linux descriptor binding");
+  }
+  const absolutePath = resolve(filePath);
+  const heldDirectories = await heldTrustedDirectoryChain(dirname(absolutePath));
+  let artifact: FileHandle | null = null;
+  try {
+    const parent = heldDirectories.at(-1)!;
+    const boundPath = `/proc/self/fd/${parent.descriptor.fd}/${basename(absolutePath)}`;
+    const pathMetadata = await lstat(boundPath);
+    assertTrustedRegularFile(pathMetadata);
+    artifact = await openBoundFunctionFile(boundPath);
+    const metadata = await artifact.stat();
+    assertTrustedRegularFile(metadata);
+    if (!sameIdentity(pathMetadata, metadata)) {
+      throw new Error("Function runtime file identity changed before import");
+    }
+    const bytes = await artifact.readFile();
+    if (createHash("sha256").update(bytes).digest("hex") !== expectedSha256) {
+      throw new Error("Function artifact SHA-256 does not match activation authority");
+    }
+    await assertHeldDirectoryBindings(heldDirectories);
+    const imported = await readArtifact(`/proc/self/fd/${artifact.fd}`);
+    const after = await artifact.stat();
+    if (fileChanged(metadata, after)) throw new Error("Function runtime file changed while importing");
+    await assertHeldDirectoryBindings(heldDirectories);
+    return imported;
+  } finally {
+    await artifact?.close();
+    await closeHeldDirectories(heldDirectories);
+  }
+}

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -32,6 +32,10 @@ import {
 
 const { parentPort } = require("node:worker_threads") as typeof import("node:worker_threads");
 import type { PgredisRuntimeBindingConfig } from "./internal-bindings";
+import {
+  assertTrustedFunctionArtifact,
+  withTrustedFunctionArtifact,
+} from "./trusted-function-files";
 
 const runtimeBunFile = Bun.file.bind(Bun);
 const setProjectRoot = initializeProjectRootControl();
@@ -170,20 +174,20 @@ async function importModuleHandler(importUrl: string): Promise<unknown> {
   }
 }
 
-async function artifactSha256(functionPath: string): Promise<string> {
-  const artifactBytes = await runtimeBunFile(functionPath).arrayBuffer();
-  const digest = await crypto.subtle.digest("SHA-256", artifactBytes);
-  return Buffer.from(digest).toString("hex");
-}
-
 async function assertAttestedArtifact(
   functionPath: string,
   identity: EdgeRuntimePreheatIdentity | undefined,
 ): Promise<void> {
   if (!identity) return;
-  if (await artifactSha256(functionPath) !== identity.artifact_sha256) {
-    throw new Error("Function artifact SHA-256 does not match preheat identity");
-  }
+  await assertTrustedFunctionArtifact(functionPath, identity.artifact_sha256);
+}
+
+async function assertExpectedArtifact(
+  functionPath: string,
+  expectedSha256: string | undefined,
+): Promise<void> {
+  if (expectedSha256 === undefined) return;
+  await assertTrustedFunctionArtifact(functionPath, expectedSha256);
 }
 
 const DISABLED_TENANT_MODULES = new Map([
@@ -257,6 +261,7 @@ function isDynamicImportLiteral(source: string, start: number, end: number): boo
 async function assertTenantModuleGraphSafe(
   entryPath: string,
   visited = new Set<string>(),
+  requireSingleFile = false,
 ): Promise<void> {
   const resolvedEntry = path.resolve(entryPath);
   if (visited.has(resolvedEntry)) return;
@@ -289,6 +294,9 @@ async function assertTenantModuleGraphSafe(
     ) {
       throw new Error(NATIVE_LOADER_DISABLED_MESSAGE);
     }
+    if (requireSingleFile) {
+      throw new Error("Attested Function artifact must be a self-contained module");
+    }
     let dependencyPath = imported.path;
     if (dependencyPath.startsWith("file:")) {
       dependencyPath = fileURLToPath(dependencyPath);
@@ -316,7 +324,7 @@ async function assertTenantModuleGraphSafe(
       }
       continue;
     }
-    await assertTenantModuleGraphSafe(dependencyPath, visited);
+    await assertTenantModuleGraphSafe(dependencyPath, visited, requireSingleFile);
   }
 }
 
@@ -462,14 +470,33 @@ async function loadModule(input: {
   const cacheKey = buildModuleCacheKey(identity);
   const cached = moduleCache.get(cacheKey);
   if (cached) {
+    try {
+      await assertExpectedArtifact(input.functionPath, input.artifactSha256);
+    } catch (error: unknown) {
+      moduleCache.delete(cacheKey);
+      throw error;
+    }
     cached.lastUsed = Date.now();
     return { handler: cached.handler, cacheHit: true, moduleCacheSize: moduleCache.size };
   }
 
   evictOldestModule();
 
-  await assertTenantModuleGraphSafe(input.functionPath);
-  const handler = await importModuleHandler(buildModuleImportUrl(identity));
+  await assertTenantModuleGraphSafe(
+    input.functionPath,
+    new Set<string>(),
+    input.artifactSha256 !== undefined,
+  );
+  const handler = input.artifactSha256 === undefined
+    ? await importModuleHandler(buildModuleImportUrl(identity))
+    : await withTrustedFunctionArtifact(
+        input.functionPath,
+        input.artifactSha256,
+        (descriptorPath) => importModuleHandler(buildModuleImportUrl({
+          ...identity,
+          functionPath: descriptorPath,
+        })),
+      );
   moduleCache.set(cacheKey, {
     handler,
     functionId: input.functionId,
@@ -734,6 +761,12 @@ async function onParentMessage(msg: unknown): Promise<void> {
       throw abortReason instanceof Error
         ? abortReason
         : new DOMException("Task cancelled", "AbortError");
+    }
+    try {
+      await assertExpectedArtifact(functionPath, msg.artifactSha256);
+    } catch (error: unknown) {
+      invalidateCachedModules((entry) => entry.functionId === functionId);
+      throw error;
     }
     postToParent({ type: "execution_started", functionId });
     const handler = moduleLoad.handler;

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
 import { WorkerPool } from "./worker-pool";
@@ -12,6 +12,7 @@ import {
 } from "./preheat-attestation";
 
 const pools: WorkerPool[] = [];
+const linuxDescriptorTest = process.platform === "linux" ? test : test.skip;
 
 async function functionArtifactSha256(functionPath: string): Promise<string> {
   const artifactBytes = Buffer.from(await Bun.file(functionPath).arrayBuffer());
@@ -665,8 +666,8 @@ describe("WorkerPool subprocess guard", () => {
     }
   });
 
-  test("returns a matching worker preheat attestation", async () => {
-    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-attested-"));
+  linuxDescriptorTest("returns a matching worker preheat attestation", async () => {
+    const projectRoot = await mkdtemp(join(homedir(), ".supacloud-preheat-attested-"));
     const functionPath = join(projectRoot, "attested.ts");
     await Bun.write(functionPath, `export default () => new Response("attested");`);
     const artifactSha256 = await functionArtifactSha256(functionPath);
@@ -695,8 +696,8 @@ describe("WorkerPool subprocess guard", () => {
     }
   });
 
-  test("preheats a legacy version-zero artifact with a matching attestation", async () => {
-    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-legacy-zero-"));
+  linuxDescriptorTest("preheats a legacy version-zero artifact with a matching attestation", async () => {
+    const projectRoot = await mkdtemp(join(homedir(), ".supacloud-preheat-legacy-zero-"));
     const functionPath = join(projectRoot, "legacy-zero.ts");
     await Bun.write(functionPath, `export default () => new Response("legacy-zero");`);
     const artifactSha256 = await functionArtifactSha256(functionPath);
@@ -728,8 +729,8 @@ describe("WorkerPool subprocess guard", () => {
     }
   });
 
-  test("rejects a worker preheat whose artifact hash changed", async () => {
-    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-hash-mismatch-"));
+  linuxDescriptorTest("rejects a worker preheat whose artifact hash changed", async () => {
+    const projectRoot = await mkdtemp(join(homedir(), ".supacloud-preheat-hash-mismatch-"));
     const functionPath = join(projectRoot, "attested.ts");
     await Bun.write(functionPath, `export default () => new Response("actual");`);
     const attestation = preheatIdentity({
@@ -751,14 +752,14 @@ describe("WorkerPool subprocess guard", () => {
       );
 
       expect(preheat.succeeded).toBe(0);
-      expect(preheat.error).toBe("Function artifact SHA-256 does not match preheat identity");
+      expect(preheat.error).toBe("Function artifact SHA-256 does not match activation authority");
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }
   });
 
-  test("does not reuse a module cache entry after artifact replacement", async () => {
-    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-preheat-artifact-aba-"));
+  linuxDescriptorTest("does not reuse a module cache entry after artifact replacement", async () => {
+    const projectRoot = await mkdtemp(join(homedir(), ".supacloud-preheat-artifact-aba-"));
     const functionPath = join(projectRoot, "attested.ts");
     const projectRef = "proj_preheat_aba";
     const functionSlug = "attested";
@@ -793,6 +794,51 @@ describe("WorkerPool subprocess guard", () => {
         request: new Request("http://edge.local/functions/v1/attested"),
       });
       expect(await response.text()).toBe("B");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  linuxDescriptorTest("rejects an attested cache hit before execution after artifact replacement", async () => {
+    const projectRoot = await mkdtemp(join(homedir(), ".supacloud-dispatch-artifact-cache-"));
+    const functionPath = join(projectRoot, "attested.ts");
+    const artifactSource = `export default () => new Response("authority");`;
+    await Bun.write(functionPath, artifactSource);
+    const artifactSha256 = await functionArtifactSha256(functionPath);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    let executions = 0;
+
+    const dispatch = () => pool.dispatch({
+      functionId: "proj_dispatch_artifact_attested_v1",
+      functionPath,
+      projectRoot,
+      projectRef: "proj_dispatch_artifact",
+      functionVersion: "1",
+      moduleVersion: "activation-1",
+      artifactSha256,
+      env: {},
+      request: new Request("http://edge.local/functions/v1/attested"),
+      onExecutionStarted: () => executions++,
+    });
+
+    try {
+      const first = await dispatch();
+      expect(first.status).toBe(200);
+      expect(await first.text()).toBe("authority");
+      expect(executions).toBe(1);
+
+      await Bun.write(functionPath, `export default () => new Response("replacement");`);
+      const rejected = await dispatch();
+      expect(rejected.status).toBe(500);
+      expect(await rejected.text()).not.toContain("replacement");
+      expect(executions).toBe(1);
+
+      await Bun.write(functionPath, artifactSource);
+      const restored = await dispatch();
+      expect(restored.status).toBe(200);
+      expect(await restored.text()).toBe("authority");
+      expect(executions).toBe(2);
     } finally {
       await rm(projectRoot, { recursive: true, force: true });
     }

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -729,6 +729,43 @@ describe("WorkerPool subprocess guard", () => {
     }
   });
 
+  linuxDescriptorTest("allows an attested artifact to read a project static asset", async () => {
+    const projectRoot = await mkdtemp(join(homedir(), ".supacloud-preheat-attested-assets-"));
+    const versionRoot = join(projectRoot, ".versions", "attested-assets", "1");
+    const functionPath = join(versionRoot, "src", ".supacloud-entry.js");
+    const assetPath = join(versionRoot, "src", "public", "message.txt");
+    await mkdir(join(versionRoot, "src", "public"), { recursive: true });
+    await Bun.write(assetPath, "attested-asset");
+    await Bun.write(functionPath, `
+      export default async () => new Response(await Bun.file(import.meta.dir + "/public/message.txt").text());
+    `);
+    const artifactSha256 = await functionArtifactSha256(functionPath);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_preheat_attested_assets_v1",
+        functionPath,
+        projectRoot,
+        projectRef: "proj_preheat_attested_assets",
+        functionVersion: "1",
+        moduleVersion: "v1",
+        artifactSha256,
+        env: {},
+        request: new Request("http://edge.local/functions/v1/attested-assets"),
+      });
+
+      const responseBody = await response.text();
+      expect({ status: response.status, body: responseBody }).toEqual({
+        status: 200,
+        body: "attested-asset",
+      });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   linuxDescriptorTest("rejects a worker preheat whose artifact hash changed", async () => {
     const projectRoot = await mkdtemp(join(homedir(), ".supacloud-preheat-hash-mismatch-"));
     const functionPath = join(projectRoot, "attested.ts");
@@ -760,7 +797,7 @@ describe("WorkerPool subprocess guard", () => {
 
   linuxDescriptorTest("does not reuse a module cache entry after artifact replacement", async () => {
     const projectRoot = await mkdtemp(join(homedir(), ".supacloud-preheat-artifact-aba-"));
-    const functionPath = join(projectRoot, "attested.ts");
+    const functionPath = join(projectRoot, ".versions", "attested", "1", "src", ".supacloud-entry.js");
     const projectRef = "proj_preheat_aba";
     const functionSlug = "attested";
     const functionId = `${projectRef}_${functionSlug}_v1`;
@@ -777,6 +814,7 @@ describe("WorkerPool subprocess guard", () => {
     };
 
     try {
+      await mkdir(join(projectRoot, ".versions", "attested", "1", "src"), { recursive: true });
       await Bun.write(functionPath, `export default () => new Response("A");`);
       expect(await preheatCurrentArtifact()).toMatchObject({ succeeded: 1, cacheMisses: 1 });
 

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -792,6 +792,24 @@ async function writePreparedBundle(
   };
 }
 
+async function writePreparedReleaseBundle(
+  stageDir: string,
+  finalDir: string,
+  code: string,
+  artifactSizeBytes?: number,
+): Promise<Pick<
+  PreparedFunctionVersion,
+  "bundleHash" | "artifactSha256" | "bundleSizeBytes" | "contentPath"
+>> {
+  const artifact = await writePreparedBundle(stageDir, finalDir, code, artifactSizeBytes);
+  const sourceDir = path.join(stageDir, "src");
+  await fs.mkdir(sourceDir, { recursive: true, mode: 0o755 });
+  const runtimeEntry = path.join(sourceDir, BUNDLED_SOURCE_RUNTIME_ENTRY);
+  await Bun.write(runtimeEntry, code);
+  await fs.chmod(runtimeEntry, 0o444);
+  return artifact;
+}
+
 async function prepareSingleFunctionVersion(
   request: EdgeFunctionReleaseRequest & { code: string },
   version: string,
@@ -809,7 +827,7 @@ async function prepareSingleFunctionVersion(
     outdir: buildDir,
     minify: request.minify ?? false,
   });
-  const artifact = await writePreparedBundle(stageDir, finalDir, bundle.code, bundle.sizeBytes);
+  const artifact = await writePreparedReleaseBundle(stageDir, finalDir, bundle.code, bundle.sizeBytes);
   await fs.rm(buildDir, { recursive: true, force: true });
   return {
     version,
@@ -834,7 +852,7 @@ async function preparePrebundledFunctionVersion(
   const normalization = await validatedPrebundledBundle(request);
   await fs.mkdir(stageDir, { recursive: true, mode: 0o755 });
   await Bun.write(path.join(stageDir, "index.src.ts"), request.code);
-  const artifact = await writePreparedBundle(stageDir, finalDir, request.code);
+  const artifact = await writePreparedReleaseBundle(stageDir, finalDir, request.code);
   return {
     version,
     bundled: true,
@@ -915,8 +933,7 @@ async function prepareBundleFunctionVersion(
     minify: request.minify ?? false,
     importMapPath: importMap ? resolveInside(sourceDir, importMap) : undefined,
   });
-  await Bun.write(path.join(sourceDir, BUNDLED_SOURCE_RUNTIME_ENTRY), bundle.code);
-  const artifact = await writePreparedBundle(stageDir, finalDir, bundle.code, bundle.sizeBytes);
+  const artifact = await writePreparedReleaseBundle(stageDir, finalDir, bundle.code, bundle.sizeBytes);
   await fs.rm(buildDir, { recursive: true, force: true });
   return {
     version,

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -201,6 +201,7 @@ const SAFE_SLUG_REGEX = /^[a-zA-Z0-9_-]{1,128}$/;
 const EXTERNAL_PACKAGE_REGEX = /^(?:@[a-zA-Z0-9._-]+\/)?[a-zA-Z0-9._-]+$/;
 const CANONICAL_VERSION_REGEX = /^(?:0|[1-9]\d*)$/;
 const SHA256_HEX_REGEX = new RegExp(EDGE_FUNCTION_SHA256_HEX_PATTERN);
+const CONTENT_ADDRESSED_ARTIFACT_REGEX = /^index\.([a-f0-9]{16})\.js$/;
 const functionDeployLocks = new Map<string, Promise<void>>();
 const FUNCTION_LOCK_TIMEOUT_MS = 30_000;
 const deployMetrics: EdgeFunctionDeployMetrics = {
@@ -742,6 +743,7 @@ type PreparedFunctionVersion = {
 type FunctionVersionMetadata = {
   version: string;
   verify_jwt: boolean;
+  artifact_sha256: string | null;
   background_routes: string[];
   import_map: string | null;
   entrypoint: string | null;
@@ -779,7 +781,9 @@ async function writePreparedBundle(
   const bundleHash = artifactSha256.slice(0, 16);
   const sizeBytes = artifactSizeBytes ?? bundleSizeBytes(code);
   await Bun.write(path.join(stageDir, "index.js"), code);
-  await Bun.write(path.join(stageDir, `index.${bundleHash}.js`), code);
+  const contentPath = path.join(stageDir, `index.${bundleHash}.js`);
+  await Bun.write(contentPath, code);
+  await fs.chmod(contentPath, 0o444);
   return {
     bundleHash,
     artifactSha256,
@@ -928,6 +932,7 @@ async function prepareBundleFunctionVersion(
 function functionVersionMetadata(
   version: string,
   functionConfig: EdgeFunctionConfig,
+  artifactSha256: string,
 ): FunctionVersionMetadata {
   if (typeof functionConfig.verify_jwt !== "boolean") {
     throw new Error("Function version config contains an invalid verify_jwt policy");
@@ -939,20 +944,35 @@ function functionVersionMetadata(
   return {
     version,
     verify_jwt: functionConfig.verify_jwt,
+    artifact_sha256: artifactSha256,
     background_routes: backgroundRoutes,
     import_map: functionConfig.import_map ?? null,
     entrypoint: functionConfig.entrypoint ?? null,
   };
 }
 
+async function versionArtifactSha256(
+  ref: string,
+  slug: string,
+  version: string,
+): Promise<string> {
+  const artifactPath = await getVersionedArtifactPath(ref, slug, version);
+  if (!artifactPath) throw new Error(EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE);
+  const artifactSha256 = await sha256Hex(await Bun.file(artifactPath).text());
+  const metadata = await readFunctionVersionMetadata(ref, slug, version);
+  if (metadata.artifact_sha256 !== artifactSha256) {
+    throw new Error("Function version artifact does not match its immutable metadata");
+  }
+  return artifactSha256;
+}
+
 async function writeFunctionVersionMetadata(
   stageDir: string,
   metadata: FunctionVersionMetadata,
 ): Promise<void> {
-  await Bun.write(
-    path.join(stageDir, FUNCTION_VERSION_METADATA_FILE),
-    JSON.stringify(metadata, null, 2),
-  );
+  const metadataPath = path.join(stageDir, FUNCTION_VERSION_METADATA_FILE);
+  await Bun.write(metadataPath, JSON.stringify(metadata, null, 2));
+  await fs.chmod(metadataPath, 0o444);
 }
 
 async function replaceFunctionVersionMetadata(
@@ -966,6 +986,7 @@ async function replaceFunctionVersionMetadata(
   );
   try {
     await Bun.write(pendingPath, JSON.stringify(metadata, null, 2));
+    await fs.chmod(pendingPath, 0o444);
     await fs.rename(pendingPath, metadataPath);
   } finally {
     await fs.rm(pendingPath, { force: true }).catch(() => {});
@@ -1014,7 +1035,11 @@ async function readFunctionVersionMetadata(
   if (!metadataRecord || typeof metadataRecord !== "object" || Array.isArray(metadataRecord)) {
     throw new Error("Function version metadata must be an object");
   }
-  if (metadataRecord.version !== version || typeof metadataRecord.verify_jwt !== "boolean") {
+  if (metadataRecord.version !== version
+    || typeof metadataRecord.verify_jwt !== "boolean"
+    || (metadataRecord.artifact_sha256 !== undefined
+      && (typeof metadataRecord.artifact_sha256 !== "string"
+        || !SHA256_HEX_REGEX.test(metadataRecord.artifact_sha256)))) {
     throw new Error("Function version metadata does not match the requested version and policy");
   }
   if (!Array.isArray(metadataRecord.background_routes)
@@ -1026,6 +1051,9 @@ async function readFunctionVersionMetadata(
   const metadata: FunctionVersionMetadata = {
     version,
     verify_jwt: metadataRecord.verify_jwt,
+    artifact_sha256: typeof metadataRecord.artifact_sha256 === "string"
+      ? metadataRecord.artifact_sha256
+      : null,
     background_routes: metadataRecord.background_routes as string[],
     import_map: nullableMetadataPath(metadataRecord, "import_map"),
     entrypoint: nullableMetadataPath(metadataRecord, "entrypoint"),
@@ -1092,10 +1120,121 @@ async function backfillActiveVersionMetadata(
         background_routes: functionConfig.background_routes ?? [],
       })
     : await sourceMetadataConfig(functionConfig, version, versionDir);
+  if (existingMetadata?.artifact_sha256) {
+    await getVersionedArtifactPath(ref, slug, version);
+    await replaceFunctionVersionMetadata(
+      versionDir,
+      functionVersionMetadata(version, sourceConfig, existingMetadata.artifact_sha256),
+    );
+    return;
+  }
+  const immutableArtifact = await legacyImmutableArtifact(versionDir);
+  const legacyArtifact = getVersionedFuncPath(ref, slug, version);
+  if (immutableArtifact === null && !await fileExists(legacyArtifact)) {
+    throw new Error(EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE);
+  }
+  const runtimeCode = immutableArtifact?.code ?? await Bun.file(legacyArtifact).text();
+  const artifactSha256 = immutableArtifact?.sha256 ?? await sha256Hex(runtimeCode);
+  const contentAddressedPath = path.join(
+    versionDir,
+    `index.${artifactSha256.slice(0, 16)}.js`,
+  );
+  if (!await fileExists(contentAddressedPath)) {
+    await preflightFunctionMutation(ref, slug);
+    await Bun.write(contentAddressedPath, runtimeCode);
+    await fs.chmod(contentAddressedPath, 0o444);
+  }
+  await preflightFunctionMutation(ref, slug);
   await replaceFunctionVersionMetadata(
     versionDir,
-    functionVersionMetadata(version, sourceConfig),
+    functionVersionMetadata(version, sourceConfig, artifactSha256),
   );
+}
+
+async function legacyImmutableArtifact(
+  versionDir: string,
+): Promise<{ code: string; sha256: string } | null> {
+  const candidates = (await fs.readdir(versionDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && CONTENT_ADDRESSED_ARTIFACT_REGEX.test(entry.name));
+  if (candidates.length === 0) return null;
+  if (candidates.length !== 1) {
+    throw new Error("Function version contains ambiguous content-addressed artifacts");
+  }
+  const candidate = candidates[0]!;
+  const code = await Bun.file(path.join(versionDir, candidate.name)).text();
+  const sha256 = await sha256Hex(code);
+  if (candidate.name !== `index.${sha256.slice(0, 16)}.js`) {
+    throw new Error("Function version content-addressed artifact does not match its name");
+  }
+  return { code, sha256 };
+}
+
+async function migrateImmutableVersionArtifact(
+  ref: string,
+  slug: string,
+  version: string,
+): Promise<boolean> {
+  const versionDir = getFunctionVersionDir(ref, slug, version);
+  let metadata: FunctionVersionMetadata | null = null;
+  try {
+    metadata = await readFunctionVersionMetadata(ref, slug, version);
+  } catch (error: unknown) {
+    if (!isMissingPathError(error)) throw error;
+  }
+  if (metadata?.artifact_sha256) {
+    await getVersionedArtifactPath(ref, slug, version);
+    return false;
+  }
+  await preflightFunctionMutation(ref, slug);
+  const immutableArtifact = await legacyImmutableArtifact(versionDir);
+  const legacyArtifact = getVersionedFuncPath(ref, slug, version);
+  if (immutableArtifact === null && !await fileExists(legacyArtifact)) {
+    if (metadata === null) return false;
+    throw new Error("Function version artifact is missing during startup migration");
+  }
+  const runtimeCode = immutableArtifact?.code ?? await Bun.file(legacyArtifact).text();
+  const artifactSha256 = immutableArtifact?.sha256 ?? await sha256Hex(runtimeCode);
+  const contentAddressedPath = assertInside(
+    versionDir,
+    path.join(versionDir, `index.${artifactSha256.slice(0, 16)}.js`),
+  );
+  if (await fileExists(contentAddressedPath)) {
+    const existingSha256 = await sha256Hex(await Bun.file(contentAddressedPath).text());
+    if (existingSha256 !== artifactSha256) {
+      throw new Error("Function version content-addressed artifact is ambiguous");
+    }
+  } else {
+    await preflightFunctionMutation(ref, slug);
+    await Bun.write(contentAddressedPath, runtimeCode);
+    await fs.chmod(contentAddressedPath, 0o444);
+  }
+  const sourceConfig = metadata
+    ? restoredFunctionConfig({ verify_jwt: metadata.verify_jwt }, metadata)
+    : await sourceMetadataConfig({ verify_jwt: true }, version, versionDir);
+  await preflightFunctionMutation(ref, slug);
+  await replaceFunctionVersionMetadata(
+    versionDir,
+    functionVersionMetadata(version, sourceConfig, artifactSha256),
+  );
+  return true;
+}
+
+async function migrateProjectImmutableVersions(ref: string): Promise<number> {
+  const versionsRoot = assertInside(getFuncDir(ref), path.join(getFuncDir(ref), VERSIONED_DIR));
+  let migrated = 0;
+  for (const slugEntry of await fs.readdir(versionsRoot, { withFileTypes: true }).catch((error) => {
+    if (isMissingPathError(error)) return [];
+    throw error;
+  })) {
+    if (!slugEntry.isDirectory()) {
+      throw new Error("Function version root contains an invalid entry");
+    }
+    const slug = validateSlug(slugEntry.name);
+    for (const version of await listVersionDirectories(ref, slug)) {
+      if (await migrateImmutableVersionArtifact(ref, slug, version)) migrated += 1;
+    }
+  }
+  return migrated;
 }
 
 async function snapshotFrozenLegacyVersion(
@@ -1113,7 +1252,7 @@ async function snapshotFrozenLegacyVersion(
   await fs.mkdir(stageDir, { recursive: true, mode: 0o755 });
   try {
     const runtimeCode = await Bun.file(snapshot.runtimePath).text();
-    await writePreparedBundle(stageDir, finalDir, runtimeCode);
+    const artifact = await writePreparedBundle(stageDir, finalDir, runtimeCode);
     await copyFrozenLegacySource(snapshot.ref, snapshot.slug, stageDir);
     const snapshotConfig = await sourceMetadataConfig(
       snapshot.functionConfig,
@@ -1122,7 +1261,7 @@ async function snapshotFrozenLegacyVersion(
     );
     await writeFunctionVersionMetadata(
       stageDir,
-      functionVersionMetadata(snapshot.version, snapshotConfig),
+      functionVersionMetadata(snapshot.version, snapshotConfig, artifact.artifactSha256),
     );
     await fs.rename(stageDir, finalDir);
     return snapshotConfig;
@@ -1177,7 +1316,7 @@ async function completeFrozenLegacyVersionSnapshot(
     );
     await replaceFunctionVersionMetadata(
       versionDir,
-      functionVersionMetadata(snapshot.version, snapshotConfig),
+      functionVersionMetadata(snapshot.version, snapshotConfig, artifact.artifactSha256),
     );
     return snapshotConfig;
   } finally {
@@ -1194,7 +1333,8 @@ async function ensureConfiguredRollbackSnapshot(
   if (parseVersionNumber(version) === null) {
     throw new Error("Function config contains an invalid version");
   }
-  if (await getVersionedArtifactPath(ref, slug, version)) {
+  const modernArtifact = getVersionedFuncPath(ref, slug, version);
+  if (await fileExists(modernArtifact) || await getVersionedArtifactPath(ref, slug, version)) {
     await backfillActiveVersionMetadata(ref, slug, version, currentConfig);
     return currentConfig;
   }
@@ -1223,7 +1363,11 @@ async function ensureLegacyVersionZeroSnapshot(
   if (versionZeroArtifact) {
     await replaceFunctionVersionMetadata(
       path.join(getVersionRoot(snapshot.ref, snapshot.slug), "0"),
-      functionVersionMetadata("0", versionZeroConfig),
+      functionVersionMetadata(
+        "0",
+        versionZeroConfig,
+        await versionArtifactSha256(snapshot.ref, snapshot.slug, "0"),
+      ),
     );
   }
   await commitFunctionActivation({
@@ -1629,19 +1773,24 @@ export async function getVersionedArtifactPath(
   version: string,
 ): Promise<string | null> {
   const dir = getFunctionVersionDir(ref, slug, version);
-  try {
-    const entries = await fs.readdir(dir);
-    const contentAddressed = entries
-      .filter((entry) => /^index\.[a-f0-9]{16}\.js$/.test(entry))
-      .sort()
-      .at(0);
-    if (contentAddressed) return assertInside(dir, path.join(dir, contentAddressed));
-  } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  const metadataPath = path.join(dir, FUNCTION_VERSION_METADATA_FILE);
+  if (!await fileExists(metadataPath)) return null;
+  const metadata = await readFunctionVersionMetadata(ref, slug, version);
+  if (metadata.artifact_sha256 === null) {
+    throw new Error("Function version metadata is missing its artifact digest");
   }
-  const modern = getVersionedFuncPath(ref, slug, version);
-  if (await fileExists(modern)) return modern;
-  return null;
+  const contentAddressedPath = assertInside(
+    dir,
+    path.join(dir, `index.${metadata.artifact_sha256.slice(0, 16)}.js`),
+  );
+  if (!await fileExists(contentAddressedPath)) {
+    throw new Error("Function version artifact is missing for immutable metadata");
+  }
+  const actualSha256 = await sha256Hex(await Bun.file(contentAddressedPath).text());
+  if (actualSha256 !== metadata.artifact_sha256) {
+    throw new Error("Function version artifact does not match its immutable metadata");
+  }
+  return contentAddressedPath;
 }
 
 async function listVersionDirectories(ref: string, slug: string): Promise<string[]> {
@@ -1797,7 +1946,7 @@ async function migrateLegacyProjectArtifacts(ref: string): Promise<number> {
     await migrateLegacyVersionedSourceDirectory(ref, directory, entry, sourceDirectory);
     moved += 1;
   }
-  return moved;
+  return moved + await migrateProjectImmutableVersions(ref);
 }
 
 export async function migrateLegacyVersionArtifacts(): Promise<{ moved: number }> {
@@ -1827,7 +1976,7 @@ async function immutableFunctionVersion(
     const functionConfig = activatedFunctionConfig(currentConfig, request.config, prepared);
     await writeFunctionVersionMetadata(
       stageDir,
-      functionVersionMetadata(version, functionConfig),
+      functionVersionMetadata(version, functionConfig, prepared.artifactSha256),
     );
     await fs.rename(stageDir, finalDir);
     return { prepared, config: functionConfig };
@@ -2523,6 +2672,9 @@ export const edgeFunctionService = {
       const versionMetadata = await readFunctionVersionMetadata(ref, slug, version);
       const updated = restoredFunctionConfig(expected.state.config, versionMetadata);
       const artifactSha256 = await sha256Hex(detail.bundle_code);
+      if (artifactSha256 !== versionMetadata.artifact_sha256) {
+        throw new Error("Function version artifact does not match its immutable metadata");
+      }
       const activation = await commitFunctionActivation({
         ref,
         slug,

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -617,6 +617,34 @@ describe("edgeFunctionService bundle metadata", () => {
     }
   });
 
+  test("migrates legacy metadata from the immutable artifact instead of a mutable alias", async () => {
+    const ref = "proj_legacy_immutable_authority";
+    const slug = "legacy-immutable-authority";
+    const versionDir = join(functionsRoot, ref, ".versions", slug, "1");
+    const immutableCode = "export default { fetch: () => new Response('immutable') };";
+    const artifactSha256 = createHash("sha256").update(immutableCode).digest("hex");
+    await mkdir(versionDir, { recursive: true });
+    await Promise.all([
+      Bun.write(join(versionDir, `index.${artifactSha256.slice(0, 16)}.js`), immutableCode),
+      Bun.write(join(versionDir, "index.js"), "export default { fetch: () => new Response('tampered') };"),
+      Bun.write(join(versionDir, ".supacloud-version.json"), JSON.stringify({
+        version: "1",
+        verify_jwt: false,
+        background_routes: [],
+        import_map: null,
+        entrypoint: null,
+      })),
+    ]);
+
+    expect(await migrateLegacyVersionArtifacts()).toEqual({ moved: 1 });
+    expect(JSON.parse(await readFile(
+      join(versionDir, ".supacloud-version.json"),
+      "utf8",
+    ))).toMatchObject({ artifact_sha256: artifactSha256 });
+    expect(await getVersionedArtifactPath(ref, slug, "1"))
+      .toBe(join(versionDir, `index.${artifactSha256.slice(0, 16)}.js`));
+  });
+
   test("rejects unsafe startup migration parents without touching an external version target", async () => {
     const migrationRoot = await mkdtemp(join(homedir(), ".supacloud-legacy-migration-"));
     const ref = "proj_unsafe_legacy_migration";
@@ -1046,6 +1074,40 @@ describe("edgeFunctionService bundle metadata", () => {
       verify_jwt: false,
       version: "2",
     });
+  });
+
+  test("never promotes a mutable version alias into immutable rollback authority", async () => {
+    const ref = "proj_immutable_rollback_authority";
+    const slug = "immutable-rollback-authority";
+    const first = await deployConditionalRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('immutable-v1') };",
+    });
+    const versionDirectory = join(functionsRoot, ref, ".versions", slug, "1");
+    const metadataPath = join(versionDirectory, ".supacloud-version.json");
+    const originalMetadata = JSON.parse(await readFile(metadataPath, "utf8")) as {
+      artifact_sha256: string;
+    };
+
+    await Bun.write(
+      join(versionDirectory, "index.js"),
+      "export default { fetch: () => new Response('tampered-alias') };",
+    );
+    const second = await deployConditionalRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('immutable-v2') };",
+    });
+
+    expect(first).toMatchObject({ success: true, version: "1" });
+    expect(second).toMatchObject({ success: true, version: "2" });
+    expect(JSON.parse(await readFile(metadataPath, "utf8"))).toMatchObject({
+      artifact_sha256: originalMetadata.artifact_sha256,
+    });
+    await activateConditionalVersion(ref, slug, "1");
+    expect(await edgeFunctionService.read(ref, slug)).toContain("immutable-v1");
+    expect(await edgeFunctionService.read(ref, slug)).not.toContain("tampered-alias");
   });
 
   test("clears bundle source metadata when a single-file version becomes active", async () => {

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } 
 import { Elysia } from "elysia";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -50,6 +50,22 @@ async function activateConditionalVersion(ref: string, slug: string, version: st
     current.version ?? "absent",
     current.activation_id,
   ))?.config ?? null;
+}
+
+async function expectAttestedRuntimeEntry(
+  ref: string,
+  slug: string,
+  deployment: { version?: string; content_path?: string | null; bundle_hash?: string },
+) {
+  const versionDir = join(functionsRoot, ref, ".versions", slug, deployment.version!);
+  const runtimeEntry = join(versionDir, "src", ".supacloud-entry.js");
+  const content = await readFile(deployment.content_path!);
+  const artifactSha256 = createHash("sha256").update(content).digest("hex");
+  expect(await readFile(runtimeEntry)).toEqual(content);
+  expect(artifactSha256.slice(0, 16)).toBe(deployment.bundle_hash);
+  expect(JSON.parse(await readFile(join(versionDir, ".supacloud-version.json"), "utf8")))
+    .toMatchObject({ artifact_sha256: artifactSha256 });
+  expect((await stat(runtimeEntry)).mode & 0o222).toBe(0);
 }
 
 async function writeConfiguredAliases(ref: string, slug: string, version: string): Promise<void> {
@@ -897,6 +913,37 @@ describe("edgeFunctionService bundle metadata", () => {
     } finally {
       buildSpy.mockRestore();
     }
+  });
+
+  test("writes the attested source entry for every immutable deployment path", async () => {
+    globalThis.fetch = runtimeSuccessFetch();
+    const single = await edgeFunctionService.deployDetailed(
+      "proj_attested_single",
+      "single",
+      "export default { fetch: () => new Response('single') };",
+    );
+    const prebundledCode = "export default { fetch: () => new Response('prebundled') };";
+    const prebundled = await edgeFunctionService.deployRelease({
+      ref: "proj_attested_prebundled",
+      slug: "prebundled",
+      expectedActiveVersion: "absent",
+      expectedActivationId: "legacy",
+      code: prebundledCode,
+      prebundled: true,
+      expectedSha256: createHash("sha256").update(prebundledCode).digest("hex"),
+    });
+    const bundle = await edgeFunctionService.deployBundleDetailed(
+      "proj_attested_bundle",
+      "bundle",
+      { "index.ts": "export default { fetch: () => new Response('bundle') };" },
+    );
+
+    expect(single.success).toBe(true);
+    expect(prebundled.success).toBe(true);
+    expect(bundle.success).toBe(true);
+    await expectAttestedRuntimeEntry("proj_attested_single", "single", single);
+    await expectAttestedRuntimeEntry("proj_attested_prebundled", "prebundled", prebundled);
+    await expectAttestedRuntimeEntry("proj_attested_bundle", "bundle", bundle);
   });
 
   test("rejects prebundled bytes that require runtime normalization before mutation", async () => {

--- a/scripts/test_supacloud_caddy_edge_proxy.sh
+++ b/scripts/test_supacloud_caddy_edge_proxy.sh
@@ -17,7 +17,7 @@ if ! command -v "$BUN_BINARY" >/dev/null 2>&1; then
   exit 1
 fi
 
-work_dir="$(mktemp -d)"
+work_dir="$(mktemp -d "$HOME/.supacloud-caddy-edge.XXXXXX")"
 functions_dir="$work_dir/functions"
 tenants_dir="$work_dir/tenants"
 cancel_started_path=""


### PR DESCRIPTION
## Summary

- bind canonical Edge Function activation authority to a full SHA-256 digest and content-addressed immutable artifact
- make authoritative runtime resolution and dispatch re-read the active or historical authority and reject artifact drift
- import attested modules on Linux through held directory/file descriptors and `/proc/self/fd`
- keep legacy non-attested Function loading compatible while failing authoritative attested imports closed on non-Linux platforms
- migrate legacy metadata only from a uniquely matching immutable artifact; never promote mutable `index.js` into rollback authority
- document the Linux-only descriptor-binding contract for canonical activations

## Dependency and scope

Follow-up to #845 and #868.

This Draft PR contains only the activation artifact integrity follow-up. It does not merge, trigger Release Please, publish a release, deploy, or write production state.

## Security regression closed

The earlier candidate hashed a held inode on macOS but imported by pathname, so a replacement could execute an unverified module before the post-import check. The final candidate rejects authoritative attested imports before invoking the module loader on non-Linux platforms.

Independent macOS black-box verification observed `loaderCalls=0` and no user-module execution. Linux imports remain bound to the verified descriptor.

## Frozen candidate

- base: `85d7e8e070e0d6aad75ad17c0ab859dda47bcc81`
- commit: `22935509ed3fd22091e84c6918b063237472e896`
- tree: `42c360bfcc4c6b51fd7899ff2a799f0ef5e6af9d`
- binary diff SHA-256: `b2aec5029504af0ec36748461e51d9f84909d9e4282c55aa8f6bcdb3364f66e4`
- stable patch-id: `aca6bfaf62c994196e90f2a1b9a9d748c836024a`

## Verification

- Edge Runtime typecheck: pass
- Management API typecheck: pass
- macOS Edge candidate: 106 pass, 14 Linux-only skip, 0 fail
- macOS non-Linux fail-closed regression: 2 pass, 3 platform skip; loader callback 0
- Management activation manifest + bundle metadata: 59 pass, 0 fail
- fresh Linux image, trusted artifact + activation race: 17 pass, 1 non-Linux-only skip, 0 fail
- fresh Linux image, worker attestation/cache: 5 pass, 0 fail
- `git diff --check`: pass
- independent review: P0/P1/P2 = 0/0/0
- clean-code-guard: 1 fixed, 0 flagged for author

## Platform contract

Canonical authoritative activation/import currently requires Linux descriptor binding. macOS and Windows binaries can start and run legacy non-attested Functions, but authoritative attested activation fails closed before user code is evaluated.
