### PR TITLE
feat(management-api): immutable frontend releases with deployment locks and durable Caddy bootstrap

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -533,6 +533,22 @@ jobs:
             --env MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio:latest server /data
 
+      # Management refuses to serve until the Caddy Admin API is reachable and
+      # accepts its canonical JSON config, so this job needs a real Caddy. The
+      # admin endpoint is published only on the runner loopback and Management
+      # connects via CADDY_ADMIN_URL=http://0.0.0.0:2019, so the /load-posted
+      # admin.listen stays 0.0.0.0:2019 and remains reachable; the :80/:443
+      # data plane stays inside the container network, unreachable from outside.
+      - name: Start Caddy fixture
+        run: |
+          printf '%s\n' '{"admin":{"listen":"0.0.0.0:2019"}}' > "$RUNNER_TEMP/caddy-ci.json"
+          docker run --detach --rm \
+            --name supacloud-ci-caddy \
+            --publish 127.0.0.1:2019:2019 \
+            --volume "$RUNNER_TEMP/caddy-ci.json:/etc/caddy/ci.json:ro" \
+            caddy:2.11.4 \
+            caddy run --config /etc/caddy/ci.json
+
       - name: Show runtime versions
         run: |
           node --version
@@ -650,7 +666,17 @@ jobs:
           echo "Starting Management API in background..."
           bun src/index.ts > api-server.log 2>&1 &
           PID=$!
-          sleep 4
+          # Startup now includes gateway readiness, recovery, and canonical
+          # reconciliation; poll instead of a fixed sleep to avoid cold-runner flakes.
+          for attempt in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:9090/health > /dev/null; then break; fi
+            if [ "$attempt" -eq 30 ]; then
+              echo "API failed to start. Logs:"
+              cat api-server.log
+              exit 1
+            fi
+            sleep 2
+          done
           curl -sf http://127.0.0.1:9090/health || (echo "API failed to start. Logs:" && cat api-server.log && exit 1)
 
           echo "===== RUNNING E2E SNAPSHOTS ====="
@@ -683,6 +709,7 @@ jobs:
           MASTER_TOKEN: super-secret-jwt-token-with-at-least-32-characters-long
           CI: "true"
           NODE_ENV: test
+          CADDY_ADMIN_URL: http://0.0.0.0:2019
           S3_ENDPOINT: http://127.0.0.1:9001
           S3_REGION: us-east-1
           STORAGE_TYPE: s3

--- a/docker/self-host/README.md
+++ b/docker/self-host/README.md
@@ -13,7 +13,9 @@ This stack is isolated from `docker/dev` and is intended for one-command self-ho
 - VictoriaLogs (persistent project logs)
 - FerretDB MongoDB wire protocol gateway, optional through the `ferretdb` Compose profile
 
-The Caddy gateway starts with a bootstrap-only Caddyfile that returns `503` until the real routing config is published. Because the `caddy` service depends on `management-api` being healthy, the Management API begins listening on `:9090` first; it then publishes the full route config as JSON via the Caddy Admin API (`POST /load` on `http://caddy:2019`), with a backoff retry loop until Caddy is reachable. Tenant routes (`/rest/v1`, `/auth/v1`, `/functions/v1`, `/platform/v1`) are owned entirely by that injected JSON, not by the Caddyfile.
+On an empty first start, Caddy validates and serves a bootstrap Caddyfile on ports `80` and `443`; both listeners return `503` until Management publishes the real routing JSON. Bootstrap HTTPS uses one fixed internal certificate for `supacloud-bootstrap.invalid` as the default and fallback SNI, so it can fail closed without issuing certificates on demand. Clients must not trust or hostname-validate that bootstrap-only certificate. Once Management has durably persisted and read back the real JSON, it creates `/etc/supacloud/caddy/INITIALIZED`. Every later Caddy start validates and serves `/etc/supacloud/caddy/config.json` directly, including a Caddy-only container recreation. If the marker remains but the JSON is missing, or if the JSON fails `caddy validate`, Caddy fails closed and leaves the mounted evidence untouched.
+
+The Compose volumes enforce the runtime ownership boundaries: Management writes `frontend-data` and `caddy-managed-config`, while Caddy mounts both read-only. `caddy-managed-state` stays writable from both containers because Management stores manual certificates there and Caddy's configured `file_system` storage writes on-demand TLS state there. Caddy's own `/data` and `/config` volumes remain separate. Caddy does not depend on Management; Management waits for Caddy health before completing its startup recovery and reconciliation. Tenant routes (`/rest/v1`, `/auth/v1`, `/functions/v1`, `/platform/v1`) remain owned by the durable JSON, never by the bootstrap Caddyfile.
 
 ## Packaged PostgreSQL extensions
 
@@ -152,6 +154,26 @@ If you enabled pgsodium on a fresh volume and need to disable it:
 4. Start the stack again: `docker compose up -d --build`.
 
 **Important**: Once pgsodium has been initialized, encrypted data (including Vault secrets) depends on the original key. Starting over with a new volume means that data is lost. If you need to keep existing data, do **not** remove the volume. Instead, keep the same `PGSODIUM_KEY` or `PGSODIUM_KEY_FILE` value and simply stop using the `pgsodium` and `vault` schemas. The extension stays loaded in `shared_preload_libraries` until you rebuild PostgreSQL with `ENABLE_PGSODIUM=false` on a fresh volume.
+
+## Frontend release activation: unresolved `outcome_unknown` recovery
+
+Management refuses to open its listener while any frontend release activation mutation is still unresolved (`pending`, `running`, `failed_retryable`, or `outcome_unknown`). Startup first drains every automatically recoverable row; only rows whose outcome cannot be proven remain. Because the Compose service uses `restart: unless-stopped`, an unresolved `outcome_unknown` row keeps the container in a restart loop. This is an intentional fail-closed gate: the platform cannot prove whether the gateway route was switched, so it refuses to serve rather than risk split-brain route authority.
+
+Symptom: the Management container never becomes healthy and logs `Frontend release activation remains unresolved after startup recovery`.
+
+Diagnosis:
+
+1. Find the blocking mutation in the platform database:
+   `SELECT project_ref, mutation_id, operation, resource_key, principal_type, principal_id, fencing_epoch, checkpoint, receipt, completed_at FROM project_mutations WHERE status = 'outcome_unknown' ORDER BY updated_at;`
+2. Establish ground truth on the gateway: compare the live Caddy configuration (`GET http://localhost:2019/config/`) and the durable JSON in the `caddy-managed-config` volume against the release recorded in the mutation's `resource_key`/`checkpoint`. Decide whether the activation actually took effect.
+
+Resolution:
+
+- There is deliberately no public reconciliation endpoint; `POST /v1/projects/:ref/mutations/:id/reconcile` returns 403. Reconciliation is an internal, audited operation (`reconcileProjectMutation` in `packages/management-api/src/services/project-mutation.service.ts`) that must be executed by a platform maintainer through a supervised one-off privileged call inside the Management environment.
+- The call must come from the mutation's original principal (`principal_type`/`principal_id`), supply the row's current `fencing_epoch` as `expectedFencingEpoch`, and include evidence whose `observedAt` falls between the row's `completed_at` and the database clock (plus skew allowance).
+- If ground truth shows the activation took effect, reconcile to `succeeded`; otherwise roll the gateway route back to the previously active release and reconcile to `failed_terminal`.
+- Never delete the row or overwrite `status` directly with SQL: that bypasses the audit event, the fencing-epoch CAS, and the evidence window, and can mask a real split-brain.
+- Once no unresolved rows remain, start Management normally; the startup gate passes and the background recovery worker resumes its normal polling.
 
 ## Notes
 

--- a/docker/self-host/caddy/Caddyfile
+++ b/docker/self-host/caddy/Caddyfile
@@ -1,12 +1,21 @@
 {
 	admin 0.0.0.0:2019
-	auto_https off
+	auto_https disable_redirects
+	default_sni supacloud-bootstrap.invalid
+	fallback_sni supacloud-bootstrap.invalid
 }
 
-# Bootstrap-only configuration.
-# The Management API publishes the real routing config as JSON via the Caddy
-# Admin API (POST /load on :2019) once it starts. These routes only exist so
-# the gateway has a sane listener before the JSON config is injected.
-:8000 {
+# Bootstrap is allowed only before Management creates INITIALIZED beside its
+# first durable JSON config. Later Caddy starts use that JSON directly.
+:80 {
+	respond "SupaCloud gateway awaiting Management API JSON config" 503
+}
+
+supacloud-bootstrap.invalid:443 {
+	tls internal
+	respond "SupaCloud gateway awaiting Management API JSON config" 503
+}
+
+:443 {
 	respond "SupaCloud gateway awaiting Management API JSON config" 503
 }

--- a/docker/self-host/caddy/entrypoint.sh
+++ b/docker/self-host/caddy/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+managed_config="${SUPACLOUD_CADDY_CONFIG_PATH:-/etc/supacloud/caddy/config.json}"
+initialized_marker="${SUPACLOUD_CADDY_INITIALIZED_MARKER:-/etc/supacloud/caddy/INITIALIZED}"
+bootstrap_config="${SUPACLOUD_CADDY_BOOTSTRAP_CONFIG:-/etc/caddy/Caddyfile}"
+
+if [ -L "$managed_config" ]; then
+    printf '%s\n' "refusing symbolic-link managed Caddy config: $managed_config" >&2
+    exit 1
+fi
+
+if [ -f "$managed_config" ]; then
+    caddy validate --config "$managed_config"
+    exec caddy run --config "$managed_config"
+fi
+
+if [ -e "$managed_config" ]; then
+    printf '%s\n' "refusing non-regular managed Caddy config: $managed_config" >&2
+    exit 1
+fi
+
+if [ -e "$initialized_marker" ] || [ -L "$initialized_marker" ]; then
+    printf '%s\n' "refusing bootstrap after initialized Caddy config was lost" >&2
+    exit 1
+fi
+
+caddy validate --config "$bootstrap_config" --adapter caddyfile
+exec caddy run --config "$bootstrap_config" --adapter caddyfile

--- a/docker/self-host/docker-compose.yml
+++ b/docker/self-host/docker-compose.yml
@@ -100,6 +100,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      caddy:
+        condition: service_healthy
       victorialogs:
         condition: service_started
     environment:
@@ -124,6 +126,8 @@ services:
       SUPAOAUTH_BFF_SIGNING_SECRET: ${SUPAOAUTH_BFF_SIGNING_SECRET}
       BASE_DOMAIN: ${BASE_DOMAIN:-localhost}
       CADDY_ADMIN_URL: http://caddy:2019
+      CADDY_CONFIG_PATH: /etc/supacloud/caddy/config.json
+      CADDY_STATE_DIR: /var/lib/supacloud/caddy
       MANAGEMENT_API_INTERNAL: management-api:9090
       EDGE_RUNTIME_MODE: external
       EDGE_RUNTIME_URL: http://edge-runtime:9005
@@ -147,6 +151,9 @@ services:
       - tenant-config:/etc/supabase/tenants
       - pgredis-tenant-config:/etc/supabase/pgredis-tenants
       - functions-data:/data/functions
+      - frontend-data:/var/supacloud/frontends
+      - caddy-managed-config:/etc/supacloud/caddy
+      - caddy-managed-state:/var/lib/supacloud/caddy
       - log-collector-state:/var/lib/supacloud/log-collector
       - type: bind
         source: ${LEGACY_SECRETS_MIGRATION_FILE}
@@ -244,24 +251,33 @@ services:
   caddy:
     image: caddy:2.11.4
     restart: unless-stopped
-    depends_on:
-      management-api:
-        condition: service_healthy
-      edge-runtime:
-        condition: service_healthy
-    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+    entrypoint: ["/usr/local/bin/supacloud-caddy-entrypoint"]
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./caddy/entrypoint.sh:/usr/local/bin/supacloud-caddy-entrypoint:ro
       - caddy-data:/data
       - caddy-config:/config
+      - frontend-data:/var/supacloud/frontends:ro
+      - caddy-managed-config:/etc/supacloud/caddy:ro
+      - caddy-managed-state:/var/lib/supacloud/caddy
     ports:
-      - "${CADDY_HTTP_PORT:-8000}:8000"
+      - "${CADDY_HTTP_PORT:-8000}:80"
+      - "${CADDY_HTTPS_PORT:-8443}:443"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--output-document=/dev/null", "http://127.0.0.1:2019/config/"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
 
 volumes:
   postgres-data:
   tenant-config:
   pgredis-tenant-config:
   functions-data:
+  frontend-data:
+  caddy-managed-config:
+  caddy-managed-state:
   caddy-data:
   caddy-config:
   victorialogs-data:

--- a/docker/self-host/test_caddy_durability.py
+++ b/docker/self-host/test_caddy_durability.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+SELF_HOST_DIR = pathlib.Path(__file__).resolve().parent
+COMPOSE_FILE = SELF_HOST_DIR / "docker-compose.yml"
+ENTRYPOINT = SELF_HOST_DIR / "caddy" / "entrypoint.sh"
+BOOTSTRAP_CONFIG = SELF_HOST_DIR / "caddy" / "Caddyfile"
+
+
+def compose_model() -> dict:
+    environment = os.environ | {
+        "LEGACY_SECRETS_MIGRATION_FILE": str(SELF_HOST_DIR / ".legacy-secrets-migration.env"),
+    }
+    command = ["docker", "compose", "-f", str(COMPOSE_FILE), "config", "--format", "json"]
+    return json.loads(subprocess.run(command, check=True, capture_output=True, text=True, env=environment).stdout)
+
+
+def volume(service: dict, target: str) -> dict:
+    return next(mount for mount in service["volumes"] if mount["target"] == target)
+
+
+def run_entrypoint(config_contents: str | None, initialized: bool = False) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    with tempfile.TemporaryDirectory() as temporary_dir:
+        root = pathlib.Path(temporary_dir)
+        managed_config = root / "config.json"
+        marker = root / "INITIALIZED"
+        bootstrap_config = root / "Caddyfile"
+        caddy_calls = root / "caddy.calls"
+        fake_caddy = root / "caddy"
+        bootstrap_config.write_text("bootstrap")
+        if config_contents is not None:
+            managed_config.write_text(config_contents)
+        if initialized:
+            marker.write_text("initialized")
+        fake_caddy.write_text(
+            '#!/bin/sh\n'
+            'printf "%s\\n" "$*" >> "$CADDY_CALLS"\n'
+            'if [ "$1" = validate ] && grep -q INVALID "$3"; then exit 1; fi\n'
+            'exit 0\n'
+        )
+        fake_caddy.chmod(0o755)
+        environment = os.environ | {
+            "PATH": f"{root}:{os.environ['PATH']}",
+            "CADDY_CALLS": str(caddy_calls),
+            "SUPACLOUD_CADDY_CONFIG_PATH": str(managed_config),
+            "SUPACLOUD_CADDY_INITIALIZED_MARKER": str(marker),
+            "SUPACLOUD_CADDY_BOOTSTRAP_CONFIG": str(bootstrap_config),
+        }
+        completed = subprocess.run([str(ENTRYPOINT)], capture_output=True, text=True, env=environment)
+        calls = caddy_calls.read_text().splitlines() if caddy_calls.exists() else []
+        return completed, calls
+
+
+class CaddyComposeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.model = compose_model()
+
+    def test_gateway_ports_and_startup_order(self) -> None:
+        caddy = self.model["services"]["caddy"]
+        management = self.model["services"]["management-api"]
+        port_pairs = {(port["published"], port["target"]) for port in caddy["ports"]}
+
+        self.assertIn(("8000", 80), port_pairs)
+        self.assertIn(("8443", 443), port_pairs)
+        self.assertNotIn("depends_on", caddy)
+        self.assertEqual(management["depends_on"]["caddy"]["condition"], "service_healthy")
+
+    def test_shared_volume_permissions(self) -> None:
+        caddy = self.model["services"]["caddy"]
+        management = self.model["services"]["management-api"]
+
+        for target in ("/var/supacloud/frontends", "/etc/supacloud/caddy"):
+            self.assertFalse(volume(management, target).get("read_only", False))
+            self.assertTrue(volume(caddy, target)["read_only"])
+        self.assertFalse(volume(management, "/var/lib/supacloud/caddy").get("read_only", False))
+        self.assertFalse(volume(caddy, "/var/lib/supacloud/caddy").get("read_only", False))
+
+    def test_bootstrap_tls_uses_only_a_fixed_internal_subject(self) -> None:
+        bootstrap = BOOTSTRAP_CONFIG.read_text()
+
+        self.assertIn("auto_https disable_redirects", bootstrap)
+        self.assertIn("default_sni supacloud-bootstrap.invalid", bootstrap)
+        self.assertIn("fallback_sni supacloud-bootstrap.invalid", bootstrap)
+        self.assertIn("supacloud-bootstrap.invalid:443", bootstrap)
+        self.assertNotIn("on_demand", bootstrap)
+
+    def test_entrypoint_uses_durable_json_and_fails_closed_after_initialization(self) -> None:
+        durable, durable_calls = run_entrypoint('{"admin":{"listen":"0.0.0.0:2019"}}')
+        durable_initialized, initialized_calls = run_entrypoint(
+            '{"admin":{"listen":"0.0.0.0:2019"}}',
+            initialized=True,
+        )
+        fresh, fresh_calls = run_entrypoint(None)
+        missing, missing_calls = run_entrypoint(None, initialized=True)
+        invalid, invalid_calls = run_entrypoint("INVALID", initialized=True)
+
+        self.assertEqual(durable.returncode, 0)
+        self.assertEqual([call.split()[0] for call in durable_calls], ["validate", "run"])
+        self.assertNotIn("--adapter", durable_calls[-1])
+        self.assertEqual(durable_initialized.returncode, 0)
+        self.assertEqual([call.split()[0] for call in initialized_calls], ["validate", "run"])
+        self.assertEqual(fresh.returncode, 0)
+        self.assertIn("--adapter caddyfile", fresh_calls[-1])
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertEqual(missing_calls, [])
+        self.assertIn("initialized Caddy config was lost", missing.stderr)
+        self.assertNotEqual(invalid.returncode, 0)
+        self.assertEqual([call.split()[0] for call in invalid_calls], ["validate"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -59,6 +59,30 @@ npx @supacloud/admin --env production ssh upgrade \
   --confirm-production host:production.example.com:2201
 ```
 
+Immutable prebuilt frontend releases use a content-addressed ZIP and an explicit
+compare-and-swap activation. Upload and activation are separate writes, and
+production requires the exact project ref confirmation:
+
+```bash
+supacloud-admin frontend list_releases --ref abc123 --id web
+supacloud-admin frontend get_release --ref abc123 --id web --release_id <sha256>
+supacloud-admin frontend upload_release --ref abc123 --id web \
+  --zip_path /secure/site.zip --confirm-production abc123
+supacloud-admin frontend activate_release --ref abc123 --id web \
+  --release_id <sha256> --expected_active_release_id absent \
+  --expected_activation_id absent --mutation_id <uuid-v4> \
+  --confirm-production abc123
+```
+
+The CLI reads the archive through a no-follow file descriptor, verifies its
+identity and SHA-256 before upload, validates bounded Management API receipts,
+and reads the immutable release or active inventory back before reporting
+success. Reuse the same `mutation_id` only when retrying the exact activation.
+Listing and release readback work on every Management API platform. Upload and
+activation mutations require the Linux held-directory-FD implementation; on
+other platforms, Management API returns HTTP 503 before it reads the upload
+body, creates release directories, or writes a mutation journal.
+
 SSH host keys are fail-closed: setting `SUPACLOUD_HOST` and credentials is not
 enough to enable SSH actions. Obtain the fingerprint through a trusted channel,
 compare it out of band, then set it explicitly. For example, the discovery

--- a/packages/admin/src/index.test.ts
+++ b/packages/admin/src/index.test.ts
@@ -489,6 +489,38 @@ describe("supacloud-admin process contract", () => {
         }
     });
 
+    test("blocks production frontend release upload before file or HTTP without exact confirmation", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-production-frontend-"));
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        writeFileSync(join(workspace, ".env.supacloud.production"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=frontend-production-token",
+            "SUPACLOUD_PROJECT_REF=prod-ref",
+        ].join("\n") + "\n");
+        try {
+            const execution = await runAdminCli([
+                "frontend", "upload_release", "--ref", "prod-ref", "--id", "web",
+                "--zip_path", join(workspace, "missing.zip"), "--env", "production",
+            ], {}, workspace);
+            expect(execution.exitCode).toBe(1);
+            expect(execution.output).toContain("--confirm-production prod-ref");
+            expect(execution.output).not.toContain("frontend-production-token");
+            expect(requestCount).toBe(0);
+        } finally {
+            server.stop(true);
+            rmSync(workspace, { recursive: true, force: true });
+        }
+    });
+
     test("blocks read-only writes before HTTP without reflecting credentials", async () => {
         const workspace = mkdtempSync(join(tmpdir(), "supacloud-admin-read-only-"));
         let requestCount = 0;

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -13,6 +13,7 @@ import { registerSshTools } from "./shared/tools/ssh-tools";
 import { registerAdvancedTools } from "./shared/tools/advanced-tools";
 import { registerAdminProjectCliTools } from "./shared/tools/project-cli-tools";
 import { registerGatewayTools } from "./shared/tools/gateway-tools";
+import { registerFrontendTools } from "./shared/tools/frontend-tools";
 import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
@@ -43,7 +44,7 @@ function unavailableTool(schema: ToolEntry["schema"], message: string): ToolEntr
     };
 }
 
-function unavailableAdminSchemas(): Record<"project" | "platform" | "gateway" | "ssh", ToolEntry["schema"]> {
+function unavailableAdminSchemas(): Record<"project" | "platform" | "gateway" | "frontend" | "ssh", ToolEntry["schema"]> {
     const schemaOnlyHttp = {} as HttpTransport;
     return {
         project: captureTools((server) =>
@@ -52,6 +53,8 @@ function unavailableAdminSchemas(): Record<"project" | "platform" | "gateway" | 
             registerAdvancedTools(server as any, schemaOnlyHttp)).platform.schema,
         gateway: captureTools((server) =>
             registerGatewayTools(server as any, schemaOnlyHttp)).gateway.schema,
+        frontend: captureTools((server) =>
+            registerFrontendTools(server as any, schemaOnlyHttp)).frontend.schema,
         ssh: captureTools((server) =>
             registerSshTools(server as any, {} as SshTransport)).ssh.schema,
     };
@@ -67,6 +70,8 @@ function registerUnavailableAdminTools(tools: ToolMap): void {
         "⚠️ SSH commands require SUPACLOUD_HOST, SSH credentials, and SUPACLOUD_SSH_HOST_FINGERPRINT.");
     tools.gateway = unavailableTool(schemas.gateway,
         "⚠️ Gateway / Caddy commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN (admin privileges).");
+    tools.frontend = unavailableTool(schemas.frontend,
+        "⚠️ Frontend commands require SUPACLOUD_API_URL and SUPACLOUD_API_TOKEN.");
 }
 
 function printHelp(context = resolveSupaCloudContext()) {
@@ -131,6 +136,9 @@ EXAMPLES
   supacloud-admin gateway upsert_route --ref abc123 --route_id webhook --hosts "api.example.com" --paths "/webhook/*" --upstream 10.0.0.5:8080
   supacloud-admin gateway config --ref abc123 --rate_limit_tier pro
   supacloud-admin gateway rebuild --ref abc123 --clean
+  supacloud-admin frontend list_releases --ref abc123 --id web
+  supacloud-admin frontend upload_release --ref abc123 --id web --zip_path /secure/site.zip
+  supacloud-admin frontend activate_release --ref abc123 --id web --release_id <sha256> --expected_active_release_id absent --expected_activation_id absent --mutation_id <uuid-v4>
 `);
 }
 
@@ -234,6 +242,7 @@ export function createAdminTools(
 
         Object.assign(tools, captureTools((server) => registerAdminProjectCliTools(server as any, http)));
         Object.assign(tools, captureTools((server) => registerGatewayTools(server as any, http)));
+        Object.assign(tools, captureTools((server) => registerFrontendTools(server as any, http)));
 
         const advancedTools = captureTools((server) => registerAdvancedTools(server as any, http));
         if (advancedTools.platform) {

--- a/packages/admin/src/shared/execution-policy.test.ts
+++ b/packages/admin/src/shared/execution-policy.test.ts
@@ -35,6 +35,7 @@ describe("Admin execution policy", () => {
                 "platform.metrics", "platform.list_backups", "platform.list_logical_backups", "platform.network",
                 "platform.list_orgs", "platform.get_org",
                 "gateway.routes", "gateway.get_certificate", "gateway.custom_hostname",
+                "frontend.list_releases", "frontend.get_release",
                 "ssh.ping", "ssh.versions", "ssh.diagnose", "ssh.exec",
                 "ssh.troubleshoot", "ssh.container_logs", "ssh.tenant_list",
                 "ssh.tenant_inspect", "ssh.tenant_diagnose",
@@ -48,6 +49,7 @@ describe("Admin execution policy", () => {
                 "gateway.config", "gateway.update_certificate", "gateway.issue_certificate",
                 "gateway.deploy_certificate", "gateway.rebuild", "gateway.set_custom_hostname",
                 "gateway.delete_custom_hostname", "gateway.verify_custom_hostname",
+                "frontend.upload_release", "frontend.activate_release",
                 "ssh.setup", "ssh.install", "ssh.upgrade", "ssh.tenant_migrate",
             ],
         } as const;
@@ -132,6 +134,26 @@ describe("Admin execution policy", () => {
         }, {
             context: productionContext(),
         })).not.toThrow();
+    });
+
+    test("requires the exact production project ref for frontend release writes", () => {
+        const args = {
+            action: "activate_release",
+            ref: "prod-ref",
+            id: "web",
+            release_id: "a".repeat(64),
+        };
+        expect(() => authorizeExecution("frontend", args, {
+            context: productionContext(),
+        })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("frontend", args, {
+            context: productionContext(),
+            confirmProduction: "prod-ref",
+        })).not.toThrow();
+        expect(() => authorizeExecution("frontend", { ...args, ref: "other-ref" }, {
+            context: productionContext(),
+            confirmProduction: "other-ref",
+        })).toThrow("different project ref");
     });
 
     test("rejects cross-project production reads and writes", () => {

--- a/packages/admin/src/shared/execution-policy.ts
+++ b/packages/admin/src/shared/execution-policy.ts
@@ -29,6 +29,10 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
             "set_custom_hostname", "delete_custom_hostname", "verify_custom_hostname",
         ],
     },
+    frontend: {
+        read: ["list_releases", "get_release"],
+        write: ["upload_release", "activate_release"],
+    },
     ssh: {
         read: [
             "ping", "versions", "diagnose", "exec", "troubleshoot", "container_logs",
@@ -126,7 +130,7 @@ function requestedProjectRef(
     if (moduleName === "platform") {
         return PLATFORM_PROJECT_REF_ACTIONS.has(action) ? stringArgument(args, "ref") : null;
     }
-    return moduleName === "gateway" ? stringArgument(args, "ref") : null;
+    return ["gateway", "frontend"].includes(moduleName) ? stringArgument(args, "ref") : null;
 }
 
 function requiresProjectRef(moduleName: string, action: string): boolean {

--- a/packages/admin/src/shared/tools/frontend-release-control.test.ts
+++ b/packages/admin/src/shared/tools/frontend-release-control.test.ts
@@ -1,0 +1,726 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+    activateFrontendRelease,
+    getFrontendRelease,
+    listFrontendReleases,
+    uploadFrontendRelease,
+} from "./frontend-release-control";
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const DEPLOYMENT_ID = "fa-web";
+const RELEASE_ID = "a".repeat(64);
+const TREE_SHA = "b".repeat(64);
+const MUTATION_ID = "00000000-0000-4000-8000-000000000001";
+const roots = new Set<string>();
+
+function release(releaseId = RELEASE_ID, treeSha = TREE_SHA) {
+    return {
+        schema: "supacloud.frontend-release.v1",
+        project_ref: PROJECT_REF,
+        deployment_id: DEPLOYMENT_ID,
+        release_id: releaseId,
+        sha256: releaseId,
+        tree_sha256: treeSha,
+        size_bytes: 3,
+        file_count: 1,
+        created_at: "2026-08-12T00:00:00.000Z",
+        kind: "prebuilt_static",
+    };
+}
+
+function parsed(response: { content: Array<{ text: string }> }): Record<string, unknown> {
+    return JSON.parse(response.content[0].text) as Record<string, unknown>;
+}
+
+afterEach(async () => {
+    await Promise.all([...roots].map((root) => rm(root, { recursive: true, force: true })));
+    roots.clear();
+});
+
+describe("admin immutable frontend release control", () => {
+    test("lists and gets only strict secret-free release projections", async () => {
+        const inventory = {
+            project_ref: PROJECT_REF,
+            deployment_id: DEPLOYMENT_ID,
+            active_release_id: null,
+            active_activation_id: null,
+            releases: [{ ...release(), token: "must-not-escape" }],
+            next_cursor: null,
+        };
+        const http = {
+            get: async (path: string) => path.includes(`/${RELEASE_ID}`)
+                ? {
+                    ok: true, status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: release(),
+                    },
+                }
+                : { ok: true, status: 200, data: inventory },
+        };
+        const malformedList = await listFrontendReleases(http as never, PROJECT_REF, DEPLOYMENT_ID);
+        expect(malformedList.isError).toBe(true);
+        expect(malformedList.content[0].text).not.toContain("must-not-escape");
+
+        inventory.releases = [release() as never];
+        const listed = await listFrontendReleases(http as never, PROJECT_REF, DEPLOYMENT_ID, undefined, 25);
+        const read = await getFrontendRelease(http as never, PROJECT_REF, DEPLOYMENT_ID, RELEASE_ID);
+        expect(parsed(listed).releases).toEqual([expect.objectContaining({ release_id: RELEASE_ID })]);
+        expect((parsed(read).release as Record<string, unknown>).tree_sha256).toBe(TREE_SHA);
+    });
+
+    test("uploads raw verified bytes and requires exact immutable readback", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-admin-frontend-release-"));
+        roots.add(root);
+        const path = join(root, "site.zip");
+        await writeFile(path, "zip");
+        const calls: Array<{ method: string; path: string; options?: Record<string, unknown> }> = [];
+        const http = {
+            postBinary: async (endpoint: string, body: {
+                stream: ReadableStream<Uint8Array>;
+            }, options: Record<string, unknown>) => {
+                calls.push({ method: "POST", path: endpoint, options });
+                const bytes = new Uint8Array(await new Response(body.stream).arrayBuffer());
+                expect(new TextDecoder().decode(bytes)).toBe("zip");
+                const digest = String(options.contentSha256);
+                return {
+                    ok: true,
+                    status: 201,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: { ...release(), release_id: digest, sha256: digest },
+                    },
+                };
+            },
+            get: async (endpoint: string) => {
+                calls.push({ method: "GET", path: endpoint });
+                const digest = endpoint.split("/").at(-1)!;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: { ...release(), release_id: digest, sha256: digest },
+                    },
+                };
+            },
+        };
+
+        const response = await uploadFrontendRelease(http as never, PROJECT_REF, DEPLOYMENT_ID, path);
+        expect(response.isError).not.toBe(true);
+        expect(calls.map((call) => call.method)).toEqual(["POST", "GET"]);
+        expect(calls[0].options).toMatchObject({ contentType: "application/zip", contentLength: 3 });
+    });
+
+    test("streams archive bytes in bounded chunks without buffering the file", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-admin-frontend-release-stream-"));
+        roots.add(root);
+        const path = join(root, "site.zip");
+        const archiveBytes = new Uint8Array(64 * 1024 * 2 + 17).fill(0x61);
+        await writeFile(path, archiveBytes);
+        const chunkLengths: number[] = [];
+        const response = await uploadFrontendRelease({
+            postBinary: async (_endpoint: string, body: {
+                stream: ReadableStream<Uint8Array>;
+                byteLength: number;
+            }, options: Record<string, unknown>) => {
+                const reader = body.stream.getReader();
+                let streamedBytes = 0;
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    chunkLengths.push(value.byteLength);
+                    streamedBytes += value.byteLength;
+                }
+                expect(streamedBytes).toBe(body.byteLength);
+                const digest = String(options.contentSha256);
+                return {
+                    ok: true,
+                    status: 201,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: release(digest),
+                    },
+                };
+            },
+            get: async (endpoint: string) => {
+                const digest = endpoint.split("/").at(-1)!;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: release(digest),
+                    },
+                };
+            },
+        } as never, PROJECT_REF, DEPLOYMENT_ID, path);
+
+        expect(response.isError).not.toBe(true);
+        expect(chunkLengths).toEqual([64 * 1024, 64 * 1024, 17]);
+    });
+
+    test("rejects upload readback envelopes and records for another deployment", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-admin-frontend-release-identity-"));
+        roots.add(root);
+        const path = join(root, "site.zip");
+        await writeFile(path, "zip");
+        const response = await uploadFrontendRelease({
+            postBinary: async (_endpoint: string, _body: unknown, options: Record<string, unknown>) => {
+                const digest = String(options.contentSha256);
+                return {
+                    ok: true,
+                    status: 201,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: { ...release(), release_id: digest, sha256: digest },
+                    },
+                };
+            },
+            get: async (endpoint: string) => {
+                const digest = endpoint.split("/").at(-1)!;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: "other-web",
+                        release: {
+                            ...release(),
+                            deployment_id: "other-web",
+                            release_id: digest,
+                            sha256: digest,
+                        },
+                    },
+                };
+            },
+        } as never, PROJECT_REF, DEPLOYMENT_ID, path);
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("converges on the content-addressed release after an upload response is lost", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-admin-frontend-release-readback-"));
+        roots.add(root);
+        const path = join(root, "site.zip");
+        await writeFile(path, "zip");
+        let digest = "";
+        const response = await uploadFrontendRelease({
+            postBinary: async (_endpoint: string, _body: unknown, options: Record<string, unknown>) => {
+                digest = String(options.contentSha256);
+                return { ok: false, status: 500, data: { token: "must-not-escape" }, transportError: true };
+            },
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    project_ref: PROJECT_REF,
+                    deployment_id: DEPLOYMENT_ID,
+                    release: { ...release(), release_id: digest, sha256: digest },
+                },
+            }),
+        } as never, PROJECT_REF, DEPLOYMENT_ID, path);
+
+        expect(response.isError).not.toBe(true);
+        expect((parsed(response).release as Record<string, unknown>).release_id).toBe(digest);
+        expect(response.content[0].text).not.toContain("must-not-escape");
+    });
+
+    test.each([400, 401, 403, 409, 429])(
+        "preserves deterministic HTTP %s upload failures without readback",
+        async (status) => {
+            const root = await mkdtemp(join(tmpdir(), "supacloud-admin-frontend-release-4xx-"));
+            roots.add(root);
+            const path = join(root, "site.zip");
+            await writeFile(path, "zip");
+            let reads = 0;
+            const response = await uploadFrontendRelease({
+                postBinary: async () => ({
+                    ok: false,
+                    status,
+                    data: { token: "must-not-escape" },
+                    responseError: true,
+                }),
+                get: async () => {
+                    reads += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            } as never, PROJECT_REF, DEPLOYMENT_ID, path);
+
+            expect(parsed(response).error).toEqual({ code: "HTTP_ERROR", http_status: status });
+            expect(reads).toBe(0);
+            expect(response.content[0].text).not.toContain("must-not-escape");
+        },
+    );
+
+    test("reads back an HTTP 408 upload outcome", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-admin-frontend-release-408-"));
+        roots.add(root);
+        const path = join(root, "site.zip");
+        await writeFile(path, "zip");
+        let digest = "";
+        let reads = 0;
+        const response = await uploadFrontendRelease({
+            postBinary: async (_endpoint: string, _body: unknown, options: Record<string, unknown>) => {
+                digest = String(options.contentSha256);
+                return { ok: false, status: 408, data: null };
+            },
+            get: async () => {
+                reads += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: release(digest),
+                    },
+                };
+            },
+        } as never, PROJECT_REF, DEPLOYMENT_ID, path);
+
+        expect(response.isError).not.toBe(true);
+        expect(reads).toBe(1);
+    });
+
+    test("rejects a symlink archive before any HTTP request", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-admin-frontend-release-link-"));
+        roots.add(root);
+        await writeFile(join(root, "site.zip"), "zip");
+        await symlink(join(root, "site.zip"), join(root, "link.zip"));
+        let requests = 0;
+        await expect(uploadFrontendRelease({
+            postBinary: async () => {
+                requests += 1;
+                return { ok: true, status: 201, data: {} };
+            },
+        } as never, PROJECT_REF, DEPLOYMENT_ID, join(root, "link.zip"))).rejects.toThrow();
+        expect(requests).toBe(0);
+    });
+
+    test("activates with exact CAS and proves the activation generation by inventory", async () => {
+        const calls: Array<{ method: string; body?: unknown }> = [];
+        const http = {
+            post: async (_path: string, body: unknown, options: Record<string, unknown>) => {
+                calls.push({ method: "POST", body });
+                expect(options).toEqual({ maxJsonBytes: 1024 * 1024 });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        active_release_id: RELEASE_ID,
+                        activation_id: MUTATION_ID,
+                        release: release(),
+                        mutation: { mutation_id: MUTATION_ID, status: "succeeded", replayed: false },
+                    },
+                };
+            },
+            get: async (path: string) => {
+                calls.push({ method: "GET" });
+                if (path.endsWith(`/${RELEASE_ID}`)) {
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: {
+                            project_ref: PROJECT_REF,
+                            deployment_id: DEPLOYMENT_ID,
+                            release: release(),
+                        },
+                    };
+                }
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        active_release_id: RELEASE_ID,
+                        active_activation_id: MUTATION_ID,
+                        releases: [release()],
+                        next_cursor: null,
+                    },
+                };
+            },
+        };
+        const response = await activateFrontendRelease(http as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+        expect(response.isError).not.toBe(true);
+        expect(calls).toEqual([
+            {
+                method: "POST",
+                body: {
+                    expected_active_release_id: "absent",
+                    expected_activation_id: "absent",
+                    mutation_id: MUTATION_ID,
+                },
+            },
+            { method: "GET" },
+            { method: "GET" },
+        ]);
+    });
+
+    test("rejects activation inventories that exceed the requested page limit", async () => {
+        let reads = 0;
+        const response = await activateFrontendRelease({
+            post: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    project_ref: PROJECT_REF,
+                    deployment_id: DEPLOYMENT_ID,
+                    active_release_id: RELEASE_ID,
+                    activation_id: MUTATION_ID,
+                    release: release(),
+                    mutation: { mutation_id: MUTATION_ID, status: "succeeded", replayed: false },
+                },
+            }),
+            get: async () => {
+                reads += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        active_release_id: RELEASE_ID,
+                        active_activation_id: MUTATION_ID,
+                        releases: Array.from({ length: 101 }, (_, index) => release(
+                            index.toString(16).padStart(64, "0"),
+                            (index + 101).toString(16).padStart(64, "0"),
+                        )),
+                        next_cursor: RELEASE_ID,
+                    },
+                };
+            },
+        } as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+        expect(reads).toBe(1);
+    });
+
+    test("rejects activation inventory records for another project", async () => {
+        const response = await activateFrontendRelease({
+            post: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    project_ref: PROJECT_REF,
+                    deployment_id: DEPLOYMENT_ID,
+                    active_release_id: RELEASE_ID,
+                    activation_id: MUTATION_ID,
+                    release: release(),
+                    mutation: { mutation_id: MUTATION_ID, status: "succeeded", replayed: false },
+                },
+            }),
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    project_ref: PROJECT_REF,
+                    deployment_id: DEPLOYMENT_ID,
+                    active_release_id: RELEASE_ID,
+                    active_activation_id: MUTATION_ID,
+                    releases: [{ ...release(), project_ref: "other-project" }],
+                    next_cursor: null,
+                },
+            }),
+        } as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("rejects an exact activation readback for another release", async () => {
+        const response = await activateFrontendRelease({
+            post: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    project_ref: PROJECT_REF,
+                    deployment_id: DEPLOYMENT_ID,
+                    active_release_id: RELEASE_ID,
+                    activation_id: MUTATION_ID,
+                    release: release(),
+                    mutation: { mutation_id: MUTATION_ID, status: "succeeded", replayed: false },
+                },
+            }),
+            get: async (path: string) => path.endsWith(`/${RELEASE_ID}`)
+                ? {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        release: release("c".repeat(64)),
+                    },
+                }
+                : {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        active_release_id: RELEASE_ID,
+                        active_activation_id: MUTATION_ID,
+                        releases: [],
+                        next_cursor: RELEASE_ID,
+                    },
+                },
+        } as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
+    });
+
+    test("does not reflect malformed or failed remote activation bodies", async () => {
+        let readbacks = 0;
+        const response = await activateFrontendRelease({
+            post: async () => ({
+                ok: false,
+                status: 503,
+                data: { token: "remote-secret", detail: "private detail" },
+            }),
+            get: async () => {
+                readbacks += 1;
+                return { ok: false, status: 404, data: { detail: "private readback" } };
+            },
+        } as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 503 });
+        expect(readbacks).toBe(1);
+        expect(response.content[0].text).not.toContain("remote-secret");
+        expect(response.content[0].text).not.toContain("private detail");
+    });
+
+    test("proves a lost activation response with durable mutation and inventory readback", async () => {
+        let reads = 0;
+        const olderReleases = Array.from({ length: 100 }, (_, index) => {
+            const releaseId = (index + 1).toString(16).padStart(64, "0");
+            return release(releaseId, (index + 101).toString(16).padStart(64, "0"));
+        });
+        const response = await activateFrontendRelease({
+            post: async () => ({ ok: false, status: 500, data: null, transportError: true }),
+            get: async (path: string) => {
+                reads += 1;
+                if (reads === 1) {
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: {
+                            project_ref: PROJECT_REF,
+                            mutation: {
+                                project_ref: PROJECT_REF,
+                                mutation_id: MUTATION_ID,
+                                operation: "frontend.release.activate",
+                                resource_key: "v1/frontend_release/ZmEtd2Vi",
+                                request_fingerprint: "bca02488f799ea07a4aebfb2d73f8a00d058d3f96763d9653a36b88d3e7c8939",
+                                principal: { type: "project", id: `project:${PROJECT_REF}` },
+                                status: "succeeded",
+                                checkpoint: {},
+                                receipt: {},
+                                response_status: 200,
+                                failure_code: null,
+                                lease: { owner: null, expires_at: null, fencing_epoch: 1 },
+                                completed_at: "2026-08-12T00:00:00.000Z",
+                                created_at: "2026-08-12T00:00:00.000Z",
+                                updated_at: "2026-08-12T00:00:00.000Z",
+                            },
+                        },
+                    };
+                }
+                if (path.endsWith(`/${RELEASE_ID}`)) {
+                    return {
+                        ok: true,
+                        status: 200,
+                        data: {
+                            project_ref: PROJECT_REF,
+                            deployment_id: DEPLOYMENT_ID,
+                            release: release(),
+                        },
+                    };
+                }
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        deployment_id: DEPLOYMENT_ID,
+                        active_release_id: RELEASE_ID,
+                        active_activation_id: MUTATION_ID,
+                        releases: olderReleases,
+                        next_cursor: olderReleases.at(-1)!.release_id,
+                    },
+                };
+            },
+        } as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+
+        expect(response.isError).not.toBe(true);
+        expect(parsed(response).activation_id).toBe(MUTATION_ID);
+        expect(reads).toBe(3);
+    });
+
+    test("rejects a lost-response mutation for a different CAS request", async () => {
+        let reads = 0;
+        const response = await activateFrontendRelease({
+            post: async () => ({ ok: false, status: 500, data: null, transportError: true }),
+            get: async () => {
+                reads += 1;
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        project_ref: PROJECT_REF,
+                        mutation: {
+                            project_ref: PROJECT_REF,
+                            mutation_id: MUTATION_ID,
+                            operation: "frontend.release.activate",
+                            resource_key: "v1/frontend_release/ZmEtd2Vi",
+                            request_fingerprint: "c".repeat(64),
+                            principal: { type: "project", id: `project:${PROJECT_REF}` },
+                            status: "succeeded",
+                            checkpoint: {},
+                            receipt: {},
+                            response_status: 200,
+                            failure_code: null,
+                            lease: { owner: null, expires_at: null, fencing_epoch: 1 },
+                            completed_at: "2026-08-12T00:00:00.000Z",
+                            created_at: "2026-08-12T00:00:00.000Z",
+                            updated_at: "2026-08-12T00:00:00.000Z",
+                        },
+                    },
+                };
+            },
+        } as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 500 });
+        expect(reads).toBe(1);
+    });
+
+    test("reads back an HTTP 408 activation outcome", async () => {
+        let reads = 0;
+        const response = await activateFrontendRelease({
+            post: async () => ({ ok: false, status: 408, data: null }),
+            get: async () => {
+                reads += 1;
+                return { ok: false, status: 404, data: null };
+            },
+        } as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: MUTATION_ID,
+        });
+
+        expect(parsed(response).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 408 });
+        expect(reads).toBe(1);
+    });
+
+    test.each([400, 401, 403, 409, 429])(
+        "preserves deterministic HTTP %s activation failures with malformed bodies",
+        async (status) => {
+            let reads = 0;
+            const response = await activateFrontendRelease({
+                post: async () => ({
+                    ok: false,
+                    status,
+                    data: { token: "must-not-escape" },
+                    responseError: true,
+                }),
+                get: async () => {
+                    reads += 1;
+                    return { ok: true, status: 200, data: {} };
+                },
+            } as never, {
+                projectRef: PROJECT_REF,
+                deploymentId: DEPLOYMENT_ID,
+                releaseId: RELEASE_ID,
+                expectedActiveReleaseId: "absent",
+                expectedActivationId: "absent",
+                mutationId: MUTATION_ID,
+            });
+
+            expect(parsed(response).error).toEqual({ code: "HTTP_ERROR", http_status: status });
+            expect(reads).toBe(0);
+            expect(response.content[0].text).not.toContain("must-not-escape");
+        },
+    );
+
+    test("rejects a non-canonical timestamp and missing activation mutation id", async () => {
+        const malformed = release();
+        malformed.created_at = "2026-02-30T00:00:00.000Z";
+        const read = await getFrontendRelease({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { project_ref: PROJECT_REF, deployment_id: DEPLOYMENT_ID, release: malformed },
+            }),
+        } as never, PROJECT_REF, DEPLOYMENT_ID, RELEASE_ID);
+        expect(read.isError).toBe(true);
+        await expect(activateFrontendRelease({} as never, {
+            projectRef: PROJECT_REF,
+            deploymentId: DEPLOYMENT_ID,
+            releaseId: RELEASE_ID,
+            expectedActiveReleaseId: "absent",
+            expectedActivationId: "absent",
+            mutationId: "",
+        })).rejects.toThrow("'mutation_id' must be a UUIDv4");
+    });
+});

--- a/packages/admin/src/shared/tools/frontend-release-control.ts
+++ b/packages/admin/src/shared/tools/frontend-release-control.ts
@@ -1,0 +1,557 @@
+import { createHash } from "node:crypto";
+import { constants as fsConstants, type BigIntStats } from "node:fs";
+import { open, type FileHandle } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { HttpResult, HttpTransport } from "../transports/http";
+
+const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,20}$/u;
+const DEPLOYMENT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/u;
+const RELEASE_ID_PATTERN = /^[0-9a-f]{64}$/u;
+const MUTATION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u;
+const ARCHIVE_MAX_BYTES = 100 * 1024 * 1024;
+const ARCHIVE_CHUNK_BYTES = 64 * 1024;
+const RESPONSE_MAX_BYTES = 1024 * 1024;
+const UPLOAD_REQUEST_TIMEOUT_MS = 10 * 60_000;
+const RELEASE_LIST_LIMIT_MAX = 100;
+
+type ToolResponse = { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+export interface FrontendReleaseRecord {
+    project_ref: string;
+    deployment_id: string;
+    release_id: string;
+    sha256: string;
+    tree_sha256: string;
+    size_bytes: number;
+    file_count: number;
+    created_at: string;
+    kind: "prebuilt_static";
+}
+
+interface FrontendReleaseInventory {
+    project_ref: string;
+    deployment_id: string;
+    active_release_id: string | null;
+    active_activation_id: string | null;
+    releases: FrontendReleaseRecord[];
+    next_cursor: string | null;
+}
+
+interface LocalArchive {
+    handle: FileHandle;
+    sizeBytes: number;
+    sha256: string;
+}
+
+function toolResponse(payload: object): ToolResponse {
+    return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function releaseFailure(
+    operation: string,
+    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "OUTCOME_UNKNOWN",
+    status: number | null,
+): ToolResponse {
+    return {
+        isError: true,
+        content: [{
+            type: "text",
+            text: JSON.stringify({ ok: false, operation, error: { code, http_status: status } }),
+        }],
+    };
+}
+
+function exactKeys(candidate: Record<string, unknown>, keys: readonly string[]): boolean {
+    const actual = Object.keys(candidate).sort();
+    const expected = [...keys].sort();
+    return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function releaseRecord(candidate: unknown): FrontendReleaseRecord | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const record = candidate as Record<string, unknown>;
+    const keys = [
+        "schema", "project_ref", "deployment_id", "release_id", "sha256", "tree_sha256",
+        "size_bytes", "file_count", "created_at", "kind",
+    ] as const;
+    if (!exactKeys(record, keys) || record.schema !== "supacloud.frontend-release.v1"
+        || typeof record.project_ref !== "string" || !PROJECT_REF_PATTERN.test(record.project_ref)
+        || typeof record.deployment_id !== "string" || !DEPLOYMENT_ID_PATTERN.test(record.deployment_id)
+        || typeof record.release_id !== "string" || !RELEASE_ID_PATTERN.test(record.release_id)
+        || record.sha256 !== record.release_id || typeof record.tree_sha256 !== "string"
+        || !RELEASE_ID_PATTERN.test(record.tree_sha256) || !Number.isSafeInteger(record.size_bytes)
+        || Number(record.size_bytes) < 1 || !Number.isSafeInteger(record.file_count)
+        || Number(record.file_count) < 1 || !canonicalTimestamp(record.created_at)
+        || record.kind !== "prebuilt_static") return null;
+    return {
+        project_ref: record.project_ref,
+        deployment_id: record.deployment_id,
+        release_id: record.release_id,
+        sha256: record.release_id,
+        tree_sha256: record.tree_sha256,
+        size_bytes: Number(record.size_bytes),
+        file_count: Number(record.file_count),
+        created_at: record.created_at,
+        kind: "prebuilt_static",
+    };
+}
+
+function releaseEnvelope(candidate: unknown, expected: {
+    projectRef: string;
+    deploymentId: string;
+    releaseId: string;
+}): FrontendReleaseRecord | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const envelope = candidate as Record<string, unknown>;
+    const release = exactKeys(envelope, ["project_ref", "deployment_id", "release"])
+        ? releaseRecord(envelope.release)
+        : null;
+    if (!release || envelope.project_ref !== expected.projectRef
+        || envelope.deployment_id !== expected.deploymentId
+        || release.project_ref !== expected.projectRef
+        || release.deployment_id !== expected.deploymentId
+        || release.release_id !== expected.releaseId) return null;
+    return release;
+}
+
+function canonicalTimestamp(candidate: unknown): candidate is string {
+    if (typeof candidate !== "string" || !TIMESTAMP_PATTERN.test(candidate)) return false;
+    const milliseconds = Date.parse(candidate);
+    return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === candidate;
+}
+
+function nullableIdentity(candidate: unknown, pattern: RegExp): string | null | undefined {
+    if (candidate === null) return null;
+    return typeof candidate === "string" && pattern.test(candidate) ? candidate : undefined;
+}
+
+function releaseInventory(
+    candidate: unknown,
+    expected?: { projectRef: string; deploymentId: string },
+): FrontendReleaseInventory | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const record = candidate as Record<string, unknown>;
+    const keys = [
+        "project_ref", "deployment_id", "active_release_id", "active_activation_id",
+        "releases", "next_cursor",
+    ] as const;
+    if (!exactKeys(record, keys) || typeof record.project_ref !== "string"
+        || !PROJECT_REF_PATTERN.test(record.project_ref) || typeof record.deployment_id !== "string"
+        || !DEPLOYMENT_ID_PATTERN.test(record.deployment_id) || !Array.isArray(record.releases)) return null;
+    const activeReleaseId = nullableIdentity(record.active_release_id, RELEASE_ID_PATTERN);
+    const activeActivationId = nullableIdentity(record.active_activation_id, MUTATION_ID_PATTERN);
+    const nextCursor = nullableIdentity(record.next_cursor, RELEASE_ID_PATTERN);
+    const releases = record.releases.map(releaseRecord);
+    if (activeReleaseId === undefined || activeActivationId === undefined || nextCursor === undefined
+        || (activeReleaseId === null) !== (activeActivationId === null)
+        || releases.some((release) => release === null)) return null;
+    const verified = releases as FrontendReleaseRecord[];
+    if (new Set(verified.map((release) => release.release_id)).size !== verified.length
+        || verified.some((release) => release.project_ref !== record.project_ref
+            || release.deployment_id !== record.deployment_id)
+        || (expected && (record.project_ref !== expected.projectRef
+            || record.deployment_id !== expected.deploymentId))) return null;
+    return {
+        project_ref: record.project_ref,
+        deployment_id: record.deployment_id,
+        active_release_id: activeReleaseId,
+        active_activation_id: activeActivationId,
+        releases: verified,
+        next_cursor: nextCursor,
+    };
+}
+
+function releaseEndpoint(projectRef: string, deploymentId: string): string {
+    if (!PROJECT_REF_PATTERN.test(projectRef)) throw new Error("'ref' is invalid for frontend releases");
+    if (!DEPLOYMENT_ID_PATTERN.test(deploymentId)) throw new Error("'id' is invalid for frontend releases");
+    return `/v1/projects/${encodeURIComponent(projectRef)}/frontend/deployments/${encodeURIComponent(deploymentId)}/releases`;
+}
+
+function releasePath(projectRef: string, deploymentId: string, releaseId: string): string {
+    if (!RELEASE_ID_PATTERN.test(releaseId)) throw new Error("'release_id' must be a SHA-256 digest");
+    return `${releaseEndpoint(projectRef, deploymentId)}/${releaseId}`;
+}
+
+function sameArchiveIdentity(left: BigIntStats, right: BigIntStats): boolean {
+    return left.dev === right.dev && left.ino === right.ino && left.size === right.size
+        && left.mtimeNs === right.mtimeNs && left.ctimeNs === right.ctimeNs;
+}
+
+async function archiveSha256(handle: FileHandle, sizeBytes: number): Promise<string> {
+    const hash = createHash("sha256");
+    const chunk = new Uint8Array(Math.min(sizeBytes, ARCHIVE_CHUNK_BYTES));
+    for (let offset = 0; offset < sizeBytes;) {
+        const requested = Math.min(chunk.byteLength, sizeBytes - offset);
+        const { bytesRead } = await handle.read(chunk, 0, requested, offset);
+        if (bytesRead < 1) throw new Error("Frontend release archive changed while it was hashed");
+        hash.update(chunk.subarray(0, bytesRead));
+        offset += bytesRead;
+    }
+    return hash.digest("hex");
+}
+
+async function verifiedArchive(path: string): Promise<LocalArchive> {
+    const archivePath = resolve(path);
+    const handle = await open(archivePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    try {
+        const before = await handle.stat({ bigint: true });
+        const sizeBytes = Number(before.size);
+        if (!before.isFile() || sizeBytes < 1 || sizeBytes > ARCHIVE_MAX_BYTES) {
+            throw new Error(`Frontend release archive must be a 1-${ARCHIVE_MAX_BYTES} byte regular file`);
+        }
+        const sha256 = await archiveSha256(handle, sizeBytes);
+        const after = await handle.stat({ bigint: true });
+        if (!sameArchiveIdentity(before, after)) {
+            throw new Error("Frontend release archive identity changed while it was hashed");
+        }
+        return { handle, sizeBytes, sha256 };
+    } catch (error: unknown) {
+        await handle.close();
+        throw error;
+    }
+}
+
+function archiveStream(archive: LocalArchive): ReadableStream<Uint8Array> {
+    let offset = 0;
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            if (offset === archive.sizeBytes) {
+                controller.close();
+                return;
+            }
+            const length = Math.min(ARCHIVE_CHUNK_BYTES, archive.sizeBytes - offset);
+            const chunk = new Uint8Array(length);
+            const { bytesRead } = await archive.handle.read(chunk, 0, length, offset);
+            if (bytesRead < 1) throw new Error("Frontend release archive changed while it was uploaded");
+            offset += bytesRead;
+            controller.enqueue(bytesRead === length ? chunk : chunk.subarray(0, bytesRead));
+        },
+    });
+}
+
+function releaseReadFailure(operation: string, response: HttpResult<unknown>): ToolResponse {
+    return releaseFailure(operation, response.ok ? "INVALID_RESPONSE" : "HTTP_ERROR", response.status);
+}
+
+export async function listFrontendReleases(
+    http: HttpTransport,
+    projectRef: string,
+    deploymentId: string,
+    cursor?: string,
+    limit = 50,
+): Promise<ToolResponse> {
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > RELEASE_LIST_LIMIT_MAX) {
+        throw new Error("'limit' must be 1-100");
+    }
+    if (cursor !== undefined && !RELEASE_ID_PATTERN.test(cursor)) throw new Error("'cursor' is invalid");
+    const query = new URLSearchParams({ limit: String(limit) });
+    if (cursor) query.set("cursor", cursor);
+    const response = await http.get(`${releaseEndpoint(projectRef, deploymentId)}?${query}`, {
+        maxJsonBytes: RESPONSE_MAX_BYTES,
+    });
+    const inventory = response.ok ? releaseInventory(response.data, { projectRef, deploymentId }) : null;
+    if (!inventory || inventory.releases.length > limit) {
+        return releaseReadFailure("frontend.list_releases", response);
+    }
+    return toolResponse(inventory);
+}
+
+export async function getFrontendRelease(
+    http: HttpTransport,
+    projectRef: string,
+    deploymentId: string,
+    releaseId: string,
+): Promise<ToolResponse> {
+    const response = await http.get(releasePath(projectRef, deploymentId, releaseId), {
+        maxJsonBytes: RESPONSE_MAX_BYTES,
+    });
+    const release = response.ok
+        ? releaseEnvelope(response.data, { projectRef, deploymentId, releaseId })
+        : null;
+    if (!release) {
+        return releaseReadFailure("frontend.get_release", response);
+    }
+    return toolResponse({ project_ref: projectRef, deployment_id: deploymentId, release });
+}
+
+export async function uploadFrontendRelease(
+    http: HttpTransport,
+    projectRef: string,
+    deploymentId: string,
+    archivePath: string,
+): Promise<ToolResponse> {
+    const endpoint = releaseEndpoint(projectRef, deploymentId);
+    const archive = await verifiedArchive(archivePath);
+    let response: HttpResult<unknown>;
+    try {
+        response = await http.postBinary(endpoint, {
+            stream: archiveStream(archive),
+            byteLength: archive.sizeBytes,
+        }, {
+            contentType: "application/zip",
+            contentLength: archive.sizeBytes,
+            contentSha256: archive.sha256,
+            maxJsonBytes: RESPONSE_MAX_BYTES,
+            timeoutMs: UPLOAD_REQUEST_TIMEOUT_MS,
+        });
+    } finally {
+        await archive.handle.close();
+    }
+    const release = response.ok
+        ? releaseEnvelope(response.data, { projectRef, deploymentId, releaseId: archive.sha256 })
+        : null;
+    if (!release) {
+        if (response.status >= 400 && response.status < 500 && response.status !== 408
+            && !response.transportError) {
+            return releaseFailure("frontend.upload_release", "HTTP_ERROR", response.status);
+        }
+        return uploadReadback(http, projectRef, deploymentId, archive.sha256, response.status);
+    }
+    const readback = await http.get(`${endpoint}/${release.release_id}`, { maxJsonBytes: RESPONSE_MAX_BYTES });
+    const verified = readback.ok
+        ? releaseEnvelope(readback.data, { projectRef, deploymentId, releaseId: release.release_id })
+        : null;
+    if (!verified || verified.tree_sha256 !== release.tree_sha256) {
+        return releaseFailure("frontend.upload_release", "OUTCOME_UNKNOWN", readback.status);
+    }
+    return toolResponse({ project_ref: projectRef, deployment_id: deploymentId, release: verified });
+}
+
+async function uploadReadback(
+    http: HttpTransport,
+    projectRef: string,
+    deploymentId: string,
+    releaseId: string,
+    uploadStatus: number,
+): Promise<ToolResponse> {
+    const response = await http.get(releasePath(projectRef, deploymentId, releaseId), {
+        maxJsonBytes: RESPONSE_MAX_BYTES,
+    });
+    const release = response.ok
+        ? releaseEnvelope(response.data, { projectRef, deploymentId, releaseId })
+        : null;
+    if (!release) {
+        return releaseFailure("frontend.upload_release", "OUTCOME_UNKNOWN", uploadStatus);
+    }
+    return toolResponse({ project_ref: projectRef, deployment_id: deploymentId, release });
+}
+
+interface PublicMutationReceipt {
+    operation: string;
+    status: string;
+    responseStatus: number | null;
+    failureCode: string | null;
+}
+
+interface ActivationIdentity {
+    projectRef: string;
+    deploymentId: string;
+    releaseId: string;
+    mutationId: string;
+}
+
+interface ActiveReleaseReadback {
+    release: FrontendReleaseRecord | null;
+    status: number;
+}
+
+function stableJson(candidate: unknown): string {
+    if (candidate === null || typeof candidate !== "object") return JSON.stringify(candidate);
+    if (Array.isArray(candidate)) return `[${candidate.map(stableJson).join(",")}]`;
+    const record = candidate as Record<string, unknown>;
+    return `{${Object.keys(record).sort().map((key) => (
+        `${JSON.stringify(key)}:${stableJson(record[key])}`
+    )).join(",")}}`;
+}
+
+function activationFingerprint(identity: ActivationIdentity & {
+    expectedActiveReleaseId: string;
+    expectedActivationId: string;
+}): string {
+    return createHash("sha256").update(stableJson({
+        project_ref: identity.projectRef,
+        deployment_id: identity.deploymentId,
+        release_id: identity.releaseId,
+        expected_active_release_id: identity.expectedActiveReleaseId,
+        activation_id: identity.mutationId,
+        expected_activation_id: identity.expectedActivationId,
+    })).digest("hex");
+}
+
+function activationResourceKey(deploymentId: string): string {
+    return `v1/frontend_release/${Buffer.from(deploymentId, "utf8").toString("base64url")}`;
+}
+
+function publicMutationReceipt(candidate: unknown, expected: {
+    projectRef: string;
+    mutationId: string;
+    resourceKey: string;
+    requestFingerprint: string;
+}): PublicMutationReceipt | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const envelope = candidate as Record<string, unknown>;
+    const mutation = envelope.mutation as Record<string, unknown> | null;
+    const expectedKeys = [
+        "project_ref", "mutation_id", "operation", "resource_key", "request_fingerprint",
+        "principal", "status", "checkpoint", "receipt", "response_status", "failure_code",
+        "lease", "completed_at", "created_at", "updated_at",
+    ] as const;
+    if (!mutation || !exactKeys(envelope, ["project_ref", "mutation"])
+        || !exactKeys(mutation, expectedKeys) || envelope.project_ref !== expected.projectRef
+        || mutation.project_ref !== expected.projectRef || mutation.mutation_id !== expected.mutationId
+        || mutation.resource_key !== expected.resourceKey
+        || mutation.request_fingerprint !== expected.requestFingerprint
+        || typeof mutation.operation !== "string" || typeof mutation.status !== "string"
+        || !(mutation.response_status === null || Number.isSafeInteger(mutation.response_status))
+        || !(mutation.failure_code === null || typeof mutation.failure_code === "string")) return null;
+    return {
+        operation: mutation.operation,
+        status: mutation.status,
+        responseStatus: mutation.response_status as number | null,
+        failureCode: mutation.failure_code as string | null,
+    };
+}
+
+function activationReceipt(candidate: unknown, input: {
+    projectRef: string;
+    deploymentId: string;
+    releaseId: string;
+    mutationId: string;
+}): FrontendReleaseRecord | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const record = candidate as Record<string, unknown>;
+    const release = releaseRecord(record.release);
+    const mutation = record.mutation as Record<string, unknown> | null;
+    if (!release || !mutation || !exactKeys(record, [
+        "project_ref", "deployment_id", "active_release_id", "activation_id", "release", "mutation",
+    ]) || !exactKeys(mutation, ["mutation_id", "status", "replayed"])
+        || record.project_ref !== input.projectRef || record.deployment_id !== input.deploymentId
+        || record.active_release_id !== input.releaseId || record.activation_id !== input.mutationId
+        || release.project_ref !== input.projectRef || release.deployment_id !== input.deploymentId
+        || release.release_id !== input.releaseId || mutation.mutation_id !== input.mutationId
+        || mutation.status !== "succeeded" || typeof mutation.replayed !== "boolean") return null;
+    return release;
+}
+
+async function activeReleaseReadback(
+    http: HttpTransport,
+    identity: ActivationIdentity,
+): Promise<ActiveReleaseReadback> {
+    const endpoint = releaseEndpoint(identity.projectRef, identity.deploymentId);
+    const inventoryRead = await http.get(`${endpoint}?limit=${RELEASE_LIST_LIMIT_MAX}`, {
+        maxJsonBytes: RESPONSE_MAX_BYTES,
+    });
+    const inventory = inventoryRead.ok
+        ? releaseInventory(inventoryRead.data, {
+            projectRef: identity.projectRef,
+            deploymentId: identity.deploymentId,
+        })
+        : null;
+    if (!inventory || inventory.releases.length > RELEASE_LIST_LIMIT_MAX
+        || inventory.active_release_id !== identity.releaseId
+        || inventory.active_activation_id !== identity.mutationId) {
+        return { release: null, status: inventoryRead.status };
+    }
+
+    const releaseRead = await http.get(releasePath(
+        identity.projectRef,
+        identity.deploymentId,
+        identity.releaseId,
+    ), { maxJsonBytes: RESPONSE_MAX_BYTES });
+    const release = releaseRead.ok
+        ? releaseEnvelope(releaseRead.data, {
+            projectRef: identity.projectRef,
+            deploymentId: identity.deploymentId,
+            releaseId: identity.releaseId,
+        })
+        : null;
+    return { release, status: releaseRead.status };
+}
+
+export async function activateFrontendRelease(
+    http: HttpTransport,
+    input: {
+        projectRef: string;
+        deploymentId: string;
+        releaseId: string;
+        expectedActiveReleaseId: string;
+        expectedActivationId: string;
+        mutationId: string;
+    },
+): Promise<ToolResponse> {
+    const mutationId = input.mutationId;
+    if (!MUTATION_ID_PATTERN.test(mutationId)) throw new Error("'mutation_id' must be a UUIDv4");
+    if (input.expectedActiveReleaseId !== "absent" && !RELEASE_ID_PATTERN.test(input.expectedActiveReleaseId)) {
+        throw new Error("'expected_active_release_id' is invalid");
+    }
+    if (input.expectedActivationId !== "absent" && !MUTATION_ID_PATTERN.test(input.expectedActivationId)) {
+        throw new Error("'expected_activation_id' is invalid");
+    }
+    const endpoint = `${releasePath(input.projectRef, input.deploymentId, input.releaseId)}/activate`;
+    const response = await http.post(endpoint, {
+        expected_active_release_id: input.expectedActiveReleaseId,
+        expected_activation_id: input.expectedActivationId,
+        mutation_id: mutationId,
+    }, { maxJsonBytes: RESPONSE_MAX_BYTES });
+    const release = activationReceipt(response.data, { ...input, mutationId });
+    if (!response.ok || !release) {
+        if (response.status >= 400 && response.status < 500 && response.status !== 408
+            && !response.transportError) {
+            return releaseFailure("frontend.activate_release", "HTTP_ERROR", response.status);
+        }
+        return activationReadback(http, input, mutationId, response.status);
+    }
+    const readback = await activeReleaseReadback(http, { ...input, mutationId });
+    if (!readback.release || readback.release.tree_sha256 !== release.tree_sha256) {
+        return releaseFailure("frontend.activate_release", "OUTCOME_UNKNOWN", readback.status);
+    }
+    return toolResponse({
+        project_ref: input.projectRef,
+        deployment_id: input.deploymentId,
+        active_release_id: input.releaseId,
+        activation_id: mutationId,
+        release: readback.release,
+    });
+}
+
+async function activationReadback(
+    http: HttpTransport,
+    input: {
+        projectRef: string;
+        deploymentId: string;
+        releaseId: string;
+        expectedActiveReleaseId: string;
+        expectedActivationId: string;
+    },
+    mutationId: string,
+    activationStatus: number,
+): Promise<ToolResponse> {
+    const mutationRead = await http.get(
+        `/v1/projects/${encodeURIComponent(input.projectRef)}/mutations/${mutationId}`,
+        { maxJsonBytes: RESPONSE_MAX_BYTES },
+    );
+    const mutationEnvelope = mutationRead.data as Record<string, unknown> | null;
+    const mutation = mutationRead.ok ? publicMutationReceipt(mutationRead.data, {
+        projectRef: input.projectRef,
+        mutationId,
+        resourceKey: activationResourceKey(input.deploymentId),
+        requestFingerprint: activationFingerprint({ ...input, mutationId }),
+    }) : null;
+    if (!mutation || mutationEnvelope?.project_ref !== input.projectRef
+        || mutation.operation !== "frontend.release.activate" || mutation.status !== "succeeded"
+        || mutation.responseStatus !== 200 || mutation.failureCode !== null) {
+        return releaseFailure("frontend.activate_release", "OUTCOME_UNKNOWN", activationStatus);
+    }
+    const readback = await activeReleaseReadback(http, { ...input, mutationId });
+    if (!readback.release) {
+        return releaseFailure("frontend.activate_release", "OUTCOME_UNKNOWN", activationStatus);
+    }
+    return toolResponse({
+        project_ref: input.projectRef,
+        deployment_id: input.deploymentId,
+        active_release_id: input.releaseId,
+        activation_id: mutationId,
+        release: readback.release,
+    });
+}

--- a/packages/admin/src/shared/tools/frontend-tools.ts
+++ b/packages/admin/src/shared/tools/frontend-tools.ts
@@ -1,129 +1,64 @@
-/**
- * Frontend Hosting — Compound tool (13→1)
- */
-import { basename } from "node:path";
 import { Type } from "@sinclair/typebox";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { HttpTransport } from "../transports/http";
+import {
+    activateFrontendRelease,
+    getFrontendRelease,
+    listFrontendReleases,
+    uploadFrontendRelease,
+} from "./frontend-release-control";
 
 export function registerFrontendTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
     server.tool(
         "frontend",
-        `Frontend hosting (static sites & SSR). Supports: static, react, vue, svelte, sveltekit, sveltekit-static, nextjs, nuxt, astro.
-Actions: list, get, create, update, delete, deploy_git, deploy_upload, redeploy, build_logs, add_domain, remove_domain, set_env, list_frameworks, list_records`,
+        `Immutable prebuilt frontend release control.
+Actions: list_releases, get_release, upload_release, activate_release`,
         {
             action: withDescription(stringEnum([
-                "list", "get", "create", "update", "delete",
-                "deploy_git", "deploy_upload", "redeploy", "build_logs",
-                "add_domain", "remove_domain", "set_env",
-                "list_frameworks", "list_records",
+                "list_releases", "get_release", "upload_release", "activate_release",
             ]), "Action"),
             ref: optional(Type.String(), "Project ref"),
             id: optional(Type.String(), "Deployment ID"),
-            // create/update params
-            name: optional(Type.String(), "[create] Deployment name"),
-            framework: optional(Type.String(), "[create] Framework (static|react|vue|svelte|sveltekit|sveltekit-static|nextjs|nuxt|astro)"),
-            domain: optional(Type.String(), "[create/update/add_domain/remove_domain] Custom domain"),
-            build_command: optional(Type.String(), "[create/update] Build command override"),
-            output_dir: optional(Type.String(), "[create/update] Output directory override"),
-            install_command: optional(Type.String(), "[create/update] Install command override"),
-            node_version: optional(Type.String(), "[create/update] Node.js version"),
-            health_check_path: optional(Type.String(), "[create/update] SSR readiness path (default: /)"),
-            env_vars: optional(Type.Record(Type.String(), Type.String()), "[create/update/set_env] Environment variables"),
-            // deploy_git params
-            git_url: optional(Type.String(), "[deploy_git] Git repository URL"),
-            branch: optional(Type.String(), "[deploy_git] Branch (default: main)"),
-            zip_path: optional(Type.String(), "[deploy_upload] Local zip file path"),
+            zip_path: optional(Type.String(), "[upload_release] Local ZIP file path"),
+            release_id: optional(Type.String(), "[get_release/activate_release] SHA-256 release ID"),
+            expected_active_release_id: optional(Type.String(), "[activate_release] Current release SHA-256 or absent"),
+            expected_activation_id: optional(Type.String(), "[activate_release] Current activation UUIDv4 or absent"),
+            mutation_id: optional(Type.String(), "[activate_release] Required retry-stable UUIDv4"),
+            cursor: optional(Type.String(), "[list_releases] Last release SHA-256 cursor"),
+            limit: optional(Type.Number(), "[list_releases] Page size, 1-100 (default 50)"),
         },
         async (args: any) => {
-            const { action, ref, id, name, framework, domain, build_command, output_dir, install_command, node_version, health_check_path, env_vars, git_url, branch, zip_path } = args;
+            const {
+                action, ref, id, zip_path, release_id,
+                expected_active_release_id, expected_activation_id, mutation_id, cursor, limit,
+            } = args;
             const need = (f: string, v: any) => { if (!v) throw new Error(`'${f}' required for '${action}'`); };
-            const ok = (res: any) => res.ok ? JSON.stringify(res.data, null, 2) : `❌ Failed (${res.status}): ${JSON.stringify(res.data)}`;
-
-            let text: string;
             switch (action) {
-                case "list":
-                    need("ref", ref);
-                    text = ok(await http.get(`/v1/projects/${ref}/frontend/deployments`));
-                    break;
-                case "get":
+                case "list_releases":
                     need("ref", ref); need("id", id);
-                    text = ok(await http.get(`/v1/projects/${ref}/frontend/deployments/${id}`));
-                    break;
-                case "create":
-                    need("ref", ref); need("name", name); need("framework", framework);
-                    text = ok(await http.post(`/v1/projects/${ref}/frontend/deployments`, {
-                        name, framework, domain, build_command, output_dir, install_command, node_version, health_check_path, env_vars,
-                    }));
-                    break;
-                case "update":
-                    need("ref", ref); need("id", id);
-                    text = ok(await http.patch(`/v1/projects/${ref}/frontend/deployments/${id}`, {
-                        name, domain, build_command, output_dir, install_command, node_version, health_check_path, env_vars,
-                    }));
-                    break;
-                case "delete":
-                    need("ref", ref); need("id", id);
-                    text = (await http.delete(`/v1/projects/${ref}/frontend/deployments/${id}`)).ok ? `✅ Deleted` : `❌ Failed`;
-                    break;
-                case "deploy_git":
-                    need("ref", ref); need("id", id); need("git_url", git_url);
-                    text = ok(await http.post(`/v1/projects/${ref}/frontend/deployments/${id}/deploy/git`, { git_url, branch }));
-                    break;
-                case "deploy_upload":
+                    return listFrontendReleases(http, ref, id, cursor, limit);
+                case "get_release":
+                    need("ref", ref); need("id", id); need("release_id", release_id);
+                    return getFrontendRelease(http, ref, id, release_id);
+                case "upload_release":
                     need("ref", ref); need("id", id); need("zip_path", zip_path);
-                    const file = Bun.file(zip_path!);
-                    if (!(await file.exists())) {
-                        throw new Error(`Zip file not found: ${zip_path}`);
-                    }
-                    const form = new FormData();
-                    form.append(
-                        "file",
-                        new File([await file.arrayBuffer()], basename(zip_path!), {
-                            type: "application/zip",
-                        }),
-                    );
-                    text = ok(
-                        await http.postMultipart(
-                            `/v1/projects/${ref}/frontend/deployments/${id}/deploy/upload`,
-                            form,
-                        ),
-                    );
-                    break;
-                case "redeploy":
-                    need("ref", ref); need("id", id);
-                    text = ok(await http.post(`/v1/projects/${ref}/frontend/deployments/${id}/redeploy`));
-                    break;
-                case "build_logs":
-                    need("ref", ref); need("id", id);
-                    const lr = await http.get(`/v1/projects/${ref}/frontend/deployments/${id}/logs`);
-                    text = lr.ok ? ((lr.data as any)?.logs || "(no logs)") : `❌ Failed (${lr.status})`;
-                    break;
-                case "add_domain":
-                    need("ref", ref); need("id", id); need("domain", domain);
-                    text = (await http.post(`/v1/projects/${ref}/frontend/deployments/${id}/domains`, { domain })).ok
-                        ? `✅ Domain ${domain} added` : `❌ Failed`;
-                    break;
-                case "remove_domain":
-                    need("ref", ref); need("id", id); need("domain", domain);
-                    text = (await http.delete(`/v1/projects/${ref}/frontend/deployments/${id}/domains/${domain}`)).ok
-                        ? `✅ Domain ${domain} removed` : `❌ Failed`;
-                    break;
-                case "set_env":
-                    need("ref", ref); need("id", id); need("env_vars", env_vars);
-                    text = (await http.put(`/v1/projects/${ref}/frontend/deployments/${id}/env`, { env_vars })).ok
-                        ? `✅ Set ${Object.keys(env_vars!).length} env vars` : `❌ Failed`;
-                    break;
-                case "list_frameworks":
-                    text = ok(await http.get("/v1/projects/_/frontend/frameworks"));
-                    break;
-                case "list_records":
-                    need("ref", ref); need("id", id);
-                    text = ok(await http.get(`/v1/projects/${ref}/frontend/deployments/${id}/records`));
-                    break;
-                default: text = `❌ Unknown action`;
+                    return uploadFrontendRelease(http, ref, id, zip_path);
+                case "activate_release":
+                    need("ref", ref); need("id", id); need("release_id", release_id);
+                    need("expected_active_release_id", expected_active_release_id);
+                    need("expected_activation_id", expected_activation_id);
+                    need("mutation_id", mutation_id);
+                    return activateFrontendRelease(http, {
+                        projectRef: ref,
+                        deploymentId: id,
+                        releaseId: release_id,
+                        expectedActiveReleaseId: expected_active_release_id,
+                        expectedActivationId: expected_activation_id,
+                        mutationId: mutation_id,
+                    });
+                default:
+                    throw new Error("Unknown immutable frontend release action");
             }
-            return { content: [{ type: "text" as const, text }] };
         }
     );
 }

--- a/packages/admin/src/shared/transports/http.test.ts
+++ b/packages/admin/src/shared/transports/http.test.ts
@@ -423,6 +423,22 @@ describe("HttpTransport bounded JSON responses", () => {
         }
     });
 
+    test("rejects oversized and malformed bounded JSON POST responses without reflection", async () => {
+        const privateMarker = "private-post-response-marker";
+        const bodies = [
+            new TextEncoder().encode(JSON.stringify({ marker: privateMarker.repeat(maxJsonBytes) })),
+            new TextEncoder().encode(`{"marker":"${privateMarker}"`),
+        ];
+
+        for (const body of bodies) {
+            globalThis.fetch = (async () => new Response(Buffer.from(body))) as unknown as typeof fetch;
+            const response = await createTransport().post("/frontend/activate", {}, { maxJsonBytes });
+
+            expect(response.responseError).toBe(true);
+            expect(JSON.stringify(response)).not.toContain(privateMarker);
+        }
+    });
+
     test.each([0, -1, 1.5])("rejects invalid JSON byte limit %d before dispatch", async maxBytes => {
         let fetchCalls = 0;
         globalThis.fetch = (async () => {
@@ -435,5 +451,85 @@ describe("HttpTransport bounded JSON responses", () => {
         await expect(createTransport().post("/resource", {}, { timeoutMs: 1, maxJsonBytes: maxBytes }))
             .rejects.toThrow("positive safe integer");
         expect(fetchCalls).toBe(0);
+    });
+});
+
+describe("HttpTransport raw binary mutations", () => {
+    function binaryBody(bytes: number[]) {
+        const body = new Uint8Array(bytes);
+        return {
+            byteLength: body.byteLength,
+            stream: new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(body);
+                    controller.close();
+                },
+            }),
+        };
+    }
+
+    test("sends an exact ZIP body and returns only a bounded JSON response", async () => {
+        const captured = { headers: new Headers(), body: [] as number[] };
+        globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+            const request = new Request(input, init);
+            captured.headers = request.headers;
+            captured.body = [...new Uint8Array(await request.arrayBuffer())];
+            return Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+
+        const response = await createTransport().postBinary(
+            "/frontend/releases",
+            binaryBody([1, 2, 3]),
+            {
+                contentType: "application/zip",
+                contentLength: 3,
+                contentSha256: "a".repeat(64),
+                maxJsonBytes: 1024,
+            },
+        );
+
+        expect(response).toEqual({ ok: true, status: 200, data: { ok: true } });
+        expect(captured.headers.get("content-type")).toBe("application/zip");
+        expect(captured.headers.get("content-length")).toBe("3");
+        expect(captured.headers.get("x-supacloud-content-sha256")).toBe("a".repeat(64));
+        expect(captured.body).toEqual([1, 2, 3]);
+    });
+
+    test("rejects invalid binary metadata before dispatch", async () => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls += 1;
+            return Response.json({});
+        }) as unknown as typeof fetch;
+        const transport = createTransport();
+        await expect(transport.postBinary("/frontend/releases", binaryBody([1]), {
+            contentType: "application/json",
+            contentLength: 1,
+            contentSha256: "a".repeat(64),
+            maxJsonBytes: 1024,
+        })).rejects.toThrow("content type");
+        await expect(transport.postBinary("/frontend/releases", binaryBody([1]), {
+            contentType: "application/zip",
+            contentLength: 2,
+            contentSha256: "a".repeat(64),
+            maxJsonBytes: 1024,
+        })).rejects.toThrow("length");
+        expect(fetchCalls).toBe(0);
+    });
+
+    test("rejects an oversized binary response without reflecting its body", async () => {
+        const privateMarker = "private-binary-response";
+        globalThis.fetch = (async () => new Response(JSON.stringify({ privateMarker }), {
+            status: 201,
+            headers: { "content-length": "2048" },
+        })) as unknown as typeof fetch;
+        const response = await createTransport().postBinary("/frontend/releases", binaryBody([1]), {
+            contentType: "application/zip",
+            contentLength: 1,
+            contentSha256: "a".repeat(64),
+            maxJsonBytes: 1024,
+        });
+        expect(response.responseError).toBe(true);
+        expect(JSON.stringify(response)).not.toContain(privateMarker);
     });
 });

--- a/packages/admin/src/shared/transports/http.ts
+++ b/packages/admin/src/shared/transports/http.ts
@@ -19,8 +19,21 @@ export interface HttpResult<T = unknown> {
 }
 
 interface HttpPostOptions {
-    timeoutMs: number;
+    timeoutMs?: number;
     maxJsonBytes?: number;
+}
+
+export interface HttpBinaryPostOptions {
+    contentType: string;
+    contentLength: number;
+    contentSha256: string;
+    maxJsonBytes: number;
+    timeoutMs?: number;
+}
+
+export interface HttpBinaryBody {
+    stream: ReadableStream<Uint8Array>;
+    byteLength: number;
 }
 
 export interface HttpGetOptions {
@@ -248,23 +261,67 @@ export class HttpTransport {
         options?: HttpPostOptions,
     ): Promise<HttpResult<T>> {
         const timeoutMs = validatedPostTimeout(options);
-        const maxJsonBytes = validatedStrictJsonLimit(options ?? {});
+        const maxJsonBytes = validatedStrictJsonLimit({ maxJsonBytes: options?.maxJsonBytes });
+        let response: Response;
         try {
-            const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
+            response = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "POST",
                 headers: this.headers(),
                 body: body ? JSON.stringify(body) : undefined,
             }, timeoutMs);
-            if (maxJsonBytes !== undefined) {
-                try {
-                    const data = await strictBoundedResponseJson(res, maxJsonBytes) as T;
-                    return { ok: res.ok, status: res.status, data };
-                } catch {
-                    return responseBodyFailure<T>(res.status);
-                }
+        } catch (error: unknown) {
+            return transportFailure<T>(error);
+        }
+        if (maxJsonBytes !== undefined) {
+            try {
+                const data = await strictBoundedResponseJson(response, maxJsonBytes) as T;
+                return { ok: response.ok, status: response.status, data };
+            } catch {
+                return responseBodyFailure<T>(response.status);
             }
-            const data = (await res.json().catch(() => null)) as T;
-            return { ok: res.ok, status: res.status, data };
+        }
+        const data = (await response.json().catch(() => null)) as T;
+        return { ok: response.ok, status: response.status, data };
+    }
+
+    async postBinary<T = unknown>(
+        path: string,
+        body: HttpBinaryBody,
+        options: HttpBinaryPostOptions,
+    ): Promise<HttpResult<T>> {
+        if (options.contentType !== "application/zip") {
+            throw new Error("Binary HTTP content type is invalid");
+        }
+        if (!Number.isSafeInteger(options.contentLength) || options.contentLength < 1
+            || options.contentLength !== body.byteLength) {
+            throw new RangeError("Binary HTTP body length is invalid");
+        }
+        if (!/^[0-9a-f]{64}$/u.test(options.contentSha256)) {
+            throw new Error("Binary HTTP body SHA-256 is invalid");
+        }
+        const maxJsonBytes = validatedStrictJsonLimit({ maxJsonBytes: options.maxJsonBytes });
+        const timeoutMs = validatedPostTimeout(
+            options.timeoutMs === undefined ? undefined : { timeoutMs: options.timeoutMs },
+        );
+        try {
+            const request = {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${this.token}`,
+                    "Content-Type": options.contentType,
+                    "Content-Length": String(options.contentLength),
+                    "x-supacloud-content-sha256": options.contentSha256,
+                },
+                body: body.stream,
+                duplex: "half",
+            } as RequestInit & { duplex: "half" };
+            const response = await fetchWithRetry(`${this.baseUrl}${path}`, request, timeoutMs);
+            try {
+                const data = await strictBoundedResponseJson(response, maxJsonBytes!) as T;
+                return { ok: response.ok, status: response.status, data };
+            } catch {
+                return responseBodyFailure<T>(response.status);
+            }
         } catch (error: unknown) {
             return transportFailure<T>(error);
         }

--- a/packages/management-api/src/db/platform-v2.ts
+++ b/packages/management-api/src/db/platform-v2.ts
@@ -186,7 +186,7 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       lease_token UUID,
       lease_expires_at TIMESTAMPTZ,
       fencing_epoch BIGINT NOT NULL DEFAULT 0 CHECK (fencing_epoch >= 0),
-      recovery_not_before TIMESTAMPTZ DEFAULT clock_timestamp(),
+      recovery_not_before TIMESTAMPTZ,
       completed_at TIMESTAMPTZ,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -204,8 +204,8 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
         status <> 'succeeded'
         OR (response_status IS NOT NULL AND response_status BETWEEN 200 AND 299)
       ),
-      CONSTRAINT project_mutations_recoverable_due_check CHECK (
-        status NOT IN ('pending', 'running', 'failed_retryable')
+      CONSTRAINT project_mutations_recovery_due_v2_check CHECK (
+        status NOT IN ('running', 'failed_retryable')
         OR recovery_not_before IS NOT NULL
       ),
       CONSTRAINT project_mutations_fencing_epoch_safe_check CHECK (
@@ -216,10 +216,10 @@ export async function ensurePlatformV2Schema(transaction: SQL): Promise<void> {
       ADD COLUMN IF NOT EXISTS recovery_not_before TIMESTAMPTZ;
     CREATE INDEX IF NOT EXISTS project_mutations_status_idx
       ON project_mutations(project_ref, status, updated_at DESC);
-    CREATE INDEX IF NOT EXISTS project_mutations_recovery_idx
+    CREATE INDEX IF NOT EXISTS project_mutations_recovery_v2_idx
       ON project_mutations(operation, recovery_not_before, updated_at, mutation_id)
       WHERE recovery_not_before IS NOT NULL
-        AND status IN ('pending', 'running', 'failed_retryable');
+        AND status IN ('running', 'failed_retryable');
     CREATE UNIQUE INDEX IF NOT EXISTS project_mutations_active_resource_idx
       ON project_mutations(project_ref, resource_key)
       WHERE resource_key IS NOT NULL

--- a/packages/management-api/src/db/project-mutation-migration.ts
+++ b/packages/management-api/src/db/project-mutation-migration.ts
@@ -1,9 +1,12 @@
 import type { SQL } from "bun";
 
 export const PROJECT_MUTATION_JOURNAL_MIGRATION_KEY = "20260812_project_mutation_journal_v3";
+export const PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY =
+  "20260813_project_mutation_recovery_contract_v4";
 
 const CANONICAL_RESOURCE_KEY_CONSTRAINT = "project_mutations_resource_key_canonical_v1_check";
 const FENCING_EPOCH_SAFE_CONSTRAINT = "project_mutations_fencing_epoch_safe_check";
+const RECOVERY_DUE_CONSTRAINT = "project_mutations_recovery_due_v2_check";
 const CANONICAL_RESOURCE_KEY_PATTERN = "^v1/[a-z0-9][a-z0-9._-]{0,63}/[A-Za-z0-9_-]{2,171}$";
 const CANONICAL_RESOURCE_KEY_FUNCTION = "public.project_mutation_resource_key_is_canonical_v1";
 
@@ -12,13 +15,13 @@ type ConstraintState = {
   convalidated: boolean;
 };
 
-async function migrationIsCompleted(transaction: SQL): Promise<boolean> {
+async function migrationIsCompleted(transaction: SQL, migrationKey: string): Promise<boolean> {
   const [marker] = await transaction`
     SELECT migration_key
     FROM public.platform_schema_migrations
-    WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+    WHERE migration_key = ${migrationKey}
   `;
-  return marker?.migration_key === PROJECT_MUTATION_JOURNAL_MIGRATION_KEY;
+  return marker?.migration_key === migrationKey;
 }
 
 async function constraintState(transaction: SQL, name: string): Promise<ConstraintState | null> {
@@ -183,21 +186,24 @@ async function ensureRecoverableDueConstraint(transaction: SQL): Promise<void> {
   }
 }
 
-async function recordMigration(transaction: SQL, backfilledRows: number): Promise<void> {
-  const details = JSON.stringify({ backfilled_recovery_rows: backfilledRows });
+async function recordMigration(
+  transaction: SQL,
+  migrationKey: string,
+  details: Record<string, number>,
+): Promise<void> {
   await transaction`
     INSERT INTO public.platform_schema_migrations (migration_key, details)
-    VALUES (${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}, ${details}::jsonb)
+    VALUES (${migrationKey}, ${JSON.stringify(details)}::jsonb)
   `;
 }
 
-export async function migrateProjectMutationJournal(transaction: SQL): Promise<void> {
+async function migrateProjectMutationJournalV3(transaction: SQL): Promise<void> {
   await transaction`
     SELECT pg_catalog.pg_advisory_xact_lock(
       pg_catalog.hashtext(${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY})
     )
   `;
-  if (await migrationIsCompleted(transaction)) return;
+  if (await migrationIsCompleted(transaction, PROJECT_MUTATION_JOURNAL_MIGRATION_KEY)) return;
 
   await ensureCanonicalResourceKeyFunction(transaction);
   await assertCanonicalResourceKeys(transaction);
@@ -210,5 +216,91 @@ export async function migrateProjectMutationJournal(transaction: SQL): Promise<v
   await ensureFencingEpochSafeConstraint(transaction);
   await ensureSucceededResponseConstraint(transaction);
   await ensureRecoverableDueConstraint(transaction);
-  await recordMigration(transaction, backfilledRows);
+  await recordMigration(transaction, PROJECT_MUTATION_JOURNAL_MIGRATION_KEY, {
+    backfilled_recovery_rows: backfilledRows,
+  });
+}
+
+async function backfillRecoverableRecoverySchedule(transaction: SQL): Promise<number> {
+  const updatedMutations = await transaction`
+    UPDATE public.project_mutations
+    SET recovery_not_before = COALESCE(updated_at, created_at, clock_timestamp())
+    WHERE recovery_not_before IS NULL
+      AND status IN ('running', 'failed_retryable')
+    RETURNING mutation_id
+  ` as Array<{ mutation_id: string }>;
+  return updatedMutations.length;
+}
+
+async function ensureRecoveryDueConstraint(transaction: SQL): Promise<void> {
+  const existing = await constraintState(transaction, RECOVERY_DUE_CONSTRAINT);
+  if (!existing) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      ADD CONSTRAINT ${RECOVERY_DUE_CONSTRAINT}
+      CHECK (
+        status NOT IN ('running', 'failed_retryable')
+        OR recovery_not_before IS NOT NULL
+      ) NOT VALID
+    `);
+  }
+  if (!existing?.convalidated) {
+    await transaction.unsafe(`
+      ALTER TABLE public.project_mutations
+      VALIDATE CONSTRAINT ${RECOVERY_DUE_CONSTRAINT}
+    `);
+  }
+}
+
+async function clearPendingRecoverySchedule(transaction: SQL): Promise<number> {
+  const updatedMutations = await transaction`
+    UPDATE public.project_mutations
+    SET recovery_not_before = NULL
+    WHERE status = 'pending' AND recovery_not_before IS NOT NULL
+    RETURNING mutation_id
+  ` as Array<{ mutation_id: string }>;
+  return updatedMutations.length;
+}
+
+async function replaceRecoveryIndex(transaction: SQL): Promise<void> {
+  await transaction.unsafe(`
+    CREATE INDEX IF NOT EXISTS project_mutations_recovery_v2_idx
+    ON public.project_mutations(operation, recovery_not_before, updated_at, mutation_id)
+    WHERE recovery_not_before IS NOT NULL
+      AND status IN ('running', 'failed_retryable')
+  `);
+  await transaction.unsafe(`
+    DROP INDEX IF EXISTS public.project_mutations_recovery_idx
+  `);
+}
+
+async function migrateProjectMutationRecoveryContractV4(transaction: SQL): Promise<void> {
+  await transaction`
+    SELECT pg_catalog.pg_advisory_xact_lock(
+      pg_catalog.hashtext(${PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY})
+    )
+  `;
+  if (await migrationIsCompleted(transaction, PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY)) return;
+
+  await transaction.unsafe(`
+    ALTER TABLE public.project_mutations
+    ALTER COLUMN recovery_not_before DROP DEFAULT
+  `);
+  const backfilledRows = await backfillRecoverableRecoverySchedule(transaction);
+  await ensureRecoveryDueConstraint(transaction);
+  await transaction.unsafe(`
+    ALTER TABLE public.project_mutations
+    DROP CONSTRAINT IF EXISTS project_mutations_recoverable_due_check
+  `);
+  const clearedPendingRows = await clearPendingRecoverySchedule(transaction);
+  await replaceRecoveryIndex(transaction);
+  await recordMigration(transaction, PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY, {
+    backfilled_recovery_rows: backfilledRows,
+    cleared_pending_recovery_rows: clearedPendingRows,
+  });
+}
+
+export async function migrateProjectMutationJournal(transaction: SQL): Promise<void> {
+  await migrateProjectMutationJournalV3(transaction);
+  await migrateProjectMutationRecoveryContractV4(transaction);
 }

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -249,58 +249,23 @@ async function getIndexHtml(): Promise<string | null> {
   }
 }
 
-// 在 Bun.serve 监听之前构建网关内存态路由。docker 模式下此时 caddy 容器尚未启动，
-// 首次 persistAndLoad 的 POST /load 会失败；这里只构建内存态，最终的 JSON 注入由
-// ensureGatewayReady 在 HTTP server 就绪（满足 caddy 的 healthcheck 前置）后补发。
-async function initializeGatewayRoutes(): Promise<{ caddyReady: boolean }> {
-  const { gatewayService } = await import("./services/gateway.service");
-  try {
-    await gatewayService.setupMasterRoutes();
-  } catch (e) {
-    // 首次 POST /load 在 caddy 未就绪时失败是预期路径，记录后由 ensureGatewayReady 重试。
-    logger.warn(
-      "Initial gateway config apply failed; will retry once Caddy is reachable",
-      e instanceof Error ? e.message : String(e),
-    );
-  }
-  try {
-    await gatewayService.setupHostedAuthRoutes();
-  } catch (e) {
-    logger.warn(
-      "Hosted auth route setup deferred; will retry once Caddy is reachable",
-      e instanceof Error ? e.message : String(e),
-    );
-  }
-  try {
-    const { frontendService } = await import("./services/frontend.service");
-    const result = await frontendService.reconcileGatewayRoutes();
-    if (result.configured > 0 || result.errors.length > 0) {
-      logger.info("[FrontendService] Reconciled gateway routes", result);
-    }
-  } catch (e) {
-    logger.warn(
-      "Frontend gateway reconciliation deferred; will retry once Caddy is reachable",
-      e instanceof Error ? e.message : String(e),
-    );
-  }
-  const caddyReady = await gatewayService.checkCaddyConnectivity();
-  return { caddyReady };
-}
-
-// HTTP server 监听之后异步触发：caddy 在 docker 模式下晚于 management-api 启动，
-// 这里带退避轮询 Admin API，可达后补一次 persistAndLoad 让 JSON 路由接管 bootstrap Caddyfile。
-async function ensureGatewayRoutesAfterServe(initialReady: boolean): Promise<void> {
-  if (initialReady) return;
+async function waitForGatewayBeforeServe(): Promise<void> {
   const { gatewayService } = await import("./services/gateway.service");
   const maxAttempts = Number(process.env.GATEWAY_READY_MAX_ATTEMPTS || 60);
   const intervalMs = Number(process.env.GATEWAY_READY_INTERVAL_MS || 1000);
   const result = await gatewayService.ensureGatewayReady({ maxAttempts, intervalMs });
   if (!result.ready) {
-    logger.error(
-      "Gateway never became reachable; bootstrap Caddyfile routes remain active",
-      result.error,
-    );
+    throw new Error(result.error || "Caddy Admin API did not become ready");
   }
+}
+
+async function reconcileGatewayBeforeServe(): Promise<void> {
+  const { reconcileCanonicalGatewayRoutes } = await import("./services/gateway.service");
+  const state = await reconcileCanonicalGatewayRoutes();
+  logger.info("[Bootstrap] Canonical gateway reconciliation completed", {
+    tenants: state.tenants.updated,
+    frontends: state.frontends.configured,
+  });
 }
 
 const app = new Elysia({ strictPath: false })
@@ -1141,8 +1106,6 @@ async function bootstrap() {
     await migrateWebhookSecretsToControlStore(controlPlaneSql);
     await migrateLegacyProviderLinkingConfig(controlPlaneSql);
 
-    const { caddyReady: initialGatewayReady } = await initializeGatewayRoutes();
-
     const { jitDatabaseAccessService } = await import("./services/jit-database-access.service");
     const jitGatewayState = await jitDatabaseAccessService.startGateway();
     if (jitGatewayState.errors.length > 0) {
@@ -1165,6 +1128,14 @@ async function bootstrap() {
     }
 
     await recoverDatabaseReplacementsBeforeServe();
+
+    await waitForGatewayBeforeServe();
+
+    const { recoverFrontendReleasesBeforeServe } =
+      await import("./workers/frontend-release-recovery.worker");
+    await recoverFrontendReleasesBeforeServe();
+
+    await reconcileGatewayBeforeServe();
 
     Bun.serve({
       port: config.port,
@@ -1376,6 +1347,10 @@ async function bootstrap() {
       await import("./workers/branch-replacement-recovery.worker");
     startBranchReplacementRecoveryWorker();
 
+    const { startFrontendReleaseRecoveryWorker } =
+      await import("./workers/frontend-release-recovery.worker");
+    startFrontendReleaseRecoveryWorker();
+
     const { scheduledFunctionWorker } = await import("./workers/scheduled-function.worker");
     scheduledFunctionWorker.start();
 
@@ -1416,15 +1391,6 @@ async function bootstrap() {
       ),
     );
 
-    // docker 模式下 caddy 容器晚于 management-api 启动，首次 gateway /load 会在
-    // initializeGatewayRoutes 中失败。这里在 HTTP server 就绪后带退避重试，
-    // 直到 caddy 可达再补发 JSON 配置，让租户路由接管 bootstrap Caddyfile。
-    ensureGatewayRoutesAfterServe(initialGatewayReady).catch((err: unknown) =>
-      logger.error("[Bootstrap] Gateway readiness check failed (non-fatal):", {
-        error: err instanceof Error ? err.message : String(err),
-      }),
-    );
-
     logger.info(`
     ============================================================
              SupaCloud Management API
@@ -1463,6 +1429,9 @@ export function startManagementApi(): void {
       const { stopBranchReplacementRecoveryWorker } =
         await import("./workers/branch-replacement-recovery.worker");
       stopBranchReplacementRecoveryWorker();
+      const { stopFrontendReleaseRecoveryWorker } =
+        await import("./workers/frontend-release-recovery.worker");
+      stopFrontendReleaseRecoveryWorker();
       const { scheduledFunctionWorker } =
         await import("./workers/scheduled-function.worker");
       scheduledFunctionWorker.stop();

--- a/packages/management-api/src/routes/frontend.ts
+++ b/packages/management-api/src/routes/frontend.ts
@@ -3,6 +3,14 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { frontendService } from "../services/frontend.service";
+import {
+  FRONTEND_RELEASE_ARCHIVE_MAX_BYTES,
+  FRONTEND_RELEASE_LIST_DEFAULT_LIMIT,
+  FRONTEND_RELEASE_LIST_MAX_LIMIT,
+  FrontendReleaseError,
+  frontendReleasePrincipal,
+  frontendReleaseService,
+} from "../services/frontend-release.service";
 import type { FrontendFramework } from "../types/frontend";
 import { FRAMEWORK_DEFAULTS } from "../types/frontend";
 import { requireProjectOrAdminAuth } from "../middleware/auth";
@@ -11,6 +19,7 @@ const FRONTEND_UPLOAD_MAX_BYTES = Number(process.env.FRONTEND_UPLOAD_MAX_BYTES |
 const FRONTEND_UPLOAD_MAX_FILES = Number(process.env.FRONTEND_UPLOAD_MAX_FILES || 10_000);
 const FRONTEND_UPLOAD_MAX_UNCOMPRESSED_BYTES = Number(process.env.FRONTEND_UPLOAD_MAX_UNCOMPRESSED_BYTES || 300 * 1024 * 1024);
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
+const IMMUTABLE_UPLOAD_CHUNK_BYTES = 64 * 1024;
 
 function isSafeZipEntryName(name: string): boolean {
   const normalized = name.replace(/\\/g, "/");
@@ -115,6 +124,89 @@ async function readUploadedZip(request: Request, body: unknown): Promise<Uint8Ar
   return new Uint8Array(0);
 }
 
+function immutableReleaseContentLength(request: Request): number {
+  const header = request.headers.get("content-length");
+  if (header === null || !/^(?:[1-9]\d*)$/u.test(header)) {
+    throw new FrontendReleaseError(
+      "FRONTEND_RELEASE_CONTENT_LENGTH_INVALID",
+      411,
+      "Frontend release upload requires a canonical Content-Length",
+    );
+  }
+  const length = Number(header);
+  if (!Number.isSafeInteger(length) || length > FRONTEND_RELEASE_ARCHIVE_MAX_BYTES) {
+    throw new FrontendReleaseError(
+      "FRONTEND_RELEASE_ARCHIVE_TOO_LARGE",
+      413,
+      `Frontend release archive exceeds ${FRONTEND_RELEASE_ARCHIVE_MAX_BYTES} bytes`,
+    );
+  }
+  return length;
+}
+
+function assertImmutableReleaseContentType(request: Request): void {
+  if (request.headers.get("content-type")?.trim().toLowerCase() !== "application/zip") {
+    throw new FrontendReleaseError(
+      "FRONTEND_RELEASE_CONTENT_TYPE_INVALID",
+      415,
+      "Frontend release upload requires application/zip",
+    );
+  }
+}
+
+async function streamImmutableReleaseZip(
+  request: Request,
+  session: Awaited<ReturnType<typeof frontendReleaseService.prepareReleaseUpload>>,
+): Promise<void> {
+  const reader = request.body?.getReader();
+  if (!reader) {
+    throw new FrontendReleaseError("FRONTEND_RELEASE_ARCHIVE_INVALID", 400, "Frontend release archive is empty");
+  }
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      try {
+        for (let offset = 0; offset < chunk.value.byteLength; offset += IMMUTABLE_UPLOAD_CHUNK_BYTES) {
+          await session.write(chunk.value.subarray(offset, offset + IMMUTABLE_UPLOAD_CHUNK_BYTES));
+        }
+      } catch (error: unknown) {
+        await reader.cancel();
+        throw error;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function releasePage(query: { cursor?: string; limit?: string }): { cursor?: string; limit: number } {
+  const limitText = query.limit ?? String(FRONTEND_RELEASE_LIST_DEFAULT_LIMIT);
+  if (!/^(?:[1-9]\d*)$/u.test(limitText)) {
+    throw new FrontendReleaseError(
+      "FRONTEND_RELEASE_PAGE_INVALID",
+      400,
+      `Frontend release page limit must be 1-${FRONTEND_RELEASE_LIST_MAX_LIMIT}`,
+    );
+  }
+  const limit = Number(limitText);
+  if (limit > FRONTEND_RELEASE_LIST_MAX_LIMIT) {
+    throw new FrontendReleaseError(
+      "FRONTEND_RELEASE_PAGE_INVALID",
+      400,
+      `Frontend release page limit must be 1-${FRONTEND_RELEASE_LIST_MAX_LIMIT}`,
+    );
+  }
+  return { ...(query.cursor ? { cursor: query.cursor } : {}), limit };
+}
+
+function releaseError(error: unknown) {
+  if (error instanceof FrontendReleaseError) {
+    return status(error.statusCode, { code: error.code, error: error.message });
+  }
+  throw error;
+}
+
 export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" })
   // 组级守卫：委托 proof 必须通过 operations 能力检查，防止越权创建部署/修改环境变量
   .onBeforeHandle(async ({ params, request }) => {
@@ -150,6 +242,98 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
         id: t.String(),
       }),
       detail: { tags: ["frontend"], summary: "Get a frontend deployment" },
+    }
+  )
+
+  .get(
+    "/deployments/:id/releases",
+    async ({ params, query }) => {
+      try {
+        return await frontendReleaseService.listReleases(params.ref, params.id, releasePage(query));
+      } catch (error: unknown) {
+        return releaseError(error);
+      }
+    },
+    {
+      params: t.Object({ ref: t.String(), id: t.String() }),
+      query: t.Object({ cursor: t.Optional(t.String()), limit: t.Optional(t.String()) }),
+      detail: { tags: ["frontend"], summary: "List verified immutable frontend releases" },
+    }
+  )
+
+  .get(
+    "/deployments/:id/releases/:releaseId",
+    async ({ params }) => {
+      try {
+        return {
+          project_ref: params.ref,
+          deployment_id: params.id,
+          release: await frontendReleaseService.release(params.ref, params.id, params.releaseId),
+        };
+      } catch (error: unknown) {
+        return releaseError(error);
+      }
+    },
+    {
+      params: t.Object({ ref: t.String(), id: t.String(), releaseId: t.String() }),
+      detail: { tags: ["frontend"], summary: "Get a verified immutable frontend release" },
+    }
+  )
+
+  .post(
+    "/deployments/:id/releases",
+    async ({ params, request }) => {
+      try {
+        assertImmutableReleaseContentType(request);
+        const expectedLength = immutableReleaseContentLength(request);
+        const upload = await frontendReleaseService.prepareReleaseUpload(params.ref, params.id, expectedLength);
+        const expectedSha256 = request.headers.get("x-supacloud-content-sha256")?.trim() || "";
+        try {
+          await streamImmutableReleaseZip(request, upload);
+          const archive = await upload.finish(expectedSha256);
+          const release = await frontendReleaseService.createRelease(params.ref, params.id, archive);
+          return status(201, { project_ref: params.ref, deployment_id: params.id, release });
+        } finally {
+          await upload.abort();
+        }
+      } catch (error: unknown) {
+        return releaseError(error);
+      }
+    },
+    {
+      params: t.Object({ ref: t.String(), id: t.String() }),
+      parse: "none",
+      detail: { tags: ["frontend"], summary: "Create a verified immutable prebuilt static release" },
+    }
+  )
+
+  .post(
+    "/deployments/:id/releases/:releaseId/activate",
+    async ({ params, body, request }) => {
+      try {
+        await frontendReleaseService.assertMutationSupported(params.ref, params.id);
+        const principal = await frontendReleasePrincipal(request);
+        return await frontendReleaseService.activateRelease({
+          projectRef: params.ref,
+          deploymentId: params.id,
+          releaseId: params.releaseId,
+          expectedActiveReleaseId: body.expected_active_release_id,
+          expectedActivationId: body.expected_activation_id,
+          mutationId: body.mutation_id,
+          principal,
+        });
+      } catch (error: unknown) {
+        return releaseError(error);
+      }
+    },
+    {
+      params: t.Object({ ref: t.String(), id: t.String(), releaseId: t.String() }),
+      body: t.Object({
+        mutation_id: t.String(),
+        expected_active_release_id: t.String(),
+        expected_activation_id: t.String(),
+      }),
+      detail: { tags: ["frontend"], summary: "CAS activate an immutable static frontend release" },
     }
   )
 
@@ -236,8 +420,14 @@ export const frontendRoutes = new Elysia({ prefix: "/v1/projects/:ref/frontend" 
   .delete(
     "/deployments/:id",
     async ({ params, set }) => {
-      const success = await frontendService.deleteDeployment(params.ref, params.id);
-      if (!success) {
+      const deletion = await frontendService.deleteDeployment(params.ref, params.id);
+      if (deletion === "active") {
+        return status(409, {
+          message: "Immutable frontend release is active",
+          code: "FRONTEND_RELEASE_ACTIVE",
+        });
+      }
+      if (deletion === "not_found") {
                 return status(404, { message: "Deployment not found", code: "404" });
       }
       return { message: "Deployment deleted successfully" };

--- a/packages/management-api/src/services/frontend-deployment-lock.ts
+++ b/packages/management-api/src/services/frontend-deployment-lock.ts
@@ -1,0 +1,103 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { sql } from "../db";
+import { logger } from "../utils/logger";
+
+type ReservedControlSql = Awaited<ReturnType<typeof sql.reserve>>;
+
+interface FrontendDeploymentLockPool {
+  reserve(): Promise<ReservedControlSql>;
+}
+
+export type FrontendDeploymentLock = <T>(
+  projectRef: string,
+  deploymentId: string,
+  operation: () => Promise<T>,
+) => Promise<T>;
+
+export class FrontendDeploymentLockReleaseError extends Error {
+  readonly code = "FRONTEND_DEPLOYMENT_LOCK_RELEASE_FAILED" as const;
+
+  constructor() {
+    super("Frontend deployment lock release could not be proven");
+    this.name = "FrontendDeploymentLockReleaseError";
+  }
+}
+
+function deploymentLockKey(projectRef: string, deploymentId: string): string {
+  return `supacloud:frontend-deployment:${projectRef}:${deploymentId}`;
+}
+
+export function createFrontendDeploymentLock(
+  pool: FrontendDeploymentLockPool = sql,
+): FrontendDeploymentLock {
+  const operationContext = new AsyncLocalStorage<ReadonlySet<string>>();
+  const deploymentTails = new Map<string, Promise<void>>();
+
+  async function runWithSessionLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const connection = await pool.reserve();
+    let operationFailed = false;
+    let operationError: unknown;
+    let operationValue: T | undefined;
+    let acquired = false;
+    let unlocked = false;
+    try {
+      await connection`SELECT pg_advisory_lock(hashtextextended(${key}, 0))`;
+      acquired = true;
+      try {
+        operationValue = await operationContext.run(new Set([...(operationContext.getStore() ?? []), key]), operation);
+      } catch (error: unknown) {
+        operationFailed = true;
+        operationError = error;
+      }
+      try {
+        const [row] = await connection<{ unlocked: boolean }[]>`
+          SELECT pg_advisory_unlock(hashtextextended(${key}, 0)) AS unlocked
+        `;
+        unlocked = row?.unlocked === true;
+      } catch (error: unknown) {
+        logger.error("[frontend-deployment-lock] advisory unlock failed", {
+          key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } finally {
+      if (acquired && unlocked) {
+        connection.release();
+      } else {
+        try {
+          await connection.close({ timeout: 0 });
+        } catch (error: unknown) {
+          logger.error("[frontend-deployment-lock] failed to discard lock connection", {
+            key,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+    if (operationFailed) throw operationError;
+    if (!unlocked) {
+      logger.error("[frontend-deployment-lock] advisory unlock was not confirmed", { key });
+      throw new FrontendDeploymentLockReleaseError();
+    }
+    return operationValue as T;
+  }
+
+  return async <T>(projectRef: string, deploymentId: string, operation: () => Promise<T>): Promise<T> => {
+    const key = deploymentLockKey(projectRef, deploymentId);
+    if (operationContext.getStore()?.has(key)) return operation();
+    const previous = deploymentTails.get(key)?.catch(() => undefined) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => { release = resolve; });
+    const tail = previous.then(() => current);
+    deploymentTails.set(key, tail);
+    await previous;
+    try {
+      return await runWithSessionLock(key, operation);
+    } finally {
+      release();
+      if (deploymentTails.get(key) === tail) deploymentTails.delete(key);
+    }
+  };
+}
+
+export const withFrontendDeploymentLock = createFrontendDeploymentLock();

--- a/packages/management-api/src/services/frontend-domain.service.ts
+++ b/packages/management-api/src/services/frontend-domain.service.ts
@@ -1,207 +1,185 @@
 /**
  * Frontend Domain & Token Service
  * Handles: custom domains, deploy tokens, env vars, git config
- * 
+ *
  * Extracted from frontend.service.ts to reduce file size.
  */
-import { $ } from "bun";
-import { logger } from "../utils/logger";
 import type {
+  DeployToken,
   FrontendDeployment,
-  FrontendDeploymentConfig,
 } from "../types/frontend";
-import {
-  FRAMEWORK_DEFAULTS,
-} from "../types/frontend";
+import type { FrontendDeploymentLock } from "./frontend-deployment-lock";
+
+interface FrontendDomainServiceOptions {
+  deploymentLock: FrontendDeploymentLock;
+  getDeployment: (projectRef: string, deploymentId: string) => Promise<FrontendDeployment | null>;
+  writeDeployment: (deployment: FrontendDeployment) => Promise<void>;
+  commitHostMutation: (
+    previous: FrontendDeployment,
+    updated: FrontendDeployment,
+  ) => Promise<void>;
+}
+
+function newDeployToken(name: string): DeployToken {
+  return {
+    id: crypto.randomUUID().substring(0, 8),
+    name,
+    token: `supa_deploy_${crypto.randomUUID().replace(/-/g, "")}`,
+    created_at: new Date().toISOString(),
+  };
+}
 
 export class FrontendDomainService {
-  constructor(
-    private baseDir: string,
-    private getDeployment: (projectRef: string, deploymentId: string) => Promise<FrontendDeployment | null>,
-    private configureGatewayRoute: (deployment: FrontendDeployment, buildDir: string, isSSR: boolean) => Promise<void>,
-  ) {}
-
-  private joinPath(...parts: string[]): string {
-    return parts.join("/").replace(/\/+/g, "/");
-  }
+  constructor(private readonly options: FrontendDomainServiceOptions) {}
 
   async setEnvVars(
     projectRef: string,
     deploymentId: string,
-    envVars: Record<string, string>
+    envVars: Record<string, string>,
   ): Promise<FrontendDeployment | null> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return null;
-
-    const updated = {
-      ...deployment,
-      env_vars: { ...deployment.env_vars, ...envVars },
-      updated_at: new Date().toISOString(),
-    };
-
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(updated, null, 2)
-    );
-
-    return updated;
+    return this.options.deploymentLock(projectRef, deploymentId, async () => {
+      const deployment = await this.options.getDeployment(projectRef, deploymentId);
+      if (!deployment) return null;
+      const updated = {
+        ...deployment,
+        env_vars: { ...deployment.env_vars, ...envVars },
+        updated_at: new Date().toISOString(),
+      };
+      await this.options.writeDeployment(updated);
+      return updated;
+    });
   }
 
   async addCustomDomain(
     projectRef: string,
     deploymentId: string,
-    domain: string
+    domain: string,
   ): Promise<FrontendDeployment | null> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return null;
-
-    if (deployment.custom_domains.includes(domain)) {
-      return deployment;
-    }
-
-    const updated = {
-      ...deployment,
-      custom_domains: [...deployment.custom_domains, domain],
-      updated_at: new Date().toISOString(),
-    };
-
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(updated, null, 2)
-    );
-
-    const buildDir = this.joinPath(this.baseDir, projectRef, deploymentId, "build");
-    const defaults = FRAMEWORK_DEFAULTS[deployment.framework];
-    await this.configureGatewayRoute(updated, buildDir, defaults.is_ssr);
-
-    return updated;
+    return this.mutateCustomDomains(projectRef, deploymentId, (deployment) => {
+      if (deployment.custom_domains.includes(domain)) return null;
+      return [...deployment.custom_domains, domain];
+    });
   }
 
   async removeCustomDomain(
     projectRef: string,
     deploymentId: string,
-    domain: string
+    domain: string,
   ): Promise<FrontendDeployment | null> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return null;
+    return this.mutateCustomDomains(projectRef, deploymentId, (deployment) => {
+      if (!deployment.custom_domains.includes(domain)) return null;
+      return deployment.custom_domains.filter((candidate) => candidate !== domain);
+    });
+  }
 
-    const updated = {
-      ...deployment,
-      custom_domains: deployment.custom_domains.filter((d) => d !== domain),
-      updated_at: new Date().toISOString(),
-    };
-
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(updated, null, 2)
-    );
-
-    const buildDir = this.joinPath(this.baseDir, projectRef, deploymentId, "build");
-    const defaults = FRAMEWORK_DEFAULTS[deployment.framework];
-    await this.configureGatewayRoute(updated, buildDir, defaults.is_ssr);
-
-    return updated;
+  private async mutateCustomDomains(
+    projectRef: string,
+    deploymentId: string,
+    customDomains: (deployment: FrontendDeployment) => string[] | null,
+  ): Promise<FrontendDeployment | null> {
+    return this.options.deploymentLock(projectRef, deploymentId, async () => {
+      const deployment = await this.options.getDeployment(projectRef, deploymentId);
+      if (!deployment) return null;
+      const domains = customDomains(deployment);
+      if (!domains) return deployment;
+      const updated = {
+        ...deployment,
+        custom_domains: domains,
+        updated_at: new Date().toISOString(),
+      };
+      await this.options.commitHostMutation(deployment, updated);
+      return updated;
+    });
   }
 
   async createDeployToken(
     projectRef: string,
     deploymentId: string,
-    name: string
+    name: string,
   ): Promise<{ id: string; token: string } | null> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return null;
-
-    const tokenId = crypto.randomUUID().substring(0, 8);
-    const token = `supa_deploy_${crypto.randomUUID().replace(/-/g, "")}`;
-
-    const deployToken = {
-      id: tokenId,
-      name,
-      token,
-      created_at: new Date().toISOString(),
-    };
-
-    const updated = {
-      ...deployment,
-      deploy_tokens: [...(deployment.deploy_tokens || []), deployToken],
-      updated_at: new Date().toISOString(),
-    };
-
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(updated, null, 2)
-    );
-
-    return { id: tokenId, token };
+    return this.options.deploymentLock(projectRef, deploymentId, async () => {
+      const deployment = await this.options.getDeployment(projectRef, deploymentId);
+      if (!deployment) return null;
+      const deployToken = newDeployToken(name);
+      await this.options.writeDeployment({
+        ...deployment,
+        deploy_tokens: [...(deployment.deploy_tokens || []), deployToken],
+        updated_at: new Date().toISOString(),
+      });
+      return { id: deployToken.id, token: deployToken.token };
+    });
   }
 
-  async listDeployTokens(projectRef: string, deploymentId: string): Promise<{ id: string; name: string; created_at: string; last_used_at?: string }[]> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
+  async listDeployTokens(
+    projectRef: string,
+    deploymentId: string,
+  ): Promise<{ id: string; name: string; created_at: string; last_used_at?: string }[]> {
+    const deployment = await this.options.getDeployment(projectRef, deploymentId);
     if (!deployment) return [];
-
-    return (deployment.deploy_tokens || []).map((t) => ({
-      id: t.id,
-      name: t.name,
-      created_at: t.created_at,
-      last_used_at: t.last_used_at,
+    return (deployment.deploy_tokens || []).map((deployToken) => ({
+      id: deployToken.id,
+      name: deployToken.name,
+      created_at: deployToken.created_at,
+      last_used_at: deployToken.last_used_at,
     }));
   }
 
-  async deleteDeployToken(projectRef: string, deploymentId: string, tokenId: string): Promise<boolean> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return false;
-
-    const updated = {
-      ...deployment,
-      deploy_tokens: (deployment.deploy_tokens || []).filter((t) => t.id !== tokenId),
-      updated_at: new Date().toISOString(),
-    };
-
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(updated, null, 2)
-    );
-
-    return true;
+  async deleteDeployToken(
+    projectRef: string,
+    deploymentId: string,
+    tokenId: string,
+  ): Promise<boolean> {
+    return this.options.deploymentLock(projectRef, deploymentId, async () => {
+      const deployment = await this.options.getDeployment(projectRef, deploymentId);
+      if (!deployment) return false;
+      await this.options.writeDeployment({
+        ...deployment,
+        deploy_tokens: (deployment.deploy_tokens || []).filter((deployToken) => deployToken.id !== tokenId),
+        updated_at: new Date().toISOString(),
+      });
+      return true;
+    });
   }
 
-  async verifyDeployToken(projectRef: string, deploymentId: string, token: string): Promise<boolean> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return false;
-
-    const foundToken = (deployment.deploy_tokens || []).find((t) => t.token === token);
-    if (!foundToken) return false;
-
-    foundToken.last_used_at = new Date().toISOString();
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(deployment, null, 2)
-    );
-
-    return true;
+  async verifyDeployToken(
+    projectRef: string,
+    deploymentId: string,
+    token: string,
+  ): Promise<boolean> {
+    return this.options.deploymentLock(projectRef, deploymentId, async () => {
+      const deployment = await this.options.getDeployment(projectRef, deploymentId);
+      if (!deployment) return false;
+      const foundToken = (deployment.deploy_tokens || []).find((candidate) => candidate.token === token);
+      if (!foundToken) return false;
+      const lastUsedAt = new Date().toISOString();
+      await this.options.writeDeployment({
+        ...deployment,
+        deploy_tokens: (deployment.deploy_tokens || []).map((candidate) => (
+          candidate.id === foundToken.id ? { ...candidate, last_used_at: lastUsedAt } : candidate
+        )),
+        updated_at: lastUsedAt,
+      });
+      return true;
+    });
   }
 
   async setGitConfig(
     projectRef: string,
     deploymentId: string,
     gitUrl: string,
-    branch: string
+    branch: string,
   ): Promise<FrontendDeployment | null> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return null;
-
-    const updated = {
-      ...deployment,
-      git_url: gitUrl,
-      git_branch: branch,
-      updated_at: new Date().toISOString(),
-    };
-
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(updated, null, 2)
-    );
-
-    return updated;
+    return this.options.deploymentLock(projectRef, deploymentId, async () => {
+      const deployment = await this.options.getDeployment(projectRef, deploymentId);
+      if (!deployment) return null;
+      const updated = {
+        ...deployment,
+        git_url: gitUrl,
+        git_branch: branch,
+        updated_at: new Date().toISOString(),
+      };
+      await this.options.writeDeployment(updated);
+      return updated;
+    });
   }
 }

--- a/packages/management-api/src/services/frontend-release-activation.ts
+++ b/packages/management-api/src/services/frontend-release-activation.ts
@@ -1,0 +1,807 @@
+import type { FrontendDeployment } from "../types/frontend";
+import {
+  assertActivationCheckpointIdentity,
+  assertExpectedActiveReleaseId,
+  assertExpectedFrontendActivationId,
+  assertFrontendIdentity,
+  assertReleaseId,
+  FRONTEND_ACTIVE_RELEASE_SCHEMA,
+  FRONTEND_ACTIVATION_CHECKPOINT_SCHEMA,
+  MUTATION_ID_PATTERN,
+  RELEASE_ID_PATTERN,
+  frontendReleaseError,
+  isFrontendGatewayDurabilityUnknown,
+  parseActivationCheckpoint,
+  type ActivateFrontendReleaseInput,
+  type FrontendActivationCheckpoint,
+  type FrontendActiveReleaseRecord,
+  type FrontendReleaseActivation,
+  type FrontendReleaseGateway,
+  type FrontendReleaseRecord,
+  type FrontendReleaseStoragePort,
+} from "./frontend-release-contract";
+import {
+  frontendReleaseMutationStore,
+  type FrontendReleaseMutationStore,
+} from "./frontend-release-mutation";
+import {
+  projectMutationFingerprint,
+  projectMutationResourceKey,
+  type ProjectMutationState,
+} from "./project-mutation.service";
+import {
+  withFrontendDeploymentLock,
+  type FrontendDeploymentLock,
+} from "./frontend-deployment-lock";
+
+const MUTATION_LEASE_SECONDS = 300;
+
+export function frontendReleaseActivationResourceKey(deploymentId: string): string {
+  return projectMutationResourceKey({ type: "frontend_release", id: deploymentId });
+}
+
+export function frontendReleaseActivationFingerprint(input: ActivateFrontendReleaseInput): string {
+  return projectMutationFingerprint({
+    project_ref: input.projectRef,
+    deployment_id: input.deploymentId,
+    release_id: input.releaseId,
+    expected_active_release_id: input.expectedActiveReleaseId,
+    activation_id: input.mutationId,
+    expected_activation_id: input.expectedActivationId,
+  });
+}
+
+export interface ClaimedActivation {
+  leaseToken: string;
+  fencingEpoch: number;
+  replayed: boolean;
+  preparedNow: boolean;
+  checkpoint: FrontendActivationCheckpoint | null;
+}
+
+interface FrontendReleaseActivationOptions {
+  storage: FrontendReleaseStoragePort;
+  gateway: FrontendReleaseGateway;
+  mutations?: FrontendReleaseMutationStore;
+  deploymentLock?: FrontendDeploymentLock;
+  now?: () => Date;
+  interruption?: (phase: "after_prepared" | "after_authority" | "after_route") => void;
+}
+
+function desiredAuthority(
+  input: ActivateFrontendReleaseInput,
+  release: FrontendReleaseRecord,
+  activatedAt: string,
+): FrontendActiveReleaseRecord {
+  return {
+    schema: FRONTEND_ACTIVE_RELEASE_SCHEMA,
+    project_ref: input.projectRef,
+    deployment_id: input.deploymentId,
+    release_id: release.release_id,
+    sha256: release.sha256,
+    tree_sha256: release.tree_sha256,
+    activation_id: input.mutationId,
+    activated_at: activatedAt,
+    mutation_id: input.mutationId,
+  };
+}
+
+function receipt(input: ActivateFrontendReleaseInput, release: FrontendReleaseRecord): Record<string, unknown> {
+  return {
+    project_ref: input.projectRef,
+    deployment_id: input.deploymentId,
+    active_release_id: release.release_id,
+    release_id: release.release_id,
+    sha256: release.sha256,
+    tree_sha256: release.tree_sha256,
+    activation_id: input.mutationId,
+  };
+}
+
+function activationResponse(
+  input: ActivateFrontendReleaseInput,
+  release: FrontendReleaseRecord,
+  replayed: boolean,
+): FrontendReleaseActivation {
+  return {
+    project_ref: input.projectRef,
+    deployment_id: input.deploymentId,
+    active_release_id: release.release_id,
+    activation_id: input.mutationId,
+    release,
+    mutation: { mutation_id: input.mutationId, status: "succeeded", replayed },
+  };
+}
+
+function checkpointMatchesInput(
+  checkpoint: FrontendActivationCheckpoint,
+  input: ActivateFrontendReleaseInput,
+): boolean {
+  return checkpoint.deployment_id === input.deploymentId
+    && checkpoint.release_id === input.releaseId
+    && checkpoint.expected_active_release_id === input.expectedActiveReleaseId
+    && checkpoint.activation_id === input.mutationId
+    && checkpoint.expected_activation_id === input.expectedActivationId;
+}
+
+function recordsExactlyMatch(
+  candidate: Record<string, unknown> | null,
+  expected: Record<string, unknown>,
+): boolean {
+  if (!candidate) return false;
+  const candidateKeys = Object.keys(candidate);
+  const expectedKeys = Object.keys(expected);
+  return candidateKeys.length === expectedKeys.length
+    && candidateKeys.every((key) => Object.hasOwn(expected, key) && candidate[key] === expected[key]);
+}
+
+export class FrontendReleaseActivationService {
+  private readonly storage: FrontendReleaseStoragePort;
+  private readonly gateway: FrontendReleaseGateway;
+  private readonly mutations: FrontendReleaseMutationStore;
+  private readonly deploymentLock: FrontendDeploymentLock;
+  private readonly now: () => Date;
+  private readonly interruption?: FrontendReleaseActivationOptions["interruption"];
+
+  constructor(options: FrontendReleaseActivationOptions) {
+    this.storage = options.storage;
+    this.gateway = options.gateway;
+    this.mutations = options.mutations ?? frontendReleaseMutationStore();
+    this.deploymentLock = options.deploymentLock ?? withFrontendDeploymentLock;
+    this.now = options.now ?? (() => new Date());
+    this.interruption = options.interruption;
+  }
+
+  private assertInput(input: ActivateFrontendReleaseInput): void {
+    assertFrontendIdentity(input.projectRef, input.deploymentId);
+    assertReleaseId(input.releaseId);
+    assertExpectedActiveReleaseId(input.expectedActiveReleaseId);
+    assertExpectedFrontendActivationId(input.expectedActivationId);
+    if (!MUTATION_ID_PATTERN.test(input.mutationId)) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_MUTATION_ID_INVALID",
+        400,
+        "mutation_id must be a UUIDv4",
+      );
+    }
+  }
+
+  private async claim(
+    input: ActivateFrontendReleaseInput,
+    initialCheckpoint?: FrontendActivationCheckpoint,
+  ): Promise<ClaimedActivation> {
+    const leaseToken = crypto.randomUUID();
+    const { begun, claimed } = await this.mutations.beginAndClaim({
+      projectRef: input.projectRef,
+      mutationId: input.mutationId,
+      operation: "frontend.release.activate",
+      resource: { type: "frontend_release", id: input.deploymentId },
+      requestFingerprint: frontendReleaseActivationFingerprint(input),
+      principal: input.principal,
+    }, {
+      leaseOwner: `management-api:frontend-release:${process.pid}`,
+      leaseToken,
+      leaseSeconds: MUTATION_LEASE_SECONDS,
+      ...(initialCheckpoint ? { initialCheckpoint: { ...initialCheckpoint } } : {}),
+    });
+    if (begun.kind === "fingerprint_conflict" || begun.kind === "principal_conflict") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_MUTATION_CONFLICT",
+        409,
+        "Frontend release mutation identity conflicts with an existing request",
+      );
+    }
+    if (begun.kind === "resource_busy") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_BUSY",
+        409,
+        "Another frontend release activation is still unresolved",
+      );
+    }
+    if (begun.kind === "replay" && begun.mutation.status === "succeeded") {
+      return {
+        leaseToken: "",
+        fencingEpoch: begun.mutation.fencingEpoch,
+        replayed: true,
+        preparedNow: false,
+        checkpoint: parseActivationCheckpoint(begun.mutation.checkpoint),
+      };
+    }
+    if (begun.kind === "replay" && ["failed_terminal", "outcome_unknown"].includes(begun.mutation.status)) {
+      const code = begun.mutation.status === "outcome_unknown"
+        ? "FRONTEND_RELEASE_OUTCOME_UNKNOWN"
+        : "FRONTEND_RELEASE_MUTATION_FAILED";
+      throw frontendReleaseError(code, 409, "Frontend release mutation is already terminal");
+    }
+    if (!claimed) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release mutation could not be claimed",
+      );
+    }
+    if (claimed.kind === "busy") {
+      throw frontendReleaseError("FRONTEND_RELEASE_BUSY", 409, "Frontend release activation is already running");
+    }
+    if (claimed.kind === "not_found") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release mutation could not be read back",
+      );
+    }
+    if (claimed.kind === "terminal") {
+      if (claimed.mutation.status === "succeeded") {
+        return {
+          leaseToken: "",
+          fencingEpoch: claimed.mutation.fencingEpoch,
+          replayed: true,
+          preparedNow: false,
+          checkpoint: parseActivationCheckpoint(claimed.mutation.checkpoint),
+        };
+      }
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_MUTATION_FAILED",
+        409,
+        "Frontend release mutation is already terminal",
+      );
+    }
+    const checkpoint = parseActivationCheckpoint(claimed.mutation.checkpoint);
+    if (checkpoint) {
+      assertActivationCheckpointIdentity(checkpoint, {
+        projectRef: input.projectRef,
+        mutationId: input.mutationId,
+      });
+      if (!checkpointMatchesInput(checkpoint, input)) {
+        throw frontendReleaseError(
+          "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+          503,
+          "Frontend release activation checkpoint does not match the request",
+        );
+      }
+    }
+    return {
+      leaseToken,
+      fencingEpoch: claimed.mutation.fencingEpoch,
+      replayed: false,
+      preparedNow: begun.kind === "started",
+      checkpoint,
+    };
+  }
+
+  private async saveCheckpoint(
+    input: ActivateFrontendReleaseInput,
+    claim: ClaimedActivation,
+    checkpoint: FrontendActivationCheckpoint,
+  ): Promise<void> {
+    const updated = await this.mutations.checkpoint({
+      projectRef: input.projectRef,
+      mutationId: input.mutationId,
+      leaseToken: claim.leaseToken,
+      fencingEpoch: claim.fencingEpoch,
+      checkpoint: { ...checkpoint },
+      leaseSeconds: MUTATION_LEASE_SECONDS,
+    });
+    if (updated !== "updated") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release activation lease was lost",
+      );
+    }
+  }
+
+  private async withLease<T>(
+    input: ActivateFrontendReleaseInput,
+    claim: ClaimedActivation,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const executed = await this.mutations.withLease({
+      projectRef: input.projectRef,
+      mutationId: input.mutationId,
+      leaseToken: claim.leaseToken,
+      fencingEpoch: claim.fencingEpoch,
+    }, operation);
+    if (executed.kind === "lease_lost") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release activation lease was lost",
+      );
+    }
+    return executed.value;
+  }
+
+  private async currentRouteKind(
+    input: ActivateFrontendReleaseInput,
+    currentActive: FrontendActiveReleaseRecord | null,
+  ): Promise<"absent" | "legacy" | "release"> {
+    const currentRoot = await this.gateway.readFrontendStaticRoot(input.projectRef, input.deploymentId);
+    if (currentActive) {
+      const expectedRoot = this.storage.releaseBuildDir(
+        input.projectRef,
+        input.deploymentId,
+        currentActive.release_id,
+      );
+      if (currentRoot !== expectedRoot) this.readbackMismatch();
+      return "release";
+    }
+    if (currentRoot === null) return "absent";
+    if (currentRoot === this.storage.legacyBuildDir(input.projectRef, input.deploymentId)) return "legacy";
+    this.readbackMismatch();
+  }
+
+  private readbackMismatch(): never {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_READBACK_MISMATCH",
+      503,
+      "Frontend active release and Caddy route do not match",
+    );
+  }
+
+  private recoveryStateUnknown(): never {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+      503,
+      "Frontend activation checkpoint and live state cannot be reconciled",
+    );
+  }
+
+  private async preparedCheckpoint(
+    input: ActivateFrontendReleaseInput,
+    currentActive: FrontendActiveReleaseRecord | null,
+  ): Promise<FrontendActivationCheckpoint> {
+    const currentReleaseId = currentActive?.release_id ?? "absent";
+    const currentActivationId = currentActive?.activation_id ?? "absent";
+    if (currentReleaseId !== input.expectedActiveReleaseId
+      || currentActivationId !== input.expectedActivationId) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_REVISION_CONFLICT",
+        409,
+        "Frontend active release revision conflict",
+      );
+    }
+    const previousRoute = await this.currentRouteKind(input, currentActive);
+    return {
+      schema: FRONTEND_ACTIVATION_CHECKPOINT_SCHEMA,
+      phase: "prepared",
+      deployment_id: input.deploymentId,
+      release_id: input.releaseId,
+      expected_active_release_id: input.expectedActiveReleaseId,
+      activation_id: input.mutationId,
+      expected_activation_id: input.expectedActivationId,
+      activated_at: this.now().toISOString(),
+      previous_authority: currentActive,
+      previous_route: previousRoute,
+    };
+  }
+
+  private async reconciledCheckpoint(
+    input: ActivateFrontendReleaseInput,
+    checkpoint: FrontendActivationCheckpoint,
+  ): Promise<FrontendActivationCheckpoint> {
+    const active = await this.storage.activeRelease(input.projectRef, input.deploymentId);
+    const activeReleaseId = active?.release_id ?? "absent";
+    const activeActivationId = active?.activation_id ?? "absent";
+    const previousMatches = activeReleaseId === checkpoint.expected_active_release_id
+      && activeActivationId === checkpoint.expected_activation_id;
+    const desiredMatches = activeReleaseId === checkpoint.release_id
+      && activeActivationId === checkpoint.activation_id;
+    if (!previousMatches && !desiredMatches) this.recoveryStateUnknown();
+    const currentRoot = await this.gateway.readFrontendStaticRoot(input.projectRef, input.deploymentId);
+    const desiredRoot = this.storage.releaseBuildDir(input.projectRef, input.deploymentId, checkpoint.release_id);
+    const previousRoot = this.previousRoot(input, checkpoint);
+    if (previousMatches) {
+      if (currentRoot !== previousRoot) this.recoveryStateUnknown();
+      return { ...checkpoint, phase: "prepared" };
+    }
+    if (currentRoot === desiredRoot) return { ...checkpoint, phase: "route_applied" };
+    if (currentRoot === previousRoot) return { ...checkpoint, phase: "authority_applied" };
+    return this.recoveryStateUnknown();
+  }
+
+  private async configureDesiredRoute(
+    deployment: FrontendDeployment,
+    release: FrontendReleaseRecord,
+  ): Promise<void> {
+    const route = {
+      projectRef: deployment.project_ref,
+      deploymentId: deployment.id,
+      hosts: [deployment.domain, ...deployment.custom_domains],
+      root: this.storage.releaseBuildDir(deployment.project_ref, deployment.id, release.release_id),
+      mode: "static" as const,
+    };
+    await this.gateway.configureFrontendRoute(route);
+  }
+
+  private previousRoot(input: ActivateFrontendReleaseInput, checkpoint: FrontendActivationCheckpoint): string | null {
+    if (checkpoint.previous_route === "absent") return null;
+    if (checkpoint.previous_route === "legacy") {
+      return this.storage.legacyBuildDir(input.projectRef, input.deploymentId);
+    }
+    return this.storage.releaseBuildDir(
+      input.projectRef,
+      input.deploymentId,
+      checkpoint.previous_authority!.release_id,
+    );
+  }
+
+  private async restorePreviousAuthority(
+    input: ActivateFrontendReleaseInput,
+    checkpoint: FrontendActivationCheckpoint,
+  ): Promise<void> {
+    const restored = await this.storage.compareAndSwapActiveRelease(
+      input.projectRef,
+      input.deploymentId,
+      checkpoint.release_id,
+      checkpoint.activation_id,
+      checkpoint.previous_authority,
+    );
+    if (restored !== "updated") this.readbackMismatch();
+  }
+
+  private async handleRouteFailure(
+    input: ActivateFrontendReleaseInput,
+    checkpoint: FrontendActivationCheckpoint,
+    routeError: unknown,
+  ): Promise<void> {
+    if (isFrontendGatewayDurabilityUnknown(routeError)) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend route durability could not be proven",
+      );
+    }
+    let liveRoot: string | null;
+    try {
+      liveRoot = await this.gateway.readFrontendStaticRoot(input.projectRef, input.deploymentId);
+    } catch {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend route outcome could not be proven",
+      );
+    }
+    const desiredRoot = this.storage.releaseBuildDir(input.projectRef, input.deploymentId, checkpoint.release_id);
+    if (liveRoot === desiredRoot) return;
+    if (liveRoot === this.previousRoot(input, checkpoint)) {
+      await this.restorePreviousAuthority(input, checkpoint);
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_ROUTE_REJECTED",
+        503,
+        "Frontend route change failed and the previous release remains authoritative",
+      );
+    }
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+      503,
+      "Frontend route outcome could not be proven",
+    );
+  }
+
+  private async ensureAuthority(
+    input: ActivateFrontendReleaseInput,
+    release: FrontendReleaseRecord,
+    checkpoint: FrontendActivationCheckpoint,
+  ): Promise<void> {
+    const current = await this.storage.activeRelease(input.projectRef, input.deploymentId);
+    if (current?.release_id === release.release_id && current.mutation_id === input.mutationId
+      && current.activation_id === input.mutationId) return;
+    const expected = current?.release_id ?? "absent";
+    const expectedActivation = current?.activation_id ?? "absent";
+    if (expected !== checkpoint.expected_active_release_id
+      || expectedActivation !== checkpoint.expected_activation_id) this.readbackMismatch();
+    await this.storage.writeActiveRelease(
+      input.projectRef,
+      input.deploymentId,
+      desiredAuthority(input, release, checkpoint.activated_at),
+    );
+  }
+
+  private async verifiedActivation(
+    input: ActivateFrontendReleaseInput,
+    release: FrontendReleaseRecord,
+    checkpoint: FrontendActivationCheckpoint,
+  ): Promise<void> {
+    const active = await this.storage.activeRelease(input.projectRef, input.deploymentId);
+    const root = await this.gateway.readFrontendStaticRoot(input.projectRef, input.deploymentId);
+    const expectedRoot = this.storage.releaseBuildDir(input.projectRef, input.deploymentId, release.release_id);
+    const expectedAuthority = desiredAuthority(input, release, checkpoint.activated_at);
+    if (!recordsExactlyMatch(
+      active as unknown as Record<string, unknown> | null,
+      expectedAuthority as unknown as Record<string, unknown>,
+    )
+      || root !== expectedRoot) this.readbackMismatch();
+    const storedRelease = await this.storage.releaseRecord(
+      input.projectRef,
+      input.deploymentId,
+      release.release_id,
+    );
+    if (!recordsExactlyMatch(
+      storedRelease as unknown as Record<string, unknown>,
+      release as unknown as Record<string, unknown>,
+    )) this.readbackMismatch();
+  }
+
+  private async applyPhases(
+    input: ActivateFrontendReleaseInput,
+    deployment: FrontendDeployment,
+    release: FrontendReleaseRecord,
+    claim: ClaimedActivation,
+    initialCheckpoint: FrontendActivationCheckpoint,
+  ): Promise<void> {
+    let checkpoint = await this.reconciledCheckpoint(input, initialCheckpoint);
+    if (checkpoint.phase !== initialCheckpoint.phase) await this.saveCheckpoint(input, claim, checkpoint);
+    if (checkpoint.phase === "prepared") {
+      await this.withLease(input, claim, () => this.ensureAuthority(input, release, checkpoint));
+      checkpoint = { ...checkpoint, phase: "authority_applied" };
+      await this.saveCheckpoint(input, claim, checkpoint);
+      this.interruption?.("after_authority");
+    }
+    if (checkpoint.phase === "authority_applied") {
+      await this.withLease(input, claim, async () => {
+        try {
+          await this.configureDesiredRoute(deployment, release);
+        } catch (error: unknown) {
+          await this.handleRouteFailure(input, checkpoint, error);
+        }
+      });
+      checkpoint = { ...checkpoint, phase: "route_applied" };
+      await this.saveCheckpoint(input, claim, checkpoint);
+      this.interruption?.("after_route");
+    }
+    await this.withLease(input, claim, () => this.verifiedActivation(input, release, checkpoint));
+  }
+
+  private async resolveSuccessfulReplay(
+    input: ActivateFrontendReleaseInput,
+    release: FrontendReleaseRecord,
+  ): Promise<FrontendReleaseActivation> {
+    await this.verifiedSuccessfulMutation(input, release);
+    return activationResponse(input, release, true);
+  }
+
+  private successJournalInvalid(): never {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+      503,
+      "Frontend release success journal is invalid",
+    );
+  }
+
+  private successfulCheckpoint(
+    mutation: ProjectMutationState,
+    input: ActivateFrontendReleaseInput,
+  ): FrontendActivationCheckpoint {
+    const checkpoint = parseActivationCheckpoint(mutation.checkpoint);
+    if (!checkpoint) return this.successJournalInvalid();
+    assertActivationCheckpointIdentity(checkpoint, {
+      projectRef: input.projectRef,
+      mutationId: input.mutationId,
+    });
+    if (checkpoint.phase !== "route_applied" || !checkpointMatchesInput(checkpoint, input)) {
+      return this.successJournalInvalid();
+    }
+    return checkpoint;
+  }
+
+  private successfulMutationMatches(
+    mutation: ProjectMutationState,
+    input: ActivateFrontendReleaseInput,
+    release: FrontendReleaseRecord,
+  ): boolean {
+    return mutation.projectRef === input.projectRef
+      && mutation.mutationId === input.mutationId
+      && mutation.operation === "frontend.release.activate"
+      && mutation.resourceKey === frontendReleaseActivationResourceKey(input.deploymentId)
+      && mutation.requestFingerprint === frontendReleaseActivationFingerprint(input)
+      && mutation.principal.type === input.principal.type
+      && mutation.principal.id === input.principal.id
+      && mutation.status === "succeeded"
+      && mutation.responseStatus === 200
+      && mutation.failureCode === null
+      && recordsExactlyMatch(mutation.receipt, receipt(input, release));
+  }
+
+  private async verifiedSuccessfulMutation(
+    input: ActivateFrontendReleaseInput,
+    release: FrontendReleaseRecord,
+  ): Promise<void> {
+    const mutation = await this.mutations.read(input.projectRef, input.mutationId);
+    if (!mutation || !this.successfulMutationMatches(mutation, input, release)) {
+      return this.successJournalInvalid();
+    }
+    const checkpoint = this.successfulCheckpoint(mutation, input);
+    await this.verifiedActivation(input, release, checkpoint);
+  }
+
+  private async completeSuccess(
+    input: ActivateFrontendReleaseInput,
+    release: FrontendReleaseRecord,
+    claim: ClaimedActivation,
+  ): Promise<void> {
+    const completed = await this.mutations.completeSuccess({
+      projectRef: input.projectRef,
+      mutationId: input.mutationId,
+      leaseToken: claim.leaseToken,
+      fencingEpoch: claim.fencingEpoch,
+      receipt: receipt(input, release),
+      responseStatus: 200,
+    });
+    if (completed !== "updated") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release success could not be recorded",
+      );
+    }
+    await this.verifiedSuccessfulMutation(input, release);
+  }
+
+  private async completeRevisionConflict(
+    input: ActivateFrontendReleaseInput,
+    claim: ClaimedActivation,
+  ): Promise<void> {
+    const completed = await this.mutations.completeFailure({
+      projectRef: input.projectRef,
+      mutationId: input.mutationId,
+      leaseToken: claim.leaseToken,
+      fencingEpoch: claim.fencingEpoch,
+      status: "failed_terminal",
+      failureCode: "ACTIVE_RELEASE_CONFLICT",
+      responseStatus: 409,
+      receipt: {
+        project_ref: input.projectRef,
+        deployment_id: input.deploymentId,
+        release_id: input.releaseId,
+        expected_active_release_id: input.expectedActiveReleaseId,
+        activation_id: input.mutationId,
+        expected_activation_id: input.expectedActivationId,
+      },
+    });
+    if (completed !== "updated") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release mutation completion could not be proven",
+      );
+    }
+  }
+
+  private terminalState(error: unknown): error is Error & { code: string } {
+    return error instanceof Error && "code" in error
+      && ["FRONTEND_RELEASE_REVISION_CONFLICT", "FRONTEND_RELEASE_MUTATION_CONFLICT"].includes(
+        String((error as Error & { code?: unknown }).code),
+      );
+  }
+
+  private async preserveRecoverableFailure(
+    input: ActivateFrontendReleaseInput,
+    claim: ClaimedActivation,
+    error: unknown,
+  ): Promise<never> {
+    const terminal = await this.mutations.read(input.projectRef, input.mutationId).catch(() => null);
+    if (terminal?.status === "succeeded") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release activation succeeded but its response could not be proven",
+      );
+    }
+    const unknown = error instanceof Error && "code" in error
+      && String((error as Error & { code?: unknown }).code) === "FRONTEND_RELEASE_OUTCOME_UNKNOWN";
+    const routeRejected = error instanceof Error && "code" in error
+      && String((error as Error & { code?: unknown }).code) === "FRONTEND_RELEASE_ROUTE_REJECTED";
+    const completed = await this.mutations.completeFailure({
+      projectRef: input.projectRef,
+      mutationId: input.mutationId,
+      leaseToken: claim.leaseToken,
+      fencingEpoch: claim.fencingEpoch,
+      status: unknown ? "outcome_unknown" : routeRejected ? "failed_terminal" : "failed_retryable",
+      failureCode: unknown ? "ROUTE_OUTCOME_UNKNOWN"
+        : routeRejected ? "ROUTE_APPLY_REJECTED" : "ACTIVATION_INTERRUPTED",
+      responseStatus: 503,
+      ...(unknown || routeRejected ? {} : { recoveryNotBefore: this.now() }),
+      receipt: {
+        project_ref: input.projectRef,
+        deployment_id: input.deploymentId,
+        release_id: input.releaseId,
+        expected_active_release_id: input.expectedActiveReleaseId,
+        activation_id: input.mutationId,
+        expected_activation_id: input.expectedActivationId,
+      },
+    });
+    if (completed !== "updated") {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+        503,
+        "Frontend release activation outcome is unknown",
+      );
+    }
+    if (this.terminalState(error) || unknown || routeRejected) throw error;
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_ACTIVATION_RETRYABLE",
+      503,
+      "Frontend release activation was interrupted and can be retried with the same mutation_id",
+    );
+  }
+
+  private async executeClaimed(
+    input: ActivateFrontendReleaseInput,
+    claim: ClaimedActivation,
+    preparedDeployment?: FrontendDeployment,
+    preparedRelease?: FrontendReleaseRecord,
+  ): Promise<FrontendReleaseActivation> {
+    this.assertInput(input);
+    try {
+      const deployment = preparedDeployment
+        ?? await this.storage.deployment(input.projectRef, input.deploymentId);
+      const release = preparedRelease
+        ?? await this.storage.releaseRecord(input.projectRef, input.deploymentId, input.releaseId);
+      if (claim.replayed) return this.resolveSuccessfulReplay(input, release);
+      let checkpoint = claim.checkpoint;
+      if (claim.preparedNow && checkpoint) this.interruption?.("after_prepared");
+      if (!checkpoint) {
+        checkpoint = await this.preparedCheckpoint(
+          input,
+          await this.storage.activeRelease(input.projectRef, input.deploymentId),
+        );
+        await this.saveCheckpoint(input, claim, checkpoint);
+        this.interruption?.("after_prepared");
+      }
+      await this.applyPhases(input, deployment, release, claim, checkpoint);
+      await this.completeSuccess(input, release, claim);
+      return activationResponse(input, release, false);
+    } catch (error: unknown) {
+      if (error instanceof Error && "code" in error
+        && String((error as Error & { code?: unknown }).code) === "FRONTEND_RELEASE_REVISION_CONFLICT") {
+        await this.completeRevisionConflict(input, claim);
+        throw error;
+      }
+      return this.preserveRecoverableFailure(input, claim, error);
+    }
+  }
+
+  async activate(input: ActivateFrontendReleaseInput): Promise<FrontendReleaseActivation> {
+    this.assertInput(input);
+    const existing = await this.mutations.read(input.projectRef, input.mutationId);
+    if (existing) {
+      const storedCheckpoint = parseActivationCheckpoint(existing.checkpoint);
+      if (storedCheckpoint) {
+        assertActivationCheckpointIdentity(storedCheckpoint, {
+          projectRef: input.projectRef,
+          mutationId: input.mutationId,
+        });
+        if (!checkpointMatchesInput(storedCheckpoint, input)) {
+          throw frontendReleaseError(
+            "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+            503,
+            "Frontend release activation checkpoint does not match the request",
+          );
+        }
+      }
+    }
+    const deployment = await this.storage.deployment(input.projectRef, input.deploymentId);
+    const release = await this.storage.releaseRecord(input.projectRef, input.deploymentId, input.releaseId);
+    const checkpoint = existing ? undefined : await this.preparedCheckpoint(
+      input,
+      await this.storage.activeRelease(input.projectRef, input.deploymentId),
+    );
+    return this.executeClaimed(input, await this.claim(input, checkpoint), deployment, release);
+  }
+
+  async resume(
+    input: ActivateFrontendReleaseInput,
+    claim: ClaimedActivation,
+  ): Promise<FrontendReleaseActivation> {
+    if (claim.replayed || !claim.leaseToken || claim.fencingEpoch < 1) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+        503,
+        "Frontend release recovery claim is invalid",
+      );
+    }
+    return this.deploymentLock(input.projectRef, input.deploymentId, () =>
+      this.executeClaimed(input, claim));
+  }
+}

--- a/packages/management-api/src/services/frontend-release-archive.ts
+++ b/packages/management-api/src/services/frontend-release-archive.ts
@@ -1,0 +1,415 @@
+import { constants as fsConstants } from "node:fs";
+import { mkdir, open, unlink, type FileHandle } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { Readable } from "node:stream";
+import { createInflateRaw } from "node:zlib";
+import {
+  FRONTEND_RELEASE_MAX_FILES,
+  FRONTEND_RELEASE_MAX_UNCOMPRESSED_BYTES,
+  frontendReleaseError,
+} from "./frontend-release-contract";
+
+const ZIP_LOCAL_HEADER = 0x04034b50;
+const ZIP_CENTRAL_HEADER = 0x02014b50;
+const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50;
+const ZIP_DATA_DESCRIPTOR = 0x08074b50;
+const ZIP_ALLOWED_FLAGS = 0x080e;
+const ZIP_MAX_END_RECORD_BYTES = 65_557;
+const ARCHIVE_CHUNK_BYTES = 64 * 1024;
+
+export interface VerifiedZipFileEntry {
+  path: string;
+  compressedSize: number;
+  uncompressedSize: number;
+  localHeaderOffset: number;
+  dataOffset: number;
+  dataEnd: number;
+  recordEnd: number;
+  crc32: number;
+  flags: number;
+  compression: number;
+}
+
+interface ArchiveIdentity {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+}
+
+export interface VerifiedZipArchive {
+  readonly size: number;
+  readonly identity: ArchiveIdentity;
+  readonly entries: readonly VerifiedZipFileEntry[];
+}
+
+interface ZipCentralDirectory {
+  offset: number;
+  size: number;
+  entries: number;
+}
+
+function invalidZip(message: string): never {
+  throw frontendReleaseError("FRONTEND_RELEASE_ARCHIVE_INVALID", 400, message);
+}
+
+function archiveIdentity(metadata: Awaited<ReturnType<FileHandle["stat"]>>): ArchiveIdentity {
+  if (!metadata.isFile()) invalidZip("Frontend release archive must be a regular file");
+  return {
+    dev: Number(metadata.dev),
+    ino: Number(metadata.ino),
+    size: Number(metadata.size),
+    mtimeMs: Number(metadata.mtimeMs),
+    ctimeMs: Number(metadata.ctimeMs),
+  };
+}
+
+function sameArchive(left: ArchiveIdentity, right: ArchiveIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino && left.size === right.size
+    && left.mtimeMs === right.mtimeMs && left.ctimeMs === right.ctimeMs;
+}
+
+async function assertArchiveIdentity(handle: FileHandle, expected: ArchiveIdentity): Promise<void> {
+  if (!sameArchive(expected, archiveIdentity(await handle.stat()))) {
+    invalidZip("Frontend release archive changed while it was verified");
+  }
+}
+
+async function readExactly(handle: FileHandle, offset: number, length: number): Promise<Buffer> {
+  if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0) {
+    return invalidZip("Zip archive range is invalid");
+  }
+  const bytes = Buffer.allocUnsafe(length);
+  let readOffset = 0;
+  while (readOffset < length) {
+    const read = await handle.read(bytes, readOffset, length - readOffset, offset + readOffset);
+    if (read.bytesRead === 0) return invalidZip("Zip archive ended unexpectedly");
+    readOffset += read.bytesRead;
+  }
+  return bytes;
+}
+
+function endRecordOffset(tail: Buffer, archiveSize: number): number {
+  for (let offset = tail.byteLength - 22; offset >= 0; offset -= 1) {
+    if (tail.readUInt32LE(offset) === ZIP_END_OF_CENTRAL_DIRECTORY) {
+      return archiveSize - tail.byteLength + offset;
+    }
+  }
+  return invalidZip("Frontend release archive is not a supported zip file");
+}
+
+async function centralDirectory(handle: FileHandle, archiveSize: number): Promise<ZipCentralDirectory> {
+  const tailSize = Math.min(archiveSize, ZIP_MAX_END_RECORD_BYTES);
+  const tail = await readExactly(handle, archiveSize - tailSize, tailSize);
+  const endOffset = endRecordOffset(tail, archiveSize);
+  const recordOffset = endOffset - (archiveSize - tailSize);
+  const entries = tail.readUInt16LE(recordOffset + 10);
+  const size = tail.readUInt32LE(recordOffset + 12);
+  const offset = tail.readUInt32LE(recordOffset + 16);
+  const commentLength = tail.readUInt16LE(recordOffset + 20);
+  const zip64 = entries === 0xffff || size === 0xffffffff || offset === 0xffffffff;
+  if (tail.readUInt16LE(recordOffset + 4) !== 0 || tail.readUInt16LE(recordOffset + 6) !== 0
+    || tail.readUInt16LE(recordOffset + 8) !== entries || zip64
+    || endOffset + 22 + commentLength !== archiveSize || offset + size !== endOffset
+    || entries < 1 || entries > FRONTEND_RELEASE_MAX_FILES) {
+    invalidZip("Zip archive structure is unsupported or invalid");
+  }
+  return { offset, size, entries };
+}
+
+function zipEntryPath(nameBytes: Uint8Array, flags: number): string {
+  if (!nameBytes.every((byte) => byte < 0x80) && (flags & 0x0800) === 0) {
+    invalidZip("Zip entry names must use UTF-8");
+  }
+  let name: string;
+  try {
+    name = new TextDecoder("utf-8", { fatal: true }).decode(nameBytes);
+  } catch {
+    return invalidZip("Zip entry names must be valid UTF-8");
+  }
+  if (!name || name.length > 1024 || name.startsWith("/") || name.includes("\\")
+    || /[\u0000-\u001f\u007f]/u.test(name)) {
+    return invalidZip("Zip archive contains an unsafe path");
+  }
+  const directory = name.endsWith("/");
+  const segments = name.split("/");
+  if (directory) segments.pop();
+  if (segments.length === 0 || segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    return invalidZip("Zip archive contains an unsafe path");
+  }
+  return directory ? `${segments.join("/")}/` : segments.join("/");
+}
+
+function assertEntryType(madeBy: number, externalAttributes: number, path: string): void {
+  const hostSystem = madeBy >>> 8;
+  const unixFileType = hostSystem === 3 ? (externalAttributes >>> 16) & 0o170000 : 0;
+  if (unixFileType !== 0 && unixFileType !== 0o100000 && unixFileType !== 0o040000) {
+    invalidZip("Zip archive contains a non-regular file");
+  }
+  const directory = path.endsWith("/");
+  const declaredDirectory = unixFileType === 0o040000 || (externalAttributes & 0x10) !== 0;
+  if (declaredDirectory !== directory || (unixFileType === 0o100000 && directory)) {
+    invalidZip("Zip archive entry type is inconsistent");
+  }
+}
+
+async function centralEntry(
+  handle: FileHandle,
+  offset: number,
+  limit: number,
+): Promise<{
+  entry: Omit<VerifiedZipFileEntry, "dataOffset" | "dataEnd" | "recordEnd"> | null;
+  nextOffset: number;
+  path: string;
+}> {
+  if (offset + 46 > limit) invalidZip("Zip central directory is invalid");
+  const header = await readExactly(handle, offset, 46);
+  if (header.readUInt32LE(0) !== ZIP_CENTRAL_HEADER) invalidZip("Zip central directory is invalid");
+  const flags = header.readUInt16LE(8);
+  const compression = header.readUInt16LE(10);
+  const compressedSize = header.readUInt32LE(20);
+  const uncompressedSize = header.readUInt32LE(24);
+  const nameLength = header.readUInt16LE(28);
+  const extraLength = header.readUInt16LE(30);
+  const commentLength = header.readUInt16LE(32);
+  const localHeaderOffset = header.readUInt32LE(42);
+  const nextOffset = offset + 46 + nameLength + extraLength + commentLength;
+  if (nextOffset > limit || nameLength === 0 || nameLength > 4096 || header.readUInt16LE(34) !== 0
+    || compressedSize === 0xffffffff || uncompressedSize === 0xffffffff
+    || localHeaderOffset === 0xffffffff || (flags & ~ZIP_ALLOWED_FLAGS) !== 0
+    || (flags & 1) !== 0 || ![0, 8].includes(compression)) {
+    invalidZip("Zip archive uses unsupported features");
+  }
+  const path = zipEntryPath(await readExactly(handle, offset + 46, nameLength), flags);
+  assertEntryType(header.readUInt16LE(4), header.readUInt32LE(38), path);
+  return {
+    entry: path.endsWith("/") ? null : {
+      path,
+      compressedSize,
+      uncompressedSize,
+      localHeaderOffset,
+      crc32: header.readUInt32LE(16),
+      flags,
+      compression,
+    },
+    nextOffset,
+    path,
+  };
+}
+
+async function dataDescriptorEnd(
+  handle: FileHandle,
+  dataEnd: number,
+  centralOffset: number,
+  entry: Omit<VerifiedZipFileEntry, "dataOffset" | "dataEnd" | "recordEnd">,
+): Promise<number> {
+  if ((entry.flags & 0x0008) === 0) return dataEnd;
+  if (dataEnd + 12 > centralOffset) invalidZip("Zip data descriptor is invalid");
+  const prefix = await readExactly(handle, dataEnd, 4);
+  const hasSignature = prefix.readUInt32LE(0) === ZIP_DATA_DESCRIPTOR;
+  const descriptorOffset = dataEnd + (hasSignature ? 4 : 0);
+  const recordEnd = descriptorOffset + 12;
+  if (recordEnd > centralOffset) invalidZip("Zip data descriptor is invalid");
+  const descriptor = await readExactly(handle, descriptorOffset, 12);
+  if (descriptor.readUInt32LE(0) !== entry.crc32
+    || descriptor.readUInt32LE(4) !== entry.compressedSize
+    || descriptor.readUInt32LE(8) !== entry.uncompressedSize) {
+    invalidZip("Zip data descriptor is invalid");
+  }
+  return recordEnd;
+}
+
+async function localEntryRange(
+  handle: FileHandle,
+  entry: Omit<VerifiedZipFileEntry, "dataOffset" | "dataEnd" | "recordEnd">,
+  centralOffset: number,
+): Promise<[number, number, number]> {
+  const offset = entry.localHeaderOffset;
+  if (offset + 30 > centralOffset) invalidZip("Zip local header is invalid");
+  const header = await readExactly(handle, offset, 30);
+  if (header.readUInt32LE(0) !== ZIP_LOCAL_HEADER) invalidZip("Zip local header is invalid");
+  const flags = header.readUInt16LE(6);
+  const compression = header.readUInt16LE(8);
+  const nameLength = header.readUInt16LE(26);
+  const extraLength = header.readUInt16LE(28);
+  const dataOffset = offset + 30 + nameLength + extraLength;
+  const dataEnd = dataOffset + entry.compressedSize;
+  if (nameLength === 0 || nameLength > 4096 || dataOffset > centralOffset || dataEnd > centralOffset) {
+    invalidZip("Zip local header is invalid");
+  }
+  const localName = zipEntryPath(await readExactly(handle, offset + 30, nameLength), flags);
+  const descriptor = (flags & 0x0008) !== 0;
+  const crcMatches = descriptor || header.readUInt32LE(14) === entry.crc32;
+  const sizesMatch = descriptor || (header.readUInt32LE(18) === entry.compressedSize
+    && header.readUInt32LE(22) === entry.uncompressedSize);
+  if (localName !== entry.path || flags !== entry.flags || compression !== entry.compression
+    || !crcMatches || !sizesMatch) {
+    invalidZip("Zip local and central records do not match");
+  }
+  return [dataOffset, dataEnd, await dataDescriptorEnd(handle, dataEnd, centralOffset, entry)];
+}
+
+function assertPathHierarchy(paths: readonly string[]): void {
+  const files = new Set(paths);
+  for (const path of paths) {
+    const segments = path.split("/");
+    segments.pop();
+    let ancestor = "";
+    for (const segment of segments) {
+      ancestor = ancestor ? `${ancestor}/${segment}` : segment;
+      if (files.has(ancestor)) invalidZip("Zip archive contains conflicting file and directory paths");
+    }
+  }
+}
+
+function assertNonOverlappingRanges(entries: readonly VerifiedZipFileEntry[]): void {
+  const ranges = entries.map((entry) => [entry.localHeaderOffset, entry.recordEnd] as const)
+    .sort((left, right) => left[0] - right[0]);
+  for (let index = 1; index < ranges.length; index += 1) {
+    if (ranges[index][0] < ranges[index - 1][1]) invalidZip("Zip archive entries overlap");
+  }
+}
+
+export async function verifiedZipArchive(
+  handle: FileHandle,
+  archiveSize: number,
+): Promise<VerifiedZipArchive> {
+  const identity = archiveIdentity(await handle.stat());
+  if (identity.size !== archiveSize || archiveSize < 22) invalidZip("Frontend release archive size is invalid");
+  const central = await centralDirectory(handle, archiveSize);
+  const centralLimit = central.offset + central.size;
+  const paths = new Set<string>();
+  const files: VerifiedZipFileEntry[] = [];
+  let totalBytes = 0;
+  let cursor = central.offset;
+  for (let index = 0; index < central.entries; index += 1) {
+    const parsed = await centralEntry(handle, cursor, centralLimit);
+    if (paths.has(parsed.path)) invalidZip("Zip archive contains duplicate paths");
+    paths.add(parsed.path);
+    if (parsed.entry) {
+      totalBytes += parsed.entry.uncompressedSize;
+      if (totalBytes > FRONTEND_RELEASE_MAX_UNCOMPRESSED_BYTES) {
+        invalidZip("Zip archive is incomplete or exceeds release limits");
+      }
+      const [dataOffset, dataEnd, recordEnd] = await localEntryRange(handle, parsed.entry, central.offset);
+      files.push({ ...parsed.entry, dataOffset, dataEnd, recordEnd });
+    }
+    cursor = parsed.nextOffset;
+  }
+  if (cursor !== centralLimit || files.length < 1 || !files.some((entry) => entry.path === "index.html")) {
+    invalidZip("Zip archive is incomplete or exceeds release limits");
+  }
+  assertPathHierarchy(files.map((entry) => entry.path));
+  assertNonOverlappingRanges(files);
+  await assertArchiveIdentity(handle, identity);
+  return { size: archiveSize, identity, entries: files };
+}
+
+async function* compressedChunks(
+  handle: FileHandle,
+  entry: VerifiedZipFileEntry,
+): AsyncGenerator<Buffer> {
+  let offset = entry.dataOffset;
+  while (offset < entry.dataEnd) {
+    const length = Math.min(ARCHIVE_CHUNK_BYTES, entry.dataEnd - offset);
+    yield await readExactly(handle, offset, length);
+    offset += length;
+  }
+}
+
+let crcTable: Uint32Array | undefined;
+
+function crc32Table(): Uint32Array {
+  if (crcTable) return crcTable;
+  crcTable = new Uint32Array(256);
+  for (let index = 0; index < 256; index += 1) {
+    let crc = index;
+    for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+    crcTable[index] = crc >>> 0;
+  }
+  return crcTable;
+}
+
+function updateCrc32(crc: number, bytes: Uint8Array): number {
+  const table = crc32Table();
+  let updated = crc;
+  for (const byte of bytes) updated = (updated >>> 8) ^ table[(updated ^ byte) & 0xff];
+  return updated >>> 0;
+}
+
+function isDeflateError(error: unknown): boolean {
+  if (!(error instanceof Error) || !("code" in error)) return false;
+  return ["Z_DATA_ERROR", "Z_BUF_ERROR", "Z_STREAM_ERROR"].includes(
+    String((error as Error & { code?: unknown }).code),
+  );
+}
+
+async function writeAll(output: FileHandle, bytes: Uint8Array): Promise<void> {
+  let offset = 0;
+  while (offset < bytes.byteLength) {
+    const written = await output.write(bytes, offset, bytes.byteLength - offset);
+    if (written.bytesWritten === 0) throw new Error("Frontend release extraction write made no progress");
+    offset += written.bytesWritten;
+  }
+}
+
+async function extractedChunks(
+  handle: FileHandle,
+  entry: VerifiedZipFileEntry,
+): Promise<AsyncIterable<Uint8Array>> {
+  const chunks = Readable.from(compressedChunks(handle, entry));
+  if (entry.compression === 0) return chunks;
+  return chunks.pipe(createInflateRaw());
+}
+
+async function writeExtractedEntry(
+  archiveHandle: FileHandle,
+  entry: VerifiedZipFileEntry,
+  outputPath: string,
+): Promise<void> {
+  const output = await open(
+    outputPath,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  let written = 0;
+  let crc = 0xffffffff;
+  try {
+    try {
+      for await (const chunk of await extractedChunks(archiveHandle, entry)) {
+        const bytes = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+        written += bytes.byteLength;
+        if (written > entry.uncompressedSize) invalidZip("Zip entry exceeds its declared size");
+        crc = updateCrc32(crc, bytes);
+        await writeAll(output, bytes);
+      }
+    } catch (error: unknown) {
+      if (isDeflateError(error)) invalidZip("Zip entry decompression failed");
+      throw error;
+    }
+    if (written !== entry.uncompressedSize || ((crc ^ 0xffffffff) >>> 0) !== entry.crc32) {
+      invalidZip("Zip entry integrity verification failed");
+    }
+    await output.sync();
+  } catch (error: unknown) {
+    await output.close().catch(() => undefined);
+    await unlink(outputPath).catch(() => undefined);
+    throw error;
+  }
+  await output.close();
+}
+
+export async function extractVerifiedZip(
+  archiveHandle: FileHandle,
+  archive: VerifiedZipArchive,
+  buildDir: string,
+): Promise<void> {
+  await assertArchiveIdentity(archiveHandle, archive.identity);
+  for (const entry of archive.entries) {
+    const outputPath = join(buildDir, entry.path);
+    await mkdir(dirname(outputPath), { recursive: true, mode: 0o700 });
+    await writeExtractedEntry(archiveHandle, entry, outputPath);
+  }
+  await assertArchiveIdentity(archiveHandle, archive.identity);
+}

--- a/packages/management-api/src/services/frontend-release-contract.ts
+++ b/packages/management-api/src/services/frontend-release-contract.ts
@@ -1,0 +1,368 @@
+import { createHash } from "node:crypto";
+import type { FrontendDeployment } from "../types/frontend";
+import type { MutationPrincipal } from "./project-mutation.service";
+
+export const FRONTEND_BASE_DIR = "/var/supacloud/frontends";
+export const FRONTEND_RELEASE_ARCHIVE_MAX_BYTES = 100 * 1024 * 1024;
+export const FRONTEND_RELEASE_MAX_FILES = 10_000;
+export const FRONTEND_RELEASE_MAX_UNCOMPRESSED_BYTES = 300 * 1024 * 1024;
+export const FRONTEND_RELEASE_LIST_DEFAULT_LIMIT = 50;
+export const FRONTEND_RELEASE_LIST_MAX_LIMIT = 100;
+export const FRONTEND_RELEASE_SCHEMA = "supacloud.frontend-release.v1" as const;
+export const FRONTEND_ACTIVE_RELEASE_SCHEMA = "supacloud.frontend-active-release.v1" as const;
+export const FRONTEND_ACTIVATION_CHECKPOINT_SCHEMA = "supacloud.frontend-release-activation.v1" as const;
+export const FRONTEND_GATEWAY_DURABILITY_UNKNOWN_CODE = "CADDY_GATEWAY_DURABILITY_UNKNOWN" as const;
+export const PROJECT_REF_PATTERN = /^[A-Za-z0-9_-]{1,20}$/;
+export const DEPLOYMENT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+export const RELEASE_ID_PATTERN = /^[0-9a-f]{64}$/;
+export const MUTATION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const CANONICAL_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+export type ExpectedActiveReleaseId = "absent" | string;
+export type ExpectedFrontendActivationId = "absent" | string;
+export type ActivationPhase = "prepared" | "authority_applied" | "route_applied";
+
+export interface FrontendReleaseRecord {
+  schema: typeof FRONTEND_RELEASE_SCHEMA;
+  project_ref: string;
+  deployment_id: string;
+  release_id: string;
+  sha256: string;
+  tree_sha256: string;
+  size_bytes: number;
+  file_count: number;
+  created_at: string;
+  kind: "prebuilt_static";
+}
+
+export interface FrontendActiveReleaseRecord {
+  schema: typeof FRONTEND_ACTIVE_RELEASE_SCHEMA;
+  project_ref: string;
+  deployment_id: string;
+  release_id: string;
+  sha256: string;
+  tree_sha256: string;
+  activation_id: string;
+  activated_at: string;
+  mutation_id: string;
+}
+
+export interface FrontendActivationCheckpoint {
+  schema: typeof FRONTEND_ACTIVATION_CHECKPOINT_SCHEMA;
+  phase: ActivationPhase;
+  deployment_id: string;
+  release_id: string;
+  expected_active_release_id: ExpectedActiveReleaseId;
+  activation_id: string;
+  expected_activation_id: ExpectedFrontendActivationId;
+  activated_at: string;
+  previous_authority: FrontendActiveReleaseRecord | null;
+  previous_route: "absent" | "legacy" | "release";
+}
+
+export interface FrontendReleaseInventory {
+  project_ref: string;
+  deployment_id: string;
+  active_release_id: string | null;
+  active_activation_id: string | null;
+  releases: FrontendReleaseRecord[];
+  next_cursor: string | null;
+}
+
+export interface FrontendReleaseListPage {
+  cursor?: string;
+  limit: number;
+}
+
+export interface VerifiedStagedFrontendArchive {
+  readonly size_bytes: number;
+  readonly sha256: string;
+}
+
+export interface FrontendReleaseUploadSession {
+  write(chunk: Uint8Array): Promise<void>;
+  finish(expectedSha256: string): Promise<VerifiedStagedFrontendArchive>;
+  abort(): Promise<void>;
+}
+
+export interface ActivateFrontendReleaseInput {
+  projectRef: string;
+  deploymentId: string;
+  releaseId: string;
+  expectedActiveReleaseId: ExpectedActiveReleaseId;
+  expectedActivationId: ExpectedFrontendActivationId;
+  mutationId: string;
+  principal: MutationPrincipal;
+}
+
+export interface FrontendReleaseActivation {
+  project_ref: string;
+  deployment_id: string;
+  active_release_id: string;
+  activation_id: string;
+  release: FrontendReleaseRecord;
+  mutation: {
+    mutation_id: string;
+    status: "succeeded";
+    replayed: boolean;
+  };
+}
+
+export interface FrontendReleaseGateway {
+  configureFrontendRoute(route: {
+    projectRef: string;
+    deploymentId: string;
+    hosts: string[];
+    root: string;
+    mode: "static";
+  }): Promise<void>;
+  removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void>;
+  readFrontendStaticRoot(projectRef: string, deploymentId: string): Promise<string | null>;
+}
+
+export interface FrontendReleaseStoragePort {
+  assertMutationSupported(projectRef: string, deploymentId: string): Promise<void>;
+  deployment(projectRef: string, deploymentId: string): Promise<FrontendDeployment>;
+  prepareReleaseUpload(
+    projectRef: string,
+    deploymentId: string,
+    expectedLength: number,
+  ): Promise<FrontendReleaseUploadSession>;
+  createRelease(
+    projectRef: string,
+    deploymentId: string,
+    archive: VerifiedStagedFrontendArchive,
+  ): Promise<FrontendReleaseRecord>;
+  listReleases(
+    projectRef: string,
+    deploymentId: string,
+    page: FrontendReleaseListPage,
+  ): Promise<FrontendReleaseInventory>;
+  releaseRecord(projectRef: string, deploymentId: string, releaseId: string): Promise<FrontendReleaseRecord>;
+  activeRelease(projectRef: string, deploymentId: string): Promise<FrontendActiveReleaseRecord | null>;
+  writeActiveRelease(
+    projectRef: string,
+    deploymentId: string,
+    record: FrontendActiveReleaseRecord | null,
+  ): Promise<void>;
+  compareAndSwapActiveRelease(
+    projectRef: string,
+    deploymentId: string,
+    expectedReleaseId: ExpectedActiveReleaseId,
+    expectedActivationId: ExpectedFrontendActivationId,
+    record: FrontendActiveReleaseRecord | null,
+  ): Promise<"updated" | "conflict">;
+  activeBuildDir(projectRef: string, deploymentId: string): Promise<string | null>;
+  hasActiveRelease(projectRef: string, deploymentId: string): Promise<boolean>;
+  releaseBuildDir(projectRef: string, deploymentId: string, releaseId: string): string;
+  legacyBuildDir(projectRef: string, deploymentId: string): string;
+}
+
+export class FrontendReleaseError extends Error {
+  constructor(
+    readonly code: string,
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "FrontendReleaseError";
+  }
+}
+
+export function frontendReleaseError(
+  code: string,
+  statusCode: number,
+  message: string,
+): FrontendReleaseError {
+  return new FrontendReleaseError(code, statusCode, message);
+}
+
+export function isFrontendGatewayDurabilityUnknown(error: unknown): boolean {
+  return error instanceof Error && "code" in error
+    && (error as Error & { code?: unknown }).code === FRONTEND_GATEWAY_DURABILITY_UNKNOWN_CODE;
+}
+
+export function frontendReleaseMutationPlatformSupported(): boolean {
+  return process.platform === "linux" && typeof process.geteuid === "function";
+}
+
+export function nodeErrorCode(error: unknown): string {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : "";
+}
+
+export function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function canonicalTimestamp(candidate: unknown): candidate is string {
+  if (typeof candidate !== "string" || !CANONICAL_TIMESTAMP_PATTERN.test(candidate)) return false;
+  const milliseconds = Date.parse(candidate);
+  return Number.isFinite(milliseconds) && new Date(milliseconds).toISOString() === candidate;
+}
+
+function exactRecord(candidate: unknown, keys: readonly string[]): Record<string, unknown> | null {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+  const record = candidate as Record<string, unknown>;
+  const actualKeys = Object.keys(record).sort();
+  const expectedKeys = [...keys].sort();
+  return JSON.stringify(actualKeys) === JSON.stringify(expectedKeys) ? record : null;
+}
+
+export function assertFrontendIdentity(projectRef: string, deploymentId: string): void {
+  if (!PROJECT_REF_PATTERN.test(projectRef)) {
+    throw frontendReleaseError("FRONTEND_RELEASE_PROJECT_INVALID", 400, "Project ref is invalid");
+  }
+  if (!DEPLOYMENT_ID_PATTERN.test(deploymentId)) {
+    throw frontendReleaseError("FRONTEND_RELEASE_DEPLOYMENT_INVALID", 400, "Frontend deployment id is invalid");
+  }
+}
+
+export function assertReleaseId(releaseId: string): void {
+  if (!RELEASE_ID_PATTERN.test(releaseId)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_ID_INVALID",
+      400,
+      "Frontend release id must be a SHA-256 digest",
+    );
+  }
+}
+
+export function assertExpectedActiveReleaseId(candidate: string): void {
+  if (candidate !== "absent" && !RELEASE_ID_PATTERN.test(candidate)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_EXPECTED_ACTIVE_INVALID",
+      400,
+      "expected_active_release_id must be 'absent' or a SHA-256 release id",
+    );
+  }
+}
+
+export function assertExpectedFrontendActivationId(candidate: string): void {
+  if (candidate !== "absent" && !MUTATION_ID_PATTERN.test(candidate)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_EXPECTED_ACTIVATION_INVALID",
+      400,
+      "expected_activation_id must be 'absent' or a UUIDv4",
+    );
+  }
+}
+
+export function parseReleaseRecord(candidate: unknown): FrontendReleaseRecord {
+  const keys = [
+    "schema", "project_ref", "deployment_id", "release_id", "sha256", "tree_sha256",
+    "size_bytes", "file_count", "created_at", "kind",
+  ] as const;
+  const record = exactRecord(candidate, keys);
+  if (!record || record.schema !== FRONTEND_RELEASE_SCHEMA || record.kind !== "prebuilt_static"
+    || typeof record.project_ref !== "string" || typeof record.deployment_id !== "string"
+    || typeof record.release_id !== "string" || !RELEASE_ID_PATTERN.test(record.release_id)
+    || record.sha256 !== record.release_id || typeof record.tree_sha256 !== "string"
+    || !RELEASE_ID_PATTERN.test(record.tree_sha256)
+    || !Number.isSafeInteger(record.size_bytes) || Number(record.size_bytes) < 1
+    || !Number.isSafeInteger(record.file_count) || Number(record.file_count) < 1
+    || !canonicalTimestamp(record.created_at)) {
+    throw frontendReleaseError("FRONTEND_RELEASE_STORAGE_INVALID", 500, "Frontend release metadata is invalid");
+  }
+  return record as unknown as FrontendReleaseRecord;
+}
+
+export function parseActiveRelease(candidate: unknown): FrontendActiveReleaseRecord {
+  const keys = [
+    "schema", "project_ref", "deployment_id", "release_id", "sha256", "tree_sha256",
+    "activation_id", "activated_at", "mutation_id",
+  ] as const;
+  const record = exactRecord(candidate, keys);
+  if (!record || record.schema !== FRONTEND_ACTIVE_RELEASE_SCHEMA
+    || typeof record.project_ref !== "string" || typeof record.deployment_id !== "string"
+    || typeof record.release_id !== "string" || !RELEASE_ID_PATTERN.test(record.release_id)
+    || record.sha256 !== record.release_id || typeof record.tree_sha256 !== "string"
+    || !RELEASE_ID_PATTERN.test(record.tree_sha256) || !canonicalTimestamp(record.activated_at)
+    || typeof record.activation_id !== "string" || !MUTATION_ID_PATTERN.test(record.activation_id)
+    || typeof record.mutation_id !== "string" || !MUTATION_ID_PATTERN.test(record.mutation_id)
+    || record.activation_id !== record.mutation_id) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_AUTHORITY_INVALID",
+      500,
+      "Frontend active release authority is invalid",
+    );
+  }
+  return record as unknown as FrontendActiveReleaseRecord;
+}
+
+export function parseActivationCheckpoint(candidate: unknown): FrontendActivationCheckpoint | null {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+  if (Object.keys(candidate as Record<string, unknown>).length === 0) return null;
+  const keys = [
+    "schema", "phase", "deployment_id", "release_id", "expected_active_release_id",
+    "activation_id", "expected_activation_id", "activated_at", "previous_authority",
+    "previous_route",
+  ] as const;
+  const record = exactRecord(candidate, keys);
+  if (!record || record.schema !== FRONTEND_ACTIVATION_CHECKPOINT_SCHEMA
+    || !["prepared", "authority_applied", "route_applied"].includes(String(record.phase))
+    || typeof record.deployment_id !== "string" || !DEPLOYMENT_ID_PATTERN.test(record.deployment_id)
+    || typeof record.release_id !== "string" || !RELEASE_ID_PATTERN.test(record.release_id)
+    || typeof record.expected_active_release_id !== "string"
+    || (record.expected_active_release_id !== "absent"
+      && !RELEASE_ID_PATTERN.test(record.expected_active_release_id))
+    || typeof record.activation_id !== "string" || !MUTATION_ID_PATTERN.test(record.activation_id)
+    || typeof record.expected_activation_id !== "string"
+    || (record.expected_activation_id !== "absent"
+      && !MUTATION_ID_PATTERN.test(record.expected_activation_id))
+    || !canonicalTimestamp(record.activated_at)
+    || !["absent", "legacy", "release"].includes(String(record.previous_route))) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+      503,
+      "Frontend release activation checkpoint is invalid",
+    );
+  }
+  if (record.previous_authority !== null) {
+    let previous: FrontendActiveReleaseRecord;
+    try {
+      previous = parseActiveRelease(record.previous_authority);
+    } catch {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+        503,
+        "Frontend release activation checkpoint is invalid",
+      );
+    }
+    if (record.previous_route !== "release"
+      || previous.deployment_id !== record.deployment_id
+      || previous.release_id !== record.expected_active_release_id
+      || previous.activation_id !== record.expected_activation_id) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+        503,
+        "Frontend release activation checkpoint is invalid",
+      );
+    }
+  } else if (record.previous_route === "release"
+    || record.expected_active_release_id !== "absent"
+    || record.expected_activation_id !== "absent") {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+      503,
+      "Frontend release activation checkpoint is invalid",
+    );
+  }
+  return record as unknown as FrontendActivationCheckpoint;
+}
+
+export function assertActivationCheckpointIdentity(
+  checkpoint: FrontendActivationCheckpoint,
+  identity: { projectRef: string; mutationId: string },
+): void {
+  if (checkpoint.activation_id !== identity.mutationId
+    || (checkpoint.previous_authority !== null
+      && checkpoint.previous_authority.project_ref !== identity.projectRef)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_CHECKPOINT_INVALID",
+      503,
+      "Frontend release activation checkpoint identity is invalid",
+    );
+  }
+}

--- a/packages/management-api/src/services/frontend-release-mutation.ts
+++ b/packages/management-api/src/services/frontend-release-mutation.ts
@@ -1,0 +1,117 @@
+import type { SQL } from "bun";
+import { sql } from "../db";
+import {
+  beginProjectMutation,
+  claimRecoverableProjectMutations,
+  checkpointProjectMutation,
+  claimOrResumeProjectMutation,
+  completeProjectMutationFailure,
+  completeProjectMutationSuccess,
+  readProjectMutation,
+  readActiveProjectMutationForResource,
+  withProjectMutationLease,
+  type BeginProjectMutationInput,
+  type BeginProjectMutationResult,
+  type CheckpointProjectMutationInput,
+  type ClaimProjectMutationInput,
+  type ClaimProjectMutationResult,
+  type CompleteProjectMutationFailureInput,
+  type CompleteProjectMutationSuccessInput,
+  type ProjectMutationState,
+  type RecoverableProjectMutationClaim,
+  type VerifyProjectMutationLeaseInput,
+  type ProjectMutationLeaseExecution,
+} from "./project-mutation.service";
+
+export interface FrontendReleaseMutationStore {
+  beginAndClaim(
+    begin: BeginProjectMutationInput,
+    claim: Omit<ClaimProjectMutationInput, "projectRef" | "mutationId"> & {
+      initialCheckpoint?: Record<string, unknown>;
+    },
+  ): Promise<{ begun: BeginProjectMutationResult; claimed?: ClaimProjectMutationResult }>;
+  checkpoint(input: CheckpointProjectMutationInput): Promise<"updated" | "lease_lost">;
+  completeSuccess(input: CompleteProjectMutationSuccessInput): Promise<"updated" | "lease_lost">;
+  completeFailure(input: CompleteProjectMutationFailureInput): Promise<"updated" | "lease_lost">;
+  read(projectRef: string, mutationId: string): Promise<ProjectMutationState | null>;
+  activeForDeployment(projectRef: string, deploymentId: string): Promise<ProjectMutationState | null>;
+  withLease<T>(
+    input: VerifyProjectMutationLeaseInput,
+    operation: () => Promise<T>,
+  ): Promise<ProjectMutationLeaseExecution<T>>;
+}
+
+export function frontendReleaseMutationStore(): FrontendReleaseMutationStore {
+  const transaction = <T>(operation: (database: SQL) => Promise<T>) => sql.begin(operation);
+  return {
+    beginAndClaim: (begin, claim) => transaction(async (database) => {
+      const begun = await beginProjectMutation(database, begin);
+      if (begun.kind !== "started" && begun.kind !== "replay") return { begun };
+      if (begun.kind === "replay" && ["succeeded", "failed_terminal", "outcome_unknown"].includes(
+        begun.mutation.status,
+      )) return { begun };
+      const claimed = await claimOrResumeProjectMutation(database, {
+        projectRef: begin.projectRef,
+        mutationId: begin.mutationId,
+        leaseOwner: claim.leaseOwner,
+        leaseToken: claim.leaseToken,
+        leaseSeconds: claim.leaseSeconds,
+      });
+      if (begun.kind !== "started" || claimed.kind !== "claimed") return { begun, claimed };
+      if (!claim.initialCheckpoint) throw new Error("New frontend release mutation requires an initial checkpoint");
+      const checkpointed = await checkpointProjectMutation(database, {
+        projectRef: begin.projectRef,
+        mutationId: begin.mutationId,
+        leaseToken: claim.leaseToken,
+        fencingEpoch: claimed.mutation.fencingEpoch,
+        checkpoint: claim.initialCheckpoint,
+        leaseSeconds: claim.leaseSeconds,
+      });
+      if (checkpointed !== "updated") throw new Error("New frontend release mutation lost its initial lease");
+      return {
+        begun,
+        claimed: {
+          ...claimed,
+          mutation: { ...claimed.mutation, checkpoint: claim.initialCheckpoint },
+        },
+      };
+    }),
+    checkpoint: (input) => transaction((database) => checkpointProjectMutation(database, input)),
+    completeSuccess: (input) => transaction((database) => completeProjectMutationSuccess(database, input)),
+    completeFailure: (input) => transaction((database) => completeProjectMutationFailure(database, input)),
+    read: (projectRef, mutationId) => readProjectMutation({ projectRef, mutationId }),
+    activeForDeployment: (projectRef, deploymentId) => readActiveProjectMutationForResource(
+      projectRef,
+      { type: "frontend_release", id: deploymentId },
+    ),
+    withLease: (input, operation) => transaction((database) =>
+      withProjectMutationLease(database, input, operation)),
+  };
+}
+
+export function claimRecoverableFrontendReleases(
+  leaseOwner: string,
+  limit: number,
+): Promise<RecoverableProjectMutationClaim[]> {
+  return claimRecoverableProjectMutations({
+    operations: ["frontend.release.activate"],
+    leaseOwner,
+    leaseSeconds: 300,
+    limit,
+  });
+}
+
+export async function hasUnresolvedFrontendReleaseActivations(): Promise<boolean> {
+  const [row] = await sql`
+    SELECT EXISTS (
+      SELECT 1
+      FROM project_mutations
+      WHERE operation = 'frontend.release.activate'
+        AND status IN ('pending', 'running', 'failed_retryable', 'outcome_unknown')
+    ) AS unresolved
+  ` as Array<{ unresolved: boolean }>;
+  if (typeof row?.unresolved !== "boolean") {
+    throw new Error("Frontend release recovery state could not be read");
+  }
+  return row.unresolved;
+}

--- a/packages/management-api/src/services/frontend-release-storage.ts
+++ b/packages/management-api/src/services/frontend-release-storage.ts
@@ -1,0 +1,1157 @@
+import { createHash, type Hash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  realpath,
+  rename,
+  rmdir,
+  rm,
+  unlink,
+} from "node:fs/promises";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import { FRAMEWORK_DEFAULTS, type FrontendDeployment } from "../types/frontend";
+import {
+  extractVerifiedZip,
+  verifiedZipArchive,
+  type VerifiedZipArchive,
+  type VerifiedZipFileEntry,
+} from "./frontend-release-archive";
+import {
+  assertFrontendIdentity,
+  assertReleaseId,
+  FRONTEND_ACTIVE_RELEASE_SCHEMA,
+  FRONTEND_BASE_DIR,
+  FRONTEND_RELEASE_ARCHIVE_MAX_BYTES,
+  FRONTEND_RELEASE_LIST_MAX_LIMIT,
+  FRONTEND_RELEASE_SCHEMA,
+  RELEASE_ID_PATTERN,
+  frontendReleaseError,
+  frontendReleaseMutationPlatformSupported,
+  nodeErrorCode,
+  parseActiveRelease,
+  parseReleaseRecord,
+  type FrontendReleaseUploadSession,
+  type FrontendActiveReleaseRecord,
+  type FrontendReleaseInventory,
+  type FrontendReleaseListPage,
+  type FrontendReleaseRecord,
+  type FrontendReleaseStoragePort,
+  type VerifiedStagedFrontendArchive,
+} from "./frontend-release-contract";
+
+const FILE_HASH_CHUNK_BYTES = 64 * 1024;
+
+interface TreeFile {
+  path: string;
+  size: number;
+  sha256: string;
+}
+
+interface FileIdentity {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+}
+
+interface OpenVerifiedFile {
+  handle: Awaited<ReturnType<typeof open>>;
+  identity: FileIdentity;
+  sha256: string;
+}
+
+interface PreparedArchiveState {
+  projectRef: string;
+  deploymentId: string;
+  expectedLength: number;
+  stagingRoot: string;
+  stagingRootBinding: OpenDirectoryBinding;
+  stagingDir: string;
+  stagingDirBinding: OpenDirectoryBinding;
+  stagingDirIdentity: DirectoryIdentity;
+  archiveHandle: Awaited<ReturnType<typeof open>>;
+  archiveIdentity: FileIdentity | null;
+  archivePath: string;
+  hash: Hash;
+  written: number;
+  status: "open" | "finished" | "consuming" | "closed";
+}
+
+async function writeArchiveChunk(state: PreparedArchiveState, chunk: Uint8Array): Promise<void> {
+  if (state.status !== "open") {
+    throw frontendReleaseError("FRONTEND_RELEASE_UPLOAD_CLOSED", 409, "Frontend release upload is closed");
+  }
+  if (state.written + chunk.byteLength > state.expectedLength) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_CONTENT_LENGTH_MISMATCH",
+      400,
+      "Frontend release upload length does not match Content-Length",
+    );
+  }
+  let chunkOffset = 0;
+  while (chunkOffset < chunk.byteLength) {
+    const written = await state.archiveHandle.write(
+      chunk,
+      chunkOffset,
+      chunk.byteLength - chunkOffset,
+      state.written + chunkOffset,
+    );
+    if (written.bytesWritten === 0) throw new Error("Frontend release staging write made no progress");
+    chunkOffset += written.bytesWritten;
+  }
+  state.hash.update(chunk);
+  state.written += chunk.byteLength;
+}
+
+async function finishArchiveUpload(
+  state: PreparedArchiveState,
+  expectedSha256: string,
+): Promise<VerifiedStagedFrontendArchive> {
+  if (state.status !== "open") {
+    throw frontendReleaseError("FRONTEND_RELEASE_UPLOAD_CLOSED", 409, "Frontend release upload is closed");
+  }
+  if (state.written !== state.expectedLength) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_CONTENT_LENGTH_MISMATCH",
+      400,
+      "Frontend release upload length does not match Content-Length",
+    );
+  }
+  if (!RELEASE_ID_PATTERN.test(expectedSha256)) {
+    throw frontendReleaseError("FRONTEND_RELEASE_ARCHIVE_INVALID", 400, "Expected SHA-256 is invalid");
+  }
+  await state.archiveHandle.sync();
+  state.archiveIdentity = fileIdentity(await state.archiveHandle.stat());
+  const digest = state.hash.digest("hex");
+  state.status = "finished";
+  if (state.archiveIdentity.size !== state.expectedLength || digest !== expectedSha256) {
+    throw frontendReleaseError(
+      digest === expectedSha256 ? "FRONTEND_RELEASE_CONTENT_LENGTH_MISMATCH" : "FRONTEND_RELEASE_SHA_MISMATCH",
+      400,
+      digest === expectedSha256
+        ? "Frontend release upload length does not match Content-Length"
+        : "Frontend release archive SHA-256 does not match the request",
+    );
+  }
+  return Object.freeze({ size_bytes: state.expectedLength, sha256: digest });
+}
+
+interface FrontendReleaseStorageOptions {
+  baseDir?: string;
+  now?: () => Date;
+  beforePublish?: (artifactDir: string, finalDir: string) => Promise<void> | void;
+}
+
+async function secureFileBytes(path: string): Promise<Uint8Array> {
+  const handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const before = await handle.stat();
+    if (!before.isFile()) throw new Error("Expected a regular file");
+    const bytes = await handle.readFile();
+    const after = await handle.stat();
+    if (before.dev !== after.dev || before.ino !== after.ino || before.size !== after.size) {
+      throw new Error("File identity changed while it was read");
+    }
+    return bytes;
+  } finally {
+    await handle.close();
+  }
+}
+
+function fileIdentity(metadata: Awaited<ReturnType<Awaited<ReturnType<typeof open>>["stat"]>>): FileIdentity {
+  if (!metadata.isFile()) throw new Error("Expected a regular file");
+  return {
+    dev: Number(metadata.dev),
+    ino: Number(metadata.ino),
+    size: Number(metadata.size),
+    mtimeMs: Number(metadata.mtimeMs),
+    ctimeMs: Number(metadata.ctimeMs),
+  };
+}
+
+function sameFile(left: FileIdentity, right: FileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino && left.size === right.size
+    && left.mtimeMs === right.mtimeMs && left.ctimeMs === right.ctimeMs;
+}
+
+async function hashHeldFile(
+  handle: Awaited<ReturnType<typeof open>>,
+  expectedSize?: number,
+): Promise<{ identity: FileIdentity; sha256: string }> {
+  const before = fileIdentity(await handle.stat());
+  if (expectedSize !== undefined && before.size !== expectedSize) {
+    throw new Error("File size does not match its trusted descriptor");
+  }
+  const hash = createHash("sha256");
+  const chunk = Buffer.allocUnsafe(FILE_HASH_CHUNK_BYTES);
+  let offset = 0;
+  while (offset < before.size) {
+    const length = Math.min(chunk.byteLength, before.size - offset);
+    const read = await handle.read(chunk, 0, length, offset);
+    if (read.bytesRead === 0) throw new Error("File ended while it was hashed");
+    hash.update(chunk.subarray(0, read.bytesRead));
+    offset += read.bytesRead;
+  }
+  const after = fileIdentity(await handle.stat());
+  if (!sameFile(before, after)) throw new Error("File identity changed while it was hashed");
+  return { identity: after, sha256: hash.digest("hex") };
+}
+
+async function openVerifiedFile(path: string, expectedSize?: number): Promise<OpenVerifiedFile> {
+  const handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    return { handle, ...await hashHeldFile(handle, expectedSize) };
+  } catch (error: unknown) {
+    await handle.close();
+    throw error;
+  }
+}
+
+async function secureFileDigest(path: string): Promise<{ size: number; sha256: string }> {
+  const verified = await openVerifiedFile(path);
+  try {
+    return { size: verified.identity.size, sha256: verified.sha256 };
+  } finally {
+    await verified.handle.close();
+  }
+}
+
+interface DirectoryIdentity {
+  dev: number;
+  ino: number;
+}
+
+interface OpenDirectoryBinding extends DirectoryIdentity {
+  handle: Awaited<ReturnType<typeof open>>;
+}
+
+async function trustedDirectoryIdentity(path: string): Promise<DirectoryIdentity> {
+  const metadata = await lstat(path);
+  const effectiveUid = process.geteuid?.();
+  if (effectiveUid === undefined || !metadata.isDirectory() || metadata.isSymbolicLink()
+    || ![0, effectiveUid].includes(metadata.uid) || (metadata.mode & 0o022) !== 0
+    || await realpath(path) !== resolve(path)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+      500,
+      "Frontend release storage is not trusted",
+    );
+  }
+  return { dev: metadata.dev, ino: metadata.ino };
+}
+
+async function openTrustedDirectory(path: string): Promise<OpenDirectoryBinding> {
+  if (!frontendReleaseMutationPlatformSupported()) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_PLATFORM_UNSUPPORTED",
+      503,
+      "Immutable frontend release storage requires Linux directory binding",
+    );
+  }
+  await assertTrustedDirectoryChain(path);
+  const expected = await trustedDirectoryIdentity(path);
+  const handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW);
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isDirectory() || metadata.dev !== expected.dev || metadata.ino !== expected.ino) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+        500,
+        "Frontend release storage identity changed",
+      );
+    }
+    return { handle, dev: metadata.dev, ino: metadata.ino };
+  } catch (error: unknown) {
+    await handle.close();
+    throw error;
+  }
+}
+
+function boundDirectoryPath(binding: OpenDirectoryBinding): string {
+  return `/proc/self/fd/${binding.handle.fd}`;
+}
+
+function sameDirectory(left: DirectoryIdentity, right: DirectoryIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+async function assertDirectoryBinding(path: string, binding: OpenDirectoryBinding): Promise<void> {
+  let current: DirectoryIdentity;
+  try {
+    current = await trustedDirectoryIdentity(path);
+  } catch {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+      500,
+      "Frontend release storage identity changed",
+    );
+  }
+  if (!sameDirectory(binding, current)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+      500,
+      "Frontend release storage identity changed",
+    );
+  }
+}
+
+function directEntryName(directory: string, path: string): string {
+  const name = relative(directory, path);
+  if (!name || name.includes("/") || name.includes("\\")) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+      500,
+      "Frontend release path is invalid",
+    );
+  }
+  return name;
+}
+
+async function pathIdentity(path: string, kind: "file" | "directory"): Promise<DirectoryIdentity> {
+  const metadata = await lstat(path);
+  const expectedType = kind === "file" ? metadata.isFile() : metadata.isDirectory();
+  if (!expectedType || metadata.isSymbolicLink()) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+      500,
+      "Frontend release path type is invalid",
+    );
+  }
+  return { dev: metadata.dev, ino: metadata.ino };
+}
+
+async function assertBoundEntry(
+  directory: string,
+  binding: OpenDirectoryBinding,
+  name: string,
+  expected: DirectoryIdentity,
+  kind: "file" | "directory",
+): Promise<void> {
+  await assertDirectoryBinding(directory, binding);
+  const boundIdentity = await pathIdentity(join(boundDirectoryPath(binding), name), kind);
+  const requestedIdentity = await pathIdentity(join(directory, name), kind);
+  if (!sameDirectory(expected, boundIdentity) || !sameDirectory(expected, requestedIdentity)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+      500,
+      "Frontend release path identity changed",
+    );
+  }
+}
+
+async function assertTrustedDirectoryChain(path: string): Promise<void> {
+  const canonicalPath = await realpath(path).catch(() => "");
+  const resolvedPath = resolve(path);
+  if (!canonicalPath || canonicalPath !== resolvedPath) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+      500,
+      "Frontend release storage is not trusted",
+    );
+  }
+  const segments = relative("/", resolvedPath).split("/").filter(Boolean);
+  let current = "/";
+  await trustedDirectoryIdentity(current);
+  for (const segment of segments) {
+    current = join(current, segment);
+    await trustedDirectoryIdentity(current);
+  }
+}
+
+async function treeFiles(root: string, requireReadOnly = false): Promise<TreeFile[]> {
+  const files: TreeFile[] = [];
+  const walk = async (directory: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const absolutePath = join(directory, entry.name);
+      const metadata = await lstat(absolutePath);
+      if (entry.isDirectory()) {
+        if (metadata.isSymbolicLink() || (requireReadOnly && (metadata.mode & 0o222) !== 0)) {
+          throw frontendReleaseError(
+            "FRONTEND_RELEASE_STORAGE_INVALID",
+            500,
+            "Frontend release directory permissions are invalid",
+          );
+        }
+        await walk(absolutePath);
+      } else if (entry.isFile()) {
+        if (metadata.isSymbolicLink() || (requireReadOnly && (metadata.mode & 0o222) !== 0)) {
+          throw frontendReleaseError(
+            "FRONTEND_RELEASE_STORAGE_INVALID",
+            500,
+            "Frontend release file permissions are invalid",
+          );
+        }
+        const filePath = relative(root, absolutePath).split("\\").join("/");
+        const digest = await secureFileDigest(absolutePath);
+        files.push({ path: filePath, size: digest.size, sha256: digest.sha256 });
+      } else {
+        throw frontendReleaseError(
+          "FRONTEND_RELEASE_STORAGE_INVALID",
+          500,
+          "Frontend release contains a non-regular file",
+        );
+      }
+    }
+  };
+  await walk(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function treeSha256(files: readonly TreeFile[]): string {
+  const hash = createHash("sha256");
+  for (const file of files) {
+    const pathBytes = Buffer.from(file.path, "utf8");
+    const frame = Buffer.alloc(12);
+    frame.writeUInt32BE(pathBytes.byteLength, 0);
+    frame.writeBigUInt64BE(BigInt(file.size), 4);
+    hash.update(frame).update(pathBytes).update(Buffer.from(file.sha256, "hex"));
+  }
+  return hash.digest("hex");
+}
+
+async function verifiedTree(
+  buildDir: string,
+  zipEntries: readonly VerifiedZipFileEntry[],
+  requireReadOnly = false,
+): Promise<TreeFile[]> {
+  if (await realpath(buildDir) !== resolve(buildDir)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_ARCHIVE_INVALID",
+      400,
+      "Extracted release path is invalid",
+    );
+  }
+  const files = await treeFiles(buildDir, requireReadOnly);
+  const expected = new Map(zipEntries.map((entry) => [entry.path, entry.uncompressedSize]));
+  if (files.length !== expected.size || files.some((file) => expected.get(file.path) !== file.size)) {
+    throw frontendReleaseError(
+      "FRONTEND_RELEASE_ARCHIVE_INVALID",
+      400,
+      "Extracted release does not match its zip inventory",
+    );
+  }
+  return files;
+}
+
+async function freezeTree(root: string, freezeRoot = true): Promise<void> {
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      await freezeTree(path);
+      await chmod(path, 0o555);
+    } else if (entry.isFile()) {
+      await chmod(path, 0o444);
+    } else {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_INVALID",
+        500,
+        "Frontend release contains a non-regular file",
+      );
+    }
+  }
+  if (freezeRoot) await chmod(root, 0o555);
+}
+
+async function makeTreeRemovable(root: string): Promise<void> {
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const directory = join(root, entry.name);
+    await chmod(directory, 0o700).catch(() => undefined);
+    await makeTreeRemovable(directory);
+  }
+}
+
+async function writeBoundFile(path: string, contents: string): Promise<DirectoryIdentity> {
+  const handle = await open(
+    path,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+    0o444,
+  );
+  try {
+    await handle.writeFile(contents, "utf8");
+    await handle.sync();
+    const metadata = await handle.stat();
+    if (!metadata.isFile()) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+        500,
+        "Frontend release path type is invalid",
+      );
+    }
+    return { dev: metadata.dev, ino: metadata.ino };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function unlinkIfPresent(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error: unknown) {
+    if (nodeErrorCode(error) !== "ENOENT") throw error;
+  }
+}
+
+async function removeBoundFile(directory: string, path: string): Promise<void> {
+  const name = directEntryName(directory, path);
+  const binding = await openTrustedDirectory(directory);
+  try {
+    await unlinkIfPresent(join(boundDirectoryPath(binding), name));
+    await binding.handle.sync();
+    await assertDirectoryBinding(directory, binding);
+    const requested = await lstat(path).catch((error: unknown) => {
+      if (nodeErrorCode(error) === "ENOENT") return null;
+      throw error;
+    });
+    if (requested !== null) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+        500,
+        "Frontend release path was not removed",
+      );
+    }
+  } finally {
+    await binding.handle.close();
+  }
+}
+
+async function writeFileAtomic(directory: string, path: string, contents: string): Promise<void> {
+  const requestedName = directEntryName(directory, path);
+  const binding = await openTrustedDirectory(directory);
+  const temporaryName = `.frontend-release-${crypto.randomUUID()}.tmp`;
+  const temporaryPath = join(boundDirectoryPath(binding), temporaryName);
+  let renamed = false;
+  try {
+    const writtenIdentity = await writeBoundFile(temporaryPath, contents);
+    await assertDirectoryBinding(directory, binding);
+    await rename(temporaryPath, join(boundDirectoryPath(binding), requestedName));
+    renamed = true;
+    await binding.handle.sync();
+    await assertBoundEntry(directory, binding, requestedName, writtenIdentity, "file");
+  } catch (error: unknown) {
+    if (!renamed) await unlinkIfPresent(temporaryPath);
+    throw error;
+  } finally {
+    await binding.handle.close();
+  }
+}
+
+interface ImmutableDirectoryPublish {
+  sourceDir: string;
+  finalDir: string;
+  beforePublish?: (sourceDir: string, finalDir: string) => Promise<void> | void;
+}
+
+async function removeBoundDirectory(path: string): Promise<void> {
+  await chmod(path, 0o700).catch(() => undefined);
+  await makeTreeRemovable(path);
+  await rm(path, { recursive: true, force: true });
+}
+
+async function publishImmutableDirectory(input: ImmutableDirectoryPublish): Promise<"published" | "exists"> {
+  const destinationParent = dirname(input.finalDir);
+  const destination = await openTrustedDirectory(destinationParent);
+  let source: OpenDirectoryBinding | undefined;
+  let published = false;
+  try {
+    const sourceParent = dirname(input.sourceDir);
+    source = await openTrustedDirectory(sourceParent);
+    const sourceName = directEntryName(sourceParent, input.sourceDir);
+    const destinationName = directEntryName(destinationParent, input.finalDir);
+    const artifactIdentity = await pathIdentity(join(boundDirectoryPath(source), sourceName), "directory");
+    await input.beforePublish?.(input.sourceDir, input.finalDir);
+    await assertBoundEntry(sourceParent, source, sourceName, artifactIdentity, "directory");
+    await assertDirectoryBinding(destinationParent, destination);
+    try {
+      await rename(
+        join(boundDirectoryPath(source), sourceName),
+        join(boundDirectoryPath(destination), destinationName),
+      );
+    } catch (error: unknown) {
+      if (["EEXIST", "ENOTEMPTY"].includes(nodeErrorCode(error))) {
+        await assertDirectoryBinding(destinationParent, destination);
+        return "exists";
+      }
+      throw error;
+    }
+    published = true;
+    const boundFinalDir = join(boundDirectoryPath(destination), destinationName);
+    await chmod(boundFinalDir, 0o555);
+    await destination.handle.sync();
+    await assertBoundEntry(destinationParent, destination, destinationName, artifactIdentity, "directory");
+    return "published";
+  } catch (error: unknown) {
+    if (published) {
+      await removeBoundDirectory(join(boundDirectoryPath(destination), basename(input.finalDir)))
+        .catch(() => undefined);
+    }
+    throw error;
+  } finally {
+    await source?.handle.close();
+    await destination.handle.close();
+  }
+}
+
+export class FrontendReleaseStorage implements FrontendReleaseStoragePort {
+  private readonly baseDir: string;
+  private readonly now: () => Date;
+  private readonly beforePublish?: FrontendReleaseStorageOptions["beforePublish"];
+  private readonly stagedArchives = new WeakMap<VerifiedStagedFrontendArchive, PreparedArchiveState>();
+
+  constructor(options: FrontendReleaseStorageOptions = {}) {
+    this.baseDir = resolve(options.baseDir ?? FRONTEND_BASE_DIR);
+    this.now = options.now ?? (() => new Date());
+    this.beforePublish = options.beforePublish;
+  }
+
+  private deploymentDir(projectRef: string, deploymentId: string): string {
+    return join(this.baseDir, projectRef, deploymentId);
+  }
+
+  private releasesDir(projectRef: string, deploymentId: string): string {
+    return join(this.deploymentDir(projectRef, deploymentId), "releases");
+  }
+
+  private releaseDir(projectRef: string, deploymentId: string, releaseId: string): string {
+    return join(this.releasesDir(projectRef, deploymentId), releaseId);
+  }
+
+  private activePath(projectRef: string, deploymentId: string): string {
+    return join(this.deploymentDir(projectRef, deploymentId), "active-release.json");
+  }
+
+  releaseBuildDir(projectRef: string, deploymentId: string, releaseId: string): string {
+    return join(this.releaseDir(projectRef, deploymentId, releaseId), "build");
+  }
+
+  legacyBuildDir(projectRef: string, deploymentId: string): string {
+    return join(this.deploymentDir(projectRef, deploymentId), "build");
+  }
+
+  async assertMutationSupported(projectRef: string, deploymentId: string): Promise<void> {
+    await this.deployment(projectRef, deploymentId);
+    const binding = await openTrustedDirectory(this.deploymentDir(projectRef, deploymentId));
+    await binding.handle.close();
+  }
+
+  async deployment(projectRef: string, deploymentId: string): Promise<FrontendDeployment> {
+    assertFrontendIdentity(projectRef, deploymentId);
+    await assertTrustedDirectoryChain(this.baseDir);
+    await trustedDirectoryIdentity(join(this.baseDir, projectRef));
+    await trustedDirectoryIdentity(this.deploymentDir(projectRef, deploymentId));
+    let candidate: unknown;
+    try {
+      candidate = JSON.parse(new TextDecoder().decode(
+        await secureFileBytes(join(this.deploymentDir(projectRef, deploymentId), "deployment.json")),
+      ));
+    } catch (error: unknown) {
+      if (nodeErrorCode(error) === "ENOENT") {
+        throw frontendReleaseError(
+          "FRONTEND_RELEASE_DEPLOYMENT_NOT_FOUND",
+          404,
+          "Frontend deployment not found",
+        );
+      }
+      throw error;
+    }
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_DEPLOYMENT_INVALID",
+        500,
+        "Frontend deployment metadata is invalid",
+      );
+    }
+    const deployment = candidate as FrontendDeployment;
+    const defaults = FRAMEWORK_DEFAULTS[deployment.framework];
+    if (deployment.project_ref !== projectRef || deployment.id !== deploymentId || !defaults) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_DEPLOYMENT_INVALID",
+        500,
+        "Frontend deployment metadata is invalid",
+      );
+    }
+    if (defaults.is_ssr) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_SSR_UNSUPPORTED",
+        409,
+        "Immutable frontend releases support prebuilt static deployments only",
+      );
+    }
+    return deployment;
+  }
+
+  private async stagingRoot(projectRef: string, deploymentId: string): Promise<string> {
+    await assertTrustedDirectoryChain(this.baseDir);
+    await trustedDirectoryIdentity(join(this.baseDir, projectRef));
+    await trustedDirectoryIdentity(this.deploymentDir(projectRef, deploymentId));
+    const releasesDir = this.releasesDir(projectRef, deploymentId);
+    await this.ensurePrivateDirectory(releasesDir);
+    const stagingRoot = join(releasesDir, ".staging");
+    await this.ensurePrivateDirectory(stagingRoot);
+    return stagingRoot;
+  }
+
+  private async ensurePrivateDirectory(path: string): Promise<void> {
+    try {
+      await mkdir(path, { mode: 0o700 });
+    } catch (error: unknown) {
+      if (nodeErrorCode(error) !== "EEXIST") throw error;
+    }
+    const binding = await openTrustedDirectory(path);
+    try {
+      await binding.handle.chmod(0o700);
+      await binding.handle.sync();
+      const metadata = await binding.handle.stat();
+      if ((metadata.mode & 0o777) !== 0o700) {
+        throw frontendReleaseError(
+          "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+          500,
+          "Frontend release staging permissions are invalid",
+        );
+      }
+      await assertDirectoryBinding(path, binding);
+    } finally {
+      await binding.handle.close();
+    }
+  }
+
+  async prepareReleaseUpload(
+    projectRef: string,
+    deploymentId: string,
+    expectedLength: number,
+  ): Promise<FrontendReleaseUploadSession> {
+    if (!Number.isSafeInteger(expectedLength) || expectedLength < 1
+      || expectedLength > FRONTEND_RELEASE_ARCHIVE_MAX_BYTES) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_ARCHIVE_TOO_LARGE",
+        413,
+        `Frontend release archive exceeds ${FRONTEND_RELEASE_ARCHIVE_MAX_BYTES} bytes`,
+      );
+    }
+    await this.assertMutationSupported(projectRef, deploymentId);
+    const stagingRoot = await this.stagingRoot(projectRef, deploymentId);
+    const stagingRootBinding = await openTrustedDirectory(stagingRoot);
+    let stagingDirBinding: OpenDirectoryBinding | undefined;
+    let archiveHandle: Awaited<ReturnType<typeof open>> | undefined;
+    let stagingDir = "";
+    try {
+      const boundStagingDir = await mkdtemp(join(boundDirectoryPath(stagingRootBinding), "upload-"));
+      const stagingDirName = basename(boundStagingDir);
+      stagingDir = join(stagingRoot, stagingDirName);
+      await chmod(boundStagingDir, 0o700);
+      const stagingDirIdentity = await pathIdentity(boundStagingDir, "directory");
+      stagingDirBinding = await openTrustedDirectory(stagingDir);
+      await assertBoundEntry(stagingRoot, stagingRootBinding, stagingDirName, stagingDirIdentity, "directory");
+      const archivePath = join(boundDirectoryPath(stagingDirBinding), "archive.zip");
+      archiveHandle = await open(
+        archivePath,
+        fsConstants.O_RDWR | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+        0o600,
+      );
+      const state: PreparedArchiveState = {
+        projectRef,
+        deploymentId,
+        expectedLength,
+        stagingRoot,
+        stagingRootBinding,
+        stagingDir,
+        stagingDirBinding,
+        stagingDirIdentity,
+        archiveHandle,
+        archiveIdentity: null,
+        archivePath,
+        hash: createHash("sha256"),
+        written: 0,
+        status: "open",
+      };
+      return this.uploadSession(state);
+    } catch (error: unknown) {
+      await archiveHandle?.close().catch(() => undefined);
+      await stagingDirBinding?.handle.close().catch(() => undefined);
+      if (stagingDir) await removeBoundDirectory(stagingDir).catch(() => undefined);
+      await stagingRootBinding.handle.close();
+      throw error;
+    }
+  }
+
+  private uploadSession(state: PreparedArchiveState): FrontendReleaseUploadSession {
+    return Object.freeze({
+      write: (chunk: Uint8Array) => writeArchiveChunk(state, chunk),
+      finish: async (expectedSha256: string) => {
+        const descriptor = await finishArchiveUpload(state, expectedSha256);
+        this.stagedArchives.set(descriptor, state);
+        return descriptor;
+      },
+      abort: () => this.abortPreparedUpload(state),
+    });
+  }
+
+  private async abortPreparedUpload(state: PreparedArchiveState): Promise<void> {
+    if (state.status === "closed" || state.status === "consuming") return;
+    state.status = "closed";
+    await state.archiveHandle.close().catch(() => undefined);
+    await this.removePreparedUpload(state);
+  }
+
+  private async removePreparedUpload(state: PreparedArchiveState): Promise<void> {
+    try {
+      await this.clearPreparedUploadContents(state);
+      await assertBoundEntry(
+        state.stagingRoot,
+        state.stagingRootBinding,
+        basename(state.stagingDir),
+        state.stagingDirIdentity,
+        "directory",
+      );
+      await rmdir(join(
+        boundDirectoryPath(state.stagingRootBinding),
+        basename(state.stagingDir),
+      ));
+      await state.stagingRootBinding.handle.sync();
+      await assertDirectoryBinding(state.stagingRoot, state.stagingRootBinding);
+    } finally {
+      await state.stagingDirBinding.handle.close().catch(() => undefined);
+      await state.stagingRootBinding.handle.close().catch(() => undefined);
+    }
+  }
+
+  private async clearPreparedUploadContents(state: PreparedArchiveState): Promise<void> {
+    const boundStagingDir = boundDirectoryPath(state.stagingDirBinding);
+    const entries = await readdir(boundStagingDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = join(boundStagingDir, entry.name);
+      if (entry.isDirectory()) {
+        await removeBoundDirectory(entryPath);
+      } else {
+        await unlink(entryPath);
+      }
+    }
+    await state.stagingDirBinding.handle.sync();
+  }
+
+  async releaseRecord(
+    projectRef: string,
+    deploymentId: string,
+    releaseId: string,
+  ): Promise<FrontendReleaseRecord> {
+    assertReleaseId(releaseId);
+    const releaseDir = this.releaseDir(projectRef, deploymentId, releaseId);
+    const directory = await lstat(releaseDir).catch(() => null);
+    if (!directory?.isDirectory() || directory.isSymbolicLink() || (directory.mode & 0o222) !== 0
+      || await realpath(releaseDir).catch(() => "") !== releaseDir) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_NOT_FOUND",
+        404,
+        "Frontend release not found or invalid",
+      );
+    }
+    const metadata = parseReleaseRecord(JSON.parse(new TextDecoder().decode(
+      await secureFileBytes(join(releaseDir, "release.json")),
+    )));
+    if (metadata.project_ref !== projectRef || metadata.deployment_id !== deploymentId
+      || metadata.release_id !== releaseId) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_INVALID",
+        500,
+        "Frontend release identity does not match its storage path",
+      );
+    }
+    const archive = await openVerifiedFile(join(releaseDir, "archive.zip"), metadata.size_bytes);
+    let zip: VerifiedZipArchive;
+    try {
+      if (archive.sha256 !== metadata.sha256) {
+        throw frontendReleaseError(
+          "FRONTEND_RELEASE_STORAGE_INVALID",
+          500,
+          "Frontend release archive verification failed",
+        );
+      }
+      zip = await verifiedZipArchive(archive.handle, metadata.size_bytes);
+    } finally {
+      await archive.handle.close();
+    }
+    const files = await verifiedTree(join(releaseDir, "build"), zip.entries, true);
+    if (files.length !== metadata.file_count || treeSha256(files) !== metadata.tree_sha256) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_INVALID",
+        500,
+        "Frontend release integrity verification failed",
+      );
+    }
+    return metadata;
+  }
+
+  async activeRelease(
+    projectRef: string,
+    deploymentId: string,
+  ): Promise<FrontendActiveReleaseRecord | null> {
+    let bytes: Uint8Array;
+    try {
+      bytes = await secureFileBytes(this.activePath(projectRef, deploymentId));
+    } catch (error: unknown) {
+      if (nodeErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    const active = parseActiveRelease(JSON.parse(new TextDecoder().decode(bytes)));
+    if (active.project_ref !== projectRef || active.deployment_id !== deploymentId) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_AUTHORITY_INVALID",
+        500,
+        "Frontend active release identity is invalid",
+      );
+    }
+    const release = await this.releaseRecord(projectRef, deploymentId, active.release_id);
+    if (release.sha256 !== active.sha256 || release.tree_sha256 !== active.tree_sha256) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_AUTHORITY_INVALID",
+        500,
+        "Frontend active release does not match its immutable artifact",
+      );
+    }
+    return active;
+  }
+
+  async writeActiveRelease(
+    projectRef: string,
+    deploymentId: string,
+    record: FrontendActiveReleaseRecord | null,
+  ): Promise<void> {
+    const directory = this.deploymentDir(projectRef, deploymentId);
+    await trustedDirectoryIdentity(directory);
+    const path = this.activePath(projectRef, deploymentId);
+    if (!record) {
+      await removeBoundFile(directory, path);
+      return;
+    }
+    await writeFileAtomic(directory, path, `${JSON.stringify(record)}\n`);
+  }
+
+  async compareAndSwapActiveRelease(
+    projectRef: string,
+    deploymentId: string,
+    expectedReleaseId: "absent" | string,
+    expectedActivationId: "absent" | string,
+    record: FrontendActiveReleaseRecord | null,
+  ): Promise<"updated" | "conflict"> {
+    const current = await this.activeRelease(projectRef, deploymentId);
+    if ((current?.release_id ?? "absent") !== expectedReleaseId
+      || (current?.activation_id ?? "absent") !== expectedActivationId) return "conflict";
+    await this.writeActiveRelease(projectRef, deploymentId, record);
+    const readBack = await this.activeRelease(projectRef, deploymentId);
+    if ((readBack?.release_id ?? "absent") !== (record?.release_id ?? "absent")
+      || (readBack?.activation_id ?? "absent") !== (record?.activation_id ?? "absent")) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_AUTHORITY_INVALID",
+        500,
+        "Frontend active release authority read-back failed",
+      );
+    }
+    return "updated";
+  }
+
+  async activeBuildDir(projectRef: string, deploymentId: string): Promise<string | null> {
+    assertFrontendIdentity(projectRef, deploymentId);
+    try {
+      await lstat(this.activePath(projectRef, deploymentId));
+    } catch (error: unknown) {
+      if (nodeErrorCode(error) === "ENOENT") return null;
+      throw error;
+    }
+    await this.deployment(projectRef, deploymentId);
+    const active = await this.activeRelease(projectRef, deploymentId);
+    return active ? this.releaseBuildDir(projectRef, deploymentId, active.release_id) : null;
+  }
+
+  async hasActiveRelease(projectRef: string, deploymentId: string): Promise<boolean> {
+    assertFrontendIdentity(projectRef, deploymentId);
+    try {
+      await lstat(this.activePath(projectRef, deploymentId));
+      return true;
+    } catch (error: unknown) {
+      if (nodeErrorCode(error) === "ENOENT") return false;
+      throw error;
+    }
+  }
+
+  async createRelease(
+    projectRef: string,
+    deploymentId: string,
+    archive: VerifiedStagedFrontendArchive,
+  ): Promise<FrontendReleaseRecord> {
+    const state = this.stagedArchives.get(archive);
+    if (!state || state.status !== "finished" || state.projectRef !== projectRef
+      || state.deploymentId !== deploymentId || state.archiveIdentity === null
+      || archive.size_bytes !== state.expectedLength || archive.sha256.length !== 64) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_ARCHIVE_INVALID",
+        400,
+        "Frontend release staged archive is invalid or already consumed",
+      );
+    }
+    state.status = "consuming";
+    this.stagedArchives.delete(archive);
+    try {
+      await this.assertPreparedArchive(state);
+      return await this.publishRelease(state, archive.sha256);
+    } finally {
+      await state.archiveHandle.close().catch(() => undefined);
+      state.status = "closed";
+      await this.removePreparedUpload(state);
+    }
+  }
+
+  private async assertPreparedArchive(state: PreparedArchiveState): Promise<void> {
+    await assertBoundEntry(
+      state.stagingRoot,
+      state.stagingRootBinding,
+      basename(state.stagingDir),
+      state.stagingDirIdentity,
+      "directory",
+    );
+    const current = fileIdentity(await state.archiveHandle.stat());
+    if (!state.archiveIdentity || !sameFile(state.archiveIdentity, current)
+      || current.size !== state.expectedLength) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+        500,
+        "Frontend release staged archive identity changed",
+      );
+    }
+    const requested = await pathIdentity(join(state.stagingDir, "archive.zip"), "file");
+    if (requested.dev !== current.dev || requested.ino !== current.ino) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_UNTRUSTED",
+        500,
+        "Frontend release staged archive path changed",
+      );
+    }
+  }
+
+  private async publishRelease(
+    state: PreparedArchiveState,
+    releaseId: string,
+  ): Promise<FrontendReleaseRecord> {
+    const zip = await verifiedZipArchive(state.archiveHandle, state.expectedLength);
+    return this.publishStagingRelease({ state, releaseId, zip });
+  }
+
+  private async publishStagingRelease(input: {
+    state: PreparedArchiveState;
+    releaseId: string;
+    zip: VerifiedZipArchive;
+  }): Promise<FrontendReleaseRecord> {
+    const artifactDir = join(input.state.stagingDir, "artifact");
+    const archivePath = join(artifactDir, "archive.zip");
+    const buildDir = join(artifactDir, "build");
+    await mkdir(artifactDir, { mode: 0o700 });
+    await mkdir(buildDir, { mode: 0o700 });
+    await extractVerifiedZip(input.state.archiveHandle, input.zip, buildDir);
+    await rename(input.state.archivePath, archivePath);
+    await input.state.stagingDirBinding.handle.sync();
+    const files = await verifiedTree(buildDir, input.zip.entries);
+    const record: FrontendReleaseRecord = {
+      schema: FRONTEND_RELEASE_SCHEMA,
+      project_ref: input.state.projectRef,
+      deployment_id: input.state.deploymentId,
+      release_id: input.releaseId,
+      sha256: input.releaseId,
+      tree_sha256: treeSha256(files),
+      size_bytes: input.state.expectedLength,
+      file_count: files.length,
+      created_at: this.now().toISOString(),
+      kind: "prebuilt_static",
+    };
+    await writeFileAtomic(artifactDir, join(artifactDir, "release.json"), `${JSON.stringify(record)}\n`);
+    await freezeTree(artifactDir, false);
+    return this.commitStagingRelease({
+      projectRef: input.state.projectRef,
+      deploymentId: input.state.deploymentId,
+      releaseId: input.releaseId,
+      artifactDir,
+    }, record);
+  }
+
+  private async commitStagingRelease(
+    input: { projectRef: string; deploymentId: string; releaseId: string; artifactDir: string },
+    record: FrontendReleaseRecord,
+  ): Promise<FrontendReleaseRecord> {
+    const finalDir = this.releaseDir(input.projectRef, input.deploymentId, input.releaseId);
+    const publish = await publishImmutableDirectory({
+      sourceDir: input.artifactDir,
+      finalDir,
+      beforePublish: this.beforePublish,
+    });
+    if (publish === "exists") {
+      return this.releaseRecord(input.projectRef, input.deploymentId, input.releaseId);
+    }
+    const readBack = await this.releaseRecord(input.projectRef, input.deploymentId, input.releaseId);
+    if (readBack.tree_sha256 !== record.tree_sha256) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_INVALID",
+        500,
+        "Frontend release publish read-back failed",
+      );
+    }
+    return readBack;
+  }
+
+  async listReleases(
+    projectRef: string,
+    deploymentId: string,
+    page: FrontendReleaseListPage,
+  ): Promise<FrontendReleaseInventory> {
+    await this.deployment(projectRef, deploymentId);
+    if (!Number.isSafeInteger(page.limit) || page.limit < 1
+      || page.limit > FRONTEND_RELEASE_LIST_MAX_LIMIT
+      || (page.cursor !== undefined && !RELEASE_ID_PATTERN.test(page.cursor))) {
+      throw frontendReleaseError(
+        "FRONTEND_RELEASE_PAGE_INVALID",
+        400,
+        `Frontend release page limit must be 1-${FRONTEND_RELEASE_LIST_MAX_LIMIT}`,
+      );
+    }
+    const entries = await readdir(this.releasesDir(projectRef, deploymentId), { withFileTypes: true })
+      .catch((error: unknown) => {
+        if (nodeErrorCode(error) === "ENOENT") return [];
+        throw error;
+      });
+    const releaseIds = entries.filter((entry) => entry.name !== ".staging").map((entry) => {
+      if (!entry.isDirectory() || !RELEASE_ID_PATTERN.test(entry.name)) {
+        throw frontendReleaseError(
+          "FRONTEND_RELEASE_STORAGE_INVALID",
+          500,
+          "Frontend release inventory contains an invalid entry",
+        );
+      }
+      return entry.name;
+    }).sort();
+    const start = page.cursor === undefined
+      ? 0
+      : releaseIds.findIndex((releaseId) => releaseId > page.cursor!);
+    const pageIds = start < 0 ? [] : releaseIds.slice(start, start + page.limit + 1);
+    const hasMore = pageIds.length > page.limit;
+    const selectedIds = hasMore ? pageIds.slice(0, page.limit) : pageIds;
+    const releases: FrontendReleaseRecord[] = [];
+    for (const releaseId of selectedIds) {
+      releases.push(await this.releaseRecord(projectRef, deploymentId, releaseId));
+    }
+    const active = await this.activeRelease(projectRef, deploymentId);
+    return {
+      project_ref: projectRef,
+      deployment_id: deploymentId,
+      active_release_id: active?.release_id ?? null,
+      active_activation_id: active?.activation_id ?? null,
+      releases,
+      next_cursor: hasMore ? selectedIds.at(-1)! : null,
+    };
+  }
+}

--- a/packages/management-api/src/services/frontend-release.service.ts
+++ b/packages/management-api/src/services/frontend-release.service.ts
@@ -1,0 +1,148 @@
+import { getVerifiedRequestPrincipal } from "../middleware/auth";
+import type { MutationPrincipal } from "./project-mutation.service";
+import { FrontendReleaseActivationService } from "./frontend-release-activation";
+import {
+  FRONTEND_RELEASE_ARCHIVE_MAX_BYTES,
+  FRONTEND_RELEASE_LIST_DEFAULT_LIMIT,
+  FrontendReleaseError,
+  type ActivateFrontendReleaseInput,
+  type FrontendReleaseActivation,
+  type FrontendReleaseGateway,
+  type FrontendReleaseInventory,
+  type FrontendReleaseListPage,
+  type FrontendReleaseRecord,
+  type FrontendReleaseUploadSession,
+  type VerifiedStagedFrontendArchive,
+} from "./frontend-release-contract";
+import { gatewayService } from "./gateway.service";
+import {
+  frontendReleaseMutationStore,
+  type FrontendReleaseMutationStore,
+} from "./frontend-release-mutation";
+import { FrontendReleaseStorage } from "./frontend-release-storage";
+import {
+  withFrontendDeploymentLock,
+  type FrontendDeploymentLock,
+} from "./frontend-deployment-lock";
+
+export {
+  FRONTEND_RELEASE_ARCHIVE_MAX_BYTES,
+  FRONTEND_RELEASE_LIST_DEFAULT_LIMIT,
+  FRONTEND_RELEASE_LIST_MAX_LIMIT,
+  FrontendReleaseError,
+  type ActivateFrontendReleaseInput,
+  type ExpectedActiveReleaseId,
+  type FrontendReleaseActivation,
+  type FrontendReleaseInventory,
+  type FrontendReleaseRecord,
+} from "./frontend-release-contract";
+
+interface FrontendReleaseServiceOptions {
+  baseDir?: string;
+  gateway?: FrontendReleaseGateway;
+  mutations?: FrontendReleaseMutationStore;
+  deploymentLock?: FrontendDeploymentLock;
+  now?: () => Date;
+  interruption?: (phase: "after_prepared" | "after_authority" | "after_route") => void;
+  beforePublish?: (artifactDir: string, finalDir: string) => Promise<void> | void;
+}
+
+export class FrontendReleaseService {
+  private readonly storage: FrontendReleaseStorage;
+  private readonly activation: FrontendReleaseActivationService;
+  private readonly mutations: FrontendReleaseMutationStore;
+  private readonly deploymentLock: FrontendDeploymentLock;
+
+  constructor(options: FrontendReleaseServiceOptions = {}) {
+    const gateway = options.gateway ?? gatewayService;
+    const mutations = options.mutations ?? frontendReleaseMutationStore();
+    this.deploymentLock = options.deploymentLock ?? withFrontendDeploymentLock;
+    this.mutations = mutations;
+    this.storage = new FrontendReleaseStorage({
+      baseDir: options.baseDir,
+      now: options.now,
+      beforePublish: options.beforePublish,
+    });
+    this.activation = new FrontendReleaseActivationService({
+      storage: this.storage,
+      gateway,
+      mutations,
+      deploymentLock: this.deploymentLock,
+      now: options.now,
+      interruption: options.interruption,
+    });
+  }
+
+  async createRelease(
+    projectRef: string,
+    deploymentId: string,
+    archive: VerifiedStagedFrontendArchive,
+  ): Promise<FrontendReleaseRecord> {
+    return this.deploymentLock(projectRef, deploymentId, async () => {
+      await this.storage.assertMutationSupported(projectRef, deploymentId);
+      return this.storage.createRelease(projectRef, deploymentId, archive);
+    });
+  }
+
+  prepareReleaseUpload(
+    projectRef: string,
+    deploymentId: string,
+    expectedLength: number,
+  ): Promise<FrontendReleaseUploadSession> {
+    return this.storage.prepareReleaseUpload(projectRef, deploymentId, expectedLength);
+  }
+
+  assertMutationSupported(projectRef: string, deploymentId: string): Promise<void> {
+    return this.storage.assertMutationSupported(projectRef, deploymentId);
+  }
+
+  release(
+    projectRef: string,
+    deploymentId: string,
+    releaseId: string,
+  ): Promise<FrontendReleaseRecord> {
+    return this.storage.releaseRecord(projectRef, deploymentId, releaseId);
+  }
+
+  listReleases(
+    projectRef: string,
+    deploymentId: string,
+    page: FrontendReleaseListPage = { limit: FRONTEND_RELEASE_LIST_DEFAULT_LIMIT },
+  ): Promise<FrontendReleaseInventory> {
+    return this.storage.listReleases(projectRef, deploymentId, page);
+  }
+
+  activeBuildDir(projectRef: string, deploymentId: string): Promise<string | null> {
+    return this.storage.activeBuildDir(projectRef, deploymentId);
+  }
+
+  hasActiveRelease(projectRef: string, deploymentId: string): Promise<boolean> {
+    return this.storage.hasActiveRelease(projectRef, deploymentId);
+  }
+
+  async hasUnresolvedActivation(projectRef: string, deploymentId: string): Promise<boolean> {
+    const mutation = await this.mutations.activeForDeployment(projectRef, deploymentId);
+    return mutation?.operation === "frontend.release.activate";
+  }
+
+  async activateRelease(input: ActivateFrontendReleaseInput): Promise<FrontendReleaseActivation> {
+    return this.deploymentLock(input.projectRef, input.deploymentId, async () => {
+      await this.storage.assertMutationSupported(input.projectRef, input.deploymentId);
+      return this.activation.activate(input);
+    });
+  }
+}
+
+export async function frontendReleasePrincipal(request: Request): Promise<MutationPrincipal> {
+  const principal = await getVerifiedRequestPrincipal(request);
+  if (!principal) {
+    throw new FrontendReleaseError(
+      "FRONTEND_RELEASE_PRINCIPAL_INVALID",
+      401,
+      "Frontend release principal could not be verified",
+    );
+  }
+  return principal;
+}
+
+export const frontendReleaseService = new FrontendReleaseService();

--- a/packages/management-api/src/services/frontend.service.ts
+++ b/packages/management-api/src/services/frontend.service.ts
@@ -12,10 +12,11 @@
  *   SSR: build -> start process -> readiness -> switch proxy route
  */
 import { $ } from "bun";
-import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
 import { logger } from "../utils/logger";
 import { config } from "../config";
+import { AppError } from "../utils/errors";
 import { normalizeBaseDomain } from "../utils/project-routing";
 import type {
   FrontendDeployment,
@@ -35,6 +36,10 @@ import {
 } from "./frontend-runtime";
 import { installManagedSystemdUnit, removeManagedSystemdUnit } from "./systemd-unit-broker";
 import { tenantRuntimeService } from "./tenant-runtime.service";
+import {
+  withFrontendDeploymentLock,
+  type FrontendDeploymentLock,
+} from "./frontend-deployment-lock";
 
 const FRONTEND_BASE_DIR = "/var/supacloud/frontends";
 const READINESS_TIMEOUT_MS = 30_000;
@@ -55,6 +60,26 @@ const STATIC_PRECOMPRESS_EXTENSIONS = new Set([
   ".xml",
 ]);
 const STATIC_IMAGE_OPTIMIZE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png"]);
+const IMMUTABLE_LEGACY_DEPLOY_ERROR = "Immutable frontend release is active or unresolved; upload and CAS activate a new release instead";
+
+export interface FrontendImmutableReleaseState {
+  activeBuildDir(projectRef: string, deploymentId: string): Promise<string | null>;
+  hasActiveRelease(projectRef: string, deploymentId: string): Promise<boolean>;
+  hasUnresolvedActivation(projectRef: string, deploymentId: string): Promise<boolean>;
+}
+
+interface PreparedLegacyBuild {
+  stagingDir: string;
+  buildLog: string;
+}
+
+type PreparedLegacySsrBuild = PreparedLegacyBuild;
+
+export type FrontendImmutableReleaseStateLoader = () => Promise<FrontendImmutableReleaseState>;
+
+const loadFrontendImmutableReleaseState: FrontendImmutableReleaseStateLoader = async () => (
+  (await import("./frontend-release.service")).frontendReleaseService
+);
 
 function normalizeHealthCheckPath(value: string | undefined): string {
   const path = value?.trim() || "/";
@@ -116,14 +141,23 @@ export class FrontendService {
   private baseDir: string;
   private domainService: FrontendDomainService;
   private recordService: FrontendRecordService;
+  private deploymentLock: FrontendDeploymentLock;
+  private releaseState: FrontendImmutableReleaseStateLoader;
 
-  constructor(baseDir: string = FRONTEND_BASE_DIR) {
+  constructor(
+    baseDir: string = FRONTEND_BASE_DIR,
+    deploymentLock: FrontendDeploymentLock = withFrontendDeploymentLock,
+    releaseState: FrontendImmutableReleaseStateLoader = loadFrontendImmutableReleaseState,
+  ) {
     this.baseDir = baseDir;
-    this.domainService = new FrontendDomainService(
-      baseDir,
-      this.getDeployment.bind(this),
-      this.configureGatewayRoute.bind(this),
-    );
+    this.deploymentLock = deploymentLock;
+    this.releaseState = releaseState;
+    this.domainService = new FrontendDomainService({
+      deploymentLock,
+      commitHostMutation: this.commitHostMutation.bind(this),
+      getDeployment: this.getDeployment.bind(this),
+      writeDeployment: this.writeDeployment.bind(this),
+    });
     this.recordService = new FrontendRecordService(baseDir);
   }
 
@@ -253,7 +287,8 @@ export class FrontendService {
           continue;
         }
 
-        const buildDir = this.joinPath(this.baseDir, ref, deployment.id, "build");
+        const activeBuildDir = await (await this.releaseState()).activeBuildDir(ref, deployment.id);
+        const buildDir = activeBuildDir || this.joinPath(this.baseDir, ref, deployment.id, "build");
         const buildStat = await stat(buildDir).catch(() => null);
         if (!buildStat?.isDirectory()) {
           skipped++;
@@ -281,6 +316,61 @@ export class FrontendService {
       logger.warn("[FrontendService] Failed to read deployment JSON", { error: err });
       return null;
     }
+  }
+
+  private async writeDeployment(deployment: FrontendDeployment): Promise<void> {
+    const deploymentPath = this.joinPath(
+      this.baseDir,
+      deployment.project_ref,
+      deployment.id,
+      "deployment.json",
+    );
+    const temporaryPath = `${deploymentPath}.tmp-${crypto.randomUUID()}`;
+    try {
+      await Bun.write(temporaryPath, JSON.stringify(deployment, null, 2));
+      await chmod(temporaryPath, 0o600);
+      await rename(temporaryPath, deploymentPath);
+    } finally {
+      try {
+        await rm(temporaryPath, { force: true });
+      } catch (error: unknown) {
+        logger.warn("[FrontendService] Failed to clean up deployment metadata temporary file", {
+          path: temporaryPath,
+          error,
+        });
+      }
+    }
+  }
+
+  private async assertLegacyMutationAllowed(
+    projectRef: string,
+    deploymentId: string,
+  ): Promise<void> {
+    const releases = await this.releaseState();
+    if (await releases.hasActiveRelease(projectRef, deploymentId)
+      || await releases.hasUnresolvedActivation(projectRef, deploymentId)) {
+      throw new AppError(
+        "Immutable frontend release is active or unresolved; use CAS release activation",
+        409,
+        "FRONTEND_RELEASE_ACTIVE",
+      );
+    }
+  }
+
+  private async legacyDeployBlocked(projectRef: string, deploymentId: string): Promise<boolean> {
+    const releases = await this.releaseState();
+    return await releases.hasActiveRelease(projectRef, deploymentId)
+      || await releases.hasUnresolvedActivation(projectRef, deploymentId);
+  }
+
+  private legacyDeployConflict(deploymentId: string): FrontendBuildResult {
+    return {
+      success: false,
+      deployment_id: deploymentId,
+      url: "",
+      build_log: "",
+      error: IMMUTABLE_LEGACY_DEPLOY_ERROR,
+    };
   }
 
   async createDeployment(projectRef: string, deploymentConfig: FrontendDeploymentConfig): Promise<FrontendDeployment> {
@@ -326,47 +416,52 @@ export class FrontendService {
     deploymentId: string,
     updates: Partial<FrontendDeploymentConfig>
   ): Promise<FrontendDeployment | null> {
-    const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) return null;
-
-    const definedUpdates = Object.fromEntries(
-      Object.entries(updates).filter(([, value]) => value !== undefined),
-    ) as Partial<FrontendDeploymentConfig>;
-    const normalizedUpdates = definedUpdates.health_check_path === undefined
-      ? definedUpdates
-      : {
-          ...definedUpdates,
-          health_check_path: normalizeHealthCheckPath(definedUpdates.health_check_path),
-        };
-    const updated = {
-      ...deployment,
-      ...normalizedUpdates,
-      updated_at: new Date().toISOString(),
-    };
-
-    await Bun.write(
-      this.joinPath(this.baseDir, projectRef, deploymentId, "deployment.json"),
-      JSON.stringify(updated, null, 2)
-    );
-
-    return updated;
+    return this.deploymentLock(projectRef, deploymentId, async () => {
+      const deployment = await this.getDeployment(projectRef, deploymentId);
+      if (!deployment) return null;
+      const definedUpdates = Object.fromEntries(
+        Object.entries(updates).filter(([, value]) => value !== undefined),
+      ) as Partial<FrontendDeploymentConfig>;
+      const normalizedUpdates = definedUpdates.health_check_path === undefined
+        ? definedUpdates
+        : {
+            ...definedUpdates,
+            health_check_path: normalizeHealthCheckPath(definedUpdates.health_check_path),
+          };
+      const updated = {
+        ...deployment,
+        ...normalizedUpdates,
+        updated_at: new Date().toISOString(),
+      };
+      const hostsChanged = deployment.domain !== updated.domain
+        || JSON.stringify(deployment.custom_domains) !== JSON.stringify(updated.custom_domains);
+      if (hostsChanged) {
+        if (deployment.status === "success") {
+          await this.commitHostMutation(deployment, updated);
+          return updated;
+        }
+        await this.assertLegacyMutationAllowed(projectRef, deploymentId);
+      }
+      await this.writeDeployment(updated);
+      return updated;
+    });
   }
 
-  async deleteDeployment(projectRef: string, deploymentId: string): Promise<boolean> {
-    const deploymentDir = this.joinPath(this.baseDir, projectRef, deploymentId);
-
-    try {
+  async deleteDeployment(
+    projectRef: string,
+    deploymentId: string,
+  ): Promise<"deleted" | "active" | "not_found"> {
+    return this.deploymentLock(projectRef, deploymentId, async () => {
+      const releases = await this.releaseState();
+      if (await releases.hasActiveRelease(projectRef, deploymentId)
+        || await releases.hasUnresolvedActivation(projectRef, deploymentId)) return "active";
       const deployment = await this.getDeployment(projectRef, deploymentId);
-      if (deployment) {
-        await this.stopProcess(projectRef, deploymentId);
-        await this.removeGatewayRoute(deployment);
-      }
-      await $`rm -rf ${deploymentDir}`.quiet();
-      return true;
-    } catch (err: unknown) {
-      logger.warn("[FrontendService] Failed to delete deployment", { error: err });
-      return false;
-    }
+      if (!deployment) return "not_found";
+      await this.stopProcess(projectRef, deploymentId);
+      await this.removeGatewayRoute(deployment);
+      await $`rm -rf ${this.joinPath(this.baseDir, projectRef, deploymentId)}`.quiet();
+      return "deleted";
+    });
   }
 
   async listDnsRecords(projectRef: string, deploymentId: string): Promise<FrontendDnsRecord[] | null> {
@@ -414,8 +509,22 @@ export class FrontendService {
     sourcePath: string
   ): Promise<FrontendBuildResult> {
     const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) {
+    if (!deployment) return this.missingDeploymentResult(deploymentId);
+    return this.deploymentLock(projectRef, deploymentId, () =>
+      this.deployFromSourceUnderLock(projectRef, deploymentId, sourcePath));
+  }
+
+  private async deployFromSourceUnderLock(
+    projectRef: string,
+    deploymentId: string,
+    sourcePath: string,
+  ): Promise<FrontendBuildResult> {
+    if (!await this.getDeployment(projectRef, deploymentId)) {
       return { success: false, deployment_id: deploymentId, url: "", build_log: "", error: "Deployment not found" };
+    }
+
+    if (await this.legacyDeployBlocked(projectRef, deploymentId)) {
+      return this.legacyDeployConflict(deploymentId);
     }
 
     const deploymentDir = this.joinPath(this.baseDir, projectRef, deploymentId);
@@ -447,8 +556,24 @@ export class FrontendService {
     branch: string = "main"
   ): Promise<FrontendBuildResult> {
     const deployment = await this.getDeployment(projectRef, deploymentId);
-    if (!deployment) {
+    if (!deployment) return this.missingDeploymentResult(deploymentId);
+    return this.deploymentLock(projectRef, deploymentId, () =>
+      this.deployFromGitUnderLock(projectRef, deploymentId, gitUrl, branch));
+  }
+
+  private async deployFromGitUnderLock(
+    projectRef: string,
+    deploymentId: string,
+    gitUrl: string,
+    branch: string,
+  ): Promise<FrontendBuildResult> {
+    if (!await this.getDeployment(projectRef, deploymentId)) {
       return { success: false, deployment_id: deploymentId, url: "", build_log: "", error: "Deployment not found" };
+    }
+
+
+    if (await this.legacyDeployBlocked(projectRef, deploymentId)) {
+      return this.legacyDeployConflict(deploymentId);
     }
 
     const deploymentDir = this.joinPath(this.baseDir, projectRef, deploymentId);
@@ -513,8 +638,6 @@ export class FrontendService {
       return { success: false, deployment_id: deploymentId, url: "", build_log: "", error: "Deployment not found" };
     }
 
-    const deploymentDir = this.joinPath(this.baseDir, projectRef, deploymentId);
-    const buildDir = this.joinPath(deploymentDir, "build");
     let buildLog = "";
 
     await this.updateDeployment(projectRef, deploymentId, { status: "building" } as Partial<FrontendDeployment>);
@@ -547,38 +670,12 @@ export class FrontendService {
       }
 
       const defaults = FRAMEWORK_DEFAULTS[deployment.framework];
-      const outputDir = this.joinPath(sourceDir, deployment.output_dir);
-      await $`rm -rf ${buildDir} && cp -r ${outputDir} ${buildDir}`.quiet();
-      if (deployment.framework === "sveltekit") {
-        await prepareSvelteKitRuntime(sourceDir, buildDir);
-      }
-      if (!defaults.is_ssr) {
-        await this.precompressStaticAssets(buildDir);
-      }
-
       if (defaults.is_ssr) {
-        // Blue-green: start process FIRST, but do NOT route traffic yet
-        const port = await this.startProcess(projectRef, deploymentId, deployment, buildDir, defaults.is_ssr);
-
-        const ready = await this.waitForReadiness(port, deployment.health_check_path || defaults.health_check_path);
-        if (!ready) {
-          // Rollback: stop the process, leave the gateway pointing at old state (or nothing)
-          logger.error(`[FrontendService] Readiness failed for ${projectRef}/${deploymentId}, stopping process`);
-          await this.stopProcess(projectRef, deploymentId);
-          throw new Error(`Frontend process failed readiness check on port ${port} within ${READINESS_TIMEOUT_MS}ms`);
-        }
+        const prepared = await this.prepareLegacySsrBuild(deployment, sourceDir, buildLog);
+        return await this.publishLegacySsrBuild(projectRef, deploymentId, prepared);
       }
-
-      // Static Caddy routes serve buildDir directly; process-backed routes proxy after readiness.
-      await this.configureGatewayRoute(deployment, buildDir, defaults.is_ssr);
-
-      await this.updateDeployment(projectRef, deploymentId, {
-        status: "success",
-        last_deployed_at: new Date().toISOString(),
-        build_log: buildLog,
-      } as Partial<FrontendDeployment>);
-
-      return { success: true, deployment_id: deploymentId, url: deployment.deployment_url, build_log: buildLog };
+      const prepared = await this.prepareLegacyBuild(deployment, sourceDir, buildLog);
+      return await this.publishLegacyBuild(projectRef, deploymentId, prepared);
     } catch (error: unknown) {
       buildLog += `\nError: ${error instanceof Error ? error.message : String(error)}\n`;
       await this.updateDeployment(projectRef, deploymentId, {
@@ -596,29 +693,283 @@ export class FrontendService {
     }
   }
 
+  private async prepareLegacyBuild(
+    deployment: FrontendDeployment,
+    sourceDir: string,
+    buildLog: string,
+  ): Promise<PreparedLegacyBuild> {
+    const deploymentDir = this.joinPath(this.baseDir, deployment.project_ref, deployment.id);
+    const stagingDir = await mkdtemp(this.joinPath(deploymentDir, ".legacy-build-"));
+    const outputDir = this.joinPath(sourceDir, deployment.output_dir);
+    try {
+      await $`cp -r ${outputDir}/. ${stagingDir}`.quiet();
+      await this.precompressStaticAssets(stagingDir);
+      await chmod(stagingDir, 0o755);
+      return { stagingDir, buildLog };
+    } catch (error: unknown) {
+      await rm(stagingDir, { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  private async publishLegacyBuild(
+    projectRef: string,
+    deploymentId: string,
+    prepared: PreparedLegacyBuild,
+  ): Promise<FrontendBuildResult> {
+    try {
+      return await this.deploymentLock(projectRef, deploymentId, async () => {
+        await this.assertLegacyMutationAllowed(projectRef, deploymentId);
+        const deployment = await this.getDeployment(projectRef, deploymentId);
+        if (!deployment) throw new Error("Deployment not found");
+        const buildDir = this.joinPath(this.baseDir, projectRef, deploymentId, "build");
+        const backupDir = await this.publishPreparedBuild(prepared.stagingDir, buildDir);
+        try {
+          await this.publishLegacyRoute(deployment, buildDir);
+          await this.writeDeployment({
+            ...deployment,
+            status: "success" as const,
+            last_deployed_at: new Date().toISOString(),
+            build_log: prepared.buildLog,
+            updated_at: new Date().toISOString(),
+          });
+        } catch (error: unknown) {
+          await this.restorePreviousBuild(buildDir, backupDir);
+          throw error;
+        }
+        if (backupDir) await this.removeLegacyBuildArtifact(backupDir);
+        return {
+          success: true,
+          deployment_id: deploymentId,
+          url: deployment.deployment_url,
+          build_log: prepared.buildLog,
+        };
+      });
+    } finally {
+      await this.removeLegacyBuildArtifact(prepared.stagingDir);
+    }
+  }
+
+  private async publishLegacySsrBuild(
+    projectRef: string,
+    deploymentId: string,
+    prepared: PreparedLegacySsrBuild,
+  ): Promise<FrontendBuildResult> {
+    try {
+      return await this.deploymentLock(projectRef, deploymentId, () =>
+        this.commitLegacySsrBuild(projectRef, deploymentId, prepared));
+    } finally {
+      await this.removeLegacyBuildArtifact(prepared.stagingDir);
+    }
+  }
+
+  private async commitLegacySsrBuild(
+    projectRef: string,
+    deploymentId: string,
+    prepared: PreparedLegacySsrBuild,
+  ): Promise<FrontendBuildResult> {
+    await this.assertLegacyMutationAllowed(projectRef, deploymentId);
+    const deployment = await this.getDeployment(projectRef, deploymentId);
+    if (!deployment) throw new Error("Deployment not found");
+    const buildDir = this.joinPath(this.baseDir, projectRef, deploymentId, "build");
+    const backupDir = await this.publishPreparedBuild(prepared.stagingDir, buildDir);
+    try {
+      await this.startReadyLegacySsrProcess(deployment, buildDir);
+      await this.applyGatewayRoute(deployment, buildDir, true, null);
+      await this.writeSuccessfulDeployment(deployment, prepared.buildLog);
+    } catch (publishError: unknown) {
+      await this.rollbackLegacySsrBuild(deployment, buildDir, backupDir, publishError);
+    }
+    if (backupDir) await this.removeLegacyBuildArtifact(backupDir);
+    return this.successfulBuildResult(deployment, prepared.buildLog);
+  }
+
+  private async startReadyLegacySsrProcess(
+    deployment: FrontendDeployment,
+    buildDir: string,
+  ): Promise<void> {
+    const port = await this.startProcess(
+      deployment.project_ref,
+      deployment.id,
+      deployment,
+      buildDir,
+      true,
+    );
+    if (await this.waitForReadiness(port, deployment.health_check_path || "/")) return;
+    throw new Error(`Frontend process failed readiness check on port ${port} within ${READINESS_TIMEOUT_MS}ms`);
+  }
+
+  private async rollbackLegacySsrBuild(
+    deployment: FrontendDeployment,
+    buildDir: string,
+    backupDir: string | null,
+    publishError: unknown,
+  ): Promise<never> {
+    try {
+      await this.stopProcess(deployment.project_ref, deployment.id);
+      await this.restorePreviousBuild(buildDir, backupDir);
+      if (backupDir) await this.startReadyLegacySsrProcess(deployment, buildDir);
+    } catch (rollbackError: unknown) {
+      throw new AggregateError(
+        [publishError, rollbackError],
+        "Frontend SSR publication and rollback both failed",
+      );
+    }
+    throw publishError;
+  }
+
+  private async writeSuccessfulDeployment(
+    deployment: FrontendDeployment,
+    buildLog: string,
+  ): Promise<void> {
+    await this.writeDeployment({
+      ...deployment,
+      status: "success" as const,
+      last_deployed_at: new Date().toISOString(),
+      build_log: buildLog,
+      updated_at: new Date().toISOString(),
+    });
+  }
+
+  private successfulBuildResult(
+    deployment: FrontendDeployment,
+    buildLog: string,
+  ): FrontendBuildResult {
+    return {
+      success: true,
+      deployment_id: deployment.id,
+      url: deployment.deployment_url,
+      build_log: buildLog,
+    };
+  }
+
+  private missingDeploymentResult(deploymentId: string): FrontendBuildResult {
+    return {
+      success: false,
+      deployment_id: deploymentId,
+      url: "",
+      build_log: "",
+      error: "Deployment not found",
+    };
+  }
+
+  private async prepareLegacySsrBuild(
+    deployment: FrontendDeployment,
+    sourceDir: string,
+    buildLog: string,
+  ): Promise<PreparedLegacySsrBuild> {
+    const deploymentDir = this.joinPath(this.baseDir, deployment.project_ref, deployment.id);
+    const stagingDir = await mkdtemp(this.joinPath(deploymentDir, ".legacy-ssr-build-"));
+    try {
+      await $`cp -r ${this.joinPath(sourceDir, deployment.output_dir)}/. ${stagingDir}`.quiet();
+      if (deployment.framework === "sveltekit") {
+        await prepareSvelteKitRuntime(sourceDir, stagingDir);
+      }
+      await chmod(stagingDir, 0o755);
+      return { stagingDir, buildLog };
+    } catch (error: unknown) {
+      await rm(stagingDir, { recursive: true, force: true });
+      throw error;
+    }
+  }
+
+  private async publishPreparedBuild(stagingDir: string, buildDir: string): Promise<string | null> {
+    const backupDir = `${buildDir}.previous-${crypto.randomUUID()}`;
+    const existing = await stat(buildDir).catch(() => null);
+    if (existing) await rename(buildDir, backupDir);
+    try {
+      await rename(stagingDir, buildDir);
+    } catch (publishError: unknown) {
+      if (!existing) throw publishError;
+      try {
+        await rename(backupDir, buildDir);
+      } catch (restoreError: unknown) {
+        throw new AggregateError(
+          [publishError, restoreError],
+          "Frontend build publication and rollback both failed",
+        );
+      }
+      throw publishError;
+    }
+    return existing ? backupDir : null;
+  }
+
+  private async restorePreviousBuild(buildDir: string, backupDir: string | null): Promise<void> {
+    await rm(buildDir, { recursive: true, force: true });
+    if (backupDir) await rename(backupDir, buildDir);
+  }
+
+  private async removeLegacyBuildArtifact(path: string): Promise<void> {
+    try {
+      await rm(path, { recursive: true, force: true });
+    } catch (error: unknown) {
+      logger.warn("[FrontendService] Failed to clean up legacy build artifact", { path, error });
+    }
+  }
+
+  private async publishLegacyRoute(
+    deployment: FrontendDeployment,
+    buildDir: string,
+  ): Promise<void> {
+    await this.applyGatewayRoute(deployment, buildDir, false, null);
+  }
+
   // ── Gateway (Web Server) Config ───────────────────────────────────
 
   async configureGatewayRoute(deployment: FrontendDeployment, buildDir: string, isSSR: boolean): Promise<void> {
-    const port = 30000 + parseInt(deployment.id, 16) % 10000;
-    const hosts = [deployment.domain, ...deployment.custom_domains];
+    await this.deploymentLock(deployment.project_ref, deployment.id, async () => {
+      const currentDeployment = await this.getDeployment(deployment.project_ref, deployment.id);
+      if (!currentDeployment) throw new Error("Deployment not found");
+      const activeBuildDir = await (await this.releaseState())
+        .activeBuildDir(deployment.project_ref, deployment.id);
+      await this.applyGatewayRoute(currentDeployment, buildDir, isSSR, activeBuildDir);
+    });
+  }
 
+  private async applyGatewayRoute(
+    deployment: FrontendDeployment,
+    buildDir: string,
+    isSSR: boolean,
+    activeBuildDir: string | null,
+  ): Promise<void> {
+    const port = 30000 + parseInt(deployment.id, 16) % 10000;
     const { gatewayService } = await import("./gateway.service");
     await gatewayService.configureFrontendRoute({
       projectRef: deployment.project_ref,
       deploymentId: deployment.id,
-      hosts,
-      port: isSSR ? port : undefined,
-      root: isSSR ? undefined : buildDir,
-      mode: isSSR ? "proxy" : "static",
+      hosts: [deployment.domain, ...deployment.custom_domains],
+      port: activeBuildDir ? undefined : isSSR ? port : undefined,
+      root: activeBuildDir || (isSSR ? undefined : buildDir),
+      mode: activeBuildDir || !isSSR ? "static" : "proxy",
     });
   }
 
   private async removeGatewayRoute(deployment: FrontendDeployment): Promise<void> {
     const { gatewayService } = await import("./gateway.service");
+    await gatewayService.removeFrontendRoute(deployment.project_ref, deployment.id);
+  }
 
+  private async commitHostMutation(
+    previous: FrontendDeployment,
+    updated: FrontendDeployment,
+  ): Promise<void> {
+    await this.assertLegacyMutationAllowed(updated.project_ref, updated.id);
+    const buildDir = this.joinPath(this.baseDir, updated.project_ref, updated.id, "build");
+    const isSSR = FRAMEWORK_DEFAULTS[previous.framework].is_ssr;
+    await this.applyGatewayRoute(updated, buildDir, isSSR, null);
     try {
-        await gatewayService.removeFrontendRoute(deployment.project_ref, deployment.id);
-    } catch (e: unknown) { logger.debug("suppressed error removing route", { error: String(e) }); }
+      await this.writeDeployment(updated);
+    } catch (commitError: unknown) {
+      try {
+        await this.applyGatewayRoute(previous, buildDir, FRAMEWORK_DEFAULTS[previous.framework].is_ssr, null);
+      } catch (rollbackError: unknown) {
+        throw new AggregateError(
+          [commitError, rollbackError],
+          "Frontend domain metadata commit and gateway rollback both failed",
+        );
+      }
+      throw commitError;
+    }
   }
 
 

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -11,8 +11,10 @@ import {
 } from "../utils/project-routing";
 import { normalizeProjectConfig, resolveExternalAuthEndpointConfig } from "../utils/project-config";
 import { uniqueStrings } from "../utils/strings";
+import { stableStringify } from "../utils/stable-json";
 import { GOTRUE_USER_ID_POSTGRES_PATTERN } from "../utils/project-user-lifecycle";
 import { assertUniqueCaddyIds, runCaddyStartupPreflight } from "./caddy-startup-preflight";
+import { FRONTEND_GATEWAY_DURABILITY_UNKNOWN_CODE } from "./frontend-release-contract";
 import {
     type CaddyHeaderValue,
     type CaddyRoute,
@@ -43,14 +45,60 @@ export {
 } from "./gateway-route-builders";
 export type { CustomGatewayRouteConfig } from "./gateway-route-builders";
 
-import * as path from "node:path";
+import { AsyncLocalStorage } from "node:async_hooks";
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 
 export interface GatewayConfig {
     rateLimitTier?: "free" | "pro" | "enterprise";
     corsOrigins?: string;
     jwtEnabled?: boolean;
     jwtSecret?: string;
+}
+
+type CaddyLiveCandidateState = "candidate" | "different" | "unknown";
+type CaddyGatewayDurabilityStage =
+    | "candidate_sync"
+    | "candidate_rename"
+    | "config_directory_sync"
+    | "notice_open"
+    | "notice_write"
+    | "notice_sync"
+    | "notice_directory_sync";
+
+class CaddyGatewayDurabilityError extends Error {
+    readonly code = FRONTEND_GATEWAY_DURABILITY_UNKNOWN_CODE;
+    readonly preserveCandidate = true;
+
+    constructor(message: string) {
+        super(message);
+        this.name = "CaddyGatewayDurabilityError";
+    }
+}
+
+function preservesGatewayCandidate(error: unknown): boolean {
+    return error instanceof CaddyGatewayDurabilityError && error.preserveCandidate;
+}
+
+function fileErrorCode(error: unknown): string {
+    return typeof error === "object" && error !== null && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : "";
+}
+
+function initializedMarkerPath(): string {
+    return path.join(path.dirname(config.caddyConfigPath), "INITIALIZED");
+}
+
+function assertDurableCaddyConfig(candidate: unknown): asserts candidate is CaddyConfig {
+    if (typeof candidate !== "object" || candidate === null || Array.isArray(candidate)) {
+        throw new Error("Durable Caddy config must be a JSON object");
+    }
+    const routes = (candidate as CaddyConfig).apps?.http?.servers?.supacloud?.routes;
+    if (!Array.isArray(routes)) {
+        throw new Error("Durable Caddy config is missing the canonical route array");
+    }
+    assertUniqueCaddyIds(candidate);
 }
 
 interface RateLimitConfig {
@@ -89,6 +137,22 @@ export interface FrontendGatewayRoute {
     mode?: "proxy" | "static";
 }
 
+interface CaddyGatewayFileOperations {
+    beforeDurabilityStage(stage: CaddyGatewayDurabilityStage): Promise<void>;
+    persistLoadedCandidate(tmpPath: string): Promise<void>;
+}
+
+export interface CanonicalGatewayReconcileState {
+    tenants: { success: boolean; updated: number; errors: string[] };
+    hostedAuth: { success: boolean; error?: string };
+    frontends: { total: number; configured: number; skipped: number; errors: string[] };
+}
+
+export interface CanonicalGatewayReconcileDependencies {
+    gateway?: GatewayProvider;
+    reconcileFrontends?: () => Promise<CanonicalGatewayReconcileState["frontends"]>;
+}
+
 export interface GatewayProvider {
     readonly name: "caddy";
     setupJwt(projectRef: string, jwtSecret: string): Promise<boolean>;
@@ -116,9 +180,11 @@ export interface GatewayProvider {
     upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }>;
     configureFrontendRoute(route: FrontendGatewayRoute): Promise<void>;
     removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void>;
+    readFrontendStaticRoot(projectRef: string, deploymentId: string): Promise<string | null>;
     setupHostedAuthRoutes(): Promise<{ success: boolean; error?: string }>;
     ensureGatewayReady(opts?: { maxAttempts?: number; intervalMs?: number }): Promise<{ ready: boolean; error?: string }>;
     checkCaddyConnectivity(): Promise<boolean>;
+    confirmCanonicalState(): Promise<void>;
 }
 
 function getRateLimitConfig(tier: string): RateLimitConfig {
@@ -151,6 +217,24 @@ type CaddyConfig = {
             servers: Record<string, CaddyServer>;
         };
     };
+};
+
+type CaddyMutableStateSnapshot = {
+    routes: Map<string, CaddyRoute>;
+    certs: Map<string, { certificate: string; key: string }>;
+    rateLimits: Map<string, { tier: string; second: number; minute: number; hour: number; enabled: boolean }>;
+    customRateLimits: Map<string, { second: number; minute: number; hour: number }>;
+    hydrated: boolean;
+};
+
+type CaddyGatewayQuarantine = {
+    candidate: CaddyConfig;
+    previousSnapshot: CaddyMutableStateSnapshot;
+};
+
+type CaddyGatewayOperationContext = {
+    token: object;
+    previousSnapshot: CaddyMutableStateSnapshot;
 };
 
 const CADDY_GENERATED_CONFIG_NOTICE_LOG =
@@ -245,7 +329,20 @@ export class CaddyGatewayProvider implements GatewayProvider {
     private deferredPersistDepth = 0;
     private deferredPersistPending = false;
     private persistAndLoadTail: Promise<void> = Promise.resolve();
+    private readonly operationContext = new AsyncLocalStorage<CaddyGatewayOperationContext>();
+    private readonly operationToken = Object.freeze({});
+    private operationTail: Promise<void> = Promise.resolve();
+    private quarantine: CaddyGatewayQuarantine | null = null;
+    private readonly fileOperations: CaddyGatewayFileOperations;
     private hydrated = false;
+
+    constructor(fileOperations?: Partial<CaddyGatewayFileOperations>) {
+        this.fileOperations = {
+            beforeDurabilityStage: async () => undefined,
+            persistLoadedCandidate: (tmpPath) => this.persistLoadedCandidate(tmpPath),
+            ...fileOperations,
+        };
+    }
 
     private async caddyRequest(pathname: string, method = "GET", body?: unknown): Promise<Response> {
         return fetch(`${config.caddyAdminUrl}${pathname}`, {
@@ -267,10 +364,14 @@ export class CaddyGatewayProvider implements GatewayProvider {
         }
     }
 
-    // 带（指数）退避的 Caddy 就绪探测：caddy 容器在 docker 模式下晚于 management-api 启动，
-    // 首次 persistAndLoad 的 POST /load 往往因 caddy 尚未监听而失败。该方法轮询 Admin API
-    // 直到可达，再补一次 persistAndLoad 让 JSON 路由真正接管 bootstrap Caddyfile。
+    // Caddy may still be starting, restarting, or temporarily unreachable when Management
+    // begins its fail-closed bootstrap. Wait for the Admin API, then publish and read back
+    // the durable JSON before Management starts serving requests.
     async ensureGatewayReady(opts?: { maxAttempts?: number; intervalMs?: number }): Promise<{ ready: boolean; error?: string }> {
+        return this.serializeOperation(() => this.ensureGatewayReadyUnlocked(opts));
+    }
+
+    private async ensureGatewayReadyUnlocked(opts?: { maxAttempts?: number; intervalMs?: number }): Promise<{ ready: boolean; error?: string }> {
         const maxAttempts = Math.max(1, Math.trunc(opts?.maxAttempts ?? 30));
         const intervalMs = Math.max(1, Math.trunc(opts?.intervalMs ?? 1000));
         for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -278,6 +379,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
             if (reachable) {
                 try {
                     await this.persistAndLoad();
+                    const liveState = await this.liveCandidateState(this.baseConfig());
+                    if (liveState !== "candidate") {
+                        throw new Error(`Caddy config read-back is ${liveState}`);
+                    }
                     logger.info(`[CaddyGatewayProvider] Gateway ready after ${attempt} attempt(s); JSON config applied`);
                     return { ready: true };
                 } catch (error: unknown) {
@@ -354,30 +459,50 @@ export class CaddyGatewayProvider implements GatewayProvider {
         };
     }
 
+    private async readDurableConfig(): Promise<CaddyConfig | null> {
+        let markerPresent = false;
+        try {
+            await fs.access(initializedMarkerPath());
+            markerPresent = true;
+        } catch (error: unknown) {
+            if (fileErrorCode(error) !== "ENOENT") throw error;
+        }
+
+        let rawConfig: string;
+        try {
+            rawConfig = await fs.readFile(config.caddyConfigPath, "utf8");
+        } catch (error: unknown) {
+            if (fileErrorCode(error) !== "ENOENT") throw error;
+            if (markerPresent) {
+                throw new Error("Initialized Caddy config is missing from durable storage");
+            }
+            return null;
+        }
+
+        let parsedConfig: unknown;
+        try {
+            parsedConfig = JSON.parse(rawConfig);
+        } catch {
+            throw new Error("Durable Caddy config is malformed JSON");
+        }
+        assertDurableCaddyConfig(parsedConfig);
+        return parsedConfig;
+    }
+
     private async hydrateFromDisk(): Promise<void> {
         if (this.hydrated) return;
-        this.hydrated = true;
-
-        try {
-            const raw = await fs.readFile(config.caddyConfigPath, "utf8");
-            const parsed = JSON.parse(raw) as CaddyConfig;
-            const routes = parsed.apps?.http?.servers?.supacloud?.routes;
-            if (Array.isArray(routes)) {
-                for (const route of routes) {
-                    const id = typeof route?.["@id"] === "string" ? route["@id"] : "";
-                    if (!id || id === CADDY_UNMATCHED_HOST_ROUTE_ID) continue;
-                    if (!this.routesById.has(id)) this.routesById.set(id, this.migrateHydratedRoute(id, route));
-                    this.hydrateRateLimitFromRoute(id, route);
-                }
+        const parsed = await this.readDurableConfig();
+        if (parsed) {
+            const routes = parsed.apps.http.servers.supacloud.routes;
+            for (const route of routes) {
+                const id = typeof route?.["@id"] === "string" ? route["@id"] : "";
+                if (!id || id === CADDY_UNMATCHED_HOST_ROUTE_ID) continue;
+                if (!this.routesById.has(id)) this.routesById.set(id, this.migrateHydratedRoute(id, route));
+                this.hydrateRateLimitFromRoute(id, route);
             }
-
             this.hydrateCertificatesFromConfig(parsed);
-        } catch (error: unknown) {
-            const code = typeof error === "object" && error && "code" in error ? String((error as { code?: unknown }).code) : "";
-            if (code !== "ENOENT") {
-                logger.warn(`[CaddyGatewayProvider] Failed to hydrate existing Caddy config: ${error instanceof Error ? error.message : String(error)}`);
-            }
         }
+        this.hydrated = true;
     }
 
     private hydrateCertificatesFromConfig(parsed: CaddyConfig): void {
@@ -393,18 +518,15 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     private async hydrateCertificatesFromDisk(): Promise<void> {
-        try {
-            const raw = await fs.readFile(config.caddyConfigPath, "utf8");
-            this.hydrateCertificatesFromConfig(JSON.parse(raw) as CaddyConfig);
-        } catch (error: unknown) {
-            const code = typeof error === "object" && error && "code" in error ? String((error as { code?: unknown }).code) : "";
-            if (code !== "ENOENT") {
-                logger.warn(`[CaddyGatewayProvider] Failed to hydrate existing Caddy certificates: ${error instanceof Error ? error.message : String(error)}`);
-            }
-        }
+        const parsed = await this.readDurableConfig();
+        if (parsed) this.hydrateCertificatesFromConfig(parsed);
     }
 
     async prepareCleanRebuild(): Promise<void> {
+        return this.serializeOperation(() => this.prepareCleanRebuildUnlocked());
+    }
+
+    private async prepareCleanRebuildUnlocked(): Promise<void> {
         await this.hydrateFromDiskIfUninitialized();
         await this.hydrateCertificatesFromDisk();
         const globalRoutes = Array.from(this.routesById.entries()).filter(([id]) =>
@@ -633,6 +755,103 @@ export class CaddyGatewayProvider implements GatewayProvider {
         await runCaddyStartupPreflight(config.caddyBinaryPath, candidatePath, candidateConfig);
     }
 
+    private async liveCandidateState(candidateConfig: CaddyConfig): Promise<CaddyLiveCandidateState> {
+        try {
+            const response = await this.caddyRequest("/config/");
+            if (!response.ok) return "unknown";
+            const liveConfig = await response.json();
+            return stableStringify(liveConfig) === stableStringify(candidateConfig) ? "candidate" : "different";
+        } catch {
+            return "unknown";
+        }
+    }
+
+    private async persistLoadedCandidate(tmpPath: string): Promise<void> {
+        const directoryPath = path.dirname(config.caddyConfigPath);
+        await this.syncCandidateFile(tmpPath);
+        await this.fileOperations.beforeDurabilityStage("candidate_rename");
+        await fs.rename(tmpPath, config.caddyConfigPath);
+        await this.fileOperations.beforeDurabilityStage("config_directory_sync");
+        await this.syncCaddyConfigDirectory(directoryPath);
+        await this.writeGeneratedConfigNotice(directoryPath);
+        await this.fileOperations.beforeDurabilityStage("notice_directory_sync");
+        await this.syncCaddyConfigDirectory(directoryPath);
+    }
+
+    private async syncCandidateFile(tmpPath: string): Promise<void> {
+        const candidateFile = await fs.open(tmpPath, "r");
+        try {
+            await this.fileOperations.beforeDurabilityStage("candidate_sync");
+            await candidateFile.sync();
+        } finally {
+            await candidateFile.close();
+        }
+    }
+
+    private async writeGeneratedConfigNotice(directoryPath: string): Promise<void> {
+        const noticePath = path.join(directoryPath, "DO-NOT-EDIT.txt");
+        await this.fileOperations.beforeDurabilityStage("notice_open");
+        const notice = await fs.open(noticePath, "w", 0o644);
+        try {
+            await this.fileOperations.beforeDurabilityStage("notice_write");
+            await notice.writeFile(caddyGeneratedConfigNotice(), "utf8");
+            await this.fileOperations.beforeDurabilityStage("notice_sync");
+            await notice.sync();
+        } finally {
+            await notice.close();
+        }
+    }
+
+    private async syncCaddyConfigDirectory(directoryPath: string): Promise<void> {
+        const directory = await fs.open(directoryPath, "r");
+        try {
+            await directory.sync();
+        } finally {
+            await directory.close();
+        }
+    }
+
+    private async writeInitializedMarker(): Promise<void> {
+        const directoryPath = path.dirname(config.caddyConfigPath);
+        const markerPath = initializedMarkerPath();
+        const temporaryPath = `${markerPath}.tmp-${process.pid}-${crypto.randomUUID()}`;
+        try {
+            const markerFile = await fs.open(temporaryPath, "wx", 0o644);
+            try {
+                await markerFile.writeFile("supacloud-caddy-config-v1\n", "utf8");
+                await markerFile.sync();
+            } finally {
+                await markerFile.close();
+            }
+            await fs.rename(temporaryPath, markerPath);
+            await this.syncCaddyConfigDirectory(directoryPath);
+        } catch (error: unknown) {
+            await fs.unlink(temporaryPath).catch(() => undefined);
+            throw error;
+        }
+    }
+
+    async confirmCanonicalState(): Promise<void> {
+        await this.serializeOperation(async () => {
+            const durableConfig = await this.readDurableConfig();
+            if (!durableConfig) throw new Error("Canonical Caddy config was not persisted");
+            const liveState = await this.liveCandidateState(durableConfig);
+            if (liveState !== "candidate") {
+                throw new Error(`Canonical Caddy read-back is ${liveState}`);
+            }
+            await this.writeInitializedMarker();
+        });
+    }
+
+    private throwQuarantinedCandidateError(candidate: CaddyConfig, message: string): never {
+        const context = this.operationContext.getStore();
+        if (!context || context.token !== this.operationToken) {
+            throw new CaddyGatewayDurabilityError("Caddy mutation context could not be proven");
+        }
+        this.quarantine = { candidate, previousSnapshot: context.previousSnapshot };
+        throw new CaddyGatewayDurabilityError(message);
+    }
+
     private async writeAndLoadCurrentConfig(): Promise<void> {
         const next = this.baseConfig();
         await fs.mkdir(path.dirname(config.caddyConfigPath), { recursive: true });
@@ -641,14 +860,32 @@ export class CaddyGatewayProvider implements GatewayProvider {
 
         try {
             await this.validateCandidateConfig(tmpPath, next);
-            const res = await this.caddyRequest("/load", "POST", next);
-            if (!res.ok) {
-                const text = await res.text().catch(() => "");
-                throw new Error(`Caddy /load failed with ${res.status}: ${text}`);
+            let response: Response;
+            try {
+                response = await this.caddyRequest("/load", "POST", next);
+            } catch (loadError: unknown) {
+                const state = await this.liveCandidateState(next);
+                if (state === "different") throw loadError;
+                if (state === "unknown") {
+                    this.throwQuarantinedCandidateError(next, "Caddy candidate state could not be proven after load");
+                }
+                try {
+                    await this.fileOperations.persistLoadedCandidate(tmpPath);
+                } catch {
+                    this.throwQuarantinedCandidateError(next, "Caddy candidate is live but its durable config could not be repaired");
+                }
+                return;
             }
-            await fs.rename(tmpPath, config.caddyConfigPath);
-            await fs.writeFile(path.join(path.dirname(config.caddyConfigPath), "DO-NOT-EDIT.txt"), caddyGeneratedConfigNotice());
-        } catch (error) {
+            if (!response.ok) {
+                const text = await response.text().catch(() => "");
+                throw new Error(`Caddy /load failed with ${response.status}: ${text}`);
+            }
+            try {
+                await this.fileOperations.persistLoadedCandidate(tmpPath);
+            } catch {
+                this.throwQuarantinedCandidateError(next, "Caddy candidate is live but its durable config could not be persisted");
+            }
+        } catch (error: unknown) {
             await fs.unlink(tmpPath).catch(() => undefined);
             throw error;
         }
@@ -660,6 +897,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
             return;
         }
 
+        await this.repairQuarantinedCandidate();
         const previous = this.persistAndLoadTail.catch(() => undefined);
         const current = previous.then(() => this.writeAndLoadCurrentConfig());
         this.persistAndLoadTail = current.catch(() => undefined);
@@ -667,21 +905,84 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async withDeferredPersist<T>(fn: () => Promise<T>, shouldFlush: (result: T) => boolean = () => true): Promise<T> {
+        return this.serializeOperation(() => this.withDeferredPersistUnlocked(fn, shouldFlush));
+    }
+
+    private async withDeferredPersistUnlocked<T>(fn: () => Promise<T>, shouldFlush: (result: T) => boolean): Promise<T> {
+        const snapshot = this.mutableStateSnapshot();
+        const pendingAtEntry = this.deferredPersistPending;
         this.deferredPersistDepth++;
         let completed = false;
+        let accepted = false;
         let result: T;
         try {
             result = await fn();
             completed = true;
+            accepted = shouldFlush(result);
             return result;
         } finally {
             this.deferredPersistDepth--;
-            if (this.deferredPersistDepth === 0) {
-                const flush = completed && this.deferredPersistPending && shouldFlush(result!);
+            if (!completed || !accepted) {
+                this.restoreMutableState(snapshot);
+                this.deferredPersistPending = pendingAtEntry;
+            } else if (this.deferredPersistDepth === 0) {
+                const flush = this.deferredPersistPending;
                 this.deferredPersistPending = false;
-                if (flush) await this.persistAndLoad();
+                if (flush) {
+                    try {
+                        await this.persistAndLoad();
+                    } catch (error: unknown) {
+                        if (!preservesGatewayCandidate(error)) this.restoreMutableState(snapshot);
+                        throw error;
+                    }
+                }
             }
         }
+    }
+
+    private async repairQuarantinedCandidate(): Promise<void> {
+        const quarantine = this.quarantine;
+        if (!quarantine) return;
+        const state = await this.liveCandidateState(quarantine.candidate);
+        if (state === "different") {
+            this.restoreMutableState(quarantine.previousSnapshot);
+            this.quarantine = null;
+            return;
+        }
+        if (state === "unknown") {
+            throw new CaddyGatewayDurabilityError("Caddy quarantined candidate state could not be proven");
+        }
+        const tmpPath = `${config.caddyConfigPath}.repair-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        try {
+            await fs.writeFile(tmpPath, JSON.stringify(quarantine.candidate, null, 2));
+            await this.fileOperations.persistLoadedCandidate(tmpPath);
+            this.quarantine = null;
+        } catch {
+            await fs.unlink(tmpPath).catch(() => undefined);
+            throw new CaddyGatewayDurabilityError("Caddy quarantined candidate durability could not be repaired");
+        }
+    }
+
+    private mutableStateSnapshot(): CaddyMutableStateSnapshot {
+        return {
+            routes: structuredClone(this.routesById),
+            certs: structuredClone(this.certsById),
+            rateLimits: structuredClone(this.rateLimits),
+            customRateLimits: structuredClone(this.customRateLimits),
+            hydrated: this.hydrated,
+        };
+    }
+
+    private restoreMutableState(snapshot: CaddyMutableStateSnapshot): void {
+        this.routesById.clear();
+        for (const [key, value] of snapshot.routes) this.routesById.set(key, value);
+        this.certsById.clear();
+        for (const [key, value] of snapshot.certs) this.certsById.set(key, value);
+        this.rateLimits.clear();
+        for (const [key, value] of snapshot.rateLimits) this.rateLimits.set(key, value);
+        this.customRateLimits.clear();
+        for (const [key, value] of snapshot.customRateLimits) this.customRateLimits.set(key, value);
+        this.hydrated = snapshot.hydrated;
     }
 
     private projectRouteIds(projectRef: string): string[] {
@@ -966,14 +1267,60 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     private async putRoute(route: CaddyRoute): Promise<void> {
-        const id = String(route["@id"]);
-        this.routesById.set(id, route);
-        await this.persistAndLoad();
+        await this.serializeOperation(async () => {
+            const id = String(route["@id"]);
+            const previous = this.routesById.get(id);
+            this.routesById.set(id, route);
+            try {
+                await this.persistAndLoad();
+            } catch (error: unknown) {
+                if (!preservesGatewayCandidate(error)) {
+                    if (previous) this.routesById.set(id, previous);
+                    else this.routesById.delete(id);
+                }
+                throw error;
+            }
+        });
     }
 
     private async removeRoutes(ids: string[]): Promise<void> {
-        for (const id of ids) this.routesById.delete(id);
-        await this.persistAndLoad();
+        await this.serializeOperation(async () => {
+            const previous = ids.flatMap((id) => {
+                const route = this.routesById.get(id);
+                return route ? [[id, route] as const] : [];
+            });
+            for (const id of ids) this.routesById.delete(id);
+            try {
+                await this.persistAndLoad();
+            } catch (error: unknown) {
+                if (!preservesGatewayCandidate(error)) {
+                    for (const [id, route] of previous) this.routesById.set(id, route);
+                }
+                throw error;
+            }
+        });
+    }
+
+    private async serializeOperation<T>(operation: () => Promise<T>): Promise<T> {
+        if (this.operationContext.getStore()?.token === this.operationToken) return operation();
+        const previous = this.operationTail.catch(() => undefined);
+        let release!: () => void;
+        const current = new Promise<void>((resolve) => { release = resolve; });
+        const tail = previous.then(() => current);
+        this.operationTail = tail;
+        await previous;
+        try {
+            await this.repairQuarantinedCandidate();
+            await this.hydrateFromDiskIfUninitialized();
+            const context = {
+                token: this.operationToken,
+                previousSnapshot: this.mutableStateSnapshot(),
+            };
+            return await this.operationContext.run(context, operation);
+        } finally {
+            release();
+            if (this.operationTail === tail) this.operationTail = Promise.resolve();
+        }
     }
 
     async setupJwt(_projectRef: string, _jwtSecret: string): Promise<boolean> {
@@ -995,6 +1342,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async setRateLimit(projectRef: string, opts: string | { second?: number; minute?: number; hour?: number } = "free"): Promise<boolean> {
+        return this.serializeOperation(() => this.setRateLimitUnlocked(projectRef, opts));
+    }
+
+    private async setRateLimitUnlocked(projectRef: string, opts: string | { second?: number; minute?: number; hour?: number }): Promise<boolean> {
         await this.hydrateFromDiskIfUninitialized();
         const defaults = RATE_LIMIT_TIERS.free;
         const limits = typeof opts === "string" ? getRateLimitConfig(opts) : {
@@ -1012,6 +1363,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async setCustomRouteRateLimit(projectRef: string, basePath: string, limits: { second?: number; minute?: number; hour?: number }): Promise<boolean> {
+        return this.serializeOperation(() => this.setCustomRouteRateLimitUnlocked(projectRef, basePath, limits));
+    }
+
+    private async setCustomRouteRateLimitUnlocked(projectRef: string, basePath: string, limits: { second?: number; minute?: number; hour?: number }): Promise<boolean> {
         await this.hydrateFromDiskIfUninitialized();
         const routeId = `route-custom-${projectRef}-${hashStr(basePath)}`;
         const parent = this.cloneRouteForCustomLimit(projectRef, basePath, routeId);
@@ -1031,6 +1386,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async removeCustomRouteRateLimit(projectRef: string, basePath: string): Promise<boolean> {
+        return this.serializeOperation(() => this.removeCustomRouteRateLimitUnlocked(projectRef, basePath));
+    }
+
+    private async removeCustomRouteRateLimitUnlocked(projectRef: string, basePath: string): Promise<boolean> {
         await this.hydrateFromDiskIfUninitialized();
         const routeId = `route-custom-${projectRef}-${hashStr(basePath)}`;
         this.customRateLimits.delete(routeId);
@@ -1040,6 +1399,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async configureCustomGatewayRoutes(projectRef: string, routes: CustomGatewayRouteConfig[]): Promise<{ success: boolean; error?: string }> {
+        return this.serializeOperation(() => this.configureCustomGatewayRoutesUnlocked(projectRef, routes));
+    }
+
+    private async configureCustomGatewayRoutesUnlocked(projectRef: string, routes: CustomGatewayRouteConfig[]): Promise<{ success: boolean; error?: string }> {
         const previousRoutes: Array<[string, CaddyRoute]> = [];
         try {
             await this.hydrateFromDiskIfUninitialized();
@@ -1056,6 +1419,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
             await this.persistAndLoad();
             return { success: true };
         } catch (error: unknown) {
+            if (preservesGatewayCandidate(error)) throw error;
             for (const id of Array.from(this.routesById.keys())) {
                 if (isCustomGatewayRouteId(projectRef, id)) this.routesById.delete(id);
             }
@@ -1090,6 +1454,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async setCors(projectRef: string, origins: string[] = DEFAULT_CORS_ORIGINS): Promise<boolean> {
+        return this.serializeOperation(() => this.setCorsUnlocked(projectRef, origins));
+    }
+
+    private async setCorsUnlocked(projectRef: string, origins: string[]): Promise<boolean> {
         logger.debug(`[CaddyGatewayProvider] CORS is rendered into route JSON for ${projectRef}`);
         await this.hydrateFromDiskIfUninitialized();
         for (const id of this.projectRouteIds(projectRef)) {
@@ -1101,12 +1469,20 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async addCorsOriginsForHosts(projectRef: string, hosts: string[]): Promise<boolean> {
+        return this.serializeOperation(() => this.addCorsOriginsForHostsUnlocked(projectRef, hosts));
+    }
+
+    private async addCorsOriginsForHostsUnlocked(projectRef: string, hosts: string[]): Promise<boolean> {
         await this.hydrateFromDiskIfUninitialized();
         const allHosts = uniqueStrings([...this.hostsForProjectRoutes(projectRef), ...hosts]);
         return this.setCors(projectRef, buildTenantCorsOrigins(projectRef, undefined, allHosts));
     }
 
     async setupUpstream(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions): Promise<{ success: boolean; error?: string }> {
+        return this.serializeOperation(() => this.setupUpstreamUnlocked(projectRef, pgrstPort, gotruePort, projectRouting, opts));
+    }
+
+    private async setupUpstreamUnlocked(projectRef: string, pgrstPort: number | string, gotruePort: number | string, projectRouting?: ProjectRoutingConfig | string, opts?: GatewaySetupOptions): Promise<{ success: boolean; error?: string }> {
         try {
             const hostIp = await this.detectHostIp();
             const projectConfig = normalizeProjectConfig(projectRouting);
@@ -1343,6 +1719,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
             logger.info(`[CaddyGatewayProvider] Routes registered for ${projectRef}`);
             return { success: true };
         } catch (error: unknown) {
+            if (preservesGatewayCandidate(error)) throw error;
             const message = error instanceof Error ? error.message : String(error);
             logger.error(`[CaddyGatewayProvider] Failed to setup upstream for ${projectRef}:`, message);
             return { success: false, error: message };
@@ -1350,6 +1727,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async addProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean> {
+        return this.serializeOperation(() => this.addProjectDomainsUnlocked(projectRef, apiDomains, studioDomains));
+    }
+
+    private async addProjectDomainsUnlocked(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean> {
         await this.hydrateFromDiskIfUninitialized();
         const existingKinds = ["opaque-rest", "opaque-graphql", "opaque-auth", "auth-admin-user-delete", "rest", "graphql", "auth", "gotrue-well-known", "functions", "storage", "realtime-api", "realtime", "management", "acme"];
         for (const kind of existingKinds) {
@@ -1367,6 +1748,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async removeProjectDomains(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean> {
+        return this.serializeOperation(() => this.removeProjectDomainsUnlocked(projectRef, apiDomains, studioDomains));
+    }
+
+    private async removeProjectDomainsUnlocked(projectRef: string, apiDomains: string[], studioDomains: string[]): Promise<boolean> {
         await this.hydrateFromDiskIfUninitialized();
         const remove = new Set([...apiDomains, ...studioDomains].map(normalizeCaddyHost));
         for (const route of this.routesById.values()) {
@@ -1384,6 +1769,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async removeService(projectRef: string): Promise<{ success: boolean; error?: string }> {
+        return this.serializeOperation(() => this.removeServiceUnlocked(projectRef));
+    }
+
+    private async removeServiceUnlocked(projectRef: string): Promise<{ success: boolean; error?: string }> {
         await this.hydrateFromDiskIfUninitialized();
         const ids = Array.from(this.routesById.keys()).filter((id) => id.includes(`-${projectRef}-`) || id.endsWith(`-${projectRef}`));
         await this.removeRoutes(ids);
@@ -1399,6 +1788,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async applyConfig(projectRef: string, gatewayConfig: GatewayConfig): Promise<{ success: boolean; message: string }> {
+        return this.serializeOperation(() => this.applyConfigUnlocked(projectRef, gatewayConfig));
+    }
+
+    private async applyConfigUnlocked(projectRef: string, gatewayConfig: GatewayConfig): Promise<{ success: boolean; message: string }> {
         if (gatewayConfig.jwtSecret) await this.setupJwt(projectRef, gatewayConfig.jwtSecret);
         if (gatewayConfig.rateLimitTier) await this.setRateLimit(projectRef, gatewayConfig.rateLimitTier);
         if (gatewayConfig.corsOrigins) {
@@ -1410,6 +1803,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async rebuildAllTenantConfigs(): Promise<{ success: boolean; updated: number; errors: string[] }> {
+        return this.serializeOperation(() => this.rebuildAllTenantConfigsUnlocked());
+    }
+
+    private async rebuildAllTenantConfigsUnlocked(): Promise<{ success: boolean; updated: number; errors: string[] }> {
         const errors: string[] = [];
         let updated = 0;
         try {
@@ -1443,6 +1840,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async setupMasterRoutes(): Promise<void> {
+        return this.serializeOperation(() => this.setupMasterRoutesUnlocked());
+    }
+
+    private async setupMasterRoutesUnlocked(): Promise<void> {
         await this.hydrateFromDiskIfUninitialized();
         const hostIp = await this.detectHostIp();
         const hosts = uniqueStrings([hostIp, config.baseDomain, `api.${config.baseDomain}`]);
@@ -1468,6 +1869,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async configureStudioDomain(domain: string, port: number): Promise<void> {
+        return this.serializeOperation(() => this.configureStudioDomainUnlocked(domain, port));
+    }
+
+    private async configureStudioDomainUnlocked(domain: string, port: number): Promise<void> {
         await this.hydrateFromDiskIfUninitialized();
         const host = normalizeCaddyHost(domain);
         if (!host) throw new Error("Studio domain is required");
@@ -1499,6 +1904,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }> {
+        return this.serializeOperation(() => this.upsertCertificateForSnisUnlocked(opts));
+    }
+
+    private async upsertCertificateForSnisUnlocked(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }): Promise<{ success: boolean; certificateId?: string; error?: string }> {
         await this.hydrateFromDiskIfUninitialized();
         const snis = uniqueStrings(opts.snis.map(normalizeCaddyHost));
         if (!opts.cert.trim() || !opts.key.trim()) return { success: false, error: "Certificate and private key are required" };
@@ -1516,27 +1925,78 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     async configureFrontendRoute(route: FrontendGatewayRoute): Promise<void> {
-        if (route.mode === "static" || route.root) {
-            await this.addCorsOriginsForHosts(route.projectRef, route.hosts);
-            await this.putRoute(this.makeStaticFrontendRoute(route));
-            return;
-        }
+        return this.serializeOperation(async () => {
+            await this.hydrateFromDiskIfUninitialized();
+            const routeId = `route-frontend-${route.projectRef}-${route.deploymentId}`;
+            const routeIds = this.projectRouteIds(route.projectRef);
+            const previous = new Map(routeIds.flatMap((id) => {
+                const existing = this.routesById.get(id);
+                return existing ? [[id, JSON.parse(JSON.stringify(existing)) as CaddyRoute] as const] : [];
+            }));
+            const allHosts = uniqueStrings([...this.hostsForProjectRoutes(route.projectRef), ...route.hosts]);
+            const origins = buildTenantCorsOrigins(route.projectRef, undefined, allHosts);
+            for (const id of routeIds) {
+                const projectRoute = this.routesById.get(id);
+                if (projectRoute) setRouteCors(projectRoute, origins);
+            }
+            const frontendRoute = route.mode === "static" || route.root
+                ? this.makeStaticFrontendRoute(route)
+                : this.proxyFrontendRoute(route, routeId);
+            this.routesById.set(routeId, frontendRoute);
+            try {
+                await this.persistAndLoad();
+            } catch (error: unknown) {
+                if (!preservesGatewayCandidate(error)) {
+                    this.routesById.delete(routeId);
+                    for (const [id, projectRoute] of previous) this.routesById.set(id, projectRoute);
+                }
+                throw error;
+            }
+        });
+    }
+
+    private proxyFrontendRoute(route: FrontendGatewayRoute, routeId: string): CaddyRoute {
         if (!route.port) {
             throw new Error("Caddy proxy frontend routes require an upstream port");
         }
-        await this.addCorsOriginsForHosts(route.projectRef, route.hosts);
-        await this.putRoute(this.makeRoute({
-            id: `route-frontend-${route.projectRef}-${route.deploymentId}`,
+        return this.makeRoute({
+            id: routeId,
             hosts: route.hosts,
             path: "/*",
             upstream: `127.0.0.1:${route.port}`,
             projectRef: route.projectRef,
             readTimeout: 60_000,
-        }));
+        });
     }
 
     async removeFrontendRoute(projectRef: string, deploymentId: string): Promise<void> {
         await this.removeRoutes([`route-frontend-${projectRef}-${deploymentId}`]);
+    }
+
+    async readFrontendStaticRoot(projectRef: string, deploymentId: string): Promise<string | null> {
+        const response = await this.caddyRequest("/config/apps/http/servers/supacloud/routes");
+        if (!response.ok) throw new Error(`Caddy route read-back failed with ${response.status}`);
+        const routes = await response.json();
+        if (!Array.isArray(routes)) throw new Error("Caddy route read-back is invalid");
+        const routeId = `route-frontend-${projectRef}-${deploymentId}`;
+        const matchingRoutes = routes.filter((candidate) => candidate?.["@id"] === routeId);
+        if (matchingRoutes.length > 1) throw new Error("Caddy frontend route identity is ambiguous");
+        const route = matchingRoutes[0];
+        if (!route) return null;
+        const roots = new Set<string>();
+        const visit = (candidate: unknown): void => {
+            if (Array.isArray(candidate)) {
+                for (const child of candidate) visit(child);
+                return;
+            }
+            if (!candidate || typeof candidate !== "object") return;
+            const record = candidate as Record<string, unknown>;
+            if (record.handler === "file_server" && typeof record.root === "string") roots.add(record.root);
+            for (const child of Object.values(record)) visit(child);
+        };
+        visit(route);
+        if (roots.size !== 1) throw new Error("Caddy frontend route does not have one canonical static root");
+        return [...roots][0];
     }
 
     private async detectHostIp(): Promise<string> {
@@ -1559,6 +2019,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
      *   - route-supauth-authorize-page: /oauth/authorize* -> authorize.html
      */
     async setupHostedAuthRoutes(): Promise<{ success: boolean; error?: string }> {
+        return this.serializeOperation(() => this.setupHostedAuthRoutesUnlocked());
+    }
+
+    private async setupHostedAuthRoutesUnlocked(): Promise<{ success: boolean; error?: string }> {
         if (!config.hostedAuthPageEnabled) {
             // 清除已有路由
             await this.hydrateFromDiskIfUninitialized();
@@ -1649,9 +2113,47 @@ export class GatewayService implements GatewayProvider {
     upsertCertificateForSnis(opts: { projectRef: string; cert: string; key: string; snis: string[]; existingCertificateId?: string }) { return this.provider.upsertCertificateForSnis(opts); }
     configureFrontendRoute(route: FrontendGatewayRoute) { return this.provider.configureFrontendRoute(route); }
     removeFrontendRoute(projectRef: string, deploymentId: string) { return this.provider.removeFrontendRoute(projectRef, deploymentId); }
+    readFrontendStaticRoot(projectRef: string, deploymentId: string) { return this.provider.readFrontendStaticRoot(projectRef, deploymentId); }
     setupHostedAuthRoutes() { return this.provider.setupHostedAuthRoutes(); }
     ensureGatewayReady(opts?: { maxAttempts?: number; intervalMs?: number }) { return this.provider.ensureGatewayReady(opts); }
     checkCaddyConnectivity() { return this.provider.checkCaddyConnectivity(); }
+    confirmCanonicalState() { return this.provider.confirmCanonicalState(); }
 }
 
 export const gatewayService = new GatewayService();
+
+function canonicalReconcileAccepted(state: CanonicalGatewayReconcileState): boolean {
+    return state.tenants.success
+        && state.hostedAuth.success
+        && state.frontends.errors.length === 0;
+}
+
+function canonicalReconcileError(state: CanonicalGatewayReconcileState): Error {
+    const failures = [
+        ...state.tenants.errors.map((message) => `tenant: ${message}`),
+        ...(state.hostedAuth.error ? [`hosted auth: ${state.hostedAuth.error}`] : []),
+        ...state.frontends.errors.map((message) => `frontend: ${message}`),
+    ];
+    return new Error(`Canonical gateway reconciliation failed: ${failures.join("; ") || "unknown error"}`);
+}
+
+export async function reconcileCanonicalGatewayRoutes(
+    dependencies: CanonicalGatewayReconcileDependencies = {},
+): Promise<CanonicalGatewayReconcileState> {
+    const gateway = dependencies.gateway ?? gatewayService;
+    const reconcileFrontends = dependencies.reconcileFrontends ?? (async () => {
+        const { frontendService } = await import("./frontend.service");
+        return frontendService.reconcileGatewayRoutes();
+    });
+    const state = await gateway.withDeferredPersist(async () => {
+        await gateway.prepareCleanRebuild();
+        await gateway.setupMasterRoutes();
+        const tenants = await gateway.rebuildAllTenantConfigs();
+        const hostedAuth = await gateway.setupHostedAuthRoutes();
+        const frontends = await reconcileFrontends();
+        return { tenants, hostedAuth, frontends };
+    }, canonicalReconcileAccepted);
+    if (!canonicalReconcileAccepted(state)) throw canonicalReconcileError(state);
+    await gateway.confirmCanonicalState();
+    return state;
+}

--- a/packages/management-api/src/services/project-mutation.service.ts
+++ b/packages/management-api/src/services/project-mutation.service.ts
@@ -136,6 +136,12 @@ export interface MutationLeaseInput {
   fencingEpoch: number;
 }
 
+export interface VerifyProjectMutationLeaseInput extends MutationLeaseInput {}
+
+export type ProjectMutationLeaseExecution<T> =
+  | { kind: "executed"; value: T }
+  | { kind: "lease_lost" };
+
 export interface CheckpointProjectMutationInput extends MutationLeaseInput {
   checkpoint: Record<string, unknown>;
   leaseSeconds: number;
@@ -192,6 +198,8 @@ export interface RecoverableProjectMutationClaim {
   mutationId: string;
   operation: string;
   resourceKey: string | null;
+  requestFingerprint: string;
+  principal: MutationPrincipal;
   checkpoint: Record<string, unknown>;
   recoveryNotBefore: string;
   leaseToken: string;
@@ -204,6 +212,9 @@ interface StoredRecoverableMutationClaimRow {
   mutation_id: string;
   operation: string;
   resource_key: string | null;
+  request_fingerprint: string;
+  principal_type: MutationPrincipal["type"];
+  principal_id: string;
   checkpoint: unknown;
   recovery_not_before: Date | string;
   lease_token: string;
@@ -362,6 +373,15 @@ function assertLeaseSeconds(leaseSeconds: number): void {
   }
 }
 
+function assertMutationPrincipal(principal: MutationPrincipal): void {
+  if (!["master", "admin", "project"].includes(principal.type)
+    || typeof principal.id !== "string"
+    || !PRINCIPAL_ID_PATTERN.test(principal.id)
+    || principal.id.trim() !== principal.id) {
+    throw new Error("Mutation principal is invalid");
+  }
+}
+
 function assertBeginInput(input: BeginProjectMutationInput): void {
   assertMutationIdentity(input.projectRef, input.mutationId);
   if (!OPERATION_PATTERN.test(input.operation)) throw new Error("Mutation operation is invalid");
@@ -370,9 +390,7 @@ function assertBeginInput(input: BeginProjectMutationInput): void {
   }
   if (input.resource) projectMutationResourceKey(input.resource);
   if (!FINGERPRINT_PATTERN.test(input.requestFingerprint)) throw new Error("Mutation fingerprint is invalid");
-  if (!PRINCIPAL_ID_PATTERN.test(input.principal.id) || input.principal.id.trim() !== input.principal.id) {
-    throw new Error("Mutation principal is invalid");
-  }
+  assertMutationPrincipal(input.principal);
 }
 
 async function lockedMutation(
@@ -402,6 +420,20 @@ async function activeResourceMutation(
   return row ?? null;
 }
 
+export async function readActiveProjectMutationForResource(
+  projectRef: string,
+  resource: ProjectMutationResource,
+): Promise<ProjectMutationState | null> {
+  if (!/^[A-Za-z0-9_-]{1,20}$/.test(projectRef)) throw new Error("Project ref is invalid");
+  const resourceKey = projectMutationResourceKey(resource);
+  const [row] = await sql`
+    SELECT * FROM project_mutations
+    WHERE project_ref = ${projectRef} AND resource_key = ${resourceKey}
+      AND status IN ('pending', 'running', 'failed_retryable', 'outcome_unknown')
+  ` as StoredProjectMutationRow[];
+  return row ? projectMutationState(row) : null;
+}
+
 function existingMutationResult(
   row: StoredProjectMutationRow,
   input: BeginProjectMutationInput,
@@ -425,10 +457,10 @@ async function insertProjectMutation(
   const [inserted] = await transaction`
     INSERT INTO project_mutations (
       project_ref, mutation_id, operation, resource_key, request_fingerprint,
-      principal_type, principal_id, recovery_not_before
+      principal_type, principal_id
     ) VALUES (
       ${input.projectRef}, ${input.mutationId}, ${input.operation}, ${resourceKey},
-      ${input.requestFingerprint}, ${input.principal.type}, ${input.principal.id}, clock_timestamp()
+      ${input.requestFingerprint}, ${input.principal.type}, ${input.principal.id}
     )
     ON CONFLICT DO NOTHING
     RETURNING *
@@ -502,6 +534,7 @@ export async function claimOrResumeProjectMutation(
     UPDATE project_mutations
     SET status = 'running', lease_owner = ${input.leaseOwner}, lease_token = ${input.leaseToken},
         lease_expires_at = clock_timestamp() + (${input.leaseSeconds} * INTERVAL '1 second'),
+        recovery_not_before = COALESCE(recovery_not_before, clock_timestamp()),
         fencing_epoch = fencing_epoch + 1, completed_at = NULL, updated_at = clock_timestamp()
     WHERE project_ref = ${input.projectRef} AND mutation_id = ${input.mutationId}
       AND fencing_epoch < 9007199254740991
@@ -528,16 +561,27 @@ function assertRecoverableClaimInput(input: ClaimRecoverableProjectMutationsInpu
 
 function recoverableMutationClaim(row: StoredRecoverableMutationClaimRow): RecoverableProjectMutationClaim {
   assertMutationIdentity(row.project_ref, row.mutation_id);
-  if (!OPERATION_PATTERN.test(row.operation)) throw new Error("Stored mutation operation is invalid");
-  if (row.resource_key !== null && !RESOURCE_KEY_PATTERN.test(row.resource_key)) {
+  if (typeof row.operation !== "string" || !OPERATION_PATTERN.test(row.operation)) {
+    throw new Error("Stored mutation operation is invalid");
+  }
+  if (row.resource_key !== null
+    && (typeof row.resource_key !== "string" || !RESOURCE_KEY_PATTERN.test(row.resource_key))) {
     throw new Error("Stored mutation resource key is invalid");
   }
+  if (typeof row.request_fingerprint !== "string"
+    || !FINGERPRINT_PATTERN.test(row.request_fingerprint)) {
+    throw new Error("Stored mutation fingerprint is invalid");
+  }
+  const principal = { type: row.principal_type, id: row.principal_id };
+  assertMutationPrincipal(principal);
   if (!isProjectMutationId(row.lease_token)) throw new Error("Stored mutation lease token is invalid");
   const fencingEpoch = storedFencingEpoch(row.fencing_epoch, 1);
   const checkpoint = publicJsonRecord(row.checkpoint);
   return {
     projectRef: row.project_ref, mutationId: row.mutation_id, operation: row.operation,
-    resourceKey: row.resource_key, checkpoint, recoveryNotBefore: timestamp(row.recovery_not_before)!,
+    resourceKey: row.resource_key, requestFingerprint: row.request_fingerprint,
+    principal,
+    checkpoint, recoveryNotBefore: timestamp(row.recovery_not_before)!,
     leaseToken: row.lease_token, leaseExpiresAt: timestamp(row.lease_expires_at)!, fencingEpoch,
   };
 }
@@ -555,7 +599,7 @@ async function claimRecoverableRows(
         AND fencing_epoch < 9007199254740991
         AND recovery_not_before IS NOT NULL
         AND recovery_not_before <= clock_timestamp()
-        AND (status IN ('pending', 'failed_retryable')
+        AND (status = 'failed_retryable'
           OR (status = 'running' AND lease_expires_at <= clock_timestamp()))
       ORDER BY recovery_not_before ASC, updated_at ASC, project_ref ASC, mutation_id ASC
       FOR UPDATE SKIP LOCKED
@@ -569,7 +613,8 @@ async function claimRecoverableRows(
     WHERE mutation.project_ref = candidates.project_ref
       AND mutation.mutation_id = candidates.mutation_id
     RETURNING mutation.project_ref, mutation.mutation_id, mutation.operation, mutation.resource_key,
-      mutation.checkpoint, mutation.recovery_not_before, mutation.lease_token,
+      mutation.request_fingerprint, mutation.principal_type, mutation.principal_id, mutation.checkpoint,
+      mutation.recovery_not_before, mutation.lease_token,
       mutation.lease_expires_at, mutation.fencing_epoch
   ` as StoredRecoverableMutationClaimRow[];
   return rows;
@@ -616,6 +661,25 @@ export async function checkpointProjectMutation(
     RETURNING mutation_id
   ` as Array<{ mutation_id: string }>;
   return updated ? "updated" : "lease_lost";
+}
+
+export async function withProjectMutationLease<T>(
+  transaction: SQL,
+  input: VerifyProjectMutationLeaseInput,
+  operation: () => Promise<T>,
+): Promise<ProjectMutationLeaseExecution<T>> {
+  assertLeaseInput(input);
+  const [row] = await transaction`
+    SELECT mutation_id
+    FROM project_mutations
+    WHERE project_ref = ${input.projectRef} AND mutation_id = ${input.mutationId}
+      AND status = 'running' AND lease_token = ${input.leaseToken}
+      AND fencing_epoch = ${input.fencingEpoch}
+      AND lease_expires_at > clock_timestamp()
+    FOR UPDATE
+  ` as Array<{ mutation_id: string }>;
+  if (!row) return { kind: "lease_lost" };
+  return { kind: "executed", value: await operation() };
 }
 
 interface FinishProjectMutationInput extends MutationLeaseInput {

--- a/packages/management-api/src/workers/frontend-release-recovery.worker.ts
+++ b/packages/management-api/src/workers/frontend-release-recovery.worker.ts
@@ -1,0 +1,164 @@
+import { logger } from "../utils/logger";
+import {
+  frontendReleaseActivationFingerprint,
+  frontendReleaseActivationResourceKey,
+  FrontendReleaseActivationService,
+} from "../services/frontend-release-activation";
+import {
+  assertActivationCheckpointIdentity,
+  frontendReleaseMutationPlatformSupported,
+  parseActivationCheckpoint,
+  type ActivateFrontendReleaseInput,
+} from "../services/frontend-release-contract";
+import { gatewayService } from "../services/gateway.service";
+import {
+  claimRecoverableFrontendReleases,
+  frontendReleaseMutationStore,
+  hasUnresolvedFrontendReleaseActivations,
+} from "../services/frontend-release-mutation";
+import type { RecoverableProjectMutationClaim } from "../services/project-mutation.service";
+import { FrontendReleaseStorage } from "../services/frontend-release-storage";
+
+const POLL_INTERVAL_MS = 30_000;
+const RECOVERY_BATCH_SIZE = 16;
+const FRONTEND_RESOURCE_KEY_PATTERN = /^v1\/frontend_release\/[A-Za-z0-9_-]{2,171}$/;
+const REQUEST_FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/;
+let timer: ReturnType<typeof setInterval> | null = null;
+let recoveryRun: Promise<number> | null = null;
+
+function recoveryInput(
+  projectRef: string,
+  mutationId: string,
+  principal: ActivateFrontendReleaseInput["principal"],
+  checkpoint: NonNullable<ReturnType<typeof parseActivationCheckpoint>>,
+): ActivateFrontendReleaseInput {
+  return {
+    projectRef,
+    deploymentId: checkpoint.deployment_id,
+    releaseId: checkpoint.release_id,
+    expectedActiveReleaseId: checkpoint.expected_active_release_id,
+    expectedActivationId: checkpoint.expected_activation_id,
+    mutationId,
+    principal,
+  };
+}
+
+function recoveryServices() {
+  const mutations = frontendReleaseMutationStore();
+  const activation = new FrontendReleaseActivationService({
+    storage: new FrontendReleaseStorage(),
+    gateway: gatewayService,
+    mutations,
+  });
+  return { activation, mutations };
+}
+
+function assertRecoveryClaimEnvelope(claim: RecoverableProjectMutationClaim): void {
+  if (claim.operation !== "frontend.release.activate"
+    || claim.resourceKey === null
+    || !FRONTEND_RESOURCE_KEY_PATTERN.test(claim.resourceKey)
+    || !REQUEST_FINGERPRINT_PATTERN.test(claim.requestFingerprint)
+    || !["master", "admin", "project"].includes(claim.principal.type)
+    || !claim.principal.id
+    || claim.principal.id.trim() !== claim.principal.id) {
+    throw new Error("Frontend release recovery claim identity is invalid");
+  }
+}
+
+async function finalizeEmptyCheckpoint(
+  claim: RecoverableProjectMutationClaim,
+  mutations: ReturnType<typeof frontendReleaseMutationStore>,
+): Promise<void> {
+  const completed = await mutations.completeFailure({
+    projectRef: claim.projectRef,
+    mutationId: claim.mutationId,
+    leaseToken: claim.leaseToken,
+    fencingEpoch: claim.fencingEpoch,
+    status: "failed_terminal",
+    failureCode: "ACTIVATION_NOT_STARTED",
+    responseStatus: 409,
+    receipt: { project_ref: claim.projectRef },
+  });
+  if (completed !== "updated") throw new Error("Empty activation recovery could not be finalized");
+}
+
+async function recoverClaim(
+  claim: RecoverableProjectMutationClaim,
+  services: ReturnType<typeof recoveryServices>,
+): Promise<void> {
+  assertRecoveryClaimEnvelope(claim);
+  const checkpoint = parseActivationCheckpoint(claim.checkpoint);
+  if (!checkpoint) return finalizeEmptyCheckpoint(claim, services.mutations);
+  assertActivationCheckpointIdentity(checkpoint, {
+    projectRef: claim.projectRef,
+    mutationId: claim.mutationId,
+  });
+  const input = recoveryInput(
+    claim.projectRef,
+    claim.mutationId,
+    claim.principal,
+    checkpoint,
+  );
+  const expectedResourceKey = frontendReleaseActivationResourceKey(input.deploymentId);
+  const expectedFingerprint = frontendReleaseActivationFingerprint(input);
+  if (claim.resourceKey !== expectedResourceKey
+    || claim.requestFingerprint !== expectedFingerprint) {
+    throw new Error("Frontend release recovery claim identity is invalid");
+  }
+  await services.activation.resume(input, {
+    leaseToken: claim.leaseToken,
+    fencingEpoch: claim.fencingEpoch,
+    replayed: false,
+    preparedNow: false,
+    checkpoint,
+  });
+}
+
+async function recoverAvailableBatch(): Promise<number> {
+  const claims = await claimRecoverableFrontendReleases(
+    `management-api:frontend-release-recovery:${process.pid}`,
+    RECOVERY_BATCH_SIZE,
+  );
+  const services = recoveryServices();
+  for (const claim of claims) await recoverClaim(claim, services);
+  return claims.length;
+}
+
+function serializedRecoveryBatch(): Promise<number> {
+  if (recoveryRun) return recoveryRun;
+  const run = recoverAvailableBatch().finally(() => {
+    if (recoveryRun === run) recoveryRun = null;
+  });
+  recoveryRun = run;
+  return run;
+}
+
+async function recoverBackgroundBatch(): Promise<void> {
+  try {
+    await serializedRecoveryBatch();
+  } catch (error: unknown) {
+    logger.error("[frontend-release-recovery] recovery scan failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function recoverFrontendReleasesBeforeServe(): Promise<void> {
+  if (!frontendReleaseMutationPlatformSupported()) return;
+  while (await serializedRecoveryBatch() === RECOVERY_BATCH_SIZE) {
+    // Drain every immediately recoverable activation before opening the listener.
+  }
+  if (await hasUnresolvedFrontendReleaseActivations()) {
+    throw new Error("Frontend release activation remains unresolved after startup recovery");
+  }
+}
+
+export function startFrontendReleaseRecoveryWorker(): void {
+  if (timer || !frontendReleaseMutationPlatformSupported()) return;
+  timer = setInterval(() => void recoverBackgroundBatch(), POLL_INTERVAL_MS);
+}
+
+export function stopFrontendReleaseRecoveryWorker(): void {
+  if (timer) clearInterval(timer);
+  timer = null;
+}

--- a/packages/management-api/src/workers/gateway-health.worker.ts
+++ b/packages/management-api/src/workers/gateway-health.worker.ts
@@ -1,10 +1,13 @@
 import { logger } from "../utils/logger";
-import { gatewayService } from "../services/gateway.service";
+import {
+    gatewayService,
+    reconcileCanonicalGatewayRoutes,
+    type CanonicalGatewayReconcileState,
+} from "../services/gateway.service";
 
-// 自愈周期：默认 60s 轮询 Caddy Admin API 可达性。systemd 模式下 caddy 直接用 config.json
-// 启动，重启后会加载磁盘快照；若 management-api 内存态在此期间变化，快照即过时。docker 模式
-// 依赖 ensureGatewayReady 完成首次注入，本 worker 提供持续的自愈：检测到"从不可达恢复可达"
-// （caddy 重启信号）即触发全量重建 + JSON /load，让最新路由配置接管。
+// Caddy restarts from its durable config, which can lag behind Management state while it is
+// unavailable. Recovery edges and periodic checks therefore use the same full reconciliation;
+// only master, tenant/custom, hosted auth, frontend, and live read-back success marks recovery.
 const HEALTH_CHECK_INTERVAL_MS = Number(process.env.GATEWAY_HEALTH_CHECK_INTERVAL_MS || 60 * 1000);
 const INITIAL_DELAY_MS = Number(process.env.GATEWAY_HEALTH_CHECK_INITIAL_DELAY_MS || 30 * 1000);
 const ROUTE_RECONCILE_INTERVAL_MS = Number(process.env.GATEWAY_ROUTE_RECONCILE_INTERVAL_MS || 5 * 60 * 1000);
@@ -21,30 +24,25 @@ export function resetGatewayHealthState(): void {
 }
 
 interface HealthCheckDeps {
-    // 触发全量租户路由重建（rebuildAllTenantConfigs），默认走 gatewayService。
-    rebuildAll?: () => Promise<{ success: boolean; updated: number; errors: string[] }>;
+    reconcileAll?: () => Promise<CanonicalGatewayReconcileState>;
     // 测试可注入时钟和周期，生产环境使用环境变量配置。
     now?: () => number;
     reconcileIntervalMs?: number;
 }
 
-// 执行一次健康探测。返回本轮是否触发了全量重建。
+// 执行一次健康探测。返回本轮是否完成了 canonical reconciliation。
 export async function runGatewayHealthCheck(deps?: HealthCheckDeps): Promise<boolean> {
-    const rebuildAll = deps?.rebuildAll ?? (() => gatewayService.rebuildAllTenantConfigs());
+    const reconcileAll = deps?.reconcileAll ?? reconcileCanonicalGatewayRoutes;
     const now = deps?.now?.() ?? Date.now();
     const reconcileIntervalMs = Math.max(0, deps?.reconcileIntervalMs ?? ROUTE_RECONCILE_INTERVAL_MS);
 
-    const rebuild = async (reason: "recovered" | "periodic"): Promise<boolean> => {
+    const reconcile = async (reason: "recovered" | "periodic"): Promise<boolean> => {
+        const state = await reconcileAll();
         lastRouteReconcileAt = now;
-        const result = await rebuildAll();
-        if (!result.success) {
-            logger.warn(`[GatewayHealth] Gateway ${reason} rebuild completed with errors`, {
-                updated: result.updated,
-                errors: result.errors,
-            });
-        } else if (result.updated > 0) {
-            logger.info(`[GatewayHealth] Gateway ${reason} rebuild applied`, { updated: result.updated });
-        }
+        logger.info(`[GatewayHealth] Canonical gateway ${reason} reconciliation applied`, {
+            tenants: state.tenants.updated,
+            frontends: state.frontends.configured,
+        });
         return true;
     };
 
@@ -61,9 +59,10 @@ export async function runGatewayHealthCheck(deps?: HealthCheckDeps): Promise<boo
 
         // 从不可达恢复可达（含首次启动）：触发全量重建让最新内存态接管。
         if (!lastSeenReachable) {
-            logger.info("[GatewayHealth] Caddy reachable (recovered or first contact); rebuilding gateway config");
+            logger.info("[GatewayHealth] Caddy reachable; reconciling the canonical gateway state");
+            const reconciled = await reconcile("recovered");
             lastSeenReachable = true;
-            return rebuild("recovered");
+            return reconciled;
         }
 
         // Caddy can stay reachable while its live config is changed out-of-band
@@ -71,7 +70,7 @@ export async function runGatewayHealthCheck(deps?: HealthCheckDeps): Promise<boo
         // replay the persisted tenant routes so managed upstreams and headers
         // cannot remain stale indefinitely.
         if (reconcileIntervalMs === 0 || now - lastRouteReconcileAt >= reconcileIntervalMs) {
-            return rebuild("periodic");
+            return reconcile("periodic");
         }
 
         return false;

--- a/packages/management-api/tests/integration/project-mutation-migration.test.ts
+++ b/packages/management-api/tests/integration/project-mutation-migration.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { SQL } from "bun";
 import {
   PROJECT_MUTATION_JOURNAL_MIGRATION_KEY,
+  PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY,
   migrateProjectMutationJournal,
 } from "../../src/db/project-mutation-migration";
 
@@ -37,7 +38,7 @@ async function insertProjectFixture(transaction: SQL, projectRef: string): Promi
 async function insertLegacyMutation(
   transaction: SQL,
   projectRef: string,
-  status: "pending" | "succeeded",
+  status: "pending" | "failed_retryable" | "succeeded",
   resourceKey: string | null = null,
   recoveryNotBefore: Date | null = null,
 ): Promise<string> {
@@ -73,7 +74,7 @@ afterAll(async () => {
 }, 30_000);
 
 describe("project mutation PostgreSQL forward migration", () => {
-  test("backfills legacy active rows before enforcing the due-time invariant", async () => {
+  test("evolves a completed v3 database without scheduling pending rows for recovery", async () => {
     await withRollback(async (transaction) => {
       await transaction.unsafe(`
         ALTER TABLE project_mutations
@@ -81,37 +82,86 @@ describe("project mutation PostgreSQL forward migration", () => {
       `);
       await transaction.unsafe(`
         ALTER TABLE project_mutations
-        ALTER COLUMN recovery_not_before DROP DEFAULT
+        DROP CONSTRAINT IF EXISTS project_mutations_recovery_due_v2_check
+      `);
+      await transaction.unsafe(`
+        ALTER TABLE project_mutations
+        ALTER COLUMN recovery_not_before SET DEFAULT clock_timestamp()
+      `);
+      await transaction.unsafe("DROP INDEX IF EXISTS project_mutations_recovery_v2_idx");
+      await transaction.unsafe(`
+        CREATE INDEX IF NOT EXISTS project_mutations_recovery_idx
+        ON project_mutations(operation, recovery_not_before, updated_at, mutation_id)
+        WHERE recovery_not_before IS NOT NULL
+          AND status IN ('pending', 'running', 'failed_retryable')
       `);
       await transaction`
         DELETE FROM platform_schema_migrations
-        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+        WHERE migration_key = ${PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY}
+      `;
+      await transaction`
+        INSERT INTO platform_schema_migrations (migration_key)
+        VALUES (${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY})
+        ON CONFLICT (migration_key) DO NOTHING
       `;
       const projectRef = `mm${process.pid.toString(36)}${Date.now().toString(36)}`.slice(0, 20);
       await insertProjectFixture(transaction, projectRef);
-      const mutationId = await insertLegacyMutation(transaction, projectRef, "pending");
+      const pendingMutationId = await insertLegacyMutation(
+        transaction,
+        projectRef,
+        "pending",
+        null,
+        new Date(),
+      );
+      const retryableMutationId = await insertLegacyMutation(
+        transaction,
+        projectRef,
+        "failed_retryable",
+      );
 
       await migrateProjectMutationJournal(transaction);
       await migrateProjectMutationJournal(transaction);
 
-      const [mutation] = await transaction`
-        SELECT recovery_not_before
-        FROM project_mutations WHERE project_ref = ${projectRef} AND mutation_id = ${mutationId}
+      const mutations = await transaction`
+        SELECT mutation_id, recovery_not_before
+        FROM project_mutations
+        WHERE project_ref = ${projectRef}
+          AND mutation_id IN (${pendingMutationId}, ${retryableMutationId})
       `;
       const [constraint] = await transaction`
         SELECT convalidated
         FROM pg_constraint
         WHERE conrelid = 'project_mutations'::regclass
-          AND conname = 'project_mutations_recoverable_due_check'
+          AND conname = 'project_mutations_recovery_due_v2_check'
+      `;
+      const [columnDefault] = await transaction`
+        SELECT column_default
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'project_mutations'
+          AND column_name = 'recovery_not_before'
+      `;
+      const indexes = await transaction`
+        SELECT indexname
+        FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'project_mutations'
+          AND indexname IN ('project_mutations_recovery_idx', 'project_mutations_recovery_v2_idx')
       `;
       const [marker] = await transaction`
         SELECT count(*)::integer AS count
         FROM platform_schema_migrations
-        WHERE migration_key = ${PROJECT_MUTATION_JOURNAL_MIGRATION_KEY}
+        WHERE migration_key = ${PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY}
       `;
 
-      expect(mutation.recovery_not_before).not.toBeNull();
+      const recoveryByMutation = new Map(
+        mutations.map((mutation) => [String(mutation.mutation_id), mutation.recovery_not_before]),
+      );
+      expect(recoveryByMutation.get(pendingMutationId)).toBeNull();
+      expect(recoveryByMutation.get(retryableMutationId)).not.toBeNull();
       expect(constraint.convalidated).toBe(true);
+      expect(columnDefault.column_default).toBeNull();
+      expect(indexes).toEqual([{ indexname: "project_mutations_recovery_v2_idx" }]);
       expect(marker.count).toBe(1);
     });
   }, 30_000);

--- a/packages/management-api/tests/unit/frontend-deployment-lock.test.ts
+++ b/packages/management-api/tests/unit/frontend-deployment-lock.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test";
+import {
+  FrontendDeploymentLockReleaseError,
+  createFrontendDeploymentLock,
+} from "../../src/services/frontend-deployment-lock";
+
+function barrier(): { wait: Promise<void>; release: () => void } {
+  let release!: () => void;
+  return { wait: new Promise<void>((resolve) => { release = resolve; }), release };
+}
+
+class FakeAdvisoryLocks {
+  private readonly tails = new Map<string, Promise<void>>();
+  releaseCount = 0;
+  closeCount = 0;
+
+  reserve(options: { unlock?: "false" | "throw" } = {}) {
+    let held: { key: string; release: () => void } | undefined;
+    const releaseConnection = () => {
+      this.releaseCount += 1;
+      held?.release();
+    };
+    const closeConnection = () => {
+      this.closeCount += 1;
+      held?.release();
+    };
+    const connection = Object.assign(
+      async (strings: TemplateStringsArray, ...values: unknown[]) => {
+        const statement = strings.join("?");
+        const key = String(values[0]);
+        if (statement.includes("pg_advisory_lock(")) {
+          const previous = this.tails.get(key) ?? Promise.resolve();
+          let release!: () => void;
+          const current = new Promise<void>((resolve) => { release = resolve; });
+          this.tails.set(key, previous.then(() => current));
+          await previous;
+          held = { key, release };
+          return [];
+        }
+        if (statement.includes("pg_advisory_unlock(")) {
+          if (options.unlock === "throw") throw new Error("database disconnected during unlock");
+          if (options.unlock === "false") return [{ unlocked: false }];
+          held?.release();
+          if (held && this.tails.get(held.key)) this.tails.delete(held.key);
+          held = undefined;
+          return [{ unlocked: true }];
+        }
+        return [];
+      },
+      { release: releaseConnection, close: async () => { closeConnection(); } },
+    );
+    return connection;
+  }
+}
+
+function fakePool(locks: FakeAdvisoryLocks, options: { unlock?: "false" | "throw" } = {}) {
+  return { reserve: async () => locks.reserve(options) as never };
+}
+
+test("serializes independent Management instances through a PostgreSQL session lock", async () => {
+  const locks = new FakeAdvisoryLocks();
+  const firstInstance = createFrontendDeploymentLock(fakePool(locks));
+  const secondInstance = createFrontendDeploymentLock(fakePool(locks));
+  const firstEntered = barrier();
+  const firstRelease = barrier();
+  let secondEntered = false;
+
+  const first = firstInstance("abcdefghijklmnopqrst", "fa-web", async () => {
+    firstEntered.release();
+    await firstRelease.wait;
+  });
+  await firstEntered.wait;
+  const second = secondInstance("abcdefghijklmnopqrst", "fa-web", async () => {
+    secondEntered = true;
+  });
+  await Promise.resolve();
+  expect(secondEntered).toBe(false);
+  firstRelease.release();
+  await Promise.all([first, second]);
+  expect(secondEntered).toBe(true);
+  expect(locks.releaseCount).toBe(2);
+  expect(locks.closeCount).toBe(0);
+});
+
+test("allows same-deployment nested operations without acquiring another session", async () => {
+  const locks = new FakeAdvisoryLocks();
+  let reservations = 0;
+  const lock = createFrontendDeploymentLock({
+    reserve: async () => {
+      reservations += 1;
+      return locks.reserve() as never;
+    },
+  });
+  await lock("abcdefghijklmnopqrst", "fa-web", () =>
+    lock("abcdefghijklmnopqrst", "fa-web", async () => "done"));
+  expect(reservations).toBe(1);
+});
+
+for (const unlock of ["false", "throw"] as const) {
+  test(`fails closed when advisory unlock returns ${unlock}`, async () => {
+    const locks = new FakeAdvisoryLocks();
+    const lock = createFrontendDeploymentLock(fakePool(locks, { unlock }));
+    await expect(lock("abcdefghijklmnopqrst", "fa-web", async () => "success"))
+      .rejects.toBeInstanceOf(FrontendDeploymentLockReleaseError);
+    expect(locks.closeCount).toBe(1);
+    expect(locks.releaseCount).toBe(0);
+  });
+}
+
+test("preserves an operation failure when advisory unlock also fails", async () => {
+  const locks = new FakeAdvisoryLocks();
+  const lock = createFrontendDeploymentLock(fakePool(locks, { unlock: "throw" }));
+  const operationError = new Error("operation failed");
+  await expect(lock("abcdefghijklmnopqrst", "fa-web", async () => { throw operationError; }))
+    .rejects.toBe(operationError);
+  expect(locks.closeCount).toBe(1);
+  expect(locks.releaseCount).toBe(0);
+});

--- a/packages/management-api/tests/unit/frontend-release-archive.test.ts
+++ b/packages/management-api/tests/unit/frontend-release-archive.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, open, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  extractVerifiedZip,
+  verifiedZipArchive,
+  type VerifiedZipFileEntry,
+} from "../../src/services/frontend-release-archive";
+import { FrontendReleaseError } from "../../src/services/frontend-release-contract";
+
+const END_SIGNATURE = 0x06054b50;
+const CENTRAL_SIGNATURE = 0x02014b50;
+const DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
+
+function endOffset(archive: Uint8Array): number {
+  const view = Buffer.from(archive.buffer, archive.byteOffset, archive.byteLength);
+  for (let offset = view.byteLength - 22; offset >= 0; offset -= 1) {
+    if (view.readUInt32LE(offset) === END_SIGNATURE) return offset;
+  }
+  throw new Error("fixture has no zip end record");
+}
+
+function firstCentralOffset(archive: Uint8Array): number {
+  const view = Buffer.from(archive.buffer, archive.byteOffset, archive.byteLength);
+  const offset = view.readUInt32LE(endOffset(archive) + 16);
+  if (view.readUInt32LE(offset) !== CENTRAL_SIGNATURE) throw new Error("fixture has no central record");
+  return offset;
+}
+
+async function zipFixture(entries: Record<string, string>): Promise<Uint8Array> {
+  const base = join(tmpdir(), `frontend-release-archive-${crypto.randomUUID()}`);
+  await Bun.$`mkdir -p ${base}`;
+  for (const [path, contents] of Object.entries(entries)) {
+    const absolutePath = join(base, path);
+    await Bun.$`mkdir -p ${join(absolutePath, "..")} `.quiet();
+    await writeFile(absolutePath, contents);
+  }
+  const archivePath = `${base}.zip`;
+  const zipped = await Bun.$`zip -q -X -r ${archivePath} .`.cwd(base).nothrow();
+  if (zipped.exitCode !== 0) throw new Error("zip fixture failed");
+  const archive = new Uint8Array(await readFile(archivePath));
+  await Bun.$`chmod -R u+w ${base}`.nothrow();
+  await Bun.$`rm -r ${base} ${archivePath}`.nothrow();
+  return archive;
+}
+
+async function verifiedEntries(archive: Uint8Array): Promise<readonly VerifiedZipFileEntry[]> {
+  const archivePath = join(tmpdir(), `frontend-release-read-${crypto.randomUUID()}.zip`);
+  await writeFile(archivePath, archive);
+  const handle = await open(archivePath, "r");
+  try {
+    return (await verifiedZipArchive(handle, archive.byteLength)).entries;
+  } finally {
+    await handle.close();
+    await unlink(archivePath);
+  }
+}
+
+async function expectInvalid(archive: Uint8Array): Promise<void> {
+  try {
+    await verifiedEntries(archive);
+    throw new Error("Expected invalid zip archive");
+  } catch (error: unknown) {
+    expect(error).toBeInstanceOf(FrontendReleaseError);
+    expect(error).toMatchObject({ code: "FRONTEND_RELEASE_ARCHIVE_INVALID", statusCode: 400 });
+  }
+}
+
+function dataDescriptorFixture(source: Uint8Array, centralIndex = 0): Uint8Array {
+  const sourceView = Buffer.from(source.buffer, source.byteOffset, source.byteLength);
+  const sourceCentralDirectory = firstCentralOffset(source);
+  let sourceCentral = sourceCentralDirectory;
+  for (let index = 0; index < centralIndex; index += 1) {
+    sourceCentral += 46 + sourceView.readUInt16LE(sourceCentral + 28)
+      + sourceView.readUInt16LE(sourceCentral + 30) + sourceView.readUInt16LE(sourceCentral + 32);
+  }
+  const localOffset = sourceView.readUInt32LE(sourceCentral + 42);
+  const compressedSize = sourceView.readUInt32LE(sourceCentral + 20);
+  const localNameLength = sourceView.readUInt16LE(localOffset + 26);
+  const localExtraLength = sourceView.readUInt16LE(localOffset + 28);
+  const dataEnd = localOffset + 30 + localNameLength + localExtraLength + compressedSize;
+  const descriptor = Buffer.alloc(16);
+  descriptor.writeUInt32LE(DATA_DESCRIPTOR_SIGNATURE, 0);
+  descriptor.writeUInt32LE(sourceView.readUInt32LE(sourceCentral + 16), 4);
+  descriptor.writeUInt32LE(compressedSize, 8);
+  descriptor.writeUInt32LE(sourceView.readUInt32LE(sourceCentral + 24), 12);
+  const archive = Buffer.concat([
+    sourceView.subarray(0, dataEnd),
+    descriptor,
+    sourceView.subarray(dataEnd),
+  ]);
+  const central = sourceCentral + descriptor.byteLength;
+  const firstCentral = sourceCentralDirectory + descriptor.byteLength;
+  const end = endOffset(archive);
+  archive.writeUInt16LE(archive.readUInt16LE(localOffset + 6) | 0x0008, localOffset + 6);
+  archive.writeUInt32LE(0, localOffset + 14);
+  archive.writeUInt32LE(0, localOffset + 18);
+  archive.writeUInt32LE(0, localOffset + 22);
+  archive.writeUInt16LE(archive.readUInt16LE(central + 8) | 0x0008, central + 8);
+  archive.writeUInt32LE(firstCentral, end + 16);
+  let centralCursor = firstCentral;
+  while (centralCursor < end) {
+    const shiftedLocalOffset = archive.readUInt32LE(centralCursor + 42);
+    if (shiftedLocalOffset >= dataEnd) {
+      archive.writeUInt32LE(shiftedLocalOffset + descriptor.byteLength, centralCursor + 42);
+    }
+    centralCursor += 46 + archive.readUInt16LE(centralCursor + 28)
+      + archive.readUInt16LE(centralCursor + 30) + archive.readUInt16LE(centralCursor + 32);
+  }
+  return new Uint8Array(archive);
+}
+
+describe("verified frontend release archives", () => {
+  test("accepts a bounded static site with an index", async () => {
+    const archive = await zipFixture({ "index.html": "ok", "assets/app.js": "js" });
+    expect((await verifiedEntries(archive)).map((entry) => entry.path).sort()).toEqual([
+      "assets/app.js",
+      "index.html",
+    ]);
+  });
+
+  test("rejects encrypted, ZIP64, overlapping, duplicate, traversal, and non-regular metadata", async () => {
+    const source = await zipFixture({ "index.html": "ok" });
+    const encrypted = source.slice();
+    Buffer.from(encrypted.buffer).writeUInt16LE(1, firstCentralOffset(encrypted) + 8);
+    await expectInvalid(encrypted);
+
+    const zip64 = source.slice();
+    Buffer.from(zip64.buffer).writeUInt32LE(0xffffffff, endOffset(zip64) + 16);
+    await expectInvalid(zip64);
+
+    const overlap = source.slice();
+    const overlapView = Buffer.from(overlap.buffer);
+    const central = firstCentralOffset(overlap);
+    overlapView.writeUInt32LE(central - 1, central + 20);
+    await expectInvalid(overlap);
+
+    const duplicate = source.slice();
+    const duplicateView = Buffer.from(duplicate.buffer);
+    const duplicateEnd = endOffset(duplicate);
+    duplicateView.writeUInt16LE(2, duplicateEnd + 8);
+    duplicateView.writeUInt16LE(2, duplicateEnd + 10);
+    await expectInvalid(duplicate);
+
+    const traversal = source.slice();
+    const traversalView = Buffer.from(traversal.buffer);
+    const traversalCentral = firstCentralOffset(traversal);
+    const nameLength = traversalView.readUInt16LE(traversalCentral + 28);
+    const unsafeName = "../evil.ht";
+    expect(Buffer.byteLength(unsafeName)).toBe(nameLength);
+    traversalView.write(unsafeName, traversalCentral + 46, "utf8");
+    const localOffset = traversalView.readUInt32LE(traversalCentral + 42);
+    traversalView.write(unsafeName, localOffset + 30, "utf8");
+    await expectInvalid(traversal);
+
+    const symlink = source.slice();
+    const symlinkView = Buffer.from(symlink.buffer);
+    const symlinkCentral = firstCentralOffset(symlink);
+    symlinkView.writeUInt16LE(3 << 8, symlinkCentral + 4);
+    symlinkView.writeUInt32LE(0o120777 * 65_536, symlinkCentral + 38);
+    await expectInvalid(symlink);
+  });
+
+  test("accepts a valid data descriptor and rejects descriptor corruption", async () => {
+    const descriptor = dataDescriptorFixture(await zipFixture({ "index.html": "ok" }));
+    expect((await verifiedEntries(descriptor))[0].recordEnd).toBe(firstCentralOffset(descriptor));
+
+    const corrupted = descriptor.slice();
+    const entry = (await verifiedEntries(corrupted))[0];
+    Buffer.from(corrupted.buffer).writeUInt32LE(0, entry.dataEnd + 4);
+    await expectInvalid(corrupted);
+  });
+
+  test("rejects a second local record that overlaps the first data descriptor", async () => {
+    const descriptor = dataDescriptorFixture(await zipFixture({
+      "index.html": "ok",
+      "second.txt": "second",
+    }), 1);
+    const entries = await verifiedEntries(descriptor);
+    expect(entries).toHaveLength(2);
+    const archive = descriptor.slice();
+    const central = firstCentralOffset(archive);
+    const view = Buffer.from(archive.buffer);
+    const firstCentralNameLength = view.readUInt16LE(central + 28);
+    const firstCentralExtraLength = view.readUInt16LE(central + 30);
+    const firstCentralCommentLength = view.readUInt16LE(central + 32);
+    const secondCentral = central + 46 + firstCentralNameLength
+      + firstCentralExtraLength + firstCentralCommentLength;
+    view.writeUInt32LE(entries[1].dataEnd, central + 42);
+    await expectInvalid(archive);
+  });
+
+  test("streams extraction and rejects CRC or deflate corruption", async () => {
+    const source = await zipFixture({ "index.html": "streamed-content".repeat(1024) });
+    const archivePath = join(tmpdir(), `frontend-release-extract-${crypto.randomUUID()}.zip`);
+    const buildDir = await mkdtemp(join(tmpdir(), "frontend-release-build-"));
+    await writeFile(archivePath, source);
+    const handle = await open(archivePath, "r");
+    try {
+      const verified = await verifiedZipArchive(handle, source.byteLength);
+      await extractVerifiedZip(handle, verified, buildDir);
+      expect((await readFile(join(buildDir, "index.html"), "utf8")).startsWith("streamed-content")).toBe(true);
+    } finally {
+      await handle.close();
+      await unlink(archivePath);
+      await rm(buildDir, { recursive: true, force: true });
+    }
+
+    for (const corrupt of ["crc", "deflate"] as const) {
+      const archive = source.slice();
+      const view = Buffer.from(archive.buffer, archive.byteOffset, archive.byteLength);
+      const central = firstCentralOffset(archive);
+      if (corrupt === "crc") {
+        view.writeUInt32LE((view.readUInt32LE(central + 16) ^ 1) >>> 0, central + 16);
+        const local = view.readUInt32LE(central + 42);
+        view.writeUInt32LE(view.readUInt32LE(central + 16), local + 14);
+      } else {
+        const local = view.readUInt32LE(central + 42);
+        const dataOffset = local + 30 + view.readUInt16LE(local + 26) + view.readUInt16LE(local + 28);
+        view[dataOffset] ^= 0xff;
+      }
+      const corruptPath = join(tmpdir(), `frontend-release-corrupt-${crypto.randomUUID()}.zip`);
+      const outputDir = await mkdtemp(join(tmpdir(), "frontend-release-corrupt-build-"));
+      await writeFile(corruptPath, archive);
+      const corruptHandle = await open(corruptPath, "r");
+      try {
+        const verified = await verifiedZipArchive(corruptHandle, archive.byteLength);
+        await expect(extractVerifiedZip(corruptHandle, verified, outputDir))
+          .rejects.toMatchObject({ code: "FRONTEND_RELEASE_ARCHIVE_INVALID" });
+      } finally {
+        await corruptHandle.close();
+        await unlink(corruptPath);
+        await rm(outputDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("extracts highly compressible content without materializing the entry", async () => {
+    const base = await mkdtemp(join(tmpdir(), "frontend-release-compressed-"));
+    const archivePath = `${base}.zip`;
+    const buildDir = `${base}-build`;
+    await writeFile(join(base, "index.html"), Buffer.alloc(32 * 1024 * 1024, 0x61));
+    const zipped = await Bun.$`zip -q -X ${archivePath} index.html`.cwd(base).nothrow();
+    if (zipped.exitCode !== 0) throw new Error("zip fixture failed");
+    await mkdir(buildDir);
+    const handle = await open(archivePath, "r");
+    const archiveSize = (await handle.stat()).size;
+    const startingRss = process.memoryUsage.rss();
+    let peakRss = startingRss;
+    const sample = setInterval(() => {
+      peakRss = Math.max(peakRss, process.memoryUsage.rss());
+    }, 1);
+    try {
+      const verified = await verifiedZipArchive(handle, archiveSize);
+      await extractVerifiedZip(handle, verified, buildDir);
+      expect((await readFile(join(buildDir, "index.html"))).byteLength).toBe(32 * 1024 * 1024);
+      expect(peakRss - startingRss).toBeLessThan(64 * 1024 * 1024);
+    } finally {
+      clearInterval(sample);
+      await handle.close();
+      await rm(base, { recursive: true, force: true });
+      await rm(archivePath, { force: true });
+      await rm(buildDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/management-api/tests/unit/frontend-release-recovery.test.ts
+++ b/packages/management-api/tests/unit/frontend-release-recovery.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const recoveryClaims: Array<Array<Record<string, unknown>>> = [];
+let unresolved = false;
+const claimRecoverableFrontendReleases = mock(async () => recoveryClaims.shift() ?? []);
+const hasUnresolvedFrontendReleaseActivations = mock(async () => unresolved);
+const completeFailure = mock(async () => "updated" as const);
+const resume = mock(async () => ({}));
+const expectedFingerprint = "f".repeat(64);
+const frontendReleaseActivationFingerprint = mock(() => expectedFingerprint);
+const frontendReleaseActivationResourceKey = mock((deploymentId: string) =>
+  `v1/frontend_release/${Buffer.from(deploymentId).toString("base64url")}`);
+const assertActivationCheckpointIdentity = mock((
+  checkpoint: Record<string, unknown>,
+  identity: { projectRef: string; mutationId: string },
+) => {
+  const previous = checkpoint.previous_authority as Record<string, unknown> | null | undefined;
+  if (checkpoint.activation_id !== identity.mutationId
+    || previous && previous.project_ref !== identity.projectRef) {
+    throw new Error("Frontend release activation checkpoint identity is invalid");
+  }
+});
+
+mock.module("../../src/services/frontend-release-contract", () => ({
+  assertActivationCheckpointIdentity,
+  frontendReleaseMutationPlatformSupported: () => true,
+  parseActivationCheckpoint: (checkpoint: unknown) => checkpoint,
+}));
+mock.module("../../src/services/frontend-release-activation", () => ({
+  frontendReleaseActivationFingerprint,
+  frontendReleaseActivationResourceKey,
+  FrontendReleaseActivationService: class {
+    resume = resume;
+  },
+}));
+mock.module("../../src/services/frontend-release-mutation", () => ({
+  claimRecoverableFrontendReleases,
+  frontendReleaseMutationStore: () => ({ completeFailure }),
+  hasUnresolvedFrontendReleaseActivations,
+}));
+mock.module("../../src/services/frontend-release-storage", () => ({
+  FrontendReleaseStorage: class {},
+}));
+mock.module("../../src/services/gateway.service", () => ({ gatewayService: {} }));
+mock.module("../../src/utils/logger", () => ({ logger: { error: () => undefined } }));
+
+const recoveryWorker = await import(
+  new URL("../../src/workers/frontend-release-recovery.worker.ts?startup-recovery-test", import.meta.url).href
+);
+
+const indexSource = readFileSync(new URL("../../src/index.ts", import.meta.url), "utf8");
+const workerSource = readFileSync(
+  new URL("../../src/workers/frontend-release-recovery.worker.ts", import.meta.url),
+  "utf8",
+);
+const selfHostCompose = readFileSync(
+  new URL("../../../../docker/self-host/docker-compose.yml", import.meta.url),
+  "utf8",
+);
+
+function recoveryCheckpoint(mutationId: string): Record<string, unknown> {
+  return {
+    deployment_id: "fa-web",
+    release_id: "a".repeat(64),
+    expected_active_release_id: "absent",
+    activation_id: mutationId,
+    expected_activation_id: "absent",
+    previous_authority: null,
+  };
+}
+
+function recoveryClaim(
+  mutationId: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    projectRef: "project_ref",
+    mutationId,
+    operation: "frontend.release.activate",
+    resourceKey: frontendReleaseActivationResourceKey("fa-web"),
+    requestFingerprint: expectedFingerprint,
+    principal: { type: "project", id: "project:project_ref" },
+    checkpoint: recoveryCheckpoint(mutationId),
+    leaseToken: mutationId.replace("8000", "8001"),
+    fencingEpoch: 1,
+    ...overrides,
+  };
+}
+
+describe("frontend release startup recovery", () => {
+  beforeEach(() => {
+    recoveryClaims.length = 0;
+    unresolved = false;
+    claimRecoverableFrontendReleases.mockClear();
+    hasUnresolvedFrontendReleaseActivations.mockClear();
+    completeFailure.mockClear();
+    resume.mockClear();
+    assertActivationCheckpointIdentity.mockClear();
+    frontendReleaseActivationFingerprint.mockClear();
+    frontendReleaseActivationResourceKey.mockClear();
+  });
+
+  test("settles activation recovery before gateway reconciliation and HTTP listen", () => {
+    const durableGateIndex = indexSource.indexOf("await waitForGatewayBeforeServe()");
+    const strictHydrateIndex = indexSource.indexOf("gatewayService.ensureGatewayReady", indexSource.indexOf("async function waitForGatewayBeforeServe"));
+    const recoveryIndex = indexSource.indexOf("await recoverFrontendReleasesBeforeServe()");
+    const gatewayIndex = indexSource.indexOf("await reconcileGatewayBeforeServe()", recoveryIndex);
+    const serveIndex = indexSource.indexOf("Bun.serve({");
+
+    expect(durableGateIndex).toBeGreaterThan(-1);
+    expect(strictHydrateIndex).toBeGreaterThan(-1);
+    expect(recoveryIndex).toBeGreaterThan(durableGateIndex);
+    expect(recoveryIndex).toBeGreaterThan(-1);
+    expect(gatewayIndex).toBeGreaterThan(recoveryIndex);
+    expect(serveIndex).toBeGreaterThan(gatewayIndex);
+  });
+
+  test("propagates recovery failures and refuses every unresolved activation", () => {
+    const startupStart = workerSource.indexOf("export async function recoverFrontendReleasesBeforeServe");
+    const startupEnd = workerSource.indexOf("export function startFrontendReleaseRecoveryWorker", startupStart);
+    const startupSource = workerSource.slice(startupStart, startupEnd);
+
+    expect(startupSource).toContain("await serializedRecoveryBatch()");
+    expect(startupSource).toContain("await hasUnresolvedFrontendReleaseActivations()");
+    expect(startupSource).toContain("throw new Error");
+    expect(startupSource).not.toContain("catch (");
+  });
+
+  test("keeps later recovery on an interval without an unawaited initial sweep", () => {
+    const workerStart = workerSource.indexOf("export function startFrontendReleaseRecoveryWorker");
+    const workerEnd = workerSource.indexOf("export function stopFrontendReleaseRecoveryWorker", workerStart);
+    const startSource = workerSource.slice(workerStart, workerEnd);
+
+    expect(startSource).toContain("setInterval");
+    expect(startSource).not.toContain("void recoverAvailableBatch()");
+    expect(startSource).not.toContain("void serializedRecoveryBatch()");
+  });
+
+  test("starts the Caddy Admin API independently from Management", () => {
+    const caddyStart = selfHostCompose.indexOf("\n  caddy:\n");
+    const caddySource = selfHostCompose.slice(caddyStart, selfHostCompose.indexOf("\nvolumes:\n", caddyStart));
+
+    expect(caddyStart).toBeGreaterThan(-1);
+    expect(caddySource).not.toContain("depends_on:");
+    expect(caddySource).toContain("127.0.0.1:2019/config/");
+    expect(caddySource).not.toContain("edge-runtime:");
+    expect(caddySource).not.toContain("condition: service_healthy");
+  });
+
+  test("drains every full recovery batch before accepting a settled state", async () => {
+    recoveryClaims.push(Array.from({ length: 16 }, (_, index) => recoveryClaim(
+      `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    )), []);
+
+    await recoveryWorker.recoverFrontendReleasesBeforeServe();
+
+    expect(claimRecoverableFrontendReleases).toHaveBeenCalledTimes(2);
+    expect(resume).toHaveBeenCalledTimes(16);
+    expect(hasUnresolvedFrontendReleaseActivations).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates a recovery failure without reading it as settled", async () => {
+    recoveryClaims.push([recoveryClaim("00000000-0000-4000-8000-000000000001")]);
+    resume.mockRejectedValueOnce(new Error("route recovery failed"));
+
+    await expect(recoveryWorker.recoverFrontendReleasesBeforeServe())
+      .rejects.toThrow("route recovery failed");
+    expect(hasUnresolvedFrontendReleaseActivations).not.toHaveBeenCalled();
+  });
+
+  test("fails closed while a fresh lease or unknown outcome remains unresolved", async () => {
+    recoveryClaims.push([]);
+    unresolved = true;
+
+    await expect(recoveryWorker.recoverFrontendReleasesBeforeServe())
+      .rejects.toThrow("remains unresolved");
+    expect(resume).not.toHaveBeenCalled();
+  });
+
+  test("rejects a mismatched recovery identity before activation I/O", async () => {
+    const mutationId = "00000000-0000-4000-8000-000000000001";
+    recoveryClaims.push([recoveryClaim(mutationId, {
+      requestFingerprint: "e".repeat(64),
+    })]);
+
+    await expect(recoveryWorker.recoverFrontendReleasesBeforeServe())
+      .rejects.toThrow("claim identity is invalid");
+    expect(resume).not.toHaveBeenCalled();
+    expect(completeFailure).not.toHaveBeenCalled();
+  });
+
+  test("validates an empty-checkpoint claim envelope before terminalizing it", async () => {
+    const mutationId = "00000000-0000-4000-8000-000000000001";
+    recoveryClaims.push([recoveryClaim(mutationId, {
+      operation: "frontend.release.delete",
+      checkpoint: {},
+    })]);
+
+    await expect(recoveryWorker.recoverFrontendReleasesBeforeServe())
+      .rejects.toThrow("claim identity is invalid");
+    expect(completeFailure).not.toHaveBeenCalled();
+    expect(resume).not.toHaveBeenCalled();
+  });
+});

--- a/packages/management-api/tests/unit/frontend-release-storage-list.test.ts
+++ b/packages/management-api/tests/unit/frontend-release-storage-list.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FrontendDeployment } from "../../src/types/frontend";
+import {
+  FRONTEND_RELEASE_SCHEMA,
+  type FrontendReleaseRecord,
+} from "../../src/services/frontend-release-contract";
+import { FrontendReleaseStorage } from "../../src/services/frontend-release-storage";
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const DEPLOYMENT_ID = "fa-web";
+const CREATED_AT = "2026-08-12T00:00:00.000Z";
+const roots = new Set<string>();
+
+function releaseId(index: number): string {
+  return index.toString(16).padStart(64, "0");
+}
+
+class ObservedReleaseStorage extends FrontendReleaseStorage {
+  reads = 0;
+  peakConcurrentReads = 0;
+  private concurrentReads = 0;
+
+  override async deployment(projectRef: string, deploymentId: string): Promise<FrontendDeployment> {
+    return {
+      id: deploymentId,
+      project_ref: projectRef,
+      name: "FA",
+      framework: "static",
+      domain: "fa.example.test",
+      custom_domains: [],
+      build_command: "",
+      output_dir: ".",
+      install_command: "",
+      node_version: "20",
+      env_vars: {},
+      status: "success",
+      created_at: CREATED_AT,
+      updated_at: CREATED_AT,
+      deployment_url: "https://fa.example.test",
+    };
+  }
+
+  override async releaseRecord(
+    projectRef: string,
+    deploymentId: string,
+    id: string,
+  ): Promise<FrontendReleaseRecord> {
+    this.concurrentReads += 1;
+    this.peakConcurrentReads = Math.max(this.peakConcurrentReads, this.concurrentReads);
+    try {
+      await Bun.sleep(1);
+      this.reads += 1;
+      return {
+        schema: FRONTEND_RELEASE_SCHEMA,
+        project_ref: projectRef,
+        deployment_id: deploymentId,
+        release_id: id,
+        sha256: id,
+        tree_sha256: id,
+        size_bytes: 1,
+        file_count: 1,
+        created_at: CREATED_AT,
+        kind: "prebuilt_static",
+      };
+    } finally {
+      this.concurrentReads -= 1;
+    }
+  }
+
+  override async activeRelease(): Promise<null> {
+    return null;
+  }
+}
+
+afterEach(async () => {
+  await Promise.all([...roots].map((root) => rm(root, { recursive: true, force: true })));
+  roots.clear();
+});
+
+test("validates a maximum release page with one full integrity read at a time", async () => {
+  const root = await mkdtemp(join(tmpdir(), "frontend-release-list-"));
+  roots.add(root);
+  const releasesDir = join(root, PROJECT_REF, DEPLOYMENT_ID, "releases");
+  await mkdir(releasesDir, { recursive: true });
+  for (let index = 0; index < 100; index += 1) {
+    await mkdir(join(releasesDir, releaseId(index)));
+  }
+  const storage = new ObservedReleaseStorage({ baseDir: root });
+
+  const inventory = await storage.listReleases(PROJECT_REF, DEPLOYMENT_ID, { limit: 100 });
+
+  expect(inventory.releases).toHaveLength(100);
+  expect(storage.reads).toBe(100);
+  expect(storage.peakConcurrentReads).toBe(1);
+});

--- a/packages/management-api/tests/unit/frontend-release.service.test.ts
+++ b/packages/management-api/tests/unit/frontend-release.service.test.ts
@@ -1,0 +1,994 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import {
+  FrontendReleaseError,
+  FrontendReleaseService,
+  type FrontendReleaseActivation,
+} from "../../src/services/frontend-release.service";
+import type { FrontendReleaseStorage } from "../../src/services/frontend-release-storage";
+import type {
+  BeginProjectMutationInput,
+  BeginProjectMutationResult,
+  ClaimProjectMutationInput,
+  ClaimProjectMutationResult,
+  CompleteProjectMutationFailureInput,
+  CompleteProjectMutationSuccessInput,
+  ProjectMutationState,
+} from "../../src/services/project-mutation.service";
+
+const PROJECT_REF = "abcdefghijklmnopqrst";
+const DEPLOYMENT_ID = "fa-web";
+const MUTATION_ID = "00000000-0000-4000-8000-000000000001";
+const SECOND_MUTATION_ID = "00000000-0000-4000-8000-000000000002";
+const THIRD_MUTATION_ID = "00000000-0000-4000-8000-000000000003";
+const FIXED_TIME = "2026-08-12T00:00:00.000Z";
+const roots = new Set<string>();
+
+interface StoredMutation {
+  begin: BeginProjectMutationInput;
+  state: ProjectMutationState;
+  leaseToken: string | null;
+}
+
+function mutationState(
+  begin: BeginProjectMutationInput,
+  overrides: Partial<ProjectMutationState> = {},
+): ProjectMutationState {
+  return {
+    projectRef: begin.projectRef,
+    mutationId: begin.mutationId,
+    operation: begin.operation,
+    resourceKey: `v1/frontend_release/${Buffer.from(DEPLOYMENT_ID).toString("base64url")}`,
+    requestFingerprint: begin.requestFingerprint,
+    principal: begin.principal,
+    status: "pending",
+    checkpoint: {},
+    receipt: null,
+    responseStatus: null,
+    failureCode: null,
+    leaseOwner: null,
+    leaseExpiresAt: null,
+    fencingEpoch: 0,
+    completedAt: null,
+    createdAt: FIXED_TIME,
+    updatedAt: FIXED_TIME,
+    ...overrides,
+  };
+}
+
+class MemoryMutations {
+  readonly mutations = new Map<string, StoredMutation>();
+  readonly events: string[] = [];
+  rejectNextLease = false;
+  leaseDepth = 0;
+  corruptNextSuccessJournal?: (state: ProjectMutationState) => ProjectMutationState;
+
+  private async begin(input: BeginProjectMutationInput): Promise<BeginProjectMutationResult> {
+    const stored = this.mutations.get(input.mutationId);
+    if (stored) {
+      if (stored.begin.requestFingerprint !== input.requestFingerprint) return { kind: "fingerprint_conflict" };
+      if (JSON.stringify(stored.begin.principal) !== JSON.stringify(input.principal)) return { kind: "principal_conflict" };
+      return { kind: "replay", mutation: stored.state };
+    }
+    const state = mutationState(input);
+    this.mutations.set(input.mutationId, { begin: input, state, leaseToken: null });
+    return { kind: "started", mutation: state };
+  }
+
+  private async claim(input: ClaimProjectMutationInput): Promise<ClaimProjectMutationResult> {
+    const stored = this.mutations.get(input.mutationId);
+    if (!stored) return { kind: "not_found" };
+    if (["succeeded", "failed_terminal", "outcome_unknown"].includes(stored.state.status)) {
+      return { kind: "terminal", mutation: stored.state };
+    }
+    stored.leaseToken = input.leaseToken;
+    stored.state = {
+      ...stored.state,
+      status: "running",
+      leaseOwner: input.leaseOwner,
+      leaseExpiresAt: "2026-08-12T00:05:00.000Z",
+      fencingEpoch: stored.state.fencingEpoch + 1,
+      completedAt: null,
+    };
+    return { kind: "claimed", mutation: stored.state };
+  }
+
+  async beginAndClaim(
+    begin: BeginProjectMutationInput,
+    claim: Omit<ClaimProjectMutationInput, "projectRef" | "mutationId"> & {
+      initialCheckpoint?: Record<string, unknown>;
+    },
+  ): Promise<{ begun: BeginProjectMutationResult; claimed?: ClaimProjectMutationResult }> {
+    const begun = await this.begin(begin);
+    if (begun.kind !== "started" && begun.kind !== "replay") return { begun };
+    if (begun.kind === "replay" && ["succeeded", "failed_terminal", "outcome_unknown"].includes(
+      begun.mutation.status,
+    )) return { begun };
+    const claimed = await this.claim({ projectRef: begin.projectRef, mutationId: begin.mutationId, ...claim });
+    if (begun.kind === "started" && claimed.kind === "claimed") {
+      if (!claim.initialCheckpoint) throw new Error("initial checkpoint required");
+      const stored = this.mutations.get(begin.mutationId)!;
+      stored.state = { ...stored.state, checkpoint: claim.initialCheckpoint };
+    }
+    return {
+      begun,
+      claimed,
+    };
+  }
+
+  async checkpoint(input: {
+    mutationId: string;
+    leaseToken: string;
+    fencingEpoch: number;
+    checkpoint: Record<string, unknown>;
+  }): Promise<"updated" | "lease_lost"> {
+    const stored = this.mutations.get(input.mutationId);
+    if (!stored || stored.leaseToken !== input.leaseToken
+      || stored.state.fencingEpoch !== input.fencingEpoch) return "lease_lost";
+    stored.state = { ...stored.state, checkpoint: input.checkpoint };
+    return "updated";
+  }
+
+  async completeSuccess(input: CompleteProjectMutationSuccessInput): Promise<"updated" | "lease_lost"> {
+    const stored = this.mutations.get(input.mutationId);
+    if (!stored || stored.leaseToken !== input.leaseToken
+      || stored.state.fencingEpoch !== input.fencingEpoch) return "lease_lost";
+    const successfulState: ProjectMutationState = {
+      ...stored.state,
+      status: "succeeded",
+      receipt: input.receipt,
+      responseStatus: input.responseStatus,
+      failureCode: null,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      completedAt: FIXED_TIME,
+    };
+    stored.state = this.corruptNextSuccessJournal?.(successfulState) ?? successfulState;
+    this.corruptNextSuccessJournal = undefined;
+    stored.leaseToken = null;
+    return "updated";
+  }
+
+  async completeFailure(input: CompleteProjectMutationFailureInput): Promise<"updated" | "lease_lost"> {
+    const stored = this.mutations.get(input.mutationId);
+    if (!stored || stored.leaseToken !== input.leaseToken
+      || stored.state.fencingEpoch !== input.fencingEpoch) return "lease_lost";
+    stored.state = {
+      ...stored.state,
+      status: input.status,
+      receipt: input.receipt ?? {},
+      responseStatus: input.responseStatus ?? null,
+      failureCode: input.failureCode,
+      leaseOwner: null,
+      leaseExpiresAt: null,
+      completedAt: FIXED_TIME,
+    };
+    stored.leaseToken = null;
+    return "updated";
+  }
+
+  async read(_projectRef: string, mutationId: string): Promise<ProjectMutationState | null> {
+    return this.mutations.get(mutationId)?.state ?? null;
+  }
+
+  async activeForDeployment(): Promise<ProjectMutationState | null> {
+    return [...this.mutations.values()].find((stored) =>
+      ["pending", "running", "failed_retryable", "outcome_unknown"].includes(stored.state.status))?.state ?? null;
+  }
+
+  async withLease<T>(input: {
+    mutationId: string;
+    leaseToken: string;
+    fencingEpoch: number;
+  }, operation: () => Promise<T>): Promise<{ kind: "executed"; value: T } | { kind: "lease_lost" }> {
+    if (this.rejectNextLease) {
+      this.rejectNextLease = false;
+      return { kind: "lease_lost" };
+    }
+    const stored = this.mutations.get(input.mutationId);
+    if (!stored || stored.leaseToken !== input.leaseToken
+      || stored.state.fencingEpoch !== input.fencingEpoch || stored.state.status !== "running") {
+      return { kind: "lease_lost" };
+    }
+    this.leaseDepth += 1;
+    this.events.push(`lease:enter:${this.leaseDepth}`);
+    try {
+      return { kind: "executed", value: await operation() };
+    } finally {
+      this.events.push(`lease:exit:${this.leaseDepth}`);
+      this.leaseDepth -= 1;
+    }
+  }
+}
+
+class MemoryGateway {
+  root: string | null = null;
+  failNext = false;
+  failAfterApply = false;
+  durabilityUnknownAfterApply = false;
+  unreadableAfterFailure = false;
+  writeCalls = 0;
+  private readFailure = false;
+
+  constructor(private readonly mutations: MemoryMutations) {}
+
+  async configureFrontendRoute(route: { root: string }): Promise<void> {
+    this.writeCalls += 1;
+    this.mutations.events.push(`route:configure:${this.mutations.leaseDepth}`);
+    if (this.durabilityUnknownAfterApply) {
+      this.durabilityUnknownAfterApply = false;
+      this.root = route.root;
+      throw Object.assign(new Error("gateway durability unknown"), {
+        code: "CADDY_GATEWAY_DURABILITY_UNKNOWN",
+      });
+    }
+    if (this.failAfterApply) {
+      this.failAfterApply = false;
+      this.root = route.root;
+      throw new Error("gateway response lost after apply");
+    }
+    if (this.failNext) {
+      this.failNext = false;
+      this.readFailure = this.unreadableAfterFailure;
+      throw new Error("gateway failure");
+    }
+    this.root = route.root;
+  }
+
+  async removeFrontendRoute(): Promise<void> {
+    this.writeCalls += 1;
+    this.mutations.events.push(`route:remove:${this.mutations.leaseDepth}`);
+    this.root = null;
+  }
+
+  async readFrontendStaticRoot(): Promise<string | null> {
+    this.mutations.events.push(`route:read:${this.mutations.leaseDepth}`);
+    if (this.readFailure) throw new Error("gateway readback failure");
+    return this.root;
+  }
+}
+
+interface AuthorityWriteProbe {
+  count: number;
+}
+
+interface Fixture {
+  root: string;
+  service: FrontendReleaseService;
+  gateway: MemoryGateway;
+  mutations: MemoryMutations;
+  authorityWrites: AuthorityWriteProbe;
+  archive: Uint8Array;
+  sha256: string;
+}
+
+interface FixtureOptions {
+  interruption?: (phase: "after_prepared" | "after_authority" | "after_route") => void;
+  beforePublish?: (artifactDir: string, finalDir: string) => Promise<void> | void;
+}
+
+function observeAuthorityWrites(
+  service: FrontendReleaseService,
+  mutations: MemoryMutations,
+): AuthorityWriteProbe {
+  const storage = (service as unknown as { storage: FrontendReleaseStorage }).storage;
+  const writeActiveRelease = storage.writeActiveRelease.bind(storage);
+  const probe = { count: 0 };
+  storage.writeActiveRelease = async (
+    ...args: Parameters<FrontendReleaseStorage["writeActiveRelease"]>
+  ): Promise<void> => {
+    probe.count += 1;
+    mutations.events.push(`authority:write:${mutations.leaseDepth}`);
+    await writeActiveRelease(...args);
+  };
+  return probe;
+}
+
+async function stagedArchive(
+  service: FrontendReleaseService,
+  archive: Uint8Array,
+  expectedSha256: string,
+) {
+  const upload = await service.prepareReleaseUpload(PROJECT_REF, DEPLOYMENT_ID, archive.byteLength);
+  try {
+    for (let offset = 0; offset < archive.byteLength; offset += 64 * 1024) {
+      await upload.write(archive.subarray(offset, offset + 64 * 1024));
+    }
+    return await upload.finish(expectedSha256);
+  } catch (error: unknown) {
+    await upload.abort();
+    throw error;
+  }
+}
+
+async function createFixtureRelease(service: FrontendReleaseService, source: Fixture) {
+  return service.createRelease(
+    PROJECT_REF,
+    DEPLOYMENT_ID,
+    await stagedArchive(service, source.archive, source.sha256),
+  );
+}
+
+async function archiveBytes(root: string, content: string): Promise<Uint8Array> {
+  const source = join(root, "source");
+  const archive = join(root, "site.zip");
+  await mkdir(source, { mode: 0o700 });
+  await writeFile(join(source, "index.html"), content);
+  const zipped = await Bun.$`zip -q -X ${archive} index.html`.cwd(source).nothrow();
+  if (zipped.exitCode !== 0) throw new Error("zip fixture failed");
+  return new Uint8Array(await readFile(archive));
+}
+
+async function fixture(
+  content = "<!doctype html><title>release</title>",
+  options: FixtureOptions = {},
+): Promise<Fixture> {
+  const root = await mkdtemp(join(homedir(), ".supacloud-frontend-release-test-"));
+  roots.add(root);
+  await chmod(root, 0o700);
+  const deploymentDir = join(root, PROJECT_REF, DEPLOYMENT_ID);
+  await mkdir(deploymentDir, { recursive: true, mode: 0o700 });
+  await writeFile(join(deploymentDir, "deployment.json"), JSON.stringify({
+    id: DEPLOYMENT_ID,
+    project_ref: PROJECT_REF,
+    name: "FA",
+    framework: "static",
+    domain: "fa.example.test",
+    custom_domains: [],
+    build_command: "",
+    output_dir: ".",
+    install_command: "",
+    node_version: "20",
+    env_vars: {},
+    status: "success",
+    created_at: FIXED_TIME,
+    updated_at: FIXED_TIME,
+    deployment_url: "https://fa.example.test",
+  }));
+  const mutations = new MemoryMutations();
+  const gateway = new MemoryGateway(mutations);
+  const archive = await archiveBytes(root, content);
+  const sha = createHash("sha256").update(archive).digest("hex");
+  const service = new FrontendReleaseService({
+    baseDir: root,
+    gateway: gateway as never,
+    mutations,
+    deploymentLock: async (_projectRef, _deploymentId, operation) => operation(),
+    now: () => new Date(FIXED_TIME),
+    interruption: options.interruption,
+    beforePublish: options.beforePublish,
+  });
+  return {
+    root,
+    gateway,
+    mutations,
+    authorityWrites: observeAuthorityWrites(service, mutations),
+    archive,
+    sha256: sha,
+    service,
+  };
+}
+
+function activation(
+  fixture: Fixture,
+  overrides: Partial<Parameters<FrontendReleaseService["activateRelease"]>[0]> = {},
+): Parameters<FrontendReleaseService["activateRelease"]>[0] {
+  return {
+    projectRef: PROJECT_REF,
+    deploymentId: DEPLOYMENT_ID,
+    releaseId: fixture.sha256,
+    expectedActiveReleaseId: "absent",
+    expectedActivationId: "absent",
+    mutationId: MUTATION_ID,
+    principal: { type: "project", id: `project:${PROJECT_REF}` },
+    ...overrides,
+  };
+}
+
+function expectActivation(response: FrontendReleaseActivation, fixture: Fixture): void {
+  expect(response.active_release_id).toBe(fixture.sha256);
+  expect(response.activation_id).toBe(response.mutation.mutation_id);
+  expect(response.release.sha256).toBe(fixture.sha256);
+  expect(response.mutation.status).toBe("succeeded");
+}
+
+function nextGenerationActivation(fixture: Fixture) {
+  return activation(fixture, {
+    expectedActiveReleaseId: fixture.sha256,
+    expectedActivationId: MUTATION_ID,
+    mutationId: SECOND_MUTATION_ID,
+  });
+}
+
+function staleFirstGenerationActivation(fixture: Fixture) {
+  return activation(fixture, {
+    expectedActiveReleaseId: fixture.sha256,
+    expectedActivationId: MUTATION_ID,
+    mutationId: THIRD_MUTATION_ID,
+  });
+}
+
+interface SuccessfulJournalCorruption {
+  name: string;
+  corrupt: (state: ProjectMutationState) => ProjectMutationState;
+  replayCode: string;
+}
+
+const SUCCESSFUL_JOURNAL_CORRUPTIONS: SuccessfulJournalCorruption[] = [
+  {
+    name: "operation",
+    corrupt: (state) => ({ ...state, operation: "frontend.release.delete" }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+  {
+    name: "resource key",
+    corrupt: (state) => ({ ...state, resourceKey: "v1/frontend_release/YXR0YWNrZXI" }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+  {
+    name: "request fingerprint",
+    corrupt: (state) => ({ ...state, requestFingerprint: "e".repeat(64) }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+  {
+    name: "principal",
+    corrupt: (state) => ({ ...state, principal: { type: "project", id: "project:attacker" } }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+  {
+    name: "status",
+    corrupt: (state) => ({ ...state, status: "failed_terminal" }),
+    replayCode: "FRONTEND_RELEASE_MUTATION_FAILED",
+  },
+  {
+    name: "response status",
+    corrupt: (state) => ({ ...state, responseStatus: 201 }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+  {
+    name: "failure code",
+    corrupt: (state) => ({ ...state, failureCode: "CORRUPTED_SUCCESS" }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+  {
+    name: "receipt",
+    corrupt: (state) => ({ ...state, receipt: {} }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+  {
+    name: "checkpoint",
+    corrupt: (state) => ({
+      ...state,
+      checkpoint: { ...state.checkpoint, phase: "authority_applied" },
+    }),
+    replayCode: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+  },
+];
+
+afterEach(async () => {
+  const makeRemovable = async (directory: string): Promise<void> => {
+    await chmod(directory, 0o700).catch(() => undefined);
+    const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (entry.isDirectory()) await makeRemovable(join(directory, entry.name));
+    }
+  };
+  await Promise.all([...roots].map(async (root) => {
+    await makeRemovable(root);
+    await rm(root, { recursive: true, force: true });
+  }));
+  roots.clear();
+});
+
+describe.skipIf(process.platform !== "linux")("FrontendReleaseService", () => {
+  test("creates an immutable release, inventories it, and CAS activates it", async () => {
+    const prepared = await fixture();
+    const created = await createFixtureRelease(prepared.service, prepared);
+    expect(created.release_id).toBe(prepared.sha256);
+    expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).active_release_id).toBeNull();
+
+    const activated = await prepared.service.activateRelease(activation(prepared));
+    expectActivation(activated, prepared);
+    expect(prepared.gateway.root).toBe(join(
+      prepared.root,
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      "releases",
+      prepared.sha256,
+      "build",
+    ));
+    const inventory = await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID);
+    expect(inventory.active_release_id).toBe(prepared.sha256);
+    expect(inventory.releases).toHaveLength(1);
+  });
+
+  test("paginates multiple releases in the same release-id order as its cursor", async () => {
+    const prepared = await fixture("<!doctype html><title>first</title>");
+    const second = await fixture("<!doctype html><title>second</title>");
+    const third = await fixture("<!doctype html><title>third</title>");
+    const archives = [prepared, second, third];
+    for (const candidate of archives) {
+      await createFixtureRelease(prepared.service, candidate);
+    }
+
+    const expectedIds = archives.map(({ sha256 }) => sha256).sort();
+    const firstPage = await prepared.service.listReleases(
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      { limit: 2 },
+    );
+    expect(firstPage.releases.map(({ release_id }) => release_id)).toEqual(expectedIds.slice(0, 2));
+    expect(firstPage.next_cursor).toBe(expectedIds[1]);
+
+    const secondPage = await prepared.service.listReleases(
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      { cursor: firstPage.next_cursor!, limit: 2 },
+    );
+    expect(secondPage.releases.map(({ release_id }) => release_id)).toEqual(expectedIds.slice(2));
+    expect(secondPage.next_cursor).toBeNull();
+  });
+
+  test("replays the exact successful activation only after receipt and live read-back", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    expectActivation(await prepared.service.activateRelease(activation(prepared)), prepared);
+
+    const replay = await prepared.service.activateRelease(activation(prepared));
+    expect(replay.mutation.replayed).toBe(true);
+    prepared.gateway.root = join(prepared.root, "attacker-controlled");
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_READBACK_MISMATCH",
+    });
+  });
+
+  for (const corruption of SUCCESSFUL_JOURNAL_CORRUPTIONS) {
+    test(`fails closed for a corrupted successful ${corruption.name} on first completion and replay`, async () => {
+      const prepared = await fixture();
+      await createFixtureRelease(prepared.service, prepared);
+      prepared.mutations.corruptNextSuccessJournal = corruption.corrupt;
+
+      await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+        code: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+      });
+      const authorityWritesAfterCompletion = prepared.authorityWrites.count;
+      const gatewayWritesAfterCompletion = prepared.gateway.writeCalls;
+      const eventsAfterCompletion = prepared.mutations.events.length;
+
+      await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+        code: corruption.replayCode,
+      });
+      expect(prepared.authorityWrites.count).toBe(authorityWritesAfterCompletion);
+      expect(prepared.gateway.writeCalls).toBe(gatewayWritesAfterCompletion);
+      expect(prepared.mutations.events).toHaveLength(eventsAfterCompletion);
+    });
+  }
+
+  test("rejects stale CAS before changing authority or Caddy", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    const stale = activation(prepared);
+    stale.expectedActiveReleaseId = "f".repeat(64);
+    await expect(prepared.service.activateRelease(stale)).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_REVISION_CONFLICT",
+      statusCode: 409,
+    });
+    expect(prepared.gateway.root).toBeNull();
+    expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).active_release_id).toBeNull();
+  });
+
+  test("rejects invalid deployment or release metadata before creating a mutation journal", async () => {
+    const prepared = await fixture();
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_NOT_FOUND",
+    });
+    expect(prepared.mutations.mutations.size).toBe(0);
+
+    await createFixtureRelease(prepared.service, prepared);
+    await writeFile(join(prepared.root, PROJECT_REF, DEPLOYMENT_ID, "deployment.json"), "{}\n");
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_DEPLOYMENT_INVALID",
+    });
+    expect(prepared.mutations.mutations.size).toBe(0);
+  });
+
+  test("never applies authority or Caddy after losing the fenced lease", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    prepared.mutations.rejectNextLease = true;
+
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+    });
+
+    expect(prepared.gateway.root).toBeNull();
+    expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).active_release_id).toBeNull();
+  });
+
+  test("rejects an A to B to A stale activation with the old activation generation", async () => {
+    const prepared = await fixture();
+    const second = await fixture("<!doctype html><title>second</title>");
+    await createFixtureRelease(prepared.service, prepared);
+    await createFixtureRelease(prepared.service, second);
+
+    await prepared.service.activateRelease(activation(prepared));
+    await prepared.service.activateRelease(activation(prepared, {
+      releaseId: second.sha256,
+      expectedActiveReleaseId: prepared.sha256,
+      expectedActivationId: MUTATION_ID,
+      mutationId: SECOND_MUTATION_ID,
+    }));
+    await prepared.service.activateRelease(activation(prepared, {
+      expectedActiveReleaseId: second.sha256,
+      expectedActivationId: SECOND_MUTATION_ID,
+      mutationId: THIRD_MUTATION_ID,
+    }));
+
+    await expect(prepared.service.activateRelease(activation(prepared, {
+      expectedActiveReleaseId: prepared.sha256,
+      expectedActivationId: MUTATION_ID,
+      mutationId: "00000000-0000-4000-8000-000000000004",
+    }))).rejects.toMatchObject({ code: "FRONTEND_RELEASE_REVISION_CONFLICT" });
+    const inventory = await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID);
+    expect(inventory.active_release_id).toBe(prepared.sha256);
+    expect(inventory.active_activation_id).toBe(THIRD_MUTATION_ID);
+  });
+
+  test("advances the activation generation without changing the content-addressed root", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    await prepared.service.activateRelease(activation(prepared));
+    const firstGenerationRoot = prepared.gateway.root;
+
+    const secondGeneration = await prepared.service.activateRelease(nextGenerationActivation(prepared));
+    expect(secondGeneration.activation_id).toBe(SECOND_MUTATION_ID);
+    expect(secondGeneration.active_release_id).toBe(prepared.sha256);
+    expect(prepared.gateway.root).toBe(firstGenerationRoot);
+    const inventory = await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID);
+    expect(inventory.active_release_id).toBe(prepared.sha256);
+    expect(inventory.active_activation_id).toBe(SECOND_MUTATION_ID);
+
+    await expect(prepared.service.activateRelease(staleFirstGenerationActivation(prepared)))
+      .rejects.toMatchObject({ code: "FRONTEND_RELEASE_REVISION_CONFLICT" });
+    expect(prepared.mutations.mutations.has(THIRD_MUTATION_ID)).toBe(false);
+  });
+
+  for (const interruptedPhase of ["after_prepared", "after_authority", "after_route"] as const) {
+    test(`recovers a same-release generation after a crash at ${interruptedPhase}`, async () => {
+      let armed = false;
+      let interrupted = false;
+      const prepared = await fixture(undefined, {
+        interruption: (phase) => {
+          if (armed && !interrupted && phase === interruptedPhase) {
+            interrupted = true;
+            throw new Error("simulated process crash");
+          }
+        },
+      });
+      await createFixtureRelease(prepared.service, prepared);
+      await prepared.service.activateRelease(activation(prepared));
+      const firstGenerationRoot = prepared.gateway.root;
+      armed = true;
+
+      await expect(prepared.service.activateRelease(nextGenerationActivation(prepared)))
+        .rejects.toMatchObject({ code: "FRONTEND_RELEASE_ACTIVATION_RETRYABLE" });
+      expect(prepared.mutations.mutations.get(SECOND_MUTATION_ID)?.state.status)
+        .toBe("failed_retryable");
+
+      const recovered = await prepared.service.activateRelease(nextGenerationActivation(prepared));
+      expect(recovered.activation_id).toBe(SECOND_MUTATION_ID);
+      expect(recovered.active_release_id).toBe(prepared.sha256);
+      expect(prepared.gateway.root).toBe(firstGenerationRoot);
+      expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).active_activation_id)
+        .toBe(SECOND_MUTATION_ID);
+      await expect(prepared.service.activateRelease(staleFirstGenerationActivation(prepared)))
+        .rejects.toMatchObject({ code: "FRONTEND_RELEASE_REVISION_CONFLICT" });
+    });
+  }
+
+  test("restores old authority and records a terminal failure when Caddy keeps the old root", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    prepared.gateway.failNext = true;
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_ROUTE_REJECTED",
+    });
+    expect(prepared.gateway.root).toBeNull();
+    expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).active_release_id).toBeNull();
+    expect(prepared.mutations.mutations.get(MUTATION_ID)?.state).toMatchObject({
+      status: "failed_terminal",
+      checkpoint: { phase: "authority_applied", release_id: prepared.sha256 },
+    });
+    const routeFailureStart = prepared.mutations.events.indexOf("route:configure:1") - 1;
+    expect(prepared.mutations.events.slice(routeFailureStart)).toEqual([
+      "lease:enter:1",
+      "route:configure:1",
+      "route:read:1",
+      "authority:write:1",
+      "lease:exit:1",
+    ]);
+  });
+
+  test("finishes activation when Caddy applied the desired root before losing its response", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    prepared.gateway.failAfterApply = true;
+
+    expectActivation(await prepared.service.activateRelease(activation(prepared)), prepared);
+    expect(prepared.mutations.mutations.get(MUTATION_ID)?.state.status).toBe("succeeded");
+    expect(prepared.gateway.root).toContain(prepared.sha256);
+  });
+
+  test("records outcome_unknown when the desired Caddy root is live but durability is unknown", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    prepared.gateway.durabilityUnknownAfterApply = true;
+
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+    });
+    expect(prepared.gateway.root).toContain(prepared.sha256);
+    expect(prepared.mutations.mutations.get(MUTATION_ID)?.state).toMatchObject({
+      status: "outcome_unknown",
+      receipt: expect.not.objectContaining({ active_release_id: prepared.sha256 }),
+    });
+  });
+
+  for (const phase of ["authority_applied", "route_applied"] as const) {
+    test(`re-drives ${phase} checkpoint after authority and route drift back to previous state`, async () => {
+      let interrupted = false;
+      const prepared = await fixture(undefined, {
+        interruption: (currentPhase) => {
+          if (!interrupted && currentPhase === (phase === "authority_applied" ? "after_authority" : "after_route")) {
+            interrupted = true;
+            throw new Error("simulated process crash");
+          }
+        },
+      });
+      await createFixtureRelease(prepared.service, prepared);
+      await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+        code: "FRONTEND_RELEASE_ACTIVATION_RETRYABLE",
+      });
+      await rm(join(prepared.root, PROJECT_REF, DEPLOYMENT_ID, "active-release.json"));
+      prepared.gateway.root = null;
+
+      expectActivation(await prepared.service.activateRelease(activation(prepared)), prepared);
+      expect(prepared.mutations.mutations.get(MUTATION_ID)?.state).toMatchObject({
+        status: "succeeded",
+        checkpoint: { phase: "route_applied" },
+      });
+    });
+  }
+
+  test("terminalizes an unreconcilable recovery drift instead of retrying forever", async () => {
+    let interrupted = false;
+    const prepared = await fixture(undefined, {
+      interruption: (phase) => {
+        if (!interrupted && phase === "after_route") {
+          interrupted = true;
+          throw new Error("simulated process crash");
+        }
+      },
+    });
+    await createFixtureRelease(prepared.service, prepared);
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_ACTIVATION_RETRYABLE",
+    });
+    prepared.gateway.root = join(prepared.root, "unrelated-live-root");
+
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+    });
+    expect(prepared.mutations.mutations.get(MUTATION_ID)?.state.status).toBe("outcome_unknown");
+  });
+
+  test("records outcome_unknown without a successful receipt when Caddy readback fails", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    prepared.gateway.failNext = true;
+    prepared.gateway.unreadableAfterFailure = true;
+
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_OUTCOME_UNKNOWN",
+    });
+    expect(prepared.mutations.mutations.get(MUTATION_ID)?.state).toMatchObject({
+      status: "outcome_unknown",
+      receipt: expect.not.objectContaining({ active_release_id: prepared.sha256 }),
+    });
+  });
+
+  test("fails inventory closed after immutable artifact tampering", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    const buildFile = join(
+      prepared.root,
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      "releases",
+      prepared.sha256,
+      "build",
+      "index.html",
+    );
+    await chmod(buildFile, 0o644);
+    await writeFile(buildFile, "attacker-controlled");
+    await expect(prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).rejects.toBeInstanceOf(FrontendReleaseError);
+  });
+
+  test("rejects split active authority before inventory, build lookup, or Gateway mutation", async () => {
+    const prepared = await fixture();
+    await createFixtureRelease(prepared.service, prepared);
+    await prepared.service.activateRelease(activation(prepared));
+    const authorityPath = join(prepared.root, PROJECT_REF, DEPLOYMENT_ID, "active-release.json");
+    const authority = JSON.parse(await readFile(authorityPath, "utf8"));
+    authority.activation_id = SECOND_MUTATION_ID;
+    await chmod(authorityPath, 0o644);
+    await writeFile(authorityPath, `${JSON.stringify(authority)}\n`);
+    prepared.gateway.root = null;
+
+    await expect(prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID))
+      .rejects.toMatchObject({ code: "FRONTEND_RELEASE_AUTHORITY_INVALID" });
+    await expect(prepared.service.activeBuildDir(PROJECT_REF, DEPLOYMENT_ID))
+      .rejects.toMatchObject({ code: "FRONTEND_RELEASE_AUTHORITY_INVALID" });
+    await expect(prepared.service.activateRelease(activation(prepared, {
+      mutationId: SECOND_MUTATION_ID,
+      expectedActiveReleaseId: prepared.sha256,
+      expectedActivationId: MUTATION_ID,
+    }))).rejects.toMatchObject({ code: "FRONTEND_RELEASE_AUTHORITY_INVALID" });
+    expect(prepared.gateway.root).toBeNull();
+    expect(prepared.mutations.mutations.has(SECOND_MUTATION_ID)).toBe(false);
+  });
+
+  test("rejects a digest mismatch without creating an inventory entry", async () => {
+    const prepared = await fixture();
+    await expect(stagedArchive(
+      prepared.service,
+      prepared.archive,
+      "0".repeat(64),
+    )).rejects.toMatchObject({ code: "FRONTEND_RELEASE_SHA_MISMATCH" });
+    expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).releases).toEqual([]);
+  });
+
+  test("cleans incomplete upload sessions and keeps concurrent staging isolated", async () => {
+    const prepared = await fixture();
+    const first = await prepared.service.prepareReleaseUpload(
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      prepared.archive.byteLength,
+    );
+    const second = await prepared.service.prepareReleaseUpload(
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      prepared.archive.byteLength,
+    );
+    await first.write(prepared.archive.subarray(0, 1));
+    await first.abort();
+    await second.write(prepared.archive);
+    const staged = await second.finish(prepared.sha256);
+    expect((await prepared.service.createRelease(PROJECT_REF, DEPLOYMENT_ID, staged)).release_id)
+      .toBe(prepared.sha256);
+    expect(await readdir(join(
+      prepared.root,
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      "releases",
+      ".staging",
+    ))).toEqual([]);
+  });
+
+  test("rejects a staged archive path replacement and removes only its bound session", async () => {
+    const prepared = await fixture();
+    const upload = await prepared.service.prepareReleaseUpload(
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      prepared.archive.byteLength,
+    );
+    await upload.write(prepared.archive);
+    const staged = await upload.finish(prepared.sha256);
+    const stagingRoot = join(prepared.root, PROJECT_REF, DEPLOYMENT_ID, "releases", ".staging");
+    const [sessionName] = await readdir(stagingRoot);
+    const archivePath = join(stagingRoot, sessionName, "archive.zip");
+    await rename(archivePath, `${archivePath}.moved`);
+    await writeFile(archivePath, "attacker-controlled");
+
+    await expect(prepared.service.createRelease(PROJECT_REF, DEPLOYMENT_ID, staged))
+      .rejects.toMatchObject({ code: "FRONTEND_RELEASE_STORAGE_UNTRUSTED" });
+    expect(await readdir(stagingRoot)).toEqual([]);
+    expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).releases).toEqual([]);
+  });
+
+  for (const interruptedPhase of ["after_prepared", "after_authority", "after_route"] as const) {
+    test(`recovers the exact terminal state after a crash at ${interruptedPhase}`, async () => {
+      let interrupted = false;
+      const prepared = await fixture(undefined, {
+        interruption: (phase) => {
+          if (!interrupted && phase === interruptedPhase) {
+            interrupted = true;
+            throw new Error("simulated process crash");
+          }
+        },
+      });
+      await createFixtureRelease(prepared.service, prepared);
+      await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+        code: "FRONTEND_RELEASE_ACTIVATION_RETRYABLE",
+      });
+      expect(prepared.mutations.mutations.get(MUTATION_ID)?.state.status).toBe("failed_retryable");
+
+      const recovered = await prepared.service.activateRelease(activation(prepared));
+      expectActivation(recovered, prepared);
+      expect(prepared.mutations.mutations.get(MUTATION_ID)?.state.status).toBe("succeeded");
+      expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).active_release_id)
+        .toBe(prepared.sha256);
+      expect(prepared.gateway.root).toBe(join(
+        prepared.root,
+        PROJECT_REF,
+        DEPLOYMENT_ID,
+        "releases",
+        prepared.sha256,
+        "build",
+      ));
+    });
+  }
+
+  test.skipIf(process.platform !== "linux")(
+    "concurrent service instances converge on the same content-addressed release",
+    async () => {
+    const prepared = await fixture();
+    const second = new FrontendReleaseService({
+      baseDir: prepared.root,
+      gateway: prepared.gateway as never,
+      mutations: prepared.mutations,
+      deploymentLock: async (_projectRef, _deploymentId, operation) => operation(),
+      now: () => new Date(FIXED_TIME),
+    });
+    const [left, right] = await Promise.all([
+      createFixtureRelease(prepared.service, prepared),
+      createFixtureRelease(second, prepared),
+    ]);
+    expect(left).toEqual(right);
+    expect((await prepared.service.listReleases(PROJECT_REF, DEPLOYMENT_ID)).releases).toHaveLength(1);
+    },
+  );
+
+  test.skipIf(process.platform !== "linux")(
+    "fails closed when an ancestor is replaced before immutable publish",
+    async () => {
+    let movedRoot = "";
+    const prepared = await fixture(undefined, {
+      beforePublish: async () => {
+        movedRoot = `${prepared.root}-moved`;
+        roots.add(movedRoot);
+        await rename(prepared.root, movedRoot);
+        await mkdir(prepared.root, { mode: 0o700 });
+      },
+    });
+    await expect(createFixtureRelease(prepared.service, prepared))
+      .rejects.toMatchObject({ code: "FRONTEND_RELEASE_STORAGE_UNTRUSTED" });
+    await expect(readdir(join(
+      prepared.root,
+      PROJECT_REF,
+      DEPLOYMENT_ID,
+      "releases",
+    ))).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+});
+
+test.skipIf(process.platform === "linux")(
+  "rejects immutable release writes before publish on unsupported platforms",
+  async () => {
+    const prepared = await fixture();
+    await expect(createFixtureRelease(prepared.service, prepared))
+      .rejects.toMatchObject({ code: "FRONTEND_RELEASE_STORAGE_PLATFORM_UNSUPPORTED" });
+    expect(prepared.mutations.mutations).toHaveLength(0);
+    await expect(prepared.service.activateRelease(activation(prepared))).rejects.toMatchObject({
+      code: "FRONTEND_RELEASE_STORAGE_PLATFORM_UNSUPPORTED",
+    });
+    expect(prepared.mutations.mutations).toHaveLength(0);
+    expect(prepared.gateway.root).toBeNull();
+    expect(await readdir(join(prepared.root, PROJECT_REF, DEPLOYMENT_ID))).toEqual(["deployment.json"]);
+  },
+);

--- a/packages/management-api/tests/unit/frontend.routes.test.ts
+++ b/packages/management-api/tests/unit/frontend.routes.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
 import { frontendService } from "../../src/services/frontend.service";
+import {
+  FrontendReleaseError,
+  frontendReleaseService,
+} from "../../src/services/frontend-release.service";
 import { rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -66,7 +70,25 @@ describe("Frontend deployment upload routes", () => {
         message: "Deployed successfully",
       };
     });
+    spyOn(frontendReleaseService, "assertMutationSupported").mockResolvedValue();
   });
+
+  function mockImmutableUpload(releaseId: string) {
+    const written: Uint8Array[] = [];
+    const staged = Object.freeze({ size_bytes: testZipBytes.byteLength, sha256: releaseId });
+    const upload = {
+      write: mock(async (chunk: Uint8Array) => { written.push(chunk.slice()); }),
+      finish: mock(async (expected: string) => {
+        if (expected !== releaseId) {
+          throw new FrontendReleaseError("FRONTEND_RELEASE_SHA_MISMATCH", 400, "digest mismatch");
+        }
+        return staged;
+      }),
+      abort: mock(async () => undefined),
+    };
+    const prepare = spyOn(frontendReleaseService, "prepareReleaseUpload").mockResolvedValue(upload);
+    return { written, staged, upload, prepare };
+  }
 
   test("supports direct raw binary uploads (application/zip)", async () => {
     const req = new Request(
@@ -226,5 +248,340 @@ describe("Frontend deployment upload routes", () => {
     expect(res.status).toBe(403);
     expect(requireProjectOrAdminAuth).toHaveBeenCalledWith(expect.any(Request), "proj123");
     expect(createDeployment).not.toHaveBeenCalled();
+  });
+
+  test("routes immutable release inventory and upload through the release service", async () => {
+    const releaseId = "a".repeat(64);
+    const stream = mockImmutableUpload(releaseId);
+    const listReleases = spyOn(frontendReleaseService, "listReleases").mockResolvedValue({
+      project_ref: "proj123",
+      deployment_id: "dep123",
+      active_release_id: null,
+      active_activation_id: null,
+      releases: [],
+      next_cursor: null,
+    });
+    const createRelease = spyOn(frontendReleaseService, "createRelease").mockResolvedValue({
+      schema: "supacloud.frontend-release.v1",
+      project_ref: "proj123",
+      deployment_id: "dep123",
+      release_id: releaseId,
+      sha256: releaseId,
+      tree_sha256: "b".repeat(64),
+      size_bytes: testZipBytes.byteLength,
+      file_count: 1,
+      created_at: "2026-08-12T00:00:00.000Z",
+      kind: "prebuilt_static",
+    });
+    const inventory = await app.handle(new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases",
+    ));
+    expect(inventory.status).toBe(200);
+    expect(listReleases).toHaveBeenCalledWith("proj123", "dep123", { limit: 50 });
+
+    const upload = await app.handle(new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Length": String(testZipBytes.byteLength),
+          "x-supacloud-content-sha256": releaseId,
+        },
+        body: testZipBytes,
+      },
+    ));
+    expect(upload.status).toBe(201);
+    expect(createRelease).toHaveBeenCalledTimes(1);
+    expect(Buffer.concat(stream.written).equals(testZipBytes)).toBe(true);
+    expect(stream.prepare).toHaveBeenCalledWith("proj123", "dep123", testZipBytes.byteLength);
+    expect(createRelease.mock.calls[0]?.slice(0, 2)).toEqual(["proj123", "dep123"]);
+    expect(createRelease.mock.calls[0]?.[2]).toBe(stream.staged);
+    expect(stream.upload.finish).toHaveBeenCalledWith(releaseId);
+    expect(stream.upload.abort).toHaveBeenCalledTimes(1);
+  });
+
+  test("gets one release and rejects non-raw or unbounded immutable uploads", async () => {
+    const releaseId = "a".repeat(64);
+    const release = {
+      schema: "supacloud.frontend-release.v1" as const,
+      project_ref: "proj123",
+      deployment_id: "dep123",
+      release_id: releaseId,
+      sha256: releaseId,
+      tree_sha256: "b".repeat(64),
+      size_bytes: testZipBytes.byteLength,
+      file_count: 1,
+      created_at: "2026-08-12T00:00:00.000Z",
+      kind: "prebuilt_static" as const,
+    };
+    const getRelease = spyOn(frontendReleaseService, "release").mockResolvedValue(release);
+    const createRelease = spyOn(frontendReleaseService, "createRelease");
+    createRelease.mockClear();
+
+    const read = await app.handle(new Request(
+      `http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases/${releaseId}`,
+    ));
+    expect(read.status).toBe(200);
+    expect(await read.json()).toEqual({
+      project_ref: "proj123",
+      deployment_id: "dep123",
+      release,
+    });
+    expect(getRelease).toHaveBeenCalledWith("proj123", "dep123", releaseId);
+
+    for (const headers of [
+      { "Content-Type": "application/json", "Content-Length": "2" },
+      { "Content-Type": "application/zip" },
+    ]) {
+      const response = await app.handle(new Request(
+        "http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases",
+        { method: "POST", headers, body: new Uint8Array([1, 2]) },
+      ));
+      expect(response.status).toBe(headers["Content-Type"] === "application/json" ? 415 : 411);
+    }
+    expect(createRelease).not.toHaveBeenCalled();
+  });
+
+  test("rejects immutable upload before reading its body when storage mutations are unsupported", async () => {
+    const preflight = spyOn(frontendReleaseService, "prepareReleaseUpload").mockRejectedValue(
+      new (await import("../../src/services/frontend-release.service")).FrontendReleaseError(
+        "FRONTEND_RELEASE_STORAGE_PLATFORM_UNSUPPORTED",
+        503,
+        "Immutable frontend release storage requires Linux directory binding",
+      ),
+    );
+    const createRelease = spyOn(frontendReleaseService, "createRelease");
+    createRelease.mockClear();
+    let bodyReaderRequests = 0;
+    const request = new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Length": "64",
+          "x-supacloud-content-sha256": "a".repeat(64),
+        },
+        body: new Uint8Array(64),
+      },
+    );
+    const requestBody = request.body!;
+    const originalGetReader = requestBody.getReader.bind(requestBody);
+    requestBody.getReader = ((...args: Parameters<typeof requestBody.getReader>) => {
+      bodyReaderRequests += 1;
+      return originalGetReader(...args);
+    }) as typeof requestBody.getReader;
+
+    const response = await app.handle(request);
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      code: "FRONTEND_RELEASE_STORAGE_PLATFORM_UNSUPPORTED",
+      error: "Immutable frontend release storage requires Linux directory binding",
+    });
+    expect(preflight).toHaveBeenCalledWith("proj123", "dep123", 64);
+    expect(createRelease).not.toHaveBeenCalled();
+    expect(bodyReaderRequests).toBe(0);
+  });
+
+  test("bounds writes for a 100 MiB upload and always aborts the staging session", async () => {
+    const byteLength = 100 * 1024 * 1024;
+    const releaseId = "a".repeat(64);
+    const sourceChunk = new Uint8Array(1024 * 1024);
+    let sourceOffset = 0;
+    let maximumWrite = 0;
+    let totalWritten = 0;
+    const startingRss = process.memoryUsage.rss();
+    let peakRss = startingRss;
+    const staged = Object.freeze({ size_bytes: byteLength, sha256: releaseId });
+    const upload = {
+      write: mock(async (chunk: Uint8Array) => {
+        maximumWrite = Math.max(maximumWrite, chunk.byteLength);
+        totalWritten += chunk.byteLength;
+        peakRss = Math.max(peakRss, process.memoryUsage.rss());
+      }),
+      finish: mock(async () => staged),
+      abort: mock(async () => undefined),
+    };
+    spyOn(frontendReleaseService, "prepareReleaseUpload").mockResolvedValue(upload);
+    spyOn(frontendReleaseService, "createRelease").mockResolvedValue({
+      schema: "supacloud.frontend-release.v1",
+      project_ref: "proj123",
+      deployment_id: "dep123",
+      release_id: releaseId,
+      sha256: releaseId,
+      tree_sha256: releaseId,
+      size_bytes: byteLength,
+      file_count: 1,
+      created_at: "2026-08-12T00:00:00.000Z",
+      kind: "prebuilt_static",
+    });
+    const response = await app.handle(new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/zip",
+          "content-length": String(byteLength),
+          "x-supacloud-content-sha256": releaseId,
+        },
+        body: new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (sourceOffset === byteLength) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(sourceChunk);
+            sourceOffset += sourceChunk.byteLength;
+          },
+        }),
+      },
+    ));
+
+    expect(response.status).toBe(201);
+    expect(totalWritten).toBe(byteLength);
+    expect(maximumWrite).toBeLessThanOrEqual(64 * 1024);
+    expect(peakRss - startingRss).toBeLessThan(64 * 1024 * 1024);
+    expect(upload.abort).toHaveBeenCalledTimes(1);
+  });
+
+  for (const uploadCase of ["short", "long", "digest"] as const) {
+    test(`aborts staged uploads after ${uploadCase} validation failure`, async () => {
+      const createRelease = spyOn(frontendReleaseService, "createRelease");
+      createRelease.mockClear();
+      let written = 0;
+      const upload = {
+        write: mock(async (chunk: Uint8Array) => {
+          written += chunk.byteLength;
+          if (uploadCase === "long" && written > 2) {
+            throw new FrontendReleaseError(
+              "FRONTEND_RELEASE_CONTENT_LENGTH_MISMATCH",
+              400,
+              "length mismatch",
+            );
+          }
+        }),
+        finish: mock(async () => {
+          throw new FrontendReleaseError(
+            uploadCase === "digest" ? "FRONTEND_RELEASE_SHA_MISMATCH" : "FRONTEND_RELEASE_CONTENT_LENGTH_MISMATCH",
+            400,
+            "upload mismatch",
+          );
+        }),
+        abort: mock(async () => undefined),
+      };
+      spyOn(frontendReleaseService, "prepareReleaseUpload").mockResolvedValue(upload);
+      const body = uploadCase === "long" ? new Uint8Array([1, 2, 3]) : new Uint8Array([1]);
+      const response = await app.handle(new Request(
+        "http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/zip",
+            "content-length": "2",
+            "x-supacloud-content-sha256": "a".repeat(64),
+          },
+          body,
+        },
+      ));
+      expect(response.status).toBe(400);
+      expect(upload.abort).toHaveBeenCalledTimes(1);
+      expect(createRelease).not.toHaveBeenCalled();
+    });
+  }
+
+  test("aborts staging when the request body stream fails", async () => {
+    const upload = {
+      write: mock(async () => undefined),
+      finish: mock(async () => Object.freeze({ size_bytes: 2, sha256: "a".repeat(64) })),
+      abort: mock(async () => undefined),
+    };
+    spyOn(frontendReleaseService, "prepareReleaseUpload").mockResolvedValue(upload);
+    const response = await app.handle(new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/zip",
+          "content-length": "2",
+          "x-supacloud-content-sha256": "a".repeat(64),
+        },
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array([1]));
+            controller.error(new Error("body interrupted"));
+          },
+        }),
+      },
+    ));
+    expect(response.status).toBe(500);
+    expect(upload.finish).not.toHaveBeenCalled();
+    expect(upload.abort).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes exact activation CAS fields and verified principal to the release service", async () => {
+    const releaseId = "a".repeat(64);
+    const mutationId = "00000000-0000-4000-8000-000000000001";
+    const principal = { type: "project" as const, id: "project:proj123" };
+    const principalSpy = spyOn(authModule, "getVerifiedRequestPrincipal").mockResolvedValue(principal);
+    const activate = spyOn(frontendReleaseService, "activateRelease").mockResolvedValue({
+      project_ref: "proj123",
+      deployment_id: "dep123",
+      active_release_id: releaseId,
+      activation_id: mutationId,
+      release: {
+        schema: "supacloud.frontend-release.v1",
+        project_ref: "proj123",
+        deployment_id: "dep123",
+        release_id: releaseId,
+        sha256: releaseId,
+        tree_sha256: "b".repeat(64),
+        size_bytes: 1,
+        file_count: 1,
+        created_at: "2026-08-12T00:00:00.000Z",
+        kind: "prebuilt_static",
+      },
+      mutation: { mutation_id: mutationId, status: "succeeded", replayed: false },
+    });
+
+    const response = await app.handle(new Request(
+      `http://localhost/v1/projects/proj123/frontend/deployments/dep123/releases/${releaseId}/activate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          expected_active_release_id: "absent",
+          expected_activation_id: "absent",
+          mutation_id: mutationId,
+        }),
+      },
+    ));
+    expect(response.status).toBe(200);
+    expect(activate).toHaveBeenCalledWith({
+      projectRef: "proj123",
+      deploymentId: "dep123",
+      releaseId,
+      expectedActiveReleaseId: "absent",
+      expectedActivationId: "absent",
+      mutationId,
+      principal,
+    });
+    expect(JSON.stringify(await response.json())).not.toContain("authorization");
+    principalSpy.mockRestore();
+  });
+
+  test("returns an explicit conflict instead of deleting an active immutable deployment", async () => {
+    const deleteDeployment = spyOn(frontendService, "deleteDeployment").mockResolvedValue("active");
+    const response = await app.handle(new Request(
+      "http://localhost/v1/projects/proj123/frontend/deployments/dep123",
+      { method: "DELETE" },
+    ));
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      message: "Immutable frontend release is active",
+      code: "FRONTEND_RELEASE_ACTIVE",
+    });
+    expect(deleteDeployment).toHaveBeenCalledWith("proj123", "dep123");
   });
 });

--- a/packages/management-api/tests/unit/frontend.service.test.ts
+++ b/packages/management-api/tests/unit/frontend.service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { access, chmod, lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -11,6 +12,21 @@ import {
 import { FRAMEWORK_DEFAULTS, type FrontendDeployment } from "../../src/types/frontend";
 
 const originalFetch = globalThis.fetch;
+const withoutDeploymentLock = async <T>(
+  _projectRef: string,
+  _deploymentId: string,
+  operation: () => Promise<T>,
+): Promise<T> => operation();
+const noImmutableRelease = async () => ({
+  activeBuildDir: async () => null,
+  hasActiveRelease: async () => false,
+  hasUnresolvedActivation: async () => false,
+});
+
+function barrier(): { wait: Promise<void>; release: () => void } {
+  let release!: () => void;
+  return { wait: new Promise<void>((resolve) => { release = resolve; }), release };
+}
 
 beforeEach(() => {
   globalThis.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({ data: [] })))) as unknown as typeof fetch;
@@ -29,7 +45,7 @@ describe("FrontendService DNS records", () => {
     try {
       for (const configuredBaseDomain of ["xai.xigu.team", "api.xai.xigu.team"]) {
         config.baseDomain = configuredBaseDomain;
-        const service = new FrontendService(baseDir);
+        const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
         const deployment = await service.createDeployment("proj123", {
           name: "site",
           framework: "static",
@@ -46,7 +62,7 @@ describe("FrontendService DNS records", () => {
 
   test("returns managed temporary domain record and expected custom domain records", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-test-"));
-    const service = new FrontendService(baseDir);
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
 
     try {
       const deployment = await service.createDeployment("proj123", {
@@ -90,7 +106,7 @@ describe("FrontendService DNS records", () => {
 
     try {
       config.baseDomain = "api.xai.xigu.team";
-      const service = new FrontendService(baseDir);
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
       const deployment = await service.createDeployment("proj123", {
         name: "site",
         framework: "static",
@@ -111,7 +127,7 @@ describe("FrontendService DNS records", () => {
 
   test("returns null when deployment does not exist", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-test-"));
-    const service = new FrontendService(baseDir);
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
 
     try {
       await expect(service.listDnsRecords("proj123", "missing123")).resolves.toBeNull();
@@ -124,7 +140,7 @@ describe("FrontendService DNS records", () => {
 describe("FrontendService SvelteKit defaults", () => {
   test("uses an adapter-node output and a root readiness probe", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-sveltekit-defaults-"));
-    const service = new FrontendService(baseDir);
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
 
     try {
       const deployment = await service.createDeployment("proj123", {
@@ -141,7 +157,7 @@ describe("FrontendService SvelteKit defaults", () => {
 
   test("keeps existing build settings when only readiness is updated", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-sveltekit-update-"));
-    const service = new FrontendService(baseDir);
+      const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
 
     try {
       const deployment = await service.createDeployment("proj123", {
@@ -168,7 +184,7 @@ describe("FrontendService SvelteKit defaults", () => {
 
   test("provides a distinct adapter-static SvelteKit profile", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-sveltekit-static-"));
-    const service = new FrontendService(baseDir);
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
 
     try {
       const deployment = await service.createDeployment("proj123", {
@@ -269,7 +285,11 @@ describe("FrontendService gateway routing", () => {
       return Promise.resolve(new Response(JSON.stringify({ data: [] })));
     }) as unknown as typeof fetch;
 
-    const service = new FrontendService("/tmp/supacloud-frontend-test");
+    const service = new FrontendService(
+      "/tmp/supacloud-frontend-test",
+      withoutDeploymentLock,
+      noImmutableRelease,
+    );
     const deployment: FrontendDeployment = {
       id: "0000002a",
       project_ref: "proj123",
@@ -288,6 +308,11 @@ describe("FrontendService gateway routing", () => {
       deployment_url: "https://site.example.com",
     };
 
+    await mkdir(join("/tmp/supacloud-frontend-test", "proj123", deployment.id), { recursive: true });
+    await writeFile(
+      join("/tmp/supacloud-frontend-test", "proj123", deployment.id, "deployment.json"),
+      JSON.stringify(deployment),
+    );
     await service.configureGatewayRoute(deployment, "/tmp/build", false);
 
     const loadCall = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
@@ -350,7 +375,7 @@ describe("FrontendService gateway routing", () => {
         deployment_url: "https://site.example.com",
       }));
 
-      const service = new FrontendService(baseDir);
+      const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
       const result = await service.reconcileGatewayRoutes();
 
       expect(result).toEqual({ total: 1, configured: 1, skipped: 0, errors: [] });
@@ -369,12 +394,328 @@ describe("FrontendService gateway routing", () => {
       await rm(baseDir, { recursive: true, force: true });
     }
   });
+
+  test("re-reads deployment hosts inside the route lock", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-stale-hosts-"));
+    const gatewayCalls: Array<{ method: string; body: any }> = [];
+    globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+      const method = init?.method || "GET";
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+      gatewayCalls.push({ method, body });
+      return Promise.resolve(new Response(JSON.stringify({ data: [] })));
+    }) as unknown as typeof fetch;
+
+    try {
+      const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+      const stale = await service.createDeployment("proj123", { name: "site", framework: "static" });
+      await writeFile(
+        join(baseDir, "proj123", stale.id, "deployment.json"),
+        JSON.stringify({ ...stale, domain: "current.example.com", custom_domains: ["www.current.example.com"] }),
+      );
+
+      await service.configureGatewayRoute(stale, join(baseDir, "build"), false);
+
+      const routes = gatewayCalls.filter((call) => call.method === "POST").at(-1)
+        ?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+      const route = routes.find((candidate: any) => candidate["@id"] === `route-frontend-proj123-${stale.id}`);
+      expect(route?.match?.[0]?.host).toEqual(["current.example.com", "www.current.example.com"]);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("FrontendService deployment serialization", () => {
+  test("keeps the complete legacy SSR deployment inside the deployment lock", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-ssr-lock-"));
+    const sourceDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-ssr-source-"));
+    const firstEntered = barrier();
+    const releaseFirst = barrier();
+    const operationContext = new AsyncLocalStorage<boolean>();
+    let tail = Promise.resolve();
+    let secondEntered = false;
+    const serializedLock = async <T>(
+      _projectRef: string,
+      _deploymentId: string,
+      operation: () => Promise<T>,
+    ): Promise<T> => {
+      if (operationContext.getStore()) return operation();
+      const previous = tail;
+      let release!: () => void;
+      tail = new Promise<void>((resolve) => { release = resolve; });
+      await previous;
+      try {
+        return await operationContext.run(true, operation);
+      } finally {
+        release();
+      }
+    };
+
+    try {
+      const setup = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+      const deployment = await setup.createDeployment("proj123", {
+        name: "ssr-site",
+        framework: "nextjs",
+        install_command: "",
+        build_command: "",
+      });
+      // createDeployment applies framework defaults for empty commands; this
+      // test exercises the full deployment flow, so store explicit empty commands.
+      await writeFile(
+        join(baseDir, "proj123", deployment.id, "deployment.json"),
+        JSON.stringify({ ...deployment, install_command: "", build_command: "" }, null, 2),
+      );
+      await mkdir(join(sourceDir, ".next"));
+      await writeFile(join(sourceDir, ".next", "index.js"), "console.log('ready')\n");
+      const service = new FrontendService(baseDir, serializedLock, noImmutableRelease);
+      // Barrier in the build phase: only the outer deployFromSource lock keeps
+      // the second operation out here; publish-time locks are re-entrant.
+      const prepareOriginal = (service as any).prepareLegacySsrBuild.bind(service);
+      (service as any).prepareLegacySsrBuild = async (...args: any[]) => {
+        firstEntered.release();
+        await releaseFirst.wait;
+        return prepareOriginal(...args);
+      };
+      (service as any).startProcess = async () => 30001;
+      (service as any).waitForReadiness = async () => true;
+      (service as any).applyGatewayRoute = async () => undefined;
+      (service as any).stopProcess = async () => undefined;
+      (service as any).removeGatewayRoute = async () => undefined;
+      const first = service.deployFromSource("proj123", deployment.id, sourceDir);
+      await firstEntered.wait;
+      let secondStarted = false;
+      const second = Promise.resolve().then(async () => {
+        secondStarted = true;
+        return service.deleteDeployment("proj123", deployment.id);
+      }).then((outcome) => {
+        secondEntered = true;
+        return outcome;
+      });
+      while (!secondStarted) await Promise.resolve();
+      expect(secondEntered).toBe(false);
+      releaseFirst.release();
+      expect((await first).success).toBe(true);
+      expect(await second).toBe("deleted");
+      expect(secondEntered).toBe(true);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+      await rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the complete legacy static deployment inside the deployment lock", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-static-lock-"));
+    const sourceDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-static-source-"));
+    const firstEntered = barrier();
+    const releaseFirst = barrier();
+    const operationContext = new AsyncLocalStorage<boolean>();
+    let tail = Promise.resolve();
+    let secondEntered = false;
+    const serializedLock = async <T>(
+      _projectRef: string,
+      _deploymentId: string,
+      operation: () => Promise<T>,
+    ): Promise<T> => {
+      if (operationContext.getStore()) return operation();
+      const previous = tail;
+      let release!: () => void;
+      tail = new Promise<void>((resolve) => { release = resolve; });
+      await previous;
+      try {
+        return await operationContext.run(true, operation);
+      } finally {
+        release();
+      }
+    };
+
+    try {
+      const setup = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+      const deployment = await setup.createDeployment("proj123", {
+        name: "static-site",
+        framework: "static",
+        install_command: "",
+        build_command: "",
+      });
+      await writeFile(join(sourceDir, "index.html"), "<!doctype html>");
+      const service = new FrontendService(baseDir, serializedLock, noImmutableRelease);
+      // Barrier in the build phase: only the outer deployFromSource lock keeps
+      // the second operation out here; publish-time locks are re-entrant.
+      const prepareOriginal = (service as any).prepareLegacyBuild.bind(service);
+      (service as any).prepareLegacyBuild = async (...args: any[]) => {
+        firstEntered.release();
+        await releaseFirst.wait;
+        return prepareOriginal(...args);
+      };
+      (service as any).applyGatewayRoute = async () => undefined;
+      (service as any).stopProcess = async () => undefined;
+      (service as any).removeGatewayRoute = async () => undefined;
+      const first = service.deployFromSource("proj123", deployment.id, sourceDir);
+      await firstEntered.wait;
+      let secondStarted = false;
+      const second = Promise.resolve().then(async () => {
+        secondStarted = true;
+        return service.deleteDeployment("proj123", deployment.id);
+      }).then((outcome) => {
+        secondEntered = true;
+        return outcome;
+      });
+      while (!secondStarted) await Promise.resolve();
+      expect(secondEntered).toBe(false);
+      releaseFirst.release();
+      expect((await first).success).toBe(true);
+      expect(await second).toBe("deleted");
+      expect(secondEntered).toBe(true);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+      await rm(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("holds the deployment lock for every metadata read-modify-write", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-rmw-lock-"));
+    const lockCalls: string[] = [];
+    const trackedLock = async <T>(projectRef: string, deploymentId: string, operation: () => Promise<T>) => {
+      lockCalls.push(`${projectRef}/${deploymentId}`);
+      return operation();
+    };
+    const service = new FrontendService(baseDir, trackedLock, noImmutableRelease);
+
+    try {
+      const deployment = await service.createDeployment("proj123", { name: "site", framework: "static" });
+      await service.updateDeployment("proj123", deployment.id, { name: "renamed" });
+      await service.setEnvVars("proj123", deployment.id, { FEATURE_FLAG: "enabled" });
+      const deployToken = await service.createDeployToken("proj123", deployment.id, "ci");
+      expect(deployToken).not.toBeNull();
+      expect(await service.verifyDeployToken("proj123", deployment.id, deployToken!.token)).toBe(true);
+      await service.setGitConfig("proj123", deployment.id, "https://git.example.com/org/repo.git", "main");
+      expect(await service.deleteDeployToken("proj123", deployment.id, deployToken!.id)).toBe(true);
+
+      expect(lockCalls).toEqual(Array(6).fill(`proj123/${deployment.id}`));
+      expect(await service.getDeployment("proj123", deployment.id)).toMatchObject({
+        name: "renamed",
+        env_vars: { FEATURE_FLAG: "enabled" },
+        git_url: "https://git.example.com/org/repo.git",
+        git_branch: "main",
+        deploy_tokens: [],
+      });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves concurrent env and git metadata updates", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-rmw-race-"));
+    let tail = Promise.resolve();
+    const serializedLock = async <T>(
+      _projectRef: string,
+      _deploymentId: string,
+      operation: () => Promise<T>,
+    ): Promise<T> => {
+      const previous = tail;
+      let release!: () => void;
+      tail = new Promise<void>((resolve) => { release = resolve; });
+      await previous;
+      try {
+        return await operation();
+      } finally {
+        release();
+      }
+    };
+    const service = new FrontendService(baseDir, serializedLock, noImmutableRelease);
+
+    try {
+      const deployment = await service.createDeployment("proj123", { name: "site", framework: "static" });
+      await Promise.all([
+        service.setEnvVars("proj123", deployment.id, { FEATURE_FLAG: "enabled" }),
+        service.setGitConfig("proj123", deployment.id, "https://git.example.com/org/repo.git", "stable"),
+      ]);
+
+      expect(await service.getDeployment("proj123", deployment.id)).toMatchObject({
+        env_vars: { FEATURE_FLAG: "enabled" },
+        git_url: "https://git.example.com/org/repo.git",
+        git_branch: "stable",
+      });
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects immutable domain mutations before changing metadata or gateway state", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-domain-block-"));
+    const gatewayRequest = mock(() => Promise.resolve(new Response(JSON.stringify({ data: [] }))));
+    globalThis.fetch = gatewayRequest as unknown as typeof fetch;
+    const activeRelease = async () => ({
+      activeBuildDir: async () => join(baseDir, "immutable"),
+      hasActiveRelease: async () => true,
+      hasUnresolvedActivation: async () => false,
+    });
+
+    try {
+      const setup = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+      const deployment = await setup.createDeployment("proj123", { name: "site", framework: "static" });
+      const service = new FrontendService(baseDir, withoutDeploymentLock, activeRelease);
+
+      await expect(service.addCustomDomain("proj123", deployment.id, "blocked.example.com"))
+        .rejects.toMatchObject({ code: "FRONTEND_RELEASE_ACTIVE", statusCode: 409 });
+      expect((await service.getDeployment("proj123", deployment.id))?.custom_domains).toEqual([]);
+      expect(gatewayRequest).not.toHaveBeenCalled();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not commit custom-domain metadata when gateway publication fails", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-domain-gateway-failure-"));
+    globalThis.fetch = mock(() => Promise.resolve(
+      new Response("gateway rejected", { status: 500 }),
+    )) as unknown as typeof fetch;
+
+    try {
+      const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
+      const deployment = await service.createDeployment("proj123", { name: "site", framework: "static" });
+
+      await expect(service.addCustomDomain("proj123", deployment.id, "uncommitted.example.com"))
+        .rejects.toThrow();
+      expect((await service.getDeployment("proj123", deployment.id))?.custom_domains).toEqual([]);
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  test("checks immutable authority again before publishing a prepared static build", async () => {
+    const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-static-cas-"));
+    const sourceDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-static-source-"));
+    let activeChecks = 0;
+    const changingReleaseState = async () => ({
+      activeBuildDir: async () => null,
+      hasActiveRelease: async () => ++activeChecks > 1,
+      hasUnresolvedActivation: async () => false,
+    });
+    const gatewayRequest = mock(() => Promise.resolve(new Response(JSON.stringify({ data: [] }))));
+    globalThis.fetch = gatewayRequest as unknown as typeof fetch;
+
+    try {
+      const service = new FrontendService(baseDir, withoutDeploymentLock, changingReleaseState);
+      const deployment = await service.createDeployment("proj123", { name: "site", framework: "static" });
+      await writeFile(join(sourceDir, "index.html"), "prepared but not published");
+
+      const result = await service.deployFromSource("proj123", deployment.id, sourceDir);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("active or unresolved");
+      await expect(access(join(baseDir, "proj123", deployment.id, "build", "index.html"))).rejects.toThrow();
+      expect(gatewayRequest).not.toHaveBeenCalled();
+    } finally {
+      await rm(baseDir, { recursive: true, force: true });
+      await rm(sourceDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("FrontendService optimizer", () => {
   test("generates br and gzip sidecars for static text assets", async () => {
     const baseDir = await mkdtemp(join(tmpdir(), "supacloud-frontend-optimizer-test-"));
-    const service = new FrontendService(baseDir);
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
     const assetPath = join(baseDir, "app.js");
 
     try {
@@ -396,7 +737,7 @@ describe("FrontendService optimizer", () => {
     const binDir = join(baseDir, "bin");
     const imagePath = join(baseDir, "hero.jpg");
     const originalPath = process.env.PATH || "";
-    const service = new FrontendService(baseDir);
+    const service = new FrontendService(baseDir, withoutDeploymentLock, noImmutableRelease);
 
     try {
       await mkdir(binDir);

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -9,10 +9,12 @@ import {
     buildTenantCorsOrigins,
     caddySensitiveRequestLogEncoder,
     gatewayService,
+    reconcileCanonicalGatewayRoutes,
 } from "../../src/services/gateway.service";
 
 function captureFetch(calls: Array<{ url: string; method: string; body: any }>) {
     const originalFetch = globalThis.fetch;
+    let loadedConfig: any = null;
     globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
         const method = init?.method || "GET";
@@ -21,6 +23,13 @@ function captureFetch(calls: Array<{ url: string; method: string; body: any }>) 
             try { body = JSON.parse(init.body); } catch { body = init.body; }
         }
         calls.push({ url, method, body });
+        if (method === "POST" && url.endsWith("/load")) loadedConfig = body;
+        if (method === "GET" && url.endsWith("/config/")) {
+            return Promise.resolve(Response.json(loadedConfig ?? {}));
+        }
+        if (method === "GET" && url.endsWith("/config/apps/http/servers/supacloud/routes")) {
+            return Promise.resolve(Response.json(loadedConfig?.apps?.http?.servers?.supacloud?.routes ?? []));
+        }
         return Promise.resolve(new Response(JSON.stringify({ id: "cert_123", data: [] })));
     }) as unknown as typeof fetch;
     return () => { globalThis.fetch = originalFetch; };
@@ -611,6 +620,82 @@ describe("CaddyGatewayProvider", () => {
         restore();
     });
 
+    test("reads back the one canonical static root for an immutable frontend route", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        try {
+            const provider = new CaddyGatewayProvider();
+            await provider.configureFrontendRoute({
+                projectRef: "proj123",
+                deploymentId: "fa-web",
+                hosts: ["fa.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/a/build",
+                mode: "static",
+            });
+
+            await expect(provider.readFrontendStaticRoot("proj123", "fa-web")).resolves.toBe(
+                "/var/supacloud/frontends/proj123/fa-web/releases/a/build",
+            );
+            await expect(provider.readFrontendStaticRoot("proj123", "missing")).resolves.toBeNull();
+        } finally {
+            restore();
+        }
+    });
+
+    test("restores the in-memory frontend and CORS candidates when Caddy rejects load", async () => {
+        const originalFetch = globalThis.fetch;
+        let loadedConfig: any = null;
+        let rejectNextLoad = false;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            const method = init?.method || "GET";
+            if (method === "POST" && url.endsWith("/load")) {
+                if (rejectNextLoad) {
+                    rejectNextLoad = false;
+                    return Promise.resolve(new Response("rejected", { status: 400 }));
+                }
+                loadedConfig = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+            }
+            if (method === "GET" && url.endsWith("/config/apps/http/servers/supacloud/routes")) {
+                return Promise.resolve(Response.json(loadedConfig?.apps?.http?.servers?.supacloud?.routes ?? []));
+            }
+            return Promise.resolve(Response.json({ ok: true }));
+        }) as unknown as typeof fetch;
+        try {
+            const provider = new CaddyGatewayProvider();
+            const oldRoot = "/var/supacloud/frontends/proj123/fa-web/releases/old/build";
+            await provider.configureFrontendRoute({
+                projectRef: "proj123",
+                deploymentId: "fa-web",
+                hosts: ["old.example.com"],
+                root: oldRoot,
+                mode: "static",
+            });
+            rejectNextLoad = true;
+            await expect(provider.configureFrontendRoute({
+                projectRef: "proj123",
+                deploymentId: "fa-web",
+                hosts: ["new.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/new/build",
+                mode: "static",
+            })).rejects.toThrow("Caddy /load failed");
+            await expect(provider.readFrontendStaticRoot("proj123", "fa-web")).resolves.toBe(oldRoot);
+
+            await provider.configureFrontendRoute({
+                projectRef: "proj123",
+                deploymentId: "other-web",
+                hosts: ["other.example.com"],
+                root: "/var/supacloud/frontends/proj123/other-web/releases/ok/build",
+                mode: "static",
+            });
+            const routes = loadedConfig?.apps?.http?.servers?.supacloud?.routes ?? [];
+            const restored = routes.find((route: any) => route["@id"] === "route-frontend-proj123-fa-web");
+            expect(restored?.match?.[0]?.host).toEqual(["old.example.com"]);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
     test("serializes Caddy load publishes so concurrent frontend routes cannot finish with stale config", async () => {
         const originalFetch = globalThis.fetch;
         const appliedLoads: any[] = [];
@@ -676,6 +761,438 @@ describe("CaddyGatewayProvider", () => {
             const finalRouteIds = (appliedLoads.at(-1)?.apps?.http?.servers?.supacloud?.routes ?? []).map((route: any) => route["@id"]);
             expect(finalRouteIds).toContain("route-frontend-proj123-admin0001");
             expect(finalRouteIds).toContain("route-frontend-proj123-mobile001");
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("does not let a failed frontend route rollback erase a concurrent successful route", async () => {
+        const originalFetch = globalThis.fetch;
+        let releaseFirstLoad: (() => void) | null = null;
+        let firstLoadStarted!: () => void;
+        const firstLoad = new Promise<void>((resolve) => { firstLoadStarted = resolve; });
+        const appliedLoads: any[] = [];
+        let loadCount = 0;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if ((init?.method || "GET") === "POST" && url.endsWith("/load")) {
+                const body = JSON.parse(String(init?.body));
+                loadCount += 1;
+                if (loadCount === 1) {
+                    firstLoadStarted();
+                    return new Promise<Response>((resolve) => {
+                        releaseFirstLoad = () => resolve(new Response("failure", { status: 500 }));
+                    });
+                }
+                appliedLoads.push(body);
+            }
+            return Promise.resolve(Response.json([]));
+        }) as unknown as typeof fetch;
+
+        try {
+            const provider = new CaddyGatewayProvider();
+            const failed = provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "failed001", hosts: ["failed.example.com"],
+                root: "/var/supacloud/frontends/proj123/failed001/build", mode: "static",
+            });
+            await firstLoad;
+            const succeeded = provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "good0001", hosts: ["good.example.com"],
+                root: "/var/supacloud/frontends/proj123/good0001/build", mode: "static",
+            });
+            await Promise.race([succeeded, Bun.sleep(20)]);
+            expect(appliedLoads).toHaveLength(0);
+            releaseFirstLoad?.();
+            await expect(failed).rejects.toThrow("Caddy /load failed with 500");
+            await succeeded;
+            const routeIds = appliedLoads.at(-1)?.apps?.http?.servers?.supacloud?.routes
+                ?.map((route: any) => route["@id"]);
+            expect(routeIds).toContain("route-frontend-proj123-good0001");
+            expect(routeIds).not.toContain("route-frontend-proj123-failed001");
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("retains an unrelated writer queued behind a failed frontend publish", async () => {
+        const originalFetch = globalThis.fetch;
+        let releaseFailedLoad!: () => void;
+        let markFailedLoadStarted!: () => void;
+        const failedLoadStarted = new Promise<void>((resolve) => { markFailedLoadStarted = resolve; });
+        const appliedLoads: any[] = [];
+        let loadCount = 0;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if ((init?.method || "GET") === "POST" && url.endsWith("/load")) {
+                const body = JSON.parse(String(init?.body));
+                loadCount += 1;
+                if (loadCount === 1) {
+                    markFailedLoadStarted();
+                    return new Promise<Response>((resolve) => {
+                        releaseFailedLoad = () => resolve(new Response("failure", { status: 500 }));
+                    });
+                }
+                appliedLoads.push(body);
+            }
+            return Promise.resolve(Response.json([]));
+        }) as unknown as typeof fetch;
+
+        try {
+            const provider = new CaddyGatewayProvider();
+            const failed = provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "failed001", hosts: ["failed.example.com"],
+                root: "/var/supacloud/frontends/proj123/failed001/build", mode: "static",
+            });
+            await failedLoadStarted;
+            const unrelated = provider.configureStudioDomain("studio.example.com", 9090);
+            await Promise.race([unrelated, Bun.sleep(20)]);
+            expect(appliedLoads).toHaveLength(0);
+            releaseFailedLoad();
+            await expect(failed).rejects.toThrow("Caddy /load failed with 500");
+            await unrelated;
+
+            const routeIds = appliedLoads.at(-1)?.apps?.http?.servers?.supacloud?.routes
+                ?.map((route: any) => route["@id"]);
+            expect(routeIds).toContain("route-frontend-_global-studio");
+            expect(routeIds).not.toContain("route-frontend-proj123-failed001");
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("removeFrontendRoute completes without nesting the operation lock", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        try {
+            const provider = new CaddyGatewayProvider();
+            await provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "remove001", hosts: ["remove.example.com"],
+                root: "/var/supacloud/frontends/proj123/remove001/build", mode: "static",
+            });
+
+            const removed = provider.removeFrontendRoute("proj123", "remove001");
+            await expect(Promise.race([
+                removed.then(() => "removed"),
+                Bun.sleep(500).then(() => "timeout"),
+            ])).resolves.toBe("removed");
+
+            const routes = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load"))
+                .at(-1)?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+            expect(routes.some((route: any) => route["@id"] === "route-frontend-proj123-remove001")).toBe(false);
+        } finally {
+            restore();
+        }
+    });
+
+    test("withDeferredPersist can call public writers reentrantly and publishes once", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        try {
+            const provider = new CaddyGatewayProvider();
+            await expect(provider.withDeferredPersist(async () => {
+                await provider.setupMasterRoutes();
+                await provider.configureStudioDomain("studio.example.com", 9090);
+                return "ok";
+            })).resolves.toBe("ok");
+
+            const loads = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load"));
+            expect(loads).toHaveLength(1);
+            const routeIds = loads[0]?.body?.apps?.http?.servers?.supacloud?.routes
+                ?.map((route: any) => route["@id"]);
+            expect(routeIds).toContain("route-system-management-api");
+            expect(routeIds).toContain("route-frontend-_global-studio");
+        } finally {
+            restore();
+        }
+    });
+
+    test("drops rejected deferred mutations before an unrelated writer publishes", async () => {
+        for (const rejectedBatch of [
+            (provider: CaddyGatewayProvider) => provider.withDeferredPersist(async () => {
+                await provider.setupMasterRoutes();
+                throw new Error("batch rejected");
+            }),
+            (provider: CaddyGatewayProvider) => provider.withDeferredPersist(async () => {
+                await provider.setupMasterRoutes();
+                return { accepted: false };
+            }, ({ accepted }) => accepted),
+        ]) {
+            const calls: Array<{ url: string; method: string; body: any }> = [];
+            const restore = captureFetch(calls);
+            try {
+                const provider = new CaddyGatewayProvider();
+                await rejectedBatch(provider).catch(() => undefined);
+                await provider.configureStudioDomain("studio.example.com", 9090);
+                const routes = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load"))
+                    .at(-1)?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+                expect(routes.some((route: any) => route["@id"] === "route-system-management-api")).toBe(false);
+            } finally {
+                restore();
+            }
+        }
+    });
+
+    test("restores a failed deferred flush before an unrelated writer publishes", async () => {
+        const originalFetch = globalThis.fetch;
+        const appliedLoads: any[] = [];
+        let loadCount = 0;
+        globalThis.fetch = mock((_input: string | URL | Request, init?: RequestInit) => {
+            if ((init?.method || "GET") === "POST") {
+                loadCount += 1;
+                if (loadCount === 1) return Promise.resolve(new Response("rejected", { status: 400 }));
+                appliedLoads.push(JSON.parse(String(init?.body)));
+            }
+            return Promise.resolve(Response.json({}));
+        }) as unknown as typeof fetch;
+        try {
+            const provider = new CaddyGatewayProvider();
+            await expect(provider.withDeferredPersist(async () => {
+                await provider.setupMasterRoutes();
+            })).rejects.toThrow("Caddy /load failed with 400");
+            await provider.configureStudioDomain("studio.example.com", 9090);
+            const routes = appliedLoads.at(-1)?.apps?.http?.servers?.supacloud?.routes ?? [];
+            expect(routes.some((route: any) => route["@id"] === "route-system-management-api")).toBe(false);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("keeps accepted outer deferred mutations while discarding a rejected inner scope", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        try {
+            const provider = new CaddyGatewayProvider();
+            await provider.withDeferredPersist(async () => {
+                await provider.configureStudioDomain("studio.example.com", 9090);
+                await provider.withDeferredPersist(async () => {
+                    await provider.setupMasterRoutes();
+                    return false;
+                }, Boolean);
+            });
+            const routes = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load"))
+                .at(-1)?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+            expect(routes.some((route: any) => route["@id"] === "route-frontend-_global-studio")).toBe(true);
+            expect(routes.some((route: any) => route["@id"] === "route-system-management-api")).toBe(false);
+        } finally {
+            restore();
+        }
+    });
+
+    test("repairs a live candidate after the load response is lost", async () => {
+        const originalFetch = globalThis.fetch;
+        let liveConfig: any = null;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.endsWith("/load") && init?.method === "POST") {
+                liveConfig = JSON.parse(String(init.body));
+                return Promise.reject(new Error("response lost"));
+            }
+            if (url.endsWith("/config/")) return Promise.resolve(Response.json(liveConfig));
+            return Promise.resolve(Response.json([]));
+        }) as unknown as typeof fetch;
+        try {
+            const provider = new CaddyGatewayProvider();
+            await provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "fa-web", hosts: ["fa.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/a/build", mode: "static",
+            });
+            expect(JSON.parse(await readFile(config.caddyConfigPath, "utf8")))
+                .toEqual(liveConfig);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("quarantines a live but non-durable candidate from unrelated writers", async () => {
+        const originalFetch = globalThis.fetch;
+        let liveConfig: any = null;
+        let loadCount = 0;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.endsWith("/load") && init?.method === "POST") {
+                loadCount += 1;
+                liveConfig = JSON.parse(String(init.body));
+            }
+            if (url.endsWith("/config/")) return Promise.resolve(Response.json(liveConfig));
+            return Promise.resolve(Response.json([]));
+        }) as unknown as typeof fetch;
+        try {
+            const provider = new CaddyGatewayProvider({
+                persistLoadedCandidate: async () => { throw new Error("rename failed"); },
+            });
+            await expect(provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "fa-web", hosts: ["fa.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/a/build", mode: "static",
+            })).rejects.toMatchObject({ code: "CADDY_GATEWAY_DURABILITY_UNKNOWN" });
+            await expect(provider.configureStudioDomain("studio.example.com", 9090))
+                .rejects.toMatchObject({ code: "CADDY_GATEWAY_DURABILITY_UNKNOWN" });
+            expect(loadCount).toBe(1);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("drops an unproven candidate once live readback is different before an unrelated writer", async () => {
+        const originalFetch = globalThis.fetch;
+        const submittedLoads: any[] = [];
+        let liveConfig: any = null;
+        let loseNextLoadResponse = false;
+        let loseNextReadback = false;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.endsWith("/load") && init?.method === "POST") {
+                const candidate = JSON.parse(String(init.body));
+                submittedLoads.push(candidate);
+                if (loseNextLoadResponse) {
+                    loseNextLoadResponse = false;
+                    return Promise.reject(new Error("response lost"));
+                }
+                liveConfig = candidate;
+            }
+            if (url.endsWith("/config/")) {
+                if (loseNextReadback) {
+                    loseNextReadback = false;
+                    return Promise.reject(new Error("readback lost"));
+                }
+                return Promise.resolve(Response.json(liveConfig));
+            }
+            return Promise.resolve(Response.json([]));
+        }) as unknown as typeof fetch;
+        try {
+            const baselineProvider = new CaddyGatewayProvider();
+            await baselineProvider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "fa-web", hosts: ["old.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/old/build", mode: "static",
+            });
+
+            const provider = new CaddyGatewayProvider();
+            loseNextLoadResponse = true;
+            loseNextReadback = true;
+            await expect(provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "fa-web", hosts: ["failed.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/failed/build", mode: "static",
+            })).rejects.toMatchObject({ code: "CADDY_GATEWAY_DURABILITY_UNKNOWN" });
+
+            await provider.configureStudioDomain("studio.example.com", 9090);
+
+            const finalRoutes = liveConfig?.apps?.http?.servers?.supacloud?.routes ?? [];
+            const restoredRoute = finalRoutes.find((route: any) => route["@id"] === "route-frontend-proj123-fa-web");
+            const restoredRouteJson = JSON.stringify(restoredRoute);
+            expect(finalRoutes.some((route: any) => route["@id"] === "route-frontend-_global-studio")).toBe(true);
+            expect(restoredRoute?.match?.[0]?.host).toEqual(["old.example.com"]);
+            expect(restoredRouteJson).toContain("/var/supacloud/frontends/proj123/fa-web/releases/old/build");
+            expect(restoredRouteJson).not.toContain("/var/supacloud/frontends/proj123/fa-web/releases/failed/build");
+            expect(submittedLoads).toHaveLength(3);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("repairs every durability stage without rolling back a live candidate", async () => {
+        const durabilityStages = [
+            "candidate_sync",
+            "candidate_rename",
+            "config_directory_sync",
+            "notice_open",
+            "notice_write",
+            "notice_sync",
+            "notice_directory_sync",
+        ] as const;
+
+        for (const failedStage of durabilityStages) {
+            const originalFetch = globalThis.fetch;
+            let liveConfig: any = null;
+            const appliedLoads: any[] = [];
+            let injected = false;
+            globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+                const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+                if (url.endsWith("/load") && init?.method === "POST") {
+                    liveConfig = JSON.parse(String(init.body));
+                    appliedLoads.push(liveConfig);
+                }
+                if (url.endsWith("/config/")) return Promise.resolve(Response.json(liveConfig));
+                return Promise.resolve(Response.json([]));
+            }) as unknown as typeof fetch;
+            try {
+                const provider = new CaddyGatewayProvider({
+                    beforeDurabilityStage: async (stage) => {
+                        if (stage === failedStage && !injected) {
+                            injected = true;
+                            throw new Error(`${stage} failed`);
+                        }
+                    },
+                });
+                await expect(provider.configureFrontendRoute({
+                    projectRef: "proj123", deploymentId: "applied-web", hosts: ["applied.example.com"],
+                    root: "/var/supacloud/frontends/proj123/applied-web/releases/a/build", mode: "static",
+                })).rejects.toMatchObject({ code: "CADDY_GATEWAY_DURABILITY_UNKNOWN" });
+
+                await provider.configureStudioDomain("studio.example.com", 9090);
+
+                const finalRoutes = liveConfig?.apps?.http?.servers?.supacloud?.routes ?? [];
+                expect(injected).toBe(true);
+                expect(appliedLoads).toHaveLength(2);
+                expect(finalRoutes.some((route: any) => route["@id"] === "route-frontend-proj123-applied-web")).toBe(true);
+                expect(finalRoutes.some((route: any) => route["@id"] === "route-frontend-_global-studio")).toBe(true);
+                expect(JSON.parse(await readFile(config.caddyConfigPath, "utf8"))).toEqual(liveConfig);
+            } finally {
+                globalThis.fetch = originalFetch;
+                await cleanCaddyTmp();
+            }
+        }
+    });
+
+    test("rolls back when a lost load response proves a different live config", async () => {
+        const originalFetch = globalThis.fetch;
+        let lostResponse = true;
+        let appliedConfig: any = null;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.endsWith("/load") && init?.method === "POST") {
+                if (lostResponse) {
+                    lostResponse = false;
+                    return Promise.reject(new Error("response lost"));
+                }
+                appliedConfig = JSON.parse(String(init.body));
+            }
+            if (url.endsWith("/config/")) return Promise.resolve(Response.json({ apps: {} }));
+            return Promise.resolve(Response.json([]));
+        }) as unknown as typeof fetch;
+        try {
+            const provider = new CaddyGatewayProvider();
+            await expect(provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "fa-web", hosts: ["fa.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/a/build", mode: "static",
+            })).rejects.toThrow("response lost");
+            await provider.configureStudioDomain("studio.example.com", 9090);
+            const routes = appliedConfig?.apps?.http?.servers?.supacloud?.routes ?? [];
+            expect(routes.some((route: any) => route["@id"] === "route-frontend-proj123-fa-web")).toBe(false);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
+
+    test("quarantines a lost load response when live state cannot be read", async () => {
+        const originalFetch = globalThis.fetch;
+        let loadCount = 0;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.endsWith("/load") && init?.method === "POST") {
+                loadCount += 1;
+                return Promise.reject(new Error("response lost"));
+            }
+            if (url.endsWith("/config/")) return Promise.reject(new Error("readback lost"));
+            return Promise.resolve(Response.json([]));
+        }) as unknown as typeof fetch;
+        try {
+            const provider = new CaddyGatewayProvider();
+            await expect(provider.configureFrontendRoute({
+                projectRef: "proj123", deploymentId: "fa-web", hosts: ["fa.example.com"],
+                root: "/var/supacloud/frontends/proj123/fa-web/releases/a/build", mode: "static",
+            })).rejects.toMatchObject({ code: "CADDY_GATEWAY_DURABILITY_UNKNOWN" });
+            await expect(provider.configureStudioDomain("studio.example.com", 9090))
+                .rejects.toMatchObject({ code: "CADDY_GATEWAY_DURABILITY_UNKNOWN" });
+            expect(loadCount).toBe(1);
         } finally {
             globalThis.fetch = originalFetch;
         }
@@ -1823,10 +2340,42 @@ describe("CaddyGatewayProvider ensureGatewayReady", () => {
         await cleanCaddyTmp();
     });
 
+    test("allows only a fresh config directory to bootstrap without durable state", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        try {
+            await expect(provider.ensureGatewayReady({ maxAttempts: 1, intervalMs: 1 }))
+                .resolves.toMatchObject({ ready: true });
+        } finally {
+            restore();
+        }
+    });
+
+    test("fails startup when the initialized marker outlives its durable config", async () => {
+        await mkdir("/tmp/supacloud-caddy-test", { recursive: true });
+        await writeFile("/tmp/supacloud-caddy-test/INITIALIZED", "supacloud-caddy-config-v1\n");
+
+        await expect(new CaddyGatewayProvider().ensureGatewayReady({ maxAttempts: 1, intervalMs: 1 }))
+            .rejects.toThrow("Initialized Caddy config is missing");
+    });
+
+    test("fails startup on malformed or structurally invalid durable config", async () => {
+        for (const durableConfig of ["{", JSON.stringify({ apps: {} })]) {
+            await mkdir("/tmp/supacloud-caddy-test", { recursive: true });
+            await writeFile(config.caddyConfigPath, durableConfig);
+
+            await expect(new CaddyGatewayProvider().ensureGatewayReady({ maxAttempts: 1, intervalMs: 1 })).rejects.toThrow();
+            await cleanCaddyTmp();
+        }
+    });
+
     test("retries until Caddy Admin API becomes reachable, then persists the JSON config", async () => {
         const calls: Array<{ url: string; method: string; body: any }> = [];
         // 前 2 次连接拒绝（模拟 caddy 尚未启动），第 3 次起返回 ok
         let configAttempts = 0;
+        let loadedConfig: unknown = {};
         const originalFetch = globalThis.fetch;
         globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
             const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
@@ -1839,8 +2388,9 @@ describe("CaddyGatewayProvider ensureGatewayReady", () => {
             if (url.endsWith("/config/")) {
                 configAttempts += 1;
                 if (configAttempts <= 2) return Promise.resolve(new Response("connection refused", { status: 502 }));
-                return Promise.resolve(new Response(JSON.stringify({ id: "root", data: [] })));
+                return Promise.resolve(Response.json(loadedConfig));
             }
+            if (url.endsWith("/load") && method === "POST") loadedConfig = body;
             return Promise.resolve(new Response(JSON.stringify({ id: "load", data: [] })));
         }) as unknown as typeof fetch;
         const restore = () => { globalThis.fetch = originalFetch; };
@@ -1895,7 +2445,101 @@ describe("CaddyGatewayProvider ensureGatewayReady", () => {
 
         restore();
     });
+
+    test("refuses readiness when the loaded config cannot be read back canonically", async () => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = mock((input: string | URL | Request, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+            if (url.endsWith("/config/")) return Promise.resolve(Response.json({ apps: {} }));
+            if (url.endsWith("/load") && init?.method === "POST") return Promise.resolve(Response.json({}));
+            return Promise.resolve(Response.json({}));
+        }) as unknown as typeof fetch;
+        try {
+            const result = await new CaddyGatewayProvider().ensureGatewayReady({ maxAttempts: 1, intervalMs: 1 });
+
+            expect(result).toEqual({ ready: false, error: "Caddy config read-back is different" });
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
 });
+
+describe("canonical gateway reconciliation", () => {
+    afterEach(cleanCaddyTmp);
+
+    test("builds every route family once and confirms the live durable candidate", async () => {
+        const events: string[] = [];
+        const state = {
+            tenants: { success: true, updated: 2, errors: [] },
+            hostedAuth: { success: true },
+            frontends: { total: 1, configured: 1, skipped: 0, errors: [] },
+        };
+        const provider = {
+            prepareCleanRebuild: async () => { events.push("prepare"); },
+            setupMasterRoutes: async () => { events.push("master"); },
+            rebuildAllTenantConfigs: async () => { events.push("tenants"); return state.tenants; },
+            setupHostedAuthRoutes: async () => { events.push("hosted-auth"); return state.hostedAuth; },
+            withDeferredPersist: async <T>(operation: () => Promise<T>) => {
+                events.push("defer:start");
+                const reconciled = await operation();
+                events.push("defer:flush");
+                return reconciled;
+            },
+            confirmCanonicalState: async () => { events.push("confirm"); },
+        };
+
+        await expect(reconcileCanonicalGatewayRoutes({
+            gateway: provider as any,
+            reconcileFrontends: async () => { events.push("frontends"); return state.frontends; },
+        })).resolves.toEqual(state);
+        expect(events).toEqual([
+            "defer:start", "prepare", "master", "tenants", "hosted-auth", "frontends", "defer:flush", "confirm",
+        ]);
+    });
+
+    test("fails without confirming when any canonical route family reports errors", async () => {
+        let confirmed = false;
+        const provider = {
+            prepareCleanRebuild: async () => undefined,
+            setupMasterRoutes: async () => undefined,
+            rebuildAllTenantConfigs: async () => ({ success: true, updated: 1, errors: [] }),
+            setupHostedAuthRoutes: async () => ({ success: true }),
+            withDeferredPersist: async <T>(operation: () => Promise<T>) => operation(),
+            confirmCanonicalState: async () => { confirmed = true; },
+        };
+
+        await expect(reconcileCanonicalGatewayRoutes({
+            gateway: provider as any,
+            reconcileFrontends: async () => ({
+                total: 1, configured: 0, skipped: 0, errors: ["project/site: route rejected"],
+            }),
+        })).rejects.toThrow("frontend: project/site: route rejected");
+        expect(confirmed).toBe(false);
+    });
+
+    test("writes the initialized marker only after durable and live state match", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        try {
+            const provider = new CaddyGatewayProvider();
+            await provider.setupMasterRoutes();
+            await provider.confirmCanonicalState();
+
+            expect(await readFile("/tmp/supacloud-caddy-test/INITIALIZED", "utf8"))
+                .toBe("supacloud-caddy-config-v1\n");
+        } finally {
+            restore();
+        }
+    });
+});
+
+function canonicalHealthState(updated: number) {
+    return {
+        tenants: { success: true, updated, errors: [] },
+        hostedAuth: { success: true },
+        frontends: { total: 0, configured: 0, skipped: 0, errors: [] },
+    };
+}
 
 describe("gateway-health worker", () => {
     afterEach(async () => {
@@ -1909,9 +2553,10 @@ describe("gateway-health worker", () => {
         resetGatewayHealthState();
 
         // 初始状态：未观测过可达 -> 首次探测可达会执行恢复重建。
-        await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 0, errors: [] }) });
+        const reconcileAll = async () => canonicalHealthState(0);
+        await runGatewayHealthCheck({ reconcileAll });
         // 第二次：仍然可达且未达到周期阈值，不应重复重建。
-        const rebuilt = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 0, errors: [] }) });
+        const rebuilt = await runGatewayHealthCheck({ reconcileAll });
 
         expect(rebuilt).toBe(false);
 
@@ -1927,16 +2572,16 @@ describe("gateway-health worker", () => {
 
         let now = 1_000;
         let rebuildCount = 0;
-        const rebuildAll = async () => {
+        const reconcileAll = async () => {
             rebuildCount += 1;
-            return { success: true, updated: 1, errors: [] };
+            return canonicalHealthState(1);
         };
 
-        await runGatewayHealthCheck({ rebuildAll, now: () => now, reconcileIntervalMs: 5_000 });
+        await runGatewayHealthCheck({ reconcileAll, now: () => now, reconcileIntervalMs: 5_000 });
         now += 4_999;
-        expect(await runGatewayHealthCheck({ rebuildAll, now: () => now, reconcileIntervalMs: 5_000 })).toBe(false);
+        expect(await runGatewayHealthCheck({ reconcileAll, now: () => now, reconcileIntervalMs: 5_000 })).toBe(false);
         now += 1;
-        expect(await runGatewayHealthCheck({ rebuildAll, now: () => now, reconcileIntervalMs: 5_000 })).toBe(true);
+        expect(await runGatewayHealthCheck({ reconcileAll, now: () => now, reconcileIntervalMs: 5_000 })).toBe(true);
         expect(rebuildCount).toBe(2);
 
         restore();
@@ -1960,10 +2605,11 @@ describe("gateway-health worker", () => {
         resetGatewayHealthState();
 
         // 第一次：不可达
-        await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 3, errors: [] }) });
+        const reconcileAll = async () => canonicalHealthState(3);
+        await runGatewayHealthCheck({ reconcileAll });
         // 模拟 caddy 重启后恢复
         reachable = true;
-        const rebuilt = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 3, errors: [] }) });
+        const rebuilt = await runGatewayHealthCheck({ reconcileAll });
 
         expect(rebuilt).toBe(true);
 
@@ -1978,12 +2624,33 @@ describe("gateway-health worker", () => {
         const { runGatewayHealthCheck, resetGatewayHealthState } = await import("../../src/workers/gateway-health.worker");
         resetGatewayHealthState();
 
-        const r1 = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 1, errors: [] }) });
-        const r2 = await runGatewayHealthCheck({ rebuildAll: async () => ({ success: true, updated: 1, errors: [] }) });
+        const reconcileAll = async () => canonicalHealthState(1);
+        const r1 = await runGatewayHealthCheck({ reconcileAll });
+        const r2 = await runGatewayHealthCheck({ reconcileAll });
 
         expect(r1).toBe(false);
         expect(r2).toBe(false);
 
         restore();
+    });
+
+    test("does not mark Caddy recovered when canonical reconciliation fails", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const { runGatewayHealthCheck, resetGatewayHealthState } = await import("../../src/workers/gateway-health.worker");
+        resetGatewayHealthState();
+        let attempts = 0;
+        const reconcileAll = async () => {
+            attempts += 1;
+            if (attempts === 1) throw new Error("frontend reconcile failed");
+            return canonicalHealthState(1);
+        };
+        try {
+            expect(await runGatewayHealthCheck({ reconcileAll })).toBe(false);
+            expect(await runGatewayHealthCheck({ reconcileAll })).toBe(true);
+            expect(attempts).toBe(2);
+        } finally {
+            restore();
+        }
     });
 });

--- a/packages/management-api/tests/unit/performance-regressions.test.ts
+++ b/packages/management-api/tests/unit/performance-regressions.test.ts
@@ -55,12 +55,16 @@ describe("performance regressions", () => {
   test("one-shot CLI commands do not initialize Caddy gateway routes", async () => {
     const indexSource = await read("../../src/index.ts");
     const serverBranch = indexSource.indexOf('args.length === 0 || args.includes("--server")');
-    const gatewayInitCall = indexSource.indexOf("await initializeGatewayRoutes();");
+    const gatewayReadyCall = indexSource.indexOf("await waitForGatewayBeforeServe();");
+    const frontendRecoveryCall = indexSource.indexOf("await recoverFrontendReleasesBeforeServe();");
+    const gatewayReconcileCall = indexSource.indexOf("await reconcileGatewayBeforeServe();");
     const serveCall = indexSource.indexOf("Bun.serve({");
 
     expect(serverBranch).toBeGreaterThan(0);
-    expect(gatewayInitCall).toBeGreaterThan(serverBranch);
-    expect(gatewayInitCall).toBeLessThan(serveCall);
+    expect(gatewayReadyCall).toBeGreaterThan(serverBranch);
+    expect(frontendRecoveryCall).toBeGreaterThan(gatewayReadyCall);
+    expect(gatewayReconcileCall).toBeGreaterThan(frontendRecoveryCall);
+    expect(gatewayReconcileCall).toBeLessThan(serveCall);
   });
 
   test("gateway rebuild-all skips inactive projects", async () => {

--- a/packages/management-api/tests/unit/platform-v2-bootstrap.test.ts
+++ b/packages/management-api/tests/unit/platform-v2-bootstrap.test.ts
@@ -54,8 +54,14 @@ test("platform v2 bootstrap executes canonical DDL as individual statements in o
   const fixture = fakeControlPool();
   await ensurePlatformV2SchemaInTransaction(fixture.database);
 
-  expect(fixture.observations()).toEqual({ beginCalls: 1, taggedCalls: 10, rolledBack: false });
+  const observations = fixture.observations();
+  expect(observations.beginCalls).toBe(1);
+  expect(observations.rolledBack).toBe(false);
+  expect(observations.taggedCalls).toBeGreaterThan(1);
   expect(fixture.transactionalStatements.length).toBeGreaterThan(30);
+  expect(fixture.transactionalStatements).toContainEqual(expect.stringContaining(
+    "ALTER COLUMN recovery_not_before DROP DEFAULT",
+  ));
   for (const statement of fixture.transactionalStatements) {
     expect(splitSqlStatements(statement)).toHaveLength(1);
   }

--- a/packages/management-api/tests/unit/platform-v2.schema.test.ts
+++ b/packages/management-api/tests/unit/platform-v2.schema.test.ts
@@ -49,20 +49,26 @@ describe("platform v2 schema contract", () => {
       schema.indexOf("CREATE TABLE IF NOT EXISTS supaoauth_bff_proof_nonces"),
     );
     expect(mutationSchema).toContain("PRIMARY KEY (project_ref, mutation_id)");
-    expect(mutationSchema).toContain("recovery_not_before TIMESTAMPTZ DEFAULT clock_timestamp()");
+    expect(mutationSchema).toContain("recovery_not_before TIMESTAMPTZ,");
+    expect(mutationSchema).not.toContain("recovery_not_before TIMESTAMPTZ DEFAULT");
     expect(mutationSchema).toContain("ADD COLUMN IF NOT EXISTS recovery_not_before TIMESTAMPTZ");
     expect(mutationSchema).toContain("project_mutations_succeeded_response_check");
-    expect(mutationSchema).toContain("project_mutations_recoverable_due_check");
+    expect(mutationSchema).toContain("project_mutations_recovery_due_v2_check");
     expect(mutationSchema).toContain("project_mutations_fencing_epoch_safe_check");
     expect(mutationSchema).toContain("fencing_epoch <= 9007199254740991");
     expect(mutationSchema).toContain("response_status IS NOT NULL AND response_status BETWEEN 200 AND 299");
-    expect(mutationSchema).toContain("project_mutations_recovery_idx");
-    expect(mutationSchema).toContain("status IN ('pending', 'running', 'failed_retryable')");
+    expect(mutationSchema).toContain("project_mutations_recovery_v2_idx");
+    expect(mutationSchema).toContain("status IN ('running', 'failed_retryable')");
+    expect(mutationSchema).not.toContain("status IN ('pending', 'running', 'failed_retryable')");
     expect(mutationSchema).toContain("project_mutations_active_resource_idx");
     expect(mutationSchema).not.toContain("DROP CONSTRAINT");
     expect(mutationMigration).toContain("INSERT INTO public.platform_schema_migrations");
     expect(mutationMigration).toContain("ALTER COLUMN recovery_not_before SET DEFAULT clock_timestamp()");
+    expect(mutationMigration).toContain("ALTER COLUMN recovery_not_before DROP DEFAULT");
     expect(mutationMigration).toContain("COALESCE(updated_at, created_at, clock_timestamp())");
+    expect(mutationMigration).toContain("20260813_project_mutation_recovery_contract_v4");
+    expect(mutationMigration).toContain("DROP CONSTRAINT IF EXISTS project_mutations_recoverable_due_check");
+    expect(mutationMigration).toContain("DROP INDEX IF EXISTS public.project_mutations_recovery_idx");
     expect(mutationMigration).toContain("project_mutation_resource_key_is_canonical_v1");
     expect(mutationMigration).toContain("canonical_id <> encoded_id");
     expect(mutationMigration).toContain("convert_from(decoded_id, 'UTF8')");
@@ -71,7 +77,6 @@ describe("platform v2 schema contract", () => {
     );
     expect(mutationMigration).toContain("VALIDATE CONSTRAINT ${CANONICAL_RESOURCE_KEY_CONSTRAINT}");
     expect(mutationMigration).toContain("VALIDATE CONSTRAINT ${FENCING_EPOCH_SAFE_CONSTRAINT}");
-    expect(mutationMigration).not.toContain("DROP CONSTRAINT");
     for (const sensitiveColumn of [
       "request_body", "request_headers", "request_payload", "credential", "service_role", "secret",
     ]) expect(mutationSchema).not.toContain(sensitiveColumn);

--- a/packages/management-api/tests/unit/project-mutation-migration.test.ts
+++ b/packages/management-api/tests/unit/project-mutation-migration.test.ts
@@ -2,18 +2,19 @@ import { describe, expect, test } from "bun:test";
 import type { SQL } from "bun";
 import {
   PROJECT_MUTATION_JOURNAL_MIGRATION_KEY,
+  PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY,
   migrateProjectMutationJournal,
 } from "../../src/db/project-mutation-migration";
 
 type MigrationFixtureOptions = {
-  markerExists?: boolean;
+  markers?: string[];
   constraints?: Record<string, boolean>;
   backfilledRows?: number;
   invalidResourceKeys?: number;
 };
 
 function migrationFixture(options: MigrationFixtureOptions = {}) {
-  let markerExists = options.markerExists ?? false;
+  const markers = new Set(options.markers ?? []);
   const constraints = new Map(Object.entries(options.constraints ?? {}));
   const taggedQueries: string[] = [];
   const unsafeQueries: string[] = [];
@@ -22,7 +23,8 @@ function migrationFixture(options: MigrationFixtureOptions = {}) {
       const query = strings.join("?").replaceAll(/\s+/g, " ").trim();
       taggedQueries.push(query);
       if (query.includes("FROM public.platform_schema_migrations")) {
-        return markerExists ? [{ migration_key: PROJECT_MUTATION_JOURNAL_MIGRATION_KEY }] : [];
+        const migrationKey = String(parameters[0]);
+        return markers.has(migrationKey) ? [{ migration_key: migrationKey }] : [];
       }
       if (query.includes("FROM pg_catalog.pg_constraint")) {
         const name = String(parameters[0]);
@@ -34,7 +36,9 @@ function migrationFixture(options: MigrationFixtureOptions = {}) {
       if (query.startsWith("UPDATE public.project_mutations")) {
         return Array.from({ length: options.backfilledRows ?? 0 }, (_, index) => ({ mutation_id: String(index) }));
       }
-      if (query.startsWith("INSERT INTO public.platform_schema_migrations")) markerExists = true;
+      if (query.startsWith("INSERT INTO public.platform_schema_migrations")) {
+        markers.add(String(parameters[0]));
+      }
       return [];
     },
     {
@@ -48,11 +52,11 @@ function migrationFixture(options: MigrationFixtureOptions = {}) {
       },
     },
   );
-  return { transaction: transaction as unknown as SQL, taggedQueries, unsafeQueries };
+  return { transaction: transaction as unknown as SQL, taggedQueries, unsafeQueries, markers };
 }
 
 describe("project mutation journal migration", () => {
-  test("backfills active recovery schedules, validates constraints, and records one marker", async () => {
+  test("runs v3 then narrows recovery scheduling in a separately marked v4 evolution", async () => {
     const fixture = migrationFixture({ backfilledRows: 2 });
 
     await migrateProjectMutationJournal(fixture.transaction);
@@ -61,20 +65,36 @@ describe("project mutation journal migration", () => {
     expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
       "ALTER COLUMN recovery_not_before SET DEFAULT clock_timestamp()",
     ));
-    expect(fixture.unsafeQueries.filter((query) => query.includes("ADD CONSTRAINT"))).toHaveLength(4);
-    expect(fixture.unsafeQueries.filter((query) => query.includes("VALIDATE CONSTRAINT"))).toHaveLength(4);
+    expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
+      "ALTER COLUMN recovery_not_before DROP DEFAULT",
+    ));
+    expect(fixture.unsafeQueries.filter((query) => query.includes("ADD CONSTRAINT"))).toHaveLength(5);
+    expect(fixture.unsafeQueries.filter((query) => query.includes("VALIDATE CONSTRAINT"))).toHaveLength(5);
     expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
       "ADD CONSTRAINT project_mutations_resource_key_canonical_v1_check",
     ));
     expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
       "ADD CONSTRAINT project_mutations_fencing_epoch_safe_check",
     ));
-    expect(fixture.unsafeQueries.some((query) => query.includes("DROP CONSTRAINT"))).toBe(false);
-    expect(fixture.taggedQueries.filter((query) => query.startsWith("UPDATE public.project_mutations"))).toHaveLength(1);
-    expect(fixture.taggedQueries.find((query) => query.startsWith("UPDATE public.project_mutations")))
+    expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
+      "DROP CONSTRAINT IF EXISTS project_mutations_recoverable_due_check",
+    ));
+    const recoveryUpdates = fixture.taggedQueries.filter((query) => query.startsWith(
+      "UPDATE public.project_mutations",
+    ));
+    expect(recoveryUpdates).toHaveLength(3);
+    expect(recoveryUpdates[0])
       .toContain("status IN ('pending', 'running', 'failed_retryable')");
+    expect(recoveryUpdates[1]).toContain("status IN ('running', 'failed_retryable')");
+    expect(recoveryUpdates[1]).not.toContain("'pending'");
+    expect(recoveryUpdates[2]).toContain("status = 'pending'");
+    expect(recoveryUpdates[2]).toContain("SET recovery_not_before = NULL");
     expect(fixture.taggedQueries.filter((query) => query.startsWith("INSERT INTO public.platform_schema_migrations")))
-      .toHaveLength(1);
+      .toHaveLength(2);
+    expect(fixture.markers).toEqual(new Set([
+      PROJECT_MUTATION_JOURNAL_MIGRATION_KEY,
+      PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY,
+    ]));
     const validatorDdl = fixture.unsafeQueries.find((query) => query.startsWith(
       "CREATE OR REPLACE FUNCTION public.project_mutation_resource_key_is_canonical_v1",
     ));
@@ -83,16 +103,43 @@ describe("project mutation journal migration", () => {
     expect(validatorDdl).not.toContain("WHEN OTHERS");
   });
 
-  test("skips all mutation DDL after the durable marker exists", async () => {
-    const fixture = migrationFixture({ markerExists: true });
+  test("runs v4 when v3 is already marked without replaying v3 mutation DDL", async () => {
+    const fixture = migrationFixture({ markers: [PROJECT_MUTATION_JOURNAL_MIGRATION_KEY] });
+
+    await migrateProjectMutationJournal(fixture.transaction);
+
+    expect(fixture.unsafeQueries).toContainEqual(expect.stringContaining(
+      "ALTER COLUMN recovery_not_before DROP DEFAULT",
+    ));
+    expect(fixture.unsafeQueries.some((query) => query.includes("SET DEFAULT clock_timestamp()"))).toBe(false);
+    expect(fixture.unsafeQueries.some((query) => query.includes(
+      "CREATE OR REPLACE FUNCTION public.project_mutation_resource_key_is_canonical_v1",
+    ))).toBe(false);
+    const recoveryUpdates = fixture.taggedQueries.filter((query) => query.startsWith(
+      "UPDATE public.project_mutations",
+    ));
+    expect(recoveryUpdates).toHaveLength(2);
+    expect(recoveryUpdates[0]).toContain("status IN ('running', 'failed_retryable')");
+    expect(recoveryUpdates[1]).toContain("status = 'pending'");
+    expect(fixture.markers.has(PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY)).toBe(true);
+  });
+
+  test("skips all mutation DDL after both durable markers exist", async () => {
+    const fixture = migrationFixture({
+      markers: [
+        PROJECT_MUTATION_JOURNAL_MIGRATION_KEY,
+        PROJECT_MUTATION_RECOVERY_CONTRACT_MIGRATION_KEY,
+      ],
+    });
 
     await migrateProjectMutationJournal(fixture.transaction);
 
     expect(fixture.unsafeQueries).toHaveLength(0);
-    expect(fixture.unsafeQueries.some((query) => query.startsWith("ALTER TABLE"))).toBe(false);
-    expect(fixture.taggedQueries).toHaveLength(2);
+    expect(fixture.taggedQueries).toHaveLength(4);
     expect(fixture.taggedQueries[0]).toContain("pg_advisory_xact_lock");
     expect(fixture.taggedQueries[1]).toContain("FROM public.platform_schema_migrations");
+    expect(fixture.taggedQueries[2]).toContain("pg_advisory_xact_lock");
+    expect(fixture.taggedQueries[3]).toContain("FROM public.platform_schema_migrations");
   });
 
   test("fails before backfill, constraints, or marker when a legacy raw resource key remains", async () => {

--- a/packages/management-api/tests/unit/project-mutation.service.test.ts
+++ b/packages/management-api/tests/unit/project-mutation.service.test.ts
@@ -45,7 +45,7 @@ function insertedMutation(parameters: unknown[]): MutationRow[] {
     principal_type: String(principalType), principal_id: String(principalId), status: "pending",
     checkpoint: {}, receipt: null, response_status: null, failure_code: null,
     lease_owner: null, lease_token: null, lease_expires_at: null, fencing_epoch: 0,
-    recovery_not_before: new Date().toISOString(),
+    recovery_not_before: null,
     completed_at: null, created_at: CREATED_AT, updated_at: CREATED_AT,
   };
   mutationRows.set(key, row);
@@ -62,6 +62,7 @@ function claimedMutation(parameters: unknown[]): MutationRow[] {
   Object.assign(row, {
     status: "running", lease_owner: leaseOwner, lease_token: leaseToken,
     lease_expires_at: new Date(Date.now() + Number(leaseSeconds) * 1000).toISOString(),
+    recovery_not_before: row.recovery_not_before ?? new Date().toISOString(),
     fencing_epoch: Number(row.fencing_epoch) + 1, completed_at: null,
   });
   return clonedRow(row);
@@ -124,7 +125,7 @@ function recoverableMutations(parameters: unknown[]): MutationRow[] {
     .filter((row) => operationNames.has(String(row.operation))
       && row.recovery_not_before !== null
       && Date.parse(String(row.recovery_not_before)) <= Date.now()
-      && (["pending", "failed_retryable"].includes(row.status)
+      && (row.status === "failed_retryable"
         || row.status === "running" && Date.parse(String(row.lease_expires_at)) <= Date.now()))
     .sort((left, right) => String(left.recovery_not_before).localeCompare(String(right.recovery_not_before))
       || String(left.updated_at).localeCompare(String(right.updated_at))
@@ -161,6 +162,14 @@ const database = mock(async (strings: TemplateStringsArray, ...parameters: unkno
   }
   if (query.includes("lease_active")) {
     return row ? [{ ...structuredClone(row), lease_active: Date.parse(String(row.lease_expires_at)) > Date.now() }] : [];
+  }
+  if (query.startsWith("SELECT mutation_id")) {
+    const [, , leaseToken, fencingEpoch] = parameters;
+    return row?.status === "running" && row.lease_token === leaseToken
+      && Number(row.fencing_epoch) === Number(fencingEpoch)
+      && Date.parse(String(row.lease_expires_at)) > Date.now()
+      ? [{ mutation_id: row.mutation_id }]
+      : [];
   }
   if (query.includes("FROM project_mutations")) return clonedRow(row);
   throw new Error(`Unexpected mutation query: ${query}`);
@@ -225,6 +234,32 @@ describe("project mutation journal", () => {
     executedQueries.length = 0;
     leaseTokenSequence = 100;
     database.mockClear();
+  });
+
+  test("does not schedule a fresh pending mutation for background recovery", async () => {
+    const begun = await mutationService.beginProjectMutation(database as never, beginInput());
+
+    expect(begun.kind).toBe("started");
+    expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))?.recovery_not_before).toBeNull();
+    const insertQuery = executedQueries.find((query) => query.startsWith("INSERT INTO project_mutations"));
+    expect(insertQuery).not.toContain("recovery_not_before");
+  });
+
+  test("schedules recovery only after a pending mutation acquires its first lease", async () => {
+    await mutationService.beginProjectMutation(database as never, beginInput());
+    const claimed = await mutationService.claimOrResumeProjectMutation(database as never, {
+      projectRef: PROJECT_REF,
+      mutationId: MUTATION_ID,
+      leaseOwner: "test-worker",
+      leaseToken: LEASE_TOKEN_A,
+      leaseSeconds: 30,
+    });
+
+    expect(claimed.kind).toBe("claimed");
+    expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))?.recovery_not_before)
+      .toEqual(expect.any(String));
+    const claimQuery = executedQueries.find((query) => query.includes("SET status = 'running'"));
+    expect(claimQuery).toContain("recovery_not_before = COALESCE(recovery_not_before, clock_timestamp())");
   });
 
   test("uses canonical full-request SHA-256 fingerprints", () => {
@@ -404,6 +439,36 @@ describe("project mutation journal", () => {
     expect(currentWrite).toBe("updated");
   });
 
+  test("holds the mutation row lock across a fenced external side effect", async () => {
+    const claim = await beginAndClaim();
+    const fencingEpoch = claim.kind === "claimed" ? claim.mutation.fencingEpoch : 0;
+    let calls = 0;
+    const executed = await mutationService.withProjectMutationLease(database as never, {
+      projectRef: PROJECT_REF,
+      mutationId: MUTATION_ID,
+      leaseToken: LEASE_TOKEN_A,
+      fencingEpoch,
+    }, async () => {
+      calls += 1;
+      return "applied";
+    });
+    const stale = await mutationService.withProjectMutationLease(database as never, {
+      projectRef: PROJECT_REF,
+      mutationId: MUTATION_ID,
+      leaseToken: LEASE_TOKEN_B,
+      fencingEpoch,
+    }, async () => {
+      calls += 1;
+      return "stale";
+    });
+
+    expect(executed).toEqual({ kind: "executed", value: "applied" });
+    expect(stale).toEqual({ kind: "lease_lost" });
+    expect(calls).toBe(1);
+    expect(executedQueries.some((query) => query.startsWith("SELECT mutation_id")
+      && query.endsWith("FOR UPDATE"))).toBe(true);
+  });
+
   test("rejects checkpoint and completion after lease expiry before any takeover", async () => {
     const firstClaim = await beginAndClaim();
     const fencingEpoch = firstClaim.kind === "claimed" ? firstClaim.mutation.fencingEpoch : 0;
@@ -443,6 +508,8 @@ describe("project mutation journal", () => {
     }
     mutationRows.get(mutationKey(PROJECT_REF, exactFirst))!.recovery_not_before = "2026-08-10T00:00:00.000Z";
     mutationRows.get(mutationKey(PROJECT_REF, exactSecond))!.recovery_not_before = "2026-08-10T00:00:01.000Z";
+    mutationRows.get(mutationKey(PROJECT_REF, exactFirst))!.status = "failed_retryable";
+    mutationRows.get(mutationKey(PROJECT_REF, exactSecond))!.status = "failed_retryable";
     mutationRows.get(mutationKey(PROJECT_REF, prefixedOperation))!.recovery_not_before = "2026-08-10T00:00:00.000Z";
     Object.assign(mutationRows.get(mutationKey(PROJECT_REF, unknownOutcome))!, {
       status: "outcome_unknown", recovery_not_before: "2026-08-10T00:00:00.000Z",
@@ -458,14 +525,14 @@ describe("project mutation journal", () => {
     expect(claimed[0]?.mutationId).toBe(exactFirst);
     expect(Object.keys(claimed[0]!).sort()).toEqual([
       "checkpoint", "fencingEpoch", "leaseExpiresAt", "leaseToken", "mutationId", "operation",
-      "projectRef", "recoveryNotBefore", "resourceKey",
+      "principal", "projectRef", "recoveryNotBefore", "requestFingerprint", "resourceKey",
     ]);
-    expect(mutationRows.get(mutationKey(PROJECT_REF, exactSecond))?.status).toBe("pending");
+    expect(mutationRows.get(mutationKey(PROJECT_REF, exactSecond))?.status).toBe("failed_retryable");
     expect(mutationRows.get(mutationKey(PROJECT_REF, prefixedOperation))?.status).toBe("pending");
     expect(mutationRows.get(mutationKey(PROJECT_REF, unknownOutcome))?.status).toBe("outcome_unknown");
     expect(mutationRows.get(mutationKey(PROJECT_REF, immediateRecovery))).toMatchObject({
       status: "pending",
-      recovery_not_before: expect.any(String),
+      recovery_not_before: null,
     });
     const claimQuery = executedQueries.find((query) => query.startsWith("WITH candidates AS"))!;
     expect(claimQuery).toContain("operation = ANY(?)");
@@ -474,12 +541,31 @@ describe("project mutation journal", () => {
     expect(claimQuery).not.toContain("LIKE");
   });
 
+  test("never exposes a fresh pending journal row to the recovery scanner", async () => {
+    await mutationService.beginProjectMutation(database as never, beginInput());
+    const fresh = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+    fresh.recovery_not_before = "2026-08-10T00:00:00.000Z";
+
+    const claimed = await mutationService.claimRecoverableProjectMutations({
+      operations: [fresh.operation], leaseOwner: "recovery-worker", leaseSeconds: 30, limit: 1,
+    });
+
+    expect(claimed).toEqual([]);
+    expect(fresh).toMatchObject({ status: "pending", fencing_epoch: 0, lease_token: null });
+    const claimQuery = executedQueries.findLast((query) => query.startsWith("WITH candidates AS"))!;
+    expect(claimQuery).not.toContain("status IN ('pending', 'failed_retryable')");
+    expect(claimQuery).toContain("status = 'failed_retryable'");
+  });
+
   test("concurrent recovery scanners receive disjoint fenced claims", async () => {
     const firstId = "00000000-0000-4000-8000-000000000020";
     const secondId = "00000000-0000-4000-8000-000000000021";
     for (const mutationId of [firstId, secondId]) {
       await mutationService.beginProjectMutation(database as never, beginInput({ mutationId }));
-      mutationRows.get(mutationKey(PROJECT_REF, mutationId))!.recovery_not_before = "2026-08-10T00:00:00.000Z";
+      Object.assign(mutationRows.get(mutationKey(PROJECT_REF, mutationId))!, {
+        status: "failed_retryable",
+        recovery_not_before: "2026-08-10T00:00:00.000Z",
+      });
     }
     const claimInput = {
       operations: ["scheduled_functions.create"], leaseSeconds: 30, limit: 1,
@@ -510,6 +596,7 @@ describe("project mutation journal", () => {
     const privateSentinel = "recovery-checkpoint-private-value";
     await mutationService.beginProjectMutation(database as never, beginInput());
     Object.assign(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!, {
+      status: "failed_retryable",
       recovery_not_before: "2026-08-10T00:00:00.000Z",
       checkpoint: { stage: { token: privateSentinel } },
     });
@@ -527,6 +614,29 @@ describe("project mutation journal", () => {
     expect(errorMessage).toContain("token");
     expect(errorMessage).not.toContain(privateSentinel);
   });
+
+  for (const [field, invalid] of [
+    ["request_fingerprint", "not-a-fingerprint"],
+    ["principal_type", "external"],
+    ["principal_id", " project:proj_1"],
+  ] as const) {
+    test(`rolls back a recovery claim with invalid stored ${field}`, async () => {
+      await mutationService.beginProjectMutation(database as never, beginInput());
+      const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
+      Object.assign(row, {
+        status: "failed_retryable",
+        recovery_not_before: "2026-08-10T00:00:00.000Z",
+        [field]: invalid,
+      });
+
+      await expect(mutationService.claimRecoverableProjectMutations({
+        operations: [row.operation as string], leaseOwner: "scanner-a", leaseSeconds: 30, limit: 1,
+      })).rejects.toThrow(/mutation/i);
+
+      expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID)))
+        .toMatchObject({ status: "failed_retryable", fencing_epoch: 0, lease_token: null });
+    });
+  }
 
   test("fails closed when status readback encounters an unsafe stored projection", async () => {
     const privateSentinel = "stored-status-private-value";
@@ -803,6 +913,7 @@ describe("project mutation journal", () => {
     await mutationService.beginProjectMutation(database as never, beginInput());
     const row = mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID))!;
     row.resource_key = "legacy:scheduled-function:nightly";
+    row.status = "failed_retryable";
     row.recovery_not_before = "2026-08-10T00:00:00.000Z";
 
     await expect(mutationService.claimRecoverableProjectMutations({
@@ -811,6 +922,6 @@ describe("project mutation journal", () => {
     })).rejects.toThrow("Stored mutation resource key is invalid");
 
     expect(mutationRows.get(mutationKey(PROJECT_REF, MUTATION_ID)))
-      .toMatchObject({ status: "pending", fencing_epoch: 0, lease_token: null });
+      .toMatchObject({ status: "failed_retryable", fencing_epoch: 0, lease_token: null });
   });
 });


### PR DESCRIPTION
## Summary

Immutable frontend releases with end-to-end deployment locking and a durable, fail-closed Caddy bootstrap.

- **Immutable release pipeline (CAS)**: content-addressable release archive ingestion with archive-abuse hardening (ZIP64/encryption/overlap/CRC/compression-bomb rejection), activation journal with `(release_id, activation_id)` generation state machine, fenced-lease route publication, exact journal validation on first success and replay, and a crash-recovery worker with pending-recovery v4 semantics (no recovery window before the first lease).
- **Full-path deployment lock**: every frontend metadata read-modify-write and every publish path — static and legacy SSR alike — is serialized behind a per-deployment PostgreSQL advisory lock with fail-closed release semantics (unconfirmed unlock discards the connection and raises). The complete legacy SSR/static commit (build-dir swap, process start, readiness gate, route switch, rollback) runs inside the lock; `deployFromSource`/`deployFromGit` hold the outer lock for all frameworks.
- **Durable Caddy bootstrap**: single fixed internal bootstrap certificate (`supacloud-bootstrap.invalid`) with default/fallback SNI instead of on-demand issuance, `INITIALIZED` marker gating, durable JSON reuse across Caddy-only recreates, fail-closed on missing/corrupt config, and a startup order that waits for Caddy before activation recovery, canonical reconcile, and `Bun.serve`.
- **Admin CLI**: only four immutable release actions, all via the Management API with strict receipts, readback, production confirmation, and read-only gates; legacy frontend actions stay on the regular CLI.
- **Shared deployment lock**: update/env/token/git/domain/legacy deploy use the same PostgreSQL advisory deployment lock.

Docs: self-host README gains an operations runbook for unresolved `outcome_unknown` activations (startup gate, diagnosis, audited reconciliation contract).

CI: the Integration & Compliance job now starts a Caddy 2.11.4 fixture (admin API published only on the runner loopback) because startup intentionally refuses to serve before the gateway accepts the canonical JSON config; the fixed 4s startup sleep is now a 30×2s poll.

## Verification

- Management official unit runner: 51 batches, 2263 pass / 0 fail / 38 Linux-only skip
- Admin package: 464 pass / 0 fail / 26 Linux-only skip; typecheck PASS (both packages)
- PostgreSQL 18 isolated container: schema 12/12, migration integration 14/14
- Management integration: 39/39; frontend routes 15/15; gateway 78/78; startup recovery 7/7
- Caddy durability Python: 4/4; Compose config PASS; live Caddy 2.11.4 handshake proof — arbitrary SNI / localhost / IP all complete TLS and receive bootstrap 503 with a single fixed certificate, no `on_demand`
- New lock tests proven non-vacuous: reintroducing the framework-conditional outer lock turns the static serialization test red
- Official SDK/CLI/OpenAPI compliance: PASS in Required Checks on this head (Integration & Compliance, 4m14s); all 9 required checks green, Build Binaries skipped per PR condition

## Review process

- Two rounds of independent read-only review. Round 1 FAIL (P1: static legacy deploy lock gap; P2: SSR lock test guard point; P2: `outcome_unknown` ops runbook) — all three closed and independently re-verified. Round 2 verdict: PASS, 0 P0–P2.
- Rebased onto `c6a3a87c` (release #889) with a clean rebase; stable patch-id identical before/after (`b066ee0f…`).

Draft: not for merge until Required Checks pass on this head.
