### PR TITLE
fix(lite): expose Auth health probe

### DIFF
--- a/packages/supacloud-lite/src/runtime/index.ts
+++ b/packages/supacloud-lite/src/runtime/index.ts
@@ -348,10 +348,11 @@ export async function createBackend(config: BackendConfig = {}): Promise<SupaClo
       )
     }
     if (
-      (path === '/auth/v1/verify' || path === '/auth/v1/authorize' || path === '/auth/v1/callback') &&
-      (req.method === 'GET' || req.method === 'POST')
+      (path === '/auth/v1/health' && req.method === 'GET') ||
+      ((path === '/auth/v1/verify' || path === '/auth/v1/authorize' || path === '/auth/v1/callback') &&
+        (req.method === 'GET' || req.method === 'POST'))
     ) {
-      // email-link clicks and OAuth provider redirects arrive without an apikey
+      // Health probes, email-link clicks, and OAuth redirects arrive without an apikey.
       return withCors(await auth.handle(req, { role: 'anon', claims: null }, url))
     }
     if (path.startsWith('/auth/v1/')) {

--- a/packages/supacloud-lite/test/auth-sessions.test.ts
+++ b/packages/supacloud-lite/test/auth-sessions.test.ts
@@ -3,6 +3,41 @@ import { createClient } from '@supabase/supabase-js'
 import { createLiteBackend, type SupaCloudLiteBackend } from '../src/index.js'
 
 describe('Auth session limits', () => {
+  test('exposes Auth health without requiring a project API key', async () => {
+    const backend = await createLiteBackend({
+      jwtSecret: 'x'.repeat(64),
+      vaultKey: 'y'.repeat(64),
+      log: () => {},
+    })
+    try {
+      const response = await backend.fetch('http://local/auth/v1/health')
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({
+        name: 'supacloud-lite-auth',
+        description: 'GoTrue-compatible auth',
+      })
+    } finally {
+      await backend.close()
+    }
+  })
+
+  test('keeps project API key enforcement on non-public Auth endpoints', async () => {
+    const backend = await createLiteBackend({
+      jwtSecret: 'x'.repeat(64),
+      vaultKey: 'y'.repeat(64),
+      log: () => {},
+    })
+    try {
+      const response = await backend.fetch('http://local/auth/v1/token?grant_type=password', {
+        method: 'POST',
+      })
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({ message: 'No API key found in request' })
+    } finally {
+      await backend.close()
+    }
+  })
+
   test('keeps Auth in-process and can disable only its public routes', async () => {
     const backend = await createLiteBackend({
       authEnabled: false,


### PR DESCRIPTION
## Summary

- allow unauthenticated `GET /auth/v1/health` probes before the project API-key gate
- preserve the disabled-Auth `404` boundary and API-key enforcement on every other non-public Auth route
- add focused regressions for all three routing outcomes

## Root cause

SupaCloud Lite's in-process Auth handler already implemented a GoTrue-compatible health response, but the outer runtime router sent `/auth/v1/health` through the general project API-key check. SupAuth's live compatibility suite reads that endpoint before its TOTP flow, so Lite returned `401 No API key found in request` even though the health response itself contains no protected project data.

The public allowlist now admits only `GET /auth/v1/health`. It does not expose other Auth routes and does not change the existing `auth.enabled = false` behavior.

## SupAuth consumer validation

Validated the latest SupAuth `main` against a Lite runtime built from this branch:

- SupAuth Auth/session/JWT/TOTP live subset: **4 passed, 0 failed**
- SupAuth full-stack RLS/Storage/Realtime/Edge Function fixture: **4 passed, 0 failed**

OIDC discovery and JWKS remain outside this patch. Lite currently signs with HS256, so the change deliberately does not publish a symmetric secret or add a misleading empty JWKS response.

## SupaCloud Lite validation

- `bun test test/auth-sessions.test.ts --test-name-pattern='exposes Auth health|keeps project API key enforcement|keeps Auth in-process'` — 3 passed
- `bun run check` — typecheck passed; 148 tests passed; package smoke passed; host standalone build and upgrade/snapshot/restore smoke passed
- `git diff --check` — passed
- independent verifier — PASS
