### PR TITLE
fix(lite): load fetch-object edge functions

### DIFF
--- a/packages/supacloud-lite/scripts/standalone-smoke.ts
+++ b/packages/supacloud-lite/scripts/standalone-smoke.ts
@@ -10,6 +10,7 @@ const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-standalone-'))
 const emptyPath = await mkdtemp(join(tmpdir(), 'supacloud-lite-empty-path-'))
 const migrationDir = join(projectDir, 'supabase', 'migrations')
 const functionDir = join(projectDir, 'supabase', 'functions', 'ping')
+const fetchObjectFunctionDir = join(projectDir, 'supabase', 'functions', 'fetch-object')
 const v1 = '20260729000000'
 const v2 = '20260729000001'
 const commandTimeoutMs = 120_000
@@ -18,6 +19,7 @@ try {
   await access(binary)
   await mkdir(migrationDir, { recursive: true })
   await mkdir(functionDir, { recursive: true })
+  await mkdir(fetchObjectFunctionDir, { recursive: true })
   await writeFile(join(projectDir, 'supabase', 'config.toml'), `
 [auth]
 enabled = false
@@ -27,6 +29,9 @@ enabled = true
 sql_paths = ["./seed.sql"]
 
 [functions.ping]
+verify_jwt = false
+
+[functions.fetch-object]
 verify_jwt = false
 `)
   await writeFile(join(migrationDir, `${v1}_create_upgrade_probe.sql`), `
@@ -51,6 +56,11 @@ on conflict (id) do update set body = excluded.body;
 `)
   await writeFile(join(functionDir, 'index.ts'), `
 Deno.serve(() => Response.json({ ok: true, runtime: 'standalone' }))
+`)
+  await writeFile(join(fetchObjectFunctionDir, 'index.ts'), `
+export default {
+  fetch: () => Response.json({ ok: true, runtime: 'fetch-object' })
+}
 `)
 
   const isolatedEnvironment = withoutRuntimePath(emptyPath)
@@ -80,6 +90,14 @@ Deno.serve(() => Response.json({ ok: true, runtime: 'standalone' }))
     assert(functionResponse.status === 200, `function returned HTTP ${functionResponse.status}`)
     const functionBody = await functionResponse.json() as { ok?: boolean; runtime?: string }
     assert(functionBody.ok === true && functionBody.runtime === 'standalone', 'function response was unexpected')
+
+    const fetchObjectResponse = await fetch(`${url}/functions/v1/fetch-object`, { method: 'POST' })
+    assert(fetchObjectResponse.status === 200, `fetch-object function returned HTTP ${fetchObjectResponse.status}`)
+    const fetchObjectBody = await fetchObjectResponse.json() as { ok?: boolean; runtime?: string }
+    assert(
+      fetchObjectBody.ok === true && fetchObjectBody.runtime === 'fetch-object',
+      'fetch-object function response was unexpected',
+    )
   })
 
   const storageDir = join(projectDir, '.supacloud-lite', 'storage')

--- a/packages/supacloud-lite/scripts/standalone-smoke.ts
+++ b/packages/supacloud-lite/scripts/standalone-smoke.ts
@@ -238,10 +238,12 @@ async function withServer(options: ServerOptions, check: (url: string) => Promis
   const stdout = new Response(processHandle.stdout).text()
   const stderr = new Response(processHandle.stderr).text()
   const url = `http://127.0.0.1:${port}`
+  let checkCompleted = false
   try {
     await waitForHealth(url, processHandle)
     console.log(`[standalone-smoke] ${options.phaseLabel}: healthy`)
     await check(url)
+    checkCompleted = true
   } finally {
     console.log(`[standalone-smoke] ${options.phaseLabel}: stop`)
     processHandle.kill('SIGTERM')
@@ -251,6 +253,10 @@ async function withServer(options: ServerOptions, check: (url: string) => Promis
       `[standalone-smoke] ${options.phaseLabel}: ${exitCode === expectedExitCode ? 'ok' : 'failed'} (exit ${exitCode})`,
     )
     const [stdoutText, stderrText] = await Promise.all([stdout, stderr])
+    if (!checkCompleted) {
+      if (stdoutText) console.error(`[standalone-smoke] ${options.phaseLabel} stdout:\n${stdoutText}`)
+      if (stderrText) console.error(`[standalone-smoke] ${options.phaseLabel} stderr:\n${stderrText}`)
+    }
     if (exitCode !== expectedExitCode) {
       throw new Error(`standalone server exited with ${exitCode}\n${stdoutText}\n${stderrText}`)
     }

--- a/packages/supacloud-lite/src/runtime/node/bundle-function.ts
+++ b/packages/supacloud-lite/src/runtime/node/bundle-function.ts
@@ -9,7 +9,7 @@
  * same trade Deno makes.
  */
 import { createHash } from 'node:crypto'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -64,16 +64,25 @@ function remotePlugin(): Bun.BunPlugin {
 export async function bundleFunction(entryPath: string, name: string): Promise<string> {
   const outDir = join(tmpdir(), 'supacloud-lite-fn-bundle', name)
   await mkdir(outDir, { recursive: true })
-  const result = await Bun.build({
-    entrypoints: [entryPath],
-    format: 'esm',
-    target: 'bun',
-    outdir: outDir,
-    naming: `${name}-[hash].[ext]`,
-    plugins: [remotePlugin()],
-  })
-  if (!result.success || result.outputs.length === 0) {
-    throw new Error(result.logs.map((item) => item.message).join('\n') || `failed to bundle ${entryPath}`)
+  try {
+    const buildOutput = await Bun.build({
+      entrypoints: [entryPath],
+      format: 'esm',
+      target: 'bun',
+      outdir: outDir,
+      naming: `${name}-[hash].[ext]`,
+      plugins: [remotePlugin()],
+    })
+    if (!buildOutput.success || buildOutput.outputs.length === 0) {
+      throw new Error(buildOutput.logs.map((item) => item.message).join('\n') || `failed to bundle ${entryPath}`)
+    }
+    return buildOutput.outputs[0]!.path
+  } catch (buildError) {
+    try {
+      await rm(outDir, { recursive: true, force: true })
+    } catch (cleanupError) {
+      throw new AggregateError([buildError, cleanupError], `failed to clean function bundle directory ${outDir}`)
+    }
+    throw buildError
   }
-  return result.outputs[0]!.path
 }

--- a/packages/supacloud-lite/src/runtime/node/bundle-function.ts
+++ b/packages/supacloud-lite/src/runtime/node/bundle-function.ts
@@ -62,7 +62,7 @@ function remotePlugin(): Bun.BunPlugin {
  * the OS temp dir).
  */
 export async function bundleFunction(entryPath: string, name: string): Promise<string> {
-  const outDir = join(tmpdir(), 'supacloud-lite-fn-bundle')
+  const outDir = join(tmpdir(), 'supacloud-lite-fn-bundle', name)
   await mkdir(outDir, { recursive: true })
   const result = await Bun.build({
     entrypoints: [entryPath],

--- a/packages/supacloud-lite/src/runtime/node/load-functions.ts
+++ b/packages/supacloud-lite/src/runtime/node/load-functions.ts
@@ -49,8 +49,9 @@ let loadQueue: Promise<void> = Promise.resolve()
  * directory name. Dirs starting with `_` or `.` are skipped (shared code), as
  * are functions disabled in config.toml. Each function is bundled with esbuild
  * when available (falling back to a plain import), then its handler is taken
- * from a default export or a captured `Deno.serve()` call. Load failures warn
- * and skip rather than throwing, so one broken function can't block startup.
+ * from a default function export, a default `{ fetch() }` export, or a captured
+ * `Deno.serve()` call. Load failures warn and skip rather than throwing, so one
+ * broken function can't block startup.
  */
 export async function loadFunctions(
   projectDir: string,
@@ -115,15 +116,22 @@ async function loadFunctionsUnlocked(
           importUrl = pathToFileURL(path).href
         }
         resetCapturedHandler()
-        const mod = (await import(importUrl)) as { default?: EdgeFunction }
-        // prefer an explicit default export; otherwise use the handler a
-        // Deno.serve() call captured during import
+        const mod = (await import(importUrl)) as {
+          default?: EdgeFunction | { fetch?: EdgeFunction }
+        }
         const denoHandler = takeCapturedHandler()
-        const handler = typeof mod.default === 'function' ? mod.default : denoHandler ? (req: Request) => denoHandler(req) : undefined
+        const defaultExport = mod.default
+        const handler = typeof defaultExport === 'function'
+          ? defaultExport
+          : defaultExport && typeof defaultExport.fetch === 'function'
+            ? defaultExport.fetch.bind(defaultExport)
+            : denoHandler
+              ? (req: Request) => denoHandler(req)
+              : undefined
         if (handler) {
           functions.set(name, handler as EdgeFunction)
         } else {
-          console.warn(`  warning: function "${name}" has no default export or Deno.serve() handler, skipped`)
+          console.warn(`  warning: function "${name}" has no default function, fetch object, or Deno.serve() handler, skipped`)
         }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e)

--- a/packages/supacloud-lite/src/runtime/node/load-functions.ts
+++ b/packages/supacloud-lite/src/runtime/node/load-functions.ts
@@ -1,6 +1,6 @@
 /** Loads edge functions from supabase/functions/<name>/index.{ts,js,mjs} (Node only). */
 import { readdir, readFile, realpath, rm, stat } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { EdgeFunction } from '../functions/handler.js'
 import { installDenoShim, resetCapturedHandler, takeCapturedHandler } from '../functions/deno-shim.js'
@@ -141,7 +141,7 @@ async function loadFunctionsUnlocked(
           console.warn(`  warning: failed to load function "${name}": ${msg}`)
         }
       } finally {
-        if (bundledPath) await rm(bundledPath, { force: true }).catch(() => {})
+        if (bundledPath) await rm(dirname(bundledPath), { recursive: true, force: true }).catch(() => {})
       }
       break
     }

--- a/packages/supacloud-lite/test/bundle-function.test.ts
+++ b/packages/supacloud-lite/test/bundle-function.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { bundleFunction } from '../src/runtime/node/bundle-function.js'
+
+test('removes its isolated output directory when bundling fails', async () => {
+  const fixtureDirectory = await mkdtemp(join(tmpdir(), 'supacloud-lite-bundle-failure-'))
+  const entryPath = join(fixtureDirectory, 'index.ts')
+  const bundleName = `failure-${crypto.randomUUID()}`
+  const outputDirectory = join(tmpdir(), 'supacloud-lite-fn-bundle', bundleName)
+  try {
+    await writeFile(entryPath, `import './missing-module.ts'\n`)
+    await expect(bundleFunction(entryPath, bundleName)).rejects.toThrow()
+    expect(existsSync(outputDirectory)).toBe(false)
+  } finally {
+    await Promise.all([
+      rm(fixtureDirectory, { recursive: true, force: true }),
+      rm(outputDirectory, { recursive: true, force: true }),
+    ])
+  }
+})

--- a/packages/supacloud-lite/test/functions-restart.test.ts
+++ b/packages/supacloud-lite/test/functions-restart.test.ts
@@ -4,12 +4,17 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { startProjectServer } from '../src/project-runtime.js'
 
-test('reloads Deno.serve functions after an in-process restart', async () => {
+test('reloads Deno.serve and default fetch-object functions after an in-process restart', async () => {
   const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-function-restart-'))
   await mkdir(join(projectDir, 'supabase', 'functions', 'restart'), { recursive: true })
+  await mkdir(join(projectDir, 'supabase', 'functions', 'fetch-object'), { recursive: true })
   await writeFile(
     join(projectDir, 'supabase', 'functions', 'restart', 'index.ts'),
     `Deno.serve(() => Response.json({ restarted: true }))\n`
+  )
+  await writeFile(
+    join(projectDir, 'supabase', 'functions', 'fetch-object', 'index.ts'),
+    `export default { fetch: () => Response.json({ fetchObject: true }) }\n`
   )
 
   try {
@@ -20,6 +25,12 @@ test('reloads Deno.serve functions after an in-process restart', async () => {
       })
       expect(response.status).toBe(200)
       expect(await response.json()).toEqual({ restarted: true })
+
+      const fetchObjectResponse = await fetch(`${running.url}/functions/v1/fetch-object`, {
+        headers: { apikey: running.backend.anonKey, authorization: `Bearer ${running.backend.anonKey}` },
+      })
+      expect(fetchObjectResponse.status).toBe(200)
+      expect(await fetchObjectResponse.json()).toEqual({ fetchObject: true })
       await running.close()
     }
   } finally {


### PR DESCRIPTION
## Summary

- accept Edge Function modules that default-export a `{ fetch() }` object
- preserve existing default-function and `Deno.serve()` handler precedence
- cover both source restarts and the standalone release binary smoke path

## SupAuth compatibility evidence

The released `supacloud-lite-v0.7.2` binary was tested against the SupAuth compatibility fixture:

- Auth/session/JWT/TOTP core: 4/4 passed
- RLS, Storage, Realtime: 3/3 passed
- JWT-protected Edge Function: failed because `compat-claims/index.ts` default-exports a fetch object; Lite skipped it and returned 404

With this change, a rebuilt standalone binary loads `compat-claims` and passes:

- SupAuth core: 4/4
- SupAuth full stack: 4/4

## Verification

- `bun run check`: 149 tests passed; typecheck, package smoke, host standalone build, upgrade/snapshot/restore standalone smoke passed
- targeted function restart regression: 1 passed, 8 assertions
- `git diff --check`: passed
- independent verifier: PASS

No SupAuth control-plane behavior or full GoTrue discovery/JWKS compatibility is claimed by this PR.