### PR TITLE
fix(lite): skip request log for auth health probe

### DIFF
--- a/packages/supacloud-lite/src/runtime/index.ts
+++ b/packages/supacloud-lite/src/runtime/index.ts
@@ -424,7 +424,7 @@ export async function createBackend(config: BackendConfig = {}): Promise<SupaClo
     const res = await safeHandle(req)
     try {
       const p = new URL(req.url).pathname
-      if (p !== '/health' && p !== '/') {
+      if (p !== '/health' && p !== '/' && p !== '/auth/v1/health') {
         const level = res.status >= 500 ? 'error' : res.status >= 400 ? 'warn' : 'info'
         logs.push(`${req.method} ${p} → ${res.status}`, level)
       }

--- a/packages/supacloud-lite/test/auth-sessions.test.ts
+++ b/packages/supacloud-lite/test/auth-sessions.test.ts
@@ -16,6 +16,8 @@ describe('Auth session limits', () => {
         name: 'supacloud-lite-auth',
         description: 'GoTrue-compatible auth',
       })
+      // health probes are public and must not add noise to the Logs pane
+      expect(backend.logs.list().some((entry) => entry.msg.includes('/auth/v1/health'))).toBe(false)
     } finally {
       await backend.close()
     }


### PR DESCRIPTION
## Summary

- exclude `GET /auth/v1/health` from `loggedFetch` request logging, matching the existing skip for `/health` and `/`
- prevents frequent auth health probes from cluttering the Studio Logs pane

## Context

Follow-up to #895, which exposed `GET /auth/v1/health` as a public endpoint that bypasses the API-key gate. That PR added the route to the public allowlist but did not extend the request-log skip list, so external probes (e.g. SupAuth compatibility suite) would still emit an `info` log line per request.

## Changes

- `packages/supacloud-lite/src/runtime/index.ts` — add `p !== '/auth/v1/health'` to the `loggedFetch` skip condition
- `packages/supacloud-lite/test/auth-sessions.test.ts` — assert the auth health probe produces no log entries

## Validation

- `bun run typecheck` — passed
- `bun test test/auth-sessions.test.ts` — 8 pass / 0 fail