### PR TITLE
fix(lite): keep inspection commands read-only

### DIFF
--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -117,6 +117,7 @@ async function main(): Promise<void> {
     }
     const project = await createProjectBackend({
       ...options,
+      applyMigrations: false,
       includeFunctions: false,
       includeWebhooks: false,
       startRuntimeServices: false,
@@ -138,6 +139,7 @@ async function main(): Promise<void> {
   if (options.command === 'inspect') {
     const project = await createProjectBackend({
       ...options,
+      applyMigrations: false,
       includeFunctions: false,
       includeWebhooks: false,
       startRuntimeServices: false,

--- a/packages/supacloud-lite/test/cli-readonly.test.ts
+++ b/packages/supacloud-lite/test/cli-readonly.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
+import { createProjectBackend } from '../src/project-runtime.js'
+
+const cliPath = resolve(import.meta.dir, '../src/cli.ts')
+const appliedVersion = '20260814010000'
+const pendingVersion = '20260814020000'
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('read-only CLI commands', () => {
+  test('inspect reports the live schema without applying pending migrations or seed', async () => {
+    const projectDir = await projectWithPendingMigration()
+    const inspection = await runCli(projectDir, ['inspect'])
+
+    expect(inspection.exitCode).toBe(0)
+    expect(inspection.stderr).toBe('')
+    expect(inspection.stdout).toContain('current_schema')
+    expect(inspection.stdout).not.toContain('pending_schema')
+    await expectLiveSchemaUnchanged(projectDir)
+  }, 30_000)
+
+  test('gen types reads the live schema without applying pending migrations or seed', async () => {
+    const projectDir = await projectWithPendingMigration()
+    const generatedTypes = await runCli(projectDir, ['gen', 'types'])
+
+    expect(generatedTypes.exitCode).toBe(0)
+    expect(generatedTypes.stderr).toBe('')
+    expect(generatedTypes.stdout).toContain('current_schema')
+    expect(generatedTypes.stdout).not.toContain('pending_schema')
+    await expectLiveSchemaUnchanged(projectDir)
+  }, 30_000)
+})
+
+async function projectWithPendingMigration(): Promise<string> {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-cli-readonly-'))
+  temporaryDirectories.push(projectDir)
+  const migrationsDir = join(projectDir, 'supabase', 'migrations')
+  await mkdir(migrationsDir, { recursive: true })
+  await writeFile(
+    join(migrationsDir, `${appliedVersion}_current_schema.sql`),
+    'create table public.current_schema (id integer primary key);\n'
+  )
+  const migrated = await runCli(projectDir, ['migrate'])
+  expect(migrated.exitCode).toBe(0)
+  expect(migrated.stderr).toBe('')
+  await writeFile(
+    join(migrationsDir, `${pendingVersion}_pending_schema.sql`),
+    'create table public.pending_schema (id integer primary key);\n'
+  )
+  await writeFile(join(projectDir, 'supabase', 'seed.sql'), 'insert into public.current_schema (id) values (1);\n')
+  return projectDir
+}
+
+async function expectLiveSchemaUnchanged(projectDir: string): Promise<void> {
+  const status = await runCli(projectDir, ['status'])
+  expect(status.exitCode).toBe(0)
+  expect(status.stdout).toContain(appliedVersion)
+  expect(status.stdout).not.toContain(pendingVersion)
+
+  const project = await createProjectBackend({
+    projectDir,
+    applyMigrations: false,
+    includeFunctions: false,
+    includeWebhooks: false,
+    startRuntimeServices: false,
+    log: () => {},
+  })
+  try {
+    const pendingTable = await project.backend.db.query<{ name: string | null }>(
+      `select to_regclass('public.pending_schema')::text as name`
+    )
+    const currentRows = await project.backend.db.query<{ count: number }>(
+      'select count(*)::int as count from public.current_schema'
+    )
+    expect(pendingTable.rows[0]?.name).toBeNull()
+    expect(currentRows.rows[0]?.count).toBe(0)
+  } finally {
+    await project.backend.close()
+  }
+}
+
+async function runCli(projectDir: string, command: string[]) {
+  const bunExecutable = Bun.which('bun')
+  if (!bunExecutable) throw new Error('Bun is required to run the Lite CLI test')
+  const cliProcess = Bun.spawn({
+    cmd: [bunExecutable, cliPath, ...command, '--project-dir', projectDir],
+    cwd: projectDir,
+    env: isolatedProjectEnvironment(),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await withWindowsSubprocessRef(() => Promise.all([
+    cliProcess.exited,
+    new Response(cliProcess.stdout).text(),
+    new Response(cliProcess.stderr).text(),
+  ]))
+  return { exitCode, stdout, stderr }
+}
+
+function isolatedProjectEnvironment(): Record<string, string | undefined> {
+  const environment = { ...process.env }
+  delete environment.SUPACLOUD_LITE_JWT_SECRET
+  delete environment.SUPACLOUD_LITE_VAULT_KEY
+  delete environment.SUPACLOUD_LITE_STATE_DIR
+  delete environment.SUPACLOUD_LITE_DATA_DIR
+  delete environment.SUPACLOUD_LITE_STORAGE_DIR
+  delete environment.SUPACLOUD_LITE_STORAGE_BACKEND
+  return environment
+}


### PR DESCRIPTION
## Summary

- prevent `inspect` from applying pending migrations or seed data
- prevent `gen types` from mutating the inspected project
- add regression coverage for migration status, pending schema objects, and seed side effects

## Reproduction on v0.7.3

1. Restore a snapshot whose database is behind the migration files on disk.
2. Confirm `status` reports the pending migration as unapplied.
3. Run `inspect` or `gen types`.
4. Before this fix, the command silently applies the pending migration and seed; afterward, `status` reports it as applied.

## Verification

- `bun test test/cli-readonly.test.ts --timeout 20000`: 2 passed, 0 failed, 22 assertions
- `bun run check`: 152 passed, 0 failed, 824 assertions
- package and standalone smoke tests: passed
- standalone snapshot restore black-box check: `inspect` and `gen types` leave migration status unchanged
- `db diff` / `db pull` adjacent tests: 4 passed, 0 failed
- typecheck and `git diff --check`: passed

The runtime-changing commands (`migrate`, `start`, and `upgrade`) keep their existing migration behavior.