### PR TITLE
fix(management-api): sync realtime config schema

### DIFF
--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -393,6 +393,10 @@ function buildRealtimeConfigResponse(raw: Record<string, unknown>) {
   response.private_only = raw.private_only ?? raw.privateOnly ?? response.private_only;
   response.connection_pool =
     raw.connection_pool ?? raw.connectionPool ?? response.connection_pool;
+  response.postgres_changes_pool =
+    raw.postgres_changes_pool ??
+    raw.postgresChangesPool ??
+    response.postgres_changes_pool;
   response.max_concurrent_users =
     raw.max_concurrent_users ??
     raw.maxConcurrentUsers ??
@@ -1614,7 +1618,7 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
           raw.maxJoinsPerSecond || raw.max_joins_per_second || 100,
         maxChannelsPerClient:
           raw.maxChannelsPerClient || raw.max_channels_per_client || 100,
-        ...raw,
+        ...buildRealtimeConfigResponse(raw),
       };
     },
     {

--- a/packages/management-api/src/utils/openapi-defaults.gen.ts
+++ b/packages/management-api/src/utils/openapi-defaults.gen.ts
@@ -315,6 +315,7 @@ export const OPENAPI_STORAGE_CONFIG_RESPONSE_TEMPLATE = {
 export const OPENAPI_REALTIME_CONFIG_RESPONSE_TEMPLATE = {
   "private_only": null,
   "connection_pool": null,
+  "postgres_changes_pool": null,
   "max_concurrent_users": null,
   "max_events_per_second": null,
   "max_bytes_per_second": null,

--- a/packages/management-api/tests/unit/project-realtime-config.routes.test.ts
+++ b/packages/management-api/tests/unit/project-realtime-config.routes.test.ts
@@ -1,0 +1,85 @@
+// @supacloud-test-isolate
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(null));
+const getProjectSettings = mock(() => Promise.resolve(null));
+const updateProjectSettings = mock(() => Promise.resolve({}));
+
+const authModule = await import("../../src/middleware/auth");
+const servicesModule = await import("../../src/services");
+
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const getProjectSettingsSpy = spyOn(servicesModule.projectService, "getProjectSettings").mockImplementation(
+  getProjectSettings as typeof servicesModule.projectService.getProjectSettings,
+);
+const updateProjectSettingsSpy = spyOn(servicesModule.projectService, "updateProjectSettings").mockImplementation(
+  updateProjectSettings as typeof servicesModule.projectService.updateProjectSettings,
+);
+
+const { projectConfigRoutes } = await import("../../src/routes/project-config");
+
+const app = new Elysia().use(projectConfigRoutes);
+
+function requestRealtimeConfig(init: RequestInit = {}) {
+  return app.handle(
+    new Request("http://localhost/v1/projects/proj_1/config/realtime", {
+      ...init,
+      headers: {
+        Authorization: "Bearer dev-master-token",
+        "content-type": "application/json",
+        ...(init.headers || {}),
+      },
+    }),
+  );
+}
+
+describe("project realtime config routes", () => {
+  afterAll(() => {
+    requireProjectOrAdminAuthSpy.mockRestore();
+    getProjectSettingsSpy.mockRestore();
+    updateProjectSettingsSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(null);
+    getProjectSettings.mockReset();
+    getProjectSettings.mockResolvedValue({ realtime: {} } as never);
+    updateProjectSettings.mockReset();
+    updateProjectSettings.mockImplementation(async (_ref, settings) => settings as never);
+  });
+
+  test("GET includes the required Postgres Changes pool default", async () => {
+    const response = await requestRealtimeConfig();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ postgres_changes_pool: null });
+  });
+
+  test("GET maps the camel-case Postgres Changes pool setting", async () => {
+    getProjectSettings.mockResolvedValue({
+      realtime: { postgresChangesPool: 17 },
+    } as never);
+
+    const response = await requestRealtimeConfig();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ postgres_changes_pool: 17 });
+  });
+
+  test("PATCH returns the official Realtime config shape", async () => {
+    const response = await requestRealtimeConfig({
+      method: "PATCH",
+      body: JSON.stringify({ postgres_changes_pool: 23 }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      postgres_changes_pool: 23,
+      presence_enabled: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add the new required `postgres_changes_pool` field to the Realtime config response template
- normalize both `postgres_changes_pool` and `postgresChangesPool` inputs
- return the official Realtime response shape from PATCH while preserving existing legacy fields
- add GET/PATCH route regression coverage

## Why

The live Supabase OpenAPI schema now requires `RealtimeConfigResponse.postgres_changes_pool` as a nullable integer from 1 to 100. Management API CI run 31780591954 failed twice because SupaCloud omitted the field. The preceding `main` run passed before the upstream schema changed, so this is an external contract drift rather than a Lite regression.

## Verification

- new route tests: 3 passed, 0 failed
- neighboring config route tests: 10 passed, 0 failed in independent verification
- complete Management API unit test runner: passed
- `bun run typecheck`: passed
- Swagger route coverage: 306/306
- official schema Ajv check: all 12 required fields present, 0 errors
- `git diff --check`: passed
- independent verifier: PASS

This PR does not change the existing PATCH status/body convention or add new input range validation.