### PR TITLE
build(deps): upgrade PostgREST to v16.1 across Compose, runtime, and CI

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -452,7 +452,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgrest:
-        image: postgrest/postgrest:v14.16
+        image: postgrest/postgrest:v16.1
         ports:
           - 3000:3000
         env:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - supacloud-dev
 
   postgrest:
-    image: postgrest/postgrest:v14.16
+    image: postgrest/postgrest:v16.1
     restart: always
     environment:
       PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/postgres

--- a/docker/self-host/docker-compose.yml
+++ b/docker/self-host/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       GOTRUE_WEBAUTHN_RP_ORIGINS: ${WEBAUTHN_RP_ORIGINS:-${STUDIO_URL}}
 
   postgrest:
-    image: postgrest/postgrest:v14.16
+    image: postgrest/postgrest:v16.1
     restart: unless-stopped
     depends_on:
       postgres:

--- a/docs/platform-component-upgrade-notes.md
+++ b/docs/platform-component-upgrade-notes.md
@@ -1,13 +1,13 @@
 # 平台组件升级兼容说明
 
-本说明对应 2026-07-29 的组件基线。它和版本号清单一起使用，明确区分“升级后自动生效的修复”“需要迁移或回滚准备的破坏性变化”和“仅作为可选能力保留的新功能”。本轮不在生产环境自动启用可选功能。
+本说明对应 2026-08-15 的组件基线。它和版本号清单一起使用，明确区分“升级后自动生效的修复”“需要迁移或回滚准备的破坏性变化”和“仅作为可选能力保留的新功能”。本轮不在生产环境自动启用可选功能。
 
 ## 版本与影响
 
 | 组件 | 旧版本 | 当前版本 | 破坏性/迁移关注点 | 本仓库处理 |
 | --- | --- | --- | --- | --- |
 | GoTrue | v2.191.0 | v2.195.0 | v2.192 增加 `custom_oauth_providers.custom_claims_allowlist` 数据库迁移；v2.193.1 不再错误接受应撤销的旧 refresh token，并关闭 OAuth authorization code 重放竞态；v2.194 的 admin users cursor pagination 默认关闭，启用后响应增加 `pagination`/`Link` 且不再返回 `X-Total-Count`；v2.195 将 SCIM router 置于实验性 feature flag 之后，持久化 v2 refresh token 签发时的 `last_sign_in_at`，并拒绝已封禁用户的 access token，无新增数据库迁移 | GoTrue 根命令启动时执行嵌入迁移；`supabase_auth_admin` 保留建表/改列权限。cursor pagination、custom claims 和 linking domains 均不默认打开；SCIM router 保持关闭，依赖被拒 access token 的错误客户端必须修复，不能放宽服务端校验 |
-| PostgREST | v14.13 | v14.16 | v14.14-v14.16 均为 admin server 错误处理与崩溃恢复修复，没有新增配置、数据库迁移或运行时前置要求 | 保持现有 per-tenant `.conf` 配置和健康检查；不需要改变 PostgreSQL 18 schema |
+| PostgREST | v14.13 | v16.1 | v16.0 为跨主版本升级：v16.0 移除 PostgreSQL 13 支持（本仓库部署在 PostgreSQL 18，不受影响）；v16.0 启动时拒绝 `db-schemas` 含 `pg_catalog`/`information_schema`（本仓库使用 `public,storage,graphql_public`，不受影响）；`jwt-role-claim-key` 从 JSPath 改为 JSON Path（本仓库不使用 `jwt-role-claim-key`，角色提取由 pre-request function 在 SQL 层完成，不受影响）；ARM64 二进制资源从 `ubuntu-aarch64` 改名为 `linux-static-aarch64`；`Prefer: timezone` 不再支持 `handling=lenient`。v16.1 修复 v16.0 的 JWT 校验时间 bug | 已同步 `tenant_runtime.sh` 的 ARM64 资源名为 `linux-static-aarch64`、更新 SHA256 pin 和默认版本；两份 Compose 和 CI workflow 镜像已统一为 v16.1；保持现有 per-tenant `.conf` 配置和健康检查；不需要改变 PostgreSQL 18 schema |
 | Realtime | v2.111.4 | v2.121.1 | 2.112 恢复 pg filters；2.117-2.121 增加 inspector/status、tenant shutdown、Muster 和 fanout 可观测性；2.121.1 仅修复 fanout tenant metric 的 feature-flag 边界并更新 pg-delta。v2.120.1 修订既有 `20241019105805_uuid_auto_generation.ex`：先回填 `realtime.messages.uuid` 空值，再设置 default 和 `NOT NULL`；已记录成功的同名迁移不会自动重跑 | 多租户默认使用 `REGION=us-east-1`、`SEED_SELF_HOST=false`，fresh tenant 先按注册契约将 `realtime` schema owner 设为 `supabase_admin`，并向 `supabase_admin`/`supabase_realtime_admin` 授予 `USAGE, CREATE`，再由官方 Realtime migrator 接管对象；PG18 没有 self-host dump 时必须走顺序迁移。只有单租户演示场景才显式设置 `REALTIME_SEED_SELF_HOST=true`。升级前备份 tenant Realtime schema，并读回 `uuid`、default、`NOT NULL`、schema owner 与 migration marker；不默认启用新管理能力或 feature flag |
 | Caddy | v2.10.2 | v2.11.4 | 2.11 对 HTTPS upstream 默认重写 `Host`；2.11.4 的路径、rewrite、模板和下划线 header 安全修复可能让依赖旧错误行为的配置失效 | SupaCloud JSON 路由显式设置 `Host`/`X-Forwarded-Host`，并只发送连字符 header；Caddy 自定义 rate-limit 模块已用 v2.11.4 双架构构建验证 |
 | JuiceFS | 1.2.2 | 1.4.0 | 1.4 是 LTS；启用 storage tiers 时所有客户端必须先到 1.4.0；元数据备份默认清理两年以上备份；1.4 包含 SQL 元数据字段类型调整 | 本平台只使用单一 gateway 和 Postgres metadata；不启用 storage tiers。已有 `juicefs` metadata 在生产升级前必须做 `juicefs dump`/pg_dump 并保留回滚副本 |
@@ -27,7 +27,7 @@ SupaCloud 的实际部署、Dockerfile 和 self-host Compose 继续使用 `postg
 ## 官方变更记录
 
 - [GoTrue v2.192.0](https://github.com/supabase/auth/releases/tag/v2.192.0)、[v2.193.1](https://github.com/supabase/auth/releases/tag/v2.193.1)、[v2.194.0](https://github.com/supabase/auth/releases/tag/v2.194.0)、[v2.195.0](https://github.com/supabase/auth/releases/tag/v2.195.0) / [v2.193.0...v2.195.0](https://github.com/supabase/auth/compare/v2.193.0...v2.195.0)
-- [PostgREST v14.14](https://github.com/PostgREST/postgrest/releases/tag/v14.14)、[v14.15](https://github.com/PostgREST/postgrest/releases/tag/v14.15)、[v14.16](https://github.com/PostgREST/postgrest/releases/tag/v14.16) / [v14.15...v14.16](https://github.com/PostgREST/postgrest/compare/v14.15...v14.16)
+- [PostgREST v14.14](https://github.com/PostgREST/postgrest/releases/tag/v14.14)、[v14.15](https://github.com/PostgREST/postgrest/releases/tag/v14.15)、[v14.16](https://github.com/PostgREST/postgrest/releases/tag/v14.16)、[v16.0](https://github.com/PostgREST/postgrest/releases/tag/v16.0)、[v16.1](https://github.com/PostgREST/postgrest/releases/tag/v16.1) / [v14.16...v16.1](https://github.com/PostgREST/postgrest/compare/v14.16...v16.1)
 - [Realtime v2.112.0](https://github.com/supabase/realtime/releases/tag/v2.112.0)、[v2.116.1](https://github.com/supabase/realtime/releases/tag/v2.116.1)、[v2.117.0](https://github.com/supabase/realtime/releases/tag/v2.117.0)、[v2.119.0](https://github.com/supabase/realtime/releases/tag/v2.119.0)、[v2.120.0](https://github.com/supabase/realtime/releases/tag/v2.120.0)、[v2.120.1](https://github.com/supabase/realtime/releases/tag/v2.120.1)、[v2.121.0](https://github.com/supabase/realtime/releases/tag/v2.121.0)、[v2.121.1](https://github.com/supabase/realtime/releases/tag/v2.121.1) / [v2.116.1...v2.121.1](https://github.com/supabase/realtime/compare/v2.116.1...v2.121.1)
 - [Caddy v2.11.1](https://github.com/caddyserver/caddy/releases/tag/v2.11.1) / [v2.11.4](https://github.com/caddyserver/caddy/releases/tag/v2.11.4)
 - [JuiceFS v1.4.0](https://github.com/juicedata/juicefs/releases/tag/v1.4.0)

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -1266,9 +1266,9 @@ describe("runtime companion version assets", () => {
     const runtime = readRepoFile("scripts/lib/tenant_runtime.sh");
     const upgrade = readRepoFile("scripts/lib/gotrue_upgrade.sh");
 
-    expect(runtime).toContain('local version="${POSTGREST_VERSION:-v14.16}"');
+    expect(runtime).toContain('local version="${POSTGREST_VERSION:-v16.1}"');
     expect(runtime).toContain('x86_64) arch="linux-static-x86-64"');
-    expect(runtime).toContain('aarch64) arch="ubuntu-aarch64"');
+    expect(runtime).toContain('aarch64) arch="linux-static-aarch64"');
     expect(runtime).toContain("postgrest-${version}-${arch}.tar.xz");
 
     expect(readShellConstant(runtime, "GOTRUE_DEFAULT_VERSION")).toBe(
@@ -1300,7 +1300,7 @@ describe("runtime companion version assets", () => {
     expect(installer).toContain('CADDY_VERSION:-2.11.4');
     expect(caddyBuilder).toContain('CADDY_VERSION="${CADDY_VERSION:-v2.11.4}"');
 
-    expect(runtime).toContain('POSTGREST_DEFAULT_VERSION="v14.16"');
+    expect(runtime).toContain('POSTGREST_DEFAULT_VERSION="v16.1"');
     expect(runtime).toContain('GOTRUE_DEFAULT_VERSION="v2.195.0"');
     for (const source of [installer, realtimeUnit, workflow]) {
       expect(source).toContain("public.ecr.aws/supabase/realtime:v2.121.1");
@@ -1308,9 +1308,9 @@ describe("runtime companion version assets", () => {
     for (const compose of [devCompose, selfHostCompose]) {
       expect(compose).toContain("caddy:2.11.4");
       expect(compose).toContain("supabase/gotrue:v2.195.0");
-      expect(compose).toContain("postgrest/postgrest:v14.16");
+      expect(compose).toContain("postgrest/postgrest:v16.1");
     }
-    expect(workflow).toContain("postgrest/postgrest:v14.16");
+    expect(workflow).toContain("postgrest/postgrest:v16.1");
     expect(workflow).toContain("supabase/gotrue:v2.195.0");
     expect(postgresDockerfile).toContain("FROM postgres:18-bookworm");
     expect(devCompose).toContain("context: ../self-host/postgres");

--- a/scripts/lib/tenant_runtime.sh
+++ b/scripts/lib/tenant_runtime.sh
@@ -22,9 +22,9 @@ SUPACLOUD_META_DB="${SUPACLOUD_META_DB:-supacloud_meta}"
 POSTGREST_RTS="${POSTGREST_RTS:--N1 -M256m -I0.5 -A4m}"
 POSTGREST_MEMORY_MAX="${POSTGREST_MEMORY_MAX:-384M}"
 POSTGREST_CPU_WEIGHT="${POSTGREST_CPU_WEIGHT:-40}"
-POSTGREST_DEFAULT_VERSION="v14.16"
-POSTGREST_X86_64_SHA256="36b8ae140f188cfcd6003494805bf35a41e895f88c12be9183d60f91782145c6"
-POSTGREST_ARM64_SHA256="086f58dfa090ef0ed7e30ca5c0b49f937a9586d77e5ce372f6a34f249370e37d"
+POSTGREST_DEFAULT_VERSION="v16.1"
+POSTGREST_X86_64_SHA256="b986c926cf16a1c5d97954c57d3a6edd894a5da225c3f3fc0c25dc4105009dd7"
+POSTGREST_ARM64_SHA256="90c801ef53671677d1c9bef4181579fe876c5a2b0c1ba51bb71ace4eebccc1c5"
 GOTRUE_DEFAULT_VERSION="v2.195.0"
 
 gotrue_binary_version() {
@@ -714,11 +714,11 @@ ensure_postgrest() {
     machine=$(uname -m)
     case "$machine" in
         x86_64) arch="linux-static-x86-64"; default_sha256="$POSTGREST_X86_64_SHA256" ;;
-        aarch64) arch="ubuntu-aarch64"; default_sha256="$POSTGREST_ARM64_SHA256" ;;
+        aarch64) arch="linux-static-aarch64"; default_sha256="$POSTGREST_ARM64_SHA256" ;;
         *) echo "ERROR: Unsupported architecture: $machine" >&2; exit 1 ;;
     esac
 
-    local version="${POSTGREST_VERSION:-v14.16}"
+    local version="${POSTGREST_VERSION:-v16.1}"
     local expected_sha256
     assert_safe_config_value "POSTGREST_VERSION" "$version" || exit 1
     case "$version" in *[!A-Za-z0-9._-]*|"") echo "ERROR: Invalid POSTGREST_VERSION" >&2; exit 1 ;; esac

--- a/scripts/lib/tenant_runtime.test.sh
+++ b/scripts/lib/tenant_runtime.test.sh
@@ -7,9 +7,9 @@ RUNTIME_SCRIPT="${SCRIPT_DIR}/tenant_runtime.sh"
 
 grep -Eq '^umask 077$' "$RUNTIME_SCRIPT"
 grep -Fq 'PGPASSWORD="$db_password" psql' "$RUNTIME_SCRIPT"
-grep -Fq 'v14.16' "$RUNTIME_SCRIPT"
-grep -Fq '36b8ae140f188cfcd6003494805bf35a41e895f88c12be9183d60f91782145c6' "$RUNTIME_SCRIPT"
-grep -Fq '086f58dfa090ef0ed7e30ca5c0b49f937a9586d77e5ce372f6a34f249370e37d' "$RUNTIME_SCRIPT"
+grep -Fq 'v16.1' "$RUNTIME_SCRIPT"
+grep -Fq 'b986c926cf16a1c5d97954c57d3a6edd894a5da225c3f3fc0c25dc4105009dd7' "$RUNTIME_SCRIPT"
+grep -Fq '90c801ef53671677d1c9bef4181579fe876c5a2b0c1ba51bb71ace4eebccc1c5' "$RUNTIME_SCRIPT"
 grep -Fq 'v2.195.0' "$RUNTIME_SCRIPT"
 grep -Fq 'GOTRUE_EXPERIMENTAL_PROVIDER_LINKING_DOMAINS' "$RUNTIME_SCRIPT"
 grep -Fq 'run the explicit SupaCloud installer/upgrade' "$RUNTIME_SCRIPT"
@@ -203,12 +203,12 @@ fi
 unset -f curl
 unset SUPACLOUD_GITHUB_PROXY
 
-if resolve_release_sha256 "PostgREST" "v99.0.0" "v14.16" "default-digest" "" >/dev/null 2>&1; then
+if resolve_release_sha256 "PostgREST" "v99.0.0" "v16.1" "default-digest" "" >/dev/null 2>&1; then
     echo "non-default PostgREST version reused the default digest" >&2
     exit 1
 fi
 explicit_digest=$(printf 'e%.0s' {1..64})
-[[ "$(resolve_release_sha256 "PostgREST" "v99.0.0" "v14.16" "$(printf 'd%.0s' {1..64})" "$explicit_digest")" == "$explicit_digest" ]]
+[[ "$(resolve_release_sha256 "PostgREST" "v99.0.0" "v16.1" "$(printf 'd%.0s' {1..64})" "$explicit_digest")" == "$explicit_digest" ]]
 
 # Archive validation rejects digest mismatches and link/special-file payloads.
 mkdir -p "$tmp_dir/archive/valid" "$tmp_dir/archive/link"


### PR DESCRIPTION
### 概述

将 PostgREST 从 v14.16 升级至最新稳定版 v16.1，统一开发环境、自托管 Compose、租户运行时脚本、CI 工作流以及版本一致性单测。本 PR 作为一个受控升级提交，替代并关闭 #904 和 #906。

### 变更明细

1. **Compose 同步**：
   - `docker/dev/docker-compose.yml`: `postgrest/postgrest:v16.1`
   - `docker/self-host/docker-compose.yml`: `postgrest/postgrest:v16.1`
2. **租户运行时脚本**：
   - `scripts/lib/tenant_runtime.sh`: 更新 `POSTGREST_DEFAULT_VERSION="v16.1"`
   - 更新 ARM64 二进制资源名从 `ubuntu-aarch64` 改为官方 `linux-static-aarch64`
   - 更新 SHA256 校验和（x86_64: `b986c926...` / arm64: `90c801ef...`）
3. **CI 服务容器**：
   - `.github/workflows/management-api.yml`: PostgREST 服务容器镜像升级为 `postgrest/postgrest:v16.1`
4. **单测与校验**：
   - `packages/management-api/tests/unit/runtime-version-assets.test.ts`: 更新所有版本断言期望为 `v16.1`
   - `scripts/lib/tenant_runtime.test.sh`: 更新版本与校验和断言
5. **升级与迁移文档**：
   - `docs/platform-component-upgrade-notes.md`: 补充 PostgREST v16.0 / v16.1 破坏性变更与兼容性分析

### 兼容性与回归证据

- **PostgreSQL 18 兼容性**：v16.0 移除 PG 13 支持，本仓库运行在 PG 18 上，无影响。
- **Schema 限制**：v16.0 禁止 `db-schemas` 包含 catalog schema，本仓库配置为 `public,storage,graphql_public`，完全合规。
- **JWT 角色提取**：本仓库使用 SQL pre-request function 提取角色，不依赖 `jwt-role-claim-key`。
- **测试通过证据**：
  - `bun test packages/management-api/tests/unit/runtime-version-assets.test.ts` (30 pass)
  - `bash scripts/lib/tenant_runtime.test.sh` (pass)
  - `bun test packages/management-api/tests/unit/postgrest*` (51 pass)

Supersedes #904, #906