### PR TITLE
fix: harden target-bound upgrade delivery

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -252,6 +252,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
       - name: Validate Docker Compose files
         run: |
           docker compose -f docker/dev/docker-compose.yml config --quiet

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -227,18 +227,24 @@ de GitHub. Caddy y GoTrue quedan fuera de esta transacción y no se reemplazan.
 Omite `--edge_runtime_version` solo cuando quieras actualizar Management y Web
 Console sin cambiar Edge Runtime; la CLI de administración informa ese límite.
 
-El binario de servidor `/usr/local/bin/supacloud` conserva la ruta local que
-solo actualiza Management/Web Console. Los servidores de producción no necesitan
-hacer `git pull` del código fuente durante las actualizaciones normales.
+Para actualizar solo Management/Web Console, usa el transporte remoto de Admin
+y omite `--edge_runtime_version`. El runner es el binario Management objetivo
+verificado, no la versión anterior instalada en el servidor.
 
 ```bash
-sudo supacloud upgrade --yes
+npx @supacloud/admin ssh upgrade \
+  --version 0.60.1 \
+  --artifact_transport remote \
+  --github_proxy direct
 ```
 
 Las descargas de instalación y actualización son directas primero. Configura un proxy de confianza solo cuando se requiere una alternativa explícita:
 
 ```bash
-sudo SUPACLOUD_GITHUB_PROXY=https://your-trusted-proxy.example supacloud upgrade --yes
+npx @supacloud/admin ssh upgrade \
+  --version 0.60.1 \
+  --artifact_transport remote \
+  --github_proxy https://your-trusted-proxy.example
 ```
 
 Los artefactos de release requieren verificación SHA256 de la misma release y atestación de procedencia de GitHub build. `SUPACLOUD_ALLOW_UNVERIFIED_RELEASE=true` es un modo de emergencia break-glass que retiene la verificación SHA256 pero no debe ser una configuración de instalación normal.
@@ -556,7 +562,7 @@ Para operadores humanos, la división de CLI ahora es:
 - `@supacloud/admin` / `supacloud-admin`: CLI de administración de servidor y plataforma
 - `supacloudctl admin ...`: punto de entrada local unificado con el mismo comportamiento offline-por-defecto; usa `supacloudctl check-update admin` explícitamente.
 - Usa `npx @supacloud/admin ssh upgrade --version <management-version> --edge_runtime_version <edge-version>` para la transacción verificada de Management, Web Console y Edge Runtime externo.
-- En servidores instalados, `/usr/local/bin/supacloud` sigue siendo el binario del servidor compilado; `sudo supacloud upgrade --yes` se limita a Management/Web Console salvo que el flujo Admin compatible reciba un objetivo exacto de Edge Runtime.
+- `/usr/local/bin/supacloud` sigue siendo el binario activo del servidor, pero todas las actualizaciones compatibles usan Admin. Las actualizaciones offline protegidas usan el transporte local verificado de Admin, que ejecuta el runner objetivo autenticado; no ejecutes el bundle runner manualmente ni permitas que la versión anterior instalada ejecute una transacción específica de la versión objetivo.
 
 
 ### Estructura del Proyecto

--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ staging tree.
 The transaction runs in a uniquely named transient systemd unit and publishes a
 protected atomic status record. Admin polls that record through short SSH calls;
 it does not blindly stop a transaction that may have entered activation. The
-legacy server-download path remains available as `--artifact_transport remote`.
+server-download path remains available as `--artifact_transport remote`; it
+also verifies and executes the exact target Management binary as the upgrade
+runner instead of delegating target-specific work to the installed prior version.
 Local, remote, and direct server upgrades share one nonblocking host-wide lock.
 
 Admin observes the remote transaction for up to 30 minutes. Reaching that
@@ -258,18 +260,25 @@ With `--artifact_transport remote` (the default), omit
 Console without changing Edge Runtime. Local transport requires exact
 Management and Edge Runtime versions.
 
-The installed `/usr/local/bin/supacloud` server binary still provides the
-Management/Web Console-only local upgrade path. Production servers do not need
-to `git pull` application source during normal upgrades.
+For a Management/Web Console-only upgrade, use Admin remote transport and omit
+`--edge_runtime_version`. Production servers do not need to `git pull`
+application source, and an installed prior Management binary is never trusted
+to implement a newer release's helper or Web activation contract.
 
 ```bash
-sudo supacloud upgrade --yes
+npx @supacloud/admin ssh upgrade \
+  --version 0.60.1 \
+  --artifact_transport remote \
+  --github_proxy direct
 ```
 
 Install and upgrade downloads are direct-first. Configure a trusted proxy only when an explicit fallback is required:
 
 ```bash
-sudo SUPACLOUD_GITHUB_PROXY=https://your-trusted-proxy.example supacloud upgrade --yes
+npx @supacloud/admin ssh upgrade \
+  --version 0.60.1 \
+  --artifact_transport remote \
+  --github_proxy https://your-trusted-proxy.example
 ```
 
 Release artifacts require same-release SHA256 verification and GitHub build provenance attestation. `SUPACLOUD_ALLOW_UNVERIFIED_RELEASE=true` is an emergency break-glass mode that retains SHA256 verification but must not be a normal installation setting.
@@ -606,7 +615,7 @@ For human operators, the CLI split is now:
 - `@supacloud/admin` / `supacloud-admin`: server and platform administration CLI
 - `supacloudctl admin ...`: unified local entrypoint with the same offline-by-default behavior; use `supacloudctl check-update admin` explicitly.
 - Use `npx @supacloud/admin ssh upgrade --version <management-version> --edge_runtime_version <edge-version>` for the verified Management, Web Console, and external Edge Runtime transaction.
-- On installed servers, `/usr/local/bin/supacloud` remains the compiled server binary; `sudo supacloud upgrade --yes` is limited to the Management/Web Console path unless an exact Edge Runtime target is supplied through the supported Admin flow.
+- `/usr/local/bin/supacloud` remains the active server binary, but all supported upgrades use Admin. Protected offline upgrades use Admin's verified local transport, which executes the authenticated target runner; do not run the bundle runner manually or let the installed prior release execute a target-specific transaction.
 
 
 ### Project Structure

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,8 +228,9 @@ attestation 参数的 `gh` 时直接复用；仅缺少合格 `gh` 时，才在�
 
 升级事务运行在唯一命名的 transient systemd unit 中，使用受保护的原子状态文件
 轮询，因此不会依赖一个长时间保持的 SSH channel，也不会在状态未知时强杀已经
-进入 activation 的事务。原服务器下载路径仍可通过 `--artifact_transport remote`
-显式使用。
+进入 activation 的事务。服务器下载路径仍可通过 `--artifact_transport remote`
+显式使用；该路径也会校验并执行目标 Management binary，不把目标版本的
+helper/Web 激活逻辑交给已安装的旧版本。
 
 该事务要求持久化配置为 `EDGE_RUNTIME_MODE=external`；embedded 模式会在
 改动 Release 制品或服务前被拒绝。命令会保留 Edge Runtime 的 systemd
@@ -240,17 +241,24 @@ SHA256 与 GitHub attestation 做校验。Caddy 和 GoTrue 不属于该事务，
 只有明确只升级 Management 和 Web Console、不改 Edge Runtime 时，才省略
 `--edge_runtime_version`；Admin CLI 会明确报告这个边界。
 
-已安装的 `/usr/local/bin/supacloud` 服务端二进制仍提供只覆盖 Management/
-Web Console 的本机升级路径。生产服务器常规升级不需要 `git pull` 源码。
+只升级 Management/Web Console 时，使用 Admin remote transport 并省略
+`--edge_runtime_version`。生产服务器不需要 `git pull`，也不会让已安装的
+旧 Management binary 执行新版本的 helper/Web 事务。
 
 ```bash
-sudo supacloud upgrade --yes
+npx @supacloud/admin ssh upgrade \
+  --version 0.60.1 \
+  --artifact_transport remote \
+  --github_proxy direct
 ```
 
 安装和升级下载默认先直连 GitHub。只有需要明确回退时才配置可信代理：
 
 ```bash
-sudo SUPACLOUD_GITHUB_PROXY=https://your-trusted-proxy.example supacloud upgrade --yes
+npx @supacloud/admin ssh upgrade \
+  --version 0.60.1 \
+  --artifact_transport remote \
+  --github_proxy https://your-trusted-proxy.example
 ```
 
 Release 产物必须同时通过同一 Release 的 SHA256 和 GitHub build provenance attestation。`SUPACLOUD_ALLOW_UNVERIFIED_RELEASE=true` 仅用于紧急 break-glass，仍会校验 SHA256，不应作为常规安装配置。
@@ -513,7 +521,7 @@ desired state 保存在项目专用元数据列里（`postgrest_desired`、`post
 - `@supacloud/admin` / `supacloud-admin`：服务器管理员 CLI，处理 SSH、安装、升级、租户运维
 - `supacloudctl admin ...`：统一本地入口，同样默认离线；需要时显式运行 `supacloudctl check-update admin`
 - Management、Web Console 与外置 Edge Runtime 的受校验事务使用 `npx @supacloud/admin ssh upgrade --version <management-version> --edge_runtime_version <edge-version>`
-- 已安装服务器上的 `/usr/local/bin/supacloud` 仍是编译后的服务端二进制；除非通过受支持的 Admin 流程提供精确 Edge Runtime 目标，否则 `sudo supacloud upgrade --yes` 只覆盖 Management/Web Console
+- `/usr/local/bin/supacloud` 仍是活动服务端二进制，但所有受支持的升级都必须通过 Admin。受保护的离线升级使用 Admin 已验证的本地产物传输，并由它执行认证后的目标 runner；不能手工执行 bundle runner，也不能让已安装的旧版本执行目标版本事务
 
 
 ### 项目结构

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -7,10 +7,10 @@ SupaCloud exposes three explicit local command surfaces with strict ownership bo
 - the optional `supacloud` npm package / `supacloudctl`, whose normal dispatch is local-only; `supacloudctl check-update [cli|admin]` explicitly queries npm without downloading or executing `latest`
 
 The bare `supacloud` command is not a local CLI compatibility alias. It is the
-compiled server binary installed at `/usr/local/bin/supacloud`; use it only for
-server lifecycle commands such as `sudo supacloud upgrade --yes`. Project work
-uses `supacloud-cli`, platform administration uses `supacloud-admin`, and the
-optional local umbrella command is `supacloudctl`.
+compiled active server binary installed at `/usr/local/bin/supacloud`; do not
+use an installed prior release to execute a target release's upgrade contract.
+Project work uses `supacloud-cli`, platform upgrades use `supacloud-admin`, and
+the optional local umbrella command is `supacloudctl`.
 
 ```text
 supacloud-cli        project-scoped user/developer CLI
@@ -330,20 +330,33 @@ all executable SSH actions disabled.
 
 ### Protected offline upgrade handoff
 
-The installed server binary provides the supported handoff for a release bundle
-that an administrator has already placed on the server. Pin both component
-versions; do not use `latest` or an inferred Edge Runtime version:
+Protected offline upgrades use Admin's verified local artifact transport. Admin
+authenticates the target Management binary, Web Console, and Edge Runtime on the
+operator host against the signed manifests, checksums, sizes, source commits,
+architectures, GitHub attestations, and pinned trusted root before any target
+code is transferred or executed. Pin both component versions; do not use
+`latest`:
 
 ```bash
-sudo /usr/local/bin/supacloud upgrade --yes \
-  --target-version 0.50.31 \
-  --edge-runtime-version 0.16.8 \
-  --asset-bundle-dir /var/lib/supacloud/upgrade-bundles/release-20260810
+npx @supacloud/admin@0.14.1 ssh upgrade \
+  --version 0.60.1 \
+  --edge_runtime_version 0.18.2 \
+  --artifact_transport local \
+  --github_proxy direct
 ```
 
-The bundle root and both component directories must be canonical, root-owned
-directories with mode `0700`. Every file must be a root-owned direct regular
-file with mode `0600`, one link, and no symlink traversal. The fixed layout is:
+The direct `sudo <bundle-runner> upgrade --asset-bundle-dir ...` handoff is not
+a supported trust bootstrap: bundle code must not authenticate itself after it
+already has root execution. Admin selects amd64 or arm64 from the verified SSH
+preflight, transfers a protected bundle and, only after remote byte-for-byte
+verification, executes that bundle's target Management runner. If the
+transaction is nonterminal or recovery is incomplete, retain the reported
+stage, runner, status, log, and recovery paths until read-back is complete.
+
+The Admin-created bundle root and both component directories are canonical,
+root-owned directories with mode `0700`. Every file must be a root-owned direct
+regular file with mode `0600`, one link, and no symlink traversal. The fixed
+layout is:
 
 ```text
 <bundle>/
@@ -360,18 +373,21 @@ file with mode `0600`, one link, and no symlink traversal. The fixed layout is:
     supacloud-edge-runtime-linux-<arch>
 ```
 
-Omit `edge-runtime/` and `--edge-runtime-version` together for a
-Management/Web Console-only transaction. When an Edge Runtime version is
-specified, both are mandatory. The offline path reads no GitHub release
-metadata and downloads no release asset. It verifies the supplied provenance
-bundles locally with `gh attestation verify` and the TUF-reviewed trusted root
-embedded in the Management binary, then checks the signed manifest,
-`SHA256SUMS`, exact asset size and digest before staging anything. This path
-does not initialize a live Sigstore TUF client and remains strict without TUF
-DNS, network access, or a pre-populated cache. A missing or outdated verifier,
-an invalid embedded root, an extra file, or a component/version mismatch fails
-before the upgrade transaction. Management and Edge Runtime may come from
-different valid release commits; each component proves its own source commit.
+The protected offline transport requires both exact component versions. The
+server reads no GitHub release metadata and downloads no release asset. Before
+upload or execution, Admin verifies the supplied provenance with its pinned
+`gh` and TUF-reviewed trusted root, then checks the signed manifest,
+`SHA256SUMS`, asset sizes and digests, including the target runner bytes. Before
+executing that authenticated runner, the server checks the protected filesystem
+identity and verifies every transferred byte against the size and digest frozen
+by Admin. The target runner then repeats the offline manifest, checksum, size,
+digest, and attestation verification before upgrade mutation or activation.
+This path does not initialize a live Sigstore TUF client and remains strict
+without TUF DNS, network access, or a pre-populated cache. A missing or outdated
+verifier, an invalid embedded root, an extra file, or a component/version
+mismatch fails before the upgrade transaction. Management and Edge Runtime may
+come from different valid release commits; each component proves its own source
+commit.
 
 ### Owned command areas
 

--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -157,8 +157,9 @@ upload-drop paths for reconciliation. Inspect that evidence before retrying and
 do not retry blindly while the remote transaction may still be running.
 
 `--artifact_transport local` accepts only `--github_proxy direct` or `none` and
-clears proxy environment variables on both hosts. The legacy server-download
-path remains available as `--artifact_transport remote`.
+clears proxy environment variables on both hosts. The server-download path
+remains available as `--artifact_transport remote`; it verifies and executes
+the target Management release as the runner even for Management-only upgrades.
 
 With `--artifact_transport remote` (the default), omitting
 `--edge_runtime_version` retains the Management and Web Console-only upgrade
@@ -175,14 +176,10 @@ command may finish later and then run its own cleanup. Reconcile the reported
 helper and trusted-root paths and read back deployed versions before deciding
 whether to retry.
 
-After a capable Management release is active, an exact rollback can use that
-active upgrader with explicit older targets, for example:
-
-```bash
-npx @supacloud/admin ssh upgrade \
-  --version 0.50.26 \
-  --edge_runtime_version 0.16.6
-```
+Targets predating the target-bound systemd-unit helper identity command are
+rejected before mutation. A failed transaction still restores its exact frozen
+prior Management/helper/Web identities; an intentional downgrade to a legacy
+release requires a separately reviewed compatibility procedure.
 
 Project commands owned by this CLI:
 

--- a/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
@@ -130,14 +130,14 @@ describe("local upgrade download trust boundary", () => {
         expect(completed).toBe(true);
     });
 
-    test("rejects a downloaded artifact whose signed digest no longer matches", () => {
+    test("rejects a tampered target Management runner at the signed bundle boundary", () => {
         const directory = mkdtempSync(join(tmpdir(), "supacloud-admin-artifact-"));
-        const artifactPath = join(directory, "artifact.bin");
+        const artifactPath = join(directory, "supacloud-linux-amd64");
         const contents = "verified release artifact";
         writeFileSync(artifactPath, contents);
         const manifest = {
             artifacts: [{
-                name: "artifact.bin",
+                name: "supacloud-linux-amd64",
                 size: Buffer.byteLength(contents),
                 sha256: createHash("sha256").update(contents).digest("hex"),
             }],

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -314,6 +314,7 @@ describe("local upgrade remote runner", () => {
         expect(script).toContain("--asset-bundle-dir \"$BUNDLE\"");
         expect(script).toContain("--target-version '0.50.31'");
         expect(script).toContain("--edge-runtime-version '0.16.8'");
+        expect(script).toContain('timeout 5s "$RUNNER" --systemd-unit-helper-sha256');
         expect(script).toContain("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE");
         expect(script).toContain("SUPACLOUD_ATTESTATION_TRUSTED_ROOT");
         expect(script).not.toContain("verify_manifest()");

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -352,6 +352,7 @@ function upgradeScriptExecution(
         "install -m 0755 \"$RUNNER_ASSET\" \"$RUNNER\"",
         "test \"$(sha256sum \"$RUNNER\"|awk '{print $1}')\" = \"$(sha256sum \"$RUNNER_ASSET\"|awk '{print $1}')\"",
         "\"$RUNNER\" --version | grep -Eq \"(^|[^0-9])${MANAGEMENT_VERSION//./\\.}([^0-9]|$)\"",
+        "timeout 5s \"$RUNNER\" --systemd-unit-helper-sha256 | grep -Eq 'SupaCloud systemd-unit helper SHA-256: [0-9a-f]{64}'",
         `env PATH=\"$VERIFIER_PATH:$PATH\" \"$RUNNER\" upgrade --yes --target-version ${quoteShell(request.managementVersion)} --edge-runtime-version ${quoteShell(request.edgeRuntimeVersion)} --asset-bundle-dir \"$BUNDLE\"`,
     ];
 }

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -564,12 +564,11 @@ function rootScriptThroughHelperSource(rootScript: string, continuationPath: str
 function rootScriptThroughBootstrap(rootScript: string, continuationPath: string): string {
     const scriptLines = rootScript.split("\n");
     const stagedSetupIndex = scriptLines.indexOf("STAGED_MANAGEMENT=''");
-    const stagedRunnerIndex = scriptLines.indexOf('  UPGRADE_RUNNER="$STAGED_MANAGEMENT"');
-    const bootstrapEndIndex = scriptLines.indexOf("fi", stagedRunnerIndex);
-    if (stagedSetupIndex < 0 || stagedRunnerIndex < stagedSetupIndex || bootstrapEndIndex < stagedRunnerIndex) {
+    const stagedRunnerIndex = scriptLines.indexOf('UPGRADE_RUNNER="$STAGED_MANAGEMENT"');
+    if (stagedSetupIndex < 0 || stagedRunnerIndex < stagedSetupIndex) {
         throw new Error("Root upgrade script lacks Management bootstrap boundaries");
     }
-    return [scriptLines[0], ...scriptLines.slice(stagedSetupIndex, bootstrapEndIndex + 1),
+    return [scriptLines[0], ...scriptLines.slice(stagedSetupIndex, stagedRunnerIndex + 1),
         `touch '${continuationPath}'`].join("\n");
 }
 
@@ -754,12 +753,45 @@ describe("ssh admin tool", () => {
         expect(() => tool.parse({ action: "upgrade", artifact_transport: "automatic" })).toThrow();
     });
 
-    test("remote artifact transport uses the host-wide upgrade lock", () => {
-        const rootScript = buildRootUpgradeScript({ helperPath: "/tmp/release-assets.sh" });
+    test("remote artifact transport uses the host-wide lock and exact target runner", () => {
+        const rootScript = buildRootUpgradeScript({
+            helperPath: "/tmp/release-assets.sh",
+            version: "0.60.1",
+        });
 
         expect(rootScript).toContain("/run/lock/supacloud-upgrade.lock");
         expect(rootScript).toContain("flock -E 75 -n 9");
         expect(rootScript).toContain("Another SupaCloud upgrade is already running");
+        expect(rootScript).toContain("supacloud_fetch_component_release management-api '0.60.1'");
+        expect(rootScript).toContain('UPGRADE_RUNNER="$STAGED_MANAGEMENT"');
+        expect(rootScript).toContain('"$STAGED_MANAGEMENT" --systemd-unit-helper-sha256');
+        expect(rootScript).not.toContain('UPGRADE_RUNNER=\'/usr/local/bin/supacloud\'');
+    });
+
+    test("remote latest resolution pins the transaction to the bootstrap target version", () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-admin-target-version-"));
+        const runner = join(directory, "target-runner");
+        try {
+            writeFileSync(runner, "#!/bin/sh\nprintf '%s' \"$SUPACLOUD_UPGRADE_TAG\"\n", { mode: 0o755 });
+            chmodSync(runner, 0o755);
+            const rootScript = buildRootUpgradeScript({ helperPath: "/tmp/release-assets.sh" });
+            const transaction = rootScript.trim().split("\n").at(-1);
+            if (!transaction) throw new Error("Generated upgrade script has no transaction command");
+            const execution = Bun.spawnSync(["bash", "-c", [
+                "set -euo pipefail",
+                "TARGET_MANAGEMENT_VERSION=0.60.1",
+                `UPGRADE_RUNNER=${JSON.stringify(runner)}`,
+                "SUPACLOUD_UPGRADE_TAG=0.60.2",
+                transaction,
+            ].join("\n")]);
+
+            expect(rootScript).toContain("supacloud_fetch_component_release management-api 'latest'");
+            expect(transaction).toContain('SUPACLOUD_UPGRADE_TAG="$TARGET_MANAGEMENT_VERSION"');
+            expect(execution.exitCode).toBe(0);
+            expect(execution.stdout.toString()).toBe("0.60.1");
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
     });
 
     test("remote component preflight preserves the full Edge Runtime mode and rejects suffixes", () => {
@@ -1019,7 +1051,7 @@ describe("ssh admin tool", () => {
         const ssh = new FakeSsh();
         const tool = captureSshTool(ssh);
 
-        await tool.invoke({ action: "upgrade", version: "0.50.27", edge_runtime_version: "0.16.7" });
+        await tool.invoke({ action: "upgrade", version: "0.60.1", edge_runtime_version: "0.16.7" });
 
         expect(ssh.commands).toHaveLength(3);
         const command = ssh.commands[1] ?? "";
@@ -1044,11 +1076,12 @@ describe("ssh admin tool", () => {
         expect(createHash("sha256").update(trustedRootUpload?.content ?? "").digest("hex"))
             .toBe(SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_SHA256);
         expect(command).toContain("supacloud_install_pinned_gh");
-        expect(command).toContain("/usr/local/bin/supacloud --version");
-        expect(command).toContain("0.50.27");
+        expect(command).not.toContain("/usr/local/bin/supacloud --version");
+        expect(command).toContain("0.60.1");
         expect(command).toContain("supacloud_fetch_component_release");
         expect(command).toContain("supacloud_download_release_asset");
         expect(command).toContain('chmod 0755 "$STAGED_MANAGEMENT"');
+        expect(command).toContain('"$STAGED_MANAGEMENT" --systemd-unit-helper-sha256');
         expect(command).toContain("SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG=");
         expect(command).toContain("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE");
         expect(command).toContain("SUPACLOUD_ATTESTATION_TRUSTED_ROOT");
@@ -1059,7 +1092,7 @@ describe("ssh admin tool", () => {
         expect(command).toContain("/tmp/.supacloud-release-assets-");
         expect(command).not.toMatch(/\/usr\/local\/bin\/supacloud upgrade --yes/);
         const rootScript = buildRootUpgradeScript({
-            version: "0.50.27",
+            version: "0.60.1",
             edgeRuntimeVersion: "0.16.7",
             helperPath: ssh.uploads[0]?.remotePath ?? "",
         });

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -233,30 +233,28 @@ type UpgradeRequest = {
     helperPath: string;
 };
 
-function upgradeEnvAssignments(request: UpgradeRequest): string {
+function upgradeTransactionEnvAssignments(request: UpgradeRequest): string {
     return [
-        request.version ? `SUPACLOUD_UPGRADE_TAG=${quoteEnvValue(request.version)}` : "",
+        'SUPACLOUD_UPGRADE_TAG="$TARGET_MANAGEMENT_VERSION"',
         request.edgeRuntimeVersion ? `SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG=${quoteEnvValue(request.edgeRuntimeVersion)}` : "",
         request.githubProxy ? `SUPACLOUD_GITHUB_PROXY=${quoteEnvValue(request.githubProxy)}` : "",
     ].filter(Boolean).join(" ");
 }
 
 function componentBootstrapCommands(request: UpgradeRequest): string[] {
-    if (!request.edgeRuntimeVersion) return [`UPGRADE_RUNNER=${quoteEnvValue("/usr/local/bin/supacloud")}`];
     const managementVersion = request.version || "latest";
     return [
-        `ACTIVE_VERSION=$(/usr/local/bin/supacloud --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
-        `UPGRADE_RUNNER=${quoteEnvValue("/usr/local/bin/supacloud")}`,
-        `if ! supacloud_version_at_least "$ACTIVE_VERSION" ${quoteEnvValue(MINIMUM_COMPONENT_UPGRADE_VERSION)}; then`,
-        `  case "$(uname -m)" in x86_64|amd64) MANAGEMENT_ASSET=supacloud-linux-amd64 ;; aarch64|arm64) MANAGEMENT_ASSET=supacloud-linux-arm64 ;; *) echo 'Unsupported Management architecture' >&2; exit 1 ;; esac`,
-        `  STAGED_MANAGEMENT=$(mktemp /tmp/supacloud-management-upgrade.XXXXXX)`,
-        `  MANAGEMENT_RELEASE=$(supacloud_fetch_component_release management-api ${quoteEnvValue(managementVersion)} "$MANAGEMENT_ASSET" web-console-build.tar.gz)`,
-        `  supacloud_download_release_asset "$MANAGEMENT_RELEASE" "$MANAGEMENT_ASSET" "$STAGED_MANAGEMENT" binary`,
-        `  chmod 0755 "$STAGED_MANAGEMENT"`,
-        `  STAGED_VERSION=$("$STAGED_MANAGEMENT" --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
-        `  supacloud_version_at_least "$STAGED_VERSION" ${quoteEnvValue(MINIMUM_COMPONENT_UPGRADE_VERSION)} || { echo 'Target Management release lacks Edge Runtime transaction capability' >&2; exit 1; }`,
-        `  UPGRADE_RUNNER="$STAGED_MANAGEMENT"`,
-        "fi",
+        `case "$(uname -m)" in x86_64|amd64) MANAGEMENT_ASSET=supacloud-linux-amd64 ;; aarch64|arm64) MANAGEMENT_ASSET=supacloud-linux-arm64 ;; *) echo 'Unsupported Management architecture' >&2; exit 1 ;; esac`,
+        `STAGED_MANAGEMENT=$(mktemp /tmp/supacloud-management-upgrade.XXXXXX)`,
+        `MANAGEMENT_RELEASE=$(supacloud_fetch_component_release management-api ${quoteEnvValue(managementVersion)} "$MANAGEMENT_ASSET" web-console-build.tar.gz)`,
+        `supacloud_download_release_asset "$MANAGEMENT_RELEASE" "$MANAGEMENT_ASSET" "$STAGED_MANAGEMENT" binary`,
+        `chmod 0755 "$STAGED_MANAGEMENT"`,
+        `TARGET_MANAGEMENT_VERSION=$(jq -er '.tag_name | capture("^management-api-v(?<version>(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$").version' <<< "$MANAGEMENT_RELEASE")`,
+        `STAGED_VERSION=$("$STAGED_MANAGEMENT" --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
+        `test "$STAGED_VERSION" = "$TARGET_MANAGEMENT_VERSION" || { echo 'Target Management binary version does not match its verified release' >&2; exit 1; }`,
+        `supacloud_version_at_least "$STAGED_VERSION" ${quoteEnvValue(MINIMUM_COMPONENT_UPGRADE_VERSION)} || { echo 'Target Management release lacks component transaction capability' >&2; exit 1; }`,
+        `"$STAGED_MANAGEMENT" --systemd-unit-helper-sha256 >/dev/null 2>&1 || { echo 'Target Management release lacks target-bound systemd-unit helper delivery' >&2; exit 1; }`,
+        `UPGRADE_RUNNER="$STAGED_MANAGEMENT"`,
     ];
 }
 
@@ -298,7 +296,7 @@ function trustedRootPreflightCommands(helperPath: string): string[] {
 }
 
 export function buildRootUpgradeScript(request: UpgradeRequest): string {
-    const envAssignments = upgradeEnvAssignments(request);
+    const envAssignments = upgradeTransactionEnvAssignments(request);
     return [
         "set -euo pipefail",
         "umask 077",
@@ -321,7 +319,7 @@ export function buildRootUpgradeScript(request: UpgradeRequest): string {
         "if ! supacloud_attestation_verifier_available; then supacloud_install_pinned_gh /usr/local/bin/gh; fi",
         "supacloud_attestation_verifier_available || { echo 'Pinned GitHub attestation verifier is unavailable' >&2; exit 1; }",
         ...componentBootstrapCommands(request),
-        `${envAssignments ? `env ${envAssignments} ` : ""}"$UPGRADE_RUNNER" upgrade --yes`,
+        `env ${envAssignments} "$UPGRADE_RUNNER" upgrade --yes`,
     ].join("\n");
 }
 

--- a/packages/management-api/src/embedded-systemd-unit-broker.ts
+++ b/packages/management-api/src/embedded-systemd-unit-broker.ts
@@ -1,0 +1,388 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fchmodSync,
+  fchownSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import systemdUnitBrokerSource from "../../../scripts/lib/systemd_unit_broker.sh" with { type: "text" };
+
+export const SYSTEMD_UNIT_BROKER_TARGET = "/usr/local/libexec/supacloud/systemd-unit";
+export const EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE = systemdUnitBrokerSource;
+export const EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256 = createHash("sha256")
+  .update(Buffer.from(systemdUnitBrokerSource, "utf8"))
+  .digest("hex");
+
+export type PrivilegedHelperOwner = {
+  uid: number;
+  gid: number;
+};
+
+export type PrivilegedHelperIdentity = PrivilegedHelperOwner & {
+  content: Buffer;
+  dev: number;
+  ino: number;
+  mode: number;
+  sha256: string;
+};
+
+export type StagedPrivilegedHelper = {
+  path: string;
+  sha256: string;
+};
+
+export type PrivilegedHelperActivationState = {
+  targetPath: string;
+  backupPath: string;
+  previous: PrivilegedHelperIdentity;
+  activatedIdentity: PrivilegedHelperIdentity;
+  backupReady: boolean;
+  activated: boolean;
+};
+
+export type PrepareSystemdUnitBrokerActivationRequest = {
+  staged: StagedPrivilegedHelper;
+  targetPath?: string;
+  runId?: string;
+  owner?: PrivilegedHelperOwner;
+  expectedPrevious?: PrivilegedHelperIdentity;
+};
+
+export type PreparedSystemdUnitBrokerActivation = {
+  owner: PrivilegedHelperOwner;
+  parent: string;
+  staged: StagedPrivilegedHelper;
+  state: PrivilegedHelperActivationState;
+};
+
+export type SystemdUnitBrokerActivationOperations = {
+  restore: (state: PrivilegedHelperActivationState, owner: PrivilegedHelperOwner) => void;
+  syncDirectory: (directory: string) => void;
+  verifyInstalled: (targetPath: string, owner: PrivilegedHelperOwner) => PrivilegedHelperIdentity;
+};
+
+function sha256(content: Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function assertOwner(uid: number, gid: number, owner: PrivilegedHelperOwner, label: string): void {
+  if (uid !== owner.uid || gid !== owner.gid) {
+    throw new Error(`${label} must be owned by uid ${owner.uid} and gid ${owner.gid}`);
+  }
+}
+
+function assertDirectRegularFile(
+  filePath: string,
+  owner: PrivilegedHelperOwner,
+  expectedMode: number,
+  label: string,
+): void {
+  const stats = lstatSync(filePath);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1) {
+    throw new Error(`${label} must be a direct regular file with one link`);
+  }
+  assertOwner(stats.uid, stats.gid, owner, label);
+  if ((stats.mode & 0o7777) !== expectedMode) {
+    throw new Error(`${label} mode must be exactly 0${expectedMode.toString(8)}`);
+  }
+}
+
+export function readPrivilegedHelperIdentity(
+  filePath: string,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+  expectedMode = 0o755,
+): PrivilegedHelperIdentity {
+  if (!existsSync(filePath)) throw new Error(`Privileged systemd-unit helper is missing: ${filePath}`);
+  assertDirectRegularFile(filePath, owner, expectedMode, "Privileged systemd-unit helper");
+
+  const before = lstatSync(filePath);
+  const descriptor = openSync(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = fstatSync(descriptor);
+    if (opened.dev !== before.dev || opened.ino !== before.ino || !opened.isFile() || opened.nlink !== 1) {
+      throw new Error("Privileged systemd-unit helper changed during identity capture");
+    }
+    assertOwner(opened.uid, opened.gid, owner, "Privileged systemd-unit helper");
+    if ((opened.mode & 0o7777) !== expectedMode) {
+      throw new Error(`Privileged systemd-unit helper mode must be exactly 0${expectedMode.toString(8)}`);
+    }
+    const content = readFileSync(descriptor);
+    const after = fstatSync(descriptor);
+    if (after.dev !== opened.dev || after.ino !== opened.ino || after.size !== content.length
+      || after.mtimeMs !== opened.mtimeMs || after.ctimeMs !== opened.ctimeMs) {
+      throw new Error("Privileged systemd-unit helper changed while it was read");
+    }
+    return {
+      content,
+      dev: opened.dev,
+      ino: opened.ino,
+      uid: opened.uid,
+      gid: opened.gid,
+      mode: opened.mode & 0o7777,
+      sha256: sha256(content),
+    };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function assertDirectParentDirectory(filePath: string, owner: PrivilegedHelperOwner): string {
+  const parent = path.dirname(filePath);
+  const stats = lstatSync(parent);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error("Privileged systemd-unit helper parent must be a direct directory");
+  }
+  assertOwner(stats.uid, stats.gid, owner, "Privileged systemd-unit helper parent");
+  if ((stats.mode & 0o022) !== 0) {
+    throw new Error("Privileged systemd-unit helper parent must not be group- or world-writable");
+  }
+  return parent;
+}
+
+function writeExclusiveFile(
+  filePath: string,
+  content: Buffer,
+  mode: number,
+  owner: PrivilegedHelperOwner,
+): void {
+  const descriptor = openSync(
+    filePath,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    writeFileSync(descriptor, content);
+    fchmodSync(descriptor, mode);
+    fchownSync(descriptor, owner.uid, owner.gid);
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+  assertDirectRegularFile(filePath, owner, mode, "Staged privileged systemd-unit helper");
+}
+
+function fsyncDirectory(directory: string): void {
+  const descriptor = openSync(directory, constants.O_RDONLY);
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+export function stageEmbeddedSystemdUnitBroker(
+  targetPath = SYSTEMD_UNIT_BROKER_TARGET,
+  runId = randomUUID(),
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+): StagedPrivilegedHelper {
+  assertDirectParentDirectory(targetPath, owner);
+  const stagedPath = `${targetPath}.new-${runId}`;
+  const content = Buffer.from(EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE, "utf8");
+  try {
+    writeExclusiveFile(stagedPath, content, 0o755, owner);
+    const staged = readPrivilegedHelperIdentity(stagedPath, owner);
+    if (staged.sha256 !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
+      throw new Error("Staged privileged systemd-unit helper digest does not match the embedded helper");
+    }
+    return { path: stagedPath, sha256: staged.sha256 };
+  } catch (error: unknown) {
+    rmSync(stagedPath, { force: true });
+    throw error;
+  }
+}
+
+function sameHelperIdentity(
+  left: PrivilegedHelperIdentity,
+  right: PrivilegedHelperIdentity,
+): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.uid === right.uid
+    && left.gid === right.gid
+    && left.mode === right.mode
+    && left.sha256 === right.sha256;
+}
+
+function frozenPreviousIdentity(
+  current: PrivilegedHelperIdentity,
+  expected?: PrivilegedHelperIdentity,
+): PrivilegedHelperIdentity {
+  if (expected && !sameHelperIdentity(current, expected)) {
+    throw new Error("Privileged systemd-unit helper changed after upgrade preflight");
+  }
+  return expected ?? current;
+}
+
+function createHelperActivationState(
+  targetPath: string,
+  runId: string,
+  previous: PrivilegedHelperIdentity,
+  activatedIdentity: PrivilegedHelperIdentity,
+): PrivilegedHelperActivationState {
+  return {
+    targetPath,
+    backupPath: `${targetPath}.bak-${runId}`,
+    previous,
+    activatedIdentity,
+    backupReady: false,
+    activated: false,
+  };
+}
+
+function assertStagedHelperIdentity(
+  staged: StagedPrivilegedHelper,
+  owner: PrivilegedHelperOwner,
+): PrivilegedHelperIdentity {
+  const identity = readPrivilegedHelperIdentity(staged.path, owner);
+  if (identity.sha256 !== staged.sha256 || identity.sha256 !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
+    throw new Error("Staged privileged systemd-unit helper identity changed before activation");
+  }
+  return identity;
+}
+
+function backupPreviousHelper(
+  state: PrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+): void {
+  writeExclusiveFile(state.backupPath, state.previous.content, state.previous.mode, owner);
+  const backup = readPrivilegedHelperIdentity(state.backupPath, owner, state.previous.mode);
+  if (backup.sha256 !== state.previous.sha256) {
+    throw new Error("Privileged systemd-unit helper rollback backup digest mismatch");
+  }
+  state.backupReady = true;
+}
+
+function assertActivationTargetUnchanged(
+  state: PrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+): void {
+  const current = readPrivilegedHelperIdentity(state.targetPath, owner, state.previous.mode);
+  if (!sameHelperIdentity(current, state.previous)) {
+    throw new Error("Privileged systemd-unit helper changed before atomic activation");
+  }
+}
+
+function rethrowAfterActivationRecovery(
+  error: unknown,
+  state: PrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+  restore: SystemdUnitBrokerActivationOperations["restore"],
+): never {
+  if (!state.activated) throw error;
+  try {
+    restore(state, owner);
+  } catch (rollbackError: unknown) {
+    throw new AggregateError(
+      [error, rollbackError],
+      "Privileged systemd-unit helper activation and rollback both failed",
+    );
+  }
+  throw error;
+}
+
+export function prepareSystemdUnitBrokerActivation(
+  request: PrepareSystemdUnitBrokerActivationRequest,
+): PreparedSystemdUnitBrokerActivation {
+  const targetPath = request.targetPath ?? SYSTEMD_UNIT_BROKER_TARGET;
+  const runId = request.runId ?? randomUUID();
+  const owner = request.owner ?? { uid: 0, gid: 0 };
+  const parent = assertDirectParentDirectory(targetPath, owner);
+  const current = readPrivilegedHelperIdentity(targetPath, owner);
+  const previous = frozenPreviousIdentity(current, request.expectedPrevious);
+  const activatedIdentity = assertStagedHelperIdentity(request.staged, owner);
+  const state = createHelperActivationState(targetPath, runId, previous, activatedIdentity);
+
+  try {
+    backupPreviousHelper(state, owner);
+    return { owner, parent, staged: request.staged, state };
+  } catch (error: unknown) {
+    rmSync(state.backupPath, { force: true });
+    throw error;
+  }
+}
+
+export function activatePreparedSystemdUnitBroker(
+  prepared: PreparedSystemdUnitBrokerActivation,
+  operations: SystemdUnitBrokerActivationOperations = {
+    restore: restoreSystemdUnitBroker,
+    syncDirectory: fsyncDirectory,
+    verifyInstalled: verifyInstalledSystemdUnitBroker,
+  },
+): PrivilegedHelperActivationState {
+  const { owner, parent, staged, state } = prepared;
+  try {
+    const stagedIdentity = assertStagedHelperIdentity(staged, owner);
+    if (!sameHelperIdentity(stagedIdentity, state.activatedIdentity)) {
+      throw new Error("Staged privileged systemd-unit helper changed after activation preparation");
+    }
+    assertActivationTargetUnchanged(state, owner);
+    renameSync(staged.path, state.targetPath);
+    state.activated = true;
+    operations.syncDirectory(parent);
+    const installed = operations.verifyInstalled(state.targetPath, owner);
+    if (!sameHelperIdentity(installed, state.activatedIdentity)) {
+      throw new Error("Installed privileged systemd-unit helper identity changed during activation");
+    }
+    return state;
+  } catch (error: unknown) {
+    rethrowAfterActivationRecovery(error, state, owner, operations.restore);
+  }
+}
+
+export function verifyInstalledSystemdUnitBroker(
+  targetPath = SYSTEMD_UNIT_BROKER_TARGET,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+): PrivilegedHelperIdentity {
+  const identity = readPrivilegedHelperIdentity(targetPath, owner);
+  if (identity.sha256 !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
+    throw new Error("Installed privileged systemd-unit helper digest does not match the Management release");
+  }
+  return identity;
+}
+
+export function restoreSystemdUnitBroker(
+  state: PrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+): void {
+  if (!state.activated) return;
+  if (!state.backupReady || !existsSync(state.backupPath)) {
+    throw new Error("Privileged systemd-unit helper rollback backup is unavailable");
+  }
+  const backup = readPrivilegedHelperIdentity(state.backupPath, owner, state.previous.mode);
+  if (backup.sha256 !== state.previous.sha256) {
+    throw new Error("Privileged systemd-unit helper rollback backup changed");
+  }
+  const activated = readPrivilegedHelperIdentity(state.targetPath, owner, state.activatedIdentity.mode);
+  if (!sameHelperIdentity(activated, state.activatedIdentity)) {
+    throw new Error("Activated privileged systemd-unit helper changed before rollback");
+  }
+
+  const parent = assertDirectParentDirectory(state.targetPath, owner);
+  const restorePath = `${state.targetPath}.restore-${randomUUID()}`;
+  try {
+    writeExclusiveFile(restorePath, backup.content, state.previous.mode, owner);
+    renameSync(restorePath, state.targetPath);
+    fsyncDirectory(parent);
+    const restored = readPrivilegedHelperIdentity(state.targetPath, owner, state.previous.mode);
+    if (restored.sha256 !== state.previous.sha256) {
+      throw new Error("Privileged systemd-unit helper rollback read-back failed");
+    }
+    state.activated = false;
+  } finally {
+    rmSync(restorePath, { force: true });
+  }
+}
+
+export function cleanupSystemdUnitBrokerBackup(state: PrivilegedHelperActivationState): void {
+  rmSync(state.backupPath, { force: true });
+}

--- a/packages/management-api/src/services/postgrest-systemd-template.ts
+++ b/packages/management-api/src/services/postgrest-systemd-template.ts
@@ -1,0 +1,45 @@
+import path from "node:path";
+
+export type PostgrestSystemdTemplateOptions = {
+  postgrestRts: string;
+  postgrestBinary: string;
+  tenantConfigDir: string;
+  memoryMax: string;
+  cpuWeight: number;
+};
+
+export function renderPostgrestSystemdTemplate(options: PostgrestSystemdTemplateOptions): string {
+  return `
+[Unit]
+Description=SupaCloud PostgREST for tenant %i
+Documentation=https://github.com/supacloud/supacloud
+After=network.target patroni.service
+Wants=patroni.service
+
+[Service]
+Type=simple
+User=supacloud-%i
+Group=supacloud-%i
+Environment="GHCRTS=${options.postgrestRts}"
+Environment="SUPACLOUD_POSTGREST_BIN=${options.postgrestBinary}"
+Environment="SUPACLOUD_POSTGREST_CONFIG_DIR=${options.tenantConfigDir}"
+Environment="SUPACLOUD_POSTGREST_CONFIG_TRUST_ROOT=${path.dirname(options.tenantConfigDir)}"
+Environment="SUPACLOUD_POSTGREST_BINARY_TRUST_ROOT=${path.dirname(path.dirname(options.postgrestBinary))}"
+Environment="SUPACLOUD_POSTGREST_CONTROL_UID=0"
+ExecStart=/usr/local/libexec/supacloud/postgrest-launcher %i +RTS ${options.postgrestRts} -RTS
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=3
+StartLimitIntervalSec=60
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadOnlyPaths=${options.tenantConfigDir}
+MemoryMax=${options.memoryMax}
+CPUWeight=${options.cpuWeight}
+
+[Install]
+WantedBy=multi-user.target
+`.trim();
+}

--- a/packages/management-api/src/services/systemd-unit-broker.ts
+++ b/packages/management-api/src/services/systemd-unit-broker.ts
@@ -97,8 +97,10 @@ function validateDirective(unitName: string, state: UnitPolicyState, line: strin
 }
 
 function validateUnitIdentity(unitName: string, state: UnitPolicyState): void {
+  const requiresEnvironmentFile = unitName !== "supacloud-pgrst@.service";
   if (!["Unit", "Service", "Install"].every((required) => state.sections.has(required))
-    || !state.user || state.user !== state.group || !state.noNewPrivileges || !state.environmentFile) {
+    || !state.user || state.user !== state.group || !state.noNewPrivileges
+    || (requiresEnvironmentFile && !state.environmentFile)) {
     throw new Error(`Systemd unit ${unitName} is missing its non-root runtime identity`);
   }
   if (unitName.includes("@") && state.user !== "supacloud-%i") {

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -49,6 +49,7 @@ import { authConfigChangesPostgrestVerifier } from "./auth-runtime-impact";
 import { runtimeCacheService } from "./runtime-cache.service";
 import { projectControlSecretsService } from "./project-control-secrets.service";
 import { installManagedSystemdUnit } from "./systemd-unit-broker";
+import { renderPostgrestSystemdTemplate } from "./postgrest-systemd-template";
 import {
     PostgrestPoolReconcileError,
     PostgrestPoolMigrationGate,
@@ -1824,39 +1825,13 @@ GOTRUE_MAILER_URLPATHS_EMAIL_CHANGE=/auth/v1/verify
             || !currentPgrstUnit.includes("/usr/local/libexec/supacloud/postgrest-launcher %i")
             || currentPgrstUnit.includes(`EnvironmentFile=${this.TENANT_CONFIG_DIR}/%i.env`);
         if (shouldWritePgrstUnit) {
-            const pgrstUnit = `
-[Unit]
-Description=SupaCloud PostgREST for tenant %i
-Documentation=https://github.com/supacloud/supacloud
-After=network.target patroni.service
-Wants=patroni.service
-
-[Service]
-Type=simple
-User=supacloud-%i
-Group=supacloud-%i
-Environment="GHCRTS=${this.POSTGREST_RTS}"
-Environment="SUPACLOUD_POSTGREST_BIN=${this.POSTGREST_BIN}"
-Environment="SUPACLOUD_POSTGREST_CONFIG_DIR=${this.TENANT_CONFIG_DIR}"
-Environment="SUPACLOUD_POSTGREST_CONFIG_TRUST_ROOT=${path.dirname(this.TENANT_CONFIG_DIR)}"
-Environment="SUPACLOUD_POSTGREST_BINARY_TRUST_ROOT=${path.dirname(path.dirname(this.POSTGREST_BIN))}"
-Environment="SUPACLOUD_POSTGREST_CONTROL_UID=0"
-ExecStart=/usr/local/libexec/supacloud/postgrest-launcher %i +RTS ${this.POSTGREST_RTS} -RTS
-Restart=on-failure
-RestartSec=5
-StartLimitBurst=3
-StartLimitIntervalSec=60
-
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=true
-ReadOnlyPaths=${this.TENANT_CONFIG_DIR}
-MemoryMax=${this.POSTGREST_MEMORY_MAX}
-CPUWeight=${this.POSTGREST_CPU_WEIGHT}
-
-[Install]
-WantedBy=multi-user.target
-`.trim();
+            const pgrstUnit = renderPostgrestSystemdTemplate({
+                postgrestRts: this.POSTGREST_RTS,
+                postgrestBinary: this.POSTGREST_BIN,
+                tenantConfigDir: this.TENANT_CONFIG_DIR,
+                memoryMax: this.POSTGREST_MEMORY_MAX,
+                cpuWeight: this.POSTGREST_CPU_WEIGHT,
+            });
             await installManagedSystemdUnit("supacloud-pgrst@.service", pgrstUnit);
         }
 

--- a/packages/management-api/src/standalone.ts
+++ b/packages/management-api/src/standalone.ts
@@ -5,10 +5,17 @@ export function isStandaloneVersionCommand(args: string[]): boolean {
   return args.length === 1 && (args[0] === "--version" || args[0] === "-v");
 }
 
+export function isSystemdUnitBrokerDigestCommand(args: string[]): boolean {
+  return args.length === 1 && args[0] === "--systemd-unit-helper-sha256";
+}
+
 if (import.meta.main) {
   const args = process.argv.slice(2);
   if (isStandaloneVersionCommand(args)) {
     logger.info(`SupaCloud Version: ${pkg.version}`);
+  } else if (isSystemdUnitBrokerDigestCommand(args)) {
+    const { EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256 } = await import("./embedded-systemd-unit-broker");
+    logger.info(`SupaCloud systemd-unit helper SHA-256: ${EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256}`);
   } else {
     const { startManagementApi } = await import("./index");
     startManagementApi();

--- a/packages/management-api/src/types/shell.d.ts
+++ b/packages/management-api/src/types/shell.d.ts
@@ -1,0 +1,4 @@
+declare module "*.sh" {
+  const source: string;
+  export default source;
+}

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -2,7 +2,26 @@ import { $, SQL } from "bun";
 import * as p from "@clack/prompts";
 import os from "node:os";
 import path from "node:path";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, readlinkSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+    chmodSync,
+    chownSync,
+    closeSync,
+    constants,
+    copyFileSync,
+    existsSync,
+    fsyncSync,
+    lstatSync,
+    mkdirSync,
+    openSync,
+    readFileSync,
+    readlinkSync,
+    readdirSync,
+    renameSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
 import { logger } from "./utils/logger";
 import { WEB_CONSOLE_CURRENT_DIR } from "./utils/web-console-path";
@@ -23,6 +42,20 @@ import {
     SUPACLOUD_UPGRADE_LOCK_PATH,
 } from "./upgrade-lock";
 import { withSigstoreVerificationDirectory } from "./sigstore-trusted-root";
+import {
+    EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256,
+    SYSTEMD_UNIT_BROKER_TARGET,
+    activatePreparedSystemdUnitBroker,
+    cleanupSystemdUnitBrokerBackup,
+    prepareSystemdUnitBrokerActivation,
+    restoreSystemdUnitBroker,
+    readPrivilegedHelperIdentity,
+    stageEmbeddedSystemdUnitBroker,
+    verifyInstalledSystemdUnitBroker,
+    type PrivilegedHelperActivationState,
+    type PrivilegedHelperIdentity,
+    type StagedPrivilegedHelper,
+} from "./embedded-systemd-unit-broker";
 
 const RELEASES_API = "https://api.github.com/repos/zuohuadong/supacloud/releases";
 const BIN_TARGET = "/usr/local/bin/supacloud";
@@ -41,6 +74,8 @@ const DEFAULT_EDGE_RUNTIME_ENV_FILE = "/etc/supabase/edge-runtime.env";
 const LEGACY_CONFIG_FILE = "/opt/supacloud/config.env";
 const DEFAULT_GITHUB_PROXY = "https://ghproxy.net/";
 const WEB_CONSOLE_ASSET = "web-console-build.tar.gz";
+const WEB_CONSOLE_MAX_ENTRIES = 10_000;
+const WEB_CONSOLE_MAX_EXTRACTED_BYTES = 256 * 1024 * 1024;
 const WEB_CONSOLE_ROOT = "/opt/supacloud/web-console";
 const WEB_CONSOLE_RELEASES_DIR = `${WEB_CONSOLE_ROOT}/releases`;
 const WEB_CONSOLE_CURRENT_LINK = WEB_CONSOLE_CURRENT_DIR;
@@ -58,7 +93,7 @@ const OFFLINE_BUNDLE_ENDPOINT: GithubEndpoint = {
     proxyPrefix: "",
 };
 
-type GithubEndpoint = {
+export type GithubEndpoint = {
     label: string;
     proxyPrefix: string;
 };
@@ -518,16 +553,65 @@ export async function verifyActivatedSystemdBinary(
     return snapshot;
 }
 
-export function validateWebConsoleArchiveEntries(entriesText: string) {
-    const entries = entriesText.split(/\r?\n/).filter(Boolean);
-    for (const entry of entries) {
-        if (entry.startsWith("/") || entry.split("/").includes("..")) {
-            throw new Error(`Web Console archive contains an unsafe path: ${entry}`);
+export type WebConsoleArchiveInventory = {
+    directories: string[];
+    files: string[];
+};
+
+function normalizeWebConsoleArchiveEntry(entry: string): { path: string; directory: boolean } | null {
+    if (!entry || entry.length > 1024 || /[\u0000-\u001f\u007f]/.test(entry)
+        || entry.includes("\\") || entry.startsWith("/")) {
+        throw new Error(`Web Console archive contains an unsafe path: ${entry}`);
+    }
+    const directory = entry.endsWith("/");
+    const withoutTrailingSlash = directory ? entry.slice(0, -1) : entry;
+    const normalized = withoutTrailingSlash.replace(/^(?:\.\/)+/, "");
+    if (!normalized || normalized === ".") return null;
+    const segments = normalized.split("/");
+    if (segments.length > 32 || segments.some(segment => !segment || segment === "." || segment === "..")) {
+        throw new Error(`Web Console archive contains an unsafe path: ${entry}`);
+    }
+    return { path: segments.join("/"), directory };
+}
+
+export function validateWebConsoleArchiveEntries(entriesText: string): WebConsoleArchiveInventory {
+    const directories = new Set<string>();
+    const files = new Set<string>();
+    const explicitEntries = new Set<string>();
+    const listedEntries = entriesText.split(/\r?\n/).filter(Boolean);
+    if (listedEntries.length > WEB_CONSOLE_MAX_ENTRIES) {
+        throw new Error("Web Console archive contains too many entries");
+    }
+    for (const entry of listedEntries) {
+        const normalized = normalizeWebConsoleArchiveEntry(entry);
+        if (!normalized) continue;
+        if (explicitEntries.has(normalized.path)) {
+            throw new Error(`Web Console archive contains a duplicate path: ${normalized.path}`);
+        }
+        explicitEntries.add(normalized.path);
+        (normalized.directory ? directories : files).add(normalized.path);
+        const segments = normalized.path.split("/");
+        for (let index = 1; index < segments.length; index += 1) {
+            const parent = segments.slice(0, index).join("/");
+            if (files.has(parent)) {
+                throw new Error(`Web Console archive path traverses a file: ${normalized.path}`);
+            }
+            directories.add(parent);
         }
     }
-    if (!entries.some(entry => /(^|\/)index\.html$/.test(entry))) {
+    if (!files.has("index.html")) {
         throw new Error("Web Console archive does not contain index.html");
     }
+    if ([...files].some(file => directories.has(file))) {
+        throw new Error("Web Console archive contains conflicting file and directory paths");
+    }
+    if (directories.size + files.size > WEB_CONSOLE_MAX_ENTRIES) {
+        throw new Error("Web Console archive materializes too many entries");
+    }
+    return {
+        directories: [...directories].sort(),
+        files: [...files].sort(),
+    };
 }
 
 export type UpgradeTransactionOperations = {
@@ -1113,6 +1197,40 @@ export function parseManagementVersionOutput(stdout: string): string {
     return match[1] as string;
 }
 
+export function parseSystemdUnitBrokerDigestOutput(stdout: string): string {
+    const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+    if (lines.length !== 1) throw new Error("Management helper digest output must contain exactly one line");
+    let message = lines[0] as string;
+    if (message.startsWith("{")) {
+        const payload = JSON.parse(message) as { message?: unknown };
+        if (typeof payload.message !== "string") throw new Error("Management helper digest JSON is invalid");
+        message = payload.message;
+    }
+    const match = message.match(/^SupaCloud systemd-unit helper SHA-256: ([0-9a-f]{64})$/);
+    if (!match) throw new Error("Management helper digest output is invalid");
+    return match[1] as string;
+}
+
+async function validateManagementSystemdUnitBroker(filePath: string, binaryName: string): Promise<void> {
+    const smoke = Bun.spawn([filePath, "--systemd-unit-helper-sha256"], { stdout: "pipe", stderr: "pipe" });
+    const timeout = setTimeout(() => smoke.kill("SIGKILL"), 5_000);
+    try {
+        const [exitCode, stdout, stderr] = await Promise.all([
+            smoke.exited,
+            new Response(smoke.stdout).text(),
+            new Response(smoke.stderr).text(),
+        ]);
+        if (exitCode !== 0 || stderr.trim()) {
+            throw new Error(`${binaryName} failed the embedded systemd-unit helper identity check`);
+        }
+        if (parseSystemdUnitBrokerDigestOutput(stdout) !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
+            throw new Error(`${binaryName} embeds an unexpected systemd-unit helper`);
+        }
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
 async function validateManagementBinaryArtifact(filePath: string, binaryName: string, expectedVersion: string) {
     await validateElfBinaryArtifact(filePath, binaryName);
     const smoke = Bun.spawn([filePath, "--version"], { stdout: "pipe", stderr: "pipe" });
@@ -1135,6 +1253,7 @@ async function validateManagementBinaryArtifact(filePath: string, binaryName: st
     if (actualVersion !== expectedVersion) {
         throw new Error(`${binaryName} reports ${actualVersion}; expected ${expectedVersion}`);
     }
+    await validateManagementSystemdUnitBroker(filePath, binaryName);
 }
 
 async function downloadReleaseChecksums(release: GithubRelease, preferredEndpoint: GithubEndpoint, forceYes?: boolean) {
@@ -1214,41 +1333,413 @@ async function stageBundledBinary(request: StageBundledBinaryRequest): Promise<S
 type StagedWebConsole = {
     releaseDir: string;
     endpoint: GithubEndpoint;
+    treeSha256: string;
 };
 
-async function validateWebConsoleArchive(archivePath: string): Promise<void> {
+export type WebConsoleLinkActivationState = {
+    activated: boolean;
+    currentLink: string;
+    nextLink: string;
+    owner: WebConsoleReleaseOwner;
+    parent: string;
+    previousTarget: string | null;
+    target: string;
+};
+
+type WebConsoleReleaseOwner = {
+    uid: number;
+    gid: number;
+};
+
+export type WebConsoleExtractionOptions = {
+    releasesDir?: string;
+    owner?: WebConsoleReleaseOwner;
+};
+
+type WebConsoleTreeSnapshot = {
+    directories: string[];
+    files: string[];
+    sha256: string;
+};
+
+type WebConsoleDirectoryEntry = {
+    relative: string;
+    kind: "directory";
+};
+
+type WebConsoleFileEntry = {
+    relative: string;
+    kind: "file";
+    bytes: number;
+    contentSha256: Buffer;
+};
+
+type WebConsoleTreeEntry = WebConsoleDirectoryEntry | WebConsoleFileEntry;
+
+type WebConsoleInspectionPhase = "extracted" | "final";
+
+function assertWebConsoleDirectory(
+    directory: string,
+    owner: WebConsoleReleaseOwner,
+    label: string,
+): void {
+    const stats = lstatSync(directory);
+    if (!stats.isDirectory() || stats.isSymbolicLink() || stats.uid !== owner.uid || stats.gid !== owner.gid) {
+        throw new Error(`${label} must be a direct directory owned by the upgrade operator`);
+    }
+    if ((stats.mode & 0o022) !== 0) {
+        throw new Error(`${label} must not be group- or world-writable`);
+    }
+}
+
+function assertWebConsolePublicDirectory(
+    directory: string,
+    owner: WebConsoleReleaseOwner,
+    label: string,
+): void {
+    assertWebConsoleDirectory(directory, owner, label);
+    if ((lstatSync(directory).mode & 0o7777) !== 0o755) {
+        throw new Error(`${label} mode must be exactly 0755`);
+    }
+}
+
+function ensureWebConsoleReleasesDir(
+    releasesDir: string,
+    owner: WebConsoleReleaseOwner,
+): void {
+    const parent = path.dirname(releasesDir);
+    assertWebConsoleDirectory(parent, owner, "Web Console root");
+    chmodSync(parent, 0o755);
+    assertWebConsolePublicDirectory(parent, owner, "Web Console root");
+    if (!existsSync(releasesDir)) {
+        mkdirSync(releasesDir, { mode: 0o755 });
+        chmodSync(releasesDir, 0o755);
+        chownSync(releasesDir, owner.uid, owner.gid);
+    }
+    assertWebConsoleDirectory(releasesDir, owner, "Web Console releases root");
+    chmodSync(releasesDir, 0o755);
+    assertWebConsolePublicDirectory(releasesDir, owner, "Web Console releases root");
+}
+
+function webConsoleDirectoryEntry(
+    absolute: string,
+    relative: string,
+    owner: WebConsoleReleaseOwner,
+    phase: WebConsoleInspectionPhase,
+): WebConsoleDirectoryEntry {
+    const stats = lstatSync(absolute);
+    if (!stats.isDirectory() || stats.isSymbolicLink() || stats.uid !== owner.uid || stats.gid !== owner.gid) {
+        throw new Error(`Web Console release contains an unsafe directory: ${relative}`);
+    }
+    if (phase === "final" && (stats.mode & 0o7777) !== 0o755) {
+        throw new Error(`Web Console directory mode is not 0755: ${relative}`);
+    }
+    if ((stats.mode & 0o7000) !== 0) {
+        throw new Error(`Web Console release contains special directory mode bits: ${relative}`);
+    }
+    return { relative, kind: "directory" };
+}
+
+function webConsoleFileEntry(
+    absolute: string,
+    relative: string,
+    owner: WebConsoleReleaseOwner,
+    phase: WebConsoleInspectionPhase,
+): WebConsoleFileEntry {
+    const stats = lstatSync(absolute);
+    if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1
+        || stats.uid !== owner.uid || stats.gid !== owner.gid) {
+        throw new Error(`Web Console release contains a link or special file: ${relative}`);
+    }
+    if (phase === "final" && (stats.mode & 0o7777) !== 0o644) {
+        throw new Error(`Web Console file mode is not 0644: ${relative}`);
+    }
+    if ((stats.mode & 0o7000) !== 0) {
+        throw new Error(`Web Console release contains special file mode bits: ${relative}`);
+    }
+    if (stats.size > WEB_CONSOLE_MAX_EXTRACTED_BYTES) {
+        throw new Error(`Web Console file exceeds the extracted size limit: ${relative}`);
+    }
+    const content = readFileSync(absolute);
+    return {
+        relative,
+        kind: "file",
+        bytes: content.length,
+        contentSha256: createHash("sha256").update(content).digest(),
+    };
+}
+
+function webConsoleTreeEntries(
+    absolute: string,
+    relative: string,
+    owner: WebConsoleReleaseOwner,
+    phase: WebConsoleInspectionPhase,
+): WebConsoleTreeEntry[] {
+    const directory = webConsoleDirectoryEntry(absolute, relative, owner, phase);
+    const descendants = readdirSync(absolute).sort().flatMap((name) => {
+        if (!name || /[\u0000-\u001f\u007f]/.test(name)) {
+            throw new Error("Web Console release contains an unsafe filename");
+        }
+        const childAbsolute = path.join(absolute, name);
+        const childRelative = relative === "." ? name : `${relative}/${name}`;
+        return lstatSync(childAbsolute).isDirectory()
+            ? webConsoleTreeEntries(childAbsolute, childRelative, owner, phase)
+            : [webConsoleFileEntry(childAbsolute, childRelative, owner, phase)];
+    });
+    return [directory, ...descendants];
+}
+
+function inspectWebConsoleTree(
+    releaseDir: string,
+    owner: WebConsoleReleaseOwner,
+    phase: WebConsoleInspectionPhase,
+): WebConsoleTreeSnapshot {
+    const entries = webConsoleTreeEntries(releaseDir, ".", owner, phase);
+    if (entries.length - 1 > WEB_CONSOLE_MAX_ENTRIES) {
+        throw new Error("Web Console release materializes too many entries");
+    }
+    const extractedBytes = entries.reduce(
+        (sum, entry) => sum + (entry.kind === "file" ? entry.bytes : 0),
+        0,
+    );
+    if (extractedBytes > WEB_CONSOLE_MAX_EXTRACTED_BYTES) {
+        throw new Error("Web Console release exceeds the extracted size limit");
+    }
+    const digest = createHash("sha256");
+    for (const entry of entries) {
+        digest.update(`${entry.kind === "directory" ? "d" : "f"}\0${entry.relative}\0`);
+        if (entry.kind === "file") {
+            digest.update(`${entry.bytes}\0`);
+            digest.update(entry.contentSha256);
+        }
+    }
+
+    return {
+        directories: entries.filter(entry => entry.kind === "directory" && entry.relative !== ".")
+            .map(entry => entry.relative),
+        files: entries.filter(entry => entry.kind === "file").map(entry => entry.relative),
+        sha256: digest.digest("hex"),
+    };
+}
+
+function assertWebConsoleInventory(
+    actual: WebConsoleTreeSnapshot,
+    expected: WebConsoleArchiveInventory,
+): void {
+    if (actual.directories.length !== expected.directories.length
+        || actual.directories.some((entry, index) => entry !== expected.directories[index])
+        || actual.files.length !== expected.files.length
+        || actual.files.some((entry, index) => entry !== expected.files[index])) {
+        throw new Error("Extracted Web Console inventory does not match the verified archive");
+    }
+}
+
+function normalizeWebConsoleTreeModes(
+    releaseDir: string,
+    inventory: WebConsoleArchiveInventory,
+    owner: WebConsoleReleaseOwner,
+): string {
+    const before = inspectWebConsoleTree(releaseDir, owner, "extracted");
+    assertWebConsoleInventory(before, inventory);
+    for (const file of before.files) chmodSync(path.join(releaseDir, file), 0o644);
+    for (const directory of before.directories) chmodSync(path.join(releaseDir, directory), 0o755);
+    chmodSync(releaseDir, 0o755);
+    const after = inspectWebConsoleTree(releaseDir, owner, "final");
+    assertWebConsoleInventory(after, inventory);
+    if (after.sha256 !== before.sha256) {
+        throw new Error("Web Console content tree changed while final modes were applied");
+    }
+    return after.sha256;
+}
+
+export function verifyWebConsoleReleaseTree(
+    releaseDir: string,
+    expectedSha256: string,
+    owner: WebConsoleReleaseOwner = { uid: 0, gid: 0 },
+): void {
+    const snapshot = inspectWebConsoleTree(releaseDir, owner, "final");
+    if (snapshot.sha256 !== expectedSha256) {
+        throw new Error("Staged Web Console content tree changed before activation");
+    }
+}
+
+function syncFilesystemDirectory(directory: string): void {
+    const descriptor = openSync(directory, constants.O_RDONLY);
+    try {
+        fsyncSync(descriptor);
+    } finally {
+        closeSync(descriptor);
+    }
+}
+
+function readWebConsoleLinkTarget(currentLink: string): string | null {
+    const stats = lstatSync(currentLink, { throwIfNoEntry: false });
+    if (!stats) return null;
+    if (!stats.isSymbolicLink()) {
+        throw new Error("Web Console current target must be a symbolic link");
+    }
+    const target = readlinkSync(currentLink);
+    if (!target) throw new Error("Web Console current symbolic link target is empty");
+    return target;
+}
+
+function assertWebConsoleLink(
+    linkPath: string,
+    expectedTarget: string,
+    owner: WebConsoleReleaseOwner,
+): void {
+    const stats = lstatSync(linkPath);
+    if (!stats.isSymbolicLink() || stats.uid !== owner.uid || stats.gid !== owner.gid
+        || readlinkSync(linkPath) !== expectedTarget) {
+        throw new Error("Web Console activation link identity is invalid");
+    }
+}
+
+export function prepareWebConsoleLinkActivation(
+    currentLink: string,
+    target: string,
+    owner: WebConsoleReleaseOwner = { uid: 0, gid: 0 },
+): WebConsoleLinkActivationState {
+    const parent = path.dirname(currentLink);
+    assertWebConsoleDirectory(parent, owner, "Web Console root");
+    const previousTarget = readWebConsoleLinkTarget(currentLink);
+    const nextLink = `${currentLink}.next-${randomUUID()}`;
+    try {
+        symlinkSync(target, nextLink);
+        assertWebConsoleLink(nextLink, target, owner);
+        return { activated: false, currentLink, nextLink, owner, parent, previousTarget, target };
+    } catch (error: unknown) {
+        rmSync(nextLink, { force: true });
+        throw error;
+    }
+}
+
+export function activatePreparedWebConsoleLink(state: WebConsoleLinkActivationState): void {
+    if (readWebConsoleLinkTarget(state.currentLink) !== state.previousTarget) {
+        throw new Error("Web Console current target changed before activation");
+    }
+    assertWebConsoleLink(state.nextLink, state.target, state.owner);
+    renameSync(state.nextLink, state.currentLink);
+    state.activated = true;
+    syncFilesystemDirectory(state.parent);
+    assertWebConsoleLink(state.currentLink, state.target, state.owner);
+}
+
+export function restoreWebConsoleLink(state: WebConsoleLinkActivationState): void {
+    if (!state.activated) return;
+    if (readWebConsoleLinkTarget(state.currentLink) !== state.target) {
+        throw new Error("Activated Web Console current target changed before rollback");
+    }
+    if (!state.previousTarget) {
+        rmSync(state.currentLink, { force: true });
+        state.activated = false;
+        syncFilesystemDirectory(state.parent);
+        return;
+    }
+    const restoreLink = `${state.currentLink}.restore-${randomUUID()}`;
+    try {
+        symlinkSync(state.previousTarget, restoreLink);
+        assertWebConsoleLink(restoreLink, state.previousTarget, state.owner);
+        renameSync(restoreLink, state.currentLink);
+        state.activated = false;
+        syncFilesystemDirectory(state.parent);
+        assertWebConsoleLink(state.currentLink, state.previousTarget, state.owner);
+    } finally {
+        rmSync(restoreLink, { force: true });
+    }
+}
+
+function verifyActivatedWebConsole(staged: StagedWebConsole): void {
+    if (readWebConsoleLinkTarget(WEB_CONSOLE_CURRENT_LINK) !== staged.releaseDir) {
+        throw new Error("Activated Web Console target does not match the staged verified release");
+    }
+    verifyWebConsoleReleaseTree(staged.releaseDir, staged.treeSha256);
+}
+
+export async function verifyWebConsoleArchiveExpandedSize(
+    archivePath: string,
+    maximumBytes: number,
+): Promise<void> {
+    if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 1) {
+        throw new Error("Web Console expanded size limit is invalid");
+    }
+    const extraction = Bun.spawn(["tar", "-xOzf", archivePath], { stdout: "pipe", stderr: "pipe" });
+    let timedOut = false;
+    let expandedSizeExceeded = false;
+    let expandedBytes = 0;
+    const timeout = setTimeout(() => {
+        timedOut = true;
+        extraction.kill("SIGKILL");
+    }, 120_000);
+    const stderrPromise = new Response(extraction.stderr).text();
+    const reader = extraction.stdout.getReader();
+    try {
+        while (true) {
+            const chunk = await reader.read();
+            if (chunk.done) break;
+            if (chunk.value.byteLength > maximumBytes - expandedBytes) {
+                expandedSizeExceeded = true;
+                extraction.kill("SIGKILL");
+                break;
+            }
+            expandedBytes += chunk.value.byteLength;
+        }
+    } finally {
+        reader.releaseLock();
+        clearTimeout(timeout);
+    }
+    const [exitCode, stderr] = await Promise.all([extraction.exited, stderrPromise]);
+    if (timedOut) throw new Error("Web Console archive expanded-size verification timed out");
+    if (expandedSizeExceeded) {
+        throw new Error("Web Console archive exceeds the expanded size limit");
+    }
+    if (exitCode !== 0) {
+        throw new Error(`Failed to inspect Web Console expanded size: ${stderr.trim().slice(-500)}`);
+    }
+}
+
+async function validateWebConsoleArchive(archivePath: string): Promise<WebConsoleArchiveInventory> {
     const listed = await $`tar -tzf ${archivePath}`.nothrow().quiet();
     if (listed.exitCode !== 0) throw new Error(`${WEB_CONSOLE_ASSET} is not a readable gzip tarball`);
-    validateWebConsoleArchiveEntries(listed.stdout.toString());
+    const inventory = validateWebConsoleArchiveEntries(listed.stdout.toString());
     const verboseListing = await $`tar -tvzf ${archivePath}`.nothrow().quiet();
     const hasUnsafeEntry = verboseListing.stdout.toString().split(/\r?\n/)
         .filter(Boolean).some(line => !["-", "d"].includes(line[0] || ""));
     if (verboseListing.exitCode !== 0 || hasUnsafeEntry) {
         throw new Error(`${WEB_CONSOLE_ASSET} contains links or special files`);
     }
+    await verifyWebConsoleArchiveExpandedSize(archivePath, WEB_CONSOLE_MAX_EXTRACTED_BYTES);
+    return inventory;
 }
 
-async function extractWebConsoleArchive(
+export async function extractWebConsoleArchive(
     archivePath: string,
     version: string,
     endpoint: GithubEndpoint,
+    options: WebConsoleExtractionOptions = {},
 ): Promise<StagedWebConsole> {
     const safeVersion = version.replace(/[^a-zA-Z0-9._-]/g, "_");
-    const releaseDir = path.join(WEB_CONSOLE_RELEASES_DIR, `${safeVersion}-${process.pid}-${Date.now()}`);
+    const releasesDir = options.releasesDir ?? WEB_CONSOLE_RELEASES_DIR;
+    const owner = options.owner ?? { uid: 0, gid: 0 };
+    const releaseDir = path.join(releasesDir, `${safeVersion}-${process.pid}-${randomUUID()}`);
     try {
-        await validateWebConsoleArchive(archivePath);
-        await $`rm -rf ${releaseDir}`.nothrow().quiet();
-        await $`mkdir -p ${releaseDir} ${WEB_CONSOLE_RELEASES_DIR}`;
+        const inventory = await validateWebConsoleArchive(archivePath);
+        ensureWebConsoleReleasesDir(releasesDir, owner);
+        mkdirSync(releaseDir, { mode: 0o700 });
+        chmodSync(releaseDir, 0o700);
+        chownSync(releaseDir, owner.uid, owner.gid);
         const extract = await $`tar --no-same-owner --no-same-permissions -xzf ${archivePath} -C ${releaseDir}`.nothrow().quiet();
         if (extract.exitCode !== 0) {
             throw new Error(`Failed to extract ${WEB_CONSOLE_ASSET}: ${extract.stderr.toString().slice(-500)}`);
         }
-        if (!existsSync(path.join(releaseDir, "index.html"))) {
+        const indexPath = path.join(releaseDir, "index.html");
+        if (!existsSync(indexPath) || !lstatSync(indexPath).isFile() || lstatSync(indexPath).isSymbolicLink()) {
             throw new Error(`${WEB_CONSOLE_ASSET} is invalid: index.html not found at archive root`);
         }
-        return { releaseDir, endpoint };
+        const treeSha256 = normalizeWebConsoleTreeModes(releaseDir, inventory, owner);
+        return { releaseDir, endpoint, treeSha256 };
     } catch (error: unknown) {
-        await $`rm -rf ${releaseDir}`.nothrow().quiet();
+        rmSync(releaseDir, { force: true, recursive: true });
         throw error;
     }
 }
@@ -1811,11 +2302,11 @@ export async function waitForUpgradeHealth() {
     await waitForEdgeRuntimeHealth();
 }
 
-type UpgradeActivationState = {
+export type UpgradeActivationState = {
     binary: BinaryBackupState;
     edgeBinary: BinaryBackupState | null;
-    oldWebTarget: string | null;
-    oldWebBackup: string | null;
+    systemdUnitBroker: PrivilegedHelperActivationState | null;
+    webConsoleLink: WebConsoleLinkActivationState | null;
     managementEnvState: FileState | null;
     edgeRuntimeEnvState: FileState | null;
     edgeRuntimeDropInState: FileState | null;
@@ -1860,9 +2351,11 @@ type UpgradeExecutionState = {
     committed: boolean;
     downloadEndpointLabel: string;
     edgeRuntimeEndpointLabel: string | null;
+    preflightSystemdUnitBroker: PrivilegedHelperIdentity | null;
     rollbackSucceeded: boolean;
     stagedEdgeRuntime: StagedBinary | null;
     stagedManagement: StagedBinary | null;
+    stagedSystemdUnitBroker: StagedPrivilegedHelper | null;
     stagedWebConsole: StagedWebConsole | null;
     webConsoleEndpointLabel: string | null;
 };
@@ -1882,12 +2375,38 @@ type UpgradeCleanupAction = {
     run: () => void;
 };
 
-async function activateArtifacts(
-    stagedBinary: StagedBinary,
-    stagedEdgeBinary: StagedBinary | null,
-    stagedWeb: StagedWebConsole | null,
-    state: UpgradeActivationState,
-) {
+export type UpgradeRecoveryAction = {
+    description: string;
+    run: () => void | Promise<void>;
+};
+
+export type UpgradeRecoveryPathState = {
+    activation?: Partial<UpgradeActivationState> | null;
+    stagedEdgeRuntime?: { path: string } | null;
+    stagedManagement?: { path: string } | null;
+    stagedSystemdUnitBroker?: { path: string } | null;
+    stagedWebConsole?: { releaseDir: string } | null;
+};
+
+type ActivateArtifactsRequest = {
+    stagedBinary: StagedBinary;
+    stagedEdgeBinary: StagedBinary | null;
+    stagedSystemdUnitBroker: StagedPrivilegedHelper;
+    preflightSystemdUnitBroker: PrivilegedHelperIdentity;
+    stagedWeb: StagedWebConsole | null;
+    state: UpgradeActivationState;
+};
+
+async function activateArtifacts(request: ActivateArtifactsRequest) {
+    const { stagedBinary, stagedEdgeBinary, stagedSystemdUnitBroker, stagedWeb, state } = request;
+    if (stagedWeb) verifyWebConsoleReleaseTree(stagedWeb.releaseDir, stagedWeb.treeSha256);
+    const preparedSystemdUnitBroker = prepareSystemdUnitBrokerActivation({
+        staged: stagedSystemdUnitBroker,
+        targetPath: SYSTEMD_UNIT_BROKER_TARGET,
+        expectedPrevious: request.preflightSystemdUnitBroker,
+    });
+    state.systemdUnitBroker = preparedSystemdUnitBroker.state;
+    activatePreparedSystemdUnitBroker(preparedSystemdUnitBroker);
     activateStagedBinary(stagedBinary.path, state.binary);
 
     if (stagedEdgeBinary && state.edgeBinary) {
@@ -1895,63 +2414,104 @@ async function activateArtifacts(
     }
 
     if (stagedWeb) {
-        await $`mkdir -p ${WEB_CONSOLE_ROOT}`;
-        const currentIsLink = await $`test -L ${WEB_CONSOLE_CURRENT_LINK}`.nothrow().quiet();
-        if (currentIsLink.exitCode === 0) {
-            const oldTarget = await $`readlink ${WEB_CONSOLE_CURRENT_LINK}`.nothrow().quiet();
-            state.oldWebTarget = oldTarget.exitCode === 0 ? oldTarget.stdout.toString().trim() : null;
-            await $`rm -f ${WEB_CONSOLE_CURRENT_LINK}`;
-        } else {
-            const currentExists = await $`test -e ${WEB_CONSOLE_CURRENT_LINK}`.nothrow().quiet();
-            if (currentExists.exitCode === 0) {
-                state.oldWebBackup = `${WEB_CONSOLE_ROOT}/current.bak-${process.pid}-${Date.now()}`;
-                await $`mv ${WEB_CONSOLE_CURRENT_LINK} ${state.oldWebBackup}`;
-            }
-        }
-        await $`ln -s ${stagedWeb.releaseDir} ${WEB_CONSOLE_CURRENT_LINK}`;
+        state.webConsoleLink = prepareWebConsoleLinkActivation(
+            WEB_CONSOLE_CURRENT_LINK,
+            stagedWeb.releaseDir,
+        );
+        activatePreparedWebConsoleLink(state.webConsoleLink);
     }
 }
 
-async function rollbackArtifacts(state: UpgradeActivationState, stagedWeb: StagedWebConsole | null) {
-    restoreCurrentBinary(state.binary);
-    if (state.edgeBinary) restoreCurrentBinary(state.edgeBinary);
-
-    if (stagedWeb) {
-        rmSync(WEB_CONSOLE_CURRENT_LINK, { force: true, recursive: true });
-        if (state.oldWebBackup) {
-            await $`mv ${state.oldWebBackup} ${WEB_CONSOLE_CURRENT_LINK}`;
-        } else if (state.oldWebTarget) {
-            await $`ln -s ${state.oldWebTarget} ${WEB_CONSOLE_CURRENT_LINK}`;
+export async function executeUpgradeRecoveryActions(actions: UpgradeRecoveryAction[]): Promise<void> {
+    const failures: Error[] = [];
+    for (const action of actions) {
+        try {
+            await action.run();
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            failures.push(new Error(`${action.description}: ${message}`));
         }
     }
+    if (failures.length > 0) throw new AggregateError(failures, "Upgrade recovery did not complete");
+}
 
-    if (state.managementEnvState) {
-        restoreFileState(state.managementEnvState);
-    }
-    if (state.edgeRuntimeEnvState) {
-        restoreFileState(state.edgeRuntimeEnvState);
-    }
-    if (state.edgeRuntimeDropInState) {
-        restoreFileState(state.edgeRuntimeDropInState);
-    }
-    if (state.managementPrivilegeDropInState) {
-        restoreFileState(state.managementPrivilegeDropInState);
-    }
-    if (state.embeddedEdgePrivilegeDropInState) {
-        restoreFileState(state.embeddedEdgePrivilegeDropInState);
-    }
-    await reloadSystemdUnits();
+function artifactRecoveryActions(state: UpgradeActivationState): UpgradeRecoveryAction[] {
+    const actions: UpgradeRecoveryAction[] = [
+        { description: "restore Management binary", run: () => restoreCurrentBinary(state.binary) },
+    ];
+    const edgeBinary = state.edgeBinary;
+    if (edgeBinary) actions.push({
+        description: "restore Edge Runtime binary",
+        run: () => restoreCurrentBinary(edgeBinary),
+    });
+    const webConsoleLink = state.webConsoleLink;
+    if (webConsoleLink) actions.push({
+        description: "restore Web Console current target",
+        run: () => restoreWebConsoleLink(webConsoleLink),
+    });
+    const managementEnvState = state.managementEnvState;
+    if (managementEnvState) actions.push({
+        description: "restore Management environment",
+        run: () => restoreFileState(managementEnvState),
+    });
+    const edgeRuntimeEnvState = state.edgeRuntimeEnvState;
+    if (edgeRuntimeEnvState) actions.push({
+        description: "restore Edge Runtime environment",
+        run: () => restoreFileState(edgeRuntimeEnvState),
+    });
+    const edgeRuntimeDropInState = state.edgeRuntimeDropInState;
+    if (edgeRuntimeDropInState) actions.push({
+        description: "restore Edge Runtime systemd drop-in",
+        run: () => restoreFileState(edgeRuntimeDropInState),
+    });
+    const managementPrivilegeDropInState = state.managementPrivilegeDropInState;
+    if (managementPrivilegeDropInState) actions.push({
+        description: "restore Management privilege drop-in",
+        run: () => restoreFileState(managementPrivilegeDropInState),
+    });
+    const embeddedEdgePrivilegeDropInState = state.embeddedEdgePrivilegeDropInState;
+    if (embeddedEdgePrivilegeDropInState) actions.push({
+        description: "restore embedded Edge privilege drop-in",
+        run: () => restoreFileState(embeddedEdgePrivilegeDropInState),
+    });
+    const systemdUnitBroker = state.systemdUnitBroker;
+    if (systemdUnitBroker) actions.push({
+        description: "restore systemd-unit helper",
+        run: () => restoreSystemdUnitBroker(systemdUnitBroker, {
+            uid: systemdUnitBroker.previous.uid,
+            gid: systemdUnitBroker.previous.gid,
+        }),
+    });
+    return actions;
+}
 
-    await restartServices(await runtimeModeForBinaryUpgrade());
-    await waitForUpgradeHealth();
+function restoredServiceRecoveryActions(): UpgradeRecoveryAction[] {
+    return [
+        { description: "reload systemd units", run: () => reloadSystemdUnits() },
+        {
+            description: "restart restored services",
+            run: async () => restartServices(await runtimeModeForBinaryUpgrade()),
+        },
+        { description: "verify restored services", run: () => waitForUpgradeHealth() },
+    ];
+}
+
+export async function rollbackArtifacts(
+    state: UpgradeActivationState,
+    serviceActions: UpgradeRecoveryAction[] = restoredServiceRecoveryActions(),
+): Promise<void> {
+    await executeUpgradeRecoveryActions([
+        ...artifactRecoveryActions(state),
+        ...serviceActions,
+    ]);
 }
 
 function createActivationState(edgeRuntimeTarget: string | null): UpgradeActivationState {
     return {
         binary: createBinaryBackupState(BIN_TARGET),
         edgeBinary: edgeRuntimeTarget ? createBinaryBackupState(edgeRuntimeTarget) : null,
-        oldWebTarget: null,
-        oldWebBackup: null,
+        systemdUnitBroker: null,
+        webConsoleLink: null,
         managementEnvState: null,
         edgeRuntimeEnvState: null,
         edgeRuntimeDropInState: null,
@@ -2082,9 +2642,11 @@ function createUpgradeExecutionState(plan: UpgradeReleasePlan): UpgradeExecution
         committed: false,
         downloadEndpointLabel: plan.endpoint.label,
         edgeRuntimeEndpointLabel: null,
+        preflightSystemdUnitBroker: null,
         rollbackSucceeded: false,
         stagedEdgeRuntime: null,
         stagedManagement: null,
+        stagedSystemdUnitBroker: null,
         stagedWebConsole: null,
         webConsoleEndpointLabel: null,
     };
@@ -2117,6 +2679,7 @@ async function verifyUpgradePreflight(context: UpgradeExecutionContext): Promise
     context.spinner.start(`Verifying ${MANAGEMENT_SERVICE_UNIT} uses the canonical upgrade target`);
     verifyBackupPrivilegeDropPreflight();
     await verifyManagementUpgradePreflight();
+    context.state.preflightSystemdUnitBroker = readPrivilegedHelperIdentity(SYSTEMD_UNIT_BROKER_TARGET);
     const edgeRuntime = context.plan.edgeRuntime;
     if (!edgeRuntime) return;
     const current = await inspectActiveSystemdBinary(EDGE_RUNTIME_SERVICE_UNIT);
@@ -2208,6 +2771,8 @@ async function stageUpgradeArtifacts(context: UpgradeExecutionContext): Promise<
     await stageManagementUpgrade(context);
     await stageEdgeRuntimeUpgrade(context);
     await stageWebConsoleUpgrade(context);
+    context.spinner.start(`Staging the Management release systemd-unit helper for ${SYSTEMD_UNIT_BROKER_TARGET}`);
+    context.state.stagedSystemdUnitBroker = stageEmbeddedSystemdUnitBroker();
 }
 
 async function migrateUpgradeMetadata(context: UpgradeExecutionContext): Promise<void> {
@@ -2220,14 +2785,18 @@ async function migrateUpgradeMetadata(context: UpgradeExecutionContext): Promise
 async function activateUpgradeArtifacts(context: UpgradeExecutionContext): Promise<void> {
     const { plan, state } = context;
     if (!state.stagedManagement) throw new Error("Upgrade binary was not staged");
+    if (!state.stagedSystemdUnitBroker) throw new Error("Upgrade systemd-unit helper was not staged");
+    if (!state.preflightSystemdUnitBroker) throw new Error("Upgrade systemd-unit helper preflight is unavailable");
     context.spinner.start("Atomically activating staged SupaCloud artifacts");
     state.activation = createActivationState(plan.edgeRuntime?.targetPath || null);
-    await activateArtifacts(
-        state.stagedManagement,
-        state.stagedEdgeRuntime,
-        state.stagedWebConsole,
-        state.activation,
-    );
+    await activateArtifacts({
+        stagedBinary: state.stagedManagement,
+        stagedEdgeBinary: state.stagedEdgeRuntime,
+        stagedSystemdUnitBroker: state.stagedSystemdUnitBroker,
+        preflightSystemdUnitBroker: state.preflightSystemdUnitBroker,
+        stagedWeb: state.stagedWebConsole,
+        state: state.activation,
+    });
 }
 
 function captureUpgradeRuntimeFiles(activation: UpgradeActivationState): void {
@@ -2275,6 +2844,8 @@ async function verifyUpgradeActivation(context: UpgradeExecutionContext): Promis
     context.spinner.start("Waiting for the SupaCloud health endpoint");
     await waitForUpgradeHealth();
     await verifyActivatedManagementBinary(stagedManagement.sha256);
+    verifyInstalledSystemdUnitBroker();
+    if (context.state.stagedWebConsole) verifyActivatedWebConsole(context.state.stagedWebConsole);
     await verifyEdgeRuntimeUpgrade(context);
     context.state.committed = true;
 }
@@ -2283,7 +2854,7 @@ async function rollbackUpgradeActivation(context: UpgradeExecutionContext): Prom
     const activation = context.state.activation;
     if (!activation) return;
     p.log.warn("Upgrade activation failed; restoring the previous binary and Web Console target.");
-    await rollbackArtifacts(activation, context.state.stagedWebConsole);
+    await rollbackArtifacts(activation);
     context.state.rollbackSucceeded = true;
 }
 
@@ -2299,6 +2870,11 @@ function stagedArtifactCleanupActions(state: UpgradeExecutionState): UpgradeClea
         description: `remove staged Edge Runtime binary ${edgeRuntime.path}`,
         run: () => rmSync(edgeRuntime.path, { force: true }),
     });
+    const systemdUnitBroker = state.stagedSystemdUnitBroker;
+    if (systemdUnitBroker) actions.push({
+        description: `remove staged systemd-unit helper ${systemdUnitBroker.path}`,
+        run: () => rmSync(systemdUnitBroker.path, { force: true }),
+    });
     const webConsole = state.stagedWebConsole;
     if (!state.committed && webConsole) actions.push({
         description: `remove staged Web Console ${webConsole.releaseDir}`,
@@ -2311,10 +2887,10 @@ function activatedBackupCleanupActions(state: UpgradeExecutionState): UpgradeCle
     const activation = state.activation;
     if (!activation) return [];
     const actions: UpgradeCleanupAction[] = [];
-    const oldWebBackup = activation.oldWebBackup;
-    if (state.committed && oldWebBackup) actions.push({
-        description: `remove previous Web Console backup ${oldWebBackup}`,
-        run: () => rmSync(oldWebBackup, { force: true, recursive: true }),
+    const webConsoleLink = activation.webConsoleLink;
+    if (webConsoleLink) actions.push({
+        description: `remove staged Web Console activation link ${webConsoleLink.nextLink}`,
+        run: () => rmSync(webConsoleLink.nextLink, { force: true }),
     });
     actions.push({
         description: `remove Management backup ${activation.binary.backupPath}`,
@@ -2324,6 +2900,11 @@ function activatedBackupCleanupActions(state: UpgradeExecutionState): UpgradeCle
     if (edgeRuntimeBackup) actions.push({
         description: `remove Edge Runtime backup ${edgeRuntimeBackup.backupPath}`,
         run: () => cleanupBinaryBackup(edgeRuntimeBackup),
+    });
+    const systemdUnitBrokerBackup = activation.systemdUnitBroker;
+    if (systemdUnitBrokerBackup) actions.push({
+        description: `remove systemd-unit helper backup ${systemdUnitBrokerBackup.backupPath}`,
+        run: () => cleanupSystemdUnitBrokerBackup(systemdUnitBrokerBackup),
     });
     return actions;
 }
@@ -2371,15 +2952,18 @@ function upgradeTransactionOperations(context: UpgradeExecutionContext): Upgrade
     };
 }
 
-function upgradeRecoveryPaths(context: UpgradeExecutionContext | null): string[] {
-    if (!context) return [];
-    const { state } = context;
+export function upgradeRecoveryPaths(state: UpgradeRecoveryPathState | null): string[] {
+    if (!state) return [];
     const candidates = [
-        state.activation?.binary.backupReady ? state.activation.binary.backupPath : null,
+        state.activation?.binary?.backupReady ? state.activation.binary.backupPath : null,
         state.activation?.edgeBinary?.backupReady ? state.activation.edgeBinary.backupPath : null,
-        state.activation?.oldWebBackup,
+        state.activation?.systemdUnitBroker?.backupReady
+            ? state.activation.systemdUnitBroker.backupPath
+            : null,
+        state.activation?.webConsoleLink?.nextLink,
         state.stagedManagement?.path,
         state.stagedEdgeRuntime?.path,
+        state.stagedSystemdUnitBroker?.path,
         state.stagedWebConsole?.releaseDir,
     ];
     return [...new Set(candidates.filter((candidate): candidate is string => Boolean(candidate && existsSync(candidate))))];
@@ -2458,7 +3042,7 @@ export async function runUpgrade(options: RunUpgradeOptions = {}) {
         }
         p.outro(upgradeSuccessMessage(executionContext));
     } catch (error: unknown) {
-        s.stop(formatUpgradeFailure(error, upgradeRecoveryPaths(executionContext)));
+        s.stop(formatUpgradeFailure(error, upgradeRecoveryPaths(executionContext?.state ?? null)));
         process.exit(1);
     }
 }

--- a/packages/management-api/tests/unit/embedded-systemd-unit-broker.test.ts
+++ b/packages/management-api/tests/unit/embedded-systemd-unit-broker.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  copyFileSync,
+  lstatSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256,
+  EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE,
+  activatePreparedSystemdUnitBroker,
+  cleanupSystemdUnitBrokerBackup,
+  prepareSystemdUnitBrokerActivation,
+  readPrivilegedHelperIdentity,
+  restoreSystemdUnitBroker,
+  stageEmbeddedSystemdUnitBroker,
+  verifyInstalledSystemdUnitBroker,
+} from "../../src/embedded-systemd-unit-broker";
+
+const owner = {
+  uid: process.getuid?.() ?? 0,
+  gid: process.getgid?.() ?? 0,
+};
+
+function helperFixture() {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-systemd-unit-helper-")));
+  const target = join(directory, "systemd-unit");
+  writeFileSync(target, "#!/bin/sh\nprintf old-helper\\n\n", { mode: 0o755 });
+  chmodSync(target, 0o755);
+  return { directory, target };
+}
+
+function activateSystemdUnitBroker(
+  request: Parameters<typeof prepareSystemdUnitBrokerActivation>[0],
+) {
+  return activatePreparedSystemdUnitBroker(prepareSystemdUnitBrokerActivation(request));
+}
+
+describe("embedded privileged systemd-unit helper", () => {
+  test("embeds the exact canonical shell helper bytes and digest", () => {
+    const sourcePath = join(import.meta.dir, "../../../../scripts/lib/systemd_unit_broker.sh");
+    const source = readFileSync(sourcePath, "utf8");
+    expect(EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE).toBe(source);
+    expect(EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256).toBe(
+      createHash("sha256").update(Buffer.from(source, "utf8")).digest("hex"),
+    );
+  });
+
+  test("delivers helper B from the target release and restores exact helper A", () => {
+    const { directory, target } = helperFixture();
+    try {
+      const previous = readPrivilegedHelperIdentity(target, owner);
+      const staged = stageEmbeddedSystemdUnitBroker(target, "stage", owner);
+      expect(previous.sha256).not.toBe(EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256);
+      expect(lstatSync(staged.path).mode & 0o777).toBe(0o755);
+      expect(staged.sha256).toBe(EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256);
+
+      const activation = activateSystemdUnitBroker({
+        staged,
+        targetPath: target,
+        runId: "activate",
+        owner,
+      });
+      expect(verifyInstalledSystemdUnitBroker(target, owner).sha256)
+        .toBe(EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256);
+      expect(readFileSync(target, "utf8")).toBe(EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE);
+      expect(lstatSync(target).mode & 0o777).toBe(0o755);
+      expect(lstatSync(activation.backupPath).nlink).toBe(1);
+
+      restoreSystemdUnitBroker(activation, owner);
+      const restored = readPrivilegedHelperIdentity(target, owner, previous.mode);
+      expect(restored.sha256).toBe(previous.sha256);
+      expect(restored.content).toEqual(previous.content);
+      expect(restored.mode).toBe(previous.mode);
+
+      cleanupSystemdUnitBrokerBackup(activation);
+      expect(() => lstatSync(activation.backupPath)).toThrow();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed on missing, symbolic-link, hard-link, or staged digest drift", () => {
+    const { directory, target } = helperFixture();
+    try {
+      expect(() => readPrivilegedHelperIdentity(join(directory, "missing"), owner)).toThrow("missing");
+
+      const symbolic = join(directory, "symbolic");
+      symlinkSync(target, symbolic);
+      expect(() => readPrivilegedHelperIdentity(symbolic, owner)).toThrow("direct regular file");
+
+      const hard = join(directory, "hard");
+      linkSync(target, hard);
+      expect(() => readPrivilegedHelperIdentity(target, owner)).toThrow("one link");
+      rmSync(hard);
+
+      const staged = stageEmbeddedSystemdUnitBroker(target, "drift", owner);
+      writeFileSync(staged.path, "#!/bin/sh\nprintf tampered\\n\n", { mode: 0o755 });
+      chmodSync(staged.path, 0o755);
+      const previous = readFileSync(target);
+      expect(() => activateSystemdUnitBroker({
+        staged,
+        targetPath: target,
+        runId: "drift",
+        owner,
+      }))
+        .toThrow("identity changed");
+      expect(readFileSync(target)).toEqual(previous);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses activation when the helper changed after the frozen preflight", () => {
+    const { directory, target } = helperFixture();
+    try {
+      const preflight = readPrivilegedHelperIdentity(target, owner);
+      const staged = stageEmbeddedSystemdUnitBroker(target, "preflight-drift", owner);
+      writeFileSync(target, "#!/bin/sh\nprintf concurrent-change\\n\n", { mode: 0o755 });
+      chmodSync(target, 0o755);
+
+      expect(() => activateSystemdUnitBroker({
+        staged,
+        targetPath: target,
+        runId: "preflight-drift",
+        owner,
+        expectedPrevious: preflight,
+      })).toThrow("changed after upgrade preflight");
+      expect(readFileSync(target, "utf8")).toContain("concurrent-change");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails rollback closed when the frozen backup digest changes", () => {
+    const { directory, target } = helperFixture();
+    try {
+      const staged = stageEmbeddedSystemdUnitBroker(target, "backup-drift", owner);
+      const activation = activateSystemdUnitBroker({
+        staged,
+        targetPath: target,
+        runId: "backup-drift",
+        owner,
+      });
+      writeFileSync(activation.backupPath, "tampered backup", { mode: 0o755 });
+      chmodSync(activation.backupPath, 0o755);
+
+      expect(() => restoreSystemdUnitBroker(activation, owner)).toThrow("backup changed");
+      expect(verifyInstalledSystemdUnitBroker(target, owner).sha256)
+        .toBe(EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("retains recovery evidence when the activated target inode or mode drifts", () => {
+    for (const drift of ["inode", "mode"] as const) {
+      const { directory, target } = helperFixture();
+      try {
+        const staged = stageEmbeddedSystemdUnitBroker(target, `activated-${drift}`, owner);
+        const prepared = prepareSystemdUnitBrokerActivation({
+          staged,
+          targetPath: target,
+          runId: `activated-${drift}`,
+          owner,
+        });
+        expect(prepared.state.backupReady).toBe(true);
+        expect(lstatSync(prepared.state.backupPath).isFile()).toBe(true);
+        const activation = activatePreparedSystemdUnitBroker(prepared);
+        if (drift === "mode") {
+          chmodSync(target, 0o700);
+        } else {
+          const replacement = join(directory, "replacement");
+          copyFileSync(target, replacement);
+          chmodSync(replacement, 0o755);
+          renameSync(replacement, target);
+        }
+
+        expect(() => restoreSystemdUnitBroker(activation, owner)).toThrow();
+        expect(lstatSync(activation.backupPath).isFile()).toBe(true);
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("refuses rollback under an unexpected ownership contract and retains the backup", () => {
+    const { directory, target } = helperFixture();
+    try {
+      const staged = stageEmbeddedSystemdUnitBroker(target, "owner-drift", owner);
+      const activation = activateSystemdUnitBroker({
+        staged,
+        targetPath: target,
+        runId: "owner-drift",
+        owner,
+      });
+      expect(() => restoreSystemdUnitBroker(activation, {
+        uid: owner.uid + 1,
+        gid: owner.gid,
+      })).toThrow("owned by uid");
+      expect(lstatSync(activation.backupPath).isFile()).toBe(true);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/management-api/tests/unit/postgrest-launcher.test.ts
+++ b/packages/management-api/tests/unit/postgrest-launcher.test.ts
@@ -170,6 +170,10 @@ describe("PostgREST launcher installation", () => {
       join(repoRoot, "packages/management-api/src/services/tenant-runtime.service.ts"),
       "utf8",
     );
+    const template = readFileSync(
+      join(repoRoot, "packages/management-api/src/services/postgrest-systemd-template.ts"),
+      "utf8",
+    );
     const canonicalPath = "/usr/local/libexec/supacloud/postgrest-launcher";
 
     expect(installer).toContain(`local launcher_target="${canonicalPath}"`);
@@ -177,7 +181,8 @@ describe("PostgREST launcher installation", () => {
     expect(installer).toContain(`supacloud_restore_file_snapshot ${canonicalPath}`);
     expect(installer).toContain("install_postgrest_launcher || activation_status=$?");
     expect(runtime).toContain(`ExecStart=${canonicalPath} %i`);
-    expect(service).toContain(`ExecStart=${canonicalPath} %i`);
-    expect(service).not.toContain("/usr/local/libexec/supacloud-postgrest-launcher");
+    expect(template).toContain(`ExecStart=${canonicalPath} %i`);
+    expect(service).toContain("renderPostgrestSystemdTemplate({");
+    expect(`${service}\n${template}`).not.toContain("/usr/local/libexec/supacloud-postgrest-launcher");
   });
 });

--- a/packages/management-api/tests/unit/standalone-version.test.ts
+++ b/packages/management-api/tests/unit/standalone-version.test.ts
@@ -3,7 +3,11 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import pkg from "../../package.json";
-import { isStandaloneVersionCommand } from "../../src/standalone";
+import {
+  isStandaloneVersionCommand,
+  isSystemdUnitBrokerDigestCommand,
+} from "../../src/standalone";
+import { EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256 } from "../../src/embedded-systemd-unit-broker";
 
 const packageRoot = join(import.meta.dir, "../..");
 const buildDirectory = mkdtempSync(join(tmpdir(), "supacloud-version-command-"));
@@ -38,6 +42,8 @@ describe("standalone version command", () => {
     expect(isStandaloneVersionCommand(["-v"])).toBe(true);
     expect(isStandaloneVersionCommand(["upgrade", "--version", "0.51.0"])).toBe(false);
     expect(isStandaloneVersionCommand(["project", "--version"])).toBe(false);
+    expect(isSystemdUnitBrokerDigestCommand(["--systemd-unit-helper-sha256"])).toBe(true);
+    expect(isSystemdUnitBrokerDigestCommand(["upgrade", "--systemd-unit-helper-sha256"])).toBe(false);
   });
 
   test("compiled binary prints its version without loading runtime configuration", async () => {
@@ -56,5 +62,13 @@ describe("standalone version command", () => {
     expect(version.exitCode).toBe(0);
     expect(version.stdout).toContain(`SupaCloud Version: ${pkg.version}`);
     expect(version.stderr).toBe("");
+
+    const helperDigest = await captureProcess([binaryPath, "--systemd-unit-helper-sha256"], 5_000);
+    expect(helperDigest.timedOut).toBe(false);
+    expect(helperDigest.exitCode).toBe(0);
+    expect(helperDigest.stdout).toContain(
+      `SupaCloud systemd-unit helper SHA-256: ${EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256}`,
+    );
+    expect(helperDigest.stderr).toBe("");
   }, 40_000);
 });

--- a/packages/management-api/tests/unit/systemd-unit-broker.test.ts
+++ b/packages/management-api/tests/unit/systemd-unit-broker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { assertManagedSystemdUnitContent } from "../../src/services/systemd-unit-broker";
+import { renderPostgrestSystemdTemplate } from "../../src/services/postgrest-systemd-template";
 
 function frontendUnit(user = "supacloud-demo", extra = ""): string {
   return `[Unit]
@@ -16,7 +17,55 @@ WantedBy=multi-user.target
 `;
 }
 
+function postgrestUnit(extra = ""): string {
+  return `[Unit]
+Description=test
+[Service]
+Type=simple
+User=supacloud-%i
+Group=supacloud-%i
+NoNewPrivileges=true
+${extra}ExecStart=/usr/local/libexec/supacloud/postgrest-launcher %i
+[Install]
+WantedBy=multi-user.target
+`;
+}
+
+function canonicalPostgrestUnit(): string {
+  return renderPostgrestSystemdTemplate({
+    postgrestRts: "-N2 -A8m",
+    postgrestBinary: "/opt/supacloud/postgrest-v16.1/bin/postgrest",
+    tenantConfigDir: "/etc/supabase/tenants",
+    memoryMax: "64M",
+    cpuWeight: 20,
+  });
+}
+
 describe("systemd unit broker policy", () => {
+  test("accepts the launcher-based PostgREST unit without an environment file", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-pgrst@.service",
+      canonicalPostgrestUnit(),
+    )).not.toThrow();
+  });
+
+  test("allows only an approved optional PostgREST environment file", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-pgrst@.service",
+      postgrestUnit("EnvironmentFile=/etc/supabase/tenants/%i.env\n"),
+    )).not.toThrow();
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-pgrst@.service",
+      postgrestUnit("EnvironmentFile=-/etc/supabase/management-api.env\n"),
+    )).toThrow(/invalid EnvironmentFile/);
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-pgrst@.service",
+      postgrestUnit(
+        "EnvironmentFile=/etc/supabase/tenants/%i.env\nEnvironmentFile=/etc/supabase/tenants/%i.env\n",
+      ),
+    )).toThrow(/invalid EnvironmentFile/);
+  });
+
   test("accepts a non-root frontend unit matching its tenant", () => {
     expect(() => assertManagedSystemdUnitContent(
       "supacloud-frontend-demo-abc123ff.service",
@@ -33,6 +82,10 @@ describe("systemd unit broker policy", () => {
       "supacloud-frontend-demo-abc123ff.service",
       frontendUnit("supacloud-demo", "ExecStartPre=/bin/sh\n"),
     )).toThrow(/unsupported directive/);
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-demo-abc123ff.service",
+      frontendUnit().replace("ExecStart=/bin/true", "ExecStart=+/bin/true"),
+    )).toThrow(/privileged execution prefix/);
   });
 
   test("rejects a frontend unit whose tenant identity does not match its name", () => {
@@ -54,5 +107,22 @@ describe("systemd unit broker policy", () => {
       "supacloud-frontend-demo-abc123ff.service",
       frontendUnit().replace("Description=test", "Description=test\u0001injected"),
     )).toThrow(/invalid content/);
+  });
+
+  test("continues to require an environment file for frontend units", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-frontend-demo-abc123ff.service",
+      frontendUnit().replace("EnvironmentFile=/var/supacloud/frontends/demo/abc123ff/.env\n", ""),
+    )).toThrow(/missing its non-root runtime identity/);
+  });
+
+  test("continues to require an environment file for GoTrue units", () => {
+    expect(() => assertManagedSystemdUnitContent(
+      "supacloud-gotrue@.service",
+      postgrestUnit().replace(
+        "ExecStart=/usr/local/libexec/supacloud/postgrest-launcher %i",
+        "ExecStart=/usr/local/bin/gotrue",
+      ),
+    )).toThrow(/missing its non-root runtime identity/);
   });
 });

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -1,7 +1,24 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { SQL } from "bun";
 import { createHash } from "node:crypto";
-import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -21,6 +38,9 @@ import {
     ensureEdgeRuntimeIdentity,
     ensureEmbeddedEdgeRuntimeSourceAccess,
     ensurePersistedEdgeRuntimeIdentity,
+    activatePreparedWebConsoleLink,
+    executeUpgradeRecoveryActions,
+    extractWebConsoleArchive,
     formatUpgradeFailure,
     inspectActiveManagementBinary,
     inspectActiveSystemdBinary,
@@ -28,9 +48,11 @@ import {
     normalizeExactManagementVersion,
     normalizeManagementReleaseTag,
     parseManagementVersionOutput,
+    parseSystemdUnitBrokerDigestOutput,
     parseSystemdExecStartPath,
     parseSystemdEnabledState,
     parseSystemdMainPid,
+    prepareWebConsoleLinkActivation,
     prepareUpgradeSecrets,
     resolveArtifactVerificationMode,
     resolveEdgeRuntimeCapacityConfig,
@@ -42,6 +64,7 @@ import {
     readSystemdEnabledState,
     runStagedDatabaseMigration,
     restoreCurrentBinary,
+    rollbackArtifacts,
     restoreFileState,
     selectEdgeRuntimeRelease,
     selectManagementRelease,
@@ -53,16 +76,27 @@ import {
     upsertPersistedEdgeRuntimePort,
     upsertEdgeRuntimeIdentityDefaults,
     UpgradeTransactionError,
+    type UpgradeActivationState,
+    upgradeRecoveryPaths,
     validateWebConsoleArchiveEntries,
     verifyArtifactAttestation,
     verifyActivatedManagementBinary,
     verifyArtifactChecksum,
     verifyManagementUpgradePreflight,
     verifyBackupPrivilegeDropPreflight,
+    verifyWebConsoleArchiveExpandedSize,
+    verifyWebConsoleReleaseTree,
+    restoreWebConsoleLink,
     waitForManagementHealth,
     waitForEdgeRuntimeHealth,
     waitForUpgradeHealth,
 } from "../../src/upgrade";
+import {
+    activatePreparedSystemdUnitBroker,
+    prepareSystemdUnitBrokerActivation,
+    readPrivilegedHelperIdentity,
+    stageEmbeddedSystemdUnitBroker,
+} from "../../src/embedded-systemd-unit-broker";
 
 const originalFetch = globalThis.fetch;
 const attestationEnvironmentKeys = [
@@ -539,6 +573,19 @@ describe("upgrade release selection", () => {
     ]) {
       expect(() => parseManagementVersionOutput(invalid)).toThrow();
     }
+  });
+
+  test("requires the Management helper identity command to report one exact digest", () => {
+    const digest = "b".repeat(64);
+    expect(parseSystemdUnitBrokerDigestOutput(
+      `SupaCloud systemd-unit helper SHA-256: ${digest}\n`,
+    )).toBe(digest);
+    expect(parseSystemdUnitBrokerDigestOutput(JSON.stringify({
+      message: `SupaCloud systemd-unit helper SHA-256: ${digest}`,
+    }))).toBe(digest);
+    expect(() => parseSystemdUnitBrokerDigestOutput(
+      `SupaCloud systemd-unit helper SHA-256: ${digest}\nextra\n`,
+    )).toThrow("exactly one line");
   });
 
   test("selects only the explicitly pinned Edge Runtime release with its own checksum", () => {
@@ -1098,6 +1145,300 @@ describe("upgrade release selection", () => {
   test("rejects Web Console archives with path traversal entries", () => {
     expect(() => validateWebConsoleArchiveEntries("index.html\n../escape\n"))
       .toThrow("unsafe path");
+    expect(() => validateWebConsoleArchiveEntries("./index.html\nindex.html\n"))
+      .toThrow("duplicate path");
+    expect(() => validateWebConsoleArchiveEntries("index.html\n_app\n_app/entry.js\n"))
+      .toThrow("traverses a file");
+    expect(() => validateWebConsoleArchiveEntries("index.html\n_app/\n_app\n"))
+      .toThrow();
+    expect(() => validateWebConsoleArchiveEntries(`index.html\n${"a/".repeat(33)}asset.js\n`))
+      .toThrow("unsafe path");
+    const maximumInventory = ["index.html", ...Array.from(
+      { length: 9_999 },
+      (_, index) => `asset-${index}.js`,
+    )].join("\n");
+    expect(validateWebConsoleArchiveEntries(maximumInventory).files).toHaveLength(10_000);
+    expect(() => validateWebConsoleArchiveEntries(`${maximumInventory}\noverflow.js`))
+      .toThrow("too many entries");
+    const materializedOverflow = ["index.html", ...Array.from(
+      { length: 5_000 },
+      (_, index) => `directory-${index}/asset.js`,
+    )].join("\n");
+    expect(() => validateWebConsoleArchiveEntries(materializedOverflow))
+      .toThrow("materializes too many entries");
+  });
+
+  test("rejects Web Console expanded bytes before filesystem extraction", async () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-console-expanded-")));
+    const source = join(directory, "source");
+    const archive = join(directory, "web-console-build.tar.gz");
+    try {
+      mkdirSync(source);
+      writeFileSync(join(source, "index.html"), "x".repeat(64));
+      expect(Bun.spawnSync(["tar", "-czf", archive, "-C", source, "."]).exitCode).toBe(0);
+      await expect(verifyWebConsoleArchiveExpandedSize(archive, 32))
+        .rejects.toThrow("exceeds the expanded size limit");
+      await expect(verifyWebConsoleArchiveExpandedSize(archive, 64)).resolves.toBeUndefined();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("extracts Web Console files with exact public modes under restrictive umask", async () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-console-mode-")));
+    const source = join(directory, "source");
+    const releases = join(directory, "releases");
+    const archive = join(directory, "web-console-build.tar.gz");
+    const owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+    mkdirSync(join(source, "_app"), { recursive: true });
+    mkdirSync(releases, { mode: 0o700 });
+    chmodSync(releases, 0o700);
+    writeFileSync(join(source, "index.html"), "<!doctype html><title>SupaCloud</title>\n", { mode: 0o600 });
+    writeFileSync(join(source, "_app", "entry.js"), "console.log('verified');\n", { mode: 0o700 });
+    const packed = Bun.spawnSync(["tar", "-czf", archive, "-C", source, "."]);
+    expect(packed.exitCode).toBe(0);
+
+    const originalUmask = process.umask(0o077);
+    try {
+      const staged = await extractWebConsoleArchive(
+        archive,
+        "management-api-v0.60.1",
+        { label: "test fixture", proxyPrefix: "" },
+        { releasesDir: releases, owner },
+      );
+      expect(statSync(staged.releaseDir).mode & 0o777).toBe(0o755);
+      expect(statSync(directory).mode & 0o777).toBe(0o755);
+      expect(statSync(releases).mode & 0o777).toBe(0o755);
+      expect(statSync(join(staged.releaseDir, "_app")).mode & 0o777).toBe(0o755);
+      expect(statSync(join(staged.releaseDir, "index.html")).mode & 0o777).toBe(0o644);
+      expect(statSync(join(staged.releaseDir, "_app", "entry.js")).mode & 0o777).toBe(0o644);
+      expect(readFileSync(join(staged.releaseDir, "index.html"), "utf8"))
+        .toBe("<!doctype html><title>SupaCloud</title>\n");
+      verifyWebConsoleReleaseTree(staged.releaseDir, staged.treeSha256, owner);
+
+      chmodSync(join(staged.releaseDir, "_app", "entry.js"), 0o600);
+      expect(() => verifyWebConsoleReleaseTree(staged.releaseDir, staged.treeSha256, owner))
+        .toThrow("mode is not 0644");
+      chmodSync(join(staged.releaseDir, "_app", "entry.js"), 0o644);
+      writeFileSync(join(staged.releaseDir, "_app", "entry.js"), "console.log('changed');\n", { mode: 0o644 });
+      expect(() => verifyWebConsoleReleaseTree(staged.releaseDir, staged.treeSha256, owner))
+        .toThrow("content tree changed");
+      expect(() => verifyWebConsoleReleaseTree(staged.releaseDir, staged.treeSha256, {
+        uid: owner.uid + 1,
+        gid: owner.gid,
+      })).toThrow("unsafe directory");
+    } finally {
+      process.umask(originalUmask);
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects Web Console link entries before creating an activatable release", async () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-console-links-")));
+    const source = join(directory, "source");
+    const releases = join(directory, "releases");
+    const archive = join(directory, "web-console-build.tar.gz");
+    const owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+    mkdirSync(source);
+    mkdirSync(releases, { mode: 0o700 });
+    chmodSync(releases, 0o700);
+    writeFileSync(join(source, "index.html"), "<!doctype html>\n");
+    symlinkSync("index.html", join(source, "linked.html"));
+    expect(Bun.spawnSync(["tar", "-czf", archive, "-C", source, "."]).exitCode).toBe(0);
+
+    try {
+      await expect(extractWebConsoleArchive(
+        archive,
+        "management-api-v0.60.1",
+        { label: "test fixture", proxyPrefix: "" },
+        { releasesDir: releases, owner },
+      )).rejects.toThrow("links or special files");
+      expect(readdirSync(releases)).toEqual([]);
+
+      rmSync(join(source, "linked.html"));
+      linkSync(join(source, "index.html"), join(source, "hard-linked.html"));
+      expect(Bun.spawnSync(["tar", "-czf", archive, "-C", source, "."]).exitCode).toBe(0);
+      await expect(extractWebConsoleArchive(
+        archive,
+        "management-api-v0.60.1",
+        { label: "test fixture", proxyPrefix: "" },
+        { releasesDir: releases, owner },
+      )).rejects.toThrow("links or special files");
+      expect(readdirSync(releases)).toEqual([]);
+
+      rmSync(join(source, "hard-linked.html"));
+      const fifoPath = join(source, "named-pipe");
+      expect(Bun.spawnSync(["mkfifo", fifoPath]).exitCode).toBe(0);
+      expect(Bun.spawnSync(["tar", "-czf", archive, "-C", source, "."]).exitCode).toBe(0);
+      await expect(extractWebConsoleArchive(
+        archive,
+        "management-api-v0.60.1",
+        { label: "test fixture", proxyPrefix: "" },
+        { releasesDir: releases, owner },
+      )).rejects.toThrow("links or special files");
+      expect(readdirSync(releases)).toEqual([]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("atomically activates and restores the Web Console current symlink", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-console-link-")));
+    const current = join(directory, "current");
+    const previous = join(directory, "previous");
+    const target = join(directory, "target");
+    const owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+    try {
+      chmodSync(directory, 0o755);
+      mkdirSync(previous);
+      mkdirSync(target);
+      symlinkSync(previous, current);
+      const activation = prepareWebConsoleLinkActivation(current, target, owner);
+      expect(readlinkSync(current)).toBe(previous);
+      expect(lstatSync(activation.nextLink).isSymbolicLink()).toBe(true);
+      activatePreparedWebConsoleLink(activation);
+      expect(readlinkSync(current)).toBe(target);
+      expect(existsSync(activation.nextLink)).toBe(false);
+      restoreWebConsoleLink(activation);
+      expect(readlinkSync(current)).toBe(previous);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses to overwrite a drifted Web Console current target during rollback", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-console-link-drift-")));
+    const current = join(directory, "current");
+    const previous = join(directory, "previous");
+    const target = join(directory, "target");
+    const unexpected = join(directory, "unexpected");
+    const owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+    try {
+      chmodSync(directory, 0o755);
+      for (const release of [previous, target, unexpected]) mkdirSync(release);
+      symlinkSync(previous, current);
+      const activation = prepareWebConsoleLinkActivation(current, target, owner);
+      activatePreparedWebConsoleLink(activation);
+      const replacement = join(directory, "replacement");
+      symlinkSync(unexpected, replacement);
+      renameSync(replacement, current);
+      expect(() => restoreWebConsoleLink(activation)).toThrow("changed before rollback");
+      expect(readlinkSync(current)).toBe(unexpected);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the previous Web Console target when prepared activation fails", () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-web-console-link-failure-")));
+    const current = join(directory, "current");
+    const previous = join(directory, "previous");
+    const target = join(directory, "target");
+    const owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+    try {
+      chmodSync(directory, 0o755);
+      mkdirSync(previous);
+      mkdirSync(target);
+      symlinkSync(previous, current);
+      const activation = prepareWebConsoleLinkActivation(current, target, owner);
+      rmSync(activation.nextLink);
+
+      expect(() => activatePreparedWebConsoleLink(activation)).toThrow();
+      expect(readlinkSync(current)).toBe(previous);
+      expect(activation.activated).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("retains helper evidence after internal recovery fails and outer rollback continues", async () => {
+    const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-helper-combined-recovery-")));
+    const helperTarget = join(directory, "systemd-unit");
+    const managementBackup = join(directory, "management.bak");
+    const owner = { uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 };
+    const previousContent = "#!/bin/sh\nprintf previous-helper\\n\n";
+    try {
+      writeFileSync(helperTarget, previousContent, { mode: 0o755 });
+      chmodSync(helperTarget, 0o755);
+      const previous = readPrivilegedHelperIdentity(helperTarget, owner);
+      const staged = stageEmbeddedSystemdUnitBroker(helperTarget, "combined", owner);
+      const prepared = prepareSystemdUnitBrokerActivation({
+        staged,
+        targetPath: helperTarget,
+        runId: "combined",
+        owner,
+        expectedPrevious: previous,
+      });
+      let activationFailure: unknown;
+      try {
+        activatePreparedSystemdUnitBroker(prepared, {
+          syncDirectory: () => { throw new Error("directory fsync failed after rename"); },
+          verifyInstalled: () => { throw new Error("verification must not run after fsync failure"); },
+          restore: () => { throw new Error("internal helper restore failed"); },
+        });
+      } catch (error: unknown) {
+        activationFailure = error;
+      }
+
+      expect(activationFailure).toBeInstanceOf(AggregateError);
+      expect(prepared.state.activated).toBe(true);
+      const frozenBackup = readPrivilegedHelperIdentity(
+        prepared.state.backupPath,
+        owner,
+        previous.mode,
+      );
+      expect(frozenBackup.content).toEqual(previous.content);
+      expect(frozenBackup.mode).toBe(previous.mode);
+
+      writeFileSync(managementBackup, "previous-management", { mode: 0o755 });
+      const activationState: UpgradeActivationState = {
+        binary: {
+          targetPath: join(directory, "missing-parent", "management"),
+          backupPath: managementBackup,
+          hadTarget: true,
+          backupReady: true,
+          activated: true,
+        },
+        edgeBinary: null,
+        systemdUnitBroker: prepared.state,
+        webConsoleLink: null,
+        managementEnvState: null,
+        edgeRuntimeEnvState: null,
+        edgeRuntimeDropInState: null,
+        managementPrivilegeDropInState: null,
+        embeddedEdgePrivilegeDropInState: null,
+      };
+      let rollbackFailure: unknown;
+      try {
+        await rollbackArtifacts(activationState, []);
+      } catch (error: unknown) {
+        rollbackFailure = error;
+      }
+
+      expect(rollbackFailure).toBeInstanceOf(AggregateError);
+      expect(readFileSync(helperTarget, "utf8")).toBe(previousContent);
+      expect(prepared.state.activated).toBe(false);
+      const recoveryPaths = upgradeRecoveryPaths({ activation: activationState });
+      expect(recoveryPaths).toContain(prepared.state.backupPath);
+      const failure = new UpgradeTransactionError(
+        "rollback-incomplete",
+        [activationFailure, rollbackFailure],
+        "Upgrade failed and rollback did not complete",
+      );
+      expect(formatUpgradeFailure(failure, recoveryPaths)).toContain(prepared.state.backupPath);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("attempts every recovery action before reporting aggregate failures", async () => {
+    const attempted: string[] = [];
+    await expect(executeUpgradeRecoveryActions([
+      { description: "Management restore", run: () => { attempted.push("management"); throw new Error("failed"); } },
+      { description: "helper restore", run: () => { attempted.push("helper"); } },
+      { description: "health read-back", run: async () => { attempted.push("health"); throw new Error("unhealthy"); } },
+    ])).rejects.toBeInstanceOf(AggregateError);
+    expect(attempted).toEqual(["management", "helper", "health"]);
   });
 
   test("restores runtime env and systemd drop-in contents, permissions, and absence exactly", () => {

--- a/scripts/lib/systemd_unit_broker.sh
+++ b/scripts/lib/systemd_unit_broker.sh
@@ -53,7 +53,7 @@ validate_environment_file() {
 
 validate_unit_content() {
     local section="" line key value user="" group="" seen_unit=0 seen_service=0 seen_install=0 seen_nnp=0 seen_env_file=0
-    local unit_bytes
+    local unit_bytes environment_file_ok=0
     unit_bytes=$(wc -c < "$source_file")
     (( unit_bytes > 0 && unit_bytes <= 16384 )) || return 1
     cmp -s "$source_file" <(LC_ALL=C tr -d '\000-\011\013-\037\177' < "$source_file") || return 1
@@ -101,7 +101,10 @@ validate_unit_content() {
             group="$value"
         fi
     done < "$source_file"
-    [[ "$seen_unit" == 1 && "$seen_service" == 1 && "$seen_install" == 1 && "$seen_nnp" == 1 && "$seen_env_file" == 1 \
+    if [[ "$unit_name" == "supacloud-pgrst@.service" || "$seen_env_file" == 1 ]]; then
+        environment_file_ok=1
+    fi
+    [[ "$seen_unit" == 1 && "$seen_service" == 1 && "$seen_install" == 1 && "$seen_nnp" == 1 && "$environment_file_ok" == 1 \
         && -n "$user" && "$user" == "$group" ]] || return 1
     if [[ "$unit_name" == *'@'* && "$user" != "supacloud-%i" ]]; then
         return 1

--- a/scripts/lib/systemd_unit_broker.test.sh
+++ b/scripts/lib/systemd_unit_broker.test.sh
@@ -21,18 +21,39 @@ cat > "$TMP_DIR/bin/systemctl" <<'SH'
 SH
 chmod 755 "$TMP_DIR/bin/"*
 
+render_canonical_postgrest_unit() {
+  (
+    cd "$ROOT_DIR/packages/management-api"
+    bun -e '
+      import { renderPostgrestSystemdTemplate } from "./src/services/postgrest-systemd-template";
+      process.stdout.write(renderPostgrestSystemdTemplate({
+        postgrestRts: "-N2 -A8m",
+        postgrestBinary: "/opt/supacloud/postgrest-v16.1/bin/postgrest",
+        tenantConfigDir: "/etc/supabase/tenants",
+        memoryMax: "64M",
+        cpuWeight: 20,
+      }));
+    '
+  )
+}
+
 token=01234567-89ab-cdef-0123-456789abcdef
 printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
-printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+render_canonical_postgrest_unit > "$TMP_DIR/requests/$token.unit"
 
 sed \
   -e "s#request_dir=\"/run/supacloud-unit-requests\"#request_dir=\"$TMP_DIR/requests\"#" \
   -e "s#/etc/systemd/system/#$TMP_DIR/units/#g" \
   "$ROOT_DIR/scripts/lib/systemd_unit_broker.sh" > "$TMP_DIR/broker.sh"
 PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token"
-grep -Fq 'ExecStart=/bin/true' "$TMP_DIR/units/supacloud-pgrst@.service"
+grep -Fq 'ExecStart=/usr/local/libexec/supacloud/postgrest-launcher %i' "$TMP_DIR/units/supacloud-pgrst@.service"
 [[ ! -e "$TMP_DIR/requests/$token.request" ]]
 [[ ! -e "$TMP_DIR/requests/$token.unit" ]]
+
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStart=/usr/local/libexec/supacloud/postgrest-launcher %%i\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token"
+grep -Fq 'EnvironmentFile=/etc/supabase/tenants/%i.env' "$TMP_DIR/units/supacloud-pgrst@.service"
 
 printf 'operation=remove\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
 PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token"
@@ -60,6 +81,13 @@ if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1;
 fi
 
 printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nExecStart=+/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted a privileged execution prefix" >&2
+  exit 1
+fi
+
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
 printf '[Unit]\nDescription=bad\001value\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
 if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
   echo "broker accepted a control character" >&2
@@ -70,5 +98,27 @@ printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/req
 printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=-/etc/supabase/management-api.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
 if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
   echo "broker accepted the control-plane environment file" >&2
+  exit 1
+fi
+
+printf 'operation=install\nunit_name=supacloud-pgrst@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nEnvironmentFile=/etc/supabase/tenants/%%i.env\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted duplicate PostgREST environment files" >&2
+  exit 1
+fi
+
+printf 'operation=install\nunit_name=supacloud-gotrue@.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-%%i\nGroup=supacloud-%%i\nNoNewPrivileges=true\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted a GoTrue unit without its environment file" >&2
+  exit 1
+fi
+
+
+printf 'operation=install\nunit_name=supacloud-frontend-demo-abc123ff.service\n' > "$TMP_DIR/requests/$token.request"
+printf '[Unit]\nDescription=test\n[Service]\nType=oneshot\nUser=supacloud-demo\nGroup=supacloud-demo\nNoNewPrivileges=true\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' > "$TMP_DIR/requests/$token.unit"
+if PATH="$TMP_DIR/bin:$PATH" bash "$TMP_DIR/broker.sh" "$token" >/dev/null 2>&1; then
+  echo "broker accepted a frontend unit without its environment file" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- allow the canonical PostgREST launcher unit to omit EnvironmentFile while preserving the stricter GoTrue and frontend contracts
- embed and attest the privileged systemd broker in the target Management runner with atomic install, exact rollback, drift detection, and recovery evidence
- harden Web Console archive validation, public modes, atomic current activation, and rollback
- make Admin remote and local upgrade transports authenticate and execute the exact target Management runner, including frozen latest resolution
- document Admin as the only supported upgrade entrypoint, including protected offline local transport

## Task contract

- Task: `SUPACLOUD-UPGRADE-DOC-INTEGRATION-FOLLOWUP-20260815`
- Parent: `SUPACLOUD-UPGRADE-RUNNER-RECOVERY-HOTFIX-20260815`
- Source: `.mailbox/129-supacloud-upgrade-runner-platform-final-review.md`
- Orchestration: high-risk panel, one writer, isolated platform/security/workflow-release reviewers

## Verification

- Management focused: 114 pass, 0 fail
- Management complete unit suite: exit 0
- Management typecheck and SQL module sync: PASS
- Admin focused: 140 pass, 0 fail
- Admin complete: 465 pass, 26 skip, 0 fail
- Admin typecheck and build: PASS
- privileged broker shell regression and `bash -n`: PASS
- compiled embedded helper SHA-256 equals source: `5f0ab74c432bae79cf26f08e099a356bb3ced88e9956998d1ea9a9c8ee7e31b2`
- integrated commit diff and whitespace checks: PASS
- platform documentation reviewer: GO (`.mailbox/132`)
- parent security reviewer: GO (`.mailbox/130`)
- parent workflow/release/SDK reviewer: GO (`.mailbox/131`)
- clean-code-guard: clean

## Release boundary

Expected patch releases are Management `0.60.1` and Admin `0.14.1`. There is no workflow RPC, payload, authorization, or public SDK change, so `@supacloud/js` remains `0.22.0`. This change does not add DBOS.

Production upgrade and durable workflow canary remain blocked until this PR, required checks, release PRs, signed manifests, checksums, attestations, and exact target assets are verified.