### PR TITLE
fix(lite): support mirrored native postgres downloads

### DIFF
--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -135,8 +135,15 @@ supacloud-lite version
 - `SUPACLOUD_LITE_STORAGE_DIR`
 - `SUPACLOUD_LITE_STORAGE_BACKEND`：`fs`（默认）、`memory` 或 `s3`
 - `SUPACLOUD_LITE_S3_PREFIX`：S3 对象 key 前缀，可被 `--s3-prefix` 覆盖
+- `SUPACLOUD_LITE_POSTGRES_MIRROR`：native 引擎下载 PostgreSQL 发布包时使用的 HTTPS 镜像前缀，例如 `https://ghproxy.net/`
 - `SUPACLOUD_LITE_JWT_SECRET`
 - `SUPACLOUD_LITE_VAULT_KEY`
+
+native 引擎首次运行会下载约 12 MB 的 Theseus PostgreSQL 发布包并缓存在 `~/.cache/supacloud-lite`。网络无法直连 GitHub 时，可设置镜像前缀；Lite 会把完整上游 URL 追加到该前缀，并在解压执行前继续校验固定或上游发布的 SHA-256。镜像不能包含 URL 凭据、query 或 fragment；除 loopback 测试地址外必须使用 HTTPS。
+
+```bash
+SUPACLOUD_LITE_POSTGRES_MIRROR=https://ghproxy.net/ supacloud-lite migrate --engine native
+```
 
 使用远端 S3 时，启动前设置 `SUPACLOUD_LITE_STORAGE_BACKEND=s3`，并按 Bun S3 约定提供 `S3_BUCKET`、`S3_ACCESS_KEY_ID`、`S3_SECRET_ACCESS_KEY`、`S3_ENDPOINT`、`S3_REGION` 等变量；也支持对应的 `AWS_*` 变量。CLI 不接受密钥参数，避免凭据出现在进程列表中。
 
@@ -469,8 +476,15 @@ Environment variables:
 - `SUPACLOUD_LITE_STORAGE_DIR`
 - `SUPACLOUD_LITE_STORAGE_BACKEND`: `fs` (default), `memory`, or `s3`
 - `SUPACLOUD_LITE_S3_PREFIX`: S3 object key prefix, can be overridden by `--s3-prefix`
+- `SUPACLOUD_LITE_POSTGRES_MIRROR`: HTTPS prefix used to proxy native-engine PostgreSQL release downloads, for example `https://ghproxy.net/`
 - `SUPACLOUD_LITE_JWT_SECRET`
 - `SUPACLOUD_LITE_VAULT_KEY`
+
+On its first run, the native engine downloads an approximately 12 MB Theseus PostgreSQL release into `~/.cache/supacloud-lite`. If GitHub is not directly reachable, set a mirror prefix; Lite appends the complete upstream URL and still verifies the pinned or published SHA-256 before extracting or executing the archive. The mirror must not contain URL credentials, a query, or a fragment, and must use HTTPS except for loopback test endpoints.
+
+```bash
+SUPACLOUD_LITE_POSTGRES_MIRROR=https://ghproxy.net/ supacloud-lite migrate --engine native
+```
 
 When using remote S3, set `SUPACLOUD_LITE_STORAGE_BACKEND=s3` before starting, and provide variables such as `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_ENDPOINT`, and `S3_REGION` according to Bun S3 conventions; the corresponding `AWS_*` variables are also supported. The CLI does not accept secret parameters to avoid credentials appearing in the process list.
 

--- a/packages/supacloud-lite/src/runtime/node/native/engine.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/engine.ts
@@ -18,6 +18,8 @@ import { PgWireClient } from './wire.js'
 import { buildWireEngine } from './wire-engine.js'
 
 const DEFAULT_PG_VERSION = '17.7.0'
+const POSTGRES_MIRROR_URL_ERROR =
+  'SUPACLOUD_LITE_POSTGRES_MIRROR must be an absolute HTTPS URL or a loopback HTTP URL'
 export const NATIVE_POSTGRES_MAJOR = DEFAULT_PG_VERSION.split('.')[0]!
 
 /** Options for {@link createNativeEngine}. */
@@ -30,6 +32,8 @@ export interface NativeEngineOptions {
   cacheDir?: string
   /** sink for progress lines (download, install); no-op when omitted */
   log?: (msg: string) => void
+  /** Optional HTTPS or loopback HTTP prefix for proxying the PostgreSQL release download. */
+  downloadMirror?: string
 }
 
 export function isNativeEngineSupported(): boolean {
@@ -77,7 +81,7 @@ const PINNED_SHA256: Record<string, string> = {
 }
 
 /** Verify `tarball` against a pinned digest, else the release's published .sha256. */
-async function verifyTarball(tarball: string, key: string, url: string): Promise<void> {
+async function verifyTarball(tarball: string, key: string, upstreamUrl: string, downloadMirror?: string): Promise<void> {
   const actual = createHash('sha256').update(readFileSync(tarball)).digest('hex')
   const pinned = PINNED_SHA256[key]
   if (pinned) {
@@ -87,7 +91,8 @@ async function verifyTarball(tarball: string, key: string, url: string): Promise
     return
   }
   // No local pin - verify against the checksum the release publishes.
-  const res = await fetchRelease(`${url}.sha256`)
+  const checksumUrl = resolvePostgresDownloadUrl(`${upstreamUrl}.sha256`, downloadMirror)
+  const res = await fetchRelease(checksumUrl)
   if (!res.ok) throw new Error(`could not fetch checksum for ${key}: HTTP ${res.status}`)
   const expected = (await res.text()).trim().split(/\s+/)[0].toLowerCase()
   if (!/^[0-9a-f]{64}$/.test(expected)) throw new Error(`malformed published checksum for ${key}`)
@@ -97,7 +102,12 @@ async function verifyTarball(tarball: string, key: string, url: string): Promise
 }
 
 /** Download + unpack Postgres binaries if not already cached (concurrency-safe). Returns the install dir. */
-export async function ensurePostgres(version = DEFAULT_PG_VERSION, cacheDir?: string, log?: (m: string) => void): Promise<string> {
+export async function ensurePostgres(
+  version = DEFAULT_PG_VERSION,
+  cacheDir?: string,
+  log?: (m: string) => void,
+  downloadMirror?: string,
+): Promise<string> {
   const t = target()
   const root = cacheDir ?? join(homedir(), '.cache', 'supacloud-lite')
   const dir = join(root, `postgresql-${version}-${t}`)
@@ -107,7 +117,8 @@ export async function ensurePostgres(version = DEFAULT_PG_VERSION, cacheDir?: st
   // a cold cache. Each downloads + extracts to unique temp paths, then atomically
   // renames into place - so no worker ever sees a half-written tarball or a
   // partially-extracted install dir.
-  const url = `https://github.com/theseus-rs/postgresql-binaries/releases/download/${version}/postgresql-${version}-${t}.tar.gz`
+  const upstreamUrl = `https://github.com/theseus-rs/postgresql-binaries/releases/download/${version}/postgresql-${version}-${t}.tar.gz`
+  const url = resolvePostgresDownloadUrl(upstreamUrl, downloadMirror)
   mkdirSync(root, { recursive: true })
   const uniq = `${process.pid}-${randomBytes(6).toString('hex')}`
   const tarball = join(root, `pg-${version}-${uniq}.tar.gz`)
@@ -120,7 +131,7 @@ export async function ensurePostgres(version = DEFAULT_PG_VERSION, cacheDir?: st
     if (!res.ok) throw new Error(`failed to download ${url}: HTTP ${res.status}`)
     await writeFile(tarball, Buffer.from(await res.arrayBuffer()))
     // Integrity-check the tarball before executing anything it contains.
-    await verifyTarball(tarball, `postgresql-${version}-${t}`, url)
+    await verifyTarball(tarball, `postgresql-${version}-${t}`, upstreamUrl, downloadMirror)
     mkdirSync(tmpDir, { recursive: true })
     await extractTar({ cwd: tmpDir, file: tarball, gzip: true, preserveOwner: false, strict: true, strip: 1 })
     if (!isCompleteInstall(tmpDir)) throw new Error('postgres archive extracted incompletely')
@@ -140,6 +151,37 @@ export async function ensurePostgres(version = DEFAULT_PG_VERSION, cacheDir?: st
     rmSync(tarball, { force: true })
     rmSync(tmpDir, { recursive: true, force: true })
   }
+}
+
+/**
+ * Prefix a trusted GitHub release URL with an operator-selected mirror. The
+ * archive is still checked against the pinned or published SHA-256 before use.
+ */
+export function resolvePostgresDownloadUrl(upstreamUrl: string, downloadMirror?: string): string {
+  const mirror = postgresDownloadMirror(downloadMirror)
+  return mirror ? `${mirror.toString().replace(/\/+$/, '')}/${upstreamUrl}` : upstreamUrl
+}
+
+function postgresDownloadMirror(downloadMirror?: string): URL | undefined {
+  const configuredMirror = downloadMirror ?? process.env.SUPACLOUD_LITE_POSTGRES_MIRROR
+  const mirrorText = configuredMirror?.trim()
+  if (!mirrorText) return undefined
+  let mirror: URL
+  try {
+    mirror = new URL(mirrorText)
+  } catch {
+    throw new Error(POSTGRES_MIRROR_URL_ERROR)
+  }
+  const loopbackHttp = mirror.protocol === 'http:' &&
+    (mirror.hostname === '127.0.0.1' || mirror.hostname === 'localhost' || mirror.hostname === '[::1]')
+  if (mirror.protocol !== 'https:' && !loopbackHttp) throw new Error(POSTGRES_MIRROR_URL_ERROR)
+  if (mirror.username || mirror.password) {
+    throw new Error('SUPACLOUD_LITE_POSTGRES_MIRROR must not contain credentials')
+  }
+  if (mirrorText.includes('?') || mirrorText.includes('#')) {
+    throw new Error('SUPACLOUD_LITE_POSTGRES_MIRROR must not contain a query or fragment')
+  }
+  return mirror
 }
 
 async function fetchRelease(url: string): Promise<Response> {
@@ -179,7 +221,7 @@ export async function createNativeEngine(opts: NativeEngineOptions): Promise<DbE
   let postgres: ChildProcess | undefined
   let removeExitHandler: (() => void) | undefined
   try {
-    const installDir = await ensurePostgres(opts.version, opts.cacheDir, opts.log)
+    const installDir = await ensurePostgres(opts.version, opts.cacheDir, opts.log, opts.downloadMirror)
     const bin = (name: string) => join(installDir, 'bin', name)
 
     if (!existsSync(join(opts.dataDir, 'PG_VERSION'))) {

--- a/packages/supacloud-lite/test/native-download.test.ts
+++ b/packages/supacloud-lite/test/native-download.test.ts
@@ -4,7 +4,11 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { create as createTar } from 'tar'
-import { ensurePostgres, resolvePostgresDownloadUrl } from '../src/runtime/node/native/engine.js'
+import {
+  ensurePostgres,
+  isNativeEngineSupported,
+  resolvePostgresDownloadUrl,
+} from '../src/runtime/node/native/engine.js'
 
 const temporaryDirectories: string[] = []
 const servers: ReturnType<typeof Bun.serve>[] = []
@@ -41,44 +45,47 @@ describe('native PostgreSQL download mirror', () => {
     )
   })
 
-  test('retries a mirrored archive and fetches its checksum through the same mirror', async () => {
-    const testRoot = await mkdtemp(join(tmpdir(), 'supacloud-lite-native-download-'))
-    temporaryDirectories.push(testRoot)
-    const archivePayload = join(testRoot, 'payload', 'postgresql')
-    await mkdir(join(archivePayload, 'bin'), { recursive: true })
-    await mkdir(join(archivePayload, 'share'), { recursive: true })
-    await writeFile(join(archivePayload, 'bin', 'postgres'), 'fixture')
-    await writeFile(join(archivePayload, 'share', 'postgres.bki'), 'fixture')
-    const archive = join(testRoot, 'postgres.tar.gz')
-    await createTar({ cwd: join(testRoot, 'payload'), file: archive, gzip: true }, ['postgresql'])
-    const archiveBytes = await readFile(archive)
-    const digest = createHash('sha256').update(archiveBytes).digest('hex')
-    let archiveAttempts = 0
-    let checksumRequests = 0
-    const mirrorServer = Bun.serve({
-      hostname: '127.0.0.1',
-      port: 0,
-      fetch(request) {
-        const requestPath = new URL(request.url).pathname
-        if (requestPath.endsWith('.tar.gz.sha256')) {
-          checksumRequests += 1
-          return new Response(`${digest}  postgres.tar.gz\n`)
-        }
-        if (requestPath.endsWith('.tar.gz')) {
-          archiveAttempts += 1
-          return archiveAttempts < 3 ? new Response('retry', { status: 503 }) : new Response(archiveBytes)
-        }
-        return new Response('not found', { status: 404 })
-      },
-    })
-    servers.push(mirrorServer)
-    process.env.SUPACLOUD_LITE_POSTGRES_MIRROR = `http://127.0.0.1:${mirrorServer.port}`
+  test.skipIf(!isNativeEngineSupported())(
+    'retries a mirrored archive and fetches its checksum through the same mirror',
+    async () => {
+      const testRoot = await mkdtemp(join(tmpdir(), 'supacloud-lite-native-download-'))
+      temporaryDirectories.push(testRoot)
+      const archivePayload = join(testRoot, 'payload', 'postgresql')
+      await mkdir(join(archivePayload, 'bin'), { recursive: true })
+      await mkdir(join(archivePayload, 'share'), { recursive: true })
+      await writeFile(join(archivePayload, 'bin', 'postgres'), 'fixture')
+      await writeFile(join(archivePayload, 'share', 'postgres.bki'), 'fixture')
+      const archive = join(testRoot, 'postgres.tar.gz')
+      await createTar({ cwd: join(testRoot, 'payload'), file: archive, gzip: true }, ['postgresql'])
+      const archiveBytes = await readFile(archive)
+      const digest = createHash('sha256').update(archiveBytes).digest('hex')
+      let archiveAttempts = 0
+      let checksumRequests = 0
+      const mirrorServer = Bun.serve({
+        hostname: '127.0.0.1',
+        port: 0,
+        fetch(request) {
+          const requestPath = new URL(request.url).pathname
+          if (requestPath.endsWith('.tar.gz.sha256')) {
+            checksumRequests += 1
+            return new Response(`${digest}  postgres.tar.gz\n`)
+          }
+          if (requestPath.endsWith('.tar.gz')) {
+            archiveAttempts += 1
+            return archiveAttempts < 3 ? new Response('retry', { status: 503 }) : new Response(archiveBytes)
+          }
+          return new Response('not found', { status: 404 })
+        },
+      })
+      servers.push(mirrorServer)
+      process.env.SUPACLOUD_LITE_POSTGRES_MIRROR = `http://127.0.0.1:${mirrorServer.port}`
 
-    const installed = await ensurePostgres('99.0.0', join(testRoot, 'cache'))
+      const installed = await ensurePostgres('99.0.0', join(testRoot, 'cache'))
 
-    expect(await readFile(join(installed, 'bin', 'postgres'), 'utf8')).toBe('fixture')
-    expect(await readFile(join(installed, 'share', 'postgres.bki'), 'utf8')).toBe('fixture')
-    expect(archiveAttempts).toBe(3)
-    expect(checksumRequests).toBe(1)
-  })
+      expect(await readFile(join(installed, 'bin', 'postgres'), 'utf8')).toBe('fixture')
+      expect(await readFile(join(installed, 'share', 'postgres.bki'), 'utf8')).toBe('fixture')
+      expect(archiveAttempts).toBe(3)
+      expect(checksumRequests).toBe(1)
+    },
+  )
 })

--- a/packages/supacloud-lite/test/native-download.test.ts
+++ b/packages/supacloud-lite/test/native-download.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { create as createTar } from 'tar'
+import { ensurePostgres, resolvePostgresDownloadUrl } from '../src/runtime/node/native/engine.js'
+
+const temporaryDirectories: string[] = []
+const servers: ReturnType<typeof Bun.serve>[] = []
+const originalMirror = process.env.SUPACLOUD_LITE_POSTGRES_MIRROR
+
+afterEach(async () => {
+  if (originalMirror === undefined) delete process.env.SUPACLOUD_LITE_POSTGRES_MIRROR
+  else process.env.SUPACLOUD_LITE_POSTGRES_MIRROR = originalMirror
+  for (const server of servers.splice(0)) server.stop(true)
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('native PostgreSQL download mirror', () => {
+  test('keeps the default URL and validates mirror prefixes without reflecting credentials', () => {
+    const upstream = 'https://github.com/theseus-rs/postgresql-binaries/releases/download/17.7.0/archive.tar.gz'
+    expect(resolvePostgresDownloadUrl(upstream, '')).toBe(upstream)
+    expect(resolvePostgresDownloadUrl(upstream, 'https://mirror.example/proxy/')).toBe(
+      `https://mirror.example/proxy/${upstream}`
+    )
+    expect(() => resolvePostgresDownloadUrl(upstream, 'http://mirror.example')).toThrow(
+      'must be an absolute HTTPS URL or a loopback HTTP URL'
+    )
+    expect(() => resolvePostgresDownloadUrl(upstream, 'https://user:secret@mirror.example')).toThrow(
+      'must not contain credentials'
+    )
+    expect(() => resolvePostgresDownloadUrl(upstream, 'https://mirror.example/?token=secret')).toThrow(
+      'must not contain a query or fragment'
+    )
+    expect(() => resolvePostgresDownloadUrl(upstream, 'https://mirror.example/?')).toThrow(
+      'must not contain a query or fragment'
+    )
+    expect(() => resolvePostgresDownloadUrl(upstream, 'https://mirror.example/#')).toThrow(
+      'must not contain a query or fragment'
+    )
+  })
+
+  test('retries a mirrored archive and fetches its checksum through the same mirror', async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), 'supacloud-lite-native-download-'))
+    temporaryDirectories.push(testRoot)
+    const archivePayload = join(testRoot, 'payload', 'postgresql')
+    await mkdir(join(archivePayload, 'bin'), { recursive: true })
+    await mkdir(join(archivePayload, 'share'), { recursive: true })
+    await writeFile(join(archivePayload, 'bin', 'postgres'), 'fixture')
+    await writeFile(join(archivePayload, 'share', 'postgres.bki'), 'fixture')
+    const archive = join(testRoot, 'postgres.tar.gz')
+    await createTar({ cwd: join(testRoot, 'payload'), file: archive, gzip: true }, ['postgresql'])
+    const archiveBytes = await readFile(archive)
+    const digest = createHash('sha256').update(archiveBytes).digest('hex')
+    let archiveAttempts = 0
+    let checksumRequests = 0
+    const mirrorServer = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch(request) {
+        const requestPath = new URL(request.url).pathname
+        if (requestPath.endsWith('.tar.gz.sha256')) {
+          checksumRequests += 1
+          return new Response(`${digest}  postgres.tar.gz\n`)
+        }
+        if (requestPath.endsWith('.tar.gz')) {
+          archiveAttempts += 1
+          return archiveAttempts < 3 ? new Response('retry', { status: 503 }) : new Response(archiveBytes)
+        }
+        return new Response('not found', { status: 404 })
+      },
+    })
+    servers.push(mirrorServer)
+    process.env.SUPACLOUD_LITE_POSTGRES_MIRROR = `http://127.0.0.1:${mirrorServer.port}`
+
+    const installed = await ensurePostgres('99.0.0', join(testRoot, 'cache'))
+
+    expect(await readFile(join(installed, 'bin', 'postgres'), 'utf8')).toBe('fixture')
+    expect(await readFile(join(installed, 'share', 'postgres.bki'), 'utf8')).toBe('fixture')
+    expect(archiveAttempts).toBe(3)
+    expect(checksumRequests).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- add `SUPACLOUD_LITE_POSTGRES_MIRROR` and `NativeEngineOptions.downloadMirror` for native PostgreSQL release downloads
- proxy both the archive and non-pinned checksum URL while preserving pinned/published SHA-256 verification
- fail closed for non-HTTPS remote mirrors, URL credentials, queries, and fragments
- document domestic GitHub proxy usage in Chinese and English

## Why

Post-release verification of SupaCloud Lite v0.8.1 found that a fresh native-engine HOME could not bootstrap when the hard-coded Theseus GitHub asset was unreachable. The existing retries kept using the same URL and there was no mirror entry point. A domestic proxy returned the same pinned asset successfully.

## Verification

- `bun test test/native-download.test.ts --timeout 20000` — 2 pass, 11 assertions
- `bun run typecheck` — pass
- `bun run check` — 174 pass, 1 native-only skip; build/package/standalone smoke pass
- `bun run check:native` — native 4/4, parity 14/14
- fresh HOME candidate standalone with `SUPACLOUD_LITE_POSTGRES_MIRROR=https://ghproxy.net/` — native download/bootstrap and extended Auth 17/17 pass
- independent recovery verifier — PASS (`.mailbox/060-lite-native-download-mirror-verifier-recovery.md`)
- `git diff --check` and clean-code guard — pass

No remote server or production data was touched.