### PR TITLE
fix(upgrade): deliver PostgREST launcher transactionally

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -411,6 +411,10 @@ describe("local upgrade remote runner", () => {
 
         try {
             const managementPackageRoot = realpathSync(join(import.meta.dir, "../../../../management-api"));
+            if (!existsSync(join(managementPackageRoot, "node_modules"))) {
+                const installResult = Bun.spawnSync(["bun", "install", "--frozen-lockfile"], { cwd: managementPackageRoot });
+                expect(installResult.exitCode, installResult.stderr?.toString() ?? "bun install failed").toBe(0);
+            }
             const compilation = Bun.spawnSync([
                 "bun",
                 "build",
@@ -418,7 +422,7 @@ describe("local upgrade remote runner", () => {
                 "--compile",
                 `--outfile=${runnerAsset}`,
             ], { cwd: managementPackageRoot });
-            expect(compilation.exitCode).toBe(0);
+            expect(compilation.exitCode, compilation.stderr?.toString() ?? "compilation failed").toBe(0);
 
             const runnerBytes = readFileSync(runnerAsset);
             const runnerFile: LocalUpgradeFile = {

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, spyOn, test } from "bun:test";
-import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -13,6 +14,7 @@ import {
     buildRemotePreflightScript,
     buildRemoteUpgradePaths,
     buildRemoteStateScript,
+    buildTargetRunnerCapabilityScript,
     buildUploadDropCleanupFailure,
     buildUpgradeLockScript,
     failureRequiresRemoteReconciliation,
@@ -21,6 +23,7 @@ import {
     startRemoteUpgrade,
 } from "./local-upgrade-transfer";
 import { githubCliArchiveIdentity, type LocalUpgradeFile, type PreparedLocalUpgradeBundle } from "./local-upgrade-bundle";
+import managementPackage from "../../../../management-api/package.json";
 
 const paths = {
     drop: "/var/tmp/.supacloud-upgrade-upload-11111111-1111-4111-8111-111111111111",
@@ -315,12 +318,140 @@ describe("local upgrade remote runner", () => {
         expect(script).toContain("--target-version '0.50.31'");
         expect(script).toContain("--edge-runtime-version '0.16.8'");
         expect(script).toContain('timeout 5s "$RUNNER" --systemd-unit-helper-sha256');
+        expect(script).toContain('timeout 5s "$RUNNER" --postgrest-launcher-sha256');
         expect(script).toContain("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE");
         expect(script).toContain("SUPACLOUD_ATTESTATION_TRUSTED_ROOT");
         expect(script).not.toContain("verify_manifest()");
         expect(script).not.toContain("MANAGEMENT_COMMIT");
         expect(script).not.toContain("jq ");
     });
+
+    test("rejects missing or malformed launcher capability before target-runner adoption", () => {
+        const fixtureDirectory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-runner-capability-")));
+        const drop = join(fixtureDirectory, "drop");
+        const runnerAsset = join(drop, "bundle/management-api/supacloud-linux-amd64");
+        const capabilityPaths = { ...paths, drop };
+        mkdirSync(join(drop, "bundle/management-api"), { recursive: true, mode: 0o700 });
+
+        const runCapability = (launcherCommand: string) => {
+            const source = [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                "case \"${1:-}\" in",
+                "  --version) printf 'SupaCloud Version: 0.50.31\\n' ;;",
+                `  --systemd-unit-helper-sha256) printf 'SupaCloud systemd-unit helper SHA-256: ${"a".repeat(64)}\\n' ;;`,
+                `  --postgrest-launcher-sha256) ${launcherCommand} ;;`,
+                "  *) exit 2 ;;",
+                "esac",
+            ].join("\n");
+            writeFileSync(runnerAsset, source, { mode: 0o600 });
+            chmodSync(runnerAsset, 0o600);
+            const runnerFile: LocalUpgradeFile = {
+                localPath: runnerAsset,
+                relativePath: "bundle/management-api/supacloud-linux-amd64",
+                sha256: createHash("sha256").update(source).digest("hex"),
+                size: Buffer.byteLength(source),
+            };
+            const bundle: PreparedLocalUpgradeBundle = {
+                directory: fixtureDirectory,
+                files: [runnerFile],
+                verifierArchive: null,
+                managementBinaryName: "supacloud-linux-amd64",
+                edgeRuntimeBinaryName: "supacloud-edge-runtime-linux-amd64",
+            };
+            const linuxScript = buildTargetRunnerCapabilityScript(capabilityPaths, bundle, {
+                managementVersion: "0.50.31",
+                edgeRuntimeVersion: "0.16.8",
+            });
+            let script = process.platform === "darwin"
+                ? linuxScript.replaceAll("stat -c '%h'", "stat -f '%l'")
+                    .replaceAll("stat -c '%s'", "stat -f '%z'")
+                : linuxScript;
+            if (!Bun.which("timeout")) script = script.replaceAll("timeout 5s ", "");
+            expect(Bun.spawnSync(["bash", "-n", "-c", script]).exitCode).toBe(0);
+            return Bun.spawnSync(["bash", "-c", script]);
+        };
+
+        try {
+            expect(runCapability("exit 2").exitCode).not.toBe(0);
+            const malformed = runCapability("printf 'unexpected launcher identity\\n'");
+            expect(malformed.stderr.toString()).toContain("lacks PostgREST launcher delivery");
+            expect(malformed.exitCode).not.toBe(0);
+            const success = runCapability(
+                `printf 'SupaCloud PostgREST launcher SHA-256: ${"b".repeat(64)}\\n'`,
+            );
+            expect(success.stderr.toString()).toBe("");
+            expect(success.exitCode).toBe(0);
+            expect(readdirSync(drop).filter(name => name.startsWith(".runner-capability."))).toEqual([]);
+        } finally {
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    });
+
+    test("accepts the exact identities emitted by a compiled Management runner", () => {
+        const fixtureDirectory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-compiled-capability-")));
+        const drop = join(fixtureDirectory, "drop");
+        const runnerAsset = join(drop, "bundle/management-api/supacloud-linux-amd64");
+        const commandDirectory = join(fixtureDirectory, "commands");
+        mkdirSync(join(drop, "bundle/management-api"), { recursive: true, mode: 0o700 });
+        mkdirSync(commandDirectory, { mode: 0o700 });
+        writeFileSync(join(commandDirectory, "timeout"), [
+            "#!/usr/bin/env bun",
+            "const [duration, executable, ...args] = process.argv.slice(2);",
+            "if (duration !== '5s' || !executable) process.exit(64);",
+            "const child = Bun.spawn([executable, ...args], { stdin: 'inherit', stdout: 'inherit', stderr: 'inherit' });",
+            "let timedOut = false;",
+            "const timer = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, 5000);",
+            "const exitCode = await child.exited;",
+            "clearTimeout(timer);",
+            "process.exit(timedOut ? 124 : exitCode);",
+            "",
+        ].join("\n"), { mode: 0o700 });
+        chmodSync(join(commandDirectory, "timeout"), 0o700);
+
+        try {
+            const managementPackageRoot = realpathSync(join(import.meta.dir, "../../../../management-api"));
+            const compilation = Bun.spawnSync([
+                "bun",
+                "build",
+                "src/standalone.ts",
+                "--compile",
+                `--outfile=${runnerAsset}`,
+            ], { cwd: managementPackageRoot });
+            expect(compilation.exitCode).toBe(0);
+
+            const runnerBytes = readFileSync(runnerAsset);
+            const runnerFile: LocalUpgradeFile = {
+                localPath: runnerAsset,
+                relativePath: "bundle/management-api/supacloud-linux-amd64",
+                sha256: createHash("sha256").update(runnerBytes).digest("hex"),
+                size: runnerBytes.byteLength,
+            };
+            const bundle: PreparedLocalUpgradeBundle = {
+                directory: fixtureDirectory,
+                files: [runnerFile],
+                verifierArchive: null,
+                managementBinaryName: "supacloud-linux-amd64",
+                edgeRuntimeBinaryName: "supacloud-edge-runtime-linux-amd64",
+            };
+            let script = buildTargetRunnerCapabilityScript({ ...paths, drop }, bundle, {
+                managementVersion: managementPackage.version,
+                edgeRuntimeVersion: "0.16.8",
+            });
+            if (process.platform === "darwin") {
+                script = script.replaceAll("stat -c '%h'", "stat -f '%l'")
+                    .replaceAll("stat -c '%s'", "stat -f '%z'");
+            }
+            const execution = Bun.spawnSync(["bash", "-c", script], {
+                env: { ...process.env, PATH: `${commandDirectory}:${process.env.PATH ?? ""}` },
+            });
+            expect(execution.exitCode).toBe(0);
+            expect(execution.stdout.toString()).toBe("");
+            expect(execution.stderr.toString()).toBe("");
+        } finally {
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    }, { timeout: 40_000 });
 
     test("executes transfer verification with nounset enabled", () => {
         const script = runScript(preparedBundle("amd64", "bundled"), "amd64");

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -11,6 +11,7 @@ import {
     githubCliArchiveIdentity,
     prepareLocalUpgradeBundle,
     STRICT_GITHUB_CAPABILITY_FLAGS,
+    type LocalUpgradeFile,
     type PreparedLocalUpgradeBundle,
     type UpgradeArchitecture,
 } from "./local-upgrade-bundle";
@@ -117,7 +118,7 @@ export function buildRemotePreflightScript(): string {
         "export PATH",
         trustedInstalledGithubFunction(),
         "test -d /run/systemd/system || { echo 'systemd is not the active init system' >&2; exit 1; }",
-        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep tail timeout flock; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep tail timeout flock install mktemp; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
         "tail -n 0 -- /dev/null >/dev/null 2>&1 || { echo 'A tail implementation with -n and -- support is required' >&2; exit 1; }",
         "systemd-run --help | grep -Eq -- '(^|[[:space:]])--collect([=[:space:]]|$)' || { echo 'systemd-run --collect is required' >&2; exit 1; }",
         "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
@@ -193,6 +194,65 @@ async function uploadBundleFiles(ssh: SshTransport, paths: RemoteUpgradePaths, b
     const uploads = [...bundle.files, ...(bundle.verifierArchive ? [bundle.verifierArchive] : [])];
     for (const upload of uploads) {
         await ssh.upload(upload.localPath, `${paths.drop}/${upload.relativePath}`, { mode: 0o600, timeoutMs: 10 * 60_000 });
+    }
+}
+
+function managementRunnerFile(bundle: PreparedLocalUpgradeBundle): LocalUpgradeFile {
+    const relativePath = `bundle/management-api/${bundle.managementBinaryName}`;
+    const runner = bundle.files.find(file => file.relativePath === relativePath);
+    if (!runner) throw new Error(`Local upgrade bundle is missing ${relativePath}`);
+    return runner;
+}
+
+function targetRunnerCapabilityCommands(): string[] {
+    return [
+        "RUNNER=$(mktemp \"$DROP/.runner-capability.XXXXXX\")",
+        "trap 'rm -f -- \"$RUNNER\"' EXIT",
+        "trap 'trap - EXIT HUP INT TERM; rm -f -- \"$RUNNER\"; exit 1' HUP INT TERM",
+        "install -m 0700 \"$RUNNER_ASSET\" \"$RUNNER\"",
+        "test \"$(sha256sum \"$RUNNER\" | awk '{print $1}')\" = \"$EXPECTED_SHA256\"",
+        "VERSION_OUTPUT=$(timeout 5s \"$RUNNER\" --version 2>&1)",
+        "[[ \"$VERSION_OUTPUT\" =~ ^SupaCloud[[:space:]]Version:[[:space:]]${EXPECTED_VERSION//./\\.}$ ]] || { echo 'Target Management runner version mismatch' >&2; exit 1; }",
+        "SYSTEMD_HELPER_OUTPUT=$(timeout 5s \"$RUNNER\" --systemd-unit-helper-sha256 2>&1)",
+        "[[ \"$SYSTEMD_HELPER_OUTPUT\" =~ ^SupaCloud[[:space:]]systemd-unit[[:space:]]helper[[:space:]]SHA-256:[[:space:]][0-9a-f]{64}$ ]] || { echo 'Target Management runner lacks systemd-unit helper delivery' >&2; exit 1; }",
+        "POSTGREST_LAUNCHER_OUTPUT=$(timeout 5s \"$RUNNER\" --postgrest-launcher-sha256 2>&1)",
+        "[[ \"$POSTGREST_LAUNCHER_OUTPUT\" =~ ^SupaCloud[[:space:]]PostgREST[[:space:]]launcher[[:space:]]SHA-256:[[:space:]][0-9a-f]{64}$ ]] || { echo 'Target Management runner lacks PostgREST launcher delivery' >&2; exit 1; }",
+        "rm -f -- \"$RUNNER\"",
+        "trap - EXIT HUP INT TERM",
+    ];
+}
+
+export function buildTargetRunnerCapabilityScript(
+    paths: RemoteUpgradePaths,
+    bundle: PreparedLocalUpgradeBundle,
+    request: LocalUpgradeTransferRequest,
+): string {
+    const runnerFile = managementRunnerFile(bundle);
+    const runnerAsset = `${paths.drop}/${runnerFile.relativePath}`;
+    return [
+        "set -euo pipefail",
+        "umask 077",
+        `DROP=${quoteShell(paths.drop)}`,
+        `RUNNER_ASSET=${quoteShell(runnerAsset)}`,
+        `EXPECTED_SIZE=${runnerFile.size}`,
+        `EXPECTED_SHA256=${quoteShell(runnerFile.sha256)}`,
+        `EXPECTED_VERSION=${quoteShell(request.managementVersion)}`,
+        "test -f \"$RUNNER_ASSET\" && test ! -L \"$RUNNER_ASSET\" && test \"$(stat -c '%h' \"$RUNNER_ASSET\")\" = 1 || { echo 'Target Management runner is not a direct single-link file' >&2; exit 1; }",
+        "test \"$(stat -c '%s' \"$RUNNER_ASSET\")\" = \"$EXPECTED_SIZE\"",
+        "test \"$(sha256sum \"$RUNNER_ASSET\" | awk '{print $1}')\" = \"$EXPECTED_SHA256\"",
+        ...targetRunnerCapabilityCommands(),
+    ].join("\n");
+}
+
+async function verifyTargetRunnerCapability(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+    bundle: PreparedLocalUpgradeBundle,
+    request: LocalUpgradeTransferRequest,
+): Promise<void> {
+    const verified = await ssh.exec(buildTargetRunnerCapabilityScript(paths, bundle, request), 30_000);
+    if (!verified.success) {
+        throw remoteFailure("Target Management runner lacks required transactional helper delivery", verified);
     }
 }
 
@@ -353,6 +413,7 @@ function upgradeScriptExecution(
         "test \"$(sha256sum \"$RUNNER\"|awk '{print $1}')\" = \"$(sha256sum \"$RUNNER_ASSET\"|awk '{print $1}')\"",
         "\"$RUNNER\" --version | grep -Eq \"(^|[^0-9])${MANAGEMENT_VERSION//./\\.}([^0-9]|$)\"",
         "timeout 5s \"$RUNNER\" --systemd-unit-helper-sha256 | grep -Eq 'SupaCloud systemd-unit helper SHA-256: [0-9a-f]{64}'",
+        "timeout 5s \"$RUNNER\" --postgrest-launcher-sha256 | grep -Eq 'SupaCloud PostgREST launcher SHA-256: [0-9a-f]{64}'",
         `env PATH=\"$VERIFIER_PATH:$PATH\" \"$RUNNER\" upgrade --yes --target-version ${quoteShell(request.managementVersion)} --edge-runtime-version ${quoteShell(request.edgeRuntimeVersion)} --asset-bundle-dir \"$BUNDLE\"`,
     ];
 }
@@ -846,6 +907,7 @@ export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: Lo
         try {
             await prepareRemoteDrop(ssh, paths, bundle);
             await uploadBundleFiles(ssh, paths, bundle);
+            await verifyTargetRunnerCapability(ssh, paths, bundle, request);
             await uploadRunScript(ssh, paths, bundle, request, preflight.architecture);
             await adoptRemoteDrop(ssh, paths);
             adopted = true;

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -572,6 +572,37 @@ function rootScriptThroughBootstrap(rootScript: string, continuationPath: string
         `touch '${continuationPath}'`].join("\n");
 }
 
+function remoteManagementCapabilityProbe(rootScript: string): string {
+    const scriptLines = rootScript.split("\n");
+    const versionProbeIndex = scriptLines.findIndex(line => line.startsWith("STAGED_VERSION="));
+    const launcherGateIndex = scriptLines.findIndex(line => line.startsWith('[[ "$POSTGREST_LAUNCHER_OUTPUT"'));
+    if (versionProbeIndex < 0 || launcherGateIndex < versionProbeIndex) {
+        throw new Error("Root upgrade script lacks Management capability boundaries");
+    }
+    return [
+        "set -euo pipefail",
+        "supacloud_version_at_least() { return 0; }",
+        'STAGED_MANAGEMENT="$RUNNER_PATH"',
+        "TARGET_MANAGEMENT_VERSION=0.60.1",
+        ...scriptLines.slice(versionProbeIndex, launcherGateIndex + 1),
+    ].join("\n");
+}
+
+function writeTestTimeoutCommand(commandDirectory: string): void {
+    writeExecutableShell(join(commandDirectory, "timeout"), [
+        "#!/usr/bin/env bun",
+        "const [duration, executable, ...args] = process.argv.slice(2);",
+        "if (duration !== '5s' || !executable) process.exit(64);",
+        "const child = Bun.spawn([executable, ...args], { stdin: 'inherit', stdout: 'inherit', stderr: 'inherit' });",
+        "let timedOut = false;",
+        "const timer = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, 1000);",
+        "const exitCode = await child.exited;",
+        "clearTimeout(timer);",
+        "process.exit(timedOut ? 124 : exitCode);",
+        "",
+    ].join("\n"));
+}
+
 function rootScriptVerifierBootstrap(rootScript: string): string {
     const scriptLines = rootScript.split("\n");
     const securityUnsetIndex = scriptLines.findIndex(line => line.startsWith("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE"));
@@ -764,9 +795,57 @@ describe("ssh admin tool", () => {
         expect(rootScript).toContain("Another SupaCloud upgrade is already running");
         expect(rootScript).toContain("supacloud_fetch_component_release management-api '0.60.1'");
         expect(rootScript).toContain('UPGRADE_RUNNER="$STAGED_MANAGEMENT"');
-        expect(rootScript).toContain('"$STAGED_MANAGEMENT" --systemd-unit-helper-sha256');
+        expect(rootScript).toContain('timeout 5s "$STAGED_MANAGEMENT" --version');
+        expect(rootScript).toContain('timeout 5s "$STAGED_MANAGEMENT" --systemd-unit-helper-sha256');
+        expect(rootScript).toContain('timeout 5s "$STAGED_MANAGEMENT" --postgrest-launcher-sha256');
+        expect(rootScript).toContain("chown timeout; do command -v");
         expect(rootScript).not.toContain('UPGRADE_RUNNER=\'/usr/local/bin/supacloud\'');
     });
+
+    test("remote target-runner capability gate rejects invalid and hanging binaries", () => {
+        const fixtureDirectory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-remote-capability-")));
+        const commandDirectory = join(fixtureDirectory, "commands");
+        const runnerPath = join(fixtureDirectory, "management-runner");
+        const probe = remoteManagementCapabilityProbe(buildRootUpgradeScript({
+            helperPath: "/tmp/release-assets.sh",
+            version: "0.60.1",
+        }));
+        mkdirSync(commandDirectory);
+        writeTestTimeoutCommand(commandDirectory);
+
+        const executeProbe = (launcherCommand: string) => {
+            writeExecutableShell(runnerPath, [
+                "#!/bin/sh",
+                "case \"${1:-}\" in",
+                "  --version) printf 'SupaCloud Version: 0.60.1\\n' ;;",
+                `  --systemd-unit-helper-sha256) printf 'SupaCloud systemd-unit helper SHA-256: ${"a".repeat(64)}\\n' ;;`,
+                `  --postgrest-launcher-sha256) ${launcherCommand} ;;`,
+                "  *) exit 2 ;;",
+                "esac",
+                "",
+            ].join("\n"));
+            return Bun.spawnSync(["bash", "-c", probe], {
+                env: {
+                    ...process.env,
+                    PATH: `${commandDirectory}:${process.env.PATH ?? ""}`,
+                    RUNNER_PATH: runnerPath,
+                },
+            });
+        };
+
+        try {
+            expect(executeProbe("exit 2").exitCode).not.toBe(0);
+            const malformed = executeProbe("printf 'unexpected launcher identity\\n'");
+            expect(malformed.exitCode).not.toBe(0);
+            expect(malformed.stderr.toString()).toContain("lacks target-bound PostgREST launcher delivery");
+            expect(executeProbe("exec sleep 30").exitCode).toBe(124);
+            expect(executeProbe(
+                `printf 'SupaCloud PostgREST launcher SHA-256: ${"b".repeat(64)}\\n'`,
+            ).exitCode).toBe(0);
+        } finally {
+            rmSync(fixtureDirectory, { recursive: true, force: true });
+        }
+    }, { timeout: 20_000 });
 
     test("remote latest resolution pins the transaction to the bootstrap target version", () => {
         const directory = mkdtempSync(join(tmpdir(), "supacloud-admin-target-version-"));
@@ -1082,6 +1161,7 @@ describe("ssh admin tool", () => {
         expect(command).toContain("supacloud_download_release_asset");
         expect(command).toContain('chmod 0755 "$STAGED_MANAGEMENT"');
         expect(command).toContain('"$STAGED_MANAGEMENT" --systemd-unit-helper-sha256');
+        expect(command).toContain('"$STAGED_MANAGEMENT" --postgrest-launcher-sha256');
         expect(command).toContain("SUPACLOUD_EDGE_RUNTIME_UPGRADE_TAG=");
         expect(command).toContain("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE");
         expect(command).toContain("SUPACLOUD_ATTESTATION_TRUSTED_ROOT");

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -250,10 +250,13 @@ function componentBootstrapCommands(request: UpgradeRequest): string[] {
         `supacloud_download_release_asset "$MANAGEMENT_RELEASE" "$MANAGEMENT_ASSET" "$STAGED_MANAGEMENT" binary`,
         `chmod 0755 "$STAGED_MANAGEMENT"`,
         `TARGET_MANAGEMENT_VERSION=$(jq -er '.tag_name | capture("^management-api-v(?<version>(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*))$").version' <<< "$MANAGEMENT_RELEASE")`,
-        `STAGED_VERSION=$("$STAGED_MANAGEMENT" --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
+        `STAGED_VERSION=$(timeout 5s "$STAGED_MANAGEMENT" --version 2>&1 | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+' | head -1 || true)`,
         `test "$STAGED_VERSION" = "$TARGET_MANAGEMENT_VERSION" || { echo 'Target Management binary version does not match its verified release' >&2; exit 1; }`,
         `supacloud_version_at_least "$STAGED_VERSION" ${quoteEnvValue(MINIMUM_COMPONENT_UPGRADE_VERSION)} || { echo 'Target Management release lacks component transaction capability' >&2; exit 1; }`,
-        `"$STAGED_MANAGEMENT" --systemd-unit-helper-sha256 >/dev/null 2>&1 || { echo 'Target Management release lacks target-bound systemd-unit helper delivery' >&2; exit 1; }`,
+        `SYSTEMD_HELPER_OUTPUT=$(timeout 5s "$STAGED_MANAGEMENT" --systemd-unit-helper-sha256 2>&1)`,
+        `[[ "$SYSTEMD_HELPER_OUTPUT" =~ ^SupaCloud[[:space:]]systemd-unit[[:space:]]helper[[:space:]]SHA-256:[[:space:]][0-9a-f]{64}$ ]] || { echo 'Target Management release lacks target-bound systemd-unit helper delivery' >&2; exit 1; }`,
+        `POSTGREST_LAUNCHER_OUTPUT=$(timeout 5s "$STAGED_MANAGEMENT" --postgrest-launcher-sha256 2>&1)`,
+        `[[ "$POSTGREST_LAUNCHER_OUTPUT" =~ ^SupaCloud[[:space:]]PostgREST[[:space:]]launcher[[:space:]]SHA-256:[[:space:]][0-9a-f]{64}$ ]] || { echo 'Target Management release lacks target-bound PostgREST launcher delivery' >&2; exit 1; }`,
         `UPGRADE_RUNNER="$STAGED_MANAGEMENT"`,
     ];
 }
@@ -306,7 +309,7 @@ export function buildRootUpgradeScript(request: UpgradeRequest): string {
         request.githubProxy
             ? `export SUPACLOUD_GITHUB_PROXY=${quoteEnvValue(request.githubProxy)}`
             : "unset SUPACLOUD_GITHUB_PROXY SUPACLOUD_GITHUB_PROXIES",
-        "for tool in curl jq file sha256sum stat tar flock find sort chown; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "for tool in curl jq file sha256sum stat tar flock find sort chown timeout; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required upgrade tool is missing: $tool\" >&2; exit 127; }; done",
         "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
         "test -x /usr/local/bin/supacloud || { echo 'SupaCloud binary not found at /usr/local/bin/supacloud; run ssh install first.' >&2; exit 127; }",
         ...trustedRootPreflightCommands(request.helperPath),

--- a/packages/management-api/src/embedded-postgrest-launcher.ts
+++ b/packages/management-api/src/embedded-postgrest-launcher.ts
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+import postgrestLauncherSource from "../../../scripts/lib/postgrest_launcher.sh" with { type: "text" };
+import {
+  activatePreparedEmbeddedPrivilegedHelper,
+  cleanupEmbeddedPrivilegedHelperBackup,
+  prepareEmbeddedPrivilegedHelperActivation,
+  readOptionalPrivilegedHelperIdentity,
+  restoreEmbeddedPrivilegedHelper,
+  stageEmbeddedPrivilegedHelper,
+  verifyInstalledEmbeddedPrivilegedHelper,
+  type EmbeddedPrivilegedHelperActivationOperations,
+  type EmbeddedPrivilegedHelperActivationState,
+  type PreparedEmbeddedPrivilegedHelperActivation,
+  type PrivilegedHelperIdentity,
+  type PrivilegedHelperOwner,
+  type StagedPrivilegedHelper,
+} from "./embedded-privileged-helper";
+
+export const POSTGREST_LAUNCHER_TARGET = "/usr/local/libexec/supacloud/postgrest-launcher";
+export const EMBEDDED_POSTGREST_LAUNCHER_SOURCE = postgrestLauncherSource;
+export const EMBEDDED_POSTGREST_LAUNCHER_SHA256 = createHash("sha256")
+  .update(Buffer.from(postgrestLauncherSource, "utf8"))
+  .digest("hex");
+
+const POSTGREST_LAUNCHER = {
+  label: "PostgREST launcher",
+  source: EMBEDDED_POSTGREST_LAUNCHER_SOURCE,
+  sha256: EMBEDDED_POSTGREST_LAUNCHER_SHA256,
+  stagedLabel: "Staged PostgREST launcher",
+  targetPath: POSTGREST_LAUNCHER_TARGET,
+} as const;
+
+export type PostgrestLauncherActivationState = EmbeddedPrivilegedHelperActivationState;
+export type PostgrestLauncherPreflight = PrivilegedHelperIdentity | null;
+export type PreparedPostgrestLauncherActivation = PreparedEmbeddedPrivilegedHelperActivation;
+export type PostgrestLauncherActivationOperations = EmbeddedPrivilegedHelperActivationOperations;
+
+export function readPostgrestLauncherPreflight(
+  targetPath = POSTGREST_LAUNCHER_TARGET,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+): PostgrestLauncherPreflight {
+  return readOptionalPrivilegedHelperIdentity(targetPath, owner, 0o755, POSTGREST_LAUNCHER.label);
+}
+
+export function stageEmbeddedPostgrestLauncher(
+  targetPath = POSTGREST_LAUNCHER_TARGET,
+  runId?: string,
+  owner?: PrivilegedHelperOwner,
+): StagedPrivilegedHelper {
+  return stageEmbeddedPrivilegedHelper(POSTGREST_LAUNCHER, targetPath, runId, owner);
+}
+
+export function preparePostgrestLauncherActivation(request: {
+  staged: StagedPrivilegedHelper;
+  targetPath?: string;
+  runId?: string;
+  owner?: PrivilegedHelperOwner;
+  expectedPrevious: PostgrestLauncherPreflight;
+}): PreparedPostgrestLauncherActivation {
+  return prepareEmbeddedPrivilegedHelperActivation({
+    helper: POSTGREST_LAUNCHER,
+    staged: request.staged,
+    targetPath: request.targetPath,
+    runId: request.runId,
+    owner: request.owner,
+    expectedPrevious: request.expectedPrevious,
+  });
+}
+
+export function activatePreparedPostgrestLauncher(
+  prepared: PreparedPostgrestLauncherActivation,
+  operations?: PostgrestLauncherActivationOperations,
+): PostgrestLauncherActivationState {
+  return activatePreparedEmbeddedPrivilegedHelper(prepared, operations);
+}
+
+export function verifyInstalledPostgrestLauncher(
+  targetPath = POSTGREST_LAUNCHER_TARGET,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+): PrivilegedHelperIdentity {
+  return verifyInstalledEmbeddedPrivilegedHelper(targetPath, owner, POSTGREST_LAUNCHER);
+}
+
+export function restorePostgrestLauncher(
+  state: PostgrestLauncherActivationState,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+): void {
+  restoreEmbeddedPrivilegedHelper(state, owner, POSTGREST_LAUNCHER);
+}
+
+export function cleanupPostgrestLauncherBackup(
+  state: PostgrestLauncherActivationState,
+  owner: PrivilegedHelperOwner = {
+    uid: state.previous?.uid ?? state.activatedIdentity.uid,
+    gid: state.previous?.gid ?? state.activatedIdentity.gid,
+  },
+): void {
+  cleanupEmbeddedPrivilegedHelperBackup(state, owner, POSTGREST_LAUNCHER);
+}

--- a/packages/management-api/src/embedded-privileged-helper.ts
+++ b/packages/management-api/src/embedded-privileged-helper.ts
@@ -1,0 +1,661 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fchownSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  type Stats,
+} from "node:fs";
+import path from "node:path";
+
+export type PrivilegedHelperOwner = {
+  uid: number;
+  gid: number;
+};
+
+export type PrivilegedHelperIdentity = PrivilegedHelperOwner & {
+  content: Buffer;
+  dev: number;
+  ino: number;
+  mode: number;
+  sha256: string;
+};
+
+export type EmbeddedPrivilegedHelper = {
+  label: string;
+  source: string;
+  sha256: string;
+  stagedLabel: string;
+  targetPath: string;
+};
+
+export type StagedPrivilegedHelper = {
+  path: string;
+  sha256: string;
+};
+
+export type EmbeddedPrivilegedHelperActivationState = {
+  targetPath: string;
+  backupPath: string;
+  previous: PrivilegedHelperIdentity | null;
+  activatedIdentity: PrivilegedHelperIdentity;
+  backupReady: boolean;
+  activated: boolean;
+};
+
+export type PrepareEmbeddedPrivilegedHelperActivationRequest = {
+  helper: EmbeddedPrivilegedHelper;
+  staged: StagedPrivilegedHelper;
+  targetPath?: string;
+  runId?: string;
+  owner?: PrivilegedHelperOwner;
+  expectedPrevious?: PrivilegedHelperIdentity | null;
+};
+
+export type PreparedEmbeddedPrivilegedHelperActivation = {
+  helper: EmbeddedPrivilegedHelper;
+  owner: PrivilegedHelperOwner;
+  parent: string;
+  staged: StagedPrivilegedHelper;
+  state: EmbeddedPrivilegedHelperActivationState;
+};
+
+export type EmbeddedPrivilegedHelperActivationOperations = {
+  restore: (
+    state: EmbeddedPrivilegedHelperActivationState,
+    owner: PrivilegedHelperOwner,
+    helper: EmbeddedPrivilegedHelper,
+  ) => void;
+  syncDirectory: (directory: string) => void;
+  verifyInstalled: (
+    targetPath: string,
+    owner: PrivilegedHelperOwner,
+    helper: EmbeddedPrivilegedHelper,
+  ) => PrivilegedHelperIdentity;
+};
+
+type PrivilegedHelperFileContract = {
+  label: string;
+  mode: number;
+  owner: PrivilegedHelperOwner;
+};
+
+type WritePrivilegedHelperFileRequest = PrivilegedHelperFileContract & {
+  content: Buffer;
+  filePath: string;
+  onReserved: () => void;
+};
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function assertOwner(uid: number, gid: number, owner: PrivilegedHelperOwner, label: string): void {
+  if (uid !== owner.uid || gid !== owner.gid) {
+    throw new Error(`${label} must be owned by uid ${owner.uid} and gid ${owner.gid}`);
+  }
+}
+
+function assertDirectRegularFileStats(
+  stats: Stats,
+  contract: PrivilegedHelperFileContract,
+): void {
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1) {
+    throw new Error(`${contract.label} must be a direct regular file with one link`);
+  }
+  assertOwner(stats.uid, stats.gid, contract.owner, contract.label);
+  if ((stats.mode & 0o7777) !== contract.mode) {
+    throw new Error(`${contract.label} mode must be exactly 0${contract.mode.toString(8)}`);
+  }
+}
+
+function directRegularFileStats(
+  filePath: string,
+  contract: PrivilegedHelperFileContract,
+): Stats {
+  const stats = lstatSync(filePath);
+  assertDirectRegularFileStats(stats, contract);
+  return stats;
+}
+
+function assertOpenedHelperIdentity(
+  opened: Stats,
+  before: Stats,
+  contract: PrivilegedHelperFileContract,
+): void {
+  if (opened.dev !== before.dev || opened.ino !== before.ino || !opened.isFile() || opened.nlink !== 1) {
+    throw new Error(`${contract.label} changed during identity capture`);
+  }
+  assertOwner(opened.uid, opened.gid, contract.owner, contract.label);
+  if ((opened.mode & 0o7777) !== contract.mode) {
+    throw new Error(`${contract.label} mode must be exactly 0${contract.mode.toString(8)}`);
+  }
+}
+
+function readStableHelperContent(descriptor: number, opened: Stats, label: string): Buffer {
+  const content = readFileSync(descriptor);
+  const after = fstatSync(descriptor);
+  if (after.dev !== opened.dev || after.ino !== opened.ino || after.size !== content.length
+    || after.mtimeMs !== opened.mtimeMs || after.ctimeMs !== opened.ctimeMs) {
+    throw new Error(`${label} changed while it was read`);
+  }
+  return content;
+}
+
+function capturedHelperIdentity(opened: Stats, content: Buffer): PrivilegedHelperIdentity {
+  return {
+    content,
+    dev: opened.dev,
+    ino: opened.ino,
+    uid: opened.uid,
+    gid: opened.gid,
+    mode: opened.mode & 0o7777,
+    sha256: createHash("sha256").update(content).digest("hex"),
+  };
+}
+
+function capturePrivilegedHelperIdentity(
+  filePath: string,
+  contract: PrivilegedHelperFileContract,
+  before = directRegularFileStats(filePath, contract),
+): PrivilegedHelperIdentity {
+  const descriptor = openSync(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = fstatSync(descriptor);
+    assertOpenedHelperIdentity(opened, before, contract);
+    return capturedHelperIdentity(opened, readStableHelperContent(descriptor, opened, contract.label));
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+export function readPrivilegedHelperIdentity(
+  filePath: string,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+  expectedMode = 0o755,
+  label = "Privileged systemd-unit helper",
+): PrivilegedHelperIdentity {
+  try {
+    return capturePrivilegedHelperIdentity(filePath, { owner, mode: expectedMode, label });
+  } catch (error: unknown) {
+    if (isMissingFileError(error)) throw new Error(`${label} is missing: ${filePath}`);
+    throw error;
+  }
+}
+
+export function readOptionalPrivilegedHelperIdentity(
+  filePath: string,
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+  expectedMode = 0o755,
+  label = "Privileged helper",
+): PrivilegedHelperIdentity | null {
+  const contract = { owner, mode: expectedMode, label };
+  const before = lstatSync(filePath, { throwIfNoEntry: false });
+  if (!before) return null;
+  assertDirectRegularFileStats(before, contract);
+  return capturePrivilegedHelperIdentity(filePath, contract, before);
+}
+
+function assertDirectParentDirectory(
+  filePath: string,
+  owner: PrivilegedHelperOwner,
+  label: string,
+): string {
+  const parent = path.dirname(filePath);
+  const stats = lstatSync(parent);
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw new Error(`${label} parent must be a direct directory`);
+  }
+  assertOwner(stats.uid, stats.gid, owner, `${label} parent`);
+  if ((stats.mode & 0o022) !== 0) {
+    throw new Error(`${label} parent must not be group- or world-writable`);
+  }
+  return parent;
+}
+
+function writeExclusiveFile(request: WritePrivilegedHelperFileRequest): void {
+  const descriptor = openSync(
+    request.filePath,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600,
+  );
+  request.onReserved();
+  try {
+    writeFileSync(descriptor, request.content);
+    fchmodSync(descriptor, request.mode);
+    fchownSync(descriptor, request.owner.uid, request.owner.gid);
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+  directRegularFileStats(request.filePath, request);
+}
+
+function fsyncDirectory(directory: string): void {
+  const descriptor = openSync(directory, constants.O_RDONLY);
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function throwWithCleanupFailure(primary: unknown, cleanup: unknown, message: string): never {
+  throw new AggregateError([primary, cleanup], message);
+}
+
+function removeReservedPathAfterFailure(
+  filePath: string,
+  reserved: boolean,
+  primary: unknown,
+  message: string,
+): never {
+  if (!reserved) throw primary;
+  try {
+    rmSync(filePath, { force: true });
+  } catch (cleanupError: unknown) {
+    throwWithCleanupFailure(primary, cleanupError, message);
+  }
+  throw primary;
+}
+
+export function stageEmbeddedPrivilegedHelper(
+  helper: EmbeddedPrivilegedHelper,
+  targetPath = helper.targetPath,
+  runId: string = randomUUID(),
+  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+): StagedPrivilegedHelper {
+  assertDirectParentDirectory(targetPath, owner, helper.label);
+  const stagedPath = `${targetPath}.new-${runId}`;
+  const content = Buffer.from(helper.source, "utf8");
+  let stagedReserved = false;
+  try {
+    writeExclusiveFile({
+      filePath: stagedPath,
+      content,
+      mode: 0o755,
+      owner,
+      label: helper.stagedLabel,
+      onReserved: () => { stagedReserved = true; },
+    });
+    const staged = readPrivilegedHelperIdentity(stagedPath, owner, 0o755, helper.stagedLabel);
+    if (staged.sha256 !== helper.sha256) {
+      throw new Error(`${helper.stagedLabel} digest does not match the embedded release artifact`);
+    }
+    return { path: stagedPath, sha256: staged.sha256 };
+  } catch (error: unknown) {
+    removeReservedPathAfterFailure(
+      stagedPath,
+      stagedReserved,
+      error,
+      `${helper.stagedLabel} staging and cleanup both failed`,
+    );
+  }
+}
+
+export function samePrivilegedHelperIdentity(
+  left: PrivilegedHelperIdentity,
+  right: PrivilegedHelperIdentity,
+): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.uid === right.uid
+    && left.gid === right.gid
+    && left.mode === right.mode
+    && left.sha256 === right.sha256;
+}
+
+function sameOptionalPrivilegedHelperIdentity(
+  left: PrivilegedHelperIdentity | null,
+  right: PrivilegedHelperIdentity | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return samePrivilegedHelperIdentity(left, right);
+}
+
+function frozenPreviousIdentity(
+  current: PrivilegedHelperIdentity | null,
+  expected: PrivilegedHelperIdentity | null | undefined,
+  label: string,
+): PrivilegedHelperIdentity | null {
+  if (expected !== undefined && !sameOptionalPrivilegedHelperIdentity(current, expected)) {
+    throw new Error(`${label} changed after upgrade preflight`);
+  }
+  return expected === undefined ? current : expected;
+}
+
+function createHelperActivationState(
+  targetPath: string,
+  runId: string,
+  previous: PrivilegedHelperIdentity | null,
+  activatedIdentity: PrivilegedHelperIdentity,
+): EmbeddedPrivilegedHelperActivationState {
+  return {
+    targetPath,
+    backupPath: `${targetPath}.bak-${runId}`,
+    previous,
+    activatedIdentity,
+    backupReady: false,
+    activated: false,
+  };
+}
+
+function assertStagedHelperIdentity(
+  helper: EmbeddedPrivilegedHelper,
+  staged: StagedPrivilegedHelper,
+  owner: PrivilegedHelperOwner,
+): PrivilegedHelperIdentity {
+  const identity = readPrivilegedHelperIdentity(staged.path, owner, 0o755, helper.stagedLabel);
+  if (identity.sha256 !== staged.sha256 || identity.sha256 !== helper.sha256) {
+    throw new Error(`${helper.stagedLabel} identity changed before activation`);
+  }
+  return identity;
+}
+
+function backupPreviousHelper(
+  helper: EmbeddedPrivilegedHelper,
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+): void {
+  const previous = state.previous;
+  if (!previous) return;
+  let backupReserved = false;
+  try {
+    writeExclusiveFile({
+      filePath: state.backupPath,
+      content: previous.content,
+      mode: previous.mode,
+      owner,
+      label: `${helper.label} rollback backup`,
+      onReserved: () => { backupReserved = true; },
+    });
+    const backup = readPrivilegedHelperIdentity(
+      state.backupPath,
+      owner,
+      previous.mode,
+      `${helper.label} rollback backup`,
+    );
+    if (backup.sha256 !== previous.sha256) {
+      throw new Error(`${helper.label} rollback backup digest mismatch`);
+    }
+    state.backupReady = true;
+  } catch (error: unknown) {
+    removeReservedPathAfterFailure(
+      state.backupPath,
+      backupReserved,
+      error,
+      `${helper.label} backup preparation and cleanup both failed`,
+    );
+  }
+}
+
+function assertActivationTargetUnchanged(
+  helper: EmbeddedPrivilegedHelper,
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+): void {
+  const expectedMode = state.previous?.mode ?? 0o755;
+  const current = readOptionalPrivilegedHelperIdentity(state.targetPath, owner, expectedMode, helper.label);
+  if (!sameOptionalPrivilegedHelperIdentity(current, state.previous)) {
+    throw new Error(`${helper.label} changed before atomic activation`);
+  }
+}
+
+function rethrowAfterActivationRecovery(
+  error: unknown,
+  helper: EmbeddedPrivilegedHelper,
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+  restore: EmbeddedPrivilegedHelperActivationOperations["restore"],
+): never {
+  if (!state.activated) throw error;
+  try {
+    restore(state, owner, helper);
+  } catch (rollbackError: unknown) {
+    throw new AggregateError(
+      [error, rollbackError],
+      `${helper.label} activation and rollback both failed`,
+    );
+  }
+  throw error;
+}
+
+export function prepareEmbeddedPrivilegedHelperActivation(
+  request: PrepareEmbeddedPrivilegedHelperActivationRequest,
+): PreparedEmbeddedPrivilegedHelperActivation {
+  const targetPath = request.targetPath ?? request.helper.targetPath;
+  const runId = request.runId ?? randomUUID();
+  const owner = request.owner ?? { uid: 0, gid: 0 };
+  const parent = assertDirectParentDirectory(targetPath, owner, request.helper.label);
+  const current = readOptionalPrivilegedHelperIdentity(targetPath, owner, 0o755, request.helper.label);
+  const previous = frozenPreviousIdentity(current, request.expectedPrevious, request.helper.label);
+  const activatedIdentity = assertStagedHelperIdentity(request.helper, request.staged, owner);
+  const state = createHelperActivationState(targetPath, runId, previous, activatedIdentity);
+
+  backupPreviousHelper(request.helper, state, owner);
+  return { helper: request.helper, owner, parent, staged: request.staged, state };
+}
+
+export function verifyInstalledEmbeddedPrivilegedHelper(
+  targetPath: string,
+  owner: PrivilegedHelperOwner,
+  helper: EmbeddedPrivilegedHelper,
+): PrivilegedHelperIdentity {
+  const identity = readPrivilegedHelperIdentity(targetPath, owner, 0o755, helper.label);
+  if (identity.sha256 !== helper.sha256) {
+    throw new Error(`${helper.label} digest does not match the Management release`);
+  }
+  return identity;
+}
+
+export function activatePreparedEmbeddedPrivilegedHelper(
+  prepared: PreparedEmbeddedPrivilegedHelperActivation,
+  operations: EmbeddedPrivilegedHelperActivationOperations = {
+    restore: restoreEmbeddedPrivilegedHelper,
+    syncDirectory: fsyncDirectory,
+    verifyInstalled: verifyInstalledEmbeddedPrivilegedHelper,
+  },
+): EmbeddedPrivilegedHelperActivationState {
+  try {
+    return activatePreparedHelperTarget(prepared, operations);
+  } catch (error: unknown) {
+    const { helper, owner, state } = prepared;
+    rethrowAfterActivationRecovery(error, helper, state, owner, operations.restore);
+  }
+}
+
+function activatePreparedHelperTarget(
+  prepared: PreparedEmbeddedPrivilegedHelperActivation,
+  operations: EmbeddedPrivilegedHelperActivationOperations,
+): EmbeddedPrivilegedHelperActivationState {
+  const { helper, owner, parent, staged, state } = prepared;
+  const stagedIdentity = assertStagedHelperIdentity(helper, staged, owner);
+  if (!samePrivilegedHelperIdentity(stagedIdentity, state.activatedIdentity)) {
+    throw new Error(`${helper.stagedLabel} changed after activation preparation`);
+  }
+  assertActivationTargetUnchanged(helper, state, owner);
+  renameSync(staged.path, state.targetPath);
+  state.activated = true;
+  operations.syncDirectory(parent);
+  const installed = operations.verifyInstalled(state.targetPath, owner, helper);
+  if (!samePrivilegedHelperIdentity(installed, state.activatedIdentity)) {
+    throw new Error(`${helper.label} identity changed during activation`);
+  }
+  return state;
+}
+
+function assertActivatedIdentity(
+  helper: EmbeddedPrivilegedHelper,
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+): void {
+  const activated = readPrivilegedHelperIdentity(
+    state.targetPath,
+    owner,
+    state.activatedIdentity.mode,
+    helper.label,
+  );
+  if (!samePrivilegedHelperIdentity(activated, state.activatedIdentity)) {
+    throw new Error(`${helper.label} changed before rollback`);
+  }
+}
+
+function restorePreviouslyAbsentHelper(
+  helper: EmbeddedPrivilegedHelper,
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+  parent: string,
+): void {
+  assertActivatedIdentity(helper, state, owner);
+  rmSync(state.targetPath);
+  fsyncDirectory(parent);
+  if (readOptionalPrivilegedHelperIdentity(state.targetPath, owner, 0o755, helper.label) !== null) {
+    throw new Error(`${helper.label} rollback removal read-back failed`);
+  }
+  state.activated = false;
+}
+
+function cleanupRestorePath(
+  restorePath: string,
+  reserved: boolean,
+  primary: unknown | null,
+  helper: EmbeddedPrivilegedHelper,
+): void {
+  if (!reserved) {
+    if (primary !== null) throw primary;
+    return;
+  }
+  try {
+    rmSync(restorePath, { force: true });
+  } catch (cleanupError: unknown) {
+    if (primary !== null) {
+      throwWithCleanupFailure(
+        primary,
+        cleanupError,
+        `${helper.label} rollback and temporary-path cleanup both failed`,
+      );
+    }
+    throw cleanupError;
+  }
+  if (primary !== null) throw primary;
+}
+
+function readRollbackBackup(
+  helper: EmbeddedPrivilegedHelper,
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+  previous: PrivilegedHelperIdentity,
+): PrivilegedHelperIdentity {
+  if (!state.backupReady) throw new Error(`${helper.label} rollback backup is unavailable`);
+  const backup = readPrivilegedHelperIdentity(
+    state.backupPath,
+    owner,
+    previous.mode,
+    `${helper.label} rollback backup`,
+  );
+  if (backup.sha256 !== previous.sha256) throw new Error(`${helper.label} rollback backup changed`);
+  return backup;
+}
+
+function installFrozenPreviousHelper(request: {
+  backup: PrivilegedHelperIdentity;
+  helper: EmbeddedPrivilegedHelper;
+  owner: PrivilegedHelperOwner;
+  parent: string;
+  previous: PrivilegedHelperIdentity;
+  restorePath: string;
+  state: EmbeddedPrivilegedHelperActivationState;
+  onReserved: () => void;
+}): void {
+  writeExclusiveFile({
+    filePath: request.restorePath,
+    content: request.backup.content,
+    mode: request.previous.mode,
+    owner: request.owner,
+    label: `${request.helper.label} restore file`,
+    onReserved: request.onReserved,
+  });
+  renameSync(request.restorePath, request.state.targetPath);
+  fsyncDirectory(request.parent);
+  const restored = readPrivilegedHelperIdentity(
+    request.state.targetPath,
+    request.owner,
+    request.previous.mode,
+    request.helper.label,
+  );
+  if (restored.sha256 !== request.previous.sha256) {
+    throw new Error(`${request.helper.label} rollback read-back failed`);
+  }
+  request.state.activated = false;
+}
+
+function restorePreviousHelper(
+  helper: EmbeddedPrivilegedHelper,
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+  parent: string,
+  previous: PrivilegedHelperIdentity,
+): void {
+  const backup = readRollbackBackup(helper, state, owner, previous);
+  assertActivatedIdentity(helper, state, owner);
+  const restorePath = `${state.targetPath}.restore-${randomUUID()}`;
+  let restoreReserved = false;
+  let primary: unknown | null = null;
+  try {
+    installFrozenPreviousHelper({
+      backup,
+      helper,
+      owner,
+      parent,
+      previous,
+      restorePath,
+      state,
+      onReserved: () => { restoreReserved = true; },
+    });
+  } catch (error: unknown) {
+    primary = error;
+  }
+  cleanupRestorePath(restorePath, restoreReserved, primary, helper);
+}
+
+export function restoreEmbeddedPrivilegedHelper(
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+  helper: EmbeddedPrivilegedHelper,
+): void {
+  if (!state.activated) return;
+  const parent = assertDirectParentDirectory(state.targetPath, owner, helper.label);
+  if (state.previous === null) {
+    restorePreviouslyAbsentHelper(helper, state, owner, parent);
+    return;
+  }
+  restorePreviousHelper(helper, state, owner, parent, state.previous);
+}
+
+export function cleanupEmbeddedPrivilegedHelperBackup(
+  state: EmbeddedPrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner,
+  helper: EmbeddedPrivilegedHelper,
+): void {
+  if (!state.backupReady || state.previous === null) return;
+  const backup = readPrivilegedHelperIdentity(
+    state.backupPath,
+    owner,
+    state.previous.mode,
+    `${helper.label} rollback backup`,
+  );
+  if (backup.sha256 !== state.previous.sha256) {
+    throw new Error(`${helper.label} rollback backup changed before cleanup`);
+  }
+  rmSync(state.backupPath);
+  fsyncDirectory(path.dirname(state.backupPath));
+  state.backupReady = false;
+}

--- a/packages/management-api/src/embedded-systemd-unit-broker.ts
+++ b/packages/management-api/src/embedded-systemd-unit-broker.ts
@@ -1,21 +1,27 @@
-import { createHash, randomUUID } from "node:crypto";
-import {
-  closeSync,
-  constants,
-  existsSync,
-  fchmodSync,
-  fchownSync,
-  fstatSync,
-  fsyncSync,
-  lstatSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import path from "node:path";
+import { createHash } from "node:crypto";
 import systemdUnitBrokerSource from "../../../scripts/lib/systemd_unit_broker.sh" with { type: "text" };
+import {
+  activatePreparedEmbeddedPrivilegedHelper,
+  cleanupEmbeddedPrivilegedHelperBackup,
+  prepareEmbeddedPrivilegedHelperActivation,
+  readPrivilegedHelperIdentity,
+  restoreEmbeddedPrivilegedHelper,
+  stageEmbeddedPrivilegedHelper,
+  verifyInstalledEmbeddedPrivilegedHelper,
+  type EmbeddedPrivilegedHelperActivationOperations,
+  type EmbeddedPrivilegedHelperActivationState,
+  type PreparedEmbeddedPrivilegedHelperActivation,
+  type PrivilegedHelperIdentity,
+  type PrivilegedHelperOwner,
+  type StagedPrivilegedHelper,
+} from "./embedded-privileged-helper";
+
+export {
+  readPrivilegedHelperIdentity,
+  type PrivilegedHelperIdentity,
+  type PrivilegedHelperOwner,
+  type StagedPrivilegedHelper,
+} from "./embedded-privileged-helper";
 
 export const SYSTEMD_UNIT_BROKER_TARGET = "/usr/local/libexec/supacloud/systemd-unit";
 export const EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE = systemdUnitBrokerSource;
@@ -23,31 +29,16 @@ export const EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256 = createHash("sha256")
   .update(Buffer.from(systemdUnitBrokerSource, "utf8"))
   .digest("hex");
 
-export type PrivilegedHelperOwner = {
-  uid: number;
-  gid: number;
-};
+const SYSTEMD_UNIT_BROKER = {
+  label: "Privileged systemd-unit helper",
+  source: EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE,
+  sha256: EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256,
+  stagedLabel: "Staged privileged systemd-unit helper",
+  targetPath: SYSTEMD_UNIT_BROKER_TARGET,
+} as const;
 
-export type PrivilegedHelperIdentity = PrivilegedHelperOwner & {
-  content: Buffer;
-  dev: number;
-  ino: number;
-  mode: number;
-  sha256: string;
-};
-
-export type StagedPrivilegedHelper = {
-  path: string;
-  sha256: string;
-};
-
-export type PrivilegedHelperActivationState = {
-  targetPath: string;
-  backupPath: string;
+export type PrivilegedHelperActivationState = EmbeddedPrivilegedHelperActivationState & {
   previous: PrivilegedHelperIdentity;
-  activatedIdentity: PrivilegedHelperIdentity;
-  backupReady: boolean;
-  activated: boolean;
 };
 
 export type PrepareSystemdUnitBrokerActivationRequest = {
@@ -58,10 +49,7 @@ export type PrepareSystemdUnitBrokerActivationRequest = {
   expectedPrevious?: PrivilegedHelperIdentity;
 };
 
-export type PreparedSystemdUnitBrokerActivation = {
-  owner: PrivilegedHelperOwner;
-  parent: string;
-  staged: StagedPrivilegedHelper;
+export type PreparedSystemdUnitBrokerActivation = PreparedEmbeddedPrivilegedHelperActivation & {
   state: PrivilegedHelperActivationState;
 };
 
@@ -71,318 +59,70 @@ export type SystemdUnitBrokerActivationOperations = {
   verifyInstalled: (targetPath: string, owner: PrivilegedHelperOwner) => PrivilegedHelperIdentity;
 };
 
-function sha256(content: Buffer): string {
-  return createHash("sha256").update(content).digest("hex");
-}
-
-function assertOwner(uid: number, gid: number, owner: PrivilegedHelperOwner, label: string): void {
-  if (uid !== owner.uid || gid !== owner.gid) {
-    throw new Error(`${label} must be owned by uid ${owner.uid} and gid ${owner.gid}`);
-  }
-}
-
-function assertDirectRegularFile(
-  filePath: string,
-  owner: PrivilegedHelperOwner,
-  expectedMode: number,
-  label: string,
-): void {
-  const stats = lstatSync(filePath);
-  if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1) {
-    throw new Error(`${label} must be a direct regular file with one link`);
-  }
-  assertOwner(stats.uid, stats.gid, owner, label);
-  if ((stats.mode & 0o7777) !== expectedMode) {
-    throw new Error(`${label} mode must be exactly 0${expectedMode.toString(8)}`);
-  }
-}
-
-export function readPrivilegedHelperIdentity(
-  filePath: string,
-  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
-  expectedMode = 0o755,
-): PrivilegedHelperIdentity {
-  if (!existsSync(filePath)) throw new Error(`Privileged systemd-unit helper is missing: ${filePath}`);
-  assertDirectRegularFile(filePath, owner, expectedMode, "Privileged systemd-unit helper");
-
-  const before = lstatSync(filePath);
-  const descriptor = openSync(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
-  try {
-    const opened = fstatSync(descriptor);
-    if (opened.dev !== before.dev || opened.ino !== before.ino || !opened.isFile() || opened.nlink !== 1) {
-      throw new Error("Privileged systemd-unit helper changed during identity capture");
-    }
-    assertOwner(opened.uid, opened.gid, owner, "Privileged systemd-unit helper");
-    if ((opened.mode & 0o7777) !== expectedMode) {
-      throw new Error(`Privileged systemd-unit helper mode must be exactly 0${expectedMode.toString(8)}`);
-    }
-    const content = readFileSync(descriptor);
-    const after = fstatSync(descriptor);
-    if (after.dev !== opened.dev || after.ino !== opened.ino || after.size !== content.length
-      || after.mtimeMs !== opened.mtimeMs || after.ctimeMs !== opened.ctimeMs) {
-      throw new Error("Privileged systemd-unit helper changed while it was read");
-    }
-    return {
-      content,
-      dev: opened.dev,
-      ino: opened.ino,
-      uid: opened.uid,
-      gid: opened.gid,
-      mode: opened.mode & 0o7777,
-      sha256: sha256(content),
-    };
-  } finally {
-    closeSync(descriptor);
-  }
-}
-
-function assertDirectParentDirectory(filePath: string, owner: PrivilegedHelperOwner): string {
-  const parent = path.dirname(filePath);
-  const stats = lstatSync(parent);
-  if (!stats.isDirectory() || stats.isSymbolicLink()) {
-    throw new Error("Privileged systemd-unit helper parent must be a direct directory");
-  }
-  assertOwner(stats.uid, stats.gid, owner, "Privileged systemd-unit helper parent");
-  if ((stats.mode & 0o022) !== 0) {
-    throw new Error("Privileged systemd-unit helper parent must not be group- or world-writable");
-  }
-  return parent;
-}
-
-function writeExclusiveFile(
-  filePath: string,
-  content: Buffer,
-  mode: number,
-  owner: PrivilegedHelperOwner,
-): void {
-  const descriptor = openSync(
-    filePath,
-    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
-    0o600,
-  );
-  try {
-    writeFileSync(descriptor, content);
-    fchmodSync(descriptor, mode);
-    fchownSync(descriptor, owner.uid, owner.gid);
-    fsyncSync(descriptor);
-  } finally {
-    closeSync(descriptor);
-  }
-  assertDirectRegularFile(filePath, owner, mode, "Staged privileged systemd-unit helper");
-}
-
-function fsyncDirectory(directory: string): void {
-  const descriptor = openSync(directory, constants.O_RDONLY);
-  try {
-    fsyncSync(descriptor);
-  } finally {
-    closeSync(descriptor);
-  }
-}
-
 export function stageEmbeddedSystemdUnitBroker(
   targetPath = SYSTEMD_UNIT_BROKER_TARGET,
-  runId = randomUUID(),
-  owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
+  runId?: string,
+  owner?: PrivilegedHelperOwner,
 ): StagedPrivilegedHelper {
-  assertDirectParentDirectory(targetPath, owner);
-  const stagedPath = `${targetPath}.new-${runId}`;
-  const content = Buffer.from(EMBEDDED_SYSTEMD_UNIT_BROKER_SOURCE, "utf8");
-  try {
-    writeExclusiveFile(stagedPath, content, 0o755, owner);
-    const staged = readPrivilegedHelperIdentity(stagedPath, owner);
-    if (staged.sha256 !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
-      throw new Error("Staged privileged systemd-unit helper digest does not match the embedded helper");
-    }
-    return { path: stagedPath, sha256: staged.sha256 };
-  } catch (error: unknown) {
-    rmSync(stagedPath, { force: true });
-    throw error;
-  }
-}
-
-function sameHelperIdentity(
-  left: PrivilegedHelperIdentity,
-  right: PrivilegedHelperIdentity,
-): boolean {
-  return left.dev === right.dev
-    && left.ino === right.ino
-    && left.uid === right.uid
-    && left.gid === right.gid
-    && left.mode === right.mode
-    && left.sha256 === right.sha256;
-}
-
-function frozenPreviousIdentity(
-  current: PrivilegedHelperIdentity,
-  expected?: PrivilegedHelperIdentity,
-): PrivilegedHelperIdentity {
-  if (expected && !sameHelperIdentity(current, expected)) {
-    throw new Error("Privileged systemd-unit helper changed after upgrade preflight");
-  }
-  return expected ?? current;
-}
-
-function createHelperActivationState(
-  targetPath: string,
-  runId: string,
-  previous: PrivilegedHelperIdentity,
-  activatedIdentity: PrivilegedHelperIdentity,
-): PrivilegedHelperActivationState {
-  return {
-    targetPath,
-    backupPath: `${targetPath}.bak-${runId}`,
-    previous,
-    activatedIdentity,
-    backupReady: false,
-    activated: false,
-  };
-}
-
-function assertStagedHelperIdentity(
-  staged: StagedPrivilegedHelper,
-  owner: PrivilegedHelperOwner,
-): PrivilegedHelperIdentity {
-  const identity = readPrivilegedHelperIdentity(staged.path, owner);
-  if (identity.sha256 !== staged.sha256 || identity.sha256 !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
-    throw new Error("Staged privileged systemd-unit helper identity changed before activation");
-  }
-  return identity;
-}
-
-function backupPreviousHelper(
-  state: PrivilegedHelperActivationState,
-  owner: PrivilegedHelperOwner,
-): void {
-  writeExclusiveFile(state.backupPath, state.previous.content, state.previous.mode, owner);
-  const backup = readPrivilegedHelperIdentity(state.backupPath, owner, state.previous.mode);
-  if (backup.sha256 !== state.previous.sha256) {
-    throw new Error("Privileged systemd-unit helper rollback backup digest mismatch");
-  }
-  state.backupReady = true;
-}
-
-function assertActivationTargetUnchanged(
-  state: PrivilegedHelperActivationState,
-  owner: PrivilegedHelperOwner,
-): void {
-  const current = readPrivilegedHelperIdentity(state.targetPath, owner, state.previous.mode);
-  if (!sameHelperIdentity(current, state.previous)) {
-    throw new Error("Privileged systemd-unit helper changed before atomic activation");
-  }
-}
-
-function rethrowAfterActivationRecovery(
-  error: unknown,
-  state: PrivilegedHelperActivationState,
-  owner: PrivilegedHelperOwner,
-  restore: SystemdUnitBrokerActivationOperations["restore"],
-): never {
-  if (!state.activated) throw error;
-  try {
-    restore(state, owner);
-  } catch (rollbackError: unknown) {
-    throw new AggregateError(
-      [error, rollbackError],
-      "Privileged systemd-unit helper activation and rollback both failed",
-    );
-  }
-  throw error;
+  return stageEmbeddedPrivilegedHelper(SYSTEMD_UNIT_BROKER, targetPath, runId, owner);
 }
 
 export function prepareSystemdUnitBrokerActivation(
   request: PrepareSystemdUnitBrokerActivationRequest,
 ): PreparedSystemdUnitBrokerActivation {
   const targetPath = request.targetPath ?? SYSTEMD_UNIT_BROKER_TARGET;
-  const runId = request.runId ?? randomUUID();
   const owner = request.owner ?? { uid: 0, gid: 0 };
-  const parent = assertDirectParentDirectory(targetPath, owner);
   const current = readPrivilegedHelperIdentity(targetPath, owner);
-  const previous = frozenPreviousIdentity(current, request.expectedPrevious);
-  const activatedIdentity = assertStagedHelperIdentity(request.staged, owner);
-  const state = createHelperActivationState(targetPath, runId, previous, activatedIdentity);
+  return prepareEmbeddedPrivilegedHelperActivation({
+    helper: SYSTEMD_UNIT_BROKER,
+    staged: request.staged,
+    targetPath,
+    runId: request.runId,
+    owner,
+    expectedPrevious: request.expectedPrevious ?? current,
+  }) as PreparedSystemdUnitBrokerActivation;
+}
 
-  try {
-    backupPreviousHelper(state, owner);
-    return { owner, parent, staged: request.staged, state };
-  } catch (error: unknown) {
-    rmSync(state.backupPath, { force: true });
-    throw error;
-  }
+function adaptOperations(
+  operations: SystemdUnitBrokerActivationOperations,
+): EmbeddedPrivilegedHelperActivationOperations {
+  return {
+    restore: (state, owner) => operations.restore(state as PrivilegedHelperActivationState, owner),
+    syncDirectory: operations.syncDirectory,
+    verifyInstalled: (targetPath, owner) => operations.verifyInstalled(targetPath, owner),
+  };
 }
 
 export function activatePreparedSystemdUnitBroker(
   prepared: PreparedSystemdUnitBrokerActivation,
-  operations: SystemdUnitBrokerActivationOperations = {
-    restore: restoreSystemdUnitBroker,
-    syncDirectory: fsyncDirectory,
-    verifyInstalled: verifyInstalledSystemdUnitBroker,
-  },
+  operations?: SystemdUnitBrokerActivationOperations,
 ): PrivilegedHelperActivationState {
-  const { owner, parent, staged, state } = prepared;
-  try {
-    const stagedIdentity = assertStagedHelperIdentity(staged, owner);
-    if (!sameHelperIdentity(stagedIdentity, state.activatedIdentity)) {
-      throw new Error("Staged privileged systemd-unit helper changed after activation preparation");
-    }
-    assertActivationTargetUnchanged(state, owner);
-    renameSync(staged.path, state.targetPath);
-    state.activated = true;
-    operations.syncDirectory(parent);
-    const installed = operations.verifyInstalled(state.targetPath, owner);
-    if (!sameHelperIdentity(installed, state.activatedIdentity)) {
-      throw new Error("Installed privileged systemd-unit helper identity changed during activation");
-    }
-    return state;
-  } catch (error: unknown) {
-    rethrowAfterActivationRecovery(error, state, owner, operations.restore);
+  if (!operations) {
+    return activatePreparedEmbeddedPrivilegedHelper(prepared) as PrivilegedHelperActivationState;
   }
+  return activatePreparedEmbeddedPrivilegedHelper(
+    prepared,
+    adaptOperations(operations),
+  ) as PrivilegedHelperActivationState;
 }
 
 export function verifyInstalledSystemdUnitBroker(
   targetPath = SYSTEMD_UNIT_BROKER_TARGET,
   owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
 ): PrivilegedHelperIdentity {
-  const identity = readPrivilegedHelperIdentity(targetPath, owner);
-  if (identity.sha256 !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
-    throw new Error("Installed privileged systemd-unit helper digest does not match the Management release");
-  }
-  return identity;
+  return verifyInstalledEmbeddedPrivilegedHelper(targetPath, owner, SYSTEMD_UNIT_BROKER);
 }
 
 export function restoreSystemdUnitBroker(
   state: PrivilegedHelperActivationState,
   owner: PrivilegedHelperOwner = { uid: 0, gid: 0 },
 ): void {
-  if (!state.activated) return;
-  if (!state.backupReady || !existsSync(state.backupPath)) {
-    throw new Error("Privileged systemd-unit helper rollback backup is unavailable");
-  }
-  const backup = readPrivilegedHelperIdentity(state.backupPath, owner, state.previous.mode);
-  if (backup.sha256 !== state.previous.sha256) {
-    throw new Error("Privileged systemd-unit helper rollback backup changed");
-  }
-  const activated = readPrivilegedHelperIdentity(state.targetPath, owner, state.activatedIdentity.mode);
-  if (!sameHelperIdentity(activated, state.activatedIdentity)) {
-    throw new Error("Activated privileged systemd-unit helper changed before rollback");
-  }
-
-  const parent = assertDirectParentDirectory(state.targetPath, owner);
-  const restorePath = `${state.targetPath}.restore-${randomUUID()}`;
-  try {
-    writeExclusiveFile(restorePath, backup.content, state.previous.mode, owner);
-    renameSync(restorePath, state.targetPath);
-    fsyncDirectory(parent);
-    const restored = readPrivilegedHelperIdentity(state.targetPath, owner, state.previous.mode);
-    if (restored.sha256 !== state.previous.sha256) {
-      throw new Error("Privileged systemd-unit helper rollback read-back failed");
-    }
-    state.activated = false;
-  } finally {
-    rmSync(restorePath, { force: true });
-  }
+  restoreEmbeddedPrivilegedHelper(state, owner, SYSTEMD_UNIT_BROKER);
 }
 
-export function cleanupSystemdUnitBrokerBackup(state: PrivilegedHelperActivationState): void {
-  rmSync(state.backupPath, { force: true });
+export function cleanupSystemdUnitBrokerBackup(
+  state: PrivilegedHelperActivationState,
+  owner: PrivilegedHelperOwner = { uid: state.previous.uid, gid: state.previous.gid },
+): void {
+  cleanupEmbeddedPrivilegedHelperBackup(state, owner, SYSTEMD_UNIT_BROKER);
 }

--- a/packages/management-api/src/standalone.ts
+++ b/packages/management-api/src/standalone.ts
@@ -1,5 +1,8 @@
 import pkg from "../package.json";
-import { logger } from "./utils/logger";
+
+function writeStandaloneIdentity(identity: string): void {
+  process.stdout.write(`${identity}\n`);
+}
 
 export function isStandaloneVersionCommand(args: string[]): boolean {
   return args.length === 1 && (args[0] === "--version" || args[0] === "-v");
@@ -9,13 +12,20 @@ export function isSystemdUnitBrokerDigestCommand(args: string[]): boolean {
   return args.length === 1 && args[0] === "--systemd-unit-helper-sha256";
 }
 
+export function isPostgrestLauncherDigestCommand(args: string[]): boolean {
+  return args.length === 1 && args[0] === "--postgrest-launcher-sha256";
+}
+
 if (import.meta.main) {
   const args = process.argv.slice(2);
   if (isStandaloneVersionCommand(args)) {
-    logger.info(`SupaCloud Version: ${pkg.version}`);
+    writeStandaloneIdentity(`SupaCloud Version: ${pkg.version}`);
   } else if (isSystemdUnitBrokerDigestCommand(args)) {
     const { EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256 } = await import("./embedded-systemd-unit-broker");
-    logger.info(`SupaCloud systemd-unit helper SHA-256: ${EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256}`);
+    writeStandaloneIdentity(`SupaCloud systemd-unit helper SHA-256: ${EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256}`);
+  } else if (isPostgrestLauncherDigestCommand(args)) {
+    const { EMBEDDED_POSTGREST_LAUNCHER_SHA256 } = await import("./embedded-postgrest-launcher");
+    writeStandaloneIdentity(`SupaCloud PostgREST launcher SHA-256: ${EMBEDDED_POSTGREST_LAUNCHER_SHA256}`);
   } else {
     const { startManagementApi } = await import("./index");
     startManagementApi();

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -56,6 +56,19 @@ import {
     type PrivilegedHelperIdentity,
     type StagedPrivilegedHelper,
 } from "./embedded-systemd-unit-broker";
+import {
+    EMBEDDED_POSTGREST_LAUNCHER_SHA256,
+    POSTGREST_LAUNCHER_TARGET,
+    activatePreparedPostgrestLauncher,
+    cleanupPostgrestLauncherBackup,
+    preparePostgrestLauncherActivation,
+    readPostgrestLauncherPreflight,
+    restorePostgrestLauncher,
+    stageEmbeddedPostgrestLauncher,
+    verifyInstalledPostgrestLauncher,
+    type PostgrestLauncherActivationState,
+    type PostgrestLauncherPreflight,
+} from "./embedded-postgrest-launcher";
 
 const RELEASES_API = "https://api.github.com/repos/zuohuadong/supacloud/releases";
 const BIN_TARGET = "/usr/local/bin/supacloud";
@@ -1211,8 +1224,35 @@ export function parseSystemdUnitBrokerDigestOutput(stdout: string): string {
     return match[1] as string;
 }
 
-async function validateManagementSystemdUnitBroker(filePath: string, binaryName: string): Promise<void> {
-    const smoke = Bun.spawn([filePath, "--systemd-unit-helper-sha256"], { stdout: "pipe", stderr: "pipe" });
+export function parsePostgrestLauncherDigestOutput(stdout: string): string {
+    const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+    if (lines.length !== 1) throw new Error("Management PostgREST launcher digest output must contain exactly one line");
+    let message = lines[0] as string;
+    if (message.startsWith("{")) {
+        const payload = JSON.parse(message) as { message?: unknown };
+        if (typeof payload.message !== "string") {
+            throw new Error("Management PostgREST launcher digest JSON is invalid");
+        }
+        message = payload.message;
+    }
+    const match = message.match(/^SupaCloud PostgREST launcher SHA-256: ([0-9a-f]{64})$/);
+    if (!match) throw new Error("Management PostgREST launcher digest output is invalid");
+    return match[1] as string;
+}
+
+type ManagementEmbeddedArtifactCheck = {
+    argument: string;
+    expectedSha256: string;
+    label: string;
+    parseDigest: (stdout: string) => string;
+};
+
+async function validateManagementEmbeddedArtifact(
+    filePath: string,
+    binaryName: string,
+    check: ManagementEmbeddedArtifactCheck,
+): Promise<void> {
+    const smoke = Bun.spawn([filePath, check.argument], { stdout: "pipe", stderr: "pipe" });
     const timeout = setTimeout(() => smoke.kill("SIGKILL"), 5_000);
     try {
         const [exitCode, stdout, stderr] = await Promise.all([
@@ -1221,14 +1261,29 @@ async function validateManagementSystemdUnitBroker(filePath: string, binaryName:
             new Response(smoke.stderr).text(),
         ]);
         if (exitCode !== 0 || stderr.trim()) {
-            throw new Error(`${binaryName} failed the embedded systemd-unit helper identity check`);
+            throw new Error(`${binaryName} failed the embedded ${check.label} identity check`);
         }
-        if (parseSystemdUnitBrokerDigestOutput(stdout) !== EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256) {
-            throw new Error(`${binaryName} embeds an unexpected systemd-unit helper`);
+        if (check.parseDigest(stdout) !== check.expectedSha256) {
+            throw new Error(`${binaryName} embeds an unexpected ${check.label}`);
         }
     } finally {
         clearTimeout(timeout);
     }
+}
+
+async function validateManagementEmbeddedUpgradeArtifacts(filePath: string, binaryName: string): Promise<void> {
+    await validateManagementEmbeddedArtifact(filePath, binaryName, {
+        argument: "--systemd-unit-helper-sha256",
+        expectedSha256: EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256,
+        label: "systemd-unit helper",
+        parseDigest: parseSystemdUnitBrokerDigestOutput,
+    });
+    await validateManagementEmbeddedArtifact(filePath, binaryName, {
+        argument: "--postgrest-launcher-sha256",
+        expectedSha256: EMBEDDED_POSTGREST_LAUNCHER_SHA256,
+        label: "PostgREST launcher",
+        parseDigest: parsePostgrestLauncherDigestOutput,
+    });
 }
 
 async function validateManagementBinaryArtifact(filePath: string, binaryName: string, expectedVersion: string) {
@@ -1253,7 +1308,7 @@ async function validateManagementBinaryArtifact(filePath: string, binaryName: st
     if (actualVersion !== expectedVersion) {
         throw new Error(`${binaryName} reports ${actualVersion}; expected ${expectedVersion}`);
     }
-    await validateManagementSystemdUnitBroker(filePath, binaryName);
+    await validateManagementEmbeddedUpgradeArtifacts(filePath, binaryName);
 }
 
 async function downloadReleaseChecksums(release: GithubRelease, preferredEndpoint: GithubEndpoint, forceYes?: boolean) {
@@ -2305,6 +2360,7 @@ export async function waitForUpgradeHealth() {
 export type UpgradeActivationState = {
     binary: BinaryBackupState;
     edgeBinary: BinaryBackupState | null;
+    postgrestLauncher: PostgrestLauncherActivationState | null;
     systemdUnitBroker: PrivilegedHelperActivationState | null;
     webConsoleLink: WebConsoleLinkActivationState | null;
     managementEnvState: FileState | null;
@@ -2351,10 +2407,12 @@ type UpgradeExecutionState = {
     committed: boolean;
     downloadEndpointLabel: string;
     edgeRuntimeEndpointLabel: string | null;
+    preflightPostgrestLauncher: PostgrestLauncherPreflight | undefined;
     preflightSystemdUnitBroker: PrivilegedHelperIdentity | null;
     rollbackSucceeded: boolean;
     stagedEdgeRuntime: StagedBinary | null;
     stagedManagement: StagedBinary | null;
+    stagedPostgrestLauncher: StagedPrivilegedHelper | null;
     stagedSystemdUnitBroker: StagedPrivilegedHelper | null;
     stagedWebConsole: StagedWebConsole | null;
     webConsoleEndpointLabel: string | null;
@@ -2384,6 +2442,7 @@ export type UpgradeRecoveryPathState = {
     activation?: Partial<UpgradeActivationState> | null;
     stagedEdgeRuntime?: { path: string } | null;
     stagedManagement?: { path: string } | null;
+    stagedPostgrestLauncher?: { path: string } | null;
     stagedSystemdUnitBroker?: { path: string } | null;
     stagedWebConsole?: { releaseDir: string } | null;
 };
@@ -2391,6 +2450,8 @@ export type UpgradeRecoveryPathState = {
 type ActivateArtifactsRequest = {
     stagedBinary: StagedBinary;
     stagedEdgeBinary: StagedBinary | null;
+    stagedPostgrestLauncher: StagedPrivilegedHelper;
+    preflightPostgrestLauncher: PostgrestLauncherPreflight;
     stagedSystemdUnitBroker: StagedPrivilegedHelper;
     preflightSystemdUnitBroker: PrivilegedHelperIdentity;
     stagedWeb: StagedWebConsole | null;
@@ -2398,7 +2459,14 @@ type ActivateArtifactsRequest = {
 };
 
 async function activateArtifacts(request: ActivateArtifactsRequest) {
-    const { stagedBinary, stagedEdgeBinary, stagedSystemdUnitBroker, stagedWeb, state } = request;
+    const {
+        stagedBinary,
+        stagedEdgeBinary,
+        stagedPostgrestLauncher,
+        stagedSystemdUnitBroker,
+        stagedWeb,
+        state,
+    } = request;
     if (stagedWeb) verifyWebConsoleReleaseTree(stagedWeb.releaseDir, stagedWeb.treeSha256);
     const preparedSystemdUnitBroker = prepareSystemdUnitBrokerActivation({
         staged: stagedSystemdUnitBroker,
@@ -2406,7 +2474,14 @@ async function activateArtifacts(request: ActivateArtifactsRequest) {
         expectedPrevious: request.preflightSystemdUnitBroker,
     });
     state.systemdUnitBroker = preparedSystemdUnitBroker.state;
+    const preparedPostgrestLauncher = preparePostgrestLauncherActivation({
+        staged: stagedPostgrestLauncher,
+        targetPath: POSTGREST_LAUNCHER_TARGET,
+        expectedPrevious: request.preflightPostgrestLauncher,
+    });
+    state.postgrestLauncher = preparedPostgrestLauncher.state;
     activatePreparedSystemdUnitBroker(preparedSystemdUnitBroker);
+    activatePreparedPostgrestLauncher(preparedPostgrestLauncher);
     activateStagedBinary(stagedBinary.path, state.binary);
 
     if (stagedEdgeBinary && state.edgeBinary) {
@@ -2482,6 +2557,14 @@ function artifactRecoveryActions(state: UpgradeActivationState): UpgradeRecovery
             gid: systemdUnitBroker.previous.gid,
         }),
     });
+    const postgrestLauncher = state.postgrestLauncher;
+    if (postgrestLauncher) actions.push({
+        description: "restore PostgREST launcher",
+        run: () => restorePostgrestLauncher(postgrestLauncher, {
+            uid: postgrestLauncher.previous?.uid ?? postgrestLauncher.activatedIdentity.uid,
+            gid: postgrestLauncher.previous?.gid ?? postgrestLauncher.activatedIdentity.gid,
+        }),
+    });
     return actions;
 }
 
@@ -2510,6 +2593,7 @@ function createActivationState(edgeRuntimeTarget: string | null): UpgradeActivat
     return {
         binary: createBinaryBackupState(BIN_TARGET),
         edgeBinary: edgeRuntimeTarget ? createBinaryBackupState(edgeRuntimeTarget) : null,
+        postgrestLauncher: null,
         systemdUnitBroker: null,
         webConsoleLink: null,
         managementEnvState: null,
@@ -2642,10 +2726,12 @@ function createUpgradeExecutionState(plan: UpgradeReleasePlan): UpgradeExecution
         committed: false,
         downloadEndpointLabel: plan.endpoint.label,
         edgeRuntimeEndpointLabel: null,
+        preflightPostgrestLauncher: undefined,
         preflightSystemdUnitBroker: null,
         rollbackSucceeded: false,
         stagedEdgeRuntime: null,
         stagedManagement: null,
+        stagedPostgrestLauncher: null,
         stagedSystemdUnitBroker: null,
         stagedWebConsole: null,
         webConsoleEndpointLabel: null,
@@ -2680,6 +2766,7 @@ async function verifyUpgradePreflight(context: UpgradeExecutionContext): Promise
     verifyBackupPrivilegeDropPreflight();
     await verifyManagementUpgradePreflight();
     context.state.preflightSystemdUnitBroker = readPrivilegedHelperIdentity(SYSTEMD_UNIT_BROKER_TARGET);
+    context.state.preflightPostgrestLauncher = readPostgrestLauncherPreflight(POSTGREST_LAUNCHER_TARGET);
     const edgeRuntime = context.plan.edgeRuntime;
     if (!edgeRuntime) return;
     const current = await inspectActiveSystemdBinary(EDGE_RUNTIME_SERVICE_UNIT);
@@ -2773,6 +2860,8 @@ async function stageUpgradeArtifacts(context: UpgradeExecutionContext): Promise<
     await stageWebConsoleUpgrade(context);
     context.spinner.start(`Staging the Management release systemd-unit helper for ${SYSTEMD_UNIT_BROKER_TARGET}`);
     context.state.stagedSystemdUnitBroker = stageEmbeddedSystemdUnitBroker();
+    context.spinner.start(`Staging the Management release PostgREST launcher for ${POSTGREST_LAUNCHER_TARGET}`);
+    context.state.stagedPostgrestLauncher = stageEmbeddedPostgrestLauncher();
 }
 
 async function migrateUpgradeMetadata(context: UpgradeExecutionContext): Promise<void> {
@@ -2787,11 +2876,17 @@ async function activateUpgradeArtifacts(context: UpgradeExecutionContext): Promi
     if (!state.stagedManagement) throw new Error("Upgrade binary was not staged");
     if (!state.stagedSystemdUnitBroker) throw new Error("Upgrade systemd-unit helper was not staged");
     if (!state.preflightSystemdUnitBroker) throw new Error("Upgrade systemd-unit helper preflight is unavailable");
+    if (!state.stagedPostgrestLauncher) throw new Error("Upgrade PostgREST launcher was not staged");
+    if (state.preflightPostgrestLauncher === undefined) {
+        throw new Error("Upgrade PostgREST launcher preflight is unavailable");
+    }
     context.spinner.start("Atomically activating staged SupaCloud artifacts");
     state.activation = createActivationState(plan.edgeRuntime?.targetPath || null);
     await activateArtifacts({
         stagedBinary: state.stagedManagement,
         stagedEdgeBinary: state.stagedEdgeRuntime,
+        stagedPostgrestLauncher: state.stagedPostgrestLauncher,
+        preflightPostgrestLauncher: state.preflightPostgrestLauncher,
         stagedSystemdUnitBroker: state.stagedSystemdUnitBroker,
         preflightSystemdUnitBroker: state.preflightSystemdUnitBroker,
         stagedWeb: state.stagedWebConsole,
@@ -2845,6 +2940,7 @@ async function verifyUpgradeActivation(context: UpgradeExecutionContext): Promis
     await waitForUpgradeHealth();
     await verifyActivatedManagementBinary(stagedManagement.sha256);
     verifyInstalledSystemdUnitBroker();
+    verifyInstalledPostgrestLauncher();
     if (context.state.stagedWebConsole) verifyActivatedWebConsole(context.state.stagedWebConsole);
     await verifyEdgeRuntimeUpgrade(context);
     context.state.committed = true;
@@ -2874,6 +2970,11 @@ function stagedArtifactCleanupActions(state: UpgradeExecutionState): UpgradeClea
     if (systemdUnitBroker) actions.push({
         description: `remove staged systemd-unit helper ${systemdUnitBroker.path}`,
         run: () => rmSync(systemdUnitBroker.path, { force: true }),
+    });
+    const postgrestLauncher = state.stagedPostgrestLauncher;
+    if (postgrestLauncher) actions.push({
+        description: `remove staged PostgREST launcher ${postgrestLauncher.path}`,
+        run: () => rmSync(postgrestLauncher.path, { force: true }),
     });
     const webConsole = state.stagedWebConsole;
     if (!state.committed && webConsole) actions.push({
@@ -2905,6 +3006,11 @@ function activatedBackupCleanupActions(state: UpgradeExecutionState): UpgradeCle
     if (systemdUnitBrokerBackup) actions.push({
         description: `remove systemd-unit helper backup ${systemdUnitBrokerBackup.backupPath}`,
         run: () => cleanupSystemdUnitBrokerBackup(systemdUnitBrokerBackup),
+    });
+    const postgrestLauncherBackup = activation.postgrestLauncher;
+    if (postgrestLauncherBackup?.backupReady) actions.push({
+        description: `remove PostgREST launcher backup ${postgrestLauncherBackup.backupPath}`,
+        run: () => cleanupPostgrestLauncherBackup(postgrestLauncherBackup),
     });
     return actions;
 }
@@ -2952,21 +3058,41 @@ function upgradeTransactionOperations(context: UpgradeExecutionContext): Upgrade
     };
 }
 
+function recoveryPathHasDirectoryEntry(filePath: string): boolean {
+    try {
+        return lstatSync(filePath, { throwIfNoEntry: false }) !== undefined;
+    } catch {
+        // Recovery diagnostics must preserve the primary failure when a path cannot be inspected.
+        return true;
+    }
+}
+
 export function upgradeRecoveryPaths(state: UpgradeRecoveryPathState | null): string[] {
     if (!state) return [];
+    const absentLauncherTarget = state.activation?.postgrestLauncher?.activated
+        && state.activation.postgrestLauncher.previous === null
+        ? state.activation.postgrestLauncher.targetPath
+        : null;
     const candidates = [
         state.activation?.binary?.backupReady ? state.activation.binary.backupPath : null,
         state.activation?.edgeBinary?.backupReady ? state.activation.edgeBinary.backupPath : null,
         state.activation?.systemdUnitBroker?.backupReady
             ? state.activation.systemdUnitBroker.backupPath
             : null,
+        state.activation?.postgrestLauncher?.backupReady
+            ? state.activation.postgrestLauncher.backupPath
+            : null,
         state.activation?.webConsoleLink?.nextLink,
         state.stagedManagement?.path,
         state.stagedEdgeRuntime?.path,
+        state.stagedPostgrestLauncher?.path,
         state.stagedSystemdUnitBroker?.path,
         state.stagedWebConsole?.releaseDir,
     ];
-    return [...new Set(candidates.filter((candidate): candidate is string => Boolean(candidate && existsSync(candidate))))];
+    const presentPaths = candidates.filter((candidate): candidate is string =>
+        Boolean(candidate && recoveryPathHasDirectoryEntry(candidate)),
+    );
+    return [...new Set(absentLauncherTarget ? [...presentPaths, absentLauncherTarget] : presentPaths)];
 }
 
 function sanitizedUpgradeDiagnostic(error: unknown): string {

--- a/packages/management-api/tests/unit/embedded-postgrest-launcher.test.ts
+++ b/packages/management-api/tests/unit/embedded-postgrest-launcher.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  lstatSync,
+  linkSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  EMBEDDED_POSTGREST_LAUNCHER_SHA256,
+  EMBEDDED_POSTGREST_LAUNCHER_SOURCE,
+  activatePreparedPostgrestLauncher,
+  cleanupPostgrestLauncherBackup,
+  preparePostgrestLauncherActivation,
+  readPostgrestLauncherPreflight,
+  restorePostgrestLauncher,
+  stageEmbeddedPostgrestLauncher,
+  verifyInstalledPostgrestLauncher,
+} from "../../src/embedded-postgrest-launcher";
+import { upgradeRecoveryPaths } from "../../src/upgrade";
+
+const owner = {
+  uid: process.getuid?.() ?? 0,
+  gid: process.getgid?.() ?? 0,
+};
+
+function launcherFixture(previous?: string) {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), "supacloud-postgrest-launcher-")));
+  const target = join(directory, "postgrest-launcher");
+  if (previous !== undefined) {
+    writeFileSync(target, previous, { mode: 0o755 });
+    chmodSync(target, 0o755);
+  }
+  return { directory, target };
+}
+
+describe("embedded PostgREST launcher", () => {
+  test("embeds the exact canonical launcher bytes and digest", () => {
+    const sourcePath = join(import.meta.dir, "../../../../scripts/lib/postgrest_launcher.sh");
+    const source = readFileSync(sourcePath, "utf8");
+    expect(EMBEDDED_POSTGREST_LAUNCHER_SOURCE).toBe(source);
+    expect(EMBEDDED_POSTGREST_LAUNCHER_SHA256).toBe(
+      createHash("sha256").update(Buffer.from(source, "utf8")).digest("hex"),
+    );
+  });
+
+  test("installs into a previously absent target and removes only that target on rollback", () => {
+    const { directory, target } = launcherFixture();
+    try {
+      const preflight = readPostgrestLauncherPreflight(target, owner);
+      expect(preflight).toBeNull();
+      const staged = stageEmbeddedPostgrestLauncher(target, "absent", owner);
+      const activation = activatePreparedPostgrestLauncher(preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "absent",
+        owner,
+        expectedPrevious: preflight,
+      }));
+
+      expect(activation.previous).toBeNull();
+      expect(activation.backupReady).toBe(false);
+      expect(verifyInstalledPostgrestLauncher(target, owner).sha256)
+        .toBe(EMBEDDED_POSTGREST_LAUNCHER_SHA256);
+
+      restorePostgrestLauncher(activation, owner);
+      expect(readPostgrestLauncherPreflight(target, owner)).toBeNull();
+      expect(activation.activated).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("replaces an existing launcher and restores its frozen bytes and mode", () => {
+    const previousContent = "#!/bin/sh\nprintf old-launcher\\n\n";
+    const { directory, target } = launcherFixture(previousContent);
+    try {
+      const preflight = readPostgrestLauncherPreflight(target, owner);
+      expect(preflight).not.toBeNull();
+      const staged = stageEmbeddedPostgrestLauncher(target, "replacement", owner);
+      const activation = activatePreparedPostgrestLauncher(preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "replacement",
+        owner,
+        expectedPrevious: preflight,
+      }));
+
+      expect(readFileSync(target, "utf8")).toBe(EMBEDDED_POSTGREST_LAUNCHER_SOURCE);
+      expect(lstatSync(activation.backupPath).nlink).toBe(1);
+      restorePostgrestLauncher(activation, owner);
+      expect(readFileSync(target, "utf8")).toBe(previousContent);
+      expect(lstatSync(target).mode & 0o7777).toBe(0o755);
+
+      cleanupPostgrestLauncherBackup(activation, owner);
+      expect(activation.backupReady).toBe(false);
+      expect(() => lstatSync(activation.backupPath)).toThrow();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed on symbolic links, hard links, unsafe mode, and preflight drift", () => {
+    const { directory, target } = launcherFixture("#!/bin/sh\nexit 0\n");
+    try {
+      const symbolic = join(directory, "symbolic");
+      symlinkSync(target, symbolic);
+      expect(() => readPostgrestLauncherPreflight(symbolic, owner)).toThrow("direct regular file");
+
+      const hard = join(directory, "hard");
+      linkSync(target, hard);
+      expect(() => readPostgrestLauncherPreflight(target, owner)).toThrow("one link");
+      rmSync(hard);
+
+      chmodSync(target, 0o700);
+      expect(() => readPostgrestLauncherPreflight(target, owner)).toThrow("mode must be exactly 0755");
+      chmodSync(target, 0o755);
+
+      const preflight = readPostgrestLauncherPreflight(target, owner);
+      const staged = stageEmbeddedPostgrestLauncher(target, "drift", owner);
+      writeFileSync(target, "#!/bin/sh\nprintf concurrent-change\\n\n", { mode: 0o755 });
+      chmodSync(target, 0o755);
+      expect(() => preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "drift",
+        owner,
+        expectedPrevious: preflight,
+      })).toThrow("changed after upgrade preflight");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("never removes staging or backup paths that it failed to reserve", () => {
+    const { directory, target } = launcherFixture("#!/bin/sh\nexit 0\n");
+    const stagedCollision = `${target}.new-collision`;
+    const backupCollision = `${target}.bak-backup-collision`;
+    try {
+      writeFileSync(stagedCollision, "foreign staged evidence", { mode: 0o600 });
+      expect(() => stageEmbeddedPostgrestLauncher(target, "collision", owner)).toThrow();
+      expect(readFileSync(stagedCollision, "utf8")).toBe("foreign staged evidence");
+
+      const preflight = readPostgrestLauncherPreflight(target, owner);
+      const staged = stageEmbeddedPostgrestLauncher(target, "backup-stage", owner);
+      writeFileSync(backupCollision, "foreign backup evidence", { mode: 0o600 });
+      expect(() => preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "backup-collision",
+        owner,
+        expectedPrevious: preflight,
+      })).toThrow();
+      expect(readFileSync(backupCollision, "utf8")).toBe("foreign backup evidence");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("restores an absent target after a post-rename failure", () => {
+    const { directory, target } = launcherFixture();
+    try {
+      const staged = stageEmbeddedPostgrestLauncher(target, "post-rename", owner);
+      const prepared = preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "post-rename",
+        owner,
+        expectedPrevious: null,
+      });
+
+      expect(() => activatePreparedPostgrestLauncher(prepared, {
+        syncDirectory: () => { throw new Error("directory fsync failed"); },
+        verifyInstalled: () => { throw new Error("must not verify after fsync failure"); },
+        restore: restorePostgrestLauncher,
+      })).toThrow("directory fsync failed");
+      expect(readPostgrestLauncherPreflight(target, owner)).toBeNull();
+      expect(prepared.state.activated).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("aggregates activation and rollback failures while retaining recovery evidence", () => {
+    const previousContent = "#!/bin/sh\nprintf previous\\n\n";
+    const { directory, target } = launcherFixture(previousContent);
+    try {
+      const preflight = readPostgrestLauncherPreflight(target, owner);
+      const staged = stageEmbeddedPostgrestLauncher(target, "aggregate", owner);
+      const prepared = preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "aggregate",
+        owner,
+        expectedPrevious: preflight,
+      });
+
+      let failure: unknown;
+      try {
+        activatePreparedPostgrestLauncher(prepared, {
+          syncDirectory: () => { throw new Error("post-rename failure"); },
+          verifyInstalled: () => { throw new Error("must not verify after fsync failure"); },
+          restore: () => { throw new Error("rollback failure"); },
+        });
+      } catch (error: unknown) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect(prepared.state.activated).toBe(true);
+      expect(readFileSync(prepared.state.backupPath, "utf8")).toBe(previousContent);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("refuses rollback after activated-target identity drift", () => {
+    const { directory, target } = launcherFixture();
+    try {
+      const staged = stageEmbeddedPostgrestLauncher(target, "rollback-drift", owner);
+      const activation = activatePreparedPostgrestLauncher(preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "rollback-drift",
+        owner,
+        expectedPrevious: null,
+      }));
+      const replacement = join(directory, "replacement");
+      writeFileSync(replacement, EMBEDDED_POSTGREST_LAUNCHER_SOURCE, { mode: 0o755 });
+      chmodSync(replacement, 0o755);
+      renameSync(replacement, target);
+
+      expect(() => restorePostgrestLauncher(activation, owner)).toThrow("changed before rollback");
+      expect(activation.activated).toBe(true);
+      expect(upgradeRecoveryPaths({ activation: { postgrestLauncher: activation } })).toContain(target);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("retains the canonical recovery path when absent-target removal is not durable", () => {
+    const { directory, target } = launcherFixture();
+    try {
+      const staged = stageEmbeddedPostgrestLauncher(target, "rollback-fsync", owner);
+      const activation = activatePreparedPostgrestLauncher(preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "rollback-fsync",
+        owner,
+        expectedPrevious: null,
+      }));
+
+      rmSync(target);
+      expect(activation.activated).toBe(true);
+      expect(readPostgrestLauncherPreflight(target, owner)).toBeNull();
+      expect(upgradeRecoveryPaths({ activation: { postgrestLauncher: activation } })).toContain(target);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("retains a dangling canonical recovery target after identity drift", () => {
+    const { directory, target } = launcherFixture();
+    try {
+      const staged = stageEmbeddedPostgrestLauncher(target, "dangling-drift", owner);
+      const activation = activatePreparedPostgrestLauncher(preparePostgrestLauncherActivation({
+        staged,
+        targetPath: target,
+        runId: "dangling-drift",
+        owner,
+        expectedPrevious: null,
+      }));
+
+      rmSync(target);
+      symlinkSync(join(directory, "missing-launcher"), target);
+      expect(() => restorePostgrestLauncher(activation, owner)).toThrow("direct regular file");
+      expect(upgradeRecoveryPaths({ activation: { postgrestLauncher: activation } })).toContain(target);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/management-api/tests/unit/standalone-version.test.ts
+++ b/packages/management-api/tests/unit/standalone-version.test.ts
@@ -4,9 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import pkg from "../../package.json";
 import {
+  isPostgrestLauncherDigestCommand,
   isStandaloneVersionCommand,
   isSystemdUnitBrokerDigestCommand,
 } from "../../src/standalone";
+import { EMBEDDED_POSTGREST_LAUNCHER_SHA256 } from "../../src/embedded-postgrest-launcher";
 import { EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256 } from "../../src/embedded-systemd-unit-broker";
 
 const packageRoot = join(import.meta.dir, "../..");
@@ -44,6 +46,8 @@ describe("standalone version command", () => {
     expect(isStandaloneVersionCommand(["project", "--version"])).toBe(false);
     expect(isSystemdUnitBrokerDigestCommand(["--systemd-unit-helper-sha256"])).toBe(true);
     expect(isSystemdUnitBrokerDigestCommand(["upgrade", "--systemd-unit-helper-sha256"])).toBe(false);
+    expect(isPostgrestLauncherDigestCommand(["--postgrest-launcher-sha256"])).toBe(true);
+    expect(isPostgrestLauncherDigestCommand(["upgrade", "--postgrest-launcher-sha256"])).toBe(false);
   });
 
   test("compiled binary prints its version without loading runtime configuration", async () => {
@@ -60,15 +64,23 @@ describe("standalone version command", () => {
     const version = await captureProcess([binaryPath, "--version"], 5_000);
     expect(version.timedOut).toBe(false);
     expect(version.exitCode).toBe(0);
-    expect(version.stdout).toContain(`SupaCloud Version: ${pkg.version}`);
+    expect(version.stdout).toBe(`SupaCloud Version: ${pkg.version}\n`);
     expect(version.stderr).toBe("");
 
     const helperDigest = await captureProcess([binaryPath, "--systemd-unit-helper-sha256"], 5_000);
     expect(helperDigest.timedOut).toBe(false);
     expect(helperDigest.exitCode).toBe(0);
-    expect(helperDigest.stdout).toContain(
-      `SupaCloud systemd-unit helper SHA-256: ${EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256}`,
+    expect(helperDigest.stdout).toBe(
+      `SupaCloud systemd-unit helper SHA-256: ${EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256}\n`,
     );
     expect(helperDigest.stderr).toBe("");
+
+    const launcherDigest = await captureProcess([binaryPath, "--postgrest-launcher-sha256"], 5_000);
+    expect(launcherDigest.timedOut).toBe(false);
+    expect(launcherDigest.exitCode).toBe(0);
+    expect(launcherDigest.stdout).toBe(
+      `SupaCloud PostgREST launcher SHA-256: ${EMBEDDED_POSTGREST_LAUNCHER_SHA256}\n`,
+    );
+    expect(launcherDigest.stderr).toBe("");
   }, 40_000);
 });

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -48,6 +48,7 @@ import {
     normalizeExactManagementVersion,
     normalizeManagementReleaseTag,
     parseManagementVersionOutput,
+    parsePostgrestLauncherDigestOutput,
     parseSystemdUnitBrokerDigestOutput,
     parseSystemdExecStartPath,
     parseSystemdEnabledState,
@@ -585,6 +586,16 @@ describe("upgrade release selection", () => {
     }))).toBe(digest);
     expect(() => parseSystemdUnitBrokerDigestOutput(
       `SupaCloud systemd-unit helper SHA-256: ${digest}\nextra\n`,
+    )).toThrow("exactly one line");
+
+    expect(parsePostgrestLauncherDigestOutput(
+      `SupaCloud PostgREST launcher SHA-256: ${digest}\n`,
+    )).toBe(digest);
+    expect(parsePostgrestLauncherDigestOutput(JSON.stringify({
+      message: `SupaCloud PostgREST launcher SHA-256: ${digest}`,
+    }))).toBe(digest);
+    expect(() => parsePostgrestLauncherDigestOutput(
+      `SupaCloud PostgREST launcher SHA-256: ${digest}\nextra\n`,
     )).toThrow("exactly one line");
   });
 
@@ -1400,6 +1411,7 @@ describe("upgrade release selection", () => {
           activated: true,
         },
         edgeBinary: null,
+        postgrestLauncher: null,
         systemdUnitBroker: prepared.state,
         webConsoleLink: null,
         managementEnvState: null,


### PR DESCRIPTION
## Summary

- embed the canonical PostgREST launcher bytes and release-bound SHA-256 in the Management binary
- include launcher preflight, staging, atomic activation, verification, rollback, cleanup, and recovery evidence in the Management upgrade transaction
- fail closed in Admin local and remote transports unless the exact target runner exposes bounded version, systemd-helper, and launcher identities
- emit stable one-line standalone identity output and cover the compiled Management binary against the generated Admin capability gate

## Root cause

The official Management binary upgrade transaction delivered the target-bound systemd unit helper but omitted the canonical PostgREST launcher required by generated tenant units. An upgrade could therefore commit while later PostgREST restarts failed with 203/EXEC.

## Transaction and recovery proof

- prior launcher absent: atomically install the release launcher and remove only that target during rollback
- prior launcher present: freeze and restore exact bytes, mode, owner, and identity
- reject symlinks, special files, extra hardlinks, unsafe ownership or mode, and identity drift
- preserve canonical recovery evidence after remove-success plus directory-fsync failure and dangling-symlink drift
- aggregate activation, rollback, and cleanup failures without reporting false success
- verify all target-runner identity commands with a 5-second timeout before adoption or transaction start

## Verification

- Management: `bun run test` PASS, including SQL sync, full unit, and integration gates
- Management: `bun run typecheck` PASS
- Admin: `bun test` 468 pass, 26 skip, 0 fail
- Admin: `bun run typecheck` PASS
- Admin: `bun run build` PASS
- Focused launcher and upgrade tests: 97 pass, 0 fail
- Focused Admin transport tests: 131 pass, 0 fail
- real `bun build --compile` Management runner accepted by generated local capability shell
- three independent platform, security, and workflow/SDK reviewers: PASS with no blocking findings
- `git diff --check` PASS

## Boundaries

This PR does not publish or deploy any component, restart services, modify production data, add DBOS, or change workflow APIs. It adds no HTTP, OpenAPI, RPC, package, or lockfile surface, so SupaCloud JS remains unchanged at 0.22.0.