### PR TITLE
fix(management-api): harden PostgREST process attestation

### DIFF
--- a/packages/management-api/src/services/linux-pidfd.ts
+++ b/packages/management-api/src/services/linux-pidfd.ts
@@ -1,0 +1,55 @@
+export interface LinuxPidfdOperations {
+  open(pid: number): number;
+  sendSignal(pidfd: number, signal: number): number;
+  close(pidfd: number): void;
+}
+
+const PIDFD_SEND_SIGNAL_SYSCALL = 424;
+const PIDFD_OPEN_SYSCALL = 434;
+
+async function linuxPidfdOperations(): Promise<LinuxPidfdOperations> {
+  if (process.platform !== "linux" || !["arm64", "x64"].includes(process.arch)) {
+    throw new Error("Linux pidfd is unavailable on this platform");
+  }
+  // Bun 1.3.14 does not expose pidfd, so termination uses the kernel handle through libc.
+  const { dlopen, FFIType } = await import("bun:ffi");
+  const libc = dlopen("libc.so.6", {
+    syscall: {
+      args: [FFIType.i64, FFIType.i64, FFIType.i64, FFIType.i64, FFIType.i64],
+      returns: FFIType.i64,
+    },
+    close: { args: [FFIType.i32], returns: FFIType.i32 },
+  });
+  return {
+    open(pid) {
+      const pidfd = Number(libc.symbols.syscall(PIDFD_OPEN_SYSCALL, pid, 0, 0, 0));
+      if (pidfd < 0) libc.close();
+      return pidfd;
+    },
+    sendSignal(pidfd, signal) {
+      return Number(libc.symbols.syscall(PIDFD_SEND_SIGNAL_SYSCALL, pidfd, signal, 0, 0));
+    },
+    close(pidfd) {
+      libc.symbols.close(pidfd);
+      libc.close();
+    },
+  };
+}
+
+export async function killVerifiedProcessWithPidfd(
+  pid: number,
+  verifyTarget: () => Promise<void>,
+  operations?: LinuxPidfdOperations,
+): Promise<void> {
+  const pidfdOperations = operations ?? await linuxPidfdOperations();
+  const pidfd = pidfdOperations.open(pid);
+  if (pidfd < 0) throw new Error("Failed to open PostgREST identity probe pidfd");
+  try {
+    await verifyTarget();
+    if (pidfdOperations.sendSignal(pidfd, 9) !== 0) {
+      throw new Error("Failed to signal PostgREST identity probe pidfd");
+    }
+  } finally {
+    pidfdOperations.close(pidfd);
+  }
+}

--- a/packages/management-api/src/services/postgrest-process-identity.ts
+++ b/packages/management-api/src/services/postgrest-process-identity.ts
@@ -1,0 +1,795 @@
+import { lstat, open, readlink, realpath } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+import {
+  killVerifiedProcessWithPidfd,
+  type LinuxPidfdOperations,
+} from "./linux-pidfd";
+
+export const POSTGREST_PROCESS_IDENTITY_PROBE_FLAG = "--postgrest-process-identity-probe-v1";
+export const POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG = "--postgrest-process-identity-terminate-v1";
+export const POSTGREST_PROCESS_IDENTITY_STDOUT_LIMIT = 64 * 1024;
+
+const POSTGREST_PROCESS_IDENTITY_STDERR_LIMIT = 4 * 1024;
+const POSTGREST_PROCESS_IDENTITY_TIMEOUT_MS = 5_000;
+const POSTGREST_PROCESS_TERMINATION_TIMEOUT_MS = 1_000;
+const MAX_LINUX_PID = 2_147_483_647;
+const MAX_LINUX_ID = 4_294_967_294;
+const MAX_PROC_STATUS_BYTES = 16 * 1024;
+const MAX_PROC_STAT_BYTES = 8 * 1024;
+const MAX_PROC_COMMAND_LINE_BYTES = 128 * 1024;
+const MAX_PROC_ENVIRONMENT_BYTES = 2 * 1024 * 1024;
+const MAX_EXECUTABLE_PATH_BYTES = 4 * 1024;
+const MAX_COMMAND_LINE_ARGUMENTS = 64;
+const MAX_COMMAND_LINE_ARGUMENT_BYTES = 16 * 1024;
+const MAX_ENVIRONMENT_NAMES = 1_024;
+const MAX_ENVIRONMENT_NAME_BYTES = 256;
+const MAX_PROCESS_START_ID_BYTES = 32;
+const SETPRIV_PATH = "/usr/bin/setpriv";
+const ENVIRONMENT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,255}$/;
+
+export interface PostgrestRuntimeIdentity {
+  uid: number;
+  gid: number;
+}
+
+export interface PostgrestProcessIdentityProbeResult {
+  version: 1;
+  startId: string;
+  executable: string;
+  commandLine: string[];
+  environmentNames: string[];
+}
+
+export interface PostgrestProcessIdentity {
+  startId: string;
+  executable: string;
+  commandLine: string[];
+  environmentNames: string[];
+}
+
+export interface PostgrestProcessIdentityCollectorOperations {
+  currentUid(): number | undefined;
+  currentGid(): number | undefined;
+  readLink(path: string): Promise<string>;
+  readFile(path: string, maxBytes: number): Promise<Buffer>;
+}
+
+export interface PostgrestProcessMetadata {
+  uid: number;
+  gid: number;
+  dev: number;
+  ino: number;
+  isDirectory: boolean;
+}
+
+export interface PostgrestIdentityProbeProcess {
+  pid: number;
+  startId: string;
+  exited: Promise<number>;
+  kill(signal: NodeJS.Signals): void;
+}
+
+export interface SpawnedPostgrestIdentityProbe extends PostgrestIdentityProbeProcess {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+}
+
+export interface PostgrestProcessIdentityParentOperations {
+  processMetadata(pid: number): Promise<PostgrestProcessMetadata>;
+  executablePath(): Promise<string>;
+  spawn(command: string[], options: {
+    cwd: "/";
+    environment: Record<string, string>;
+    stdin: "ignore";
+  }): Promise<SpawnedPostgrestIdentityProbe>;
+}
+
+export interface PostgrestProcessIdentityTerminationOperations {
+  spawn(command: string[], options: {
+    cwd: "/";
+    environment: Record<string, string>;
+    stdin: "ignore";
+  }): { exited: Promise<number> };
+}
+
+type ProbeExecutionOptions = {
+  timeoutMs?: number;
+};
+
+type CompletedProbeOutput = {
+  exitCode: number;
+  stdout: Uint8Array;
+  stderr: Uint8Array;
+};
+
+function parseBoundedDecimal(rawDecimal: string, minimum: number, maximum: number): number | null {
+  if (!/^(?:0|[1-9]\d*)$/.test(rawDecimal)) return null;
+  const parsed = Number(rawDecimal);
+  return Number.isSafeInteger(parsed) && parsed >= minimum && parsed <= maximum ? parsed : null;
+}
+
+export function parseLinuxProcessId(rawPid: string): number {
+  const parsed = parseBoundedDecimal(rawPid, 1, MAX_LINUX_PID);
+  if (parsed === null) throw new Error("Invalid Linux process id");
+  return parsed;
+}
+
+export function parseSystemdMainPid(rawPid: string): number {
+  const parsed = parseBoundedDecimal(rawPid, 0, MAX_LINUX_PID);
+  if (parsed === null) throw new Error("Invalid systemd process id");
+  return parsed;
+}
+
+export function parseLinuxRuntimeId(rawId: string): number {
+  const parsed = parseBoundedDecimal(rawId, 1, MAX_LINUX_ID);
+  if (parsed === null) throw new Error("Invalid Linux runtime id");
+  return parsed;
+}
+
+function parseProbeArguments(args: string[]): { pid: number; identity: PostgrestRuntimeIdentity } {
+  if (args.length !== 3) throw new Error("Invalid PostgREST process identity probe arguments");
+  let pid: number;
+  let uid: number;
+  let gid: number;
+  try {
+    pid = parseLinuxProcessId(args[0]!);
+    uid = parseLinuxRuntimeId(args[1]!);
+    gid = parseLinuxRuntimeId(args[2]!);
+  } catch {
+    throw new Error("Invalid PostgREST process identity probe arguments");
+  }
+  return { pid, identity: { uid, gid } };
+}
+
+function parseProcessStartId(rawStartId: string): string {
+  if (!/^(?:0|[1-9]\d*)$/.test(rawStartId)
+    || Buffer.byteLength(rawStartId, "utf8") > MAX_PROCESS_START_ID_BYTES) {
+    throw new Error("Invalid process start identity");
+  }
+  return rawStartId;
+}
+
+function parseTerminationArguments(args: string[]): {
+  pid: number;
+  identity: PostgrestRuntimeIdentity;
+  startId: string;
+} {
+  if (args.length !== 4) throw new Error("Invalid PostgREST process identity termination arguments");
+  try {
+    const { pid, identity } = parseProbeArguments(args.slice(0, 3));
+    return { pid, identity, startId: parseProcessStartId(args[3]!) };
+  } catch {
+    throw new Error("Invalid PostgREST process identity termination arguments");
+  }
+}
+
+async function readFileBounded(path: string, maxBytes: number): Promise<Buffer> {
+  const file = await open(path, "r");
+  try {
+    const boundedBytes = Buffer.allocUnsafe(maxBytes + 1);
+    let offset = 0;
+    while (offset <= maxBytes) {
+      const { bytesRead } = await file.read(
+        boundedBytes,
+        offset,
+        Math.min(16 * 1024, maxBytes + 1 - offset),
+        null,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > maxBytes) throw new Error("PostgREST process identity input exceeded limit");
+    return boundedBytes.subarray(0, offset);
+  } finally {
+    await file.close();
+  }
+}
+
+const defaultCollectorOperations: PostgrestProcessIdentityCollectorOperations = {
+  currentUid: () => process.getuid?.(),
+  currentGid: () => process.getgid?.(),
+  readLink: readlink,
+  readFile: readFileBounded,
+};
+
+function decodeUtf8(rawBytes: Uint8Array): string {
+  return new TextDecoder("utf-8", { fatal: true }).decode(rawBytes);
+}
+
+function statusIdentity(status: string, label: "Uid" | "Gid"): number[] {
+  const match = status.match(new RegExp(`^${label}:[ \\t]+([0-9]+)[ \\t]+([0-9]+)[ \\t]+([0-9]+)[ \\t]+([0-9]+)[ \\t]*$`, "m"));
+  if (!match) throw new Error(`Invalid process ${label} identity`);
+  const maximum = MAX_LINUX_ID;
+  const parsedIds = match.slice(1).map((rawId) => parseBoundedDecimal(rawId!, 0, maximum));
+  if (parsedIds.some((parsedId) => parsedId === null)) throw new Error(`Invalid process ${label} identity`);
+  return parsedIds as number[];
+}
+
+function assertExactStatusIdentity(
+  status: string,
+  expected: PostgrestRuntimeIdentity,
+  label: string,
+): void {
+  const uids = statusIdentity(status, "Uid");
+  const gids = statusIdentity(status, "Gid");
+  if (uids.some((uid) => uid !== expected.uid) || gids.some((gid) => gid !== expected.gid)) {
+    throw new Error(`${label} has unexpected uid/gid`);
+  }
+}
+
+function assertClearedSupplementaryGroups(status: string): void {
+  const match = status.match(/^Groups:[ \t]*(.*)$/m);
+  if (!match) throw new Error("Cannot verify probe supplementary groups");
+  if (match[1]!.trim() !== "") throw new Error("Probe retained supplementary groups");
+}
+
+function assertClearedCapabilities(status: string): void {
+  for (const label of ["CapInh", "CapPrm", "CapEff", "CapAmb"] as const) {
+    const match = status.match(new RegExp(`^${label}:[ \\t]*([a-fA-F0-9]+)[ \\t]*$`, "m"));
+    if (!match || BigInt(`0x${match[1]}`) !== 0n) {
+      throw new Error("Probe retained process capabilities");
+    }
+  }
+}
+
+async function assertSandboxedRuntime(
+  label: string,
+  identity: PostgrestRuntimeIdentity,
+  operations: PostgrestProcessIdentityCollectorOperations,
+): Promise<void> {
+  if (operations.currentUid() !== identity.uid || operations.currentGid() !== identity.gid) {
+    throw new Error(`${label} has unexpected uid/gid`);
+  }
+  const selfStatus = decodeUtf8(await operations.readFile("/proc/self/status", MAX_PROC_STATUS_BYTES));
+  assertExactStatusIdentity(selfStatus, identity, label);
+  assertClearedSupplementaryGroups(selfStatus);
+  assertClearedCapabilities(selfStatus);
+}
+
+function procStartId(statContent: string, expectedPid: number): string {
+  const commandStart = statContent.indexOf(" (");
+  const commandEnd = statContent.lastIndexOf(")");
+  if (commandStart <= 0 || commandEnd <= commandStart + 1) {
+    throw new Error("Invalid process start identity");
+  }
+  let observedPid: number;
+  try {
+    observedPid = parseLinuxProcessId(statContent.slice(0, commandStart).trim());
+  } catch {
+    throw new Error("Invalid process start identity");
+  }
+  if (observedPid !== expectedPid) throw new Error("Process stat has unexpected process id");
+  const fieldsAfterCommand = statContent.slice(commandEnd + 1).trim().split(/\s+/);
+  const startId = fieldsAfterCommand[19];
+  if (!startId) throw new Error("Invalid process start identity");
+  return parseProcessStartId(startId);
+}
+
+async function processStartId(
+  pid: number,
+  operations: PostgrestProcessIdentityCollectorOperations,
+): Promise<string> {
+  return procStartId(decodeUtf8(
+    await operations.readFile(`/proc/${pid}/stat`, MAX_PROC_STAT_BYTES),
+  ), pid);
+}
+
+function nulDelimitedEntries(rawBytes: Buffer, label: string): Buffer[] {
+  if (rawBytes.length === 0) return [];
+  if (rawBytes[rawBytes.length - 1] !== 0) throw new Error(`Invalid ${label}`);
+  const entries: Buffer[] = [];
+  let start = 0;
+  for (let index = 0; index < rawBytes.length; index += 1) {
+    if (rawBytes[index] !== 0) continue;
+    entries.push(rawBytes.subarray(start, index));
+    start = index + 1;
+  }
+  return entries;
+}
+
+function commandLine(commandLineBytes: Buffer): string[] {
+  const entries = nulDelimitedEntries(commandLineBytes, "process command line");
+  if (entries.length === 0 || entries.length > MAX_COMMAND_LINE_ARGUMENTS) {
+    throw new Error("Invalid process command line");
+  }
+  return entries.map((entry) => {
+    if (entry.length > MAX_COMMAND_LINE_ARGUMENT_BYTES) throw new Error("Invalid process command line");
+    return decodeUtf8(entry);
+  });
+}
+
+function environmentNames(environmentBytes: Buffer): string[] {
+  const entries = nulDelimitedEntries(environmentBytes, "process environment");
+  if (entries.length > MAX_ENVIRONMENT_NAMES) throw new Error("Invalid process environment");
+  const names = entries.map((entry) => {
+    const separator = entry.indexOf(0x3d);
+    if (separator <= 0 || separator > MAX_ENVIRONMENT_NAME_BYTES) {
+      throw new Error("Invalid process environment name");
+    }
+    const name = decodeUtf8(entry.subarray(0, separator));
+    if (!ENVIRONMENT_NAME_PATTERN.test(name)) throw new Error("Invalid process environment name");
+    return name;
+  }).sort();
+  if (new Set(names).size !== names.length) throw new Error("Duplicate process environment name");
+  return names;
+}
+
+function assertExecutablePath(executable: string): void {
+  if (!isAbsolute(executable)
+    || executable.includes("\0")
+    || Buffer.byteLength(executable, "utf8") > MAX_EXECUTABLE_PATH_BYTES) {
+    throw new Error("Invalid process executable path");
+  }
+}
+
+export async function collectPostgrestProcessIdentity(
+  args: string[],
+  operations: PostgrestProcessIdentityCollectorOperations = defaultCollectorOperations,
+): Promise<PostgrestProcessIdentityProbeResult> {
+  const { pid, identity } = parseProbeArguments(args);
+  await assertSandboxedRuntime("Probe", identity, operations);
+
+  const targetStatusBefore = decodeUtf8(await operations.readFile(`/proc/${pid}/status`, MAX_PROC_STATUS_BYTES));
+  assertExactStatusIdentity(targetStatusBefore, identity, "PostgREST process");
+  const startIdBefore = await processStartId(pid, operations);
+  const [executable, commandLineBytes, environmentBytes] = await Promise.all([
+    operations.readLink(`/proc/${pid}/exe`),
+    operations.readFile(`/proc/${pid}/cmdline`, MAX_PROC_COMMAND_LINE_BYTES),
+    operations.readFile(`/proc/${pid}/environ`, MAX_PROC_ENVIRONMENT_BYTES),
+  ]);
+  const startIdAfter = await processStartId(pid, operations);
+  const targetStatusAfter = decodeUtf8(await operations.readFile(`/proc/${pid}/status`, MAX_PROC_STATUS_BYTES));
+  assertExactStatusIdentity(targetStatusAfter, identity, "PostgREST process");
+  if (startIdBefore !== startIdAfter) throw new Error("PostgREST process changed during identity probe");
+  assertExecutablePath(executable);
+
+  return {
+    version: 1,
+    startId: startIdAfter,
+    executable,
+    commandLine: commandLine(commandLineBytes),
+    environmentNames: environmentNames(environmentBytes),
+  };
+}
+
+async function verifyTerminationTarget(
+  pid: number,
+  identity: PostgrestRuntimeIdentity,
+  expectedStartId: string,
+  operations: PostgrestProcessIdentityCollectorOperations,
+): Promise<void> {
+  const startIdBefore = await processStartId(pid, operations);
+  const targetStatus = decodeUtf8(await operations.readFile(`/proc/${pid}/status`, MAX_PROC_STATUS_BYTES));
+  assertExactStatusIdentity(targetStatus, identity, "PostgREST identity probe");
+  const startIdAfter = await processStartId(pid, operations);
+  if (startIdBefore !== expectedStartId || startIdAfter !== expectedStartId) {
+    throw new Error("PostgREST identity probe process changed before termination");
+  }
+}
+
+export async function terminatePostgrestIdentityProbeByPidfd(
+  args: string[],
+  operations: PostgrestProcessIdentityCollectorOperations = defaultCollectorOperations,
+  pidfdOperations?: LinuxPidfdOperations,
+): Promise<void> {
+  const { pid, identity, startId } = parseTerminationArguments(args);
+  await assertSandboxedRuntime("Termination helper", identity, operations);
+  await killVerifiedProcessWithPidfd(
+    pid,
+    () => verifyTerminationTarget(pid, identity, startId, operations),
+    pidfdOperations,
+  );
+}
+
+function boundedProbeString(candidate: unknown, maxBytes: number): candidate is string {
+  return typeof candidate === "string"
+    && candidate.length > 0
+    && Buffer.byteLength(candidate, "utf8") <= maxBytes;
+}
+
+function boundedProbeArgument(candidate: unknown): candidate is string {
+  return typeof candidate === "string"
+    && Buffer.byteLength(candidate, "utf8") <= MAX_COMMAND_LINE_ARGUMENT_BYTES
+    && !candidate.includes("\0");
+}
+
+function strictProbeResult(candidate: unknown): PostgrestProcessIdentityProbeResult {
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  const probeOutput = candidate as Record<string, unknown>;
+  const keys = Object.keys(probeOutput).sort();
+  if (JSON.stringify(keys) !== JSON.stringify([
+    "commandLine",
+    "environmentNames",
+    "executable",
+    "startId",
+    "version",
+  ])) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  if (probeOutput.version !== 1
+    || !boundedProbeString(probeOutput.startId, MAX_PROCESS_START_ID_BYTES)
+    || !/^(?:0|[1-9]\d*)$/.test(probeOutput.startId)
+    || !boundedProbeString(probeOutput.executable, MAX_EXECUTABLE_PATH_BYTES)
+    || !isAbsolute(probeOutput.executable)
+    || probeOutput.executable.includes("\0")) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  if (!Array.isArray(probeOutput.commandLine)
+    || probeOutput.commandLine.length === 0
+    || probeOutput.commandLine.length > MAX_COMMAND_LINE_ARGUMENTS
+    || probeOutput.commandLine.some((argument) => !boundedProbeArgument(argument))) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  if (!Array.isArray(probeOutput.environmentNames)
+    || probeOutput.environmentNames.length > MAX_ENVIRONMENT_NAMES
+    || probeOutput.environmentNames.some((name) => !boundedProbeString(name, MAX_ENVIRONMENT_NAME_BYTES)
+      || !ENVIRONMENT_NAME_PATTERN.test(name))) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  const sortedNames = [...probeOutput.environmentNames].sort();
+  if (JSON.stringify(sortedNames) !== JSON.stringify(probeOutput.environmentNames)
+    || new Set(probeOutput.environmentNames).size !== probeOutput.environmentNames.length) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  return probeOutput as unknown as PostgrestProcessIdentityProbeResult;
+}
+
+export function parsePostgrestProcessIdentityProbeOutput(
+  output: Uint8Array,
+): PostgrestProcessIdentity {
+  if (output.byteLength === 0 || output.byteLength > POSTGREST_PROCESS_IDENTITY_STDOUT_LIMIT) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  let text: string;
+  try {
+    text = decodeUtf8(output);
+  } catch {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  if (!text.endsWith("\n") || text.slice(0, -1).includes("\n")) {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text.slice(0, -1));
+  } catch {
+    throw new Error("Invalid PostgREST process identity probe output");
+  }
+  const { version: _version, ...identity } = strictProbeResult(parsed);
+  return identity;
+}
+
+export function buildPostgrestProcessIdentityProbeCommand(
+  executable: string,
+  pid: number,
+  identity: PostgrestRuntimeIdentity,
+): string[] {
+  parseProbeArguments([String(pid), String(identity.uid), String(identity.gid)]);
+  if (!isAbsolute(executable)) {
+    throw new Error("Invalid PostgREST process identity probe executable");
+  }
+  return [
+    SETPRIV_PATH,
+    "--reuid",
+    String(identity.uid),
+    "--regid",
+    String(identity.gid),
+    "--clear-groups",
+    "--",
+    executable,
+    POSTGREST_PROCESS_IDENTITY_PROBE_FLAG,
+    String(pid),
+    String(identity.uid),
+    String(identity.gid),
+  ];
+}
+
+export function buildPostgrestProcessIdentityTerminationCommand(
+  executable: string,
+  child: PostgrestIdentityProbeProcess,
+  identity: PostgrestRuntimeIdentity,
+): string[] {
+  parseTerminationArguments([
+    String(child.pid),
+    String(identity.uid),
+    String(identity.gid),
+    child.startId,
+  ]);
+  if (!isAbsolute(executable)) {
+    throw new Error("Invalid PostgREST process identity termination executable");
+  }
+  return [
+    SETPRIV_PATH,
+    "--reuid",
+    String(identity.uid),
+    "--regid",
+    String(identity.gid),
+    "--clear-groups",
+    "--",
+    executable,
+    POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG,
+    String(child.pid),
+    String(identity.uid),
+    String(identity.gid),
+    child.startId,
+  ];
+}
+
+function isPermissionDenied(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === "EPERM";
+}
+
+const defaultTerminationOperations: PostgrestProcessIdentityTerminationOperations = {
+  spawn(command, options) {
+    const terminator = Bun.spawn({
+      cmd: command,
+      cwd: options.cwd,
+      env: options.environment,
+      stdin: options.stdin,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return { exited: terminator.exited };
+  },
+};
+
+async function processExitWithin(
+  exited: Promise<number>,
+  timeoutMessage: string,
+): Promise<number> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(timeoutMessage)), POSTGREST_PROCESS_TERMINATION_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+async function terminateProbeAsTenant(
+  child: PostgrestIdentityProbeProcess,
+  identity: PostgrestRuntimeIdentity,
+  executable: string,
+  operations: PostgrestProcessIdentityTerminationOperations,
+): Promise<void> {
+  const terminator = operations.spawn(
+    buildPostgrestProcessIdentityTerminationCommand(executable, child, identity),
+    {
+      cwd: "/",
+      environment: { LANG: "C", LC_ALL: "C" },
+      stdin: "ignore",
+    },
+  );
+  const exitCode = await processExitWithin(
+    terminator.exited,
+    "PostgREST process identity termination helper timed out",
+  );
+  if (exitCode !== 0) {
+    throw new Error("Failed to terminate PostgREST process identity probe");
+  }
+}
+
+export async function terminatePostgrestIdentityProbe(
+  child: PostgrestIdentityProbeProcess,
+  identity: PostgrestRuntimeIdentity,
+  executable: string,
+  operations: PostgrestProcessIdentityTerminationOperations = defaultTerminationOperations,
+): Promise<void> {
+  try {
+    child.kill("SIGKILL");
+  } catch (error) {
+    if (!isPermissionDenied(error)) throw error;
+    await terminateProbeAsTenant(child, identity, executable, operations);
+  }
+  await processExitWithin(
+    child.exited,
+    "PostgREST process identity probe did not exit after termination",
+  );
+}
+
+function sameProcessMetadata(
+  before: PostgrestProcessMetadata,
+  after: PostgrestProcessMetadata,
+): boolean {
+  return before.isDirectory && after.isDirectory
+    && before.uid === after.uid
+    && before.gid === after.gid
+    && before.dev === after.dev
+    && before.ino === after.ino;
+}
+
+function assertProcessOwner(
+  metadata: PostgrestProcessMetadata,
+  identity: PostgrestRuntimeIdentity,
+): void {
+  if (!metadata.isDirectory || metadata.uid !== identity.uid || metadata.gid !== identity.gid) {
+    throw new Error("PostgREST process has unexpected owner");
+  }
+}
+
+async function readBoundedStream(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+  label: "stdout" | "stderr",
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value: chunk } = await reader.read();
+      if (done) break;
+      total += chunk.byteLength;
+      if (total > maxBytes) throw new Error(`PostgREST process identity probe ${label} output exceeded limit`);
+      chunks.push(chunk);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+const defaultParentOperations: PostgrestProcessIdentityParentOperations = {
+  async processMetadata(pid) {
+    const metadata = await lstat(`/proc/${pid}`);
+    return {
+      uid: metadata.uid,
+      gid: metadata.gid,
+      dev: metadata.dev,
+      ino: metadata.ino,
+      isDirectory: metadata.isDirectory(),
+    };
+  },
+  executablePath: () => realpath(process.execPath),
+  async spawn(command, options) {
+    const child = Bun.spawn({
+      cmd: command,
+      cwd: options.cwd,
+      env: options.environment,
+      stdin: options.stdin,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const startId = procStartId(decodeUtf8(
+      await readFileBounded(`/proc/${child.pid}/stat`, MAX_PROC_STAT_BYTES),
+    ), child.pid);
+    return {
+      pid: child.pid,
+      startId,
+      stdout: child.stdout,
+      stderr: child.stderr,
+      exited: child.exited,
+      kill: (signal) => { child.kill(signal); },
+    };
+  },
+};
+
+async function completedProbeOutput(
+  child: SpawnedPostgrestIdentityProbe,
+): Promise<CompletedProbeOutput> {
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    readBoundedStream(child.stdout, POSTGREST_PROCESS_IDENTITY_STDOUT_LIMIT, "stdout"),
+    readBoundedStream(child.stderr, POSTGREST_PROCESS_IDENTITY_STDERR_LIMIT, "stderr"),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+function successfulProbeStdout(completed: CompletedProbeOutput): Uint8Array {
+  if (completed.exitCode !== 0 || completed.stderr.byteLength !== 0) {
+    throw new Error("PostgREST process identity probe failed");
+  }
+  return completed.stdout;
+}
+
+async function throwProbeFailureAfterTermination(
+  child: SpawnedPostgrestIdentityProbe,
+  identity: PostgrestRuntimeIdentity,
+  executable: string,
+  probeError: unknown,
+): Promise<never> {
+  try {
+    await terminatePostgrestIdentityProbe(child, identity, executable);
+  } catch (terminationError) {
+    throw new AggregateError(
+      [probeError, terminationError],
+      "PostgREST process identity probe failed and could not be terminated",
+    );
+  }
+  throw probeError;
+}
+
+async function boundedProbeStdout(
+  child: SpawnedPostgrestIdentityProbe,
+  identity: PostgrestRuntimeIdentity,
+  executable: string,
+  timeoutMs: number,
+): Promise<Uint8Array> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutFailure = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error("PostgREST process identity probe timed out"));
+    }, timeoutMs);
+  });
+  let completed: CompletedProbeOutput;
+  try {
+    completed = await Promise.race([
+      completedProbeOutput(child),
+      timeoutFailure,
+    ]);
+  } catch (error) {
+    return throwProbeFailureAfterTermination(child, identity, executable, error);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+  return successfulProbeStdout(completed);
+}
+
+export async function probePostgrestProcessIdentity(
+  pid: number,
+  identity: PostgrestRuntimeIdentity,
+  operations: PostgrestProcessIdentityParentOperations = defaultParentOperations,
+  options: ProbeExecutionOptions = {},
+): Promise<PostgrestProcessIdentity> {
+  parseProbeArguments([String(pid), String(identity.uid), String(identity.gid)]);
+  const timeoutMs = options.timeoutMs ?? POSTGREST_PROCESS_IDENTITY_TIMEOUT_MS;
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > POSTGREST_PROCESS_IDENTITY_TIMEOUT_MS) {
+    throw new Error("Invalid PostgREST process identity probe timeout");
+  }
+  const before = await operations.processMetadata(pid);
+  assertProcessOwner(before, identity);
+  const executable = await operations.executablePath();
+  const child = await operations.spawn(
+    buildPostgrestProcessIdentityProbeCommand(executable, pid, identity),
+    {
+      cwd: "/",
+      environment: { LANG: "C", LC_ALL: "C" },
+      stdin: "ignore",
+    },
+  );
+  const stdout = await boundedProbeStdout(child, identity, executable, timeoutMs);
+  const probeIdentity = parsePostgrestProcessIdentityProbeOutput(stdout);
+  const after = await operations.processMetadata(pid);
+  assertProcessOwner(after, identity);
+  if (!sameProcessMetadata(before, after)) {
+    throw new Error("PostgREST process changed during identity probe");
+  }
+  return probeIdentity;
+}
+
+export async function runPostgrestProcessIdentityProbe(args: string[]): Promise<number> {
+  try {
+    const probeIdentity = await collectPostgrestProcessIdentity(args);
+    const output = `${JSON.stringify(probeIdentity)}\n`;
+    if (Buffer.byteLength(output, "utf8") > POSTGREST_PROCESS_IDENTITY_STDOUT_LIMIT) {
+      throw new Error("PostgREST process identity probe output exceeded limit");
+    }
+    process.stdout.write(output);
+    return 0;
+  } catch {
+    process.stderr.write("PostgREST process identity probe failed\n");
+    return 1;
+  }
+}
+
+export async function runPostgrestProcessIdentityTermination(args: string[]): Promise<number> {
+  try {
+    await terminatePostgrestIdentityProbeByPidfd(args);
+    return 0;
+  } catch {
+    process.stderr.write("PostgREST process identity termination failed\n");
+    return 1;
+  }
+}

--- a/packages/management-api/src/services/postgrest-runtime-attestation.ts
+++ b/packages/management-api/src/services/postgrest-runtime-attestation.ts
@@ -1,10 +1,19 @@
-import { readFile, readlink, realpath } from "node:fs/promises";
+import { realpath } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import {
   readPostgrestPointerTarget,
   validatePostgrestGenerationTarget,
   type PostgrestControlOwnership,
 } from "./postgrest-generation";
+import {
+  parseLinuxRuntimeId,
+  parseSystemdMainPid,
+  probePostgrestProcessIdentity,
+  type PostgrestProcessIdentity,
+  type PostgrestRuntimeIdentity,
+} from "./postgrest-process-identity";
+
+export type { PostgrestProcessIdentity } from "./postgrest-process-identity";
 
 export type PostgrestAttestationState =
   | "loaded"
@@ -40,17 +49,10 @@ export interface SystemdProcessIdentity {
   loadedAt: string | null;
 }
 
-export interface PostgrestProcessIdentity {
-  startId: string;
-  executable: string;
-  commandLine: string[];
-  environmentNames: string[];
-}
-
 export interface PostgrestAttestationOperations {
   systemdMainProcess(unit: string): Promise<SystemdProcessIdentity>;
-  runtimeGroupGid(projectRef: string): Promise<number>;
-  processIdentity(pid: number): Promise<PostgrestProcessIdentity>;
+  runtimeIdentity(projectRef: string): Promise<PostgrestRuntimeIdentity>;
+  processIdentity(pid: number, identity: PostgrestRuntimeIdentity): Promise<PostgrestProcessIdentity>;
   health(port: number): Promise<"healthy" | "unhealthy">;
 }
 
@@ -69,6 +71,8 @@ type ControlPointerObservation =
   | { kind: "valid"; target: string; generation: ValidatedGeneration }
   | { kind: "absent" | "invalid" };
 
+const ID_PATH = "/usr/bin/id";
+
 function systemdTimestamp(rawTimestamp: string): string | null {
   if (!rawTimestamp || rawTimestamp === "n/a") return null;
   const timestamp = Date.parse(rawTimestamp);
@@ -81,7 +85,12 @@ export function parsePostgrestSystemdShow(output: string): SystemdProcessIdentit
     return separator === -1 ? [line, ""] : [line.slice(0, separator), line.slice(separator + 1)];
   }));
   const rawPid = properties.get("MainPID") || "";
-  if (!/^\d+$/.test(rawPid)) throw new Error("Invalid systemd MainPID");
+  let mainPid: number;
+  try {
+    mainPid = parseSystemdMainPid(rawPid);
+  } catch {
+    throw new Error("Invalid systemd MainPID");
+  }
   const activity = properties.get("ActiveState") || "";
   if (!["active", "activating", "reloading", "deactivating", "inactive", "failed"].includes(activity)) {
     throw new Error("Invalid systemd ActiveState");
@@ -89,18 +98,18 @@ export function parsePostgrestSystemdShow(output: string): SystemdProcessIdentit
   const invocationId = properties.get("InvocationID") || "";
   const startMonotonic = properties.get("ExecMainStartTimestampMonotonic") || "";
   if (activity === "active" && (
-    Number(rawPid) <= 0
+    mainPid <= 0
     || !/^[a-f0-9]{32}$/.test(invocationId)
     || !/^\d+$/.test(startMonotonic)
   )) {
     throw new Error("Invalid active systemd process identity");
   }
-  if (activity === "inactive" && Number(rawPid) !== 0) {
+  if (activity === "inactive" && mainPid !== 0) {
     throw new Error("Inactive systemd unit reported a main process");
   }
   return {
     activity: activity as PostgrestSystemdActivity,
-    mainPid: Number(rawPid),
+    mainPid,
     invocationId,
     startMonotonic,
     loadedAt: systemdTimestamp(properties.get("ExecMainStartTimestamp") || ""),
@@ -120,23 +129,6 @@ async function runCommand(command: string[]): Promise<string> {
   return stdout;
 }
 
-function procStartId(statContent: string): string {
-  const commandEnd = statContent.lastIndexOf(")");
-  const fieldsAfterCommand = statContent.slice(commandEnd + 2).trim().split(/\s+/);
-  const startId = fieldsAfterCommand[19];
-  if (!startId || !/^\d+$/.test(startId)) throw new Error("Invalid process start identity");
-  return startId;
-}
-
-function environmentNames(environmentBytes: Buffer): string[] {
-  return environmentBytes.toString("utf8")
-    .split("\0")
-    .filter(Boolean)
-    .map((entry) => entry.slice(0, entry.indexOf("=")))
-    .filter(Boolean)
-    .sort();
-}
-
 const defaultOperations: PostgrestAttestationOperations = {
   async systemdMainProcess(unit) {
     return parsePostgrestSystemdShow(await runCommand([
@@ -150,24 +142,22 @@ const defaultOperations: PostgrestAttestationOperations = {
       "--property=ExecMainStartTimestamp",
     ]));
   },
-  async runtimeGroupGid(projectRef) {
-    const groupId = (await runCommand(["id", "-g", `supacloud-${projectRef}`])).trim();
-    if (!/^\d+$/.test(groupId)) throw new Error("Invalid tenant runtime group");
-    return Number(groupId);
-  },
-  async processIdentity(pid) {
-    const [executable, commandLineBytes, statContent, environmentBytes] = await Promise.all([
-      readlink(`/proc/${pid}/exe`),
-      readFile(`/proc/${pid}/cmdline`),
-      readFile(`/proc/${pid}/stat`, "utf8"),
-      readFile(`/proc/${pid}/environ`),
+  async runtimeIdentity(projectRef) {
+    const runtimeUser = `supacloud-${projectRef}`;
+    const [userId, groupId] = await Promise.all([
+      runCommand([ID_PATH, "-u", runtimeUser]),
+      runCommand([ID_PATH, "-g", runtimeUser]),
     ]);
-    return {
-      startId: procStartId(statContent),
-      executable,
-      commandLine: commandLineBytes.toString("utf8").split("\0").filter(Boolean),
-      environmentNames: environmentNames(environmentBytes),
-    };
+    const uid = userId.trim();
+    const gid = groupId.trim();
+    try {
+      return { uid: parseLinuxRuntimeId(uid), gid: parseLinuxRuntimeId(gid) };
+    } catch {
+      throw new Error("Invalid tenant runtime identity");
+    }
+  },
+  processIdentity(pid, identity) {
+    return probePostgrestProcessIdentity(pid, identity);
   },
   async health(port) {
     try {
@@ -431,11 +421,12 @@ async function attestActivePostgrestRuntime(
   request: PostgrestAttestationRequest,
   operations: PostgrestAttestationOperations,
   ownership: PostgrestControlOwnership,
+  runtimeIdentity: PostgrestRuntimeIdentity,
   pointerBefore: ControlPointerObservation,
   systemdBefore: SystemdProcessIdentity,
 ): Promise<PostgrestAttestation> {
   try {
-    const beforeProcess = await operations.processIdentity(systemdBefore.mainPid);
+    const beforeProcess = await operations.processIdentity(systemdBefore.mainPid, runtimeIdentity);
     const expectedExecutable = await realpath(request.postgrestBinary);
     const health = await operations.health(request.port);
     const configArgument = managedConfigArgument(beforeProcess.commandLine);
@@ -444,7 +435,7 @@ async function attestActivePostgrestRuntime(
     const systemdAfter = await operations.systemdMainProcess(request.unit);
     const changedUnit = changedUnitAttestation(request, systemdAfter, health);
     if (changedUnit) return changedUnit;
-    const afterProcess = await operations.processIdentity(systemdAfter.mainPid);
+    const afterProcess = await operations.processIdentity(systemdAfter.mainPid, runtimeIdentity);
     if (!sameProcess(systemdBefore, systemdAfter, beforeProcess, afterProcess)) {
       return failureAttestation(request.desiredRevision, "unreachable", health);
     }
@@ -470,10 +461,12 @@ export async function attestPostgrestRuntime(
   operations: PostgrestAttestationOperations = defaultOperations,
 ): Promise<PostgrestAttestation> {
   let ownership: PostgrestControlOwnership;
+  let runtimeIdentity: PostgrestRuntimeIdentity;
   try {
+    runtimeIdentity = await operations.runtimeIdentity(request.projectRef);
     ownership = {
       controlOwnerUid: request.controlOwnerUid ?? 0,
-      runtimeGroupGid: await operations.runtimeGroupGid(request.projectRef),
+      runtimeGroupGid: runtimeIdentity.gid,
     };
   } catch {
     return failureAttestation(request.desiredRevision, "unreachable", "unknown");
@@ -491,6 +484,7 @@ export async function attestPostgrestRuntime(
     request,
     operations,
     ownership,
+    runtimeIdentity,
     pointerBefore,
     systemdBefore,
   );

--- a/packages/management-api/src/standalone.ts
+++ b/packages/management-api/src/standalone.ts
@@ -16,6 +16,14 @@ export function isPostgrestLauncherDigestCommand(args: string[]): boolean {
   return args.length === 1 && args[0] === "--postgrest-launcher-sha256";
 }
 
+export function isPostgrestProcessIdentityProbeCommand(args: string[]): boolean {
+  return args.length === 4 && args[0] === "--postgrest-process-identity-probe-v1";
+}
+
+export function isPostgrestProcessIdentityTerminationCommand(args: string[]): boolean {
+  return args.length === 5 && args[0] === "--postgrest-process-identity-terminate-v1";
+}
+
 if (import.meta.main) {
   const args = process.argv.slice(2);
   if (isStandaloneVersionCommand(args)) {
@@ -26,6 +34,12 @@ if (import.meta.main) {
   } else if (isPostgrestLauncherDigestCommand(args)) {
     const { EMBEDDED_POSTGREST_LAUNCHER_SHA256 } = await import("./embedded-postgrest-launcher");
     writeStandaloneIdentity(`SupaCloud PostgREST launcher SHA-256: ${EMBEDDED_POSTGREST_LAUNCHER_SHA256}`);
+  } else if (isPostgrestProcessIdentityProbeCommand(args)) {
+    const { runPostgrestProcessIdentityProbe } = await import("./services/postgrest-process-identity");
+    process.exitCode = await runPostgrestProcessIdentityProbe(args.slice(1));
+  } else if (isPostgrestProcessIdentityTerminationCommand(args)) {
+    const { runPostgrestProcessIdentityTermination } = await import("./services/postgrest-process-identity");
+    process.exitCode = await runPostgrestProcessIdentityTermination(args.slice(1));
   } else {
     const { startManagementApi } = await import("./index");
     startManagementApi();

--- a/packages/management-api/tests/unit/postgrest-process-identity.linux.test.ts
+++ b/packages/management-api/tests/unit/postgrest-process-identity.linux.test.ts
@@ -1,0 +1,178 @@
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { chmod, lstat, mkdtemp, readFile, readlink, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  probePostgrestProcessIdentity,
+  terminatePostgrestIdentityProbe,
+  type PostgrestProcessIdentityParentOperations,
+} from "../../src/services/postgrest-process-identity";
+
+const SETPRIV_PATH = "/usr/bin/setpriv";
+const TENANT_UID = 981;
+const TENANT_GID = 981;
+const SECRET_VALUE = "same-uid-smoke-secret-value";
+
+function capabilityMask(label: "CapEff" | "CapPrm" | "CapBnd"): bigint | null {
+  if (process.platform !== "linux") return null;
+  const status = readFileSync("/proc/self/status", "utf8");
+  const match = status.match(new RegExp(`^${label}:\\s*([a-fA-F0-9]+)$`, "m"));
+  return match ? BigInt(`0x${match[1]}`) : null;
+}
+
+async function processStartId(pid: number): Promise<string> {
+  const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+  const commandEnd = stat.lastIndexOf(")");
+  if (commandEnd < 0) throw new Error("Invalid Linux process stat");
+  const startId = stat.slice(commandEnd + 1).trim().split(/\s+/)[19];
+  if (!startId || !/^\d+$/.test(startId)) throw new Error("Invalid Linux process start identity");
+  return startId;
+}
+
+const managementCapabilityMask = 0xcbn;
+const canRunLinuxPrivilegeSmoke = process.platform === "linux"
+  && process.getuid?.() === 0
+  && existsSync(SETPRIV_PATH)
+  && capabilityMask("CapEff") === managementCapabilityMask
+  && capabilityMask("CapPrm") === managementCapabilityMask
+  && capabilityMask("CapBnd") === managementCapabilityMask;
+const linuxPrivilegeTest = canRunLinuxPrivilegeSmoke ? test : test.skip;
+
+linuxPrivilegeTest("compiled probe reads a same-UID process without CAP_SYS_PTRACE", async () => {
+  const packageRoot = join(import.meta.dir, "../..");
+  const buildDirectory = await mkdtemp(join(tmpdir(), "supacloud-postgrest-identity-linux-"));
+  const binaryPath = join(buildDirectory, "supacloud");
+  await chmod(buildDirectory, 0o755);
+  let target: ReturnType<typeof Bun.spawn> | undefined;
+  let targetStartId: string | undefined;
+  try {
+    const build = Bun.spawn({
+      cmd: ["bun", "build", "src/standalone.ts", "--compile", `--outfile=${binaryPath}`],
+      cwd: packageRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildExit, buildStderr] = await Promise.all([
+      build.exited,
+      new Response(build.stderr).text(),
+      new Response(build.stdout).text(),
+    ]);
+    expect(buildExit, buildStderr).toBe(0);
+    await chmod(binaryPath, 0o755);
+
+    target = Bun.spawn({
+      cmd: [
+        SETPRIV_PATH,
+        "--reuid",
+        String(TENANT_UID),
+        "--regid",
+        String(TENANT_GID),
+        "--clear-groups",
+        "--",
+        "/usr/bin/env",
+        "-i",
+        `POSTGREST_SMOKE_SECRET=${SECRET_VALUE}`,
+        "/bin/sleep",
+        "30",
+      ],
+      cwd: "/",
+      env: { LANG: "C", LC_ALL: "C" },
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const tenantProcess = target;
+    const targetPid = tenantProcess.pid;
+    targetStartId = await processStartId(targetPid);
+    let ready = false;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      try {
+        const metadata = await lstat(`/proc/${targetPid}`);
+        const commandLine = await readFile(`/proc/${targetPid}/cmdline`, "utf8");
+        if (metadata.uid === TENANT_UID
+          && metadata.gid === TENANT_GID
+          && commandLine.startsWith("/bin/sleep\0")) {
+          ready = true;
+          break;
+        }
+      } catch {
+        // The bounded poll below handles the short setpriv -> sleep exec transition.
+      }
+      await Bun.sleep(10);
+    }
+    expect(ready).toBe(true);
+    expect(capabilityMask("CapEff")).toBe(managementCapabilityMask);
+    expect(capabilityMask("CapPrm")).toBe(managementCapabilityMask);
+    expect(capabilityMask("CapBnd")).toBe(managementCapabilityMask);
+    expect((managementCapabilityMask & (1n << 19n))).toBe(0n);
+    expect((await readFile(`/proc/${targetPid}/cmdline`)).byteLength).toBeGreaterThan(0);
+    await expect(readlink(`/proc/${targetPid}/exe`)).rejects.toBeDefined();
+    await expect(readFile(`/proc/${targetPid}/environ`)).rejects.toBeDefined();
+
+    let capturedStdout: Promise<string> | undefined;
+    let capturedStderr: Promise<string> | undefined;
+    const operations: PostgrestProcessIdentityParentOperations = {
+      async processMetadata(pid) {
+        const metadata = await lstat(`/proc/${pid}`);
+        return {
+          uid: metadata.uid,
+          gid: metadata.gid,
+          dev: metadata.dev,
+          ino: metadata.ino,
+          isDirectory: metadata.isDirectory(),
+        };
+      },
+      async executablePath() {
+        return binaryPath;
+      },
+      async spawn(command, options) {
+        const child = Bun.spawn({
+          cmd: command,
+          cwd: options.cwd,
+          env: options.environment,
+          stdin: options.stdin,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [probeStdout, reviewStdout] = child.stdout.tee();
+        const [probeStderr, reviewStderr] = child.stderr.tee();
+        capturedStdout = new Response(reviewStdout).text();
+        capturedStderr = new Response(reviewStderr).text();
+        return {
+          pid: child.pid,
+          startId: await processStartId(child.pid),
+          stdout: probeStdout,
+          stderr: probeStderr,
+          exited: child.exited,
+          kill: (signal) => { child.kill(signal); },
+        };
+      },
+    };
+    const identity = await probePostgrestProcessIdentity(
+      targetPid,
+      { uid: TENANT_UID, gid: TENANT_GID },
+      operations,
+    );
+    expect(identity.executable.endsWith("/sleep")).toBe(true);
+    expect(identity.environmentNames).toEqual(["POSTGREST_SMOKE_SECRET"]);
+    expect(JSON.stringify(identity)).not.toContain(SECRET_VALUE);
+    expect(await capturedStdout).not.toContain(SECRET_VALUE);
+    expect(await capturedStderr).not.toContain(SECRET_VALUE);
+    expect(() => tenantProcess.kill("SIGKILL")).toThrow();
+  } finally {
+    try {
+      if (target && targetStartId) {
+        const tenantTarget = target;
+        await terminatePostgrestIdentityProbe({
+          pid: tenantTarget.pid,
+          startId: targetStartId,
+          exited: tenantTarget.exited,
+          kill: (signal) => { tenantTarget.kill(signal); },
+        }, { uid: TENANT_UID, gid: TENANT_GID }, binaryPath);
+      }
+    } finally {
+      await rm(buildDirectory, { recursive: true, force: true });
+    }
+  }
+}, 40_000);

--- a/packages/management-api/tests/unit/postgrest-process-identity.test.ts
+++ b/packages/management-api/tests/unit/postgrest-process-identity.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from "bun:test";
+import {
+  POSTGREST_PROCESS_IDENTITY_PROBE_FLAG,
+  POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG,
+  POSTGREST_PROCESS_IDENTITY_STDOUT_LIMIT,
+  buildPostgrestProcessIdentityProbeCommand,
+  buildPostgrestProcessIdentityTerminationCommand,
+  collectPostgrestProcessIdentity,
+  parsePostgrestProcessIdentityProbeOutput,
+  probePostgrestProcessIdentity,
+  terminatePostgrestIdentityProbe,
+  terminatePostgrestIdentityProbeByPidfd,
+  type PostgrestProcessIdentityCollectorOperations,
+  type PostgrestProcessIdentityParentOperations,
+  type PostgrestProcessIdentityTerminationOperations,
+  type SpawnedPostgrestIdentityProbe,
+} from "../../src/services/postgrest-process-identity";
+import type { LinuxPidfdOperations } from "../../src/services/linux-pidfd";
+
+const PID = 4172;
+const UID = 981;
+const GID = 981;
+const SECRET_VALUE = "must-never-leave-the-probe";
+
+function bytes(value: string): Buffer {
+  return Buffer.from(value, "utf8");
+}
+
+function probeStatus(groups = "", effectiveCapabilities = "0000000000000000"): Buffer {
+  return bytes([
+    "Name:\tprobe",
+    `Uid:\t${UID}\t${UID}\t${UID}\t${UID}`,
+    `Gid:\t${GID}\t${GID}\t${GID}\t${GID}`,
+    `Groups:\t${groups}`,
+    "CapInh:\t0000000000000000",
+    "CapPrm:\t0000000000000000",
+    `CapEff:\t${effectiveCapabilities}`,
+    "CapBnd:\t00000000000000cb",
+    "CapAmb:\t0000000000000000",
+    "",
+  ].join("\n"));
+}
+
+function collectorOperations(overrides: Partial<PostgrestProcessIdentityCollectorOperations> = {}) {
+  let statReads = 0;
+  const operations: PostgrestProcessIdentityCollectorOperations = {
+    currentUid: () => UID,
+    currentGid: () => GID,
+    async readLink(path) {
+      expect(path).toBe(`/proc/${PID}/exe`);
+      return "/usr/bin/postgrest";
+    },
+    async readFile(path) {
+      if (path === "/proc/self/status") {
+        return probeStatus();
+      }
+      if (path === `/proc/${PID}/status`) {
+        return bytes(`Name:\tpostgrest\nUid:\t${UID}\t${UID}\t${UID}\t${UID}\nGid:\t${GID}\t${GID}\t${GID}\t${GID}\nGroups:\t${GID}\n`);
+      }
+      if (path === `/proc/${PID}/stat`) {
+        statReads += 1;
+        const startId = statReads === 1 ? "987654321" : "987654321";
+        return bytes(`${PID} (postgrest worker) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 ${startId} 20 21\n`);
+      }
+      if (path === `/proc/${PID}/cmdline`) {
+        return bytes(`/usr/bin/postgrest\0/var/lib/supacloud/tenants/example.conf\0`);
+      }
+      if (path === `/proc/${PID}/environ`) {
+        return bytes(`PGRST_DB_URI=${SECRET_VALUE}\0SAFE_NAME=value\0`);
+      }
+      throw new Error(`Unexpected path: ${path}`);
+    },
+    ...overrides,
+  };
+  return operations;
+}
+
+function stream(value: string): ReadableStream<Uint8Array> {
+  return new Blob([value]).stream();
+}
+
+function completedChild(
+  stdout: string,
+  stderr = "",
+  exitCode = 0,
+): SpawnedPostgrestIdentityProbe {
+  return {
+    pid: PID + 1,
+    startId: "123456789",
+    stdout: stream(stdout),
+    stderr: stream(stderr),
+    exited: Promise.resolve(exitCode),
+    kill: () => {},
+  };
+}
+
+function parentOperations(
+  child: SpawnedPostgrestIdentityProbe,
+  metadata = { uid: UID, gid: GID, dev: 1, ino: 99, isDirectory: true },
+): PostgrestProcessIdentityParentOperations {
+  return {
+    async processMetadata(pid) {
+      expect(pid).toBe(PID);
+      return metadata;
+    },
+    async executablePath() {
+      return "/usr/local/bin/supacloud";
+    },
+    async spawn(command, options) {
+      expect(options).toEqual({
+        cwd: "/",
+        environment: { LANG: "C", LC_ALL: "C" },
+        stdin: "ignore",
+      });
+      expect(command).toEqual(buildPostgrestProcessIdentityProbeCommand(
+        "/usr/local/bin/supacloud",
+        PID,
+        { uid: UID, gid: GID },
+      ));
+      return child;
+    },
+  };
+}
+
+const validProbeOutput = `${JSON.stringify({
+  version: 1,
+  startId: "987654321",
+  executable: "/usr/bin/postgrest",
+  commandLine: ["/usr/bin/postgrest", "/var/lib/supacloud/tenants/example.conf"],
+  environmentNames: ["PGRST_DB_URI", "SAFE_NAME"],
+})}\n`;
+
+describe("PostgREST same-UID process identity probe", () => {
+  test("builds a fixed setpriv command with exact uid/gid and cleared groups", () => {
+    expect(buildPostgrestProcessIdentityProbeCommand(
+      "/usr/local/bin/supacloud",
+      PID,
+      { uid: UID, gid: GID },
+    )).toEqual([
+      "/usr/bin/setpriv",
+      "--reuid",
+      String(UID),
+      "--regid",
+      String(GID),
+      "--clear-groups",
+      "--",
+      "/usr/local/bin/supacloud",
+      POSTGREST_PROCESS_IDENTITY_PROBE_FLAG,
+      String(PID),
+      String(UID),
+      String(GID),
+    ]);
+
+    expect(buildPostgrestProcessIdentityTerminationCommand(
+      "/usr/local/bin/supacloud",
+      completedChild(validProbeOutput),
+      { uid: UID, gid: GID },
+    )).toEqual([
+      "/usr/bin/setpriv",
+      "--reuid",
+      String(UID),
+      "--regid",
+      String(GID),
+      "--clear-groups",
+      "--",
+      "/usr/local/bin/supacloud",
+      POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG,
+      String(PID + 1),
+      String(UID),
+      String(GID),
+      "123456789",
+    ]);
+  });
+
+  test("binds termination to a pidfd and revalidates start identity before signaling", async () => {
+    const calls: string[] = [];
+    const pidfdOperations: LinuxPidfdOperations = {
+      open(pid) {
+        calls.push(`open:${pid}`);
+        return 73;
+      },
+      sendSignal(pidfd, signal) {
+        calls.push(`signal:${pidfd}:${signal}`);
+        return 0;
+      },
+      close(pidfd) {
+        calls.push(`close:${pidfd}`);
+      },
+    };
+    const baseCollector = collectorOperations();
+    const recordingCollector = collectorOperations({
+      async readFile(path, limit) {
+        if (path === `/proc/${PID}/stat`) calls.push("read:stat");
+        return baseCollector.readFile(path, limit);
+      },
+    });
+    await terminatePostgrestIdentityProbeByPidfd(
+      [String(PID), String(UID), String(GID), "987654321"],
+      recordingCollector,
+      pidfdOperations,
+    );
+    expect(calls).toEqual([`open:${PID}`, "read:stat", "read:stat", "signal:73:9", "close:73"]);
+
+    calls.length = 0;
+    await expect(terminatePostgrestIdentityProbeByPidfd(
+      [String(PID), String(UID), String(GID), "987654320"],
+      collectorOperations(),
+      pidfdOperations,
+    )).rejects.toThrow("changed before termination");
+    expect(calls).toEqual([`open:${PID}`, "close:73"]);
+  });
+
+  test("collects only executable, argv, start identity, and environment names", async () => {
+    const identity = await collectPostgrestProcessIdentity(
+      [String(PID), String(UID), String(GID)],
+      collectorOperations(),
+    );
+    expect(identity).toEqual({
+      version: 1,
+      startId: "987654321",
+      executable: "/usr/bin/postgrest",
+      commandLine: ["/usr/bin/postgrest", "/var/lib/supacloud/tenants/example.conf"],
+      environmentNames: ["PGRST_DB_URI", "SAFE_NAME"],
+    });
+    expect(JSON.stringify(identity)).not.toContain(SECRET_VALUE);
+  });
+
+  test("rejects malformed ids, retained supplementary groups, and target identity drift", async () => {
+    await expect(collectPostgrestProcessIdentity(
+      ["0", String(UID), String(GID)],
+      collectorOperations(),
+    )).rejects.toThrow("Invalid PostgREST process identity probe arguments");
+    await expect(collectPostgrestProcessIdentity(
+      [String(PID), "0", String(GID)],
+      collectorOperations(),
+    )).rejects.toThrow("Invalid PostgREST process identity probe arguments");
+
+    await expect(collectPostgrestProcessIdentity(
+      [String(PID), String(UID), String(GID)],
+      collectorOperations({
+        async readFile(path, limit) {
+          if (path === `/proc/${PID}/stat`) {
+            return bytes(`${PID + 1} (postgrest) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 987654321 20\n`);
+          }
+          return collectorOperations().readFile(path, limit);
+        },
+      }),
+    )).rejects.toThrow("unexpected process id");
+
+    await expect(collectPostgrestProcessIdentity(
+      [String(PID), String(UID), String(GID)],
+      collectorOperations({
+        async readFile(path, limit) {
+          if (path === "/proc/self/status") {
+            return probeStatus("27");
+          }
+          return collectorOperations().readFile(path, limit);
+        },
+      }),
+    )).rejects.toThrow("supplementary groups");
+
+    await expect(collectPostgrestProcessIdentity(
+      [String(PID), String(UID), String(GID)],
+      collectorOperations({
+        async readFile(path, limit) {
+          if (path === "/proc/self/status") return probeStatus("", "0000000000000080");
+          return collectorOperations().readFile(path, limit);
+        },
+      }),
+    )).rejects.toThrow("retained process capabilities");
+
+    let statReads = 0;
+    await expect(collectPostgrestProcessIdentity(
+      [String(PID), String(UID), String(GID)],
+      collectorOperations({
+        async readFile(path, limit) {
+          if (path === `/proc/${PID}/stat`) {
+            statReads += 1;
+            const startId = statReads === 1 ? "987654321" : "987654322";
+            return bytes(`${PID} (postgrest) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 ${startId} 20\n`);
+          }
+          return collectorOperations().readFile(path, limit);
+        },
+      }),
+    )).rejects.toThrow("changed during identity probe");
+  });
+
+  test("strictly parses the versioned bounded output schema", () => {
+    expect(parsePostgrestProcessIdentityProbeOutput(bytes(validProbeOutput))).toEqual({
+      startId: "987654321",
+      executable: "/usr/bin/postgrest",
+      commandLine: ["/usr/bin/postgrest", "/var/lib/supacloud/tenants/example.conf"],
+      environmentNames: ["PGRST_DB_URI", "SAFE_NAME"],
+    });
+    expect(() => parsePostgrestProcessIdentityProbeOutput(bytes(
+      `${JSON.stringify({ ...JSON.parse(validProbeOutput), unexpected: true })}\n`,
+    ))).toThrow("Invalid PostgREST process identity probe output");
+    expect(() => parsePostgrestProcessIdentityProbeOutput(bytes(
+      `${JSON.stringify({ ...JSON.parse(validProbeOutput), startId: "01" })}\n`,
+    ))).toThrow("Invalid PostgREST process identity probe output");
+    expect(() => parsePostgrestProcessIdentityProbeOutput(bytes("{}"))).toThrow(
+      "Invalid PostgREST process identity probe output",
+    );
+  });
+
+  test("validates process ownership before and after a successful bounded probe", async () => {
+    expect(await probePostgrestProcessIdentity(
+      PID,
+      { uid: UID, gid: GID },
+      parentOperations(completedChild(validProbeOutput)),
+    )).toEqual({
+      startId: "987654321",
+      executable: "/usr/bin/postgrest",
+      commandLine: ["/usr/bin/postgrest", "/var/lib/supacloud/tenants/example.conf"],
+      environmentNames: ["PGRST_DB_URI", "SAFE_NAME"],
+    });
+
+    await expect(probePostgrestProcessIdentity(
+      PID,
+      { uid: UID, gid: GID },
+      parentOperations(completedChild(validProbeOutput), {
+        uid: 999,
+        gid: GID,
+        dev: 1,
+        ino: 99,
+        isDirectory: true,
+      }),
+    )).rejects.toThrow("unexpected owner");
+  });
+
+  test("kills and rejects timed-out or oversized probe output without echoing stderr", async () => {
+    let killed = false;
+    let finish!: (code: number) => void;
+    let closeStdout!: () => void;
+    let closeStderr!: () => void;
+    const hangingChild: SpawnedPostgrestIdentityProbe = {
+      pid: PID + 1,
+      startId: "123456789",
+      stdout: new ReadableStream({ start(controller) { closeStdout = () => controller.close(); } }),
+      stderr: new ReadableStream({ start(controller) { closeStderr = () => controller.close(); } }),
+      exited: new Promise((resolve) => { finish = resolve; }),
+      kill() {
+        killed = true;
+        closeStdout();
+        closeStderr();
+        finish(137);
+      },
+    };
+    await expect(probePostgrestProcessIdentity(
+      PID,
+      { uid: UID, gid: GID },
+      parentOperations(hangingChild),
+      { timeoutMs: 5 },
+    )).rejects.toThrow("timed out");
+    expect(killed).toBe(true);
+
+    const oversized = completedChild("x".repeat(POSTGREST_PROCESS_IDENTITY_STDOUT_LIMIT + 1));
+    await expect(probePostgrestProcessIdentity(
+      PID,
+      { uid: UID, gid: GID },
+      parentOperations(oversized),
+    )).rejects.toThrow("output exceeded limit");
+
+    await expect(probePostgrestProcessIdentity(
+      PID,
+      { uid: UID, gid: GID },
+      parentOperations(completedChild("", SECRET_VALUE, 1)),
+    )).rejects.not.toThrow(SECRET_VALUE);
+  });
+
+  test("bounds termination helper and child reap waits", async () => {
+    const permissionDenied = new Error("operation not permitted") as NodeJS.ErrnoException;
+    permissionDenied.code = "EPERM";
+    const helperNeverExits: PostgrestProcessIdentityTerminationOperations = {
+      spawn: () => ({ exited: new Promise<number>(() => {}) }),
+    };
+    await expect(terminatePostgrestIdentityProbe({
+      pid: PID + 1,
+      startId: "123456789",
+      exited: Promise.resolve(137),
+      kill: () => { throw permissionDenied; },
+    }, { uid: UID, gid: GID }, "/usr/local/bin/supacloud", helperNeverExits)).rejects.toThrow(
+      "termination helper timed out",
+    );
+
+    const childNeverExits: SpawnedPostgrestIdentityProbe = {
+      pid: PID + 1,
+      startId: "123456789",
+      stdout: stream(""),
+      stderr: stream(""),
+      exited: new Promise<number>(() => {}),
+      kill: () => {},
+    };
+    await expect(terminatePostgrestIdentityProbe(
+      childNeverExits,
+      { uid: UID, gid: GID },
+      "/usr/local/bin/supacloud",
+    )).rejects.toThrow("did not exit after termination");
+  }, 5_000);
+});

--- a/packages/management-api/tests/unit/postgrest-runtime-attestation.test.ts
+++ b/packages/management-api/tests/unit/postgrest-runtime-attestation.test.ts
@@ -71,7 +71,7 @@ function stoppedOperations(
   mainPid = 0,
 ): PostgrestAttestationOperations {
   return {
-    runtimeGroupGid: async () => currentGid(),
+    runtimeIdentity: async () => ({ uid: currentUid(), gid: currentGid() }),
     systemdMainProcess: async () => ({
       ...ACTIVE_IDENTITY,
       activity,
@@ -106,7 +106,7 @@ async function activeFixture(content = "db-pool = 10\n") {
     environmentNames: [],
   });
   const operations: PostgrestAttestationOperations = {
-    runtimeGroupGid: async () => currentGid(),
+    runtimeIdentity: async () => ({ uid: currentUid(), gid: currentGid() }),
     systemdMainProcess: async () => ACTIVE_IDENTITY,
     processIdentity: async () => processIdentity(),
     health: async () => "healthy",

--- a/packages/management-api/tests/unit/standalone-version.test.ts
+++ b/packages/management-api/tests/unit/standalone-version.test.ts
@@ -5,9 +5,15 @@ import { join } from "node:path";
 import pkg from "../../package.json";
 import {
   isPostgrestLauncherDigestCommand,
+  isPostgrestProcessIdentityProbeCommand,
+  isPostgrestProcessIdentityTerminationCommand,
   isStandaloneVersionCommand,
   isSystemdUnitBrokerDigestCommand,
 } from "../../src/standalone";
+import {
+  POSTGREST_PROCESS_IDENTITY_PROBE_FLAG,
+  POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG,
+} from "../../src/services/postgrest-process-identity";
 import { EMBEDDED_POSTGREST_LAUNCHER_SHA256 } from "../../src/embedded-postgrest-launcher";
 import { EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256 } from "../../src/embedded-systemd-unit-broker";
 
@@ -48,6 +54,25 @@ describe("standalone version command", () => {
     expect(isSystemdUnitBrokerDigestCommand(["upgrade", "--systemd-unit-helper-sha256"])).toBe(false);
     expect(isPostgrestLauncherDigestCommand(["--postgrest-launcher-sha256"])).toBe(true);
     expect(isPostgrestLauncherDigestCommand(["upgrade", "--postgrest-launcher-sha256"])).toBe(false);
+    expect(isPostgrestProcessIdentityProbeCommand([
+      POSTGREST_PROCESS_IDENTITY_PROBE_FLAG,
+      "4172",
+      "981",
+      "981",
+    ])).toBe(true);
+    expect(isPostgrestProcessIdentityProbeCommand([POSTGREST_PROCESS_IDENTITY_PROBE_FLAG])).toBe(false);
+    expect(isPostgrestProcessIdentityProbeCommand(["upgrade", POSTGREST_PROCESS_IDENTITY_PROBE_FLAG])).toBe(false);
+    expect(isPostgrestProcessIdentityTerminationCommand([
+      POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG,
+      "4172",
+      "981",
+      "981",
+      "987654321",
+    ])).toBe(true);
+    expect(isPostgrestProcessIdentityTerminationCommand([
+      POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG,
+      "4172",
+    ])).toBe(false);
   });
 
   test("compiled binary prints its version without loading runtime configuration", async () => {
@@ -82,5 +107,30 @@ describe("standalone version command", () => {
       `SupaCloud PostgREST launcher SHA-256: ${EMBEDDED_POSTGREST_LAUNCHER_SHA256}\n`,
     );
     expect(launcherDigest.stderr).toBe("");
+
+    const invalidIdentityProbe = await captureProcess([
+      binaryPath,
+      POSTGREST_PROCESS_IDENTITY_PROBE_FLAG,
+      "invalid",
+      "981",
+      "981",
+    ], 5_000);
+    expect(invalidIdentityProbe.timedOut).toBe(false);
+    expect(invalidIdentityProbe.exitCode).not.toBe(0);
+    expect(invalidIdentityProbe.stdout).toBe("");
+    expect(invalidIdentityProbe.stderr).toBe("PostgREST process identity probe failed\n");
+
+    const invalidIdentityTermination = await captureProcess([
+      binaryPath,
+      POSTGREST_PROCESS_IDENTITY_TERMINATE_FLAG,
+      "invalid",
+      "981",
+      "981",
+      "987654321",
+    ], 5_000);
+    expect(invalidIdentityTermination.timedOut).toBe(false);
+    expect(invalidIdentityTermination.exitCode).not.toBe(0);
+    expect(invalidIdentityTermination.stdout).toBe("");
+    expect(invalidIdentityTermination.stderr).toBe("PostgREST process identity termination failed\n");
   }, 40_000);
 });


### PR DESCRIPTION
## Summary

- attest PostgREST executable, argv, start identity, and environment names through a compiled same-UID probe instead of privileged cross-UID procfs reads
- validate probe UID/GID, cleared supplementary groups and active capabilities, bounded input/output, stable process identity, and secret-free output
- terminate timed-out cross-UID probes through a same-UID pidfd helper that opens the process handle before revalidating PID/startId/UID/GID
- bound both termination-helper and original-child reap waits and remove the numeric-PID kill fallback

## Bun API decision

Bun 1.3.14 exposes spawn timeout and killSignal, but Management lacks CAP_KILL after the child drops to the tenant UID, so that timeout cannot terminate this process boundary. Bun has no public pidfd API. The implementation therefore uses bun:ffi for Linux pidfd_open and pidfd_send_signal without adding a dependency.

## Verification

- focused tests: 21 pass, 1 platform skip, 0 fail, 110 assertions
- typecheck: PASS
- complete Management unit gate: PASS with exit 0
- exact 0xcb Linux arm64 capability smoke: 1 pass, 15 assertions
- Linux arm64 compiled runtime smoke: PASS
- Linux x64 cross-compile and baseline compiled runtime smoke: PASS
- git diff check: PASS
- independent security Round 2: PASS
- independent platform/release Round 2: PASS

## Compatibility and rollout

This changes only internal Management runtime code and tests. It adds no HTTP, OpenAPI, RPC, database, package, or public SDK surface, so @supacloud/js does not require an update. Release and deployment are intentionally out of scope.