### PR TITLE
test(lite): cover queue auth and workflow parity

### DIFF
--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -250,7 +250,7 @@ S3 模式的快照只包含数据库中的 Storage 元数据和密钥，不复�
 | `supabase.storage` | 已验证核心 | 覆盖上传下载、列表、删除、TUS/RLS、远端 S3 驱动，以及 Bun.Image 的 `contain`/`fill`、格式和质量变换子集；`cover` 明确不支持 |
 | `supabase.channel()` | 已验证核心 | 自动测试覆盖 `postgres_changes`、DELETE RLS 隔离和事件快照校验；Broadcast、Presence 属于实验性兼容 |
 | `supabase.functions.invoke()` | 已验证核心 | 自动测试覆盖 Bun.build、`Deno.serve()`、公开函数和同进程重启 |
-| Supabase Queues / PGMQ | 已验证核心 | 提供 `pgmq_public` 的 `send`、`send_batch`、`read`、`pop`、`archive`、`delete` RPC；队列数据持久化在同一 PGlite 项目中 |
+| Supabase Queues / PGMQ | 已验证核心 | 提供 `pgmq_public` 的 `send`、`send_batch`、`read`、`pop`、`archive`、`delete` RPC；队列数据持久化在项目数据库（PGlite 或 native PostgreSQL）中 |
 | Edge Functions `SupaCloud.pgredis` | 已验证核心 | 提供单项目持久 KV、TTL、原子 `getset`/`getdel`；绑定只在当前函数请求内可用 |
 | Supabase migrations | 支持 | 按文件名排序，记录到 `supabase_migrations` |
 | PostgreSQL RLS | 支持 | 使用 `anon`、`authenticated`、`service_role` 数据库角色执行 |
@@ -274,7 +274,7 @@ Lite 使用 Bun 原生 bcrypt，并兼容验证常见 GoTrue bcrypt 密码散列
 
 ### 队列与 Edge 缓存
 
-Lite 在同一个 PGlite 数据库中提供 Supabase Queues 的公开 RPC façade。应用可以直接使用官方客户端的
+Lite 在项目数据库（PGlite 或 native PostgreSQL）中提供 Supabase Queues 的公开 RPC façade。应用可以直接使用官方客户端的
 `supabase.schema('pgmq_public').rpc(...)`，无需额外的队列进程：
 
 ```sql
@@ -298,6 +298,7 @@ const { data: messages } = await queues.rpc('read', {
 
 Lite 的 `pgmq` 模拟层还提供 `set_vt`，支持直接 SQL 调整可见性超时。消息按 PGMQ 语义至少投递一次；`pop` 会立即删除消息，`archive` 是确认路径。队列创建、指标、purge、设置和管理 API 不属于 Lite 的公开 RPC façade，仍需由项目 SQL 或完整 SupaCloud 控制面处理。
 队列名遵循标准版的 1-128 位小写字母、数字、下划线和短横线规则，并且必须以字母或数字开头；Lite 会安全映射超出 PostgreSQL 63-byte 标识符上限的名称，避免截断后串队。默认 Data API 暴露 `public` 和 `pgmq_public`；如果显式设置 `dbSchemas`，Lite 会严格使用该列表，需要队列 RPC 时应把 `pgmq_public` 明确加入。
+Durable workflow 的 run、step、event 和内部队列也保存在同一项目数据库中，可跨进程重启恢复；内部 workflow 队列不会通过 `pgmq_public` 暴露给 Data API 角色。
 
 Edge Function 内可使用 `globalThis.SupaCloud.pgredis`：
 
@@ -591,7 +592,7 @@ In-memory databases have no persistable data, so `snapshot` and `upgrade` reject
 | `supabase.storage` | Verified core | Covers upload/download, list, delete, TUS/RLS, remote S3 driver, and a subset of Bun.Image `contain`/`fill`, format, and quality transforms; `cover` is explicitly unsupported |
 | `supabase.channel()` | Verified core | Automated tests cover `postgres_changes`, DELETE RLS isolation, and event snapshot validation; Broadcast and Presence are experimentally compatible |
 | `supabase.functions.invoke()` | Verified core | Automated tests cover Bun.build, `Deno.serve()`, public functions, and in-process restart |
-| Supabase Queues / PGMQ | Verified core | Provides `send`, `send_batch`, `read`, `pop`, `archive`, and `delete` RPCs for `pgmq_public`; queue data is persisted in the same PGlite project |
+| Supabase Queues / PGMQ | Verified core | Provides `send`, `send_batch`, `read`, `pop`, `archive`, and `delete` RPCs for `pgmq_public`; queue data is persisted in the project database (PGlite or native PostgreSQL) |
 | Edge Functions `SupaCloud.pgredis` | Verified core | Provides single-project persistent KV, TTL, and atomic `getset`/`getdel`; the binding is only available within the current function request |
 | Supabase migrations | Supported | Sorted by filename, recorded in `supabase_migrations` |
 | PostgreSQL RLS | Supported | Executed using the `anon`, `authenticated`, and `service_role` database roles |
@@ -615,7 +616,7 @@ Lite uses Bun's native bcrypt and is compatible with validating common GoTrue bc
 
 ### Queues and Edge Cache
 
-Lite provides a public RPC façade for Supabase Queues within the same PGlite database. Applications can directly use the official client's
+Lite provides a public RPC façade for Supabase Queues in the project database (PGlite or native PostgreSQL). Applications can directly use the official client's
 `supabase.schema('pgmq_public').rpc(...)` without an additional queue process:
 
 ```sql
@@ -639,6 +640,7 @@ const { data: messages } = await queues.rpc('read', {
 
 Lite's `pgmq` emulation layer also provides `set_vt`, allowing direct SQL adjustment of visibility timeouts. Messages are delivered at least once according to PGMQ semantics; `pop` deletes the message immediately, and `archive` is the acknowledgment path. Queue creation, metrics, purge, settings, and management APIs are not part of Lite's public RPC façade and must still be handled by project SQL or the full SupaCloud control plane.
 Queue names follow the standard 1-128 character lowercase letter, digit, underscore, and hyphen rule, and must start with a letter or digit; Lite safely maps names that exceed PostgreSQL's 63-byte identifier limit to avoid cross-queue collisions after truncation. The default Data API exposes `public` and `pgmq_public`; if `dbSchemas` is set explicitly, Lite uses that list strictly, and `pgmq_public` should be explicitly included when queue RPCs are needed.
+Durable workflow runs, steps, events, and the internal queue are stored in the same project database and survive process restarts. Data API roles cannot access the internal workflow queue through `pgmq_public`.
 
 Within an Edge Function, you can use `globalThis.SupaCloud.pgredis`:
 

--- a/packages/supacloud-lite/package.json
+++ b/packages/supacloud-lite/package.json
@@ -37,7 +37,7 @@
     "dev": "bun run src/cli.ts start",
     "start": "bun run src/cli.ts start",
     "test": "bun test --timeout 20000",
-    "test:native": "SUPACLOUD_LITE_TEST_NATIVE=1 bun test test/native-engine.test.ts --timeout 180000",
+    "test:native": "SUPACLOUD_LITE_TEST_NATIVE=1 bun test test/native-engine.test.ts test/qauth-workflow-matrix.test.ts --timeout 180000",
     "parity": "bun run parity/harness.ts",
     "parity:native": "SUPACLOUD_LITE_TEST_NATIVE=1 bun run parity/harness.ts --engine native",
     "check:native": "bun run test:native && bun run parity:native",

--- a/packages/supacloud-lite/parity/harness.ts
+++ b/packages/supacloud-lite/parity/harness.ts
@@ -84,7 +84,7 @@ async function createLite(): Promise<{ backend: SupaCloudLiteBackend }> {
 
 async function verifyReferenceSchema(service: SupabaseClient): Promise<void> {
   const response = await service.rpc('parity_schema_version')
-  if (response.error || response.data !== 'supacloud-lite-parity-v1') {
+  if (response.error || response.data !== 'supacloud-lite-parity-v2') {
     throw new Error('reference Supabase is missing parity/schema.sql or has a different schema version')
   }
 }

--- a/packages/supacloud-lite/parity/scenarios.ts
+++ b/packages/supacloud-lite/parity/scenarios.ts
@@ -106,6 +106,111 @@ export const PARITY_SCENARIOS: ParityScenario[] = [
       (observation.data as { otherCount?: number; serviceCount?: number })?.serviceCount === 1,
   },
   {
+    name: 'JWT tenant and owner claims resist spoofing',
+    module: 'rls',
+    run: async ({ anon, service, runId }) => {
+      const initialSignOut = await anon.auth.signOut()
+      const owner = await anon.auth.signUp({
+        email: `tenant-owner-${runId}@example.com`,
+        password: 'password123',
+        options: { data: { tenant_id: 'tenant-blue' } },
+      })
+      const ownerId = owner.data.user?.id
+      const ownerInsert = await anon.from('tenant_documents').insert({
+        tenant_id: 'tenant-blue',
+        content: `tenant-secret-${runId}`,
+      })
+      const ownerSignOut = await anon.auth.signOut()
+      const anonymousRead = await anon.from('tenant_documents').select('id').eq('content', `tenant-secret-${runId}`)
+      const other = await anon.auth.signUp({
+        email: `tenant-other-${runId}@example.com`,
+        password: 'password123',
+        options: { data: { tenant_id: 'tenant-red' } },
+      })
+      const forgedOwner = await anon.from('tenant_documents').insert({
+        tenant_id: 'tenant-red',
+        owner_id: ownerId,
+        content: `forged-owner-${runId}`,
+      })
+      const forgedTenant = await anon.from('tenant_documents').insert({
+        tenant_id: 'tenant-blue',
+        content: `forged-tenant-${runId}`,
+      })
+      const otherRows = await anon.from('tenant_documents').select('id').eq('content', `tenant-secret-${runId}`)
+      const serviceRows = await service.from('tenant_documents').select('id').eq('content', `tenant-secret-${runId}`)
+      return {
+        ok: Boolean(ownerId)
+          && !initialSignOut.error
+          && !owner.error
+          && !ownerInsert.error
+          && !ownerSignOut.error
+          && !other.error
+          && !otherRows.error
+          && !serviceRows.error,
+        data: {
+          anonymousCount: anonymousRead.data?.length ?? -1,
+          forgedOwnerCode: forgedOwner.error?.code,
+          forgedTenantCode: forgedTenant.error?.code,
+          otherCount: otherRows.data?.length ?? -1,
+          serviceCount: serviceRows.data?.length ?? -1,
+        },
+      }
+    },
+    expect: (observation) => observation.ok &&
+      (observation.data as { anonymousCount?: number })?.anonymousCount === 0 &&
+      (observation.data as { forgedOwnerCode?: string })?.forgedOwnerCode === '42501' &&
+      (observation.data as { forgedTenantCode?: string })?.forgedTenantCode === '42501' &&
+      (observation.data as { otherCount?: number })?.otherCount === 0 &&
+      (observation.data as { serviceCount?: number })?.serviceCount === 1,
+  },
+  {
+    name: 'private storage objects stay owner scoped',
+    module: 'storage',
+    run: async ({ anon, service, runId }) => {
+      const objectName = `private-${runId}.txt`
+      const initialSignOut = await anon.auth.signOut()
+      const owner = await anon.auth.signUp({
+        email: `storage-owner-${runId}@example.com`,
+        password: 'password123',
+      })
+      const uploaded = await anon.storage.from('parity-private').upload(objectName, 'owner-only')
+      const ownerSignOut = await anon.auth.signOut()
+      const anonymousDownload = await anon.storage.from('parity-private').download(objectName)
+      const other = await anon.auth.signUp({
+        email: `storage-other-${runId}@example.com`,
+        password: 'password123',
+      })
+      const otherDownload = await anon.storage.from('parity-private').download(objectName)
+      const otherList = await anon.storage.from('parity-private').list('', { search: objectName })
+      const otherOverwrite = await anon.storage.from('parity-private').upload(objectName, 'forged', { upsert: true })
+      const otherRemove = await anon.storage.from('parity-private').remove([objectName])
+      const serviceDownload = await service.storage.from('parity-private').download(objectName)
+      return {
+        ok: !initialSignOut.error
+          && !owner.error
+          && !uploaded.error
+          && !ownerSignOut.error
+          && !other.error
+          && !serviceDownload.error,
+        data: {
+          anonymousDenied: Boolean(anonymousDownload.error),
+          otherDenied: Boolean(otherDownload.error),
+          otherListCount: otherList.data?.length ?? -1,
+          overwriteDenied: Boolean(otherOverwrite.error),
+          otherRemoveCount: otherRemove.data?.length ?? -1,
+          serviceBody: serviceDownload.data ? await serviceDownload.data.text() : null,
+        },
+      }
+    },
+    expect: (observation) => observation.ok &&
+      (observation.data as { anonymousDenied?: boolean })?.anonymousDenied === true &&
+      (observation.data as { otherDenied?: boolean })?.otherDenied === true &&
+      (observation.data as { otherListCount?: number })?.otherListCount === 0 &&
+      (observation.data as { overwriteDenied?: boolean })?.overwriteDenied === true &&
+      (observation.data as { otherRemoveCount?: number })?.otherRemoveCount === 0 &&
+      (observation.data as { serviceBody?: string })?.serviceBody === 'owner-only',
+  },
+  {
     name: 'storage lifecycle',
     module: 'storage',
     run: async ({ service, runId }) => {

--- a/packages/supacloud-lite/parity/schema.sql
+++ b/packages/supacloud-lite/parity/schema.sql
@@ -24,11 +24,47 @@ drop policy if exists parity_note_owner on public.notes;
 create policy parity_note_owner on public.notes for all to authenticated
   using (owner_id = auth.uid()) with check (owner_id = auth.uid());
 
+create table if not exists public.tenant_documents (
+  id uuid primary key default gen_random_uuid(),
+  tenant_id text not null,
+  owner_id uuid not null default auth.uid(),
+  content text not null
+);
+
+alter table public.tenant_documents enable row level security;
+drop policy if exists parity_tenant_document_owner on public.tenant_documents;
+create policy parity_tenant_document_owner on public.tenant_documents for all to authenticated
+  using (
+    tenant_id = auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+    and owner_id = auth.uid()
+  )
+  with check (
+    tenant_id = auth.jwt() -> 'user_metadata' ->> 'tenant_id'
+    and owner_id = auth.uid()
+  );
+
 grant usage on schema public to anon, authenticated, service_role;
 grant select on public.authors, public.posts to anon, authenticated;
 grant all on public.authors, public.posts, public.notes to service_role;
 grant select, insert, update, delete on public.notes to authenticated;
+grant all on public.tenant_documents to service_role;
+grant select, insert, update, delete on public.tenant_documents to authenticated;
 grant usage, select on all sequences in schema public to anon, authenticated, service_role;
+
+insert into storage.buckets (id, name, public)
+values ('parity-private', 'parity-private', false)
+on conflict (id) do update set public = excluded.public;
+
+drop policy if exists parity_private_object_owner on storage.objects;
+create policy parity_private_object_owner on storage.objects for all to authenticated
+  using (
+    bucket_id = 'parity-private'
+    and owner_id = auth.uid()::text
+  )
+  with check (
+    bucket_id = 'parity-private'
+    and owner_id = auth.uid()::text
+  );
 
 insert into public.authors (id, name, email) values
   (1, 'Ada', 'ada@parity.invalid'),
@@ -47,7 +83,7 @@ create or replace function public.parity_add_two(left_value integer, right_value
 returns integer language sql immutable as $$ select left_value + right_value $$;
 
 create or replace function public.parity_schema_version()
-returns text language sql immutable as $$ select 'supacloud-lite-parity-v1'::text $$;
+returns text language sql immutable as $$ select 'supacloud-lite-parity-v2'::text $$;
 
 grant execute on function public.parity_add_two(integer, integer) to anon, authenticated, service_role;
 grant execute on function public.parity_schema_version() to anon, authenticated, service_role;

--- a/packages/supacloud-lite/test/qauth-workflow-matrix.test.ts
+++ b/packages/supacloud-lite/test/qauth-workflow-matrix.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { createSupaCloudClient } from './helpers/supacloud-js-source.js'
+import {
+  createLiteBackend,
+  createNativeEngine,
+  signJwt,
+  type SupaCloudLiteBackend,
+} from '../src/index.js'
+
+const backendConfig = {
+  jwtSecret: 'x'.repeat(64),
+  vaultKey: 'y'.repeat(64),
+  log: () => {},
+}
+const nativeMode = process.env.SUPACLOUD_LITE_TEST_NATIVE === '1'
+type WorkflowClient = ReturnType<typeof workflowClient>
+
+describe(`queue, authorization, and workflow matrix (${nativeMode ? 'native' : 'pglite'})`, () => {
+  test('preserves queue delivery, visibility, concurrency, and access boundaries', async () => {
+    await withBackend('queues', exerciseQueueMatrix)
+  }, 180_000)
+
+  test('preserves workflow claims, lease recovery, backoff, cancellation, and dead letters', async () => {
+    await withBackend('workflows', exerciseWorkflowMatrix)
+  }, 180_000)
+
+  test('reopens queued messages and workflow snapshots from persistent storage', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), `supacloud-lite-matrix-persistence-${nativeMode ? 'native' : 'pglite'}-`))
+    const dataDir = join(rootDir, 'database')
+    const runId = crypto.randomUUID()
+    let backend: SupaCloudLiteBackend | undefined
+    try {
+      backend = await matrixBackend(dataDir)
+      await backend.db.query(`select pgmq.create('persistent_jobs')`)
+      await backend.db.query(`select pgmq.send('persistent_jobs', '{"persisted":true}'::jsonb, 0)`)
+      await startWorkflow(workflowClient(backend), runId, 2)
+      await backend.close()
+      backend = undefined
+      backend = await matrixBackend(dataDir)
+      await expectPersistentState(backend, runId)
+    } finally {
+      await backend?.close()
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  }, 180_000)
+})
+
+async function withBackend(label: string, run: (backend: SupaCloudLiteBackend) => Promise<void>): Promise<void> {
+  const rootDir = await mkdtemp(join(tmpdir(), `supacloud-lite-matrix-${label}-${nativeMode ? 'native' : 'pglite'}-`))
+  let backend: SupaCloudLiteBackend | undefined
+  try {
+    backend = await matrixBackend(join(rootDir, 'database'))
+    await run(backend)
+  } finally {
+    await backend?.close()
+    await rm(rootDir, { recursive: true, force: true })
+  }
+}
+
+async function exerciseQueueMatrix(backend: SupaCloudLiteBackend): Promise<void> {
+  const clients = await roleClients(backend)
+  const queue = clients.anon.schema('pgmq_public')
+  await backend.db.query(`select pgmq.create('matrix_jobs')`)
+  await expectConcurrentQueueClaims(backend, clients)
+  await expectQueueVisibility(queue)
+  for (const client of Object.values(clients)) await expectInternalQueueDenied(client)
+  for (const client of [clients.anon, clients.authenticated]) await expectRawQueueDenied(client)
+}
+
+async function expectConcurrentQueueClaims(
+  backend: SupaCloudLiteBackend,
+  clients: Record<'anon' | 'authenticated' | 'service', SupabaseClient>,
+) {
+  const queue = clients.anon.schema('pgmq_public')
+  const sent = await queue.rpc('send', {
+    queue_name: 'matrix_jobs',
+    message: { sequence: 1 },
+    sleep_seconds: 0,
+  })
+  expect(sent.error).toBeNull()
+  const reads = await Promise.all([
+    clients.authenticated.schema('pgmq_public').rpc('read', queueRead('matrix_jobs', 30)),
+    clients.service.schema('pgmq_public').rpc('read', queueRead('matrix_jobs', 30)),
+  ])
+  const claimedIds = reads.flatMap((response) => queueMessageIds(response.data))
+  expect(reads.map((response) => response.error)).toEqual([null, null])
+  expect(claimedIds).toEqual([1])
+  expect(reads.map((response) => queueMessageIds(response.data).length).sort()).toEqual([0, 1])
+  expect(queueMessageIds((await queue.rpc('read', queueRead('matrix_jobs', 30))).data)).toEqual([])
+  expect((await queue.rpc('archive', { queue_name: 'matrix_jobs', message_id: 1 })).data).toBe(true)
+  await expectArchivedQueueInvariant(backend)
+  expect((await queue.rpc('send_batch', {
+    queue_name: 'matrix_jobs',
+    messages: [{ sequence: 2 }, { sequence: 3 }],
+    sleep_seconds: 0,
+  })).error).toBeNull()
+  expect((await queue.rpc('delete', { queue_name: 'matrix_jobs', message_id: 2 })).data).toBe(true)
+  expect(queueMessageIds((await queue.rpc('pop', { queue_name: 'matrix_jobs' })).data)).toEqual([3])
+}
+
+async function expectArchivedQueueInvariant(backend: SupaCloudLiteBackend): Promise<void> {
+  const counts = await backend.db.query<{ active_count: number; archive_count: number }>(`
+    select
+      (select count(*)::integer from pgmq.q_matrix_jobs where msg_id = 1) as active_count,
+      (select count(*)::integer from pgmq.a_matrix_jobs where msg_id = 1) as archive_count
+  `)
+  expect(counts.rows).toEqual([{ active_count: 0, archive_count: 1 }])
+}
+
+async function expectQueueVisibility(queue: ReturnType<SupabaseClient['schema']>): Promise<void> {
+  const sent = await queue.rpc('send', {
+    queue_name: 'matrix_jobs',
+    message: { visibility: true },
+    sleep_seconds: 0,
+  })
+  expect(sent.error).toBeNull()
+  const firstVisible = queueMessage((await queue.rpc('read', queueRead('matrix_jobs', 0))).data)
+  const redelivered = queueMessage((await queue.rpc('read', queueRead('matrix_jobs', 30))).data)
+  expect(redelivered).toMatchObject({ msg_id: firstVisible.msg_id, read_ct: 2 })
+}
+
+async function exerciseWorkflowMatrix(backend: SupaCloudLiteBackend): Promise<void> {
+  const workflows = workflowClient(backend)
+  await expectSingleWorkflowClaim(workflows)
+  await expectWorkflowLeaseRecovery(backend, workflows)
+  await expectWorkflowCancellation(workflows)
+  await expectWorkflowDeadLetter(workflows)
+}
+
+async function expectSingleWorkflowClaim(workflows: WorkflowClient): Promise<void> {
+  const runId = crypto.randomUUID()
+  const starts = await Promise.all([
+    startWorkflow(workflows, runId, 3),
+    startWorkflow(workflows, runId, 3),
+  ])
+  expect(starts.map((snapshot) => snapshot.idempotent).sort()).toEqual([false, true])
+  expect(starts.every((snapshot) => snapshot.steps.length === 1)).toBe(true)
+  const claims = await Promise.all([
+    workflows.claim({ workerId: 'worker-a', visibilityTimeoutSeconds: 30 }),
+    workflows.claim({ workerId: 'worker-b', visibilityTimeoutSeconds: 30 }),
+  ])
+  const claimed = claims.filter(isClaimed)
+  expect(claimed).toHaveLength(1)
+  expect(claims.filter((claim) => claim === null)).toHaveLength(1)
+  await workflows.complete({ ...attemptRequest(requireClaim(claimed[0] ?? null)), runOutput: { completed: true } })
+}
+
+async function expectWorkflowLeaseRecovery(backend: SupaCloudLiteBackend, workflows: WorkflowClient): Promise<void> {
+  const runId = crypto.randomUUID()
+  await startWorkflow(workflows, runId, 3)
+  const expired = requireClaim(await workflows.claim({ workerId: 'expired-worker', visibilityTimeoutSeconds: 30 }))
+  await makeWorkflowMessageVisible(backend, expired)
+  const reclaimed = requireClaim(await workflows.claim({ workerId: 'recovery-worker', visibilityTimeoutSeconds: 30 }))
+  expect(reclaimed).toMatchObject({ runId, attempt: 2 })
+  await expectStaleWorkflowAttemptDenied(workflows, expired)
+  await expectWorkflowBackoff(backend, workflows, reclaimed, runId)
+}
+
+async function expectStaleWorkflowAttemptDenied(workflows: WorkflowClient, expired: Record<string, unknown>) {
+  await expect(workflows.advance({
+    ...attemptRequest(expired),
+    output: { stale: true },
+    nextStepKey: 'should-not-run',
+    nextInput: {},
+  })).rejects.toMatchObject({ code: '40001' })
+  await expect(workflows.complete({
+    ...attemptRequest(expired),
+    runOutput: { stale: true },
+  })).rejects.toMatchObject({ code: '40001' })
+}
+
+async function expectWorkflowBackoff(
+  backend: SupaCloudLiteBackend,
+  workflows: WorkflowClient,
+  reclaimed: Record<string, unknown>,
+  runId: string,
+): Promise<void> {
+  const retried = await workflows.retry({
+    ...attemptRequest(reclaimed),
+    errorMessage: 'dependency unavailable',
+    delaySeconds: 30,
+  })
+  expect(retried.steps[0]).toMatchObject({ status: 'queued', attempts: 2 })
+  expect(await workflows.claim({ workerId: 'early-worker', visibilityTimeoutSeconds: 30 })).toBeNull()
+  await makeWorkflowMessageVisible(backend, reclaimed)
+  const finalClaim = requireClaim(await workflows.claim({ workerId: 'final-worker', visibilityTimeoutSeconds: 30 }))
+  expect(finalClaim).toMatchObject({ runId, attempt: 3 })
+  await workflows.complete({ ...attemptRequest(finalClaim), runOutput: { recovered: true } })
+}
+
+async function expectWorkflowCancellation(workflows: WorkflowClient): Promise<void> {
+  const runId = crypto.randomUUID()
+  await startWorkflow(workflows, runId, 2)
+  const claim = requireClaim(await workflows.claim({ workerId: 'cancelled-worker', visibilityTimeoutSeconds: 30 }))
+  expect((await workflows.cancel(runId, 'operator request')).status).toBe('cancelled')
+  await expect(workflows.complete({
+    ...attemptRequest(claim),
+    runOutput: { shouldNotComplete: true },
+  })).rejects.toMatchObject({ code: '40001' })
+  expect(await workflows.get(runId)).toMatchObject({ runId, status: 'cancelled' })
+  expect(await workflows.claim({ workerId: 'cancel-check', visibilityTimeoutSeconds: 30 })).toBeNull()
+}
+
+async function expectWorkflowDeadLetter(workflows: WorkflowClient): Promise<void> {
+  const runId = crypto.randomUUID()
+  await startWorkflow(workflows, runId, 1)
+  const claim = requireClaim(await workflows.claim({ workerId: 'dead-letter-worker', visibilityTimeoutSeconds: 30 }))
+  const exhausted = await workflows.retry({ ...attemptRequest(claim), errorMessage: 'permanent failure' })
+  expect(exhausted).toMatchObject({ status: 'failed' })
+  expect(exhausted.steps[0]).toMatchObject({ status: 'dead_lettered', attempts: 1 })
+  expect((await workflows.events(runId)).map((event) => event.eventType)).toContain('step_dead_lettered')
+}
+
+async function expectPersistentState(backend: SupaCloudLiteBackend, runId: string): Promise<void> {
+  const queueRows = await backend.db.query<{ message: { persisted?: boolean } }>(
+    `select * from pgmq.read('persistent_jobs', 30, 1)`
+  )
+  expect(queueRows.rows[0]?.message).toEqual({ persisted: true })
+  const workflows = workflowClient(backend)
+  expect(await workflows.get(runId)).toMatchObject({ runId, status: 'queued' })
+  expect((await workflows.events(runId)).map((event) => event.eventType)).toContain('run_started')
+  const claim = requireClaim(await workflows.claim({ workerId: 'restart-worker', visibilityTimeoutSeconds: 30 }))
+  expect(claim).toMatchObject({ runId, attempt: 1 })
+  expect((await workflows.complete({ ...attemptRequest(claim), runOutput: { restarted: true } })).status).toBe('completed')
+  expect((await workflows.events(runId)).map((event) => event.eventType)).toContain('run_completed')
+}
+
+async function matrixBackend(dataDir: string): Promise<SupaCloudLiteBackend> {
+  if (!nativeMode) return createLiteBackend({ ...backendConfig, dataDir })
+  return createLiteBackend({ ...backendConfig, engine: await createNativeEngine({ dataDir }) })
+}
+
+async function roleClients(backend: SupaCloudLiteBackend): Promise<Record<'anon' | 'authenticated' | 'service', SupabaseClient>> {
+  const token = await signJwt(
+    { role: 'authenticated', sub: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+    backend.jwtSecret,
+  )
+  return {
+    anon: supabaseClient(backend, backend.anonKey),
+    authenticated: supabaseClient(backend, token),
+    service: supabaseClient(backend, backend.serviceRoleKey, backend.serviceRoleKey),
+  }
+}
+
+function supabaseClient(backend: SupaCloudLiteBackend, bearer: string, apiKey = backend.anonKey): SupabaseClient {
+  return createClient('http://local', apiKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    global: {
+      fetch: backend.fetch,
+      headers: { authorization: `Bearer ${bearer}` },
+    },
+  })
+}
+
+function workflowClient(backend: SupaCloudLiteBackend) {
+  return createSupaCloudClient({
+    supabase: supabaseClient(backend, backend.serviceRoleKey, backend.serviceRoleKey),
+    managementApiUrl: 'http://management-not-used',
+    projectRef: 'lite',
+  }).workflows
+}
+
+function queueRead(queueName: string, visibilityTimeoutSeconds: number) {
+  return { queue_name: queueName, sleep_seconds: visibilityTimeoutSeconds, n: 1 }
+}
+
+function queueMessageIds(payload: unknown): number[] {
+  if (!Array.isArray(payload)) return []
+  return payload.flatMap((entry) => isQueueMessage(entry) ? [entry.msg_id] : [])
+}
+
+function queueMessage(payload: unknown): { msg_id: number; read_ct: number } {
+  if (!Array.isArray(payload) || !isQueueMessage(payload[0])) throw new Error('expected one queue message')
+  return payload[0]
+}
+
+function isQueueMessage(candidate: unknown): candidate is { msg_id: number; read_ct: number } {
+  return typeof candidate === 'object' && candidate !== null
+    && typeof (candidate as Record<string, unknown>).msg_id === 'number'
+    && typeof (candidate as Record<string, unknown>).read_ct === 'number'
+}
+
+async function expectInternalQueueDenied(client: SupabaseClient): Promise<void> {
+  const queue = client.schema('pgmq_public')
+  const responses = await Promise.all([
+    queue.rpc('send', {
+      queue_name: 'supacloud_internal_workflows',
+      message: { denied: true },
+      sleep_seconds: 0,
+    }),
+    queue.rpc('read', queueRead('supacloud_internal_workflows', 30)),
+    queue.rpc('pop', { queue_name: 'supacloud_internal_workflows' }),
+  ])
+  expect(responses.map((response) => response.data)).toEqual([null, null, null])
+  expect(responses.map((response) => response.error?.code)).toEqual(['42501', '42501', '42501'])
+}
+
+async function expectRawQueueDenied(client: SupabaseClient): Promise<void> {
+  const response = await client.schema('pgmq').rpc('read', queueRead('matrix_jobs', 30))
+  expect(response.data).toBeNull()
+  expect(response.error?.code).toBe('PGRST106')
+}
+
+async function startWorkflow(
+  workflows: WorkflowClient,
+  runId: string,
+  maxAttempts: number,
+): ReturnType<WorkflowClient['start']> {
+  return workflows.start({
+    runId,
+    workflowName: 'matrix.workflow',
+    workflowVersion: '1',
+    firstStepKey: 'execute',
+    input: { runId },
+    maxAttempts,
+  })
+}
+
+function isClaimed(claim: Record<string, unknown> | null): claim is Record<string, unknown> {
+  return claim?.status === 'claimed'
+}
+
+function requireClaim(claim: Record<string, unknown> | null): Record<string, unknown> {
+  expect(claim).toMatchObject({ status: 'claimed' })
+  if (!isClaimed(claim)) throw new Error('expected a claimed workflow step')
+  return claim
+}
+
+function attemptRequest(claim: Record<string, unknown>) {
+  return {
+    stepId: String(claim.stepId),
+    messageId: String(claim.messageId),
+    attempt: Number(claim.attempt),
+    workerId: String(claim.workerId),
+  }
+}
+
+async function makeWorkflowMessageVisible(
+  backend: SupaCloudLiteBackend,
+  claim: Record<string, unknown>,
+): Promise<void> {
+  await backend.db.query(
+    `select * from pgmq.set_vt('supacloud_internal_workflows', $1, 0)`,
+    [String(claim.messageId)],
+  )
+}

--- a/packages/supacloud-lite/test/workflows.test.ts
+++ b/packages/supacloud-lite/test/workflows.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'bun:test'
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { createSupaCloudClient } from './helpers/supacloud-js-source.js'
 import { createLiteBackend } from '../src/index.js'
-import { WORKFLOWS_SQL } from '../src/runtime/db/emulated.js'
 import { signJwt } from '../src/runtime/jwt.js'
 
 const backendConfig = {
@@ -23,7 +22,6 @@ describe('Durable workflows', () => {
   test('enforces service-role access and durable step semantics end to end', async () => {
     const backend = await createLiteBackend(backendConfig)
     try {
-      await backend.db.exec(WORKFLOWS_SQL)
       const anon = supabaseClient(backend.anonKey, backend.fetch)
       const authenticatedToken = await signJwt(
         { role: 'authenticated', sub: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },


### PR DESCRIPTION
## Summary
- add a shared PGlite/native queue, authorization, and durable-workflow contract matrix
- extend public parity with tenant JWT/RLS and private Storage ownership boundaries
- verify workflow SQL is installed by normal bootstrap and document PGlite/native persistence

## Verification
- `bun run check` (177 pass, 1 native-only skip)
- `bun test test/qauth-workflow-matrix.test.ts test/workflows.test.ts --timeout 180000` (4 pass, 115 assertions)
- `bun run parity` (16/16)
- `SUPACLOUD_LITE_POSTGRES_MIRROR=https://ghproxy.net/ bun run check:native` (7/7 tests, parity 16/16)
- independent verifier: local matrix PASS

## Follow-up found during release validation
The official v0.8.2 Linux x64 artifact passes version and SHA-256 verification, but currently misclassifies AlmaLinux 10.1 / GNU libc 2.39 as non-glibc and rejects `--engine native`. That runtime defect is intentionally not mixed into this test-only PR and will be submitted as a focused follow-up.