### PR TITLE
fix(lite): detect glibc in standalone runtime

### DIFF
--- a/packages/supacloud-lite/src/runtime/node/native/engine.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/engine.ts
@@ -5,7 +5,7 @@
  * and manages the postgres child process. Trust auth over a private unix
  * socket directory (0700), never TCP.
  */
-import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
+import { execFileSync, spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import { createHash, randomBytes } from 'node:crypto'
 import { appendFileSync, chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
@@ -21,6 +21,24 @@ const DEFAULT_PG_VERSION = '17.7.0'
 const POSTGRES_MIRROR_URL_ERROR =
   'SUPACLOUD_LITE_POSTGRES_MIRROR must be an absolute HTTPS URL or a loopback HTTP URL'
 export const NATIVE_POSTGRES_MAJOR = DEFAULT_PG_VERSION.split('.')[0]!
+
+const GLIBC_DYNAMIC_LOADERS = {
+  x64: [
+    '/lib64/ld-linux-x86-64.so.2',
+    '/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2',
+  ],
+  arm64: [
+    '/lib/ld-linux-aarch64.so.1',
+    '/lib64/ld-linux-aarch64.so.1',
+    '/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1',
+  ],
+} as const
+
+export interface GlibcRuntimeEvidence {
+  runtimeVersion?: string
+  dynamicLoaderPresent: boolean
+  lddVersion?: string
+}
 
 /** Options for {@link createNativeEngine}. */
 export interface NativeEngineOptions {
@@ -43,12 +61,36 @@ export function isNativeEngineSupported(): boolean {
 }
 
 function isGlibcLinux(): boolean {
-  try {
-    const version = execFileSync('ldd', ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
-    return /glibc|gnu libc/i.test(version)
-  } catch {
-    return false
+  const runtimeEvidence: GlibcRuntimeEvidence = {
+    runtimeVersion: reportedGlibcVersion(),
+    dynamicLoaderPresent: glibcDynamicLoaderPresent(),
   }
+  return isGlibcRuntime(runtimeEvidence) || isGlibcRuntime({ ...runtimeEvidence, lddVersion: lddVersion() })
+}
+
+export function isGlibcRuntime(evidence: GlibcRuntimeEvidence): boolean {
+  return Boolean(evidence.runtimeVersion?.trim()) ||
+    evidence.dynamicLoaderPresent ||
+    /glibc|gnu libc/i.test(evidence.lddVersion ?? '')
+}
+
+function reportedGlibcVersion(): string | undefined {
+  const report = process.report?.getReport() as { header?: { glibcVersionRuntime?: unknown } } | undefined
+  const runtimeVersion = report?.header?.glibcVersionRuntime
+  return typeof runtimeVersion === 'string' ? runtimeVersion : undefined
+}
+
+function glibcDynamicLoaderPresent(): boolean {
+  const loaderPaths = process.arch === 'x64'
+    ? GLIBC_DYNAMIC_LOADERS.x64
+    : process.arch === 'arm64' ? GLIBC_DYNAMIC_LOADERS.arm64 : []
+  return loaderPaths.some((loaderPath) => existsSync(loaderPath))
+}
+
+function lddVersion(): string | undefined {
+  const command = spawnSync('ldd', ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+  if (command.error || command.status !== 0) return undefined
+  return `${command.stdout}\n${command.stderr}`.trim()
 }
 
 function target(): string {

--- a/packages/supacloud-lite/test/native-platform.test.ts
+++ b/packages/supacloud-lite/test/native-platform.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test'
+import { isGlibcRuntime } from '../src/runtime/node/native/engine.js'
+
+describe('native PostgreSQL platform detection', () => {
+  test('accepts independent glibc evidence and rejects musl or unknown runtimes', () => {
+    // Cases: runtime report, dynamic loader, ldd fallback, musl, and no evidence.
+    expect(isGlibcRuntime({ runtimeVersion: '2.39', dynamicLoaderPresent: false })).toBe(true)
+    expect(isGlibcRuntime({ dynamicLoaderPresent: true })).toBe(true)
+    expect(isGlibcRuntime({ dynamicLoaderPresent: false, lddVersion: 'ldd (GNU libc) 2.39' })).toBe(true)
+    expect(isGlibcRuntime({ dynamicLoaderPresent: false, lddVersion: 'musl libc (x86_64)' })).toBe(false)
+    expect(isGlibcRuntime({ dynamicLoaderPresent: false })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- detect glibc from Bun/Node runtime reports or known x64/arm64 dynamic loaders before invoking ldd
- retain ldd as a fallback and keep musl/unknown Linux fail-closed
- add focused regression coverage for report, loader, ldd, musl, and unknown evidence

## Root cause

The published Linux x64 standalone binary rejected native mode on AlmaLinux 10.1 even though the host provides GNU libc 2.39. The previous platform gate depended only on child-process execution of ldd, which is unreliable in the compiled runtime.

## Verification

- bun run check: 178 pass, 1 native-only skip
- mirrored bun run check:native: 7/7 native tests and 16/16 parity scenarios
- focused platform/download/native tests plus typecheck: PASS
- Linux x64 candidate SHA-256: ad484601f49440b201c7568ead06b86e3b67d73cf0ebfcaf678a98db02debda3
- Test AlmaLinux 10.1 / GNU libc 2.39, non-root, fresh HOME, dynamic loopback ports: native Auth, REST/Storage RLS, queues, workflows, queue visibility redelivery, workflow lease reclaim, stale-worker rejection, and restart persistence all PASS
- test processes and named temporary paths cleaned
- independent verifier recovery verdict: PASS

## Safety

Known glibc runtime/loader evidence is required before bypassing ldd. A musl response or missing evidence still returns unsupported; PostgreSQL artifact checksum verification is unchanged.