### PR TITLE
feat(web-console): upgrade svadmin UI integration

### DIFF
--- a/packages/web-console/bun.lock
+++ b/packages/web-console/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "web-console",
       "dependencies": {
-        "@svadmin/core": "^0.35.0",
+        "@svadmin/core": "^0.36.0",
         "@svadmin/elysia": "^0.11.0",
-        "@svadmin/sveltekit": "^0.9.8",
-        "@svadmin/ui": "0.41.1",
+        "@svadmin/sveltekit": "^0.9.9",
+        "@svadmin/ui": "0.42.0",
         "@tanstack/svelte-query": "^6.1.38",
         "highlight.js": "^11.11.2",
         "isomorphic-dompurify": "^3.22.0",
@@ -217,13 +217,13 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@svadmin/core": ["@svadmin/core@0.35.0", "", { "peerDependencies": { "@tanstack/svelte-query": "^6.1.38", "svelte": "^5.56.8" }, "optionalPeers": ["@tanstack/svelte-query", "svelte"] }, "sha512-k/jcUBsH5eA/bLR+Sg96ok1KMZUkku2EdjPO9APB6IqtMlBZx/shH7rjBol7nZCVwLdvLfF6qXAYr1ZELqgKkQ=="],
+    "@svadmin/core": ["@svadmin/core@0.36.0", "", { "peerDependencies": { "@tanstack/svelte-query": "^6.1.38", "svelte": "^5.56.8" }, "optionalPeers": ["@tanstack/svelte-query", "svelte"] }, "sha512-BzvF8ctKd0Ns0uePT753IgnKJXYeS32Mkp+7tIdNdw0McK5K6qFY4M9gSAo9qfQIQWeO+jeIjWFF93D1p2is8g=="],
 
     "@svadmin/elysia": ["@svadmin/elysia@0.11.0", "", { "peerDependencies": { "@elysiajs/eden": ">=1.4.9", "@svadmin/core": "^0.35.0", "elysia": ">=1.4.29" }, "optionalPeers": ["@elysiajs/eden", "@svadmin/core", "elysia"] }, "sha512-uDXfvd2K/lzqdnYGwBqXnU+gMP0uENyOm5wLsqy11djiVuCFHwjlC+RPGDd2FjKuf1Hq6g88suZ1fAbJwD1TiQ=="],
 
-    "@svadmin/sveltekit": ["@svadmin/sveltekit@0.9.8", "", { "peerDependencies": { "@svadmin/core": ">=0.32.2 <0.36.0", "@sveltejs/kit": "^2.70.2", "svelte": "^5.56.8" }, "optionalPeers": ["@svadmin/core", "@sveltejs/kit", "svelte"] }, "sha512-V222o97KlIJPu9IQK1xV+js5C5j9JNk8GRea6A/zTslS7JLPCrMP6NjFaUVN/v/dYh/IDya8M0t23AvE8JiBRw=="],
+    "@svadmin/sveltekit": ["@svadmin/sveltekit@0.9.9", "", { "peerDependencies": { "@svadmin/core": ">=0.32.2 <0.37.0", "@sveltejs/kit": "^2.70.2", "svelte": "^5.56.8" }, "optionalPeers": ["@svadmin/core", "@sveltejs/kit", "svelte"] }, "sha512-9wiezNq6hwEm1U5Tu40z21/jhrOBWSyq8Ma68UHoysPr3Ib8Eo0bhDAEh1SFQMVUxmnmEkiGVhhAAGaPPyD2pw=="],
 
-    "@svadmin/ui": ["@svadmin/ui@0.41.1", "", { "dependencies": { "@floating-ui/dom": "^1.8.0", "@lucide/svelte": "^1.30.0", "@tanstack/svelte-store": "^0.12.1", "@tanstack/svelte-table": "9.1.2", "@tanstack/table-core": "9.1.2", "bits-ui": "^2.18.1", "clsx": "^2.1.1", "svelte-sonner": "^1.1.1", "tailwind-merge": "^3.6.0", "tailwind-variants": "^3.3.1" }, "peerDependencies": { "@svadmin/core": "^0.35.0", "@svadmin/editor": "*", "@tanstack/svelte-query": "^6.1.38", "highlight.js": "^11.11.1", "isomorphic-dompurify": "^3.22.0", "marked": "^18.0.9", "marked-highlight": "^2.2.4", "svelte": "^5.56.8" }, "optionalPeers": ["@svadmin/core", "@svadmin/editor", "@tanstack/svelte-query", "highlight.js", "isomorphic-dompurify", "marked", "marked-highlight", "svelte"] }, "sha512-lDU1n8pmQoX3XkCGlrV7KybEKX4OUajikTVAPQju42yNvrC2ypVPfqUw+CVbKrErMj6JnWRJ/Lyc8aFDsbDzNA=="],
+    "@svadmin/ui": ["@svadmin/ui@0.42.0", "", { "dependencies": { "@floating-ui/dom": "^1.8.0", "@lucide/svelte": "^1.30.0", "@tanstack/svelte-store": "^0.12.1", "@tanstack/svelte-table": "9.1.2", "@tanstack/table-core": "9.1.2", "bits-ui": "^2.18.1", "clsx": "^2.1.1", "svelte-sonner": "^1.1.1", "tailwind-merge": "^3.6.0", "tailwind-variants": "^3.3.1" }, "peerDependencies": { "@svadmin/core": "^0.36.0", "@svadmin/editor": "*", "@tanstack/svelte-query": "^6.1.38", "highlight.js": "^11.11.1", "isomorphic-dompurify": "^3.22.0", "marked": "^18.0.9", "marked-highlight": "^2.2.4", "svelte": "^5.56.8" }, "optionalPeers": ["@svadmin/core", "@svadmin/editor", "@tanstack/svelte-query", "highlight.js", "isomorphic-dompurify", "marked", "marked-highlight", "svelte"] }, "sha512-22uzo0tprGLGrbg4QXteWUdmA0oyjvSBp/+RI2EJBvZWhgZiNwD2tVgf5xwV822Z54yCqHDuqUOIsn7rZsO33A=="],
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.12", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-J1jNYG23QWd67UfrQSFHtjhV37r9mVi0gdc12A3MWPldOjRK35Xk+um+qACPVjgw3AleiqoyEAhok8Wm3q46NA=="],
 

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -40,10 +40,10 @@
     "vite": "8.2.1"
   },
   "dependencies": {
-    "@svadmin/core": "^0.35.0",
+    "@svadmin/core": "^0.36.0",
     "@svadmin/elysia": "^0.11.0",
-    "@svadmin/sveltekit": "^0.9.8",
-    "@svadmin/ui": "0.41.1",
+    "@svadmin/sveltekit": "^0.9.9",
+    "@svadmin/ui": "0.42.0",
     "@tanstack/svelte-query": "^6.1.38",
     "highlight.js": "^11.11.2",
     "isomorphic-dompurify": "^3.22.0",

--- a/packages/web-console/src/lib/components/ProjectSwitcher.svelte
+++ b/packages/web-console/src/lib/components/ProjectSwitcher.svelte
@@ -1,54 +1,45 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
-  import { cn } from "$lib/utils";
-  import { ChevronDown, Plus } from "lucide-svelte";
   import { goto } from "$app/navigation";
-  
-  let { projects = [], currentProject = null } = $props();
-  let isOpen = $state(false);
+  import { Button, TenantSwitcher } from "@svadmin/ui";
+  import { Plus } from "lucide-svelte";
+
+  interface ProjectSummary {
+    ref: string;
+    name?: string;
+  }
+
+  let {
+    projects = [],
+    currentProject = null,
+  }: {
+    projects?: ProjectSummary[];
+    currentProject?: ProjectSummary | null;
+  } = $props();
+
+  const tenants = $derived(projects.map((project) => ({
+    id: project.ref,
+    name: project.name ?? project.ref,
+  })));
 
   function switchProject(ref: string) {
-    isOpen = false;
     goto(`/project/${ref}`);
   }
 </script>
 
-<div class="relative px-3 py-4 border-b">
-  <button 
-    onclick={() => isOpen = !isOpen}
-    class="w-full flex items-center justify-between px-3 py-2 rounded-md hover:bg-secondary transition-colors"
+<div class="space-y-1 border-b px-3 py-4">
+  <TenantSwitcher
+    {tenants}
+    currentTenantId={currentProject?.ref}
+    onSwitch={switchProject}
+  />
+  <Button
+    variant="ghost"
+    size="sm"
+    class="w-full justify-start text-brand"
+    onclick={() => goto("/projects/create")}
   >
-    <div class="flex items-center gap-3">
-      <div class="w-2 h-2 rounded-full bg-brand"></div>
-      <span class="text-sm font-semibold truncate">
-        {currentProject?.name || $t("Project.select_project")}
-      </span>
-    </div>
-    <ChevronDown class="w-4 h-4 text-muted-foreground" />
-  </button>
-
-  {#if isOpen}
-    <div class="absolute left-3 right-3 top-full mt-1 bg-popover border rounded-md shadow-lg z-50 py-1">
-      {#each projects as project}
-        <button 
-          class="w-full text-left px-3 py-2 text-sm hover:bg-secondary flex items-center gap-2"
-          onclick={() => switchProject(project.ref)}
-        >
-          <div class="w-2 h-2 rounded-full bg-brand"></div>
-          {project.name}
-        </button>
-      {/each}
-      <div class="border-t my-1"></div>
-      <button
-        class="w-full text-left px-3 py-2 text-sm hover:bg-secondary text-brand flex items-center gap-2"
-        onclick={() => {
-          isOpen = false;
-          goto("/projects/create");
-        }}
-      >
-        <Plus class="w-4 h-4" />
-        {$t("Project.new_project")}
-      </button>
-    </div>
-  {/if}
+    <Plus data-icon="inline-start" />
+    {$t("Project.new_project")}
+  </Button>
 </div>

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -32,7 +32,14 @@
     setTheme,
   } from "@svadmin/core";
   import { createSvelteKitRouterProvider } from "@svadmin/sveltekit";
-  import { ChatDialog, DevTools, Toast as SvadminToast } from "@svadmin/ui";
+  import {
+    Button,
+    ChatDialog,
+    DevTools,
+    Header,
+    PageSkeleton,
+    Toast as SvadminToast,
+  } from "@svadmin/ui";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import { Menu, Plug, X } from "lucide-svelte";
   import { dataProvider, chatProvider } from "$lib/admin/provider";
@@ -315,10 +322,9 @@
         {@render children()}
       </div>
     {:else if isCoreLoading}
-      <div class="flex-1 flex flex-col items-center justify-center space-y-4">
-        <div class="w-12 h-12 border-4 border-brand border-t-transparent rounded-full animate-spin"></div>
-        <p class="text-muted-foreground animate-pulse text-sm">{$t("Common.loading") || "Loading..."}</p>
-      </div>
+      <main class="flex-1 overflow-y-auto bg-muted/30 p-4 sm:p-6">
+        <PageSkeleton type="list" rows={5} />
+      </main>
     {:else if !isAuthenticated}
       <div class="flex-1 flex flex-col items-center justify-center space-y-4">
         <p class="text-muted-foreground text-sm">{$t("Login.redirecting", { default: "Redirecting to login..." })}</p>
@@ -368,7 +374,8 @@
       {/if}
       
       <main class="flex-1 overflow-y-auto relative bg-muted/30">
-        <div class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b bg-background px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
+        <Header showBreadcrumbs={false} showSearch={false}>
+          {#snippet children()}
           <button
             bind:this={mobileNavTrigger}
             type="button"
@@ -380,29 +387,33 @@
           >
             <Menu class="h-5 w-5" />
           </button>
-          <div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
-            <div class="flex items-center gap-2 text-sm text-muted-foreground">
-              <span class="hover:text-foreground cursor-pointer transition-colors">{$t("Dashboard.org_default") || "Default Organization"}</span>
-              <span>/</span>
-              <span class="text-foreground font-medium">{isPlatformRoute ? ($t("Sidebar.platform_admin") || "Platform Admin") : (currentProject?.name || ($t("Project.home") || "Home"))}</span>
-            </div>
+          <div class="flex items-center gap-2 text-sm text-muted-foreground">
+            <span class="hover:text-foreground cursor-pointer transition-colors">{$t("Dashboard.org_default") || "Default Organization"}</span>
+            <span>/</span>
+            <span class="text-foreground font-medium">{isPlatformRoute ? ($t("Sidebar.platform_admin") || "Platform Admin") : (currentProject?.name || ($t("Project.home") || "Home"))}</span>
           </div>
+          {/snippet}
+          {#snippet rightActions()}
           {#if !isPlatformRoute && currentProject?.ref}
-            <a
+            <Button
               href={resolve("/project/[ref]/api", { ref: currentProject.ref })}
-              class="inline-flex h-9 items-center gap-2 rounded-lg border bg-background px-3 text-xs font-semibold text-foreground transition-colors hover:border-brand/40 hover:bg-brand/5 hover:text-brand"
+              variant="outline"
+              size="sm"
+              class="border-brand/20 text-brand hover:border-brand/40 hover:bg-brand/5"
             >
-              <Plug class="h-4 w-4" />
+              <Plug data-icon="inline-start" />
               <span class="hidden sm:inline">{$t("Navigation.connect_api")}</span>
-            </a>
+            </Button>
           {/if}
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onclick={handleLogout}
-            class="px-3 py-1.5 text-xs font-medium rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
           >
             {$t("Auth.signOut") || "Logout"}
-          </button>
-        </div>
+          </Button>
+          {/snippet}
+        </Header>
 
         <div class="p-4 sm:p-6">
           {#key currentProject?.ref}

--- a/packages/web-console/src/routes/layout.test.ts
+++ b/packages/web-console/src/routes/layout.test.ts
@@ -47,6 +47,8 @@ describe("root layout source guards", () => {
 
   test("keeps one SvAdmin toast host and never falls back an unknown project route", () => {
     expect(layoutSource.match(/<SvadminToast/g)).toHaveLength(1);
+    expect(layoutSource).toContain("<PageSkeleton");
+    expect(layoutSource).toContain("<Header");
     expect(layoutSource).not.toContain("<Toaster");
     expect(layoutSource).not.toContain("projects.find(p => p.ref === refFromUrl) || projects[0]");
     expect(layoutSource).toContain("projects.find((project) => project.ref === refFromUrl) ?? null");

--- a/packages/web-console/src/routes/page.test.ts
+++ b/packages/web-console/src/routes/page.test.ts
@@ -44,6 +44,8 @@ describe("SupaCloud root dashboard", () => {
   test("keeps every new-project entrypoint connected to the creation form", () => {
     expect(projectsPageSource).toContain('href="/projects/create"');
     expect(projectSwitcherSource).toContain('goto("/projects/create")');
+    expect(projectSwitcherSource).toContain("TenantSwitcher");
+    expect(projectSwitcherSource).toContain("onSwitch={switchProject}");
     expect(createProjectPageSource).toContain('apiClient("/v1/projects"');
     expect(createProjectPageSource).toContain("method: \"POST\"");
     expect(createProjectPageSource).toContain("window.location.assign");
@@ -58,13 +60,13 @@ describe("SupaCloud root dashboard", () => {
   });
 
   test("locks the released svadmin adapters and Vite compatibility rule", () => {
-    expect(packageJson.dependencies["@svadmin/core"]).toBe("^0.35.0");
-    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.41.1");
-    expect(packageJson.dependencies["@svadmin/sveltekit"]).toBe("^0.9.8");
+    expect(packageJson.dependencies["@svadmin/core"]).toBe("^0.36.0");
+    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.42.0");
+    expect(packageJson.dependencies["@svadmin/sveltekit"]).toBe("^0.9.9");
     expect(packageJson.dependencies["@svadmin/elysia"]).toBe("^0.11.0");
-    expect(lockSource).toContain('"@svadmin/core@0.35.0"');
-    expect(lockSource).toContain('"@svadmin/ui@0.41.1"');
-    expect(lockSource).toContain('"@svadmin/sveltekit@0.9.8"');
+    expect(lockSource).toContain('"@svadmin/core@0.36.0"');
+    expect(lockSource).toContain('"@svadmin/ui@0.42.0"');
+    expect(lockSource).toContain('"@svadmin/sveltekit@0.9.9"');
     expect(lockSource).toContain('"@svadmin/elysia@0.11.0"');
     expect(viteSource).toContain("'@svadmin/core'");
   });

--- a/packages/web-console/src/routes/project/[ref]/hosting/[id]/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/hosting/[id]/+page.svelte
@@ -188,10 +188,7 @@
       queryClient.invalidateQueries({ queryKey: ["deployment", projectRef, deployId] });
       queryClient.invalidateQueries({ queryKey: ["deployment_logs", projectRef, deployId] });
       queryClient.invalidateQueries({
-        queryKey: keys()
-          .resource(`v1/projects/${projectRef}/frontend/deployments`)
-          .action("list")
-          .get(),
+        queryKey: keys().data.list(`v1/projects/${projectRef}/frontend/deployments`),
       });
       setTimeout(() => actionMsg = null, 4000);
     },

--- a/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/hosting/page.test.ts
@@ -20,7 +20,7 @@ describe("hosting deployment entrypoints", () => {
     expect(settingsSource).toContain('uploadBody.append("file", file)');
     expect(settingsSource).toContain("timeoutMs: FRONTEND_DEPLOY_TIMEOUT_MS");
     expect(settingsSource).not.toContain('headers: { "Content-Type": "application/zip" }');
-    expect(settingsSource).toContain('.resource(`v1/projects/${projectRef}/frontend/deployments`)');
+    expect(settingsSource).toContain('keys().data.list(`v1/projects/${projectRef}/frontend/deployments`)');
   });
 
   test("localizes the Pages header and preserves the Webhook endpoint", () => {

--- a/packages/web-console/src/routes/project/[ref]/tables/page.test.ts
+++ b/packages/web-console/src/routes/project/[ref]/tables/page.test.ts
@@ -216,9 +216,9 @@ describe("database tables column visibility", () => {
     const packageJson = await Bun.file(new URL("package.json", packageRoot)).json();
     const lockSource = await Bun.file(new URL("bun.lock", packageRoot)).text();
 
-    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.41.1");
-    expect(lockSource).toContain('"@svadmin/ui": "0.41.1"');
-    expect(lockSource).toContain('"@svadmin/ui@0.41.1"');
+    expect(packageJson.dependencies["@svadmin/ui"]).toBe("0.42.0");
+    expect(lockSource).toContain('"@svadmin/ui": "0.42.0"');
+    expect(lockSource).toContain('"@svadmin/ui@0.42.0"');
   });
 
   test("keeps unavailable row estimates from rendering as negative counts", async () => {


### PR DESCRIPTION
## Summary
- Upgrade @svadmin/core 0.35→0.36, @svadmin/ui 0.41.1→0.42.0, @svadmin/sveltekit 0.9.8→0.9.9
- Migrate Query Key API to v2 (keys().data.list(...)) replacing removed .resource() chain
- Reuse svadmin TenantSwitcher, PageSkeleton, Header, Button instead of hand-rolled equivalents
- Keep custom project/platform sidebars (dynamic routes, grouping, i18n)

## Verification
- bun run check: pass
- bun test: 213 pass, 0 fail
- bun run build: pass (pre-existing Tailwind gradient warning only)