### PR TITLE
fix(pgredis-runtime): update PostgresX dependencies

### DIFF
--- a/packages/pgredis-runtime/bun.lock
+++ b/packages/pgredis-runtime/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "@supacloud/pgredis-runtime",
       "dependencies": {
-        "@postgresx/bun-listen": "0.3.1",
-        "@postgresx/noredis": "0.6.1",
+        "@postgresx/bun-listen": "0.3.2",
+        "@postgresx/noredis": "0.7.0",
         "elysia": "^1.4.29",
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
   "packages": {
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
-    "@postgresx/bun-listen": ["@postgresx/bun-listen@0.3.1", "", {}, "sha512-FOC6sSIRyMjNFH64Hyzlh2kR6vp7Hp2XxlTNJavCXGu9UXALGD9P0B0c8GlgFC5mA2f6j5gz3tH4cDiSuoBXDg=="],
+    "@postgresx/bun-listen": ["@postgresx/bun-listen@0.3.2", "", {}, "sha512-uXC4dCYdUR0NG4GTC6WC3i3FH08uhL4x8/lqOCc3bbVUkk/IjlNr6e/lUwHzmCQV9it62vXQVRI2/yZpW0RTLA=="],
 
-    "@postgresx/noredis": ["@postgresx/noredis@0.6.1", "", {}, "sha512-rQMre1iEPK51ifdx3q2RoIXgq41Wy2HWB5IzWXts3T8breHXYnT5QaEVlvWQDng7ZnRkf7/+KbkRY74dfIsgCg=="],
+    "@postgresx/noredis": ["@postgresx/noredis@0.7.0", "", {}, "sha512-Y0d9/pENYpEuw9wFaw1I+sVd6+/GhuRJP+TIXYri0o9ncdXjhZC+jE9PfaJhUUHeiEBtc7DEZcjrK2Z/VBDRTw=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 

--- a/packages/pgredis-runtime/package.json
+++ b/packages/pgredis-runtime/package.json
@@ -17,8 +17,8 @@
     "build:macos": "bun run build:macos-amd64 && bun run build:macos-arm64"
   },
   "dependencies": {
-    "@postgresx/bun-listen": "0.3.1",
-    "@postgresx/noredis": "0.6.1",
+    "@postgresx/bun-listen": "0.3.2",
+    "@postgresx/noredis": "0.7.0",
     "elysia": "^1.4.29"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- update the actual PostgresX consumer, `packages/pgredis-runtime`, to `@postgresx/noredis@0.7.0`
- update its listener dependency to `@postgresx/bun-listen@0.3.2`
- keep the manifest/lockfile diff limited to the two intended exact versions and checksums

## Verification

- domestic mirror frozen install and exact dependency resolution
- pgredis runtime typecheck
- pgredis runtime full suite against PostgreSQL 18: 25 passed
- macOS arm64 binary build and health smoke
- standard Linux x64 binary build
- Linux x64 baseline binary health smoke under Apple Silicon Docker emulation
- Edge Runtime typecheck and focused pgredis capability/internal binding tests: 3 passed
- dependency audit: no vulnerabilities
- `git diff --check`
- isolated verifier: PASS

## Scope clarification

SupaCloud Lite's embedded `globalThis.SupaCloud.pgredis` is a separate implementation and does not import these PostgresX packages. This PR intentionally updates only the independent `pgredis-runtime` service and does not claim Lite dependency adoption.

## Linux note

The standard Bun Linux x64 executable builds successfully. Apple Silicon's amd64 emulator exposes no AVX and cannot run Bun's standard x64 runtime, so local executable smoke used Bun's x64 baseline target. The repository's native Linux x64 CI remains the authoritative runtime check for the release-shaped standard binary.
