### PR TITLE
feat(cli): add verified release controls

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -106,6 +106,28 @@ loopback development origins, with the default `:80` likewise omitted. Use
 `SUPACLOUD_PROJECT_REF` when it cannot be inferred from a managed
 `<ref>.api.*` application hostname.
 
+### Verified release controls
+
+`release` is an official CLI entry point for the existing Management API
+logical-backup and PostgREST lifecycle capabilities. It requires the Management
+API context above; it does not promote an application `service_role` key to
+Management authority. Restore remains an admin-only operation and is not
+exposed by this command group.
+
+```bash
+supacloud-cli release logical_backup_list --ref abc123
+supacloud-cli release logical_backup_create --ref abc123
+supacloud-cli release postgrest_status --ref abc123
+supacloud-cli release postgrest_restart --ref abc123
+```
+
+Backup creation reports success only after the CLI verifies exactly one new
+logical-backup receipt against the inventory before and after the mutation.
+PostgREST restart reports success only after it receives a matching restart
+receipt and reads back `desired=running`, `actual=running`, and
+`health=healthy`. Both mutating controls follow the normal production
+confirmation and read-only protections.
+
 The legacy `.env` fallback is unclassified and therefore does not enable the
 production confirmation gate. Production automation must select a `prod` or
 `production` profile, or set `SUPACLOUD_ENV=production` together with a complete

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2428,7 +2428,10 @@ describe("supacloud-cli process contract", () => {
         expect(result.stdout + result.stderr).not.toContain("application-only-service-role");
     });
 
-    test("blocks Management-backed commands for pure application profiles before HTTP", async () => {
+    test.each([
+        ["project", "health"],
+        ["release", "logical_backup_create"],
+    ])("blocks %s %s for pure application profiles before HTTP", async (moduleName, action) => {
         let requestCount = 0;
         const server = Bun.serve({
             hostname: "127.0.0.1",
@@ -2440,7 +2443,7 @@ describe("supacloud-cli process contract", () => {
         });
         servers.push(server);
 
-        const result = await runProjectCli(["project", "health"], {
+        const result = await runProjectCli([moduleName, action], {
             SUPABASE_URL: `http://127.0.0.1:${server.port}`,
             SUPABASE_SERVICE_ROLE_KEY: "application-only-service-role",
             SUPACLOUD_PROJECT_REF: "abc123",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import { registerSupabaseCliTools } from "./shared/tools/supabase-cli-tools";
 import { registerAiTools } from "./shared/tools/ai-tools";
 import { registerScheduledFunctionTools } from "./shared/tools/scheduled-function-tools";
 import { registerMutationTools } from "./shared/tools/mutation-tools";
+import { registerReleaseTools } from "./shared/tools/release-tools";
 import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
@@ -282,6 +283,9 @@ EXAMPLES
   ${preferredCommand} project get
   ${preferredCommand} project logs --log_type database
   ${preferredCommand} project task_stats
+  ${preferredCommand} release logical_backup_create --ref abc123
+  ${preferredCommand} release postgrest_status --ref abc123
+  ${preferredCommand} release postgrest_restart --ref abc123
   ${preferredCommand} queue stats --queue emails
   ${preferredCommand} queue dlq --queue emails --limit 20
   ${preferredCommand} frontend list --ref abc123
@@ -381,7 +385,7 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
                 ],
             }),
         };
-        for (const name of ["database", "auth", "storage", "edge_functions", "secrets", "frontend", "queue", "task_events", "scheduled_functions", "mutations", "diagnostics", "gateway", "branch"]) {
+        for (const name of ["database", "auth", "storage", "edge_functions", "secrets", "frontend", "queue", "task_events", "scheduled_functions", "mutations", "diagnostics", "gateway", "branch", "release"]) {
             tools[name] = {
                 schema: { action: genericActionSchema },
                 callback: async () => ({
@@ -469,6 +473,9 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
         readOnly: context.readOnly,
     })));
     assign(captureTools((server) => registerMutationTools(server as any, http)));
+    assign(captureTools((server) => registerReleaseTools(server as any, http, {
+        projectRef: context.projectRef || undefined,
+    })));
     assign(captureTools((server) => registerFrontendTools(server as any, http)));
     assign(captureTools((server) => registerGatewayTools(server as any, http, {
         projectRef: context.projectRef || undefined,

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -147,6 +147,19 @@ describe("CLI execution policy", () => {
         }
     });
 
+    test("classifies verified release controls and protects their mutations", () => {
+        expect(executionMode("release", "logical_backup_list", {})).toBe("read");
+        expect(executionMode("release", "postgrest_status", {})).toBe("read");
+        expect(executionMode("release", "logical_backup_create", {})).toBe("write");
+        expect(executionMode("release", "postgrest_restart", {})).toBe("write");
+        expect(() => authorizeExecution("release", { action: "logical_backup_create" }, {
+            context: context(),
+        })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("release", { action: "postgrest_restart" }, {
+            context: context({ production: false, environment: "test", readOnly: true }),
+        })).toThrow("SUPACLOUD_READ_ONLY=true");
+    });
+
     test("allows migration previews and local authoring without production confirmation", () => {
         expect(executionMode("database", "migration_inventory", {})).toBe("read");
         expect(executionMode("database", "push_migrations", { dry_run: true })).toBe("read");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -38,6 +38,10 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     },
     scheduled_functions: { read: ["list", "get"], write: ["create", "update", "delete"] },
     mutations: { read: ["status"] },
+    release: {
+        read: ["logical_backup_list", "postgrest_status"],
+        write: ["logical_backup_create", "postgrest_restart"],
+    },
     secrets: { read: ["list"], write: ["upsert", "delete"] },
     frontend: {
         read: ["list", "get", "build_logs", "list_frameworks", "list_records"],

--- a/packages/cli/src/shared/tools/release-tools.test.ts
+++ b/packages/cli/src/shared/tools/release-tools.test.ts
@@ -1,0 +1,237 @@
+import { expect, test } from "bun:test";
+import { registerReleaseTools } from "./release-tools";
+
+const PROJECT_REF = "proj";
+const CREATED_AT = "2026-08-17T00:00:00.000Z";
+const COMPLETED_AT = "2026-08-17T00:00:01.000Z";
+const SHA256 = "a".repeat(64);
+const BACKUP_ID = `logical-full_${PROJECT_REF}_${"b".repeat(32)}`;
+
+type ToolResult = {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+};
+
+type ReleaseCallback = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function verifiedBackup(overrides: Record<string, unknown> = {}) {
+    return {
+        backup_id: BACKUP_ID,
+        project_ref: PROJECT_REF,
+        database: "private_database_name",
+        kind: "logical-full",
+        created_at: CREATED_AT,
+        completed_at: COMPLETED_AT,
+        bytes: 42,
+        sha256: SHA256,
+        receipt_hmac_sha256: "private-receipt-hmac",
+        archive_path: "/private/archive.dump",
+        ...overrides,
+    };
+}
+
+function healthyPostgrest(overrides: Record<string, unknown> = {}) {
+    return {
+        component: "postgrest",
+        desired: "running",
+        actual: "running",
+        health: "healthy",
+        unit: "private-unit-name",
+        port: 3000,
+        ...overrides,
+    };
+}
+
+function captureReleaseTool(http: Record<string, unknown>): ReleaseCallback {
+    let callback: ReleaseCallback | undefined;
+    registerReleaseTools({
+        tool(name, _description, _schema, toolCallback) {
+            if (name === "release") callback = toolCallback;
+        },
+    }, http as never, { projectRef: PROJECT_REF });
+    if (!callback) throw new Error("release tool was not registered");
+    return callback;
+}
+
+function payload(response: ToolResult): Record<string, unknown> {
+    return JSON.parse(response.content[0].text) as Record<string, unknown>;
+}
+
+test("logical backup list returns only the safe verified receipt projection", async () => {
+    const requests: Array<{ path: string; options: Record<string, unknown> }> = [];
+    const callback = captureReleaseTool({
+        get: async (path: string, options: Record<string, unknown>) => {
+            requests.push({ path, options });
+            return { ok: true, status: 200, data: { backups: [verifiedBackup()] } };
+        },
+    });
+
+    const response = await callback({ action: "logical_backup_list" });
+    const result = payload(response);
+
+    expect(requests).toEqual([{
+        path: "/v1/projects/proj/database/backups/logical",
+        options: { maxJsonBytes: 1024 * 1024, responseTimeoutMs: 5_000 },
+    }]);
+    expect(result).toMatchObject({
+        ok: true,
+        operation: "release.logical_backup.list",
+        project_ref: PROJECT_REF,
+        backups: [{ backup_id: BACKUP_ID, sha256: SHA256 }],
+    });
+    expect(response.content[0].text).not.toContain("private_database_name");
+    expect(response.content[0].text).not.toContain("private-receipt-hmac");
+    expect(response.content[0].text).not.toContain("/private/archive.dump");
+});
+
+test("logical backup create requires matching pre/post inventory evidence", async () => {
+    const requests: Array<{ method: "get" | "post"; path: string; options?: Record<string, unknown> }> = [];
+    let inventoryReads = 0;
+    const callback = captureReleaseTool({
+        get: async (path: string, options: Record<string, unknown>) => {
+            requests.push({ method: "get", path, options });
+            inventoryReads += 1;
+            return {
+                ok: true,
+                status: 200,
+                data: { backups: inventoryReads === 1 ? [] : [verifiedBackup()] },
+            };
+        },
+        postReleaseMutation: async (path: string, _body: unknown, options: Record<string, unknown>) => {
+            requests.push({ method: "post", path, options });
+            return { ok: true, status: 200, data: { backup: verifiedBackup() } };
+        },
+    });
+
+    const response = await callback({ action: "logical_backup_create" });
+    const result = payload(response);
+
+    expect(requests).toEqual([
+        {
+            method: "get",
+            path: "/v1/projects/proj/database/backups/logical",
+            options: { maxJsonBytes: 1024 * 1024, responseTimeoutMs: 5_000 },
+        },
+        {
+            method: "post",
+            path: "/v1/projects/proj/database/backups/logical",
+            options: { timeoutMs: 36 * 60_000 },
+        },
+        {
+            method: "get",
+            path: "/v1/projects/proj/database/backups/logical",
+            options: { maxJsonBytes: 1024 * 1024, responseTimeoutMs: 5_000 },
+        },
+    ]);
+    expect(result).toMatchObject({
+        ok: true,
+        operation: "release.logical_backup.create",
+        backup: { backup_id: BACKUP_ID, sha256: SHA256 },
+    });
+});
+
+test("logical backup create fails closed when post-mutation inventory is ambiguous", async () => {
+    const secondBackup = verifiedBackup({ backup_id: `logical-full_${PROJECT_REF}_${"c".repeat(32)}` });
+    let inventoryReads = 0;
+    const callback = captureReleaseTool({
+        get: async () => {
+            inventoryReads += 1;
+            return {
+                ok: true,
+                status: 200,
+                data: { backups: inventoryReads === 1 ? [] : [verifiedBackup(), secondBackup] },
+            };
+        },
+        postReleaseMutation: async () => ({ ok: true, status: 200, data: { backup: verifiedBackup() } }),
+    });
+
+    const response = await callback({ action: "logical_backup_create" });
+
+    expect(response.isError).toBe(true);
+    expect(payload(response)).toMatchObject({
+        ok: false,
+        operation: "release.logical_backup.create",
+        error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+    });
+    expect(response.content[0].text).not.toContain("private_database_name");
+});
+
+test("PostgREST status exposes only the desired, actual, and health fields", async () => {
+    const callback = captureReleaseTool({
+        get: async () => ({ ok: true, status: 200, data: healthyPostgrest() }),
+    });
+
+    const response = await callback({ action: "postgrest_status" });
+
+    expect(payload(response)).toMatchObject({
+        ok: true,
+        operation: "release.postgrest.status",
+        postgrest: { desired: "running", actual: "running", health: "healthy" },
+    });
+    expect(response.content[0].text).not.toContain("private-unit-name");
+    expect(response.content[0].text).not.toContain("3000");
+});
+
+test("PostgREST restart requires a matching receipt and healthy status readback", async () => {
+    const requests: Array<{ method: "get" | "post"; path: string }> = [];
+    const callback = captureReleaseTool({
+        postReleaseMutation: async (path: string) => {
+            requests.push({ method: "post", path });
+            return {
+                ok: true,
+                status: 200,
+                data: { service: "postgrest", action: "restart", success: true, private_receipt: "hidden" },
+            };
+        },
+        get: async (path: string) => {
+            requests.push({ method: "get", path });
+            return { ok: true, status: 200, data: healthyPostgrest() };
+        },
+    });
+
+    const response = await callback({ action: "postgrest_restart" });
+
+    expect(requests).toEqual([
+        { method: "post", path: "/v1/projects/proj/services/postgrest/restart" },
+        { method: "get", path: "/v1/projects/proj/services/postgrest/status" },
+    ]);
+    expect(payload(response)).toMatchObject({
+        ok: true,
+        operation: "release.postgrest.restart",
+        postgrest: { desired: "running", actual: "running", health: "healthy" },
+    });
+    expect(response.content[0].text).not.toContain("hidden");
+});
+
+test("PostgREST restart fails closed when the healthy readback is absent", async () => {
+    const callback = captureReleaseTool({
+        postReleaseMutation: async () => ({
+            ok: true,
+            status: 200,
+            data: { service: "postgrest", action: "restart", success: true },
+        }),
+        get: async () => ({ ok: true, status: 200, data: healthyPostgrest({ health: "unhealthy" }) }),
+    });
+
+    const response = await callback({ action: "postgrest_restart" });
+
+    expect(response.isError).toBe(true);
+    expect(payload(response)).toMatchObject({
+        ok: false,
+        operation: "release.postgrest.restart",
+        error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+    });
+});
+
+test("an unsupported release action cannot issue a mutation", async () => {
+    let postCalls = 0;
+    const callback = captureReleaseTool({
+        postReleaseMutation: async () => {
+            postCalls += 1;
+            return { ok: true, status: 200, data: {} };
+        },
+    });
+
+    await expect(callback({ action: "delete_everything" })).rejects.toThrow("Unknown release control action");
+    expect(postCalls).toBe(0);
+});

--- a/packages/cli/src/shared/tools/release-tools.ts
+++ b/packages/cli/src/shared/tools/release-tools.ts
@@ -1,0 +1,299 @@
+import { Type } from "@sinclair/typebox";
+import { optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+import type { HttpResult, HttpTransport } from "../transports/http";
+import { releaseControlFailure, releaseControlSuccess, type ReleaseControlToolResponse } from "./release-control-response";
+
+type ToolServer = {
+    tool: (
+        name: string,
+        description: string,
+        schema: ToolSchema,
+        callback: (args: Record<string, unknown>) => Promise<ReleaseControlToolResponse>,
+    ) => void;
+};
+
+type ReleaseOperation =
+    | "release.logical_backup.list"
+    | "release.logical_backup.create"
+    | "release.postgrest.status"
+    | "release.postgrest.restart";
+
+type VerifiedLogicalBackup = {
+    backup_id: string;
+    project_ref: string;
+    database: string;
+    kind: "logical-full";
+    created_at: string;
+    completed_at: string;
+    bytes: number;
+    sha256: string;
+};
+
+type ReleasePostgrestStatus = {
+    desired: "running" | "stopped";
+    actual: "running" | "stopped" | "starting" | "error";
+    health: "healthy" | "unhealthy" | "unknown";
+};
+
+const SAFE_PROJECT_REF = /^[A-Za-z0-9_-]{1,64}$/;
+const BACKUP_ID = /^logical-full_[A-Za-z0-9_-]{1,64}_[a-f0-9]{32}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+const SAFE_DATABASE = /^[^\u0000-\u001f\u007f]{1,128}$/;
+const INVENTORY_MAX_BYTES = 1024 * 1024;
+const MUTATION_MAX_BYTES = 64 * 1024;
+const BACKUP_TIMEOUT_MS = 36 * 60_000;
+const RELEASE_READ_RESPONSE_TIMEOUT_MS = 5_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+    if (typeof value !== "string") return false;
+    const parsed = new Date(value);
+    return Number.isFinite(parsed.valueOf()) && parsed.toISOString() === value;
+}
+
+function validProjectRef(ref: string): boolean {
+    return SAFE_PROJECT_REF.test(ref);
+}
+
+function backupBelongsToProject(backupId: string, projectRef: string): boolean {
+    return BACKUP_ID.test(backupId) && backupId.startsWith(`logical-full_${projectRef}_`);
+}
+
+function verifiedBackup(value: unknown, projectRef: string): VerifiedLogicalBackup | null {
+    if (!isRecord(value)
+        || typeof value.backup_id !== "string"
+        || !backupBelongsToProject(value.backup_id, projectRef)
+        || value.project_ref !== projectRef
+        || typeof value.database !== "string"
+        || !SAFE_DATABASE.test(value.database)
+        || value.kind !== "logical-full"
+        || !canonicalTimestamp(value.created_at)
+        || !canonicalTimestamp(value.completed_at)
+        || new Date(value.completed_at).valueOf() < new Date(value.created_at).valueOf()
+        || typeof value.bytes !== "number"
+        || !Number.isSafeInteger(value.bytes)
+        || value.bytes <= 0
+        || typeof value.sha256 !== "string"
+        || !SHA256.test(value.sha256)) return null;
+    return {
+        backup_id: value.backup_id,
+        project_ref: projectRef,
+        database: value.database,
+        kind: "logical-full",
+        created_at: value.created_at,
+        completed_at: value.completed_at,
+        bytes: value.bytes,
+        sha256: value.sha256,
+    };
+}
+
+function backupInventory(value: unknown, projectRef: string): VerifiedLogicalBackup[] | null {
+    if (!isRecord(value) || !Array.isArray(value.backups)) return null;
+    const backups = value.backups.map((backup) => verifiedBackup(backup, projectRef));
+    if (backups.some((backup) => backup === null)) return null;
+    const inventory = backups as VerifiedLogicalBackup[];
+    return new Set(inventory.map((backup) => backup.backup_id)).size === inventory.length
+        ? inventory
+        : null;
+}
+
+function publicBackup(backup: VerifiedLogicalBackup) {
+    return {
+        backup_id: backup.backup_id,
+        project_ref: backup.project_ref,
+        kind: backup.kind,
+        created_at: backup.created_at,
+        completed_at: backup.completed_at,
+        bytes: backup.bytes,
+        sha256: backup.sha256,
+    };
+}
+
+function equalBackup(left: VerifiedLogicalBackup, right: VerifiedLogicalBackup): boolean {
+    return left.backup_id === right.backup_id
+        && left.project_ref === right.project_ref
+        && left.database === right.database
+        && left.kind === right.kind
+        && left.created_at === right.created_at
+        && left.completed_at === right.completed_at
+        && left.bytes === right.bytes
+        && left.sha256 === right.sha256;
+}
+
+function newlyCreatedBackup(
+    before: readonly VerifiedLogicalBackup[],
+    after: readonly VerifiedLogicalBackup[],
+): VerifiedLogicalBackup | null {
+    const afterById = new Map(after.map((backup) => [backup.backup_id, backup]));
+    for (const previous of before) {
+        const current = afterById.get(previous.backup_id);
+        if (!current || !equalBackup(previous, current)) return null;
+    }
+    const known = new Set(before.map((backup) => backup.backup_id));
+    const additions = after.filter((backup) => !known.has(backup.backup_id));
+    return additions.length === 1 ? additions[0]! : null;
+}
+
+function endpoint(projectRef: string): string {
+    if (!validProjectRef(projectRef)) throw new Error("'ref' is invalid for release controls");
+    return `/v1/projects/${encodeURIComponent(projectRef)}`;
+}
+
+function httpFailure(operation: ReleaseOperation, response: HttpResult<unknown>): ReleaseControlToolResponse {
+    if (response.responseReadError) {
+        return releaseControlFailure(operation, "INVALID_RESPONSE", response.status);
+    }
+    return releaseControlFailure(operation, "HTTP_ERROR", response.transportError ? null : response.status);
+}
+
+function mutationFailure(operation: ReleaseOperation, response: HttpResult<unknown>): ReleaseControlToolResponse {
+    if (response.responseReadError || response.transportError || response.status === 408 || response.status >= 500) {
+        return releaseControlFailure(operation, "OUTCOME_UNKNOWN", response.transportError ? null : response.status);
+    }
+    return releaseControlFailure(operation, "HTTP_ERROR", response.status);
+}
+
+async function readInventory(
+    http: HttpTransport,
+    projectRef: string,
+): Promise<{ response: HttpResult<unknown>; inventory: VerifiedLogicalBackup[] | null }> {
+    const response = await http.get(`${endpoint(projectRef)}/database/backups/logical`, {
+        maxJsonBytes: INVENTORY_MAX_BYTES,
+        responseTimeoutMs: RELEASE_READ_RESPONSE_TIMEOUT_MS,
+    });
+    return { response, inventory: response.ok && response.status === 200 ? backupInventory(response.data, projectRef) : null };
+}
+
+function readInventoryFailure(
+    operation: ReleaseOperation,
+    read: { response: HttpResult<unknown>; inventory: VerifiedLogicalBackup[] | null },
+): ReleaseControlToolResponse | null {
+    if (!read.response.ok) return httpFailure(operation, read.response);
+    if (read.response.status !== 200 || !read.inventory) {
+        return releaseControlFailure(operation, "INVALID_RESPONSE", read.response.status);
+    }
+    return null;
+}
+
+function postgrestStatus(value: unknown): ReleasePostgrestStatus | null {
+    if (!isRecord(value)
+        || value.component !== "postgrest"
+        || !["running", "stopped"].includes(String(value.desired))
+        || !["running", "stopped", "starting", "error"].includes(String(value.actual))
+        || !["healthy", "unhealthy", "unknown"].includes(String(value.health))) return null;
+    return {
+        desired: value.desired as ReleasePostgrestStatus["desired"],
+        actual: value.actual as ReleasePostgrestStatus["actual"],
+        health: value.health as ReleasePostgrestStatus["health"],
+    };
+}
+
+async function readPostgrestStatus(
+    http: HttpTransport,
+    projectRef: string,
+): Promise<{ response: HttpResult<unknown>; status: ReleasePostgrestStatus | null }> {
+    const response = await http.get(`${endpoint(projectRef)}/services/postgrest/status`, {
+        maxJsonBytes: MUTATION_MAX_BYTES,
+        responseTimeoutMs: RELEASE_READ_RESPONSE_TIMEOUT_MS,
+    });
+    return { response, status: response.ok && response.status === 200 ? postgrestStatus(response.data) : null };
+}
+
+function readPostgrestFailure(
+    operation: ReleaseOperation,
+    read: { response: HttpResult<unknown>; status: ReleasePostgrestStatus | null },
+): ReleaseControlToolResponse | null {
+    if (!read.response.ok) return httpFailure(operation, read.response);
+    return read.response.status === 200 && read.status
+        ? null
+        : releaseControlFailure(operation, "INVALID_RESPONSE", read.response.status);
+}
+
+function isRestartReceipt(value: unknown): boolean {
+    return isRecord(value)
+        && value.service === "postgrest"
+        && value.action === "restart"
+        && value.success === true;
+}
+
+export function registerReleaseTools(
+    server: ToolServer,
+    http: HttpTransport,
+    options: { projectRef?: string } = {},
+): void {
+    server.tool(
+        "release",
+        "Verified release controls using a Management API credential. Actions: logical_backup_list, logical_backup_create, postgrest_status, postgrest_restart",
+        {
+            action: withDescription(stringEnum([
+                "logical_backup_list", "logical_backup_create", "postgrest_status", "postgrest_restart",
+            ]), "Release control action"),
+            ref: optional(Type.String(), options.projectRef ? "Optional override when not auto-linked" : "Project ref"),
+        },
+        async ({ action, ref }) => {
+            const projectRef = typeof ref === "string" && ref || options.projectRef;
+            if (!projectRef) throw new Error("'ref' is required for release controls");
+            if (!validProjectRef(projectRef)) throw new Error("'ref' is invalid for release controls");
+
+            if (action === "logical_backup_list") {
+                const read = await readInventory(http, projectRef);
+                const failure = readInventoryFailure("release.logical_backup.list", read);
+                return failure ?? releaseControlSuccess("release.logical_backup.list", {
+                    project_ref: projectRef,
+                    backups: read.inventory!.map(publicBackup),
+                });
+            }
+            if (action === "logical_backup_create") {
+                const before = await readInventory(http, projectRef);
+                const beforeFailure = readInventoryFailure("release.logical_backup.create", before);
+                if (beforeFailure) return beforeFailure;
+                const mutation = await http.postReleaseMutation(`${endpoint(projectRef)}/database/backups/logical`, {}, {
+                    timeoutMs: BACKUP_TIMEOUT_MS,
+                });
+                const after = await readInventory(http, projectRef);
+                if (!mutation.ok || mutation.status !== 200) {
+                    return mutationFailure("release.logical_backup.create", mutation);
+                }
+                const responseBackup = isRecord(mutation.data) ? verifiedBackup(mutation.data.backup, projectRef) : null;
+                const afterFailure = readInventoryFailure("release.logical_backup.create", after);
+                const addedBackup = after.inventory && newlyCreatedBackup(before.inventory!, after.inventory);
+                if (!responseBackup || afterFailure || !addedBackup || !equalBackup(responseBackup, addedBackup)) {
+                    return releaseControlFailure("release.logical_backup.create", "OUTCOME_UNKNOWN", mutation.status);
+                }
+                return releaseControlSuccess("release.logical_backup.create", {
+                    project_ref: projectRef,
+                    backup: publicBackup(addedBackup),
+                });
+            }
+            if (action === "postgrest_status") {
+                const read = await readPostgrestStatus(http, projectRef);
+                const failure = readPostgrestFailure("release.postgrest.status", read);
+                return failure ?? releaseControlSuccess("release.postgrest.status", {
+                    project_ref: projectRef,
+                    postgrest: read.status!,
+                });
+            }
+            if (action !== "postgrest_restart") throw new Error("Unknown release control action");
+            const mutation = await http.postReleaseMutation(`${endpoint(projectRef)}/services/postgrest/restart`);
+            const read = await readPostgrestStatus(http, projectRef);
+            if (!mutation.ok || mutation.status !== 200) {
+                return mutationFailure("release.postgrest.restart", mutation);
+            }
+            const readFailure = readPostgrestFailure("release.postgrest.restart", read);
+            if (!isRestartReceipt(mutation.data) || readFailure
+                || read.status!.desired !== "running"
+                || read.status!.actual !== "running"
+                || read.status!.health !== "healthy") {
+                return releaseControlFailure("release.postgrest.restart", "OUTCOME_UNKNOWN", mutation.status);
+            }
+            return releaseControlSuccess("release.postgrest.restart", {
+                project_ref: projectRef,
+                postgrest: read.status,
+            });
+        },
+    );
+}

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -275,6 +275,33 @@ describe("HttpTransport retry policy", () => {
         });
         expect(fetchCalls).toBe(0);
     });
+
+    test.each([0, 36 * 60_000 + 1, 1.5])("rejects invalid bounded POST timeout %s before dispatch", async timeoutMs => {
+        let fetchCalls = 0;
+        globalThis.fetch = (async () => {
+            fetchCalls += 1;
+            return Response.json({ ok: true });
+        }) as unknown as typeof fetch;
+
+        await expect(createTransport().post("/resource", {}, { timeoutMs })).rejects.toThrow(
+            "HTTP request timeout must be between",
+        );
+        expect(fetchCalls).toBe(0);
+    });
+
+    test("uses an explicit ordinary POST header timeout", async () => {
+        const scheduledDelays: number[] = [];
+        globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number) => {
+            scheduledDelays.push(delay ?? 0);
+            return ++nextTimerId as unknown as ReturnType<typeof setTimeout>;
+        }) as typeof setTimeout;
+        globalThis.fetch = (async () => Response.json({ ok: true })) as unknown as typeof fetch;
+
+        const response = await createTransport().post("/resource", {}, { timeoutMs: 120_000 });
+
+        expect(response).toEqual({ ok: true, status: 200, data: { ok: true } });
+        expect(scheduledDelays).toEqual([120_000]);
+    });
 });
 
 describe("HttpTransport bounded GET responses", () => {
@@ -355,9 +382,66 @@ describe("HttpTransport bounded GET responses", () => {
 
         expect(response).toMatchObject({ ok: true, status: 200, data: null });
     });
+
+    test("times out an explicitly bounded GET body after headers", async () => {
+        globalThis.setTimeout = originalSetTimeout;
+        globalThis.clearTimeout = originalClearTimeout;
+        const secretSentinel = "private-stalled-get-response";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => new Response(new ReadableStream<Uint8Array>({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode(`{\"token\":\"${secretSentinel}`));
+                },
+            }), { headers: { "Content-Type": "application/json" } }),
+        });
+        servers.push(server);
+        const transport = new HttpTransport({
+            baseUrl: `http://127.0.0.1:${server.port}`,
+            token: "test-token",
+        });
+        const startedAt = Date.now();
+
+        const response = await transport.get("/resource", {
+            maxJsonBytes: 64 * 1024,
+            responseTimeoutMs: 10,
+        });
+
+        expect(Date.now() - startedAt).toBeLessThan(1_000);
+        expect(response).toMatchObject({ ok: false, status: 200, responseReadError: true });
+        expect(JSON.stringify(response)).not.toContain(secretSentinel);
+    });
 });
 
 describe("HttpTransport release mutation response boundary", () => {
+    test("keeps a long release header timeout separate from the body deadline", async () => {
+        const scheduledDelays: number[] = [];
+        globalThis.setTimeout = ((callback: (...args: unknown[]) => void, delay?: number) => {
+            scheduledDelays.push(delay ?? 0);
+            return ++nextTimerId as unknown as ReturnType<typeof setTimeout>;
+        }) as typeof setTimeout;
+        globalThis.fetch = (async () => Response.json({ success: true })) as unknown as typeof fetch;
+
+        const response = await createTransport().postReleaseMutation("/resource", {}, {
+            timeoutMs: 36 * 60_000,
+        });
+
+        expect(response).toEqual({ ok: true, status: 200, data: { success: true } });
+        expect(scheduledDelays).toEqual([36 * 60_000, 5_000]);
+    });
+
+    test("bounds an explicitly selected POST JSON response", async () => {
+        const secretSentinel = "private-bounded-post-response";
+        const body = JSON.stringify({ token: secretSentinel.repeat(64) });
+        globalThis.fetch = (async () => chunkedTextResponse(body, {}, 1024)) as unknown as typeof fetch;
+
+        const response = await createTransport().post("/resource", {}, { maxJsonBytes: 64 });
+
+        expect(response).toMatchObject({ ok: false, status: 200, responseReadError: true });
+        expect(JSON.stringify(response)).not.toContain(secretSentinel);
+    });
+
     test.each([
         ["POST", (transport: HttpTransport) => transport.postReleaseMutation("/resource", { expected: "1" })],
         ["PATCH", (transport: HttpTransport) => transport.patchReleaseMutation("/resource", { expected: "1" })],

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -20,9 +20,21 @@ export interface HttpResult<T = unknown> {
 
 export interface HttpGetOptions {
     maxResponseBytes?: number;
+    maxJsonBytes?: number;
+    responseTimeoutMs?: number;
+}
+
+export interface HttpPostOptions {
+    timeoutMs?: number;
+    maxJsonBytes?: number;
+}
+
+export interface HttpReleaseMutationOptions {
+    timeoutMs?: number;
 }
 
 const DEFAULT_TIMEOUT = 30_000;
+const MAX_POST_TIMEOUT_MS = 36 * 60_000;
 const RELEASE_MUTATION_RESPONSE_TIMEOUT = 5_000;
 const RELEASE_MUTATION_RESPONSE_MAX_BYTES = 64 * 1024;
 const MAX_RETRIES = 2;
@@ -35,6 +47,30 @@ function validatedGetResponseLimit(options: HttpGetOptions): number | undefined 
         throw new RangeError("HTTP response limit must be a positive safe integer");
     }
     return maxBytes;
+}
+
+function validatedJsonResponseLimit(maxBytes: number | undefined): number | undefined {
+    if (maxBytes === undefined) return undefined;
+    if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+        throw new RangeError("HTTP JSON response limit must be a positive safe integer");
+    }
+    return maxBytes;
+}
+
+function validatedPostTimeout(options?: HttpPostOptions): number {
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_POST_TIMEOUT_MS) {
+        throw new RangeError(`HTTP request timeout must be between 1 and ${MAX_POST_TIMEOUT_MS} ms`);
+    }
+    return timeoutMs;
+}
+
+function validatedResponseTimeout(timeoutMs: number | undefined): number | undefined {
+    if (timeoutMs === undefined) return undefined;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_POST_TIMEOUT_MS) {
+        throw new RangeError(`HTTP response timeout must be between 1 and ${MAX_POST_TIMEOUT_MS} ms`);
+    }
+    return timeoutMs;
 }
 
 type ResponseBytesRead =
@@ -80,9 +116,13 @@ function responseReadFailure<T>(status: number): HttpResult<T> {
     };
 }
 
-async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+async function fetchWithTimeout(
+    url: string,
+    options: RequestInit,
+    timeoutMs = DEFAULT_TIMEOUT,
+): Promise<Response> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
         return await fetch(url, {
             ...options,
@@ -97,11 +137,12 @@ async function fetchWithTimeout(url: string, options: RequestInit): Promise<Resp
 async function fetchWithRetry(
     url: string,
     options: RequestInit,
+    timeoutMs = DEFAULT_TIMEOUT,
 ): Promise<Response> {
     const retries = isRetryableMethod(options.method) ? MAX_RETRIES : 0;
     for (let attempt = 0; attempt <= retries; attempt++) {
         try {
-            const res = await fetchWithTimeout(url, options);
+            const res = await fetchWithTimeout(url, options, timeoutMs);
 
             if (res.status >= 500 && res.status < 600 && attempt < retries) {
                 const delay = RETRY_BASE_DELAY * Math.pow(2, attempt);
@@ -167,14 +208,20 @@ async function responseBytesFromReader(
     }
 }
 
-async function responseBytesWithinLimit(response: Response, maxBytes: number): Promise<Uint8Array | null> {
+async function responseBytesWithinLimit(
+    response: Response,
+    maxBytes: number,
+    responseTimeoutMs?: number,
+): Promise<Uint8Array | null> {
     if (declaredResponseTooLarge(response, maxBytes)) {
         await response.body?.cancel();
         return null;
     }
     if (!response.body) return new Uint8Array();
     const reader = response.body.getReader();
-    const bodyRead = await responseBytesFromReader(reader, maxBytes, null);
+    const bodyRead = responseTimeoutMs === undefined
+        ? await responseBytesFromReader(reader, maxBytes, null)
+        : await responseBytesBeforeDeadline(reader, maxBytes, null, responseTimeoutMs);
     return bodyRead.ok ? bodyRead.bytes : null;
 }
 
@@ -188,8 +235,12 @@ function parsedUtf8Json(responseBytes: Uint8Array): ResponseJsonRead {
     }
 }
 
-async function boundedResponseJson(response: Response, maxBytes: number): Promise<unknown> {
-    const responseBytes = await responseBytesWithinLimit(response, maxBytes);
+async function boundedResponseJson(
+    response: Response,
+    maxBytes: number,
+    responseTimeoutMs?: number,
+): Promise<unknown> {
+    const responseBytes = await responseBytesWithinLimit(response, maxBytes, responseTimeoutMs);
     if (responseBytes === null) return null;
     const parsed = parsedUtf8Json(responseBytes);
     return parsed.ok ? parsed.parsedJson : null;
@@ -217,23 +268,30 @@ async function releaseMutationResponseBytes(response: Response): Promise<Respons
             ? { ok: true, bytes: new Uint8Array() }
             : { ok: false };
     }
-    return responseBytesBeforeDeadline(response.body.getReader(), declaredBytes);
+    return responseBytesBeforeDeadline(
+        response.body.getReader(),
+        RELEASE_MUTATION_RESPONSE_MAX_BYTES,
+        declaredBytes,
+        RELEASE_MUTATION_RESPONSE_TIMEOUT,
+    );
 }
 
 async function responseBytesBeforeDeadline(
     reader: ReadableStreamDefaultReader<Uint8Array>,
+    maxBytes: number,
     declaredBytes: number | null,
+    responseTimeoutMs: number,
 ): Promise<ResponseBytesRead> {
     let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
     const deadline = new Promise<ResponseBytesRead>((resolve) => {
         deadlineTimer = setTimeout(() => {
             cancelResponseReader(reader);
             resolve({ ok: false });
-        }, RELEASE_MUTATION_RESPONSE_TIMEOUT);
+        }, responseTimeoutMs);
     });
     try {
         return await Promise.race([
-            responseBytesFromReader(reader, RELEASE_MUTATION_RESPONSE_MAX_BYTES, declaredBytes),
+            responseBytesFromReader(reader, maxBytes, declaredBytes),
             deadline,
         ]);
     } catch {
@@ -277,13 +335,14 @@ export class HttpTransport {
         path: string,
         serializedBody: string | undefined,
         responseReader: (response: Response) => Promise<ResponseJsonRead<T>>,
+        timeoutMs = DEFAULT_TIMEOUT,
     ): Promise<HttpResult<T>> {
         try {
             const response = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method,
                 headers: this.headers(),
                 body: serializedBody,
-            });
+            }, timeoutMs);
             const responseBody = await responseReader(response);
             return responseBody.ok
                 ? { ok: response.ok, status: response.status, data: responseBody.parsedJson }
@@ -295,11 +354,22 @@ export class HttpTransport {
 
     async get<T = unknown>(path: string, options: HttpGetOptions = {}): Promise<HttpResult<T>> {
         const maxResponseBytes = validatedGetResponseLimit(options);
+        const maxJsonBytes = validatedJsonResponseLimit(options.maxJsonBytes);
+        const responseTimeoutMs = validatedResponseTimeout(options.responseTimeoutMs);
+        if (maxResponseBytes !== undefined && maxJsonBytes !== undefined) {
+            throw new RangeError("HTTP response limit options are mutually exclusive");
+        }
         try {
             const res = await fetchWithRetry(`${this.baseUrl}${path}`, {
                 method: "GET",
                 headers: this.headers(),
             });
+            if (maxJsonBytes !== undefined) {
+                const data = await boundedResponseJson(res, maxJsonBytes, responseTimeoutMs);
+                return data === null
+                    ? responseReadFailure<T>(res.status)
+                    : { ok: res.ok, status: res.status, data: data as T };
+            }
             const data = (maxResponseBytes === undefined
                 ? await res.json().catch(() => null)
                 : await boundedResponseJson(res, maxResponseBytes)) as T;
@@ -309,25 +379,45 @@ export class HttpTransport {
         }
     }
 
-    async post<T = unknown>(path: string, body?: unknown): Promise<HttpResult<T>> {
+    async post<T = unknown>(path: string, body?: unknown, options?: HttpPostOptions): Promise<HttpResult<T>> {
+        const timeoutMs = validatedPostTimeout(options);
+        const maxJsonBytes = validatedJsonResponseLimit(options?.maxJsonBytes);
         try {
-            return await this.mutationWithResponseReader(
-                "POST",
-                path,
-                serializedRequestBody(body),
-                responseJsonOrNull<T>,
-            );
+            if (maxJsonBytes === undefined) {
+                return await this.mutationWithResponseReader(
+                    "POST",
+                    path,
+                    serializedRequestBody(body),
+                    responseJsonOrNull<T>,
+                    timeoutMs,
+                );
+            }
+            const response = await fetchWithRetry(`${this.baseUrl}${path}`, {
+                method: "POST",
+                headers: this.headers(),
+                body: serializedRequestBody(body),
+            }, timeoutMs);
+            const data = await boundedResponseJson(response, maxJsonBytes);
+            return data === null
+                ? responseReadFailure<T>(response.status)
+                : { ok: response.ok, status: response.status, data: data as T };
         } catch (error: unknown) {
             return transportFailure<T>(error);
         }
     }
 
-    async postReleaseMutation<T = unknown>(path: string, body?: unknown): Promise<HttpResult<T>> {
+    async postReleaseMutation<T = unknown>(
+        path: string,
+        body?: unknown,
+        options?: HttpReleaseMutationOptions,
+    ): Promise<HttpResult<T>> {
+        const timeoutMs = validatedPostTimeout(options);
         return this.mutationWithResponseReader(
             "POST",
             path,
             serializedRequestBody(body),
             releaseMutationResponseJson<T>,
+            timeoutMs,
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds the official `release` CLI group for verified logical-backup list/create and PostgREST status/restart.
- Uses only the existing Management API credential context; application `service_role` remains unable to invoke these controls.
- Verifies backup inventory before and after creation, and requires a healthy PostgREST readback after restart.
- Bounds responses and fails closed when a response body stalls, is oversized, malformed, or cannot prove the outcome.

## Scope
- Reuses the existing platform capabilities delivered by #879, #885, #886, #919, and #923.
- Does not change service-role privileges, expose restore, deploy any server, or create the FA non-human canary fixture.

## Verification
- `cd packages/cli && bun test` (763 pass)
- `cd packages/cli && bun run typecheck`
- `cd packages/cli && bun run build`
- `git diff --check`
- Independent read-only review: PASS