### PR TITLE
feat(cli): add verified logical backup restore

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -111,18 +111,32 @@ loopback development origins, with the default `:80` likewise omitted. Use
 `release` is an official CLI entry point for the existing Management API
 logical-backup and PostgREST lifecycle capabilities. It requires the Management
 API context above; it does not promote an application `service_role` key to
-Management authority. Restore remains an admin-only operation and is not
-exposed by this command group.
+Management authority.
 
 ```bash
 supacloud-cli release logical_backup_list --ref abc123
 supacloud-cli release logical_backup_create --ref abc123
+supacloud-cli release logical_backup_restore --ref abc123 \
+  --backup_id logical-full_abc123_<backup-id-suffix> \
+  --expected_sha256 <64-lowercase-hex> \
+  --restore_confirmation RESTORE_PROJECT:abc123:logical-full_abc123_<backup-id-suffix>:<64-lowercase-hex>
 supacloud-cli release postgrest_status --ref abc123
 supacloud-cli release postgrest_restart --ref abc123
 ```
 
 Backup creation reports success only after the CLI verifies exactly one new
 logical-backup receipt against the inventory before and after the mutation.
+Logical restore is project-scoped: pause the selected project first, obtain the
+backup ID and SHA-256 from `logical_backup_list`, and supply both the normal
+production `--confirm-production <ref>` value (for production profiles) and
+the exact `--restore_confirmation
+RESTORE_PROJECT:<ref>:<backup_id>:<sha256>`. Before POST, the CLI re-reads
+that same project's inventory and binds the request to the complete verified
+backup identity; it then verifies both the server receipt and a fresh inventory
+read. It never retries a restore. A transport, server, or unreadable-response
+failure is reported as `OUTCOME_UNKNOWN`; read the inventory and investigate
+before any new restore decision.
+
 PostgREST restart reports success only after it receives a matching restart
 receipt and reads back `desired=running`, `actual=running`, and
 `health=healthy`. Both mutating controls follow the normal production

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -33,6 +33,8 @@ const SCHEDULE_UPDATED_AT = "2026-08-11T00:00:00.000Z";
 const EXPECTED_ACTIVATION_ID = "a1111111-1111-4111-8111-111111111111";
 const COMMITTED_ACTIVATION_ID = "b2222222-2222-4222-8222-222222222222";
 const RECREATED_ACTIVATION_ID = "c3333333-3333-4333-8333-333333333333";
+const LOGICAL_BACKUP_ID = "logical-full_abc123_0123456789abcdef0123456789abcdef";
+const LOGICAL_BACKUP_SHA256 = "a".repeat(64);
 const PATH_ESCAPE_INPUTS = [
     ".", "..", "%2e", "%2e%2e", ".%2e", "%2e.", "%252e%252e", "a/b", "a?b", "a#b",
 ];
@@ -111,6 +113,30 @@ function chunkedJsonResponse(body: string): Response {
         },
     });
     return new Response(stream, { headers: { "Content-Type": "application/json" } });
+}
+
+function logicalBackup(overrides: Record<string, unknown> = {}) {
+    return {
+        backup_id: LOGICAL_BACKUP_ID,
+        project_ref: "abc123",
+        database: "postgres",
+        kind: "logical-full",
+        created_at: "2026-08-17T12:00:00.000Z",
+        completed_at: "2026-08-17T12:01:00.000Z",
+        bytes: 128,
+        sha256: LOGICAL_BACKUP_SHA256,
+        ...overrides,
+    };
+}
+
+function logicalBackupRestoreArguments(overrides: Record<string, string> = {}): string[] {
+    const confirmation = `RESTORE_PROJECT:abc123:${LOGICAL_BACKUP_ID}:${LOGICAL_BACKUP_SHA256}`;
+    return [
+        "release", "logical_backup_restore", "--ref", "abc123",
+        "--backup_id", overrides.backup_id ?? LOGICAL_BACKUP_ID,
+        "--expected_sha256", overrides.expected_sha256 ?? LOGICAL_BACKUP_SHA256,
+        "--restore_confirmation", overrides.restore_confirmation ?? confirmation,
+    ];
 }
 
 describe("supacloud-cli process contract", () => {
@@ -2130,6 +2156,275 @@ describe("supacloud-cli process contract", () => {
         });
         expect(requestedBody).toContain(configSecret);
         expect(response.stdout + response.stderr).not.toContain(configSecret);
+    });
+
+    test("restores only the exact inventory-bound logical backup through the release CLI", async () => {
+        const requests: Array<{ method: string; path: string; body: unknown; authorization: string | null }> = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const url = new URL(request.url);
+                requests.push({
+                    method: request.method,
+                    path: url.pathname,
+                    body: request.method === "POST" ? await request.json() : null,
+                    authorization: request.headers.get("authorization"),
+                });
+                if (request.method === "GET") return Response.json({ backups: [logicalBackup()] });
+                return Response.json({ restored_backup: logicalBackup(), server_only: "do-not-echo" });
+            },
+        });
+        servers.push(server);
+        const apiToken = "release-management-token";
+
+        const result = await runProjectCli(logicalBackupRestoreArguments(), {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: apiToken,
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "release.logical_backup.restore",
+            project_ref: "abc123",
+            backup: {
+                backup_id: LOGICAL_BACKUP_ID,
+                project_ref: "abc123",
+                kind: "logical-full",
+                created_at: "2026-08-17T12:00:00.000Z",
+                completed_at: "2026-08-17T12:01:00.000Z",
+                bytes: 128,
+                sha256: LOGICAL_BACKUP_SHA256,
+            },
+        });
+        expect(requests).toEqual([
+            { method: "GET", path: "/v1/projects/abc123/database/backups/logical", body: null, authorization: `Bearer ${apiToken}` },
+            {
+                method: "POST",
+                path: "/v1/projects/abc123/database/backups/logical/restore",
+                body: {
+                    backup_id: LOGICAL_BACKUP_ID,
+                    expected_sha256: LOGICAL_BACKUP_SHA256,
+                    confirmation: `RESTORE_PROJECT:abc123:${LOGICAL_BACKUP_ID}:${LOGICAL_BACKUP_SHA256}`,
+                },
+                authorization: `Bearer ${apiToken}`,
+            },
+            { method: "GET", path: "/v1/projects/abc123/database/backups/logical", body: null, authorization: `Bearer ${apiToken}` },
+        ]);
+        expect(result.stdout + result.stderr).not.toContain(apiToken);
+        expect(result.stdout + result.stderr).not.toContain("do-not-echo");
+    });
+
+    test.each([
+        ["missing backup ID", [
+            "release", "logical_backup_restore", "--ref", "abc123",
+            "--expected_sha256", LOGICAL_BACKUP_SHA256,
+            "--restore_confirmation", `RESTORE_PROJECT:abc123:${LOGICAL_BACKUP_ID}:${LOGICAL_BACKUP_SHA256}`,
+        ]],
+        ["wrong-project backup ID", logicalBackupRestoreArguments({
+            backup_id: "logical-full_other_0123456789abcdef0123456789abcdef",
+        })],
+        ["malformed SHA-256", logicalBackupRestoreArguments({ expected_sha256: "private-invalid-digest" })],
+        ["mismatched restore confirmation", logicalBackupRestoreArguments({
+            restore_confirmation: "private-invalid-confirmation",
+        })],
+    ])("rejects logical restore %s before inventory or mutation HTTP", async (_label, args) => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({ unexpected: true });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(args, {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "release-management-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(requestCount).toBe(0);
+        expect(result.stdout + result.stderr).not.toContain("release-management-token");
+        expect(result.stdout + result.stderr).not.toContain("private-invalid-digest");
+        expect(result.stdout + result.stderr).not.toContain("private-invalid-confirmation");
+    });
+
+    test("rejects a valid-looking logical backup that is absent from the selected project inventory", async () => {
+        let postCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                if (request.method === "POST") postCount += 1;
+                return Response.json({ backups: [logicalBackup({ sha256: "b".repeat(64) })] });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(logicalBackupRestoreArguments(), {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "release-management-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "release.logical_backup.restore",
+            error: { code: "MUTATION_NOT_SUCCEEDED", http_status: null },
+        });
+        expect(postCount).toBe(0);
+    });
+
+    test("rejects malformed or cross-project logical inventory before restore HTTP", async () => {
+        let postCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                if (request.method === "POST") postCount += 1;
+                return Response.json({
+                    backups: [logicalBackup({
+                        backup_id: "logical-full_other_0123456789abcdef0123456789abcdef",
+                    })],
+                });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(logicalBackupRestoreArguments(), {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "release-management-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "release.logical_backup.restore",
+            error: { code: "INVALID_RESPONSE", http_status: 200 },
+        });
+        expect(postCount).toBe(0);
+    });
+
+    test.each([
+        ["a response identity mismatch", logicalBackup({ sha256: "b".repeat(64) }), logicalBackup()],
+        ["a post-restore inventory identity drift", logicalBackup(), logicalBackup({ sha256: "b".repeat(64) })],
+    ])("reports OUTCOME_UNKNOWN for logical restore with %s", async (_label, restoredBackup, postRestoreBackup) => {
+        let inventoryReads = 0;
+        let postCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                if (request.method === "POST") {
+                    postCount += 1;
+                    return Response.json({ restored_backup: restoredBackup, private_server_body: "do-not-echo" });
+                }
+                inventoryReads += 1;
+                return Response.json({ backups: [inventoryReads === 1 ? logicalBackup() : postRestoreBackup] });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(logicalBackupRestoreArguments(), {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "release-management-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "release.logical_backup.restore",
+            error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+        });
+        expect([inventoryReads, postCount]).toEqual([2, 1]);
+        expect(result.stdout + result.stderr).not.toContain("do-not-echo");
+    });
+
+    test.each([
+        [409, "HTTP_ERROR"],
+        [503, "OUTCOME_UNKNOWN"],
+    ] as const)("returns the safe logical restore result for a mutation HTTP %d", async (status, code) => {
+        let inventoryReads = 0;
+        let postCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                if (request.method === "POST") {
+                    postCount += 1;
+                    return Response.json({ private_server_body: "do-not-echo" }, { status });
+                }
+                inventoryReads += 1;
+                return Response.json({ backups: [logicalBackup()] });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(logicalBackupRestoreArguments(), {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "release-management-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "release.logical_backup.restore",
+            error: { code, http_status: status },
+        });
+        expect([inventoryReads, postCount]).toEqual([1, 1]);
+        expect(result.stdout + result.stderr).not.toContain("do-not-echo");
+    });
+
+    test("treats an unreadable logical restore response as unknown without retrying", async () => {
+        let inventoryReads = 0;
+        let postCount = 0;
+        const responseSecret = "private-unreadable-restore-response";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                if (request.method === "POST") {
+                    postCount += 1;
+                    return new Response(`{\"private_server_body\":\"${responseSecret}`, {
+                        headers: { "Content-Type": "application/json" },
+                    });
+                }
+                inventoryReads += 1;
+                return Response.json({ backups: [logicalBackup()] });
+            },
+        });
+        servers.push(server);
+
+        const result = await runProjectCli(logicalBackupRestoreArguments(), {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "release-management-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: false,
+            operation: "release.logical_backup.restore",
+            error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+        });
+        expect([inventoryReads, postCount]).toEqual([1, 1]);
+        expect(result.stdout + result.stderr).not.toContain(responseSecret);
     });
 
     test("status reports missing configuration and exits non-zero", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -284,6 +284,7 @@ EXAMPLES
   ${preferredCommand} project logs --log_type database
   ${preferredCommand} project task_stats
   ${preferredCommand} release logical_backup_create --ref abc123
+  ${preferredCommand} release logical_backup_restore --ref abc123 --backup_id <backup_id> --expected_sha256 <sha256> --restore_confirmation RESTORE_PROJECT:abc123:<backup_id>:<sha256>
   ${preferredCommand} release postgrest_status --ref abc123
   ${preferredCommand} release postgrest_restart --ref abc123
   ${preferredCommand} queue stats --queue emails

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -151,11 +151,19 @@ describe("CLI execution policy", () => {
         expect(executionMode("release", "logical_backup_list", {})).toBe("read");
         expect(executionMode("release", "postgrest_status", {})).toBe("read");
         expect(executionMode("release", "logical_backup_create", {})).toBe("write");
+        expect(executionMode("release", "logical_backup_restore", {})).toBe("write");
         expect(executionMode("release", "postgrest_restart", {})).toBe("write");
         expect(() => authorizeExecution("release", { action: "logical_backup_create" }, {
             context: context(),
         })).toThrow("--confirm-production prod-ref");
         expect(() => authorizeExecution("release", { action: "postgrest_restart" }, {
+            context: context({ production: false, environment: "test", readOnly: true }),
+        })).toThrow("SUPACLOUD_READ_ONLY=true");
+        expect(() => authorizeExecution("release", { action: "logical_backup_restore", ref: "other-ref" }, {
+            context: context(),
+            confirmProduction: "other-ref",
+        })).toThrow("cannot target a different project");
+        expect(() => authorizeExecution("release", { action: "logical_backup_restore" }, {
             context: context({ production: false, environment: "test", readOnly: true }),
         })).toThrow("SUPACLOUD_READ_ONLY=true");
     });

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -40,7 +40,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     mutations: { read: ["status"] },
     release: {
         read: ["logical_backup_list", "postgrest_status"],
-        write: ["logical_backup_create", "postgrest_restart"],
+        write: ["logical_backup_create", "logical_backup_restore", "postgrest_restart"],
     },
     secrets: { read: ["list"], write: ["upsert", "delete"] },
     frontend: {

--- a/packages/cli/src/shared/tools/release-tools.test.ts
+++ b/packages/cli/src/shared/tools/release-tools.test.ts
@@ -156,6 +156,106 @@ test("logical backup create fails closed when post-mutation inventory is ambiguo
     expect(response.content[0].text).not.toContain("private_database_name");
 });
 
+test("logical backup restore binds the exact inventory identity before and after one mutation", async () => {
+    const confirmation = `RESTORE_PROJECT:${PROJECT_REF}:${BACKUP_ID}:${SHA256}`;
+    const requests: Array<{ method: "get" | "post"; path: string; body?: unknown }> = [];
+    let inventoryReads = 0;
+    const callback = captureReleaseTool({
+        get: async (path: string) => {
+            requests.push({ method: "get", path });
+            inventoryReads += 1;
+            return { ok: true, status: 200, data: { backups: [verifiedBackup()] } };
+        },
+        postReleaseMutation: async (path: string, body: unknown) => {
+            requests.push({ method: "post", path, body });
+            return { ok: true, status: 200, data: { restored_backup: verifiedBackup() } };
+        },
+    });
+
+    const response = await callback({
+        action: "logical_backup_restore",
+        backup_id: BACKUP_ID,
+        expected_sha256: SHA256,
+        restore_confirmation: confirmation,
+    });
+
+    expect(requests).toEqual([
+        { method: "get", path: "/v1/projects/proj/database/backups/logical" },
+        {
+            method: "post",
+            path: "/v1/projects/proj/database/backups/logical/restore",
+            body: { backup_id: BACKUP_ID, expected_sha256: SHA256, confirmation },
+        },
+        { method: "get", path: "/v1/projects/proj/database/backups/logical" },
+    ]);
+    expect(inventoryReads).toBe(2);
+    expect(payload(response)).toMatchObject({
+        ok: true,
+        operation: "release.logical_backup.restore",
+        backup: { backup_id: BACKUP_ID, sha256: SHA256 },
+    });
+    expect(response.content[0].text).not.toContain("private_database_name");
+    expect(response.content[0].text).not.toContain("private-receipt-hmac");
+});
+
+test.each([
+    ["transport failure", { ok: false, status: 500, data: {}, transportError: true }, null],
+    ["unreadable response", { ok: false, status: 200, data: {}, responseReadError: true }, 200],
+    ["server failure", { ok: false, status: 503, data: {} }, 503],
+] as const)("logical backup restore has no retry after a %s", async (_label, mutation, expectedStatus) => {
+    let postCalls = 0;
+    const callback = captureReleaseTool({
+        get: async () => ({ ok: true, status: 200, data: { backups: [verifiedBackup()] } }),
+        postReleaseMutation: async () => {
+            postCalls += 1;
+            return mutation;
+        },
+    });
+
+    const response = await callback({
+        action: "logical_backup_restore",
+        backup_id: BACKUP_ID,
+        expected_sha256: SHA256,
+        restore_confirmation: `RESTORE_PROJECT:${PROJECT_REF}:${BACKUP_ID}:${SHA256}`,
+    });
+
+    expect(postCalls).toBe(1);
+    expect(payload(response)).toMatchObject({
+        ok: false,
+        operation: "release.logical_backup.restore",
+        error: { code: "OUTCOME_UNKNOWN", http_status: expectedStatus },
+    });
+});
+
+test("logical backup restore reports an unknown outcome when post-restore inventory is invalid", async () => {
+    let inventoryReads = 0;
+    const callback = captureReleaseTool({
+        get: async () => {
+            inventoryReads += 1;
+            return {
+                ok: true,
+                status: 200,
+                data: inventoryReads === 1 ? { backups: [verifiedBackup()] } : { backups: [] },
+            };
+        },
+        postReleaseMutation: async () => ({ ok: true, status: 200, data: { restored_backup: verifiedBackup() } }),
+    });
+
+    const response = await callback({
+        action: "logical_backup_restore",
+        backup_id: BACKUP_ID,
+        expected_sha256: SHA256,
+        restore_confirmation: `RESTORE_PROJECT:${PROJECT_REF}:${BACKUP_ID}:${SHA256}`,
+    });
+
+    expect(inventoryReads).toBe(2);
+    expect(payload(response)).toMatchObject({
+        ok: false,
+        operation: "release.logical_backup.restore",
+        error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+    });
+});
+
 test("PostgREST status exposes only the desired, actual, and health fields", async () => {
     const callback = captureReleaseTool({
         get: async () => ({ ok: true, status: 200, data: healthyPostgrest() }),

--- a/packages/cli/src/shared/tools/release-tools.ts
+++ b/packages/cli/src/shared/tools/release-tools.ts
@@ -16,6 +16,7 @@ type ToolServer = {
 type ReleaseOperation =
     | "release.logical_backup.list"
     | "release.logical_backup.create"
+    | "release.logical_backup.restore"
     | "release.postgrest.status"
     | "release.postgrest.restart";
 
@@ -138,6 +139,25 @@ function newlyCreatedBackup(
     return additions.length === 1 ? additions[0]! : null;
 }
 
+function restoreRequest(
+    projectRef: string,
+    backupId: unknown,
+    expectedSha256: unknown,
+    restoreConfirmation: unknown,
+): { backup_id: string; expected_sha256: string; confirmation: string } {
+    if (typeof backupId !== "string" || !backupBelongsToProject(backupId, projectRef)) {
+        throw new Error("'backup_id' must identify a logical-full backup for 'ref'");
+    }
+    if (typeof expectedSha256 !== "string" || !SHA256.test(expectedSha256)) {
+        throw new Error("'expected_sha256' must be a lowercase SHA-256 digest");
+    }
+    const confirmation = `RESTORE_PROJECT:${projectRef}:${backupId}:${expectedSha256}`;
+    if (restoreConfirmation !== confirmation) {
+        throw new Error("'restore_confirmation' must exactly confirm the selected logical backup restore");
+    }
+    return { backup_id: backupId, expected_sha256: expectedSha256, confirmation };
+}
+
 function endpoint(projectRef: string): string {
     if (!validProjectRef(projectRef)) throw new Error("'ref' is invalid for release controls");
     return `/v1/projects/${encodeURIComponent(projectRef)}`;
@@ -227,14 +247,17 @@ export function registerReleaseTools(
 ): void {
     server.tool(
         "release",
-        "Verified release controls using a Management API credential. Actions: logical_backup_list, logical_backup_create, postgrest_status, postgrest_restart",
+        "Verified release controls using a Management API credential. Actions: logical_backup_list, logical_backup_create, logical_backup_restore, postgrest_status, postgrest_restart",
         {
             action: withDescription(stringEnum([
-                "logical_backup_list", "logical_backup_create", "postgrest_status", "postgrest_restart",
+                "logical_backup_list", "logical_backup_create", "logical_backup_restore", "postgrest_status", "postgrest_restart",
             ]), "Release control action"),
             ref: optional(Type.String(), options.projectRef ? "Optional override when not auto-linked" : "Project ref"),
+            backup_id: optional(Type.String(), "[logical_backup_restore] Exact verified logical-full backup ID from the selected project inventory"),
+            expected_sha256: optional(Type.String(), "[logical_backup_restore] Exact lowercase SHA-256 from the selected project inventory"),
+            restore_confirmation: optional(Type.String(), "[logical_backup_restore] Exact RESTORE_PROJECT:<ref>:<backup_id>:<sha256> confirmation"),
         },
-        async ({ action, ref }) => {
+        async ({ action, ref, backup_id, expected_sha256, restore_confirmation }) => {
             const projectRef = typeof ref === "string" && ref || options.projectRef;
             if (!projectRef) throw new Error("'ref' is required for release controls");
             if (!validProjectRef(projectRef)) throw new Error("'ref' is invalid for release controls");
@@ -267,6 +290,43 @@ export function registerReleaseTools(
                 return releaseControlSuccess("release.logical_backup.create", {
                     project_ref: projectRef,
                     backup: publicBackup(addedBackup),
+                });
+            }
+            if (action === "logical_backup_restore") {
+                const request = restoreRequest(projectRef, backup_id, expected_sha256, restore_confirmation);
+                const before = await readInventory(http, projectRef);
+                const beforeFailure = readInventoryFailure("release.logical_backup.restore", before);
+                if (beforeFailure) return beforeFailure;
+                const selectedBackup = before.inventory!.find((backup) =>
+                    backup.backup_id === request.backup_id && backup.sha256 === request.expected_sha256,
+                );
+                if (!selectedBackup) {
+                    return releaseControlFailure("release.logical_backup.restore", "MUTATION_NOT_SUCCEEDED", null);
+                }
+                const mutation = await http.postReleaseMutation(
+                    `${endpoint(projectRef)}/database/backups/logical/restore`,
+                    request,
+                    { timeoutMs: BACKUP_TIMEOUT_MS },
+                );
+                if (!mutation.ok || mutation.status !== 200) {
+                    return mutationFailure("release.logical_backup.restore", mutation);
+                }
+                const responseBackup = isRecord(mutation.data)
+                    ? verifiedBackup(mutation.data.restored_backup, projectRef)
+                    : null;
+                const after = await readInventory(http, projectRef);
+                const afterFailure = readInventoryFailure("release.logical_backup.restore", after);
+                const restoredInventoryBackup = after.inventory?.find((backup) => backup.backup_id === request.backup_id);
+                if (!responseBackup
+                    || !equalBackup(responseBackup, selectedBackup)
+                    || afterFailure
+                    || !restoredInventoryBackup
+                    || !equalBackup(restoredInventoryBackup, selectedBackup)) {
+                    return releaseControlFailure("release.logical_backup.restore", "OUTCOME_UNKNOWN", mutation.status);
+                }
+                return releaseControlSuccess("release.logical_backup.restore", {
+                    project_ref: projectRef,
+                    backup: publicBackup(selectedBackup),
                 });
             }
             if (action === "postgrest_status") {


### PR DESCRIPTION
## Summary\n\nAdds the official project-scoped logical backup restore command to SupaCloud CLI.\n\n- Fresh inventory binding for project, backup ID, and SHA-256 before exactly one restore POST.\n- Exact RESTORE_PROJECT confirmation plus the existing production confirmation.\n- Receipt and post-restore inventory verification; ambiguous outcomes are OUTCOME_UNKNOWN with no retry.\n- Documents the required paused project and Management credential boundary.\n\n## Verification\n\n- bun test packages/cli/src: 780 pass\n- bun run --cwd packages/cli typecheck\n- bun run --cwd packages/cli build\n- git diff --check\n\n## Governance\n\nTask Contract: SUPACLOUD-CLI-LOGICAL-BACKUP-RESTORE-CONTROL-20260817\n\nHigh-risk panel evidence:\n- independent security review: PASS\n- independent release-control review: PASS\n\nNo restore, deployment, merge, credential access, or other production mutation was performed.