### PR TITLE
feat(cli): add project recovery controls

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,6 +113,22 @@ logical-backup and PostgREST lifecycle capabilities. It requires the Management
 API context above; it does not promote an application `service_role` key to
 Management authority.
 
+Project pause and restore are explicit lifecycle commands. A logical backup
+restore requires an operator to pause the selected project first and then use
+`project get` to confirm that its status is `paused`. `project restore` resumes
+the paused project lifecycle when its database exists; if the database is
+missing, the platform begins project re-provisioning instead. It does not
+restore a database backup and is never invoked automatically by the CLI.
+
+```bash
+supacloud-cli project pause --ref abc123
+supacloud-cli release logical_backup_restore --ref abc123 \
+  --backup_id logical-full_abc123_<backup-id-suffix> \
+  --expected_sha256 <64-lowercase-hex> \
+  --restore_confirmation RESTORE_PROJECT:abc123:logical-full_abc123_<backup-id-suffix>:<64-lowercase-hex>
+supacloud-cli project restore --ref abc123
+```
+
 ```bash
 supacloud-cli release logical_backup_list --ref abc123
 supacloud-cli release logical_backup_create --ref abc123

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -250,14 +250,14 @@ describe("supacloud-cli process contract", () => {
         ].join("\n") + "\n");
 
         const unconfirmed = await runProjectCli([
-            "--env", "prod", "project", "task_cancel", "--task_id", "task-1",
+            "--env", "prod", "project", "pause",
         ], {}, workspace);
         const confirmed = await runProjectCli([
-            "project", "task_cancel", "--task_id", "task-1",
+            "project", "pause",
             "--env=prod", "--confirm-production=prod-ref",
         ], {}, workspace);
         const crossRef = await runProjectCli([
-            "project", "task_cancel", "--task_id", "task-1", "--ref", "other-ref",
+            "project", "restore", "--ref", "other-ref",
             "--env", "prod", "--confirm-production", "other-ref",
         ], {}, workspace);
 
@@ -266,7 +266,59 @@ describe("supacloud-cli process contract", () => {
         expect(confirmed.exitCode).toBe(0);
         expect(crossRef.exitCode).toBe(1);
         expect(crossRef.stderr).toContain("cannot target a different project");
-        expect(requestedPaths).toEqual(["/v1/projects/prod-ref/tasks/task-1/cancel"]);
+        expect(requestedPaths).toEqual(["/v1/projects/prod-ref/pause"]);
+    });
+
+    test("blocks project recovery actions in read-only mode before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        for (const action of ["pause", "restore"]) {
+            const response = await runProjectCli(["project", action], {
+                SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+                SUPACLOUD_API_TOKEN: "test-token",
+                SUPACLOUD_PROJECT_REF: "abc123",
+                SUPACLOUD_READ_ONLY: "true",
+            });
+
+            expect(response.exitCode).toBe(1);
+            expect(response.stdout + response.stderr).toContain("read-only");
+        }
+
+        expect(requestCount).toBe(0);
+    });
+
+    test("blocks project recovery actions for application-only profiles before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        for (const action of ["pause", "restore"]) {
+            const response = await runProjectCli(["project", action], {
+                SUPABASE_URL: `http://127.0.0.1:${server.port}`,
+                SUPABASE_SERVICE_ROLE_KEY: "application-service-role-key",
+            });
+
+            expect(response.exitCode).toBe(1);
+            expect(response.stdout + response.stderr).toContain("Management API context");
+        }
+
+        expect(requestCount).toBe(0);
     });
 
     test("requires production confirmation for secrets from environment before HTTP", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,7 +33,7 @@ type ToolMap = Record<string, ToolEntry>;
 const commandName = "supacloud-cli";
 const preferredCommand = commandName;
 const projectActionSchema = stringEnum([
-    "get", "health", "logs", "api_keys", "settings",
+    "get", "pause", "restore", "health", "logs", "api_keys", "settings",
     "tasks", "task_detail", "task_cancel", "task_retry", "task_stats", "dlq", "background_settings", "update_background_settings",
 ]);
 const genericActionSchema = Type.String();

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -67,12 +67,15 @@ function context(overrides: Partial<ResolvedContext> = {}): ResolvedContext {
 
 describe("CLI execution policy", () => {
     test("requires an exact production confirmation for remote writes", () => {
-        expect(() => authorizeExecution("project", { action: "task_cancel" }, { context: context() }))
-            .toThrow("--confirm-production prod-ref");
-        expect(() => authorizeExecution("project", { action: "task_cancel" }, {
-            context: context(),
-            confirmProduction: "prod-ref",
-        })).not.toThrow();
+        for (const action of ["pause", "restore"]) {
+            expect(executionMode("project", action, {})).toBe("write");
+            expect(() => authorizeExecution("project", { action }, { context: context() }))
+                .toThrow("--confirm-production prod-ref");
+            expect(() => authorizeExecution("project", { action }, {
+                context: context(),
+                confirmProduction: "prod-ref",
+            })).not.toThrow();
+        }
     });
 
     test("rejects cross-project production overrides even when confirmed", () => {
@@ -130,6 +133,11 @@ describe("CLI execution policy", () => {
         expect(() => authorizeExecution("frontend", { action: "redeploy" }, {
             context: context({ production: false, environment: "test", readOnly: true }),
         })).toThrow("SUPACLOUD_READ_ONLY=true");
+        for (const action of ["pause", "restore"]) {
+            expect(() => authorizeExecution("project", { action }, {
+                context: context({ production: false, environment: "test", readOnly: true }),
+            })).toThrow("SUPACLOUD_READ_ONLY=true");
+        }
     });
 
     test("classifies Function, Scheduled Function, and Storage lifecycle actions", () => {

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -13,7 +13,7 @@ interface ModulePolicy {
 const ACTION_POLICY: Record<string, ModulePolicy> = {
     project: {
         read: ["get", "health", "logs", "api_keys", "settings", "tasks", "task_detail", "task_stats", "dlq", "background_settings"],
-        write: ["task_cancel", "task_retry", "update_background_settings"],
+        write: ["pause", "restore", "task_cancel", "task_retry", "update_background_settings"],
     },
     database: {
         read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "migration_inventory", "project_url", "generate_types"],

--- a/packages/cli/src/shared/tools/project-cli-tools.test.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.test.ts
@@ -106,6 +106,32 @@ describe("project CLI reads", () => {
     });
 });
 
+describe("project CLI recovery actions", () => {
+    test("targets the selected project and keeps failed response bodies private", async () => {
+        const remoteSecret = "project-recovery-private-sentinel";
+        const calls: string[] = [];
+        const callback = captureProjectTool({
+            post: async (path: string) => {
+                calls.push(path);
+                return calls.length === 1
+                    ? { ok: true, status: 200, data: {} }
+                    : { ok: false, status: 503, data: { message: remoteSecret } };
+            },
+        }, "default-ref");
+
+        const pause = await callback({ action: "pause", ref: "selected-ref" });
+        const restore = await callback({ action: "restore", ref: "selected-ref" });
+
+        expect(calls).toEqual([
+            "/v1/projects/selected-ref/pause",
+            "/v1/projects/selected-ref/restore",
+        ]);
+        expect(pause.content[0].text).toBe("✅ Project selected-ref paused");
+        expect(restore.content[0].text).toBe("❌ Failed (503)");
+        expect(restore.content[0].text).not.toContain(remoteSecret);
+    });
+});
+
 describe("project CLI task actions", () => {
     test("prefers an explicit ref over the auto-linked project", async () => {
         const calls: string[] = [];
@@ -206,6 +232,7 @@ describe("admin project create compatibility", () => {
         }, {} as any, { projectRef: "proj" });
 
         if (!userProjectSchema) throw new Error("user project tool was not registered");
+        expect(schemaEnumValues(userProjectSchema.action)).toEqual(expect.arrayContaining(["pause", "restore"]));
         expect(schemaEnumValues(userProjectSchema.action)).not.toContain("create");
         expect(userProjectSchema.domain).toBeUndefined();
         expect(userProjectSchema.api_domain).toBeUndefined();

--- a/packages/cli/src/shared/tools/project-cli-tools.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.ts
@@ -132,10 +132,10 @@ export function registerUserProjectCliTools(
     server.tool(
         "project",
         `Project-scoped inspection and developer operations.
-Actions: get, health, logs, api_keys, settings, tasks, task_detail, task_cancel, task_retry, task_stats, dlq, background_settings, update_background_settings`,
+Actions: get, pause, restore, health, logs, api_keys, settings, tasks, task_detail, task_cancel, task_retry, task_stats, dlq, background_settings, update_background_settings`,
         {
             action: withDescription(stringEnum([
-                "get", "health", "logs", "api_keys", "settings",
+                "get", "pause", "restore", "health", "logs", "api_keys", "settings",
                 "tasks", "task_detail", "task_cancel", "task_retry", "task_stats", "dlq",
                 "background_settings", "update_background_settings",
             ]), "Action to perform"),
@@ -158,6 +158,12 @@ Actions: get, health, logs, api_keys, settings, tasks, task_detail, task_cancel,
                         }),
                         resolvedRef,
                     ));
+                case "pause":
+                    text = simple(await http.post(`/v1/projects/${resolvedRef}/pause`), `Project ${resolvedRef} paused`);
+                    break;
+                case "restore":
+                    text = simple(await http.post(`/v1/projects/${resolvedRef}/restore`), `Project ${resolvedRef} restored`);
+                    break;
                 case "health":
                     text = ok(await http.get(`/v1/projects/${resolvedRef}/health`));
                     break;


### PR DESCRIPTION
## Summary
- expose explicit project pause and restore through the official SupaCloud CLI
- classify both actions as production-confirmed, read-only-blocked writes
- document the required pause/read-back/logical-restore/operator-resume sequence

## Verification
- bun test packages/cli/src (783 pass)
- bun run --cwd packages/cli typecheck
- bun run --cwd packages/cli build
- git diff --check

## Safety
- Management context only; application service-role profiles make no HTTP request
- no automatic pause, logical backup restore, or project resume