### PR TITLE
feat(cli): add release canary OAuth client controls

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -196,6 +196,16 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).toContain("--allowed_mime_types");
     });
 
+    test("keeps the release-canary OAuth client command discoverable without project configuration", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-oauth-client-help-"));
+        temporaryDirectories.push(workspace);
+
+        const response = await runProjectCli(["oauth_clients", "--help"], {}, workspace);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("oauth_clients <action>");
+    });
+
     test("loads named environments with global flags after the command and keeps status secret-free", async () => {
         const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-named-env-"));
         temporaryDirectories.push(workspace);
@@ -267,6 +277,103 @@ describe("supacloud-cli process contract", () => {
         expect(crossRef.exitCode).toBe(1);
         expect(crossRef.stderr).toContain("cannot target a different project");
         expect(requestedPaths).toEqual(["/v1/projects/prod-ref/pause"]);
+    });
+
+    test("protects a release-canary OAuth client create and keeps upstream secrets out of the process receipt", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-oauth-client-production-env-"));
+        temporaryDirectories.push(workspace);
+        const responseSecret = "oauth-client-secret-must-not-leak";
+        const requestedPaths: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const path = new URL(request.url).pathname;
+                requestedPaths.push(path);
+                if (request.method === "GET" && path.endsWith("/oauth-clients")) {
+                    return Response.json({ clients: [] });
+                }
+                if (request.method === "POST" && path.endsWith("/oauth-clients")) {
+                    return Response.json({ client_id: "release-canary.client-1", client_secret: responseSecret });
+                }
+                if (request.method === "GET" && path.endsWith("/oauth-clients/release-canary.client-1")) {
+                    return Response.json({
+                        client_id: "release-canary.client-1",
+                        client_name: "supacloud-release-canary",
+                        client_type: "public",
+                        token_endpoint_auth_method: "none",
+                        redirect_uris: ["https://release-canary.example.test/callback"],
+                        grant_types: ["authorization_code"],
+                        response_types: ["code"],
+                        client_secret: responseSecret,
+                    });
+                }
+                return Response.json({}, { status: 404 });
+            },
+        });
+        servers.push(server);
+        writeFileSync(join(workspace, ".env.supacloud.prod"), [
+            "SUPACLOUD_ENV=production",
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=prod-secret-token",
+            "SUPACLOUD_PROJECT_REF=prod-ref",
+        ].join("\n") + "\n");
+
+        const unconfirmed = await runProjectCli([
+            "--env", "prod", "oauth_clients", "create",
+            "--ref", "prod-ref",
+            "--redirect_uri", "https://release-canary.example.test/callback",
+        ], {}, workspace);
+        const confirmed = await runProjectCli([
+            "oauth_clients", "create",
+            "--ref", "prod-ref",
+            "--redirect_uri", "https://release-canary.example.test/callback",
+            "--env", "prod", "--confirm-production", "prod-ref",
+        ], {}, workspace);
+
+        expect(unconfirmed.exitCode).toBe(1);
+        expect(unconfirmed.stderr).toContain("--confirm-production prod-ref");
+        expect(confirmed.exitCode).toBe(0);
+        expect(requestedPaths).toEqual([
+            "/v1/projects/prod-ref/auth/oauth-clients",
+            "/v1/projects/prod-ref/auth/oauth-clients",
+            "/v1/projects/prod-ref/auth/oauth-clients/release-canary.client-1",
+        ]);
+        expect(confirmed.stdout).not.toContain(responseSecret);
+        expect(JSON.parse(confirmed.stdout)).toMatchObject({
+            ok: true,
+            operation: "oauth_clients.create",
+            project_ref: "prod-ref",
+            reused: false,
+        });
+    });
+
+    test("blocks a release-canary OAuth client mutation in read-only mode before HTTP dispatch", async () => {
+        let requestCount = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch() {
+                requestCount += 1;
+                return Response.json({});
+            },
+        });
+        servers.push(server);
+
+        const response = await runProjectCli([
+            "oauth_clients", "create",
+            "--ref", "abc123",
+            "--redirect_uri", "https://release-canary.example.test/callback",
+        ], {
+            SUPACLOUD_API_URL: `http://127.0.0.1:${server.port}`,
+            SUPACLOUD_API_TOKEN: "read-only-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            SUPACLOUD_READ_ONLY: "true",
+        });
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stdout + response.stderr).toContain("read-only");
+        expect(requestCount).toBe(0);
     });
 
     test("blocks project recovery actions in read-only mode before HTTP dispatch", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { authorizeExecution, validateExecutionPolicyCoverage } from "./shared/ex
 import { HttpTransport } from "./shared/transports/http";
 import { registerDatabaseTools } from "./shared/tools/database-tools";
 import { registerAuthTools } from "./shared/tools/auth-tools";
+import { registerOAuthClientTools } from "./shared/tools/oauth-client-tools";
 import { registerStorageTools } from "./shared/tools/storage-tools";
 import { registerAdvancedTools } from "./shared/tools/advanced-tools";
 import { registerFrontendTools } from "./shared/tools/frontend-tools";
@@ -386,7 +387,7 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
                 ],
             }),
         };
-        for (const name of ["database", "auth", "storage", "edge_functions", "secrets", "frontend", "queue", "task_events", "scheduled_functions", "mutations", "diagnostics", "gateway", "branch", "release"]) {
+        for (const name of ["database", "auth", "oauth_clients", "storage", "edge_functions", "secrets", "frontend", "queue", "task_events", "scheduled_functions", "mutations", "diagnostics", "gateway", "branch", "release"]) {
             tools[name] = {
                 schema: { action: genericActionSchema },
                 callback: async () => ({
@@ -466,6 +467,7 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     pushMigrations = databaseTools.database?.callback;
     assign(databaseTools);
     assign(captureTools((server) => registerAuthTools(server as any, http)));
+    assign(captureTools((server) => registerOAuthClientTools(server as any, http)));
     assign(captureTools((server) => registerStorageTools(server as any, http)));
     assign(captureTools((server) => registerAdvancedTools(server as any, http, process.env, {
         readOnly: context.readOnly,

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -155,6 +155,23 @@ describe("CLI execution policy", () => {
         }
     });
 
+    test("classifies dedicated release-canary OAuth client reads and mutations", () => {
+        expect(executionMode("oauth_clients", "list", {})).toBe("read");
+        expect(executionMode("oauth_clients", "get", {})).toBe("read");
+        expect(executionMode("oauth_clients", "create", {})).toBe("write");
+        expect(executionMode("oauth_clients", "delete", {})).toBe("write");
+        expect(() => authorizeExecution("oauth_clients", { action: "create", ref: "prod-ref" }, {
+            context: context(),
+        })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("oauth_clients", { action: "delete", ref: "prod-ref" }, {
+            context: context(),
+            confirmProduction: "prod-ref",
+        })).not.toThrow();
+        expect(() => authorizeExecution("oauth_clients", { action: "create", ref: "prod-ref" }, {
+            context: context({ production: false, environment: "test", readOnly: true }),
+        })).toThrow("SUPACLOUD_READ_ONLY=true");
+    });
+
     test("classifies verified release controls and protects their mutations", () => {
         expect(executionMode("release", "logical_backup_list", {})).toBe("read");
         expect(executionMode("release", "postgrest_status", {})).toBe("read");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -27,6 +27,10 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         read: ["list_providers", "get_provider", "supported_providers", "get_settings", "get_config"],
         write: ["configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config"],
     },
+    oauth_clients: {
+        read: ["list", "get"],
+        write: ["create", "delete"],
+    },
     storage: {
         read: ["status", "list_buckets", "get_bucket", "list_files"],
         write: ["create_bucket", "update_bucket", "delete_bucket", "upload_base64", "delete_file"],

--- a/packages/cli/src/shared/tools/oauth-client-tools.test.ts
+++ b/packages/cli/src/shared/tools/oauth-client-tools.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolSchema } from "../schema";
+import { registerOAuthClientTools } from "./oauth-client-tools";
+
+const PROJECT_REF = "central-supauth";
+const CLIENT_ID = "release-canary.client-1";
+const HTTPS_CALLBACK = "https://release-canary.example.test/callback";
+
+type ToolResult = {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+};
+
+type OAuthClientsCallback = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function releaseCanaryClient(overrides: Record<string, unknown> = {}) {
+    return {
+        client_id: CLIENT_ID,
+        client_name: "supacloud-release-canary",
+        client_type: "public",
+        token_endpoint_auth_method: "none",
+        redirect_uris: [HTTPS_CALLBACK],
+        grant_types: ["authorization_code"],
+        response_types: ["code"],
+        ...overrides,
+    };
+}
+
+function captureOAuthClientsTool(http: Record<string, unknown>): { schema: ToolSchema; callback: OAuthClientsCallback } {
+    let schema: ToolSchema | undefined;
+    let callback: OAuthClientsCallback | undefined;
+    registerOAuthClientTools({
+        tool(name, _description, toolSchema, toolCallback) {
+            if (name !== "oauth_clients") return;
+            schema = toolSchema;
+            callback = toolCallback;
+        },
+    }, http as never);
+    if (!schema || !callback) throw new Error("oauth_clients tool was not registered");
+    return { schema, callback };
+}
+
+function payload(response: ToolResult): Record<string, unknown> {
+    return JSON.parse(response.content[0]?.text ?? "{}") as Record<string, unknown>;
+}
+
+describe("release-canary OAuth client CLI control", () => {
+    test("lists a strict public projection without exposing upstream-only fields", async () => {
+        const calls: Array<{ path: string; options: unknown }> = [];
+        const responseSecret = "client-secret-value-must-not-leak";
+        const { callback } = captureOAuthClientsTool({
+            get: async (path: string, options: unknown) => {
+                calls.push({ path, options });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: { clients: [releaseCanaryClient({ client_secret: responseSecret, created_at: "private" })] },
+                };
+            },
+        });
+
+        const response = await callback({ action: "list", ref: PROJECT_REF });
+
+        expect(calls).toEqual([{
+            path: `/v1/projects/${PROJECT_REF}/auth/oauth-clients`,
+            options: { maxJsonBytes: 256 * 1024, responseTimeoutMs: 5_000 },
+        }]);
+        expect(payload(response)).toEqual({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "oauth_clients.list",
+            project_ref: PROJECT_REF,
+            clients: [releaseCanaryClient()],
+        });
+        expect(response.content[0]?.text).not.toContain(responseSecret);
+        expect(response.content[0]?.text).not.toContain("private");
+    });
+
+    test.each([
+        { grant_types: ["authorization_code", "refresh_token"] },
+        { response_types: ["code", "token"] },
+    ])("fails closed when a named client in the list does not satisfy the immutable contract", async (overrides) => {
+        const { callback } = captureOAuthClientsTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { clients: [releaseCanaryClient(overrides)] },
+            }),
+        });
+
+        const response = await callback({ action: "list", ref: PROJECT_REF });
+
+        expect(response.isError).toBe(true);
+        expect(payload(response)).toMatchObject({
+            ok: false,
+            operation: "oauth_clients.list",
+            error: { code: "INVALID_RESPONSE", http_status: 200 },
+        });
+    });
+
+    test.each([200, 201])("creates from a %i GoTrue client-id receipt and requires an exact post-read", async (status) => {
+        const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+        let reads = 0;
+        const { callback } = captureOAuthClientsTool({
+            get: async (path: string) => {
+                requests.push({ method: "get", path });
+                reads += 1;
+                return reads === 1
+                    ? { ok: true, status: 200, data: { clients: [] } }
+                    : { ok: true, status: 200, data: releaseCanaryClient() };
+            },
+            postReleaseMutation: async (path: string, body: unknown) => {
+                requests.push({ method: "post", path, body });
+                return { ok: true, status, data: { client_id: CLIENT_ID } };
+            },
+        });
+
+        const response = await callback({ action: "create", ref: PROJECT_REF, redirect_uri: HTTPS_CALLBACK });
+
+        expect(requests).toEqual([
+            { method: "get", path: `/v1/projects/${PROJECT_REF}/auth/oauth-clients` },
+            {
+                method: "post",
+                path: `/v1/projects/${PROJECT_REF}/auth/oauth-clients`,
+                body: {
+                    client_type: "public",
+                    token_endpoint_auth_method: "none",
+                    redirect_uris: [HTTPS_CALLBACK],
+                    grant_types: ["authorization_code"],
+                    client_name: "supacloud-release-canary",
+                },
+            },
+            { method: "get", path: `/v1/projects/${PROJECT_REF}/auth/oauth-clients/${CLIENT_ID}` },
+        ]);
+        expect(payload(response)).toMatchObject({
+            ok: true,
+            operation: "oauth_clients.create",
+            project_ref: PROJECT_REF,
+            client: releaseCanaryClient(),
+            reused: false,
+        });
+    });
+
+    test("reuses only the exact already-registered immutable client", async () => {
+        let mutationCount = 0;
+        const { callback } = captureOAuthClientsTool({
+            get: async () => ({ ok: true, status: 200, data: { clients: [releaseCanaryClient()] } }),
+            postReleaseMutation: async () => {
+                mutationCount += 1;
+                return { ok: true, status: 200, data: { client_id: CLIENT_ID } };
+            },
+        });
+
+        const response = await callback({ action: "create", ref: PROJECT_REF, redirect_uri: HTTPS_CALLBACK });
+
+        expect(mutationCount).toBe(0);
+        expect(payload(response)).toMatchObject({
+            ok: true,
+            operation: "oauth_clients.create",
+            reused: true,
+        });
+    });
+
+    test("never mutates when a named client has a different callback", async () => {
+        let mutationCount = 0;
+        const { callback } = captureOAuthClientsTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { clients: [releaseCanaryClient({ redirect_uris: ["https://other.example.test/callback"] })] },
+            }),
+            postReleaseMutation: async () => {
+                mutationCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        const response = await callback({ action: "create", ref: PROJECT_REF, redirect_uri: HTTPS_CALLBACK });
+
+        expect(mutationCount).toBe(0);
+        expect(response.isError).toBe(true);
+        expect(payload(response)).toMatchObject({
+            error: { code: "MUTATION_NOT_SUCCEEDED", http_status: null },
+        });
+    });
+
+    test("reports an unknown outcome when create read-back is not exact", async () => {
+        let reads = 0;
+        const { callback } = captureOAuthClientsTool({
+            get: async () => {
+                reads += 1;
+                return reads === 1
+                    ? { ok: true, status: 200, data: { clients: [] } }
+                    : { ok: true, status: 200, data: releaseCanaryClient({ grant_types: ["refresh_token"] }) };
+            },
+            postReleaseMutation: async () => ({ ok: true, status: 200, data: { client_id: CLIENT_ID } }),
+        });
+
+        const response = await callback({ action: "create", ref: PROJECT_REF, redirect_uri: HTTPS_CALLBACK });
+
+        expect(response.isError).toBe(true);
+        expect(payload(response)).toMatchObject({
+            ok: false,
+            operation: "oauth_clients.create",
+            error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+        });
+    });
+
+    test.each([
+        "http://release-canary.example.test/callback",
+        "http://127.0.0.1/callback",
+        "https://release-canary.example.test/callback?code=unsafe",
+        "https://user:password@release-canary.example.test/callback",
+    ])("rejects unsafe redirect %s before a mutation", async (redirectUri) => {
+        let requestCount = 0;
+        const { callback } = captureOAuthClientsTool({
+            get: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: { clients: [] } };
+            },
+            postReleaseMutation: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: {} };
+            },
+        });
+
+        await expect(callback({ action: "create", ref: PROJECT_REF, redirect_uri: redirectUri })).rejects.toThrow("redirect_uri");
+        expect(requestCount).toBe(0);
+    });
+
+    test("accepts a strict HTTPS callback and a port-bound loopback callback", async () => {
+        const requests: unknown[] = [];
+        const { callback } = captureOAuthClientsTool({
+            get: async () => ({ ok: true, status: 200, data: { clients: [] } }),
+            postReleaseMutation: async (_path: string, body: unknown) => {
+                requests.push(body);
+                return { ok: true, status: 200, data: { client_id: CLIENT_ID } };
+            },
+        });
+        let postRead = false;
+        const postReadTool = captureOAuthClientsTool({
+            get: async () => {
+                if (postRead) return { ok: true, status: 200, data: releaseCanaryClient({ redirect_uris: ["http://127.0.0.1:43859/callback"] }) };
+                postRead = true;
+                return { ok: true, status: 200, data: { clients: [] } };
+            },
+            postReleaseMutation: async (_path: string, body: unknown) => {
+                requests.push(body);
+                return { ok: true, status: 200, data: { client_id: CLIENT_ID } };
+            },
+        });
+
+        await callback({ action: "create", ref: PROJECT_REF, redirect_uri: HTTPS_CALLBACK });
+        const loopbackResponse = await postReadTool.callback({
+            action: "create", ref: PROJECT_REF, redirect_uri: "http://127.0.0.1:43859/callback",
+        });
+
+        expect(payload(loopbackResponse)).toMatchObject({ ok: true, reused: false });
+        expect(requests).toEqual([
+            expect.objectContaining({ redirect_uris: [HTTPS_CALLBACK] }),
+            expect.objectContaining({ redirect_uris: ["http://127.0.0.1:43859/callback"] }),
+        ]);
+    });
+
+    test("deletes only after matching the exact client and callback, then proving absence", async () => {
+        const requests: Array<{ method: string; path: string }> = [];
+        const { callback } = captureOAuthClientsTool({
+            get: async (path: string) => {
+                requests.push({ method: "get", path });
+                return path.endsWith(`/${CLIENT_ID}`)
+                    ? { ok: true, status: 200, data: releaseCanaryClient() }
+                    : { ok: true, status: 200, data: { clients: [] } };
+            },
+            deleteReleaseMutation: async (path: string) => {
+                requests.push({ method: "delete", path });
+                return { ok: true, status: 204, data: null };
+            },
+        });
+
+        const response = await callback({
+            action: "delete", ref: PROJECT_REF, client_id: CLIENT_ID, redirect_uri: HTTPS_CALLBACK,
+        });
+
+        expect(requests).toEqual([
+            { method: "get", path: `/v1/projects/${PROJECT_REF}/auth/oauth-clients/${CLIENT_ID}` },
+            { method: "delete", path: `/v1/projects/${PROJECT_REF}/auth/oauth-clients/${CLIENT_ID}` },
+            { method: "get", path: `/v1/projects/${PROJECT_REF}/auth/oauth-clients` },
+        ]);
+        expect(payload(response)).toMatchObject({
+            ok: true,
+            operation: "oauth_clients.delete",
+            project_ref: PROJECT_REF,
+            client_id: CLIENT_ID,
+            deleted: true,
+        });
+    });
+
+    test.each([
+        ["transport failure", { ok: false, status: 500, data: {}, transportError: true }],
+        ["unreadable response", { ok: false, status: 200, data: {}, responseReadError: true }],
+        ["server failure", { ok: false, status: 503, data: {} }],
+        ["still-present client", { ok: true, status: 200, data: { clients: [releaseCanaryClient()] } }],
+    ] as const)("reports an unknown deletion outcome after %s", async (_label, postRead) => {
+        const { callback } = captureOAuthClientsTool({
+            get: async (path: string) => path.endsWith(`/${CLIENT_ID}`)
+                ? { ok: true, status: 200, data: releaseCanaryClient() }
+                : postRead,
+            deleteReleaseMutation: async () => ({ ok: true, status: 204, data: null }),
+        });
+
+        const response = await callback({
+            action: "delete", ref: PROJECT_REF, client_id: CLIENT_ID, redirect_uri: HTTPS_CALLBACK,
+        });
+
+        expect(response.isError).toBe(true);
+        expect(payload(response)).toMatchObject({
+            ok: false,
+            operation: "oauth_clients.delete",
+            error: { code: "OUTCOME_UNKNOWN", http_status: 204 },
+        });
+    });
+});

--- a/packages/cli/src/shared/tools/oauth-client-tools.ts
+++ b/packages/cli/src/shared/tools/oauth-client-tools.ts
@@ -1,0 +1,301 @@
+import { Type } from "@sinclair/typebox";
+import { projectRefPathSegment } from "../project-ref";
+import { optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+import type { HttpResult, HttpTransport } from "../transports/http";
+import {
+    releaseControlFailure,
+    releaseControlMutationFailure,
+    releaseControlSuccess,
+    type ReleaseControlToolResponse,
+} from "./release-control-response";
+
+type ToolServer = {
+    tool: (
+        name: string,
+        description: string,
+        schema: ToolSchema,
+        callback: (args: Record<string, unknown>) => Promise<ReleaseControlToolResponse>,
+    ) => void;
+};
+
+type ReleaseCanaryOAuthClient = {
+    client_id: string;
+    client_name: "supacloud-release-canary";
+    client_type: "public";
+    token_endpoint_auth_method: "none";
+    redirect_uris: [string];
+    grant_types: ["authorization_code"];
+    response_types: ["code"];
+};
+
+const RELEASE_CANARY_CLIENT_NAME = "supacloud-release-canary";
+const CLIENT_ID_PATTERN = /^[A-Za-z0-9._~-]{1,256}$/;
+const MAX_CLIENT_LIST_BYTES = 256 * 1024;
+const READ_TIMEOUT_MS = 5_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function releaseCanaryCallbackUri(value: unknown): string {
+    if (typeof value !== "string" || !value.trim()) {
+        throw new Error("'redirect_uri' is required");
+    }
+    let uri: URL;
+    try {
+        uri = new URL(value);
+    } catch {
+        throw new Error("'redirect_uri' must be an absolute HTTPS or loopback HTTP URL");
+    }
+    const loopback = uri.hostname === "127.0.0.1" || uri.hostname === "[::1]";
+    const isHttps = uri.protocol === "https:";
+    const isPortBoundLoopback = uri.protocol === "http:" && loopback && Boolean(uri.port);
+    if ((!isHttps && !isPortBoundLoopback) || !uri.hostname || uri.username || uri.password || uri.search || uri.hash) {
+        throw new Error("'redirect_uri' must be an exact HTTPS callback or port-bound loopback HTTP callback without credentials, query, or fragment");
+    }
+    return uri.toString();
+}
+
+function createdClientId(value: unknown): string | null {
+    if (!isRecord(value)) return null;
+    try {
+        return clientId(value.client_id);
+    } catch {
+        return null;
+    }
+}
+
+function clientId(value: unknown): string {
+    if (typeof value !== "string" || !CLIENT_ID_PATTERN.test(value)) {
+        throw new Error("'client_id' is invalid");
+    }
+    return value;
+}
+
+function projectRef(value: unknown): string {
+    if (typeof value !== "string" || !value.trim()) throw new Error("'ref' is required");
+    return projectRefPathSegment(value.trim(), "OAuth client");
+}
+
+function oauthClientsPath(ref: string): string {
+    return `/v1/projects/${encodeURIComponent(ref)}/auth/oauth-clients`;
+}
+
+function expectedClient(value: unknown, redirectUri?: string): ReleaseCanaryOAuthClient | null {
+    if (!isRecord(value)
+        || typeof value.client_id !== "string"
+        || !CLIENT_ID_PATTERN.test(value.client_id)
+        || value.client_name !== RELEASE_CANARY_CLIENT_NAME
+        || value.client_type !== "public"
+        || value.token_endpoint_auth_method !== "none"
+        || !Array.isArray(value.redirect_uris)
+        || value.redirect_uris.length !== 1
+        || !Array.isArray(value.grant_types)
+        || value.grant_types.length !== 1
+        || value.grant_types[0] !== "authorization_code"
+        || !Array.isArray(value.response_types)
+        || value.response_types.length !== 1
+        || value.response_types[0] !== "code") return null;
+    let callback: string;
+    try {
+        callback = releaseCanaryCallbackUri(value.redirect_uris[0]);
+    } catch {
+        return null;
+    }
+    if (redirectUri !== undefined && callback !== redirectUri) return null;
+    return {
+        client_id: value.client_id,
+        client_name: RELEASE_CANARY_CLIENT_NAME,
+        client_type: "public",
+        token_endpoint_auth_method: "none",
+        redirect_uris: [callback],
+        grant_types: ["authorization_code"],
+        response_types: ["code"],
+    };
+}
+
+function clientInventory(value: unknown): ReleaseCanaryOAuthClient[] | null {
+    if (!isRecord(value) || !Array.isArray(value.clients)) return null;
+    const clients = value.clients
+        .filter((client) => isRecord(client) && client.client_name === RELEASE_CANARY_CLIENT_NAME)
+        .map((client) => expectedClient(client));
+    if (clients.some((client) => client === null)) return null;
+    const inventory = clients as ReleaseCanaryOAuthClient[];
+    return new Set(inventory.map((client) => client.client_id)).size === inventory.length ? inventory : null;
+}
+
+function readFailure(
+    operation: string,
+    response: HttpResult<unknown>,
+): ReleaseControlToolResponse | null {
+    if (!response.ok) {
+        return releaseControlFailure(
+            operation,
+            response.responseReadError ? "INVALID_RESPONSE" : "HTTP_ERROR",
+            response.transportError ? null : response.status,
+        );
+    }
+    return null;
+}
+
+async function listClients(
+    http: HttpTransport,
+    ref: string,
+): Promise<{ response: HttpResult<unknown>; clients: ReleaseCanaryOAuthClient[] | null }> {
+    const response = await http.get(oauthClientsPath(ref), {
+        maxJsonBytes: MAX_CLIENT_LIST_BYTES,
+        responseTimeoutMs: READ_TIMEOUT_MS,
+    });
+    return { response, clients: response.ok && response.status === 200 ? clientInventory(response.data) : null };
+}
+
+async function getClient(
+    http: HttpTransport,
+    ref: string,
+    id: string,
+): Promise<{ response: HttpResult<unknown>; client: ReleaseCanaryOAuthClient | null }> {
+    const response = await http.get(`${oauthClientsPath(ref)}/${encodeURIComponent(id)}`, {
+        maxJsonBytes: MAX_CLIENT_LIST_BYTES,
+        responseTimeoutMs: READ_TIMEOUT_MS,
+    });
+    return { response, client: response.ok && response.status === 200 ? expectedClient(response.data) : null };
+}
+
+function exactSingleClient(
+    inventory: readonly ReleaseCanaryOAuthClient[],
+    redirectUri: string,
+): ReleaseCanaryOAuthClient | null {
+    return inventory.length === 1 && inventory[0]?.redirect_uris[0] === redirectUri
+        ? inventory[0]
+        : null;
+}
+
+async function listReleaseCanaryClients(
+    http: HttpTransport,
+    ref: string,
+): Promise<ReleaseControlToolResponse> {
+    const read = await listClients(http, ref);
+    const failure = readFailure("oauth_clients.list", read.response);
+    if (failure) return failure;
+    if (!read.clients) return releaseControlFailure("oauth_clients.list", "INVALID_RESPONSE", read.response.status);
+    return releaseControlSuccess("oauth_clients.list", { project_ref: ref, clients: read.clients });
+}
+
+async function getReleaseCanaryClient(
+    http: HttpTransport,
+    ref: string,
+    id: string,
+): Promise<ReleaseControlToolResponse> {
+    const read = await getClient(http, ref, id);
+    const failure = readFailure("oauth_clients.get", read.response);
+    if (failure) return failure;
+    if (!read.client || read.client.client_id !== id) {
+        return releaseControlFailure("oauth_clients.get", "INVALID_RESPONSE", read.response.status);
+    }
+    return releaseControlSuccess("oauth_clients.get", { project_ref: ref, client: read.client });
+}
+
+async function createReleaseCanaryClient(
+    http: HttpTransport,
+    ref: string,
+    redirectUri: string,
+): Promise<ReleaseControlToolResponse> {
+    const before = await listClients(http, ref);
+    const beforeFailure = readFailure("oauth_clients.create", before.response);
+    if (beforeFailure) return beforeFailure;
+    if (!before.clients) return releaseControlFailure("oauth_clients.create", "INVALID_RESPONSE", before.response.status);
+    const existing = exactSingleClient(before.clients, redirectUri);
+    if (existing) {
+        return releaseControlSuccess("oauth_clients.create", {
+            project_ref: ref,
+            client: existing,
+            reused: true,
+        });
+    }
+    if (before.clients.length > 0) {
+        return releaseControlFailure("oauth_clients.create", "MUTATION_NOT_SUCCEEDED", null, { project_ref: ref });
+    }
+    const mutation = await http.postReleaseMutation(oauthClientsPath(ref), {
+        client_type: "public",
+        token_endpoint_auth_method: "none",
+        redirect_uris: [redirectUri],
+        grant_types: ["authorization_code"],
+        client_name: RELEASE_CANARY_CLIENT_NAME,
+    });
+    if (!mutation.ok) {
+        return releaseControlMutationFailure("oauth_clients.create", mutation, { project_ref: ref });
+    }
+    // Only the create receipt identity is trusted before the exact post-read.
+    const createdId = createdClientId(mutation.data);
+    if (!createdId) return releaseControlFailure("oauth_clients.create", "OUTCOME_UNKNOWN", mutation.status, { project_ref: ref });
+    const read = await getClient(http, ref, createdId);
+    const readFailureResult = readFailure("oauth_clients.create", read.response);
+    if (readFailureResult || !read.client || read.client.client_id !== createdId
+        || read.client.redirect_uris[0] !== redirectUri) {
+        return releaseControlFailure("oauth_clients.create", "OUTCOME_UNKNOWN", mutation.status, { project_ref: ref });
+    }
+    return releaseControlSuccess("oauth_clients.create", {
+        project_ref: ref,
+        client: read.client,
+        reused: false,
+    });
+}
+
+async function deleteReleaseCanaryClient(
+    http: HttpTransport,
+    ref: string,
+    id: string,
+    redirectUri: string,
+): Promise<ReleaseControlToolResponse> {
+    const before = await getClient(http, ref, id);
+    const beforeFailure = readFailure("oauth_clients.delete", before.response);
+    if (beforeFailure) return beforeFailure;
+    if (!before.client || before.client.client_id !== id || before.client.redirect_uris[0] !== redirectUri) {
+        return releaseControlFailure("oauth_clients.delete", "MUTATION_NOT_SUCCEEDED", null, { project_ref: ref });
+    }
+    const mutation = await http.deleteReleaseMutation(`${oauthClientsPath(ref)}/${encodeURIComponent(id)}`);
+    if (!mutation.ok || ![200, 204].includes(mutation.status)) {
+        return releaseControlMutationFailure("oauth_clients.delete", mutation, { project_ref: ref });
+    }
+    const after = await listClients(http, ref);
+    const afterFailure = readFailure("oauth_clients.delete", after.response);
+    if (afterFailure || !after.clients || after.clients.some((client) => client.client_id === id)) {
+        return releaseControlFailure("oauth_clients.delete", "OUTCOME_UNKNOWN", mutation.status, { project_ref: ref });
+    }
+    return releaseControlSuccess("oauth_clients.delete", {
+        project_ref: ref,
+        client_id: id,
+        deleted: true,
+    });
+}
+
+export function registerOAuthClientTools(server: ToolServer, http: HttpTransport): void {
+    server.tool(
+        "oauth_clients",
+        "Dedicated release-canary public OAuth client lifecycle. It only manages the exact supacloud-release-canary public authorization-code client and never returns client secrets.",
+        {
+            action: withDescription(stringEnum(["list", "get", "create", "delete"]), "OAuth client action"),
+            ref: withDescription(Type.String(), "Central SupAuth project ref"),
+            client_id: optional(Type.String(), "[get/delete] Exact release-canary public OAuth client ID"),
+            redirect_uri: optional(Type.String(), "[create/delete] Exact HTTPS or port-bound RFC 8252 loopback callback"),
+        },
+        async ({ action, ref, client_id, redirect_uri }) => {
+            const targetRef = projectRef(ref);
+            if (action === "list") return listReleaseCanaryClients(http, targetRef);
+            if (action === "get") return getReleaseCanaryClient(http, targetRef, clientId(client_id));
+            if (action === "create") {
+                return createReleaseCanaryClient(http, targetRef, releaseCanaryCallbackUri(redirect_uri));
+            }
+            if (action === "delete") {
+                return deleteReleaseCanaryClient(
+                    http,
+                    targetRef,
+                    clientId(client_id),
+                    releaseCanaryCallbackUri(redirect_uri),
+                );
+            }
+            throw new Error("Unknown OAuth client action");
+        },
+    );
+}


### PR DESCRIPTION
## Summary

Adds an official SupaCloud CLI `oauth_clients` control for the one release-canary public OAuth client class (`supacloud-release-canary`).

- Browser-driven OAuth + PKCE remains the intended downstream canary flow; this PR does not implement browser exchange or require a human to copy a token.
- Restricts lifecycle to list/get/create/delete for a public, authorization-code-only client with strict HTTPS or port-bound loopback callbacks.
- Uses pre-read, one mutation, exact read-back, no retry on ambiguity, and secret-free public receipts.
- Classifies creates/deletes as writes: production requires exact `--confirm-production <ref>` and read-only profiles block before HTTP.
- Does not modify GoTrue, create a production OAuth client, or deploy FA.

## Governance

Task: `SUPACLOUD-CLI-RELEASE-CANARY-OAUTH-CLIENT-20260818`

Two isolated reviewers approved the final direction:

- Authentication/security: PASS
- Release/CLI compatibility: PASS

Known platform constraint: the Management API does not expose a CAS/ETag for OAuth client configuration. The CLI fails closed when its observed pre/post state is ambiguous; the later browser runner must still use a fixed callback and proactively enforce PKCE S256.

## Verification

```text
bun test packages/cli/src
bun run --cwd packages/cli typecheck
bun run --cwd packages/cli build
git diff --check
```

Results: 805 passing tests; typecheck, build, and diff check pass.