### PR TITLE
feat(cli): add authoritative project endpoint projection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## Quick Links
 
 - [CLI Guide](./cli-guide.md) - User CLI vs admin CLI entrypoints and command boundaries
+- [Project Endpoint Projection](./project-endpoint-projection.md) - Authoritative API/Auth/Studio origins and project/Admin read boundaries
 - [Deploy Guide](./deploy-guide.md) - Complete deployment guide
 - [Deploy API](./deploy-api.md) - Deployment API reference
 - [Configuration Example](./supacloud.yml.example) - Configuration file example
@@ -32,6 +33,7 @@
 ## Operations
 
 - [CLI Guide](./cli-guide.md) - `@supacloud/cli` and `@supacloud/admin`
+- [Project Endpoint Projection](./project-endpoint-projection.md) - Fixed endpoint schema, commands, and readiness limitations
 - [PostgREST Runtime Lifecycle](./postgrest-runtime-lifecycle.md) - Component-level PostgREST desired state, pause/resume/status, and reconciliation
 - [pgredis Runtime](./pgredis-runtime.md) - Private cache data plane, control-plane APIs, Web Console operations, and safety boundaries
 - [Platform Component Upgrade Notes](./platform-component-upgrade-notes.md) - Breaking changes, migrations, optional features, and rollback notes for current runtime components

--- a/docs/project-endpoint-projection.md
+++ b/docs/project-endpoint-projection.md
@@ -1,0 +1,105 @@
+# Project endpoint projection
+
+SupaCloud exposes one credential-free, authoritative projection of each project's public API, Auth/OIDC, and Studio origins. Consumers must use this projection instead of reconstructing domains from a project ref or a platform base domain.
+
+## Management API
+
+Selected-project read:
+
+```http
+GET /v1/projects/:ref/endpoint/projection
+```
+
+This route accepts the selected project's Management API credential or an Admin credential.
+
+Platform inventory:
+
+```http
+GET /v1/projects/endpoints
+```
+
+The inventory route is Admin-only. It does not widen project-scoped credentials or return project secrets.
+
+A projection has the fixed schema:
+
+```json
+{
+  "schema": "supacloud.project-endpoints.v1",
+  "project_ref": "abc123",
+  "endpoints": {
+    "api": {
+      "origin": "https://api.example.com",
+      "host": "api.example.com",
+      "scheme": "https",
+      "source": "explicit_api_domain",
+      "aliases": ["abc123.api.platform.example"]
+    },
+    "auth": {
+      "origin": "https://auth.example.com",
+      "host": "auth.example.com",
+      "scheme": "https",
+      "source": "explicit_auth_domain",
+      "aliases": []
+    },
+    "studio": {
+      "origin": "https://studio.example.com",
+      "host": "studio.example.com",
+      "scheme": "https",
+      "source": "explicit_studio_domain",
+      "aliases": []
+    }
+  }
+}
+```
+
+The allowed `source` values are:
+
+- `explicit_api_domain`
+- `explicit_auth_domain`
+- `explicit_studio_domain`
+- `custom_domain`
+- `derived_api_domain`
+- `generated`
+
+The projection reuses the same routing resolver that builds tenant gateway configuration. It canonicalizes origins and aliases and never includes credentials, paths, query strings, fragments, project config, API keys, or runtime receipts.
+
+## CLI commands
+
+Selected project:
+
+```bash
+supacloud-cli project endpoints --ref abc123
+```
+
+`--ref` may be omitted when the selected Management profile already binds one project.
+
+Admin reads:
+
+```bash
+supacloud-admin project endpoints --ref abc123
+supacloud-admin project list_endpoints
+```
+
+`supacloud-cli project list` deliberately does not enumerate the fleet. It returns guidance to use `supacloud-admin project list`, preserving the project/Admin credential boundary.
+
+## What the projection proves
+
+The projection proves how SupaCloud currently resolves the configured public origins. It does **not** prove that:
+
+- DNS resolves to the intended gateway;
+- a certificate has been issued or deployed;
+- Caddy has published the route;
+- API, Auth, or Studio is healthy;
+- a custom hostname verification challenge has completed.
+
+Use project health, gateway route, custom-hostname, and certificate inspection commands before reporting readiness.
+
+## Compatibility
+
+The existing Studio-compatible endpoint remains unchanged:
+
+```http
+GET /v1/projects/:ref/endpoint
+```
+
+The new projection uses a separate path and fixed response schema so existing integrations are not forced to accept additional fields. Release Please owns package version and changelog updates; feature commits must not manually bump package versions.

--- a/packages/admin/src/shared/execution-policy.ts
+++ b/packages/admin/src/shared/execution-policy.ts
@@ -13,7 +13,7 @@ interface ModulePolicy {
 const ACTION_POLICY: Record<string, ModulePolicy> = {
     project: {
         read: [
-            "list", "get", "settings", "api_keys", "health", "logs", "tasks", "services", "runtime_snapshot",
+            "list", "get", "endpoints", "list_endpoints", "settings", "api_keys", "health", "logs", "tasks", "services", "runtime_snapshot",
         ],
         write: ["create", "delete", "pause", "restore", "restart", "update_settings"],
     },
@@ -125,7 +125,7 @@ function requestedProjectRef(
 ): string | null {
     if (moduleName === "ssh") return sshRequestedProjectRef(action, args);
     if (moduleName === "project") {
-        return ["list", "create"].includes(action) ? null : stringArgument(args, "ref");
+        return ["list", "list_endpoints", "create"].includes(action) ? null : stringArgument(args, "ref");
     }
     if (moduleName === "platform") {
         return PLATFORM_PROJECT_REF_ACTIONS.has(action) ? stringArgument(args, "ref") : null;

--- a/packages/admin/src/shared/tools/project-cli-tools.ts
+++ b/packages/admin/src/shared/tools/project-cli-tools.ts
@@ -23,6 +23,12 @@ import {
     projectListRead,
     type ProjectReadResult,
 } from "./project-read-projection";
+import {
+    PROJECT_ENDPOINT_LIST_RESPONSE_MAX_BYTES,
+    PROJECT_ENDPOINT_RESPONSE_MAX_BYTES,
+    projectEndpointListRead,
+    projectEndpointRead,
+} from "./project-endpoint-read";
 import { parseProjectRuntimeSnapshot } from "./project-runtime-snapshot";
 
 type ToolServer = {
@@ -511,6 +517,10 @@ function resolveRef(refFromArgs: string | undefined, defaultRef?: string): strin
     return ref;
 }
 
+function projectEndpointProjectionPath(ref: string): string {
+    return `/v1/projects/${encodeURIComponent(ref)}/endpoint/projection`;
+}
+
 export function registerUserProjectCliTools(
     server: ToolServer,
     http: HttpTransport,
@@ -574,14 +584,14 @@ export function registerAdminProjectCliTools(
     const fileOperations = options.projectEnvFileOperations;
     server.tool(
         "project",
-        "Platform-level project lifecycle management. Actions: list, create, get, delete, pause, restore, restart, settings, update_settings, api_keys, health, logs, tasks, services, runtime_snapshot, service_control",
+        "Platform-level project lifecycle management. Actions: list, list_endpoints, create, get, endpoints, delete, pause, restore, restart, settings, update_settings, api_keys, health, logs, tasks, services, runtime_snapshot, service_control",
         {
             action: withDescription(stringEnum([
-                "list", "create", "get", "delete", "pause", "restore",
+                "list", "list_endpoints", "create", "get", "endpoints", "delete", "pause", "restore",
                 "restart", "settings", "update_settings", "api_keys",
                 "health", "logs", "tasks", "services", "runtime_snapshot", "service_control",
             ]), "Action to perform"),
-            ref: optional(Type.String(), "[*] Project ref (required for most actions except 'list' and 'create')"),
+            ref: optional(Type.String(), "[*] Project ref (required for most actions except 'list', 'list_endpoints', and 'create')"),
             name: optional(Type.String(), "[create] Project name"),
             region: optional(Type.String(), "[create] Region (default: local)"),
             organization_id: optional(Type.String(), "[create] Organization ID"),
@@ -628,6 +638,10 @@ export function registerAdminProjectCliTools(
                 case "list":
                     return projectReadResponse(projectListRead(await http.get("/v1/projects", {
                         maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                    })));
+                case "list_endpoints":
+                    return projectReadResponse(projectEndpointListRead(await http.get("/v1/projects/endpoints", {
+                        maxResponseBytes: PROJECT_ENDPOINT_LIST_RESPONSE_MAX_BYTES,
                     })));
                 case "create": {
                     if (!name) throw new Error("'name' is required for create");
@@ -676,6 +690,15 @@ export function registerAdminProjectCliTools(
                     return projectReadResponse(projectGetRead(
                         await http.get(`/v1/projects/${resolvedRef}`, {
                             maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                        }),
+                        resolvedRef,
+                    ));
+                }
+                case "endpoints": {
+                    const resolvedRef = resolveRef(ref);
+                    return projectReadResponse(projectEndpointRead(
+                        await http.get(projectEndpointProjectionPath(resolvedRef), {
+                            maxResponseBytes: PROJECT_ENDPOINT_RESPONSE_MAX_BYTES,
                         }),
                         resolvedRef,
                     ));

--- a/packages/admin/src/shared/tools/project-endpoint-read.ts
+++ b/packages/admin/src/shared/tools/project-endpoint-read.ts
@@ -1,0 +1,1 @@
+export * from "../../../../cli/src/shared/tools/project-endpoint-read";

--- a/packages/admin/src/shared/tools/project-endpoint-tools.test.ts
+++ b/packages/admin/src/shared/tools/project-endpoint-tools.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { schemaEnumValues, type ToolSchema } from "../schema";
+import { registerAdminProjectCliTools } from "./project-cli-tools";
+
+const PROJECT_REF = "abc123";
+const PROJECT_ENDPOINTS = {
+    schema: "supacloud.project-endpoints.v1",
+    project_ref: PROJECT_REF,
+    endpoints: {
+        api: {
+            origin: "https://api.example.com",
+            host: "api.example.com",
+            scheme: "https",
+            source: "explicit_api_domain",
+            aliases: ["abc123.api.platform.example"],
+        },
+        auth: {
+            origin: "https://auth.example.com",
+            host: "auth.example.com",
+            scheme: "https",
+            source: "explicit_auth_domain",
+            aliases: [],
+        },
+        studio: {
+            origin: "https://studio.example.com",
+            host: "studio.example.com",
+            scheme: "https",
+            source: "explicit_studio_domain",
+            aliases: [],
+        },
+    },
+};
+
+type CapturedProjectTool = {
+    schema: ToolSchema;
+    callback: (args: Record<string, unknown>) => Promise<any>;
+};
+
+function captureAdminProjectTool(http: Record<string, unknown>): CapturedProjectTool {
+    let captured: CapturedProjectTool | undefined;
+    registerAdminProjectCliTools({
+        tool(name: string, _description: string, schema: ToolSchema, callback: CapturedProjectTool["callback"]) {
+            if (name === "project") captured = { schema, callback };
+        },
+    }, http as any);
+    if (!captured) throw new Error("admin project tool was not registered");
+    return captured;
+}
+
+describe("admin project endpoint CLI actions", () => {
+    test("exposes single-project and fleet endpoint reads", async () => {
+        const requests: Array<{ path: string; maxResponseBytes?: number }> = [];
+        const tool = captureAdminProjectTool({
+            get: async (path: string, options?: { maxResponseBytes?: number }) => {
+                requests.push({ path, maxResponseBytes: options?.maxResponseBytes });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: path === "/v1/projects/endpoints" ? [PROJECT_ENDPOINTS] : PROJECT_ENDPOINTS,
+                };
+            },
+        });
+
+        expect(schemaEnumValues(tool.schema.action)).toEqual(
+            expect.arrayContaining(["endpoints", "list_endpoints"]),
+        );
+
+        const single = await tool.callback({ action: "endpoints", ref: PROJECT_REF });
+        const list = await tool.callback({ action: "list_endpoints" });
+
+        expect(requests).toEqual([
+            {
+                path: `/v1/projects/${PROJECT_REF}/endpoint/projection`,
+                maxResponseBytes: 256 * 1024,
+            },
+            {
+                path: "/v1/projects/endpoints",
+                maxResponseBytes: 1024 * 1024,
+            },
+        ]);
+        expect(single.isError).not.toBe(true);
+        expect(list.isError).not.toBe(true);
+        expect(JSON.parse(single.content[0].text)).toEqual(PROJECT_ENDPOINTS);
+        expect(JSON.parse(list.content[0].text)).toEqual([PROJECT_ENDPOINTS]);
+    });
+
+    test("rejects secret-bearing endpoint responses without reflection", async () => {
+        const remoteSecret = "admin-project-endpoint-private-sentinel";
+        const tool = captureAdminProjectTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { ...PROJECT_ENDPOINTS, credentials: { service_role_key: remoteSecret } },
+            }),
+        });
+
+        const response = await tool.callback({ action: "endpoints", ref: PROJECT_REF });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toBe("❌ Invalid project endpoint response");
+        expect(response.content[0].text).not.toContain(remoteSecret);
+    });
+});

--- a/packages/cli/skills/supacloud-cli/SKILL.md
+++ b/packages/cli/skills/supacloud-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: supacloud-cli
-description: Use when operating, implementing, diagnosing, deploying, or documenting a SupaCloud project through supacloud-cli, especially database schema, functions/RPC, triggers, RLS, indexes, grants, extensions, migrations, backups, auth, storage, Edge Functions, frontend, queues, task events, diagnostics, or gateway work. Also use when an AI might otherwise call SQL, psql, a database API, or the Management API directly.
+description: Use when operating, implementing, diagnosing, deploying, or documenting a SupaCloud project through supacloud-cli, especially project endpoint discovery, database schema, functions/RPC, triggers, RLS, indexes, grants, extensions, migrations, backups, auth, storage, Edge Functions, frontend, queues, task events, diagnostics, or gateway work. Also use when an AI might otherwise call SQL, psql, a database API, or the Management API directly.
 ---
 
 # SupaCloud CLI
@@ -24,6 +24,8 @@ Use `supacloud-cli` as the project-level control surface and keep durable change
 5. Run a remote migration dry-run before apply. Production apply requires explicit user approval in the current task.
 6. Do not edit `supabase_migrations.schema_migrations` through ordinary SQL. Migration history is an application ledger, not a schema backup or source of truth. For a proven-equivalent historical baseline, use the controlled `database baseline_migrations` action with dry-run and explicit approval.
 7. Service-role credentials authenticate the SupaCloud Management API. Never reinterpret them as PostgreSQL passwords or forward them to the official Supabase CLI.
+8. Read project domains through `supacloud-cli project endpoints`. Do not infer API, Auth, or Studio origins by concatenating project refs and base domains. The projection reports configuration, not DNS/certificate/runtime readiness.
+9. Cross-project enumeration is an Admin boundary. Use `supacloud-admin project list` or `supacloud-admin project list_endpoints`; do not attempt to widen project credentials.
 
 ## Workflow
 
@@ -35,6 +37,20 @@ Use `supacloud-cli` as the project-level control surface and keep durable change
 6. Preview remote changes with `--dry_run`.
 7. Apply only within the user-authorized environment and scope.
 8. Read back migration history and affected resources; report exact evidence and any remaining drift.
+
+## Project endpoint inspection
+
+For the selected project:
+
+```bash
+supacloud-cli status
+supacloud-cli project endpoints
+```
+
+The fixed projection contains credential-free API/Auth/Studio origins, hosts,
+schemes, source classifications, and API aliases. Follow it with the relevant
+health or gateway command before claiming that DNS, TLS, routing, or a runtime is
+ready. Project-wide or fleet-wide inventories belong to `supacloud-admin`.
 
 ## Database default
 
@@ -66,8 +82,8 @@ supacloud-cli database baseline_migrations \
 
 ## CLI boundaries
 
-- `supacloud-cli`: project status, database, migrations, auth, storage, Edge Functions, frontend, queues, task events, diagnostics, and project gateway configuration.
-- `supacloud-admin`: installation, upgrades, SSH diagnostics, platform-wide project lifecycle, tenant runtime, and server operations.
+- `supacloud-cli`: selected-project status and endpoint projection, database, migrations, auth, storage, Edge Functions, frontend, queues, task events, diagnostics, and project gateway configuration.
+- `supacloud-admin`: installation, upgrades, SSH diagnostics, platform-wide project/endpoint inventory, project lifecycle, tenant runtime, and server operations.
 - Official `supabase` CLI: invoked only through the allowlisted `supacloud-cli supabase` adapter for supported local authoring or explicit-DSN inspection commands.
 - Direct HTTP/SQL: read-only diagnosis or an explicitly approved break-glass path; never the default implementation path.
 

--- a/packages/cli/skills/supacloud-cli/references/command-map.md
+++ b/packages/cli/skills/supacloud-cli/references/command-map.md
@@ -7,6 +7,8 @@ Load this reference when selecting a command surface or when a user asks an AI t
 | Intent | Use | Guardrail |
 | --- | --- | --- |
 | Inspect current project binding | `supacloud-cli status` | Read-only; run first |
+| Inspect selected project API/Auth/Studio origins | `supacloud-cli project endpoints` | Uses the Management API's authoritative projection; do not reconstruct domains locally |
+| Enumerate projects or endpoint projections | `supacloud-admin project list` / `project list_endpoints` | Platform-wide read; never promote a project credential to Admin authority |
 | Inspect project health/logs/tasks | `project`, `queue`, `task_events`, `diagnostics` | Prefer bounded reads |
 | Read database rows or metadata | `database query` and database inspection actions | `SELECT`/read-only by default |
 | Create schema/function/RPC/trigger/RLS/index/grant/extension | `supabase migration_new`, then edit SQL | Never direct remote DDL |
@@ -26,7 +28,7 @@ until a project-scoped context is resolved.
 ## Command groups
 
 - `status`: resolved context, Management API connectivity, authentication, and project reachability.
-- `project`: project metadata, health, logs, API keys/settings, background tasks, retry/cancel, DLQ, and background settings.
+- `project`: selected-project metadata, authoritative endpoint projection, health, logs, API keys/settings, background tasks, retry/cancel, DLQ, and background settings. `project list` deliberately redirects to `supacloud-admin`; cross-project enumeration is not a project CLI capability.
 - `database`: read/query, schema inspection, extensions, indexes, RLS, stats, migration push, controlled historical baseline, and SQL-file execution.
 - `supabase`: allowlisted official CLI adapter for migration authoring, local reset/diff, explicit-DSN inspection/backup/type generation, and SupaCloud-controlled migration push.
 - `auth`: provider and authentication configuration.
@@ -43,8 +45,14 @@ until a project-scoped context is resolved.
 ```bash
 supacloud-cli status
 supacloud-cli project get
+supacloud-cli project endpoints
 supacloud-cli project health
 supacloud-cli supabase migration_list --db_url "$SUPACLOUD_DB_URL"
 ```
+
+The endpoint projection returns bounded, credential-free API/Auth/Studio origins,
+canonical hosts, URL schemes, configuration sources, and API aliases. It does
+not assert DNS, certificate, or runtime readiness; use the relevant health and
+gateway inspection commands for those checks.
 
 Do not paste the DSN value into chat or commit it to shell scripts. Prefer an environment variable supplied outside the repository.

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -12,8 +12,9 @@ interface ModulePolicy {
 
 const ACTION_POLICY: Record<string, ModulePolicy> = {
     project: {
-        read: ["get", "health", "logs", "api_keys", "settings", "tasks", "task_detail", "task_stats", "dlq", "background_settings"],
+        read: ["get", "endpoints", "health", "logs", "api_keys", "settings", "tasks", "task_detail", "task_stats", "dlq", "background_settings"],
         write: ["pause", "restore", "task_cancel", "task_retry", "update_background_settings"],
+        local: ["list"],
     },
     database: {
         read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "migration_inventory", "project_url", "generate_types"],

--- a/packages/cli/src/shared/tools/project-cli-tools.ts
+++ b/packages/cli/src/shared/tools/project-cli-tools.ts
@@ -8,6 +8,12 @@ import {
     projectListRead,
     type ProjectReadResult,
 } from "./project-read-projection";
+import {
+    PROJECT_ENDPOINT_LIST_RESPONSE_MAX_BYTES,
+    PROJECT_ENDPOINT_RESPONSE_MAX_BYTES,
+    projectEndpointListRead,
+    projectEndpointRead,
+} from "./project-endpoint-read";
 
 type ToolServer = {
     tool: (
@@ -120,6 +126,10 @@ function resolveRef(refFromArgs: string | undefined, defaultRef?: string): strin
     return ref;
 }
 
+function projectEndpointProjectionPath(ref: string): string {
+    return `/v1/projects/${encodeURIComponent(ref)}/endpoint/projection`;
+}
+
 // --- User-facing project tool ---
 
 export function registerUserProjectCliTools(
@@ -132,10 +142,10 @@ export function registerUserProjectCliTools(
     server.tool(
         "project",
         `Project-scoped inspection and developer operations.
-Actions: get, pause, restore, health, logs, api_keys, settings, tasks, task_detail, task_cancel, task_retry, task_stats, dlq, background_settings, update_background_settings`,
+Actions: list (Admin guidance), get, endpoints, pause, restore, health, logs, api_keys, settings, tasks, task_detail, task_cancel, task_retry, task_stats, dlq, background_settings, update_background_settings`,
         {
             action: withDescription(stringEnum([
-                "get", "pause", "restore", "health", "logs", "api_keys", "settings",
+                "list", "get", "endpoints", "pause", "restore", "health", "logs", "api_keys", "settings",
                 "tasks", "task_detail", "task_cancel", "task_retry", "task_stats", "dlq",
                 "background_settings", "update_background_settings",
             ]), "Action to perform"),
@@ -147,6 +157,19 @@ Actions: get, pause, restore, health, logs, api_keys, settings, tasks, task_deta
             max_attempts: optional(Type.Number(), "[update_background_settings] Max attempts for background tasks"),
         },
         async ({ action, ref, log_type, task_id, limit, concurrency, max_attempts }) => {
+            if (action === "list") {
+                return {
+                    isError: true,
+                    content: [{
+                        type: "text" as const,
+                        text: [
+                            "⚠️ Project enumeration is a platform administration operation.",
+                            "Use `supacloud-admin project list` with an admin Management API context.",
+                        ].join("\n"),
+                    }],
+                };
+            }
+
             const resolvedRef = resolveRef(ref, projectRef);
             let text: string;
 
@@ -155,6 +178,13 @@ Actions: get, pause, restore, health, logs, api_keys, settings, tasks, task_deta
                     return projectReadResponse(projectGetRead(
                         await http.get(`/v1/projects/${resolvedRef}`, {
                             maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                        }),
+                        resolvedRef,
+                    ));
+                case "endpoints":
+                    return projectReadResponse(projectEndpointRead(
+                        await http.get(projectEndpointProjectionPath(resolvedRef), {
+                            maxResponseBytes: PROJECT_ENDPOINT_RESPONSE_MAX_BYTES,
                         }),
                         resolvedRef,
                     ));
@@ -250,16 +280,16 @@ export function registerAdminProjectCliTools(server: ToolServer, http: HttpTrans
     server.tool(
         "project",
         `Platform-level project lifecycle management.
-Actions: list, create, get, delete, pause, restore, restart, settings, update_settings, api_keys, health, logs, tasks, task_detail, task_cancel, task_retry, task_stats, dlq, background_settings, update_background_settings`,
+Actions: list, list_endpoints, create, get, endpoints, delete, pause, restore, restart, settings, update_settings, api_keys, health, logs, tasks, task_detail, task_cancel, task_retry, task_stats, dlq, background_settings, update_background_settings`,
         {
             action: withDescription(stringEnum([
-                "list", "create", "get", "delete", "pause", "restore",
+                "list", "list_endpoints", "create", "get", "endpoints", "delete", "pause", "restore",
                 "restart", "settings", "update_settings", "api_keys",
                 "health", "logs",
                 "tasks", "task_detail", "task_cancel", "task_retry", "task_stats", "dlq",
                 "background_settings", "update_background_settings",
             ]), "Action to perform"),
-            ref: optional(Type.String(), "Project ref (required for most actions except 'list' and 'create')"),
+            ref: optional(Type.String(), "Project ref (required for most actions except 'list', 'list_endpoints', and 'create')"),
             name: optional(Type.String(), "[create] Project name"),
             region: optional(Type.String(), "[create] Region (default: local)"),
             organization_id: optional(Type.String(), "[create] Organization ID"),
@@ -298,6 +328,10 @@ Actions: list, create, get, delete, pause, restore, restart, settings, update_se
                     return projectReadResponse(projectListRead(await http.get("/v1/projects", {
                         maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
                     })));
+                case "list_endpoints":
+                    return projectReadResponse(projectEndpointListRead(await http.get("/v1/projects/endpoints", {
+                        maxResponseBytes: PROJECT_ENDPOINT_LIST_RESPONSE_MAX_BYTES,
+                    })));
                 case "create": {
                     if (!name) throw new Error("'name' is required for create");
                     const createRequest: Record<string, string | undefined> = {
@@ -317,6 +351,15 @@ Actions: list, create, get, delete, pause, restore, restart, settings, update_se
                     return projectReadResponse(projectGetRead(
                         await http.get(`/v1/projects/${resolvedRef}`, {
                             maxResponseBytes: PROJECT_READ_RESPONSE_MAX_BYTES,
+                        }),
+                        resolvedRef,
+                    ));
+                }
+                case "endpoints": {
+                    const resolvedRef = resolveRef(ref);
+                    return projectReadResponse(projectEndpointRead(
+                        await http.get(projectEndpointProjectionPath(resolvedRef), {
+                            maxResponseBytes: PROJECT_ENDPOINT_RESPONSE_MAX_BYTES,
                         }),
                         resolvedRef,
                     ));

--- a/packages/cli/src/shared/tools/project-endpoint-read.ts
+++ b/packages/cli/src/shared/tools/project-endpoint-read.ts
@@ -1,0 +1,192 @@
+import type { HttpResult } from "../transports/http";
+
+export const PROJECT_ENDPOINT_RESPONSE_MAX_BYTES = 256 * 1024;
+export const PROJECT_ENDPOINT_LIST_RESPONSE_MAX_BYTES = 1024 * 1024;
+
+const PROJECT_REF_PATTERN = /^[a-z0-9-]{1,20}$/;
+const PROJECT_ENDPOINTS_SCHEMA = "supacloud.project-endpoints.v1";
+const PROJECT_ENDPOINT_SOURCES = new Set([
+    "explicit_api_domain",
+    "explicit_auth_domain",
+    "explicit_studio_domain",
+    "custom_domain",
+    "derived_api_domain",
+    "generated",
+]);
+const ROOT_KEYS = new Set(["schema", "project_ref", "endpoints"]);
+const ENDPOINTS_KEYS = new Set(["api", "auth", "studio"]);
+const ENDPOINT_KEYS = new Set(["origin", "host", "scheme", "source", "aliases"]);
+const MAX_PROJECTS = 10_000;
+const MAX_ALIASES = 64;
+
+export type ProjectEndpointReadResult = {
+    text: string;
+    isError: boolean;
+};
+
+type SafeProjectEndpoint = {
+    origin: string;
+    host: string;
+    scheme: "http" | "https";
+    source: string;
+    aliases: string[];
+};
+
+type SafeProjectEndpointProjection = {
+    schema: typeof PROJECT_ENDPOINTS_SCHEMA;
+    project_ref: string;
+    endpoints: {
+        api: SafeProjectEndpoint;
+        auth: SafeProjectEndpoint;
+        studio: SafeProjectEndpoint;
+    };
+};
+
+function plainRecord(candidate: unknown): Record<string, unknown> | null {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+    const prototype = Object.getPrototypeOf(candidate);
+    return prototype === Object.prototype || prototype === null
+        ? candidate as Record<string, unknown>
+        : null;
+}
+
+function hasOnlyKeys(record: Record<string, unknown>, allowedKeys: ReadonlySet<string>): boolean {
+    return Object.keys(record).every((key) => allowedKeys.has(key));
+}
+
+function boundedText(candidate: unknown, maxLength: number): string | null {
+    return typeof candidate === "string"
+        && candidate.length > 0
+        && candidate.length <= maxLength
+        && !/[\u0000-\u001f\u007f]/u.test(candidate)
+        ? candidate
+        : null;
+}
+
+function canonicalHost(candidate: unknown, scheme: "http" | "https"): string | null {
+    const host = boundedText(candidate, 255);
+    if (!host) return null;
+    try {
+        const parsed = new URL(`${scheme}://${host}`);
+        return parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash
+            || parsed.host !== host
+            ? null
+            : host;
+    } catch {
+        return null;
+    }
+}
+
+function projectEndpoint(candidate: unknown): SafeProjectEndpoint | null {
+    const endpoint = plainRecord(candidate);
+    if (!endpoint || !hasOnlyKeys(endpoint, ENDPOINT_KEYS)) return null;
+    const scheme = endpoint.scheme === "http" || endpoint.scheme === "https"
+        ? endpoint.scheme
+        : null;
+    const origin = boundedText(endpoint.origin, 2_048);
+    const source = boundedText(endpoint.source, 64);
+    if (!scheme || !origin || !source || !PROJECT_ENDPOINT_SOURCES.has(source)) return null;
+
+    let parsedOrigin: URL;
+    try {
+        parsedOrigin = new URL(origin);
+    } catch {
+        return null;
+    }
+    if (parsedOrigin.protocol !== `${scheme}:`
+        || parsedOrigin.origin !== origin
+        || parsedOrigin.username
+        || parsedOrigin.password
+        || parsedOrigin.pathname !== "/"
+        || parsedOrigin.search
+        || parsedOrigin.hash) return null;
+
+    const host = canonicalHost(endpoint.host, scheme);
+    if (!host || host !== parsedOrigin.host || !Array.isArray(endpoint.aliases)
+        || endpoint.aliases.length > MAX_ALIASES) return null;
+
+    const aliases: string[] = [];
+    const seenAliases = new Set<string>();
+    for (const aliasCandidate of endpoint.aliases) {
+        const alias = canonicalHost(aliasCandidate, scheme);
+        if (!alias || alias === host || seenAliases.has(alias)) return null;
+        seenAliases.add(alias);
+        aliases.push(alias);
+    }
+
+    return { origin, host, scheme, source, aliases };
+}
+
+function projectEndpointProjection(candidate: unknown): SafeProjectEndpointProjection | null {
+    const projection = plainRecord(candidate);
+    if (!projection || !hasOnlyKeys(projection, ROOT_KEYS)
+        || projection.schema !== PROJECT_ENDPOINTS_SCHEMA
+        || typeof projection.project_ref !== "string"
+        || !PROJECT_REF_PATTERN.test(projection.project_ref)) return null;
+
+    const endpoints = plainRecord(projection.endpoints);
+    if (!endpoints || !hasOnlyKeys(endpoints, ENDPOINTS_KEYS)) return null;
+    const api = projectEndpoint(endpoints.api);
+    const auth = projectEndpoint(endpoints.auth);
+    const studio = projectEndpoint(endpoints.studio);
+    return api && auth && studio
+        ? {
+            schema: PROJECT_ENDPOINTS_SCHEMA,
+            project_ref: projection.project_ref,
+            endpoints: { api, auth, studio },
+        }
+        : null;
+}
+
+function validHttpStatus(status: number): boolean {
+    return Number.isSafeInteger(status) && status >= 100 && status <= 599;
+}
+
+function successfulResponse(response: HttpResult<unknown>): boolean {
+    return response.ok === true
+        && validHttpStatus(response.status)
+        && response.status >= 200
+        && response.status <= 299;
+}
+
+function failedResult(message: string): ProjectEndpointReadResult {
+    return { text: `❌ ${message}`, isError: true };
+}
+
+function failedHttpResult(label: string, status: number): ProjectEndpointReadResult {
+    return failedResult(validHttpStatus(status) ? `${label} request failed (${status})` : `${label} request failed`);
+}
+
+function successfulResult(payload: SafeProjectEndpointProjection | SafeProjectEndpointProjection[]): ProjectEndpointReadResult {
+    return { text: JSON.stringify(payload, null, 2), isError: false };
+}
+
+export function projectEndpointRead(
+    response: HttpResult<unknown>,
+    expectedRef: string,
+): ProjectEndpointReadResult {
+    if (!successfulResponse(response)) return failedHttpResult("Project endpoints", response.status);
+    const projection = projectEndpointProjection(response.data);
+    return projection && projection.project_ref === expectedRef
+        ? successfulResult(projection)
+        : failedResult("Invalid project endpoint response");
+}
+
+export function projectEndpointListRead(response: HttpResult<unknown>): ProjectEndpointReadResult {
+    if (!successfulResponse(response)) return failedHttpResult("Project endpoint list", response.status);
+    if (!Array.isArray(response.data) || response.data.length > MAX_PROJECTS) {
+        return failedResult("Invalid project endpoint list response");
+    }
+
+    const projections: SafeProjectEndpointProjection[] = [];
+    const refs = new Set<string>();
+    for (const candidate of response.data) {
+        const projection = projectEndpointProjection(candidate);
+        if (!projection || refs.has(projection.project_ref)) {
+            return failedResult("Invalid project endpoint list response");
+        }
+        refs.add(projection.project_ref);
+        projections.push(projection);
+    }
+    return successfulResult(projections);
+}

--- a/packages/cli/src/shared/tools/project-endpoint-tools.test.ts
+++ b/packages/cli/src/shared/tools/project-endpoint-tools.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import { schemaEnumValues, type ToolSchema } from "../schema";
+import { registerAdminProjectCliTools, registerUserProjectCliTools } from "./project-cli-tools";
+
+const PROJECT_REF = "abc123";
+const PROJECT_ENDPOINTS = {
+    schema: "supacloud.project-endpoints.v1",
+    project_ref: PROJECT_REF,
+    endpoints: {
+        api: {
+            origin: "https://api.example.com",
+            host: "api.example.com",
+            scheme: "https",
+            source: "explicit_api_domain",
+            aliases: ["abc123.api.platform.example"],
+        },
+        auth: {
+            origin: "https://auth.example.com",
+            host: "auth.example.com",
+            scheme: "https",
+            source: "explicit_auth_domain",
+            aliases: [],
+        },
+        studio: {
+            origin: "https://studio.example.com",
+            host: "studio.example.com",
+            scheme: "https",
+            source: "explicit_studio_domain",
+            aliases: [],
+        },
+    },
+};
+
+type CapturedProjectTool = {
+    schema: ToolSchema;
+    callback: (args: Record<string, unknown>) => Promise<any>;
+};
+
+function captureUserProjectTool(http: Record<string, unknown>, projectRef = PROJECT_REF): CapturedProjectTool {
+    let captured: CapturedProjectTool | undefined;
+    registerUserProjectCliTools({
+        tool(name: string, _description: string, schema: ToolSchema, callback: CapturedProjectTool["callback"]) {
+            if (name === "project") captured = { schema, callback };
+        },
+    }, http as any, { projectRef });
+    if (!captured) throw new Error("project tool was not registered");
+    return captured;
+}
+
+function captureAdminProjectTool(http: Record<string, unknown>): CapturedProjectTool {
+    let captured: CapturedProjectTool | undefined;
+    registerAdminProjectCliTools({
+        tool(name: string, _description: string, schema: ToolSchema, callback: CapturedProjectTool["callback"]) {
+            if (name === "project") captured = { schema, callback };
+        },
+    }, http as any);
+    if (!captured) throw new Error("admin project tool was not registered");
+    return captured;
+}
+
+describe("project endpoint CLI actions", () => {
+    test("reads the selected project endpoint projection through the user CLI", async () => {
+        const requests: Array<{ path: string; maxResponseBytes?: number }> = [];
+        const tool = captureUserProjectTool({
+            get: async (path: string, options?: { maxResponseBytes?: number }) => {
+                requests.push({ path, maxResponseBytes: options?.maxResponseBytes });
+                return { ok: true, status: 200, data: PROJECT_ENDPOINTS };
+            },
+        });
+
+        expect(schemaEnumValues(tool.schema.action)).toEqual(expect.arrayContaining(["endpoints", "list"]));
+        const response = await tool.callback({ action: "endpoints" });
+
+        expect(requests).toEqual([{
+            path: `/v1/projects/${PROJECT_REF}/endpoint/projection`,
+            maxResponseBytes: 256 * 1024,
+        }]);
+        expect(response.isError).not.toBe(true);
+        expect(JSON.parse(response.content[0].text)).toEqual(PROJECT_ENDPOINTS);
+    });
+
+    test("redirects cross-project enumeration to the Admin CLI without HTTP", async () => {
+        let requestCount = 0;
+        const tool = captureUserProjectTool({
+            get: async () => {
+                requestCount += 1;
+                return { ok: true, status: 200, data: [] };
+            },
+        });
+
+        const response = await tool.callback({ action: "list" });
+
+        expect(requestCount).toBe(0);
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toContain("supacloud-admin project list");
+    });
+
+    test("supports single and bulk endpoint reads through the Admin CLI", async () => {
+        const requests: Array<{ path: string; maxResponseBytes?: number }> = [];
+        const tool = captureAdminProjectTool({
+            get: async (path: string, options?: { maxResponseBytes?: number }) => {
+                requests.push({ path, maxResponseBytes: options?.maxResponseBytes });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: path === "/v1/projects/endpoints" ? [PROJECT_ENDPOINTS] : PROJECT_ENDPOINTS,
+                };
+            },
+        });
+
+        expect(schemaEnumValues(tool.schema.action)).toEqual(expect.arrayContaining(["endpoints", "list_endpoints"]));
+        const single = await tool.callback({ action: "endpoints", ref: PROJECT_REF });
+        const list = await tool.callback({ action: "list_endpoints" });
+
+        expect(requests).toEqual([
+            {
+                path: `/v1/projects/${PROJECT_REF}/endpoint/projection`,
+                maxResponseBytes: 256 * 1024,
+            },
+            {
+                path: "/v1/projects/endpoints",
+                maxResponseBytes: 1024 * 1024,
+            },
+        ]);
+        expect(JSON.parse(single.content[0].text)).toEqual(PROJECT_ENDPOINTS);
+        expect(JSON.parse(list.content[0].text)).toEqual([PROJECT_ENDPOINTS]);
+    });
+
+    test("rejects malformed endpoint projections without reflecting remote content", async () => {
+        const remoteSecret = "project-endpoint-private-sentinel";
+        const tool = captureUserProjectTool({
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: { ...PROJECT_ENDPOINTS, credentials: { service_role_key: remoteSecret } },
+            }),
+        });
+
+        const response = await tool.callback({ action: "endpoints" });
+
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).toBe("❌ Invalid project endpoint response");
+        expect(response.content[0].text).not.toContain(remoteSecret);
+    });
+});

--- a/packages/management-api/src/routes/project-endpoints.ts
+++ b/packages/management-api/src/routes/project-endpoints.ts
@@ -1,0 +1,121 @@
+import { Elysia, status, t } from "elysia";
+import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
+import { projectService } from "../services";
+import {
+  buildProjectEndpointsProjection,
+  PROJECT_ENDPOINTS_SCHEMA,
+} from "../utils/project-endpoint-projection";
+import { validationErrorResponse } from "../utils/http-validation";
+import { logger } from "../utils/logger";
+
+const ProjectEndpointSourceSchema = t.Union([
+  t.Literal("explicit_api_domain"),
+  t.Literal("explicit_auth_domain"),
+  t.Literal("explicit_studio_domain"),
+  t.Literal("custom_domain"),
+  t.Literal("derived_api_domain"),
+  t.Literal("generated"),
+]);
+
+const ProjectEndpointSchema = t.Object(
+  {
+    origin: t.String(),
+    host: t.String(),
+    scheme: t.Union([t.Literal("http"), t.Literal("https")]),
+    source: ProjectEndpointSourceSchema,
+    aliases: t.Array(t.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const V1ProjectEndpointsResponseSchema = t.Object(
+  {
+    schema: t.Literal(PROJECT_ENDPOINTS_SCHEMA),
+    project_ref: t.String(),
+    endpoints: t.Object(
+      {
+        api: ProjectEndpointSchema,
+        auth: ProjectEndpointSchema,
+        studio: ProjectEndpointSchema,
+      },
+      { additionalProperties: false },
+    ),
+  },
+  { additionalProperties: false },
+);
+
+const ProjectEndpointErrorSchema = t.Object(
+  {
+    message: t.String(),
+    code: t.String(),
+  },
+  { additionalProperties: false },
+);
+
+function endpointProjection(project: any) {
+  return buildProjectEndpointsProjection(project.ref, project.config);
+}
+
+export const projectEndpointRoutes = new Elysia({ prefix: "/v1/projects" })
+  .onError(({ code, error, set }) => {
+    if (code === "VALIDATION") return validationErrorResponse(set);
+    logger.error(`[ProjectEndpoints] Unhandled error [${code}]:`, error);
+    set.status = code === "NOT_FOUND" ? 404 : 500;
+    return {
+      message: code === "NOT_FOUND" ? "Not found" : "Failed to project project endpoints",
+      code: code === "NOT_FOUND" ? "NOT_FOUND" : "PROJECT_ENDPOINT_PROJECTION_FAILED",
+    };
+  })
+  .get(
+    "/endpoints",
+    async ({ request }) => {
+      const authError = await requireAdminAuth(request);
+      if (authError) {
+        return status(authError.status as 401 | 403, {
+          message: authError.body.error,
+          code: String(authError.status),
+        });
+      }
+
+      const projects = await projectService.listProjects();
+      return projects.map(endpointProjection);
+    },
+    {
+      response: {
+        200: t.Array(V1ProjectEndpointsResponseSchema),
+        401: ProjectEndpointErrorSchema,
+        403: ProjectEndpointErrorSchema,
+        500: ProjectEndpointErrorSchema,
+      },
+      detail: { tags: ["projects"], summary: "List authoritative project endpoint projections" },
+    },
+  )
+  .get(
+    "/:ref/endpoint/projection",
+    async ({ params, request }) => {
+      const authError = await requireProjectOrAdminAuth(request, params.ref);
+      if (authError) {
+        return status(authError.status as 401 | 403, {
+          message: authError.body.error,
+          code: String(authError.status),
+        });
+      }
+
+      const project = await projectService.getProject(params.ref);
+      if (!project) {
+        return status(404, { message: "Project not found", code: "404" });
+      }
+      return endpointProjection(project);
+    },
+    {
+      params: t.Object({ ref: t.String({ minLength: 1, maxLength: 20 }) }),
+      response: {
+        200: V1ProjectEndpointsResponseSchema,
+        401: ProjectEndpointErrorSchema,
+        403: ProjectEndpointErrorSchema,
+        404: ProjectEndpointErrorSchema,
+        500: ProjectEndpointErrorSchema,
+      },
+      detail: { tags: ["projects"], summary: "Get an authoritative project endpoint projection" },
+    },
+  );

--- a/packages/management-api/src/routes/project-endpoints.ts
+++ b/packages/management-api/src/routes/project-endpoints.ts
@@ -2,11 +2,17 @@ import { Elysia, status, t } from "elysia";
 import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
 import { projectService } from "../services";
 import {
+  projectEndpointSourceService,
+  type ProjectEndpointRoutingSource,
+} from "../services/project-endpoint-source.service";
+import {
   buildProjectEndpointsProjection,
   PROJECT_ENDPOINTS_SCHEMA,
 } from "../utils/project-endpoint-projection";
 import { validationErrorResponse } from "../utils/http-validation";
 import { logger } from "../utils/logger";
+
+const MAX_PROJECT_ENDPOINT_PROJECTIONS = 10_000;
 
 const ProjectEndpointSourceSchema = t.Union([
   t.Literal("explicit_api_domain"),
@@ -52,7 +58,7 @@ const ProjectEndpointErrorSchema = t.Object(
   { additionalProperties: false },
 );
 
-function endpointProjection(project: any) {
+function endpointProjection(project: ProjectEndpointRoutingSource) {
   return buildProjectEndpointsProjection(project.ref, project.config);
 }
 
@@ -77,7 +83,13 @@ export const projectEndpointRoutes = new Elysia({ prefix: "/v1/projects" })
         });
       }
 
-      const projects = await projectService.listProjects();
+      const projects = await projectEndpointSourceService.listRoutingSources();
+      if (projects.length > MAX_PROJECT_ENDPOINT_PROJECTIONS) {
+        return status(500, {
+          message: "Project endpoint inventory exceeds the supported limit",
+          code: "PROJECT_ENDPOINT_INVENTORY_TOO_LARGE",
+        });
+      }
       return projects.map(endpointProjection);
     },
     {

--- a/packages/management-api/src/routes/projects.ts
+++ b/packages/management-api/src/routes/projects.ts
@@ -2,18 +2,21 @@
  * Project Routes — Re-export barrel
  * 
  * Original monolithic file has been split into:
- * - project-crud.ts     — CRUD operations (list, create, get, update, delete, pause, restore)
- * - project-services.ts — Service control (health, status, usage, restart, service start/stop)
- * - project-config.ts   — Configuration (settings, API keys, auth config, gateway, pgbouncer)
+ * - project-crud.ts      — CRUD operations (list, create, get, update, delete, pause, restore)
+ * - project-endpoints.ts — Authoritative API/Auth/Studio endpoint projections
+ * - project-services.ts  — Service control (health, status, usage, restart, service start/stop)
+ * - project-config.ts    — Configuration (settings, API keys, auth config, gateway, pgbouncer)
  * 
  * This file composes them back into a single `projectRoutes` export for backward compatibility.
  */
 import { Elysia } from "elysia";
 import { projectCrudRoutes } from "./project-crud";
+import { projectEndpointRoutes } from "./project-endpoints";
 import { projectServiceRoutes } from "./project-services";
 import { projectConfigRoutes } from "./project-config";
 
 export const projectRoutes = new Elysia()
+  .use(projectEndpointRoutes)
   .use(projectCrudRoutes)
   .use(projectServiceRoutes)
   .use(projectConfigRoutes);

--- a/packages/management-api/src/services/project-endpoint-source.service.ts
+++ b/packages/management-api/src/services/project-endpoint-source.service.ts
@@ -1,0 +1,24 @@
+import { projectRepository } from "../repositories/project.repository";
+
+export interface ProjectEndpointRoutingSource {
+  ref: string;
+  config: unknown;
+}
+
+/**
+ * Read only the fields required to calculate authoritative endpoint origins.
+ *
+ * `projectService.listProjects()` intentionally returns public project summaries
+ * and therefore omits the private project config. Fleet endpoint projection must
+ * not infer custom domains from those summaries, and it must not expose the full
+ * project record either.
+ */
+export const projectEndpointSourceService = {
+  async listRoutingSources(): Promise<ProjectEndpointRoutingSource[]> {
+    const projects = await projectRepository.findAll();
+    return projects.map((project) => ({
+      ref: project.ref,
+      config: project.config,
+    }));
+  },
+};

--- a/packages/management-api/src/services/project-endpoint-source.service.ts
+++ b/packages/management-api/src/services/project-endpoint-source.service.ts
@@ -1,8 +1,41 @@
 import { projectRepository } from "../repositories/project.repository";
+import {
+  normalizeProjectRoutingConfig,
+  type ProjectRoutingConfig,
+} from "../utils/project-routing";
+
+const PROJECT_ENDPOINT_ROUTING_KEYS = [
+  "custom_domain",
+  "api_domain",
+  "additional_api_domains",
+  "api_domains",
+  "auth_domain",
+  "studio_domain",
+  "external_url_scheme",
+  "public_url_scheme",
+  "url_scheme",
+  "api_url_scheme",
+  "auth_url_scheme",
+  "studio_url_scheme",
+] as const satisfies readonly (keyof ProjectRoutingConfig)[];
 
 export interface ProjectEndpointRoutingSource {
   ref: string;
-  config: unknown;
+  config: ProjectRoutingConfig | undefined;
+}
+
+function endpointRoutingConfig(rawConfig: unknown): ProjectRoutingConfig | undefined {
+  const normalized = normalizeProjectRoutingConfig(rawConfig);
+  if (!normalized) return undefined;
+
+  const projected: Record<string, unknown> = {};
+  for (const key of PROJECT_ENDPOINT_ROUTING_KEYS) {
+    const value = normalized[key];
+    if (value !== undefined) projected[key] = value;
+  }
+  return Object.keys(projected).length > 0
+    ? projected as ProjectRoutingConfig
+    : undefined;
 }
 
 /**
@@ -10,15 +43,15 @@ export interface ProjectEndpointRoutingSource {
  *
  * `projectService.listProjects()` intentionally returns public project summaries
  * and therefore omits the private project config. Fleet endpoint projection must
- * not infer custom domains from those summaries, and it must not expose the full
- * project record either.
+ * not infer custom domains from those summaries. This source also strips every
+ * non-routing config key before the route builds its credential-free projection.
  */
 export const projectEndpointSourceService = {
   async listRoutingSources(): Promise<ProjectEndpointRoutingSource[]> {
     const projects = await projectRepository.findAll();
     return projects.map((project) => ({
       ref: project.ref,
-      config: project.config,
+      config: endpointRoutingConfig(project.config),
     }));
   },
 };

--- a/packages/management-api/src/utils/project-endpoint-projection.ts
+++ b/packages/management-api/src/utils/project-endpoint-projection.ts
@@ -1,0 +1,148 @@
+import {
+  deriveStudioHostFromApiHost,
+  normalizeProjectRoutingConfig,
+  resolveProjectApiHost,
+  resolveProjectApiHosts,
+  resolveProjectApiUrl,
+  resolveProjectAuthHost,
+  resolveProjectAuthUrl,
+  resolveProjectStudioHost,
+  resolveProjectStudioUrl,
+  type ProjectRoutingConfig,
+} from "./project-routing";
+
+export const PROJECT_ENDPOINTS_SCHEMA = "supacloud.project-endpoints.v1" as const;
+
+export const PROJECT_ENDPOINT_SOURCES = [
+  "explicit_api_domain",
+  "explicit_auth_domain",
+  "explicit_studio_domain",
+  "custom_domain",
+  "derived_api_domain",
+  "generated",
+] as const;
+
+export type ProjectEndpointSource = typeof PROJECT_ENDPOINT_SOURCES[number];
+export type ProjectEndpointScheme = "http" | "https";
+
+export interface ProjectEndpointProjection {
+  origin: string;
+  host: string;
+  scheme: ProjectEndpointScheme;
+  source: ProjectEndpointSource;
+  aliases: string[];
+}
+
+export interface ProjectEndpointsProjection {
+  schema: typeof PROJECT_ENDPOINTS_SCHEMA;
+  project_ref: string;
+  endpoints: {
+    api: ProjectEndpointProjection;
+    auth: ProjectEndpointProjection;
+    studio: ProjectEndpointProjection;
+  };
+}
+
+function configuredString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function apiSource(projectConfig: ProjectRoutingConfig | undefined): ProjectEndpointSource {
+  if (configuredString(projectConfig?.api_domain)) return "explicit_api_domain";
+  if (configuredString(projectConfig?.custom_domain)) return "custom_domain";
+  return "generated";
+}
+
+function authSource(projectConfig: ProjectRoutingConfig | undefined): ProjectEndpointSource {
+  if (configuredString(projectConfig?.auth_domain)) return "explicit_auth_domain";
+  if (configuredString(projectConfig?.api_domain)) return "explicit_api_domain";
+  if (configuredString(projectConfig?.custom_domain)) return "custom_domain";
+  return "generated";
+}
+
+function studioSource(projectConfig: ProjectRoutingConfig | undefined): ProjectEndpointSource {
+  if (configuredString(projectConfig?.studio_domain)) return "explicit_studio_domain";
+  if (configuredString(projectConfig?.custom_domain)) return "custom_domain";
+  if (deriveStudioHostFromApiHost(projectConfig?.api_domain)) return "derived_api_domain";
+  return "generated";
+}
+
+function canonicalHost(candidate: string, scheme: ProjectEndpointScheme): string | null {
+  try {
+    const parsed = new URL(`${scheme}://${candidate}`);
+    return parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash
+      ? null
+      : parsed.host;
+  } catch {
+    return null;
+  }
+}
+
+function endpointProjection(
+  origin: string,
+  expectedHost: string,
+  source: ProjectEndpointSource,
+  aliases: readonly string[] = [],
+): ProjectEndpointProjection {
+  const parsed = new URL(origin);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Unsupported project endpoint protocol: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash) {
+    throw new Error("Project endpoint origin must not include credentials, path, query, or fragment");
+  }
+
+  const scheme = parsed.protocol.slice(0, -1) as ProjectEndpointScheme;
+  const host = parsed.host;
+  const normalizedExpectedHost = canonicalHost(expectedHost, scheme);
+  if (!normalizedExpectedHost || normalizedExpectedHost !== host) {
+    throw new Error("Project endpoint host does not match its resolved origin");
+  }
+
+  const normalizedAliases = aliases
+    .map((alias) => canonicalHost(alias, scheme))
+    .filter((alias): alias is string => Boolean(alias) && alias !== host);
+
+  return {
+    origin: parsed.origin,
+    host,
+    scheme,
+    source,
+    aliases: [...new Set(normalizedAliases)],
+  };
+}
+
+export function buildProjectEndpointsProjection(
+  projectRef: string,
+  rawProjectConfig: unknown,
+): ProjectEndpointsProjection {
+  const projectConfig = normalizeProjectRoutingConfig(rawProjectConfig);
+  const apiHost = resolveProjectApiHost(projectRef, projectConfig);
+  const authHost = resolveProjectAuthHost(projectRef, projectConfig);
+  const studioHost = resolveProjectStudioHost(projectRef, projectConfig);
+
+  return {
+    schema: PROJECT_ENDPOINTS_SCHEMA,
+    project_ref: projectRef,
+    endpoints: {
+      api: endpointProjection(
+        resolveProjectApiUrl(projectRef, projectConfig),
+        apiHost,
+        apiSource(projectConfig),
+        resolveProjectApiHosts(projectRef, projectConfig),
+      ),
+      auth: endpointProjection(
+        resolveProjectAuthUrl(projectRef, projectConfig),
+        authHost,
+        authSource(projectConfig),
+      ),
+      studio: endpointProjection(
+        resolveProjectStudioUrl(projectRef, projectConfig),
+        studioHost,
+        studioSource(projectConfig),
+      ),
+    },
+  };
+}

--- a/packages/management-api/src/utils/project-endpoint-projection.ts
+++ b/packages/management-api/src/utils/project-endpoint-projection.ts
@@ -101,9 +101,14 @@ function endpointProjection(
     throw new Error("Project endpoint host does not match its resolved origin");
   }
 
-  const normalizedAliases = aliases
-    .map((alias) => canonicalHost(alias, scheme))
-    .filter((alias): alias is string => Boolean(alias) && alias !== host);
+  const normalizedAliases: string[] = [];
+  for (const alias of aliases) {
+    const normalizedAlias = canonicalHost(alias, scheme);
+    if (!normalizedAlias) {
+      throw new Error("Project endpoint alias is invalid");
+    }
+    if (normalizedAlias !== host) normalizedAliases.push(normalizedAlias);
+  }
 
   return {
     origin: parsed.origin,

--- a/packages/management-api/tests/unit/project-endpoint-projection.test.ts
+++ b/packages/management-api/tests/unit/project-endpoint-projection.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { config } from "../../src/config";
+import {
+  buildProjectEndpointsProjection,
+  PROJECT_ENDPOINTS_SCHEMA,
+} from "../../src/utils/project-endpoint-projection";
+
+const originalBaseDomain = config.baseDomain;
+const originalEnableSsl = config.enableSsl;
+
+afterEach(() => {
+  config.baseDomain = originalBaseDomain;
+  config.enableSsl = originalEnableSsl;
+});
+
+describe("project endpoint projection", () => {
+  test("projects explicit domains and preserves canonical API aliases", () => {
+    config.baseDomain = "platform.example";
+    config.enableSsl = false;
+
+    expect(buildProjectEndpointsProjection("abc123", {
+      api_domain: "api.example.com",
+      auth_domain: "auth.example.com",
+      additional_api_domains: ["api-alt.example.com"],
+    })).toEqual({
+      schema: PROJECT_ENDPOINTS_SCHEMA,
+      project_ref: "abc123",
+      endpoints: {
+        api: {
+          origin: "https://api.example.com",
+          host: "api.example.com",
+          scheme: "https",
+          source: "explicit_api_domain",
+          aliases: ["abc123.api.platform.example", "api-alt.example.com"],
+        },
+        auth: {
+          origin: "https://auth.example.com",
+          host: "auth.example.com",
+          scheme: "https",
+          source: "explicit_auth_domain",
+          aliases: [],
+        },
+        studio: {
+          origin: "https://studio.example.com",
+          host: "studio.example.com",
+          scheme: "https",
+          source: "derived_api_domain",
+          aliases: [],
+        },
+      },
+    });
+  });
+
+  test("labels custom-domain and generated endpoint sources without claiming readiness", () => {
+    config.baseDomain = "192.168.1.10.sslip.io";
+    config.enableSsl = false;
+
+    const custom = buildProjectEndpointsProjection("abc123", "example.com");
+    expect(custom.endpoints.api).toMatchObject({
+      origin: "https://api.example.com",
+      source: "custom_domain",
+    });
+    expect(custom.endpoints.auth).toMatchObject({
+      origin: "https://api.example.com",
+      source: "custom_domain",
+    });
+    expect(custom.endpoints.studio).toMatchObject({
+      origin: "https://studio.example.com",
+      source: "custom_domain",
+    });
+
+    const generated = buildProjectEndpointsProjection("abc123", null);
+    expect(generated.endpoints.api).toMatchObject({
+      origin: "http://abc123.api.192.168.1.10.sslip.io",
+      source: "generated",
+    });
+    expect(generated.endpoints.auth).toMatchObject({
+      origin: "http://abc123.api.192.168.1.10.sslip.io",
+      source: "generated",
+    });
+    expect(generated.endpoints.studio).toMatchObject({
+      origin: "http://studio-abc123.192.168.1.10.sslip.io",
+      source: "generated",
+    });
+  });
+});

--- a/packages/management-api/tests/unit/project-endpoint-projection.test.ts
+++ b/packages/management-api/tests/unit/project-endpoint-projection.test.ts
@@ -83,4 +83,14 @@ describe("project endpoint projection", () => {
       source: "generated",
     });
   });
+
+  test("fails closed instead of silently dropping an invalid API alias", () => {
+    config.baseDomain = "platform.example";
+    config.enableSsl = true;
+
+    expect(() => buildProjectEndpointsProjection("abc123", {
+      api_domain: "api.example.com",
+      additional_api_domains: ["operator@example.com"],
+    })).toThrow("Project endpoint alias is invalid");
+  });
 });

--- a/packages/management-api/tests/unit/project-endpoint-source.service.test.ts
+++ b/packages/management-api/tests/unit/project-endpoint-source.service.test.ts
@@ -19,7 +19,7 @@ describe("project endpoint routing source service", () => {
     findAll.mockResolvedValue([] as never);
   });
 
-  test("returns only refs and private routing configs required by projection", async () => {
+  test("returns only refs and endpoint routing config fields", async () => {
     findAll.mockResolvedValue([
       {
         id: "internal-id",
@@ -27,7 +27,11 @@ describe("project endpoint routing source service", () => {
         name: "Project",
         config: {
           api_domain: "api.example.com",
-          service_role_key: "must-not-be-copied-from-config-fixture",
+          additional_api_domains: ["api-alt.example.com"],
+          api_url_scheme: "https",
+          service_role_key: "must-not-leave-private-config",
+          pgrst_port: 30123,
+          nested_private_config: { token: "private-token" },
         },
         db_password: "private-db-password",
         jwt_secret: "private-jwt-secret",
@@ -41,12 +45,26 @@ describe("project endpoint routing source service", () => {
         ref: "abc123",
         config: {
           api_domain: "api.example.com",
-          service_role_key: "must-not-be-copied-from-config-fixture",
+          additional_api_domains: ["api-alt.example.com"],
+          api_url_scheme: "https",
         },
       },
     ]);
+    expect(JSON.stringify(sources)).not.toContain("private");
     expect(sources[0]).not.toHaveProperty("db_password");
     expect(sources[0]).not.toHaveProperty("jwt_secret");
     expect(sources[0]).not.toHaveProperty("name");
+  });
+
+  test("preserves the legacy string-as-custom-domain routing contract", async () => {
+    findAll.mockResolvedValue([
+      { ref: "legacy", config: "example.com" },
+      { ref: "generated", config: { unrelated: true } },
+    ] as never);
+
+    expect(await projectEndpointSourceService.listRoutingSources()).toEqual([
+      { ref: "legacy", config: { custom_domain: "example.com" } },
+      { ref: "generated", config: undefined },
+    ]);
   });
 });

--- a/packages/management-api/tests/unit/project-endpoint-source.service.test.ts
+++ b/packages/management-api/tests/unit/project-endpoint-source.service.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+const findAll = mock(() => Promise.resolve([]));
+const repositoryModule = await import("../../src/repositories/project.repository");
+const findAllSpy = spyOn(repositoryModule.projectRepository, "findAll").mockImplementation(
+  findAll as typeof repositoryModule.projectRepository.findAll,
+);
+const { projectEndpointSourceService } = await import(
+  "../../src/services/project-endpoint-source.service"
+);
+
+describe("project endpoint routing source service", () => {
+  afterAll(() => {
+    findAllSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    findAll.mockReset();
+    findAll.mockResolvedValue([] as never);
+  });
+
+  test("returns only refs and private routing configs required by projection", async () => {
+    findAll.mockResolvedValue([
+      {
+        id: "internal-id",
+        ref: "abc123",
+        name: "Project",
+        config: {
+          api_domain: "api.example.com",
+          service_role_key: "must-not-be-copied-from-config-fixture",
+        },
+        db_password: "private-db-password",
+        jwt_secret: "private-jwt-secret",
+      },
+    ] as never);
+
+    const sources = await projectEndpointSourceService.listRoutingSources();
+
+    expect(sources).toEqual([
+      {
+        ref: "abc123",
+        config: {
+          api_domain: "api.example.com",
+          service_role_key: "must-not-be-copied-from-config-fixture",
+        },
+      },
+    ]);
+    expect(sources[0]).not.toHaveProperty("db_password");
+    expect(sources[0]).not.toHaveProperty("jwt_secret");
+    expect(sources[0]).not.toHaveProperty("name");
+  });
+});

--- a/packages/management-api/tests/unit/project-endpoints.routes.test.ts
+++ b/packages/management-api/tests/unit/project-endpoints.routes.test.ts
@@ -3,11 +3,12 @@ import { Elysia } from "elysia";
 
 const requireAdminAuth = mock(() => Promise.resolve(undefined));
 const requireProjectOrAdminAuth = mock(() => Promise.resolve(undefined));
-const listProjects = mock(() => Promise.resolve([]));
+const listRoutingSources = mock(() => Promise.resolve([]));
 const getProject = mock(() => Promise.resolve(null));
 
 const authModule = await import("../../src/middleware/auth");
 const servicesModule = await import("../../src/services");
+const endpointSourceModule = await import("../../src/services/project-endpoint-source.service");
 
 const requireAdminAuthSpy = spyOn(authModule, "requireAdminAuth").mockImplementation(
   requireAdminAuth as typeof authModule.requireAdminAuth,
@@ -15,8 +16,11 @@ const requireAdminAuthSpy = spyOn(authModule, "requireAdminAuth").mockImplementa
 const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
   requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
 );
-const listProjectsSpy = spyOn(servicesModule.projectService, "listProjects").mockImplementation(
-  listProjects as typeof servicesModule.projectService.listProjects,
+const listRoutingSourcesSpy = spyOn(
+  endpointSourceModule.projectEndpointSourceService,
+  "listRoutingSources",
+).mockImplementation(
+  listRoutingSources as typeof endpointSourceModule.projectEndpointSourceService.listRoutingSources,
 );
 const getProjectSpy = spyOn(servicesModule.projectService, "getProject").mockImplementation(
   getProject as typeof servicesModule.projectService.getProject,
@@ -44,7 +48,7 @@ describe("project endpoint routes", () => {
   afterAll(() => {
     requireAdminAuthSpy.mockRestore();
     requireProjectOrAdminAuthSpy.mockRestore();
-    listProjectsSpy.mockRestore();
+    listRoutingSourcesSpy.mockRestore();
     getProjectSpy.mockRestore();
   });
 
@@ -53,8 +57,8 @@ describe("project endpoint routes", () => {
     requireAdminAuth.mockResolvedValue(undefined);
     requireProjectOrAdminAuth.mockReset();
     requireProjectOrAdminAuth.mockResolvedValue(undefined);
-    listProjects.mockReset();
-    listProjects.mockResolvedValue([] as never);
+    listRoutingSources.mockReset();
+    listRoutingSources.mockResolvedValue([] as never);
     getProject.mockReset();
     getProject.mockResolvedValue(project as never);
   });
@@ -88,8 +92,8 @@ describe("project endpoint routes", () => {
     expect(getProject).toHaveBeenCalledWith("abc123");
   });
 
-  test("returns an Admin-only endpoint inventory", async () => {
-    listProjects.mockResolvedValue([project] as never);
+  test("returns an Admin-only endpoint inventory from private routing sources", async () => {
+    listRoutingSources.mockResolvedValue([project] as never);
 
     const response = await request("/v1/projects/endpoints");
 
@@ -99,12 +103,17 @@ describe("project endpoint routes", () => {
     expect(body[0]).toMatchObject({
       schema: "supacloud.project-endpoints.v1",
       project_ref: "abc123",
+      endpoints: {
+        api: { origin: "https://api.example.com", source: "explicit_api_domain" },
+        auth: { origin: "https://auth.example.com", source: "explicit_auth_domain" },
+        studio: { origin: "https://studio.example.com", source: "explicit_studio_domain" },
+      },
     });
     expect(requireAdminAuth).toHaveBeenCalledWith(expect.any(Request));
-    expect(listProjects).toHaveBeenCalledTimes(1);
+    expect(listRoutingSources).toHaveBeenCalledTimes(1);
   });
 
-  test("does not read projects when authorization fails", async () => {
+  test("does not read routing sources when authorization fails", async () => {
     requireAdminAuth.mockResolvedValue({
       status: 403,
       body: { error: "Admin privileges required" },
@@ -117,7 +126,22 @@ describe("project endpoint routes", () => {
       message: "Admin privileges required",
       code: "403",
     });
-    expect(listProjects).not.toHaveBeenCalled();
+    expect(listRoutingSources).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when the endpoint inventory exceeds its limit", async () => {
+    listRoutingSources.mockResolvedValue(Array.from(
+      { length: 10_001 },
+      (_, index) => ({ ref: `p${index}`, config: null }),
+    ) as never);
+
+    const response = await request("/v1/projects/endpoints");
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      message: "Project endpoint inventory exceeds the supported limit",
+      code: "PROJECT_ENDPOINT_INVENTORY_TOO_LARGE",
+    });
   });
 
   test("returns 404 for a missing project", async () => {

--- a/packages/management-api/tests/unit/project-endpoints.routes.test.ts
+++ b/packages/management-api/tests/unit/project-endpoints.routes.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const requireAdminAuth = mock(() => Promise.resolve(undefined));
+const requireProjectOrAdminAuth = mock(() => Promise.resolve(undefined));
+const listProjects = mock(() => Promise.resolve([]));
+const getProject = mock(() => Promise.resolve(null));
+
+const authModule = await import("../../src/middleware/auth");
+const servicesModule = await import("../../src/services");
+
+const requireAdminAuthSpy = spyOn(authModule, "requireAdminAuth").mockImplementation(
+  requireAdminAuth as typeof authModule.requireAdminAuth,
+);
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const listProjectsSpy = spyOn(servicesModule.projectService, "listProjects").mockImplementation(
+  listProjects as typeof servicesModule.projectService.listProjects,
+);
+const getProjectSpy = spyOn(servicesModule.projectService, "getProject").mockImplementation(
+  getProject as typeof servicesModule.projectService.getProject,
+);
+
+const { projectEndpointRoutes } = await import("../../src/routes/project-endpoints");
+const app = new Elysia().use(projectEndpointRoutes);
+
+function request(path: string) {
+  return app.handle(new Request(`http://localhost${path}`, {
+    headers: { Authorization: "Bearer test-token" },
+  }));
+}
+
+const project = {
+  ref: "abc123",
+  config: {
+    api_domain: "api.example.com",
+    auth_domain: "auth.example.com",
+    studio_domain: "studio.example.com",
+  },
+};
+
+describe("project endpoint routes", () => {
+  afterAll(() => {
+    requireAdminAuthSpy.mockRestore();
+    requireProjectOrAdminAuthSpy.mockRestore();
+    listProjectsSpy.mockRestore();
+    getProjectSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    requireAdminAuth.mockReset();
+    requireAdminAuth.mockResolvedValue(undefined);
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(undefined);
+    listProjects.mockReset();
+    listProjects.mockResolvedValue([] as never);
+    getProject.mockReset();
+    getProject.mockResolvedValue(project as never);
+  });
+
+  test("returns one project-scoped endpoint projection", async () => {
+    const response = await request("/v1/projects/abc123/endpoint/projection");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      schema: "supacloud.project-endpoints.v1",
+      project_ref: "abc123",
+      endpoints: {
+        api: {
+          origin: "https://api.example.com",
+          host: "api.example.com",
+          source: "explicit_api_domain",
+        },
+        auth: {
+          origin: "https://auth.example.com",
+          host: "auth.example.com",
+          source: "explicit_auth_domain",
+        },
+        studio: {
+          origin: "https://studio.example.com",
+          host: "studio.example.com",
+          source: "explicit_studio_domain",
+        },
+      },
+    });
+    expect(requireProjectOrAdminAuth).toHaveBeenCalledWith(expect.any(Request), "abc123");
+    expect(getProject).toHaveBeenCalledWith("abc123");
+  });
+
+  test("returns an Admin-only endpoint inventory", async () => {
+    listProjects.mockResolvedValue([project] as never);
+
+    const response = await request("/v1/projects/endpoints");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      schema: "supacloud.project-endpoints.v1",
+      project_ref: "abc123",
+    });
+    expect(requireAdminAuth).toHaveBeenCalledWith(expect.any(Request));
+    expect(listProjects).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not read projects when authorization fails", async () => {
+    requireAdminAuth.mockResolvedValue({
+      status: 403,
+      body: { error: "Admin privileges required" },
+    });
+
+    const response = await request("/v1/projects/endpoints");
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      message: "Admin privileges required",
+      code: "403",
+    });
+    expect(listProjects).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 for a missing project", async () => {
+    getProject.mockResolvedValue(null);
+
+    const response = await request("/v1/projects/missing/endpoint/projection");
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ message: "Project not found", code: "404" });
+  });
+});


### PR DESCRIPTION
## Summary

Add a fixed, credential-free projection of each project's public API, Auth/OIDC, and Studio origins, backed by the existing authoritative routing resolver.

## What changed

- Add `GET /v1/projects/:ref/endpoint/projection` for project-scoped or Admin reads.
- Add Admin-only `GET /v1/projects/endpoints` for fleet inventory.
- Add `supacloud-cli project endpoints` for the selected project.
- Add `supacloud-admin project endpoints --ref <ref>` and `project list_endpoints`.
- Make `supacloud-cli project list` return explicit Admin CLI guidance instead of widening the project CLI boundary.
- Strictly validate and bound CLI response projections; reject extra fields and never reflect malformed remote payloads.
- Reuse `project-routing` for canonical origins, schemes, hosts, source classification, and API aliases.
- Fail closed when configured aliases cannot be represented as canonical hosts.
- Document that endpoint configuration does not prove DNS, TLS, gateway publication, or runtime readiness.

## Security and compatibility

- No project config, API keys, credentials, paths, queries, fragments, or runtime receipts are returned.
- Cross-project inventory remains Admin-only.
- Existing `GET /v1/projects/:ref/endpoint` behavior is unchanged.
- Production cross-ref read restrictions and read-only/write policies remain intact.
- Package versions are not manually changed; Release Please remains authoritative.

## Validation added

- Management projection unit tests for explicit, custom, derived, generated, and invalid-alias configurations.
- Route tests for project-scoped reads, Admin inventory, auth denial, and missing projects.
- CLI tests for selected-project reads, Admin inventory, project-list guidance, response bounds, and malformed secret-bearing responses.
- Skill, command map, and operator documentation updates.

## Deliberate non-goal

This PR does not reintroduce the historical `management-full` restore behavior. Its Admin-only inspect/plan/import contract and required legacy fixture are tracked in #951.