### PR TITLE
fix: repair Grafana subpath during upgrades

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,6 +29,7 @@ Edge Function .logs
 
 - `grafana.ini` 必须设置 `root_url = https://<studio 域名>/grafana/` 且 `serve_from_sub_path = true`。
 - 安装器在 Pigsty 安装完成后自动写入上述配置（`configure_grafana_subpath`），并同步修补 Pigsty 的 `grafana.ini.j2` 模板，避免 infra playbook 重跑后回退到 Pigsty 默认的 `/ui/`。
+- Management API 二进制升级会事务性修复旧实例的 live 配置、Pigsty 模板和 `GRAFANA_URL`；失败时恢复原文件，并在 Grafana 原本运行时重启服务使配置生效。
 
 ## 默认配置
 

--- a/packages/management-api/src/grafana-subpath.ts
+++ b/packages/management-api/src/grafana-subpath.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import {
+    chmodSync,
+    chownSync,
+    lstatSync,
+    readFileSync,
+    renameSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+
+const SECTION_HEADER = /^\s*\[[^\]]+\]\s*(?:[;#].*)?$/;
+const SERVER_SECTION = /^\s*\[server\]\s*(?:[;#].*)?$/i;
+const ROOT_URL_SETTING = /^\s*root_url\s*=.*$/i;
+const GRAFANA_ROOT_URL = /=\s*\S*\/grafana\/\s*$/i;
+const SERVE_FROM_SUB_PATH_SETTING = /^\s*serve_from_sub_path\s*=.*$/i;
+
+export type GrafanaConfigSnapshot = {
+    path: string;
+    content: Buffer;
+    mode: number;
+    uid: number;
+    gid: number;
+};
+
+function settingInsertionIndex(sectionLines: string[]): number {
+    let insertionIndex = sectionLines.length;
+    while (insertionIndex > 0 && sectionLines[insertionIndex - 1]?.trim() === "") insertionIndex -= 1;
+    return insertionIndex;
+}
+
+function setServerSetting(
+    sectionLines: string[],
+    settingPattern: RegExp,
+    renderSetting: (currentSetting?: string) => string,
+    settingName: string,
+): string[] {
+    const matches = sectionLines.flatMap((line, index) => settingPattern.test(line) ? [index] : []);
+    if (matches.length > 1) throw new Error(`Grafana [server] contains duplicate ${settingName} settings`);
+    if (matches.length === 0) {
+        const insertionIndex = settingInsertionIndex(sectionLines);
+        return [...sectionLines.slice(0, insertionIndex), renderSetting(), ...sectionLines.slice(insertionIndex)];
+    }
+    const updatedLines = [...sectionLines];
+    const settingIndex = matches[0] as number;
+    updatedLines[settingIndex] = renderSetting(updatedLines[settingIndex]);
+    return updatedLines;
+}
+
+export function renderGrafanaSubpathConfig(source: string): string {
+    const newline = source.includes("\r\n") ? "\r\n" : "\n";
+    const trailingNewline = source.endsWith("\n");
+    const lines = source.split(/\r?\n/);
+    if (trailingNewline) lines.pop();
+    const serverStart = lines.findIndex(line => SERVER_SECTION.test(line));
+    if (serverStart < 0) throw new Error("Grafana config does not contain a [server] section");
+    const nextSection = lines.findIndex((line, index) => index > serverStart && SECTION_HEADER.test(line));
+    const serverEnd = nextSection < 0 ? lines.length : nextSection;
+    let serverLines = lines.slice(serverStart + 1, serverEnd);
+    serverLines = setServerSetting(serverLines, ROOT_URL_SETTING, current => (
+        current && GRAFANA_ROOT_URL.test(current) ? current : "root_url = /grafana/"
+    ), "root_url");
+    serverLines = setServerSetting(
+        serverLines,
+        SERVE_FROM_SUB_PATH_SETTING,
+        () => "serve_from_sub_path = true",
+        "serve_from_sub_path",
+    );
+    const rendered = [...lines.slice(0, serverStart + 1), ...serverLines, ...lines.slice(serverEnd)].join(newline);
+    return trailingNewline ? `${rendered}${newline}` : rendered;
+}
+
+function captureGrafanaConfig(path: string): GrafanaConfigSnapshot | null {
+    const stats = lstatSync(path, { throwIfNoEntry: false });
+    if (!stats) return null;
+    if (!stats.isFile() || stats.nlink !== 1) {
+        throw new Error(`Grafana config must be a direct regular file: ${path}`);
+    }
+    return {
+        path,
+        content: readFileSync(path),
+        mode: stats.mode & 0o777,
+        uid: stats.uid,
+        gid: stats.gid,
+    };
+}
+
+export function captureGrafanaConfigSnapshots(paths: string[]): GrafanaConfigSnapshot[] {
+    return [...new Set(paths)].flatMap(path => {
+        const snapshot = captureGrafanaConfig(path);
+        return snapshot ? [snapshot] : [];
+    });
+}
+
+function replaceGrafanaConfig(snapshot: GrafanaConfigSnapshot, content: string | Buffer): void {
+    const temporaryPath = `${snapshot.path}.tmp-${process.pid}-${randomUUID()}`;
+    try {
+        writeFileSync(temporaryPath, content, { flag: "wx", mode: snapshot.mode });
+        chownSync(temporaryPath, snapshot.uid, snapshot.gid);
+        chmodSync(temporaryPath, snapshot.mode);
+        renameSync(temporaryPath, snapshot.path);
+    } finally {
+        rmSync(temporaryPath, { force: true });
+    }
+}
+
+export function applyGrafanaSubpathConfig(snapshots: GrafanaConfigSnapshot[]): boolean {
+    let changed = false;
+    for (const snapshot of snapshots) {
+        const current = snapshot.content.toString("utf8");
+        const rendered = renderGrafanaSubpathConfig(current);
+        if (rendered === current) continue;
+        replaceGrafanaConfig(snapshot, rendered);
+        changed = true;
+    }
+    return changed;
+}
+
+export function restoreGrafanaConfig(snapshot: GrafanaConfigSnapshot): void {
+    replaceGrafanaConfig(snapshot, snapshot.content);
+}

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -69,6 +69,12 @@ import {
     type PostgrestLauncherActivationState,
     type PostgrestLauncherPreflight,
 } from "./embedded-postgrest-launcher";
+import {
+    applyGrafanaSubpathConfig,
+    captureGrafanaConfigSnapshots,
+    restoreGrafanaConfig,
+    type GrafanaConfigSnapshot,
+} from "./grafana-subpath";
 
 const RELEASES_API = "https://api.github.com/repos/vibeunion/supacloud/releases";
 const BIN_TARGET = "/usr/local/bin/supacloud";
@@ -79,6 +85,10 @@ const EDGE_RUNTIME_BINARY_TARGETS = new Set([
     "/opt/supacloud/bin/supacloud-edge-runtime",
 ]);
 const DEFAULT_MANAGEMENT_ENV_FILE = "/etc/supabase/management-api.env";
+const DEFAULT_GRAFANA_CONFIG_FILE = "/etc/grafana/grafana.ini";
+const DEFAULT_GRAFANA_UPSTREAM = "http://127.0.0.1:3000/grafana";
+const DEFAULT_PIGSTY_PATH = "/root/pigsty";
+const GRAFANA_TEMPLATE_RELATIVE_PATH = "roles/infra/templates/grafana/grafana.ini.j2";
 const DEFAULT_EDGE_RUNTIME_USER = "supacloud-edge";
 const DEFAULT_EDGE_RUNTIME_GROUP = "supacloud-edge";
 const DEFAULT_EDGE_RUNTIME_PORT = 9005;
@@ -2053,6 +2063,56 @@ function managementEnvFile() {
     return process.env.SUPACLOUD_MANAGEMENT_ENV_FILE || DEFAULT_MANAGEMENT_ENV_FILE;
 }
 
+type GrafanaServiceOperations = {
+    isActive: () => Promise<boolean>;
+    restart: () => Promise<void>;
+};
+
+function grafanaServiceOperations(): GrafanaServiceOperations {
+    return {
+        isActive: async () => (await $`systemctl is-active --quiet grafana-server`.nothrow().quiet()).exitCode === 0,
+        restart: async () => {
+            const restarted = await $`systemctl restart grafana-server`.nothrow().quiet();
+            if (restarted.exitCode !== 0) {
+                throw new Error(`Failed to restart grafana-server: ${restarted.stderr.toString().trim().slice(-500)}`);
+            }
+        },
+    };
+}
+
+export function grafanaSubpathConfigPaths(runtimeEnv: Record<string, string>): string[] {
+    const pigstyPath = runtimeEnv.PIGSTY_PATH?.trim() || DEFAULT_PIGSTY_PATH;
+    if (!path.isAbsolute(pigstyPath)) throw new Error("PIGSTY_PATH must be absolute during Grafana repair");
+    return [
+        DEFAULT_GRAFANA_CONFIG_FILE,
+        path.join(pigstyPath, GRAFANA_TEMPLATE_RELATIVE_PATH),
+    ];
+}
+
+type GrafanaUpgradeOptions = {
+    configPaths?: string[];
+    managementEnvPath?: string;
+    service?: GrafanaServiceOperations;
+};
+
+export async function applyGrafanaUpgradeSettings(
+    activation: UpgradeActivationState,
+    runtimeEnv: Record<string, string>,
+    options: GrafanaUpgradeOptions = {},
+): Promise<void> {
+    const configPaths = options.configPaths ?? grafanaSubpathConfigPaths(runtimeEnv);
+    const configStates = captureGrafanaConfigSnapshots(configPaths);
+    const service = options.service ?? grafanaServiceOperations();
+    activation.grafanaConfigStates = configStates;
+    activation.grafanaWasActive = await service.isActive();
+    if (activation.grafanaWasActive && !configStates.some(snapshot => snapshot.path === configPaths[0])) {
+        throw new Error(`Active grafana-server config is missing: ${configPaths[0]}`);
+    }
+    const configChanged = applyGrafanaSubpathConfig(configStates);
+    upsertEnvFileValue(options.managementEnvPath ?? managementEnvFile(), "GRAFANA_URL", DEFAULT_GRAFANA_UPSTREAM);
+    if (configChanged && activation.grafanaWasActive) await service.restart();
+}
+
 async function runHostIdentityCommand(command: string[]): Promise<HostIdentityCommandResult> {
     const child = Bun.spawn({ cmd: command, stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([
@@ -2369,6 +2429,8 @@ export type UpgradeActivationState = {
     edgeRuntimeDropInState: FileState | null;
     managementPrivilegeDropInState: FileState | null;
     embeddedEdgePrivilegeDropInState: FileState | null;
+    grafanaConfigStates: GrafanaConfigSnapshot[];
+    grafanaWasActive: boolean | null;
 };
 
 type RunUpgradeOptions = {
@@ -2550,6 +2612,12 @@ function artifactRecoveryActions(state: UpgradeActivationState): UpgradeRecovery
         description: "restore embedded Edge privilege drop-in",
         run: () => restoreFileState(embeddedEdgePrivilegeDropInState),
     });
+    for (const grafanaConfigState of state.grafanaConfigStates) {
+        actions.push({
+            description: `restore Grafana config ${grafanaConfigState.path}`,
+            run: () => restoreGrafanaConfig(grafanaConfigState),
+        });
+    }
     const systemdUnitBroker = state.systemdUnitBroker;
     if (systemdUnitBroker) actions.push({
         description: "restore systemd-unit helper",
@@ -2569,20 +2637,26 @@ function artifactRecoveryActions(state: UpgradeActivationState): UpgradeRecovery
     return actions;
 }
 
-function restoredServiceRecoveryActions(): UpgradeRecoveryAction[] {
-    return [
+function restoredServiceRecoveryActions(state: UpgradeActivationState): UpgradeRecoveryAction[] {
+    const actions: UpgradeRecoveryAction[] = [];
+    if (state.grafanaWasActive) actions.push({
+        description: "restart restored Grafana service",
+        run: () => grafanaServiceOperations().restart(),
+    });
+    actions.push(
         { description: "reload systemd units", run: () => reloadSystemdUnits() },
         {
             description: "restart restored services",
             run: async () => restartServices(await runtimeModeForBinaryUpgrade()),
         },
         { description: "verify restored services", run: () => waitForUpgradeHealth() },
-    ];
+    );
+    return actions;
 }
 
 export async function rollbackArtifacts(
     state: UpgradeActivationState,
-    serviceActions: UpgradeRecoveryAction[] = restoredServiceRecoveryActions(),
+    serviceActions: UpgradeRecoveryAction[] = restoredServiceRecoveryActions(state),
 ): Promise<void> {
     await executeUpgradeRecoveryActions([
         ...artifactRecoveryActions(state),
@@ -2602,6 +2676,8 @@ function createActivationState(edgeRuntimeTarget: string | null): UpgradeActivat
         edgeRuntimeDropInState: null,
         managementPrivilegeDropInState: null,
         embeddedEdgePrivilegeDropInState: null,
+        grafanaConfigStates: [],
+        grafanaWasActive: null,
     };
 }
 
@@ -2908,6 +2984,7 @@ async function applyUpgradeRuntimeSettings(context: UpgradeExecutionContext): Pr
     if (!activation) throw new Error("Upgrade activation state is unavailable");
     context.spinner.start("Applying runtime settings and restarting SupaCloud services");
     captureUpgradeRuntimeFiles(activation);
+    await applyGrafanaUpgradeSettings(activation, context.preparedSecrets.runtimeEnv);
     const edgeRuntimeIdentity = await ensurePersistedEdgeRuntimeIdentity(managementEnvFile());
     upsertPersistedEdgeRuntimePort(managementEnvFile(), edgeRuntimeEnvFile());
     const edgeRuntimeMode = await runtimeModeForBinaryUpgrade();

--- a/packages/management-api/tests/unit/grafana-subpath.test.ts
+++ b/packages/management-api/tests/unit/grafana-subpath.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyGrafanaSubpathConfig,
+  captureGrafanaConfigSnapshots,
+  renderGrafanaSubpathConfig,
+  restoreGrafanaConfig,
+} from "../../src/grafana-subpath";
+
+describe("Grafana subpath configuration", () => {
+  test("replaces the active root URL and adds subpath serving inside [server]", () => {
+    const source = [
+      "[server]",
+      "root_url = /ui/",
+      "domain = localhost",
+      "",
+      "[database]",
+      "type = sqlite3",
+      "",
+    ].join("\n");
+
+    expect(renderGrafanaSubpathConfig(source)).toBe([
+      "[server]",
+      "root_url = /grafana/",
+      "domain = localhost",
+      "serve_from_sub_path = true",
+      "",
+      "[database]",
+      "type = sqlite3",
+      "",
+    ].join("\n"));
+  });
+
+  test("preserves commented defaults and updates existing active settings", () => {
+    const source = "[server]\r\n;root_url = %(protocol)s://%(domain)s/\r\nserve_from_sub_path = false\r\n";
+    expect(renderGrafanaSubpathConfig(source)).toBe(
+      "[server]\r\n;root_url = %(protocol)s://%(domain)s/\r\nserve_from_sub_path = true\r\nroot_url = /grafana/\r\n",
+    );
+  });
+
+  test("preserves an already-correct absolute Grafana root URL", () => {
+    const source = "[server]\nroot_url = https://studio.example.com/grafana/\nserve_from_sub_path = true\n";
+    expect(renderGrafanaSubpathConfig(source)).toBe(source);
+  });
+
+  test("rejects ambiguous or structurally invalid server configuration", () => {
+    expect(() => renderGrafanaSubpathConfig("[server]\nroot_url = /one\nroot_url = /two\n"))
+      .toThrow("duplicate root_url");
+    expect(() => renderGrafanaSubpathConfig("[database]\ntype = sqlite3\n"))
+      .toThrow("does not contain a [server] section");
+  });
+
+  test("updates and restores direct files without changing permissions", () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-grafana-config-"));
+    const configPath = join(directory, "grafana.ini");
+    const original = "[server]\nroot_url = /ui/\n";
+    try {
+      writeFileSync(configPath, original);
+      chmodSync(configPath, 0o640);
+      const snapshots = captureGrafanaConfigSnapshots([configPath]);
+
+      expect(applyGrafanaSubpathConfig(snapshots)).toBe(true);
+      expect(readFileSync(configPath, "utf8")).toContain("root_url = /grafana/");
+      expect(lstatSync(configPath).mode & 0o777).toBe(0o640);
+
+      restoreGrafanaConfig(snapshots[0]!);
+      expect(readFileSync(configPath, "utf8")).toBe(original);
+      expect(lstatSync(configPath).mode & 0o777).toBe(0o640);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects symlinked configuration targets", () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-grafana-link-"));
+    const targetPath = join(directory, "target.ini");
+    const linkedPath = join(directory, "grafana.ini");
+    try {
+      writeFileSync(targetPath, "[server]\nroot_url = /ui/\n");
+      symlinkSync(targetPath, linkedPath);
+      expect(() => captureGrafanaConfigSnapshots([linkedPath])).toThrow("direct regular file");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -31,6 +31,7 @@ import {
     buildRuntimeServiceRestartPlan,
     assertExternalEdgeRuntimeUpgradeMode,
     assertEdgeRuntimeBinaryTarget,
+    applyGrafanaUpgradeSettings,
     captureFileState,
     cleanupBinaryBackup,
     createBinaryBackupState,
@@ -42,6 +43,7 @@ import {
     executeUpgradeRecoveryActions,
     extractWebConsoleArchive,
     formatUpgradeFailure,
+    grafanaSubpathConfigPaths,
     inspectActiveManagementBinary,
     inspectActiveSystemdBinary,
     normalizeEdgeRuntimeReleaseTag,
@@ -207,6 +209,23 @@ const ensureHealthTimeout = () => {
   process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEMPTS = "1";
   process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS = "1";
 };
+
+function emptyUpgradeActivationState(binaryPath: string): UpgradeActivationState {
+  return {
+    binary: createBinaryBackupState(binaryPath),
+    edgeBinary: null,
+    postgrestLauncher: null,
+    systemdUnitBroker: null,
+    webConsoleLink: null,
+    managementEnvState: null,
+    edgeRuntimeEnvState: null,
+    edgeRuntimeDropInState: null,
+    managementPrivilegeDropInState: null,
+    embeddedEdgePrivilegeDropInState: null,
+    grafanaConfigStates: [],
+    grafanaWasActive: null,
+  };
+}
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -1419,6 +1438,8 @@ describe("upgrade release selection", () => {
         edgeRuntimeDropInState: null,
         managementPrivilegeDropInState: null,
         embeddedEdgePrivilegeDropInState: null,
+        grafanaConfigStates: [],
+        grafanaWasActive: null,
       };
       let rollbackFailure: unknown;
       try {
@@ -1484,6 +1505,75 @@ describe("upgrade release selection", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  test("repairs Grafana subpath settings transactionally during an existing-host upgrade", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-grafana-upgrade-"));
+    const managementEnv = join(directory, "management-api.env");
+    const liveConfig = join(directory, "grafana.ini");
+    const templateConfig = join(directory, "grafana.ini.j2");
+    const previousEnv = "GRAFANA_URL=http://127.0.0.1:3000\nCUSTOM=keep\n";
+    const previousConfig = "[server]\nroot_url = /ui/\nserve_from_sub_path = false\n";
+    const activationState = emptyUpgradeActivationState(join(directory, "supacloud"));
+    let restartCount = 0;
+    try {
+      writeFileSync(managementEnv, previousEnv);
+      writeFileSync(liveConfig, previousConfig);
+      writeFileSync(templateConfig, previousConfig);
+      activationState.managementEnvState = captureFileState(managementEnv);
+
+      await applyGrafanaUpgradeSettings(activationState, {}, {
+        configPaths: [liveConfig, templateConfig],
+        managementEnvPath: managementEnv,
+        service: {
+          isActive: async () => true,
+          restart: async () => { restartCount += 1; },
+        },
+      });
+
+      expect(restartCount).toBe(1);
+      expect(activationState.grafanaWasActive).toBe(true);
+      expect(activationState.grafanaConfigStates).toHaveLength(2);
+      expect(readFileSync(liveConfig, "utf8")).toContain("root_url = /grafana/");
+      expect(readFileSync(templateConfig, "utf8")).toContain("serve_from_sub_path = true");
+      expect(readFileSync(managementEnv, "utf8")).toContain("GRAFANA_URL=http://127.0.0.1:3000/grafana");
+
+      await rollbackArtifacts(activationState, []);
+      expect(readFileSync(liveConfig, "utf8")).toBe(previousConfig);
+      expect(readFileSync(templateConfig, "utf8")).toBe(previousConfig);
+      expect(readFileSync(managementEnv, "utf8")).toBe(previousEnv);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails before runtime mutation when an active Grafana config is missing", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "supacloud-grafana-missing-"));
+    const managementEnv = join(directory, "management-api.env");
+    const activationState = emptyUpgradeActivationState(join(directory, "supacloud"));
+    try {
+      writeFileSync(managementEnv, "GRAFANA_URL=http://127.0.0.1:3000\n");
+      await expect(applyGrafanaUpgradeSettings(activationState, {}, {
+        configPaths: [join(directory, "missing-grafana.ini")],
+        managementEnvPath: managementEnv,
+        service: {
+          isActive: async () => true,
+          restart: async () => { throw new Error("restart must not run"); },
+        },
+      })).rejects.toThrow("Active grafana-server config is missing");
+      expect(readFileSync(managementEnv, "utf8")).toBe("GRAFANA_URL=http://127.0.0.1:3000\n");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("derives the Grafana template from the persisted absolute Pigsty path", () => {
+    expect(grafanaSubpathConfigPaths({ PIGSTY_PATH: "/srv/pigsty" })).toEqual([
+      "/etc/grafana/grafana.ini",
+      "/srv/pigsty/roles/infra/templates/grafana/grafana.ini.j2",
+    ]);
+    expect(() => grafanaSubpathConfigPaths({ PIGSTY_PATH: "relative/pigsty" }))
+      .toThrow("PIGSTY_PATH must be absolute");
   });
 
   test("a failed current backup never restores a stale historical .bak file", () => {


### PR DESCRIPTION
修复旧实例升级时 Grafana 子路径配置未同步的问题。

- 升级事务修复 live 配置、Pigsty 模板和 GRAFANA_URL
- 失败时恢复配置并按原运行状态重启 Grafana
- 增加回归测试

验证：相关测试 92 pass；全量 unit、typecheck、build、diff check 通过。