### PR TITLE
feat(cli): expose controlled auth user and login link lifecycle

### DIFF
--- a/packages/cli/skills/supacloud-cli/references/command-map.md
+++ b/packages/cli/skills/supacloud-cli/references/command-map.md
@@ -17,6 +17,7 @@ Load this reference when selecting a command surface or when a user asks an AI t
 | Inspect or back up a remote database | `supabase db_pull`, `migration_list`, `db_dump`, `gen_types` | Requires explicit PostgreSQL DSN; redact it |
 | Preview/apply migrations remotely | `supabase push` | Always dry-run first; production needs explicit approval |
 | Mark proven-equivalent historical migrations as applied | `database baseline_migrations` | Dry-run, schema-equivalence proof, backup, explicit approval |
+| Inspect auth users or generate a controlled login link | `auth list_users`, `auth get_user`, `auth generate_link` | User reads are bounded; login-link generation is a production-confirmed write and action links stay in the calling process |
 | Manage Auth/Storage/Edge Functions/frontend/secrets | Corresponding project module | Keep deployable config/code in version control |
 | Configure project gateway routes | `gateway` | Requires an admin-capable project token; inspect before write |
 | Install/upgrade/debug SupaCloud servers | `supacloud-admin` | Platform boundary; not a project CLI action |
@@ -31,7 +32,7 @@ until a project-scoped context is resolved.
 - `project`: selected-project metadata, authoritative endpoint projection, health, logs, API keys/settings, background tasks, retry/cancel, DLQ, and background settings. `project list` deliberately redirects to `supacloud-admin`; cross-project enumeration is not a project CLI capability.
 - `database`: read/query, schema inspection, extensions, indexes, RLS, stats, migration push, controlled historical baseline, and SQL-file execution.
 - `supabase`: allowlisted official CLI adapter for migration authoring, local reset/diff, explicit-DSN inspection/backup/type generation, and SupaCloud-controlled migration push.
-- `auth`: provider and authentication configuration.
+- `auth`: provider/configuration plus bounded user lookup and production-confirmed login-link generation.
 - `storage`: buckets and object-management workflows.
 - `edge_functions`: list, atomically read one active or deleted identity with `get_config`, read immutable source, deploy, activate, configure, and delete Edge Functions. For every mutation, pass the `activation_id` read from the same `list` or `get_config` snapshot as `--expected-activation-id`; use `legacy` only for a never-created or listed legacy Function, not for a deleted slug with a tombstone UUID. Deploy and activate actions also require the non-negative observed version as `--expected-active-version`; use `absent` for a never-created slug or a `get_config` tombstone. Version `0` is a legacy version token and cannot be used as a source or activation target.
 - `frontend`: list, build/deploy, domain, and deployment workflows.

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -172,6 +172,19 @@ describe("CLI execution policy", () => {
         })).toThrow("SUPACLOUD_READ_ONLY=true");
     });
 
+    test("classifies auth user reads and generate_link as a production-confirmed write", () => {
+        expect(executionMode("auth", "list_users", {})).toBe("read");
+        expect(executionMode("auth", "get_user", {})).toBe("read");
+        expect(executionMode("auth", "generate_link", {})).toBe("write");
+        expect(() => authorizeExecution("auth", { action: "generate_link", ref: "prod-ref" }, {
+            context: context(),
+        })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("auth", { action: "generate_link", ref: "prod-ref" }, {
+            context: context(),
+            confirmProduction: "prod-ref",
+        })).not.toThrow();
+    });
+
     test("classifies verified release controls and protects their mutations", () => {
         expect(executionMode("release", "logical_backup_list", {})).toBe("read");
         expect(executionMode("release", "postgrest_status", {})).toBe("read");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -25,8 +25,8 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         write: ["push"],
     },
     auth: {
-        read: ["list_providers", "get_provider", "supported_providers", "get_settings", "get_config"],
-        write: ["configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config"],
+        read: ["list_users", "get_user", "list_providers", "get_provider", "supported_providers", "get_settings", "get_config"],
+        write: ["generate_link", "configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config"],
     },
     oauth_clients: {
         read: ["list", "get"],

--- a/packages/cli/src/shared/tools/auth-tools.test.ts
+++ b/packages/cli/src/shared/tools/auth-tools.test.ts
@@ -22,6 +22,117 @@ function captureAuthTool(http: Record<string, unknown>) {
 }
 
 describe("auth CLI mutation contract", () => {
+    test("lists bounded users with pagination and projects safe fields", async () => {
+        const requests: Array<{ path: string; options: unknown }> = [];
+        const { schema, callback } = captureAuthTool({
+            get: async (path: string, options: unknown) => {
+                requests.push({ path, options });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        users: [{
+                            id: "00000000-0000-4000-8000-000000000001",
+                            email: "operator@example.test",
+                            encrypted_password: "must-not-return",
+                            confirmation_token: "must-not-return",
+                        }],
+                        total: 1,
+                        page: 2,
+                        per_page: 1,
+                    },
+                };
+            },
+        });
+
+        const args = parseToolArguments(schema, {
+            action: "list_users",
+            ref: "project-a",
+            page: 2,
+            per_page: 1,
+            search: "operator@example.test",
+        });
+        const response = await callback(args);
+        const output = JSON.parse(response.content[0].text);
+
+        expect(requests[0]?.path).toBe("/v1/projects/project-a/auth/users?page=2&per_page=1&search=operator%40example.test");
+        expect(requests[0]?.options).toEqual({ maxJsonBytes: 64 * 1024, responseTimeoutMs: 5_000 });
+        expect(output.users).toEqual([{ id: "00000000-0000-4000-8000-000000000001", email: "operator@example.test" }]);
+        expect(response.content[0].text).not.toContain("must-not-return");
+    });
+
+    test("gets an exact UUID user and rejects path injection", async () => {
+        const paths: string[] = [];
+        const { callback } = captureAuthTool({
+            get: async (path: string) => {
+                paths.push(path);
+                return { ok: true, status: 200, data: { id: "00000000-0000-4000-8000-000000000002", email: "user@example.test" } };
+            },
+        });
+
+        const response = await callback({
+            action: "get_user",
+            ref: "project-a",
+            user_id: "00000000-0000-4000-8000-000000000002",
+        });
+        expect(paths).toEqual(["/v1/projects/project-a/auth/users/00000000-0000-4000-8000-000000000002"]);
+        expect(JSON.parse(response.content[0].text).user.email).toBe("user@example.test");
+        await expect(callback({ action: "get_user", ref: "project-a", user_id: "../../secrets" })).rejects.toThrow("must be a UUID");
+    });
+
+    test("returns only the action link from a successful bounded generate_link response", async () => {
+        const requests: Array<{ path: string; body: unknown }> = [];
+        const { callback } = captureAuthTool({
+            postReleaseMutation: async (path: string, body: unknown) => {
+                requests.push({ path, body });
+                return {
+                    ok: true,
+                    status: 200,
+                    data: {
+                        properties: {
+                            action_link: "https://auth.example.test/verify?token=one-time",
+                            hashed_token: "must-not-return",
+                        },
+                        user: { email: "user@example.test" },
+                    },
+                };
+            },
+        });
+
+        const response = await callback({
+            action: "generate_link",
+            ref: "project-a",
+            type: "magiclink",
+            email: "user@example.test",
+            redirect_to: "https://app.example.test/callback",
+        });
+        expect(requests).toEqual([{
+            path: "/v1/projects/project-a/auth/generate_link",
+            body: { type: "magiclink", email: "user@example.test", redirect_to: "https://app.example.test/callback" },
+        }]);
+        expect(JSON.parse(response.content[0].text)).toEqual({
+            ok: true,
+            operation: "auth.generate_link",
+            action_link: "https://auth.example.test/verify?token=one-time",
+        });
+        expect(response.content[0].text).not.toContain("must-not-return");
+    });
+
+    test("does not echo sensitive upstream bodies from generate_link failures", async () => {
+        const secret = "action-link-secret";
+        const { callback } = captureAuthTool({
+            postReleaseMutation: async () => ({
+                ok: false,
+                status: 502,
+                data: { action_link: secret, email: "user@example.test", token: secret },
+            }),
+        });
+        const response = await callback({ action: "generate_link", ref: "project-a", type: "magiclink", email: "user@example.test" });
+        expect(response.isError).toBe(true);
+        expect(response.content[0].text).not.toContain(secret);
+        expect(response.content[0].text).not.toContain("user@example.test");
+    });
+
     test("decodes a CLI JSON config before sending the PATCH request", async () => {
         const requests: Array<{ path: string; body: unknown }> = [];
         const { schema, callback } = captureAuthTool({

--- a/packages/cli/src/shared/tools/auth-tools.ts
+++ b/packages/cli/src/shared/tools/auth-tools.ts
@@ -2,6 +2,7 @@
  * Auth — Compound tool (10→1)
  */
 import { Type } from "@sinclair/typebox";
+import { projectRefPathSegment } from "../project-ref";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import type { HttpResult, HttpTransport } from "../transports/http";
 
@@ -10,6 +11,16 @@ const safeAuthMutationCodes = new Set([
     "AUTH_RUNTIME_APPLY_FAILED",
     "SUPAUTH_DEPENDENT_REFRESH_FAILED",
 ]);
+const MAX_AUTH_READ_BYTES = 64 * 1024;
+const AUTH_READ_TIMEOUT_MS = 5_000;
+const USER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const AUTH_LINK_TYPES = [
+    "signup", "magiclink", "recovery", "invite", "email_change", "email_change_current", "email_change_new",
+] as const;
+
+const SAFE_USER_FIELDS = [
+    "id", "email", "phone", "created_at", "last_sign_in_at",
+] as const;
 
 function parseAuthConfig(input: string | Record<string, unknown>): unknown {
     if (typeof input !== "string") return input;
@@ -67,6 +78,156 @@ function authMutationResult(response: HttpResult<unknown>, successMessage: strin
     };
 }
 
+function requiredRef(candidate: unknown): string {
+    if (typeof candidate !== "string" || !candidate.trim()) throw new Error("'ref' is required");
+    return projectRefPathSegment(candidate.trim(), "Auth");
+}
+
+function requiredUserId(candidate: unknown): string {
+    if (typeof candidate !== "string" || !USER_ID_PATTERN.test(candidate.trim())) {
+        throw new Error("'user_id' must be a UUID");
+    }
+    return candidate.trim().toLowerCase();
+}
+
+function boundedPage(candidate: unknown): number {
+    if (candidate === undefined) return 1;
+    if (typeof candidate !== "number" || !Number.isSafeInteger(candidate) || candidate < 1) {
+        throw new Error("'page' must be a positive integer");
+    }
+    return candidate;
+}
+
+function boundedPerPage(candidate: unknown): number {
+    if (candidate === undefined) return 50;
+    if (typeof candidate !== "number" || !Number.isSafeInteger(candidate) || candidate < 1 || candidate > 100) {
+        throw new Error("'per_page' must be an integer between 1 and 100");
+    }
+    return candidate;
+}
+
+function safeRedirectTo(candidate: unknown): string | undefined {
+    if (candidate === undefined) return undefined;
+    if (typeof candidate !== "string" || !candidate.trim()) throw new Error("'redirect_to' must be an absolute HTTPS or loopback HTTP URL");
+    let uri: URL;
+    try {
+        uri = new URL(candidate.trim());
+    } catch {
+        throw new Error("'redirect_to' must be an absolute HTTPS or loopback HTTP URL");
+    }
+    const loopback = uri.hostname === "127.0.0.1" || uri.hostname === "[::1]";
+    const validProtocol = uri.protocol === "https:" || (uri.protocol === "http:" && loopback && Boolean(uri.port));
+    if (!validProtocol || uri.username || uri.password || uri.hash) {
+        throw new Error("'redirect_to' must be an absolute HTTPS or loopback HTTP URL without credentials or fragment");
+    }
+    return uri.toString();
+}
+
+function isRecord(candidate: unknown): candidate is Record<string, unknown> {
+    return candidate !== null && typeof candidate === "object" && !Array.isArray(candidate);
+}
+
+function projectUser(candidate: unknown): Record<string, unknown> | null {
+    if (!isRecord(candidate) || typeof candidate.id !== "string") return null;
+    const projectedUser: Record<string, unknown> = {};
+    for (const field of SAFE_USER_FIELDS) {
+        if (field in candidate) projectedUser[field] = candidate[field];
+    }
+    return projectedUser;
+}
+
+function projectUserList(candidate: unknown): Record<string, unknown> | null {
+    if (!isRecord(candidate) || !Array.isArray(candidate.users)) return null;
+    const users = candidate.users.map(projectUser);
+    if (users.some((user) => user === null)) return null;
+    const projectedFields: Record<string, unknown> = { users };
+    for (const field of ["total", "page", "per_page", "next_page", "last_page"] as const) {
+        if (field in candidate && (typeof candidate[field] === "number" || candidate[field] === null)) {
+            projectedFields[field] = candidate[field];
+        }
+    }
+    return projectedFields;
+}
+
+function actionLink(candidate: unknown): string | null {
+    const candidates: unknown[] = [candidate];
+    if (isRecord(candidate)) {
+        candidates.push(candidate.data, candidate.properties);
+        if (isRecord(candidate.data)) candidates.push(candidate.data.properties);
+    }
+    for (const candidate of candidates) {
+        if (isRecord(candidate) && typeof candidate.action_link === "string" && candidate.action_link.length > 0) {
+            return candidate.action_link;
+        }
+    }
+    return null;
+}
+
+function safeAuthReadFailure(operation: string, response: HttpResult<unknown>) {
+    return {
+        isError: true,
+        content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+                ok: false,
+                operation,
+                http_status: response.transportError || response.responseReadError ? null : response.status,
+                error: response.responseReadError ? "INVALID_RESPONSE" : response.transportError ? "NETWORK_ERROR" : "HTTP_ERROR",
+            }, null, 2),
+        }],
+    };
+}
+
+async function listUsers(http: HttpTransport, args: Record<string, unknown>) {
+    const ref = requiredRef(args.ref);
+    const page = boundedPage(args.page);
+    const perPage = boundedPerPage(args.per_page);
+    const params = new URLSearchParams({ page: String(page), per_page: String(perPage) });
+    for (const key of ["search", "email_like"] as const) {
+        if (args[key] !== undefined) {
+            if (typeof args[key] !== "string" || !args[key].trim()) throw new Error(`'${key}' must be a non-empty string`);
+            params.set(key, args[key].trim());
+        }
+    }
+    const response = await http.get(`/v1/projects/${ref}/auth/users?${params.toString()}`, {
+        maxJsonBytes: MAX_AUTH_READ_BYTES,
+        responseTimeoutMs: AUTH_READ_TIMEOUT_MS,
+    });
+    if (!response.ok) return safeAuthReadFailure("auth.list_users", response);
+    const users = projectUserList(response.data);
+    if (!users) return safeAuthReadFailure("auth.list_users", { ...response, responseReadError: true });
+    return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, operation: "auth.list_users", project_ref: ref, ...users }, null, 2) }] };
+}
+
+async function getUser(http: HttpTransport, args: Record<string, unknown>) {
+    const ref = requiredRef(args.ref);
+    const userId = requiredUserId(args.user_id);
+    const response = await http.get(`/v1/projects/${ref}/auth/users/${encodeURIComponent(userId)}`, {
+        maxJsonBytes: MAX_AUTH_READ_BYTES,
+        responseTimeoutMs: AUTH_READ_TIMEOUT_MS,
+    });
+    if (!response.ok) return safeAuthReadFailure("auth.get_user", response);
+    const user = projectUser(response.data);
+    if (!user) return safeAuthReadFailure("auth.get_user", { ...response, responseReadError: true });
+    return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, operation: "auth.get_user", project_ref: ref, user }, null, 2) }] };
+}
+
+async function generateLink(http: HttpTransport, args: Record<string, unknown>) {
+    const ref = requiredRef(args.ref);
+    if (typeof args.type !== "string" || !(AUTH_LINK_TYPES as readonly string[]).includes(args.type)) {
+        throw new Error("'type' is invalid for 'generate_link'");
+    }
+    if (typeof args.email !== "string" || !args.email.trim()) throw new Error("'email' is required for 'generate_link'");
+    const body: Record<string, unknown> = { type: args.type, email: args.email.trim() };
+    const redirectTo = safeRedirectTo(args.redirect_to);
+    if (redirectTo) body.redirect_to = redirectTo;
+    const response = await http.postReleaseMutation(`/v1/projects/${ref}/auth/generate_link`, body);
+    if (!response.ok) return safeAuthReadFailure("auth.generate_link", response);
+    const link = actionLink(response.data);
+    if (!link) return safeAuthReadFailure("auth.generate_link", { ...response, responseReadError: true });
+    return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, operation: "auth.generate_link", action_link: link }, null, 2) }] };
+}
+
 function formatProviders(data: unknown): string {
     if (!data || typeof data !== "object") return JSON.stringify(data, null, 2);
     const result = data as { providers?: Record<string, { enabled: boolean; client_id?: string }> };
@@ -84,10 +245,11 @@ function formatProviders(data: unknown): string {
 export function registerAuthTools(server: { tool: (...args: any[]) => void }, http: HttpTransport): void {
     server.tool(
         "auth",
-        `Auth & OAuth provider management.
-Actions: list_providers, get_provider, configure_provider, update_provider, disable_provider, supported_providers, wechat_mini, wechat_open, get_settings, update_settings, get_config, update_config`,
+        `Auth & OAuth provider management, controlled user lookup, and login-link generation.
+Actions: list_users, get_user, generate_link, list_providers, get_provider, configure_provider, update_provider, disable_provider, supported_providers, wechat_mini, wechat_open, get_settings, update_settings, get_config, update_config`,
         {
             action: withDescription(stringEnum([
+                "list_users", "get_user", "generate_link",
                 "list_providers", "get_provider", "configure_provider", "update_provider",
                 "disable_provider", "supported_providers",
                 "wechat_mini", "wechat_open",
@@ -95,6 +257,14 @@ Actions: list_providers, get_provider, configure_provider, update_provider, disa
                 "get_config", "update_config",
             ]), "Action to perform"),
             ref: optional(Type.String(), "Project ref (required for most actions)"),
+            user_id: optional(Type.String(), "[get_user] Exact auth user UUID"),
+            page: optional(Type.Integer({ minimum: 1 }), "[list_users] 1-based page"),
+            per_page: optional(Type.Integer({ minimum: 1, maximum: 100 }), "[list_users] Users per page (1-100)"),
+            search: optional(Type.String(), "[list_users] Search user email, phone, or UUID"),
+            email_like: optional(Type.String(), "[list_users] Search user email or phone"),
+            type: optional(stringEnum(AUTH_LINK_TYPES), "[generate_link] GoTrue link type"),
+            email: optional(Type.String(), "[generate_link] User email"),
+            redirect_to: optional(Type.String(), "[generate_link] Absolute HTTPS or loopback callback"),
             provider: optional(Type.String(), "[*_provider] Provider name (github, google, wechat, etc.)"),
             client_id: optional(Type.String(), "[configure/update] OAuth Client ID"),
             client_secret: optional(Type.String(), "[configure/update] OAuth Client Secret"),
@@ -111,6 +281,12 @@ Actions: list_providers, get_provider, configure_provider, update_provider, disa
 
             let text: string;
             switch (action) {
+                case "list_users":
+                    return listUsers(http, args);
+                case "get_user":
+                    return getUser(http, args);
+                case "generate_link":
+                    return generateLink(http, args);
                 case "list_providers":
                     need("ref");
                     const lp = await http.get(`/v1/projects/${ref}/auth/providers`);


### PR DESCRIPTION
## Summary
- expose bounded exact/paginated auth user lookup in the official CLI
- add production-confirmed auth generate_link with sensitive response projection
- classify the new actions in execution policy and document the CLI surface

## Security
- project refs and UUID user IDs are validated before path construction
- user reads use 64 KiB / 5 second response bounds
- generate_link uses the bounded release-mutation transport
- upstream error bodies and sensitive fields are never reflected

## Verification
- `cd packages/cli && bun test` (810 pass)
- `bun run typecheck`
- `bun run build`
- `git diff --check`

Parent/follow-up: SUPACLOUD-CLI-AUTH-USER-LINK-LIFECYCLE-20260818
Source: FA production release blocker