### PR TITLE
fix(management): normalize webhook replay timestamps

### DIFF
--- a/packages/management-api/src/services/webhook-delivery.service.ts
+++ b/packages/management-api/src/services/webhook-delivery.service.ts
@@ -571,6 +571,9 @@ export const webhookDeliveryService = {
         WHERE d.project_ref = ${ref} AND d.webhook_id = ${webhookId} AND d.id = ${deliveryId}
       `;
       if (!delivery) throw new NotFoundError("Webhook delivery", deliveryId);
+      const occurredAt = delivery.occurred_at instanceof Date
+        ? delivery.occurred_at.toISOString()
+        : String(delivery.occurred_at);
       await tx`SELECT pg_advisory_xact_lock(hashtext(${`webhook-outbox:${ref}`}))`;
       await assertOutboxCapacity(tx, ref, 1);
       const [row] = await tx`
@@ -579,7 +582,7 @@ export const webhookDeliveryService = {
           idempotency_key, max_attempts, replay_of_delivery_id, created_by
         ) VALUES (
           ${ref}, ${webhookId}, ${delivery.event_id}::uuid, ${String(delivery.event_type)},
-          ${JSON.stringify(delivery.payload || {})}::jsonb, ${String(delivery.occurred_at)}::timestamptz,
+          ${JSON.stringify(delivery.payload || {})}::jsonb, ${occurredAt}::timestamptz,
           ${String(delivery.api_version || SIGNATURE_API_VERSION)},
           ${`replay:${deliveryId}:${crypto.randomUUID()}`}, ${DEFAULT_MAX_ATTEMPTS},
           ${deliveryId}::uuid, ${actor}

--- a/packages/management-api/tests/unit/webhook-delivery.service.test.ts
+++ b/packages/management-api/tests/unit/webhook-delivery.service.test.ts
@@ -363,6 +363,8 @@ describe("durable webhook delivery processing", () => {
     expect(replayInsert?.values).toContain(originalDelivery.event_id);
     expect(replayInsert?.values).toContain(originalDelivery.event_type);
     expect(replayInsert?.values).toContain(originalDelivery.api_version);
+    expect(replayInsert?.values).toContain(originalDelivery.occurred_at.toISOString());
+    expect(replayInsert?.values).not.toContain(String(originalDelivery.occurred_at));
     expect(replayInsert?.values).toContain("admin-one");
     expect(replayInsert?.text).toContain("replay_of_delivery_id, created_by");
   });


### PR DESCRIPTION
## 目标\n\n修复测试服 CNB #81 Webhook replay 在 Asia/Shanghai 时区下返回 500/503。\n\n## 根因\n\nPostgreSQL 返回的 Date 被 String 转换为包含 GMT+0800 的本地化文本；目标 PostgreSQL 不接受该时区表示。replay 现在对 Date 使用 UTC ISO 8601。\n\n## Follow-up 关联\n\n- parent: cnb-68-83-complete-20260818\n- source: CNB #81 测试服真机 replay，位于 SupAuth PR #94 与 SupaCloud PR #964 部署后\n- reason: replay 时间戳本地化序列化导致 PostgreSQL 500，随后被 facade 映射为 503\n\n## 验证\n\n- TZ=Asia/Shanghai bun test tests/unit/webhook-delivery.service.test.ts：15 pass，76 assertions\n- bun run typecheck：PASS\n- git diff --check：PASS\n- clean-code-guard：clean\n\n合并部署后仍需在 192.168.200.112 上验证 replay 返回 202、queued=true、新 outbox/new delivery 与 replay_of_delivery_id。