### PR TITLE
feat(cli): replay release canary fixture receipts

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -108,10 +108,12 @@ loopback development origins, with the default `:80` likewise omitted. Use
 
 ### Verified release controls
 
-`release` is an official CLI entry point for the existing Management API
-logical-backup and PostgREST lifecycle capabilities. It requires the Management
-API context above; it does not promote an application `service_role` key to
-Management authority.
+`release` is an official CLI entry point for verified Management API controls
+and the release-canary fixture receipt replay. Management actions require the
+Management API context above. `release_canary_fixture_stage_replay` additionally
+requires the same project's `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`; the
+key is sent only to that application origin and is never promoted to Management
+authority.
 
 Project pause and restore are explicit lifecycle commands. A logical backup
 restore requires an operator to pause the selected project first and then use
@@ -138,6 +140,8 @@ supacloud-cli release logical_backup_restore --ref abc123 \
   --restore_confirmation RESTORE_PROJECT:abc123:logical-full_abc123_<backup-id-suffix>:<64-lowercase-hex>
 supacloud-cli release postgrest_status --ref abc123
 supacloud-cli release postgrest_restart --ref abc123
+supacloud-cli release release_canary_fixture_stage_replay --ref abc123 \
+  --subject <central-subject-uuid> --request_id <stage-request-uuid>
 ```
 
 Backup creation reports success only after the CLI verifies exactly one new
@@ -157,6 +161,15 @@ PostgREST restart reports success only after it receives a matching restart
 receipt and reads back `desired=running`, `actual=running`, and
 `health=healthy`. Both mutating controls follow the normal production
 confirmation and read-only protections.
+
+`release_canary_fixture_stage_replay` performs one non-retried, response-bounded
+call to the fixed `fa_release_canary_fixture_stage` PostgREST RPC with both
+bearer and `apikey` service-role headers. It accepts only canonical subject and
+request UUIDs, requires a strict `staged` and `idempotent=true` four-field
+receipt, and emits only that safe projection. Before and after the call, the CLI
+reads the selected project's authoritative endpoint projection and requires the
+configured application origin to match its API origin or alias. Production
+confirmation is mandatory.
 
 The legacy `.env` fallback is unclassified and therefore does not enable the
 production confirmation gate. Production automation must select a `prod` or

--- a/packages/cli/skills/supacloud-cli/references/command-map.md
+++ b/packages/cli/skills/supacloud-cli/references/command-map.md
@@ -15,6 +15,7 @@ Load this reference when selecting a command surface or when a user asks an AI t
 | Generate migration from local schema changes | `supabase db_diff` | Review generated SQL before use |
 | Rebuild local database | `supabase db_reset` | Local only; preserve required seed behavior |
 | Inspect or back up a remote database | `supabase db_pull`, `migration_list`, `db_dump`, `gen_types` | Requires explicit PostgreSQL DSN; redact it |
+| Replay the release-canary fixture stage receipt | `release release_canary_fixture_stage_replay` | Dual-bind Management project context and that project's service-role application origin; accepts only the exact subject/request UUID pair and a strict idempotent receipt |
 | Preview/apply migrations remotely | `supabase push` | Always dry-run first; production needs explicit approval |
 | Mark proven-equivalent historical migrations as applied | `database baseline_migrations` | Dry-run, schema-equivalence proof, backup, explicit approval |
 | Inspect auth users or generate a controlled login link | `auth list_users`, `auth get_user`, `auth generate_link` | User reads are bounded; generation supports only `magiclink`, `recovery`, and `invite`, requires production confirmation, and returns only a validated action URL |
@@ -39,6 +40,7 @@ until a project-scoped context is resolved.
 - `secrets`: project secret management; never print values after write.
 - `queue`, `task_events`, `diagnostics`: asynchronous workload operations and bounded diagnostics.
 - `gateway`: project route/config/rebuild operations.
+- `release`: verified backup/PostgREST lifecycle controls plus a production-confirmed, non-retried, strict release-canary fixture stage replay. The replay requires both the selected Management project binding and that project's `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`.
 - `ai`: inspect or install this packaged Skill.
 
 ## Safe inspection pattern

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2704,6 +2704,106 @@ describe("supacloud-cli process contract", () => {
         expect(result.stdout + result.stderr).not.toContain("application-service-role");
     });
 
+    test("release-canary stage replay uses the dual-bound service role and strict safe receipt", async () => {
+        const serviceRoleKey = "application-service-role-private";
+        const rpcRequests: Array<{
+            path: string;
+            authorization: string | null;
+            apiKey: string | null;
+            body: unknown;
+        }> = [];
+        const applicationServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                rpcRequests.push({
+                    path: new URL(request.url).pathname,
+                    authorization: request.headers.get("authorization"),
+                    apiKey: request.headers.get("apikey"),
+                    body: await request.json(),
+                });
+                return Response.json({
+                    fixtureId: "11111111-1111-4111-8111-111111111111",
+                    tenantKey: "release-canary-22222222-2222-4222-8222-222222222222",
+                    state: "staged",
+                    idempotent: true,
+                });
+            },
+        });
+        servers.push(applicationServer);
+        const applicationOrigin = `http://127.0.0.1:${applicationServer.port}`;
+        const managementRequests: string[] = [];
+        const managementServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                managementRequests.push(new URL(request.url).pathname);
+                return Response.json({
+                    schema: "supacloud.project-endpoints.v1",
+                    project_ref: "abc123",
+                    endpoints: {
+                        api: {
+                            origin: applicationOrigin,
+                            host: `127.0.0.1:${applicationServer.port}`,
+                            scheme: "http",
+                            source: "explicit_api_domain",
+                            aliases: [],
+                        },
+                        auth: { origin: "https://auth.example.test", host: "auth.example.test", scheme: "https", source: "explicit_auth_domain", aliases: [] },
+                        studio: { origin: "https://studio.example.test", host: "studio.example.test", scheme: "https", source: "explicit_studio_domain", aliases: [] },
+                    },
+                });
+            },
+        });
+        servers.push(managementServer);
+        const privateSubject = "33333333-3333-4333-8333-333333333333";
+        const requestId = "44444444-4444-4444-8444-444444444444";
+        const environment = {
+            SUPACLOUD_ENV: "production",
+            SUPACLOUD_API_URL: `http://127.0.0.1:${managementServer.port}`,
+            SUPACLOUD_API_TOKEN: "management-private-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            SUPABASE_URL: applicationOrigin,
+            SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+        };
+
+        const blocked = await runProjectCli([
+            "release", "release_canary_fixture_stage_replay", "--ref", "abc123",
+            "--subject", privateSubject, "--request_id", requestId,
+        ], environment);
+        expect(blocked.exitCode).toBe(1);
+        expect(rpcRequests).toHaveLength(0);
+
+        const result = await runProjectCli([
+            "release", "release_canary_fixture_stage_replay", "--ref", "abc123",
+            "--subject", privateSubject, "--request_id", requestId,
+            "--confirm-production", "abc123",
+        ], environment);
+        const receipt = JSON.parse(result.stdout);
+
+        expect(result.exitCode).toBe(0);
+        expect(receipt).toMatchObject({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "release.release_canary.fixture_stage_replay",
+            project_ref: "abc123",
+            receipt: { state: "staged", idempotent: true },
+        });
+        expect(rpcRequests).toEqual([{
+            path: "/rest/v1/rpc/fa_release_canary_fixture_stage",
+            authorization: `Bearer ${serviceRoleKey}`,
+            apiKey: serviceRoleKey,
+            body: { p_subject: privateSubject, p_request_id: requestId },
+        }]);
+        expect(managementRequests).toEqual([
+            "/v1/projects/abc123/endpoint/projection",
+            "/v1/projects/abc123/endpoint/projection",
+        ]);
+        expect(result.stdout + result.stderr).not.toContain(serviceRoleKey);
+        expect(result.stdout + result.stderr).not.toContain("management-private-token");
+        expect(result.stdout + result.stderr).not.toContain(privateSubject);
+    });
+
     test.each([["401", 401], ["403", 403]] as const)(
         "status reports application credential rejection %s without reflecting the key",
         async (_statusLabel, rejectionStatus) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -267,7 +267,8 @@ DEFAULT CONTEXT
   Without a selector or project variables, runs use the current project's legacy .env.
   Application status accepts SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.
   Management-backed project commands require SUPACLOUD_API_URL +
-  SUPACLOUD_API_TOKEN. These credential scopes are never mixed.
+  SUPACLOUD_API_TOKEN. Only release release_canary_fixture_stage_replay may additionally use
+  the selected project's SUPABASE_* pair for one application-origin RPC.
   SUPACLOUD_PROJECT_REF is required when it cannot be inferred from <ref>.api.*.
 
   SUPACLOUD_READ_ONLY=true blocks remote writes. Production writes require an
@@ -288,6 +289,7 @@ EXAMPLES
   ${preferredCommand} release logical_backup_restore --ref abc123 --backup_id <backup_id> --expected_sha256 <sha256> --restore_confirmation RESTORE_PROJECT:abc123:<backup_id>:<sha256>
   ${preferredCommand} release postgrest_status --ref abc123
   ${preferredCommand} release postgrest_restart --ref abc123
+  ${preferredCommand} release release_canary_fixture_stage_replay --ref abc123 --subject <uuid> --request_id <uuid>
   ${preferredCommand} queue stats --queue emails
   ${preferredCommand} queue dlq --queue emails --limit 20
   ${preferredCommand} frontend list --ref abc123
@@ -454,6 +456,13 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
         baseUrl: context.apiUrl,
         token: context.apiToken,
     });
+    const applicationHttp = context.inferredSupabaseUrl && context.inferredServiceRoleKey
+        ? new HttpTransport({
+            baseUrl: context.inferredSupabaseUrl,
+            token: context.inferredServiceRoleKey,
+            apiKey: context.inferredServiceRoleKey,
+        })
+        : undefined;
 
     const assign = (extra: ToolMap) => Object.assign(tools, extra);
 
@@ -478,6 +487,8 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     assign(captureTools((server) => registerMutationTools(server as any, http)));
     assign(captureTools((server) => registerReleaseTools(server as any, http, {
         projectRef: context.projectRef || undefined,
+        applicationHttp,
+        applicationOrigin: context.inferredSupabaseUrl || undefined,
     })));
     assign(captureTools((server) => registerFrontendTools(server as any, http)));
     assign(captureTools((server) => registerGatewayTools(server as any, http, {

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -191,12 +191,16 @@ describe("CLI execution policy", () => {
         expect(executionMode("release", "logical_backup_create", {})).toBe("write");
         expect(executionMode("release", "logical_backup_restore", {})).toBe("write");
         expect(executionMode("release", "postgrest_restart", {})).toBe("write");
+        expect(executionMode("release", "release_canary_fixture_stage_replay", {})).toBe("write");
         expect(() => authorizeExecution("release", { action: "logical_backup_create" }, {
             context: context(),
         })).toThrow("--confirm-production prod-ref");
         expect(() => authorizeExecution("release", { action: "postgrest_restart" }, {
             context: context({ production: false, environment: "test", readOnly: true }),
         })).toThrow("SUPACLOUD_READ_ONLY=true");
+        expect(() => authorizeExecution("release", { action: "release_canary_fixture_stage_replay", ref: "prod-ref" }, {
+            context: context(),
+        })).toThrow("--confirm-production prod-ref");
         expect(() => authorizeExecution("release", { action: "logical_backup_restore", ref: "other-ref" }, {
             context: context(),
             confirmProduction: "other-ref",

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -45,7 +45,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     mutations: { read: ["status"] },
     release: {
         read: ["logical_backup_list", "postgrest_status"],
-        write: ["logical_backup_create", "logical_backup_restore", "postgrest_restart"],
+        write: ["logical_backup_create", "logical_backup_restore", "postgrest_restart", "release_canary_fixture_stage_replay"],
     },
     secrets: { read: ["list"], write: ["upsert", "delete"] },
     frontend: {

--- a/packages/cli/src/shared/tools/project-endpoint-read.ts
+++ b/packages/cli/src/shared/tools/project-endpoint-read.ts
@@ -172,6 +172,14 @@ export function projectEndpointRead(
         : failedResult("Invalid project endpoint response");
 }
 
+export function projectApiOrigins(response: HttpResult<unknown>, expectedRef: string): string[] | null {
+    if (!successfulResponse(response)) return null;
+    const projection = projectEndpointProjection(response.data);
+    if (!projection || projection.project_ref !== expectedRef) return null;
+    const api = projection.endpoints.api;
+    return [api.origin, ...api.aliases.map((alias) => `${api.scheme}://${alias}`)];
+}
+
 export function projectEndpointListRead(response: HttpResult<unknown>): ProjectEndpointReadResult {
     if (!successfulResponse(response)) return failedHttpResult("Project endpoint list", response.status);
     if (!Array.isArray(response.data) || response.data.length > MAX_PROJECTS) {

--- a/packages/cli/src/shared/tools/project-endpoint-tools.test.ts
+++ b/packages/cli/src/shared/tools/project-endpoint-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { schemaEnumValues, type ToolSchema } from "../schema";
 import { registerAdminProjectCliTools, registerUserProjectCliTools } from "./project-cli-tools";
+import { projectApiOrigins } from "./project-endpoint-read";
 
 const PROJECT_REF = "abc123";
 const PROJECT_ENDPOINTS = {
@@ -59,6 +60,14 @@ function captureAdminProjectTool(http: Record<string, unknown>): CapturedProject
 }
 
 describe("project endpoint CLI actions", () => {
+    test("projects the authoritative API origin and aliases for release binding", () => {
+        expect(projectApiOrigins({ ok: true, status: 200, data: PROJECT_ENDPOINTS }, PROJECT_REF)).toEqual([
+            "https://api.example.com",
+            "https://abc123.api.platform.example",
+        ]);
+        expect(projectApiOrigins({ ok: true, status: 200, data: PROJECT_ENDPOINTS }, "other")).toBeNull();
+    });
+
     test("reads the selected project endpoint projection through the user CLI", async () => {
         const requests: Array<{ path: string; maxResponseBytes?: number }> = [];
         const tool = captureUserProjectTool({

--- a/packages/cli/src/shared/tools/release-tools.test.ts
+++ b/packages/cli/src/shared/tools/release-tools.test.ts
@@ -6,6 +6,7 @@ const CREATED_AT = "2026-08-17T00:00:00.000Z";
 const COMPLETED_AT = "2026-08-17T00:00:01.000Z";
 const SHA256 = "a".repeat(64);
 const BACKUP_ID = `logical-full_${PROJECT_REF}_${"b".repeat(32)}`;
+const APPLICATION_ORIGIN = "https://api.example.test";
 
 type ToolResult = {
     content: Array<{ type: "text"; text: string }>;
@@ -42,13 +43,33 @@ function healthyPostgrest(overrides: Record<string, unknown> = {}) {
     };
 }
 
-function captureReleaseTool(http: Record<string, unknown>): ReleaseCallback {
+function projectEndpoints(apiOrigin = APPLICATION_ORIGIN) {
+    const api = new URL(apiOrigin);
+    return {
+        schema: "supacloud.project-endpoints.v1",
+        project_ref: PROJECT_REF,
+        endpoints: {
+            api: { origin: api.origin, host: api.host, scheme: api.protocol.slice(0, -1), source: "explicit_api_domain", aliases: [] },
+            auth: { origin: "https://auth.example.test", host: "auth.example.test", scheme: "https", source: "explicit_auth_domain", aliases: [] },
+            studio: { origin: "https://studio.example.test", host: "studio.example.test", scheme: "https", source: "explicit_studio_domain", aliases: [] },
+        },
+    };
+}
+
+function captureReleaseTool(
+    http: Record<string, unknown>,
+    applicationHttp?: Record<string, unknown>,
+): ReleaseCallback {
     let callback: ReleaseCallback | undefined;
     registerReleaseTools({
         tool(name, _description, _schema, toolCallback) {
             if (name === "release") callback = toolCallback;
         },
-    }, http as never, { projectRef: PROJECT_REF });
+    }, http as never, {
+        projectRef: PROJECT_REF,
+        applicationHttp: applicationHttp as never,
+        applicationOrigin: applicationHttp ? APPLICATION_ORIGIN : undefined,
+    });
     if (!callback) throw new Error("release tool was not registered");
     return callback;
 }
@@ -320,6 +341,129 @@ test("PostgREST restart fails closed when the healthy readback is absent", async
         ok: false,
         operation: "release.postgrest.restart",
         error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+    });
+});
+
+test("release-canary fixture stage replay returns only a strict idempotent receipt", async () => {
+    const requests: Array<{ path: string; body: unknown }> = [];
+    let endpointReads = 0;
+    const callback = captureReleaseTool({
+        get: async () => {
+            endpointReads += 1;
+            return { ok: true, status: 200, data: projectEndpoints() };
+        },
+    }, {
+        postReleaseMutation: async (path: string, body: unknown) => {
+            requests.push({ path, body });
+            return {
+                ok: true,
+                status: 200,
+                data: {
+                    fixtureId: "11111111-1111-4111-8111-111111111111",
+                    tenantKey: "release-canary-22222222-2222-4222-8222-222222222222",
+                    state: "staged",
+                    idempotent: true,
+                },
+            };
+        },
+    });
+    const privateSubject = "33333333-3333-4333-8333-333333333333";
+    const requestId = "44444444-4444-4444-8444-444444444444";
+
+    const response = await callback({
+        action: "release_canary_fixture_stage_replay",
+        subject: privateSubject,
+        request_id: requestId,
+    });
+
+    expect(endpointReads).toBe(2);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.path).toBe("/rest/v1/rpc/fa_release_canary_fixture_stage");
+    expect(requests[0]?.body).toEqual({ p_subject: privateSubject, p_request_id: requestId });
+    expect(payload(response)).toMatchObject({
+        ok: true,
+        operation: "release.release_canary.fixture_stage_replay",
+        project_ref: PROJECT_REF,
+        receipt: { state: "staged", idempotent: true },
+    });
+    expect(response.content[0].text).not.toContain(privateSubject);
+});
+
+test("release-canary fixture stage replay fails closed for missing application context and unsafe receipts", async () => {
+    const callbackWithoutApplication = captureReleaseTool({});
+    await expect(callbackWithoutApplication({
+        action: "release_canary_fixture_stage_replay",
+        subject: "33333333-3333-4333-8333-333333333333",
+        request_id: "44444444-4444-4444-8444-444444444444",
+    })).rejects.toThrow("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+
+    const callbackWithInvalidResponse = captureReleaseTool({
+        get: async () => ({ ok: true, status: 200, data: projectEndpoints() }),
+    }, {
+        postReleaseMutation: async () => ({
+            ok: true,
+            status: 200,
+            data: {
+                fixtureId: "11111111-1111-4111-8111-111111111111",
+                tenantKey: "release-canary-22222222-2222-4222-8222-222222222222",
+                state: "staged",
+                idempotent: true,
+                privateEcho: "must-not-be-reflected",
+            },
+        }),
+    });
+    const response = await callbackWithInvalidResponse({
+        action: "release_canary_fixture_stage_replay",
+        subject: "33333333-3333-4333-8333-333333333333",
+        request_id: "44444444-4444-4444-8444-444444444444",
+    });
+    expect(payload(response)).toMatchObject({
+        ok: false,
+        operation: "release.release_canary.fixture_stage_replay",
+        error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+    });
+    expect(response.content[0].text).not.toContain("must-not-be-reflected");
+});
+
+test.each([
+    ["invalid subject", { subject: "not-a-uuid", request_id: "44444444-4444-4444-8444-444444444444" }],
+    ["invalid request ID", { subject: "33333333-3333-4333-8333-333333333333", request_id: "not-a-uuid" }],
+])("release-canary fixture stage replay rejects %s before dispatch", async (_label, input) => {
+    let calls = 0;
+    const callback = captureReleaseTool({
+        get: async () => ({ ok: true, status: 200, data: {} }),
+    }, {
+        postReleaseMutation: async () => {
+            calls += 1;
+            return { ok: true, status: 200, data: {} };
+        },
+    });
+    await expect(callback({ action: "release_canary_fixture_stage_replay", ...input })).rejects.toThrow();
+    expect(calls).toBe(0);
+});
+
+test("release-canary fixture stage replay refuses an application origin outside the selected project projection", async () => {
+    let calls = 0;
+    const callback = captureReleaseTool({
+        get: async () => ({ ok: true, status: 200, data: projectEndpoints("https://other.example.test") }),
+    }, {
+        postReleaseMutation: async () => {
+            calls += 1;
+            return { ok: true, status: 200, data: {} };
+        },
+    });
+
+    const response = await callback({
+        action: "release_canary_fixture_stage_replay",
+        subject: "33333333-3333-4333-8333-333333333333",
+        request_id: "44444444-4444-4444-8444-444444444444",
+    });
+
+    expect(calls).toBe(0);
+    expect(payload(response)).toMatchObject({
+        ok: false,
+        operation: "release.release_canary.fixture_stage_replay",
+        error: { code: "INVALID_RESPONSE", http_status: null },
     });
 });
 

--- a/packages/cli/src/shared/tools/release-tools.ts
+++ b/packages/cli/src/shared/tools/release-tools.ts
@@ -3,6 +3,7 @@ import { optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
 import type { HttpResult, HttpTransport } from "../transports/http";
 import { releaseControlFailure, releaseControlSuccess, type ReleaseControlToolResponse } from "./release-control-response";
+import { PROJECT_ENDPOINT_RESPONSE_MAX_BYTES, projectApiOrigins } from "./project-endpoint-read";
 
 type ToolServer = {
     tool: (
@@ -18,7 +19,15 @@ type ReleaseOperation =
     | "release.logical_backup.create"
     | "release.logical_backup.restore"
     | "release.postgrest.status"
-    | "release.postgrest.restart";
+    | "release.postgrest.restart"
+    | "release.release_canary.fixture_stage_replay";
+
+type ReleaseCanaryStageReceipt = {
+    fixtureId: string;
+    tenantKey: string;
+    state: "staged";
+    idempotent: true;
+};
 
 type VerifiedLogicalBackup = {
     backup_id: string;
@@ -45,6 +54,9 @@ const INVENTORY_MAX_BYTES = 1024 * 1024;
 const MUTATION_MAX_BYTES = 64 * 1024;
 const BACKUP_TIMEOUT_MS = 36 * 60_000;
 const RELEASE_READ_RESPONSE_TIMEOUT_MS = 5_000;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const RELEASE_CANARY_TENANT_KEY = /^release-canary-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const RELEASE_CANARY_STAGE_RECEIPT_KEYS = new Set(["fixtureId", "tenantKey", "state", "idempotent"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -240,24 +252,58 @@ function isRestartReceipt(value: unknown): boolean {
         && value.success === true;
 }
 
+function releaseCanaryStageInput(subject: unknown, requestId: unknown): { p_subject: string; p_request_id: string } {
+    if (typeof subject !== "string" || !UUID.test(subject)) throw new Error("'subject' must be a canonical UUID");
+    if (typeof requestId !== "string" || !UUID.test(requestId)) throw new Error("'request_id' must be a canonical UUID");
+    return { p_subject: subject, p_request_id: requestId };
+}
+
+function releaseCanaryStageReceipt(value: unknown): ReleaseCanaryStageReceipt | null {
+    if (!isRecord(value)
+        || Object.keys(value).some((key) => !RELEASE_CANARY_STAGE_RECEIPT_KEYS.has(key))
+        || Object.keys(value).length !== RELEASE_CANARY_STAGE_RECEIPT_KEYS.size
+        || typeof value.fixtureId !== "string"
+        || !UUID.test(value.fixtureId)
+        || typeof value.tenantKey !== "string"
+        || !RELEASE_CANARY_TENANT_KEY.test(value.tenantKey)
+        || value.state !== "staged"
+        || value.idempotent !== true) return null;
+    return {
+        fixtureId: value.fixtureId,
+        tenantKey: value.tenantKey,
+        state: "staged",
+        idempotent: true,
+    };
+}
+
+async function applicationOriginMatches(http: HttpTransport, projectRef: string, applicationOrigin: string): Promise<boolean> {
+    const endpointRead = await http.get(
+        `${endpoint(projectRef)}/endpoint/projection`,
+        { maxResponseBytes: PROJECT_ENDPOINT_RESPONSE_MAX_BYTES },
+    );
+    return projectApiOrigins(endpointRead, projectRef)?.includes(applicationOrigin) === true;
+}
+
 export function registerReleaseTools(
     server: ToolServer,
     http: HttpTransport,
-    options: { projectRef?: string } = {},
+    options: { projectRef?: string; applicationHttp?: HttpTransport; applicationOrigin?: string } = {},
 ): void {
     server.tool(
         "release",
-        "Verified release controls using a Management API credential. Actions: logical_backup_list, logical_backup_create, logical_backup_restore, postgrest_status, postgrest_restart",
+        "Verified release controls. Management actions use the Management API; release_canary_fixture_stage_replay additionally requires the selected project's SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
         {
             action: withDescription(stringEnum([
-                "logical_backup_list", "logical_backup_create", "logical_backup_restore", "postgrest_status", "postgrest_restart",
+                "logical_backup_list", "logical_backup_create", "logical_backup_restore", "postgrest_status", "postgrest_restart", "release_canary_fixture_stage_replay",
             ]), "Release control action"),
             ref: optional(Type.String(), options.projectRef ? "Optional override when not auto-linked" : "Project ref"),
             backup_id: optional(Type.String(), "[logical_backup_restore] Exact verified logical-full backup ID from the selected project inventory"),
             expected_sha256: optional(Type.String(), "[logical_backup_restore] Exact lowercase SHA-256 from the selected project inventory"),
             restore_confirmation: optional(Type.String(), "[logical_backup_restore] Exact RESTORE_PROJECT:<ref>:<backup_id>:<sha256> confirmation"),
+            subject: optional(Type.String(), "[release_canary_fixture_stage_replay] Exact central subject UUID"),
+            request_id: optional(Type.String(), "[release_canary_fixture_stage_replay] Exact idempotent stage request UUID"),
         },
-        async ({ action, ref, backup_id, expected_sha256, restore_confirmation }) => {
+        async ({ action, ref, backup_id, expected_sha256, restore_confirmation, subject, request_id }) => {
             const projectRef = typeof ref === "string" && ref || options.projectRef;
             if (!projectRef) throw new Error("'ref' is required for release controls");
             if (!validProjectRef(projectRef)) throw new Error("'ref' is invalid for release controls");
@@ -335,6 +381,30 @@ export function registerReleaseTools(
                 return failure ?? releaseControlSuccess("release.postgrest.status", {
                     project_ref: projectRef,
                     postgrest: read.status!,
+                });
+            }
+            if (action === "release_canary_fixture_stage_replay") {
+                if (!options.applicationHttp || !options.applicationOrigin) {
+                    throw new Error("release_canary_fixture_stage_replay requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+                }
+                const request = releaseCanaryStageInput(subject, request_id);
+                if (!await applicationOriginMatches(http, projectRef, options.applicationOrigin)) {
+                    return releaseControlFailure("release.release_canary.fixture_stage_replay", "INVALID_RESPONSE", null);
+                }
+                const response = await options.applicationHttp.postReleaseMutation(
+                    "/rest/v1/rpc/fa_release_canary_fixture_stage",
+                    request,
+                );
+                if (!response.ok || response.status !== 200) {
+                    return mutationFailure("release.release_canary.fixture_stage_replay", response);
+                }
+                const receipt = releaseCanaryStageReceipt(response.data);
+                if (!receipt || !await applicationOriginMatches(http, projectRef, options.applicationOrigin)) {
+                    return releaseControlFailure("release.release_canary.fixture_stage_replay", "OUTCOME_UNKNOWN", response.status);
+                }
+                return releaseControlSuccess("release.release_canary.fixture_stage_replay", {
+                    project_ref: projectRef,
+                    receipt,
                 });
             }
             if (action !== "postgrest_restart") throw new Error("Unknown release control action");

--- a/packages/cli/src/shared/transports/http.test.ts
+++ b/packages/cli/src/shared/transports/http.test.ts
@@ -36,6 +36,25 @@ function createTransport(): HttpTransport {
     return new HttpTransport({ baseUrl: "https://api.example.test", token: "test-token" });
 }
 
+test("HttpTransport sends an optional application API key only when configured", async () => {
+    const observedHeaders: Array<[string | null, string | null]> = [];
+    globalThis.fetch = (async (_input, init) => {
+        const headers = new Headers(init?.headers);
+        observedHeaders.push([headers.get("authorization"), headers.get("apikey")]);
+        return Response.json({ ok: true });
+    }) as typeof fetch;
+
+    await createTransport().postReleaseMutation("/without-api-key", {});
+    await new HttpTransport({
+        baseUrl: "https://api.example.test", token: "service-role", apiKey: "service-role",
+    }).postReleaseMutation("/with-api-key", {});
+
+    expect(observedHeaders).toEqual([
+        ["Bearer test-token", null],
+        ["Bearer service-role", "service-role"],
+    ]);
+});
+
 function retryableNetworkError(kind: "AbortError" | "ECONNREFUSED" | "ECONNRESET"): Error {
     const error = new Error(kind);
     if (kind === "AbortError") error.name = kind;

--- a/packages/cli/src/shared/transports/http.ts
+++ b/packages/cli/src/shared/transports/http.ts
@@ -8,6 +8,7 @@
 export interface HttpConfig {
     baseUrl: string;
     token: string;
+    apiKey?: string;
 }
 
 export interface HttpResult<T = unknown> {
@@ -317,16 +318,19 @@ async function responseJsonOrNull<T>(response: Response): Promise<ResponseJsonRe
 export class HttpTransport {
     private baseUrl: string;
     private token: string;
+    private apiKey: string;
 
     constructor(config: HttpConfig) {
         this.baseUrl = config.baseUrl.replace(/\/$/, "");
         this.token = config.token;
+        this.apiKey = config.apiKey ?? "";
     }
 
     private headers(): Record<string, string> {
         return {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
+            ...(this.apiKey ? { apikey: this.apiKey } : {}),
         };
     }
 


### PR DESCRIPTION
## Summary

- add a fixed `release_canary_fixture_stage_replay` release control
- bind the service-role application origin to the selected project endpoint projection before and after the RPC
- accept only canonical UUID inputs and a strict four-field idempotent receipt
- keep production confirmation, read-only, no-retry, redirect, timeout, and response-size protections

## Security boundary

- no generic RPC surface
- no GoTrue changes
- Management and application credentials remain separate
- service role is sent only to the selected project's validated application origin as Bearer and `apikey`
- response fields outside the strict safe projection fail closed

## Verification

- 255 targeted CLI tests passed
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- staged secret-value scan passed
- independent integration review: PASS
- independent security review: PASS
