### PR TITLE
fix(gateway): add differential security rate limits

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -557,6 +557,9 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Build Caddy integration image
+        run: docker build --tag supacloud-caddy:2.11.4-ratelimit docker/self-host/caddy
+
       - name: Start MinIO fixture
         run: |
           docker run --detach --rm \
@@ -574,13 +577,15 @@ jobs:
       # data plane stays inside the container network, unreachable from outside.
       - name: Start Caddy fixture
         run: |
+          caddy_modules="$(docker run --rm --entrypoint caddy supacloud-caddy:2.11.4-ratelimit list-modules)"
+          grep -Fx http.handlers.rate_limit <<<"${caddy_modules}"
+          grep -Fx http.matchers.query <<<"${caddy_modules}"
           printf '%s\n' '{"admin":{"listen":"0.0.0.0:2019"}}' > "$RUNNER_TEMP/caddy-ci.json"
           docker run --detach --rm \
             --name supacloud-ci-caddy \
             --publish 127.0.0.1:2019:2019 \
-            --volume "$RUNNER_TEMP/caddy-ci.json:/etc/caddy/ci.json:ro" \
-            caddy:2.11.4 \
-            caddy run --config /etc/caddy/ci.json
+            --volume "$RUNNER_TEMP/caddy-ci.json:/etc/supacloud/caddy/config.json:ro" \
+            supacloud-caddy:2.11.4-ratelimit
 
       - name: Show runtime versions
         run: |

--- a/config.env
+++ b/config.env
@@ -67,6 +67,13 @@ SUPABASE_PUBLISHABLE_KEY=""
 SUPABASE_SECRET_KEY=""
 SUPACLOUD_INSTALL_LEGACY_SUPABASE_STACK="false"
 
+# Gateway security limits are enabled by default and isolated by project,
+# request category, and direct Caddy client socket IP.
+SUPACLOUD_RATE_LIMIT_PASSWORD_PER_MINUTE="10"
+SUPACLOUD_RATE_LIMIT_SIGNUP_PER_MINUTE="5"
+SUPACLOUD_RATE_LIMIT_REFRESH_PER_MINUTE="120"
+SUPACLOUD_RATE_LIMIT_API_PER_MINUTE="100"
+
 # Storage Configuration
 # Options: minio, juicefs (default), external
 # - juicefs: uses PostgreSQL LO as storage backend, extremely low resource usage [Recommended]

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,8 +1,10 @@
 services:
   caddy:
-    image: caddy:2.11.4
+    build:
+      context: ../self-host/caddy
+    image: supacloud-caddy:2.11.4-ratelimit
     restart: always
-    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+    entrypoint: ["/usr/local/bin/supacloud-caddy-entrypoint"]
     ports:
       - "${CADDY_HTTP_PORT:-8000}:80"
       - "${CADDY_HTTPS_PORT:-8443}:443"

--- a/docker/self-host/caddy/Dockerfile
+++ b/docker/self-host/caddy/Dockerfile
@@ -1,0 +1,14 @@
+FROM caddy:2.11.4-builder@sha256:522c540599fa8f6a340b18dea8ee12dfd9d8198347cefa2c4c54344159ae6c0b AS builder
+
+RUN GOBIN=/usr/bin go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.5 \
+    && xcaddy build v2.11.4 \
+        --with github.com/mholt/caddy-ratelimit@5625512f24f6f59d6f64fb3aafe5eecff0b286db \
+        --output /usr/bin/caddy
+
+FROM caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+COPY entrypoint.sh /usr/local/bin/supacloud-caddy-entrypoint
+RUN chmod 0755 /usr/local/bin/supacloud-caddy-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/supacloud-caddy-entrypoint"]

--- a/docker/self-host/docker-compose.yml
+++ b/docker/self-host/docker-compose.yml
@@ -249,12 +249,13 @@ services:
       - edge-pgredis
 
   caddy:
-    image: caddy:2.11.4
+    build:
+      context: ./caddy
+    image: supacloud-caddy:2.11.4-ratelimit
     restart: unless-stopped
     entrypoint: ["/usr/local/bin/supacloud-caddy-entrypoint"]
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./caddy/entrypoint.sh:/usr/local/bin/supacloud-caddy-entrypoint:ro
       - caddy-data:/data
       - caddy-config:/config
       - frontend-data:/var/supacloud/frontends:ro

--- a/docs/gateway-customization.md
+++ b/docs/gateway-customization.md
@@ -181,6 +181,31 @@ curl -X POST "$HOST/v1/projects/$REF/gateway/routes" \
 
 ## 网关配置（tier / CORS / JWT）
 
+### 默认安全限流
+
+Caddy 默认在路径 rewrite/strip-prefix 之前执行四个互相隔离的 1 分钟滑动窗口。每个 zone
+按项目和 `{http.request.remote.host}`（直接连接 Caddy 的 socket IP）计数，IPv6 按 `/64`
+归并；不会读取 `Forwarded`、`X-Forwarded-For` 或 `X-Real-IP`。429 由
+`caddy-ratelimit` 返回，并包含正整数 `Retry-After`；该响应头也在默认 CORS expose
+headers 中，浏览器可以读取。
+
+| 类别 | 精确匹配 | 默认上限 | 环境变量 |
+|------|----------|---------:|------------|
+| password | `POST /auth/v1/token?grant_type=password` | 10/min | `SUPACLOUD_RATE_LIMIT_PASSWORD_PER_MINUTE` |
+| signup | `POST /auth/v1/signup` | 5/min | `SUPACLOUD_RATE_LIMIT_SIGNUP_PER_MINUTE` |
+| refresh | `POST /auth/v1/token?grant_type=refresh_token` | 120/min | `SUPACLOUD_RATE_LIMIT_REFRESH_PER_MINUTE` |
+| ordinary API | 除 `OPTIONS` 外的 `/api/v1` 与 `/api/v1/*` | 100/min | `SUPACLOUD_RATE_LIMIT_API_PER_MINUTE` |
+
+四个环境变量必须是正整数。password、refresh 和普通 API 不共享计数；OAuth
+authorization code、OTP/Magic Link、其他 token grant、CORS preflight、页面和
+`/v1/public/*` 不进入上述低阈值桶。安全限流与项目 tier/单路径自定义限流同时生效，
+配置热加载使用稳定 zone 名保留当前窗口。
+
+`{http.request.remote.host}` 只有在公网客户端直连唯一权威 Caddy，或上游负载均衡器不会
+隐藏真实客户端 socket IP 时才代表最终客户端。本实现不信任可伪造的代理头，也不宣称
+多个 Caddy 实例会自动聚合计数；多实例部署必须显式配置共享 storage/distributed，并在
+上线前单独验证。
+
 `POST /v1/projects/:ref/gateway/config` 一次性更新项目的限流 tier、CORS origins、JWT 开关。对应 `GatewayService.applyConfig`。
 
 | 字段 | 类型 | 说明 |

--- a/packages/management-api/src/config.ts
+++ b/packages/management-api/src/config.ts
@@ -149,6 +149,10 @@ export interface Config {
   poolerHost: string;
   poolerPort: number;
   rateLimitTier: string;
+  rateLimitPasswordPerMinute: number;
+  rateLimitSignupPerMinute: number;
+  rateLimitRefreshPerMinute: number;
+  rateLimitApiPerMinute: number;
   corsOrigins: string;
   dbAllowedCidrs: string;
   dbAllowedCidrsV6: string;
@@ -343,6 +347,10 @@ export const config: Config = {
   poolerHost: getEnv("POOLER_HOST", pgHost),
   poolerPort: Number(getEnv("POOLER_PORT", "6543")),
   rateLimitTier: getEnv("RATE_LIMIT_TIER", ""),
+  rateLimitPasswordPerMinute: Number(getEnv("SUPACLOUD_RATE_LIMIT_PASSWORD_PER_MINUTE", "10")),
+  rateLimitSignupPerMinute: Number(getEnv("SUPACLOUD_RATE_LIMIT_SIGNUP_PER_MINUTE", "5")),
+  rateLimitRefreshPerMinute: Number(getEnv("SUPACLOUD_RATE_LIMIT_REFRESH_PER_MINUTE", "120")),
+  rateLimitApiPerMinute: Number(getEnv("SUPACLOUD_RATE_LIMIT_API_PER_MINUTE", "100")),
   corsOrigins: getEnv("CORS_ORIGINS", ""),
   dbAllowedCidrs: getEnv("DB_ALLOWED_CIDRS", ""),
   dbAllowedCidrsV6: getEnv("DB_ALLOWED_CIDRS_V6", ""),
@@ -430,6 +438,16 @@ function validateConfig() {
   }
   if (!Number.isInteger(config.managementProjectPoolCacheSize) || config.managementProjectPoolCacheSize <= 0) {
     throw new Error("Invalid MANAGEMENT_PROJECT_POOL_CACHE_SIZE configuration. Must be a positive integer.");
+  }
+  for (const [name, limit] of [
+    ["SUPACLOUD_RATE_LIMIT_PASSWORD_PER_MINUTE", config.rateLimitPasswordPerMinute],
+    ["SUPACLOUD_RATE_LIMIT_SIGNUP_PER_MINUTE", config.rateLimitSignupPerMinute],
+    ["SUPACLOUD_RATE_LIMIT_REFRESH_PER_MINUTE", config.rateLimitRefreshPerMinute],
+    ["SUPACLOUD_RATE_LIMIT_API_PER_MINUTE", config.rateLimitApiPerMinute],
+  ] as const) {
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new Error(`Invalid ${name} configuration. Must be a positive integer.`);
+    }
   }
 
   const isDevelopment = DEVELOPMENT_ENVS.has(config.nodeEnv) || process.env.BUN_ENV === "test" || config.isGithubActions;

--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -53,7 +53,7 @@ export const DEFAULT_CORS_EXPOSED = [
     "Content-Length", "Content-Range", "X-Content-Range", "X-JSON",
     "x-supabase-api-version", "X-Client-Info", "Prefer",
     "Content-Profile", "accept-profile", "Range", "Range-Unit",
-    "X-Relay-Error", "link", "x-total-count", "Content-Disposition",
+    "X-Relay-Error", "link", "x-total-count", "Content-Disposition", "Retry-After",
 ];
 
 export const DEFAULT_CORS_ORIGINS = [
@@ -392,7 +392,7 @@ function isCorsHeaderHandler(handler: Record<string, unknown>): boolean {
         && typeof (handler.response as any)?.set?.["Access-Control-Allow-Origin"] !== "undefined";
 }
 
-function isCorsSubroute(handler: Record<string, unknown>): boolean {
+export function isCorsSubroute(handler: Record<string, unknown>): boolean {
     if (handler.handler !== "subroute" || !Array.isArray(handler.routes)) return false;
     return handler.routes.some((route: any) =>
         Array.isArray(route?.handle) && route.handle.some((item: any) => isCorsHeaderHandler(item)),

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -17,10 +17,12 @@ import { assertUniqueCaddyIds, runCaddyStartupPreflight } from "./caddy-startup-
 import { FRONTEND_GATEWAY_DURABILITY_UNKNOWN_CODE } from "./frontend-release-contract";
 import {
     type CaddyHeaderValue,
+    type CaddyMatcher,
     type CaddyRoute,
     type CustomGatewayRouteConfig,
     DEFAULT_CORS_ORIGINS,
     buildTenantCorsOrigins,
+    isCorsSubroute,
     isCustomGatewayRouteId,
     makeCorsSubroute,
     makeCustomGatewayRoute,
@@ -124,6 +126,65 @@ const RATE_LIMIT_WINDOW_MS: Record<keyof RateLimitConfig, number> = {
     minute: 60_000,
     hour: 3_600_000,
 };
+
+const SECURITY_RATE_LIMIT_ROUTE_PREFIX = "route-security-project-";
+const SECURITY_AUTH_PATHS = ["/auth/v1/token", "/auth/v1/token/", "/auth/v1/signup", "/auth/v1/signup/"];
+const SECURITY_API_PATHS = ["/api/v1", "/api/v1/*"];
+const SECURITY_PASSWORD_MATCHERS: CaddyMatcher[] = [{
+    method: ["POST"],
+    path: ["/auth/v1/token", "/auth/v1/token/"],
+    query: { grant_type: ["password"] },
+}];
+const SECURITY_SIGNUP_MATCHERS: CaddyMatcher[] = [{
+    method: ["POST"],
+    path: ["/auth/v1/signup", "/auth/v1/signup/"],
+}];
+const SECURITY_REFRESH_MATCHERS: CaddyMatcher[] = [{
+    method: ["POST"],
+    path: ["/auth/v1/token", "/auth/v1/token/"],
+    query: { grant_type: ["refresh_token"] },
+}];
+const SECURITY_API_MATCHERS: CaddyMatcher[] = [{
+    path: SECURITY_API_PATHS,
+    not: [{ method: ["OPTIONS"] }],
+}];
+
+function routeMatcherStrings(route: CaddyRoute, field: "host" | "path"): string[] {
+    if (!Array.isArray(route.match)) return [];
+    return uniqueStrings(route.match.flatMap((matcher) => {
+        const values = (matcher as Record<string, unknown>)[field];
+        return Array.isArray(values) ? values.map(String) : [];
+    }));
+}
+
+function customRouteMayServeOrdinaryApi(route: CaddyRoute): boolean {
+    return routeMatcherStrings(route, "path").some((pattern) => {
+        const wildcard = pattern.indexOf("*");
+        if (wildcard < 0) return pattern === "/api/v1" || pattern.startsWith("/api/v1/");
+        const prefix = pattern.slice(0, wildcard);
+        return prefix.startsWith("/api/v1/") || "/api/v1/".startsWith(prefix);
+    });
+}
+
+function hostScopedCorsHandlers(route: CaddyRoute): Record<string, unknown>[] {
+    const hosts = routeMatcherStrings(route, "host");
+    if (hosts.length === 0) return [];
+    const handlers = Array.isArray(route.handle) ? route.handle as Record<string, unknown>[] : [];
+    return handlers.filter(isCorsSubroute).map((handler) => ({
+        handler: "subroute",
+        routes: [{ match: [{ host: hosts }], handle: [handler] }],
+    }));
+}
+
+function uniqueCaddyHandlers(handlers: Record<string, unknown>[]): Record<string, unknown>[] {
+    const seen = new Set<string>();
+    return handlers.filter((handler) => {
+        const encoded = stableStringify(handler);
+        if (seen.has(encoded)) return false;
+        seen.add(encoded);
+        return true;
+    });
+}
 
 type GatewaySetupOptions = { functionsPort?: number; storagePort?: number; realtimeApiPort?: number; realtimeWsPort?: number };
 
@@ -400,7 +461,8 @@ export class CaddyGatewayProvider implements GatewayProvider {
     }
 
     private baseConfig(): CaddyConfig {
-        const routes = Array.from(this.routesById.values())
+        const managedRoutes = Array.from(this.routesById.values());
+        const routes = [...managedRoutes, ...this.makeSecurityRateLimitRoutes(managedRoutes)]
             .sort((a, b) => this.compareRoutesForCaddy(a, b))
             .map((route) => this.renderRouteForCaddy(route));
         routes.push(this.makeUnmatchedHostRoute());
@@ -496,6 +558,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
             for (const route of routes) {
                 const id = typeof route?.["@id"] === "string" ? route["@id"] : "";
                 if (!id || id === CADDY_UNMATCHED_HOST_ROUTE_ID) continue;
+                if (id.startsWith(SECURITY_RATE_LIMIT_ROUTE_PREFIX)) continue;
                 if (!this.routesById.has(id)) this.routesById.set(id, this.migrateHydratedRoute(id, route));
                 this.hydrateRateLimitFromRoute(id, route);
             }
@@ -642,6 +705,9 @@ export class CaddyGatewayProvider implements GatewayProvider {
     private compareRoutesForCaddy(a: CaddyRoute, b: CaddyRoute): number {
         const aid = String(a["@id"] || "");
         const bid = String(b["@id"] || "");
+        const aSecurity = aid.startsWith(SECURITY_RATE_LIMIT_ROUTE_PREFIX);
+        const bSecurity = bid.startsWith(SECURITY_RATE_LIMIT_ROUTE_PREFIX);
+        if (aSecurity !== bSecurity) return aSecurity ? -1 : 1;
         const aCustom = aid.startsWith("route-custom-") || aid.startsWith("route-hosted-") || aid.startsWith("route-supauth-");
         const bCustom = bid.startsWith("route-custom-") || bid.startsWith("route-hosted-") || bid.startsWith("route-supauth-");
         if (aCustom !== bCustom) return aCustom ? -1 : 1;
@@ -693,6 +759,88 @@ export class CaddyGatewayProvider implements GatewayProvider {
         };
     }
 
+    private securityZoneName(projectRef: string, category: string): string {
+        return `supacloud_${sanitizeCaddyId(projectRef)}_security_${category}_minute`;
+    }
+
+    private makeSecurityRateLimitZone(projectRef: string, category: string, maxEvents: number, match: CaddyMatcher[]) {
+        return {
+            [this.securityZoneName(projectRef, category)]: {
+                key: "{http.request.remote.host}",
+                window: "1m",
+                max_events: maxEvents,
+                ipv6_prefix: 64,
+                match,
+            },
+        };
+    }
+
+    private makeSecurityRateLimitHandler(projectRef: string): Record<string, unknown> {
+        return {
+            handler: "rate_limit",
+            rate_limits: {
+                ...this.makeSecurityRateLimitZone(projectRef, "password", config.rateLimitPasswordPerMinute, SECURITY_PASSWORD_MATCHERS),
+                ...this.makeSecurityRateLimitZone(projectRef, "signup", config.rateLimitSignupPerMinute, SECURITY_SIGNUP_MATCHERS),
+                ...this.makeSecurityRateLimitZone(projectRef, "refresh", config.rateLimitRefreshPerMinute, SECURITY_REFRESH_MATCHERS),
+                ...this.makeSecurityRateLimitZone(projectRef, "api", config.rateLimitApiPerMinute, SECURITY_API_MATCHERS),
+            },
+        };
+    }
+
+    private canonicalProjectRefs(routes: CaddyRoute[]): string[] {
+        return uniqueStrings(routes.flatMap((route) => {
+            const projectRef = this.projectRefFromRouteId(String(route["@id"] || ""));
+            return projectRef ? [projectRef] : [];
+        }));
+    }
+
+    private customGatewayProjectRef(routeId: string, projectRefs: string[]): string | null {
+        const matches = projectRefs.filter((projectRef) =>
+            routeId.startsWith(`route-custom-gateway-${sanitizeCaddyId(projectRef)}-`),
+        );
+        return matches.sort((a, b) => b.length - a.length)[0] || null;
+    }
+
+    private securityRouteSources(projectRef: string, routes: CaddyRoute[], projectRefs: string[]): { authRoutes: CaddyRoute[]; apiRoutes: CaddyRoute[] } {
+        const authIds = new Set([
+            caddyRouteId(projectRef, "auth"),
+            caddyRouteId(projectRef, "auth-domain-auth"),
+        ]);
+        const authRoutes = routes.filter((route) => authIds.has(String(route["@id"] || "")));
+        const apiRoutes = routes.filter((route) => {
+            const routeId = String(route["@id"] || "");
+            return this.customGatewayProjectRef(routeId, projectRefs) === projectRef
+                && customRouteMayServeOrdinaryApi(route);
+        });
+        return { authRoutes, apiRoutes };
+    }
+
+    private makeSecurityRateLimitRoute(projectRef: string, routes: CaddyRoute[], projectRefs: string[]): CaddyRoute | null {
+        const sources = this.securityRouteSources(projectRef, routes, projectRefs);
+        const authHosts = uniqueStrings(sources.authRoutes.flatMap((route) => routeMatcherStrings(route, "host")));
+        const apiHosts = uniqueStrings(sources.apiRoutes.flatMap((route) => routeMatcherStrings(route, "host")));
+        const match: CaddyMatcher[] = [];
+        if (authHosts.length > 0) match.push({ host: authHosts, path: SECURITY_AUTH_PATHS });
+        if (apiHosts.length > 0) match.push({ host: apiHosts, path: SECURITY_API_PATHS });
+        if (match.length === 0) return null;
+        const corsHandlers = uniqueCaddyHandlers(
+            [...sources.authRoutes, ...sources.apiRoutes].flatMap(hostScopedCorsHandlers),
+        );
+        return {
+            "@id": `${SECURITY_RATE_LIMIT_ROUTE_PREFIX}${sanitizeCaddyId(projectRef)}`,
+            match,
+            handle: [...corsHandlers, this.makeSecurityRateLimitHandler(projectRef)],
+        };
+    }
+
+    private makeSecurityRateLimitRoutes(routes: CaddyRoute[]): CaddyRoute[] {
+        const projectRefs = this.canonicalProjectRefs(routes);
+        return projectRefs.flatMap((projectRef) => {
+            const route = this.makeSecurityRateLimitRoute(projectRef, routes, projectRefs);
+            return route ? [route] : [];
+        });
+    }
+
     private projectRefForRoute(routeId: string): string | null {
         for (const projectRef of this.rateLimits.keys()) {
             if (routeId.startsWith(`route-project-${projectRef}-`)) return projectRef;
@@ -704,6 +852,7 @@ export class CaddyGatewayProvider implements GatewayProvider {
         const rendered = JSON.parse(JSON.stringify(route)) as CaddyRoute;
         delete rendered.__supacloud_priority;
         const id = String(rendered["@id"] || "");
+        if (id.startsWith(SECURITY_RATE_LIMIT_ROUTE_PREFIX)) return rendered;
         const handle = Array.isArray(rendered.handle) ? rendered.handle as Record<string, unknown>[] : [];
         const withoutRateLimit = handle.filter((handler) => handler.handler !== "rate_limit");
 
@@ -721,8 +870,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
         }
 
         if (rateLimitHandler) {
-            const proxyIndex = withoutRateLimit.findIndex((handler) => handler.handler === "reverse_proxy");
-            const insertAt = proxyIndex >= 0 ? proxyIndex : withoutRateLimit.length;
+            const transformIndex = withoutRateLimit.findIndex((handler) =>
+                handler.handler === "rewrite" || handler.handler === "reverse_proxy",
+            );
+            const insertAt = transformIndex >= 0 ? transformIndex : withoutRateLimit.length;
             withoutRateLimit.splice(insertAt, 0, rateLimitHandler);
             rendered.handle = withoutRateLimit;
         }

--- a/packages/management-api/tests/unit/caddy-build-reproducibility.test.ts
+++ b/packages/management-api/tests/unit/caddy-build-reproducibility.test.ts
@@ -5,6 +5,44 @@ const builder = readFileSync(
   new URL("../../../../scripts/build_supacloud_caddy.sh", import.meta.url),
   "utf8",
 );
+const workflow = readFileSync(
+  new URL("../../../../.github/workflows/management-api.yml", import.meta.url),
+  "utf8",
+);
+const caddyDockerfile = readFileSync(
+  new URL("../../../../docker/self-host/caddy/Dockerfile", import.meta.url),
+  "utf8",
+);
+const caddyEntrypoint = readFileSync(
+  new URL("../../../../docker/self-host/caddy/entrypoint.sh", import.meta.url),
+  "utf8",
+);
+const devCompose = readFileSync(
+  new URL("../../../../docker/dev/docker-compose.yml", import.meta.url),
+  "utf8",
+);
+const selfHostCompose = readFileSync(
+  new URL("../../../../docker/self-host/docker-compose.yml", import.meta.url),
+  "utf8",
+);
+
+function composeService(source: string, service: string): string {
+  const startMarker = `\n  ${service}:\n`;
+  const start = source.indexOf(startMarker);
+  if (start < 0) throw new Error(`Missing Compose service: ${service}`);
+  const body = source.slice(start + startMarker.length);
+  const end = body.search(/\n(?:  [a-zA-Z0-9_-]+:|volumes:|networks:)\n/);
+  return end < 0 ? body : body.slice(0, end);
+}
+
+function workflowJob(source: string, job: string): string {
+  const startMarker = `\n  ${job}:\n`;
+  const start = source.indexOf(startMarker);
+  if (start < 0) throw new Error(`Missing workflow job: ${job}`);
+  const body = source.slice(start + startMarker.length);
+  const end = body.search(/\n  [a-zA-Z0-9_-]+:\n/);
+  return end < 0 ? body : body.slice(0, end);
+}
 
 describe("Caddy release build reproducibility", () => {
   test("pins the rate-limit plugin to an immutable upstream commit", () => {
@@ -13,5 +51,50 @@ describe("Caddy release build reproducibility", () => {
     expect(builder).not.toContain(
       'RATE_LIMIT_MODULE="${RATE_LIMIT_MODULE:-github.com/mholt/caddy-ratelimit}"',
     );
+  });
+
+  test("self-host and development Compose build the pinned custom Caddy image", () => {
+    expect(caddyDockerfile.match(/^FROM .+$/gm)).toEqual([
+      "FROM caddy:2.11.4-builder@sha256:522c540599fa8f6a340b18dea8ee12dfd9d8198347cefa2c4c54344159ae6c0b AS builder",
+      "FROM caddy:2.11.4@sha256:df7f1c2fb114453b951de51a98efc010db1655a92c2e86be6706714e2417a78d",
+    ]);
+    expect(caddyDockerfile).toContain("xcaddy/cmd/xcaddy@v0.4.5");
+    expect(caddyDockerfile).toContain(
+      "github.com/mholt/caddy-ratelimit@5625512f24f6f59d6f64fb3aafe5eecff0b286db",
+    );
+    expect(caddyDockerfile).not.toContain("@latest");
+    expect(caddyDockerfile).toContain('ENTRYPOINT ["/usr/local/bin/supacloud-caddy-entrypoint"]');
+
+    const devCaddy = composeService(devCompose, "caddy");
+    const selfHostCaddy = composeService(selfHostCompose, "caddy");
+    expect(devCaddy).toContain("context: ../self-host/caddy");
+    expect(selfHostCaddy).toContain("context: ./caddy");
+    for (const service of [devCaddy, selfHostCaddy]) {
+      expect(service).toContain("image: supacloud-caddy:2.11.4-ratelimit");
+      expect(service).toContain('entrypoint: ["/usr/local/bin/supacloud-caddy-entrypoint"]');
+      expect(service).not.toContain("image: caddy:2.11.4");
+    }
+    expect(devCaddy).toContain("./caddy/Caddyfile:/etc/caddy/Caddyfile:ro");
+    expect(selfHostCaddy).not.toContain("entrypoint.sh:");
+    expect(caddyEntrypoint).toContain('if [ -f "$managed_config" ]');
+    expect(caddyEntrypoint).toContain('exec caddy run --config "$managed_config"');
+    expect(caddyEntrypoint).toContain('exec caddy run --config "$bootstrap_config" --adapter caddyfile');
+  });
+
+  test("integration tests build and run the same supported Caddy image", () => {
+    const integration = workflowJob(workflow, "integration-test");
+    expect(integration).toContain(
+      "docker build --tag supacloud-caddy:2.11.4-ratelimit docker/self-host/caddy",
+    );
+    expect(integration).toContain("supacloud-caddy:2.11.4-ratelimit list-modules");
+    expect(integration).toContain("grep -Fx http.handlers.rate_limit");
+    expect(integration).toContain("grep -Fx http.matchers.query");
+    expect(integration).toContain(
+      '$RUNNER_TEMP/caddy-ci.json:/etc/supacloud/caddy/config.json:ro',
+    );
+    expect(integration).not.toContain("Setup Go");
+    expect(integration).not.toContain("go install");
+    expect(integration).not.toMatch(/(?:^|[\s"])(?:docker\.io\/library\/)?caddy:2\.11\.4(?:[\s"\\]|$)/);
+    expect(integration).not.toContain("/usr/bin/supacloud-caddy");
   });
 });

--- a/packages/management-api/tests/unit/config-loading.test.ts
+++ b/packages/management-api/tests/unit/config-loading.test.ts
@@ -37,6 +37,10 @@ function cleanEnv(overrides: Record<string, string>) {
     "MANAGEMENT_PROJECT_DB_POOL",
     "MANAGEMENT_PROJECT_ROLE_DB_POOL",
     "MANAGEMENT_PROJECT_POOL_CACHE_SIZE",
+    "SUPACLOUD_RATE_LIMIT_PASSWORD_PER_MINUTE",
+    "SUPACLOUD_RATE_LIMIT_SIGNUP_PER_MINUTE",
+    "SUPACLOUD_RATE_LIMIT_REFRESH_PER_MINUTE",
+    "SUPACLOUD_RATE_LIMIT_API_PER_MINUTE",
   ]) {
     delete env[key];
   }
@@ -94,6 +98,15 @@ function loadCaddyTlsIssuer(env: Record<string, string>) {
   ].join(" ")], { cwd: packageRoot, env, encoding: "utf8" });
   expect(configProcess.status, configProcess.stderr).toBe(0);
   return configProcess.stdout.match(/RESULT=([^\n]+)/)?.[1];
+}
+
+function loadSecurityRateLimits(env: Record<string, string>) {
+  const result = spawnSync("bun", ["-e", [
+    'import { config } from "./src/config.ts";',
+    'console.log(`RESULT=${config.rateLimitPasswordPerMinute}:${config.rateLimitSignupPerMinute}:${config.rateLimitRefreshPerMinute}:${config.rateLimitApiPerMinute}`);',
+  ].join(" ")], { cwd: packageRoot, env, encoding: "utf8" });
+  expect(result.status, result.stderr).toBe(0);
+  return result.stdout.match(/RESULT=([^\n]+)/)?.[1];
 }
 
 describe("production config loading boundaries", () => {
@@ -207,6 +220,33 @@ describe("production config loading boundaries", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("POOL");
+  });
+
+  test("uses secure differential rate-limit defaults and honors explicit overrides", () => {
+    expect(loadSecurityRateLimits(cleanEnv({ NODE_ENV: "production" }))).toBe("10:5:120:100");
+    expect(loadSecurityRateLimits(cleanEnv({
+      NODE_ENV: "production",
+      SUPACLOUD_RATE_LIMIT_PASSWORD_PER_MINUTE: "20",
+      SUPACLOUD_RATE_LIMIT_SIGNUP_PER_MINUTE: "8",
+      SUPACLOUD_RATE_LIMIT_REFRESH_PER_MINUTE: "240",
+      SUPACLOUD_RATE_LIMIT_API_PER_MINUTE: "150",
+    }))).toBe("20:8:240:150");
+  });
+
+  test.each([
+    { SUPACLOUD_RATE_LIMIT_PASSWORD_PER_MINUTE: "0" },
+    { SUPACLOUD_RATE_LIMIT_SIGNUP_PER_MINUTE: "1.5" },
+    { SUPACLOUD_RATE_LIMIT_REFRESH_PER_MINUTE: "not-a-number" },
+    { SUPACLOUD_RATE_LIMIT_API_PER_MINUTE: "-1" },
+  ])("rejects invalid differential rate-limit capacity: %p", (limitEnv) => {
+    const result = spawnSync("bun", ["-e", 'import "./src/config.ts";'], {
+      cwd: packageRoot,
+      env: cleanEnv({ NODE_ENV: "production", ...limitEnv }),
+      encoding: "utf8",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("SUPACLOUD_RATE_LIMIT_");
   });
 
   test("rejects a BFF signing secret shared with another privileged key", () => {

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -135,6 +135,7 @@ describe("GatewayService provider selection", () => {
 
     test("default cors exposed headers allow browsers to read download filenames", () => {
         expect(DEFAULT_CORS_EXPOSED).toContain("Content-Disposition");
+        expect(DEFAULT_CORS_EXPOSED).toContain("Retry-After");
     });
 
     test("default Caddy logger redacts sensitive request headers", () => {
@@ -338,6 +339,122 @@ describe("CaddyGatewayProvider", () => {
         expect(adminUserDelete?.match?.[0]?.host).toContain("auth.example.com");
 
         restore();
+    });
+
+    test("renders isolated project security limits before rewrites and preserves configured limits across reload", async () => {
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        try {
+            const projectRef = "tenant-with-hyphen";
+            await provider.setupUpstream(projectRef, 3000, 9999, {
+                api_domain: "tenant-api.example.com",
+                auth_domain: "tenant-auth.example.com",
+            });
+            await provider.configureCustomGatewayRoutes(projectRef, [{
+                id: "supauth-api",
+                hosts: ["supauth-api.example.com"],
+                path: ["/api/*", "/v1/*"],
+                upstream: "127.0.0.1:9090",
+                rewrite_uri: "/functions/v1/supauth{http.request.uri.path}",
+                cors: ["https://admin.example.com"],
+                priority: 110,
+            }]);
+            await provider.setRateLimit(projectRef, "free");
+            await provider.setCustomRouteRateLimit(projectRef, "/auth/v1/token", { minute: 200 });
+
+            const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+            const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+            const security = routes.find((route: any) => route["@id"] === `route-security-project-${projectRef}`);
+            const securityHandler = security?.handle?.find((handler: any) => handler.handler === "rate_limit");
+            const zones = Object.entries(securityHandler?.rate_limits ?? {}) as Array<[string, any]>;
+            const zone = (category: string) => zones.find(([name]) => name.endsWith(`_security_${category}_minute`));
+
+            expect(security).toBeDefined();
+            expect(security?.terminal).toBeUndefined();
+            expect(security?.match).toContainEqual({
+                host: ["supauth-api.example.com"],
+                path: ["/api/v1", "/api/v1/*"],
+            });
+            expect(security?.match).toContainEqual({
+                host: expect.arrayContaining(["tenant-api.example.com", "tenant-auth.example.com"]),
+                path: ["/auth/v1/token", "/auth/v1/token/", "/auth/v1/signup", "/auth/v1/signup/"],
+            });
+            expect(zones).toHaveLength(4);
+            expect(zone("password")?.[1]).toMatchObject({
+                key: "{http.request.remote.host}",
+                window: "1m",
+                max_events: 10,
+                ipv6_prefix: 64,
+                match: [{
+                    method: ["POST"],
+                    path: ["/auth/v1/token", "/auth/v1/token/"],
+                    query: { grant_type: ["password"] },
+                }],
+            });
+            expect(zone("signup")?.[1]).toMatchObject({ max_events: 5, match: [{ method: ["POST"] }] });
+            expect(zone("refresh")?.[1]).toMatchObject({
+                max_events: 120,
+                match: [{ query: { grant_type: ["refresh_token"] } }],
+            });
+            expect(zone("api")?.[1]).toMatchObject({
+                max_events: 100,
+                match: [{ path: ["/api/v1", "/api/v1/*"], not: [{ method: ["OPTIONS"] }] }],
+            });
+            expect(JSON.stringify(securityHandler)).not.toMatch(/Forwarded|X-Real-IP/i);
+
+            const corsHandlers = security.handle.filter((handler: any) => handler.handler === "subroute");
+            const apiCors = corsHandlers.find((handler: any) =>
+                handler.routes?.[0]?.match?.[0]?.host?.includes("supauth-api.example.com"),
+            );
+            const authCors = corsHandlers.filter((handler: any) =>
+                !handler.routes?.[0]?.match?.[0]?.host?.includes("supauth-api.example.com"),
+            );
+            const corsIndex = security.handle.indexOf(corsHandlers[0]);
+            const securityLimitIndex = security.handle.indexOf(securityHandler);
+            expect(corsIndex).toBeLessThan(securityLimitIndex);
+            expect(JSON.stringify(apiCors)).toContain("https://admin.example.com");
+            expect(JSON.stringify(apiCors)).toContain("Retry-After");
+            expect(authCors.length).toBeGreaterThan(0);
+            expect(authCors.every((handler: any) =>
+                !JSON.stringify(handler).includes("https://admin.example.com"),
+            )).toBe(true);
+            expect(authCors.every((handler: any) => JSON.stringify(handler).includes("Retry-After"))).toBe(true);
+
+            const customLimitRoute = routes.find((route: any) => route["@id"]?.startsWith(`route-custom-${projectRef}-`));
+            const customLimitHandler = customLimitRoute?.handle?.find((handler: any) => handler.handler === "rate_limit");
+            const customRewriteIndex = customLimitRoute?.handle?.findIndex((handler: any) => handler.handler === "rewrite");
+            expect(routes.indexOf(security)).toBeLessThan(routes.indexOf(customLimitRoute));
+            expect(customLimitRoute?.handle?.indexOf(customLimitHandler)).toBeLessThan(customRewriteIndex);
+
+            await provider.setupUpstream("tenant", 3010, 9998, { api_domain: "short-tenant.example.com" });
+            const multiProjectLoad = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+            const multiProjectRoutes = multiProjectLoad?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+            const securityRoutes = multiProjectRoutes.filter((route: any) => route["@id"]?.startsWith("route-security-project-"));
+            const securityZoneNames = securityRoutes.map((route: any) => Object.keys(
+                route.handle.find((handler: any) => handler.handler === "rate_limit")?.rate_limits ?? {},
+            ));
+            const shortProjectSecurity = securityRoutes.find((route: any) => route["@id"] === "route-security-project-tenant");
+            expect(securityRoutes).toHaveLength(2);
+            expect(new Set(securityZoneNames.flat()).size).toBe(8);
+            expect(JSON.stringify(shortProjectSecurity?.match)).not.toContain("supauth-api.example.com");
+
+            const restartedProvider = new CaddyGatewayProvider();
+            await restartedProvider.setupMasterRoutes();
+            expect(await restartedProvider.getRateLimit(projectRef)).toEqual({
+                tier: "custom",
+                second: 60,
+                minute: 3000,
+                hour: 100000,
+                enabled: true,
+            });
+            const reload = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+            const reloadedRoutes = reload?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+            expect(reloadedRoutes.filter((route: any) => route["@id"] === security["@id"])).toHaveLength(1);
+        } finally {
+            restore();
+        }
     });
 
     test("setupUpstream splits business auth routes to an external IdP upstream", async () => {
@@ -1554,8 +1671,10 @@ describe("CaddyGatewayProvider", () => {
         const rest = routes.find((route: any) => route["@id"] === "route-project-testref123-rest");
         const rateLimit = rest?.handle?.find((handler: any) => handler.handler === "rate_limit");
         const zones = Object.values(rateLimit?.rate_limits ?? {}) as any[];
+        const rewriteIndex = rest?.handle?.findIndex((handler: any) => handler.handler === "rewrite");
 
         expect(rateLimit).toBeDefined();
+        expect(rest?.handle?.indexOf(rateLimit)).toBeLessThan(rewriteIndex);
         expect(zones.some((zone) => zone.window === "1s" && zone.max_events === 7)).toBe(true);
         expect(zones.some((zone) => zone.window === "1m" && zone.max_events === 70)).toBe(true);
         expect(zones.some((zone) => zone.window === "1h" && zone.max_events === 700)).toBe(true);
@@ -1858,7 +1977,9 @@ describe("CaddyGatewayProvider", () => {
         const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
         const custom = routes.find((route: any) => route["@id"]?.startsWith("route-custom-testref123-"));
 
-        expect(routes[0]?.["@id"]).toStartWith("route-custom-testref123-");
+        expect(routes.indexOf(custom)).toBeLessThan(
+            routes.findIndex((route: any) => route["@id"] === "route-project-testref123-rest"),
+        );
         expect(custom?.match?.[0]?.path).toEqual(["/rest/v1/audit*"]);
         expect(custom?.handle?.some((handler: any) => handler.handler === "rate_limit")).toBe(true);
 

--- a/packages/management-api/tests/unit/runtime-version-assets.test.ts
+++ b/packages/management-api/tests/unit/runtime-version-assets.test.ts
@@ -1306,7 +1306,7 @@ describe("runtime companion version assets", () => {
       expect(source).toContain("public.ecr.aws/supabase/realtime:v2.129.0");
     }
     for (const compose of [devCompose, selfHostCompose]) {
-      expect(compose).toContain("caddy:2.11.4");
+      expect(compose).toContain("image: supacloud-caddy:2.11.4-ratelimit");
       expect(compose).toContain("supabase/gotrue:v2.195.0");
       expect(compose).toContain("postgrest/postgrest:v16.1");
     }


### PR DESCRIPTION
## Summary

- add host-scoped, non-terminal security pre-routes for password login, signup, refresh, and ordinary API traffic
- use independent stable sliding-window zones keyed by direct remote host, without trusting forwarded client-IP headers
- expose Retry-After through CORS and document/configure per-route limits

## Verification

- 113 targeted tests passed
- management API unit suite passed
- typecheck passed
- standalone build passed
- pinned Caddy v2.11.4 JSON validation passed
- independent round-2 verifier passed

## Follow-up

CNB #75 will remain open until the merged build passes real-device validation on the test server.