### PR TITLE
feat(cli): add release canary fixture disable replay

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -142,6 +142,9 @@ supacloud-cli release postgrest_status --ref abc123
 supacloud-cli release postgrest_restart --ref abc123
 supacloud-cli release release_canary_fixture_stage_replay --ref abc123 \
   --subject <central-subject-uuid> --request_id <stage-request-uuid>
+supacloud-cli release release_canary_fixture_disable_replay --ref abc123 \
+  --fixture_id <fixture-uuid> --disable_request_id <disable-request-uuid> \
+  --issuer <issuer-url> --subject <central-subject-uuid>
 ```
 
 Backup creation reports success only after the CLI verifies exactly one new
@@ -170,6 +173,16 @@ receipt, and emits only that safe projection. Before and after the call, the CLI
 reads the selected project's authoritative endpoint projection and requires the
 configured application origin to match its API origin or alias. Production
 confirmation is mandatory.
+
+`release_canary_fixture_disable_replay` performs one non-retried call to the
+fixed `fa_release_canary_fixture_disable` PostgREST RPC using the selected
+project's application service-role origin. Its receipt must contain exactly
+`fixtureId`, `state="disabled"`, and a boolean `idempotent`; both the first
+disable (`idempotent=false`) and same-request replay (`idempotent=true`) are
+valid. The CLI then calls the existing fixed
+`fa_release_canary_fixture_pending` RPC with the exact fixture, issuer, and
+subject and requires an identity-matching `pending=false` read-back before
+reporting success. Management endpoint projection is checked before and after.
 
 The legacy `.env` fallback is unclassified and therefore does not enable the
 production confirmation gate. Production automation must select a `prod` or

--- a/packages/cli/skills/supacloud-cli/references/command-map.md
+++ b/packages/cli/skills/supacloud-cli/references/command-map.md
@@ -16,6 +16,7 @@ Load this reference when selecting a command surface or when a user asks an AI t
 | Rebuild local database | `supabase db_reset` | Local only; preserve required seed behavior |
 | Inspect or back up a remote database | `supabase db_pull`, `migration_list`, `db_dump`, `gen_types` | Requires explicit PostgreSQL DSN; redact it |
 | Replay the release-canary fixture stage receipt | `release release_canary_fixture_stage_replay` | Dual-bind Management project context and that project's service-role application origin; accepts only the exact subject/request UUID pair and a strict idempotent receipt |
+| Disable a staged release-canary fixture | `release release_canary_fixture_disable_replay` | Uses the fixed disable RPC once, accepts idempotent false/true receipts, then requires the existing pending RPC to read back pending=false for the exact fixture/issuer/subject binding |
 | Preview/apply migrations remotely | `supabase push` | Always dry-run first; production needs explicit approval |
 | Mark proven-equivalent historical migrations as applied | `database baseline_migrations` | Dry-run, schema-equivalence proof, backup, explicit approval |
 | Inspect auth users or generate a controlled login link | `auth list_users`, `auth get_user`, `auth generate_link` | User reads are bounded; generation supports only `magiclink`, `recovery`, and `invite`, requires production confirmation, and returns only a validated action URL |
@@ -40,7 +41,7 @@ until a project-scoped context is resolved.
 - `secrets`: project secret management; never print values after write.
 - `queue`, `task_events`, `diagnostics`: asynchronous workload operations and bounded diagnostics.
 - `gateway`: project route/config/rebuild operations.
-- `release`: verified backup/PostgREST lifecycle controls plus a production-confirmed, non-retried, strict release-canary fixture stage replay. The replay requires both the selected Management project binding and that project's `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`.
+- `release`: verified backup/PostgREST lifecycle controls plus production-confirmed, non-retried, strict release-canary fixture stage and disable replay actions. These actions require both the selected Management project binding and that project's `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`.
 - `ai`: inspect or install this packaged Skill.
 
 ## Safe inspection pattern

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2804,6 +2804,108 @@ describe("supacloud-cli process contract", () => {
         expect(result.stdout + result.stderr).not.toContain(privateSubject);
     });
 
+    test("release-canary disable replay uses the dual-bound service role and pending readback", async () => {
+        const serviceRoleKey = "application-service-role-disable-private";
+        const fixtureId = "11111111-1111-4111-8111-111111111111";
+        const disableRequestId = "55555555-5555-4555-8555-555555555555";
+        const subject = "33333333-3333-4333-8333-333333333333";
+        const issuer = "https://issuer.example.test/auth/v1";
+        const applicationRequests: Array<{ path: string; method: string; authorization: string | null; apiKey: string | null; body: unknown }> = [];
+        const applicationServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const url = new URL(request.url);
+                applicationRequests.push({
+                    path: `${url.pathname}${url.search}`,
+                    method: request.method,
+                    authorization: request.headers.get("authorization"),
+                    apiKey: request.headers.get("apikey"),
+                    body: request.method === "POST" ? await request.json() : null,
+                });
+                if (request.method === "POST") return Response.json({ fixtureId, state: "disabled", idempotent: false });
+                return Response.json({ fixtureId, issuer, subject, pending: false });
+            },
+        });
+        servers.push(applicationServer);
+        const applicationOrigin = `http://127.0.0.1:${applicationServer.port}`;
+        const managementRequests: string[] = [];
+        const managementServer = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                managementRequests.push(new URL(request.url).pathname);
+                return Response.json({
+                    schema: "supacloud.project-endpoints.v1",
+                    project_ref: "abc123",
+                    endpoints: {
+                        api: { origin: applicationOrigin, host: `127.0.0.1:${applicationServer.port}`, scheme: "http", source: "explicit_api_domain", aliases: [] },
+                        auth: { origin: "https://auth.example.test", host: "auth.example.test", scheme: "https", source: "explicit_auth_domain", aliases: [] },
+                        studio: { origin: "https://studio.example.test", host: "studio.example.test", scheme: "https", source: "explicit_studio_domain", aliases: [] },
+                    },
+                });
+            },
+        });
+        servers.push(managementServer);
+        const environment = {
+            SUPACLOUD_ENV: "production",
+            SUPACLOUD_API_URL: `http://127.0.0.1:${managementServer.port}`,
+            SUPACLOUD_API_TOKEN: "management-disable-private-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            SUPABASE_URL: applicationOrigin,
+            SUPABASE_SERVICE_ROLE_KEY: serviceRoleKey,
+        };
+
+        const blocked = await runProjectCli([
+            "release", "release_canary_fixture_disable_replay", "--ref", "abc123",
+            "--fixture_id", fixtureId, "--disable_request_id", disableRequestId,
+            "--issuer", issuer, "--subject", subject,
+        ], environment);
+        expect(blocked.exitCode).toBe(1);
+        expect(applicationRequests).toHaveLength(0);
+
+        const result = await runProjectCli([
+            "release", "release_canary_fixture_disable_replay", "--ref", "abc123",
+            "--fixture_id", fixtureId, "--disable_request_id", disableRequestId,
+            "--issuer", issuer, "--subject", subject, "--confirm-production", "abc123",
+        ], environment);
+        const receipt = JSON.parse(result.stdout);
+
+        expect(result.exitCode).toBe(0);
+        expect(receipt).toMatchObject({
+            schema: "supacloud.cli.release-control.v1",
+            ok: true,
+            operation: "release.release_canary.fixture_disable_replay",
+            project_ref: "abc123",
+            receipt: { fixtureId, state: "disabled", idempotent: false },
+            pending: false,
+        });
+        expect(applicationRequests).toEqual([
+            {
+                path: "/rest/v1/rpc/fa_release_canary_fixture_disable",
+                method: "POST",
+                authorization: `Bearer ${serviceRoleKey}`,
+                apiKey: serviceRoleKey,
+                body: { p_fixture_id: fixtureId, p_disable_request_id: disableRequestId, p_issuer: issuer, p_subject: subject },
+            },
+            {
+                path: `/rest/v1/rpc/fa_release_canary_fixture_pending?p_fixture_id=${fixtureId}&p_issuer=https%3A%2F%2Fissuer.example.test%2Fauth%2Fv1&p_subject=${subject}`,
+                method: "GET",
+                authorization: `Bearer ${serviceRoleKey}`,
+                apiKey: serviceRoleKey,
+                body: null,
+            },
+        ]);
+        expect(managementRequests).toEqual([
+            "/v1/projects/abc123/endpoint/projection",
+            "/v1/projects/abc123/endpoint/projection",
+        ]);
+        expect(result.stdout + result.stderr).not.toContain(serviceRoleKey);
+        expect(result.stdout + result.stderr).not.toContain("management-disable-private-token");
+        expect(result.stdout + result.stderr).not.toContain(issuer);
+        expect(result.stdout + result.stderr).not.toContain(subject);
+    });
+
     test.each([["401", 401], ["403", 403]] as const)(
         "status reports application credential rejection %s without reflecting the key",
         async (_statusLabel, rejectionStatus) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -267,8 +267,8 @@ DEFAULT CONTEXT
   Without a selector or project variables, runs use the current project's legacy .env.
   Application status accepts SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.
   Management-backed project commands require SUPACLOUD_API_URL +
-  SUPACLOUD_API_TOKEN. Only release release_canary_fixture_stage_replay may additionally use
-  the selected project's SUPABASE_* pair for one application-origin RPC.
+  SUPACLOUD_API_TOKEN. Only release canary stage/disable replay actions may additionally use
+  the selected project's SUPABASE_* pair for fixed application-origin RPCs.
   SUPACLOUD_PROJECT_REF is required when it cannot be inferred from <ref>.api.*.
 
   SUPACLOUD_READ_ONLY=true blocks remote writes. Production writes require an
@@ -290,6 +290,7 @@ EXAMPLES
   ${preferredCommand} release postgrest_status --ref abc123
   ${preferredCommand} release postgrest_restart --ref abc123
   ${preferredCommand} release release_canary_fixture_stage_replay --ref abc123 --subject <uuid> --request_id <uuid>
+  ${preferredCommand} release release_canary_fixture_disable_replay --ref abc123 --fixture_id <uuid> --disable_request_id <uuid> --issuer <issuer-url> --subject <uuid>
   ${preferredCommand} queue stats --queue emails
   ${preferredCommand} queue dlq --queue emails --limit 20
   ${preferredCommand} frontend list --ref abc123

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -192,6 +192,7 @@ describe("CLI execution policy", () => {
         expect(executionMode("release", "logical_backup_restore", {})).toBe("write");
         expect(executionMode("release", "postgrest_restart", {})).toBe("write");
         expect(executionMode("release", "release_canary_fixture_stage_replay", {})).toBe("write");
+        expect(executionMode("release", "release_canary_fixture_disable_replay", {})).toBe("write");
         expect(() => authorizeExecution("release", { action: "logical_backup_create" }, {
             context: context(),
         })).toThrow("--confirm-production prod-ref");
@@ -201,6 +202,12 @@ describe("CLI execution policy", () => {
         expect(() => authorizeExecution("release", { action: "release_canary_fixture_stage_replay", ref: "prod-ref" }, {
             context: context(),
         })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("release", { action: "release_canary_fixture_disable_replay", ref: "prod-ref" }, {
+            context: context(),
+        })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("release", { action: "release_canary_fixture_disable_replay" }, {
+            context: context({ production: false, environment: "test", readOnly: true }),
+        })).toThrow("SUPACLOUD_READ_ONLY=true");
         expect(() => authorizeExecution("release", { action: "logical_backup_restore", ref: "other-ref" }, {
             context: context(),
             confirmProduction: "other-ref",

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -45,7 +45,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     mutations: { read: ["status"] },
     release: {
         read: ["logical_backup_list", "postgrest_status"],
-        write: ["logical_backup_create", "logical_backup_restore", "postgrest_restart", "release_canary_fixture_stage_replay"],
+        write: ["logical_backup_create", "logical_backup_restore", "postgrest_restart", "release_canary_fixture_stage_replay", "release_canary_fixture_disable_replay"],
     },
     secrets: { read: ["list"], write: ["upsert", "delete"] },
     frontend: {

--- a/packages/cli/src/shared/tools/release-tools.test.ts
+++ b/packages/cli/src/shared/tools/release-tools.test.ts
@@ -467,6 +467,113 @@ test("release-canary fixture stage replay refuses an application origin outside 
     });
 });
 
+test.each([false, true] as const)("release-canary fixture disable replay accepts idempotent=%s and proves pending=false", async (idempotent) => {
+    const fixtureId = "11111111-1111-4111-8111-111111111111";
+    const disableRequestId = "55555555-5555-4555-8555-555555555555";
+    const subject = "33333333-3333-4333-8333-333333333333";
+    const issuer = "https://issuer.example.test/auth/v1";
+    const managementRequests: string[] = [];
+    const applicationRequests: Array<{ method: string; path: string; body?: unknown }> = [];
+    const callback = captureReleaseTool({
+        get: async (path: string, options: Record<string, unknown>) => {
+            managementRequests.push(`${path}:${JSON.stringify(options)}`);
+            return { ok: true, status: 200, data: projectEndpoints() };
+        },
+    }, {
+        postReleaseMutation: async (path: string, body: unknown) => {
+            applicationRequests.push({ method: "POST", path, body });
+            return { ok: true, status: 200, data: { fixtureId, state: "disabled", idempotent } };
+        },
+        get: async (path: string, options: Record<string, unknown>) => {
+            applicationRequests.push({ method: "GET", path, body: options });
+            return { ok: true, status: 200, data: { fixtureId, issuer, subject, pending: false } };
+        },
+    });
+
+    const response = await callback({
+        action: "release_canary_fixture_disable_replay",
+        fixture_id: fixtureId,
+        disable_request_id: disableRequestId,
+        issuer,
+        subject,
+    });
+
+    expect(payload(response)).toMatchObject({
+        ok: true,
+        operation: "release.release_canary.fixture_disable_replay",
+        project_ref: PROJECT_REF,
+        receipt: { fixtureId, state: "disabled", idempotent },
+        pending: false,
+    });
+    expect(managementRequests).toHaveLength(2);
+    expect(applicationRequests).toEqual([
+        {
+            method: "POST",
+            path: "/rest/v1/rpc/fa_release_canary_fixture_disable",
+            body: {
+                p_fixture_id: fixtureId,
+                p_disable_request_id: disableRequestId,
+                p_issuer: issuer,
+                p_subject: subject,
+            },
+        },
+        {
+            method: "GET",
+            path: `/rest/v1/rpc/fa_release_canary_fixture_pending?p_fixture_id=${fixtureId}&p_issuer=https%3A%2F%2Fissuer.example.test%2Fauth%2Fv1&p_subject=${subject}`,
+            body: { maxJsonBytes: 64 * 1024, responseTimeoutMs: 5_000 },
+        },
+    ]);
+    expect(response.content[0].text).not.toContain(issuer);
+    expect(response.content[0].text).not.toContain(subject);
+});
+
+test("release-canary fixture disable replay fails closed when pending readback is not authoritative", async () => {
+    const fixtureId = "11111111-1111-4111-8111-111111111111";
+    const callback = captureReleaseTool({
+        get: async () => ({ ok: true, status: 200, data: projectEndpoints() }),
+    }, {
+        postReleaseMutation: async () => ({ ok: true, status: 200, data: { fixtureId, state: "disabled", idempotent: false } }),
+        get: async () => ({ ok: true, status: 200, data: { fixtureId, issuer: "https://issuer.example.test/auth/v1", subject: "33333333-3333-4333-8333-333333333333", pending: true } }),
+    });
+    const response = await callback({
+        action: "release_canary_fixture_disable_replay",
+        fixture_id: fixtureId,
+        disable_request_id: "55555555-5555-4555-8555-555555555555",
+        issuer: "https://issuer.example.test/auth/v1",
+        subject: "33333333-3333-4333-8333-333333333333",
+    });
+    expect(payload(response)).toMatchObject({
+        ok: false,
+        operation: "release.release_canary.fixture_disable_replay",
+        error: { code: "OUTCOME_UNKNOWN", http_status: 200 },
+    });
+});
+
+test.each([
+    ["invalid fixture ID", { fixture_id: "not-a-uuid", disable_request_id: "55555555-5555-4555-8555-555555555555" }],
+    ["invalid disable request ID", { fixture_id: "11111111-1111-4111-8111-111111111111", disable_request_id: "not-a-uuid" }],
+    ["invalid issuer", { fixture_id: "11111111-1111-4111-8111-111111111111", disable_request_id: "55555555-5555-4555-8555-555555555555", issuer: "javascript:alert(1)" }],
+    ["external HTTP issuer", { fixture_id: "11111111-1111-4111-8111-111111111111", disable_request_id: "55555555-5555-4555-8555-555555555555", issuer: "http://issuer.example.test/auth/v1" }],
+    ["HTTP issuer without an explicit loopback port", { fixture_id: "11111111-1111-4111-8111-111111111111", disable_request_id: "55555555-5555-4555-8555-555555555555", issuer: "http://127.0.0.1/auth/v1" }],
+])("release-canary fixture disable replay rejects %s before dispatch", async (_label, input) => {
+    let calls = 0;
+    const inputRecord = input as Record<string, string>;
+    const callback = captureReleaseTool({ get: async () => ({ ok: true, status: 200, data: projectEndpoints() }) }, {
+        postReleaseMutation: async () => {
+            calls += 1;
+            return { ok: true, status: 200, data: {} };
+        },
+    });
+    await expect(callback({
+        action: "release_canary_fixture_disable_replay",
+        fixture_id: inputRecord.fixture_id,
+        disable_request_id: inputRecord.disable_request_id,
+        issuer: inputRecord.issuer ?? "https://issuer.example.test/auth/v1",
+        subject: "33333333-3333-4333-8333-333333333333",
+    })).rejects.toThrow();
+    expect(calls).toBe(0);
+});
+
 test("an unsupported release action cannot issue a mutation", async () => {
     let postCalls = 0;
     const callback = captureReleaseTool({

--- a/packages/cli/src/shared/tools/release-tools.ts
+++ b/packages/cli/src/shared/tools/release-tools.ts
@@ -20,13 +20,20 @@ type ReleaseOperation =
     | "release.logical_backup.restore"
     | "release.postgrest.status"
     | "release.postgrest.restart"
-    | "release.release_canary.fixture_stage_replay";
+    | "release.release_canary.fixture_stage_replay"
+    | "release.release_canary.fixture_disable_replay";
 
 type ReleaseCanaryStageReceipt = {
     fixtureId: string;
     tenantKey: string;
     state: "staged";
     idempotent: true;
+};
+
+type ReleaseCanaryDisableReceipt = {
+    fixtureId: string;
+    state: "disabled";
+    idempotent: boolean;
 };
 
 type VerifiedLogicalBackup = {
@@ -57,6 +64,11 @@ const RELEASE_READ_RESPONSE_TIMEOUT_MS = 5_000;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const RELEASE_CANARY_TENANT_KEY = /^release-canary-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const RELEASE_CANARY_STAGE_RECEIPT_KEYS = new Set(["fixtureId", "tenantKey", "state", "idempotent"]);
+const RELEASE_CANARY_DISABLE_RECEIPT_KEYS = new Set(["fixtureId", "state", "idempotent"]);
+const RELEASE_CANARY_PENDING_READBACK_KEYS = new Set(["fixtureId", "issuer", "subject", "pending"]);
+const RELEASE_CANARY_DISABLE_RPC_PATH = "/rest/v1/rpc/fa_release_canary_fixture_disable";
+const RELEASE_CANARY_PENDING_RPC_PATH = "/rest/v1/rpc/fa_release_canary_fixture_pending";
+const RELEASE_CANARY_CLAIM_MAX_LENGTH = 2_048;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -276,10 +288,94 @@ function releaseCanaryStageReceipt(value: unknown): ReleaseCanaryStageReceipt | 
     };
 }
 
+function releaseCanaryIssuer(value: unknown): string {
+    if (typeof value !== "string" || value.length === 0 || value.length > RELEASE_CANARY_CLAIM_MAX_LENGTH
+        || value !== value.trim()
+        || /[\u0000-\u001f\u007f]/u.test(value)) {
+        throw new Error("'issuer' must be a bounded absolute HTTP(S) issuer");
+    }
+    let parsed: URL;
+    try {
+        parsed = new URL(value);
+    } catch {
+        throw new Error("'issuer' must be a bounded absolute HTTP(S) issuer");
+    }
+    const loopbackHttp = parsed.protocol === "http:"
+        && ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname)
+        && parsed.port.length > 0;
+    if ((parsed.protocol !== "https:" && !loopbackHttp)
+        || parsed.username
+        || parsed.password
+        || parsed.search
+        || parsed.hash) {
+        throw new Error("'issuer' must be a bounded absolute HTTP(S) issuer");
+    }
+    return value;
+}
+
+function releaseCanaryDisableInput(
+    fixtureId: unknown,
+    disableRequestId: unknown,
+    issuer: unknown,
+    subject: unknown,
+): { p_fixture_id: string; p_disable_request_id: string; p_issuer: string; p_subject: string } {
+    if (typeof fixtureId !== "string" || !UUID.test(fixtureId)) {
+        throw new Error("'fixture_id' must be a canonical UUID");
+    }
+    if (typeof disableRequestId !== "string" || !UUID.test(disableRequestId)) {
+        throw new Error("'disable_request_id' must be a canonical UUID");
+    }
+    if (typeof subject !== "string" || !UUID.test(subject)) {
+        throw new Error("'subject' must be a canonical UUID");
+    }
+    return {
+        p_fixture_id: fixtureId,
+        p_disable_request_id: disableRequestId,
+        p_issuer: releaseCanaryIssuer(issuer),
+        p_subject: subject,
+    };
+}
+
+function releaseCanaryDisableReceipt(receiptCandidate: unknown, fixtureId: string): ReleaseCanaryDisableReceipt | null {
+    if (!isRecord(receiptCandidate)
+        || Object.keys(receiptCandidate).some((key) => !RELEASE_CANARY_DISABLE_RECEIPT_KEYS.has(key))
+        || Object.keys(receiptCandidate).length !== RELEASE_CANARY_DISABLE_RECEIPT_KEYS.size
+        || receiptCandidate.fixtureId !== fixtureId
+        || receiptCandidate.state !== "disabled"
+        || typeof receiptCandidate.idempotent !== "boolean") return null;
+    return { fixtureId, state: "disabled", idempotent: receiptCandidate.idempotent };
+}
+
+function releaseCanaryPendingPath(request: {
+    p_fixture_id: string;
+    p_issuer: string;
+    p_subject: string;
+}): string {
+    const params = new URLSearchParams({
+        p_fixture_id: request.p_fixture_id,
+        p_issuer: request.p_issuer,
+        p_subject: request.p_subject,
+    });
+    return `${RELEASE_CANARY_PENDING_RPC_PATH}?${params.toString()}`;
+}
+
+function releaseCanaryPendingReadback(
+    readbackCandidate: unknown,
+    request: { p_fixture_id: string; p_issuer: string; p_subject: string },
+): boolean {
+    return isRecord(readbackCandidate)
+        && Object.keys(readbackCandidate).every((key) => RELEASE_CANARY_PENDING_READBACK_KEYS.has(key))
+        && Object.keys(readbackCandidate).length === RELEASE_CANARY_PENDING_READBACK_KEYS.size
+        && readbackCandidate.fixtureId === request.p_fixture_id
+        && readbackCandidate.issuer === request.p_issuer
+        && readbackCandidate.subject === request.p_subject
+        && readbackCandidate.pending === false;
+}
+
 async function applicationOriginMatches(http: HttpTransport, projectRef: string, applicationOrigin: string): Promise<boolean> {
     const endpointRead = await http.get(
         `${endpoint(projectRef)}/endpoint/projection`,
-        { maxResponseBytes: PROJECT_ENDPOINT_RESPONSE_MAX_BYTES },
+        { maxJsonBytes: PROJECT_ENDPOINT_RESPONSE_MAX_BYTES, responseTimeoutMs: RELEASE_READ_RESPONSE_TIMEOUT_MS },
     );
     return projectApiOrigins(endpointRead, projectRef)?.includes(applicationOrigin) === true;
 }
@@ -291,19 +387,22 @@ export function registerReleaseTools(
 ): void {
     server.tool(
         "release",
-        "Verified release controls. Management actions use the Management API; release_canary_fixture_stage_replay additionally requires the selected project's SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
+        "Verified release controls. Management actions use the Management API; release canary stage/disable replay additionally require the selected project's SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
         {
             action: withDescription(stringEnum([
-                "logical_backup_list", "logical_backup_create", "logical_backup_restore", "postgrest_status", "postgrest_restart", "release_canary_fixture_stage_replay",
+                "logical_backup_list", "logical_backup_create", "logical_backup_restore", "postgrest_status", "postgrest_restart", "release_canary_fixture_stage_replay", "release_canary_fixture_disable_replay",
             ]), "Release control action"),
             ref: optional(Type.String(), options.projectRef ? "Optional override when not auto-linked" : "Project ref"),
             backup_id: optional(Type.String(), "[logical_backup_restore] Exact verified logical-full backup ID from the selected project inventory"),
             expected_sha256: optional(Type.String(), "[logical_backup_restore] Exact lowercase SHA-256 from the selected project inventory"),
             restore_confirmation: optional(Type.String(), "[logical_backup_restore] Exact RESTORE_PROJECT:<ref>:<backup_id>:<sha256> confirmation"),
-            subject: optional(Type.String(), "[release_canary_fixture_stage_replay] Exact central subject UUID"),
+            subject: optional(Type.String(), "[release_canary_fixture_stage_replay/disable_replay] Exact central subject UUID"),
             request_id: optional(Type.String(), "[release_canary_fixture_stage_replay] Exact idempotent stage request UUID"),
+            fixture_id: optional(Type.String(), "[release_canary_fixture_disable_replay] Exact staged fixture UUID"),
+            disable_request_id: optional(Type.String(), "[release_canary_fixture_disable_replay] Exact idempotent disable request UUID"),
+            issuer: optional(Type.String(), "[release_canary_fixture_disable_replay] Exact HTTP(S) issuer"),
         },
-        async ({ action, ref, backup_id, expected_sha256, restore_confirmation, subject, request_id }) => {
+        async ({ action, ref, backup_id, expected_sha256, restore_confirmation, subject, request_id, fixture_id, disable_request_id, issuer }) => {
             const projectRef = typeof ref === "string" && ref || options.projectRef;
             if (!projectRef) throw new Error("'ref' is required for release controls");
             if (!validProjectRef(projectRef)) throw new Error("'ref' is invalid for release controls");
@@ -405,6 +504,49 @@ export function registerReleaseTools(
                 return releaseControlSuccess("release.release_canary.fixture_stage_replay", {
                     project_ref: projectRef,
                     receipt,
+                });
+            }
+            if (action === "release_canary_fixture_disable_replay") {
+                if (!options.applicationHttp || !options.applicationOrigin) {
+                    throw new Error("release_canary_fixture_disable_replay requires SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY");
+                }
+                const request = releaseCanaryDisableInput(fixture_id, disable_request_id, issuer, subject);
+                if (!await applicationOriginMatches(http, projectRef, options.applicationOrigin)) {
+                    return releaseControlFailure("release.release_canary.fixture_disable_replay", "INVALID_RESPONSE", null);
+                }
+                const response = await options.applicationHttp.postReleaseMutation(
+                    RELEASE_CANARY_DISABLE_RPC_PATH,
+                    request,
+                );
+                if (!response.ok || response.status !== 200) {
+                    return mutationFailure("release.release_canary.fixture_disable_replay", response);
+                }
+                const receipt = releaseCanaryDisableReceipt(response.data, request.p_fixture_id);
+                if (!receipt) {
+                    return releaseControlFailure("release.release_canary.fixture_disable_replay", "OUTCOME_UNKNOWN", response.status);
+                }
+                const pendingRequest = {
+                    p_fixture_id: request.p_fixture_id,
+                    p_issuer: request.p_issuer,
+                    p_subject: request.p_subject,
+                };
+                const pendingResponse = await options.applicationHttp.get(
+                    releaseCanaryPendingPath(pendingRequest),
+                    { maxJsonBytes: MUTATION_MAX_BYTES, responseTimeoutMs: RELEASE_READ_RESPONSE_TIMEOUT_MS },
+                );
+                if (!pendingResponse.ok || pendingResponse.status !== 200
+                    || !releaseCanaryPendingReadback(pendingResponse.data, pendingRequest)
+                    || !await applicationOriginMatches(http, projectRef, options.applicationOrigin)) {
+                    return releaseControlFailure(
+                        "release.release_canary.fixture_disable_replay",
+                        "OUTCOME_UNKNOWN",
+                        pendingResponse.transportError ? null : pendingResponse.status,
+                    );
+                }
+                return releaseControlSuccess("release.release_canary.fixture_disable_replay", {
+                    project_ref: projectRef,
+                    receipt,
+                    pending: false,
                 });
             }
             if (action !== "postgrest_restart") throw new Error("Unknown release control action");


### PR DESCRIPTION
## Summary
- add the fixed `release_canary_fixture_disable_replay` action with strict UUID/issuer/subject validation
- call the fixed disable RPC once, accept idempotent false/true receipts, then use the existing pending RPC for identity-bound `pending=false` readback
- preserve Management/application credential separation, endpoint projection before/after, production confirmation, no-retry/redirect and bounded responses
- add process-contract/unit/policy tests and docs

## Verification
- `bun test packages/cli/src` (836 pass, 0 fail)
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli build`
- `git diff --check`
- three independent high-risk security reviewers: PASS

No GoTrue or generic server RPC changes.