### PR TITLE
fix(upgrade): back up control plane before migrations

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -124,8 +124,8 @@ external Edge Runtime as a single rollback-capable transaction:
 
 ```bash
 npx @supacloud/admin ssh upgrade \
-  --version 0.50.31 \
-  --edge_runtime_version 0.16.8 \
+  --version 0.61.4 \
+  --edge_runtime_version 0.18.2 \
   --artifact_transport local \
   --github_proxy direct
 ```
@@ -149,6 +149,43 @@ SSH channel. It preserves the Edge Runtime systemd `ExecStart`, port, mode, and
 enabled state. Component upgrades require persisted `EDGE_RUNTIME_MODE=external`;
 embedded mode is rejected before release artifacts or services are changed.
 Local, remote, and direct server upgrades share one nonblocking host-wide lock.
+
+Local artifact upgrades require Management 0.61.4 or newer. After stopping the
+old Management service and before writing runtime secrets or running
+`--init-db`, the target binary verifies that `DATABASE_URL` identifies the
+Management control-plane database, rejects a registered tenant database, and
+creates a verified custom-format PostgreSQL archive. Backups and their private
+receipts are stored under
+`/var/lib/supacloud/backups/control-plane-upgrades/<backup-id>/`; the five most
+recent trusted backups are retained.
+
+The inspection transaction remains open while `pg_dump` imports its exported
+snapshot, so a different PostgreSQL server cannot satisfy the dump step. The
+root process reserves the private archive first; the `postgres` identity receives
+only that inherited output descriptor and never gains path access to the
+root-only backup directory.
+
+The inspection transaction also keeps its exported snapshot alive until staged
+`--init-db` finishes. The child receives the database fingerprint and snapshot
+only in its process environment, imports that live snapshot, verifies the
+PostgreSQL cluster and database identity, and performs all initialization writes
+inside that same transaction. This keeps the writes on one PostgreSQL backend
+even when `DATABASE_URL` points through a transaction-pooling proxy. A copied
+data directory, promoted standby, restored disk snapshot, or other node cannot
+import the exporter-owned snapshot even when its static fingerprint matches.
+The guard is not persisted or printed. A guard rejection restores the previous
+runtime environment but leaves Management stopped for explicit reconciliation
+instead of reconnecting it to an unverified target.
+
+A committed transaction emits exactly one redacted
+`supacloud.control-plane-upgrade-safety.v1` receipt. It contains only the backup
+identifier and directory, byte count, SHA-256 digest, migration candidate
+counts, checkpoint state, and completion time. Admin validates the exact
+receipt schema before deleting the transient
+status and log records. A missing or malformed receipt leaves those records in
+place and requires reconciliation. Restoring a control-plane backup is a
+separate destructive operation and requires an explicit, independently reviewed
+recovery decision; the upgrade command never restores one automatically.
 
 Admin observes the remote transaction for up to 30 minutes. Reaching that
 deadline stops only local observation; it does not stop, clean up, or mark the

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 
 import {
     adoptRemoteDrop,
+    assertControlPlaneSafetyVersion,
     awaitRemoteUpgrade,
     buildAdoptDropScript,
     buildCleanupUnstartedUpgradeScript,
@@ -17,7 +18,9 @@ import {
     buildTargetRunnerCapabilityScript,
     buildUploadDropCleanupFailure,
     buildUpgradeLockScript,
+    executeLocalUpgradeTransfer,
     failureRequiresRemoteReconciliation,
+    parseControlPlaneSafetyEvidence,
     parseRemotePreflight,
     remoteUpgradePreflight,
     startRemoteUpgrade,
@@ -55,6 +58,71 @@ class ScriptedSsh {
 function remoteResult(stdout = "", success = true): ScriptedResult {
     return { success, stdout, stderr: success ? "" : "remote failure", code: success ? 0 : 1 };
 }
+
+const controlPlaneSafetyEvidence = {
+    schema: "supacloud.control-plane-upgrade-safety.v1" as const,
+    backup_id: "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000001",
+    backup_directory: "/var/lib/supacloud/backups/control-plane-upgrades/control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000001",
+    bytes: 2048,
+    candidate_counts: {
+        deprecated_webhook_secrets: 0,
+        legacy_deployment_history_rows: 0,
+        legacy_project_config_rows: 0,
+        opaque_key_backfill_projects: 0,
+        stored_secret_values: 6,
+    },
+    completed_at: "2026-08-19T00:00:00.000Z",
+    current_key_checkpoint_present: true,
+    sha256: "c".repeat(64),
+};
+
+function successfulUpgradeLog(message = "upgrade committed"): string {
+    return `${message}\nSUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=${JSON.stringify(controlPlaneSafetyEvidence)}\n`;
+}
+
+describe("control-plane safety receipt", () => {
+    test("requires the first Management release with in-transaction control-plane backup safety", () => {
+        expect(() => assertControlPlaneSafetyVersion("0.61.3")).toThrow("0.61.4 or newer");
+        expect(() => assertControlPlaneSafetyVersion("0.61.4")).not.toThrow();
+        expect(() => assertControlPlaneSafetyVersion("0.62.0")).not.toThrow();
+        expect(() => assertControlPlaneSafetyVersion("1.0.0")).not.toThrow();
+        expect(() => assertControlPlaneSafetyVersion("latest")).toThrow("exact stable version");
+        expect(() => assertControlPlaneSafetyVersion("999999999999999999999.61.4"))
+            .toThrow("exact stable version");
+    });
+
+    test("rejects Management 0.61.3 before remote access", async () => {
+        let remoteAccesses = 0;
+        const ssh = {
+            exec: async () => {
+                remoteAccesses += 1;
+                throw new Error("remote access must not run");
+            },
+        };
+        await expect(executeLocalUpgradeTransfer(ssh as never, {
+            managementVersion: "0.61.3",
+            edgeRuntimeVersion: "0.18.2",
+        })).rejects.toThrow("0.61.4 or newer");
+        expect(remoteAccesses).toBe(0);
+    });
+
+    test("accepts one exact redacted receipt", () => {
+        expect(parseControlPlaneSafetyEvidence(successfulUpgradeLog())).toEqual(controlPlaneSafetyEvidence);
+    });
+
+    test("rejects missing, duplicate, secret-bearing, and malformed receipts", () => {
+        expect(() => parseControlPlaneSafetyEvidence("upgrade committed\n")).toThrow("one control-plane safety receipt");
+        expect(() => parseControlPlaneSafetyEvidence(`${successfulUpgradeLog()}${successfulUpgradeLog()}`))
+            .toThrow("one control-plane safety receipt");
+        expect(() => parseControlPlaneSafetyEvidence(successfulUpgradeLog().replace(
+            '"sha256"',
+            '"password":"not-allowed","sha256"',
+        ))).toThrow("receipt is invalid");
+        expect(() => parseControlPlaneSafetyEvidence(
+            "SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY={not-json}\n",
+        )).toThrow("not valid JSON");
+    });
+});
 
 type RemoteStateFixture = {
     dropExists?: boolean;
@@ -1059,7 +1127,7 @@ describe("local upgrade remote runner", () => {
         const ssh = new ScriptedSsh([
             new Error("SSH connection reset while monitoring"),
             remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
-            remoteResult("transaction complete\n"),
+            remoteResult(successfulUpgradeLog("transaction complete")),
             remoteResult(),
         ]);
 
@@ -1175,7 +1243,7 @@ describe("local upgrade remote runner", () => {
     test("removes terminal records only after a completed unit publishes success", async () => {
         const ssh = new ScriptedSsh([
             remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
-            remoteResult("upgrade committed\n"),
+            remoteResult(successfulUpgradeLog()),
             remoteResult(),
         ]);
 
@@ -1194,7 +1262,7 @@ describe("local upgrade remote runner", () => {
         ] as const) {
             const ssh = new ScriptedSsh([
                 remoteState({ status: "SUCCEEDED", serviceState, unitLoadState, unitExists }),
-                remoteResult("upgrade committed\n"),
+                remoteResult(successfulUpgradeLog()),
                 remoteResult(),
             ]);
 
@@ -1242,7 +1310,7 @@ describe("local upgrade remote runner", () => {
     test("requires reconciliation when successful record cleanup disconnects", async () => {
         const ssh = new ScriptedSsh([
             remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
-            remoteResult("upgrade committed\n"),
+            remoteResult(successfulUpgradeLog()),
             new Error("SSH stream closed during record cleanup"),
         ]);
 
@@ -1251,6 +1319,21 @@ describe("local upgrade remote runner", () => {
         expect(String(failure)).toContain("cleanup could not be confirmed");
         expect(String(failure)).toContain(paths.status);
         expect(String(failure)).toContain(paths.log);
+    });
+
+    test("retains successful status and log records when the safety receipt is missing", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
+            remoteResult("upgrade committed without safety evidence\n"),
+        ]);
+
+        const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("control-plane safety evidence is invalid");
+        expect(String(failure)).toContain(paths.status);
+        expect(String(failure)).toContain(paths.log);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes("rm -f --"))).toBe(false);
     });
 
     test("requires reconciliation when a successful log disappears after state read-back", async () => {

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -53,12 +53,98 @@ const REMOTE_RUN_ROOT = "/var/lib/supacloud/upgrade-runs";
 const REMOTE_LOG_ROOT = "/var/log/supacloud";
 const REMOTE_UPLOAD_ROOT = "/var/tmp";
 const REMOTE_COMMAND_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const CONTROL_PLANE_BACKUP_ROOT = "/var/lib/supacloud/backups/control-plane-upgrades";
+const CONTROL_PLANE_SAFETY_PREFIX = "SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=";
+const MINIMUM_CONTROL_PLANE_SAFETY_VERSION = [0, 61, 4] as const;
 const POLL_INTERVAL_MS = 2_000;
 const STATE_READ_ATTEMPTS = 3;
 const REMOTE_STATE_READ_TIMEOUT_MS = 15_000;
 export const UPGRADE_OBSERVATION_TIMEOUT_MS = 30 * 60_000;
 
 class RemoteUpgradeReconciliationError extends AggregateError {}
+
+type ControlPlaneSafetyEvidence = {
+    backup_id: string;
+    backup_directory: string;
+    bytes: number;
+    candidate_counts: Record<string, number>;
+    completed_at: string;
+    current_key_checkpoint_present: boolean;
+    schema: "supacloud.control-plane-upgrade-safety.v1";
+    sha256: string;
+};
+
+function exactObjectKeys(candidate: Record<string, unknown>, expected: readonly string[]): boolean {
+    const actual = Object.keys(candidate).sort();
+    return actual.length === expected.length && actual.every((key, index) => key === [...expected].sort()[index]);
+}
+
+function nonNegativeIntegerRecord(candidate: unknown, expectedKeys: readonly string[]): candidate is Record<string, number> {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return false;
+    const record = candidate as Record<string, unknown>;
+    return exactObjectKeys(record, expectedKeys)
+        && Object.values(record).every((value) => Number.isSafeInteger(value) && Number(value) >= 0);
+}
+
+function canonicalTimestamp(candidate: unknown): candidate is string {
+    if (typeof candidate !== "string") return false;
+    const timestamp = new Date(candidate);
+    return Number.isFinite(timestamp.valueOf()) && timestamp.toISOString() === candidate;
+}
+
+export function parseControlPlaneSafetyEvidence(log: string): ControlPlaneSafetyEvidence {
+    const receiptLines = log.split(/\r?\n/)
+        .filter((line) => line.startsWith(CONTROL_PLANE_SAFETY_PREFIX));
+    if (receiptLines.length !== 1) throw new Error("Remote upgrade did not emit one control-plane safety receipt");
+    let candidate: unknown;
+    try {
+        candidate = JSON.parse(receiptLines[0]!.slice(CONTROL_PLANE_SAFETY_PREFIX.length));
+    } catch {
+        throw new Error("Remote control-plane safety receipt is not valid JSON");
+    }
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error("Remote control-plane safety receipt is invalid");
+    }
+    const receipt = candidate as Record<string, unknown>;
+    const expectedKeys = [
+        "backup_id", "backup_directory", "bytes", "candidate_counts", "completed_at",
+        "current_key_checkpoint_present", "schema", "sha256",
+    ];
+    const candidateKeys = [
+        "deprecated_webhook_secrets", "legacy_deployment_history_rows", "legacy_project_config_rows",
+        "opaque_key_backfill_projects", "stored_secret_values",
+    ];
+    const validBackupId = typeof receipt.backup_id === "string"
+        && /^control-plane-\d{8}T\d{6}Z-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(receipt.backup_id);
+    const validDigest = typeof receipt.sha256 === "string" && /^[0-9a-f]{64}$/.test(receipt.sha256);
+    if (!exactObjectKeys(receipt, expectedKeys)
+        || receipt.schema !== "supacloud.control-plane-upgrade-safety.v1"
+        || !validBackupId
+        || receipt.backup_directory !== `${CONTROL_PLANE_BACKUP_ROOT}/${receipt.backup_id}`
+        || !Number.isSafeInteger(receipt.bytes) || Number(receipt.bytes) <= 0
+        || !canonicalTimestamp(receipt.completed_at)
+        || typeof receipt.current_key_checkpoint_present !== "boolean"
+        || !validDigest
+        || !nonNegativeIntegerRecord(receipt.candidate_counts, candidateKeys)) {
+        throw new Error("Remote control-plane safety receipt is invalid");
+    }
+    return receipt as ControlPlaneSafetyEvidence;
+}
+
+export function assertControlPlaneSafetyVersion(version: string): void {
+    const match = version.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
+    if (!match) throw new Error("Management version must be an exact stable version");
+    const requested = match.slice(1).map(Number);
+    if (!requested.every(Number.isSafeInteger)) {
+        throw new Error("Management version must be an exact stable version");
+    }
+    for (let index = 0; index < requested.length; index += 1) {
+        if (requested[index]! > MINIMUM_CONTROL_PLANE_SAFETY_VERSION[index]!) return;
+        if (requested[index]! < MINIMUM_CONTROL_PLANE_SAFETY_VERSION[index]!) {
+            throw new Error("Local artifact upgrades require Management 0.61.4 or newer with control-plane backup safety");
+        }
+    }
+}
 
 function quoteShell(shellText: string): string {
     return `'${shellText.split("'").join("'\\''")}'`;
@@ -118,7 +204,7 @@ export function buildRemotePreflightScript(): string {
         "export PATH",
         trustedInstalledGithubFunction(),
         "test -d /run/systemd/system || { echo 'systemd is not the active init system' >&2; exit 1; }",
-        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep tail timeout flock install mktemp; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
+        "for tool in systemctl systemd-run sha256sum stat realpath tar file find sort awk grep tail timeout flock install mktemp setpriv id pg_dump pg_restore; do command -v \"$tool\" >/dev/null 2>&1 || { echo \"Required local-upgrade tool is missing: $tool\" >&2; exit 127; }; done",
         "tail -n 0 -- /dev/null >/dev/null 2>&1 || { echo 'A tail implementation with -n and -- support is required' >&2; exit 1; }",
         "systemd-run --help | grep -Eq -- '(^|[[:space:]])--collect([=[:space:]]|$)' || { echo 'systemd-run --collect is required' >&2; exit 1; }",
         "test -d /run/lock || { echo '/run/lock is unavailable' >&2; exit 1; }",
@@ -814,6 +900,14 @@ async function completedUpgradeOutput(ssh: SshTransport, paths: RemoteUpgradePat
             "Upgrade succeeded but its retained log could not be read", [error], paths,
         );
     }
+    let safetyEvidence: ControlPlaneSafetyEvidence;
+    try {
+        safetyEvidence = parseControlPlaneSafetyEvidence(log);
+    } catch (error: unknown) {
+        throw remoteReconciliationFailure(
+            "Upgrade succeeded but control-plane safety evidence is invalid", [error], paths,
+        );
+    }
     try {
         await cleanupRemoteRecords(ssh, paths);
     } catch (error: unknown) {
@@ -821,7 +915,7 @@ async function completedUpgradeOutput(ssh: SshTransport, paths: RemoteUpgradePat
             "Upgrade succeeded but remote evidence cleanup could not be confirmed", [error], paths,
         );
     }
-    return `✅ Upgrade done\n${log.slice(-1_500)}`;
+    return `✅ Upgrade done\n${JSON.stringify(safetyEvidence)}\n${log.slice(-1_500)}`;
 }
 
 async function throwRemoteUpgradeFailure(ssh: SshTransport, paths: RemoteUpgradePaths, status: string): Promise<never> {
@@ -897,6 +991,7 @@ export async function awaitRemoteUpgrade(ssh: SshTransport, paths: RemoteUpgrade
 }
 
 export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: LocalUpgradeTransferRequest): Promise<string> {
+    assertControlPlaneSafetyVersion(request.managementVersion);
     const runId = randomUUID();
     const paths = buildRemoteUpgradePaths(runId);
     const preflight = await remoteUpgradePreflight(ssh);

--- a/packages/management-api/src/control-plane-upgrade-safety.ts
+++ b/packages/management-api/src/control-plane-upgrade-safety.ts
@@ -1,0 +1,618 @@
+import { SQL } from "bun";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants as fsConstants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  rmSync,
+  type Stats,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  controlPlaneDatabaseFingerprint,
+  inspectControlPlaneDatabaseIdentity,
+  parseExpectedControlPlaneDatabaseSnapshot,
+} from "./db/control-plane-database-identity";
+import { hasSecretEncryptionCheckpoint } from "./db/secret-key-migration";
+
+const BACKUP_ROOT = "/var/lib/supacloud/backups/control-plane-upgrades";
+const BACKUP_ID_PATTERN = /^control-plane-\d{8}T\d{6}Z-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const BACKUP_LIMIT = 5;
+const BACKUP_USER = "postgres";
+const COMMAND_TIMEOUT_SECONDS = 1800;
+const MAX_RECEIPT_BYTES = 8 * 1024;
+const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_.-]{0,62}$/;
+const SETPRIV_PATH = ["/usr/bin/setpriv", "/bin/setpriv"].find(existsSync) ?? "/usr/bin/setpriv";
+const ID_PATH = ["/usr/bin/id", "/bin/id"].find(existsSync) ?? "/usr/bin/id";
+const PG_DUMP_PATH = ["/usr/bin/pg_dump", "/usr/local/bin/pg_dump"].find(existsSync) ?? "/usr/bin/pg_dump";
+const PG_RESTORE_PATH = ["/usr/bin/pg_restore", "/usr/local/bin/pg_restore"].find(existsSync) ?? "/usr/bin/pg_restore";
+const TIMEOUT_PATH = ["/usr/bin/timeout", "/bin/timeout"].find(existsSync) ?? "/usr/bin/timeout";
+
+export type ControlPlaneMigrationCandidates = {
+  deprecated_webhook_secrets: number;
+  legacy_deployment_history_rows: number;
+  legacy_project_config_rows: number;
+  opaque_key_backfill_projects: number;
+  stored_secret_values: number;
+};
+
+export type ControlPlaneUpgradeSafetyEvidence = {
+  schema: "supacloud.control-plane-upgrade-safety.v1";
+  backup_id: string;
+  backup_directory: string;
+  bytes: number;
+  candidate_counts: ControlPlaneMigrationCandidates;
+  completed_at: string;
+  current_key_checkpoint_present: boolean;
+  sha256: string;
+};
+
+type DatabaseTarget = {
+  database: string;
+  hostname: string;
+  password: string;
+  port: string;
+  username: string;
+};
+
+type CommandRequest = {
+  args: string[];
+  env?: Record<string, string | undefined>;
+  stdin?: number;
+  stdout?: number;
+};
+
+type ControlPlaneBackupOperations = {
+  backupRoot: string;
+  identity: (user: string) => Promise<{ gid: number; uid: number }>;
+  now: () => Date;
+  randomId: () => string;
+  remove?: (directory: string) => void;
+  run: (request: CommandRequest) => Promise<number>;
+};
+
+type ControlPlaneSafetyOperations = {
+  backup: (
+    target: DatabaseTarget,
+    inspection: ControlPlaneInspection,
+  ) => Promise<ControlPlaneUpgradeSafetyEvidence>;
+  withInspection: <T>(
+    databaseUrl: string,
+    currentKey: string,
+    operation: (inspection: ControlPlaneInspection) => Promise<T>,
+  ) => Promise<T>;
+};
+
+export type ControlPlaneUpgradeSafetyLease = {
+  databaseFingerprint: string;
+  evidence: ControlPlaneUpgradeSafetyEvidence;
+  snapshotId: string;
+};
+
+type ControlPlaneInspection = {
+  candidateCounts: ControlPlaneMigrationCandidates;
+  checkpointPresent: boolean;
+  databaseFingerprint: string;
+  databaseTargetFingerprint: string;
+  snapshotId: string;
+};
+
+function databaseTarget(databaseUrl: string): DatabaseTarget {
+  const parsed = new URL(databaseUrl);
+  if (!["postgres:", "postgresql:"].includes(parsed.protocol)) {
+    throw new Error("Control-plane backup requires a PostgreSQL DATABASE_URL");
+  }
+  const database = decodeURIComponent(parsed.pathname.replace(/^\/+/, ""));
+  const username = decodeURIComponent(parsed.username);
+  const port = parsed.port || "5432";
+  if (!POSTGRES_IDENTIFIER.test(database)
+    || !POSTGRES_IDENTIFIER.test(username)
+    || !parsed.hostname
+    || !/^\d{1,5}$/.test(port)
+    || Number(port) < 1
+    || Number(port) > 65_535
+    || parsed.search
+    || parsed.hash) {
+    throw new Error("Control-plane backup DATABASE_URL is incomplete");
+  }
+  return {
+    database,
+    hostname: parsed.hostname,
+    password: decodeURIComponent(parsed.password),
+    port,
+    username,
+  };
+}
+
+function databaseTargetFingerprint(target: DatabaseTarget): string {
+  return createHash("sha256")
+    .update([target.hostname, target.port, target.database].join("\0"))
+    .digest("hex");
+}
+
+async function tableExists(database: SQL, table: string): Promise<boolean> {
+  const [row] = await database`
+    SELECT to_regclass(${`public.${table}`}) IS NOT NULL AS present
+  `;
+  return row?.present === true;
+}
+
+async function legacyDeploymentRows(database: SQL): Promise<number> {
+  const [legacy] = await database`
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'deployment_history'
+        AND column_name = 'project_ref'
+    ) AS present
+  `;
+  if (legacy?.present !== true) return 0;
+  const [count] = await database`SELECT COUNT(*)::int AS count FROM deployment_history`;
+  return Number(count?.count || 0);
+}
+
+async function projectCandidateCounts(database: SQL) {
+  const [counts] = await database`
+    SELECT
+      COUNT(*) FILTER (
+        WHERE config ? 'webhooks'
+           OR config #> '{auth,external}' IS NOT NULL
+           OR config #> '{auth,hooks}' IS NOT NULL
+           OR config #> '{auth,experimental,providers_with_own_linking_domain}' IS NOT NULL
+           OR config #> '{auth,security_captcha_secret}' IS NOT NULL
+      )::int AS legacy_config,
+      COUNT(*) FILTER (
+        WHERE publishable_key IS NULL
+           OR secret_key_hash IS NULL
+           OR secret_key_encrypted IS NULL
+      )::int AS opaque_keys,
+      COUNT(*) FILTER (WHERE db_password_encrypted IS NOT NULL)::int
+        + COUNT(*) FILTER (WHERE jwt_secret_encrypted IS NOT NULL)::int
+        + COUNT(*) FILTER (WHERE service_role_key_encrypted IS NOT NULL)::int
+        + COUNT(*) FILTER (WHERE secret_key_encrypted IS NOT NULL)::int
+        + COUNT(*) FILTER (WHERE s3_secret_key_encrypted IS NOT NULL)::int AS project_secrets
+    FROM projects
+  `;
+  return {
+    legacyConfig: Number(counts?.legacy_config || 0),
+    opaqueKeys: Number(counts?.opaque_keys || 0),
+    projectSecrets: Number(counts?.project_secrets || 0),
+  };
+}
+
+async function optionalTableCount(database: SQL, table: string, expression = "COUNT(*)"): Promise<number> {
+  if (!(await tableExists(database, table))) return 0;
+  const allowed = new Map([
+    ["platform_settings", "COUNT(*) FILTER (WHERE is_secret = true)"],
+    ["project_control_secrets", "COUNT(*)"],
+    ["project_secrets", "COUNT(*)"],
+    ["project_tasks", "COUNT(*) FILTER (WHERE payload ? 'auth')"],
+    ["project_webhooks", "COUNT(*) FILTER (WHERE secret_encrypted IS NOT NULL OR previous_secret_encrypted IS NOT NULL)"],
+  ]);
+  if (allowed.get(table) !== expression) throw new Error("Unsupported control-plane preflight query");
+  const [count] = await database.unsafe(`SELECT (${expression})::int AS count FROM ${table}`);
+  return Number(count?.count || 0);
+}
+
+async function storedSecretCount(database: SQL, projectSecrets: number): Promise<number> {
+  const counts = await Promise.all([
+    optionalTableCount(database, "project_secrets"),
+    optionalTableCount(database, "project_control_secrets"),
+    optionalTableCount(database, "platform_settings", "COUNT(*) FILTER (WHERE is_secret = true)"),
+    optionalTableCount(database, "project_tasks", "COUNT(*) FILTER (WHERE payload ? 'auth')"),
+    optionalTableCount(
+      database,
+      "project_webhooks",
+      "COUNT(*) FILTER (WHERE secret_encrypted IS NOT NULL OR previous_secret_encrypted IS NOT NULL)",
+    ),
+  ]);
+  return projectSecrets + counts.reduce((total, count) => total + count, 0);
+}
+
+async function inspectControlPlane(
+  database: SQL,
+  target: DatabaseTarget,
+  currentKey: string,
+): Promise<ControlPlaneInspection> {
+  const identity = await inspectControlPlaneDatabaseIdentity(database);
+  const [controlPlane] = await database`
+    SELECT to_regclass('public.projects') IS NOT NULL AS projects_table_exists
+  `;
+  if (identity.databaseName !== target.database || controlPlane?.projects_table_exists !== true) {
+    throw new Error("DATABASE_URL is not the SupaCloud Management control-plane database");
+  }
+  const [collision] = await database`
+    SELECT COUNT(*)::int AS count FROM projects WHERE db_name = current_database()
+  `;
+  if (Number(collision?.count || 0) !== 0) {
+    throw new Error("DATABASE_URL resolves to a registered tenant database");
+  }
+  const projects = await projectCandidateCounts(database);
+  const [snapshot] = await database`SELECT pg_export_snapshot() AS snapshot_id`;
+  if (typeof snapshot?.snapshot_id !== "string") {
+    throw new Error("Control-plane database did not export a valid backup snapshot");
+  }
+  const snapshotId = parseExpectedControlPlaneDatabaseSnapshot(snapshot.snapshot_id);
+  return {
+    candidateCounts: {
+      deprecated_webhook_secrets: await optionalTableCount(
+        database,
+        "project_webhooks",
+        "COUNT(*) FILTER (WHERE secret_encrypted IS NOT NULL OR previous_secret_encrypted IS NOT NULL)",
+      ),
+      legacy_deployment_history_rows: await legacyDeploymentRows(database),
+      legacy_project_config_rows: projects.legacyConfig,
+      opaque_key_backfill_projects: projects.opaqueKeys,
+      stored_secret_values: await storedSecretCount(database, projects.projectSecrets),
+    },
+    checkpointPresent: await hasSecretEncryptionCheckpoint(database, currentKey),
+    databaseFingerprint: controlPlaneDatabaseFingerprint(identity),
+    databaseTargetFingerprint: databaseTargetFingerprint(target),
+    snapshotId,
+  };
+}
+
+async function withControlPlaneInspection<T>(
+  databaseUrl: string,
+  currentKey: string,
+  operation: (inspection: ControlPlaneInspection) => Promise<T>,
+): Promise<T> {
+  const target = databaseTarget(databaseUrl);
+  const database = new SQL({ url: databaseUrl, database: target.database, max: 1 });
+  try {
+    return await database.begin(async (transaction) => {
+      await transaction.unsafe("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
+      return operation(await inspectControlPlane(transaction, target, currentKey));
+    });
+  } finally {
+    await database.close();
+  }
+}
+
+async function commandIdentity(user: string): Promise<{ gid: number; uid: number }> {
+  const values = await Promise.all(["-u", "-g"].map(async (flag) => {
+    const process = Bun.spawn([TIMEOUT_PATH, "5", ID_PATH, flag, user], {
+      env: {}, stdout: "pipe", stderr: "ignore",
+    });
+    const [exitCode, stdout] = await Promise.all([process.exited, new Response(process.stdout).text()]);
+    const numericIdentity = stdout.trim();
+    if (exitCode !== 0 || !/^\d+$/.test(numericIdentity)) {
+      throw new Error("Control-plane backup account lookup failed");
+    }
+    return Number(numericIdentity);
+  }));
+  return { uid: values[0]!, gid: values[1]! };
+}
+
+async function runCommand(request: CommandRequest): Promise<number> {
+  const childProcess = Bun.spawn(request.args, {
+    env: request.env ?? {},
+    stdin: request.stdin ?? "ignore",
+    stdout: request.stdout ?? "ignore",
+    stderr: "ignore",
+  });
+  return childProcess.exited;
+}
+
+function defaultBackupOperations(): ControlPlaneBackupOperations {
+  return {
+    backupRoot: BACKUP_ROOT,
+    identity: commandIdentity,
+    now: () => new Date(),
+    randomId: randomUUID,
+    run: runCommand,
+  };
+}
+
+function assertPrivateDirectory(directory: string, expectedUid: number): void {
+  const metadata = lstatSync(directory);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink() || metadata.uid !== expectedUid) {
+    throw new Error("Control-plane backup directory is not a trusted directory");
+  }
+  if ((metadata.mode & 0o777) !== 0o700) {
+    throw new Error("Control-plane backup directory permissions must be 0700");
+  }
+}
+
+function createBackupDirectory(operations: ControlPlaneBackupOperations, backupId: string): string {
+  const currentUid = process.getuid?.() ?? 0;
+  if (!existsSync(operations.backupRoot)) mkdirSync(operations.backupRoot, { mode: 0o700, recursive: true });
+  assertPrivateDirectory(operations.backupRoot, currentUid);
+  const backupDirectory = join(operations.backupRoot, backupId);
+  mkdirSync(backupDirectory, { mode: 0o700 });
+  assertPrivateDirectory(backupDirectory, currentUid);
+  return backupDirectory;
+}
+
+function dumpArguments(target: DatabaseTarget, inspection: ControlPlaneInspection, uid: number, gid: number): string[] {
+  return [
+    TIMEOUT_PATH, "--kill-after=30s", String(COMMAND_TIMEOUT_SECONDS),
+    SETPRIV_PATH, "--reuid", String(uid), "--regid", String(gid), "--init-groups", "--",
+    PG_DUMP_PATH, "--host", target.hostname, "--port", target.port, "--username", target.username,
+    "--dbname", target.database, "--format=custom", "--compress=6", "--snapshot", inspection.snapshotId,
+  ];
+}
+
+function verifyArguments(): string[] {
+  return [TIMEOUT_PATH, "60", PG_RESTORE_PATH, "--list"];
+}
+
+function fileSha256(descriptor: number, bytes: number): string {
+  const digest = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(Math.min(1024 * 1024, bytes));
+  let position = 0;
+  while (position < bytes) {
+    const bytesRead = readSync(descriptor, buffer, 0, Math.min(buffer.length, bytes - position), position);
+    if (bytesRead === 0) throw new Error("Control-plane backup archive ended during hashing");
+    digest.update(buffer.subarray(0, bytesRead));
+    position += bytesRead;
+  }
+  return digest.digest("hex");
+}
+
+function syncPath(filePath: string, directory = false): void {
+  const flags = directory
+    ? fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW
+    : fsConstants.O_RDWR | fsConstants.O_NOFOLLOW;
+  const descriptor = openSync(filePath, flags);
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function assertBackupArchive(metadata: Stats, expectedUid: number, expectedBytes?: number): void {
+  if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.nlink !== 1 || metadata.uid !== expectedUid
+    || (metadata.mode & 0o777) !== 0o600
+    || (expectedBytes !== undefined && metadata.size !== expectedBytes)) {
+    throw new Error("Control-plane backup archive is not a trusted regular file");
+  }
+}
+
+function reserveBackupArchive(archivePath: string): number {
+  const descriptor = openSync(
+    archivePath,
+    fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_RDWR | fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    assertBackupArchive(fstatSync(descriptor), process.getuid?.() ?? 0, 0);
+    return descriptor;
+  } catch (error: unknown) {
+    closeSync(descriptor);
+    throw error;
+  }
+}
+
+function openBackupArchive(archivePath: string, expectedUid: number): number {
+  const pathMetadata = lstatSync(archivePath);
+  assertBackupArchive(pathMetadata, expectedUid);
+  const descriptor = openSync(archivePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const descriptorMetadata = fstatSync(descriptor);
+    assertBackupArchive(descriptorMetadata, expectedUid);
+    if (descriptorMetadata.dev !== pathMetadata.dev || descriptorMetadata.ino !== pathMetadata.ino) {
+      throw new Error("Control-plane backup archive identity changed");
+    }
+    if (descriptorMetadata.size <= 0) throw new Error("Control-plane backup archive is empty");
+    return descriptor;
+  } catch (error: unknown) {
+    closeSync(descriptor);
+    throw error;
+  }
+}
+
+function assertStableBackupArchive(archivePath: string, descriptor: number): void {
+  const opened = fstatSync(descriptor);
+  const current = lstatSync(archivePath);
+  assertBackupArchive(opened, process.getuid?.() ?? 0);
+  assertBackupArchive(current, process.getuid?.() ?? 0);
+  if (opened.dev !== current.dev || opened.ino !== current.ino || opened.size !== current.size
+    || opened.mtimeMs !== current.mtimeMs || opened.ctimeMs !== current.ctimeMs) {
+    throw new Error("Control-plane backup archive changed during verification");
+  }
+}
+
+function completedTimestamp(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+function retentionCandidates(root: string, currentId: string): string[] {
+  const backupIds = readdirSync(root).filter((entry) => BACKUP_ID_PATTERN.test(entry)).sort().reverse();
+  const retainedIds = new Set([
+    currentId,
+    ...backupIds.filter((backupId) => backupId !== currentId).slice(0, BACKUP_LIMIT - 1),
+  ]);
+  return backupIds.filter((backupId) => !retainedIds.has(backupId));
+}
+
+function storedReceipt(directory: string, backupId: string): { bytes: number; sha256: string } {
+  const currentUid = process.getuid?.() ?? 0;
+  const receiptPath = join(directory, "receipt.json");
+  const pathMetadata = lstatSync(receiptPath);
+  assertBackupArchive(pathMetadata, currentUid);
+  if (pathMetadata.size <= 0 || pathMetadata.size > MAX_RECEIPT_BYTES) {
+    throw new Error("Control-plane backup receipt size is invalid");
+  }
+  const descriptor = openSync(receiptPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  try {
+    const opened = fstatSync(descriptor);
+    assertBackupArchive(opened, currentUid, pathMetadata.size);
+    if (opened.dev !== pathMetadata.dev || opened.ino !== pathMetadata.ino) {
+      throw new Error("Control-plane backup receipt identity changed");
+    }
+    const parsed = JSON.parse(readFileSync(descriptor, "utf8")) as unknown;
+    const current = lstatSync(receiptPath);
+    assertBackupArchive(current, currentUid, opened.size);
+    if (current.dev !== opened.dev || current.ino !== opened.ino
+      || current.mtimeMs !== opened.mtimeMs || current.ctimeMs !== opened.ctimeMs) {
+      throw new Error("Control-plane backup receipt changed while it was read");
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("Control-plane backup receipt is invalid");
+    }
+    const receipt = parsed as Record<string, unknown>;
+    if (receipt.schema !== "supacloud.control-plane-upgrade-safety.v1"
+      || receipt.backup_id !== backupId
+      || receipt.backup_directory !== directory
+      || !Number.isSafeInteger(receipt.bytes) || Number(receipt.bytes) <= 0
+      || typeof receipt.sha256 !== "string" || !/^[0-9a-f]{64}$/.test(receipt.sha256)) {
+      throw new Error("Control-plane backup receipt does not match its directory");
+    }
+    return { bytes: Number(receipt.bytes), sha256: receipt.sha256 };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+async function assertTrustedStoredBackup(
+  root: string,
+  backupId: string,
+  operations: ControlPlaneBackupOperations,
+): Promise<void> {
+  const directory = join(root, backupId);
+  assertPrivateDirectory(directory, process.getuid?.() ?? 0);
+  if (readdirSync(directory).sort().join("\0") !== "control-plane.dump\0receipt.json") {
+    throw new Error("Control-plane backup directory contents are not trusted");
+  }
+  const receipt = storedReceipt(directory, backupId);
+  const archivePath = join(directory, "control-plane.dump");
+  const descriptor = openBackupArchive(archivePath, process.getuid?.() ?? 0);
+  try {
+    if (fstatSync(descriptor).size !== receipt.bytes || fileSha256(descriptor, receipt.bytes) !== receipt.sha256) {
+      throw new Error("Control-plane backup archive does not match its receipt");
+    }
+    if (await operations.run({ args: verifyArguments(), stdin: descriptor }) !== 0) {
+      throw new Error("Control-plane retained backup catalog is invalid");
+    }
+    assertStableBackupArchive(archivePath, descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+async function retainRecentBackups(
+  operations: ControlPlaneBackupOperations,
+  currentId: string,
+): Promise<void> {
+  const candidates = retentionCandidates(operations.backupRoot, currentId);
+  for (const backupId of candidates) {
+    await assertTrustedStoredBackup(operations.backupRoot, backupId, operations);
+  }
+  for (const backupId of candidates) {
+    const directory = join(operations.backupRoot, backupId);
+    if (operations.remove) operations.remove(directory);
+    else rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+async function createControlPlaneBackup(
+  target: DatabaseTarget,
+  inspection: ControlPlaneInspection,
+  operations: ControlPlaneBackupOperations = defaultBackupOperations(),
+): Promise<ControlPlaneUpgradeSafetyEvidence> {
+  const backupId = `control-plane-${completedTimestamp(operations.now())}-${operations.randomId()}`;
+  const backupDirectory = createBackupDirectory(operations, backupId);
+  const archivePath = join(backupDirectory, "control-plane.dump");
+  let durableBackup = false;
+  try {
+    const backupIdentity = await operations.identity(BACKUP_USER);
+    const archiveDescriptor = reserveBackupArchive(archivePath);
+    let bytes: number;
+    let sha256: string;
+    try {
+      if (await operations.run({
+        args: dumpArguments(target, inspection, backupIdentity.uid, backupIdentity.gid),
+        env: { PGPASSWORD: target.password },
+        stdout: archiveDescriptor,
+      }) !== 0) throw new Error("Control-plane pg_dump failed");
+      fsyncSync(archiveDescriptor);
+      assertStableBackupArchive(archivePath, archiveDescriptor);
+      bytes = fstatSync(archiveDescriptor).size;
+      if (bytes <= 0) throw new Error("Control-plane backup archive is empty");
+      if (await operations.run({ args: verifyArguments(), stdin: archiveDescriptor }) !== 0) {
+        throw new Error("Control-plane backup archive verification failed");
+      }
+      sha256 = fileSha256(archiveDescriptor, bytes);
+      assertStableBackupArchive(archivePath, archiveDescriptor);
+    } finally {
+      closeSync(archiveDescriptor);
+    }
+    const evidence: ControlPlaneUpgradeSafetyEvidence = {
+      schema: "supacloud.control-plane-upgrade-safety.v1",
+      backup_id: backupId,
+      backup_directory: backupDirectory,
+      bytes,
+      candidate_counts: inspection.candidateCounts,
+      completed_at: operations.now().toISOString(),
+      current_key_checkpoint_present: inspection.checkpointPresent,
+      sha256,
+    };
+    const receiptPath = join(backupDirectory, "receipt.json");
+    writeFileSync(receiptPath, `${JSON.stringify(evidence)}\n`, { flag: "wx", mode: 0o600 });
+    syncPath(receiptPath);
+    syncPath(backupDirectory, true);
+    syncPath(operations.backupRoot, true);
+    durableBackup = true;
+    await retainRecentBackups(operations, backupId);
+    syncPath(operations.backupRoot, true);
+    return evidence;
+  } catch (error: unknown) {
+    if (!durableBackup) rmSync(backupDirectory, { force: true, recursive: true });
+    throw error;
+  }
+}
+
+function defaultSafetyOperations(): ControlPlaneSafetyOperations {
+  return {
+    backup: (target, inspection) => createControlPlaneBackup(target, inspection),
+    withInspection: withControlPlaneInspection,
+  };
+}
+
+export async function prepareControlPlaneUpgradeSafety(
+  databaseUrl: string,
+  currentKey: string,
+  operations: ControlPlaneSafetyOperations = defaultSafetyOperations(),
+): Promise<ControlPlaneUpgradeSafetyEvidence> {
+  return withControlPlaneUpgradeSafety(databaseUrl, currentKey, async () => {}, operations);
+}
+
+export async function withControlPlaneUpgradeSafety(
+  databaseUrl: string,
+  currentKey: string,
+  operation: (lease: ControlPlaneUpgradeSafetyLease) => Promise<void>,
+  operations: ControlPlaneSafetyOperations = defaultSafetyOperations(),
+): Promise<ControlPlaneUpgradeSafetyEvidence> {
+  const target = databaseTarget(databaseUrl);
+  return operations.withInspection(databaseUrl, currentKey, async (inspection) => {
+    if (inspection.databaseTargetFingerprint !== databaseTargetFingerprint(target)) {
+      throw new Error("Control-plane database identity changed before backup");
+    }
+    const evidence = await operations.backup(target, inspection);
+    await operation({
+      databaseFingerprint: inspection.databaseFingerprint,
+      evidence,
+      snapshotId: inspection.snapshotId,
+    });
+    return evidence;
+  });
+}
+
+export const controlPlaneUpgradeSafetyInternals = {
+  createControlPlaneBackup,
+  databaseTargetFingerprint,
+  databaseTarget,
+  dumpArguments,
+  verifyArguments,
+};

--- a/packages/management-api/src/db/control-plane-database-identity.ts
+++ b/packages/management-api/src/db/control-plane-database-identity.ts
@@ -1,0 +1,157 @@
+import type { SQL, TransactionSQL } from "bun";
+import { createHash } from "node:crypto";
+
+export const CONTROL_PLANE_DATABASE_FINGERPRINT_ENV =
+  "SUPACLOUD_EXPECTED_CONTROL_PLANE_DATABASE_FINGERPRINT";
+export const CONTROL_PLANE_DATABASE_SNAPSHOT_ENV =
+  "SUPACLOUD_EXPECTED_CONTROL_PLANE_DATABASE_SNAPSHOT";
+export const CONTROL_PLANE_DATABASE_GUARD_EXIT_CODE = 78;
+
+const DATABASE_FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/;
+const SYSTEM_IDENTIFIER_PATTERN = /^\d{1,20}$/;
+const DATABASE_OID_PATTERN = /^[1-9]\d{0,9}$/;
+const SNAPSHOT_ID_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{8}-\d+$/i;
+
+export type ControlPlaneDatabaseIdentity = {
+  systemIdentifier: string;
+  databaseOid: string;
+  databaseName: string;
+  databaseOwner: string;
+};
+
+export class ControlPlaneDatabaseGuardError extends Error {
+  override readonly name = "ControlPlaneDatabaseGuardError";
+}
+
+type ControlPlaneDatabaseGuard = {
+  fingerprint: string;
+  snapshot: string;
+};
+
+function postgresIdentifier(rawIdentifier: unknown, identifierField: string): string {
+  if (typeof rawIdentifier !== "string"
+    || rawIdentifier.length === 0
+    || Buffer.byteLength(rawIdentifier, "utf8") > 63
+    || /[\u0000-\u001f\u007f]/u.test(rawIdentifier)) {
+    throw new Error(`Control-plane database ${identifierField} is invalid`);
+  }
+  return rawIdentifier;
+}
+
+export function controlPlaneDatabaseFingerprint(identity: ControlPlaneDatabaseIdentity): string {
+  return createHash("sha256")
+    .update("supacloud.control-plane-database-identity.v1\0")
+    .update([
+      identity.systemIdentifier,
+      identity.databaseOid,
+      identity.databaseName,
+      identity.databaseOwner,
+    ].join("\0"))
+    .digest("hex");
+}
+
+export async function inspectControlPlaneDatabaseIdentity(
+  database: SQL,
+): Promise<ControlPlaneDatabaseIdentity> {
+  const [row] = await database`
+    SELECT (pg_control_system()).system_identifier::text AS system_identifier,
+           database.oid::text AS database_oid,
+           database.datname AS database_name,
+           pg_get_userbyid(database.datdba) AS database_owner
+    FROM pg_database AS database
+    WHERE database.datname = current_database()
+  `;
+  if (!row
+    || typeof row.system_identifier !== "string"
+    || !SYSTEM_IDENTIFIER_PATTERN.test(row.system_identifier)
+    || typeof row.database_oid !== "string"
+    || !DATABASE_OID_PATTERN.test(row.database_oid)) {
+    throw new Error("Control-plane physical database identity is unavailable");
+  }
+  return {
+    systemIdentifier: row.system_identifier,
+    databaseOid: row.database_oid,
+    databaseName: postgresIdentifier(row.database_name, "name"),
+    databaseOwner: postgresIdentifier(row.database_owner, "owner"),
+  };
+}
+
+export function parseExpectedControlPlaneDatabaseFingerprint(rawFingerprint: string): string {
+  if (!DATABASE_FINGERPRINT_PATTERN.test(rawFingerprint)) {
+    throw new Error(`${CONTROL_PLANE_DATABASE_FINGERPRINT_ENV} must be a lowercase SHA-256 fingerprint`);
+  }
+  return rawFingerprint;
+}
+
+export function parseExpectedControlPlaneDatabaseSnapshot(rawSnapshot: string): string {
+  if (!SNAPSHOT_ID_PATTERN.test(rawSnapshot)) {
+    throw new Error(`${CONTROL_PLANE_DATABASE_SNAPSHOT_ENV} must be a PostgreSQL snapshot identifier`);
+  }
+  return rawSnapshot;
+}
+
+function expectedControlPlaneDatabaseGuard(
+  expectedFingerprint: string | undefined,
+  expectedSnapshot: string | undefined,
+): ControlPlaneDatabaseGuard | null {
+  if (expectedFingerprint === undefined && expectedSnapshot === undefined) return null;
+  if (expectedFingerprint === undefined || expectedSnapshot === undefined) {
+    throw new ControlPlaneDatabaseGuardError("Control-plane upgrade database identity guard is incomplete");
+  }
+  try {
+    return {
+      fingerprint: parseExpectedControlPlaneDatabaseFingerprint(expectedFingerprint),
+      snapshot: parseExpectedControlPlaneDatabaseSnapshot(expectedSnapshot),
+    };
+  } catch (error: unknown) {
+    throw new ControlPlaneDatabaseGuardError("Control-plane upgrade database identity guard is invalid", {
+      cause: error,
+    });
+  }
+}
+
+async function assertLiveControlPlaneDatabaseGuard(
+  database: SQL,
+  guard: ControlPlaneDatabaseGuard,
+): Promise<void> {
+  try {
+    await database.unsafe("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+    await database.unsafe(`SET TRANSACTION SNAPSHOT '${guard.snapshot}'`);
+    const actual = controlPlaneDatabaseFingerprint(await inspectControlPlaneDatabaseIdentity(database));
+    if (actual !== guard.fingerprint) {
+      throw new ControlPlaneDatabaseGuardError(
+        "Control-plane database identity does not match the verified upgrade backup",
+      );
+    }
+  } catch (error: unknown) {
+    if (error instanceof ControlPlaneDatabaseGuardError) throw error;
+    throw new ControlPlaneDatabaseGuardError(
+      "Control-plane database identity guard could not verify the live backup snapshot",
+      { cause: error },
+    );
+  }
+}
+
+export async function assertExpectedControlPlaneDatabaseIdentity(
+  database: SQL,
+  expectedFingerprint = process.env[CONTROL_PLANE_DATABASE_FINGERPRINT_ENV],
+  expectedSnapshot = process.env[CONTROL_PLANE_DATABASE_SNAPSHOT_ENV],
+): Promise<void> {
+  const guard = expectedControlPlaneDatabaseGuard(expectedFingerprint, expectedSnapshot);
+  if (guard) {
+    await database.begin((transaction) => assertLiveControlPlaneDatabaseGuard(transaction, guard));
+  }
+}
+
+export async function withExpectedControlPlaneDatabaseTransaction<T>(
+  database: SQL,
+  operation: (transaction: TransactionSQL) => Promise<T>,
+  expectedFingerprint = process.env[CONTROL_PLANE_DATABASE_FINGERPRINT_ENV],
+  expectedSnapshot = process.env[CONTROL_PLANE_DATABASE_SNAPSHOT_ENV],
+): Promise<T> {
+  const guard = expectedControlPlaneDatabaseGuard(expectedFingerprint, expectedSnapshot);
+  return database.begin(async (transaction) => {
+    if (guard) await assertLiveControlPlaneDatabaseGuard(transaction, guard);
+    return operation(transaction);
+  });
+}

--- a/packages/management-api/src/db/init.ts
+++ b/packages/management-api/src/db/init.ts
@@ -1,6 +1,6 @@
 import { config } from "../config";
 import { logger } from "../utils/logger";
-import { SQL } from "bun";
+import { SQL, type TransactionSQL } from "bun";
 import {
   generatePublishableApiKey,
   generateSecretApiKey,
@@ -22,6 +22,7 @@ import { migrateAuditChainSequences } from "./audit-chain-migration";
 import { migrateProjectMutationJournal } from "./project-mutation-migration";
 import { migrateLegacyEncryptedSecretsInTransaction } from "./secret-key-migration";
 import { GOTRUE_USER_ID_POSTGRES_PATTERN } from "../utils/project-user-lifecycle";
+import { withExpectedControlPlaneDatabaseTransaction } from "./control-plane-database-identity";
 
 function sqlStringLiteral(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
@@ -350,7 +351,7 @@ export async function initDatabase() {
   `;
 
   // Use explicit config instead of URL to ensure correct database name
-  const sql = new SQL({
+  const sqlPool = new SQL({
     hostname,
     port: parseInt(port, 10),
     database,
@@ -358,22 +359,25 @@ export async function initDatabase() {
     password,
     max: 2,
   });
+  // One explicit transaction keeps guarded upgrades on one PostgreSQL backend through pooling proxies.
+  const sqlConnection = await sqlPool.reserve();
+  let sql: SQL = sqlConnection;
 
   async function runMigrationStatement(statement: string, options?: { swallowError?: boolean; description?: string }) {
-    try {
+    if (!options?.swallowError) {
       await sql.unsafe(statement);
-    } catch (error: any) {
-      if (options?.swallowError) {
-        logger.warn(`Skipped optional migration${options.description ? ` (${options.description})` : ""}: ${error?.message || String(error)}`);
-        return;
-      }
-      throw error;
+      return;
+    }
+    try {
+      await (sql as TransactionSQL).savepoint((migration) => migration.unsafe(statement));
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`Skipped optional migration${options.description ? ` (${options.description})` : ""}: ${message}`);
     }
   }
 
-  try {
-    await sql`SELECT 1`;
-    logger.info("Connected to database");
+  async function initializeControlPlaneSchema(transaction: TransactionSQL): Promise<void> {
+    sql = transaction;
 
     // Check current database
     const [dbInfo] =
@@ -740,7 +744,7 @@ export async function initDatabase() {
     }
     logger.info("Schema migrations applied.");
 
-    await sql.begin(async (transaction) => {
+    await transaction.savepoint(async (transaction) => {
       await ensurePlatformV2Schema(transaction);
       await migrateProjectMutationJournal(transaction);
       await migrateAuditChainSequences(transaction);
@@ -874,13 +878,20 @@ export async function initDatabase() {
         );
       }
     });
+  }
+
+  try {
+    await sql`SELECT 1`;
+    logger.info("Connected to database");
+    await withExpectedControlPlaneDatabaseTransaction(sqlConnection, initializeControlPlaneSchema);
   } catch (error: unknown) {
     logger.error("Failed to initialize database:", {
       error: error instanceof Error ? error.message : String(error),
     });
     throw error;
   } finally {
-    await sql.close();
+    sqlConnection.release();
+    await sqlPool.close();
   }
 }
 

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -37,6 +37,10 @@ import { studioAuthRoutes } from "./routes/studio-auth";
 import { caddyAskRoutes } from "./routes/caddy-ask";
 import { validationErrorResponse } from "./utils/http-validation";
 import { withLogicalBackupMutationTimeoutController } from "./utils/logical-backup-request-timeout";
+import {
+  CONTROL_PLANE_DATABASE_GUARD_EXIT_CODE,
+  ControlPlaneDatabaseGuardError,
+} from "./db/control-plane-database-identity";
 
 function getWebConsoleDir(): string {
   return resolveWebConsoleDir();
@@ -917,7 +921,9 @@ async function bootstrap() {
       logger.error("Failed to initialize database:", {
         error: err instanceof Error ? err.message : String(err),
       });
-      process.exit(1);
+      process.exit(err instanceof ControlPlaneDatabaseGuardError
+        ? CONTROL_PLANE_DATABASE_GUARD_EXIT_CODE
+        : 1);
     }
   } else if (args.includes("install") || args.includes("--install")) {
     const { runInstall } = await import("./install");

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -27,6 +27,12 @@ import { logger } from "./utils/logger";
 import { WEB_CONSOLE_CURRENT_DIR } from "./utils/web-console-path";
 import { hasSecretEncryptionCheckpoint } from "./db/secret-key-migration";
 import {
+    CONTROL_PLANE_DATABASE_GUARD_EXIT_CODE,
+    CONTROL_PLANE_DATABASE_FINGERPRINT_ENV,
+    CONTROL_PLANE_DATABASE_SNAPSHOT_ENV,
+    ControlPlaneDatabaseGuardError,
+} from "./db/control-plane-database-identity";
+import {
     RELEASE_REPOSITORY,
     RELEASE_SIGNER_WORKFLOW,
     RELEASE_SOURCE_REF,
@@ -42,6 +48,11 @@ import {
     SUPACLOUD_UPGRADE_LOCK_PATH,
 } from "./upgrade-lock";
 import { withSigstoreVerificationDirectory } from "./sigstore-trusted-root";
+import {
+    withControlPlaneUpgradeSafety,
+    type ControlPlaneUpgradeSafetyEvidence,
+    type ControlPlaneUpgradeSafetyLease,
+} from "./control-plane-upgrade-safety";
 import {
     EMBEDDED_SYSTEMD_UNIT_BROKER_SHA256,
     SYSTEMD_UNIT_BROKER_TARGET,
@@ -115,6 +126,7 @@ const OFFLINE_BUNDLE_ENDPOINT: GithubEndpoint = {
     label: "verified offline bundle",
     proxyPrefix: "",
 };
+const CONTROL_PLANE_SAFETY_PREFIX = "SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=";
 
 export type GithubEndpoint = {
     label: string;
@@ -536,8 +548,13 @@ export function verifyBackupPrivilegeDropPreflight(
 ): void {
     const setprivPath = ["/usr/bin/setpriv", "/bin/setpriv"].find(pathExists);
     const idPath = ["/usr/bin/id", "/bin/id"].find(pathExists);
+    const pgDumpPath = ["/usr/bin/pg_dump", "/usr/local/bin/pg_dump"].find(pathExists);
+    const pgRestorePath = ["/usr/bin/pg_restore", "/usr/local/bin/pg_restore"].find(pathExists);
+    const timeoutPath = ["/usr/bin/timeout", "/bin/timeout"].find(pathExists);
     if (!setprivPath) throw new Error("Management upgrade requires setpriv for backup privilege separation");
     if (!idPath) throw new Error("Management upgrade requires id for backup account resolution");
+    if (!pgDumpPath || !pgRestorePath) throw new Error("Management upgrade requires pg_dump and pg_restore");
+    if (!timeoutPath) throw new Error("Management upgrade requires timeout for bounded backup commands");
 }
 
 export async function verifyActivatedManagementBinary(
@@ -1840,6 +1857,9 @@ async function runInitDb(binaryPath: string, env: Record<string, string | undefi
         env,
     });
     const exitCode = await proc.exited;
+    if (exitCode === CONTROL_PLANE_DATABASE_GUARD_EXIT_CODE) {
+        throw new ControlPlaneDatabaseGuardError("Staged init-db rejected the control-plane database identity guard");
+    }
     if (exitCode !== 0) {
         throw new Error(`supacloud --init-db exited with code ${exitCode}`);
     }
@@ -1924,6 +1944,11 @@ async function checkpointExists(databaseUrl: string, encryptionKey: string): Pro
 
 export type StagedMigrationOperations = {
     captureRuntimeEnv: () => FileState;
+    withSafety: (
+        databaseUrl: string,
+        encryptionKey: string,
+        operation: (lease: ControlPlaneUpgradeSafetyLease) => Promise<void>,
+    ) => Promise<ControlPlaneUpgradeSafetyEvidence>;
     stopService: () => Promise<void>;
     persistSecrets: (secrets: Record<string, string>) => void;
     runInit: (binaryPath: string, env: Record<string, string | undefined>) => Promise<void>;
@@ -1936,6 +1961,7 @@ export type StagedMigrationOperations = {
 function stagedMigrationOperations(): StagedMigrationOperations {
     return {
         captureRuntimeEnv: () => captureFileState(managementEnvFile()),
+        withSafety: withControlPlaneUpgradeSafety,
         stopService: () => stopManagementService(),
         persistSecrets: persistUpgradeRuntimeSecrets,
         runInit: runInitDb,
@@ -1960,19 +1986,53 @@ export async function runStagedDatabaseMigration(
     binaryPath: string,
     preparedSecrets: PreparedUpgradeSecrets,
     operations: StagedMigrationOperations = stagedMigrationOperations(),
-): Promise<void> {
+): Promise<ControlPlaneUpgradeSafetyEvidence> {
     const databaseUrl = preparedSecrets.runtimeEnv.DATABASE_URL;
     if (!databaseUrl) throw new Error("DATABASE_URL is required for secret migration checkpoint verification");
     const encryptionKey = preparedSecrets.runtimeSecretsToPersist.SECRETS_ENCRYPTION_KEY;
     const runtimeEnvState = operations.captureRuntimeEnv();
     await operations.stopService();
+    let migrationStarted = false;
     try {
-        operations.persistSecrets(preparedSecrets.runtimeSecretsToPersist);
-        await operations.runInit(binaryPath, preparedSecrets.runtimeEnv);
-        if (!(await operations.hasCheckpoint(databaseUrl, encryptionKey))) {
-            throw new Error("Secret migration checkpoint is missing after init-db");
-        }
+        const safetyEvidence = await operations.withSafety(databaseUrl, encryptionKey, async (lease) => {
+            migrationStarted = true;
+            operations.persistSecrets(preparedSecrets.runtimeSecretsToPersist);
+            await operations.runInit(binaryPath, {
+                ...preparedSecrets.runtimeEnv,
+                [CONTROL_PLANE_DATABASE_FINGERPRINT_ENV]: lease.databaseFingerprint,
+                [CONTROL_PLANE_DATABASE_SNAPSHOT_ENV]: lease.snapshotId,
+            });
+            if (!(await operations.hasCheckpoint(databaseUrl, encryptionKey))) {
+                throw new Error("Secret migration checkpoint is missing after init-db");
+            }
+        });
+        return safetyEvidence;
     } catch (migrationError: unknown) {
+        if (!migrationStarted) {
+            try {
+                await restoreRuntimeAfterMigrationFailure(runtimeEnvState, false, operations);
+            } catch (recoveryError: unknown) {
+                throw new AggregateError(
+                    [migrationError, recoveryError],
+                    "Control-plane backup failed and the Management service could not be restored",
+                );
+            }
+            throw migrationError;
+        }
+        if (migrationError instanceof ControlPlaneDatabaseGuardError) {
+            try {
+                operations.restoreRuntimeEnv(runtimeEnvState);
+            } catch (recoveryError: unknown) {
+                throw new AggregateError(
+                    [migrationError, recoveryError],
+                    "Control-plane database guard failed and runtime secrets could not be restored; the service remains stopped",
+                );
+            }
+            throw new Error(
+                "Control-plane database guard failed; runtime secrets were restored and the service remains stopped",
+                { cause: migrationError },
+            );
+        }
         let rotationComplete: boolean;
         try {
             rotationComplete = await operations.hasCheckpoint(databaseUrl, encryptionKey);
@@ -2468,6 +2528,7 @@ type UpgradeExecutionState = {
     activatedEdgeRuntimeMode: EdgeRuntimeMode | null;
     activation: UpgradeActivationState | null;
     committed: boolean;
+    controlPlaneSafety: ControlPlaneUpgradeSafetyEvidence | null;
     downloadEndpointLabel: string;
     edgeRuntimeEndpointLabel: string | null;
     preflightPostgrestLauncher: PostgrestLauncherPreflight | undefined;
@@ -2801,6 +2862,7 @@ function createUpgradeExecutionState(plan: UpgradeReleasePlan): UpgradeExecution
         activatedEdgeRuntimeMode: null,
         activation: null,
         committed: false,
+        controlPlaneSafety: null,
         downloadEndpointLabel: plan.endpoint.label,
         edgeRuntimeEndpointLabel: null,
         preflightPostgrestLauncher: undefined,
@@ -2944,8 +3006,11 @@ async function stageUpgradeArtifacts(context: UpgradeExecutionContext): Promise<
 async function migrateUpgradeMetadata(context: UpgradeExecutionContext): Promise<void> {
     const stagedManagement = context.state.stagedManagement;
     if (!stagedManagement) throw new Error("Upgrade binary was not staged");
-    context.spinner.start("Applying backward-compatible metadata database migrations with the staged binary");
-    await runStagedDatabaseMigration(stagedManagement.path, context.preparedSecrets);
+    context.spinner.start("Creating a verified control-plane backup before applying metadata migrations");
+    context.state.controlPlaneSafety = await runStagedDatabaseMigration(
+        stagedManagement.path,
+        context.preparedSecrets,
+    );
 }
 
 async function activateUpgradeArtifacts(context: UpgradeExecutionContext): Promise<void> {
@@ -3214,7 +3279,14 @@ function upgradeSuccessMessage(context: UpgradeExecutionContext): string {
     const edgeSummary = plan.edgeRuntime
         ? `; Edge Runtime upgraded to ${plan.edgeRuntime.release.tag_name} at ${plan.edgeRuntime.targetPath} (${state.edgeRuntimeEndpointLabel})`
         : "; Edge Runtime was not upgraded";
-    return `SupaCloud upgraded to ${plan.remoteVersion} via ${plan.binaryName} (${state.downloadEndpointLabel})${webSummary}${edgeSummary}`;
+    const safetySummary = state.controlPlaneSafety
+        ? `; control-plane safety ${JSON.stringify(state.controlPlaneSafety)}`
+        : "";
+    return `SupaCloud upgraded to ${plan.remoteVersion} via ${plan.binaryName} (${state.downloadEndpointLabel})${webSummary}${edgeSummary}${safetySummary}`;
+}
+
+export function controlPlaneSafetyReceiptLine(evidence: ControlPlaneUpgradeSafetyEvidence): string {
+    return `${CONTROL_PLANE_SAFETY_PREFIX}${JSON.stringify(evidence)}`;
 }
 
 export async function runUpgrade(options: RunUpgradeOptions = {}) {
@@ -3244,6 +3316,10 @@ export async function runUpgrade(options: RunUpgradeOptions = {}) {
         } finally {
             upgradeLock.release();
         }
+        if (!executionContext.state.controlPlaneSafety) {
+            throw new Error("Control-plane upgrade safety evidence is missing after transaction commit");
+        }
+        console.log(controlPlaneSafetyReceiptLine(executionContext.state.controlPlaneSafety));
         p.outro(upgradeSuccessMessage(executionContext));
     } catch (error: unknown) {
         s.stop(formatUpgradeFailure(error, upgradeRecoveryPaths(executionContext?.state ?? null)));

--- a/packages/management-api/tests/unit/control-plane-database-identity.test.ts
+++ b/packages/management-api/tests/unit/control-plane-database-identity.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import type { SQL } from "bun";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  assertExpectedControlPlaneDatabaseIdentity,
+  controlPlaneDatabaseFingerprint,
+  inspectControlPlaneDatabaseIdentity,
+  parseExpectedControlPlaneDatabaseFingerprint,
+  parseExpectedControlPlaneDatabaseSnapshot,
+  withExpectedControlPlaneDatabaseTransaction,
+  type ControlPlaneDatabaseIdentity,
+} from "../../src/db/control-plane-database-identity";
+
+const identity: ControlPlaneDatabaseIdentity = {
+  systemIdentifier: "7627039817244368896",
+  databaseOid: "16384",
+  databaseName: "supacloud_meta",
+  databaseOwner: "postgres",
+};
+const snapshotId = "00000003-0000001B-1";
+
+function databaseReturning(row: Record<string, unknown>, snapshotAvailable = true): SQL {
+  const transaction = Object.assign(async () => [row], {
+    unsafe: async (statement: string) => {
+      if (statement.startsWith("SET TRANSACTION SNAPSHOT") && !snapshotAvailable) {
+        throw new Error("snapshot is not valid on this server");
+      }
+      return [];
+    },
+  });
+  return Object.assign(async () => [row], {
+    begin: async (operation: (connection: SQL) => Promise<unknown>) => operation(transaction as unknown as SQL),
+  }) as unknown as SQL;
+}
+
+describe("control-plane physical database identity", () => {
+  test("derives a stable fingerprint from cluster and database identity", () => {
+    const fingerprint = controlPlaneDatabaseFingerprint(identity);
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(controlPlaneDatabaseFingerprint({ ...identity })).toBe(fingerprint);
+    expect(controlPlaneDatabaseFingerprint({ ...identity, databaseOid: "16385" })).not.toBe(fingerprint);
+    expect(controlPlaneDatabaseFingerprint({ ...identity, systemIdentifier: "7627039817244368897" }))
+      .not.toBe(fingerprint);
+  });
+
+  test("accepts identity A and rejects a migration connection to identity B", async () => {
+    const identityA = databaseReturning({
+      system_identifier: identity.systemIdentifier,
+      database_oid: identity.databaseOid,
+      database_name: identity.databaseName,
+      database_owner: identity.databaseOwner,
+    });
+    expect(await inspectControlPlaneDatabaseIdentity(identityA)).toEqual(identity);
+    await expect(assertExpectedControlPlaneDatabaseIdentity(
+      identityA,
+      controlPlaneDatabaseFingerprint(identity),
+      snapshotId,
+    )).resolves.toBeUndefined();
+    const identityB = databaseReturning({
+      system_identifier: "7627039817244368897",
+      database_oid: identity.databaseOid,
+      database_name: identity.databaseName,
+      database_owner: identity.databaseOwner,
+    });
+    await expect(assertExpectedControlPlaneDatabaseIdentity(
+      identityB,
+      controlPlaneDatabaseFingerprint(identity),
+      snapshotId,
+    ))
+      .rejects.toThrow("does not match the verified upgrade backup");
+  });
+
+  test("rejects a cloned node with the same static fingerprint but no live exporter snapshot", async () => {
+    const clonedNode = databaseReturning({
+      system_identifier: identity.systemIdentifier,
+      database_oid: identity.databaseOid,
+      database_name: identity.databaseName,
+      database_owner: identity.databaseOwner,
+    }, false);
+    await expect(assertExpectedControlPlaneDatabaseIdentity(
+      clonedNode,
+      controlPlaneDatabaseFingerprint(identity),
+      snapshotId,
+    )).rejects.toThrow("could not verify the live backup snapshot");
+  });
+
+  test("keeps the live snapshot guard and migration writes in one transaction", async () => {
+    const events: string[] = [];
+    const transaction = Object.assign(async () => {
+      events.push("identity");
+      return [{
+        system_identifier: identity.systemIdentifier,
+        database_oid: identity.databaseOid,
+        database_name: identity.databaseName,
+        database_owner: identity.databaseOwner,
+      }];
+    }, {
+      unsafe: async (statement: string) => {
+        events.push(statement.startsWith("SET TRANSACTION SNAPSHOT") ? "snapshot" : "isolation");
+        return [];
+      },
+    }) as unknown as SQL;
+    const database = Object.assign(async () => [], {
+      begin: async (operation: (connection: SQL) => Promise<unknown>) => {
+        events.push("begin");
+        const operationResult = await operation(transaction);
+        events.push("commit");
+        return operationResult;
+      },
+    }) as unknown as SQL;
+
+    await withExpectedControlPlaneDatabaseTransaction(database, async (migration) => {
+      expect(migration).toBe(transaction);
+      events.push("write");
+    }, controlPlaneDatabaseFingerprint(identity), snapshotId);
+
+    expect(events).toEqual(["begin", "isolation", "snapshot", "identity", "write", "commit"]);
+  });
+
+  test("runs all init-db writes inside the guarded transaction", () => {
+    const source = readFileSync(join(import.meta.dir, "../../src/db/init.ts"), "utf8");
+    const reserve = source.indexOf("const sqlConnection = await sqlPool.reserve()");
+    const initializer = source.indexOf("async function initializeControlPlaneSchema(transaction: TransactionSQL)");
+    const transaction = source.indexOf("sql = transaction", initializer);
+    const firstWrite = source.indexOf("await sql.unsafe(ddlQuery)");
+    const guard = source.indexOf(
+      "await withExpectedControlPlaneDatabaseTransaction(sqlConnection, initializeControlPlaneSchema)",
+    );
+    expect(reserve).toBeGreaterThan(0);
+    expect(initializer).toBeGreaterThan(reserve);
+    expect(transaction).toBeGreaterThan(initializer);
+    expect(firstWrite).toBeGreaterThan(transaction);
+    expect(guard).toBeGreaterThan(firstWrite);
+    expect(source).not.toContain("await sql.begin");
+    expect(source).toContain("sqlConnection.release()");
+  });
+
+  test("keeps standalone init-db compatible when no expected fingerprint is supplied", async () => {
+    let queried = false;
+    const database = (async () => {
+      queried = true;
+      throw new Error("must not query without an upgrade guard");
+    }) as unknown as SQL;
+    await expect(assertExpectedControlPlaneDatabaseIdentity(database, undefined)).resolves.toBeUndefined();
+    expect(queried).toBe(false);
+  });
+
+  test("rejects malformed expected fingerprints before reading the database", async () => {
+    let queried = false;
+    const database = (async () => {
+      queried = true;
+      return [];
+    }) as unknown as SQL;
+    for (const invalid of ["", "A".repeat(64), "0".repeat(63), "0".repeat(65)]) {
+      expect(() => parseExpectedControlPlaneDatabaseFingerprint(invalid)).toThrow("lowercase SHA-256");
+      await expect(assertExpectedControlPlaneDatabaseIdentity(database, invalid, snapshotId))
+        .rejects.toThrow("identity guard is invalid");
+    }
+    expect(queried).toBe(false);
+  });
+
+  test("rejects incomplete and malformed snapshot guards before reading the database", async () => {
+    let queried = false;
+    const database = Object.assign(async () => {
+      queried = true;
+      return [];
+    }, {
+      begin: async () => {
+        queried = true;
+      },
+    }) as unknown as SQL;
+    const fingerprint = controlPlaneDatabaseFingerprint(identity);
+    await expect(assertExpectedControlPlaneDatabaseIdentity(database, fingerprint, "invalid"))
+      .rejects.toThrow("identity guard is invalid");
+    expect(() => parseExpectedControlPlaneDatabaseSnapshot("invalid"))
+      .toThrow("PostgreSQL snapshot identifier");
+    await expect(assertExpectedControlPlaneDatabaseIdentity(database, fingerprint, undefined))
+      .rejects.toThrow("identity guard is incomplete");
+    expect(queried).toBe(false);
+  });
+
+  test("rejects incomplete physical database identity rows", async () => {
+    await expect(inspectControlPlaneDatabaseIdentity(databaseReturning({
+      system_identifier: identity.systemIdentifier,
+      database_oid: "0",
+      database_name: identity.databaseName,
+      database_owner: identity.databaseOwner,
+    }))).rejects.toThrow("identity is unavailable");
+  });
+});

--- a/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
+++ b/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  controlPlaneUpgradeSafetyInternals,
+  prepareControlPlaneUpgradeSafety,
+  withControlPlaneUpgradeSafety,
+} from "../../src/control-plane-upgrade-safety";
+
+const databaseUrl = "postgresql://postgres:private-password@127.0.0.1:5432/supacloud_meta";
+const target = controlPlaneUpgradeSafetyInternals.databaseTarget(databaseUrl);
+const inspection = {
+  candidateCounts: {
+    deprecated_webhook_secrets: 0,
+    legacy_deployment_history_rows: 0,
+    legacy_project_config_rows: 0,
+    opaque_key_backfill_projects: 0,
+    stored_secret_values: 4,
+  },
+  checkpointPresent: true,
+  databaseFingerprint: "b".repeat(64),
+  databaseTargetFingerprint: controlPlaneUpgradeSafetyInternals.databaseTargetFingerprint(target),
+  snapshotId: "00000003-0000001B-1",
+};
+
+function writeTrustedBackup(backupRoot: string, backupId: string): void {
+  const backupDirectory = join(backupRoot, backupId);
+  const archive = "verified-historical-control-plane-dump";
+  mkdirSync(backupDirectory, { mode: 0o700 });
+  writeFileSync(join(backupDirectory, "control-plane.dump"), archive, { mode: 0o600 });
+  writeFileSync(join(backupDirectory, "receipt.json"), `${JSON.stringify({
+    schema: "supacloud.control-plane-upgrade-safety.v1",
+    backup_id: backupId,
+    backup_directory: backupDirectory,
+    bytes: Buffer.byteLength(archive),
+    candidate_counts: inspection.candidateCounts,
+    completed_at: "2026-08-18T00:00:00.000Z",
+    current_key_checkpoint_present: true,
+    sha256: createHash("sha256").update(archive).digest("hex"),
+  })}\n`, { mode: 0o600 });
+}
+
+describe("control-plane upgrade safety", () => {
+  test("creates a private verified dump receipt without putting the password in command arguments", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-backup-"));
+    chmodSync(backupRoot, 0o700);
+    const commands: string[][] = [];
+    try {
+      const evidence = await controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000001",
+        run: async ({ args, env, stdout }) => {
+          commands.push(args);
+          if (args.some((argument) => argument.endsWith("/pg_dump"))) {
+            expect(env?.PGPASSWORD).toBe("private-password");
+            expect(Object.keys(env || {})).toEqual(["PGPASSWORD"]);
+            writeFileSync(stdout!, "verified-control-plane-dump");
+          }
+          return 0;
+        },
+      });
+
+      expect(commands.flat()).not.toContain("private-password");
+      expect(commands[0]).toContain("--reuid");
+      expect(commands[0]).toContain("--snapshot");
+      expect(commands[0]).toContain(inspection.snapshotId);
+      expect(commands[1]?.some((argument) => argument.endsWith("/pg_restore"))).toBe(true);
+      expect(commands[1]).toContain("--list");
+      expect(evidence).toMatchObject({
+        schema: "supacloud.control-plane-upgrade-safety.v1",
+        backup_id: "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000001",
+        bytes: 27,
+        candidate_counts: inspection.candidateCounts,
+        current_key_checkpoint_present: true,
+      });
+      expect(evidence.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(statSync(join(evidence.backup_directory, "control-plane.dump")).mode & 0o777).toBe(0o600);
+      expect(statSync(join(evidence.backup_directory, "receipt.json")).mode & 0o777).toBe(0o600);
+      expect(JSON.parse(readFileSync(join(evidence.backup_directory, "receipt.json"), "utf8"))).toEqual(evidence);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("removes partial backup state when archive verification fails", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-backup-failure-"));
+    chmodSync(backupRoot, 0o700);
+    try {
+      await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000002",
+        run: async ({ args, stdout }) => {
+          if (args.some((argument) => argument.endsWith("/pg_dump"))) {
+            writeFileSync(stdout!, "incomplete");
+          }
+          return args.some((argument) => argument.endsWith("/pg_restore")) ? 1 : 0;
+        },
+      })).rejects.toThrow("archive verification failed");
+      expect(readdirSync(backupRoot)).toEqual([]);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("lets the postgres identity write only through the inherited root-owned archive descriptor", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-descriptor-"));
+    chmodSync(backupRoot, 0o700);
+    let dumpArguments: string[] = [];
+    try {
+      const evidence = await controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: 65_534, gid: 65_534 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000007",
+        run: async ({ args, stdout }) => {
+          if (args.some((argument) => argument.endsWith("/pg_dump"))) {
+            dumpArguments = args;
+            writeFileSync(stdout!, "descriptor-only-dump");
+          }
+          return 0;
+        },
+      });
+      expect(dumpArguments).toContain("65534");
+      expect(dumpArguments.some((argument) => argument.startsWith(backupRoot))).toBe(false);
+      expect(statSync(backupRoot).mode & 0o777).toBe(0o700);
+      expect(statSync(evidence.backup_directory).mode & 0o777).toBe(0o700);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects an empty archive before catalog verification", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-empty-"));
+    chmodSync(backupRoot, 0o700);
+    let catalogChecks = 0;
+    try {
+      await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000003",
+        run: async ({ args }) => {
+          if (!args.some((argument) => argument.endsWith("/pg_dump"))) {
+            catalogChecks += 1;
+          }
+          return 0;
+        },
+      })).rejects.toThrow("archive is empty");
+      expect(catalogChecks).toBe(0);
+      expect(readdirSync(backupRoot)).toEqual([]);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects symlink, directory, and multiply-linked dump outputs", async () => {
+    for (const archiveKind of ["symlink", "directory", "hardlink"] as const) {
+      const backupRoot = mkdtempSync(join(tmpdir(), `supacloud-control-plane-${archiveKind}-`));
+      chmodSync(backupRoot, 0o700);
+      try {
+        await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+          backupRoot,
+          identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+          now: () => new Date("2026-08-19T00:00:00.000Z"),
+          randomId: () => "00000000-0000-4000-8000-000000000004",
+          run: async ({ args, stdout }) => {
+            if (!args.some((argument) => argument.endsWith("/pg_dump"))) return 0;
+            writeFileSync(stdout!, "dump-written-only-to-reserved-descriptor");
+            const archivePath = join(
+              backupRoot,
+              "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000004",
+              "control-plane.dump",
+            );
+            rmSync(archivePath, { force: true, recursive: true });
+            if (archiveKind === "directory") mkdirSync(archivePath);
+            if (archiveKind === "symlink") {
+              const targetPath = join(backupRoot, "untrusted-target");
+              writeFileSync(targetPath, "not-a-dump", { mode: 0o600 });
+              symlinkSync(targetPath, archivePath);
+            }
+            if (archiveKind === "hardlink") {
+              const targetPath = join(backupRoot, "multiply-linked-target");
+              writeFileSync(targetPath, "not-a-dump", { mode: 0o600 });
+              linkSync(targetPath, archivePath);
+            }
+            return 0;
+          },
+        })).rejects.toThrow("trusted regular file");
+        expect(readdirSync(backupRoot).some((entry) => entry.startsWith("control-plane-"))).toBe(false);
+      } finally {
+        rmSync(backupRoot, { force: true, recursive: true });
+      }
+    }
+  });
+
+  test("retains the current backup and four newest trusted predecessors", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-retention-"));
+    chmodSync(backupRoot, 0o700);
+    const historicalIds = Array.from({ length: 6 }, (_, index) => (
+      `control-plane-20260818T00000${index}Z-00000000-0000-4000-8000-00000000000${index}`
+    ));
+    for (const backupId of historicalIds) writeTrustedBackup(backupRoot, backupId);
+    mkdirSync(join(backupRoot, "manual-keep"), { mode: 0o700 });
+    try {
+      const evidence = await controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000005",
+        run: async ({ args, stdout }) => {
+          if (args.some((argument) => argument.endsWith("/pg_dump"))) {
+            writeFileSync(stdout!, "verified-control-plane-dump");
+          }
+          return 0;
+        },
+      });
+      const retainedIds = readdirSync(backupRoot).filter((entry) => entry.startsWith("control-plane-"));
+      expect(retainedIds).toHaveLength(5);
+      expect(retainedIds).toContain(evidence.backup_id);
+      expect(retainedIds).toEqual(expect.arrayContaining(historicalIds.slice(-4)));
+      expect(readdirSync(backupRoot)).toContain("manual-keep");
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("refuses to remove an untrusted matching retention entry", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-retention-trust-"));
+    chmodSync(backupRoot, 0o700);
+    const targetDirectory = join(backupRoot, "manual-target");
+    mkdirSync(targetDirectory, { mode: 0o700 });
+    const untrustedId = "control-plane-20260817T000000Z-00000000-0000-4000-8000-000000000000";
+    symlinkSync(targetDirectory, join(backupRoot, untrustedId));
+    for (let index = 1; index <= 5; index += 1) {
+      writeTrustedBackup(
+        backupRoot,
+        `control-plane-20260818T00000${index}Z-00000000-0000-4000-8000-00000000000${index}`,
+      );
+    }
+    try {
+      await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000006",
+        run: async ({ args, stdout }) => {
+          if (args.some((argument) => argument.endsWith("/pg_dump"))) {
+            writeFileSync(stdout!, "verified-control-plane-dump");
+          }
+          return 0;
+        },
+      })).rejects.toThrow("trusted directory");
+      expect(statSync(targetDirectory).isDirectory()).toBe(true);
+      expect(readdirSync(backupRoot)).toContain(untrustedId);
+      expect(readdirSync(backupRoot)).toContain(
+        "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000006",
+      );
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("refuses a root-owned matching directory without a complete backup pair", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-retention-pair-"));
+    chmodSync(backupRoot, 0o700);
+    const misplacedId = "control-plane-20260817T000000Z-00000000-0000-4000-8000-000000000010";
+    mkdirSync(join(backupRoot, misplacedId), { mode: 0o700 });
+    for (let index = 1; index <= 5; index += 1) {
+      writeTrustedBackup(
+        backupRoot,
+        `control-plane-20260818T00000${index}Z-00000000-0000-4000-8000-00000000001${index}`,
+      );
+    }
+    const currentId = "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000011";
+    try {
+      await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000011",
+        run: async ({ args, stdout }) => {
+          if (args.some((argument) => argument.endsWith("/pg_dump"))) {
+            writeFileSync(stdout!, "verified-control-plane-dump");
+          }
+          return 0;
+        },
+      })).rejects.toThrow("contents are not trusted");
+      expect(readdirSync(backupRoot)).toContain(misplacedId);
+      expect(readdirSync(backupRoot)).toContain(currentId);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("keeps the durable current backup when retention deletion stops midway", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-retention-failure-"));
+    chmodSync(backupRoot, 0o700);
+    const historicalIds = Array.from({ length: 6 }, (_, index) => (
+      `control-plane-20260818T00000${index}Z-00000000-0000-4000-8000-00000000000${index}`
+    ));
+    for (const backupId of historicalIds) writeTrustedBackup(backupRoot, backupId);
+    let removals = 0;
+    const currentId = "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000008";
+    try {
+      await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000008",
+        remove: (directory) => {
+          removals += 1;
+          if (removals === 2) throw new Error("retention delete failed");
+          rmSync(directory, { force: true, recursive: true });
+        },
+        run: async ({ args, stdout }) => {
+          if (args.some((argument) => argument.endsWith("/pg_dump"))) {
+            writeFileSync(stdout!, "verified-control-plane-dump");
+          }
+          return 0;
+        },
+      })).rejects.toThrow("retention delete failed");
+      expect(removals).toBe(2);
+      expect(readdirSync(backupRoot)).toContain(currentId);
+      expect(readdirSync(join(backupRoot, currentId)).sort()).toEqual(["control-plane.dump", "receipt.json"]);
+      expect(readdirSync(backupRoot).filter((entry) => entry.startsWith("control-plane-"))).toHaveLength(6);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("holds the exported snapshot inspection open through backup", async () => {
+    let inspectionOpen = false;
+    await withControlPlaneUpgradeSafety(databaseUrl, "k".repeat(32), async (lease) => {
+      expect(inspectionOpen).toBe(true);
+      expect(lease.snapshotId).toBe(inspection.snapshotId);
+      expect(lease.databaseFingerprint).toBe(inspection.databaseFingerprint);
+      expect(lease.evidence).not.toHaveProperty("database_fingerprint");
+    }, {
+      withInspection: async (_databaseUrl, _currentKey, operation) => {
+        inspectionOpen = true;
+        try {
+          return await operation(inspection);
+        } finally {
+          inspectionOpen = false;
+        }
+      },
+      backup: async (_target, inspected) => {
+        expect(inspectionOpen).toBe(true);
+        expect(inspected.snapshotId).toBe(inspection.snapshotId);
+        return {
+          schema: "supacloud.control-plane-upgrade-safety.v1",
+          backup_id: "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000009",
+          backup_directory: "/var/lib/supacloud/backups/control-plane-upgrades/control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000009",
+          bytes: 1,
+          candidate_counts: inspection.candidateCounts,
+          completed_at: "2026-08-19T00:00:00.000Z",
+          current_key_checkpoint_present: true,
+          sha256: "a".repeat(64),
+        };
+      },
+    });
+    expect(inspectionOpen).toBe(false);
+  });
+
+  test("fails closed when inspection and backup resolve different database identities", async () => {
+    await expect(prepareControlPlaneUpgradeSafety(databaseUrl, "k".repeat(32), {
+      withInspection: async (_databaseUrl, _currentKey, operation) => operation({
+        ...inspection,
+        databaseTargetFingerprint: "0".repeat(64),
+      }),
+      backup: async () => { throw new Error("backup must not run"); },
+    })).rejects.toThrow("database identity changed");
+  });
+
+  test("rejects incomplete or non-PostgreSQL database targets", () => {
+    expect(() => controlPlaneUpgradeSafetyInternals.databaseTarget("https://example.com/db"))
+      .toThrow("PostgreSQL");
+    expect(() => controlPlaneUpgradeSafetyInternals.databaseTarget("postgresql://localhost"))
+      .toThrow("incomplete");
+  });
+});

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -34,6 +34,7 @@ import {
     applyGrafanaUpgradeSettings,
     captureFileState,
     cleanupBinaryBackup,
+    controlPlaneSafetyReceiptLine,
     createBinaryBackupState,
     executeUpgradeTransaction,
     ensureEdgeRuntimeIdentity,
@@ -93,6 +94,7 @@ import {
     waitForManagementHealth,
     waitForEdgeRuntimeHealth,
     waitForUpgradeHealth,
+    type StagedMigrationOperations,
 } from "../../src/upgrade";
 import {
     activatePreparedSystemdUnitBroker,
@@ -100,6 +102,7 @@ import {
     readPrivilegedHelperIdentity,
     stageEmbeddedSystemdUnitBroker,
 } from "../../src/embedded-systemd-unit-broker";
+import { ControlPlaneDatabaseGuardError } from "../../src/db/control-plane-database-identity";
 
 const originalFetch = globalThis.fetch;
 const attestationEnvironmentKeys = [
@@ -125,6 +128,36 @@ const originalUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_HEALTH_ATTEM
 const originalEdgeUpgradeHealthAttempts = process.env.SUPACLOUD_UPGRADE_EDGE_HEALTH_ATTEMPTS;
 const canonicalManagementBinary = "/usr/local/bin/supacloud";
 const currentBinarySha256 = "a".repeat(64);
+const controlPlaneSafetyEvidence = {
+  schema: "supacloud.control-plane-upgrade-safety.v1" as const,
+  backup_id: "control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000001",
+  backup_directory: "/var/lib/supacloud/backups/control-plane-upgrades/control-plane-test",
+  bytes: 1024,
+  candidate_counts: {
+    deprecated_webhook_secrets: 0,
+    legacy_deployment_history_rows: 0,
+    legacy_project_config_rows: 0,
+    opaque_key_backfill_projects: 0,
+    stored_secret_values: 3,
+  },
+  completed_at: "2026-08-19T00:00:00.000Z",
+  current_key_checkpoint_present: true,
+  sha256: "c".repeat(64),
+};
+const controlPlaneDatabaseFingerprint = "b".repeat(64);
+const controlPlaneSnapshotId = "00000003-0000001B-1";
+
+function successfulControlPlaneSafety(events: string[]): StagedMigrationOperations["withSafety"] {
+  return async (_databaseUrl, _encryptionKey, operation) => {
+    events.push("safety");
+    await operation({
+      databaseFingerprint: controlPlaneDatabaseFingerprint,
+      evidence: controlPlaneSafetyEvidence,
+      snapshotId: controlPlaneSnapshotId,
+    });
+    return controlPlaneSafetyEvidence;
+  };
+}
 
 type ManagementBinaryFixture = {
   execStartPath?: string;
@@ -413,15 +446,26 @@ describe("upgrade release selection", () => {
     await expect(runStagedDatabaseMigration("/staged/supacloud", prepared, {
       captureRuntimeEnv: () => ({ path: "/runtime.env", existed: true, content: Buffer.from("old"), mode: 0o600 }),
       stopService: async () => { events.push("stop"); },
-      persistSecrets: () => { events.push("persist"); },
-      runInit: async () => { events.push("init"); throw new Error("init failed"); },
+      withSafety: successfulControlPlaneSafety(events),
+      persistSecrets: (secrets) => {
+        events.push("persist");
+        expect(secrets.SUPACLOUD_EXPECTED_CONTROL_PLANE_DATABASE_FINGERPRINT).toBeUndefined();
+        expect(secrets.SUPACLOUD_EXPECTED_CONTROL_PLANE_DATABASE_SNAPSHOT).toBeUndefined();
+      },
+      runInit: async (_binary, env) => {
+        events.push("init");
+        expect(env.SUPACLOUD_EXPECTED_CONTROL_PLANE_DATABASE_FINGERPRINT)
+          .toBe(controlPlaneDatabaseFingerprint);
+        expect(env.SUPACLOUD_EXPECTED_CONTROL_PLANE_DATABASE_SNAPSHOT).toBe(controlPlaneSnapshotId);
+        throw new Error("init failed");
+      },
       hasCheckpoint: async () => { events.push("checkpoint:false"); return false; },
       restoreRuntimeEnv: () => { events.push("restore-env"); },
       restart: async () => { events.push("restart"); },
       healthCheck: async () => { events.push("health"); },
     })).rejects.toThrow("init failed");
 
-    expect(events).toEqual(["stop", "persist", "init", "checkpoint:false", "restore-env", "restart", "health"]);
+    expect(events).toEqual(["stop", "safety", "persist", "init", "checkpoint:false", "restore-env", "restart", "health"]);
   });
 
   test("keeps the current runtime key when init-db reports failure after a durable rotation checkpoint", async () => {
@@ -434,6 +478,7 @@ describe("upgrade release selection", () => {
     await expect(runStagedDatabaseMigration("/staged/supacloud", prepared, {
       captureRuntimeEnv: () => ({ path: "/runtime.env", existed: true, content: Buffer.from("old"), mode: 0o600 }),
       stopService: async () => { events.push("stop"); },
+      withSafety: successfulControlPlaneSafety(events),
       persistSecrets: () => { events.push("persist"); },
       runInit: async () => { events.push("init"); throw new Error("post-commit failure"); },
       hasCheckpoint: async () => { events.push("checkpoint:true"); return true; },
@@ -442,7 +487,7 @@ describe("upgrade release selection", () => {
       healthCheck: async () => { events.push("health"); },
     })).rejects.toThrow("post-commit failure");
 
-    expect(events).toEqual(["stop", "persist", "init", "checkpoint:true", "restart", "health"]);
+    expect(events).toEqual(["stop", "safety", "persist", "init", "checkpoint:true", "restart", "health"]);
   });
 
   test("leaves the service stopped when checkpoint state cannot be read safely", async () => {
@@ -455,6 +500,7 @@ describe("upgrade release selection", () => {
     await expect(runStagedDatabaseMigration("/staged/supacloud", prepared, {
       captureRuntimeEnv: () => ({ path: "/runtime.env", existed: false }),
       stopService: async () => { events.push("stop"); },
+      withSafety: successfulControlPlaneSafety(events),
       persistSecrets: () => { events.push("persist"); },
       runInit: async () => { events.push("init"); throw new Error("init failed"); },
       hasCheckpoint: async () => { events.push("checkpoint:error"); throw new Error("database unavailable"); },
@@ -463,7 +509,62 @@ describe("upgrade release selection", () => {
       healthCheck: async () => { events.push("health"); },
     })).rejects.toThrow("service remains stopped");
 
-    expect(events).toEqual(["stop", "persist", "init", "checkpoint:error"]);
+    expect(events).toEqual(["stop", "safety", "persist", "init", "checkpoint:error"]);
+  });
+
+  test("restores runtime secrets but leaves Management stopped when the live snapshot guard rejects", async () => {
+    const events: string[] = [];
+    const prepared = prepareUpgradeSecrets({
+      MASTER_TOKEN: "master-token-0123456789abcdef0123456789abcdef",
+      DATABASE_URL: "postgresql://postgres:test@localhost:5432/supacloud_meta",
+    });
+
+    await expect(runStagedDatabaseMigration("/staged/supacloud", prepared, {
+      captureRuntimeEnv: () => ({ path: "/runtime.env", existed: true, content: Buffer.from("old"), mode: 0o600 }),
+      stopService: async () => { events.push("stop"); },
+      withSafety: successfulControlPlaneSafety(events),
+      persistSecrets: () => { events.push("persist"); },
+      runInit: async () => {
+        events.push("init");
+        throw new ControlPlaneDatabaseGuardError("snapshot belongs to another server");
+      },
+      hasCheckpoint: async () => { events.push("checkpoint"); return false; },
+      restoreRuntimeEnv: () => { events.push("restore-env"); },
+      restart: async () => { events.push("restart"); },
+      healthCheck: async () => { events.push("health"); },
+    })).rejects.toThrow("service remains stopped");
+
+    expect(events).toEqual(["stop", "safety", "persist", "init", "restore-env"]);
+  });
+
+  test("restarts Management without changing runtime secrets when control-plane backup fails", async () => {
+    const events: string[] = [];
+    const prepared = prepareUpgradeSecrets({
+      MASTER_TOKEN: "master-token-0123456789abcdef0123456789abcdef",
+      DATABASE_URL: "postgresql://postgres:test@localhost:5432/supacloud_meta",
+    });
+
+    await expect(runStagedDatabaseMigration("/staged/supacloud", prepared, {
+      captureRuntimeEnv: () => ({ path: "/runtime.env", existed: true, content: Buffer.from("old"), mode: 0o600 }),
+      stopService: async () => { events.push("stop"); },
+      withSafety: async () => { events.push("safety"); throw new Error("backup failed"); },
+      persistSecrets: () => { events.push("persist"); },
+      runInit: async () => { events.push("init"); },
+      hasCheckpoint: async () => { events.push("checkpoint"); return false; },
+      restoreRuntimeEnv: () => { events.push("restore-env"); },
+      restart: async () => { events.push("restart"); },
+      healthCheck: async () => { events.push("health"); },
+    })).rejects.toThrow("backup failed");
+
+    expect(events).toEqual(["stop", "safety", "restore-env", "restart", "health"]);
+  });
+
+  test("prints one machine-readable control-plane safety receipt without secrets", () => {
+    const line = controlPlaneSafetyReceiptLine(controlPlaneSafetyEvidence);
+    expect(line).toStartWith("SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=");
+    expect(JSON.parse(line.split("=", 2)[1]!)).toEqual(controlPlaneSafetyEvidence);
+    expect(line).not.toContain("private-password");
+    expect(line).not.toContain(controlPlaneDatabaseFingerprint);
   });
 
   test("recovers a service that partially stopped before reporting a systemctl error", async () => {
@@ -934,12 +1035,19 @@ describe("upgrade release selection", () => {
   });
 
   test("upgrade preflight requires setpriv and id before staging", () => {
-    const installedPaths = new Set(["/usr/bin/setpriv", "/usr/bin/id"]);
+    const installedPaths = new Set([
+      "/usr/bin/setpriv", "/usr/bin/id", "/usr/bin/pg_dump", "/usr/bin/pg_restore", "/usr/bin/timeout",
+    ]);
     expect(() => verifyBackupPrivilegeDropPreflight((filePath) => installedPaths.has(filePath))).not.toThrow();
     expect(() => verifyBackupPrivilegeDropPreflight((filePath) => filePath.endsWith("/id")))
       .toThrow("requires setpriv");
     expect(() => verifyBackupPrivilegeDropPreflight((filePath) => filePath.endsWith("/setpriv")))
       .toThrow("requires id");
+    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => (
+      filePath.endsWith("/setpriv") || filePath.endsWith("/id")
+    ))).toThrow("requires pg_dump and pg_restore");
+    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => !filePath.endsWith("/timeout")))
+      .toThrow("requires timeout");
   });
 
   test("rejects a deleted active executable", async () => {


### PR DESCRIPTION
## Summary
- require a durable, verified control-plane PostgreSQL backup before local upgrade metadata migrations
- bind backup inspection, exported snapshot challenge, identity verification, and every staged init-db write to one PostgreSQL transaction/backend
- emit only a strict redacted backup receipt; fingerprint and snapshot remain child-process-only
- make Admin fail closed on unsupported Management versions or missing/malformed safety evidence

## Safety boundaries
- no GoTrue changes
- runtime secrets are restored and Management remains stopped when the database guard rejects
- retained backups are reverified before bounded retention deletion

## Verification
- 163 targeted tests passed
- Management full unit suite passed
- Management and Admin typecheck passed
- Admin build passed
- Management SQL sync check passed
- Admin full suite process-timeout flakes passed on isolated rerun
- git diff --check and staged secret-pattern scan passed
- independent security review: GO (.mailbox/288-control-plane-upgrade-safety-security-final.md)
- independent integration Standards/Spec Fidelity review: GO (.agents/mailbox/288-control-plane-upgrade-integration-final.md)