### PR TITLE
fix(upgrade): trust pinned pre-transfer edge release

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
@@ -10,6 +10,7 @@ import {
     assertLocalUpgradeBundleSize,
     assertSignedArtifact,
     githubAttestationVerificationArguments,
+    manifestAttestationDownloadUrl,
     parseGithubReleaseMetadata,
     prepareLocalUpgradeBundle,
     runGithubCli,
@@ -17,7 +18,10 @@ import {
     settleLocalBundleDownloads,
     type LocalUpgradeFile,
 } from "./local-upgrade-bundle";
-import { RELEASE_BUNDLE_SIZE_LIMITS } from "../../../../management-api/src/release-manifest";
+import {
+    LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY,
+    RELEASE_BUNDLE_SIZE_LIMITS,
+} from "../../../../management-api/src/release-manifest";
 import {
     SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_FILENAME,
     SIGSTORE_PUBLIC_GOOD_TRUSTED_ROOT_JSONL,
@@ -89,6 +93,35 @@ describe("local upgrade download trust boundary", () => {
 
         expect(serialized).toBe('{"mediaType":"one"}\n{"mediaType":"two"}\n');
         expect(() => serializeAttestationBundles({ attestations: [] })).toThrow("did not contain attestations");
+    });
+
+    test("downloads only the exact legacy manifest attestation from its signed release asset", () => {
+        const digest = "a".repeat(64);
+        const currentRelease = parseGithubReleaseMetadata(releaseMetadata(
+            `https://github.com/vibeunion/supacloud/releases/download/${RELEASE_TAG}/SUPACLOUD-RELEASE.json`,
+        ), RELEASE_TAG);
+        expect(manifestAttestationDownloadUrl(currentRelease, {
+            repository: "vibeunion/supacloud",
+        } as never, digest)).toBe(`https://api.github.com/repos/vibeunion/supacloud/attestations/sha256:${digest}`);
+
+        const legacyTag = LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.tag;
+        const legacyRelease = parseGithubReleaseMetadata({
+            tag_name: legacyTag,
+            draft: false,
+            prerelease: false,
+            assets: [{
+                name: "SUPACLOUD-RELEASE.attestation.jsonl",
+                browser_download_url: `https://github.com/vibeunion/supacloud/releases/download/${legacyTag}/SUPACLOUD-RELEASE.attestation.jsonl`,
+            }],
+        }, legacyTag);
+        expect(manifestAttestationDownloadUrl(legacyRelease, {
+            repository: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository,
+        } as never, digest)).toBe(
+            `https://github.com/vibeunion/supacloud/releases/download/${legacyTag}/SUPACLOUD-RELEASE.attestation.jsonl`,
+        );
+        expect(() => manifestAttestationDownloadUrl(legacyRelease, {
+            repository: "untrusted/supacloud",
+        } as never, digest)).toThrow("not supported");
     });
 
     test("counts the optional verifier archive against the shared bundle limit", () => {
@@ -188,6 +221,26 @@ describe("local upgrade download trust boundary", () => {
         expect(arguments_).toContain("--custom-trusted-root");
         expect(arguments_[arguments_.indexOf("--custom-trusted-root") + 1]).toBe(trustedRootPath);
         expect(arguments_.filter(argument => argument === "--custom-trusted-root")).toHaveLength(1);
+    });
+
+    test("binds the exact legacy Edge Runtime release to its pre-transfer attestation identity", () => {
+        const arguments_ = githubAttestationVerificationArguments({
+            artifactPath: "/bundle/SUPACLOUD-RELEASE.json",
+            bundlePath: "/bundle/SUPACLOUD-RELEASE.attestation.jsonl",
+            trustedRootPath: "/private/trusted_root.jsonl",
+            manifest: {
+                repository: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository,
+                workflow: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow,
+                source: {
+                    ref: "refs/heads/main",
+                    commit: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.sourceCommit,
+                },
+            } as never,
+        });
+
+        expect(arguments_).toContain(LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository);
+        expect(arguments_).toContain(LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow);
+        expect(arguments_).toContain(LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.sourceCommit);
     });
 
     test("fails closed when the pinned local trusted root is missing, altered, linked, or too permissive", () => {

--- a/packages/admin/src/shared/releases/local-upgrade-bundle.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, chmodSync, constants as fsConstants, createWriteStream, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { accessSync, chmodSync, constants as fsConstants, createWriteStream, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import type { IncomingMessage } from "node:http";
 import { get } from "node:https";
 import { tmpdir } from "node:os";
@@ -12,10 +12,9 @@ import {
     RELEASE_ATTESTATION_NAME,
     RELEASE_BUNDLE_SIZE_LIMITS,
     RELEASE_CHECKSUMS_NAME,
+    LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY,
     RELEASE_MANIFEST_NAME,
     RELEASE_REPOSITORY,
-    RELEASE_SIGNER_WORKFLOW,
-    RELEASE_SOURCE_REF,
     manifestArtifact,
     parseReleaseChecksums,
     parseReleaseManifest,
@@ -73,6 +72,13 @@ type ComponentDownloadRequest = {
     assetNames: string[];
     destination: string;
     trustedRootPath: string;
+};
+
+type ManifestAttestationDownloadRequest = {
+    release: GithubRelease;
+    manifest: ReleaseManifest;
+    manifestPath: string;
+    destination: string;
 };
 
 type HttpsDownloadRequest = {
@@ -489,9 +495,9 @@ export function githubAttestationVerificationArguments(request: GithubAttestatio
     return [
         "attestation", "verify", request.artifactPath,
         "--bundle", request.bundlePath,
-        "--repo", RELEASE_REPOSITORY,
-        "--signer-workflow", RELEASE_SIGNER_WORKFLOW,
-        "--source-ref", RELEASE_SOURCE_REF,
+        "--repo", request.manifest.repository,
+        "--signer-workflow", request.manifest.workflow,
+        "--source-ref", request.manifest.source.ref,
         "--source-digest", request.manifest.source.commit,
         "--deny-self-hosted-runners",
         "--custom-trusted-root", request.trustedRootPath,
@@ -539,17 +545,38 @@ async function downloadReleaseMetadata(component: ReleaseComponent, version: str
     }
 }
 
-async function downloadManifestAttestation(manifestPath: string, destination: string): Promise<void> {
+export function manifestAttestationDownloadUrl(
+    release: GithubRelease,
+    manifest: ReleaseManifest,
+    manifestDigest: string,
+): string {
+    if (manifest.repository === RELEASE_REPOSITORY) {
+        return `${ATTESTATIONS_API}/sha256:${manifestDigest}`;
+    }
+    if (manifest.repository === LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository) {
+        return releaseAssetUrl(release, RELEASE_ATTESTATION_NAME);
+    }
+    throw new Error("Release manifest repository is not supported");
+}
+
+async function downloadManifestAttestation(
+    request: ManifestAttestationDownloadRequest,
+): Promise<void> {
+    const { release, manifest, manifestPath, destination } = request;
     const responsePath = `${destination}.response`;
     try {
         await downloadDirect(
-            `${ATTESTATIONS_API}/sha256:${sha256File(manifestPath)}`,
+            manifestAttestationDownloadUrl(release, manifest, sha256File(manifestPath)),
             responsePath,
             RELEASE_BUNDLE_SIZE_LIMITS.attestation,
         );
-        const bundles = serializeAttestationBundles(parseJsonFile(responsePath, "GitHub attestation response"));
-        writeFileSync(destination, bundles, { mode: 0o600, flag: "wx" });
-        chmodSync(destination, 0o600);
+        if (manifest.repository === RELEASE_REPOSITORY) {
+            const bundles = serializeAttestationBundles(parseJsonFile(responsePath, "GitHub attestation response"));
+            writeFileSync(destination, bundles, { mode: 0o600, flag: "wx" });
+            chmodSync(destination, 0o600);
+        } else {
+            renameSync(responsePath, destination);
+        }
     } finally {
         rmSync(responsePath, { force: true });
     }
@@ -563,7 +590,7 @@ async function downloadComponent(request: ComponentDownloadRequest): Promise<Loc
         releaseAssetUrl(release, RELEASE_MANIFEST_NAME), manifestPath, RELEASE_BUNDLE_SIZE_LIMITS.manifest,
     );
     const manifest = parseReleaseManifest(readFileSync(manifestPath, "utf8"), request);
-    await downloadManifestAttestation(manifestPath, attestationPath);
+    await downloadManifestAttestation({ release, manifest, manifestPath, destination: attestationPath });
     await verifyManifestAttestation({
         artifactPath: manifestPath,
         bundlePath: attestationPath,

--- a/packages/management-api/src/offline-upgrade-bundle.ts
+++ b/packages/management-api/src/offline-upgrade-bundle.ts
@@ -6,9 +6,6 @@ import {
   RELEASE_BUNDLE_SIZE_LIMITS,
   RELEASE_CHECKSUMS_NAME,
   RELEASE_MANIFEST_NAME,
-  RELEASE_REPOSITORY,
-  RELEASE_SIGNER_WORKFLOW,
-  RELEASE_SOURCE_REF,
   type ReleaseComponent,
   type ReleaseManifest,
   manifestArtifact,
@@ -58,7 +55,6 @@ type PreparedOfflineRelease = {
   version: string;
   directory: string;
   manifestText: string;
-  sourceCommit: string;
   selectedAssetNames: string[];
   assetPaths: Map<string, string>;
 };
@@ -136,20 +132,6 @@ function assertBoundedFile(filePath: string, limit: number, label: string): void
   if (size <= 0 || size > limit) throw new Error(`${label} exceeds its size limit`);
 }
 
-function sourceCommitFromUntrustedManifest(text: string): string {
-  let candidate: unknown;
-  try {
-    candidate = JSON.parse(text);
-  } catch {
-    throw new Error("Release manifest is not valid JSON");
-  }
-  const commit = (candidate as { source?: { commit?: unknown } } | null)?.source?.commit;
-  if (typeof commit !== "string" || !/^[0-9a-f]{40}$/.test(commit)) {
-    throw new Error("Release manifest source commit is invalid");
-  }
-  return commit;
-}
-
 export async function runGithubCliWithTimeout(
   githubArguments: string[],
   timeoutMs: number,
@@ -206,6 +188,7 @@ async function assertStrictOfflineVerifier(): Promise<void> {
 
 async function verifyOfflineAttestation(
   prepared: PreparedOfflineRelease,
+  manifest: ReleaseManifest,
   artifactPath: string,
   trustedRootPath: string,
 ): Promise<void> {
@@ -214,10 +197,10 @@ async function verifyOfflineAttestation(
     "attestation", "verify", artifactPath,
     "--bundle", attestationPath,
     "--custom-trusted-root", trustedRootPath,
-    "--repo", RELEASE_REPOSITORY,
-    "--signer-workflow", RELEASE_SIGNER_WORKFLOW,
-    "--source-ref", RELEASE_SOURCE_REF,
-    "--source-digest", prepared.sourceCommit,
+    "--repo", manifest.repository,
+    "--signer-workflow", manifest.workflow,
+    "--source-ref", manifest.source.ref,
+    "--source-digest", manifest.source.commit,
     "--deny-self-hosted-runners",
   ], GH_VERIFICATION_TIMEOUT_MS);
   if (verification.exitCode !== 0) {
@@ -295,7 +278,6 @@ function prepareOfflineRelease(request: OfflineReleaseRequest): PreparedOfflineR
     version: request.version,
     directory: path.join(request.bundleRoot, request.component),
     manifestText,
-    sourceCommit: sourceCommitFromUntrustedManifest(manifestText),
     selectedAssetNames: selectedNames,
     assetPaths,
   };
@@ -316,7 +298,7 @@ async function verifiedChecksums(
 ): Promise<{ text: string; byName: Map<string, string> }> {
   const checksumsPath = requiredPath(prepared.assetPaths, RELEASE_CHECKSUMS_NAME);
   assertManifestArtifact(checksumsPath, manifest, RELEASE_CHECKSUMS_NAME);
-  await verifyOfflineAttestation(prepared, checksumsPath, trustedRootPath);
+  await verifyOfflineAttestation(prepared, manifest, checksumsPath, trustedRootPath);
   const text = readFileSync(checksumsPath, "utf8");
   return { text, byName: parseReleaseChecksums(text, manifest) };
 }
@@ -333,7 +315,7 @@ async function verifySelectedAssets(
     if (checksums.get(name) !== manifestArtifact(manifest, name).sha256) {
       throw new Error(`${name} does not match SHA256SUMS`);
     }
-    await verifyOfflineAttestation(prepared, assetPath, trustedRootPath);
+    await verifyOfflineAttestation(prepared, manifest, assetPath, trustedRootPath);
   }
 }
 
@@ -342,11 +324,11 @@ async function loadOfflineRelease(
   trustedRootPath: string,
 ): Promise<OfflineReleaseBundle> {
   const manifestPath = requiredPath(prepared.assetPaths, RELEASE_MANIFEST_NAME);
-  await verifyOfflineAttestation(prepared, manifestPath, trustedRootPath);
   const manifest = parseReleaseManifest(prepared.manifestText, {
     component: prepared.component,
     version: prepared.version,
   });
+  await verifyOfflineAttestation(prepared, manifest, manifestPath, trustedRootPath);
   const checksums = await verifiedChecksums(prepared, manifest, trustedRootPath);
   await verifySelectedAssets(prepared, manifest, checksums.byName, trustedRootPath);
   return {

--- a/packages/management-api/src/release-manifest.ts
+++ b/packages/management-api/src/release-manifest.ts
@@ -4,6 +4,14 @@ export const RELEASE_CHECKSUMS_NAME = "SHA256SUMS";
 export const RELEASE_REPOSITORY = "vibeunion/supacloud";
 export const RELEASE_SOURCE_REF = "refs/heads/main";
 export const RELEASE_SIGNER_WORKFLOW = `${RELEASE_REPOSITORY}/.github/workflows/release-please.yml`;
+export const LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY = {
+  repository: "zuohuadong/supacloud",
+  workflow: "zuohuadong/supacloud/.github/workflows/release-please.yml",
+  component: "edge-runtime",
+  version: "0.18.2",
+  tag: "edge-runtime-v0.18.2",
+  sourceCommit: "c6a3a87cf4e41e0f3dafadb018dd0c7d5b99b7d9",
+} as const;
 const MEBIBYTE = 1024 * 1024;
 
 export const RELEASE_BUNDLE_SIZE_LIMITS = {
@@ -48,12 +56,12 @@ export type ReleaseManifestArtifact = {
 
 export type ReleaseManifest = {
   schemaVersion: 1;
-  repository: typeof RELEASE_REPOSITORY;
+  repository: typeof RELEASE_REPOSITORY | typeof LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository;
   source: {
     ref: typeof RELEASE_SOURCE_REF;
     commit: string;
   };
-  workflow: typeof RELEASE_SIGNER_WORKFLOW;
+  workflow: typeof RELEASE_SIGNER_WORKFLOW | typeof LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow;
   release: {
     component: ReleaseComponent;
     version: string;
@@ -155,6 +163,26 @@ function parseArtifacts(candidate: unknown, component: ReleaseComponent): Releas
   return artifacts;
 }
 
+function parseIdentity(
+  manifest: Record<string, unknown>,
+  source: ReleaseManifest["source"],
+  release: ReleaseManifest["release"],
+): Pick<ReleaseManifest, "repository" | "workflow"> {
+  const current = manifest.repository === RELEASE_REPOSITORY
+    && manifest.workflow === RELEASE_SIGNER_WORKFLOW;
+  const legacyEdgeRuntime = manifest.repository === LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository
+    && manifest.workflow === LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow
+    && release.component === LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.component
+    && release.version === LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.version
+    && release.tag === LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.tag
+    && source.commit === LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.sourceCommit;
+  if (!current && !legacyEdgeRuntime) throw new Error("Release manifest identity is invalid");
+  return {
+    repository: manifest.repository as ReleaseManifest["repository"],
+    workflow: manifest.workflow as ReleaseManifest["workflow"],
+  };
+}
+
 export function parseReleaseManifest(text: string, expected: ExpectedReleaseManifest): ReleaseManifest {
   let candidate: unknown;
   try {
@@ -164,16 +192,15 @@ export function parseReleaseManifest(text: string, expected: ExpectedReleaseMani
   }
   const manifest = manifestObject(candidate, "Release manifest");
   assertExactKeys(manifest, ["schemaVersion", "repository", "source", "workflow", "release", "artifacts"], "Release manifest");
-  if (manifest.schemaVersion !== 1 || manifest.repository !== RELEASE_REPOSITORY
-    || manifest.workflow !== RELEASE_SIGNER_WORKFLOW) {
-    throw new Error("Release manifest identity is invalid");
-  }
+  if (manifest.schemaVersion !== 1) throw new Error("Release manifest identity is invalid");
+  const source = parseSource(manifest.source);
+  const release = parseRelease(manifest.release, expected);
+  const identity = parseIdentity(manifest, source, release);
   return {
     schemaVersion: 1,
-    repository: RELEASE_REPOSITORY,
-    source: parseSource(manifest.source),
-    workflow: RELEASE_SIGNER_WORKFLOW,
-    release: parseRelease(manifest.release, expected),
+    ...identity,
+    source,
+    release,
     artifacts: parseArtifacts(manifest.artifacts, expected.component),
   };
 }

--- a/packages/management-api/tests/unit/offline-upgrade-bundle.test.ts
+++ b/packages/management-api/tests/unit/offline-upgrade-bundle.test.ts
@@ -35,6 +35,7 @@ import {
   RELEASE_BUNDLE_SIZE_LIMITS,
   RELEASE_CHECKSUMS_NAME,
   RELEASE_MANIFEST_NAME,
+  LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY,
   RELEASE_REPOSITORY,
   RELEASE_SIGNER_WORKFLOW,
   RELEASE_SOURCE_REF,
@@ -260,6 +261,37 @@ describe("offline upgrade bundle", () => {
     }
     expect(trustedRootPaths.size).toBe(1);
     expect(existsSync([...trustedRootPaths][0]!)).toBe(false);
+  });
+
+  test("uses the exact pre-transfer attestation identity only for Edge Runtime 0.18.2", async () => {
+    const fixture = bundleFixture();
+    const legacyEdge = manifestFixture(
+      "edge-runtime",
+      LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.version,
+      LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.sourceCommit,
+    );
+    legacyEdge.manifest.repository = LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository;
+    legacyEdge.manifest.workflow = LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow;
+    legacyEdge.manifest.release.tag = LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.tag;
+    writeSecureFile(join(fixture.edgeDir, RELEASE_MANIFEST_NAME), `${JSON.stringify(legacyEdge.manifest)}\n`);
+    writeSecureFile(join(fixture.edgeDir, RELEASE_CHECKSUMS_NAME), legacyEdge.checksums);
+    writeSecureFile(
+      join(fixture.edgeDir, edgeBinary),
+      releaseAssetContent("edge-runtime", LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.version, edgeBinary),
+    );
+
+    await loadOfflineUpgradeBundle({
+      assetBundleDir: fixture.root,
+      management: { version: managementVersion, binaryName: managementBinary },
+      edgeRuntime: { version: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.version, binaryName: edgeBinary },
+    });
+    const calls = readFileSync(fixture.recordPath, "utf8").trim().split("\n");
+    const edgeCalls = calls.filter(call => call.includes(LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.sourceCommit));
+    expect(edgeCalls).toHaveLength(3);
+    for (const call of edgeCalls) {
+      expect(call).toContain(`--repo ${LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository}`);
+      expect(call).toContain(`--signer-workflow ${LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow}`);
+    }
   });
 
   test("fails closed when gh cannot consume a custom trusted root", async () => {

--- a/packages/management-api/tests/unit/release-manifest.test.ts
+++ b/packages/management-api/tests/unit/release-manifest.test.ts
@@ -4,6 +4,9 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY,
+  RELEASE_REPOSITORY,
+  RELEASE_SIGNER_WORKFLOW,
   RELEASE_CHECKSUMS_NAME,
   RELEASE_BUNDLE_SIZE_LIMITS,
   RELEASE_MANIFEST_NAME,
@@ -97,6 +100,43 @@ describe("signed release manifest", () => {
     expect(() => parseReleaseManifest(JSON.stringify(oversized), expected)).toThrow("size limit");
     expect(() => parseReleaseManifest(JSON.stringify(manifest), { ...expected, version: "1.2.4" }))
       .toThrow("does not match");
+  });
+
+  test("accepts only the exact pre-transfer Edge Runtime 0.18.2 identity", () => {
+    const current = generateManifest("edge-runtime");
+    const legacy = {
+      ...current,
+      repository: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository,
+      workflow: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow,
+      source: {
+        ref: current.source.ref,
+        commit: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.sourceCommit,
+      },
+      release: {
+        component: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.component,
+        version: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.version,
+        tag: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.tag,
+      },
+    };
+    const expected = { component: "edge-runtime" as const, version: "0.18.2" };
+
+    expect(parseReleaseManifest(JSON.stringify(legacy), expected)).toMatchObject({
+      repository: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.repository,
+      workflow: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.workflow,
+      source: { commit: LEGACY_EDGE_RUNTIME_RELEASE_IDENTITY.sourceCommit },
+      release: expected,
+    });
+    for (const drift of [
+      { ...legacy, repository: RELEASE_REPOSITORY },
+      { ...legacy, workflow: RELEASE_SIGNER_WORKFLOW },
+      { ...legacy, source: { ...legacy.source, commit: "f".repeat(40) } },
+    ]) {
+      expect(() => parseReleaseManifest(JSON.stringify(drift), expected)).toThrow("identity");
+    }
+    expect(() => parseReleaseManifest(JSON.stringify({
+      ...legacy,
+      release: { component: "edge-runtime", version: "0.18.3", tag: "edge-runtime-v0.18.3" },
+    }), { component: "edge-runtime", version: "0.18.3" })).toThrow("identity");
   });
 
   test("requires SHA256SUMS to agree exactly with the signed manifest", () => {


### PR DESCRIPTION
## Summary

- accept only the exact pre-transfer `edge-runtime-v0.18.2` repository/workflow/source identity
- bind local and offline attestation verification to the strictly parsed manifest identity
- use the transferred official release attestation asset only for that pinned legacy release; keep current releases on the current Attestations API
- reject every unknown repository and preserve current release download identity

## Production evidence

The official Admin 0.15.2 production upgrade stopped before remote writes with `Release manifest identity is invalid`. Read-only reconciliation confirmed production remained Management 0.60.3 / Edge 0.18.2 and healthy. The immutable Edge 0.18.2 release predates the repository transfer and is signed by the previous official repository/workflow at source commit `c6a3a87cf4e41e0f3dafadb018dd0c7d5b99b7d9`.

## Verification

- 31 targeted tests pass / 0 fail / 181 expectations
- Management API full unit suite passes
- Management API and Admin typechecks pass
- Admin build passes
- SQL module sync check passes
- real official `0.61.4 + 0.18.2` local bundle preparation verifies all 9 files
- `git diff --check` and secret-pattern scan pass
- independent integration and security reviewers: GO

No GoTrue, production, release asset, or FA mutation is included.