### PR TITLE
fix(admin): bound verified release downloads

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -9,11 +9,13 @@ import {
     assertLocalTrustedRootDirectory,
     assertLocalUpgradeBundleSize,
     assertSignedArtifact,
+    downloadPinnedGithubCli,
     githubAttestationVerificationArguments,
     manifestAttestationDownloadUrl,
     parseGithubReleaseMetadata,
     prepareLocalUpgradeBundle,
     runGithubCli,
+    runGithubCliDownload,
     serializeAttestationBundles,
     settleLocalBundleDownloads,
     type LocalUpgradeFile,
@@ -207,6 +209,74 @@ describe("local upgrade download trust boundary", () => {
         ].join("\n"), async () => {
             await expect(assertLocalGithubVerifier()).rejects.toThrow("current gh attestation verifier");
         });
+    });
+
+    test("downloads the pinned verifier through the required local GitHub CLI", async () => {
+        const downloadDirectory = mkdtempSync(join(tmpdir(), "supacloud-admin-verifier-"));
+        const argumentsPath = join(downloadDirectory, "arguments.txt");
+        const environmentPath = join(downloadDirectory, "environment.txt");
+        const previousArgumentsPath = process.env.SUPACLOUD_TEST_GH_ARGUMENTS;
+        const previousEnvironmentPath = process.env.SUPACLOUD_TEST_GH_ENVIRONMENT;
+        const previousGithubHost = process.env.GH_HOST;
+        process.env.SUPACLOUD_TEST_GH_ARGUMENTS = argumentsPath;
+        process.env.SUPACLOUD_TEST_GH_ENVIRONMENT = environmentPath;
+        process.env.GH_HOST = "github.enterprise.invalid";
+        try {
+            await withFakeGithubCli([
+                "#!/usr/bin/env bash",
+                "printf '%s\\n' \"$@\" > \"$SUPACLOUD_TEST_GH_ARGUMENTS\"",
+                "printf '%s' \"${GH_HOST-unset}\" > \"$SUPACLOUD_TEST_GH_ENVIRONMENT\"",
+                "exit 42",
+            ].join("\n"), async () => {
+                await expect(downloadPinnedGithubCli(downloadDirectory, "amd64"))
+                    .rejects.toThrow("GitHub release asset download failed");
+            });
+            expect(readFileSync(argumentsPath, "utf8").split("\n").filter(Boolean)).toEqual([
+                "release", "download", "v2.96.0", "--repo", "github.com/cli/cli",
+                "--pattern", "gh_2.96.0_linux_amd64.tar.gz", "--output", "-",
+            ]);
+            expect(readFileSync(environmentPath, "utf8")).toBe("unset");
+        } finally {
+            if (previousArgumentsPath === undefined) delete process.env.SUPACLOUD_TEST_GH_ARGUMENTS;
+            else process.env.SUPACLOUD_TEST_GH_ARGUMENTS = previousArgumentsPath;
+            if (previousEnvironmentPath === undefined) delete process.env.SUPACLOUD_TEST_GH_ENVIRONMENT;
+            else process.env.SUPACLOUD_TEST_GH_ENVIRONMENT = previousEnvironmentPath;
+            if (previousGithubHost === undefined) delete process.env.GH_HOST;
+            else process.env.GH_HOST = previousGithubHost;
+            rmSync(downloadDirectory, { recursive: true, force: true });
+        }
+    });
+
+    test("rejects a verifier archive that the GitHub CLI downloads with the wrong digest", async () => {
+        const downloadDirectory = mkdtempSync(join(tmpdir(), "supacloud-admin-verifier-"));
+        try {
+            await withFakeGithubCli([
+                "#!/usr/bin/env bash",
+                "printf 'tampered'",
+            ].join("\n"), async () => {
+                await expect(downloadPinnedGithubCli(downloadDirectory, "amd64"))
+                    .rejects.toThrow("Pinned GitHub CLI archive SHA256 mismatch");
+            });
+        } finally {
+            rmSync(downloadDirectory, { recursive: true, force: true });
+        }
+    });
+
+    test("stops a GitHub CLI asset download when the stream exceeds its byte limit", async () => {
+        const downloadDirectory = mkdtempSync(join(tmpdir(), "supacloud-admin-verifier-"));
+        const destination = join(downloadDirectory, "asset.bin");
+        try {
+            await withFakeGithubCli([
+                "#!/usr/bin/env bash",
+                "printf '123456789'",
+            ].join("\n"), async () => {
+                await expect(runGithubCliDownload(["release", "download"], destination, 8, 5_000))
+                    .rejects.toThrow("Download exceeded 8 bytes");
+            });
+            expect(() => statSync(destination)).toThrow();
+        } finally {
+            rmSync(downloadDirectory, { recursive: true, force: true });
+        }
     });
 
     test("uses the same fixed trusted root for every local attestation verification", () => {

--- a/packages/admin/src/shared/releases/local-upgrade-bundle.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-bundle.ts
@@ -1,12 +1,12 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { accessSync, chmodSync, constants as fsConstants, createWriteStream, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { accessSync, chmodSync, constants as fsConstants, createWriteStream, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import type { IncomingMessage } from "node:http";
 import { get } from "node:https";
 import { tmpdir } from "node:os";
 import { basename, delimiter, join } from "node:path";
 import { pipeline } from "node:stream/promises";
-import { Transform } from "node:stream";
+import { Transform, type Readable } from "node:stream";
 
 import {
     RELEASE_ATTESTATION_NAME,
@@ -89,6 +89,14 @@ type HttpsDownloadRequest = {
     deadline: number;
 };
 
+type GithubReleaseAssetDownloadRequest = {
+    repository: string;
+    tag: string;
+    assetName: string;
+    destination: string;
+    maxBytes: number;
+};
+
 type LocalBundleLayout = {
     directory: string;
     managementDirectory: string;
@@ -108,6 +116,7 @@ type LocalBundleDownloads = [LocalUpgradeFile[], LocalUpgradeFile[], LocalUpgrad
 
 const RELEASES_API = `https://api.github.com/repos/${RELEASE_REPOSITORY}/releases`;
 const ATTESTATIONS_API = `https://api.github.com/repos/${RELEASE_REPOSITORY}/attestations`;
+const GITHUB_CLI_REPOSITORY = "cli/cli";
 const GH_VERSION = "2.96.0";
 const GH_ARCHIVE_SHA256: Record<UpgradeArchitecture, string> = {
     amd64: "83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60",
@@ -333,6 +342,33 @@ async function downloadDirect(url: string, destination: string, maxBytes: number
     throw new AggregateError(retryFailures, `Unable to download ${parsed.hostname}${parsed.pathname}`);
 }
 
+async function downloadGithubReleaseAsset(request: GithubReleaseAssetDownloadRequest): Promise<void> {
+    const download = await runGithubCliDownload([
+        "release", "download", request.tag,
+        "--repo", `github.com/${request.repository}`,
+        "--pattern", request.assetName,
+        "--output", "-",
+    ], request.destination, request.maxBytes, DOWNLOAD_TIMEOUT_MS);
+    if (download.exitCode !== 0) {
+        rmSync(request.destination, { force: true });
+        throw new Error(`GitHub release asset download failed: ${download.stderr.trim().slice(-1_000) || download.exitCode}`);
+    }
+    assertDownloadedReleaseAsset(request);
+}
+
+function assertDownloadedReleaseAsset(request: GithubReleaseAssetDownloadRequest): void {
+    const stats = lstatSync(request.destination);
+    if (!stats.isFile() || stats.isSymbolicLink() || stats.nlink !== 1) {
+        rmSync(request.destination, { force: true });
+        throw new Error("GitHub release asset must be a direct regular file");
+    }
+    if (stats.size > request.maxBytes) {
+        rmSync(request.destination, { force: true });
+        throw new Error(`GitHub release asset exceeded ${request.maxBytes} bytes`);
+    }
+    chmodSync(request.destination, 0o600);
+}
+
 function parseJsonFile(filePath: string, label: string): unknown {
     const contents = readFileSync(filePath, "utf8");
     try {
@@ -408,7 +444,7 @@ function directEnvironment(): NodeJS.ProcessEnv {
     const environment = { ...process.env };
     for (const key of Object.keys(environment)) {
         if (/(?:^|_)proxy$/i.test(key)
-            || /^(?:SUPACLOUD_GITHUB_PROXIES|NODE_USE_ENV_PROXY)$/.test(key)) {
+            || /^(?:GH_HOST|GH_REPO|SUPACLOUD_GITHUB_PROXIES|NODE_USE_ENV_PROXY)$/.test(key)) {
             delete environment[key];
         }
     }
@@ -437,16 +473,18 @@ function githubCliExecutable(environment: NodeJS.ProcessEnv): string {
 }
 
 type GithubCliResult = { exitCode: number; stdout: string; stderr: string };
+type GithubCliProcess = ChildProcessByStdio<null, Readable, Readable>;
 
-export async function runGithubCli(arguments_: string[], timeoutMs: number): Promise<GithubCliResult> {
-    return await new Promise<GithubCliResult>((resolve, reject) => {
-        const environment = directEnvironment();
-        const child = spawn(githubCliExecutable(environment), arguments_, {
-            env: environment,
-            stdio: ["ignore", "pipe", "pipe"],
-        });
-        let stdout = "";
-        let stderr = "";
+function spawnGithubCli(arguments_: string[]): GithubCliProcess {
+    const environment = directEnvironment();
+    return spawn(githubCliExecutable(environment), arguments_, {
+        env: environment,
+        stdio: ["ignore", "pipe", "pipe"],
+    });
+}
+
+function githubCliExitCode(child: GithubCliProcess, timeoutMs: number): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
         let timedOut = false;
         let settled = false;
         let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
@@ -461,13 +499,50 @@ export async function runGithubCli(arguments_: string[], timeoutMs: number): Pro
             clearTimeout(timeout);
             if (forceKillTimer) clearTimeout(forceKillTimer);
             if (error) reject(error);
-            else resolve({ exitCode: timedOut ? 124 : exitCode, stdout, stderr });
+            else resolve(timedOut ? 124 : exitCode);
         };
-        child.stdout.on("data", (chunk: Buffer) => { stdout = `${stdout}${chunk.toString()}`.slice(-8_000); });
-        child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-8_000); });
         child.once("error", (error) => settleExecution(error, 127));
         child.once("close", (code) => settleExecution(undefined, code ?? 1));
     });
+}
+
+export async function runGithubCli(arguments_: string[], timeoutMs: number): Promise<GithubCliResult> {
+    const child = spawnGithubCli(arguments_);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => { stdout = `${stdout}${chunk.toString()}`.slice(-8_000); });
+    child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-8_000); });
+    const exitCode = await githubCliExitCode(child, timeoutMs);
+    return { exitCode, stdout, stderr };
+}
+
+export async function runGithubCliDownload(
+    arguments_: string[],
+    destination: string,
+    maxBytes: number,
+    timeoutMs: number,
+): Promise<GithubCliResult> {
+    const child = spawnGithubCli(arguments_);
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => { stderr = `${stderr}${chunk.toString()}`.slice(-8_000); });
+    const write = pipeline(
+        child.stdout,
+        boundedWriter(maxBytes),
+        createWriteStream(destination, { flags: "wx", mode: 0o600 }),
+    ).catch((error: unknown) => {
+        child.kill("SIGKILL");
+        throw error;
+    });
+    const [writeState, exitState] = await Promise.allSettled([write, githubCliExitCode(child, timeoutMs)]);
+    if (writeState.status === "rejected") {
+        rmSync(destination, { force: true });
+        throw writeState.reason;
+    }
+    if (exitState.status === "rejected") {
+        rmSync(destination, { force: true });
+        throw exitState.reason;
+    }
+    return { exitCode: exitState.value, stdout: "", stderr };
 }
 
 function supportsStrictGithubVerification(execution: GithubCliResult): boolean {
@@ -563,6 +638,16 @@ async function downloadManifestAttestation(
     request: ManifestAttestationDownloadRequest,
 ): Promise<void> {
     const { release, manifest, manifestPath, destination } = request;
+    if (manifest.repository !== RELEASE_REPOSITORY) {
+        await downloadGithubReleaseAsset({
+            repository: RELEASE_REPOSITORY,
+            tag: release.tag_name,
+            assetName: RELEASE_ATTESTATION_NAME,
+            destination,
+            maxBytes: RELEASE_BUNDLE_SIZE_LIMITS.attestation,
+        });
+        return;
+    }
     const responsePath = `${destination}.response`;
     try {
         await downloadDirect(
@@ -570,13 +655,9 @@ async function downloadManifestAttestation(
             responsePath,
             RELEASE_BUNDLE_SIZE_LIMITS.attestation,
         );
-        if (manifest.repository === RELEASE_REPOSITORY) {
-            const bundles = serializeAttestationBundles(parseJsonFile(responsePath, "GitHub attestation response"));
-            writeFileSync(destination, bundles, { mode: 0o600, flag: "wx" });
-            chmodSync(destination, 0o600);
-        } else {
-            renameSync(responsePath, destination);
-        }
+        const bundles = serializeAttestationBundles(parseJsonFile(responsePath, "GitHub attestation response"));
+        writeFileSync(destination, bundles, { mode: 0o600, flag: "wx" });
+        chmodSync(destination, 0o600);
     } finally {
         rmSync(responsePath, { force: true });
     }
@@ -586,9 +667,11 @@ async function downloadComponent(request: ComponentDownloadRequest): Promise<Loc
     const release = await downloadReleaseMetadata(request.component, request.version, request.destination);
     const manifestPath = directChildPath(request.destination, RELEASE_MANIFEST_NAME);
     const attestationPath = directChildPath(request.destination, RELEASE_ATTESTATION_NAME);
-    await downloadDirect(
-        releaseAssetUrl(release, RELEASE_MANIFEST_NAME), manifestPath, RELEASE_BUNDLE_SIZE_LIMITS.manifest,
-    );
+    releaseAssetUrl(release, RELEASE_MANIFEST_NAME);
+    await downloadGithubReleaseAsset({
+        repository: RELEASE_REPOSITORY, tag: release.tag_name, assetName: RELEASE_MANIFEST_NAME,
+        destination: manifestPath, maxBytes: RELEASE_BUNDLE_SIZE_LIMITS.manifest,
+    });
     const manifest = parseReleaseManifest(readFileSync(manifestPath, "utf8"), request);
     await downloadManifestAttestation({ release, manifest, manifestPath, destination: attestationPath });
     await verifyManifestAttestation({
@@ -599,16 +682,20 @@ async function downloadComponent(request: ComponentDownloadRequest): Promise<Loc
     });
 
     const checksumsPath = directChildPath(request.destination, RELEASE_CHECKSUMS_NAME);
-    await downloadDirect(
-        releaseAssetUrl(release, RELEASE_CHECKSUMS_NAME), checksumsPath, RELEASE_BUNDLE_SIZE_LIMITS.checksums,
-    );
+    releaseAssetUrl(release, RELEASE_CHECKSUMS_NAME);
+    await downloadGithubReleaseAsset({
+        repository: RELEASE_REPOSITORY, tag: release.tag_name, assetName: RELEASE_CHECKSUMS_NAME,
+        destination: checksumsPath, maxBytes: RELEASE_BUNDLE_SIZE_LIMITS.checksums,
+    });
     assertSignedArtifact(checksumsPath, manifest);
     const checksums = parseReleaseChecksums(readFileSync(checksumsPath, "utf8"), manifest);
     for (const assetName of request.assetNames) {
         const assetPath = directChildPath(request.destination, assetName);
-        await downloadDirect(
-            releaseAssetUrl(release, assetName), assetPath, releaseAssetSizeLimit(request.component, assetName),
-        );
+        releaseAssetUrl(release, assetName);
+        await downloadGithubReleaseAsset({
+            repository: RELEASE_REPOSITORY, tag: release.tag_name, assetName,
+            destination: assetPath, maxBytes: releaseAssetSizeLimit(request.component, assetName),
+        });
         verifyDownloadedFile(assetPath, manifest, checksums);
     }
     return [RELEASE_MANIFEST_NAME, RELEASE_ATTESTATION_NAME, RELEASE_CHECKSUMS_NAME, ...request.assetNames]
@@ -617,11 +704,16 @@ async function downloadComponent(request: ComponentDownloadRequest): Promise<Loc
         ));
 }
 
-async function downloadPinnedGithubCli(directory: string, architecture: UpgradeArchitecture): Promise<LocalUpgradeFile> {
+export async function downloadPinnedGithubCli(
+    directory: string,
+    architecture: UpgradeArchitecture,
+): Promise<LocalUpgradeFile> {
     const identity = githubCliArchiveIdentity(architecture);
     const archivePath = directChildPath(directory, identity.archiveName);
-    const url = `https://github.com/cli/cli/releases/download/v${identity.version}/${identity.archiveName}`;
-    await downloadDirect(url, archivePath, MAX_GH_ARCHIVE_BYTES);
+    await downloadGithubReleaseAsset({
+        repository: GITHUB_CLI_REPOSITORY, tag: `v${identity.version}`, assetName: identity.archiveName,
+        destination: archivePath, maxBytes: MAX_GH_ARCHIVE_BYTES,
+    });
     if (sha256File(archivePath) !== identity.sha256) {
         throw new Error("Pinned GitHub CLI archive SHA256 mismatch");
     }


### PR DESCRIPTION
## Summary
- download fixed GitHub release assets through the required local gh process
- stream assets through the existing byte limiter and remove partial files on failure
- pin github.com and clear inherited GH_HOST and GH_REPO
- preserve exact tag, asset, manifest, checksum, attestation, and pinned verifier checks

## Verification
- 73 focused tests passed
- full Admin suite: 480 passed, 0 failed
- Admin typecheck and build passed
- real Management 0.61.5 + Edge 0.18.2 + gh 2.96.0 bundle preparation passed
- independent security review: GO
- git diff --check passed