### PR TITLE
fix(upgrade): verify backup from a fresh descriptor

### DIFF
--- a/packages/management-api/src/control-plane-upgrade-safety.ts
+++ b/packages/management-api/src/control-plane-upgrade-safety.ts
@@ -540,8 +540,14 @@ async function createControlPlaneBackup(
       assertStableBackupArchive(archivePath, archiveDescriptor);
       bytes = fstatSync(archiveDescriptor).size;
       if (bytes <= 0) throw new Error("Control-plane backup archive is empty");
-      if (await operations.run({ args: verifyArguments(), stdin: archiveDescriptor }) !== 0) {
-        throw new Error("Control-plane backup archive verification failed");
+      const verificationDescriptor = openBackupArchive(archivePath, process.getuid?.() ?? 0);
+      try {
+        if (await operations.run({ args: verifyArguments(), stdin: verificationDescriptor }) !== 0) {
+          throw new Error("Control-plane backup archive verification failed");
+        }
+        assertStableBackupArchive(archivePath, verificationDescriptor);
+      } finally {
+        closeSync(verificationDescriptor);
       }
       sha256 = fileSha256(archiveDescriptor, bytes);
       assertStableBackupArchive(archivePath, archiveDescriptor);

--- a/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
+++ b/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
@@ -64,12 +64,15 @@ describe("control-plane upgrade safety", () => {
         identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000001",
-        run: async ({ args, env, stdout }) => {
+        run: async ({ args, env, stdin, stdout }) => {
           commands.push(args);
           if (args.some((argument) => argument.endsWith("/pg_dump"))) {
             expect(env?.PGPASSWORD).toBe("private-password");
             expect(Object.keys(env || {})).toEqual(["PGPASSWORD"]);
             writeFileSync(stdout!, "verified-control-plane-dump");
+          }
+          if (args.some((argument) => argument.endsWith("/pg_restore"))) {
+            expect(readFileSync(stdin!, "utf8")).toBe("verified-control-plane-dump");
           }
           return 0;
         },


### PR DESCRIPTION
## Summary
- verify the freshly written control-plane archive through a separate trusted descriptor at offset zero
- preserve the root-owned writer descriptor, inode/mode/link checks, fsync, digest, receipt, and retention boundaries
- add a regression that reads the complete dump bytes from the verification descriptor

## Production evidence
- official transaction 76f30b75-fe0c-473e-bcbc-12971dddee2d terminally failed at archive verification
- automatic rollback read-back kept Management 0.60.3, Edge 0.18.2, Caddy 2.11.4, Web 0.33.0, PostgreSQL 18.4, and healthy services
- no production retry was attempted

## Verification
- focused safety and upgrade tests: 98 passed, 0 failed
- full Management local test suite passed
- Management typecheck passed
- Linux amd64 compiled binary verification passed
- two independent platform/security reviews: GO
- git diff --check passed