### PR TITLE
fix(upgrade): preflight control-plane backup

### DIFF
--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -21,6 +21,8 @@ import {
     executeLocalUpgradeTransfer,
     failureRequiresRemoteReconciliation,
     parseControlPlaneSafetyEvidence,
+    parseControlPlanePreflightEvidence,
+    parseUpgradeFailureEvidence,
     parseRemotePreflight,
     remoteUpgradePreflight,
     startRemoteUpgrade,
@@ -36,7 +38,16 @@ const paths = {
     unit: "supacloud-upgrade-11111111-1111-4111-8111-111111111111.service",
 };
 
-type ScriptedResult = { success: boolean; stdout: string; stderr: string; code: number };
+type ScriptedResult = {
+    success: boolean;
+    stdout: string;
+    stderr: string;
+    code: number;
+    stdoutRedacted?: boolean;
+    stdoutTruncated?: boolean;
+    stderrRedacted?: boolean;
+    stderrTruncated?: boolean;
+};
 type ScriptedResponse = ScriptedResult | Error;
 
 class ScriptedSsh {
@@ -77,13 +88,23 @@ const controlPlaneSafetyEvidence = {
 };
 
 function successfulUpgradeLog(message = "upgrade committed"): string {
-    return `${message}\nSUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=${JSON.stringify(controlPlaneSafetyEvidence)}\n`;
+    return `${message}\n`
+        + `SUPACLOUD_CONTROL_PLANE_UPGRADE_PREFLIGHT=${JSON.stringify(controlPlaneSafetyEvidence)}\n`
+        + `SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=${JSON.stringify(controlPlaneSafetyEvidence)}\n`;
+}
+
+function failedUpgradeLog(summary = "Control-plane backup archive verification failed"): string {
+    return `SUPACLOUD_UPGRADE_FAILURE=${JSON.stringify({
+        schema: "supacloud.upgrade-failure.v1",
+        summary,
+        causes: [],
+    })}\n`;
 }
 
 describe("control-plane safety receipt", () => {
     test("requires the first Management release with in-transaction control-plane backup safety", () => {
-        expect(() => assertControlPlaneSafetyVersion("0.61.3")).toThrow("0.61.4 or newer");
-        expect(() => assertControlPlaneSafetyVersion("0.61.4")).not.toThrow();
+        expect(() => assertControlPlaneSafetyVersion("0.61.6")).toThrow("0.61.7 or newer");
+        expect(() => assertControlPlaneSafetyVersion("0.61.7")).not.toThrow();
         expect(() => assertControlPlaneSafetyVersion("0.62.0")).not.toThrow();
         expect(() => assertControlPlaneSafetyVersion("1.0.0")).not.toThrow();
         expect(() => assertControlPlaneSafetyVersion("latest")).toThrow("exact stable version");
@@ -91,7 +112,7 @@ describe("control-plane safety receipt", () => {
             .toThrow("exact stable version");
     });
 
-    test("rejects Management 0.61.3 before remote access", async () => {
+    test("rejects Management 0.61.6 before remote access", async () => {
         let remoteAccesses = 0;
         const ssh = {
             exec: async () => {
@@ -100,23 +121,81 @@ describe("control-plane safety receipt", () => {
             },
         };
         await expect(executeLocalUpgradeTransfer(ssh as never, {
-            managementVersion: "0.61.3",
+            managementVersion: "0.61.6",
             edgeRuntimeVersion: "0.18.2",
-        })).rejects.toThrow("0.61.4 or newer");
+        })).rejects.toThrow("0.61.7 or newer");
         expect(remoteAccesses).toBe(0);
     });
 
     test("accepts one exact redacted receipt", () => {
         expect(parseControlPlaneSafetyEvidence(successfulUpgradeLog())).toEqual(controlPlaneSafetyEvidence);
+        expect(parseControlPlanePreflightEvidence(successfulUpgradeLog())).toEqual(controlPlaneSafetyEvidence);
+    });
+
+    test("accepts one exact structured failure receipt", () => {
+        expect(parseUpgradeFailureEvidence(failedUpgradeLog())).toEqual({
+            schema: "supacloud.upgrade-failure.v1",
+            summary: "Control-plane backup archive verification failed",
+            causes: [],
+        });
+        expect(() => parseUpgradeFailureEvidence("transaction failed\n"))
+            .toThrow("one structured failure receipt");
+        expect(() => parseUpgradeFailureEvidence(`${failedUpgradeLog()}${failedUpgradeLog()}`))
+            .toThrow("one structured failure receipt");
+        expect(() => parseUpgradeFailureEvidence(
+            "SUPACLOUD_UPGRADE_FAILURE={not-json}\n",
+        )).toThrow("not valid JSON");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog("failure\nforged log line")))
+            .toThrow("receipt is invalid");
+        expect(() => parseUpgradeFailureEvidence(`SUPACLOUD_UPGRADE_FAILURE=${JSON.stringify({
+            schema: "supacloud.upgrade-failure.v1",
+            summary: "Control-plane backup failed",
+            causes: [],
+            unexpected: true,
+        })}\n`)).toThrow("receipt is invalid");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(
+            "DATABASE_URL=postgresql://admin:database-password@localhost/supacloud",
+        ))).toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(`SUPACLOUD_UPGRADE_FAILURE=${JSON.stringify({
+            schema: "supacloud.upgrade-failure.v1",
+            summary: "Control-plane backup failed",
+            causes: ["API_TOKEN=raw-token"],
+        })}\n`)).toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog("request failed Bearer raw-access-token")))
+            .toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(
+            "postgresql://:raw-password@localhost/supacloud",
+        ))).toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog('{"token":"raw-token"}')))
+            .toThrow("contains sensitive data");
+        expect(parseUpgradeFailureEvidence(failedUpgradeLog('{"token":"[REDACTED]"}')).summary)
+            .toBe('{"token":"[REDACTED]"}');
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(String.raw`{\"token\":\"raw-token\"}suffix`)))
+            .toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(
+            String.raw`{"token":"prefix-\\"synthetic-escaped-tail"}`,
+        ))).toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(String.raw`{"to\\u006ben":"unicode-token"}`)))
+            .toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(
+            String.raw`{\"to\\u006ben\":\"escaped-unicode-token\"}`,
+        ))).toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(
+            String.raw`{to\\u006ben:"unquoted-unicode-token"}`,
+        ))).toThrow("contains sensitive data");
+        expect(() => parseUpgradeFailureEvidence(failedUpgradeLog(
+            String.raw`{to\\u{006b}en:"codepoint-unicode-token"}`,
+        ))).toThrow("contains sensitive data");
     });
 
     test("rejects missing, duplicate, secret-bearing, and malformed receipts", () => {
         expect(() => parseControlPlaneSafetyEvidence("upgrade committed\n")).toThrow("one control-plane safety receipt");
         expect(() => parseControlPlaneSafetyEvidence(`${successfulUpgradeLog()}${successfulUpgradeLog()}`))
             .toThrow("one control-plane safety receipt");
+        const safetyLine = `SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=${JSON.stringify(controlPlaneSafetyEvidence)}`;
         expect(() => parseControlPlaneSafetyEvidence(successfulUpgradeLog().replace(
-            '"sha256"',
-            '"password":"not-allowed","sha256"',
+            safetyLine,
+            safetyLine.replace('"sha256"', '"password":"not-allowed","sha256"'),
         ))).toThrow("receipt is invalid");
         expect(() => parseControlPlaneSafetyEvidence(
             "SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY={not-json}\n",
@@ -387,6 +466,11 @@ describe("local upgrade remote runner", () => {
         expect(script).toContain("--edge-runtime-version '0.16.8'");
         expect(script).toContain('timeout 5s "$RUNNER" --systemd-unit-helper-sha256');
         expect(script).toContain('timeout 5s "$RUNNER" --postgrest-launcher-sha256');
+        expect(script).toContain('"$RUNNER" --control-plane-upgrade-preflight');
+        expect(script.indexOf("--control-plane-upgrade-preflight"))
+            .toBeLessThan(script.indexOf("upgrade --yes --target-version"));
+        expect(script.indexOf("printf '%s\\n' \"$CONTROL_PLANE_PREFLIGHT_RECEIPT\""))
+            .toBeGreaterThan(script.indexOf("upgrade --yes --target-version"));
         expect(script).toContain("unset SUPACLOUD_ALLOW_UNVERIFIED_RELEASE");
         expect(script).toContain("SUPACLOUD_ATTESTATION_TRUSTED_ROOT");
         expect(script).not.toContain("verify_manifest()");
@@ -1182,7 +1266,7 @@ describe("local upgrade remote runner", () => {
             remoteState({
                 status: "FAILED:9:TRANSACTION", serviceState: "failed", stageExists: false,
             }),
-            remoteResult("transaction failed\n"),
+            remoteResult(failedUpgradeLog()),
             remoteResult(),
         ]);
 
@@ -1199,7 +1283,7 @@ describe("local upgrade remote runner", () => {
         ] as const) {
             const ssh = new ScriptedSsh([
                 remoteState({ status: "FAILED:9:TRANSACTION", serviceState, unitLoadState, unitExists }),
-                remoteResult("transaction failed\n"),
+                remoteResult(failedUpgradeLog()),
                 remoteResult(),
             ]);
 
@@ -1329,11 +1413,71 @@ describe("local upgrade remote runner", () => {
 
         const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
         expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
-        expect(String(failure)).toContain("control-plane safety evidence is invalid");
+        expect(String(failure)).toContain("control-plane preflight or safety evidence is invalid");
         expect(String(failure)).toContain(paths.status);
         expect(String(failure)).toContain(paths.log);
         expect(ssh.commands).toHaveLength(2);
         expect(ssh.commands.some((command) => command.includes("rm -f --"))).toBe(false);
+    });
+
+    test("retains successful status and log records when the preflight receipt is missing", async () => {
+        const log = successfulUpgradeLog().split("\n")
+            .filter(line => !line.startsWith("SUPACLOUD_CONTROL_PLANE_UPGRADE_PREFLIGHT="))
+            .join("\n");
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "SUCCEEDED", serviceState: "inactive", unitExists: false }),
+            remoteResult(log),
+        ]);
+
+        const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+        expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+        expect(String(failure)).toContain("control-plane preflight or safety evidence is invalid");
+        expect(String(failure)).toContain(paths.status);
+        expect(String(failure)).toContain(paths.log);
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands.some((command) => command.includes("rm -f --"))).toBe(false);
+    });
+
+    test("retains failed status and log records when structured failure evidence is missing, malformed, or sensitive", async () => {
+        for (const log of [
+            "transaction failed without a structured receipt\n",
+            `${failedUpgradeLog()}${failedUpgradeLog()}`,
+            "SUPACLOUD_UPGRADE_FAILURE={not-json}\n",
+            failedUpgradeLog(String.raw`{to\\u006ben:"unquoted-unicode-token"}`),
+        ]) {
+            const ssh = new ScriptedSsh([
+                remoteState({ status: "FAILED:9:TRANSACTION", serviceState: "failed", stageExists: false }),
+                remoteResult(log),
+            ]);
+
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+            expect(String(failure)).toContain("without valid structured failure evidence");
+            expect(String(failure)).toContain(paths.status);
+            expect(String(failure)).toContain(paths.log);
+            expect(ssh.commands).toHaveLength(2);
+            expect(ssh.commands.some((command) => command.includes("rm -f --"))).toBe(false);
+        }
+    });
+
+    test("retains failed status and log records when SSH changed the receipt stream", async () => {
+        const redactedLog = failedUpgradeLog("DATABASE_URL=[REDACTED]");
+        for (const integrityFlag of [
+            "stdoutRedacted", "stderrRedacted", "stdoutTruncated", "stderrTruncated",
+        ] as const) {
+            const ssh = new ScriptedSsh([
+                remoteState({ status: "FAILED:9:TRANSACTION", serviceState: "failed", stageExists: false }),
+                { ...remoteResult(redactedLog), [integrityFlag]: true },
+            ]);
+
+            const failure = await awaitRemoteUpgrade(ssh as never, paths).catch((error: unknown) => error);
+            expect(failureRequiresRemoteReconciliation(failure)).toBe(true);
+            expect(String(failure)).toContain("retained log could not be read");
+            expect(String(failure)).toContain(paths.status);
+            expect(String(failure)).toContain(paths.log);
+            expect(ssh.commands).toHaveLength(2);
+            expect(ssh.commands.some((command) => command.includes("rm -f --"))).toBe(false);
+        }
     });
 
     test("requires reconciliation when a successful log disappears after state read-back", async () => {

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { basename } from "node:path";
 
-import type { SshResult, SshTransport } from "../transports/ssh";
+import { redactSshOutput, type SshResult, type SshTransport } from "../transports/ssh";
 import {
     buildUpgradeLockScript,
     SUPACLOUD_UPGRADE_LOCK_PATH,
@@ -54,8 +54,10 @@ const REMOTE_LOG_ROOT = "/var/log/supacloud";
 const REMOTE_UPLOAD_ROOT = "/var/tmp";
 const REMOTE_COMMAND_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const CONTROL_PLANE_BACKUP_ROOT = "/var/lib/supacloud/backups/control-plane-upgrades";
+const CONTROL_PLANE_PREFLIGHT_PREFIX = "SUPACLOUD_CONTROL_PLANE_UPGRADE_PREFLIGHT=";
 const CONTROL_PLANE_SAFETY_PREFIX = "SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=";
-const MINIMUM_CONTROL_PLANE_SAFETY_VERSION = [0, 61, 4] as const;
+const UPGRADE_FAILURE_PREFIX = "SUPACLOUD_UPGRADE_FAILURE=";
+const MINIMUM_CONTROL_PLANE_SAFETY_VERSION = [0, 61, 7] as const;
 const POLL_INTERVAL_MS = 2_000;
 const STATE_READ_ATTEMPTS = 3;
 const REMOTE_STATE_READ_TIMEOUT_MS = 15_000;
@@ -72,6 +74,12 @@ type ControlPlaneSafetyEvidence = {
     current_key_checkpoint_present: boolean;
     schema: "supacloud.control-plane-upgrade-safety.v1";
     sha256: string;
+};
+
+type UpgradeFailureEvidence = {
+    causes: string[];
+    schema: "supacloud.upgrade-failure.v1";
+    summary: string;
 };
 
 function exactObjectKeys(candidate: Record<string, unknown>, expected: readonly string[]): boolean {
@@ -92,13 +100,13 @@ function canonicalTimestamp(candidate: unknown): candidate is string {
     return Number.isFinite(timestamp.valueOf()) && timestamp.toISOString() === candidate;
 }
 
-export function parseControlPlaneSafetyEvidence(log: string): ControlPlaneSafetyEvidence {
+function parseControlPlaneSafetyReceipt(log: string, prefix: string): ControlPlaneSafetyEvidence {
     const receiptLines = log.split(/\r?\n/)
-        .filter((line) => line.startsWith(CONTROL_PLANE_SAFETY_PREFIX));
+        .filter((line) => line.startsWith(prefix));
     if (receiptLines.length !== 1) throw new Error("Remote upgrade did not emit one control-plane safety receipt");
     let candidate: unknown;
     try {
-        candidate = JSON.parse(receiptLines[0]!.slice(CONTROL_PLANE_SAFETY_PREFIX.length));
+        candidate = JSON.parse(receiptLines[0]!.slice(prefix.length));
     } catch {
         throw new Error("Remote control-plane safety receipt is not valid JSON");
     }
@@ -131,6 +139,57 @@ export function parseControlPlaneSafetyEvidence(log: string): ControlPlaneSafety
     return receipt as ControlPlaneSafetyEvidence;
 }
 
+export function parseControlPlaneSafetyEvidence(log: string): ControlPlaneSafetyEvidence {
+    return parseControlPlaneSafetyReceipt(log, CONTROL_PLANE_SAFETY_PREFIX);
+}
+
+export function parseControlPlanePreflightEvidence(log: string): ControlPlaneSafetyEvidence {
+    return parseControlPlaneSafetyReceipt(log, CONTROL_PLANE_PREFLIGHT_PREFIX);
+}
+
+function parsedUpgradeFailureReceipt(log: string): Record<string, unknown> {
+    const receiptLines = log.split(/\r?\n/).filter((line) => line.startsWith(UPGRADE_FAILURE_PREFIX));
+    if (receiptLines.length !== 1) throw new Error("Remote upgrade did not emit one structured failure receipt");
+    let candidate: unknown;
+    try {
+        candidate = JSON.parse(receiptLines[0]!.slice(UPGRADE_FAILURE_PREFIX.length));
+    } catch {
+        throw new Error("Remote upgrade failure receipt is not valid JSON");
+    }
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error("Remote upgrade failure receipt is invalid");
+    }
+    return candidate as Record<string, unknown>;
+}
+
+function upgradeFailureReceiptIsInvalid(receipt: Record<string, unknown>): boolean {
+    const causes = receipt.causes;
+    return !exactObjectKeys(receipt, ["causes", "schema", "summary"])
+        || receipt.schema !== "supacloud.upgrade-failure.v1"
+        || typeof receipt.summary !== "string" || !receipt.summary || receipt.summary.length > 500
+        || /[\u0000-\u001f\u007f]/.test(receipt.summary)
+        || !Array.isArray(causes) || causes.length > 8
+        || causes.some(cause => typeof cause !== "string" || !cause || cause.length > 500
+            || /[\u0000-\u001f\u007f]/.test(cause));
+}
+
+function upgradeFailureMessageContainsSensitiveData(message: string): boolean {
+    const bareBearer = /\bBearer\s+(?!\[REDACTED\](?:\s|$|[,;.)]))\S+/i;
+    return redactSshOutput(message) !== message || bareBearer.test(message);
+}
+
+export function parseUpgradeFailureEvidence(log: string): UpgradeFailureEvidence {
+    const receipt = parsedUpgradeFailureReceipt(log);
+    if (upgradeFailureReceiptIsInvalid(receipt)) {
+        throw new Error("Remote upgrade failure receipt is invalid");
+    }
+    const messages = [receipt.summary, ...(receipt.causes as string[])] as string[];
+    if (messages.some(upgradeFailureMessageContainsSensitiveData)) {
+        throw new Error("Remote upgrade failure receipt contains sensitive data");
+    }
+    return receipt as UpgradeFailureEvidence;
+}
+
 export function assertControlPlaneSafetyVersion(version: string): void {
     const match = version.match(/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/);
     if (!match) throw new Error("Management version must be an exact stable version");
@@ -141,7 +200,7 @@ export function assertControlPlaneSafetyVersion(version: string): void {
     for (let index = 0; index < requested.length; index += 1) {
         if (requested[index]! > MINIMUM_CONTROL_PLANE_SAFETY_VERSION[index]!) return;
         if (requested[index]! < MINIMUM_CONTROL_PLANE_SAFETY_VERSION[index]!) {
-            throw new Error("Local artifact upgrades require Management 0.61.4 or newer with control-plane backup safety");
+            throw new Error("Local artifact upgrades require Management 0.61.7 or newer with control-plane backup preflight safety");
         }
     }
 }
@@ -490,6 +549,7 @@ function upgradeScriptExecution(
 ): string[] {
     const runnerAsset = `${paths.stage}/bundle/management-api/${bundle.managementBinaryName}`;
     const runner = `${paths.stage}/runner`;
+    const preflight = "CONTROL_PLANE_PREFLIGHT_RECEIPT=$(env PATH=\"$VERIFIER_PATH:$PATH\" \"$RUNNER\" --control-plane-upgrade-preflight)";
     return [
         `MANAGEMENT_VERSION=${quoteShell(request.managementVersion)}`,
         `RUNNER_ASSET=${quoteShell(runnerAsset)}`,
@@ -500,7 +560,9 @@ function upgradeScriptExecution(
         "\"$RUNNER\" --version | grep -Eq \"(^|[^0-9])${MANAGEMENT_VERSION//./\\.}([^0-9]|$)\"",
         "timeout 5s \"$RUNNER\" --systemd-unit-helper-sha256 | grep -Eq 'SupaCloud systemd-unit helper SHA-256: [0-9a-f]{64}'",
         "timeout 5s \"$RUNNER\" --postgrest-launcher-sha256 | grep -Eq 'SupaCloud PostgREST launcher SHA-256: [0-9a-f]{64}'",
+        preflight,
         `env PATH=\"$VERIFIER_PATH:$PATH\" \"$RUNNER\" upgrade --yes --target-version ${quoteShell(request.managementVersion)} --edge-runtime-version ${quoteShell(request.edgeRuntimeVersion)} --asset-bundle-dir \"$BUNDLE\"`,
+        "printf '%s\\n' \"$CONTROL_PLANE_PREFLIGHT_RECEIPT\"",
     ];
 }
 
@@ -761,6 +823,10 @@ async function remoteLogTail(ssh: SshTransport, paths: RemoteUpgradePaths): Prom
     ].join("\n");
     const output = await ssh.exec(rootCommand(script), 15_000);
     if (!output.success) throw remoteFailure("Unable to read the remote upgrade log", output);
+    if (output.stdoutRedacted || output.stderrRedacted
+        || output.stdoutTruncated || output.stderrTruncated) {
+        throw new Error("Remote upgrade log required transport redaction or truncation");
+    }
     return output.stdout.slice(-4_000);
 }
 
@@ -900,12 +966,14 @@ async function completedUpgradeOutput(ssh: SshTransport, paths: RemoteUpgradePat
             "Upgrade succeeded but its retained log could not be read", [error], paths,
         );
     }
+    let preflightEvidence: ControlPlaneSafetyEvidence;
     let safetyEvidence: ControlPlaneSafetyEvidence;
     try {
+        preflightEvidence = parseControlPlanePreflightEvidence(log);
         safetyEvidence = parseControlPlaneSafetyEvidence(log);
     } catch (error: unknown) {
         throw remoteReconciliationFailure(
-            "Upgrade succeeded but control-plane safety evidence is invalid", [error], paths,
+            "Upgrade succeeded but control-plane preflight or safety evidence is invalid", [error], paths,
         );
     }
     try {
@@ -915,7 +983,7 @@ async function completedUpgradeOutput(ssh: SshTransport, paths: RemoteUpgradePat
             "Upgrade succeeded but remote evidence cleanup could not be confirmed", [error], paths,
         );
     }
-    return `✅ Upgrade done\n${JSON.stringify(safetyEvidence)}\n${log.slice(-1_500)}`;
+    return `✅ Upgrade done\n${JSON.stringify({ preflight: preflightEvidence, transaction: safetyEvidence })}\n${log.slice(-1_500)}`;
 }
 
 async function throwRemoteUpgradeFailure(ssh: SshTransport, paths: RemoteUpgradePaths, status: string): Promise<never> {
@@ -927,17 +995,32 @@ async function throwRemoteUpgradeFailure(ssh: SshTransport, paths: RemoteUpgrade
             "Remote upgrade failed but its retained log could not be read", [error], paths,
         );
     }
-    const failure = new Error(`Remote local upgrade failed (${status}): ${log.slice(-1_500)}`);
     if (status.endsWith(":CLEANUP_AFTER_TRANSACTION")) {
         throw remoteReconciliationFailure(
-            "Upgrade transaction completed but staging cleanup is incomplete", [failure], paths,
+            "Upgrade transaction completed but staging cleanup is incomplete",
+            [new Error(`Remote local upgrade ended with ${status}`)],
+            paths,
         );
     }
     if (status.includes("CLEANUP")) {
         throw remoteReconciliationFailure(
-            "Upgrade transaction and staging cleanup both failed", [failure], paths,
+            "Upgrade transaction and staging cleanup both failed",
+            [new Error(`Remote local upgrade ended with ${status}`)],
+            paths,
         );
     }
+    let failureEvidence: UpgradeFailureEvidence;
+    try {
+        failureEvidence = parseUpgradeFailureEvidence(log);
+    } catch (error: unknown) {
+        throw remoteReconciliationFailure(
+            "Remote upgrade failed without valid structured failure evidence", [error], paths,
+        );
+    }
+    const failure = new Error(
+        `Remote local upgrade failed (${status}): ${failureEvidence.summary}`
+        + (failureEvidence.causes.length > 0 ? `; causes: ${failureEvidence.causes.join(" | ")}` : ""),
+    );
     try {
         await cleanupRemoteRecords(ssh, paths);
     } catch (cleanupError: unknown) {

--- a/packages/admin/src/shared/transports/ssh.test.ts
+++ b/packages/admin/src/shared/transports/ssh.test.ts
@@ -164,6 +164,7 @@ describe("SshTransport audit safety", () => {
             "export PGRST_JWT_SECRET='jwt secret with spaces'",
             '{"token":"api-token","status":"ok"}',
             "DATABASE_URL=postgres://admin:url-password@localhost/postgres",
+            "postgresql://:empty-user-password@localhost/postgres",
             "Authorization: Bearer bearer-token",
             "PUBLIC_DOMAIN=api.example.com",
         ].join("\n"));
@@ -172,9 +173,43 @@ describe("SshTransport audit safety", () => {
         expect(output).not.toContain("jwt secret with spaces");
         expect(output).not.toContain("api-token");
         expect(output).not.toContain("url-password");
+        expect(output).not.toContain("empty-user-password");
         expect(output).not.toContain("bearer-token");
         expect(output).toContain("PUBLIC_DOMAIN=api.example.com");
         expect(output.match(/\[REDACTED\]/g)?.length).toBeGreaterThanOrEqual(5);
+        expect(redactSshOutput('{"token":"[REDACTED]"}')).toBe('{"token":"[REDACTED]"}');
+        const escapedOutput = redactSshOutput(String.raw`{\"token\":\"raw-token\"}suffix`);
+        expect(escapedOutput).toBe("[REDACTED: structured secret output]");
+        expect(escapedOutput).not.toContain("raw-token");
+        for (const structuredSecret of [
+            String.raw`{"token":"prefix-\\"synthetic-escaped-tail"}`,
+            String.raw`{"to\\u006ben":"unicode-token"}`,
+            String.raw`{\"to\\u006ben\":\"escaped-unicode-token\"}`,
+            String.raw`{to\\u006ben:"unquoted-unicode-token"}`,
+            String.raw`{to\\u{006b}en:"codepoint-unicode-token"}`,
+        ]) {
+            expect(redactSshOutput(structuredSecret)).toBe("[REDACTED: structured secret output]");
+        }
+    });
+
+    test("marks command output when transport redaction changed it", async () => {
+        const client = new FakeSshClient();
+        client.stdout = Buffer.from("DATABASE_URL=postgres://admin:database-password@localhost/postgres\n");
+        const transport = new SshTransport({
+            host: "server.example.com",
+            port: 22,
+            username: "root",
+            hostFingerprint: TEST_HOST_FINGERPRINT,
+        }, { clientFactory: () => client as never });
+
+        try {
+            const result = await transport.exec("hostname");
+            expect(result.stdout).toContain("[REDACTED]");
+            expect(result.stdout).not.toContain("database-password");
+            expect(result.stdoutRedacted).toBe(true);
+        } finally {
+            transport.close();
+        }
     });
 
     test("redacts secrets from blocked results, console output, and retained audit entries", async () => {

--- a/packages/admin/src/shared/transports/ssh.ts
+++ b/packages/admin/src/shared/transports/ssh.ts
@@ -38,6 +38,8 @@ export interface SshResult {
     code: number;
     stdoutTruncated?: boolean;
     stderrTruncated?: boolean;
+    stdoutRedacted?: boolean;
+    stderrRedacted?: boolean;
 }
 
 export class SshCommandOutcomeUnknownError extends Error {
@@ -112,7 +114,7 @@ class BoundedOutputCollector {
         this.truncated = buffer.length > copied;
     }
 
-    finalize(): string {
+    finalize(): { output: string; redacted: boolean } {
         let output = this.storage.subarray(0, this.bytes).toString("utf8");
         if (this.truncated) {
             // Never retain an incomplete final line: it may contain a credential
@@ -121,8 +123,10 @@ class BoundedOutputCollector {
             output = lastNewline >= 0 ? output.slice(0, lastNewline + 1) : "";
         }
         const redacted = redactSshOutput(output);
-        if (!this.truncated) return redacted;
-        return `${redacted}${redacted && !redacted.endsWith("\n") ? "\n" : ""}[TRUNCATED: output exceeded ${this.limit}-byte limit]`;
+        const bounded = !this.truncated
+            ? redacted
+            : `${redacted}${redacted && !redacted.endsWith("\n") ? "\n" : ""}[TRUNCATED: output exceeded ${this.limit}-byte limit]`;
+        return { output: bounded, redacted: redacted !== output };
     }
 }
 
@@ -145,17 +149,80 @@ export function redactSshCommand(command: string): string {
             "$1$2Bearer [REDACTED]$2",
         )
         .replace(/(\b--(?:password|token|secret|api-key)\s+)(\S+)/gi, "$1[REDACTED]")
-        .replace(/(postgres(?:ql)?:\/\/[^:\s/]+:)[^@\s]+@/gi, "$1[REDACTED]@");
+        .replace(/(postgres(?:ql)?:\/\/[^:\s/]*:)[^@\s]+@/gi, "$1[REDACTED]@");
+}
+
+const SENSITIVE_STRUCTURED_FIELD = /(?:password|pass|secret|token|key|credential|db_uri|database_url|dsn)/i;
+
+function decodedStructuredFieldName(encodedName: string): string | null {
+    let decodedName = encodedName.replace(/\\'/g, "'");
+    for (let decodingPass = 0; decodingPass < 3; decodingPass += 1) {
+        if (decodedName.length > 256) return null;
+        try {
+            const nextName = JSON.parse(`"${decodedName.replace(/"/g, '\\"')}"`);
+            if (typeof nextName !== "string" || nextName === decodedName) return decodedName;
+            decodedName = nextName;
+        } catch {
+            return null;
+        }
+    }
+    return decodedName;
+}
+
+function containsSensitiveStructuredField(message: string): boolean {
+    const normalizedQuotes = message.replace(/\\"/g, '"').replace(/\\'/g, "'");
+    const fieldPatterns = [
+        /"((?:\\.|[^"\\\r\n])*)"\s*:/g,
+        /'((?:\\.|[^'\\\r\n])*)'\s*:/g,
+        /(?:^|[{,]\s*)([A-Za-z_$\\][A-Za-z0-9_$\\{}]{0,255})\s*:/g,
+    ];
+    return fieldPatterns.some(pattern => [...normalizedQuotes.matchAll(pattern)].some(match => {
+        const decodedName = decodedStructuredFieldName(match[1]!);
+        return decodedName === null || SENSITIVE_STRUCTURED_FIELD.test(decodedName);
+    }));
+}
+
+function structuredSensitiveFieldsAreRedacted(message: string): boolean {
+    const normalizedQuotes = message.replace(/\\"/g, '"').replace(/\\'/g, "'");
+    try {
+        const parsedDiagnostic = JSON.parse(normalizedQuotes);
+        if (!parsedDiagnostic || typeof parsedDiagnostic !== "object") return false;
+        let foundSensitiveField = false;
+        const pending = [parsedDiagnostic];
+        while (pending.length > 0) {
+            const current = pending.pop();
+            if (!current || typeof current !== "object") continue;
+            for (const [fieldName, fieldValue] of Object.entries(current)) {
+                if (SENSITIVE_STRUCTURED_FIELD.test(fieldName)) {
+                    foundSensitiveField = true;
+                    if (fieldValue !== "[REDACTED]") return false;
+                } else if (fieldValue && typeof fieldValue === "object") {
+                    pending.push(fieldValue);
+                }
+            }
+        }
+        return foundSensitiveField;
+    } catch {
+        return false;
+    }
 }
 
 export function redactSshOutput(output: string): string {
-    const redactedLines = output.replace(
+    const redactedEscapedFields = output.split("\n").map(line => (
+        containsSensitiveStructuredField(line) && !structuredSensitiveFieldsAreRedacted(line)
+            ? "[REDACTED: structured secret output]"
+            : line
+    )).join("\n");
+    const redactedLines = redactedEscapedFields.replace(
         /^(\s*(?:export\s+)?[A-Z0-9_]*(?:PASSWORD|PASS|SECRET|TOKEN|KEY|CREDENTIAL|DB_URI|DATABASE_URL|DSN)[A-Z0-9_]*\s*=\s*).*$/gim,
         "$1[REDACTED]",
     );
     const redactedStructuredFields = redactedLines.replace(
-        /((?:["']?(?:password|pass|secret|token|key|credential|db_uri|database_url|dsn)["']?)\s*:\s*)(?:"[^"]*"|'[^']*'|[^,}\]\r\n]+)/gi,
-        "$1[REDACTED]",
+        /((?:["']?(?:password|pass|secret|token|key|credential|db_uri|database_url|dsn)["']?)\s*:\s*)("[^"]*"|'[^']*'|[^,}\]\r\n]+)/gi,
+        (_match, prefix: string, literal: string) => {
+            const quote = literal[0];
+            return `${prefix}${quote === '"' || quote === "'" ? `${quote}[REDACTED]${quote}` : "[REDACTED]"}`;
+        },
     );
     return redactSshCommand(redactedStructuredFields);
 }
@@ -324,13 +391,17 @@ export class SshTransport {
                                     ));
                                     return;
                                 }
+                                const finalizedStdout = stdout.finalize();
+                                const finalizedStderr = stderr.finalize();
                                 resolve({
                                     success: code === 0,
-                                    stdout: stdout.finalize(),
-                                    stderr: stderr.finalize(),
+                                    stdout: finalizedStdout.output,
+                                    stderr: finalizedStderr.output,
                                     code: code ?? 128,
                                     stdoutTruncated: stdout.truncated,
                                     stderrTruncated: stderr.truncated,
+                                    stdoutRedacted: finalizedStdout.redacted,
+                                    stderrRedacted: finalizedStderr.redacted,
                                 });
                             })
                             .on("error", () => {

--- a/packages/management-api/src/index.ts
+++ b/packages/management-api/src/index.ts
@@ -911,7 +911,19 @@ async function recoverDatabaseReplacementsBeforeServe(): Promise<void> {
  * Core logic: Based on command line arguments, decide whether to execute a single task or start the API server.
  */
 async function bootstrap() {
-  if (args.includes("--init-db")) {
+  if (args.includes("--control-plane-upgrade-preflight")) {
+    const {
+      runControlPlaneUpgradePreflight,
+      upgradeFailureReceiptLine,
+    } = await import("./upgrade");
+    try {
+      await runControlPlaneUpgradePreflight();
+      process.exit(0);
+    } catch (err: unknown) {
+      console.error(upgradeFailureReceiptLine(err));
+      process.exit(1);
+    }
+  } else if (args.includes("--init-db")) {
     const { initDatabase } = await import("./db/init");
     try {
       await initDatabase();

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -49,6 +49,7 @@ import {
 } from "./upgrade-lock";
 import { withSigstoreVerificationDirectory } from "./sigstore-trusted-root";
 import {
+    prepareControlPlaneUpgradeSafety,
     withControlPlaneUpgradeSafety,
     type ControlPlaneUpgradeSafetyEvidence,
     type ControlPlaneUpgradeSafetyLease,
@@ -126,7 +127,9 @@ const OFFLINE_BUNDLE_ENDPOINT: GithubEndpoint = {
     label: "verified offline bundle",
     proxyPrefix: "",
 };
+const CONTROL_PLANE_PREFLIGHT_PREFIX = "SUPACLOUD_CONTROL_PLANE_UPGRADE_PREFLIGHT=";
 const CONTROL_PLANE_SAFETY_PREFIX = "SUPACLOUD_CONTROL_PLANE_UPGRADE_SAFETY=";
+const UPGRADE_FAILURE_PREFIX = "SUPACLOUD_UPGRADE_FAILURE=";
 
 export type GithubEndpoint = {
     label: string;
@@ -3238,12 +3241,78 @@ export function upgradeRecoveryPaths(state: UpgradeRecoveryPathState | null): st
     return [...new Set(absentLauncherTarget ? [...presentPaths, absentLauncherTarget] : presentPaths)];
 }
 
+const SENSITIVE_STRUCTURED_FIELD = /(?:password|pass|secret|token|key|credential|db_uri|database_url|dsn)/i;
+
+function decodedStructuredFieldName(encodedName: string): string | null {
+    let decodedName = encodedName.replace(/\\'/g, "'");
+    for (let decodingPass = 0; decodingPass < 3; decodingPass += 1) {
+        if (decodedName.length > 256) return null;
+        try {
+            const nextName = JSON.parse(`"${decodedName.replace(/"/g, '\\"')}"`);
+            if (typeof nextName !== "string" || nextName === decodedName) return decodedName;
+            decodedName = nextName;
+        } catch {
+            return null;
+        }
+    }
+    return decodedName;
+}
+
+function containsSensitiveStructuredField(message: string): boolean {
+    const normalizedQuotes = message.replace(/\\"/g, '"').replace(/\\'/g, "'");
+    const fieldPatterns = [
+        /"((?:\\.|[^"\\\r\n])*)"\s*:/g,
+        /'((?:\\.|[^'\\\r\n])*)'\s*:/g,
+        /(?:^|[{,]\s*)([A-Za-z_$\\][A-Za-z0-9_$\\{}]{0,255})\s*:/g,
+    ];
+    return fieldPatterns.some(pattern => [...normalizedQuotes.matchAll(pattern)].some(match => {
+        const decodedName = decodedStructuredFieldName(match[1]!);
+        return decodedName === null || SENSITIVE_STRUCTURED_FIELD.test(decodedName);
+    }));
+}
+
+function structuredSensitiveFieldsAreRedacted(message: string): boolean {
+    const normalizedQuotes = message.replace(/\\"/g, '"').replace(/\\'/g, "'");
+    try {
+        const parsedDiagnostic = JSON.parse(normalizedQuotes);
+        if (!parsedDiagnostic || typeof parsedDiagnostic !== "object") return false;
+        let foundSensitiveField = false;
+        const pending = [parsedDiagnostic];
+        while (pending.length > 0) {
+            const current = pending.pop();
+            if (!current || typeof current !== "object") continue;
+            for (const [fieldName, fieldValue] of Object.entries(current)) {
+                if (SENSITIVE_STRUCTURED_FIELD.test(fieldName)) {
+                    foundSensitiveField = true;
+                    if (fieldValue !== "[REDACTED]") return false;
+                } else if (fieldValue && typeof fieldValue === "object") {
+                    pending.push(fieldValue);
+                }
+            }
+        }
+        return foundSensitiveField;
+    } catch {
+        return false;
+    }
+}
+
 function sanitizedUpgradeDiagnostic(error: unknown): string {
     const message = error instanceof Error ? error.message : String(error);
+    if (containsSensitiveStructuredField(message) && !structuredSensitiveFieldsAreRedacted(message)) {
+        return "Upgrade failure details were redacted";
+    }
     return message
+        .replace(
+            /((?:["']?(?:password|pass|secret|token|key|credential|db_uri|database_url|dsn)["']?)\s*:\s*)("[^"]*"|'[^']*'|[^,}\]\r\n]+)/gi,
+            (_match, prefix: string, literal: string) => {
+                const quote = literal[0];
+                return `${prefix}${quote === '"' || quote === "'" ? `${quote}[REDACTED]${quote}` : "[REDACTED]"}`;
+            },
+        )
         .replace(/(\b(?:[A-Z0-9_]*(?:PASSWORD|PASS|SECRET|TOKEN|KEY|CREDENTIAL)[A-Z0-9_]*|DATABASE_URL|DB_URI|DSN)=)(?:"[^"]*"|'[^']*'|[^\s;]+)/gi, "$1[REDACTED]")
-        .replace(/(postgres(?:ql)?:\/\/[^:\s/]+:)[^@\s]+@/gi, "$1[REDACTED]@")
-        .replace(/[\r\n\t]+/g, " ")
+        .replace(/(postgres(?:ql)?:\/\/[^:\s/]*:)[^@\s]+@/gi, "$1[REDACTED]@")
+        .replace(/(\bBearer\s+)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+)/gi, "$1[REDACTED]")
+        .replace(/[\u0000-\u001f\u007f]+/g, " ")
         .trim()
         .slice(0, 500);
 }
@@ -3289,6 +3358,40 @@ export function controlPlaneSafetyReceiptLine(evidence: ControlPlaneUpgradeSafet
     return `${CONTROL_PLANE_SAFETY_PREFIX}${JSON.stringify(evidence)}`;
 }
 
+export function controlPlanePreflightReceiptLine(evidence: ControlPlaneUpgradeSafetyEvidence): string {
+    return `${CONTROL_PLANE_PREFLIGHT_PREFIX}${JSON.stringify(evidence)}`;
+}
+
+type UpgradeFailureEvidence = {
+    schema: "supacloud.upgrade-failure.v1";
+    summary: string;
+    causes: string[];
+};
+
+export function upgradeFailureReceiptLine(error: unknown): string {
+    const summary = sanitizedUpgradeDiagnostic(error);
+    const causes = [...new Set(nestedUpgradeDiagnostics(error))]
+        .filter(message => message && message !== summary)
+        .slice(0, 8);
+    const evidence: UpgradeFailureEvidence = {
+        schema: "supacloud.upgrade-failure.v1",
+        summary,
+        causes,
+    };
+    return `${UPGRADE_FAILURE_PREFIX}${JSON.stringify(evidence)}`;
+}
+
+export async function runControlPlaneUpgradePreflight(): Promise<ControlPlaneUpgradeSafetyEvidence> {
+    verifyBackupPrivilegeDropPreflight();
+    const preparedSecrets = prepareUpgradeSecrets(await resolveUpgradeEnvironment());
+    const databaseUrl = preparedSecrets.runtimeEnv.DATABASE_URL;
+    if (!databaseUrl) throw new Error("DATABASE_URL is required for the control-plane upgrade preflight");
+    const encryptionKey = preparedSecrets.runtimeSecretsToPersist.SECRETS_ENCRYPTION_KEY;
+    const evidence = await prepareControlPlaneUpgradeSafety(databaseUrl, encryptionKey);
+    console.log(controlPlanePreflightReceiptLine(evidence));
+    return evidence;
+}
+
 export async function runUpgrade(options: RunUpgradeOptions = {}) {
     p.intro("\x1b[46m SupaCloud Binary Upgrade \x1b[0m");
 
@@ -3323,6 +3426,7 @@ export async function runUpgrade(options: RunUpgradeOptions = {}) {
         p.outro(upgradeSuccessMessage(executionContext));
     } catch (error: unknown) {
         s.stop(formatUpgradeFailure(error, upgradeRecoveryPaths(executionContext?.state ?? null)));
+        console.error(upgradeFailureReceiptLine(error));
         process.exit(1);
     }
 }

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -34,6 +34,7 @@ import {
     applyGrafanaUpgradeSettings,
     captureFileState,
     cleanupBinaryBackup,
+    controlPlanePreflightReceiptLine,
     controlPlaneSafetyReceiptLine,
     createBinaryBackupState,
     executeUpgradeTransaction,
@@ -79,6 +80,7 @@ import {
     upsertManagementWebConsoleDir,
     upsertPersistedEdgeRuntimePort,
     upsertEdgeRuntimeIdentityDefaults,
+    upgradeFailureReceiptLine,
     UpgradeTransactionError,
     type UpgradeActivationState,
     upgradeRecoveryPaths,
@@ -565,6 +567,53 @@ describe("upgrade release selection", () => {
     expect(JSON.parse(line.split("=", 2)[1]!)).toEqual(controlPlaneSafetyEvidence);
     expect(line).not.toContain("private-password");
     expect(line).not.toContain(controlPlaneDatabaseFingerprint);
+  });
+
+  test("prints distinct preflight and redacted failure receipts", () => {
+    const preflight = controlPlanePreflightReceiptLine(controlPlaneSafetyEvidence);
+    expect(preflight).toStartWith("SUPACLOUD_CONTROL_PLANE_UPGRADE_PREFLIGHT=");
+    expect(JSON.parse(preflight.split("=", 2)[1]!)).toEqual(controlPlaneSafetyEvidence);
+
+    const failure = new AggregateError([
+      new Error("DATABASE_URL=postgresql://admin:database-password@localhost/supacloud"),
+      new Error("API_TOKEN=raw-token"),
+    ], "Control-plane backup failed");
+    const line = upgradeFailureReceiptLine(failure);
+    expect(line).toStartWith("SUPACLOUD_UPGRADE_FAILURE=");
+    expect(JSON.parse(line.slice(line.indexOf("=") + 1))).toEqual({
+      schema: "supacloud.upgrade-failure.v1",
+      summary: "Control-plane backup failed",
+      causes: ["DATABASE_URL=[REDACTED]", "API_TOKEN=[REDACTED]"],
+    });
+    expect(line).not.toContain("database-password");
+    expect(line).not.toContain("raw-token");
+    expect(upgradeFailureReceiptLine(new Error("failure\u0000with\u007fcontrols")))
+      .toContain('"summary":"failure with controls"');
+    expect(upgradeFailureReceiptLine(new Error("Authorization: Bearer raw-access-token")))
+      .toContain('"summary":"Authorization: Bearer [REDACTED]"');
+    expect(upgradeFailureReceiptLine(new Error("postgresql://:raw-password@localhost/supacloud")))
+      .toContain("postgresql://:[REDACTED]@localhost/supacloud");
+    expect(upgradeFailureReceiptLine(new Error('{"token":"raw-token"}')))
+      .toContain('"summary":"Upgrade failure details were redacted"');
+    const escapedStructuredSecret = String.raw`{\"token\":\"raw-token\"}suffix`;
+    const escapedReceipt = upgradeFailureReceiptLine(new Error(escapedStructuredSecret));
+    expect(escapedReceipt).toContain('"summary":"Upgrade failure details were redacted"');
+    expect(escapedReceipt).not.toContain("raw-token");
+    for (const structuredSecret of [
+      String.raw`{"token":"prefix-\\"synthetic-escaped-tail"}`,
+      String.raw`{"to\\u006ben":"unicode-token"}`,
+      String.raw`{\"to\\u006ben\":\"escaped-unicode-token\"}`,
+      String.raw`{to\\u006ben:"unquoted-unicode-token"}`,
+      String.raw`{to\\u{006b}en:"codepoint-unicode-token"}`,
+    ]) {
+      const structuredReceipt = upgradeFailureReceiptLine(new Error(structuredSecret));
+      expect(structuredReceipt).toContain('"summary":"Upgrade failure details were redacted"');
+      expect(structuredReceipt).not.toContain("synthetic-escaped-tail");
+      expect(structuredReceipt).not.toContain("unicode-token");
+      expect(structuredReceipt).not.toContain("escaped-unicode-token");
+      expect(structuredReceipt).not.toContain("unquoted-unicode-token");
+      expect(structuredReceipt).not.toContain("codepoint-unicode-token");
+    }
   });
 
   test("recovers a service that partially stopped before reporting a systemctl error", async () => {


### PR DESCRIPTION
## Summary
- verify an independent control-plane pg_dump/pg_restore preflight before stopping Management or running migrations
- require distinct preflight and transaction safety receipts, preserving remote evidence on malformed or redacted output
- fail closed on secret-bearing structured diagnostics across raw, escaped, Unicode-escaped, and unquoted field names
- raise the Admin local-upgrade gate to Management 0.61.7

## Supabase alignment
- follows the official self-hosted guidance to take an independent database backup before updating
- validates recoverability before mutation and retains rollback evidence until post-upgrade verification
- keeps stop/migration/restart ordering transactional; no GoTrue changes

## Verification
- Management unit gate: PASS (1633+ shared/isolated tests, latest run exit 0)
- Admin full suite: 485 pass, 26 skip, 0 fail
- targeted Management: 99 pass, 0 fail
- targeted Admin: 77 pass, 0 fail
- Management/Admin typecheck: PASS
- Admin build and Linux amd64 Management compile: PASS
- independent platform and security final reviews: GO
- git diff --check: PASS