### PR TITLE
fix(upgrade): isolate generic control-plane backup

### DIFF
--- a/packages/management-api/src/control-plane-upgrade-safety.ts
+++ b/packages/management-api/src/control-plane-upgrade-safety.ts
@@ -12,8 +12,10 @@ import {
   readFileSync,
   readSync,
   readdirSync,
+  renameSync,
   rmSync,
   type Stats,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -27,14 +29,14 @@ import { hasSecretEncryptionCheckpoint } from "./db/secret-key-migration";
 const BACKUP_ROOT = "/var/lib/supacloud/backups/control-plane-upgrades";
 const BACKUP_ID_PATTERN = /^control-plane-\d{8}T\d{6}Z-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const BACKUP_LIMIT = 5;
-const BACKUP_USER = "postgres";
 const COMMAND_TIMEOUT_SECONDS = 1800;
+const SYSTEMD_RUN_TIMEOUT_SECONDS = COMMAND_TIMEOUT_SECONDS + 60;
 const MAX_RECEIPT_BYTES = 8 * 1024;
 const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_.-]{0,62}$/;
-const SETPRIV_PATH = ["/usr/bin/setpriv", "/bin/setpriv"].find(existsSync) ?? "/usr/bin/setpriv";
-const ID_PATH = ["/usr/bin/id", "/bin/id"].find(existsSync) ?? "/usr/bin/id";
 const PG_DUMP_PATH = ["/usr/bin/pg_dump", "/usr/local/bin/pg_dump"].find(existsSync) ?? "/usr/bin/pg_dump";
 const PG_RESTORE_PATH = ["/usr/bin/pg_restore", "/usr/local/bin/pg_restore"].find(existsSync) ?? "/usr/bin/pg_restore";
+const SYSTEMD_RUN_PATH = ["/usr/bin/systemd-run", "/bin/systemd-run"].find(existsSync) ?? "/usr/bin/systemd-run";
+const SYSTEMCTL_PATH = ["/usr/bin/systemctl", "/bin/systemctl"].find(existsSync) ?? "/usr/bin/systemctl";
 const TIMEOUT_PATH = ["/usr/bin/timeout", "/bin/timeout"].find(existsSync) ?? "/usr/bin/timeout";
 
 export type ControlPlaneMigrationCandidates = {
@@ -66,19 +68,34 @@ type DatabaseTarget = {
 
 type CommandRequest = {
   args: string[];
-  env?: Record<string, string | undefined>;
   stdin?: number;
   stdout?: number;
 };
 
 type ControlPlaneBackupOperations = {
   backupRoot: string;
-  identity: (user: string) => Promise<{ gid: number; uid: number }>;
   now: () => Date;
   randomId: () => string;
+  reconcileUnit?: (unitName: string) => Promise<void>;
   remove?: (directory: string) => void;
   run: (request: CommandRequest) => Promise<number>;
 };
+
+type CapturedCommand = {
+  exitCode: number;
+  stdout: string;
+};
+
+type UnitReconciliationOperations = {
+  capture: (args: string[]) => Promise<CapturedCommand>;
+  run: (request: CommandRequest) => Promise<number>;
+};
+
+class UnreconciledBackupUnitError extends AggregateError {
+  constructor(dumpError: unknown, reconciliationError: unknown) {
+    super([dumpError, reconciliationError], "Control-plane pg_dump failure could not be reconciled");
+  }
+}
 
 type ControlPlaneSafetyOperations = {
   backup: (
@@ -278,24 +295,9 @@ async function withControlPlaneInspection<T>(
   }
 }
 
-async function commandIdentity(user: string): Promise<{ gid: number; uid: number }> {
-  const values = await Promise.all(["-u", "-g"].map(async (flag) => {
-    const process = Bun.spawn([TIMEOUT_PATH, "5", ID_PATH, flag, user], {
-      env: {}, stdout: "pipe", stderr: "ignore",
-    });
-    const [exitCode, stdout] = await Promise.all([process.exited, new Response(process.stdout).text()]);
-    const numericIdentity = stdout.trim();
-    if (exitCode !== 0 || !/^\d+$/.test(numericIdentity)) {
-      throw new Error("Control-plane backup account lookup failed");
-    }
-    return Number(numericIdentity);
-  }));
-  return { uid: values[0]!, gid: values[1]! };
-}
-
 async function runCommand(request: CommandRequest): Promise<number> {
   const childProcess = Bun.spawn(request.args, {
-    env: request.env ?? {},
+    env: {},
     stdin: request.stdin ?? "ignore",
     stdout: request.stdout ?? "ignore",
     stderr: "ignore",
@@ -303,10 +305,18 @@ async function runCommand(request: CommandRequest): Promise<number> {
   return childProcess.exited;
 }
 
+async function captureCommand(args: string[]): Promise<CapturedCommand> {
+  const childProcess = Bun.spawn(args, { env: {}, stdout: "pipe", stderr: "ignore" });
+  const [exitCode, stdout] = await Promise.all([
+    childProcess.exited,
+    new Response(childProcess.stdout).text(),
+  ]);
+  return { exitCode, stdout };
+}
+
 function defaultBackupOperations(): ControlPlaneBackupOperations {
   return {
     backupRoot: BACKUP_ROOT,
-    identity: commandIdentity,
     now: () => new Date(),
     randomId: randomUUID,
     run: runCommand,
@@ -333,10 +343,100 @@ function createBackupDirectory(operations: ControlPlaneBackupOperations, backupI
   return backupDirectory;
 }
 
-function dumpArguments(target: DatabaseTarget, inspection: ControlPlaneInspection, uid: number, gid: number): string[] {
+function pgpassField(field: string): string {
+  if (/[\r\n]/.test(field)) throw new Error("Control-plane backup credentials cannot contain line breaks");
+  return field.replaceAll("\\", "\\\\").replaceAll(":", "\\:");
+}
+
+function writePgpassCredential(filePath: string, target: DatabaseTarget): void {
+  const fields = [target.hostname, target.port, target.database, target.username, target.password].map(pgpassField);
+  writeFileSync(filePath, `${fields.join(":")}\n`, { flag: "wx", mode: 0o600 });
+  assertBackupArchive(lstatSync(filePath), process.getuid?.() ?? 0);
+}
+
+function backupUnitName(backupId: string): string {
+  if (!BACKUP_ID_PATTERN.test(backupId)) throw new Error("Control-plane backup ID is invalid");
+  return `supacloud-${backupId}`;
+}
+
+function inactiveBackupUnit(output: CapturedCommand): boolean {
+  if (output.exitCode !== 0 || output.stdout.length > 512) return false;
+  const lines = output.stdout.trim().split("\n");
+  if (lines.length !== 4 || lines.some((line) => !line.includes("="))) return false;
+  const properties = new Map(lines.map((line) => line.split("=", 2) as [string, string]));
+  if (properties.size !== 4) return false;
+  const activeState = properties.get("ActiveState");
+  const loadState = properties.get("LoadState");
+  return ["inactive", "failed"].includes(activeState ?? "")
+    && ["loaded", "not-found"].includes(loadState ?? "")
+    && ["dead", "failed"].includes(properties.get("SubState") ?? "")
+    && properties.get("MainPID") === "0";
+}
+
+async function reconcileBackupUnit(
+  unitName: string,
+  operations: UnitReconciliationOperations = { capture: captureCommand, run: runCommand },
+): Promise<void> {
+  const service = `${unitName}.service`;
+  await operations.run({ args: [TIMEOUT_PATH, "45", SYSTEMCTL_PATH, "stop", "--", service] });
+  const state = await operations.capture([
+    TIMEOUT_PATH, "10", SYSTEMCTL_PATH, "show",
+    "--property=LoadState", "--property=ActiveState", "--property=SubState", "--property=MainPID",
+    "--", service,
+  ]);
+  if (!inactiveBackupUnit(state)) throw new Error("Control-plane backup transient unit did not stop cleanly");
+}
+
+async function runIsolatedDump(
+  request: CommandRequest,
+  unitName: string,
+  operations: ControlPlaneBackupOperations,
+): Promise<void> {
+  let dumpError: unknown;
+  try {
+    if (await operations.run(request) === 0) return;
+    dumpError = new Error("Control-plane pg_dump failed");
+  } catch (error: unknown) {
+    dumpError = error;
+  }
+  try {
+    await (operations.reconcileUnit ?? reconcileBackupUnit)(unitName);
+  } catch (reconciliationError: unknown) {
+    throw new UnreconciledBackupUnitError(dumpError, reconciliationError);
+  }
+  throw dumpError;
+}
+
+function quarantineUnresolvedBackup(
+  backupDirectory: string,
+  credentialPath: string,
+  backupRoot: string,
+): void {
+  rmSync(credentialPath, { force: true });
+  renameSync(backupDirectory, `${backupDirectory}.unresolved`);
+  syncPath(backupRoot, true);
+}
+
+function dumpArguments(
+  target: DatabaseTarget,
+  inspection: ControlPlaneInspection,
+  unitName: string,
+  credentialPath: string,
+): string[] {
+  const credentialDirectory = `/run/credentials/${unitName}.service`;
   return [
-    TIMEOUT_PATH, "--kill-after=30s", String(COMMAND_TIMEOUT_SECONDS),
-    SETPRIV_PATH, "--reuid", String(uid), "--regid", String(gid), "--init-groups", "--",
+    TIMEOUT_PATH, "--kill-after=30s", String(SYSTEMD_RUN_TIMEOUT_SECONDS),
+    SYSTEMD_RUN_PATH, "--quiet", "--wait", "--pipe", "--collect", `--unit=${unitName}`,
+    "--property=Type=exec", "--property=KillMode=control-group", "--property=TimeoutStopSec=30s",
+    `--property=RuntimeMaxSec=${COMMAND_TIMEOUT_SECONDS}s`,
+    "--property=DynamicUser=yes", "--property=NoNewPrivileges=yes",
+    "--property=PrivateTmp=yes", "--property=ProtectHome=yes", "--property=ProtectSystem=strict",
+    "--property=ProtectProc=invisible", "--property=ProcSubset=pid", "--property=PrivateDevices=yes",
+    "--property=ProtectKernelTunables=yes", "--property=ProtectKernelModules=yes",
+    "--property=ProtectControlGroups=yes", "--property=LockPersonality=yes",
+    "--property=RestrictSUIDSGID=yes", "--property=RestrictRealtime=yes", "--property=UMask=0077",
+    `--property=LoadCredential=pgpass:${credentialPath}`,
+    `--property=Environment=PGPASSFILE=${credentialDirectory}/pgpass`, "--",
     PG_DUMP_PATH, "--host", target.hostname, "--port", target.port, "--username", target.username,
     "--dbname", target.database, "--format=custom", "--compress=6", "--snapshot", inspection.snapshotId,
   ];
@@ -524,18 +624,20 @@ async function createControlPlaneBackup(
   const backupId = `control-plane-${completedTimestamp(operations.now())}-${operations.randomId()}`;
   const backupDirectory = createBackupDirectory(operations, backupId);
   const archivePath = join(backupDirectory, "control-plane.dump");
+  const credentialPath = join(backupDirectory, ".pgpass");
   let durableBackup = false;
   try {
-    const backupIdentity = await operations.identity(BACKUP_USER);
+    writePgpassCredential(credentialPath, target);
     const archiveDescriptor = reserveBackupArchive(archivePath);
     let bytes: number;
     let sha256: string;
     try {
-      if (await operations.run({
-        args: dumpArguments(target, inspection, backupIdentity.uid, backupIdentity.gid),
-        env: { PGPASSWORD: target.password },
+      const unitName = backupUnitName(backupId);
+      await runIsolatedDump({
+        args: dumpArguments(target, inspection, unitName, credentialPath),
         stdout: archiveDescriptor,
-      }) !== 0) throw new Error("Control-plane pg_dump failed");
+      }, unitName, operations);
+      unlinkSync(credentialPath);
       fsyncSync(archiveDescriptor);
       assertStableBackupArchive(archivePath, archiveDescriptor);
       bytes = fstatSync(archiveDescriptor).size;
@@ -574,7 +676,13 @@ async function createControlPlaneBackup(
     syncPath(operations.backupRoot, true);
     return evidence;
   } catch (error: unknown) {
-    if (!durableBackup) rmSync(backupDirectory, { force: true, recursive: true });
+    if (!durableBackup) {
+      if (error instanceof UnreconciledBackupUnitError) {
+        quarantineUnresolvedBackup(backupDirectory, credentialPath, operations.backupRoot);
+      } else {
+        rmSync(backupDirectory, { force: true, recursive: true });
+      }
+    }
     throw error;
   }
 }
@@ -620,5 +728,8 @@ export const controlPlaneUpgradeSafetyInternals = {
   databaseTargetFingerprint,
   databaseTarget,
   dumpArguments,
+  inactiveBackupUnit,
+  pgpassField,
+  reconcileBackupUnit,
   verifyArguments,
 };

--- a/packages/management-api/src/upgrade.ts
+++ b/packages/management-api/src/upgrade.ts
@@ -549,13 +549,13 @@ export async function verifyManagementUpgradePreflight(
 export function verifyBackupPrivilegeDropPreflight(
     pathExists: (filePath: string) => boolean = existsSync,
 ): void {
-    const setprivPath = ["/usr/bin/setpriv", "/bin/setpriv"].find(pathExists);
-    const idPath = ["/usr/bin/id", "/bin/id"].find(pathExists);
+    const systemdRunPath = ["/usr/bin/systemd-run", "/bin/systemd-run"].find(pathExists);
     const pgDumpPath = ["/usr/bin/pg_dump", "/usr/local/bin/pg_dump"].find(pathExists);
     const pgRestorePath = ["/usr/bin/pg_restore", "/usr/local/bin/pg_restore"].find(pathExists);
+    const systemctlPath = ["/usr/bin/systemctl", "/bin/systemctl"].find(pathExists);
     const timeoutPath = ["/usr/bin/timeout", "/bin/timeout"].find(pathExists);
-    if (!setprivPath) throw new Error("Management upgrade requires setpriv for backup privilege separation");
-    if (!idPath) throw new Error("Management upgrade requires id for backup account resolution");
+    if (!systemdRunPath) throw new Error("Management upgrade requires systemd-run for isolated backups");
+    if (!systemctlPath) throw new Error("Management upgrade requires systemctl for backup reconciliation");
     if (!pgDumpPath || !pgRestorePath) throw new Error("Management upgrade requires pg_dump and pg_restore");
     if (!timeoutPath) throw new Error("Management upgrade requires timeout for bounded backup commands");
 }

--- a/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
+++ b/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
@@ -54,21 +54,22 @@ function writeTrustedBackup(backupRoot: string, backupId: string): void {
 }
 
 describe("control-plane upgrade safety", () => {
-  test("creates a private verified dump receipt without putting the password in command arguments", async () => {
+  test("creates a private verified dump receipt with a systemd credential", async () => {
     const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-backup-"));
     chmodSync(backupRoot, 0o700);
     const commands: string[][] = [];
     try {
       const evidence = await controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000001",
-        run: async ({ args, env, stdin, stdout }) => {
+        run: async ({ args, stdin, stdout }) => {
           commands.push(args);
           if (args.some((argument) => argument.endsWith("/pg_dump"))) {
-            expect(env?.PGPASSWORD).toBe("private-password");
-            expect(Object.keys(env || {})).toEqual(["PGPASSWORD"]);
+            const credential = args.find((argument) => argument.startsWith("--property=LoadCredential=pgpass:"));
+            const credentialPath = credential?.slice("--property=LoadCredential=pgpass:".length);
+            expect(statSync(credentialPath!).mode & 0o777).toBe(0o600);
+            expect(readFileSync(credentialPath!, "utf8")).toBe("127.0.0.1:5432:supacloud_meta:postgres:private-password\n");
             writeFileSync(stdout!, "verified-control-plane-dump");
           }
           if (args.some((argument) => argument.endsWith("/pg_restore"))) {
@@ -78,8 +79,13 @@ describe("control-plane upgrade safety", () => {
         },
       });
 
-      expect(commands.flat()).not.toContain("private-password");
-      expect(commands[0]).toContain("--reuid");
+      expect(commands.flat().join("\0")).not.toContain("private-password");
+      expect(commands[0]).toContain("--property=DynamicUser=yes");
+      expect(commands[0]).toContain("--property=ProtectProc=invisible");
+      expect(commands[0]).toContain("--property=ProcSubset=pid");
+      expect(commands[0]).toContain("--property=RuntimeMaxSec=1800s");
+      expect(commands[0]).toContain("--property=KillMode=control-group");
+      expect(commands[0]?.some((argument) => argument.startsWith("--property=Environment=PGPASSFILE=/run/credentials/"))).toBe(true);
       expect(commands[0]).toContain("--snapshot");
       expect(commands[0]).toContain(inspection.snapshotId);
       expect(commands[1]?.some((argument) => argument.endsWith("/pg_restore"))).toBe(true);
@@ -94,6 +100,7 @@ describe("control-plane upgrade safety", () => {
       expect(evidence.sha256).toMatch(/^[0-9a-f]{64}$/);
       expect(statSync(join(evidence.backup_directory, "control-plane.dump")).mode & 0o777).toBe(0o600);
       expect(statSync(join(evidence.backup_directory, "receipt.json")).mode & 0o777).toBe(0o600);
+      expect(readdirSync(evidence.backup_directory).sort()).toEqual(["control-plane.dump", "receipt.json"]);
       expect(JSON.parse(readFileSync(join(evidence.backup_directory, "receipt.json"), "utf8"))).toEqual(evidence);
     } finally {
       rmSync(backupRoot, { force: true, recursive: true });
@@ -106,7 +113,6 @@ describe("control-plane upgrade safety", () => {
     try {
       await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000002",
         run: async ({ args, stdout }) => {
@@ -122,14 +128,78 @@ describe("control-plane upgrade safety", () => {
     }
   });
 
-  test("lets the postgres identity write only through the inherited root-owned archive descriptor", async () => {
+  test("stops and reads back the transient unit when the systemd-run client fails", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-unit-failure-"));
+    chmodSync(backupRoot, 0o700);
+    let reconciledUnit = "";
+    try {
+      await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000012",
+        reconcileUnit: async (unitName) => { reconciledUnit = unitName; },
+        run: async ({ args }) => args.some((argument) => argument.endsWith("/pg_dump")) ? 124 : 0,
+      })).rejects.toThrow("Control-plane pg_dump failed");
+      expect(reconciledUnit).toBe(
+        "supacloud-control-plane-20260819T000000Z-00000000-0000-4000-8000-000000000012",
+      );
+      expect(readdirSync(backupRoot)).toEqual([]);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("fails closed when transient unit shutdown cannot be proven", async () => {
+    const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-unit-unknown-"));
+    chmodSync(backupRoot, 0o700);
+    try {
+      await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
+        backupRoot,
+        now: () => new Date("2026-08-19T00:00:00.000Z"),
+        randomId: () => "00000000-0000-4000-8000-000000000013",
+        reconcileUnit: async () => { throw new Error("unit state unavailable"); },
+        run: async ({ args }) => args.some((argument) => argument.endsWith("/pg_dump")) ? 124 : 0,
+      })).rejects.toThrow("pg_dump failure could not be reconciled");
+      const [quarantine] = readdirSync(backupRoot);
+      expect(quarantine).toEndWith(".unresolved");
+      expect(readdirSync(join(backupRoot, quarantine!))).toEqual(["control-plane.dump"]);
+      expect(statSync(join(backupRoot, quarantine!)).mode & 0o777).toBe(0o700);
+      expect(statSync(join(backupRoot, quarantine!, "control-plane.dump")).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(backupRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("accepts only an inactive transient unit with no main process", async () => {
+    const commands: string[][] = [];
+    await controlPlaneUpgradeSafetyInternals.reconcileBackupUnit("supacloud-control-plane-test", {
+      capture: async (args) => {
+        commands.push(args);
+        return {
+          exitCode: 0,
+          stdout: "LoadState=not-found\nActiveState=inactive\nSubState=dead\nMainPID=0\n",
+        };
+      },
+      run: async ({ args }) => { commands.push(args); return 1; },
+    });
+    expect(commands[0]).toContain("stop");
+    expect(commands[1]).toContain("show");
+    await expect(controlPlaneUpgradeSafetyInternals.reconcileBackupUnit("supacloud-control-plane-test", {
+      capture: async () => ({
+        exitCode: 0,
+        stdout: "LoadState=loaded\nActiveState=active\nSubState=running\nMainPID=42\n",
+      }),
+      run: async () => 0,
+    })).rejects.toThrow("did not stop cleanly");
+  });
+
+  test("lets an isolated dynamic identity write only through the inherited root-owned archive descriptor", async () => {
     const backupRoot = mkdtempSync(join(tmpdir(), "supacloud-control-plane-descriptor-"));
     chmodSync(backupRoot, 0o700);
     let dumpArguments: string[] = [];
     try {
       const evidence = await controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: 65_534, gid: 65_534 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000007",
         run: async ({ args, stdout }) => {
@@ -140,13 +210,21 @@ describe("control-plane upgrade safety", () => {
           return 0;
         },
       });
-      expect(dumpArguments).toContain("65534");
-      expect(dumpArguments.some((argument) => argument.startsWith(backupRoot))).toBe(false);
+      expect(dumpArguments).toContain("--property=DynamicUser=yes");
+      expect(dumpArguments).toContain("--property=NoNewPrivileges=yes");
+      expect(dumpArguments).toContain("--property=PrivateDevices=yes");
+      expect(dumpArguments.some((argument) => argument.endsWith("/control-plane.dump"))).toBe(false);
       expect(statSync(backupRoot).mode & 0o777).toBe(0o700);
       expect(statSync(evidence.backup_directory).mode & 0o777).toBe(0o700);
     } finally {
       rmSync(backupRoot, { force: true, recursive: true });
     }
+  });
+
+  test("escapes pgpass fields and rejects line breaks", () => {
+    expect(controlPlaneUpgradeSafetyInternals.pgpassField("pa:ss\\word")).toBe("pa\\:ss\\\\word");
+    expect(() => controlPlaneUpgradeSafetyInternals.pgpassField("line\nbreak"))
+      .toThrow("cannot contain line breaks");
   });
 
   test("rejects an empty archive before catalog verification", async () => {
@@ -156,7 +234,6 @@ describe("control-plane upgrade safety", () => {
     try {
       await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000003",
         run: async ({ args }) => {
@@ -180,7 +257,6 @@ describe("control-plane upgrade safety", () => {
       try {
         await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
           backupRoot,
-          identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
           now: () => new Date("2026-08-19T00:00:00.000Z"),
           randomId: () => "00000000-0000-4000-8000-000000000004",
           run: async ({ args, stdout }) => {
@@ -224,7 +300,6 @@ describe("control-plane upgrade safety", () => {
     try {
       const evidence = await controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000005",
         run: async ({ args, stdout }) => {
@@ -260,7 +335,6 @@ describe("control-plane upgrade safety", () => {
     try {
       await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000006",
         run: async ({ args, stdout }) => {
@@ -295,7 +369,6 @@ describe("control-plane upgrade safety", () => {
     try {
       await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000011",
         run: async ({ args, stdout }) => {
@@ -324,7 +397,6 @@ describe("control-plane upgrade safety", () => {
     try {
       await expect(controlPlaneUpgradeSafetyInternals.createControlPlaneBackup(target, inspection, {
         backupRoot,
-        identity: async () => ({ uid: process.getuid?.() ?? 0, gid: process.getgid?.() ?? 0 }),
         now: () => new Date("2026-08-19T00:00:00.000Z"),
         randomId: () => "00000000-0000-4000-8000-000000000008",
         remove: (directory) => {

--- a/packages/management-api/tests/unit/upgrade.test.ts
+++ b/packages/management-api/tests/unit/upgrade.test.ts
@@ -1083,18 +1083,19 @@ describe("upgrade release selection", () => {
     }))).rejects.toThrow("MainPID changed from 4242 to 4343");
   });
 
-  test("upgrade preflight requires setpriv and id before staging", () => {
+  test("upgrade preflight requires systemd-run before staging", () => {
     const installedPaths = new Set([
-      "/usr/bin/setpriv", "/usr/bin/id", "/usr/bin/pg_dump", "/usr/bin/pg_restore", "/usr/bin/timeout",
+      "/usr/bin/systemd-run", "/usr/bin/systemctl", "/usr/bin/pg_dump", "/usr/bin/pg_restore", "/usr/bin/timeout",
     ]);
     expect(() => verifyBackupPrivilegeDropPreflight((filePath) => installedPaths.has(filePath))).not.toThrow();
-    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => filePath.endsWith("/id")))
-      .toThrow("requires setpriv");
-    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => filePath.endsWith("/setpriv")))
-      .toThrow("requires id");
+    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => !filePath.endsWith("/systemd-run")))
+      .toThrow("requires systemd-run");
+    expect(() => verifyBackupPrivilegeDropPreflight((filePath) => !filePath.endsWith("/systemctl")))
+      .toThrow("requires systemctl");
     expect(() => verifyBackupPrivilegeDropPreflight((filePath) => (
-      filePath.endsWith("/setpriv") || filePath.endsWith("/id")
-    ))).toThrow("requires pg_dump and pg_restore");
+      filePath.endsWith("/systemd-run") || filePath.endsWith("/systemctl")
+    )))
+      .toThrow("requires pg_dump and pg_restore");
     expect(() => verifyBackupPrivilegeDropPreflight((filePath) => !filePath.endsWith("/timeout")))
       .toThrow("requires timeout");
   });


### PR DESCRIPTION
## Summary

- replace the local postgres OS-account assumption with a hardened systemd transient service
- use DynamicUser plus LoadCredential-backed pgpass so the database password is absent from argv and the ordinary child environment
- preserve the root-reserved archive descriptor, exported snapshot, fresh pg_restore catalog validation, digest/receipt checks, and bounded retention
- on timeout, stop and strictly read back the transient unit; quarantine unresolved root-only evidence instead of deleting a potentially live archive inode
- require systemd-run and systemctl in direct Management upgrade preflight

## Production evidence

Management 0.61.7 transaction acd4373d-d9a5-4e58-9831-3fbf4c26b9de failed before stop or migration because the generic/external PostgreSQL host has no local postgres OS account. Production remained on Management 0.60.3 and healthy; the failed transaction was not retried.

No GoTrue, tenant database, migration, production host, or deployment state is changed by this PR.

## Verification

- 112 focused tests pass
- full Management unit suite passes
- Management typecheck passes
- Linux amd64 compile passes
- git diff --check passes
- independent platform/release review: GO
- independent security review after three bounded rounds: GO
- clean-code-guard: clean
