### PR TITLE
fix(upgrade): materialize private pgpass credential

### DIFF
--- a/packages/management-api/src/control-plane-upgrade-safety.ts
+++ b/packages/management-api/src/control-plane-upgrade-safety.ts
@@ -35,6 +35,8 @@ const MAX_RECEIPT_BYTES = 8 * 1024;
 const POSTGRES_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_.-]{0,62}$/;
 const PG_DUMP_PATH = ["/usr/bin/pg_dump", "/usr/local/bin/pg_dump"].find(existsSync) ?? "/usr/bin/pg_dump";
 const PG_RESTORE_PATH = ["/usr/bin/pg_restore", "/usr/local/bin/pg_restore"].find(existsSync) ?? "/usr/bin/pg_restore";
+const INSTALL_PATH = ["/usr/bin/install", "/bin/install"].find(existsSync) ?? "/usr/bin/install";
+const SH_PATH = ["/bin/sh", "/usr/bin/sh"].find(existsSync) ?? "/bin/sh";
 const SYSTEMD_RUN_PATH = ["/usr/bin/systemd-run", "/bin/systemd-run"].find(existsSync) ?? "/usr/bin/systemd-run";
 const SYSTEMCTL_PATH = ["/usr/bin/systemctl", "/bin/systemctl"].find(existsSync) ?? "/usr/bin/systemctl";
 const TIMEOUT_PATH = ["/usr/bin/timeout", "/bin/timeout"].find(existsSync) ?? "/usr/bin/timeout";
@@ -423,7 +425,14 @@ function dumpArguments(
   unitName: string,
   credentialPath: string,
 ): string[] {
-  const credentialDirectory = `/run/credentials/${unitName}.service`;
+  const runtimeCredentialPath = `$RUNTIME_DIRECTORY/pgpass`;
+  const credentialBootstrap = [
+    "set -eu",
+    "umask 077",
+    `${INSTALL_PATH} --mode=0600 -- \"$CREDENTIALS_DIRECTORY/pgpass\" \"${runtimeCredentialPath}\"`,
+    `export PGPASSFILE=\"${runtimeCredentialPath}\"`,
+    "exec \"$@\"",
+  ].join("\n");
   return [
     TIMEOUT_PATH, "--kill-after=30s", String(SYSTEMD_RUN_TIMEOUT_SECONDS),
     SYSTEMD_RUN_PATH, "--quiet", "--wait", "--pipe", "--collect", `--unit=${unitName}`,
@@ -435,8 +444,9 @@ function dumpArguments(
     "--property=ProtectKernelTunables=yes", "--property=ProtectKernelModules=yes",
     "--property=ProtectControlGroups=yes", "--property=LockPersonality=yes",
     "--property=RestrictSUIDSGID=yes", "--property=RestrictRealtime=yes", "--property=UMask=0077",
+    `--property=RuntimeDirectory=${unitName}`, "--property=RuntimeDirectoryMode=0700",
     `--property=LoadCredential=pgpass:${credentialPath}`,
-    `--property=Environment=PGPASSFILE=${credentialDirectory}/pgpass`, "--",
+    "--", SH_PATH, "-c", credentialBootstrap, "supacloud-control-plane-pg-dump",
     PG_DUMP_PATH, "--host", target.hostname, "--port", target.port, "--username", target.username,
     "--dbname", target.database, "--format=custom", "--compress=6", "--snapshot", inspection.snapshotId,
   ];

--- a/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
+++ b/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
@@ -85,7 +85,14 @@ describe("control-plane upgrade safety", () => {
       expect(commands[0]).toContain("--property=ProcSubset=pid");
       expect(commands[0]).toContain("--property=RuntimeMaxSec=1800s");
       expect(commands[0]).toContain("--property=KillMode=control-group");
-      expect(commands[0]?.some((argument) => argument.startsWith("--property=Environment=PGPASSFILE=/run/credentials/"))).toBe(true);
+      expect(commands[0]).toContain("--property=RuntimeDirectoryMode=0700");
+      expect(commands[0]?.some((argument) => argument.startsWith("--property=RuntimeDirectory=supacloud-control-plane-"))).toBe(true);
+      expect(commands[0]?.some((argument) => argument.startsWith("--property=Environment=PGPASSFILE="))).toBe(false);
+      const credentialBootstrap = commands[0]?.find((argument) => argument.includes("CREDENTIALS_DIRECTORY/pgpass"));
+      expect(credentialBootstrap).toContain("install --mode=0600");
+      expect(credentialBootstrap).toContain("$RUNTIME_DIRECTORY/pgpass");
+      expect(credentialBootstrap).toContain("export PGPASSFILE=");
+      expect(credentialBootstrap).toContain('exec "$@"');
       expect(commands[0]).toContain("--snapshot");
       expect(commands[0]).toContain(inspection.snapshotId);
       expect(commands[1]?.some((argument) => argument.endsWith("/pg_restore"))).toBe(true);


### PR DESCRIPTION
## Summary
- copy the systemd-loaded pgpass credential into the DynamicUser runtime directory with strict 0600 mode before invoking pg_dump
- keep the password out of argv and ordinary child environment while preserving the root-reserved archive FD and exported snapshot
- cover RuntimeDirectory lifecycle and bootstrap command shape

## Production evidence
A fresh official 0.61.8 transaction (`63ff249e-8914-48a6-a227-00e19484cede`) stopped before migration with `Control-plane pg_dump failed`; official CLI read-back confirmed Management 0.60.3 and all health checks unchanged. Ubuntu 26.04 + PostgreSQL 18.4 reproduction showed libpq rejecting the ACL-readable LoadCredential file as non-0600, and the RuntimeDirectory copy completed the same exported-snapshot dump successfully.

## Verification
- focused Management tests: 103 pass / 0 fail
- official `bun run test:unit`: PASS
- Management typecheck: PASS
- Linux amd64 compile: PASS
- `git diff --check`: PASS
- integration panel: GO (`.agents/mailbox/324-pgdump-runtime-integration-review.md`)
- security panel: GO (`.agents/mailbox/325-pgdump-runtime-security-review.md`)

No GoTrue, tenant schema, application data, or nonofficial deployment path changes.