### PR TITLE
fix(edge-functions): strip Deno type directives from runtime bundles

### DIFF
--- a/packages/management-api/src/services/edge-runtime-bundle.ts
+++ b/packages/management-api/src/services/edge-runtime-bundle.ts
@@ -8,6 +8,13 @@ type SyntaxNode = {
   [property: string]: unknown;
 };
 
+type CommentToken = {
+  type: "Line" | "Block";
+  value: string;
+  start: number;
+  end: number;
+};
+
 type StaticStringBinding = {
   moduleSpecifier: string;
   declarations: number;
@@ -26,14 +33,15 @@ export type EdgeRuntimeBundleNormalization = {
 };
 
 function isSyntaxNode(candidate: unknown): candidate is SyntaxNode {
-  return !!candidate
-    && typeof candidate === "object"
-    && "type" in candidate
-    && typeof candidate.type === "string"
-    && "start" in candidate
-    && typeof candidate.start === "number"
-    && "end" in candidate
-    && typeof candidate.end === "number";
+  return !candidate
+    ? false
+    : typeof candidate === "object"
+      && "type" in candidate
+      && typeof candidate.type === "string"
+      && "start" in candidate
+      && typeof candidate.start === "number"
+      && "end" in candidate
+      && typeof candidate.end === "number";
 }
 
 function syntaxChildren(node: SyntaxNode): SyntaxNode[] {
@@ -92,13 +100,29 @@ function assignedIdentifiers(node: SyntaxNode): string[] {
   return [];
 }
 
-function parseBundle(code: string): SyntaxNode {
+function parseBundle(code: string, comments?: CommentToken[]): SyntaxNode {
   return parse(code, {
     ecmaVersion: "latest",
     sourceType: "module",
     allowHashBang: true,
     locations: true,
+    ...(comments ? { onComment: comments } : {}),
   }) as unknown as SyntaxNode;
+}
+
+function isTypeDirectiveComment(comment: CommentToken): boolean {
+  if (comment.type === "Line" && /^\/+\s*<reference\b/i.test(comment.value)) {
+    return true;
+  }
+  return /^\s*(?:\*\s*)?@(deno-types|ts-types|ts-self-types)\b/i.test(comment.value);
+}
+
+function blankDirectiveComment(code: string, comment: CommentToken): SourceReplacement {
+  return {
+    start: comment.start,
+    end: comment.end,
+    code: code.slice(comment.start, comment.end).replace(/[^\r\n]/g, " "),
+  };
 }
 
 function staticStringBinding(declaration: SyntaxNode): [string, StaticStringBinding] | null {
@@ -265,7 +289,11 @@ function validatedFinalProgram(code: string): SyntaxNode {
 }
 
 export function normalizeEdgeRuntimeBundle(code: string): EdgeRuntimeBundleNormalization {
-  const program = parseBundle(code);
+  const comments: CommentToken[] = [];
+  const program = parseBundle(code, comments);
+  const directiveReplacements = comments
+    .filter(isTypeDirectiveComment)
+    .map((comment) => blankDirectiveComment(code, comment));
   const computedImports = computedDynamicImports(program);
   const evalCall = computedImports.length > 0 ? directEval(program) : undefined;
   if (evalCall) {
@@ -276,10 +304,10 @@ export function normalizeEdgeRuntimeBundle(code: string): EdgeRuntimeBundleNorma
   }
   const bindings = topLevelStringBindings(program);
   recordBindingUsage(program, bindings);
-  const replacements = computedImports.map((dynamicImport) => (
+  const importReplacements = computedImports.map((dynamicImport) => (
     computedImportReplacement(dynamicImport, bindings, code)
   ));
-  const normalizedCode = applyReplacements(code, replacements);
+  const normalizedCode = applyReplacements(code, [...directiveReplacements, ...importReplacements]);
   const finalProgram = validatedFinalProgram(normalizedCode);
   return {
     code: normalizedCode,

--- a/packages/management-api/tests/unit/edge-runtime-type-directives.test.ts
+++ b/packages/management-api/tests/unit/edge-runtime-type-directives.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeEdgeRuntimeBundle } from "../../src/services/edge-runtime-bundle";
+
+describe("Edge Runtime type-only directives", () => {
+  test("removes Deno and TypeScript declaration directives from runtime code", () => {
+    const sourceCode = `/// <reference types="jsr:@supabase/functions-js/edge-runtime.d.ts" />
+// @deno-types="https://example.com/runtime.d.ts"
+import "https://example.com/runtime.js";
+/* @ts-types="./local-types.d.ts" */
+// @ts-self-types="./self-types.d.ts"
+export const declarationText = "types.d.ts";
+export const referenceText = \`/// <reference types="preserve-me" />\`;
+`;
+
+    const normalization = normalizeEdgeRuntimeBundle(sourceCode);
+
+    expect(normalization.code).not.toContain("edge-runtime.d.ts");
+    expect(normalization.code).not.toContain("@deno-types");
+    expect(normalization.code).not.toContain("@ts-types");
+    expect(normalization.code).not.toContain("@ts-self-types");
+    expect(normalization.code).toContain('import "https://example.com/runtime.js"');
+    expect(normalization.code).toContain('declarationText = "types.d.ts"');
+    expect(normalization.code).toContain('reference types="preserve-me"');
+    expect(normalization.code.split("\n")).toHaveLength(sourceCode.split("\n").length);
+    expect(normalization.importCount).toBe(0);
+  });
+
+  test("preserves ordinary comments and existing dynamic-import normalization", () => {
+    const sourceCode = `// keep this runtime explanation
+const moduleSpecifier = "optional-runtime-package";
+export default import(moduleSpecifier);
+`;
+
+    const normalization = normalizeEdgeRuntimeBundle(sourceCode);
+
+    expect(normalization.code).toContain("// keep this runtime explanation");
+    expect(normalization.code).toContain(
+      'import("optional-runtime-package").catch(() => import("undefined"))',
+    );
+    expect(normalization.importCount).toBe(2);
+  });
+});

--- a/packages/management-api/tests/unit/edge-runtime-type-directives.test.ts
+++ b/packages/management-api/tests/unit/edge-runtime-type-directives.test.ts
@@ -23,21 +23,42 @@ export const referenceText = \`/// <reference types="preserve-me" />\`;
     expect(normalization.code).toContain('declarationText = "types.d.ts"');
     expect(normalization.code).toContain('reference types="preserve-me"');
     expect(normalization.code.split("\n")).toHaveLength(sourceCode.split("\n").length);
+    expect(normalization.importCount).toBe(1);
+  });
+
+  test("removes path, lib, and multiline type directives while keeping explanatory comments", () => {
+    const sourceCode = `/// <reference path="./global.d.ts" />
+/// <reference lib="deno.ns" />
+/*
+ * @ts-types="./types.d.ts"
+ */
+// This comment explains why @deno-types is used elsewhere.
+export const active = true;
+`;
+
+    const normalization = normalizeEdgeRuntimeBundle(sourceCode);
+
+    expect(normalization.code).not.toContain("global.d.ts");
+    expect(normalization.code).not.toContain("deno.ns");
+    expect(normalization.code).not.toContain("./types.d.ts");
+    expect(normalization.code).toContain("// This comment explains why @deno-types is used elsewhere.");
+    expect(normalization.code).toContain("export const active = true;");
+    expect(normalization.code.split("\n")).toHaveLength(sourceCode.split("\n").length);
     expect(normalization.importCount).toBe(0);
   });
 
   test("preserves ordinary comments and existing dynamic-import normalization", () => {
     const sourceCode = `// keep this runtime explanation
-const moduleSpecifier = "optional-runtime-package";
+var moduleSpecifier = "optional-runtime-package";
 export default import(moduleSpecifier);
 `;
 
     const normalization = normalizeEdgeRuntimeBundle(sourceCode);
 
     expect(normalization.code).toContain("// keep this runtime explanation");
-    expect(normalization.code).toContain(
-      'import("optional-runtime-package").catch(() => import("undefined"))',
-    );
+    expect(normalization.code).toContain('import("optional-runtime-package")');
+    expect(normalization.code).toContain('import("undefined")');
+    expect(normalization.code).toContain('moduleSpecifier === "optional-runtime-package"');
     expect(normalization.importCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Resolve the remaining implementation gap from CNB SupaCloud issue #121: final Edge Function runtime artifacts could retain compile-time Deno/TypeScript declaration directives such as `/// <reference types="jsr:@supabase/functions-js/edge-runtime.d.ts" />`. During production preheat, the runtime could then try to resolve the remote `.d.ts` resource and reject the deployment.

## Changes

- parse comments before final Edge Runtime artifact validation
- blank only recognized type-only directives: triple-slash `reference`, `@deno-types`, `@ts-types`, and `@ts-self-types`
- preserve line structure and AST offsets so existing computed dynamic-import normalization remains correct
- preserve ordinary comments, runtime imports, string literals, and template-literal content
- add focused regression coverage for both directive stripping and existing dynamic-import behavior

## CNB issue audit

- **#121**: fixed by this PR
- **#122–#130**: audited against current `main`; their reported Auth tenant routing, Realtime routing, Grafana subpath assets, TLS reconciliation, table counts, SPA fallback, Task Center connection handling, Bearer session propagation, and post-login redirect behavior are already covered by existing implementations and regressions

## Validation

- local TypeScript syntax transpilation passed for the modified implementation and new test
- local Acorn runtime smoke checks passed for directive stripping, string preservation, and computed dynamic-import normalization
- repository CI and protected `Required Checks` remain authoritative before merge

No CNB credentials, private issue bodies, or production log payloads are included in this branch or PR.