### PR TITLE
feat(admin): inspect retained upgrade status

### DIFF
--- a/packages/admin/README.md
+++ b/packages/admin/README.md
@@ -100,6 +100,7 @@ npx @supacloud/admin status
 npx @supacloud/admin ssh ping
 npx @supacloud/admin ssh versions
 npx @supacloud/admin ssh diagnose
+npx @supacloud/admin ssh upgrade_status --transaction_id 11111111-1111-4111-8111-111111111111
 npx @supacloud/admin project create --name my-app --domain example.com \
   --env_file /secure/path/.env.project-credentials.test --environment test
 npx @supacloud/admin project list
@@ -192,6 +193,33 @@ deadline stops only local observation; it does not stop, clean up, or mark the
 remote transaction as failed. The CLI reports the unit, stage, status, log, and
 upload-drop paths for reconciliation. Inspect that evidence before retrying and
 do not retry blindly while the remote transaction may still be running.
+
+When observation ends after 30 minutes, or to safely reconcile a retained
+local-artifact upgrade transaction, use the read-only `ssh upgrade_status`
+command:
+
+```bash
+npx @supacloud/admin ssh upgrade_status \
+  --transaction_id 11111111-1111-4111-8111-111111111111
+```
+
+`ssh upgrade_status` is classified as a read-only command and is permitted in
+read-only mode (`SUPACLOUD_READ_ONLY=true`). It requires a strict UUID v4
+transaction ID before performing any SSH access. It never deletes status, log,
+stage, or upload-drop records, and never mutates service state. The command emits
+a strict JSON projection (`supacloud.admin.upgrade-status.v1`) containing the
+normalized transaction ID, lifecycle state (`running`, `succeeded`, or
+`failed`), raw bounded status, systemd active/load states, boolean
+evidence-presence flags, and validated structured receipts:
+- Nonterminal (`running`): no receipts or failure evidence are included.
+- Succeeded: path-free projections of the validated control-plane preflight and
+  transaction safety receipts.
+- Failed: validated failure evidence with credentials and remote paths redacted.
+
+The command fails closed for missing or inconsistent terminal evidence, stopped
+nonterminal units, malformed or missing structured receipts, redacted or
+truncated SSH output, or unknown status, without emitting raw logs, remote
+filesystem paths, secrets, bearer material, env values, or customer data.
 
 `--artifact_transport local` accepts only `--github_proxy direct` or `none` and
 clears proxy environment variables on both hosts. The server-download path

--- a/packages/admin/src/shared/execution-policy.test.ts
+++ b/packages/admin/src/shared/execution-policy.test.ts
@@ -38,7 +38,7 @@ describe("Admin execution policy", () => {
                 "frontend.list_releases", "frontend.get_release",
                 "ssh.ping", "ssh.versions", "ssh.diagnose", "ssh.exec",
                 "ssh.troubleshoot", "ssh.container_logs", "ssh.tenant_list",
-                "ssh.tenant_inspect", "ssh.tenant_diagnose",
+                "ssh.tenant_inspect", "ssh.tenant_diagnose", "ssh.upgrade_status",
             ],
             write: [
                 "project.create", "project.delete", "project.pause", "project.restore",

--- a/packages/admin/src/shared/execution-policy.ts
+++ b/packages/admin/src/shared/execution-policy.ts
@@ -36,7 +36,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     ssh: {
         read: [
             "ping", "versions", "diagnose", "exec", "troubleshoot", "container_logs",
-            "tenant_list", "tenant_inspect", "tenant_diagnose",
+            "tenant_list", "tenant_inspect", "tenant_diagnose", "upgrade_status",
         ],
         write: ["setup", "install", "upgrade", "tenant_migrate"],
     },

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import {
     adoptRemoteDrop,
     assertControlPlaneSafetyVersion,
+    assertValidTransactionId,
     awaitRemoteUpgrade,
     buildAdoptDropScript,
     buildCleanupUnstartedUpgradeScript,
@@ -20,6 +21,7 @@ import {
     buildUpgradeLockScript,
     executeLocalUpgradeTransfer,
     failureRequiresRemoteReconciliation,
+    inspectRemoteUpgradeStatus,
     parseControlPlaneSafetyEvidence,
     parseControlPlanePreflightEvidence,
     parseUpgradeFailureEvidence,
@@ -85,6 +87,16 @@ const controlPlaneSafetyEvidence = {
     completed_at: "2026-08-19T00:00:00.000Z",
     current_key_checkpoint_present: true,
     sha256: "c".repeat(64),
+};
+
+const upgradeStatusControlPlaneEvidence = {
+    backup_id: controlPlaneSafetyEvidence.backup_id,
+    bytes: controlPlaneSafetyEvidence.bytes,
+    candidate_counts: controlPlaneSafetyEvidence.candidate_counts,
+    completed_at: controlPlaneSafetyEvidence.completed_at,
+    current_key_checkpoint_present: controlPlaneSafetyEvidence.current_key_checkpoint_present,
+    receipt_schema: controlPlaneSafetyEvidence.schema,
+    sha256: controlPlaneSafetyEvidence.sha256,
 };
 
 function successfulUpgradeLog(message = "upgrade committed"): string {
@@ -1536,5 +1548,279 @@ describe("local upgrade remote runner", () => {
             now.mockRestore();
             timeout.mockRestore();
         }
+    });
+});
+describe("upgrade_status inspection", () => {
+    const validUuid = "11111111-1111-4111-8111-111111111111";
+
+    test("validates UUID v4 transaction ID before any SSH interaction", () => {
+        expect(() => assertValidTransactionId(undefined)).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+        expect(() => assertValidTransactionId(null)).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+        expect(() => assertValidTransactionId("")).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+        expect(() => assertValidTransactionId("not-a-uuid")).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+        expect(() => assertValidTransactionId("11111111-1111-1111-8111-111111111111")).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+        expect(() => assertValidTransactionId("11111111-1111-4111-7111-111111111111")).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+        expect(() => assertValidTransactionId("11111111-1111-4111-8111-11111111111g")).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+        expect(() => assertValidTransactionId(" 11111111-1111-4111-8111-111111111111 ")).toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+
+        expect(assertValidTransactionId(validUuid)).toBe(validUuid);
+        expect(assertValidTransactionId("550E8400-E29B-41D4-A716-446655440000")).toBe("550e8400-e29b-41d4-a716-446655440000");
+    });
+
+    test("emits a running nonterminal projection without receipts or mutation", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "RUNNING", serviceState: "active", stageExists: true, stageIsDirectory: true }),
+        ]);
+
+        const projection = await inspectRemoteUpgradeStatus(ssh as never, validUuid);
+        expect(projection).toEqual({
+            schema: "supacloud.admin.upgrade-status.v1",
+            transaction_id: validUuid,
+            lifecycle: "running",
+            status: "RUNNING",
+            service_state: "active",
+            unit_load_state: "loaded",
+            evidence: {
+                drop_exists: false,
+                log_exists: true,
+                stage_exists: true,
+                stage_is_directory: true,
+                status_exists: true,
+                unit_exists: true,
+            },
+        });
+        expect((projection as any).preflight).toBeUndefined();
+        expect((projection as any).transaction).toBeUndefined();
+        expect((projection as any).failure).toBeUndefined();
+        expect(ssh.commands).toHaveLength(1);
+        expect(ssh.commands[0]).toContain("systemctl is-active");
+        expect(ssh.commands[0]).not.toContain("rm ");
+        expect(ssh.commands[0]).not.toContain("systemctl stop");
+    });
+
+    test("emits a succeeded projection with validated safety receipts and no mutation", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "SUCCEEDED",
+                serviceState: "inactive",
+                unitLoadState: "not-found",
+                stageExists: false,
+                stageIsDirectory: false,
+                dropExists: false,
+                logExists: true,
+                statusExists: true,
+            }),
+            remoteResult(successfulUpgradeLog()),
+        ]);
+
+        const projection = await inspectRemoteUpgradeStatus(ssh as never, validUuid);
+        expect(projection).toEqual({
+            schema: "supacloud.admin.upgrade-status.v1",
+            transaction_id: validUuid,
+            lifecycle: "succeeded",
+            status: "SUCCEEDED",
+            service_state: "inactive",
+            unit_load_state: "not-found",
+            evidence: {
+                drop_exists: false,
+                log_exists: true,
+                stage_exists: false,
+                stage_is_directory: false,
+                status_exists: true,
+                unit_exists: false,
+            },
+            preflight: upgradeStatusControlPlaneEvidence,
+            transaction: upgradeStatusControlPlaneEvidence,
+        });
+        expect(JSON.stringify(projection)).not.toContain("/var/");
+        expect(ssh.commands).toHaveLength(2);
+        expect(ssh.commands[0]).toContain("systemctl is-active");
+        expect(ssh.commands[1]).toContain("tail -n 80");
+        for (const cmd of ssh.commands) {
+            expect(cmd).not.toContain("rm ");
+            expect(cmd).not.toContain("systemctl stop");
+            expect(cmd).not.toContain("systemctl restart");
+        }
+    });
+
+    test("emits a failed projection with validated failure receipt and no mutation", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "FAILED:9:TRANSACTION",
+                serviceState: "failed",
+                unitLoadState: "loaded",
+                stageExists: false,
+                stageIsDirectory: false,
+                dropExists: false,
+                logExists: true,
+                statusExists: true,
+            }),
+            remoteResult(failedUpgradeLog("Preflight schema verification failed")),
+        ]);
+
+        const projection = await inspectRemoteUpgradeStatus(ssh as never, validUuid);
+        expect(projection).toEqual({
+            schema: "supacloud.admin.upgrade-status.v1",
+            transaction_id: validUuid,
+            lifecycle: "failed",
+            status: "FAILED:9:TRANSACTION",
+            service_state: "failed",
+            unit_load_state: "loaded",
+            evidence: {
+                drop_exists: false,
+                log_exists: true,
+                stage_exists: false,
+                stage_is_directory: false,
+                status_exists: true,
+                unit_exists: true,
+            },
+            failure: {
+                causes: [],
+                receipt_schema: "supacloud.upgrade-failure.v1",
+                summary: "Preflight schema verification failed",
+            },
+        });
+        expect(ssh.commands).toHaveLength(2);
+        for (const cmd of ssh.commands) {
+            expect(cmd).not.toContain("rm ");
+            expect(cmd).not.toContain("systemctl stop");
+            expect(cmd).not.toContain("systemctl restart");
+        }
+    });
+
+    test("redacts remote paths from validated failure evidence", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "FAILED:9:TRANSACTION",
+                serviceState: "failed",
+                unitLoadState: "loaded",
+                stageExists: false,
+                dropExists: false,
+            }),
+            remoteResult(`SUPACLOUD_UPGRADE_FAILURE=${JSON.stringify({
+                schema: "supacloud.upgrade-failure.v1",
+                summary: "Backup verification failed at [/var/lib/supacloud/backups/control-plane.dump], file:///etc/private, and https://storage.example.com/archive?download=private",
+                causes: ["status=`/var/lib/supacloud/upgrade-runs/private.status`"],
+            })}\n`),
+        ]);
+
+        const projection = await inspectRemoteUpgradeStatus(ssh as never, validUuid);
+        expect(projection.lifecycle).toBe("failed");
+        if (projection.lifecycle !== "failed") throw new Error("Expected failed projection");
+        expect(projection.failure).toEqual({
+            receipt_schema: "supacloud.upgrade-failure.v1",
+            summary: "Backup verification failed at [[REDACTED_PATH]], [REDACTED_PATH], and [REDACTED_URL]",
+            causes: ["status=`[REDACTED_PATH]`"],
+        });
+        expect(JSON.stringify(projection)).not.toContain("/var/");
+    });
+
+    test("fails closed when a succeeded state has malformed receipts", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "SUCCEEDED",
+                serviceState: "inactive",
+                unitLoadState: "not-found",
+                stageExists: false,
+                stageIsDirectory: false,
+                dropExists: false,
+                logExists: true,
+                statusExists: true,
+            }),
+            remoteResult("SUPACLOUD_CONTROL_PLANE_UPGRADE_PREFLIGHT={invalid json\n"),
+        ]);
+
+        await expect(inspectRemoteUpgradeStatus(ssh as never, validUuid))
+            .rejects.toThrow("safety receipts are missing or invalid");
+        expect(ssh.commands).toHaveLength(2);
+        for (const cmd of ssh.commands) {
+            expect(cmd).not.toContain("rm ");
+        }
+    });
+
+    test("fails closed when a failed state has malformed failure receipt", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "FAILED:9:TRANSACTION",
+                serviceState: "inactive",
+                unitLoadState: "not-found",
+                stageExists: false,
+                stageIsDirectory: false,
+                dropExists: false,
+                logExists: true,
+                statusExists: true,
+            }),
+            remoteResult("SUPACLOUD_UPGRADE_FAILURE={invalid json\n"),
+        ]);
+
+        await expect(inspectRemoteUpgradeStatus(ssh as never, validUuid))
+            .rejects.toThrow("failure receipt is missing or invalid");
+        expect(ssh.commands).toHaveLength(2);
+        for (const cmd of ssh.commands) {
+            expect(cmd).not.toContain("rm ");
+        }
+    });
+
+    test("fails closed when nonterminal unit stopped unexpectedly", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "RUNNING", serviceState: "inactive", unitLoadState: "not-found" }),
+        ]);
+
+        await expect(inspectRemoteUpgradeStatus(ssh as never, validUuid))
+            .rejects.toThrow("Remote upgrade nonterminal state is inconsistent");
+        expect(ssh.commands).toHaveLength(1);
+    });
+
+    test("fails closed when terminal evidence is inconsistent", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "SUCCEEDED",
+                serviceState: "inactive",
+                unitLoadState: "not-found",
+                stageExists: true,
+            }),
+        ]);
+
+        await expect(inspectRemoteUpgradeStatus(ssh as never, validUuid))
+            .rejects.toThrow("terminal evidence is incomplete or inconsistent");
+        expect(ssh.commands).toHaveLength(1);
+    });
+
+    test("fails closed when status is unknown", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({ status: "UNKNOWN_/var/lib/private.status", serviceState: "active" }),
+        ]);
+
+        const failure = await inspectRemoteUpgradeStatus(ssh as never, validUuid).catch((error: unknown) => error);
+        expect(String(failure)).toContain("Remote upgrade status is unknown or invalid");
+        expect(String(failure)).not.toContain("/var/");
+        expect(ssh.commands).toHaveLength(1);
+    });
+
+    test("fails closed when log tail was redacted by transport", async () => {
+        const ssh = new ScriptedSsh([
+            remoteState({
+                status: "SUCCEEDED",
+                serviceState: "inactive",
+                unitLoadState: "not-found",
+                stageExists: false,
+                stageIsDirectory: false,
+                dropExists: false,
+                logExists: true,
+                statusExists: true,
+            }),
+            {
+                success: true,
+                stdout: successfulUpgradeLog(),
+                stderr: "",
+                code: 0,
+                stdoutRedacted: true,
+            },
+        ]);
+
+        const err = await inspectRemoteUpgradeStatus(ssh as never, validUuid).catch((e: unknown) => e);
+        expect(String(err)).toContain("retained log could not be read safely");
+        expect(String(err)).not.toContain(paths.status);
+        expect(String(err)).not.toContain(paths.log);
     });
 });

--- a/packages/admin/src/shared/releases/local-upgrade-transfer.ts
+++ b/packages/admin/src/shared/releases/local-upgrade-transfer.ts
@@ -82,6 +82,107 @@ type UpgradeFailureEvidence = {
     summary: string;
 };
 
+type UpgradeStatusEvidencePresence = {
+    drop_exists: boolean;
+    log_exists: boolean;
+    stage_exists: boolean;
+    stage_is_directory: boolean;
+    status_exists: boolean;
+    unit_exists: boolean;
+};
+
+type UpgradeStatusNonterminalProjection = {
+    schema: "supacloud.admin.upgrade-status.v1";
+    transaction_id: string;
+    lifecycle: "running";
+    status: string;
+    service_state: string;
+    unit_load_state: string;
+    evidence: UpgradeStatusEvidencePresence;
+};
+
+type UpgradeStatusControlPlaneEvidence = {
+    backup_id: string;
+    bytes: number;
+    candidate_counts: Record<string, number>;
+    completed_at: string;
+    current_key_checkpoint_present: boolean;
+    receipt_schema: ControlPlaneSafetyEvidence["schema"];
+    sha256: string;
+};
+
+type UpgradeStatusFailureEvidence = {
+    causes: string[];
+    receipt_schema: UpgradeFailureEvidence["schema"];
+    summary: string;
+};
+
+type UpgradeStatusSucceededProjection = {
+    schema: "supacloud.admin.upgrade-status.v1";
+    transaction_id: string;
+    lifecycle: "succeeded";
+    status: string;
+    service_state: string;
+    unit_load_state: string;
+    evidence: UpgradeStatusEvidencePresence;
+    preflight: UpgradeStatusControlPlaneEvidence;
+    transaction: UpgradeStatusControlPlaneEvidence;
+};
+
+type UpgradeStatusFailedProjection = {
+    schema: "supacloud.admin.upgrade-status.v1";
+    transaction_id: string;
+    lifecycle: "failed";
+    status: string;
+    service_state: string;
+    unit_load_state: string;
+    evidence: UpgradeStatusEvidencePresence;
+    failure: UpgradeStatusFailureEvidence;
+};
+
+export type UpgradeStatusProjection =
+    | UpgradeStatusNonterminalProjection
+    | UpgradeStatusSucceededProjection
+    | UpgradeStatusFailedProjection;
+
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function assertValidTransactionId(transactionId: unknown): string {
+    if (typeof transactionId !== "string" || !UUID_V4_PATTERN.test(transactionId)) {
+        throw new Error("Invalid 'transaction_id': must be a valid UUID v4");
+    }
+    return transactionId.toLowerCase();
+}
+
+function upgradeStatusControlPlaneEvidence(
+    receipt: ControlPlaneSafetyEvidence,
+): UpgradeStatusControlPlaneEvidence {
+    return {
+        backup_id: receipt.backup_id,
+        bytes: receipt.bytes,
+        candidate_counts: { ...receipt.candidate_counts },
+        completed_at: receipt.completed_at,
+        current_key_checkpoint_present: receipt.current_key_checkpoint_present,
+        receipt_schema: receipt.schema,
+        sha256: receipt.sha256,
+    };
+}
+
+function redactRemotePaths(message: string): string {
+    return message
+        .replace(/\bhttps?:\/\/[^\s"'`,;)\]}]+/gi, "[REDACTED_URL]")
+        .replace(/\bfile:\/\/\/[^\s"'`,;)\]}]+/gi, "[REDACTED_PATH]")
+        .replace(/(^|[^A-Za-z0-9:/])\/(?!\/)[^\s"'`,;)\]}]+/g, "$1[REDACTED_PATH]");
+}
+
+function upgradeStatusFailureEvidence(receipt: UpgradeFailureEvidence): UpgradeStatusFailureEvidence {
+    return {
+        causes: receipt.causes.map(redactRemotePaths),
+        receipt_schema: receipt.schema,
+        summary: redactRemotePaths(receipt.summary),
+    };
+}
+
 function exactObjectKeys(candidate: Record<string, unknown>, expected: readonly string[]): boolean {
     const actual = Object.keys(candidate).sort();
     return actual.length === expected.length && actual.every((key, index) => key === [...expected].sort()[index]);
@@ -1112,4 +1213,145 @@ export async function executeLocalUpgradeTransfer(ssh: SshTransport, request: Lo
             throw new AggregateError([cleanupError], "Remote local upgrade completed but local bundle cleanup did not complete");
         }
     }
+}
+
+type UpgradeStatusLifecycle = UpgradeStatusProjection["lifecycle"];
+
+function upgradeStatusLifecycle(status: string): UpgradeStatusLifecycle {
+    if (["PREPARED", "RUNNING", "CLEANING"].includes(status)) return "running";
+    if (status === "SUCCEEDED") return "succeeded";
+    const failedStatus = status.match(
+        /^FAILED:([1-9]\d{0,2}):(TRANSACTION|TRANSACTION_AND_CLEANUP|CLEANUP_AFTER_TRANSACTION)$/,
+    );
+    if (failedStatus && Number(failedStatus[1]) <= 255) return "failed";
+    throw new Error("Remote upgrade status is unknown or invalid");
+}
+
+function upgradeStatusEvidence(state: RemoteUpgradeState): UpgradeStatusEvidencePresence {
+    return {
+        drop_exists: state.dropExists,
+        log_exists: state.logExists,
+        stage_exists: state.stageExists,
+        stage_is_directory: state.stageIsDirectory,
+        status_exists: state.statusExists,
+        unit_exists: state.unitExists,
+    };
+}
+
+// CLI error formatting traverses nested causes, so these read-only inspection
+// wrappers deliberately replace path-bearing SSH and reconciliation diagnostics.
+async function readUpgradeStatusState(
+    ssh: SshTransport,
+    paths: RemoteUpgradePaths,
+): Promise<RemoteUpgradeState> {
+    try {
+        return await readRemoteState(ssh, paths);
+    } catch {
+        throw new Error("Unable to read remote upgrade state safely");
+    }
+}
+
+async function readUpgradeStatusLog(ssh: SshTransport, paths: RemoteUpgradePaths): Promise<string> {
+    try {
+        return await remoteLogTail(ssh, paths);
+    } catch {
+        throw new Error("Remote upgrade retained log could not be read safely");
+    }
+}
+
+function assertUpgradeStatusTerminalEvidence(
+    state: RemoteUpgradeState,
+    paths: RemoteUpgradePaths,
+    lifecycle: Exclude<UpgradeStatusLifecycle, "running">,
+): void {
+    try {
+        if (lifecycle === "succeeded") assertSuccessfulUnitStoppedNormally(state, paths);
+        else assertFailedUnitReachedTerminalState(state, paths);
+        assertTerminalEvidence(state, paths);
+    } catch {
+        throw new Error("Remote upgrade terminal evidence is incomplete or inconsistent");
+    }
+}
+
+function succeededUpgradeStatus(
+    transactionId: string,
+    state: RemoteUpgradeState,
+    log: string,
+): UpgradeStatusSucceededProjection {
+    let preflight: ControlPlaneSafetyEvidence;
+    let transaction: ControlPlaneSafetyEvidence;
+    try {
+        preflight = parseControlPlanePreflightEvidence(log);
+        transaction = parseControlPlaneSafetyEvidence(log);
+    } catch {
+        throw new Error("Remote upgrade safety receipts are missing or invalid");
+    }
+    return {
+        schema: "supacloud.admin.upgrade-status.v1",
+        transaction_id: transactionId,
+        lifecycle: "succeeded",
+        status: state.status,
+        service_state: state.serviceState,
+        unit_load_state: state.unitLoadState,
+        evidence: upgradeStatusEvidence(state),
+        preflight: upgradeStatusControlPlaneEvidence(preflight),
+        transaction: upgradeStatusControlPlaneEvidence(transaction),
+    };
+}
+
+function failedUpgradeStatus(
+    transactionId: string,
+    state: RemoteUpgradeState,
+    log: string,
+): UpgradeStatusFailedProjection {
+    let failure: UpgradeFailureEvidence;
+    try {
+        failure = parseUpgradeFailureEvidence(log);
+    } catch {
+        throw new Error("Remote upgrade failure receipt is missing or invalid");
+    }
+    return {
+        schema: "supacloud.admin.upgrade-status.v1",
+        transaction_id: transactionId,
+        lifecycle: "failed",
+        status: state.status,
+        service_state: state.serviceState,
+        unit_load_state: state.unitLoadState,
+        evidence: upgradeStatusEvidence(state),
+        failure: upgradeStatusFailureEvidence(failure),
+    };
+}
+
+function runningUpgradeStatus(
+    transactionId: string,
+    state: RemoteUpgradeState,
+): UpgradeStatusNonterminalProjection {
+    if (!unitIsRunning(state.serviceState) || state.unitLoadState !== "loaded" || !state.statusExists) {
+        throw new Error("Remote upgrade nonterminal state is inconsistent");
+    }
+    return {
+        schema: "supacloud.admin.upgrade-status.v1",
+        transaction_id: transactionId,
+        lifecycle: "running",
+        status: state.status,
+        service_state: state.serviceState,
+        unit_load_state: state.unitLoadState,
+        evidence: upgradeStatusEvidence(state),
+    };
+}
+
+export async function inspectRemoteUpgradeStatus(
+    ssh: SshTransport,
+    transactionIdInput: unknown,
+): Promise<UpgradeStatusProjection> {
+    const transactionId = assertValidTransactionId(transactionIdInput);
+    const paths = buildRemoteUpgradePaths(transactionId);
+    const state = await readUpgradeStatusState(ssh, paths);
+    const lifecycle = upgradeStatusLifecycle(state.status);
+    if (lifecycle === "running") return runningUpgradeStatus(transactionId, state);
+    assertUpgradeStatusTerminalEvidence(state, paths, lifecycle);
+    const log = await readUpgradeStatusLog(ssh, paths);
+    return lifecycle === "succeeded"
+        ? succeededUpgradeStatus(transactionId, state, log)
+        : failedUpgradeStatus(transactionId, state, log);
 }

--- a/packages/admin/src/shared/tools/ssh-tools.test.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.test.ts
@@ -2534,4 +2534,30 @@ describe("ssh admin tool", () => {
         const command = ssh.commands.find(candidate => candidate.includes("pg_dump")) ?? "";
         expect(command).toContain("-n 'public' -n 'auth' -n 'tenant_data'");
     });
+
+    test("upgrade_status rejects missing or invalid transaction_id before SSH", async () => {
+        const ssh = new FakeSsh();
+        const tool = captureSshTool(ssh);
+
+        await expect(tool.invoke({ action: "upgrade_status" }))
+            .rejects.toThrow("'transaction_id' required");
+        expect(ssh.commands).toHaveLength(0);
+
+        for (const invalid of ["not-a-uuid", "11111111-1111-1111-8111-111111111111", "550e8400-e29b-41d4-a716-44665544000g"]) {
+            await expect(tool.invoke({ action: "upgrade_status", transaction_id: invalid }))
+                .rejects.toThrow("Invalid 'transaction_id': must be a valid UUID v4");
+            expect(ssh.commands).toHaveLength(0);
+        }
+    });
+
+    test("upgrade_status schema includes transaction_id and action help", () => {
+        const tool = captureSshTool(new FakeSsh());
+        const parsed = tool.parse({
+            action: "upgrade_status",
+            transaction_id: "550E8400-E29B-41D4-A716-446655440000",
+        });
+        expect(parsed.action).toBe("upgrade_status");
+        expect(parsed.transaction_id).toBe("550E8400-E29B-41D4-A716-446655440000");
+    });
+
 });

--- a/packages/admin/src/shared/tools/ssh-tools.ts
+++ b/packages/admin/src/shared/tools/ssh-tools.ts
@@ -10,8 +10,10 @@ import { Type } from "@sinclair/typebox";
 import { decodedSchema, optional, stringEnum, withDescription } from "../schema";
 import { redactSshOutput, SshCommandOutcomeUnknownError, type SshTransport } from "../transports/ssh";
 import {
+    assertValidTransactionId,
     buildUpgradeLockScript,
     executeLocalUpgradeTransfer,
+    inspectRemoteUpgradeStatus,
     SUPACLOUD_UPGRADE_LOCK_PATH,
     UPGRADE_OBSERVATION_TIMEOUT_MS,
 } from "../releases/local-upgrade-transfer";
@@ -1086,10 +1088,10 @@ export function registerSshTools(server: { tool: (...args: any[]) => void }, ssh
     server.tool(
         "ssh",
         `Server management via SSH. Available before & after SupaCloud installation.
-Actions: ping, setup, install, upgrade, versions, diagnose, exec, troubleshoot, container_logs, tenant_manage, tenant_list, tenant_inspect, tenant_diagnose, tenant_migrate`,
+Actions: ping, setup, install, upgrade, upgrade_status, versions, diagnose, exec, troubleshoot, container_logs, tenant_manage, tenant_list, tenant_inspect, tenant_diagnose, tenant_migrate`,
         {
             action: withDescription(stringEnum([
-                "ping", "setup", "install", "upgrade", "versions", "diagnose", "exec",
+                "ping", "setup", "install", "upgrade", "upgrade_status", "versions", "diagnose", "exec",
                 "troubleshoot", "container_logs",
                 "tenant_manage", "tenant_list", "tenant_inspect", "tenant_diagnose", "tenant_migrate",
             ]), "Action to perform"),
@@ -1101,6 +1103,7 @@ Actions: ping, setup, install, upgrade, versions, diagnose, exec, troubleshoot, 
             dashboard_password: optional(secretSchema("dashboard_password"), "[install] Console password"),
             edge_runtime: optional(stringEnum(["bun"]), "[install] Runtime (default: bun)"),
             storage_type: optional(stringEnum(["juicefs", "minio"]), "[install] Storage backend configurable through Admin"),
+            transaction_id: optional(Type.String(), "[upgrade_status] UUID v4 transaction ID of a retained local-artifact upgrade"),
             version: optional(Type.String(), "[upgrade] Specific version"),
             edge_runtime_version: optional(Type.String(), "[upgrade] Exact independent Edge Runtime version"),
             artifact_transport: optional(stringEnum(["local", "remote"]), "[upgrade] Download verified release assets locally or on the server (default: remote)"),
@@ -1304,6 +1307,13 @@ Actions: ping, setup, install, upgrade, versions, diagnose, exec, troubleshoot, 
                     const upgradeExecution = await executeOfficialUpgrade(ssh, helperPath, cmd, upgradeTimeoutMs);
                     const edgeBoundary = edgeRuntimeVersion ? "" : "\n⚠️ Edge Runtime was not upgraded; provide --edge_runtime_version for a component transaction.";
                     text = `✅ Upgrade done\n${upgradeExecution.stdout.slice(-300)}${edgeBoundary}`;
+                    break;
+                }
+                case "upgrade_status": {
+                    if (!args.transaction_id) throw new Error("'transaction_id' required");
+                    const transactionId = assertValidTransactionId(args.transaction_id);
+                    const projection = await inspectRemoteUpgradeStatus(ssh, transactionId);
+                    text = JSON.stringify(projection, null, 2);
                     break;
                 }
                 case "versions": {


### PR DESCRIPTION
## Summary

- add read-only `ssh upgrade_status --transaction_id <uuid-v4>` inspection for retained local-artifact upgrade transactions
- validate the exact UUID/status lifecycle and reuse bounded remote state, log-tail, terminal-evidence, and receipt parsers
- emit `supacloud.admin.upgrade-status.v1` projections without raw logs, remote paths, credentials, environment values, or remote mutation
- classify the action as an SSH read and document its recovery workflow

## Safety boundaries

- does not delete status, log, stage, or upload-drop evidence
- does not stop, restart, or otherwise mutate services
- fails before SSH for invalid transaction IDs
- does not change GoTrue

## Verification

- `bun test packages/admin` — 498 pass, 26 skip, 0 fail
- `bun run typecheck` in `packages/admin`
- `bun run build` in `packages/admin`
- invalid UUID CLI black-box exits non-zero before SSH
- `git diff --check`
