### PR TITLE
feat(database): harden migration safety and schema reloads

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -232,6 +232,7 @@ supacloud-cli task_events inspect_webhook --ref abc123
 supacloud-cli database query --sql "select now()"
 supacloud-cli database query --ref abc123 --file ./queries/vector-search.sql
 supacloud-cli database migration_inventory --ref abc123
+supacloud-cli database lint_migrations --dir supabase/migrations
 supacloud-cli database push_migrations --ref abc123 --dir supabase/migrations --dry_run
 supacloud-cli supabase migration_new --name add_accounts
 supacloud-cli supabase db_diff --schema public --name add_accounts
@@ -284,6 +285,20 @@ reports the local files applied or skipped before the failed file, so operators
 can reconcile a partially completed sequence without exposing SQL. Baseline
 success requires a bounded migration-inventory readback that confirms every
 requested version, name, baseline marker, and checksum.
+
+`database lint_migrations` is local-only and works without Management API
+credentials. Inspect one source with `--sql`, `--file`, or `--dir`; these inputs
+are mutually exclusive. `--strict` (or `--fail_on_high`) exits non-zero for HIGH
+findings, `--fail_on_medium` also fails on MEDIUM findings, and `--json` emits a
+structured report. The analyzer detects destructive DDL (`DROP TABLE`,
+`DROP COLUMN`, `TRUNCATE`, `RENAME`), table-locking risks, opaque `DO` blocks,
+and statements that cannot run in the transactional migration executor.
+`CREATE/DROP INDEX CONCURRENTLY`, `VACUUM`, and other non-transactional work must
+run through an approved maintenance path outside `push_migrations`.
+
+Migration applications and DDL executions send PostgREST schema reload
+notifications (`NOTIFY pgrst_<ref>, 'reload schema'`) so schema changes become
+visible without a manual PostgREST restart.
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
 Bun and runs a local syntax check before upload. The Management API validates and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -278,6 +278,11 @@ it never empties a bucket. Mutation receipts bind `project_ref`, `bucket_id`,
 name with another version, or a local version with another name, before either
 dry-run reporting or apply can continue. This keeps the preview consistent with
 the server conflict that would otherwise occur after deployment starts.
+`push_migrations` requires canonical string migration identities; the narrower
+`baseline_migrations` compatibility path also accepts historical safe-integer
+versions and normalizes them before comparison. Repeated historical `cli_push`
+names are treated as generic labels; version and exact content remain the
+authority.
 Mutation failures use the release-control receipt schema and never include the
 server response body. `OUTCOME_UNKNOWN` requires a fresh migration inventory
 read before deciding whether a retry is safe. A migration push failure also
@@ -292,13 +297,36 @@ are mutually exclusive. `--strict` (or `--fail_on_high`) exits non-zero for HIGH
 findings, `--fail_on_medium` also fails on MEDIUM findings, and `--json` emits a
 structured report. The analyzer detects destructive DDL (`DROP TABLE`,
 `DROP COLUMN`, `TRUNCATE`, `RENAME`), table-locking risks, opaque `DO` blocks,
-and statements that cannot run in the transactional migration executor.
+procedural definitions/calls that require manual review, and statements that
+cannot run in the transactional migration executor. Empty migrations,
+unterminated strings/comments/dollar quotes, role or cluster management,
+external database access, server file/process access, transaction-boundary or
+session-identity control, advisory locks, public-schema rename/removal, and
+direct migration-ledger schema, table, recorder, or privilege mutation fail
+before the first remote migration write. Ledger indexes, triggers, rules,
+policies, comments, security labels, and table maintenance commands are covered
+by the same fail-closed rule. Top-level `COPY` is also rejected
+because the HTTP migration executor cannot provide a safe client stream and
+server-file targets cross the project boundary. Unicode-escaped identifiers
+(`U&"..."`) are rejected because the policy cannot safely canonicalize protected
+schema and ledger names. One matching outer `BEGIN`/`COMMIT` wrapper is removed
+because the platform owns the transaction.
+Adding a `NOT NULL` column is assessed per top-level `ALTER TABLE` subcommand;
+function-based defaults remain MEDIUM risk because they may rewrite the table.
+Dry-run exits non-zero for statements the transactional executor cannot apply,
+even when strict destructive-risk mode is not enabled.
 `CREATE/DROP INDEX CONCURRENTLY`, `VACUUM`, and other non-transactional work must
 run through an approved maintenance path outside `push_migrations`.
 
 Migration applications and DDL executions send PostgREST schema reload
 notifications (`NOTIFY pgrst_<ref>, 'reload schema'`) so schema changes become
-visible without a manual PostgREST restart.
+visible without a manual PostgREST restart. Responses distinguish `notified`
+from `notification_failed` and include `ddl_committed=true` when the platform
+can prove the DDL committed. Admin SQL with explicit transaction control or
+indirect `CALL`/`DO` execution omits `ddl_committed`; for
+`database create_table_rls`, a committed DDL batch followed by a failed reload
+returns `PARTIAL_SUCCESS` instead of claiming complete success or an unknown DDL
+outcome.
 
 `edge_functions deploy --path` bundles local TypeScript and dependencies with
 Bun and runs a local syntax check before upload. The Management API validates and

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -196,6 +196,51 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).toContain("--allowed_mime_types");
     });
 
+    test("runs migration lint locally without project credentials", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-local-lint-"));
+        temporaryDirectories.push(workspace);
+        const migrationPath = join(workspace, "safe.sql");
+        writeFileSync(migrationPath, "CREATE TABLE public.items (id bigint PRIMARY KEY);");
+
+        const response = await runProjectCli([
+            "database", "lint_migrations", "--file", migrationPath,
+        ], {}, workspace);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stdout).toContain("Migration Risk Level: LOW");
+        expect(response.stdout).not.toContain("requires Management API context");
+    });
+
+    test("returns a non-zero process exit for strict local migration lint", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-local-lint-strict-"));
+        temporaryDirectories.push(workspace);
+        const migrationPath = join(workspace, "destructive.sql");
+        writeFileSync(migrationPath, "DROP TABLE public.legacy_items;");
+
+        const response = await runProjectCli([
+            "database", "lint_migrations", "--file", migrationPath, "--strict",
+        ], {}, workspace);
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stdout).toContain("Migration Risk Level: HIGH");
+    });
+
+    test("documents all local lint inputs without unrelated schema flags", async () => {
+        const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-local-lint-help-"));
+        temporaryDirectories.push(workspace);
+
+        const response = await runProjectCli(["database", "lint", "--help"], {}, workspace);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("--sql");
+        expect(response.stderr).toContain("--file");
+        expect(response.stderr).toContain("--dir");
+        expect(response.stderr).toContain("--strict");
+        expect(response.stderr).toContain("--fail_on_medium");
+        expect(response.stderr).toContain("--json");
+        expect(response.stderr).not.toContain("--schema");
+    });
+
     test("keeps the release-canary OAuth client command discoverable without project configuration", async () => {
         const workspace = mkdtempSync(join(tmpdir(), "supacloud-cli-oauth-client-help-"));
         temporaryDirectories.push(workspace);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -297,6 +297,7 @@ EXAMPLES
   ${preferredCommand} database query --sql "select now()"
   ${preferredCommand} database query --ref abc123 --file ./queries/vector-search.sql
   ${preferredCommand} database migration_inventory --ref abc123
+  ${preferredCommand} database lint_migrations --dir supabase/migrations
   ${preferredCommand} database push_migrations --ref abc123 --dir supabase/migrations --dry_run
   ${preferredCommand} supabase migration_new --name add_accounts
   ${preferredCommand} supabase db_diff --schema public --name add_accounts
@@ -420,6 +421,9 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
 
     if (context.credentialScope !== "management" || !context.apiUrl || !context.apiToken) {
         registerContextAwareHelp();
+        Object.assign(tools, captureTools((server) => registerDatabaseTools(server as any, undefined, {
+            localOnly: true,
+        })));
         tools.setup_help = {
             schema: {},
             callback: async () => ({

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -141,6 +141,8 @@ describe("CLI execution policy", () => {
     });
 
     test("classifies Function, Scheduled Function, and Storage lifecycle actions", () => {
+        expect(executionMode("database", "lint_migrations", {})).toBe("local");
+        expect(executionMode("database", "lint", {})).toBe("local");
         expect(executionMode("edge_functions", "get_config", {})).toBe("read");
         expect(executionMode("edge_functions", "config", {})).toBe("write");
         expect(executionMode("edge_functions", "activate", {})).toBe("write");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -18,6 +18,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     },
     database: {
         read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "migration_inventory", "project_url", "generate_types"],
+        local: ["lint_migrations", "lint"],
         write: ["query", "apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"],
     },
     supabase: {

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -1620,4 +1620,204 @@ describe("database migration helpers", () => {
       columns: "id uuid); DROP TABLE secrets; --",
     })).rejects.toThrow("Unsafe column definitions");
   });
+  test("lint_migrations action inspects SQL files and reports risks", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-lint-test-"));
+    try {
+      writeFileSync(join(dir, "20260819000001_safe.sql"), "CREATE TABLE public.items (id bigint PRIMARY KEY);");
+      writeFileSync(join(dir, "20260819000002_lock.sql"), "CREATE INDEX idx_items_id ON public.items (id);");
+      writeFileSync(join(dir, "20260819000003_drop.sql"), "DROP TABLE public.legacy_items;");
+
+      const callback = captureDatabaseTool({});
+      const result = await callback({
+        action: "lint_migrations",
+        dir,
+      });
+
+      const text = result.content[0].text;
+      expect(text).toContain("🔴 Migration Risk Level: HIGH");
+      expect(text).toContain("20260819000002_lock.sql");
+      expect(text).toContain("20260819000003_drop.sql");
+      expect(text).toContain("CREATE INDEX CONCURRENTLY");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("push_migrations dry_run includes Risk Assessment section", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-dryrun-risk-test-"));
+    try {
+      writeFileSync(join(dir, "20260819000001_add_index.sql"), "CREATE INDEX idx_users_name ON public.users (name);");
+
+      const callback = captureDatabaseTool({
+        get: async () => ({ ok: true, status: 200, data: [] }),
+      });
+
+      const result = await callback({
+        action: "push_migrations",
+        ref: "proj",
+        dir,
+        dry_run: true,
+      });
+
+      const text = result.content[0].text;
+      expect(text).toContain("Migration dry run for");
+      expect(text).toContain("Risk Assessment:");
+      expect(text).toContain("Migration Risk Level: MEDIUM");
+      expect(text).toContain("CREATE INDEX CONCURRENTLY");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  test("lint_migrations returns isError in strict mode when high risk detected", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-lint-strict-test-"));
+    try {
+      writeFileSync(join(dir, "20260819000001_drop.sql"), "DROP TABLE public.legacy_users;");
+
+      const callback = captureDatabaseTool({});
+      const normalResult = await callback({
+        action: "lint_migrations",
+        dir,
+      });
+      expect(normalResult.isError).toBeFalsy();
+
+      const strictResult = await callback({
+        action: "lint_migrations",
+        dir,
+        strict: true,
+      });
+      expect(strictResult.isError).toBe(true);
+      expect(strictResult.content[0].text).toContain("🔴 Migration Risk Level: HIGH");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  test("lint_migrations action supports inline sql and json output", async () => {
+    const callback = captureDatabaseTool({});
+    const result = await callback({
+      action: "lint_migrations",
+      sql: "DROP TABLE public.temp_users;",
+      json: true,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.overallRisk).toBe("HIGH");
+    expect(parsed.highRiskCount).toBe(1);
+    expect(parsed.files[0].file).toBe("inline.sql");
+  });
+
+  test("lint_migrations action supports single file and fail_on_medium", async () => {
+    const filePath = join(tmpdir(), `supacloud-single-lint-${Date.now()}.sql`);
+    try {
+      writeFileSync(filePath, "CREATE INDEX idx_items ON public.items (id);");
+      const callback = captureDatabaseTool({});
+
+      const normalResult = await callback({
+        action: "lint_migrations",
+        file: filePath,
+      });
+      expect(normalResult.isError).toBeFalsy();
+      expect(normalResult.content[0].text).toContain("Migration Risk Level: MEDIUM");
+      expect(normalResult.content[0].text).toContain(filePath);
+
+      const failResult = await callback({
+        action: "lint_migrations",
+        file: filePath,
+        fail_on_medium: true,
+      });
+      expect(failResult.isError).toBe(true);
+    } finally {
+      rmSync(filePath, { force: true });
+    }
+  });
+
+  test("push_migrations with strict flag aborts when high-risk migrations exist", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-push-strict-"));
+    try {
+      writeFileSync(join(dir, "20260819000001_drop.sql"), "DROP TABLE public.critical_data;");
+      let postCalled = false;
+
+      const callback = captureDatabaseTool({
+        get: async () => ({ ok: true, status: 200, data: [] }),
+        postReleaseMutation: async () => {
+          postCalled = true;
+          return { ok: true, status: 200, data: { name: "drop", version: "1", checksum: "abc" } };
+        },
+      });
+
+      const result = await callback({
+        action: "push_migrations",
+        ref: "proj",
+        dir,
+        strict: true,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Migration push aborted due to strict risk policy");
+      expect(result.content[0].text).toContain("DROP TABLE public.critical_data");
+      expect(postCalled).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("push_migrations dry_run returns an error under strict risk policy", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-push-dryrun-strict-"));
+    try {
+      writeFileSync(join(dir, "20260819000001_drop.sql"), "DROP TABLE public.critical_data;");
+      const callback = captureDatabaseTool({
+        get: async () => ({ ok: true, status: 200, data: [] }),
+      });
+
+      const result = await callback({
+        action: "push_migrations",
+        ref: "proj",
+        dir,
+        dry_run: true,
+        strict: true,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("Migration dry run for");
+      expect(result.content[0].text).toContain("Migration Risk Level: HIGH");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("push_migrations blocks non-transactional SQL before the first mutation", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-push-non-transactional-"));
+    let postCalls = 0;
+    try {
+      writeFileSync(
+        join(dir, "20260819000001_concurrent_index.sql"),
+        "CREATE INDEX CONCURRENTLY idx_users_email ON public.users(email);",
+      );
+      const callback = captureDatabaseTool({
+        get: async () => ({ ok: true, status: 200, data: [] }),
+        postReleaseMutation: async () => {
+          postCalls += 1;
+          return { ok: true, status: 200, data: {} };
+        },
+      });
+
+      const result = await callback({ action: "push_migrations", ref: "proj", dir });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("transactional executor cannot run");
+      expect(result.content[0].text).toContain("CREATE INDEX CONCURRENTLY");
+      expect(postCalls).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("lint_migrations rejects ambiguous input sources", async () => {
+    const callback = captureDatabaseTool({});
+
+    await expect(callback({
+      action: "lint_migrations",
+      sql: "SELECT 1;",
+      file: "migration.sql",
+    })).rejects.toThrow("Use only one of --sql, --file, or --dir");
+  });
 });

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -77,10 +77,14 @@ function baselineInventory(migrations: Array<{ version: string; name: string }>)
     }));
 }
 
-function sqlBatchReceipt(commands: string[]) {
+function sqlBatchReceipt(
+    commands: string[],
+    schemaReloadStatus: "notified" | "notification_failed" = "notified",
+) {
     return {
         command: "BATCH",
         statements: commands.map((command, index) => ({ index: index + 1, command, rowCount: 0, durationMs: 1 })),
+        schema_reload: { status: schemaReloadStatus, ddl_committed: true },
     };
 }
 
@@ -549,6 +553,7 @@ describe("database migration helpers", () => {
     test.each([
         ["non-string name", { version: "1785220280", name: {}, statements: ["CREATE TABLE users (id uuid);"] }],
         ["non-string version", { version: {}, name: "20260425123000_create_users", statements: ["CREATE TABLE users (id uuid);"] }],
+        ["numeric version", { version: 1785220280, name: "20260425123000_create_users", statements: ["CREATE TABLE users (id uuid);"] }],
     ])("rejects a %s before dry-run or apply without writing", async (_case, remoteMigration) => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         const posts: unknown[] = [];
@@ -1279,6 +1284,67 @@ describe("database migration helpers", () => {
         }
     });
 
+    test("accepts a safe historical numeric version while planning a baseline", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [{
+                        version: 20260425123000,
+                        name: "20260425123000_create_users",
+                        statements: ["baseline:20260425123000_create_users"],
+                    }],
+                }),
+            });
+
+            const result = await callback({ action: "baseline_migrations", ref: "proj", dir, dry_run: true });
+
+            expect(result.content[0].text).toContain("Would mark as applied:\n  - none");
+            expect(result.content[0].text).toContain("Already applied:\n  - 20260425123000_create_users.sql");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("accepts repeated generic cli_push names when versions and contents are distinct", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
+        try {
+            writeFileSync(join(dir, "20260425123000_create_users.sql"), "CREATE TABLE users (id uuid);\n");
+            writeFileSync(join(dir, "20260425124000_create_tasks.sql"), "CREATE TABLE tasks (id uuid);\n");
+            const callback = captureDatabaseTool({
+                get: async () => ({
+                    ok: true,
+                    status: 200,
+                    data: [
+                        {
+                            version: "20260425123000",
+                            name: "cli_push",
+                            statements: ["CREATE TABLE users (id uuid);"],
+                        },
+                        {
+                            version: "20260425124000",
+                            name: "cli_push",
+                            statements: ["CREATE TABLE tasks (id uuid);"],
+                        },
+                    ],
+                }),
+            });
+
+            const push = await callback({ action: "push_migrations", ref: "proj", dir, dry_run: true });
+            const baseline = await callback({ action: "baseline_migrations", ref: "proj", dir, dry_run: true });
+
+            expect(push.content[0].text).toContain("Pending:\n  - none");
+            expect(push.content[0].text).toContain("Already applied:\n  - 20260425123000_create_users.sql");
+            expect(baseline.content[0].text).toContain("Would mark as applied:\n  - none");
+            expect(baseline.content[0].text).toContain("Already applied:\n  - 20260425123000_create_users.sql");
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     test("rejects a baseline identity without content evidence before mutation", async () => {
         const dir = mkdtempSync(join(tmpdir(), "supacloud-migrations-"));
         let mutationCount = 0;
@@ -1581,6 +1647,33 @@ describe("database migration helpers", () => {
     expect(JSON.parse(response.content[0].text).error).toEqual({ code: "OUTCOME_UNKNOWN", http_status: 200 });
   });
 
+  test("reports committed table DDL as partial success when schema reload fails", async () => {
+    const callback = captureDatabaseTool({
+      postReleaseMutation: async () => ({
+        ok: true,
+        status: 200,
+        data: sqlBatchReceipt(["CREATE", "ALTER", ...Array(5).fill("DROP")], "notification_failed"),
+      }),
+    });
+
+    const response = await callback({
+      action: "create_table_rls",
+      ref: "proj",
+      table: "todos",
+      columns: "id uuid primary key",
+    });
+    const receipt = JSON.parse(response.content[0].text);
+
+    expect(response.isError).toBe(true);
+    expect(receipt).toMatchObject({
+      ok: false,
+      operation: "database.create_table_rls",
+      ddl_committed: true,
+      schema_reload: { status: "notification_failed" },
+      error: { code: "PARTIAL_SUCCESS", http_status: 200 },
+    });
+  });
+
   test.each([201, 202, 204])("does not treat HTTP %d as a completed table and RLS mutation", async (status) => {
     const callback = captureDatabaseTool({
       postReleaseMutation: async () => ({
@@ -1664,6 +1757,30 @@ describe("database migration helpers", () => {
       expect(text).toContain("Risk Assessment:");
       expect(text).toContain("Migration Risk Level: MEDIUM");
       expect(text).toContain("CREATE INDEX CONCURRENTLY");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  test("push_migrations dry_run fails when transactional SQL cannot be applied", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "supacloud-dryrun-blocker-test-"));
+    try {
+      writeFileSync(
+        join(dir, "20260819000001_concurrent_index.sql"),
+        "CREATE INDEX CONCURRENTLY idx_users_name ON public.users (name);",
+      );
+      const callback = captureDatabaseTool({
+        get: async () => ({ ok: true, status: 200, data: [] }),
+      });
+
+      const result = await callback({
+        action: "push_migrations",
+        ref: "proj",
+        dir,
+        dry_run: true,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("cannot run inside the transactional migration executor");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -10,8 +10,10 @@ import { projectRefPathSegment } from "../project-ref";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { HttpResult, HttpTransport } from "../transports/http";
 import { releaseControlFailure, releaseControlMutationFailure } from "./release-control-response";
+import { analyzeMigrationFiles, formatMigrationRiskReport } from "./migration-risk";
 
 export interface DatabaseToolsConfig {
+    localOnly?: boolean;
     readOnly?: boolean;
     projectRef?: string;
 }
@@ -447,13 +449,13 @@ export function vectorWarningsForPendingMigrations(
 
 export function registerDatabaseTools(
     server: { tool: (...args: any[]) => void },
-    http: HttpTransport,
+    http: HttpTransport | undefined,
     config: DatabaseToolsConfig = {}
 ): void {
-    const { readOnly = false, projectRef } = config;
+    const { localOnly = false, readOnly = false, projectRef } = config;
 
-    // Build action list dynamically
-    const actions = [
+    const localActions = ["lint_migrations", "lint"] as const;
+    const readActions = [
         "query", "list_tables", "describe_columns", "list_indexes", "list_constraints",
         "list_extensions", "rls_status", "rls_policies",
         "list_auth_users", "get_auth_user",
@@ -461,22 +463,31 @@ export function registerDatabaseTools(
         "list_migrations", "migration_inventory", "project_url", "generate_types",
     ] as const;
     const writeActions = ["apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"] as const;
-    const allActions = readOnly ? actions : [...actions, ...writeActions];
+    const remoteActions = [...readActions, ...localActions] as const;
+    const allActions = localOnly
+        ? localActions
+        : readOnly
+            ? remoteActions
+            : [...remoteActions, ...writeActions] as const;
 
     server.tool(
         "database",
         `Database operations: query, schema, RLS, migrations, stats.
-Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
+Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ? " (read-only mode)" : ""}`,
         {
             action: withDescription(stringEnum(allActions as unknown as [string, ...string[]]), "Action"),
             ref: projectRef ? Type.Optional(Type.String()) : optional(Type.String(), "Project ref"),
             // query
-            sql: optional(Type.String(), "[query/apply_migration] SQL statement"),
-            file: optional(Type.String(), "[query/apply_migration] Read SQL from local file path (avoids shell escaping issues with $$ and multi-statement DDL)"),
-            dir: optional(Type.String(), "[push_migrations/baseline_migrations] Directory containing .sql migration files (default: supabase/migrations)"),
+            sql: optional(Type.String(), "[query/apply_migration/lint_migrations/lint] SQL statement"),
+            file: optional(Type.String(), "[query/apply_migration/lint_migrations/lint] Read SQL from local file path (avoids shell escaping issues with $$ and multi-statement DDL)"),
+            dir: optional(Type.String(), "[push_migrations/baseline_migrations/lint_migrations/lint] Directory containing .sql migration files (default: supabase/migrations)"),
             dry_run: optional(Type.Boolean(), "[push_migrations/baseline_migrations] Preview changes without applying them"),
+            strict: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint] Exit with error if high-risk destructive migrations are detected"),
+            fail_on_high: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint] Alias for --strict"),
+            fail_on_medium: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint] Exit with error if medium-risk or high-risk migrations are detected"),
+            json: optional(Type.Boolean(), "[lint_migrations/lint] Output structured JSON analysis"),
             // schema
-            schema: optional(Type.String(), "[*] Schema name (default: public)"),
+            schema: optional(Type.String(), "[describe_columns/list_indexes/list_constraints/rls_status/rls_policies/create_table_rls] Schema name (default: public)"),
             table: optional(Type.String(), "[describe_columns/indexes/constraints/rls_*] Table name"),
             schemas: optional(Type.Array(Type.String()), "[list_tables/generate_types] Schemas array"),
             // auth users
@@ -491,12 +502,19 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
         },
         async (args: any) => {
             const { action } = args;
+            if (localOnly && action !== "lint_migrations" && action !== "lint") {
+                throw new Error(`Database action '${String(action)}' requires Management API context`);
+            }
+            const managementHttp = (): HttpTransport => {
+                if (!http) throw new Error(`Database action '${String(action)}' requires Management API context`);
+                return http;
+            };
             const ref = args.ref || projectRef;
             const schema = args.schema || "public";
             const schemas = args.schemas || ["public"];
 
             // Resolve SQL from --file if provided (avoids shell $$ and ; escaping)
-            if (args.file && !args.sql) {
+            if (args.file && !args.sql && action !== "lint_migrations" && action !== "lint") {
                 try {
                     args.sql = readFileSync(args.file, "utf-8");
                 } catch (e: any) {
@@ -505,7 +523,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
             }
 
             const execSql = async (sql: string, mode?: "read" | "migration" | "admin") =>
-                http.post(`/v1/projects/${ref}/database/sql`, mode ? { sql, mode } : { sql });
+                managementHttp().post(`/v1/projects/${ref}/database/sql`, mode ? { sql, mode } : { sql });
 
             let text: string;
             switch (action) {
@@ -605,14 +623,14 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     break;
                 }
                 case "migration_inventory": {
-                    const response = await http.get(
+                    const response = await managementHttp().get(
                         migrationInventoryPath(ref),
                         { maxResponseBytes: MAX_MIGRATION_INVENTORY_BYTES },
                     );
                     return migrationInventoryResponse(response);
                 }
                 case "project_url": {
-                    const r = await http.get(`/v1/projects/${ref}`);
+                    const r = await managementHttp().get(`/v1/projects/${ref}`);
                     text = r.ok ? JSON.stringify({ url: (r.data as any).api?.url || `https://${ref}.supabase.co` }, null, 2) : `❌ Failed (${r.status})`;
                     break;
                 }
@@ -622,9 +640,57 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     text = r.ok ? generateTypeScriptTypes(r.data, schemas) : `❌ Failed (${r.status})`;
                     break;
                 }
+                case "lint_migrations":
+                case "lint": {
+                    let migrationFiles: Array<{ file: string; sql: string }> = [];
+                    const explicitInputs = [args.sql, args.file, args.dir]
+                        .filter((input) => typeof input === "string" && input.length > 0);
+                    if (explicitInputs.length > 1) {
+                        throw new Error("Use only one of --sql, --file, or --dir for migration lint");
+                    }
+
+                    if (args.sql) {
+                        migrationFiles = [{ file: "inline.sql", sql: args.sql }];
+                    } else if (args.file) {
+                        if (!existsSync(args.file) || !statSync(args.file).isFile()) {
+                            throw new Error(`Migration file not found: ${args.file}`);
+                        }
+                        migrationFiles = [{ file: args.file, sql: readFileSync(args.file, "utf8") }];
+                    } else {
+                        const dir = args.dir || "supabase/migrations";
+                        if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+                            throw new Error(`Migration directory not found: ${dir}`);
+                        }
+
+                        const files = readdirSync(dir)
+                            .filter((file) => file.endsWith(".sql"))
+                            .sort();
+
+                        if (!files.length) {
+                            text = `No .sql migration files found in ${dir}`;
+                            break;
+                        }
+
+                        migrationFiles = sortMigrationFiles(files.map((file) => readMigrationFile(dir, file)));
+                    }
+
+                    const analysis = analyzeMigrationFiles(migrationFiles);
+                    if (args.json) {
+                        text = JSON.stringify(analysis, null, 2);
+                    } else {
+                        text = formatMigrationRiskReport(analysis);
+                    }
+
+                    const strict = args.strict === true || args.fail_on_high === true;
+                    const failOnMedium = args.fail_on_medium === true;
+                    if ((strict && analysis.highRiskCount > 0) || (failOnMedium && (analysis.highRiskCount > 0 || analysis.mediumRiskCount > 0))) {
+                        return { content: [{ type: "text" as const, text }], isError: true };
+                    }
+                    break;
+                }
                 case "apply_migration": {
                     if (!args.name || !args.sql) throw new Error("'name' and 'sql' required");
-                    const r = await http.postReleaseMutation(
+                    const r = await managementHttp().postReleaseMutation(
                         `/v1/projects/${ref}/database/migrations`,
                         { name: args.name, sql: args.sql },
                     );
@@ -655,7 +721,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
 
                     const migrationFiles = sortMigrationFiles(files.map((file) => readMigrationFile(dir, file)));
 
-                    const migrationsResult = await http.get(`/v1/projects/${ref}/database/migrations`);
+                    const migrationsResult = await managementHttp().get(`/v1/projects/${ref}/database/migrations`);
                     if (!migrationsResult.ok) {
                         return releaseControlFailure(
                             "database.push_migrations",
@@ -665,6 +731,11 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     }
 
                     const migrationPlan = migrationPushPlan(migrationsResult.data, migrationFiles);
+                    const riskAnalysis = analyzeMigrationFiles(migrationPlan.pending);
+                    const strict = args.strict === true || args.fail_on_high === true;
+                    const failOnMedium = args.fail_on_medium === true;
+                    const riskPolicyFailed = (strict && riskAnalysis.highRiskCount > 0)
+                        || (failOnMedium && (riskAnalysis.highRiskCount > 0 || riskAnalysis.mediumRiskCount > 0));
 
                     if (args.dry_run) {
                         const pending = migrationPlan.pending;
@@ -678,6 +749,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                                 : null;
                         }
                         const warnings = vectorWarningsForPendingMigrations(pendingWithSql, vectorEnabled);
+                        const riskReport = formatMigrationRiskReport(riskAnalysis);
                         text = [
                             `Migration dry run for ${dir}`,
                             `Total: ${migrationFiles.length}`,
@@ -688,8 +760,36 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                             "Already applied:",
                             ...(alreadyApplied.length ? alreadyApplied.map(({ file, version }) => `  - ${file} (${version})`) : ["  - none"]),
                             ...(warnings.length ? ["", "Warnings:", ...warnings.map((warning) => `  - ${warning}`)] : []),
+                            "",
+                            "Risk Assessment:",
+                            ...riskReport.split("\n").map((line) => `  ${line}`),
                         ].join("\n");
-                        break;
+                        return {
+                            content: [{ type: "text" as const, text }],
+                            ...(riskPolicyFailed ? { isError: true } : {}),
+                        };
+                    }
+
+                    if (riskAnalysis.transactionalPushBlockerCount > 0) {
+                        const riskReport = formatMigrationRiskReport(riskAnalysis);
+                        return {
+                            content: [{
+                                type: "text" as const,
+                                text: `❌ Migration push aborted because the transactional executor cannot run one or more statements:\n\n${riskReport}`,
+                            }],
+                            isError: true,
+                        };
+                    }
+
+                    if (riskPolicyFailed) {
+                        const riskReport = formatMigrationRiskReport(riskAnalysis);
+                        return {
+                            content: [{
+                                type: "text" as const,
+                                text: `❌ Migration push aborted due to strict risk policy:\n\n${riskReport}`,
+                            }],
+                            isError: true,
+                        };
                     }
 
                     const pending = new Set(migrationPlan.pending.map(({ file }) => file));
@@ -700,7 +800,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                             skipped.push(file);
                             continue;
                         }
-                        const r = await http.postReleaseMutation(
+                        const r = await managementHttp().postReleaseMutation(
                             `/v1/projects/${ref}/database/migrations`,
                             { name, sql, version },
                         );
@@ -743,7 +843,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
 
                     const migrationFiles = sortMigrationFiles(files.map((file) => readMigrationFile(dir, file)));
 
-                    const r = await http.get(`/v1/projects/${ref}/database/migrations`);
+                    const r = await managementHttp().get(`/v1/projects/${ref}/database/migrations`);
                     if (!r.ok) {
                         return releaseControlFailure(
                             "database.baseline_migrations",
@@ -778,7 +878,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                         break;
                     }
 
-                    const baselineResult = await http.postReleaseMutation(
+                    const baselineResult = await managementHttp().postReleaseMutation(
                         `/v1/projects/${ref}/database/migrations/baseline`,
                         { migrations: missing.map(({ name, version }) => ({ name, version })) },
                     );
@@ -792,7 +892,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     if (!receipt) {
                         return releaseControlFailure("database.baseline_migrations", "OUTCOME_UNKNOWN", baselineResult.status);
                     }
-                    const inventoryResult = await http.get(
+                    const inventoryResult = await managementHttp().get(
                         `/v1/projects/${ref}/database/migrations`,
                         { maxResponseBytes: MAX_MIGRATION_INVENTORY_BYTES },
                     );
@@ -821,7 +921,7 @@ Actions: ${allActions.join(", ")}${readOnly ? " (read-only mode)" : ""}`,
                     if (policyMode !== "deny_all" && policyMode !== "owner") throw new Error("Invalid RLS policy mode");
                     const policySql = buildRlsPolicySql(qualifiedTable, policyMode, args.owner_column);
                     const sql = `BEGIN; CREATE TABLE IF NOT EXISTS ${qualifiedTable} (${columns}); ALTER TABLE ${qualifiedTable} ENABLE ROW LEVEL SECURITY; ${policySql} COMMIT;`;
-                    const r = await http.postReleaseMutation(
+                    const r = await managementHttp().postReleaseMutation(
                         `/v1/projects/${ref}/database/sql`,
                         { sql, mode: "migration" },
                     );

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -23,6 +23,7 @@ const FALLBACK_MIGRATION_VERSION_BASE = 8_000_000_000_000_000_000n;
 const FALLBACK_MIGRATION_VERSION_RANGE = 1_000_000_000_000_000_000n;
 const FALLBACK_MIGRATION_VERSION_LIMIT = FALLBACK_MIGRATION_VERSION_BASE + FALLBACK_MIGRATION_VERSION_RANGE;
 const MAX_MIGRATION_INVENTORY_BYTES = 64 * 1024 * 1024;
+const GENERIC_MIGRATION_NAMES = new Set(["cli_push"]);
 
 interface MigrationFile {
     file: string;
@@ -225,11 +226,41 @@ function migrationIdentity(row: unknown): RemoteMigrationIdentity {
     if (!isMigrationInventoryVersion(migration.version) || !isMigrationInventoryName(migration.name)) {
         throw new Error("Invalid remote migration identity");
     }
-    return { version: migration.version, name: migration.name, statements: migration.statements };
+    return {
+        version: migration.version,
+        name: migration.name !== null && GENERIC_MIGRATION_NAMES.has(migration.name) ? null : migration.name,
+        statements: migration.statements,
+    };
 }
 
-function migrationIdentities(data: unknown): RemoteMigrationIdentity[] {
-    const identities = migrationRows(data).map(migrationIdentity);
+function historicalMigrationVersion(version: unknown): string | null {
+    if (isMigrationInventoryVersion(version)) return version;
+    if (typeof version !== "number" || !Number.isSafeInteger(version)) return null;
+    const normalized = String(version);
+    return isMigrationInventoryVersion(normalized) ? normalized : null;
+}
+
+function baselineMigrationIdentity(row: unknown): RemoteMigrationIdentity {
+    if (!row || typeof row !== "object" || Array.isArray(row)) {
+        throw new Error("Invalid remote migration identity");
+    }
+    const migration = row as Record<string, unknown>;
+    const version = historicalMigrationVersion(migration.version);
+    if (!version || !isMigrationInventoryName(migration.name)) {
+        throw new Error("Invalid remote migration identity");
+    }
+    return {
+        version,
+        name: migration.name !== null && GENERIC_MIGRATION_NAMES.has(migration.name) ? null : migration.name,
+        statements: migration.statements,
+    };
+}
+
+function migrationIdentities(
+    data: unknown,
+    parseIdentity: (row: unknown) => RemoteMigrationIdentity,
+): RemoteMigrationIdentity[] {
+    const identities = migrationRows(data).map(parseIdentity);
     const versions = new Set<string>();
     const names = new Set<string>();
     for (const identity of identities) {
@@ -280,14 +311,27 @@ function migrationDisposition(
     if (!sameVersion.length && !sameName.length) return "pending";
     if (sameVersion[0] && sameName[0] && sameVersion[0] !== sameName[0]) throw migrationIdentityConflict(local);
     const remote = sameVersion[0] ?? sameName[0]!;
-    const exactIdentity = remote.version === local.version && remote.name === local.name;
-    if (exactIdentity && exactIdentityIsApplied(local, remote)) return "applied";
+    const versionIdentity = remote.version === local.version
+        && (remote.name === local.name || remote.name === null);
+    if (versionIdentity && exactIdentityIsApplied(local, remote)) return "applied";
     if (!sameVersion.length && legacyIdentityIsApplied(local, remote)) return "applied";
     throw migrationIdentityConflict(local);
 }
 
 function migrationPushPlan(data: unknown, migrationFiles: MigrationFile[]): MigrationPushPlan {
-    const remoteMigrations = migrationIdentities(data);
+    return migrationPlan(data, migrationFiles, migrationIdentity);
+}
+
+function migrationBaselinePlan(data: unknown, migrationFiles: MigrationFile[]): MigrationPushPlan {
+    return migrationPlan(data, migrationFiles, baselineMigrationIdentity);
+}
+
+function migrationPlan(
+    data: unknown,
+    migrationFiles: MigrationFile[],
+    parseIdentity: (row: unknown) => RemoteMigrationIdentity,
+): MigrationPushPlan {
+    const remoteMigrations = migrationIdentities(data, parseIdentity);
     const plan: MigrationPushPlan = { alreadyApplied: [], pending: [] };
     for (const migration of migrationFiles) {
         const disposition = migrationDisposition(migration, remoteMigrations);
@@ -383,6 +427,15 @@ function confirmedSqlBatchReceipt(payload: unknown, expectedCommands: string[]):
         if (typeof statement.durationMs !== "number" || !Number.isFinite(statement.durationMs) || statement.durationMs < 0) return false;
         return true;
     });
+}
+
+function schemaReloadStatus(payload: unknown): "notified" | "notification_failed" | null {
+    const receipt = recordPayload(payload);
+    const schemaReload = recordPayload(receipt?.schema_reload);
+    if (schemaReload?.ddl_committed !== true) return null;
+    return schemaReload.status === "notified" || schemaReload.status === "notification_failed"
+        ? schemaReload.status
+        : null;
 }
 
 function rlsStatementCommands(policyMode: "deny_all" | "owner"): string[] {
@@ -766,7 +819,9 @@ Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ?
                         ].join("\n");
                         return {
                             content: [{ type: "text" as const, text }],
-                            ...(riskPolicyFailed ? { isError: true } : {}),
+                            ...(riskPolicyFailed || riskAnalysis.transactionalPushBlockerCount > 0
+                                ? { isError: true }
+                                : {}),
                         };
                     }
 
@@ -852,7 +907,7 @@ Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ?
                         );
                     }
 
-                    const migrationPlan = migrationPushPlan(r.data, migrationFiles);
+                    const migrationPlan = migrationBaselinePlan(r.data, migrationFiles);
                     const missing = migrationPlan.pending;
                     const alreadyApplied = migrationPlan.alreadyApplied;
 
@@ -930,6 +985,18 @@ Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ?
                         return releaseControlFailure("database.create_table_rls", "OUTCOME_UNKNOWN", r.status);
                     }
                     if (!confirmedSqlBatchReceipt(r.data, rlsStatementCommands(policyMode))) {
+                        return releaseControlFailure("database.create_table_rls", "OUTCOME_UNKNOWN", r.status);
+                    }
+                    const reloadStatus = schemaReloadStatus(r.data);
+                    if (reloadStatus === "notification_failed") {
+                        return releaseControlFailure(
+                            "database.create_table_rls",
+                            "PARTIAL_SUCCESS",
+                            r.status,
+                            { ddl_committed: true, schema_reload: { status: reloadStatus } },
+                        );
+                    }
+                    if (reloadStatus !== "notified") {
                         return releaseControlFailure("database.create_table_rls", "OUTCOME_UNKNOWN", r.status);
                     }
                     text = `✅ Table '${schema}.${args.table}' created with RLS (${policyMode === "owner" ? "auth.uid() owner policy" : "deny-all by default"})`;

--- a/packages/cli/src/shared/tools/migration-risk.test.ts
+++ b/packages/cli/src/shared/tools/migration-risk.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+import {
+    analyzeMigrationFiles,
+    analyzeMigrationSql,
+    formatMigrationRiskReport,
+} from "./migration-risk";
+
+describe("migration risk analysis", () => {
+    test("detects safe additive migrations as LOW risk", () => {
+        const sql = `
+            CREATE TABLE public.posts (
+                id bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+                title text NOT NULL,
+                created_at timestamptz NOT NULL DEFAULT now()
+            );
+            ALTER TABLE public.posts ADD CONSTRAINT fk_user FOREIGN KEY (author_id) REFERENCES public.users(id) NOT VALID;
+            ALTER TABLE public.posts ADD CONSTRAINT chk_title CHECK (length(title) > 0) NOT VALID;
+        `;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toHaveLength(0);
+
+        const analysis = analyzeMigrationFiles([{ file: "20260819_add_posts.sql", sql }]);
+        expect(analysis.overallRisk).toBe("LOW");
+        expect(analysis.highRiskCount).toBe(0);
+        expect(analysis.mediumRiskCount).toBe(0);
+        expect(formatMigrationRiskReport(analysis)).toContain("✅ All migrations follow safe, non-blocking Expand-Contract patterns.");
+    });
+
+    test("detects non-concurrent index creation as MEDIUM risk", () => {
+        const sql = `CREATE INDEX idx_users_email ON public.users (email);`;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                level: "MEDIUM",
+                type: "locking_non_concurrent_index",
+            }),
+        ]);
+        expect(risks[0].recommendation).toContain("CREATE INDEX CONCURRENTLY");
+    });
+
+    test("detects non-concurrent drop index as MEDIUM risk", () => {
+        const sql = `DROP INDEX idx_users_old;`;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                level: "MEDIUM",
+                type: "locking_drop_index_non_concurrent",
+            }),
+        ]);
+        expect(risks[0].recommendation).toContain("DROP INDEX CONCURRENTLY");
+    });
+
+    test("blocks concurrent index operations in the transactional push executor", () => {
+        const sql = `
+            CREATE INDEX CONCURRENTLY idx_users_email ON public.users (email);
+            CREATE UNIQUE INDEX CONCURRENTLY idx_users_name ON public.users (name);
+            DROP INDEX CONCURRENTLY idx_users_legacy;
+        `;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toHaveLength(3);
+        expect(risks.every((risk) => risk.type === "unsupported_concurrent_index_migration")).toBe(true);
+        expect(risks.every((risk) => risk.blocksTransactionalPush === true)).toBe(true);
+
+        const analysis = analyzeMigrationFiles([{ file: "concurrent.sql", sql }]);
+        expect(analysis.transactionalPushBlockerCount).toBe(3);
+    });
+
+    test("detects ADD COLUMN NOT NULL without DEFAULT as MEDIUM risk", () => {
+        const sql = `ALTER TABLE public.users ADD COLUMN status text NOT NULL;`;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                level: "MEDIUM",
+                type: "locking_not_null_no_default",
+            }),
+        ]);
+        expect(risks[0].recommendation).toContain("Expand-Contract");
+    });
+
+    test("does not flag ADD COLUMN NOT NULL with DEFAULT", () => {
+        expect(analyzeMigrationSql(
+            `ALTER TABLE public.users ADD COLUMN status text NOT NULL DEFAULT 'active';`,
+        )).toHaveLength(0);
+        expect(analyzeMigrationSql(
+            `ALTER TABLE public.users ADD COLUMN attempts integer DEFAULT 1 NOT NULL;`,
+        )).toHaveLength(0);
+    });
+
+    test("detects destructive DROP TABLE and DROP VIEW as HIGH risk", () => {
+        expect(analyzeMigrationSql("DROP TABLE public.legacy_logs;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "destructive_drop_table" }),
+        ]);
+        expect(analyzeMigrationSql("DROP VIEW public.active_users;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "destructive_drop_view" }),
+        ]);
+        expect(analyzeMigrationSql("DROP MATERIALIZED VIEW public.monthly_stats;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "destructive_drop_view" }),
+        ]);
+    });
+
+    test("detects destructive DROP COLUMN as HIGH risk", () => {
+        const sql = `ALTER TABLE public.users DROP COLUMN deprecated_field;`;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                level: "HIGH",
+                type: "destructive_drop_column",
+            }),
+        ]);
+    });
+
+    test("detects destructive TRUNCATE, RENAME COLUMN, and RENAME TABLE as HIGH risk", () => {
+        expect(analyzeMigrationSql("TRUNCATE TABLE audit_events;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "destructive_truncate" }),
+        ]);
+        expect(analyzeMigrationSql("ALTER TABLE users RENAME COLUMN email TO primary_email;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "destructive_rename_column" }),
+        ]);
+        expect(analyzeMigrationSql("ALTER TABLE old_orders RENAME TO orders;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "destructive_rename_table" }),
+        ]);
+    });
+
+    test("detects altering column type as MEDIUM locking risk", () => {
+        const sql = `ALTER TABLE users ALTER COLUMN age TYPE bigint;`;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                level: "MEDIUM",
+                type: "locking_alter_type",
+            }),
+        ]);
+    });
+
+    test("detects SET NOT NULL and constraints without NOT VALID as MEDIUM risk", () => {
+        expect(analyzeMigrationSql("ALTER TABLE users ALTER COLUMN email SET NOT NULL;")).toEqual([
+            expect.objectContaining({ level: "MEDIUM", type: "locking_alter_column_set_not_null" }),
+        ]);
+        expect(analyzeMigrationSql("ALTER TABLE orders ADD CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id);")).toEqual([
+            expect.objectContaining({ level: "MEDIUM", type: "locking_foreign_key_without_not_valid" }),
+        ]);
+        expect(analyzeMigrationSql("ALTER TABLE orders ADD CONSTRAINT chk_price CHECK (price > 0);")).toEqual([
+            expect.objectContaining({ level: "MEDIUM", type: "locking_check_constraint_without_not_valid" }),
+        ]);
+    });
+
+    test("does not treat UNIQUE USING INDEX as a new locking index build", () => {
+        expect(analyzeMigrationSql(
+            "ALTER TABLE users ADD CONSTRAINT users_email_key UNIQUE USING INDEX users_email_idx;",
+        )).toHaveLength(0);
+    });
+
+    test("does not classify DROP CONSTRAINT or DROP NOT NULL as DROP COLUMN", () => {
+        expect(analyzeMigrationSql("ALTER TABLE users DROP CONSTRAINT users_email_key;")).toEqual([
+            expect.objectContaining({ type: "destructive_drop_constraint" }),
+        ]);
+        expect(analyzeMigrationSql("ALTER TABLE users ALTER COLUMN email DROP NOT NULL;")).toHaveLength(0);
+    });
+
+    test("does not classify safe constraints or identifiers as procedural SQL", () => {
+        expect(analyzeMigrationSql(
+            "ALTER TABLE users ADD CONSTRAINT users_email_nn CHECK (email IS NOT NULL) NOT VALID;",
+        )).toHaveLength(0);
+        expect(analyzeMigrationSql("CREATE TABLE task_state (do text);")).toHaveLength(0);
+        expect(analyzeMigrationSql("COMMENT ON COLUMN task_state.do IS 'action';")).toHaveLength(0);
+    });
+
+    test("detects VACUUM FULL and CLUSTER as HIGH locking risk", () => {
+        expect(analyzeMigrationSql("VACUUM FULL public.users;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "locking_vacuum_full" }),
+        ]);
+        expect(analyzeMigrationSql("CLUSTER public.users USING idx_users_pkey;")).toEqual([
+            expect.objectContaining({ level: "HIGH", type: "locking_cluster" }),
+        ]);
+        expect(analyzeMigrationSql("ALTER TABLE public.users CLUSTER ON idx_users_pkey;")).toHaveLength(0);
+    });
+
+    test("ignores comments and string literals to prevent false positives", () => {
+        const sql = `
+            -- DROP TABLE users;
+            /*
+               ALTER TABLE users DROP COLUMN email;
+               CREATE INDEX idx_fake ON fake (id);
+            */
+            SELECT 'DROP TABLE users' AS note;
+            SELECT $$ALTER TABLE users DROP COLUMN phone$$ AS log_note;
+        `;
+        const risks = analyzeMigrationSql(sql);
+        expect(risks).toHaveLength(0);
+    });
+
+    test("ignores E-strings and quoted identifiers containing risk keywords", () => {
+        const sql = `
+            SELECT E'DROP TABLE users\\nCREATE INDEX idx_fake ON users(id)' AS note;
+            CREATE TABLE public."DROP TABLE users" ("CREATE INDEX idx" integer);
+        `;
+        expect(analyzeMigrationSql(sql)).toHaveLength(0);
+    });
+
+    test("requires manual review for DO blocks even when their body is dollar-quoted", () => {
+        const risks = analyzeMigrationSql(`DO $$ BEGIN EXECUTE 'DROP TABLE users'; END $$;`);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                level: "HIGH",
+                type: "manual_review_do_block",
+                blocksTransactionalPush: true,
+            }),
+        ]);
+    });
+
+    test("formats multi-file risk report with clear guidance", () => {
+        const files = [
+            {
+                file: "20260819_01_safe.sql",
+                sql: "CREATE TABLE t (id int);",
+            },
+            {
+                file: "20260819_02_index.sql",
+                sql: "CREATE INDEX idx_t ON t (id);",
+            },
+            {
+                file: "20260819_03_drop.sql",
+                sql: "DROP TABLE old_t;",
+            },
+        ];
+        const analysis = analyzeMigrationFiles(files);
+        expect(analysis.overallRisk).toBe("HIGH");
+        expect(analysis.highRiskCount).toBe(1);
+        expect(analysis.mediumRiskCount).toBe(1);
+
+        const report = formatMigrationRiskReport(analysis);
+        expect(report).toContain("🔴 Migration Risk Level: HIGH");
+        expect(report).toContain("20260819_02_index.sql");
+        expect(report).toContain("20260819_03_drop.sql");
+        expect(report).toContain("CREATE INDEX CONCURRENTLY");
+    });
+});

--- a/packages/cli/src/shared/tools/migration-risk.test.ts
+++ b/packages/cli/src/shared/tools/migration-risk.test.ts
@@ -86,6 +86,31 @@ describe("migration risk analysis", () => {
         )).toHaveLength(0);
     });
 
+    test("analyzes each ALTER TABLE subcommand independently", () => {
+        const risks = analyzeMigrationSql(`
+            ALTER TABLE public.users
+              ADD COLUMN safe_count integer DEFAULT 0,
+              ADD COLUMN required_label text NOT NULL;
+        `);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                type: "locking_not_null_no_default",
+                statementSnippet: expect.stringContaining("required_label"),
+            }),
+        ]);
+    });
+
+    test("flags function-based defaults conservatively but allows known stable timestamps", () => {
+        expect(analyzeMigrationSql(
+            "ALTER TABLE users ADD COLUMN request_id uuid DEFAULT gen_random_uuid() NOT NULL;",
+        )).toEqual([
+            expect.objectContaining({ type: "locking_not_null_expression_default" }),
+        ]);
+        expect(analyzeMigrationSql(
+            "ALTER TABLE users ADD COLUMN created_at timestamptz DEFAULT now() NOT NULL;",
+        )).toHaveLength(0);
+    });
+
     test("detects destructive DROP TABLE and DROP VIEW as HIGH risk", () => {
         expect(analyzeMigrationSql("DROP TABLE public.legacy_logs;")).toEqual([
             expect.objectContaining({ level: "HIGH", type: "destructive_drop_table" }),
@@ -206,6 +231,140 @@ describe("migration risk analysis", () => {
                 blocksTransactionalPush: true,
             }),
         ]);
+    });
+
+    test("requires manual review for procedural definitions and calls", () => {
+        expect(analyzeMigrationSql(
+            "CREATE FUNCTION public.answer() RETURNS integer LANGUAGE sql AS $$ SELECT 42 $$;",
+        )).toEqual([
+            expect.objectContaining({ type: "manual_review_procedural_definition", level: "HIGH" }),
+        ]);
+        expect(analyzeMigrationSql("CALL public.rebuild_reporting();")).toEqual([
+            expect.objectContaining({ type: "manual_review_procedure_call", level: "HIGH" }),
+        ]);
+    });
+
+    test("blocks project-scope and server-access operations before push", () => {
+        for (const sql of [
+            "ALTER ROLE postgres SUPERUSER;",
+            "DROP SCHEMA public CASCADE;",
+            "DROP SCHEMA application_private, public CASCADE;",
+            "ALTER SCHEMA public RENAME TO application_public;",
+            "COPY public.accounts TO PROGRAM 'cat';",
+            "COPY public.accounts TO '/var/lib/postgresql/accounts.csv';",
+            "SELECT pg_read_file('/etc/passwd');",
+            "CREATE SERVER remote_db FOREIGN DATA WRAPPER postgres_fdw;",
+            "SELECT dblink('host=remote', 'SELECT 1');",
+        ]) {
+            expect(analyzeMigrationSql(sql)).toEqual(expect.arrayContaining([
+                expect.objectContaining({ level: "HIGH", blocksTransactionalPush: true }),
+            ]));
+        }
+    });
+
+    test("allows one outer transaction wrapper but blocks nested transaction control", () => {
+        expect(analyzeMigrationSql("BEGIN; CREATE TABLE wrapped(id bigint); COMMIT;"))
+            .toHaveLength(0);
+        expect(analyzeMigrationSql("CREATE TABLE partial(id bigint); COMMIT;"))
+            .toEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    type: "unsupported_transaction_control",
+                    blocksTransactionalPush: true,
+                }),
+            ]));
+        expect(analyzeMigrationSql("CREATE TABLE partial(id bigint); ABORT AND CHAIN; SELECT 1;"))
+            .toEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    type: "unsupported_transaction_control",
+                    blocksTransactionalPush: true,
+                }),
+            ]));
+    });
+
+    test("blocks empty migrations after removing an outer transaction wrapper", () => {
+        expect(analyzeMigrationSql("BEGIN; COMMIT;"))
+            .toEqual([expect.objectContaining({
+                type: "unsupported_empty_migration",
+                blocksTransactionalPush: true,
+            })]);
+    });
+
+    test.each([
+        "SELECT 'unterminated",
+        'CREATE TABLE "unterminated (id bigint)',
+        "SELECT $body$unterminated",
+        "SELECT 1 /* unterminated",
+    ])("rejects malformed SQL before risk classification: %s", (sql) => {
+        expect(() => analyzeMigrationSql(sql)).toThrow("Unterminated SQL");
+    });
+
+    test("blocks session, advisory lock, and migration ledger control", () => {
+        for (const sql of [
+            "SET ROLE postgres;",
+            "SELECT pg_advisory_lock(42);",
+            "SELECT pg_catalog.\"pg_advisory_lock\"(42);",
+            "SELECT pg_catalog.\"pg_read_file\"('/etc/passwd');",
+            "SELECT extensions.\"dblink\"('host=remote', 'SELECT 1');",
+            "INSERT INTO supabase_migrations.schema_migrations(version) VALUES ('1');",
+            "DELETE FROM \"public\".\"schema_migrations\" WHERE version = '1';",
+            "DROP TABLE IF EXISTS \"supabase_migrations\".\"schema_migrations\";",
+            "DROP TABLE public.disposable, public.schema_migrations CASCADE;",
+            "TRUNCATE TABLE public.disposable, ONLY public.schema_migrations;",
+            "LOCK TABLE public.disposable, public.schema_migrations IN ACCESS EXCLUSIVE MODE;",
+            "ALTER TABLE IF EXISTS public.schema_migrations ADD COLUMN tampered boolean;",
+            "CREATE INDEX ledger_version_idx ON public.schema_migrations(version);",
+            "CREATE TRIGGER ledger_guard BEFORE INSERT ON public.schema_migrations FOR EACH ROW EXECUTE FUNCTION public.audit();",
+            "DROP TRIGGER IF EXISTS ledger_guard ON public.schema_migrations;",
+            "CREATE RULE ledger_rule AS ON INSERT TO public.schema_migrations DO INSTEAD NOTHING;",
+            "DROP RULE IF EXISTS ledger_rule ON public.schema_migrations;",
+            "CREATE POLICY ledger_policy ON public.schema_migrations USING (true);",
+            "COMMENT ON TABLE public.schema_migrations IS 'tampered';",
+            "SECURITY LABEL ON TABLE public.schema_migrations IS 'tampered';",
+            "REINDEX TABLE public.schema_migrations;",
+            "REINDEX (VERBOSE) TABLE CONCURRENTLY public.schema_migrations;",
+            "CLUSTER VERBOSE public.schema_migrations;",
+            "VACUUM (ANALYZE) public.schema_migrations;",
+            "ANALYZE public.schema_migrations;",
+            "GRANT SELECT ON public.accounts, public.schema_migrations TO authenticated;",
+            "GRANT SELECT ON ALL TABLES IN SCHEMA supabase_migrations TO authenticated;",
+            "GRANT ALL ON ALL TABLES IN SCHEMA public TO authenticated;",
+            "SELECT \"supabase_migrations\".\"record_schema_migration\"('1', ARRAY['SELECT 1'], 'fake', 'checksum');",
+        ]) {
+            expect(analyzeMigrationSql(sql)).toEqual(expect.arrayContaining([
+                expect.objectContaining({ level: "HIGH", blocksTransactionalPush: true }),
+            ]));
+        }
+        expect(analyzeMigrationSql("GRANT SELECT ON public.accounts TO schema_migrations;"))
+            .toHaveLength(0);
+        expect(analyzeMigrationSql("GRANT EXECUTE ON FUNCTION public.audit(schema_migrations) TO authenticated;"))
+            .toHaveLength(0);
+        expect(analyzeMigrationSql("GRANT USAGE ON SCHEMA schema_migrations TO authenticated;"))
+            .toHaveLength(0);
+        expect(analyzeMigrationSql("GRANT EXECUTE ON FUNCTION public.schema_migrations(text) TO authenticated;"))
+            .toHaveLength(0);
+        expect(analyzeMigrationSql("CREATE INDEX account_email_idx ON public.accounts(email);"))
+            .not.toContainEqual(expect.objectContaining({ type: "unsupported_migration_ledger_access" }));
+        expect(analyzeMigrationSql("COMMENT ON TABLE public.accounts IS 'application data';"))
+            .not.toContainEqual(expect.objectContaining({ type: "unsupported_migration_ledger_access" }));
+    });
+
+    test("blocks quoted public schema removal before push", () => {
+        expect(analyzeMigrationSql('DROP SCHEMA "public" CASCADE;')).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                type: "unsupported_public_schema_removal",
+                blocksTransactionalPush: true,
+            }),
+        ]));
+    });
+
+    test("blocks Unicode-escaped identifiers that could hide protected names", () => {
+        expect(analyzeMigrationSql(String.raw`DROP SCHEMA U&"p\0075blic" CASCADE;`))
+            .toEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    type: "unsupported_unicode_escaped_identifier",
+                    blocksTransactionalPush: true,
+                }),
+            ]));
     });
 
     test("formats multi-file risk report with clear guidance", () => {

--- a/packages/cli/src/shared/tools/migration-risk.ts
+++ b/packages/cli/src/shared/tools/migration-risk.ts
@@ -54,12 +54,12 @@ function maskSingleQuotedString(sql: string, start: number): { masked: string; e
             end += 2;
         } else if (sql[end] === "'") {
             end += 1;
-            break;
+            return { masked: " ".repeat(end - start), end };
         } else {
             end += 1;
         }
     }
-    return { masked: " ".repeat(end - start), end };
+    throw new Error("Unterminated SQL single-quoted string");
 }
 
 function maskDoubleQuotedIdentifier(sql: string, start: number): { masked: string; end: number } {
@@ -69,12 +69,17 @@ function maskDoubleQuotedIdentifier(sql: string, start: number): { masked: strin
             end += 2;
         } else if (sql[end] === '"') {
             end += 1;
-            break;
+            return { masked: `"${"_".repeat(Math.max(0, end - start - 2))}"`, end };
         } else {
             end += 1;
         }
     }
-    return { masked: `"${"_".repeat(Math.max(0, end - start - 2))}"`, end };
+    throw new Error("Unterminated SQL double-quoted identifier");
+}
+
+function preserveDoubleQuotedIdentifier(sql: string, start: number): { masked: string; end: number } {
+    const identifier = maskDoubleQuotedIdentifier(sql, start);
+    return { masked: sql.slice(start, identifier.end), end: identifier.end };
 }
 
 function lineCommentEnd(sql: string, start: number): number {
@@ -96,6 +101,7 @@ function blockCommentEnd(sql: string, start: number): number {
             cursor++;
         }
     }
+    if (depth > 0) throw new Error("Unterminated SQL block comment");
     return cursor;
 }
 
@@ -103,12 +109,16 @@ function maskDollarQuotedString(sql: string, start: number): { masked: string; e
     const tag = dollarQuoteTagAt(sql, start);
     if (!tag) return null;
     const closingTag = sql.indexOf(tag, start + tag.length);
-    if (closingTag === -1) return null;
+    if (closingTag === -1) throw new Error("Unterminated SQL dollar-quoted body");
     const end = closingTag + tag.length;
     return { masked: " ".repeat(end - start), end };
 }
 
-function maskSqlSpan(sql: string, start: number): { masked: string; end: number } | null {
+function maskSqlSpan(
+    sql: string,
+    start: number,
+    quotedIdentifier: typeof maskDoubleQuotedIdentifier,
+): { masked: string; end: number } | null {
     if (sql.startsWith("--", start)) {
         const end = lineCommentEnd(sql, start);
         return { masked: " ".repeat(end - start), end };
@@ -118,16 +128,19 @@ function maskSqlSpan(sql: string, start: number): { masked: string; end: number 
         return { masked: " ".repeat(end - start), end };
     }
     if (sql[start] === "'") return maskSingleQuotedString(sql, start);
-    if (sql[start] === '"') return maskDoubleQuotedIdentifier(sql, start);
+    if (sql[start] === '"') return quotedIdentifier(sql, start);
     if (sql[start] === "$") return maskDollarQuotedString(sql, start);
     return null;
 }
 
-export function maskSqlNoise(sql: string): string {
+function maskSql(
+    sql: string,
+    quotedIdentifier: typeof maskDoubleQuotedIdentifier,
+): string {
     let masked = "";
     let cursor = 0;
     while (cursor < sql.length) {
-        const protectedSpan = maskSqlSpan(sql, cursor);
+        const protectedSpan = maskSqlSpan(sql, cursor, quotedIdentifier);
         if (protectedSpan) {
             masked += protectedSpan.masked;
             cursor = protectedSpan.end;
@@ -137,6 +150,14 @@ export function maskSqlNoise(sql: string): string {
         }
     }
     return masked;
+}
+
+export function maskSqlNoise(sql: string): string {
+    return maskSql(sql, maskDoubleQuotedIdentifier);
+}
+
+function maskSqlPolicyNoise(sql: string): string {
+    return maskSql(sql, preserveDoubleQuotedIdentifier);
 }
 
 export function splitSqlStatements(sql: string): string[] {
@@ -162,6 +183,42 @@ export function splitSqlStatements(sql: string): string[] {
     }
 
     return statements;
+}
+
+function normalizedTransactionStatement(statement: string): string {
+    return maskSqlNoise(statement).replace(/\s+/g, " ").trim();
+}
+
+function migrationExecutionStatements(statements: readonly string[]): string[] {
+    if (statements.length < 2) return [...statements];
+    const first = normalizedTransactionStatement(statements[0]);
+    const last = normalizedTransactionStatement(statements[statements.length - 1]);
+    const hasOuterTransaction = /^(?:BEGIN(?:\s+(?:WORK|TRANSACTION))?|START\s+TRANSACTION)$/i.test(first)
+        && /^(?:COMMIT|END)(?:\s+(?:WORK|TRANSACTION))?$/i.test(last);
+    return hasOuterTransaction ? statements.slice(1, -1) : [...statements];
+}
+
+function splitTopLevelClauses(sql: string): string[] {
+    const masked = maskSqlNoise(sql);
+    const clauses: string[] = [];
+    let parenthesisDepth = 0;
+    let bracketDepth = 0;
+    let clauseStart = 0;
+    for (let cursor = 0; cursor < masked.length; cursor += 1) {
+        const character = masked[cursor];
+        if (character === "(") parenthesisDepth += 1;
+        else if (character === ")") parenthesisDepth -= 1;
+        else if (character === "[") bracketDepth += 1;
+        else if (character === "]") bracketDepth -= 1;
+        if (parenthesisDepth < 0 || bracketDepth < 0) throw new Error("Unbalanced SQL delimiters");
+        if (character === "," && parenthesisDepth === 0 && bracketDepth === 0) {
+            clauses.push(sql.slice(clauseStart, cursor).trim());
+            clauseStart = cursor + 1;
+        }
+    }
+    if (parenthesisDepth !== 0 || bracketDepth !== 0) throw new Error("Unbalanced SQL delimiters");
+    clauses.push(sql.slice(clauseStart).trim());
+    return clauses.filter(Boolean);
 }
 
 interface RiskRule {
@@ -249,6 +306,20 @@ const RISK_RULES: readonly RiskRule[] = [
         blocksTransactionalPush: true,
     },
     {
+        type: "manual_review_procedural_definition",
+        level: "HIGH",
+        pattern: /^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:FUNCTION|PROCEDURE)\b/i,
+        description: "Defines procedural SQL whose body can hide data, privilege, or schema side effects from static rules.",
+        recommendation: "Review the complete function or procedure body and require strict migration approval.",
+    },
+    {
+        type: "manual_review_procedure_call",
+        level: "HIGH",
+        pattern: /^\s*CALL\b/i,
+        description: "Calls a stored procedure whose side effects cannot be determined statically.",
+        recommendation: "Replace the call with explicit migration SQL or require strict manual approval.",
+    },
+    {
         type: "locking_vacuum_full",
         level: "HIGH",
         pattern: /^\s*VACUUM\b/i,
@@ -294,14 +365,6 @@ const RISK_RULES: readonly RiskRule[] = [
         recommendation: "For a live table, use the approved non-transactional maintenance path for DROP INDEX CONCURRENTLY; push_migrations cannot execute it.",
     },
     {
-        type: "locking_not_null_no_default",
-        level: "MEDIUM",
-        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bADD\s+(?!CONSTRAINT\b)(?:COLUMN\s+)?[a-z0-9_"]+\s+[^;]+?\bNOT\s+NULL\b(?!\s+DEFAULT\b)/i,
-        excludePattern: /\bADD\s+(?:COLUMN\s+)?[a-z0-9_"]+\s+[\s\S]*?\bDEFAULT\b[\s\S]*?\bNOT\s+NULL\b/i,
-        description: "Adding a NOT NULL column without a DEFAULT value requires full table verification and will fail if the table contains existing rows.",
-        recommendation: "Follow Expand-Contract: Add column as nullable or with a DEFAULT value first, backfill data if necessary, then add NOT NULL constraint.",
-    },
-    {
         type: "locking_alter_column_set_not_null",
         level: "MEDIUM",
         pattern: /\bALTER\s+TABLE\b[\s\S]*?\bALTER\s+(?:COLUMN\s+)?[a-z0-9_"]+\s+SET\s+NOT\s+NULL\b/i,
@@ -339,25 +402,249 @@ const RISK_RULES: readonly RiskRule[] = [
     },
 ];
 
+const MIGRATION_LEDGER_RELATION = String.raw`(?:(?:"?(?:supabase_migrations|public)"?)\s*\.\s*)?"?schema_migrations"?`;
+const MIGRATION_LEDGER_RELATION_END = String.raw`(?=$|[\s,;(*])`;
+const MIGRATION_LEDGER_DDL_OR_MAINTENANCE_PREFIX = String.raw`(?:CREATE\s+(?:UNIQUE\s+)?INDEX\b[^;]*\bON\s+(?:ONLY\s+)?|CREATE\s+(?:CONSTRAINT\s+)?TRIGGER\b[^;]*\bON\s+|DROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?[^;]*\bON\s+|CREATE\s+RULE\b[^;]*\bTO\s+|DROP\s+RULE\s+(?:IF\s+EXISTS\s+)?[^;]*\bON\s+|CREATE\s+POLICY\b[^;]*\bON\s+|ALTER\s+POLICY\b[^;]*\bON\s+|DROP\s+POLICY\s+(?:IF\s+EXISTS\s+)?[^;]*\bON\s+|COMMENT\s+ON\s+TABLE\s+|SECURITY\s+LABEL(?:\s+FOR\s+[^;\s]+)?\s+ON\s+TABLE\s+|REINDEX(?:\s*\([^;)]*\))?\s+TABLE\s+(?:CONCURRENTLY\s+)?|CLUSTER(?:\s+VERBOSE)?\s+|VACUUM(?:\s*\([^;)]*\))?(?:\s+(?:FULL|FREEZE|VERBOSE|ANALYZE))*\s+|ANALYZE(?:\s*\([^;)]*\))?(?:\s+VERBOSE)?\s+)`;
+const MIGRATION_LEDGER_MODIFICATION_PATTERN = new RegExp(
+    String.raw`\b(?:(?:CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?|INSERT\s+INTO\s+(?:ONLY\s+)?|UPDATE\s+(?:ONLY\s+)?|DELETE\s+FROM\s+(?:ONLY\s+)?|MERGE\s+INTO\s+(?:ONLY\s+)?|ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?|COPY\s+)`
+    + MIGRATION_LEDGER_RELATION
+    + MIGRATION_LEDGER_RELATION_END
+    + String.raw`|(?:DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?|TRUNCATE(?:\s+TABLE)?\s+|LOCK\s+(?:TABLE\s+)?)[^;]*`
+    + MIGRATION_LEDGER_RELATION
+    + MIGRATION_LEDGER_RELATION_END
+    + String.raw`|`
+    + MIGRATION_LEDGER_DDL_OR_MAINTENANCE_PREFIX
+    + MIGRATION_LEDGER_RELATION
+    + MIGRATION_LEDGER_RELATION_END
+    + String.raw`)`,
+    "i",
+);
+const NON_TABLE_PRIVILEGE_TARGET = String.raw`(?:ALL\s+(?:FUNCTIONS|PROCEDURES|ROUTINES|SEQUENCES)\s+IN\s+SCHEMA|DATABASE|DOMAIN|FOREIGN\s+DATA\s+WRAPPER|FOREIGN\s+SERVER|FUNCTION|LANGUAGE|LARGE\s+OBJECT|PARAMETER|PROCEDURE|ROUTINE|SCHEMA|SEQUENCE|TABLESPACE|TYPE)\b`;
+const MIGRATION_LEDGER_PRIVILEGE_PATTERN = new RegExp(
+    String.raw`\b(?:GRANT|REVOKE)\b[^;]*\bON\s+(?:(?:TABLE\s+)?(?!`
+    + NON_TABLE_PRIVILEGE_TARGET
+    + String.raw`)(?:(?!\b(?:TO|FROM)\b)[^;])*?`
+    + MIGRATION_LEDGER_RELATION
+    + MIGRATION_LEDGER_RELATION_END
+    + String.raw`(?=[^;]*\b(?:TO|FROM)\b)|ALL\s+TABLES\s+IN\s+SCHEMA\s+"?(?:supabase_migrations|public)"?(?=$|[\s,;]))`,
+    "i",
+);
+
+const PUSH_BLOCKER_RULES: readonly RiskRule[] = [
+    {
+        type: "unsupported_project_scope_management",
+        level: "HIGH",
+        pattern: /\b(?:ALTER\s+DATABASE|DROP\s+SCHEMA\s+(?:IF\s+EXISTS\s+)?(?:[^;]*,\s*)?public(?=\s*(?:,|CASCADE\b|RESTRICT\b|$))|(?:DROP|REASSIGN)\s+OWNED\b|(?:CREATE|ALTER|DROP)\s+(?:ROLE|USER)\b|ALTER\s+SUBSCRIPTION\b)\b/i,
+        description: "Attempts cluster-wide or platform-owned database management outside the project migration boundary.",
+        recommendation: "Use an approved platform administration path instead of push_migrations.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_platform_schema_management",
+        level: "HIGH",
+        pattern: /\b(?:ALTER\s+SCHEMA\s+"?public"?|(?:CREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?|ALTER\s+SCHEMA\s+)"?supabase_migrations"?|DROP\s+SCHEMA\s+(?:IF\s+EXISTS\s+)?(?:[^;]*,\s*)?"?supabase_migrations"?(?=\s*(?:,|CASCADE\b|RESTRICT\b|$)))\b/i,
+        description: "Attempts to rename or re-own the public API schema, or to manage the platform migration schema.",
+        recommendation: "Keep public and supabase_migrations under platform ownership; change project-owned schemas instead.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_unicode_escaped_identifier",
+        level: "HIGH",
+        pattern: /\bU&"/i,
+        description: "Uses a Unicode-escaped identifier that cannot be safely canonicalized by the migration policy.",
+        recommendation: "Use a plain or directly quoted PostgreSQL identifier in controlled migrations.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_server_access",
+        level: "HIGH",
+        pattern: /^\s*COPY\b|\b(?:(?:lo_import|lo_export|pg_read_file|pg_write_file|pg_ls_dir|pg_stat_file|pg_execute_server_program)\s*\(|pg_(?:terminate|cancel)_backend\s*\(|LOAD\b)/i,
+        description: "Attempts server file, process, backend, or dynamic-library access from a project migration.",
+        recommendation: "Run host-level maintenance through an approved platform administration path.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_external_database_access",
+        level: "HIGH",
+        pattern: /\bdblink(?:_[a-z_]+)?\s*\(|\b(?:CREATE|ALTER|DROP)\s+(?:SERVER|USER\s+MAPPING|FOREIGN\s+DATA\s+WRAPPER)\b|\bIMPORT\s+FOREIGN\s+SCHEMA\b|\bCREATE\s+FOREIGN\s+TABLE\b/i,
+        description: "Attempts external database or foreign-data-wrapper access outside the project migration boundary.",
+        recommendation: "Provision external connectivity through an approved platform administration path.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_transaction_control",
+        level: "HIGH",
+        pattern: /^\s*(?:BEGIN|START\s+TRANSACTION|COMMIT|END|ROLLBACK|ABORT|SAVEPOINT|RELEASE\s+SAVEPOINT|PREPARE\s+TRANSACTION)\b/i,
+        description: "Contains transaction control inside a migration whose atomic transaction is owned by the platform.",
+        recommendation: "Remove internal transaction control; one matching outer BEGIN/COMMIT wrapper is stripped automatically.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_session_control",
+        level: "HIGH",
+        pattern: /\b(?:SET\s+(?:(?:LOCAL|SESSION)\s+)?(?:ROLE|SESSION\s+AUTHORIZATION)|RESET\s+(?:ROLE|SESSION\s+AUTHORIZATION)|DISCARD\s+ALL)\b/i,
+        description: "Attempts to change the database session identity or discard platform-managed session state.",
+        recommendation: "Keep migrations within the delegated project role and remove session identity control.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_advisory_lock_control",
+        level: "HIGH",
+        pattern: /\bpg_(?:try_)?advisory_(?:xact_)?(?:lock|unlock)(?:_shared|_all)?\s*\(/i,
+        description: "Attempts advisory lock control that can conflict with the platform migration lock.",
+        recommendation: "Remove custom advisory lock operations; push_migrations already serializes project migrations.",
+        blocksTransactionalPush: true,
+    },
+];
+
+const QUOTED_FUNCTION_BLOCKER_RULES: readonly RiskRule[] = [
+    {
+        type: "unsupported_server_access",
+        level: "HIGH",
+        pattern: /"(?:lo_import|lo_export|pg_read_file|pg_write_file|pg_ls_dir|pg_stat_file|pg_execute_server_program|pg_terminate_backend|pg_cancel_backend)"\s*\(/,
+        description: "Attempts server file, process, backend, or dynamic-library access from a project migration.",
+        recommendation: "Run host-level maintenance through an approved platform administration path.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_external_database_access",
+        level: "HIGH",
+        pattern: /"dblink(?:_[a-z_]+)?"\s*\(/,
+        description: "Attempts external database or foreign-data-wrapper access outside the project migration boundary.",
+        recommendation: "Provision external connectivity through an approved platform administration path.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_advisory_lock_control",
+        level: "HIGH",
+        pattern: /"pg_(?:try_)?advisory_(?:xact_)?(?:lock|unlock)(?:_shared|_all)?"\s*\(/,
+        description: "Attempts advisory lock control that can conflict with the platform migration lock.",
+        recommendation: "Remove custom advisory lock operations; push_migrations already serializes project migrations.",
+        blocksTransactionalPush: true,
+    },
+];
+
+const MIGRATION_LEDGER_BLOCKER_RULES: readonly RiskRule[] = [
+    {
+        type: "unsupported_public_schema_removal",
+        level: "HIGH",
+        pattern: /\bDROP\s+SCHEMA\s+(?:IF\s+EXISTS\s+)?(?:[^;]*,\s*)?"?public"?(?=\s*(?:,|CASCADE\b|RESTRICT\b|$))/i,
+        description: "Attempts to remove the platform-required public schema.",
+        recommendation: "Drop project objects individually through an approved contract migration; do not remove public.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_migration_ledger_access",
+        level: "HIGH",
+        pattern: MIGRATION_LEDGER_MODIFICATION_PATTERN,
+        description: "Attempts to modify or bypass the platform-owned migration ledger.",
+        recommendation: "Let push_migrations record the ledger entry after the migration transaction commits.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_migration_ledger_privileges",
+        level: "HIGH",
+        pattern: MIGRATION_LEDGER_PRIVILEGE_PATTERN,
+        description: "Attempts to change privileges on the platform-owned migration ledger.",
+        recommendation: "Keep migration ledger privileges under platform control.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_migration_ledger_recorder_access",
+        level: "HIGH",
+        pattern: /"?supabase_migrations"?\s*\.\s*"?record_schema_migration"?\s*\(/i,
+        description: "Attempts to call or redefine the platform migration ledger recorder.",
+        recommendation: "Let push_migrations invoke the recorder with a platform-issued lease.",
+        blocksTransactionalPush: true,
+    },
+];
+
+function matchingRisks(
+    rawStatement: string,
+    maskedStatement: string,
+    rules: readonly RiskRule[],
+): MigrationRiskItem[] {
+    return rules
+        .filter((rule) => rule.pattern.test(maskedStatement) && !rule.excludePattern?.test(maskedStatement))
+        .map((rule) => ({
+            level: rule.level,
+            type: rule.type,
+            description: rule.description,
+            recommendation: rule.recommendation,
+            statementSnippet: rawStatement.replace(/\s+/g, " ").slice(0, 100),
+            ...(rule.blocksTransactionalPush ? { blocksTransactionalPush: true as const } : {}),
+        }));
+}
+
+function defaultExpression(maskedClause: string): string {
+    const defaultIndex = maskedClause.search(/\bDEFAULT\b/i);
+    if (defaultIndex === -1) return "";
+    const expression = maskedClause.slice(defaultIndex + "DEFAULT".length);
+    const constraintIndex = expression.search(/\b(?:COLLATE|CONSTRAINT|GENERATED|NOT\s+NULL|NULL|PRIMARY\s+KEY|REFERENCES|UNIQUE|CHECK)\b/i);
+    return (constraintIndex === -1 ? expression : expression.slice(0, constraintIndex)).trim();
+}
+
+function defaultMayRequireTableRewrite(maskedClause: string): boolean {
+    const expression = defaultExpression(maskedClause);
+    if (!expression) return false;
+    const withoutKnownStableCalls = expression.replace(
+        /\b(?:now|transaction_timestamp|statement_timestamp)\s*\(\s*\)/gi,
+        "",
+    );
+    return /\b[A-Za-z_][A-Za-z0-9_$]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_$]*)?\s*\(/.test(withoutKnownStableCalls);
+}
+
+function addedNotNullColumnRisks(rawStatement: string): MigrationRiskItem[] {
+    const maskedStatement = maskSqlNoise(rawStatement);
+    if (!/^\s*ALTER\s+TABLE\b/i.test(maskedStatement)) return [];
+    const risks: MigrationRiskItem[] = [];
+    for (const clause of splitTopLevelClauses(rawStatement)) {
+        const maskedClause = maskSqlNoise(clause);
+        if (!/\bADD\s+(?!CONSTRAINT\b)(?:COLUMN\s+)?[a-z0-9_"]+\s+[\s\S]*\bNOT\s+NULL\b/i.test(maskedClause)) continue;
+        const snippet = clause.replace(/\s+/g, " ").slice(0, 100);
+        if (!/\bDEFAULT\b/i.test(maskedClause)) {
+            risks.push({
+                level: "MEDIUM",
+                type: "locking_not_null_no_default",
+                description: "Adding a NOT NULL column without a DEFAULT value requires full table verification and fails when existing rows cannot satisfy it.",
+                recommendation: "Follow Expand-Contract: add the column as nullable, backfill it, then add NOT NULL separately.",
+                statementSnippet: snippet,
+            });
+        } else if (defaultMayRequireTableRewrite(maskedClause)) {
+            risks.push({
+                level: "MEDIUM",
+                type: "locking_not_null_expression_default",
+                description: "Adding a NOT NULL column with a function-based DEFAULT may rewrite the table while holding a strong lock.",
+                recommendation: "Use a literal or known stable default, or add the column nullable and backfill in a separate step.",
+                statementSnippet: snippet,
+            });
+        }
+    }
+    return risks;
+}
+
 export function analyzeMigrationSql(sql: string): MigrationRiskItem[] {
-    const statements = splitSqlStatements(sql);
+    const statements = migrationExecutionStatements(splitSqlStatements(sql));
+    if (statements.length === 0) {
+        return [{
+            level: "HIGH",
+            type: "unsupported_empty_migration",
+            description: "Contains no executable SQL after removing the platform-managed outer transaction wrapper.",
+            recommendation: "Remove the empty migration file or add the intended project-scoped SQL statement.",
+            statementSnippet: sql.replace(/\s+/g, " ").slice(0, 100),
+            blocksTransactionalPush: true,
+        }];
+    }
     const risks: MigrationRiskItem[] = [];
 
     for (const rawStatement of statements) {
         const masked = maskSqlNoise(rawStatement);
-        for (const rule of RISK_RULES) {
-            if (rule.pattern.test(masked) && !rule.excludePattern?.test(masked)) {
-                const snippet = rawStatement.replace(/\s+/g, " ").slice(0, 100);
-                risks.push({
-                    level: rule.level,
-                    type: rule.type,
-                    description: rule.description,
-                    recommendation: rule.recommendation,
-                    statementSnippet: snippet,
-                    ...(rule.blocksTransactionalPush ? { blocksTransactionalPush: true as const } : {}),
-                });
-            }
-        }
+        const policyMasked = maskSqlPolicyNoise(rawStatement);
+        risks.push(...matchingRisks(rawStatement, masked, RISK_RULES));
+        risks.push(...addedNotNullColumnRisks(rawStatement));
+        risks.push(...matchingRisks(rawStatement, masked, PUSH_BLOCKER_RULES));
+        risks.push(...matchingRisks(rawStatement, policyMasked, QUOTED_FUNCTION_BLOCKER_RULES));
+        risks.push(...matchingRisks(rawStatement, policyMasked, MIGRATION_LEDGER_BLOCKER_RULES));
     }
 
     return risks;

--- a/packages/cli/src/shared/tools/migration-risk.ts
+++ b/packages/cli/src/shared/tools/migration-risk.ts
@@ -1,0 +1,441 @@
+/**
+ * Migration Risk Analysis Engine
+ *
+ * Statically analyzes SQL migrations for Expand-Contract violations, destructive DDL,
+ * and lock-heavy operations (e.g. non-concurrent index creation, non-null additions without default).
+ */
+
+export type MigrationRiskLevel = "HIGH" | "MEDIUM" | "LOW";
+
+export interface MigrationRiskItem {
+    level: MigrationRiskLevel;
+    type: string;
+    description: string;
+    recommendation: string;
+    statementSnippet?: string;
+    blocksTransactionalPush?: true;
+}
+
+export interface MigrationFileRisk {
+    file: string;
+    overallRisk: MigrationRiskLevel;
+    risks: MigrationRiskItem[];
+}
+
+export interface MigrationRiskAnalysis {
+    overallRisk: MigrationRiskLevel;
+    highRiskCount: number;
+    mediumRiskCount: number;
+    lowRiskCount: number;
+    transactionalPushBlockerCount: number;
+    files: MigrationFileRisk[];
+}
+
+function startsEscapeString(sql: string, quoteIndex: number): boolean {
+    const prefixIndex = quoteIndex - 1;
+    const prefix = sql[prefixIndex] || "";
+    const preceding = sql[prefixIndex - 1] || "";
+    return /[eE]/.test(prefix) && !/[A-Za-z0-9_$]/.test(preceding);
+}
+
+function dollarQuoteTagAt(sql: string, index: number): string {
+    const previous = sql[index - 1] || "";
+    if (/[A-Za-z0-9_$]/.test(previous)) return "";
+    return sql.slice(index).match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/)?.[0] || "";
+}
+
+function maskSingleQuotedString(sql: string, start: number): { masked: string; end: number } {
+    const usesBackslashEscapes = startsEscapeString(sql, start);
+    let end = start + 1;
+    while (end < sql.length) {
+        if (usesBackslashEscapes && sql[end] === "\\" && sql[end + 1]) {
+            end += 2;
+        } else if (sql[end] === "'" && sql[end + 1] === "'") {
+            end += 2;
+        } else if (sql[end] === "'") {
+            end += 1;
+            break;
+        } else {
+            end += 1;
+        }
+    }
+    return { masked: " ".repeat(end - start), end };
+}
+
+function maskDoubleQuotedIdentifier(sql: string, start: number): { masked: string; end: number } {
+    let end = start + 1;
+    while (end < sql.length) {
+        if (sql[end] === '"' && sql[end + 1] === '"') {
+            end += 2;
+        } else if (sql[end] === '"') {
+            end += 1;
+            break;
+        } else {
+            end += 1;
+        }
+    }
+    return { masked: `"${"_".repeat(Math.max(0, end - start - 2))}"`, end };
+}
+
+function lineCommentEnd(sql: string, start: number): number {
+    const end = sql.indexOf("\n", start + 2);
+    return end === -1 ? sql.length : end;
+}
+
+function blockCommentEnd(sql: string, start: number): number {
+    let depth = 1;
+    let cursor = start + 2;
+    while (cursor < sql.length && depth > 0) {
+        if (sql.startsWith("/*", cursor)) {
+            depth++;
+            cursor += 2;
+        } else if (sql.startsWith("*/", cursor)) {
+            depth--;
+            cursor += 2;
+        } else {
+            cursor++;
+        }
+    }
+    return cursor;
+}
+
+function maskDollarQuotedString(sql: string, start: number): { masked: string; end: number } | null {
+    const tag = dollarQuoteTagAt(sql, start);
+    if (!tag) return null;
+    const closingTag = sql.indexOf(tag, start + tag.length);
+    if (closingTag === -1) return null;
+    const end = closingTag + tag.length;
+    return { masked: " ".repeat(end - start), end };
+}
+
+function maskSqlSpan(sql: string, start: number): { masked: string; end: number } | null {
+    if (sql.startsWith("--", start)) {
+        const end = lineCommentEnd(sql, start);
+        return { masked: " ".repeat(end - start), end };
+    }
+    if (sql.startsWith("/*", start)) {
+        const end = blockCommentEnd(sql, start);
+        return { masked: " ".repeat(end - start), end };
+    }
+    if (sql[start] === "'") return maskSingleQuotedString(sql, start);
+    if (sql[start] === '"') return maskDoubleQuotedIdentifier(sql, start);
+    if (sql[start] === "$") return maskDollarQuotedString(sql, start);
+    return null;
+}
+
+export function maskSqlNoise(sql: string): string {
+    let masked = "";
+    let cursor = 0;
+    while (cursor < sql.length) {
+        const protectedSpan = maskSqlSpan(sql, cursor);
+        if (protectedSpan) {
+            masked += protectedSpan.masked;
+            cursor = protectedSpan.end;
+        } else {
+            masked += sql[cursor];
+            cursor++;
+        }
+    }
+    return masked;
+}
+
+export function splitSqlStatements(sql: string): string[] {
+    const masked = maskSqlNoise(sql);
+    const statements: string[] = [];
+    let lastIndex = 0;
+    let cursor = 0;
+
+    while (cursor < masked.length) {
+        if (masked[cursor] === ";") {
+            const rawStatement = sql.slice(lastIndex, cursor).trim();
+            if (rawStatement.length > 0) {
+                statements.push(rawStatement);
+            }
+            lastIndex = cursor + 1;
+        }
+        cursor++;
+    }
+
+    const trailing = sql.slice(lastIndex).trim();
+    if (trailing.length > 0) {
+        statements.push(trailing);
+    }
+
+    return statements;
+}
+
+interface RiskRule {
+    type: string;
+    level: MigrationRiskLevel;
+    pattern: RegExp;
+    excludePattern?: RegExp;
+    description: string;
+    recommendation: string;
+    blocksTransactionalPush?: true;
+}
+
+const RISK_RULES: readonly RiskRule[] = [
+    {
+        type: "destructive_drop_database",
+        level: "HIGH",
+        pattern: /\bDROP\s+DATABASE\b/i,
+        description: "Drops entire database.",
+        recommendation: "Never drop databases in automated migrations.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "destructive_drop_schema",
+        level: "HIGH",
+        pattern: /\bDROP\s+SCHEMA\b/i,
+        description: "Drops entire schema and all contained objects.",
+        recommendation: "Ensure schema objects are migrated or deleted in contract phase before dropping schema.",
+    },
+    {
+        type: "destructive_drop_table",
+        level: "HIGH",
+        pattern: /\bDROP\s+TABLE\b/i,
+        description: "Drops table and permanently removes data. Old code referencing this table will break.",
+        recommendation: "Follow Expand-Contract: Deprecate usage in application code before dropping table.",
+    },
+    {
+        type: "destructive_drop_column",
+        level: "HIGH",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bDROP\s+(?:COLUMN\s+)?[a-z0-9_"]+/i,
+        excludePattern: /\bDROP\s+CONSTRAINT\b|\bALTER\s+(?:COLUMN\s+)?[a-z0-9_"]+\s+DROP\s+(?:DEFAULT|NOT\s+NULL|IDENTITY|EXPRESSION)\b/i,
+        description: "Drops column. Running application code selecting or writing this column will fail immediately.",
+        recommendation: "Follow Expand-Contract: Ensure all running application versions have stopped accessing this column before dropping.",
+    },
+    {
+        type: "destructive_drop_constraint",
+        level: "HIGH",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bDROP\s+CONSTRAINT\b/i,
+        description: "Drops constraint. Dropping constraints may break uniqueness guarantees or foreign key integrity.",
+        recommendation: "Ensure application code and data no longer depend on this constraint before dropping.",
+    },
+    {
+        type: "destructive_drop_view",
+        level: "HIGH",
+        pattern: /\bDROP\s+(?:MATERIALIZED\s+)?VIEW\b/i,
+        description: "Drops view or materialized view. Queries or API endpoints selecting from this view will break.",
+        recommendation: "Follow Expand-Contract: Deprecate client/API dependencies on this view before dropping.",
+    },
+    {
+        type: "destructive_truncate",
+        level: "HIGH",
+        pattern: /\bTRUNCATE(?:\s+TABLE)?\b/i,
+        description: "Truncates table data permanently.",
+        recommendation: "Avoid TRUNCATE in schema migrations; use soft deletes or targeted archived data cleanup.",
+    },
+    {
+        type: "destructive_rename_column",
+        level: "HIGH",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bRENAME\s+(?:COLUMN\s+)?[a-z0-9_"]+\s+TO\b/i,
+        description: "Renames column. Causes immediate downtime for old application code expecting the previous column name.",
+        recommendation: "Follow Expand-Contract: Add new column, dual-write, backfill, migrate reads, then drop old column.",
+    },
+    {
+        type: "destructive_rename_table",
+        level: "HIGH",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bRENAME\s+TO\b/i,
+        description: "Renames table. Causes immediate downtime for application code.",
+        recommendation: "Follow Expand-Contract: Create a view or alias table during transition.",
+    },
+    {
+        type: "manual_review_do_block",
+        level: "HIGH",
+        pattern: /^\s*DO\b/i,
+        description: "DO blocks can execute dynamic or procedural DDL that static rules cannot inspect safely.",
+        recommendation: "Move schema changes into explicit SQL statements; push_migrations rejects opaque procedural SQL.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "locking_vacuum_full",
+        level: "HIGH",
+        pattern: /^\s*VACUUM\b/i,
+        description: "VACUUM cannot run inside the transactional migration executor; VACUUM FULL also locks and rewrites the table.",
+        recommendation: "Run VACUUM through an approved non-transactional maintenance path; do not place it in push_migrations files.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "locking_cluster",
+        level: "HIGH",
+        pattern: /^\s*CLUSTER\s+[a-z0-9_"]+/i,
+        description: "CLUSTER acquires an ACCESS EXCLUSIVE lock on the table, blocking all concurrent access.",
+        recommendation: "Avoid CLUSTER on active production tables; consider pg_repack for online table reordering.",
+    },
+    {
+        type: "unsupported_concurrent_index_migration",
+        level: "HIGH",
+        pattern: /\b(?:CREATE\s+(?:UNIQUE\s+)?INDEX|DROP\s+INDEX|REINDEX\b[\s\S]*?)\s+CONCURRENTLY\b/i,
+        description: "CONCURRENTLY operations cannot run inside the transactional migration executor.",
+        recommendation: "Run the concurrent index operation through an approved non-transactional maintenance path, outside push_migrations.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "unsupported_non_transactional_migration",
+        level: "HIGH",
+        pattern: /\b(?:CREATE\s+DATABASE|CREATE\s+TABLESPACE|DROP\s+TABLESPACE|CREATE\s+SUBSCRIPTION|DROP\s+SUBSCRIPTION|ALTER\s+SYSTEM)\b/i,
+        description: "This operation cannot run inside the transactional, project-scoped migration executor.",
+        recommendation: "Use an approved platform maintenance path instead of push_migrations.",
+        blocksTransactionalPush: true,
+    },
+    {
+        type: "locking_non_concurrent_index",
+        level: "MEDIUM",
+        pattern: /\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+(?!CONCURRENTLY\b)/i,
+        description: "Creates index non-concurrently. Acquires SHARE lock and blocks concurrent writes (INSERT/UPDATE/DELETE) on the table until index build completes.",
+        recommendation: "For a live large table, use the approved non-transactional maintenance path for CREATE INDEX CONCURRENTLY; push_migrations cannot execute it.",
+    },
+    {
+        type: "locking_drop_index_non_concurrent",
+        level: "MEDIUM",
+        pattern: /\bDROP\s+INDEX\s+(?!CONCURRENTLY\b)/i,
+        description: "Drops index non-concurrently. Acquires ACCESS EXCLUSIVE lock on the table, blocking concurrent reads and writes.",
+        recommendation: "For a live table, use the approved non-transactional maintenance path for DROP INDEX CONCURRENTLY; push_migrations cannot execute it.",
+    },
+    {
+        type: "locking_not_null_no_default",
+        level: "MEDIUM",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bADD\s+(?!CONSTRAINT\b)(?:COLUMN\s+)?[a-z0-9_"]+\s+[^;]+?\bNOT\s+NULL\b(?!\s+DEFAULT\b)/i,
+        excludePattern: /\bADD\s+(?:COLUMN\s+)?[a-z0-9_"]+\s+[\s\S]*?\bDEFAULT\b[\s\S]*?\bNOT\s+NULL\b/i,
+        description: "Adding a NOT NULL column without a DEFAULT value requires full table verification and will fail if the table contains existing rows.",
+        recommendation: "Follow Expand-Contract: Add column as nullable or with a DEFAULT value first, backfill data if necessary, then add NOT NULL constraint.",
+    },
+    {
+        type: "locking_alter_column_set_not_null",
+        level: "MEDIUM",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bALTER\s+(?:COLUMN\s+)?[a-z0-9_"]+\s+SET\s+NOT\s+NULL\b/i,
+        description: "Setting NOT NULL on an existing column scans the entire table under an ACCESS EXCLUSIVE lock unless a validated CHECK constraint already exists.",
+        recommendation: "Add a CHECK (column IS NOT NULL) NOT VALID constraint first, validate it with VALIDATE CONSTRAINT, then SET NOT NULL.",
+    },
+    {
+        type: "locking_alter_type",
+        level: "MEDIUM",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bALTER\s+(?:COLUMN\s+)?[a-z0-9_"]+\s+(?:SET\s+DATA\s+)?TYPE\b/i,
+        description: "Altering column type acquires ACCESS EXCLUSIVE lock and may trigger a full table rewrite.",
+        recommendation: "Add a new column with the target type, dual-write, copy data, switch reads, then drop old column.",
+    },
+    {
+        type: "locking_unique_constraint_without_index",
+        level: "MEDIUM",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bADD\s+CONSTRAINT\b[\s\S]*?\bUNIQUE\b/i,
+        excludePattern: /\bUNIQUE\s+USING\s+INDEX\b/i,
+        description: "Adding UNIQUE constraint directly acquires an ACCESS EXCLUSIVE lock while creating the index.",
+        recommendation: "Build the unique index through the approved non-transactional maintenance path, then attach it with ADD CONSTRAINT ... UNIQUE USING INDEX in a migration.",
+    },
+    {
+        type: "locking_foreign_key_without_not_valid",
+        level: "MEDIUM",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bADD\s+CONSTRAINT\b[\s\S]*?\bFOREIGN\s+KEY\b(?!\s*[^;]*?\bNOT\s+VALID\b)/i,
+        description: "Adding a FOREIGN KEY constraint without NOT VALID locks the table for a full scan to validate existing rows.",
+        recommendation: "Add foreign key constraint with 'NOT VALID' first, then run 'ALTER TABLE ... VALIDATE CONSTRAINT' separately.",
+    },
+    {
+        type: "locking_check_constraint_without_not_valid",
+        level: "MEDIUM",
+        pattern: /\bALTER\s+TABLE\b[\s\S]*?\bADD\s+CONSTRAINT\b[\s\S]*?\bCHECK\b(?!\s*[^;]*?\bNOT\s+VALID\b)/i,
+        description: "Adding a CHECK constraint without NOT VALID scans the entire table under an ACCESS EXCLUSIVE lock.",
+        recommendation: "Add constraint with 'NOT VALID' first, then validate with 'ALTER TABLE ... VALIDATE CONSTRAINT'.",
+    },
+];
+
+export function analyzeMigrationSql(sql: string): MigrationRiskItem[] {
+    const statements = splitSqlStatements(sql);
+    const risks: MigrationRiskItem[] = [];
+
+    for (const rawStatement of statements) {
+        const masked = maskSqlNoise(rawStatement);
+        for (const rule of RISK_RULES) {
+            if (rule.pattern.test(masked) && !rule.excludePattern?.test(masked)) {
+                const snippet = rawStatement.replace(/\s+/g, " ").slice(0, 100);
+                risks.push({
+                    level: rule.level,
+                    type: rule.type,
+                    description: rule.description,
+                    recommendation: rule.recommendation,
+                    statementSnippet: snippet,
+                    ...(rule.blocksTransactionalPush ? { blocksTransactionalPush: true as const } : {}),
+                });
+            }
+        }
+    }
+
+    return risks;
+}
+
+export function analyzeMigrationFiles(
+    files: Array<{ file: string; sql: string }>,
+): MigrationRiskAnalysis {
+    const fileRisks: MigrationFileRisk[] = [];
+    let highCount = 0;
+    let mediumCount = 0;
+    let lowCount = 0;
+    let transactionalPushBlockerCount = 0;
+
+    for (const { file, sql } of files) {
+        const risks = analyzeMigrationSql(sql);
+        transactionalPushBlockerCount += risks.filter((risk) => risk.blocksTransactionalPush).length;
+        let fileLevel: MigrationRiskLevel = "LOW";
+
+        for (const risk of risks) {
+            if (risk.level === "HIGH") {
+                fileLevel = "HIGH";
+                highCount++;
+            } else if (risk.level === "MEDIUM") {
+                if (fileLevel !== "HIGH") fileLevel = "MEDIUM";
+                mediumCount++;
+            }
+        }
+
+        if (fileLevel === "LOW") {
+            lowCount++;
+        }
+
+        fileRisks.push({
+            file,
+            overallRisk: fileLevel,
+            risks,
+        });
+    }
+
+    let overallRisk: MigrationRiskLevel = "LOW";
+    if (highCount > 0) overallRisk = "HIGH";
+    else if (mediumCount > 0) overallRisk = "MEDIUM";
+
+    return {
+        overallRisk,
+        highRiskCount: highCount,
+        mediumRiskCount: mediumCount,
+        lowRiskCount: lowCount,
+        transactionalPushBlockerCount,
+        files: fileRisks,
+    };
+}
+
+export function formatMigrationRiskReport(analysis: MigrationRiskAnalysis): string {
+    const lines: string[] = [];
+    const riskIcon = analysis.overallRisk === "HIGH" ? "🔴" : analysis.overallRisk === "MEDIUM" ? "🟡" : "🟢";
+    lines.push(`${riskIcon} Migration Risk Level: ${analysis.overallRisk}`);
+    lines.push(`Total issues detected: ${analysis.highRiskCount} High (Destructive), ${analysis.mediumRiskCount} Medium (Locking/Constraint)`);
+
+    const filesWithRisks = analysis.files.filter((fileRisk) => fileRisk.risks.length > 0);
+    if (!filesWithRisks.length) {
+        lines.push("", "✅ All migrations follow safe, non-blocking Expand-Contract patterns.");
+        return lines.join("\n");
+    }
+
+    lines.push("", "Detailed Findings:");
+    for (const { file, overallRisk, risks } of filesWithRisks) {
+        const fileIcon = overallRisk === "HIGH" ? "🔴" : "🟡";
+        lines.push(`  ${fileIcon} ${file} [${overallRisk}]`);
+        for (const risk of risks) {
+            lines.push(`    - [${risk.level}] ${risk.description}`);
+            if (risk.statementSnippet) {
+                lines.push(`      Snippet: ${risk.statementSnippet}`);
+            }
+            lines.push(`      💡 Suggestion: ${risk.recommendation}`);
+        }
+    }
+
+    return lines.join("\n");
+}

--- a/packages/cli/src/shared/tools/release-control-response.ts
+++ b/packages/cli/src/shared/tools/release-control-response.ts
@@ -21,7 +21,7 @@ export function releaseControlSuccess(
 
 export function releaseControlFailure(
     operation: string,
-    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "MUTATION_NOT_SUCCEEDED" | "OUTCOME_UNKNOWN",
+    code: "HTTP_ERROR" | "INVALID_RESPONSE" | "MUTATION_NOT_SUCCEEDED" | "OUTCOME_UNKNOWN" | "PARTIAL_SUCCESS",
     httpStatus: number | null,
     safeState: Record<string, unknown> = {},
 ): ReleaseControlToolResponse {

--- a/packages/management-api/src/db/sql-policy.ts
+++ b/packages/management-api/src/db/sql-policy.ts
@@ -6,26 +6,68 @@ interface SqlPattern {
   pattern: RegExp;
 }
 
+const TRANSACTION_CONTROL_PATTERN = /(?:^|;)\s*(?:BEGIN|START\s+TRANSACTION|COMMIT|END|ROLLBACK|ABORT|SAVEPOINT|RELEASE\s+SAVEPOINT|PREPARE\s+TRANSACTION)\b/i;
+
+const MIGRATION_LEDGER_RELATION = String.raw`(?:(?:"?(?:supabase_migrations|public)"?)\s*\.\s*)?"?schema_migrations"?`;
+const MIGRATION_LEDGER_RELATION_END = String.raw`(?=$|[\s,;(*])`;
+const MIGRATION_LEDGER_DDL_OR_MAINTENANCE_PREFIX = String.raw`(?:CREATE\s+(?:UNIQUE\s+)?INDEX\b[^;]*\bON\s+(?:ONLY\s+)?|CREATE\s+(?:CONSTRAINT\s+)?TRIGGER\b[^;]*\bON\s+|DROP\s+TRIGGER\s+(?:IF\s+EXISTS\s+)?[^;]*\bON\s+|CREATE\s+RULE\b[^;]*\bTO\s+|DROP\s+RULE\s+(?:IF\s+EXISTS\s+)?[^;]*\bON\s+|CREATE\s+POLICY\b[^;]*\bON\s+|ALTER\s+POLICY\b[^;]*\bON\s+|DROP\s+POLICY\s+(?:IF\s+EXISTS\s+)?[^;]*\bON\s+|COMMENT\s+ON\s+TABLE\s+|SECURITY\s+LABEL(?:\s+FOR\s+[^;\s]+)?\s+ON\s+TABLE\s+|REINDEX(?:\s*\([^;)]*\))?\s+TABLE\s+(?:CONCURRENTLY\s+)?|CLUSTER(?:\s+VERBOSE)?\s+|VACUUM(?:\s*\([^;)]*\))?(?:\s+(?:FULL|FREEZE|VERBOSE|ANALYZE))*\s+|ANALYZE(?:\s*\([^;)]*\))?(?:\s+VERBOSE)?\s+)`;
+const MIGRATION_LEDGER_MODIFICATION_PATTERN = new RegExp(
+  String.raw`\b(?:(?:CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?|INSERT\s+INTO\s+(?:ONLY\s+)?|UPDATE\s+(?:ONLY\s+)?|DELETE\s+FROM\s+(?:ONLY\s+)?|MERGE\s+INTO\s+(?:ONLY\s+)?|ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?|COPY\s+)`
+  + MIGRATION_LEDGER_RELATION
+  + MIGRATION_LEDGER_RELATION_END
+  + String.raw`|(?:DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?|TRUNCATE(?:\s+TABLE)?\s+|LOCK\s+(?:TABLE\s+)?)[^;]*`
+  + MIGRATION_LEDGER_RELATION
+  + MIGRATION_LEDGER_RELATION_END
+  + String.raw`|`
+  + MIGRATION_LEDGER_DDL_OR_MAINTENANCE_PREFIX
+  + MIGRATION_LEDGER_RELATION
+  + MIGRATION_LEDGER_RELATION_END
+  + String.raw`)`,
+  "i",
+);
+const NON_TABLE_PRIVILEGE_TARGET = String.raw`(?:ALL\s+(?:FUNCTIONS|PROCEDURES|ROUTINES|SEQUENCES)\s+IN\s+SCHEMA|DATABASE|DOMAIN|FOREIGN\s+DATA\s+WRAPPER|FOREIGN\s+SERVER|FUNCTION|LANGUAGE|LARGE\s+OBJECT|PARAMETER|PROCEDURE|ROUTINE|SCHEMA|SEQUENCE|TABLESPACE|TYPE)\b`;
+const MIGRATION_LEDGER_PRIVILEGE_PATTERN = new RegExp(
+  String.raw`\b(?:GRANT|REVOKE)\b[^;]*\bON\s+(?:(?:TABLE\s+)?(?!`
+  + NON_TABLE_PRIVILEGE_TARGET
+  + String.raw`)(?:(?!\b(?:TO|FROM)\b)[^;])*?`
+  + MIGRATION_LEDGER_RELATION
+  + MIGRATION_LEDGER_RELATION_END
+  + String.raw`(?=[^;]*\b(?:TO|FROM)\b)|ALL\s+TABLES\s+IN\s+SCHEMA\s+"?(?:supabase_migrations|public)"?(?=$|[\s,;]))`,
+  "i",
+);
+
 const PRIVILEGED_MIGRATION_PATTERNS: readonly SqlPattern[] = [
   { label: "database management", pattern: /\b(?:CREATE|ALTER|DROP)\s+DATABASE\b/i },
-  { label: "public schema removal", pattern: /\bDROP\s+SCHEMA\s+(?:IF\s+EXISTS\s+)?public\b/i },
+  { label: "public schema removal", pattern: /\bDROP\s+SCHEMA\s+(?:IF\s+EXISTS\s+)?(?:[^;]*,\s*)?"?public"?(?=\s*(?:,|CASCADE\b|RESTRICT\b|$))/i },
+  { label: "public schema alteration", pattern: /\bALTER\s+SCHEMA\s+"?public"?\b/i },
+  { label: "migration ledger schema management", pattern: /\b(?:(?:CREATE\s+SCHEMA\s+(?:IF\s+NOT\s+EXISTS\s+)?|ALTER\s+SCHEMA\s+)"?supabase_migrations"?|DROP\s+SCHEMA\s+(?:IF\s+EXISTS\s+)?(?:[^;]*,\s*)?"?supabase_migrations"?(?=\s*(?:,|CASCADE\b|RESTRICT\b|$)))/i },
+  { label: "unicode escaped identifier", pattern: /\bU&"/i },
   { label: "cluster ownership management", pattern: /\b(?:DROP|REASSIGN)\s+OWNED\b/i },
   { label: "cluster role management", pattern: /\b(?:CREATE|ALTER|DROP)\s+(?:ROLE|USER)\b/i },
   { label: "server configuration", pattern: /\bALTER\s+SYSTEM\b/i },
+  { label: "server copy access", pattern: /(?:^|;)\s*COPY\b/i },
   { label: "server-side program execution", pattern: /\bCOPY\b[\s\S]*?\b(?:TO|FROM)\s+PROGRAM\b/i },
   { label: "server file access", pattern: /\b(?:lo_import|lo_export|pg_read_file|pg_write_file|pg_ls_dir|pg_stat_file|pg_execute_server_program)\s*\(/i },
+  { label: "server file access", pattern: /"(?:lo_import|lo_export|pg_read_file|pg_write_file|pg_ls_dir|pg_stat_file|pg_execute_server_program)"\s*\(/ },
   { label: "backend control", pattern: /\bpg_(?:terminate|cancel)_backend\s*\(/i },
+  { label: "backend control", pattern: /"pg_(?:terminate|cancel)_backend"\s*\(/ },
   { label: "external database access", pattern: /\bdblink(?:_[a-z_]+)?\s*\(|\b(?:CREATE|ALTER|DROP)\s+(?:SERVER|USER\s+MAPPING|FOREIGN\s+DATA\s+WRAPPER)\b|\bIMPORT\s+FOREIGN\s+SCHEMA\b|\bCREATE\s+FOREIGN\s+TABLE\b/i },
+  { label: "external database access", pattern: /"dblink(?:_[a-z_]+)?"\s*\(/ },
   { label: "tablespace management", pattern: /\b(?:CREATE|DROP)\s+TABLESPACE\b/i },
   { label: "subscription management", pattern: /\b(?:CREATE|ALTER|DROP)\s+SUBSCRIPTION\b/i },
   { label: "dynamic library loading", pattern: /\bLOAD\b/i },
   { label: "opaque procedural SQL", pattern: /(?:^|;)\s*DO\b/i },
-  { label: "transaction control", pattern: /(?:^|;)\s*(?:BEGIN|START\s+TRANSACTION|COMMIT|END|ROLLBACK|SAVEPOINT|RELEASE\s+SAVEPOINT|PREPARE\s+TRANSACTION)\b/i },
+  { label: "transaction control", pattern: TRANSACTION_CONTROL_PATTERN },
   { label: "session role control", pattern: /\b(?:SET\s+(?:(?:LOCAL|SESSION)\s+)?(?:ROLE|SESSION\s+AUTHORIZATION)|RESET\s+(?:ROLE|SESSION\s+AUTHORIZATION)|DISCARD\s+ALL)\b/i },
   { label: "advisory lock control", pattern: /\bpg_(?:try_)?advisory_(?:xact_)?(?:lock|unlock)(?:_shared|_all)?\s*\(/i },
+  { label: "advisory lock control", pattern: /"pg_(?:try_)?advisory_(?:xact_)?(?:lock|unlock)(?:_shared|_all)?"\s*\(/ },
   {
     label: "migration ledger modification",
-    pattern: /\b(?:CREATE\s+TABLE|INSERT\s+INTO|UPDATE|DELETE\s+FROM|MERGE\s+INTO|TRUNCATE(?:\s+TABLE)?|ALTER\s+TABLE|DROP\s+TABLE|COPY|GRANT[\s\S]*?\bON\s+(?:TABLE\s+)?|REVOKE[\s\S]*?\bON\s+(?:TABLE\s+)?)\s+(?:(?:"?(?:supabase_migrations|public)"?)\s*\.\s*)?"?schema_migrations"?\b/i,
+    pattern: MIGRATION_LEDGER_MODIFICATION_PATTERN,
+  },
+  {
+    label: "migration ledger privilege modification",
+    pattern: MIGRATION_LEDGER_PRIVILEGE_PATTERN,
   },
   {
     label: "migration ledger recorder access",
@@ -161,9 +203,13 @@ export function isDangerousSQL(sqlQuery: string): boolean {
     || PRIVILEGED_MIGRATION_PATTERNS.some(({ pattern }) => pattern.test(normalized));
 }
 
+export function sqlContainsTransactionControl(sqlQuery: string): boolean {
+  return TRANSACTION_CONTROL_PATTERN.test(normalizeSqlForPolicy(sqlQuery));
+}
+
 export function projectMigrationSqlViolations(statements: readonly string[]): string[] {
   const normalized = statements.map(normalizeSqlForPolicy).join("; ");
-  return PRIVILEGED_MIGRATION_PATTERNS
+  return [...new Set(PRIVILEGED_MIGRATION_PATTERNS
     .filter(({ pattern }) => pattern.test(normalized))
-    .map(({ label }) => label);
+    .map(({ label }) => label))];
 }

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -29,6 +29,10 @@ import {
   BranchReplacementJournalActiveError,
   branchReplacementJournal,
 } from "../services/branch-replacement-journal";
+import {
+  notifyPostgrestSchemaReload,
+  tryNotifyPostgrestSchemaReload,
+} from "../services/database-schema-notify";
 import { logger } from "../utils/logger";
 
 export type MigrationBody =
@@ -135,6 +139,37 @@ export function sqlRouteResponse(result: Awaited<ReturnType<typeof db.executeQue
     ...(result.statements ? { statements: result.statements } : {}),
     durationMs: result.durationMs,
   };
+}
+
+const POSTGREST_SCHEMA_COMMANDS = new Set([
+  "ALTER",
+  "CALL",
+  "COMMENT",
+  "CREATE",
+  "DO",
+  "DROP",
+  "GRANT",
+  "IMPORT",
+  "REVOKE",
+  "SECURITY",
+]);
+
+export function sqlExecutionMayChangeSchema(
+  executionResult: Awaited<ReturnType<typeof db.executeQuery>>,
+  sqlQuery?: string,
+): boolean {
+  const resultCommands = [
+    executionResult.command,
+    ...(executionResult.statements || []).map((statement) => statement.command),
+  ];
+  if (resultCommands.some((command) => POSTGREST_SCHEMA_COMMANDS.has(command.toUpperCase()))) {
+    return true;
+  }
+  if (!sqlQuery) return false;
+  return splitSqlStatements(sqlQuery).some((statement) => {
+    const command = normalizeSqlForPolicy(statement).match(/^([A-Z]+)/i)?.[1]?.toUpperCase();
+    return command ? POSTGREST_SCHEMA_COMMANDS.has(command) : false;
+  });
 }
 
 export function sqlRouteErrorResponse(error: unknown) {
@@ -869,6 +904,7 @@ async function executeMigrationTransaction(
             `Migration ${input.name} conflicts with an existing version, name, or checksum`,
           );
         }
+        await notifyPostgrestSchemaReload(tx, input.projectRef);
         return true;
       }
       const unsupported = detectUnsupportedMigrationOperations(execution.statements);
@@ -883,6 +919,7 @@ async function executeMigrationTransaction(
       const issuedLease = await issueMigrationLedgerLease(adminDb, input.version, execution.checksum);
       leaseHolder.current = issuedLease;
       await insertMigrationLedger(tx, input, execution.checksum, issuedLease.token);
+      await notifyPostgrestSchemaReload(tx, input.projectRef);
       return false;
     });
   } finally {
@@ -1376,7 +1413,10 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
 
             try {
                 const sql = buildCreateMaterializedViewSql(body);
-                await projectDb.unsafe(sql);
+                await projectDb.begin(async (transaction) => {
+                    await transaction.unsafe(sql);
+                    await notifyPostgrestSchemaReload(transaction, params.ref);
+                });
                 set.status = 201;
                 return {
                     schema: body.schema || "public",
@@ -1468,11 +1508,14 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
             }
 
             try {
-                await projectDb.unsafe(buildDropMaterializedViewSql({
-                    schema: params.schema,
-                    name: params.name,
-                    ifExists: query.if_exists === "true" || query.if_exists === "1",
-                }));
+                await projectDb.begin(async (transaction) => {
+                    await transaction.unsafe(buildDropMaterializedViewSql({
+                        schema: params.schema,
+                        name: params.name,
+                        ifExists: query.if_exists === "true" || query.if_exists === "1",
+                    }));
+                    await notifyPostgrestSchemaReload(transaction, params.ref);
+                });
                 return { schema: params.schema, name: params.name, deleted: true };
             } catch (error: unknown) {
                 set.status = 400;
@@ -1656,13 +1699,19 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
                   if (mode === "migration") {
                     await branchReplacementJournal.assertInactive([params.ref]);
                   }
-                  return db.executeQuery(credentials.db_name, sqlQuery, {
+                  const result = await db.executeQuery(credentials.db_name, sqlQuery, {
                     mode,
                     ...(typeof body.query_id === "string"
                       ? { projectRef: params.ref, queryId: body.query_id }
                       : {}),
                     ...(useRoleConnection ? { username: credentials.db_user, password: credentials.db_password } : {}),
                   });
+                  const adminMayChangeSchema = mode === "admin" && sqlExecutionMayChangeSchema(result, sqlQuery);
+                  if (mode === "migration" || adminMayChangeSchema) {
+                    const adminDb = getProjectDb(credentials.db_name);
+                    await tryNotifyPostgrestSchemaReload(adminDb, params.ref);
+                  }
+                  return result;
                 };
                 const result = mode === "migration"
                   ? await withProjectMigrationLocks({ projectRefs: [params.ref] }, execute)

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -2,7 +2,7 @@ import { Elysia, t } from "elysia";
 import type { SQL, TransactionSQL } from "bun";
 import { projectService } from "../services";
 import { db, getProjectDb, getProjectRoleDb, removeProjectDbCache, resolveAuthenticatorName, resolveDbName, sql as metaSql, type SqlExecutionMode } from "../db";
-import { isDangerousSQL, normalizeSqlForPolicy } from "../db/sql-policy";
+import { isDangerousSQL, normalizeSqlForPolicy, sqlContainsTransactionControl } from "../db/sql-policy";
 import { cancelActiveSqlQuery } from "../db/sql-query-registry";
 import { splitSqlStatements, stripOuterTransactionStatements } from "../db/sql-statements";
 import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
@@ -129,7 +129,16 @@ function normalizeMigrationName(rawName: unknown, fallback: string): string {
   return name;
 }
 
-export function sqlRouteResponse(result: Awaited<ReturnType<typeof db.executeQuery>>) {
+type SchemaReloadStatus = "notified" | "notification_failed";
+type SchemaReloadMetadata = {
+  schemaReloadStatus?: SchemaReloadStatus;
+  ddlCommitted?: true;
+};
+
+export function sqlRouteResponse(
+  result: Awaited<ReturnType<typeof db.executeQuery>>,
+  metadata: SchemaReloadMetadata = {},
+) {
   return {
     rows: result.rows,
     rowCount: result.rowCount,
@@ -138,6 +147,12 @@ export function sqlRouteResponse(result: Awaited<ReturnType<typeof db.executeQue
     notices: result.notices || [],
     ...(result.statements ? { statements: result.statements } : {}),
     durationMs: result.durationMs,
+    ...(metadata.schemaReloadStatus ? {
+      schema_reload: {
+        status: metadata.schemaReloadStatus,
+        ...(metadata.ddlCommitted ? { ddl_committed: true as const } : {}),
+      },
+    } : {}),
   };
 }
 
@@ -153,6 +168,12 @@ const POSTGREST_SCHEMA_COMMANDS = new Set([
   "REVOKE",
   "SECURITY",
 ]);
+const INDIRECT_SCHEMA_EXECUTION_PATTERN = /(?:^|;)\s*(?:CALL|DO)\b/i;
+
+function adminSqlCanConfirmDdlCommitted(sqlQuery: string): boolean {
+  return !sqlContainsTransactionControl(sqlQuery)
+    && !INDIRECT_SCHEMA_EXECUTION_PATTERN.test(normalizeSqlForPolicy(sqlQuery));
+}
 
 export function sqlExecutionMayChangeSchema(
   executionResult: Awaited<ReturnType<typeof db.executeQuery>>,
@@ -1707,16 +1728,26 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
                     ...(useRoleConnection ? { username: credentials.db_user, password: credentials.db_password } : {}),
                   });
                   const adminMayChangeSchema = mode === "admin" && sqlExecutionMayChangeSchema(result, sqlQuery);
+                  let schemaReloadStatus: SchemaReloadStatus | undefined;
+                  let ddlCommitted: true | undefined;
                   if (mode === "migration" || adminMayChangeSchema) {
                     const adminDb = getProjectDb(credentials.db_name);
-                    await tryNotifyPostgrestSchemaReload(adminDb, params.ref);
+                    schemaReloadStatus = await tryNotifyPostgrestSchemaReload(adminDb, params.ref)
+                      ? "notified"
+                      : "notification_failed";
+                    if (mode === "migration" || adminSqlCanConfirmDdlCommitted(sqlQuery)) {
+                      ddlCommitted = true;
+                    }
                   }
-                  return result;
+                  return { result, schemaReloadStatus, ddlCommitted };
                 };
-                const result = mode === "migration"
+                const execution = mode === "migration"
                   ? await withProjectMigrationLocks({ projectRefs: [params.ref] }, execute)
                   : await execute();
-                return sqlRouteResponse(result);
+                return sqlRouteResponse(execution.result, {
+                  schemaReloadStatus: execution.schemaReloadStatus,
+                  ddlCommitted: execution.ddlCommitted,
+                });
             } catch (error: unknown) {
                 if (error instanceof ProjectMigrationLockError) {
                     set.status = error.httpStatus;

--- a/packages/management-api/src/routes/extensions.ts
+++ b/packages/management-api/src/routes/extensions.ts
@@ -1,11 +1,15 @@
 import { Elysia, t, status } from "elysia";
 import { extensionService } from '../services/extension.service';
-import { requireAdminAuth } from '../middleware/auth';
+import { requireAdminAuth, requireProjectOrAdminAuth } from '../middleware/auth';
 import { logger } from "../utils/logger";
 
 const ErrorResponse = t.Object({ message: t.String() });
 
 export const extensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/extensions" })
+    .onBeforeHandle(async ({ params, request }) => {
+        const authError = await requireProjectOrAdminAuth(request, params.ref);
+        if (authError) return status(authError.status, authError.body);
+    })
     .onError(({ code, error, set }) => {
         logger.error(`[Extensions] Unhandled error [${code}]:`, error);
         set.status = 500;
@@ -76,6 +80,10 @@ export const extensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/extension
     });
 
 export const databaseExtensionRoutes = new Elysia({ prefix: "/v1/projects/:ref/database/extensions" })
+    .onBeforeHandle(async ({ params, request }) => {
+        const authError = await requireProjectOrAdminAuth(request, params.ref);
+        if (authError) return status(authError.status, authError.body);
+    })
     .onError(({ code, error, set }) => {
         logger.error(`[DatabaseExtensions] Unhandled error [${code}]:`, error);
         set.status = 500;

--- a/packages/management-api/src/services/branch.service.ts
+++ b/packages/management-api/src/services/branch.service.ts
@@ -50,6 +50,7 @@ import {
   issueMigrationLedgerLease,
   releaseMigrationLedgerLease,
 } from "./migration-ledger-lease";
+import { notifyPostgrestSchemaReload } from "./database-schema-notify";
 
 type ProjectSql = ReturnType<typeof getProjectDb>;
 type ReservedProjectSql = Awaited<ReturnType<ProjectSql["reserve"]>>;
@@ -652,7 +653,7 @@ class BranchService {
       for (const entry of entries) {
         this.assertPromotionSqlSupported(entry, applied);
         try {
-          await this.applyMigrationEntry(connection, adminDb, entry);
+          await this.applyMigrationEntry(connection, adminDb, parentRef, entry);
           applied.push(summarizeMigrationLedgerEntry(entry));
         } catch (error: unknown) {
           this.throwPromotionApplyError(error, entry, applied);
@@ -683,6 +684,7 @@ class BranchService {
   private async applyMigrationEntry(
     connection: ReservedProjectSql,
     adminDb: ProjectSql,
+    parentRef: string,
     entry: MigrationLedgerEntry,
   ): Promise<void> {
     const leaseHolder: { current?: Awaited<ReturnType<typeof issueMigrationLedgerLease>> } = {};
@@ -713,6 +715,7 @@ class BranchService {
             ${issuedLease.token}
           )
         `;
+        await notifyPostgrestSchemaReload(tx, parentRef);
       });
     } finally {
       const lease = leaseHolder.current;

--- a/packages/management-api/src/services/database-schema-notify.ts
+++ b/packages/management-api/src/services/database-schema-notify.ts
@@ -1,0 +1,30 @@
+import { resolvePgrstChannel, type getProjectDb } from "../db";
+import { logger } from "../utils/logger";
+
+type ProjectSql = ReturnType<typeof getProjectDb>;
+type ReservedProjectSql = Awaited<ReturnType<ProjectSql["reserve"]>>;
+
+export async function notifyPostgrestSchemaReload(
+  dbInstance: ProjectSql | ReservedProjectSql,
+  projectRef: string,
+): Promise<void> {
+  const channel = resolvePgrstChannel(projectRef);
+  await dbInstance`
+    SELECT pg_notify(${channel}, 'reload schema'), pg_notify('pgrst', 'reload schema')
+  `;
+}
+
+export async function tryNotifyPostgrestSchemaReload(
+  dbInstance: ProjectSql | ReservedProjectSql,
+  projectRef: string,
+): Promise<boolean> {
+  try {
+    await notifyPostgrestSchemaReload(dbInstance, projectRef);
+    return true;
+  } catch (error: unknown) {
+    logger.warn(`[database] failed to send schema reload notification for ${projectRef}`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/packages/management-api/src/services/extension.service.ts
+++ b/packages/management-api/src/services/extension.service.ts
@@ -1,5 +1,6 @@
-import { getProjectDb, resolveDbName } from "../db";
 import { $ } from "bun";
+import { getProjectDb, resolveDbName } from "../db";
+import { notifyPostgrestSchemaReload } from "./database-schema-notify";
 
 const IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
 type SystemExtensionInfo = { name: string; version: string; status: string; description: string };
@@ -96,25 +97,28 @@ export class ExtensionService {
         const safeSchema = schema ? validatePgIdentifier(schema, 'schema') : null;
         const dbName = await resolveDbName(projectRef);
         const db = getProjectDb(dbName);
-        if (safeExt === "pg_graphql") {
-            const rows = await db`
-                SELECT installed_version
-                FROM pg_available_extensions
-                WHERE name = 'pg_graphql'
-            `;
-            const isInstalled = rows.some((row: { installed_version?: string | null }) => row.installed_version);
-            if (!isInstalled) {
-                await db.unsafe(`
-                    DROP FUNCTION IF EXISTS graphql_public.graphql(text, text, jsonb, jsonb);
-                    DROP FUNCTION IF EXISTS graphql_public.graphql(text, text, jsonb);
-                `);
+        await db.begin(async (transaction) => {
+            if (safeExt === "pg_graphql") {
+                const installedRows = await transaction`
+                    SELECT installed_version
+                    FROM pg_available_extensions
+                    WHERE name = 'pg_graphql'
+                `;
+                const isInstalled = installedRows.some((row: { installed_version?: string | null }) => row.installed_version);
+                if (!isInstalled) {
+                    await transaction.unsafe(`
+                        DROP FUNCTION IF EXISTS graphql_public.graphql(text, text, jsonb, jsonb);
+                        DROP FUNCTION IF EXISTS graphql_public.graphql(text, text, jsonb);
+                    `);
+                }
             }
-        }
-        let sql = `CREATE EXTENSION IF NOT EXISTS "${safeExt}"`;
-        if (safeSchema) sql += ` SCHEMA "${safeSchema}"`;
-        if (version) sql += ` VERSION '${version.replace(/'/g, "''")}'`;
-        sql += ` CASCADE`;
-        await db.unsafe(sql);
+            let sql = `CREATE EXTENSION IF NOT EXISTS "${safeExt}"`;
+            if (safeSchema) sql += ` SCHEMA "${safeSchema}"`;
+            if (version) sql += ` VERSION '${version.replace(/'/g, "''")}'`;
+            sql += ` CASCADE`;
+            await transaction.unsafe(sql);
+            await notifyPostgrestSchemaReload(transaction, projectRef);
+        });
 
         const rows = await db`
             SELECT name, default_version, installed_version, comment,
@@ -128,7 +132,10 @@ export class ExtensionService {
         const safeExt = validatePgIdentifier(extension, 'extension');
         const dbName = await resolveDbName(projectRef);
         const db = getProjectDb(dbName);
-        await db.unsafe(`DROP EXTENSION IF EXISTS "${safeExt}" CASCADE`);
+        await db.begin(async (transaction) => {
+            await transaction.unsafe(`DROP EXTENSION IF EXISTS "${safeExt}" CASCADE`);
+            await notifyPostgrestSchemaReload(transaction, projectRef);
+        });
 
         const rows = await db`
             SELECT name, default_version, installed_version, comment,

--- a/packages/management-api/tests/unit/branch.service.test.ts
+++ b/packages/management-api/tests/unit/branch.service.test.ts
@@ -204,6 +204,46 @@ describe("branchService", () => {
     }
   });
 
+  test("queues schema reload inside each promoted migration transaction", async () => {
+    const entry = createMigrationLedgerEntry({
+      version: "20260819091000",
+      name: "create_reload_probe",
+      statements: ["CREATE TABLE reload_probe(id bigint primary key)"],
+    });
+    const transactionCalls: Array<{ text: string; values: unknown[] }> = [];
+    const transaction = Object.assign(
+      (strings: TemplateStringsArray, ...values: unknown[]) => {
+        transactionCalls.push({ text: strings.join("?"), values });
+        return Promise.resolve([]);
+      },
+      {
+        array: (values: readonly string[]) => values,
+        unsafe: async () => [],
+      },
+    );
+    const connection = {
+      begin: async (operation: (tx: typeof transaction) => Promise<void>) => operation(transaction),
+    };
+    const adminDb = ((strings: TemplateStringsArray) => Promise.resolve([])) as any;
+    const service = branchService as unknown as {
+      applyMigrationEntry(
+        connection: typeof connection,
+        adminDb: typeof adminDb,
+        parentRef: string,
+        entry: typeof entry,
+      ): Promise<void>;
+    };
+
+    await service.applyMigrationEntry(connection, adminDb, "parent", entry);
+
+    const recordIndex = transactionCalls.findIndex(({ text }) => text.includes("record_schema_migration"));
+    const notifyIndex = transactionCalls.findIndex(({ text, values }) =>
+      text.includes("pg_notify") && values.includes("pgrst_parent")
+    );
+    expect(recordIndex).toBeGreaterThan(-1);
+    expect(notifyIndex).toBeGreaterThan(recordIndex);
+  });
+
   test("promoteBranch rejects a stale reviewed plan before applying SQL", async () => {
     const entry = createMigrationLedgerEntry({
       version: "202607180001",

--- a/packages/management-api/tests/unit/database-migration-baseline.routes.test.ts
+++ b/packages/management-api/tests/unit/database-migration-baseline.routes.test.ts
@@ -179,6 +179,21 @@ describe("database migration baseline route", () => {
     expect(transaction.mock.invocationCallOrder.at(-1)).toBeGreaterThan(transaction.mock.invocationCallOrder[0]!);
   });
 
+  test("rejects ABORT transaction control before executing or recording a migration", async () => {
+    const response = await migrationRequest({
+      version: "20260819090001",
+      name: "20260819090001_abort_transaction",
+      sql: "CREATE TABLE public.abort_probe(id bigint); ABORT AND CHAIN; SELECT 1",
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("unsupported_migration_sql");
+    expect(transaction.unsafe).not.toHaveBeenCalled();
+    expect(issueMigrationLedgerLease).not.toHaveBeenCalled();
+    expect(transactionCalls.some(({ text }) => text.includes("record_schema_migration"))).toBe(false);
+  });
+
   test("retries schema reload for an already-applied migration", async () => {
     existingMigrationRows = [{
       version: "20260819090000",

--- a/packages/management-api/tests/unit/database-migration-baseline.routes.test.ts
+++ b/packages/management-api/tests/unit/database-migration-baseline.routes.test.ts
@@ -23,7 +23,10 @@ const transaction = Object.assign(
     }
     return Promise.resolve([]);
   }),
-  { array: (values: unknown[]) => values },
+  {
+    array: (values: unknown[]) => values,
+    unsafe: mock(async () => []),
+  },
 );
 const connection = {
   begin: mock(async (operation: (sql: typeof transaction) => Promise<unknown>) => operation(transaction)),
@@ -111,6 +114,14 @@ function baselineRequest(migrations: Array<{ version: string; name: string }>) {
   }));
 }
 
+function migrationRequest(migration: { version: string; name: string; sql: string }) {
+  return app.handle(new Request("http://localhost/v1/projects/proj_1/database/migrations", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(migration),
+  }));
+}
+
 describe("database migration baseline route", () => {
   beforeEach(() => {
     resetEnsuredMigrationTablesForTests();
@@ -118,6 +129,7 @@ describe("database migration baseline route", () => {
     existingMigrationRows = [];
     transactionFailure = null;
     transaction.mockClear();
+    transaction.unsafe.mockClear();
     connection.begin.mockClear();
     connection.unsafe.mockClear();
     connection.release.mockClear();
@@ -150,6 +162,43 @@ describe("database migration baseline route", () => {
     expect(recordCalls[0]?.values[1]).toEqual(["baseline:20260729090000_create_orders"]);
     expect(issueMigrationLedgerLease).toHaveBeenCalledTimes(2);
     expect(releaseMigrationLedgerLease).toHaveBeenCalledTimes(2);
+  });
+
+  test("records schema reload notification in the migration transaction", async () => {
+    const response = await migrationRequest({
+      version: "20260819090000",
+      name: "20260819090000_create_items",
+      sql: "CREATE TABLE public.items(id bigint)",
+    });
+
+    expect(response.status).toBe(200);
+    expect(transactionCalls.some(({ text }) => text.includes("record_schema_migration"))).toBe(true);
+    expect(transactionCalls.some(({ text, values }) =>
+      text.includes("pg_notify") && values.includes("pgrst_proj_1")
+    )).toBe(true);
+    expect(transaction.mock.invocationCallOrder.at(-1)).toBeGreaterThan(transaction.mock.invocationCallOrder[0]!);
+  });
+
+  test("retries schema reload for an already-applied migration", async () => {
+    existingMigrationRows = [{
+      version: "20260819090000",
+      name: "20260819090000_create_items",
+      statements: ["CREATE TABLE public.items(id bigint)"],
+    }];
+
+    const response = await migrationRequest({
+      version: "20260819090000",
+      name: "20260819090000_create_items",
+      sql: "CREATE TABLE public.items(id bigint)",
+    });
+    const body = await response.json() as Record<string, unknown>;
+
+    expect({ status: response.status, body }).toMatchObject({
+      status: 409,
+      body: { message: "Migration already applied", code: "409" },
+    });
+    expect(issueMigrationLedgerLease).not.toHaveBeenCalled();
+    expect(transactionCalls.some(({ text }) => text.includes("pg_notify"))).toBe(true);
   });
 
   test("is idempotent for an identical baseline marker", async () => {

--- a/packages/management-api/tests/unit/database-routes.test.ts
+++ b/packages/management-api/tests/unit/database-routes.test.ts
@@ -305,6 +305,22 @@ describe("database route helpers", () => {
     });
   });
 
+  test("sqlRouteResponse exposes schema reload completion without obscuring committed DDL", () => {
+    const response = sqlRouteResponse({
+      rows: [],
+      rowCount: 0,
+      command: "ALTER",
+      fields: [],
+      notices: [],
+      durationMs: 12,
+    }, { schemaReloadStatus: "notification_failed", ddlCommitted: true });
+
+    expect(response.schema_reload).toEqual({
+      status: "notification_failed",
+      ddl_committed: true,
+    });
+  });
+
   test("sqlRouteErrorResponse preserves SQL error code and duration", () => {
     expect(sqlRouteErrorResponse(Object.assign(new Error("Query cancelled"), {
       code: "QUERY_CANCELLED",

--- a/packages/management-api/tests/unit/database-routes.test.ts
+++ b/packages/management-api/tests/unit/database-routes.test.ts
@@ -18,10 +18,15 @@ import {
   normalizeMigrationVersion,
   resetEnsuredMigrationTablesForTests,
   resolveMigrationStatements,
+  sqlExecutionMayChangeSchema,
   sqlRouteErrorResponse,
   sqlRouteResponse,
 } from "../../src/routes/database";
 import { projectMigrationSqlViolations } from "../../src/db/sql-policy";
+import {
+  notifyPostgrestSchemaReload,
+  tryNotifyPostgrestSchemaReload,
+} from "../../src/services/database-schema-notify";
 import { calculateMigrationChecksum } from "../../src/services/migration-promotion";
 
 describe("database route helpers", () => {
@@ -314,6 +319,29 @@ describe("database route helpers", () => {
     });
   });
 
+  test("detects SQL execution results that may change the PostgREST schema", () => {
+    const result = {
+      rows: [],
+      rowCount: 0,
+      command: "SELECT",
+      fields: [],
+      notices: [],
+      durationMs: 1,
+    };
+    expect(sqlExecutionMayChangeSchema(result)).toBe(false);
+    expect(sqlExecutionMayChangeSchema({ ...result, command: "CREATE" })).toBe(true);
+    expect(sqlExecutionMayChangeSchema({
+      ...result,
+      command: "BATCH",
+      statements: [{ index: 1, command: "ALTER", rowCount: 0, durationMs: 1 }],
+    })).toBe(true);
+    expect(sqlExecutionMayChangeSchema(
+      result,
+      "CREATE TABLE public.items(id bigint); SELECT 1",
+    )).toBe(true);
+    expect(sqlExecutionMayChangeSchema(result, "CALL admin.refresh_api_schema()")).toBe(true);
+  });
+
   test("builds safe materialized view SQL", () => {
     expect(
       buildCreateMaterializedViewSql({
@@ -438,5 +466,31 @@ describe("database route helpers", () => {
       expect(contents).toContain("ALTER TABLE public.tasks REPLICA IDENTITY FULL");
       expect(contents).toContain("ALTER PUBLICATION supabase_realtime ADD TABLE public.tasks");
     }
+  });
+  test("notifyPostgrestSchemaReload sends NOTIFY to project and pgrst channels", async () => {
+    const executed: Array<{ query: string; values: unknown[] }> = [];
+    const projectDb = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+      executed.push({ query: strings.join("?"), values });
+      return Promise.resolve([]);
+    }) as any;
+
+    await notifyPostgrestSchemaReload(projectDb, "test_proj");
+
+    expect(executed).toHaveLength(1);
+    expect(executed[0].query).toContain("SELECT pg_notify(?");
+    expect(executed[0].values).toContain("pgrst_test_proj");
+    expect(executed[0].query).toContain("pg_notify('pgrst', 'reload schema')");
+  });
+
+  test("notifyPostgrestSchemaReload propagates failures for transactional callers", async () => {
+    const projectDb = (() => Promise.reject(new Error("connection lost"))) as any;
+
+    await expect(notifyPostgrestSchemaReload(projectDb, "test_proj")).rejects.toThrow("connection lost");
+  });
+
+  test("tryNotifyPostgrestSchemaReload keeps post-commit reload attempts non-fatal", async () => {
+    const projectDb = (() => Promise.reject(new Error("connection lost"))) as any;
+
+    await expect(tryNotifyPostgrestSchemaReload(projectDb, "test_proj")).resolves.toBe(false);
   });
 });

--- a/packages/management-api/tests/unit/database-sql.routes.test.ts
+++ b/packages/management-api/tests/unit/database-sql.routes.test.ts
@@ -39,6 +39,7 @@ const rlsUnsafe = mock(async (query: string) => {
   return Array.from({ length: 501 }, (_, index) => ({ id: index + 1 }));
 });
 const schemaReloadQueries: Array<{ text: string; values: unknown[] }> = [];
+let schemaReloadShouldFail = false;
 const rlsConnection = Object.assign(
   ((..._args: unknown[]) => Promise.resolve([])) as unknown as Record<string, unknown>,
   { unsafe: rlsUnsafe, release: mock(() => undefined) },
@@ -46,7 +47,10 @@ const rlsConnection = Object.assign(
 const rlsDb = Object.assign(
   ((strings: TemplateStringsArray, ...values: unknown[]) => {
     const sql = strings.join(" ");
-    if (sql.includes("pg_notify")) schemaReloadQueries.push({ text: sql, values });
+    if (sql.includes("pg_notify")) {
+      schemaReloadQueries.push({ text: sql, values });
+      if (schemaReloadShouldFail) return Promise.reject(new Error("schema reload unavailable"));
+    }
     if (sql.includes("FROM pg_extension")) {
       return Promise.resolve([{ schema_name: "extensions", has_view: true }]);
     }
@@ -127,6 +131,7 @@ describe("database SQL routes", () => {
     rlsUnsafe.mockClear();
     rlsConnection.release.mockClear();
     schemaReloadQueries.length = 0;
+    schemaReloadShouldFail = false;
     rlsDb.begin.mockClear();
     rlsDb.reserve.mockClear();
     getProjectDb.mockClear();
@@ -230,6 +235,9 @@ describe("database SQL routes", () => {
     });
     expect(getProjectDb).toHaveBeenCalledWith("shared_tenant_db");
     expect(schemaReloadQueries.some(({ values }) => values.includes("pgrst_project-a"))).toBe(true);
+    expect(await response.json()).toMatchObject({
+      schema_reload: { status: "notified", ddl_committed: true },
+    });
   });
 
   test("sends a schema reload after admin-mode DDL", async () => {
@@ -267,6 +275,65 @@ describe("database SQL routes", () => {
 
     expect(response.status).toBe(200);
     expect(schemaReloadQueries.some(({ values }) => values.includes("pgrst_project-a"))).toBe(true);
+  });
+
+  test("does not claim committed DDL for admin SQL with caller-controlled transactions", async () => {
+    const response = await request("project-a", "/sql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sql: "BEGIN; CREATE TABLE public.items(id bigint); ROLLBACK;",
+        mode: "admin",
+        admin: true,
+      }),
+    });
+    const payload = await response.json() as { schema_reload?: Record<string, unknown> };
+
+    expect(response.status).toBe(200);
+    expect(payload.schema_reload).toMatchObject({ status: "notified" });
+    expect(payload.schema_reload).not.toHaveProperty("ddl_committed");
+  });
+
+  test.each([
+    "CALL public.rollback_schema_change()",
+    "DO $$ BEGIN EXECUTE 'CREATE TABLE public.items(id bigint)'; ROLLBACK; END $$",
+  ])("does not claim committed DDL for indirect admin SQL: %s", async (sql) => {
+    executeQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: sql.startsWith("CALL") ? "CALL" : "DO",
+      fields: [],
+      notices: [],
+      durationMs: 1,
+    });
+
+    const response = await request("project-a", "/sql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sql, mode: "admin", admin: true }),
+    });
+    const payload = await response.json() as { schema_reload?: Record<string, unknown> };
+
+    expect(response.status).toBe(200);
+    expect(payload.schema_reload).toMatchObject({ status: "notified" });
+    expect(payload.schema_reload).not.toHaveProperty("ddl_committed");
+  });
+
+  test("returns an explicit partial-success receipt when schema reload notification fails", async () => {
+    schemaReloadShouldFail = true;
+
+    const response = await request("project-a", "/sql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sql: "ALTER TABLE public.items ADD COLUMN note text", mode: "migration" }),
+    });
+    const payload = await response.json() as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({
+      schema_reload: { status: "notification_failed", ddl_committed: true },
+    });
+    expect(executeQuery).toHaveBeenCalledTimes(1);
   });
 
   test("creates and drops materialized views with transactional schema reloads", async () => {

--- a/packages/management-api/tests/unit/database-sql.routes.test.ts
+++ b/packages/management-api/tests/unit/database-sql.routes.test.ts
@@ -24,6 +24,7 @@ const managementDb = mock((strings: TemplateStringsArray) => {
   return Promise.resolve([]);
 });
 const getProject = mock(async (ref: string) => ({ ref }));
+const requireAdminAuth = mock(async () => undefined);
 const requireProjectOrAdminAuth = mock(async () => undefined as undefined | {
   status: number;
   body: { error: string };
@@ -37,13 +38,15 @@ const rlsUnsafe = mock(async (query: string) => {
   }
   return Array.from({ length: 501 }, (_, index) => ({ id: index + 1 }));
 });
+const schemaReloadQueries: Array<{ text: string; values: unknown[] }> = [];
 const rlsConnection = Object.assign(
   ((..._args: unknown[]) => Promise.resolve([])) as unknown as Record<string, unknown>,
   { unsafe: rlsUnsafe, release: mock(() => undefined) },
 );
 const rlsDb = Object.assign(
-  ((strings: TemplateStringsArray) => {
+  ((strings: TemplateStringsArray, ...values: unknown[]) => {
     const sql = strings.join(" ");
+    if (sql.includes("pg_notify")) schemaReloadQueries.push({ text: sql, values });
     if (sql.includes("FROM pg_extension")) {
       return Promise.resolve([{ schema_name: "extensions", has_view: true }]);
     }
@@ -55,10 +58,16 @@ const rlsDb = Object.assign(
     }
     return Promise.resolve([]);
   }) as unknown as Record<string, unknown>,
-  { reserve: mock(async () => rlsConnection), unsafe: rlsUnsafe },
+  {
+    reserve: mock(async () => rlsConnection),
+    unsafe: rlsUnsafe,
+    begin: mock(async (operation: (transaction: typeof rlsDb) => Promise<unknown>) => operation(rlsDb)),
+  },
 );
 const getProjectDb = mock(() => rlsDb);
 const getProjectRoleDb = mock(() => rlsDb);
+const withProjectMigrationLocks = mock(async (_scope: unknown, operation: () => Promise<unknown>) => operation());
+const assertInactive = mock(async () => undefined);
 
 const actualDb = await import("../../src/db");
 mock.module("../../src/db", () => ({
@@ -69,8 +78,18 @@ mock.module("../../src/db", () => ({
   getProjectRoleDb,
 }));
 mock.module("../../src/services", () => ({ projectService: { getProject } }));
+const actualLock = await import("../../src/services/migration-lock");
+mock.module("../../src/services/migration-lock", () => ({
+  ...actualLock,
+  withProjectMigrationLocks,
+}));
+const actualJournal = await import("../../src/services/branch-replacement-journal");
+mock.module("../../src/services/branch-replacement-journal", () => ({
+  ...actualJournal,
+  branchReplacementJournal: { assertInactive },
+}));
 mock.module("../../src/middleware/auth", () => ({
-  requireAdminAuth: mock(async () => undefined),
+  requireAdminAuth,
   requireProjectOrAdminAuth,
 }));
 mock.module("../../src/utils/logger", () => ({
@@ -107,12 +126,18 @@ describe("database SQL routes", () => {
     managementDb.mockClear();
     rlsUnsafe.mockClear();
     rlsConnection.release.mockClear();
+    schemaReloadQueries.length = 0;
+    rlsDb.begin.mockClear();
     rlsDb.reserve.mockClear();
     getProjectDb.mockClear();
     getProjectRoleDb.mockClear();
     getProject.mockClear();
     requireProjectOrAdminAuth.mockReset();
     requireProjectOrAdminAuth.mockResolvedValue(undefined);
+    requireAdminAuth.mockReset();
+    requireAdminAuth.mockResolvedValue(undefined);
+    withProjectMigrationLocks.mockClear();
+    assertInactive.mockClear();
   });
 
   test("authenticates SQL execution before project lookup", async () => {
@@ -188,6 +213,85 @@ describe("database SQL routes", () => {
         password: "test-password",
       }],
     ]);
+  });
+
+  test("sends a schema reload after migration-mode SQL", async () => {
+    const response = await request("project-a", "/sql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sql: "CREATE TABLE public.items(id bigint)", mode: "migration" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeQuery).toHaveBeenCalledWith("shared_tenant_db", "CREATE TABLE public.items(id bigint)", {
+      mode: "migration",
+      username: "tenant_user",
+      password: "test-password",
+    });
+    expect(getProjectDb).toHaveBeenCalledWith("shared_tenant_db");
+    expect(schemaReloadQueries.some(({ values }) => values.includes("pgrst_project-a"))).toBe(true);
+  });
+
+  test("sends a schema reload after admin-mode DDL", async () => {
+    executeQuery.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+      command: "ALTER",
+      fields: [],
+      notices: [],
+      durationMs: 1,
+    });
+
+    const response = await request("project-a", "/sql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sql: "ALTER TABLE public.items ADD COLUMN name text", mode: "admin", admin: true }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(requireAdminAuth).toHaveBeenCalledTimes(1);
+    expect(getProjectDb).toHaveBeenCalledWith("shared_tenant_db");
+    expect(schemaReloadQueries.some(({ values }) => values.includes("pgrst_project-a"))).toBe(true);
+  });
+
+  test("detects admin DDL from the submitted SQL when the driver reports the final command", async () => {
+    const response = await request("project-a", "/sql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sql: "CREATE TABLE public.items(id bigint); SELECT 1",
+        mode: "admin",
+        admin: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(schemaReloadQueries.some(({ values }) => values.includes("pgrst_project-a"))).toBe(true);
+  });
+
+  test("creates and drops materialized views with transactional schema reloads", async () => {
+    const createResponse = await request("project-a", "/materialized-views", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        schema: "public",
+        name: "orders_daily",
+        definition: "SELECT current_date AS day",
+        withData: false,
+      }),
+    });
+    const dropResponse = await request(
+      "project-a",
+      "/materialized-views/public/orders_daily?if_exists=true",
+      { method: "DELETE" },
+    );
+
+    expect(createResponse.status).toBe(201);
+    expect(dropResponse.status).toBe(200);
+    expect(rlsDb.begin).toHaveBeenCalledTimes(2);
+    expect(rlsUnsafe.mock.calls.some((call) => String(call[0]).startsWith("CREATE MATERIALIZED VIEW"))).toBe(true);
+    expect(rlsUnsafe.mock.calls.some((call) => String(call[0]).startsWith("DROP MATERIALIZED VIEW"))).toBe(true);
+    expect(schemaReloadQueries.filter(({ values }) => values.includes("pgrst_project-a"))).toHaveLength(2);
   });
 
   test("reads query performance through a fixed admin-only statistics query", async () => {

--- a/packages/management-api/tests/unit/extension.service.test.ts
+++ b/packages/management-api/tests/unit/extension.service.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, test, expect, mock } from "bun:test";
 
 const unsafeCalls: string[] = [];
+const taggedCalls: string[] = [];
+let beginCalls = 0;
+let createExtensionFailure: Error | null = null;
 
 const mockDbFn = Object.assign(
     async (strings: TemplateStringsArray, extension?: string) => {
         const sql = strings.join("?");
+        taggedCalls.push(sql);
         if (extension === "pg_graphql" || sql.includes("pg_graphql")) {
             return [{ name: "pg_graphql", default_version: "1.5", installed_version: null, comment: "GraphQL support", is_installed: false }];
         }
@@ -14,14 +18,20 @@ const mockDbFn = Object.assign(
         close: async () => { },
         unsafe: async (sql: string) => {
             unsafeCalls.push(sql);
+            if (createExtensionFailure && sql.startsWith("CREATE EXTENSION")) throw createExtensionFailure;
             return [{ name: "pg_stat_statements", default_version: "1.10", installed_version: "1.10", comment: "track stats", is_installed: true }];
+        },
+        begin: async (operation: (transaction: typeof mockDbFn) => Promise<unknown>) => {
+            beginCalls += 1;
+            return operation(mockDbFn);
         },
     }
 );
 
 mock.module("../../src/db", () => ({
     getProjectDb: () => mockDbFn,
-    resolveDbName: async () => "project_testref123"
+    resolveDbName: async () => "project_testref123",
+    resolvePgrstChannel: (projectRef: string) => `pgrst_${projectRef}`,
 }));
 
 import { extensionService, parsePigExtensionList } from "../../src/services/extension.service";
@@ -29,6 +39,9 @@ import { extensionService, parsePigExtensionList } from "../../src/services/exte
 describe("ExtensionService", () => {
     beforeEach(() => {
         unsafeCalls.length = 0;
+        taggedCalls.length = 0;
+        beginCalls = 0;
+        createExtensionFailure = null;
     });
 
     test("listExtensions should parse DB output", async () => {
@@ -41,6 +54,8 @@ describe("ExtensionService", () => {
         const result = await extensionService.enableExtension("testref123", "postgis");
         expect(result.name).toBe("pg_stat_statements");
         expect(result.is_installed).toBe(true);
+        expect(beginCalls).toBe(1);
+        expect(taggedCalls.some((sql) => sql.includes("pg_notify"))).toBe(true);
     });
 
     test("enableExtension should drop GraphQL fallback before installing pg_graphql", async () => {
@@ -53,6 +68,26 @@ describe("ExtensionService", () => {
             "DROP FUNCTION IF EXISTS graphql_public.graphql(text, text, jsonb)",
         );
         expect(unsafeCalls[1]).toBe('CREATE EXTENSION IF NOT EXISTS "pg_graphql" CASCADE');
+        expect(beginCalls).toBe(1);
+    });
+
+    test("enableExtension rolls GraphQL fallback cleanup and extension creation into one transaction", async () => {
+        createExtensionFailure = new Error("extension install failed");
+
+        await expect(extensionService.enableExtension("testref123", "pg_graphql"))
+            .rejects.toThrow("extension install failed");
+
+        expect(beginCalls).toBe(1);
+        expect(unsafeCalls).toHaveLength(2);
+    });
+
+    test("disableExtension drops and reloads schema in one transaction", async () => {
+        const result = await extensionService.disableExtension("testref123", "postgis");
+
+        expect(result.is_installed).toBe(true);
+        expect(beginCalls).toBe(1);
+        expect(unsafeCalls).toEqual(['DROP EXTENSION IF EXISTS "postgis" CASCADE']);
+        expect(taggedCalls.some((sql) => sql.includes("pg_notify"))).toBe(true);
     });
 
     test("parsePigExtensionList should ignore psql table footers", () => {

--- a/packages/management-api/tests/unit/extensions.routes.test.ts
+++ b/packages/management-api/tests/unit/extensions.routes.test.ts
@@ -1,0 +1,74 @@
+// @supacloud-test-isolate
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const listExtensions = mock(async () => []);
+const enableExtension = mock(async (_ref: string, name: string) => ({ name, is_installed: true }));
+const disableExtension = mock(async (_ref: string, name: string) => ({ name, is_installed: false }));
+const requireProjectOrAdminAuth = mock(async () => undefined as undefined | {
+  status: number;
+  body: { error: string };
+});
+
+mock.module("../../src/services/extension.service", () => ({
+  extensionService: {
+    listExtensions,
+    enableExtension,
+    disableExtension,
+  },
+}));
+mock.module("../../src/middleware/auth", () => ({
+  requireAdminAuth: mock(async () => undefined),
+  requireProjectOrAdminAuth,
+}));
+mock.module("../../src/utils/logger", () => ({
+  logger: {
+    error: mock(() => undefined),
+  },
+}));
+
+const { extensionRoutes, databaseExtensionRoutes } = await import(
+  new URL("../../src/routes/extensions.ts?extensions-routes-test", import.meta.url).href,
+);
+const app = new Elysia().use(extensionRoutes).use(databaseExtensionRoutes);
+
+function request(path: string, init?: RequestInit) {
+  return app.handle(new Request(`http://localhost/v1/projects/proj_1${path}`, init));
+}
+
+describe("extension routes", () => {
+  beforeEach(() => {
+    listExtensions.mockClear();
+    enableExtension.mockClear();
+    disableExtension.mockClear();
+    requireProjectOrAdminAuth.mockReset();
+    requireProjectOrAdminAuth.mockResolvedValue(undefined);
+  });
+
+  test("rejects delegated requests without the required project capability", async () => {
+    requireProjectOrAdminAuth.mockResolvedValueOnce({
+      status: 403,
+      body: { error: "operations.manage required" },
+    });
+
+    const response = await request("/extensions/enable", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ extension: "postgis" }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(enableExtension).not.toHaveBeenCalled();
+  });
+
+  test("checks project capability on both extension route families", async () => {
+    const first = await request("/extensions");
+    const second = await request("/database/extensions");
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(requireProjectOrAdminAuth).toHaveBeenCalledTimes(2);
+    expect(requireProjectOrAdminAuth.mock.calls.map((call) => call[1])).toEqual(["proj_1", "proj_1"]);
+    expect(listExtensions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/management-api/tests/unit/sql-policy.test.ts
+++ b/packages/management-api/tests/unit/sql-policy.test.ts
@@ -9,13 +9,19 @@ describe("project migration SQL policy", () => {
     const statements = [
       "alter role postgres superuser",
       "copy public.accounts to program 'sh'",
+      "copy public.accounts to '/var/lib/postgresql/accounts.csv'",
       "select dblink('host=other', 'select 1')",
+      "select extensions.\"dblink\"('host=other', 'select 1')",
       "commit",
+      "abort and chain",
       "select pg_advisory_unlock_all()",
+      "select pg_catalog.\"pg_advisory_lock\"(42)",
+      "select pg_catalog.\"pg_read_file\"('/etc/passwd')",
     ];
 
     expect(projectMigrationSqlViolations(statements)).toEqual(expect.arrayContaining([
       "cluster role management",
+      "server copy access",
       "server-side program execution",
       "external database access",
       "transaction control",
@@ -30,15 +36,69 @@ describe("project migration SQL policy", () => {
     ])).toEqual([]);
   });
 
+  test("blocks quoted and unquoted public schema removal", () => {
+    expect(projectMigrationSqlViolations(["DROP SCHEMA public CASCADE"]))
+      .toContain("public schema removal");
+    expect(projectMigrationSqlViolations(['DROP SCHEMA "public" CASCADE']))
+      .toContain("public schema removal");
+    expect(projectMigrationSqlViolations(["DROP SCHEMA app_private, public CASCADE"]))
+      .toContain("public schema removal");
+  });
+
+  test("blocks platform schema renames and migration schema management", () => {
+    expect(projectMigrationSqlViolations(['ALTER SCHEMA "public" RENAME TO app_public']))
+      .toContain("public schema alteration");
+    expect(projectMigrationSqlViolations(["DROP SCHEMA IF EXISTS supabase_migrations CASCADE"]))
+      .toContain("migration ledger schema management");
+    expect(projectMigrationSqlViolations(["ALTER SCHEMA app RENAME TO app_v2"]))
+      .not.toContain("public schema alteration");
+    expect(projectMigrationSqlViolations([String.raw`DROP SCHEMA U&"p\0075blic" CASCADE`]))
+      .toContain("unicode escaped identifier");
+  });
+
   test("blocks direct migration ledger writes and recorder calls", () => {
     expect(projectMigrationSqlViolations([
       "insert into supabase_migrations.schema_migrations(version) values ('999')",
       "delete from public.schema_migrations where version = '1'",
+      "drop table if exists supabase_migrations.schema_migrations",
+      "drop table public.disposable, public.schema_migrations cascade",
+      "truncate table public.disposable, only public.schema_migrations",
+      "lock table public.disposable, public.schema_migrations in access exclusive mode",
+      "alter table if exists only public.schema_migrations add column tampered boolean",
+      "create index ledger_version_idx on public.schema_migrations(version)",
+      "create trigger ledger_guard before insert on public.schema_migrations for each row execute function public.audit()",
+      "drop trigger if exists ledger_guard on public.schema_migrations",
+      "create rule ledger_rule as on insert to public.schema_migrations do instead nothing",
+      "drop rule if exists ledger_rule on public.schema_migrations",
+      "create policy ledger_policy on public.schema_migrations using (true)",
+      "comment on table public.schema_migrations is 'tampered'",
+      "security label on table public.schema_migrations is 'tampered'",
+      "reindex table public.schema_migrations",
+      "reindex (verbose) table concurrently public.schema_migrations",
+      "cluster verbose public.schema_migrations",
+      "vacuum (analyze) public.schema_migrations",
+      "analyze public.schema_migrations",
+      "grant select on public.accounts, public.schema_migrations to authenticated",
+      "grant select on all tables in schema supabase_migrations to authenticated",
+      "grant all on all tables in schema public to authenticated",
       "select supabase_migrations.record_schema_migration('2', array['select 1'], 'fake', 'checksum')",
     ])).toEqual(expect.arrayContaining([
       "migration ledger modification",
+      "migration ledger privilege modification",
       "migration ledger recorder access",
     ]));
+    expect(projectMigrationSqlViolations(["grant select on public.accounts to schema_migrations"]))
+      .not.toContain("migration ledger privilege modification");
+    expect(projectMigrationSqlViolations(["grant execute on function public.audit(schema_migrations) to authenticated"]))
+      .not.toContain("migration ledger privilege modification");
+    expect(projectMigrationSqlViolations(["grant usage on schema schema_migrations to authenticated"]))
+      .not.toContain("migration ledger privilege modification");
+    expect(projectMigrationSqlViolations(["grant execute on function public.schema_migrations(text) to authenticated"]))
+      .not.toContain("migration ledger privilege modification");
+    expect(projectMigrationSqlViolations(["create index account_email_idx on public.accounts(email)"]))
+      .not.toContain("migration ledger modification");
+    expect(projectMigrationSqlViolations(["comment on table public.accounts is 'application data'"]))
+      .not.toContain("migration ledger modification");
   });
 
   test("does not treat PL/pgSQL function-body operations as top-level migration control", () => {


### PR DESCRIPTION
## Summary
- add local-only CLI migration linting with SQL/file/directory, strict, medium-risk, and JSON modes
- block unsupported transactional migration SQL before the first remote write and improve destructive/locking risk detection
- preserve historical safe-integer baseline versions while keeping `push_migrations` identities canonical and content-bound
- reload PostgREST schema cache transactionally for migrations, branch promotion, materialized views, and extensions
- return explicit schema reload receipts, including partial success when DDL committed but notification failed
- omit `ddl_committed` for admin SQL whose commit cannot be proven because it uses transaction control, `CALL`, or `DO`
- enforce delegated project authorization on extension routes
- close `ABORT ... AND CHAIN` and quoted privileged-function policy bypasses

## Validation
- `cd packages/cli && bun test && bun run typecheck && bun run build` — 885 passed, 0 failed
- `cd packages/management-api && bun run sql:check && bun run test:unit && bun run typecheck` — passed
- focused Management SQL route regression — 19 passed, 0 failed
- independent adversarial review — no remaining P0-P2; `CALL`, `DO`, explicit transaction, comment-gap, and quoted-function variants fail closed
- `git diff --check`
- clean-code-guard: clean

## Scope
- no production deployment or runtime mutation