### PR TITLE
fix(console): fix overview navigation, dashboard table counts, and function build diagnostics

### DIFF
--- a/packages/management-api/src/routes/project-dashboard.ts
+++ b/packages/management-api/src/routes/project-dashboard.ts
@@ -101,10 +101,10 @@ export const projectDashboardRoutes = new Elysia({ prefix: "/v1/projects" })
               SELECT count(*)::int AS total FROM auth.users
             `),
         safeRead<DashboardRow[]>("table count", [], () => projectDb`
-          SELECT count(*)::int AS cnt FROM pg_stat_user_tables
+          SELECT count(*)::int AS cnt FROM pg_stat_user_tables WHERE schemaname = 'public'
         `),
         safeRead<DashboardRow[]>("index count", [], () => projectDb`
-          SELECT count(*)::int AS cnt FROM pg_stat_user_indexes
+          SELECT count(*)::int AS cnt FROM pg_stat_user_indexes WHERE schemaname = 'public'
         `),
         safeRead<DashboardRow[]>("storage size", [], () => projectDb`
           SELECT pg_size_pretty(coalesce(sum(

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -675,7 +675,7 @@ async function buildFunctionCode(request: BundleFunctionRequest): Promise<string
       .map((logEntry: { message?: string }) => logEntry.message || String(logEntry))
       .join("\n");
     logger.error(`[EdgeFunction] Bun.build() failed:\n${messages}`);
-    throw new Error("Bun.build() failed while bundling the function");
+    throw new Error(messages ? `Bun.build() failed while bundling the function: ${messages}` : "Bun.build() failed while bundling the function");
   }
 
   const artifact = buildResult.outputs.find((output) => output.kind === "entry-point")

--- a/packages/management-api/tests/unit/database-sql.routes.test.ts
+++ b/packages/management-api/tests/unit/database-sql.routes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { Elysia } from "elysia";
 import {
   clearActiveSqlQueriesForTests,
@@ -73,37 +73,28 @@ const getProjectRoleDb = mock(() => rlsDb);
 const withProjectMigrationLocks = mock(async (_scope: unknown, operation: () => Promise<unknown>) => operation());
 const assertInactive = mock(async () => undefined);
 
-const actualDb = await import("../../src/db");
-mock.module("../../src/db", () => ({
-  ...actualDb,
-  db: { ...actualDb.db, executeQuery },
-  sql: managementDb,
-  getProjectDb,
-  getProjectRoleDb,
-}));
-mock.module("../../src/services", () => ({ projectService: { getProject } }));
-const actualLock = await import("../../src/services/migration-lock");
-mock.module("../../src/services/migration-lock", () => ({
-  ...actualLock,
-  withProjectMigrationLocks,
-}));
-const actualJournal = await import("../../src/services/branch-replacement-journal");
-mock.module("../../src/services/branch-replacement-journal", () => ({
-  ...actualJournal,
-  branchReplacementJournal: { assertInactive },
-}));
-mock.module("../../src/middleware/auth", () => ({
-  requireAdminAuth,
-  requireProjectOrAdminAuth,
-}));
-mock.module("../../src/utils/logger", () => ({
-  logger: {
-    debug: mock(() => undefined),
-    error: mock(() => undefined),
-    info: mock(() => undefined),
-    warn: mock(() => undefined),
-  },
-}));
+const dbModule = await import("../../src/db");
+const servicesModule = await import("../../src/services");
+const authModule = await import("../../src/middleware/auth");
+const loggerModule = await import("../../src/utils/logger");
+
+const executeQuerySpy = spyOn(dbModule.db, "executeQuery").mockImplementation(executeQuery as never);
+const sqlSpy = spyOn(dbModule, "sql").mockImplementation(managementDb as never);
+const getProjectDbSpy = spyOn(dbModule, "getProjectDb").mockImplementation(getProjectDb as never);
+const getProjectRoleDbSpy = spyOn(dbModule, "getProjectRoleDb").mockImplementation(getProjectRoleDb as never);
+const getProjectSpy = spyOn(servicesModule.projectService, "getProject").mockImplementation(getProject as never);
+const requireAdminAuthSpy = spyOn(authModule, "requireAdminAuth").mockResolvedValue(undefined as never);
+const requireProjectOrAdminAuthSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const loggerDebugSpy = spyOn(loggerModule.logger, "debug").mockImplementation(() => undefined as never);
+const loggerErrorSpy = spyOn(loggerModule.logger, "error").mockImplementation(() => undefined as never);
+const loggerInfoSpy = spyOn(loggerModule.logger, "info").mockImplementation(() => undefined as never);
+const loggerWarnSpy = spyOn(loggerModule.logger, "warn").mockImplementation(() => undefined as never);
+const lockModule = await import("../../src/services/migration-lock");
+const journalModule = await import("../../src/services/branch-replacement-journal");
+const withProjectMigrationLocksSpy = spyOn(lockModule, "withProjectMigrationLocks").mockImplementation(withProjectMigrationLocks as never);
+const assertInactiveSpy = spyOn(journalModule.branchReplacementJournal, "assertInactive").mockImplementation(assertInactive as never);
 
 const { databaseRoutes } = await import(
   new URL("../../src/routes/database.ts?database-sql-routes-test", import.meta.url).href,
@@ -124,6 +115,21 @@ function executeSql(ref: string, scopedQueryId = queryId) {
 }
 
 describe("database SQL routes", () => {
+  afterAll(() => {
+    executeQuerySpy.mockRestore();
+    sqlSpy.mockRestore();
+    getProjectDbSpy.mockRestore();
+    getProjectRoleDbSpy.mockRestore();
+    getProjectSpy.mockRestore();
+    requireAdminAuthSpy.mockRestore();
+    requireProjectOrAdminAuthSpy.mockRestore();
+    loggerDebugSpy.mockRestore();
+    loggerErrorSpy.mockRestore();
+    loggerInfoSpy.mockRestore();
+    loggerWarnSpy.mockRestore();
+    withProjectMigrationLocksSpy.mockRestore();
+    assertInactiveSpy.mockRestore();
+  });
   beforeEach(() => {
     clearActiveSqlQueriesForTests();
     executeQuery.mockClear();
@@ -139,8 +145,8 @@ describe("database SQL routes", () => {
     getProject.mockClear();
     requireProjectOrAdminAuth.mockReset();
     requireProjectOrAdminAuth.mockResolvedValue(undefined);
-    requireAdminAuth.mockReset();
-    requireAdminAuth.mockResolvedValue(undefined);
+    requireAdminAuthSpy.mockReset();
+    requireAdminAuthSpy.mockResolvedValue(undefined as never);
     withProjectMigrationLocks.mockClear();
     assertInactive.mockClear();
   });
@@ -257,7 +263,7 @@ describe("database SQL routes", () => {
     });
 
     expect(response.status).toBe(200);
-    expect(requireAdminAuth).toHaveBeenCalledTimes(1);
+    expect(requireAdminAuthSpy).toHaveBeenCalledTimes(1);
     expect(getProjectDb).toHaveBeenCalledWith("shared_tenant_db");
     expect(schemaReloadQueries.some(({ values }) => values.includes("pgrst_project-a"))).toBe(true);
   });

--- a/packages/management-api/tests/unit/extension.service.test.ts
+++ b/packages/management-api/tests/unit/extension.service.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, test, expect, mock } from "bun:test";
+import { afterAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as dbModule from "../../src/db";
+import { extensionService, parsePigExtensionList } from "../../src/services/extension.service";
 
 const unsafeCalls: string[] = [];
 const taggedCalls: string[] = [];
@@ -28,15 +30,17 @@ const mockDbFn = Object.assign(
     }
 );
 
-mock.module("../../src/db", () => ({
-    getProjectDb: () => mockDbFn,
-    resolveDbName: async () => "project_testref123",
-    resolvePgrstChannel: (projectRef: string) => `pgrst_${projectRef}`,
-}));
-
-import { extensionService, parsePigExtensionList } from "../../src/services/extension.service";
+const getProjectDbSpy = spyOn(dbModule, "getProjectDb").mockImplementation(() => mockDbFn as never);
+const resolveDbNameSpy = spyOn(dbModule, "resolveDbName").mockResolvedValue("project_testref123");
+const resolvePgrstChannelSpy = spyOn(dbModule, "resolvePgrstChannel").mockImplementation((ref: string) => `pgrst_${ref}`);
 
 describe("ExtensionService", () => {
+    afterAll(() => {
+        getProjectDbSpy.mockRestore();
+        resolveDbNameSpy.mockRestore();
+        resolvePgrstChannelSpy.mockRestore();
+    });
+
     beforeEach(() => {
         unsafeCalls.length = 0;
         taggedCalls.length = 0;

--- a/packages/management-api/tests/unit/project-dashboard.test.ts
+++ b/packages/management-api/tests/unit/project-dashboard.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const dashboardRouteSource = readFileSync(
+  new URL("../../src/routes/project-dashboard.ts", import.meta.url),
+  "utf8"
+);
+const edgeFunctionSource = readFileSync(
+  new URL("../../src/services/edge-function.service.ts", import.meta.url),
+  "utf8"
+);
+
+describe("project dashboard and edge function diagnostics", () => {
+  test("dashboard table and index counters filter for public schema tables", () => {
+    expect(dashboardRouteSource).toContain("SELECT count(*)::int AS cnt FROM pg_stat_user_tables WHERE schemaname = 'public'");
+    expect(dashboardRouteSource).toContain("SELECT count(*)::int AS cnt FROM pg_stat_user_indexes WHERE schemaname = 'public'");
+  });
+
+  test("edge function bundling reports detailed compiler diagnostics on failure", () => {
+    expect(edgeFunctionSource).toContain("messages ? `Bun.build() failed while bundling the function: ${messages}` : \"Bun.build() failed while bundling the function\"");
+  });
+});

--- a/packages/web-console/src/routes/+layout.svelte
+++ b/packages/web-console/src/routes/+layout.svelte
@@ -103,11 +103,12 @@
   let isCoreLoading = $derived(projectsLoading || ($isLoading && !i18nLoadGuardExpired));
 
   // Route Detection
-  let isRawPage = $derived(
-    ($page.url.pathname as string) === "/" ||
-    ($page.url.pathname as string) === "/login" ||
-    ($page.url.pathname as string) === "/register"
+  const isAuthRoute = (path: string) => path === "/login" || path === "/register";
+  let isAuthPage = $derived(isAuthRoute($page.url.pathname as string));
+  let isStandaloneLayout = $derived(
+    ($page.url.pathname as string) === "/" || isAuthRoute($page.url.pathname as string)
   );
+  let isRawPage = $derived(isStandaloneLayout);
   let isPlatformRoute = $derived($page.url.pathname.startsWith("/platform"));
 
   let refFromUrl = $derived(typeof $page.params.ref === "string" ? $page.params.ref : null);
@@ -261,8 +262,8 @@
         i18nLoadGuardExpired = true;
       }, 4000);
 
-      // Skip auth check on raw pages (login/register)
-      if (isRawPage) {
+      // Skip auth check on unauthenticated pages (login/register)
+      if (isAuthRoute(window.location.pathname)) {
         projectsLoading = false;
         clearGuardTimer();
         cleanupLocale();

--- a/packages/web-console/src/routes/layout.test.ts
+++ b/packages/web-console/src/routes/layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const layoutSource = readFileSync(new URL("./+layout.svelte", import.meta.url), "utf8");
 const loginPageSource = readFileSync(new URL("./login/+page.svelte", import.meta.url), "utf8");
@@ -21,6 +21,21 @@ describe("root layout source guards", () => {
     expect(loginPageSource).toContain("window.location.href = CONSOLE_LANDING_PATH");
     expect(loginPageSource).not.toContain('window.location.replace("/")');
     expect(loginPageSource).not.toContain('window.location.href = "/"');
+  });
+
+  test("does not skip authentication check on the overview root route", () => {
+    expect(layoutSource).toContain('const isAuthRoute = (path: string) => path === "/login" || path === "/register";');
+    expect(layoutSource).toContain("if (isAuthRoute(window.location.pathname))");
+    expect(layoutSource).not.toContain("if (isRawPage) {\n        projectsLoading = false;\n        clearGuardTimer();\n        cleanupLocale();\n        return;\n      }");
+  });
+
+  test("general settings route alias exists and forwards to project settings", () => {
+    const generalPageTs = new URL("./project/[ref]/settings/general/+page.ts", import.meta.url);
+    const generalPageSvelte = new URL("./project/[ref]/settings/general/+page.svelte", import.meta.url);
+    expect(existsSync(generalPageTs)).toBe(true);
+    expect(existsSync(generalPageSvelte)).toBe(true);
+    const tsSource = readFileSync(generalPageTs, "utf8");
+    expect(tsSource).toContain('redirect(307, resolve("/project/[ref]/settings"');
   });
 
   test("logout redirects only after the backend confirms success", () => {

--- a/packages/web-console/src/routes/project/[ref]/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/+page.svelte
@@ -156,8 +156,8 @@
               (SELECT round(100.0 * blks_hit / NULLIF(blks_hit + blks_read, 0), 1) FROM pg_stat_database WHERE datname = current_database()) as cache_ratio;`),
       runSql(ref, `SELECT count(*) as active FROM pg_stat_activity WHERE backend_type = 'client backend';`),
       canReadLocalAuth ? runSql(ref, `SELECT count(*) as total FROM auth.users;`) : Promise.resolve([]),
-      runSql(ref, `SELECT count(*) as cnt FROM pg_stat_user_tables;`),
-      runSql(ref, `SELECT count(*) as cnt FROM pg_stat_user_indexes;`),
+      runSql(ref, `SELECT count(*) as cnt FROM pg_stat_user_tables WHERE schemaname = 'public';`),
+      runSql(ref, `SELECT count(*) as cnt FROM pg_stat_user_indexes WHERE schemaname = 'public';`),
       runSql(ref, `SELECT pg_size_pretty(coalesce(sum(CASE WHEN metadata->>'size' ~ '^[0-9]+$' THEN (metadata->>'size')::bigint ELSE 0 END), 0)) as size FROM storage.objects;`),
       canReadLocalAuth
         ? runSql(ref, `SELECT email, created_at::text FROM auth.users ORDER BY created_at DESC LIMIT 5;`)

--- a/packages/web-console/src/routes/project/[ref]/settings/general/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/settings/general/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+  import { page } from "$app/state";
+  import { resolve } from "$app/paths";
+
+  const projectRef = $derived(page.params.ref);
+
+  onMount(() => {
+    if (projectRef) {
+      goto(resolve("/project/[ref]/settings", { ref: projectRef }), { replaceState: true });
+    }
+  });
+</script>

--- a/packages/web-console/src/routes/project/[ref]/settings/general/+page.ts
+++ b/packages/web-console/src/routes/project/[ref]/settings/general/+page.ts
@@ -1,0 +1,7 @@
+import { redirect } from "@sveltejs/kit";
+import { resolve } from "$app/paths";
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = ({ params }) => {
+  redirect(307, resolve("/project/[ref]/settings", { ref: params.ref }));
+};


### PR DESCRIPTION
## Summary
- Fix Issue #122: Do not skip authentication check on the overview root route `/` in `+layout.svelte`, preventing navigation to `/projects` from getting stuck in an unauthenticated redirecting loop.
- Fix Issue #124: Add `/project/[ref]/settings/general` route alias redirecting to `/project/[ref]/settings`.
- Fix Issue #125: Filter public schema tables and indexes in `project-dashboard.ts` and project overview `+page.svelte` so the dashboard database summary matches the Table Editor count.
- Fix Issue #130: Include detailed Bun compiler/bundler diagnostics in edge function deploy errors instead of masking them behind a generic 500 error.
- Verified with unit tests in `web-console` and `management-api`.