### PR TITLE
feat(cli): deploy self-contained function bundle directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ supacloud-cli edge_functions list --ref <ref>
 supacloud-cli edge_functions source --ref <ref> --slug hello --version 1 --output ./hello-v1.ts
 supacloud-cli edge_functions deploy --ref <ref> --slug hello --path ./supabase/functions/hello --expected-active-version absent
 supacloud-cli edge_functions deploy --ref <ref> --slug hello --prebundled-path ./dist/hello.js --expected-sha256 <sha256> --expected-active-version 1
+supacloud-cli edge_functions deploy_bundle --ref <ref> --slug supauth --bundle-dir ./artifacts/supacloud-app/function-bundle --entrypoint index.ts --expected-active-version 1 --expected-activation-id <uuid>
 supacloud-cli edge_functions activate --ref <ref> --slug hello --version 2 --expected-active-version 3
 supacloud-cli storage list_buckets --ref <ref>
 ```
@@ -346,6 +347,11 @@ Use `deploy --prebundled-path` with the required lowercase
 artifact without local or server rebundling. The mode rejects caller-hash,
 file-stability, UTF-8, runtime-policy, and normalization mismatches before
 activation.
+Use `deploy_bundle --bundle-dir` for a locally built, self-contained multi-file
+Function directory. The CLI reads only regular UTF-8 files and rejects
+`node_modules`, `.git`, AppleDouble entries, symlinks, and special files before
+calling the Management API. The target host therefore needs neither a source
+checkout nor a package installation.
 Version `0` is reserved for a listed legacy Function's active-version CAS token.
 It is valid only as `--expected-active-version 0`; immutable source reads and
 activation targets still require a positive version.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1288,6 +1288,19 @@ describe("supacloud-cli process contract", () => {
         expect(response.stderr).not.toContain("--expected_sha256");
     });
 
+    test("documents the self-contained multi-file bundle directory flag", async () => {
+        const response = await runProjectCli(["edge_functions", "deploy_bundle", "--help"], {
+            SUPACLOUD_API_URL: "http://127.0.0.1:1",
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+        });
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toContain("--bundle-dir");
+        expect(response.stderr).toContain("node_modules");
+        expect(response.stderr).not.toContain("--bundle_dir");
+    });
+
     test("deploys exact verified prebundled Function bytes through the process CLI", async () => {
         const directory = mkdtempSync(join(tmpdir(), "supacloud-cli-prebundled-"));
         temporaryDirectories.push(directory);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -311,6 +311,7 @@ EXAMPLES
   ${preferredCommand} edge_functions get_config --ref abc123 --slug hello
   ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello --expected-active-version absent --expected-activation-id legacy
   ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --prebundled-path ./dist/hello.js --expected-sha256 <sha256> --expected-active-version 4 --expected-activation-id <uuid>
+  ${preferredCommand} edge_functions deploy_bundle --ref abc123 --slug supauth --bundle-dir ./artifacts/supacloud-app/function-bundle --entrypoint index.ts --expected-active-version 4 --expected-activation-id <uuid>
   ${preferredCommand} edge_functions activate --ref abc123 --slug hello --version 3 --expected-active-version 4 --expected-activation-id <uuid>
   ${preferredCommand} scheduled_functions list --ref abc123
   ${preferredCommand} mutations status --ref abc123 --mutation_id 00000000-0000-4000-8000-000000000001

--- a/packages/cli/src/shared/tools/advanced-tools.test.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { registerAdvancedTools } from "./advanced-tools";
@@ -9,6 +9,24 @@ import type { ToolSchema } from "../schema";
 
 const EXPECTED_ACTIVATION_ID = "a1111111-1111-4111-8111-111111111111";
 const COMMITTED_ACTIVATION_ID = "b2222222-2222-4222-8222-222222222222";
+
+function confirmedFunctionMutation(slug: string) {
+    return {
+        ok: true,
+        status: 200,
+        data: {
+            success: true,
+            project_ref: "proj",
+            slug,
+            previous_active_version: "3",
+            expected_activation_id: EXPECTED_ACTIVATION_ID,
+            activation_id: COMMITTED_ACTIVATION_ID,
+            active_version: "4",
+            version: "4",
+            config: { version: "4", verify_jwt: false, activation_id: COMMITTED_ACTIVATION_ID },
+        },
+    };
+}
 
 function captureEdgeFunctionsTool(
     http: Record<string, unknown>,
@@ -614,6 +632,96 @@ describe("edge_functions CLI tool", () => {
                 operation: "edge_functions.deploy",
                 active_version: "4",
             });
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    test("uploads a self-contained multi-file bundle directory without node_modules", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-bundle-dir-"));
+        mkdirSync(join(directory, "admin-console", "build"), { recursive: true });
+        writeFileSync(join(directory, "index.ts"), "export default {};\n");
+        writeFileSync(join(directory, "admin-console", "build", "index.html"), "<!doctype html>\n");
+        let requestBody: Record<string, unknown> | undefined;
+        const { callback } = captureEdgeFunctionsTool({
+            post: async (_path: string, body: Record<string, unknown>) => {
+                requestBody = body;
+                return confirmedFunctionMutation("supauth");
+            },
+        });
+
+        try {
+            await callback({
+                action: "deploy_bundle",
+                ref: "proj",
+                slug: "supauth",
+                "bundle-dir": directory,
+                entrypoint: "index.ts",
+                "expected-active-version": "3",
+                "expected-activation-id": EXPECTED_ACTIVATION_ID,
+            });
+            expect(requestBody).toMatchObject({
+                files: {
+                    "index.ts": "export default {};\n",
+                    "admin-console/build/index.html": "<!doctype html>\n",
+                },
+                entrypoint: "index.ts",
+            });
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    test.each(["node_modules", ".git", "._metadata"])(
+        "rejects forbidden bundle directory entry %s before HTTP dispatch",
+        async (entryName) => {
+            const directory = mkdtempSync(join(tmpdir(), "supacloud-forbidden-bundle-dir-"));
+            const entryPath = join(directory, entryName);
+            if (entryName.startsWith(".")) writeFileSync(entryPath, "forbidden");
+            else {
+                mkdirSync(entryPath);
+                writeFileSync(join(entryPath, "dependency.js"), "forbidden");
+            }
+            let requestCount = 0;
+            const { callback } = captureEdgeFunctionsTool({
+                post: async () => {
+                    requestCount += 1;
+                    return confirmedFunctionMutation("supauth");
+                },
+            });
+
+            try {
+                await expect(callback({
+                    action: "deploy_bundle",
+                    ref: "proj",
+                    slug: "supauth",
+                    "bundle-dir": directory,
+                    "expected-active-version": "3",
+                    "expected-activation-id": EXPECTED_ACTIVATION_ID,
+                })).rejects.toThrow("forbidden path");
+                expect(requestCount).toBe(0);
+            } finally {
+                rmSync(directory, { recursive: true, force: true });
+            }
+        },
+    );
+
+    test("rejects symlinks in a bundle directory before HTTP dispatch", async () => {
+        const directory = mkdtempSync(join(tmpdir(), "supacloud-symlink-bundle-dir-"));
+        const target = join(directory, "target.ts");
+        writeFileSync(target, "export default {};\n");
+        symlinkSync(target, join(directory, "index.ts"));
+        const { callback } = captureEdgeFunctionsTool({ post: async () => confirmedFunctionMutation("supauth") });
+
+        try {
+            await expect(callback({
+                action: "deploy_bundle",
+                ref: "proj",
+                slug: "supauth",
+                "bundle-dir": directory,
+                "expected-active-version": "3",
+                "expected-activation-id": EXPECTED_ACTIVATION_ID,
+            })).rejects.toThrow("must not contain symlinks");
         } finally {
             rmSync(directory, { recursive: true, force: true });
         }

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -7,15 +7,17 @@ import {
     constants as fsConstants,
     existsSync,
     fstatSync,
+    lstatSync,
     mkdtempSync,
     openSync,
     readFileSync,
+    readdirSync,
     rmSync,
     statSync,
     writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, join, relative, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { execFile } from "node:child_process";
 import { Type } from "@sinclair/typebox";
@@ -40,6 +42,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
+const FORBIDDEN_BUNDLE_SEGMENTS = new Set(["node_modules", ".git"]);
 
 type OpenFileIdentity = {
     dev: bigint;
@@ -109,6 +112,57 @@ function readVerifiedPrebundledCode(pathArg: string, expectedSha256: string): st
     } finally {
         closeSync(descriptor);
     }
+}
+
+function canonicalBundlePath(root: string, filePath: string): string {
+    const bundlePath = relative(root, filePath).split(sep).join("/");
+    const segments = bundlePath.split("/");
+    if (!bundlePath || bundlePath.startsWith("/") || segments.some((segment) => (
+        !segment
+        || segment === "."
+        || segment === ".."
+        || segment.startsWith("._")
+        || FORBIDDEN_BUNDLE_SEGMENTS.has(segment)
+    ))) {
+        throw new Error(`Bundle directory contains a forbidden path: ${bundlePath || filePath}`);
+    }
+    return bundlePath;
+}
+
+function readBundleDirectory(root: string, directory: string = root): Record<string, string> {
+    const files: Record<string, string> = {};
+    const entries = readdirSync(directory, { withFileTypes: true })
+        .sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+        const entryPath = join(directory, entry.name);
+        const bundlePath = canonicalBundlePath(root, entryPath);
+        const entryState = lstatSync(entryPath);
+        if (entryState.isSymbolicLink()) throw new Error(`Bundle directory must not contain symlinks: ${bundlePath}`);
+        if (entryState.isDirectory()) {
+            Object.assign(files, readBundleDirectory(root, entryPath));
+            continue;
+        }
+        if (!entryState.isFile()) throw new Error(`Bundle directory must contain only regular files: ${bundlePath}`);
+        files[bundlePath] = verifiedUtf8Code(readFileSync(entryPath));
+    }
+    return files;
+}
+
+function preparedBundleFiles(args: Record<string, unknown>): Record<string, string> {
+    const files = args.files;
+    const bundleDirectory = args["bundle-dir"];
+    if ((files === undefined) === (bundleDirectory === undefined)) {
+        throw new Error("Exactly one of '--files' or '--bundle-dir' is required for 'deploy_bundle'");
+    }
+    if (typeof bundleDirectory !== "string") return files as Record<string, string>;
+    const resolvedDirectory = resolve(bundleDirectory);
+    const rootState = lstatSync(resolvedDirectory);
+    if (rootState.isSymbolicLink() || !rootState.isDirectory()) {
+        throw new Error("'--bundle-dir' must be a regular directory and must not be a symlink");
+    }
+    const bundleFiles = readBundleDirectory(resolvedDirectory);
+    if (Object.keys(bundleFiles).length === 0) throw new Error("'--bundle-dir' must not be empty");
+    return bundleFiles;
 }
 
 async function runBunBuild(args: string[]): Promise<{ stdout: string; stderr: string }> {
@@ -186,11 +240,14 @@ async function bundledDeployCode(pathArg: string): Promise<PreparedDeployCode> {
     }
 }
 
-function rejectPrebundledFlagsOutsideDeploy(action: string, args: Record<string, unknown>): void {
+function rejectActionSpecificFlags(action: string, args: Record<string, unknown>): void {
     for (const flag of ["prebundled-path", "expected-sha256"]) {
         if (action !== "deploy" && args[flag] !== undefined) {
             throw new Error(`'--${flag}' is not supported for '${action}'`);
         }
+    }
+    if (action !== "deploy_bundle" && args["bundle-dir"] !== undefined) {
+        throw new Error(`'--bundle-dir' is not supported for '${action}'`);
     }
 }
 
@@ -775,6 +832,7 @@ Actions: list, get_config, deploy, deploy_bundle, config, source, activate, dele
             ),
             output: optional(Type.String(), "[source] Write source to this local file instead of stdout; the file must not already exist"),
             files: optional(functionFilesSchema, "[deploy_bundle] File map as a JSON object: { 'index.ts': '...', '_shared/x.ts': '...' }"),
+            "bundle-dir": optional(Type.String(), "[deploy_bundle] Local self-contained UTF-8 bundle directory; excludes node_modules, .git, AppleDouble, symlinks, and special files"),
             entrypoint: optional(Type.String(), "[deploy_bundle] Entrypoint file (default: index.ts)"),
             minify: optional(Type.Boolean(), "[deploy/deploy_bundle] Minify bundle"),
             verify_jwt: optional(Type.Boolean(), "[deploy/deploy_bundle/config] Set JWT verification for this function"),
@@ -790,8 +848,8 @@ Actions: list, get_config, deploy, deploy_bundle, config, source, activate, dele
         },
         async (args: any) => {
             if (args.action === "activate") return activateFunctionVersion(http, args, options.readOnly);
-            const { action, ref, slug, path: pathArg, output, files, entrypoint, minify, verify_jwt, background_routes } = args;
-            rejectPrebundledFlagsOutsideDeploy(action, args);
+            const { action, ref, slug, path: pathArg, output, entrypoint, minify, verify_jwt, background_routes } = args;
+            rejectActionSpecificFlags(action, args);
             const expectedActiveVersion = action === "deploy" || action === "deploy_bundle"
                 ? requiredExpectedActiveVersion(args, action)
                 : undefined;
@@ -876,9 +934,10 @@ Actions: list, get_config, deploy, deploy_bundle, config, source, activate, dele
                         config: functionConfig(),
                     }, deploymentResponse);
                 case "deploy_bundle":
-                    need("slug", slug); need("files", files);
+                    need("slug", slug);
+                    const deployBundleFiles = preparedBundleFiles(args);
                     const bundleResponse = await http.postReleaseMutation(`${edgeFunctionResourcePath(ref, slug)}/bundle`, {
-                        files,
+                        files: deployBundleFiles,
                         entrypoint,
                         minify,
                         expected_active_version: expectedActiveVersion,


### PR DESCRIPTION
## Summary
- add `edge_functions deploy_bundle --bundle-dir` for locally built multi-file Function artifacts
- reject `node_modules`, `.git`, AppleDouble entries, symlinks, special files, empty directories, and non-UTF-8 files before Management API dispatch
- preserve activation/version CAS and existing bounded mutation receipts

## Verification
- `bun test ./packages/cli/src/shared/tools/advanced-tools.test.ts ./packages/cli/src/index.test.ts` (272 pass)
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli build`
- `git diff origin/main...HEAD --check`

## Deployment boundary
The CLI runs on the connected operator machine and uploads the verified file map. The target SupaCloud host does not need a source checkout, package manager access, or `node_modules`.