### PR TITLE
fix(edge-runtime): pass canonical path to module loader to avoid descriptor collision

### DIFF
--- a/packages/edge-runtime/trusted-function-files.test.ts
+++ b/packages/edge-runtime/trusted-function-files.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, expect, test } from "bun:test";
 import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
@@ -113,6 +114,36 @@ describe("trusted Function runtime files", () => {
         await expect(readTrustedFunctionFile(artifactPath)).rejects.toThrow(
           "Function runtime file is not trusted",
         );
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+     },
+  );
+
+  test.skipIf(process.platform !== "linux")(
+    "passes canonical verified artifact path to loader without ephemeral descriptor collision",
+    async () => {
+      const root = await mkdtemp(join(trustedTemporaryRoot, ".supacloud-runtime-canonical-"));
+      const artifact1Path = join(root, "index.aaaaaaaaaaaaaaaa.js");
+      const artifact2Path = join(root, "index.bbbbbbbbbbbbbbbb.js");
+      await writeFile(artifact1Path, "export const name = 'artifact1';");
+      await writeFile(artifact2Path, "export const name = 'artifact2';");
+      const sha1 = createHash("sha256").update("export const name = 'artifact1';").digest("hex");
+      const sha2 = createHash("sha256").update("export const name = 'artifact2';").digest("hex");
+      try {
+        const pathsLoaded: string[] = [];
+        await withTrustedFunctionArtifact(artifact1Path, sha1, async (loadedPath) => {
+          pathsLoaded.push(loadedPath);
+          return null;
+        });
+        await withTrustedFunctionArtifact(artifact2Path, sha2, async (loadedPath) => {
+          pathsLoaded.push(loadedPath);
+          return null;
+        });
+        expect(pathsLoaded[0]).toBe(artifact1Path);
+        expect(pathsLoaded[1]).toBe(artifact2Path);
+        expect(pathsLoaded[0]).not.toContain("/proc/self/fd");
+        expect(pathsLoaded[1]).not.toContain("/proc/self/fd");
       } finally {
         await rm(root, { recursive: true, force: true });
       }

--- a/packages/edge-runtime/trusted-function-files.ts
+++ b/packages/edge-runtime/trusted-function-files.ts
@@ -257,7 +257,7 @@ export async function withTrustedFunctionArtifact<T>(
       throw new Error("Function artifact SHA-256 does not match activation authority");
     }
     await assertHeldDirectoryBindings(heldDirectories);
-    const imported = await readArtifact(`/proc/self/fd/${artifact.fd}`);
+    const imported = await readArtifact(absolutePath);
     const after = await artifact.stat();
     if (fileChanged(metadata, after)) throw new Error("Function runtime file changed while importing");
     await assertHeldDirectoryBindings(heldDirectories);


### PR DESCRIPTION
### Summary

Fixes an Edge Runtime cross-function module collision bug caused by ephemeral `/proc/self/fd` descriptor path reuse in Bun's module cache.

#### Root Cause
1. `withTrustedFunctionArtifact` opens an artifact via Linux directory-chain descriptor binding, performs SHA-256 validation, passes `/proc/self/fd/${artifact.fd}` to the loader callback, and closes the descriptor in `finally`.
2. Linux kernel eagerly reuses released lowest integer file descriptors across successive function loads.
3. Bun's dynamic `import()` caches ES modules by path specifier. Successive functions opening with the same file descriptor number were colliding in Bun's module registry, causing one function to inadvertently execute another function's handler (e.g. `fa-access-context` executing `fa-worker-scheduled`).

#### Solution
- Pass the canonical verified `absolutePath` to the loader callback after descriptor-bound directory-chain, stat-identity, and SHA-256 assertions complete.
- Add regression test asserting that canonical paths are passed without `/proc/self/fd` descriptor collision.