### PR TITLE
test(cli): cover wrapped DO migration risk

### DIFF
--- a/packages/cli/src/shared/tools/migration-risk.test.ts
+++ b/packages/cli/src/shared/tools/migration-risk.test.ts
@@ -233,6 +233,21 @@ describe("migration risk analysis", () => {
         ]);
     });
 
+    test("requires manual review for a DO block inside the allowed outer transaction wrapper", () => {
+        const risks = analyzeMigrationSql(`
+            BEGIN;
+            DO $migration$ BEGIN EXECUTE 'DROP TABLE users'; END $migration$;
+            COMMIT;
+        `);
+        expect(risks).toEqual([
+            expect.objectContaining({
+                level: "HIGH",
+                type: "manual_review_do_block",
+                blocksTransactionalPush: true,
+            }),
+        ]);
+    });
+
     test("requires manual review for procedural definitions and calls", () => {
         expect(analyzeMigrationSql(
             "CREATE FUNCTION public.answer() RETURNS integer LANGUAGE sql AS $$ SELECT 42 $$;",


### PR DESCRIPTION
## Summary
- cover the production migration shape `BEGIN; DO ...; COMMIT;`
- assert the CLI dry-run keeps reporting `manual_review_do_block`
- prevent dry-run/apply policy drift from regressing

## Verification
- `bun test packages/cli/src/shared/tools/migration-risk.test.ts`
- `git diff --check`

The implementation fix is already present on `main` via #1000; this PR adds the exact incident regression.