### PR TITLE
feat(cli): migrate project OAuth signing keys

### DIFF
--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -162,6 +162,8 @@ describe("CLI execution policy", () => {
         expect(executionMode("oauth_clients", "get", {})).toBe("read");
         expect(executionMode("oauth_clients", "create", {})).toBe("write");
         expect(executionMode("oauth_clients", "delete", {})).toBe("write");
+        expect(executionMode("auth", "get_oauth_server", {})).toBe("read");
+        expect(executionMode("auth", "migrate_oauth_server", {})).toBe("write");
         expect(() => authorizeExecution("oauth_clients", { action: "create", ref: "prod-ref" }, {
             context: context(),
         })).toThrow("--confirm-production prod-ref");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -26,8 +26,8 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         write: ["push"],
     },
     auth: {
-        read: ["list_users", "get_user", "list_providers", "get_provider", "supported_providers", "get_settings", "get_config"],
-        write: ["generate_link", "configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config"],
+        read: ["list_users", "get_user", "list_providers", "get_provider", "supported_providers", "get_settings", "get_config", "get_oauth_server"],
+        write: ["generate_link", "configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config", "migrate_oauth_server"],
     },
     oauth_clients: {
         read: ["list", "get"],

--- a/packages/cli/src/shared/tools/auth-tools.test.ts
+++ b/packages/cli/src/shared/tools/auth-tools.test.ts
@@ -22,6 +22,76 @@ function captureAuthTool(http: Record<string, unknown>) {
 }
 
 describe("auth CLI mutation contract", () => {
+    test("migrates OAuth signing keys and requires an exact ES256 read-back", async () => {
+        const requests: Array<{ method: string; path: string; body?: unknown }> = [];
+        const status = {
+            project_ref: "project-a",
+            enabled: true,
+            allow_dynamic_registration: false,
+            issuer: "https://auth.example.test/auth/v1",
+            authorization_path: "/oauth/authorize",
+            signing_alg: "ES256",
+            key_id: "key-one",
+            oidc_id_token_ready: true,
+            migration_status: "oidc_es256_migrated",
+            jwt_keys: [{ private_key: "must-not-return" }],
+        };
+        const { schema, callback } = captureAuthTool({
+            postReleaseMutation: async (path: string, body: unknown) => {
+                requests.push({ method: "POST", path, body });
+                return { ok: true, status: 200, data: status };
+            },
+            get: async (path: string) => {
+                requests.push({ method: "GET", path });
+                return { ok: true, status: 200, data: status };
+            },
+        });
+        const args = parseToolArguments(schema, {
+            action: "migrate_oauth_server",
+            ref: "project-a",
+            allow_dynamic_registration: false,
+            authorization_path: "/oauth/authorize",
+        });
+
+        const response = await callback(args);
+        const output = JSON.parse(response.content[0].text);
+
+        expect(requests).toEqual([
+            { method: "POST", path: "/v1/projects/project-a/auth/oauth-server/migrate", body: { allow_dynamic_registration: false, authorization_path: "/oauth/authorize" } },
+            { method: "GET", path: "/v1/projects/project-a/auth/oauth-server" },
+        ]);
+        expect(output).toMatchObject({ ok: true, operation: "auth.migrate_oauth_server", signing_alg: "ES256", oidc_id_token_ready: true });
+        expect(response.content[0].text).not.toContain("must-not-return");
+    });
+
+    test("fails closed when OAuth migration read-back is not ES256-ready", async () => {
+        const { callback } = captureAuthTool({
+            postReleaseMutation: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    project_ref: "project-a", enabled: true, allow_dynamic_registration: false,
+                    issuer: "https://auth.example.test/auth/v1", signing_alg: "ES256",
+                    oidc_id_token_ready: true, migration_status: "oidc_es256_migrated",
+                },
+            }),
+            get: async () => ({
+                ok: true,
+                status: 200,
+                data: {
+                    project_ref: "project-a", enabled: false, allow_dynamic_registration: false,
+                    issuer: "https://auth.example.test/auth/v1", signing_alg: "not_migrated",
+                    oidc_id_token_ready: false, migration_status: "not_migrated",
+                },
+            }),
+        });
+
+        const response = await callback({ action: "migrate_oauth_server", ref: "project-a" });
+
+        expect(response.isError).toBe(true);
+        expect(JSON.parse(response.content[0].text)).toMatchObject({ operation: "auth.migrate_oauth_server", error: "INVALID_RESPONSE" });
+    });
+
     test("lists bounded users with pagination and projects safe fields", async () => {
         const requests: Array<{ path: string; options: unknown }> = [];
         const { schema, callback } = captureAuthTool({

--- a/packages/cli/src/shared/tools/auth-tools.ts
+++ b/packages/cli/src/shared/tools/auth-tools.ts
@@ -15,6 +15,7 @@ const MAX_AUTH_READ_BYTES = 64 * 1024;
 const AUTH_READ_TIMEOUT_MS = 5_000;
 const USER_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const AUTH_LINK_TYPES = ["magiclink", "recovery", "invite"] as const;
+const OAUTH_AUTHORIZATION_PATH_MAX_LENGTH = 2_048;
 
 const SAFE_USER_FIELDS = [
     "email", "phone", "created_at", "last_sign_in_at",
@@ -86,6 +87,83 @@ function authMutationResult(response: HttpResult<unknown>, successMessage: strin
 function requiredRef(candidate: unknown): string {
     if (typeof candidate !== "string" || !candidate.trim()) throw new Error("'ref' is required");
     return projectRefPathSegment(candidate.trim(), "Auth");
+}
+
+function optionalAuthorizationPath(candidate: unknown): string | undefined {
+    if (candidate === undefined) return undefined;
+    return boundedText(candidate, "authorization_path", OAUTH_AUTHORIZATION_PATH_MAX_LENGTH);
+}
+
+function oauthServerStatus(value: unknown, expectedRef: string): Record<string, unknown> | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const status = value as Record<string, unknown>;
+    if (status.project_ref !== expectedRef
+        || typeof status.enabled !== "boolean"
+        || typeof status.allow_dynamic_registration !== "boolean"
+        || typeof status.issuer !== "string"
+        || typeof status.signing_alg !== "string"
+        || typeof status.oidc_id_token_ready !== "boolean"
+        || typeof status.migration_status !== "string") return null;
+    return {
+        project_ref: status.project_ref,
+        enabled: status.enabled,
+        allow_dynamic_registration: status.allow_dynamic_registration,
+        issuer: status.issuer,
+        authorization_path: typeof status.authorization_path === "string" ? status.authorization_path : null,
+        signing_alg: status.signing_alg,
+        key_id: typeof status.key_id === "string" ? status.key_id : null,
+        oidc_id_token_ready: status.oidc_id_token_ready,
+        migration_status: status.migration_status,
+    };
+}
+
+function oauthServerFailure(operation: string, response: HttpResult<unknown>) {
+    return {
+        isError: true,
+        content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+                ok: false,
+                operation,
+                http_status: response.transportError || response.responseReadError ? null : response.status,
+                error: response.responseReadError ? "INVALID_RESPONSE" : response.transportError ? "NETWORK_ERROR" : "HTTP_ERROR",
+            }, null, 2),
+        }],
+    };
+}
+
+async function getOAuthServer(http: HttpTransport, ref: string) {
+    const response = await http.get(`/v1/projects/${ref}/auth/oauth-server`, {
+        maxJsonBytes: MAX_AUTH_READ_BYTES,
+        responseTimeoutMs: AUTH_READ_TIMEOUT_MS,
+    });
+    if (!response.ok) return oauthServerFailure("auth.get_oauth_server", response);
+    const status = oauthServerStatus(response.data, ref);
+    if (!status) return oauthServerFailure("auth.get_oauth_server", { ...response, responseReadError: true });
+    return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, operation: "auth.get_oauth_server", ...status }, null, 2) }] };
+}
+
+async function migrateOAuthServer(http: HttpTransport, args: Record<string, unknown>) {
+    const ref = requiredRef(args.ref);
+    const body: Record<string, unknown> = {
+        allow_dynamic_registration: args.allow_dynamic_registration === true,
+    };
+    const authorizationPath = optionalAuthorizationPath(args.authorization_path);
+    if (authorizationPath !== undefined) body.authorization_path = authorizationPath;
+    const mutation = await http.postReleaseMutation(`/v1/projects/${ref}/auth/oauth-server/migrate`, body);
+    if (!mutation.ok) return oauthServerFailure("auth.migrate_oauth_server", mutation);
+    const mutationStatus = oauthServerStatus(mutation.data, ref);
+    if (!mutationStatus) return oauthServerFailure("auth.migrate_oauth_server", { ...mutation, responseReadError: true });
+    const read = await http.get(`/v1/projects/${ref}/auth/oauth-server`, {
+        maxJsonBytes: MAX_AUTH_READ_BYTES,
+        responseTimeoutMs: AUTH_READ_TIMEOUT_MS,
+    });
+    if (!read.ok) return oauthServerFailure("auth.migrate_oauth_server", read);
+    const status = oauthServerStatus(read.data, ref);
+    if (!status || status.signing_alg !== "ES256" || status.oidc_id_token_ready !== true) {
+        return oauthServerFailure("auth.migrate_oauth_server", { ...read, responseReadError: true });
+    }
+    return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, operation: "auth.migrate_oauth_server", ...status }, null, 2) }] };
 }
 
 function requiredUserId(candidate: unknown): string {
@@ -341,7 +419,7 @@ export function registerAuthTools(server: { tool: (...args: any[]) => void }, ht
     server.tool(
         "auth",
         `Auth & OAuth provider management, controlled user lookup, and login-link generation.
-Actions: list_users, get_user, generate_link, list_providers, get_provider, configure_provider, update_provider, disable_provider, supported_providers, wechat_mini, wechat_open, get_settings, update_settings, get_config, update_config`,
+Actions: list_users, get_user, generate_link, list_providers, get_provider, configure_provider, update_provider, disable_provider, supported_providers, wechat_mini, wechat_open, get_settings, update_settings, get_config, update_config, get_oauth_server, migrate_oauth_server`,
         {
             action: withDescription(stringEnum([
                 "list_users", "get_user", "generate_link",
@@ -350,6 +428,7 @@ Actions: list_users, get_user, generate_link, list_providers, get_provider, conf
                 "wechat_mini", "wechat_open",
                 "get_settings", "update_settings",
                 "get_config", "update_config",
+                "get_oauth_server", "migrate_oauth_server",
             ]), "Action to perform"),
             ref: optional(Type.String(), "Project ref (required for most actions)"),
             user_id: optional(Type.String(), "[get_user] Exact auth user UUID"),
@@ -368,6 +447,8 @@ Actions: list_users, get_user, generate_link, list_providers, get_provider, conf
             app_id: optional(Type.String(), "[wechat_*] WeChat App ID"),
             app_secret: optional(Type.String(), "[wechat_*] WeChat App Secret"),
             config: optional(authConfigSchema, "[update_settings/update_config] Config fields as a JSON object"),
+            allow_dynamic_registration: optional(Type.Boolean(), "[migrate_oauth_server] Enable dynamic client registration"),
+            authorization_path: optional(Type.String(), "[migrate_oauth_server] Hosted OAuth authorization path"),
         },
         async (args: any) => {
             const { action, ref, provider, client_id, client_secret, redirect_uri, url, app_id, app_secret, config } = args;
@@ -382,6 +463,10 @@ Actions: list_users, get_user, generate_link, list_providers, get_provider, conf
                     return getUser(http, args);
                 case "generate_link":
                     return generateLink(http, args);
+                case "get_oauth_server":
+                    return getOAuthServer(http, requiredRef(ref));
+                case "migrate_oauth_server":
+                    return migrateOAuthServer(http, args);
                 case "list_providers":
                     need("ref");
                     const lp = await http.get(`/v1/projects/${ref}/auth/providers`);


### PR DESCRIPTION
## Summary
- add `auth get_oauth_server` for bounded project OAuth status read-back
- add production-confirmed `auth migrate_oauth_server`
- require post-migration ES256/OIDC readiness read-back and omit signing material

## Validation
- `bun test src/shared/tools/auth-tools.test.ts src/shared/execution-policy.test.ts` (30 pass)
- `bun run typecheck`
- `bun run build`

This unblocks the existing `oauth_clients` lifecycle when Management API returns 409 because a project has not yet created project-scoped OAuth signing keys.