### PR TITLE
fix(gateway): use Caddy scheme vars matcher for protocol-scoped routes

### DIFF
--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -515,7 +515,11 @@ export function makeCustomGatewayRoute(projectRef: string, input: CustomGatewayR
         host: route.hosts,
         path: Array.isArray(route.path) ? route.path : [route.path],
     };
-    if (route.protocol) match.protocol = route.protocol;
+    if (route.protocol) {
+        match.vars = {
+            "{http.request.scheme}": route.protocol,
+        };
+    }
 
     return {
         "@id": customGatewayRouteId(projectRef, route.id),

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -720,8 +720,10 @@ export class CaddyGatewayProvider implements GatewayProvider {
         const bPath = Array.isArray((b.match as any)?.[0]?.path) ? String((b.match as any)[0].path[0] || "") : "";
         if (aPath.length !== bPath.length) return bPath.length - aPath.length;
 
-        const aProtocol = typeof (a.match as any)?.[0]?.protocol === "string";
-        const bProtocol = typeof (b.match as any)?.[0]?.protocol === "string";
+        const aProtocol = typeof (a.match as any)?.[0]?.vars?.["{http.request.scheme}"] === "string"
+            || typeof (a.match as any)?.[0]?.protocol === "string";
+        const bProtocol = typeof (b.match as any)?.[0]?.vars?.["{http.request.scheme}"] === "string"
+            || typeof (b.match as any)?.[0]?.protocol === "string";
         if (aProtocol !== bProtocol) return aProtocol ? -1 : 1;
         return aid.localeCompare(bid);
     }

--- a/packages/management-api/tests/unit/gateway-route-builders.test.ts
+++ b/packages/management-api/tests/unit/gateway-route-builders.test.ts
@@ -246,7 +246,9 @@ describe("gateway route builders", () => {
         expect(route.match).toEqual([{
             host: ["www.example.com"],
             path: ["/*"],
-            protocol: "http",
+            vars: {
+                "{http.request.scheme}": "http",
+            },
         }]);
         expect(route.handle).toEqual([{
             handler: "static_response",

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -627,7 +627,9 @@ describe("CaddyGatewayProvider", () => {
         expect(redirect?.match?.[0]).toEqual({
             host: ["studio.example.com"],
             path: ["/*"],
-            protocol: "http",
+            vars: {
+                "{http.request.scheme}": "http",
+            },
         });
         expect(redirect?.handle?.[0]).toMatchObject({
             handler: "static_response",


### PR DESCRIPTION
### Summary
- Fixes custom gateway route generation where `protocol` (`http` / `https`) was incorrectly assigned to Caddy's ALPN `match.protocol` instead of the scheme `vars` matcher (`{http.request.scheme}`).
- Updates route sorting logic in `CaddyGatewayProvider` to recognize scheme vars matcher.
- Updates unit tests in `gateway-route-builders.test.ts` and `gateway.service.test.ts`.