### PR TITLE
feat: add application state and PowerSync readiness references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,8 @@
 - [@supacloud/js](./supacloud-js.md) - Official platform SDK layered on top of `supabase-js`, including tasks, lifecycle webhooks, queues, and OAuth helpers
 - [Queues PGMQ Migration Guide](./queues-pgmq-migration.md) - Migration notes for Supabase Queues compatibility and SupaCloud queue extensions
 - [Durable Workflows](./durable-workflows.md) - Service-role-only PostgreSQL/PGMQ workflow execution and DBOS design rationale
+- [Application Business State Machines](./business-state-machines.md) - Maker-Checker transition RPC, audit, versioning, and XState projection pattern
+- [PowerSync Local-First Integration](./powersync-local-first.md) - Self-hosted sync boundary, replication readiness, RLS upload path, ELN conflicts, and cleanup
 
 ## Product Positioning
 

--- a/docs/business-state-machines.md
+++ b/docs/business-state-machines.md
@@ -1,0 +1,99 @@
+# Application Business State Machines
+
+SupaCloud Durable Workflows owns execution mechanics such as leases, retries,
+checkpoints, and cancellation. Application tables remain authoritative for
+Maker-Checker, report rework, ticket, signing, and delivery states.
+
+Use the reference files together:
+
+- [`examples/maker-checker-state-machine.sql`](./examples/maker-checker-state-machine.sql)
+  is an application migration template.
+- [`examples/maker-checker-machine.ts`](./examples/maker-checker-machine.ts)
+  is an XState projection for frontend and Edge Function code.
+- [`examples/maker-checker-workflow-bridge.sql`](./examples/maker-checker-workflow-bridge.sql)
+  is an optional transactional outbox and service-role dispatch bridge to
+  SupaCloud Durable Workflows and PGMQ.
+- [`examples/maker-checker-workflow-dispatcher.ts`](./examples/maker-checker-workflow-dispatcher.ts)
+  is the corresponding trusted Worker or Scheduled Function loop.
+
+The TypeScript file belongs in the consuming application, which owns and pins
+its XState v5 dependency. SupaCloud core does not import or install XState.
+
+## Required boundary
+
+The browser must not update a business `status` column directly. It sends an
+event to a database RPC with the entity ID, expected row version, reason, and an
+idempotency key. The RPC locks the row and atomically validates the transition,
+actor role, Maker-Checker separation, frozen payload checksum, and replay
+identity before updating the entity and appending an audit event.
+
+The reference freezes both the submitted JSON payload and its checksum. The
+Checker approval path compares both values against the live payload, avoiding
+approval of content that changed after submission and avoiding reliance on a
+checksum alone.
+
+## Transactional side effects
+
+Business state and asynchronous intent must not be committed independently.
+The optional workflow bridge uses an `AFTER INSERT` trigger on the immutable
+transition event. For approval and completion events, it appends a private
+outbox row in the same PostgreSQL transaction.
+
+A trusted service-role dispatcher claims outbox rows with a bounded lease,
+starts Durable Workflows with the stored fixed `runId`, then marks the dispatch
+complete. Durable Workflows creates its run, first step, lifecycle event, and
+private PGMQ message atomically. If the dispatcher crashes after workflow start
+but before acknowledgement, retrying the same `runId` is idempotent.
+
+The workflow input contains only the document ID, transition event ID, and entity
+version. Workers read the authoritative document after claiming the step; do
+not copy mutable or sensitive business payloads into workflow input. A worker
+must never write `review_documents.status` directly. It may call another
+domain RPC after an external effect succeeds.
+
+The workflow service can be temporarily unavailable without losing or rolling
+back an accepted approval; the outbox remains pending. Exhausted or explicitly
+terminal dispatches are dead-lettered for operator review. Do not use a
+best-effort Edge Function call from a trigger or client.
+
+XState improves shared vocabulary and UI behavior, but it is not an
+authorization boundary. A stale client, compromised browser, concurrent actor,
+or offline replay can bypass client guards, so PostgreSQL must repeat every
+decision.
+
+## Adapting the migration
+
+1. Rename the example tables and states to match the domain.
+2. Replace `review_document_members` with the application's authoritative RBAC
+   or ReBAC lookup. Never trust a role supplied in the request body.
+3. Keep entity creation and membership assignment in a separate controlled
+   intake RPC.
+4. Preserve `row_version`, the per-entity idempotency uniqueness constraint,
+   the append-only event fence, and the direct-transition fence.
+5. Add every new event to both the SQL transition matrix and the XState
+   projection. The SQL matrix remains authoritative.
+6. Pin active records to a machine version when a domain must support multiple
+   state graph versions at once.
+
+For report rework, create a linked new report/case version rather than moving a
+delivered report back to drafting. The prior version becomes superseded only
+after the replacement passes review and signing.
+
+## Verification matrix
+
+At minimum, application tests must cover:
+
+- every allowed `(state, event, role)` transition;
+- every state/event combination that must fail;
+- Maker and Checker identity equality;
+- stale `expectedVersion`;
+- identical and conflicting idempotency replay;
+- payload changes after submission;
+- direct status updates and audit event mutation;
+- RLS visibility for members and non-members.
+
+Use Durable Workflows only for side effects derived from an accepted domain
+transition, for example to render a report, notify a customer, archive an
+artifact, or retry an external integration. Use the transactional outbox above
+when workflow availability must not block the business transition, and never
+let a workflow become the authoritative business state.

--- a/docs/durable-workflows.md
+++ b/docs/durable-workflows.md
@@ -90,6 +90,25 @@ Use `retry` for a transient error, `fail` for a terminal error, `complete` for t
 
 `claim` can return `null`, `claimed`, `dead_lettered`, or `discarded`. A discarded result means the internal queue contained an invalid, orphaned, or no-longer-claimable message; it has already been archived and the worker can continue polling. A `40001` claim error indicates concurrent work on the same run; retry the claim because its queue lease was rolled back.
 
+## Application transition handoff
+
+Applications should append workflow intent to a private domain outbox in the
+same transaction as the accepted business transition. A trusted service-role
+dispatcher leases the outbox item, calls `supacloud_workflow_start()` with a
+stored fixed run ID, and records completion. A lost acknowledgement retries the
+same run ID, so workflow start remains idempotent.
+
+Pass identifiers and the accepted entity version to workflow input, then let
+the worker read authoritative application data. Do not duplicate mutable
+business payloads or use workflow status as approval, signing, delivery, or
+ticket state. See [Application Business State Machines](./business-state-machines.md)
+for the Maker-Checker reference and optional workflow bridge.
+
+This preserves the workflow RPC's service-role-only boundary and lets a
+temporary worker or workflow outage accumulate visible pending intent without
+rolling back approval. Direct best-effort HTTP calls from a database trigger or
+browser provide neither atomicity nor durable recovery.
+
 ## Security and operations
 
 - Only `service_role` can execute the public workflow RPCs.

--- a/docs/examples/maker-checker-machine.ts
+++ b/docs/examples/maker-checker-machine.ts
@@ -1,0 +1,67 @@
+import { setup } from "xstate";
+
+type ReviewContext = {
+  actorId: string;
+  actorRole: "maker" | "checker";
+  makerId: string;
+  payloadChecksum: string;
+  submittedPayloadChecksum: string | null;
+};
+
+type ReviewEvent =
+  | { type: "SUBMIT" }
+  | { type: "RETURN"; reason: string }
+  | { type: "APPROVE" }
+  | { type: "COMPLETE" };
+
+export const reviewDocumentMachine = setup({
+  types: {
+    context: {} as ReviewContext,
+    events: {} as ReviewEvent,
+    input: {} as ReviewContext,
+  },
+  guards: {
+    isMaker: ({ context }) =>
+      context.actorRole === "maker" && context.actorId === context.makerId,
+    isSeparatedChecker: ({ context }) =>
+      context.actorRole === "checker" && context.actorId !== context.makerId,
+  },
+}).createMachine({
+  id: "review-document-v1",
+  initial: "draft",
+  context: ({ input }) => input,
+  states: {
+    draft: {
+      on: { SUBMIT: { target: "submitted", guard: "isMaker" } },
+    },
+    returned: {
+      on: { SUBMIT: { target: "submitted", guard: "isMaker" } },
+    },
+    submitted: {
+      on: {
+        RETURN: {
+          target: "returned",
+          guard: ({ context, event }) =>
+            context.actorRole === "checker"
+            && context.actorId !== context.makerId
+            && event.reason.trim().length > 0,
+        },
+        APPROVE: {
+          target: "approved",
+          guard: ({ context }) =>
+            context.actorRole === "checker"
+            && context.actorId !== context.makerId
+            && context.submittedPayloadChecksum !== null
+            && context.submittedPayloadChecksum === context.payloadChecksum,
+        },
+      },
+    },
+    approved: {
+      on: { COMPLETE: { target: "completed", guard: "isSeparatedChecker" } },
+    },
+    completed: { type: "final" },
+  },
+});
+
+// This machine controls UI affordances only. Always submit the event to
+// transition_review_document(), which rechecks state, actor, version, and checksum.

--- a/docs/examples/maker-checker-state-machine.sql
+++ b/docs/examples/maker-checker-state-machine.sql
@@ -1,0 +1,303 @@
+-- Application migration reference: adapt table and permission names to the domain.
+-- The database RPC is authoritative. XState or other clients only project allowed actions.
+
+CREATE TABLE public.review_documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  status text NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'submitted', 'returned', 'approved', 'completed')),
+  maker_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  checker_id uuid REFERENCES auth.users(id) ON DELETE RESTRICT,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(payload) = 'object'),
+  submitted_payload jsonb CHECK (
+    submitted_payload IS NULL OR jsonb_typeof(submitted_payload) = 'object'
+  ),
+  submitted_payload_checksum text CHECK (
+    submitted_payload_checksum IS NULL
+    OR char_length(submitted_payload_checksum) = 32
+  ),
+  row_version bigint NOT NULL DEFAULT 1 CHECK (row_version > 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (checker_id IS NULL OR checker_id <> maker_id),
+  CHECK (
+    (
+      status IN ('draft', 'returned')
+      AND submitted_payload IS NULL
+      AND submitted_payload_checksum IS NULL
+    )
+    OR (
+      status IN ('submitted', 'approved', 'completed')
+      AND submitted_payload IS NOT NULL
+      AND submitted_payload_checksum IS NOT NULL
+    )
+  )
+);
+
+CREATE TABLE public.review_document_members (
+  document_id uuid NOT NULL REFERENCES public.review_documents(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role text NOT NULL CHECK (role IN ('maker', 'checker')),
+  PRIMARY KEY (document_id, user_id, role)
+);
+
+CREATE TABLE public.review_document_transition_events (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  document_id uuid NOT NULL REFERENCES public.review_documents(id) ON DELETE RESTRICT,
+  from_state text NOT NULL,
+  to_state text NOT NULL,
+  event text NOT NULL CHECK (event IN ('submit', 'return', 'approve', 'complete')),
+  actor_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  actor_role text NOT NULL CHECK (actor_role IN ('maker', 'checker')),
+  reason text NOT NULL DEFAULT '' CHECK (char_length(reason) <= 2000),
+  idempotency_key text NOT NULL CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  expected_version bigint NOT NULL CHECK (expected_version > 0),
+  entity_version bigint NOT NULL CHECK (entity_version > 0),
+  payload_checksum text NOT NULL CHECK (char_length(payload_checksum) = 32),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (document_id, idempotency_key)
+);
+
+CREATE INDEX review_document_transition_events_document_idx
+  ON public.review_document_transition_events (document_id, id);
+
+ALTER TABLE public.review_documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.review_document_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.review_document_transition_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY review_documents_member_read
+  ON public.review_documents FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.review_document_members member
+    WHERE member.document_id = review_documents.id
+      AND member.user_id = (SELECT auth.uid())
+  ));
+
+CREATE POLICY review_document_members_self_read
+  ON public.review_document_members FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY review_document_events_member_read
+  ON public.review_document_transition_events FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1
+    FROM public.review_document_members member
+    WHERE member.document_id = review_document_transition_events.document_id
+      AND member.user_id = (SELECT auth.uid())
+  ));
+
+REVOKE ALL ON public.review_documents FROM anon, authenticated;
+REVOKE ALL ON public.review_document_members FROM anon, authenticated;
+REVOKE ALL ON public.review_document_transition_events FROM anon, authenticated;
+GRANT SELECT ON public.review_documents TO authenticated;
+GRANT SELECT ON public.review_document_members TO authenticated;
+GRANT SELECT ON public.review_document_transition_events TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.review_document_snapshot(
+  p_document_id uuid,
+  p_idempotent boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object(
+    'documentId', document.id,
+    'status', document.status,
+    'makerId', document.maker_id,
+    'checkerId', document.checker_id,
+    'rowVersion', document.row_version::text,
+    'submittedPayloadChecksum', document.submitted_payload_checksum,
+    'updatedAt', document.updated_at,
+    'idempotent', p_idempotent
+  )
+  FROM public.review_documents document
+  WHERE document.id = p_document_id
+$$;
+
+CREATE OR REPLACE FUNCTION public.guard_review_document_transition()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF OLD.payload IS DISTINCT FROM NEW.payload
+     AND OLD.status NOT IN ('draft', 'returned') THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_PAYLOAD_FROZEN' USING ERRCODE = '55000';
+  END IF;
+
+  IF (
+       OLD.status IS DISTINCT FROM NEW.status
+       OR OLD.checker_id IS DISTINCT FROM NEW.checker_id
+       OR OLD.submitted_payload IS DISTINCT FROM NEW.submitted_payload
+       OR OLD.submitted_payload_checksum IS DISTINCT FROM NEW.submitted_payload_checksum
+       OR OLD.row_version IS DISTINCT FROM NEW.row_version
+     )
+     AND current_setting('app.review_transition_document_id', true)
+       IS DISTINCT FROM OLD.id::text THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_DIRECT_TRANSITION_FORBIDDEN' USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.guard_review_document_transition() FROM PUBLIC;
+
+CREATE TRIGGER review_document_transition_fence
+BEFORE UPDATE ON public.review_documents
+FOR EACH ROW EXECUTE FUNCTION public.guard_review_document_transition();
+
+CREATE OR REPLACE FUNCTION public.guard_review_document_event_append_only()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RAISE EXCEPTION 'REVIEW_DOCUMENT_EVENT_APPEND_ONLY' USING ERRCODE = '55000';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.guard_review_document_event_append_only() FROM PUBLIC;
+
+CREATE TRIGGER review_document_event_append_only
+BEFORE UPDATE OR DELETE ON public.review_document_transition_events
+FOR EACH ROW EXECUTE FUNCTION public.guard_review_document_event_append_only();
+
+CREATE TRIGGER review_document_event_no_truncate
+BEFORE TRUNCATE ON public.review_document_transition_events
+FOR EACH STATEMENT EXECUTE FUNCTION public.guard_review_document_event_append_only();
+
+CREATE OR REPLACE FUNCTION public.transition_review_document(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_document_id uuid;
+  v_actor_id uuid := auth.uid();
+  v_transition_event text := nullif(btrim(request ->> 'event'), '');
+  v_idempotency_key text := nullif(btrim(request ->> 'idempotencyKey'), '');
+  v_reason text := coalesce(btrim(request ->> 'reason'), '');
+  v_expected_version bigint;
+  v_actor_role text;
+  v_target_state text;
+  v_payload_checksum text;
+  document public.review_documents%ROWTYPE;
+  existing_event public.review_document_transition_events%ROWTYPE;
+BEGIN
+  IF v_actor_id IS NULL OR jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_UNAUTHENTICATED' USING ERRCODE = '42501';
+  END IF;
+
+  v_document_id := (request ->> 'documentId')::uuid;
+  v_expected_version := (request ->> 'expectedVersion')::bigint;
+  IF v_document_id IS NULL
+     OR v_expected_version IS NULL
+     OR v_transition_event IS NULL
+     OR v_idempotency_key IS NULL
+     OR char_length(v_idempotency_key) NOT BETWEEN 8 AND 200
+     OR char_length(v_reason) > 2000
+     OR v_expected_version < 1 THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_TRANSITION_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO document
+  FROM public.review_documents candidate
+  WHERE candidate.id = v_document_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT * INTO existing_event
+  FROM public.review_document_transition_events event_record
+  WHERE event_record.document_id = v_document_id
+    AND event_record.idempotency_key = v_idempotency_key;
+  IF FOUND THEN
+    IF existing_event.event <> v_transition_event
+       OR existing_event.actor_id <> v_actor_id
+       OR existing_event.reason <> v_reason
+       OR existing_event.expected_version <> v_expected_version THEN
+      RAISE EXCEPTION 'REVIEW_DOCUMENT_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+    END IF;
+    RETURN public.review_document_snapshot(v_document_id, true);
+  END IF;
+
+  IF document.row_version <> v_expected_version THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_STALE_VERSION' USING ERRCODE = '40001';
+  END IF;
+
+  SELECT member.role INTO v_actor_role
+  FROM public.review_document_members member
+  WHERE member.document_id = v_document_id
+    AND member.user_id = v_actor_id
+    AND member.role = CASE WHEN v_transition_event = 'submit' THEN 'maker' ELSE 'checker' END;
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_ROLE_FORBIDDEN' USING ERRCODE = '42501';
+  END IF;
+
+  v_payload_checksum := md5(document.payload::text);
+  CASE
+    WHEN v_transition_event = 'submit'
+      AND document.status IN ('draft', 'returned')
+      AND v_actor_role = 'maker'
+      AND document.maker_id = v_actor_id THEN
+        v_target_state := 'submitted';
+    WHEN v_transition_event = 'return'
+      AND document.status = 'submitted'
+      AND v_actor_role = 'checker'
+      AND document.maker_id <> v_actor_id
+      AND v_reason <> '' THEN
+        v_target_state := 'returned';
+    WHEN v_transition_event = 'approve'
+      AND document.status = 'submitted'
+      AND v_actor_role = 'checker'
+      AND document.maker_id <> v_actor_id
+      AND document.submitted_payload = document.payload
+      AND document.submitted_payload_checksum = v_payload_checksum THEN
+        v_target_state := 'approved';
+    WHEN v_transition_event = 'complete'
+      AND document.status = 'approved'
+      AND v_actor_role = 'checker'
+      AND document.maker_id <> v_actor_id THEN
+        v_target_state := 'completed';
+    ELSE
+      RAISE EXCEPTION 'REVIEW_DOCUMENT_TRANSITION_FORBIDDEN' USING ERRCODE = '55000';
+  END CASE;
+
+  PERFORM set_config('app.review_transition_document_id', document.id::text, true);
+  UPDATE public.review_documents
+  SET status = v_target_state,
+      checker_id = CASE
+        WHEN v_transition_event IN ('return', 'approve', 'complete') THEN v_actor_id
+        ELSE NULL
+      END,
+      submitted_payload = CASE
+        WHEN v_transition_event = 'submit' THEN payload
+        WHEN v_transition_event = 'return' THEN NULL
+        ELSE submitted_payload
+      END,
+      submitted_payload_checksum = CASE
+        WHEN v_transition_event = 'submit' THEN v_payload_checksum
+        WHEN v_transition_event = 'return' THEN NULL
+        ELSE submitted_payload_checksum
+      END,
+      row_version = row_version + 1,
+      updated_at = now()
+  WHERE id = document.id;
+
+  INSERT INTO public.review_document_transition_events (
+    document_id, from_state, to_state, event, actor_id, actor_role,
+    reason, idempotency_key, expected_version, entity_version, payload_checksum
+  ) VALUES (
+    document.id, document.status, v_target_state, v_transition_event, v_actor_id, v_actor_role,
+    v_reason, v_idempotency_key, v_expected_version,
+    v_expected_version + 1, v_payload_checksum
+  );
+
+  RETURN public.review_document_snapshot(document.id, false);
+EXCEPTION
+  WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_TRANSITION_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.review_document_snapshot(uuid, boolean)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.transition_review_document(jsonb)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.transition_review_document(jsonb) TO authenticated;
+
+-- Application intake code owns document/member creation. Do not grant authenticated
+-- users direct INSERT/UPDATE/DELETE rights merely to make this reference executable.

--- a/docs/examples/maker-checker-workflow-bridge.sql
+++ b/docs/examples/maker-checker-workflow-bridge.sql
@@ -1,0 +1,306 @@
+-- Optional application migration applied after maker-checker-state-machine.sql.
+-- It atomically appends workflow intent. A trusted service-role dispatcher
+-- starts SupaCloud Durable Workflows after commit with the stored run ID.
+
+CREATE TABLE public.review_document_workflow_outbox (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  transition_event_id bigint NOT NULL UNIQUE
+    REFERENCES public.review_document_transition_events(id) ON DELETE RESTRICT,
+  document_id uuid NOT NULL
+    REFERENCES public.review_documents(id) ON DELETE RESTRICT,
+  workflow_run_id uuid NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  workflow_name text NOT NULL,
+  workflow_version text NOT NULL,
+  first_step_key text NOT NULL,
+  entity_version bigint NOT NULL CHECK (entity_version > 0),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE public.review_document_workflow_dispatches (
+  outbox_id bigint PRIMARY KEY
+    REFERENCES public.review_document_workflow_outbox(id) ON DELETE RESTRICT,
+  claimed_by text NOT NULL CHECK (char_length(claimed_by) BETWEEN 1 AND 120),
+  claim_token uuid NOT NULL,
+  claimed_until timestamptz NOT NULL,
+  attempts integer NOT NULL DEFAULT 1 CHECK (attempts BETWEEN 1 AND 100),
+  dispatched_at timestamptz,
+  dead_lettered_at timestamptz,
+  last_error text NOT NULL DEFAULT '' CHECK (char_length(last_error) <= 2000),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX review_document_workflow_outbox_document_idx
+  ON public.review_document_workflow_outbox (document_id, id);
+CREATE INDEX review_document_workflow_dispatch_pending_idx
+  ON public.review_document_workflow_dispatches (claimed_until, outbox_id)
+  WHERE dispatched_at IS NULL AND dead_lettered_at IS NULL;
+
+ALTER TABLE public.review_document_workflow_outbox ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.review_document_workflow_dispatches ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.review_document_workflow_outbox
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON public.review_document_workflow_dispatches
+  FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.guard_review_document_workflow_outbox_append_only()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_OUTBOX_APPEND_ONLY' USING ERRCODE = '55000';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.guard_review_document_workflow_outbox_append_only()
+  FROM PUBLIC;
+
+CREATE TRIGGER review_document_workflow_outbox_append_only
+BEFORE UPDATE OR DELETE ON public.review_document_workflow_outbox
+FOR EACH ROW EXECUTE FUNCTION public.guard_review_document_workflow_outbox_append_only();
+
+CREATE TRIGGER review_document_workflow_outbox_no_truncate
+BEFORE TRUNCATE ON public.review_document_workflow_outbox
+FOR EACH STATEMENT EXECUTE FUNCTION public.guard_review_document_workflow_outbox_append_only();
+
+CREATE OR REPLACE FUNCTION public.enqueue_review_document_workflow_intent()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_workflow_name text;
+  v_first_step_key text;
+BEGIN
+  CASE NEW.event
+    WHEN 'approve' THEN
+      v_workflow_name := 'review-document.after-approval';
+      v_first_step_key := 'render';
+    WHEN 'complete' THEN
+      v_workflow_name := 'review-document.after-completion';
+      v_first_step_key := 'archive';
+    ELSE
+      RETURN NEW;
+  END CASE;
+
+  INSERT INTO public.review_document_workflow_outbox (
+    transition_event_id, document_id, workflow_name,
+    workflow_version, first_step_key, entity_version
+  ) VALUES (
+    NEW.id, NEW.document_id, v_workflow_name,
+    '1', v_first_step_key, NEW.entity_version
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enqueue_review_document_workflow_intent()
+  FROM PUBLIC;
+
+CREATE TRIGGER review_document_workflow_handoff
+AFTER INSERT ON public.review_document_transition_events
+FOR EACH ROW EXECUTE FUNCTION public.enqueue_review_document_workflow_intent();
+
+CREATE OR REPLACE FUNCTION public.claim_review_document_workflow(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_worker_id text;
+  v_lease_seconds integer;
+  v_claim_token uuid := gen_random_uuid();
+  v_candidate public.review_document_workflow_outbox%ROWTYPE;
+BEGIN
+  IF auth.role() <> 'service_role'
+     OR jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_CLAIM_FORBIDDEN' USING ERRCODE = '42501';
+  END IF;
+
+  v_worker_id := nullif(btrim(request ->> 'workerId'), '');
+  v_lease_seconds := coalesce((request ->> 'leaseSeconds')::integer, 300);
+  IF v_worker_id IS NULL
+     OR char_length(v_worker_id) > 120
+     OR v_lease_seconds NOT BETWEEN 30 AND 900 THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_CLAIM_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.review_document_workflow_dispatches dispatch
+  SET dead_lettered_at = now(),
+      last_error = CASE
+        WHEN dispatch.last_error = '' THEN 'maximum dispatch attempts reached'
+        ELSE dispatch.last_error
+      END,
+      updated_at = now()
+  WHERE dispatch.dispatched_at IS NULL
+    AND dispatch.dead_lettered_at IS NULL
+    AND dispatch.attempts >= 100
+    AND dispatch.claimed_until <= now();
+
+  SELECT outbox.* INTO v_candidate
+  FROM public.review_document_workflow_outbox outbox
+  LEFT JOIN public.review_document_workflow_dispatches dispatch
+    ON dispatch.outbox_id = outbox.id
+  WHERE dispatch.dispatched_at IS NULL
+    AND dispatch.dead_lettered_at IS NULL
+    AND (dispatch.outbox_id IS NULL OR dispatch.claimed_until <= now())
+  ORDER BY outbox.id
+  FOR UPDATE OF outbox SKIP LOCKED
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN NULL;
+  END IF;
+
+  INSERT INTO public.review_document_workflow_dispatches (
+    outbox_id, claimed_by, claim_token, claimed_until
+  ) VALUES (
+    v_candidate.id, v_worker_id, v_claim_token,
+    now() + make_interval(secs => v_lease_seconds)
+  )
+  ON CONFLICT (outbox_id) DO UPDATE
+  SET claimed_by = EXCLUDED.claimed_by,
+      claim_token = EXCLUDED.claim_token,
+      claimed_until = EXCLUDED.claimed_until,
+      attempts = public.review_document_workflow_dispatches.attempts + 1,
+      last_error = '',
+      updated_at = now()
+  WHERE public.review_document_workflow_dispatches.dispatched_at IS NULL
+    AND public.review_document_workflow_dispatches.dead_lettered_at IS NULL
+    AND public.review_document_workflow_dispatches.claimed_until <= now();
+
+  IF NOT FOUND THEN
+    RETURN NULL;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'outboxId', v_candidate.id::text,
+    'claimToken', v_claim_token,
+    'runId', v_candidate.workflow_run_id,
+    'workflowName', v_candidate.workflow_name,
+    'workflowVersion', v_candidate.workflow_version,
+    'firstStepKey', v_candidate.first_step_key,
+    'input', jsonb_build_object(
+      'documentId', v_candidate.document_id,
+      'transitionEventId', v_candidate.transition_event_id::text,
+      'entityVersion', v_candidate.entity_version::text
+    )
+  );
+EXCEPTION
+  WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_CLAIM_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.complete_review_document_workflow_dispatch(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_outbox_id bigint;
+  v_claim_token uuid;
+  v_worker_id text;
+BEGIN
+  IF auth.role() <> 'service_role'
+     OR jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_COMPLETE_FORBIDDEN' USING ERRCODE = '42501';
+  END IF;
+
+  v_outbox_id := (request ->> 'outboxId')::bigint;
+  v_claim_token := (request ->> 'claimToken')::uuid;
+  v_worker_id := nullif(btrim(request ->> 'workerId'), '');
+  IF v_outbox_id < 1 OR v_claim_token IS NULL OR v_worker_id IS NULL THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_COMPLETE_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.review_document_workflow_dispatches dispatch
+  SET dispatched_at = now(),
+      claimed_until = now(),
+      updated_at = now()
+  WHERE dispatch.outbox_id = v_outbox_id
+    AND dispatch.claim_token = v_claim_token
+    AND dispatch.claimed_by = v_worker_id
+    AND dispatch.dispatched_at IS NULL
+    AND dispatch.dead_lettered_at IS NULL
+    AND dispatch.claimed_until > now();
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_CLAIM_STALE' USING ERRCODE = '40001';
+  END IF;
+
+  RETURN jsonb_build_object('outboxId', v_outbox_id::text, 'dispatched', true);
+EXCEPTION
+  WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_COMPLETE_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.release_review_document_workflow_dispatch(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_outbox_id bigint;
+  v_claim_token uuid;
+  v_worker_id text;
+  v_error_message text;
+  v_terminal boolean;
+  v_dead_lettered boolean;
+BEGIN
+  IF auth.role() <> 'service_role'
+     OR jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_RELEASE_FORBIDDEN' USING ERRCODE = '42501';
+  END IF;
+
+  v_outbox_id := (request ->> 'outboxId')::bigint;
+  v_claim_token := (request ->> 'claimToken')::uuid;
+  v_worker_id := nullif(btrim(request ->> 'workerId'), '');
+  v_error_message := coalesce(request ->> 'errorMessage', '');
+  v_terminal := coalesce((request ->> 'terminal')::boolean, false);
+  IF v_outbox_id < 1
+     OR v_claim_token IS NULL
+     OR v_worker_id IS NULL
+     OR char_length(v_error_message) > 2000 THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_RELEASE_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.review_document_workflow_dispatches dispatch
+  SET claimed_until = now(),
+      last_error = v_error_message,
+      dead_lettered_at = CASE
+        WHEN v_terminal OR dispatch.attempts >= 100 THEN now()
+        ELSE NULL
+      END,
+      updated_at = now()
+  WHERE dispatch.outbox_id = v_outbox_id
+    AND dispatch.claim_token = v_claim_token
+    AND dispatch.claimed_by = v_worker_id
+    AND dispatch.dispatched_at IS NULL
+    AND dispatch.dead_lettered_at IS NULL
+  RETURNING dispatch.dead_lettered_at IS NOT NULL INTO v_dead_lettered;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_CLAIM_STALE' USING ERRCODE = '40001';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'outboxId', v_outbox_id::text,
+    'released', true,
+    'deadLettered', v_dead_lettered
+  );
+EXCEPTION
+  WHEN invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'REVIEW_DOCUMENT_WORKFLOW_RELEASE_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_review_document_workflow(jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.complete_review_document_workflow_dispatch(jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.release_review_document_workflow_dispatch(jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_review_document_workflow(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.complete_review_document_workflow_dispatch(jsonb)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.release_review_document_workflow_dispatch(jsonb)
+  TO service_role;
+
+-- Dispatcher sequence:
+-- 1. claim_review_document_workflow()
+-- 2. supacloud_workflow_start() with the returned fixed runId and input
+-- 3. complete_review_document_workflow_dispatch()
+-- A crash after step 2 retries the same runId, so workflow start is idempotent.

--- a/docs/examples/maker-checker-workflow-dispatcher.ts
+++ b/docs/examples/maker-checker-workflow-dispatcher.ts
@@ -1,0 +1,74 @@
+import { createClient } from "@supabase/supabase-js";
+import { createSupaCloudClient } from "@supacloud/js";
+
+type WorkflowClaim = {
+  outboxId: string;
+  claimToken: string;
+  runId: string;
+  workflowName: string;
+  workflowVersion: string;
+  firstStepKey: string;
+  input: Record<string, unknown>;
+};
+
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+const supacloud = createSupaCloudClient({
+  supabase,
+  managementApiUrl: process.env.SUPACLOUD_MANAGEMENT_URL!,
+  projectRef: process.env.SUPACLOUD_PROJECT_REF!,
+});
+const workerId = process.env.WORKER_ID || `review-workflow-${crypto.randomUUID()}`;
+
+async function invokeWorkflowBridgeRpc<T>(
+  name: string,
+  request: Record<string, unknown>,
+): Promise<T> {
+  const { data, error } = await supabase.rpc(name, { request });
+  if (error) throw error;
+  return data as T;
+}
+
+export async function dispatchOne(): Promise<boolean> {
+  const claim = await invokeWorkflowBridgeRpc<WorkflowClaim | null>(
+    "claim_review_document_workflow",
+    { workerId, leaseSeconds: 300 },
+  );
+  if (!claim) return false;
+
+  try {
+    await supacloud.workflows.start({
+      runId: claim.runId,
+      workflowName: claim.workflowName,
+      workflowVersion: claim.workflowVersion,
+      firstStepKey: claim.firstStepKey,
+      input: claim.input,
+      maxAttempts: 5,
+    });
+    await invokeWorkflowBridgeRpc("complete_review_document_workflow_dispatch", {
+      outboxId: claim.outboxId,
+      claimToken: claim.claimToken,
+      workerId,
+    });
+    return true;
+  } catch {
+    try {
+      await invokeWorkflowBridgeRpc("release_review_document_workflow_dispatch", {
+        outboxId: claim.outboxId,
+        claimToken: claim.claimToken,
+        workerId,
+        errorMessage: "workflow start or acknowledgement failed",
+        terminal: false,
+      });
+    } catch {
+      // Completion may have committed before its response was lost.
+    }
+    return false;
+  }
+}
+
+// Run dispatchOne() from a trusted Scheduled Function or long-running Worker.
+// A fixed runId makes retry safe when workflow start committed but its response
+// was lost. Never bundle this file into a browser or ship the service-role key.

--- a/docs/powersync-local-first.md
+++ b/docs/powersync-local-first.md
@@ -1,0 +1,280 @@
+# PowerSync Local-First Integration
+
+PowerSync is the selected external Local-First integration for SupaCloud
+applications that require a durable local SQLite database, offline writes, and
+recovery after weak or unavailable networks. SupaCloud does not start, stop,
+create, or delete PowerSync replication resources automatically in this phase.
+
+Use the official PowerSync Supabase integration and self-hosting documentation
+for the exact release-specific service configuration:
+
+- <https://docs.powersync.com/integrations/supabase/guide>
+- <https://docs.powersync.com/configuration/powersync-service/self-hosted-instances>
+
+## Responsibility boundary
+
+SupaCloud owns PostgreSQL, Auth, RLS, application RPCs, Logical Replication
+prerequisites, and read-only operational evidence. PowerSync owns the local
+SQLite client database, download synchronization, and the client upload queue.
+The application owns synchronization rules, mutation APIs, conflict semantics,
+and domain state transitions.
+
+PowerSync synchronization rules determine which rows are downloaded. They do
+not authorize uploads. Every uploaded mutation must return through a SupaCloud
+Data API or application RPC, where RLS and business transition checks run again.
+Never place a service-role key or replication credential in a client.
+
+## Self-hosted deployment baseline
+
+Run PowerSync as a separately versioned service, not inside the Management API
+or an Edge Function. A production deployment needs four explicit inputs:
+
+1. a direct PostgreSQL replication connection to the SupaCloud project;
+2. a separate PowerSync bucket storage database;
+3. a reviewed Sync Streams file scoped by authenticated tenant membership; and
+4. JWKS-based client token verification with a pinned audience.
+
+The pinned PowerSync release owns its image and configuration schema. Pin the
+container image by immutable digest, mount `service.yaml` and
+`sync-config.yaml` read-only, and inject only `PS_`-prefixed secrets from the
+deployment secret store. The following is a shape reference, not a substitute
+for validating the configuration against the pinned release:
+
+```yaml
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_SOURCE_DATABASE_URI
+      sslmode: verify-full
+
+storage:
+  type: postgresql
+  uri: !env PS_BUCKET_STORAGE_URI
+  sslmode: verify-full
+
+port: 80
+sync_config:
+  path: /config/sync-config.yaml
+
+client_auth:
+  jwks_uri: !env PS_JWKS_URI
+  audience:
+    - supacloud-powersync
+```
+
+Bucket storage is not the replication source. Use a separate database and
+dedicated owner; a separate PostgreSQL server is preferred in production to
+keep synchronization load and failure recovery isolated. Put the API behind
+the platform TLS ingress, restrict operational endpoints to the internal
+network, and monitor service restarts, source lag, bucket storage capacity,
+upload failures, and retained WAL.
+
+Roll out in this order: prepare the source role and publication, deploy bucket
+storage, validate Sync Streams against a non-production tenant, start the
+pinned PowerSync service, read back its exact slot from the SupaCloud
+replication endpoint, then enable token issuance for a small client cohort.
+SupaCloud never creates the slot on the service's behalf.
+
+## Readiness inspection
+
+Project administrators can inspect the existing read-only endpoint:
+
+```text
+GET /v1/projects/:ref/database/replication
+```
+
+The endpoint preserves `replication_slots` and `publications`, and adds:
+
+- `replication_settings`: `wal_level`, `max_wal_senders`,
+  `max_replication_slots`, `max_slot_wal_keep_size`, `wal_keep_size`,
+  `max_wal_size`, `checkpoint_timeout`, and
+  `idle_replication_slot_timeout` when supported by the server;
+- `replication_setting_details`, including units, configuration source, and
+  whether a restart is still pending;
+- WAL sender `configured`, `active`, and `free` capacity from
+  `pg_stat_replication`;
+- slot `retained_wal_bytes`, `unconfirmed_wal_bytes`, `wal_status`,
+  `safe_wal_size`, inactivity, failover, conflict, and invalidation evidence;
+- publication table count, DML flags, and tables missing a usable replica
+  identity;
+- `powersync_readiness`, with provisioning blockers and operational warnings.
+
+`powersync_readiness.ready` is a provisioning preflight. It means the database
+currently has logical WAL, one free WAL sender, one free replication slot, and
+an explicit `powersync` publication with tables, INSERT/UPDATE/DELETE enabled,
+and usable replica identity. It does not prove that an already-running
+PowerSync instance is healthy, or that authentication, Sync Streams, network
+routing, and client upload handlers are correct.
+
+Blocker codes are:
+
+- `WAL_LEVEL_NOT_LOGICAL`
+- `WAL_SENDERS_DISABLED`
+- `NO_FREE_WAL_SENDER`
+- `REPLICATION_SLOTS_DISABLED`
+- `NO_FREE_REPLICATION_SLOT`
+- `NO_PUBLISHED_TABLES`
+- `POWERSYNC_PUBLICATION_MISSING`
+- `POWERSYNC_PUBLICATION_EMPTY`
+- `POWERSYNC_PUBLICATION_DML_INCOMPLETE`
+- `POWERSYNC_REPLICA_IDENTITY_INCOMPLETE`
+
+Warning codes are:
+
+- `POWERSYNC_PUBLICATION_ALL_TABLES`
+- `INVALID_LOGICAL_SLOTS`
+- `LOGICAL_SLOT_WAL_UNRESERVED`
+- `LOGICAL_SLOT_SAFE_WAL_EXHAUSTED`
+- `SLOT_WAL_KEEP_SIZE_UNBOUNDED`
+- `SLOT_WAL_KEEP_SIZE_ZERO`
+- `REPLICATION_SETTINGS_PENDING_RESTART`
+
+The Docker self-host baseline configures `wal_level=logical`,
+`max_wal_senders=10`, and `max_replication_slots=10`. Realtime, pipelines, and
+other CDC consumers share that cluster-level slot capacity, so do not allocate
+the final free slot without a capacity and rollback plan.
+
+Treat `wal_status=unreserved`, `wal_status=lost`, a non-null
+`invalidation_reason`, or `safe_wal_size=0` as an incident. A lost slot cannot
+resume from removed WAL; stop the affected deployment, determine the exact
+recorded slot, and follow the pinned PowerSync resnapshot procedure. Do not
+drop and recreate a slot merely to clear the warning.
+
+Alert on a rising `unconfirmed_wal_bytes`, falling `safe_wal_size`, an inactive
+slot that still retains WAL, and any requested replication setting with
+`pending_restart=true`. Bytes are returned as decimal strings so JavaScript
+does not lose PostgreSQL `bigint` precision.
+
+## Database preparation
+
+Run database mutations through a reviewed application migration or an explicit
+operator procedure. Do not expose replication management through browser or
+general-purpose application APIs.
+
+Use a dedicated login role with `REPLICATION BYPASSRLS`, database `CONNECT`,
+schema `USAGE`, and `SELECT` only on tables that PowerSync must snapshot. Do not
+reuse `supabase_admin`, a service role, or an application owner. Keep its
+password in the PowerSync secret store, not Git or migration files. Because
+the replication role bypasses RLS, publication and Sync Streams allowlists are
+mandatory data-exposure boundaries for downloads.
+
+Create a dedicated publication containing an explicit allowlist of tables:
+
+```sql
+CREATE PUBLICATION powersync FOR TABLE
+  public.eln_entries,
+  public.eln_observations,
+  public.eln_attachments;
+```
+
+For tables whose updates or deletes must include the previous row identity,
+configure an appropriate primary key and replica identity. Avoid
+`FOR ALL TABLES`; replication bypasses application RLS and the sync service can
+observe every row in its publication before applying client-specific rules.
+
+Before adding a table, verify that it has a primary key or an explicit replica
+identity and that every published column needed by Sync Streams remains
+available. The readiness endpoint treats default replica identity without a
+primary key, `REPLICA IDENTITY NOTHING`, and an invalid identity index as
+incomplete.
+
+Let the selected, pinned PowerSync deployment own its configured slot. Record
+the exact slot name, publication, PowerSync release, database, and deployment
+identity before activation. Never guess a slot name during cleanup.
+
+## Auth and upload path
+
+The client authenticates with SupaCloud Auth and obtains a PowerSync token from
+a trusted backend endpoint. That endpoint maps the authenticated user to a
+tenant, project, and permitted sync scope. Sync rules should mirror the same
+membership model used by RLS, but RLS remains authoritative for writes.
+
+Uploaded changes should call narrow RPCs. For business state changes, use the
+pattern in [Application Business State Machines](./business-state-machines.md):
+
+```text
+local outbox event
+  -> authenticated application RPC
+  -> RLS and membership check
+  -> row lock, expected version, idempotency, transition matrix
+  -> PostgreSQL commit
+  -> Logical Replication back to every authorized client
+```
+
+An offline approval is only an `approval_requested` outbox item. The local
+domain record must not become `approved` until the server accepts the RPC and
+the confirmed state returns through synchronization.
+
+## ELN conflict model
+
+Do not apply one generic last-write-wins policy to laboratory data.
+
+| Data | Recommended merge rule |
+| --- | --- |
+| Raw observations and instrument readings | Append-only, client UUID plus idempotency key |
+| Corrections | New row with `supersedes_id`; never overwrite the original |
+| Draft narrative fields | Field-level merge or explicitly accepted last-write-wins |
+| Attachments | Durable outbox, content checksum, immutable object identity |
+| Assignment | Expected row version and server-authoritative transition |
+| Approval, signing, delivery | Online server confirmation only |
+
+Every offline-created row should carry a client-generated UUID, `device_id`,
+local sequence, capture timestamp, server receipt timestamp, and idempotency
+key. Preserve both device and server time because field devices can have an
+incorrect clock.
+
+## Schema evolution
+
+Use expand-contract migrations because old mobile clients and the PowerSync
+service may continue reading the previous shape during rollout:
+
+1. add nullable columns, new tables, indexes, and replica identity first;
+2. add the table to the explicit `powersync` publication only after grants and
+   Sync Streams are ready;
+3. deploy backward-compatible upload RPCs and Sync Streams;
+4. deploy clients that can read both shapes and write only the new contract;
+5. backfill in bounded batches and observe replication lag;
+6. stop old writes, enforce new constraints, then remove obsolete columns in a
+   later release.
+
+Never rename or drop a published column in the same release that introduces
+its replacement. Remove a table from Sync Streams and the publication only
+after supported clients no longer depend on it.
+
+## Verification before adoption
+
+Validate with production-shaped but non-production data:
+
+1. Initial snapshot and incremental download are scoped to one authorized
+   project.
+2. A removed member loses token issuance and cannot upload; synchronized local
+   data follows the application's revocation policy.
+3. Twenty-four hours offline can enqueue, restart, and later upload without
+   duplication.
+4. Two devices editing the same draft produce the documented conflict result.
+5. Duplicate mutation delivery is idempotent.
+6. An offline Maker cannot approve their own record or bypass expected version.
+7. Slot retained WAL remains bounded during a stopped or disconnected service.
+8. Schema migrations are applied in an expand-contract order compatible with
+   the pinned PowerSync release and existing clients.
+9. A forced slot interruption produces a visible warning and follows the
+   documented resnapshot path without deleting an unrelated slot.
+
+## Disable and cleanup
+
+Cleanup is an explicit operator action:
+
+1. Stop issuing new PowerSync tokens.
+2. Drain or intentionally abandon client outboxes according to the incident or
+   retirement plan.
+3. Stop the exact PowerSync deployment and confirm it will not reconnect.
+4. Read back the configured slot, `active` state, restart LSN, and retained WAL
+   bytes from the replication endpoint.
+5. Back up required audit and application data.
+6. Drop only the recorded inactive slot and publication using an approved
+   database procedure.
+7. Read back slot/publication inventory and WAL retention after cleanup.
+
+SupaCloud intentionally does not automate steps 3 through 6 because deleting a
+live slot can break synchronization, while retaining an abandoned slot can
+exhaust disk through unbounded WAL retention.

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -68,6 +68,10 @@ import {
 } from "../services/project-database-config.service";
 import { publicScheduledFunctionProjectConfig } from "../utils/scheduled-function-config";
 import { normalizeOAuthServerConfig } from "../utils/project-config";
+import {
+  type ReplicationSettingRow,
+  summarizePowerSyncReadiness,
+} from "../services/replication-readiness";
 
 /** Map PostgreSQL column types to TypeScript types */
 function pgTypeToTs(udtName: string, dataType: string): string {
@@ -1352,15 +1356,110 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       const { getProjectDb, resolveDbName } = await import("../db");
       const dbName = await resolveDbName(params.ref);
       const db = getProjectDb(dbName);
-      const slots = await db`
-        SELECT slot_name, slot_type, active, restart_lsn
-        FROM pg_replication_slots
-      `;
-      const publications = await db`
-        SELECT pubname, pubinsert, pubupdate, pubdelete, pubtruncate
-        FROM pg_publication
-      `;
-      return { replication_slots: slots, publications };
+      const [slots, publications, replicationSettings, walSenderUsage] =
+        await Promise.all([
+          db`
+            SELECT slot_name, plugin, slot_type, database, active,
+                   restart_lsn, confirmed_flush_lsn,
+                   CASE
+                     WHEN restart_lsn IS NULL THEN NULL
+                     ELSE pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::text
+                   END AS retained_wal_bytes,
+                   CASE
+                     WHEN confirmed_flush_lsn IS NULL THEN NULL
+                     ELSE pg_wal_lsn_diff(
+                       pg_current_wal_lsn(), confirmed_flush_lsn
+                     )::text
+                   END AS unconfirmed_wal_bytes,
+                   to_jsonb(replication_slot) ->> 'wal_status' AS wal_status,
+                   to_jsonb(replication_slot) ->> 'safe_wal_size' AS safe_wal_size,
+                   to_jsonb(replication_slot) ->> 'inactive_since' AS inactive_since,
+                   to_jsonb(replication_slot) ->> 'conflicting' AS conflicting,
+                   to_jsonb(replication_slot) ->> 'invalidation_reason' AS invalidation_reason,
+                   to_jsonb(replication_slot) ->> 'failover' AS failover,
+                   to_jsonb(replication_slot) ->> 'synced' AS synced
+            FROM pg_replication_slots replication_slot
+            ORDER BY slot_name
+          `,
+          db`
+            SELECT publication.pubname,
+                   publication.puballtables,
+                   publication.pubinsert,
+                   publication.pubupdate,
+                   publication.pubdelete,
+                   publication.pubtruncate,
+                   (
+                     SELECT count(*)::integer
+                     FROM pg_publication_tables published_table
+                     WHERE published_table.pubname = publication.pubname
+                   ) AS table_count,
+                   (
+                     SELECT count(*)::integer
+                     FROM pg_publication_tables published_table
+                     JOIN pg_namespace namespace
+                       ON namespace.nspname = published_table.schemaname
+                     JOIN pg_class relation
+                       ON relation.relnamespace = namespace.oid
+                      AND relation.relname = published_table.tablename
+                     WHERE published_table.pubname = publication.pubname
+                       AND (
+                         relation.relreplident = 'n'
+                         OR (
+                           relation.relreplident = 'i'
+                           AND NOT EXISTS (
+                             SELECT 1
+                             FROM pg_index relation_index
+                             WHERE relation_index.indrelid = relation.oid
+                               AND relation_index.indisreplident
+                           )
+                         )
+                         OR (
+                           relation.relreplident = 'd'
+                           AND NOT EXISTS (
+                             SELECT 1
+                             FROM pg_index relation_index
+                             WHERE relation_index.indrelid = relation.oid
+                               AND relation_index.indisprimary
+                           )
+                         )
+                       )
+                   ) AS replica_identity_missing_table_count
+            FROM pg_publication publication
+            ORDER BY publication.pubname
+          `,
+          db`
+            SELECT name, setting, unit, source, pending_restart
+            FROM pg_settings
+            WHERE name IN (
+              'wal_level', 'max_wal_senders', 'max_replication_slots',
+              'max_slot_wal_keep_size', 'wal_keep_size', 'max_wal_size',
+              'checkpoint_timeout', 'idle_replication_slot_timeout'
+            )
+            ORDER BY name
+          `,
+          db`
+            SELECT count(*)::integer AS active_wal_senders
+            FROM pg_stat_replication
+          `,
+        ]);
+      const activeWalSenders = Number(walSenderUsage[0]?.active_wal_senders ?? 0);
+      return {
+        replication_slots: slots,
+        publications,
+        replication_settings: Object.fromEntries(
+          replicationSettings.map((row: ReplicationSettingRow) => [
+            String(row.name),
+            String(row.setting),
+          ]),
+        ),
+        replication_setting_details: replicationSettings,
+        powersync_readiness: summarizePowerSyncReadiness({
+          settings: replicationSettings,
+          slots,
+          publications,
+          activeWalSenders,
+        }),
+      };
     },
     {
 

--- a/packages/management-api/src/services/replication-readiness.ts
+++ b/packages/management-api/src/services/replication-readiness.ts
@@ -1,0 +1,314 @@
+export interface ReplicationSettingRow {
+  name: unknown;
+  setting: unknown;
+  pending_restart?: unknown;
+}
+
+export interface ReplicationSlotRow {
+  slot_type?: unknown;
+  active?: unknown;
+  wal_status?: unknown;
+  retained_wal_bytes?: unknown;
+  unconfirmed_wal_bytes?: unknown;
+  safe_wal_size?: unknown;
+  conflicting?: unknown;
+  invalidation_reason?: unknown;
+}
+
+export interface ReplicationPublicationRow {
+  pubname?: unknown;
+  puballtables?: unknown;
+  pubinsert?: unknown;
+  pubupdate?: unknown;
+  pubdelete?: unknown;
+  table_count?: unknown;
+  replica_identity_missing_table_count?: unknown;
+}
+
+export interface PowerSyncReadiness {
+  provider: "powersync";
+  ready: boolean;
+  blockers: string[];
+  warnings: string[];
+  checks: {
+    wal_level: { ok: boolean; actual: string };
+    wal_senders: {
+      ok: boolean;
+      configured: number;
+      active: number;
+      free: number;
+    };
+    replication_slots: {
+      ok: boolean;
+      configured: number;
+      used: number;
+      free: number;
+      logical: number;
+      active_logical: number;
+    };
+    logical_slot_health: {
+      ok: boolean;
+      invalid: number;
+      wal_unreserved: number;
+      wal_lost: number;
+      safe_wal_exhausted: number;
+      max_retained_wal_bytes: string;
+      max_unconfirmed_wal_bytes: string;
+      min_safe_wal_bytes: string | null;
+    };
+    wal_retention: {
+      setting: string;
+      bounded: boolean | null;
+    };
+    pending_restart: {
+      ok: boolean;
+      settings: string[];
+    };
+    publications: {
+      ok: boolean;
+      count: number;
+      published_tables: number;
+      powersync: {
+        present: boolean;
+        all_tables: boolean;
+        table_count: number;
+        publishes_insert: boolean;
+        publishes_update: boolean;
+        publishes_delete: boolean;
+        replica_identity_missing_tables: number;
+      };
+    };
+  };
+}
+
+function nonNegativeInteger(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function trueValue(value: unknown): boolean {
+  return value === true || value === 1 || value === "1" || value === "t" || value === "true";
+}
+
+function nonNegativeBigInt(value: unknown): bigint | null {
+  const normalized = String(value ?? "");
+  if (!/^\d+$/.test(normalized)) return null;
+  try {
+    return BigInt(normalized);
+  } catch {
+    return null;
+  }
+}
+
+function extremeBigIntString(
+  values: readonly bigint[],
+  pick: (left: bigint, right: bigint) => bigint,
+): string | null {
+  return values.length > 0 ? values.reduce(pick).toString() : null;
+}
+
+function capacityReadiness(
+  settings: ReadonlyMap<string, string>,
+  slots: readonly ReplicationSlotRow[],
+  activeWalSendersInput: unknown,
+) {
+  const walLevel = settings.get("wal_level") || "unknown";
+  const maxWalSenders = nonNegativeInteger(settings.get("max_wal_senders"));
+  const activeWalSenders = nonNegativeInteger(activeWalSendersInput);
+  const freeWalSenders = Math.max(0, maxWalSenders - activeWalSenders);
+  const maxSlots = nonNegativeInteger(settings.get("max_replication_slots"));
+  const logicalSlots = slots.filter((slot) => slot.slot_type === "logical");
+  const freeSlots = Math.max(0, maxSlots - slots.length);
+  const blockers: string[] = [];
+  if (walLevel !== "logical") blockers.push("WAL_LEVEL_NOT_LOGICAL");
+  if (maxWalSenders < 1) blockers.push("WAL_SENDERS_DISABLED");
+  else if (freeWalSenders < 1) blockers.push("NO_FREE_WAL_SENDER");
+  if (maxSlots < 1) blockers.push("REPLICATION_SLOTS_DISABLED");
+  else if (freeSlots < 1) blockers.push("NO_FREE_REPLICATION_SLOT");
+  return {
+    blockers,
+    walLevel: { ok: walLevel === "logical", actual: walLevel },
+    walSenders: {
+      ok: maxWalSenders > 0 && freeWalSenders > 0,
+      configured: maxWalSenders,
+      active: activeWalSenders,
+      free: freeWalSenders,
+    },
+    replicationSlots: {
+      ok: maxSlots > 0 && freeSlots > 0,
+      configured: maxSlots,
+      used: slots.length,
+      free: freeSlots,
+      logical: logicalSlots.length,
+      active_logical: logicalSlots.filter((slot) => trueValue(slot.active)).length,
+    },
+  };
+}
+
+function logicalSlotReadiness(slots: readonly ReplicationSlotRow[]) {
+  const logicalSlots = slots.filter((slot) => slot.slot_type === "logical");
+  const invalid = logicalSlots.filter((slot) =>
+    String(slot.invalidation_reason ?? "") !== ""
+    || String(slot.wal_status ?? "") === "lost"
+    || trueValue(slot.conflicting)
+  );
+  const unreserved = logicalSlots.filter((slot) => slot.wal_status === "unreserved");
+  const lost = logicalSlots.filter((slot) => slot.wal_status === "lost");
+  const safeWalExhausted = logicalSlots.filter(
+    (slot) => nonNegativeBigInt(slot.safe_wal_size) === 0n,
+  );
+  const retained = logicalSlots.flatMap((slot) => {
+    const bytes = nonNegativeBigInt(slot.retained_wal_bytes);
+    return bytes === null ? [] : [bytes];
+  });
+  const unconfirmed = logicalSlots.flatMap((slot) => {
+    const bytes = nonNegativeBigInt(slot.unconfirmed_wal_bytes);
+    return bytes === null ? [] : [bytes];
+  });
+  const safeWalSizes = logicalSlots.flatMap((slot) => {
+    const bytes = nonNegativeBigInt(slot.safe_wal_size);
+    return bytes === null ? [] : [bytes];
+  });
+  const warnings: string[] = [];
+  if (invalid.length > 0) warnings.push("INVALID_LOGICAL_SLOTS");
+  if (unreserved.length > 0) warnings.push("LOGICAL_SLOT_WAL_UNRESERVED");
+  if (safeWalExhausted.length > 0) warnings.push("LOGICAL_SLOT_SAFE_WAL_EXHAUSTED");
+  return {
+    warnings,
+    check: {
+      ok: invalid.length === 0 && unreserved.length === 0 && safeWalExhausted.length === 0,
+      invalid: invalid.length,
+      wal_unreserved: unreserved.length,
+      wal_lost: lost.length,
+      safe_wal_exhausted: safeWalExhausted.length,
+      max_retained_wal_bytes: extremeBigIntString(
+        retained,
+        (left, right) => left > right ? left : right,
+      ) ?? "0",
+      max_unconfirmed_wal_bytes: extremeBigIntString(
+        unconfirmed,
+        (left, right) => left > right ? left : right,
+      ) ?? "0",
+      min_safe_wal_bytes: extremeBigIntString(
+        safeWalSizes,
+        (left, right) => left < right ? left : right,
+      ),
+    },
+  };
+}
+
+function walRetentionReadiness(settings: ReadonlyMap<string, string>) {
+  const setting = settings.get("max_slot_wal_keep_size") ?? "unknown";
+  const warnings: string[] = [];
+  if (setting === "-1") warnings.push("SLOT_WAL_KEEP_SIZE_UNBOUNDED");
+  if (setting === "0") warnings.push("SLOT_WAL_KEEP_SIZE_ZERO");
+  return {
+    warnings,
+    check: {
+      setting,
+      bounded: setting === "unknown" ? null : setting !== "-1",
+    },
+  };
+}
+
+function pendingRestartReadiness(settings: readonly ReplicationSettingRow[]) {
+  const pending = settings
+    .filter((setting) => trueValue(setting.pending_restart))
+    .map((setting) => String(setting.name))
+    .sort();
+  return {
+    warnings: pending.length > 0 ? ["REPLICATION_SETTINGS_PENDING_RESTART"] : [],
+    check: { ok: pending.length === 0, settings: pending },
+  };
+}
+
+function publicationReadiness(publications: readonly ReplicationPublicationRow[]) {
+  const publishedTables = publications.reduce(
+    (total, publication) => total + nonNegativeInteger(publication.table_count),
+    0,
+  );
+  const publication = publications.find(
+    (candidate) => String(candidate.pubname).toLowerCase() === "powersync",
+  );
+  const tableCount = nonNegativeInteger(publication?.table_count);
+  const missingIdentity = nonNegativeInteger(
+    publication?.replica_identity_missing_table_count,
+  );
+  const publishesInsert = trueValue(publication?.pubinsert);
+  const publishesUpdate = trueValue(publication?.pubupdate);
+  const publishesDelete = trueValue(publication?.pubdelete);
+  const blockers: string[] = [];
+  const warnings: string[] = [];
+  if (publishedTables < 1) blockers.push("NO_PUBLISHED_TABLES");
+  if (!publication) blockers.push("POWERSYNC_PUBLICATION_MISSING");
+  else {
+    if (tableCount < 1) blockers.push("POWERSYNC_PUBLICATION_EMPTY");
+    if (!publishesInsert || !publishesUpdate || !publishesDelete) {
+      blockers.push("POWERSYNC_PUBLICATION_DML_INCOMPLETE");
+    }
+    if (missingIdentity > 0) blockers.push("POWERSYNC_REPLICA_IDENTITY_INCOMPLETE");
+    if (trueValue(publication.puballtables)) warnings.push("POWERSYNC_PUBLICATION_ALL_TABLES");
+  }
+  return {
+    blockers,
+    warnings,
+    check: {
+      ok: Boolean(publication)
+        && tableCount > 0
+        && publishesInsert
+        && publishesUpdate
+        && publishesDelete
+        && missingIdentity === 0,
+      count: publications.length,
+      published_tables: publishedTables,
+      powersync: {
+        present: Boolean(publication),
+        all_tables: trueValue(publication?.puballtables),
+        table_count: tableCount,
+        publishes_insert: publishesInsert,
+        publishes_update: publishesUpdate,
+        publishes_delete: publishesDelete,
+        replica_identity_missing_tables: missingIdentity,
+      },
+    },
+  };
+}
+
+export function summarizePowerSyncReadiness(input: {
+  settings: readonly ReplicationSettingRow[];
+  slots: readonly ReplicationSlotRow[];
+  publications: readonly ReplicationPublicationRow[];
+  activeWalSenders: unknown;
+}): PowerSyncReadiness {
+  const settings = new Map(
+    input.settings.map((row) => [String(row.name), String(row.setting)]),
+  );
+  const capacity = capacityReadiness(settings, input.slots, input.activeWalSenders);
+  const slotHealth = logicalSlotReadiness(input.slots);
+  const walRetention = walRetentionReadiness(settings);
+  const pendingRestart = pendingRestartReadiness(input.settings);
+  const publications = publicationReadiness(input.publications);
+  const blockers = [...capacity.blockers, ...publications.blockers];
+  const warnings = [
+    ...publications.warnings,
+    ...slotHealth.warnings,
+    ...walRetention.warnings,
+    ...pendingRestart.warnings,
+  ];
+
+  return {
+    provider: "powersync",
+    ready: blockers.length === 0,
+    blockers,
+    warnings,
+    checks: {
+      wal_level: capacity.walLevel,
+      wal_senders: capacity.walSenders,
+      replication_slots: capacity.replicationSlots,
+      logical_slot_health: slotHealth.check,
+      wal_retention: walRetention.check,
+      pending_restart: pendingRestart.check,
+      publications: publications.check,
+    },
+  };
+}

--- a/packages/management-api/tests/unit/application-state-machine-reference.test.ts
+++ b/packages/management-api/tests/unit/application-state-machine-reference.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repositoryRoot = resolve(import.meta.dir, "../../../..");
+const migration = readFileSync(
+  resolve(repositoryRoot, "docs/examples/maker-checker-state-machine.sql"),
+  "utf8",
+);
+const machine = readFileSync(
+  resolve(repositoryRoot, "docs/examples/maker-checker-machine.ts"),
+  "utf8",
+);
+const workflowBridge = readFileSync(
+  resolve(repositoryRoot, "docs/examples/maker-checker-workflow-bridge.sql"),
+  "utf8",
+);
+const workflowDispatcher = readFileSync(
+  resolve(repositoryRoot, "docs/examples/maker-checker-workflow-dispatcher.ts"),
+  "utf8",
+);
+const managementPackage = JSON.parse(readFileSync(
+  resolve(repositoryRoot, "packages/management-api/package.json"),
+  "utf8",
+));
+
+describe("Maker-Checker application reference", () => {
+  test("keeps transition, concurrency, replay, and audit enforcement in PostgreSQL", () => {
+    expect(migration).toContain("FOR UPDATE;");
+    expect(migration).toContain("v_document_id uuid;");
+    expect(migration).not.toContain("\n  document_id uuid;");
+    expect(migration.indexOf("FOR UPDATE;")).toBeLessThan(
+      migration.indexOf("SELECT * INTO existing_event"),
+    );
+    expect(migration).toContain("REVIEW_DOCUMENT_STALE_VERSION");
+    expect(migration).toContain("REVIEW_DOCUMENT_IDEMPOTENCY_CONFLICT");
+    expect(migration).toContain("document.maker_id <> v_actor_id");
+    expect(migration).toContain("document.submitted_payload = document.payload");
+    expect(migration).toContain("document.submitted_payload_checksum = v_payload_checksum");
+    expect(migration).toContain("WHEN v_transition_event = 'submit' THEN payload");
+    expect(migration).toContain("LANGUAGE sql VOLATILE SECURITY DEFINER");
+    expect(migration).toContain("REVIEW_DOCUMENT_DIRECT_TRANSITION_FORBIDDEN");
+    expect(migration).toContain("REVIEW_DOCUMENT_EVENT_APPEND_ONLY");
+    expect(migration).toContain("BEFORE TRUNCATE");
+    expect(migration).toContain(
+      "REVOKE ALL ON FUNCTION public.guard_review_document_transition() FROM PUBLIC",
+    );
+    expect(migration).toContain("UNIQUE (document_id, idempotency_key)");
+    expect(migration).not.toMatch(/GRANT\s+(?:INSERT|UPDATE|DELETE).*authenticated/i);
+  });
+
+  test("keeps XState as a UI projection with the same state vocabulary", () => {
+    for (const state of ["draft", "submitted", "returned", "approved", "completed"]) {
+      expect(machine).toContain(`${state}:`);
+    }
+    expect(machine).toContain("context.actorId !== context.makerId");
+    expect(machine).toContain("context.submittedPayloadChecksum === context.payloadChecksum");
+    expect(machine).toContain("transition_review_document()");
+    expect(machine).toContain("input: {} as ReviewContext");
+    expect(managementPackage.dependencies).not.toHaveProperty("xstate");
+  });
+
+  test("hands transition side effects to Durable Workflows through a leased outbox", () => {
+    expect(workflowBridge).toContain("AFTER INSERT ON public.review_document_transition_events");
+    expect(workflowBridge).toContain("FOR UPDATE OF outbox SKIP LOCKED");
+    expect(workflowBridge).toContain("workflow_run_id uuid NOT NULL");
+    expect(workflowBridge).toContain("GRANT EXECUTE ON FUNCTION public.claim_review_document_workflow");
+    expect(workflowBridge).toContain("transitionEventId");
+    expect(workflowBridge).toContain("entityVersion");
+    expect(workflowBridge).toContain("REVIEW_DOCUMENT_WORKFLOW_OUTBOX_APPEND_ONLY");
+    expect(workflowBridge).not.toContain("NEW.payload");
+    expect(workflowBridge).not.toContain("PERFORM public.supacloud_workflow_start");
+    expect(workflowBridge).not.toMatch(/GRANT\s+EXECUTE.*authenticated/i);
+    expect(workflowBridge).not.toMatch(/GRANT\s+EXECUTE.*anon/i);
+    expect(workflowDispatcher).toContain("supacloud.workflows.start({");
+    expect(workflowDispatcher).toContain("invokeWorkflowBridgeRpc");
+    expect(workflowDispatcher).toContain("runId: claim.runId");
+    expect(workflowDispatcher).toContain("complete_review_document_workflow_dispatch");
+    expect(workflowDispatcher).toContain("release_review_document_workflow_dispatch");
+    expect(workflowDispatcher).not.toContain("SUPABASE_SERVICE_ROLE_KEY,");
+  });
+});

--- a/packages/management-api/tests/unit/project-replication-config.routes.test.ts
+++ b/packages/management-api/tests/unit/project-replication-config.routes.test.ts
@@ -1,0 +1,149 @@
+// @supacloud-test-isolate
+import { afterAll, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const authModule = await import("../../src/middleware/auth");
+const databaseModule = await import("../../src/db");
+
+const requireProjectOrAdminAuth = mock(async () => null);
+const queries: string[] = [];
+
+const tenantDb = async (strings: TemplateStringsArray) => {
+  const query = strings.join("?");
+  queries.push(query);
+  if (query.includes("FROM pg_replication_slots")) {
+    return [{
+      slot_name: "powersync_proj_1",
+      plugin: "pgoutput",
+      slot_type: "logical",
+      database: "supa_proj_1",
+      active: true,
+      restart_lsn: "0/100",
+      confirmed_flush_lsn: "0/120",
+      retained_wal_bytes: "4096",
+      unconfirmed_wal_bytes: "1024",
+      wal_status: "reserved",
+      safe_wal_size: "1048576",
+      inactive_since: null,
+      conflicting: "false",
+      invalidation_reason: null,
+      failover: "false",
+      synced: "false",
+    }];
+  }
+  if (query.includes("FROM pg_publication publication")) {
+    return [{
+      pubname: "powersync",
+      puballtables: false,
+      pubinsert: true,
+      pubupdate: true,
+      pubdelete: true,
+      pubtruncate: true,
+      table_count: 3,
+      replica_identity_missing_table_count: 0,
+    }];
+  }
+  if (query.includes("FROM pg_settings")) {
+    return [
+      {
+        name: "max_replication_slots",
+        setting: "10",
+        unit: null,
+        source: "configuration file",
+        pending_restart: false,
+      },
+      {
+        name: "max_slot_wal_keep_size",
+        setting: "10240",
+        unit: "MB",
+        source: "configuration file",
+        pending_restart: false,
+      },
+      {
+        name: "max_wal_senders",
+        setting: "10",
+        unit: null,
+        source: "configuration file",
+        pending_restart: false,
+      },
+      {
+        name: "wal_level",
+        setting: "logical",
+        unit: null,
+        source: "configuration file",
+        pending_restart: false,
+      },
+    ];
+  }
+  if (query.includes("FROM pg_stat_replication")) {
+    return [{ active_wal_senders: 1 }];
+  }
+  throw new Error(`Unexpected query: ${query}`);
+};
+
+const authSpy = spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+  requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+);
+const resolveDbNameSpy = spyOn(databaseModule, "resolveDbName").mockResolvedValue("supa_proj_1");
+const getProjectDbSpy = spyOn(databaseModule, "getProjectDb").mockReturnValue(tenantDb as never);
+
+const { projectConfigRoutes } = await import(
+  "../../src/routes/project-config?project-replication-config-routes-test"
+);
+const app = new Elysia().use(projectConfigRoutes);
+
+afterAll(() => {
+  authSpy.mockRestore();
+  resolveDbNameSpy.mockRestore();
+  getProjectDbSpy.mockRestore();
+});
+
+describe("project replication config route", () => {
+  test("returns raw inventory and a read-only PowerSync readiness projection", async () => {
+    queries.length = 0;
+    const response = await app.handle(new Request(
+      "http://localhost/v1/projects/proj_1/database/replication",
+      { headers: { authorization: "Bearer dev-master-token" } },
+    ));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.replication_slots[0]).toMatchObject({
+      slot_name: "powersync_proj_1",
+      retained_wal_bytes: "4096",
+    });
+    expect(body.publications[0]).toMatchObject({ pubname: "powersync", table_count: 3 });
+    expect(body.replication_settings).toMatchObject({
+      wal_level: "logical",
+      max_replication_slots: "10",
+    });
+    expect(body.replication_setting_details).toContainEqual(expect.objectContaining({
+      name: "max_slot_wal_keep_size",
+      unit: "MB",
+      pending_restart: false,
+    }));
+    expect(body.powersync_readiness).toMatchObject({
+      provider: "powersync",
+      ready: true,
+      blockers: [],
+      warnings: [],
+      checks: {
+        wal_senders: { configured: 10, active: 1, free: 9 },
+        logical_slot_health: {
+          ok: true,
+          max_retained_wal_bytes: "4096",
+          max_unconfirmed_wal_bytes: "1024",
+          min_safe_wal_bytes: "1048576",
+        },
+        publications: {
+          powersync: {
+            present: true,
+            replica_identity_missing_tables: 0,
+          },
+        },
+      },
+    });
+    expect(queries).toHaveLength(4);
+    expect(queries.every((query) => /^\s*SELECT\b/i.test(query))).toBe(true);
+  });
+});

--- a/packages/management-api/tests/unit/replication-readiness.test.ts
+++ b/packages/management-api/tests/unit/replication-readiness.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { summarizePowerSyncReadiness } from "../../src/services/replication-readiness";
+
+describe("PowerSync replication readiness", () => {
+  test("reports a ready logical replication source with spare capacity", () => {
+    expect(summarizePowerSyncReadiness({
+      settings: [
+        { name: "wal_level", setting: "logical" },
+        { name: "max_wal_senders", setting: "10" },
+        { name: "max_replication_slots", setting: "10" },
+        { name: "max_slot_wal_keep_size", setting: "10240" },
+      ],
+      slots: [
+        {
+          slot_type: "logical",
+          active: true,
+          wal_status: "reserved",
+          retained_wal_bytes: "4096",
+          unconfirmed_wal_bytes: "1024",
+          safe_wal_size: "1048576",
+        },
+        { slot_type: "physical", active: false },
+      ],
+      publications: [{
+        pubname: "powersync",
+        puballtables: false,
+        pubinsert: true,
+        pubupdate: true,
+        pubdelete: true,
+        table_count: 4,
+        replica_identity_missing_table_count: 0,
+      }],
+      activeWalSenders: 2,
+    })).toEqual({
+      provider: "powersync",
+      ready: true,
+      blockers: [],
+      warnings: [],
+      checks: {
+        wal_level: { ok: true, actual: "logical" },
+        wal_senders: { ok: true, configured: 10, active: 2, free: 8 },
+        replication_slots: {
+          ok: true,
+          configured: 10,
+          used: 2,
+          free: 8,
+          logical: 1,
+          active_logical: 1,
+        },
+        logical_slot_health: {
+          ok: true,
+          invalid: 0,
+          wal_unreserved: 0,
+          wal_lost: 0,
+          safe_wal_exhausted: 0,
+          max_retained_wal_bytes: "4096",
+          max_unconfirmed_wal_bytes: "1024",
+          min_safe_wal_bytes: "1048576",
+        },
+        wal_retention: { setting: "10240", bounded: true },
+        pending_restart: { ok: true, settings: [] },
+        publications: {
+          ok: true,
+          count: 1,
+          published_tables: 4,
+          powersync: {
+            present: true,
+            all_tables: false,
+            table_count: 4,
+            publishes_insert: true,
+            publishes_update: true,
+            publishes_delete: true,
+            replica_identity_missing_tables: 0,
+          },
+        },
+      },
+    });
+  });
+
+  test("fails closed when WAL, slot capacity, and publications are unavailable", () => {
+    const result = summarizePowerSyncReadiness({
+      settings: [
+        { name: "wal_level", setting: "replica" },
+        { name: "max_wal_senders", setting: "0" },
+        { name: "max_replication_slots", setting: "1" },
+      ],
+      slots: [{ slot_type: "logical", active: false }],
+      publications: [{ table_count: 0 }],
+      activeWalSenders: 0,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.blockers).toEqual([
+      "WAL_LEVEL_NOT_LOGICAL",
+      "WAL_SENDERS_DISABLED",
+      "NO_FREE_REPLICATION_SLOT",
+      "NO_PUBLISHED_TABLES",
+      "POWERSYNC_PUBLICATION_MISSING",
+    ]);
+    expect(result.checks.replication_slots).toMatchObject({ free: 0, ok: false });
+  });
+
+  test("normalizes missing and malformed PostgreSQL settings to a blocked result", () => {
+    const result = summarizePowerSyncReadiness({
+      settings: [{ name: "max_replication_slots", setting: "invalid" }],
+      slots: [],
+      publications: [],
+      activeWalSenders: "invalid",
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.checks.wal_level.actual).toBe("unknown");
+    expect(result.checks.replication_slots.configured).toBe(0);
+    expect(result.blockers).toContain("REPLICATION_SLOTS_DISABLED");
+  });
+
+  test("blocks when every configured WAL sender is already active", () => {
+    const result = summarizePowerSyncReadiness({
+      settings: [
+        { name: "wal_level", setting: "logical" },
+        { name: "max_wal_senders", setting: "2" },
+        { name: "max_replication_slots", setting: "3" },
+      ],
+      slots: [],
+      publications: [{
+        pubname: "powersync",
+        pubinsert: true,
+        pubupdate: true,
+        pubdelete: true,
+        table_count: 1,
+      }],
+      activeWalSenders: 2,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.blockers).toContain("NO_FREE_WAL_SENDER");
+    expect(result.checks.wal_senders).toEqual({
+      ok: false,
+      configured: 2,
+      active: 2,
+      free: 0,
+    });
+  });
+
+  test("reports PowerSync publication, slot WAL, and restart risks without hiding capacity", () => {
+    const result = summarizePowerSyncReadiness({
+      settings: [
+        { name: "wal_level", setting: "logical", pending_restart: true },
+        { name: "max_wal_senders", setting: "4" },
+        { name: "max_replication_slots", setting: "4" },
+        { name: "max_slot_wal_keep_size", setting: "-1" },
+      ],
+      slots: [{
+        slot_type: "logical",
+        active: false,
+        wal_status: "lost",
+        retained_wal_bytes: "9007199254740993",
+        unconfirmed_wal_bytes: "8192",
+        safe_wal_size: "0",
+        invalidation_reason: "wal_removed",
+      }],
+      publications: [{
+        pubname: "powersync",
+        puballtables: true,
+        pubinsert: true,
+        pubupdate: false,
+        pubdelete: true,
+        table_count: 3,
+        replica_identity_missing_table_count: 1,
+      }],
+      activeWalSenders: 1,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.blockers).toContain("POWERSYNC_PUBLICATION_DML_INCOMPLETE");
+    expect(result.blockers).toContain("POWERSYNC_REPLICA_IDENTITY_INCOMPLETE");
+    expect(result.warnings).toEqual([
+      "POWERSYNC_PUBLICATION_ALL_TABLES",
+      "INVALID_LOGICAL_SLOTS",
+      "LOGICAL_SLOT_SAFE_WAL_EXHAUSTED",
+      "SLOT_WAL_KEEP_SIZE_UNBOUNDED",
+      "REPLICATION_SETTINGS_PENDING_RESTART",
+    ]);
+    expect(result.checks.logical_slot_health).toMatchObject({
+      ok: false,
+      invalid: 1,
+      wal_lost: 1,
+      safe_wal_exhausted: 1,
+      max_retained_wal_bytes: "9007199254740993",
+      max_unconfirmed_wal_bytes: "8192",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add database-authoritative Maker-Checker migration and application-owned XState projection references
- bridge accepted transitions to Durable Workflows through a leased transactional outbox
- extend the read-only replication endpoint with PowerSync provisioning and operational readiness evidence
- document self-hosted PowerSync, RLS upload paths, ELN conflict handling, schema evolution, and cleanup

## Boundaries
- no XState or PowerSync dependency is added to SupaCloud core
- replication diagnostics remain SELECT-only and never create or delete slots/publications
- workflow bridge RPCs remain service-role-only

## Verification
- bun run test:unit
- focused tests: 9 pass / 0 fail
- bun run typecheck
- git diff --check
- PostgreSQL 18 migration, transition, idempotency, outbox, publication, and slot execution checks