### PR TITLE
feat: complete Lite application primitives and PowerSync profile

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,8 @@
 - [Durable Workflows](./durable-workflows.md) - Service-role-only PostgreSQL/PGMQ workflow execution and DBOS design rationale
 - [Application Business State Machines](./business-state-machines.md) - Maker-Checker transition RPC, audit, versioning, and XState projection pattern
 - [PowerSync Local-First Integration](./powersync-local-first.md) - Self-hosted sync boundary, replication readiness, RLS upload path, ELN conflicts, and cleanup
+- [Application Architecture Guide](./application-architecture.md) - Scalable monorepo, migration, Function, worker, and contract boundaries for SupaCloud applications
+- [Application Platform Primitives](./application-platform-primitives.md) - Custom PostgREST schemas, transactional command receipts, and immutable artifact lineage
 
 ## Product Positioning
 

--- a/docs/application-architecture.md
+++ b/docs/application-architecture.md
@@ -1,0 +1,114 @@
+# Application Architecture Guide
+
+This guide recommends a scalable application layout for teams building a domain-heavy product on SupaCloud. It is an application convention, not a platform-required filesystem layout. Keep the existing Supabase CLI layout when a project already uses it; do not create a second deployment root merely for organization.
+
+The examples use `supabase/` because it is the standard CLI root. A project whose established deployment tooling requires `supacloud/` can use that name instead, but it must have one authoritative platform root.
+
+## Recommended Monorepo Layout
+
+```text
+application/
+├─ apps/
+│  └─ web/
+│     ├─ app/                 # Application bootstrap, routing, providers
+│     ├─ pages/               # Route-level composition
+│     ├─ widgets/             # Reusable business sections
+│     ├─ features/            # User-facing business actions
+│     ├─ entities/            # Entity state and presentation
+│     └─ shared/              # UI, API clients, utilities, configuration
+│
+├─ packages/
+│  ├─ domain-contracts/
+│  │  ├─ domain/              # DTOs and Zod schemas by domain
+│  │  ├─ auth/                # Capabilities, roles, and policy inputs/outputs
+│  │  ├─ commands/            # Idempotent command contracts
+│  │  ├─ events/              # Audit, webhook, and workflow event contracts
+│  │  └─ state-machines/      # Pure transitions and guards
+│  └─ shared-ui/              # Framework-specific but domain-neutral UI primitives
+│
+├─ supabase/
+│  ├─ schemas/                # Optional authored schema sources for new work
+│  ├─ migrations/             # Immutable, timestamp-ordered migration history
+│  ├─ seed.sql
+│  └─ functions/
+│     ├─ _shared/
+│     │  ├─ platform/         # Clients for Supabase/SupaCloud services
+│     │  ├─ http/             # Authentication, error mapping, tracing
+│     │  └─ observability/    # Logging and metrics helpers
+│     ├─ app-api/             # Synchronous application API entrypoint
+│     ├─ app-worker/          # Durable command, workflow, and queue consumers
+│     ├─ app-webhooks/        # Third-party callback boundary
+│     └─ app-scheduled/       # Scheduled dispatch and maintenance, when needed
+│
+└─ docs/
+   └─ architecture/           # Architecture decision records and domain maps
+```
+
+Use a name meaningful to the application in place of `domain-contracts`, `app-api`, and `app-worker`. For example, a failure-analysis application may choose `fa-contracts`, `fa-api`, and `fa-worker`.
+
+## Ownership Boundaries
+
+### Contracts
+
+`packages/<domain>-contracts` is the shared language of the application. It may contain TypeScript types, Zod schemas, command/event envelopes, and pure state-transition rules. It must not depend on browser APIs, Supabase clients, Storage, secrets, database connections, or Function runtime globals.
+
+Keep authorization models here only when they are application contracts used by multiple callers. Split a separate cross-product auth package only after there are multiple independently released products that actually share the same model.
+
+Generated database types are useful clients of these contracts, but they do not replace domain contracts: generated types describe database shape, while contracts describe accepted commands, public API payloads, and state transitions.
+
+`shared-ui` may depend on the chosen frontend framework, but must not depend on application entities, authorization policy, or a Supabase client.
+
+### Database And Migrations
+
+The `migrations/` directory is an append-only deployment ledger. Do not rename, regroup, rewrite, or delete historical migrations in order to make a large project look cleaner.
+
+For projects with many migrations, `schemas/` can hold the current authored structure divided by domain, for example `core.sql`, `cases.sql`, `reports.sql`, `ocr.sql`, `audit.sql`, and `api.sql`. Treat a schema-source change and its generated migration as one reviewed change. The migration remains the authoritative input to deployment.
+
+Each domain should own its tables, indexes, RLS policies, views, triggers, and application RPCs. Cross-domain reads should be explicit through a view, RPC, or documented repository boundary rather than ad hoc joins copied across Functions.
+
+Use a private domain outbox when an accepted transaction must cause asynchronous work. The transaction writes the domain change and the outbox/command intent together; a trusted worker dispatches it later. Do not make browser requests or database triggers depend on best-effort external HTTP delivery.
+
+### Edge Functions
+
+Use a small number of externally addressable Functions with clear trust boundaries:
+
+- `app-api` accepts synchronous application requests and routes to domain modules.
+- `app-worker` claims and dispatches durable commands, workflow steps, or queue messages.
+- `app-webhooks` verifies and accepts third-party callbacks separately from user-facing APIs.
+- `app-scheduled` starts periodic work only when a scheduled boundary is genuinely needed.
+
+An entrypoint should be thin. Domain code belongs under the owning Function, such as `app-api/cases/`, `app-api/reports/`, or `app-worker/ocr/`. `_shared` is reserved for technical cross-cutting code; placing all business services under `_shared` turns it into an unowned dependency sink.
+
+Pass identifiers, immutable input versions, and object paths to asynchronous workers. The worker must read current authoritative domain data, honor leases/cancellation, and make side effects idempotent. Do not put secrets in task, workflow, command, or event payloads.
+
+## SupaCloud Application Capabilities
+
+Use the standard `@supabase/supabase-js` client for normal application runtime traffic:
+
+- Auth sessions and user-scoped authorization.
+- PostgREST database access subject to RLS.
+- Storage uploads and downloads.
+- Realtime subscriptions.
+- Standard `supabase.functions.invoke()` calls.
+
+Use `@supacloud/js` from trusted server-side code for platform-specific capabilities:
+
+- Background task submission, status, cancellation, retry, wait, subscription, and DLQ inspection.
+- Supabase Queues/PGMQ send, receive, acknowledgement, archive, and diagnostics helpers.
+- Service-role-only Durable Workflow execution: claim, advance, retry, fail, complete, and cancel.
+- Service-role-only transactional command receipts for idempotent, atomic domain transition plus enqueue.
+- Immutable Storage artifact registration and acyclic artifact lineage.
+- Project OAuth/OIDC migration helpers and trusted SupAuth provisioning, reconciliation, and verification helpers.
+
+The related platform contracts are documented in [Background Functions](./background-functions.md), [Durable Workflows](./durable-workflows.md), and [Application Platform Primitives](./application-platform-primitives.md).
+
+## Security Rules
+
+- Browser and mobile clients use user sessions and RLS-protected APIs only.
+- `service_role`, Management API tokens, tenant database credentials, and webhook secrets remain in trusted server-side configuration.
+- Platform workflow, command, and artifact ledgers are execution/audit mechanisms; domain tables remain the authority for approval, signing, delivery, and other business state.
+- Large async inputs and outputs belong in Storage or application tables. Queue and workflow payloads should carry small identifiers and trace metadata.
+
+## Incremental Adoption
+
+Do not reorganize a mature product in one migration. First document domain ownership and introduce contracts for new or changed behavior. Then add the outbox/worker pattern for the highest-risk asynchronous flow. Move individual Functions or frontend features only when they change for business reasons, preserving the existing deployment topology throughout.

--- a/docs/application-platform-primitives.md
+++ b/docs/application-platform-primitives.md
@@ -1,0 +1,115 @@
+# Application Platform Primitives
+
+SupaCloud provides three project-scoped primitives for applications with private domain schemas, durable commands, and immutable generated artifacts. They are infrastructure mechanisms, not application business models.
+
+## Custom PostgREST schemas
+
+Projects can expose validated project-owned schemas in addition to the platform baseline:
+
+```http
+PATCH /v1/projects/:ref/config/postgrest
+Authorization: Bearer <project-or-management-token>
+Content-Type: application/json
+
+{
+  "exposed_schemas": ["api", "rpc"],
+  "expected_revision": "<sha256-from-previous-read>"
+}
+```
+
+The platform always keeps `public`, `storage`, and `graphql_public`. It adds `pgmq_public` only when the wrapper exists. Custom schemas:
+
+- must already exist in the project database;
+- are normalized to unique, sorted lowercase identifiers;
+- cannot use PostgreSQL, Supabase, SupaCloud, Auth, Storage, Realtime, Vault, or PGMQ reserved names;
+- are limited to 16 schemas;
+- use an optimistic revision to prevent lost updates.
+
+For a running project, a successful update renders and restarts the managed PostgREST generation. A paused runtime stores the new desired configuration and reports `restart_required=true`. An apply failure attempts to restore both the previous project configuration and the previous runtime generation.
+
+Application migrations still own the schemas, views, grants, RLS policies, and RPC definitions. Removing a schema from `exposed_schemas` does not drop it.
+
+## Transactional command receipts
+
+`supacloud_commands` adds an idempotent command receipt on top of Durable Workflows. The public `supacloud_command_submit` and `supacloud_command_get` RPCs are service-role-only.
+
+```ts
+const receipt = await supacloud.commands.submit({
+  commandId: crypto.randomUUID(),
+  commandType: "report.issue",
+  targetType: "report",
+  targetId: reportId,
+  actorId: userId,
+  payload: { reportId },
+  maxAttempts: 3,
+});
+```
+
+For atomic business writes, call the private function from an application-owned `SECURITY DEFINER` RPC in the same PostgreSQL transaction:
+
+```sql
+update domain.reports
+set status = 'issuing'
+where id = p_report_id and status = 'approved';
+
+perform supacloud_commands.submit(jsonb_build_object(
+  'commandId', p_command_id,
+  'commandType', 'report.issue',
+  'targetType', 'report',
+  'targetId', p_report_id,
+  'actorId', auth.uid(),
+  'payload', jsonb_build_object('reportId', p_report_id),
+  'maxAttempts', 3
+));
+```
+
+If either statement fails, PostgreSQL rolls back the domain write, receipt, workflow step, and PGMQ message together. Replaying the same command ID and payload returns `idempotent=true`; changing the command identity fields or payload returns an idempotency conflict.
+
+Workers use `supacloud.workflows.claim()` and process workflow names beginning with `command.`. Completion, retry, failure, stale-attempt fencing, and events use the existing Durable Workflows API.
+
+The application remains authoritative for approval rules, signing decisions, and domain status. SupaCloud owns only the execution receipt and delivery mechanics.
+
+## Artifact registry
+
+Upload the object to a private Storage bucket first, calculate its SHA-256 digest, then register the exact Storage object:
+
+```ts
+const artifact = await supacloud.artifacts.register({
+  artifactId: crypto.randomUUID(),
+  bucketId: "reports",
+  objectPath: "2026/report-123.pdf",
+  artifactType: "report.pdf",
+  sha256,
+  sizeBytes,
+  mimeType: "application/pdf",
+  retentionUntil: "2033-01-01T00:00:00Z",
+  metadata: { reportId: "report-123", version: 4 },
+});
+```
+
+Registration requires an existing `storage.objects` row and binds:
+
+- Storage object ID, bucket, path, and object version;
+- SHA-256, byte size, MIME type, and artifact type;
+- optional creator, retention date, and application metadata.
+
+Once registered, updates and deletion of the bound `storage.objects` row fail closed. Derived artifacts can record acyclic lineage:
+
+```ts
+await supacloud.artifacts.link({
+  parentArtifactId: sourcePdfId,
+  childArtifactId: ocrResultId,
+  relationType: "derived_from",
+});
+```
+
+The registry does not upload files, calculate hashes, infer OCR fields, or decide legal retention. Those remain application responsibilities.
+
+## Security and rollback
+
+- Public RPCs require `service_role`; never expose that key to browser or mobile clients.
+- Private schemas and tables are not granted to `anon`, `authenticated`, or `service_role`.
+- Command and workflow payloads are durable project data and must not contain credentials.
+- Artifact metadata is immutable; create a new Storage object and artifact ID for a new version.
+- Roll back application adoption by stopping new command submissions/workers and new artifact registrations. Keep the private ledgers for recovery and audit evidence.
+- Removing custom PostgREST schemas is reversible and does not alter application schemas or data.

--- a/docs/business-state-machines.md
+++ b/docs/business-state-machines.md
@@ -97,3 +97,9 @@ transition, for example to render a report, notify a customer, archive an
 artifact, or retry an external integration. Use the transactional outbox above
 when workflow availability must not block the business transition, and never
 let a workflow become the authoritative business state.
+
+SupaCloud Lite runs the reference state-machine migration and workflow bridge
+as an automated PGlite/native matrix. The test exercises illegal ordering,
+Maker-Checker separation, stale versions, idempotent replay, direct-update and
+append-only fences, outbox creation, dispatcher acknowledgement, and the full
+`@supacloud/js` Durable Workflow start/claim/complete path.

--- a/docs/durable-workflows.md
+++ b/docs/durable-workflows.md
@@ -8,6 +8,8 @@ Workflow durability belongs beside Queues and Scheduled Functions because it own
 
 Applications still own business meaning. Approval decisions, document signing states, role assignments, and domain records stay in application tables protected by their own RBAC and RLS policies. A durable workflow may coordinate those operations, but it does not become their source of truth.
 
+For application commands that need an idempotent receipt and atomic enqueue, use the [Application Platform Primitives](./application-platform-primitives.md) command layer. It creates the receipt and starts a `command.*` workflow in the caller's PostgreSQL transaction without moving domain state into the workflow ledger.
+
 ## Relationship to DBOS
 
 [DBOS Transact TypeScript](https://github.com/dbos-inc/dbos-transact-ts) is a useful reference for durable execution semantics: deterministic workflow identity, PostgreSQL checkpoints, durable steps, retry, and recovery after process failure.
@@ -117,6 +119,6 @@ browser provide neither atomicity nor durable recovery.
 - A worker completion is accepted only for the exact message ID, attempt number, and worker ID that claimed the step.
 - Inputs, outputs, and errors are durable project data. Do not place secrets or customer-sensitive plaintext in them unless the project data policy explicitly permits it.
 
-Fresh tenants install the schema during bootstrap. Existing tenants receive the same idempotent module through the tenant schema migration path. SupaCloud Lite installs the identical SQL contract on its PGlite-backed PGMQ emulation.
+Fresh tenants install the schema during bootstrap. Existing tenants receive the same idempotent module through the tenant schema migration path. SupaCloud Lite installs the identical SQL contract on both its PGlite and embedded native PostgreSQL engines.
 
 To roll back application adoption, stop workers and stop starting new runs first. The safest platform rollback leaves the private ledger intact while removing callers; deleting workflow tables would discard recovery and audit evidence.

--- a/docs/powersync-local-first.md
+++ b/docs/powersync-local-first.md
@@ -2,8 +2,10 @@
 
 PowerSync is the selected external Local-First integration for SupaCloud
 applications that require a durable local SQLite database, offline writes, and
-recovery after weak or unavailable networks. SupaCloud does not start, stop,
-create, or delete PowerSync replication resources automatically in this phase.
+recovery after weak or unavailable networks. Full SupaCloud exposes read-only
+replication readiness. Native Lite additionally provides an explicit
+`powersync` source profile. Neither runtime starts or stops PowerSync, and
+neither creates or deletes PowerSync replication slots.
 
 Use the official PowerSync Supabase integration and self-hosting documentation
 for the exact release-specific service configuration:
@@ -74,6 +76,55 @@ storage, validate Sync Streams against a non-production tenant, start the
 pinned PowerSync service, read back its exact slot from the SupaCloud
 replication endpoint, then enable token issuance for a small client cohort.
 SupaCloud never creates the slot on the service's behalf.
+
+## SupaCloud Lite boundary
+
+PGlite is not a PowerSync replication source and `supacloud-lite doctor --json`
+reports both `logical_replication` and `powersync_source` as `unsupported`.
+Do not emulate PostgreSQL replication catalogs or infer readiness from Lite
+Realtime. For a single field workstation, PGlite can remain the local
+single-project server. For multiple offline devices, use one of these explicit
+topologies:
+
+1. clients synchronize through central SupaCloud + PowerSync;
+2. Native Lite runs the opt-in PowerSync profile on the site server; or
+3. an application-owned idempotent outbox uploads PGlite data to central
+   SupaCloud, which remains the PowerSync source.
+
+Native Lite keeps replication disabled by default. Enable it only with an
+explicit table allowlist and a secret-store password:
+
+```bash
+export SUPACLOUD_LITE_POWERSYNC_PASSWORD='<at-least-32-characters>'
+supacloud-lite migrate \
+  --engine native \
+  --replication-profile powersync \
+  --powersync-tables public.eln_entries,public.eln_observations
+```
+
+The default profile listens on `127.0.0.1:54322`, uses SCRAM, creates the
+dedicated `supacloud_powersync` role and explicit `powersync` publication, and
+sets bounded capacity: four WAL senders, four replication slots, and 1024MB
+maximum retained WAL per slot. It never creates a slot. A non-loopback listener
+is rejected unless TLS certificate/key files and explicit client CIDRs are
+provided. Keep the default loopback connection when PowerSync shares the host;
+otherwise terminate and verify PostgreSQL TLS rather than exposing plaintext
+database traffic.
+
+After migration, inspect the live native catalog without slot DDL:
+
+```bash
+supacloud-lite doctor --json \
+  --engine native \
+  --replication-profile powersync \
+  --powersync-tables public.eln_entries,public.eln_observations
+```
+
+The report includes the stable Lite capability fields plus
+`powersync_readiness`: connection/TLS policy, WAL and slot capacity, role
+attributes, exact publication tables, replica identity blockers, and existing
+logical slot health. `ready=true` remains a source preflight, not proof that the
+PowerSync service, tokens, Sync Streams, uploads, or clients are correct.
 
 ## Readiness inspection
 
@@ -259,6 +310,22 @@ Validate with production-shaped but non-production data:
    the pinned PowerSync release and existing clients.
 9. A forced slot interruption produces a visible warning and follows the
    documented resnapshot path without deleting an unrelated slot.
+
+Record evidence for each independent plane rather than treating source
+readiness as end-to-end acceptance:
+
+- **JWKS and custom auth:** issue a token with the pinned PowerSync audience,
+  verify accepted and rejected issuer/audience/key-rotation cases, and confirm
+  removed membership prevents new token issuance.
+- **Sync Streams:** validate the pinned service configuration against two
+  tenants and prove that each initial snapshot and incremental change remains
+  inside its membership scope.
+- **RLS writeback:** upload through authenticated narrow RPCs, then test tenant
+  denial, Maker-Checker separation, stale row version, duplicate idempotency
+  keys, and immutable artifact handling.
+- **Resnapshot:** stop the test service until its bounded slot becomes invalid,
+  capture `doctor`/Management API evidence, follow the pinned PowerSync
+  resnapshot procedure, and prove no unrelated slot or publication was changed.
 
 ## Disable and cleanup
 

--- a/packages/management-api/src/db/schemas/supabase.sql
+++ b/packages/management-api/src/db/schemas/supabase.sql
@@ -1804,6 +1804,452 @@ GRANT EXECUTE ON FUNCTION public.supacloud_workflow_get(jsonb) TO service_role;
 GRANT EXECUTE ON FUNCTION public.supacloud_workflow_events(jsonb) TO service_role;
 -- supacloud:sql-module:workflows-public:end
 
+-- supacloud:sql-module:commands-public:start
+CREATE SCHEMA IF NOT EXISTS supacloud_commands;
+REVOKE ALL ON SCHEMA supacloud_commands FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA supacloud_commands TO service_role;
+
+CREATE TABLE IF NOT EXISTS supacloud_commands.receipts (
+  id uuid PRIMARY KEY,
+  command_type text NOT NULL
+    CHECK (command_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  target_type text NOT NULL
+    CHECK (target_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  target_id text NOT NULL CHECK (char_length(target_id) BETWEEN 1 AND 500),
+  actor_id uuid,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb
+    CHECK (jsonb_typeof(payload) = 'object'),
+  payload_fingerprint text NOT NULL CHECK (char_length(payload_fingerprint) = 36),
+  workflow_run_id uuid NOT NULL UNIQUE
+    REFERENCES supacloud_workflows.runs(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_commands_target_idx
+  ON supacloud_commands.receipts (target_type, target_id, created_at DESC, id);
+
+CREATE OR REPLACE FUNCTION supacloud_commands.snapshot(
+  p_command_id uuid,
+  p_idempotent boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object(
+    'commandId', receipt.id,
+    'commandType', receipt.command_type,
+    'targetType', receipt.target_type,
+    'targetId', receipt.target_id,
+    'actorId', receipt.actor_id,
+    'payloadFingerprint', receipt.payload_fingerprint,
+    'createdAt', receipt.created_at,
+    'idempotent', p_idempotent,
+    'workflow', supacloud_workflows.snapshot(receipt.workflow_run_id, false)
+  )
+  FROM supacloud_commands.receipts receipt
+  WHERE receipt.id = p_command_id
+$$;
+
+-- Application-owned SECURITY DEFINER RPCs may call this after their domain
+-- mutation. PostgreSQL commits the domain write, receipt, and workflow enqueue
+-- together, so a lost response can be replayed with the same command ID.
+DROP FUNCTION IF EXISTS supacloud_commands.submit(uuid, text, text, text, uuid, jsonb, integer);
+CREATE OR REPLACE FUNCTION supacloud_commands.submit(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  command_id_text text;
+  command_id uuid;
+  actor_id uuid;
+  max_attempts integer;
+  payload jsonb;
+  normalized_command_type text;
+  normalized_target_type text;
+  normalized_target_id text;
+  fingerprint text;
+  existing supacloud_commands.receipts%ROWTYPE;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id_text := request ->> 'commandId';
+  IF command_id_text IS NULL
+     OR command_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id := command_id_text::uuid;
+  IF request ? 'actorId' AND request ->> 'actorId' IS NOT NULL THEN
+    actor_id := (request ->> 'actorId')::uuid;
+  END IF;
+  max_attempts := coalesce((request ->> 'maxAttempts')::integer, 3);
+  payload := coalesce(request -> 'payload', '{}'::jsonb);
+  normalized_command_type := nullif(btrim(request ->> 'commandType'), '');
+  normalized_target_type := nullif(btrim(request ->> 'targetType'), '');
+  normalized_target_id := nullif(btrim(request ->> 'targetId'), '');
+  IF normalized_command_type IS NULL
+     OR normalized_command_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_target_type IS NULL
+     OR normalized_target_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_target_id IS NULL
+     OR char_length(normalized_target_id) > 500
+     OR jsonb_typeof(payload) IS DISTINCT FROM 'object'
+     OR max_attempts NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  fingerprint := 'md5:' || md5(payload::text);
+  PERFORM pg_advisory_xact_lock(hashtextextended(command_id::text, 0));
+  SELECT * INTO existing FROM supacloud_commands.receipts WHERE id = command_id;
+  IF FOUND THEN
+    IF existing.command_type <> normalized_command_type
+       OR existing.target_type <> normalized_target_type
+       OR existing.target_id <> normalized_target_id
+       OR existing.actor_id IS DISTINCT FROM actor_id
+       OR existing.payload <> payload
+       OR existing.payload_fingerprint <> fingerprint THEN
+      RAISE EXCEPTION 'SUPACLOUD_COMMAND_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+    END IF;
+    RETURN supacloud_commands.snapshot(command_id, true);
+  END IF;
+
+  PERFORM supacloud_workflows.start_run(
+    command_id,
+    'command.' || normalized_command_type,
+    '1',
+    'execute',
+    jsonb_build_object(
+      'commandId', command_id,
+      'commandType', normalized_command_type,
+      'targetType', normalized_target_type,
+      'targetId', normalized_target_id,
+      'actorId', actor_id,
+      'payload', payload,
+      'payloadFingerprint', fingerprint
+    ),
+    max_attempts
+  );
+
+  INSERT INTO supacloud_commands.receipts (
+    id, command_type, target_type, target_id, actor_id, payload,
+    payload_fingerprint, workflow_run_id
+  ) VALUES (
+    command_id, normalized_command_type, normalized_target_type,
+    normalized_target_id, actor_id, payload, fingerprint, command_id
+  );
+  RETURN supacloud_commands.snapshot(command_id, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_command_submit(request jsonb)
+RETURNS jsonb
+LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT supacloud_commands.submit(request)
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_command_get(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  command_id_text text;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id_text := request ->> 'commandId';
+  IF command_id_text IS NULL
+     OR command_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+  END IF;
+  RETURN supacloud_commands.snapshot(command_id_text::uuid, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA supacloud_commands
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA supacloud_commands
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.supacloud_command_submit(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_command_get(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.supacloud_command_submit(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_command_get(jsonb) TO service_role;
+-- supacloud:sql-module:commands-public:end
+
+-- supacloud:sql-module:artifacts-public:start
+CREATE SCHEMA IF NOT EXISTS supacloud_artifacts;
+REVOKE ALL ON SCHEMA supacloud_artifacts FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA supacloud_artifacts TO service_role;
+
+CREATE TABLE IF NOT EXISTS supacloud_artifacts.artifacts (
+  id uuid PRIMARY KEY,
+  storage_object_id uuid NOT NULL UNIQUE REFERENCES storage.objects(id) ON DELETE RESTRICT,
+  bucket_id text NOT NULL,
+  object_path text NOT NULL,
+  object_version text NOT NULL,
+  artifact_type text NOT NULL
+    CHECK (artifact_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  sha256 text NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+  size_bytes bigint NOT NULL CHECK (size_bytes >= 0),
+  mime_type text NOT NULL CHECK (char_length(mime_type) BETWEEN 1 AND 255),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  retention_until timestamptz,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (retention_until IS NULL OR retention_until >= created_at),
+  UNIQUE (bucket_id, object_path, object_version)
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_artifacts_lookup_idx
+  ON supacloud_artifacts.artifacts (artifact_type, created_at DESC, id);
+
+CREATE TABLE IF NOT EXISTS supacloud_artifacts.lineage (
+  parent_artifact_id uuid NOT NULL REFERENCES supacloud_artifacts.artifacts(id) ON DELETE RESTRICT,
+  child_artifact_id uuid NOT NULL REFERENCES supacloud_artifacts.artifacts(id) ON DELETE RESTRICT,
+  relation_type text NOT NULL
+    CHECK (relation_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (parent_artifact_id, child_artifact_id, relation_type),
+  CHECK (parent_artifact_id <> child_artifact_id)
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_artifacts_lineage_child_idx
+  ON supacloud_artifacts.lineage (child_artifact_id, created_at, parent_artifact_id);
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.guard_storage_object()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM supacloud_artifacts.artifacts artifact
+    WHERE artifact.storage_object_id = OLD.id
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IMMUTABLE' USING ERRCODE = '55000';
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS supacloud_artifact_storage_fence ON storage.objects;
+CREATE TRIGGER supacloud_artifact_storage_fence
+BEFORE UPDATE OR DELETE ON storage.objects
+FOR EACH ROW EXECUTE FUNCTION supacloud_artifacts.guard_storage_object();
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.snapshot(
+  p_artifact_id uuid,
+  p_idempotent boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object(
+    'artifactId', artifact.id,
+    'bucketId', artifact.bucket_id,
+    'objectPath', artifact.object_path,
+    'objectVersion', artifact.object_version,
+    'artifactType', artifact.artifact_type,
+    'sha256', artifact.sha256,
+    'sizeBytes', artifact.size_bytes::text,
+    'mimeType', artifact.mime_type,
+    'metadata', artifact.metadata,
+    'retentionUntil', artifact.retention_until,
+    'createdBy', artifact.created_by,
+    'createdAt', artifact.created_at,
+    'idempotent', p_idempotent,
+    'parents', coalesce((
+      SELECT jsonb_agg(jsonb_build_object(
+        'artifactId', edge.parent_artifact_id,
+        'relationType', edge.relation_type,
+        'metadata', edge.metadata,
+        'createdAt', edge.created_at
+      ) ORDER BY edge.created_at, edge.parent_artifact_id)
+      FROM supacloud_artifacts.lineage edge
+      WHERE edge.child_artifact_id = artifact.id
+    ), '[]'::jsonb)
+  )
+  FROM supacloud_artifacts.artifacts artifact
+  WHERE artifact.id = p_artifact_id
+$$;
+
+DROP FUNCTION IF EXISTS supacloud_artifacts.register(uuid, text, text, text, text, bigint, text, jsonb, timestamptz, uuid);
+CREATE OR REPLACE FUNCTION supacloud_artifacts.register(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  artifact_id uuid;
+  size_bytes bigint;
+  metadata jsonb;
+  retention_until timestamptz;
+  created_by uuid;
+  normalized_bucket text;
+  normalized_path text;
+  normalized_type text;
+  normalized_sha256 text;
+  normalized_mime text;
+  object_row storage.objects%ROWTYPE;
+  existing supacloud_artifacts.artifacts%ROWTYPE;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+  END IF;
+  artifact_id := (request ->> 'artifactId')::uuid;
+  size_bytes := (request ->> 'sizeBytes')::bigint;
+  metadata := coalesce(request -> 'metadata', '{}'::jsonb);
+  retention_until := (request ->> 'retentionUntil')::timestamptz;
+  created_by := (request ->> 'createdBy')::uuid;
+  normalized_bucket := nullif(btrim(request ->> 'bucketId'), '');
+  normalized_path := nullif(btrim(request ->> 'objectPath'), '');
+  normalized_type := nullif(btrim(request ->> 'artifactType'), '');
+  normalized_sha256 := lower(nullif(btrim(request ->> 'sha256'), ''));
+  normalized_mime := lower(nullif(btrim(request ->> 'mimeType'), ''));
+  IF artifact_id IS NULL OR normalized_bucket IS NULL OR normalized_path IS NULL
+     OR normalized_path LIKE '/%' OR normalized_path LIKE '%\\%'
+     OR normalized_path ~ '(^|/)(\.|\.\.)(/|$)'
+     OR normalized_type IS NULL
+     OR normalized_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_sha256 IS NULL OR normalized_sha256 !~ '^[0-9a-f]{64}$'
+     OR size_bytes IS NULL OR size_bytes < 0
+     OR normalized_mime IS NULL OR char_length(normalized_mime) > 255
+     OR jsonb_typeof(metadata) IS DISTINCT FROM 'object'
+     OR (retention_until IS NOT NULL AND retention_until < now()) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO object_row FROM storage.objects
+  WHERE bucket_id = normalized_bucket AND name = normalized_path;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_OBJECT_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(artifact_id::text, 0));
+  SELECT * INTO existing FROM supacloud_artifacts.artifacts WHERE id = artifact_id;
+  IF FOUND THEN
+    IF existing.storage_object_id <> object_row.id
+       OR existing.artifact_type <> normalized_type
+       OR existing.sha256 <> normalized_sha256
+       OR existing.size_bytes <> size_bytes
+       OR existing.mime_type <> normalized_mime
+       OR existing.metadata <> metadata
+       OR existing.retention_until IS DISTINCT FROM retention_until
+       OR existing.created_by IS DISTINCT FROM created_by THEN
+      RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+    END IF;
+    RETURN supacloud_artifacts.snapshot(artifact_id, true);
+  END IF;
+
+  INSERT INTO supacloud_artifacts.artifacts (
+    id, storage_object_id, bucket_id, object_path, object_version,
+    artifact_type, sha256, size_bytes, mime_type, metadata,
+    retention_until, created_by
+  ) VALUES (
+    artifact_id, object_row.id, normalized_bucket, normalized_path,
+    object_row.version::text, normalized_type, normalized_sha256,
+    size_bytes, normalized_mime, metadata, retention_until, created_by
+  );
+  RETURN supacloud_artifacts.snapshot(artifact_id, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.link(
+  p_parent_artifact_id uuid,
+  p_child_artifact_id uuid,
+  p_relation_type text,
+  p_metadata jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  normalized_relation text := nullif(btrim(p_relation_type), '');
+  inserted_count integer;
+BEGIN
+  IF p_parent_artifact_id IS NULL OR p_child_artifact_id IS NULL
+     OR p_parent_artifact_id = p_child_artifact_id
+     OR normalized_relation IS NULL
+     OR normalized_relation !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR jsonb_typeof(p_metadata) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_INVALID' USING ERRCODE = '22023';
+  END IF;
+  IF EXISTS (
+    WITH RECURSIVE descendants(artifact_id) AS (
+      SELECT edge.child_artifact_id
+      FROM supacloud_artifacts.lineage edge
+      WHERE edge.parent_artifact_id = p_child_artifact_id
+      UNION
+      SELECT edge.child_artifact_id
+      FROM supacloud_artifacts.lineage edge
+      JOIN descendants current ON edge.parent_artifact_id = current.artifact_id
+    )
+    SELECT 1 FROM descendants WHERE artifact_id = p_parent_artifact_id
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_CYCLE' USING ERRCODE = '23514';
+  END IF;
+  INSERT INTO supacloud_artifacts.lineage (
+    parent_artifact_id, child_artifact_id, relation_type, metadata
+  ) VALUES (
+    p_parent_artifact_id, p_child_artifact_id, normalized_relation, p_metadata
+  ) ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS inserted_count = ROW_COUNT;
+  IF inserted_count = 0 AND NOT EXISTS (
+    SELECT 1 FROM supacloud_artifacts.lineage
+    WHERE parent_artifact_id = p_parent_artifact_id
+      AND child_artifact_id = p_child_artifact_id
+      AND relation_type = normalized_relation
+      AND metadata = p_metadata
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+  END IF;
+  RETURN supacloud_artifacts.snapshot(p_child_artifact_id, inserted_count = 0);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_register(request jsonb)
+RETURNS jsonb
+LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT supacloud_artifacts.register(request)
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_get(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RETURN supacloud_artifacts.snapshot((request ->> 'artifactId')::uuid, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_GET_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_link(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RETURN supacloud_artifacts.link(
+    (request ->> 'parentArtifactId')::uuid,
+    (request ->> 'childArtifactId')::uuid,
+    request ->> 'relationType',
+    coalesce(request -> 'metadata', '{}'::jsonb)
+  );
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA supacloud_artifacts
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA supacloud_artifacts
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_register(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_get(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_link(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_register(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_get(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_link(jsonb) TO service_role;
+-- supacloud:sql-module:artifacts-public:end
+
 -- 8. Functions Schema (Webhooks)
 CREATE SCHEMA IF NOT EXISTS supabase_functions;
 GRANT USAGE ON SCHEMA supabase_functions TO postgres, anon, authenticated, service_role;

--- a/packages/management-api/src/db/sql-module-sync.ts
+++ b/packages/management-api/src/db/sql-module-sync.ts
@@ -29,11 +29,13 @@ export const SQL_MODULE_TARGETS = [
       "postgrest-request-context",
       "pgmq-public",
       "workflows-public",
+      "commands-public",
+      "artifacts-public",
     ],
   },
   {
     relativePath: "packages/supacloud-lite/src/runtime/db/emulated.ts",
-    moduleIds: ["pgmq-public", "workflows-public"],
+    moduleIds: ["pgmq-public", "workflows-public", "commands-public", "artifacts-public"],
   },
   {
     relativePath: "scripts/004_background_task_mirror_migration.sql",

--- a/packages/management-api/src/db/sql-modules.ts
+++ b/packages/management-api/src/db/sql-modules.ts
@@ -1,6 +1,8 @@
 import authJwtHelpersSql from "./sql-modules/auth-jwt-helpers.sql" with { type: "text" };
+import artifactsPublicSql from "./sql-modules/artifacts-public.sql" with { type: "text" };
 import backgroundTaskMirrorDownSql from "./sql-modules/background-task-mirror-down.sql" with { type: "text" };
 import backgroundTaskMirrorUpSql from "./sql-modules/background-task-mirror-up.sql" with { type: "text" };
+import commandsPublicSql from "./sql-modules/commands-public.sql" with { type: "text" };
 import pgmqPublicSql from "./sql-modules/pgmq-public.sql" with { type: "text" };
 import postgrestRequestContextSql from "./sql-modules/postgrest-request-context.sql" with { type: "text" };
 import realtimeAutoAttachTriggerSql from "./sql-modules/realtime-auto-attach-trigger.sql" with { type: "text" };
@@ -10,8 +12,10 @@ import workflowsPublicSql from "./sql-modules/workflows-public.sql" with { type:
 
 export const SQL_MODULES = {
   "auth-jwt-helpers": authJwtHelpersSql.trim(),
+  "artifacts-public": artifactsPublicSql.trim(),
   "background-task-mirror-down": backgroundTaskMirrorDownSql.trim(),
   "background-task-mirror-up": backgroundTaskMirrorUpSql.trim(),
+  "commands-public": commandsPublicSql.trim(),
   "pgmq-public": pgmqPublicSql.trim(),
   "postgrest-request-context": postgrestRequestContextSql.trim(),
   "realtime-auto-attach-trigger": realtimeAutoAttachTriggerSql.trim(),

--- a/packages/management-api/src/db/sql-modules/artifacts-public.sql
+++ b/packages/management-api/src/db/sql-modules/artifacts-public.sql
@@ -1,0 +1,269 @@
+CREATE SCHEMA IF NOT EXISTS supacloud_artifacts;
+REVOKE ALL ON SCHEMA supacloud_artifacts FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA supacloud_artifacts TO service_role;
+
+CREATE TABLE IF NOT EXISTS supacloud_artifacts.artifacts (
+  id uuid PRIMARY KEY,
+  storage_object_id uuid NOT NULL UNIQUE REFERENCES storage.objects(id) ON DELETE RESTRICT,
+  bucket_id text NOT NULL,
+  object_path text NOT NULL,
+  object_version text NOT NULL,
+  artifact_type text NOT NULL
+    CHECK (artifact_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  sha256 text NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+  size_bytes bigint NOT NULL CHECK (size_bytes >= 0),
+  mime_type text NOT NULL CHECK (char_length(mime_type) BETWEEN 1 AND 255),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  retention_until timestamptz,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (retention_until IS NULL OR retention_until >= created_at),
+  UNIQUE (bucket_id, object_path, object_version)
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_artifacts_lookup_idx
+  ON supacloud_artifacts.artifacts (artifact_type, created_at DESC, id);
+
+CREATE TABLE IF NOT EXISTS supacloud_artifacts.lineage (
+  parent_artifact_id uuid NOT NULL REFERENCES supacloud_artifacts.artifacts(id) ON DELETE RESTRICT,
+  child_artifact_id uuid NOT NULL REFERENCES supacloud_artifacts.artifacts(id) ON DELETE RESTRICT,
+  relation_type text NOT NULL
+    CHECK (relation_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (parent_artifact_id, child_artifact_id, relation_type),
+  CHECK (parent_artifact_id <> child_artifact_id)
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_artifacts_lineage_child_idx
+  ON supacloud_artifacts.lineage (child_artifact_id, created_at, parent_artifact_id);
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.guard_storage_object()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM supacloud_artifacts.artifacts artifact
+    WHERE artifact.storage_object_id = OLD.id
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IMMUTABLE' USING ERRCODE = '55000';
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS supacloud_artifact_storage_fence ON storage.objects;
+CREATE TRIGGER supacloud_artifact_storage_fence
+BEFORE UPDATE OR DELETE ON storage.objects
+FOR EACH ROW EXECUTE FUNCTION supacloud_artifacts.guard_storage_object();
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.snapshot(
+  p_artifact_id uuid,
+  p_idempotent boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object(
+    'artifactId', artifact.id,
+    'bucketId', artifact.bucket_id,
+    'objectPath', artifact.object_path,
+    'objectVersion', artifact.object_version,
+    'artifactType', artifact.artifact_type,
+    'sha256', artifact.sha256,
+    'sizeBytes', artifact.size_bytes::text,
+    'mimeType', artifact.mime_type,
+    'metadata', artifact.metadata,
+    'retentionUntil', artifact.retention_until,
+    'createdBy', artifact.created_by,
+    'createdAt', artifact.created_at,
+    'idempotent', p_idempotent,
+    'parents', coalesce((
+      SELECT jsonb_agg(jsonb_build_object(
+        'artifactId', edge.parent_artifact_id,
+        'relationType', edge.relation_type,
+        'metadata', edge.metadata,
+        'createdAt', edge.created_at
+      ) ORDER BY edge.created_at, edge.parent_artifact_id)
+      FROM supacloud_artifacts.lineage edge
+      WHERE edge.child_artifact_id = artifact.id
+    ), '[]'::jsonb)
+  )
+  FROM supacloud_artifacts.artifacts artifact
+  WHERE artifact.id = p_artifact_id
+$$;
+
+DROP FUNCTION IF EXISTS supacloud_artifacts.register(uuid, text, text, text, text, bigint, text, jsonb, timestamptz, uuid);
+CREATE OR REPLACE FUNCTION supacloud_artifacts.register(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  artifact_id uuid;
+  size_bytes bigint;
+  metadata jsonb;
+  retention_until timestamptz;
+  created_by uuid;
+  normalized_bucket text;
+  normalized_path text;
+  normalized_type text;
+  normalized_sha256 text;
+  normalized_mime text;
+  object_row storage.objects%ROWTYPE;
+  existing supacloud_artifacts.artifacts%ROWTYPE;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+  END IF;
+  artifact_id := (request ->> 'artifactId')::uuid;
+  size_bytes := (request ->> 'sizeBytes')::bigint;
+  metadata := coalesce(request -> 'metadata', '{}'::jsonb);
+  retention_until := (request ->> 'retentionUntil')::timestamptz;
+  created_by := (request ->> 'createdBy')::uuid;
+  normalized_bucket := nullif(btrim(request ->> 'bucketId'), '');
+  normalized_path := nullif(btrim(request ->> 'objectPath'), '');
+  normalized_type := nullif(btrim(request ->> 'artifactType'), '');
+  normalized_sha256 := lower(nullif(btrim(request ->> 'sha256'), ''));
+  normalized_mime := lower(nullif(btrim(request ->> 'mimeType'), ''));
+  IF artifact_id IS NULL OR normalized_bucket IS NULL OR normalized_path IS NULL
+     OR normalized_path LIKE '/%' OR normalized_path LIKE '%\\%'
+     OR normalized_path ~ '(^|/)(\.|\.\.)(/|$)'
+     OR normalized_type IS NULL
+     OR normalized_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_sha256 IS NULL OR normalized_sha256 !~ '^[0-9a-f]{64}$'
+     OR size_bytes IS NULL OR size_bytes < 0
+     OR normalized_mime IS NULL OR char_length(normalized_mime) > 255
+     OR jsonb_typeof(metadata) IS DISTINCT FROM 'object'
+     OR (retention_until IS NOT NULL AND retention_until < now()) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO object_row FROM storage.objects
+  WHERE bucket_id = normalized_bucket AND name = normalized_path;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_OBJECT_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(artifact_id::text, 0));
+  SELECT * INTO existing FROM supacloud_artifacts.artifacts WHERE id = artifact_id;
+  IF FOUND THEN
+    IF existing.storage_object_id <> object_row.id
+       OR existing.artifact_type <> normalized_type
+       OR existing.sha256 <> normalized_sha256
+       OR existing.size_bytes <> size_bytes
+       OR existing.mime_type <> normalized_mime
+       OR existing.metadata <> metadata
+       OR existing.retention_until IS DISTINCT FROM retention_until
+       OR existing.created_by IS DISTINCT FROM created_by THEN
+      RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+    END IF;
+    RETURN supacloud_artifacts.snapshot(artifact_id, true);
+  END IF;
+
+  INSERT INTO supacloud_artifacts.artifacts (
+    id, storage_object_id, bucket_id, object_path, object_version,
+    artifact_type, sha256, size_bytes, mime_type, metadata,
+    retention_until, created_by
+  ) VALUES (
+    artifact_id, object_row.id, normalized_bucket, normalized_path,
+    object_row.version::text, normalized_type, normalized_sha256,
+    size_bytes, normalized_mime, metadata, retention_until, created_by
+  );
+  RETURN supacloud_artifacts.snapshot(artifact_id, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.link(
+  p_parent_artifact_id uuid,
+  p_child_artifact_id uuid,
+  p_relation_type text,
+  p_metadata jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  normalized_relation text := nullif(btrim(p_relation_type), '');
+  inserted_count integer;
+BEGIN
+  IF p_parent_artifact_id IS NULL OR p_child_artifact_id IS NULL
+     OR p_parent_artifact_id = p_child_artifact_id
+     OR normalized_relation IS NULL
+     OR normalized_relation !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR jsonb_typeof(p_metadata) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_INVALID' USING ERRCODE = '22023';
+  END IF;
+  IF EXISTS (
+    WITH RECURSIVE descendants(artifact_id) AS (
+      SELECT edge.child_artifact_id
+      FROM supacloud_artifacts.lineage edge
+      WHERE edge.parent_artifact_id = p_child_artifact_id
+      UNION
+      SELECT edge.child_artifact_id
+      FROM supacloud_artifacts.lineage edge
+      JOIN descendants current ON edge.parent_artifact_id = current.artifact_id
+    )
+    SELECT 1 FROM descendants WHERE artifact_id = p_parent_artifact_id
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_CYCLE' USING ERRCODE = '23514';
+  END IF;
+  INSERT INTO supacloud_artifacts.lineage (
+    parent_artifact_id, child_artifact_id, relation_type, metadata
+  ) VALUES (
+    p_parent_artifact_id, p_child_artifact_id, normalized_relation, p_metadata
+  ) ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS inserted_count = ROW_COUNT;
+  IF inserted_count = 0 AND NOT EXISTS (
+    SELECT 1 FROM supacloud_artifacts.lineage
+    WHERE parent_artifact_id = p_parent_artifact_id
+      AND child_artifact_id = p_child_artifact_id
+      AND relation_type = normalized_relation
+      AND metadata = p_metadata
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+  END IF;
+  RETURN supacloud_artifacts.snapshot(p_child_artifact_id, inserted_count = 0);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_register(request jsonb)
+RETURNS jsonb
+LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT supacloud_artifacts.register(request)
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_get(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RETURN supacloud_artifacts.snapshot((request ->> 'artifactId')::uuid, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_GET_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_link(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RETURN supacloud_artifacts.link(
+    (request ->> 'parentArtifactId')::uuid,
+    (request ->> 'childArtifactId')::uuid,
+    request ->> 'relationType',
+    coalesce(request -> 'metadata', '{}'::jsonb)
+  );
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA supacloud_artifacts
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA supacloud_artifacts
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_register(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_get(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_link(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_register(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_get(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_link(jsonb) TO service_role;

--- a/packages/management-api/src/db/sql-modules/commands-public.sql
+++ b/packages/management-api/src/db/sql-modules/commands-public.sql
@@ -1,0 +1,171 @@
+CREATE SCHEMA IF NOT EXISTS supacloud_commands;
+REVOKE ALL ON SCHEMA supacloud_commands FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA supacloud_commands TO service_role;
+
+CREATE TABLE IF NOT EXISTS supacloud_commands.receipts (
+  id uuid PRIMARY KEY,
+  command_type text NOT NULL
+    CHECK (command_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  target_type text NOT NULL
+    CHECK (target_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  target_id text NOT NULL CHECK (char_length(target_id) BETWEEN 1 AND 500),
+  actor_id uuid,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb
+    CHECK (jsonb_typeof(payload) = 'object'),
+  payload_fingerprint text NOT NULL CHECK (char_length(payload_fingerprint) = 36),
+  workflow_run_id uuid NOT NULL UNIQUE
+    REFERENCES supacloud_workflows.runs(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_commands_target_idx
+  ON supacloud_commands.receipts (target_type, target_id, created_at DESC, id);
+
+CREATE OR REPLACE FUNCTION supacloud_commands.snapshot(
+  p_command_id uuid,
+  p_idempotent boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object(
+    'commandId', receipt.id,
+    'commandType', receipt.command_type,
+    'targetType', receipt.target_type,
+    'targetId', receipt.target_id,
+    'actorId', receipt.actor_id,
+    'payloadFingerprint', receipt.payload_fingerprint,
+    'createdAt', receipt.created_at,
+    'idempotent', p_idempotent,
+    'workflow', supacloud_workflows.snapshot(receipt.workflow_run_id, false)
+  )
+  FROM supacloud_commands.receipts receipt
+  WHERE receipt.id = p_command_id
+$$;
+
+-- Application-owned SECURITY DEFINER RPCs may call this after their domain
+-- mutation. PostgreSQL commits the domain write, receipt, and workflow enqueue
+-- together, so a lost response can be replayed with the same command ID.
+DROP FUNCTION IF EXISTS supacloud_commands.submit(uuid, text, text, text, uuid, jsonb, integer);
+CREATE OR REPLACE FUNCTION supacloud_commands.submit(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  command_id_text text;
+  command_id uuid;
+  actor_id uuid;
+  max_attempts integer;
+  payload jsonb;
+  normalized_command_type text;
+  normalized_target_type text;
+  normalized_target_id text;
+  fingerprint text;
+  existing supacloud_commands.receipts%ROWTYPE;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id_text := request ->> 'commandId';
+  IF command_id_text IS NULL
+     OR command_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id := command_id_text::uuid;
+  IF request ? 'actorId' AND request ->> 'actorId' IS NOT NULL THEN
+    actor_id := (request ->> 'actorId')::uuid;
+  END IF;
+  max_attempts := coalesce((request ->> 'maxAttempts')::integer, 3);
+  payload := coalesce(request -> 'payload', '{}'::jsonb);
+  normalized_command_type := nullif(btrim(request ->> 'commandType'), '');
+  normalized_target_type := nullif(btrim(request ->> 'targetType'), '');
+  normalized_target_id := nullif(btrim(request ->> 'targetId'), '');
+  IF normalized_command_type IS NULL
+     OR normalized_command_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_target_type IS NULL
+     OR normalized_target_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_target_id IS NULL
+     OR char_length(normalized_target_id) > 500
+     OR jsonb_typeof(payload) IS DISTINCT FROM 'object'
+     OR max_attempts NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  fingerprint := 'md5:' || md5(payload::text);
+  PERFORM pg_advisory_xact_lock(hashtextextended(command_id::text, 0));
+  SELECT * INTO existing FROM supacloud_commands.receipts WHERE id = command_id;
+  IF FOUND THEN
+    IF existing.command_type <> normalized_command_type
+       OR existing.target_type <> normalized_target_type
+       OR existing.target_id <> normalized_target_id
+       OR existing.actor_id IS DISTINCT FROM actor_id
+       OR existing.payload <> payload
+       OR existing.payload_fingerprint <> fingerprint THEN
+      RAISE EXCEPTION 'SUPACLOUD_COMMAND_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+    END IF;
+    RETURN supacloud_commands.snapshot(command_id, true);
+  END IF;
+
+  PERFORM supacloud_workflows.start_run(
+    command_id,
+    'command.' || normalized_command_type,
+    '1',
+    'execute',
+    jsonb_build_object(
+      'commandId', command_id,
+      'commandType', normalized_command_type,
+      'targetType', normalized_target_type,
+      'targetId', normalized_target_id,
+      'actorId', actor_id,
+      'payload', payload,
+      'payloadFingerprint', fingerprint
+    ),
+    max_attempts
+  );
+
+  INSERT INTO supacloud_commands.receipts (
+    id, command_type, target_type, target_id, actor_id, payload,
+    payload_fingerprint, workflow_run_id
+  ) VALUES (
+    command_id, normalized_command_type, normalized_target_type,
+    normalized_target_id, actor_id, payload, fingerprint, command_id
+  );
+  RETURN supacloud_commands.snapshot(command_id, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_command_submit(request jsonb)
+RETURNS jsonb
+LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT supacloud_commands.submit(request)
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_command_get(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  command_id_text text;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id_text := request ->> 'commandId';
+  IF command_id_text IS NULL
+     OR command_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+  END IF;
+  RETURN supacloud_commands.snapshot(command_id_text::uuid, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA supacloud_commands
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA supacloud_commands
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.supacloud_command_submit(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_command_get(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.supacloud_command_submit(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_command_get(jsonb) TO service_role;

--- a/packages/management-api/src/routes/project-config.ts
+++ b/packages/management-api/src/routes/project-config.ts
@@ -72,6 +72,35 @@ import {
   type ReplicationSettingRow,
   summarizePowerSyncReadiness,
 } from "../services/replication-readiness";
+import {
+  tenantRuntimeService,
+  type PostgrestRuntimeStatus,
+} from "../services/tenant-runtime.service";
+import {
+  effectivePostgrestSchemas,
+  normalizeCustomPostgrestSchemas,
+  postgrestSchemasRevision,
+  PostgrestSchemaConfigError,
+  projectCustomPostgrestSchemas,
+} from "../utils/postgrest-schema-config";
+
+type ProjectSettings = Record<string, unknown>;
+
+interface PostgrestSchemaPatchRequest {
+  exposed_schemas: string[];
+  expected_revision?: string;
+}
+
+class PostgrestSchemaUpdateError extends Error {
+  constructor(
+    readonly httpStatus: 400 | 409 | 503,
+    readonly code: string,
+    message: string,
+    readonly details: Record<string, unknown> = {},
+  ) {
+    super(message);
+  }
+}
 
 /** Map PostgreSQL column types to TypeScript types */
 function pgTypeToTs(udtName: string, dataType: string): string {
@@ -218,6 +247,208 @@ async function projectDatabaseConnection(projectRef: string) {
   const databaseName = await resolveDbName(projectRef);
   quoteDatabaseIdentifier(databaseName);
   return { databaseName, database: getProjectDb(databaseName) };
+}
+
+async function readPostgrestSchemaState(
+  projectRef: string,
+  settings: ProjectSettings,
+) {
+  const customSchemas = projectCustomPostgrestSchemas(settings);
+  const { database } = await projectDatabaseConnection(projectRef);
+  const rows = await database.unsafe(
+    "SELECT nspname FROM pg_namespace ORDER BY nspname",
+  ) as Array<{ nspname: string }>;
+  const availableSchemas = new Set(rows.map((row) => row.nspname));
+  const missingSchemas = customSchemas.filter(
+    (schema) => !availableSchemas.has(schema),
+  );
+  return {
+    exposed_schemas: customSchemas,
+    effective_schemas: effectivePostgrestSchemas(
+      customSchemas,
+      availableSchemas.has("pgmq_public"),
+    ),
+    revision: postgrestSchemasRevision(customSchemas),
+    missing_schemas: missingSchemas,
+  };
+}
+
+type PostgrestSchemaState = Awaited<
+  ReturnType<typeof readPostgrestSchemaState>
+>;
+
+function currentPostgrestSettings(settings: ProjectSettings) {
+  return (settings.postgrest as ProjectSettings | undefined) || {};
+}
+
+function settingsWithPostgrestSchemas(
+  settings: ProjectSettings,
+  exposedSchemas: string[],
+) {
+  return {
+    ...settings,
+    postgrest: {
+      ...currentPostgrestSettings(settings),
+      exposed_schemas: exposedSchemas,
+    },
+  };
+}
+
+function assertPostgrestRevision(
+  settings: ProjectSettings,
+  expectedRevision?: string,
+) {
+  const currentRevision = postgrestSchemasRevision(
+    projectCustomPostgrestSchemas(settings),
+  );
+  if (!expectedRevision || expectedRevision === currentRevision) {
+    return currentRevision;
+  }
+  throw new PostgrestSchemaUpdateError(
+    409,
+    "POSTGREST_SCHEMA_REVISION_CONFLICT",
+    "PostgREST schema configuration changed since it was read",
+    { revision: currentRevision },
+  );
+}
+
+async function validatePostgrestSchemas(
+  projectRef: string,
+  settings: ProjectSettings,
+  exposedSchemas: string[],
+): Promise<PostgrestSchemaState> {
+  let schemaState: PostgrestSchemaState;
+  try {
+    schemaState = await readPostgrestSchemaState(
+      projectRef,
+      settingsWithPostgrestSchemas(settings, exposedSchemas),
+    );
+  } catch (error: unknown) {
+    logger.warn("[project-config] Failed to validate PostgREST schemas", {
+      projectRef,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new PostgrestSchemaUpdateError(
+      503,
+      "POSTGREST_SCHEMA_VALIDATION_FAILED",
+      "Failed to validate schemas against the project database",
+    );
+  }
+  if (schemaState.missing_schemas.length === 0) return schemaState;
+  throw new PostgrestSchemaUpdateError(
+    400,
+    "POSTGREST_SCHEMA_NOT_FOUND",
+    "Every exposed schema must exist before it can be configured",
+    { missing_schemas: schemaState.missing_schemas },
+  );
+}
+
+async function readPostgrestRuntimeState(projectRef: string) {
+  try {
+    return await tenantRuntimeService.statusPostgrest(projectRef);
+  } catch (error: unknown) {
+    logger.warn("[project-config] Failed to read PostgREST runtime state", {
+      projectRef,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new PostgrestSchemaUpdateError(
+      503,
+      "POSTGREST_RUNTIME_READ_FAILED",
+      "Failed to read PostgREST runtime state; persisted configuration was not changed",
+    );
+  }
+}
+
+interface PostgrestSchemaApplyContext {
+  projectRef: string;
+  settings: ProjectSettings;
+  exposedSchemas: string[];
+  schemaState: PostgrestSchemaState;
+  runtimeBefore: PostgrestRuntimeStatus;
+}
+
+async function restorePostgrestSchemaConfig(
+  context: PostgrestSchemaApplyContext,
+) {
+  try {
+    await projectService.updateProjectSettings(context.projectRef, {
+      ...context.settings,
+      postgrest: currentPostgrestSettings(context.settings),
+    });
+    if (context.runtimeBefore.desired === "running") {
+      await tenantRuntimeService.restartPostgrest(context.projectRef);
+    }
+    return true;
+  } catch (error: unknown) {
+    logger.error("[project-config] Failed to roll back PostgREST schema config", {
+      projectRef: context.projectRef,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+async function applyPostgrestSchemaConfig(
+  context: PostgrestSchemaApplyContext,
+) {
+  try {
+    const persisted = await projectService.updateProjectSettings(
+      context.projectRef,
+      settingsWithPostgrestSchemas(context.settings, context.exposedSchemas),
+    );
+    if (!persisted) throw new Error("Project settings update returned no result");
+    const runtimeApplied = context.runtimeBefore.desired === "running";
+    const runtime = runtimeApplied
+      ? await tenantRuntimeService.restartPostgrest(context.projectRef)
+      : context.runtimeBefore;
+    return {
+      ...context.schemaState,
+      idempotent: false,
+      runtime_applied: runtimeApplied,
+      restart_required: !runtimeApplied,
+      runtime,
+    };
+  } catch (error: unknown) {
+    logger.warn("[project-config] Failed to apply PostgREST schema config", {
+      projectRef: context.projectRef,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    const rollbackSucceeded = await restorePostgrestSchemaConfig(context);
+    throw new PostgrestSchemaUpdateError(
+      503,
+      "POSTGREST_SCHEMA_APPLY_FAILED",
+      "Failed to apply PostgREST schema configuration",
+      { rollback: { attempted: true, succeeded: rollbackSucceeded } },
+    );
+  }
+}
+
+async function updatePostgrestSchemaConfig(
+  projectRef: string,
+  settings: ProjectSettings,
+  request: PostgrestSchemaPatchRequest,
+) {
+  const exposedSchemas = normalizeCustomPostgrestSchemas(request.exposed_schemas);
+  const currentRevision = assertPostgrestRevision(
+    settings,
+    request.expected_revision,
+  );
+  const schemaState = await validatePostgrestSchemas(
+    projectRef,
+    settings,
+    exposedSchemas,
+  );
+  if (schemaState.revision === currentRevision) {
+    return { ...schemaState, idempotent: true, runtime_applied: false };
+  }
+  const runtimeBefore = await readPostgrestRuntimeState(projectRef);
+  return applyPostgrestSchemaConfig({
+    projectRef,
+    settings,
+    exposedSchemas,
+    schemaState,
+    runtimeBefore,
+  });
 }
 
 const CustomGatewayHostsSchema = t.Array(t.String(), {
@@ -1618,7 +1849,59 @@ export const projectConfigRoutes = new Elysia({ prefix: "/v1/projects" })
       detail: { tags: ["projects"], summary: "Update database config" },
 },
   )
-  .use(addConfigRoutes("postgrest"))
+  .get(
+    "/:ref/config/postgrest",
+    async ({ params }) => {
+      const settings = await projectService.getProjectSettings(params.ref);
+      if (!settings) return status(404, { message: "Project not found", code: "404" });
+      try {
+        return await readPostgrestSchemaState(params.ref, settings);
+      } catch (error: unknown) {
+        logger.warn("[project-config] Failed to read PostgREST schema state", {
+          projectRef: params.ref,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return status(503, {
+          code: "POSTGREST_SCHEMA_READ_FAILED",
+          message: "Failed to read the project PostgREST schema state",
+        });
+      }
+    },
+    {
+      params: t.Object({ ref: t.String() }),
+      detail: { tags: ["projects"], summary: "Get PostgREST exposed schemas" },
+    },
+  )
+  .patch(
+    "/:ref/config/postgrest",
+    async ({ params, body }) => {
+      const settings = await projectService.getProjectSettings(params.ref);
+      if (!settings) return status(404, { message: "Project not found", code: "404" });
+      try {
+        return await updatePostgrestSchemaConfig(params.ref, settings, body);
+      } catch (error: unknown) {
+        if (error instanceof PostgrestSchemaConfigError) {
+          return status(400, { code: error.code, message: error.message });
+        }
+        if (error instanceof PostgrestSchemaUpdateError) {
+          return status(error.httpStatus, {
+            code: error.code,
+            message: error.message,
+            ...error.details,
+          });
+        }
+        throw error;
+      }
+    },
+    {
+      params: t.Object({ ref: t.String() }),
+      body: t.Object({
+        exposed_schemas: t.Array(t.String(), { maxItems: 16 }),
+        expected_revision: t.Optional(t.String({ pattern: "^[0-9a-f]{64}$" })),
+      }),
+      detail: { tags: ["projects"], summary: "Update PostgREST exposed schemas" },
+    },
+  )
 
   // Config Storage — with official default fields
   .get(

--- a/packages/management-api/src/scripts/migrate-tenant-schema.ts
+++ b/packages/management-api/src/scripts/migrate-tenant-schema.ts
@@ -620,6 +620,12 @@ ${SQL_MODULES["pgmq-public"]}
 -- 17a. Service-role-only durable workflow execution built on PGMQ.
 ${SQL_MODULES["workflows-public"]}
 
+-- 17b. Transactional command receipts backed by durable workflows.
+${SQL_MODULES["commands-public"]}
+
+-- 17c. Immutable Storage artifact metadata and lineage.
+${SQL_MODULES["artifacts-public"]}
+
 -- 18. Realtime WAL logical replication support
 DO $$
 BEGIN

--- a/packages/management-api/src/services/tenant-runtime-config.ts
+++ b/packages/management-api/src/services/tenant-runtime-config.ts
@@ -1,6 +1,7 @@
 import { renderGoTrueEmailTemplateEnv } from "../utils/auth-email-templates";
 import { serializedProviderLinkingDomains } from "../utils/provider-linking";
 import { renderSystemdEnvLine } from "../utils/systemd-env";
+import { effectivePostgrestSchemas } from "../utils/postgrest-schema-config";
 
 export { renderGoTrueSessionPolicyEnv } from "./auth-session-policy";
 export { renderSystemdEnvLine } from "../utils/systemd-env";
@@ -84,12 +85,11 @@ export function pickPositivePort(value: unknown): number | null {
     return Math.trunc(port);
 }
 
-const DEFAULT_POSTGREST_SCHEMAS = ["public", "storage", "graphql_public"] as const;
-
-export function renderPostgrestDbSchemas(includePgmqPublic = false): string {
-    const schemas: string[] = [...DEFAULT_POSTGREST_SCHEMAS];
-    if (includePgmqPublic) schemas.push("pgmq_public");
-    return schemas.join(", ");
+export function renderPostgrestDbSchemas(
+    includePgmqPublic = false,
+    customSchemas: readonly string[] = [],
+): string {
+    return effectivePostgrestSchemas(customSchemas, includePgmqPublic).join(", ");
 }
 
 export function renderTenantInternalRuntimeEnv(pgrstPort: number, gotruePort: number): string {

--- a/packages/management-api/src/services/tenant-runtime-migration.ts
+++ b/packages/management-api/src/services/tenant-runtime-migration.ts
@@ -570,5 +570,7 @@ ${SQL_MODULES["background-task-mirror-up"]}
 -- Keep existing tenant databases aligned with the durable workflow runtime.
 ${SQL_MODULES["pgmq-public"]}
 ${SQL_MODULES["workflows-public"]}
+${SQL_MODULES["commands-public"]}
+${SQL_MODULES["artifacts-public"]}
 
 `;

--- a/packages/management-api/src/services/tenant-runtime.service.ts
+++ b/packages/management-api/src/services/tenant-runtime.service.ts
@@ -14,6 +14,7 @@ import {
     normalizeProjectConfig,
     resolveProjectExternalAuthEndpointConfig,
 } from "../utils/project-config";
+import { projectCustomPostgrestSchemas } from "../utils/postgrest-schema-config";
 import {
     buildSharedProjectJwtVerificationMaterial,
     normalizeProjectJwtKeys,
@@ -369,6 +370,7 @@ interface PostgrestCredentialMaterial {
     thirdPartyJwtPolicy: ThirdPartyJwtPolicy | null;
     dbName: string;
     apiUrl: string;
+    customPostgrestSchemas: string[];
 }
 
 export function renderDesiredPostgrestConfig(
@@ -1207,7 +1209,8 @@ class TenantRuntimeService {
             postgrestDesired: project.postgrest_desired,
             siteUrl,
             uriAllowList,
-            authConfig
+            authConfig,
+            customPostgrestSchemas: projectCustomPostgrestSchemas(projectConfig),
         };
     }
 
@@ -1472,6 +1475,7 @@ class TenantRuntimeService {
     ): Promise<string> {
         const databaseSchemas = renderPostgrestDbSchemas(
             await this.hasPgmqPublicSchema(ref, credentials.dbName, credentials.dbPassword),
+            credentials.customPostgrestSchemas,
         );
         return this.renderPostgrestCredentialConfig(
             ref,
@@ -1490,6 +1494,7 @@ class TenantRuntimeService {
         }
         const databaseSchemas = renderPostgrestDbSchemas(
             await this.queryPgmqPublicSchema(ref, credentials.dbName, credentials.dbPassword),
+            credentials.customPostgrestSchemas,
         );
         const content = this.renderPostgrestCredentialConfig(
             ref,

--- a/packages/management-api/src/utils/postgrest-schema-config.ts
+++ b/packages/management-api/src/utils/postgrest-schema-config.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+import { normalizeProjectConfig } from "./project-config";
+
+export const BASE_POSTGREST_SCHEMAS = ["public", "storage", "graphql_public"] as const;
+export const MAX_CUSTOM_POSTGREST_SCHEMAS = 16;
+
+const SCHEMA_NAME_PATTERN = /^[a-z][a-z0-9_]{0,62}$/;
+const RESERVED_SCHEMAS = new Set([
+  ...BASE_POSTGREST_SCHEMAS,
+  "auth",
+  "extensions",
+  "information_schema",
+  "pg_catalog",
+  "pgmq",
+  "pgmq_public",
+  "realtime",
+  "supabase_migrations",
+  "vault",
+]);
+
+export class PostgrestSchemaConfigError extends Error {
+  constructor(
+    message: string,
+    readonly code = "INVALID_POSTGREST_SCHEMAS",
+  ) {
+    super(message);
+    this.name = "PostgrestSchemaConfigError";
+  }
+}
+
+export function normalizeCustomPostgrestSchemas(value: unknown): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new PostgrestSchemaConfigError("exposed_schemas must be an array of schema names");
+  }
+  if (value.length > MAX_CUSTOM_POSTGREST_SCHEMAS) {
+    throw new PostgrestSchemaConfigError(
+      `exposed_schemas cannot contain more than ${MAX_CUSTOM_POSTGREST_SCHEMAS} schemas`,
+    );
+  }
+
+  const normalized = value.map((entry) => {
+    if (typeof entry !== "string") {
+      throw new PostgrestSchemaConfigError("exposed_schemas must contain only strings");
+    }
+    const schema = entry.trim().toLowerCase();
+    if (!SCHEMA_NAME_PATTERN.test(schema)) {
+      throw new PostgrestSchemaConfigError(`Invalid PostgREST schema name: ${entry}`);
+    }
+    if (RESERVED_SCHEMAS.has(schema) || schema.startsWith("pg_")
+      || schema.startsWith("supabase_") || schema.startsWith("supacloud_")) {
+      throw new PostgrestSchemaConfigError(`Schema is reserved by the platform: ${schema}`);
+    }
+    return schema;
+  });
+
+  return [...new Set(normalized)].sort();
+}
+
+export function projectCustomPostgrestSchemas(projectConfig: unknown): string[] {
+  const config = normalizeProjectConfig(projectConfig);
+  const postgrest = config.postgrest;
+  if (!postgrest || typeof postgrest !== "object" || Array.isArray(postgrest)) return [];
+  return normalizeCustomPostgrestSchemas((postgrest as Record<string, unknown>).exposed_schemas);
+}
+
+export function effectivePostgrestSchemas(
+  customSchemas: readonly string[],
+  includePgmqPublic = false,
+): string[] {
+  return [
+    ...BASE_POSTGREST_SCHEMAS,
+    ...(includePgmqPublic ? ["pgmq_public"] : []),
+    ...customSchemas,
+  ];
+}
+
+export function postgrestSchemasRevision(customSchemas: readonly string[]): string {
+  return createHash("sha256").update(JSON.stringify([...customSchemas])).digest("hex");
+}

--- a/packages/management-api/tests/unit/postgrest-schema-config.test.ts
+++ b/packages/management-api/tests/unit/postgrest-schema-config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import {
+  effectivePostgrestSchemas,
+  normalizeCustomPostgrestSchemas,
+  postgrestSchemasRevision,
+  projectCustomPostgrestSchemas,
+} from "../../src/utils/postgrest-schema-config";
+
+describe("PostgREST schema configuration", () => {
+  test("normalizes project-owned schemas deterministically", () => {
+    expect(normalizeCustomPostgrestSchemas(["RPC", " api ", "rpc"])).toEqual(["api", "rpc"]);
+    expect(projectCustomPostgrestSchemas({ postgrest: { exposed_schemas: ["workflow", "api"] } }))
+      .toEqual(["api", "workflow"]);
+    expect(effectivePostgrestSchemas(["api"], true)).toEqual([
+      "public", "storage", "graphql_public", "pgmq_public", "api",
+    ]);
+  });
+
+  test("rejects reserved, quoted, and platform-owned schemas", () => {
+    for (const schema of ["auth", "pg_catalog", "pg_secret", "supabase_demo", "supacloud_demo", "Api-V2"]) {
+      expect(() => normalizeCustomPostgrestSchemas([schema])).toThrow();
+    }
+  });
+
+  test("binds revisions to the normalized schema set", () => {
+    const first = normalizeCustomPostgrestSchemas(["rpc", "api"]);
+    const second = normalizeCustomPostgrestSchemas(["api", "rpc"]);
+    expect(postgrestSchemasRevision(first)).toBe(postgrestSchemasRevision(second));
+    expect(postgrestSchemasRevision(first)).not.toBe(postgrestSchemasRevision(["api"]));
+  });
+});

--- a/packages/management-api/tests/unit/project-postgrest-config.routes.test.ts
+++ b/packages/management-api/tests/unit/project-postgrest-config.routes.test.ts
@@ -1,0 +1,163 @@
+// @supacloud-test-isolate
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const authModule = await import("../../src/middleware/auth");
+const databaseModule = await import("../../src/db");
+const servicesModule = await import("../../src/services");
+const runtimeModule = await import("../../src/services/tenant-runtime.service");
+
+const requireProjectOrAdminAuth = mock(async () => null);
+const getProjectSettings = mock(async () => ({ postgrest: { exposed_schemas: ["api"] } }));
+const updateProjectSettings = mock(async (_ref: string, settings: unknown) => settings);
+const databaseUnsafe = mock(async () => [
+  { nspname: "api" },
+  { nspname: "graphql_public" },
+  { nspname: "pgmq_public" },
+  { nspname: "public" },
+  { nspname: "storage" },
+]);
+const statusPostgrest = mock(async () => ({ desired: "running", actual: "running", health: "healthy" }));
+const restartPostgrest = mock(async () => ({ desired: "running", actual: "running", health: "healthy" }));
+
+const spies = [
+  spyOn(authModule, "requireProjectOrAdminAuth").mockImplementation(
+    requireProjectOrAdminAuth as typeof authModule.requireProjectOrAdminAuth,
+  ),
+  spyOn(databaseModule, "resolveDbName").mockResolvedValue("supa_proj_1"),
+  spyOn(databaseModule, "getProjectDb").mockImplementation(
+    () => ({ unsafe: databaseUnsafe }) as never,
+  ),
+  spyOn(servicesModule.projectService, "getProjectSettings").mockImplementation(
+    getProjectSettings as typeof servicesModule.projectService.getProjectSettings,
+  ),
+  spyOn(servicesModule.projectService, "updateProjectSettings").mockImplementation(
+    updateProjectSettings as typeof servicesModule.projectService.updateProjectSettings,
+  ),
+  spyOn(runtimeModule.tenantRuntimeService, "statusPostgrest").mockImplementation(
+    statusPostgrest as typeof runtimeModule.tenantRuntimeService.statusPostgrest,
+  ),
+  spyOn(runtimeModule.tenantRuntimeService, "restartPostgrest").mockImplementation(
+    restartPostgrest as typeof runtimeModule.tenantRuntimeService.restartPostgrest,
+  ),
+];
+
+const { projectConfigRoutes } = await import(
+  "../../src/routes/project-config?project-postgrest-config-routes-test"
+);
+const app = new Elysia().use(projectConfigRoutes);
+
+function request(method: "GET" | "PATCH", body?: Record<string, unknown>) {
+  return app.handle(new Request("http://localhost/v1/projects/proj_1/config/postgrest", {
+    method,
+    headers: {
+      authorization: "Bearer dev-master-token",
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  }));
+}
+
+afterAll(() => spies.forEach((spy) => spy.mockRestore()));
+
+beforeEach(() => {
+  getProjectSettings.mockReset();
+  getProjectSettings.mockResolvedValue({ postgrest: { exposed_schemas: ["api"] } } as never);
+  updateProjectSettings.mockReset();
+  updateProjectSettings.mockImplementation(async (_ref, settings) => settings as never);
+  databaseUnsafe.mockReset();
+  databaseUnsafe.mockResolvedValue([
+    { nspname: "api" }, { nspname: "graphql_public" }, { nspname: "pgmq_public" },
+    { nspname: "public" }, { nspname: "rpc" }, { nspname: "storage" },
+  ]);
+  statusPostgrest.mockReset();
+  statusPostgrest.mockResolvedValue({ desired: "running", actual: "running", health: "healthy" } as never);
+  restartPostgrest.mockReset();
+  restartPostgrest.mockResolvedValue({ desired: "running", actual: "running", health: "healthy" } as never);
+});
+
+describe("project PostgREST schema config routes", () => {
+  test("GET reports custom, effective, and missing schemas", async () => {
+    const response = await request("GET");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      exposed_schemas: ["api"],
+      effective_schemas: ["public", "storage", "graphql_public", "pgmq_public", "api"],
+      missing_schemas: [],
+    });
+  });
+
+  test("PATCH persists a normalized schema set and restarts a running runtime", async () => {
+    const response = await request("PATCH", { exposed_schemas: ["RPC", "api"] });
+    expect(response.status).toBe(200);
+    expect(updateProjectSettings).toHaveBeenCalledWith("proj_1", expect.objectContaining({
+      postgrest: { exposed_schemas: ["api", "rpc"] },
+    }));
+    expect(restartPostgrest).toHaveBeenCalledTimes(1);
+    expect(await response.json()).toMatchObject({
+      exposed_schemas: ["api", "rpc"],
+      runtime_applied: true,
+      idempotent: false,
+    });
+  });
+
+  test("PATCH rejects missing schemas before persistence", async () => {
+    databaseUnsafe.mockResolvedValue([{ nspname: "public" }, { nspname: "storage" }, { nspname: "graphql_public" }]);
+    const response = await request("PATCH", { exposed_schemas: ["missing_api"] });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      code: "POSTGREST_SCHEMA_NOT_FOUND",
+      missing_schemas: ["missing_api"],
+    });
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+  });
+
+  test("PATCH rejects stale revisions without side effects", async () => {
+    const response = await request("PATCH", {
+      exposed_schemas: ["api", "rpc"],
+      expected_revision: "0".repeat(64),
+    });
+    expect(response.status).toBe(409);
+    expect(updateProjectSettings).not.toHaveBeenCalled();
+    expect(restartPostgrest).not.toHaveBeenCalled();
+  });
+
+  test("PATCH persists paused runtime changes without restarting PostgREST", async () => {
+    statusPostgrest.mockResolvedValue({
+      desired: "stopped",
+      actual: "stopped",
+      health: "unknown",
+    } as never);
+
+    const response = await request("PATCH", { exposed_schemas: ["api", "rpc"] });
+
+    expect(response.status).toBe(200);
+    expect(restartPostgrest).not.toHaveBeenCalled();
+    expect(await response.json()).toMatchObject({
+      runtime_applied: false,
+      restart_required: true,
+    });
+  });
+
+  test("PATCH restores persisted and running state after restart failure", async () => {
+    restartPostgrest.mockRejectedValueOnce(new Error("restart failed"));
+    restartPostgrest.mockResolvedValueOnce({
+      desired: "running",
+      actual: "running",
+      health: "healthy",
+    } as never);
+
+    const response = await request("PATCH", { exposed_schemas: ["api", "rpc"] });
+
+    expect(response.status).toBe(503);
+    expect(updateProjectSettings).toHaveBeenCalledTimes(2);
+    expect(updateProjectSettings.mock.calls[1]?.[1]).toMatchObject({
+      postgrest: { exposed_schemas: ["api"] },
+    });
+    expect(restartPostgrest).toHaveBeenCalledTimes(2);
+    expect(await response.json()).toMatchObject({
+      code: "POSTGREST_SCHEMA_APPLY_FAILED",
+      rollback: { attempted: true, succeeded: true },
+    });
+  });
+});

--- a/packages/management-api/tests/unit/tenant-runtime.env.test.ts
+++ b/packages/management-api/tests/unit/tenant-runtime.env.test.ts
@@ -116,6 +116,15 @@ describe("TenantRuntimeService PostgREST schema rendering", () => {
     expect(renderPostgrestDbSchemas(true)).toBe("public, storage, graphql_public, pgmq_public");
   });
 
+  test("appends validated project-owned schemas after platform schemas", () => {
+    expect(renderPostgrestDbSchemas(false, ["api", "rpc"])).toBe(
+      "public, storage, graphql_public, api, rpc",
+    );
+    expect(renderPostgrestDbSchemas(true, ["api"])).toBe(
+      "public, storage, graphql_public, pgmq_public, api",
+    );
+  });
+
   test("renders tenant-local internal runtime env for Edge Functions", () => {
     expect(renderTenantInternalRuntimeEnv(3272, 4272)).toBe([
       "SUPACLOUD_INTERNAL_POSTGREST_PORT=3272",

--- a/packages/supacloud-js/README.md
+++ b/packages/supacloud-js/README.md
@@ -10,6 +10,8 @@ It does **not** replace [`@supabase/supabase-js`](https://www.npmjs.com/package/
 - Realtime subscription with polling fallback
 - Supabase Queues helpers backed by the official `pgmq_public` RPC API, plus SupaCloud management extensions for queue administration and diagnostics
 - Service-role-only durable workflow helpers backed by PostgreSQL and PGMQ
+- Service-role-only transactional command receipts backed by Durable Workflows
+- Immutable Storage artifact registration and lineage helpers
 - project OAuth/OIDC migration and OAuth client management
 - SupAuth provisioning and runtime verification helpers
 
@@ -178,6 +180,11 @@ The current package focuses on:
 - `supauth.rollback`
 - `supauth.getClientConfig`
 - `supauth.verify`
+- `commands.submit`
+- `commands.get`
+- `artifacts.register`
+- `artifacts.get`
+- `artifacts.link`
 
 ## Status Subscription
 

--- a/packages/supacloud-js/src/artifacts.test.ts
+++ b/packages/supacloud-js/src/artifacts.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createSupaCloudClient } from "./index";
+
+function artifactClient() {
+  const rpc = mock(async (functionName: string, params: { request: object }) => ({
+    data: { functionName, params }, error: null,
+  }));
+  const supabase = { rpc, auth: { getSession: async () => ({ data: { session: null }, error: null }) } };
+  return {
+    artifacts: createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "http://management-not-used",
+      projectRef: "project-ref",
+    }).artifacts,
+    rpc,
+  };
+}
+
+describe("SupaCloud artifact registry client", () => {
+  test("maps register, get, and lineage link to RPCs", async () => {
+    const { artifacts, rpc } = artifactClient();
+    await artifacts.register({
+      artifactId: "11111111-1111-4111-8111-111111111111",
+      bucketId: "reports",
+      objectPath: "2026/report.pdf",
+      artifactType: "report.pdf",
+      sha256: "a".repeat(64),
+      sizeBytes: "1024",
+      mimeType: "application/pdf",
+    });
+    await artifacts.get("11111111-1111-4111-8111-111111111111");
+    await artifacts.link({
+      parentArtifactId: "22222222-2222-4222-8222-222222222222",
+      childArtifactId: "11111111-1111-4111-8111-111111111111",
+      relationType: "rendered_from",
+    });
+    expect(rpc).toHaveBeenCalledTimes(3);
+    expect(rpc.mock.calls[0]?.[0]).toBe("supacloud_artifact_register");
+    expect(rpc.mock.calls[1]?.[0]).toBe("supacloud_artifact_get");
+    expect(rpc.mock.calls[2]?.[0]).toBe("supacloud_artifact_link");
+  });
+});

--- a/packages/supacloud-js/src/artifacts.ts
+++ b/packages/supacloud-js/src/artifacts.ts
@@ -1,0 +1,67 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { invokeServiceRoleRpc } from "./service-role-rpc.js";
+
+export type SupaCloudArtifactJson = Record<string, unknown>;
+
+export interface SupaCloudArtifactParent {
+  artifactId: string;
+  relationType: string;
+  metadata: SupaCloudArtifactJson;
+  createdAt: string;
+}
+
+export interface SupaCloudArtifact {
+  artifactId: string;
+  bucketId: string;
+  objectPath: string;
+  objectVersion: string;
+  artifactType: string;
+  sha256: string;
+  sizeBytes: string;
+  mimeType: string;
+  metadata: SupaCloudArtifactJson;
+  retentionUntil: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  idempotent: boolean;
+  parents: SupaCloudArtifactParent[];
+}
+
+export interface SupaCloudArtifactRegisterRequest {
+  artifactId: string;
+  bucketId: string;
+  objectPath: string;
+  artifactType: string;
+  sha256: string;
+  sizeBytes: string | number;
+  mimeType: string;
+  metadata?: SupaCloudArtifactJson;
+  retentionUntil?: string;
+  createdBy?: string;
+}
+
+export interface SupaCloudArtifactLinkRequest {
+  parentArtifactId: string;
+  childArtifactId: string;
+  relationType: string;
+  metadata?: SupaCloudArtifactJson;
+}
+
+/** Service-role-only immutable Storage artifact registry client. */
+export class SupaCloudArtifactsClient<TClient extends SupabaseClient = SupabaseClient> {
+  constructor(private readonly supabase: TClient) {}
+
+  register(request: SupaCloudArtifactRegisterRequest): Promise<SupaCloudArtifact> {
+    return invokeServiceRoleRpc(this.supabase, "supacloud_artifact_register", request);
+  }
+
+  get(artifactId: string): Promise<SupaCloudArtifact | null> {
+    return invokeServiceRoleRpc(this.supabase, "supacloud_artifact_get", {
+      artifactId,
+    });
+  }
+
+  link(request: SupaCloudArtifactLinkRequest): Promise<SupaCloudArtifact> {
+    return invokeServiceRoleRpc(this.supabase, "supacloud_artifact_link", request);
+  }
+}

--- a/packages/supacloud-js/src/commands.test.ts
+++ b/packages/supacloud-js/src/commands.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createSupaCloudClient } from "./index";
+
+function commandClient() {
+  const rpc = mock(async (functionName: string, params: { request: object }) => ({
+    data: { functionName, params }, error: null,
+  }));
+  const supabase = { rpc, auth: { getSession: async () => ({ data: { session: null }, error: null }) } };
+  return {
+    commands: createSupaCloudClient({
+      supabase: supabase as never,
+      managementApiUrl: "http://management-not-used",
+      projectRef: "project-ref",
+    }).commands,
+    rpc,
+  };
+}
+
+describe("SupaCloud command receipts client", () => {
+  test("maps submit and get to service-role RPCs", async () => {
+    const { commands, rpc } = commandClient();
+    const request = {
+      commandId: "11111111-1111-4111-8111-111111111111",
+      commandType: "report.issue",
+      targetType: "report",
+      targetId: "report-1",
+      actorId: "22222222-2222-4222-8222-222222222222",
+      payload: { reportId: "report-1" },
+      maxAttempts: 4,
+    };
+    await commands.submit(request);
+    await commands.get(request.commandId);
+    expect(rpc).toHaveBeenCalledTimes(2);
+    expect(rpc.mock.calls[0]?.[0]).toBe("supacloud_command_submit");
+    expect(rpc.mock.calls[1]?.[0]).toBe("supacloud_command_get");
+    expect(rpc.mock.calls[0]?.[1]).toMatchObject({ request });
+  });
+});

--- a/packages/supacloud-js/src/commands.ts
+++ b/packages/supacloud-js/src/commands.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { invokeServiceRoleRpc } from "./service-role-rpc.js";
+import type { SupaCloudWorkflowJson, SupaCloudWorkflowRun } from "./workflows.js";
+
+export interface SupaCloudCommandSubmitRequest {
+  commandId: string;
+  commandType: string;
+  targetType: string;
+  targetId: string;
+  actorId?: string;
+  payload?: SupaCloudWorkflowJson;
+  maxAttempts?: number;
+}
+
+export interface SupaCloudCommandReceipt {
+  commandId: string;
+  commandType: string;
+  targetType: string;
+  targetId: string;
+  actorId: string | null;
+  payloadFingerprint: string;
+  createdAt: string;
+  idempotent: boolean;
+  workflow: SupaCloudWorkflowRun;
+}
+
+/**
+ * Service-role-only transactional command receipt client. Application-owned
+ * database RPCs can call `supacloud_commands.submit` directly inside a larger
+ * transaction when the domain write and durable enqueue must commit together.
+ */
+export class SupaCloudCommandsClient<TClient extends SupabaseClient = SupabaseClient> {
+  constructor(private readonly supabase: TClient) {}
+
+  submit(request: SupaCloudCommandSubmitRequest): Promise<SupaCloudCommandReceipt> {
+    return invokeServiceRoleRpc(this.supabase, "supacloud_command_submit", request);
+  }
+
+  get(commandId: string): Promise<SupaCloudCommandReceipt | null> {
+    return invokeServiceRoleRpc(this.supabase, "supacloud_command_get", {
+      commandId,
+    });
+  }
+}

--- a/packages/supacloud-js/src/index.ts
+++ b/packages/supacloud-js/src/index.ts
@@ -3,12 +3,16 @@ import type {
   SupabaseClient,
 } from "@supabase/supabase-js";
 import { SupaCloudWorkflowsClient } from "./workflows.js";
+import { SupaCloudCommandsClient } from "./commands.js";
+import { SupaCloudArtifactsClient } from "./artifacts.js";
 
 export {
   createSupaCloudOAuthFetch,
   type SupaCloudOAuthFetchOptions,
 } from "./auth-fetch.js";
 export * from "./workflows.js";
+export * from "./commands.js";
+export * from "./artifacts.js";
 
 export type SupaCloudTaskStatus =
   | "pending"
@@ -1338,6 +1342,8 @@ export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseC
   const supauth = new SupaCloudSupAuthClient(normalized);
   const queues = new SupaCloudQueuesClient(normalized);
   const workflows = new SupaCloudWorkflowsClient(options.supabase);
+  const commands = new SupaCloudCommandsClient(options.supabase);
+  const artifacts = new SupaCloudArtifactsClient(options.supabase);
 
   return {
     supabase: options.supabase,
@@ -1349,6 +1355,8 @@ export function createSupaCloudClient<TClient extends SupabaseClient = SupabaseC
     },
     tasks,
     workflows,
+    commands,
+    artifacts,
     supauth,
     queues,
     queue: (name: string) => new SupaCloudQueueClient(normalized, name),

--- a/packages/supacloud-js/src/service-role-rpc.ts
+++ b/packages/supacloud-js/src/service-role-rpc.ts
@@ -1,0 +1,22 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+type ServiceRoleRpcClient = {
+  rpc(
+    rpcName: string,
+    params: { request: object },
+  ): Promise<{ data: unknown; error: unknown }>;
+};
+
+export async function invokeServiceRoleRpc<T>(
+  supabase: SupabaseClient,
+  functionName: string,
+  request: object,
+): Promise<T> {
+  const rpcClient = supabase as unknown as ServiceRoleRpcClient;
+  const { data: rpcResponse, error: rpcError } = await rpcClient.rpc(
+    functionName,
+    { request },
+  );
+  if (rpcError) throw rpcError;
+  return rpcResponse as T;
+}

--- a/packages/supacloud-js/src/workflows.ts
+++ b/packages/supacloud-js/src/workflows.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { invokeServiceRoleRpc } from "./service-role-rpc.js";
 
 export type SupaCloudWorkflowRunStatus =
   | "queued"
@@ -150,57 +151,48 @@ export interface SupaCloudWorkflowEvent {
 export class SupaCloudWorkflowsClient<TClient extends SupabaseClient = SupabaseClient> {
   constructor(private readonly supabase: TClient) {}
 
-  private async invoke<T>(functionName: string, request: object): Promise<T> {
-    const rpcClient = this.supabase as unknown as {
-      rpc(
-        rpcName: string,
-        params: { request: object },
-      ): Promise<{ data: unknown; error: unknown }>;
-    };
-    const { data: rpcResponse, error: rpcError } = await rpcClient.rpc(
-      functionName,
-      { request },
-    );
-    if (rpcError) throw rpcError;
-    return rpcResponse as T;
-  }
-
   start(request: SupaCloudWorkflowStartRequest): Promise<SupaCloudWorkflowRun> {
-    return this.invoke("supacloud_workflow_start", request);
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_start", request);
   }
 
   claim(request: SupaCloudWorkflowClaimRequest): Promise<SupaCloudWorkflowClaimResult> {
-    return this.invoke("supacloud_workflow_claim", request);
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_claim", request);
   }
 
   advance(request: SupaCloudWorkflowAdvanceRequest): Promise<SupaCloudWorkflowRun> {
-    return this.invoke("supacloud_workflow_advance", request);
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_advance", request);
   }
 
   complete(request: SupaCloudWorkflowCompleteRequest): Promise<SupaCloudWorkflowRun> {
-    return this.invoke("supacloud_workflow_complete", request);
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_complete", request);
   }
 
   retry(request: SupaCloudWorkflowRetryRequest): Promise<SupaCloudWorkflowRun> {
-    return this.invoke("supacloud_workflow_retry", request);
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_retry", request);
   }
 
   fail(request: SupaCloudWorkflowFailRequest): Promise<SupaCloudWorkflowRun> {
-    return this.invoke("supacloud_workflow_fail", request);
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_fail", request);
   }
 
   cancel(runId: string, reason: string): Promise<SupaCloudWorkflowRun> {
-    return this.invoke("supacloud_workflow_cancel", { runId, reason });
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_cancel", {
+      runId,
+      reason,
+    });
   }
 
   get(runId: string): Promise<SupaCloudWorkflowRun | null> {
-    return this.invoke("supacloud_workflow_get", { runId });
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_get", { runId });
   }
 
   events(
     runId: string,
     options: { afterEventId?: string; limit?: number } = {},
   ): Promise<SupaCloudWorkflowEvent[]> {
-    return this.invoke("supacloud_workflow_events", { runId, ...options });
+    return invokeServiceRoleRpc(this.supabase, "supacloud_workflow_events", {
+      runId,
+      ...options,
+    });
   }
 }

--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -312,7 +312,7 @@ supacloud-lite doctor --json \
   --powersync-tables public.eln_entries,public.eln_observations
 ```
 
-该 profile 使用独立 `supacloud_powersync` 登录角色、显式 `powersync` publication、`wal_level=logical`、4 个 sender、4 个 slot 和 `max_slot_wal_keep_size=1024MB`。默认只允许 loopback 上的 SCRAM 连接；非 loopback 监听必须同时提供 TLS 证书、权限受限的私钥和显式 CIDR allowlist。
+该 profile 使用独立 `supacloud_powersync` 登录角色、显式 `powersync` publication、`wal_level=logical`、4 个 sender、4 个 slot 和 `max_slot_wal_keep_size=1024MB`。默认只允许 loopback 上的 SCRAM 连接；非 loopback 监听必须同时提供 TLS 证书、权限受限的私钥和显式 CIDR allowlist。POSIX 平台要求私钥 mode 不向 group/other 开放；Windows 部署应通过文件 ACL 达到同等限制。
 
 Lite 会创建或更新 replication role 与 publication allowlist，但**不会创建、删除或猜测 replication slot**。slot 由固定版本的 PowerSync 服务和运维流程持有。`doctor` 只读检查 WAL、sender/slot 容量、角色、publication、replica identity 和现有 slot 的滞留/失效状态。
 
@@ -683,7 +683,7 @@ supacloud-lite doctor --json --engine native --replication-profile powersync \
   --powersync-tables public.eln_entries,public.eln_observations
 ```
 
-The profile manages the dedicated `supacloud_powersync` login role and explicit `powersync` publication, with four WAL senders, four slots, and `max_slot_wal_keep_size=1024MB`. It uses loopback SCRAM by default; non-loopback listeners require TLS files and explicit CIDRs. Lite never creates or deletes a replication slot. PowerSync and the operator remain responsible for the exact slot lifecycle.
+The profile manages the dedicated `supacloud_powersync` login role and explicit `powersync` publication, with four WAL senders, four slots, and `max_slot_wal_keep_size=1024MB`. It uses loopback SCRAM by default; non-loopback listeners require TLS files and explicit CIDRs. POSIX systems reject group/other-readable private keys; Windows deployments must enforce the equivalent file ACL. Lite never creates or deletes a replication slot. PowerSync and the operator remain responsible for the exact slot lifecycle.
 
 ### Migrating from Supabase
 

--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -106,6 +106,7 @@ supacloud-lite snapshot create [-o backup.tar.gz]
 supacloud-lite snapshot restore <backup.tar.gz> [--force]
 supacloud-lite upgrade [-o pre-upgrade.tar.gz]
 supacloud-lite inspect
+supacloud-lite doctor [--json]
 supacloud-lite version
 ```
 
@@ -136,6 +137,13 @@ supacloud-lite version
 - `SUPACLOUD_LITE_STORAGE_BACKEND`：`fs`（默认）、`memory` 或 `s3`
 - `SUPACLOUD_LITE_S3_PREFIX`：S3 对象 key 前缀，可被 `--s3-prefix` 覆盖
 - `SUPACLOUD_LITE_POSTGRES_MIRROR`：native 引擎下载 PostgreSQL 发布包时使用的 HTTPS 镜像前缀，例如 `https://ghproxy.net/`
+- `SUPACLOUD_LITE_ENGINE`：`pglite`（默认）或 `native`
+- `SUPACLOUD_LITE_REPLICATION_PROFILE`：仅支持显式值 `powersync`，且仅用于 native 引擎
+- `SUPACLOUD_LITE_REPLICATION_HOST` / `SUPACLOUD_LITE_REPLICATION_PORT`：PowerSync 数据库监听地址和端口，默认 `127.0.0.1:54322`
+- `SUPACLOUD_LITE_REPLICATION_ALLOW_CIDRS`：逗号分隔的 PowerSync 客户端 CIDR allowlist
+- `SUPACLOUD_LITE_POWERSYNC_TABLES`：逗号分隔、带 schema 的 publication 表 allowlist
+- `SUPACLOUD_LITE_POWERSYNC_PASSWORD`：独立 replication role 密码，至少 32 字符；不支持 CLI 密码参数
+- `SUPACLOUD_LITE_REPLICATION_TLS_CERT_FILE` / `SUPACLOUD_LITE_REPLICATION_TLS_KEY_FILE`：非 loopback 监听必需
 - `SUPACLOUD_LITE_JWT_SECRET`
 - `SUPACLOUD_LITE_VAULT_KEY`
 
@@ -254,12 +262,59 @@ S3 模式的快照只包含数据库中的 Storage 元数据和密钥，不复�
 | Edge Functions `SupaCloud.pgredis` | 已验证核心 | 提供单项目持久 KV、TTL、原子 `getset`/`getdel`；绑定只在当前函数请求内可用 |
 | Supabase migrations | 支持 | 按文件名排序，记录到 `supabase_migrations` |
 | PostgreSQL RLS | 支持 | 使用 `anon`、`authenticated`、`service_role` 数据库角色执行 |
+| Maker-Checker SQL | 支持 | 参考 migration 在 PGlite/native 自动测试中覆盖角色分离、行版本、幂等、非法跃迁和只增审计 |
+| Commands / Artifacts | 支持 | 与完整 SupaCloud 使用相同 SQL contract；PGlite/native 均通过 `@supacloud/js` 端到端测试 |
+| Logical Replication / PowerSync source | 有条件支持 | PGlite 不支持；native 仅在显式 `powersync` profile 下支持，默认关闭 |
 | PostgREST 完整线协议 | 部分支持 | 目标是常用 `supabase-js` 行为，不承诺所有 PostgREST 边角行为 |
 | PostgreSQL 扩展 | 部分支持 | 仅支持 PGlite 内置或 Lite 模拟的扩展能力 |
 | Supabase Studio | 不支持 | V1 不提供管理 UI |
 | 多项目控制面 | 不支持 | V1 每个进程只运行一个项目，可通过多个进程部署多个项目 |
 
 RLS 表的 Realtime DELETE 无法在行删除后安全重放 SELECT policy，因此 V1 只向 `service_role` 订阅者发送这类 DELETE 事件。普通用户仍可收到通过逐行 RLS 校验的 INSERT/UPDATE 事件。
+
+### Capability doctor 与 PowerSync profile
+
+`doctor` 输出 Lite 自己的稳定能力契约，不复制完整 Management API：
+
+```bash
+supacloud-lite doctor --json
+```
+
+默认 PGlite 输出会明确包含：
+
+```json
+{
+  "engine": "pglite",
+  "state_machine_sql": "supported",
+  "durable_workflows": "supported",
+  "commands": "supported",
+  "artifacts": "supported",
+  "postgrest_schema_config": "static",
+  "logical_replication": "unsupported",
+  "powersync_source": "unsupported"
+}
+```
+
+PGlite 永远不伪造 WAL、publication 或 replication slot。单机现场 ELN 可以直接把 Lite 当作本地服务器；多设备离线同步应使用中央 SupaCloud + PowerSync，或由应用 outbox 把本地 Lite 数据推送到中央 SupaCloud。PowerSync 客户端本地数据库是 SQLite，与 Lite/PGlite 不是同一层能力。
+
+Native Lite 默认仍使用 `wal_level=minimal`、关闭 WAL sender 并且不监听数据库 TCP。只有显式启用 profile 才配置有界 Logical Replication：
+
+```bash
+export SUPACLOUD_LITE_POWERSYNC_PASSWORD='<secret-store-value-at-least-32-characters>'
+supacloud-lite migrate \
+  --engine native \
+  --replication-profile powersync \
+  --powersync-tables public.eln_entries,public.eln_observations
+
+supacloud-lite doctor --json \
+  --engine native \
+  --replication-profile powersync \
+  --powersync-tables public.eln_entries,public.eln_observations
+```
+
+该 profile 使用独立 `supacloud_powersync` 登录角色、显式 `powersync` publication、`wal_level=logical`、4 个 sender、4 个 slot 和 `max_slot_wal_keep_size=1024MB`。默认只允许 loopback 上的 SCRAM 连接；非 loopback 监听必须同时提供 TLS 证书、权限受限的私钥和显式 CIDR allowlist。
+
+Lite 会创建或更新 replication role 与 publication allowlist，但**不会创建、删除或猜测 replication slot**。slot 由固定版本的 PowerSync 服务和运维流程持有。`doctor` 只读检查 WAL、sender/slot 容量、角色、publication、replica identity 和现有 slot 的滞留/失效状态。
 
 ### 从 Supabase 迁移
 
@@ -448,6 +503,7 @@ supacloud-lite snapshot create [-o backup.tar.gz]
 supacloud-lite snapshot restore <backup.tar.gz> [--force]
 supacloud-lite upgrade [-o pre-upgrade.tar.gz]
 supacloud-lite inspect
+supacloud-lite doctor [--json]
 supacloud-lite version
 ```
 
@@ -478,6 +534,13 @@ Environment variables:
 - `SUPACLOUD_LITE_STORAGE_BACKEND`: `fs` (default), `memory`, or `s3`
 - `SUPACLOUD_LITE_S3_PREFIX`: S3 object key prefix, can be overridden by `--s3-prefix`
 - `SUPACLOUD_LITE_POSTGRES_MIRROR`: HTTPS prefix used to proxy native-engine PostgreSQL release downloads, for example `https://ghproxy.net/`
+- `SUPACLOUD_LITE_ENGINE`: `pglite` (default) or `native`
+- `SUPACLOUD_LITE_REPLICATION_PROFILE`: explicit `powersync` opt-in for the native engine only
+- `SUPACLOUD_LITE_REPLICATION_HOST` / `SUPACLOUD_LITE_REPLICATION_PORT`: PowerSync database listener, default `127.0.0.1:54322`
+- `SUPACLOUD_LITE_REPLICATION_ALLOW_CIDRS`: comma-separated PowerSync client CIDR allowlist
+- `SUPACLOUD_LITE_POWERSYNC_TABLES`: comma-separated schema-qualified publication table allowlist
+- `SUPACLOUD_LITE_POWERSYNC_PASSWORD`: dedicated replication-role password of at least 32 characters; no CLI password flag is provided
+- `SUPACLOUD_LITE_REPLICATION_TLS_CERT_FILE` / `SUPACLOUD_LITE_REPLICATION_TLS_KEY_FILE`: required for non-loopback listeners
 - `SUPACLOUD_LITE_JWT_SECRET`
 - `SUPACLOUD_LITE_VAULT_KEY`
 
@@ -596,12 +659,31 @@ In-memory databases have no persistable data, so `snapshot` and `upgrade` reject
 | Edge Functions `SupaCloud.pgredis` | Verified core | Provides single-project persistent KV, TTL, and atomic `getset`/`getdel`; the binding is only available within the current function request |
 | Supabase migrations | Supported | Sorted by filename, recorded in `supabase_migrations` |
 | PostgreSQL RLS | Supported | Executed using the `anon`, `authenticated`, and `service_role` database roles |
+| Maker-Checker SQL | Supported | The reference migration is tested on PGlite/native for role separation, row versions, idempotency, illegal transitions, and append-only audit |
+| Commands / Artifacts | Supported | Uses the same SQL contract as full SupaCloud; PGlite/native are both exercised end-to-end through `@supacloud/js` |
+| Logical Replication / PowerSync source | Conditional | PGlite is unsupported; native requires the explicit `powersync` profile and remains disabled by default |
 | Full PostgREST wire protocol | Partial | Targets common `supabase-js` behavior; does not promise all PostgREST edge-case behavior |
 | PostgreSQL extensions | Partial | Only supports extensions built into PGlite or emulated by Lite |
 | Supabase Studio | Not supported | V1 does not provide an admin UI |
 | Multi-project control plane | Not supported | V1 runs only one project per process; multiple projects can be deployed via multiple processes |
 
 Realtime DELETE on RLS tables cannot safely replay SELECT policies after a row is deleted, so V1 only sends such DELETE events to `service_role` subscribers. Regular users can still receive INSERT/UPDATE events that pass row-by-row RLS validation.
+
+### Capability doctor and PowerSync profile
+
+`supacloud-lite doctor --json` reports a stable Lite capability contract without copying the full Management API. PGlite explicitly reports Logical Replication and PowerSync source support as `unsupported`; it never emulates WAL, publications, or slots. Multi-device offline deployments should use central SupaCloud + PowerSync, while a single field workstation can use Lite as a local project server or upload through an application-owned outbox.
+
+Native Lite keeps `wal_level=minimal`, WAL senders, and database TCP disabled by default. The explicit profile enables bounded Logical Replication:
+
+```bash
+export SUPACLOUD_LITE_POWERSYNC_PASSWORD='<secret-store-value-at-least-32-characters>'
+supacloud-lite migrate --engine native --replication-profile powersync \
+  --powersync-tables public.eln_entries,public.eln_observations
+supacloud-lite doctor --json --engine native --replication-profile powersync \
+  --powersync-tables public.eln_entries,public.eln_observations
+```
+
+The profile manages the dedicated `supacloud_powersync` login role and explicit `powersync` publication, with four WAL senders, four slots, and `max_slot_wal_keep_size=1024MB`. It uses loopback SCRAM by default; non-loopback listeners require TLS files and explicit CIDRs. Lite never creates or deletes a replication slot. PowerSync and the operator remain responsible for the exact slot lifecycle.
 
 ### Migrating from Supabase
 

--- a/packages/supacloud-lite/package.json
+++ b/packages/supacloud-lite/package.json
@@ -38,7 +38,7 @@
     "dev": "bun run src/cli.ts start",
     "start": "bun run src/cli.ts start",
     "test": "bun test --timeout 20000",
-    "test:native": "SUPACLOUD_LITE_TEST_NATIVE=1 bun test test/native-engine.test.ts test/qauth-workflow-matrix.test.ts --timeout 180000",
+    "test:native": "SUPACLOUD_LITE_TEST_NATIVE=1 bun test test/native-engine.test.ts test/qauth-workflow-matrix.test.ts test/maker-checker-workflow.test.ts test/commands-artifacts.test.ts --timeout 180000",
     "parity": "bun run parity/harness.ts",
     "parity:native": "SUPACLOUD_LITE_TEST_NATIVE=1 bun run parity/harness.ts --engine native",
     "check:native": "bun run test:native && bun run parity:native",

--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { existsSync } from 'node:fs'
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import packageJson from '../package.json' with { type: 'json' }
@@ -6,6 +7,7 @@ import { generateTypes, inspectDb } from './runtime/index.js'
 import { computeDbDiff, createTemporaryNativeEngine, pullSchema } from './runtime/node/db-diff.js'
 import { assertDataDirUnlocked } from './runtime/db/data-dir-lock.js'
 import { createNativeEngine } from './runtime/node/native/engine.js'
+import { inspectPowerSyncReadiness, liteCapabilities } from './runtime/node/native/readiness.js'
 import { loadSupabaseProject } from './runtime/node/project.js'
 import {
   createProjectBackend,
@@ -14,6 +16,7 @@ import {
   mintProjectKeys,
   resolveStorageBackend,
   resolveProjectPaths,
+  resolveNativeReplicationOptions,
   startProjectServer,
   type ProjectRuntimeOptions,
 } from './project-runtime.js'
@@ -27,6 +30,7 @@ interface CliOptions extends ProjectRuntimeOptions {
   diffFile?: string
   serviceRole: boolean
   force: boolean
+  json: boolean
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -42,6 +46,7 @@ function parseArgs(argv: string[]): CliOptions {
       : 54321,
     serviceRole: false,
     force: false,
+    json: false,
   }
 
   for (let index = 0; index < args.length; index++) {
@@ -62,11 +67,21 @@ function parseArgs(argv: string[]): CliOptions {
     else if (argument === '--storage-backend') options.storageBackend = next() as ProjectRuntimeOptions['storageBackend']
     else if (argument === '--s3-prefix') options.s3 = { ...options.s3, prefix: next() }
     else if (argument === '--engine') options.engine = next() as ProjectRuntimeOptions['engine']
+    else if (argument === '--replication-profile') {
+      options.replicationProfile = next() as ProjectRuntimeOptions['replicationProfile']
+    }
+    else if (argument === '--replication-host') options.replicationHost = next()
+    else if (argument === '--replication-port') options.replicationPort = Number.parseInt(next(), 10)
+    else if (argument === '--replication-allow-cidrs') options.replicationAllowCidrs = commaSeparated(next())
+    else if (argument === '--powersync-tables') options.powersyncPublicationTables = commaSeparated(next())
+    else if (argument === '--replication-tls-cert') options.replicationTlsCertFile = resolve(next())
+    else if (argument === '--replication-tls-key') options.replicationTlsKeyFile = resolve(next())
     else if (argument === '--memory') options.memory = true
     else if (argument === '--output' || argument === '-o') options.output = resolve(next())
     else if (argument === '--file' || argument === '-f') options.diffFile = next()
     else if (argument === '--service-role') options.serviceRole = true
     else if (argument === '--force') options.force = true
+    else if (argument === '--json') options.json = true
     else if (argument === '--version') {
       console.log(packageJson.version)
       process.exit(0)
@@ -156,6 +171,25 @@ async function main(): Promise<void> {
     return
   }
 
+  if (options.command === 'doctor') {
+    const replication = resolveNativeReplicationOptions(options, paths.databaseEngine)
+    const report = liteCapabilities(paths.databaseEngine, replication?.profile)
+    if (paths.databaseEngine === 'native' && replication) {
+      if (!paths.dataDir || !existsSync(join(paths.dataDir, 'PG_VERSION'))) {
+        throw new Error('PowerSync readiness requires an initialized native database; run migrate first')
+      }
+      const engine = await createNativeEngine({ dataDir: paths.dataDir, log: quietLog, replication })
+      try {
+        report.powersync_readiness = await inspectPowerSyncReadiness(engine, replication)
+      } finally {
+        await engine.close()
+      }
+    }
+    if (options.json) await writeStandardOutput(`${JSON.stringify(report, null, 2)}\n`)
+    else await printDoctor(report)
+    return
+  }
+
   if (options.command === 'migrate' || options.command === 'status') {
     const project = await createProjectBackend({
       ...options,
@@ -233,7 +267,11 @@ async function runDbCommand(options: CliOptions): Promise<void> {
   const project = await loadSupabaseProject(resolve(options.projectDir ?? process.cwd()))
   if (subcommand === 'diff') {
     const liveEngine = paths.databaseEngine === 'native'
-      ? await createNativeEngine({ dataDir: paths.dataDir!, log: quietLog })
+      ? await createNativeEngine({
+          dataDir: paths.dataDir!,
+          log: quietLog,
+          replication: resolveNativeReplicationOptions(options, paths.databaseEngine),
+        })
       : undefined
     const ddl = await computeDbDiff({
       liveDataDir: paths.databaseEngine === 'pglite' ? paths.dataDir : undefined,
@@ -258,7 +296,11 @@ async function runDbCommand(options: CliOptions): Promise<void> {
 
   if (subcommand === 'pull') {
     const liveEngine = paths.databaseEngine === 'native'
-      ? await createNativeEngine({ dataDir: paths.dataDir!, log: quietLog })
+      ? await createNativeEngine({
+          dataDir: paths.dataDir!,
+          log: quietLog,
+          replication: resolveNativeReplicationOptions(options, paths.databaseEngine),
+        })
       : undefined
     const result = await pullSchema({
       liveDataDir: paths.databaseEngine === 'pglite' ? paths.dataDir : undefined,
@@ -360,6 +402,18 @@ async function printInspection(rows: Awaited<ReturnType<typeof inspectDb>>): Pro
   await writeStandardOutput(`${output.join('\n')}\n`)
 }
 
+async function printDoctor(report: ReturnType<typeof liteCapabilities>): Promise<void> {
+  const output = Object.entries(report)
+    .filter(([, value]) => typeof value !== 'object')
+    .map(([name, value]) => `${name}: ${value}`)
+  if (report.powersync_readiness) {
+    output.push(`powersync_ready: ${report.powersync_readiness.ready}`)
+    for (const blocker of report.powersync_readiness.blockers) output.push(`blocker: ${blocker}`)
+    for (const warning of report.powersync_readiness.warnings) output.push(`warning: ${warning}`)
+  }
+  await writeStandardOutput(`${output.join('\n')}\n`)
+}
+
 async function writeStandardOutput(output: string): Promise<void> {
   await Bun.write(Bun.stdout, output)
 }
@@ -374,8 +428,12 @@ function timestamp(): string {
 
 function quietLog(): void {}
 
+function commaSeparated(value: string): string[] {
+  return value.split(',').map((entry) => entry.trim()).filter(Boolean)
+}
+
 function printHelp(): void {
-  console.log(`supacloud-lite - Bun-native Supabase-compatible backend on PGlite
+  console.log(`supacloud-lite - Bun-native Supabase-compatible backend on PGlite or native PostgreSQL
 
 Usage: supacloud-lite [command] [options]
 
@@ -393,6 +451,7 @@ Commands:
   snapshot restore <f>  restore a snapshot into an empty target
   upgrade               snapshot first, then apply pending migrations
   inspect               show table rows and sizes
+  doctor                report Lite capability and replication readiness
   version               print the package version
 
 Fresh projects must run "supacloud-lite migrate" before "db reset".
@@ -409,7 +468,15 @@ Options:
       --storage-backend <b> fs, memory, or s3 (default fs)
       --s3-prefix <p>      optional key prefix for the s3 backend
       --engine <e>         pglite (default) or native (macOS/glibc Linux x64/arm64)
+      --replication-profile <p> optional powersync profile (native only)
+      --replication-host <ip> database listener (default 127.0.0.1)
+      --replication-port <n> database listener port (default 54322)
+      --replication-allow-cidrs <list> explicit client CIDRs
+      --powersync-tables <list> schema-qualified publication table allowlist
+      --replication-tls-cert <p> PostgreSQL TLS certificate
+      --replication-tls-key <p> PostgreSQL TLS private key
       --memory            use an in-memory PGlite database
+      --json              emit machine-readable doctor output
   -o, --output <p>        output file for gen types
   -f, --file <name>       migration suffix for db diff
       --force             replace non-empty restore targets and retain rollback copies

--- a/packages/supacloud-lite/src/index.ts
+++ b/packages/supacloud-lite/src/index.ts
@@ -41,10 +41,29 @@ export {
   type NativeEngineOptions,
 } from './runtime/node/native/engine.js'
 export {
+  POWERSYNC_PUBLICATION,
+  POWERSYNC_REPLICATION_ROLE,
+  buildPowerSyncPostgresArgs,
+  ensurePowerSyncReplicationCatalog,
+  validatePowerSyncReplicationOptions,
+  writePowerSyncHba,
+  type NativeReplicationOptions,
+  type NativeReplicationTlsOptions,
+  type PowerSyncReplicationOptions,
+} from './runtime/node/native/replication.js'
+export {
+  inspectPowerSyncReadiness,
+  liteCapabilities,
+  type LiteCapabilityStatus,
+  type LiteDoctorReport,
+  type PowerSyncReadiness,
+} from './runtime/node/native/readiness.js'
+export {
   createProjectBackend,
   ensureProjectSecrets,
   mintProjectKeys,
   resolveDatabaseEngine,
+  resolveNativeReplicationOptions,
   resolveStorageBackend,
   resolveProjectPaths,
   startProjectServer,
@@ -64,6 +83,7 @@ export type {
   ProjectPaths,
   ProjectRuntimeOptions,
   ProjectSecrets,
+  ReplicationProfile,
   RunningProjectServer,
   StorageBackend,
 } from './project-runtime.js'

--- a/packages/supacloud-lite/src/project-runtime.ts
+++ b/packages/supacloud-lite/src/project-runtime.ts
@@ -8,6 +8,11 @@ import { FsStorageDriver } from './runtime/node/fs-driver.js'
 import { loadProjectConfig, type ProjectConfig } from './runtime/node/load-config.js'
 import { loadFunctionEnv, loadFunctions } from './runtime/node/load-functions.js'
 import { createNativeEngine, isNativeEngineSupported } from './runtime/node/native/engine.js'
+import {
+  ensurePowerSyncReplicationCatalog,
+  validatePowerSyncReplicationOptions,
+  type NativeReplicationOptions,
+} from './runtime/node/native/replication.js'
 import { loadSupabaseProject } from './runtime/node/project.js'
 import { MemoryStorageDriver } from './runtime/storage/driver.js'
 import { S3StorageDriver, type S3StorageDriverOptions } from './runtime/storage/s3-driver.js'
@@ -46,6 +51,14 @@ export interface ProjectRuntimeOptions {
   siteUrl?: string
   memory?: boolean
   engine?: DatabaseEngine
+  replicationProfile?: ReplicationProfile
+  replicationHost?: string
+  replicationPort?: number
+  replicationAllowCidrs?: string[]
+  powersyncPublicationTables?: string[]
+  powersyncPassword?: string
+  replicationTlsCertFile?: string
+  replicationTlsKeyFile?: string
   applyMigrations?: boolean
   includeFunctions?: boolean
   includeWebhooks?: boolean
@@ -66,9 +79,11 @@ export interface ProjectBackend {
   webhookCount: number
   storageBackend: StorageBackend
   databaseEngine: DatabaseEngine
+  replicationProfile?: ReplicationProfile
 }
 
 export type DatabaseEngine = 'pglite' | 'native'
+export type ReplicationProfile = 'powersync'
 export type StorageBackend = 'fs' | 'memory' | 's3' | 'custom'
 export type ConfiguredStorageBackend = Exclude<StorageBackend, 'custom'>
 
@@ -259,6 +274,7 @@ export async function createProjectBackend(options: ProjectRuntimeOptions = {}):
   const configuredStorageBackend = options.storageDriver ? 'fs' : resolveStorageBackend(options.storageBackend)
   const storageBackend: StorageBackend = options.storageDriver ? 'custom' : configuredStorageBackend
   const databaseEngine = paths.databaseEngine
+  const replication = resolveNativeReplicationOptions(options, databaseEngine)
 
   if (paths.dataDir) {
     await mkdir(paths.dataDir, { recursive: true, mode: 0o700 })
@@ -269,9 +285,9 @@ export async function createProjectBackend(options: ProjectRuntimeOptions = {}):
 
   const storageDriver = options.storageDriver ?? createStorageDriver(configuredStorageBackend, paths.storageDir, options.s3)
   const engine = databaseEngine === 'native'
-    ? await createNativeEngine({ dataDir: paths.dataDir!, log: options.log })
+    ? await createNativeEngine({ dataDir: paths.dataDir!, log: options.log, replication })
     : undefined
-  let backend: SupaCloudLiteBackend
+  let backend: SupaCloudLiteBackend | undefined
   try {
     backend = await createBackend({
       engine,
@@ -306,8 +322,17 @@ export async function createProjectBackend(options: ProjectRuntimeOptions = {}):
       storageDriver,
       log: options.log,
     })
+    if (replication && options.applyMigrations !== false) {
+      await ensurePowerSyncReplicationCatalog(backend.db.engine, replication)
+    }
   } catch (error) {
-    if (engine) {
+    if (backend) {
+      try {
+        await backend.close()
+      } catch (cleanupError) {
+        throw new AggregateError([error, cleanupError], 'project database startup cleanup failed')
+      }
+    } else if (engine) {
       try {
         await engine.close()
       } catch (cleanupError) {
@@ -329,7 +354,38 @@ export async function createProjectBackend(options: ProjectRuntimeOptions = {}):
     webhookCount: webhooks.length,
     storageBackend,
     databaseEngine,
+    replicationProfile: replication?.profile,
   }
+}
+
+export function resolveNativeReplicationOptions(
+  options: ProjectRuntimeOptions,
+  databaseEngine = resolveDatabaseEngine(options.engine, options.memory),
+): NativeReplicationOptions | undefined {
+  const profile = options.replicationProfile ?? process.env.SUPACLOUD_LITE_REPLICATION_PROFILE
+  if (!profile) return undefined
+  if (profile !== 'powersync') throw new Error(`unsupported SUPACLOUD_LITE_REPLICATION_PROFILE: ${profile}`)
+  if (databaseEngine !== 'native') throw new Error('PowerSync replication is only supported by --engine native')
+
+  const tlsCertFile = options.replicationTlsCertFile ?? process.env.SUPACLOUD_LITE_REPLICATION_TLS_CERT_FILE
+  const tlsKeyFile = options.replicationTlsKeyFile ?? process.env.SUPACLOUD_LITE_REPLICATION_TLS_KEY_FILE
+  if (Boolean(tlsCertFile) !== Boolean(tlsKeyFile)) {
+    throw new Error('PowerSync replication TLS requires both certificate and key files')
+  }
+
+  return validatePowerSyncReplicationOptions({
+    profile,
+    host: options.replicationHost ?? process.env.SUPACLOUD_LITE_REPLICATION_HOST ?? '127.0.0.1',
+    port: options.replicationPort ?? parsePort(process.env.SUPACLOUD_LITE_REPLICATION_PORT, 54322),
+    allowCidrs: options.replicationAllowCidrs
+      ?? commaSeparated(process.env.SUPACLOUD_LITE_REPLICATION_ALLOW_CIDRS, ['127.0.0.1/32', '::1/128']),
+    publicationTables: options.powersyncPublicationTables
+      ?? commaSeparated(process.env.SUPACLOUD_LITE_POWERSYNC_TABLES),
+    password: options.powersyncPassword ?? process.env.SUPACLOUD_LITE_POWERSYNC_PASSWORD ?? '',
+    tls: tlsCertFile && tlsKeyFile
+      ? { certFile: tlsCertFile, keyFile: tlsKeyFile }
+      : undefined,
+  })
 }
 
 export function resolveDatabaseEngine(value?: DatabaseEngine, memory = false): DatabaseEngine {
@@ -441,6 +497,12 @@ function parsePort(value: string | undefined, fallback: number): number {
   const port = Number.parseInt(value, 10)
   if (!Number.isInteger(port) || port < 0 || port > 65535) throw new Error(`invalid port: ${value}`)
   return port
+}
+
+function commaSeparated(value: string | undefined, fallback: string[] = []): string[] {
+  return value === undefined
+    ? fallback
+    : value.split(',').map((entry) => entry.trim()).filter(Boolean)
 }
 
 function displayHost(host: string): string {

--- a/packages/supacloud-lite/src/runtime/db/emulated.ts
+++ b/packages/supacloud-lite/src/runtime/db/emulated.ts
@@ -1354,6 +1354,452 @@ GRANT EXECUTE ON FUNCTION public.supacloud_workflow_cancel(jsonb) TO service_rol
 GRANT EXECUTE ON FUNCTION public.supacloud_workflow_get(jsonb) TO service_role;
 GRANT EXECUTE ON FUNCTION public.supacloud_workflow_events(jsonb) TO service_role;
 -- supacloud:sql-module:workflows-public:end
+
+-- supacloud:sql-module:commands-public:start
+CREATE SCHEMA IF NOT EXISTS supacloud_commands;
+REVOKE ALL ON SCHEMA supacloud_commands FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA supacloud_commands TO service_role;
+
+CREATE TABLE IF NOT EXISTS supacloud_commands.receipts (
+  id uuid PRIMARY KEY,
+  command_type text NOT NULL
+    CHECK (command_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  target_type text NOT NULL
+    CHECK (target_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  target_id text NOT NULL CHECK (char_length(target_id) BETWEEN 1 AND 500),
+  actor_id uuid,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb
+    CHECK (jsonb_typeof(payload) = 'object'),
+  payload_fingerprint text NOT NULL CHECK (char_length(payload_fingerprint) = 36),
+  workflow_run_id uuid NOT NULL UNIQUE
+    REFERENCES supacloud_workflows.runs(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_commands_target_idx
+  ON supacloud_commands.receipts (target_type, target_id, created_at DESC, id);
+
+CREATE OR REPLACE FUNCTION supacloud_commands.snapshot(
+  p_command_id uuid,
+  p_idempotent boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object(
+    'commandId', receipt.id,
+    'commandType', receipt.command_type,
+    'targetType', receipt.target_type,
+    'targetId', receipt.target_id,
+    'actorId', receipt.actor_id,
+    'payloadFingerprint', receipt.payload_fingerprint,
+    'createdAt', receipt.created_at,
+    'idempotent', p_idempotent,
+    'workflow', supacloud_workflows.snapshot(receipt.workflow_run_id, false)
+  )
+  FROM supacloud_commands.receipts receipt
+  WHERE receipt.id = p_command_id
+$$;
+
+-- Application-owned SECURITY DEFINER RPCs may call this after their domain
+-- mutation. PostgreSQL commits the domain write, receipt, and workflow enqueue
+-- together, so a lost response can be replayed with the same command ID.
+DROP FUNCTION IF EXISTS supacloud_commands.submit(uuid, text, text, text, uuid, jsonb, integer);
+CREATE OR REPLACE FUNCTION supacloud_commands.submit(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  command_id_text text;
+  command_id uuid;
+  actor_id uuid;
+  max_attempts integer;
+  payload jsonb;
+  normalized_command_type text;
+  normalized_target_type text;
+  normalized_target_id text;
+  fingerprint text;
+  existing supacloud_commands.receipts%ROWTYPE;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id_text := request ->> 'commandId';
+  IF command_id_text IS NULL
+     OR command_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id := command_id_text::uuid;
+  IF request ? 'actorId' AND request ->> 'actorId' IS NOT NULL THEN
+    actor_id := (request ->> 'actorId')::uuid;
+  END IF;
+  max_attempts := coalesce((request ->> 'maxAttempts')::integer, 3);
+  payload := coalesce(request -> 'payload', '{}'::jsonb);
+  normalized_command_type := nullif(btrim(request ->> 'commandType'), '');
+  normalized_target_type := nullif(btrim(request ->> 'targetType'), '');
+  normalized_target_id := nullif(btrim(request ->> 'targetId'), '');
+  IF normalized_command_type IS NULL
+     OR normalized_command_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_target_type IS NULL
+     OR normalized_target_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_target_id IS NULL
+     OR char_length(normalized_target_id) > 500
+     OR jsonb_typeof(payload) IS DISTINCT FROM 'object'
+     OR max_attempts NOT BETWEEN 1 AND 100 THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  fingerprint := 'md5:' || md5(payload::text);
+  PERFORM pg_advisory_xact_lock(hashtextextended(command_id::text, 0));
+  SELECT * INTO existing FROM supacloud_commands.receipts WHERE id = command_id;
+  IF FOUND THEN
+    IF existing.command_type <> normalized_command_type
+       OR existing.target_type <> normalized_target_type
+       OR existing.target_id <> normalized_target_id
+       OR existing.actor_id IS DISTINCT FROM actor_id
+       OR existing.payload <> payload
+       OR existing.payload_fingerprint <> fingerprint THEN
+      RAISE EXCEPTION 'SUPACLOUD_COMMAND_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+    END IF;
+    RETURN supacloud_commands.snapshot(command_id, true);
+  END IF;
+
+  PERFORM supacloud_workflows.start_run(
+    command_id,
+    'command.' || normalized_command_type,
+    '1',
+    'execute',
+    jsonb_build_object(
+      'commandId', command_id,
+      'commandType', normalized_command_type,
+      'targetType', normalized_target_type,
+      'targetId', normalized_target_id,
+      'actorId', actor_id,
+      'payload', payload,
+      'payloadFingerprint', fingerprint
+    ),
+    max_attempts
+  );
+
+  INSERT INTO supacloud_commands.receipts (
+    id, command_type, target_type, target_id, actor_id, payload,
+    payload_fingerprint, workflow_run_id
+  ) VALUES (
+    command_id, normalized_command_type, normalized_target_type,
+    normalized_target_id, actor_id, payload, fingerprint, command_id
+  );
+  RETURN supacloud_commands.snapshot(command_id, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_command_submit(request jsonb)
+RETURNS jsonb
+LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT supacloud_commands.submit(request)
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_command_get(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  command_id_text text;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+  END IF;
+  command_id_text := request ->> 'commandId';
+  IF command_id_text IS NULL
+     OR command_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+  END IF;
+  RETURN supacloud_commands.snapshot(command_id_text::uuid, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_COMMAND_GET_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA supacloud_commands
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA supacloud_commands
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.supacloud_command_submit(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_command_get(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.supacloud_command_submit(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_command_get(jsonb) TO service_role;
+-- supacloud:sql-module:commands-public:end
+
+-- supacloud:sql-module:artifacts-public:start
+CREATE SCHEMA IF NOT EXISTS supacloud_artifacts;
+REVOKE ALL ON SCHEMA supacloud_artifacts FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA supacloud_artifacts TO service_role;
+
+CREATE TABLE IF NOT EXISTS supacloud_artifacts.artifacts (
+  id uuid PRIMARY KEY,
+  storage_object_id uuid NOT NULL UNIQUE REFERENCES storage.objects(id) ON DELETE RESTRICT,
+  bucket_id text NOT NULL,
+  object_path text NOT NULL,
+  object_version text NOT NULL,
+  artifact_type text NOT NULL
+    CHECK (artifact_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  sha256 text NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+  size_bytes bigint NOT NULL CHECK (size_bytes >= 0),
+  mime_type text NOT NULL CHECK (char_length(mime_type) BETWEEN 1 AND 255),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  retention_until timestamptz,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (retention_until IS NULL OR retention_until >= created_at),
+  UNIQUE (bucket_id, object_path, object_version)
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_artifacts_lookup_idx
+  ON supacloud_artifacts.artifacts (artifact_type, created_at DESC, id);
+
+CREATE TABLE IF NOT EXISTS supacloud_artifacts.lineage (
+  parent_artifact_id uuid NOT NULL REFERENCES supacloud_artifacts.artifacts(id) ON DELETE RESTRICT,
+  child_artifact_id uuid NOT NULL REFERENCES supacloud_artifacts.artifacts(id) ON DELETE RESTRICT,
+  relation_type text NOT NULL
+    CHECK (relation_type ~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(metadata) = 'object'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (parent_artifact_id, child_artifact_id, relation_type),
+  CHECK (parent_artifact_id <> child_artifact_id)
+);
+
+CREATE INDEX IF NOT EXISTS supacloud_artifacts_lineage_child_idx
+  ON supacloud_artifacts.lineage (child_artifact_id, created_at, parent_artifact_id);
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.guard_storage_object()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM supacloud_artifacts.artifacts artifact
+    WHERE artifact.storage_object_id = OLD.id
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IMMUTABLE' USING ERRCODE = '55000';
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS supacloud_artifact_storage_fence ON storage.objects;
+CREATE TRIGGER supacloud_artifact_storage_fence
+BEFORE UPDATE OR DELETE ON storage.objects
+FOR EACH ROW EXECUTE FUNCTION supacloud_artifacts.guard_storage_object();
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.snapshot(
+  p_artifact_id uuid,
+  p_idempotent boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT jsonb_build_object(
+    'artifactId', artifact.id,
+    'bucketId', artifact.bucket_id,
+    'objectPath', artifact.object_path,
+    'objectVersion', artifact.object_version,
+    'artifactType', artifact.artifact_type,
+    'sha256', artifact.sha256,
+    'sizeBytes', artifact.size_bytes::text,
+    'mimeType', artifact.mime_type,
+    'metadata', artifact.metadata,
+    'retentionUntil', artifact.retention_until,
+    'createdBy', artifact.created_by,
+    'createdAt', artifact.created_at,
+    'idempotent', p_idempotent,
+    'parents', coalesce((
+      SELECT jsonb_agg(jsonb_build_object(
+        'artifactId', edge.parent_artifact_id,
+        'relationType', edge.relation_type,
+        'metadata', edge.metadata,
+        'createdAt', edge.created_at
+      ) ORDER BY edge.created_at, edge.parent_artifact_id)
+      FROM supacloud_artifacts.lineage edge
+      WHERE edge.child_artifact_id = artifact.id
+    ), '[]'::jsonb)
+  )
+  FROM supacloud_artifacts.artifacts artifact
+  WHERE artifact.id = p_artifact_id
+$$;
+
+DROP FUNCTION IF EXISTS supacloud_artifacts.register(uuid, text, text, text, text, bigint, text, jsonb, timestamptz, uuid);
+CREATE OR REPLACE FUNCTION supacloud_artifacts.register(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  artifact_id uuid;
+  size_bytes bigint;
+  metadata jsonb;
+  retention_until timestamptz;
+  created_by uuid;
+  normalized_bucket text;
+  normalized_path text;
+  normalized_type text;
+  normalized_sha256 text;
+  normalized_mime text;
+  object_row storage.objects%ROWTYPE;
+  existing supacloud_artifacts.artifacts%ROWTYPE;
+BEGIN
+  IF jsonb_typeof(request) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+  END IF;
+  artifact_id := (request ->> 'artifactId')::uuid;
+  size_bytes := (request ->> 'sizeBytes')::bigint;
+  metadata := coalesce(request -> 'metadata', '{}'::jsonb);
+  retention_until := (request ->> 'retentionUntil')::timestamptz;
+  created_by := (request ->> 'createdBy')::uuid;
+  normalized_bucket := nullif(btrim(request ->> 'bucketId'), '');
+  normalized_path := nullif(btrim(request ->> 'objectPath'), '');
+  normalized_type := nullif(btrim(request ->> 'artifactType'), '');
+  normalized_sha256 := lower(nullif(btrim(request ->> 'sha256'), ''));
+  normalized_mime := lower(nullif(btrim(request ->> 'mimeType'), ''));
+  IF artifact_id IS NULL OR normalized_bucket IS NULL OR normalized_path IS NULL
+     OR normalized_path LIKE '/%' OR normalized_path LIKE '%\\%'
+     OR normalized_path ~ '(^|/)(\.|\.\.)(/|$)'
+     OR normalized_type IS NULL
+     OR normalized_type !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR normalized_sha256 IS NULL OR normalized_sha256 !~ '^[0-9a-f]{64}$'
+     OR size_bytes IS NULL OR size_bytes < 0
+     OR normalized_mime IS NULL OR char_length(normalized_mime) > 255
+     OR jsonb_typeof(metadata) IS DISTINCT FROM 'object'
+     OR (retention_until IS NOT NULL AND retention_until < now()) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT * INTO object_row FROM storage.objects
+  WHERE bucket_id = normalized_bucket AND name = normalized_path;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_OBJECT_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(artifact_id::text, 0));
+  SELECT * INTO existing FROM supacloud_artifacts.artifacts WHERE id = artifact_id;
+  IF FOUND THEN
+    IF existing.storage_object_id <> object_row.id
+       OR existing.artifact_type <> normalized_type
+       OR existing.sha256 <> normalized_sha256
+       OR existing.size_bytes <> size_bytes
+       OR existing.mime_type <> normalized_mime
+       OR existing.metadata <> metadata
+       OR existing.retention_until IS DISTINCT FROM retention_until
+       OR existing.created_by IS DISTINCT FROM created_by THEN
+      RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+    END IF;
+    RETURN supacloud_artifacts.snapshot(artifact_id, true);
+  END IF;
+
+  INSERT INTO supacloud_artifacts.artifacts (
+    id, storage_object_id, bucket_id, object_path, object_version,
+    artifact_type, sha256, size_bytes, mime_type, metadata,
+    retention_until, created_by
+  ) VALUES (
+    artifact_id, object_row.id, normalized_bucket, normalized_path,
+    object_row.version::text, normalized_type, normalized_sha256,
+    size_bytes, normalized_mime, metadata, retention_until, created_by
+  );
+  RETURN supacloud_artifacts.snapshot(artifact_id, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation OR numeric_value_out_of_range THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION supacloud_artifacts.link(
+  p_parent_artifact_id uuid,
+  p_child_artifact_id uuid,
+  p_relation_type text,
+  p_metadata jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  normalized_relation text := nullif(btrim(p_relation_type), '');
+  inserted_count integer;
+BEGIN
+  IF p_parent_artifact_id IS NULL OR p_child_artifact_id IS NULL
+     OR p_parent_artifact_id = p_child_artifact_id
+     OR normalized_relation IS NULL
+     OR normalized_relation !~ '^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$'
+     OR jsonb_typeof(p_metadata) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_INVALID' USING ERRCODE = '22023';
+  END IF;
+  IF EXISTS (
+    WITH RECURSIVE descendants(artifact_id) AS (
+      SELECT edge.child_artifact_id
+      FROM supacloud_artifacts.lineage edge
+      WHERE edge.parent_artifact_id = p_child_artifact_id
+      UNION
+      SELECT edge.child_artifact_id
+      FROM supacloud_artifacts.lineage edge
+      JOIN descendants current ON edge.parent_artifact_id = current.artifact_id
+    )
+    SELECT 1 FROM descendants WHERE artifact_id = p_parent_artifact_id
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_CYCLE' USING ERRCODE = '23514';
+  END IF;
+  INSERT INTO supacloud_artifacts.lineage (
+    parent_artifact_id, child_artifact_id, relation_type, metadata
+  ) VALUES (
+    p_parent_artifact_id, p_child_artifact_id, normalized_relation, p_metadata
+  ) ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS inserted_count = ROW_COUNT;
+  IF inserted_count = 0 AND NOT EXISTS (
+    SELECT 1 FROM supacloud_artifacts.lineage
+    WHERE parent_artifact_id = p_parent_artifact_id
+      AND child_artifact_id = p_child_artifact_id
+      AND relation_type = normalized_relation
+      AND metadata = p_metadata
+  ) THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_IDEMPOTENCY_CONFLICT' USING ERRCODE = '23505';
+  END IF;
+  RETURN supacloud_artifacts.snapshot(p_child_artifact_id, inserted_count = 0);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_register(request jsonb)
+RETURNS jsonb
+LANGUAGE sql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+  SELECT supacloud_artifacts.register(request)
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_get(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RETURN supacloud_artifacts.snapshot((request ->> 'artifactId')::uuid, false);
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_GET_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.supacloud_artifact_link(request jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RETURN supacloud_artifacts.link(
+    (request ->> 'parentArtifactId')::uuid,
+    (request ->> 'childArtifactId')::uuid,
+    request ->> 'relationType',
+    coalesce(request -> 'metadata', '{}'::jsonb)
+  );
+EXCEPTION
+  WHEN invalid_parameter_value OR invalid_text_representation THEN
+    RAISE EXCEPTION 'SUPACLOUD_ARTIFACT_LINEAGE_INVALID' USING ERRCODE = '22023';
+END;
+$$;
+
+REVOKE ALL ON ALL TABLES IN SCHEMA supacloud_artifacts
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL FUNCTIONS IN SCHEMA supacloud_artifacts
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_register(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_get(jsonb) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.supacloud_artifact_link(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_register(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_get(jsonb) TO service_role;
+GRANT EXECUTE ON FUNCTION public.supacloud_artifact_link(jsonb) TO service_role;
+-- supacloud:sql-module:artifacts-public:end
 `
 
 // ── cron (scheduled jobs) ────────────────────────────────────────────────────

--- a/packages/supacloud-lite/src/runtime/node/native/engine.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/engine.ts
@@ -14,6 +14,11 @@ import { join } from 'node:path'
 import { extract as extractTar } from 'tar'
 import { acquireDataDirLock } from '../../db/data-dir-lock.js'
 import type { DbEngine } from '../../db/engine.js'
+import {
+  buildPowerSyncPostgresArgs,
+  writePowerSyncHba,
+  type NativeReplicationOptions,
+} from './replication.js'
 import { PgWireClient } from './wire.js'
 import { buildWireEngine } from './wire-engine.js'
 
@@ -52,6 +57,8 @@ export interface NativeEngineOptions {
   log?: (msg: string) => void
   /** Optional HTTPS or loopback HTTP prefix for proxying the PostgreSQL release download. */
   downloadMirror?: string
+  /** Optional externally reachable logical-replication profile. Disabled by default. */
+  replication?: NativeReplicationOptions
 }
 
 export function isNativeEngineSupported(): boolean {
@@ -249,6 +256,7 @@ dynamic_shared_memory_type = posix
 max_connections = 10
 wal_level = minimal
 max_wal_senders = 0
+max_replication_slots = 0
 logging_collector = off
 `
 
@@ -284,10 +292,24 @@ export async function createNativeEngine(opts: NativeEngineOptions): Promise<DbE
     socketDirectory = mkdtempSync(join(tmpdir(), 'scl-'))
     chmodSync(socketDirectory, 0o700)
 
-    postgres = spawn(bin('postgres'), ['-D', opts.dataDir, '-k', socketDirectory, '-c', 'timezone=UTC'], {
-      stdio: ['ignore', 'ignore', 'pipe'],
-      detached: false,
-    })
+    const replicationHba = opts.replication ? join(opts.dataDir, 'supacloud-powersync-hba.conf') : undefined
+    if (opts.replication && replicationHba) writePowerSyncHba(replicationHba, opts.replication)
+    const replicationArgs = opts.replication && replicationHba
+      ? buildPowerSyncPostgresArgs(opts.replication, replicationHba)
+      : [
+          '-c', 'listen_addresses=',
+          '-c', 'wal_level=minimal',
+          '-c', 'max_wal_senders=0',
+          '-c', 'max_replication_slots=0',
+        ]
+    postgres = spawn(
+      bin('postgres'),
+      ['-D', opts.dataDir, '-k', socketDirectory, '-c', 'timezone=UTC', ...replicationArgs],
+      {
+        stdio: ['ignore', 'ignore', 'pipe'],
+        detached: false,
+      }
+    )
     let postgresExited = false
     let postgresStderr = ''
     postgres.stderr?.on('data', (chunk: Buffer) => {
@@ -301,7 +323,8 @@ export async function createNativeEngine(opts: NativeEngineOptions): Promise<DbE
     process.once('exit', killPostgres)
     removeExitHandler = () => process.off('exit', killPostgres)
 
-    const socketPath = join(socketDirectory, '.s.PGSQL.5432')
+    const postgresPort = opts.replication?.port ?? 5432
+    const socketPath = join(socketDirectory, `.s.PGSQL.${postgresPort}`)
     const connect = async (): Promise<PgWireClient> => {
       const deadline = Date.now() + 20_000
       while (Date.now() <= deadline) {

--- a/packages/supacloud-lite/src/runtime/node/native/readiness.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/readiness.ts
@@ -1,0 +1,374 @@
+import type { DbEngine } from '../../db/engine.js'
+import {
+  POWERSYNC_PUBLICATION,
+  POWERSYNC_REPLICATION_ROLE,
+  type PowerSyncReplicationOptions,
+} from './replication.js'
+
+export type LiteCapabilityStatus = 'supported' | 'static' | 'disabled' | 'unsupported'
+
+export interface LiteDoctorReport {
+  engine: 'pglite' | 'native'
+  state_machine_sql: 'supported'
+  durable_workflows: 'supported'
+  commands: 'supported'
+  artifacts: 'supported'
+  postgrest_schema_config: 'static'
+  logical_replication: LiteCapabilityStatus
+  powersync_source: LiteCapabilityStatus
+  replication_profile?: 'powersync'
+  powersync_readiness?: PowerSyncReadiness
+}
+
+export interface PowerSyncReadiness {
+  ready: boolean
+  blockers: string[]
+  warnings: string[]
+  connection: {
+    host: string
+    port: number
+    tls: boolean
+    allowed_cidrs: string[]
+  }
+  wal: {
+    level: string
+    max_senders: number
+    active_senders: number
+    max_replication_slots: number
+    used_replication_slots: number
+    max_slot_wal_keep_size: string
+  }
+  role: {
+    name: string
+    present: boolean
+    login: boolean
+    replication: boolean
+    bypass_rls: boolean
+    unexpected_selectable_tables: string[]
+  }
+  publication: {
+    name: string
+    present: boolean
+    all_tables: boolean
+    tables: string[]
+    expected_tables: string[]
+    publishes_insert: boolean
+    publishes_update: boolean
+    publishes_delete: boolean
+    replica_identity_missing_tables: string[]
+  }
+  slots: Array<{
+    name: string
+    active: boolean
+    wal_status: string | null
+    retained_wal_bytes: string
+    unconfirmed_wal_bytes: string
+    safe_wal_size: string | null
+    invalidation_reason: string | null
+  }>
+}
+
+export function liteCapabilities(
+  engine: 'pglite' | 'native',
+  replicationProfile?: 'powersync',
+): LiteDoctorReport {
+  if (engine === 'pglite') {
+    return {
+      engine,
+      state_machine_sql: 'supported',
+      durable_workflows: 'supported',
+      commands: 'supported',
+      artifacts: 'supported',
+      postgrest_schema_config: 'static',
+      logical_replication: 'unsupported',
+      powersync_source: 'unsupported',
+    }
+  }
+  return {
+    engine,
+    state_machine_sql: 'supported',
+    durable_workflows: 'supported',
+    commands: 'supported',
+    artifacts: 'supported',
+    postgrest_schema_config: 'static',
+    logical_replication: replicationProfile ? 'supported' : 'disabled',
+    powersync_source: replicationProfile ? 'supported' : 'disabled',
+    ...(replicationProfile ? { replication_profile: replicationProfile } : {}),
+  }
+}
+
+export async function inspectPowerSyncReadiness(
+  engine: DbEngine,
+  options: PowerSyncReplicationOptions,
+): Promise<PowerSyncReadiness> {
+  return buildReadiness(await loadReplicationInventory(engine), options)
+}
+
+interface ReplicationRoleRow {
+  rolcanlogin: boolean
+  rolreplication: boolean
+  rolbypassrls: boolean
+}
+
+interface ReplicationPublicationRow {
+  puballtables: boolean
+  pubinsert: boolean
+  pubupdate: boolean
+  pubdelete: boolean
+}
+
+interface ReplicationPublicationTableRow {
+  qualified_name: string
+  replica_identity_missing: boolean
+}
+
+interface ReplicationSlotRow {
+  slot_name: string
+  active: boolean
+  wal_status: string | null
+  retained_wal_bytes: string
+  unconfirmed_wal_bytes: string
+  safe_wal_size: string | null
+  invalidation_reason: string | null
+}
+
+interface ReplicationInventory {
+  settings: Map<string, string>
+  activeSenders: number
+  role?: ReplicationRoleRow
+  publication?: ReplicationPublicationRow
+  publicationTables: ReplicationPublicationTableRow[]
+  selectableTables: string[]
+  slots: ReplicationSlotRow[]
+}
+
+async function loadReplicationInventory(engine: DbEngine): Promise<ReplicationInventory> {
+  const [settings, senders, role, publication, publicationTables, selectableTables, slots] = await Promise.all([
+    engine.query<{ name: string; setting: string }>(`
+      SELECT name, setting
+      FROM pg_settings
+      WHERE name IN (
+        'wal_level', 'max_wal_senders', 'max_replication_slots',
+        'max_slot_wal_keep_size', 'ssl', 'listen_addresses', 'port'
+      )
+    `),
+    engine.query<{ count: number }>('SELECT count(*)::integer AS count FROM pg_stat_replication'),
+    engine.query<{ rolcanlogin: boolean; rolreplication: boolean; rolbypassrls: boolean }>(`
+      SELECT rolcanlogin, rolreplication, rolbypassrls
+      FROM pg_roles WHERE rolname = '${POWERSYNC_REPLICATION_ROLE}'
+    `),
+    engine.query<ReplicationPublicationRow>(`
+      SELECT puballtables, pubinsert, pubupdate, pubdelete
+      FROM pg_publication WHERE pubname = '${POWERSYNC_PUBLICATION}'
+    `),
+    engine.query<ReplicationPublicationTableRow>(`
+      SELECT
+        quote_ident(namespace.nspname) || '.' || quote_ident(relation.relname) AS qualified_name,
+        relation.relreplident = 'n' OR (
+          relation.relreplident = 'd'
+          AND NOT EXISTS (
+            SELECT 1 FROM pg_index index_record
+            WHERE index_record.indrelid = relation.oid AND index_record.indisprimary
+          )
+        ) AS replica_identity_missing
+      FROM pg_publication_tables published
+      JOIN pg_namespace namespace ON namespace.nspname = published.schemaname
+      JOIN pg_class relation
+        ON relation.relnamespace = namespace.oid AND relation.relname = published.tablename
+      WHERE published.pubname = '${POWERSYNC_PUBLICATION}'
+      ORDER BY namespace.nspname, relation.relname
+    `),
+    engine.query<{ qualified_name: string }>(`
+      SELECT namespace.nspname || '.' || relation.relname AS qualified_name
+      FROM pg_roles role_record
+      JOIN pg_class relation ON true
+      JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+      WHERE role_record.rolname = '${POWERSYNC_REPLICATION_ROLE}'
+        AND relation.relkind IN ('r', 'p')
+        AND namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+        AND namespace.nspname !~ '^pg_toast'
+        AND has_table_privilege(role_record.oid, relation.oid, 'SELECT')
+      ORDER BY namespace.nspname, relation.relname
+    `),
+    engine.query<ReplicationSlotRow>(`
+      SELECT
+        slot_name,
+        active,
+        wal_status,
+        coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn), 0)::text AS retained_wal_bytes,
+        coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn), 0)::text AS unconfirmed_wal_bytes,
+        safe_wal_size::text,
+        invalidation_reason
+      FROM pg_replication_slots
+      WHERE slot_type = 'logical'
+      ORDER BY slot_name
+    `),
+  ])
+  return {
+    settings: new Map(settings.rows.map((row) => [row.name, row.setting])),
+    activeSenders: senders.rows[0]?.count ?? 0,
+    role: role.rows[0],
+    publication: publication.rows[0],
+    publicationTables: publicationTables.rows,
+    selectableTables: selectableTables.rows.map((row) => row.qualified_name),
+    slots: slots.rows,
+  }
+}
+
+function buildReadiness(
+  inventory: ReplicationInventory,
+  options: PowerSyncReplicationOptions,
+): PowerSyncReadiness {
+  const actualTables = catalogTableNames(inventory.publicationTables)
+  const expectedTables = [...options.publicationTables].sort()
+  const missingIdentity = missingReplicaIdentity(inventory.publicationTables)
+  const blockers = readinessBlockers(inventory, actualTables, expectedTables, missingIdentity)
+  return {
+    ready: blockers.length === 0,
+    blockers,
+    warnings: readinessWarnings(inventory),
+    connection: {
+      host: options.host,
+      port: options.port,
+      tls: Boolean(options.tls),
+      allowed_cidrs: options.allowCidrs,
+    },
+    wal: {
+      level: inventory.settings.get('wal_level') ?? 'unknown',
+      max_senders: integerSetting(inventory.settings.get('max_wal_senders')),
+      active_senders: inventory.activeSenders,
+      max_replication_slots: integerSetting(inventory.settings.get('max_replication_slots')),
+      used_replication_slots: inventory.slots.length,
+      max_slot_wal_keep_size: inventory.settings.get('max_slot_wal_keep_size') ?? 'unknown',
+    },
+    role: roleReadiness(inventory.role, unexpectedSelectableTables(inventory, expectedTables)),
+    publication: publicationReadiness(inventory.publication, actualTables, expectedTables, missingIdentity),
+    slots: inventory.slots.map((slot) => ({
+      name: slot.slot_name,
+      active: slot.active,
+      wal_status: slot.wal_status,
+      retained_wal_bytes: slot.retained_wal_bytes,
+      unconfirmed_wal_bytes: slot.unconfirmed_wal_bytes,
+      safe_wal_size: slot.safe_wal_size,
+      invalidation_reason: slot.invalidation_reason,
+    })),
+  }
+}
+
+function readinessBlockers(
+  inventory: ReplicationInventory,
+  actualTables: readonly string[],
+  expectedTables: readonly string[],
+  missingIdentity: readonly string[],
+): string[] {
+  const blockers = capacityBlockers(inventory)
+  if (!roleIsReady(inventory.role)) blockers.push('POWERSYNC_ROLE_NOT_READY')
+  if (unexpectedSelectableTables(inventory, expectedTables).length > 0) {
+    blockers.push('POWERSYNC_ROLE_SELECT_OUTSIDE_ALLOWLIST')
+  }
+  blockers.push(...publicationBlockers(inventory.publication, actualTables, expectedTables, missingIdentity))
+  return blockers
+}
+
+function capacityBlockers(inventory: ReplicationInventory): string[] {
+  const blockers: string[] = []
+  const maxSenders = integerSetting(inventory.settings.get('max_wal_senders'))
+  const maxSlots = integerSetting(inventory.settings.get('max_replication_slots'))
+  if (inventory.settings.get('wal_level') !== 'logical') blockers.push('WAL_LEVEL_NOT_LOGICAL')
+  if (maxSenders - inventory.activeSenders < 1) blockers.push('NO_FREE_WAL_SENDER')
+  if (maxSlots - inventory.slots.length < 1) blockers.push('NO_FREE_REPLICATION_SLOT')
+  return blockers
+}
+
+function publicationBlockers(
+  publication: ReplicationPublicationRow | undefined,
+  actualTables: readonly string[],
+  expectedTables: readonly string[],
+  missingIdentity: readonly string[],
+): string[] {
+  if (!publication) return ['POWERSYNC_PUBLICATION_MISSING']
+  const blockers: string[] = []
+  if (publication.puballtables) blockers.push('POWERSYNC_PUBLICATION_NOT_ALLOWLISTED')
+  if (!publication.pubinsert || !publication.pubupdate || !publication.pubdelete) {
+    blockers.push('POWERSYNC_PUBLICATION_DML_INCOMPLETE')
+  }
+  if (!sameStrings(actualTables, expectedTables)) blockers.push('POWERSYNC_PUBLICATION_TABLE_MISMATCH')
+  if (missingIdentity.length > 0) blockers.push('POWERSYNC_REPLICA_IDENTITY_INCOMPLETE')
+  return blockers
+}
+
+function readinessWarnings(inventory: ReplicationInventory): string[] {
+  const warnings: string[] = []
+  if (inventory.settings.get('max_slot_wal_keep_size') === '-1') warnings.push('SLOT_WAL_KEEP_SIZE_UNBOUNDED')
+  if (inventory.slots.some((slot) => slot.wal_status === 'lost' || slot.invalidation_reason)) {
+    warnings.push('INVALID_LOGICAL_SLOTS')
+  }
+  return warnings
+}
+
+function roleIsReady(role: ReplicationRoleRow | undefined): boolean {
+  return Boolean(role?.rolcanlogin && role.rolreplication && role.rolbypassrls)
+}
+
+function roleReadiness(
+  role: ReplicationRoleRow | undefined,
+  unexpectedTables: string[],
+): PowerSyncReadiness['role'] {
+  return {
+    name: POWERSYNC_REPLICATION_ROLE,
+    present: Boolean(role),
+    login: role?.rolcanlogin ?? false,
+    replication: role?.rolreplication ?? false,
+    bypass_rls: role?.rolbypassrls ?? false,
+    unexpected_selectable_tables: unexpectedTables,
+  }
+}
+
+function unexpectedSelectableTables(
+  inventory: ReplicationInventory,
+  expectedTables: readonly string[],
+): string[] {
+  const expected = new Set(expectedTables)
+  return inventory.selectableTables.filter((table) => !expected.has(table))
+}
+
+function publicationReadiness(
+  publication: ReplicationPublicationRow | undefined,
+  tables: string[],
+  expectedTables: string[],
+  missingIdentity: string[],
+): PowerSyncReadiness['publication'] {
+  return {
+    name: POWERSYNC_PUBLICATION,
+    present: Boolean(publication),
+    all_tables: publication?.puballtables ?? false,
+    tables,
+    expected_tables: expectedTables,
+    publishes_insert: publication?.pubinsert ?? false,
+    publishes_update: publication?.pubupdate ?? false,
+    publishes_delete: publication?.pubdelete ?? false,
+    replica_identity_missing_tables: missingIdentity,
+  }
+}
+
+function catalogTableNames(rows: readonly ReplicationPublicationTableRow[]): string[] {
+  return rows.map((row) => normalizeCatalogTable(row.qualified_name))
+}
+
+function missingReplicaIdentity(rows: readonly ReplicationPublicationTableRow[]): string[] {
+  return rows.filter((row) => row.replica_identity_missing)
+    .map((row) => normalizeCatalogTable(row.qualified_name))
+}
+
+function integerSetting(value: string | undefined): number {
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 0
+}
+
+function normalizeCatalogTable(value: string): string {
+  return value.replaceAll('"', '').toLowerCase()
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}

--- a/packages/supacloud-lite/src/runtime/node/native/replication.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/replication.ts
@@ -261,7 +261,7 @@ function validateTlsOptions(options: NativeReplicationTlsOptions): NativeReplica
   for (const path of [tls.certFile, tls.keyFile]) {
     if (!existsSync(path) || !statSync(path).isFile()) throw new Error(`PowerSync TLS file does not exist: ${path}`)
   }
-  if ((statSync(tls.keyFile).mode & 0o077) !== 0) {
+  if (process.platform !== 'win32' && (statSync(tls.keyFile).mode & 0o077) !== 0) {
     throw new Error('PowerSync TLS private key must not be readable by group or other users')
   }
   return tls

--- a/packages/supacloud-lite/src/runtime/node/native/replication.ts
+++ b/packages/supacloud-lite/src/runtime/node/native/replication.ts
@@ -1,0 +1,313 @@
+import { existsSync, statSync, writeFileSync } from 'node:fs'
+import { isIP } from 'node:net'
+import { resolve } from 'node:path'
+import type { DbEngine, EngineTx } from '../../db/engine.js'
+
+export const POWERSYNC_REPLICATION_ROLE = 'supacloud_powersync'
+export const POWERSYNC_PUBLICATION = 'powersync'
+
+export interface NativeReplicationTlsOptions {
+  certFile: string
+  keyFile: string
+}
+
+export interface PowerSyncReplicationOptions {
+  profile: 'powersync'
+  host: string
+  port: number
+  allowCidrs: string[]
+  publicationTables: string[]
+  password: string
+  tls?: NativeReplicationTlsOptions
+}
+
+export type NativeReplicationOptions = PowerSyncReplicationOptions
+
+export function validatePowerSyncReplicationOptions(
+  options: PowerSyncReplicationOptions,
+): PowerSyncReplicationOptions {
+  const host = options.host.trim()
+  validateConnectionInput(host, options.port, options.password)
+  const publicationTables = uniqueSorted(options.publicationTables.map(normalizeQualifiedTable))
+  const allowCidrs = uniqueSorted(options.allowCidrs.map(normalizeCidr))
+  validateAllowlists(publicationTables, allowCidrs)
+  validateNetworkBoundary(host, allowCidrs, Boolean(options.tls))
+  const tls = options.tls ? validateTlsOptions(options.tls) : undefined
+  return { ...options, host, allowCidrs, publicationTables, tls }
+}
+
+export function buildPowerSyncPostgresArgs(options: PowerSyncReplicationOptions, hbaFile: string): string[] {
+  const validated = validatePowerSyncReplicationOptions(options)
+  const args = [
+    '-c', `listen_addresses=${validated.host}`,
+    '-c', `port=${validated.port}`,
+    '-c', 'wal_level=logical',
+    '-c', 'max_wal_senders=4',
+    '-c', 'max_replication_slots=4',
+    '-c', 'max_slot_wal_keep_size=1024MB',
+    '-c', 'wal_keep_size=64MB',
+    '-c', `hba_file=${resolve(hbaFile)}`,
+  ]
+  if (!validated.tls) return [...args, '-c', 'ssl=off']
+  args.push(
+    '-c', 'ssl=on',
+    '-c', `ssl_cert_file=${validated.tls.certFile}`,
+    '-c', `ssl_key_file=${validated.tls.keyFile}`,
+  )
+  return args
+}
+
+export function writePowerSyncHba(path: string, options: PowerSyncReplicationOptions): void {
+  const validated = validatePowerSyncReplicationOptions(options)
+  const hostRecord = validated.tls ? 'hostssl' : 'host'
+  const lines = [
+    '# Managed by SupaCloud Lite. Changes are replaced when the PowerSync profile starts.',
+    'local all postgres trust',
+    ...validated.allowCidrs.flatMap((cidr) => [
+      `${hostRecord} postgres ${POWERSYNC_REPLICATION_ROLE} ${cidr} scram-sha-256`,
+      `${hostRecord} replication ${POWERSYNC_REPLICATION_ROLE} ${cidr} scram-sha-256`,
+    ]),
+    'host all all 0.0.0.0/0 reject',
+    'host all all ::/0 reject',
+    '',
+  ]
+  writeFileSync(path, lines.join('\n'), { mode: 0o600 })
+}
+
+export async function ensurePowerSyncReplicationCatalog(
+  engine: DbEngine,
+  options: PowerSyncReplicationOptions,
+): Promise<void> {
+  const validated = validatePowerSyncReplicationOptions(options)
+  await engine.transaction(async (tx) => {
+    const tables = await inspectPublicationTables(tx, validated.publicationTables)
+    validatePublicationTables(tables)
+    await configureReplicationRole(tx, validated.password)
+    await synchronizeReplicationGrants(tx, tables)
+    await assertEffectiveSelectAllowlist(tx, tables)
+    await synchronizePublication(tx, tables)
+  })
+}
+
+function validatePublicationTables(tables: readonly PublicationTableInspection[]): void {
+  const missing = tables.filter((table) => !table.present).map((table) => table.name)
+  if (missing.length > 0) {
+    throw new Error(`PowerSync publication tables do not exist: ${missing.join(', ')}`)
+  }
+  const unsupported = tables.filter((table) => table.present && !['r', 'p'].includes(table.relkind ?? ''))
+  if (unsupported.length > 0) {
+    throw new Error(`PowerSync publication only accepts ordinary or partitioned tables: ${unsupported.map((table) => table.name).join(', ')}`)
+  }
+}
+
+async function configureReplicationRole(tx: EngineTx, passwordValue: string): Promise<void> {
+  await tx.exec(`
+    DO $profile$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${POWERSYNC_REPLICATION_ROLE}') THEN
+        CREATE ROLE ${POWERSYNC_REPLICATION_ROLE};
+      END IF;
+    END
+    $profile$;
+    ALTER ROLE ${POWERSYNC_REPLICATION_ROLE}
+      WITH LOGIN NOINHERIT REPLICATION BYPASSRLS CONNECTION LIMIT 4 PASSWORD ${quoteLiteral(passwordValue)};
+    ALTER ROLE ${POWERSYNC_REPLICATION_ROLE} SET search_path = pg_catalog;
+    GRANT CONNECT ON DATABASE postgres TO ${POWERSYNC_REPLICATION_ROLE};
+  `)
+}
+
+async function synchronizeReplicationGrants(
+  tx: EngineTx,
+  tables: readonly PublicationTableInspection[],
+): Promise<void> {
+  await revokeReplicationGrants(tx)
+  await grantReplicationAllowlist(tx, tables)
+}
+
+async function revokeReplicationGrants(tx: EngineTx): Promise<void> {
+  const staleGrants = await tx.query<{ table_schema: string; table_name: string }>(`
+    SELECT DISTINCT table_schema, table_name
+    FROM information_schema.role_table_grants
+    WHERE grantee = '${POWERSYNC_REPLICATION_ROLE}' AND privilege_type = 'SELECT'
+  `)
+  for (const grant of staleGrants.rows) {
+    await tx.exec(
+      `REVOKE SELECT ON TABLE ${quoteIdentifier(grant.table_schema)}.${quoteIdentifier(grant.table_name)} ` +
+      `FROM ${POWERSYNC_REPLICATION_ROLE}`
+    )
+  }
+
+  const applicationSchemas = await tx.query<{ schema_name: string }>(`
+    SELECT nspname AS schema_name
+    FROM pg_namespace
+    WHERE nspname NOT IN ('pg_catalog', 'information_schema')
+      AND nspname !~ '^pg_toast'
+  `)
+  for (const schema of applicationSchemas.rows) {
+    await tx.exec(`REVOKE USAGE ON SCHEMA ${quoteIdentifier(schema.schema_name)} FROM ${POWERSYNC_REPLICATION_ROLE}`)
+  }
+}
+
+async function grantReplicationAllowlist(
+  tx: EngineTx,
+  tables: readonly PublicationTableInspection[],
+): Promise<void> {
+  const schemas = uniqueSorted(tables.map((table) => table.schema!))
+  for (const schema of schemas) {
+    await tx.exec(`GRANT USAGE ON SCHEMA ${quoteIdentifier(schema)} TO ${POWERSYNC_REPLICATION_ROLE}`)
+  }
+  for (const table of tables) {
+    await tx.exec(`GRANT SELECT ON TABLE ${quoteQualifiedTable(table.name)} TO ${POWERSYNC_REPLICATION_ROLE}`)
+  }
+}
+
+async function assertEffectiveSelectAllowlist(
+  tx: EngineTx,
+  tables: readonly PublicationTableInspection[],
+): Promise<void> {
+  const allowed = new Set(tables.map((table) => table.name))
+  const selectable = await tx.query<{ qualified_name: string }>(`
+    SELECT namespace.nspname || '.' || relation.relname AS qualified_name
+    FROM pg_class relation
+    JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+    WHERE relation.relkind IN ('r', 'p')
+      AND namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND namespace.nspname !~ '^pg_toast'
+      AND has_table_privilege('${POWERSYNC_REPLICATION_ROLE}', relation.oid, 'SELECT')
+    ORDER BY namespace.nspname, relation.relname
+  `)
+  const outsideAllowlist = selectable.rows.map((row) => row.qualified_name)
+    .filter((table) => !allowed.has(table))
+  if (outsideAllowlist.length > 0) {
+    throw new Error(`PowerSync role has SELECT outside the publication allowlist: ${outsideAllowlist.join(', ')}`)
+  }
+}
+
+async function synchronizePublication(tx: EngineTx, tables: readonly PublicationTableInspection[]): Promise<void> {
+  const publication = await tx.query<{ puballtables: boolean }>(
+    `SELECT puballtables FROM pg_publication WHERE pubname = '${POWERSYNC_PUBLICATION}'`
+  )
+  if (publication.rows[0]?.puballtables) {
+    throw new Error('existing powersync publication uses FOR ALL TABLES; replace it with an explicit allowlist')
+  }
+  if (publication.rows.length === 0) {
+    await tx.exec(`CREATE PUBLICATION ${POWERSYNC_PUBLICATION} WITH (publish = 'insert, update, delete')`)
+  }
+  await tx.exec(
+    `ALTER PUBLICATION ${POWERSYNC_PUBLICATION} SET TABLE ${tables.map((table) => quoteQualifiedTable(table.name)).join(', ')}; ` +
+    `ALTER PUBLICATION ${POWERSYNC_PUBLICATION} SET (publish = 'insert, update, delete')`
+  )
+}
+
+interface PublicationTableInspection {
+  name: string
+  schema?: string
+  relkind?: string
+  present: boolean
+}
+
+async function inspectPublicationTables(
+  tx: EngineTx,
+  names: readonly string[],
+): Promise<PublicationTableInspection[]> {
+  const rows: PublicationTableInspection[] = []
+  for (const name of names) {
+    const tableLookup = await tx.query<{ schema_name: string; relkind: string }>(`
+      SELECT namespace.nspname AS schema_name, relation.relkind
+      FROM pg_class relation
+      JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+      WHERE relation.oid = to_regclass($1)
+    `, [name])
+    const row = tableLookup.rows[0]
+    rows.push({ name, schema: row?.schema_name, relkind: row?.relkind, present: Boolean(row) })
+  }
+  return rows
+}
+
+function validateConnectionInput(host: string, port: number, password: string): void {
+  if (!host || (host !== 'localhost' && isIP(host) === 0)) {
+    throw new Error('PowerSync replication host must be localhost or an explicit IP address')
+  }
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('PowerSync replication port must be between 1 and 65535')
+  }
+  if (password.length < 32) {
+    throw new Error('SUPACLOUD_LITE_POWERSYNC_PASSWORD must contain at least 32 characters')
+  }
+  if (password.includes('\0')) throw new Error('SUPACLOUD_LITE_POWERSYNC_PASSWORD must not contain NUL bytes')
+}
+
+function validateAllowlists(publicationTables: string[], allowCidrs: string[]): void {
+  if (publicationTables.length === 0) {
+    throw new Error('PowerSync replication requires an explicit publication table allowlist')
+  }
+  if (allowCidrs.length === 0) throw new Error('PowerSync replication requires at least one client CIDR')
+}
+
+function validateNetworkBoundary(host: string, allowCidrs: string[], tls: boolean): void {
+  if (!isLoopbackHost(host) && !tls) {
+    throw new Error('non-loopback PowerSync replication requires TLS certificate and key files')
+  }
+  if (!tls && allowCidrs.some((cidr) => !isLoopbackCidr(cidr))) {
+    throw new Error('non-loopback PowerSync client CIDRs require TLS')
+  }
+}
+
+function validateTlsOptions(options: NativeReplicationTlsOptions): NativeReplicationTlsOptions {
+  const tls = {
+    certFile: resolve(options.certFile),
+    keyFile: resolve(options.keyFile),
+  }
+  for (const path of [tls.certFile, tls.keyFile]) {
+    if (!existsSync(path) || !statSync(path).isFile()) throw new Error(`PowerSync TLS file does not exist: ${path}`)
+  }
+  if ((statSync(tls.keyFile).mode & 0o077) !== 0) {
+    throw new Error('PowerSync TLS private key must not be readable by group or other users')
+  }
+  return tls
+}
+
+function normalizeQualifiedTable(tableName: string): string {
+  const normalized = tableName.trim().toLowerCase()
+  if (!/^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/.test(normalized)) {
+    throw new Error(`invalid PowerSync publication table: ${tableName}`)
+  }
+  return normalized
+}
+
+function normalizeCidr(cidr: string): string {
+  const normalized = cidr.trim()
+  const match = /^(.+)\/(\d{1,3})$/.exec(normalized)
+  if (!match) throw new Error(`invalid PowerSync client CIDR: ${cidr}`)
+  const address = match[1]!
+  const family = isIP(address)
+  const prefix = Number(match[2])
+  if (family === 0 || prefix < 0 || prefix > (family === 4 ? 32 : 128)) {
+    throw new Error(`invalid PowerSync client CIDR: ${cidr}`)
+  }
+  return `${address}/${prefix}`
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1'
+}
+
+function isLoopbackCidr(cidr: string): boolean {
+  return cidr === '127.0.0.1/32' || cidr === '::1/128'
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`
+}
+
+function quoteQualifiedTable(tableName: string): string {
+  return tableName.split('.').map(quoteIdentifier).join('.')
+}
+
+function quoteLiteral(literal: string): string {
+  return `'${literal.replaceAll("'", "''")}'`
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort()
+}

--- a/packages/supacloud-lite/test/cli-readonly.test.ts
+++ b/packages/supacloud-lite/test/cli-readonly.test.ts
@@ -15,6 +15,25 @@ afterEach(async () => {
 })
 
 describe('read-only CLI commands', () => {
+  test('doctor --json reports the stable PGlite capability contract without initializing a database', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-cli-doctor-'))
+    temporaryDirectories.push(projectDir)
+    const doctor = await runCli(projectDir, ['doctor', '--json'])
+
+    expect(doctor.exitCode).toBe(0)
+    expect(doctor.stderr).toBe('')
+    expect(JSON.parse(doctor.stdout)).toEqual({
+      engine: 'pglite',
+      state_machine_sql: 'supported',
+      durable_workflows: 'supported',
+      commands: 'supported',
+      artifacts: 'supported',
+      postgrest_schema_config: 'static',
+      logical_replication: 'unsupported',
+      powersync_source: 'unsupported',
+    })
+  })
+
   test('inspect reports the live schema without applying pending migrations or seed', async () => {
     const projectDir = await projectWithPendingMigration()
     const inspection = await runCli(projectDir, ['inspect'])
@@ -112,5 +131,13 @@ function isolatedProjectEnvironment(): Record<string, string | undefined> {
   delete environment.SUPACLOUD_LITE_DATA_DIR
   delete environment.SUPACLOUD_LITE_STORAGE_DIR
   delete environment.SUPACLOUD_LITE_STORAGE_BACKEND
+  delete environment.SUPACLOUD_LITE_REPLICATION_PROFILE
+  delete environment.SUPACLOUD_LITE_REPLICATION_HOST
+  delete environment.SUPACLOUD_LITE_REPLICATION_PORT
+  delete environment.SUPACLOUD_LITE_REPLICATION_ALLOW_CIDRS
+  delete environment.SUPACLOUD_LITE_POWERSYNC_TABLES
+  delete environment.SUPACLOUD_LITE_POWERSYNC_PASSWORD
+  delete environment.SUPACLOUD_LITE_REPLICATION_TLS_CERT_FILE
+  delete environment.SUPACLOUD_LITE_REPLICATION_TLS_KEY_FILE
   return environment
 }

--- a/packages/supacloud-lite/test/commands-artifacts.test.ts
+++ b/packages/supacloud-lite/test/commands-artifacts.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { createSupaCloudClient } from './helpers/supacloud-js-source.js'
+import { createLiteBackend, createNativeEngine, type SupaCloudLiteBackend } from '../src/index.js'
+
+const config = {
+  jwtSecret: 'x'.repeat(64),
+  vaultKey: 'y'.repeat(64),
+  log: () => {},
+}
+const nativeMode = process.env.SUPACLOUD_LITE_TEST_NATIVE === '1'
+
+describe(`Transactional commands and artifact registry (${nativeMode ? 'native' : 'pglite'})`, () => {
+  test('enforces service-role access, idempotency, durability, and immutability', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), `supacloud-lite-primitives-${nativeMode ? 'native' : 'pglite'}-`))
+    const backend = await primitivesBackend(join(rootDir, 'database'))
+    try {
+      const anon = supabaseClient(backend.anonKey, backend.fetch)
+      const serviceSupabase = supabaseClient(backend.serviceRoleKey, backend.fetch)
+      const client = createSupaCloudClient({
+        supabase: serviceSupabase,
+        managementApiUrl: 'http://management-not-used',
+        projectRef: 'lite',
+      })
+      const commandId = '11111111-1111-4111-8111-111111111111'
+
+      const denied = await anon.rpc('supacloud_command_get', { request: { commandId } })
+      expect(denied.data).toBeNull()
+      expect(denied.error?.code).toBe('42501')
+
+      const commandRequest = {
+        commandId,
+        commandType: 'report.issue',
+        targetType: 'report',
+        targetId: 'report-1',
+        payload: { reportId: 'report-1' },
+        maxAttempts: 2,
+      }
+      expect(await client.commands.submit(commandRequest)).toMatchObject({
+        commandId,
+        commandType: 'report.issue',
+        idempotent: false,
+        workflow: { status: 'queued' },
+      })
+      expect((await client.commands.submit(commandRequest)).idempotent).toBe(true)
+      await expect(client.commands.submit({
+        ...commandRequest,
+        payload: { reportId: 'changed' },
+      })).rejects.toMatchObject({ code: '23505' })
+
+      const claim = await client.workflows.claim({ workerId: 'command-worker', visibilityTimeoutSeconds: 30 })
+      expect(claim).toMatchObject({
+        status: 'claimed',
+        runId: commandId,
+        workflowName: 'command.report.issue',
+      })
+      if (!claim || claim.status !== 'claimed') throw new Error('expected command workflow claim')
+      await client.workflows.complete({
+        stepId: claim.stepId,
+        messageId: claim.messageId,
+        attempt: claim.attempt,
+        workerId: claim.workerId,
+        runOutput: { reportVersion: 2 },
+      })
+      expect(await client.commands.get(commandId)).toMatchObject({
+        commandId,
+        workflow: { status: 'completed', output: { reportVersion: 2 } },
+      })
+
+      await backend.db.query(`insert into storage.buckets (id, name, public) values ('reports', 'reports', false)`)
+      const objectIds = [
+        '22222222-2222-4222-8222-222222222222',
+        '33333333-3333-4333-8333-333333333333',
+      ]
+      await backend.db.query(
+        `insert into storage.objects (id, bucket_id, name, version, metadata)
+         values ($1, 'reports', 'source.pdf', 'v1', '{"size":100}'::jsonb),
+                ($2, 'reports', 'derived.json', 'v1', '{"size":20}'::jsonb)`,
+        objectIds,
+      )
+      const sourceArtifactId = '44444444-4444-4444-8444-444444444444'
+      const derivedArtifactId = '55555555-5555-4555-8555-555555555555'
+      const sourceRequest = {
+        artifactId: sourceArtifactId,
+        bucketId: 'reports',
+        objectPath: 'source.pdf',
+        artifactType: 'document.pdf',
+        sha256: 'a'.repeat(64),
+        sizeBytes: 100,
+        mimeType: 'application/pdf',
+      }
+      expect(await client.artifacts.register(sourceRequest)).toMatchObject({
+        artifactId: sourceArtifactId,
+        objectVersion: 'v1',
+        idempotent: false,
+      })
+      expect((await client.artifacts.register(sourceRequest)).idempotent).toBe(true)
+      await expect(client.artifacts.register({ ...sourceRequest, sha256: 'b'.repeat(64) }))
+        .rejects.toMatchObject({ code: '23505' })
+      await client.artifacts.register({
+        artifactId: derivedArtifactId,
+        bucketId: 'reports',
+        objectPath: 'derived.json',
+        artifactType: 'ocr.result',
+        sha256: 'c'.repeat(64),
+        sizeBytes: 20,
+        mimeType: 'application/json',
+      })
+      expect(await client.artifacts.link({
+        parentArtifactId: sourceArtifactId,
+        childArtifactId: derivedArtifactId,
+        relationType: 'derived_from',
+      })).toMatchObject({
+        artifactId: derivedArtifactId,
+        parents: [{ artifactId: sourceArtifactId, relationType: 'derived_from' }],
+      })
+      await expect(client.artifacts.link({
+        parentArtifactId: derivedArtifactId,
+        childArtifactId: sourceArtifactId,
+        relationType: 'derived_from',
+      })).rejects.toMatchObject({ code: '23514' })
+      await expect(backend.db.query(
+        `update storage.objects set name = 'changed.pdf' where id = $1`,
+        [objectIds[0]],
+      )).rejects.toThrow('SUPACLOUD_ARTIFACT_IMMUTABLE')
+      await expect(backend.db.query(
+        `delete from storage.objects where id = $1`,
+        [objectIds[0]],
+      )).rejects.toThrow('SUPACLOUD_ARTIFACT_IMMUTABLE')
+    } finally {
+      await backend.close()
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  }, 180_000)
+})
+
+async function primitivesBackend(dataDir: string): Promise<SupaCloudLiteBackend> {
+  if (!nativeMode) return createLiteBackend({ ...config, dataDir })
+  return createLiteBackend({ ...config, engine: await createNativeEngine({ dataDir }) })
+}
+
+function supabaseClient(key: string, fetchImpl: typeof fetch): SupabaseClient {
+  return createClient('http://local', key, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    global: { fetch: fetchImpl, headers: { authorization: `Bearer ${key}` } },
+  })
+}

--- a/packages/supacloud-lite/test/helpers/supacloud-js-source.d.ts
+++ b/packages/supacloud-lite/test/helpers/supacloud-js-source.d.ts
@@ -34,6 +34,31 @@ interface WorkflowRun {
   }>
 }
 
+interface CommandReceipt {
+  commandId: string
+  commandType: string
+  idempotent: boolean
+  workflow: WorkflowRun & { output?: Record<string, unknown> }
+}
+
+interface CommandClient {
+  submit(request: Record<string, unknown>): Promise<CommandReceipt>
+  get(commandId: string): Promise<CommandReceipt | null>
+}
+
+interface Artifact {
+  artifactId: string
+  objectVersion: string
+  idempotent: boolean
+  parents: Array<{ artifactId: string; relationType: string }>
+}
+
+interface ArtifactClient {
+  register(request: Record<string, unknown>): Promise<Artifact>
+  get(artifactId: string): Promise<Artifact | null>
+  link(request: Record<string, unknown>): Promise<Artifact>
+}
+
 interface WorkflowClient {
   start(request: Record<string, unknown>): Promise<WorkflowRun>
   claim(request: Record<string, unknown>): Promise<Record<string, unknown> | null>
@@ -53,4 +78,6 @@ export function createSupaCloudClient(options: {
 }): {
   queue(name: string): QueueClient
   workflows: WorkflowClient
+  commands: CommandClient
+  artifacts: ArtifactClient
 }

--- a/packages/supacloud-lite/test/maker-checker-workflow.test.ts
+++ b/packages/supacloud-lite/test/maker-checker-workflow.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { createSupaCloudClient } from './helpers/supacloud-js-source.js'
+import {
+  createLiteBackend,
+  createNativeEngine,
+  signJwt,
+  type SupaCloudLiteBackend,
+} from '../src/index.js'
+
+const nativeMode = process.env.SUPACLOUD_LITE_TEST_NATIVE === '1'
+const makerId = '11111111-1111-4111-8111-111111111111'
+const checkerId = '22222222-2222-4222-8222-222222222222'
+const documentId = '33333333-3333-4333-8333-333333333333'
+
+describe(`Maker-Checker and workflow dispatcher (${nativeMode ? 'native' : 'pglite'})`, () => {
+  test('enforces transitions and dispatches the durable workflow through @supacloud/js', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), `supacloud-lite-maker-checker-${nativeMode ? 'native' : 'pglite'}-`))
+    let backend: SupaCloudLiteBackend | undefined
+    try {
+      backend = await makerCheckerBackend(join(rootDir, 'database'))
+      await seedReviewDocument(backend)
+      const maker = await authenticatedClient(backend, makerId)
+      const checker = await authenticatedClient(backend, checkerId)
+      const service = supabaseClient(backend, backend.serviceRoleKey, backend.serviceRoleKey)
+      const supacloud = createSupaCloudClient({
+        supabase: service,
+        managementApiUrl: 'http://management-not-used',
+        projectRef: 'lite',
+      })
+
+      expect((await checker.rpc('transition_review_document', {
+        request: transitionRequest('approve', 1, 'checker-before-submit'),
+      })).error?.code).toBe('55000')
+      expect((await maker.rpc('transition_review_document', {
+        request: transitionRequest('submit', 1, 'maker-submit'),
+      })).data).toMatchObject({ status: 'submitted', rowVersion: '2', idempotent: false })
+      expect((await maker.rpc('transition_review_document', {
+        request: transitionRequest('submit', 1, 'maker-submit'),
+      })).data).toMatchObject({ status: 'submitted', rowVersion: '2', idempotent: true })
+      expect((await maker.rpc('transition_review_document', {
+        request: transitionRequest('approve', 2, 'maker-self-approval'),
+      })).error?.code).toBe('42501')
+      expect((await checker.rpc('transition_review_document', {
+        request: transitionRequest('approve', 1, 'stale-approval'),
+      })).error?.code).toBe('40001')
+      expect((await checker.rpc('transition_review_document', {
+        request: transitionRequest('approve', 2, 'checker-approval'),
+      })).data).toMatchObject({ status: 'approved', rowVersion: '3', idempotent: false })
+
+      await expect(backend.db.query(
+        `update public.review_documents set status = 'draft' where id = $1`,
+        [documentId],
+      )).rejects.toThrow('REVIEW_DOCUMENT_DIRECT_TRANSITION_FORBIDDEN')
+      await expect(backend.db.query(
+        `delete from public.review_document_transition_events where document_id = $1`,
+        [documentId],
+      )).rejects.toThrow('REVIEW_DOCUMENT_EVENT_APPEND_ONLY')
+
+      const transitionState = await backend.db.query<{ status: string; row_version: number; event_count: number; outbox_count: number }>(`
+        SELECT
+          document.status,
+          document.row_version,
+          (SELECT count(*)::integer FROM public.review_document_transition_events event
+           WHERE event.document_id = document.id) AS event_count,
+          (SELECT count(*)::integer FROM public.review_document_workflow_outbox outbox
+           WHERE outbox.document_id = document.id) AS outbox_count
+        FROM public.review_documents document WHERE document.id = $1
+      `, [documentId])
+      expect(transitionState.rows).toEqual([{
+        status: 'approved',
+        row_version: 3,
+        event_count: 2,
+        outbox_count: 1,
+      }])
+
+      const dispatch = await service.rpc('claim_review_document_workflow', {
+        request: { workerId: 'lite-dispatcher', leaseSeconds: 300 },
+      })
+      expect(dispatch.error).toBeNull()
+      const claim = requireDispatchClaim(dispatch.data)
+      expect(claim).toMatchObject({
+        workflowName: 'review-document.after-approval',
+        workflowVersion: '1',
+        firstStepKey: 'render',
+      })
+      const started = await supacloud.workflows.start({
+        runId: claim.runId,
+        workflowName: claim.workflowName,
+        workflowVersion: claim.workflowVersion,
+        firstStepKey: claim.firstStepKey,
+        input: claim.input,
+        maxAttempts: 5,
+      })
+      expect(started).toMatchObject({ runId: claim.runId, status: 'queued', idempotent: false })
+      expect((await supacloud.workflows.start({
+        runId: claim.runId,
+        workflowName: claim.workflowName,
+        workflowVersion: claim.workflowVersion,
+        firstStepKey: claim.firstStepKey,
+        input: claim.input,
+        maxAttempts: 5,
+      })).idempotent).toBe(true)
+      expect((await service.rpc('complete_review_document_workflow_dispatch', {
+        request: {
+          outboxId: claim.outboxId,
+          claimToken: claim.claimToken,
+          workerId: 'lite-dispatcher',
+        },
+      })).data).toEqual({ outboxId: claim.outboxId, dispatched: true })
+      expect((await service.rpc('claim_review_document_workflow', {
+        request: { workerId: 'lite-dispatcher', leaseSeconds: 300 },
+      })).data).toBeNull()
+
+      const workflowClaim = await supacloud.workflows.claim({
+        workerId: 'lite-workflow-worker',
+        visibilityTimeoutSeconds: 30,
+      })
+      if (!workflowClaim || workflowClaim.status !== 'claimed') throw new Error('expected queued workflow step')
+      const completed = await supacloud.workflows.complete({
+        stepId: workflowClaim.stepId,
+        messageId: workflowClaim.messageId,
+        attempt: workflowClaim.attempt,
+        workerId: workflowClaim.workerId,
+        runOutput: { artifactId: '44444444-4444-4444-8444-444444444444' },
+      })
+      expect(completed).toMatchObject({ runId: claim.runId, status: 'completed' })
+    } finally {
+      await backend?.close()
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  }, 180_000)
+})
+
+async function makerCheckerBackend(dataDir: string): Promise<SupaCloudLiteBackend> {
+  const examples = resolve(import.meta.dir, '../../../docs/examples')
+  const migrations = await Promise.all([
+    ['20260820010000_maker_checker', 'maker-checker-state-machine.sql'],
+    ['20260820010001_workflow_bridge', 'maker-checker-workflow-bridge.sql'],
+  ].map(async ([name, file]) => ({ name, sql: await readFile(join(examples, file), 'utf8') })))
+  const config = {
+    jwtSecret: 'x'.repeat(64),
+    vaultKey: 'y'.repeat(64),
+    migrations,
+    log: () => {},
+  }
+  if (!nativeMode) return createLiteBackend({ ...config, dataDir })
+  return createLiteBackend({ ...config, engine: await createNativeEngine({ dataDir }) })
+}
+
+async function seedReviewDocument(backend: SupaCloudLiteBackend): Promise<void> {
+  await backend.db.query(`
+    insert into auth.users (id, aud, role, raw_app_meta_data, raw_user_meta_data)
+    values
+      ($1, 'authenticated', 'authenticated', '{"provider":"email","providers":["email"]}', '{}'),
+      ($2, 'authenticated', 'authenticated', '{"provider":"email","providers":["email"]}', '{}')
+  `, [makerId, checkerId])
+  await backend.db.query(`
+    insert into public.review_documents (id, maker_id, payload)
+    values ($2, $1, '{"sampleId":"sample-1","result":"pass"}')
+  `, [makerId, documentId])
+  await backend.db.query(`
+    insert into public.review_document_members (document_id, user_id, role)
+    values ($1, $2, 'maker'), ($1, $3, 'checker')
+  `, [documentId, makerId, checkerId])
+}
+
+async function authenticatedClient(backend: SupaCloudLiteBackend, userId: string): Promise<SupabaseClient> {
+  const token = await signJwt({ role: 'authenticated', sub: userId }, backend.jwtSecret)
+  return supabaseClient(backend, token)
+}
+
+function supabaseClient(backend: SupaCloudLiteBackend, bearer: string, apiKey = backend.anonKey): SupabaseClient {
+  return createClient('http://local', apiKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
+    global: { fetch: backend.fetch, headers: { authorization: `Bearer ${bearer}` } },
+  })
+}
+
+function transitionRequest(event: string, expectedVersion: number, idempotencyKey: string) {
+  return { documentId, event, expectedVersion, idempotencyKey }
+}
+
+function requireDispatchClaim(value: unknown): {
+  outboxId: string
+  claimToken: string
+  runId: string
+  workflowName: string
+  workflowVersion: string
+  firstStepKey: string
+  input: Record<string, unknown>
+} {
+  if (!value || typeof value !== 'object') throw new Error('expected workflow dispatch claim')
+  return value as ReturnType<typeof requireDispatchClaim>
+}

--- a/packages/supacloud-lite/test/native-engine.test.ts
+++ b/packages/supacloud-lite/test/native-engine.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createBackend } from '../src/runtime/index.js'
 import { createNativeEngine, isNativeEngineSupported } from '../src/runtime/node/native/engine.js'
+import { ensurePowerSyncReplicationCatalog } from '../src/runtime/node/native/replication.js'
+import { inspectPowerSyncReadiness } from '../src/runtime/node/native/readiness.js'
 import { buildWireEngine } from '../src/runtime/node/native/wire-engine.js'
-import { decodeValue, parsePgArray, type PgWireClient } from '../src/runtime/node/native/wire.js'
+import { decodeValue, parsePgArray, PgWireClient } from '../src/runtime/node/native/wire.js'
 
 const nativeIntegrationEnabled = process.env.SUPACLOUD_LITE_TEST_NATIVE === '1' && isNativeEngineSupported()
 const temporaryDirectories: string[] = []
@@ -118,6 +120,125 @@ describe.skipIf(!nativeIntegrationEnabled)('native PostgreSQL engine', () => {
       await backend.close()
     }
   }, 120_000)
+
+  test('enables a bounded PowerSync source only through the explicit profile', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'supacloud-lite-native-powersync-'))
+    temporaryDirectories.push(projectRoot)
+    const port = await freePort()
+    const password = `powersync-${crypto.randomUUID()}-${crypto.randomUUID()}`
+    const replication = {
+      profile: 'powersync' as const,
+      host: '127.0.0.1',
+      port,
+      allowCidrs: ['127.0.0.1/32'],
+      publicationTables: ['public.lab_entries'],
+      password,
+    }
+    const engine = await createNativeEngine({ dataDir: join(projectRoot, 'pgdata'), replication })
+    const backend = await createBackend({
+      engine,
+      migrations: [{
+        name: '20260820010000_powersync_source',
+        sql: `
+          create table public.lab_entries (
+            id uuid primary key default gen_random_uuid(),
+            payload jsonb not null default '{}'::jsonb
+          );
+        `,
+      }],
+      startRuntimeServices: false,
+    })
+    try {
+      await ensurePowerSyncReplicationCatalog(backend.db.engine, replication)
+      const readiness = await inspectPowerSyncReadiness(backend.db.engine, replication)
+      expect(readiness).toMatchObject({
+        ready: true,
+        blockers: [],
+        wal: {
+          level: 'logical',
+          max_senders: 4,
+          max_replication_slots: 4,
+          used_replication_slots: 0,
+          max_slot_wal_keep_size: '1024',
+        },
+        role: {
+          name: 'supacloud_powersync',
+          present: true,
+          login: true,
+          replication: true,
+          bypass_rls: true,
+        },
+        publication: {
+          name: 'powersync',
+          present: true,
+          all_tables: false,
+          tables: ['public.lab_entries'],
+          expected_tables: ['public.lab_entries'],
+        },
+        slots: [],
+      })
+
+      const powersync = await PgWireClient.connect({
+        host: '127.0.0.1',
+        port,
+        user: 'supacloud_powersync',
+        database: 'postgres',
+        password,
+      })
+      try {
+        expect((await powersync.query<{ count: number }>('select count(*)::integer as count from public.lab_entries')).rows)
+          .toEqual([{ count: 0 }])
+        await expect(powersync.query('create table public.forbidden (id integer)')).rejects.toMatchObject({ code: '42501' })
+      } finally {
+        await powersync.close()
+      }
+
+      await backend.db.exec(`
+        create table public.not_published (id integer primary key);
+        grant select on public.not_published to supacloud_powersync;
+      `)
+      const drifted = await inspectPowerSyncReadiness(backend.db.engine, replication)
+      expect(drifted.ready).toBe(false)
+      expect(drifted.blockers).toContain('POWERSYNC_ROLE_SELECT_OUTSIDE_ALLOWLIST')
+      expect(drifted.role.unexpected_selectable_tables).toEqual(['public.not_published'])
+    } finally {
+      await backend.close()
+    }
+  }, 180_000)
+
+  test('returns an existing native data directory to the lightweight defaults after profile shutdown', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'supacloud-lite-native-profile-reset-'))
+    temporaryDirectories.push(projectRoot)
+    const dataDir = join(projectRoot, 'pgdata')
+    const replication = {
+      profile: 'powersync' as const,
+      host: '127.0.0.1',
+      port: await freePort(),
+      allowCidrs: ['127.0.0.1/32'],
+      publicationTables: ['public.placeholder'],
+      password: `powersync-${crypto.randomUUID()}-${crypto.randomUUID()}`,
+    }
+    const profiled = await createNativeEngine({ dataDir, replication })
+    expect((await replicationSettings(profiled)).rows).toEqual([{
+      listen_addresses: '127.0.0.1',
+      wal_level: 'logical',
+      max_wal_senders: '4',
+      max_replication_slots: '4',
+    }])
+    await profiled.close()
+
+    const lightweight = await createNativeEngine({ dataDir })
+    try {
+      expect((await replicationSettings(lightweight)).rows).toEqual([{
+        listen_addresses: '',
+        wal_level: 'minimal',
+        max_wal_senders: '0',
+        max_replication_slots: '0',
+      }])
+    } finally {
+      await lightweight.close()
+    }
+  }, 180_000)
 })
 
 function wireClient(): PgWireClient {
@@ -127,4 +248,26 @@ function wireClient(): PgWireClient {
     exec: async () => [],
     close: async () => undefined,
   } as unknown as PgWireClient
+}
+
+async function freePort(): Promise<number> {
+  const server = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { data() {} } })
+  const port = server.port
+  server.stop(true)
+  return port
+}
+
+function replicationSettings(engine: Awaited<ReturnType<typeof createNativeEngine>>) {
+  return engine.query<{
+    listen_addresses: string
+    wal_level: string
+    max_wal_senders: string
+    max_replication_slots: string
+  }>(`
+    SELECT
+      current_setting('listen_addresses') AS listen_addresses,
+      current_setting('wal_level') AS wal_level,
+      current_setting('max_wal_senders') AS max_wal_senders,
+      current_setting('max_replication_slots') AS max_replication_slots
+  `)
 }

--- a/packages/supacloud-lite/test/replication-profile.test.ts
+++ b/packages/supacloud-lite/test/replication-profile.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  buildPowerSyncPostgresArgs,
+  liteCapabilities,
+  validatePowerSyncReplicationOptions,
+  writePowerSyncHba,
+  type PowerSyncReplicationOptions,
+} from '../src/index.js'
+
+const baseOptions: PowerSyncReplicationOptions = {
+  profile: 'powersync',
+  host: '127.0.0.1',
+  port: 54322,
+  allowCidrs: ['127.0.0.1/32'],
+  publicationTables: ['public.lab_entries'],
+  password: 'x'.repeat(48),
+}
+
+describe('PowerSync native replication profile', () => {
+  test('keeps PGlite explicitly unsupported and native opt-in', () => {
+    expect(liteCapabilities('pglite')).toEqual({
+      engine: 'pglite',
+      state_machine_sql: 'supported',
+      durable_workflows: 'supported',
+      commands: 'supported',
+      artifacts: 'supported',
+      postgrest_schema_config: 'static',
+      logical_replication: 'unsupported',
+      powersync_source: 'unsupported',
+    })
+    expect(liteCapabilities('native')).toMatchObject({
+      logical_replication: 'disabled',
+      powersync_source: 'disabled',
+    })
+    expect(liteCapabilities('native', 'powersync')).toMatchObject({
+      logical_replication: 'supported',
+      powersync_source: 'supported',
+      replication_profile: 'powersync',
+    })
+  })
+
+  test('requires an allowlist, strong password, and TLS outside loopback', () => {
+    expect(() => validatePowerSyncReplicationOptions({
+      ...baseOptions,
+      publicationTables: [],
+    })).toThrow('explicit publication table allowlist')
+    expect(() => validatePowerSyncReplicationOptions({
+      ...baseOptions,
+      password: 'short',
+    })).toThrow('at least 32 characters')
+    expect(() => validatePowerSyncReplicationOptions({
+      ...baseOptions,
+      host: '0.0.0.0',
+      allowCidrs: ['10.20.0.0/16'],
+    })).toThrow('requires TLS')
+  })
+
+  test('writes a deny-by-default HBA and bounded WAL settings', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'supacloud-lite-replication-profile-'))
+    const hbaFile = join(root, 'pg_hba.conf')
+    try {
+      writePowerSyncHba(hbaFile, baseOptions)
+      const hba = await readFile(hbaFile, 'utf8')
+      expect(hba).toContain('host postgres supacloud_powersync 127.0.0.1/32 scram-sha-256')
+      expect(hba).toContain('host replication supacloud_powersync 127.0.0.1/32 scram-sha-256')
+      expect(hba).toContain('host all all 0.0.0.0/0 reject')
+
+      const args = buildPowerSyncPostgresArgs(baseOptions, hbaFile)
+      expect(args).toContain('wal_level=logical')
+      expect(args).toContain('max_wal_senders=4')
+      expect(args).toContain('max_replication_slots=4')
+      expect(args).toContain('max_slot_wal_keep_size=1024MB')
+      expect(args).toContain('ssl=off')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test('accepts non-loopback listeners only with protected TLS material and CIDRs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'supacloud-lite-replication-tls-'))
+    const certFile = join(root, 'server.crt')
+    const keyFile = join(root, 'server.key')
+    try {
+      await writeFile(certFile, 'certificate')
+      await writeFile(keyFile, 'private-key')
+      await chmod(keyFile, 0o600)
+      const validated = validatePowerSyncReplicationOptions({
+        ...baseOptions,
+        host: '0.0.0.0',
+        allowCidrs: ['10.20.0.0/16'],
+        tls: { certFile, keyFile },
+      })
+      expect(validated.tls).toEqual({ certFile, keyFile })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- publish shared Commands/Artifacts SQL modules and typed `@supacloud/js` clients across full SupaCloud and Lite
- add Maker-Checker and workflow dispatcher PGlite/native contract tests plus stable `supacloud-lite doctor --json` capability output
- add an opt-in Native Lite PowerSync replication profile with bounded WAL capacity, SCRAM/TLS network controls, explicit role/publication allowlists, and read-only readiness diagnostics
- keep PGlite explicitly unsupported as a PowerSync source and document central SupaCloud/outbox alternatives, auth/upload/conflict/resnapshot acceptance, and cleanup boundaries

## Verification
- `packages/supacloud-lite`: typecheck, focused PGlite tests, `test:native`, build
- `packages/supacloud-js`: runtime/test typecheck, workflows/commands/artifacts tests, build
- `packages/management-api`: typecheck, SQL module synchronization, focused schema/runtime tests
- `git diff --check`

## Safety boundaries
- PowerSync profile is disabled by default and PGlite never emulates replication catalogs
- non-loopback database listeners require TLS and explicit CIDRs
- Lite does not create or delete replication slots
- existing unrelated dirty work was preserved before this isolated commit
