### PR TITLE
feat(cli): support SupaCloud Lite commands

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -105,6 +105,29 @@ The packaged Skill enforces these defaults for agents:
 Restart or reload the agent after installing/updating a Skill so its discovery
 catalog is refreshed.
 
+### SupaCloud Lite CLI adapter
+
+Lite supports CLI workflows through its standalone `supacloud-lite` binary and
+through `supacloud-cli lite`. The main CLI adapter is local-only: it does not
+use Management API credentials, the official Supabase CLI, or a Postgres DSN
+for the PGlite state directory.
+
+```bash
+supacloud-cli lite migrate --project_dir .
+supacloud-cli lite status --project_dir .
+supacloud-cli lite db_diff --project_dir . --file add_accounts
+supacloud-cli lite db_pull --project_dir . --file remote_schema
+supacloud-cli lite gen_types --project_dir . --output src/database.types.ts
+supacloud-cli lite snapshot_create --project_dir . --output backups/lite.tar.gz
+supacloud-cli lite doctor --project_dir . --json
+supacloud-cli lite start --project_dir . --port 54321
+```
+
+Executable resolution is `SUPACLOUD_LITE_CLI_BIN`, then the project-local
+`@supacloud/lite` launcher, then `supacloud-lite` on `PATH`. The `supabase`
+module remains reserved for the official Supabase CLI and Management-backed
+remote project operations.
+
 ### Official Supabase CLI adapter
 
 `supacloud-cli supabase` is a thin, allowlisted adapter around the official

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -440,6 +440,35 @@ Use `--data_mode full_clone` only for an explicitly approved non-sensitive or
 masked debugging dataset. Whole-database replacement is an administrator-only
 break-glass API mode and is intentionally not exposed by this project CLI.
 
+## SupaCloud Lite CLI adapter
+
+Lite can be used from its standalone `supacloud-lite` CLI and from the main
+`supacloud-cli` through the local-only `lite` module. The adapter never calls
+the Management API, never invokes the official Supabase CLI, and never treats a
+PGlite data directory as a Postgres DSN.
+
+```bash
+supacloud-cli lite migrate --project_dir .
+supacloud-cli lite status --project_dir .
+supacloud-cli lite db_diff --project_dir . --file add_accounts
+supacloud-cli lite db_pull --project_dir . --file remote_schema
+supacloud-cli lite gen_types --project_dir . --output src/database.types.ts
+supacloud-cli lite snapshot_create --project_dir . --output backups/lite.tar.gz
+supacloud-cli lite doctor --project_dir . --json
+supacloud-cli lite start --project_dir . --port 54321
+```
+
+The adapter resolves the executable in this order:
+
+1. `SUPACLOUD_LITE_CLI_BIN`
+2. `<workdir>/node_modules/@supacloud/lite/dist/launcher.cjs`
+3. `supacloud-lite` on `PATH`
+
+Install `@supacloud/lite` or provide an explicit binary before using the
+adapter. Lite actions are local-only, so Management API context and project
+refs are not required. The `supabase` module remains the official CLI adapter;
+use it for upstream Supabase CLI actions and Management-backed remote pushes.
+
 ## Official Supabase CLI adapter
 
 The `supabase` command group is a thin, allowlisted adapter around the official

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { registerQueueTools } from "./shared/tools/queue-tools";
 import { registerGatewayTools } from "./shared/tools/gateway-tools";
 import { registerBranchTools } from "./shared/tools/branch-tools";
 import { registerSupabaseCliTools } from "./shared/tools/supabase-cli-tools";
+import { registerLiteCliTools } from "./shared/tools/lite-cli-tools";
 import { registerAiTools } from "./shared/tools/ai-tools";
 import { registerScheduledFunctionTools } from "./shared/tools/scheduled-function-tools";
 import { registerMutationTools } from "./shared/tools/mutation-tools";
@@ -303,6 +304,9 @@ EXAMPLES
   ${preferredCommand} supabase db_diff --schema public --name add_accounts
   ${preferredCommand} supabase push --ref abc123 --dir supabase/migrations --dry_run
   ${preferredCommand} supabase db_dump --db_url "postgresql://..." --file backups/schema.sql
+  ${preferredCommand} lite migrate --project_dir .
+  ${preferredCommand} lite start --project_dir . --port 54321
+  ${preferredCommand} lite doctor --project_dir . --json
   ${preferredCommand} branch create --name feature-auth --data_mode schema_only
   ${preferredCommand} branch promotion_plan --branch_ref preview123
   ${preferredCommand} branch promote --branch_ref preview123 --plan_checksum <sha256>
@@ -362,6 +366,7 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
         projectRef: context.projectRef || undefined,
         readOnly: context.readOnly,
     })));
+    Object.assign(tools, captureTools((server) => registerLiteCliTools(server as any)));
     Object.assign(tools, captureTools((server) => registerAiTools(server as any)));
 
     const registerContextAwareHelp = () => {
@@ -531,7 +536,7 @@ async function main() {
     }
 
     const cliTools = createCliTools(context, globalOptions.confirmProduction);
-    if (args.length === 1 && !["ai", "supabase"].includes(args[0]) && cliTools[args[0]]) {
+    if (args.length === 1 && !["ai", "supabase", "lite"].includes(args[0]) && cliTools[args[0]]) {
         const result = await cliTools[args[0]].callback({});
         if (result?.content && Array.isArray(result.content)) {
             for (const chunk of result.content) {

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -25,6 +25,12 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         local: ["version", "migration_new", "db_diff", "db_reset", "db_pull", "db_dump", "migration_list", "gen_types"],
         write: ["push"],
     },
+    lite: {
+        local: [
+            "version", "start", "migrate", "status", "keys", "gen_types", "db_reset", "db_diff", "db_pull",
+            "snapshot_create", "snapshot_restore", "upgrade", "inspect", "doctor",
+        ],
+    },
     auth: {
         read: ["list_users", "get_user", "list_providers", "get_provider", "supported_providers", "get_settings", "get_config", "get_oauth_server"],
         write: ["generate_link", "configure_provider", "update_provider", "disable_provider", "wechat_mini", "wechat_open", "update_settings", "update_config", "migrate_oauth_server"],

--- a/packages/cli/src/shared/tools/lite-cli-tools.test.ts
+++ b/packages/cli/src/shared/tools/lite-cli-tools.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import {
+    buildLiteArgs,
+    registerLiteCliTools,
+    resolveLiteCommand,
+} from "./lite-cli-tools";
+
+describe("SupaCloud Lite CLI adapter", () => {
+    test("maps Lite commands without creating a Postgres DSN", () => {
+        expect(buildLiteArgs({
+            action: "migrate",
+            project_dir: "/workspace/project",
+            engine: "pglite",
+        })).toEqual(["migrate", "--project-dir", "/workspace/project", "--engine", "pglite"]);
+
+        expect(buildLiteArgs({
+            action: "db_pull",
+            project_dir: "/workspace/project",
+            file: "remote_schema",
+        })).toEqual(["db", "pull", "remote_schema", "--project-dir", "/workspace/project"]);
+
+        expect(buildLiteArgs({
+            action: "snapshot_restore",
+            project_dir: "/workspace/project",
+            snapshot_file: "/tmp/backup.tar.gz",
+            force: true,
+        })).toEqual([
+            "snapshot", "restore", "/tmp/backup.tar.gz",
+            "--project-dir", "/workspace/project", "--force",
+        ]);
+    });
+
+    test("resolves explicit binaries and rejects unsafe paths", () => {
+        expect(resolveLiteCommand("/workspace/project", {
+            SUPACLOUD_LITE_CLI_BIN: "/opt/bin/supacloud-lite",
+        })).toEqual(["/opt/bin/supacloud-lite"]);
+        expect(() => resolveLiteCommand("/workspace/project", {
+            SUPACLOUD_LITE_CLI_BIN: "bad\0path",
+        })).toThrow("Invalid SUPACLOUD_LITE_CLI_BIN");
+    });
+
+    test("keeps Lite actions local and never calls the Management callback", async () => {
+        let registered: ((args: any) => Promise<any>) | undefined;
+        let request: any;
+        registerLiteCliTools({
+            tool(_name, _description, _schema, callback) {
+                registered = callback;
+            },
+        }, {
+            executeLiteCli: async (value) => {
+                request = value;
+                return { exitCode: 0, stdout: "ready\n", stderr: "" };
+            },
+        });
+
+        const result = await registered!({ action: "doctor", project_dir: resolve(".") });
+
+        expect(request).toEqual({ action: "doctor", project_dir: resolve(".") });
+        expect(result.isError).toBe(false);
+        expect(result.content[0].text).toContain("SupaCloud Lite doctor completed");
+    });
+});

--- a/packages/cli/src/shared/tools/lite-cli-tools.ts
+++ b/packages/cli/src/shared/tools/lite-cli-tools.ts
@@ -1,0 +1,270 @@
+import { spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { Type } from "@sinclair/typebox";
+import { optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+
+type ToolServer = {
+    tool: (
+        name: string,
+        description: string,
+        schema: ToolSchema,
+        callback: (requestArguments: any) => Promise<any>,
+    ) => void;
+};
+
+export type LiteCliAction =
+    | "version" | "start" | "migrate" | "status" | "keys" | "gen_types"
+    | "db_reset" | "db_diff" | "db_pull" | "snapshot_create" | "snapshot_restore"
+    | "upgrade" | "inspect" | "doctor";
+
+export interface LiteCliArgs {
+    action: LiteCliAction;
+    workdir?: string;
+    project_dir?: string;
+    state_dir?: string;
+    data_dir?: string;
+    storage_dir?: string;
+    storage_backend?: "fs" | "memory" | "s3";
+    s3_prefix?: string;
+    engine?: "pglite" | "native";
+    host?: string;
+    port?: number;
+    api_url?: string;
+    site_url?: string;
+    replication_profile?: "powersync";
+    replication_host?: string;
+    replication_port?: number;
+    replication_allow_cidrs?: string;
+    powersync_tables?: string;
+    replication_tls_cert?: string;
+    replication_tls_key?: string;
+    output?: string;
+    file?: string;
+    snapshot_file?: string;
+    service_role?: boolean;
+    force?: boolean;
+    memory?: boolean;
+    json?: boolean;
+}
+
+export interface LiteCliExecutionResult {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+}
+
+type LiteCliExecutor = (request: LiteCliArgs) => Promise<LiteCliExecutionResult>;
+
+export interface LiteCliToolOptions {
+    executeLiteCli?: LiteCliExecutor;
+    environment?: NodeJS.ProcessEnv;
+    currentWorkingDirectory?: string;
+}
+
+function requireWorkdir(workdir: string | undefined, fallback: string): string {
+    const resolved = resolve(workdir || fallback);
+    if (!existsSync(resolved) || !statSync(resolved).isDirectory()) {
+        throw new Error(`Lite workdir not found: ${resolved}`);
+    }
+    return resolved;
+}
+
+function optionalFlag(args: string[], flag: string, value: string | number | undefined): void {
+    if (value !== undefined) args.push(flag, String(value));
+}
+
+function booleanFlag(args: string[], flag: string, value: boolean | undefined): void {
+    if (value === true) args.push(flag);
+}
+
+export function buildLiteArgs(request: LiteCliArgs): string[] {
+    const args: string[] = [];
+    if (request.action === "version") return ["--version"];
+
+    switch (request.action) {
+        case "start": case "migrate": case "status": case "keys": case "upgrade": case "inspect": case "doctor":
+            args.push(request.action);
+            break;
+        case "gen_types": args.push("gen", "types"); break;
+        case "db_reset": args.push("db", "reset"); break;
+        case "db_diff": args.push("db", "diff"); break;
+        case "db_pull":
+            args.push("db", "pull");
+            if (request.file) args.push(request.file);
+            break;
+        case "snapshot_create": args.push("snapshot", "create"); break;
+        case "snapshot_restore":
+            if (!request.snapshot_file) throw new Error("snapshot_restore requires --snapshot_file");
+            args.push("snapshot", "restore", request.snapshot_file);
+            break;
+        default: throw new Error(`Unsupported Lite CLI action: ${String(request.action)}`);
+    }
+
+    optionalFlag(args, "--project-dir", request.project_dir);
+    optionalFlag(args, "--state-dir", request.state_dir);
+    optionalFlag(args, "--data-dir", request.data_dir);
+    optionalFlag(args, "--storage-dir", request.storage_dir);
+    optionalFlag(args, "--storage-backend", request.storage_backend);
+    optionalFlag(args, "--s3-prefix", request.s3_prefix);
+    optionalFlag(args, "--engine", request.engine);
+    optionalFlag(args, "--host", request.host);
+    optionalFlag(args, "--port", request.port);
+    optionalFlag(args, "--api-url", request.api_url);
+    optionalFlag(args, "--site-url", request.site_url);
+    optionalFlag(args, "--replication-profile", request.replication_profile);
+    optionalFlag(args, "--replication-host", request.replication_host);
+    optionalFlag(args, "--replication-port", request.replication_port);
+    optionalFlag(args, "--replication-allow-cidrs", request.replication_allow_cidrs);
+    optionalFlag(args, "--powersync-tables", request.powersync_tables);
+    optionalFlag(args, "--replication-tls-cert", request.replication_tls_cert);
+    optionalFlag(args, "--replication-tls-key", request.replication_tls_key);
+    optionalFlag(args, "--output", request.output);
+    optionalFlag(args, "--file", request.action === "db_diff" ? request.file : undefined);
+    booleanFlag(args, "--service-role", request.service_role);
+    booleanFlag(args, "--force", request.force);
+    booleanFlag(args, "--memory", request.memory);
+    booleanFlag(args, "--json", request.json);
+    return args;
+}
+
+export function resolveLiteCommand(workdir: string, environment: NodeJS.ProcessEnv = process.env): string[] {
+    const explicitBinary = environment.SUPACLOUD_LITE_CLI_BIN?.trim();
+    if (explicitBinary) {
+        if (explicitBinary.includes("\0")) throw new Error("Invalid SUPACLOUD_LITE_CLI_BIN");
+        return [explicitBinary];
+    }
+    const localPackageEntry = join(resolve(workdir), "node_modules", "@supacloud", "lite", "dist", "launcher.cjs");
+    if (existsSync(localPackageEntry)) return [process.execPath, localPackageEntry];
+    return ["supacloud-lite"];
+}
+
+function spawnLiteCommand(
+    command: string[],
+    workdir: string,
+    environment: NodeJS.ProcessEnv,
+    inheritOutput: boolean,
+): Promise<LiteCliExecutionResult> {
+    const [executable, ...commandArguments] = command;
+    return new Promise((resolveExecution, rejectExecution) => {
+        const child = spawn(executable, commandArguments, {
+            cwd: workdir, env: { ...environment, NO_COLOR: "1" }, shell: false,
+            stdio: inheritOutput ? ["inherit", "inherit", "inherit"] : ["ignore", "pipe", "pipe"],
+            windowsHide: true,
+        });
+        const forwardSignal = (signal: NodeJS.Signals) => child.kill(signal);
+        process.once("SIGINT", forwardSignal);
+        process.once("SIGTERM", forwardSignal);
+        const cleanup = () => {
+            process.off("SIGINT", forwardSignal);
+            process.off("SIGTERM", forwardSignal);
+        };
+        if (inheritOutput) {
+            child.once("error", (error) => {
+                cleanup();
+                rejectExecution(error);
+            });
+            child.once("close", (exitCode) => {
+                cleanup();
+                resolveExecution({ exitCode: exitCode ?? 1, stdout: "", stderr: "" });
+            });
+            return;
+        }
+        if (!child.stdout || !child.stderr) {
+            cleanup();
+            rejectExecution(new Error("Lite CLI child process did not expose piped output"));
+            return;
+        }
+        let standardOutput = "";
+        let standardError = "";
+        child.stdout.setEncoding("utf8");
+        child.stderr.setEncoding("utf8");
+        child.stdout.on("data", (chunk: string) => { standardOutput += chunk; });
+        child.stderr.on("data", (chunk: string) => { standardError += chunk; });
+        child.once("error", (error) => {
+            cleanup();
+            rejectExecution(error);
+        });
+        child.once("close", (exitCode) => {
+            cleanup();
+            resolveExecution({ exitCode: exitCode ?? 1, stdout: standardOutput, stderr: standardError });
+        });
+    });
+}
+
+async function executeLiteCli(
+    request: LiteCliArgs,
+    environment: NodeJS.ProcessEnv,
+    fallbackWorkdir: string,
+): Promise<LiteCliExecutionResult> {
+    const workdir = requireWorkdir(request.workdir, fallbackWorkdir);
+    const command = [...resolveLiteCommand(workdir, environment), ...buildLiteArgs({ ...request, workdir })];
+    try {
+        return await spawnLiteCommand(command, workdir, environment, request.action === "start");
+    } catch (error) {
+        const failureMessage = error instanceof Error ? error.message : String(error);
+        throw new Error([
+            "SupaCloud Lite CLI could not be started.",
+            "Install @supacloud/lite, put supacloud-lite on PATH, or set SUPACLOUD_LITE_CLI_BIN.",
+            failureMessage,
+        ].join(" "));
+    }
+}
+
+function formatExecutionText(action: LiteCliAction, execution: LiteCliExecutionResult): string {
+    const combinedOutput = [execution.stdout.trim(), execution.stderr.trim()].filter(Boolean).join("\n");
+    const heading = execution.exitCode === 0
+        ? `✅ SupaCloud Lite ${action} completed`
+        : `❌ SupaCloud Lite ${action} failed (exit ${execution.exitCode})`;
+    return combinedOutput ? `${heading}\n${combinedOutput}` : heading;
+}
+
+export function registerLiteCliTools(server: ToolServer, options: LiteCliToolOptions = {}): void {
+    const environment = options.environment || process.env;
+    const fallbackWorkdir = options.currentWorkingDirectory || process.cwd();
+    const execute = options.executeLiteCli || ((request) => executeLiteCli(request, environment, fallbackWorkdir));
+    server.tool(
+        "lite",
+        "Controlled adapter for the local SupaCloud Lite CLI. Lite actions are local-only and never use the Management API or official Supabase CLI.",
+        {
+            action: withDescription(stringEnum([
+                "version", "start", "migrate", "status", "keys", "gen_types", "db_reset", "db_diff", "db_pull",
+                "snapshot_create", "snapshot_restore", "upgrade", "inspect", "doctor",
+            ]), "Lite CLI action"),
+            workdir: optional(Type.String(), "[*] Process working directory (default: current directory)"),
+            project_dir: optional(Type.String(), "[*] Project containing supabase/"),
+            state_dir: optional(Type.String(), "[*] Lite state root"),
+            data_dir: optional(Type.String(), "[*] PGlite/native data directory"),
+            storage_dir: optional(Type.String(), "[*] Object storage directory"),
+            storage_backend: optional(stringEnum(["fs", "memory", "s3"]), "[*] Storage backend"),
+            s3_prefix: optional(Type.String(), "[*] S3 object key prefix"),
+            engine: optional(stringEnum(["pglite", "native"]), "[*] Database engine"),
+            host: optional(Type.String(), "[start] Listen host"),
+            port: optional(Type.Number(), "[start] Listen port"),
+            api_url: optional(Type.String(), "[start] Public API URL"),
+            site_url: optional(Type.String(), "[start] Auth site URL"),
+            replication_profile: optional(stringEnum(["powersync"]), "[start/doctor] Replication profile"),
+            replication_host: optional(Type.String(), "[start] Replication listener host"),
+            replication_port: optional(Type.Number(), "[start] Replication listener port"),
+            replication_allow_cidrs: optional(Type.String(), "[start] Replication client CIDRs"),
+            powersync_tables: optional(Type.String(), "[start] PowerSync publication tables"),
+            replication_tls_cert: optional(Type.String(), "[start] Replication TLS certificate"),
+            replication_tls_key: optional(Type.String(), "[start] Replication TLS private key"),
+            output: optional(Type.String(), "[gen_types/snapshot_create/upgrade] Output path"),
+            file: optional(Type.String(), "[db_diff/db_pull] Migration suffix or name"),
+            snapshot_file: optional(Type.String(), "[snapshot_restore] Snapshot archive"),
+            service_role: optional(Type.Boolean(), "[keys] Also print the service_role key"),
+            force: optional(Type.Boolean(), "[snapshot_restore] Replace non-empty restore targets"),
+            memory: optional(Type.Boolean(), "[*] Use an in-memory PGlite database"),
+            json: optional(Type.Boolean(), "[doctor] Emit machine-readable output"),
+        },
+        async (request: LiteCliArgs) => {
+            const execution = await execute(request);
+            return {
+                isError: execution.exitCode !== 0,
+                content: [{ type: "text" as const, text: formatExecutionText(request.action, execution) }],
+            };
+        },
+    );
+}

--- a/packages/cli/src/supabase-cli.integration.test.ts
+++ b/packages/cli/src/supabase-cli.integration.test.ts
@@ -43,6 +43,15 @@ async function runCli(args: string[], environment: Record<string, string> = {}) 
 }
 
 describe("supacloud-cli official Supabase CLI surface", () => {
+    test("exposes the local Lite action surface without project credentials", async () => {
+        const result = await runCli(["lite"]);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain("Available actions");
+        expect(result.stderr).toContain("snapshot_create");
+        expect(result.stderr).toContain("doctor");
+    });
+
     test("shows action help when the command group is invoked without an action", async () => {
         const result = await runCli(["supabase"]);
 


### PR DESCRIPTION
## Summary
- add `supacloud-cli lite` local adapter for SupaCloud Lite workflows
- keep Lite actions separate from official Supabase CLI and Management API
- add execution policy, tests, and documentation

## Verification
- `bun run typecheck`
- targeted CLI tests: 24 passed
- `git diff --check`