### PR TITLE
fix(management-api): release snapshot inspection locks

### DIFF
--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -402,6 +402,12 @@ jobs:
         # E2E Storage fixture that init.ts enables when CI variables are set.
         run: env -u CI -u GITHUB_ACTIONS bun src/db/init.ts
 
+      - name: Verify control-plane snapshot lock lifetime on PostgreSQL 18
+        working-directory: packages/management-api
+        env:
+          CONTROL_PLANE_SNAPSHOT_TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+        run: bun test tests/integration/control-plane-snapshot-lock.test.ts
+
       - name: Verify audit chain migration on PostgreSQL 18
         working-directory: packages/management-api
         env:

--- a/packages/management-api/src/control-plane-upgrade-safety.ts
+++ b/packages/management-api/src/control-plane-upgrade-safety.ts
@@ -104,10 +104,14 @@ type ControlPlaneSafetyOperations = {
     target: DatabaseTarget,
     inspection: ControlPlaneInspection,
   ) => Promise<ControlPlaneUpgradeSafetyEvidence>;
-  withInspection: <T>(
+  inspect: (
     databaseUrl: string,
     currentKey: string,
-    operation: (inspection: ControlPlaneInspection) => Promise<T>,
+    snapshotId: string,
+  ) => Promise<ControlPlaneInspection>;
+  withSnapshot: <T>(
+    databaseUrl: string,
+    operation: (snapshotId: string) => Promise<T>,
   ) => Promise<T>;
 };
 
@@ -241,6 +245,7 @@ async function inspectControlPlane(
   database: SQL,
   target: DatabaseTarget,
   currentKey: string,
+  snapshotId: string,
 ): Promise<ControlPlaneInspection> {
   const identity = await inspectControlPlaneDatabaseIdentity(database);
   const [controlPlane] = await database`
@@ -256,11 +261,6 @@ async function inspectControlPlane(
     throw new Error("DATABASE_URL resolves to a registered tenant database");
   }
   const projects = await projectCandidateCounts(database);
-  const [snapshot] = await database`SELECT pg_export_snapshot() AS snapshot_id`;
-  if (typeof snapshot?.snapshot_id !== "string") {
-    throw new Error("Control-plane database did not export a valid backup snapshot");
-  }
-  const snapshotId = parseExpectedControlPlaneDatabaseSnapshot(snapshot.snapshot_id);
   return {
     candidateCounts: {
       deprecated_webhook_secrets: await optionalTableCount(
@@ -280,17 +280,39 @@ async function inspectControlPlane(
   };
 }
 
-async function withControlPlaneInspection<T>(
+async function inspectControlPlaneSnapshot(
   databaseUrl: string,
   currentKey: string,
-  operation: (inspection: ControlPlaneInspection) => Promise<T>,
+  rawSnapshotId: string,
+): Promise<ControlPlaneInspection> {
+  const target = databaseTarget(databaseUrl);
+  const snapshotId = parseExpectedControlPlaneDatabaseSnapshot(rawSnapshotId);
+  const database = new SQL({ url: databaseUrl, database: target.database, max: 1 });
+  try {
+    return await database.begin(async (transaction) => {
+      await transaction.unsafe("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
+      await transaction.unsafe(`SET TRANSACTION SNAPSHOT '${snapshotId}'`);
+      return inspectControlPlane(transaction, target, currentKey, snapshotId);
+    });
+  } finally {
+    await database.close();
+  }
+}
+
+async function withControlPlaneSnapshot<T>(
+  databaseUrl: string,
+  operation: (snapshotId: string) => Promise<T>,
 ): Promise<T> {
   const target = databaseTarget(databaseUrl);
   const database = new SQL({ url: databaseUrl, database: target.database, max: 1 });
   try {
     return await database.begin(async (transaction) => {
       await transaction.unsafe("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
-      return operation(await inspectControlPlane(transaction, target, currentKey));
+      const [snapshot] = await transaction`SELECT pg_export_snapshot() AS snapshot_id`;
+      if (typeof snapshot?.snapshot_id !== "string") {
+        throw new Error("Control-plane database did not export a valid backup snapshot");
+      }
+      return operation(parseExpectedControlPlaneDatabaseSnapshot(snapshot.snapshot_id));
     });
   } finally {
     await database.close();
@@ -700,7 +722,8 @@ async function createControlPlaneBackup(
 function defaultSafetyOperations(): ControlPlaneSafetyOperations {
   return {
     backup: (target, inspection) => createControlPlaneBackup(target, inspection),
-    withInspection: withControlPlaneInspection,
+    inspect: inspectControlPlaneSnapshot,
+    withSnapshot: withControlPlaneSnapshot,
   };
 }
 
@@ -719,7 +742,11 @@ export async function withControlPlaneUpgradeSafety(
   operations: ControlPlaneSafetyOperations = defaultSafetyOperations(),
 ): Promise<ControlPlaneUpgradeSafetyEvidence> {
   const target = databaseTarget(databaseUrl);
-  return operations.withInspection(databaseUrl, currentKey, async (inspection) => {
+  return operations.withSnapshot(databaseUrl, async (snapshotId) => {
+    const inspection = await operations.inspect(databaseUrl, currentKey, snapshotId);
+    if (inspection.snapshotId !== snapshotId) {
+      throw new Error("Control-plane inspection did not use the exported backup snapshot");
+    }
     if (inspection.databaseTargetFingerprint !== databaseTargetFingerprint(target)) {
       throw new Error("Control-plane database identity changed before backup");
     }
@@ -739,7 +766,9 @@ export const controlPlaneUpgradeSafetyInternals = {
   databaseTarget,
   dumpArguments,
   inactiveBackupUnit,
+  inspectControlPlaneSnapshot,
   pgpassField,
   reconcileBackupUnit,
   verifyArguments,
+  withControlPlaneSnapshot,
 };

--- a/packages/management-api/tests/integration/control-plane-snapshot-lock.test.ts
+++ b/packages/management-api/tests/integration/control-plane-snapshot-lock.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { SQL } from "bun";
+import { controlPlaneUpgradeSafetyInternals } from "../../src/control-plane-upgrade-safety";
+
+const databaseUrl = process.env.CONTROL_PLANE_SNAPSHOT_TEST_DATABASE_URL;
+
+test.skipIf(!databaseUrl)(
+  "keeps an exported snapshot importable without retaining inspection locks during DDL",
+  async () => {
+    const writer = new SQL({ url: databaseUrl!, max: 1 });
+    const column = `snapshot_lock_probe_${randomUUID().replaceAll("-", "")}`;
+
+    try {
+      await controlPlaneUpgradeSafetyInternals.withControlPlaneSnapshot(databaseUrl!, async (snapshotId) => {
+        const inspection = await controlPlaneUpgradeSafetyInternals.inspectControlPlaneSnapshot(
+          databaseUrl!,
+          "k".repeat(32),
+          snapshotId,
+        );
+        expect(inspection.snapshotId).toBe(snapshotId);
+
+        await writer.begin(async (transaction) => {
+          await transaction.unsafe("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+          await transaction.unsafe(`SET TRANSACTION SNAPSHOT '${snapshotId}'`);
+          await transaction.unsafe("SET LOCAL lock_timeout = '1s'");
+          await transaction.unsafe(`ALTER TABLE public.project_secrets ADD COLUMN ${column} integer`);
+          const [added] = await transaction<{ present: boolean }[]>`
+            SELECT EXISTS (
+              SELECT 1
+              FROM information_schema.columns
+              WHERE table_schema = 'public'
+                AND table_name = 'project_secrets'
+                AND column_name = ${column}
+            ) AS present
+          `;
+          expect(added?.present).toBe(true);
+          await transaction.unsafe(`ALTER TABLE public.project_secrets DROP COLUMN ${column}`);
+        });
+      });
+    } finally {
+      await writer.close({ timeout: 1 });
+    }
+  },
+  10_000,
+);

--- a/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
+++ b/packages/management-api/tests/unit/control-plane-upgrade-safety.test.ts
@@ -427,24 +427,37 @@ describe("control-plane upgrade safety", () => {
     }
   });
 
-  test("holds the exported snapshot inspection open through backup", async () => {
+  test("closes inspection locks while retaining the exported snapshot through backup and migration", async () => {
     let inspectionOpen = false;
+    let snapshotOpen = false;
     await withControlPlaneUpgradeSafety(databaseUrl, "k".repeat(32), async (lease) => {
-      expect(inspectionOpen).toBe(true);
+      expect(inspectionOpen).toBe(false);
+      expect(snapshotOpen).toBe(true);
       expect(lease.snapshotId).toBe(inspection.snapshotId);
       expect(lease.databaseFingerprint).toBe(inspection.databaseFingerprint);
       expect(lease.evidence).not.toHaveProperty("database_fingerprint");
     }, {
-      withInspection: async (_databaseUrl, _currentKey, operation) => {
+      withSnapshot: async (_databaseUrl, operation) => {
+        snapshotOpen = true;
+        try {
+          return await operation(inspection.snapshotId);
+        } finally {
+          snapshotOpen = false;
+        }
+      },
+      inspect: async (_databaseUrl, _currentKey, snapshotId) => {
+        expect(snapshotOpen).toBe(true);
+        expect(snapshotId).toBe(inspection.snapshotId);
         inspectionOpen = true;
         try {
-          return await operation(inspection);
+          return inspection;
         } finally {
           inspectionOpen = false;
         }
       },
       backup: async (_target, inspected) => {
-        expect(inspectionOpen).toBe(true);
+        expect(inspectionOpen).toBe(false);
+        expect(snapshotOpen).toBe(true);
         expect(inspected.snapshotId).toBe(inspection.snapshotId);
         return {
           schema: "supacloud.control-plane-upgrade-safety.v1",
@@ -459,16 +472,29 @@ describe("control-plane upgrade safety", () => {
       },
     });
     expect(inspectionOpen).toBe(false);
+    expect(snapshotOpen).toBe(false);
   });
 
   test("fails closed when inspection and backup resolve different database identities", async () => {
     await expect(prepareControlPlaneUpgradeSafety(databaseUrl, "k".repeat(32), {
-      withInspection: async (_databaseUrl, _currentKey, operation) => operation({
+      withSnapshot: async (_databaseUrl, operation) => operation(inspection.snapshotId),
+      inspect: async () => ({
         ...inspection,
         databaseTargetFingerprint: "0".repeat(64),
       }),
       backup: async () => { throw new Error("backup must not run"); },
     })).rejects.toThrow("database identity changed");
+  });
+
+  test("fails closed when inspection did not import the exported snapshot", async () => {
+    await expect(prepareControlPlaneUpgradeSafety(databaseUrl, "k".repeat(32), {
+      withSnapshot: async (_databaseUrl, operation) => operation(inspection.snapshotId),
+      inspect: async () => ({
+        ...inspection,
+        snapshotId: "00000003-0000001B-2",
+      }),
+      backup: async () => { throw new Error("backup must not run"); },
+    })).rejects.toThrow("did not use the exported backup snapshot");
   });
 
   test("rejects incomplete or non-PostgreSQL database targets", () => {


### PR DESCRIPTION
## Summary
- keep the exported PostgreSQL snapshot alive in a dedicated transaction
- run control-plane identity and candidate inspection in a separate imported read-only transaction that closes before backup and staged DDL
- add a PostgreSQL 18 regression proving a snapshot-importing writer can acquire the `project_secrets` DDL lock while the exporter remains open

## Verification
- `bun run sql:check`
- `bun run typecheck`
- `bun run test:unit`
- `CONTROL_PLANE_SNAPSHOT_TEST_DATABASE_URL=... bun test tests/integration/control-plane-snapshot-lock.test.ts` on PostgreSQL 18
- `bun run build:amd64`
- `git diff --check`
- independent platform review: PASS
- independent security review: PASS

## Production note
Management `0.65.0` must not be retried on production because its long-lived inspection transaction deterministically self-blocks staged `--init-db` DDL. Publish and deploy the corrected official release only.