### PR TITLE
fix(management-api): serialize Caddy vars matchers

### DIFF
--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -547,7 +547,7 @@ export function makeCustomGatewayRoute(projectRef: string, input: CustomGatewayR
     };
     if (route.protocol) {
         match.vars = {
-            "{http.request.scheme}": route.protocol,
+            "{http.request.scheme}": [route.protocol],
         };
     }
 

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -720,9 +720,11 @@ export class CaddyGatewayProvider implements GatewayProvider {
         const bPath = Array.isArray((b.match as any)?.[0]?.path) ? String((b.match as any)[0].path[0] || "") : "";
         if (aPath.length !== bPath.length) return bPath.length - aPath.length;
 
-        const aProtocol = typeof (a.match as any)?.[0]?.vars?.["{http.request.scheme}"] === "string"
+        const aProtocolMatcher = (a.match as any)?.[0]?.vars?.["{http.request.scheme}"];
+        const bProtocolMatcher = (b.match as any)?.[0]?.vars?.["{http.request.scheme}"];
+        const aProtocol = typeof aProtocolMatcher === "string" || Array.isArray(aProtocolMatcher)
             || typeof (a.match as any)?.[0]?.protocol === "string";
-        const bProtocol = typeof (b.match as any)?.[0]?.vars?.["{http.request.scheme}"] === "string"
+        const bProtocol = typeof bProtocolMatcher === "string" || Array.isArray(bProtocolMatcher)
             || typeof (b.match as any)?.[0]?.protocol === "string";
         if (aProtocol !== bProtocol) return aProtocol ? -1 : 1;
         return aid.localeCompare(bid);

--- a/packages/management-api/tests/unit/gateway-route-builders.test.ts
+++ b/packages/management-api/tests/unit/gateway-route-builders.test.ts
@@ -231,7 +231,7 @@ describe("gateway route builders", () => {
         } as any)).toThrow("managed_upstream must be edge-functions");
     });
 
-    test("renders a protocol-scoped permanent redirect and preserves the request URI", () => {
+    test("renders a Caddy-compatible protocol-scoped redirect and preserves the request URI", () => {
         const normalized = normalizeCustomGatewayRoute({
             id: "canonical-https",
             hosts: ["WWW.EXAMPLE.COM"],
@@ -247,7 +247,7 @@ describe("gateway route builders", () => {
             host: ["www.example.com"],
             path: ["/*"],
             vars: {
-                "{http.request.scheme}": "http",
+                "{http.request.scheme}": ["http"],
             },
         }]);
         expect(route.handle).toEqual([{

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -628,7 +628,7 @@ describe("CaddyGatewayProvider", () => {
             host: ["studio.example.com"],
             path: ["/*"],
             vars: {
-                "{http.request.scheme}": "http",
+                "{http.request.scheme}": ["http"],
             },
         });
         expect(redirect?.handle?.[0]).toMatchObject({


### PR DESCRIPTION
## Summary
- serialize protocol-scoped Caddy vars matcher values as string arrays required by Caddy 2.11.4
- preserve route precedence for both new arrays and hydrated legacy scalar matchers
- update exact gateway JSON regressions

## Production evidence
- official transaction `3b04b6d5-0103-4d0c-919c-db57d3143467` failed during `runner_upgrade` because Caddy rejected the scalar matcher, then automatically restored Management 0.61.9 / Edge 0.18.3 / Web 0.34.2
- exact target Caddy 2.11.4 rejects the old scalar shape and validates the new array shape

## Verification
- `bun test packages/management-api/tests/unit/gateway-route-builders.test.ts packages/management-api/tests/unit/gateway.service.test.ts` (90 pass)
- `bun run --cwd packages/management-api test:unit`
- `bun run --cwd packages/management-api test:integration` (39 pass)
- `bun run --cwd packages/management-api typecheck`
- `bun run --cwd packages/management-api sql:check`
- `bun run --cwd packages/management-api build:amd64`
- `git diff --check`
- independent platform/release and security/runtime reviews: PASS

## Scope
No migration, tenant data, Edge Runtime, Web Console, Caddy binary, or upgrade rollback changes.