### PR TITLE
docs(release-control): mark atomic manifests as proposed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@
 - [Deploy API](./deploy-api.md) - Deployment API documentation
 - [CI/CD Integration](./ci-cd-integration.md) - CI/CD integration with GitHub webhooks
 - [Frontend Hosting](./frontend-hosting.md) - SupaCloud Pages static site hosting
-- [Release Control Automation & Canary Spec](./release-control-automation-spec.md) - Automated headless PKCE canary, batch function releases, and CAS rollback primitives
+- [Release Control Automation & Canary Spec](./release-control-automation-spec.md) - Proposed contracts for headless PKCE canary, batch function releases, and CAS rollback primitives
 
 ## Authentication
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -332,6 +332,13 @@ Version `0` is reserved for a listed legacy Function's active-version CAS token.
 The public CLI and Management API accept it only as the expected active version;
 immutable source reads and activation targets still require positive versions.
 
+Multi-Function atomic deployment is not currently available. Release runners
+must deploy each Function with its observed version and activation identity,
+stop on `OUTCOME_UNKNOWN`, and reconcile with `edge_functions list` plus an
+immutable `source --version <N>` read before retrying or applying reverse-order
+CAS compensation. The `edge_functions deploy_manifest --atomic` interface in
+the release-control automation specification is a proposed contract.
+
 The readback contract stays simple for automation: `edge_functions list`
 prints a JSON array whose entries have a string `slug` and a non-negative safe
 integer numeric `version`; `edge_functions source` prints exactly

--- a/docs/release-control-automation-spec.md
+++ b/docs/release-control-automation-spec.md
@@ -1,5 +1,11 @@
 # Release Control Automation and Headless Canary Specification
 
+> **Status: Proposed architecture.** Command and API examples in this document
+> describe target contracts, not necessarily released interfaces. Use the
+> [CLI guide](./cli-guide.md) as the source of truth for currently supported
+> commands. In particular, `edge_functions deploy_manifest --atomic` is not
+> implemented in the current main release.
+
 This specification defines platform-level mechanisms for automated application deployment, headless canary verification, batch function activations, and zero-downtime rollbacks across SupaCloud project instances.
 
 ## Background & Motivation
@@ -68,9 +74,12 @@ supacloud-cli auth canary-probe \
 
 ---
 
-## 2. Atomic Release Manifest & Multi-Function Batch Activation
+## 2. Proposed Atomic Release Manifest & Multi-Function Batch Activation
 
-Enables applications with multiple Edge Functions to deploy, activate, and roll back atomically as a single release unit.
+The target design enables applications with multiple Edge Functions to deploy,
+activate, and roll back atomically as a single release unit. The CLI and
+Management API do not currently implement this batch contract; do not emulate
+atomicity with an untracked sequence of single-Function mutations.
 
 ### Release Manifest Schema (`deploy-manifest.json`)
 
@@ -90,7 +99,7 @@ Enables applications with multiple Edge Functions to deploy, activate, and roll 
 }
 ```
 
-### Batch Deployment Command
+### Proposed Batch Deployment Command
 
 ```bash
 supacloud-cli edge_functions deploy_manifest \
@@ -111,7 +120,6 @@ supacloud-cli edge_functions deploy_manifest \
 supacloud-cli edge_functions delete \
   --ref "$PROJECT_REF" \
   --slug "legacy-function" \
-  --expected-active-version "1.2.0" \
   --expected-activation-id "22222222-2222-4222-8222-222222222222"
 ```
 
@@ -187,13 +195,13 @@ supacloud-cli frontend activate_release \
 
 ---
 
-## Benefits & Impact
+## Target Benefits & Impact
 
-| Capability | Previous Client Workaround | Native SupaCloud Primitive |
+| Capability | Current Client Workaround | Target SupaCloud Primitive |
 | :--- | :--- | :--- |
 | **PKCE Auth Canary** | Local loopback HTTP listener + browser consent | Native headless `auth canary-probe` API/CLI |
-| **Multi-Function Deploy** | Sequential CLI calls + client reverse rollback loop | `edge_functions deploy_manifest --atomic` |
-| **Function Cleanup** | Manual dashboard deletion (no CLI CAS delete) | `edge_functions delete --expected-version ...` |
+| **Multi-Function Deploy** | Sequential CAS calls + authoritative readback + client reverse rollback | Proposed `edge_functions deploy_manifest --atomic` |
+| **Function Cleanup** | Manual dashboard deletion (no CLI CAS delete) | `edge_functions delete --expected-activation-id ...` |
 | **Secrets Update** | Blind upsert without mutation receipt | CAS-checked `secrets upsert` with revision receipt |
 | **Schema Reload** | Manual `postgrest_restart` + client table polling | Native reload notification & status confirmation |
 | **Frontend Rollback** | Client re-compilation and re-upload of old zip | Instant immutable release activation by SHA-256 with CAS |

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1260,7 +1260,7 @@ describe("supacloud-cli process contract", () => {
         }
     });
 
-    test("documents get_config as the atomic Function identity read", async () => {
+    test("documents current single-Function release controls", async () => {
         const response = await runProjectCli(["edge_functions", "--help"], {
             SUPACLOUD_API_URL: "http://127.0.0.1:1",
             SUPACLOUD_API_TOKEN: "test-token",
@@ -1269,6 +1269,18 @@ describe("supacloud-cli process contract", () => {
 
         expect(response.exitCode).toBe(0);
         expect(response.stderr).toContain("get_config");
+        expect(response.stderr).not.toContain("deploy_manifest");
+    });
+
+    test("marks the atomic Function manifest as a proposed contract", () => {
+        const spec = readFileSync(
+            join(PACKAGE_ROOT, "../../docs/release-control-automation-spec.md"),
+            "utf8",
+        );
+
+        expect(spec).toContain("> **Status: Proposed architecture.");
+        expect(spec).toContain("`edge_functions deploy_manifest --atomic` is not");
+        expect(spec).toContain("Proposed `edge_functions deploy_manifest --atomic`");
     });
 
     test("reads an allowlisted tombstone identity through get_config", async () => {


### PR DESCRIPTION
## Summary

- mark the release-control automation document as a proposed architecture
- clarify that `edge_functions deploy_manifest --atomic` is not implemented
- document the current per-Function CAS, authoritative readback, and reverse compensation workflow
- add a CLI contract test that keeps the proposed action out of current command help

## Motivation

The architecture specification currently presents the atomic multi-Function interface alongside released primitives. Current CLI and Management API implementations only provide single-Function CAS mutations. This can cause release automation for large projects to assume an atomic boundary that does not exist.

This PR corrects documentation truth without implementing a sequential loop that would falsely claim atomicity. A future implementation should define durable cross-Function mutation identity, request fingerprinting, authoritative status readback, crash recovery, and rollback semantics first.

## Verification

- `cd packages/cli && bun test src/index.test.ts` (142 pass)
- `cd packages/cli && bun run typecheck`
- `cd packages/cli && bun run build`
- `git diff --check`