### PR TITLE
fix(edge-runtime): make recycle budget configurable

### DIFF
--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -3,6 +3,7 @@ import { Elysia } from "elysia";
 import cors from "@elysiajs/cors";
 import {
   WorkerPool,
+  resolveWorkerReplacementBudget,
   type WorkerPoolPreheatResult,
   type WorkerPoolVersionPreheatResult,
 } from "./worker-pool";
@@ -81,6 +82,12 @@ const MGMT_API = process.env.MANAGEMENT_API_URL || "http://127.0.0.1:9090";
 const FUNCTION_REQUEST_TIMEOUT_MS = Number(process.env.EDGE_FUNCTION_TIMEOUT_MS) || 60_000;
 const BACKGROUND_FUNCTION_TIMEOUT_MS = Number(process.env.EDGE_BACKGROUND_FUNCTION_TIMEOUT_MS) || 300_000;
 const WORKER_RECYCLE_RESPONSE_GRACE_MS = 100;
+const WORKER_REPLACEMENT_BUDGET = resolveWorkerReplacementBudget(
+  process.env.EDGE_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE,
+);
+const WORKER_REPLACEMENT_BUDGET_OPTIONS = WORKER_REPLACEMENT_BUDGET === undefined
+  ? {}
+  : { maxWorkerReplacementsBeforeRecycle: WORKER_REPLACEMENT_BUDGET };
 const INTERNAL_TOKEN = process.env.EDGE_RUNTIME_MASTER_KEY || process.env.MASTER_TOKEN || "";
 const RUNTIME_INSTANCE_ID = process.env.EDGE_RUNTIME_INSTANCE_ID?.trim() || crypto.randomUUID();
 const PROJECT_REF_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
@@ -317,6 +324,7 @@ const pool = new WorkerPool({
   size: POOL_SIZE,
   requestTimeout: FUNCTION_REQUEST_TIMEOUT_MS,
   smol: FOREGROUND_WORKER_SMOL,
+  ...WORKER_REPLACEMENT_BUDGET_OPTIONS,
   onWorkerRecycleRequired: requestRuntimeRecycle,
 });
 
@@ -324,6 +332,7 @@ const backgroundPool = new WorkerPool({
   size: BACKGROUND_POOL_SIZE,
   requestTimeout: BACKGROUND_FUNCTION_TIMEOUT_MS,
   smol: BACKGROUND_WORKER_SMOL,
+  ...WORKER_REPLACEMENT_BUDGET_OPTIONS,
   onWorkerRecycleRequired: requestRuntimeRecycle,
 });
 

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
-import { WorkerPool } from "./worker-pool";
+import { resolveWorkerReplacementBudget, WorkerPool } from "./worker-pool";
 import {
   EDGE_RUNTIME_PREHEAT_ATTESTATION_SCHEMA,
   type EdgeRuntimePreheatIdentity,
@@ -2766,6 +2766,17 @@ describe("WorkerPool Bun plugin project isolation", () => {
 });
 
 describe("WorkerPool module cache", () => {
+  test("parses only explicit safe worker replacement budget overrides", () => {
+    expect(resolveWorkerReplacementBudget(undefined)).toBeUndefined();
+    expect(resolveWorkerReplacementBudget("")).toBeUndefined();
+    expect(resolveWorkerReplacementBudget("256")).toBe(256);
+    for (const invalidBudget of ["0", "-1", "1.5", " 256", "256 ", "1e3", "9007199254740992"]) {
+      expect(() => resolveWorkerReplacementBudget(invalidBudget)).toThrow(
+        "EDGE_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE",
+      );
+    }
+  });
+
   function moduleLoadCounterSource(counterPath: string): string {
     return `
       const counterPath = ${JSON.stringify(counterPath)};

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -68,6 +68,19 @@ const DEFAULT_MAX_RETIREMENT_AGE_MS = 60_000;
 const DEFAULT_PREHEAT_TIMEOUT_MS = 10_000;
 // Bun/JSC retains fixed host memory after Worker exit, so bound churn before recycling the process.
 const DEFAULT_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE = 128;
+const MAX_WORKER_REPLACEMENTS_ENV = "EDGE_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE";
+
+export function resolveWorkerReplacementBudget(rawBudget?: string): number | undefined {
+  if (rawBudget === undefined || rawBudget === "") return undefined;
+  if (!/^[1-9]\d*$/.test(rawBudget)) {
+    throw new Error(`${MAX_WORKER_REPLACEMENTS_ENV} must be a positive integer`);
+  }
+  const parsedBudget = Number(rawBudget);
+  if (!Number.isSafeInteger(parsedBudget)) {
+    throw new Error(`${MAX_WORKER_REPLACEMENTS_ENV} must be a safe integer`);
+  }
+  return parsedBudget;
+}
 
 function cancelledResponse(): Response {
   return new Response(JSON.stringify({ error: "Task cancelled" }), {


### PR DESCRIPTION
## Root cause

A production Function activation rotates both 20-worker pools. Seven versioned activations reached the fixed 128 replacement budget and restarted `supacloud-edge-runtime`, causing a transient FA 503.

## Change

- Add strict `EDGE_MAX_WORKER_REPLACEMENTS_BEFORE_RECYCLE` parsing.
- Preserve the existing 128 default if the variable is absent.
- Apply one validated override consistently to foreground and background pools.
- Reject zero, signed, decimal, whitespace-padded, scientific notation, and unsafe-integer inputs.

## Verification

- `bun test worker-pool.test.ts worker-retirement-stress.test.ts` (80 pass, 6 platform skips, 0 fail)
- `bun run typecheck`
- `bun run build:amd64`
- `git diff --check`

CNB CI was not used.