### PR TITLE
feat(database): add governance linter and RPC catalog

### DIFF
--- a/docker/self-host/postgres/Dockerfile
+++ b/docker/self-host/postgres/Dockerfile
@@ -29,6 +29,8 @@ RUN set -eux; \
       postgresql-18-pg-stat-kcache \
       postgresql-18-pg-plan-filter \
       postgresql-18-pgmq \
+      postgresql-18-plpgsql-check \
+      postgresql-18-pgtap \
       postgresql-18-supautils \
       postgresql-18-vault \
       postgresql-18-wal2json \

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -17,7 +17,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         local: ["list"],
     },
     database: {
-        read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "migration_inventory", "project_url", "generate_types"],
+        read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "migration_inventory", "project_url", "generate_types", "database_lint", "db_lint", "rpc_catalog", "list_rpcs"],
         local: ["lint_migrations", "lint"],
         write: ["query", "apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"],
     },

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -1937,4 +1937,131 @@ describe("database migration helpers", () => {
       file: "migration.sql",
     })).rejects.toThrow("Use only one of --sql, --file, or --dir");
   });
+
+  test("database_lint action formats issues and supports strict mode and json mode", async () => {
+    const lintPayload = {
+      schema: "public",
+      total_issues: 2,
+      danger_count: 1,
+      warning_count: 1,
+      info_count: 0,
+      issues: [
+        {
+          type: "security_definer_no_search_path",
+          severity: "danger",
+          category: "security",
+          schema_name: "public",
+          object_name: "approve_order",
+          detail: "Function public.approve_order() is SECURITY DEFINER with no search_path",
+          recommendation: "Set search_path = pg_catalog",
+          fix_sql: "ALTER FUNCTION public.approve_order() SET search_path = pg_catalog;",
+        },
+        {
+          type: "no_rls",
+          severity: "warning",
+          category: "security",
+          schema_name: "public",
+          object_name: "orders",
+          detail: "RLS disabled on public.orders",
+          recommendation: "Enable RLS",
+          fix_sql: "ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;",
+        },
+      ],
+    };
+
+    const callback = captureDatabaseTool({
+      get: async (path: string) => {
+        expect(path).toBe("/v1/projects/proj/database/linter?schema=public");
+        return { ok: true, status: 200, data: lintPayload };
+      },
+    });
+
+    const result = await callback({ action: "database_lint", ref: "proj" });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain("Database Lint (public): 2 issue(s) detected [1 Danger, 1 Warning, 0 Info]");
+    expect(result.content[0].text).toContain("approve_order");
+    expect(result.content[0].text).toContain("ALTER FUNCTION public.approve_order() SET search_path = pg_catalog;");
+
+    const jsonResult = await callback({ action: "db_lint", ref: "proj", json: true });
+    expect(JSON.parse(jsonResult.content[0].text).total_issues).toBe(2);
+
+    const strictResult = await callback({ action: "database_lint", ref: "proj", strict: true });
+    expect(strictResult.isError).toBe(true);
+  });
+
+  test("rpc_catalog action formats RPC catalog and outputs json", async () => {
+    const catalogPayload = {
+      schemas: ["public", "api"],
+      total_rpcs: 2,
+      commands: 1,
+      queries: 1,
+      internal: 0,
+      rpcs: [
+        {
+          schema_name: "public",
+          function_name: "approve_case",
+          identity_args: "p_id uuid",
+          arguments_display: "p_id uuid",
+          return_type: "json",
+          volatility: "VOLATILE",
+          security: "DEFINER",
+          search_path: "pg_catalog",
+          inferred_kind: "command",
+          smart_tags: { domain: "approval", api: "command" },
+        },
+        {
+          schema_name: "public",
+          function_name: "get_case",
+          identity_args: "p_id uuid",
+          arguments_display: "p_id uuid",
+          return_type: "json",
+          volatility: "STABLE",
+          security: "INVOKER",
+          search_path: null,
+          inferred_kind: "query",
+          smart_tags: {},
+        },
+      ],
+    };
+
+    const callback = captureDatabaseTool({
+      get: async (path: string) => {
+        expect(path).toBe("/v1/projects/proj/database/rpc-catalog?schemas=public%2Capi");
+        return { ok: true, status: 200, data: catalogPayload };
+      },
+    });
+
+    const result = await callback({ action: "rpc_catalog", ref: "proj", schemas: ["public", "api"] });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain("RPC Catalog (2 total: 1 commands, 1 queries, 0 internal)");
+    expect(result.content[0].text).toContain("approve_case");
+    expect(result.content[0].text).toContain("⚡ [COMMAND]");
+    expect(result.content[0].text).toContain("🔍 [QUERY]");
+
+    const jsonResult = await callback({ action: "list_rpcs", ref: "proj", json: true });
+    expect(JSON.parse(jsonResult.content[0].text).total_rpcs).toBe(2);
+  });
+
+  test("database governance reads reject unsafe refs and do not reflect failed response bodies", async () => {
+    let requests = 0;
+    const callback = captureDatabaseTool({
+      get: async () => {
+        requests += 1;
+        return { ok: false, status: 500, data: { detail: "postgresql://secret" } };
+      },
+    });
+
+    await expect(callback({ action: "database_lint", ref: "../other" })).rejects.toThrow();
+    expect(requests).toBe(0);
+
+    const lintFailure = await callback({ action: "database_lint", ref: "proj" });
+    expect(lintFailure.isError).toBe(true);
+    expect(lintFailure.content[0].text).toBe("❌ Database lint request failed (500)");
+    expect(lintFailure.content[0].text).not.toContain("secret");
+
+    const catalogFailure = await callback({ action: "rpc_catalog", ref: "proj" });
+    expect(catalogFailure.isError).toBe(true);
+    expect(catalogFailure.content[0].text).toBe("❌ RPC catalog request failed (500)");
+    expect(catalogFailure.content[0].text).not.toContain("secret");
+  });
 });

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -514,6 +514,7 @@ export function registerDatabaseTools(
         "list_auth_users", "get_auth_user",
         "connections", "stats", "slow_queries",
         "list_migrations", "migration_inventory", "project_url", "generate_types",
+        "database_lint", "db_lint", "rpc_catalog", "list_rpcs",
     ] as const;
     const writeActions = ["apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"] as const;
     const remoteActions = [...readActions, ...localActions] as const;
@@ -535,14 +536,14 @@ Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ?
             file: optional(Type.String(), "[query/apply_migration/lint_migrations/lint] Read SQL from local file path (avoids shell escaping issues with $$ and multi-statement DDL)"),
             dir: optional(Type.String(), "[push_migrations/baseline_migrations/lint_migrations/lint] Directory containing .sql migration files (default: supabase/migrations)"),
             dry_run: optional(Type.Boolean(), "[push_migrations/baseline_migrations] Preview changes without applying them"),
-            strict: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint] Exit with error if high-risk destructive migrations are detected"),
-            fail_on_high: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint] Alias for --strict"),
+            strict: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint/database_lint] Exit with error if high-risk issues or migrations are detected"),
+            fail_on_high: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint/database_lint] Alias for --strict"),
             fail_on_medium: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint] Exit with error if medium-risk or high-risk migrations are detected"),
-            json: optional(Type.Boolean(), "[lint_migrations/lint] Output structured JSON analysis"),
+            json: optional(Type.Boolean(), "[lint_migrations/lint/database_lint/rpc_catalog] Output structured JSON analysis"),
             // schema
-            schema: optional(Type.String(), "[describe_columns/list_indexes/list_constraints/rls_status/rls_policies/create_table_rls] Schema name (default: public)"),
+            schema: optional(Type.String(), "[describe_columns/list_indexes/list_constraints/rls_status/rls_policies/create_table_rls/database_lint] Schema name (default: public)"),
             table: optional(Type.String(), "[describe_columns/indexes/constraints/rls_*] Table name"),
-            schemas: optional(Type.Array(Type.String()), "[list_tables/generate_types] Schemas array"),
+            schemas: optional(Type.Array(Type.String()), "[list_tables/generate_types/rpc_catalog] Schemas array"),
             // auth users
             user_id: optional(Type.String(), "[get_auth_user] User UUID"),
             limit: optional(Type.Number(), "[list_auth_users] Max users (default: 20)"),
@@ -1002,6 +1003,41 @@ Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ?
                     text = `✅ Table '${schema}.${args.table}' created with RLS (${policyMode === "owner" ? "auth.uid() owner policy" : "deny-all by default"})`;
                     break;
                 }
+                case "database_lint":
+                case "db_lint": {
+                    const targetSchema = args.schema || "public";
+                    const safeRef = projectRefPathSegment(ref, "database_lint");
+                    const r = await managementHttp().get(`/v1/projects/${safeRef}/database/linter?schema=${encodeURIComponent(targetSchema)}`);
+                    if (!r.ok) {
+                        return { content: [{ type: "text" as const, text: `❌ Database lint request failed (${r.status})` }], isError: true };
+                    }
+                    if (args.json) {
+                        text = JSON.stringify(r.data, null, 2);
+                    } else {
+                        text = formatDatabaseLintReport(r.data);
+                    }
+                    const strict = args.strict === true || args.fail_on_high === true;
+                    const dangerCount = (r.data as any)?.danger_count || 0;
+                    if (strict && dangerCount > 0) {
+                        return { content: [{ type: "text" as const, text }], isError: true };
+                    }
+                    break;
+                }
+                case "rpc_catalog":
+                case "list_rpcs": {
+                    const schemasList = args.schemas && args.schemas.length > 0 ? args.schemas : (args.schema ? [args.schema] : ["public", "api"]);
+                    const safeRef = projectRefPathSegment(ref, "rpc_catalog");
+                    const r = await managementHttp().get(`/v1/projects/${safeRef}/database/rpc-catalog?schemas=${encodeURIComponent(schemasList.join(","))}`);
+                    if (!r.ok) {
+                        return { content: [{ type: "text" as const, text: `❌ RPC catalog request failed (${r.status})` }], isError: true };
+                    }
+                    if (args.json) {
+                        text = JSON.stringify(r.data, null, 2);
+                    } else {
+                        text = formatRpcCatalog(r.data);
+                    }
+                    break;
+                }
                 default: text = `❌ Unknown action: ${action}`;
             }
             return { content: [{ type: "text" as const, text }] };
@@ -1057,6 +1093,93 @@ function buildRlsPolicySql(
 }
 
 // ── Format Helpers ──
+function formatDatabaseLintReport(data: unknown): string {
+    if (!data || typeof data !== "object") return JSON.stringify(data, null, 2);
+    const d = data as {
+        schema?: string;
+        total_issues?: number;
+        danger_count?: number;
+        warning_count?: number;
+        info_count?: number;
+        issues?: Array<{
+            type: string;
+            severity: string;
+            category: string;
+            schema_name: string;
+            object_name: string;
+            detail: string;
+            recommendation: string;
+            fix_sql: string;
+        }>;
+    };
+
+    if (!d.issues || d.issues.length === 0) {
+        return "✅ Database Lint: No issues found! Schema follows best practices for RLS, primary keys, and function security.";
+    }
+
+    const lines: string[] = [];
+    const icon = (d.danger_count || 0) > 0 ? "🔴" : (d.warning_count || 0) > 0 ? "🟡" : "ℹ️";
+    lines.push(`${icon} Database Lint (${d.schema || "public"}): ${d.total_issues} issue(s) detected [${d.danger_count || 0} Danger, ${d.warning_count || 0} Warning, ${d.info_count || 0} Info]`);
+    lines.push("");
+
+    for (const issue of d.issues) {
+        const itemIcon = issue.severity === "danger" ? "🔴" : issue.severity === "warning" ? "🟡" : "ℹ️";
+        lines.push(`  ${itemIcon} [${issue.severity.toUpperCase()}] ${issue.schema_name}.${issue.object_name} (${issue.type})`);
+        lines.push(`     Detail: ${issue.detail}`);
+        lines.push(`     Recommendation: ${issue.recommendation}`);
+        if (issue.fix_sql) {
+            lines.push(`     Fix SQL: ${issue.fix_sql}`);
+        }
+        lines.push("");
+    }
+
+    return lines.join("\n").trimEnd();
+}
+
+function formatRpcCatalog(data: unknown): string {
+    if (!data || typeof data !== "object") return JSON.stringify(data, null, 2);
+    const d = data as {
+        schemas?: string[];
+        total_rpcs?: number;
+        commands?: number;
+        queries?: number;
+        internal?: number;
+        rpcs?: Array<{
+            schema_name: string;
+            function_name: string;
+            identity_args: string;
+            arguments_display: string;
+            return_type: string;
+            volatility: string;
+            security: string;
+            search_path: string | null;
+            inferred_kind: string;
+            smart_tags: Record<string, unknown>;
+        }>;
+    };
+
+    if (!d.rpcs || d.rpcs.length === 0) {
+        return `No RPC functions found in schema(s): ${(d.schemas || []).join(", ")}`;
+    }
+
+    const lines: string[] = [];
+    lines.push(`📋 RPC Catalog (${d.total_rpcs || d.rpcs.length} total: ${d.commands || 0} commands, ${d.queries || 0} queries, ${d.internal || 0} internal)`);
+    lines.push("");
+
+    for (const rpc of d.rpcs) {
+        const kindBadge = rpc.inferred_kind === "command" ? "⚡ [COMMAND]" : rpc.inferred_kind === "query" ? "🔍 [QUERY]" : "🔒 [INTERNAL]";
+        const secBadge = rpc.security === "DEFINER" ? "🛡️ DEFINER" : "👤 INVOKER";
+        lines.push(`  ${kindBadge} ${rpc.schema_name}.${rpc.function_name}(${rpc.identity_args}) -> ${rpc.return_type}`);
+        lines.push(`     Security: ${secBadge} | Volatility: ${rpc.volatility}${rpc.search_path ? ` | search_path: ${rpc.search_path}` : ""}`);
+        const tagEntries = Object.entries(rpc.smart_tags || {});
+        if (tagEntries.length > 0) {
+            lines.push(`     Tags: ${tagEntries.map(([k, v]) => `@${k}${v === true ? "" : ` ${v}`}`).join(", ")}`);
+        }
+    }
+
+    return lines.join("\n");
+}
+
 function formatSqlResult(data: unknown): string {
     if (!data || typeof data !== "object") return JSON.stringify(data, null, 2);
     const r = data as { rows?: unknown[]; rowCount?: number };

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -34,6 +34,9 @@ import {
   tryNotifyPostgrestSchemaReload,
 } from "../services/database-schema-notify";
 import { logger } from "../utils/logger";
+import { normalizeDatabaseSchema, normalizeRpcSchemas } from "../services/database-governance-input";
+import { runDatabaseLinter } from "../services/database-linter.service";
+import { readRpcCatalog } from "../services/database-rpc-catalog.service";
 
 export type MigrationBody =
   | { query: string; version?: number | string }
@@ -2188,4 +2191,110 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
             }
         },
         { params: t.Object({ ref: t.String({ minLength: 1 }) }), detail: { tags: ["projects"], summary: "List database publications" } }
+    )
+    .get(
+        "/linter",
+        async ({ params, query, set, request }) => {
+            const authError = await requireProjectOrAdminAuth(request, params.ref);
+            if (authError) return projectAuthResponse(authError, set);
+
+            const project = await projectService.getProject(params.ref);
+            if (!project) {
+                set.status = 404;
+                return { message: "Project not found", code: "404", status: 404 };
+            }
+            let targetSchema: string;
+            try {
+                targetSchema = normalizeDatabaseSchema(query.schema as string | undefined);
+            } catch (error: unknown) {
+                set.status = 400;
+                return {
+                    message: error instanceof Error ? error.message : "Invalid schema",
+                    code: "INVALID_SCHEMA",
+                    status: 400,
+                };
+            }
+            try {
+                const projectDb = await getProjectSql(params.ref);
+                if (!projectDb) {
+                    set.status = 404;
+                    return { message: "Project database credentials not found", code: "404", status: 404 };
+                }
+                const issues = await runDatabaseLinter(projectDb, targetSchema);
+                return {
+                    schema: targetSchema,
+                    total_issues: issues.length,
+                    danger_count: issues.filter((i) => i.severity === "danger").length,
+                    warning_count: issues.filter((i) => i.severity === "warning").length,
+                    info_count: issues.filter((i) => i.severity === "info").length,
+                    issues,
+                };
+            } catch (error: unknown) {
+                logger.error("[database] linter execution failed", {
+                    projectRef: params.ref,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+                set.status = 500;
+                return { message: "Database linter failed", code: "LINTER_FAILED", status: 500 };
+            }
+        },
+        {
+            params: t.Object({ ref: t.String({ minLength: 1 }) }),
+            query: t.Object({ schema: t.Optional(t.String()) }),
+            detail: { tags: ["projects"], summary: "Run built-in database linter on project database" },
+        }
+    )
+    .get(
+        "/rpc-catalog",
+        async ({ params, query, set, request }) => {
+            const authError = await requireProjectOrAdminAuth(request, params.ref);
+            if (authError) return projectAuthResponse(authError, set);
+
+            const project = await projectService.getProject(params.ref);
+            if (!project) {
+                set.status = 404;
+                return { message: "Project not found", code: "404", status: 404 };
+            }
+            let schemasParam: string[];
+            try {
+                schemasParam = normalizeRpcSchemas(
+                    query.schemas ? query.schemas.split(",").filter(Boolean) : undefined,
+                );
+            } catch (error: unknown) {
+                set.status = 400;
+                return {
+                    message: error instanceof Error ? error.message : "Invalid schemas",
+                    code: "INVALID_SCHEMAS",
+                    status: 400,
+                };
+            }
+            try {
+                const projectDb = await getProjectSql(params.ref);
+                if (!projectDb) {
+                    set.status = 404;
+                    return { message: "Project database credentials not found", code: "404", status: 404 };
+                }
+                const rpcs = await readRpcCatalog(projectDb, schemasParam);
+                return {
+                    schemas: schemasParam,
+                    total_rpcs: rpcs.length,
+                    commands: rpcs.filter((r) => r.inferred_kind === "command").length,
+                    queries: rpcs.filter((r) => r.inferred_kind === "query").length,
+                    internal: rpcs.filter((r) => r.inferred_kind === "internal").length,
+                    rpcs,
+                };
+            } catch (error: unknown) {
+                logger.error("[database] rpc catalog introspection failed", {
+                    projectRef: params.ref,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+                set.status = 500;
+                return { message: "RPC catalog inspection failed", code: "RPC_CATALOG_FAILED", status: 500 };
+            }
+        },
+        {
+            params: t.Object({ ref: t.String({ minLength: 1 }) }),
+            query: t.Object({ schemas: t.Optional(t.String()) }),
+            detail: { tags: ["projects"], summary: "Introspect RPC catalog with smart tags and signatures" },
+        }
     );

--- a/packages/management-api/src/services/database-governance-input.ts
+++ b/packages/management-api/src/services/database-governance-input.ts
@@ -1,0 +1,25 @@
+const PG_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function normalizeSchemaIdentifier(value: string): string {
+  const schema = value.trim();
+  if (!PG_IDENTIFIER_PATTERN.test(schema) || schema.length > 63) {
+    throw new Error("schema must be a PostgreSQL identifier of at most 63 characters");
+  }
+  return schema;
+}
+
+export function normalizeDatabaseSchema(value: string | undefined, fallback = "public"): string {
+  return normalizeSchemaIdentifier(value ?? fallback);
+}
+
+export function normalizeRpcSchemas(schemas: readonly string[] | undefined): string[] {
+  const values = schemas && schemas.length > 0 ? schemas : ["public", "api"];
+  if (values.length > 16) {
+    throw new Error("schemas must contain at most 16 PostgreSQL identifiers of at most 63 characters");
+  }
+  try {
+    return [...new Set(values.map(normalizeSchemaIdentifier))];
+  } catch {
+    throw new Error("schemas must contain at most 16 PostgreSQL identifiers of at most 63 characters");
+  }
+}

--- a/packages/management-api/src/services/database-linter.service.ts
+++ b/packages/management-api/src/services/database-linter.service.ts
@@ -1,0 +1,206 @@
+import type { SQL } from "bun";
+import { normalizeDatabaseSchema } from "./database-governance-input";
+
+export type LintSeverity = "danger" | "warning" | "info";
+export type LintCategory = "security" | "performance" | "integrity";
+
+export interface DatabaseLintIssue {
+  type: string;
+  severity: LintSeverity;
+  category: LintCategory;
+  schema_name: string;
+  object_name: string;
+  detail: string;
+  recommendation: string;
+  fix_sql: string;
+  column_name?: string | null;
+  column_names?: string[];
+  identity_args?: string | null;
+}
+
+function quoteIdent(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function qualifiedName(schema: string, name: string): string {
+  return `${quoteIdent(schema)}.${quoteIdent(name)}`;
+}
+
+function schemaLiteral(targetSchema: string): string {
+  return targetSchema.replaceAll("'", "''");
+}
+
+async function readMissingPrimaryKeyIssues(projectDb: SQL, targetSchema: string): Promise<DatabaseLintIssue[]> {
+  const schema = schemaLiteral(targetSchema);
+  const rows = await projectDb.unsafe(`
+    SELECT
+      t.table_schema,
+      t.table_name
+    FROM information_schema.tables t
+    LEFT JOIN information_schema.table_constraints tc
+      ON tc.table_schema = t.table_schema
+     AND tc.table_name = t.table_name
+     AND tc.constraint_type = 'PRIMARY KEY'
+    WHERE t.table_schema = '${schema}'
+      AND t.table_type = 'BASE TABLE'
+      AND tc.constraint_name IS NULL
+    ORDER BY t.table_schema, t.table_name;
+  `);
+
+  return (rows as Array<Record<string, unknown>>).map((row) => {
+    const schema = String(row.table_schema);
+    const table = String(row.table_name);
+    return {
+      type: "no_primary_key",
+      severity: "danger",
+      category: "integrity",
+      schema_name: schema,
+      object_name: table,
+      detail: `Table ${schema}.${table} has no primary key defined.`,
+      recommendation: "Add a primary key constraint or identity column to uniquely identify rows and enable replication.",
+      fix_sql: `ALTER TABLE ${qualifiedName(schema, table)} ADD COLUMN id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY;`,
+    };
+  });
+}
+
+async function readMissingRlsIssues(projectDb: SQL, targetSchema: string): Promise<DatabaseLintIssue[]> {
+  const schema = schemaLiteral(targetSchema);
+  const rows = await projectDb.unsafe(`
+    SELECT
+      schemaname,
+      tablename
+    FROM pg_tables
+    WHERE schemaname = '${schema}'
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = pg_tables.schemaname
+          AND c.relname = pg_tables.tablename
+          AND c.relrowsecurity = true
+      )
+    ORDER BY schemaname, tablename;
+  `);
+
+  return (rows as Array<Record<string, unknown>>).map((row) => {
+    const schema = String(row.schemaname);
+    const table = String(row.tablename);
+    return {
+      type: "no_rls",
+      severity: "warning",
+      category: "security",
+      schema_name: schema,
+      object_name: table,
+      detail: `Row Level Security (RLS) is not enabled on table ${schema}.${table}.`,
+      recommendation: "Enable Row Level Security to prevent unauthorized access via PostgREST / Supabase Client.",
+      fix_sql: `ALTER TABLE ${qualifiedName(schema, table)} ENABLE ROW LEVEL SECURITY;`,
+    };
+  });
+}
+
+async function readMissingForeignKeyIndexIssues(projectDb: SQL, targetSchema: string): Promise<DatabaseLintIssue[]> {
+  const schema = schemaLiteral(targetSchema);
+  const rows = await projectDb.unsafe(`
+    SELECT
+      ns.nspname AS table_schema,
+      rel.relname AS table_name,
+      ARRAY(
+        SELECT att.attname
+        FROM unnest(fk.conkey) WITH ORDINALITY AS key_col(attnum, ordinality)
+        JOIN pg_attribute att ON att.attrelid = rel.oid AND att.attnum = key_col.attnum
+        ORDER BY key_col.ordinality
+      ) AS column_names
+    FROM pg_constraint fk
+    JOIN pg_class rel ON rel.oid = fk.conrelid
+    JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+    WHERE fk.contype = 'f'
+      AND ns.nspname = '${schema}'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_index idx
+        WHERE idx.indrelid = fk.conrelid
+          AND idx.indisvalid
+          AND idx.indpred IS NULL
+          AND idx.indnkeyatts >= cardinality(fk.conkey)
+          AND NOT EXISTS (
+            SELECT 1
+            FROM unnest(fk.conkey) WITH ORDINALITY AS fk_col(attnum, ordinality)
+            WHERE NOT EXISTS (
+              SELECT 1
+              FROM unnest(idx.indkey) WITH ORDINALITY AS idx_col(attnum, ordinality)
+              WHERE idx_col.ordinality = fk_col.ordinality
+                AND idx_col.attnum = fk_col.attnum
+            )
+          )
+      )
+    ORDER BY ns.nspname, rel.relname, fk.conname;
+  `);
+
+  return (rows as Array<Record<string, unknown>>).map((row) => {
+    const schema = String(row.table_schema);
+    const table = String(row.table_name);
+    const columns = Array.isArray(row.column_names) ? row.column_names.map(String) : [];
+    const columnList = columns.map((column) => quoteIdent(column)).join(", ");
+    return {
+      type: "no_index_on_fk",
+      severity: "info",
+      category: "performance",
+      schema_name: schema,
+      object_name: table,
+      column_names: columns,
+      detail: `Foreign key columns ${columnList} on table ${schema}.${table} have no supporting index.`,
+      recommendation: "Create an index on foreign key columns to improve JOIN and cascading operation performance.",
+      fix_sql: `CREATE INDEX ON ${qualifiedName(schema, table)} (${columns.map(quoteIdent).join(", ")});`,
+    };
+  });
+}
+
+async function readUnsafeSecurityDefinerIssues(projectDb: SQL, targetSchema: string): Promise<DatabaseLintIssue[]> {
+  const schema = schemaLiteral(targetSchema);
+  const rows = await projectDb.unsafe(`
+    SELECT
+      n.nspname AS schema_name,
+      p.proname AS function_name,
+      pg_catalog.pg_get_function_identity_arguments(p.oid) AS identity_args,
+      p.proconfig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.prosecdef = true
+      AND p.prokind = 'f'
+      AND n.nspname = '${schema}'
+      AND (
+        p.proconfig IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM unnest(p.proconfig) AS cfg WHERE cfg LIKE 'search_path=%'
+        )
+      )
+    ORDER BY n.nspname, p.proname;
+  `);
+
+  return (rows as Array<Record<string, unknown>>).map((row) => {
+    const schema = String(row.schema_name);
+    const funcName = String(row.function_name);
+    const identityArgs = String(row.identity_args || "");
+    return {
+      type: "security_definer_no_search_path",
+      severity: "danger",
+      category: "security",
+      schema_name: schema,
+      object_name: funcName,
+      identity_args: identityArgs,
+      detail: `Function ${schema}.${funcName}(${identityArgs}) is SECURITY DEFINER but has no explicit search_path configured.`,
+      recommendation: "Always set an explicit immutable search_path (e.g. search_path = pg_catalog) on SECURITY DEFINER functions to prevent privilege escalation via schema poisoning.",
+      fix_sql: `ALTER FUNCTION ${qualifiedName(schema, funcName)}(${identityArgs}) SET search_path = pg_catalog;`,
+    };
+  });
+}
+
+export async function runDatabaseLinter(projectDb: SQL, targetSchema = "public"): Promise<DatabaseLintIssue[]> {
+  const normalizedSchema = normalizeDatabaseSchema(targetSchema);
+  const issueGroups = await Promise.all([
+    readMissingPrimaryKeyIssues(projectDb, normalizedSchema),
+    readMissingRlsIssues(projectDb, normalizedSchema),
+    readMissingForeignKeyIndexIssues(projectDb, normalizedSchema),
+    readUnsafeSecurityDefinerIssues(projectDb, normalizedSchema),
+  ]);
+  return issueGroups.flat();
+}

--- a/packages/management-api/src/services/database-rpc-catalog.service.ts
+++ b/packages/management-api/src/services/database-rpc-catalog.service.ts
@@ -1,0 +1,149 @@
+import type { SQL } from "bun";
+import { normalizeRpcSchemas } from "./database-governance-input";
+
+export type RpcKind = "command" | "query" | "internal";
+export type RpcVolatility = "VOLATILE" | "STABLE" | "IMMUTABLE";
+export type RpcSecurity = "DEFINER" | "INVOKER";
+
+export interface RpcCatalogEntry {
+  schema_name: string;
+  function_name: string;
+  identity_args: string;
+  arguments_display: string;
+  return_type: string;
+  language: string;
+  volatility: RpcVolatility;
+  security: RpcSecurity;
+  search_path: string | null;
+  comment: string | null;
+  smart_tags: Record<string, string | boolean>;
+  inferred_kind: RpcKind;
+  is_strict: boolean;
+}
+
+export function parseSmartTags(comment: string | null | undefined): Record<string, string | boolean> {
+  if (!comment) return {};
+  const tags: Record<string, string | boolean> = {};
+  const regex = /^\s*@([a-zA-Z0-9_]+)(?:[ \t]+([^\n\r]+))?\s*$/gm;
+  let match;
+  while ((match = regex.exec(comment)) !== null) {
+    const key = match[1];
+    const rawVal = match[2]?.trim();
+    tags[key] = rawVal !== undefined && rawVal.length > 0 ? rawVal : true;
+  }
+  return tags;
+}
+
+export function inferRpcKind(
+  name: string,
+  volatility: RpcVolatility,
+  returnType: string,
+  smartTags: Record<string, string | boolean>,
+): RpcKind {
+  const explicitApi = typeof smartTags.api === "string" ? smartTags.api.toLowerCase() : undefined;
+  if (explicitApi === "command" || explicitApi === "mutation") return "command";
+  if (explicitApi === "query") return "query";
+  if (explicitApi === "internal" || explicitApi === "ignore" || smartTags.internal) return "internal";
+
+  const lowerName = name.toLowerCase();
+
+  const commandPrefixes = [
+    "create_", "update_", "delete_", "upsert_", "approve_", "reject_",
+    "cancel_", "submit_", "process_", "apply_", "push_", "sync_", "set_",
+    "add_", "remove_", "assign_", "reconcile_", "complete_", "lock_", "unlock_",
+  ];
+  if (commandPrefixes.some((prefix) => lowerName.startsWith(prefix))) {
+    return "command";
+  }
+
+  const queryPrefixes = [
+    "get_", "list_", "find_", "search_", "fetch_", "read_", "count_",
+    "check_", "is_", "has_", "validate_", "calculate_",
+  ];
+  if (queryPrefixes.some((prefix) => lowerName.startsWith(prefix))) {
+    return "query";
+  }
+
+  if (volatility === "STABLE" || volatility === "IMMUTABLE") {
+    return "query";
+  }
+
+  const lowerReturnType = returnType.toLowerCase();
+  if (lowerReturnType === "void" || lowerReturnType === "boolean" || lowerReturnType.includes("receipt")) {
+    return "command";
+  }
+
+  return "command";
+}
+
+export async function readRpcCatalog(
+  projectDb: SQL,
+  schemas = ["public", "api"],
+): Promise<RpcCatalogEntry[]> {
+  const normalizedSchemas = normalizeRpcSchemas(schemas);
+  const schemaList = normalizedSchemas.map((s) => `'${s.replaceAll("'", "''")}'`).join(", ");
+  if (!schemaList) return [];
+
+  const rows = await projectDb.unsafe(`
+    SELECT
+      n.nspname AS schema_name,
+      p.proname AS function_name,
+      pg_catalog.pg_get_function_identity_arguments(p.oid) AS identity_args,
+      pg_catalog.pg_get_function_arguments(p.oid) AS arguments_display,
+      pg_catalog.pg_get_function_result(p.oid) AS return_type,
+      l.lanname AS language,
+      p.provolatile AS volatility_char,
+      p.prosecdef AS security_definer,
+      p.proisstrict AS is_strict,
+      p.proconfig AS config,
+      pg_catalog.obj_description(p.oid, 'pg_proc') AS comment
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_language l ON l.oid = p.prolang
+    WHERE p.prokind = 'f'
+      AND n.nspname IN (${schemaList})
+    ORDER BY n.nspname, p.proname;
+  `);
+
+  return (rows as Array<Record<string, unknown>>).map((row) => {
+    const schema = String(row.schema_name);
+    const funcName = String(row.function_name);
+    const identityArgs = String(row.identity_args || "");
+    const argumentsDisplay = String(row.arguments_display || "");
+    const returnType = String(row.return_type || "void");
+    const language = String(row.language);
+    const isStrict = row.is_strict === true;
+    const isSecDef = row.security_definer === true;
+    const volatilityChar = String(row.volatility_char || "v");
+    const volatility: RpcVolatility = volatilityChar === "i"
+      ? "IMMUTABLE"
+      : volatilityChar === "s"
+        ? "STABLE"
+        : "VOLATILE";
+    const security: RpcSecurity = isSecDef ? "DEFINER" : "INVOKER";
+
+    const configArray = Array.isArray(row.config) ? (row.config as string[]) : [];
+    const searchPathConfig = configArray.find((cfg) => cfg.startsWith("search_path="));
+    const searchPath = searchPathConfig ? searchPathConfig.slice("search_path=".length) : null;
+
+    const comment = row.comment ? String(row.comment) : null;
+    const smartTags = parseSmartTags(comment);
+    const inferredKind = inferRpcKind(funcName, volatility, returnType, smartTags);
+
+    return {
+      schema_name: schema,
+      function_name: funcName,
+      identity_args: identityArgs,
+      arguments_display: argumentsDisplay,
+      return_type: returnType,
+      language,
+      volatility,
+      security,
+      search_path: searchPath,
+      comment,
+      smart_tags: smartTags,
+      inferred_kind: inferredKind,
+      is_strict: isStrict,
+    };
+  });
+}

--- a/packages/management-api/tests/unit/database-governance.routes.test.ts
+++ b/packages/management-api/tests/unit/database-governance.routes.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Elysia } from "elysia";
+
+const tenantQueries: string[] = [];
+
+const managementDb = mock((strings: TemplateStringsArray) => {
+  if (strings.join("?").includes("SELECT db_name, db_user, db_password")) {
+    return Promise.resolve([{ db_name: "tenant_db", db_user: "tenant_user", db_password: "test-password" }]);
+  }
+  return Promise.resolve([]);
+});
+
+const tenantDb = Object.assign(
+  mock(() => Promise.resolve([])),
+  {
+    unsafe: mock(async (query: string) => {
+      tenantQueries.push(query);
+      if (query.includes("WHERE p.prosecdef = true")) {
+        return [{ schema_name: "public", function_name: "unsafe_rpc", identity_args: "", proconfig: null }];
+      }
+      if (query.includes("pg_catalog.obj_description")) {
+        return [{
+          schema_name: "public",
+          function_name: "get_case",
+          identity_args: "case_id uuid",
+          arguments_display: "case_id uuid",
+          return_type: "jsonb",
+          language: "sql",
+          volatility_char: "s",
+          security_definer: false,
+          is_strict: true,
+          config: null,
+          comment: "@api query",
+        }];
+      }
+      return [];
+    }),
+  },
+);
+
+const getProject = mock(async () => ({ ref: "proj_1" }));
+const requireProjectOrAdminAuth = mock(async () => undefined);
+
+const actualDb = await import("../../src/db");
+mock.module("../../src/db", () => ({
+  ...actualDb,
+  sql: managementDb,
+  getProjectRoleDb: mock(() => tenantDb),
+}));
+mock.module("../../src/services", () => ({ projectService: { getProject } }));
+mock.module("../../src/middleware/auth", () => ({
+  requireAdminAuth: mock(async () => undefined),
+  requireProjectOrAdminAuth,
+}));
+
+const { databaseRoutes } = await import(
+  new URL("../../src/routes/database.ts?database-governance-routes-test", import.meta.url).href,
+);
+const app = new Elysia().use(databaseRoutes);
+
+function request(path: string) {
+  return app.handle(new Request(`http://localhost/v1/projects/proj_1/database/${path}`));
+}
+
+describe("database governance routes", () => {
+  beforeEach(() => {
+    tenantQueries.length = 0;
+    managementDb.mockClear();
+    tenantDb.mockClear();
+    tenantDb.unsafe.mockClear();
+    getProject.mockClear();
+    requireProjectOrAdminAuth.mockClear();
+  });
+
+  test("returns bounded linter results from the selected schema", async () => {
+    const response = await request("linter?schema=public");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      schema: "public",
+      total_issues: 1,
+      danger_count: 1,
+      warning_count: 0,
+      info_count: 0,
+    });
+    expect(tenantQueries.find((query) => query.includes("WHERE p.prosecdef = true"))).toContain(
+      "n.nspname = 'public'",
+    );
+  });
+
+  test("rejects invalid schema selectors before opening the tenant database", async () => {
+    const response = await request(`linter?schema=${encodeURIComponent("public; drop schema x")}`);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ code: "INVALID_SCHEMA", status: 400 });
+    expect(managementDb).not.toHaveBeenCalled();
+    expect(tenantQueries).toHaveLength(0);
+  });
+
+  test("returns only ordinary functions in the RPC catalog", async () => {
+    const response = await request("rpc-catalog?schemas=public,api,public");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      schemas: ["public", "api"],
+      total_rpcs: 1,
+      commands: 0,
+      queries: 1,
+      internal: 0,
+    });
+    expect(tenantQueries.find((query) => query.includes("pg_catalog.obj_description"))).toContain(
+      "p.prokind = 'f'",
+    );
+  });
+
+  test("rejects excessive RPC schemas before opening the tenant database", async () => {
+    const schemas = Array.from({ length: 17 }, (_, index) => `s${index}`).join(",");
+    const response = await request(`rpc-catalog?schemas=${schemas}`);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ code: "INVALID_SCHEMAS", status: 400 });
+    expect(managementDb).not.toHaveBeenCalled();
+    expect(tenantQueries).toHaveLength(0);
+  });
+});

--- a/packages/management-api/tests/unit/database-linter.service.test.ts
+++ b/packages/management-api/tests/unit/database-linter.service.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeDatabaseSchema } from "../../src/services/database-governance-input";
+import { runDatabaseLinter } from "../../src/services/database-linter.service";
+
+describe("normalizeDatabaseSchema", () => {
+  it("accepts standard PostgreSQL schema identifiers", () => {
+    expect(normalizeDatabaseSchema(" public ")).toBe("public");
+  });
+
+  it("rejects unsafe and oversized schema identifiers", () => {
+    expect(() => normalizeDatabaseSchema("public; drop schema x")).toThrow();
+    expect(() => normalizeDatabaseSchema("a".repeat(64))).toThrow();
+  });
+});
+
+describe("runDatabaseLinter", () => {
+  it("detects tables without primary keys, RLS disabled, missing FK indexes, and search_path missing on security definer functions", async () => {
+    const mockDb = {
+      unsafe: async (sqlText: string) => {
+        if (sqlText.includes("FROM information_schema.tables t")) {
+          return [
+            { table_schema: "public", table_name: "events_log" },
+          ];
+        }
+        if (sqlText.includes("FROM pg_tables")) {
+          return [
+            { schemaname: "public", tablename: "events_log" },
+            { schemaname: "public", tablename: "audit_trail" },
+          ];
+        }
+        if (sqlText.includes("FROM pg_constraint fk")) {
+          return [
+            { table_schema: "public", table_name: "orders", column_names: ["customer_id", "region_id"] },
+          ];
+        }
+        if (sqlText.includes("WHERE p.prosecdef = true")) {
+          return [
+            {
+              schema_name: "public",
+              function_name: "approve_order",
+              identity_args: "order_id uuid, approved_by uuid",
+              proconfig: null,
+            },
+          ];
+        }
+        return [];
+      },
+    };
+
+    const issues = await runDatabaseLinter(mockDb as any, "public");
+
+    expect(issues.length).toBe(5);
+
+    const noPk = issues.find((i) => i.type === "no_primary_key");
+    expect(noPk).toBeDefined();
+    expect(noPk?.severity).toBe("danger");
+    expect(noPk?.category).toBe("integrity");
+    expect(noPk?.object_name).toBe("events_log");
+    expect(noPk?.fix_sql).toContain("ADD COLUMN id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY");
+
+    const noRlsList = issues.filter((i) => i.type === "no_rls");
+    expect(noRlsList.length).toBe(2);
+    expect(noRlsList[0]?.severity).toBe("warning");
+    expect(noRlsList[0]?.category).toBe("security");
+    expect(noRlsList[0]?.fix_sql).toContain("ENABLE ROW LEVEL SECURITY");
+
+    const noFkIndex = issues.find((i) => i.type === "no_index_on_fk");
+    expect(noFkIndex).toBeDefined();
+    expect(noFkIndex?.severity).toBe("info");
+    expect(noFkIndex?.column_names).toEqual(["customer_id", "region_id"]);
+    expect(noFkIndex?.fix_sql).toContain('CREATE INDEX ON "public"."orders" ("customer_id", "region_id")');
+
+    const secDef = issues.find((i) => i.type === "security_definer_no_search_path");
+    expect(secDef).toBeDefined();
+    expect(secDef?.severity).toBe("danger");
+    expect(secDef?.category).toBe("security");
+    expect(secDef?.object_name).toBe("approve_order");
+    expect(secDef?.fix_sql).toBe('ALTER FUNCTION "public"."approve_order"(order_id uuid, approved_by uuid) SET search_path = pg_catalog;');
+  });
+
+  it("uses exact catalog metadata for foreign-key coverage and scopes function checks", async () => {
+    const statements: string[] = [];
+    const mockDb = {
+      unsafe: async (sqlText: string) => {
+        statements.push(sqlText);
+        return [];
+      },
+    };
+
+    await runDatabaseLinter(mockDb as any, "tenant_api");
+
+    const foreignKeyQuery = statements.find((sql) => sql.includes("FROM pg_constraint fk"));
+    expect(foreignKeyQuery).toContain("unnest(idx.indkey) WITH ORDINALITY");
+    expect(foreignKeyQuery).toContain("idx.indpred IS NULL");
+    expect(foreignKeyQuery).not.toContain("indexdef LIKE");
+
+    const functionQuery = statements.find((sql) => sql.includes("WHERE p.prosecdef = true"));
+    expect(functionQuery).toContain("p.prokind = 'f'");
+    expect(functionQuery).toContain("n.nspname = 'tenant_api'");
+  });
+});

--- a/packages/management-api/tests/unit/database-rpc-catalog.service.test.ts
+++ b/packages/management-api/tests/unit/database-rpc-catalog.service.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeRpcSchemas } from "../../src/services/database-governance-input";
+import {
+  parseSmartTags,
+  inferRpcKind,
+  readRpcCatalog,
+} from "../../src/services/database-rpc-catalog.service";
+
+describe("normalizeRpcSchemas", () => {
+  it("defaults, trims, and de-duplicates schemas", () => {
+    expect(normalizeRpcSchemas([" public ", "api", "public"])).toEqual(["public", "api"]);
+    expect(normalizeRpcSchemas(undefined)).toEqual(["public", "api"]);
+  });
+
+  it("rejects unsafe or excessive schema selectors", () => {
+    expect(() => normalizeRpcSchemas(["public;drop schema x"])).toThrow();
+    expect(() => normalizeRpcSchemas(Array.from({ length: 17 }, (_, i) => `s${i}`))).toThrow();
+  });
+});
+
+describe("parseSmartTags", () => {
+  it("parses tags from SQL comment", () => {
+    const comment = `
+@api command
+@domain case_approval
+@owner fa_team
+@idempotency command_id
+@auth authenticated
+@strict
+`;
+    const tags = parseSmartTags(comment);
+    expect(tags.api).toBe("command");
+    expect(tags.domain).toBe("case_approval");
+    expect(tags.owner).toBe("fa_team");
+    expect(tags.idempotency).toBe("command_id");
+    expect(tags.auth).toBe("authenticated");
+    expect(tags.strict).toBe(true);
+  });
+
+  it("returns empty object on null or empty comment", () => {
+    expect(parseSmartTags(null)).toEqual({});
+    expect(parseSmartTags("")).toEqual({});
+  });
+
+  it("ignores at-signs embedded in ordinary comment text", () => {
+    expect(parseSmartTags("Owner: dev@example.com\nThis is not @api metadata")).toEqual({});
+  });
+});
+
+describe("inferRpcKind", () => {
+  it("respects explicit @api smart tags", () => {
+    expect(inferRpcKind("some_func", "VOLATILE", "void", { api: "query" })).toBe("query");
+    expect(inferRpcKind("get_data", "STABLE", "json", { api: "command" })).toBe("command");
+    expect(inferRpcKind("internal_calc", "VOLATILE", "void", { api: "internal" })).toBe("internal");
+  });
+
+  it("infers command from naming prefixes", () => {
+    expect(inferRpcKind("approve_case", "VOLATILE", "json", {})).toBe("command");
+    expect(inferRpcKind("create_order", "VOLATILE", "uuid", {})).toBe("command");
+    expect(inferRpcKind("delete_record", "VOLATILE", "void", {})).toBe("command");
+  });
+
+  it("infers query from naming prefixes and STABLE/IMMUTABLE volatility", () => {
+    expect(inferRpcKind("get_case_summary", "VOLATILE", "json", {})).toBe("query");
+    expect(inferRpcKind("calculate_tax", "IMMUTABLE", "numeric", {})).toBe("query");
+    expect(inferRpcKind("custom_search", "STABLE", "setof cases", {})).toBe("query");
+  });
+});
+
+describe("readRpcCatalog", () => {
+  it("maps postgres catalog rows to typed RpcCatalogEntry items", async () => {
+    let catalogQuery = "";
+    const mockDb = {
+      unsafe: async (sqlText: string) => {
+        catalogQuery = sqlText;
+        return [
+        {
+          schema_name: "public",
+          function_name: "approve_case",
+          identity_args: "p_case_id uuid, p_user_id uuid",
+          arguments_display: "p_case_id uuid, p_user_id uuid",
+          return_type: "json",
+          language: "plpgsql",
+          volatility_char: "v",
+          security_definer: true,
+          is_strict: true,
+          config: ["search_path=pg_catalog, public"],
+          comment: "@api command\n@domain approval",
+        },
+        {
+          schema_name: "public",
+          function_name: "get_case_details",
+          identity_args: "p_case_id uuid",
+          arguments_display: "p_case_id uuid",
+          return_type: "jsonb",
+          language: "sql",
+          volatility_char: "s",
+          security_definer: false,
+          is_strict: false,
+          config: null,
+          comment: null,
+        },
+        ];
+      },
+    };
+
+    const catalog = await readRpcCatalog(mockDb as any, ["public"]);
+    expect(catalog.length).toBe(2);
+
+    const approve = catalog[0]!;
+    expect(approve.function_name).toBe("approve_case");
+    expect(approve.security).toBe("DEFINER");
+    expect(approve.search_path).toBe("pg_catalog, public");
+    expect(approve.inferred_kind).toBe("command");
+    expect(approve.smart_tags.domain).toBe("approval");
+
+    const getDetails = catalog[1]!;
+    expect(getDetails.function_name).toBe("get_case_details");
+    expect(getDetails.security).toBe("INVOKER");
+    expect(getDetails.search_path).toBeNull();
+    expect(getDetails.inferred_kind).toBe("query");
+    expect(catalogQuery).toContain("p.prokind = 'f'");
+  });
+});

--- a/packages/management-api/tests/unit/supabase-schema.test.ts
+++ b/packages/management-api/tests/unit/supabase-schema.test.ts
@@ -518,6 +518,16 @@ describe("supabase bootstrap schema", () => {
     expect(bootstrap).toContain("'pgmq'");
   });
 
+  test("self-host postgres image preinstalls database test tools without enabling them for every tenant", () => {
+    const dockerfile = readRepoFile("../../docker/self-host/postgres/Dockerfile");
+    const bootstrap = readRepoFile("../../docker/self-host/postgres/initdb/01-bootstrap-extensions.sql");
+
+    expect(dockerfile).toContain("postgresql-18-plpgsql-check");
+    expect(dockerfile).toContain("postgresql-18-pgtap");
+    expect(bootstrap).not.toContain("'plpgsql_check'");
+    expect(bootstrap).not.toContain("'pgtap'");
+  });
+
   test("SupaCloud leaves official Realtime objects to the upstream migrator", () => {
     const bootstrap = readRepoFile("src/db/schemas/supabase.sql");
     const tenantMigrationSources = [

--- a/packages/web-console/src/lib/i18n/locales/en.json
+++ b/packages/web-console/src/lib/i18n/locales/en.json
@@ -1266,7 +1266,9 @@
     "severity_danger": "Danger",
     "severity_info": "Info",
     "table": "Table",
-    "fix_hint": "Suggested Fix"
+    "fix_hint": "Suggested Fix",
+    "security_definer_no_search_path": "SECURITY DEFINER Missing search_path",
+    "security_definer_no_search_path_desc": "SECURITY DEFINER functions without a fixed search_path are vulnerable to privilege escalation."
   },
   "Logs": {
     "title": "Logs Explorer",

--- a/packages/web-console/src/lib/i18n/locales/zh.json
+++ b/packages/web-console/src/lib/i18n/locales/zh.json
@@ -1266,7 +1266,9 @@
     "severity_danger": "危险",
     "severity_info": "信息",
     "table": "表",
-    "fix_hint": "建议修复"
+    "fix_hint": "建议修复",
+    "security_definer_no_search_path": "SECURITY DEFINER 缺少 search_path",
+    "security_definer_no_search_path_desc": "SECURITY DEFINER 函数未固定 search_path，存在被提权攻击的风险。"
   },
   "Logs": {
     "title": "日志探索器",

--- a/packages/web-console/src/routes/project/[ref]/reports/database-linter/+page.svelte
+++ b/packages/web-console/src/routes/project/[ref]/reports/database-linter/+page.svelte
@@ -3,106 +3,34 @@
 
   import { page } from "$app/state";
   import { t } from "svelte-i18n";
-  import { Loader2, ShieldCheck, AlertTriangle, ShieldAlert, Info, CheckCircle2 } from "lucide-svelte";
+  import { Loader2, AlertTriangle, ShieldAlert, Info, CheckCircle2 } from "lucide-svelte";
   import { createQuery } from "@tanstack/svelte-query";
 
   interface LintIssue {
-    type: "no_primary_key" | "no_rls" | "no_index_on_fk";
+    type: "no_primary_key" | "no_rls" | "no_index_on_fk" | "security_definer_no_search_path" | string;
     severity: "danger" | "warning" | "info";
-    table_schema: string;
-    table_name: string;
+    category: "security" | "performance" | "integrity";
+    schema_name: string;
+    object_name: string;
     detail: string;
+    recommendation: string;
     fix_sql: string;
-    column_name?: string;
+    column_name?: string | null;
+    column_names?: string[];
+    identity_args?: string | null;
   }
-
-  type RawLintIssue = Omit<LintIssue, "fix_sql">;
 
   const projectRef = $derived(page.params.ref);
-
-  const LINT_SQL = `
-    SELECT
-      'no_primary_key' as type, 'danger' as severity,
-      t.table_schema, t.table_name,
-      null::text as column_name,
-      'Table has no primary key' as detail
-    FROM information_schema.tables t
-    LEFT JOIN information_schema.table_constraints tc
-      ON tc.table_schema = t.table_schema AND tc.table_name = t.table_name AND tc.constraint_type = 'PRIMARY KEY'
-    WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE' AND tc.constraint_name IS NULL
-
-    UNION ALL
-
-    SELECT
-      'no_rls' as type, 'warning' as severity,
-      schemaname as table_schema, tablename as table_name,
-      null::text as column_name,
-      'Row Level Security is not enabled' as detail
-    FROM pg_tables
-    WHERE schemaname = 'public'
-      AND NOT EXISTS (
-        SELECT 1 FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = pg_tables.schemaname
-          AND c.relname = pg_tables.tablename
-          AND c.relrowsecurity = true
-      )
-
-    UNION ALL
-
-    SELECT
-      'no_index_on_fk' as type, 'info' as severity,
-      tc.table_schema, tc.table_name,
-      kcu.column_name,
-      'Foreign key column "' || kcu.column_name || '" has no index' as detail
-    FROM information_schema.table_constraints tc
-    JOIN information_schema.key_column_usage kcu
-      ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
-    WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = 'public'
-      AND NOT EXISTS (
-        SELECT 1 FROM pg_indexes pi
-        WHERE pi.schemaname = tc.table_schema
-          AND pi.tablename = tc.table_name
-          AND pi.indexdef LIKE '%' || kcu.column_name || '%'
-      )
-    ORDER BY severity, type, table_name;
-  `;
-
-  function quoteIdent(identifier: string): string {
-    return `"${identifier.replaceAll('"', '""')}"`;
-  }
-
-  function qualifiedTable(issue: RawLintIssue): string {
-    return `${quoteIdent(issue.table_schema)}.${quoteIdent(issue.table_name)}`;
-  }
-
-  function buildFixSql(issue: RawLintIssue): string {
-    if (issue.type === "no_primary_key") {
-      return `ALTER TABLE ${qualifiedTable(issue)} ADD COLUMN id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY;`;
-    }
-    if (issue.type === "no_rls") {
-      return `ALTER TABLE ${qualifiedTable(issue)} ENABLE ROW LEVEL SECURITY;`;
-    }
-    if (issue.type === "no_index_on_fk" && issue.column_name) {
-      return `CREATE INDEX ON ${qualifiedTable(issue)} (${quoteIdent(issue.column_name)});`;
-    }
-    return "";
-  }
 
   const lintQuery = createQuery(() => ({
     queryKey: ["database-lint", projectRef],
     queryFn: async () => {
-      const res = await apiClient(`/v1/projects/${projectRef}/database/sql`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sql: LINT_SQL })
+      const res = await apiClient(`/v1/projects/${projectRef}/database/linter`, {
+        method: "GET",
       });
       const data = await res.json();
       if (!res.ok || data.error) throw new Error(data.message || data.error || "Database linter query failed");
-      return ((data.rows || []) as RawLintIssue[]).map((issue) => ({
-        ...issue,
-        fix_sql: buildFixSql(issue)
-      }));
+      return (data.issues || []) as LintIssue[];
     }
   }));
 
@@ -117,17 +45,15 @@
   }
 
   function getTypeLabel(type: string): string {
-    if (type === "no_primary_key") return $t("DatabaseLinter.no_primary_key");
-    if (type === "no_rls") return $t("DatabaseLinter.no_rls");
-    if (type === "no_index_on_fk") return $t("DatabaseLinter.no_index_on_fk");
-    return type;
+    const key = `DatabaseLinter.${type}`;
+    const translated = $t(key);
+    return translated !== key ? translated : type;
   }
 
   function getTypeDesc(type: string): string {
-    if (type === "no_primary_key") return $t("DatabaseLinter.no_primary_key_desc");
-    if (type === "no_rls") return $t("DatabaseLinter.no_rls_desc");
-    if (type === "no_index_on_fk") return $t("DatabaseLinter.no_index_on_fk_desc");
-    return "";
+    const key = `DatabaseLinter.${type}_desc`;
+    const translated = $t(key);
+    return translated !== key ? translated : "";
   }
 
   function getSeverityLabel(severity: string): string {
@@ -164,7 +90,7 @@
         <p class="text-sm font-medium">{$t("DatabaseLinter.no_issues")}</p>
       </div>
     {:else}
-      {#each issues as issue (`${issue.type}-${issue.table_schema}-${issue.table_name}-${issue.column_name || ""}`)}
+      {#each issues as issue (`${issue.type}-${issue.schema_name}-${issue.object_name}-${issue.column_name || issue.column_names?.join(",") || issue.identity_args || ""}`)}
         <div class="rounded-lg border {getSeverityColor(issue.severity)} p-4 transition-all hover:shadow-sm">
           <div class="flex items-start justify-between gap-4">
             <div class="flex items-start gap-3 flex-1">
@@ -182,10 +108,10 @@
                   <span class="font-semibold text-sm">{getTypeLabel(issue.type)}</span>
                   <span class="text-[10px] font-bold uppercase px-1.5 py-0.5 rounded {getSeverityColor(issue.severity)}">{getSeverityLabel(issue.severity)}</span>
                 </div>
-                <p class="text-xs text-muted-foreground mb-2">{getTypeDesc(issue.type)}</p>
+                <p class="text-xs text-muted-foreground mb-2">{getTypeDesc(issue.type) || issue.detail}</p>
                 <div class="flex items-center gap-2 text-xs">
                   <span class="font-medium">{$t("DatabaseLinter.table")}:</span>
-                  <code class="px-1.5 py-0.5 bg-muted/50 rounded font-mono text-[11px]">{issue.table_schema}.{issue.table_name}</code>
+                  <code class="px-1.5 py-0.5 bg-muted/50 rounded font-mono text-[11px]">{issue.schema_name}.{issue.object_name}{issue.identity_args ? `(${issue.identity_args})` : ""}</code>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add Management API database linter and RPC catalog endpoints
- expose read-only CLI actions with strict/JSON output and ref/schema validation
- route Web Console Database Linter through the Management API
- preinstall PostgreSQL 18 `plpgsql_check` and `pgTAP` without enabling them for every tenant

## Validation
- `bun test packages/management-api/tests/unit/database-governance.routes.test.ts packages/management-api/tests/unit/database-linter.service.test.ts packages/management-api/tests/unit/database-rpc-catalog.service.test.ts packages/management-api/tests/unit/supabase-schema.test.ts packages/cli/src/shared/tools/database-tools.test.ts packages/cli/src/shared/execution-policy.test.ts`
- `bun run typecheck` in `packages/management-api`
- `bun run typecheck` in `packages/cli`
- `bun run check` in `packages/web-console`
- `git diff --check`

Docker image build was attempted but canceled during slow cross-architecture base image/APT resolution; no production deployment was performed.
