### PR TITLE
fix(management-api): isolate immutable function version reads

### DIFF
--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -1855,6 +1855,47 @@ async function statIso(filePath: string | null): Promise<string | null> {
   }
 }
 
+async function functionVersionRecord(
+  ref: string,
+  slug: string,
+  version: string,
+  activeVersion: string | null,
+): Promise<EdgeFunctionVersionRecord | null> {
+  const versionDir = getFunctionVersionDir(ref, slug, version);
+  try {
+    if (!(await fs.lstat(versionDir)).isDirectory()) return null;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  const bundlePath = await getVersionedArtifactPath(ref, slug, version);
+  const sourcePath = getVersionedSrcPath(ref, slug, version);
+  const sourceDirPath = assertInside(versionDir, path.join(versionDir, "src"));
+  const [hasBundle, hasSource, hasSourceDir] = await Promise.all([
+    bundlePath ? fileExists(bundlePath) : Promise.resolve(false),
+    fileExists(sourcePath),
+    fileExists(sourceDirPath),
+  ]);
+  const updatedAt =
+    (await statIso(bundlePath)) ||
+    (await statIso(sourcePath)) ||
+    (await statIso(sourceDirPath)) ||
+    new Date().toISOString();
+
+  return {
+    version,
+    is_active: version === activeVersion,
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    bundle_path: hasBundle ? bundlePath : null,
+    source_path: hasSource ? sourcePath : null,
+    source_dir_path: hasSourceDir ? sourceDirPath : null,
+    has_bundle: hasBundle,
+    has_source: hasSource,
+    has_source_dir: hasSourceDir,
+  };
+}
+
 function parseLegacyVersionedFile(entry: string): { slug: string; version: string; kind: "js" | "src" } | null {
   const jsMatch = entry.match(/^(.*)\.v(\d+)\.js$/);
   if (jsMatch) {
@@ -2618,40 +2659,9 @@ export const edgeFunctionService = {
     const activeVersion = cfg.version ?? null;
     const versions = await listVersionDirectories(ref, slug);
 
-    const records = await Promise.all(
-      versions.map(async (version) => {
-        const versionDir = getFunctionVersionDir(ref, slug, version);
-        const bundlePath = await getVersionedArtifactPath(ref, slug, version);
-        const sourcePath = getVersionedSrcPath(ref, slug, version);
-        const sourceDirPath = assertInside(versionDir, path.join(versionDir, "src"));
-        const [hasBundle, hasSource, hasSourceDir] = await Promise.all([
-          bundlePath ? fileExists(bundlePath) : Promise.resolve(false),
-          fileExists(sourcePath),
-          fileExists(sourceDirPath),
-        ]);
-
-        const updatedAt =
-          (await statIso(bundlePath)) ||
-          (await statIso(sourcePath)) ||
-          (await statIso(sourceDirPath)) ||
-          new Date().toISOString();
-
-        const createdAt = updatedAt;
-
-        return {
-          version,
-          is_active: version === activeVersion,
-          created_at: createdAt,
-          updated_at: updatedAt,
-          bundle_path: hasBundle ? bundlePath : null,
-          source_path: hasSource ? sourcePath : null,
-          source_dir_path: hasSourceDir ? sourceDirPath : null,
-          has_bundle: hasBundle,
-          has_source: hasSource,
-          has_source_dir: hasSourceDir,
-        } satisfies EdgeFunctionVersionRecord;
-      }),
-    );
+    const records = (await Promise.all(
+      versions.map((version) => functionVersionRecord(ref, slug, version, activeVersion)),
+    )).filter((record): record is EdgeFunctionVersionRecord => record !== null);
 
     if (activeVersion !== null) {
       const activeRecord = records.find((record) => record.version === activeVersion);
@@ -2670,9 +2680,13 @@ export const edgeFunctionService = {
     slug: string,
     version: string,
   ): Promise<EdgeFunctionVersionDetail | null> {
-    const versions = await this.listVersions(ref, slug);
-    const record = versions.find((item) => item.version === version);
+    const cfg = await this.getConfig(ref, slug);
+    const activeVersion = cfg.version ?? null;
+    const record = await functionVersionRecord(ref, slug, version, activeVersion);
     if (!record) return null;
+    if (record.is_active && !record.has_bundle) {
+      throw new Error(EDGE_FUNCTION_ACTIVE_ARTIFACT_MISSING_MESSAGE);
+    }
 
     const [bundleCode, sourceCode] = await Promise.all([
       record.has_bundle ? readVersionedFunctionCode(ref, slug, version) : Promise.resolve(null),

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -588,6 +588,55 @@ describe("edgeFunctionService bundle metadata", () => {
     }
   });
 
+  test("reads a valid immutable version without traversing corrupt unrelated history", async () => {
+    const ref = "proj_version_read_isolation";
+    const slug = "isolated-source";
+    globalThis.fetch = runtimeSuccessFetch();
+    const first = await deployConditionalRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('first') };",
+    });
+    const second = await deployConditionalRelease({
+      ref,
+      slug,
+      code: "export default { fetch: () => new Response('second') };",
+    });
+    const firstArtifact = await getVersionedArtifactPath(ref, slug, first.version!);
+    const firstArtifactContent = await readFile(firstArtifact!);
+    await fs.chmod(firstArtifact!, 0o644);
+    try {
+      await Bun.write(firstArtifact!, "corrupt unrelated history");
+
+      await expect(edgeFunctionService.listVersions(ref, slug))
+        .rejects.toThrow("Function version artifact does not match its immutable metadata");
+      await expect(edgeFunctionService.getVersion(ref, slug, first.version!))
+        .rejects.toThrow("Function version artifact does not match its immutable metadata");
+      expect(await edgeFunctionService.getVersion(ref, slug, second.version!)).toMatchObject({
+        version: second.version,
+        is_active: true,
+        source_code: "export default { fetch: () => new Response('second') };",
+      });
+
+      const { projectFunctionsRoutes } = await import("../../src/routes/project-functions");
+      const app = new Elysia().use(projectFunctionsRoutes);
+      const request = (suffix: string) => app.handle(new Request(
+        `http://localhost/v1/projects/${ref}/functions/${slug}/versions${suffix}`,
+        { headers: { Authorization: "Bearer dev-master-token" } },
+      ));
+      expect((await request("")).status).toBe(500);
+      const versionResponse = await request(`/${second.version}`);
+      expect(versionResponse.status).toBe(200);
+      expect(await versionResponse.json()).toMatchObject({
+        version: second.version,
+        source_code: "export default { fetch: () => new Response('second') };",
+      });
+    } finally {
+      await Bun.write(firstArtifact!, firstArtifactContent);
+      await fs.chmod(firstArtifact!, 0o444);
+    }
+  });
+
   test("keeps manifest-less legacy version zero readable without a versioned bundle", async () => {
     const ref = "proj_manifestless_legacy_zero";
     const slug = "legacy-zero";


### PR DESCRIPTION
## Summary

- Read `/versions/:version` directly instead of traversing every historical version.
- Preserve strict full-history validation for `listVersions`.
- Keep active-artifact and immutable SHA checks fail-closed.
- Add service and HTTP route regression coverage for corrupt unrelated history.

## Production evidence

On project `vxmnblbzsxzutzrjntyu`, `fa-provider-adapter` version `69` was valid, while unrelated historical version `61` had an artifact SHA mismatch. The Management API returned HTTP 500 for both `/versions` and `/versions/69` because `getVersion()` called `listVersions()` first. This change isolates the requested version so version `69` remains readable while `/versions` still reports the corruption.

## Validation

- `bun test tests/unit/edge-function.service.bundle-metadata.test.ts tests/unit/edge-function.service.activation.test.ts tests/unit/final-security-regression.test.ts`
- `bun run typecheck`
- `bun run sql:check`
- `git diff --check`

Result: 129 passed, 1 skipped, 0 failed.
