### PR TITLE
fix(management-api): skip migrated function history at startup

### DIFF
--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -1220,7 +1220,6 @@ async function migrateImmutableVersionArtifact(
     if (!isMissingPathError(error)) throw error;
   }
   if (metadata?.artifact_sha256) {
-    await getVersionedArtifactPath(ref, slug, version);
     return false;
   }
   await preflightFunctionMutation(ref, slug);

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -608,6 +608,9 @@ describe("edgeFunctionService bundle metadata", () => {
     try {
       await Bun.write(firstArtifact!, "corrupt unrelated history");
 
+      await expect(migrateLegacyVersionArtifacts()).resolves.toMatchObject({
+        moved: expect.any(Number),
+      });
       await expect(edgeFunctionService.listVersions(ref, slug))
         .rejects.toThrow("Function version artifact does not match its immutable metadata");
       await expect(edgeFunctionService.getVersion(ref, slug, first.version!))


### PR DESCRIPTION
## Problem
A historical immutable Edge Function version with a mismatched artifact causes `migrateLegacyVersionArtifacts()` to fail during Management API startup, taking `supacloud.service` into a restart loop.

## Fix
Startup migration no longer revalidates versions that already have immutable artifact metadata. Explicit version listing and source reads remain strict and continue to report mismatched artifacts.

## Validation
- `bun test tests/unit/edge-function.service.bundle-metadata.test.ts`
- `bun run typecheck`
- `bun run sql:check`
- `git diff --check`

Production incident evidence: `fa-provider-adapter` version 61 had mismatched bytes while active version 69 was valid; version 61 was quarantined without changing version 69.