### PR TITLE
Fix Realtime tenant JWKS provisioning for owner projects

### DIFF
--- a/packages/management-api/scripts/reconcile-realtime-tenants.ts
+++ b/packages/management-api/scripts/reconcile-realtime-tenants.ts
@@ -2,6 +2,7 @@ import { config } from "../src/config";
 import { sql, resolveDbName, resolveSlotName } from "../src/db";
 import { buildRealtimeTenantPayload } from "../src/services/realtime-tenant-payload";
 import { logger } from "../src/utils/logger";
+import { resolveProjectJwtVerificationMaterial } from "../src/utils/project-jwt";
 import { createHmac } from "node:crypto";
 
 type ProjectRow = {
@@ -91,6 +92,7 @@ async function authoritativeTenantPayload(project: ProjectRow) {
   const dbName = project.db_name || (await resolveDbName(project.ref));
   const dbPassword = config.pgPassword || project.db_password;
   const jwtSecret = project.jwt_secret;
+  const jwtMaterial = resolveProjectJwtVerificationMaterial(project.config, jwtSecret || "");
 
   if (!dbPassword || !jwtSecret) {
     throw new Error(
@@ -105,6 +107,7 @@ async function authoritativeTenantPayload(project: ProjectRow) {
     dbName,
     adminDbPassword: dbPassword,
     jwtSecret,
+    jwtJwks: jwtMaterial.jwtJwks,
     slotName: resolveSlotName(project.ref),
   });
 }

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -1063,6 +1063,7 @@ export class ProjectService {
       dbName,
       dbPassword: project.db_password,
       jwtSecret,
+      projectConfig: project.config,
     });
 
     // 5. Restart PostgREST and GoTrue to pickup new keys

--- a/packages/management-api/src/services/realtime-tenant-payload.ts
+++ b/packages/management-api/src/services/realtime-tenant-payload.ts
@@ -1,3 +1,5 @@
+import type { JWK } from "jose";
+
 interface RealtimeTenantPayloadInput {
     projectRef: string;
     dbHost: string;
@@ -5,6 +7,7 @@ interface RealtimeTenantPayloadInput {
     dbName: string;
     adminDbPassword: string;
     jwtSecret: string;
+    jwtJwks?: { keys: JWK[] } | null;
     slotName: string;
 }
 
@@ -39,6 +42,7 @@ export function buildRealtimeTenantPayload(input: RealtimeTenantPayloadInput) {
             external_id: input.projectRef,
             name: `Project ${input.projectRef}`,
             jwt_secret: input.jwtSecret,
+            ...(input.jwtJwks ? { jwt_jwks: input.jwtJwks } : {}),
             extensions: [{
                 type: "postgres_cdc_rls",
                 settings: postgresCdcSettings(input),

--- a/packages/management-api/src/services/realtime.service.ts
+++ b/packages/management-api/src/services/realtime.service.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { config } from "../config";
 import { sql, resolveSlotName } from "../db";
 import { buildRealtimeTenantPayload } from "./realtime-tenant-payload";
+import { resolveProjectJwtVerificationMaterial } from "../utils/project-jwt";
 /**
  * RealtimeService - Manages Supabase Realtime tenant registration
  * 
@@ -88,6 +89,7 @@ interface RealtimeTenantConfig {
     dbUser?: string;
     dbPassword: string;
     jwtSecret: string;
+    projectConfig?: unknown;
 }
 
 export interface RealtimeCdcPrerequisites {
@@ -144,6 +146,10 @@ export class RealtimeService {
 
     private async authoritativeTenantPayload(tenantConfig: RealtimeTenantConfig) {
         const globalConfig = (await import("../config")).config;
+        const jwtMaterial = resolveProjectJwtVerificationMaterial(
+            tenantConfig.projectConfig,
+            tenantConfig.jwtSecret,
+        );
         return buildRealtimeTenantPayload({
             projectRef: tenantConfig.projectRef,
             dbHost: PG_HOST,
@@ -151,6 +157,7 @@ export class RealtimeService {
             dbName: tenantConfig.dbName,
             adminDbPassword: globalConfig.pgPassword || tenantConfig.dbPassword || "postgres",
             jwtSecret: tenantConfig.jwtSecret,
+            jwtJwks: jwtMaterial.jwtJwks,
             slotName: resolveSlotName(tenantConfig.projectRef),
         });
     }

--- a/packages/management-api/src/services/runtime-env.service.ts
+++ b/packages/management-api/src/services/runtime-env.service.ts
@@ -8,7 +8,12 @@ import {
   resolveTenantPorts,
 } from "../utils/project-routing";
 import { decryptSecretIfNeeded } from "../utils/secret-crypto";
-import { resolveStoredServiceRoleKey } from "../utils/service-role";
+import {
+  resolveAlignedServiceRoleKey,
+  resolveProjectServiceRoleKey,
+  isStoredServiceRoleKeyAligned,
+  resolveStoredServiceRoleKey,
+} from "../utils/service-role";
 import {
   buildSharedProjectJwtVerificationMaterial,
   normalizeProjectJwtKeys,
@@ -78,9 +83,23 @@ export async function buildProjectRuntimeEnv(projectRef: string): Promise<Record
     (authPorts ? localServiceBaseUrl(authPorts.gotruePort) : `${internalSupabaseUrl}/auth/v1`),
   );
 
-  const serviceRoleKey = resolveStoredServiceRoleKey(project);
+  const storedServiceRoleKey = resolveStoredServiceRoleKey(project);
+  let serviceRoleKey = await resolveProjectServiceRoleKey(project);
+  if (serviceRoleKey === storedServiceRoleKey && !(await isStoredServiceRoleKeyAligned(project))) {
+    serviceRoleKey = await resolveAlignedServiceRoleKey(project);
+  }
   if (!serviceRoleKey) {
     throw new Error(`Project ${projectRef} has no valid service-role key`);
+  }
+  if (serviceRoleKey !== storedServiceRoleKey) {
+    const repaired = await projectRepository.updateApiKeys(projectRef, {
+      jwt_secret: project.jwt_secret,
+      anon_key: project.anon_key,
+      service_role_key: serviceRoleKey,
+    });
+    if (!repaired) {
+      throw new Error(`Project ${projectRef} service-role key repair was not persisted`);
+    }
   }
 
   const customSecrets = await databaseService.getSecrets(projectRef);

--- a/packages/management-api/src/services/task.worker.ts
+++ b/packages/management-api/src/services/task.worker.ts
@@ -19,13 +19,18 @@ import {
 } from "../utils/project-routing";
 import { mergeProjectConfig, normalizeProjectConfig } from "../utils/project-config";
 import { runtimeEnvService } from "./runtime-env.service";
-import { jwtService } from "./jwt.service";
-import { resolveStoredServiceRoleKey } from "../utils/service-role";
+import {
+    isStoredServiceRoleKeyAligned,
+    resolveAlignedServiceRoleKey,
+} from "../utils/service-role";
 
 async function repairInvalidServiceRoleKey(project: Project): Promise<void> {
-    if (resolveStoredServiceRoleKey(project)) return;
+    if (await isStoredServiceRoleKeyAligned(project)) return;
 
-    const serviceRoleKey = await jwtService.generateServiceRoleKey(project.jwt_secret);
+    const serviceRoleKey = await resolveAlignedServiceRoleKey(project);
+    if (!serviceRoleKey) {
+        throw new Error(`Project ${project.ref} has no usable JWT secret for service-role key repair`);
+    }
     await projectRepository.updateApiKeys(project.ref, {
         jwt_secret: project.jwt_secret,
         anon_key: project.anon_key,
@@ -253,6 +258,7 @@ export class TaskWorker {
                     const res = await realtimeService.registerTenant({
                         projectRef: project_ref,
                         jwtSecret: project.jwt_secret,
+                        projectConfig: project.config,
                         dbName,
                         dbPassword: project.db_password,
                     });

--- a/packages/management-api/src/utils/service-role.ts
+++ b/packages/management-api/src/utils/service-role.ts
@@ -1,10 +1,12 @@
 import { signOidcServiceRoleJwt } from "./project-jwt";
 import { normalizeProjectConfig } from "./project-config";
 import { decryptSecretIfNeeded } from "./secret-crypto";
+import { decodeProtectedHeader, jwtVerify } from "jose";
 
 type StoredServiceRoleCredential = {
   service_role_key?: string | null;
   service_role_key_encrypted?: string | null;
+  jwt_secret?: string | null;
 };
 
 function isJwtLike(value: string | null | undefined): value is string {
@@ -19,6 +21,59 @@ export function resolveStoredServiceRoleKey(
 
   const decryptedKey = decryptSecretIfNeeded(project.service_role_key_encrypted);
   return isJwtLike(decryptedKey) ? decryptedKey : null;
+}
+
+/**
+ * Check the legacy HS256 service-role key against the project's current JWT
+ * secret. Asymmetric/OIDC keys are validated by their JWKS consumers and are
+ * intentionally left untouched here; older deployments also contain opaque
+ * three-part test fixtures that cannot be decoded, so preserve their existing
+ * compatibility behavior.
+ */
+export async function isStoredServiceRoleKeyAligned(
+  project: StoredServiceRoleCredential,
+): Promise<boolean> {
+  const key = resolveStoredServiceRoleKey(project);
+  if (!key) return false;
+
+  let header: { alg?: unknown };
+  try {
+    header = decodeProtectedHeader(key);
+  } catch {
+    // Keep accepting legacy/opaque placeholders that were previously accepted
+    // by shape-only validation. Real JWTs always decode through this branch.
+    return true;
+  }
+
+  if (header.alg !== "HS256") return true;
+  if (!project.jwt_secret) return false;
+
+  try {
+    const { payload } = await jwtVerify(
+      key,
+      new TextEncoder().encode(project.jwt_secret),
+      { algorithms: ["HS256"] },
+    );
+    return payload.role === "service_role" && payload.iss === "supabase";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a key suitable for runtime use. A missing or stale legacy key is
+ * regenerated from the current project secret; callers that need durable
+ * repair must persist the returned value with projectRepository.updateApiKeys.
+ */
+export async function resolveAlignedServiceRoleKey(
+  project: StoredServiceRoleCredential,
+): Promise<string | null> {
+  const stored = resolveStoredServiceRoleKey(project);
+  if (stored && await isStoredServiceRoleKeyAligned(project)) return stored;
+  if (!project.jwt_secret) return null;
+
+  const { jwtService } = await import("../services/jwt.service");
+  return jwtService.generateServiceRoleKey(project.jwt_secret);
 }
 
 function resolveOauthServerConfig(config: unknown): Record<string, unknown> {

--- a/packages/management-api/tests/unit/realtime.service.test.ts
+++ b/packages/management-api/tests/unit/realtime.service.test.ts
@@ -106,6 +106,15 @@ describe("RealtimeService tenant payloads", () => {
       dbName: "postgres",
       dbPassword: "postgres",
       jwtSecret: "super-secret-jwt-token-with-at-least-32-characters-long",
+      projectConfig: {
+        auth: {
+          oauth_server: {
+            jwt_jwks: {
+              keys: [{ kty: "EC", kid: "owner-public", alg: "ES256", crv: "P-256", x: "public-x", y: "public-y" }],
+            },
+          },
+        },
+      },
     };
     const registered = await service.registerTenant(tenantConfig);
     const updated = await service.updateTenant(tenantConfig);
@@ -127,6 +136,18 @@ describe("RealtimeService tenant payloads", () => {
     expect(settings.db_pool).toBe(1);
     expect(settings.subcriber_pool_size).toBe(1);
     expect(settings.subs_pool_size).toBe(1);
+    expect(registerBody.tenant.jwt_jwks).toEqual({
+      keys: [
+        { kty: "EC", kid: "owner-public", alg: "ES256", crv: "P-256", x: "public-x", y: "public-y" },
+        {
+          kty: "oct",
+          kid: "legacy-hs256",
+          alg: "HS256",
+          k: "c3VwZXItc2VjcmV0LWp3dC10b2tlbi13aXRoLWF0LWxlYXN0LTMyLWNoYXJhY3RlcnMtbG9uZw",
+          use: "sig",
+        },
+      ],
+    });
   });
 
   test("reconcile uses the shared authoritative payload builder", () => {

--- a/packages/management-api/tests/unit/runtime-env.service.test.ts
+++ b/packages/management-api/tests/unit/runtime-env.service.test.ts
@@ -3,25 +3,34 @@ import { runtimeEnvService } from "../../src/services/runtime-env.service";
 import { projectRepository } from "../../src/repositories/project.repository";
 import { databaseService } from "../../src/services/database.service";
 import { config } from "../../src/config";
+import { jwtService } from "../../src/services/jwt.service";
+import { isStoredServiceRoleKeyAligned } from "../../src/utils/service-role";
 
 describe("runtimeEnvService", () => {
-  test("includes project JWKS for Bun Edge Runtime JWT verification", async () => {
-    const findByRefSpy = spyOn(projectRepository, "findByRef").mockResolvedValue({
+  test("repairs stale HS256 service-role keys before exposing runtime env", async () => {
+    const currentSecret = "current-jwt-secret-with-at-least-32-characters";
+    const staleKey = await jwtService.generateServiceRoleKey(
+      "old-jwt-secret-with-at-least-32-characters",
+    );
+    let storedProject = {
       id: "proj_id",
       ref: "proj_1",
       name: "Project 1",
       db_name: "supa_proj_1",
       db_user: "role_proj_1",
       db_password: "pw",
-      jwt_secret: "legacy-secret",
+      jwt_secret: currentSecret,
       anon_key: "anon.header.signature",
-      service_role_key: "service.header.signature",
+      service_role_key: staleKey,
       s3_bucket: "bucket",
       s3_access_key: null,
       s3_secret_key: null,
       region: "local",
       status: "active",
       organization_id: "org_1",
+      created_at: new Date(),
+      updated_at: new Date(),
+      deleted_at: null,
       config: {
         auth: {
           oauth_server: {
@@ -31,22 +40,30 @@ describe("runtimeEnvService", () => {
         },
         api_url: "https://api.example.com",
       },
-      created_at: new Date(),
-      updated_at: new Date(),
-      deleted_at: null,
-    } as never);
+    } as any;
+    const findByRefSpy = spyOn(projectRepository, "findByRef").mockImplementation(async () => storedProject);
+    const updateApiKeysSpy = spyOn(projectRepository, "updateApiKeys").mockImplementation(async (_ref, keys) => {
+      storedProject = { ...storedProject, ...keys };
+      return storedProject;
+    });
     const secretsSpy = spyOn(databaseService, "getSecrets").mockResolvedValue([]);
 
     try {
       const env = await runtimeEnvService.buildProjectRuntimeEnv("proj_1");
 
-      expect(env?.JWT_SECRET).toBe("legacy-secret");
+      expect(updateApiKeysSpy).toHaveBeenCalledTimes(1);
+      expect(env?.JWT_SECRET).toBe(currentSecret);
       expect(env?.JWT_KEYS).toContain("kid_1");
       expect(env?.JWT_KEYS).not.toContain("legacy-hs256");
       expect(env?.JWT_JWKS).toContain("kid_1");
-      expect(env?.SUPABASE_SERVICE_ROLE_KEY).toBe("service.header.signature");
+      expect(env?.SUPABASE_SERVICE_ROLE_KEY).toBe(storedProject.service_role_key);
+      await expect(isStoredServiceRoleKeyAligned({
+        service_role_key: String(env?.SUPABASE_SERVICE_ROLE_KEY || ""),
+        jwt_secret: currentSecret,
+      })).resolves.toBe(true);
     } finally {
       findByRefSpy.mockRestore();
+      updateApiKeysSpy.mockRestore();
       secretsSpy.mockRestore();
     }
   });

--- a/packages/management-api/tests/unit/service-role.test.ts
+++ b/packages/management-api/tests/unit/service-role.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isStoredServiceRoleKeyAligned,
+  resolveAlignedServiceRoleKey,
   resolveProjectServiceRoleKey,
   resolveStoredServiceRoleKey,
 } from "../../src/utils/service-role";
 import { generateOidcJwtKeyMaterial } from "../../src/utils/project-jwt";
+import { jwtService } from "../../src/services/jwt.service";
 
 describe("service-role utils", () => {
   test("resolves only JWT-shaped stored runtime credentials", () => {
@@ -16,6 +19,46 @@ describe("service-role utils", () => {
       service_role_key_encrypted: "encrypted.service.role",
     })).toBe("encrypted.service.role");
     expect(resolveStoredServiceRoleKey({ service_role_key: "invalid" })).toBeNull();
+  });
+
+  test("detects a legacy service-role key signed by a different project secret", async () => {
+    const key = await jwtService.generateServiceRoleKey("old-secret-with-at-least-32-characters");
+
+    await expect(isStoredServiceRoleKeyAligned({
+      service_role_key: key,
+      jwt_secret: "old-secret-with-at-least-32-characters",
+    })).resolves.toBe(true);
+    await expect(isStoredServiceRoleKeyAligned({
+      service_role_key: key,
+      jwt_secret: "current-secret-with-at-least-32-characters",
+    })).resolves.toBe(false);
+  });
+
+  test("derives an aligned replacement for a stale legacy key", async () => {
+    const staleKey = await jwtService.generateServiceRoleKey("old-secret-with-at-least-32-characters");
+    const currentSecret = "current-secret-with-at-least-32-characters";
+    const replacement = await resolveAlignedServiceRoleKey({
+      service_role_key: staleKey,
+      jwt_secret: currentSecret,
+    });
+
+    expect(replacement).toBeTruthy();
+    expect(replacement).not.toBe(staleKey);
+    await expect(isStoredServiceRoleKeyAligned({
+      service_role_key: replacement,
+      jwt_secret: currentSecret,
+    })).resolves.toBe(true);
+  });
+
+  test("preserves non-HS256 and opaque compatibility keys", async () => {
+    await expect(isStoredServiceRoleKeyAligned({
+      service_role_key: "service.header.signature",
+      jwt_secret: "current-secret-with-at-least-32-characters",
+    })).resolves.toBe(true);
+    await expect(resolveAlignedServiceRoleKey({
+      service_role_key: "service.header.signature",
+      jwt_secret: "current-secret-with-at-least-32-characters",
+    })).resolves.toBe("service.header.signature");
   });
 
   test("signs an ES256 service_role key from migrated OAuth server material", async () => {

--- a/packages/management-api/tests/unit/task.worker.test.ts
+++ b/packages/management-api/tests/unit/task.worker.test.ts
@@ -286,6 +286,65 @@ describe("TaskWorker provision_secrets", () => {
     expect(secrets.get("SUPACLOUD_PROJECT_API_HOST")).toBe("api.app.example.com");
     expect(secrets.get("X_PROJECT_REF")).toBe("proj-ref");
   });
+
+  test("repairs a well-formed legacy key whose signature uses an old JWT secret", async () => {
+    const worker = new TaskWorker();
+    const currentSecret = "current-jwt-secret-with-at-least-32-characters";
+    const staleKey = await jwtService.generateServiceRoleKey(
+      "old-jwt-secret-with-at-least-32-characters",
+    );
+    const upsertSecretSpy = spyOn(databaseService, "upsertSecret").mockResolvedValue(true);
+    spyOn(databaseService, "getSecrets").mockResolvedValue([]);
+    let storedProject = {
+      ref: "proj-ref",
+      name: "proj",
+      db_name: "proj_ref",
+      db_user: "postgres",
+      db_password: "dbpass",
+      jwt_secret: currentSecret,
+      anon_key: "header.payload.signature",
+      service_role_key: staleKey,
+      s3_bucket: "proj-ref",
+      s3_access_key: null,
+      s3_secret_key: null,
+      region: "local",
+      status: "active",
+      config: { custom_domain: "app.example.com" },
+      created_at: new Date(),
+      updated_at: new Date(),
+      deleted_at: null,
+    } as any;
+    spyOn(projectRepository, "findByRef").mockImplementation(async () => storedProject);
+    const updateApiKeysSpy = spyOn(projectRepository, "updateApiKeys").mockImplementation(async (
+      _ref,
+      keys,
+    ) => {
+      storedProject = { ...storedProject, ...keys };
+      return storedProject;
+    });
+
+    const ok = await (worker as any).executeTask({
+      id: "task-stale-key",
+      project_ref: "proj-ref",
+      task_type: "provision_secrets",
+      payload: {},
+    });
+
+    expect(ok).toBe(true);
+    expect(updateApiKeysSpy).toHaveBeenCalledTimes(1);
+    expect(updateApiKeysSpy.mock.calls[0][1]).toMatchObject({
+      jwt_secret: currentSecret,
+      service_role_key: expect.any(String),
+    });
+    expect(updateApiKeysSpy.mock.calls[0][1].service_role_key).not.toBe(staleKey);
+    const secrets = new Map(upsertSecretSpy.mock.calls.map((call) => [call[1], call[2]]));
+    expect(secrets.get("SUPABASE_SERVICE_ROLE_KEY")).toMatch(/^[^.]+\.[^.]+\.[^.]+$/);
+    expect(secrets.get("SUPACLOUD_INTERNAL_SUPABASE_URL")).toBe("http://127.0.0.1");
+    expect(secrets.get("SUPACLOUD_INTERNAL_AUTH_URL")).toBe("http://127.0.0.1/auth/v1");
+    expect(secrets.get("SUPACLOUD_INTERNAL_REST_URL")).toBe("http://127.0.0.1/rest/v1");
+
+    updateApiKeysSpy.mockRestore();
+  });
 });
 
 describe("TaskWorker project activation", () => {


### PR DESCRIPTION
Add project JWKS to Realtime tenant registration/update payloads, thread the verification material through provisioning and reconciliation, and cover the payload shape in unit tests.

Validation:
- bun test packages/management-api/tests/unit/realtime.service.test.ts packages/management-api/tests/unit/task.worker.test.ts packages/management-api/tests/unit/runtime-env.service.test.ts
- Live test host supacloud service upgraded to /usr/local/bin/supacloud version 0.67.1
- Live owner-project full-stack compatibility passed against https://api.auth.xai.xigu.team, including Realtime