### PR TITLE
feat: add first-class Function capability and limit profiles

### DIFF
--- a/docs/edge-runtime-guide.md
+++ b/docs/edge-runtime-guide.md
@@ -170,6 +170,44 @@ edge_functions scaffold --slug api --framework sveltekit-function --path ./api
 
 ## SDK Compatibility
 
+### Function Manifest v2
+
+Each Function may declare a runtime profile alongside `verify_jwt` and
+`framework`. The profile is persisted with the activation and is rechecked by
+the runtime before dispatch:
+
+```json
+{
+  "framework": "hono",
+  "capabilities": {
+    "secrets": ["STRIPE_SECRET_KEY"],
+    "outbound_hosts": ["api.stripe.com"],
+    "bindings": ["pgredis"],
+    "background": true
+  },
+  "limits": {
+    "timeout_ms": 30000,
+    "max_request_body_bytes": 1048576,
+    "max_response_body_bytes": 4194304,
+    "wait_until_timeout_ms": 60000
+  }
+}
+```
+
+`secrets` is an allow-list for injected tenant secrets. When it is omitted,
+legacy injection behavior is retained; when present, only named secrets are
+injected. `outbound_hosts` restricts HTTPS and HTTP `fetch()` destinations by
+hostname. `bindings` controls optional host bindings such as `pgredis`.
+`background: false` rejects `EdgeRuntime.waitUntil()` for that Function;
+omitting it preserves legacy behavior. Limits are upper-bounded by the host
+policy, so a Function cannot raise the runtime-wide maximum. A timed-out
+`waitUntil` execution retires its worker to prevent leaked tenant state.
+
+This is a host capability and resource contract, not a claim of hard process
+isolation: Functions in the same project still share the configured Worker
+Pool. Use separate runtime processes or systemd/cgroup boundaries when hard
+memory or CPU isolation is required.
+
 The Edge Runtime is fully compatible with `supabase.functions.invoke()`:
 
 ```typescript

--- a/packages/cli/src/shared/tools/advanced-tools.ts
+++ b/packages/cli/src/shared/tools/advanced-tools.ts
@@ -352,6 +352,18 @@ const backgroundRoutesSchema = Type.Optional(decodedSchema(
 ));
 
 const functionFilesRecordSchema = Type.Record(Type.String(), Type.String());
+const functionCapabilitiesSchema = Type.Object({
+    secrets: Type.Optional(Type.Array(Type.String({ minLength: 1 }), { maxItems: 128 })),
+    outbound_hosts: Type.Optional(Type.Array(Type.String({ minLength: 1 }), { maxItems: 128 })),
+    bindings: Type.Optional(Type.Array(Type.String({ minLength: 1 }), { maxItems: 128 })),
+    background: Type.Optional(Type.Boolean()),
+}, { additionalProperties: false });
+const functionLimitsSchema = Type.Object({
+    timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 900_000 })),
+    max_request_body_bytes: Type.Optional(Type.Integer({ minimum: 1, maximum: 30 * 1024 * 1024 })),
+    max_response_body_bytes: Type.Optional(Type.Integer({ minimum: 1, maximum: 30 * 1024 * 1024 })),
+    wait_until_timeout_ms: Type.Optional(Type.Integer({ minimum: 1, maximum: 900_000 })),
+}, { additionalProperties: false });
 
 function parseFunctionFiles(input: string | Record<string, string>): unknown {
     if (typeof input !== "string") return input;
@@ -592,6 +604,10 @@ function confirmedFunctionConfig(payload: unknown, expected: EdgeFunctionConfigI
         if (!Array.isArray(response.background_routes)) return false;
         if (JSON.stringify(response.background_routes) !== JSON.stringify(expected.background_routes)) return false;
     }
+    if (expected.capabilities !== undefined
+        && JSON.stringify(response.capabilities) !== JSON.stringify(expected.capabilities)) return false;
+    if (expected.limits !== undefined
+        && JSON.stringify(response.limits) !== JSON.stringify(expected.limits)) return false;
     return true;
 }
 
@@ -675,6 +691,8 @@ interface ConfirmedFunctionMutation {
     activationId: string;
     verifyJwt: boolean;
     framework?: EdgeFunctionConfigInput["framework"];
+    capabilities?: EdgeFunctionConfigInput["capabilities"];
+    limits?: EdgeFunctionConfigInput["limits"];
 }
 
 function mutationIdentityMatches(
@@ -784,6 +802,8 @@ function confirmedFunctionMutation(
         activationId,
         verifyJwt: config.verify_jwt,
         ...(framework === undefined ? {} : { framework: framework as FunctionFramework }),
+        ...(config.capabilities === undefined ? {} : { capabilities: config.capabilities as EdgeFunctionConfigInput["capabilities"] }),
+        ...(config.limits === undefined ? {} : { limits: config.limits as EdgeFunctionConfigInput["limits"] }),
     };
 }
 
@@ -806,6 +826,8 @@ function functionMutationResponse(
         version: confirmed.activeVersion,
         verify_jwt: confirmed.verifyJwt,
         ...(confirmed.framework === undefined ? {} : { framework: confirmed.framework }),
+        ...(confirmed.capabilities === undefined ? {} : { capabilities: confirmed.capabilities }),
+        ...(confirmed.limits === undefined ? {} : { limits: confirmed.limits }),
     });
 }
 
@@ -915,6 +937,8 @@ Actions: list, get_config, deploy, deploy_bundle, config, source, activate, dele
             verify_jwt: optional(Type.Boolean(), "[deploy/deploy_bundle/config] Set JWT verification for this function"),
             background_routes: withDescription(backgroundRoutesSchema, "[deploy/deploy_bundle/config] Background route paths; pass comma-separated or JSON array in CLI"),
             framework: optional(withDescription(stringEnum(["fetch", "elysia", "hono", "sveltekit-function"]), "[deploy/deploy_bundle/config/scaffold] Fetch framework adapter profile")),
+            capabilities: optional(functionCapabilitiesSchema, "[deploy/deploy_bundle/config] Host capabilities: secrets, outbound_hosts, bindings, background"),
+            limits: optional(functionLimitsSchema, "[deploy/deploy_bundle/config] Execution limits in milliseconds/bytes"),
             "expected-active-version": withDescription(
                 expectedActiveVersionSchema,
                 "[deploy/deploy_bundle/activate] Required current active version, or 'absent' when none exists",
@@ -929,7 +953,7 @@ Actions: list, get_config, deploy, deploy_bundle, config, source, activate, dele
             if (args.action === "scaffold") {
                 return { content: [{ type: "text" as const, text: scaffoldFunction(args.path, args.slug, args.framework) }] };
             }
-            const { action, ref, slug, path: pathArg, output, entrypoint, minify, verify_jwt, background_routes, framework } = args;
+            const { action, ref, slug, path: pathArg, output, entrypoint, minify, verify_jwt, background_routes, framework, capabilities, limits } = args;
             rejectActionSpecificFlags(action, args);
             const expectedActiveVersion = action === "deploy" || action === "deploy_bundle"
                 ? requiredExpectedActiveVersion(args, action)
@@ -946,6 +970,8 @@ Actions: list, get_config, deploy, deploy_bundle, config, source, activate, dele
                 ...(typeof verify_jwt === "boolean" ? { verify_jwt } : {}),
                 ...(Array.isArray(background_routes) ? { background_routes } : {}),
                 ...(typeof framework === "string" ? { framework: framework as EdgeFunctionConfigInput["framework"] } : {}),
+                ...(capabilities === undefined ? {} : { capabilities }),
+                ...(limits === undefined ? {} : { limits }),
             });
 
             const hasFunctionConfig = () => Object.keys(functionConfig()).length > 0;
@@ -1037,7 +1063,7 @@ Actions: list, get_config, deploy, deploy_bundle, config, source, activate, dele
                 case "config":
                     need("slug", slug);
                     if (!hasFunctionConfig()) {
-                        throw new Error("'verify_jwt', 'background_routes', or 'framework' required for 'config'");
+                        throw new Error("'verify_jwt', 'background_routes', 'framework', 'capabilities', or 'limits' required for 'config'");
                     }
                     return updateFunctionConfiguration(http, {
                         projectRef: ref,

--- a/packages/cli/src/shared/tools/edge-function-response.test.ts
+++ b/packages/cli/src/shared/tools/edge-function-response.test.ts
@@ -21,6 +21,8 @@ function configReceipt(overrides: Record<string, unknown> = {}) {
         verify_jwt: false,
         background_routes: ["/queue/*"],
         framework: "hono",
+        capabilities: { background: true },
+        limits: { wait_until_timeout_ms: 5000 },
         ...overrides,
     };
 }
@@ -49,6 +51,8 @@ describe("Edge Function response projection", () => {
             version: 4,
             activation_id: EXPECTED_ACTIVATION_ID,
             verify_jwt: true,
+            capabilities: { outbound_hosts: ["api.example.com"], background: false },
+            limits: { timeout_ms: 5000 },
             private: "list-private-sentinel",
         }]);
         const projectedIdentity = projectedFunctionIdentity({
@@ -59,6 +63,8 @@ describe("Edge Function response projection", () => {
             activation_id: EXPECTED_ACTIVATION_ID,
             verify_jwt: true,
             background_routes: [],
+            capabilities: { secrets: ["API_KEY"] },
+            limits: { max_response_body_bytes: 1024 },
             private: "config-private-sentinel",
         }, "proj", "hook");
 
@@ -67,6 +73,8 @@ describe("Edge Function response projection", () => {
             version: 4,
             activation_id: EXPECTED_ACTIVATION_ID,
             verify_jwt: true,
+            capabilities: { outbound_hosts: ["api.example.com"], background: false },
+            limits: { timeout_ms: 5000 },
         }]);
         expect(projectedIdentity).toEqual({
             project_ref: "proj",
@@ -76,6 +84,8 @@ describe("Edge Function response projection", () => {
             verify_jwt: true,
             background_routes: [],
             version: "4",
+            capabilities: { secrets: ["API_KEY"] },
+            limits: { max_response_body_bytes: 1024 },
         });
         expect(JSON.stringify({ projectedList, projectedIdentity })).not.toContain("sentinel");
     });
@@ -87,7 +97,13 @@ describe("Edge Function response projection", () => {
                 projectRef: "proj",
                 slug: "hook",
                 expectedActivationId: EXPECTED_ACTIVATION_ID,
-                config: { verify_jwt: false, background_routes: ["/queue/*"], framework: "hono" },
+                config: {
+                    verify_jwt: false,
+                    background_routes: ["/queue/*"],
+                    framework: "hono",
+                    capabilities: { background: true },
+                    limits: { wait_until_timeout_ms: 5000 },
+                },
             },
         );
 
@@ -99,6 +115,8 @@ describe("Edge Function response projection", () => {
             verify_jwt: false,
             background_routes: ["/queue/*"],
             framework: "hono",
+            capabilities: { background: true },
+            limits: { wait_until_timeout_ms: 5000 },
         });
         expect(JSON.stringify(confirmed)).not.toContain("sentinel");
     });

--- a/packages/cli/src/shared/tools/edge-function-response.ts
+++ b/packages/cli/src/shared/tools/edge-function-response.ts
@@ -4,6 +4,18 @@ const ACTIVATION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][
 const LEGACY_ACTIVATION_ID = "legacy";
 const FUNCTION_FRAMEWORKS = ["fetch", "elysia", "hono", "sveltekit-function"] as const;
 type FunctionFramework = typeof FUNCTION_FRAMEWORKS[number];
+type FunctionCapabilities = {
+    secrets?: string[];
+    outbound_hosts?: string[];
+    bindings?: string[];
+    background?: boolean;
+};
+type FunctionLimits = {
+    timeout_ms?: number;
+    max_request_body_bytes?: number;
+    max_response_body_bytes?: number;
+    wait_until_timeout_ms?: number;
+};
 const LIST_STRING_FIELDS = [
     "id",
     "name",
@@ -19,6 +31,8 @@ export type FunctionConfigInput = {
     verify_jwt?: boolean;
     background_routes?: string[];
     framework?: FunctionFramework;
+    capabilities?: FunctionCapabilities;
+    limits?: FunctionLimits;
 };
 
 export type FunctionIdentityResponse = {
@@ -32,6 +46,8 @@ export type FunctionIdentityResponse = {
     version?: string;
     import_map?: string;
     entrypoint?: string;
+    capabilities?: FunctionCapabilities;
+    limits?: FunctionLimits;
 };
 
 export type FunctionConfigMutationExpectation = {
@@ -61,6 +77,41 @@ function canonicalVersion(candidate: unknown): candidate is string {
 
 function stringRoutes(candidate: unknown): candidate is string[] {
     return Array.isArray(candidate) && candidate.every((route) => typeof route === "string");
+}
+
+export function projectedFunctionCapabilities(candidate: unknown): FunctionCapabilities | null {
+    const record = objectRecord(candidate);
+    if (!record) return null;
+    const projected: FunctionCapabilities = {};
+    for (const field of ["secrets", "outbound_hosts", "bindings"] as const) {
+        if (record[field] !== undefined && (!Array.isArray(record[field])
+            || record[field].some((entry) => typeof entry !== "string"))) return null;
+        if (record[field] !== undefined) projected[field] = record[field] as string[];
+    }
+    if (record.background !== undefined && typeof record.background !== "boolean") return null;
+    if (typeof record.background === "boolean") projected.background = record.background;
+    return projected;
+}
+
+export function projectedFunctionLimits(candidate: unknown): FunctionLimits | null {
+    const record = objectRecord(candidate);
+    if (!record) return null;
+    const projected: FunctionLimits = {};
+    const maxima: Record<keyof FunctionLimits, number> = {
+        timeout_ms: 900_000,
+        max_request_body_bytes: 30 * 1024 * 1024,
+        max_response_body_bytes: 30 * 1024 * 1024,
+        wait_until_timeout_ms: 900_000,
+    };
+    for (const field of Object.keys(maxima) as Array<keyof FunctionLimits>) {
+        const value = record[field];
+        if (value === undefined) continue;
+        if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1 || value > maxima[field]) {
+            return null;
+        }
+        projected[field] = value;
+    }
+    return projected;
 }
 
 function optionalTypedFields(
@@ -95,6 +146,13 @@ function projectedFunctionListEntry(candidate: unknown): Record<string, unknown>
             && !FUNCTION_FRAMEWORKS.includes(functionRecord.framework as FunctionFramework))
         || (functionRecord.background_routes !== undefined
             && !stringRoutes(functionRecord.background_routes))) return null;
+    const capabilities = functionRecord.capabilities === undefined
+        ? undefined
+        : projectedFunctionCapabilities(functionRecord.capabilities);
+    const limits = functionRecord.limits === undefined
+        ? undefined
+        : projectedFunctionLimits(functionRecord.limits);
+    if (capabilities === null || limits === null) return null;
     const projected: Record<string, unknown> = {
         slug: functionRecord.slug,
         version: functionRecord.version,
@@ -106,6 +164,8 @@ function projectedFunctionListEntry(candidate: unknown): Record<string, unknown>
     if (functionRecord.background_routes !== undefined) {
         projected.background_routes = functionRecord.background_routes;
     }
+    if (capabilities !== undefined) projected.capabilities = capabilities;
+    if (limits !== undefined) projected.limits = limits;
     return projected;
 }
 
@@ -161,6 +221,13 @@ export function projectedFunctionIdentity(
         || !coherentFunctionVersion(response.active_version as string, optionalFields.version)) return null;
     const framework = response.framework;
     if (framework !== undefined && !FUNCTION_FRAMEWORKS.includes(framework as FunctionFramework)) return null;
+    const capabilities = response.capabilities === undefined
+        ? undefined
+        : projectedFunctionCapabilities(response.capabilities);
+    const limits = response.limits === undefined
+        ? undefined
+        : projectedFunctionLimits(response.limits);
+    if (capabilities === null || limits === null) return null;
     return {
         project_ref: expectedProjectRef,
         slug: expectedSlug,
@@ -169,6 +236,8 @@ export function projectedFunctionIdentity(
         background_routes: response.background_routes,
         ...(framework === undefined ? {} : { framework: framework as FunctionFramework }),
         ...optionalFields,
+        ...(capabilities === undefined ? {} : { capabilities }),
+        ...(limits === undefined ? {} : { limits }),
         activation_id: response.activation_id,
     };
 }
@@ -195,6 +264,8 @@ function configMatchesExpectation(
     if (response.framework !== undefined && !FUNCTION_FRAMEWORKS.includes(response.framework as FunctionFramework)) return false;
     if (expected.verify_jwt !== undefined && response.verify_jwt !== expected.verify_jwt) return false;
     if (expected.framework !== undefined && response.framework !== expected.framework) return false;
+    if (expected.capabilities !== undefined && JSON.stringify(response.capabilities) !== JSON.stringify(expected.capabilities)) return false;
+    if (expected.limits !== undefined && JSON.stringify(response.limits) !== JSON.stringify(expected.limits)) return false;
     return expected.background_routes === undefined
         || JSON.stringify(response.background_routes) === JSON.stringify(expected.background_routes);
 }
@@ -207,6 +278,13 @@ export function confirmedFunctionConfigMutation(
     if (!response
         || !mutationIdentityMatches(response, expectation)
         || !configMatchesExpectation(response, expectation.config)) return null;
+    const capabilities = response.capabilities === undefined
+        ? undefined
+        : projectedFunctionCapabilities(response.capabilities);
+    const limits = response.limits === undefined
+        ? undefined
+        : projectedFunctionLimits(response.limits);
+    if (capabilities === null || limits === null) return null;
     const optionalFields = optionalConfigFields(response);
     if (!optionalFields) return null;
     return {
@@ -218,6 +296,8 @@ export function confirmedFunctionConfigMutation(
         background_routes: response.background_routes,
         ...(response.framework === undefined ? {} : { framework: response.framework as FunctionFramework }),
         ...optionalFields,
+        ...(capabilities === undefined ? {} : { capabilities }),
+        ...(limits === undefined ? {} : { limits }),
     };
 }
 

--- a/packages/edge-runtime/function-activation.test.ts
+++ b/packages/edge-runtime/function-activation.test.ts
@@ -65,4 +65,10 @@ describe("Edge Function capability and limit profiles", () => {
     expect(() => parseEdgeFunctionActivationManifest(JSON.stringify({ limits: { timeout_ms: 0 } })))
       .toThrow("invalid limits.timeout_ms");
   });
+
+  test("rejects system-managed secrets in capability profiles", () => {
+    expect(() => parseEdgeFunctionActivationManifest(JSON.stringify({
+      capabilities: { secrets: ["SUPABASE_SERVICE_ROLE_KEY"] },
+    }))).toThrow("reserved capabilities.secrets");
+  });
 });

--- a/packages/edge-runtime/function-activation.test.ts
+++ b/packages/edge-runtime/function-activation.test.ts
@@ -37,3 +37,32 @@ describe("Edge Function framework profiles", () => {
       .toThrow("unsupported framework");
   });
 });
+
+describe("Edge Function capability and limit profiles", () => {
+  test("defaults omitted capability and limit profiles to empty objects", () => {
+    const config = parseEdgeFunctionActivationManifest('{"verify_jwt":true,"version":"1"}').config;
+    expect(config.capabilities).toEqual({});
+    expect(config.limits).toEqual({});
+  });
+
+  test("preserves declared capability and limit profiles", () => {
+    const config = parseEdgeFunctionActivationManifest(JSON.stringify({
+      version: "2",
+      capabilities: { secrets: ["A"], outbound_hosts: ["api.example.com"], bindings: ["pgredis"] },
+      limits: { timeout_ms: 5000, max_request_body_bytes: 1024 },
+    })).config;
+    expect(config.capabilities).toEqual({
+      secrets: ["A"],
+      outbound_hosts: ["api.example.com"],
+      bindings: ["pgredis"],
+    });
+    expect(config.limits).toEqual({ timeout_ms: 5000, max_request_body_bytes: 1024 });
+  });
+
+  test("rejects malformed capability and limit profiles", () => {
+    expect(() => parseEdgeFunctionActivationManifest(JSON.stringify({ capabilities: { secrets: [1] } })))
+      .toThrow("invalid capabilities.secrets");
+    expect(() => parseEdgeFunctionActivationManifest(JSON.stringify({ limits: { timeout_ms: 0 } })))
+      .toThrow("invalid limits.timeout_ms");
+  });
+});

--- a/packages/edge-runtime/function-activation.ts
+++ b/packages/edge-runtime/function-activation.ts
@@ -8,6 +8,9 @@ const ACTIVATION_ID_PATTERN = /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][
 const FUNCTION_SLUG_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
 const VERSION_PATTERN = /^(?:0|[1-9]\d*)$/;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const MAX_FUNCTION_TIMEOUT_MS = 900_000;
+const MAX_FUNCTION_BODY_BYTES = 30 * 1024 * 1024;
+const MAX_WAIT_UNTIL_TIMEOUT_MS = 900_000;
 const AUTHORITY_KEYS = [
   "activation_generation",
   "activation_id",
@@ -30,6 +33,18 @@ export type EdgeFunctionActivationConfig = {
   verify_jwt: boolean;
   framework: "fetch" | "elysia" | "hono" | "sveltekit-function";
   version: string | null;
+  capabilities: {
+    secrets?: string[];
+    outbound_hosts?: string[];
+    bindings?: string[];
+    background?: boolean;
+  };
+  limits: {
+    timeout_ms?: number;
+    max_request_body_bytes?: number;
+    max_response_body_bytes?: number;
+    wait_until_timeout_ms?: number;
+  };
 };
 
 export type EdgeFunctionActivationManifest = {
@@ -110,6 +125,56 @@ function parseConfig(document: Record<string, unknown>): EdgeFunctionActivationC
     verify_jwt: document.verify_jwt !== false,
     framework,
     version: rawVersion ?? null,
+    capabilities: parseCapabilities(document.capabilities),
+    limits: parseLimits(document.limits),
+  };
+}
+
+function parseCapabilities(value: unknown): EdgeFunctionActivationConfig["capabilities"] {
+  if (value === undefined) return {};
+  if (!isPlainRecord(value)) throw new Error("Function activation config contains invalid capabilities");
+  const strings = (candidate: unknown): string[] | undefined => Array.isArray(candidate)
+    && candidate.length <= 128
+    && candidate.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+      ? candidate as string[]
+      : undefined;
+  for (const key of ["secrets", "outbound_hosts", "bindings"] as const) {
+    if (value[key] !== undefined && !strings(value[key])) {
+      throw new Error(`Function activation config contains invalid capabilities.${key}`);
+    }
+  }
+  if (value.background !== undefined && typeof value.background !== "boolean") {
+    throw new Error("Function activation config contains invalid capabilities.background");
+  }
+  return {
+    ...(strings(value.secrets) ? { secrets: strings(value.secrets) } : {}),
+    ...(strings(value.outbound_hosts) ? { outbound_hosts: strings(value.outbound_hosts) } : {}),
+    ...(strings(value.bindings) ? { bindings: strings(value.bindings) } : {}),
+    ...(typeof value.background === "boolean" ? { background: value.background } : {}),
+  };
+}
+
+function parseLimits(value: unknown): EdgeFunctionActivationConfig["limits"] {
+  if (value === undefined) return {};
+  if (!isPlainRecord(value)) throw new Error("Function activation config contains invalid limits");
+  const maxima = {
+    timeout_ms: MAX_FUNCTION_TIMEOUT_MS,
+    max_request_body_bytes: MAX_FUNCTION_BODY_BYTES,
+    max_response_body_bytes: MAX_FUNCTION_BODY_BYTES,
+    wait_until_timeout_ms: MAX_WAIT_UNTIL_TIMEOUT_MS,
+  } as const;
+  const positive = (candidate: unknown, max: number): candidate is number =>
+    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0 && candidate <= max;
+  for (const key of Object.keys(maxima) as Array<keyof typeof maxima>) {
+    if (value[key] !== undefined && !positive(value[key], maxima[key])) {
+      throw new Error(`Function activation config contains invalid limits.${key}`);
+    }
+  }
+  return {
+    ...(positive(value.timeout_ms, maxima.timeout_ms) ? { timeout_ms: value.timeout_ms } : {}),
+    ...(positive(value.max_request_body_bytes, maxima.max_request_body_bytes) ? { max_request_body_bytes: value.max_request_body_bytes } : {}),
+    ...(positive(value.max_response_body_bytes, maxima.max_response_body_bytes) ? { max_response_body_bytes: value.max_response_body_bytes } : {}),
+    ...(positive(value.wait_until_timeout_ms, maxima.wait_until_timeout_ms) ? { wait_until_timeout_ms: value.wait_until_timeout_ms } : {}),
   };
 }
 

--- a/packages/edge-runtime/function-activation.ts
+++ b/packages/edge-runtime/function-activation.ts
@@ -143,11 +143,25 @@ function parseCapabilities(value: unknown): EdgeFunctionActivationConfig["capabi
       throw new Error(`Function activation config contains invalid capabilities.${key}`);
     }
   }
+  const secrets = strings(value.secrets);
+  if (secrets?.some((name) => {
+    const normalized = name.trim().toUpperCase();
+    return normalized === "JWT_SECRET"
+      || normalized === "JWT_KEYS"
+      || normalized === "JWT_JWKS"
+      || normalized === "X_PROJECT_REF"
+      || normalized.startsWith("SUPABASE_")
+      || normalized.startsWith("SUPACLOUD_")
+      || normalized.startsWith("SUPAOAUTH_")
+      || normalized.startsWith("ADMIN_SSO_");
+  })) {
+    throw new Error("Function activation config contains reserved capabilities.secrets");
+  }
   if (value.background !== undefined && typeof value.background !== "boolean") {
     throw new Error("Function activation config contains invalid capabilities.background");
   }
   return {
-    ...(strings(value.secrets) ? { secrets: strings(value.secrets) } : {}),
+    ...(secrets ? { secrets } : {}),
     ...(strings(value.outbound_hosts) ? { outbound_hosts: strings(value.outbound_hosts) } : {}),
     ...(strings(value.bindings) ? { bindings: strings(value.bindings) } : {}),
     ...(typeof value.background === "boolean" ? { background: value.background } : {}),

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -931,6 +931,19 @@ function functionCapabilities(value: unknown): FunctionCapabilities {
   const secrets = list("secrets");
   const outboundHosts = list("outbound_hosts");
   const bindings = list("bindings");
+  if (secrets?.some((name) => {
+    const normalized = name.trim().toUpperCase();
+    return normalized === "JWT_SECRET"
+      || normalized === "JWT_KEYS"
+      || normalized === "JWT_JWKS"
+      || normalized === "X_PROJECT_REF"
+      || normalized.startsWith("SUPABASE_")
+      || normalized.startsWith("SUPACLOUD_")
+      || normalized.startsWith("SUPAOAUTH_")
+      || normalized.startsWith("ADMIN_SSO_");
+  })) {
+    throw new Error("Function activation capabilities.secrets contains a reserved system secret");
+  }
   return {
     ...(secrets ? { secrets } : {}),
     ...(outboundHosts ? { outbound_hosts: outboundHosts } : {}),

--- a/packages/edge-runtime/server.ts
+++ b/packages/edge-runtime/server.ts
@@ -361,6 +361,8 @@ type FunctionActivationSnapshot = {
   responseVersion: string | null;
   verifyJwt: boolean;
   framework: "fetch" | "elysia" | "hono" | "sveltekit-function";
+  capabilities: FunctionCapabilities;
+  limits: FunctionLimits;
   moduleVersion: string;
   artifactSha256: string;
   activationId: string | null;
@@ -479,6 +481,8 @@ async function resolvedFunctionPath(
       responseVersion,
       verifyJwt: resolvedConfig.verify_jwt,
       framework: resolvedConfig.framework,
+      capabilities: resolvedConfig.capabilities,
+      limits: resolvedConfig.limits,
       artifactSha256: artifact.sha256,
       activationId: resolvedConfig.activationId,
       authorityKind: resolvedConfig.authorityKind,
@@ -574,7 +578,14 @@ async function dispatchFunction(
     const functionId = `${projectRef}_${functionName}${versionSuffix}`;
     const targetPool = opts?.background ? backgroundPool : pool;
     const tenantEnvLoad = opts?.tenantEnvLoad || await loadTenantRuntimeEnv(projectRef);
-    const dispatchEnv = opts?.tenantEnv || tenantEnvLoad.env;
+    const completeDispatchEnv = opts?.tenantEnv || tenantEnvLoad.env;
+    const dispatchEnv = activation.capabilities.secrets === undefined
+      ? completeDispatchEnv
+      : Object.fromEntries(
+          activation.capabilities.secrets
+            .filter((name) => Object.hasOwn(completeDispatchEnv, name))
+            .map((name) => [name, completeDispatchEnv[name]]),
+        );
     const executionProfile = opts?.background ? "background" : "foreground";
     const moduleEnvProof = tenantEnvModuleProof(
       projectRef,
@@ -601,8 +612,12 @@ async function dispatchFunction(
       projectRoot,
       projectRef,
       framework: activation.framework,
+      capabilities: activation.capabilities,
+      limits: activation.limits,
       functionVersion: responseVersion,
       internalBindings: PGREDIS_RUNTIME_ENDPOINT
+        && (activation.capabilities.bindings === undefined
+          || activation.capabilities.bindings.includes("pgredis"))
         ? {
             baseUrl: PGREDIS_RUNTIME_ENDPOINT.baseUrl,
             capabilityToken: createPgredisCapability(PGREDIS_RUNTIME_ENDPOINT.signingSecret, {
@@ -700,6 +715,22 @@ type FunctionConfig = {
   targetState: "active" | "absent" | null;
   artifactSha256: string | null;
   authorityKind: "active" | "historical" | "legacy";
+  capabilities: FunctionCapabilities;
+  limits: FunctionLimits;
+};
+
+type FunctionCapabilities = {
+  secrets?: string[];
+  outbound_hosts?: string[];
+  bindings?: string[];
+  background?: boolean;
+};
+
+type FunctionLimits = {
+  timeout_ms?: number;
+  max_request_body_bytes?: number;
+  max_response_body_bytes?: number;
+  wait_until_timeout_ms?: number;
 };
 
 type ActivationPoolControl = Awaited<ReturnType<WorkerPool["invalidateProject"]>>;
@@ -745,6 +776,8 @@ async function getFunctionConfig(
     return {
       verify_jwt: cached.verify_jwt,
       framework: cached.framework,
+      capabilities: cached.capabilities,
+      limits: cached.limits,
       version: cached.version,
       activationId: cached.activationId,
       targetState: cached.targetState,
@@ -767,6 +800,8 @@ async function getFunctionConfig(
         targetState: null,
         artifactSha256: null,
         authorityKind: "legacy" as const,
+        capabilities: {},
+        limits: {},
       }
     : {
         verify_jwt: manifest.config.verify_jwt,
@@ -780,6 +815,8 @@ async function getFunctionConfig(
         targetState: manifest.authority?.target_state ?? null,
         artifactSha256: manifest.authority?.artifact_sha256 ?? null,
         authorityKind: manifest.authority === null ? "legacy" as const : "active" as const,
+        capabilities: functionCapabilities(manifest.config.capabilities),
+        limits: functionLimits(manifest.config.limits),
       };
   configCache.set(key, { ...config, expiresAt: Date.now() + CONFIG_CACHE_TTL });
   return config;
@@ -820,6 +857,8 @@ async function immutableVersionConfig(
     targetState: "active",
     artifactSha256: record.artifact_sha256,
     authorityKind: "historical",
+    capabilities: functionCapabilities(record.capabilities),
+    limits: functionLimits(record.limits),
   };
 }
 
@@ -841,6 +880,8 @@ async function assertDispatchAuthorityCurrent(
     || current.version !== activation.activeVersion
     || current.verify_jwt !== activation.verifyJwt
     || current.framework !== activation.framework
+    || JSON.stringify(current.capabilities) !== JSON.stringify(activation.capabilities)
+    || JSON.stringify(current.limits) !== JSON.stringify(activation.limits)
     || current.targetState !== "active"
     || current.artifactSha256 !== activation.artifactSha256) {
     configCache.delete(`${projectRef}/${functionName}`);
@@ -865,6 +906,57 @@ async function activeFunctionConfig(
     targetState: manifest.authority?.target_state ?? null,
     artifactSha256: manifest.authority?.artifact_sha256 ?? null,
     authorityKind: manifest.authority === null ? "legacy" : "active",
+    capabilities: functionCapabilities(manifest.config.capabilities),
+    limits: functionLimits(manifest.config.limits),
+  };
+}
+
+function functionCapabilities(value: unknown): FunctionCapabilities {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Function activation capabilities must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const list = (field: string): string[] | undefined => {
+    const candidate = record[field];
+    if (candidate === undefined) return undefined;
+    if (!Array.isArray(candidate) || candidate.some((entry) => typeof entry !== "string")) {
+      throw new Error(`Function activation capabilities.${field} is invalid`);
+    }
+    return candidate as string[];
+  };
+  if (record.background !== undefined && typeof record.background !== "boolean") {
+    throw new Error("Function activation capabilities.background is invalid");
+  }
+  const secrets = list("secrets");
+  const outboundHosts = list("outbound_hosts");
+  const bindings = list("bindings");
+  return {
+    ...(secrets ? { secrets } : {}),
+    ...(outboundHosts ? { outbound_hosts: outboundHosts } : {}),
+    ...(bindings ? { bindings } : {}),
+    ...(typeof record.background === "boolean" ? { background: record.background } : {}),
+  };
+}
+
+function functionLimits(value: unknown): FunctionLimits {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Function activation limits must be an object");
+  }
+  const record = value as Record<string, unknown>;
+  const integer = (candidate: unknown): candidate is number =>
+    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0;
+  for (const field of ["timeout_ms", "max_request_body_bytes", "max_response_body_bytes", "wait_until_timeout_ms"]) {
+    if (record[field] !== undefined && !integer(record[field])) {
+      throw new Error(`Function activation limits.${field} is invalid`);
+    }
+  }
+  return {
+    ...(integer(record.timeout_ms) ? { timeout_ms: record.timeout_ms } : {}),
+    ...(integer(record.max_request_body_bytes) ? { max_request_body_bytes: record.max_request_body_bytes } : {}),
+    ...(integer(record.max_response_body_bytes) ? { max_response_body_bytes: record.max_response_body_bytes } : {}),
+    ...(integer(record.wait_until_timeout_ms) ? { wait_until_timeout_ms: record.wait_until_timeout_ms } : {}),
   };
 }
 

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -95,6 +95,18 @@ type ExecuteMessage = Omit<PreheatMessage, "type"> & {
   body?: ArrayBuffer | null;
   internalBindings?: Omit<PgredisRuntimeBindingConfig, "signal">;
   framework?: "fetch" | "elysia" | "hono" | "sveltekit-function";
+  capabilities?: {
+    secrets?: string[];
+    outbound_hosts?: string[];
+    bindings?: string[];
+    background?: boolean;
+  };
+  limits?: {
+    timeout_ms?: number;
+    max_request_body_bytes?: number;
+    max_response_body_bytes?: number;
+    wait_until_timeout_ms?: number;
+  };
 };
 type ParentMessage =
   | InvalidateModuleMessage
@@ -423,10 +435,13 @@ function runCleanup(cleanup: () => void): void {
   }
 }
 
-function setupEdgeRuntimeCompat() {
+function setupEdgeRuntimeCompat(backgroundAllowed = true) {
   currentWaitUntilTasks = [];
   (globalThis as any).EdgeRuntime = {
     waitUntil(promise: PromiseLike<unknown> | unknown) {
+      if (!backgroundAllowed) {
+        throw new Error("EdgeRuntime.waitUntil is not enabled by the Function capability policy");
+      }
       const task = Promise.resolve(promise).catch((error) => {
         console.error("[EdgeRuntime.waitUntil] background task failed", error);
       });
@@ -640,6 +655,29 @@ function postToParent(message: unknown) {
   parentPort!.postMessage(message);
 }
 
+function installOutboundHostPolicy(allowedHosts: string[] | undefined): () => void {
+  if (allowedHosts === undefined) return () => {};
+  const originalFetch = globalThis.fetch;
+  const allowed = new Set(allowedHosts.map((host) => host.toLowerCase()));
+  globalThis.fetch = ((input, init) => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.href : input.url);
+    if (!allowed.has(url.hostname.toLowerCase())) {
+      throw new Error(`Outbound host is not allowed by Function capability policy: ${url.hostname}`);
+    }
+    return originalFetch(input, init);
+  }) as typeof globalThis.fetch;
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+class FunctionResponseLimitError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Function response exceeded the configured limit of ${maxBytes} bytes`);
+    this.name = "FunctionResponseLimitError";
+  }
+}
+
 async function onParentMessage(msg: unknown): Promise<void> {
   if (!isParentMessage(msg)) {
     console.warn("[Worker] Ignoring invalid parent message");
@@ -738,16 +776,18 @@ async function onParentMessage(msg: unknown): Promise<void> {
   const requestAbortController = new AbortController();
   currentAbortController = requestAbortController;
   let restoreFetchTlsPolicy = () => {};
+  let restoreOutboundHostPolicy = () => {};
 
   try {
     setProjectRoot(projectRoot || path.dirname(functionPath));
     injectEnv(env);
     setInjectedEnv(env);
     setupConsoleCapture(functionId);
-    setupEdgeRuntimeCompat();
+    setupEdgeRuntimeCompat(msg.capabilities?.background !== false);
     restoreFetchTlsPolicy = installEdgeFetchTlsPolicy(
       await resolveMessageTlsPolicy(tlsPolicy),
     );
+    restoreOutboundHostPolicy = installOutboundHostPolicy(msg.capabilities?.outbound_hosts);
     const moduleLoad = await loadModule({
       functionId,
       functionPath,
@@ -787,6 +827,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
         });
 
         const response = await executeFunction(handler, req);
+        const maxResponseBody = msg.limits?.max_response_body_bytes;
 
         if (
           response.body &&
@@ -804,6 +845,7 @@ async function onParentMessage(msg: unknown): Promise<void> {
 
           try {
             const reader = response.body.getReader();
+            let responseBytes = 0;
             while (true) {
               const { done, value } = await reader.read();
               if (done) {
@@ -813,6 +855,11 @@ async function onParentMessage(msg: unknown): Promise<void> {
                   done: true,
                 });
                 break;
+              }
+              responseBytes += value.byteLength;
+              if (maxResponseBody !== undefined && responseBytes > maxResponseBody) {
+                await reader.cancel();
+                throw new FunctionResponseLimitError(maxResponseBody);
               }
               postToParent({
                 type: "stream_chunk",
@@ -836,6 +883,9 @@ async function onParentMessage(msg: unknown): Promise<void> {
         const resBody = response.body
           ? Buffer.from(await response.arrayBuffer()).buffer
           : null;
+        if (maxResponseBody !== undefined && resBody && resBody.byteLength > maxResponseBody) {
+          throw new FunctionResponseLimitError(maxResponseBody);
+        }
 
         const resHeaders: Record<string, string | string[]> = {};
         response.headers.forEach((v, k) => {
@@ -863,13 +913,14 @@ async function onParentMessage(msg: unknown): Promise<void> {
     const aborted = currentAbortController?.signal.aborted || err?.name === "AbortError";
     const message = err instanceof Error ? err.message : String(err);
     postToParent({
-      status: aborted ? 499 : 500,
+      status: aborted ? 499 : err instanceof FunctionResponseLimitError ? 502 : 500,
       headers: { "Content-Type": "application/json" },
       body: Buffer.from(
         JSON.stringify({ error: message, name: err.name }),
       ).buffer,
     });
   } finally {
+    runCleanup(restoreOutboundHostPolicy);
     runCleanup(restoreFetchTlsPolicy);
     currentAbortController = null;
     runCleanup(clearEdgeRuntimeCompat);

--- a/packages/edge-runtime/worker-pool.test.ts
+++ b/packages/edge-runtime/worker-pool.test.ts
@@ -290,6 +290,67 @@ describe("WorkerPool EdgeRuntime.waitUntil", () => {
       await rm(projectRoot, { recursive: true, force: true });
     }
   });
+
+  test("rejects waitUntil when background execution is explicitly disabled", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-waituntil-disabled-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default async () => {
+        try {
+          EdgeRuntime.waitUntil(Promise.resolve());
+          return new Response("unexpected");
+        } catch (error) {
+          return new Response(error instanceof Error ? error.message : String(error), { status: 400 });
+        }
+      }
+    `);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_waituntil_disabled",
+        projectRef: "test-project",
+        functionPath,
+        projectRoot,
+        env: {},
+        capabilities: { background: false },
+        request: new Request("http://edge.local/functions/v1/waituntil-disabled"),
+      });
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("not enabled by the Function capability policy");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("applies the function waitUntil timeout limit", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-waituntil-limit-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default async () => {
+        EdgeRuntime.waitUntil(new Promise((resolve) => setTimeout(resolve, 2_000)));
+        return new Response("queued", { status: 202 });
+      }
+    `);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 5_000 });
+    pools.push(pool);
+    try {
+      const response = await pool.dispatch({
+        functionId: "proj_waituntil_limit",
+        projectRef: "test-project",
+        functionPath,
+        projectRoot,
+        env: {},
+        limits: { wait_until_timeout_ms: 25 },
+        request: new Request("http://edge.local/functions/v1/waituntil-limit"),
+      });
+      expect(response.status).toBe(202);
+      await Bun.sleep(100);
+      expect(pool.snapshotMetrics("waituntil_limit")["waituntil_limit_total_worker_retirements"]).toBe(1);
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("WorkerPool subprocess guard", () => {
@@ -3669,6 +3730,82 @@ describe("WorkerPool module cache", () => {
 });
 
 describe("WorkerPool body size limit", () => {
+  test("enforces per-function request and response limits", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-function-limits-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default {
+        async fetch(request) {
+          if (new URL(request.url).pathname.endsWith("/response")) return new Response("12345");
+          return new Response("ok");
+        }
+      }
+    `);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    try {
+      const request = new Request("http://edge.local/functions/v1/test", {
+        method: "POST",
+        body: "12345",
+      });
+      const requestResult = await pool.dispatch({
+        functionId: "test_function_limits_request",
+        projectRef: "test-project",
+        functionPath,
+        projectRoot,
+        env: {},
+        limits: { max_request_body_bytes: 4 },
+        request,
+      });
+      expect(requestResult.status).toBe(413);
+
+      const responseResult = await pool.dispatch({
+        functionId: "test_function_limits_response",
+        projectRef: "test-project",
+        functionPath,
+        projectRoot,
+        env: {},
+        limits: { max_response_body_bytes: 4 },
+        request: new Request("http://edge.local/functions/v1/test/response"),
+      });
+      expect(responseResult.status).toBe(502);
+      expect(await responseResult.json()).toMatchObject({ name: "FunctionResponseLimitError" });
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("enforces outbound host capability", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-function-capability-"));
+    const functionPath = join(projectRoot, "fn.ts");
+    await Bun.write(functionPath, `
+      export default async () => {
+        try {
+          await fetch("https://blocked.example.com/");
+          return new Response("unexpected");
+        } catch (error) {
+          return new Response(error instanceof Error ? error.message : String(error));
+        }
+      }
+    `);
+    const pool = new WorkerPool({ size: 1, requestTimeout: 2_000 });
+    pools.push(pool);
+    try {
+      const result = await pool.dispatch({
+        functionId: "test_function_capability",
+        projectRef: "test-project",
+        functionPath,
+        projectRoot,
+        env: {},
+        capabilities: { outbound_hosts: ["allowed.example.com"] },
+        request: new Request("http://edge.local/functions/v1/test"),
+      });
+      expect(await result.text()).toContain("Outbound host is not allowed");
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   test("rejects request with content-length exceeding default limit (30MB)", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "supacloud-body-limit-"));
     const functionPath = join(projectRoot, "fn.ts");

--- a/packages/edge-runtime/worker-pool.ts
+++ b/packages/edge-runtime/worker-pool.ts
@@ -20,6 +20,18 @@ interface DispatchOptions {
   projectRoot: string;
   projectRef: string;
   framework?: "fetch" | "elysia" | "hono" | "sveltekit-function";
+  capabilities?: {
+    secrets?: string[];
+    outbound_hosts?: string[];
+    bindings?: string[];
+    background?: boolean;
+  };
+  limits?: {
+    timeout_ms?: number;
+    max_request_body_bytes?: number;
+    max_response_body_bytes?: number;
+    wait_until_timeout_ms?: number;
+  };
   functionVersion?: string | null;
   moduleVersion?: string;
   envProof?: string;
@@ -59,6 +71,12 @@ function resolveMaxBodySizeBytes(value = process.env.EDGE_MAX_BODY_SIZE_MB): num
     ? configuredMb
     : DEFAULT_MAX_BODY_SIZE_MB;
   return maxBodySizeMb * 1024 * 1024;
+}
+
+function formatBodyLimit(bytes: number): string {
+  return bytes % (1024 * 1024) === 0
+    ? `${bytes / (1024 * 1024)}MB`
+    : `${bytes} bytes`;
 }
 
 const MAX_BODY_SIZE = resolveMaxBodySizeBytes();
@@ -574,7 +592,7 @@ export class WorkerPool {
       clearCancellationState();
       resolveOnce(new Response("Gateway Timeout", { status: 504 }));
       this.retireWorker(worker);
-    }, this.config.requestTimeout);
+    }, Math.min(this.config.requestTimeout, opts.limits?.timeout_ms ?? this.config.requestTimeout));
 
     const replaceCancelledWorker = () => {
       detachResponseListeners();
@@ -635,12 +653,13 @@ export class WorkerPool {
     let body: ArrayBuffer | null = null;
     if (opts.request.body && !["GET", "HEAD"].includes(opts.request.method)) {
       const contentLength = opts.request.headers.get("content-length");
-      if (contentLength && parseInt(contentLength) > MAX_BODY_SIZE) {
+      const maxRequestBody = Math.min(MAX_BODY_SIZE, opts.limits?.max_request_body_bytes ?? MAX_BODY_SIZE);
+      if (contentLength && parseInt(contentLength) > maxRequestBody) {
         releaseBeforeExecution();
         resolveOnce(
           new Response(
             JSON.stringify({
-              error: `Request body too large (max ${MAX_BODY_SIZE / 1024 / 1024}MB)`,
+              error: `Request body too large (max ${formatBodyLimit(maxRequestBody)})`,
             }),
             {
               status: 413,
@@ -658,12 +677,12 @@ export class WorkerPool {
         throw error;
       }
       if (finishCancelledBeforeExecution()) return;
-      if (body.byteLength > MAX_BODY_SIZE) {
+      if (body.byteLength > maxRequestBody) {
         releaseBeforeExecution();
         resolveOnce(
           new Response(
             JSON.stringify({
-              error: `Request body too large (max ${MAX_BODY_SIZE / 1024 / 1024}MB)`,
+              error: `Request body too large (max ${formatBodyLimit(maxRequestBody)})`,
             }),
             {
               status: 413,
@@ -756,7 +775,7 @@ export class WorkerPool {
           clearCancellationState();
           console.error("[Pool] EdgeRuntime.waitUntil timed out; replacing worker");
           this.retireWorker(worker);
-        }, WAIT_UNTIL_TIMEOUT_MS);
+        }, Math.min(WAIT_UNTIL_TIMEOUT_MS, opts.limits?.wait_until_timeout_ms ?? WAIT_UNTIL_TIMEOUT_MS));
       } else {
         worker.removeListener("message", onMsg);
       }
@@ -887,6 +906,8 @@ export class WorkerPool {
         projectRoot: opts.projectRoot,
         projectRef: opts.projectRef,
         framework: opts.framework,
+        capabilities: opts.capabilities,
+        limits: opts.limits,
         moduleVersion: opts.moduleVersion,
         envProof: opts.envProof,
         artifactSha256: opts.artifactSha256,

--- a/packages/management-api/src/routes/project-functions.ts
+++ b/packages/management-api/src/routes/project-functions.ts
@@ -12,6 +12,8 @@ import {
   type EdgeFunctionActivationId,
   type EdgeFunctionActiveVersion,
   type EdgeFunctionConfigSnapshot,
+  type EdgeFunctionCapabilities,
+  type EdgeFunctionLimits,
   type EdgeFunctionDeploymentConfig,
   type EdgeFunctionDeployResult,
   EDGE_FUNCTION_FRAMEWORKS,
@@ -35,6 +37,18 @@ const expectedActivationIdSchema = t.Union([
     maxLength: 36,
   }),
 ]);
+const functionCapabilitiesSchema = t.Object({
+  secrets: t.Optional(t.Array(t.String({ minLength: 1 }), { maxItems: 128 })),
+  outbound_hosts: t.Optional(t.Array(t.String({ minLength: 1 }), { maxItems: 128 })),
+  bindings: t.Optional(t.Array(t.String({ minLength: 1 }), { maxItems: 128 })),
+  background: t.Optional(t.Boolean()),
+}, { additionalProperties: false });
+const functionLimitsSchema = t.Object({
+  timeout_ms: t.Optional(t.Integer({ minimum: 1, maximum: 900_000 })),
+  max_request_body_bytes: t.Optional(t.Integer({ minimum: 1, maximum: 30 * 1024 * 1024 })),
+  max_response_body_bytes: t.Optional(t.Integer({ minimum: 1, maximum: 30 * 1024 * 1024 })),
+  wait_until_timeout_ms: t.Optional(t.Integer({ minimum: 1, maximum: 900_000 })),
+}, { additionalProperties: false });
 
 async function requireFunctionManagementAuth(request: Request, ref: string) {
   const authError = await requireProjectOrAdminAuth(request, ref);
@@ -66,11 +80,15 @@ function deploymentConfig(
   verifyJwt: boolean | undefined,
   backgroundRoutes: string[] | undefined,
   framework: EdgeFunctionFramework | undefined,
+  capabilities?: EdgeFunctionCapabilities,
+  limits?: EdgeFunctionLimits,
 ): EdgeFunctionDeploymentConfig {
   return {
     ...(typeof verifyJwt === "boolean" ? { verify_jwt: verifyJwt } : {}),
     ...(backgroundRoutes ? { background_routes: backgroundRoutes } : {}),
     ...(framework ? { framework } : {}),
+    ...(capabilities ? { capabilities } : {}),
+    ...(limits ? { limits } : {}),
   };
 }
 
@@ -82,6 +100,8 @@ function functionConfigProjection(config: EdgeFunctionConfigSnapshot) {
     ...(config.version === undefined ? {} : { version: config.version }),
     ...(config.import_map === undefined ? {} : { import_map: config.import_map }),
     ...(config.entrypoint === undefined ? {} : { entrypoint: config.entrypoint }),
+    ...(config.capabilities === undefined ? {} : { capabilities: config.capabilities }),
+    ...(config.limits === undefined ? {} : { limits: config.limits }),
   };
 }
 
@@ -242,6 +262,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt?: boolean;
         background_routes?: string[];
         framework?: EdgeFunctionFramework;
+        capabilities?: EdgeFunctionCapabilities;
+        limits?: EdgeFunctionLimits;
         name?: string;
         expected_active_version?: string;
         expected_activation_id?: string;
@@ -309,7 +331,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         expectedActivationId: expectedId,
         files: fileMap,
         entrypoint,
-        config: deploymentConfig(metadata.verify_jwt, backgroundRoutes, framework),
+        config: deploymentConfig(metadata.verify_jwt, backgroundRoutes, framework, metadata.capabilities, metadata.limits),
       });
       const failure = deploymentFailure(deployment);
       if (failure) return failure;
@@ -337,6 +359,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         framework: funcConfig.framework ?? "fetch",
+        capabilities: funcConfig.capabilities ?? {},
+        limits: funcConfig.limits ?? {},
         entrypoint_path: entrypoint,
         import_map: deployment.import_map != null || !!metadata.import_map_path,
         import_map_path: deployment.import_map ?? metadata.import_map_path ?? null,
@@ -411,7 +435,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           expectedActiveVersion: expectedVersion,
           expectedActivationId: expectedId,
           code,
-          config: deploymentConfig(verifyJwt, backgroundRoutes, framework),
+          config: deploymentConfig(verifyJwt, backgroundRoutes, framework, body?.capabilities, body?.limits),
         });
         const failure = deploymentFailure(deployResult);
         if (failure) return failure;
@@ -455,6 +479,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         framework: funcConfig.framework ?? "fetch",
+        capabilities: funcConfig.capabilities ?? {},
+        limits: funcConfig.limits ?? {},
         status: version === null ? "INACTIVE" : "ACTIVE",
         created_at: now,
         updated_at: now,
@@ -480,6 +506,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           import_map_path: t.Optional(t.String()),
           background_routes: t.Optional(t.Array(t.String())),
           framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+          capabilities: t.Optional(functionCapabilitiesSchema),
+          limits: t.Optional(functionLimitsSchema),
           expected_activation_id: t.Optional(expectedActivationIdSchema),
         },
         { additionalProperties: true },
@@ -493,6 +521,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           verify_jwt: t.Optional(t.Boolean()),
           background_routes: t.Optional(t.Array(t.String())),
           framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+          capabilities: t.Optional(functionCapabilitiesSchema),
+          limits: t.Optional(functionLimitsSchema),
           expected_active_version: t.Optional(expectedActiveVersionSchema),
           expected_activation_id: t.Optional(expectedActivationIdSchema),
         }),
@@ -515,6 +545,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt?: boolean;
         background_routes?: string[];
         framework?: EdgeFunctionFramework;
+        capabilities?: EdgeFunctionCapabilities;
+        limits?: EdgeFunctionLimits;
         expected_active_version: EdgeFunctionActiveVersion;
         expected_activation_id: EdgeFunctionActivationId;
       }>;
@@ -544,6 +576,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
             fn.verify_jwt,
             normalizedBackgroundRoutes(fn.background_routes),
             fn.framework,
+            fn.capabilities,
+            fn.limits,
           ),
         });
 
@@ -560,6 +594,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           activation_id: deployResult.activation_id ?? deployResult.config?.activation_id,
           verify_jwt: deployResult.config?.verify_jwt,
           background_routes: deployResult.config?.background_routes || [],
+          capabilities: deployResult.config?.capabilities ?? {},
+          limits: deployResult.config?.limits ?? {},
           updated_at: now,
         });
       }
@@ -582,6 +618,9 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           code: t.Optional(t.String()),
           verify_jwt: t.Optional(t.Boolean()),
           background_routes: t.Optional(t.Array(t.String())),
+          framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+          capabilities: t.Optional(functionCapabilitiesSchema),
+          limits: t.Optional(functionLimitsSchema),
           expected_active_version: expectedActiveVersionSchema,
           expected_activation_id: expectedActivationIdSchema,
         }),
@@ -853,6 +892,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           body.verify_jwt,
           normalizedBackgroundRoutes(body.background_routes),
           body.framework,
+          body.capabilities,
+          body.limits,
         ),
       });
       const failure = deploymentFailure(deployment);
@@ -875,6 +916,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: deployment.config?.verify_jwt ?? true,
         background_routes: deployment.config?.background_routes || [],
         framework: deployment.config?.framework ?? "fetch",
+        capabilities: deployment.config?.capabilities ?? {},
+        limits: deployment.config?.limits ?? {},
         config: deployment.config,
       };
     },
@@ -893,6 +936,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
         framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+        capabilities: t.Optional(functionCapabilitiesSchema),
+        limits: t.Optional(functionLimitsSchema),
         expected_active_version: expectedActiveVersionSchema,
         expected_activation_id: expectedActivationIdSchema,
       }),
@@ -923,6 +968,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         body.verify_jwt,
         normalizedBackgroundRoutes(body.background_routes),
         framework,
+        body.capabilities,
+        body.limits,
       );
       const expectedId = expectedActivationId(body.expected_activation_id);
       if (expectedId === null) return invalidExpectedActivationId();
@@ -981,6 +1028,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: funcConfig.verify_jwt,
         background_routes: funcConfig.background_routes || [],
         framework: funcConfig.framework ?? "fetch",
+        capabilities: funcConfig.capabilities ?? {},
+        limits: funcConfig.limits ?? {},
         bundle_hash: deployResult?.bundle_hash ?? null,
         bundle_size_bytes: deployResult?.bundle_size_bytes ?? null,
         import_count: deployResult?.import_count ?? null,
@@ -999,6 +1048,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
         framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+        capabilities: t.Optional(functionCapabilitiesSchema),
+        limits: t.Optional(functionLimitsSchema),
         expected_active_version: t.Optional(expectedActiveVersionSchema),
         expected_activation_id: expectedActivationIdSchema,
       }),
@@ -1027,6 +1078,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
           body.verify_jwt,
           normalizedBackgroundRoutes(body.background_routes),
           body.framework,
+          body.capabilities,
+          body.limits,
         ),
       });
       const failure = deploymentFailure(deployment);
@@ -1051,6 +1104,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: deployment.config?.verify_jwt ?? true,
         background_routes: deployment.config?.background_routes || [],
         framework: deployment.config?.framework ?? "fetch",
+        capabilities: deployment.config?.capabilities ?? {},
+        limits: deployment.config?.limits ?? {},
         config: deployment.config,
       };
     },
@@ -1063,6 +1118,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
         framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+        capabilities: t.Optional(functionCapabilitiesSchema),
+        limits: t.Optional(functionLimitsSchema),
         expected_active_version: expectedActiveVersionSchema,
         expected_activation_id: expectedActivationIdSchema,
       }),
@@ -1217,7 +1274,7 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         const updated = await edgeFunctionService.updateConfig(
           params.ref,
           params.slug,
-          deploymentConfig(body.verify_jwt, body.background_routes, body.framework),
+          deploymentConfig(body.verify_jwt, body.background_routes, body.framework, body.capabilities, body.limits),
           expectedId,
         );
         return {
@@ -1240,6 +1297,8 @@ export const projectFunctionsRoutes = new Elysia({ prefix: "/v1/projects" })
         verify_jwt: t.Optional(t.Boolean()),
         background_routes: t.Optional(t.Array(t.String())),
         framework: t.Optional(t.Union(EDGE_FUNCTION_FRAMEWORKS.map((value) => t.Literal(value)))),
+        capabilities: t.Optional(functionCapabilitiesSchema),
+        limits: t.Optional(functionLimitsSchema),
         expected_activation_id: expectedActivationIdSchema,
       }),
       detail: { tags: ["frontend"], summary: "Update function configuration" },

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -32,6 +32,23 @@ export interface EdgeFunctionConfig {
   entrypoint?: string;
   version?: string;
   background_routes?: string[];
+  /** Explicit host capabilities and enforceable execution limits. */
+  capabilities?: EdgeFunctionCapabilities;
+  limits?: EdgeFunctionLimits;
+}
+
+export interface EdgeFunctionCapabilities {
+  secrets?: string[];
+  outbound_hosts?: string[];
+  bindings?: string[];
+  background?: boolean;
+}
+
+export interface EdgeFunctionLimits {
+  timeout_ms?: number;
+  max_request_body_bytes?: number;
+  max_response_body_bytes?: number;
+  wait_until_timeout_ms?: number;
 }
 
 export const EDGE_FUNCTION_FRAMEWORKS = [
@@ -109,7 +126,7 @@ export interface EdgeFunctionActivationResult {
 
 export type EdgeFunctionDeploymentConfig = Pick<
   Partial<EdgeFunctionConfig>,
-  "verify_jwt" | "background_routes" | "framework"
+  "verify_jwt" | "background_routes" | "framework" | "capabilities" | "limits"
 >;
 
 type EdgeFunctionReleaseBase = {
@@ -536,7 +553,94 @@ function validatedFunctionConfig(
   if (functionConfig.version !== undefined) {
     functionConfig.version = canonicalFunctionVersion(functionConfig.version);
   }
+  if (functionConfig.capabilities !== undefined) {
+    functionConfig.capabilities = validatedFunctionCapabilities(functionConfig.capabilities);
+  }
+  if (functionConfig.limits !== undefined) {
+    functionConfig.limits = validatedFunctionLimits(functionConfig.limits);
+  }
   return functionConfig;
+}
+
+const MAX_FUNCTION_TIMEOUT_MS = 900_000;
+const MAX_FUNCTION_BODY_BYTES = 30 * 1024 * 1024;
+const MAX_WAIT_UNTIL_TIMEOUT_MS = 900_000;
+const FUNCTION_HOST_PATTERN = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/i;
+
+function validatedStringList(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.length > 128
+    || value.some((entry) => typeof entry !== "string" || entry.trim().length === 0)) {
+    throw new Error(`Function config contains invalid ${field}`);
+  }
+  return [...new Set(value.map((entry) => entry.trim()))];
+}
+
+function validatedFunctionCapabilities(value: unknown): EdgeFunctionCapabilities {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Function config contains invalid capabilities");
+  }
+  const record = value as Record<string, unknown>;
+  const capabilities: EdgeFunctionCapabilities = {};
+  if (record.secrets !== undefined) {
+    capabilities.secrets = validatedStringList(record.secrets, "capabilities.secrets");
+  }
+  if (record.outbound_hosts !== undefined) {
+    const hosts = validatedStringList(record.outbound_hosts, "capabilities.outbound_hosts");
+    if (hosts.some((host) => !FUNCTION_HOST_PATTERN.test(host))) {
+      throw new Error("Function config contains invalid capabilities.outbound_hosts");
+    }
+    capabilities.outbound_hosts = hosts.map((host) => host.toLowerCase());
+  }
+  if (record.bindings !== undefined) {
+    capabilities.bindings = validatedStringList(record.bindings, "capabilities.bindings");
+  }
+  if (record.background !== undefined) {
+    if (typeof record.background !== "boolean") {
+      throw new Error("Function config contains invalid capabilities.background");
+    }
+    capabilities.background = record.background;
+  }
+  return capabilities;
+}
+
+function validatedPositiveLimit(value: unknown, field: string, max: number): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1 || value > max) {
+    throw new Error(`Function config contains invalid ${field}`);
+  }
+  return value;
+}
+
+function validatedFunctionLimits(value: unknown): EdgeFunctionLimits {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Function config contains invalid limits");
+  }
+  const record = value as Record<string, unknown>;
+  const limits: EdgeFunctionLimits = {};
+  if (record.timeout_ms !== undefined) {
+    limits.timeout_ms = validatedPositiveLimit(record.timeout_ms, "limits.timeout_ms", MAX_FUNCTION_TIMEOUT_MS);
+  }
+  if (record.max_request_body_bytes !== undefined) {
+    limits.max_request_body_bytes = validatedPositiveLimit(
+      record.max_request_body_bytes,
+      "limits.max_request_body_bytes",
+      MAX_FUNCTION_BODY_BYTES,
+    );
+  }
+  if (record.max_response_body_bytes !== undefined) {
+    limits.max_response_body_bytes = validatedPositiveLimit(
+      record.max_response_body_bytes,
+      "limits.max_response_body_bytes",
+      MAX_FUNCTION_BODY_BYTES,
+    );
+  }
+  if (record.wait_until_timeout_ms !== undefined) {
+    limits.wait_until_timeout_ms = validatedPositiveLimit(
+      record.wait_until_timeout_ms,
+      "limits.wait_until_timeout_ms",
+      MAX_WAIT_UNTIL_TIMEOUT_MS,
+    );
+  }
+  return limits;
 }
 
 type FunctionManifestState = {
@@ -759,6 +863,8 @@ type FunctionVersionMetadata = {
   import_map: string | null;
   entrypoint: string | null;
   framework: EdgeFunctionFramework;
+  capabilities?: EdgeFunctionCapabilities;
+  limits?: EdgeFunctionLimits;
 };
 
 type PreparedFunctionRelease = {
@@ -982,6 +1088,8 @@ function functionVersionMetadata(
     import_map: functionConfig.import_map ?? null,
     entrypoint: functionConfig.entrypoint ?? null,
     framework,
+    ...(functionConfig.capabilities ? { capabilities: functionConfig.capabilities } : {}),
+    ...(functionConfig.limits ? { limits: functionConfig.limits } : {}),
   };
 }
 
@@ -1092,6 +1200,12 @@ async function readFunctionVersionMetadata(
     import_map: nullableMetadataPath(metadataRecord, "import_map"),
     entrypoint: nullableMetadataPath(metadataRecord, "entrypoint"),
     framework: metadataRecord.framework === undefined ? "fetch" : metadataRecord.framework as EdgeFunctionFramework,
+    ...(metadataRecord.capabilities === undefined
+      ? {}
+      : { capabilities: validatedFunctionCapabilities(metadataRecord.capabilities) }),
+    ...(metadataRecord.limits === undefined
+      ? {}
+      : { limits: validatedFunctionLimits(metadataRecord.limits) }),
   };
   if (!EDGE_FUNCTION_FRAMEWORKS.includes(metadata.framework)) {
     throw new Error("Function version metadata contains an unsupported framework");
@@ -2101,6 +2215,8 @@ function restoredFunctionConfig(
     version: metadata.version,
     framework: metadata.framework,
   };
+  if (metadata.capabilities) restored.capabilities = metadata.capabilities;
+  if (metadata.limits) restored.limits = metadata.limits;
   if (metadata.import_map === null) delete restored.import_map;
   else restored.import_map = metadata.import_map;
   if (metadata.entrypoint === null) delete restored.entrypoint;

--- a/packages/management-api/src/services/edge-function.service.ts
+++ b/packages/management-api/src/services/edge-function.service.ts
@@ -6,6 +6,7 @@ import path from "path";
 import fs from "fs/promises";
 import type { Dirent } from "node:fs";
 import { acquireSupaCloudUpgradeLock, type SupaCloudUpgradeLock } from "../upgrade-lock";
+import { isSystemManagedProjectSecretName } from "../utils/project-secret-visibility";
 import {
   validateEdgeRuntimePreheat,
   type ExpectedEdgeRuntimePreheat,
@@ -582,7 +583,11 @@ function validatedFunctionCapabilities(value: unknown): EdgeFunctionCapabilities
   const record = value as Record<string, unknown>;
   const capabilities: EdgeFunctionCapabilities = {};
   if (record.secrets !== undefined) {
-    capabilities.secrets = validatedStringList(record.secrets, "capabilities.secrets");
+    const secrets = validatedStringList(record.secrets, "capabilities.secrets");
+    if (secrets.some((name) => isSystemManagedProjectSecretName(name))) {
+      throw new Error("Function config contains reserved capabilities.secrets");
+    }
+    capabilities.secrets = secrets;
   }
   if (record.outbound_hosts !== undefined) {
     const hosts = validatedStringList(record.outbound_hosts, "capabilities.outbound_hosts");

--- a/packages/management-api/src/services/project.service.ts
+++ b/packages/management-api/src/services/project.service.ts
@@ -13,6 +13,8 @@ import {
   type EdgeFunctionActivationId,
   type EdgeFunctionActivationResult,
   type EdgeFunctionDeploymentRequest,
+  type EdgeFunctionCapabilities,
+  type EdgeFunctionLimits,
 } from "./edge-function.service";
 import { logger } from "../utils/logger";
 import { config } from "../config";
@@ -129,6 +131,8 @@ export interface FunctionResponse {
   verify_jwt: boolean;
   framework: "fetch" | "elysia" | "hono" | "sveltekit-function";
   background_routes?: string[];
+  capabilities?: EdgeFunctionCapabilities;
+  limits?: EdgeFunctionLimits;
   import_map: boolean;
   entrypoint_path: string;
   created_at: string;
@@ -870,6 +874,8 @@ export class ProjectService {
         verify_jwt: cfg.verify_jwt,
         framework: cfg.framework ?? "fetch",
         background_routes: cfg.background_routes || [],
+        capabilities: cfg.capabilities ?? {},
+        limits: cfg.limits ?? {},
         import_map: !!cfg.import_map,
         entrypoint_path: `file:///home/deno/functions/${slug}/index.ts`,
         created_at,

--- a/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
+++ b/packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts
@@ -1244,20 +1244,60 @@ describe("edgeFunctionService bundle metadata", () => {
     expect(deployed.config).toMatchObject({ verify_jwt: true, version: "1" });
   });
 
-  test("persists and restores the selected framework profile", async () => {
+  test("persists and restores the selected framework, capability, and limit profiles", async () => {
     const ref = "proj_framework_profile";
     const slug = "svelte-api";
     const deployed = await deployConditionalRelease({
       ref,
       slug,
       code: "export default { fetch: () => new Response('api') };",
-      config: { framework: "sveltekit-function" },
+      config: {
+        framework: "sveltekit-function",
+        capabilities: {
+          secrets: ["API_KEY"],
+          outbound_hosts: ["api.example.com"],
+          bindings: ["pgredis"],
+          background: true,
+        },
+        limits: {
+          timeout_ms: 10_000,
+          max_request_body_bytes: 1_048_576,
+          max_response_body_bytes: 2_097_152,
+          wait_until_timeout_ms: 20_000,
+        },
+      },
     });
 
-    expect(deployed.config).toMatchObject({ framework: "sveltekit-function" });
+    expect(deployed.config).toMatchObject({
+      framework: "sveltekit-function",
+      capabilities: {
+        secrets: ["API_KEY"],
+        outbound_hosts: ["api.example.com"],
+        bindings: ["pgredis"],
+        background: true,
+      },
+      limits: {
+        timeout_ms: 10_000,
+        max_request_body_bytes: 1_048_576,
+        max_response_body_bytes: 2_097_152,
+        wait_until_timeout_ms: 20_000,
+      },
+    });
     expect(JSON.parse(await readFile(join(functionsRoot, ref, ".versions", slug, "1", ".supacloud-version.json"), "utf8")))
       .toMatchObject({ framework: "sveltekit-function" });
     expect((await edgeFunctionService.getConfig(ref, slug)).framework).toBe("sveltekit-function");
+    expect((await edgeFunctionService.getConfig(ref, slug)).capabilities).toEqual({
+      secrets: ["API_KEY"],
+      outbound_hosts: ["api.example.com"],
+      bindings: ["pgredis"],
+      background: true,
+    });
+    expect((await edgeFunctionService.getConfig(ref, slug)).limits).toEqual({
+      timeout_ms: 10_000,
+      max_request_body_bytes: 1_048_576,
+      max_response_body_bytes: 2_097_152,
+      wait_until_timeout_ms: 20_000,
+    });
   });
 
   test("snapshots frozen legacy aliases before first deploy and restores version zero", async () => {


### PR DESCRIPTION
## Summary
- add Function Manifest v2 capability and limit profiles
- persist and restore profiles through deploy, activation, rollback, Management API, and CLI
- enforce secret allow-lists, outbound host allow-lists, optional bindings, body limits, execution limits, and waitUntil policy
- fail closed on malformed manifests and document the runtime contract

## Validation
- `bun test packages/edge-runtime/*.test.ts`
- `bun test packages/management-api/tests/unit/edge-function.service.activation.test.ts packages/management-api/tests/unit/edge-function.service.bundle-metadata.test.ts`
- `bun test packages/cli/src/shared/tools/advanced-tools.test.ts packages/cli/src/shared/tools/edge-function-response.test.ts`
- Edge Runtime, Management API, and CLI typecheck
- `git diff --check`

No WASM or production deployment is included.
