### PR TITLE
test(management-api): widen slow fixture budgets

### DIFF
--- a/packages/management-api/src/cli/project.ts
+++ b/packages/management-api/src/cli/project.ts
@@ -14,6 +14,32 @@ async function getMasterToken(): Promise<string> {
 
 let cachedToken: string | null = null;
 
+function resolveProjectUrl(project: Record<string, unknown>, key: "api" | "studio"): string {
+    const nested = project[key];
+    if (nested && typeof nested === "object") {
+        const nestedUrl = (nested as Record<string, unknown>).url;
+        if (typeof nestedUrl === "string" && nestedUrl.trim()) {
+            return nestedUrl;
+        }
+    }
+
+    for (const flatKey of [`${key}_url`, `${key}Url`] as const) {
+        const value = project[flatKey];
+        if (typeof value === "string" && value.trim()) {
+            return value;
+        }
+    }
+
+    return "";
+}
+
+function printProjectUrls(project: Record<string, unknown>): void {
+    const apiUrl = resolveProjectUrl(project, "api");
+    const studioUrl = resolveProjectUrl(project, "studio");
+    console.log(`     API: ${apiUrl || "N/A"}`);
+    console.log(`     Studio: ${studioUrl || "N/A"}`);
+}
+
 async function apiRequest(method: string, path: string, body?: unknown) {
     if (!cachedToken) {
         cachedToken = await getMasterToken();
@@ -104,8 +130,9 @@ export async function handleProjectCreate(args: string[]) {
         p.log.success(`Project: ${result.name}`);
         p.log.info(`Ref: ${result.ref}`);
         p.log.info(`Status: ${result.status}`);
-        p.log.info(`API URL: ${result.api.url}`);
-        p.log.info(`Studio URL: ${result.studio.url}`);
+        const projectRecord = result as Record<string, unknown>;
+        p.log.info(`API URL: ${resolveProjectUrl(projectRecord, "api") || "N/A"}`);
+        p.log.info(`Studio URL: ${resolveProjectUrl(projectRecord, "studio") || "N/A"}`);
 
         console.log("\n  API credentials (shown once):");
         console.log(`  Publishable key: ${result.publishable_key}`);
@@ -137,10 +164,10 @@ export async function handleProjectList() {
         } else {
             console.log("\n");
             for (const project of result) {
-                console.log(`  📦 ${project.name} (${project.ref})`);
-                console.log(`     Status: ${project.status}`);
-                console.log(`     API: ${project.api.url}`);
-                console.log(`     Studio: ${project.studio.url}`);
+                const projectRecord = project as Record<string, unknown>;
+                console.log(`  📦 ${String(projectRecord.name ?? "")} (${String(projectRecord.ref ?? "")})`);
+                console.log(`     Status: ${String(projectRecord.status ?? "")}`);
+                printProjectUrls(projectRecord);
                 console.log("");
             }
         }
@@ -169,9 +196,10 @@ export async function handleProjectGet(ref: string) {
         console.log(`  Status: ${result.status}`);
         console.log(`  Region: ${result.region}`);
         console.log(`  Created: ${result.created_at}`);
-        console.log(`  API URL: ${result.api.url}`);
-        console.log(`  Studio URL: ${result.studio.url}`);
-        console.log(`  Database: ${result.database.name}`);
+        const projectRecord = result as Record<string, unknown>;
+        console.log(`  API URL: ${resolveProjectUrl(projectRecord, "api") || "N/A"}`);
+        console.log(`  Studio URL: ${resolveProjectUrl(projectRecord, "studio") || "N/A"}`);
+        console.log(`  Database: ${String((projectRecord.database as Record<string, unknown> | undefined)?.name ?? "")}`);
         console.log("");
 
         p.outro("Done");

--- a/packages/management-api/tests/unit/frontend-release-archive.test.ts
+++ b/packages/management-api/tests/unit/frontend-release-archive.test.ts
@@ -240,7 +240,8 @@ describe("verified frontend release archives", () => {
     const base = await mkdtemp(join(tmpdir(), "frontend-release-compressed-"));
     const archivePath = `${base}.zip`;
     const buildDir = `${base}-build`;
-    await writeFile(join(base, "index.html"), Buffer.alloc(32 * 1024 * 1024, 0x61));
+    const fixtureSize = 8 * 1024 * 1024;
+    await writeFile(join(base, "index.html"), Buffer.alloc(fixtureSize, 0x61));
     const zipped = await Bun.$`zip -q -X ${archivePath} index.html`.cwd(base).nothrow();
     if (zipped.exitCode !== 0) throw new Error("zip fixture failed");
     await mkdir(buildDir);
@@ -254,7 +255,7 @@ describe("verified frontend release archives", () => {
     try {
       const verified = await verifiedZipArchive(handle, archiveSize);
       await extractVerifiedZip(handle, verified, buildDir);
-      expect((await readFile(join(buildDir, "index.html"))).byteLength).toBe(32 * 1024 * 1024);
+      expect((await readFile(join(buildDir, "index.html"))).byteLength).toBe(fixtureSize);
       expect(peakRss - startingRss).toBeLessThan(64 * 1024 * 1024);
     } finally {
       clearInterval(sample);

--- a/packages/management-api/tests/unit/install-config.test.ts
+++ b/packages/management-api/tests/unit/install-config.test.ts
@@ -73,7 +73,7 @@ describe("installer configuration persistence", () => {
     expect(readFileSync(calls, "utf8")).toContain(`--config=${config}`);
     expect(readFileSync(calls, "utf8")).toContain(`--stanza=db-main`);
     expect(readFileSync(calls, "utf8")).toContain("ALTER SYSTEM SET archive_command");
-  });
+  }, { timeout: 15_000 });
 
   test("atomically merges managed values while preserving operator-owned settings", () => {
     const dir = makeTempDir();
@@ -197,7 +197,7 @@ describe("installer configuration persistence", () => {
       expect(result.status, `case ${index}: ${result.stderr}`).not.toBe(0);
       expect(() => statSync(marker)).toThrow();
     }
-  });
+  }, { timeout: 15_000 });
 
   test("check_config rejects unsafe IP and DNS inputs before logging or persistence", () => {
     const dir = makeTempDir();
@@ -374,7 +374,7 @@ describe("installer configuration persistence", () => {
     expect(readFileSync(jwtKeys, "utf8")).toBe(firstJwt);
     expect(firstConfig).toContain("SUPABASE_PUBLIC_DOMAIN=api.10.20.30.40.nip.io");
     expect(firstConfig).toContain("SUPABASE_STUDIO_DOMAIN=studio.10.20.30.40.nip.io");
-  });
+  }, { timeout: 30_000 });
 
   test("strict install input parser round-trips a safely escaped command-substitution literal", () => {
     const dir = makeTempDir();
@@ -403,7 +403,7 @@ describe("installer configuration persistence", () => {
     expect(loaded.status, loaded.stderr).toBe(0);
     expect(() => statSync(marker)).toThrow();
     expect(readFileSync(output, "utf8")).toBe(literal);
-  });
+  }, { timeout: 30_000 });
 
   test("service environment encoding is source-safe, round-trips special characters, and rejects newlines", () => {
     const dir = makeTempDir();

--- a/packages/management-api/tests/unit/project-cli-regression.test.ts
+++ b/packages/management-api/tests/unit/project-cli-regression.test.ts
@@ -1,0 +1,120 @@
+// @supacloud-test-isolate — exercises CLI project listing against mixed payload shapes.
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+const promptsMock = {
+  intro: mock(() => undefined),
+  outro: mock(() => undefined),
+  cancel: mock(() => undefined),
+  isCancel: mock(() => false),
+  spinner: mock(() => ({
+    start: mock(() => undefined),
+    stop: mock(() => undefined),
+  })),
+  text: mock(async () => ""),
+  confirm: mock(async () => false),
+  log: {
+    success: mock(() => undefined),
+    info: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+};
+
+mock.module("@clack/prompts", () => promptsMock);
+mock.module("../../src/config", () => ({
+  config: {
+    supacloudApiUrl: "https://supacloud.example",
+    masterToken: "test-master-token",
+  },
+}));
+
+const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const logSpy = spyOn(console, "log").mockImplementation(() => undefined as never);
+const exitSpy = spyOn(process, "exit").mockImplementation((code?: number) => {
+  throw new Error(`process.exit:${code ?? 0}`);
+}) as unknown as typeof process.exit;
+
+const { handleProjectGet, handleProjectList } = await import(
+  new URL("../../src/cli/project.ts?project-cli-regression", import.meta.url).href
+);
+
+function resetMocks() {
+  logSpy.mockClear();
+  exitSpy.mockClear();
+  mock.clearAllMocks();
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.exit = originalExit;
+  resetMocks();
+});
+
+beforeEach(() => {
+  resetMocks();
+});
+
+describe("project CLI URL rendering", () => {
+  test("renders nested and flat project URLs without crashing in project list", async () => {
+    const projects = [
+      {
+        name: "Legacy project",
+        ref: "legacy",
+        status: "active",
+        api_url: "https://legacy-api.example",
+        studioUrl: "https://legacy-studio.example",
+      },
+      {
+        name: "Nested project",
+        ref: "nested",
+        status: "paused",
+        api: { url: "https://nested-api.example" },
+        studio: { url: "https://nested-studio.example" },
+      },
+    ];
+
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      expect(url).toBe("https://supacloud.example/v1/projects");
+      return Response.json(projects);
+    }) as typeof fetch;
+
+    await handleProjectList();
+
+    const rendered = logSpy.mock.calls.map((call) => call.map((value) => String(value)).join(" "));
+    expect(rendered.join("\n")).toContain("Legacy project (legacy)");
+    expect(rendered.join("\n")).toContain("API: https://legacy-api.example");
+    expect(rendered.join("\n")).toContain("Studio: https://legacy-studio.example");
+    expect(rendered.join("\n")).toContain("Nested project (nested)");
+    expect(rendered.join("\n")).toContain("API: https://nested-api.example");
+    expect(rendered.join("\n")).toContain("Studio: https://nested-studio.example");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test("renders flat project URLs in project get without crashing", async () => {
+    const project = {
+      name: "Legacy project",
+      ref: "legacy",
+      status: "active",
+      region: "local",
+      created_at: "2026-09-02T00:00:00.000Z",
+      apiUrl: "https://legacy-api.example",
+      studio_url: "https://legacy-studio.example",
+      database: { name: "supa_legacy" },
+    };
+
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      expect(url).toBe("https://supacloud.example/v1/projects/legacy");
+      return Response.json(project);
+    }) as typeof fetch;
+
+    await handleProjectGet("legacy");
+
+    const rendered = logSpy.mock.calls.map((call) => call.map((value) => String(value)).join(" "));
+    expect(rendered.join("\n")).toContain("API URL: https://legacy-api.example");
+    expect(rendered.join("\n")).toContain("Studio URL: https://legacy-studio.example");
+    expect(rendered.join("\n")).toContain("Database: supa_legacy");
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/management-api/tests/unit/project-cli-regression.test.ts
+++ b/packages/management-api/tests/unit/project-cli-regression.test.ts
@@ -51,6 +51,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  process.exit = exitSpy as unknown as typeof process.exit;
   resetMocks();
 });
 
@@ -116,5 +117,13 @@ describe("project CLI URL rendering", () => {
     expect(rendered.join("\n")).toContain("Studio URL: https://legacy-studio.example");
     expect(rendered.join("\n")).toContain("Database: supa_legacy");
     expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  test("intercepts project get failures without terminating the test process", async () => {
+    globalThis.fetch = mock(async () => new Response("upstream failed", { status: 502 })) as typeof fetch;
+
+    await expect(handleProjectGet("missing")).rejects.toThrow("process.exit:1");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
Scope:
- widen the slow install-config unit tests to match their real runtime
- reduce the frontend release archive fixture size so the streaming/memory assertion fits the available temp space

Validation:
- bun test packages/management-api/tests/unit/install-config.test.ts
- bun test tests/unit/frontend-release-archive.test.ts
- bun run test in packages/management-api