### PR TITLE
feat: add database governance and testing packages (db, testing)

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,100 @@
+# @supacloud/db
+
+SupaCloud 的数据库治理层：把 RLS 策略、RPC 函数、触发器、授权（grant）作为**一等资源**做声明式管理，并与 PostgreSQL 真实 Catalog 对账。
+
+定位：它是 Drizzle（schema/迁移）之上的治理层 —— Drizzle 负责表结构，本包负责表结构之外的安全与业务对象（策略、函数、权限）的声明、静态检查与漂移检测。**driver 无关**：所有 Catalog 读取都通过注入的 `QueryExecutor` 完成，不依赖任何数据库客户端，也不 import drizzle-orm（仅类型层兼容 drizzle Table 的内部形状）。
+
+## 目录约定示例
+
+```
+db/
+  policies/cases_select.sql      -- create policy ... + enable row level security
+  functions/case_create.sql      -- security definer set search_path = public
+  triggers/cases_updated_at.sql
+  grants/cases.sql
+  tests/cases_select.sql         -- pgTAP 或 SQL 冒烟测试
+```
+
+```ts
+import { defineDatabaseModule } from '@supacloud/db';
+import { cases } from './schema'; // drizzle 表对象
+
+export const casesModule = defineDatabaseModule({
+  name: 'cases',
+  tables: [cases], // 也接受 'public.cases' 字符串
+  policies: [
+    {
+      name: 'cases_select',
+      table: 'public.cases',
+      operation: 'select',
+      roles: ['authenticated'],
+      source: 'db/policies/cases_select.sql',
+      tests: ['db/tests/cases_select.sql'],
+    },
+  ],
+  functions: [
+    {
+      name: 'public.case_create',
+      source: 'db/functions/case_create.sql',
+      security: 'definer',
+      permission: 'case.create',
+      tests: ['db/tests/case_create.sql'],
+    },
+  ],
+  grants: [
+    { object: 'public.cases', privilege: 'SELECT', role: 'authenticated', source: 'db/grants/cases.sql' },
+  ],
+});
+```
+
+## API
+
+| 导出 | 说明 |
+| --- | --- |
+| `defineDatabaseModule(options)` | 声明一个数据库模块，归一化表名为 `schema.name` |
+| `readCatalog(executor, schemas?)` | 通过注入的查询执行器读取 PostgreSQL Catalog（默认 `['public']`，参数化 `$1`） |
+| `reconcileModule(module, catalog)` | Manifest 与 Catalog 对账，产出 `ReconcileReport` |
+| `lintSql(sql, file)` / `lintModule(module, readFile)` | 纯 SQL 文本静态分析，无需数据库 |
+| `buildDatabaseManifest(modules)` | 汇总模块为可 JSON 序列化的 `DatabaseManifest`（version 1） |
+| `explainObject(manifest, name)` | 人类可读地解释对象的所属模块、类型、源文件、权限、测试 |
+
+## 诊断码
+
+### 对账（reconcile）
+
+| code | 级别 | 含义 |
+| --- | --- | --- |
+| `missing-policy` | error | 声明的策略在 catalog 中不存在 |
+| `missing-function` | error | 声明的 RPC 函数在 catalog 中不存在 |
+| `undeclared-policy` | warn | 归属表上存在 manifest 未声明的策略（漂移） |
+| `rls-disabled` | error | 归属表 `relrowsecurity = false` |
+| `definer-without-search-path` | error | security definer 函数未设置固定 search_path（含空元素或 `pg_temp` 也算不固定） |
+| `security-mismatch` | warn | 声明的 invoker/definer 与 catalog 实际不一致 |
+| `wildcard-grant` | error | 归属表上存在授予 `PUBLIC` 的权限 |
+| `grant-drift` | warn | 声明的授权在 catalog 中不存在 |
+
+`ReconcileReport.ok = true` 当且仅当没有 error 级问题。
+
+### Lint（静态分析，正则级、大小写不敏感）
+
+| code | 级别 | 含义 |
+| --- | --- | --- |
+| `definer-no-search-path` | error | 源文件含 `security definer` 但不含 `set search_path` |
+| `grant-to-public` | error | `grant ... to public` |
+| `missing-rls-enable` | warn | 声明了策略但所有策略源文件都没有 `enable row level security` |
+| `drop-without-if-exists` | warn | `drop table/column` 缺少 `if exists` |
+| `policy-without-test` | warn | 声明的策略/函数没有 `tests` 条目 |
+
+## 与 Supabase / PostgreSQL 的关系
+
+SupaCloud 兼容 Supabase 的托管 PostgreSQL 模型：`authenticated` / `anon` / `service_role` 角色、RLS 策略、`security definer` RPC 都是治理对象。本包读取的系统目录（`pg_class` / `pg_policy` / `pg_proc` / `information_schema`）是标准 PostgreSQL 接口，因此同样适用于自托管 PostgreSQL；针对 Supabase 风格的角色与 schema 约定没有硬编码依赖。
+
+## 开发
+
+```sh
+bun install
+bun test            # bun test，同置 *.test.ts
+bun run typecheck
+bun run typecheck:test
+bun run build       # bun build --target node + tsc 声明文件
+```

--- a/packages/db/bun.lock
+++ b/packages/db/bun.lock
@@ -1,0 +1,64 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@supacloud/db",
+      "devDependencies": {
+        "@types/bun": "^1.4.0",
+        "typescript": "^7.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@supacloud/db",
+  "version": "0.1.0",
+  "description": "Database governance layer for SupaCloud: RLS policies, RPC functions and grants as first-class resources, with manifest/catalog reconciliation",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "bun run clean && bun run build:js && bun run build:types",
+    "build:js": "bun build src/index.ts --outdir dist --target node",
+    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "bun run build",
+    "test": "bun test",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
+  },
+  "keywords": [
+    "supacloud",
+    "database",
+    "governance",
+    "rls",
+    "postgresql"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vibeunion/supacloud.git",
+    "directory": "packages/db"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.4.0",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/db/src/catalog.test.ts
+++ b/packages/db/src/catalog.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  extractSearchPath,
+  readCatalog,
+  type QueryExecutor,
+} from './catalog.js';
+
+interface CapturedCall {
+  sql: string;
+  params?: unknown[];
+}
+
+/** 按 SQL 关键字路由返回固定行的 mock executor */
+function mockExecutor(routes: Array<{ match: string; rows: unknown[] }>): {
+  executor: QueryExecutor;
+  calls: CapturedCall[];
+} {
+  const calls: CapturedCall[] = [];
+  const executor: QueryExecutor = {
+    query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {
+      calls.push({ sql, params });
+      const route = routes.find((r) => sql.includes(r.match));
+      return Promise.resolve((route?.rows ?? []) as T[]);
+    },
+  };
+  return { executor, calls };
+}
+
+const FULL_ROWS = [
+  {
+    match: 'pg_class c\nJOIN pg_namespace',
+    rows: [
+      { schema: 'public', name: 'cases', rls_enabled: true, rls_forced: false },
+    ],
+  },
+  {
+    match: 'pg_policy',
+    rows: [
+      {
+        schema: 'public',
+        table: 'cases',
+        name: 'cases_select',
+        command: 'r',
+        roles: ['authenticated'],
+        using_expr: 'tenant_id = current_tenant()',
+        check_expr: null,
+      },
+      {
+        schema: 'public',
+        table: 'cases',
+        name: 'cases_all_admin',
+        command: '*',
+        roles: ['service_role'],
+        using_expr: null,
+        check_expr: null,
+      },
+    ],
+  },
+  {
+    match: 'pg_proc',
+    rows: [
+      {
+        schema: 'public',
+        name: 'case_create',
+        security_definer: true,
+        config: ['search_path=public'],
+        language: 'plpgsql',
+      },
+      {
+        schema: 'public',
+        name: 'case_list',
+        security_definer: false,
+        config: null,
+        language: 'sql',
+      },
+    ],
+  },
+  {
+    match: 'role_table_grants',
+    rows: [
+      {
+        object_schema: 'public',
+        object_name: 'cases',
+        privilege: 'SELECT',
+        grantee: 'authenticated',
+      },
+    ],
+  },
+];
+
+describe('readCatalog', () => {
+  test('默认 schema 过滤为 public 且参数化 $1', async () => {
+    const { executor, calls } = mockExecutor([]);
+    await readCatalog(executor);
+    expect(calls).toHaveLength(4);
+    for (const call of calls) {
+      expect(call.sql).toContain('$1');
+      expect(call.params).toEqual([['public']]);
+    }
+  });
+
+  test('自定义 schemas 透传为参数', async () => {
+    const { executor, calls } = mockExecutor([]);
+    await readCatalog(executor, ['public', 'app']);
+    expect(calls[0].params).toEqual([['public', 'app']]);
+  });
+
+  test('表行映射 rls 字段', async () => {
+    const { executor } = mockExecutor(FULL_ROWS);
+    const catalog = await readCatalog(executor);
+    expect(catalog.tables).toEqual([
+      { schema: 'public', name: 'cases', rlsEnabled: true, rlsForced: false },
+    ]);
+  });
+
+  test('polcmd 映射为语义化操作名', async () => {
+    const { executor } = mockExecutor(FULL_ROWS);
+    const catalog = await readCatalog(executor);
+    expect(catalog.policies[0].command).toBe('select');
+    expect(catalog.policies[0].usingExpr).toBe('tenant_id = current_tenant()');
+    expect(catalog.policies[0].checkExpr).toBeUndefined();
+    expect(catalog.policies[1].command).toBe('all');
+    expect(catalog.policies[1].roles).toEqual(['service_role']);
+  });
+
+  test('prosecdef 映射 security，proconfig 提取 search_path', async () => {
+    const { executor } = mockExecutor(FULL_ROWS);
+    const catalog = await readCatalog(executor);
+    expect(catalog.functions[0].security).toBe('definer');
+    expect(catalog.functions[0].searchPath).toBe('public');
+    expect(catalog.functions[0].language).toBe('plpgsql');
+    expect(catalog.functions[1].security).toBe('invoker');
+    expect(catalog.functions[1].searchPath).toBeNull();
+  });
+
+  test('grants 行原样映射', async () => {
+    const { executor } = mockExecutor(FULL_ROWS);
+    const catalog = await readCatalog(executor);
+    expect(catalog.grants).toEqual([
+      {
+        objectSchema: 'public',
+        objectName: 'cases',
+        privilege: 'SELECT',
+        grantee: 'authenticated',
+      },
+    ]);
+  });
+});
+
+describe('extractSearchPath', () => {
+  test('从 proconfig 数组提取 search_path', () => {
+    expect(extractSearchPath(['search_path=public, extensions'])).toBe(
+      'public, extensions',
+    );
+  });
+
+  test('无 search_path 配置返回 null', () => {
+    expect(extractSearchPath(['work_mem=64MB'])).toBeNull();
+    expect(extractSearchPath([])).toBeNull();
+    expect(extractSearchPath(null)).toBeNull();
+  });
+});

--- a/packages/db/src/catalog.ts
+++ b/packages/db/src/catalog.ts
@@ -1,0 +1,201 @@
+/**
+ * Catalog 读取：通过注入的 QueryExecutor 从 PostgreSQL 系统目录读取真实状态。
+ * 所有 SQL 参数化（$1 = schemas 数组），默认只读 public schema。
+ */
+
+import type { PolicyOperation } from './module.js';
+
+export interface QueryExecutor {
+  query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+}
+
+export interface CatalogTable {
+  schema: string;
+  name: string;
+  rlsEnabled: boolean;
+  rlsForced: boolean;
+}
+
+export interface CatalogPolicy {
+  schema: string;
+  table: string;
+  name: string;
+  command: PolicyOperation;
+  roles: string[];
+  usingExpr?: string;
+  checkExpr?: string;
+}
+
+export interface CatalogFunction {
+  schema: string;
+  name: string;
+  security: 'invoker' | 'definer';
+  searchPath: string | null;
+  language: string;
+}
+
+export interface CatalogGrant {
+  objectSchema: string;
+  objectName: string;
+  privilege: string;
+  grantee: string;
+}
+
+export interface DatabaseCatalog {
+  tables: CatalogTable[];
+  policies: CatalogPolicy[];
+  functions: CatalogFunction[];
+  grants: CatalogGrant[];
+}
+
+const TABLES_SQL = `
+SELECT n.nspname AS schema,
+       c.relname AS name,
+       c.relrowsecurity AS rls_enabled,
+       c.relforcerowsecurity AS rls_forced
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relkind = 'r'
+  AND n.nspname = ANY($1)
+ORDER BY n.nspname, c.relname
+`;
+
+const POLICIES_SQL = `
+SELECT n.nspname AS schema,
+       c.relname AS table,
+       p.polname AS name,
+       p.polcmd AS command,
+       ARRAY(
+         SELECT CASE WHEN r = 0 THEN 'PUBLIC' ELSE pg_get_userbyid(r) END
+         FROM unnest(p.polroles) AS r
+       ) AS roles,
+       pg_get_expr(p.polqual, p.polrelid) AS using_expr,
+       pg_get_expr(p.polwithcheck, p.polrelid) AS check_expr
+FROM pg_policy p
+JOIN pg_class c ON c.oid = p.polrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = ANY($1)
+ORDER BY n.nspname, c.relname, p.polname
+`;
+
+const FUNCTIONS_SQL = `
+SELECT n.nspname AS schema,
+       p.proname AS name,
+       p.prosecdef AS security_definer,
+       p.proconfig AS config,
+       l.lanname AS language
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+JOIN pg_language l ON l.oid = p.prolang
+WHERE n.nspname = ANY($1)
+ORDER BY n.nspname, p.proname
+`;
+
+const GRANTS_SQL = `
+SELECT table_schema AS object_schema,
+       table_name AS object_name,
+       privilege_type AS privilege,
+       grantee
+FROM information_schema.role_table_grants
+WHERE table_schema = ANY($1)
+UNION ALL
+SELECT routine_schema AS object_schema,
+       routine_name AS object_name,
+       privilege_type AS privilege,
+       grantee
+FROM information_schema.routine_privileges
+WHERE routine_schema = ANY($1)
+`;
+
+interface TableRow {
+  schema: string;
+  name: string;
+  rls_enabled: boolean;
+  rls_forced: boolean;
+}
+
+interface PolicyRow {
+  schema: string;
+  table: string;
+  name: string;
+  command: string;
+  roles: string[] | null;
+  using_expr: string | null;
+  check_expr: string | null;
+}
+
+interface FunctionRow {
+  schema: string;
+  name: string;
+  security_definer: boolean;
+  config: string[] | null;
+  language: string;
+}
+
+interface GrantRow {
+  object_schema: string;
+  object_name: string;
+  privilege: string;
+  grantee: string;
+}
+
+/** pg_policy.polcmd → 语义化操作名 */
+const POLCMD_MAP: Record<string, PolicyOperation> = {
+  r: 'select',
+  a: 'insert',
+  w: 'update',
+  d: 'delete',
+  '*': 'all',
+};
+
+/** 从 proconfig（text[]）中提取 search_path=... 配置，无则 null */
+export function extractSearchPath(config: string[] | null): string | null {
+  if (!config) return null;
+  const entry = config.find((item) => item.startsWith('search_path='));
+  if (!entry) return null;
+  return entry.slice('search_path='.length);
+}
+
+export async function readCatalog(
+  executor: QueryExecutor,
+  schemas: string[] = ['public'],
+): Promise<DatabaseCatalog> {
+  const params = [schemas];
+  const [tableRows, policyRows, functionRows, grantRows] = await Promise.all([
+    executor.query<TableRow>(TABLES_SQL, params),
+    executor.query<PolicyRow>(POLICIES_SQL, params),
+    executor.query<FunctionRow>(FUNCTIONS_SQL, params),
+    executor.query<GrantRow>(GRANTS_SQL, params),
+  ]);
+
+  return {
+    tables: tableRows.map((row) => ({
+      schema: row.schema,
+      name: row.name,
+      rlsEnabled: row.rls_enabled,
+      rlsForced: row.rls_forced,
+    })),
+    policies: policyRows.map((row) => ({
+      schema: row.schema,
+      table: row.table,
+      name: row.name,
+      command: POLCMD_MAP[row.command] ?? 'all',
+      roles: row.roles ?? [],
+      usingExpr: row.using_expr ?? undefined,
+      checkExpr: row.check_expr ?? undefined,
+    })),
+    functions: functionRows.map((row) => ({
+      schema: row.schema,
+      name: row.name,
+      security: row.security_definer ? 'definer' : 'invoker',
+      searchPath: extractSearchPath(row.config),
+      language: row.language,
+    })),
+    grants: grantRows.map((row) => ({
+      objectSchema: row.object_schema,
+      objectName: row.object_name,
+      privilege: row.privilege,
+      grantee: row.grantee,
+    })),
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,38 @@
+export {
+  defineDatabaseModule,
+  type DatabaseModule,
+  type DatabaseModuleOptions,
+  type DrizzleTableLike,
+  type FunctionDecl,
+  type GrantDecl,
+  type PolicyDecl,
+  type PolicyOperation,
+  type TableRef,
+  type TriggerDecl,
+} from './module.js';
+
+export {
+  extractSearchPath,
+  readCatalog,
+  type CatalogFunction,
+  type CatalogGrant,
+  type CatalogPolicy,
+  type CatalogTable,
+  type DatabaseCatalog,
+  type QueryExecutor,
+} from './catalog.js';
+
+export {
+  reconcileModule,
+  type ReconcileIssue,
+  type ReconcileReport,
+} from './reconcile.js';
+
+export { lintModule, lintSql, type LintIssue } from './lint.js';
+
+export {
+  buildDatabaseManifest,
+  explainObject,
+  type DatabaseManifest,
+  type DatabaseManifestModule,
+} from './manifest.js';

--- a/packages/db/src/lint.test.ts
+++ b/packages/db/src/lint.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test';
+
+import { lintModule, lintSql } from './lint.js';
+import { defineDatabaseModule } from './module.js';
+
+function codes(issues: Array<{ code: string }>): string[] {
+  return issues.map((issue) => issue.code);
+}
+
+describe('lintSql', () => {
+  test('definer-no-search-path：security definer 缺少 set search_path', () => {
+    const sql = `create function public.f() returns int language sql security definer as $$ select 1 $$;`;
+    const issues = lintSql(sql, 'f.sql');
+    expect(codes(issues)).toContain('definer-no-search-path');
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].file).toBe('f.sql');
+    expect(issues[0].line).toBe(1);
+  });
+
+  test('definer-no-search-path：带 set search_path 时不命中', () => {
+    const sql = `create function public.f() returns int language sql security definer set search_path = public as $$ select 1 $$;`;
+    expect(codes(lintSql(sql, 'f.sql'))).not.toContain('definer-no-search-path');
+  });
+
+  test('grant-to-public：授予 PUBLIC 报错', () => {
+    const issues = lintSql('grant select on table public.cases to public;', 'g.sql');
+    expect(codes(issues)).toContain('grant-to-public');
+    expect(issues[0].severity).toBe('error');
+  });
+
+  test('grant-to-public：授予具名角色不命中', () => {
+    const issues = lintSql('grant select on table public.cases to authenticated;', 'g.sql');
+    expect(codes(issues)).not.toContain('grant-to-public');
+  });
+
+  test('drop-without-if-exists：命中与豁免', () => {
+    expect(codes(lintSql('drop table public.old;', 'm.sql'))).toContain(
+      'drop-without-if-exists',
+    );
+    expect(codes(lintSql('alter table t drop column c;', 'm.sql'))).toContain(
+      'drop-without-if-exists',
+    );
+    expect(codes(lintSql('drop table if exists public.old;', 'm.sql'))).not.toContain(
+      'drop-without-if-exists',
+    );
+    expect(codes(lintSql('alter table t drop column if exists c;', 'm.sql'))).not.toContain(
+      'drop-without-if-exists',
+    );
+  });
+
+  test('line 指向命中行', () => {
+    const sql = `create table t (id int);\n\ndrop table t;`;
+    const issues = lintSql(sql, 'm.sql');
+    expect(issues[0].line).toBe(3);
+  });
+});
+
+describe('lintModule', () => {
+  const files: Record<string, string> = {
+    'db/policies/cases_select.sql':
+      'alter table public.cases enable row level security;\ncreate policy cases_select on public.cases for select to authenticated using (true);',
+    'db/functions/case_create.sql':
+      'create function public.case_create() returns int language sql security definer set search_path = public as $$ select 1 $$;',
+  };
+  const readFile = (path: string): Promise<string> => {
+    const content = files[path];
+    if (content === undefined) return Promise.reject(new Error(`missing file: ${path}`));
+    return Promise.resolve(content);
+  };
+
+  test('干净模块无 lint 问题', async () => {
+    const module = defineDatabaseModule({
+      name: 'cases',
+      tables: ['public.cases'],
+      policies: [
+        {
+          name: 'cases_select',
+          table: 'public.cases',
+          operation: 'select',
+          roles: ['authenticated'],
+          source: 'db/policies/cases_select.sql',
+          tests: ['db/tests/cases_select.sql'],
+        },
+      ],
+      functions: [
+        {
+          name: 'public.case_create',
+          source: 'db/functions/case_create.sql',
+          security: 'definer',
+          tests: ['db/tests/case_create.sql'],
+        },
+      ],
+    });
+    expect(await lintModule(module, readFile)).toEqual([]);
+  });
+
+  test('missing-rls-enable：有策略但源文件未开启 RLS', async () => {
+    const module = defineDatabaseModule({
+      name: 'cases',
+      policies: [
+        {
+          name: 'cases_select',
+          table: 'public.cases',
+          operation: 'select',
+          roles: ['authenticated'],
+          source: 'db/functions/case_create.sql',
+          tests: ['t.sql'],
+        },
+      ],
+    });
+    const issues = await lintModule(module, readFile);
+    expect(codes(issues)).toContain('missing-rls-enable');
+  });
+
+  test('policy-without-test：策略/函数缺 tests 条目', async () => {
+    const module = defineDatabaseModule({
+      name: 'cases',
+      policies: [
+        {
+          name: 'cases_select',
+          table: 'public.cases',
+          operation: 'select',
+          roles: ['authenticated'],
+          source: 'db/policies/cases_select.sql',
+        },
+      ],
+      functions: [
+        { name: 'public.case_create', source: 'db/functions/case_create.sql', security: 'definer' },
+      ],
+    });
+    const issues = await lintModule(module, readFile);
+    const noTest = issues.filter((i) => i.code === 'policy-without-test');
+    expect(noTest).toHaveLength(2);
+    expect(noTest.every((i) => i.severity === 'warn')).toBe(true);
+  });
+
+  test('源文件中的 SQL 问题被聚合上报', async () => {
+    const module = defineDatabaseModule({
+      name: 'cases',
+      grants: [
+        {
+          object: 'public.cases',
+          privilege: 'SELECT',
+          role: 'authenticated',
+          source: 'db/policies/cases_select.sql',
+        },
+      ],
+    });
+    // 复用含 grant 的文件场景：直接注入含 to public 的文件
+    const issues = await lintModule(module, (path) =>
+      Promise.resolve(path.endsWith('.sql') ? 'grant select on public.cases to public;' : ''),
+    );
+    expect(codes(issues)).toContain('grant-to-public');
+  });
+});

--- a/packages/db/src/lint.ts
+++ b/packages/db/src/lint.ts
@@ -1,0 +1,134 @@
+/**
+ * Lint：对 SQL 源文本做正则级静态分析，无需数据库连接。
+ */
+
+import type { DatabaseModule } from './module.js';
+
+export interface LintIssue {
+  severity: 'error' | 'warn';
+  code: string;
+  message: string;
+  file: string;
+  line?: number;
+}
+
+const SECURITY_DEFINER_RE = /\bsecurity\s+definer\b/i;
+const SET_SEARCH_PATH_RE = /\bset\s+search_path\b/i;
+const GRANT_TO_PUBLIC_RE = /\bgrant\b[^;]*\bto\s+public\b/i;
+const DROP_WITHOUT_IF_EXISTS_RE = /\bdrop\s+(?:table|column)\s+(?!if\s+exists\b)/i;
+const ENABLE_RLS_RE = /\benable\s+row\s+level\s+security\b/i;
+
+function lineOf(sql: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (sql.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+export function lintSql(sql: string, file: string): LintIssue[] {
+  const issues: LintIssue[] = [];
+
+  const definer = SECURITY_DEFINER_RE.exec(sql);
+  if (definer && !SET_SEARCH_PATH_RE.test(sql)) {
+    issues.push({
+      severity: 'error',
+      code: 'definer-no-search-path',
+      message: 'security definer 函数必须显式 set search_path，避免 search_path 劫持',
+      file,
+      line: lineOf(sql, definer.index),
+    });
+  }
+
+  const grantPublic = GRANT_TO_PUBLIC_RE.exec(sql);
+  if (grantPublic) {
+    issues.push({
+      severity: 'error',
+      code: 'grant-to-public',
+      message: '禁止将权限授予 PUBLIC 角色',
+      file,
+      line: lineOf(sql, grantPublic.index),
+    });
+  }
+
+  const drop = DROP_WITHOUT_IF_EXISTS_RE.exec(sql);
+  if (drop) {
+    issues.push({
+      severity: 'warn',
+      code: 'drop-without-if-exists',
+      message: 'drop table/column 建议使用 if exists，保证迁移可重入',
+      file,
+      line: lineOf(sql, drop.index),
+    });
+  }
+
+  return issues;
+}
+
+export async function lintModule(
+  module: DatabaseModule,
+  readFile: (path: string) => Promise<string>,
+): Promise<LintIssue[]> {
+  const issues: LintIssue[] = [];
+
+  // 收集全部声明的源文件并读取
+  const sources = new Set<string>();
+  for (const decl of [
+    ...module.policies,
+    ...module.functions,
+    ...module.triggers,
+    ...module.grants,
+  ]) {
+    sources.add(decl.source);
+  }
+  const contents = new Map<string, string>();
+  await Promise.all(
+    [...sources].map(async (path) => {
+      contents.set(path, await readFile(path));
+    }),
+  );
+
+  // 逐文件做 SQL 静态分析
+  for (const [file, sql] of contents) {
+    issues.push(...lintSql(sql, file));
+  }
+
+  // missing-rls-enable：声明了策略但没有任何源文件开启 RLS
+  if (module.policies.length > 0) {
+    const anyEnable = module.policies.some((policy) =>
+      ENABLE_RLS_RE.test(contents.get(policy.source) ?? ''),
+    );
+    if (!anyEnable) {
+      issues.push({
+        severity: 'warn',
+        code: 'missing-rls-enable',
+        message: `模块 ${module.name} 声明了 ${module.policies.length} 条策略，但所有策略源文件都没有 enable row level security`,
+        file: module.policies[0].source,
+      });
+    }
+  }
+
+  // policy-without-test：声明的策略/函数缺少测试条目
+  for (const policy of module.policies) {
+    if (!policy.tests || policy.tests.length === 0) {
+      issues.push({
+        severity: 'warn',
+        code: 'policy-without-test',
+        message: `策略 ${policy.name} 未声明测试文件`,
+        file: policy.source,
+      });
+    }
+  }
+  for (const fn of module.functions) {
+    if (!fn.tests || fn.tests.length === 0) {
+      issues.push({
+        severity: 'warn',
+        code: 'policy-without-test',
+        message: `函数 ${fn.name} 未声明测试文件`,
+        file: fn.source,
+      });
+    }
+  }
+
+  return issues;
+}

--- a/packages/db/src/manifest.test.ts
+++ b/packages/db/src/manifest.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildDatabaseManifest, explainObject } from './manifest.js';
+import { defineDatabaseModule } from './module.js';
+
+const casesModule = defineDatabaseModule({
+  name: 'cases',
+  tables: ['public.cases'],
+  policies: [
+    {
+      name: 'cases_select',
+      table: 'public.cases',
+      operation: 'select',
+      roles: ['authenticated'],
+      source: 'db/policies/cases_select.sql',
+      tests: ['db/tests/cases_select.sql'],
+    },
+  ],
+  functions: [
+    {
+      name: 'public.case_create',
+      source: 'db/functions/case_create.sql',
+      security: 'definer',
+      permission: 'case.create',
+      tests: ['db/tests/case_create.sql'],
+    },
+  ],
+  triggers: [
+    { name: 'cases_updated_at', table: 'public.cases', source: 'db/triggers/cases_updated_at.sql' },
+  ],
+  grants: [
+    {
+      object: 'public.cases',
+      privilege: 'SELECT',
+      role: 'authenticated',
+      source: 'db/grants/cases.sql',
+    },
+  ],
+});
+
+const iamModule = defineDatabaseModule({
+  name: 'iam',
+  tables: ['public.profiles'],
+});
+
+describe('buildDatabaseManifest', () => {
+  test('结构：version=1 且模块字段完整', () => {
+    const manifest = buildDatabaseManifest([casesModule, iamModule]);
+    expect(manifest.version).toBe(1);
+    expect(manifest.modules).toHaveLength(2);
+    expect(manifest.modules[0].name).toBe('cases');
+    expect(manifest.modules[0].tables).toEqual(['public.cases']);
+    expect(manifest.modules[0].policies).toHaveLength(1);
+    expect(manifest.modules[0].functions).toHaveLength(1);
+    expect(manifest.modules[0].triggers).toHaveLength(1);
+    expect(manifest.modules[0].grants).toHaveLength(1);
+    expect(manifest.modules[1].name).toBe('iam');
+  });
+
+  test('manifest 可 JSON 序列化', () => {
+    const manifest = buildDatabaseManifest([casesModule]);
+    const round = JSON.parse(JSON.stringify(manifest)) as typeof manifest;
+    expect(round).toEqual(manifest);
+  });
+});
+
+describe('explainObject', () => {
+  const manifest = buildDatabaseManifest([casesModule, iamModule]);
+
+  test('函数：输出包含模块、类型、源文件、权限、测试', () => {
+    const text = explainObject(manifest, 'public.case_create');
+    expect(text).toContain('public.case_create');
+    expect(text).toContain('函数');
+    expect(text).toContain('cases');
+    expect(text).toContain('db/functions/case_create.sql');
+    expect(text).toContain('case.create');
+    expect(text).toContain('definer');
+    expect(text).toContain('db/tests/case_create.sql');
+  });
+
+  test('策略：按名字或 table.name 均可命中', () => {
+    for (const key of ['cases_select', 'public.cases.cases_select']) {
+      const text = explainObject(manifest, key);
+      expect(text).toContain('策略');
+      expect(text).toContain('db/policies/cases_select.sql');
+      expect(text).toContain('authenticated');
+    }
+  });
+
+  test('表、触发器、授权均可解释', () => {
+    expect(explainObject(manifest, 'public.cases')).toContain('表');
+    expect(explainObject(manifest, 'cases_updated_at')).toContain('触发器');
+    expect(explainObject(manifest, 'public.profiles')).toContain('iam');
+  });
+
+  test('未知对象返回未找到提示', () => {
+    expect(explainObject(manifest, 'public.nonexistent')).toContain('未找到');
+  });
+});

--- a/packages/db/src/manifest.ts
+++ b/packages/db/src/manifest.ts
@@ -1,0 +1,126 @@
+/**
+ * Manifest：把若干 DatabaseModule 汇总为可序列化的数据库治理清单，
+ * 并提供 explainObject 做人类可读的对象解释。
+ */
+
+import type {
+  DatabaseModule,
+  FunctionDecl,
+  GrantDecl,
+  PolicyDecl,
+  TriggerDecl,
+} from './module.js';
+
+export interface DatabaseManifestModule {
+  name: string;
+  tables: string[];
+  policies: PolicyDecl[];
+  functions: FunctionDecl[];
+  triggers: TriggerDecl[];
+  grants: GrantDecl[];
+}
+
+export interface DatabaseManifest {
+  version: 1;
+  modules: DatabaseManifestModule[];
+}
+
+export function buildDatabaseManifest(modules: DatabaseModule[]): DatabaseManifest {
+  return {
+    version: 1,
+    modules: modules.map((module) => ({
+      name: module.name,
+      tables: module.tables,
+      policies: module.policies,
+      functions: module.functions,
+      triggers: module.triggers,
+      grants: module.grants,
+    })),
+  };
+}
+
+function describePolicy(moduleName: string, policy: PolicyDecl): string {
+  const lines = [
+    `对象: ${policy.table}.${policy.name}`,
+    '类型: 策略 (policy)',
+    `所属模块: ${moduleName}`,
+    `表: ${policy.table}`,
+    `操作: ${policy.operation}`,
+    `角色: ${policy.roles.join(', ')}`,
+    `源文件: ${policy.source}`,
+  ];
+  if (policy.tests && policy.tests.length > 0) lines.push(`测试: ${policy.tests.join(', ')}`);
+  return lines.join('\n');
+}
+
+function describeFunction(moduleName: string, fn: FunctionDecl): string {
+  const lines = [
+    `对象: ${fn.name}`,
+    '类型: 函数 (function)',
+    `所属模块: ${moduleName}`,
+    `源文件: ${fn.source}`,
+    `安全模式: ${fn.security}`,
+  ];
+  if (fn.permission) lines.push(`权限: ${fn.permission}`);
+  if (fn.transaction) lines.push(`事务: ${fn.transaction}`);
+  if (fn.audit) lines.push(`审计: ${fn.audit}`);
+  if (fn.idempotency) lines.push(`幂等: ${fn.idempotency}`);
+  if (fn.tests && fn.tests.length > 0) lines.push(`测试: ${fn.tests.join(', ')}`);
+  return lines.join('\n');
+}
+
+function describeTrigger(moduleName: string, trigger: TriggerDecl): string {
+  return [
+    `对象: ${trigger.name}`,
+    '类型: 触发器 (trigger)',
+    `所属模块: ${moduleName}`,
+    `表: ${trigger.table}`,
+    `源文件: ${trigger.source}`,
+  ].join('\n');
+}
+
+function describeGrant(moduleName: string, grant: GrantDecl): string {
+  return [
+    `对象: ${grant.object}`,
+    '类型: 授权 (grant)',
+    `所属模块: ${moduleName}`,
+    `权限: ${grant.privilege}`,
+    `角色: ${grant.role}`,
+    `源文件: ${grant.source}`,
+  ].join('\n');
+}
+
+/**
+ * 按名字解释一个对象：策略（name 或 table.name）、函数（schema.name）、
+ * 触发器（name）、归属表（schema.name）、授权对象（schema.name，最后兜底）。
+ */
+export function explainObject(manifest: DatabaseManifest, name: string): string {
+  for (const module of manifest.modules) {
+    for (const policy of module.policies) {
+      if (policy.name === name || `${policy.table}.${policy.name}` === name) {
+        return describePolicy(module.name, policy);
+      }
+    }
+    for (const fn of module.functions) {
+      if (fn.name === name) return describeFunction(module.name, fn);
+    }
+    for (const trigger of module.triggers) {
+      if (trigger.name === name || `${trigger.table}.${trigger.name}` === name) {
+        return describeTrigger(module.name, trigger);
+      }
+    }
+    for (const table of module.tables) {
+      if (table === name) {
+        return [
+          `对象: ${table}`,
+          '类型: 表 (table)',
+          `所属模块: ${module.name}`,
+        ].join('\n');
+      }
+    }
+    for (const grant of module.grants) {
+      if (grant.object === name) return describeGrant(module.name, grant);
+    }
+  }
+  return `未找到对象: ${name}`;
+}

--- a/packages/db/src/module.test.ts
+++ b/packages/db/src/module.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+
+import { defineDatabaseModule } from './module.js';
+
+describe('defineDatabaseModule', () => {
+  test('空选项归一化为空数组', () => {
+    const module = defineDatabaseModule({ name: 'cases' });
+    expect(module.name).toBe('cases');
+    expect(module.tables).toEqual([]);
+    expect(module.policies).toEqual([]);
+    expect(module.functions).toEqual([]);
+    expect(module.triggers).toEqual([]);
+    expect(module.grants).toEqual([]);
+  });
+
+  test('字符串表名原样保留', () => {
+    const module = defineDatabaseModule({
+      name: 'cases',
+      tables: ['public.cases', 'app.orders'],
+    });
+    expect(module.tables).toEqual(['public.cases', 'app.orders']);
+  });
+
+  test('drizzle 形表对象提取 schema.name', () => {
+    const casesTable = { _: { name: 'cases', schema: 'public' } };
+    const module = defineDatabaseModule({
+      name: 'cases',
+      tables: [casesTable],
+    });
+    expect(module.tables).toEqual(['public.cases']);
+  });
+
+  test('drizzle 形表对象无 schema 时默认 public', () => {
+    const profilesTable = { _: { name: 'profiles' } };
+    const module = defineDatabaseModule({
+      name: 'iam',
+      tables: [profilesTable],
+    });
+    expect(module.tables).toEqual(['public.profiles']);
+  });
+
+  test('声明数组原样透传', () => {
+    const module = defineDatabaseModule({
+      name: 'cases',
+      policies: [
+        {
+          name: 'cases_select',
+          table: 'public.cases',
+          operation: 'select',
+          roles: ['authenticated'],
+          source: 'db/policies/cases_select.sql',
+        },
+      ],
+      functions: [
+        {
+          name: 'public.case_create',
+          source: 'db/functions/case_create.sql',
+          security: 'definer',
+          permission: 'case.create',
+        },
+      ],
+    });
+    expect(module.policies).toHaveLength(1);
+    expect(module.functions[0].security).toBe('definer');
+  });
+});

--- a/packages/db/src/module.ts
+++ b/packages/db/src/module.ts
@@ -1,0 +1,92 @@
+/**
+ * 模块声明：数据库治理的一等资源（RLS 策略 / RPC 函数 / 触发器 / 授权）。
+ * driver 无关，纯声明层。
+ */
+
+export type PolicyOperation = 'select' | 'insert' | 'update' | 'delete' | 'all';
+
+export interface PolicyDecl {
+  /** 策略名，如 cases_select */
+  name: string;
+  /** 带 schema 的表名：public.cases */
+  table: string;
+  operation: PolicyOperation;
+  /** 适用角色，如 ['authenticated'] */
+  roles: string[];
+  /** SQL 源文件相对路径 */
+  source: string;
+  /** 测试文件相对路径 */
+  tests?: string[];
+}
+
+export interface FunctionDecl {
+  /** 带 schema 的函数名：public.case_create */
+  name: string;
+  source: string;
+  /** 业务权限标识，如 case.create */
+  permission?: string;
+  transaction?: 'required' | 'none';
+  security: 'invoker' | 'definer';
+  audit?: string;
+  idempotency?: string;
+  tests?: string[];
+}
+
+export interface TriggerDecl {
+  name: string;
+  /** 带 schema 的表名 */
+  table: string;
+  source: string;
+}
+
+export interface GrantDecl {
+  /** 带 schema 的对象名：public.cases */
+  object: string;
+  privilege: string;
+  role: string;
+  source: string;
+}
+
+/** drizzle Table 的内部结构形状（仅类型层兼容，不 import drizzle-orm） */
+export interface DrizzleTableLike {
+  _: { name: string; schema?: string };
+}
+
+export type TableRef = string | DrizzleTableLike;
+
+export interface DatabaseModuleOptions {
+  name: string;
+  /** 归属表：drizzle 表对象或带 schema 表名均可 */
+  tables?: TableRef[];
+  policies?: PolicyDecl[];
+  functions?: FunctionDecl[];
+  triggers?: TriggerDecl[];
+  grants?: GrantDecl[];
+}
+
+export interface DatabaseModule {
+  name: string;
+  /** 归一化为 'schema.name' 形式的表名 */
+  tables: string[];
+  policies: PolicyDecl[];
+  functions: FunctionDecl[];
+  triggers: TriggerDecl[];
+  grants: GrantDecl[];
+}
+
+function normalizeTable(ref: TableRef): string {
+  if (typeof ref === 'string') return ref;
+  const schema = ref._.schema ?? 'public';
+  return `${schema}.${ref._.name}`;
+}
+
+export function defineDatabaseModule(options: DatabaseModuleOptions): DatabaseModule {
+  return {
+    name: options.name,
+    tables: (options.tables ?? []).map(normalizeTable),
+    policies: options.policies ?? [],
+    functions: options.functions ?? [],
+    triggers: options.triggers ?? [],
+    grants: options.grants ?? [],
+  };
+}

--- a/packages/db/src/reconcile.test.ts
+++ b/packages/db/src/reconcile.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { DatabaseCatalog } from './catalog.js';
+import { defineDatabaseModule } from './module.js';
+import { reconcileModule } from './reconcile.js';
+
+const baseModule = defineDatabaseModule({
+  name: 'cases',
+  tables: ['public.cases'],
+  policies: [
+    {
+      name: 'cases_select',
+      table: 'public.cases',
+      operation: 'select',
+      roles: ['authenticated'],
+      source: 'db/policies/cases_select.sql',
+      tests: ['db/tests/cases_select.sql'],
+    },
+  ],
+  functions: [
+    {
+      name: 'public.case_create',
+      source: 'db/functions/case_create.sql',
+      security: 'definer',
+      permission: 'case.create',
+    },
+  ],
+  grants: [
+    {
+      object: 'public.cases',
+      privilege: 'SELECT',
+      role: 'authenticated',
+      source: 'db/grants/cases.sql',
+    },
+  ],
+});
+
+const baseCatalog: DatabaseCatalog = {
+  tables: [
+    { schema: 'public', name: 'cases', rlsEnabled: true, rlsForced: false },
+  ],
+  policies: [
+    {
+      schema: 'public',
+      table: 'cases',
+      name: 'cases_select',
+      command: 'select',
+      roles: ['authenticated'],
+      usingExpr: 'tenant_id = current_tenant()',
+    },
+  ],
+  functions: [
+    {
+      schema: 'public',
+      name: 'case_create',
+      security: 'definer',
+      searchPath: 'public',
+      language: 'plpgsql',
+    },
+  ],
+  grants: [
+    {
+      objectSchema: 'public',
+      objectName: 'cases',
+      privilege: 'SELECT',
+      grantee: 'authenticated',
+    },
+  ],
+};
+
+function cloneCatalog(): DatabaseCatalog {
+  return structuredClone(baseCatalog);
+}
+
+function codes(report: ReturnType<typeof reconcileModule>): string[] {
+  return report.issues.map((issue) => issue.code);
+}
+
+describe('reconcileModule', () => {
+  test('全一致时 ok=true 且无 issue', () => {
+    const report = reconcileModule(baseModule, cloneCatalog());
+    expect(report.module).toBe('cases');
+    expect(report.issues).toEqual([]);
+    expect(report.ok).toBe(true);
+  });
+
+  test('missing-policy：声明的策略在 catalog 中不存在', () => {
+    const catalog = cloneCatalog();
+    catalog.policies = [];
+    const report = reconcileModule(baseModule, catalog);
+    expect(report.ok).toBe(false);
+    expect(codes(report)).toContain('missing-policy');
+  });
+
+  test('missing-function：声明的函数在 catalog 中不存在', () => {
+    const catalog = cloneCatalog();
+    catalog.functions = [];
+    const report = reconcileModule(baseModule, catalog);
+    expect(report.ok).toBe(false);
+    expect(codes(report)).toContain('missing-function');
+  });
+
+  test('undeclared-policy：归属表上的额外策略告警，非归属表不告警', () => {
+    const catalog = cloneCatalog();
+    catalog.policies.push(
+      {
+        schema: 'public',
+        table: 'cases',
+        name: 'cases_extra',
+        command: 'delete',
+        roles: ['authenticated'],
+      },
+      {
+        schema: 'public',
+        table: 'other_table',
+        name: 'other_policy',
+        command: 'select',
+        roles: ['authenticated'],
+      },
+    );
+    const report = reconcileModule(baseModule, catalog);
+    const undeclared = report.issues.filter((i) => i.code === 'undeclared-policy');
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0].severity).toBe('warn');
+    expect(undeclared[0].object).toContain('cases_extra');
+    expect(report.ok).toBe(true);
+  });
+
+  test('rls-disabled：归属表未开启 RLS', () => {
+    const catalog = cloneCatalog();
+    catalog.tables[0].rlsEnabled = false;
+    const report = reconcileModule(baseModule, catalog);
+    expect(report.ok).toBe(false);
+    expect(codes(report)).toContain('rls-disabled');
+  });
+
+  test('definer-without-search-path：searchPath 为 null', () => {
+    const catalog = cloneCatalog();
+    catalog.functions[0].searchPath = null;
+    const report = reconcileModule(baseModule, catalog);
+    expect(report.ok).toBe(false);
+    expect(codes(report)).toContain('definer-without-search-path');
+  });
+
+  test('definer-without-search-path：searchPath 含 pg_temp 或空元素', () => {
+    for (const bad of ['public, pg_temp', 'public, ', '"$user", public,,']) {
+      const catalog = cloneCatalog();
+      catalog.functions[0].searchPath = bad;
+      const report = reconcileModule(baseModule, catalog);
+      expect(codes(report)).toContain('definer-without-search-path');
+    }
+  });
+
+  test('security-mismatch：声明 invoker 但 catalog 为 definer（路径固定则不报 error）', () => {
+    const module = defineDatabaseModule({
+      ...baseModule,
+      functions: [{ ...baseModule.functions[0], security: 'invoker' }],
+    });
+    const report = reconcileModule(module, cloneCatalog());
+    expect(codes(report)).toContain('security-mismatch');
+    expect(codes(report)).not.toContain('definer-without-search-path');
+    expect(report.ok).toBe(true);
+  });
+
+  test('wildcard-grant：归属表上存在授予 PUBLIC 的权限', () => {
+    const catalog = cloneCatalog();
+    catalog.grants.push({
+      objectSchema: 'public',
+      objectName: 'cases',
+      privilege: 'SELECT',
+      grantee: 'PUBLIC',
+    });
+    const report = reconcileModule(baseModule, catalog);
+    expect(report.ok).toBe(false);
+    expect(codes(report)).toContain('wildcard-grant');
+  });
+
+  test('grant-drift：声明的授权在 catalog 中不存在', () => {
+    const catalog = cloneCatalog();
+    catalog.grants = [];
+    const report = reconcileModule(baseModule, catalog);
+    expect(codes(report)).toContain('grant-drift');
+    expect(report.ok).toBe(true);
+  });
+});

--- a/packages/db/src/reconcile.ts
+++ b/packages/db/src/reconcile.ts
@@ -1,0 +1,168 @@
+/**
+ * 对账：声明式 Manifest（DatabaseModule）与 PostgreSQL 真实 Catalog 比对。
+ */
+
+import type { DatabaseCatalog } from './catalog.js';
+import type { DatabaseModule } from './module.js';
+
+export interface ReconcileIssue {
+  severity: 'error' | 'warn';
+  code: string;
+  message: string;
+  /** 涉及对象名 */
+  object: string;
+}
+
+export interface ReconcileReport {
+  module: string;
+  issues: ReconcileIssue[];
+  /** 无 error 级问题 */
+  ok: boolean;
+}
+
+/** 'public.cases' → ['public', 'cases']；无 schema 前缀时默认 public */
+function splitQualifiedName(name: string): [string, string] {
+  const dot = name.indexOf('.');
+  if (dot === -1) return ['public', name];
+  return [name.slice(0, dot), name.slice(dot + 1)];
+}
+
+/**
+ * search_path 是否固定安全：
+ * 必须显式设置（非 null），且不含空元素或 pg_temp 等非固定 schema。
+ */
+function isFixedSearchPath(searchPath: string | null): boolean {
+  if (searchPath === null) return false;
+  const parts = searchPath.split(',').map((part) => part.trim().replace(/^"|"$/g, ''));
+  return parts.every((part) => part !== '' && part.toLowerCase() !== 'pg_temp');
+}
+
+export function reconcileModule(
+  module: DatabaseModule,
+  catalog: DatabaseCatalog,
+): ReconcileReport {
+  const issues: ReconcileIssue[] = [];
+  const ownedTables = new Set(module.tables);
+
+  const push = (
+    severity: ReconcileIssue['severity'],
+    code: string,
+    object: string,
+    message: string,
+  ) => issues.push({ severity, code, object, message });
+
+  // missing-policy：声明的策略在 catalog 中不存在
+  for (const policy of module.policies) {
+    const [schema, table] = splitQualifiedName(policy.table);
+    const found = catalog.policies.some(
+      (cp) => cp.schema === schema && cp.table === table && cp.name === policy.name,
+    );
+    if (!found) {
+      push(
+        'error',
+        'missing-policy',
+        `${policy.table}.${policy.name}`,
+        `声明的策略 ${policy.name} 在表 ${policy.table} 的 catalog 中不存在`,
+      );
+    }
+  }
+
+  // undeclared-policy：归属表上 catalog 有但 manifest 未声明的策略（漂移提示）
+  const declaredPolicyKeys = new Set(module.policies.map((p) => `${p.table}::${p.name}`));
+  for (const cp of catalog.policies) {
+    const qualified = `${cp.schema}.${cp.table}`;
+    if (ownedTables.has(qualified) && !declaredPolicyKeys.has(`${qualified}::${cp.name}`)) {
+      push(
+        'warn',
+        'undeclared-policy',
+        `${qualified}.${cp.name}`,
+        `归属表 ${qualified} 上存在未声明的策略 ${cp.name}，可能发生漂移`,
+      );
+    }
+  }
+
+  // missing-function / security-mismatch / definer-without-search-path
+  for (const fn of module.functions) {
+    const [schema, name] = splitQualifiedName(fn.name);
+    const cf = catalog.functions.find((f) => f.schema === schema && f.name === name);
+    if (!cf) {
+      push(
+        'error',
+        'missing-function',
+        fn.name,
+        `声明的函数 ${fn.name} 在 catalog 中不存在`,
+      );
+      continue;
+    }
+    if (cf.security !== fn.security) {
+      push(
+        'warn',
+        'security-mismatch',
+        fn.name,
+        `函数 ${fn.name} 声明为 security ${fn.security}，catalog 实际为 ${cf.security}`,
+      );
+    }
+    const effectiveDefiner = fn.security === 'definer' || cf.security === 'definer';
+    if (effectiveDefiner && !isFixedSearchPath(cf.searchPath)) {
+      push(
+        'error',
+        'definer-without-search-path',
+        fn.name,
+        `security definer 函数 ${fn.name} 未设置固定 search_path（当前: ${cf.searchPath ?? '未设置'}）`,
+      );
+    }
+  }
+
+  // rls-disabled：归属表未开启行级安全
+  for (const table of module.tables) {
+    const [schema, name] = splitQualifiedName(table);
+    const ct = catalog.tables.find((t) => t.schema === schema && t.name === name);
+    if (ct && !ct.rlsEnabled) {
+      push(
+        'error',
+        'rls-disabled',
+        table,
+        `归属表 ${table} 未开启行级安全（relrowsecurity = false）`,
+      );
+    }
+  }
+
+  // wildcard-grant：归属表上存在授予 PUBLIC 的权限
+  for (const grant of catalog.grants) {
+    const qualified = `${grant.objectSchema}.${grant.objectName}`;
+    if (ownedTables.has(qualified) && grant.grantee.toUpperCase() === 'PUBLIC') {
+      push(
+        'error',
+        'wildcard-grant',
+        qualified,
+        `归属表 ${qualified} 存在授予 PUBLIC 的 ${grant.privilege} 权限`,
+      );
+    }
+  }
+
+  // grant-drift：声明的授权在 catalog 中不存在
+  for (const grant of module.grants) {
+    const [schema, name] = splitQualifiedName(grant.object);
+    const found = catalog.grants.some(
+      (cg) =>
+        cg.objectSchema === schema &&
+        cg.objectName === name &&
+        cg.privilege.toLowerCase() === grant.privilege.toLowerCase() &&
+        cg.grantee.toLowerCase() === grant.role.toLowerCase(),
+    );
+    if (!found) {
+      push(
+        'warn',
+        'grant-drift',
+        grant.object,
+        `声明的授权 ${grant.privilege} ON ${grant.object} TO ${grant.role} 在 catalog 中不存在`,
+      );
+    }
+  }
+
+  return {
+    module: module.name,
+    issues,
+    ok: !issues.some((issue) => issue.severity === 'error'),
+  };
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": [
+    "src/index.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/db/tsconfig.test.json
+++ b/packages/db/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,73 @@
+# @supacloud/testing
+
+Testing utilities for SupaCloud applications. The package is dependency-free:
+all inputs are accepted through structural typing, so it works with
+`@supacloud/app` metadata, Elysia apps and any SQL executor without importing
+them (npm-publish safe — no `file:` dependencies).
+
+## Provider overrides — `createTestModule`
+
+Instantiate a module with a lightweight container and replace any provider
+with a fake. Deps are read from the static metadata written by
+`@Injectable()` / `@Inject()` (`supacloud:injectable`, `supacloud:inject-params`)
+or from explicit `deps` on object providers.
+
+```ts
+import { createTestModule } from "@supacloud/testing";
+
+const container = createTestModule(caseModuleMeta, [
+  { token: CASE_REPOSITORY, useValue: fakeRepository },
+]);
+
+const command = container.createCaseCommand as CreateCaseCommand;
+// command's transitive CASE_REPOSITORY dependency is the fake.
+```
+
+Result keys are derived from the token: `InjectionToken` names are camelCased
+(`'case.repository'` → `caseRepository`), classes use the class name with a
+lowercase first letter. `tokenKey(token)` exposes the same mapping for
+assertions. Circular dependencies throw with the ring path. Only
+application-level instantiation is supported — re-create request/job scoped
+providers yourself with a context object.
+
+## HTTP helpers — `testRequest` / `testJson`
+
+Dispatch in-memory requests against any fetch-style handle (Elysia included):
+
+```ts
+import { testJson, testRequest } from "@supacloud/testing";
+
+const res = await testRequest(app, "/health");
+const { status, body } = await testJson<{ id: string }>(app, "/cases", {
+  method: "POST",
+  body: JSON.stringify({ title: "hello" }),
+});
+```
+
+## SQL tests and RLS assertions — `runSqlTests`, `assertPolicyAllows`, `assertPolicyDenies`
+
+Write SQL tests as files with `-- @test <name>` segments; each segment runs in
+a `BEGIN`/`ROLLBACK` transaction. Add `-- @expect error` to a segment that
+must fail:
+
+```sql
+-- @test owner can read own cases
+SELECT * FROM cases;
+
+-- @test anonymous cannot insert
+-- @expect error
+INSERT INTO cases (title) VALUES ('x');
+```
+
+```ts
+import { assertPolicyDenies, assertPolicyAllows, runSqlTests } from "@supacloud/testing";
+
+const results = await runSqlTests(executor, ["sql/cases.test.sql"]);
+expect(results.every((r) => r.passed)).toBe(true);
+
+await assertPolicyAllows(userExecutor, "SELECT * FROM cases WHERE id = $1", { params: [id] });
+await assertPolicyDenies(anonExecutor, "DELETE FROM cases"); // throws, or returns 0 rows
+```
+
+`SqlExecutor` is structural (`query(sql, params)`), so postgres.js, `pg` or a
+fake all work.

--- a/packages/testing/bun.lock
+++ b/packages/testing/bun.lock
@@ -1,0 +1,64 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@supacloud/testing",
+      "devDependencies": {
+        "@types/bun": "^1.4.0",
+        "typescript": "^7.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@supacloud/testing",
+  "version": "0.1.0",
+  "description": "Testing utilities for SupaCloud applications: provider-override test modules, HTTP test helpers and SQL/RLS test runners",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "bun run clean && bun run build:js && bun run build:types",
+    "build:js": "bun build src/index.ts --outdir dist --target node",
+    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "bun run build",
+    "test": "bun test",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
+  },
+  "keywords": [
+    "supacloud",
+    "testing",
+    "di",
+    "dependency-injection",
+    "rls"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vibeunion/supacloud.git",
+    "directory": "packages/testing"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.4.0",
+    "typescript": "^7.0.2"
+  }
+}

--- a/packages/testing/src/db.test.ts
+++ b/packages/testing/src/db.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import { assertPolicyAllows, assertPolicyDenies, runSqlTests } from "./db";
+import type { SqlExecutor } from "./db";
+
+interface Call {
+  sql: string;
+  params?: unknown[];
+}
+
+/**
+ * Fake executor: statements containing FAIL throw insufficient_privilege,
+ * statements containing EMPTY return no rows, everything else returns one row.
+ */
+function createFakeExecutor(): { executor: SqlExecutor; calls: Call[] } {
+  const calls: Call[] = [];
+  return {
+    calls,
+    executor: {
+      async query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {
+        calls.push({ sql, params });
+        if (sql.includes("FAIL")) {
+          const error = new Error("permission denied for table cases");
+          (error as { code?: string }).code = "42501"; // insufficient_privilege
+          throw error;
+        }
+        if (sql.includes("EMPTY")) {
+          return [];
+        }
+        return [{ id: 1 }] as T[];
+      },
+    },
+  };
+}
+
+const SQL_FILE = [
+  "-- @test insert a case",
+  "INSERT INTO cases (title) VALUES ('a');",
+  "-- @test insert fails without permission",
+  "-- @expect error",
+  "INSERT INTO cases (title) VALUES ('FAIL');",
+].join("\n");
+
+async function readVirtual(path: string): Promise<string> {
+  if (path === "cases.test.sql") return SQL_FILE;
+  throw new Error(`unknown file: ${path}`);
+}
+
+describe("runSqlTests", () => {
+  test("splits files into @test segments and wraps each in a transaction", async () => {
+    const { executor, calls } = createFakeExecutor();
+    const results = await runSqlTests(executor, ["cases.test.sql"], readVirtual);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ file: "cases.test.sql", name: "insert a case", passed: true });
+    expect(results[1]).toMatchObject({
+      file: "cases.test.sql",
+      name: "insert fails without permission",
+      passed: true,
+    });
+
+    // Each segment is wrapped in BEGIN ... ROLLBACK.
+    expect(calls.map((c) => c.sql)).toEqual([
+      "BEGIN",
+      "INSERT INTO cases (title) VALUES ('a');\n",
+      "ROLLBACK",
+      "BEGIN",
+      "INSERT INTO cases (title) VALUES ('FAIL');\n",
+      "ROLLBACK",
+    ]);
+  });
+
+  test("fails a segment that throws unexpectedly", async () => {
+    const { executor } = createFakeExecutor();
+    const read = async () => "-- @test boom\nFAIL;\n";
+    const results = await runSqlTests(executor, ["x.sql"], read);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].error).toContain("permission denied");
+  });
+
+  test("fails an @expect error segment that succeeds", async () => {
+    const { executor } = createFakeExecutor();
+    const read = async () => "-- @test should fail\n-- @expect error\nSELECT 1;\n";
+    const results = await runSqlTests(executor, ["x.sql"], read);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].error).toContain("expected an error");
+  });
+});
+
+describe("assertPolicyAllows", () => {
+  test("passes when the query succeeds", async () => {
+    const { executor } = createFakeExecutor();
+    await assertPolicyAllows(executor, "SELECT * FROM cases;");
+  });
+
+  test("fails when the query throws", async () => {
+    const { executor } = createFakeExecutor();
+    await expect(assertPolicyAllows(executor, "FAIL")).rejects.toThrow(/expected the statement to be allowed/);
+  });
+});
+
+describe("assertPolicyDenies", () => {
+  test("passes when the query throws a permission error", async () => {
+    const { executor } = createFakeExecutor();
+    await assertPolicyDenies(executor, "FAIL");
+  });
+
+  test("passes when RLS silently filters all rows", async () => {
+    const { executor } = createFakeExecutor();
+    await assertPolicyDenies(executor, "SELECT EMPTY FROM cases;");
+  });
+
+  test("fails when rows come back", async () => {
+    const { executor } = createFakeExecutor();
+    await expect(assertPolicyDenies(executor, "SELECT * FROM cases;")).rejects.toThrow(
+      /returned 1 row/,
+    );
+  });
+});

--- a/packages/testing/src/db.ts
+++ b/packages/testing/src/db.ts
@@ -1,0 +1,140 @@
+/**
+ * SQL test runner and RLS assertion helpers.
+ *
+ * The executor is structural: anything with a query(sql, params) method
+ * (postgres.js, pg, an in-memory fake) satisfies it.
+ */
+
+export interface SqlExecutor {
+  query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+}
+
+export interface SqlTestResult {
+  file: string;
+  name: string;
+  passed: boolean;
+  error?: string;
+}
+
+interface SqlTestCase {
+  name: string;
+  sql: string;
+  expectError: boolean;
+}
+
+/** Split a SQL test file into cases delimited by `-- @test <name>` markers. */
+function parseSqlTests(content: string): SqlTestCase[] {
+  const cases: SqlTestCase[] = [];
+  let current: SqlTestCase | undefined;
+  for (const line of content.split(/\r?\n/)) {
+    const testMatch = line.match(/^\s*--\s*@test\s+(.+?)\s*$/);
+    if (testMatch) {
+      current = { name: testMatch[1], sql: "", expectError: false };
+      cases.push(current);
+      continue;
+    }
+    if (!current) continue; // preamble before the first @test marker is ignored
+    if (/^\s*--\s*@expect\s+error\s*$/.test(line)) {
+      current.expectError = true;
+      continue;
+    }
+    current.sql += `${line}\n`;
+  }
+  return cases;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Default file reader: uses Bun.file without requiring bun types at compile time. */
+function defaultReadFile(path: string): Promise<string> {
+  const bun = (globalThis as { Bun?: { file(p: string): { text(): Promise<string> } } }).Bun;
+  if (!bun) {
+    throw new Error("runSqlTests: no readFile provided and Bun.file is not available");
+  }
+  return bun.file(path).text();
+}
+
+/**
+ * Execute SQL test files in order. Each `-- @test <name>` segment runs inside
+ * a transaction (BEGIN; ...; ROLLBACK) for isolation. A segment containing
+ * `-- @expect error` passes when the executor throws; otherwise it must
+ * succeed. `readFile` defaults to Bun.file(path).text().
+ */
+export async function runSqlTests(
+  executor: SqlExecutor,
+  files: string[],
+  readFile: (path: string) => Promise<string> = defaultReadFile,
+): Promise<SqlTestResult[]> {
+  const results: SqlTestResult[] = [];
+  for (const file of files) {
+    const content = await readFile(file);
+    for (const testCase of parseSqlTests(content)) {
+      results.push(await runSqlTestCase(executor, file, testCase));
+    }
+  }
+  return results;
+}
+
+async function runSqlTestCase(
+  executor: SqlExecutor,
+  file: string,
+  testCase: SqlTestCase,
+): Promise<SqlTestResult> {
+  const base = { file, name: testCase.name };
+  await executor.query("BEGIN");
+  try {
+    await executor.query(testCase.sql);
+    if (testCase.expectError) {
+      return { ...base, passed: false, error: "expected an error but the statement succeeded" };
+    }
+    return { ...base, passed: true };
+  } catch (error) {
+    if (testCase.expectError) {
+      return { ...base, passed: true };
+    }
+    return { ...base, passed: false, error: errorMessage(error) };
+  } finally {
+    await executor.query("ROLLBACK");
+  }
+}
+
+/**
+ * Assert that a policy allows the statement: passes when the query does not
+ * throw, regardless of the returned rows.
+ */
+export async function assertPolicyAllows(
+  executor: SqlExecutor,
+  sql: string,
+  opts: { params?: unknown[] } = {},
+): Promise<void> {
+  try {
+    await executor.query(sql, opts.params);
+  } catch (error) {
+    throw new Error(`assertPolicyAllows: expected the statement to be allowed, but it failed: ${errorMessage(error)}`);
+  }
+}
+
+/**
+ * Assert that a policy denies the statement: passes when the executor throws
+ * (insufficient_privilege / RLS violation / permission error) or when the
+ * statement returns an empty result set (RLS silently filtered the rows).
+ * Fails when rows come back.
+ */
+export async function assertPolicyDenies(
+  executor: SqlExecutor,
+  sql: string,
+  opts: { params?: unknown[] } = {},
+): Promise<void> {
+  let rows: unknown[];
+  try {
+    rows = await executor.query(sql, opts.params);
+  } catch {
+    return; // permission or RLS error: denied as expected
+  }
+  if (rows.length === 0) return; // RLS silently filtered all rows
+  throw new Error(
+    `assertPolicyDenies: expected the statement to be denied, but it returned ${rows.length} row(s)`,
+  );
+}

--- a/packages/testing/src/http.test.ts
+++ b/packages/testing/src/http.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { testJson, testRequest } from "./http";
+import type { HandleLike } from "./http";
+
+/** Echo handle: reports the request method and URL as JSON. */
+function echoApp(status = 200): HandleLike {
+  return {
+    handle(request: Request): Response {
+      return Response.json(
+        { method: request.method, url: request.url },
+        { status },
+      );
+    },
+  };
+}
+
+describe("testRequest", () => {
+  test("dispatches a GET request and returns the response", async () => {
+    const response = await testRequest(echoApp(), "/cases");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { method: string; url: string };
+    expect(body.method).toBe("GET");
+    expect(body.url).toBe("http://localhost/cases");
+  });
+
+  test("forwards method and body from init", async () => {
+    const response = await testRequest(echoApp(), "/cases", {
+      method: "POST",
+      body: JSON.stringify({ title: "hello" }),
+    });
+    const body = (await response.json()) as { method: string };
+    expect(body.method).toBe("POST");
+  });
+});
+
+describe("testJson", () => {
+  test("returns status and parsed body", async () => {
+    const { status, body } = await testJson<{ method: string; url: string }>(
+      echoApp(201),
+      "/cases?page=1",
+      { method: "PUT" },
+    );
+    expect(status).toBe(201);
+    expect(body.method).toBe("PUT");
+    expect(body.url).toBe("http://localhost/cases?page=1");
+  });
+});

--- a/packages/testing/src/http.ts
+++ b/packages/testing/src/http.ts
@@ -1,0 +1,29 @@
+/**
+ * HTTP test helpers. Structural typing only — works with Elysia or any
+ * fetch-style handler without importing a framework package.
+ */
+
+export interface HandleLike {
+  handle(request: Request): Promise<Response> | Response;
+}
+
+/** Dispatch an in-memory request against an app handle. */
+export async function testRequest(
+  app: HandleLike,
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const request = new Request(`http://localhost${path}`, init);
+  return app.handle(request);
+}
+
+/** Dispatch a request and parse the JSON body together with the status. */
+export async function testJson<T = unknown>(
+  app: HandleLike,
+  path: string,
+  init: RequestInit = {},
+): Promise<{ status: number; body: T }> {
+  const response = await testRequest(app, path, init);
+  const body = (await response.json()) as T;
+  return { status: response.status, body };
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,0 +1,6 @@
+export { createTestModule, tokenKey } from "./test-module";
+export type { ModuleMetaLike, ProviderOverride } from "./test-module";
+export { testJson, testRequest } from "./http";
+export type { HandleLike } from "./http";
+export { assertPolicyAllows, assertPolicyDenies, runSqlTests } from "./db";
+export type { SqlExecutor, SqlTestResult } from "./db";

--- a/packages/testing/src/test-module.test.ts
+++ b/packages/testing/src/test-module.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { createTestModule, tokenKey } from "./test-module";
+import type { ModuleMetaLike } from "./test-module";
+
+type Class = new (...args: any[]) => unknown;
+
+/** Mimic @Injectable() metadata without importing @supacloud/app. */
+function injectable(cls: Class, deps: unknown[] = []): void {
+  Object.defineProperty(cls, "supacloud:injectable", {
+    value: { scope: "application", deps },
+  });
+}
+
+/** Mimic @Inject(token) on a constructor parameter. */
+function injectParam(cls: Class, index: number, token: unknown): void {
+  const existing =
+    ((cls as unknown as Record<string, Record<number, unknown>>)["supacloud:inject-params"]) ?? {};
+  Object.defineProperty(cls, "supacloud:inject-params", {
+    value: { ...existing, [index]: token },
+  });
+}
+
+const CASE_REPOSITORY = { name: "case.repository" };
+
+class PgCaseRepository {
+  findAll(): string[] {
+    return ["real"];
+  }
+}
+injectable(PgCaseRepository);
+
+class CaseService {
+  readonly repo: unknown;
+  constructor(repo: unknown) {
+    this.repo = repo;
+  }
+}
+injectable(CaseService, [CASE_REPOSITORY]);
+
+class CreateCaseCommand {
+  readonly service: CaseService;
+  constructor(service: CaseService) {
+    this.service = service;
+  }
+}
+injectable(CreateCaseCommand);
+injectParam(CreateCaseCommand, 0, CaseService);
+
+function appMeta(): ModuleMetaLike {
+  return {
+    name: "case",
+    providers: [
+      { provide: CASE_REPOSITORY, useClass: PgCaseRepository },
+      CaseService,
+      CreateCaseCommand,
+    ],
+  };
+}
+
+describe("tokenKey", () => {
+  test("camelCases InjectionToken names", () => {
+    expect(tokenKey({ name: "case.repository" })).toBe("caseRepository");
+    expect(tokenKey({ name: "CASE_REPOSITORY" })).toBe("caseRepository");
+  });
+
+  test("lowercases the first letter of class names", () => {
+    expect(tokenKey(CaseService)).toBe("caseService");
+  });
+});
+
+describe("createTestModule", () => {
+  test("instantiates a three-layer graph with real providers", () => {
+    const container = createTestModule(appMeta());
+    const command = container.createCaseCommand as CreateCaseCommand;
+    expect(command.service).toBeInstanceOf(CaseService);
+    expect((command.service.repo as PgCaseRepository).findAll()).toEqual(["real"]);
+    expect(container.caseRepository).toBeInstanceOf(PgCaseRepository);
+    expect(container.caseService).toBeInstanceOf(CaseService);
+  });
+
+  test("override replaces the repository with a fake across the whole graph", () => {
+    const fakeRepo = { findAll: () => ["fake"] };
+    const container = createTestModule(appMeta(), [
+      { token: CASE_REPOSITORY, useValue: fakeRepo },
+    ]);
+    const command = container.createCaseCommand as CreateCaseCommand;
+    expect(command.service.repo).toBe(fakeRepo);
+    expect((command.service.repo as typeof fakeRepo).findAll()).toEqual(["fake"]);
+    expect(container.caseRepository).toBe(fakeRepo);
+  });
+
+  test("override with useClass receives the original deps", () => {
+    class SpyService {
+      readonly repo: unknown;
+      constructor(repo: unknown) {
+        this.repo = repo;
+      }
+    }
+    const container = createTestModule(appMeta(), [
+      { token: CaseService, useClass: SpyService },
+    ]);
+    const command = container.createCaseCommand as CreateCaseCommand;
+    expect(command.service).toBeInstanceOf(SpyService);
+    expect(command.service.repo).toBeInstanceOf(PgCaseRepository);
+  });
+
+  test("reports the ring path on circular dependencies", () => {
+    class AlphaService {}
+    class BetaService {}
+    injectable(AlphaService, [BetaService]);
+    injectable(BetaService, [AlphaService]);
+    const meta: ModuleMetaLike = {
+      name: "cycle",
+      providers: [AlphaService, BetaService],
+    };
+    expect(() => createTestModule(meta)).toThrow(
+      /circular dependency detected: alphaService -> betaService -> alphaService/,
+    );
+  });
+
+  test("resolves providers from imported modules", () => {
+    class SharedConfig {
+      value = 42;
+    }
+    injectable(SharedConfig);
+    const shared: ModuleMetaLike = { name: "shared", providers: [SharedConfig] };
+    class ConsumerService {
+      readonly config: SharedConfig;
+      constructor(config: SharedConfig) {
+        this.config = config;
+      }
+    }
+    injectable(ConsumerService, [SharedConfig]);
+    const container = createTestModule({
+      name: "app",
+      imports: [shared],
+      providers: [ConsumerService],
+    });
+    expect((container.consumerService as ConsumerService).config.value).toBe(42);
+  });
+});

--- a/packages/testing/src/test-module.ts
+++ b/packages/testing/src/test-module.ts
@@ -1,0 +1,247 @@
+/**
+ * Provider-override test container for SupaCloud modules.
+ *
+ * Accepts structural module metadata (compatible in shape with the ModuleMeta
+ * produced by @supacloud/app decorators) without importing any runtime package.
+ */
+
+/** Static metadata keys used by @supacloud/app decorators. */
+const INJECTABLE_METADATA = "supacloud:injectable";
+const INJECT_PARAMS_METADATA = "supacloud:inject-params";
+const MODULE_METADATA = "supacloud:module";
+
+export interface ProviderOverride {
+  /** InjectionToken instance or class identifying the provider to replace. */
+  token: unknown;
+  useValue?: unknown;
+  useClass?: new (...args: any[]) => unknown;
+  useFactory?: (...deps: any[]) => unknown;
+}
+
+export interface ModuleMetaLike {
+  name: string;
+  /** Classes or { provide, useClass|useValue|useFactory|useExisting, deps?, scope? } records. */
+  providers: unknown[];
+  imports?: Array<new (...args: any[]) => unknown> | ModuleMetaLike[];
+  [key: string]: unknown;
+}
+
+interface ProviderRecord {
+  token: unknown;
+  provider: unknown;
+  override?: ProviderOverride;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isClass(value: unknown): value is new (...args: any[]) => unknown {
+  return typeof value === "function";
+}
+
+/** Convert a dotted/snake/kebab token name to camelCase. */
+function camelCase(name: string): string {
+  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean);
+  return parts
+    .map((part, index) => {
+      const lower = part.toLowerCase();
+      return index === 0 ? lower : lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join("");
+}
+
+/**
+ * Stable result-map key for a token: InjectionToken names are camelCased
+ * ('case.repository' -> caseRepository, 'CASE_REPOSITORY' -> caseRepository),
+ * classes use the class name with a lowercase first letter.
+ */
+export function tokenKey(token: unknown): string {
+  if (isClass(token)) {
+    const name = (token as { name?: string }).name;
+    if (!name) {
+      throw new Error("tokenKey: anonymous class tokens are not supported");
+    }
+    return name.charAt(0).toLowerCase() + name.slice(1);
+  }
+  if (isRecord(token) && typeof token.name === "string") {
+    return camelCase(token.name);
+  }
+  throw new Error("tokenKey: unsupported token (expected an InjectionToken-like object or a class)");
+}
+
+function describeToken(token: unknown): string {
+  try {
+    return tokenKey(token);
+  } catch {
+    return String(token);
+  }
+}
+
+/** Merge @Injectable deps with @Inject param tokens into a positional array. */
+function classDeps(cls: new (...args: any[]) => unknown): unknown[] {
+  const statics = cls as unknown as Record<string, unknown>;
+  const meta = statics[INJECTABLE_METADATA] as { deps?: unknown[] } | undefined;
+  const params = statics[INJECT_PARAMS_METADATA] as Record<number, unknown> | undefined;
+  const deps: unknown[] = [...(meta?.deps ?? [])];
+  if (params) {
+    for (const [index, token] of Object.entries(params)) {
+      deps[Number(index)] = token;
+    }
+  }
+  return deps;
+}
+
+/** Explicit deps declared on an object provider, if any. */
+function explicitDeps(provider: unknown): unknown[] | undefined {
+  if (isRecord(provider) && Array.isArray(provider.deps)) {
+    return provider.deps;
+  }
+  return undefined;
+}
+
+/** Deps used to construct an override, falling back to the original declaration. */
+function overrideDeps(record: ProviderRecord, overrideClass?: new (...args: any[]) => unknown): unknown[] {
+  if (overrideClass) {
+    const own = classDeps(overrideClass);
+    if (own.length > 0) return own;
+  }
+  const explicit = explicitDeps(record.provider);
+  if (explicit) return explicit;
+  if (isClass(record.provider)) return classDeps(record.provider);
+  if (isRecord(record.provider) && isClass(record.provider.useClass)) {
+    return classDeps(record.provider.useClass);
+  }
+  return [];
+}
+
+function collectProviders(meta: ModuleMetaLike, records: ProviderRecord[]): void {
+  for (const imported of meta.imports ?? []) {
+    if (isClass(imported)) {
+      const importedMeta = (imported as unknown as Record<string, unknown>)[MODULE_METADATA] as
+        | ModuleMetaLike
+        | undefined;
+      if (importedMeta) collectProviders(importedMeta, records);
+    } else if (isRecord(imported)) {
+      collectProviders(imported as ModuleMetaLike, records);
+    }
+  }
+  for (const provider of meta.providers ?? []) {
+    const token = isClass(provider)
+      ? provider
+      : isRecord(provider) && "provide" in provider
+        ? provider.provide
+        : undefined;
+    if (token === undefined) {
+      throw new Error(`createTestModule: unrecognized provider in module "${meta.name}"`);
+    }
+    records.push({ token, provider });
+  }
+}
+
+/**
+ * Instantiate a module with a lightweight container: deps are resolved
+ * recursively in provider declaration order and every override whose token
+ * matches (===) replaces the original provider. Circular dependencies throw
+ * with the dependency ring path.
+ *
+ * Only application-level instantiation is supported; request/job scoped
+ * providers should be re-created by the caller with a context object.
+ */
+export function createTestModule(
+  meta: ModuleMetaLike,
+  overrides: ProviderOverride[] = [],
+): Record<string, unknown> {
+  const records: ProviderRecord[] = [];
+  collectProviders(meta, records);
+
+  // Later declarations win on token collision (own providers override imports).
+  const byToken = new Map<unknown, ProviderRecord>();
+  for (const record of records) {
+    byToken.set(record.token, record);
+  }
+
+  for (const override of overrides) {
+    const existing = byToken.get(override.token);
+    if (existing) {
+      existing.override = override;
+    } else {
+      // Override for a token the module does not declare: register it anyway.
+      byToken.set(override.token, { token: override.token, provider: undefined, override });
+    }
+  }
+
+  const instances = new Map<unknown, unknown>();
+  const resolving: unknown[] = [];
+
+  const resolve = (token: unknown): unknown => {
+    if (instances.has(token)) return instances.get(token);
+    const record = byToken.get(token);
+    if (!record) {
+      throw new Error(`createTestModule: no provider registered for token "${describeToken(token)}"`);
+    }
+    const cycleStart = resolving.indexOf(token);
+    if (cycleStart !== -1) {
+      const ring = [...resolving.slice(cycleStart), token].map(describeToken).join(" -> ");
+      throw new Error(`createTestModule: circular dependency detected: ${ring}`);
+    }
+    resolving.push(token);
+    try {
+      const instance = instantiate(record, resolve);
+      instances.set(token, instance);
+      return instance;
+    } finally {
+      resolving.pop();
+    }
+  };
+
+  for (const token of byToken.keys()) {
+    resolve(token);
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [token, instance] of instances) {
+    result[tokenKey(token)] = instance;
+  }
+  return result;
+}
+
+function instantiate(
+  record: ProviderRecord,
+  resolve: (token: unknown) => unknown,
+): unknown {
+  const { provider, override } = record;
+
+  if (override) {
+    if ("useValue" in override) return override.useValue;
+    if (override.useClass) {
+      const deps = overrideDeps(record, override.useClass).map(resolve);
+      return new override.useClass(...deps);
+    }
+    if (override.useFactory) {
+      return override.useFactory(...overrideDeps(record).map(resolve));
+    }
+    throw new Error(`createTestModule: override for "${describeToken(record.token)}" has no use* value`);
+  }
+
+  // Bare class provider: the class is its own token.
+  if (isClass(provider)) {
+    return new provider(...classDeps(provider).map(resolve));
+  }
+  if (!isRecord(provider)) {
+    throw new Error(`createTestModule: invalid provider for "${describeToken(record.token)}"`);
+  }
+  if ("useValue" in provider) return provider.useValue;
+  if (isClass(provider.useClass)) {
+    const deps = (explicitDeps(provider) ?? classDeps(provider.useClass)).map(resolve);
+    return new provider.useClass(...deps);
+  }
+  if (typeof provider.useFactory === "function") {
+    const deps = (explicitDeps(provider) ?? []).map(resolve);
+    return (provider.useFactory as (...deps: any[]) => unknown)(...deps);
+  }
+  if ("useExisting" in provider) {
+    return resolve(provider.useExisting);
+  }
+  throw new Error(`createTestModule: invalid provider for "${describeToken(record.token)}"`);
+}

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": [
+    "src/index.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/testing/tsconfig.test.json
+++ b/packages/testing/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## 概要

SupaCloud 应用框架阶段 2（PR-2/4）：数据库治理层 + 测试工具包。

### @supacloud/db（0.1.0）
RLS 策略与 RPC 函数升级为一等资源，解决大型项目"SQL 堆积、无人知道谁在保护什么"的问题：

- `defineDatabaseModule()`：声明模块拥有的表、策略、函数、触发器、授权（SQL 仍是实现来源，Manifest 是治理来源）
- `readCatalog()`：从真实 PostgreSQL 读取 pg_policy / pg_proc / pg_class / grants（driver 无关，注入 query 执行器）
- `reconcileModule()`：声明 ↔ Catalog 对账 —— missing-policy / missing-function / rls-disabled / definer-without-search-path / wildcard-grant / security-mismatch / grant-drift
- `lintSql()`：SQL 源静态检查 —— security definer 无 search_path、grant to public、缺 RLS enable、drop 无 if exists、policy 无测试
- `buildDatabaseManifest()` / `explainObject()`：数据库依赖图与影响分析的数据基础

### @supacloud/testing（0.1.0）
- `createTestModule(meta, overrides)`：Provider override 测试容器（读 app 包静态元数据，支持 useValue/useClass/useFactory/useExisting，循环依赖报环路径）
- `testRequest` / `testJson`：Elysia 风格 `handle()` 的 HTTP 测试辅助（结构类型，不依赖 elysia）
- `runSqlTests`：`-- @test` 分段 + 事务隔离（BEGIN/ROLLBACK）的 SQL 测试执行器；`assertPolicyAllows/Denies` RLS 断言

## 验证

- db 39 测试 / testing 18 测试全绿；各自 typecheck + build 通过
- 两包均无 runtime 依赖、无本地 file: 依赖（npm 发布兼容）

## 范围说明

- 发布流水线接入在 PR-4；CLI 命令（db_lint / db_module_check / db_explain）在 PR-4
- 本期只到只读对账，不含 db plan/apply 生产执行器