### PR TITLE
feat(cli): add app framework and database governance commands

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -69,6 +69,41 @@ One-off execution without global install:
 npm exec --package @supacloud/cli -- supacloud-cli status
 ```
 
+### Application framework commands
+
+Local commands for the application framework (`@supacloud/app` +
+`@supacloud/compiler`) and database governance (`@supacloud/db`). They run
+without a Management API context and never mutate the database.
+
+```bash
+# scaffold modules, commands, queries and controllers
+supacloud-cli app generate --kind module --name case
+supacloud-cli app generate --kind command --name accept --module case
+
+# compile decorator metadata into static factories + app.manifest.json
+supacloud-cli app compile --root . --out_dir generated --strict
+
+# validate only (no files written), print the module dependency tree,
+# or explain a single provider/command/controller
+supacloud-cli app check
+supacloud-cli app graph --format json
+supacloud-cli app explain --target CaseService
+
+# SQL governance over defineDatabaseModule sources
+supacloud-cli db lint --module_file db/modules.ts
+supacloud-cli db explain --target public.case_create
+
+# read-only catalog reconcile against a live database
+supacloud-cli db module_check --module_file db/modules.ts --database_url "$DATABASE_URL"
+```
+
+`db module_check` is classified read-only: it introspects `pg_policy`,
+`pg_proc`, `pg_class` and grants, and reports drift between the declared
+manifest and the live catalog (missing policies, RLS disabled, security
+definer without a pinned `search_path`, PUBLIC grants). See
+[Database Governance](./database-governance.md) and
+[Application Framework](./application-framework.md).
+
 ### AI/Agent Skill
 
 `@supacloud/cli` ships a `supacloud-cli` Skill for Codex and other Skill-compatible

--- a/packages/cli/bun.lock
+++ b/packages/cli/bun.lock
@@ -1,11 +1,13 @@
 {
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@supacloud/cli",
       "dependencies": {
         "@sinclair/typebox": "^0.34.52",
+        "@supacloud/compiler": "^0.1.0",
+        "@supacloud/db": "^0.1.0",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
@@ -14,56 +16,110 @@
     },
   },
   "packages": {
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
-    "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
-    "@types/node": ["@types/node@26.4.0", "https://registry.npmmirror.com/@types/node/-/node-26.4.0.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+    "@supacloud/compiler": ["@supacloud/compiler@0.1.0", "", { "dependencies": { "ts-morph": "^26.0.0" } }, "sha512-bQpxB9VmsfI4lFsAKDfLmFgaLnUQn1jsnvcCyPPFXrbT1ZUau+EQb01NV3lpJQRvqhxiQiFoMkir7eP6rSGZLg=="],
 
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+    "@supacloud/db": ["@supacloud/db@0.1.0", "", {}, "sha512-MCiK4MS2CsZjoi5DnUiUDrzZ7wJtAxNdmGJQ07HYKDGrzvxjYg2LBRXAeryizlXsInptdptRHLZAox65c1Kd3g=="],
 
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+    "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
 
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
 
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
 
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
 
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
 
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
 
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
 
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
 
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
 
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
 
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
 
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
 
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
 
-    "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
 
-    "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
 
-    "undici-types": ["undici-types@8.3.0", "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fastq": ["fastq@1.20.3", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,9 @@
     "directory": "packages/cli"
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.34.52"
+    "@sinclair/typebox": "^0.34.52",
+    "@supacloud/compiler": "^0.1.0",
+    "@supacloud/db": "^0.1.0"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,8 @@ import { registerBranchTools } from "./shared/tools/branch-tools";
 import { registerSupabaseCliTools } from "./shared/tools/supabase-cli-tools";
 import { registerLiteCliTools } from "./shared/tools/lite-cli-tools";
 import { registerAiTools } from "./shared/tools/ai-tools";
+import { registerAppTools } from "./shared/tools/app-tools";
+import { registerDbGovernanceTools } from "./shared/tools/db-governance-tools";
 import { registerScheduledFunctionTools } from "./shared/tools/scheduled-function-tools";
 import { registerMutationTools } from "./shared/tools/mutation-tools";
 import { registerReleaseTools } from "./shared/tools/release-tools";
@@ -312,6 +314,15 @@ EXAMPLES
   ${preferredCommand} branch promote --branch_ref preview123 --plan_checksum <sha256>
   ${preferredCommand} ai show_skill
   ${preferredCommand} ai install_skill --dry_run
+  ${preferredCommand} app generate --kind module --name billing
+  ${preferredCommand} app generate --kind command --module billing --name issue-invoice
+  ${preferredCommand} app compile --root .
+  ${preferredCommand} app check --root . --strict
+  ${preferredCommand} app graph --root . --format json
+  ${preferredCommand} app explain --target CaseService
+  ${preferredCommand} db lint --root . --module_file db/modules.ts
+  ${preferredCommand} db explain --target public.cases --module_file db/modules.ts
+  ${preferredCommand} db module_check --module_file db/modules.ts --database_url "postgresql://..."
   ${preferredCommand} edge_functions get_config --ref abc123 --slug hello
   ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --path ./supabase/functions/hello --expected-active-version absent --expected-activation-id legacy
   ${preferredCommand} edge_functions deploy --ref abc123 --slug hello --prebundled-path ./dist/hello.js --expected-sha256 <sha256> --expected-active-version 4 --expected-activation-id <uuid>
@@ -368,6 +379,8 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     })));
     Object.assign(tools, captureTools((server) => registerLiteCliTools(server as any)));
     Object.assign(tools, captureTools((server) => registerAiTools(server as any)));
+    Object.assign(tools, captureTools((server) => registerAppTools(server as any)));
+    Object.assign(tools, captureTools((server) => registerDbGovernanceTools(server as any)));
 
     const registerContextAwareHelp = () => {
         tools.project = {
@@ -543,7 +556,7 @@ async function main() {
     }
 
     const cliTools = createCliTools(context, globalOptions.confirmProduction);
-    if (args.length === 1 && !["ai", "supabase", "lite"].includes(args[0]) && cliTools[args[0]]) {
+    if (args.length === 1 && !["ai", "supabase", "lite", "app", "db"].includes(args[0]) && cliTools[args[0]]) {
         const result = await cliTools[args[0]].callback({});
         if (result?.content && Array.isArray(result.content)) {
             for (const chunk of result.content) {

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -71,6 +71,8 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         write: ["send", "receive", "ack", "release", "fail", "retry", "delete_message", "update_settings"],
     },
     ai: { local: ["show_skill", "install_skill"] },
+    app: { local: ["generate", "compile", "check", "graph", "explain"] },
+    db: { local: ["lint", "explain"], read: ["module_check"] },
 };
 
 export interface ExecutionAuthorization {

--- a/packages/cli/src/shared/tools/app-tools.test.ts
+++ b/packages/cli/src/shared/tools/app-tools.test.ts
@@ -1,0 +1,284 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { executionMode } from "../execution-policy";
+import { registerAppTools, type AppToolArguments } from "./app-tools";
+
+type AppCallback = (args: Partial<AppToolArguments>) => Promise<{
+    isError: boolean;
+    content: Array<{ type: "text"; text: string }>;
+}>;
+
+function captureAppCallback(): AppCallback {
+    let callback: AppCallback | undefined;
+    registerAppTools({
+        tool(_name, _description, _schema, registered) {
+            callback = registered as AppCallback;
+        },
+    });
+    if (!callback) throw new Error("app tool was not registered");
+    return callback;
+}
+
+const FIXTURE_TSCONFIG = `{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "experimentalDecorators": true,
+    "strict": true
+  }
+}
+`;
+
+/** @supacloud/app 的本地 noop 替身：AST 分析只按装饰器名匹配。 */
+const RUNTIME_SOURCE = `export class InjectionToken<T = unknown> {
+  readonly name: string;
+  constructor(name: string) { this.name = name; }
+}
+export function Injectable(_options: Record<string, unknown> = {}) { return () => {}; }
+export function Inject(_token: unknown) { return () => {}; }
+export function Module(_options: Record<string, unknown>) { return () => {}; }
+export function Command(_options: Record<string, unknown>) { return () => {}; }
+export function Query(_options: Record<string, unknown>) { return () => {}; }
+export function Controller(_path: string) { return () => {}; }
+export function Get(_path: string, _options?: Record<string, unknown>) { return () => {}; }
+export function Post(_path: string, _options?: Record<string, unknown>) { return () => {}; }
+`;
+
+const FIXTURE_FILES: Record<string, string> = {
+    "tsconfig.json": FIXTURE_TSCONFIG,
+    "src/runtime.ts": RUNTIME_SOURCE,
+
+    "src/features/shared/tokens.ts": `import { InjectionToken } from "../../runtime";
+
+export const DB_CLIENT = new InjectionToken("supacloud.db-client");
+export const AUDIT_SERVICE = new InjectionToken("supacloud.audit-service");
+`,
+
+    "src/features/audit/audit.service.ts": `import { Injectable } from "../../runtime";
+
+@Injectable()
+export class AuditService {
+  record(event: string): string {
+    return event;
+  }
+}
+`,
+
+    "src/features/audit/audit.module.ts": `import { Module } from "../../runtime";
+import { AUDIT_SERVICE } from "../shared/tokens";
+import { AuditService } from "./audit.service";
+
+@Module({
+  name: "audit",
+  providers: [{ provide: AUDIT_SERVICE, useClass: AuditService }],
+  exports: [AUDIT_SERVICE],
+})
+export class AuditModule {}
+`,
+
+    "src/features/case/case.service.ts": `import { Inject, Injectable } from "../../runtime";
+import { AUDIT_SERVICE, DB_CLIENT } from "../shared/tokens";
+
+@Injectable()
+export class CaseService {
+  constructor(
+    @Inject(AUDIT_SERVICE) readonly audit: unknown,
+    @Inject(DB_CLIENT) readonly db: unknown,
+  ) {}
+}
+`,
+
+    "src/features/case/accept-case.command.ts": `import { Command, Inject, Injectable } from "../../runtime";
+import { CaseService } from "./case.service";
+
+@Injectable()
+@Command({
+  name: "case.accept",
+  permission: "case.accept",
+  transaction: "required",
+  audit: "case.accepted",
+})
+export class AcceptCaseCommand {
+  constructor(@Inject(CaseService) readonly cases: unknown) {}
+}
+`,
+
+    "src/features/case/case.controller.ts": `import { Controller, Get, Inject } from "../../runtime";
+import { CaseService } from "./case.service";
+
+@Controller("/cases")
+export class CaseController {
+  constructor(@Inject(CaseService) readonly cases: unknown) {}
+
+  @Get("/:caseId")
+  detail(): { ok: boolean } {
+    return { ok: true };
+  }
+}
+`,
+
+    "src/features/case/case.module.ts": `import { Module } from "../../runtime";
+import { AuditModule } from "../audit/audit.module";
+import { CaseService } from "./case.service";
+import { AcceptCaseCommand } from "./accept-case.command";
+import { CaseController } from "./case.controller";
+
+@Module({
+  name: "case",
+  imports: [AuditModule],
+  providers: [CaseService, AcceptCaseCommand],
+  controllers: [CaseController],
+})
+export class CaseModule {}
+`,
+};
+
+describe("app tools", () => {
+    let root: string;
+    const app = captureAppCallback();
+
+    beforeAll(async () => {
+        root = mkdtempSync(join(tmpdir(), "supacloud-app-tools-"));
+        const { mkdir, writeFile } = await import("node:fs/promises");
+        const { dirname } = await import("node:path");
+        for (const [relativePath, content] of Object.entries(FIXTURE_FILES)) {
+            const absolute = join(root, relativePath);
+            await mkdir(dirname(absolute), { recursive: true });
+            await writeFile(absolute, content, "utf8");
+        }
+    });
+
+    afterAll(() => {
+        rmSync(root, { recursive: true, force: true });
+    });
+
+    test("generate scaffolds module/command/query/controller files", async () => {
+        const moduleResult = await app({ action: "generate", kind: "module", name: "billing", root });
+        expect(moduleResult.isError).toBe(false);
+        const moduleFile = join(root, "src/features/billing/billing.module.ts");
+        expect(existsSync(moduleFile)).toBe(true);
+        const moduleSource = readFileSync(moduleFile, "utf8");
+        expect(moduleSource).toContain('from "@supacloud/app"');
+        expect(moduleSource).toContain('name: "billing"');
+        expect(moduleSource).toContain("export class BillingModule");
+
+        const commandResult = await app({
+            action: "generate", kind: "command", module: "billing", name: "issue-invoice", root,
+        });
+        expect(commandResult.isError).toBe(false);
+        const commandFile = join(root, "src/features/billing/commands/issue-invoice.command.ts");
+        const commandSource = readFileSync(commandFile, "utf8");
+        expect(commandSource).toContain("@Command({");
+        expect(commandSource).toContain('name: "billing.issueInvoice"');
+        expect(commandSource).toContain("TODO");
+        expect(commandSource).toContain("export class IssueInvoiceCommand");
+
+        const queryResult = await app({
+            action: "generate", kind: "query", module: "billing", name: "list-invoices", root,
+        });
+        expect(queryResult.isError).toBe(false);
+        expect(readFileSync(join(root, "src/features/billing/queries/list-invoices.query.ts"), "utf8"))
+            .toContain("export class ListInvoicesQuery");
+
+        const controllerResult = await app({ action: "generate", kind: "controller", module: "billing", root });
+        expect(controllerResult.isError).toBe(false);
+        expect(readFileSync(join(root, "src/features/billing/billing.controller.ts"), "utf8"))
+            .toContain('@Controller("/billing")');
+    });
+
+    test("generate refuses to overwrite without --force and rejects duplicate controllers", async () => {
+        const moduleFile = join(root, "src/features/billing/billing.module.ts");
+        await expect(app({ action: "generate", kind: "module", name: "billing", root }))
+            .rejects.toThrow("already exists");
+
+        const forced = await app({ action: "generate", kind: "module", name: "billing", root, force: true });
+        expect(forced.isError).toBe(false);
+        expect(forced.content[0].text).toContain("overwritten");
+        expect(existsSync(moduleFile)).toBe(true);
+
+        // fixture 已有 case.controller.ts → 提示手工合并，--force 也不覆盖
+        await expect(app({ action: "generate", kind: "controller", module: "case", root }))
+            .rejects.toThrow("手工合并");
+        await expect(app({ action: "generate", kind: "controller", module: "case", root, force: true }))
+            .rejects.toThrow("手工合并");
+    });
+
+    test("check analyzes without writing files", async () => {
+        const result = await app({ action: "check", root });
+        expect(result.isError).toBe(false);
+        expect(result.content[0].text).toContain("no files written");
+        expect(existsSync(join(root, "generated"))).toBe(false);
+    });
+
+    test("compile writes application.ts and app.manifest.json", async () => {
+        const result = await app({ action: "compile", root });
+        expect(result.isError).toBe(false);
+        expect(existsSync(join(root, "generated", "application.ts"))).toBe(true);
+        expect(existsSync(join(root, "generated", "app.manifest.json"))).toBe(true);
+    });
+
+    test("graph renders the module tree and json format", async () => {
+        const textResult = await app({ action: "graph", root });
+        expect(textResult.isError).toBe(false);
+        const text = textResult.content[0].text;
+        expect(text).toContain("└─ case");
+        expect(text).toContain("└─ audit");
+        expect(text).toContain("provider: CaseService");
+        expect(text).toContain("controller: CaseController /cases");
+        expect(text).toContain("route: GET /:caseId -> detail");
+        expect(text).toContain("command: case.accept (AcceptCaseCommand)");
+        expect(text).toContain("externalTokens: DB_CLIENT");
+
+        const jsonResult = await app({ action: "graph", root, format: "json" });
+        const manifest = JSON.parse(jsonResult.content[0].text);
+        expect(manifest.version).toBe(1);
+        expect(manifest.modules.map((module: { name: string }) => module.name))
+            .toEqual(expect.arrayContaining(["audit", "case"]));
+    });
+
+    test("explain resolves providers, commands and external tokens", async () => {
+        const provider = await app({ action: "explain", root, target: "CaseService" });
+        expect(provider.isError).toBe(false);
+        expect(provider.content[0].text).toContain("所属模块: case");
+        expect(provider.content[0].text).toContain("scope: application");
+        expect(provider.content[0].text).toContain("deps: AUDIT_SERVICE, DB_CLIENT");
+        expect(provider.content[0].text).toContain("被依赖: case/AcceptCaseCommand, case/CaseController");
+
+        const command = await app({ action: "explain", root, target: "case.accept" });
+        expect(command.content[0].text).toContain("类型: command");
+        expect(command.content[0].text).toContain("permission: case.accept");
+        expect(command.content[0].text).toContain("transaction: required");
+        expect(command.content[0].text).toContain("audit: case.accepted");
+
+        const controller = await app({ action: "explain", root, target: "CaseController" });
+        expect(controller.content[0].text).toContain("路由: GET /cases/:caseId -> detail");
+
+        const external = await app({ action: "explain", root, target: "DB_CLIENT" });
+        expect(external.content[0].text).toContain("externalToken");
+
+        const missing = await app({ action: "explain", root, target: "Nope" });
+        expect(missing.isError).toBe(true);
+        expect(missing.content[0].text).toContain("未找到对象: Nope");
+    });
+
+    test("graph/explain fail with a clear error when the manifest is missing", async () => {
+        const emptyRoot = mkdtempSync(join(tmpdir(), "supacloud-app-tools-empty-"));
+        try {
+            await expect(app({ action: "graph", root: emptyRoot }))
+                .rejects.toThrow("Manifest not found");
+            await expect(app({ action: "explain", root: emptyRoot, target: "CaseService" }))
+                .rejects.toThrow("app compile");
+        } finally {
+            rmSync(emptyRoot, { recursive: true, force: true });
+        }
+    });
+
+    test("all app actions are classified as local in the execution policy", () => {
+        for (const action of ["generate", "compile", "check", "graph", "explain"]) {
+            expect(executionMode("app", action, {})).toBe("local");
+        }
+    });
+});

--- a/packages/cli/src/shared/tools/app-tools.ts
+++ b/packages/cli/src/shared/tools/app-tools.ts
@@ -1,0 +1,417 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { Type } from "@sinclair/typebox";
+import {
+    analyzeProject,
+    compileProject,
+    validateGraph,
+    type Diagnostic,
+    type ModuleNode,
+} from "@supacloud/compiler";
+import { optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+
+type ToolServer = {
+    tool: (
+        name: string,
+        description: string,
+        schema: ToolSchema,
+        callback: (requestArguments: AppToolArguments) => Promise<unknown>,
+    ) => void;
+};
+
+export interface AppToolArguments {
+    action: "generate" | "compile" | "check" | "graph" | "explain";
+    kind?: "module" | "command" | "query" | "controller";
+    name?: string;
+    module?: string;
+    dir?: string;
+    force?: boolean;
+    root?: string;
+    include?: string;
+    out_dir?: string;
+    strict?: boolean;
+    format?: "text" | "json";
+    target?: string;
+}
+
+interface ToolResult {
+    isError: boolean;
+    content: Array<{ type: "text"; text: string }>;
+}
+
+function textResult(text: string, isError = false): ToolResult {
+    return { isError, content: [{ type: "text" as const, text }] };
+}
+
+/** kebab/snake/空格分隔名 → PascalCase（generate 的类名）。 */
+function pascalName(name: string): string {
+    const joined = name
+        .split(/[^A-Za-z0-9]+/)
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join("");
+    return joined || "App";
+}
+
+/** kebab-case → camelCase（command/query 的语义名后缀）。 */
+function camelName(name: string): string {
+    const pascal = pascalName(name);
+    return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+function requireIdentifier(value: string | undefined, flag: string): string {
+    const trimmed = value?.trim();
+    if (!trimmed) throw new Error(`app generate requires --${flag}`);
+    if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(trimmed)) {
+        throw new Error(`Invalid --${flag} value: ${value}`);
+    }
+    return trimmed;
+}
+
+async function writeScaffold(path: string, content: string, force: boolean): Promise<"created" | "overwritten"> {
+    if (existsSync(path)) {
+        if (!force) {
+            throw new Error(`File already exists: ${path}（使用 --force 覆盖）`);
+        }
+        await writeFile(path, content, "utf8");
+        return "overwritten";
+    }
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content, "utf8");
+    return "created";
+}
+
+function moduleScaffold(name: string): string {
+    return `import { Module } from "@supacloud/app";
+
+@Module({
+    name: ${JSON.stringify(name)},
+    providers: [],
+})
+export class ${pascalName(name)}Module {}
+`;
+}
+
+function commandScaffold(moduleName: string, name: string): string {
+    return `import { Command, Injectable } from "@supacloud/app";
+
+@Injectable()
+@Command({
+    name: ${JSON.stringify(`${moduleName}.${camelName(name)}`)},
+    // TODO: 声明业务权限标识（如 ${moduleName}.${camelName(name)}）
+    permission: "TODO",
+})
+export class ${pascalName(name)}Command {}
+`;
+}
+
+function queryScaffold(moduleName: string, name: string): string {
+    return `import { Injectable, Query } from "@supacloud/app";
+
+@Injectable()
+@Query({ name: ${JSON.stringify(`${moduleName}.${camelName(name)}`)} })
+export class ${pascalName(name)}Query {}
+`;
+}
+
+function controllerScaffold(moduleName: string): string {
+    return `import { Controller } from "@supacloud/app";
+
+@Controller("/${moduleName}")
+export class ${pascalName(moduleName)}Controller {}
+`;
+}
+
+async function generateScaffold(args: AppToolArguments): Promise<ToolResult> {
+    const kind = args.kind;
+    if (!kind) throw new Error("app generate requires --kind (module|command|query|controller)");
+    const root = resolve(args.root || process.cwd());
+    const dir = args.dir || "src/features";
+
+    if (kind === "module") {
+        const name = requireIdentifier(args.name, "name");
+        const path = join(root, dir, name, `${name}.module.ts`);
+        const status = await writeScaffold(path, moduleScaffold(name), args.force === true);
+        return textResult(`✅ ${status}: ${path}`);
+    }
+
+    const moduleName = requireIdentifier(args.module, "module");
+    const name = kind === "controller" ? moduleName : requireIdentifier(args.name, "name");
+    const fileName = kind === "controller"
+        ? `${moduleName}.controller.ts`
+        : `${name}.${kind}.ts`;
+    const subdir = kind === "command" ? "commands" : kind === "query" ? "queries" : "";
+    const path = join(root, dir, moduleName, subdir, fileName);
+    if (kind === "controller" && existsSync(path)) {
+        throw new Error(`Controller already exists: ${path}（请手工合并路由到现有 controller）`);
+    }
+    const content = kind === "command"
+        ? commandScaffold(moduleName, name)
+        : kind === "query"
+            ? queryScaffold(moduleName, name)
+            : controllerScaffold(moduleName);
+    const status = await writeScaffold(path, content, args.force === true);
+    return textResult(`✅ ${status}: ${path}`);
+}
+
+function formatDiagnostic(diagnostic: Diagnostic): string {
+    const location = diagnostic.file
+        ? ` ${diagnostic.file}${diagnostic.line ? `:${diagnostic.line}` : ""}`
+        : "";
+    return `${diagnostic.severity} ${diagnostic.code}${location} ${diagnostic.message}`;
+}
+
+function formatDiagnostics(diagnostics: Diagnostic[]): string {
+    if (diagnostics.length === 0) return "no diagnostics";
+    return diagnostics.map(formatDiagnostic).join("\n");
+}
+
+function parseInclude(include: string | undefined): string[] | undefined {
+    const patterns = include?.split(",").map((entry) => entry.trim()).filter(Boolean);
+    return patterns && patterns.length > 0 ? patterns : undefined;
+}
+
+async function runCompile(args: AppToolArguments): Promise<ToolResult> {
+    const root = resolve(args.root || process.cwd());
+    const outDir = resolve(args.out_dir || join(root, "generated"));
+    const result = await compileProject({
+        rootDir: root,
+        include: parseInclude(args.include),
+        outDir,
+        strict: args.strict === true,
+    });
+    const hasError = result.diagnostics.some((diagnostic) => diagnostic.severity === "error");
+    const text = [
+        formatDiagnostics(result.diagnostics),
+        "",
+        `written (${result.written.length}):`,
+        ...result.written.map((path) => `  ${path}`),
+    ].join("\n");
+    return textResult(text, hasError);
+}
+
+async function runCheck(args: AppToolArguments): Promise<ToolResult> {
+    const root = resolve(args.root || process.cwd());
+    const graph = await analyzeProject(root, parseInclude(args.include));
+    const diagnostics: Diagnostic[] = [
+        ...(graph.diagnostics ?? []),
+        ...validateGraph(graph, args.strict === true),
+    ];
+    if (args.strict === true) {
+        for (const diagnostic of diagnostics) {
+            if (diagnostic.severity === "warn") diagnostic.severity = "error";
+        }
+    }
+    const hasError = diagnostics.some((diagnostic) => diagnostic.severity === "error");
+    const summary = `checked ${graph.modules.length} module(s), no files written`;
+    return textResult(`${formatDiagnostics(diagnostics)}\n\n${summary}`, hasError);
+}
+
+interface AppManifest {
+    version: number;
+    modules: ModuleNode[];
+    externalTokens: string[];
+}
+
+async function readManifest(root: string): Promise<AppManifest> {
+    const manifestPath = join(root, "generated", "app.manifest.json");
+    if (!existsSync(manifestPath)) {
+        throw new Error(`Manifest not found: ${manifestPath}（先运行 app compile 生成）`);
+    }
+    const parsed = JSON.parse(await readFile(manifestPath, "utf8")) as AppManifest;
+    if (!Array.isArray(parsed.modules)) {
+        throw new Error(`Invalid manifest: ${manifestPath}`);
+    }
+    return parsed;
+}
+
+function formatGraphText(manifest: AppManifest): string {
+    const lines: string[] = [`application (${manifest.modules.length} module(s))`];
+    for (const module of manifest.modules) {
+        lines.push(`└─ ${module.name} (${module.file}:${module.line})`);
+        if (module.imports.length > 0) lines.push(`   imports: ${module.imports.join(", ")}`);
+        for (const provider of module.providers) {
+            lines.push(`   provider: ${provider.token} (${provider.kind}, scope=${provider.scope})`);
+        }
+        for (const controller of module.controllers) {
+            lines.push(`   controller: ${controller.className} ${controller.path} (scope=${controller.scope})`);
+            for (const route of controller.routes) {
+                lines.push(`     route: ${route.method} ${route.path} -> ${route.handler}`);
+            }
+        }
+        for (const command of module.commands) {
+            lines.push(`   command: ${command.name} (${command.className})`);
+        }
+        for (const query of module.queries) {
+            lines.push(`   query: ${query.name} (${query.className})`);
+        }
+        if (module.exports.length > 0) lines.push(`   exports: ${module.exports.join(", ")}`);
+    }
+    if (manifest.externalTokens.length > 0) {
+        lines.push(`externalTokens: ${manifest.externalTokens.join(", ")}`);
+    }
+    return lines.join("\n");
+}
+
+async function runGraph(args: AppToolArguments): Promise<ToolResult> {
+    const root = resolve(args.root || process.cwd());
+    const manifest = await readManifest(root);
+    if (args.format === "json") return textResult(JSON.stringify(manifest, null, 2));
+    return textResult(formatGraphText(manifest));
+}
+
+/** token → 依赖它的 provider/controller 所属模块与名称（反向索引）。 */
+function reverseDependencies(manifest: AppManifest, token: string): string[] {
+    const dependents: string[] = [];
+    for (const module of manifest.modules) {
+        for (const provider of module.providers) {
+            if (provider.token !== token && provider.deps.includes(token)) {
+                dependents.push(`${module.name}/${provider.token}`);
+            }
+        }
+        for (const controller of module.controllers) {
+            if (controller.deps.includes(token)) {
+                dependents.push(`${module.name}/${controller.className}`);
+            }
+        }
+    }
+    return dependents;
+}
+
+function explainProvider(manifest: AppManifest, module: ModuleNode, index: number): string {
+    const provider = module.providers[index];
+    const lines = [
+        `对象: ${provider.token}`,
+        `类型: provider (${provider.kind})`,
+        `所属模块: ${module.name}`,
+        `scope: ${provider.scope}`,
+        `位置: ${provider.file}:${provider.line}`,
+        `deps: ${provider.deps.length > 0 ? provider.deps.join(", ") : "(none)"}`,
+    ];
+    if (provider.useClass) lines.push(`useClass: ${provider.useClass}`);
+    if (provider.useFactoryName) lines.push(`useFactory: ${provider.useFactoryName}`);
+    if (provider.useExisting) lines.push(`useExisting: ${provider.useExisting}`);
+    lines.push(`exported: ${provider.exported}`);
+    const dependents = reverseDependencies(manifest, provider.token);
+    lines.push(`被依赖: ${dependents.length > 0 ? dependents.join(", ") : "(none)"}`);
+    return lines.join("\n");
+}
+
+function explainController(manifest: AppManifest, module: ModuleNode, index: number): string {
+    const controller = module.controllers[index];
+    const lines = [
+        `对象: ${controller.className}`,
+        "类型: controller",
+        `所属模块: ${module.name}`,
+        `路径: ${controller.path}`,
+        `scope: ${controller.scope}`,
+        `deps: ${controller.deps.length > 0 ? controller.deps.join(", ") : "(none)"}`,
+    ];
+    for (const route of controller.routes) {
+        lines.push(`路由: ${route.method} ${controller.path}${route.path} -> ${route.handler}`);
+    }
+    return lines.join("\n");
+}
+
+async function runExplain(args: AppToolArguments): Promise<ToolResult> {
+    const target = args.target?.trim();
+    if (!target) throw new Error("app explain requires --target（provider 类名 / token 名 / command 名）");
+    const root = resolve(args.root || process.cwd());
+    const manifest = await readManifest(root);
+
+    for (const module of manifest.modules) {
+        const providerIndex = module.providers.findIndex(
+            (provider) => provider.token === target || provider.useClass === target,
+        );
+        if (providerIndex >= 0) return textResult(explainProvider(manifest, module, providerIndex));
+
+        const controllerIndex = module.controllers.findIndex(
+            (controller) => controller.className === target,
+        );
+        if (controllerIndex >= 0) return textResult(explainController(manifest, module, controllerIndex));
+
+        const command = module.commands.find(
+            (entry) => entry.name === target || entry.className === target,
+        );
+        if (command) {
+            const lines = [
+                `对象: ${command.name}`,
+                "类型: command",
+                `所属模块: ${module.name}`,
+                `类: ${command.className}`,
+            ];
+            if (command.permission) lines.push(`permission: ${command.permission}`);
+            if (command.transaction) lines.push(`transaction: ${command.transaction}`);
+            if (command.audit) lines.push(`audit: ${command.audit}`);
+            if (command.idempotency) lines.push(`idempotency: ${command.idempotency}`);
+            const dependents = reverseDependencies(manifest, command.className);
+            lines.push(`被依赖: ${dependents.length > 0 ? dependents.join(", ") : "(none)"}`);
+            return textResult(lines.join("\n"));
+        }
+
+        const query = module.queries.find(
+            (entry) => entry.name === target || entry.className === target,
+        );
+        if (query) {
+            return textResult([
+                `对象: ${query.name}`,
+                "类型: query",
+                `所属模块: ${module.name}`,
+                `类: ${query.className}`,
+            ].join("\n"));
+        }
+    }
+
+    if (manifest.externalTokens.includes(target)) {
+        const dependents = reverseDependencies(manifest, target);
+        return textResult([
+            `对象: ${target}`,
+            "类型: externalToken（平台注入，无模块提供）",
+            `被依赖: ${dependents.length > 0 ? dependents.join(", ") : "(none)"}`,
+        ].join("\n"));
+    }
+
+    return textResult(`未找到对象: ${target}`, true);
+}
+
+export function registerAppTools(server: ToolServer): void {
+    server.tool(
+        "app",
+        "Local @supacloud/app framework commands: scaffold, compile, check, graph and explain. Actions: generate, compile, check, graph, explain",
+        {
+            action: withDescription(stringEnum(["generate", "compile", "check", "graph", "explain"]), "App action"),
+            kind: optional(stringEnum(["module", "command", "query", "controller"]), "[generate] Scaffold kind"),
+            name: optional(Type.String(), "[generate] Object name (module name / command / query name)"),
+            module: optional(Type.String(), "[generate] Target feature module (required for command/query/controller)"),
+            dir: optional(Type.String(), "[generate] Feature root directory (default: src/features)"),
+            force: optional(Type.Boolean(), "[generate] Overwrite existing files"),
+            root: optional(Type.String(), "[generate/compile/check/graph/explain] Project root (default: current directory)"),
+            include: optional(Type.String(), "[compile/check] Comma-separated glob patterns for source files"),
+            out_dir: optional(Type.String(), "[compile] Output directory (default: <root>/generated)"),
+            strict: optional(Type.Boolean(), "[compile/check] Promote warnings to errors"),
+            format: optional(stringEnum(["text", "json"]), "[graph] Output format (default: text)"),
+            target: optional(Type.String(), "[explain] Provider class name / token name / command name"),
+        },
+        async (request) => {
+            switch (request.action) {
+                case "generate": return generateScaffold(request);
+                case "compile": return runCompile(request);
+                case "check": return runCheck(request);
+                case "graph": return runGraph(request);
+                case "explain": return runExplain(request);
+                default:
+                    return textResult(`Unknown app action: ${String(request.action)}`, true);
+            }
+        },
+    );
+}
+
+// 供测试与内部复用
+export const __internal = {
+    pascalName,
+    camelName,
+    formatGraphText,
+    reverseDependencies,
+};

--- a/packages/cli/src/shared/tools/db-governance-tools.test.ts
+++ b/packages/cli/src/shared/tools/db-governance-tools.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import type { DatabaseModule, QueryExecutor } from "@supacloud/db";
+import { executionMode } from "../execution-policy";
+import {
+    loadDatabaseModules,
+    registerDbGovernanceTools,
+    runModuleCheck,
+    type DbToolArguments,
+} from "./db-governance-tools";
+
+type DbCallback = (args: Partial<DbToolArguments>) => Promise<{
+    isError: boolean;
+    content: Array<{ type: "text"; text: string }>;
+}>;
+
+function captureDbCallback(environment: NodeJS.ProcessEnv = {}): DbCallback {
+    let callback: DbCallback | undefined;
+    registerDbGovernanceTools({
+        tool(_name, _description, _schema, registered) {
+            callback = registered as DbCallback;
+        },
+    }, { environment });
+    if (!callback) throw new Error("db tool was not registered");
+    return callback;
+}
+
+const MODULES_SOURCE = `export default [
+  {
+    name: "cases",
+    tables: ["public.cases"],
+    policies: [
+      {
+        name: "cases_select",
+        table: "public.cases",
+        operation: "select",
+        roles: ["authenticated"],
+        source: "db/policies/cases_select.sql",
+      },
+    ],
+    functions: [
+      {
+        name: "public.case_create",
+        source: "db/functions/case_create.sql",
+        security: "definer",
+        permission: "case.create",
+        transaction: "required",
+        audit: "case.created",
+      },
+    ],
+    triggers: [],
+    grants: [
+      { object: "public.cases", privilege: "select", role: "authenticated", source: "db/grants/cases.sql" },
+    ],
+  },
+  {
+    name: "clean",
+    tables: ["public.clean"],
+    policies: [
+      {
+        name: "clean_select",
+        table: "public.clean",
+        operation: "select",
+        roles: ["authenticated"],
+        source: "db/policies/clean_select.sql",
+        tests: ["tests/clean_select.sql"],
+      },
+    ],
+    functions: [],
+    triggers: [],
+    grants: [],
+  },
+];
+`;
+
+const FIXTURE_FILES: Record<string, string> = {
+    "db/modules.ts": MODULES_SOURCE,
+    "db/policies/cases_select.sql": `alter table public.cases enable row level security;
+create policy cases_select on public.cases for select to authenticated using (true);
+`,
+    // security definer 但未 set search_path → definer-no-search-path error
+    "db/functions/case_create.sql": `create or replace function public.case_create()
+returns void language plpgsql security definer as $$ begin end; $$;
+`,
+    "db/grants/cases.sql": `grant select on public.cases to authenticated;
+`,
+    "db/policies/clean_select.sql": `alter table public.clean enable row level security;
+create policy clean_select on public.clean for select to authenticated using (true);
+`,
+    // 供 loader 边界测试：必须在任何同目录 import 发生前落盘（Bun 会缓存目录列表）
+    "db/single.ts": `export const modules = { name: "solo" };\n`,
+    "db/invalid.ts": `export default 42;\n`,
+};
+
+/** 按 catalog SQL 文本分派的 mock executor。 */
+function mockExecutor(overrides: { policies?: unknown[] } = {}): QueryExecutor {
+    return {
+        async query<T>(sql: string): Promise<T[]> {
+            if (sql.includes("FROM pg_policy")) {
+                return (overrides.policies ?? [{
+                    schema: "public", table: "cases", name: "cases_select",
+                    command: "r", roles: ["authenticated"], using_expr: "true", check_expr: null,
+                }]) as T[];
+            }
+            if (sql.includes("FROM pg_proc")) {
+                return [{
+                    schema: "public", name: "case_create",
+                    security_definer: true, config: ["search_path=public"], language: "plpgsql",
+                }] as T[];
+            }
+            if (sql.includes("role_table_grants")) {
+                return [{
+                    object_schema: "public", object_name: "cases",
+                    privilege: "SELECT", grantee: "authenticated",
+                }] as T[];
+            }
+            return [{ schema: "public", name: "cases", rls_enabled: true, rls_forced: false }] as T[];
+        },
+    };
+}
+
+const CASES_MODULE: DatabaseModule = {
+    name: "cases",
+    tables: ["public.cases"],
+    policies: [{
+        name: "cases_select", table: "public.cases", operation: "select",
+        roles: ["authenticated"], source: "db/policies/cases_select.sql",
+    }],
+    functions: [{
+        name: "public.case_create", source: "db/functions/case_create.sql", security: "definer",
+    }],
+    triggers: [],
+    grants: [{ object: "public.cases", privilege: "select", role: "authenticated", source: "db/grants/cases.sql" }],
+};
+
+describe("db governance tools", () => {
+    let root: string;
+    const db = captureDbCallback();
+
+    beforeAll(() => {
+        root = mkdtempSync(join(tmpdir(), "supacloud-db-tools-"));
+        for (const [relativePath, content] of Object.entries(FIXTURE_FILES)) {
+            const absolute = join(root, relativePath);
+            mkdirSync(dirname(absolute), { recursive: true });
+            writeFileSync(absolute, content, "utf8");
+        }
+    });
+
+    afterAll(() => {
+        rmSync(root, { recursive: true, force: true });
+    });
+
+    test("loadDatabaseModules resolves default/named exports and validates shape", async () => {
+        const modules = await loadDatabaseModules(root);
+        expect(modules.map((module) => module.name)).toEqual(["cases", "clean"]);
+
+        const single = join(root, "db/single.ts");
+        expect(existsSync(single)).toBe(true);
+        const [solo] = await loadDatabaseModules(root, "db/single.ts");
+        expect(solo).toEqual({
+            name: "solo", tables: [], policies: [], functions: [], triggers: [], grants: [],
+        });
+
+        await expect(loadDatabaseModules(root, "db/invalid.ts")).rejects.toThrow("Invalid database module");
+        await expect(loadDatabaseModules(root, "db/missing.ts")).rejects.toThrow("Module file not found");
+    });
+
+    test("lint reports error-level issues and exits as error", async () => {
+        const result = await db({ action: "lint", root });
+        expect(result.isError).toBe(true);
+        const text = result.content[0].text;
+        expect(text).toContain("linted 2 module(s): cases, clean");
+        expect(text).toContain("error definer-no-search-path db/functions/case_create.sql:2");
+        expect(text).toContain("warn policy-without-test");
+    });
+
+    test("lint --module filters to a single clean module", async () => {
+        const result = await db({ action: "lint", root, module: "clean" });
+        expect(result.isError).toBe(false);
+        expect(result.content[0].text).toContain("linted 1 module(s): clean");
+        expect(result.content[0].text).toContain("no issues");
+
+        await expect(db({ action: "lint", root, module: "nope" }))
+            .rejects.toThrow("未找到数据库模块: nope");
+    });
+
+    test("explain renders objects and flags unknown targets", async () => {
+        const policy = await db({ action: "explain", root, target: "cases_select" });
+        expect(policy.isError).toBe(false);
+        expect(policy.content[0].text).toContain("类型: 策略 (policy)");
+        expect(policy.content[0].text).toContain("所属模块: cases");
+
+        const fn = await db({ action: "explain", root, target: "public.case_create" });
+        expect(fn.content[0].text).toContain("类型: 函数 (function)");
+        expect(fn.content[0].text).toContain("权限: case.create");
+
+        const table = await db({ action: "explain", root, target: "public.cases" });
+        expect(table.content[0].text).toContain("类型: 表 (table)");
+
+        const missing = await db({ action: "explain", root, target: "public.nope" });
+        expect(missing.isError).toBe(true);
+        expect(missing.content[0].text).toContain("未找到对象");
+    });
+
+    test("runModuleCheck reconciles declared state against a mocked catalog", async () => {
+        const okReport = await runModuleCheck(CASES_MODULE, mockExecutor(), ["public"]);
+        expect(okReport.ok).toBe(true);
+        expect(okReport.issues).toEqual([]);
+
+        const driftReport = await runModuleCheck(CASES_MODULE, mockExecutor({ policies: [] }), ["public"]);
+        expect(driftReport.ok).toBe(false);
+        expect(driftReport.issues.some((issue) =>
+            issue.severity === "error" && issue.code === "missing-policy"
+        )).toBe(true);
+    });
+
+    test("module_check requires a database URL", async () => {
+        await expect(db({ action: "module_check", root, module_file: "db/modules.ts" }))
+            .rejects.toThrow("--database_url");
+
+        const withEnv = captureDbCallback({ DATABASE_URL: "postgresql://127.0.0.1:1/nope" });
+        // URL 存在但连不上 → 清晰的连接错误而不是裸异常
+        await expect(withEnv({ action: "module_check", root, module_file: "db/modules.ts" }))
+            .rejects.toThrow("无法读取数据库 catalog");
+    });
+
+    test("db actions are classified in the execution policy", () => {
+        expect(executionMode("db", "lint", {})).toBe("local");
+        expect(executionMode("db", "explain", {})).toBe("local");
+        expect(executionMode("db", "module_check", {})).toBe("read");
+    });
+});

--- a/packages/cli/src/shared/tools/db-governance-tools.ts
+++ b/packages/cli/src/shared/tools/db-governance-tools.ts
@@ -1,0 +1,220 @@
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { Type } from "@sinclair/typebox";
+import {
+    buildDatabaseManifest,
+    explainObject,
+    lintModule,
+    readCatalog,
+    reconcileModule,
+    type DatabaseModule,
+    type LintIssue,
+    type QueryExecutor,
+    type ReconcileReport,
+} from "@supacloud/db";
+import { optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+
+type ToolServer = {
+    tool: (
+        name: string,
+        description: string,
+        schema: ToolSchema,
+        callback: (requestArguments: DbToolArguments) => Promise<unknown>,
+    ) => void;
+};
+
+export interface DbToolArguments {
+    action: "lint" | "explain" | "module_check";
+    module?: string;
+    root?: string;
+    module_file?: string;
+    target?: string;
+    database_url?: string;
+    schema?: string;
+}
+
+export interface DbGovernanceToolOptions {
+    environment?: NodeJS.ProcessEnv;
+    currentWorkingDirectory?: string;
+}
+
+interface ToolResult {
+    isError: boolean;
+    content: Array<{ type: "text"; text: string }>;
+}
+
+function textResult(text: string, isError = false): ToolResult {
+    return { isError, content: [{ type: "text" as const, text }] };
+}
+
+/** 归一化动态 import 出来的模块声明：缺省数组补空，保证 lint/reconcile 不崩。 */
+function normalizeModule(candidate: unknown, sourcePath: string): DatabaseModule {
+    if (typeof candidate !== "object" || candidate === null || typeof (candidate as { name?: unknown }).name !== "string") {
+        throw new Error(`Invalid database module export in ${sourcePath}（应导出 defineDatabaseModule(...) 结果）`);
+    }
+    const raw = candidate as Partial<DatabaseModule> & { name: string };
+    return {
+        name: raw.name,
+        tables: raw.tables ?? [],
+        policies: raw.policies ?? [],
+        functions: raw.functions ?? [],
+        triggers: raw.triggers ?? [],
+        grants: raw.grants ?? [],
+    };
+}
+
+/**
+ * 加载数据库治理模块声明：
+ * --module_file 指向一个 `export default defineDatabaseModule(...)`（或数组）的文件；
+ * 缺省读 <root>/db/modules.ts（default 或命名 exports modules，单个或数组均可）。
+ */
+export async function loadDatabaseModules(root: string, moduleFile?: string): Promise<DatabaseModule[]> {
+    const filePath = moduleFile
+        ? resolve(root, moduleFile)
+        : join(root, "db", "modules.ts");
+    if (!existsSync(filePath)) {
+        throw new Error(moduleFile
+            ? `Module file not found: ${filePath}`
+            : `Module file not found: ${filePath}（用 --module_file 指定一个导出 defineDatabaseModule(...) 的文件）`);
+    }
+    let imported: Record<string, unknown>;
+    try {
+        // 注意：用绝对路径而非 file:// URL——Bun 对 file:// import 有目录缓存，
+        // 运行中新写入的同目录文件会误报 Cannot find module。
+        imported = await import(filePath);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to import module file ${filePath}: ${message}`);
+    }
+    const exported = imported.default ?? imported.modules;
+    if (exported === undefined) {
+        throw new Error(`Module file ${filePath} must have a default export or a named export "modules"`);
+    }
+    const list = Array.isArray(exported) ? exported : [exported];
+    return list.map((entry) => normalizeModule(entry, filePath));
+}
+
+function formatLintIssue(issue: LintIssue): string {
+    const location = issue.line ? `${issue.file}:${issue.line}` : issue.file;
+    return `${issue.severity} ${issue.code} ${location} ${issue.message}`;
+}
+
+function formatReconcileReport(report: ReconcileReport): string {
+    const lines = [`module: ${report.module} (${report.ok ? "ok" : "FAILED"})`];
+    for (const issue of report.issues) {
+        lines.push(`  ${issue.severity} ${issue.code} ${issue.object} ${issue.message}`);
+    }
+    if (report.issues.length === 0) lines.push("  no issues");
+    return lines.join("\n");
+}
+
+/** 可测试的编排点：注入 executor，读取 catalog 并与声明模块对账。 */
+export async function runModuleCheck(
+    module: DatabaseModule,
+    executor: QueryExecutor,
+    schemas: string[] = ["public"],
+): Promise<ReconcileReport> {
+    const catalog = await readCatalog(executor, schemas);
+    return reconcileModule(module, catalog);
+}
+
+function parseSchemas(schema: string | undefined): string[] {
+    const schemas = schema?.split(",").map((entry) => entry.trim()).filter(Boolean);
+    return schemas && schemas.length > 0 ? schemas : ["public"];
+}
+
+async function runLint(args: DbToolArguments, root: string): Promise<ToolResult> {
+    const modules = await loadDatabaseModules(root, args.module_file);
+    const selected = args.module ? modules.filter((module) => module.name === args.module) : modules;
+    if (args.module && selected.length === 0) {
+        throw new Error(`未找到数据库模块: ${args.module}（可用: ${modules.map((module) => module.name).join(", ") || "none"}）`);
+    }
+    const issues: LintIssue[] = [];
+    for (const module of selected) {
+        const readSqlFile = async (path: string): Promise<string> => {
+            const absolute = resolve(root, path);
+            try {
+                return await Bun.file(absolute).text();
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                throw new Error(`SQL 源文件不可读: ${absolute}（声明于模块 ${module.name}）: ${message}`);
+            }
+        };
+        issues.push(...await lintModule(module, readSqlFile));
+    }
+    const hasError = issues.some((issue) => issue.severity === "error");
+    const header = `linted ${selected.length} module(s): ${selected.map((module) => module.name).join(", ")}`;
+    const body = issues.length > 0 ? issues.map(formatLintIssue).join("\n") : "no issues";
+    return textResult(`${header}\n${body}`, hasError);
+}
+
+async function runExplain(args: DbToolArguments, root: string): Promise<ToolResult> {
+    const target = args.target?.trim();
+    if (!target) throw new Error("db explain requires --target（策略名 / 函数名 / 表名等）");
+    const modules = await loadDatabaseModules(root, args.module_file);
+    const manifest = buildDatabaseManifest(modules);
+    const text = explainObject(manifest, target);
+    return textResult(text, text.startsWith("未找到对象"));
+}
+
+async function runModuleCheckAction(
+    args: DbToolArguments,
+    root: string,
+    environment: NodeJS.ProcessEnv,
+): Promise<ToolResult> {
+    const databaseUrl = args.database_url?.trim() || environment.DATABASE_URL?.trim();
+    if (!databaseUrl) {
+        throw new Error("db module_check requires --database_url 或环境变量 DATABASE_URL");
+    }
+    const modules = await loadDatabaseModules(root, args.module_file);
+    const schemas = parseSchemas(args.schema);
+
+    const client = new Bun.SQL(databaseUrl);
+    const executor: QueryExecutor = {
+        async query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {
+            return await client.unsafe(sql, params ?? []) as T[];
+        },
+    };
+    try {
+        const reports: ReconcileReport[] = [];
+        for (const module of modules) {
+            reports.push(await runModuleCheck(module, executor, schemas));
+        }
+        const hasError = reports.some((report) => !report.ok);
+        return textResult(reports.map(formatReconcileReport).join("\n"), hasError);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`db module_check 无法读取数据库 catalog（${databaseUrl.replace(/\/\/[^@/]*@/, "//***@")}）: ${message}`);
+    } finally {
+        await client.close({ timeout: 0 }).catch(() => {});
+    }
+}
+
+export function registerDbGovernanceTools(server: ToolServer, options: DbGovernanceToolOptions = {}): void {
+    const environment = options.environment || process.env;
+    const fallbackRoot = options.currentWorkingDirectory || process.cwd();
+    server.tool(
+        "db",
+        "Local database governance (@supacloud/db): lint declared modules, explain objects, reconcile against a live catalog. Actions: lint, explain, module_check",
+        {
+            action: withDescription(stringEnum(["lint", "explain", "module_check"]), "Database governance action"),
+            module: optional(Type.String(), "[lint] Only lint this manifest module (default: all)"),
+            root: optional(Type.String(), "[*] Project root (default: current directory)"),
+            module_file: optional(Type.String(), "[*] File exporting defineDatabaseModule(...) (default: <root>/db/modules.ts)"),
+            target: optional(Type.String(), "[explain] Policy / function / table name to explain"),
+            database_url: optional(Type.String(), "[module_check] Postgres connection URL (default: DATABASE_URL)"),
+            schema: optional(Type.String(), "[module_check] Comma-separated schemas to inspect (default: public)"),
+        },
+        async (request) => {
+            const root = resolve(request.root || fallbackRoot);
+            switch (request.action) {
+                case "lint": return runLint(request, root);
+                case "explain": return runExplain(request, root);
+                case "module_check": return runModuleCheckAction(request, root, environment);
+                default:
+                    return textResult(`Unknown db action: ${String(request.action)}`, true);
+            }
+        },
+    );
+}


### PR DESCRIPTION
## 概要

SupaCloud 应用框架阶段 4b：CLI 工具链。依赖已发布的 `@supacloud/compiler@0.1.0` 与 `@supacloud/db@0.1.0`（lockfile 为 npm registry 正式解析）。

### `app` 模块（全部 local）
- `app generate`：module / command / query / controller 脚手架（`--force` 控制覆盖，controller 已存在时提示手工合并）
- `app compile`：调用 `compileProject()`，结构化诊断输出，error 时非零退出
- `app check`：只分析 + 校验，不写文件
- `app graph`：从 `app.manifest.json` 输出模块/Provider/路由依赖树（text/json）
- `app explain`：Provider/Command/Controller 详情，含反向依赖索引与治理元数据（permission/transaction/audit）

### `db` 治理（db-governance-tools）
- `db lint`（local）：对 `defineDatabaseModule` 的 SQL 源做静态检查（security definer 无 search_path、grant to public、缺 RLS enable 等）
- `db explain`（local）：数据库对象归属、权限、测试位置
- `db module_check`（read）：Bun 内置 SQL 连接 `DATABASE_URL`，`readCatalog` + `reconcileModule` 只读对账（missing-policy / rls-disabled / definer-without-search-path 等）

### 注册义务
- `index.ts`：context 检查前注册（本地命令始终可用）、`printHelp()` 示例、单参数直达模块帮助
- `execution-policy.ts`：`app` 5 个 local action、`db` 2 local + 1 read（module_check）

## 验证

- `bun run typecheck` + `bun test src`：**968 pass / 0 fail**（含 15 个新测试：generate→compile→check→graph→explain 全链路、lint/explain fixture、mock executor 对账编排、连接错误路径、execution-policy 覆盖）
- 冒烟：`bun run src/index.ts app`、`app generate --kind module`、`db lint` 缺文件错误路径均符合预期