### PR TITLE
feat(cli): one-command deploy for monorepos

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -60,35 +60,77 @@ supacloud-cli frontend list_releases --ref abc123 --id web
 supacloud-cli frontend upload_release --ref abc123 --id web --zip_path ./dist.zip
 ```
 
-### One-command frontend deploy
+### One-command deploy
 
-`supacloud-cli deploy` is the normal developer path for a linked frontend. It
-selects the only configured frontend (or matches `frontend.id`), runs the build,
-creates a deterministic immutable release archive, uploads it, activates it with
-optimistic concurrency, and reads the final deployment URL back.
+`supacloud-cli deploy` is the normal developer path for a linked application. It
+supports a frontend and backend living in separate directories. Frontend targets
+use immutable static releases; `edge_function` targets use the existing verified
+Edge Function bundle protocol. The command runs the target build, publishes only
+that target, and reads the final identity back.
 
-Simple projects usually need no file. Monorepos and nonstandard build layouts
-can add `supacloud.json` once:
+Simple single-frontend projects usually need no file. Monorepos should add a
+repository-root `supacloud.json`:
 
 ```json
 {
-  "frontend": {
-    "id": "web",
-    "buildCommand": "bun run build:web",
-    "outputDirectory": "apps/web/dist"
+  "defaultTarget": "web",
+  "targets": {
+    "web": {
+      "type": "frontend",
+      "root": "apps/web",
+      "id": "web",
+      "buildCommand": "bun run build",
+      "outputDirectory": "dist"
+    },
+    "api": {
+      "type": "edge_function",
+      "root": "apps/api",
+      "slug": "api",
+      "buildCommand": "bun run bundle",
+      "bundleDirectory": "dist",
+      "entrypoint": "index.ts",
+      "verifyJwt": true,
+      "minify": true
+    }
   }
 }
 ```
 
 ```bash
-# Build and deploy the linked frontend.
+# From a target workspace, the target is selected automatically.
+cd apps/web
+supacloud-cli deploy
+cd ../api
 supacloud-cli deploy
 
+# From the repository root, select a target explicitly.
+supacloud-cli deploy --target web
+supacloud-cli deploy --target api
+
 # Inspect the resolved plan without building or writing remotely.
-supacloud-cli deploy --dry_run
+supacloud-cli deploy --target web --dry_run
 
 # Publish an output directory already built by CI.
-supacloud-cli deploy --skip_build --output_dir dist
+supacloud-cli deploy --target web --skip_build --output_dir dist
+```
+
+When multiple targets exist and the command runs at the repository root, it
+fails closed unless `defaultTarget` or `--target` is provided. Running inside a
+target directory selects the deepest matching `root`. Relative output and bundle
+directories are resolved against that target root, while lockfiles are detected
+from the target root up to the repository root.
+
+The legacy shape remains supported:
+
+```json
+{
+  "frontend": {
+    "id": "web",
+    "root": "apps/web",
+    "buildCommand": "bun run build",
+    "outputDirectory": "dist"
+  }
+}
 ```
 
 Production profiles retain the standard explicit confirmation gate:

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -46,6 +46,7 @@ explicitly to override host inference.
 npm install -g @supacloud/cli
 
 supacloud-cli status
+supacloud-cli deploy
 supacloud-cli project get
 supacloud-cli project logs --log_type database
 supacloud-cli database query --sql "select now()"
@@ -57,6 +58,43 @@ supacloud-cli supabase push --ref abc123 --dir supabase/migrations --dry_run
 supacloud-cli frontend list --ref abc123
 supacloud-cli frontend list_releases --ref abc123 --id web
 supacloud-cli frontend upload_release --ref abc123 --id web --zip_path ./dist.zip
+```
+
+### One-command frontend deploy
+
+`supacloud-cli deploy` is the normal developer path for a linked frontend. It
+selects the only configured frontend (or matches `frontend.id`), runs the build,
+creates a deterministic immutable release archive, uploads it, activates it with
+optimistic concurrency, and reads the final deployment URL back.
+
+Simple projects usually need no file. Monorepos and nonstandard build layouts
+can add `supacloud.json` once:
+
+```json
+{
+  "frontend": {
+    "id": "web",
+    "buildCommand": "bun run build:web",
+    "outputDirectory": "apps/web/dist"
+  }
+}
+```
+
+```bash
+# Build and deploy the linked frontend.
+supacloud-cli deploy
+
+# Inspect the resolved plan without building or writing remotely.
+supacloud-cli deploy --dry_run
+
+# Publish an output directory already built by CI.
+supacloud-cli deploy --skip_build --output_dir dist
+```
+
+Production profiles retain the standard explicit confirmation gate:
+
+```bash
+supacloud-cli --env production --confirm-production abc123 deploy
 ```
 
 Both `--key value` and `--key=value` syntax are supported. `supacloud-cli status`

--- a/packages/cli/bun.lock
+++ b/packages/cli/bun.lock
@@ -8,6 +8,7 @@
         "@sinclair/typebox": "^0.34.52",
         "@supacloud/compiler": "^0.1.0",
         "@supacloud/db": "^0.1.0",
+        "fflate": "^0.8.3",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
@@ -65,6 +66,8 @@
     "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
 
     "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "fflate": ["fflate@0.8.3", "https://registry.npmmirror.com/fflate/-/fflate-0.8.3.tgz", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@sinclair/typebox": "^0.34.52",
     "@supacloud/compiler": "^0.1.0",
-    "@supacloud/db": "^0.1.0"
+    "@supacloud/db": "^0.1.0",
+    "fflate": "^0.8.3"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,7 @@ import { registerDbGovernanceTools } from "./shared/tools/db-governance-tools";
 import { registerScheduledFunctionTools } from "./shared/tools/scheduled-function-tools";
 import { registerMutationTools } from "./shared/tools/mutation-tools";
 import { registerReleaseTools } from "./shared/tools/release-tools";
+import { deployToolSchema, registerDeployTools } from "./shared/tools/deploy-tools";
 import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
@@ -251,6 +252,7 @@ function printHelp(context: ResolvedContext) {
 
 USAGE
 
+  ${preferredCommand} [global flags] deploy [--flags]
   ${preferredCommand} [global flags] <module> <action> [--flags]
   ${preferredCommand} [global flags] status
   ${preferredCommand} --help
@@ -285,6 +287,7 @@ DEFAULT CONTEXT
 EXAMPLES
 
   ${preferredCommand} status
+  ${preferredCommand} deploy
   ${preferredCommand} project get
   ${preferredCommand} project logs --log_type database
   ${preferredCommand} project task_stats
@@ -447,6 +450,16 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
 
     if (context.credentialScope !== "management" || !context.apiUrl || !context.apiToken) {
         registerContextAwareHelp();
+        tools.deploy = {
+            schema: deployToolSchema,
+            callback: async () => ({
+                isError: true,
+                content: [{
+                    type: "text" as const,
+                    text: `⚠️ Deploy requires Management API context. Run \`${preferredCommand} status\` to inspect current detection.`,
+                }],
+            }),
+        };
         Object.assign(tools, captureTools((server) => registerDatabaseTools(server as any, undefined, {
             localOnly: true,
         })));
@@ -522,6 +535,10 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
         applicationOrigin: context.inferredSupabaseUrl || undefined,
     })));
     assign(captureTools((server) => registerFrontendTools(server as any, http)));
+    assign(captureTools((server) => registerDeployTools(server as any, http, {
+        projectRef: context.projectRef || undefined,
+        cwd: process.cwd(),
+    })));
     assign(captureTools((server) => registerGatewayTools(server as any, http, {
         projectRef: context.projectRef || undefined,
     })));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ import { registerDbGovernanceTools } from "./shared/tools/db-governance-tools";
 import { registerScheduledFunctionTools } from "./shared/tools/scheduled-function-tools";
 import { registerMutationTools } from "./shared/tools/mutation-tools";
 import { registerReleaseTools } from "./shared/tools/release-tools";
-import { deployToolSchema, registerDeployTools } from "./shared/tools/deploy-tools";
+import { deployToolSchema, findDeployConfigRoot, registerDeployTools } from "./shared/tools/deploy-tools";
 import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
@@ -288,6 +288,8 @@ EXAMPLES
 
   ${preferredCommand} status
   ${preferredCommand} deploy
+  ${preferredCommand} deploy --target web
+  ${preferredCommand} deploy --target api
   ${preferredCommand} project get
   ${preferredCommand} project logs --log_type database
   ${preferredCommand} project task_stats
@@ -522,9 +524,10 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     assign(captureTools((server) => registerAuthTools(server as any, http)));
     assign(captureTools((server) => registerOAuthClientTools(server as any, http)));
     assign(captureTools((server) => registerStorageTools(server as any, http)));
-    assign(captureTools((server) => registerAdvancedTools(server as any, http, process.env, {
+    const advancedTools = captureTools((server) => registerAdvancedTools(server as any, http, process.env, {
         readOnly: context.readOnly,
-    })));
+    }));
+    assign(advancedTools);
     assign(captureTools((server) => registerScheduledFunctionTools(server as any, http, process.env, {
         readOnly: context.readOnly,
     })));
@@ -538,6 +541,7 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     assign(captureTools((server) => registerDeployTools(server as any, http, {
         projectRef: context.projectRef || undefined,
         cwd: process.cwd(),
+        edgeFunctionDeploy: advancedTools.edge_functions?.callback,
     })));
     assign(captureTools((server) => registerGatewayTools(server as any, http, {
         projectRef: context.projectRef || undefined,
@@ -562,7 +566,8 @@ async function main() {
     }
     const globalOptions = parseGlobalOptions(rawArgs);
     const args = globalOptions.args;
-    const context = resolveSupaCloudContext(process.env, process.cwd(), {
+    const contextDirectory = args[0] === "deploy" ? await findDeployConfigRoot(process.cwd()) : process.cwd();
+    const context = resolveSupaCloudContext(process.env, contextDirectory, {
         environmentName: globalOptions.environmentName,
         envFile: globalOptions.envFile,
     });

--- a/packages/cli/src/shared/cli.ts
+++ b/packages/cli/src/shared/cli.ts
@@ -92,11 +92,12 @@ export async function runCli(
         const shape = getSchemaShape(tool.schema);
         const actionField = shape.action;
         const actionOptions = getEnumOptions(actionField);
+        const actionless = toolName === "deploy";
         const otherFields = Object.entries(shape).filter(([name]) => name !== "action");
 
         const actionLines = actionOptions.length
             ? `Available actions:\n  ${actionOptions.join("\n  ")}`
-            : "This command does not declare action metadata.";
+            : actionless ? "" : "This command does not declare action metadata.";
 
         const argLines = otherFields.length
             ? otherFields
@@ -108,10 +109,9 @@ export async function runCli(
             : "  (no additional flags)";
 
         return [
-            `Usage: ${commandName} ${toolName} <action> [--flags]`,
+            `Usage: ${commandName} ${toolName}${actionless ? "" : " <action>"} [--flags]`,
             "",
-            actionLines,
-            "",
+            ...(actionLines ? [actionLines, ""] : []),
             "Flags:",
             argLines,
         ].join("\n");

--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -66,6 +66,21 @@ function context(overrides: Partial<ResolvedContext> = {}): ResolvedContext {
 }
 
 describe("CLI execution policy", () => {
+    test("treats one-command deploy as a protected write and dry run as read-only", () => {
+        expect(executionMode("deploy", "deploy", {})).toBe("write");
+        expect(executionMode("deploy", "deploy", { dry_run: true })).toBe("read");
+        expect(() => authorizeExecution("deploy", { ref: "prod-ref" }, {
+            context: context(),
+        })).toThrow("--confirm-production prod-ref");
+        expect(() => authorizeExecution("deploy", { ref: "prod-ref" }, {
+            context: context(),
+            confirmProduction: "prod-ref",
+        })).not.toThrow();
+        expect(() => authorizeExecution("deploy", { ref: "prod-ref", dry_run: true }, {
+            context: context(),
+        })).not.toThrow();
+    });
+
     test("requires an exact production confirmation for remote writes", () => {
         for (const action of ["pause", "restore"]) {
             expect(executionMode("project", action, {})).toBe("write");

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -11,6 +11,7 @@ interface ModulePolicy {
 }
 
 const ACTION_POLICY: Record<string, ModulePolicy> = {
+    deploy: { write: ["deploy"] },
     project: {
         read: ["get", "endpoints", "health", "logs", "api_keys", "settings", "tasks", "task_detail", "task_stats", "dlq", "background_settings"],
         write: ["pause", "restore", "task_cancel", "task_retry", "update_background_settings"],
@@ -94,6 +95,7 @@ function declaredMode(moduleName: string, action: string): ExecutionMode | undef
 }
 
 export function executionMode(moduleName: string, action: string, args: Record<string, unknown>): ExecutionMode | undefined {
+    if (moduleName === "deploy" && args.dry_run === true) return "read";
     if (moduleName === "database"
         && ["push_migrations", "baseline_migrations"].includes(action)
         && args.dry_run === true) return "read";
@@ -106,7 +108,7 @@ export function authorizeExecution(
     args: Record<string, unknown>,
     authorization: ExecutionAuthorization,
 ): void {
-    const action = typeof args.action === "string" ? args.action : "";
+    const action = typeof args.action === "string" ? args.action : moduleName === "deploy" ? "deploy" : "";
     if (!action) return;
     const mode = executionMode(moduleName, action, args);
     const { context, confirmProduction } = authorization;

--- a/packages/cli/src/shared/tools/deploy-tools.test.ts
+++ b/packages/cli/src/shared/tools/deploy-tools.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -53,16 +53,28 @@ async function workspace(): Promise<string> {
     return directory;
 }
 
-async function runCli(directory: string, apiUrl: string, args: string[]) {
-    const child = Bun.spawn([process.execPath, CLI_ENTRYPOINT, ...args], {
-        cwd: directory,
-        env: {
-            ...process.env,
+async function runCli(
+    directory: string,
+    apiUrl: string,
+    args: string[],
+    options: { injectContext?: boolean } = {},
+) {
+    const environment: Record<string, string | undefined> = { ...process.env };
+    if (options.injectContext === false) {
+        for (const key of ["SUPACLOUD_API_URL", "SUPACLOUD_API_TOKEN", "SUPACLOUD_PROJECT_REF", "SUPACLOUD_ENV"]) {
+            delete environment[key];
+        }
+    } else {
+        Object.assign(environment, {
             SUPACLOUD_API_URL: apiUrl,
             SUPACLOUD_API_TOKEN: "test-token",
             SUPACLOUD_PROJECT_REF: "abc123",
             SUPACLOUD_ENV: "test",
-        },
+        });
+    }
+    const child = Bun.spawn([process.execPath, CLI_ENTRYPOINT, ...args], {
+        cwd: directory,
+        env: environment,
         stdout: "pipe",
         stderr: "pipe",
     });
@@ -74,7 +86,264 @@ async function runCli(directory: string, apiUrl: string, args: string[]) {
     return { exitCode, stdout, stderr };
 }
 
-describe("one-command frontend deploy", () => {
+describe("one-command deploy", () => {
+    test("loads repository-root context when invoked from a nested frontend workspace", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "supacloud-monorepo-env-test-"));
+        temporaryDirectories.push(directory);
+        const webRoot = join(directory, "apps", "web");
+        await mkdir(join(webRoot, "dist"), { recursive: true });
+        await writeFile(join(webRoot, "dist", "index.html"), "web\n");
+        await writeFile(join(directory, "supacloud.json"), JSON.stringify({
+            targets: {
+                web: {
+                    type: "frontend",
+                    root: "apps/web",
+                    id: "web",
+                    outputDirectory: "dist",
+                },
+            },
+        }));
+
+        const requests: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                const url = new URL(request.url);
+                requests.push(`${request.method} ${url.pathname}`);
+                if (url.pathname === "/v1/projects/abc123/frontend/deployments") return Response.json([deployment()]);
+                return new Response("not found", { status: 404 });
+            },
+        });
+        servers.push(server);
+        await writeFile(join(directory, ".env"), [
+            `SUPACLOUD_API_URL=http://127.0.0.1:${server.port}`,
+            "SUPACLOUD_API_TOKEN=test-token",
+            "SUPACLOUD_PROJECT_REF=abc123",
+            "SUPACLOUD_ENV=test",
+            "",
+        ].join("\n"));
+
+        const response = await runCli(webRoot, "", ["deploy", "--skip_build", "--dry_run", "--json"], {
+            injectContext: false,
+        });
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toMatchObject({
+            ok: true,
+            dry_run: true,
+            project_ref: "abc123",
+            deployment_id: "web",
+            output_directory: join(await realpath(directory), "apps", "web", "dist"),
+        });
+        expect(requests).toEqual(["GET /v1/projects/abc123/frontend/deployments"]);
+    });
+
+    test("selects a frontend target from a monorepo subdirectory and keeps output rooted there", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "supacloud-monorepo-test-"));
+        temporaryDirectories.push(directory);
+        await mkdir(join(directory, "apps", "web", "dist"), { recursive: true });
+        await mkdir(join(directory, "apps", "api", "dist"), { recursive: true });
+        await writeFile(join(directory, "package.json"), JSON.stringify({
+            private: true,
+            workspaces: ["apps/*"],
+        }));
+        await writeFile(join(directory, "bun.lock"), "lockfile\n");
+        await writeFile(join(directory, "supacloud.json"), JSON.stringify({
+            defaultTarget: "web",
+            targets: {
+                web: {
+                    type: "frontend",
+                    root: "apps/web",
+                    id: "web",
+                    buildCommand: "bun run build:web",
+                    outputDirectory: "dist",
+                },
+                api: {
+                    type: "edge_function",
+                    root: "apps/api",
+                    slug: "api",
+                    bundleDirectory: "dist",
+                },
+            },
+        }));
+        await writeFile(join(directory, "apps", "web", "dist", "index.html"), "web\n");
+
+        const requests: string[] = [];
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                const url = new URL(request.url);
+                requests.push(`${request.method} ${url.pathname}`);
+                if (url.pathname === "/v1/projects/abc123/frontend/deployments") return Response.json([deployment()]);
+                if (url.pathname === "/v1/projects/abc123/frontend/deployments/web/releases") {
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        active_release_id: null,
+                        active_activation_id: null,
+                        releases: [],
+                        next_cursor: null,
+                    });
+                }
+                return new Response("not found", { status: 404 });
+            },
+        });
+        servers.push(server);
+
+        const response = await runCli(join(directory, "apps", "web"), `http://127.0.0.1:${server.port}`, [
+            "deploy", "--skip_build", "--dry_run", "--json",
+        ]);
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toMatchObject({
+            ok: true,
+            dry_run: true,
+            deployment_id: "web",
+            output_directory: join(await realpath(directory), "apps", "web", "dist"),
+        });
+        expect(requests).toEqual(["GET /v1/projects/abc123/frontend/deployments"]);
+    });
+
+    test("requires an explicit target at the monorepo root", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "supacloud-monorepo-root-test-"));
+        temporaryDirectories.push(directory);
+        await mkdir(join(directory, "apps", "web"), { recursive: true });
+        await mkdir(join(directory, "apps", "api"), { recursive: true });
+        await writeFile(join(directory, "supacloud.json"), JSON.stringify({
+            targets: {
+                web: { type: "frontend", root: "apps/web", id: "web" },
+                api: { type: "edge_function", root: "apps/api", slug: "api" },
+            },
+        }));
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch: () => Response.json([]),
+        });
+        servers.push(server);
+
+        const response = await runCli(directory, `http://127.0.0.1:${server.port}`, ["deploy", "--dry_run"]);
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stderr).toContain("Multiple deploy targets found");
+    });
+
+    test("deploys an edge-function backend from its own monorepo workspace", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "supacloud-monorepo-api-test-"));
+        temporaryDirectories.push(directory);
+        const apiRoot = join(directory, "apps", "api");
+        await mkdir(join(apiRoot, "dist"), { recursive: true });
+        await writeFile(join(apiRoot, "dist", "index.ts"), "export default { fetch: () => new Response('ok') };\n");
+        await writeFile(join(directory, "supacloud.json"), JSON.stringify({
+            targets: {
+                web: { type: "frontend", root: "apps/web", id: "web" },
+                api: {
+                    type: "edge_function",
+                    root: "apps/api",
+                    slug: "api",
+                    bundleDirectory: "dist",
+                    entrypoint: "index.ts",
+                },
+            },
+        }));
+        const previousActivationId = "a1111111-1111-4111-8111-111111111111";
+        const committedActivationId = "b2222222-2222-4222-8222-222222222222";
+        let requestBody: Record<string, unknown> | null = null;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const url = new URL(request.url);
+                if (request.method === "GET" && url.pathname === "/v1/projects/abc123/functions") {
+                    return Response.json([{
+                        slug: "api",
+                        version: 4,
+                        activation_id: previousActivationId,
+                        verify_jwt: true,
+                    }]);
+                }
+                if (request.method === "POST" && url.pathname === "/v1/projects/abc123/functions/api/bundle") {
+                    requestBody = await request.json() as Record<string, unknown>;
+                    return Response.json({
+                        success: true,
+                        project_ref: "abc123",
+                        slug: "api",
+                        previous_active_version: "4",
+                        expected_activation_id: previousActivationId,
+                        activation_id: committedActivationId,
+                        active_version: "5",
+                        version: "5",
+                        config: {
+                            version: "5",
+                            verify_jwt: true,
+                            activation_id: committedActivationId,
+                        },
+                    });
+                }
+                return new Response("not found", { status: 404 });
+            },
+        });
+        servers.push(server);
+
+        const response = await runCli(apiRoot, `http://127.0.0.1:${server.port}`, [
+            "deploy", "--skip_build", "--json",
+        ]);
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toMatchObject({
+            ok: true,
+            type: "edge_function",
+            target: "api",
+            slug: "api",
+            active_version: "5",
+            activation_id: committedActivationId,
+        });
+        expect(requestBody).toMatchObject({
+            files: { "index.ts": "export default { fetch: () => new Response('ok') };\n" },
+            entrypoint: "index.ts",
+            expected_active_version: "4",
+            expected_activation_id: previousActivationId,
+        });
+    });
+
+    test("fails closed before backend deployment when the active function identity is invalid", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "supacloud-monorepo-api-identity-test-"));
+        temporaryDirectories.push(directory);
+        const apiRoot = join(directory, "apps", "api");
+        await mkdir(join(apiRoot, "dist"), { recursive: true });
+        await writeFile(join(apiRoot, "dist", "index.ts"), "export default { fetch: () => new Response('ok') };\n");
+        await writeFile(join(directory, "supacloud.json"), JSON.stringify({
+            targets: {
+                api: {
+                    type: "edge_function",
+                    root: "apps/api",
+                    slug: "api",
+                    bundleDirectory: "dist",
+                },
+            },
+        }));
+        let writes = 0;
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request) {
+                if (request.method !== "GET") writes++;
+                return Response.json({ unexpected: true });
+            },
+        });
+        servers.push(server);
+
+        const response = await runCli(apiRoot, `http://127.0.0.1:${server.port}`, [
+            "deploy", "--skip_build", "--json",
+        ]);
+
+        expect(response.exitCode).toBe(1);
+        expect(response.stderr).toContain("Unable to read the current identity for Edge Function 'api'");
+        expect(writes).toBe(0);
+    });
+
     test("creates deterministic archives with paths rooted at the output directory", async () => {
         const directory = await workspace();
         const first = await createFrontendArchive(join(directory, "dist"));

--- a/packages/cli/src/shared/tools/deploy-tools.test.ts
+++ b/packages/cli/src/shared/tools/deploy-tools.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { unzipSync } from "fflate";
+import { createFrontendArchive } from "./deploy-tools";
+
+const CLI_ENTRYPOINT = fileURLToPath(new URL("../../index.ts", import.meta.url));
+const temporaryDirectories: string[] = [];
+const servers: Array<{ stop(closeActiveConnections?: boolean): void }> = [];
+
+afterEach(async () => {
+    for (const server of servers.splice(0)) server.stop(true);
+    await Promise.all(temporaryDirectories.splice(0).map((directory) => (
+        rm(directory, { recursive: true, force: true })
+    )));
+});
+
+function release(projectRef: string, deploymentId: string, releaseId: string) {
+    return {
+        schema: "supacloud.frontend-release.v1",
+        project_ref: projectRef,
+        deployment_id: deploymentId,
+        release_id: releaseId,
+        sha256: releaseId,
+        tree_sha256: "b".repeat(64),
+        size_bytes: 128,
+        file_count: 2,
+        created_at: "2026-09-02T08:00:00.000Z",
+        kind: "prebuilt_static",
+    };
+}
+
+function deployment(id = "web") {
+    return {
+        id,
+        name: id,
+        framework: "static",
+        build_command: "",
+        output_dir: "dist",
+        deployment_url: "https://web.example.com",
+    };
+}
+
+async function workspace(): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), "supacloud-deploy-test-"));
+    temporaryDirectories.push(directory);
+    await mkdir(join(directory, "dist", "assets"), { recursive: true });
+    await writeFile(join(directory, "dist", "index.html"), "<h1>hello</h1>\n");
+    await writeFile(join(directory, "dist", "assets", "app.js"), "console.log('hello');\n");
+    return directory;
+}
+
+async function runCli(directory: string, apiUrl: string, args: string[]) {
+    const child = Bun.spawn([process.execPath, CLI_ENTRYPOINT, ...args], {
+        cwd: directory,
+        env: {
+            ...process.env,
+            SUPACLOUD_API_URL: apiUrl,
+            SUPACLOUD_API_TOKEN: "test-token",
+            SUPACLOUD_PROJECT_REF: "abc123",
+            SUPACLOUD_ENV: "test",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr };
+}
+
+describe("one-command frontend deploy", () => {
+    test("creates deterministic archives with paths rooted at the output directory", async () => {
+        const directory = await workspace();
+        const first = await createFrontendArchive(join(directory, "dist"));
+        const second = await createFrontendArchive(join(directory, "dist"));
+        try {
+            expect(first.sha256).toBe(second.sha256);
+            const archive = unzipSync(new Uint8Array(await readFile(first.archivePath)));
+            expect(Object.keys(archive).sort()).toEqual(["assets/app.js", "index.html"]);
+            expect(new TextDecoder().decode(archive["index.html"])).toBe("<h1>hello</h1>\n");
+        } finally {
+            await Promise.all([first.cleanup(), second.cleanup()]);
+        }
+    });
+
+    test("builds the immutable release flow and prints the final URL", async () => {
+        const directory = await workspace();
+        const requests: string[] = [];
+        let releaseId = "";
+        let activationId = "";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const url = new URL(request.url);
+                requests.push(`${request.method} ${url.pathname}${url.search}`);
+                const base = "/v1/projects/abc123/frontend/deployments/web/releases";
+                if (request.method === "GET" && url.pathname === "/v1/projects/abc123/frontend/deployments") {
+                    return Response.json([deployment()]);
+                }
+                if (request.method === "GET" && url.pathname === base) {
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        active_release_id: releaseId || null,
+                        active_activation_id: activationId || null,
+                        releases: releaseId ? [release("abc123", "web", releaseId)] : [],
+                        next_cursor: null,
+                    });
+                }
+                if (request.method === "POST" && url.pathname === base) {
+                    const bytes = new Uint8Array(await request.arrayBuffer());
+                    releaseId = createHash("sha256").update(bytes).digest("hex");
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        release: release("abc123", "web", releaseId),
+                    }, { status: 201 });
+                }
+                if (request.method === "GET" && url.pathname === `${base}/${releaseId}`) {
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        release: release("abc123", "web", releaseId),
+                    });
+                }
+                if (request.method === "POST" && url.pathname === `${base}/${releaseId}/activate`) {
+                    const body = await request.json() as Record<string, string>;
+                    activationId = body.mutation_id;
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        active_release_id: releaseId,
+                        activation_id: activationId,
+                        release: release("abc123", "web", releaseId),
+                        mutation: { mutation_id: activationId, status: "succeeded", replayed: false },
+                    });
+                }
+                if (request.method === "GET" && url.pathname === "/v1/projects/abc123/frontend/deployments/web") {
+                    return Response.json(deployment());
+                }
+                return new Response("not found", { status: 404 });
+            },
+        });
+        servers.push(server);
+
+        const response = await runCli(directory, `http://127.0.0.1:${server.port}`, [
+            "deploy", "--skip_build", "--json",
+        ]);
+
+        expect(response.exitCode).toBe(0);
+        expect(response.stderr).toBe("");
+        const result = JSON.parse(response.stdout);
+        expect(result).toMatchObject({
+            ok: true,
+            unchanged: false,
+            project_ref: "abc123",
+            deployment_id: "web",
+            release_id: releaseId,
+            activation_id: activationId,
+            url: "https://web.example.com",
+            file_count: 2,
+        });
+        expect(requests).toEqual([
+            "GET /v1/projects/abc123/frontend/deployments",
+            "GET /v1/projects/abc123/frontend/deployments/web/releases?limit=100",
+            "POST /v1/projects/abc123/frontend/deployments/web/releases",
+            `GET /v1/projects/abc123/frontend/deployments/web/releases/${releaseId}`,
+            `POST /v1/projects/abc123/frontend/deployments/web/releases/${releaseId}/activate`,
+            "GET /v1/projects/abc123/frontend/deployments/web/releases?limit=100",
+            `GET /v1/projects/abc123/frontend/deployments/web/releases/${releaseId}`,
+            "GET /v1/projects/abc123/frontend/deployments/web",
+        ]);
+    });
+
+    test("skips upload and activation when the content-addressed release is already active", async () => {
+        const directory = await workspace();
+        let writes = 0;
+        let releaseId = "";
+        let activationId = "";
+        const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+                const url = new URL(request.url);
+                if (request.method !== "GET") writes++;
+                const base = "/v1/projects/abc123/frontend/deployments/web/releases";
+                if (request.method === "GET" && url.pathname === "/v1/projects/abc123/frontend/deployments") {
+                    return Response.json([deployment()]);
+                }
+                if (request.method === "GET" && url.pathname === base) {
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        active_release_id: releaseId || null,
+                        active_activation_id: activationId || null,
+                        releases: releaseId ? [release("abc123", "web", releaseId)] : [],
+                        next_cursor: null,
+                    });
+                }
+                if (request.method === "POST" && url.pathname === base) {
+                    const bytes = new Uint8Array(await request.arrayBuffer());
+                    releaseId = createHash("sha256").update(bytes).digest("hex");
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        release: release("abc123", "web", releaseId),
+                    }, { status: 201 });
+                }
+                if (request.method === "GET" && url.pathname === `${base}/${releaseId}`) {
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        release: release("abc123", "web", releaseId),
+                    });
+                }
+                if (request.method === "POST" && url.pathname === `${base}/${releaseId}/activate`) {
+                    const body = await request.json() as Record<string, string>;
+                    activationId = body.mutation_id;
+                    return Response.json({
+                        project_ref: "abc123",
+                        deployment_id: "web",
+                        active_release_id: releaseId,
+                        activation_id: activationId,
+                        release: release("abc123", "web", releaseId),
+                        mutation: { mutation_id: activationId, status: "succeeded", replayed: false },
+                    });
+                }
+                if (request.method === "GET" && url.pathname === "/v1/projects/abc123/frontend/deployments/web") {
+                    return Response.json(deployment());
+                }
+                return new Response("not found", { status: 404 });
+            },
+        });
+        servers.push(server);
+
+        const first = await runCli(directory, `http://127.0.0.1:${server.port}`, [
+            "deploy", "--skip_build", "--json",
+        ]);
+        expect(first.exitCode).toBe(0);
+        expect(writes).toBe(2);
+
+        const response = await runCli(directory, `http://127.0.0.1:${server.port}`, [
+            "deploy", "--skip_build", "--json",
+        ]);
+
+        expect(response.exitCode).toBe(0);
+        expect(JSON.parse(response.stdout)).toMatchObject({
+            ok: true,
+            unchanged: true,
+            release_id: releaseId,
+        });
+        expect(writes).toBe(2);
+    });
+});

--- a/packages/cli/src/shared/tools/deploy-tools.ts
+++ b/packages/cli/src/shared/tools/deploy-tools.ts
@@ -1,7 +1,7 @@
 import { access, lstat, mkdtemp, opendir, readFile, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
-import { basename, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { spawn } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import { zipSync, type Zippable } from "fflate";
@@ -12,16 +12,34 @@ import {
     listFrontendReleases,
     uploadFrontendRelease,
 } from "./frontend-release-control";
+import { projectedFunctionList } from "./edge-function-response";
 
 const FIXED_ZIP_MTIME = new Date("1980-01-01T00:00:00.000Z");
 const MAX_SOURCE_BYTES = 256 * 1024 * 1024;
 
 interface DeployConfig {
+    defaultTarget?: string;
+    targets?: Record<string, DeployTargetConfig>;
     frontend?: {
         id?: string;
+        root?: string;
         buildCommand?: string;
         outputDirectory?: string;
     };
+}
+
+interface DeployTargetConfig {
+    type: "frontend" | "edge_function";
+    root?: string;
+    id?: string;
+    slug?: string;
+    buildCommand?: string;
+    outputDirectory?: string;
+    bundleDirectory?: string;
+    entrypoint?: string;
+    verifyJwt?: boolean;
+    minify?: boolean;
+    framework?: "fetch" | "elysia" | "hono" | "sveltekit-function";
 }
 
 interface FrontendDeployment {
@@ -36,6 +54,7 @@ interface FrontendDeployment {
 interface DeployToolOptions {
     projectRef?: string;
     cwd?: string;
+    edgeFunctionDeploy?: (args: Record<string, unknown>) => Promise<ToolResponse>;
 }
 
 interface ToolResponse {
@@ -45,6 +64,7 @@ interface ToolResponse {
 
 export const deployToolSchema = {
     ref: optional(Type.String(), "Project ref (defaults to the linked project)"),
+    target: optional(Type.String(), "Named deploy target from supacloud.json"),
     id: optional(Type.String(), "Frontend deployment ID (auto-selected when unambiguous)"),
     cwd: optional(Type.String(), "Project directory (default: current directory)"),
     build_command: optional(Type.String(), "Build command override"),
@@ -91,23 +111,75 @@ async function readJson(path: string): Promise<unknown> {
     }
 }
 
-async function readDeployConfig(projectDirectory: string): Promise<DeployConfig> {
-    const configPath = join(projectDirectory, "supacloud.json");
+export async function findDeployConfigRoot(startDirectory: string): Promise<string> {
+    let directory = resolve(startDirectory);
+    while (true) {
+        if (await pathExists(join(directory, "supacloud.json"))) return directory;
+        const parent = dirname(directory);
+        if (parent === directory) return resolve(startDirectory);
+        directory = parent;
+    }
+}
+
+function optionalText(value: unknown, field: string): string | undefined {
+    if (value === undefined) return undefined;
+    if (typeof value !== "string" || !value.trim()) {
+        throw new Error(`supacloud.json ${field} must be a non-empty string`);
+    }
+    return value.trim();
+}
+
+function optionalBoolean(value: unknown, field: string): boolean | undefined {
+    if (value === undefined) return undefined;
+    if (typeof value !== "boolean") throw new Error(`supacloud.json ${field} must be a boolean`);
+    return value;
+}
+
+function deployTargetConfig(candidate: unknown, name: string): DeployTargetConfig {
+    const value = record(candidate);
+    if (!value || (value.type !== "frontend" && value.type !== "edge_function")) {
+        throw new Error(`supacloud.json targets.${name}.type must be 'frontend' or 'edge_function'`);
+    }
+    const framework = optionalText(value.framework, `targets.${name}.framework`);
+    if (framework && !["fetch", "elysia", "hono", "sveltekit-function"].includes(framework)) {
+        throw new Error(`supacloud.json targets.${name}.framework is invalid`);
+    }
+    return {
+        type: value.type,
+        root: optionalText(value.root, `targets.${name}.root`),
+        id: optionalText(value.id, `targets.${name}.id`),
+        slug: optionalText(value.slug, `targets.${name}.slug`),
+        buildCommand: optionalText(value.buildCommand, `targets.${name}.buildCommand`),
+        outputDirectory: optionalText(value.outputDirectory, `targets.${name}.outputDirectory`),
+        bundleDirectory: optionalText(value.bundleDirectory, `targets.${name}.bundleDirectory`),
+        entrypoint: optionalText(value.entrypoint, `targets.${name}.entrypoint`),
+        verifyJwt: optionalBoolean(value.verifyJwt, `targets.${name}.verifyJwt`),
+        minify: optionalBoolean(value.minify, `targets.${name}.minify`),
+        framework: framework as DeployTargetConfig["framework"],
+    };
+}
+
+async function readDeployConfig(configRoot: string): Promise<DeployConfig> {
+    const configPath = join(configRoot, "supacloud.json");
     const candidate = await readJson(configPath);
     if (candidate === null) return {};
     const config = record(candidate);
     const frontend = record(config?.frontend);
-    if (!config || (config.frontend !== undefined && !frontend)) {
-        throw new Error("supacloud.json must contain an object-valued 'frontend' configuration");
+    const targetValues = record(config?.targets);
+    if (!config || (config.frontend !== undefined && !frontend)
+        || (config.targets !== undefined && !targetValues)) {
+        throw new Error("supacloud.json must contain object-valued 'frontend' or 'targets' configuration");
     }
-    const optionalText = (value: unknown, field: string) => {
-        if (value === undefined) return undefined;
-        if (typeof value !== "string" || !value.trim()) throw new Error(`supacloud.json ${field} must be a non-empty string`);
-        return value.trim();
-    };
     return {
+        defaultTarget: optionalText(config.defaultTarget, "defaultTarget"),
+        targets: targetValues
+            ? Object.fromEntries(Object.entries(targetValues).map(([name, value]) => (
+                [name, deployTargetConfig(value, name)]
+            )))
+            : undefined,
         frontend: frontend ? {
             id: optionalText(frontend.id, "frontend.id"),
+            root: optionalText(frontend.root, "frontend.root"),
             buildCommand: optionalText(frontend.buildCommand, "frontend.buildCommand"),
             outputDirectory: optionalText(frontend.outputDirectory, "frontend.outputDirectory"),
         } : undefined,
@@ -123,16 +195,23 @@ async function pathExists(path: string): Promise<boolean> {
     return access(path).then(() => true, () => false);
 }
 
-async function defaultBuildCommand(projectDirectory: string): Promise<string> {
+async function defaultBuildCommand(projectDirectory: string, configRoot: string): Promise<string> {
     const packageJson = record(await readJson(join(projectDirectory, "package.json")));
     const scripts = record(packageJson?.scripts);
     if (typeof scripts?.build !== "string" || !scripts.build.trim()) {
         throw new Error("No build command was configured and package.json has no build script");
     }
-    if (await pathExists(join(projectDirectory, "bun.lock"))
-        || await pathExists(join(projectDirectory, "bun.lockb"))) return "bun run build";
-    if (await pathExists(join(projectDirectory, "pnpm-lock.yaml"))) return "pnpm run build";
-    if (await pathExists(join(projectDirectory, "yarn.lock"))) return "yarn build";
+    let directory = projectDirectory;
+    while (true) {
+        if (await pathExists(join(directory, "bun.lock"))
+            || await pathExists(join(directory, "bun.lockb"))) return "bun run build";
+        if (await pathExists(join(directory, "pnpm-lock.yaml"))) return "pnpm run build";
+        if (await pathExists(join(directory, "yarn.lock"))) return "yarn build";
+        if (directory === configRoot) break;
+        const parent = dirname(directory);
+        if (parent === directory || !directory.startsWith(`${configRoot}${sep}`)) break;
+        directory = parent;
+    }
     return "npm run build";
 }
 
@@ -167,6 +246,64 @@ function selectDeployment(
         : `Multiple frontend deployments found (${ids}). Set frontend.id in supacloud.json or pass --id`);
 }
 
+interface SelectedTarget {
+    name: string;
+    config: DeployTargetConfig;
+    root: string;
+}
+
+function targetRoot(configRoot: string, target: DeployTargetConfig, name: string): string {
+    const root = resolve(configRoot, target.root || (name === "frontend" ? "." : name));
+    const prefix = `${resolve(configRoot)}${sep}`;
+    if (root !== resolve(configRoot) && !root.startsWith(prefix)) {
+        throw new Error(`Deploy target '${name}' root must stay inside the repository root`);
+    }
+    return root;
+}
+
+function selectTarget(
+    configRoot: string,
+    invocationDirectory: string,
+    config: DeployConfig,
+    requestedName?: string,
+): SelectedTarget {
+    const targets = config.targets
+        ? Object.entries(config.targets)
+        : [["frontend", {
+            type: "frontend" as const,
+            root: config.frontend?.root,
+            id: config.frontend?.id,
+            buildCommand: config.frontend?.buildCommand,
+            outputDirectory: config.frontend?.outputDirectory,
+        }]] as Array<[string, DeployTargetConfig]>;
+    if (targets.length === 0) throw new Error("supacloud.json defines no deploy targets");
+
+    if (requestedName) {
+        const selected = targets.find(([name]) => name === requestedName);
+        if (!selected) throw new Error(`Deploy target '${requestedName}' was not found in supacloud.json`);
+        return { name: selected[0], config: selected[1], root: targetRoot(configRoot, selected[1], selected[0]) };
+    }
+    const containing = targets
+        .map(([name, target]) => ({ name, target, root: targetRoot(configRoot, target, name) }))
+        .filter((candidate) => invocationDirectory === candidate.root
+            || invocationDirectory.startsWith(`${candidate.root}${sep}`))
+        .sort((left, right) => right.root.length - left.root.length);
+    if (containing.length === 1 || (containing.length > 1 && containing[0].root !== containing[1].root)) {
+        const selected = containing[0];
+        return { name: selected.name, config: selected.target, root: selected.root };
+    }
+    if (config.defaultTarget) {
+        const selected = targets.find(([name]) => name === config.defaultTarget);
+        if (!selected) throw new Error(`supacloud.json defaultTarget '${config.defaultTarget}' was not found`);
+        return { name: selected[0], config: selected[1], root: targetRoot(configRoot, selected[1], selected[0]) };
+    }
+    if (targets.length === 1) {
+        const selected = targets[0];
+        return { name: selected[0], config: selected[1], root: targetRoot(configRoot, selected[1], selected[0]) };
+    }
+    throw new Error(`Multiple deploy targets found (${targets.map(([name]) => name).sort().join(", ")}). Pass --target`);
+}
+
 function defaultOutputDirectory(framework: string): string {
     switch (framework) {
         case "sveltekit-static": return "build";
@@ -176,11 +313,12 @@ function defaultOutputDirectory(framework: string): string {
     }
 }
 
-function resolveInsideProject(projectDirectory: string, candidate: string): string {
+function resolveInsideProject(projectDirectory: string, candidate: string, allowRoot = false): string {
     const resolved = resolve(projectDirectory, candidate);
     const projectRoot = resolve(projectDirectory);
     const projectPrefix = `${projectRoot}${sep}`;
-    if (!resolved.startsWith(projectPrefix)) {
+    if ((!allowRoot && resolved === projectRoot)
+        || (resolved !== projectRoot && !resolved.startsWith(projectPrefix))) {
         throw new Error("Frontend output directory must stay inside the project directory");
     }
     return resolved;
@@ -277,10 +415,11 @@ function phaseReporter(json: boolean | undefined) {
 function deployResponse(result: Record<string, unknown>, json: boolean | undefined): ToolResponse {
     if (json) return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
     const lines = [
-        result.unchanged === true ? "Already up to date." : `Deployed ${String(result.deployment_id)}.`,
+        result.unchanged === true ? "Already up to date." : `Deployed ${String(result.target || result.deployment_id || result.slug)}.`,
         result.url ? `URL: ${String(result.url)}` : null,
-        `Release: ${String(result.release_id)}`,
-        `Files: ${String(result.file_count)}`,
+        result.release_id ? `Release: ${String(result.release_id)}` : null,
+        result.active_version ? `Active version: ${String(result.active_version)}` : null,
+        result.file_count ? `Files: ${String(result.file_count)}` : null,
         `Duration: ${(Number(result.duration_ms) / 1000).toFixed(1)}s`,
     ].filter((line): line is string => Boolean(line));
     return { content: [{ type: "text", text: lines.join("\n") }] };
@@ -296,21 +435,103 @@ export function registerDeployTools(
         "Build and publish the linked frontend with one command",
         deployToolSchema,
         async (args: Record<string, unknown>) => {
-            const projectDirectory = resolve(String(args.cwd || options.cwd || process.cwd()));
+            const invocationDirectory = resolve(String(args.cwd || options.cwd || process.cwd()));
             const projectRef = String(args.ref || options.projectRef || "").trim();
             if (!projectRef) throw new Error("A linked project ref is required. Set SUPACLOUD_PROJECT_REF or pass --ref");
-            const config = await readDeployConfig(projectDirectory);
-            const requestedId = String(args.id || config.frontend?.id || "").trim() || undefined;
+            const configRoot = await findDeployConfigRoot(invocationDirectory);
+            const config = await readDeployConfig(configRoot);
+            const target = selectTarget(configRoot, invocationDirectory, config, String(args.target || "").trim() || undefined);
+            const projectDirectory = target.root;
+            const targetState = await lstat(projectDirectory).catch(() => null);
+            if (!targetState?.isDirectory() || targetState.isSymbolicLink()) {
+                throw new Error(`Deploy target '${target.name}' root is not a regular directory: ${projectDirectory}`);
+            }
+            const requestedId = String(args.id || target.config.id || "").trim() || undefined;
             const report = phaseReporter(args.json === true);
-            report("inspect", `project ${projectRef}`);
+            report("inspect", `${target.name} (${projectRef})`);
+
+            if (target.config.type === "edge_function") {
+                if (!options.edgeFunctionDeploy) throw new Error("Edge Function deploy support is unavailable in this CLI context");
+                const slug = target.config.slug || requestedId || target.name;
+                const functionListResponse = await options.edgeFunctionDeploy({
+                    action: "list",
+                    ref: projectRef,
+                });
+                if (functionListResponse.isError) {
+                    throw new Error(`Unable to read the current identity for Edge Function '${slug}'`);
+                }
+                const functionListText = functionListResponse.content.find((chunk) => chunk.type === "text")?.text;
+                if (!functionListText) throw new Error(`Unable to read the current identity for Edge Function '${slug}'`);
+                const functions = projectedFunctionList(JSON.parse(functionListText));
+                if (!functions) throw new Error(`Invalid current identity for Edge Function '${slug}'`);
+                const current = functions?.find((candidate) => candidate.slug === slug);
+                const activeVersion = current && typeof current.version === "number" ? String(current.version) : "absent";
+                const activationId = current && typeof current.activation_id === "string" ? current.activation_id : "legacy";
+                if (!activeVersion || !activationId) throw new Error(`Edge Function '${slug}' has an invalid active identity`);
+                const buildCommand = String(args.build_command || target.config.buildCommand || "").trim()
+                    || (args.skip_build === true ? "" : await defaultBuildCommand(projectDirectory, configRoot));
+                const bundleDirectory = resolveInsideProject(
+                    projectDirectory,
+                    String(args.output_dir || target.config.bundleDirectory || target.config.outputDirectory || "dist"),
+                    true,
+                );
+                if (args.dry_run === true) {
+                    return { content: [{ type: "text" as const, text: JSON.stringify({
+                        ok: true,
+                        dry_run: true,
+                        type: target.config.type,
+                        target: target.name,
+                        project_ref: projectRef,
+                        slug,
+                        build_command: args.skip_build === true ? null : buildCommand,
+                        bundle_directory: bundleDirectory,
+                        expected_active_version: activeVersion,
+                        expected_activation_id: activationId,
+                    }, null, 2) }] };
+                }
+                if (args.skip_build !== true) {
+                    report("build", buildCommand);
+                    await runBuild(buildCommand, projectDirectory);
+                } else {
+                    report("build", "skipped");
+                }
+                report("deploy", `edge function ${slug}`);
+                const deployed = await options.edgeFunctionDeploy({
+                    action: "deploy_bundle",
+                    ref: projectRef,
+                    slug,
+                    "bundle-dir": bundleDirectory,
+                    entrypoint: target.config.entrypoint || "index.ts",
+                    minify: target.config.minify,
+                    verify_jwt: target.config.verifyJwt,
+                    framework: target.config.framework,
+                    "expected-active-version": activeVersion,
+                    "expected-activation-id": activationId,
+                });
+                if (deployed.isError) return deployed;
+                const deployedText = deployed.content.find((chunk) => chunk.type === "text")?.text;
+                const deployedPayload = deployedText ? record(JSON.parse(deployedText)) : null;
+                const durationMs = report("done", slug);
+                return deployResponse({
+                    ok: true,
+                    unchanged: false,
+                    type: target.config.type,
+                    target: target.name,
+                    project_ref: projectRef,
+                    slug,
+                    active_version: deployedPayload?.active_version,
+                    activation_id: deployedPayload?.activation_id,
+                    duration_ms: durationMs,
+                }, args.json === true);
+            }
 
             const listResponse = await http.get(`/v1/projects/${encodeURIComponent(projectRef)}/frontend/deployments`);
             if (!listResponse.ok) throw new Error(`Failed to list frontend deployments (HTTP ${listResponse.status})`);
             const selected = selectDeployment(deploymentList(listResponse.data), requestedId, await packageName(projectDirectory));
-            const configuredBuildCommand = String(args.build_command || config.frontend?.buildCommand || selected.buildCommand || "").trim();
+            const configuredBuildCommand = String(args.build_command || target.config.buildCommand || selected.buildCommand || "").trim();
             const buildCommand = configuredBuildCommand
-                || (args.skip_build === true ? "" : await defaultBuildCommand(projectDirectory));
-            const configuredOutput = String(args.output_dir || config.frontend?.outputDirectory || "").trim();
+                || (args.skip_build === true ? "" : await defaultBuildCommand(projectDirectory, configRoot));
+            const configuredOutput = String(args.output_dir || target.config.outputDirectory || "").trim();
             const remoteOutput = selected.outputDirectory && selected.outputDirectory !== "." ? selected.outputDirectory : "";
             const outputDirectory = resolveInsideProject(
                 projectDirectory,

--- a/packages/cli/src/shared/tools/deploy-tools.ts
+++ b/packages/cli/src/shared/tools/deploy-tools.ts
@@ -1,0 +1,398 @@
+import { access, lstat, mkdtemp, opendir, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { basename, join, relative, resolve, sep } from "node:path";
+import { spawn } from "node:child_process";
+import { Type } from "@sinclair/typebox";
+import { zipSync, type Zippable } from "fflate";
+import { optional } from "../schema";
+import type { HttpTransport } from "../transports/http";
+import {
+    activateFrontendRelease,
+    listFrontendReleases,
+    uploadFrontendRelease,
+} from "./frontend-release-control";
+
+const FIXED_ZIP_MTIME = new Date("1980-01-01T00:00:00.000Z");
+const MAX_SOURCE_BYTES = 256 * 1024 * 1024;
+
+interface DeployConfig {
+    frontend?: {
+        id?: string;
+        buildCommand?: string;
+        outputDirectory?: string;
+    };
+}
+
+interface FrontendDeployment {
+    id: string;
+    name: string;
+    framework: string;
+    buildCommand: string;
+    outputDirectory: string;
+    deploymentUrl: string | null;
+}
+
+interface DeployToolOptions {
+    projectRef?: string;
+    cwd?: string;
+}
+
+interface ToolResponse {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+}
+
+export const deployToolSchema = {
+    ref: optional(Type.String(), "Project ref (defaults to the linked project)"),
+    id: optional(Type.String(), "Frontend deployment ID (auto-selected when unambiguous)"),
+    cwd: optional(Type.String(), "Project directory (default: current directory)"),
+    build_command: optional(Type.String(), "Build command override"),
+    output_dir: optional(Type.String(), "Build output directory override"),
+    skip_build: optional(Type.Boolean(), "Use an existing output directory without building"),
+    dry_run: optional(Type.Boolean(), "Resolve and validate the deployment without building or publishing"),
+    json: optional(Type.Boolean(), "Print only the final JSON result"),
+};
+
+function record(candidate: unknown): Record<string, unknown> | null {
+    return candidate && typeof candidate === "object" && !Array.isArray(candidate)
+        ? candidate as Record<string, unknown>
+        : null;
+}
+
+function requiredString(candidate: unknown, field: string): string {
+    if (typeof candidate !== "string" || !candidate.trim()) {
+        throw new Error(`Invalid frontend deployment response: missing ${field}`);
+    }
+    return candidate.trim();
+}
+
+function frontendDeployment(candidate: unknown): FrontendDeployment {
+    const value = record(candidate);
+    if (!value) throw new Error("Invalid frontend deployment response");
+    return {
+        id: requiredString(value.id, "id"),
+        name: typeof value.name === "string" && value.name.trim() ? value.name.trim() : requiredString(value.id, "id"),
+        framework: typeof value.framework === "string" ? value.framework.trim() : "static",
+        buildCommand: typeof value.build_command === "string" ? value.build_command.trim() : "",
+        outputDirectory: typeof value.output_dir === "string" ? value.output_dir.trim() : "",
+        deploymentUrl: typeof value.deployment_url === "string" && value.deployment_url.trim()
+            ? value.deployment_url.trim()
+            : null,
+    };
+}
+
+async function readJson(path: string): Promise<unknown> {
+    try {
+        return JSON.parse(await readFile(path, "utf8"));
+    } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+        throw new Error(`Invalid JSON file ${path}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+
+async function readDeployConfig(projectDirectory: string): Promise<DeployConfig> {
+    const configPath = join(projectDirectory, "supacloud.json");
+    const candidate = await readJson(configPath);
+    if (candidate === null) return {};
+    const config = record(candidate);
+    const frontend = record(config?.frontend);
+    if (!config || (config.frontend !== undefined && !frontend)) {
+        throw new Error("supacloud.json must contain an object-valued 'frontend' configuration");
+    }
+    const optionalText = (value: unknown, field: string) => {
+        if (value === undefined) return undefined;
+        if (typeof value !== "string" || !value.trim()) throw new Error(`supacloud.json ${field} must be a non-empty string`);
+        return value.trim();
+    };
+    return {
+        frontend: frontend ? {
+            id: optionalText(frontend.id, "frontend.id"),
+            buildCommand: optionalText(frontend.buildCommand, "frontend.buildCommand"),
+            outputDirectory: optionalText(frontend.outputDirectory, "frontend.outputDirectory"),
+        } : undefined,
+    };
+}
+
+async function packageName(projectDirectory: string): Promise<string | null> {
+    const candidate = record(await readJson(join(projectDirectory, "package.json")));
+    return typeof candidate?.name === "string" && candidate.name.trim() ? candidate.name.trim() : null;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+    return access(path).then(() => true, () => false);
+}
+
+async function defaultBuildCommand(projectDirectory: string): Promise<string> {
+    const packageJson = record(await readJson(join(projectDirectory, "package.json")));
+    const scripts = record(packageJson?.scripts);
+    if (typeof scripts?.build !== "string" || !scripts.build.trim()) {
+        throw new Error("No build command was configured and package.json has no build script");
+    }
+    if (await pathExists(join(projectDirectory, "bun.lock"))
+        || await pathExists(join(projectDirectory, "bun.lockb"))) return "bun run build";
+    if (await pathExists(join(projectDirectory, "pnpm-lock.yaml"))) return "pnpm run build";
+    if (await pathExists(join(projectDirectory, "yarn.lock"))) return "yarn build";
+    return "npm run build";
+}
+
+function deploymentList(candidate: unknown): FrontendDeployment[] {
+    const values = Array.isArray(candidate)
+        ? candidate
+        : Array.isArray(record(candidate)?.deployments) ? record(candidate)?.deployments as unknown[] : null;
+    if (!values) throw new Error("Invalid frontend deployment list response");
+    return values.map(frontendDeployment);
+}
+
+function selectDeployment(
+    deployments: FrontendDeployment[],
+    requestedId: string | undefined,
+    projectName: string | null,
+): FrontendDeployment {
+    if (requestedId) {
+        const selected = deployments.find((deployment) => deployment.id === requestedId);
+        if (!selected) throw new Error(`Frontend deployment '${requestedId}' was not found`);
+        return selected;
+    }
+    if (deployments.length === 1) return deployments[0];
+    if (projectName) {
+        const matches = deployments.filter((deployment) => (
+            deployment.id === projectName || deployment.name === projectName
+        ));
+        if (matches.length === 1) return matches[0];
+    }
+    const ids = deployments.map((deployment) => deployment.id).sort().join(", ");
+    throw new Error(deployments.length === 0
+        ? "No frontend deployments exist for this project"
+        : `Multiple frontend deployments found (${ids}). Set frontend.id in supacloud.json or pass --id`);
+}
+
+function defaultOutputDirectory(framework: string): string {
+    switch (framework) {
+        case "sveltekit-static": return "build";
+        case "nextjs": return "out";
+        case "static": return "dist";
+        default: return "dist";
+    }
+}
+
+function resolveInsideProject(projectDirectory: string, candidate: string): string {
+    const resolved = resolve(projectDirectory, candidate);
+    const projectRoot = resolve(projectDirectory);
+    const projectPrefix = `${projectRoot}${sep}`;
+    if (!resolved.startsWith(projectPrefix)) {
+        throw new Error("Frontend output directory must stay inside the project directory");
+    }
+    return resolved;
+}
+
+async function runBuild(command: string, cwd: string): Promise<void> {
+    await new Promise<void>((resolvePromise, reject) => {
+        const child = spawn(command, { cwd, env: process.env, shell: true, stdio: "inherit" });
+        child.once("error", reject);
+        child.once("exit", (code, signal) => {
+            if (code === 0) resolvePromise();
+            else reject(new Error(`Build command failed (${signal ? `signal ${signal}` : `exit ${code ?? "unknown"}`}): ${command}`));
+        });
+    });
+}
+
+async function collectArchiveFiles(root: string): Promise<{ files: Zippable; bytes: number; count: number }> {
+    const rootStat = await lstat(root).catch(() => null);
+    if (!rootStat?.isDirectory() || rootStat.isSymbolicLink()) {
+        throw new Error(`Frontend output directory does not exist or is not a regular directory: ${root}`);
+    }
+    const paths: string[] = [];
+    const visit = async (directory: string): Promise<void> => {
+        const entries = [];
+        for await (const entry of await opendir(directory)) entries.push(entry);
+        entries.sort((left, right) => left.name.localeCompare(right.name, "en"));
+        for (const entry of entries) {
+            const path = join(directory, entry.name);
+            const stats = await lstat(path);
+            if (stats.isSymbolicLink()) throw new Error(`Frontend output cannot contain symbolic links: ${path}`);
+            if (stats.isDirectory()) await visit(path);
+            else if (stats.isFile()) paths.push(path);
+            else throw new Error(`Frontend output contains an unsupported file type: ${path}`);
+        }
+    };
+    await visit(root);
+    if (paths.length === 0) throw new Error(`Frontend output directory is empty: ${root}`);
+
+    let bytes = 0;
+    const files: Zippable = {};
+    for (const path of paths) {
+        const data = new Uint8Array(await readFile(path));
+        bytes += data.byteLength;
+        if (bytes > MAX_SOURCE_BYTES) throw new Error(`Frontend output exceeds ${MAX_SOURCE_BYTES} bytes`);
+        const archivePath = relative(root, path).split(sep).join("/");
+        files[archivePath] = [data, { mtime: FIXED_ZIP_MTIME }];
+    }
+    return { files, bytes, count: paths.length };
+}
+
+export async function createFrontendArchive(outputDirectory: string): Promise<{
+    archivePath: string;
+    sha256: string;
+    sourceBytes: number;
+    fileCount: number;
+    cleanup(): Promise<void>;
+}> {
+    const collected = await collectArchiveFiles(outputDirectory);
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), "supacloud-deploy-"));
+    const archivePath = join(temporaryDirectory, `${basename(outputDirectory)}.zip`);
+    try {
+        const archiveBytes = zipSync(collected.files, { level: 6, mtime: FIXED_ZIP_MTIME });
+        await writeFile(archivePath, archiveBytes);
+        const sha256 = createHash("sha256").update(archiveBytes).digest("hex");
+        return {
+            archivePath,
+            sha256,
+            sourceBytes: collected.bytes,
+            fileCount: collected.count,
+            cleanup: () => rm(temporaryDirectory, { recursive: true, force: true }),
+        };
+    } catch (error) {
+        await rm(temporaryDirectory, { recursive: true, force: true });
+        throw error;
+    }
+}
+
+function payload(response: ToolResponse): Record<string, unknown> {
+    if (response.isError) throw new Error(response.content[0]?.text || "Deployment operation failed");
+    const text = response.content.find((chunk) => chunk.type === "text")?.text;
+    const parsed = text ? record(JSON.parse(text)) : null;
+    if (!parsed) throw new Error("Deployment operation returned an invalid response");
+    return parsed;
+}
+
+function phaseReporter(json: boolean | undefined) {
+    const started = performance.now();
+    return (phase: string, detail: string) => {
+        if (!json) console.error(`  ${phase.padEnd(10)} ${detail}`);
+        return Math.round(performance.now() - started);
+    };
+}
+
+function deployResponse(result: Record<string, unknown>, json: boolean | undefined): ToolResponse {
+    if (json) return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    const lines = [
+        result.unchanged === true ? "Already up to date." : `Deployed ${String(result.deployment_id)}.`,
+        result.url ? `URL: ${String(result.url)}` : null,
+        `Release: ${String(result.release_id)}`,
+        `Files: ${String(result.file_count)}`,
+        `Duration: ${(Number(result.duration_ms) / 1000).toFixed(1)}s`,
+    ].filter((line): line is string => Boolean(line));
+    return { content: [{ type: "text", text: lines.join("\n") }] };
+}
+
+export function registerDeployTools(
+    server: { tool: (...args: any[]) => void },
+    http: HttpTransport,
+    options: DeployToolOptions = {},
+): void {
+    server.tool(
+        "deploy",
+        "Build and publish the linked frontend with one command",
+        deployToolSchema,
+        async (args: Record<string, unknown>) => {
+            const projectDirectory = resolve(String(args.cwd || options.cwd || process.cwd()));
+            const projectRef = String(args.ref || options.projectRef || "").trim();
+            if (!projectRef) throw new Error("A linked project ref is required. Set SUPACLOUD_PROJECT_REF or pass --ref");
+            const config = await readDeployConfig(projectDirectory);
+            const requestedId = String(args.id || config.frontend?.id || "").trim() || undefined;
+            const report = phaseReporter(args.json === true);
+            report("inspect", `project ${projectRef}`);
+
+            const listResponse = await http.get(`/v1/projects/${encodeURIComponent(projectRef)}/frontend/deployments`);
+            if (!listResponse.ok) throw new Error(`Failed to list frontend deployments (HTTP ${listResponse.status})`);
+            const selected = selectDeployment(deploymentList(listResponse.data), requestedId, await packageName(projectDirectory));
+            const configuredBuildCommand = String(args.build_command || config.frontend?.buildCommand || selected.buildCommand || "").trim();
+            const buildCommand = configuredBuildCommand
+                || (args.skip_build === true ? "" : await defaultBuildCommand(projectDirectory));
+            const configuredOutput = String(args.output_dir || config.frontend?.outputDirectory || "").trim();
+            const remoteOutput = selected.outputDirectory && selected.outputDirectory !== "." ? selected.outputDirectory : "";
+            const outputDirectory = resolveInsideProject(
+                projectDirectory,
+                configuredOutput || remoteOutput || defaultOutputDirectory(selected.framework),
+            );
+
+            if (args.dry_run === true) {
+                return { content: [{ type: "text" as const, text: JSON.stringify({
+                    ok: true,
+                    dry_run: true,
+                    project_ref: projectRef,
+                    deployment_id: selected.id,
+                    build_command: args.skip_build === true ? null : buildCommand,
+                    output_directory: outputDirectory,
+                }, null, 2) }] };
+            }
+
+            if (args.skip_build !== true) {
+                report("build", buildCommand);
+                await runBuild(buildCommand, projectDirectory);
+            } else {
+                report("build", "skipped");
+            }
+
+            report("package", relative(projectDirectory, outputDirectory) || ".");
+            const archive = await createFrontendArchive(outputDirectory);
+            try {
+                const inventory = payload(await listFrontendReleases(http, projectRef, selected.id, undefined, 100));
+                const activeReleaseId = typeof inventory.active_release_id === "string" ? inventory.active_release_id : null;
+                const activeActivationId = typeof inventory.active_activation_id === "string" ? inventory.active_activation_id : null;
+
+                if (archive.sha256 === activeReleaseId) {
+                    const durationMs = report("done", "already current");
+                    return deployResponse({
+                        ok: true,
+                        unchanged: true,
+                        project_ref: projectRef,
+                        deployment_id: selected.id,
+                        release_id: archive.sha256,
+                        url: selected.deploymentUrl,
+                        file_count: archive.fileCount,
+                        source_bytes: archive.sourceBytes,
+                        duration_ms: durationMs,
+                    }, args.json === true);
+                }
+
+                report("upload", `${archive.fileCount} files`);
+                const uploaded = payload(await uploadFrontendRelease(http, projectRef, selected.id, archive.archivePath));
+                const release = record(uploaded.release);
+                const releaseId = requiredString(release?.release_id, "release.release_id");
+                if (releaseId !== archive.sha256) throw new Error("Uploaded release identity does not match the local archive");
+
+                report("activate", releaseId.slice(0, 12));
+                const mutationId = crypto.randomUUID();
+                const activated = payload(await activateFrontendRelease(http, {
+                    projectRef,
+                    deploymentId: selected.id,
+                    releaseId,
+                    expectedActiveReleaseId: activeReleaseId || "absent",
+                    expectedActivationId: activeActivationId || "absent",
+                    mutationId,
+                }));
+                const finalResponse = await http.get(
+                    `/v1/projects/${encodeURIComponent(projectRef)}/frontend/deployments/${encodeURIComponent(selected.id)}`,
+                );
+                const finalDeployment = finalResponse.ok ? frontendDeployment(finalResponse.data) : selected;
+                const durationMs = report("done", finalDeployment.deploymentUrl || selected.id);
+                return deployResponse({
+                    ok: true,
+                    unchanged: false,
+                    project_ref: projectRef,
+                    deployment_id: selected.id,
+                    release_id: activated.active_release_id,
+                    activation_id: activated.activation_id,
+                    url: finalDeployment.deploymentUrl,
+                    file_count: archive.fileCount,
+                    source_bytes: archive.sourceBytes,
+                    duration_ms: durationMs,
+                }, args.json === true);
+            } finally {
+                await archive.cleanup();
+            }
+        },
+    );
+}


### PR DESCRIPTION
## Summary
- add `supacloud-cli deploy` for deterministic immutable frontend releases
- support separate frontend and Edge Function backend targets in monorepos
- auto-discover repository-root `supacloud.json` and `.env` from nested workspaces
- preserve optimistic concurrency and fail-closed backend identity checks

## Validation
- `bun test src`: 978 pass, 0 fail
- focused deploy and execution-policy tests: 23 pass, 0 fail
- `bun run typecheck`
- `bun run build`
