### PR TITLE
test(lite): widen Windows test budgets for slow-runner paths

### DIFF
--- a/packages/supacloud-lite/test/chat-issues-compatibility.test.ts
+++ b/packages/supacloud-lite/test/chat-issues-compatibility.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test'
+import { testTimeout } from './helpers/timeouts.js'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -82,4 +83,4 @@ test('兼容 Supabase 聊天项目的 messages 迁移、即时读取、Realtime 
     await running.close()
     await rm(projectDir, { recursive: true, force: true })
   }
-}, 60_000)
+}, testTimeout(60_000))

--- a/packages/supacloud-lite/test/cli-readonly.test.ts
+++ b/packages/supacloud-lite/test/cli-readonly.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import { testTimeout } from './helpers/timeouts.js'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
@@ -43,7 +44,7 @@ describe('read-only CLI commands', () => {
     expect(inspection.stdout).toContain('current_schema')
     expect(inspection.stdout).not.toContain('pending_schema')
     await expectLiveSchemaUnchanged(projectDir)
-  }, 30_000)
+  }, testTimeout(30_000))
 
   test('gen types reads the live schema without applying pending migrations or seed', async () => {
     const projectDir = await projectWithPendingMigration()
@@ -54,7 +55,7 @@ describe('read-only CLI commands', () => {
     expect(generatedTypes.stdout).toContain('current_schema')
     expect(generatedTypes.stdout).not.toContain('pending_schema')
     await expectLiveSchemaUnchanged(projectDir)
-  }, 30_000)
+  }, testTimeout(30_000))
 })
 
 async function projectWithPendingMigration(): Promise<string> {

--- a/packages/supacloud-lite/test/functions-elysia.test.ts
+++ b/packages/supacloud-lite/test/functions-elysia.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test'
+import { testTimeout } from './helpers/timeouts.js'
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -50,4 +51,4 @@ test('loads an Elysia function with framework profile and routes function-local 
   } finally {
     await rm(projectDir, { recursive: true, force: true })
   }
-}, 60_000)
+}, testTimeout(60_000))

--- a/packages/supacloud-lite/test/functions-restart.test.ts
+++ b/packages/supacloud-lite/test/functions-restart.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'bun:test'
+import { testTimeout } from './helpers/timeouts.js'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -36,4 +37,4 @@ test('reloads Deno.serve and default fetch-object functions after an in-process 
   } finally {
     await rm(projectDir, { recursive: true, force: true })
   }
-}, 60_000)
+}, testTimeout(60_000))

--- a/packages/supacloud-lite/test/helpers/timeouts.ts
+++ b/packages/supacloud-lite/test/helpers/timeouts.ts
@@ -1,0 +1,8 @@
+/**
+ * Windows CI runners boot PGlite (WASM) and spawn CLI subprocesses noticeably
+ * slower than Linux/macOS. Apply a uniform multiplier to per-test budgets so
+ * slow-but-correct runs don't fail Required Checks.
+ */
+export function testTimeout(ms: number): number {
+  return process.platform === 'win32' ? ms * 3 : ms
+}

--- a/packages/supacloud-lite/test/queues-pgredis.test.ts
+++ b/packages/supacloud-lite/test/queues-pgredis.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { testTimeout } from './helpers/timeouts.js'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -333,7 +334,7 @@ describe('Edge Function pgredis compatibility', () => {
     } finally {
       await rm(projectDir, { recursive: true, force: true })
     }
-  })
+  }, testTimeout(20_000))
 })
 
 function pgredis(): PgredisCacheBinding {


### PR DESCRIPTION
## 概要

Windows CI runner 上 PGlite（WASM）启动与 CLI 子进程明显更慢，最近多次在 Required Checks 中阻塞与本 PR 内容无关的合并（#1083、#1086 发布 PR、#1093 均遇到）。

### 变更

- 新增 `test/helpers/timeouts.ts`：`testTimeout(ms)` 在 win32 上按 3 倍放宽预算
- 应用到实际观测到超时的路径：
  - `chat-issues-compatibility`（realtime 订阅，60s）
  - `cli-readonly`（inspect / gen types 子进程，30s × 2）
  - `queues-pgredis`（file-backed PGlite 持久化，原走默认 20s）
  - 顺带覆盖同类风险点：`functions-restart`、`functions-elysia`（esbuild bundling，60s）

不改变任何测试逻辑与断言，仅放宽 Windows 下的时间预算；Linux/macOS 数值不变。

## 验证

- `tsc --noEmit` 干净
- 受改文件本地全绿（cli-readonly + queues-pgredis 12/12）