### PR TITLE
feat(app): enforce command governance at runtime

### DIFF
--- a/docs/application-framework.md
+++ b/docs/application-framework.md
@@ -58,7 +58,11 @@ export class AcceptCaseCommand { /* ... */ }
 export class CaseController {
   constructor(private readonly acceptCase: AcceptCaseCommand) {}
 
-  @Post("/:caseId/accept", { body: CaseAcceptInput, response: CaseAcceptResult })
+  @Post("/:caseId/accept", {
+    body: CaseAcceptInput,
+    response: CaseAcceptResult,
+    command: AcceptCaseCommand,
+  })
   accept(ctx: { body: unknown; params: Record<string, string> }) {
     return this.acceptCase.execute(ctx.params.caseId, ctx.body);
   }
@@ -90,7 +94,7 @@ const result = await compileProject({
 });
 ```
 
-诊断码：`circular-dependency`、`scope-violation`、`module-boundary`、`unresolved-token`、`duplicate-token`、`command-missing-permission`（strict 下为 error）、`missing-deps`。
+诊断码：`circular-dependency`、`scope-violation`、`module-boundary`、`unresolved-token`、`duplicate-token`、`duplicate-module`、`duplicate-command`、`duplicate-route`、`route-command-unresolved`、`command-missing-permission`（strict 下为 error）、`missing-deps`。
 
 产物：
 
@@ -106,12 +110,18 @@ import { createCompiledModules } from "./generated/application";
 export default createApplication({
   name: "fa-api",
   modules: createCompiledModules({ dbClient, /* 平台依赖 */ }),
+  commandExecutor: async (invocation, next) => {
+    await authorize(invocation.requestContext, invocation.command.permission);
+    return next();
+  },
 });
 ```
 
 - application 级服务经 `.decorate()` 挂载，全实例共享
 - request 级 provider 经 `.resolve()` 每请求新建，并发请求互不串扰
 - 路由自动接 TypeBox body/params/query/response 校验（失败返回 422）
+- 绑定 `command` 的路由必须通过 `commandExecutor`；未配置执行器时 fail-closed
+- `errorMapper` 可把业务异常映射为统一错误协议
 - 部署清单使用 `framework: "elysia"`，Edge Runtime 直接调用 `app.handle(request)`
 
 ## 大型项目迁移模式（Strangler）
@@ -128,7 +138,7 @@ export default createApplication({
 `@supacloud/testing` 提供：
 
 - `createTestModule(meta, overrides)`：Provider 替换（fake repository、fake OCR provider 等）
-- `testRequest` / `testJson`：HTTP 级测试
+- `testRequest` / `testJson` / `testJsonError`：HTTP 与统一错误协议测试
 - `runSqlTests` / `assertPolicyAllows` / `assertPolicyDenies`：数据库与 RLS 测试
 
 参见 [Database Governance](./database-governance.md)。

--- a/packages/app/src/decorators.test.ts
+++ b/packages/app/src/decorators.test.ts
@@ -128,19 +128,28 @@ describe("@Controller and route decorators", () => {
   test("accumulates routes in declaration order", () => {
     const CreateCaseInput = { type: "object" };
 
+    @Command({ name: "case.create", permission: "case.create" })
+    class CreateCaseCommand {}
+
     @Controller("/cases")
     class CaseController {
       @Get("/:id")
       get() {}
 
-      @Post("/", { body: CreateCaseInput })
+      @Post("/", { body: CreateCaseInput, command: CreateCaseCommand })
       create() {}
     }
 
     expect(getControllerMeta(CaseController)).toEqual({ path: "/cases" });
     expect(getRoutes(CaseController)).toEqual([
       { method: "GET", path: "/:id", handler: "get" },
-      { method: "POST", path: "/", handler: "create", body: CreateCaseInput },
+      {
+        method: "POST",
+        path: "/",
+        handler: "create",
+        body: CreateCaseInput,
+        command: CreateCaseCommand,
+      },
     ]);
   });
 });

--- a/packages/app/src/decorators.ts
+++ b/packages/app/src/decorators.ts
@@ -75,6 +75,8 @@ export interface RouteOptions {
   query?: unknown;
   /** TypeBox schema for the response. */
   response?: unknown;
+  /** Command class whose governance metadata must be enforced for this route. */
+  command?: Type<unknown>;
 }
 
 export interface RouteDefinition extends RouteOptions {

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -64,6 +64,10 @@ interface ApplicationGraph {
 | `module-boundary` | error | 依赖的 token 由未 import 的模块提供 |
 | `unresolved-token` | error | 依赖的 token 无法解析且不属于平台注入 |
 | `duplicate-token` | error | 同一 token 在同模块重复注册 |
+| `duplicate-module` | error | 应用中存在重复模块名 |
+| `duplicate-command` | error | 应用中存在重复业务 command 名 |
+| `duplicate-route` | error | 规范化后 HTTP method + path 冲突 |
+| `route-command-unresolved` | error | 路由绑定了本模块未声明的 command 类 |
 | `command-missing-permission` | warn（strict 时 error） | `@Command` 未声明 permission |
 | `missing-deps` | warn（strict 时 error） | 构造/工厂依赖无法静态解析 |
 

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -108,7 +108,7 @@ describe("analyzeProject：controller 与路由", () => {
     expect(controller.className).toBe("CaseController");
     expect(controller.path).toBe("/cases");
     expect(controller.scope).toBe("request");
-    expect(controller.deps).toEqual(["CASE_REPOSITORY", "REQUEST_CONTEXT"]);
+    expect(controller.deps).toEqual(["CASE_REPOSITORY", "AUDIT_SERVICE", "REQUEST_CONTEXT"]);
     expect(controller.importPath).toBe("src/features/case/case.controller");
   });
 
@@ -122,6 +122,7 @@ describe("analyzeProject：controller 与路由", () => {
       body: "CreateCaseBody",
       params: "AcceptParams",
       response: "AcceptResult",
+      command: "AcceptCaseCommand",
     });
     expect(controller.schemaImports).toEqual({
       CreateCaseBody: "src/features/case/contracts",

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -480,6 +480,13 @@ function parseController(el: Expression, ctx: AnalysisContext): ControllerNode |
             if (importPath) schemaImports[schemaExpr.getText()] = importPath;
           }
         }
+        const commandExpr = getProp(optionsArg, "command");
+        if (commandExpr && Node.isIdentifier(commandExpr)) {
+          const commandDecl = resolveDeclaration(commandExpr)[0];
+          route.command = commandDecl && Node.isClassDeclaration(commandDecl)
+            ? (commandDecl.getName() ?? commandExpr.getText())
+            : commandExpr.getText();
+        }
       }
       routes.push(route);
     }

--- a/packages/compiler/src/fixtures/bad-project.ts
+++ b/packages/compiler/src/fixtures/bad-project.ts
@@ -114,4 +114,41 @@ export class MysteryService {
 })
 export class MiscModule {}
 `,
+
+  "src/routes.ts": `import { Command, Controller, Module, Post } from "./runtime";
+
+@Command({ name: "bad.duplicate", permission: "bad.write" })
+export class FirstCommand {}
+
+@Command({ name: "bad.duplicate", permission: "bad.write" })
+export class SecondCommand {}
+
+export class MissingCommand {}
+
+@Controller("/duplicate")
+export class FirstController {
+  @Post("/", { command: FirstCommand })
+  execute() {}
+}
+
+@Controller("/duplicate")
+export class SecondController {
+  @Post("/", { command: MissingCommand })
+  execute() {}
+}
+
+@Module({
+  name: "route-one",
+  providers: [FirstCommand],
+  controllers: [FirstController],
+})
+export class FirstRouteModule {}
+
+@Module({
+  name: "route-two",
+  providers: [SecondCommand],
+  controllers: [SecondController],
+})
+export class SecondRouteModule {}
+`,
 };

--- a/packages/compiler/src/fixtures/good-project.ts
+++ b/packages/compiler/src/fixtures/good-project.ts
@@ -115,13 +115,15 @@ export class AcceptCaseCommand {
 `,
 
   "src/features/case/case.controller.ts": `import { Controller, Inject, Post, REQUEST_CONTEXT } from "../../runtime";
-import { CASE_REPOSITORY } from "../shared/tokens";
+import { AUDIT_SERVICE, CASE_REPOSITORY } from "../shared/tokens";
+import { AcceptCaseCommand } from "./accept-case.command";
 import { AcceptParams, AcceptResult, CreateCaseBody } from "./contracts";
 
 @Controller("/cases")
 export class CaseController {
   constructor(
     @Inject(CASE_REPOSITORY) readonly repository: unknown,
+    @Inject(AUDIT_SERVICE) readonly audit: unknown,
     @Inject(REQUEST_CONTEXT) readonly ctx: unknown,
   ) {}
 
@@ -129,6 +131,7 @@ export class CaseController {
     body: CreateCaseBody,
     params: AcceptParams,
     response: AcceptResult,
+    command: AcceptCaseCommand,
   })
   accept(): { ok: boolean } {
     return { ok: true };

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -52,6 +52,7 @@ describe("generate：application.ts 关键内容", () => {
     expect(applicationCode).toContain("export interface CompiledModule {");
     expect(applicationCode).toContain("export interface CompiledController {");
     expect(applicationCode).toContain("export interface CompiledRoute {");
+    expect(applicationCode).toContain("export interface CompiledCommand {");
     expect(applicationCode).not.toContain("@supacloud/app");
     expect(applicationCode).not.toContain("@supacloud/elysia");
   });
@@ -100,7 +101,7 @@ describe("generate：application.ts 关键内容", () => {
   test("request 工厂：REQUEST_CONTEXT 传 ctx，其余从 services 解析", () => {
     expect(applicationCode).toContain("createCaseRequestScope");
     expect(applicationCode).toContain(
-      "const caseController = new CaseController(services.caseRepository, ctx);",
+      "const caseController = new CaseController(services.caseRepository, imported.audit.auditService, ctx);",
     );
   });
 
@@ -108,7 +109,7 @@ describe("generate：application.ts 关键内容", () => {
     expect(applicationCode).toContain('serviceKey: "caseController"');
     expect(applicationCode).toContain('path: "/cases"');
     expect(applicationCode).toContain(
-      '{ method: "POST", path: "/:caseId/accept", handler: "accept", body: CreateCaseBody, params: AcceptParams, response: AcceptResult }',
+      '{ method: "POST", path: "/:caseId/accept", handler: "accept", body: CreateCaseBody, params: AcceptParams, response: AcceptResult, command: "AcceptCaseCommand" }',
     );
   });
 });
@@ -130,6 +131,11 @@ describe("generate：application.ts 可被 bun 直接执行", () => {
       "health",
     ]);
     expect(modules[0].controllers).toEqual([]);
+    expect(modules[1].commands[0]).toMatchObject({
+      className: "AcceptCaseCommand",
+      name: "case.accept",
+      permission: "case.accept",
+    });
     expect(typeof modules[1].createRequestScope).toBe("function");
     expect(modules[2].createRequestScope).toBeUndefined();
   });
@@ -164,11 +170,13 @@ describe("generate：application.ts 可被 bun 直接执行", () => {
 
     const ctx1 = { requestId: "r1" };
     const ctx2 = { requestId: "r2" };
-    const scope1 = caseModule.createRequestScope(services, ctx1);
-    const scope2 = caseModule.createRequestScope(services, ctx2);
+    const imported = { audit: modules[0].createServices(deps, {}) };
+    const scope1 = caseModule.createRequestScope(services, ctx1, imported);
+    const scope2 = caseModule.createRequestScope(services, ctx2, imported);
 
     expect(scope1.caseController.ctx).toBe(ctx1);
     expect(scope1.caseController.repository).toBe(services.caseRepository);
+    expect(scope1.caseController.audit).toBe(imported.audit.auditService);
     expect(scope2.caseController.ctx).toBe(ctx2);
     expect(scope2.caseController).not.toBe(scope1.caseController);
   });

--- a/packages/compiler/src/generate.ts
+++ b/packages/compiler/src/generate.ts
@@ -24,6 +24,16 @@ const INTERFACES = `export interface CompiledRoute {
   params?: unknown;
   query?: unknown;
   response?: unknown;
+  command?: string;
+}
+
+export interface CompiledCommand {
+  className: string;
+  name: string;
+  permission?: string;
+  transaction?: string;
+  audit?: string;
+  idempotency?: string;
 }
 
 export interface CompiledController {
@@ -42,12 +52,15 @@ export interface CompiledModule {
   createRequestScope?(
     services: Record<string, unknown>,
     ctx: unknown,
+    imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
   createJobScope?(
     services: Record<string, unknown>,
     ctx: unknown,
+    imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
   controllers: CompiledController[];
+  commands: CompiledCommand[];
 }`;
 
 export interface GenerateOptions {
@@ -232,6 +245,7 @@ class ModuleGenerator {
       lines.push(`  createJobScope: create${this.pascal}JobScope,`);
     }
     lines.push(`  controllers: ${this.renderControllers()},`);
+    lines.push(`  commands: ${JSON.stringify(this.module.commands)},`);
     lines.push(`}`);
     return lines.join("\n");
   }
@@ -259,6 +273,7 @@ class ModuleGenerator {
             fields.push(`${field}: ${local}`);
           }
         }
+        if (route.command) fields.push(`command: ${JSON.stringify(route.command)}`);
         return `{ ${fields.join(", ")} }`;
       });
       return [
@@ -290,6 +305,7 @@ class ModuleGenerator {
       `function create${this.pascal}${suffix}(`,
       `  services: Record<string, unknown>,`,
       `  ctx: unknown,`,
+      `  imported: Record<string, Record<string, unknown>> = {},`,
       `): Record<string, unknown> {`,
       indent(this.renderFactoryBody(kind), 2),
       `}`,
@@ -412,7 +428,7 @@ class ModuleGenerator {
       const imported = this.graph.modules.find((m) => m.name === importName);
       if (!imported?.exports.includes(token)) continue;
       if (kind === "services") return `imported.${importName}.${camelName(token)}`;
-      return `services.${camelName(token)}`;
+      return `imported.${importName}.${camelName(token)}`;
     }
 
     if (kind === "services") return `deps.${camelName(token)}`;

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -44,6 +44,8 @@ export interface RouteNode {
   params?: string;
   query?: string;
   response?: string;
+  /** @Command-decorated class explicitly bound by the route. */
+  command?: string;
 }
 
 export interface ControllerNode {

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -97,4 +97,23 @@ describe("validateGraph：坏 fixture 诊断", () => {
   test("HIDDEN_TOKEN 有 provider，不算 externalToken", () => {
     expect(graph.externalTokens).not.toContain("HIDDEN_TOKEN");
   });
+
+  test("duplicate-command：拒绝重复的业务命令名", () => {
+    const duplicates = byCode("duplicate-command");
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0].message).toContain("bad.duplicate");
+  });
+
+  test("duplicate-route：拒绝规范化后重复的方法和路径", () => {
+    const duplicates = byCode("duplicate-route");
+    expect(duplicates).toHaveLength(1);
+    expect(duplicates[0].message).toContain("POST /duplicate");
+  });
+
+  test("route-command-unresolved：路由只能绑定本模块声明的命令", () => {
+    const unresolved = byCode("route-command-unresolved");
+    expect(unresolved).toHaveLength(1);
+    expect(unresolved[0].message).toContain("MissingCommand");
+    expect(unresolved[0].message).toContain("route-two");
+  });
 });

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -65,6 +65,66 @@ export function validateGraph(graph: ApplicationGraph, strict = false): Diagnost
     diagnostics.push({ severity: strict ? "error" : "warn", code, message, file, line });
   };
 
+  const modulesByName = new Map<string, ModuleNode>();
+  const commandsByName = new Map<string, { module: ModuleNode; className: string }>();
+  const routesByKey = new Map<string, { module: ModuleNode; controller: ControllerNode }>();
+
+  for (const module of graph.modules) {
+    const previousModule = modulesByName.get(module.name);
+    if (previousModule) {
+      error(
+        "duplicate-module",
+        `模块名 ${module.name} 重复（首次声明于 ${previousModule.file}:${previousModule.line}）`,
+        module.file,
+        module.line,
+      );
+    } else {
+      modulesByName.set(module.name, module);
+    }
+
+    for (const command of module.commands) {
+      const previousName = commandsByName.get(command.name);
+      if (previousName) {
+        error(
+          "duplicate-command",
+          `command 名 ${command.name} 重复（首次由模块 ${previousName.module.name} 的 ${previousName.className} 声明）`,
+          module.file,
+          module.line,
+        );
+      } else {
+        commandsByName.set(command.name, { module, className: command.className });
+      }
+    }
+
+  }
+
+  for (const module of graph.modules) {
+    for (const controller of module.controllers) {
+      for (const route of controller.routes) {
+        const fullPath = joinRoutePaths(controller.path, route.path);
+        const key = `${route.method} ${fullPath}`;
+        const previous = routesByKey.get(key);
+        if (previous) {
+          error(
+            "duplicate-route",
+            `路由 ${key} 重复（首次声明于模块 ${previous.module.name} 的 ${previous.controller.className}）`,
+            controller.file,
+          );
+        } else {
+          routesByKey.set(key, { module, controller });
+        }
+
+        if (route.command && !module.commands.some((command) => command.className === route.command)) {
+          error(
+            "route-command-unresolved",
+            `路由 ${key} 绑定的 command 类 ${route.command} 未在模块 ${module.name} 声明`,
+            controller.file,
+          );
+        }
+      }
+    }
+  }
+
   for (const module of graph.modules) {
     // duplicate-token：同一 token 在同模块重复注册。
     const seen = new Map<string, ProviderNode>();
@@ -136,6 +196,12 @@ export function validateGraph(graph: ApplicationGraph, strict = false): Diagnost
 
   diagnostics.push(...detectCycles(graph, resolveDep));
   return diagnostics;
+}
+
+function joinRoutePaths(prefix: string, path: string): string {
+  const joined = `${prefix}/${path}`.replace(/\/{2,}/g, "/");
+  const normalized = joined.length > 1 ? joined.replace(/\/+$/, "") : joined;
+  return normalized.replace(/:[^/]+/g, ":param");
 }
 
 /** provider 级循环依赖检测（DFS，报环路径）。 */

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -18,6 +18,16 @@ interface CompiledRoute {
   params?: unknown;
   query?: unknown;
   response?: unknown;
+  command?: string;  // @Command class name bound to the route
+}
+
+interface CompiledCommand {
+  className: string;
+  name: string;
+  permission?: string;
+  transaction?: string;
+  audit?: string;
+  idempotency?: string;
 }
 
 interface CompiledController {
@@ -36,8 +46,10 @@ interface CompiledModule {
   createRequestScope?(
     services: Record<string, unknown>,
     ctx: unknown,
+    imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
   controllers: CompiledController[];
+  commands?: CompiledCommand[];
 }
 ```
 
@@ -61,6 +73,10 @@ const app = createApplication({
     requestId: request.headers.get("x-request-id") ?? crypto.randomUUID(),
     request,
   }),
+  commandExecutor: async (invocation, next) => {
+    await authorize(invocation.requestContext, invocation.command.permission);
+    return next();
+  },
 });
 
 export default app;
@@ -78,6 +94,10 @@ export default app;
 - Full route paths are `controller.path + route.path` (slashes normalized);
   schema options (`body` / `params` / `query` / `response`) are passed to
   Elysia only when the corresponding field exists.
+- A route with `command` must pass through `commandExecutor`. Missing executors
+  fail closed with `501 COMMAND_EXECUTOR_UNAVAILABLE`.
+- `errorMapper` can map failures to an application-specific envelope. The
+  default response is `{ ok: false, code, message, details? }`.
 
 Lower-level building blocks:
 

--- a/packages/elysia/src/index.test.ts
+++ b/packages/elysia/src/index.test.ts
@@ -106,8 +106,19 @@ function createCaseModule(captured: Captured): CompiledModule {
             handler: "create",
             body: t.Object({ title: t.String() }),
             response: t.Object({ id: t.String(), title: t.String() }),
+            command: "CreateCaseCommand",
           },
         ],
+      },
+    ],
+    commands: [
+      {
+        className: "CreateCaseCommand",
+        name: "case.create",
+        permission: "case.create",
+        transaction: "required",
+        audit: "case.created",
+        idempotency: "required",
       },
     ],
   };
@@ -132,7 +143,7 @@ function createApp(captured: Captured, options?: Partial<ApplicationOptions>) {
 
 describe("createApplication", () => {
   test("serves GET and POST routes with JSON responses", async () => {
-    const app = createApp({});
+    const app = createApp({}, { commandExecutor: (_invocation, next) => next() });
 
     const getRes = await testRequest(app, "/cases/42", {
       headers: { "x-request-id": "req-get" },
@@ -154,7 +165,7 @@ describe("createApplication", () => {
   });
 
   test("rejects invalid bodies with 422 via Elysia validation", async () => {
-    const app = createApp({});
+    const app = createApp({}, { commandExecutor: (_invocation, next) => next() });
 
     const res = await testRequest(app, "/cases", {
       method: "POST",
@@ -202,6 +213,56 @@ describe("createApplication", () => {
     const res = await testRequest(app, "/cases/7");
     expect(res.status).toBe(200);
     expect(captured.auditService?.entries).toEqual(["case.get:7"]);
+  });
+
+  test("enforces command-bound routes through the configured executor", async () => {
+    const events: string[] = [];
+    const app = createApp({}, {
+      commandExecutor: async (invocation, next) => {
+        events.push(`${invocation.command.name}:${invocation.command.permission}`);
+        return next();
+      },
+    });
+
+    const res = await testRequest(app, "/cases", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "governed" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "case-1", title: "governed" });
+    expect(events).toEqual(["case.create:case.create"]);
+  });
+
+  test("fails closed when a command-bound route has no executor", async () => {
+    const app = createApp({});
+    const res = await testRequest(app, "/cases", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "blocked" }),
+    });
+    expect(res.status).toBe(501);
+    expect(await res.json()).toMatchObject({
+      ok: false,
+      code: "COMMAND_EXECUTOR_UNAVAILABLE",
+    });
+  });
+
+  test("allows applications to map errors to their public envelope", async () => {
+    const app = createApp({}, {
+      errorMapper: (error, context) => Response.json({
+        ok: false,
+        code: context.frameworkCode,
+        message: error instanceof Error ? error.message : String(error),
+      }, { status: 409 }),
+    });
+    const res = await testRequest(app, "/cases", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "blocked" }),
+    });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ ok: false });
   });
 });
 

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -14,6 +14,17 @@ export interface CompiledRoute {
   params?: unknown;
   query?: unknown;
   response?: unknown;
+  /** Class name of the @Command explicitly bound to this route. */
+  command?: string;
+}
+
+export interface CompiledCommand {
+  className: string;
+  name: string;
+  permission?: string;
+  transaction?: string;
+  audit?: string;
+  idempotency?: string;
 }
 
 export interface CompiledController {
@@ -34,8 +45,11 @@ export interface CompiledModule {
   createRequestScope?(
     services: Record<string, unknown>,
     ctx: unknown,
+    imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
   controllers: CompiledController[];
+  /** Optional for compatibility with previously generated modules. */
+  commands?: CompiledCommand[];
 }
 
 // ---------------------------------------------------------------------------
@@ -46,6 +60,55 @@ export type RequestContextFactory = (
   request: Request,
 ) => unknown | Promise<unknown>;
 
+export interface CommandInvocation {
+  command: CompiledCommand;
+  input: {
+    body: unknown;
+    params: Record<string, string>;
+    query: Record<string, unknown>;
+  };
+  request: Request;
+  requestContext: unknown;
+  scope?: Record<string, unknown>;
+  services: Record<string, unknown>;
+}
+
+export type CommandExecutor = (
+  invocation: CommandInvocation,
+  next: () => unknown | Promise<unknown>,
+) => unknown | Promise<unknown>;
+
+export interface ApplicationErrorOptions {
+  status?: number;
+  code?: string;
+  details?: unknown;
+}
+
+export class ApplicationError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details?: unknown;
+
+  constructor(message: string, options: ApplicationErrorOptions = {}) {
+    super(message);
+    this.name = "ApplicationError";
+    this.status = options.status ?? 500;
+    this.code = options.code ?? "INTERNAL_ERROR";
+    this.details = options.details;
+  }
+}
+
+export interface ErrorContext {
+  request: Request;
+  requestContext: unknown;
+  frameworkCode: string | number | undefined;
+}
+
+export type ErrorMapper = (
+  error: unknown,
+  context: ErrorContext,
+) => Response | undefined | Promise<Response | undefined>;
+
 export interface ApplicationOptions {
   name?: string;
   /** Modules in topological import order. */
@@ -54,6 +117,10 @@ export interface ApplicationOptions {
   deps?: Record<string, unknown>;
   /** Builds the per-request context object. Defaults to { requestId, request }. */
   requestContext?: RequestContextFactory;
+  /** Enforces permission/audit/idempotency policy for command-bound routes. */
+  commandExecutor?: CommandExecutor;
+  /** Maps framework or application failures to the public HTTP contract. */
+  errorMapper?: ErrorMapper;
 }
 
 const defaultRequestContext: RequestContextFactory = (request) => ({
@@ -73,6 +140,7 @@ interface HttpContext {
   query: Record<string, unknown>;
   request: Request;
   scope?: Record<string, unknown>;
+  requestContext?: unknown;
 }
 
 type ControllerInstance = Record<
@@ -98,18 +166,21 @@ export function createModulePlugin(
   compiled: CompiledModule,
   services: Record<string, unknown>,
   ctxFactory: RequestContextFactory = defaultRequestContext,
+  options: Pick<ApplicationOptions, "commandExecutor" | "errorMapper"> = {},
+  imported: Record<string, Record<string, unknown>> = {},
 ): Elysia {
+  const requestContexts = new WeakMap<Request, unknown>();
   const plugin = new Elysia({ name: `supacloud:${compiled.name}` }).decorate(
     "services",
     services,
   );
 
-  if (compiled.createRequestScope) {
-    const createRequestScope = compiled.createRequestScope;
-    plugin.resolve(async ({ request }) => ({
-      scope: createRequestScope(services, await ctxFactory(request)),
-    }));
-  }
+  const createRequestScope = compiled.createRequestScope;
+  plugin.resolve(async ({ request }) => {
+    const requestContext = await ctxFactory(request);
+    requestContexts.set(request, requestContext);
+    return { requestContext };
+  });
 
   for (const controller of compiled.controllers) {
     for (const route of controller.routes) {
@@ -121,8 +192,12 @@ export function createModulePlugin(
       if (route.response !== undefined) schema.response = route.response;
 
       const handler = async (ctx: HttpContext) => {
+        const requestContext = ctx.requestContext ?? await ctxFactory(ctx.request);
+        const requestScope = createRequestScope
+          ? createRequestScope(services, requestContext, imported)
+          : undefined;
         const source =
-          controller.scope === "request" ? ctx.scope : services;
+          controller.scope === "request" ? requestScope : services;
         const instance = source?.[controller.serviceKey] as
           | ControllerInstance
           | undefined;
@@ -132,13 +207,37 @@ export function createModulePlugin(
             `supacloud: controller "${controller.serviceKey}" has no handler "${route.handler}" in scope "${controller.scope}"`,
           );
         }
-        return method.call(instance, {
+        const input = {
           body: ctx.body,
           params: ctx.params,
           query: ctx.query,
           request: ctx.request,
-          scope: ctx.scope,
-        });
+          scope: requestScope,
+          requestContext,
+        };
+        const invoke = () => method.call(instance, input);
+        if (!route.command) return invoke();
+
+        const command = compiled.commands?.find((item) => item.className === route.command);
+        if (!command) {
+          throw new ApplicationError(`Command "${route.command}" is not registered`, {
+            code: "COMMAND_NOT_REGISTERED",
+          });
+        }
+        if (!options.commandExecutor) {
+          throw new ApplicationError(`Command "${command.name}" has no executor`, {
+            status: 501,
+            code: "COMMAND_EXECUTOR_UNAVAILABLE",
+          });
+        }
+        return options.commandExecutor({
+          command,
+          input,
+          request: ctx.request,
+          requestContext,
+          scope: requestScope,
+          services,
+        }, invoke);
       };
 
       switch (route.method) {
@@ -161,7 +260,43 @@ export function createModulePlugin(
     }
   }
 
+  plugin.onError({ as: "global" }, async ({ code, error, request }) => {
+    const context: ErrorContext = {
+      request,
+      requestContext: requestContexts.get(request),
+      frameworkCode: code,
+    };
+    const mapped = await options.errorMapper?.(error, context);
+    return mapped ?? defaultErrorResponse(error, code);
+  });
+
   return plugin as unknown as Elysia;
+}
+
+export function defaultErrorResponse(
+  error: unknown,
+  frameworkCode?: string | number,
+): Response {
+  if (error instanceof ApplicationError) {
+    return Response.json({
+      ok: false,
+      code: error.code,
+      message: error.message,
+      ...(error.details === undefined ? {} : { details: error.details }),
+    }, { status: error.status });
+  }
+  if (frameworkCode === "VALIDATION") {
+    return Response.json({
+      ok: false,
+      code: "VALIDATION_ERROR",
+      message: "Request validation failed",
+    }, { status: 422 });
+  }
+  return Response.json({
+    ok: false,
+    code: "INTERNAL_ERROR",
+    message: "Internal Server Error",
+  }, { status: 500 });
 }
 
 /**
@@ -173,13 +308,21 @@ export function createModulePlugin(
  */
 export function createApplication(options: ApplicationOptions): Elysia {
   const app = new Elysia({ name: options.name ?? "supacloud:app" });
-  const ctxFactory = options.requestContext ?? defaultRequestContext;
+  const configuredContextFactory = options.requestContext ?? defaultRequestContext;
+  const contextCache = new WeakMap<Request, Promise<unknown>>();
+  const ctxFactory: RequestContextFactory = (request) => {
+    const cached = contextCache.get(request);
+    if (cached) return cached;
+    const pending = Promise.resolve(configuredContextFactory(request));
+    contextCache.set(request, pending);
+    return pending;
+  };
   const imported: Record<string, Record<string, unknown>> = {};
 
   for (const module of options.modules) {
     const services = module.createServices(options.deps ?? {}, imported);
     imported[module.name] = services;
-    app.use(createModulePlugin(module, services, ctxFactory));
+    app.use(createModulePlugin(module, services, ctxFactory, options, imported));
   }
 
   return app as unknown as Elysia;

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -30,17 +30,22 @@ assertions. Circular dependencies throw with the ring path. Only
 application-level instantiation is supported — re-create request/job scoped
 providers yourself with a context object.
 
-## HTTP helpers — `testRequest` / `testJson`
+## HTTP helpers — `testRequest` / `testJson` / `testJsonError`
 
 Dispatch in-memory requests against any fetch-style handle (Elysia included):
 
 ```ts
-import { testJson, testRequest } from "@supacloud/testing";
+import { testJson, testJsonError, testRequest } from "@supacloud/testing";
 
 const res = await testRequest(app, "/health");
 const { status, body } = await testJson<{ id: string }>(app, "/cases", {
   method: "POST",
   body: JSON.stringify({ title: "hello" }),
+});
+
+await testJsonError(app, "/cases/forbidden", {
+  status: 403,
+  code: "FORBIDDEN",
 });
 ```
 

--- a/packages/testing/src/http.test.ts
+++ b/packages/testing/src/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { testJson, testRequest } from "./http";
+import { testJson, testJsonError, testRequest } from "./http";
 import type { HandleLike } from "./http";
 
 /** Echo handle: reports the request method and URL as JSON. */
@@ -43,5 +43,36 @@ describe("testJson", () => {
     expect(status).toBe(201);
     expect(body.method).toBe("PUT");
     expect(body.url).toBe("http://localhost/cases?page=1");
+  });
+});
+
+describe("testJsonError", () => {
+  test("validates the standard error envelope", async () => {
+    const app: HandleLike = {
+      handle: () => Response.json({
+        ok: false,
+        code: "FORBIDDEN",
+        message: "Forbidden",
+      }, { status: 403 }),
+    };
+    const body = await testJsonError(app, "/cases", {
+      status: 403,
+      code: "FORBIDDEN",
+    });
+    expect(body.message).toBe("Forbidden");
+  });
+
+  test("rejects mismatched status or code", async () => {
+    const app: HandleLike = {
+      handle: () => Response.json({
+        ok: false,
+        code: "NOT_FOUND",
+        message: "Not Found",
+      }, { status: 404 }),
+    };
+    expect(testJsonError(app, "/cases", {
+      status: 403,
+      code: "FORBIDDEN",
+    })).rejects.toThrow("Expected status 403");
   });
 });

--- a/packages/testing/src/http.ts
+++ b/packages/testing/src/http.ts
@@ -27,3 +27,37 @@ export async function testJson<T = unknown>(
   const body = (await response.json()) as T;
   return { status: response.status, body };
 }
+
+export interface JsonErrorBody {
+  ok: false;
+  code: string;
+  message: string;
+  details?: unknown;
+}
+
+/** Dispatch a request and assert the standard SupaCloud JSON error contract. */
+export async function testJsonError(
+  app: HandleLike,
+  path: string,
+  expected: { status: number; code: string },
+  init: RequestInit = {},
+): Promise<JsonErrorBody> {
+  const response = await testRequest(app, path, init);
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error(`Expected JSON error response, received status ${response.status}`);
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("Expected JSON error response body to be an object");
+  }
+  const error = body as Record<string, unknown>;
+  if (response.status !== expected.status) {
+    throw new Error(`Expected status ${expected.status}, received ${response.status}`);
+  }
+  if (error.ok !== false || error.code !== expected.code || typeof error.message !== "string") {
+    throw new Error(`Expected error code ${expected.code}, received ${String(error.code)}`);
+  }
+  return error as unknown as JsonErrorBody;
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,6 +1,6 @@
 export { createTestModule, tokenKey } from "./test-module";
 export type { ModuleMetaLike, ProviderOverride } from "./test-module";
-export { testJson, testRequest } from "./http";
-export type { HandleLike } from "./http";
+export { testJson, testJsonError, testRequest } from "./http";
+export type { HandleLike, JsonErrorBody } from "./http";
 export { assertPolicyAllows, assertPolicyDenies, runSqlTests } from "./db";
 export type { SqlExecutor, SqlTestResult } from "./db";


### PR DESCRIPTION
## Summary
- bind routes to command metadata and generate command metadata
- add duplicate and unresolved command/route diagnostics
- add Elysia command executor and fail-closed error mapping
- preserve request-scope dependency propagation across modules
- add `testJsonError` helper and update framework documentation/tests

## Validation
- app: 17 tests, typecheck, test typecheck, build
- compiler: 33 tests, typecheck, test typecheck, build
- elysia: 8 tests, typecheck, test typecheck, build
- testing: 20 tests, typecheck, test typecheck, build
- `git diff --check`