### PR TITLE
feat(lite): enforce function limits and capability declarations locally

### DIFF
--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -96,6 +96,27 @@ framework = "elysia"   # fetch（默认）| elysia | hono
 
 注意：浏览器预检（OPTIONS）会转发给框架应用，框架函数应自行挂载 CORS（如 `@elysiajs/cors`），与生产 Edge Runtime 行为一致。
 
+#### Function 限制与能力声明
+
+`[functions.<name>]` 可声明运行限制（limits）与能力（capabilities），字段与生产 Edge Runtime Manifest v2 一一对应：
+
+```toml
+[functions.api]
+timeout_ms = 15000                        # limits.timeout_ms
+max_request_body_bytes = 1048576          # limits.max_request_body_bytes
+outbound_hosts = ["api.example.com"]      # capabilities.outbound_hosts
+secrets = ["OPENAI_API_KEY"]              # capabilities.secrets
+```
+
+| config.toml 字段 | 类型 | 语义 | 生产 Edge Runtime 对应 |
+| --- | --- | --- | --- |
+| `timeout_ms` | integer | 单次调用超时；超时返回 504 并 abort 请求 | `limits.timeout_ms` |
+| `max_request_body_bytes` | integer | 请求体上限；content-length 超限返回 413，无长度声明的流式 body 超限则中断读取 | `limits.max_request_body_bytes` |
+| `outbound_hosts` | string[] | `fetch` 出站 host 白名单（精确匹配，不含端口）；loopback（localhost/127.0.0.1/::1）始终放行，未声明的 host 直接抛错 | `capabilities.outbound_hosts` |
+| `secrets` | string[] | 函数可见的环境变量白名单：基础三键（`SUPABASE_URL`/`SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_ROLE_KEY`）+ 声明的 key，同时约束 `Deno.env` 与 `ctx.env` | `capabilities.secrets` |
+
+与生产的差异：Lite 面向本地开发，未声明时默认**不限制**（不包 fetch、env 全量可见）；生产 Edge Runtime 有 900s 超时与 30MB 请求体的默认上限。OPTIONS 预检与正常请求走同一路径、受同一组限制约束。
+
 #### Auth 运行方式
 
 Lite 不下载、安装或启动独立的 GoTrue 进程。`/auth/v1/*` 由同一个 Bun 进程中的内置 Auth 实现处理，并与该 Lite 项目的 PGlite `auth` schema 共享生命周期；这避免了 sidecar 的配置、端口和会话一致性负担。

--- a/packages/supacloud-lite/src/runtime/functions/fetch-policy.ts
+++ b/packages/supacloud-lite/src/runtime/functions/fetch-policy.ts
@@ -1,0 +1,58 @@
+/**
+ * Outbound fetch policy for edge functions: while a function that declares
+ * capabilities.outbound_hosts runs, globalThis.fetch may only reach the
+ * declared hosts (exact host match, port excluded) plus loopback - loopback is
+ * always allowed so a function can call back into the local API. Mirrors the
+ * SupaCloud Edge Runtime Manifest v2 capabilities.outbound_hosts semantics.
+ *
+ * Like the Deno/pgredis shims, the wrapped fetch is installed once per process
+ * and the allowlist lives in an AsyncLocalStorage store, so concurrent
+ * invocations of functions with different policies each enforce their own list
+ * (a naive global swap + finally-restore would race across interleaved awaits).
+ * Outside a policy scope - including functions that don't declare
+ * outbound_hosts - the wrapper passes straight through to the original fetch.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+const policyStore = new AsyncLocalStorage<ReadonlySet<string>>()
+
+// functions legitimately call back into the Lite API / DB on loopback
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(['localhost', '127.0.0.1', '::1'])
+
+let installed = false
+
+function installFetchPolicyShim(): void {
+  if (installed) return
+  installed = true
+  const original = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const allowed = policyStore.getStore()
+    if (!allowed) return original(input, init)
+    const host = hostOf(input)
+    if (host !== undefined && !LOOPBACK_HOSTS.has(host) && !allowed.has(host)) {
+      throw new Error(`outbound host not allowed: ${host}`)
+    }
+    return original(input, init)
+  }) as typeof fetch
+}
+
+/**
+ * Run `fn` with fetch restricted to `allowedHosts` (plus loopback). The
+ * binding lives in an async-context store, so it stays correct across awaits
+ * and never leaks into other invocations - there is nothing to restore.
+ */
+export function runWithFetchPolicy<T>(allowedHosts: string[], fn: () => Promise<T>): Promise<T> {
+  installFetchPolicyShim()
+  return policyStore.run(new Set(allowedHosts), fn)
+}
+
+/** Extract the comparison host (no port, no IPv6 brackets) from a fetch input. */
+function hostOf(input: RequestInfo | URL): string | undefined {
+  try {
+    const raw = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const host = new URL(raw).hostname
+    return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+  } catch {
+    return undefined
+  }
+}

--- a/packages/supacloud-lite/src/runtime/functions/handler.ts
+++ b/packages/supacloud-lite/src/runtime/functions/handler.ts
@@ -11,6 +11,7 @@
  */
 import type { RequestContext } from '../types.js'
 import { runWithDenoEnv } from './deno-shim.js'
+import { runWithFetchPolicy } from './fetch-policy.js'
 import { type PgredisCache, runWithPgredisCache } from './pgredis.js'
 
 /** An edge function: a fetch handler invoked with the resolved request context. */
@@ -35,11 +36,39 @@ export interface FrameworkObjectHandler {
 /** Anything registerable as a function: plain fetch handler or router object. */
 export type FunctionHandler = EdgeFunction | FrameworkObjectHandler
 
-/** A loaded function plus its declared framework profile. */
+/**
+ * Per-invocation resource limits, aligned with the Edge Runtime Manifest v2
+ * `limits` block (timeout_ms / max_request_body_bytes). Lite defaults to no
+ * limit when undeclared; production caps at 900s / 30MB.
+ */
+export interface FunctionLimits {
+  /** limits.timeout_ms: max wall time per invocation; on expiry the request is aborted and a 504 returned. */
+  timeoutMs?: number
+  /** limits.max_request_body_bytes: max inbound body size; oversized bodies get a 413. */
+  maxRequestBodyBytes?: number
+}
+
+/**
+ * Declared capabilities, aligned with the Edge Runtime Manifest v2
+ * `capabilities` block (secrets / outbound_hosts). Undeclared means
+ * unrestricted (back-compat).
+ */
+export interface FunctionCapabilities {
+  /** capabilities.secrets: env keys (beyond the SUPABASE_* base trio) visible to the function. */
+  secrets?: string[]
+  /** capabilities.outbound_hosts: exact fetch host allowlist (no port); loopback is always allowed. */
+  outboundHosts?: string[]
+}
+
+/** A loaded function plus its declared framework profile, limits, and capabilities. */
 export interface LoadedFunction {
   handler: FunctionHandler
   /** config.toml [functions.<name>].framework; `fetch` keeps legacy routing. */
   framework?: FunctionFramework
+  /** config.toml [functions.<name>] timeout_ms / max_request_body_bytes. */
+  limits?: FunctionLimits
+  /** config.toml [functions.<name>] secrets / outbound_hosts. */
+  capabilities?: FunctionCapabilities
 }
 
 /** Registry value: a bare handler or a {@link LoadedFunction} entry. */
@@ -112,7 +141,12 @@ export class FunctionsHandler {
     return [...this.functions.keys()]
   }
 
-  /** Dispatch a /functions/v1/<name> request to its handler, returning a 404 when unknown and a 500 when the handler throws or returns a non-Response. */
+  /**
+   * Dispatch a /functions/v1/<name> request to its handler, returning a 404 when
+   * unknown and a 500 when the handler throws or returns a non-Response.
+   * Declared limits/capabilities are enforced in order: request body size (413),
+   * invocation timeout (504), outbound host allowlist, secrets allowlist.
+   */
   async handle(req: Request, ctx: RequestContext, url: URL): Promise<Response> {
     const name = url.pathname.replace(/^\/functions\/v1\/?/, '').split('/')[0]
     if (!name) {
@@ -123,16 +157,48 @@ export class FunctionsHandler {
       return json(404, { error: `function "${name}" not found` })
     }
     const entry = normalizeEntry(value)
+    const limits = entry.limits
+    const capabilities = entry.capabilities
+
+    // 1. Request body limit. A declared content-length is checked up front;
+    // a chunked/lengthless body is counted while streaming below.
+    const maxBody = limits?.maxRequestBodyBytes
+    let request = req
+    if (maxBody !== undefined) {
+      const contentLength = req.headers.get('content-length')
+      if (contentLength !== null && Number(contentLength) > maxBody) {
+        return json(413, { error: `function "${name}" request body exceeded ${maxBody} bytes` })
+      }
+      if (contentLength === null && req.body) {
+        request = withCountedBody(request, maxBody)
+      }
+    }
+
     const routeAware =
       (entry.framework !== undefined && entry.framework !== 'fetch') ||
       isFrameworkRouterHandler(entry.handler)
-    const target = routeAware ? new Request(toFunctionLocalUrl(req.url), req) : req
+    if (routeAware) request = new Request(toFunctionLocalUrl(req.url), request)
+
+    // 2. Invocation timeout: the abort signal rides on the forwarded Request so
+    // a cooperative handler (or its body reads) can cancel early.
+    const timeoutMs = limits?.timeoutMs
+    const abort = timeoutMs !== undefined ? new AbortController() : undefined
+    if (abort) request = withSignal(request, abort.signal)
+
     try {
+      // 4. Secrets allowlist: the function sees the SUPABASE_* base trio plus
+      // only the declared secret keys - both via Deno.env and ctx.env.
+      const env = capabilities?.secrets ? filterSecretsEnv(this.env, capabilities.secrets) : this.env
       // Bind Deno.env to this backend's function env for the call so a
       // Deno.serve/Deno.env-style function reads its own secrets, not another
       // backend's or the host process.env.
-      const invoke = () => this.invoke(entry.handler, target, ctx)
-      const res = await runWithDenoEnv(this.env, () => runWithPgredisCache(this.pgredis, invoke))
+      const invoke = () => this.invoke(entry.handler, request, ctx, env)
+      const inner = () => runWithDenoEnv(env, () => runWithPgredisCache(this.pgredis, invoke))
+      // 3. Outbound host allowlist; undeclared means fetch is not wrapped at all.
+      const run = capabilities?.outboundHosts
+        ? () => runWithFetchPolicy(capabilities.outboundHosts!, inner)
+        : inner
+      const res = timeoutMs !== undefined ? await this.withTimeout(name, timeoutMs, run, abort!) : await run()
       if (!(res instanceof Response)) {
         return json(500, { error: `function "${name}" did not return a Response` })
       }
@@ -143,9 +209,43 @@ export class FunctionsHandler {
     }
   }
 
-  private invoke(handler: FunctionHandler, req: Request, ctx: RequestContext): Promise<Response> {
+  /** Race the invocation against `timeoutMs`; on timeout abort the request and answer 504. */
+  private async withTimeout(
+    name: string,
+    timeoutMs: number,
+    run: () => Promise<Response>,
+    abort: AbortController
+  ): Promise<Response> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const pending = run()
+    try {
+      const winner = await Promise.race([
+        pending.then((res) => ({ timedOut: false as const, res })),
+        new Promise<{ timedOut: true }>((resolve) => {
+          timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs)
+        }),
+      ])
+      if (winner.timedOut) {
+        abort.abort()
+        // the handler may still settle after the timeout; swallow its late
+        // result/rejection so it never surfaces as an unhandled rejection
+        pending.then(() => {}, () => {})
+        return json(504, { error: `function "${name}" timed out after ${timeoutMs}ms` })
+      }
+      return winner.res
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
+  private invoke(
+    handler: FunctionHandler,
+    req: Request,
+    ctx: RequestContext,
+    env: FunctionContext['env']
+  ): Promise<Response> {
     if (typeof handler === 'function') {
-      return Promise.resolve(handler(req, { auth: ctx, env: this.env }))
+      return Promise.resolve(handler(req, { auth: ctx, env }))
     }
     if (typeof handler.handle === 'function') {
       return Promise.resolve(handler.handle.call(handler, req))
@@ -155,6 +255,45 @@ export class FunctionsHandler {
     }
     throw new Error('function handler must be a function or an object with handle()/fetch()')
   }
+}
+
+/** The base env every function sees; declared secrets are added on top. */
+const BASE_ENV_KEYS = ['SUPABASE_URL', 'SUPABASE_ANON_KEY', 'SUPABASE_SERVICE_ROLE_KEY'] as const
+
+/** Base trio + declared secret keys only (Manifest v2 capabilities.secrets). */
+function filterSecretsEnv(env: FunctionContext['env'], secrets: string[]): FunctionContext['env'] {
+  const out: Record<string, string> = {}
+  for (const key of BASE_ENV_KEYS) out[key] = env[key]
+  for (const key of secrets) {
+    if (env[key] !== undefined) out[key] = env[key]
+  }
+  return out as FunctionContext['env']
+}
+
+/**
+ * Count a lengthless (chunked) request body against `limit`. On overflow the
+ * stream errors, so the handler's body read rejects and surfaces as a 500 -
+ * once the body is streaming in, there is no way to turn it into a clean 413.
+ */
+function withCountedBody(req: Request, limit: number): Request {
+  let seen = 0
+  const counter = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      seen += chunk.byteLength
+      if (seen > limit) {
+        controller.error(new Error(`request body exceeded ${limit} bytes`))
+        return
+      }
+      controller.enqueue(chunk)
+    },
+  })
+  // `duplex: 'half'` is required when the body is a stream (undici; harmless in Bun).
+  return new Request(req, { body: req.body!.pipeThrough(counter), duplex: 'half' } as RequestInit)
+}
+
+/** Clone a request carrying an abort signal (Bun accepts `new Request(req, { signal })`). */
+function withSignal(req: Request, signal: AbortSignal): Request {
+  return new Request(req, { signal, ...(req.body ? { duplex: 'half' } : {}) } as RequestInit)
 }
 
 function json(status: number, body: unknown): Response {

--- a/packages/supacloud-lite/src/runtime/index.ts
+++ b/packages/supacloud-lite/src/runtime/index.ts
@@ -44,9 +44,11 @@ export {
   toFunctionLocalUrl,
   type EdgeFunction,
   type FrameworkObjectHandler,
+  type FunctionCapabilities,
   type FunctionContext,
   type FunctionFramework,
   type FunctionHandler,
+  type FunctionLimits,
   type FunctionRegistryValue,
   type LoadedFunction,
 } from './functions/handler.js'

--- a/packages/supacloud-lite/src/runtime/node/load-config.ts
+++ b/packages/supacloud-lite/src/runtime/node/load-config.ts
@@ -95,6 +95,14 @@ export interface FunctionOptions {
   entrypoint?: string
   /** [functions.<name>].framework: fetch (default), elysia, or hono */
   framework?: import('../functions/handler.js').FunctionFramework
+  /** [functions.<name>].timeout_ms: invocation timeout (Edge Runtime limits.timeout_ms) */
+  timeoutMs?: number
+  /** [functions.<name>].max_request_body_bytes (Edge Runtime limits.max_request_body_bytes) */
+  maxRequestBodyBytes?: number
+  /** [functions.<name>].outbound_hosts: fetch host allowlist (Edge Runtime capabilities.outbound_hosts) */
+  outboundHosts?: string[]
+  /** [functions.<name>].secrets: env keys exposed to the function (Edge Runtime capabilities.secrets) */
+  secrets?: string[]
 }
 
 /** Parse supabase/config.toml once and project it into a {@link ProjectConfig}. */
@@ -343,6 +351,14 @@ function readFunctions(root: ConfigTable): Record<string, FunctionOptions> {
         console.warn(`  warning: [functions.${name}] framework "${framework}" is not one of fetch/elysia/hono; falling back to fetch`)
       }
     }
+    const timeoutMs = getInt(t, 'timeout_ms')
+    if (timeoutMs !== undefined && timeoutMs > 0) opts.timeoutMs = timeoutMs
+    const maxRequestBodyBytes = getInt(t, 'max_request_body_bytes')
+    if (maxRequestBodyBytes !== undefined && maxRequestBodyBytes > 0) opts.maxRequestBodyBytes = maxRequestBodyBytes
+    const outboundHosts = getStringArray(t, 'outbound_hosts')
+    if (outboundHosts !== undefined) opts.outboundHosts = outboundHosts
+    const secrets = getStringArray(t, 'secrets')
+    if (secrets !== undefined) opts.secrets = secrets
     out[name] = opts
   }
   return out

--- a/packages/supacloud-lite/src/runtime/node/load-functions.ts
+++ b/packages/supacloud-lite/src/runtime/node/load-functions.ts
@@ -42,6 +42,14 @@ export interface LoadFunctionOptions {
   entrypoint?: string
   /** Framework profile: fetch (default, legacy routing), elysia, or hono. */
   framework?: FunctionFramework
+  /** Invocation timeout in ms (Edge Runtime limits.timeout_ms). */
+  timeoutMs?: number
+  /** Max inbound request body bytes (Edge Runtime limits.max_request_body_bytes). */
+  maxRequestBodyBytes?: number
+  /** Outbound fetch host allowlist (Edge Runtime capabilities.outbound_hosts). */
+  outboundHosts?: string[]
+  /** Env keys exposed to the function beyond the SUPABASE_* base trio (Edge Runtime capabilities.secrets). */
+  secrets?: string[]
 }
 
 const FUNCTION_FRAMEWORKS: ReadonlySet<string> = new Set(['fetch', 'elysia', 'hono'])
@@ -143,9 +151,26 @@ async function loadFunctionsUnlocked(
                 ? (req: Request) => denoHandler(req)
                 : undefined
         if (handler) {
+          const opts = options[name]
+          const limits =
+            opts && (opts.timeoutMs !== undefined || opts.maxRequestBodyBytes !== undefined)
+              ? {
+                  ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
+                  ...(opts.maxRequestBodyBytes !== undefined ? { maxRequestBodyBytes: opts.maxRequestBodyBytes } : {}),
+                }
+              : undefined
+          const capabilities =
+            opts && (opts.outboundHosts !== undefined || opts.secrets !== undefined)
+              ? {
+                  ...(opts.outboundHosts !== undefined ? { outboundHosts: opts.outboundHosts } : {}),
+                  ...(opts.secrets !== undefined ? { secrets: opts.secrets } : {}),
+                }
+              : undefined
           functions.set(name, {
             handler,
-            framework: resolveFramework(name, options[name]?.framework),
+            framework: resolveFramework(name, opts?.framework),
+            ...(limits ? { limits } : {}),
+            ...(capabilities ? { capabilities } : {}),
           })
         } else {
           console.warn(`  warning: function "${name}" has no default function, handle/fetch object, or Deno.serve() handler, skipped`)

--- a/packages/supacloud-lite/test/functions-limits.test.ts
+++ b/packages/supacloud-lite/test/functions-limits.test.ts
@@ -1,0 +1,228 @@
+import { expect, test } from 'bun:test'
+import { createServer, type Server } from 'node:http'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { AddressInfo } from 'node:net'
+import { createBackend, type LoadedFunction } from '../src/runtime/index.js'
+import { loadProjectConfig } from '../src/runtime/node/load-config.js'
+import { loadFunctions } from '../src/runtime/node/load-functions.js'
+
+type Backend = Awaited<ReturnType<typeof createBackend>>
+
+async function withBackend(
+  functions: Map<string, Parameters<Backend['functions']['register']>[1]>,
+  run: (backend: Backend) => Promise<void>,
+  config: { functionEnv?: Record<string, string> } = {}
+) {
+  const backend = await createBackend({
+    startRuntimeServices: false,
+    log: () => {},
+    functions,
+    ...config,
+  })
+  try {
+    await run(backend)
+  } finally {
+    await backend.close()
+  }
+}
+
+function invoke(
+  backend: Backend,
+  path: string,
+  init: { method?: string; body?: BodyInit; headers?: Record<string, string> } = {}
+) {
+  return backend.fetch(
+    new Request(`http://localhost/functions/v1${path}`, {
+      method: init.method,
+      body: init.body,
+      // a streamed body has no content-length and (per undici) needs duplex
+      ...(init.body instanceof ReadableStream ? { duplex: 'half' } : {}),
+      headers: { apikey: backend.anonKey, authorization: `Bearer ${backend.anonKey}`, ...init.headers },
+    } as RequestInit)
+  )
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+test('declared content-length over maxRequestBodyBytes gets a 413', async () => {
+  const entry: LoadedFunction = {
+    handler: async (req) => new Response(await req.text()),
+    limits: { maxRequestBodyBytes: 8 },
+  }
+  await withBackend(new Map([['limited', entry]]), async (backend) => {
+    // Bun does not auto-set content-length for string bodies; declare it explicitly
+    const over = await invoke(backend, '/limited', {
+      method: 'POST',
+      body: 'x'.repeat(100),
+      headers: { 'content-length': '100' },
+    })
+    expect(over.status).toBe(413)
+    expect(await over.json()).toEqual({ error: 'function "limited" request body exceeded 8 bytes' })
+
+    const under = await invoke(backend, '/limited', {
+      method: 'POST',
+      body: 'ok',
+      headers: { 'content-length': '2' },
+    })
+    expect(under.status).toBe(200)
+    expect(await under.text()).toBe('ok')
+  })
+})
+
+test('lengthless streamed body over maxRequestBodyBytes fails the read (500)', async () => {
+  const entry: LoadedFunction = {
+    handler: async (req) => new Response(await req.text()),
+    limits: { maxRequestBodyBytes: 8 },
+  }
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('x'.repeat(100)))
+      controller.close()
+    },
+  })
+  await withBackend(new Map([['limited', entry]]), async (backend) => {
+    const res = await invoke(backend, '/limited', { method: 'POST', body })
+    expect(res.status).toBe(500)
+    expect((await res.json()).error).toContain('request body exceeded 8 bytes')
+  })
+})
+
+test('timeoutMs aborts a slow invocation with a 504', async () => {
+  const entry: LoadedFunction = {
+    handler: async () => {
+      await sleep(200)
+      return new Response('late')
+    },
+    limits: { timeoutMs: 50 },
+  }
+  await withBackend(new Map([['slow', entry]]), async (backend) => {
+    const res = await invoke(backend, '/slow')
+    expect(res.status).toBe(504)
+    expect(await res.json()).toEqual({ error: 'function "slow" timed out after 50ms' })
+  })
+})
+
+test('outboundHosts allows loopback and rejects undeclared hosts', async () => {
+  const server: Server = createServer((_req, res) => res.end('pong'))
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  try {
+    const capabilities = { outboundHosts: ['api.example.com'] }
+    const functions = new Map<string, LoadedFunction>([
+      [
+        'net-ok',
+        {
+          capabilities,
+          handler: async () => new Response(await (await fetch(`http://127.0.0.1:${port}/`)).text()),
+        },
+      ],
+      [
+        'net-denied',
+        {
+          capabilities,
+          // rejected by the policy before any network I/O happens
+          handler: async () => new Response(await (await fetch('https://example.com/')).text()),
+        },
+      ],
+    ])
+    await withBackend(functions, async (backend) => {
+      const ok = await invoke(backend, '/net-ok')
+      expect(ok.status).toBe(200)
+      expect(await ok.text()).toBe('pong')
+
+      const denied = await invoke(backend, '/net-denied')
+      expect(denied.status).toBe(500)
+      expect((await denied.json()).error).toContain('outbound host not allowed: example.com')
+    })
+  } finally {
+    server.close()
+  }
+})
+
+test('secrets allowlist limits Deno.env and ctx.env to the base trio + declared keys', async () => {
+  const deno = () => (globalThis as unknown as { Deno: { env: { get(k: string): string | undefined } } }).Deno
+  const entry: LoadedFunction = {
+    capabilities: { secrets: ['MY_KEY'] },
+    handler: (_req, ctx) =>
+      Response.json({
+        denoMyKey: deno().env.get('MY_KEY'),
+        denoOther: deno().env.get('OTHER') ?? null,
+        denoSupabaseUrl: deno().env.get('SUPABASE_URL'),
+        ctxMyKey: ctx.env.MY_KEY,
+        ctxOther: ctx.env.OTHER ?? null,
+      }),
+  }
+  await withBackend(
+    new Map([['scoped', entry]]),
+    async (backend) => {
+      const res = await invoke(backend, '/scoped')
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.denoMyKey).toBe('x')
+      expect(body.denoOther).toBeNull()
+      expect(body.denoSupabaseUrl).toBeTruthy()
+      expect(body.ctxMyKey).toBe('x')
+      expect(body.ctxOther).toBeNull()
+    },
+    { functionEnv: { MY_KEY: 'x', OTHER: 'y' } }
+  )
+})
+
+test('functions without limits/capabilities keep the previous behavior', async () => {
+  const deno = () => (globalThis as unknown as { Deno: { env: { get(k: string): string | undefined } } }).Deno
+  const plain = async (req: Request) => {
+    await sleep(100) // no timeout declared: slow is fine
+    return Response.json({ body: await req.text(), other: deno().env.get('OTHER') ?? null })
+  }
+  await withBackend(
+    new Map([['plain', plain]]),
+    async (backend) => {
+      const res = await invoke(backend, '/plain', { method: 'POST', body: 'x'.repeat(4096) })
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ body: 'x'.repeat(4096), other: 'y' })
+    },
+    { functionEnv: { OTHER: 'y' } }
+  )
+})
+
+test('loadFunctions maps config.toml limits/capabilities onto LoadedFunction', async () => {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-fn-limits-'))
+  try {
+    await mkdir(join(projectDir, 'supabase', 'functions', 'api'), { recursive: true })
+    await writeFile(
+      join(projectDir, 'supabase', 'functions', 'api', 'index.ts'),
+      `export default () => new Response('ok')`
+    )
+    await writeFile(
+      join(projectDir, 'supabase', 'config.toml'),
+      `
+[functions.api]
+framework = "elysia"
+timeout_ms = 15000
+max_request_body_bytes = 1048576
+outbound_hosts = ["api.example.com"]
+secrets = ["OPENAI_API_KEY"]
+`
+    )
+    const config = loadProjectConfig(projectDir)
+    expect(config.functions.api).toMatchObject({
+      framework: 'elysia',
+      timeoutMs: 15000,
+      maxRequestBodyBytes: 1048576,
+      outboundHosts: ['api.example.com'],
+      secrets: ['OPENAI_API_KEY'],
+    })
+
+    const loaded = await loadFunctions(projectDir, config.functions)
+    const fn = loaded.get('api')
+    expect(fn).toBeDefined()
+    expect(fn!.framework).toBe('elysia')
+    expect(fn!.limits).toEqual({ timeoutMs: 15000, maxRequestBodyBytes: 1048576 })
+    expect(fn!.capabilities).toEqual({ outboundHosts: ['api.example.com'], secrets: ['OPENAI_API_KEY'] })
+    expect(typeof fn!.handler).toBe('function')
+  } finally {
+    await rm(projectDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 概要

让 lite 的 Function 运行时落地 Edge Runtime Manifest v2 的限制与能力声明，使"本地通过 = 生产准入通过"， closes the loop on the framework work (#1082/#1093)。

### config.toml 新字段（与生产字段名一一对应）

```toml
[functions.api]
framework = "elysia"
timeout_ms = 15000
max_request_body_bytes = 1048576
outbound_hosts = ["api.example.com"]
secrets = ["OPENAI_API_KEY"]
```

### 执行语义（FunctionsHandler）

- **请求体限制**：content-length 超限 → 413 快速路径；无 content-length 的流式 body 用计数 TransformStream 包装，超限 abort（500，流式途中无法改状态码，代码注释说明）
- **执行超时**：`Promise.race` + AbortController，超时 504；signal 经 `new Request(req, { signal })` 传入转发请求（在路由改写之后执行，保留 function-local URL）；late-settling promise 已防 unhandled rejection
- **出站域名白名单**：新增 `fetch-policy.ts`，仿 deno-shim 的 AsyncLocalStorage 模式（进程级幂等安装、并发安全、无全局覆盖恢复问题）；精确 hostname 匹配 + loopback 始终放行（函数要回调本地 API）；未声明则不包装（零开销、向后兼容）
- **secrets 白名单**：声明后函数可见 env = 基础三键 + 仅声明的 key，同时约束 `Deno.env` 绑定与 `ctx.env`

未声明任何 limits/capabilities 的函数保持无限行为（本地开发向后兼容；与生产默认 900s/30MB 上限的差异已在 README 注明）。

## 验证

- 新增 `functions-limits.test.ts` 7 用例：413 快速路径/流式超限、504 超时、loopback 放行 + 未声明 host 拒绝（不触网）、secrets 过滤（Deno.env 与 ctx.env 双通道）、无声明回归、loader 全字段映射
- `typecheck` 干净；5 个函数相关测试文件 20 pass / 0 fail；`build` 通过
- 既有 functions-framework/cors/restart/elysia 全部回归通过

## 已知差异（README 已注明）

- `max_response_body_bytes` / `wait_until_timeout_ms` 本期未落地
- `outbound_hosts` 仅精确 host 匹配，无端口/通配符规则