### PR TITLE
feat(lite): add response body limits and EdgeRuntime.waitUntil support

### DIFF
--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -104,16 +104,24 @@ framework = "elysia"   # fetch（默认）| elysia | hono
 [functions.api]
 timeout_ms = 15000                        # limits.timeout_ms
 max_request_body_bytes = 1048576          # limits.max_request_body_bytes
+max_response_body_bytes = 524288          # limits.max_response_body_bytes
+wait_until_timeout_ms = 2000              # limits.wait_until_timeout_ms
 outbound_hosts = ["api.example.com"]      # capabilities.outbound_hosts
 secrets = ["OPENAI_API_KEY"]              # capabilities.secrets
+background = true                         # capabilities.background
 ```
 
 | config.toml 字段 | 类型 | 语义 | 生产 Edge Runtime 对应 |
 | --- | --- | --- | --- |
 | `timeout_ms` | integer | 单次调用超时；超时返回 504 并 abort 请求 | `limits.timeout_ms` |
 | `max_request_body_bytes` | integer | 请求体上限；content-length 超限返回 413，无长度声明的流式 body 超限则中断读取 | `limits.max_request_body_bytes` |
+| `max_response_body_bytes` | integer | 响应体上限；content-length 超限直接替换为 502，流式 body 超限则在传输中截断（状态行已提交，客户端看到流中断） | `limits.max_response_body_bytes` |
+| `wait_until_timeout_ms` | integer | 响应返回后等待 `EdgeRuntime.waitUntil` 后台任务的最长时间；超时不再等待（任务继续运行，记录警告） | `limits.wait_until_timeout_ms` |
 | `outbound_hosts` | string[] | `fetch` 出站 host 白名单（精确匹配，不含端口）；loopback（localhost/127.0.0.1/::1）始终放行，未声明的 host 直接抛错 | `capabilities.outbound_hosts` |
 | `secrets` | string[] | 函数可见的环境变量白名单：基础三键（`SUPABASE_URL`/`SUPABASE_ANON_KEY`/`SUPABASE_SERVICE_ROLE_KEY`）+ 声明的 key，同时约束 `Deno.env` 与 `ctx.env` | `capabilities.secrets` |
+| `background` | boolean | 是否允许 `EdgeRuntime.waitUntil`；设为 `false` 时调用抛出与生产一致的错误 | `capabilities.background` |
+
+`EdgeRuntime.waitUntil(promise)` 注册跨响应的后台任务：响应照常返回，任务在响应后等待 allSettled（上限 `wait_until_timeout_ms`），任务中再次调用 `waitUntil` 的嵌套任务同样被追踪。Lite 面向本地开发默认**允许** `waitUntil`（向后兼容）；生产 Edge Runtime 需要声明 `background` capability。`backend.close()` 不等待仍在漂移的后台任务。
 
 与生产的差异：Lite 面向本地开发，未声明时默认**不限制**（不包 fetch、env 全量可见）；生产 Edge Runtime 有 900s 超时与 30MB 请求体的默认上限。OPTIONS 预检与正常请求走同一路径、受同一组限制约束。
 

--- a/packages/supacloud-lite/src/runtime/functions/edge-runtime-shim.ts
+++ b/packages/supacloud-lite/src/runtime/functions/edge-runtime-shim.ts
@@ -1,0 +1,113 @@
+/**
+ * Minimal `EdgeRuntime` global shim: Supabase-style background tasks via
+ * `EdgeRuntime.waitUntil(promise)`, aligned with the SupaCloud Edge Runtime
+ * (worker-executor.ts) semantics:
+ *
+ *   EdgeRuntime.waitUntil(promise)   // runs past the response
+ *
+ * Like the Deno/fetch-policy shims, the global is installed once per process
+ * and the per-invocation task list lives in an AsyncLocalStorage store, so
+ * concurrent invocations each track their own tasks. waitUntil is scoped to
+ * the invocation: tasks scheduled while a function runs are flushed after its
+ * response returns (the flush never blocks the response), and tasks scheduled
+ * from within a background task are tracked too (while-splice drain loop,
+ * mirroring flushWaitUntilTasks).
+ *
+ * Capability gating: production requires capabilities.background; lite
+ * defaults to ALLOWED for local-development back-compat, and only an explicit
+ * `background = false` takes the production error path. A waitUntil call
+ * outside any invocation runs detached (there is no per-invocation scope to
+ * gate or track it against).
+ */
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+interface BackgroundScope {
+  /** capabilities.background; lite defaults to true unless explicitly false. */
+  allowed: boolean
+  /** tasks scheduled by this invocation, in scheduling order */
+  tasks: Promise<unknown>[]
+}
+
+const scopeStore = new AsyncLocalStorage<BackgroundScope>()
+
+/** The production error message, kept verbatim for compatibility tests. */
+const NOT_ENABLED_MESSAGE = 'EdgeRuntime.waitUntil is not enabled by the Function capability policy'
+
+interface EdgeRuntimeGlobal {
+  waitUntil(promise: PromiseLike<unknown> | unknown): void
+}
+
+// Kept so repeat installs return early instead of clobbering, and so tests can
+// assert the installed surface.
+let installed: EdgeRuntimeGlobal | undefined
+
+/** Install globalThis.EdgeRuntime.waitUntil once per process (idempotent). */
+export function installEdgeRuntimeShim(): void {
+  if (installed) return
+  const runtime: EdgeRuntimeGlobal = {
+    waitUntil(promise: PromiseLike<unknown> | unknown) {
+      const scope = scopeStore.getStore()
+      if (scope && !scope.allowed) {
+        throw new Error(NOT_ENABLED_MESSAGE)
+      }
+      const task = Promise.resolve(promise).catch((error) => {
+        console.error('[EdgeRuntime.waitUntil] background task failed', error)
+      })
+      // outside an invocation there is no flush to join; run detached
+      scope?.tasks.push(task)
+    },
+  }
+  installed = runtime
+  ;(globalThis as Record<string, unknown>).EdgeRuntime = runtime
+}
+
+/**
+ * Run `fn` with an EdgeRuntime.waitUntil scope. When `fn` settles, its
+ * background tasks are flushed without blocking the returned value: the flush
+ * waits for allSettled up to `timeoutMs` (wait_until_timeout_ms), after which
+ * it stops waiting and warns - like production, abandoned tasks keep running.
+ * Lite backend close() does not wait for in-flight background tasks; tasks
+ * still drifting at shutdown are dropped with the process.
+ */
+export function runWithBackgroundTasks<T>(
+  options: { allowed: boolean; timeoutMs?: number },
+  fn: () => Promise<T>
+): Promise<T> {
+  installEdgeRuntimeShim()
+  const scope: BackgroundScope = { allowed: options.allowed, tasks: [] }
+  return scopeStore.run(scope, async () => {
+    try {
+      return await fn()
+    } finally {
+      // fire-and-forget: never block the response on background work
+      void flushBackgroundTasks(scope.tasks, options.timeoutMs)
+    }
+  })
+}
+
+/**
+ * Drain `tasks` (including tasks scheduled by tasks themselves) with an
+ * optional overall wait cap. Mutates `tasks` in place; on timeout the
+ * remaining tasks are left to drift, matching production's wait_until
+ * timeout behavior.
+ */
+async function flushBackgroundTasks(tasks: Promise<unknown>[], timeoutMs?: number): Promise<void> {
+  if (tasks.length === 0) return
+  const drain = (async () => {
+    while (tasks.length > 0) {
+      const batch = tasks.splice(0)
+      await Promise.allSettled(batch)
+    }
+  })()
+  if (timeoutMs === undefined) {
+    await drain
+    return
+  }
+  const timedOut = await Promise.race([
+    drain.then(() => false),
+    new Promise<true>((resolve) => setTimeout(() => resolve(true), timeoutMs)),
+  ])
+  if (timedOut) {
+    console.warn(`[EdgeRuntime.waitUntil] background tasks did not settle within ${timeoutMs}ms; no longer waiting`)
+  }
+}

--- a/packages/supacloud-lite/src/runtime/functions/handler.ts
+++ b/packages/supacloud-lite/src/runtime/functions/handler.ts
@@ -11,6 +11,7 @@
  */
 import type { RequestContext } from '../types.js'
 import { runWithDenoEnv } from './deno-shim.js'
+import { runWithBackgroundTasks } from './edge-runtime-shim.js'
 import { runWithFetchPolicy } from './fetch-policy.js'
 import { type PgredisCache, runWithPgredisCache } from './pgredis.js'
 
@@ -38,7 +39,8 @@ export type FunctionHandler = EdgeFunction | FrameworkObjectHandler
 
 /**
  * Per-invocation resource limits, aligned with the Edge Runtime Manifest v2
- * `limits` block (timeout_ms / max_request_body_bytes). Lite defaults to no
+ * `limits` block (timeout_ms / max_request_body_bytes /
+ * max_response_body_bytes / wait_until_timeout_ms). Lite defaults to no
  * limit when undeclared; production caps at 900s / 30MB.
  */
 export interface FunctionLimits {
@@ -46,18 +48,28 @@ export interface FunctionLimits {
   timeoutMs?: number
   /** limits.max_request_body_bytes: max inbound body size; oversized bodies get a 413. */
   maxRequestBodyBytes?: number
+  /** limits.max_response_body_bytes: max outbound body size; oversized responses get a 502 / cut stream. */
+  maxResponseBodyBytes?: number
+  /** limits.wait_until_timeout_ms: max time to wait for EdgeRuntime.waitUntil tasks after the response. */
+  waitUntilTimeoutMs?: number
 }
 
 /**
  * Declared capabilities, aligned with the Edge Runtime Manifest v2
- * `capabilities` block (secrets / outbound_hosts). Undeclared means
- * unrestricted (back-compat).
+ * `capabilities` block (secrets / outbound_hosts / background). Undeclared
+ * means unrestricted (back-compat).
  */
 export interface FunctionCapabilities {
   /** capabilities.secrets: env keys (beyond the SUPABASE_* base trio) visible to the function. */
   secrets?: string[]
   /** capabilities.outbound_hosts: exact fetch host allowlist (no port); loopback is always allowed. */
   outboundHosts?: string[]
+  /**
+   * capabilities.background: whether EdgeRuntime.waitUntil is enabled. Lite
+   * defaults to allowed (local back-compat); only an explicit `false` takes
+   * the production error path.
+   */
+  background?: boolean
 }
 
 /** A loaded function plus its declared framework profile, limits, and capabilities. */
@@ -65,9 +77,9 @@ export interface LoadedFunction {
   handler: FunctionHandler
   /** config.toml [functions.<name>].framework; `fetch` keeps legacy routing. */
   framework?: FunctionFramework
-  /** config.toml [functions.<name>] timeout_ms / max_request_body_bytes. */
+  /** config.toml [functions.<name>] timeout_ms / max_request_body_bytes / max_response_body_bytes / wait_until_timeout_ms. */
   limits?: FunctionLimits
-  /** config.toml [functions.<name>] secrets / outbound_hosts. */
+  /** config.toml [functions.<name>] secrets / outbound_hosts / background. */
   capabilities?: FunctionCapabilities
 }
 
@@ -145,7 +157,8 @@ export class FunctionsHandler {
    * Dispatch a /functions/v1/<name> request to its handler, returning a 404 when
    * unknown and a 500 when the handler throws or returns a non-Response.
    * Declared limits/capabilities are enforced in order: request body size (413),
-   * invocation timeout (504), outbound host allowlist, secrets allowlist.
+   * invocation timeout (504), outbound host allowlist, secrets allowlist,
+   * EdgeRuntime.waitUntil background scope, response body size (502).
    */
   async handle(req: Request, ctx: RequestContext, url: URL): Promise<Response> {
     const name = url.pathname.replace(/^\/functions\/v1\/?/, '').split('/')[0]
@@ -198,11 +211,26 @@ export class FunctionsHandler {
       const run = capabilities?.outboundHosts
         ? () => runWithFetchPolicy(capabilities.outboundHosts!, inner)
         : inner
-      const res = timeoutMs !== undefined ? await this.withTimeout(name, timeoutMs, run, abort!) : await run()
+      // 5. EdgeRuntime.waitUntil scope. Always installed (ALS overhead is
+      // negligible) so the lite default of allowing background tasks holds;
+      // an explicit capabilities.background=false gates waitUntil like
+      // production, and waitUntilTimeoutMs caps the post-response flush.
+      const invokeWithBackground = () =>
+        runWithBackgroundTasks(
+          { allowed: capabilities?.background !== false, timeoutMs: limits?.waitUntilTimeoutMs },
+          run
+        )
+      const res =
+        timeoutMs !== undefined
+          ? await this.withTimeout(name, timeoutMs, invokeWithBackground, abort!)
+          : await invokeWithBackground()
       if (!(res instanceof Response)) {
         return json(500, { error: `function "${name}" did not return a Response` })
       }
-      return res
+      // 6. Response body limit: declared content-length is checked up front;
+      // a streamed body is counted while streaming to the client.
+      const maxResponse = limits?.maxResponseBodyBytes
+      return maxResponse !== undefined ? withResponseLimit(name, res, maxResponse) : res
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
       return json(500, { error: message })
@@ -289,6 +317,35 @@ function withCountedBody(req: Request, limit: number): Request {
   })
   // `duplex: 'half'` is required when the body is a stream (undici; harmless in Bun).
   return new Request(req, { body: req.body!.pipeThrough(counter), duplex: 'half' } as RequestInit)
+}
+
+/**
+ * Enforce limits.max_response_body_bytes on a function response. A declared
+ * content-length over the limit is replaced with a clean 502 up front (the
+ * production FunctionResponseLimitError -> 502 path). Otherwise the body is
+ * counted while streaming; on overflow the stream errors, so the client sees
+ * a cut-off body after an already-committed status line - the local
+ * equivalent of production's reader.cancel(), since the status line can no
+ * longer be rewritten mid-stream.
+ */
+function withResponseLimit(name: string, res: Response, limit: number): Response {
+  const contentLength = res.headers.get('content-length')
+  if (contentLength !== null && Number(contentLength) > limit) {
+    return json(502, { error: `function "${name}" response exceeded ${limit} bytes` })
+  }
+  if (!res.body) return res
+  let seen = 0
+  const counter = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      seen += chunk.byteLength
+      if (seen > limit) {
+        controller.error(new Error(`function "${name}" response exceeded ${limit} bytes`))
+        return
+      }
+      controller.enqueue(chunk)
+    },
+  })
+  return new Response(res.body.pipeThrough(counter), res)
 }
 
 /** Clone a request carrying an abort signal (Bun accepts `new Request(req, { signal })`). */

--- a/packages/supacloud-lite/src/runtime/index.ts
+++ b/packages/supacloud-lite/src/runtime/index.ts
@@ -55,6 +55,7 @@ export {
 export { type PgredisCacheBinding } from './functions/pgredis.js'
 export { generateTypes } from './gen-types.js'
 export { installDenoShim } from './functions/deno-shim.js'
+export { installEdgeRuntimeShim } from './functions/edge-runtime-shim.js'
 export { WebhooksService, type WebhookConfig, type WebhookDelivery } from './webhooks/service.js'
 export { CronService, cronMatches } from './cron/service.js'
 export { NetService, type NetDelivery } from './net/service.js'

--- a/packages/supacloud-lite/src/runtime/node/load-config.ts
+++ b/packages/supacloud-lite/src/runtime/node/load-config.ts
@@ -99,10 +99,16 @@ export interface FunctionOptions {
   timeoutMs?: number
   /** [functions.<name>].max_request_body_bytes (Edge Runtime limits.max_request_body_bytes) */
   maxRequestBodyBytes?: number
+  /** [functions.<name>].max_response_body_bytes (Edge Runtime limits.max_response_body_bytes) */
+  maxResponseBodyBytes?: number
+  /** [functions.<name>].wait_until_timeout_ms (Edge Runtime limits.wait_until_timeout_ms) */
+  waitUntilTimeoutMs?: number
   /** [functions.<name>].outbound_hosts: fetch host allowlist (Edge Runtime capabilities.outbound_hosts) */
   outboundHosts?: string[]
   /** [functions.<name>].secrets: env keys exposed to the function (Edge Runtime capabilities.secrets) */
   secrets?: string[]
+  /** [functions.<name>].background: EdgeRuntime.waitUntil gate (Edge Runtime capabilities.background); lite defaults to true */
+  background?: boolean
 }
 
 /** Parse supabase/config.toml once and project it into a {@link ProjectConfig}. */
@@ -355,10 +361,16 @@ function readFunctions(root: ConfigTable): Record<string, FunctionOptions> {
     if (timeoutMs !== undefined && timeoutMs > 0) opts.timeoutMs = timeoutMs
     const maxRequestBodyBytes = getInt(t, 'max_request_body_bytes')
     if (maxRequestBodyBytes !== undefined && maxRequestBodyBytes > 0) opts.maxRequestBodyBytes = maxRequestBodyBytes
+    const maxResponseBodyBytes = getInt(t, 'max_response_body_bytes')
+    if (maxResponseBodyBytes !== undefined && maxResponseBodyBytes > 0) opts.maxResponseBodyBytes = maxResponseBodyBytes
+    const waitUntilTimeoutMs = getInt(t, 'wait_until_timeout_ms')
+    if (waitUntilTimeoutMs !== undefined && waitUntilTimeoutMs > 0) opts.waitUntilTimeoutMs = waitUntilTimeoutMs
     const outboundHosts = getStringArray(t, 'outbound_hosts')
     if (outboundHosts !== undefined) opts.outboundHosts = outboundHosts
     const secrets = getStringArray(t, 'secrets')
     if (secrets !== undefined) opts.secrets = secrets
+    const background = getBool(t, 'background')
+    if (background !== undefined) opts.background = background
     out[name] = opts
   }
   return out

--- a/packages/supacloud-lite/src/runtime/node/load-functions.ts
+++ b/packages/supacloud-lite/src/runtime/node/load-functions.ts
@@ -46,10 +46,16 @@ export interface LoadFunctionOptions {
   timeoutMs?: number
   /** Max inbound request body bytes (Edge Runtime limits.max_request_body_bytes). */
   maxRequestBodyBytes?: number
+  /** Max outbound response body bytes (Edge Runtime limits.max_response_body_bytes). */
+  maxResponseBodyBytes?: number
+  /** Max wait for EdgeRuntime.waitUntil tasks after the response (Edge Runtime limits.wait_until_timeout_ms). */
+  waitUntilTimeoutMs?: number
   /** Outbound fetch host allowlist (Edge Runtime capabilities.outbound_hosts). */
   outboundHosts?: string[]
   /** Env keys exposed to the function beyond the SUPABASE_* base trio (Edge Runtime capabilities.secrets). */
   secrets?: string[]
+  /** EdgeRuntime.waitUntil gate (Edge Runtime capabilities.background); lite defaults to allowed. */
+  background?: boolean
 }
 
 const FUNCTION_FRAMEWORKS: ReadonlySet<string> = new Set(['fetch', 'elysia', 'hono'])
@@ -153,17 +159,24 @@ async function loadFunctionsUnlocked(
         if (handler) {
           const opts = options[name]
           const limits =
-            opts && (opts.timeoutMs !== undefined || opts.maxRequestBodyBytes !== undefined)
+            opts &&
+            (opts.timeoutMs !== undefined ||
+              opts.maxRequestBodyBytes !== undefined ||
+              opts.maxResponseBodyBytes !== undefined ||
+              opts.waitUntilTimeoutMs !== undefined)
               ? {
                   ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
                   ...(opts.maxRequestBodyBytes !== undefined ? { maxRequestBodyBytes: opts.maxRequestBodyBytes } : {}),
+                  ...(opts.maxResponseBodyBytes !== undefined ? { maxResponseBodyBytes: opts.maxResponseBodyBytes } : {}),
+                  ...(opts.waitUntilTimeoutMs !== undefined ? { waitUntilTimeoutMs: opts.waitUntilTimeoutMs } : {}),
                 }
               : undefined
           const capabilities =
-            opts && (opts.outboundHosts !== undefined || opts.secrets !== undefined)
+            opts && (opts.outboundHosts !== undefined || opts.secrets !== undefined || opts.background !== undefined)
               ? {
                   ...(opts.outboundHosts !== undefined ? { outboundHosts: opts.outboundHosts } : {}),
                   ...(opts.secrets !== undefined ? { secrets: opts.secrets } : {}),
+                  ...(opts.background !== undefined ? { background: opts.background } : {}),
                 }
               : undefined
           functions.set(name, {

--- a/packages/supacloud-lite/test/functions-background.test.ts
+++ b/packages/supacloud-lite/test/functions-background.test.ts
@@ -1,0 +1,237 @@
+import { expect, test } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createBackend, type LoadedFunction } from '../src/runtime/index.js'
+import { loadProjectConfig } from '../src/runtime/node/load-config.js'
+import { loadFunctions } from '../src/runtime/node/load-functions.js'
+import { testTimeout } from './helpers/timeouts.js'
+
+type Backend = Awaited<ReturnType<typeof createBackend>>
+
+async function withBackend(
+  functions: Map<string, Parameters<Backend['functions']['register']>[1]>,
+  run: (backend: Backend) => Promise<void>
+) {
+  const backend = await createBackend({ startRuntimeServices: false, log: () => {}, functions })
+  try {
+    await run(backend)
+  } finally {
+    await backend.close()
+  }
+}
+
+function invoke(backend: Backend, path: string) {
+  return backend.fetch(
+    new Request(`http://localhost/functions/v1${path}`, {
+      headers: { apikey: backend.anonKey, authorization: `Bearer ${backend.anonKey}` },
+    })
+  )
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const edgeRuntime = () => (globalThis as unknown as { EdgeRuntime: { waitUntil(p: unknown): void } }).EdgeRuntime
+
+/** Poll `cond` until it holds; background tasks settle off the response path. */
+async function eventually(cond: () => boolean, budgetMs = 2_000): Promise<void> {
+  const start = Date.now()
+  while (!cond()) {
+    if (Date.now() - start > budgetMs) throw new Error('timed out waiting for background task')
+    await sleep(10)
+  }
+}
+
+test(
+  'response with content-length over maxResponseBodyBytes is replaced with a 502',
+  async () => {
+    const entry: LoadedFunction = {
+      handler: () => new Response('x'.repeat(100), { headers: { 'content-length': '100' } }),
+      limits: { maxResponseBodyBytes: 8 },
+    }
+    await withBackend(new Map([['big', entry]]), async (backend) => {
+      const res = await invoke(backend, '/big')
+      expect(res.status).toBe(502)
+      expect(await res.json()).toEqual({ error: 'function "big" response exceeded 8 bytes' })
+    })
+  },
+  testTimeout(15_000)
+)
+
+test(
+  'streamed response over maxResponseBodyBytes fails the read',
+  async () => {
+    const entry: LoadedFunction = {
+      handler: () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('x'.repeat(100)))
+              controller.close()
+            },
+          })
+        ),
+      limits: { maxResponseBodyBytes: 8 },
+    }
+    await withBackend(new Map([['big-stream', entry]]), async (backend) => {
+      const res = await invoke(backend, '/big-stream')
+      // the status line was committed before the limit tripped
+      expect(res.status).toBe(200)
+      await expect(res.text()).rejects.toThrow('function "big-stream" response exceeded 8 bytes')
+    })
+  },
+  testTimeout(15_000)
+)
+
+test(
+  'response within maxResponseBodyBytes streams through untouched',
+  async () => {
+    const entry: LoadedFunction = {
+      handler: () => new Response('ok'),
+      limits: { maxResponseBodyBytes: 8 },
+    }
+    await withBackend(new Map([['small', entry]]), async (backend) => {
+      const res = await invoke(backend, '/small')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('ok')
+    })
+  },
+  testTimeout(15_000)
+)
+
+test(
+  'EdgeRuntime.waitUntil is allowed by default and runs past the response',
+  async () => {
+    const done: string[] = []
+    const entry: LoadedFunction = {
+      handler: () => {
+        edgeRuntime().waitUntil(sleep(50).then(() => done.push('ran')))
+        return new Response('first')
+      },
+    }
+    await withBackend(new Map([['bg', entry]]), async (backend) => {
+      const res = await invoke(backend, '/bg')
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('first')
+      // the task is still in flight when the response lands
+      expect(done).toEqual([])
+      await eventually(() => done.length === 1)
+      expect(done).toEqual(['ran'])
+    })
+  },
+  testTimeout(15_000)
+)
+
+test(
+  'background = false gates EdgeRuntime.waitUntil like production',
+  async () => {
+    const entry: LoadedFunction = {
+      capabilities: { background: false },
+      handler: () => {
+        edgeRuntime().waitUntil(Promise.resolve())
+        return new Response('unreachable')
+      },
+    }
+    await withBackend(new Map([['no-bg', entry]]), async (backend) => {
+      const res = await invoke(backend, '/no-bg')
+      expect(res.status).toBe(500)
+      expect(await res.json()).toEqual({
+        error: 'EdgeRuntime.waitUntil is not enabled by the Function capability policy',
+      })
+    })
+  },
+  testTimeout(15_000)
+)
+
+test(
+  'waitUntilTimeoutMs stops waiting on slow tasks without blocking the response',
+  async () => {
+    const warnings: string[] = []
+    const originalWarn = console.warn
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(' '))
+    try {
+      const done: string[] = []
+      const entry: LoadedFunction = {
+        limits: { waitUntilTimeoutMs: 50 },
+        handler: () => {
+          edgeRuntime().waitUntil(sleep(500).then(() => done.push('late')))
+          return new Response('fast')
+        },
+      }
+      await withBackend(new Map([['slow-bg', entry]]), async (backend) => {
+        const res = await invoke(backend, '/slow-bg')
+        expect(res.status).toBe(200)
+        expect(await res.text()).toBe('fast')
+        await eventually(() => warnings.length > 0)
+        expect(warnings[0]).toContain('did not settle within 50ms')
+      })
+    } finally {
+      console.warn = originalWarn
+    }
+  },
+  testTimeout(15_000)
+)
+
+test(
+  'tasks scheduled from within a background task are tracked too',
+  async () => {
+    const done: string[] = []
+    const entry: LoadedFunction = {
+      handler: () => {
+        edgeRuntime().waitUntil(
+          sleep(30).then(() => {
+            done.push('outer')
+            edgeRuntime().waitUntil(sleep(30).then(() => done.push('inner')))
+          })
+        )
+        return new Response('ok')
+      },
+    }
+    await withBackend(new Map([['nested', entry]]), async (backend) => {
+      const res = await invoke(backend, '/nested')
+      expect(res.status).toBe(200)
+      await res.text()
+      await eventually(() => done.length === 2)
+      expect(done).toEqual(['outer', 'inner'])
+    })
+  },
+  testTimeout(15_000)
+)
+
+test(
+  'loadFunctions maps config.toml response/waitUntil limits and background onto LoadedFunction',
+  async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-fn-bg-'))
+    try {
+      await mkdir(join(projectDir, 'supabase', 'functions', 'api'), { recursive: true })
+      await writeFile(
+        join(projectDir, 'supabase', 'functions', 'api', 'index.ts'),
+        `export default () => new Response('ok')`
+      )
+      await writeFile(
+        join(projectDir, 'supabase', 'config.toml'),
+        `
+[functions.api]
+max_response_body_bytes = 524288
+wait_until_timeout_ms = 2000
+background = false
+`
+      )
+      const config = loadProjectConfig(projectDir)
+      expect(config.functions.api).toMatchObject({
+        maxResponseBodyBytes: 524288,
+        waitUntilTimeoutMs: 2000,
+        background: false,
+      })
+
+      const loaded = await loadFunctions(projectDir, config.functions)
+      const fn = loaded.get('api')
+      expect(fn).toBeDefined()
+      expect(fn!.limits).toEqual({ maxResponseBodyBytes: 524288, waitUntilTimeoutMs: 2000 })
+      expect(fn!.capabilities).toEqual({ background: false })
+    } finally {
+      await rm(projectDir, { recursive: true, force: true })
+    }
+  },
+  testTimeout(15_000)
+)


### PR DESCRIPTION
## 概要

补齐 lite 与 Edge Runtime Manifest v2 的剩余限制项（继 #1093、#1097 之后）。

### 变更

- **`max_response_body_bytes`**：content-length 超限 → 502 快速路径；流式响应用计数 TransformStream 截断（状态行已提交时等价于生产的 `reader.cancel()`）
- **`EdgeRuntime.waitUntil`**：进程级幂等 shim + AsyncLocalStorage 调用作用域（与 deno-shim/fetch-policy 同构）：
  - 按调用追踪任务，响应先返回、后台 flush 不阻塞
  - 嵌套 `waitUntil` 的新任务同样被排干（while-splice，与生产一致）
  - `wait_until_timeout_ms` 是 flush 等待上限，超时 warn 后任务继续漂移（与生产一致）
  - `background = false` 时调用抛错，错误消息与生产逐字一致
  - lite 默认允许 `waitUntil`（本地开发向后兼容）；生产需显式 background capability 的差异已写入 README
- config.toml `[functions.<name>]` 新增 `max_response_body_bytes`、`wait_until_timeout_ms`、`background`

## 验证

- 新增 `functions-background.test.ts` 8 用例（502 快速路径、流式截断、waitUntil 默认允许/门控/超时/嵌套、loader 字段映射），全部含 Windows 预算
- 既有 functions-limits/framework/cors/restart/elysia 回归全绿；typecheck、build 通过

## 与生产的剩余差异（README 注明）

- SSE 流生产逐 chunk 上报并可给干净 502；lite 统一 TransformStream 截断
- 生产 flush 后向父进程发 `wait_until_done`；lite 为进程内等待 + 超时 warn
- `wait_until_timeout_ms` 生产有全局钳制上限，lite 直接用声明值