### PR TITLE
feat(lite): add read-only db check against the live catalog

### DIFF
--- a/packages/supacloud-lite/README.md
+++ b/packages/supacloud-lite/README.md
@@ -145,6 +145,7 @@ supacloud-lite gen types [-o database.types.ts]
 supacloud-lite db reset
 supacloud-lite db diff [-f migration_name]
 supacloud-lite db pull [migration_name]
+supacloud-lite db check [--module-file supabase/db/modules.ts]
 supacloud-lite snapshot create [-o backup.tar.gz]
 supacloud-lite snapshot restore <backup.tar.gz> [--force]
 supacloud-lite upgrade [-o pre-upgrade.tar.gz]
@@ -154,6 +155,8 @@ supacloud-lite version
 ```
 
 首次初始化或 state 目录不存在/为空时，先运行 `supacloud-lite migrate`。`db reset` 只接受已经初始化且保留有效 `secrets.json` 标记的 state；它不会为 reset 创建或覆盖项目 secrets。
+
+`db check` 是只读治理命令：加载 `@supacloud/db` 的 `defineDatabaseModule` 清单（默认 `supabase/db/modules.ts`），对声明的 SQL 源做静态 lint，并把声明的表/RLS 策略/RPC/授权与 Lite 数据库的真实 Catalog 对账（pg_policy、pg_proc、grants）。存在 error 级问题（声明缺失、RLS 未启用、security definer 未固定 search_path、PUBLIC 授权）时以非零退出码结束，可接入 CI；不会修改数据库。
 
 通用参数：
 
@@ -542,6 +545,7 @@ supacloud-lite gen types [-o database.types.ts]
 supacloud-lite db reset
 supacloud-lite db diff [-f migration_name]
 supacloud-lite db pull [migration_name]
+supacloud-lite db check [--module-file supabase/db/modules.ts]
 supacloud-lite snapshot create [-o backup.tar.gz]
 supacloud-lite snapshot restore <backup.tar.gz> [--force]
 supacloud-lite upgrade [-o pre-upgrade.tar.gz]

--- a/packages/supacloud-lite/bun.lock
+++ b/packages/supacloud-lite/bun.lock
@@ -6,6 +6,7 @@
       "name": "@supacloud/lite",
       "dependencies": {
         "@electric-sql/pglite": "0.5.8",
+        "@supacloud/db": "^0.1.0",
         "tar": "^7.5.22",
       },
       "devDependencies": {
@@ -38,6 +39,8 @@
     "@supabase/storage-js": ["@supabase/storage-js@2.112.4", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.112.4.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A=="],
 
     "@supabase/supabase-js": ["@supabase/supabase-js@2.112.4", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.112.4.tgz", { "dependencies": { "@supabase/auth-js": "2.112.4", "@supabase/functions-js": "2.112.4", "@supabase/postgrest-js": "2.112.4", "@supabase/realtime-js": "2.112.4", "@supabase/storage-js": "2.112.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw=="],
+
+    "@supacloud/db": ["@supacloud/db@0.1.0", "", {}, "sha512-MCiK4MS2CsZjoi5DnUiUDrzZ7wJtAxNdmGJQ07HYKDGrzvxjYg2LBRXAeryizlXsInptdptRHLZAox65c1Kd3g=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 

--- a/packages/supacloud-lite/package.json
+++ b/packages/supacloud-lite/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "0.5.8",
+    "@supacloud/db": "^0.1.0",
     "tar": "^7.5.22"
   },
   "devDependencies": {

--- a/packages/supacloud-lite/src/cli.ts
+++ b/packages/supacloud-lite/src/cli.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path'
 import packageJson from '../package.json' with { type: 'json' }
 import { generateTypes, inspectDb } from './runtime/index.js'
 import { computeDbDiff, createTemporaryNativeEngine, pullSchema } from './runtime/node/db-diff.js'
+import { checkDatabaseModules, formatDatabaseModuleCheck } from './runtime/node/db-check.js'
 import { assertDataDirUnlocked } from './runtime/db/data-dir-lock.js'
 import { createNativeEngine } from './runtime/node/native/engine.js'
 import { inspectPowerSyncReadiness, liteCapabilities } from './runtime/node/native/readiness.js'
@@ -28,6 +29,8 @@ interface CliOptions extends ProjectRuntimeOptions {
   positionals: string[]
   output?: string
   diffFile?: string
+  /** db check: database module manifest path (default supabase/db/modules.ts). */
+  moduleFile?: string
   serviceRole: boolean
   force: boolean
   json: boolean
@@ -79,6 +82,7 @@ function parseArgs(argv: string[]): CliOptions {
     else if (argument === '--memory') options.memory = true
     else if (argument === '--output' || argument === '-o') options.output = resolve(next())
     else if (argument === '--file' || argument === '-f') options.diffFile = next()
+    else if (argument === '--module-file') options.moduleFile = resolve(next())
     else if (argument === '--service-role') options.serviceRole = true
     else if (argument === '--force') options.force = true
     else if (argument === '--json') options.json = true
@@ -315,6 +319,30 @@ async function runDbCommand(options: CliOptions): Promise<void> {
     return
   }
 
+  if (subcommand === 'check') {
+    const moduleFile = options.moduleFile ?? join(paths.projectDir, 'supabase', 'db', 'modules.ts')
+    const project = await createProjectBackend({
+      ...options,
+      applyMigrations: false,
+      includeFunctions: false,
+      includeWebhooks: false,
+      startRuntimeServices: false,
+      log: quietLog,
+    })
+    try {
+      const executor = {
+        query: async <T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> =>
+          (await project.backend.db.query<T>(sql, params)).rows,
+      }
+      const result = await checkDatabaseModules({ moduleFile, executor })
+      await writeStandardOutput(formatDatabaseModuleCheck(result))
+      if (!result.ok) throw new Error('db check found error-level issues')
+    } finally {
+      await project.backend.close()
+    }
+    return
+  }
+
   throw new Error(`unknown db subcommand: ${subcommand ?? '(none)'}`)
 }
 
@@ -447,6 +475,7 @@ Commands:
   db reset              reset initialized database/storage and re-run migrations
   db diff               print schema changes outside migrations
   db pull [name]        write live schema changes as an applied migration
+  db check              reconcile database module manifests (@supacloud/db) against the live catalog
   snapshot create       create a compressed database/storage/secrets snapshot
   snapshot restore <f>  restore a snapshot into an empty target
   upgrade               snapshot first, then apply pending migrations
@@ -479,6 +508,7 @@ Options:
       --json              emit machine-readable doctor output
   -o, --output <p>        output file for gen types
   -f, --file <name>       migration suffix for db diff
+      --module-file <p>   database module manifest for db check (default supabase/db/modules.ts)
       --force             replace non-empty restore targets and retain rollback copies
 `)
 }

--- a/packages/supacloud-lite/src/runtime/node/db-check.ts
+++ b/packages/supacloud-lite/src/runtime/node/db-check.ts
@@ -1,0 +1,105 @@
+/**
+ * `db check` support: reconcile declared database modules (@supacloud/db
+ * manifests) against the live Lite database catalog, plus SQL source lint.
+ * Read-only - never mutates the database.
+ */
+import { readFile, stat } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import {
+  lintModule,
+  readCatalog,
+  reconcileModule,
+  type DatabaseModule,
+  type LintIssue,
+  type QueryExecutor,
+  type ReconcileReport,
+} from '@supacloud/db'
+
+export interface DatabaseModuleCheckOptions {
+  /** Path to the module manifest file (default export: module or module[]). */
+  moduleFile: string
+  /** Catalog schema filter. Default: public. */
+  schema?: string
+  /** Live database query executor (superuser introspection channel). */
+  executor: QueryExecutor
+}
+
+export interface DatabaseModuleCheckReport {
+  module: string
+  lintIssues: LintIssue[]
+  reconcile: ReconcileReport
+}
+
+export interface DatabaseModuleCheckResult {
+  ok: boolean
+  reports: DatabaseModuleCheckReport[]
+}
+
+/** Load database module declarations from a manifest file. */
+export async function loadDatabaseModules(moduleFile: string): Promise<DatabaseModule[]> {
+  const absolute = resolve(moduleFile)
+  try {
+    await stat(absolute)
+  } catch {
+    throw new Error(`database module manifest not found: ${absolute}`)
+  }
+  const mod = (await import(pathToFileURL(absolute).href)) as {
+    default?: DatabaseModule | DatabaseModule[]
+    modules?: DatabaseModule[]
+  }
+  const candidate = mod.default ?? mod.modules
+  const list = Array.isArray(candidate) ? candidate : candidate ? [candidate] : []
+  if (list.length === 0) {
+    throw new Error(`database module manifest ${absolute} must export a default module or module array`)
+  }
+  for (const entry of list) {
+    if (!entry || typeof entry.name !== 'string') {
+      throw new Error(`database module manifest ${absolute} contains an entry without a name`)
+    }
+  }
+  return list
+}
+
+/**
+ * Lint declared SQL sources and reconcile every declared module against the
+ * live catalog. `ok` is false when any error-severity issue exists.
+ */
+export async function checkDatabaseModules(
+  options: DatabaseModuleCheckOptions
+): Promise<DatabaseModuleCheckResult> {
+  const modules = await loadDatabaseModules(options.moduleFile)
+  const baseDir = dirname(resolve(options.moduleFile))
+  const readSource = (path: string) => readFile(resolve(baseDir, path), 'utf8')
+  const catalog = await readCatalog(options.executor, [options.schema ?? 'public'])
+
+  const reports: DatabaseModuleCheckReport[] = []
+  for (const module of modules) {
+    const lintIssues = await lintModule(module, readSource)
+    const reconcile = reconcileModule(module, catalog)
+    reports.push({ module: module.name, lintIssues, reconcile })
+  }
+  const ok = reports.every(
+    (report) =>
+      report.reconcile.ok && !report.lintIssues.some((issue) => issue.severity === 'error')
+  )
+  return { ok, reports }
+}
+
+/** Human-readable rendering for the CLI. */
+export function formatDatabaseModuleCheck(result: DatabaseModuleCheckResult): string {
+  const lines: string[] = []
+  for (const report of result.reports) {
+    lines.push(`module ${report.module}:`)
+    for (const issue of report.lintIssues) {
+      lines.push(`  [lint ${issue.severity}] ${issue.code}: ${issue.message} (${issue.file})`)
+    }
+    for (const issue of report.reconcile.issues) {
+      lines.push(`  [catalog ${issue.severity}] ${issue.code}: ${issue.message} (${issue.object})`)
+    }
+    if (report.lintIssues.length === 0 && report.reconcile.issues.length === 0) {
+      lines.push('  ok')
+    }
+  }
+  return `${lines.join('\n')}\n`
+}

--- a/packages/supacloud-lite/test/db-check.test.ts
+++ b/packages/supacloud-lite/test/db-check.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { testTimeout } from './helpers/timeouts.js'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { withWindowsSubprocessRef } from '../scripts/subprocess.js'
+
+const cliPath = resolve(import.meta.dir, '../src/cli.ts')
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+describe('db check', () => {
+  test('reconciles declared modules against the live catalog', async () => {
+    const projectDir = await moduleProject({ declareMissingPolicy: false })
+    await runCli(projectDir, ['migrate'])
+
+    const check = await runCli(projectDir, ['db', 'check'])
+    expect(check.stderr).toBe('')
+    expect(check.stdout).toContain('module docs:')
+    expect(check.stdout).toContain('ok')
+    expect(check.exitCode).toBe(0)
+  }, testTimeout(60_000))
+
+  test('fails with a non-zero exit code when a declared policy is missing', async () => {
+    const projectDir = await moduleProject({ declareMissingPolicy: true })
+    await runCli(projectDir, ['migrate'])
+
+    const check = await runCli(projectDir, ['db', 'check'])
+    expect(check.stdout).toContain('missing-policy')
+    expect(check.exitCode).toBe(1)
+  }, testTimeout(60_000))
+
+  test('reports a clear error when the module manifest is absent', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-db-check-empty-'))
+    temporaryDirectories.push(projectDir)
+
+    const check = await runCli(projectDir, ['db', 'check'])
+    expect(check.exitCode).toBe(1)
+    expect(check.stderr).toContain('database module manifest not found')
+  }, testTimeout(60_000))
+})
+
+async function moduleProject(options: { declareMissingPolicy: boolean }): Promise<string> {
+  const projectDir = await mkdtemp(join(tmpdir(), 'supacloud-lite-db-check-'))
+  temporaryDirectories.push(projectDir)
+  // The manifest imports @supacloud/db; give the fixture project a
+  // node_modules link like a real project checkout would have.
+  await symlink(join(packageRoot, 'node_modules'), join(projectDir, 'node_modules'))
+  await mkdir(join(projectDir, 'supabase', 'migrations'), { recursive: true })
+  await mkdir(join(projectDir, 'supabase', 'db', 'sql'), { recursive: true })
+
+  await writeFile(
+    join(projectDir, 'supabase', 'migrations', '20260902010000_init.sql'),
+    `create table public.docs (
+  id uuid primary key default gen_random_uuid(),
+  title text not null
+);
+
+alter table public.docs enable row level security;
+
+create policy docs_select on public.docs
+  for select to authenticated
+  using (true);
+
+create function public.docs_count()
+returns bigint
+language sql
+security invoker
+as $$ select count(*) from public.docs $$;
+`
+  )
+
+  await writeFile(
+    join(projectDir, 'supabase', 'db', 'sql', 'docs_select.sql'),
+    `alter table public.docs enable row level security;
+
+create policy docs_select on public.docs
+  for select to authenticated
+  using (true);
+`
+  )
+  await writeFile(
+    join(projectDir, 'supabase', 'db', 'sql', 'docs_count.sql'),
+    `create function public.docs_count()
+returns bigint
+language sql
+security invoker
+as $$ select count(*) from public.docs $$;
+`
+  )
+
+  await writeFile(
+    join(projectDir, 'supabase', 'db', 'sql', 'docs.test.sql'),
+    `-- @test docs are readable
+select 1 from public.docs;
+`
+  )
+
+  const missingPolicyDecl = options.declareMissingPolicy
+    ? `,
+    {
+      name: 'docs_insert',
+      table: 'public.docs',
+      operation: 'insert',
+      roles: ['authenticated'],
+      source: 'sql/docs_select.sql',
+    }`
+    : ''
+  await writeFile(
+    join(projectDir, 'supabase', 'db', 'modules.ts'),
+    `import { defineDatabaseModule } from '@supacloud/db'
+
+export default defineDatabaseModule({
+  name: 'docs',
+  tables: ['public.docs'],
+  policies: [
+    {
+      name: 'docs_select',
+      table: 'public.docs',
+      operation: 'select',
+      roles: ['authenticated'],
+      source: 'sql/docs_select.sql',
+      tests: ['sql/docs.test.sql'],
+    }${missingPolicyDecl}
+  ],
+  functions: [
+    {
+      name: 'public.docs_count',
+      source: 'sql/docs_count.sql',
+      security: 'invoker',
+      tests: ['sql/docs.test.sql'],
+    },
+  ],
+})
+`
+  )
+  return projectDir
+}
+
+async function runCli(projectDir: string, command: string[]) {
+  const bunExecutable = Bun.which('bun')
+  if (!bunExecutable) throw new Error('Bun is required to run the Lite CLI test')
+  const cliProcess = Bun.spawn({
+    cmd: [bunExecutable, cliPath, ...command, '--project-dir', projectDir],
+    cwd: projectDir,
+    env: isolatedProjectEnvironment(),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await withWindowsSubprocessRef(() => Promise.all([
+    cliProcess.exited,
+    new Response(cliProcess.stdout).text(),
+    new Response(cliProcess.stderr).text(),
+  ]))
+  return { exitCode, stdout, stderr }
+}
+
+function isolatedProjectEnvironment(): Record<string, string | undefined> {
+  const environment = { ...process.env }
+  delete environment.SUPACLOUD_LITE_JWT_SECRET
+  delete environment.SUPACLOUD_LITE_HOST
+  delete environment.SUPACLOUD_LITE_PORT
+  return environment
+}


### PR DESCRIPTION
## 概要

补上数据库治理的本地闭环：`@supacloud/db` 的 RLS/RPC 治理现在可以在 lite 本地环境直接运行，无需外部数据库连接（CLI 的 `db module_check` 走 DATABASE_URL，lite 此前没有 TCP 连接串可用）。

### 变更

- 新子命令 `supacloud-lite db check [--module-file <p>]`（默认 `supabase/db/modules.ts`）：
  - 动态加载 `defineDatabaseModule` 清单（default 导出单个模块或数组）
  - 对声明的 SQL 源做静态 lint（definer-no-search-path、grant-to-public、policy-without-test 等）
  - 用 lite 进程内数据库读取真实 Catalog（pg_policy / pg_proc / pg_class / grants），与声明对账（missing-policy / rls-disabled / definer-without-search-path / wildcard-grant / 漂移 warn）
  - error 级问题非零退出，可接入 CI；**只读，不改数据库**
- 新增 `src/runtime/node/db-check.ts`（可测试的纯逻辑：`loadDatabaseModules` / `checkDatabaseModules` / `formatDatabaseModuleCheck`）
- lite 新增依赖 `@supacloud/db ^0.1.0`（无传递运行时依赖）

### 验证

- `test/db-check.test.ts` 3 个端到端用例（子进程跑真实 CLI）：声明与 Catalog 一致 → exit 0 且输出 ok；声明了不存在的策略 → 输出 missing-policy 且 exit 1；清单文件缺失 → 清晰报错 exit 1
- 既有 cli-readonly 回归通过；typecheck、build 干净