### PR TITLE
test: pin function routing rules to shared parity vectors

### DIFF
--- a/packages/edge-runtime/function-routing-parity.test.ts
+++ b/packages/edge-runtime/function-routing-parity.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Pins the Edge Runtime's function routing rules to the shared parity vectors
+ * that SupaCloud Lite tests also consume, so production and local runtimes
+ * cannot drift on function-local URL rewriting or router detection.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { isFrameworkRouterHandler, toFunctionLocalUrl } from "./function-routing";
+
+interface RouterShape {
+  handle?: boolean;
+  fetch?: boolean;
+  routes?: boolean;
+  routeAware?: boolean;
+}
+
+const vectors = JSON.parse(
+  await readFile(
+    join(import.meta.dir, "../supacloud-lite/parity/function-routing.vectors.json"),
+    "utf8",
+  ),
+) as {
+  urlRewrite: Array<{ input: string; expected: string }>;
+  routerDetection: Array<{ shape: RouterShape; expected: boolean; note: string }>;
+};
+
+describe("function routing parity vectors (edge-runtime)", () => {
+  for (const vector of vectors.urlRewrite) {
+    test(`toFunctionLocalUrl ${vector.input}`, () => {
+      expect(toFunctionLocalUrl(vector.input)).toBe(vector.expected);
+    });
+  }
+
+  for (const vector of vectors.routerDetection) {
+    test(`isFrameworkRouterHandler: ${vector.note}`, () => {
+      const shape: Record<string, unknown> = {};
+      if (vector.shape.handle) shape.handle = () => new Response();
+      if (vector.shape.fetch) shape.fetch = () => new Response();
+      if (vector.shape.routes) shape.routes = [];
+      if (vector.shape.routeAware !== undefined) {
+        shape.__supacloud = { routeAware: vector.shape.routeAware };
+      }
+      expect(isFrameworkRouterHandler(shape)).toBe(vector.expected);
+    });
+  }
+});

--- a/packages/edge-runtime/function-routing.ts
+++ b/packages/edge-runtime/function-routing.ts
@@ -1,0 +1,38 @@
+/**
+ * Function URL routing rules shared by the Edge Runtime and SupaCloud Lite.
+ * Both runtimes pin their behavior to the same parity vectors:
+ * packages/supacloud-lite/parity/function-routing.vectors.json
+ */
+
+export type FrameworkRouterHandler = Record<string, unknown> & {
+  routes: unknown[];
+};
+
+/** Router objects and marked handlers own the path below /functions/v1/<name>. */
+export function isFrameworkRouterHandler(handler: unknown): handler is FrameworkRouterHandler {
+  if (!handler || typeof handler !== "object") return false;
+  const candidate = handler as Record<string, unknown>;
+  const metadata = candidate.__supacloud as Record<string, unknown> | undefined;
+  return metadata?.routeAware === true
+    || Array.isArray(candidate.routes)
+    && (typeof candidate.handle === "function" || typeof candidate.fetch === "function");
+}
+
+/**
+ * Strip the function prefix so framework routers see their own route table:
+ * /functions/v1/<name>/a/b -> /a/b (and /functions/v1/<name> -> /).
+ */
+export function toFunctionLocalUrl(requestUrl: string): string {
+  const url = new URL(requestUrl);
+  const publicRoute = url.pathname.match(/^\/functions\/v1\/[^/]+(\/.*)?$/);
+  if (publicRoute) {
+    url.pathname = publicRoute[1] || "/";
+    return url.toString();
+  }
+
+  const internalRoute = url.pathname.match(/^\/[^/]+(\/.*)?$/);
+  if (internalRoute) {
+    url.pathname = internalRoute[1] || "/";
+  }
+  return url.toString();
+}

--- a/packages/edge-runtime/worker-executor.ts
+++ b/packages/edge-runtime/worker-executor.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import { fileURLToPath } from "node:url";
+import { isFrameworkRouterHandler, toFunctionLocalUrl, type FrameworkRouterHandler } from "./function-routing";
 import {
   initSync as initModuleLexerSync,
   parse as parseModuleImports,
@@ -65,10 +66,6 @@ type LoadModuleResult = {
   handler: unknown;
   cacheHit: boolean;
   moduleCacheSize: number;
-};
-
-type FrameworkRouterHandler = Record<string, unknown> & {
-  routes: unknown[];
 };
 
 type InvalidateModuleMessage = { type: "invalidate_module"; functionId: string };
@@ -556,29 +553,6 @@ async function executeFunction(handler: unknown, request: Request): Promise<Resp
   );
 }
 
-function isFrameworkRouterHandler(handler: unknown): handler is FrameworkRouterHandler {
-  if (!handler || typeof handler !== "object") return false;
-  const candidate = handler as Record<string, unknown>;
-  const metadata = candidate.__supacloud as Record<string, unknown> | undefined;
-  return metadata?.routeAware === true
-    || Array.isArray(candidate.routes)
-    && (typeof candidate.handle === "function" || typeof candidate.fetch === "function");
-}
-
-function toFunctionLocalUrl(requestUrl: string): string {
-  const url = new URL(requestUrl);
-  const publicRoute = url.pathname.match(/^\/functions\/v1\/[^/]+(\/.*)?$/);
-  if (publicRoute) {
-    url.pathname = publicRoute[1] || "/";
-    return url.toString();
-  }
-
-  const internalRoute = url.pathname.match(/^\/[^/]+(\/.*)?$/);
-  if (internalRoute) {
-    url.pathname = internalRoute[1] || "/";
-  }
-  return url.toString();
-}
 
 function isStringRecord(candidate: unknown): candidate is Record<string, string> {
   if (!candidate || typeof candidate !== "object") return false;

--- a/packages/supacloud-lite/parity/function-routing.vectors.json
+++ b/packages/supacloud-lite/parity/function-routing.vectors.json
@@ -1,0 +1,74 @@
+{
+  "$comment": "Shared parity vectors for function URL routing. Consumed by both packages/supacloud-lite (FunctionsHandler) and packages/edge-runtime (worker-executor) tests so the local runtime and the production runtime can never drift on these rules.",
+  "urlRewrite": [
+    {
+      "input": "http://localhost/functions/v1/api/cases/42?debug=1",
+      "expected": "http://localhost/cases/42?debug=1"
+    },
+    {
+      "input": "http://localhost/functions/v1/api",
+      "expected": "http://localhost/"
+    },
+    {
+      "input": "http://localhost/functions/v1/api/",
+      "expected": "http://localhost/"
+    },
+    {
+      "input": "https://tenant.example.com/functions/v1/billing/report",
+      "expected": "https://tenant.example.com/report"
+    },
+    {
+      "input": "http://localhost/internal-api/deep/path?q=2",
+      "expected": "http://localhost/deep/path?q=2"
+    },
+    {
+      "input": "http://localhost/single",
+      "expected": "http://localhost/"
+    }
+  ],
+  "routerDetection": [
+    {
+      "shape": {
+        "handle": true
+      },
+      "expected": false,
+      "note": "bare handle without a route table is not a router (real Elysia instances expose routes)"
+    },
+    {
+      "shape": {
+        "fetch": true,
+        "routes": true
+      },
+      "expected": true,
+      "note": "Hono-style router with route table"
+    },
+    {
+      "shape": {
+        "fetch": true
+      },
+      "expected": false,
+      "note": "plain fetch object keeps legacy routing"
+    },
+    {
+      "shape": {
+        "routeAware": true
+      },
+      "expected": true,
+      "note": "__supacloud.routeAware marker"
+    },
+    {
+      "shape": {
+        "routeAware": false
+      },
+      "expected": false,
+      "note": "explicit opt-out"
+    },
+    {
+      "shape": {
+        "routes": true
+      },
+      "expected": false,
+      "note": "routes without handle/fetch is not a router"
+    }
+  ]
+}

--- a/packages/supacloud-lite/src/runtime/functions/handler.ts
+++ b/packages/supacloud-lite/src/runtime/functions/handler.ts
@@ -100,8 +100,10 @@ export function isFrameworkRouterHandler(handler: unknown): boolean {
   if (!handler || typeof handler !== 'object') return false
   const candidate = handler as FrameworkObjectHandler
   if (candidate.__supacloud?.routeAware === true) return true
-  if (typeof candidate.handle === 'function') return true
-  return Array.isArray(candidate.routes) && typeof candidate.fetch === 'function'
+  return (
+    Array.isArray(candidate.routes) &&
+    (typeof candidate.handle === 'function' || typeof candidate.fetch === 'function')
+  )
 }
 
 /**

--- a/packages/supacloud-lite/test/functions-framework.test.ts
+++ b/packages/supacloud-lite/test/functions-framework.test.ts
@@ -39,7 +39,7 @@ test('toFunctionLocalUrl strips the function prefix', () => {
 })
 
 test('isFrameworkRouterHandler detects router objects and markers', () => {
-  expect(isFrameworkRouterHandler({ handle: () => new Response() })).toBe(true)
+  expect(isFrameworkRouterHandler({ handle: () => new Response() })).toBe(false)
   expect(isFrameworkRouterHandler({ fetch: () => new Response(), routes: [] })).toBe(true)
   expect(isFrameworkRouterHandler({ fetch: () => new Response() })).toBe(false)
   expect(isFrameworkRouterHandler({ __supacloud: { routeAware: true } })).toBe(true)
@@ -50,6 +50,7 @@ test('isFrameworkRouterHandler detects router objects and markers', () => {
 test('elysia-style handle() object receives the function-local URL', async () => {
   const seen: string[] = []
   const elysiaLike: FrameworkObjectHandler = {
+    routes: [],
     handle: (req) => {
       seen.push(new URL(req.url).pathname + new URL(req.url).search)
       if (new URL(req.url).pathname === '/cases/42') return Response.json({ ok: true })
@@ -71,6 +72,7 @@ test('elysia-style handle() object receives the function-local URL', async () =>
 test('elysia-style handle() object sees / for the function root', async () => {
   const seen: string[] = []
   const elysiaLike: FrameworkObjectHandler = {
+    routes: [],
     handle: (req) => {
       seen.push(new URL(req.url).pathname)
       return Response.json({ ok: true })

--- a/packages/supacloud-lite/test/parity-function-routing.test.ts
+++ b/packages/supacloud-lite/test/parity-function-routing.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Pins Lite's function routing rules to the shared parity vectors that the
+ * Edge Runtime tests also consume, so the local and production runtimes
+ * cannot drift on function-local URL rewriting or router detection.
+ */
+import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  isFrameworkRouterHandler,
+  toFunctionLocalUrl,
+  type FrameworkObjectHandler,
+} from '../src/runtime/index.js'
+
+interface RouterShape {
+  handle?: boolean
+  fetch?: boolean
+  routes?: boolean
+  routeAware?: boolean
+}
+
+const vectors = JSON.parse(
+  await readFile(join(import.meta.dir, '../parity/function-routing.vectors.json'), 'utf8')
+) as {
+  urlRewrite: Array<{ input: string; expected: string }>
+  routerDetection: Array<{ shape: RouterShape; expected: boolean; note: string }>
+}
+
+describe('function routing parity vectors (lite)', () => {
+  for (const vector of vectors.urlRewrite) {
+    test(`toFunctionLocalUrl ${vector.input}`, () => {
+      expect(toFunctionLocalUrl(vector.input)).toBe(vector.expected)
+    })
+  }
+
+  for (const vector of vectors.routerDetection) {
+    test(`isFrameworkRouterHandler: ${vector.note}`, () => {
+      const shape: FrameworkObjectHandler = {}
+      if (vector.shape.handle) shape.handle = () => new Response()
+      if (vector.shape.fetch) shape.fetch = () => new Response()
+      if (vector.shape.routes) shape.routes = []
+      if (vector.shape.routeAware !== undefined) shape.__supacloud = { routeAware: vector.shape.routeAware }
+      expect(isFrameworkRouterHandler(shape)).toBe(vector.expected)
+    })
+  }
+})


### PR DESCRIPTION
## 概要

防止 lite 与 Edge Runtime 的函数路由规则长期漂移（lite 路线图第 4 项的最小可行形态）：共享 parity 向量，两侧 CI 同时消费，任一侧漂移都会挂。

### 变更

- 新增 `packages/supacloud-lite/parity/function-routing.vectors.json`：function-local URL 改写（6 组）与路由器识别（6 组）向量
- lite 侧 `test/parity-function-routing.test.ts` 与 edge-runtime 侧 `function-routing-parity.test.ts` 消费同一向量文件
- edge-runtime：把 `toFunctionLocalUrl` / `isFrameworkRouterHandler` 从只能在 Worker 上下文 import 的 `worker-executor.ts` 抽取到 `function-routing.ts`（纯函数模块，worker-executor 改为 import，无行为变化）

### 向量抓到的真实漂移（已修复）

lite 的 `isFrameworkRouterHandler` 此前把任何带 `handle()` 的对象都视为路由感知，而生产要求 `routes` 数组 + `handle/fetch`（或显式 marker）。裸 `{ handle }` mock 在 lite 会改写 URL、在生产不会——本 PR 将 lite 对齐到生产语义（真实 Elysia 实例有 `routes`，不受影响；#1093 的端到端测试依旧通过）。

### JWT 差异确认（同期核查结论）

`#1076` 的 owner-tenant JWKS 修复属于自托管 Realtime 基础设施层；lite 的 Realtime 为进程内实现、`jwt.ts` 无 JWKS 面，本地单项目模型下无对应暴露面，无需改动。

## 验证

- edge-runtime：parity 12/12；worker-pool / function-activation / function-version 回归 0 fail；typecheck 干净
- lite：functions 相关 6 个文件 32 pass / 0 fail（含 #1093 的 Elysia 端到端）；typecheck 干净