### PR TITLE
feat(compiler): default compiled modules dependency injection to empty map

### DIFF
--- a/docs/application-framework.md
+++ b/docs/application-framework.md
@@ -109,7 +109,8 @@ import { createCompiledModules } from "./generated/application";
 
 export default createApplication({
   name: "fa-api",
-  modules: createCompiledModules({ dbClient, /* 平台依赖 */ }),
+  modules: createCompiledModules(),
+  deps: { dbClient, /* 平台依赖 */ },
   commandExecutor: async (invocation, next) => {
     await authorize(invocation.requestContext, invocation.command.permission);
     return next();

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -123,13 +123,13 @@ describe("generate：application.ts 可被 bun 直接执行", () => {
     compiled = await import(url);
   });
 
-  test("createCompiledModules 返回拓扑序模块描述", () => {
-    const modules = compiled.createCompiledModules({});
-    expect(modules.map((m: { name: string }) => m.name)).toEqual([
-      "audit",
-      "case",
-      "health",
-    ]);
+ test("createCompiledModules 返回拓扑序模块描述", () => {
+   const modules = compiled.createCompiledModules();
+   expect(modules.map((m: { name: string }) => m.name)).toEqual([
+     "audit",
+     "case",
+     "health",
+   ]);
     expect(modules[0].controllers).toEqual([]);
     expect(modules[1].commands[0]).toMatchObject({
       className: "AcceptCaseCommand",

--- a/packages/compiler/src/generate.ts
+++ b/packages/compiler/src/generate.ts
@@ -94,7 +94,7 @@ export async function generateApplication(
     ...(imports.size > 0 ? [""] : []),
     INTERFACES,
     "",
-    "export function createCompiledModules(deps: Record<string, unknown>): CompiledModule[] {",
+    "export function createCompiledModules(deps: Record<string, unknown> = {}): CompiledModule[] {",
     "  return [",
     ...descriptorEntries.map((entry) => indent(entry, 4) + ","),
     "  ];",


### PR DESCRIPTION
## Summary
- Defaults `createCompiledModules(deps: Record<string, unknown> = {})` in generated code so callers can invoke `createCompiledModules()` cleanly.
- Updates compiler test fixtures and framework documentation to match the streamlined invocation signature.

## Validation
- `bun run test`, `bun run typecheck`, `bun run typecheck:test`, and `bun run build` pass across all packages.