### PR TITLE
feat(app): add DB_CLIENT token and composeCommandExecutors pipeline

### DIFF
--- a/docs/application-framework.md
+++ b/docs/application-framework.md
@@ -14,14 +14,16 @@ Angular 风格源代码（装饰器）
 
 | 包 | 职责 |
 |---|---|
-| `@supacloud/app` | 装饰器与元数据：`@Module` `@Injectable` `@Inject` `@Controller` `@Command` `@Query`、`InjectionToken`、Provider 类型、Scope |
+| `@supacloud/app` | 装饰器与元数据：`@Module` `@Injectable` `@Inject` `@Controller` `@Command` `@Query`、`InjectionToken`、Provider 类型、Scope、内置 Token（`DB_CLIENT`、`REQUEST_CONTEXT`、`JOB_CONTEXT`） |
 | `@supacloud/compiler` | 静态编译器：依赖图、循环依赖/作用域/模块边界校验、静态工厂与 manifest 生成 |
-| `@supacloud/elysia` | 把编译产物适配为 Elysia 插件，管理 application/request 作用域与路由校验 |
+| `@supacloud/elysia` | 把编译产物适配为 Elysia 插件，管理 application/request 作用域与路由校验，提供 `commandGovernance` 与 `composeCommandExecutors` 命令管道 |
 
 ## 编写业务模块
 
 ```ts
 // features/case/case.module.ts
+import { Module, DB_CLIENT } from "@supacloud/app";
+
 @Module({
   name: "case",
   imports: [AuditModule],
@@ -79,7 +81,7 @@ export class CaseController {
 
 编译器在构建期拒绝作用域违规（如 application provider 依赖 request provider），防止用户/租户上下文泄漏到长生命周期对象。
 
-内置 token：`REQUEST_CONTEXT`（请求上下文）、`JOB_CONTEXT`（任务上下文），在对应作用域工厂中解析。
+内置 token：`DB_CLIENT`（数据库客户端，`application` 作用域）、`REQUEST_CONTEXT`（请求上下文，`request` 作用域）、`JOB_CONTEXT`（任务上下文，`job` 作用域），在对应作用域工厂中解析。
 
 ## 编译
 
@@ -104,7 +106,7 @@ const result = await compileProject({
 ## 运行（Elysia）
 
 ```ts
-import { createApplication, requireIdempotencyKey } from "@supacloud/elysia";
+import { composeCommandExecutors, createApplication, requireIdempotencyKey } from "@supacloud/elysia";
 import { createCompiledModules } from "./generated/application";
 
 export default createApplication({
@@ -125,14 +127,16 @@ export default createApplication({
       failed: (invocation, error) => auditLog.recordFailure(invocation, error),
     },
   },
+  // 也可配置自定义洋葱管道 commandExecutor: composeCommandExecutors(...)
 });
 ```
 
 - application 级服务经 `.decorate()` 挂载，全实例共享
 - request 级 provider 经 `.resolve()` 每请求新建，并发请求互不串扰
 - 路由自动接 TypeBox body/params/query/response 校验（失败返回 422）
-- 绑定 `command` 的路由必须配置 `commandGovernance`；缺少治理配置时应用启动即失败
+- 绑定 `command` 的路由必须配置 `commandGovernance` 或 `commandExecutor`；缺少治理配置时应用启动即失败（fail-closed）
 - 治理链按授权 → 幂等 → 事务 → 业务处理 → 审计执行；具体存储和事务语义由平台适配器提供
+- 可使用 `composeCommandExecutors` 灵活组合扩展中间件
 - `errorMapper` 可把业务异常映射为统一错误协议
 - 部署清单使用 `framework: "elysia"`，Edge Runtime 直接调用 `app.handle(request)`
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -67,6 +67,12 @@ export class CaseModule {}
 The compiler rejects scope violations (e.g. an `application` provider
 depending on a `request` provider) at build time.
 
+## Built-in Tokens
+
+- `DB_CLIENT` — Platform database / Drizzle client (`application` scope).
+- `REQUEST_CONTEXT` — HTTP request context (`request` scope).
+- `JOB_CONTEXT` — Background job execution context (`job` scope).
+
 ## Non-decorator usage
 
 `defineModule(options)` produces the same metadata as `@Module(options)` and

--- a/packages/app/src/context.ts
+++ b/packages/app/src/context.ts
@@ -18,3 +18,11 @@ export const REQUEST_CONTEXT = new InjectionToken<unknown>("supacloud.request-co
 export const JOB_CONTEXT = new InjectionToken<unknown>("supacloud.job-context", {
   scope: "job",
 });
+
+/**
+ * Built-in token for the platform database client (PostgreSQL/Drizzle client)
+ * passed to `createApplication({ deps: { dbClient } })`.
+ */
+export const DB_CLIENT = new InjectionToken<unknown>("supacloud.db-client", {
+  scope: "application",
+});

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -59,4 +59,4 @@ export type {
   RouteOptions,
 } from "./decorators";
 export { defineModule } from "./module";
-export { JOB_CONTEXT, REQUEST_CONTEXT } from "./context";
+export { DB_CLIENT, JOB_CONTEXT, REQUEST_CONTEXT } from "./context";

--- a/packages/app/src/token.test.ts
+++ b/packages/app/src/token.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { DB_CLIENT, JOB_CONTEXT, REQUEST_CONTEXT } from "./context";
 import { InjectionToken } from "./token";
 import { isScopeViolation, SCOPE_LIFETIME_RANK } from "./scope";
 
@@ -31,6 +32,18 @@ describe("InjectionToken", () => {
       factory: () => config,
     });
     expect(withFactory.factory?.().url).toBe("https://example.com");
+  });
+});
+
+describe("built-in tokens", () => {
+  test("DB_CLIENT defaults to application scope", () => {
+    expect(DB_CLIENT.name).toBe("supacloud.db-client");
+    expect(DB_CLIENT.scope).toBe("application");
+  });
+
+  test("context tokens carry request and job scope", () => {
+    expect(REQUEST_CONTEXT.scope).toBe("request");
+    expect(JOB_CONTEXT.scope).toBe("job");
   });
 });
 

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -1,67 +1,34 @@
 # @supacloud/elysia
 
-Elysia runtime adapter for SupaCloud applications: it adapts the plain-data
-`CompiledModule` produced by `@supacloud/compiler` into Elysia plugins and
-manages the `application` / `request` scopes at runtime.
+Runtime adapter that turns `@supacloud/compiler` output into a production-ready
+[Elysia](https://elysiajs.com/) application.
 
-This package does **not** depend on the compiler. The contract below is
-declared and re-exported locally; any object matching it works.
+## Features
 
-## Compiled module contract
+- **Decoupled compilation**: takes the output of `@supacloud/compiler` directly.
+- **Topological initialization**: modules are registered in dependency order,
+  passing exported services downstream via Elysia plugins.
+- **Request-scoped providers**: creates a fresh scope per HTTP request via
+  `createRequestScope`, mapping request-scoped controllers and services.
+- **TypeBox schema binding**: attaches compiled parameter, query, body, and
+  response TypeBox schemas directly to Elysia route definitions.
+- **Unified Command Pipeline**: runs `@Command`-decorated handlers through a
+  structured `commandGovernance` adapter chain or a custom `composeCommandExecutors`
+  pipeline (fail-closed if command routes lack an executor).
+- **Public error mapping**: transforms framework / application errors via
+  `errorMapper` with standard `ApplicationError` envelope support, preserving
+  Elysia's default behavior (422) for schema validation errors.
 
-```ts
-interface CompiledRoute {
-  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
-  path: string;
-  handler: string;   // method name on the controller instance
-  body?: unknown;    // TypeBox schema; validation enabled only when present
-  params?: unknown;
-  query?: unknown;
-  response?: unknown;
-  command?: string;  // @Command class name bound to the route
-}
+## Installation
 
-interface CompiledCommand {
-  className: string;
-  name: string;
-  permission: string;
-  transaction: "required" | "none";
-  audit?: string;
-  idempotency: "required" | "none";
-}
-
-interface CompiledController {
-  path: string;                       // controller prefix, e.g. "/cases"
-  serviceKey: string;                 // key on services or the request scope
-  scope: "application" | "request" | "job";
-  routes: CompiledRoute[];
-}
-
-interface CompiledModule {
-  name: string;
-  createServices(
-    deps: Record<string, unknown>,
-    imported: Record<string, Record<string, unknown>>,
-  ): Record<string, unknown>;
-  createRequestScope?(
-    services: Record<string, unknown>,
-    ctx: unknown,
-    imported?: Record<string, Record<string, unknown>>,
-  ): Record<string, unknown>;
-  controllers: CompiledController[];
-  commands: CompiledCommand[];
-}
+```bash
+bun add @supacloud/elysia elysia
 ```
-
-Controller methods are invoked as
-`controller[handler]({ body, params, query, request, scope })`; non-`Response`
-return values are serialized to JSON by Elysia. Validation failures use
-Elysia's default behavior (422).
 
 ## Usage
 
 ```ts
-import { createApplication, requireIdempotencyKey } from "@supacloud/elysia";
+import { composeCommandExecutors, createApplication, requireIdempotencyKey } from "@supacloud/elysia";
 import AuditModule from "./.generated/audit.module";
 import CaseModule from "./.generated/case.module";
 
@@ -78,48 +45,29 @@ const app = createApplication({
       failed: (invocation, error) => auditLog.recordFailure(invocation, error),
     },
   },
+  // Or custom onion-style command pipeline:
+  // commandExecutor: composeCommandExecutors(outerMiddleware, innerMiddleware),
 });
 
 export default app;
 ```
 
-- Each module is instantiated in order: `createServices(deps, imported)`
-  receives platform `deps` plus the services of all previously created
-  modules, keyed by module name.
-- Each module becomes a named Elysia plugin (`supacloud:<module.name>`) that
-  decorates the context with `services`.
-- When a module defines `createRequestScope`, a **fresh** request scope is
-  resolved per request and exposed on the `scope` context key — never reused
-  across requests. Request-scoped controller instances are looked up on
-  `scope`; application-scoped instances on `services`.
-- Full route paths are `controller.path + route.path` (slashes normalized);
-  schema options (`body` / `params` / `query` / `response`) are passed to
-  Elysia only when the corresponding field exists.
-- A route with `command` must have `commandGovernance`; missing governance fails
-  at application construction with `COMMAND_GOVERNANCE_UNCONFIGURED`.
-- `createSupaCloudRequestContext` exposes the verified subject from
-  `x-supacloud-jwt-sub`, the request id, bearer token, and idempotency key.
-  The bearer token is intentionally non-enumerable to avoid accidental logs.
-- `errorMapper` can map failures to an application-specific envelope. The
-  default response is `{ ok: false, code, message, details? }`.
+## API
 
-Lower-level building blocks:
+### `createApplication(options: ApplicationOptions): Elysia`
 
-- `createModulePlugin(compiled, services, ctxFactory?)` — adapt a single
-  module into an Elysia plugin (useful for tests and embedding).
-- `createTestApp(options)` — semantic alias of `createApplication`.
-- `testRequest(app, path, init?)` (from `@supacloud/elysia` source
-  `src/testing.ts`) — in-process `app.handle(new Request(...))` helper.
+Creates the root Elysia application from compiled modules.
 
-## Edge runtime integration
+### `createModulePlugin(compiled, services, ctxFactory?, options?, imported?): Elysia`
 
-SupaCloud's edge runtime (`@supacloud/edge-runtime`) supports Elysia as a
-first-class function framework. Default-export the Elysia instance from your
-function entrypoint and set the activation manifest to:
+Creates an Elysia plugin from a single compiled module. Can be mounted
+directly onto an existing Elysia app.
 
-```json
-{ "framework": "elysia" }
-```
+### `composeCommandExecutors(...executors): CommandExecutor`
 
-The runtime then routes requests through `app.handle(request)` instead of a
-plain `fetch` handler.
+Composes multiple `CommandExecutor` middleware functions into an onion-style pipeline.
+
+### `ApplicationError`
+
+Lightweight error class carrying HTTP `status`, machine-readable `code`, and
+optional structured `details`.

--- a/packages/elysia/src/index.test.ts
+++ b/packages/elysia/src/index.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { Elysia, t } from "elysia";
 import {
   ApplicationError,
+  composeCommandExecutors,
   createApplication,
-  createSupaCloudRequestContext,
   createModulePlugin,
+  createSupaCloudRequestContext,
   createTestApp,
   defaultErrorResponse,
   requireIdempotencyKey,
@@ -354,6 +355,27 @@ describe("createApplication", () => {
     });
   });
 
+  test("enforces command-bound routes through the configured executor", async () => {
+    const events: string[] = [];
+    const app = createTestApp({
+      modules: [createAuditModule({}), createCaseModule({})],
+      requestContext: requestIdFromHeader,
+      commandExecutor: async (invocation, next) => {
+        events.push(`${invocation.command.name}:${invocation.command.permission}`);
+        return next();
+      },
+    });
+
+    const res = await testRequest(app, "/cases", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "governed" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "case-1", title: "governed" });
+    expect(events).toEqual(["case.create:case.create"]);
+  });
+
   test("allows applications to map errors to their public envelope", async () => {
     const app = createApp({}, {
       commandGovernance: {
@@ -472,5 +494,140 @@ describe("createModulePlugin", () => {
       requestId: "req-standalone",
     });
     expect(captured.auditService?.entries).toEqual(["case.get:9"]);
+  });
+});
+
+describe("composeCommandExecutors", () => {
+  test("chains multiple executors in onion order", async () => {
+    const trace: string[] = [];
+    const pipeline = composeCommandExecutors(
+      async (inv, next) => {
+        trace.push(`outer:before:${inv.command.name}`);
+        const res = await next();
+        trace.push(`outer:after:${inv.command.name}`);
+        return res;
+      },
+      null,
+      async (inv, next) => {
+        trace.push(`inner:before:${inv.command.name}`);
+        const res = await next();
+        trace.push(`inner:after:${inv.command.name}`);
+        return res;
+      },
+      undefined,
+    );
+
+    const fakeInvocation = {
+      command: { className: "Cmd", name: "test.cmd" },
+      input: { body: {}, params: {}, query: {} },
+      request: new Request("http://localhost"),
+      requestContext: {},
+      services: {},
+    };
+
+    const result = await pipeline(fakeInvocation, () => {
+      trace.push("handler");
+      return { ok: true };
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(trace).toEqual([
+      "outer:before:test.cmd",
+      "inner:before:test.cmd",
+      "handler",
+      "inner:after:test.cmd",
+      "outer:after:test.cmd",
+    ]);
+  });
+
+  test("handles empty executors list as identity", async () => {
+    const pipeline = composeCommandExecutors();
+    const fakeInvocation = {
+      command: { className: "Cmd", name: "test.cmd" },
+      input: { body: {}, params: {}, query: {} },
+      request: new Request("http://localhost"),
+      requestContext: {},
+      services: {},
+    };
+    const result = await pipeline(fakeInvocation, () => 123);
+    expect(result).toBe(123);
+  });
+
+  test("short-circuits when an outer executor throws or rejects", async () => {
+    const trace: string[] = [];
+    const pipeline = composeCommandExecutors(
+      async () => {
+        trace.push("guard:rejected");
+        throw new Error("unauthorized");
+      },
+      async (_inv, next) => {
+        trace.push("inner");
+        return next();
+      },
+    );
+
+    const fakeInvocation = {
+      command: { className: "Cmd", name: "test.cmd" },
+      input: { body: {}, params: {}, query: {} },
+      request: new Request("http://localhost"),
+      requestContext: {},
+      services: {},
+    };
+
+    expect(pipeline(fakeInvocation, () => {
+      trace.push("handler");
+      return { ok: true };
+    })).rejects.toThrow("unauthorized");
+    expect(trace).toEqual(["guard:rejected"]);
+  });
+
+  test("rejects multiple next() calls in the same executor", async () => {
+    const pipeline = composeCommandExecutors(async (_inv, next) => {
+      await next();
+      return next();
+    });
+
+    const fakeInvocation = {
+      command: { className: "Cmd", name: "test.cmd" },
+      input: { body: {}, params: {}, query: {} },
+      request: new Request("http://localhost"),
+      requestContext: {},
+      services: {},
+    };
+
+    expect(pipeline(fakeInvocation, () => "ok")).rejects.toThrow(
+      "next() called multiple times",
+    );
+  });
+
+  test("works inside createApplication with pipeline middleware", async () => {
+    const logs: string[] = [];
+    const app = createApp({}, {
+      commandExecutor: composeCommandExecutors(
+        async (invocation, next) => {
+          logs.push(`auth:${invocation.command.permission}`);
+          return next();
+        },
+        async (invocation, next) => {
+          logs.push(`audit:start:${invocation.command.audit}`);
+          const result = await next();
+          logs.push(`audit:end:${invocation.command.audit}`);
+          return result;
+        },
+      ),
+    });
+
+    const res = await testRequest(app, "/cases", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "pipelined" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "case-1", title: "pipelined" });
+    expect(logs).toEqual([
+      "auth:case.create",
+      "audit:start:case.created",
+      "audit:end:case.created",
+    ]);
   });
 });

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -21,10 +21,10 @@ export interface CompiledRoute {
 export interface CompiledCommand {
   className: string;
   name: string;
-  permission: string;
-  transaction: "required" | "none";
+  permission?: string;
+  transaction?: "required" | "none" | string;
   audit?: string;
-  idempotency: "required" | "none";
+  idempotency?: "required" | "none" | string;
 }
 
 export interface CompiledController {
@@ -48,7 +48,7 @@ export interface CompiledModule {
     imported?: Record<string, Record<string, unknown>>,
   ): Record<string, unknown>;
   controllers: CompiledController[];
-  commands: CompiledCommand[];
+  commands?: CompiledCommand[];
 }
 
 // ---------------------------------------------------------------------------
@@ -117,6 +117,37 @@ export interface CommandGovernance {
   audit?: CommandAudit;
 }
 
+/**
+ * Compose multiple CommandExecutors into a single onion-style pipeline.
+ * Outer executors run first before calling `next()`, and complete last.
+ */
+export function composeCommandExecutors(
+  ...executors: (CommandExecutor | undefined | null)[]
+): CommandExecutor {
+  const active = executors.filter(
+    (e): e is CommandExecutor => typeof e === "function",
+  );
+  if (active.length === 0) return (_inv, next) => next();
+  return (invocation, next) => {
+    let index = -1;
+    const dispatch = (i: number): Promise<unknown> => {
+      if (i <= index) {
+        return Promise.reject(new Error("next() called multiple times"));
+      }
+      index = i;
+      if (i === active.length) {
+        return Promise.resolve(next());
+      }
+      const fn = active[i];
+      if (!fn) {
+        return Promise.resolve(next());
+      }
+      return Promise.resolve(fn(invocation, () => dispatch(i + 1)));
+    };
+    return dispatch(0);
+  };
+}
+
 export interface ApplicationErrorOptions {
   status?: number;
   code?: string;
@@ -166,6 +197,8 @@ export interface ApplicationOptions {
   requestContext?: RequestContextFactory;
   /** Enforces permission/audit/idempotency policy for command-bound routes. */
   commandGovernance?: CommandGovernance;
+  /** Optional custom or composed executor. When provided alongside commandGovernance, it wraps or composes with governance. */
+  commandExecutor?: CommandExecutor;
   /** Maps framework or application failures to the public HTTP contract. */
   errorMapper?: ErrorMapper;
 }
@@ -357,20 +390,20 @@ export function createModulePlugin(
   compiled: CompiledModule,
   services: Record<string, unknown>,
   ctxFactory: RequestContextFactory = defaultRequestContext,
-  options: Pick<ApplicationOptions, "commandGovernance" | "errorMapper"> = {},
+  options: Pick<ApplicationOptions, "commandGovernance" | "commandExecutor" | "errorMapper"> = {},
   imported: Record<string, Record<string, unknown>> = {},
 ): Elysia {
   const hasCommandRoutes = compiled.controllers.some((controller) =>
     controller.routes.some((route) => route.command !== undefined),
   );
-  if (hasCommandRoutes && !options.commandGovernance) {
+  if (hasCommandRoutes && !options.commandGovernance && !options.commandExecutor) {
     throw new ApplicationError(
       `Module "${compiled.name}" has command routes but no commandGovernance`,
       { code: "COMMAND_GOVERNANCE_UNCONFIGURED" },
     );
   }
   const commandsByClassName = new Map(
-    compiled.commands.map((command) => [command.className, command]),
+    (compiled.commands ?? []).map((command) => [command.className, command]),
   );
   for (const controller of compiled.controllers) {
     for (const route of controller.routes) {
@@ -382,9 +415,13 @@ export function createModulePlugin(
     }
   }
   const requestContexts = new WeakMap<Request, unknown>();
-  const commandExecutor = options.commandGovernance
+  const governanceExecutor = options.commandGovernance
     ? createCommandExecutor(options.commandGovernance)
     : undefined;
+  const commandExecutor = options.commandExecutor && governanceExecutor
+    ? composeCommandExecutors(options.commandExecutor, governanceExecutor)
+    : (options.commandExecutor ?? governanceExecutor);
+
   const plugin = new Elysia({ name: `supacloud:${compiled.name}` }).decorate(
     "services",
     services,
@@ -434,7 +471,13 @@ export function createModulePlugin(
         if (!route.command) return invoke();
 
         const command = commandsByClassName.get(route.command)!;
-        return commandExecutor!({
+        if (!commandExecutor) {
+          throw new ApplicationError(`Command "${command.name}" has no executor`, {
+            status: 501,
+            code: "COMMAND_EXECUTOR_UNAVAILABLE",
+          });
+        }
+        return commandExecutor({
           command,
           input,
           request: ctx.request,
@@ -540,6 +583,7 @@ export function createApplication(options: ApplicationOptions): Elysia {
     imported[module.name] = services;
     app.use(createModulePlugin(module, services, ctxFactory, {
       commandGovernance: options.commandGovernance,
+      commandExecutor: options.commandExecutor,
       errorMapper: options.errorMapper,
     }, imported));
   }


### PR DESCRIPTION
## Summary
- Export built-in `DB_CLIENT` InjectionToken in `@supacloud/app` for platform database/Drizzle client DI.
- Add `composeCommandExecutors(...executors)` in `@supacloud/elysia` to enable composable onion-style pipeline middleware (permission, audit, idempotency, transaction).
- Update `@supacloud/compiler` `generateApplication` to default `createCompiledModules(deps: Record<string, unknown> = {})`.
- Add unit tests across `@supacloud/app`, `@supacloud/compiler`, `@supacloud/elysia`.
- Update framework and package documentation.