### PR TITLE
feat(db): trigger reconcile and transactional plan/apply executor

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -59,6 +59,8 @@ export const casesModule = defineDatabaseModule({
 | `buildDatabaseManifest(modules)` | 汇总模块为可 JSON 序列化的 `DatabaseManifest`（version 1） |
 | `explainObject(manifest, name)` | 人类可读地解释对象的所属模块、类型、源文件、权限、测试 |
 | `createDatabaseAccessBoundary(options)` | 统一用户 RLS 客户端与显式 service-role 客户端的访问边界 |
+| `planModule(module, readFile)` | 把模块声明编译为有序 `ModulePlan`（step 依赖序：function → policy → trigger → grant），含 sha256 与 lint 风险 |
+| `applyModulePlan(executor, plan)` | 按 plan 落库：账本幂等 + advisory lock + 单事务 + catalog 回读验证 |
 
 ### 数据库访问边界
 
@@ -85,7 +87,9 @@ const workerDb = await database.forService("scheduled-worker");
 | --- | --- | --- |
 | `missing-policy` | error | 声明的策略在 catalog 中不存在 |
 | `missing-function` | error | 声明的 RPC 函数在 catalog 中不存在 |
+| `missing-trigger` | error | 声明的触发器在 catalog 中不存在（按 schema.table + name 匹配） |
 | `undeclared-policy` | warn | 归属表上存在 manifest 未声明的策略（漂移） |
+| `undeclared-trigger` | warn | 归属表上存在 manifest 未声明的触发器（含已禁用的，漂移） |
 | `rls-disabled` | error | 归属表 `relrowsecurity = false` |
 | `definer-without-search-path` | error | security definer 函数未设置固定 search_path（含空元素或 `pg_temp` 也算不固定） |
 | `security-mismatch` | warn | 声明的 invoker/definer 与 catalog 实际不一致 |
@@ -102,7 +106,24 @@ const workerDb = await database.forService("scheduled-worker");
 | `grant-to-public` | error | `grant ... to public` |
 | `missing-rls-enable` | warn | 声明了策略但所有策略源文件都没有 `enable row level security` |
 | `drop-without-if-exists` | warn | `drop table/column` 缺少 `if exists` |
+| `non-idempotent-policy` | warn | `create policy` 前缺少 `drop policy if exists`（PostgreSQL CREATE POLICY 无 IF NOT EXISTS，不先 drop 就不可重复执行） |
 | `policy-without-test` | warn | 声明的策略/函数没有 `tests` 条目 |
+
+## Plan / Apply
+
+`planModule` 把模块声明编译为 `ModulePlan`（version 1）：每个声明对象（函数/策略/触发器/授权）对应一个 `PlanStep`，按依赖序 **function → policy → trigger → grant** 排列；每个 step 携带源文件内容的 sha256、`lintSql` 静态分析得出的 `risk`（error 级 lint 原样保留 severity=error），plan 级 `digest` 为全部 step sha256 的组合哈希。step 的 `name` 是对象标识：函数为 schema 限定名，策略/触发器为 `table.name`，授权为 `object:privilege:role`。
+
+`applyModulePlan` 的语义：
+
+1. plan 含任何 error 级 risk → 直接抛错拒绝执行，不触碰数据库。
+2. 确保账本：`create schema if not exists _supacloud` + `create table if not exists _supacloud.db_object_ledger(object_identity text primary key, module text, sha256 text, applied_at timestamptz default now())`。
+3. `pg_advisory_lock(hashtext('supacloud-db-apply'))` 串行化并发 apply，`finally` 中 unlock。
+4. 单事务内逐 step 执行：`object_identity = ${kind}:${name}` 查账本，sha256 一致则 `skipped`；否则执行 step.sql 并 upsert 账本。任何 step 失败 → ROLLBACK 并返回 `failed`；全成功 → COMMIT。
+5. 提交后 `readCatalog` 回读验证声明对象真实存在，结果进 `verified`，缺失进 `failed`。
+
+**幂等要求**：step.sql 必须可重复执行（`create or replace function`、`drop policy if exists` + `create policy`、`drop trigger if exists` + `create trigger`、`grant` 天然幂等）。sha256 一致即跳过，因此改源文件才会触发重放。executor 提供可选 `transaction(fn)` 时用它管理事务，否则退化为顺序执行 `begin/commit/rollback` 语句。
+
+**与 migration 的边界**：本执行器只管模块声明的**可重复 SQL 对象**（函数/策略/触发器/授权），不做表结构变更 —— 建表、加列等表结构演进仍走前向 migration（Drizzle/SQL migration 文件）。
 
 ## 与 Supabase / PostgreSQL 的关系
 

--- a/packages/db/src/apply.test.ts
+++ b/packages/db/src/apply.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, test } from 'bun:test';
+
+import { applyModulePlan } from './apply.js';
+import type { QueryExecutor } from './catalog.js';
+import { defineDatabaseModule } from './module.js';
+import { planModule, type ModulePlan } from './plan.js';
+
+interface CapturedCall {
+  sql: string;
+  params?: unknown[];
+}
+
+const files: Record<string, string> = {
+  'db/functions/case_create.sql':
+    'create or replace function public.case_create() returns int language sql security definer set search_path = public as $$ select 1 $$;',
+  'db/policies/cases_select.sql':
+    'drop policy if exists cases_select on public.cases;\ncreate policy cases_select on public.cases for select to authenticated using (true);',
+  'db/triggers/cases_updated_at.sql':
+    'drop trigger if exists cases_updated_at on public.cases;\ncreate trigger cases_updated_at before update on public.cases for each row execute function public.set_updated_at();',
+  'db/grants/cases.sql': 'grant select on public.cases to authenticated;',
+};
+
+const readFile = (path: string): Promise<string> => {
+  const content = files[path];
+  if (content === undefined) return Promise.reject(new Error(`missing file: ${path}`));
+  return Promise.resolve(content);
+};
+
+function testModule() {
+  return defineDatabaseModule({
+    name: 'cases',
+    tables: ['public.cases'],
+    functions: [
+      {
+        name: 'public.case_create',
+        source: 'db/functions/case_create.sql',
+        security: 'definer',
+      },
+    ],
+    policies: [
+      {
+        name: 'cases_select',
+        table: 'public.cases',
+        operation: 'select',
+        roles: ['authenticated'],
+        source: 'db/policies/cases_select.sql',
+      },
+    ],
+    triggers: [
+      {
+        name: 'cases_updated_at',
+        table: 'public.cases',
+        source: 'db/triggers/cases_updated_at.sql',
+      },
+    ],
+    grants: [
+      {
+        object: 'public.cases',
+        privilege: 'SELECT',
+        role: 'authenticated',
+        source: 'db/grants/cases.sql',
+      },
+    ],
+  });
+}
+
+const STEP_NAMES = [
+  'public.case_create',
+  'public.cases.cases_select',
+  'public.cases.cases_updated_at',
+  'public.cases:SELECT:authenticated',
+];
+
+/** 应用后 catalog 回读验证用的固定行（覆盖全部四个声明对象） */
+const HAPPY_CATALOG_ROUTES = [
+  { match: 'pg_class c\nJOIN pg_namespace', rows: [] },
+  {
+    match: 'pg_policy',
+    rows: [
+      {
+        schema: 'public',
+        table: 'cases',
+        name: 'cases_select',
+        command: 'r',
+        roles: ['authenticated'],
+        using_expr: 'true',
+        check_expr: null,
+      },
+    ],
+  },
+  {
+    match: 'pg_proc',
+    rows: [
+      {
+        schema: 'public',
+        name: 'case_create',
+        security_definer: true,
+        config: ['search_path=public'],
+        language: 'sql',
+      },
+    ],
+  },
+  {
+    match: 'pg_trigger',
+    rows: [{ schema: 'public', table: 'cases', name: 'cases_updated_at', enabled: true }],
+  },
+  {
+    match: 'role_table_grants',
+    rows: [
+      {
+        object_schema: 'public',
+        object_name: 'cases',
+        privilege: 'SELECT',
+        grantee: 'authenticated',
+      },
+    ],
+  },
+];
+
+interface MockOptions {
+  /** step.sql 含此片段时抛错，模拟执行失败 */
+  failOn?: string;
+  /** 提供 transaction(fn)，走托管事务路径 */
+  withTransaction?: boolean;
+}
+
+/**
+ * 内存版 mock executor：用 Map 模拟 _supacloud.db_object_ledger，
+ * begin/commit/rollback 语义真实生效（事务内写入 pending，commit 落账，rollback 丢弃）。
+ */
+function mockApplyExecutor(options: MockOptions = {}): {
+  executor: QueryExecutor;
+  calls: CapturedCall[];
+  ledger: Map<string, { module: string; sha256: string }>;
+} {
+  const calls: CapturedCall[] = [];
+  const ledger = new Map<string, { module: string; sha256: string }>();
+  let pending: Map<string, { module: string; sha256: string }> | null = null;
+
+  const beginTx = () => {
+    pending = new Map();
+  };
+  const commitTx = () => {
+    if (pending) {
+      for (const [key, value] of pending) ledger.set(key, value);
+    }
+    pending = null;
+  };
+  const rollbackTx = () => {
+    pending = null;
+  };
+
+  const executor: QueryExecutor = {
+    query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]> {
+      calls.push({ sql, params });
+      const head = sql.trim().toLowerCase();
+      if (head === 'begin') {
+        beginTx();
+        return Promise.resolve([]);
+      }
+      if (head === 'commit') {
+        commitTx();
+        return Promise.resolve([]);
+      }
+      if (head === 'rollback') {
+        rollbackTx();
+        return Promise.resolve([]);
+      }
+      if (options.failOn && sql.includes(options.failOn)) {
+        return Promise.reject(new Error(`boom: ${options.failOn}`));
+      }
+      if (sql.includes('db_object_ledger where object_identity')) {
+        const identity = params?.[0] as string;
+        // 事务内读：先看事务缓冲，再回退到已提交账本（read-your-writes + 已提交数据可见）
+        const row = pending?.get(identity) ?? ledger.get(identity);
+        return Promise.resolve((row ? [{ sha256: row.sha256 }] : []) as T[]);
+      }
+      if (sql.includes('insert into _supacloud.db_object_ledger')) {
+        const store = pending ?? ledger;
+        store.set(params?.[0] as string, {
+          module: params?.[1] as string,
+          sha256: params?.[2] as string,
+        });
+        return Promise.resolve([]);
+      }
+      const route = HAPPY_CATALOG_ROUTES.find((r) => sql.includes(r.match));
+      return Promise.resolve((route?.rows ?? []) as T[]);
+    },
+  };
+
+  if (options.withTransaction) {
+    executor.transaction = async <T>(fn: (tx: QueryExecutor) => Promise<T>): Promise<T> => {
+      beginTx();
+      try {
+        const value = await fn(executor);
+        commitTx();
+        return value;
+      } catch (error) {
+        rollbackTx();
+        throw error;
+      }
+    };
+  }
+
+  return { executor, calls, ledger };
+}
+
+async function makePlan(): Promise<ModulePlan> {
+  return planModule(testModule(), readFile);
+}
+
+function sqls(calls: CapturedCall[]): string[] {
+  return calls.map((call) => call.sql);
+}
+
+describe('applyModulePlan', () => {
+  test('全绿路径：账本为空时全部 applied 并 verified', async () => {
+    const { executor, ledger } = mockApplyExecutor();
+    const result = await applyModulePlan(executor, await makePlan());
+    expect(result.module).toBe('cases');
+    expect(result.applied).toEqual(STEP_NAMES);
+    expect(result.skipped).toEqual([]);
+    expect(result.verified).toEqual(STEP_NAMES);
+    expect(result.failed).toBeUndefined();
+    expect(ledger.size).toBe(4);
+  });
+
+  test('幂等：ledger 已有同 sha256 时全部 skipped，不重复执行 SQL', async () => {
+    const { executor, calls, ledger } = mockApplyExecutor();
+    const plan = await makePlan();
+    await applyModulePlan(executor, plan);
+    expect(ledger.size).toBe(4);
+
+    calls.length = 0;
+    const second = await applyModulePlan(executor, plan);
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual(STEP_NAMES);
+    expect(second.verified).toEqual(STEP_NAMES);
+    expect(second.failed).toBeUndefined();
+    const executed = sqls(calls);
+    expect(executed.some((sql) => sql.includes('create or replace function'))).toBe(false);
+    expect(executed.some((sql) => sql.includes('create policy'))).toBe(false);
+  });
+
+  test('失败回滚：第二步抛错则 ROLLBACK，ledger 无写入，后续 step 不执行', async () => {
+    const { executor, calls, ledger } = mockApplyExecutor({ failOn: 'create policy' });
+    const result = await applyModulePlan(executor, await makePlan());
+    expect(result.failed?.step).toBe('public.cases.cases_select');
+    expect(result.failed?.error).toContain('boom');
+    expect(result.applied).toEqual([]);
+    expect(result.verified).toEqual([]);
+    const executed = sqls(calls);
+    expect(executed.filter((sql) => sql.trim() === 'rollback')).toHaveLength(1);
+    expect(executed.some((sql) => sql.trim() === 'commit')).toBe(false);
+    expect(executed.some((sql) => sql.includes('create trigger'))).toBe(false);
+    expect(ledger.size).toBe(0);
+  });
+
+  test('error 级 risk 直接拒绝执行，不触碰数据库', async () => {
+    const badModule = defineDatabaseModule({
+      name: 'bad',
+      functions: [{ name: 'public.f', source: 'f.sql', security: 'definer' }],
+    });
+    const plan = await planModule(badModule, () =>
+      Promise.resolve(
+        'create function public.f() returns int language sql security definer as $$ select 1 $$;',
+      ),
+    );
+    const { executor, calls } = mockApplyExecutor();
+    await expect(applyModulePlan(executor, plan)).rejects.toThrow('拒绝执行');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('advisory lock/unlock 成对调用且包裹事务', async () => {
+    const { executor, calls } = mockApplyExecutor();
+    await applyModulePlan(executor, await makePlan());
+    const executed = sqls(calls);
+    const lockIndex = executed.findIndex((sql) => sql.includes('pg_advisory_lock'));
+    const unlockIndex = executed.findIndex((sql) => sql.includes('pg_advisory_unlock'));
+    const beginIndex = executed.findIndex((sql) => sql.trim() === 'begin');
+    const commitIndex = executed.findIndex((sql) => sql.trim() === 'commit');
+    expect(lockIndex).toBeGreaterThanOrEqual(0);
+    expect(unlockIndex).toBeGreaterThan(commitIndex);
+    expect(lockIndex).toBeLessThan(beginIndex);
+    // 失败路径同样必须 unlock
+    const failing = mockApplyExecutor({ failOn: 'create policy' });
+    await applyModulePlan(failing.executor, await makePlan());
+    const failingSqls = sqls(failing.calls);
+    expect(failingSqls.some((sql) => sql.includes('pg_advisory_lock'))).toBe(true);
+    expect(failingSqls.some((sql) => sql.includes('pg_advisory_unlock'))).toBe(true);
+  });
+
+  test('executor 提供 transaction 时走托管事务，不直接执行 begin/commit', async () => {
+    const { executor, calls, ledger } = mockApplyExecutor({ withTransaction: true });
+    const result = await applyModulePlan(executor, await makePlan());
+    expect(result.applied).toEqual(STEP_NAMES);
+    expect(result.failed).toBeUndefined();
+    expect(ledger.size).toBe(4);
+    const executed = sqls(calls);
+    expect(executed.some((sql) => sql.trim() === 'begin')).toBe(false);
+    expect(executed.some((sql) => sql.trim() === 'commit')).toBe(false);
+  });
+
+  test('托管事务路径失败同样回滚并返回 failed', async () => {
+    const { executor, ledger } = mockApplyExecutor({
+      withTransaction: true,
+      failOn: 'create policy',
+    });
+    const result = await applyModulePlan(executor, await makePlan());
+    expect(result.failed?.step).toBe('public.cases.cases_select');
+    expect(ledger.size).toBe(0);
+  });
+});

--- a/packages/db/src/apply.ts
+++ b/packages/db/src/apply.ts
@@ -1,0 +1,197 @@
+/**
+ * Apply：把 ModulePlan 落到数据库 —— 账本幂等 + advisory lock + 单事务 + catalog 回读验证。
+ * 边界与 plan 一致：只管模块声明的可重复 SQL 对象，不做表结构 migration。
+ */
+
+import { readCatalog, type DatabaseCatalog, type QueryExecutor } from './catalog.js';
+import type { ModulePlan, PlanStep } from './plan.js';
+import { splitQualifiedName } from './reconcile.js';
+
+export interface ApplyResult {
+  module: string;
+  /** 实际执行了 SQL 的 step 名 */
+  applied: string[];
+  /** ledger 哈希一致跳过的 */
+  skipped: string[];
+  /** 应用后在 catalog 中确认存在的对象 */
+  verified: string[];
+  failed?: { step: string; error: string };
+}
+
+const LEDGER_SCHEMA_SQL = 'create schema if not exists _supacloud';
+const LEDGER_TABLE_SQL = `create table if not exists _supacloud.db_object_ledger(
+  object_identity text primary key,
+  module text not null,
+  sha256 text not null,
+  applied_at timestamptz not null default now()
+)`;
+const LOCK_SQL = `select pg_advisory_lock(hashtext('supacloud-db-apply'))`;
+const UNLOCK_SQL = `select pg_advisory_unlock(hashtext('supacloud-db-apply'))`;
+const LEDGER_READ_SQL =
+  'select sha256 from _supacloud.db_object_ledger where object_identity = $1';
+const LEDGER_UPSERT_SQL = `insert into _supacloud.db_object_ledger (object_identity, module, sha256)
+values ($1, $2, $3)
+on conflict (object_identity) do update
+set module = excluded.module, sha256 = excluded.sha256, applied_at = now()`;
+
+/** 携带失败 step 名的内部错误，事务回滚后据此填充 ApplyResult.failed */
+class StepFailure extends Error {
+  constructor(
+    readonly step: string,
+    cause: unknown,
+  ) {
+    super(cause instanceof Error ? cause.message : String(cause));
+  }
+}
+
+function toFailure(error: unknown): { step: string; error: string } {
+  if (error instanceof StepFailure) return { step: error.step, error: error.message };
+  return { step: '(unknown)', error: error instanceof Error ? error.message : String(error) };
+}
+
+/**
+ * 在事务中执行 fn：executor 提供 transaction 时交给它管理 begin/commit/rollback，
+ * 否则在当前 executor 上顺序执行 begin/commit/rollback 语句。
+ * 失败时回滚并返回失败信息（不抛出）。
+ */
+async function runInTransaction(
+  executor: QueryExecutor,
+  fn: (tx: QueryExecutor) => Promise<void>,
+): Promise<{ step: string; error: string } | undefined> {
+  if (executor.transaction) {
+    try {
+      await executor.transaction(fn);
+      return undefined;
+    } catch (error) {
+      return toFailure(error);
+    }
+  }
+  await executor.query('begin');
+  try {
+    await fn(executor);
+  } catch (error) {
+    await executor.query('rollback');
+    return toFailure(error);
+  }
+  await executor.query('commit');
+  return undefined;
+}
+
+/** step 声明的对象在 catalog 中是否存在 */
+function existsInCatalog(step: PlanStep, catalog: DatabaseCatalog): boolean {
+  switch (step.kind) {
+    case 'function': {
+      const [schema, name] = splitQualifiedName(step.name);
+      return catalog.functions.some((f) => f.schema === schema && f.name === name);
+    }
+    case 'policy': {
+      const [schema, table, ...rest] = step.name.split('.');
+      const name = rest.join('.');
+      return catalog.policies.some(
+        (p) => p.schema === schema && p.table === table && p.name === name,
+      );
+    }
+    case 'trigger': {
+      const [schema, table, ...rest] = step.name.split('.');
+      const name = rest.join('.');
+      return catalog.triggers.some(
+        (t) => t.schema === schema && t.table === table && t.name === name,
+      );
+    }
+    case 'grant': {
+      const [object, privilege, role] = step.name.split(':');
+      const [schema, name] = splitQualifiedName(object);
+      return catalog.grants.some(
+        (g) =>
+          g.objectSchema === schema &&
+          g.objectName === name &&
+          g.privilege.toLowerCase() === privilege.toLowerCase() &&
+          g.grantee.toLowerCase() === role.toLowerCase(),
+      );
+    }
+  }
+}
+
+/** 从 step 名推导 catalog 验证需要覆盖的 schema 集合 */
+function planSchemas(plan: ModulePlan): string[] {
+  const schemas = new Set<string>();
+  for (const step of plan.steps) {
+    const target = step.kind === 'grant' ? step.name.split(':')[0] : step.name;
+    schemas.add(splitQualifiedName(target)[0]);
+  }
+  return schemas.size > 0 ? [...schemas].sort() : ['public'];
+}
+
+export async function applyModulePlan(
+  executor: QueryExecutor,
+  plan: ModulePlan,
+): Promise<ApplyResult> {
+  // error 级风险直接拒绝执行，不触碰数据库
+  const errorRisks = plan.steps.flatMap((step) =>
+    step.risk
+      .filter((risk) => risk.severity === 'error')
+      .map((risk) => `${step.name}: ${risk.code} ${risk.message}`),
+  );
+  if (errorRisks.length > 0) {
+    throw new Error(`plan 含 error 级风险，拒绝执行: ${errorRisks.join('; ')}`);
+  }
+
+  const result: ApplyResult = {
+    module: plan.module,
+    applied: [],
+    skipped: [],
+    verified: [],
+  };
+
+  // 确保账本表存在
+  await executor.query(LEDGER_SCHEMA_SQL);
+  await executor.query(LEDGER_TABLE_SQL);
+
+  await executor.query(LOCK_SQL);
+  try {
+    // 事务内先写入局部数组，提交成功后才算真正 applied/skipped（回滚则丢弃）
+    const applied: string[] = [];
+    const skipped: string[] = [];
+    const failed = await runInTransaction(executor, async (tx) => {
+      for (const step of plan.steps) {
+        const identity = `${step.kind}:${step.name}`;
+        const rows = await tx.query<{ sha256: string }>(LEDGER_READ_SQL, [identity]);
+        if (rows[0]?.sha256 === step.sha256) {
+          skipped.push(step.name);
+          continue;
+        }
+        try {
+          await tx.query(step.sql);
+          await tx.query(LEDGER_UPSERT_SQL, [identity, plan.module, step.sha256]);
+        } catch (error) {
+          throw new StepFailure(step.name, error);
+        }
+        applied.push(step.name);
+      }
+    });
+    if (failed) {
+      result.failed = failed;
+      return result;
+    }
+    result.applied = applied;
+    result.skipped = skipped;
+  } finally {
+    await executor.query(UNLOCK_SQL);
+  }
+
+  // 应用后读回 catalog，验证声明对象真实存在
+  const catalog = await readCatalog(executor, planSchemas(plan));
+  for (const step of plan.steps) {
+    if (existsInCatalog(step, catalog)) {
+      result.verified.push(step.name);
+    } else {
+      result.failed = {
+        step: step.name,
+        error: `应用后 catalog 中未找到 ${step.kind} ${step.name}`,
+      };
+      break;
+    }
+  }
+
+  return result;
+}

--- a/packages/db/src/catalog.test.ts
+++ b/packages/db/src/catalog.test.ts
@@ -77,6 +77,13 @@ const FULL_ROWS = [
     ],
   },
   {
+    match: 'pg_trigger',
+    rows: [
+      { schema: 'public', table: 'cases', name: 'cases_updated_at', enabled: true },
+      { schema: 'public', table: 'cases', name: 'cases_legacy_audit', enabled: false },
+    ],
+  },
+  {
     match: 'role_table_grants',
     rows: [
       {
@@ -93,7 +100,7 @@ describe('readCatalog', () => {
   test('默认 schema 过滤为 public 且参数化 $1', async () => {
     const { executor, calls } = mockExecutor([]);
     await readCatalog(executor);
-    expect(calls).toHaveLength(4);
+    expect(calls).toHaveLength(5);
     for (const call of calls) {
       expect(call.sql).toContain('$1');
       expect(call.params).toEqual([['public']]);
@@ -132,6 +139,25 @@ describe('readCatalog', () => {
     expect(catalog.functions[0].language).toBe('plpgsql');
     expect(catalog.functions[1].security).toBe('invoker');
     expect(catalog.functions[1].searchPath).toBeNull();
+  });
+
+  test('triggers 行映射 schema/table/name/enabled', async () => {
+    const { executor } = mockExecutor(FULL_ROWS);
+    const catalog = await readCatalog(executor);
+    expect(catalog.triggers).toEqual([
+      { schema: 'public', table: 'cases', name: 'cases_updated_at', enabled: true },
+      { schema: 'public', table: 'cases', name: 'cases_legacy_audit', enabled: false },
+    ]);
+  });
+
+  test('trigger 查询排除内部触发器并按 tgenabled 判定 enabled', async () => {
+    const { executor, calls } = mockExecutor([]);
+    await readCatalog(executor);
+    const triggerCall = calls.find((call) => call.sql.includes('pg_trigger'));
+    expect(triggerCall).toBeDefined();
+    expect(triggerCall?.sql).toContain('NOT t.tgisinternal');
+    expect(triggerCall?.sql).toContain("t.tgenabled <> 'D'");
+    expect(triggerCall?.params).toEqual([['public']]);
   });
 
   test('grants 行原样映射', async () => {

--- a/packages/db/src/catalog.ts
+++ b/packages/db/src/catalog.ts
@@ -7,6 +7,11 @@ import type { PolicyOperation } from './module.js';
 
 export interface QueryExecutor {
   query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<T[]>;
+  /**
+   * 可选事务封装：提供时 apply 用它包裹 begin/commit/rollback；
+   * 缺省时退化为在 executor 上顺序执行 begin/commit/rollback 语句（mock 友好）。
+   */
+  transaction?<T>(fn: (executor: QueryExecutor) => Promise<T>): Promise<T>;
 }
 
 export interface CatalogTable {
@@ -34,6 +39,14 @@ export interface CatalogFunction {
   language: string;
 }
 
+export interface CatalogTrigger {
+  schema: string;
+  table: string;
+  name: string;
+  /** tgenabled !== 'D'（未被 disable） */
+  enabled: boolean;
+}
+
 export interface CatalogGrant {
   objectSchema: string;
   objectName: string;
@@ -45,6 +58,7 @@ export interface DatabaseCatalog {
   tables: CatalogTable[];
   policies: CatalogPolicy[];
   functions: CatalogFunction[];
+  triggers: CatalogTrigger[];
   grants: CatalogGrant[];
 }
 
@@ -91,6 +105,19 @@ WHERE n.nspname = ANY($1)
 ORDER BY n.nspname, p.proname
 `;
 
+const TRIGGERS_SQL = `
+SELECT n.nspname AS schema,
+       c.relname AS table,
+       t.tgname AS name,
+       t.tgenabled <> 'D' AS enabled
+FROM pg_trigger t
+JOIN pg_class c ON c.oid = t.tgrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE NOT t.tgisinternal
+  AND n.nspname = ANY($1)
+ORDER BY n.nspname, c.relname, t.tgname
+`;
+
 const GRANTS_SQL = `
 SELECT table_schema AS object_schema,
        table_name AS object_name,
@@ -132,6 +159,13 @@ interface FunctionRow {
   language: string;
 }
 
+interface TriggerRow {
+  schema: string;
+  table: string;
+  name: string;
+  enabled: boolean;
+}
+
 interface GrantRow {
   object_schema: string;
   object_name: string;
@@ -161,10 +195,11 @@ export async function readCatalog(
   schemas: string[] = ['public'],
 ): Promise<DatabaseCatalog> {
   const params = [schemas];
-  const [tableRows, policyRows, functionRows, grantRows] = await Promise.all([
+  const [tableRows, policyRows, functionRows, triggerRows, grantRows] = await Promise.all([
     executor.query<TableRow>(TABLES_SQL, params),
     executor.query<PolicyRow>(POLICIES_SQL, params),
     executor.query<FunctionRow>(FUNCTIONS_SQL, params),
+    executor.query<TriggerRow>(TRIGGERS_SQL, params),
     executor.query<GrantRow>(GRANTS_SQL, params),
   ]);
 
@@ -190,6 +225,12 @@ export async function readCatalog(
       security: row.security_definer ? 'definer' : 'invoker',
       searchPath: extractSearchPath(row.config),
       language: row.language,
+    })),
+    triggers: triggerRows.map((row) => ({
+      schema: row.schema,
+      table: row.table,
+      name: row.name,
+      enabled: row.enabled,
     })),
     grants: grantRows.map((row) => ({
       objectSchema: row.object_schema,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -18,17 +18,23 @@ export {
   type CatalogGrant,
   type CatalogPolicy,
   type CatalogTable,
+  type CatalogTrigger,
   type DatabaseCatalog,
   type QueryExecutor,
 } from './catalog.js';
 
 export {
   reconcileModule,
+  splitQualifiedName,
   type ReconcileIssue,
   type ReconcileReport,
 } from './reconcile.js';
 
 export { lintModule, lintSql, type LintIssue } from './lint.js';
+
+export { planModule, type ModulePlan, type PlanStep } from './plan.js';
+
+export { applyModulePlan, type ApplyResult } from './apply.js';
 
 export {
   buildDatabaseManifest,

--- a/packages/db/src/lint.test.ts
+++ b/packages/db/src/lint.test.ts
@@ -53,12 +53,33 @@ describe('lintSql', () => {
     const issues = lintSql(sql, 'm.sql');
     expect(issues[0].line).toBe(3);
   });
+
+  test('non-idempotent-policy：create policy 前缺少 drop policy if exists', () => {
+    const issues = lintSql(
+      'create policy cases_select on public.cases for select to authenticated using (true);',
+      'p.sql',
+    );
+    expect(codes(issues)).toContain('non-idempotent-policy');
+    expect(issues[0].severity).toBe('warn');
+  });
+
+  test('non-idempotent-policy：先 drop policy if exists 则不命中', () => {
+    const sql =
+      'drop policy if exists cases_select on public.cases;\ncreate policy cases_select on public.cases for select to authenticated using (true);';
+    expect(codes(lintSql(sql, 'p.sql'))).not.toContain('non-idempotent-policy');
+  });
+
+  test('non-idempotent-policy：drop 在 create 之后仍然命中', () => {
+    const sql =
+      'create policy cases_select on public.cases for select to authenticated using (true);\ndrop policy if exists cases_select on public.cases;';
+    expect(codes(lintSql(sql, 'p.sql'))).toContain('non-idempotent-policy');
+  });
 });
 
 describe('lintModule', () => {
   const files: Record<string, string> = {
     'db/policies/cases_select.sql':
-      'alter table public.cases enable row level security;\ncreate policy cases_select on public.cases for select to authenticated using (true);',
+      'alter table public.cases enable row level security;\ndrop policy if exists cases_select on public.cases;\ncreate policy cases_select on public.cases for select to authenticated using (true);',
     'db/functions/case_create.sql':
       'create function public.case_create() returns int language sql security definer set search_path = public as $$ select 1 $$;',
   };

--- a/packages/db/src/lint.ts
+++ b/packages/db/src/lint.ts
@@ -17,6 +17,8 @@ const SET_SEARCH_PATH_RE = /\bset\s+search_path\b/i;
 const GRANT_TO_PUBLIC_RE = /\bgrant\b[^;]*\bto\s+public\b/i;
 const DROP_WITHOUT_IF_EXISTS_RE = /\bdrop\s+(?:table|column)\s+(?!if\s+exists\b)/i;
 const ENABLE_RLS_RE = /\benable\s+row\s+level\s+security\b/i;
+const CREATE_POLICY_RE = /\bcreate\s+policy\b/i;
+const DROP_POLICY_IF_EXISTS_RE = /\bdrop\s+policy\s+if\s+exists\b/i;
 
 function lineOf(sql: string, index: number): number {
   let line = 1;
@@ -60,6 +62,21 @@ export function lintSql(sql: string, file: string): LintIssue[] {
       file,
       line: lineOf(sql, drop.index),
     });
+  }
+
+  // PostgreSQL CREATE POLICY 不支持 IF NOT EXISTS，不先 drop 就不可重复执行
+  const createPolicy = CREATE_POLICY_RE.exec(sql);
+  if (createPolicy) {
+    const dropPolicy = DROP_POLICY_IF_EXISTS_RE.exec(sql);
+    if (!dropPolicy || dropPolicy.index > createPolicy.index) {
+      issues.push({
+        severity: 'warn',
+        code: 'non-idempotent-policy',
+        message: 'create policy 前缺少 drop policy if exists，策略不可重复执行',
+        file,
+        line: lineOf(sql, createPolicy.index),
+      });
+    }
   }
 
   return issues;

--- a/packages/db/src/plan.test.ts
+++ b/packages/db/src/plan.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+
+import { defineDatabaseModule } from './module.js';
+import { planModule } from './plan.js';
+
+export const planFiles: Record<string, string> = {
+  'db/functions/case_create.sql':
+    'create or replace function public.case_create() returns int language sql security definer set search_path = public as $$ select 1 $$;',
+  'db/policies/cases_select.sql':
+    'drop policy if exists cases_select on public.cases;\ncreate policy cases_select on public.cases for select to authenticated using (true);',
+  'db/triggers/cases_updated_at.sql':
+    'drop trigger if exists cases_updated_at on public.cases;\ncreate trigger cases_updated_at before update on public.cases for each row execute function public.set_updated_at();',
+  'db/grants/cases.sql': 'grant select on public.cases to authenticated;',
+};
+
+export function planReadFile(path: string): Promise<string> {
+  const content = planFiles[path];
+  if (content === undefined) return Promise.reject(new Error(`missing file: ${path}`));
+  return Promise.resolve(content);
+}
+
+/** 四种对象各一条，声明顺序故意打乱以验证 step 依赖序 */
+export function planTestModule() {
+  return defineDatabaseModule({
+    name: 'cases',
+    tables: ['public.cases'],
+    grants: [
+      {
+        object: 'public.cases',
+        privilege: 'SELECT',
+        role: 'authenticated',
+        source: 'db/grants/cases.sql',
+      },
+    ],
+    triggers: [
+      {
+        name: 'cases_updated_at',
+        table: 'public.cases',
+        source: 'db/triggers/cases_updated_at.sql',
+      },
+    ],
+    policies: [
+      {
+        name: 'cases_select',
+        table: 'public.cases',
+        operation: 'select',
+        roles: ['authenticated'],
+        source: 'db/policies/cases_select.sql',
+      },
+    ],
+    functions: [
+      {
+        name: 'public.case_create',
+        source: 'db/functions/case_create.sql',
+        security: 'definer',
+      },
+    ],
+  });
+}
+
+describe('planModule', () => {
+  test('step 依赖序为 function -> policy -> trigger -> grant', async () => {
+    const plan = await planModule(planTestModule(), planReadFile);
+    expect(plan.version).toBe(1);
+    expect(plan.module).toBe('cases');
+    expect(plan.steps.map((step) => step.kind)).toEqual([
+      'function',
+      'policy',
+      'trigger',
+      'grant',
+    ]);
+    expect(plan.steps.map((step) => step.name)).toEqual([
+      'public.case_create',
+      'public.cases.cases_select',
+      'public.cases.cases_updated_at',
+      'public.cases:SELECT:authenticated',
+    ]);
+  });
+
+  test('sha256 与 digest 对同一输入稳定', async () => {
+    const a = await planModule(planTestModule(), planReadFile);
+    const b = await planModule(planTestModule(), planReadFile);
+    expect(a.steps.map((step) => step.sha256)).toEqual(
+      b.steps.map((step) => step.sha256),
+    );
+    expect(a.digest).toBe(b.digest);
+    expect(a.digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('源文件内容变化时 sha256 与 digest 变化', async () => {
+    const a = await planModule(planTestModule(), planReadFile);
+    const b = await planModule(planTestModule(), (path) =>
+      Promise.resolve(path.endsWith('grants/cases.sql') ? 'grant insert on public.cases to authenticated;' : planFiles[path]),
+    );
+    expect(b.steps[3].sha256).not.toBe(a.steps[3].sha256);
+    expect(b.digest).not.toBe(a.digest);
+  });
+
+  test('error 级 lint 原样进入 step.risk', async () => {
+    const module = defineDatabaseModule({
+      name: 'bad',
+      functions: [
+        { name: 'public.f', source: 'f.sql', security: 'definer' },
+      ],
+    });
+    const plan = await planModule(module, () =>
+      Promise.resolve(
+        'create function public.f() returns int language sql security definer as $$ select 1 $$;',
+      ),
+    );
+    expect(plan.steps[0].risk).toEqual([
+      {
+        severity: 'error',
+        code: 'definer-no-search-path',
+        message: 'security definer 函数必须显式 set search_path，避免 search_path 劫持',
+      },
+    ]);
+  });
+
+  test('non-idempotent-policy：policy 源文件缺 drop policy if exists 时进 step.risk', async () => {
+    const module = defineDatabaseModule({
+      name: 'cases',
+      policies: [
+        {
+          name: 'cases_select',
+          table: 'public.cases',
+          operation: 'select',
+          roles: ['authenticated'],
+          source: 'p.sql',
+        },
+      ],
+    });
+    const plan = await planModule(module, () =>
+      Promise.resolve(
+        'create policy cases_select on public.cases for select to authenticated using (true);',
+      ),
+    );
+    expect(plan.steps[0].risk).toHaveLength(1);
+    expect(plan.steps[0].risk[0].severity).toBe('warn');
+    expect(plan.steps[0].risk[0].code).toBe('non-idempotent-policy');
+  });
+
+  test('干净模块的 step.risk 为空', async () => {
+    const plan = await planModule(planTestModule(), planReadFile);
+    for (const step of plan.steps) {
+      expect(step.risk).toEqual([]);
+    }
+  });
+});

--- a/packages/db/src/plan.ts
+++ b/packages/db/src/plan.ts
@@ -1,0 +1,93 @@
+/**
+ * Plan：把模块声明的可重复 SQL 对象（函数/策略/触发器/授权）编译为有序执行计划。
+ * 边界：只管可重复对象，不做表结构 migration —— 表结构仍走前向 migration。
+ */
+
+import { lintSql } from './lint.js';
+import type { DatabaseModule } from './module.js';
+
+export interface PlanStep {
+  kind: 'function' | 'policy' | 'trigger' | 'grant';
+  /** 对象标识：函数为 schema 限定名；策略/触发器为 table.name；授权为 object:privilege:role */
+  name: string;
+  /** 模块相对路径 */
+  source: string;
+  /** 源文件内容哈希 */
+  sha256: string;
+  sql: string;
+  risk: Array<{ severity: 'error' | 'warn'; code: string; message: string }>;
+}
+
+export interface ModulePlan {
+  version: 1;
+  module: string;
+  createdAt: string;
+  /** 依赖序：function -> policy -> trigger -> grant */
+  steps: PlanStep[];
+  /** 全部 step sha256 的组合哈希 */
+  digest: string;
+}
+
+/** WebCrypto SHA-256（Node/Bun 均可用的全局 crypto），输出小写 hex */
+async function sha256Hex(content: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(content));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function planModule(
+  module: DatabaseModule,
+  readFile: (path: string) => Promise<string>,
+): Promise<ModulePlan> {
+  // 同一源文件可能被多个声明引用，按路径缓存避免重复读取
+  const contents = new Map<string, string>();
+  const load = async (path: string): Promise<string> => {
+    const cached = contents.get(path);
+    if (cached !== undefined) return cached;
+    const sql = await readFile(path);
+    contents.set(path, sql);
+    return sql;
+  };
+
+  const steps: PlanStep[] = [];
+  const addStep = async (
+    kind: PlanStep['kind'],
+    name: string,
+    source: string,
+  ): Promise<void> => {
+    const sql = await load(source);
+    steps.push({
+      kind,
+      name,
+      source,
+      sha256: await sha256Hex(sql),
+      sql,
+      // 复用 lintSql 的静态分析结果作为 step 风险（error 级 lint 原样保留 severity=error）
+      risk: lintSql(sql, source).map(({ severity, code, message }) => ({
+        severity,
+        code,
+        message,
+      })),
+    });
+  };
+
+  for (const fn of module.functions) {
+    await addStep('function', fn.name, fn.source);
+  }
+  for (const policy of module.policies) {
+    await addStep('policy', `${policy.table}.${policy.name}`, policy.source);
+  }
+  for (const trigger of module.triggers) {
+    await addStep('trigger', `${trigger.table}.${trigger.name}`, trigger.source);
+  }
+  for (const grant of module.grants) {
+    await addStep('grant', `${grant.object}:${grant.privilege}:${grant.role}`, grant.source);
+  }
+
+  return {
+    version: 1,
+    module: module.name,
+    createdAt: new Date().toISOString(),
+    steps,
+    digest: await sha256Hex(steps.map((step) => step.sha256).join('\n')),
+  };
+}

--- a/packages/db/src/reconcile.test.ts
+++ b/packages/db/src/reconcile.test.ts
@@ -25,6 +25,13 @@ const baseModule = defineDatabaseModule({
       permission: 'case.create',
     },
   ],
+  triggers: [
+    {
+      name: 'cases_updated_at',
+      table: 'public.cases',
+      source: 'db/triggers/cases_updated_at.sql',
+    },
+  ],
   grants: [
     {
       object: 'public.cases',
@@ -57,6 +64,9 @@ const baseCatalog: DatabaseCatalog = {
       searchPath: 'public',
       language: 'plpgsql',
     },
+  ],
+  triggers: [
+    { schema: 'public', table: 'cases', name: 'cases_updated_at', enabled: true },
   ],
   grants: [
     {
@@ -181,5 +191,40 @@ describe('reconcileModule', () => {
     const report = reconcileModule(baseModule, catalog);
     expect(codes(report)).toContain('grant-drift');
     expect(report.ok).toBe(true);
+  });
+
+  test('missing-trigger：声明的触发器在 catalog 中不存在', () => {
+    const catalog = cloneCatalog();
+    catalog.triggers = [];
+    const report = reconcileModule(baseModule, catalog);
+    expect(report.ok).toBe(false);
+    expect(codes(report)).toContain('missing-trigger');
+  });
+
+  test('undeclared-trigger：归属表上的额外触发器告警（含已禁用），非归属表不告警', () => {
+    const catalog = cloneCatalog();
+    catalog.triggers.push(
+      { schema: 'public', table: 'cases', name: 'cases_extra', enabled: true },
+      { schema: 'public', table: 'cases', name: 'cases_disabled', enabled: false },
+      { schema: 'public', table: 'other_table', name: 'other_trigger', enabled: true },
+    );
+    const report = reconcileModule(baseModule, catalog);
+    const undeclared = report.issues.filter((i) => i.code === 'undeclared-trigger');
+    expect(undeclared).toHaveLength(2);
+    expect(undeclared.every((i) => i.severity === 'warn')).toBe(true);
+    expect(undeclared.map((i) => i.object)).toEqual([
+      'public.cases.cases_extra',
+      'public.cases.cases_disabled',
+    ]);
+    expect(undeclared[1].message).toContain('已禁用');
+    expect(report.ok).toBe(true);
+  });
+
+  test('已声明的禁用触发器不报 undeclared-trigger', () => {
+    const catalog = cloneCatalog();
+    catalog.triggers[0].enabled = false;
+    const report = reconcileModule(baseModule, catalog);
+    expect(codes(report)).not.toContain('undeclared-trigger');
+    expect(codes(report)).not.toContain('missing-trigger');
   });
 });

--- a/packages/db/src/reconcile.ts
+++ b/packages/db/src/reconcile.ts
@@ -21,7 +21,7 @@ export interface ReconcileReport {
 }
 
 /** 'public.cases' → ['public', 'cases']；无 schema 前缀时默认 public */
-function splitQualifiedName(name: string): [string, string] {
+export function splitQualifiedName(name: string): [string, string] {
   const dot = name.indexOf('.');
   if (dot === -1) return ['public', name];
   return [name.slice(0, dot), name.slice(dot + 1)];
@@ -109,6 +109,37 @@ export function reconcileModule(
         'definer-without-search-path',
         fn.name,
         `security definer 函数 ${fn.name} 未设置固定 search_path（当前: ${cf.searchPath ?? '未设置'}）`,
+      );
+    }
+  }
+
+  // missing-trigger：声明的触发器在 catalog 中不存在（按 schema.table + name 匹配）
+  for (const trigger of module.triggers) {
+    const [schema, table] = splitQualifiedName(trigger.table);
+    const found = catalog.triggers.some(
+      (ct) => ct.schema === schema && ct.table === table && ct.name === trigger.name,
+    );
+    if (!found) {
+      push(
+        'error',
+        'missing-trigger',
+        `${trigger.table}.${trigger.name}`,
+        `声明的触发器 ${trigger.name} 在表 ${trigger.table} 的 catalog 中不存在`,
+      );
+    }
+  }
+
+  // undeclared-trigger：归属表上 catalog 有但 manifest 未声明的触发器（含已禁用的，
+  // 禁用的触发器同样属于漂移，需要显式声明或清理）
+  const declaredTriggerKeys = new Set(module.triggers.map((t) => `${t.table}::${t.name}`));
+  for (const ct of catalog.triggers) {
+    const qualified = `${ct.schema}.${ct.table}`;
+    if (ownedTables.has(qualified) && !declaredTriggerKeys.has(`${qualified}::${ct.name}`)) {
+      push(
+        'warn',
+        'undeclared-trigger',
+        `${qualified}.${ct.name}`,
+        `归属表 ${qualified} 上存在未声明的触发器 ${ct.name}${ct.enabled ? '' : '（已禁用）'}，可能发生漂移`,
       );
     }
   }


### PR DESCRIPTION
## 概要

`@supacloud/db` 治理闭环的写路径：trigger 对账 + 事务化 plan/apply 执行器（此前只有只读 check/lint/reconcile）。

### Trigger 对账

- Catalog 读取 pg_trigger（排除约束内部 trigger，保留禁用状态）
- 新诊断：error `missing-trigger`、warn `undeclared-trigger`（归属表上的未声明漂移）

### planModule()

- 依赖序 step（function → policy → trigger → grant），每步带源文件 sha256、聚合 lint 风险、整体 plan digest
- 新 lint warn `non-idempotent-policy`（`create policy` 前无 `drop policy if exists`，PG 无 IF NOT EXISTS，否则不可重复执行）

### applyModulePlan()

- error 级风险直接拒绝执行
- `_supacloud.db_object_ledger` 账本记录每对象 checksum，重复执行幂等跳过
- `pg_advisory_lock` + 单事务：任一 step 失败整体 ROLLBACK，账本无残留
- 应用后 readCatalog 回读验证对象存在
- 保持 driver 无关（QueryExecutor，可选托管事务）

**边界**：执行器只管可重复 SQL 对象（策略/函数/触发器/授权）；表结构仍走前向 migration。

## 验证

- 60 pass / 0 fail（原 41 + 新 19），全 mock 无真实数据库
- 覆盖：幂等跳过、失败回滚、error 风险拒绝、锁成对、托管事务路径
- typecheck / build 全绿