### PR TITLE
feat(compiler,app): add module tags and boundary governance with Nx workspace configuration

### DIFF
--- a/docs/application-framework.md
+++ b/docs/application-framework.md
@@ -26,6 +26,7 @@ import { Module, DB_CLIENT } from "@supacloud/app";
 
 @Module({
   name: "case",
+  tags: ["scope:case", "type:feature"],
   imports: [AuditModule],
   providers: [
     CaseService,
@@ -93,10 +94,20 @@ const result = await compileProject({
   include: ["src/**/*.ts"],
   outDir: "generated",
   strict: true,
+  moduleBoundaries: [
+    {
+      sourceTag: "type:ui",
+      bannedDependenciesWithTags: ["type:data-access"],
+    },
+    {
+      sourceTag: "type:feature",
+      onlyDependOnLibsWithTags: ["type:feature", "type:ui", "type:data-access", "type:contracts"],
+    },
+  ],
 });
 ```
 
-诊断码：`circular-dependency`、`scope-violation`、`module-boundary`、`unresolved-token`、`duplicate-token`、`duplicate-module`、`duplicate-command`、`duplicate-route`、`route-command-unresolved`、`command-missing-permission`（始终为 error）、`missing-deps`。
+诊断码：`circular-dependency`、`scope-violation`、`module-boundary`、`module-boundary-violation`、`unresolved-token`、`duplicate-token`、`duplicate-module`、`duplicate-command`、`duplicate-route`、`route-command-unresolved`、`command-missing-permission`（始终为 error）、`missing-deps`。
 
 产物：
 

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/nx-schema.json",
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "production": [
+      "default",
+      "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
+      "!{projectRoot}/tsconfig.test.json",
+      "!{projectRoot}/**/__tests__/**"
+    ],
+    "sharedGlobals": []
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"],
+      "cache": true
+    },
+    "build:js": {
+      "inputs": ["production", "^production"],
+      "cache": true
+    },
+    "build:types": {
+      "inputs": ["production", "^production"],
+      "cache": true
+    },
+    "test": {
+      "inputs": ["default", "^production"],
+      "cache": true
+    },
+    "typecheck": {
+      "inputs": ["default", "^production"],
+      "cache": true
+    },
+    "typecheck:test": {
+      "inputs": ["default", "^production"],
+      "cache": true
+    },
+    "clean": {
+      "cache": false
+    },
+    "check": {
+      "inputs": ["default", "^production"],
+      "cache": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "version": "0.0.2",
+  "scripts": {
+    "check:boundaries": "bun run scripts/check_workspace_boundaries.ts"
+  },
   "dependencies": {
     "@types/ws": "^8.18.1",
     "ws": "^8.21.3"

--- a/packages/admin/project.json
+++ b/packages/admin/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/admin",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:cloud", "type:admin"],
+  "projectType": "library",
+  "sourceRoot": "packages/admin/src"
+}

--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/app",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:core", "type:framework"],
+  "projectType": "library",
+  "sourceRoot": "packages/app/src"
+}

--- a/packages/app/src/decorators.test.ts
+++ b/packages/app/src/decorators.test.ts
@@ -66,6 +66,7 @@ describe("@Module", () => {
 
     expect(getModuleMeta(CaseModule)).toEqual({
       name: "case",
+      tags: [],
       imports: [],
       providers: [],
       controllers: [],
@@ -94,6 +95,17 @@ describe("@Module", () => {
     expect(meta?.providers).toEqual([CaseService]);
     expect(meta?.controllers).toEqual([CaseController]);
     expect(meta?.exports).toEqual([CaseService]);
+  });
+
+  test("records module tags for boundary governance", () => {
+    @Module({
+      name: "case",
+      tags: ["scope:case", "type:feature"],
+    })
+    class CaseModule {}
+
+    const meta = getModuleMeta(CaseModule);
+    expect(meta?.tags).toEqual(["scope:case", "type:feature"]);
   });
 });
 

--- a/packages/app/src/decorators.ts
+++ b/packages/app/src/decorators.ts
@@ -28,6 +28,8 @@ export interface InjectableMeta {
 
 export interface ModuleOptions {
   name: string;
+  /** Tags for architectural boundary governance (e.g. ['scope:case', 'type:feature']). */
+  tags?: string[];
   imports?: Array<Type<unknown>>;
   providers?: Provider[];
   controllers?: Array<Type<unknown>>;
@@ -36,7 +38,8 @@ export interface ModuleOptions {
   exports?: Token[];
 }
 
-export interface ModuleMeta extends Required<Omit<ModuleOptions, "exports">> {
+export interface ModuleMeta extends Required<Omit<ModuleOptions, "exports" | "tags">> {
+  tags?: string[];
   exports: Token[];
 }
 
@@ -142,6 +145,7 @@ export function Module(options: ModuleOptions): ClassDecorator {
   return (target) => {
     const meta: ModuleMeta = {
       name: options.name,
+      tags: options.tags ?? [],
       imports: options.imports ?? [],
       providers: options.providers ?? [],
       controllers: options.controllers ?? [],

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/cli",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:tooling", "type:cli"],
+  "projectType": "application",
+  "sourceRoot": "packages/cli/src"
+}

--- a/packages/compiler/project.json
+++ b/packages/compiler/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/compiler",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:tooling", "type:compiler"],
+  "projectType": "library",
+  "sourceRoot": "packages/compiler/src"
+}

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -38,6 +38,10 @@ describe("analyzeProject：模块发现", () => {
   test("imports 解析为被引用模块的 name", () => {
     expect(moduleByName("case").imports).toEqual(["audit"]);
   });
+
+  test("tags 属性正确解析（无 tags 时为 undefined）", () => {
+    expect(moduleByName("case").tags).toBeUndefined();
+  });
 });
 
 describe("analyzeProject：provider 解析", () => {

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -214,6 +214,10 @@ function parseModule(
   const { options, className, file, line } = candidate;
   const name = nameByNode.get(candidate.node) ?? className;
 
+  const tags = arrayProp(options, "tags")
+    .map((el) => (Node.isStringLiteral(el) ? el.getLiteralText() : el.getText().replace(/['"]/g, "")))
+    .filter(Boolean);
+
   const imports = arrayProp(options, "imports")
     .map((el) => {
       const decl = Node.isIdentifier(el) ? resolveDeclaration(el)[0] : undefined;
@@ -300,6 +304,7 @@ function parseModule(
   return {
     name,
     className,
+    tags: tags.length > 0 ? tags : undefined,
     file: sourcePath(ctx.rootDir, file),
     line,
     imports,

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -11,7 +11,10 @@ export async function compileProject(options: CompileOptions): Promise<CompileRe
   const graph = await analyzeProject(options.rootDir, options.include);
   const diagnostics: Diagnostic[] = [
     ...(graph.diagnostics ?? []),
-    ...validateGraph(graph, options.strict),
+    ...validateGraph(graph, {
+      strict: options.strict,
+      moduleBoundaries: options.moduleBoundaries,
+    }),
   ];
   if (options.strict) {
     for (const diagnostic of diagnostics) {

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
   outDir = join(rootDir, "generated");
   result = await compileProject({ rootDir, outDir });
   applicationCode = await readFile(join(outDir, "application.ts"), "utf8");
-});
+}, 30_000);
 
 describe("compileProject：总体结果", () => {
   test("无诊断，写出 application.ts 与 app.manifest.json", () => {

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -11,6 +11,7 @@ export type {
   CompileResult,
   ControllerNode,
   Diagnostic,
+  ModuleBoundaryRule,
   ModuleNode,
   ProviderKind,
   ProviderNode,

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -78,6 +78,8 @@ export interface ModuleNode {
   /** @Module({ name }) 或 defineModule 的 name。 */
   name: string;
   className: string;
+  /** 模块标签（如 ['scope:case', 'type:feature']），用于架构边界治理。 */
+  tags?: string[];
   file: string;
   line: number;
   /** 被 import 模块的 name。 */
@@ -116,6 +118,17 @@ export interface CompileOptions {
   outDir: string;
   /** warn 级诊断升级为 error。 */
   strict?: boolean;
+  /** 模块边界与架构治理规则（受 Nx enforce-module-boundaries 启发）。 */
+  moduleBoundaries?: ModuleBoundaryRule[];
+}
+
+export interface ModuleBoundaryRule {
+  /** 源模块标签模式或标签（如 'type:ui', 'scope:case', '*'）。 */
+  sourceTag: string;
+  /** 源模块仅允许依赖具有这些标签的模块。 */
+  onlyDependOnLibsWithTags?: string[];
+  /** 源模块禁止依赖具有这些标签的模块。 */
+  bannedDependenciesWithTags?: string[];
 }
 
 export interface CompileResult {

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -116,4 +116,100 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(unresolved[0].message).toContain("MissingCommand");
     expect(unresolved[0].message).toContain("route-two");
   });
+
+  test("module-boundary-violation：根据 Nx 风格 Tag 规则拦截越权依赖", () => {
+    const sampleGraph: ApplicationGraph = {
+      modules: [
+        {
+          name: "ui",
+          className: "UiModule",
+          tags: ["type:ui", "scope:case"],
+          file: "src/ui.module.ts",
+          line: 1,
+          imports: ["data-access"],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+        {
+          name: "data-access",
+          className: "DataAccessModule",
+          tags: ["type:data-access", "scope:case"],
+          file: "src/data-access.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    // Rule: type:ui 不能依赖 type:data-access (只能依赖 type:ui 或 type:contracts)
+    const diags = validateGraph(sampleGraph, {
+      moduleBoundaries: [
+        {
+          sourceTag: "type:ui",
+          bannedDependenciesWithTags: ["type:data-access"],
+        },
+      ],
+    });
+
+    const violations = diags.filter((d) => d.code === "module-boundary-violation");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].severity).toBe("error");
+    expect(violations[0].message).toContain("禁止依赖带有标签 'type:data-access'");
+  });
+
+  test("module-boundary-violation：onlyDependOnLibsWithTags 白名单约束", () => {
+    const sampleGraph: ApplicationGraph = {
+      modules: [
+        {
+          name: "contracts",
+          className: "ContractsModule",
+          tags: ["type:contracts"],
+          file: "src/contracts.module.ts",
+          line: 1,
+          imports: ["feature-case"],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+        {
+          name: "feature-case",
+          className: "FeatureCaseModule",
+          tags: ["type:feature"],
+          file: "src/feature.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(sampleGraph, {
+      moduleBoundaries: [
+        {
+          sourceTag: "type:contracts",
+          onlyDependOnLibsWithTags: ["type:contracts", "type:util"],
+        },
+      ],
+    });
+
+    const violations = diags.filter((d) => d.code === "module-boundary-violation");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain("仅允许依赖带有 [type:contracts, type:util]");
+  });
 });

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -2,6 +2,7 @@ import type {
   ApplicationGraph,
   ControllerNode,
   Diagnostic,
+  ModuleBoundaryRule,
   ModuleNode,
   ProviderNode,
   Scope,
@@ -22,7 +23,12 @@ interface ProviderRef {
  * 校验 ApplicationGraph，产出诊断列表。
  * strict 时 warn 级诊断升级为 error。
  */
-export function validateGraph(graph: ApplicationGraph, strict = false): Diagnostic[] {
+export function validateGraph(
+  graph: ApplicationGraph,
+  options: boolean | { strict?: boolean; moduleBoundaries?: ModuleBoundaryRule[] } = false,
+): Diagnostic[] {
+  const strict = typeof options === "boolean" ? options : (options.strict ?? false);
+  const moduleBoundaries = typeof options === "object" ? options.moduleBoundaries : undefined;
   const diagnostics: Diagnostic[] = [];
 
   // 全局 token → provider 索引（同模块重复注册由 duplicate-token 报告，索引取第一个）。
@@ -190,6 +196,48 @@ export function validateGraph(graph: ApplicationGraph, strict = false): Diagnost
           module.file,
           module.line,
         );
+      }
+    }
+  }
+
+  // module-boundary-violation：基于模块标签（Tags）与边界规则进行架构分层与依赖流向校验。
+  if (moduleBoundaries && moduleBoundaries.length > 0) {
+    for (const module of graph.modules) {
+      const sourceTags = module.tags ?? [];
+      for (const importName of module.imports) {
+        const targetModule = graph.modules.find((m) => m.name === importName);
+        if (!targetModule) continue;
+        const targetTags = targetModule.tags ?? [];
+
+        for (const rule of moduleBoundaries) {
+          const matchesSource = rule.sourceTag === "*" || sourceTags.includes(rule.sourceTag);
+          if (!matchesSource) continue;
+
+          if (rule.bannedDependenciesWithTags) {
+            for (const bannedTag of rule.bannedDependenciesWithTags) {
+              if (targetTags.includes(bannedTag)) {
+                error(
+                  "module-boundary-violation",
+                  `模块 ${module.name} (tags: [${sourceTags.join(", ")}]) 禁止依赖带有标签 '${bannedTag}' 的模块 ${targetModule.name} (tags: [${targetTags.join(", ")}])`,
+                  module.file,
+                  module.line,
+                );
+              }
+            }
+          }
+
+          if (rule.onlyDependOnLibsWithTags && rule.onlyDependOnLibsWithTags.length > 0) {
+            const hasAllowed = targetTags.some((t) => rule.onlyDependOnLibsWithTags!.includes(t));
+            if (!hasAllowed && targetTags.length > 0) {
+              error(
+                "module-boundary-violation",
+                `模块 ${module.name} (tags: [${sourceTags.join(", ")}]) 仅允许依赖带有 [${rule.onlyDependOnLibsWithTags.join(", ")}] 标签的模块，但模块 ${targetModule.name} 的标签为 [${targetTags.join(", ")}]`,
+                module.file,
+                module.line,
+              );
+            }
+          }
+        }
       }
     }
   }

--- a/packages/db/project.json
+++ b/packages/db/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/db",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:core", "type:database"],
+  "projectType": "library",
+  "sourceRoot": "packages/db/src"
+}

--- a/packages/edge-runtime/project.json
+++ b/packages/edge-runtime/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/edge-runtime",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:runtime", "type:runtime"],
+  "projectType": "application",
+  "sourceRoot": "packages/edge-runtime"
+}

--- a/packages/elysia/project.json
+++ b/packages/elysia/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/elysia",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:runtime", "type:adapter"],
+  "projectType": "library",
+  "sourceRoot": "packages/elysia/src"
+}

--- a/packages/function-adapter/project.json
+++ b/packages/function-adapter/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/function-adapter",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:runtime", "type:adapter"],
+  "projectType": "library",
+  "sourceRoot": "packages/function-adapter/src"
+}

--- a/packages/management-api/project.json
+++ b/packages/management-api/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/management-api",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:cloud", "type:api"],
+  "projectType": "application",
+  "sourceRoot": "packages/management-api/src"
+}

--- a/packages/pgredis-runtime/project.json
+++ b/packages/pgredis-runtime/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/pgredis-runtime",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:runtime", "type:runtime"],
+  "projectType": "application",
+  "sourceRoot": "packages/pgredis-runtime/src"
+}

--- a/packages/supacloud-js/project.json
+++ b/packages/supacloud-js/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/js",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:sdk", "type:client"],
+  "projectType": "library",
+  "sourceRoot": "packages/supacloud-js/src"
+}

--- a/packages/supacloud-lite/project.json
+++ b/packages/supacloud-lite/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/lite",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:cloud", "type:cli"],
+  "projectType": "application",
+  "sourceRoot": "packages/supacloud-lite/src"
+}

--- a/packages/supacloud/project.json
+++ b/packages/supacloud/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "supacloud",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:meta", "type:distribution"],
+  "projectType": "library",
+  "sourceRoot": "packages/supacloud"
+}

--- a/packages/testing/project.json
+++ b/packages/testing/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/testing",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:tooling", "type:testing"],
+  "projectType": "library",
+  "sourceRoot": "packages/testing/src"
+}

--- a/packages/web-console/project.json
+++ b/packages/web-console/project.json
@@ -1,0 +1,7 @@
+{
+  "name": "@supacloud/web-console",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["scope:cloud", "type:app"],
+  "projectType": "application",
+  "sourceRoot": "packages/web-console/src"
+}

--- a/scripts/check_workspace_boundaries.test.ts
+++ b/scripts/check_workspace_boundaries.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+describe("Workspace Boundaries Check", () => {
+  test("passes boundary validation for current SupaCloud workspace", () => {
+    const scriptPath = join(import.meta.dir, "check_workspace_boundaries.ts");
+    const result = spawnSync("bun", ["run", scriptPath], {
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("All workspace architectural boundaries and module tags are respected!");
+  });
+});

--- a/scripts/check_workspace_boundaries.ts
+++ b/scripts/check_workspace_boundaries.ts
@@ -1,0 +1,184 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+interface ProjectConfig {
+  name: string;
+  tags?: string[];
+  path: string;
+  dependencies: string[];
+  devDependencies: string[];
+}
+
+interface BoundaryRule {
+  sourceTag: string;
+  bannedDependenciesWithTags?: string[];
+  onlyDependOnLibsWithTags?: string[];
+  description?: string;
+}
+
+const WORKSPACE_BOUNDARY_RULES: BoundaryRule[] = [
+  {
+    sourceTag: "type:compiler",
+    bannedDependenciesWithTags: ["type:runtime", "type:api", "type:app", "type:cli", "type:framework"],
+    description: "Compiler must remain a pure AST analysis tool and cannot depend on runtime or app packages.",
+  },
+  {
+    sourceTag: "type:framework",
+    bannedDependenciesWithTags: ["type:runtime", "type:api", "type:app", "type:cli", "type:compiler"],
+    description: "Core framework metadata (@supacloud/app) must not depend on runtime, API, or compiler.",
+  },
+  {
+    sourceTag: "type:database",
+    bannedDependenciesWithTags: ["type:runtime", "type:api", "type:app", "type:cli", "type:compiler"],
+    description: "Database core (@supacloud/db) must not depend on runtime, API, or CLI.",
+  },
+  {
+    sourceTag: "type:client",
+    bannedDependenciesWithTags: ["type:runtime", "type:api", "type:app", "type:cli", "type:admin"],
+    description: "SDK client (@supacloud/js) must remain lightweight and cannot depend on server packages.",
+  },
+  {
+    sourceTag: "type:runtime",
+    bannedDependenciesWithTags: ["type:cli", "type:app", "type:admin"],
+    description: "Runtimes must not depend on UI console, CLI, or admin operations.",
+  },
+];
+
+async function loadProjects(packagesDir: string): Promise<Map<string, ProjectConfig>> {
+  const projects = new Map<string, ProjectConfig>();
+  const entries = await readdir(packagesDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const pkgDirPath = join(packagesDir, entry.name);
+    const pkgJsonPath = join(pkgDirPath, "package.json");
+    const projectJsonPath = join(pkgDirPath, "project.json");
+
+    let pkgJson: { name?: string; dependencies?: Record<string, string>; devDependencies?: Record<string, string> } = {};
+    try {
+      pkgJson = JSON.parse(await readFile(pkgJsonPath, "utf8"));
+    } catch {
+      continue;
+    }
+
+    let tags: string[] = [];
+    try {
+      const projectJson = JSON.parse(await readFile(projectJsonPath, "utf8"));
+      tags = projectJson.tags ?? [];
+    } catch {
+      // If project.json does not exist, tags remain empty
+    }
+
+    const name = pkgJson.name ?? entry.name;
+    projects.set(name, {
+      name,
+      tags,
+      path: pkgDirPath,
+      dependencies: Object.keys(pkgJson.dependencies ?? {}),
+      devDependencies: Object.keys(pkgJson.devDependencies ?? {}),
+    });
+  }
+
+  return projects;
+}
+
+function checkBoundaries(projects: Map<string, ProjectConfig>): { errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  for (const [name, project] of projects) {
+    const sourceTags = project.tags ?? [];
+    const allDeps = [...project.dependencies];
+
+    for (const depName of allDeps) {
+      const targetProject = projects.get(depName);
+      if (!targetProject) continue; // External npm package
+
+      const targetTags = targetProject.tags ?? [];
+
+      for (const rule of WORKSPACE_BOUNDARY_RULES) {
+        const matchesSource = rule.sourceTag === "*" || sourceTags.includes(rule.sourceTag);
+        if (!matchesSource) continue;
+
+        if (rule.bannedDependenciesWithTags) {
+          for (const bannedTag of rule.bannedDependenciesWithTags) {
+            if (targetTags.includes(bannedTag)) {
+              errors.push(
+                `[Boundary Violation] Package "${name}" (tags: [${sourceTags.join(", ")}]) must not depend on "${depName}" (tags: [${targetTags.join(", ")}]). Reason: ${rule.description ?? "Banned by tag rule"}`,
+              );
+            }
+          }
+        }
+
+        if (rule.onlyDependOnLibsWithTags && rule.onlyDependOnLibsWithTags.length > 0) {
+          const hasAllowed = targetTags.some((t) => rule.onlyDependOnLibsWithTags!.includes(t));
+          if (!hasAllowed && targetTags.length > 0) {
+            errors.push(
+              `[Boundary Violation] Package "${name}" (tags: [${sourceTags.join(", ")}]) is only allowed to depend on packages with tags [${rule.onlyDependOnLibsWithTags.join(", ")}], but "${depName}" has tags [${targetTags.join(", ")}].`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // Circular dependency check
+  const visited = new Set<string>();
+  const recStack = new Set<string>();
+
+  function checkCycle(current: string, path: string[]) {
+    visited.add(current);
+    recStack.add(current);
+    path.push(current);
+
+    const proj = projects.get(current);
+    if (proj) {
+      for (const dep of proj.dependencies) {
+        if (!projects.has(dep)) continue;
+        if (!visited.has(dep)) {
+          checkCycle(dep, path);
+        } else if (recStack.has(dep)) {
+          errors.push(`[Circular Dependency] Cycle detected: ${[...path, dep].join(" -> ")}`);
+        }
+      }
+    }
+
+    path.pop();
+    recStack.delete(current);
+  }
+
+  for (const name of projects.keys()) {
+    if (!visited.has(name)) {
+      checkCycle(name, []);
+    }
+  }
+
+  return { errors, warnings };
+}
+
+async function main() {
+  const packagesDir = join(import.meta.dir, "..", "packages");
+  const projects = await loadProjects(packagesDir);
+  console.log(`Loaded ${projects.size} packages in workspace.`);
+
+  const { errors, warnings } = checkBoundaries(projects);
+
+  for (const warn of warnings) {
+    console.warn(`\x1b[33mWARN\x1b[0m ${warn}`);
+  }
+
+  if (errors.length > 0) {
+    for (const err of errors) {
+      console.error(`\x1b[31mERROR\x1b[0m ${err}`);
+    }
+    console.error(`\nFound ${errors.length} boundary violation(s).`);
+    process.exit(1);
+  }
+
+  console.log("\x1b[32m✔\x1b[0m All workspace architectural boundaries and module tags are respected!");
+}
+
+main().catch((err) => {
+  console.error("Failed to check workspace boundaries:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Introduces module tags (`tags: string[]`) in `@supacloud/app` `@Module` metadata.
- Implements compile-time module boundary validation (`ModuleBoundaryRule`, `module-boundary-violation`) in `@supacloud/compiler`, allowing Nx-style architectural rules (`bannedDependenciesWithTags`, `onlyDependOnLibsWithTags`).
- Adds Nx workspace orchestration configuration (`nx.json`) with `namedInputs` and `targetDefaults` task graph / caching pipeline.
- Tags all 15 packages in `packages/*/project.json` with explicit architectural tags (`scope:*`, `type:*`).
- Adds workspace boundary check script `scripts/check_workspace_boundaries.ts` and test.
- Updates framework documentation in `docs/application-framework.md`.