### PR TITLE
fix(upgrade): harden embedded edge source recovery

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1473,7 +1473,7 @@ supacloud_select_binary_source() {
     shift
     local candidate
     supacloud_resolve_artifact_policy || return 1
-    if [[ "$SUPACLOUD_RESOLVED_ARTIFACT_MODE" == "release" ]]; then
+    if [[ "${SUPACLOUD_RESOLVED_ARTIFACT_MODE:-}" == "release" ]]; then
         candidate="${SCRIPT_DIR}/dist/${asset_name}"
         [[ -f "$candidate" ]] && supacloud_validate_binary "$candidate" "$asset_name" || {
             log_error "Release artifact policy requires a valid dist/${asset_name}"
@@ -1605,7 +1605,7 @@ ensure_edge_runtime_user() {
 
 configure_edge_runtime_source_access() {
     local source_dir="$1"
-    chmod -R g-w,g+rX "$source_dir" || {
+    chmod -R go-w,g+rX "$source_dir" || {
         log_error "Failed to grant Edge Runtime source access"
         return 1
     }
@@ -3047,12 +3047,109 @@ management_edge_runtime_source_transaction() {
     local management_transaction_dir="$1"
     local marker="${management_transaction_dir}/${EDGE_RUNTIME_SOURCE_TRANSACTION_MARKER}"
     local transaction_dir target_parent
-    [[ -f "$marker" && ! -L "$marker" ]] || return 1
-    transaction_dir=$(<"$marker")
     target_parent=$(dirname "$EDGE_RUNTIME_SOURCE_DIR")
-    [[ "$transaction_dir" == "$target_parent"/.edge-runtime-source.* ]] || return 1
-    [[ -d "$transaction_dir" && ! -L "$transaction_dir" ]] || return 1
+    transaction_dir=$(python3 - "$marker" "$target_parent" <<'PY'
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+marker = Path(sys.argv[1])
+target_parent = Path(sys.argv[2])
+metadata = marker.lstat()
+if not stat.S_ISREG(metadata.st_mode) or marker.is_symlink() \
+        or metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid() \
+        or stat.S_IMODE(metadata.st_mode) != 0o600 or metadata.st_nlink != 1:
+    raise SystemExit("Edge Runtime source transaction marker is unsafe")
+value = marker.read_text()
+if not value.endswith("\n") or value.count("\n") != 1 or not value[:-1].startswith("/"):
+    raise SystemExit("Edge Runtime source transaction marker is invalid")
+transaction_value = value[:-1]
+transaction = Path(transaction_value)
+if str(transaction) != transaction_value or transaction.parent != target_parent \
+        or not re.fullmatch(r"\.edge-runtime-source\.[A-Za-z0-9]+", transaction.name):
+    raise SystemExit("Edge Runtime source transaction marker path is outside the target parent")
+print(transaction_value, end="")
+PY
+    ) || return 1
+    if [[ -d "$transaction_dir" && ! -L "$transaction_dir" ]]; then
+        [[ ! -e "${transaction_dir}.cleanup" && ! -L "${transaction_dir}.cleanup" ]] || return 1
+    elif [[ -d "${transaction_dir}.cleanup" && ! -L "${transaction_dir}.cleanup" ]]; then
+        [[ ! -e "$transaction_dir" && ! -L "$transaction_dir" ]] || return 1
+    elif [[ -f "${transaction_dir}.outcome" && ! -L "${transaction_dir}.outcome" ]]; then
+        supacloud_edge_runtime_source_transaction_outcome "$transaction_dir" >/dev/null || return 1
+    else
+        return 1
+    fi
     printf '%s\n' "$transaction_dir"
+}
+
+write_management_edge_runtime_source_transaction_marker() {
+    local management_transaction_dir="$1"
+    local transaction_dir="$2"
+    local marker="${management_transaction_dir}/${EDGE_RUNTIME_SOURCE_TRANSACTION_MARKER}"
+    python3 - "$management_transaction_dir" "$marker" "$transaction_dir" <<'PY'
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+management_transaction = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+transaction = sys.argv[3]
+metadata = management_transaction.lstat()
+if not stat.S_ISDIR(metadata.st_mode) or management_transaction.is_symlink() \
+        or metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid():
+    raise SystemExit("Management transaction directory is unsafe")
+if marker.exists() or marker.is_symlink():
+    raise SystemExit("Edge Runtime source transaction marker already exists")
+fd, temporary = tempfile.mkstemp(prefix=f".{marker.name}.", dir=management_transaction)
+try:
+    with os.fdopen(fd, "w") as handle:
+        handle.write(transaction + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, marker)
+    directory_fd = os.open(management_transaction, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+PY
+}
+
+remove_management_edge_runtime_source_transaction_marker() {
+    local management_transaction_dir="$1"
+    local transaction_dir="$2"
+    local marker="${management_transaction_dir}/${EDGE_RUNTIME_SOURCE_TRANSACTION_MARKER}"
+    python3 - "$management_transaction_dir" "$marker" "$transaction_dir" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+management_transaction = Path(sys.argv[1])
+marker = Path(sys.argv[2])
+expected = sys.argv[3] + "\n"
+metadata = marker.lstat()
+if not stat.S_ISREG(metadata.st_mode) or marker.is_symlink() \
+        or metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid() \
+        or stat.S_IMODE(metadata.st_mode) != 0o600 or metadata.st_nlink != 1 \
+        or marker.read_text() != expected:
+    raise SystemExit("Edge Runtime source transaction marker is unsafe or changed")
+marker.unlink()
+directory_fd = os.open(management_transaction, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(directory_fd)
+finally:
+    os.close(directory_fd)
+PY
 }
 
 capture_management_edge_runtime_source_state() {
@@ -3131,7 +3228,6 @@ management_edge_runtime_service_prior_enabled_state() {
 prepare_management_edge_runtime_source() {
     local management_transaction_dir="$1"
     local source_dir="$EDGE_RUNTIME_SOURCE_INPUT_DIR"
-    local marker="${management_transaction_dir}/${EDGE_RUNTIME_SOURCE_TRANSACTION_MARKER}"
     local transaction_dir staged_dir identity version sha256
 
     [[ -d "$source_dir" && ! -L "$source_dir" ]] || {
@@ -3144,64 +3240,51 @@ prepare_management_edge_runtime_source() {
     }
     transaction_dir=$(supacloud_stage_edge_runtime_source "$source_dir" "$EDGE_RUNTIME_SOURCE_DIR") || return 1
     EDGE_RUNTIME_SOURCE_TRANSACTION_DIR="$transaction_dir"
-    printf '%s\n' "$transaction_dir" > "$marker" || {
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
+    if ! write_management_edge_runtime_source_transaction_marker \
+        "$management_transaction_dir" "$transaction_dir"; then
+        if supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR"; then
+            supacloud_clear_edge_runtime_source_transaction_outcome \
+                "$transaction_dir" rollback || true
+        fi
         EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
         return 1
-    }
-    chmod 600 "$marker" || {
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-        rm -f "$marker"
-        EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
-        return 1
-    }
+    fi
     staged_dir="${transaction_dir}/staged"
 
     log_info "Installing Edge Runtime dependencies in the staged source tree..."
     if [[ "$SUPACLOUD_RESOLVED_ARTIFACT_MODE" == "release" ]]; then
-        (cd "$staged_dir" && bun install --frozen-lockfile) || {
+        (cd "$staged_dir" && bun install --backend=copyfile --frozen-lockfile) || {
             log_error "Release Edge Runtime dependencies do not match the lockfile"
-            supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-            rm -f "$marker"
+            rollback_management_edge_runtime_source "$management_transaction_dir" || true
             EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
             return 1
         }
-    elif ! { (cd "$staged_dir" && bun install --frozen-lockfile 2>/dev/null) || \
-        (cd "$staged_dir" && bun install); }; then
+    elif ! { (cd "$staged_dir" && bun install --backend=copyfile --frozen-lockfile 2>/dev/null) || \
+        (cd "$staged_dir" && bun install --backend=copyfile); }; then
         log_error "Failed to install staged Edge Runtime dependencies"
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-        rm -f "$marker"
+        rollback_management_edge_runtime_source "$management_transaction_dir" || true
         EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
         return 1
     fi
     if ! configure_edge_runtime_source_access "$staged_dir"; then
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-        rm -f "$marker"
+        rollback_management_edge_runtime_source "$management_transaction_dir" || true
         EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
         return 1
     fi
     if ! identity=$(supacloud_refresh_edge_runtime_source_identity "$staged_dir"); then
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-        rm -f "$marker"
+        rollback_management_edge_runtime_source "$management_transaction_dir" || true
         EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
         return 1
     fi
-    if ! printf '%s\n' "$identity" > "${transaction_dir}/expected-identity"; then
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-        rm -f "$marker"
-        EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
-        return 1
-    fi
-    if ! chmod 600 "${transaction_dir}/expected-identity"; then
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-        rm -f "$marker"
+    if ! supacloud_write_edge_runtime_transaction_identity \
+        "$transaction_dir" expected-identity "$identity"; then
+        rollback_management_edge_runtime_source "$management_transaction_dir" || true
         EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
         return 1
     fi
     IFS=$'\t' read -r version sha256 <<< "$identity"
     if ! supacloud_verify_edge_runtime_source_identity "$staged_dir" "$version" "$sha256"; then
-        supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || true
-        rm -f "$marker"
+        rollback_management_edge_runtime_source "$management_transaction_dir" || true
         EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
         return 1
     fi
@@ -3222,7 +3305,10 @@ rollback_management_edge_runtime_source() {
     [[ -e "$marker" || -L "$marker" ]] || return 0
     transaction_dir=$(management_edge_runtime_source_transaction "$management_transaction_dir") || return 1
     supacloud_rollback_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || return 1
-    rm -f "$marker"
+    remove_management_edge_runtime_source_transaction_marker \
+        "$management_transaction_dir" "$transaction_dir" || return 1
+    supacloud_clear_edge_runtime_source_transaction_outcome \
+        "$transaction_dir" rollback || return 1
     [[ "$EDGE_RUNTIME_SOURCE_TRANSACTION_DIR" == "$transaction_dir" ]] && EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
 }
 
@@ -3253,11 +3339,13 @@ verify_recovered_management_edge_runtime_source() {
 
 commit_management_edge_runtime_source() {
     local management_transaction_dir="$1"
-    local marker="${management_transaction_dir}/${EDGE_RUNTIME_SOURCE_TRANSACTION_MARKER}"
     local transaction_dir
     transaction_dir=$(management_edge_runtime_source_transaction "$management_transaction_dir") || return 1
     supacloud_commit_edge_runtime_source "$transaction_dir" "$EDGE_RUNTIME_SOURCE_DIR" || return 1
-    rm -f "$marker"
+    remove_management_edge_runtime_source_transaction_marker \
+        "$management_transaction_dir" "$transaction_dir" || return 1
+    supacloud_clear_edge_runtime_source_transaction_outcome \
+        "$transaction_dir" commit || return 1
     [[ "$EDGE_RUNTIME_SOURCE_TRANSACTION_DIR" == "$transaction_dir" ]] && EDGE_RUNTIME_SOURCE_TRANSACTION_DIR=""
 }
 

--- a/packages/management-api/tests/unit/install-config.test.ts
+++ b/packages/management-api/tests/unit/install-config.test.ts
@@ -28,6 +28,73 @@ function runBash(script: string, env: Record<string, string> = {}) {
   });
 }
 
+const edgeRuntimeIdentityName = ".supacloud-source-identity.json";
+const edgeRuntimeStableVersion = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+
+function writeEdgeRuntimeSourceIdentity(root: string) {
+  const packagePath = join(root, "package.json");
+  const rootStat = statSync(root);
+  const packageStat = statSync(packagePath);
+
+  if (!rootStat.isDirectory() || lstatSync(root).isSymbolicLink() || !packageStat.isFile() || lstatSync(packagePath).isSymbolicLink()) {
+    throw new Error("Edge Runtime source package is missing or unsafe");
+  }
+
+  const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+  if (pkg.name !== "@supacloud/edge-runtime") {
+    throw new Error("Edge Runtime package name is invalid");
+  }
+  if (typeof pkg.version !== "string" || !edgeRuntimeStableVersion.test(pkg.version)) {
+    throw new Error("Edge Runtime package version must be an exact stable version");
+  }
+
+  const ignoredDirectories = new Set(["node_modules", ".tmp", "dist"]);
+  const files: Array<{ relative: string; path: string }> = [];
+  const pending = [root];
+  while (pending.length > 0) {
+    const current = pending.pop() as string;
+    for (const name of readdirSync(current)) {
+      const candidate = join(current, name);
+      const relative = candidate.slice(root.length + 1);
+      const metadata = lstatSync(candidate);
+      if (metadata.isDirectory()) {
+        if (!ignoredDirectories.has(name)) {
+          pending.push(candidate);
+        }
+      } else if (metadata.isFile()) {
+        if (relative === edgeRuntimeIdentityName || relative.split("/").some((part) => ignoredDirectories.has(part))) {
+          continue;
+        }
+        files.push({ relative, path: candidate });
+      } else if (metadata.isSymbolicLink()) {
+        throw new Error(`Staged Edge Runtime source contains a symbolic link: ${relative}`);
+      } else {
+        throw new Error(`Staged Edge Runtime source contains a special file: ${relative}`);
+      }
+    }
+  }
+
+  const digest = createHash("sha256");
+  for (const entry of files.sort((left, right) => (left.relative < right.relative ? -1 : left.relative > right.relative ? 1 : 0))) {
+    const metadata = lstatSync(entry.path);
+    digest.update("file\0");
+    digest.update(entry.relative);
+    digest.update("\0");
+    digest.update((metadata.mode & 0o777).toString(8).padStart(4, "0"));
+    digest.update("\0");
+    digest.update(readFileSync(entry.path));
+    digest.update("\0");
+  }
+
+  const identity = {
+    schemaVersion: 1,
+    packageName: "@supacloud/edge-runtime",
+    packageVersion: pkg.version,
+    sourceSha256: digest.digest("hex"),
+  };
+  writeFileSync(join(root, edgeRuntimeIdentityName), `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o644 });
+}
+
 describe("installer configuration persistence", () => {
   test("recognizes only Unit-scoped systemd start limits as canonical", () => {
     const dir = makeTempDir();
@@ -1182,6 +1249,10 @@ describe("installer configuration persistence", () => {
       version: "1.2.3",
     }));
     writeFileSync(join(sourceDir, "server.ts"), "new-runtime\n");
+    writeFileSync(join(targetDir, "package.json"), JSON.stringify({
+      name: "@supacloud/edge-runtime",
+      version: "1.0.0",
+    }));
     writeFileSync(join(targetDir, "server.ts"), "old-runtime\n");
     writeFileSync(join(targetDir, "removed.ts"), "old-only\n");
     writeFileSync(join(fakeBin, "bun"), [
@@ -1190,6 +1261,7 @@ describe("installer configuration persistence", () => {
       "printf 'installed\\n' > node_modules/installed.txt",
       "",
     ].join("\n"), { mode: 0o755 });
+    writeEdgeRuntimeSourceIdentity(targetDir);
 
     const result = runBash([
       "source install.sh",
@@ -1214,7 +1286,7 @@ describe("installer configuration persistence", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(join(targetDir, "server.ts"), "utf8")).toBe("old-runtime\n");
     expect(readFileSync(join(targetDir, "removed.ts"), "utf8")).toBe("old-only\n");
-  });
+  }, { timeout: 15_000 });
 
   test("management Edge release staging fails closed when the lockfile install fails", () => {
     const dir = makeTempDir();
@@ -1254,7 +1326,7 @@ describe("installer configuration persistence", () => {
 
     expect(result.status).not.toBe(0);
     expect(readFileSync(calls, "utf8").trim().split("\n")).toEqual([
-      "install --frozen-lockfile",
+      "install --backend=copyfile --frozen-lockfile",
     ]);
     expect(result.stdout).toContain("do not match the lockfile");
     expect(existsSync(targetDir)).toBe(false);
@@ -1494,7 +1566,7 @@ describe("installer configuration persistence", () => {
 
     expect(configured.status, configured.stderr).toBe(0);
     expect(readFileSync(calls, "utf8")).toBe([
-      `chmod:-R g-w,g+rX ${sourceDir}`,
+      `chmod:-R go-w,g+rX ${sourceDir}`,
       `chgrp:-R supacloud-edge ${sourceDir}`,
       "",
     ].join("\n"));

--- a/scripts/lib/edge_runtime_source.sh
+++ b/scripts/lib/edge_runtime_source.sh
@@ -2,6 +2,668 @@
 
 SUPACLOUD_EDGE_RUNTIME_SOURCE_IDENTITY_NAME="${SUPACLOUD_EDGE_RUNTIME_SOURCE_IDENTITY_NAME:-.supacloud-source-identity.json}"
 
+supacloud_edge_runtime_directory_node() {
+    local directory="$1"
+    python3 - "$directory" <<'PY'
+import stat
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+metadata = path.lstat()
+if not stat.S_ISDIR(metadata.st_mode) or path.is_symlink():
+    raise SystemExit("Edge Runtime directory must be a real directory")
+print(f"{metadata.st_dev}:{metadata.st_ino}", end="")
+PY
+}
+
+supacloud_edge_runtime_tree_sha256() {
+    local source_dir="$1"
+    python3 - "$source_dir" <<'PY'
+import hashlib
+import os
+import stat
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+metadata = root.lstat()
+if not stat.S_ISDIR(metadata.st_mode) or root.is_symlink():
+    raise SystemExit("Edge Runtime tree must be a real directory")
+
+entries = [(".", "dir", str(root), metadata)]
+pending = [(root, Path("."))]
+while pending:
+    current, relative_root = pending.pop()
+    with os.scandir(current) as directory:
+        children = list(directory)
+    for child in children:
+        relative = (relative_root / child.name) if relative_root != Path(".") else Path(child.name)
+        relative_name = relative.as_posix()
+        if any(ord(character) < 32 for character in relative_name):
+            raise SystemExit("Edge Runtime tree contains a control character in a path")
+        child_metadata = child.stat(follow_symlinks=False)
+        if stat.S_ISDIR(child_metadata.st_mode):
+            entries.append((relative_name, "dir", child.path, child_metadata))
+            pending.append((Path(child.path), relative))
+        elif stat.S_ISREG(child_metadata.st_mode):
+            entries.append((relative_name, "file", child.path, child_metadata))
+        elif stat.S_ISLNK(child_metadata.st_mode):
+            entries.append((relative_name, "symlink", child.path, child_metadata))
+        else:
+            raise SystemExit(f"Edge Runtime tree contains a special entry: {relative_name}")
+
+digest = hashlib.sha256()
+for relative_name, entry_type, path, entry_metadata in sorted(entries, key=lambda item: item[0]):
+    digest.update(entry_type.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(relative_name.encode("utf-8", "surrogateescape"))
+    digest.update(b"\0")
+    digest.update(f"{stat.S_IMODE(entry_metadata.st_mode):04o}".encode("ascii"))
+    digest.update(b"\0")
+    digest.update(str(entry_metadata.st_uid).encode("ascii"))
+    digest.update(b"\0")
+    digest.update(str(entry_metadata.st_gid).encode("ascii"))
+    digest.update(b"\0")
+    digest.update(str(entry_metadata.st_nlink).encode("ascii"))
+    digest.update(b"\0")
+    if entry_type == "file":
+        with open(path, "rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+    elif entry_type == "symlink":
+        digest.update(os.fsencode(os.readlink(path)))
+    digest.update(b"\0")
+print(digest.hexdigest(), end="")
+PY
+}
+
+supacloud_prepare_edge_runtime_tree_for_exchange() {
+    local source_dir="$1"
+    python3 - "$source_dir" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+root_resolved = root.resolve(strict=True)
+expected_uid = os.geteuid()
+directories = []
+
+def validate_metadata(path: Path, metadata: os.stat_result, entry_type: str) -> None:
+    if metadata.st_uid != expected_uid:
+        raise SystemExit(f"Edge Runtime {entry_type} has an unexpected owner: {path}")
+    if entry_type != "symlink" and stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise SystemExit(f"Edge Runtime {entry_type} is group/other writable: {path}")
+    if entry_type in {"file", "symlink"} and metadata.st_nlink != 1:
+        raise SystemExit(f"Edge Runtime {entry_type} is hard-linked: {path}")
+
+root_metadata = root.lstat()
+if not stat.S_ISDIR(root_metadata.st_mode) or root.is_symlink():
+    raise SystemExit("Edge Runtime deployable tree must be a real directory")
+validate_metadata(root, root_metadata, "directory")
+directories.append(root)
+
+pending = [root]
+while pending:
+    current = pending.pop()
+    with os.scandir(current) as directory:
+        children = list(directory)
+    for child in children:
+        path = Path(child.path)
+        metadata = child.stat(follow_symlinks=False)
+        if stat.S_ISDIR(metadata.st_mode):
+            validate_metadata(path, metadata, "directory")
+            directories.append(path)
+            pending.append(path)
+        elif stat.S_ISREG(metadata.st_mode):
+            validate_metadata(path, metadata, "file")
+            descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            try:
+                opened = os.fstat(descriptor)
+                if not stat.S_ISREG(opened.st_mode) or (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+                    raise SystemExit(f"Edge Runtime file changed during validation: {path}")
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        elif stat.S_ISLNK(metadata.st_mode):
+            validate_metadata(path, metadata, "symlink")
+            target = os.readlink(path)
+            if os.path.isabs(target):
+                raise SystemExit(f"Edge Runtime symlink target must be relative: {path}")
+            resolved_target = (path.parent / target).resolve(strict=False)
+            try:
+                resolved_target.relative_to(root_resolved)
+            except ValueError:
+                raise SystemExit(f"Edge Runtime symlink escapes the runtime tree: {path}")
+        else:
+            raise SystemExit(f"Edge Runtime tree contains a special entry: {path}")
+
+for directory in sorted(directories, key=lambda path: len(path.parts), reverse=True):
+    descriptor = os.open(directory, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+PY
+}
+
+supacloud_stable_edge_runtime_tree_sha256() {
+    local source_dir="$1"
+    local first second
+    first=$(supacloud_edge_runtime_tree_sha256 "$source_dir") || return 1
+    second=$(supacloud_edge_runtime_tree_sha256 "$source_dir") || return 1
+    [[ "$first" == "$second" ]] || {
+        printf '%s\n' "Edge Runtime tree changed while calculating its digest" >&2
+        return 1
+    }
+    printf '%s\n' "$first"
+}
+
+supacloud_write_edge_runtime_transaction_state() {
+    local transaction_dir="$1"
+    local state="$2"
+    [[ "$state" =~ ^[a-z][a-z-]*$ ]] || return 1
+    python3 - "$transaction_dir" "$state" <<'PY'
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+transaction = Path(sys.argv[1])
+state = sys.argv[2]
+metadata = transaction.lstat()
+if not stat.S_ISDIR(metadata.st_mode) or transaction.is_symlink():
+    raise SystemExit("Edge Runtime transaction path must be a real directory")
+fd, temporary = tempfile.mkstemp(prefix=".state.", dir=transaction)
+try:
+    with os.fdopen(fd, "w") as handle:
+        handle.write(state + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, transaction / "state")
+    directory_fd = os.open(transaction, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+PY
+}
+
+supacloud_write_edge_runtime_transaction_identity() {
+    local transaction_dir="$1"
+    local name="$2"
+    local identity="$3"
+    [[ "$name" == expected-identity || "$name" == prior-identity ]] || return 1
+    [[ "$identity" =~ ^[0-9]+\.[0-9]+\.[0-9]+$'\t'[0-9a-f]{64}$ ]] || return 1
+    python3 - "$transaction_dir" "$name" "$identity" <<'PY'
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+transaction = Path(sys.argv[1])
+name = sys.argv[2]
+identity = sys.argv[3]
+metadata = transaction.lstat()
+if not stat.S_ISDIR(metadata.st_mode) or transaction.is_symlink():
+    raise SystemExit("Edge Runtime transaction path must be a real directory")
+fd, temporary = tempfile.mkstemp(prefix=f".{name}.", dir=transaction)
+try:
+    with os.fdopen(fd, "w") as handle:
+        handle.write(identity + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, transaction / name)
+    directory_fd = os.open(transaction, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+PY
+}
+
+supacloud_remove_edge_runtime_outcome_writer_temps() {
+    local transaction_dir="$1"
+    python3 - "$transaction_dir" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+transaction = Path(sys.argv[1])
+parent = transaction.parent
+parent_metadata = parent.lstat()
+if not stat.S_ISDIR(parent_metadata.st_mode) or parent.is_symlink():
+    raise SystemExit("Edge Runtime transaction parent is unsafe")
+prefix = f".{transaction.name}.outcome."
+removed = False
+for entry in parent.iterdir():
+    if not entry.name.startswith(prefix):
+        continue
+    metadata = entry.lstat()
+    if not stat.S_ISREG(metadata.st_mode) or entry.is_symlink() \
+            or metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid() \
+            or stat.S_IMODE(metadata.st_mode) != 0o600 or metadata.st_nlink != 1:
+        raise SystemExit("Edge Runtime transaction outcome temporary file is unsafe")
+    entry.unlink()
+    removed = True
+if removed:
+    parent_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(parent_fd)
+    finally:
+        os.close(parent_fd)
+PY
+}
+
+supacloud_remove_edge_runtime_source_transaction() {
+    local transaction_dir="$1"
+    local expected_outcome="$2"
+    local target_dir="$3"
+    local cleanup_dir="${transaction_dir}.cleanup"
+    local active="$transaction_dir"
+    local outcome_file="${transaction_dir}.outcome"
+    [[ "$expected_outcome" == commit || "$expected_outcome" == rollback ]] || return 1
+    [[ -n "$target_dir" ]] || return 1
+    supacloud_remove_edge_runtime_outcome_writer_temps "$transaction_dir" || return 1
+    local target_state target_tree target_node target_path expected_identity prior_identity
+    target_path=$(python3 - "$target_dir" <<'PY'
+import sys
+from pathlib import Path
+print(str(Path(sys.argv[1]).absolute()), end="")
+PY
+    ) || return 1
+    if [[ -e "$target_dir" || -L "$target_dir" ]]; then
+        [[ -d "$target_dir" && ! -L "$target_dir" ]] || return 1
+        target_state=present
+        target_tree=$(supacloud_stable_edge_runtime_tree_sha256 "$target_dir") || return 1
+        target_node=$(supacloud_edge_runtime_directory_node "$target_dir") || return 1
+    else
+        target_state=absent
+        target_tree=absent
+        target_node=absent
+    fi
+    if [[ ! -e "$transaction_dir" && ! -L "$transaction_dir" && -d "$cleanup_dir" && ! -L "$cleanup_dir" ]]; then
+        active="$cleanup_dir"
+    fi
+    expected_identity=$(cat "${active}/expected-identity" 2>/dev/null || true)
+    prior_identity=$(cat "${active}/prior-identity" 2>/dev/null || true)
+    python3 - "$transaction_dir" "$cleanup_dir" "$outcome_file" "$expected_outcome" \
+        "$target_path" "$target_state" "$target_tree" "$target_node" \
+        "$expected_identity" "$prior_identity" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+transaction = Path(sys.argv[1])
+cleanup = Path(sys.argv[2])
+outcome_file = Path(sys.argv[3])
+expected_outcome = sys.argv[4]
+target_path = sys.argv[5]
+target_state = sys.argv[6]
+target_tree = sys.argv[7]
+target_node = sys.argv[8]
+expected_identity = sys.argv[9] or None
+prior_identity = sys.argv[10] or None
+parent = transaction.parent
+
+def validate_directory(path: Path) -> str:
+    metadata = path.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or path.is_symlink() \
+            or metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid() \
+            or stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise SystemExit("Edge Runtime transaction path is unsafe")
+    state_path = path / "state"
+    state_metadata = state_path.lstat()
+    if not stat.S_ISREG(state_metadata.st_mode) or state_path.is_symlink() \
+            or state_metadata.st_uid != os.geteuid() or state_metadata.st_gid != os.getegid() \
+            or stat.S_IMODE(state_metadata.st_mode) != 0o600 or state_metadata.st_nlink != 1:
+        raise SystemExit("Edge Runtime transaction state is unsafe")
+    return state_path.read_text().rstrip("\n")
+
+active = transaction
+if not transaction.exists() and not transaction.is_symlink():
+    active = cleanup
+elif cleanup.exists() or cleanup.is_symlink():
+    raise SystemExit("Edge Runtime transaction and cleanup tombstone both exist")
+state = validate_directory(active)
+if expected_outcome == "commit":
+    if not state.startswith("commit-intent-"):
+        raise SystemExit("Edge Runtime transaction is not committed")
+elif state != "prepared" and not state.startswith("rolled-back-"):
+    raise SystemExit("Edge Runtime transaction is not rollback-compatible")
+intent = None
+intent_path = active / "exchange-intent.json"
+if intent_path.exists() or intent_path.is_symlink():
+    intent_metadata = intent_path.lstat()
+    if not stat.S_ISREG(intent_metadata.st_mode) or intent_path.is_symlink() \
+            or intent_metadata.st_uid != os.geteuid() or intent_metadata.st_gid != os.getegid() \
+            or stat.S_IMODE(intent_metadata.st_mode) != 0o600 or intent_metadata.st_nlink != 1:
+        raise SystemExit("Edge Runtime exchange intent is unsafe")
+    try:
+        intent = json.loads(intent_path.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"Edge Runtime exchange intent is invalid: {error}")
+    required = {
+        "schemaVersion", "targetPath", "expectedIdentity", "priorState", "priorIdentityState",
+        "priorIdentity", "stagedTreeSha256", "priorTreeSha256", "stagedNode", "targetNode",
+    }
+    if set(intent) != required or intent.get("schemaVersion") != 2 \
+            or intent.get("targetPath") != target_path:
+        raise SystemExit("Edge Runtime exchange intent contract is invalid")
+    if intent.get("expectedIdentity") != expected_identity:
+        raise SystemExit("Edge Runtime exchange expected identity changed")
+    if intent.get("priorIdentity") != (prior_identity or None):
+        raise SystemExit("Edge Runtime exchange prior identity changed")
+elif expected_outcome == "commit":
+    raise SystemExit("Edge Runtime commit requires an exchange intent")
+
+if outcome_file.exists() or outcome_file.is_symlink():
+    outcome_metadata = outcome_file.lstat()
+    if not stat.S_ISREG(outcome_metadata.st_mode) or outcome_file.is_symlink() \
+            or outcome_metadata.st_uid != os.geteuid() or outcome_metadata.st_gid != os.getegid() \
+            or stat.S_IMODE(outcome_metadata.st_mode) != 0o600 or outcome_metadata.st_nlink != 1:
+        raise SystemExit("Edge Runtime transaction outcome is unsafe or conflicting")
+    try:
+        receipt = json.loads(outcome_file.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"Edge Runtime transaction outcome is invalid: {error}")
+    if receipt.get("outcome") != expected_outcome:
+        raise SystemExit("Edge Runtime transaction outcome conflicts")
+else:
+    fd, temporary = tempfile.mkstemp(prefix=f".{outcome_file.name}.", dir=parent)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            receipt = {
+                "schemaVersion": 1,
+                "transactionPath": str(transaction.absolute()),
+                "outcome": expected_outcome,
+                "targetPath": target_path,
+                "targetState": target_state,
+                "targetTreeSha256": target_tree,
+                "targetNode": target_node,
+                "expectedIdentity": expected_identity,
+                "priorIdentity": prior_identity or None,
+                "priorState": intent.get("priorState") if intent else None,
+                "stagedTreeSha256": intent.get("stagedTreeSha256") if intent else None,
+                "priorTreeSha256": intent.get("priorTreeSha256") if intent else None,
+            }
+            json.dump(receipt, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, outcome_file)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+if active == transaction:
+    os.rename(transaction, cleanup)
+parent_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(parent_fd)
+finally:
+    os.close(parent_fd)
+PY
+}
+
+supacloud_edge_runtime_source_transaction_outcome() {
+    local transaction_dir="$1"
+    local outcome_file="${transaction_dir}.outcome"
+    supacloud_remove_edge_runtime_outcome_writer_temps "$transaction_dir" || return 1
+    python3 - "$outcome_file" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+outcome = Path(sys.argv[1])
+metadata = outcome.lstat()
+if not stat.S_ISREG(metadata.st_mode) or outcome.is_symlink() \
+        or metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid() \
+        or stat.S_IMODE(metadata.st_mode) != 0o600 or metadata.st_nlink != 1:
+    raise SystemExit("Edge Runtime transaction outcome is unsafe")
+try:
+    receipt = json.loads(outcome.read_text())
+except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+    raise SystemExit(f"Edge Runtime transaction outcome is invalid: {error}")
+required = {
+    "schemaVersion", "transactionPath", "outcome", "targetPath", "targetState",
+    "targetTreeSha256", "targetNode", "expectedIdentity", "priorIdentity", "priorState",
+    "stagedTreeSha256", "priorTreeSha256",
+}
+if set(receipt) != required or receipt.get("schemaVersion") != 1 \
+        or receipt.get("outcome") not in {"commit", "rollback"}:
+    raise SystemExit("Edge Runtime transaction outcome contract is invalid")
+print(receipt["outcome"], end="")
+PY
+}
+
+supacloud_validate_edge_runtime_source_transaction_outcome() {
+    local transaction_dir="$1"
+    local target_dir="$2"
+    local expected_outcome="$3"
+    local outcome_file="${transaction_dir}.outcome"
+    local target_path target_state target_tree target_node
+    [[ "$expected_outcome" == commit || "$expected_outcome" == rollback ]] || return 1
+    [[ -f "$outcome_file" && ! -L "$outcome_file" ]] || return 1
+    target_path=$(python3 - "$target_dir" <<'PY'
+import sys
+from pathlib import Path
+print(str(Path(sys.argv[1]).absolute()), end="")
+PY
+    ) || return 1
+    if [[ -e "$target_dir" || -L "$target_dir" ]]; then
+        [[ -d "$target_dir" && ! -L "$target_dir" ]] || return 1
+        target_state=present
+        target_tree=$(supacloud_stable_edge_runtime_tree_sha256 "$target_dir") || return 1
+        target_node=$(supacloud_edge_runtime_directory_node "$target_dir") || return 1
+    else
+        target_state=absent
+        target_tree=absent
+        target_node=absent
+    fi
+    python3 - "$outcome_file" "$expected_outcome" "$target_path" "$target_state" \
+        "$target_tree" "$target_node" "$transaction_dir" <<'PY'
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+outcome = Path(sys.argv[1])
+expected_outcome, target_path, target_state, target_tree, target_node, transaction_path = sys.argv[2:]
+metadata = outcome.lstat()
+if not stat.S_ISREG(metadata.st_mode) or outcome.is_symlink() \
+        or metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid() \
+        or stat.S_IMODE(metadata.st_mode) != 0o600 or metadata.st_nlink != 1:
+    raise SystemExit("Edge Runtime transaction outcome is unsafe")
+try:
+    receipt = json.loads(outcome.read_text())
+except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+    raise SystemExit(f"Edge Runtime transaction outcome is invalid: {error}")
+required = {
+    "schemaVersion", "transactionPath", "outcome", "targetPath", "targetState",
+    "targetTreeSha256", "targetNode", "expectedIdentity", "priorIdentity", "priorState",
+    "stagedTreeSha256", "priorTreeSha256",
+}
+if set(receipt) != required or receipt.get("schemaVersion") != 1 \
+        or receipt.get("outcome") != expected_outcome \
+        or receipt.get("transactionPath") != str(Path(transaction_path).absolute()) \
+        or receipt.get("targetPath") != target_path \
+        or receipt.get("targetState") != target_state \
+        or receipt.get("targetTreeSha256") != target_tree \
+        or receipt.get("targetNode") != target_node:
+    raise SystemExit("Edge Runtime transaction outcome does not match current target")
+PY
+    local expected_identity prior_identity version sha256
+    expected_identity=$(python3 - "$outcome_file" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1]))["expectedIdentity"] or "", end="")
+PY
+    ) || return 1
+    prior_identity=$(python3 - "$outcome_file" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1]))["priorIdentity"] or "", end="")
+PY
+    ) || return 1
+    if [[ "$expected_outcome" == commit ]]; then
+        [[ -n "$expected_identity" ]] || return 1
+        IFS=$'\t' read -r version sha256 <<< "$expected_identity"
+        supacloud_verify_edge_runtime_source_identity "$target_dir" "$version" "$sha256" || return 1
+    elif [[ -n "$prior_identity" ]]; then
+        IFS=$'\t' read -r version sha256 <<< "$prior_identity"
+        supacloud_verify_edge_runtime_source_identity "$target_dir" "$version" "$sha256" || return 1
+    fi
+}
+
+supacloud_finalize_edge_runtime_source_transaction() {
+    local transaction_dir="$1"
+    local expected_outcome="$2"
+    local target_dir="$3"
+    local cleanup_dir="${transaction_dir}.cleanup"
+    supacloud_remove_edge_runtime_source_transaction \
+        "$transaction_dir" "$expected_outcome" "$target_dir" || return 1
+    rm -rf -- "$cleanup_dir" || return 1
+    python3 - "$(dirname "$transaction_dir")" <<'PY'
+import os
+import sys
+
+directory_fd = os.open(sys.argv[1], os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(directory_fd)
+finally:
+    os.close(directory_fd)
+PY
+}
+
+supacloud_clear_edge_runtime_source_transaction_outcome() {
+    local transaction_dir="$1"
+    local expected_outcome="$2"
+    [[ "$expected_outcome" == commit || "$expected_outcome" == rollback ]] || return 1
+    [[ ! -e "$transaction_dir" && ! -L "$transaction_dir" \
+        && ! -e "${transaction_dir}.cleanup" && ! -L "${transaction_dir}.cleanup" ]] || return 1
+    [[ "$(supacloud_edge_runtime_source_transaction_outcome "$transaction_dir")" == "$expected_outcome" ]] || return 1
+    rm -f -- "${transaction_dir}.outcome" || return 1
+    python3 - "$(dirname "$transaction_dir")" <<'PY'
+import os
+import sys
+
+directory_fd = os.open(sys.argv[1], os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(directory_fd)
+finally:
+    os.close(directory_fd)
+PY
+}
+
+supacloud_resolve_edge_runtime_source_transaction() {
+    local transaction_dir="$1"
+    local cleanup_dir="${transaction_dir}.cleanup"
+    if [[ -d "$transaction_dir" && ! -L "$transaction_dir" ]]; then
+        [[ ! -e "$cleanup_dir" && ! -L "$cleanup_dir" ]] || return 1
+        printf '%s\n' "$transaction_dir"
+        return 0
+    fi
+    if [[ ! -e "$transaction_dir" && ! -L "$transaction_dir" && -d "$cleanup_dir" && ! -L "$cleanup_dir" ]]; then
+        printf '%s\n' "$cleanup_dir"
+        return 0
+    fi
+    return 1
+}
+
+supacloud_validate_edge_runtime_transaction() {
+    local transaction_dir="$1"
+    python3 - "$transaction_dir" <<'PY'
+import os
+import stat
+import sys
+from pathlib import Path
+
+transaction = Path(sys.argv[1])
+metadata = transaction.lstat()
+if not stat.S_ISDIR(metadata.st_mode) or transaction.is_symlink():
+    raise SystemExit("Edge Runtime transaction must be a real directory")
+if metadata.st_uid != os.geteuid() or metadata.st_gid != os.getegid():
+    raise SystemExit("Edge Runtime transaction has an unexpected owner")
+if stat.S_IMODE(metadata.st_mode) != 0o700:
+    raise SystemExit("Edge Runtime transaction has unsafe permissions")
+allowed = {"staged", "state", "expected-identity", "prior-identity", "exchange-intent.json"}
+temporary_prefixes = (".state.", ".expected-identity.", ".prior-identity.", ".exchange-intent.")
+entries = set()
+removed_temporary = False
+for entry in transaction.iterdir():
+    if entry.name.startswith(temporary_prefixes):
+        entry_metadata = entry.lstat()
+        if not stat.S_ISREG(entry_metadata.st_mode) or entry_metadata.st_uid != os.geteuid() \
+                or entry_metadata.st_gid != os.getegid() or stat.S_IMODE(entry_metadata.st_mode) != 0o600 \
+                or entry_metadata.st_nlink != 1:
+            raise SystemExit(f"Edge Runtime transaction temporary file is unsafe: {entry.name}")
+        entry.unlink()
+        removed_temporary = True
+        continue
+    entries.add(entry.name)
+if removed_temporary:
+    directory_fd = os.open(transaction, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+if not entries.issubset(allowed):
+    raise SystemExit("Edge Runtime transaction contains an unexpected entry")
+staged = transaction / "staged"
+if staged.exists() or staged.is_symlink():
+    staged_metadata = staged.lstat()
+    if not stat.S_ISDIR(staged_metadata.st_mode) or staged.is_symlink():
+        raise SystemExit("Edge Runtime transaction staged path is unsafe")
+for name in ("state", "expected-identity", "prior-identity"):
+    candidate = transaction / name
+    if candidate.exists() or candidate.is_symlink():
+        candidate_metadata = candidate.lstat()
+        if not stat.S_ISREG(candidate_metadata.st_mode) or candidate_metadata.st_uid != os.geteuid() \
+                or candidate_metadata.st_gid != os.getegid() or stat.S_IMODE(candidate_metadata.st_mode) != 0o600 \
+                or candidate_metadata.st_nlink != 1:
+            raise SystemExit(f"Edge Runtime transaction file is unsafe: {name}")
+PY
+}
+
+supacloud_edge_runtime_transaction_prior_identity() {
+    local transaction_dir="$1"
+    transaction_dir=$(supacloud_resolve_edge_runtime_source_transaction "$transaction_dir") || return 1
+    [[ -f "${transaction_dir}/prior-identity" && ! -L "${transaction_dir}/prior-identity" ]] || return 1
+    cat "${transaction_dir}/prior-identity"
+}
+
+supacloud_edge_runtime_identity_or_absent() {
+    local source_dir="$1"
+    if [[ -e "$source_dir" || -L "$source_dir" ]]; then
+        [[ -d "$source_dir" && ! -L "$source_dir" ]] || return 1
+        supacloud_read_edge_runtime_source_identity "$source_dir"
+    else
+        printf '%s\n' absent
+    fi
+}
+
 supacloud_validate_edge_runtime_source_identity_name() {
     [[ "$SUPACLOUD_EDGE_RUNTIME_SOURCE_IDENTITY_NAME" =~ ^[A-Za-z0-9._-]+$ ]] || {
         printf '%s\n' "Edge Runtime source identity name must be a safe basename" >&2
@@ -77,7 +739,7 @@ for current, directories, files in os.walk(source, topdown=True, followlinks=Fal
     for name in files:
         if relative_root == Path(".") and name.startswith("supacloud-edge-runtime-"):
             continue
-        if name == identity_name:
+        if relative_root == Path(".") and name == identity_name:
             continue
         candidate = current_path / name
         metadata = candidate.lstat()
@@ -101,8 +763,6 @@ def source_sha256(root: Path) -> str:
             relative = candidate.relative_to(root)
             if name in ignored_directories:
                 continue
-            if identity_name in relative.parts:
-                continue
             metadata = candidate.lstat()
             if stat.S_ISLNK(metadata.st_mode):
                 raise SystemExit(f"Staged Edge Runtime source contains a symbolic link: {relative}")
@@ -113,7 +773,7 @@ def source_sha256(root: Path) -> str:
         for name in names:
             candidate = current_path / name
             relative = candidate.relative_to(root)
-            if identity_name in relative.parts or any(part in ignored_directories for part in relative.parts):
+            if relative == Path(identity_name) or any(part in ignored_directories for part in relative.parts):
                 continue
             files.append((relative.as_posix(), candidate))
     for relative_name, candidate in sorted(files):
@@ -153,9 +813,14 @@ PY
         rm -rf -- "$transaction_dir"
         return 1
     }
-    printf '%s\n' "$identity" > "${transaction_dir}/expected-identity"
-    chmod 600 "${transaction_dir}/expected-identity"
-    printf 'prepared\n' > "${transaction_dir}/state"
+    supacloud_write_edge_runtime_transaction_identity "$transaction_dir" expected-identity "$identity" || {
+        rm -rf -- "$transaction_dir"
+        return 1
+    }
+    supacloud_write_edge_runtime_transaction_state "$transaction_dir" prepared || {
+        rm -rf -- "$transaction_dir"
+        return 1
+    }
     printf '%s\n' "$transaction_dir"
 }
 
@@ -198,7 +863,7 @@ for current, directories, names in os.walk(root, topdown=True, followlinks=False
     for name in directories:
         candidate = current_path / name
         relative = candidate.relative_to(root)
-        if name in ignored_directories or identity_name in relative.parts:
+        if name in ignored_directories:
             continue
         metadata = candidate.lstat()
         if stat.S_ISLNK(metadata.st_mode):
@@ -210,7 +875,7 @@ for current, directories, names in os.walk(root, topdown=True, followlinks=False
     for name in names:
         candidate = current_path / name
         relative = candidate.relative_to(root)
-        if identity_name in relative.parts or any(part in ignored_directories for part in relative.parts):
+        if relative == Path(identity_name) or any(part in ignored_directories for part in relative.parts):
             continue
         files.append((relative.as_posix(), candidate))
 
@@ -248,6 +913,11 @@ try:
         os.fsync(handle.fileno())
     os.chmod(temporary_name, 0o644)
     os.replace(temporary_name, identity_path)
+    directory_fd = os.open(root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
 finally:
     if os.path.exists(temporary_name):
         os.unlink(temporary_name)
@@ -275,6 +945,11 @@ identity_path = root / identity_name
 
 if not root.is_dir() or root.is_symlink() or not identity_path.is_file() or identity_path.is_symlink():
     raise SystemExit("Edge Runtime source identity is missing or unsafe")
+identity_metadata = identity_path.lstat()
+if not stat.S_ISREG(identity_metadata.st_mode) or identity_path.is_symlink() \
+        or stat.S_IMODE(identity_metadata.st_mode) & 0o022 \
+        or identity_metadata.st_nlink != 1:
+    raise SystemExit("Edge Runtime source identity metadata is unsafe")
 try:
     identity = json.loads(identity_path.read_text())
 except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
@@ -307,7 +982,7 @@ for current, directories, names in os.walk(root, topdown=True, followlinks=False
     for name in directories:
         candidate = current_path / name
         relative = candidate.relative_to(root)
-        if name in ignored_directories or identity_name in relative.parts:
+        if name in ignored_directories:
             continue
         metadata = candidate.lstat()
         if stat.S_ISLNK(metadata.st_mode):
@@ -319,7 +994,7 @@ for current, directories, names in os.walk(root, topdown=True, followlinks=False
     for name in names:
         candidate = current_path / name
         relative = candidate.relative_to(root)
-        if identity_name in relative.parts or any(part in ignored_directories for part in relative.parts):
+        if relative == Path(identity_name) or any(part in ignored_directories for part in relative.parts):
             continue
         files.append((relative.as_posix(), candidate))
 
@@ -359,8 +1034,333 @@ supacloud_verify_edge_runtime_source_identity() {
 
 supacloud_edge_runtime_transaction_identity() {
     local transaction_dir="$1"
-    [[ -f "${transaction_dir}/expected-identity" ]] || return 1
+    transaction_dir=$(supacloud_resolve_edge_runtime_source_transaction "$transaction_dir") || return 1
+    supacloud_validate_edge_runtime_transaction "$transaction_dir" || return 1
+    [[ -f "${transaction_dir}/expected-identity" && ! -L "${transaction_dir}/expected-identity" ]] || return 1
     cat "${transaction_dir}/expected-identity"
+}
+
+supacloud_prepare_edge_runtime_source_exchange() {
+    local transaction_dir="$1"
+    local target_dir="$2"
+    local staged_dir="${transaction_dir}/staged"
+    local expected version sha256 staged_tree_sha256
+    local prior_identity="" prior_identity_state prior_state prior_tree_sha256
+
+    [[ -d "$transaction_dir" && ! -L "$transaction_dir" && ! -e "${transaction_dir}.cleanup" && ! -L "${transaction_dir}.cleanup" ]] || return 1
+    supacloud_validate_edge_runtime_transaction "$transaction_dir" || return 1
+    [[ ! -e "${transaction_dir}/exchange-intent.json" && ! -L "${transaction_dir}/exchange-intent.json" ]] || return 1
+    expected=$(supacloud_edge_runtime_transaction_identity "$transaction_dir") || return 1
+    IFS=$'\t' read -r version sha256 <<< "$expected"
+    supacloud_verify_edge_runtime_source_identity "$staged_dir" "$version" "$sha256" || return 1
+    supacloud_prepare_edge_runtime_tree_for_exchange "$staged_dir" || return 1
+    staged_tree_sha256=$(supacloud_stable_edge_runtime_tree_sha256 "$staged_dir") || return 1
+
+    if [[ -e "$target_dir" || -L "$target_dir" ]]; then
+        [[ -d "$target_dir" && ! -L "$target_dir" ]] || return 1
+        prior_state=present
+        prior_tree_sha256=$(supacloud_stable_edge_runtime_tree_sha256 "$target_dir") || return 1
+        prior_identity=$(supacloud_read_edge_runtime_source_identity "$target_dir" 2>/dev/null) || return 1
+        prior_identity_state=verified
+        supacloud_write_edge_runtime_transaction_identity \
+            "$transaction_dir" prior-identity "$prior_identity" || return 1
+    else
+        prior_state=absent
+        prior_identity_state=absent
+        prior_tree_sha256=absent
+    fi
+
+    python3 - "$transaction_dir" "$target_dir" "$expected" "$prior_state" \
+        "$prior_identity_state" "$prior_identity" "$staged_tree_sha256" "$prior_tree_sha256" <<'PY'
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+transaction = Path(sys.argv[1])
+target = Path(sys.argv[2])
+expected_identity = sys.argv[3]
+prior_state = sys.argv[4]
+prior_identity_state = sys.argv[5]
+prior_identity = sys.argv[6] or None
+staged_tree_sha256 = sys.argv[7]
+prior_tree_sha256 = sys.argv[8]
+staged = transaction / "staged"
+
+def directory_node(path: Path) -> dict[str, int]:
+    metadata = path.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or path.is_symlink():
+        raise SystemExit(f"Edge Runtime exchange path must be a real directory: {path}")
+    return {"dev": metadata.st_dev, "ino": metadata.st_ino}
+
+staged_node = directory_node(staged)
+target_node = None
+if prior_state == "present":
+    target_node = directory_node(target)
+    if target_node == staged_node:
+        raise SystemExit("Edge Runtime target and staged directories must be distinct")
+elif prior_state == "absent":
+    if target.exists() or target.is_symlink():
+        raise SystemExit("Edge Runtime target appeared during exchange preparation")
+    parent_node = directory_node(target.parent)
+    if parent_node["dev"] != staged_node["dev"]:
+        raise SystemExit("Edge Runtime first install must remain on one filesystem")
+else:
+    raise SystemExit("Edge Runtime exchange prior state is invalid")
+if (prior_state, prior_identity_state) not in {
+        ("present", "verified"), ("absent", "absent")
+}:
+    raise SystemExit("Edge Runtime exchange prior identity state is invalid")
+if not re.fullmatch(r"[0-9a-f]{64}", staged_tree_sha256):
+    raise SystemExit("Edge Runtime staged tree digest is invalid")
+if prior_state == "present":
+    if not re.fullmatch(r"[0-9a-f]{64}", prior_tree_sha256):
+        raise SystemExit("Edge Runtime prior tree digest is invalid")
+else:
+    if prior_tree_sha256 != "absent":
+        raise SystemExit("Edge Runtime absent prior tree digest is invalid")
+    prior_tree_sha256 = None
+if prior_identity_state == "verified":
+    if not isinstance(prior_identity, str) or not re.fullmatch(
+            r"[0-9]+\.[0-9]+\.[0-9]+\t[0-9a-f]{64}", prior_identity):
+        raise SystemExit("Edge Runtime prior identity is invalid")
+elif prior_identity is not None:
+    raise SystemExit("Absent prior identity must be empty")
+
+payload = {
+    "schemaVersion": 2,
+    "targetPath": str(target.absolute()),
+    "expectedIdentity": expected_identity,
+    "priorState": prior_state,
+    "priorIdentityState": prior_identity_state,
+    "priorIdentity": prior_identity,
+    "stagedTreeSha256": staged_tree_sha256,
+    "priorTreeSha256": prior_tree_sha256,
+    "stagedNode": staged_node,
+    "targetNode": target_node,
+}
+fd, temporary = tempfile.mkstemp(prefix=".exchange-intent.", dir=transaction)
+try:
+    with os.fdopen(fd, "w") as handle:
+        json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, transaction / "exchange-intent.json")
+    directory_fd = os.open(transaction, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+finally:
+    if os.path.exists(temporary):
+        os.unlink(temporary)
+PY
+    supacloud_write_edge_runtime_transaction_state \
+        "$transaction_dir" "exchange-intent-${prior_state}"
+}
+
+supacloud_edge_runtime_exchange_position() {
+    local transaction_dir="$1"
+    local target_dir="$2"
+    transaction_dir=$(supacloud_resolve_edge_runtime_source_transaction "$transaction_dir") || return 1
+    supacloud_validate_edge_runtime_transaction "$transaction_dir" || return 1
+    python3 - "$transaction_dir" "$target_dir" <<'PY'
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+transaction = Path(sys.argv[1])
+target = Path(sys.argv[2])
+intent_path = transaction / "exchange-intent.json"
+intent_metadata = intent_path.lstat()
+if not stat.S_ISREG(intent_metadata.st_mode) or intent_path.is_symlink() \
+        or intent_metadata.st_uid != os.geteuid() or intent_metadata.st_gid != os.getegid() \
+        or stat.S_IMODE(intent_metadata.st_mode) != 0o600 or intent_metadata.st_nlink != 1:
+    raise SystemExit("Edge Runtime exchange intent is unsafe")
+try:
+    intent = json.loads(intent_path.read_text())
+except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+    raise SystemExit(f"Edge Runtime exchange intent is invalid: {error}")
+expected_fields = {
+    "schemaVersion", "targetPath", "expectedIdentity", "priorState", "priorIdentityState",
+    "priorIdentity", "stagedTreeSha256", "priorTreeSha256", "stagedNode", "targetNode",
+}
+if set(intent) != expected_fields or intent.get("schemaVersion") != 2 \
+        or intent.get("targetPath") != str(target.absolute()):
+    raise SystemExit("Edge Runtime exchange intent contract is invalid")
+if intent.get("priorState") not in {"present", "absent"}:
+    raise SystemExit("Edge Runtime exchange intent prior state is invalid")
+if (intent.get("priorState"), intent.get("priorIdentityState")) not in {
+        ("present", "verified"), ("absent", "absent")
+}:
+    raise SystemExit("Edge Runtime exchange intent prior identity state is invalid")
+expected_identity_path = transaction / "expected-identity"
+expected_identity = intent.get("expectedIdentity")
+if not isinstance(expected_identity, str) or not re.fullmatch(
+        r"[0-9]+\.[0-9]+\.[0-9]+\t[0-9a-f]{64}", expected_identity):
+    raise SystemExit("Edge Runtime exchange intent expected identity is invalid")
+if expected_identity != expected_identity_path.read_text().rstrip("\n"):
+    raise SystemExit("Edge Runtime exchange intent identity changed")
+staged_tree_sha256 = intent.get("stagedTreeSha256")
+prior_tree_sha256 = intent.get("priorTreeSha256")
+if not isinstance(staged_tree_sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", staged_tree_sha256):
+    raise SystemExit("Edge Runtime exchange intent staged tree digest is invalid")
+prior_identity_path = transaction / "prior-identity"
+if intent["priorState"] == "present":
+    if not isinstance(prior_tree_sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", prior_tree_sha256):
+        raise SystemExit("Edge Runtime exchange intent prior tree digest is invalid")
+    prior_identity = intent.get("priorIdentity")
+    if not isinstance(prior_identity, str) or not re.fullmatch(
+            r"[0-9]+\.[0-9]+\.[0-9]+\t[0-9a-f]{64}", prior_identity):
+        raise SystemExit("Edge Runtime exchange intent prior identity is invalid")
+    try:
+        recorded_prior_identity = prior_identity_path.read_text().rstrip("\n")
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        raise SystemExit("Edge Runtime transaction prior identity is missing or unreadable")
+    if recorded_prior_identity != prior_identity:
+        raise SystemExit("Edge Runtime exchange intent prior identity changed")
+else:
+    if intent.get("priorIdentity") is not None or prior_tree_sha256 is not None:
+        raise SystemExit("Edge Runtime exchange intent absent prior contract is invalid")
+    if prior_identity_path.exists() or prior_identity_path.is_symlink():
+        raise SystemExit("Edge Runtime absent transaction unexpectedly has a prior identity")
+
+def node(path: Path):
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISDIR(metadata.st_mode) or path.is_symlink():
+        raise SystemExit(f"Edge Runtime exchange path is unsafe: {path}")
+    return {"dev": metadata.st_dev, "ino": metadata.st_ino}
+
+def tree_sha256(root: Path):
+    if root is None:
+        return None
+    try:
+        metadata = root.lstat()
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISDIR(metadata.st_mode) or root.is_symlink():
+        raise SystemExit(f"Edge Runtime exchange tree is unsafe: {root}")
+    entries = [(".", "dir", root, metadata)]
+    pending = [(root, Path("."))]
+    while pending:
+        current, relative_root = pending.pop()
+        with os.scandir(current) as directory:
+            children = list(directory)
+        for child in children:
+            relative = (relative_root / child.name) if relative_root != Path(".") else Path(child.name)
+            relative_name = relative.as_posix()
+            child_metadata = child.stat(follow_symlinks=False)
+            if stat.S_ISDIR(child_metadata.st_mode):
+                entries.append((relative_name, "dir", Path(child.path), child_metadata))
+                pending.append((Path(child.path), relative))
+            elif stat.S_ISREG(child_metadata.st_mode):
+                entries.append((relative_name, "file", Path(child.path), child_metadata))
+            elif stat.S_ISLNK(child_metadata.st_mode):
+                entries.append((relative_name, "symlink", Path(child.path), child_metadata))
+            else:
+                raise SystemExit(f"Edge Runtime exchange tree contains a special entry: {relative_name}")
+    digest = hashlib.sha256()
+    for relative_name, entry_type, path, entry_metadata in sorted(entries, key=lambda item: item[0]):
+        digest.update(entry_type.encode("ascii"))
+        digest.update(b"\0")
+        digest.update(relative_name.encode("utf-8", "surrogateescape"))
+        digest.update(b"\0")
+        digest.update(f"{stat.S_IMODE(entry_metadata.st_mode):04o}".encode("ascii"))
+        digest.update(b"\0")
+        digest.update(str(entry_metadata.st_uid).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(str(entry_metadata.st_gid).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(str(entry_metadata.st_nlink).encode("ascii"))
+        digest.update(b"\0")
+        if entry_type == "file":
+            with path.open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    digest.update(chunk)
+        elif entry_type == "symlink":
+            digest.update(os.fsencode(os.readlink(path)))
+        digest.update(b"\0")
+    first = digest.hexdigest()
+    # Recompute immediately so a concurrent mutation cannot be accepted.
+    second_entries = []
+    pending = [(root, Path("."))]
+    root_metadata = root.lstat()
+    second_entries.append((".", "dir", root, root_metadata))
+    while pending:
+        current, relative_root = pending.pop()
+        with os.scandir(current) as directory:
+            children = list(directory)
+        for child in children:
+            relative = (relative_root / child.name) if relative_root != Path(".") else Path(child.name)
+            child_metadata = child.stat(follow_symlinks=False)
+            if stat.S_ISDIR(child_metadata.st_mode):
+                second_entries.append((relative.as_posix(), "dir", Path(child.path), child_metadata))
+                pending.append((Path(child.path), relative))
+            elif stat.S_ISREG(child_metadata.st_mode):
+                second_entries.append((relative.as_posix(), "file", Path(child.path), child_metadata))
+            elif stat.S_ISLNK(child_metadata.st_mode):
+                second_entries.append((relative.as_posix(), "symlink", Path(child.path), child_metadata))
+            else:
+                raise SystemExit("Edge Runtime exchange tree changed to a special entry")
+    second_digest = hashlib.sha256()
+    for relative_name, entry_type, path, entry_metadata in sorted(second_entries, key=lambda item: item[0]):
+        second_digest.update(entry_type.encode("ascii")); second_digest.update(b"\0")
+        second_digest.update(relative_name.encode("utf-8", "surrogateescape")); second_digest.update(b"\0")
+        second_digest.update(f"{stat.S_IMODE(entry_metadata.st_mode):04o}".encode("ascii")); second_digest.update(b"\0")
+        second_digest.update(str(entry_metadata.st_uid).encode("ascii")); second_digest.update(b"\0")
+        second_digest.update(str(entry_metadata.st_gid).encode("ascii")); second_digest.update(b"\0")
+        second_digest.update(str(entry_metadata.st_nlink).encode("ascii")); second_digest.update(b"\0")
+        if entry_type == "file":
+            with path.open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    second_digest.update(chunk)
+        elif entry_type == "symlink":
+            second_digest.update(os.fsencode(os.readlink(path)))
+        second_digest.update(b"\0")
+    if first != second_digest.hexdigest():
+        raise SystemExit("Edge Runtime exchange tree changed while hashing")
+    return first
+
+staged_node = node(transaction / "staged")
+target_node = node(target)
+staged_tree = tree_sha256(transaction / "staged")
+target_tree = tree_sha256(target)
+prior_state = intent["priorState"]
+before = target_node == intent["targetNode"] and staged_node == intent["stagedNode"]
+if prior_state == "present":
+    after = target_node == intent["stagedNode"] and staged_node == intent["targetNode"]
+else:
+    after = target_node == intent["stagedNode"] and staged_node is None
+if staged_tree is not None and staged_tree not in {staged_tree_sha256, prior_tree_sha256}:
+    raise SystemExit("Edge Runtime staged tree digest does not match transaction intent")
+if target_tree is not None and target_tree not in {staged_tree_sha256, prior_tree_sha256}:
+    raise SystemExit("Edge Runtime target tree digest does not match transaction intent")
+if prior_state == "present":
+    if before and (staged_tree != staged_tree_sha256 or target_tree != prior_tree_sha256):
+        raise SystemExit("Edge Runtime pre-exchange tree digest does not match transaction intent")
+    if after and (target_tree != staged_tree_sha256 or staged_tree != prior_tree_sha256):
+        raise SystemExit("Edge Runtime post-exchange tree digest does not match transaction intent")
+else:
+    if before and (staged_tree != staged_tree_sha256 or target_tree is not None):
+        raise SystemExit("Edge Runtime pre-exchange first-install tree digest is invalid")
+    if after and (target_tree != staged_tree_sha256 or staged_tree is not None):
+        raise SystemExit("Edge Runtime post-exchange first-install tree digest is invalid")
+if before == after:
+    raise SystemExit("Edge Runtime exchange position is ambiguous")
+print(f"{prior_state}\t{'after' if after else 'before'}", end="")
+PY
 }
 
 supacloud_exchange_edge_runtime_directories() {
@@ -395,6 +1395,31 @@ else:
 if result != 0:
     error = ctypes.get_errno()
     raise OSError(error, os.strerror(error))
+for parent in sorted({os.path.dirname(first), os.path.dirname(second)}):
+    descriptor = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+PY
+}
+
+supacloud_move_edge_runtime_directory() {
+    local source_dir="$1"
+    local target_dir="$2"
+    python3 - "$source_dir" "$target_dir" <<'PY'
+import os
+import sys
+
+source = os.fsencode(sys.argv[1])
+target = os.fsencode(sys.argv[2])
+os.rename(source, target)
+for parent in sorted({os.path.dirname(source), os.path.dirname(target)}):
+    descriptor = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 PY
 }
 
@@ -402,21 +1427,45 @@ supacloud_activate_edge_runtime_source() {
     local transaction_dir="$1"
     local target_dir="$2"
     local staged_dir="${transaction_dir}/staged"
-    local expected version sha256 prior_state
+    local expected version sha256 state position prior_state placement
 
+    [[ -d "$transaction_dir" && ! -L "$transaction_dir" && ! -e "${transaction_dir}.cleanup" && ! -L "${transaction_dir}.cleanup" ]] || return 1
     expected=$(supacloud_edge_runtime_transaction_identity "$transaction_dir") || return 1
     IFS=$'\t' read -r version sha256 <<< "$expected"
-    supacloud_verify_edge_runtime_source_identity "$staged_dir" "$version" "$sha256" || return 1
-
-    if [[ -e "$target_dir" || -L "$target_dir" ]]; then
-        [[ -d "$target_dir" && ! -L "$target_dir" ]] || return 1
-        prior_state="present"
-        supacloud_exchange_edge_runtime_directories "$staged_dir" "$target_dir" || return 1
-    else
-        prior_state="absent"
-        mv "$staged_dir" "$target_dir" || return 1
+    [[ -f "${transaction_dir}/state" && ! -L "${transaction_dir}/state" ]] || return 1
+    state=$(<"${transaction_dir}/state") || return 1
+    if [[ ! -e "${transaction_dir}/exchange-intent.json" && ! -L "${transaction_dir}/exchange-intent.json" ]]; then
+        [[ "$state" == prepared ]] || return 1
+        supacloud_prepare_edge_runtime_source_exchange "$transaction_dir" "$target_dir" || return 1
+        state=$(<"${transaction_dir}/state")
     fi
-    printf 'activated-%s\n' "$prior_state" > "${transaction_dir}/state"
+
+    position=$(supacloud_edge_runtime_exchange_position "$transaction_dir" "$target_dir") || return 1
+    IFS=$'\t' read -r prior_state placement <<< "$position"
+    case "$state" in
+        prepared|exchange-intent-present|exchange-intent-absent)
+            [[ "$state" == prepared || "$state" == "exchange-intent-${prior_state}" ]] || return 1
+            if [[ "$placement" == before ]]; then
+                supacloud_verify_edge_runtime_source_identity "$staged_dir" "$version" "$sha256" || return 1
+                if [[ "$prior_state" == present ]]; then
+                    supacloud_exchange_edge_runtime_directories "$staged_dir" "$target_dir" || return 1
+                else
+                    supacloud_move_edge_runtime_directory "$staged_dir" "$target_dir" || return 1
+                fi
+            fi
+            position=$(supacloud_edge_runtime_exchange_position "$transaction_dir" "$target_dir") || return 1
+            [[ "$position" == "${prior_state}"$'\t'after ]] || return 1
+            supacloud_prepare_edge_runtime_tree_for_exchange "$target_dir" || return 1
+            supacloud_write_edge_runtime_transaction_state "$transaction_dir" "activated-${prior_state}" || return 1
+            ;;
+        activated-present|activated-absent)
+            [[ "$state" == "activated-${prior_state}" && "$placement" == after ]] || return 1
+            supacloud_prepare_edge_runtime_tree_for_exchange "$target_dir" || return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 
     if ! supacloud_verify_edge_runtime_source_identity "$target_dir" "$version" "$sha256"; then
         supacloud_rollback_edge_runtime_source "$transaction_dir" "$target_dir" || true
@@ -425,42 +1474,197 @@ supacloud_activate_edge_runtime_source() {
 }
 
 supacloud_rollback_edge_runtime_source() {
-    local transaction_dir="$1"
+    local requested_transaction_dir="$1"
     local target_dir="$2"
-    local staged_dir="${transaction_dir}/staged"
-    local state
-    [[ -d "$transaction_dir" && -f "${transaction_dir}/state" ]] || return 0
+    local transaction_dir cleanup_dir staged_dir
+    local state position prior_state placement prior_identity
+    if [[ ! -e "$requested_transaction_dir" && ! -L "$requested_transaction_dir" ]]; then
+        cleanup_dir="${requested_transaction_dir}.cleanup"
+        if [[ -d "$cleanup_dir" && ! -L "$cleanup_dir" ]]; then
+            transaction_dir="$cleanup_dir"
+        elif [[ -f "${requested_transaction_dir}.outcome" && ! -L "${requested_transaction_dir}.outcome" ]]; then
+            supacloud_validate_edge_runtime_source_transaction_outcome \
+                "$requested_transaction_dir" "$target_dir" rollback || return 1
+            return
+        else
+            return 0
+        fi
+    else
+        transaction_dir="$requested_transaction_dir"
+    fi
+    if ! supacloud_validate_edge_runtime_transaction "$transaction_dir"; then
+        if [[ -f "${requested_transaction_dir}.outcome" && ! -L "${requested_transaction_dir}.outcome" ]] \
+            && supacloud_validate_edge_runtime_source_transaction_outcome \
+                "$requested_transaction_dir" "$target_dir" rollback; then
+            rm -rf -- "$transaction_dir" || return 1
+            python3 - "$(dirname "$requested_transaction_dir")" <<'PY'
+import os
+import sys
+descriptor = os.open(sys.argv[1], os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(descriptor)
+finally:
+    os.close(descriptor)
+PY
+            return
+        fi
+        return 1
+    fi
+    [[ -f "${transaction_dir}/state" && ! -L "${transaction_dir}/state" ]] || return 1
     state=$(<"${transaction_dir}/state")
+    if [[ "$transaction_dir" == *.cleanup ]]; then
+        case "$state" in
+            commit-intent-*)
+                return 1
+                ;;
+            prepared)
+                [[ ! -e "${transaction_dir}/exchange-intent.json" \
+                    && ! -L "${transaction_dir}/exchange-intent.json" ]] || return 1
+                supacloud_finalize_edge_runtime_source_transaction "$requested_transaction_dir" rollback "$target_dir"
+                return
+                ;;
+            rolled-back-*)
+                position=$(supacloud_edge_runtime_exchange_position "$requested_transaction_dir" "$target_dir") || return 1
+                [[ "$position" == "${state#rolled-back-}"$'\t'before ]] || return 1
+                supacloud_finalize_edge_runtime_source_transaction "$requested_transaction_dir" rollback "$target_dir"
+                return
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    fi
+    staged_dir="${transaction_dir}/staged"
+    if [[ ! -e "${transaction_dir}/exchange-intent.json" && ! -L "${transaction_dir}/exchange-intent.json" ]]; then
+        [[ "$state" == prepared ]] || return 1
+        supacloud_finalize_edge_runtime_source_transaction "$transaction_dir" rollback "$target_dir"
+        return
+    fi
+
+    position=$(supacloud_edge_runtime_exchange_position "$transaction_dir" "$target_dir") || return 1
+    IFS=$'\t' read -r prior_state placement <<< "$position"
     case "$state" in
-        prepared)
-            rm -rf -- "$transaction_dir"
+        prepared|exchange-intent-present|exchange-intent-absent)
+            [[ "$state" == prepared || "$state" == "exchange-intent-${prior_state}" ]] || return 1
+            if [[ "$placement" == before ]]; then
+                supacloud_write_edge_runtime_transaction_state \
+                    "$transaction_dir" "rollback-intent-${prior_state}" || return 1
+                state="rollback-intent-${prior_state}"
+            else
+                supacloud_write_edge_runtime_transaction_state \
+                    "$transaction_dir" "activated-${prior_state}" || return 1
+                state="activated-${prior_state}"
+            fi
             ;;
-        activated-present)
-            [[ -d "$target_dir" && ! -L "$target_dir" && -d "$staged_dir" && ! -L "$staged_dir" ]] || return 1
-            supacloud_exchange_edge_runtime_directories "$target_dir" "$staged_dir" || return 1
-            rm -rf -- "$transaction_dir"
+        activated-present|activated-absent)
+            [[ "$state" == "activated-${prior_state}" && "$placement" == after ]] || return 1
             ;;
-        activated-absent)
-            [[ -d "$target_dir" && ! -L "$target_dir" ]] || return 1
-            rm -rf -- "$target_dir"
-            rm -rf -- "$transaction_dir"
+        rollback-intent-present|rollback-intent-absent)
+            [[ "$state" == "rollback-intent-${prior_state}" ]] || return 1
+            ;;
+        rolled-back-present|rolled-back-absent)
+            [[ "$state" == "rolled-back-${prior_state}" && "$placement" == before ]] || return 1
             ;;
         *)
             return 1
             ;;
     esac
+
+    if [[ "$state" != rolled-back-* ]]; then
+        supacloud_write_edge_runtime_transaction_state "$transaction_dir" "rollback-intent-${prior_state}" || return 1
+        if [[ "$placement" == after ]]; then
+            if [[ "$prior_state" == present ]]; then
+                [[ -d "$target_dir" && ! -L "$target_dir" && -d "$staged_dir" && ! -L "$staged_dir" ]] || return 1
+                supacloud_exchange_edge_runtime_directories "$target_dir" "$staged_dir" || return 1
+            else
+                [[ -d "$target_dir" && ! -L "$target_dir" && ! -e "$staged_dir" && ! -L "$staged_dir" ]] || return 1
+                supacloud_move_edge_runtime_directory "$target_dir" "$staged_dir" || return 1
+            fi
+        fi
+        supacloud_write_edge_runtime_transaction_state "$transaction_dir" "rolled-back-${prior_state}" || return 1
+    fi
+
+    position=$(supacloud_edge_runtime_exchange_position "$transaction_dir" "$target_dir") || return 1
+    [[ "$position" == "${prior_state}"$'\t'before ]] || return 1
+    if [[ "$prior_state" == present ]]; then
+        [[ -d "$target_dir" && ! -L "$target_dir" ]] || return 1
+        if [[ -f "${transaction_dir}/prior-identity" ]]; then
+            prior_identity=$(supacloud_edge_runtime_transaction_prior_identity "$transaction_dir") || return 1
+            [[ "$(supacloud_read_edge_runtime_source_identity "$target_dir")" == "$prior_identity" ]] || return 1
+        fi
+    else
+        [[ ! -e "$target_dir" && ! -L "$target_dir" ]] || return 1
+    fi
+    supacloud_finalize_edge_runtime_source_transaction "$transaction_dir" rollback "$target_dir"
 }
 
 supacloud_commit_edge_runtime_source() {
-    local transaction_dir="$1"
+    local requested_transaction_dir="$1"
     local target_dir="$2"
-    local expected version sha256 state
+    local transaction_dir cleanup_dir expected version sha256 state position prior_state placement
+    if [[ ! -e "$requested_transaction_dir" && ! -L "$requested_transaction_dir" ]]; then
+        cleanup_dir="${requested_transaction_dir}.cleanup"
+        if [[ -d "$cleanup_dir" && ! -L "$cleanup_dir" ]]; then
+            transaction_dir="$cleanup_dir"
+        elif [[ -f "${requested_transaction_dir}.outcome" && ! -L "${requested_transaction_dir}.outcome" ]]; then
+            supacloud_validate_edge_runtime_source_transaction_outcome \
+                "$requested_transaction_dir" "$target_dir" commit || return 1
+            return
+        else
+            return 1
+        fi
+    else
+        transaction_dir="$requested_transaction_dir"
+    fi
+    if [[ "$transaction_dir" == *.cleanup ]]; then
+        if ! supacloud_validate_edge_runtime_transaction "$transaction_dir"; then
+            if [[ -f "${requested_transaction_dir}.outcome" && ! -L "${requested_transaction_dir}.outcome" ]] \
+                && supacloud_validate_edge_runtime_source_transaction_outcome \
+                    "$requested_transaction_dir" "$target_dir" commit; then
+                rm -rf -- "$transaction_dir" || return 1
+                python3 - "$(dirname "$requested_transaction_dir")" <<'PY'
+import os
+import sys
+descriptor = os.open(sys.argv[1], os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+try:
+    os.fsync(descriptor)
+finally:
+    os.close(descriptor)
+PY
+                return
+            fi
+            return 1
+        fi
+        state=$(<"${transaction_dir}/state")
+        [[ "$state" == commit-intent-* ]] || return 1
+        position=$(supacloud_edge_runtime_exchange_position "$requested_transaction_dir" "$target_dir") || return 1
+        [[ "$position" == "${state#commit-intent-}"$'\t'after ]] || return 1
+        expected=$(cat "${transaction_dir}/expected-identity") || return 1
+        IFS=$'\t' read -r version sha256 <<< "$expected"
+        supacloud_verify_edge_runtime_source_identity "$target_dir" "$version" "$sha256" || return 1
+        supacloud_prepare_edge_runtime_tree_for_exchange "$target_dir" || return 1
+        supacloud_finalize_edge_runtime_source_transaction "$requested_transaction_dir" commit "$target_dir"
+        return
+    fi
     expected=$(supacloud_edge_runtime_transaction_identity "$transaction_dir") || return 1
     IFS=$'\t' read -r version sha256 <<< "$expected"
     state=$(<"${transaction_dir}/state")
-    [[ "$state" == activated-present || "$state" == activated-absent ]] || return 1
+    [[ -f "${transaction_dir}/exchange-intent.json" && ! -L "${transaction_dir}/exchange-intent.json" ]] || return 1
+    position=$(supacloud_edge_runtime_exchange_position "$transaction_dir" "$target_dir") || return 1
+    IFS=$'\t' read -r prior_state placement <<< "$position"
+    [[ "$placement" == after ]] || return 1
+    case "$state" in
+        prepared|exchange-intent-present|exchange-intent-absent|activated-present|activated-absent|commit-intent-present|commit-intent-absent)
+            [[ "$state" == prepared || "$state" == *"-${prior_state}" ]] || return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
     supacloud_verify_edge_runtime_source_identity "$target_dir" "$version" "$sha256" || return 1
-    rm -rf -- "$transaction_dir"
+    supacloud_prepare_edge_runtime_tree_for_exchange "$target_dir" || return 1
+    supacloud_write_edge_runtime_transaction_state "$transaction_dir" "commit-intent-${prior_state}" || return 1
+    supacloud_finalize_edge_runtime_source_transaction "$transaction_dir" commit "$target_dir"
 }
 
 supacloud_wait_edge_runtime_source_identity() {

--- a/scripts/lib/edge_runtime_source.test.sh
+++ b/scripts/lib/edge_runtime_source.test.sh
@@ -28,6 +28,14 @@ printf '{"name":"@supacloud/edge-runtime","version":"1.0.0"}\n' > "$target/packa
 printf 'old runtime\n' > "$target/server.ts"
 printf 'must be removed\n' > "$target/removed.ts"
 printf 'old dependency\n' > "$target/node_modules/keep-on-rollback.js"
+supacloud_refresh_edge_runtime_source_identity "$target" >/dev/null
+
+reset_target_to_source_one() {
+    rm -rf -- "$target"
+    mkdir -p "$target"
+    cp -R "$source_one"/. "$target"/
+    supacloud_refresh_edge_runtime_source_identity "$target" >/dev/null
+}
 
 transaction=$(supacloud_stage_edge_runtime_source "$source_one" "$target")
 expected=$(supacloud_edge_runtime_transaction_identity "$transaction")
@@ -43,20 +51,169 @@ supacloud_activate_edge_runtime_source "$transaction" "$target"
 supacloud_verify_edge_runtime_source_identity "$target" "$expected_version" "$expected_sha256"
 supacloud_commit_edge_runtime_source "$transaction" "$target"
 [[ ! -e "$transaction" ]]
+[[ "$(supacloud_edge_runtime_source_transaction_outcome "$transaction")" == commit ]]
+supacloud_commit_edge_runtime_source "$transaction" "$target"
+[[ "$(supacloud_edge_runtime_source_transaction_outcome "$transaction")" == commit ]]
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" commit
 
 source_two="$tmp_dir/source-two"
 make_source "$source_two" "1.2.4"
+
+# A pre-activation rollback tombstone resumes from the prepared state.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_remove_edge_runtime_source_transaction "$transaction" rollback "$target"
+[[ ! -e "$transaction" && -d "${transaction}.cleanup" ]]
+[[ "$(<"${transaction}.cleanup/state")" == prepared ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+[[ ! -e "$transaction" && ! -e "${transaction}.cleanup" ]]
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+
 transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
 supacloud_activate_edge_runtime_source "$transaction" "$target"
 grep -Fq '1.2.4' "$target/server.ts"
 supacloud_rollback_edge_runtime_source "$transaction" "$target"
 grep -Fq '1.2.3' "$target/server.ts"
+[[ "$(supacloud_edge_runtime_source_transaction_outcome "$transaction")" == rollback ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+[[ "$(supacloud_edge_runtime_source_transaction_outcome "$transaction")" == rollback ]]
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+
+# Exchange preparation rejects an existing target whose recorded source
+# identity no longer matches its content.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+printf 'tampered prior\n' >> "$target/server.ts"
+if supacloud_prepare_edge_runtime_source_exchange "$transaction" "$target"; then
+    echo "Edge Runtime exchange accepted a tampered prior tree" >&2
+    exit 1
+fi
+rm -rf -- "$transaction" "$transaction.cleanup" "$transaction.outcome"
+reset_target_to_source_one
+
+# A verified present prior tree must retain its identity evidence.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_activate_edge_runtime_source "$transaction" "$target"
+rm "$transaction/prior-identity"
+if supacloud_rollback_edge_runtime_source "$transaction" "$target"; then
+    echo "Edge Runtime rollback accepted a missing prior identity" >&2
+    exit 1
+fi
+rm -rf -- "$transaction" "$transaction.cleanup" "$transaction.outcome"
+reset_target_to_source_one
+
+# Commit verifies the complete quarantined rollback tree, not only its source
+# identity metadata.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_activate_edge_runtime_source "$transaction" "$target"
+printf 'tampered rollback payload\n' >> "$transaction/staged/server.ts"
+if supacloud_commit_edge_runtime_source "$transaction" "$target"; then
+    echo "Edge Runtime commit accepted a tampered rollback tree" >&2
+    exit 1
+fi
+rm -rf -- "$transaction" "$transaction.cleanup" "$transaction.outcome"
+reset_target_to_source_one
+
+# Commit tombstones are resumable and cannot be mistaken for rollback work.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_activate_edge_runtime_source "$transaction" "$target"
+supacloud_write_edge_runtime_transaction_state "$transaction" commit-intent-present
+supacloud_remove_edge_runtime_source_transaction "$transaction" commit "$target"
+[[ ! -e "$transaction" && -d "${transaction}.cleanup" ]]
+if supacloud_rollback_edge_runtime_source "$transaction" "$target"; then
+    echo "Edge Runtime rollback accepted a committed tombstone" >&2
+    exit 1
+fi
+supacloud_commit_edge_runtime_source "$transaction" "$target"
+[[ ! -e "$transaction" && ! -e "${transaction}.cleanup" ]]
+[[ "$(supacloud_edge_runtime_source_transaction_outcome "$transaction")" == commit ]]
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" commit
+grep -Fq '1.2.4' "$target/server.ts"
+transaction=$(supacloud_stage_edge_runtime_source "$source_one" "$target")
+supacloud_activate_edge_runtime_source "$transaction" "$target"
+supacloud_commit_edge_runtime_source "$transaction" "$target"
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" commit
+grep -Fq '1.2.3' "$target/server.ts"
+
+# Rollback tombstones are likewise resumable after a crash during quarantine.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_activate_edge_runtime_source "$transaction" "$target"
+supacloud_write_edge_runtime_transaction_state "$transaction" rollback-intent-present
+supacloud_exchange_edge_runtime_directories "$target" "$transaction/staged"
+supacloud_write_edge_runtime_transaction_state "$transaction" rolled-back-present
+supacloud_remove_edge_runtime_source_transaction "$transaction" rollback "$target"
+[[ ! -e "$transaction" && -d "${transaction}.cleanup" ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+[[ ! -e "$transaction" && ! -e "${transaction}.cleanup" ]]
+[[ "$(supacloud_edge_runtime_source_transaction_outcome "$transaction")" == rollback ]]
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+grep -Fq '1.2.3' "$target/server.ts"
 supacloud_verify_edge_runtime_source_identity "$target" "$expected_version" "$expected_sha256"
+
+# A crash after recording the durable exchange intent but before the atomic
+# exchange can resume activation without losing either tree.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_prepare_edge_runtime_source_exchange "$transaction" "$target"
+[[ "$(<"$transaction/state")" == exchange-intent-present ]]
+[[ "$(supacloud_edge_runtime_exchange_position "$transaction" "$target")" == $'present\tbefore' ]]
+supacloud_activate_edge_runtime_source "$transaction" "$target"
+[[ "$(<"$transaction/state")" == activated-present ]]
+grep -Fq '1.2.4' "$target/server.ts"
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+grep -Fq '1.2.3' "$target/server.ts"
+
+# A durable intent can be rolled back before the forward exchange starts.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_prepare_edge_runtime_source_exchange "$transaction" "$target"
+[[ "$(supacloud_edge_runtime_exchange_position "$transaction" "$target")" == $'present\tbefore' ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+grep -Fq '1.2.3' "$target/server.ts"
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+
+# A crash after the atomic exchange but before the activated-state write is
+# recovered from the recorded directory identities and rolls back safely.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_prepare_edge_runtime_source_exchange "$transaction" "$target"
+supacloud_exchange_edge_runtime_directories "$transaction/staged" "$target"
+[[ "$(<"$transaction/state")" == exchange-intent-present ]]
+[[ "$(supacloud_edge_runtime_exchange_position "$transaction" "$target")" == $'present\tafter' ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+grep -Fq '1.2.3' "$target/server.ts"
+
+# Resuming activation from the same post-exchange crash point records the
+# activated state without performing a second exchange.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+supacloud_prepare_edge_runtime_source_exchange "$transaction" "$target"
+supacloud_exchange_edge_runtime_directories "$transaction/staged" "$target"
+supacloud_activate_edge_runtime_source "$transaction" "$target"
+[[ "$(<"$transaction/state")" == activated-present ]]
+grep -Fq '1.2.4' "$target/server.ts"
+
+# Rollback is also resumable when the reverse exchange completed before its
+# state update was made durable.
+supacloud_write_edge_runtime_transaction_state "$transaction" rollback-intent-present
+supacloud_exchange_edge_runtime_directories "$target" "$transaction/staged"
+[[ "$(supacloud_edge_runtime_exchange_position "$transaction" "$target")" == $'present\tbefore' ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+grep -Fq '1.2.3' "$target/server.ts"
 
 absent_target="$tmp_dir/first-install"
 transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$absent_target")
+supacloud_prepare_edge_runtime_source_exchange "$transaction" "$absent_target"
+[[ "$(supacloud_edge_runtime_exchange_position "$transaction" "$absent_target")" == $'absent\tbefore' ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$absent_target"
+[[ ! -e "$absent_target" ]]
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$absent_target")
 supacloud_activate_edge_runtime_source "$transaction" "$absent_target"
 [[ -d "$absent_target" ]]
+supacloud_rollback_edge_runtime_source "$transaction" "$absent_target"
+[[ ! -e "$absent_target" ]]
+
+# First-install recovery distinguishes a completed move from an unstarted one.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$absent_target")
+supacloud_prepare_edge_runtime_source_exchange "$transaction" "$absent_target"
+mv "$transaction/staged" "$absent_target"
+[[ "$(supacloud_edge_runtime_exchange_position "$transaction" "$absent_target")" == $'absent\tafter' ]]
 supacloud_rollback_edge_runtime_source "$transaction" "$absent_target"
 [[ ! -e "$absent_target" ]]
 
@@ -70,6 +227,20 @@ fi
 printf 'export const runtime = "1.2.4";\n' > "$target/server.ts"
 supacloud_rollback_edge_runtime_source "$transaction" "$target"
 grep -Fq '1.2.3' "$target/server.ts"
+
+# Only the root identity file is metadata. A nested path with the same basename
+# remains part of the source digest and cannot hide a payload change.
+nested_source="$tmp_dir/nested-source"
+make_source "$nested_source" "1.2.7"
+mkdir -p "$nested_source/modules/.supacloud-source-identity.json"
+printf 'nested payload\n' > "$nested_source/modules/.supacloud-source-identity.json/payload.ts"
+supacloud_refresh_edge_runtime_source_identity "$nested_source" >/dev/null
+nested_identity=$(supacloud_read_edge_runtime_source_identity "$nested_source")
+printf 'nested tamper\n' >> "$nested_source/modules/.supacloud-source-identity.json/payload.ts"
+if [[ "$(supacloud_read_edge_runtime_source_identity "$nested_source" 2>/dev/null || true)" == "$nested_identity" ]]; then
+    echo "Nested identity-named payload was excluded from source digest" >&2
+    exit 1
+fi
 
 unsafe_source="$tmp_dir/unsafe-source"
 make_source "$unsafe_source" "1.2.5"
@@ -104,11 +275,96 @@ staged_identity=$(supacloud_edge_runtime_transaction_identity "$transaction")
 chmod 0664 "$transaction/staged/server.ts"
 refreshed_identity=$(supacloud_refresh_edge_runtime_source_identity "$transaction/staged")
 [[ "$refreshed_identity" != "$staged_identity" ]]
-printf '%s\n' "$refreshed_identity" > "$transaction/expected-identity"
+supacloud_write_edge_runtime_transaction_identity \
+    "$transaction" expected-identity "$refreshed_identity"
 IFS=$'\t' read -r refreshed_version refreshed_sha256 <<< "$refreshed_identity"
 supacloud_verify_edge_runtime_source_identity \
     "$transaction/staged" "$refreshed_version" "$refreshed_sha256"
 supacloud_rollback_edge_runtime_source "$transaction" "$target"
+
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+ln "$transaction/expected-identity" "$transaction/expected-identity.hardlink"
+if supacloud_edge_runtime_transaction_identity "$transaction" >/dev/null 2>&1; then
+    echo "Edge Runtime transaction accepted a hard-linked identity file" >&2
+    exit 1
+fi
+rm "$transaction/expected-identity.hardlink"
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+for temporary in .state.crash .expected-identity.crash .prior-identity.crash .exchange-intent.crash; do
+    printf 'orphaned writer temp\n' > "$transaction/$temporary"
+    chmod 0600 "$transaction/$temporary"
+done
+supacloud_edge_runtime_transaction_identity "$transaction" >/dev/null
+for temporary in .state.crash .expected-identity.crash .prior-identity.crash .exchange-intent.crash; do
+    [[ ! -e "$transaction/$temporary" ]]
+done
+ln -s /etc/passwd "$transaction/.state.unsafe"
+if supacloud_edge_runtime_transaction_identity "$transaction" >/dev/null 2>&1; then
+    echo "Edge Runtime transaction accepted an unsafe orphaned temporary file" >&2
+    exit 1
+fi
+rm "$transaction/.state.unsafe"
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+
+# Missing state is never inferred from the remaining directory contents.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+rm "$transaction/state"
+if supacloud_activate_edge_runtime_source "$transaction" "$target" >/dev/null 2>&1; then
+    echo "Edge Runtime activation accepted a transaction without state" >&2
+    exit 1
+fi
+if supacloud_rollback_edge_runtime_source "$transaction" "$target" >/dev/null 2>&1; then
+    echo "Edge Runtime rollback accepted a transaction without state" >&2
+    exit 1
+fi
+rm -rf -- "$transaction" "$transaction.cleanup" "$transaction.outcome"
+
+# Safe orphaned outcome-writer files are removed durably; unsafe aliases fail
+# closed before the transaction can be finalized.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+outcome_temporary="$(dirname "$transaction")/.$(basename "$transaction").outcome.crash"
+printf 'orphaned outcome writer\n' > "$outcome_temporary"
+chmod 0600 "$outcome_temporary"
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+[[ ! -e "$outcome_temporary" ]]
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+outcome_temporary="$(dirname "$transaction")/.$(basename "$transaction").outcome.unsafe"
+ln -s /etc/passwd "$outcome_temporary"
+if supacloud_rollback_edge_runtime_source "$transaction" "$target" >/dev/null 2>&1; then
+    echo "Edge Runtime rollback accepted an unsafe outcome temporary file" >&2
+    exit 1
+fi
+rm "$outcome_temporary"
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+
+# A deployable staged tree is private, owned by the installer, and detached
+# from hard-linked package-manager cache files.
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+external_link="$tmp_dir/staged-server-hardlink"
+ln "$transaction/staged/server.ts" "$external_link"
+if supacloud_prepare_edge_runtime_source_exchange "$transaction" "$target" >/dev/null 2>&1; then
+    echo "Edge Runtime exchange accepted a hard-linked staged file" >&2
+    exit 1
+fi
+rm "$external_link"
+supacloud_rollback_edge_runtime_source "$transaction" "$target"
+supacloud_clear_edge_runtime_source_transaction_outcome "$transaction" rollback
+
+transaction=$(supacloud_stage_edge_runtime_source "$source_two" "$target")
+chmod 0666 "$transaction/staged/server.ts"
+refreshed_identity=$(supacloud_refresh_edge_runtime_source_identity "$transaction/staged")
+supacloud_write_edge_runtime_transaction_identity \
+    "$transaction" expected-identity "$refreshed_identity"
+if supacloud_prepare_edge_runtime_source_exchange "$transaction" "$target" >/dev/null 2>&1; then
+    echo "Edge Runtime exchange accepted a group/other-writable staged file" >&2
+    exit 1
+fi
+rm -rf -- "$transaction" "$transaction.cleanup" "$transaction.outcome"
 
 health_sha256="$expected_sha256"
 curl() {


### PR DESCRIPTION
## Summary
- harden embedded Edge Runtime source transaction marker and outcome validation
- make rollback/recovery idempotent and fail closed across interrupted commits
- preserve runtime source access and stable BFF secret handling during installer recovery

## Validation
- `bash -n install.sh scripts/lib/edge_runtime_source.sh`
- `bash scripts/lib/edge_runtime_source.test.sh`
- `bun test --isolate packages/management-api/tests/unit/install-config.test.ts` (61 pass, 0 fail)