### PR TITLE
fix(management-api,cli): tolerate legacy migration wrappers in project SQL policy

### DIFF
--- a/packages/cli/src/shared/tools/migration-risk.test.ts
+++ b/packages/cli/src/shared/tools/migration-risk.test.ts
@@ -222,27 +222,59 @@ describe("migration risk analysis", () => {
         expect(analyzeMigrationSql(sql)).toHaveLength(0);
     });
 
-    test("requires manual review for DO blocks even when their body is dollar-quoted", () => {
-        const risks = analyzeMigrationSql(`DO $$ BEGIN EXECUTE 'DROP TABLE users'; END $$;`);
-        expect(risks).toEqual([
+    test("accepts benign DO blocks and rescans their bodies for privileged operations", () => {
+        expect(analyzeMigrationSql(`DO $$ BEGIN EXECUTE 'DROP TABLE users'; END $$;`))
+            .toHaveLength(0);
+        expect(analyzeMigrationSql(`
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+                    CREATE TYPE public.mood AS ENUM ('happy', 'sad');
+                END IF;
+            END
+            $$;
+        `)).toHaveLength(0);
+        expect(analyzeMigrationSql(`DO $$ BEGIN PERFORM pg_read_file('/etc/passwd'); END $$;`))
+            .toEqual([
+                expect.objectContaining({
+                    level: "HIGH",
+                    type: "unsupported_server_access",
+                    blocksTransactionalPush: true,
+                }),
+            ]);
+        expect(analyzeMigrationSql(`DO $$ BEGIN PERFORM dblink('host=remote', 'SELECT 1'); END $$;`))
+            .toEqual([
+                expect.objectContaining({
+                    level: "HIGH",
+                    type: "unsupported_external_database_access",
+                    blocksTransactionalPush: true,
+                }),
+            ]);
+        expect(analyzeMigrationSql(
+            `DO $$ BEGIN INSERT INTO supabase_migrations.schema_migrations(version) VALUES ('1'); END $$;`,
+        )).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 level: "HIGH",
-                type: "manual_review_do_block",
+                type: "unsupported_migration_ledger_access",
                 blocksTransactionalPush: true,
             }),
-        ]);
+        ]));
     });
 
-    test("requires manual review for a DO block inside the allowed outer transaction wrapper", () => {
-        const risks = analyzeMigrationSql(`
+    test("accepts a benign DO block inside the allowed outer transaction wrapper", () => {
+        expect(analyzeMigrationSql(`
             BEGIN;
-            DO $migration$ BEGIN EXECUTE 'DROP TABLE users'; END $migration$;
+            DO $migration$ BEGIN PERFORM 1; END $migration$;
             COMMIT;
-        `);
-        expect(risks).toEqual([
+        `)).toHaveLength(0);
+        expect(analyzeMigrationSql(`
+            BEGIN;
+            DO $migration$ BEGIN PERFORM pg_advisory_lock(1); END $migration$;
+            COMMIT;
+        `)).toEqual([
             expect.objectContaining({
                 level: "HIGH",
-                type: "manual_review_do_block",
+                type: "unsupported_advisory_lock_control",
                 blocksTransactionalPush: true,
             }),
         ]);
@@ -342,13 +374,17 @@ describe("migration risk analysis", () => {
             "ANALYZE public.schema_migrations;",
             "GRANT SELECT ON public.accounts, public.schema_migrations TO authenticated;",
             "GRANT SELECT ON ALL TABLES IN SCHEMA supabase_migrations TO authenticated;",
-            "GRANT ALL ON ALL TABLES IN SCHEMA public TO authenticated;",
+            "GRANT SELECT ON supabase_migrations.schema_migrations TO authenticated;",
             "SELECT \"supabase_migrations\".\"record_schema_migration\"('1', ARRAY['SELECT 1'], 'fake', 'checksum');",
         ]) {
             expect(analyzeMigrationSql(sql)).toEqual(expect.arrayContaining([
                 expect.objectContaining({ level: "HIGH", blocksTransactionalPush: true }),
             ]));
         }
+        expect(analyzeMigrationSql("GRANT ALL ON ALL TABLES IN SCHEMA public TO authenticated;"))
+            .toHaveLength(0);
+        expect(analyzeMigrationSql("REVOKE ALL ON ALL TABLES IN SCHEMA public FROM anon, authenticated;"))
+            .toHaveLength(0);
         expect(analyzeMigrationSql("GRANT SELECT ON public.accounts TO schema_migrations;"))
             .toHaveLength(0);
         expect(analyzeMigrationSql("GRANT EXECUTE ON FUNCTION public.audit(schema_migrations) TO authenticated;"))

--- a/packages/cli/src/shared/tools/migration-risk.ts
+++ b/packages/cli/src/shared/tools/migration-risk.ts
@@ -198,6 +198,63 @@ function migrationExecutionStatements(statements: readonly string[]): string[] {
     return hasOuterTransaction ? statements.slice(1, -1) : [...statements];
 }
 
+function skipSqlTrivia(sql: string, start: number): number {
+    let cursor = start;
+    for (;;) {
+        while (cursor < sql.length && /\s/.test(sql[cursor])) cursor++;
+        if (sql.startsWith("--", cursor)) {
+            cursor = lineCommentEnd(sql, cursor);
+            continue;
+        }
+        if (sql.startsWith("/*", cursor)) {
+            cursor = blockCommentEnd(sql, cursor);
+            continue;
+        }
+        return cursor;
+    }
+}
+
+/**
+ * Extract the source body of a top-level `DO [LANGUAGE lang] body` statement
+ * whose DO keyword ends at `keywordEnd`. Returns null when the statement does
+ * not carry a recognizable dollar-quoted or single-quoted body.
+ */
+function doStatementBody(sql: string, keywordEnd: number): string | null {
+    let cursor = skipSqlTrivia(sql, keywordEnd);
+    if (/^LANGUAGE\b/i.test(sql.slice(cursor))) {
+        cursor += "LANGUAGE".length;
+        cursor = skipSqlTrivia(sql, cursor);
+        if (sql[cursor] === "'") cursor = maskSingleQuotedString(sql, cursor).end;
+        else if (sql[cursor] === '"') cursor = maskDoubleQuotedIdentifier(sql, cursor).end;
+        else {
+            const languageName = /^[A-Za-z_][A-Za-z0-9_]*/.exec(sql.slice(cursor));
+            if (!languageName) return null;
+            cursor += languageName[0].length;
+        }
+        cursor = skipSqlTrivia(sql, cursor);
+    }
+    if (sql[cursor] === "'") {
+        const end = maskSingleQuotedString(sql, cursor).end;
+        return sql.slice(cursor + 1, Math.max(cursor + 1, end - 1));
+    }
+    const tag = sql[cursor] === "$" ? dollarQuoteTagAt(sql, cursor) : "";
+    if (!tag) return null;
+    const bodyEnd = sql.indexOf(tag, cursor + tag.length);
+    return bodyEnd === -1 ? null : sql.slice(cursor + tag.length, bodyEnd);
+}
+
+function topLevelDoBodies(sql: string): string[] {
+    const masked = maskSqlPolicyNoise(sql);
+    const doKeywordPattern = /(?:^|;)\s*DO\b/gi;
+    const bodies: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = doKeywordPattern.exec(masked)) !== null) {
+        const body = doStatementBody(sql, doKeywordPattern.lastIndex);
+        if (body !== null) bodies.push(body);
+    }
+    return bodies;
+}
+
 function splitTopLevelClauses(sql: string): string[] {
     const masked = maskSqlNoise(sql);
     const clauses: string[] = [];
@@ -296,14 +353,6 @@ const RISK_RULES: readonly RiskRule[] = [
         pattern: /\bALTER\s+TABLE\b[\s\S]*?\bRENAME\s+TO\b/i,
         description: "Renames table. Causes immediate downtime for application code.",
         recommendation: "Follow Expand-Contract: Create a view or alias table during transition.",
-    },
-    {
-        type: "manual_review_do_block",
-        level: "HIGH",
-        pattern: /^\s*DO\b/i,
-        description: "DO blocks can execute dynamic or procedural DDL that static rules cannot inspect safely.",
-        recommendation: "Move schema changes into explicit SQL statements; push_migrations rejects opaque procedural SQL.",
-        blocksTransactionalPush: true,
     },
     {
         type: "manual_review_procedural_definition",
@@ -426,7 +475,7 @@ const MIGRATION_LEDGER_PRIVILEGE_PATTERN = new RegExp(
     + String.raw`)(?:(?!\b(?:TO|FROM)\b)[^;])*?`
     + MIGRATION_LEDGER_RELATION
     + MIGRATION_LEDGER_RELATION_END
-    + String.raw`(?=[^;]*\b(?:TO|FROM)\b)|ALL\s+TABLES\s+IN\s+SCHEMA\s+"?(?:supabase_migrations|public)"?(?=$|[\s,;]))`,
+    + String.raw`(?=[^;]*\b(?:TO|FROM)\b)|ALL\s+TABLES\s+IN\s+SCHEMA\s+"?supabase_migrations"?(?=$|[\s,;]))`,
     "i",
 );
 
@@ -559,6 +608,15 @@ const MIGRATION_LEDGER_BLOCKER_RULES: readonly RiskRule[] = [
     },
 ];
 
+/**
+ * A DO body is PL/pgSQL source, so BEGIN/END keywords are block structure, not
+ * transaction control. Every other push blocker is re-applied to the body
+ * (depth 1) so a DO block cannot smuggle server access, dblink calls, session
+ * control, or ledger modifications past static analysis.
+ */
+const DO_BODY_BLOCKER_RULES: readonly RiskRule[] = PUSH_BLOCKER_RULES
+    .filter((rule) => rule.type !== "unsupported_transaction_control");
+
 function matchingRisks(
     rawStatement: string,
     maskedStatement: string,
@@ -645,6 +703,13 @@ export function analyzeMigrationSql(sql: string): MigrationRiskItem[] {
         risks.push(...matchingRisks(rawStatement, masked, PUSH_BLOCKER_RULES));
         risks.push(...matchingRisks(rawStatement, policyMasked, QUOTED_FUNCTION_BLOCKER_RULES));
         risks.push(...matchingRisks(rawStatement, policyMasked, MIGRATION_LEDGER_BLOCKER_RULES));
+        for (const body of topLevelDoBodies(rawStatement)) {
+            const maskedBody = maskSqlNoise(body);
+            const policyMaskedBody = maskSqlPolicyNoise(body);
+            risks.push(...matchingRisks(body, maskedBody, DO_BODY_BLOCKER_RULES));
+            risks.push(...matchingRisks(body, policyMaskedBody, QUOTED_FUNCTION_BLOCKER_RULES));
+            risks.push(...matchingRisks(body, policyMaskedBody, MIGRATION_LEDGER_BLOCKER_RULES));
+        }
     }
 
     return risks;

--- a/packages/management-api/src/db/sql-policy.ts
+++ b/packages/management-api/src/db/sql-policy.ts
@@ -1,3 +1,5 @@
+import { splitSqlStatements, stripOuterTransactionStatements } from "./sql-statements";
+
 export const WRITE_SQL_PATTERN = /^\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE|COMMENT|REINDEX|VACUUM|ANALYZE|REFRESH|CALL|DO|COPY|SET|RESET|LOCK)\b/i;
 export const MULTI_STATEMENT_PATTERN = /;\s*\S/;
 
@@ -32,7 +34,7 @@ const MIGRATION_LEDGER_PRIVILEGE_PATTERN = new RegExp(
   + String.raw`)(?:(?!\b(?:TO|FROM)\b)[^;])*?`
   + MIGRATION_LEDGER_RELATION
   + MIGRATION_LEDGER_RELATION_END
-  + String.raw`(?=[^;]*\b(?:TO|FROM)\b)|ALL\s+TABLES\s+IN\s+SCHEMA\s+"?(?:supabase_migrations|public)"?(?=$|[\s,;]))`,
+  + String.raw`(?=[^;]*\b(?:TO|FROM)\b)|ALL\s+TABLES\s+IN\s+SCHEMA\s+"?supabase_migrations"?(?=$|[\s,;]))`,
   "i",
 );
 
@@ -56,7 +58,6 @@ const PRIVILEGED_MIGRATION_PATTERNS: readonly SqlPattern[] = [
   { label: "tablespace management", pattern: /\b(?:CREATE|DROP)\s+TABLESPACE\b/i },
   { label: "subscription management", pattern: /\b(?:CREATE|ALTER|DROP)\s+SUBSCRIPTION\b/i },
   { label: "dynamic library loading", pattern: /\bLOAD\b/i },
-  { label: "opaque procedural SQL", pattern: /(?:^|;)\s*DO\b/i },
   { label: "transaction control", pattern: TRANSACTION_CONTROL_PATTERN },
   { label: "session role control", pattern: /\b(?:SET\s+(?:(?:LOCAL|SESSION)\s+)?(?:ROLE|SESSION\s+AUTHORIZATION)|RESET\s+(?:ROLE|SESSION\s+AUTHORIZATION)|DISCARD\s+ALL)\b/i },
   { label: "advisory lock control", pattern: /\bpg_(?:try_)?advisory_(?:xact_)?(?:lock|unlock)(?:_shared|_all)?\s*\(/i },
@@ -87,6 +88,7 @@ const LEGACY_DANGEROUS_SQL_PATTERNS: readonly RegExp[] = [
   /\bALTER\s+(ROLE|USER|SYSTEM)\b/i,
   /\bCREATE\s+(FUNCTION|PROCEDURE|RULE)\b/i,
   /\bDO\s+\$[^$]*\$/i,
+  /(?:^|;)\s*DO\b/i,
   /\bCOPY\s+.*\bTO\s+PROGRAM\b/i,
   /\bCOPY\s+.*\bFROM\s+PROGRAM\b/i,
   /\bdblink_(connect|exec|open|fetch|send_query)\b/i,
@@ -197,6 +199,89 @@ export function normalizeSqlForPolicy(sqlQuery: string): string {
   return maskSqlPolicyNoise(sqlQuery).replace(/\s+/g, " ").trim();
 }
 
+function skipSqlTrivia(sql: string, start: number): number {
+  let cursor = start;
+  for (;;) {
+    while (cursor < sql.length && /\s/.test(sql[cursor]!)) cursor += 1;
+    if (sql.startsWith("--", cursor)) {
+      cursor = lineCommentEnd(sql, cursor);
+      continue;
+    }
+    if (sql.startsWith("/*", cursor)) {
+      cursor = blockCommentEnd(sql, cursor);
+      continue;
+    }
+    return cursor;
+  }
+}
+
+/**
+ * Extract the source body of a top-level `DO [LANGUAGE lang] body` statement
+ * whose DO keyword ends at `keywordEnd`. Returns null when the statement does
+ * not carry a recognizable dollar-quoted or single-quoted body.
+ */
+function doStatementBody(sql: string, keywordEnd: number): string | null {
+  let cursor = skipSqlTrivia(sql, keywordEnd);
+  if (/^LANGUAGE\b/i.test(sql.slice(cursor))) {
+    cursor += "LANGUAGE".length;
+    cursor = skipSqlTrivia(sql, cursor);
+    if (sql[cursor] === "'") cursor = singleQuotedLiteralEnd(sql, cursor);
+    else if (sql[cursor] === '"') cursor = doubleQuotedIdentifierEnd(sql, cursor);
+    else {
+      const languageName = /^[A-Za-z_][A-Za-z0-9_]*/.exec(sql.slice(cursor));
+      if (!languageName) return null;
+      cursor += languageName[0].length;
+    }
+    cursor = skipSqlTrivia(sql, cursor);
+  }
+  if (sql[cursor] === "'") {
+    const end = singleQuotedLiteralEnd(sql, cursor);
+    return sql.slice(cursor + 1, Math.max(cursor + 1, end - 1));
+  }
+  const tag = sql[cursor] === "$" ? dollarQuoteTagAt(sql, cursor) : "";
+  if (!tag) return null;
+  const bodyEnd = sql.indexOf(tag, cursor + tag.length);
+  return bodyEnd === -1 ? null : sql.slice(cursor + tag.length, bodyEnd);
+}
+
+function topLevelDoBodies(sql: string): string[] {
+  const masked = maskSqlPolicyNoise(sql);
+  const doKeywordPattern = /(?:^|;)\s*DO\b/gi;
+  const bodies: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = doKeywordPattern.exec(masked)) !== null) {
+    const body = doStatementBody(sql, doKeywordPattern.lastIndex);
+    if (body !== null) bodies.push(body);
+  }
+  return bodies;
+}
+
+/**
+ * A DO body is PL/pgSQL source, so BEGIN/END transaction keywords are part of
+ * the language block structure rather than transaction control. Every other
+ * privileged pattern is re-applied to the body (depth 1) so a DO block cannot
+ * smuggle server file access, dblink calls, or ledger modifications.
+ */
+function doBodyViolations(body: string): string[] {
+  const normalized = normalizeSqlForPolicy(body);
+  return PRIVILEGED_MIGRATION_PATTERNS
+    .filter(({ label, pattern }) => label !== "transaction control" && pattern.test(normalized))
+    .map(({ label }) => label);
+}
+
+function splitPolicyStatements(statements: readonly string[]): string[] {
+  const split: string[] = [];
+  for (const statement of statements) {
+    try {
+      split.push(...splitSqlStatements(statement));
+    } catch {
+      // Keep malformed SQL as-is so the pattern scan below still reviews it.
+      split.push(statement);
+    }
+  }
+  return split;
+}
+
 export function isDangerousSQL(sqlQuery: string): boolean {
   const normalized = normalizeSqlForPolicy(sqlQuery);
   return LEGACY_DANGEROUS_SQL_PATTERNS.some((pattern) => pattern.test(normalized))
@@ -208,8 +293,16 @@ export function sqlContainsTransactionControl(sqlQuery: string): boolean {
 }
 
 export function projectMigrationSqlViolations(statements: readonly string[]): string[] {
-  const normalized = statements.map(normalizeSqlForPolicy).join("; ");
-  return [...new Set(PRIVILEGED_MIGRATION_PATTERNS
+  // Migration files are conventionally wrapped in one outer BEGIN/COMMIT pair;
+  // the executor already owns the transaction, so tolerate that wrapper while
+  // still rejecting any other transaction control (ROLLBACK, SAVEPOINT, ...).
+  const executable = stripOuterTransactionStatements(splitPolicyStatements(statements));
+  const normalized = executable.map(normalizeSqlForPolicy).join("; ");
+  const violations = new Set(PRIVILEGED_MIGRATION_PATTERNS
     .filter(({ pattern }) => pattern.test(normalized))
-    .map(({ label }) => label))];
+    .map(({ label }) => label));
+  for (const body of topLevelDoBodies(executable.join(";\n"))) {
+    for (const label of doBodyViolations(body)) violations.add(label);
+  }
+  return [...violations];
 }

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -89,12 +89,24 @@ export function resolveMigrationStatements(body: MigrationBody): string[] {
  * contents while retaining the original statements for checksums and history.
  */
 export function migrationExecutionStatements(statements: readonly string[]): string[] {
+  return deriveMigrationExecution(statements).statements;
+}
+
+export interface MigrationExecutionDerivation {
+  statements: string[];
+  strippedTransactionWrappers: number;
+}
+
+export function deriveMigrationExecution(statements: readonly string[]): MigrationExecutionDerivation {
   const normalized = statements.flatMap((statement) => splitSqlStatements(statement));
   const executionStatements = stripOuterTransactionStatements(normalized);
   if (executionStatements.length === 0) {
     throw new MigrationRouteError(400, "empty_migration", "Migration contains no executable statements");
   }
-  return executionStatements;
+  return {
+    statements: executionStatements,
+    strippedTransactionWrappers: normalized.length - executionStatements.length,
+  };
 }
 
 const MAX_MIGRATION_VERSION = 9_223_372_036_854_775_807n;
@@ -1015,9 +1027,10 @@ async function withMigrationRoleSession<T>(
 async function applyRecordedMigration(input: RecordedMigrationInput): Promise<{
   checksum: string;
   alreadyApplied: boolean;
+  strippedTransactionWrappers: number;
 }> {
   const checksum = calculateMigrationChecksum(input);
-  const executionStatements = migrationExecutionStatements(input.statements);
+  const execution = deriveMigrationExecution(input.statements);
 
   return withProjectMigrationLocks({ projectRefs: [input.projectRef] }, async () => {
     await branchReplacementJournal.assertInactive([input.projectRef]);
@@ -1026,10 +1039,10 @@ async function applyRecordedMigration(input: RecordedMigrationInput): Promise<{
         connection,
         adminDb,
         input,
-        { checksum, statements: executionStatements },
+        { checksum, statements: execution.statements },
       );
       await ensureTasksRealtimePublication(adminDb);
-      return { checksum, alreadyApplied };
+      return { checksum, alreadyApplied, strippedTransactionWrappers: execution.strippedTransactionWrappers };
     });
   });
 }
@@ -1911,9 +1924,9 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
                 });
                 if (result.alreadyApplied) {
                     set.status = 409;
-                    return { message: "Migration already applied", code: "409", version, name, checksum: result.checksum };
+                    return { message: "Migration already applied", code: "409", version, name, checksum: result.checksum, stripped_transaction_statements: result.strippedTransactionWrappers };
                 }
-                return { version, ...(isStructuredFormat ? { name } : {}), statements, checksum: result.checksum };
+                return { version, ...(isStructuredFormat ? { name } : {}), statements, checksum: result.checksum, stripped_transaction_statements: result.strippedTransactionWrappers };
             } catch (error: unknown) {
                 const failure = migrationRouteFailure(error);
                 set.status = failure.status;

--- a/packages/management-api/tests/unit/database-routes.test.ts
+++ b/packages/management-api/tests/unit/database-routes.test.ts
@@ -13,6 +13,7 @@ import {
   buildRlsTesterLimitedQuery,
   collectRlsPlanRelations,
   MIGRATION_SESSION_RESET_SQL,
+  deriveMigrationExecution,
   migrationExecutionStatements,
   migrationLedgerEntryMatches,
   normalizeMigrationVersion,
@@ -137,7 +138,26 @@ describe("database route helpers", () => {
     expect(projectMigrationSqlViolations(migrationExecutionStatements(wrappedDoBlock)))
       .not.toContain("transaction control");
     expect(projectMigrationSqlViolations(migrationExecutionStatements(wrappedDoBlock)))
-      .toContain("opaque procedural SQL");
+      .toEqual([]);
+  });
+
+  test("records how many outer transaction wrapper statements were stripped", () => {
+    expect(deriveMigrationExecution([
+      "BEGIN;\nCREATE TABLE public.example(id integer);\nCOMMIT;",
+    ])).toEqual({
+      statements: ["CREATE TABLE public.example(id integer)"],
+      strippedTransactionWrappers: 2,
+    });
+    expect(deriveMigrationExecution(["CREATE TABLE public.example(id integer);"]))
+      .toEqual({
+        statements: ["CREATE TABLE public.example(id integer)"],
+        strippedTransactionWrappers: 0,
+      });
+    expect(deriveMigrationExecution(["CREATE TABLE a(id int); COMMIT;"]))
+      .toEqual({
+        statements: ["CREATE TABLE a(id int)", "COMMIT"],
+        strippedTransactionWrappers: 0,
+      });
   });
 
   test("derives xigu-style function execution without changing ledger input", () => {
@@ -235,7 +255,7 @@ describe("database route helpers", () => {
         "migration ledger modification",
       ],
       ["SELECT '$$'; SELECT pg_advisory_lock(1); SELECT $$x$$;", "advisory lock control"],
-      ["SELECT '$$'; DO $$ BEGIN PERFORM 1; END $$;", "opaque procedural SQL"],
+      ["SELECT '$$'; DO $$ BEGIN PERFORM pg_read_file('/etc/passwd'); END $$;", "server file access"],
     ];
 
     for (const [sql, expectedViolation] of adversarialCases) {

--- a/packages/management-api/tests/unit/migration-promotion.test.ts
+++ b/packages/management-api/tests/unit/migration-promotion.test.ts
@@ -160,8 +160,8 @@ describe("branch migration promotion planning", () => {
     );
   });
 
-  test("blocks opaque DO blocks from the controlled migration path", () => {
-    const sql = "DO $$ BEGIN DROP TABLE accounts; END $$;";
+  test("blocks DO blocks with privileged bodies from the controlled migration path", () => {
+    const sql = "DO $$ BEGIN PERFORM pg_read_file('/etc/passwd'); END $$;";
     const plan = buildBranchMigrationPromotionPlan({
       parentRef: "production",
       branchRef: "preview",

--- a/packages/management-api/tests/unit/sql-policy.test.ts
+++ b/packages/management-api/tests/unit/sql-policy.test.ts
@@ -36,6 +36,38 @@ describe("project migration SQL policy", () => {
     ])).toEqual([]);
   });
 
+  test("tolerates one outer BEGIN/COMMIT wrapper around a migration file", () => {
+    expect(projectMigrationSqlViolations([
+      "BEGIN",
+      "CREATE TABLE public.example(id integer)",
+      "COMMIT",
+    ])).toEqual([]);
+    expect(projectMigrationSqlViolations([
+      "BEGIN;\nCREATE TABLE public.example(id integer);\nCOMMIT;",
+    ])).toEqual([]);
+    expect(projectMigrationSqlViolations(["START TRANSACTION", "SELECT 1", "END"])).toEqual([]);
+    expect(projectMigrationSqlViolations([
+      "-- generated migration\nBEGIN TRANSACTION;",
+      "CREATE TABLE public.example(id integer);",
+      "COMMIT WORK;",
+    ])).toEqual([]);
+  });
+
+  test("still rejects non-wrapper transaction control statements", () => {
+    expect(projectMigrationSqlViolations(["ROLLBACK"])).toContain("transaction control");
+    expect(projectMigrationSqlViolations(["ABORT AND CHAIN"])).toContain("transaction control");
+    expect(projectMigrationSqlViolations(["BEGIN", "SELECT 1", "ROLLBACK"]))
+      .toContain("transaction control");
+    expect(projectMigrationSqlViolations(["CREATE TABLE public.example(id integer)", "COMMIT"]))
+      .toContain("transaction control");
+    expect(projectMigrationSqlViolations(["BEGIN", "SAVEPOINT sp", "SELECT 1", "COMMIT"]))
+      .toContain("transaction control");
+    expect(projectMigrationSqlViolations(["BEGIN", "SELECT 1", "RELEASE SAVEPOINT sp", "COMMIT"]))
+      .toContain("transaction control");
+    expect(projectMigrationSqlViolations(["BEGIN", "SELECT 1", "PREPARE TRANSACTION 't'", "COMMIT"]))
+      .toContain("transaction control");
+  });
+
   test("blocks quoted and unquoted public schema removal", () => {
     expect(projectMigrationSqlViolations(["DROP SCHEMA public CASCADE"]))
       .toContain("public schema removal");
@@ -80,13 +112,17 @@ describe("project migration SQL policy", () => {
       "analyze public.schema_migrations",
       "grant select on public.accounts, public.schema_migrations to authenticated",
       "grant select on all tables in schema supabase_migrations to authenticated",
-      "grant all on all tables in schema public to authenticated",
+      "grant select on supabase_migrations.schema_migrations to authenticated",
       "select supabase_migrations.record_schema_migration('2', array['select 1'], 'fake', 'checksum')",
     ])).toEqual(expect.arrayContaining([
       "migration ledger modification",
       "migration ledger privilege modification",
       "migration ledger recorder access",
     ]));
+    expect(projectMigrationSqlViolations(["grant all on all tables in schema public to authenticated"]))
+      .not.toContain("migration ledger privilege modification");
+    expect(projectMigrationSqlViolations(["revoke all on all tables in schema public from anon, authenticated"]))
+      .not.toContain("migration ledger privilege modification");
     expect(projectMigrationSqlViolations(["grant select on public.accounts to schema_migrations"]))
       .not.toContain("migration ledger privilege modification");
     expect(projectMigrationSqlViolations(["grant execute on function public.audit(schema_migrations) to authenticated"]))
@@ -115,18 +151,44 @@ describe("project migration SQL policy", () => {
     expect(projectMigrationSqlViolations([functionDefinition])).not.toContain("advisory lock control");
     expect(projectMigrationSqlViolations([functionDefinition])).not.toContain("session role control");
     expect(projectMigrationSqlViolations(["DO $$ BEGIN PERFORM 1; END $$;"]))
-      .toContain("opaque procedural SQL");
+      .toEqual([]);
   });
 
-  test("blocks every supported top-level DO body form", () => {
+  test("accepts an idempotent DO block guard", () => {
+    const guardedDo = `
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+          CREATE TYPE public.mood AS ENUM ('happy', 'sad');
+        END IF;
+      END
+      $$;
+    `;
+    expect(projectMigrationSqlViolations([guardedDo])).toEqual([]);
+  });
+
+  test("rescans top-level DO bodies for privileged operations", () => {
     for (const statement of [
       "DO LANGUAGE plpgsql $$ BEGIN PERFORM pg_advisory_lock(1); END $$;",
-      "DO /* generated */ LANGUAGE plpgsql $$ BEGIN SET ROLE postgres; END $$;",
       "DO 'BEGIN PERFORM pg_advisory_lock(1); END';",
+    ]) {
+      expect(projectMigrationSqlViolations([statement])).toContain("advisory lock control");
+    }
+    for (const statement of [
+      "DO /* generated */ LANGUAGE plpgsql $$ BEGIN SET ROLE postgres; END $$;",
       "DO LANGUAGE plpgsql 'BEGIN SET ROLE postgres; END';",
     ]) {
-      expect(projectMigrationSqlViolations([statement])).toContain("opaque procedural SQL");
+      expect(projectMigrationSqlViolations([statement])).toContain("session role control");
     }
+    expect(projectMigrationSqlViolations([
+      "DO $$ BEGIN PERFORM pg_read_file('/etc/passwd'); END $$;",
+    ])).toContain("server file access");
+    expect(projectMigrationSqlViolations([
+      "DO $$ BEGIN PERFORM dblink('host=other', 'select 1'); END $$;",
+    ])).toContain("external database access");
+    expect(projectMigrationSqlViolations([
+      "DO $$ BEGIN INSERT INTO supabase_migrations.schema_migrations(version) VALUES ('1'); END $$;",
+    ])).toContain("migration ledger modification");
   });
 
   test("continues to block privileged operations at the migration top level", () => {


### PR DESCRIPTION
## 问题

下游项目（xigu-fa）的 396 个 PostgreSQL migration 在当前平台（management API 0.68.x + CLI ≥0.35）下**全部无法部署**。用 main 分支的 `projectMigrationSqlViolations` 对这 396 个文件实测，违规分布：

| 违规标签 | 文件数 | 实际情况 |
| --- | --- | --- |
| `transaction control` | 379 | 文件按 PostgreSQL 生态惯例用 `BEGIN; ... COMMIT;` 包裹；服务端 `executeMigrationTransaction` 本就在 `connection.begin` 事务内执行，文件级包装是冗余而非危险 |
| `opaque procedural SQL` | 27 | DO 块被无差别拒绝；DO 是幂等守卫（`IF NOT EXISTS` 等）的标准写法 |
| `migration ledger privilege modification` | 1 | **误报**：`REVOKE ALL ON ALL TABLES IN SCHEMA public FROM anon, authenticated` 被 `ALL TABLES IN SCHEMA public` 分支当成篡改 ledger |

## 修复内容

1. **事务包装容忍**（`sql-policy.ts` / `migration-risk.ts`）：扫描前先拆分语句并剥离一对「整条语句仅为 BEGIN/START TRANSACTION」+「整条语句仅为 COMMIT/END」的顶层包装。剥离数量通过新增的 `deriveMigrationExecution` 在执行记录中暴露（`POST /v1/projects/:ref/database/migrations` 响应新增 `stripped_transaction_statements` 字段）。CLI 端 `unsupported_transaction_control` 只命中剥离后仍存在的非包装事务控制语句。
2. **DO 块改为 body 重扫**：移除 `opaque procedural SQL` 顶层一刀切规则（`isDangerousSQL` 的旧保守行为通过在 LEGACY 列表保留等价 DO 模式维持不变）。遇到顶层 `DO [LANGUAGE lang] body` 时提取其 dollar-quoted / 单引号 body，用同一套特权模式（排除 transaction control——PL/pgSQL 的 BEGIN/END 是块结构）对 body 做深度 1 层的重扫；body 命中 `pg_read_file`、`dblink`、ledger 修改等仍拒绝并报告内层命中标签。CLI `manual_review_do_block` 同步移除并改为 body 重扫（`DO_BODY_BLOCKER_RULES`）。
3. **误报修复**：`MIGRATION_LEDGER_PRIVILEGE_PATTERN` 的 `ALL TABLES IN SCHEMA` 分支去掉 `public`，只保留 `supabase_migrations`（两端同步）。

## 安全语义不变项

- `ROLLBACK` / `ABORT` / `SAVEPOINT` / `RELEASE SAVEPOINT` / `PREPARE TRANSACTION`、以及不配对的 `BEGIN`/`COMMIT` **仍然违规**（中途回滚会破坏 ledger 一致性），均有测试锁定。
- DO body 重扫使用既有 masking 基础设施（注释/字面量/dollar body 遮蔽未改动）；body 内嵌 `pg_read_file`、`dblink`、`schema_migrations` 写入、advisory lock、`SET ROLE` 均仍拒绝。
- ledger 保护对 `supabase_migrations.schema_migrations` 直接授权和 `ALL TABLES IN SCHEMA supabase_migrations` 仍然生效。

## 测试证据

- 服务端新增/更新用例（`sql-policy.test.ts`、`database-routes.test.ts`、`migration-promotion.test.ts`）：BEGIN/COMMIT 包装接受且剥离数正确、纯 ROLLBACK/SAVEPOINT 等仍拒绝、良性 DO（IF NOT EXISTS guard）接受、DO 内嵌 pg_read_file/dblink/ledger 写入拒绝、`GRANT ON ALL TABLES IN SCHEMA public` 接受、`GRANT ON supabase_migrations.schema_migrations` 与 `GRANT ALL TABLES IN SCHEMA supabase_migrations` 拒绝。
- CLI `migration-risk.test.ts` 同步补充镜像用例。
- **语料级验证**：对下游 396 个 migration 文件跑修改后的 `projectMigrationSqlViolations`——**0 违规**（修复前：transaction control 379 + opaque procedural SQL 27 + ledger 误报 1，共 383 个文件）。CLI `analyzeMigrationFiles` 同语料 `transactionalPushBlockerCount = 0`。
- 回归：`packages/management-api` 单元测试全部分片 0 fail（首轮 1797 pass 中唯一失败的 migration-promotion DO 用例已按新语义更新并通过）；`packages/cli` 981 pass / 0 fail；两包 `tsc --noEmit` 通过；`sql:check` 通过。