### PR TITLE
fix(management-api): forward OPTIONS preflight to upstreams and preserve function CORS

### DIFF
--- a/packages/management-api/src/routes/sdk-proxy.ts
+++ b/packages/management-api/src/routes/sdk-proxy.ts
@@ -577,10 +577,9 @@ type ProxyInterceptors = {
 
 async function executeProxy(request: Request, targetUrl: string, interceptors: ProxyInterceptors) {
     try {
-        if (request.method === 'OPTIONS') {
-             return new Response(null, { status: 204 });
-        }
-
+        // OPTIONS preflight is forwarded like any other method: each upstream
+        // owns its CORS policy (edge-runtime dispatches preflight to the
+        // function itself; PostgREST/GoTrue/Realtime answer natively).
         const body = ["GET", "HEAD"].includes(request.method) ? undefined : request.body;
         
         const reqHeaders = new Headers(request.headers);
@@ -646,11 +645,9 @@ async function executeProxy(request: Request, targetUrl: string, interceptors: P
         response.headers.forEach((val, key) => {
             const lowerKey = key.toLowerCase();
             if (lowerKey === 'set-cookie') return;
-            if (lowerKey === 'access-control-allow-origin') return;
-            if (lowerKey === 'access-control-allow-credentials') return;
-            if (lowerKey === 'access-control-allow-methods') return;
-            if (lowerKey === 'access-control-allow-headers') return;
-            if (lowerKey === 'access-control-expose-headers') return;
+            // Upstream access-control-* headers are preserved: the upstream owns
+            // its CORS policy. Gateway routes that manage CORS themselves drop
+            // these headers at the Caddy layer (see preserveUpstreamCors).
 
             if (lowerKey === 'link' && interceptors.linkOrigin) {
                 const rewritten = val.replace(/<(https?:\/\/[^>]+)(\/[^>]*)>/g, `<${interceptors.linkOrigin}$2>`);

--- a/packages/management-api/src/services/gateway-route-builders.ts
+++ b/packages/management-api/src/services/gateway-route-builders.ts
@@ -404,7 +404,23 @@ export function isCorsSubroute(handler: Record<string, unknown>): boolean {
     );
 }
 
+/**
+ * Routes whose upstream owns the CORS policy (functions, storage) keep the
+ * upstream access-control-* headers instead of deleting them at the gateway.
+ */
+export function routePreservesUpstreamCors(route: CaddyRoute): boolean {
+    const handle = Array.isArray(route.handle) ? route.handle as Array<Record<string, any>> : [];
+    return handle.some((handler) => {
+        if (handler?.handler !== "reverse_proxy") return false;
+        const deletions = handler?.headers?.response?.delete;
+        return !(Array.isArray(deletions) && deletions.includes("Access-Control-Allow-Origin"));
+    });
+}
+
 export function setRouteCors(route: CaddyRoute, origins: string[]): void {
+    // Routes that preserve upstream CORS (functions, storage) answer preflight
+    // themselves; never re-attach the gateway CORS subroute to them.
+    if (routePreservesUpstreamCors(route)) return;
     const corsSubroute = makeCorsSubroute(origins);
     const handle = Array.isArray(route.handle) ? route.handle as Record<string, unknown>[] : [];
     const withoutCors = handle.filter((handler) => !isCorsHeaderHandler(handler) && !isCorsSubroute(handler));

--- a/packages/management-api/src/services/gateway.service.ts
+++ b/packages/management-api/src/services/gateway.service.ts
@@ -622,9 +622,11 @@ export class CaddyGatewayProvider implements GatewayProvider {
 
         const migrated = JSON.parse(JSON.stringify(route)) as CaddyRoute;
         const handle = Array.isArray(migrated.handle) ? migrated.handle as Record<string, unknown>[] : [];
-        const migratedHandle = isStorageRoute
-            ? handle.filter((handler) => handler.strip_path_prefix !== "/storage/v1")
-            : handle;
+        // Functions and storage routes own their upstream CORS policy; drop any
+        // gateway-rendered CORS subroute left over from older route shapes.
+        const migratedHandle = handle.filter((handler) =>
+            !(isStorageRoute && handler.strip_path_prefix === "/storage/v1")
+            && !isCorsSubroute(handler));
         migrated.handle = migratedHandle;
 
         const proxy = migratedHandle.find((handler) => handler.handler === "reverse_proxy") as Record<string, any> | undefined;
@@ -644,6 +646,14 @@ export class CaddyGatewayProvider implements GatewayProvider {
             proxy.headers.response = proxy.headers.response && typeof proxy.headers.response === "object" ? proxy.headers.response : {};
             delete proxy.headers.response.delete;
             delete proxy.flush_interval;
+        }
+
+        if (isFunctionsRoute) {
+            // Preserve function-owned CORS headers on existing deployments.
+            if (proxy.headers.response && typeof proxy.headers.response === "object") {
+                delete proxy.headers.response.delete;
+                if (Object.keys(proxy.headers.response).length === 0) delete proxy.headers.response;
+            }
         }
 
         return migrated;
@@ -1786,6 +1796,9 @@ export class CaddyGatewayProvider implements GatewayProvider {
                     ],
                     readTimeout: 500_000,
                     corsOrigins,
+                    // Functions own their CORS policy (origin allowlists, custom
+                    // headers); preflight must reach the function itself.
+                    preserveUpstreamCors: true,
                 }),
                 this.makeRoute({
                     id: caddyRouteId(projectRef, "storage-resumable"),

--- a/packages/management-api/tests/unit/gateway.service.test.ts
+++ b/packages/management-api/tests/unit/gateway.service.test.ts
@@ -267,8 +267,10 @@ describe("CaddyGatewayProvider", () => {
         expect(reverseProxyHandlers.every((handler: any) => !handler.upstreams?.[0]?.dial?.includes("/"))).toBe(true);
         for (const handler of reverseProxyHandlers) {
             const routeId = findRouteIdForHandler(routes, handler);
-            const isStorageRoute = routeId?.endsWith("-storage") || routeId?.endsWith("-storage-resumable");
-            if (isStorageRoute) {
+            const preservesUpstreamCors = routeId?.endsWith("-storage")
+                || routeId?.endsWith("-storage-resumable")
+                || routeId?.endsWith("-functions");
+            if (preservesUpstreamCors) {
                 expect(handler.headers?.response?.delete).toBeUndefined();
             } else {
                 expect(handler.headers?.response?.delete).toContain("Access-Control-Allow-Origin");
@@ -289,6 +291,9 @@ describe("CaddyGatewayProvider", () => {
         const restProxy = rest?.handle?.find((h: any) => h.handler === "reverse_proxy");
         expect(restProxy?.flush_interval).toBe(-1);
         expect(functions?.match?.[0]?.path).toEqual(["/functions/v1*"]);
+        expect(findCorsSubroute(functions)).toBeUndefined();
+        const functionsProxy = functions?.handle?.find((h: any) => h.handler === "reverse_proxy");
+        expect(functionsProxy?.headers?.response).toBeUndefined();
         expect(realtime?.match?.[0]?.path).toEqual(["/realtime/v1/websocket*"]);
         expect(management?.match?.[0]?.path).toEqual(["/v1/projects/testref123", "/v1/projects/testref123/*"]);
         expect(management?.handle?.some((handler: any) => handler.handler === "rewrite")).toBe(false);
@@ -595,12 +600,16 @@ describe("CaddyGatewayProvider", () => {
         expect(route?.match?.[0]?.host).toEqual(["site.example.com", "www.example.com"]);
         expect(route?.match?.[0]?.path).toEqual(["/*"]);
         expect(route?.handle?.at(-1)?.upstreams?.[0]?.dial).toBe("127.0.0.1:30042");
-        const apiRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-functions");
+        const apiRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-rest");
         const corsSubroute = findCorsSubroute(apiRoute);
         const exactMatcher = corsSubroute?.routes?.[0]?.match?.find((matcher: any) => matcher.header?.Origin);
         expect(exactMatcher?.header?.Origin).toContain("https://site.example.com");
         expect(exactMatcher?.header?.Origin).toContain("https://www.example.com");
         expect(exactMatcher?.header?.Origin).toContain("https://api.example.com");
+        // The functions route owns its upstream CORS policy and never carries a
+        // gateway-rendered CORS subroute.
+        const functionsRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-functions");
+        expect(findCorsSubroute(functionsRoute)).toBeUndefined();
 
         restore();
     });
@@ -660,11 +669,15 @@ describe("CaddyGatewayProvider", () => {
 
         const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
         const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
-        const functionsRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-functions");
-        const corsSubroute = findCorsSubroute(functionsRoute);
+        const restRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-rest");
+        const corsSubroute = findCorsSubroute(restRoute);
         const exactMatcher = corsSubroute?.routes?.[0]?.match?.find((matcher: any) => matcher.header?.Origin);
         expect(exactMatcher?.header?.Origin).toContain("https://app.example.com");
         expect(exactMatcher?.header?.Origin).toContain("https://api.example.com");
+        // Functions keep their upstream-owned CORS policy instead of the
+        // gateway-rendered subroute.
+        const functionsRoute = routes.find((item: any) => item["@id"] === "route-project-proj123-functions");
+        expect(findCorsSubroute(functionsRoute)).toBeUndefined();
 
         restore();
     });
@@ -2355,6 +2368,75 @@ describe("CaddyGatewayProvider route headers", () => {
         expect(requestSet?.["X-Project-Ref"]).toEqual(["legacyfn"]);
         expect(requestSet?.["x-project-ref"]).toEqual(["legacyfn"]);
         expect(requestSet?.["X-Forwarded-Proto"]).toEqual(["{http.request.scheme}"]);
+
+        restore();
+    });
+
+    test("hydrates legacy functions routes into upstream-owned CORS", async () => {
+        await mkdir("/tmp/supacloud-caddy-test", { recursive: true });
+        await writeFile("/tmp/supacloud-caddy-test/config.json", JSON.stringify({
+            apps: {
+                http: {
+                    servers: {
+                        supacloud: {
+                            routes: [
+                                {
+                                    "@id": "route-project-legacyfn2-functions",
+                                    match: [{ host: ["legacyfn2.api.example.com"], path: ["/functions/v1*"] }],
+                                    handle: [
+                                        {
+                                            handler: "subroute",
+                                            routes: [{
+                                                match: [{ method: ["OPTIONS"] }],
+                                                handle: [{
+                                                    handler: "headers",
+                                                    response: { set: { "Access-Control-Allow-Origin": ["{http.request.header.Origin}"] } },
+                                                }, { handler: "static_response", status_code: 204 }],
+                                                terminal: true,
+                                            }],
+                                        },
+                                        {
+                                            handler: "reverse_proxy",
+                                            headers: {
+                                                request: { set: { Host: ["{http.request.host}"] } },
+                                                response: {
+                                                    delete: [
+                                                        "Access-Control-Allow-Origin",
+                                                        "Access-Control-Allow-Credentials",
+                                                        "Access-Control-Allow-Methods",
+                                                        "Access-Control-Allow-Headers",
+                                                        "Access-Control-Expose-Headers",
+                                                        "Access-Control-Max-Age",
+                                                    ],
+                                                },
+                                            },
+                                            upstreams: [{ dial: "127.0.0.1:9090" }],
+                                        },
+                                    ],
+                                    terminal: true,
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        }));
+
+        const calls: Array<{ url: string; method: string; body: any }> = [];
+        const restore = captureFetch(calls);
+        const provider = new CaddyGatewayProvider();
+
+        await provider.setCors("legacyfn2", ["https://app.example.com"]);
+
+        const load = calls.filter((call) => call.method === "POST" && call.url.endsWith("/load")).at(-1);
+        const routes = load?.body?.apps?.http?.servers?.supacloud?.routes ?? [];
+        const functions = routes.find((route: any) => route["@id"] === "route-project-legacyfn2-functions");
+        expect(functions).toBeDefined();
+        // Gateway CORS subroute is stripped and never re-attached by setCors.
+        expect(findCorsSubroute(functions)).toBeUndefined();
+        const functionsProxy = functions?.handle?.find((h: any) => h.handler === "reverse_proxy");
+        expect(functionsProxy?.headers?.response).toBeUndefined();
+        expect(functionsProxy?.headers?.request?.set?.["X-Project-Ref"]).toEqual(["legacyfn2"]);
 
         restore();
     });

--- a/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
+++ b/packages/management-api/tests/unit/sdk-proxy.functions.test.ts
@@ -192,8 +192,29 @@ describe("sdkProxyRoutes functions proxy", () => {
     });
   });
 
-  test("OPTIONS /functions/v1 stops at the SDK proxy without emitting CORS headers", async () => {
-    await withSdkProxyTestContext(async ({ calls }) => {
+  test("OPTIONS /functions/v1 forwards preflight upstream and passes through its CORS headers", async () => {
+    await withSdkProxyTestContext(async ({ calls, trackSpy }) => {
+      trackSpy(spyOn(edgeFunctionService, "getConfig").mockResolvedValue({
+        verify_jwt: false,
+        version: "7",
+      } as Awaited<ReturnType<typeof edgeFunctionService.getConfig>>));
+      setSdkProxyFetchForTests(((input: string | URL | Request, init?: RequestInit & { duplex?: "half" }) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+        calls.push({ url, init });
+        return Promise.resolve(new Response(null, {
+          status: 204,
+          headers: {
+            "access-control-allow-origin": "https://aorist.net",
+            "access-control-allow-headers": "authorization, content-type, x-supacloud-async",
+            "access-control-allow-methods": "GET, POST, OPTIONS",
+          },
+        }));
+      }) as typeof fetch);
+
       const response = await request("/functions/v1/aorist-generation/generate/crop", {
         method: "OPTIONS",
         headers: {
@@ -206,9 +227,48 @@ describe("sdkProxyRoutes functions proxy", () => {
       });
 
       expect(response.status).toBe(204);
-      expect(calls).toHaveLength(0);
-      expect(response.headers.has("access-control-allow-origin")).toBe(false);
-      expect(response.headers.has("access-control-allow-headers")).toBe(false);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("http://127.0.0.1:9005/functions/v1/aorist-generation/generate/crop");
+      expect(calls[0]?.init?.method).toBe("OPTIONS");
+      expect(response.headers.get("access-control-allow-origin")).toBe("https://aorist.net");
+      expect(response.headers.get("access-control-allow-headers")).toBe("authorization, content-type, x-supacloud-async");
+      expect(response.headers.get("access-control-allow-methods")).toBe("GET, POST, OPTIONS");
+    });
+  });
+
+  test("POST /functions/v1 preserves upstream CORS headers on actual responses", async () => {
+    await withSdkProxyTestContext(async ({ calls }) => {
+      setSdkProxyFetchForTests(((input: string | URL | Request, init?: RequestInit & { duplex?: "half" }) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+        calls.push({ url, init });
+        return Promise.resolve(new Response(JSON.stringify({ ok: true }), {
+          headers: {
+            "Content-Type": "application/json",
+            "access-control-allow-origin": "https://aorist.net",
+            "access-control-expose-headers": "x-custom-token",
+          },
+        }));
+      }) as typeof fetch);
+
+      const response = await request("/functions/v1/hello", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-project-ref": "proj_1",
+          apikey: "anon",
+          origin: "https://aorist.net",
+        },
+        body: JSON.stringify({ ping: true }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(calls).toHaveLength(1);
+      expect(response.headers.get("access-control-allow-origin")).toBe("https://aorist.net");
+      expect(response.headers.get("access-control-expose-headers")).toBe("x-custom-token");
     });
   });
 


### PR DESCRIPTION
## 问题

management-api 的 SDK 代理层对所有 OPTIONS 请求无条件短路，函数/上游永远收不到 preflight。

staging 三层实测（management-api 0.69.0 + edge-runtime 0.21.1，已含 #1113/#1114）：

| 路径 | 结果 |
| --- | --- |
| 直连 edge-runtime（127.0.0.1:9005）`OPTIONS /functions/v1/fa-api/cases` 带 Origin | 204 + `Access-Control-Allow-Origin` 精确回显（函数自己的 preflight 应答）✅ |
| 经 management-api（9090 / 公网域名）同一请求 | 裸 204，**完全无 access-control-\* 头** ❌ |

根因：`packages/management-api/src/routes/sdk-proxy.ts` `executeProxy` 开头（原 580-582 行）`if (request.method === 'OPTIONS') return new Response(null, { status: 204 })`，且响应头拷贝处（原 649-653 行）丢弃上游全部 access-control-\* 头。

历史排查：该短路由 8cd4c7a2（"refactor(gateway): move CORS enforcement from application layer to Caddy"）引入，前提是「Caddy 统一兜底 preflight」。但 Caddy 侧 functions 路由是 `preserveUpstreamCors` 语义缺口：网关不为它渲染 preflight 处理器（`makeRoute` 中 `corsOrigins && !preserveUpstreamCors` 才挂 cors subroute），而对不在租户 CORS 白名单中的 Origin，Caddy 也不应答——于是 OPTIONS 穿透 Caddy 到达 management-api 后被裸 204 短路，端到端没有任何 CORS 头。

## 修复内容

1. **`sdk-proxy.ts` `executeProxy`：移除 OPTIONS 短路**，preflight 与其他方法一样转发上游；**保留上游 access-control-\* 响应头**不再丢弃。非 preserve 路由在 Caddy 层本就会删除上游 CORS 头（`makeReverseProxy` 的 `response.headers.delete`），因此生产路径不会出现重复 CORS 头。
2. **`gateway.service.ts`：functions 路由加 `preserveUpstreamCors: true`**（与 storage 一致）——不再挂网关 CORS 子路由、不再删除上游 CORS 头，函数自己的 CORS 策略端到端生效。
3. **存量部署迁移**：`migrateHydratedRoute` hydrate 时剥离 functions/storage 路由上网关渲染的 CORS 子路由，并移除 functions 反向代理的 CORS delete 列表；`setRouteCors` 新增 `routePreservesUpstreamCors` 守卫，后续 `setCors`/`configureFrontendRoute` 不会把网关 CORS 子路由重新挂回这些路由。

## 各路径 OPTIONS 行为变化

| 路径 | 修复前 | 修复后 |
| --- | --- | --- |
| `/functions/v1` | 代理层裸 204；公网路径上白名单内 Origin 由 Caddy 以默认头应答（不含函数自定义 allow-headers），白名单外裸 204 | preflight 直达函数，函数的 ACAO/ACAH/ACAM 原样透传（直连与公网路径一致） |
| `/rest/v1`、`/graphql/v1` | 代理层裸 204（直连 9090 时）；公网路径白名单内由 Caddy 应答 | 直连时转发 PostgREST 原生 preflight 应答（含其 `server-cors-allowed-origins` 策略）；公网路径不变（Caddy 仍兜底并删除上游 CORS 头，无重复） |
| `/auth/v1` | 同上 | 同上（GoTrue 原生处理 OPTIONS） |
| `/realtime/v1` | 代理层裸 204 | 转发 Realtime 上游；公网路径不变 |
| `/storage/v1` | 不经 executeProxy（storage-compat 自设 CORS，Caddy 已 preserve） | 不变；`setRouteCors` 跳过守卫使其不再被 setCors 重新挂上网关 CORS 子路由（与 storage-compat 的设计注释一致） |

## 取舍说明

- 选择「全路径移除短路」而非「只对 /functions/v1 转发」：PostgREST/GoTrue/Realtime 都能原生正确处理 OPTIONS，统一转发更简单也更符合「上游拥有自己的 CORS 策略」；公网路径上非 preserve 路由仍由 Caddy 统一兜底，行为不变。
- 函数若刻意不对某 Origin 返回 ACAO，edge-runtime 的平台默认回显仍会兜底（与 #1114 后的行为一致），不在本 PR 扩大。

## 测试证据

- `sdk-proxy.functions.test.ts`：原「OPTIONS stops at the SDK proxy」用例反转为「OPTIONS 转发到 edge-runtime 且上游 CORS 头原样透传」（断言上游收到 `OPTIONS http://127.0.0.1:9005/functions/v1/...`、响应 ACAO/ACAH/ACAM 逐值透传）；新增 POST 实际响应保留上游 ACAO/ACEH 用例。
- `gateway.service.test.ts`：路由形态断言更新——functions 路由无 CORS 子路由、反向代理无 response delete（与 storage 一致）；frontend 域名 CORS 来源断言改到 rest 路由；新增「存量 functions 路由（带 CORS 子路由 + delete 列表）经 hydrate 迁移为上游自治 CORS 且 setCors 不再回挂」用例。
- `packages/management-api` 全量单元测试 **0 fail**；`tsc --noEmit` 通过；`sql:check` 通过。