### PR TITLE
fix(management-api): grant BYPASSRLS to the project migration role

### DIFF
--- a/packages/management-api/src/services/project-migration-role.ts
+++ b/packages/management-api/src/services/project-migration-role.ts
@@ -21,6 +21,10 @@ export function renderProjectMigrationRoleSql(dbName: string, dbUser: string): s
 
   return `
     GRANT CREATE ON DATABASE ${quotedDatabase} TO ${quotedUser};
+    -- 迁移 SQL 经 sql-policy 特权扫描后由服务端在受控事务 + ledger lease 中执行，
+    -- 不开放客户端直达面；平台表（如 storage.buckets）启用 RLS，迁移角色需要
+    -- BYPASSRLS 才能初始化项目私有的平台对象。ALTER ROLE 幂等，重复执行无副作用。
+    ALTER ROLE ${quotedUser} BYPASSRLS;
     ALTER SCHEMA public OWNER TO ${quotedUser};
     GRANT USAGE ON SCHEMA supabase_migrations TO ${quotedUser};
     REVOKE ALL ON TABLE supabase_migrations.schema_migrations FROM PUBLIC, anon, authenticated, service_role, ${quotedUser};

--- a/packages/management-api/tests/unit/project-migration-role.test.ts
+++ b/packages/management-api/tests/unit/project-migration-role.test.ts
@@ -6,6 +6,7 @@ describe("project migration role preparation", () => {
     const sql = renderProjectMigrationRoleSql("supa_parent", "role_parent");
 
     expect(sql).toContain('GRANT CREATE ON DATABASE "supa_parent" TO "role_parent"');
+    expect(sql).toContain('ALTER ROLE "role_parent" BYPASSRLS');
     expect(sql).toContain('ALTER SCHEMA public OWNER TO "role_parent"');
     expect(sql).toContain("c.relname <> 'schema_migrations'");
     expect(sql).toContain("d.deptype = 'e'");
@@ -30,5 +31,25 @@ describe("project migration role preparation", () => {
   test("rejects unsafe database and role identifiers", () => {
     expect(() => renderProjectMigrationRoleSql("supa_parent; drop database x", "role_parent")).toThrow();
     expect(() => renderProjectMigrationRoleSql("supa_parent", "role_parent; alter role postgres")).toThrow();
+  });
+
+  test("grants BYPASSRLS idempotently so migrations can write RLS-protected platform tables", async () => {
+    const { prepareProjectMigrationRole } = await import("../../src/services/project-migration-role");
+    const executed: string[] = [];
+    const adminDb = {
+      unsafe(statement: string) {
+        executed.push(statement);
+        return Promise.resolve([]);
+      },
+    };
+
+    await prepareProjectMigrationRole(adminDb, "supa_parent", "role_parent");
+    await prepareProjectMigrationRole(adminDb, "supa_parent", "role_parent");
+
+    expect(executed).toHaveLength(2);
+    for (const statement of executed) {
+      expect(statement).toContain('ALTER ROLE "role_parent" BYPASSRLS');
+      expect(statement).not.toContain("SUPERUSER");
+    }
   });
 });


### PR DESCRIPTION
## 问题

staging（management-api 0.69.0）实测：项目迁移角色（`role_<ref>`）执行包含 `INSERT INTO storage.buckets ...` 的 baseline migration 时报 500——「新行违背了表 "buckets" 的行级安全策略」。

三种角色配置下的行为对比（同一 migration）：

| 角色配置 | 结果 |
| --- | --- |
| 现状（无 BYPASSRLS） | 500：`new row violates row-level security policy for table "buckets"` |
| `SET row_security = off` | 仍失败：「查询将被表 buckets 的行级安全性策略所影响」——无可用 permissive policy 时 `row_security=off` 会报错而非放行 |
| `ALTER ROLE role_<ref> BYPASSRLS` | **200 成功** ✅ |

根因：`renderProjectMigrationRoleSql`（`packages/management-api/src/services/project-migration-role.ts`）只授权限与 ledger 保护，未让迁移角色突破 RLS；而 `storage.buckets` 等平台表启用了 RLS，项目级迁移（如初始化项目私有 bucket）需要写入它们。

## 修复

在 `renderProjectMigrationRoleSql` 顶部为迁移角色增加幂等的 `ALTER ROLE <role> BYPASSRLS`。

存量角色自动收敛：`prepareProjectMigrationRole` 在**每次迁移执行前**都会运行（`database.ts` `withMigrationRoleSession`，branch 路径同样调用），`ALTER ROLE ... BYPASSRLS` 幂等，现有项目的迁移角色在下一次迁移/分支操作时自动补齐，无需手工修复脚本。

## 安全论证

- 迁移 SQL 已经过 sql-policy 特权扫描（拒绝 ledger 篡改、服务文件访问、dblink、角色/集群管理等），并在服务端受控事务 + ledger lease + 迁移锁中执行——属于受信执行路径。
- 该迁移角色不能从公开 API 使用：客户端 SQL 端点走独立的认证与 `isDangerousSQL` 保守策略，RLS Tester 显式 `SET LOCAL ROLE anon/authenticated` 且只读事务。
- BYPASSRLS 是仓库既有先例：`service_role`、`supabase_admin` 均为 `BYPASSRLS`（`db/schemas/supabase.sql`、`database.service.ts`）。迁移角色的权限面仍远小于它们（无 LOGIN 之外的平台级授权、无 REPLICATION）。
- 影响的另外一条路径是管理端 SQL 编辑器（admin 模式），其语义本就和 Supabase SQL editor 一致（以项目超级用户级角色执行），BYPASSRLS 不改变其信任边界。

## 测试证据

- `tests/unit/project-migration-role.test.ts`：既有渲染断言更新（含 `ALTER ROLE "role_parent" BYPASSRLS`，且仍不含 `SUPERUSER`/`CREATEROLE`）；新增幂等性用例——`prepareProjectMigrationRole` 连续两次执行均下发带 BYPASSRLS 的 SQL（证明存量角色经既有调和路径自动收敛）。
- RLS 写入放行本身是 PostgreSQL 对 BYPASSRLS 的语义保证，并已由上方 staging 实测（`ALTER ROLE ... BYPASSRLS` 后同一 migration 200）验证；仓库无可用的真实 PG 集成环境，未新增端到端用例。
- `packages/management-api` 全量单元测试 **0 fail**；`tsc --noEmit` 通过；`sql:check` 通过。