### PR TITLE
feat(cli): add remote test dev sync with drizzle migration flow

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -68,6 +68,57 @@ use immutable static releases; `edge_function` targets use the existing verified
 Edge Function bundle protocol. The command runs the target build, publishes only
 that target, and reads the final identity back.
 
+### Remote test development sync
+
+For a dedicated test server, use `dev` to synchronize source files over SSH and
+reload only the affected development target. This path is separate from
+immutable Function releases and is rejected for production environments.
+
+```bash
+supacloud-cli --env test dev sync --target functions --function api
+supacloud-cli --env test dev sync --target db
+supacloud-cli --env test dev watch --target project
+supacloud-cli --env test dev status
+```
+
+The selected environment supplies `SUPACLOUD_DEV_HOST` (or `SUPACLOUD_HOST`)
+and the existing `SUPACLOUD_SSH_*` settings. A repository may add a `dev` section to
+`supacloud.json`:
+
+```json
+{
+  "dev": {
+    "remoteRoot": "/var/lib/supacloud/dev/test-project",
+    "reloadCommand": "supacloud-dev-agent reload",
+    "compile": true,
+    "compileRoot": ".",
+    "compileOutDir": "generated",
+    "compileStrict": true,
+    "database": {
+      "drizzleConfig": "drizzle.config.ts",
+      "migrationsDir": "supabase/migrations",
+      "strict": true
+    },
+    "excludes": ["node_modules", ".git", ".env*", "dist"]
+  }
+}
+```
+
+The syncer creates the target directory remotely, transfers the selected source
+tree with checksum-aware `rsync`, and invokes the configured reload agent over
+SSH. Secrets and environment files are excluded by default. Database syncing is
+explicit (`dev sync --target db`); file watching does not execute migrations
+automatically. When `dev.compile` is enabled, `@supacloud/compiler` runs before
+sync; generated factories and `app.manifest.json` must be written inside the
+selected sync tree or be included by the project target. Compilation errors stop
+the sync and reload. `dev migrate` runs `drizzle-kit generate`, performs a
+SupaCloud migration dry-run, and only applies when `--apply` is explicitly set:
+
+```bash
+supacloud-cli --env test dev migrate
+supacloud-cli --env test dev migrate --apply
+```
+
 Simple single-frontend projects usually need no file. Monorepos should add a
 repository-root `supacloud.json`:
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,7 @@ import { registerScheduledFunctionTools } from "./shared/tools/scheduled-functio
 import { registerMutationTools } from "./shared/tools/mutation-tools";
 import { registerReleaseTools } from "./shared/tools/release-tools";
 import { deployToolSchema, findDeployConfigRoot, registerDeployTools } from "./shared/tools/deploy-tools";
+import { registerRemoteDevTools } from "./shared/tools/remote-dev-tools";
 import packageMetadata from "../package.json" with { type: "json" };
 
 type ToolEntry = { schema: any; callback: (args: any) => Promise<any> };
@@ -290,6 +291,11 @@ EXAMPLES
   ${preferredCommand} deploy
   ${preferredCommand} deploy --target web
   ${preferredCommand} deploy --target api
+  ${preferredCommand} dev sync --env test --target functions --function api
+  ${preferredCommand} dev status --env test
+  ${preferredCommand} dev watch --env test --target project
+  ${preferredCommand} dev sync --env test --target db
+  ${preferredCommand} dev migrate --env test
   ${preferredCommand} project get
   ${preferredCommand} project logs --log_type database
   ${preferredCommand} project task_stats
@@ -387,7 +393,6 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     Object.assign(tools, captureTools((server) => registerAiTools(server as any)));
     Object.assign(tools, captureTools((server) => registerAppTools(server as any)));
     Object.assign(tools, captureTools((server) => registerDbGovernanceTools(server as any)));
-
     const registerContextAwareHelp = () => {
         tools.project = {
             schema: { action: projectActionSchema },
@@ -466,6 +471,15 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
         Object.assign(tools, captureTools((server) => registerDatabaseTools(server as any, undefined, {
             localOnly: true,
         })));
+        Object.assign(tools, captureTools((server) => registerRemoteDevTools(server as any, {
+            cwd: process.cwd(),
+            host: process.env.SUPACLOUD_DEV_HOST || context.host,
+            sshUser: context.sshUser,
+            sshPort: context.sshPort,
+            sshKey: context.sshKey,
+            projectRef: context.projectRef || undefined,
+            environment: context.environment,
+        })));
         tools.setup_help = {
             schema: {},
             callback: async () => ({
@@ -522,6 +536,16 @@ function createCliTools(context: ResolvedContext, confirmProduction?: string): T
     }));
     pushMigrations = databaseTools.database?.callback;
     assign(databaseTools);
+    assign(captureTools((server) => registerRemoteDevTools(server as any, {
+        cwd: process.cwd(),
+        host: process.env.SUPACLOUD_DEV_HOST || context.host,
+        sshUser: context.sshUser,
+        sshPort: context.sshPort,
+        sshKey: context.sshKey,
+        projectRef: context.projectRef || undefined,
+        environment: context.environment,
+        runDatabase: databaseTools.database?.callback,
+    })));
     assign(captureTools((server) => registerAuthTools(server as any, http)));
     assign(captureTools((server) => registerOAuthClientTools(server as any, http)));
     assign(captureTools((server) => registerStorageTools(server as any, http)));

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -74,6 +74,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     ai: { local: ["show_skill", "install_skill"] },
     app: { local: ["generate", "compile", "check", "graph", "explain"] },
     db: { local: ["lint", "explain"], read: ["module_check"] },
+    dev: { read: ["status"], write: ["sync", "watch", "migrate"] },
 };
 
 export interface ExecutionAuthorization {
@@ -100,6 +101,7 @@ export function executionMode(moduleName: string, action: string, args: Record<s
         && ["push_migrations", "baseline_migrations"].includes(action)
         && args.dry_run === true) return "read";
     if (moduleName === "supabase" && action === "push" && args.dry_run === true) return "read";
+    if (moduleName === "dev" && action === "migrate" && args.apply !== true) return "read";
     return declaredMode(moduleName, action);
 }
 

--- a/packages/cli/src/shared/tools/remote-dev-tools.test.ts
+++ b/packages/cli/src/shared/tools/remote-dev-tools.test.ts
@@ -1,0 +1,74 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { registerRemoteDevTools } from "./remote-dev-tools";
+
+describe("remote dev tools", () => {
+    test("syncs through mkdir, rsync, and reload without shell execution", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-dev-"));
+        await mkdir(join(root, "supabase", "functions", "api"), { recursive: true });
+        await writeFile(join(root, "supabase", "functions", "api", "index.ts"), "export default {}\n");
+        const calls: Array<{ command: string; args: string[] }> = [];
+        let index = 0;
+        let tool: ((args: any) => Promise<any>) | undefined;
+        registerRemoteDevTools({ tool(_name, _description, _schema, handler) { tool = handler; } }, {
+            cwd: root,
+            host: "test.example.com",
+            sshUser: "deploy",
+            sshPort: 22,
+            sshKey: "/tmp/test-key",
+            projectRef: "test-project",
+            environment: "test",
+            execute: async (command, args) => {
+                calls.push({ command, args });
+                index += 1;
+                return { exitCode: 0, stdout: index === 3 ? "reloaded" : "", stderr: "" };
+            },
+        });
+        const response = await tool!({ action: "sync", target: "functions", function: "api", project_dir: root });
+        expect(response.isError).not.toBe(true);
+        expect(calls.map((call) => call.command)).toEqual(["ssh", "rsync", "ssh"]);
+        expect(calls[1].args).not.toContain("sh");
+        expect(calls[1].args).toContain("--checksum");
+    });
+
+    test("rejects production before starting a remote process", async () => {
+        let tool: ((args: any) => Promise<any>) | undefined;
+        registerRemoteDevTools({ tool(_name, _description, _schema, handler) { tool = handler; } }, {
+            host: "test.example.com",
+            sshUser: "deploy",
+            sshKey: "/tmp/test-key",
+            projectRef: "prod-project",
+            environment: "production",
+            execute: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        });
+        await expect(tool!({ action: "status" })).rejects.toThrow("forbidden for production");
+    });
+
+    test("generates Drizzle migrations and previews SupaCloud apply without writing by default", async () => {
+        const root = await mkdtemp(join(tmpdir(), "supacloud-drizzle-"));
+        await writeFile(join(root, "drizzle.config.ts"), "export default {}\n");
+        const commands: string[] = [];
+        const databaseCalls: any[] = [];
+        let tool: ((args: any) => Promise<any>) | undefined;
+        registerRemoteDevTools({ tool(_name, _description, _schema, handler) { tool = handler; } }, {
+            cwd: root,
+            projectRef: "test-project",
+            environment: "test",
+            execute: async (command) => {
+                commands.push(command);
+                return { exitCode: 0, stdout: "generated", stderr: "" };
+            },
+            runDatabase: async (args) => {
+                databaseCalls.push(args);
+                return { content: [{ type: "text", text: "dry-run ok" }] };
+            },
+        });
+        const response = await tool!({ action: "migrate", project_dir: root });
+        expect(response.isError).not.toBe(true);
+        expect(commands).toEqual(["drizzle-kit"]);
+        expect(databaseCalls).toEqual([{ action: "push_migrations", dir: "supabase/migrations", dry_run: true, strict: true }]);
+        expect(response.content[0].text).toContain('"applied": false');
+    });
+});

--- a/packages/cli/src/shared/tools/remote-dev-tools.ts
+++ b/packages/cli/src/shared/tools/remote-dev-tools.ts
@@ -1,0 +1,305 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { Type } from "@sinclair/typebox";
+import { compileProject } from "@supacloud/compiler";
+import { optional, stringEnum, withDescription } from "../schema";
+import type { ToolSchema } from "../schema";
+
+type ToolServer = { tool: (name: string, description: string, schema: ToolSchema, callback: (args: any) => Promise<any>) => void };
+type CommandResult = { exitCode: number; stdout: string; stderr: string };
+type CommandExecutor = (command: string, args: string[], cwd: string) => Promise<CommandResult>;
+type DatabaseCallback = (args: Record<string, unknown>) => Promise<any>;
+
+export interface RemoteDevToolOptions {
+    cwd?: string;
+    host?: string;
+    sshUser?: string;
+    sshPort?: number;
+    sshKey?: string;
+    projectRef?: string;
+    environment?: string;
+    execute?: CommandExecutor;
+    runDatabase?: DatabaseCallback;
+}
+
+interface DevConfig {
+    host?: string;
+    user?: string;
+    port?: number;
+    key?: string;
+    remoteRoot?: string;
+    reloadCommand?: string;
+    statusCommand?: string;
+    excludes?: string[];
+    compile?: boolean;
+    compileRoot?: string;
+    compileOutDir?: string;
+    compileStrict?: boolean;
+    database?: {
+        drizzleConfig?: string;
+        migrationsDir?: string;
+        drizzleBin?: string;
+        strict?: boolean;
+    };
+}
+
+interface ProjectConfig {
+    dev?: DevConfig;
+    targets?: Record<string, { type?: string; root?: string; slug?: string }>;
+}
+
+const SAFE_TOKEN = /^[A-Za-z0-9._:@/+,-]+$/;
+const SAFE_REMOTE_ROOT = /^\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+\/?$/;
+
+export const remoteDevToolSchema = {
+    action: withDescription(stringEnum(["sync", "watch", "status", "migrate"]), "Remote development action"),
+    target: optional(stringEnum(["db", "functions", "frontend", "project"]), "Sync target (default: project)"),
+    project_dir: optional(Type.String(), "Local project directory (default: current directory)"),
+    remote_root: optional(Type.String(), "Remote development root"),
+    remote_host: optional(Type.String(), "Remote test server host"),
+    remote_user: optional(Type.String(), "SSH user"),
+    remote_port: optional(Type.Number(), "SSH port"),
+    remote_key: optional(Type.String(), "SSH private key path"),
+    function: optional(Type.String(), "Function slug"),
+    delete: optional(Type.Boolean(), "Delete remote files absent locally"),
+    reload: optional(Type.Boolean(), "Reload the affected target after sync (default: true)"),
+    interval_ms: optional(Type.Number(), "Watch debounce interval in milliseconds (default: 300)"),
+    json: optional(Type.Boolean(), "Emit machine-readable JSON"),
+    apply: optional(Type.Boolean(), "Apply generated migrations to the selected test database"),
+    drizzle_config: optional(Type.String(), "Drizzle config path"),
+    migrations_dir: optional(Type.String(), "Migration directory"),
+    drizzle_bin: optional(Type.String(), "drizzle-kit executable"),
+};
+
+function runProcess(executable: string, args: string[], cwd: string): Promise<CommandResult> {
+    return new Promise((resolveResult, reject) => {
+        const child = spawn(executable, args, { cwd, shell: false, stdio: ["ignore", "pipe", "pipe"] });
+        let stdout = "";
+        let stderr = "";
+        child.stdout?.setEncoding("utf8");
+        child.stderr?.setEncoding("utf8");
+        child.stdout?.on("data", (chunk) => { stdout += String(chunk); });
+        child.stderr?.on("data", (chunk) => { stderr += String(chunk); });
+        child.once("error", reject);
+        child.once("close", (exitCode) => resolveResult({ exitCode: exitCode ?? 1, stdout, stderr }));
+    });
+}
+
+function resolveDrizzleCommand(root: string, configured: string | undefined): string {
+    if (configured?.trim()) return configured.trim();
+    const local = join(root, "node_modules", ".bin", "drizzle-kit");
+    return existsSync(local) ? local : "drizzle-kit";
+}
+
+function toolFailed(value: any): boolean {
+    return value?.isError === true || value?.content?.some((chunk: any) => typeof chunk?.text === "string" && chunk.text.trimStart().startsWith("❌"));
+}
+
+async function migrateDatabase(args: Record<string, unknown>, options: RemoteDevToolOptions): Promise<Record<string, unknown>> {
+    const root = resolve(String(args.project_dir || options.cwd || process.cwd()));
+    const projectConfig = await readProjectConfig(root);
+    const config = projectConfig.dev || {};
+    const database = config.database || {};
+    const execute = options.execute || ((command, commandArgs, cwd) => runProcess(command, commandArgs, cwd));
+    const drizzleConfig = resolve(root, String(args.drizzle_config || database.drizzleConfig || "drizzle.config.ts"));
+    const migrationsDir = String(args.migrations_dir || database.migrationsDir || "supabase/migrations");
+    if (!existsSync(drizzleConfig)) throw new Error(`Drizzle config not found: ${drizzleConfig}`);
+    const generated = await execute(resolveDrizzleCommand(root, typeof args.drizzle_bin === "string" ? args.drizzle_bin : database.drizzleBin), ["generate", "--config", drizzleConfig], root);
+    if (generated.exitCode !== 0) throw new Error(`Drizzle migration generation failed: ${generated.stderr.trim() || `exit ${generated.exitCode}`}`);
+    if (!options.runDatabase) throw new Error("dev migrate requires Management API context");
+    const dryRun = await options.runDatabase({ action: "push_migrations", dir: migrationsDir, dry_run: true, strict: database.strict !== false });
+    if (toolFailed(dryRun)) throw new Error("SupaCloud migration dry-run failed");
+    if (args.apply !== true) return { ok: true, mode: "dev", action: "migrate", generated: true, applied: false, migrations_dir: migrationsDir, dry_run: dryRun };
+    const applied = await options.runDatabase({ action: "push_migrations", dir: migrationsDir, strict: database.strict !== false });
+    if (toolFailed(applied)) throw new Error("SupaCloud migration apply failed");
+    return { ok: true, mode: "dev", action: "migrate", generated: true, applied: true, migrations_dir: migrationsDir, result: applied };
+}
+
+async function readProjectConfig(root: string): Promise<ProjectConfig> {
+    const file = join(root, "supacloud.json");
+    if (!existsSync(file)) return {};
+    try {
+        const parsed = JSON.parse(await readFile(file, "utf8"));
+        return parsed && typeof parsed === "object" ? parsed as ProjectConfig : {};
+    } catch (error) {
+        throw new Error(`Invalid supacloud.json: ${error instanceof Error ? error.message : String(error)}`);
+    }
+}
+
+async function readDevConfig(root: string): Promise<DevConfig> {
+    const config = await readProjectConfig(root);
+    return config.dev || {};
+}
+
+async function sourceFingerprint(root: string): Promise<string> {
+    const files: string[] = [];
+    const visit = async (directory: string): Promise<void> => {
+        const entries = await readdir(directory, { withFileTypes: true });
+        for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+            const path = join(directory, entry.name);
+            if (entry.isDirectory() && ![".git", "node_modules", "dist", "generated", ".supacloud"].includes(entry.name)) await visit(path);
+            else if (entry.isFile()) files.push(path);
+        }
+    };
+    await visit(root);
+    const hash = createHash("sha256");
+    for (const file of files) {
+        hash.update(file.slice(root.length).replace(/\\/g, "/"));
+        hash.update(await readFile(file));
+    }
+    return hash.digest("hex");
+}
+
+function safeToken(value: string, label: string): string {
+    if (!value || !SAFE_TOKEN.test(value)) throw new Error(`Invalid ${label}`);
+    return value;
+}
+
+function remoteRoot(value: string): string {
+    const normalized = value.trim().replace(/\\/g, "/");
+    if (!SAFE_REMOTE_ROOT.test(normalized) || normalized.includes("..")) throw new Error("Invalid remote_root");
+    return normalized.replace(/\/$/, "");
+}
+
+function targetDirectory(root: string, target: string, functionSlug?: string, config: Record<string, unknown> = {}): string {
+    if (target === "db") return join(root, "supabase", "migrations");
+    if (target === "functions") {
+        const targets = config.targets && typeof config.targets === "object" ? config.targets as Record<string, any> : {};
+        const match = Object.values(targets).find((entry) => entry?.type === "edge_function"
+            && (!functionSlug || String(entry.slug || "") === functionSlug));
+        const base = match?.root ? resolve(root, String(match.root)) : join(root, "supabase", "functions");
+        return match?.root ? base : functionSlug ? join(base, safeToken(functionSlug, "function")) : base;
+    }
+    if (target === "frontend") {
+        const targets = config.targets && typeof config.targets === "object" ? config.targets as Record<string, any> : {};
+        const match = Object.values(targets).find((entry) => entry?.type === "frontend");
+        return match?.root ? resolve(root, String(match.root)) : join(root, "apps", "web");
+    }
+    return root;
+}
+
+function remoteTargetRoot(root: string, target: string, functionSlug?: string): string {
+    if (target === "db") return `${root}/database/migrations`;
+    if (target === "functions") return `${root}/functions/${functionSlug ? safeToken(functionSlug, "function") : ""}`.replace(/\/$/, "");
+    if (target === "frontend") return `${root}/frontend`;
+    return `${root}/project`;
+}
+
+function connectionArgs(options: RemoteDevToolOptions, config: DevConfig, args: Record<string, unknown>): { host: string; user: string; port: number; key: string } {
+    const host = String(args.remote_host || config.host || options.host || "").trim();
+    const user = String(args.remote_user || config.user || options.sshUser || "").trim();
+    const port = Number(args.remote_port || config.port || options.sshPort || 22);
+    const key = String(args.remote_key || config.key || options.sshKey || "").trim();
+    if (!host) throw new Error("Remote dev requires SUPACLOUD_HOST or --remote_host");
+    safeToken(host, "remote_host");
+    safeToken(user, "remote_user");
+    if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error("Invalid remote_port");
+    if (!key || key.includes("\0") || key.includes("\n")) throw new Error("Invalid remote_key");
+    return { host, user, port, key };
+}
+
+function targetConfigPath(target: string): string {
+    return target === "project" ? "project" : target;
+}
+
+function reloadCommand(config: DevConfig, target: string, projectRef: string | undefined, functionSlug?: string): string[] {
+    const command = config.reloadCommand?.trim() || "supacloud-dev-agent reload";
+    if (!/^[A-Za-z0-9._/-]+(?: [A-Za-z0-9._:/=-]+)*$/.test(command)) throw new Error("Invalid reloadCommand in supacloud.json");
+    return [...command.split(" "), "--project-ref", safeToken(projectRef || "test", "project_ref"), "--target", targetConfigPath(target), ...(functionSlug ? ["--function", safeToken(functionSlug, "function")] : [])];
+}
+
+function sshArgs(connection: { host: string; user: string; port: number; key: string }, remoteCommand: string[]): string[] {
+    return ["-p", String(connection.port), "-i", resolve(connection.key), "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=yes", `${connection.user}@${connection.host}`, ...remoteCommand];
+}
+
+function rsyncArgs(connection: { host: string; user: string; port: number; key: string }, source: string, destination: string, excludes: string[], deleteRemote: boolean): string[] {
+    const args = ["-az", "--checksum", "--partial", "--protect-args", "-e", `ssh -p ${connection.port} -i ${resolve(connection.key)} -o BatchMode=yes -o StrictHostKeyChecking=yes`];
+    if (deleteRemote) args.push("--delete-delay");
+    for (const exclude of excludes) {
+        if (!/^\/?[A-Za-z0-9._*/-]+$/.test(exclude)) throw new Error("Invalid dev exclude pattern");
+        args.push("--exclude", exclude);
+    }
+    args.push(`${source.replace(/\/$/, "")}/`, `${connection.user}@${connection.host}:${destination.replace(/\/$/, "")}/`);
+    return args;
+}
+
+async function syncOnce(args: Record<string, unknown>, options: RemoteDevToolOptions): Promise<Record<string, unknown>> {
+    const root = resolve(String(args.project_dir || options.cwd || process.cwd()));
+    const projectConfig = await readProjectConfig(root);
+    const config = projectConfig.dev || {};
+    const target = String(args.target || "project");
+    const source = targetDirectory(root, target, typeof args.function === "string" ? args.function : undefined, projectConfig as Record<string, unknown>);
+    if (!existsSync(source)) throw new Error(`Dev source directory not found: ${source}`);
+    let compiled = false;
+    if (config.compile === true && target !== "db") {
+        const compileRoot = resolve(root, config.compileRoot || ".");
+        const compileOutDir = resolve(root, config.compileOutDir || "generated");
+        const compilation = await compileProject({
+            rootDir: compileRoot,
+            outDir: compileOutDir,
+            strict: config.compileStrict !== false,
+        });
+        const errors = compilation.diagnostics.filter((diagnostic) => diagnostic.severity === "error");
+        if (errors.length > 0) {
+            throw new Error(`DI compile failed: ${errors.map((diagnostic) => `${diagnostic.code} ${diagnostic.message}`).join("; ")}`);
+        }
+        compiled = true;
+    }
+    const remoteBase = remoteRoot(String(args.remote_root || config.remoteRoot || `/var/lib/supacloud/dev/${options.projectRef || "project"}`));
+    const slug = typeof args.function === "string" ? args.function : undefined;
+    const destination = remoteTargetRoot(remoteBase, target, slug);
+    const connection = connectionArgs(options, config, args);
+    const execute = options.execute || ((command, commandArgs, cwd) => runProcess(command, commandArgs, cwd));
+    const mkdir = await execute("ssh", sshArgs(connection, ["mkdir", "-p", destination]), root);
+    if (mkdir.exitCode !== 0) throw new Error(`Remote dev prepare failed: ${mkdir.stderr.trim() || `exit ${mkdir.exitCode}`}`);
+    const excludes = Array.isArray(config.excludes) ? config.excludes : ["node_modules", ".git", ".env*", "dist", ".supacloud"];
+    const sync = await execute("rsync", rsyncArgs(connection, source, destination, excludes, args.delete === true), root);
+    if (sync.exitCode !== 0) throw new Error(`Remote dev sync failed: ${sync.stderr.trim() || `exit ${sync.exitCode}`}`);
+    const shouldReload = args.reload !== false;
+    let reload: CommandResult | null = null;
+    if (shouldReload) {
+        reload = await execute("ssh", sshArgs(connection, reloadCommand(config, target, options.projectRef, slug)), root);
+        if (reload.exitCode !== 0) throw new Error(`Remote dev reload failed: ${reload.stderr.trim() || `exit ${reload.exitCode}`}`);
+    }
+    return { ok: true, mode: "dev", action: "sync", environment: options.environment || null, target, source, destination, host: connection.host, compiled, reloaded: shouldReload };
+}
+
+export function registerRemoteDevTools(server: ToolServer, options: RemoteDevToolOptions = {}): void {
+    server.tool("dev", "Remote test-server development sync. It never targets production and never syncs secrets.", remoteDevToolSchema, async (args) => {
+        if (["production", "prod"].includes((options.environment || "").toLowerCase())) throw new Error("Remote dev mode is forbidden for production environments");
+        if (args.action === "status") {
+            const root = resolve(String(args.project_dir || options.cwd || process.cwd()));
+            const config = await readDevConfig(root);
+            const connection = connectionArgs(options, config, args);
+            const execute = options.execute || ((command, commandArgs, cwd) => runProcess(command, commandArgs, cwd));
+            const status = await execute("ssh", sshArgs(connection, ["supacloud-dev-agent", "status", "--project-ref", safeToken(options.projectRef || "test", "project_ref")]), root);
+            return { content: [{ type: "text" as const, text: JSON.stringify({ ok: status.exitCode === 0, mode: "dev", action: "status", host: connection.host, output: status.stdout.trim(), error: status.stderr.trim() }, null, 2) }], isError: status.exitCode !== 0 };
+        }
+        if (args.action === "sync") {
+            return { content: [{ type: "text" as const, text: JSON.stringify(await syncOnce(args, options), null, 2) }] };
+        }
+        if (args.action === "migrate") {
+            return { content: [{ type: "text" as const, text: JSON.stringify(await migrateDatabase(args, options), null, 2) }] };
+        }
+        if (args.action === "watch") {
+            const root = resolve(String(args.project_dir || options.cwd || process.cwd()));
+            const interval = Math.max(100, Math.min(10_000, Number(args.interval_ms || 300)));
+            let fingerprint = "";
+            let lastSync: Record<string, unknown> | null = null;
+            for (;;) {
+                const nextFingerprint = await sourceFingerprint(root);
+                if (nextFingerprint !== fingerprint) {
+                    lastSync = await syncOnce(args, options);
+                    fingerprint = nextFingerprint;
+                    process.stdout.write(`${JSON.stringify({ ...lastSync, watching: true })}\n`);
+                }
+                await new Promise((resolveDelay) => setTimeout(resolveDelay, interval));
+            }
+        }
+        throw new Error("Unsupported remote dev action");
+    });
+}


### PR DESCRIPTION
## Summary
Adds remote test server development synchronization and Drizzle migration workflow to `supacloud-cli`.

### Key Capabilities
- `supacloud-cli --env test dev sync`: sync source files via SSH and checksum-aware `rsync`, triggering target reload agent without full immutable deployments.
- `supacloud-cli --env test dev watch`: watch local source tree and sync changes.
- `supacloud-cli --env test dev migrate`: executes `drizzle-kit generate`, performs SupaCloud migration dry-run linting, and safely applies with `--apply`.
- Execution policy fail-closed protection against production environments.

### Verification
- `bun test packages/cli/src/shared/tools/remote-dev-tools.test.ts` passed (3 pass, 0 fail)
- `bun run --filter @supacloud/cli build` passed (bundled 372 modules)
- `bun run --filter @supacloud/cli typecheck` passed
- `git diff --check` passed