### PR TITLE
feat(cli): export app commands as AI tool contracts

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -219,6 +219,8 @@ supacloud-cli app compile --root . --out_dir generated --strict
 supacloud-cli app check
 supacloud-cli app graph --format json
 supacloud-cli app explain --target CaseService
+supacloud-cli app export-tools
+supacloud-cli app export-tools --format json
 
 # SQL governance over defineDatabaseModule sources
 supacloud-cli db lint --module_file db/modules.ts
@@ -230,6 +232,13 @@ supacloud-cli db module_check --module_file db/modules.ts --database_url "$DATAB
 # or reconcile against a local SupaCloud Lite project (delegates to supacloud-lite db check)
 supacloud-cli db module_check --lite --project_dir .
 ```
+
+`app export-tools` reads `generated/app.manifest.json` and exports commands with
+declared permissions as OpenAI Function Calling and MCP tool contracts. The
+default mode writes `generated/tool-definitions.openai.json` and
+`generated/tool-definitions.mcp.json`; `--format json` prints both contracts
+without writing files. Input schemas retain their source TypeBox symbol names
+as references until a schema exporter is added to the compiler.
 
 `db module_check` is classified read-only: it introspects `pg_policy`,
 `pg_proc`, `pg_class` and grants, and reports drift between the declared

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -72,7 +72,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
         write: ["send", "receive", "ack", "release", "fail", "retry", "delete_message", "update_settings"],
     },
     ai: { local: ["show_skill", "install_skill"] },
-    app: { local: ["generate", "compile", "check", "graph", "explain"] },
+    app: { local: ["generate", "compile", "check", "graph", "explain", "export-tools"] },
     db: { local: ["lint", "explain"], read: ["module_check"] },
     dev: { read: ["status"], write: ["sync", "watch", "migrate"] },
 };

--- a/packages/cli/src/shared/tools/app-tool-export.ts
+++ b/packages/cli/src/shared/tools/app-tool-export.ts
@@ -1,0 +1,178 @@
+import type { ModuleNode } from "@supacloud/compiler";
+
+export interface AppManifest {
+    version: number;
+    modules: ModuleNode[];
+    externalTokens: string[];
+}
+
+export interface ToolSchemaProperty {
+    type: string;
+    description: string;
+    additionalProperties?: boolean;
+}
+
+export interface ToolInputSchema {
+    type: "object";
+    properties: Record<string, ToolSchemaProperty>;
+    required: string[];
+    additionalProperties?: boolean;
+}
+
+export interface OpenAIToolDefinition {
+    type: "function";
+    function: {
+        name: string;
+        description: string;
+        parameters: ToolInputSchema;
+    };
+}
+
+export interface McpToolDefinition {
+    name: string;
+    description: string;
+    inputSchema: ToolInputSchema;
+    annotations: {
+        readOnly: boolean;
+        audited: boolean;
+        permission: string;
+        httpPath?: string;
+        httpMethod?: string;
+    };
+}
+
+export interface ExportedToolDefinitions {
+    openai: OpenAIToolDefinition[];
+    mcp: McpToolDefinition[];
+}
+
+interface CommandRoute {
+    httpMethod: string;
+    path: string;
+    bodySchema?: string;
+    paramsSchema?: string;
+    querySchema?: string;
+}
+
+function sanitizeToolName(name: string): string {
+    const sanitized = name.replace(/[^a-zA-Z0-9_]/g, "_").slice(0, 64);
+    return sanitized || "supacloud_command";
+}
+
+function uniqueToolName(name: string, moduleName: string, used: Set<string>): string {
+    const base = sanitizeToolName(name);
+    if (!used.has(base)) {
+        used.add(base);
+        return base;
+    }
+
+    const prefix = sanitizeToolName(moduleName).slice(0, 32);
+    const candidateBase = `${prefix}_${base}`.slice(0, 64);
+    let candidate = candidateBase;
+    let suffix = 2;
+    while (used.has(candidate)) {
+        candidate = `${candidateBase.slice(0, 64 - String(suffix).length - 1)}_${suffix}`;
+        suffix += 1;
+    }
+    used.add(candidate);
+    return candidate;
+}
+
+function findRouteForCommand(manifest: AppManifest, commandClassName: string): CommandRoute | undefined {
+    for (const module of manifest.modules) {
+        for (const controller of module.controllers) {
+            for (const route of controller.routes) {
+                if (route.command !== commandClassName) continue;
+                return {
+                    httpMethod: route.method,
+                    path: `${controller.path}${route.path}`,
+                    bodySchema: route.body,
+                    paramsSchema: route.params,
+                    querySchema: route.query,
+                };
+            }
+        }
+    }
+    return undefined;
+}
+
+function inputSchema(route: CommandRoute | undefined): ToolInputSchema {
+    const properties: Record<string, ToolSchemaProperty> = {};
+
+    if (route?.bodySchema) {
+        properties.body = {
+            type: "object",
+            description: `Request body. Schema reference: ${route.bodySchema}`,
+            additionalProperties: true,
+        };
+    }
+    if (route?.paramsSchema) {
+        properties.params = {
+            type: "object",
+            description: `Path parameters. Schema reference: ${route.paramsSchema}`,
+            additionalProperties: true,
+        };
+    }
+    if (route?.querySchema) {
+        properties.query = {
+            type: "object",
+            description: `Query parameters. Schema reference: ${route.querySchema}`,
+            additionalProperties: true,
+        };
+    }
+
+    return {
+        type: "object",
+        properties,
+        required: [],
+        additionalProperties: Object.keys(properties).length === 0,
+    };
+}
+
+function descriptionForCommand(
+    command: ModuleNode["commands"][number],
+    route: CommandRoute | undefined,
+): string {
+    const parts = [`Command ${command.name}`, `permission ${command.permission}`];
+    if (command.transaction === "required") parts.push("transaction required");
+    if (command.idempotency === "required") parts.push("idempotent");
+    if (command.audit) parts.push(`audit ${command.audit}`);
+    if (route) parts.push(`HTTP ${route.httpMethod} ${route.path}`);
+    return `${parts.join("; ")}.`;
+}
+
+export function buildToolDefinitions(manifest: AppManifest): ExportedToolDefinitions {
+    const openai: OpenAIToolDefinition[] = [];
+    const mcp: McpToolDefinition[] = [];
+    const usedNames = new Set<string>();
+
+    for (const module of manifest.modules) {
+        for (const command of module.commands) {
+            if (!command.permission) continue;
+
+            const route = findRouteForCommand(manifest, command.className);
+            const name = uniqueToolName(command.name, module.name, usedNames);
+            const description = descriptionForCommand(command, route);
+            const parameters = inputSchema(route);
+
+            openai.push({
+                type: "function",
+                function: { name, description, parameters },
+            });
+            mcp.push({
+                name,
+                description,
+                inputSchema: parameters,
+                annotations: {
+                    readOnly: false,
+                    audited: !!command.audit,
+                    permission: command.permission,
+                    ...(route ? { httpPath: route.path, httpMethod: route.httpMethod } : {}),
+                },
+            });
+        }
+    }
+
+    return { openai, mcp };
+}
+

--- a/packages/cli/src/shared/tools/app-tools.test.ts
+++ b/packages/cli/src/shared/tools/app-tools.test.ts
@@ -106,8 +106,13 @@ export class AcceptCaseCommand {
 }
 `,
 
-    "src/features/case/case.controller.ts": `import { Controller, Get, Inject } from "../../runtime";
+    "src/features/case/case.controller.ts": `import { Controller, Get, Inject, Post } from "../../runtime";
 import { CaseService } from "./case.service";
+import { AcceptCaseCommand } from "./accept-case.command";
+
+const AcceptCaseBody = { type: "object" };
+const AcceptCaseParams = { type: "object" };
+const AcceptCaseQuery = { type: "object" };
 
 @Controller("/cases")
 export class CaseController {
@@ -115,6 +120,16 @@ export class CaseController {
 
   @Get("/:caseId")
   detail(): { ok: boolean } {
+    return { ok: true };
+  }
+
+  @Post("/accept", {
+    command: AcceptCaseCommand,
+    body: AcceptCaseBody,
+    params: AcceptCaseParams,
+    query: AcceptCaseQuery,
+  })
+  accept(): { ok: boolean } {
     return { ok: true };
   }
 }
@@ -264,6 +279,42 @@ describe("app tools", () => {
         expect(missing.content[0].text).toContain("未找到对象: Nope");
     });
 
+    test("export-tools writes OpenAI and MCP definitions from command governance metadata", async () => {
+        await app({ action: "compile", root });
+        const result = await app({ action: "export-tools", root });
+        expect(result.isError).toBe(false);
+        expect(result.content[0].text).toContain("case_accept");
+
+        const openai = JSON.parse(readFileSync(join(root, "generated/tool-definitions.openai.json"), "utf8"));
+        expect(openai).toHaveLength(1);
+        expect(openai[0].function.name).toBe("case_accept");
+        expect(openai[0].function.description).toContain("permission case.accept");
+        expect(openai[0].function.description).toContain("HTTP POST /cases/accept");
+        expect(openai[0].function.parameters.properties).toEqual(expect.objectContaining({
+            body: expect.any(Object),
+            params: expect.any(Object),
+            query: expect.any(Object),
+        }));
+
+        const mcp = JSON.parse(readFileSync(join(root, "generated/tool-definitions.mcp.json"), "utf8"));
+        expect(mcp[0].annotations).toEqual(expect.objectContaining({
+            readOnly: false,
+            audited: true,
+            permission: "case.accept",
+            httpMethod: "POST",
+            httpPath: "/cases/accept",
+        }));
+    });
+
+    test("export-tools json format returns both contracts without writing artifacts", async () => {
+        const result = await app({ action: "export-tools", root, format: "json" });
+        expect(result.isError).toBe(false);
+        const payload = JSON.parse(result.content[0].text);
+        expect(payload.openai[0].function.name).toBe("case_accept");
+        expect(payload.mcp[0].inputSchema.properties.body.description)
+            .toContain("AcceptCaseBody");
+    });
+
     test("graph/explain fail with a clear error when the manifest is missing", async () => {
         const emptyRoot = mkdtempSync(join(tmpdir(), "supacloud-app-tools-empty-"));
         try {
@@ -277,7 +328,7 @@ describe("app tools", () => {
     });
 
     test("all app actions are classified as local in the execution policy", () => {
-        for (const action of ["generate", "compile", "check", "graph", "explain"]) {
+        for (const action of ["generate", "compile", "check", "graph", "explain", "export-tools"]) {
             expect(executionMode("app", action, {})).toBe("local");
         }
     });

--- a/packages/cli/src/shared/tools/app-tools.ts
+++ b/packages/cli/src/shared/tools/app-tools.ts
@@ -11,6 +11,7 @@ import {
 } from "@supacloud/compiler";
 import { optional, stringEnum, withDescription } from "../schema";
 import type { ToolSchema } from "../schema";
+import { buildToolDefinitions, type AppManifest } from "./app-tool-export";
 
 type ToolServer = {
     tool: (
@@ -22,7 +23,7 @@ type ToolServer = {
 };
 
 export interface AppToolArguments {
-    action: "generate" | "compile" | "check" | "graph" | "explain";
+    action: "generate" | "compile" | "check" | "graph" | "explain" | "export-tools";
     kind?: "module" | "command" | "query" | "controller";
     name?: string;
     module?: string;
@@ -209,12 +210,6 @@ async function runCheck(args: AppToolArguments): Promise<ToolResult> {
     return textResult(`${formatDiagnostics(diagnostics)}\n\n${summary}`, hasError);
 }
 
-interface AppManifest {
-    version: number;
-    modules: ModuleNode[];
-    externalTokens: string[];
-}
-
 async function readManifest(root: string): Promise<AppManifest> {
     const manifestPath = join(root, "generated", "app.manifest.json");
     if (!existsSync(manifestPath)) {
@@ -376,22 +371,50 @@ async function runExplain(args: AppToolArguments): Promise<ToolResult> {
     return textResult(`未找到对象: ${target}`, true);
 }
 
+async function runExportTools(args: AppToolArguments): Promise<ToolResult> {
+    const root = resolve(args.root || process.cwd());
+    const manifest = await readManifest(root);
+    const definitions = buildToolDefinitions(manifest);
+
+    const outDir = resolve(args.out_dir || join(root, "generated"));
+    await mkdir(outDir, { recursive: true });
+
+    if (args.format === "json") {
+        // JSON mode returns the combined contract on stdout without writing artifacts.
+        return textResult(JSON.stringify(definitions, null, 2));
+    }
+
+    const openaiPath = join(outDir, "tool-definitions.openai.json");
+    const mcpPath = join(outDir, "tool-definitions.mcp.json");
+    await writeFile(openaiPath, JSON.stringify(definitions.openai, null, 2), "utf8");
+    await writeFile(mcpPath, JSON.stringify(definitions.mcp, null, 2), "utf8");
+
+    const summary = [
+        `exported ${definitions.openai.length} tool(s):`,
+        `  openai → ${openaiPath}`,
+        `  mcp    → ${mcpPath}`,
+        "",
+        definitions.openai.map((t) => `  ${t.function.name}`).join("\n"),
+    ].join("\n");
+    return textResult(summary);
+}
+
 export function registerAppTools(server: ToolServer): void {
     server.tool(
         "app",
-        "Local @supacloud/app framework commands: scaffold, compile, check, graph and explain. Actions: generate, compile, check, graph, explain",
+        "Local @supacloud/app framework commands: scaffold, compile, check, graph, explain and export-tools. Actions: generate, compile, check, graph, explain, export-tools",
         {
-            action: withDescription(stringEnum(["generate", "compile", "check", "graph", "explain"]), "App action"),
+            action: withDescription(stringEnum(["generate", "compile", "check", "graph", "explain", "export-tools"]), "App action"),
             kind: optional(stringEnum(["module", "command", "query", "controller"]), "[generate] Scaffold kind"),
             name: optional(Type.String(), "[generate] Object name (module name / command / query name)"),
             module: optional(Type.String(), "[generate] Target feature module (required for command/query/controller)"),
             dir: optional(Type.String(), "[generate] Feature root directory (default: src/features)"),
             force: optional(Type.Boolean(), "[generate] Overwrite existing files"),
-            root: optional(Type.String(), "[generate/compile/check/graph/explain] Project root (default: current directory)"),
+            root: optional(Type.String(), "[generate/compile/check/graph/explain/export-tools] Project root (default: current directory)"),
             include: optional(Type.String(), "[compile/check] Comma-separated glob patterns for source files"),
-            out_dir: optional(Type.String(), "[compile] Output directory (default: <root>/generated)"),
+            out_dir: optional(Type.String(), "[compile/export-tools] Output directory (default: <root>/generated)"),
             strict: optional(Type.Boolean(), "[compile/check] Promote warnings to errors"),
-            format: optional(stringEnum(["text", "json"]), "[graph] Output format (default: text)"),
+            format: optional(stringEnum(["text", "json"]), "[graph/export-tools] Output format (default: text)"),
             target: optional(Type.String(), "[explain] Provider class name / token name / command name"),
         },
         async (request) => {
@@ -401,6 +424,7 @@ export function registerAppTools(server: ToolServer): void {
                 case "check": return runCheck(request);
                 case "graph": return runGraph(request);
                 case "explain": return runExplain(request);
+                case "export-tools": return runExportTools(request);
                 default:
                     return textResult(`Unknown app action: ${String(request.action)}`, true);
             }


### PR DESCRIPTION
## Summary

- add `supacloud-cli app export-tools`
- export permissioned `@Command` metadata as OpenAI Function Calling and MCP tool contracts
- preserve body, path params, and query schema symbol references from the compiled app manifest
- write stable JSON artifacts or return both contracts with `--format json`
- add regression coverage, execution-policy classification, and CLI documentation

## Verification

- `bun test src/shared/tools/app-tools.test.ts`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

Schema fields currently retain TypeBox symbol references because the manifest does not yet serialize full JSON Schema. A follow-up compiler capability can replace these permissive object fields with exact schemas.