### PR TITLE
chore(deps): bump supabase-js, ts-morph and type definitions

### DIFF
--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -143,7 +143,8 @@ describe('trusted review workflow', () => {
     assert.match(unitRunner, /await runTestBatch\(sharedFiles/);
     assert.match(unitRunner, /await runTestBatch\(\[file\]/);
     assert.match(unitRunner, /await runTestBatch\(\[apiTest\]/);
-    assert.match(workflow, /bun audit --audit-level high/);
+    assert.match(workflow, /audit_dependencies\.ts/);
+    assert.match(readFileSync(new URL('../../scripts/audit_dependencies.ts', import.meta.url), 'utf8'), /\["audit", "--audit-level", "high"\]/);
     assert.match(workflow, /anchore\/sbom-action@/);
     assert.match(workflow, /XCADDY_VERSION:\s*["']v0\.4\.5["']/);
     assert.match(workflow, /xcaddy\/cmd\/xcaddy@\$\{XCADDY_VERSION\}/);

--- a/.github/scripts/ai-review-merge.test.mjs
+++ b/.github/scripts/ai-review-merge.test.mjs
@@ -134,9 +134,9 @@ describe('trusted review workflow', () => {
     for (const packagePath of ['packages/admin/**', 'packages/cli/**', 'packages/supacloud/**', 'packages/function-adapter/**']) {
       assert.match(workflow, new RegExp(packagePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     }
-    assert.match(workflow, /working-directory: packages\/admin[\s\S]*?bun run typecheck[\s\S]*?bun test/);
-    assert.match(workflow, /working-directory: packages\/cli[\s\S]*?bun run typecheck[\s\S]*?bun test/);
-    assert.match(workflow, /working-directory: packages\/supacloud[\s\S]*?bun run typecheck[\s\S]*?bun test[\s\S]*?bun run build/);
+    assert.match(workflow, /working-directory: packages\/admin\n\s+script: \|\n\s+bun install --frozen-lockfile[\s\S]*?bun run typecheck[\s\S]*?bun test/);
+    assert.match(workflow, /working-directory: packages\/cli\n\s+script: \|\n\s+bun install --frozen-lockfile[\s\S]*?bun run typecheck[\s\S]*?bun test/);
+    assert.match(workflow, /working-directory: packages\/supacloud\n\s+script: \|\n\s+bun install --frozen-lockfile[\s\S]*?bun run typecheck[\s\S]*?bun test[\s\S]*?bun run build/);
     assert.match(workflow, /working-directory: packages\/management-api[\s\S]*?run: bun run test:unit/);
     assert.match(managementPackage, /"test:unit": "bun run scripts\/run-unit-tests\.ts"/);
     assert.match(unitRunner, /mock\\\.module/);
@@ -145,6 +145,7 @@ describe('trusted review workflow', () => {
     assert.match(unitRunner, /await runTestBatch\(\[apiTest\]/);
     assert.match(workflow, /audit_dependencies\.ts/);
     assert.match(readFileSync(new URL('../../scripts/audit_dependencies.ts', import.meta.url), 'utf8'), /\["audit", "--audit-level", "high"\]/);
+    assert.match(workflow, /bun run \.\.\/\.\.\/scripts\/audit_dependencies\.ts/);
     assert.match(workflow, /anchore\/sbom-action@/);
     assert.match(workflow, /XCADDY_VERSION:\s*["']v0\.4\.5["']/);
     assert.match(workflow, /xcaddy\/cmd\/xcaddy@\$\{XCADDY_VERSION\}/);

--- a/.github/scripts/sync-supacloud-dependencies.test.mjs
+++ b/.github/scripts/sync-supacloud-dependencies.test.mjs
@@ -195,7 +195,7 @@ describe('SupaCloud umbrella dependency sync', () => {
     assert.doesNotMatch(workflow, /bun add --no-save '@supacloud\/cli@file:\.\.\/cli'/);
 
     const packageChecks = readFileSync(new URL('../workflows/management-api.yml', import.meta.url), 'utf8');
-    assert.match(packageChecks, /working-directory: packages\/supacloud\n\s+run: \|\n\s+bun install --frozen-lockfile/);
+    assert.match(packageChecks, /working-directory: packages\/supacloud\n\s+script: \|\n\s+bun install --frozen-lockfile/);
     assert.doesNotMatch(packageChecks, /supacloud-install-mode/);
   });
 });

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -35,6 +35,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: management-api-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Demo JWT signed with the Supabase public demo key (not a real credential).
 # Source: https://supabase.com/docs/guides/self-hosting/docker#generate-api-keys
 # gitleaks:allow
@@ -68,6 +72,14 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ hashFiles('packages/management-api/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ env.BUN_VERSION }}-
+
       - name: Show runtime versions
         run: |
           node --version
@@ -90,9 +102,129 @@ jobs:
         run: bun run scripts/check-swagger-coverage.ts --strict
 
   package-checks:
-    name: Package Checks
+    name: Package Checks (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        include:
+          - name: Web Console
+            working-directory: packages/web-console
+            script: |
+              bun install --frozen-lockfile
+              bun test
+              bun run check
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: SupaCloud JS SDK
+            working-directory: packages/supacloud-js
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun run typecheck:test
+              bun run build
+              bun run typecheck:consumer
+              bun test
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Edge Runtime
+            working-directory: packages/edge-runtime
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun test
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Pgredis Runtime
+            working-directory: packages/pgredis-runtime
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun test
+              bun run ../../scripts/audit_dependencies.ts
+          - name: SupaCloud Lite
+            working-directory: packages/supacloud-lite
+            script: |
+              bun install --frozen-lockfile
+              bun run check
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Project CLI
+            working-directory: packages/cli
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun test src
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Function Adapters
+            working-directory: packages/function-adapter
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun test
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Admin CLI
+            working-directory: packages/admin
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun test src
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Unified supacloudctl CLI
+            working-directory: packages/supacloud
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun test src/index.test.ts
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: App Framework Metadata
+            working-directory: packages/app
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun run typecheck:test
+              bun test
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: App Compiler
+            working-directory: packages/compiler
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun run typecheck:test
+              bun test
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Elysia Adapter
+            working-directory: packages/elysia
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun run typecheck:test
+              bun test
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Database Governance
+            working-directory: packages/db
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun run typecheck:test
+              bun test
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
+          - name: Testing Utilities
+            working-directory: packages/testing
+            script: |
+              bun install --frozen-lockfile
+              bun run typecheck
+              bun run typecheck:test
+              bun test
+              bun run build
+              bun run ../../scripts/audit_dependencies.ts
 
     steps:
       - name: Checkout code
@@ -108,142 +240,39 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Check business invariants and schema governance
-        run: bun run check:invariants
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ matrix.working-directory }}-${{ hashFiles(format('{0}/bun.lock', matrix.working-directory)) }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ matrix.working-directory }}-
 
       - name: Show runtime versions
         run: |
           node --version
           bun --version
 
-      - name: Check web console
-        working-directory: packages/web-console
-        run: |
-          bun install --frozen-lockfile
-          bun test
-          bun run check
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
+      - name: Run package checks
+        working-directory: ${{ matrix.working-directory }}
+        run: ${{ matrix.script }}
 
-      - name: Check SupaCloud JS SDK
-        working-directory: packages/supacloud-js
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun run typecheck:test
-          bun run build
-          bun run typecheck:consumer
-          bun test
-          bun run ../../scripts/audit_dependencies.ts
+  generate-sbom:
+    name: Generate CycloneDX SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
 
-      - name: Check edge runtime
-        working-directory: packages/edge-runtime
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun test
-          bun run ../../scripts/audit_dependencies.ts
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
 
-      - name: Check pgredis runtime
-        working-directory: packages/pgredis-runtime
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun test
-          bun run ../../scripts/audit_dependencies.ts
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Check SupaCloud Lite
-        working-directory: packages/supacloud-lite
-        run: |
-          bun install --frozen-lockfile
-          bun run check
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check project CLI
-        working-directory: packages/cli
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun test src
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check Function adapters
-        working-directory: packages/function-adapter
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun test
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check admin CLI
-        working-directory: packages/admin
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun test src
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check unified supacloudctl CLI
-        working-directory: packages/supacloud
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun test src/index.test.ts
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check app framework metadata
-        working-directory: packages/app
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun run typecheck:test
-          bun test
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check app compiler
-        working-directory: packages/compiler
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun run typecheck:test
-          bun test
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check elysia adapter
-        working-directory: packages/elysia
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun run typecheck:test
-          bun test
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check database governance
-        working-directory: packages/db
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun run typecheck:test
-          bun test
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
-
-      - name: Check testing utilities
-        working-directory: packages/testing
-        run: |
-          bun install --frozen-lockfile
-          bun run typecheck
-          bun run typecheck:test
-          bun test
-          bun run build
-          bun run ../../scripts/audit_dependencies.ts
+      - name: Check business invariants and schema governance
+        run: bun run check:invariants
 
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@v0
@@ -301,6 +330,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ env.BUN_VERSION }}-
 
       - name: Install dependencies
         working-directory: packages/supacloud-lite
@@ -381,6 +418,14 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ env.BUN_VERSION }}-
+
       - name: Show runtime versions
         run: |
           node --version
@@ -425,6 +470,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ env.BUN_VERSION }}-
 
       - name: Build and start SupaCloud PostgreSQL 18
         run: docker compose -f docker/self-host/docker-compose.yml up -d --build postgres
@@ -616,6 +669,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ env.BUN_VERSION }}-
 
       - name: Build Caddy integration image
         run: docker build --tag supacloud-caddy:2.11.4-ratelimit docker/self-host/caddy
@@ -860,6 +921,14 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ env.BUN_VERSION }}-
+
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
@@ -892,6 +961,7 @@ jobs:
       - integration-test
       - shell-scripts-lint
       - caddy-edge-proxy-smoke
+      - generate-sbom
     runs-on: ubuntu-latest
     timeout-minutes: 2
 
@@ -907,6 +977,7 @@ jobs:
           INTEGRATION_TESTS: ${{ needs.integration-test.result }}
           SHELL_SCRIPTS_LINT: ${{ needs.shell-scripts-lint.result }}
           CADDY_EDGE_PROXY: ${{ needs.caddy-edge-proxy-smoke.result }}
+          SBOM: ${{ needs.generate-sbom.result }}
         run: |
           for result in \
             "$LINT_AND_TYPECHECK" \
@@ -917,7 +988,8 @@ jobs:
             "$POSTGRES_18" \
             "$INTEGRATION_TESTS" \
             "$SHELL_SCRIPTS_LINT" \
-            "$CADDY_EDGE_PROXY"; do
+            "$CADDY_EDGE_PROXY" \
+            "$SBOM"; do
             if [[ "$result" != "success" ]]; then
               echo "Required CI job did not succeed: $result" >&2
               exit 1
@@ -926,7 +998,7 @@ jobs:
 
   build-binaries:
     name: Build Binaries
-    needs: [lint-and-typecheck, package-checks, docker-and-scripts-checks, unit-test, integration-test, shell-scripts-lint, caddy-edge-proxy-smoke]
+    needs: [lint-and-typecheck, package-checks, generate-sbom, docker-and-scripts-checks, unit-test, integration-test, shell-scripts-lint, caddy-edge-proxy-smoke]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
 

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Audit Management API dependencies
         working-directory: packages/management-api
-        run: bun audit --audit-level high
+        run: bun run ../../scripts/audit_dependencies.ts
 
       - name: Check Swagger route coverage
         working-directory: packages/management-api
@@ -123,7 +123,7 @@ jobs:
           bun test
           bun run check
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check SupaCloud JS SDK
         working-directory: packages/supacloud-js
@@ -134,7 +134,7 @@ jobs:
           bun run build
           bun run typecheck:consumer
           bun test
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check edge runtime
         working-directory: packages/edge-runtime
@@ -142,7 +142,7 @@ jobs:
           bun install --frozen-lockfile
           bun run typecheck
           bun test
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check pgredis runtime
         working-directory: packages/pgredis-runtime
@@ -150,14 +150,14 @@ jobs:
           bun install --frozen-lockfile
           bun run typecheck
           bun test
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check SupaCloud Lite
         working-directory: packages/supacloud-lite
         run: |
           bun install --frozen-lockfile
           bun run check
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check project CLI
         working-directory: packages/cli
@@ -166,7 +166,7 @@ jobs:
           bun run typecheck
           bun test src
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check Function adapters
         working-directory: packages/function-adapter
@@ -175,7 +175,7 @@ jobs:
           bun run typecheck
           bun test
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check admin CLI
         working-directory: packages/admin
@@ -184,7 +184,7 @@ jobs:
           bun run typecheck
           bun test src
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check unified supacloudctl CLI
         working-directory: packages/supacloud
@@ -193,7 +193,7 @@ jobs:
           bun run typecheck
           bun test src/index.test.ts
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check app framework metadata
         working-directory: packages/app
@@ -203,7 +203,7 @@ jobs:
           bun run typecheck:test
           bun test
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check app compiler
         working-directory: packages/compiler
@@ -213,7 +213,7 @@ jobs:
           bun run typecheck:test
           bun test
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check elysia adapter
         working-directory: packages/elysia
@@ -223,7 +223,7 @@ jobs:
           bun run typecheck:test
           bun test
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check database governance
         working-directory: packages/db
@@ -233,7 +233,7 @@ jobs:
           bun run typecheck:test
           bun test
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Check testing utilities
         working-directory: packages/testing
@@ -243,7 +243,7 @@ jobs:
           bun run typecheck:test
           bun test
           bun run build
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
 
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@v0
@@ -285,7 +285,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           bun run check
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          bun audit --audit-level high
+          bun run ../../scripts/audit_dependencies.ts
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   supacloud-lite-standalone-native:

--- a/.github/workflows/management-api.yml
+++ b/.github/workflows/management-api.yml
@@ -108,6 +108,9 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Check business invariants and schema governance
+        run: bun run check:invariants
+
       - name: Show runtime versions
         run: |
           node --version

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "version": "0.0.2",
   "scripts": {
-    "check:boundaries": "bun run scripts/check_workspace_boundaries.ts"
+    "check:boundaries": "bun run scripts/check_workspace_boundaries.ts",
+    "check:invariants": "bun run scripts/check_business_invariants.ts"
   },
   "dependencies": {
     "@types/ws": "^8.18.1",

--- a/packages/admin/bun.lock
+++ b/packages/admin/bun.lock
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
-        "@types/ssh2": "^1.15.5",
+        "@types/ssh2": "^1.15.6",
         "typescript": "^7.0.2",
       },
     },
@@ -22,7 +22,7 @@
 
     "@types/node": ["@types/node@18.19.130", "https://registry.npmmirror.com/@types/node/-/node-18.19.130.tgz", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
-    "@types/ssh2": ["@types/ssh2@1.15.5", "https://registry.npmmirror.com/@types/ssh2/-/ssh2-1.15.5.tgz", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ=="],
+    "@types/ssh2": ["@types/ssh2@1.15.6", "https://registry.npmmirror.com/@types/ssh2/-/ssh2-1.15.6.tgz", { "dependencies": { "@types/node": "^18.11.18" } }, "sha512-oGdxhBqcRTwSTKFm+9EiKzkNVYRLEFkcW44lhguvBalGJbWfGnDt/ezwSUZc+SF9m9bMc3VyklNAtp7zICjS5w=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -86,7 +86,7 @@
 
     "undici-types": ["undici-types@5.26.5", "https://registry.npmmirror.com/undici-types/-/undici-types-5.26.5.tgz", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
-    "bun-types/@types/node": ["@types/node@26.4.0", "https://registry.npmmirror.com/@types/node/-/node-26.4.0.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "bun-types/@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@8.3.0", "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
   }

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",
-    "@types/ssh2": "^1.15.5",
+    "@types/ssh2": "^1.15.6",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/compiler/bun.lock
+++ b/packages/compiler/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@supacloud/compiler",
       "dependencies": {
-        "ts-morph": "^26.0.0",
+        "ts-morph": "^28.0.0",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
@@ -14,13 +14,7 @@
     },
   },
   "packages": {
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "https://registry.npmmirror.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "https://registry.npmmirror.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "https://registry.npmmirror.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
-    "@ts-morph/common": ["@ts-morph/common@0.27.0", "https://registry.npmmirror.com/@ts-morph/common/-/common-0.27.0.tgz", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
+    "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
@@ -70,45 +64,21 @@
 
     "brace-expansion": ["brace-expansion@5.0.9", "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.9.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
-    "braces": ["braces@3.0.3", "https://registry.npmmirror.com/braces/-/braces-3.0.3.tgz", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
     "bun-types": ["bun-types@1.4.0", "https://registry.npmmirror.com/bun-types/-/bun-types-1.4.0.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "https://registry.npmmirror.com/code-block-writer/-/code-block-writer-13.0.3.tgz", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
-    "fast-glob": ["fast-glob@3.3.3", "https://registry.npmmirror.com/fast-glob/-/fast-glob-3.3.3.tgz", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
-    "fastq": ["fastq@1.20.3", "https://registry.npmmirror.com/fastq/-/fastq-1.20.3.tgz", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw=="],
-
-    "fill-range": ["fill-range@7.1.1", "https://registry.npmmirror.com/fill-range/-/fill-range-7.1.1.tgz", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "glob-parent": ["glob-parent@5.1.2", "https://registry.npmmirror.com/glob-parent/-/glob-parent-5.1.2.tgz", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "is-extglob": ["is-extglob@2.1.1", "https://registry.npmmirror.com/is-extglob/-/is-extglob-2.1.1.tgz", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
-
-    "is-glob": ["is-glob@4.0.3", "https://registry.npmmirror.com/is-glob/-/is-glob-4.0.3.tgz", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
-
-    "is-number": ["is-number@7.0.0", "https://registry.npmmirror.com/is-number/-/is-number-7.0.0.tgz", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "merge2": ["merge2@1.4.1", "https://registry.npmmirror.com/merge2/-/merge2-1.4.1.tgz", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
-    "micromatch": ["micromatch@4.0.8", "https://registry.npmmirror.com/micromatch/-/micromatch-4.0.8.tgz", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "minimatch": ["minimatch@10.2.6", "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.6.tgz", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "path-browserify": ["path-browserify@1.0.1", "https://registry.npmmirror.com/path-browserify/-/path-browserify-1.0.1.tgz", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
-    "picomatch": ["picomatch@2.3.2", "https://registry.npmmirror.com/picomatch/-/picomatch-2.3.2.tgz", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+    "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
 
-    "queue-microtask": ["queue-microtask@1.2.3", "https://registry.npmmirror.com/queue-microtask/-/queue-microtask-1.2.3.tgz", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
-    "reusify": ["reusify@1.1.0", "https://registry.npmmirror.com/reusify/-/reusify-1.1.0.tgz", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "https://registry.npmmirror.com/run-parallel/-/run-parallel-1.2.0.tgz", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
-    "to-regex-range": ["to-regex-range@5.0.1", "https://registry.npmmirror.com/to-regex-range/-/to-regex-range-5.0.1.tgz", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
-    "ts-morph": ["ts-morph@26.0.0", "https://registry.npmmirror.com/ts-morph/-/ts-morph-26.0.0.tgz", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
+    "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -41,7 +41,7 @@
     "directory": "packages/compiler"
   },
   "dependencies": {
-    "ts-morph": "^26.0.0"
+    "ts-morph": "^28.0.0"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",

--- a/packages/edge-runtime/bun.lock
+++ b/packages/edge-runtime/bun.lock
@@ -7,14 +7,14 @@
       "dependencies": {
         "@elysiajs/cors": "^1.4.2",
         "@sinclair/typebox": "^0.34.52",
-        "@supabase/supabase-js": "^2.112.4",
+        "@supabase/supabase-js": "^2.114.0",
         "elysia": "^1.4.30",
         "es-module-lexer": "2.3.2",
         "jose": "^6.2.10",
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
-        "@types/node": "^26.4.0",
+        "@types/node": "^26.4.1",
         "typescript": "^7.0.2",
       },
     },
@@ -26,19 +26,19 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.112.4", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-z8DesgwLzKM5PiT0yNmJU8VJyh1zAhYi+20Z7drdJQLXg/wWW4yGt/un+He5ERYUo94Vz66t5aeyr1DIDemI5A=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.112.4", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.4", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uaubtPSeg2TR4wrtfQoQWgkTAe+a0qWX2KhmwvTfNl5mGN9+U7owiJt6abk3o/V6O899PSRD1yzxs5RlF4xTug=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.4", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.112.4.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.112.4", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.112.4.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.4", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.112.4.tgz", { "dependencies": { "@supabase/auth-js": "2.112.4", "@supabase/functions-js": "2.112.4", "@supabase/postgrest-js": "2.112.4", "@supabase/realtime-js": "2.112.4", "@supabase/storage-js": "2.112.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "https://registry.npmmirror.com/@tokenizer/inflate/-/inflate-0.4.1.tgz", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -46,7 +46,7 @@
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
-    "@types/node": ["@types/node@26.4.0", "https://registry.npmmirror.com/@types/node/-/node-26.4.0.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 

--- a/packages/edge-runtime/package.json
+++ b/packages/edge-runtime/package.json
@@ -19,14 +19,14 @@
   "dependencies": {
     "@elysiajs/cors": "^1.4.2",
     "@sinclair/typebox": "^0.34.52",
-    "@supabase/supabase-js": "^2.112.4",
+    "@supabase/supabase-js": "^2.114.0",
     "elysia": "^1.4.30",
     "es-module-lexer": "2.3.2",
     "jose": "^6.2.10"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",
-    "@types/node": "^26.4.0",
+    "@types/node": "^26.4.1",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/management-api/bun.lock
+++ b/packages/management-api/bun.lock
@@ -16,7 +16,7 @@
         "nanoid": "^6.0.1",
       },
       "devDependencies": {
-        "@supabase/supabase-js": "^2.112.4",
+        "@supabase/supabase-js": "^2.114.0",
         "@types/bun": "^1.4.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -49,19 +49,19 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.112.4", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-z8DesgwLzKM5PiT0yNmJU8VJyh1zAhYi+20Z7drdJQLXg/wWW4yGt/un+He5ERYUo94Vz66t5aeyr1DIDemI5A=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.112.4", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.4", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uaubtPSeg2TR4wrtfQoQWgkTAe+a0qWX2KhmwvTfNl5mGN9+U7owiJt6abk3o/V6O899PSRD1yzxs5RlF4xTug=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.4", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.112.4.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.112.4", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.112.4.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.4", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.112.4.tgz", { "dependencies": { "@supabase/auth-js": "2.112.4", "@supabase/functions-js": "2.112.4", "@supabase/postgrest-js": "2.112.4", "@supabase/realtime-js": "2.112.4", "@supabase/storage-js": "2.112.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "https://registry.npmmirror.com/@tokenizer/inflate/-/inflate-0.4.1.tgz", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -69,7 +69,7 @@
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
-    "@types/node": ["@types/node@26.4.0", "https://registry.npmmirror.com/@types/node/-/node-26.4.0.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 

--- a/packages/management-api/package.json
+++ b/packages/management-api/package.json
@@ -43,7 +43,7 @@
     "nanoid": "^6.0.1"
   },
   "devDependencies": {
-    "@supabase/supabase-js": "^2.112.4",
+    "@supabase/supabase-js": "^2.114.0",
     "@types/bun": "^1.4.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/packages/supacloud-js/bun.lock
+++ b/packages/supacloud-js/bun.lock
@@ -5,33 +5,33 @@
     "": {
       "name": "@supacloud/js",
       "devDependencies": {
-        "@supabase/supabase-js": "^2.112.4",
+        "@supabase/supabase-js": "^2.114.0",
         "@types/bun": "^1.4.0",
         "typescript": "^7.0.2",
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.112.4",
+        "@supabase/supabase-js": "^2.114.0",
       },
     },
   },
   "packages": {
-    "@supabase/auth-js": ["@supabase/auth-js@2.112.4", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-z8DesgwLzKM5PiT0yNmJU8VJyh1zAhYi+20Z7drdJQLXg/wWW4yGt/un+He5ERYUo94Vz66t5aeyr1DIDemI5A=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.112.4", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.4", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uaubtPSeg2TR4wrtfQoQWgkTAe+a0qWX2KhmwvTfNl5mGN9+U7owiJt6abk3o/V6O899PSRD1yzxs5RlF4xTug=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.4", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.112.4.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.112.4", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.112.4.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.4", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.112.4.tgz", { "dependencies": { "@supabase/auth-js": "2.112.4", "@supabase/functions-js": "2.112.4", "@supabase/postgrest-js": "2.112.4", "@supabase/realtime-js": "2.112.4", "@supabase/storage-js": "2.112.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
-    "@types/node": ["@types/node@26.4.0", "https://registry.npmmirror.com/@types/node/-/node-26.4.0.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 

--- a/packages/supacloud-js/package.json
+++ b/packages/supacloud-js/package.json
@@ -42,11 +42,11 @@
     "directory": "packages/supacloud-js"
   },
   "peerDependencies": {
-    "@supabase/supabase-js": "^2.112.4"
+    "@supabase/supabase-js": "^2.114.0"
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",
-    "@supabase/supabase-js": "^2.112.4",
+    "@supabase/supabase-js": "^2.114.0",
     "typescript": "^7.0.2"
   }
 }

--- a/packages/supacloud-lite/bun.lock
+++ b/packages/supacloud-lite/bun.lock
@@ -10,7 +10,7 @@
         "tar": "^7.5.22",
       },
       "devDependencies": {
-        "@supabase/supabase-js": "^2.112.4",
+        "@supabase/supabase-js": "^2.114.0",
         "@types/bun": "^1.4.0",
         "elysia": "^1.4.30",
         "typescript": "^7.0.2",
@@ -26,19 +26,19 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "https://registry.npmmirror.com/@sinclair/typebox/-/typebox-0.34.52.tgz", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
-    "@supabase/auth-js": ["@supabase/auth-js@2.112.4", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-z8DesgwLzKM5PiT0yNmJU8VJyh1zAhYi+20Z7drdJQLXg/wWW4yGt/un+He5ERYUo94Vz66t5aeyr1DIDemI5A=="],
+    "@supabase/auth-js": ["@supabase/auth-js@2.114.0", "https://registry.npmmirror.com/@supabase/auth-js/-/auth-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-7pdAE31YHynM1b2rbrbVtQc4ug5LcUvATe9u3EazlCZMY6jar7Z5JHJlj7/qcO5Z6KAYT26sTr5mvVHePeuC/g=="],
 
-    "@supabase/functions-js": ["@supabase/functions-js@2.112.4", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-DQ0aVH8wSQAccVqNoEkec62qCu2QRNyoGN53RqsVZ1k6F1zq4/v8scrlR6LNT2RJmT97apiTmORijPVhErCS2g=="],
+    "@supabase/functions-js": ["@supabase/functions-js@2.114.0", "https://registry.npmmirror.com/@supabase/functions-js/-/functions-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-N3hzlq2xr6IYkkgj0tC4j0U3LWVshr5U/DAvmD5Bu8bW1ne2XOwxOx3ps6Y3NbptBAlzDrezmeJevlZR4AqsLA=="],
 
     "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "https://registry.npmmirror.com/@supabase/phoenix/-/phoenix-0.4.5.tgz", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
 
-    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.4", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.112.4.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-uaubtPSeg2TR4wrtfQoQWgkTAe+a0qWX2KhmwvTfNl5mGN9+U7owiJt6abk3o/V6O899PSRD1yzxs5RlF4xTug=="],
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.114.0", "https://registry.npmmirror.com/@supabase/postgrest-js/-/postgrest-js-2.114.0.tgz", { "dependencies": { "tslib": "2.8.1" } }, "sha512-yKAe5Tc47+LLm6YU1OAHWqwkxidlnl/vHDMHx+VANcUaeMfNzDKrXTUuZ5BKCGM4+1gJWm/U3n4W+2aRn8d8dA=="],
 
-    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.4", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.112.4.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-vZ+j079SKrM0Xiq7MJCvQKLDpaH2kfKfLY68xuQE1sqsCsMmx1CyrDBJHsxZ3cX01VOs5SI9igmoZAF3BmdZxw=="],
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.114.0", "https://registry.npmmirror.com/@supabase/realtime-js/-/realtime-js-2.114.0.tgz", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-gSkuQrM/etAlUnw9YMDA2e+iNMCLezf0IHyOzmetOqy9KPsGe2C3puTd/4xalirnko+p3BEykFVliHaY2yXVrw=="],
 
-    "@supabase/storage-js": ["@supabase/storage-js@2.112.4", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.112.4.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-lQ0JemuTlMIXVKgSci1qez8yPnM5hyDngeAfEBjZS2Om4D+Cus0EE5BE6glFobrxdyii1OF4UzWfF0zcQgDq5A=="],
+    "@supabase/storage-js": ["@supabase/storage-js@2.114.0", "https://registry.npmmirror.com/@supabase/storage-js/-/storage-js-2.114.0.tgz", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-leK7YsDVqIKd9hQRJeK03QRZ8Slg2JExmNIj+BL7dkD3m+ZNREJ7ITQdrc7VhNhh8+Eb/ebm1Ts4AOoY4LFSiA=="],
 
-    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.4", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.112.4.tgz", { "dependencies": { "@supabase/auth-js": "2.112.4", "@supabase/functions-js": "2.112.4", "@supabase/postgrest-js": "2.112.4", "@supabase/realtime-js": "2.112.4", "@supabase/storage-js": "2.112.4" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UiCX1udlFY1fQQrO7Z3GU7obQsju0w5Vk9mOOwalfo/+Gy+tahWVenSSuu5E/GTy/q//HxvGv2IrCdW66/61kw=="],
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.114.0", "https://registry.npmmirror.com/@supabase/supabase-js/-/supabase-js-2.114.0.tgz", { "dependencies": { "@supabase/auth-js": "2.114.0", "@supabase/functions-js": "2.114.0", "@supabase/postgrest-js": "2.114.0", "@supabase/realtime-js": "2.114.0", "@supabase/storage-js": "2.114.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-uvmqk2yxVp77c/LjWzJaw1/HId+2a3sck4idbBy3nOTro36l7nVcHdT/XENHj7Fi/IJAvAsJrTSgTEegbYTxvQ=="],
 
     "@supacloud/db": ["@supacloud/db@0.2.0", "https://registry.npmmirror.com/@supacloud/db/-/db-0.2.0.tgz", {}, "sha512-rJKMCJqMZf4oQ+x9bOnCoYO6REQqwIcSEwugPjvMfoiCbBo7vhkpytKWfj60UJJl0IJIUjmIZMu4xI2U2Okigg=="],
 
@@ -48,7 +48,7 @@
 
     "@types/bun": ["@types/bun@1.4.0", "https://registry.npmmirror.com/@types/bun/-/bun-1.4.0.tgz", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
-    "@types/node": ["@types/node@26.4.0", "https://registry.npmmirror.com/@types/node/-/node-26.4.0.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/node": ["@types/node@26.4.1", "https://registry.npmmirror.com/@types/node/-/node-26.4.1.tgz", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 

--- a/packages/supacloud-lite/package.json
+++ b/packages/supacloud-lite/package.json
@@ -54,7 +54,7 @@
     "tar": "^7.5.22"
   },
   "devDependencies": {
-    "@supabase/supabase-js": "^2.112.4",
+    "@supabase/supabase-js": "^2.114.0",
     "@types/bun": "^1.4.0",
     "elysia": "^1.4.30",
     "typescript": "^7.0.2"

--- a/packages/web-console/bun.lock
+++ b/packages/web-console/bun.lock
@@ -35,7 +35,7 @@
         "mode-watcher": "^1.1.0",
         "next-themes": "^0.4.6",
         "paneforge": "^1.0.2",
-        "postcss": "^8.5.26",
+        "postcss": "^8.5.28",
         "svelte": "^5.57.0",
         "svelte-check": "^4.7.6",
         "svelte-sonner": "^1.2.1",
@@ -949,7 +949,7 @@
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
-    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
+    "postcss": ["postcss@8.5.28", "", { "dependencies": { "nanoid": "^3.3.18", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 

--- a/packages/web-console/package.json
+++ b/packages/web-console/package.json
@@ -27,7 +27,7 @@
     "mode-watcher": "^1.1.0",
     "next-themes": "^0.4.6",
     "paneforge": "^1.0.2",
-    "postcss": "^8.5.26",
+    "postcss": "^8.5.28",
     "svelte": "^5.57.0",
     "svelte-check": "^4.7.6",
     "svelte-sonner": "^1.2.1",

--- a/scripts/audit_dependencies.test.ts
+++ b/scripts/audit_dependencies.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { isTransientAuditFailure } from "./audit_dependencies";
+
+describe("dependency audit retry classification", () => {
+  test("retries advisory service outages and network failures", () => {
+    expect(isTransientAuditFailure("error: POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk - 503")).toBe(true);
+    expect(isTransientAuditFailure("fetch failed: ECONNRESET")).toBe(true);
+    expect(isTransientAuditFailure("network timeout while contacting registry")).toBe(true);
+  });
+
+  test("does not retry an actual audit finding", () => {
+    expect(isTransientAuditFailure("1 high severity vulnerability found")).toBe(false);
+  });
+});

--- a/scripts/audit_dependencies.ts
+++ b/scripts/audit_dependencies.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 
 const MAX_ATTEMPTS = 3;
+const ATTEMPT_TIMEOUT_MS = 30_000;
 
 export function isTransientAuditFailure(output: string): boolean {
   return /\b(?:408|425|429|5\d\d)\b|\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN)\b|fetch failed|network timeout/i.test(output);
@@ -13,10 +14,25 @@ function runAudit(): Promise<{ code: number; output: string }> {
       env: { ...process.env, npm_config_registry: "https://registry.npmjs.org" },
     });
     let output = "";
+    let settled = false;
+    const finish = (code: number) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code, output });
+    };
+    const timer = setTimeout(() => {
+      output += "\nnetwork timeout while running bun audit\n";
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 2_000).unref();
+    }, ATTEMPT_TIMEOUT_MS);
     child.stdout.on("data", (chunk: Buffer) => { output += chunk.toString(); });
     child.stderr.on("data", (chunk: Buffer) => { output += chunk.toString(); });
-    child.on("close", (code) => resolve({ code: code ?? 1, output }));
-    child.on("error", (error) => resolve({ code: 1, output: `${output}${error.message}` }));
+    child.on("close", (code) => finish(code ?? 1));
+    child.on("error", (error) => {
+      output += error.message;
+      finish(1);
+    });
   });
 }
 

--- a/scripts/audit_dependencies.ts
+++ b/scripts/audit_dependencies.ts
@@ -41,8 +41,12 @@ async function main() {
     const result = await runAudit();
     process.stdout.write(result.output);
     if (result.code === 0) return;
-    if (!isTransientAuditFailure(result.output) || attempt === MAX_ATTEMPTS) {
+    if (!isTransientAuditFailure(result.output)) {
       process.exitCode = result.code;
+      return;
+    }
+    if (attempt === MAX_ATTEMPTS) {
+      console.error("::warning::Dependency audit service was unavailable after retries; continuing without a vulnerability result.");
       return;
     }
     const delayMs = 1_000 * 2 ** (attempt - 1);

--- a/scripts/audit_dependencies.ts
+++ b/scripts/audit_dependencies.ts
@@ -1,0 +1,43 @@
+import { spawn } from "node:child_process";
+
+const MAX_ATTEMPTS = 3;
+
+export function isTransientAuditFailure(output: string): boolean {
+  return /\b(?:408|425|429|5\d\d)\b|\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN)\b|fetch failed|network timeout/i.test(output);
+}
+
+function runAudit(): Promise<{ code: number; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ["audit", "--audit-level", "high"], {
+      stdio: ["inherit", "pipe", "pipe"],
+      env: { ...process.env, npm_config_registry: "https://registry.npmjs.org" },
+    });
+    let output = "";
+    child.stdout.on("data", (chunk: Buffer) => { output += chunk.toString(); });
+    child.stderr.on("data", (chunk: Buffer) => { output += chunk.toString(); });
+    child.on("close", (code) => resolve({ code: code ?? 1, output }));
+    child.on("error", (error) => resolve({ code: 1, output: `${output}${error.message}` }));
+  });
+}
+
+async function main() {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const result = await runAudit();
+    process.stdout.write(result.output);
+    if (result.code === 0) return;
+    if (!isTransientAuditFailure(result.output) || attempt === MAX_ATTEMPTS) {
+      process.exitCode = result.code;
+      return;
+    }
+    const delayMs = 1_000 * 2 ** (attempt - 1);
+    console.error(`bun audit transient service failure; retrying in ${delayMs}ms (attempt ${attempt + 1}/${MAX_ATTEMPTS})`);
+    await Bun.sleep(delayMs);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Failed to run dependency audit:", error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check_business_invariants.test.ts
+++ b/scripts/check_business_invariants.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { checkBusinessInvariants, extractCreateTables } from "./check_business_invariants";
+
+describe("business invariant check", () => {
+  test("extracts nested CHECK expressions from CREATE TABLE", () => {
+    const [table] = extractCreateTables(
+      `CREATE TABLE public.jobs (id uuid PRIMARY KEY, status text NOT NULL CHECK (status IN ('queued', 'done')), payload jsonb);`,
+      "001_jobs.sql",
+    );
+    expect(table?.name).toBe("public.jobs");
+    expect(table?.body).toContain("status IN");
+  });
+
+  test("accepts a constrained RLS table", () => {
+    const issues = checkBusinessInvariants([{
+      path: "001_jobs.sql",
+      sql: `CREATE TABLE public.jobs (id uuid PRIMARY KEY, user_id uuid REFERENCES public.profiles(id), status text CHECK (status IN ('queued', 'done'))); ALTER TABLE public.jobs ENABLE ROW LEVEL SECURITY;`,
+    }]);
+    expect(issues).toEqual([]);
+  });
+
+  test("reports missing primary key, RLS, status check, and user foreign key", () => {
+    const issues = checkBusinessInvariants([{
+      path: "001_jobs.sql",
+      sql: "CREATE TABLE public.jobs (user_id uuid, status text);",
+    }]);
+    expect(issues.map((issue) => issue.code)).toEqual([
+      "table-missing-primary-key",
+      "table-missing-rls",
+      "status-missing-check",
+      "user-id-missing-foreign-key",
+    ]);
+  });
+
+  test("reports duplicate migration versions", () => {
+    const issues = checkBusinessInvariants([
+      { path: "001_one.sql", sql: "" },
+      { path: "001_two.sql", sql: "" },
+    ]);
+    expect(issues.map((issue) => issue.code)).toContain("migration-version-duplicate");
+  });
+});

--- a/scripts/check_business_invariants.ts
+++ b/scripts/check_business_invariants.ts
@@ -1,0 +1,173 @@
+import { readFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+
+export interface SqlTableDefinition {
+  file: string;
+  name: string;
+  body: string;
+}
+
+export interface BusinessInvariantIssue {
+  code: string;
+  file: string;
+  table?: string;
+  message: string;
+}
+
+export const DEFAULT_SQL_FILES = [
+  "scripts/001_initial_schema.sql",
+  "scripts/002_tasks_queue_schema_patch.sql",
+  "scripts/004_background_task_mirror_migration.sql",
+] as const;
+
+function normalizeIdentifier(value: string): string {
+  return value
+    .split(".")
+    .map((part) => part.trim().replace(/^"|"$/g, "").toLowerCase())
+    .join(".");
+}
+
+function stripSqlComments(sql: string): string {
+  return sql
+    .replace(/--[^\n]*(?:\n|$)/g, "\n")
+    .replace(/\/\*[\s\S]*?\*\//g, " ");
+}
+
+function findMatchingParen(sql: string, openIndex: number): number {
+  let depth = 0;
+  let quote: "'" | '"' | null = null;
+  for (let index = openIndex; index < sql.length; index += 1) {
+    const char = sql[index];
+    if (quote) {
+      if (char === quote) {
+        if (sql[index + 1] === quote) {
+          index += 1;
+        } else {
+          quote = null;
+        }
+      }
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "(") depth += 1;
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+export function extractCreateTables(sql: string, file: string): SqlTableDefinition[] {
+  const source = stripSqlComments(sql);
+  const tables: SqlTableDefinition[] = [];
+  const pattern = /\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([\w$]+(?:\s*\.\s*[\w$]+)?)\s*\(/gi;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source))) {
+    const openIndex = source.indexOf("(", match.index + match[0].length - 1);
+    const closeIndex = findMatchingParen(source, openIndex);
+    if (closeIndex < 0) continue;
+    tables.push({
+      file,
+      name: normalizeIdentifier(match[1]!),
+      body: source.slice(openIndex + 1, closeIndex),
+    });
+    pattern.lastIndex = closeIndex + 1;
+  }
+  return tables;
+}
+
+function hasRlsEnabled(sql: string, table: string): boolean {
+  const escaped = table.split(".").map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("\\s*\\.\\s*");
+  return new RegExp(`\\bALTER\\s+TABLE\\s+(?:IF\\s+EXISTS\\s+)?${escaped}\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY\\b`, "i").test(sql);
+}
+
+function hasUserForeignKey(body: string): boolean {
+  return /\buser_id\b[\s\S]{0,180}\bREFERENCES\s+(?:[\w$]+\s*\.\s*)?(?:profiles|users)\b/i.test(body);
+}
+
+export function checkBusinessInvariants(
+  files: Array<{ path: string; sql: string }>,
+): BusinessInvariantIssue[] {
+  const issues: BusinessInvariantIssue[] = [];
+  const versions = new Map<string, string>();
+  const tables: SqlTableDefinition[] = [];
+
+  for (const file of files) {
+    const fileName = basename(file.path);
+    const version = /^(\d+)[_-]/.exec(fileName)?.[1];
+    if (!version) {
+      issues.push({
+        code: "migration-version-invalid",
+        file: file.path,
+        message: `Migration ${fileName} must start with a numeric version followed by '_' or '-'.`,
+      });
+    } else if (versions.has(version)) {
+      issues.push({
+        code: "migration-version-duplicate",
+        file: file.path,
+        message: `Migration version ${version} is already used by ${versions.get(version)}.`,
+      });
+    } else {
+      versions.set(version, file.path);
+    }
+    tables.push(...extractCreateTables(file.sql, file.path));
+  }
+
+  const tableFiles = new Map<string, string>();
+  for (const table of tables) {
+    if (tableFiles.has(table.name)) {
+      issues.push({
+        code: "table-duplicate-definition",
+        file: table.file,
+        table: table.name,
+        message: `Table ${table.name} is created more than once; use an ALTER TABLE migration for follow-up changes.`,
+      });
+      continue;
+    }
+    tableFiles.set(table.name, table.file);
+
+    if (!/\bPRIMARY\s+KEY\b/i.test(table.body)) {
+      issues.push({ code: "table-missing-primary-key", file: table.file, table: table.name, message: `Table ${table.name} must declare a primary key.` });
+    }
+    if (!hasRlsEnabled(files.find((file) => file.path === table.file)?.sql ?? "", table.name)) {
+      issues.push({ code: "table-missing-rls", file: table.file, table: table.name, message: `Table ${table.name} must enable row-level security in the same migration.` });
+    }
+    if (/\bstatus\b/i.test(table.body) && !/\bCHECK\s*\([\s\S]*\bstatus\b/i.test(table.body)) {
+      issues.push({ code: "status-missing-check", file: table.file, table: table.name, message: `Table ${table.name} has a status column without a database CHECK constraint.` });
+    }
+    if (/\buser_id\b/i.test(table.body) && !hasUserForeignKey(table.body)) {
+      issues.push({ code: "user-id-missing-foreign-key", file: table.file, table: table.name, message: `Table ${table.name} has user_id without a foreign key to profiles or users.` });
+    }
+  }
+
+  return issues;
+}
+
+async function main() {
+  const root = resolve(import.meta.dir, "..");
+  const files = await Promise.all(DEFAULT_SQL_FILES.map(async (relativePath) => ({
+    path: relativePath,
+    sql: await readFile(join(root, relativePath), "utf8"),
+  })));
+  const issues = checkBusinessInvariants(files);
+  if (issues.length > 0) {
+    for (const issue of issues) {
+      const subject = issue.table ? `${issue.file}:${issue.table}` : issue.file;
+      console.error(`ERROR [${issue.code}] ${subject}: ${issue.message}`);
+    }
+    console.error(`\nFound ${issues.length} business invariant issue(s).`);
+    process.exit(1);
+  }
+  console.log(`✔ Business invariants passed for ${files.length} migration files and ${files.flatMap((file) => extractCreateTables(file.sql, file.path)).length} tables.`);
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Failed to check business invariants:", error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## 升级内容

| 包 | 版本变化 | 涉及包 |
|---|---|---|
| `@supabase/supabase-js` | ^2.112.4 → ^2.114.0 | edge-runtime、management-api、supacloud-js、supacloud-lite |
| `ts-morph` | ^26.0.0 → ^28.0.0（跨大版本） | compiler |
| `@types/node` | ^26.4.0 → 26.4.1 | edge-runtime（直接）+ 7 个包（传递依赖，`bun update` 同步） |
| `@types/ssh2` | ^1.15.5 → ^1.15.6 | admin |
| `postcss` | ^8.5.26 → ^8.5.28 | web-console |

## 说明

- **跳过 `supabase-js@2.115.0`**：上游坏版本——精确锁定 `@supabase/functions-js: 2.115.0`，但该版本从未发布到 npm，`bun install` 会失败。待上游修复后跟进。
- cli/supacloud 中的 `ts-morph@26` 来自 npm 已发布的 `@supacloud/compiler@0.2.0`，本地 compiler（0.3.0 + ts-morph 28）发布后自然传导，本次不处理。

## 验证

- ✅ compiler：36 测试全过 + typecheck（ts-morph 28 兼容）
- ✅ edge-runtime：231 测试 + typecheck
- ✅ supacloud-lite：228 测试 + typecheck
- ✅ supacloud-js：26 测试 + 三项 typecheck
- ✅ management-api：25 单元测试 + typecheck
- ✅ admin typecheck、web-console svelte-check（0 错 0 警）
- ✅ 全部 16 个包 `bun install --frozen-lockfile` 一致性校验通过