### PR TITLE
feat(database): support database execute action and query mutation modes

### DIFF
--- a/packages/cli/src/shared/execution-policy.test.ts
+++ b/packages/cli/src/shared/execution-policy.test.ts
@@ -148,6 +148,9 @@ describe("CLI execution policy", () => {
         expect(() => authorizeExecution("frontend", { action: "redeploy" }, {
             context: context({ production: false, environment: "test", readOnly: true }),
         })).toThrow("SUPACLOUD_READ_ONLY=true");
+        expect(() => authorizeExecution("database", { action: "execute", ref: "prod-ref" }, {
+            context: context({ production: false, environment: "test", readOnly: true }),
+        })).toThrow("SUPACLOUD_READ_ONLY=true");
         for (const action of ["pause", "restore"]) {
             expect(() => authorizeExecution("project", { action }, {
                 context: context({ production: false, environment: "test", readOnly: true }),
@@ -256,6 +259,7 @@ describe("CLI execution policy", () => {
     test("allows migration previews and local authoring without production confirmation", () => {
         expect(executionMode("database", "migration_inventory", {})).toBe("read");
         expect(executionMode("database", "push_migrations", { dry_run: true })).toBe("read");
+        expect(executionMode("database", "execute", {})).toBe("write");
         expect(executionMode("supabase", "push", { dry_run: true })).toBe("read");
         expect(() => authorizeExecution("supabase", { action: "db_dump" }, { context: context() }))
             .not.toThrow();

--- a/packages/cli/src/shared/execution-policy.ts
+++ b/packages/cli/src/shared/execution-policy.ts
@@ -20,7 +20,7 @@ const ACTION_POLICY: Record<string, ModulePolicy> = {
     database: {
         read: ["list_tables", "describe_columns", "list_indexes", "list_constraints", "list_extensions", "rls_status", "rls_policies", "list_auth_users", "get_auth_user", "connections", "stats", "slow_queries", "list_migrations", "migration_inventory", "project_url", "generate_types", "database_lint", "db_lint", "rpc_catalog", "list_rpcs"],
         local: ["lint_migrations", "lint"],
-        write: ["query", "apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"],
+        write: ["query", "execute", "apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"],
     },
     supabase: {
         local: ["version", "migration_new", "db_diff", "db_reset", "db_pull", "db_dump", "migration_list", "gen_types"],

--- a/packages/cli/src/shared/tools/database-tools.test.ts
+++ b/packages/cli/src/shared/tools/database-tools.test.ts
@@ -2064,4 +2064,122 @@ describe("database migration helpers", () => {
     expect(catalogFailure.content[0].text).toBe("❌ RPC catalog request failed (500)");
     expect(catalogFailure.content[0].text).not.toContain("secret");
   });
+
+  test("execute action sends SQL with default migration mode and formats result", async () => {
+    const posts: Array<{ path: string; body: { sql: string; mode?: string } }> = [];
+    const callback = captureDatabaseTool({
+      post: async (path: string, body: { sql: string; mode?: string }) => {
+        posts.push({ path, body });
+        return {
+          ok: true,
+          status: 200,
+          data: { command: "CREATE TABLE", rowCount: 0, rows: [] },
+        };
+      },
+    });
+
+    const result = await callback({
+      action: "execute",
+      ref: "proj",
+      sql: "CREATE TABLE public.items (id uuid);",
+    });
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].path).toBe("/v1/projects/proj/database/sql");
+    expect(posts[0].body.sql).toBe("CREATE TABLE public.items (id uuid);");
+    expect(posts[0].body.mode).toBe("migration");
+    expect(result.content[0].text).toContain("✅ Query OK. No rows returned.");
+  });
+
+  test("execute action supports reading SQL from local file", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "supacloud-exec-file-"));
+    const sqlFile = join(tmpDir, "migration.sql");
+    const posts: Array<{ path: string; body: { sql: string; mode?: string } }> = [];
+    try {
+      writeFileSync(sqlFile, "ALTER TABLE public.items ADD COLUMN tag text;");
+      const callback = captureDatabaseTool({
+        post: async (path: string, body: { sql: string; mode?: string }) => {
+          posts.push({ path, body });
+          return {
+            ok: true,
+            status: 200,
+            data: { command: "ALTER TABLE", rowCount: 0, rows: [] },
+          };
+        },
+      });
+
+      const result = await callback({
+        action: "execute",
+        ref: "proj",
+        file: sqlFile,
+      });
+
+      expect(posts).toHaveLength(1);
+      expect(posts[0].body.sql).toBe("ALTER TABLE public.items ADD COLUMN tag text;");
+      expect(posts[0].body.mode).toBe("migration");
+      expect(result.content[0].text).toContain("✅ Query OK");
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("execute action supports explicit mode and admin flag", async () => {
+    const posts: Array<{ path: string; body: { sql: string; mode?: string; admin?: boolean } }> = [];
+    const callback = captureDatabaseTool({
+      post: async (path: string, body: { sql: string; mode?: string; admin?: boolean }) => {
+        posts.push({ path, body });
+        return { ok: true, status: 200, data: { command: "SELECT", rows: [{ num: 42 }], rowCount: 1 } };
+      },
+    });
+
+    const result = await callback({
+      action: "execute",
+      ref: "proj",
+      sql: "SELECT 42 as num;",
+      mode: "admin",
+      admin: true,
+    });
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.mode).toBe("admin");
+    expect(posts[0].body.admin).toBe(true);
+    expect(result.content[0].text).toContain("42");
+  });
+
+  test("query action passes mode if specified", async () => {
+    const posts: Array<{ path: string; body: { sql: string; mode?: string } }> = [];
+    const callback = captureDatabaseTool({
+      post: async (path: string, body: { sql: string; mode?: string }) => {
+        posts.push({ path, body });
+        return { ok: true, status: 200, data: { command: "SELECT", rows: [{ id: "1" }], rowCount: 1 } };
+      },
+    });
+
+    await callback({
+      action: "query",
+      ref: "proj",
+      sql: "SELECT id FROM users",
+      mode: "read",
+    });
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].body.mode).toBe("read");
+  });
+
+  test("execute action is rejected when readOnly is enabled", async () => {
+    let callback: ((args: Record<string, unknown>) => Promise<CapturedDatabaseToolResponse>) | undefined;
+    registerDatabaseTools({
+      tool(name: string, _description: string, _schema: Record<string, unknown>, toolCallback: typeof callback) {
+        if (name === "database") callback = toolCallback;
+      },
+    }, {} as any, { readOnly: true });
+
+    const response = await callback!({
+      action: "execute",
+      ref: "proj",
+      sql: "INSERT INTO items VALUES (1)",
+    });
+
+    expect(response.content[0].text).toContain("Write blocked: execute (read-only mode)");
+  });
 });

--- a/packages/cli/src/shared/tools/database-tools.ts
+++ b/packages/cli/src/shared/tools/database-tools.ts
@@ -516,7 +516,7 @@ export function registerDatabaseTools(
         "list_migrations", "migration_inventory", "project_url", "generate_types",
         "database_lint", "db_lint", "rpc_catalog", "list_rpcs",
     ] as const;
-    const writeActions = ["apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"] as const;
+    const writeActions = ["execute", "apply_migration", "push_migrations", "baseline_migrations", "create_table_rls"] as const;
     const remoteActions = [...readActions, ...localActions] as const;
     const allActions = localOnly
         ? localActions
@@ -531,9 +531,11 @@ Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ?
         {
             action: withDescription(stringEnum(allActions as unknown as [string, ...string[]]), "Action"),
             ref: projectRef ? Type.Optional(Type.String()) : optional(Type.String(), "Project ref"),
-            // query
-            sql: optional(Type.String(), "[query/apply_migration/lint_migrations/lint] SQL statement"),
-            file: optional(Type.String(), "[query/apply_migration/lint_migrations/lint] Read SQL from local file path (avoids shell escaping issues with $$ and multi-statement DDL)"),
+            // query / execute
+            sql: optional(Type.String(), "[query/execute/apply_migration/lint_migrations/lint] SQL statement"),
+            file: optional(Type.String(), "[query/execute/apply_migration/lint_migrations/lint] Read SQL from local file path (avoids shell escaping issues with $$ and multi-statement DDL)"),
+            mode: optional(stringEnum(["read", "migration", "admin"]), "[query/execute] SQL execution mode: read, migration, or admin. execute defaults to migration; query defaults to read/auto"),
+            admin: optional(Type.Boolean(), "[query/execute] Admin execution flag (required when mode=admin)"),
             dir: optional(Type.String(), "[push_migrations/baseline_migrations/lint_migrations/lint] Directory containing .sql migration files (default: supabase/migrations)"),
             dry_run: optional(Type.Boolean(), "[push_migrations/baseline_migrations] Preview changes without applying them"),
             strict: optional(Type.Boolean(), "[push_migrations/lint_migrations/lint/database_lint] Exit with error if high-risk issues or migrations are detected"),
@@ -576,20 +578,34 @@ Actions: ${allActions.join(", ")}${localOnly ? " (local-only mode)" : readOnly ?
                 }
             }
 
-            const execSql = async (sql: string, mode?: "read" | "migration" | "admin") =>
-                managementHttp().post(`/v1/projects/${ref}/database/sql`, mode ? { sql, mode } : { sql });
+            const execSql = async (sql: string, mode?: "read" | "migration" | "admin", admin?: boolean) =>
+                managementHttp().post(`/v1/projects/${ref}/database/sql`, {
+                    sql,
+                    ...(mode ? { mode } : {}),
+                    ...(admin !== undefined ? { admin } : {}),
+                });
 
             let text: string;
             switch (action) {
                 case "query": {
-                    if (!args.sql) throw new Error("'sql' required");
+                    if (!args.sql) throw new Error("'sql' or 'file' required");
                     if (readOnly) {
                         const upper = args.sql.trim().toUpperCase();
                         for (const kw of ["INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER", "TRUNCATE"]) {
                             if (upper.startsWith(kw)) return { content: [{ type: "text" as const, text: `❌ Write blocked: ${kw} (read-only mode)` }] };
                         }
                     }
-                    const r = await execSql(args.sql);
+                    const r = await execSql(args.sql, args.mode, args.admin);
+                    text = r.ok ? formatSqlResult(r.data) : `❌ Failed (${r.status}): ${JSON.stringify(r.data)}`;
+                    break;
+                }
+                case "execute": {
+                    if (readOnly) {
+                        return { content: [{ type: "text" as const, text: "❌ Write blocked: execute (read-only mode)" }] };
+                    }
+                    if (!args.sql) throw new Error("'sql' or 'file' required");
+                    const mode = args.mode || "migration";
+                    const r = await execSql(args.sql, mode, args.admin);
                     text = r.ok ? formatSqlResult(r.data) : `❌ Failed (${r.status}): ${JSON.stringify(r.data)}`;
                     break;
                 }

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -2,7 +2,7 @@ import { Elysia, t } from "elysia";
 import type { SQL, TransactionSQL } from "bun";
 import { projectService } from "../services";
 import { db, getProjectDb, getProjectRoleDb, removeProjectDbCache, resolveAuthenticatorName, resolveDbName, sql as metaSql, type SqlExecutionMode } from "../db";
-import { isDangerousSQL, normalizeSqlForPolicy, sqlContainsTransactionControl } from "../db/sql-policy";
+import { isDangerousSQL, normalizeSqlForPolicy, sqlContainsTransactionControl, WRITE_SQL_PATTERN } from "../db/sql-policy";
 import { cancelActiveSqlQuery } from "../db/sql-query-registry";
 import { splitSqlStatements, stripOuterTransactionStatements } from "../db/sql-statements";
 import { requireAdminAuth, requireProjectOrAdminAuth } from "../middleware/auth";
@@ -525,9 +525,18 @@ async function readQueryPerformanceStats(credentials: {
   return { installed: true, rows };
 }
 
-function resolveSqlMode(body: Record<string, unknown>): SqlExecutionMode {
-  const mode = typeof body.mode === "string" ? body.mode : "read";
+function resolveSqlMode(body: Record<string, unknown>, sqlQuery?: string): SqlExecutionMode {
+  const mode = typeof body.mode === "string" ? body.mode : undefined;
   if (mode === "migration" || mode === "admin") return mode;
+  if (mode === "read") return "read";
+  if (sqlQuery) {
+    const rawStatements = splitSqlStatements(sqlQuery);
+    if (rawStatements.length > 1) return "migration";
+    const normalized = normalizeSqlForPolicy(rawStatements[0] || "");
+    if (WRITE_SQL_PATTERN.test(normalized) || !/^\s*(SELECT|WITH|EXPLAIN|SHOW)\b/i.test(normalized)) {
+      return "migration";
+    }
+  }
   return "read";
 }
 
@@ -1158,6 +1167,101 @@ function createTableFailure(error: unknown, projectRef: string) {
   return { message: "Failed to create table", code: "500", status: 500 as const };
 }
 
+async function executeProjectSqlRoute({
+  projectRef,
+  body,
+  request,
+  set,
+}: {
+  projectRef: string;
+  body: Record<string, unknown>;
+  request: Request;
+  set: { status: number | string };
+}) {
+  const authError = await requireProjectOrAdminAuth(request, projectRef);
+  if (authError) return projectAuthResponse(authError, set);
+
+  const project = await projectService.getProject(projectRef);
+  if (!project) {
+    set.status = 404;
+    return { message: "Project not found", code: "404", status: 404 };
+  }
+
+  try {
+    const sqlQuery = typeof body.query === "string" && body.query
+      ? body.query
+      : typeof body.sql === "string" && body.sql
+        ? body.sql
+        : undefined;
+    if (!sqlQuery) {
+      set.status = 400;
+      return { message: "query or sql is required", code: "400", status: 400 };
+    }
+    const mode = resolveSqlMode(body, sqlQuery);
+
+    if (mode === "admin") {
+      if (!requireAdminMode(body)) {
+        set.status = 403;
+        return { message: "Admin SQL requires mode=admin and admin=true", code: "403", status: 403 };
+      }
+      const authError = await requireAdminAuth(request);
+      if (authError) {
+        set.status = authError.status;
+        return { message: authError.body.error, code: String(authError.status), status: authError.status };
+      }
+    }
+    const credentials = await getProjectDatabaseCredentials(projectRef);
+    if (!credentials) {
+      set.status = 404;
+      return { message: "Project database credentials not found", code: "404", status: 404 };
+    }
+    const useRoleConnection = mode !== "admin";
+    const execute = async () => {
+      if (mode === "migration") {
+        await branchReplacementJournal.assertInactive([projectRef]);
+      }
+      const result = await db.executeQuery(credentials.db_name, sqlQuery, {
+        mode,
+        ...(typeof body.query_id === "string"
+          ? { projectRef, queryId: body.query_id }
+          : {}),
+        ...(useRoleConnection ? { username: credentials.db_user, password: credentials.db_password } : {}),
+      });
+      const adminMayChangeSchema = mode === "admin" && sqlExecutionMayChangeSchema(result, sqlQuery);
+      let schemaReloadStatus: SchemaReloadStatus | undefined;
+      let ddlCommitted: true | undefined;
+      if (mode === "migration" || adminMayChangeSchema) {
+        const adminDb = getProjectDb(credentials.db_name);
+        schemaReloadStatus = await tryNotifyPostgrestSchemaReload(adminDb, projectRef)
+          ? "notified"
+          : "notification_failed";
+        if (mode === "migration" || adminSqlCanConfirmDdlCommitted(sqlQuery)) {
+          ddlCommitted = true;
+        }
+      }
+      return { result, schemaReloadStatus, ddlCommitted };
+    };
+    const execution = mode === "migration"
+      ? await withProjectMigrationLocks({ projectRefs: [projectRef] }, execute)
+      : await execute();
+    return sqlRouteResponse(execution.result, {
+      schemaReloadStatus: execution.schemaReloadStatus,
+      ddlCommitted: execution.ddlCommitted,
+    });
+  } catch (error: unknown) {
+    if (error instanceof ProjectMigrationLockError) {
+      set.status = error.httpStatus;
+      return { message: error.message, code: error.code, status: error.httpStatus };
+    }
+    if (error instanceof BranchReplacementJournalActiveError) {
+      set.status = error.httpStatus;
+      return { message: error.message, code: error.code, status: error.httpStatus };
+    }
+    set.status = 400;
+    return sqlRouteErrorResponse(error);
+  }
+}
+
 export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" })
     .get(
         "/tables",
@@ -1621,38 +1725,23 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
     .post(
         "/query",
         async ({ params, body, set, request }) => {
-            const authError = await requireProjectOrAdminAuth(request, params.ref);
-            if (authError) return projectAuthResponse(authError, set);
-
-            const project = await projectService.getProject(params.ref);
-            if (!project) {
-                set.status = 404;
-                return { message: "Project not found", code: "404", status: 404 };
-            }
-
-            try {
-                const credentials = await getProjectDatabaseCredentials(params.ref);
-                if (!credentials) {
-                    set.status = 404;
-                    return { message: "Project database credentials not found", code: "404", status: 404 };
-                }
-                const result = await db.executeQuery(credentials.db_name, body.query, {
-                    mode: "read",
-                    username: credentials.db_user,
-                    password: credentials.db_password,
-                });
-                return sqlRouteResponse(result);
-            } catch (error: unknown) {
-                set.status = 400;
-                return sqlRouteErrorResponse(error);
-            }
+            return executeProjectSqlRoute({
+                projectRef: params.ref,
+                body: body as Record<string, unknown>,
+                request,
+                set,
+            });
         },
         {
             params: t.Object({ ref: t.String({ minLength: 1 }) }),
             body: t.Object({
-                query: t.String(),
+                sql: t.Optional(t.String()),
+                query: t.Optional(t.String()),
+                mode: t.Optional(t.Union([t.Literal("read"), t.Literal("migration"), t.Literal("admin")])),
+                admin: t.Optional(t.Boolean()),
+                query_id: t.Optional(t.String({ minLength: 16, maxLength: 128, pattern: "^[A-Za-z0-9_-]+$" })),
             }),
-            detail: { tags: ["projects"], summary: "Execute a read-only SQL query" },
+            detail: { tags: ["projects"], summary: "Execute a SQL query with mode control" },
         }
     )
     .get(
@@ -1698,84 +1787,12 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
     .post(
         "/sql",
         async ({ params, body, set, request }) => {
-            const authError = await requireProjectOrAdminAuth(request, params.ref);
-            if (authError) return projectAuthResponse(authError, set);
-
-            const project = await projectService.getProject(params.ref);
-            if (!project) {
-                set.status = 404;
-                return { message: "Project not found", code: "404", status: 404 };
-            }
-
-            try {
-                const sqlQuery = body.query || body.sql;
-                if (!sqlQuery) {
-                    set.status = 400;
-                    return { message: "query or sql is required", code: "400", status: 400 };
-                }
-                const mode = resolveSqlMode(body as Record<string, unknown>);
-
-                if (mode === "admin") {
-                    if (!requireAdminMode(body as Record<string, unknown>)) {
-                        set.status = 403;
-                        return { message: "Admin SQL requires mode=admin and admin=true", code: "403", status: 403 };
-                    }
-                    const authError = await requireAdminAuth(request);
-                    if (authError) {
-                        set.status = authError.status;
-                        return { message: authError.body.error, code: String(authError.status), status: authError.status };
-                    }
-                }
-                const credentials = await getProjectDatabaseCredentials(params.ref);
-                if (!credentials) {
-                    set.status = 404;
-                    return { message: "Project database credentials not found", code: "404", status: 404 };
-                }
-                const useRoleConnection = mode !== "admin";
-                const execute = async () => {
-                  if (mode === "migration") {
-                    await branchReplacementJournal.assertInactive([params.ref]);
-                  }
-                  const result = await db.executeQuery(credentials.db_name, sqlQuery, {
-                    mode,
-                    ...(typeof body.query_id === "string"
-                      ? { projectRef: params.ref, queryId: body.query_id }
-                      : {}),
-                    ...(useRoleConnection ? { username: credentials.db_user, password: credentials.db_password } : {}),
-                  });
-                  const adminMayChangeSchema = mode === "admin" && sqlExecutionMayChangeSchema(result, sqlQuery);
-                  let schemaReloadStatus: SchemaReloadStatus | undefined;
-                  let ddlCommitted: true | undefined;
-                  if (mode === "migration" || adminMayChangeSchema) {
-                    const adminDb = getProjectDb(credentials.db_name);
-                    schemaReloadStatus = await tryNotifyPostgrestSchemaReload(adminDb, params.ref)
-                      ? "notified"
-                      : "notification_failed";
-                    if (mode === "migration" || adminSqlCanConfirmDdlCommitted(sqlQuery)) {
-                      ddlCommitted = true;
-                    }
-                  }
-                  return { result, schemaReloadStatus, ddlCommitted };
-                };
-                const execution = mode === "migration"
-                  ? await withProjectMigrationLocks({ projectRefs: [params.ref] }, execute)
-                  : await execute();
-                return sqlRouteResponse(execution.result, {
-                  schemaReloadStatus: execution.schemaReloadStatus,
-                  ddlCommitted: execution.ddlCommitted,
-                });
-            } catch (error: unknown) {
-                if (error instanceof ProjectMigrationLockError) {
-                    set.status = error.httpStatus;
-                    return { message: error.message, code: error.code, status: error.httpStatus };
-                }
-                if (error instanceof BranchReplacementJournalActiveError) {
-                    set.status = error.httpStatus;
-                    return { message: error.message, code: error.code, status: error.httpStatus };
-                }
-                set.status = 400;
-                return sqlRouteErrorResponse(error);
-            }
+            return executeProjectSqlRoute({
+                projectRef: params.ref,
+                body: body as Record<string, unknown>,
+                request,
+                set,
+            });
         },
         {
             params: t.Object({ ref: t.String({ minLength: 1 }) }),

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -1176,7 +1176,7 @@ async function executeProjectSqlRoute({
   projectRef: string;
   body: Record<string, unknown>;
   request: Request;
-  set: { status: number | string };
+  set: { status?: number | string };
 }) {
   const authError = await requireProjectOrAdminAuth(request, projectRef);
   if (authError) return projectAuthResponse(authError, set);

--- a/packages/management-api/src/routes/database.ts
+++ b/packages/management-api/src/routes/database.ts
@@ -1172,11 +1172,13 @@ async function executeProjectSqlRoute({
   body,
   request,
   set,
+  skipReplacementJournalCheck = false,
 }: {
   projectRef: string;
   body: Record<string, unknown>;
   request: Request;
   set: { status?: number | string };
+  skipReplacementJournalCheck?: boolean;
 }) {
   const authError = await requireProjectOrAdminAuth(request, projectRef);
   if (authError) return projectAuthResponse(authError, set);
@@ -1217,7 +1219,7 @@ async function executeProjectSqlRoute({
     }
     const useRoleConnection = mode !== "admin";
     const execute = async () => {
-      if (mode === "migration") {
+      if (mode === "migration" && !skipReplacementJournalCheck) {
         await branchReplacementJournal.assertInactive([projectRef]);
       }
       const result = await db.executeQuery(credentials.db_name, sqlQuery, {
@@ -1787,11 +1789,20 @@ export const databaseRoutes = new Elysia({ prefix: "/v1/projects/:ref/database" 
     .post(
         "/sql",
         async ({ params, body, set, request }) => {
+            const sqlQuery = typeof body.query === "string" && body.query
+                ? body.query
+                : typeof body.sql === "string" && body.sql
+                    ? body.sql
+                    : undefined;
+            if (resolveSqlMode(body as Record<string, unknown>, sqlQuery) === "migration") {
+                await branchReplacementJournal.assertInactive([params.ref]);
+            }
             return executeProjectSqlRoute({
                 projectRef: params.ref,
                 body: body as Record<string, unknown>,
                 request,
                 set,
+                skipReplacementJournalCheck: true,
             });
         },
         {

--- a/packages/management-api/tests/unit/database-sql.routes.test.ts
+++ b/packages/management-api/tests/unit/database-sql.routes.test.ts
@@ -499,4 +499,81 @@ describe("database SQL routes", () => {
     expect(response.status).toBe(400);
     expect(rlsDb.reserve).not.toHaveBeenCalled();
   });
+
+  test("POST /query executes SELECT queries with default read mode", async () => {
+    const response = await request("project-a", "/query", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "SELECT id, name FROM public.users" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeQuery).toHaveBeenCalledWith("shared_tenant_db", "SELECT id, name FROM public.users", {
+      mode: "read",
+      username: "tenant_user",
+      password: "test-password",
+    });
+  });
+
+  test("POST /query auto-detects DDL/DML mutations and executes in migration mode", async () => {
+    const response = await request("project-a", "/query", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "CREATE TABLE public.widgets (id uuid PRIMARY KEY, name text)" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeQuery).toHaveBeenCalledWith(
+      "shared_tenant_db",
+      "CREATE TABLE public.widgets (id uuid PRIMARY KEY, name text)",
+      {
+        mode: "migration",
+        username: "tenant_user",
+        password: "test-password",
+      },
+    );
+    expect(withProjectMigrationLocks).toHaveBeenCalledTimes(1);
+    expect(schemaReloadQueries.some(({ values }) => values.includes("pgrst_project-a"))).toBe(true);
+  });
+
+  test("POST /query accepts sql field as alias for query", async () => {
+    const response = await request("project-a", "/query", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sql: "INSERT INTO public.widgets (name) VALUES ('gear')" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeQuery).toHaveBeenCalledWith(
+      "shared_tenant_db",
+      "INSERT INTO public.widgets (name) VALUES ('gear')",
+      {
+        mode: "migration",
+        username: "tenant_user",
+        password: "test-password",
+      },
+    );
+  });
+
+  test("POST /query supports explicit mode and query_id cancellation tracking", async () => {
+    const customQueryId = "query-e2e-cancel-id-123456";
+    const response = await request("project-a", "/query", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: "SELECT 1",
+        mode: "read",
+        query_id: customQueryId,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(executeQuery).toHaveBeenCalledWith("shared_tenant_db", "SELECT 1", {
+      mode: "read",
+      projectRef: "project-a",
+      queryId: customQueryId,
+      username: "tenant_user",
+      password: "test-password",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

This PR enhances SupaCloud's database execution capabilities across Management API and CLI to allow executing DDL, DML, and SQL scripts over HTTP/CLI without requiring direct database port access or manual SSH `psql` sessions.

### Problem
Previously, executing database mutations, schema adjustments, or batch maintenance required direct connection to PostgreSQL (port 5432, typically firewalled) or SSH direct `psql` commands:
1. `POST /v1/projects/:ref/database/query` hardcoded `mode: "read"` and only accepted `{ query: string }`, rejecting all DDL/DML or multi-statement scripts.
2. The CLI `database` compound tool had only `query` (no `execute` action) and did not support mutation scripts or passing execution modes.

### Changes
1. **Management API (`packages/management-api/src/routes/database.ts`)**:
   - Unified route handler `executeProjectSqlRoute` for `POST /database/query` and `POST /database/sql`.
   - Supports both `query` and `sql` payload fields.
   - Smart mode resolution: if `mode` is omitted, inspects the SQL statements and automatically promotes DDL/DML mutations (`WRITE_SQL_PATTERN` or multiple statements) to `"migration"` mode with transactional locking and PostgREST schema reload notifications. Pure read statements retain `"read"` fast-path execution.
   - Explicit `mode` (`"read" | "migration" | "admin"`), `admin: true` guard, and `query_id` cancellation tracking supported on both endpoints.
2. **CLI Database Tool (`packages/cli/src/shared/tools/database-tools.ts`)**:
   - Added `execute` write action (defaulting to `mode: "migration"`).
   - Supports reading SQL from `--file` for `query` and `execute`.
   - Supports `--mode` and `--admin` flags.
3. **Execution Policy (`packages/cli/src/shared/execution-policy.ts`)**:
   - Registered `database.execute` under protected write actions with `--confirm-production` enforcement and read-only mode protection.
4. **Unit Tests**:
   - Added comprehensive tests in `database-sql.routes.test.ts`, `database-tools.test.ts`, and `execution-policy.test.ts` (156 passing tests).

### Verification
- Ran `bun test packages/management-api/tests/unit/database-sql.routes.test.ts packages/cli/src/shared/tools/database-tools.test.ts packages/cli/src/shared/execution-policy.test.ts` (156 passed, 0 failed).
- Ran `git diff --check` (clean).