### PR TITLE
feat(compiler): add built-in module boundary governance presets and profiles

### DIFF
--- a/docs/application-framework.md
+++ b/docs/application-framework.md
@@ -94,20 +94,27 @@ const result = await compileProject({
   include: ["src/**/*.ts"],
   outDir: "generated",
   strict: true,
+  // 内置架构边界预设：'modular-monolith' | 'angular-enterprise' | 'clean-architecture'
+  moduleBoundaryPreset: "modular-monolith",
+  // 可选：叠加自定义规则（与 preset 自动合并）
   moduleBoundaries: [
     {
       sourceTag: "type:ui",
       bannedDependenciesWithTags: ["type:data-access"],
     },
-    {
-      sourceTag: "type:feature",
-      onlyDependOnLibsWithTags: ["type:feature", "type:ui", "type:data-access", "type:contracts"],
-    },
   ],
 });
 ```
 
-诊断码：`circular-dependency`、`scope-violation`、`module-boundary`、`module-boundary-violation`、`unresolved-token`、`duplicate-token`、`duplicate-module`、`duplicate-command`、`duplicate-route`、`route-command-unresolved`、`command-missing-permission`（始终为 error）、`missing-deps`。
+诊断码：`circular-dependency`、`scope-violation`、`module-boundary`、`module-boundary-violation`、`invalid-boundary-preset`、`unresolved-token`、`duplicate-token`、`duplicate-module`、`duplicate-command`、`duplicate-route`、`route-command-unresolved`、`command-missing-permission`（始终为 error）、`missing-deps`。
+
+### 模块边界治理预设（Module Boundary Profiles）
+
+`@supacloud/compiler` 内置三套开箱即用的架构治理预设 Profile：
+
+- **`modular-monolith`**（别名 `feature-slices`、`vertical-slices`）：适用于业务垂直切片/模块化单体。禁止 `type:feature` 之间交叉依赖；`type:root` / `type:app` 仅允许聚合 `feature` / `core` / `shared` / `domain` 模块；`type:core` / `type:shared` 禁止向上反向依赖业务切片。
+- **`angular-enterprise`**（别名 `angular`）：适用于 Angular / Nx 企业级 monorepo。约束 `type:feature`、`type:ui`、`type:data-access`、`type:util`、`type:shared`、`type:core` 的单向流向。
+- **`clean-architecture`**（别名 `domain-driven`）：适用于 Clean Architecture / Spring Boot DDD 分层。严格限制 `Presentation/API -> Application -> Domain <- Infrastructure` 的依赖倒置与领域层纯净性。
 
 产物：
 

--- a/docs/application-framework.md
+++ b/docs/application-framework.md
@@ -94,9 +94,9 @@ const result = await compileProject({
   include: ["src/**/*.ts"],
   outDir: "generated",
   strict: true,
-  // 内置架构边界预设：'modular-monolith' | 'angular-enterprise' | 'clean-architecture'
+  // Built-in architecture boundary preset: 'modular-monolith' | 'angular-enterprise' | 'clean-architecture'
   moduleBoundaryPreset: "modular-monolith",
-  // 可选：叠加自定义规则（与 preset 自动合并）
+  // Optional: merge custom rules with the preset.
   moduleBoundaries: [
     {
       sourceTag: "type:ui",
@@ -106,15 +106,15 @@ const result = await compileProject({
 });
 ```
 
-诊断码：`circular-dependency`、`scope-violation`、`module-boundary`、`module-boundary-violation`、`invalid-boundary-preset`、`unresolved-token`、`duplicate-token`、`duplicate-module`、`duplicate-command`、`duplicate-route`、`route-command-unresolved`、`command-missing-permission`（始终为 error）、`missing-deps`。
+Diagnostic codes: `circular-dependency`, `scope-violation`, `module-boundary`, `module-boundary-violation`, `invalid-boundary-preset`, `unresolved-token`, `duplicate-token`, `duplicate-module`, `duplicate-command`, `duplicate-route`, `route-command-unresolved`, `command-missing-permission` (always an error), and `missing-deps`.
 
-### 模块边界治理预设（Module Boundary Profiles）
+### Module Boundary Profiles
 
-`@supacloud/compiler` 内置三套开箱即用的架构治理预设 Profile：
+`@supacloud/compiler` includes three built-in architecture governance profiles:
 
-- **`modular-monolith`**（别名 `feature-slices`、`vertical-slices`）：适用于业务垂直切片/模块化单体。禁止 `type:feature` 之间交叉依赖；`type:root` / `type:app` 仅允许聚合 `feature` / `core` / `shared` / `domain` 模块；`type:core` / `type:shared` 禁止向上反向依赖业务切片。
-- **`angular-enterprise`**（别名 `angular`）：适用于 Angular / Nx 企业级 monorepo。约束 `type:feature`、`type:ui`、`type:data-access`、`type:util`、`type:shared`、`type:core` 的单向流向。
-- **`clean-architecture`**（别名 `domain-driven`）：适用于 Clean Architecture / Spring Boot DDD 分层。严格限制 `Presentation/API -> Application -> Domain <- Infrastructure` 的依赖倒置与领域层纯净性。
+- **`modular-monolith`** (aliases: `feature-slices`, `vertical-slices`): for vertical slices and modular monoliths. Blocks cross-feature dependencies; `type:root` / `type:app` may aggregate only `feature` / `core` / `shared` / `domain` modules; `type:core` / `type:shared` cannot depend upward on feature slices.
+- **`angular-enterprise`** (alias: `angular`): for Angular / Nx enterprise monorepos. Enforces one-way flow across `type:feature`, `type:ui`, `type:data-access`, `type:util`, `type:shared`, and `type:core`.
+- **`clean-architecture`** (alias: `domain-driven`): for Clean Architecture / Spring Boot DDD layering. Enforces `presentation/API -> application -> domain <- infrastructure` dependency inversion and domain purity.
 
 产物：
 

--- a/packages/compiler/src/compile.ts
+++ b/packages/compiler/src/compile.ts
@@ -13,6 +13,7 @@ export async function compileProject(options: CompileOptions): Promise<CompileRe
     ...(graph.diagnostics ?? []),
     ...validateGraph(graph, {
       strict: options.strict,
+      moduleBoundaryPreset: options.moduleBoundaryPreset,
       moduleBoundaries: options.moduleBoundaries,
     }),
   ];

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -4,6 +4,15 @@ export { generateApplication } from "./generate";
 export type { GenerateOptions } from "./generate";
 export { validateGraph } from "./validate";
 export { camelName } from "./util";
+export {
+  ANGULAR_ENTERPRISE_RULES,
+  CLEAN_ARCHITECTURE_RULES,
+  MODULAR_MONOLITH_RULES,
+  MODULE_BOUNDARY_PROFILES,
+  getModuleBoundaryPreset,
+  getModuleBoundaryProfile,
+  resolveModuleBoundaries,
+} from "./profiles";
 export type {
   ApplicationGraph,
   CommandNode,
@@ -11,6 +20,8 @@ export type {
   CompileResult,
   ControllerNode,
   Diagnostic,
+  ModuleBoundaryPresetName,
+  ModuleBoundaryProfile,
   ModuleBoundaryRule,
   ModuleNode,
   ProviderKind,
@@ -19,4 +30,5 @@ export type {
   RouteNode,
   Scope,
   TokenKind,
+  ValidateOptions,
 } from "./types";

--- a/packages/compiler/src/profiles.test.ts
+++ b/packages/compiler/src/profiles.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ANGULAR_ENTERPRISE_RULES,
+  CLEAN_ARCHITECTURE_RULES,
+  MODULAR_MONOLITH_RULES,
+  MODULE_BOUNDARY_PROFILES,
+  getModuleBoundaryPreset,
+  getModuleBoundaryProfile,
+  resolveModuleBoundaries,
+} from "./profiles";
+import type { ModuleBoundaryRule } from "./types";
+
+describe("架构治理预设 Profile (profiles.ts)", () => {
+  test("内置预设完整性：覆盖 modular-monolith / angular-enterprise / clean-architecture 及常用别名", () => {
+    const presetNames = Object.keys(MODULE_BOUNDARY_PROFILES);
+    expect(presetNames).toContain("modular-monolith");
+    expect(presetNames).toContain("feature-slices");
+    expect(presetNames).toContain("vertical-slices");
+    expect(presetNames).toContain("angular-enterprise");
+    expect(presetNames).toContain("angular");
+    expect(presetNames).toContain("clean-architecture");
+    expect(presetNames).toContain("domain-driven");
+  });
+
+  test("getModuleBoundaryProfile：获取预设元数据与规则副本（防外部篡改）", () => {
+    const profile = getModuleBoundaryProfile("modular-monolith");
+    expect(profile.name).toBe("modular-monolith");
+    expect(profile.description).toContain("模块化单体");
+    expect(profile.rules.length).toBeGreaterThan(0);
+
+    // 修改返回数组不影响预设原始定义
+    const originalLength = profile.rules.length;
+    profile.rules.push({ sourceTag: "test" });
+    const reloaded = getModuleBoundaryProfile("modular-monolith");
+    expect(reloaded.rules.length).toBe(originalLength);
+  });
+
+  test("getModuleBoundaryPreset：直接获取规则列表副本", () => {
+    const rules = getModuleBoundaryPreset("angular-enterprise");
+    expect(rules).toEqual(ANGULAR_ENTERPRISE_RULES);
+    expect(rules).not.toBe(ANGULAR_ENTERPRISE_RULES); // 独立引用
+  });
+
+  test("getModuleBoundaryProfile：未知预设抛出友好异常提示", () => {
+    expect(() => getModuleBoundaryProfile("unknown-preset" as any)).toThrow(
+      "未知的模块边界预设 Profile: 'unknown-preset'",
+    );
+  });
+
+  test("resolveModuleBoundaries：无入参返回 undefined", () => {
+    expect(resolveModuleBoundaries()).toBeUndefined();
+    expect(resolveModuleBoundaries({})).toBeUndefined();
+  });
+
+  test("resolveModuleBoundaries：仅指定 preset 时加载内置规则", () => {
+    const resolved = resolveModuleBoundaries({ preset: "modular-monolith" });
+    expect(resolved).toEqual(MODULAR_MONOLITH_RULES);
+  });
+
+  test("resolveModuleBoundaries：仅指定 custom rules 时保留自定义规则", () => {
+    const custom: ModuleBoundaryRule[] = [{ sourceTag: "custom", bannedDependenciesWithTags: ["bad"] }];
+    const resolved = resolveModuleBoundaries({ rules: custom });
+    expect(resolved).toEqual(custom);
+  });
+
+  test("resolveModuleBoundaries：叠加 preset 与 custom rules（preset 在前，custom 在后）", () => {
+    const custom: ModuleBoundaryRule[] = [{ sourceTag: "custom", bannedDependenciesWithTags: ["bad"] }];
+    const resolved = resolveModuleBoundaries({ preset: "domain-driven", rules: custom });
+    expect(resolved).toBeDefined();
+    expect(resolved!.length).toBe(CLEAN_ARCHITECTURE_RULES.length + 1);
+    expect(resolved![resolved!.length - 1]).toEqual(custom[0]);
+  });
+});

--- a/packages/compiler/src/profiles.test.ts
+++ b/packages/compiler/src/profiles.test.ts
@@ -10,8 +10,8 @@ import {
 } from "./profiles";
 import type { ModuleBoundaryRule } from "./types";
 
-describe("架构治理预设 Profile (profiles.ts)", () => {
-  test("内置预设完整性：覆盖 modular-monolith / angular-enterprise / clean-architecture 及常用别名", () => {
+describe("Architecture governance presets (profiles.ts)", () => {
+  test("includes the built-in presets and their aliases", () => {
     const presetNames = Object.keys(MODULE_BOUNDARY_PROFILES);
     expect(presetNames).toContain("modular-monolith");
     expect(presetNames).toContain("feature-slices");
@@ -22,48 +22,48 @@ describe("架构治理预设 Profile (profiles.ts)", () => {
     expect(presetNames).toContain("domain-driven");
   });
 
-  test("getModuleBoundaryProfile：获取预设元数据与规则副本（防外部篡改）", () => {
+  test("getModuleBoundaryProfile returns metadata and defensive rule copies", () => {
     const profile = getModuleBoundaryProfile("modular-monolith");
     expect(profile.name).toBe("modular-monolith");
-    expect(profile.description).toContain("模块化单体");
+    expect(profile.description).toContain("Modular monolith");
     expect(profile.rules.length).toBeGreaterThan(0);
 
-    // 修改返回数组不影响预设原始定义
+    // Mutating the returned array must not affect the original preset definition.
     const originalLength = profile.rules.length;
     profile.rules.push({ sourceTag: "test" });
     const reloaded = getModuleBoundaryProfile("modular-monolith");
     expect(reloaded.rules.length).toBe(originalLength);
   });
 
-  test("getModuleBoundaryPreset：直接获取规则列表副本", () => {
+  test("getModuleBoundaryPreset returns a defensive rule copy", () => {
     const rules = getModuleBoundaryPreset("angular-enterprise");
     expect(rules).toEqual(ANGULAR_ENTERPRISE_RULES);
-    expect(rules).not.toBe(ANGULAR_ENTERPRISE_RULES); // 独立引用
+    expect(rules).not.toBe(ANGULAR_ENTERPRISE_RULES); // Independent reference.
   });
 
-  test("getModuleBoundaryProfile：未知预设抛出友好异常提示", () => {
+  test("getModuleBoundaryProfile rejects unknown presets with a useful error", () => {
     expect(() => getModuleBoundaryProfile("unknown-preset" as any)).toThrow(
-      "未知的模块边界预设 Profile: 'unknown-preset'",
+      "Unknown module boundary preset: 'unknown-preset'",
     );
   });
 
-  test("resolveModuleBoundaries：无入参返回 undefined", () => {
+  test("resolveModuleBoundaries returns undefined without options", () => {
     expect(resolveModuleBoundaries()).toBeUndefined();
     expect(resolveModuleBoundaries({})).toBeUndefined();
   });
 
-  test("resolveModuleBoundaries：仅指定 preset 时加载内置规则", () => {
+  test("resolveModuleBoundaries loads built-in rules for a preset", () => {
     const resolved = resolveModuleBoundaries({ preset: "modular-monolith" });
     expect(resolved).toEqual(MODULAR_MONOLITH_RULES);
   });
 
-  test("resolveModuleBoundaries：仅指定 custom rules 时保留自定义规则", () => {
+  test("resolveModuleBoundaries preserves custom rules without a preset", () => {
     const custom: ModuleBoundaryRule[] = [{ sourceTag: "custom", bannedDependenciesWithTags: ["bad"] }];
     const resolved = resolveModuleBoundaries({ rules: custom });
     expect(resolved).toEqual(custom);
   });
 
-  test("resolveModuleBoundaries：叠加 preset 与 custom rules（preset 在前，custom 在后）", () => {
+  test("resolveModuleBoundaries appends custom rules after preset rules", () => {
     const custom: ModuleBoundaryRule[] = [{ sourceTag: "custom", bannedDependenciesWithTags: ["bad"] }];
     const resolved = resolveModuleBoundaries({ preset: "domain-driven", rules: custom });
     expect(resolved).toBeDefined();

--- a/packages/compiler/src/profiles.ts
+++ b/packages/compiler/src/profiles.ts
@@ -1,0 +1,208 @@
+import type { ModuleBoundaryPresetName, ModuleBoundaryProfile, ModuleBoundaryRule } from "./types";
+
+/**
+ * 模块化单体 / 垂直切片架构规则集：
+ * - type:feature 业务垂直切片之间禁止相互依赖（高内聚低耦合），禁止反向依赖 root/app；
+ * - type:root / type:app 顶层入口模块仅允许汇聚组装 feature、core、shared、domain 模块；
+ * - type:core 底层核心单例/基础设施禁止向上依赖 feature 或 root/app；
+ * - type:shared 通用公共工具/组件禁止依赖 feature 或 root/app。
+ */
+export const MODULAR_MONOLITH_RULES: ModuleBoundaryRule[] = [
+  {
+    sourceTag: "type:feature",
+    bannedDependenciesWithTags: ["type:feature", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:root",
+    onlyDependOnLibsWithTags: ["type:feature", "type:core", "type:shared", "type:domain"],
+  },
+  {
+    sourceTag: "type:app",
+    onlyDependOnLibsWithTags: ["type:feature", "type:core", "type:shared", "type:domain"],
+  },
+  {
+    sourceTag: "type:core",
+    bannedDependenciesWithTags: ["type:feature", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:shared",
+    bannedDependenciesWithTags: ["type:feature", "type:core", "type:root", "type:app"],
+  },
+];
+
+/**
+ * Angular / Nx 企业级 monorepo 架构分层规则集：
+ * 遵循 Nx / Angular Enterprise Monorepo 推荐规范：
+ * - feature 业务切片禁止互相直接依赖；
+ * - ui / data-access / util / shared 库禁止反向上层依赖 feature 或 root；
+ * - root / app 仅作为组装入口。
+ */
+export const ANGULAR_ENTERPRISE_RULES: ModuleBoundaryRule[] = [
+  {
+    sourceTag: "type:feature",
+    bannedDependenciesWithTags: ["type:feature", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:ui",
+    bannedDependenciesWithTags: ["type:feature", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:data-access",
+    bannedDependenciesWithTags: ["type:feature", "type:ui", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:util",
+    bannedDependenciesWithTags: ["type:feature", "type:ui", "type:data-access", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:shared",
+    bannedDependenciesWithTags: ["type:feature", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:core",
+    bannedDependenciesWithTags: ["type:feature", "type:root", "type:app"],
+  },
+  {
+    sourceTag: "type:root",
+    onlyDependOnLibsWithTags: ["type:feature", "type:ui", "type:data-access", "type:core", "type:shared", "type:util"],
+  },
+  {
+    sourceTag: "type:app",
+    onlyDependOnLibsWithTags: ["type:feature", "type:ui", "type:data-access", "type:core", "type:shared", "type:util"],
+  },
+];
+
+/**
+ * Clean Architecture / DDD 经典分层架构规则集（类似 Spring Boot DDD 规范）：
+ * - 控制/展现层（api/controller/presentation）仅能依赖应用服务层、领域层与公共层；
+ * - 应用服务层（application/service）编排业务用例，仅依赖领域层与公共层；
+ * - 领域核心层（domain）保持绝对纯净，禁止依赖任何表现层、应用服务层、基础设施层或根模块；
+ * - 基础设施层（infrastructure/infra）依赖倒置，实现领域接口，仅允许依赖领域层与公共层。
+ */
+export const CLEAN_ARCHITECTURE_RULES: ModuleBoundaryRule[] = [
+  {
+    sourceTag: "type:api",
+    onlyDependOnLibsWithTags: ["type:application", "type:domain", "type:shared", "type:common"],
+  },
+  {
+    sourceTag: "type:controller",
+    onlyDependOnLibsWithTags: ["type:application", "type:domain", "type:shared", "type:common"],
+  },
+  {
+    sourceTag: "type:presentation",
+    onlyDependOnLibsWithTags: ["type:application", "type:domain", "type:shared", "type:common"],
+  },
+  {
+    sourceTag: "type:application",
+    onlyDependOnLibsWithTags: ["type:domain", "type:shared", "type:common"],
+  },
+  {
+    sourceTag: "type:service",
+    onlyDependOnLibsWithTags: ["type:domain", "type:shared", "type:common"],
+  },
+  {
+    sourceTag: "type:domain",
+    bannedDependenciesWithTags: [
+      "type:api",
+      "type:controller",
+      "type:presentation",
+      "type:application",
+      "type:service",
+      "type:infrastructure",
+      "type:infra",
+      "type:root",
+      "type:app",
+    ],
+  },
+  {
+    sourceTag: "type:infrastructure",
+    onlyDependOnLibsWithTags: ["type:domain", "type:shared", "type:common"],
+  },
+  {
+    sourceTag: "type:infra",
+    onlyDependOnLibsWithTags: ["type:domain", "type:shared", "type:common"],
+  },
+];
+
+/** 内置支持的模块边界 Profile 注册表。 */
+export const MODULE_BOUNDARY_PROFILES: Record<ModuleBoundaryPresetName, ModuleBoundaryProfile> = {
+  "modular-monolith": {
+    name: "modular-monolith",
+    description: "模块化单体 / 垂直业务切片预设（禁止 Feature 交叉依赖，Root 模块仅聚合 Feature/Core/Shared/Domain）",
+    rules: MODULAR_MONOLITH_RULES,
+  },
+  "feature-slices": {
+    name: "feature-slices",
+    description: "垂直业务切片预设（modular-monolith 别名）",
+    rules: MODULAR_MONOLITH_RULES,
+  },
+  "vertical-slices": {
+    name: "vertical-slices",
+    description: "垂直切片架构预设（modular-monolith 别名）",
+    rules: MODULAR_MONOLITH_RULES,
+  },
+  "angular-enterprise": {
+    name: "angular-enterprise",
+    description: "Angular / Nx 企业级 monorepo 预设（约束 Feature、UI、Data-Access、Util、Shared 与 Root 分层流向）",
+    rules: ANGULAR_ENTERPRISE_RULES,
+  },
+  "angular": {
+    name: "angular",
+    description: "Angular 企业级分层预设（angular-enterprise 别名）",
+    rules: ANGULAR_ENTERPRISE_RULES,
+  },
+  "clean-architecture": {
+    name: "clean-architecture",
+    description: "Clean Architecture / DDD 分层预设（API/Presentation -> Application -> Domain <- Infrastructure）",
+    rules: CLEAN_ARCHITECTURE_RULES,
+  },
+  "domain-driven": {
+    name: "domain-driven",
+    description: "DDD 分层架构预设（clean-architecture 别名）",
+    rules: CLEAN_ARCHITECTURE_RULES,
+  },
+};
+
+/**
+ * 根据预设名称获取对应的架构治理规则集合。
+ */
+export function getModuleBoundaryProfile(name: ModuleBoundaryPresetName): ModuleBoundaryProfile {
+  const profile = MODULE_BOUNDARY_PROFILES[name];
+  if (!profile) {
+    throw new Error(
+      `未知的模块边界预设 Profile: '${name}'。支持的预设包括: ${Object.keys(MODULE_BOUNDARY_PROFILES).join(", ")}`,
+    );
+  }
+  return {
+    ...profile,
+    rules: profile.rules.map((rule) => ({
+      ...rule,
+      onlyDependOnLibsWithTags: rule.onlyDependOnLibsWithTags ? [...rule.onlyDependOnLibsWithTags] : undefined,
+      bannedDependenciesWithTags: rule.bannedDependenciesWithTags ? [...rule.bannedDependenciesWithTags] : undefined,
+    })),
+  };
+}
+
+/**
+ * 获取指定预设包含的规则列表副本。
+ */
+export function getModuleBoundaryPreset(name: ModuleBoundaryPresetName): ModuleBoundaryRule[] {
+  return getModuleBoundaryProfile(name).rules;
+}
+
+/**
+ * 解析并合并模块边界规则（支持 preset 预设 + 用户自定义 rules 叠加扩展）。
+ */
+export function resolveModuleBoundaries(options?: {
+  preset?: ModuleBoundaryPresetName;
+  rules?: ModuleBoundaryRule[];
+}): ModuleBoundaryRule[] | undefined {
+  if (!options) return undefined;
+  const { preset, rules } = options;
+  if (!preset && !rules) return undefined;
+
+  const presetRules = preset ? getModuleBoundaryPreset(preset) : [];
+  const customRules = rules ?? [];
+  const merged = [...presetRules, ...customRules];
+  return merged.length > 0 ? merged : undefined;
+}

--- a/packages/compiler/src/profiles.ts
+++ b/packages/compiler/src/profiles.ts
@@ -1,11 +1,11 @@
 import type { ModuleBoundaryPresetName, ModuleBoundaryProfile, ModuleBoundaryRule } from "./types";
 
 /**
- * 模块化单体 / 垂直切片架构规则集：
- * - type:feature 业务垂直切片之间禁止相互依赖（高内聚低耦合），禁止反向依赖 root/app；
- * - type:root / type:app 顶层入口模块仅允许汇聚组装 feature、core、shared、domain 模块；
- * - type:core 底层核心单例/基础设施禁止向上依赖 feature 或 root/app；
- * - type:shared 通用公共工具/组件禁止依赖 feature 或 root/app。
+ * Modular monolith / vertical slice architecture rules:
+ * - type:feature slices cannot depend on one another or on root/app modules;
+ * - type:root / type:app entry modules may aggregate feature, core, shared, and domain modules;
+ * - type:core foundational modules cannot depend upward on feature or root/app modules;
+ * - type:shared common utilities/components cannot depend on feature or root/app modules.
  */
 export const MODULAR_MONOLITH_RULES: ModuleBoundaryRule[] = [
   {
@@ -31,11 +31,11 @@ export const MODULAR_MONOLITH_RULES: ModuleBoundaryRule[] = [
 ];
 
 /**
- * Angular / Nx 企业级 monorepo 架构分层规则集：
- * 遵循 Nx / Angular Enterprise Monorepo 推荐规范：
- * - feature 业务切片禁止互相直接依赖；
- * - ui / data-access / util / shared 库禁止反向上层依赖 feature 或 root；
- * - root / app 仅作为组装入口。
+ * Angular / Nx enterprise monorepo layering rules:
+ * follows the recommended Nx / Angular enterprise workspace conventions:
+ * - feature slices cannot directly depend on one another;
+ * - ui / data-access / util / shared libraries cannot depend upward on feature or root modules;
+ * - root / app modules serve only as composition entry points.
  */
 export const ANGULAR_ENTERPRISE_RULES: ModuleBoundaryRule[] = [
   {
@@ -73,11 +73,11 @@ export const ANGULAR_ENTERPRISE_RULES: ModuleBoundaryRule[] = [
 ];
 
 /**
- * Clean Architecture / DDD 经典分层架构规则集（类似 Spring Boot DDD 规范）：
- * - 控制/展现层（api/controller/presentation）仅能依赖应用服务层、领域层与公共层；
- * - 应用服务层（application/service）编排业务用例，仅依赖领域层与公共层；
- * - 领域核心层（domain）保持绝对纯净，禁止依赖任何表现层、应用服务层、基础设施层或根模块；
- * - 基础设施层（infrastructure/infra）依赖倒置，实现领域接口，仅允许依赖领域层与公共层。
+ * Clean Architecture / DDD layering rules (similar to Spring Boot DDD conventions):
+ * - presentation layers (api/controller/presentation) may depend only on application, domain, and shared layers;
+ * - application layers (application/service) orchestrate use cases and depend only on domain and shared layers;
+ * - the domain layer remains pure and cannot depend on presentation, application, infrastructure, or root modules;
+ * - infrastructure layers (infrastructure/infra) implement domain ports and may depend only on domain and shared layers.
  */
 export const CLEAN_ARCHITECTURE_RULES: ModuleBoundaryRule[] = [
   {
@@ -124,53 +124,51 @@ export const CLEAN_ARCHITECTURE_RULES: ModuleBoundaryRule[] = [
   },
 ];
 
-/** 内置支持的模块边界 Profile 注册表。 */
+/** Registry of built-in module boundary profiles. */
 export const MODULE_BOUNDARY_PROFILES: Record<ModuleBoundaryPresetName, ModuleBoundaryProfile> = {
   "modular-monolith": {
     name: "modular-monolith",
-    description: "模块化单体 / 垂直业务切片预设（禁止 Feature 交叉依赖，Root 模块仅聚合 Feature/Core/Shared/Domain）",
+    description: "Modular monolith / vertical slice preset (blocks cross-feature dependencies and limits root aggregation to feature/core/shared/domain)",
     rules: MODULAR_MONOLITH_RULES,
   },
   "feature-slices": {
     name: "feature-slices",
-    description: "垂直业务切片预设（modular-monolith 别名）",
+    description: "Vertical slice preset (alias for modular-monolith)",
     rules: MODULAR_MONOLITH_RULES,
   },
   "vertical-slices": {
     name: "vertical-slices",
-    description: "垂直切片架构预设（modular-monolith 别名）",
+    description: "Vertical slice architecture preset (alias for modular-monolith)",
     rules: MODULAR_MONOLITH_RULES,
   },
   "angular-enterprise": {
     name: "angular-enterprise",
-    description: "Angular / Nx 企业级 monorepo 预设（约束 Feature、UI、Data-Access、Util、Shared 与 Root 分层流向）",
+    description: "Angular / Nx enterprise monorepo preset (enforces one-way layering across feature, UI, data-access, util, shared, and root modules)",
     rules: ANGULAR_ENTERPRISE_RULES,
   },
   "angular": {
     name: "angular",
-    description: "Angular 企业级分层预设（angular-enterprise 别名）",
+    description: "Angular enterprise layering preset (alias for angular-enterprise)",
     rules: ANGULAR_ENTERPRISE_RULES,
   },
   "clean-architecture": {
     name: "clean-architecture",
-    description: "Clean Architecture / DDD 分层预设（API/Presentation -> Application -> Domain <- Infrastructure）",
+    description: "Clean Architecture / DDD layering preset (API/presentation -> application -> domain <- infrastructure)",
     rules: CLEAN_ARCHITECTURE_RULES,
   },
   "domain-driven": {
     name: "domain-driven",
-    description: "DDD 分层架构预设（clean-architecture 别名）",
+    description: "DDD layering preset (alias for clean-architecture)",
     rules: CLEAN_ARCHITECTURE_RULES,
   },
 };
 
-/**
- * 根据预设名称获取对应的架构治理规则集合。
- */
+/** Return the architecture governance rules for a preset name. */
 export function getModuleBoundaryProfile(name: ModuleBoundaryPresetName): ModuleBoundaryProfile {
   const profile = MODULE_BOUNDARY_PROFILES[name];
   if (!profile) {
     throw new Error(
-      `未知的模块边界预设 Profile: '${name}'。支持的预设包括: ${Object.keys(MODULE_BOUNDARY_PROFILES).join(", ")}`,
+      `Unknown module boundary preset: '${name}'. Supported presets: ${Object.keys(MODULE_BOUNDARY_PROFILES).join(", ")}`,
     );
   }
   return {
@@ -183,16 +181,12 @@ export function getModuleBoundaryProfile(name: ModuleBoundaryPresetName): Module
   };
 }
 
-/**
- * 获取指定预设包含的规则列表副本。
- */
+/** Return a copy of the rules included in a preset. */
 export function getModuleBoundaryPreset(name: ModuleBoundaryPresetName): ModuleBoundaryRule[] {
   return getModuleBoundaryProfile(name).rules;
 }
 
-/**
- * 解析并合并模块边界规则（支持 preset 预设 + 用户自定义 rules 叠加扩展）。
- */
+/** Resolve and merge preset rules with optional user-defined rules. */
 export function resolveModuleBoundaries(options?: {
   preset?: ModuleBoundaryPresetName;
   rules?: ModuleBoundaryRule[];

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -118,6 +118,8 @@ export interface CompileOptions {
   outDir: string;
   /** warn 级诊断升级为 error。 */
   strict?: boolean;
+  /** 内置架构边界预设 Profile（如 'modular-monolith' | 'angular-enterprise' | 'clean-architecture'）。 */
+  moduleBoundaryPreset?: ModuleBoundaryPresetName;
   /** 模块边界与架构治理规则（受 Nx enforce-module-boundaries 启发）。 */
   moduleBoundaries?: ModuleBoundaryRule[];
 }
@@ -129,6 +131,28 @@ export interface ModuleBoundaryRule {
   onlyDependOnLibsWithTags?: string[];
   /** 源模块禁止依赖具有这些标签的模块。 */
   bannedDependenciesWithTags?: string[];
+}
+
+/** 内置的模块边界预设 Profile 名称。 */
+export type ModuleBoundaryPresetName =
+  | "modular-monolith"
+  | "feature-slices"
+  | "vertical-slices"
+  | "angular-enterprise"
+  | "angular"
+  | "clean-architecture"
+  | "domain-driven";
+
+export interface ModuleBoundaryProfile {
+  name: ModuleBoundaryPresetName;
+  description: string;
+  rules: ModuleBoundaryRule[];
+}
+
+export interface ValidateOptions {
+  strict?: boolean;
+  moduleBoundaryPreset?: ModuleBoundaryPresetName;
+  moduleBoundaries?: ModuleBoundaryRule[];
 }
 
 export interface CompileResult {

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -118,22 +118,22 @@ export interface CompileOptions {
   outDir: string;
   /** warn 级诊断升级为 error。 */
   strict?: boolean;
-  /** 内置架构边界预设 Profile（如 'modular-monolith' | 'angular-enterprise' | 'clean-architecture'）。 */
+  /** Built-in architecture boundary preset (for example, 'modular-monolith'). */
   moduleBoundaryPreset?: ModuleBoundaryPresetName;
-  /** 模块边界与架构治理规则（受 Nx enforce-module-boundaries 启发）。 */
+  /** Module boundary and architecture governance rules inspired by Nx enforce-module-boundaries. */
   moduleBoundaries?: ModuleBoundaryRule[];
 }
 
 export interface ModuleBoundaryRule {
-  /** 源模块标签模式或标签（如 'type:ui', 'scope:case', '*'）。 */
+  /** Source module tag pattern or tag (for example, 'type:ui', 'scope:case', or '*'). */
   sourceTag: string;
-  /** 源模块仅允许依赖具有这些标签的模块。 */
+  /** Tags allowed for modules imported by the source module. */
   onlyDependOnLibsWithTags?: string[];
-  /** 源模块禁止依赖具有这些标签的模块。 */
+  /** Tags forbidden for modules imported by the source module. */
   bannedDependenciesWithTags?: string[];
 }
 
-/** 内置的模块边界预设 Profile 名称。 */
+/** Names of built-in module boundary presets. */
 export type ModuleBoundaryPresetName =
   | "modular-monolith"
   | "feature-slices"

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -212,4 +212,181 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(violations).toHaveLength(1);
     expect(violations[0].message).toContain("仅允许依赖带有 [type:contracts, type:util]");
   });
+
+  test("moduleBoundaryPreset：modular-monolith 预设拦截 Feature 之间交叉依赖与 Core 反向依赖", () => {
+    const sampleGraph: ApplicationGraph = {
+      modules: [
+        {
+          name: "app",
+          className: "AppModule",
+          tags: ["type:root"],
+          file: "src/app.module.ts",
+          line: 1,
+          imports: ["feature-case", "core-auth"],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+        {
+          name: "feature-case",
+          className: "FeatureCaseModule",
+          tags: ["type:feature"],
+          file: "src/case.module.ts",
+          line: 1,
+          imports: ["feature-billing"], // 违规：Feature 之间禁止交叉依赖
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+        {
+          name: "feature-billing",
+          className: "FeatureBillingModule",
+          tags: ["type:feature"],
+          file: "src/billing.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+        {
+          name: "core-auth",
+          className: "CoreAuthModule",
+          tags: ["type:core"],
+          file: "src/core.module.ts",
+          line: 1,
+          imports: ["feature-billing"], // 违规：Core 禁止反向依赖 Feature
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(sampleGraph, {
+      moduleBoundaryPreset: "modular-monolith",
+    });
+
+    const violations = diags.filter((d) => d.code === "module-boundary-violation");
+    expect(violations).toHaveLength(2);
+    expect(violations[0].message).toContain("feature-case");
+    expect(violations[0].message).toContain("禁止依赖带有标签 'type:feature'");
+    expect(violations[1].message).toContain("core-auth");
+    expect(violations[1].message).toContain("禁止依赖带有标签 'type:feature'");
+  });
+
+  test("moduleBoundaryPreset：clean-architecture 预设保护领域层纯净与分层依赖流向", () => {
+    const sampleGraph: ApplicationGraph = {
+      modules: [
+        {
+          name: "domain-case",
+          className: "DomainCaseModule",
+          tags: ["type:domain"],
+          file: "src/domain.module.ts",
+          line: 1,
+          imports: ["api-controller"], // 违规：Domain 绝不能依赖上层 API/Controller
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+        {
+          name: "api-controller",
+          className: "ApiControllerModule",
+          tags: ["type:api"],
+          file: "src/api.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(sampleGraph, {
+      moduleBoundaryPreset: "clean-architecture",
+    });
+
+    const violations = diags.filter((d) => d.code === "module-boundary-violation");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain("domain-case");
+    expect(violations[0].message).toContain("禁止依赖带有标签 'type:api'");
+  });
+
+  test("moduleBoundaryPreset：预设与自定义规则合并生效", () => {
+    const sampleGraph: ApplicationGraph = {
+      modules: [
+        {
+          name: "feature-case",
+          className: "FeatureCaseModule",
+          tags: ["type:feature", "scope:case"],
+          file: "src/case.module.ts",
+          line: 1,
+          imports: ["feature-billing"], // 违规 1：modular-monolith 预设拦截 feature 间依赖
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+        {
+          name: "feature-billing",
+          className: "FeatureBillingModule",
+          tags: ["type:feature", "scope:billing"],
+          file: "src/billing.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(sampleGraph, {
+      moduleBoundaryPreset: "modular-monolith",
+      moduleBoundaries: [
+        {
+          sourceTag: "scope:case",
+          bannedDependenciesWithTags: ["scope:billing"], // 违规 2：自定义 scope 隔离规则
+        },
+      ],
+    });
+
+    const violations = diags.filter((d) => d.code === "module-boundary-violation");
+    expect(violations).toHaveLength(2);
+  });
+
+  test("moduleBoundaryPreset：传入未知预设时产生明确的 invalid-boundary-preset 错误诊断", () => {
+    const sampleGraph: ApplicationGraph = {
+      modules: [],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(sampleGraph, {
+      moduleBoundaryPreset: "non-existent-preset" as any,
+    });
+
+    const errors = diags.filter((d) => d.code === "invalid-boundary-preset");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].severity).toBe("error");
+    expect(errors[0].message).toContain("未知的模块边界预设 Profile");
+  });
 });

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -213,7 +213,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(violations[0].message).toContain("仅允许依赖带有 [type:contracts, type:util]");
   });
 
-  test("moduleBoundaryPreset：modular-monolith 预设拦截 Feature 之间交叉依赖与 Core 反向依赖", () => {
+  test("moduleBoundaryPreset blocks cross-feature dependencies and core-to-feature dependencies", () => {
     const sampleGraph: ApplicationGraph = {
       modules: [
         {
@@ -235,7 +235,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
           tags: ["type:feature"],
           file: "src/case.module.ts",
           line: 1,
-          imports: ["feature-billing"], // 违规：Feature 之间禁止交叉依赖
+          imports: ["feature-billing"], // Violation: feature slices cannot depend on one another.
           providers: [],
           controllers: [],
           commands: [],
@@ -261,7 +261,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
           tags: ["type:core"],
           file: "src/core.module.ts",
           line: 1,
-          imports: ["feature-billing"], // 违规：Core 禁止反向依赖 Feature
+          imports: ["feature-billing"], // Violation: core modules cannot depend upward on features.
           providers: [],
           controllers: [],
           commands: [],
@@ -279,12 +279,12 @@ describe("validateGraph：坏 fixture 诊断", () => {
     const violations = diags.filter((d) => d.code === "module-boundary-violation");
     expect(violations).toHaveLength(2);
     expect(violations[0].message).toContain("feature-case");
-    expect(violations[0].message).toContain("禁止依赖带有标签 'type:feature'");
+    expect(violations[0].message).toContain("feature-billing");
     expect(violations[1].message).toContain("core-auth");
-    expect(violations[1].message).toContain("禁止依赖带有标签 'type:feature'");
+    expect(violations[1].message).toContain("feature-billing");
   });
 
-  test("moduleBoundaryPreset：clean-architecture 预设保护领域层纯净与分层依赖流向", () => {
+  test("moduleBoundaryPreset protects domain purity and layering direction", () => {
     const sampleGraph: ApplicationGraph = {
       modules: [
         {
@@ -293,7 +293,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
           tags: ["type:domain"],
           file: "src/domain.module.ts",
           line: 1,
-          imports: ["api-controller"], // 违规：Domain 绝不能依赖上层 API/Controller
+          imports: ["api-controller"], // Violation: the domain cannot depend on API/controller layers.
           providers: [],
           controllers: [],
           commands: [],
@@ -324,10 +324,10 @@ describe("validateGraph：坏 fixture 诊断", () => {
     const violations = diags.filter((d) => d.code === "module-boundary-violation");
     expect(violations).toHaveLength(1);
     expect(violations[0].message).toContain("domain-case");
-    expect(violations[0].message).toContain("禁止依赖带有标签 'type:api'");
+    expect(violations[0].message).toContain("api-controller");
   });
 
-  test("moduleBoundaryPreset：预设与自定义规则合并生效", () => {
+  test("moduleBoundaryPreset merges with custom rules", () => {
     const sampleGraph: ApplicationGraph = {
       modules: [
         {
@@ -336,7 +336,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
           tags: ["type:feature", "scope:case"],
           file: "src/case.module.ts",
           line: 1,
-          imports: ["feature-billing"], // 违规 1：modular-monolith 预设拦截 feature 间依赖
+          imports: ["feature-billing"], // Violation 1: the modular-monolith preset blocks cross-feature dependencies.
           providers: [],
           controllers: [],
           commands: [],
@@ -365,7 +365,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
       moduleBoundaries: [
         {
           sourceTag: "scope:case",
-          bannedDependenciesWithTags: ["scope:billing"], // 违规 2：自定义 scope 隔离规则
+          bannedDependenciesWithTags: ["scope:billing"], // Violation 2: custom scope isolation rule.
         },
       ],
     });
@@ -374,7 +374,7 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(violations).toHaveLength(2);
   });
 
-  test("moduleBoundaryPreset：传入未知预设时产生明确的 invalid-boundary-preset 错误诊断", () => {
+  test("moduleBoundaryPreset reports invalid-boundary-preset for unknown presets", () => {
     const sampleGraph: ApplicationGraph = {
       modules: [],
       externalTokens: [],
@@ -387,6 +387,6 @@ describe("validateGraph：坏 fixture 诊断", () => {
     const errors = diags.filter((d) => d.code === "invalid-boundary-preset");
     expect(errors).toHaveLength(1);
     expect(errors[0].severity).toBe("error");
-    expect(errors[0].message).toContain("未知的模块边界预设 Profile");
+    expect(errors[0].message).toContain("Unknown module boundary preset");
   });
 });

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -6,7 +6,9 @@ import type {
   ModuleNode,
   ProviderNode,
   Scope,
+  ValidateOptions,
 } from "./types";
+import { resolveModuleBoundaries } from "./profiles";
 
 const SCOPE_LIFETIME_RANK: Record<Scope, number> = {
   application: 0,
@@ -25,11 +27,28 @@ interface ProviderRef {
  */
 export function validateGraph(
   graph: ApplicationGraph,
-  options: boolean | { strict?: boolean; moduleBoundaries?: ModuleBoundaryRule[] } = false,
+  options: boolean | ValidateOptions = false,
 ): Diagnostic[] {
   const strict = typeof options === "boolean" ? options : (options.strict ?? false);
-  const moduleBoundaries = typeof options === "object" ? options.moduleBoundaries : undefined;
   const diagnostics: Diagnostic[] = [];
+
+  let moduleBoundaries: ModuleBoundaryRule[] | undefined;
+  if (typeof options === "object") {
+    try {
+      moduleBoundaries = resolveModuleBoundaries({
+        preset: options.moduleBoundaryPreset,
+        rules: options.moduleBoundaries,
+      });
+    } catch (err) {
+      diagnostics.push({
+        severity: "error",
+        code: "invalid-boundary-preset",
+        message: err instanceof Error ? err.message : String(err),
+        file: graph.modules[0]?.file,
+        line: graph.modules[0]?.line,
+      });
+    }
+  }
 
   // 全局 token → provider 索引（同模块重复注册由 duplicate-token 报告，索引取第一个）。
   const globalProviders = new Map<string, ProviderRef>();


### PR DESCRIPTION
## Summary
Abstracts and introduces out-of-the-box architecture governance profiles and presets for `@supacloud/compiler`:

- **Built-in Presets & Profiles (`MODULE_BOUNDARY_PROFILES`)**:
  - `modular-monolith` (aliases: `feature-slices`, `vertical-slices`): Enforces vertical slice independence by banning cross-dependencies among `type:feature` modules, allows `type:root` / `type:app` to aggregate `feature`/`core`/`shared`/`domain`, and protects `type:core`/`type:shared` from inverted dependencies on feature slices.
  - `angular-enterprise` (alias: `angular`): Implements Angular / Nx enterprise workspace constraints across `type:feature`, `type:ui`, `type:data-access`, `type:util`, `type:shared`, and `type:core`.
  - `clean-architecture` (alias: `domain-driven`): Implements Clean Architecture / Spring Boot DDD layer rules (`Presentation -> Application -> Domain <- Infrastructure`) ensuring domain layer purity.
- **Compiler Options & APIs**:
  - Added `moduleBoundaryPreset` to `CompileOptions` and `ValidateOptions`.
  - Auto-merges preset rules with project-specific custom `moduleBoundaries`.
  - Exported `getModuleBoundaryPreset`, `getModuleBoundaryProfile`, and `resolveModuleBoundaries`.
  - Gracefully reports `invalid-boundary-preset` diagnostic when an unrecognized preset name is passed.
- **Documentation & Verification**:
  - Updated `docs/application-framework.md` with preset usage and profiles guide.
  - Added full test coverage in `profiles.test.ts` and `validate.test.ts` (48 compiler tests passing; all 109 framework tests across `app`, `compiler`, `elysia`, and `testing` green).
  - Validated against consumption in enterprise modular project (`xigu-fa`).