### PR TITLE
feat(storage): support conditional writes in JuiceFS S3 gateway

### DIFF
--- a/packages/management-api/src/routes/storage-s3.ts
+++ b/packages/management-api/src/routes/storage-s3.ts
@@ -11,6 +11,8 @@
  *   DELETE /:bucket        DeleteBucket
  *   HEAD /:bucket          HeadBucket
  *   PUT /:bucket/:key      PutObject
+ *                           (If-None-Match: * and If-Match supported when the
+ *                            configured driver exposes conditional writes)
  *   GET /:bucket/:key      GetObject
  *   HEAD /:bucket/:key     HeadObject
  *   DELETE /:bucket/:key   DeleteObject
@@ -308,6 +310,42 @@ export const storageS3Routes = new Elysia({ prefix: "/v1/storage/:ref/s3" })
     if (!body) return s3Error("IncompleteBody", "Missing request body", 400);
 
     const contentType = request.headers.get("content-type") || "application/octet-stream";
+    const ifNoneMatch = request.headers.get("if-none-match");
+    const ifMatch = request.headers.get("if-match");
+    if (ifNoneMatch !== null && ifMatch !== null) {
+      return s3Error("InvalidRequest", "If-None-Match and If-Match cannot be combined", 400);
+    }
+    if (ifNoneMatch !== null && ifNoneMatch.trim() !== "*") {
+      return s3Error("InvalidRequest", "Only If-None-Match: * is supported", 400);
+    }
+    const expectedEtag = ifMatch === null ? null : ifMatch.trim();
+    if (ifMatch !== null && (!expectedEtag || expectedEtag === "*")) {
+      return s3Error("InvalidRequest", "If-Match requires an object ETag", 400);
+    }
+
+    if (ifNoneMatch !== null || ifMatch !== null) {
+      const conditionalResult = await StorageService.uploadFileConditional(
+        params.ref,
+        params.bucket,
+        key,
+        await request.arrayBuffer(),
+        contentType,
+        ifNoneMatch !== null ? null : expectedEtag,
+      );
+      if (!conditionalResult) {
+        return s3Error("NotImplemented", "Conditional writes are not supported by this storage backend", 501);
+      }
+      if (conditionalResult.outcome === "exists" || conditionalResult.outcome === "etag_mismatch") {
+        return s3Error("PreconditionFailed", "The object precondition was not met", 412);
+      }
+      if (!("etag" in conditionalResult)) {
+        return s3Error("InternalError", "Conditional write returned an invalid result", 500);
+      }
+      set.headers["ETag"] = `"${conditionalResult.etag}"`;
+      set.status = 200;
+      return "";
+    }
+
     const ok = await StorageService.uploadFile(params.ref, params.bucket, key, body as ReadableStream, contentType);
     if (!ok) return s3Error("InternalError", "Failed to store object", 500);
 

--- a/packages/management-api/src/services/storage.adapter.ts
+++ b/packages/management-api/src/services/storage.adapter.ts
@@ -6,6 +6,7 @@ import { resolveBucketName } from "../db";
 import * as fs from "node:fs/promises";
 import * as syncFs from "node:fs";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 import { S3Client } from "bun";
 import { AwsClient } from "aws4fetch";
 
@@ -66,6 +67,14 @@ export interface StorageDriver {
     data: Blob | Buffer | Uint8Array | ArrayBuffer | ReadableStream,
     contentType: string,
   ): Promise<boolean>;
+  uploadFileConditional?(
+    projectRef: string,
+    bucket: string,
+    key: string,
+    data: Blob | Buffer | Uint8Array | ArrayBuffer | ReadableStream,
+    contentType: string,
+    expectedEtag: string | null,
+  ): Promise<ConditionalUploadResult>;
   copyFile(
     projectRef: string,
     srcBucket: string,
@@ -87,6 +96,10 @@ export interface StorageDriver {
     key: string,
   ): Promise<Response | null>;
 }
+
+export type ConditionalUploadResult =
+  | { outcome: "created" | "replaced"; etag: string }
+  | { outcome: "exists" | "etag_mismatch" };
 
 export type BucketDeletionResult =
   | { success: true }
@@ -113,6 +126,10 @@ async function createObjectParent(bucketPath: string, objectKey: string): Promis
       }
     }
   }
+}
+
+function objectEtag(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 export class JuiceFSDriver implements StorageDriver {
@@ -220,6 +237,66 @@ export class JuiceFSDriver implements StorageDriver {
         error: e instanceof Error ? e.message : String(e),
       });
       return false;
+    }
+  }
+
+  /**
+   * Best-effort conditional write for the filesystem-backed JuiceFS driver.
+   * Create-only writes use O_EXCL; replacements validate the current content
+   * before an atomic temp-file rename. External SMB writers can still race a
+   * replacement after validation, so callers must treat this as an adapter
+   * capability rather than a distributed CAS primitive.
+   */
+  async uploadFileConditional(
+    projectRef: string,
+    bucket: string,
+    key: string,
+    data: Blob | Buffer | Uint8Array | ArrayBuffer | ReadableStream,
+    _contentType: string,
+    expectedEtag: string | null,
+  ): Promise<ConditionalUploadResult> {
+    const cleanKey = normalizeObjectKey(key);
+    const bucketPath = this.getBasePath(projectRef, bucket);
+    await createObjectParent(bucketPath, cleanKey);
+    const filePath = this.getBasePath(projectRef, bucket, cleanKey);
+    const bytes = await toUint8Array(data);
+
+    if (expectedEtag === null) {
+      let handle: fs.FileHandle | undefined;
+      try {
+        handle = await fs.open(filePath, "wx");
+        await handle.writeFile(bytes);
+        return { outcome: "created", etag: objectEtag(bytes) };
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          return { outcome: "exists" };
+        }
+        throw error;
+      } finally {
+        await handle?.close().catch(() => undefined);
+      }
+    }
+
+    let currentBytes: Buffer;
+    try {
+      currentBytes = await fs.readFile(filePath);
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { outcome: "etag_mismatch" };
+      }
+      throw error;
+    }
+    if (objectEtag(currentBytes) !== expectedEtag.replace(/^"|"$/g, "")) {
+      return { outcome: "etag_mismatch" };
+    }
+
+    const temporaryPath = `${filePath}.supacloud-${crypto.randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(temporaryPath, bytes, { flag: "wx" });
+      await fs.rename(temporaryPath, filePath);
+      return { outcome: "replaced", etag: objectEtag(bytes) };
+    } finally {
+      await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
     }
   }
 

--- a/packages/management-api/src/services/storage.service.ts
+++ b/packages/management-api/src/services/storage.service.ts
@@ -1,6 +1,6 @@
 import { config } from "../config";
 import { logger } from "../utils/logger";
-import { getStorageDriver } from "./storage.adapter";
+import { getStorageDriver, type ConditionalUploadResult } from "./storage.adapter";
 import {
   storageBucketInputError,
   storageBucketRevisionError,
@@ -291,6 +291,21 @@ export class StorageService {
 
   static async uploadFile(projectRef: string, bucketName: string, fileName: string, fileData: Blob | Buffer | Uint8Array | ArrayBuffer | ReadableStream, contentType: string): Promise<boolean> {
     return await getStorageDriver().uploadFile(projectRef, bucketName, fileName, fileData, contentType);
+  }
+
+  static async uploadFileConditional(
+    projectRef: string,
+    bucketName: string,
+    fileName: string,
+    fileData: Blob | Buffer | Uint8Array | ArrayBuffer | ReadableStream,
+    contentType: string,
+    expectedEtag: string | null,
+  ): Promise<ConditionalUploadResult | null> {
+    const driver = getStorageDriver();
+    if (!driver.uploadFileConditional) return null;
+    return await driver.uploadFileConditional(
+      projectRef, bucketName, fileName, fileData, contentType, expectedEtag,
+    );
   }
 
   static async copyFile(projectRef: string, srcBucket: string, srcKey: string, destBucket: string, destKey: string): Promise<boolean> {

--- a/packages/management-api/tests/unit/storage-s3.routes.test.ts
+++ b/packages/management-api/tests/unit/storage-s3.routes.test.ts
@@ -7,6 +7,7 @@ const mockListBuckets = mock(() => Promise.resolve([]));
 const mockCreateBucket = mock(() => Promise.resolve({ success: true }));
 const mockListFiles = mock(() => Promise.resolve([]));
 const mockUploadFile = mock(() => Promise.resolve(true));
+const mockUploadFileConditional = mock(() => Promise.resolve<{ outcome: "created" | "replaced"; etag: string }>({ outcome: "created", etag: "etag-conditional" }));
 const mockDeleteFile = mock(() => Promise.resolve(true));
 const mockDeleteBucket = mock(() => Promise.resolve({ success: true }));
 const mockGetDownloadResponse = mock(() => Promise.resolve(null));
@@ -27,6 +28,7 @@ const storageSpies = [
   spyOn(StorageService, "createBucket").mockImplementation(mockCreateBucket as never),
   spyOn(StorageService, "listFiles").mockImplementation(mockListFiles as never),
   spyOn(StorageService, "uploadFile").mockImplementation(mockUploadFile as never),
+  spyOn(StorageService, "uploadFileConditional").mockImplementation(mockUploadFileConditional as never),
   spyOn(StorageService, "deleteFile").mockImplementation(mockDeleteFile as never),
   spyOn(StorageService, "deleteBucket").mockImplementation(mockDeleteBucket as never),
   spyOn(StorageService, "getDownloadResponse").mockImplementation(mockGetDownloadResponse as never),
@@ -71,6 +73,7 @@ beforeEach(() => {
   mockCreateBucket.mockReset();
   mockListFiles.mockReset();
   mockUploadFile.mockReset();
+  mockUploadFileConditional.mockReset();
   mockDeleteFile.mockReset();
   mockDeleteBucket.mockReset();
   mockGetDownloadResponse.mockReset();
@@ -253,6 +256,47 @@ describe("storageS3Routes", () => {
     expect(res.status).toBe(500);
     const xml = await res.text();
     expect(xml).toContain("InternalError");
+  });
+
+  test("PUT /:bucket/* honors If-None-Match and returns a stable ETag", async () => {
+    mockUploadFileConditional.mockResolvedValue({ outcome: "created", etag: "abc123" });
+    const res = await authedRequest("/v1/storage/testproj/s3/mybucket/file.txt", {
+      method: "PUT",
+      body: "hello",
+      headers: { "if-none-match": "*" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toBe('"abc123"');
+    expect(mockUploadFileConditional).toHaveBeenCalledWith(
+      "testproj", "mybucket", "file.txt", expect.any(ArrayBuffer), "application/octet-stream", null,
+    );
+  });
+
+  test("PUT /:bucket/* returns 412 for conditional conflicts and 501 when unsupported", async () => {
+    mockUploadFileConditional.mockResolvedValue({ outcome: "exists" });
+    const exists = await authedRequest("/v1/storage/testproj/s3/mybucket/file.txt", {
+      method: "PUT",
+      body: "hello",
+      headers: { "if-none-match": "*" },
+    });
+    expect(exists.status).toBe(412);
+    expect(await exists.text()).toContain("PreconditionFailed");
+
+    mockUploadFileConditional.mockResolvedValue({ outcome: "etag_mismatch" });
+    const mismatch = await authedRequest("/v1/storage/testproj/s3/mybucket/file.txt", {
+      method: "PUT",
+      body: "hello",
+      headers: { "if-match": '"stale"' },
+    });
+    expect(mismatch.status).toBe(412);
+
+    mockUploadFileConditional.mockResolvedValue(null as never);
+    const unsupported = await authedRequest("/v1/storage/testproj/s3/mybucket/file.txt", {
+      method: "PUT",
+      body: "hello",
+      headers: { "if-none-match": "*" },
+    });
+    expect(unsupported.status).toBe(501);
   });
 
   // --- GetObject ----------------------------------------------------------

--- a/packages/management-api/tests/unit/storage.adapter.test.ts
+++ b/packages/management-api/tests/unit/storage.adapter.test.ts
@@ -219,6 +219,43 @@ describe("JuiceFSDriver uploadFile", () => {
   });
 });
 
+describe("JuiceFSDriver conditional uploadFile", () => {
+  test("creates exclusively, rejects stale ETags, and replaces with the current ETag", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-storage-conditional-"));
+    try {
+      const driver = new JuiceFSDriver();
+      (driver as unknown as { getBasePath: (...parts: string[]) => string }).getBasePath =
+        (_projectRef: string, bucket?: string, key?: string) => join(root, bucket || "", key || "");
+      expect(await driver.createBucket("testref", "gallery")).toBe(true);
+
+      const first = await driver.uploadFileConditional(
+        "testref", "gallery", "raw.txt", new TextEncoder().encode("one"), "text/plain", null,
+      );
+      expect(first.outcome).toBe("created");
+      expect(await readFile(join(root, "gallery", "raw.txt"), "utf8")).toBe("one");
+
+      const duplicate = await driver.uploadFileConditional(
+        "testref", "gallery", "raw.txt", new TextEncoder().encode("two"), "text/plain", null,
+      );
+      expect(duplicate).toEqual({ outcome: "exists" });
+      expect(await readFile(join(root, "gallery", "raw.txt"), "utf8")).toBe("one");
+
+      const stale = await driver.uploadFileConditional(
+        "testref", "gallery", "raw.txt", new TextEncoder().encode("two"), "text/plain", "stale",
+      );
+      expect(stale).toEqual({ outcome: "etag_mismatch" });
+
+      const replaced = await driver.uploadFileConditional(
+        "testref", "gallery", "raw.txt", new TextEncoder().encode("two"), "text/plain", first.etag,
+      );
+      expect(replaced.outcome).toBe("replaced");
+      expect(await readFile(join(root, "gallery", "raw.txt"), "utf8")).toBe("two");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("JuiceFSDriver path traversal protection", () => {
   async function withTempMount<T>(fn: (mount: string) => Promise<T>): Promise<T> {
     const mount = await mkdtemp(join(tmpdir(), "supacloud-mount-"));


### PR DESCRIPTION
## Summary
- add If-None-Match: * and If-Match handling to the SupaCloud S3 compatibility route
- add JuiceFS exclusive create (O_EXCL) and best-effort ETag-checked atomic replacement
- return standard 412 PreconditionFailed responses and stable content ETags
- preserve 501 behavior for drivers without conditional-write capability

## Scope and limitation
This intentionally fixes the SupaCloud S3 compatibility route without changing juicedata/juicefs or migrating the SMB namespace. Replacement validation is best-effort when external SMB writers race after validation; it is not a distributed CAS primitive. The FA deployment must point FA_S3_ENDPOINT at the SupaCloud S3 compatibility route to use this behavior.

## Verification
- bun run typecheck (packages/management-api)
- bun test packages/management-api/tests/unit/storage-s3.routes.test.ts packages/management-api/tests/unit/storage.adapter.test.ts
- bun run test:unit (packages/management-api)
- git diff --check