### PR TITLE
feat(compiler): add forwardRef, DestroyRef AbortSignal, Route title/data, and shadowed route detection

### DIFF
--- a/packages/app/src/context.ts
+++ b/packages/app/src/context.ts
@@ -51,6 +51,7 @@ export interface OnDestroy {
  * Modeled directly after Angular's DestroyRef.
  */
 export interface DestroyRef {
+  readonly signal?: AbortSignal;
   onDestroy(callback: () => void | Promise<void>): () => void;
 }
 
@@ -68,15 +69,20 @@ export const DESTROY_REF = new InjectionToken<DestroyRef>("supacloud.destroy-ref
  */
 export function createDestroyRef(): DestroyRef & {
   readonly destroyed: boolean;
+  readonly signal: AbortSignal;
   destroy(): Promise<void>;
   _teardowns: Array<() => void | Promise<void>>;
 } {
   let isDestroyed = false;
+  const abortController = new AbortController();
   const callbacks: Array<() => void | Promise<void>> = [];
 
   return {
     get destroyed() {
       return isDestroyed;
+    },
+    get signal() {
+      return abortController.signal;
     },
     onDestroy(callback: () => void | Promise<void>): () => void {
       if (isDestroyed) {
@@ -91,6 +97,7 @@ export function createDestroyRef(): DestroyRef & {
     async destroy(): Promise<void> {
       if (isDestroyed) return;
       isDestroyed = true;
+      abortController.abort();
       const reversed = [...callbacks].reverse();
       callbacks.length = 0;
       for (const cb of reversed) {

--- a/packages/app/src/decorators.test.ts
+++ b/packages/app/src/decorators.test.ts
@@ -473,4 +473,50 @@ describe("Angular-style functional inject() & injection context", () => {
       expect(typeof ref.onDestroy).toBe("function");
     });
   });
+
+  test("forwardRef wraps and resolveForwardRef unwraps lazily evaluated token", () => {
+    const { forwardRef, resolveForwardRef, isForwardRef } = require("./index");
+    class TargetService {}
+    const ref = forwardRef(() => TargetService);
+    expect(isForwardRef(ref)).toBe(true);
+    expect(resolveForwardRef(ref)).toBe(TargetService);
+    expect(resolveForwardRef("plain")).toBe("plain");
+  });
+
+  test("DestroyRef.signal aborts when destroyed and injectDestroySignal returns signal", async () => {
+    const { createDestroyRef, injectDestroySignal, runInInjectionContext, DESTROY_REF } = require("./index");
+    const destroyRef = createDestroyRef();
+    expect(destroyRef.signal.aborted).toBe(false);
+
+    let caughtSignal: AbortSignal | undefined;
+    const injector = {
+      get: (token: any) => token === DESTROY_REF ? destroyRef : undefined,
+    };
+    runInInjectionContext(injector, () => {
+      caughtSignal = injectDestroySignal();
+    });
+
+    expect(caughtSignal).toBe(destroyRef.signal);
+    await destroyRef.destroy();
+    expect(destroyRef.signal.aborted).toBe(true);
+  });
+
+  test("Title and Data route metadata can be declared via options and decorators", () => {
+    const { Get, Title, Data, getRoutes } = require("./index");
+    class MetadataController {
+      @Get("/profile", { title: "User Profile", data: { role: "admin" } })
+      profile() {}
+
+      @Get("/settings")
+      @Title("Settings Page")
+      @Data({ flag: "experimental" })
+      settings() {}
+    }
+
+    const routes = getRoutes(MetadataController);
+    expect(routes[0].title).toBe("User Profile");
+    expect(routes[0].data).toEqual({ role: "admin" });
+    expect(routes[1].title).toBe("Settings Page");
+    expect(routes[1].data).toEqual({ flag: "experimental" });
+  });
 });

--- a/packages/app/src/decorators.ts
+++ b/packages/app/src/decorators.ts
@@ -21,6 +21,8 @@ export const SELF_PARAMS_METADATA = "supacloud:self-params";
 export const SKIP_SELF_PARAMS_METADATA = "supacloud:skip-self-params";
 export const HOST_PARAMS_METADATA = "supacloud:host-params";
 export const GUARDS_METADATA = "supacloud:guards";
+export const TITLE_METADATA = "supacloud:route:title";
+export const DATA_METADATA = "supacloud:route:data";
 export const ROUTE_PARAMS_METADATA = "supacloud:route-params";
 
 export interface RouteParamBinding {
@@ -131,6 +133,10 @@ export interface RouteOptions {
   redirectTo?: string;
   /** Angular-style route path matching strategy. */
   pathMatch?: "full" | "prefix";
+  /** Route title or label (modeled after Angular Route.title). */
+  title?: string;
+  /** Static route metadata dictionary (modeled after Angular Route.data). */
+  data?: Record<string, unknown>;
 }
 
 export interface RouteDefinition extends RouteOptions {
@@ -413,6 +419,13 @@ function createRouteDecorator(method: HttpMethod) {
   return (path: string, options: RouteOptions = {}): MethodDecorator =>
     (target, propertyKey) => {
       const cls = (target as { constructor: Type<unknown> }).constructor;
+      const titleKey = `${TITLE_METADATA}:${String(propertyKey)}`;
+      const dataKey = `${DATA_METADATA}:${String(propertyKey)}`;
+      const title = options.title ?? readOwnOrInherited<string>(cls, titleKey);
+      const data = {
+        ...(readOwnOrInherited<Record<string, unknown>>(cls, dataKey) ?? {}),
+        ...(options.data ?? {}),
+      };
       const routes: RouteDefinition[] = [
         ...(readOwnOrInherited<RouteDefinition[]>(cls, ROUTES_METADATA) ?? []),
       ];
@@ -421,6 +434,8 @@ function createRouteDecorator(method: HttpMethod) {
         path,
         handler: String(propertyKey),
         ...options,
+        title: title || undefined,
+        data: Object.keys(data).length > 0 ? data : undefined,
       });
       defineMetadata(cls, ROUTES_METADATA, routes);
     };
@@ -433,6 +448,39 @@ export const Patch = createRouteDecorator("PATCH");
 export const Delete = createRouteDecorator("DELETE");
 export const Head = createRouteDecorator("HEAD");
 export const Options = createRouteDecorator("OPTIONS");
+
+/**
+ * Sets a route title. Modeled after Angular Route.title.
+ */
+export function Title(title: string): MethodDecorator {
+  return (target, propertyKey) => {
+    const cls = (target as { constructor: Type<unknown> }).constructor;
+    const key = `${TITLE_METADATA}:${String(propertyKey)}`;
+    defineMetadata(cls, key, title);
+    const routes = readOwnOrInherited<RouteDefinition[]>(cls, ROUTES_METADATA) ?? [];
+    const route = routes.find((r) => r.handler === String(propertyKey));
+    if (route) {
+      route.title = title;
+    }
+  };
+}
+
+/**
+ * Attaches arbitrary static metadata to a route. Modeled after Angular Route.data.
+ */
+export function Data(data: Record<string, unknown>): MethodDecorator {
+  return (target, propertyKey) => {
+    const cls = (target as { constructor: Type<unknown> }).constructor;
+    const key = `${DATA_METADATA}:${String(propertyKey)}`;
+    const existing = readOwnOrInherited<Record<string, unknown>>(cls, key) ?? {};
+    defineMetadata(cls, key, { ...existing, ...data });
+    const routes = readOwnOrInherited<RouteDefinition[]>(cls, ROUTES_METADATA) ?? [];
+    const route = routes.find((r) => r.handler === String(propertyKey));
+    if (route) {
+      route.data = { ...route.data, ...data };
+    }
+  };
+}
 
 export function getRoutes(target: object): RouteDefinition[] {
   return readOwnOrInherited(target, ROUTES_METADATA) ?? [];

--- a/packages/app/src/forward_ref.ts
+++ b/packages/app/src/forward_ref.ts
@@ -1,0 +1,29 @@
+/**
+ * Allows referring to references which are not yet defined.
+ * Modeled directly after Angular's `forwardRef`.
+ *
+ * Example:
+ * ```ts
+ * @Inject(forwardRef(() => DependentService))
+ * ```
+ */
+export interface ForwardRefFn<T = unknown> {
+  (): T;
+  __forward_ref__?: typeof forwardRef;
+}
+
+export function forwardRef<T>(fn: () => T): ForwardRefFn<T> {
+  (fn as ForwardRefFn<T>).__forward_ref__ = forwardRef;
+  return fn;
+}
+
+export function resolveForwardRef<T>(type: T): T {
+  if (isForwardRef(type)) {
+    return (type as unknown as () => T)();
+  }
+  return type;
+}
+
+export function isForwardRef(fn: unknown): fn is ForwardRefFn {
+  return typeof fn === "function" && (fn as unknown as Record<string, unknown>).__forward_ref__ === forwardRef;
+}

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -27,6 +27,7 @@ export {
   Body,
   Command,
   Controller,
+  Data,
   Delete,
   Get,
   Head,
@@ -44,6 +45,7 @@ export {
   Query,
   Self,
   SkipSelf,
+  Title,
   UseGuards,
   getCommandMeta,
   getControllerMeta,
@@ -100,6 +102,9 @@ export {
   createChildInjector,
   getActiveInjector,
   inject,
+  injectDestroySignal,
   runInInjectionContext,
 } from "./inject";
 export type { InjectFlags, InjectorLike } from "./inject";
+export { forwardRef, isForwardRef, resolveForwardRef } from "./forward_ref";
+export type { ForwardRefFn } from "./forward_ref";

--- a/packages/app/src/inject.ts
+++ b/packages/app/src/inject.ts
@@ -1,9 +1,17 @@
 import type { Token } from "./provider";
+import { DESTROY_REF } from "./context";
+import { resolveForwardRef } from "./forward_ref";
 import { InjectionToken } from "./token";
 
 export interface InjectFlags {
   /** If true, returns undefined instead of throwing when token is not found. */
   optional?: boolean;
+  /** If true, requires token to be resolved from current local injector. */
+  self?: boolean;
+  /** If true, skips current local injector and resolves from parent. */
+  skipSelf?: boolean;
+  /** If true, resolves from host injector. */
+  host?: boolean;
 }
 
 export interface InjectorLike {
@@ -52,15 +60,16 @@ export function inject<T>(token: Token<T>, options?: InjectFlags): T {
     );
   }
 
-  const value = currentInjector.get(token);
+  const resolved = resolveForwardRef(token);
+  const value = currentInjector.get(resolved);
   if (value === undefined) {
     if (options?.optional) {
       return undefined as unknown as T;
     }
-    if (token instanceof InjectionToken && token.factory) {
-      return token.factory();
+    if (resolved instanceof InjectionToken && resolved.factory) {
+      return resolved.factory();
     }
-    throw new Error(`NullInjectorError: No provider for ${tokenToString(token)}`);
+    throw new Error(`NullInjectorError: No provider for ${tokenToString(resolved)}`);
   }
   return value as T;
 }
@@ -79,13 +88,14 @@ export function createChildInjector(
 
   return {
     get<T>(token: Token<T>): T | undefined {
-      if (providerMap.has(token)) {
-        return providerMap.get(token) as T;
+      const resolved = resolveForwardRef(token);
+      if (providerMap.has(resolved)) {
+        return providerMap.get(resolved) as T;
       }
-      if (token instanceof InjectionToken && providerMap.has(token.name)) {
-        return providerMap.get(token.name) as T;
+      if (resolved instanceof InjectionToken && providerMap.has(resolved.name)) {
+        return providerMap.get(resolved.name) as T;
       }
-      return parent.get(token);
+      return parent.get(resolved);
     },
   };
 }
@@ -98,6 +108,17 @@ export function assertInInjectionContext(fnName: string): void {
   if (!currentInjector) {
     throw new Error(`${fnName} must be called from an active injection context.`);
   }
+}
+
+/**
+ * Injects the AbortSignal of the active DestroyRef.
+ * Automatically aborted when the active context or service is destroyed.
+ * Modeled after Angular's DestroyRef signal pattern.
+ */
+export function injectDestroySignal(): AbortSignal {
+  const ref = inject(DESTROY_REF);
+  if (ref.signal) return ref.signal;
+  throw new Error("Active DestroyRef does not provide an AbortSignal");
 }
 
 function tokenToString(token: Token<any>): string {

--- a/packages/app/src/provider.ts
+++ b/packages/app/src/provider.ts
@@ -1,4 +1,5 @@
 import type { InjectionToken } from "./token";
+import type { ForwardRefFn } from "./forward_ref";
 import { APP_INITIALIZER } from "./context";
 import type { Scope } from "./scope";
 
@@ -8,7 +9,7 @@ export interface Type<T> {
 }
 
 /** Anything that can identify a provider: an InjectionToken or a class. */
-export type Token<T = any> = InjectionToken<T> | Type<T>;
+export type Token<T = any> = InjectionToken<T> | Type<T> | ForwardRefFn<InjectionToken<T> | Type<T>>;
 
 interface BaseProvider {
   /** Overrides the scope derived from @Injectable / token defaults. */
@@ -21,7 +22,7 @@ interface BaseProvider {
 
 export interface ClassProvider<T = any> extends BaseProvider {
   provide: Token<T>;
-  useClass: Type<T>;
+  useClass: Type<T> | ForwardRefFn<Type<T>>;
   /** Explicit dependency tokens, positional (constructor order). */
   deps?: Token[];
 }

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -250,4 +250,107 @@ describe("analyzeProject：command 与 externalTokens", () => {
     expect(ctrl?.routes[0].queryTransforms).toEqual({ limit: "number" });
     expect(ctrl?.routes[0].queryDefaults).toEqual({ limit: 20 });
   });
+
+  test("unwraps forwardRef in @Inject, useClass, and provider tokens", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-forwardref-"));
+    await writeFixtureProject(root, {
+      "tsconfig.json": GOOD_PROJECT_FILES["tsconfig.json"],
+      "src/test.service.ts": `
+        import { Injectable, Inject, Module, forwardRef, InjectionToken } from "@supacloud/app";
+
+        export const SERVICE_TOKEN = new InjectionToken<string>("service-token");
+
+        @Injectable()
+        export class FirstService {
+          constructor(@Inject(forwardRef(() => SecondService)) private second: any) {}
+        }
+
+        @Injectable()
+        export class SecondService {
+          constructor(private first: FirstService) {}
+        }
+
+        @Module({
+          name: "forwardRefModule",
+          providers: [
+            FirstService,
+            SecondService,
+            {
+              provide: forwardRef(() => SERVICE_TOKEN),
+              useClass: forwardRef(() => FirstService),
+            },
+          ],
+        })
+        export class ForwardRefModule {}
+      `,
+    });
+
+    const analyzed = await analyzeProject(root);
+    const mod = analyzed.modules.find((m) => m.name === "forwardRefModule");
+    expect(mod).toBeDefined();
+
+    const first = mod?.providers.find((p) => p.token === "FirstService");
+    expect(first?.deps).toEqual(["SecondService"]);
+
+    const alias = mod?.providers.find((p) => p.token === "SERVICE_TOKEN");
+    expect(alias).toBeDefined();
+    expect(alias?.useClass).toBe("FirstService");
+  });
+
+  test("analyzes route title and data metadata from options and decorators", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-route-metadata-"));
+    await writeFixtureProject(root, {
+      "tsconfig.json": GOOD_PROJECT_FILES["tsconfig.json"],
+      "src/test.controller.ts": `
+        import { Controller, Get, Title, Data } from "@supacloud/app";
+
+        @Controller({ path: "/docs", standalone: true })
+        export class DocsController {
+          @Get("/overview", { title: "Documentation Overview", data: { auth: false, version: 2 } })
+          getOverview() {}
+
+          @Get("/advanced")
+          @Title("Advanced Guides")
+          @Data({ auth: true, tier: "pro" })
+          getAdvanced() {}
+        }
+      `,
+    });
+
+    const analyzed = await analyzeProject(root);
+    const rootMod = analyzed.modules.find((m) => m.name === "root");
+    const ctrl = rootMod?.controllers.find((c) => c.className === "DocsController");
+    expect(ctrl).toBeDefined();
+    expect(ctrl?.routes[0].title).toBe("Documentation Overview");
+    expect(ctrl?.routes[0].data).toEqual({ auth: false, version: 2 });
+    expect(ctrl?.routes[1].title).toBe("Advanced Guides");
+    expect(ctrl?.routes[1].data).toEqual({ auth: true, tier: "pro" });
+  });
+
+  test("analyzes property-level inject with self, skipSelf, and host flags", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-inject-modifiers-"));
+    await writeFixtureProject(root, {
+      "tsconfig.json": GOOD_PROJECT_FILES["tsconfig.json"],
+      "src/test.service.ts": `
+        import { Injectable, inject, InjectionToken } from "@supacloud/app";
+        const LOCAL_SVC = new InjectionToken<string>("local");
+        const PARENT_SVC = new InjectionToken<string>("parent");
+        const HOST_SVC = new InjectionToken<string>("host");
+
+        @Injectable({ providedIn: 'root' })
+        export class ScopedService {
+          private local = inject(LOCAL_SVC, { self: true });
+          private parent = inject(PARENT_SVC, { skipSelf: true });
+          private host = inject(HOST_SVC, { host: true });
+        }
+      `,
+    });
+
+    const analyzed = await analyzeProject(root);
+    const rootMod = analyzed.modules.find((m) => m.name === "root");
+    const prov = rootMod?.providers.find((p) => p.token === "ScopedService");
+    expect(prov?.selfDeps).toContain("LOCAL_SVC");
+    expect(prov?.skipSelfDeps).toContain("PARENT_SVC");
+    expect(prov?.hostDeps).toContain("HOST_SVC");
+  });
 });

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -454,7 +454,8 @@ function parseModule(
 
   const imports = arrayProp(options, "imports")
     .map((el) => {
-      const decl = Node.isIdentifier(el) ? resolveDeclaration(el)[0] : undefined;
+      const unwrapped = unwrapForwardRef(el);
+      const decl = Node.isIdentifier(unwrapped) ? resolveDeclaration(unwrapped)[0] : undefined;
       if (decl) {
         const known = nameByNode.get(decl);
         if (known) return known;
@@ -567,11 +568,12 @@ function parseProvider(
   const file = sourcePath(ctx.rootDir, el.getSourceFile().getFilePath());
   const line = el.getStartLineNumber();
 
+  const unwrappedEl = unwrapForwardRef(el);
   // Bare class reference -> class provider, token = class name
-  if (Node.isIdentifier(el)) {
-    const decl = resolveDeclaration(el)[0];
+  if (Node.isIdentifier(unwrappedEl)) {
+    const decl = resolveDeclaration(unwrappedEl)[0];
     const cls = decl && Node.isClassDeclaration(decl) ? decl : undefined;
-    const className = cls?.getName() ?? el.getText();
+    const className = cls?.getName() ?? unwrappedEl.getText();
     const { deps, optionalDeps, selfDeps, skipSelfDeps, hostDeps, missing } = cls
       ? classDeps(cls, ctx)
       : { deps: [], optionalDeps: [], selfDeps: [], skipSelfDeps: [], hostDeps: [], missing: false };
@@ -613,9 +615,10 @@ function parseProvider(
   const useExistingExpr = getProp(el, "useExisting");
 
   if (useClassExpr) {
-    const decl = Node.isIdentifier(useClassExpr) ? resolveDeclaration(useClassExpr)[0] : undefined;
+    const unwrappedClass = unwrapForwardRef(useClassExpr);
+    const decl = Node.isIdentifier(unwrappedClass) ? resolveDeclaration(unwrappedClass)[0] : undefined;
     const cls = decl && Node.isClassDeclaration(decl) ? decl : undefined;
-    const useClass = cls?.getName() ?? useClassExpr.getText();
+    const useClass = cls?.getName() ?? unwrappedClass.getText();
     let deps = explicitDeps;
     let optionalDeps: string[] = [];
     let selfDeps: string[] = [];
@@ -724,8 +727,9 @@ function parseController(
   let decl: ClassDeclaration | undefined;
   if (Node.isClassDeclaration(input)) {
     decl = input;
-  } else if (Node.isIdentifier(input)) {
-    const resolved = resolveDeclaration(input)[0];
+  } else {
+    const unwrapped = unwrapForwardRef(input);
+    const resolved = Node.isIdentifier(unwrapped) ? resolveDeclaration(unwrapped)[0] : undefined;
     if (resolved && Node.isClassDeclaration(resolved)) {
       decl = resolved;
     }
@@ -821,9 +825,21 @@ function parseController(
 
       const routeGuards: string[] = [...classGuards];
       for (const mDec of method.getDecorators()) {
-        if (decoratorName(mDec) === "UseGuards") {
-          for (const gArg of mDec.getArguments()) {
+        const dName = decoratorName(mDec);
+        const mArgs = mDec.getArguments();
+        if (dName === "UseGuards") {
+          for (const gArg of mArgs) {
             routeGuards.push(tokenText(gArg as Expression));
+          }
+        } else if (dName === "Title") {
+          const tArg = mArgs[0];
+          if (tArg && Node.isStringLiteral(tArg)) {
+            route.title = tArg.getLiteralText();
+          }
+        } else if (dName === "Data") {
+          const dArg = mArgs[0];
+          if (dArg && Node.isObjectLiteralExpression(dArg)) {
+            route.data = { ...route.data, ...parseObjectLiteralValues(dArg) };
           }
         }
       }
@@ -885,6 +901,14 @@ function parseController(
           if (val === "full" || val === "prefix") {
             route.pathMatch = val;
           }
+        }
+        const titleExpr = getProp(optionsArg, "title");
+        if (titleExpr && Node.isStringLiteral(titleExpr)) {
+          route.title = titleExpr.getLiteralText();
+        }
+        const dataExpr = getProp(optionsArg, "data");
+        if (dataExpr && Node.isObjectLiteralExpression(dataExpr)) {
+          route.data = { ...route.data, ...parseObjectLiteralValues(dataExpr) };
         }
       }
       if (routeGuards.length > 0) {
@@ -984,6 +1008,18 @@ function classDeps(
               if (isOptional && !optionalDeps.includes(tokenName)) {
                 optionalDeps.push(tokenName);
               }
+              const isSelf = booleanProp(optionsArg, "self");
+              if (isSelf && !selfDeps.includes(tokenName)) {
+                selfDeps.push(tokenName);
+              }
+              const isSkipSelf = booleanProp(optionsArg, "skipSelf");
+              if (isSkipSelf && !skipSelfDeps.includes(tokenName)) {
+                skipSelfDeps.push(tokenName);
+              }
+              const isHost = booleanProp(optionsArg, "host");
+              if (isHost && !hostDeps.includes(tokenName)) {
+                hostDeps.push(tokenName);
+              }
             }
           }
         }
@@ -1069,14 +1105,31 @@ function parseModifierParams(cls: ClassDeclaration, modifierName: string): Set<n
   return result;
 }
 
+function unwrapForwardRef(expr: Expression): Expression {
+  if (Node.isCallExpression(expr)) {
+    const exprText = expr.getExpression().getText();
+    if (exprText === "forwardRef" || exprText.endsWith(".forwardRef")) {
+      const arg = expr.getArguments()[0];
+      if (arg && (Node.isArrowFunction(arg) || Node.isFunctionExpression(arg))) {
+        const body = arg.getBody();
+        if (body && Node.isExpression(body)) {
+          return unwrapForwardRef(body);
+        }
+      }
+    }
+  }
+  return expr;
+}
+
 function tokenText(expr: Expression): string {
-  if (Node.isStringLiteral(expr)) return expr.getLiteralText();
-  if (Node.isIdentifier(expr)) {
-    const decl = resolveDeclaration(expr)[0];
-    if (decl && Node.isClassDeclaration(decl)) return decl.getName() ?? expr.getText();
+  const unwrapped = unwrapForwardRef(expr);
+  if (Node.isStringLiteral(unwrapped)) return unwrapped.getLiteralText();
+  if (Node.isIdentifier(unwrapped)) {
+    const decl = resolveDeclaration(unwrapped)[0];
+    if (decl && Node.isClassDeclaration(decl)) return decl.getName() ?? unwrapped.getText();
     if (decl && Node.isVariableDeclaration(decl)) return decl.getName();
   }
-  return expr.getText();
+  return unwrapped.getText();
 }
 
 function resolveScope(
@@ -1095,8 +1148,9 @@ function resolveScope(
 
 /** Identifier -> token name + kind (resolves across imports to declaration). */
 function tokenNameOf(expr: Expression, ctx: AnalysisContext): { name: string; kind: TokenKind } {
-  if (Node.isIdentifier(expr)) {
-    const decl = resolveDeclaration(expr)[0];
+  const unwrapped = unwrapForwardRef(expr);
+  if (Node.isIdentifier(unwrapped)) {
+    const decl = resolveDeclaration(unwrapped)[0];
     if (decl && Node.isClassDeclaration(decl)) {
       return { name: decl.getName() ?? expr.getText(), kind: "class" };
     }
@@ -1247,7 +1301,27 @@ function parseLiteralValue(node: Node): unknown {
   if (Node.isNumericLiteral(node)) return node.getLiteralValue();
   if (node.getKindName() === "TrueKeyword") return true;
   if (node.getKindName() === "FalseKeyword") return false;
+  if (Node.isArrayLiteralExpression(node)) {
+    return node.getElements().map(parseLiteralValue);
+  }
+  if (Node.isObjectLiteralExpression(node)) {
+    return parseObjectLiteralValues(node);
+  }
   return undefined;
+}
+
+function parseObjectLiteralValues(obj: ObjectLiteralExpression): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const prop of obj.getProperties()) {
+    if (Node.isPropertyAssignment(prop)) {
+      const name = prop.getName();
+      const init = prop.getInitializer();
+      if (init) {
+        result[name] = parseLiteralValue(init);
+      }
+    }
+  }
+  return result;
 }
 
 /** Absolute path -> posix-style module path relative to rootDir without extension (for import generation). */

--- a/packages/compiler/src/generate.test.ts
+++ b/packages/compiler/src/generate.test.ts
@@ -488,4 +488,50 @@ describe("generate：client.ts 与 permissions.ts 端到端代码生成", () => 
       "firstService",
     ]);
   });
+
+  test("renderApplication and renderClient generate route title and static data metadata", () => {
+    const rendered = renderApplication(
+      {
+        modules: [
+          {
+            name: "meta",
+            className: "MetaModule",
+            file: "src/meta.module.ts",
+            line: 1,
+            imports: [],
+            providers: [],
+            controllers: [
+              {
+                className: "MetaController",
+                path: "/meta",
+                scope: "request",
+                deps: [],
+                routes: [
+                  {
+                    method: "GET",
+                    path: "/info",
+                    handler: "getInfo",
+                    title: "System Information",
+                    data: { tier: "enterprise", public: false },
+                  },
+                ],
+                file: "src/meta.controller.ts",
+                importPath: "./meta.controller",
+              },
+            ],
+            commands: [],
+            queries: [],
+            exports: [],
+          },
+        ],
+        externalTokens: [],
+      },
+      { rootDir: "/app", outDir: "/app/gen", generateClient: true },
+    );
+
+    expect(rendered.applicationCode).toContain('title: "System Information"');
+    expect(rendered.applicationCode).toContain('data: {"tier":"enterprise","public":false}');
+    expect(rendered.clientCode).toContain('"title": "System Information"');
+    expect(rendered.clientCode).toContain('"tier": "enterprise"');
+  });
 });

--- a/packages/compiler/src/generate.ts
+++ b/packages/compiler/src/generate.ts
@@ -35,6 +35,8 @@ const INTERFACES = `export interface CompiledRoute {
   paramDefaults?: Record<string, unknown>;
   queryTransforms?: Record<string, "number" | "boolean" | "string">;
   queryDefaults?: Record<string, unknown>;
+  title?: string;
+  data?: Record<string, unknown>;
 }
 
 export interface CompiledCommand {
@@ -390,6 +392,12 @@ class ModuleGenerator {
         if (route.queryDefaults && Object.keys(route.queryDefaults).length > 0) {
           fields.push(`queryDefaults: ${JSON.stringify(route.queryDefaults)}`);
         }
+        if (route.title) {
+          fields.push(`title: ${JSON.stringify(route.title)}`);
+        }
+        if (route.data && Object.keys(route.data).length > 0) {
+          fields.push(`data: ${JSON.stringify(route.data)}`);
+        }
         return `{ ${fields.join(", ")} }`;
       });
       return [
@@ -629,6 +637,8 @@ export function renderClient(graph: ApplicationGraph, _options?: GenerateOptions
     paramDefaults?: Record<string, unknown>;
     queryTransforms?: Record<string, "number" | "boolean" | "string">;
     queryDefaults?: Record<string, unknown>;
+    title?: string;
+    data?: Record<string, unknown>;
   }> = [];
 
   for (const module of graph.modules) {
@@ -653,6 +663,8 @@ export function renderClient(graph: ApplicationGraph, _options?: GenerateOptions
           paramDefaults: route.paramDefaults,
           queryTransforms: route.queryTransforms,
           queryDefaults: route.queryDefaults,
+          title: route.title,
+          data: route.data,
         });
 
         routeMethods.push(`

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -88,6 +88,10 @@ export interface RouteNode {
   queryTransforms?: Record<string, "number" | "boolean" | "string">;
   /** Query defaults declared via @Query({ default: ... }) */
   queryDefaults?: Record<string, unknown>;
+  /** Route title (Angular Route.title style). */
+  title?: string;
+  /** Route static metadata dictionary (Angular Route.data style). */
+  data?: Record<string, unknown>;
 }
 
 export interface ControllerNode {

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -1022,4 +1022,82 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(bodyDiag?.message).toContain("binds @Body() on HTTP GET route");
     expect(bodyDiag?.suggestion).toContain("Use POST, PUT, or PATCH");
   });
+
+  test("Ivy-style route order checking: shadowed-route detects specific routes shadowed by earlier wildcard", () => {
+    const badGraph: ApplicationGraph = {
+      modules: [
+        {
+          name: "items",
+          className: "ItemsModule",
+          file: "src/items.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [
+            {
+              className: "ItemsController",
+              path: "/items",
+              scope: "request",
+              deps: [],
+              routes: [
+                {
+                  method: "GET",
+                  path: "/:id",
+                  handler: "getItem",
+                },
+                {
+                  method: "GET",
+                  path: "/overview",
+                  handler: "getOverview",
+                },
+              ],
+              file: "src/items.controller.ts",
+              importPath: "./items.controller",
+            },
+          ],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(badGraph);
+    const shadowDiag = diags.find((d) => d.code === "shadowed-route");
+    expect(shadowDiag).toBeDefined();
+    expect(shadowDiag?.message).toContain("Route GET /items/overview (ItemsController.getOverview) is shadowed");
+    expect(shadowDiag?.message).toContain("earlier parameterized route GET /items/:id");
+    expect(shadowDiag?.suggestion).toContain("Move specific route '/overview' before parameterized route '/:id'");
+
+    // If ordered correctly (specific first, then parameterized), no shadowed-route diagnostic
+    const goodGraph: ApplicationGraph = {
+      ...badGraph,
+      modules: [
+        {
+          ...badGraph.modules[0],
+          controllers: [
+            {
+              ...badGraph.modules[0].controllers[0],
+              routes: [
+                {
+                  method: "GET",
+                  path: "/overview",
+                  handler: "getOverview",
+                },
+                {
+                  method: "GET",
+                  path: "/:id",
+                  handler: "getItem",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const goodDiags = validateGraph(goodGraph);
+    expect(goodDiags.find((d) => d.code === "shadowed-route")).toBeUndefined();
+  });
 });

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -101,6 +101,7 @@ export function validateGraph(
   const modulesByName = new Map<string, ModuleNode>();
   const commandsByName = new Map<string, { module: ModuleNode; className: string }>();
   const routesByKey = new Map<string, { module: ModuleNode; controller: ControllerNode }>();
+  const declaredRoutes: Array<{ method: string; path: string; fullPath: string; rawFullPath: string; controller: ControllerNode; module: ModuleNode; handler: string }> = [];
 
   for (const module of graph.modules) {
     const previousModule = modulesByName.get(module.name);
@@ -135,6 +136,7 @@ export function validateGraph(
     for (const controller of module.controllers) {
       for (const route of controller.routes) {
         const fullPath = joinRoutePaths(controller.path, route.path);
+        const rawFullPath = joinRawRoutePaths(controller.path, route.path);
         const key = `${route.method} ${fullPath}`;
         const previous = routesByKey.get(key);
         if (previous) {
@@ -146,6 +148,20 @@ export function validateGraph(
         } else {
           routesByKey.set(key, { module, controller });
         }
+
+        // Shadowed route detection: specific route shadowed by earlier parameterized route on same HTTP method
+        for (const prev of declaredRoutes) {
+          if (prev.method === route.method && isRouteShadowed(prev.rawFullPath, rawFullPath)) {
+            warn(
+              "shadowed-route",
+              `Route ${route.method} ${rawFullPath} (${controller.className}.${route.handler}) is shadowed by earlier parameterized route ${prev.method} ${prev.rawFullPath} (${prev.controller.className}.${prev.handler}) and will never be matched.`,
+              controller.file,
+              undefined,
+              `Move specific route '${route.path}' before parameterized route '${prev.path}'.`,
+            );
+          }
+        }
+        declaredRoutes.push({ method: route.method, path: route.path, fullPath, rawFullPath, controller, module, handler: route.handler });
 
         if (route.command && !module.commands.some((command) => command.className === route.command)) {
           error(
@@ -472,6 +488,42 @@ function joinRoutePaths(prefix: string, path: string): string {
   const joined = `${prefix}/${path}`.replace(/\/{2,}/g, "/");
   const normalized = joined.length > 1 ? joined.replace(/\/+$/, "") : joined;
   return normalized.replace(/:[^/]+/g, ":param");
+}
+
+function joinRawRoutePaths(prefix: string, path: string): string {
+  const joined = `${prefix}/${path}`.replace(/\/{2,}/g, "/");
+  return joined.length > 1 ? joined.replace(/\/+$/, "") : joined;
+}
+
+/**
+ * Detects if laterPath is shadowed by earlierPath on the same HTTP method.
+ * E.g., earlierPath="/users/:id" shadows laterPath="/users/profile".
+ * But earlierPath="/users/profile" does NOT shadow laterPath="/users/:id".
+ */
+function isRouteShadowed(earlierPath: string, laterPath: string): boolean {
+  const earlierSegments = earlierPath.split("/").filter(Boolean);
+  const laterSegments = laterPath.split("/").filter(Boolean);
+
+  if (earlierSegments.length !== laterSegments.length) {
+    return false;
+  }
+
+  let hasParamShadowing = false;
+  for (let i = 0; i < earlierSegments.length; i += 1) {
+    const e = earlierSegments[i];
+    const l = laterSegments[i];
+
+    if (e === l) {
+      continue;
+    }
+    if (e.startsWith(":") && !l.startsWith(":")) {
+      hasParamShadowing = true;
+      continue;
+    }
+    return false;
+  }
+
+  return hasParamShadowing;
 }
 
 /** Provider-level circular dependency detection (DFS, reporting cycle path). */


### PR DESCRIPTION
## Summary

This PR implements key Angular-inspired developer experience (DX) and heavy-compilation capabilities to shift work from runtime to compile time:

1. **`forwardRef` Support**:
   - Introduced `forwardRef()`, `resolveForwardRef()`, and `isForwardRef()` in `@supacloud/app`.
   - Updated compiler AST analysis to transparently unwrap `forwardRef(() => Target)` in `@Inject()`, `useClass`, `useExisting`, and `providers`/`controllers`/`imports`.

2. **`DestroyRef` Auto-Cancellation Signal**:
   - Added `signal: AbortSignal` to `DestroyRef` in `@supacloud/app`, automatically aborted when the active context or service is destroyed.
   - Added `injectDestroySignal()` helper to bind async tasks or HTTP fetches to the teardown lifecycle without boilerplate.

3. **Route `title` & `data` Static Metadata**:
   - Added `title` and `data` to route options, along with `@Title()` and `@Data()` decorators.
   - Extracted into `RouteNode` during compilation and emitted into `application.ts` route descriptors and client `API_ROUTES`.

4. **Shadowed Route Detection (`shadowed-route`)**:
   - Static compile-time route order validation in `validate.ts` detecting when a specific route is placed after a wildcard/parameterized route on the same HTTP method (e.g. `GET /items/:id` before `GET /items/overview`), providing actionable suggestions.

5. **Extended `inject()` Modifier Flags**:
   - Supported `self`, `skipSelf`, and `host` in `InjectFlags` and property-level `inject(TOKEN, options)` analysis.

## Verification
- Unit and integration tests pass across `@supacloud/app` (48 tests) and `@supacloud/compiler` (83 tests).
- Workspace invariant and architecture boundary checks pass.