### PR TITLE
feat(compiler): finalize Angular DX with linkedSignal, EnvironmentInjector, TransferState, and route input binding

### DIFF
--- a/packages/app/src/context.ts
+++ b/packages/app/src/context.ts
@@ -39,6 +39,15 @@ export const APP_INITIALIZER = new InjectionToken<() => void | Promise<void>>(
 );
 
 /**
+ * Built-in multi-provider token for environment initialization hooks.
+ * Modeled directly after Angular 14+ ENVIRONMENT_INITIALIZER.
+ */
+export const ENVIRONMENT_INITIALIZER = new InjectionToken<() => void | Promise<void>>(
+  "supacloud.environment-initializer",
+  { scope: "application" },
+);
+
+/**
  * Lifecycle interface for services that need to perform teardown logic when the application shuts down.
  * Modeled after Angular's OnDestroy.
  */

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -102,18 +102,27 @@ export type {
   RouteParamBinding,
 } from "./decorators";
 export { defineModule } from "./module";
-export { APP_INITIALIZER, DB_CLIENT, DESTROY_REF, JOB_CONTEXT, REQUEST_CONTEXT, createDestroyRef } from "./context";
+export {
+  APP_INITIALIZER,
+  DB_CLIENT,
+  DESTROY_REF,
+  ENVIRONMENT_INITIALIZER,
+  JOB_CONTEXT,
+  REQUEST_CONTEXT,
+  createDestroyRef,
+} from "./context";
 export type { DestroyRef, OnDestroy } from "./context";
 export {
   assertInInjectionContext,
   createChildInjector,
+  createEnvironmentInjector,
   getActiveInjector,
   inject,
   injectAll,
   injectDestroySignal,
   runInInjectionContext,
 } from "./inject";
-export type { InjectFlags, InjectorLike } from "./inject";
+export type { EnvironmentInjector, InjectFlags, InjectorLike } from "./inject";
 export { forwardRef, isForwardRef, resolveForwardRef } from "./forward_ref";
 export type { ForwardRefFn } from "./forward_ref";
 export { matchRoute } from "./route_match";
@@ -129,10 +138,11 @@ export type { HttpInterceptorFn, HttpRequestPayload } from "./interceptor";
 export {
   computed,
   effect,
+  linkedSignal,
   signal,
   untracked,
 } from "./signal";
-export type { Signal, WritableSignal } from "./signal";
+export type { LinkedSignalOptions, Signal, WritableSignal } from "./signal";
 export { resource } from "./resource";
 export type {
   ResourceLoaderParams,
@@ -145,3 +155,9 @@ export type { RoutePipelineContext, RoutePipelineDefinition, RoutePipelineResult
 export { TestBed } from "./testing";
 export type { TestModuleMetadata } from "./testing";
 export { provideRouter, ROUTE_CONFIG } from "./route_provider";
+export {
+  TransferState,
+  TRANSFER_STATE,
+  makeStateKey,
+} from "./transfer_state";
+export type { StateKey } from "./transfer_state";

--- a/packages/app/src/inject.test.ts
+++ b/packages/app/src/inject.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "bun:test";
+import { createEnvironmentInjector, inject, runInInjectionContext } from "./inject";
+import { InjectionToken } from "./token";
+import { DESTROY_REF, type OnDestroy } from "./context";
+import { provideEnvironmentInitializer, provideToken } from "./provider";
+
+describe("Angular 14+ EnvironmentInjector and createEnvironmentInjector", () => {
+  it("resolves basic providers and executes runInContext", () => {
+    const API_URL = new InjectionToken<string>("API_URL");
+    class GreetingService {
+      greet(name: string) {
+        return `Hello, ${name}`;
+      }
+    }
+
+    const env = createEnvironmentInjector([
+      provideToken(API_URL, "https://api.test.local"),
+      GreetingService,
+    ]);
+
+    expect(env.get(API_URL)).toBe("https://api.test.local");
+    const greeter = env.get(GreetingService);
+    expect(greeter.greet("World")).toBe("Hello, World");
+
+    const result = env.runInContext(() => {
+      return inject(API_URL);
+    });
+    expect(result).toBe("https://api.test.local");
+    expect(env.destroyed).toBe(false);
+  });
+
+  it("automatically executes provideEnvironmentInitializer hooks on creation", () => {
+    let initialized = false;
+    let inContext = false;
+    const FLAG = new InjectionToken<string>("FLAG");
+
+    const env = createEnvironmentInjector([
+      provideToken(FLAG, "ready"),
+      provideEnvironmentInitializer(() => {
+        initialized = true;
+        const f = inject(FLAG);
+        if (f === "ready") {
+          inContext = true;
+        }
+      }),
+    ]);
+
+    expect(initialized).toBe(true);
+    expect(inContext).toBe(true);
+    expect(env.get(FLAG)).toBe("ready");
+  });
+
+  it("executes DestroyRef teardowns and OnDestroy hooks on destroy()", () => {
+    let destroyRefTeardownRan = false;
+    let onDestroyHookRan = false;
+
+    class CleanableService implements OnDestroy {
+      onDestroy() {
+        onDestroyHookRan = true;
+      }
+    }
+
+    const env = createEnvironmentInjector([
+      CleanableService,
+      provideEnvironmentInitializer(() => {
+        const ref = inject(DESTROY_REF);
+        ref.onDestroy(() => {
+          destroyRefTeardownRan = true;
+        });
+      }),
+    ]);
+
+    // Instantiate service inside env
+    const service = env.get(CleanableService);
+    expect(service).toBeDefined();
+    expect(destroyRefTeardownRan).toBe(false);
+    expect(onDestroyHookRan).toBe(false);
+
+    env.destroy();
+    expect(env.destroyed).toBe(true);
+    expect(destroyRefTeardownRan).toBe(true);
+    expect(onDestroyHookRan).toBe(true);
+
+    // Operations after destroy throw
+    expect(() => env.get(CleanableService)).toThrow("already been destroyed");
+    expect(() => env.runInContext(() => 42)).toThrow("already been destroyed");
+  });
+
+  it("delegates to parent injector when token is not found in child", () => {
+    const ROOT_CONFIG = new InjectionToken<string>("ROOT_CONFIG");
+    const CHILD_CONFIG = new InjectionToken<string>("CHILD_CONFIG");
+
+    const parent = createEnvironmentInjector([
+      provideToken(ROOT_CONFIG, "root-val"),
+    ]);
+
+    const child = createEnvironmentInjector([
+      provideToken(CHILD_CONFIG, "child-val"),
+    ], parent);
+
+    expect(child.get(CHILD_CONFIG)).toBe("child-val");
+    expect(child.get(ROOT_CONFIG)).toBe("root-val");
+  });
+});

--- a/packages/app/src/inject.ts
+++ b/packages/app/src/inject.ts
@@ -1,5 +1,6 @@
-import type { Token } from "./provider";
-import { DESTROY_REF } from "./context";
+import type { EnvironmentProviders, Provider, Token, Type } from "./provider";
+import { flattenProviders, isClassProvider, isExistingProvider, isFactoryProvider, isValueProvider } from "./provider";
+import { APP_INITIALIZER, DESTROY_REF, ENVIRONMENT_INITIALIZER, createDestroyRef } from "./context";
 import { resolveForwardRef } from "./forward_ref";
 import { InjectionToken } from "./token";
 
@@ -152,4 +153,213 @@ function tokenToString(token: Token<any>): string {
   if (token instanceof InjectionToken) return token.toString();
   if (typeof token === "function") return token.name || "AnonymousClass";
   return String(token);
+}
+
+export interface EnvironmentInjector extends InjectorLike {
+  get<T>(token: Token<T>, options?: InjectFlags): T;
+  get<T>(token: Token<T>, notFoundValue: T, options?: InjectFlags): T;
+  runInContext<R>(fn: () => R): R;
+  destroy(): void;
+  readonly destroyed: boolean;
+  readonly parent?: InjectorLike;
+}
+
+/**
+ * Creates an EnvironmentInjector with an isolated dependency scope and lifecycle.
+ * Modeled directly after Angular 14+ createEnvironmentInjector.
+ * Automatically executes all ENVIRONMENT_INITIALIZER / APP_INITIALIZER hooks upon creation,
+ * and executes DestroyRef teardowns and OnDestroy hooks upon destroy().
+ */
+export function createEnvironmentInjector(
+  providers: Array<Provider | EnvironmentProviders>,
+  parent?: InjectorLike,
+): EnvironmentInjector {
+  let isDestroyed = false;
+  const flatProviders = flattenProviders(providers);
+  const effectiveProviders = new Map<Token<unknown>, Provider>();
+  const multiProviders = new Map<Token<unknown>, Provider[]>();
+  const instances = new Map<Token<unknown> | string, unknown>();
+
+  // Create isolated destroyRef for this environment injector
+  const localDestroyRef = createDestroyRef();
+  instances.set(DESTROY_REF, localDestroyRef);
+
+  for (const p of flatProviders) {
+    const token = typeof p === "function" ? resolveForwardRef(p) : resolveForwardRef(p.provide);
+    if (typeof p !== "function" && p.multi) {
+      const list = multiProviders.get(token) ?? [];
+      list.push(p);
+      multiProviders.set(token, list);
+    } else {
+      effectiveProviders.set(token, p);
+    }
+  }
+
+  const injector: EnvironmentInjector = {
+    parent,
+    get destroyed() {
+      return isDestroyed;
+    },
+    runInContext<R>(fn: () => R): R {
+      if (isDestroyed) {
+        throw new Error("EnvironmentInjector has already been destroyed.");
+      }
+      return runInInjectionContext(injector, fn);
+    },
+    destroy(): void {
+      if (isDestroyed) return;
+      isDestroyed = true;
+      void localDestroyRef.destroy();
+      for (const inst of instances.values()) {
+        if (inst && typeof inst === "object" && inst !== localDestroyRef) {
+          if ("onDestroy" in inst && typeof (inst as any).onDestroy === "function") {
+            try {
+              (inst as any).onDestroy();
+            } catch (err) {
+              console.error("Error in onDestroy hook:", err);
+            }
+          }
+          if ("ngOnDestroy" in inst && typeof (inst as any).ngOnDestroy === "function") {
+            try {
+              (inst as any).ngOnDestroy();
+            } catch (err) {
+              console.error("Error in ngOnDestroy hook:", err);
+            }
+          }
+        }
+      }
+      instances.clear();
+    },
+    get<T>(token: Token<T>, notFoundOrOptions?: T | InjectFlags, maybeOptions?: InjectFlags): T {
+      if (isDestroyed) {
+        throw new Error("EnvironmentInjector has already been destroyed.");
+      }
+      let notFoundValue: T | undefined = undefined;
+      let flags: InjectFlags | undefined = undefined;
+
+      if (
+        notFoundOrOptions !== undefined &&
+        (typeof notFoundOrOptions !== "object" ||
+          notFoundOrOptions === null ||
+          (!("optional" in notFoundOrOptions) &&
+            !("skipSelf" in notFoundOrOptions) &&
+            !("self" in notFoundOrOptions) &&
+            !("host" in notFoundOrOptions)))
+      ) {
+        notFoundValue = notFoundOrOptions as T;
+        flags = maybeOptions;
+      } else if (notFoundOrOptions && typeof notFoundOrOptions === "object") {
+        flags = notFoundOrOptions as InjectFlags;
+      }
+
+      const resolved = resolveForwardRef(token);
+
+      if (flags?.skipSelf) {
+        if (!parent) {
+          if (flags.optional) return undefined as unknown as T;
+          if (notFoundValue !== undefined) return notFoundValue;
+          throw new Error(`NullInjectorError: No parent provider found for skipSelf token ${tokenToString(resolved)}`);
+        }
+        const val = parent.get(resolved, flags);
+        if (val === undefined && notFoundValue !== undefined) return notFoundValue;
+        return val as T;
+      }
+
+      if (instances.has(resolved)) {
+        return instances.get(resolved) as T;
+      }
+      if (resolved instanceof InjectionToken && instances.has(resolved.name)) {
+        return instances.get(resolved.name) as T;
+      }
+
+      if (multiProviders.has(resolved)) {
+        const provs = multiProviders.get(resolved)!;
+        const results = provs.map((prov) => {
+          if (isValueProvider(prov)) return prov.useValue;
+          if (isFactoryProvider(prov)) return runInInjectionContext(injector, () => prov.useFactory());
+          if (isClassProvider(prov)) return runInInjectionContext(injector, () => new (prov.useClass as Type<any>)());
+          if (isExistingProvider(prov)) return injector.get(prov.useExisting);
+          return undefined;
+        });
+        instances.set(resolved, results);
+        if (resolved instanceof InjectionToken) {
+          instances.set(resolved.name, results);
+        }
+        return results as unknown as T;
+      }
+
+      const provider = effectiveProviders.get(resolved);
+      if (!provider) {
+        if (flags?.self) {
+          if (flags.optional) return undefined as unknown as T;
+          if (notFoundValue !== undefined) return notFoundValue;
+          throw new Error(`NullInjectorError: No local provider for ${tokenToString(resolved)}`);
+        }
+        if (parent) {
+          const fromParent = parent.get(resolved, flags);
+          if (fromParent !== undefined) return fromParent as T;
+        }
+        if (flags?.optional) return undefined as unknown as T;
+        if (notFoundValue !== undefined) return notFoundValue;
+        if (resolved instanceof InjectionToken && resolved.factory && !flags?.self && !flags?.skipSelf) {
+          const inst = resolved.factory();
+          instances.set(resolved, inst);
+          return inst;
+        }
+        if (typeof resolved === "function") {
+          try {
+            const inst = new (resolved as Type<T>)();
+            instances.set(resolved, inst);
+            return inst;
+          } catch {
+            // not a zero-arg constructor
+          }
+        }
+        throw new Error(`NullInjectorError: No provider for ${tokenToString(resolved)}`);
+      }
+
+      let created: unknown;
+      if (typeof provider === "function") {
+        created = runInInjectionContext(injector, () => new (provider as Type<any>)());
+      } else if (isValueProvider(provider)) {
+        created = provider.useValue;
+      } else if (isFactoryProvider(provider)) {
+        created = runInInjectionContext(injector, () => provider.useFactory());
+      } else if (isClassProvider(provider)) {
+        created = runInInjectionContext(injector, () => new (provider.useClass as Type<any>)());
+      } else if (isExistingProvider(provider)) {
+        created = injector.get(provider.useExisting);
+      }
+
+      instances.set(resolved, created);
+      return created as T;
+    },
+  };
+
+  // Run all ENVIRONMENT_INITIALIZER / APP_INITIALIZER tokens automatically upon creation
+  const envInitializers = injector.get(ENVIRONMENT_INITIALIZER, { optional: true });
+  const seenInits = new Set<unknown>();
+  if (Array.isArray(envInitializers)) {
+    for (const init of envInitializers) {
+      if (typeof init === "function") {
+        seenInits.add(init);
+        runInInjectionContext(injector, () => {
+          void init();
+        });
+      }
+    }
+  }
+  const appInitializers = injector.get(APP_INITIALIZER, { optional: true });
+  if (Array.isArray(appInitializers)) {
+    for (const init of appInitializers) {
+      if (typeof init === "function" && !seenInits.has(init)) {
+        seenInits.add(init);
+        runInInjectionContext(injector, () => {
+          void init();
+        });
+      }
+    }
+  }
+
+  return injector;
 }

--- a/packages/app/src/provider.ts
+++ b/packages/app/src/provider.ts
@@ -1,6 +1,6 @@
 import type { InjectionToken } from "./token";
 import type { ForwardRefFn } from "./forward_ref";
-import { APP_INITIALIZER } from "./context";
+import { APP_INITIALIZER, ENVIRONMENT_INITIALIZER } from "./context";
 import type { Scope } from "./scope";
 
 /** A class usable as a DI token / provider implementation. */
@@ -118,7 +118,13 @@ export function provideAppInitializer(
 export function provideEnvironmentInitializer(
   initializerFn: () => void | Promise<void>,
 ): EnvironmentProviders {
-  return provideAppInitializer(initializerFn);
+  return makeEnvironmentProviders([
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      useValue: initializerFn,
+      multi: true,
+    },
+  ]);
 }
 
 /**

--- a/packages/app/src/signal.test.ts
+++ b/packages/app/src/signal.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { signal, computed, effect, untracked, linkedSignal } from "./signal";
+
+describe("Angular 19-style linkedSignal API", () => {
+  it("creates shorthand linkedSignal derived from a computation and resets on source change", () => {
+    const shippingMethods = signal(["Standard", "Express", "Overnight"]);
+    const selected = linkedSignal(() => shippingMethods()[0]);
+
+    expect(selected()).toBe("Standard");
+
+    // User overrides the linked signal manually
+    selected.set("Express");
+    expect(selected()).toBe("Express");
+
+    // Upstream dependency changes: linked signal automatically resets to the new computation
+    shippingMethods.set(["Courier", "Drone"]);
+    expect(selected()).toBe("Courier");
+
+    // User can override again
+    selected.set("Drone");
+    expect(selected()).toBe("Drone");
+  });
+
+  it("supports update() and asReadonly() on linkedSignal", () => {
+    const count = signal(5);
+    const quantity = linkedSignal(() => count() * 2);
+
+    expect(quantity()).toBe(10);
+
+    quantity.update((q) => q + 3);
+    expect(quantity()).toBe(13);
+
+    const ro = quantity.asReadonly();
+    expect(ro()).toBe(13);
+
+    count.set(10);
+    expect(quantity()).toBe(20);
+    expect(ro()).toBe(20);
+  });
+
+  it("supports detailed options object with source and computation preserving previous state", () => {
+    const options = signal(["apple", "banana", "cherry"]);
+    const choice = linkedSignal<string[], string>({
+      source: () => options(),
+      computation: (source, previous) => {
+        // If the previous value is still valid in the new options, keep it!
+        if (previous && source.includes(previous.value)) {
+          return previous.value;
+        }
+        return source[0];
+      },
+    });
+
+    expect(choice()).toBe("apple");
+
+    // Override to banana
+    choice.set("banana");
+    expect(choice()).toBe("banana");
+
+    // New options list that still contains banana: preserves banana!
+    options.set(["banana", "date", "elderberry"]);
+    expect(choice()).toBe("banana");
+
+    // New options list without banana: falls back to source[0] (fig)
+    options.set(["fig", "grape"]);
+    expect(choice()).toBe("fig");
+  });
+
+  it("integrates with reactive effects and does not recompute when source produces equal value", () => {
+    const filter = signal("active");
+    const page = linkedSignal(() => `page-1-${filter()}`);
+
+    const log: string[] = [];
+    const stopEffect = effect(() => {
+      log.push(page());
+    });
+
+    expect(log).toEqual(["page-1-active"]);
+
+    page.set("page-2-active");
+    expect(log).toEqual(["page-1-active", "page-2-active"]);
+
+    // Setting the same filter value does not reset page override
+    filter.set("active");
+    expect(page()).toBe("page-2-active");
+    expect(log).toEqual(["page-1-active", "page-2-active"]);
+
+    // Changing filter to new value resets page
+    filter.set("archived");
+    expect(page()).toBe("page-1-archived");
+    expect(log).toEqual(["page-1-active", "page-2-active", "page-1-archived"]);
+
+    stopEffect();
+  });
+});

--- a/packages/app/src/signal.ts
+++ b/packages/app/src/signal.ts
@@ -130,3 +130,112 @@ export function untracked<T>(fn: () => T): T {
     isTrackingEnabled = prevTracking;
   }
 }
+
+export interface LinkedSignalOptions<S, D> {
+  source: () => S;
+  computation: (source: S, previous?: { source: S; value: D }) => D;
+  equal?: (a: D, b: D) => boolean;
+}
+
+/**
+ * Creates a writable signal whose value is linked to a source reactive computation.
+ * When the source dependencies change, the linkedSignal automatically recomputes its value.
+ * Unlike a standard computed signal, a linkedSignal is writable and can be manually modified.
+ * Modeled directly after Angular 19's linkedSignal.
+ */
+export function linkedSignal<D>(
+  computation: () => D,
+  options?: { equal?: (a: D, b: D) => boolean },
+): WritableSignal<D>;
+export function linkedSignal<S, D = S>(
+  options: LinkedSignalOptions<S, D>,
+): WritableSignal<D>;
+export function linkedSignal<S, D>(
+  computationOrOptions: (() => D) | LinkedSignalOptions<S, D>,
+  shorthandOptions?: { equal?: (a: D, b: D) => boolean },
+): WritableSignal<D> {
+  let sourceFn: () => S;
+  let computationFn: (source: S, previous?: { source: S; value: D }) => D;
+  let equalFn: (a: D, b: D) => boolean;
+
+  if (typeof computationOrOptions === "function") {
+    sourceFn = computationOrOptions as unknown as () => S;
+    computationFn = (s: S) => s as unknown as D;
+    equalFn = shorthandOptions?.equal ?? Object.is;
+  } else {
+    sourceFn = computationOrOptions.source;
+    computationFn = computationOrOptions.computation;
+    equalFn = computationOrOptions.equal ?? Object.is;
+  }
+
+  let currentValue: D;
+  let hasValue = false;
+  let previousRecord: { source: S; value: D } | undefined = undefined;
+  let isDirty = true;
+  const subscribers = new Set<Consumer>();
+
+  const onSourceChanged = () => {
+    if (!isDirty) {
+      isDirty = true;
+      for (const notify of [...subscribers]) {
+        notify();
+      }
+    }
+  };
+
+  const recompute = () => {
+    const prevConsumer = activeConsumer;
+    activeConsumer = onSourceChanged;
+    let nextSource: S;
+    try {
+      nextSource = sourceFn();
+    } finally {
+      activeConsumer = prevConsumer;
+    }
+
+    if (hasValue && previousRecord && Object.is(nextSource, previousRecord.source)) {
+      isDirty = false;
+      return currentValue;
+    }
+
+    const nextValue = computationFn(nextSource, previousRecord);
+    currentValue = nextValue;
+    hasValue = true;
+    previousRecord = { source: nextSource, value: currentValue };
+    isDirty = false;
+    return currentValue;
+  };
+
+  const read = (() => {
+    if (isTrackingEnabled && activeConsumer) {
+      subscribers.add(activeConsumer);
+    }
+    if (isDirty || !hasValue) {
+      return recompute();
+    }
+    return currentValue;
+  }) as WritableSignal<D>;
+
+  read.set = (newValue: D) => {
+    if (!hasValue || isDirty) {
+      recompute();
+    }
+    if (!equalFn(currentValue, newValue)) {
+      currentValue = newValue;
+      if (previousRecord) {
+        previousRecord.value = newValue;
+      }
+      for (const notify of [...subscribers]) {
+        notify();
+      }
+    }
+  };
+
+  read.update = (updateFn: (current: D) => D) => {
+    read.set(updateFn(read()));
+  };
+
+  read.asReadonly = () => (() => read()) as Signal<D>;
+
+  return read;
+}

--- a/packages/app/src/transfer_state.test.ts
+++ b/packages/app/src/transfer_state.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { TransferState, TRANSFER_STATE, makeStateKey } from "./transfer_state";
+import { createEnvironmentInjector } from "./inject";
+
+describe("Angular Universal TransferState for SSR/Hydration", () => {
+  interface UserSession {
+    id: string;
+    role: string;
+  }
+
+  const USER_KEY = makeStateKey<UserSession>("current_user");
+  const THEME_KEY = makeStateKey<string>("app_theme");
+
+  it("stores and retrieves state with type safety", () => {
+    const state = new TransferState();
+    expect(state.isEmpty()).toBe(true);
+    expect(state.hasKey(USER_KEY)).toBe(false);
+
+    state.set(USER_KEY, { id: "usr_101", role: "admin" });
+    expect(state.isEmpty()).toBe(false);
+    expect(state.hasKey(USER_KEY)).toBe(true);
+
+    const session = state.get(USER_KEY, { id: "guest", role: "anonymous" });
+    expect(session).toEqual({ id: "usr_101", role: "admin" });
+
+    const theme = state.get(THEME_KEY, "dark");
+    expect(theme).toBe("dark");
+  });
+
+  it("supports remove() and key deletion", () => {
+    const state = new TransferState();
+    state.set(THEME_KEY, "light");
+    expect(state.hasKey(THEME_KEY)).toBe(true);
+
+    state.remove(THEME_KEY);
+    expect(state.hasKey(THEME_KEY)).toBe(false);
+    expect(state.isEmpty()).toBe(true);
+  });
+
+  it("serializes to and deserializes from JSON", () => {
+    const serverState = new TransferState();
+    serverState.set(USER_KEY, { id: "usr_202", role: "viewer" });
+    serverState.set(THEME_KEY, "nord");
+
+    const json = serverState.toJson();
+    expect(typeof json).toBe("string");
+    expect(json).toContain("usr_202");
+
+    // Client hydration from serialized string
+    const clientState = TransferState.fromJson(json);
+    expect(clientState.hasKey(USER_KEY)).toBe(true);
+    expect(clientState.get(USER_KEY, { id: "", role: "" })).toEqual({ id: "usr_202", role: "viewer" });
+    expect(clientState.get(THEME_KEY, "default")).toBe("nord");
+  });
+
+  it("can be injected via TRANSFER_STATE token in an EnvironmentInjector", () => {
+    const env = createEnvironmentInjector([]);
+    const ts = env.get(TRANSFER_STATE);
+    expect(ts).toBeInstanceOf(TransferState);
+
+    ts.set(THEME_KEY, "solarized");
+    expect(ts.get(THEME_KEY, "light")).toBe("solarized");
+  });
+});

--- a/packages/app/src/transfer_state.ts
+++ b/packages/app/src/transfer_state.ts
@@ -1,0 +1,105 @@
+import { InjectionToken } from "./token";
+
+export type StateKey<T> = string & { readonly __type_brand?: T };
+
+/**
+ * Creates a type-safe StateKey for TransferState.
+ * Modeled directly after Angular's makeStateKey.
+ */
+export function makeStateKey<T>(key: string): StateKey<T> {
+  return key as StateKey<T>;
+}
+
+/**
+ * Key-value store used to transfer application state between server and client (SSR / Edge hydration).
+ * Modeled directly after Angular Universal TransferState.
+ */
+export class TransferState {
+  private store = new Map<string, unknown>();
+
+  /**
+   * Retrieves the value associated with the key, or defaultValue if not present.
+   */
+  get<T>(key: StateKey<T> | string, defaultValue: T): T {
+    if (this.store.has(key as string)) {
+      return this.store.get(key as string) as T;
+    }
+    return defaultValue;
+  }
+
+  /**
+   * Sets the value for the given key.
+   */
+  set<T>(key: StateKey<T> | string, value: T): void {
+    this.store.set(key as string, value);
+  }
+
+  /**
+   * Checks whether the key exists in the store.
+   */
+  hasKey<T>(key: StateKey<T> | string): boolean {
+    return this.store.has(key as string);
+  }
+
+  /**
+   * Removes a key from the store.
+   */
+  remove<T>(key: StateKey<T> | string): void {
+    this.store.delete(key as string);
+  }
+
+  /**
+   * Checks whether the store is empty.
+   */
+  isEmpty(): boolean {
+    return this.store.size === 0;
+  }
+
+  /**
+   * Serializes the current state store into a JSON string.
+   */
+  toJson(): string {
+    const obj: Record<string, unknown> = {};
+    for (const [k, v] of this.store.entries()) {
+      obj[k] = v;
+    }
+    return JSON.stringify(obj);
+  }
+
+  /**
+   * Deserializes a JSON string into a TransferState store.
+   */
+  static fromJson(json: string): TransferState {
+    const state = new TransferState();
+    try {
+      const parsed = JSON.parse(json);
+      if (parsed && typeof parsed === "object" && parsed !== null) {
+        for (const [k, v] of Object.entries(parsed)) {
+          state.set(k, v);
+        }
+      }
+    } catch {
+      // ignore parse error, return empty state
+    }
+    return state;
+  }
+
+  /**
+   * Creates a TransferState initialized with a plain record object.
+   */
+  static fromObject(record: Record<string, unknown>): TransferState {
+    const state = new TransferState();
+    for (const [k, v] of Object.entries(record)) {
+      state.set(k, v);
+    }
+    return state;
+  }
+}
+
+/**
+ * Built-in injection token for TransferState.
+ */
+export const TRANSFER_STATE = new InjectionToken<TransferState>("supacloud.transfer-state", {
+  scope: "application",
+  factory: () => new TransferState(),
+});

--- a/packages/compiler/src/analyze.test.ts
+++ b/packages/compiler/src/analyze.test.ts
@@ -431,4 +431,30 @@ describe("analyzeProject：command 与 externalTokens", () => {
       org: "OrgResolver",
     });
   });
+
+  test("automatically infers route parameter bindings and transforms from method signature (withComponentInputBinding)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "supacloud-input-binding-"));
+    await writeFixtureProject(root, {
+      "tsconfig.json": GOOD_PROJECT_FILES["tsconfig.json"],
+      "src/auto_binding.controller.ts": `
+        import { Controller, Get, Query } from "@supacloud/app";
+
+        @Controller({ path: "/inventory", standalone: true })
+        export class InventoryController {
+          @Get("/:itemId/details/:subId")
+          getItem(itemId: string, subId: number, @Query("format") format: string) {}
+        }
+      `,
+    });
+
+    const analyzed = await analyzeProject(root);
+    const rootMod = analyzed.modules.find((m) => m.name === "root");
+    const ctrl = rootMod?.controllers.find((c) => c.className === "InventoryController");
+    expect(ctrl).toBeDefined();
+    const route = ctrl?.routes[0];
+    expect(route?.pathParams).toEqual(["itemId", "subId"]);
+    expect(route?.paramBindings).toEqual(["itemId", "subId"]);
+    expect(route?.paramTransforms?.["subId"]).toBe("number");
+    expect(route?.queryBindings).toEqual(["format"]);
+  });
 });

--- a/packages/compiler/src/analyze.ts
+++ b/packages/compiler/src/analyze.ts
@@ -798,21 +798,38 @@ function parseController(
       const queryDefaults: Record<string, unknown> = {};
       let hasBodyBinding = false;
       for (const p of method.getParameters()) {
+        const pName = p.getName();
+        let hasBindingDecorator = false;
         for (const pDec of p.getDecorators()) {
           const dName = decoratorName(pDec);
           const dArgs = pDec.getArguments();
           if (dName === "Param") {
-            const parsed = parseBindingOptions(dArgs, p.getName());
+            hasBindingDecorator = true;
+            const parsed = parseBindingOptions(dArgs, pName);
             paramBindings.push(parsed.name);
             if (parsed.transform) paramTransforms[parsed.name] = parsed.transform;
             if (parsed.default !== undefined) paramDefaults[parsed.name] = parsed.default;
           } else if (dName === "Query") {
-            const parsed = parseBindingOptions(dArgs, p.getName());
+            hasBindingDecorator = true;
+            const parsed = parseBindingOptions(dArgs, pName);
             queryBindings.push(parsed.name);
             if (parsed.transform) queryTransforms[parsed.name] = parsed.transform;
             if (parsed.default !== undefined) queryDefaults[parsed.name] = parsed.default;
           } else if (dName === "Body") {
+            hasBindingDecorator = true;
             hasBodyBinding = true;
+          }
+        }
+        // Automatic route parameter binding (Angular withComponentInputBinding pattern):
+        // If a method parameter name matches a route path parameter (:name) and has no explicit binding decorator,
+        // automatically infer the path parameter binding and deduce its primitive transform.
+        if (!hasBindingDecorator && pathParams.includes(pName)) {
+          paramBindings.push(pName);
+          const typeText = p.getType().getText();
+          if (typeText === "number") {
+            paramTransforms[pName] = "number";
+          } else if (typeText === "boolean") {
+            paramTransforms[pName] = "boolean";
           }
         }
       }

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -1455,4 +1455,62 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(redirectCycleDiag?.errorCode).toBe("SC3003");
     expect(redirectCycleDiag?.message).toContain("/step-a -> /step-b -> /step-c -> /step-a");
   });
+
+  test("detects malformed route paths with consecutive slashes, empty params, or query characters (SC3010)", () => {
+    const graphWithMalformedRoutes: ApplicationGraph = {
+      modules: [
+        {
+          name: "MalformedModule",
+          className: "MalformedModule",
+          file: "src/malformed.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [
+            {
+              className: "MalformedController",
+              path: "/api",
+              scope: "request",
+              deps: [],
+              routes: [
+                {
+                  method: "GET",
+                  path: "/users//profile",
+                  handler: "getProfile",
+                },
+                {
+                  method: "GET",
+                  path: "/items/:",
+                  handler: "getItems",
+                },
+                {
+                  method: "GET",
+                  path: "/search?q=test",
+                  handler: "search",
+                },
+              ],
+              file: "src/malformed.controller.ts",
+              importPath: "./malformed.controller",
+            },
+          ],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(graphWithMalformedRoutes);
+    const malformedDiags = diags.filter((d) => d.code === "malformed-route-path");
+    expect(malformedDiags).toHaveLength(3);
+    for (const diag of malformedDiags) {
+      expect(diag.errorCode).toBe("SC3010");
+      expect(diag.docsUrl).toBe("https://supacloud.dev/errors/SC3010");
+      expect(diag.suggestion).toBeDefined();
+    }
+    expect(malformedDiags.some((d) => d.message.includes("consecutive slashes"))).toBe(true);
+    expect(malformedDiags.some((d) => d.message.includes("missing a parameter identifier"))).toBe(true);
+    expect(malformedDiags.some((d) => d.message.includes("invalid URL query"))).toBe(true);
+  });
 });

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -42,6 +42,7 @@ export const COMPILER_DIAGNOSTIC_CODES: Record<string, { code: string; docsUrl: 
   "duplicate-route": { code: "SC3007", docsUrl: "https://supacloud.dev/errors/SC3007" },
   "missing-body-schema": { code: "SC3008", docsUrl: "https://supacloud.dev/errors/SC3008" },
   "unused-route-schema": { code: "SC3009", docsUrl: "https://supacloud.dev/errors/SC3009" },
+  "malformed-route-path": { code: "SC3010", docsUrl: "https://supacloud.dev/errors/SC3010" },
   "command-missing-permission": { code: "SC4001", docsUrl: "https://supacloud.dev/errors/SC4001" },
   "duplicate-command": { code: "SC4002", docsUrl: "https://supacloud.dev/errors/SC4002" },
   "route-command-unresolved": { code: "SC4003", docsUrl: "https://supacloud.dev/errors/SC4003" },
@@ -191,6 +192,33 @@ export function validateGraph(
   for (const module of graph.modules) {
     for (const controller of module.controllers) {
       for (const route of controller.routes) {
+        // Malformed route path detection (SC3010, Angular Ivy Router style)
+        if (route.path.includes("//") || controller.path.includes("//")) {
+          error(
+            "malformed-route-path",
+            `Route ${route.method} ${route.path} has malformed path: contains consecutive slashes '//'.`,
+            controller.file,
+            undefined,
+            "Remove duplicate consecutive slashes from the route path.",
+          );
+        } else if (/(^|\/):(\/|$)/.test(route.path) || route.path.endsWith("/:")) {
+          error(
+            "malformed-route-path",
+            `Route ${route.method} ${route.path} has malformed path: parameter colon ':' is missing a parameter identifier.`,
+            controller.file,
+            undefined,
+            "Specify a valid parameter name following the colon (e.g. ':id').",
+          );
+        } else if (route.path.includes("?") || route.path.includes("#")) {
+          error(
+            "malformed-route-path",
+            `Route ${route.method} ${route.path} has malformed path: contains invalid URL query '?' or fragment '#' character.`,
+            controller.file,
+            undefined,
+            "Declare query parameters using @Query() decorators instead of in the route path.",
+          );
+        }
+
         const fullPath = joinRoutePaths(controller.path, route.path);
         const rawFullPath = joinRawRoutePaths(controller.path, route.path);
         const key = `${route.method} ${fullPath}`;
@@ -618,7 +646,7 @@ export function validateGraph(
   for (const mod of graph.modules) {
     for (const exp of mod.exports) referencedTokens.add(exp);
     for (const ctrl of mod.controllers) {
-      for (const d of ctrl.deps) referencedTokens.add(d);
+      for (const d of ctrl.deps ?? []) referencedTokens.add(d);
       for (const d of ctrl.optionalDeps ?? []) referencedTokens.add(d);
       for (const d of ctrl.selfDeps ?? []) referencedTokens.add(d);
       for (const d of ctrl.skipSelfDeps ?? []) referencedTokens.add(d);


### PR DESCRIPTION
### Summary of Angular Heavy-Compilation DX Additions

1. **Angular 19 `linkedSignal` (`packages/app/src/signal.ts`)**:
   - Implemented reactive writable signal derived from source computations with automatic reset and manual override support.
   - Supports shorthand (`linkedSignal(() => source())`) and options object (`linkedSignal({ source: () => ..., computation: (src, prev) => ... })`).
   - Prevents spurious recomputations when source produces equal values.

2. **Angular 14+ `EnvironmentInjector` & `createEnvironmentInjector` (`packages/app/src/inject.ts`)**:
   - Provides scoped dependency resolution environments with full lifecycle management.
   - Automatically executes `ENVIRONMENT_INITIALIZER` and `APP_INITIALIZER` hooks upon creation.
   - Manages isolated `DestroyRef` instances and calls `onDestroy()` / `ngOnDestroy()` on instantiated singletons upon `destroy()`.

3. **Angular Universal `TransferState` (`packages/app/src/transfer_state.ts`)**:
   - Type-safe state transfer store (`makeStateKey<T>`, `TransferState`, `TRANSFER_STATE` token).
   - Enables zero-redundancy state hydration between server execution (Edge runtime / SSR) and client SDKs.

4. **Angular 16+ Automatic Route Parameter Binding (`packages/compiler/src/analyze.ts`)**:
   - Follows Angular's `withComponentInputBinding` pattern: automatically infers route path parameters and primitive type transforms (`number` / `boolean`) from controller method parameter signatures without requiring redundant `@Param()` boilerplate.

5. **Angular Ivy Compile-Time Path Diagnostics `SC3010` (`packages/compiler/src/validate.ts`)**:
   - Added `SC3010: malformed-route-path` to `COMPILER_DIAGNOSTIC_CODES` to intercept consecutive slashes (`//`), missing parameter names (`:`), and query characters (`?`, `#`) at compile time.

### Verification
- `packages/app`: 84/84 tests pass, zero typecheck errors, build succeeds.
- `packages/compiler`: 98/98 tests pass, zero typecheck errors, build succeeds.
- Root checks: `bun run check:boundaries` and `bun run check:invariants` all green.