### PR TITLE
feat(compiler): heavy-compilation DX with INJECTOR, PLATFORM_ID, router events, and Ivy diagnostics SC2006/SC3011

### DIFF
--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -113,6 +113,7 @@ export {
 } from "./context";
 export type { DestroyRef, OnDestroy } from "./context";
 export {
+  INJECTOR,
   assertInInjectionContext,
   createChildInjector,
   createEnvironmentInjector,
@@ -151,7 +152,14 @@ export type {
   ResourceStatus,
 } from "./resource";
 export { executeRoutePipeline } from "./route_pipeline";
-export type { RoutePipelineContext, RoutePipelineDefinition, RoutePipelineResult } from "./route_pipeline";
+export type {
+  RoutePipelineContext,
+  RoutePipelineDefinition,
+  RoutePipelineOptions,
+  RoutePipelineResult,
+  RouterEvent,
+  RouterEventType,
+} from "./route_pipeline";
 export { TestBed } from "./testing";
 export type { TestModuleMetadata } from "./testing";
 export { provideRouter, ROUTE_CONFIG } from "./route_provider";
@@ -161,3 +169,14 @@ export {
   makeStateKey,
 } from "./transfer_state";
 export type { StateKey } from "./transfer_state";
+export {
+  PLATFORM_BROWSER_ID,
+  PLATFORM_EDGE_ID,
+  PLATFORM_ID,
+  PLATFORM_SERVER_ID,
+  detectPlatform,
+  isPlatformBrowser,
+  isPlatformEdge,
+  isPlatformServer,
+} from "./platform";
+export type { PlatformId } from "./platform";

--- a/packages/app/src/inject.test.ts
+++ b/packages/app/src/inject.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { createEnvironmentInjector, inject, runInInjectionContext } from "./inject";
+import { INJECTOR, createEnvironmentInjector, inject, runInInjectionContext } from "./inject";
 import { InjectionToken } from "./token";
 import { DESTROY_REF, type OnDestroy } from "./context";
 import { provideEnvironmentInitializer, provideToken } from "./provider";
@@ -100,5 +100,13 @@ describe("Angular 14+ EnvironmentInjector and createEnvironmentInjector", () => 
 
     expect(child.get(CHILD_CONFIG)).toBe("child-val");
     expect(child.get(ROOT_CONFIG)).toBe("root-val");
+  });
+
+  it("resolves the INJECTOR token within an active injection context", () => {
+    const env = createEnvironmentInjector([]);
+    const resolvedInjector = env.runInContext(() => {
+      return inject(INJECTOR);
+    });
+    expect(resolvedInjector).toBe(env);
   });
 });

--- a/packages/app/src/inject.ts
+++ b/packages/app/src/inject.ts
@@ -30,6 +30,21 @@ export function getActiveInjector(): InjectorLike | null {
 }
 
 /**
+ * Built-in injection token for resolving the active injector instance.
+ * Modeled directly after Angular's INJECTOR token.
+ */
+export const INJECTOR = new InjectionToken<InjectorLike>("supacloud.injector", {
+  scope: "application",
+  factory: () => {
+    const active = getActiveInjector();
+    if (!active) {
+      throw new Error("Cannot resolve INJECTOR outside of an active injection context.");
+    }
+    return active;
+  },
+});
+
+/**
  * Executes a function within the scope of a specific injector.
  * Modeled directly after Angular's `runInInjectionContext(injector, fn)`.
  */
@@ -335,6 +350,7 @@ export function createEnvironmentInjector(
       return created as T;
     },
   };
+  instances.set(INJECTOR, injector);
 
   // Run all ENVIRONMENT_INITIALIZER / APP_INITIALIZER tokens automatically upon creation
   const envInitializers = injector.get(ENVIRONMENT_INITIALIZER, { optional: true });

--- a/packages/app/src/platform.test.ts
+++ b/packages/app/src/platform.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  PLATFORM_BROWSER_ID,
+  PLATFORM_EDGE_ID,
+  PLATFORM_ID,
+  PLATFORM_SERVER_ID,
+  detectPlatform,
+  isPlatformBrowser,
+  isPlatformEdge,
+  isPlatformServer,
+} from "./platform";
+import { createEnvironmentInjector } from "./inject";
+
+describe("Angular Universal PLATFORM_ID and platform detection", () => {
+  it("detects current runtime platform in Bun/Node environment", () => {
+    const current = detectPlatform();
+    expect(current).toBe(PLATFORM_SERVER_ID);
+    expect(isPlatformServer(current)).toBe(true);
+    expect(isPlatformBrowser(current)).toBe(false);
+    expect(isPlatformEdge(current)).toBe(false);
+  });
+
+  it("evaluates platform helper predicate functions correctly", () => {
+    expect(isPlatformBrowser(PLATFORM_BROWSER_ID)).toBe(true);
+    expect(isPlatformBrowser(PLATFORM_SERVER_ID)).toBe(false);
+
+    expect(isPlatformServer(PLATFORM_SERVER_ID)).toBe(true);
+    expect(isPlatformServer(PLATFORM_EDGE_ID)).toBe(true);
+    expect(isPlatformServer(PLATFORM_BROWSER_ID)).toBe(false);
+
+    expect(isPlatformEdge(PLATFORM_EDGE_ID)).toBe(true);
+    expect(isPlatformEdge(PLATFORM_SERVER_ID)).toBe(false);
+    expect(isPlatformEdge(PLATFORM_BROWSER_ID)).toBe(false);
+  });
+
+  it("injects PLATFORM_ID via EnvironmentInjector", () => {
+    const env = createEnvironmentInjector([]);
+    const platform = env.get(PLATFORM_ID);
+    expect(platform).toBe(PLATFORM_SERVER_ID);
+    expect(isPlatformServer(platform)).toBe(true);
+  });
+});

--- a/packages/app/src/platform.ts
+++ b/packages/app/src/platform.ts
@@ -1,0 +1,52 @@
+import { InjectionToken } from "./token";
+
+export const PLATFORM_SERVER_ID = "server";
+export const PLATFORM_BROWSER_ID = "browser";
+export const PLATFORM_EDGE_ID = "edge";
+
+export type PlatformId = "server" | "browser" | "edge";
+
+/**
+ * Detects the runtime execution platform.
+ */
+export function detectPlatform(): PlatformId {
+  if (typeof window !== "undefined" && typeof (window as any).document !== "undefined") {
+    return PLATFORM_BROWSER_ID;
+  }
+  if (typeof (globalThis as any).EdgeRuntime === "string") {
+    return PLATFORM_EDGE_ID;
+  }
+  return PLATFORM_SERVER_ID;
+}
+
+/**
+ * Built-in injection token for platform identification.
+ * Modeled directly after Angular's PLATFORM_ID.
+ */
+export const PLATFORM_ID = new InjectionToken<string>("supacloud.platform-id", {
+  scope: "application",
+  factory: () => detectPlatform(),
+});
+
+/**
+ * Returns whether a platform id represents a browser environment.
+ * Modeled directly after Angular's isPlatformBrowser.
+ */
+export function isPlatformBrowser(platformId: unknown): boolean {
+  return platformId === PLATFORM_BROWSER_ID;
+}
+
+/**
+ * Returns whether a platform id represents a server-side environment (Node.js/Bun/Edge).
+ * Modeled directly after Angular's isPlatformServer.
+ */
+export function isPlatformServer(platformId: unknown): boolean {
+  return platformId === PLATFORM_SERVER_ID || platformId === PLATFORM_EDGE_ID;
+}
+
+/**
+ * Returns whether a platform id represents an edge runtime environment.
+ */
+export function isPlatformEdge(platformId: unknown): boolean {
+  return platformId === PLATFORM_EDGE_ID;
+}

--- a/packages/app/src/route_pipeline.test.ts
+++ b/packages/app/src/route_pipeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { executeRoutePipeline } from "./route_pipeline";
-import type { RoutePipelineDefinition } from "./route_pipeline";
+import type { RoutePipelineDefinition, RouterEvent } from "./route_pipeline";
 
 describe("Angular Router lifecycle pipeline (executeRoutePipeline)", () => {
   it("executes handler successfully on happy path", async () => {
@@ -145,5 +145,42 @@ describe("Angular Router lifecycle pipeline (executeRoutePipeline)", () => {
 
     expect(result.status).toBe(500);
     expect(result.error).toBe("Simulated backend failure");
+  });
+
+  it("emits Angular Router events throughout navigation lifecycle", async () => {
+    const events: RouterEvent[] = [];
+    const route: RoutePipelineDefinition = {
+      path: "/items/:id",
+      method: "GET",
+      canMatch: [() => true],
+      guards: [() => true],
+      resolvers: {
+        item: () => ({ id: "item-123" }),
+      },
+      handler: (ctx) => ({ success: true, item: ctx.resolved?.item }),
+    };
+
+    const result = await executeRoutePipeline(
+      route,
+      { url: "/items/item-123", method: "GET" },
+      undefined,
+      { onEvent: (e) => events.push(e) },
+    );
+
+    expect(result.status).toBe(200);
+    const eventTypes = events.map((e) => e.type);
+    expect(eventTypes).toEqual([
+      "NavigationStart",
+      "RoutesRecognized",
+      "GuardsCheckStart",
+      "GuardsCheckEnd",
+      "GuardsCheckStart",
+      "GuardsCheckEnd",
+      "ResolveStart",
+      "ResolveEnd",
+      "ExecutionStart",
+      "ExecutionEnd",
+      "NavigationEnd",
+    ]);
   });
 });

--- a/packages/app/src/route_pipeline.ts
+++ b/packages/app/src/route_pipeline.ts
@@ -33,6 +33,30 @@ export interface RoutePipelineResult<T = unknown> {
   resolvedData?: Record<string, unknown>;
 }
 
+export type RouterEventType =
+  | "NavigationStart"
+  | "RoutesRecognized"
+  | "GuardsCheckStart"
+  | "GuardsCheckEnd"
+  | "ResolveStart"
+  | "ResolveEnd"
+  | "ExecutionStart"
+  | "ExecutionEnd"
+  | "NavigationEnd"
+  | "NavigationCancel"
+  | "NavigationError";
+
+export interface RouterEvent {
+  type: RouterEventType;
+  url: string;
+  timestamp: number;
+  data?: unknown;
+}
+
+export interface RoutePipelineOptions {
+  onEvent?: (event: RouterEvent) => void;
+}
+
 /**
  * Executes a full route lifecycle pipeline matching Angular Router execution semantics:
  * 1. canMatch guards check if route can match
@@ -45,37 +69,62 @@ export async function executeRoutePipeline<T = unknown>(
   route: RoutePipelineDefinition,
   ctx: RoutePipelineContext,
   componentInstance?: any,
+  options?: RoutePipelineOptions,
 ): Promise<RoutePipelineResult<T>> {
+  const emit = (type: RouterEventType, data?: unknown) => {
+    if (options?.onEvent) {
+      options.onEvent({
+        type,
+        url: ctx.url,
+        timestamp: Date.now(),
+        data,
+      });
+    }
+  };
+
+  emit("NavigationStart");
+  emit("RoutesRecognized", { method: route.method, path: route.path });
+
   // 1. Evaluate CanMatch guards
   if (route.canMatch && route.canMatch.length > 0) {
+    emit("GuardsCheckStart", { stage: "canMatch" });
     for (const guard of route.canMatch) {
       if (typeof guard === "function") {
         const can = await guard(ctx);
         if (!can) {
+          emit("GuardsCheckEnd", { stage: "canMatch", allowed: false });
+          emit("NavigationCancel", { reason: "CanMatch guard rejected" });
           return { matched: false, status: 404, error: "Route match rejected by CanMatch guard" };
         }
       }
     }
+    emit("GuardsCheckEnd", { stage: "canMatch", allowed: true });
   }
 
   // 2. Evaluate CanActivate guards
   if (route.guards && route.guards.length > 0) {
+    emit("GuardsCheckStart", { stage: "canActivate" });
     for (const guard of route.guards) {
       if (typeof guard === "function") {
         const allowed = await guard(ctx);
         if (!allowed) {
+          emit("GuardsCheckEnd", { stage: "canActivate", allowed: false });
+          emit("NavigationCancel", { reason: "CanActivate guard rejected" });
           return { matched: true, status: 403, error: "Route activation rejected by CanActivate guard" };
         }
       }
     }
+    emit("GuardsCheckEnd", { stage: "canActivate", allowed: true });
   }
 
   // 3. Execute Resolvers
   let resolvedData: Record<string, unknown> | undefined;
   if (route.resolvers && Object.keys(route.resolvers).length > 0) {
+    emit("ResolveStart", { keys: Object.keys(route.resolvers) });
     resolvedData = await executeResolvers(route.resolvers, ctx);
     ctx.resolved = { ...(ctx.resolved ?? {}), ...resolvedData };
     ctx.data = { ...(ctx.data ?? {}), ...(route.data ?? {}), ...resolvedData };
+    emit("ResolveEnd", { keys: Object.keys(route.resolvers) });
   } else if (route.data) {
     ctx.data = { ...(ctx.data ?? {}), ...route.data };
   }
@@ -83,6 +132,7 @@ export async function executeRoutePipeline<T = unknown>(
   // 4. Execute Route Handler
   let responseBody: T;
   try {
+    emit("ExecutionStart");
     if (componentInstance && typeof route.handler === "string" && typeof componentInstance[route.handler] === "function") {
       responseBody = await componentInstance[route.handler](ctx);
     } else if (typeof route.handler === "function") {
@@ -90,21 +140,27 @@ export async function executeRoutePipeline<T = unknown>(
     } else {
       throw new Error(`Handler '${String(route.handler)}' is not executable on component instance.`);
     }
+    emit("ExecutionEnd");
   } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    emit("NavigationError", { error: errorMsg });
     return {
       matched: true,
       status: 500,
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMsg,
       resolvedData,
     };
   }
 
   // 5. Evaluate CanDeactivate guards if component exists
   if (route.canDeactivate && route.canDeactivate.length > 0 && componentInstance) {
+    emit("GuardsCheckStart", { stage: "canDeactivate" });
     for (const guard of route.canDeactivate) {
       if (typeof guard === "function") {
         const canLeave = await guard(componentInstance, ctx);
         if (!canLeave) {
+          emit("GuardsCheckEnd", { stage: "canDeactivate", allowed: false });
+          emit("NavigationCancel", { reason: "CanDeactivate guard rejected" });
           return {
             matched: true,
             status: 409,
@@ -115,8 +171,10 @@ export async function executeRoutePipeline<T = unknown>(
         }
       }
     }
+    emit("GuardsCheckEnd", { stage: "canDeactivate", allowed: true });
   }
 
+  emit("NavigationEnd");
   return {
     matched: true,
     status: 200,

--- a/packages/app/src/testing.test.ts
+++ b/packages/app/src/testing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "bun:test";
 import { InjectionToken } from "./token";
 import { TestBed } from "./testing";
-import { inject, injectAll } from "./inject";
+import { INJECTOR, inject, injectAll } from "./inject";
 import { provideRouter, ROUTE_CONFIG } from "./route_provider";
 
 describe("Angular-style TestBed testing environment", () => {
@@ -85,6 +85,14 @@ describe("Angular-style TestBed testing environment", () => {
 
     const viaInjectAll = TestBed.run(() => injectAll(PLUGIN_TOKEN));
     expect(viaInjectAll).toEqual(["plugin-a", "plugin-b", "plugin-c"]);
+
+    // Directly via TestBed.injectAll
+    const directInjectAll = TestBed.injectAll(PLUGIN_TOKEN);
+    expect(directInjectAll).toEqual(["plugin-a", "plugin-b", "plugin-c"]);
+
+    // Resolving INJECTOR token from TestBed
+    const testBedInjector = TestBed.inject(INJECTOR);
+    expect(testBedInjector).toBeDefined();
   });
 
   it("supports provideRouter and ROUTE_CONFIG in TestBed", () => {

--- a/packages/app/src/testing.ts
+++ b/packages/app/src/testing.ts
@@ -1,6 +1,6 @@
 import type { EnvironmentProviders, Provider, Token, Type } from "./provider";
 import { flattenProviders, isClassProvider, isExistingProvider, isFactoryProvider, isValueProvider } from "./provider";
-import { runInInjectionContext, type InjectFlags, type InjectorLike } from "./inject";
+import { INJECTOR, injectAll, runInInjectionContext, type InjectFlags, type InjectorLike } from "./inject";
 import { resolveForwardRef } from "./forward_ref";
 import { InjectionToken } from "./token";
 
@@ -59,6 +59,16 @@ export class TestBed {
         throw new Error(`TestBed: No provider found for token ${String(resolved)}`);
       }
       return val as T;
+    });
+  }
+
+  /**
+   * Injects all instances registered for a multi-provider token from the test environment.
+   */
+  static injectAll<T>(token: Token<T>): T[] {
+    const injector = TestBed.getOrCreateInjector();
+    return runInInjectionContext(injector, () => {
+      return injectAll(token);
     });
   }
 
@@ -175,6 +185,7 @@ export class TestBed {
     };
 
     TestBed.activeInjector = rootInjector;
+    instances.set(INJECTOR, rootInjector);
     return rootInjector;
   }
 }

--- a/packages/compiler/src/validate.test.ts
+++ b/packages/compiler/src/validate.test.ts
@@ -1513,4 +1513,75 @@ describe("validateGraph：坏 fixture 诊断", () => {
     expect(malformedDiags.some((d) => d.message.includes("missing a parameter identifier"))).toBe(true);
     expect(malformedDiags.some((d) => d.message.includes("invalid URL query"))).toBe(true);
   });
+
+  test("detects unprovided exported tokens in modules (SC2006)", () => {
+    const graphWithUnprovidedExport: ApplicationGraph = {
+      modules: [
+        {
+          name: "FaultyExportModule",
+          className: "FaultyExportModule",
+          file: "src/faulty.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [],
+          commands: [],
+          queries: [],
+          exports: ["GhostToken"],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(graphWithUnprovidedExport);
+    const exportDiag = diags.find((d) => d.code === "export-unprovided-token");
+    expect(exportDiag).toBeDefined();
+    expect(exportDiag?.errorCode).toBe("SC2006");
+    expect(exportDiag?.docsUrl).toBe("https://supacloud.dev/errors/SC2006");
+    expect(exportDiag?.message).toContain("GhostToken");
+  });
+
+  test("detects duplicate path parameters in route paths (SC3011)", () => {
+    const graphWithDuplicateParam: ApplicationGraph = {
+      modules: [
+        {
+          name: "DupParamModule",
+          className: "DupParamModule",
+          file: "src/dup_param.module.ts",
+          line: 1,
+          imports: [],
+          providers: [],
+          controllers: [
+            {
+              className: "DupParamController",
+              path: "/orgs",
+              scope: "request",
+              deps: [],
+              routes: [
+                {
+                  method: "GET",
+                  path: "/:slug/teams/:slug",
+                  pathParams: ["slug", "slug"],
+                  handler: "getTeam",
+                },
+              ],
+              file: "src/dup_param.controller.ts",
+              importPath: "./dup_param.controller",
+            },
+          ],
+          commands: [],
+          queries: [],
+          exports: [],
+        },
+      ],
+      externalTokens: [],
+    };
+
+    const diags = validateGraph(graphWithDuplicateParam);
+    const dupParamDiag = diags.find((d) => d.code === "duplicate-path-param");
+    expect(dupParamDiag).toBeDefined();
+    expect(dupParamDiag?.errorCode).toBe("SC3011");
+    expect(dupParamDiag?.docsUrl).toBe("https://supacloud.dev/errors/SC3011");
+    expect(dupParamDiag?.message).toContain(":slug");
+  });
 });

--- a/packages/compiler/src/validate.ts
+++ b/packages/compiler/src/validate.ts
@@ -33,6 +33,7 @@ export const COMPILER_DIAGNOSTIC_CODES: Record<string, { code: string; docsUrl: 
   "disallow-controller-direct-db": { code: "SC2003", docsUrl: "https://supacloud.dev/errors/SC2003" },
   "self-dependency-violation": { code: "SC2004", docsUrl: "https://supacloud.dev/errors/SC2004" },
   "skip-self-dependency-violation": { code: "SC2005", docsUrl: "https://supacloud.dev/errors/SC2005" },
+  "export-unprovided-token": { code: "SC2006", docsUrl: "https://supacloud.dev/errors/SC2006" },
   "shadowed-route": { code: "SC3001", docsUrl: "https://supacloud.dev/errors/SC3001" },
   "unresolved-route-redirect": { code: "SC3002", docsUrl: "https://supacloud.dev/errors/SC3002" },
   "circular-route-redirect": { code: "SC3003", docsUrl: "https://supacloud.dev/errors/SC3003" },
@@ -43,6 +44,7 @@ export const COMPILER_DIAGNOSTIC_CODES: Record<string, { code: string; docsUrl: 
   "missing-body-schema": { code: "SC3008", docsUrl: "https://supacloud.dev/errors/SC3008" },
   "unused-route-schema": { code: "SC3009", docsUrl: "https://supacloud.dev/errors/SC3009" },
   "malformed-route-path": { code: "SC3010", docsUrl: "https://supacloud.dev/errors/SC3010" },
+  "duplicate-path-param": { code: "SC3011", docsUrl: "https://supacloud.dev/errors/SC3011" },
   "command-missing-permission": { code: "SC4001", docsUrl: "https://supacloud.dev/errors/SC4001" },
   "duplicate-command": { code: "SC4002", docsUrl: "https://supacloud.dev/errors/SC4002" },
   "route-command-unresolved": { code: "SC4003", docsUrl: "https://supacloud.dev/errors/SC4003" },
@@ -276,6 +278,20 @@ export function validateGraph(
         }
 
         const pathParams = route.pathParams ?? [];
+        const seenParams = new Set<string>();
+        for (const p of pathParams) {
+          if (seenParams.has(p)) {
+            error(
+              "duplicate-path-param",
+              `Route ${route.method} '${route.path}' defines duplicate path parameter ':${p}'. Each parameter in a route path must be unique.`,
+              controller.file,
+              undefined,
+              `Rename the duplicate parameter ':${p}' to a unique name (e.g. ':${p}Id').`,
+            );
+          }
+          seenParams.add(p);
+        }
+
         const paramBindings = route.paramBindings ?? [];
 
         for (const binding of paramBindings) {
@@ -671,6 +687,23 @@ export function validateGraph(
           `Inject "${provider.token}" in a service or controller, export it, or remove providedIn: 'root' to enable tree-shaking.`,
         );
       }
+    }
+  }
+
+  // Angular Ivy-style export validation (SC2006)
+  for (const module of graph.modules) {
+    for (const expToken of module.exports) {
+      const resolved = resolveDep(module, expToken);
+      if (resolved) continue;
+      if (module.imports.includes(expToken)) continue;
+
+      error(
+        "export-unprovided-token",
+        `Module '${module.name}' exports token '${expToken}', but it is neither provided in '${module.name}' nor imported from an imported module.`,
+        module.file,
+        module.line,
+        `Add a provider for '${expToken}' to '${module.name}.providers', or remove '${expToken}' from exports.`,
+      );
     }
   }
 


### PR DESCRIPTION
### Summary of Changes

1. **Angular-style `INJECTOR` Token (`packages/app/src/inject.ts`, `packages/app/src/index.ts`)**:
   - Implemented the built-in `INJECTOR` token to resolve the active injector instance dynamically within active injection contexts.
   - Automatically wired into `createEnvironmentInjector` and `TestBed`.

2. **Angular Testing `TestBed.injectAll` (`packages/app/src/testing.ts`)**:
   - Added `TestBed.injectAll<T>(token: Token<T>): T[]` to allow direct static retrieval of multi-provider implementations during unit testing.

3. **Angular Universal `PLATFORM_ID` and Platform Detection (`packages/app/src/platform.ts`, `packages/app/src/index.ts`)**:
   - Modeled after `@angular/common` platform tokens and detection helpers.
   - Provides `PLATFORM_ID` InjectionToken, platform string constants (`server`, `browser`, `edge`), `detectPlatform()`, and type predicates (`isPlatformBrowser`, `isPlatformServer`, `isPlatformEdge`).

4. **Angular Router Events Lifecycle (`packages/app/src/route_pipeline.ts`, `packages/app/src/index.ts`)**:
   - Implemented router event lifecycle interfaces (`NavigationStart`, `RoutesRecognized`, `GuardsCheckStart`, `GuardsCheckEnd`, `ResolveStart`, `ResolveEnd`, `ExecutionStart`, `ExecutionEnd`, `NavigationEnd`, `NavigationCancel`, `NavigationError`).
   - Added stage-by-stage event dispatch via `onEvent` in `executeRoutePipeline`.

5. **Angular Ivy Static Diagnostics (`packages/compiler/src/validate.ts`)**:
   - Added diagnostic `SC2006` (`export-unprovided-token`): statically flags modules exporting tokens that are neither provided nor imported from imported modules.
   - Added diagnostic `SC3011` (`duplicate-path-param`): statically flags routes with duplicated path parameter identifiers (e.g. `/:slug/teams/:slug`).

### Verification
- `packages/app`: 89 passing unit tests across 10 test files; `typecheck`, `typecheck:test`, and `build` clean.
- `packages/compiler`: 100 passing unit tests across 7 test files; `typecheck`, `typecheck:test`, and `build` clean.
- Workspace: `check:boundaries` and `check:invariants` passed cleanly.